### PR TITLE
fix(pacquet): limit settings-only workspaces to root project

### DIFF
--- a/pacquet/crates/cli/src/cli_args/exec/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/exec/recursive.rs
@@ -23,6 +23,7 @@ use miette::{Context, Diagnostic, IntoDiagnostic};
 use pacquet_config::Config;
 use pacquet_workspace::{
     FindWorkspaceProjectsOpts, find_workspace_projects, read_workspace_manifest,
+    workspace_package_patterns,
 };
 use pacquet_workspace_projects_graph::{CreateProjectsGraphOptions, create_projects_graph};
 use std::{
@@ -67,7 +68,7 @@ pub fn exec_recursive(args: &ExecArgs, config: &Config, dir: &Path) -> miette::R
     let patterns = read_workspace_manifest(workspace_root)
         .into_diagnostic()
         .wrap_err("reading pnpm-workspace.yaml")?
-        .and_then(|manifest| manifest.packages);
+        .map(|manifest| workspace_package_patterns(&manifest));
     let projects = find_workspace_projects(workspace_root, &FindWorkspaceProjectsOpts { patterns })
         .wrap_err("finding workspace projects")?;
     // pnpm throws `RECURSIVE_EXEC_NO_PACKAGE` when the selected set is

--- a/pacquet/crates/cli/src/cli_args/run/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/run/recursive.rs
@@ -27,6 +27,7 @@ use miette::{Context, Diagnostic, IntoDiagnostic};
 use pacquet_config::Config;
 use pacquet_workspace::{
     FindWorkspaceProjectsOpts, find_workspace_projects, read_workspace_manifest,
+    workspace_package_patterns,
 };
 use pacquet_workspace_projects_graph::{CreateProjectsGraphOptions, create_projects_graph};
 use std::{
@@ -87,7 +88,7 @@ pub fn run_recursive(args: &RunArgs, config: &Config, dir: &Path) -> miette::Res
     let patterns = read_workspace_manifest(workspace_root)
         .into_diagnostic()
         .wrap_err("reading pnpm-workspace.yaml")?
-        .and_then(|manifest| manifest.packages);
+        .map(|manifest| workspace_package_patterns(&manifest));
     let projects = find_workspace_projects(workspace_root, &FindWorkspaceProjectsOpts { patterns })
         .wrap_err("finding workspace projects")?;
 

--- a/pacquet/crates/cli/tests/exec_recursive.rs
+++ b/pacquet/crates/cli/tests/exec_recursive.rs
@@ -145,3 +145,42 @@ fn recursive_exec_bail_stops_at_first_failure() {
 
     drop(root);
 }
+
+/// A settings-only `pnpm-workspace.yaml` (no `packages:`) enumerates the
+/// root project only; it must not recursively pick up vendored fixture
+/// packages.
+#[test]
+fn recursive_exec_settings_only_workspace_enumerates_root_only() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "name": "root", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write root package.json");
+    fs::write(workspace.join("pnpm-workspace.yaml"), "allowBuilds:\n  esbuild: false\n")
+        .expect("write settings-only workspace manifest");
+
+    let nested = workspace.join("test-e2e/fixtures/vendor/preact/.cache/10.10.2");
+    fs::create_dir_all(&nested).expect("create vendored package dir");
+    fs::write(
+        nested.join("package.json"),
+        json!({ "name": "preact", "version": "10.10.2" }).to_string(),
+    )
+    .expect("write vendored package.json");
+
+    pacquet
+        .with_arg("-r")
+        .with_arg("exec")
+        .with_arg("touch")
+        .with_arg("ran.txt")
+        .assert()
+        .success();
+
+    assert!(workspace.join("ran.txt").exists(), "root project should run the command");
+    assert!(
+        !nested.join("ran.txt").exists(),
+        "settings-only workspace manifests must not recursively enumerate vendored packages",
+    );
+
+    drop(root);
+}

--- a/pacquet/crates/cli/tests/run_recursive.rs
+++ b/pacquet/crates/cli/tests/run_recursive.rs
@@ -89,6 +89,46 @@ fn recursive_run_executes_script_in_every_project() {
     drop(root);
 }
 
+#[test]
+fn recursive_run_settings_only_workspace_enumerates_root_only() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "root",
+            "version": "1.0.0",
+            "scripts": { "build": "touch root-ran.txt" },
+        })
+        .to_string(),
+    )
+    .expect("write root package.json");
+    fs::write(workspace.join("pnpm-workspace.yaml"), "allowBuilds:\n  esbuild: false\n")
+        .expect("write settings-only workspace manifest");
+
+    let nested = workspace.join("test-e2e/fixtures/vendor/preact/.cache/10.10.2");
+    fs::create_dir_all(&nested).expect("create vendored package dir");
+    fs::write(
+        nested.join("package.json"),
+        json!({
+            "name": "preact",
+            "version": "10.10.2",
+            "scripts": { "build": "touch vendored-ran.txt" },
+        })
+        .to_string(),
+    )
+    .expect("write vendored package.json");
+
+    pacquet.with_arg("-r").with_arg("run").with_arg("build").assert().success();
+
+    assert!(workspace.join("root-ran.txt").exists(), "root build script should run");
+    assert!(
+        !nested.join("vendored-ran.txt").exists(),
+        "settings-only workspace manifests must not recursively enumerate vendored packages",
+    );
+
+    drop(root);
+}
+
 /// `pacquet -r run --resume-from <pkg>` skips every chunk that sorts
 /// before the chunk containing `<pkg>`. With `project-2` and `project-3`
 /// both depending on `project-1`, the sorted chunks are

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1921,7 +1921,9 @@ fn load_workspace_projects(
 ) -> Result<Option<Vec<pacquet_workspace::Project>>, pacquet_workspace::FindWorkspaceProjectsError>
 {
     let Some(manifest) = workspace_manifest else { return Ok(None) };
-    let opts = pacquet_workspace::FindWorkspaceProjectsOpts { patterns: manifest.packages.clone() };
+    let opts = pacquet_workspace::FindWorkspaceProjectsOpts {
+        patterns: Some(pacquet_workspace::workspace_package_patterns(manifest)),
+    };
     pacquet_workspace::find_workspace_projects(workspace_root, &opts).map(Some)
 }
 

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -3,7 +3,10 @@
     reason = "struct-literal test fixtures; field types are evident from the literal and naming each would force ~20 imports"
 )]
 
-use super::{Install, InstallError, UpToDateFastPathCheck, install_already_up_to_date};
+use super::{
+    Install, InstallError, UpToDateFastPathCheck, install_already_up_to_date,
+    load_workspace_projects,
+};
 use pacquet_config::Config;
 use pacquet_lockfile::{Lockfile, MaybeLazyLockfile};
 use pacquet_modules_yaml::{
@@ -25,7 +28,7 @@ use pacquet_workspace_state::{
     self as workspace_state, NodeLinker as WorkspaceStateNodeLinker, load_workspace_state,
 };
 use pipe_trait::Pipe;
-use std::sync::Mutex;
+use std::{fs, sync::Mutex};
 use tempfile::tempdir;
 use text_block_macros::text_block;
 
@@ -63,6 +66,39 @@ fn scoped_package_body(registry_url: &str) -> String {
   }}
 }}"#,
     )
+}
+
+#[test]
+fn workspace_without_packages_field_enumerates_root_only() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("package.json"),
+        r#"{"name":"root","version":"0.0.0","scripts":{"prepare":"node root.js"}}"#,
+    )
+    .expect("write root package.json");
+    let nested = dir.path().join("test-e2e/fixtures/vendor/preact/.cache/10.10.2");
+    fs::create_dir_all(&nested).expect("mkdir vendored package");
+    fs::write(
+        nested.join("package.json"),
+        r#"{"name":"preact","version":"10.10.2","scripts":{"prepare":"run-s build"}}"#,
+    )
+    .expect("write vendored package.json");
+    fs::write(dir.path().join("pnpm-workspace.yaml"), "allowBuilds:\n  esbuild: false\n")
+        .expect("write settings-only workspace manifest");
+
+    let manifest = pacquet_workspace::read_workspace_manifest(dir.path())
+        .expect("read workspace manifest")
+        .expect("workspace manifest present");
+
+    let projects = load_workspace_projects(dir.path(), Some(&manifest))
+        .expect("load workspace projects")
+        .expect("workspace projects");
+    let names: Vec<&str> = projects
+        .iter()
+        .filter_map(|project| project.manifest.value().get("name").and_then(|name| name.as_str()))
+        .collect();
+
+    assert_eq!(names, vec!["root"]);
 }
 
 #[tokio::test]

--- a/pacquet/crates/workspace/src/lib.rs
+++ b/pacquet/crates/workspace/src/lib.rs
@@ -28,7 +28,7 @@ pub use api::{EnvVarOs, Host};
 pub use importer_id::importer_id_from_root_dir;
 pub use manifest::{
     InvalidWorkspaceManifestError, ReadWorkspaceManifestError, WORKSPACE_MANIFEST_FILENAME,
-    WorkspaceManifest, read_workspace_manifest,
+    WorkspaceManifest, read_workspace_manifest, workspace_package_patterns,
 };
 pub use project_manifest::{
     ReadProjectManifestError, ReadProjectManifestOnlyError, read_exact_project_manifest,

--- a/pacquet/crates/workspace/src/manifest.rs
+++ b/pacquet/crates/workspace/src/manifest.rs
@@ -107,11 +107,6 @@ pub enum ReadWorkspaceManifestError {
     Invalid(#[error(source)] InvalidWorkspaceManifestError),
 }
 
-/// Read and validate the `pnpm-workspace.yaml` under `dir`.
-///
-/// Returns `Ok(None)` when the file does not exist (matching upstream's
-/// `ENOENT`-as-undefined contract). Every other read or parse failure
-/// propagates.
 /// Resolve `pnpm-workspace.yaml` `packages:` into pnpm's workspace
 /// package pattern default.
 ///
@@ -119,10 +114,16 @@ pub enum ReadWorkspaceManifestError {
 /// `workspaceManifest?.packages ?? ['.']`. A settings-only workspace
 /// manifest therefore enumerates the root project only; it does not use
 /// the lower-level `findPackages` recursive default.
+#[must_use]
 pub fn workspace_package_patterns(manifest: &WorkspaceManifest) -> Vec<String> {
     manifest.packages.clone().unwrap_or_else(|| vec![".".to_string()])
 }
 
+/// Read and validate the `pnpm-workspace.yaml` under `dir`.
+///
+/// Returns `Ok(None)` when the file does not exist (matching upstream's
+/// `ENOENT`-as-undefined contract). Every other read or parse failure
+/// propagates.
 pub fn read_workspace_manifest(
     dir: &Path,
 ) -> Result<Option<WorkspaceManifest>, ReadWorkspaceManifestError> {

--- a/pacquet/crates/workspace/src/manifest.rs
+++ b/pacquet/crates/workspace/src/manifest.rs
@@ -49,12 +49,13 @@ pub struct WorkspaceManifest {
     /// the workspace dir.
     ///
     /// `Option` rather than `Vec` so callers can distinguish three
-    /// states: `None` (the `packages` key is absent — fall back to the
-    /// default `['.', '**']` patterns, matching upstream's
-    /// `opts.patterns ?? defaults`), `Some(vec![])` (explicit empty
-    /// array — enumerate only the workspace root), and `Some(...)`
-    /// (the user's patterns). Collapsing the first two would silently
-    /// promote `packages: []` into a recursive scan.
+    /// states: `None` (the `packages` key is absent), `Some(vec![])`
+    /// (explicit empty array), and `Some(...)` (the user's patterns).
+    /// Callers that enumerate a real workspace should pass this through
+    /// [`workspace_package_patterns`], while direct `findPackages`-style
+    /// callers can still choose the lower-level recursive default.
+    /// Collapsing the first two would silently lose the difference
+    /// between omitted and explicitly-empty `packages`.
     #[serde(default)]
     pub packages: Option<Vec<String>>,
 
@@ -111,6 +112,17 @@ pub enum ReadWorkspaceManifestError {
 /// Returns `Ok(None)` when the file does not exist (matching upstream's
 /// `ENOENT`-as-undefined contract). Every other read or parse failure
 /// propagates.
+/// Resolve `pnpm-workspace.yaml` `packages:` into pnpm's workspace
+/// package pattern default.
+///
+/// Mirrors config-reader's `workspacePackagePatterns` fallback:
+/// `workspaceManifest?.packages ?? ['.']`. A settings-only workspace
+/// manifest therefore enumerates the root project only; it does not use
+/// the lower-level `findPackages` recursive default.
+pub fn workspace_package_patterns(manifest: &WorkspaceManifest) -> Vec<String> {
+    manifest.packages.clone().unwrap_or_else(|| vec![".".to_string()])
+}
+
 pub fn read_workspace_manifest(
     dir: &Path,
 ) -> Result<Option<WorkspaceManifest>, ReadWorkspaceManifestError> {

--- a/pacquet/crates/workspace/src/manifest/tests.rs
+++ b/pacquet/crates/workspace/src/manifest/tests.rs
@@ -49,10 +49,6 @@ fn settings_only_manifest_leaves_packages_none() {
     assert_eq!(manifest.packages, None);
 }
 
-/// An explicit `packages: []` survives as `Some(vec![])` and is
-/// distinct from the omitted case. Downstream this means "enumerate
-/// only the workspace root project," not "fall back to the recursive
-/// `**` default."
 #[test]
 fn workspace_package_patterns_default_settings_only_manifest_to_root() {
     let manifest = WorkspaceManifest { packages: None, ..WorkspaceManifest::default() };
@@ -65,6 +61,10 @@ fn workspace_package_patterns_preserve_explicit_empty_packages() {
     assert_eq!(workspace_package_patterns(&manifest), Vec::<String>::new());
 }
 
+/// An explicit `packages: []` survives as `Some(vec![])` and is
+/// distinct from the omitted case. Downstream this means "enumerate
+/// only the workspace root project," not "fall back to the recursive
+/// `**` default."
 #[test]
 fn empty_packages_array_preserved_as_some_empty() {
     let tmp = TempDir::new().unwrap();

--- a/pacquet/crates/workspace/src/manifest/tests.rs
+++ b/pacquet/crates/workspace/src/manifest/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     InvalidWorkspaceManifestError, ReadWorkspaceManifestError, WORKSPACE_MANIFEST_FILENAME,
-    WorkspaceManifest, read_workspace_manifest,
+    WorkspaceManifest, read_workspace_manifest, workspace_package_patterns,
 };
 use pacquet_catalogs_types::{Catalog, Catalogs};
 use pretty_assertions::assert_eq;
@@ -35,13 +35,8 @@ fn parses_packages_array() {
 }
 
 /// Settings-only manifests (no `packages:`) leave `packages` as
-/// `None` so [`find_workspace_projects`] can apply the
-/// `['.', '**']` defaults. Matches upstream's
-/// `opts.patterns ?? defaults` rule, where the fallback fires for
-/// omitted-only, not for an explicit empty array. Distinguishing
-/// the two states is the whole point of the [`Option`] wrapper.
-///
-/// [`find_workspace_projects`]: crate::find_workspace_projects
+/// `None` so callers can decide whether to apply pnpm's workspace
+/// package pattern default or the lower-level recursive default.
 #[test]
 fn settings_only_manifest_leaves_packages_none() {
     let tmp = TempDir::new().unwrap();
@@ -58,6 +53,18 @@ fn settings_only_manifest_leaves_packages_none() {
 /// distinct from the omitted case. Downstream this means "enumerate
 /// only the workspace root project," not "fall back to the recursive
 /// `**` default."
+#[test]
+fn workspace_package_patterns_default_settings_only_manifest_to_root() {
+    let manifest = WorkspaceManifest { packages: None, ..WorkspaceManifest::default() };
+    assert_eq!(workspace_package_patterns(&manifest), vec![".".to_string()]);
+}
+
+#[test]
+fn workspace_package_patterns_preserve_explicit_empty_packages() {
+    let manifest = WorkspaceManifest { packages: Some(Vec::new()), ..WorkspaceManifest::default() };
+    assert_eq!(workspace_package_patterns(&manifest), Vec::<String>::new());
+}
+
 #[test]
 fn empty_packages_array_preserved_as_some_empty() {
     let tmp = TempDir::new().unwrap();

--- a/pacquet/crates/workspace/src/projects.rs
+++ b/pacquet/crates/workspace/src/projects.rs
@@ -66,10 +66,10 @@ pub struct Project {
 /// option names.
 #[derive(Debug, Default, Clone)]
 pub struct FindWorkspaceProjectsOpts {
-    /// `packages:` from `pnpm-workspace.yaml`. When `None`, upstream
-    /// falls back to `['.', '**']`. Pacquet mirrors that default so a
-    /// workspace whose manifest only carries settings still enumerates
-    /// projects.
+    /// Package discovery patterns. When `None`, this lower-level
+    /// `findPackages` port falls back to `['.', '**']`. Callers
+    /// enumerating a real workspace manifest should pass
+    /// [`crate::workspace_package_patterns`] instead.
     pub patterns: Option<Vec<String>>,
 }
 

--- a/pacquet/tasks/integrated-benchmark/src/latency_proxy/tests.rs
+++ b/pacquet/tasks/integrated-benchmark/src/latency_proxy/tests.rs
@@ -168,13 +168,18 @@ fn slow_start_ramps_per_connection_throughput() {
     };
     // Flat: ~2×20ms latency + 256KiB/10MB/s ≈ 66 ms. Ramped: the first
     // windows (14.6 KB and doubling) each serialize at cwnd/RTT, adding ~3-4
-    // window-times before the rate approaches the cap. Compare the best of
-    // several samples on each side: the minimum is the noise-resistant
-    // estimator on a loaded CI runner — scheduler stalls only ever inflate a
-    // sample, while slow start's ramp overhead is structural and survives in
-    // every sample, including the minimum.
-    let flat = best_of(3, false);
-    let ramped = best_of(3, true);
+    // window-times before the rate approaches the cap, so the structural gap
+    // is well over 100 ms — far above the 25 ms the assertion requires.
+    // Compare the best of several samples on each side: the minimum is the
+    // noise-resistant estimator on a loaded CI runner — scheduler stalls only
+    // ever inflate a sample, while slow start's ramp overhead is structural
+    // and survives in every sample, including the minimum. The only way to
+    // falsely fail is for *every* flat sample to be stalled at once, so take
+    // the minimum over enough samples that a near-clean flat reading is
+    // effectively guaranteed.
+    const SAMPLES: u32 = 8;
+    let flat = best_of(SAMPLES, false);
+    let ramped = best_of(SAMPLES, true);
     assert!(
         ramped > flat + Duration::from_millis(25),
         "slow start should add ramp-up time: flat {flat:?} vs ramped {ramped:?}",


### PR DESCRIPTION
Fixes pacquet workspace project enumeration when `pnpm-workspace.yaml` exists but does not define `packages`.

A settings-only workspace manifest like this:

```yaml
allowBuilds:
  esbuild: false
```

should still make the project a workspace, but it should only enumerate the root importer. Pacquet was passing the missing packages field through to the lower-level workspace project finder, which uses the recursive `['.', '**']` default. That could accidentally treat vendored fixture packages as workspace projects.

This maps absent packages to `['.']` in the install path, matching pnpm’s config-reader `workspacePackagePatterns` default:

```ts
cliOptions['workspace-packages'] ?? workspaceManifest?.packages ?? ['.']
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace enumeration now respects workspace package patterns from manifests, avoiding inclusion of vendored or fixture packages during recursive operations.

* **Tests**
  * Added integration and unit tests verifying root-only enumeration for settings-style workspace manifests and explicit-empty-package behavior.

* **Documentation**
  * Clarified workspace manifest and pattern behavior in docs to explain the difference between omitted vs explicitly empty package lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->