### PR TITLE
fix: preserve workspace specs on update

### DIFF
--- a/.changeset/preserve-workspace-update-spec.md
+++ b/.changeset/preserve-workspace-update-spec.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fixed `pnpm update` rewriting a `workspace:` dependency that points at a local path (e.g. `workspace:../packages/foo/dist`) into a normalized `link:` or version-range specifier. Such specifiers are now preserved verbatim when the workspace protocol is preserved [#3902](https://github.com/pnpm/pnpm/issues/3902).

--- a/installing/deps-resolver/src/updateProjectManifest.ts
+++ b/installing/deps-resolver/src/updateProjectManifest.ts
@@ -25,7 +25,7 @@ export async function updateProjectManifest (
       return {
         alias: rdd.alias,
         peer: importer.peer,
-        bareSpecifier: rdd.catalogLookup?.userSpecifiedBareSpecifier ?? rdd.normalizedBareSpecifier ?? wantedDep.bareSpecifier,
+        bareSpecifier: getBareSpecifierToSave(wantedDep, rdd, opts.preserveWorkspaceProtocol),
         resolvedVersion: rdd.version,
         pinnedVersion: importer.pinnedVersion,
         saveType: importer.targetDependenciesField,
@@ -53,4 +53,24 @@ export async function updateProjectManifest (
     )
     : undefined
   return [hookedManifest, originalManifest]
+}
+
+function getBareSpecifierToSave (
+  wantedDep: ImporterToResolve['wantedDependencies'][number],
+  resolvedDep: ResolvedDirectDependency,
+  preserveWorkspaceProtocol: boolean
+): string {
+  if (resolvedDep.catalogLookup != null) {
+    return resolvedDep.catalogLookup.userSpecifiedBareSpecifier
+  }
+  if (preserveWorkspaceProtocol && isWorkspaceLocalPathSpecifier(wantedDep.bareSpecifier)) {
+    return wantedDep.bareSpecifier
+  }
+  return resolvedDep.normalizedBareSpecifier ?? wantedDep.bareSpecifier
+}
+
+function isWorkspaceLocalPathSpecifier (bareSpecifier: string): boolean {
+  if (!bareSpecifier.startsWith('workspace:')) return false
+  const pref = bareSpecifier.slice('workspace:'.length)
+  return pref.startsWith('.') || pref.startsWith('/') || pref.startsWith('~/') || /^[A-Z]:/i.test(pref)
 }

--- a/installing/deps-resolver/test/updateProjectManifest.test.ts
+++ b/installing/deps-resolver/test/updateProjectManifest.test.ts
@@ -1,0 +1,100 @@
+import { expect, test } from '@jest/globals'
+import type { PkgResolutionId, ProjectId, ProjectRootDir } from '@pnpm/types'
+
+import type { ImporterToResolve } from '../lib/index.js'
+import type { ResolvedDirectDependency } from '../lib/resolveDependencyTree.js'
+import { updateProjectManifest } from '../lib/updateProjectManifest.js'
+
+test('updateProjectManifest preserves workspace protocol specs when requested', async () => {
+  const [manifest] = await updateProjectManifest(createImporter('workspace:../packages/foo/dist'), {
+    directDependencies: [createDirectDependency()],
+    preserveWorkspaceProtocol: true,
+    saveWorkspaceProtocol: 'rolling',
+  })
+
+  expect(manifest?.dependencies?.foo).toBe('workspace:../packages/foo/dist')
+})
+
+test('updateProjectManifest saves normalized local specs when workspace protocol is not preserved', async () => {
+  const [manifest] = await updateProjectManifest(createImporter('workspace:../packages/foo/dist'), {
+    directDependencies: [createDirectDependency()],
+    preserveWorkspaceProtocol: false,
+    saveWorkspaceProtocol: 'rolling',
+  })
+
+  expect(manifest?.dependencies?.foo).toBe('link:../packages/foo/dist')
+})
+
+test('updateProjectManifest saves normalized workspace range specs', async () => {
+  const [manifest] = await updateProjectManifest(createImporter('workspace:*'), {
+    directDependencies: [
+      createDirectDependency({
+        normalizedBareSpecifier: 'workspace:^1.0.0',
+      }),
+    ],
+    preserveWorkspaceProtocol: true,
+    saveWorkspaceProtocol: 'rolling',
+  })
+
+  expect(manifest?.dependencies?.foo).toBe('workspace:^1.0.0')
+})
+
+test('updateProjectManifest preserves catalog specifier precedence', async () => {
+  const [manifest] = await updateProjectManifest(createImporter('workspace:../packages/foo/dist'), {
+    directDependencies: [
+      createDirectDependency({
+        catalogLookup: {
+          catalogName: 'default',
+          specifier: '^1.0.0',
+          userSpecifiedBareSpecifier: 'catalog:',
+        },
+      }),
+    ],
+    preserveWorkspaceProtocol: true,
+    saveWorkspaceProtocol: 'rolling',
+  })
+
+  expect(manifest?.dependencies?.foo).toBe('catalog:')
+})
+
+function createImporter (bareSpecifier: string): ImporterToResolve {
+  return {
+    binsDir: '/project/node_modules/.bin',
+    id: '.' as ProjectId,
+    manifest: {
+      dependencies: {
+        foo: bareSpecifier,
+      },
+    },
+    modulesDir: '/project/node_modules',
+    rootDir: '/project' as ProjectRootDir,
+    targetDependenciesField: 'dependencies',
+    updatePackageManifest: true,
+    wantedDependencies: [
+      {
+        alias: 'foo',
+        bareSpecifier,
+        dev: false,
+        optional: false,
+        updateSpec: true,
+      },
+    ],
+  }
+}
+
+function createDirectDependency (overrides: Partial<ResolvedDirectDependency> = {}): ResolvedDirectDependency {
+  return {
+    alias: 'foo',
+    dev: false,
+    name: 'foo',
+    normalizedBareSpecifier: 'link:../packages/foo/dist',
+    optional: false,
+    pkgId: 'link:../packages/foo/dist' as PkgResolutionId,
+    resolution: {
+      directory: '../packages/foo/dist',
+      type: 'directory',
+    },
+    version: '1.0.0',
+    ...overrides,
+  }
+}

--- a/pacquet/crates/cli/tests/update.rs
+++ b/pacquet/crates/cli/tests/update.rs
@@ -188,6 +188,46 @@ fn update_latest_preserves_exact() {
     drop((root, anchor));
 }
 
+/// `--latest` must not rewrite a `workspace:` dependency that points at a
+/// local path. Resolving it against the registry would either fail (the
+/// package is workspace-only, not published) or replace the path — which can
+/// target a publish directory — with a version range. Regression test for
+/// <https://github.com/pnpm/pnpm/issues/3902>.
+#[test]
+fn update_latest_preserves_workspace_local_path_specifier() {
+    let (root, workspace, anchor) = setup();
+
+    // A workspace-only sibling package, not published to the mocked
+    // registry, referenced by a `workspace:` local path.
+    let sibling = workspace.join("local-dep");
+    fs::create_dir_all(&sibling).expect("mkdir local-dep");
+    fs::write(sibling.join("package.json"), r#"{ "name": "local-dep", "version": "1.0.0" }"#)
+        .expect("write local-dep/package.json");
+
+    let workspace_yaml = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&workspace_yaml).expect("read pnpm-workspace.yaml");
+    // Fail loudly if the harness ever starts writing `packages:` — appending a
+    // second top-level mapping key produces invalid YAML.
+    assert!(
+        !yaml.contains("packages:"),
+        "pnpm-workspace.yaml already has a `packages:` key — update this test",
+    );
+    if !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    yaml.push_str("packages:\n  - 'local-dep'\n");
+    fs::write(&workspace_yaml, yaml).expect("write pnpm-workspace.yaml");
+
+    write_manifest(&workspace, r#"{ "local-dep": "workspace:./local-dep" }"#);
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["update", "--latest"]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, "local-dep").as_deref(), Some("workspace:./local-dep"));
+
+    drop((root, anchor));
+}
+
 /// A package selector only updates the matched dependency; others keep
 /// their manifest ranges.
 #[test]

--- a/pacquet/crates/package-manager/src/update.rs
+++ b/pacquet/crates/package-manager/src/update.rs
@@ -288,7 +288,7 @@ impl Update<'_> {
                 if is_ignored(name) {
                     continue;
                 }
-                if latest {
+                if latest && !is_workspace_local_path_specifier(prev) {
                     let version = fetch_latest(name, http_client, config).await?;
                     let pin =
                         latest_pin(&mut catalog_ctx, manifest, config, prev, name, pinned_version)?;
@@ -390,7 +390,7 @@ impl Update<'_> {
             } else {
                 for (name, group, prev) in &matched_direct {
                     drop_names.insert(name.clone());
-                    if latest {
+                    if latest && !is_workspace_local_path_specifier(prev) {
                         let version = fetch_latest(name, http_client, config).await?;
                         let pin = latest_pin(
                             &mut catalog_ctx,
@@ -700,6 +700,28 @@ async fn fetch_latest(
     )
     .await
     .map_err(|error| UpdateError::ResolveLatest { name: name.to_string(), error })
+}
+
+/// Whether `bare_specifier` is a `workspace:` spec that points at a local
+/// path (e.g. `workspace:../packages/foo/dist`) rather than a version range
+/// (`workspace:*`, `workspace:^1.0.0`). Such specs are preserved verbatim on
+/// `--latest` instead of being resolved against the registry, since the path
+/// may target a publish directory that a normalized range would drop.
+///
+/// pnpm keeps these out of the registry-resolution path via
+/// `preserveWorkspaceProtocol`, which is always on under `update --latest`
+/// (the override that derives it from `linkWorkspacePackages` only runs under
+/// `--workspace`, and `--workspace` cannot be combined with `--latest`).
+/// Mirrors [`isWorkspaceLocalPathSpecifier`](https://github.com/pnpm/pnpm/blob/fddb8a4032/installing/deps-resolver/src/updateProjectManifest.ts#L72-L76).
+fn is_workspace_local_path_specifier(bare_specifier: &str) -> bool {
+    let Some(pref) = bare_specifier.strip_prefix("workspace:") else {
+        return false;
+    };
+    let is_windows_drive = {
+        let mut chars = pref.chars();
+        chars.next().is_some_and(|first| first.is_ascii_alphabetic()) && chars.next() == Some(':')
+    };
+    pref.starts_with('.') || pref.starts_with('/') || pref.starts_with("~/") || is_windows_drive
 }
 
 #[cfg(test)]

--- a/pacquet/crates/package-manager/src/update/tests.rs
+++ b/pacquet/crates/package-manager/src/update/tests.rs
@@ -1,4 +1,4 @@
-use super::parse_update_param;
+use super::{is_workspace_local_path_specifier, parse_update_param};
 
 #[test]
 fn parses_bare_name_without_version() {
@@ -49,4 +49,35 @@ fn negated_unscoped_pattern_without_version() {
     let parsed = parse_update_param("!foo");
     assert_eq!(parsed.pattern, "!foo");
     assert_eq!(parsed.version, None);
+}
+
+#[test]
+fn workspace_local_path_specifiers_are_detected() {
+    for spec in [
+        "workspace:.",
+        "workspace:./packages/foo",
+        "workspace:../packages/foo/dist",
+        "workspace:/abs/path",
+        "workspace:~/home/path",
+        r"workspace:C:\packages\foo",
+    ] {
+        assert!(is_workspace_local_path_specifier(spec), "expected {spec} to be a local path");
+    }
+}
+
+#[test]
+fn workspace_range_specifiers_are_not_local_paths() {
+    for spec in [
+        "workspace:*",
+        "workspace:^",
+        "workspace:~",
+        "workspace:^1.0.0",
+        "workspace:~1.2.3",
+        "workspace:1.0.0",
+        "workspace:alias@*",
+        "^1.0.0",
+        "link:../foo",
+    ] {
+        assert!(!is_workspace_local_path_specifier(spec), "expected {spec} not to be a local path");
+    }
 }


### PR DESCRIPTION
## What
- preserve existing `workspace:` dependency specifiers when `updateProjectManifest` saves updated direct dependencies and `preserveWorkspaceProtocol` is enabled
- keep catalog specifiers taking precedence over resolver-normalized specs
- add focused coverage for preserved and normalized local spec behavior
- add a changeset for the published `@pnpm/installing.deps-resolver` change

### pacquet parity
Ported the same fix to pacquet's `update` command. Previously `pacquet update --latest` routed every direct dependency through a registry `latest` lookup, so a `workspace:` local-path dependency (e.g. `workspace:../packages/foo/dist`) was rewritten into a registry version — corrupting the manifest (in the regression test it became `0.0.1-security`). Both `--latest` rewrite sites now skip registry resolution for such specs via `is_workspace_local_path_specifier`, a faithful port of pnpm's `isWorkspaceLocalPathSpecifier`. The gate is unconditional in the `--latest` path because `preserveWorkspaceProtocol` is always on there (its only override derives from `linkWorkspacePackages` under `--workspace`, which cannot be combined with `--latest`).

Fixes #3902

## Testing
pnpm side:
- `pnpm --dir installing/deps-resolver exec tsgo --build`
- `env NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" pnpm --dir installing/deps-resolver exec jest updateProjectManifest.test.ts`
- `pnpm --dir installing/deps-resolver exec eslint src/updateProjectManifest.ts test/updateProjectManifest.test.ts`

pacquet side:
- `cargo nextest run -p pacquet-package-manager workspace` — helper unit tests
- `cargo nextest run -E 'test(update_latest_preserves_workspace_local_path_specifier)'` — integration regression test (verified it fails without the guard: the manifest spec was rewritten to `0.0.1-security`)
- `cargo clippy -p pacquet-package-manager -p pacquet-cli --all-targets -- --deny warnings`
- `cargo fmt --check`

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved dependency specifier selection by prioritizing catalog-provided specifiers and centralizing `workspace:` preservation vs normalization logic.

* **Bug Fixes**
  * Fixed `pnpm update` / `pacquet update --latest` rewriting `workspace:` specifiers that point to local paths, keeping them as-is when appropriate.

* **Tests**
  * Added Jest and Rust regression/unit tests covering workspace protocol edge cases (local-path detection, range forms, catalog precedence) and shared test fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
