### PR TITLE
feat(pnpr): support `--lockfile-only` on the pnpr install path (resolve-only mode)

### DIFF
--- a/.changeset/pnpr-lockfile-only.md
+++ b/.changeset/pnpr-lockfile-only.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/agent.client": minor
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+`pnpm install --lockfile-only` (and the `lockfileOnly` setting) is now honored when an agent / `pnprServer` is configured. The agent path resolves and writes `pnpm-lock.yaml` but fetches no files into the store and links no `node_modules`, matching the local lockfile-only behavior. The client ignores any file/index lines an older agent server still streams, so the store stays untouched even against a server that predates the resolve-only mode [#12146](https://github.com/pnpm/pnpm/issues/12146).

--- a/agent/client/src/fetchFromPnpmRegistry.ts
+++ b/agent/client/src/fetchFromPnpmRegistry.ts
@@ -32,7 +32,7 @@ export interface FetchFromPnpmRegistryOptions {
   overrides?: Record<string, string>
   /** Node.js version for resolution */
   nodeVersion?: string
-  /** Minimum release age in seconds */
+  /** Minimum release age in minutes */
   minimumReleaseAge?: number
   /** Existing lockfile for incremental resolution */
   lockfile?: LockfileObject

--- a/agent/client/src/fetchFromPnpmRegistry.ts
+++ b/agent/client/src/fetchFromPnpmRegistry.ts
@@ -36,6 +36,15 @@ export interface FetchFromPnpmRegistryOptions {
   minimumReleaseAge?: number
   /** Existing lockfile for incremental resolution */
   lockfile?: LockfileObject
+  /**
+   * `--lockfile-only`: resolve and return only the lockfile — fetch no
+   * files into the local store. Forwarded to the server (which skips the
+   * file diff when it understands the flag); the client also ignores any
+   * `D`/`I` lines so the store stays untouched even against an older
+   * server. Mirrors pnpm's resolve + write, fetch nothing, link nothing.
+   * See https://github.com/pnpm/pnpm/issues/12146.
+   */
+  lockfileOnly?: boolean
 }
 
 export interface FetchFromPnpmRegistryResult {
@@ -77,6 +86,7 @@ export async function fetchFromPnpmRegistry (
     arch: process.arch,
     minimumReleaseAge: opts.minimumReleaseAge,
     lockfile: opts.lockfile,
+    lockfileOnly: opts.lockfileOnly,
     storeIntegrities,
   })
 
@@ -106,6 +116,9 @@ export async function fetchFromPnpmRegistry (
       const tabIdx = line.indexOf('\t')
       const type = line.charAt(0)
       if (type === 'D') {
+        // `--lockfile-only` fetches nothing — ignore any file digests an
+        // older server still streams rather than writing them to the store.
+        if (opts.lockfileOnly) return
         const parts = line.split('\t')
         currentBatch.push({
           digest: parts[1],
@@ -133,6 +146,9 @@ export async function fetchFromPnpmRegistry (
           indexEntries,
         })
       } else if (type === 'I') {
+        // `--lockfile-only` writes no store-index entries — ignore any an
+        // older server still streams.
+        if (opts.lockfileOnly) return
         // Format: I\t{integrity}\t{pkgId}\t{base64}
         // Key is "{integrity}\t{pkgId}" — everything between first and last tab
         const rest = line.substring(tabIdx + 1)

--- a/agent/server/test/integration.ts
+++ b/agent/server/test/integration.ts
@@ -129,6 +129,39 @@ describe('pnpm-agent integration', () => {
     }
   })
 
+  it('lockfileOnly resolves without writing files or index entries to the client store', async () => {
+    const tmpClient = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-agent-test-lockfile-only-'))
+    const clientStoreDir = path.join(tmpClient, 'store')
+    await fs.mkdir(clientStoreDir, { recursive: true })
+    const clientStoreIndex = new StoreIndex(clientStoreDir)
+
+    try {
+      const result = await fetchFromPnpmRegistry({
+        registryUrl: `http://localhost:${serverPort}`,
+        storeDir: clientStoreDir,
+        storeIndex: clientStoreIndex,
+        dependencies: {
+          'is-positive': '1.0.0',
+        },
+        lockfileOnly: true,
+      })
+
+      // Resolution still happened — the lockfile is returned.
+      expect(Object.keys(result.lockfile.packages ?? {}).length).toBeGreaterThanOrEqual(1)
+
+      // But nothing is fetched into the client store: no index entries are
+      // collected and no CAFS files are written, even though the server may
+      // still stream D/I lines.
+      expect(result.indexEntries).toEqual([])
+      await result.fileDownloads
+      const cafsFilesDir = path.join(clientStoreDir, 'files')
+      await expect(fs.access(cafsFilesDir)).rejects.toThrow()
+    } finally {
+      clientStoreIndex.close()
+      await fs.rm(tmpClient, { recursive: true, force: true })
+    }
+  })
+
   it('returns consistent lockfile on repeated requests', async () => {
     const tmpClient = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-agent-test-client2-'))
     const clientStoreDir = path.join(tmpClient, 'store')

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -2415,6 +2415,10 @@ async function installFromPnpmRegistry (
     // pnpm fetches nothing and links nothing in this mode — stop before the
     // headless install. See https://github.com/pnpm/pnpm/issues/12146.
     if (opts.lockfileOnly) {
+      // Nothing is downloaded in this mode, but the lockfile arrives before
+      // the stream closes — observe `fileDownloads` so a stream error after
+      // the `L` frame doesn't surface as an unhandled rejection.
+      void fileDownloads.catch(() => {})
       return {
         updatedCatalogs: undefined,
         updatedManifest: manifest,

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -2385,6 +2385,7 @@ async function installFromPnpmRegistry (
         overrides: opts.overrides,
         minimumReleaseAge: opts.minimumReleaseAge,
         lockfile: existingLockfile ?? undefined,
+        lockfileOnly: opts.lockfileOnly,
       }))
 
       // Write store index entries so headless install finds them.
@@ -2409,6 +2410,20 @@ async function installFromPnpmRegistry (
       message: `Resolved ${agentStats.totalPackages} packages: ${agentStats.alreadyInStore} cached, ${agentStats.filesToDownload} files to download`,
       prefix: rootDir,
     })
+
+    // `--lockfile-only`: the agent resolved and we wrote the lockfile, but
+    // pnpm fetches nothing and links nothing in this mode — stop before the
+    // headless install. See https://github.com/pnpm/pnpm/issues/12146.
+    if (opts.lockfileOnly) {
+      return {
+        updatedCatalogs: undefined,
+        updatedManifest: manifest,
+        ignoredBuilds: undefined,
+        stats: { added: 0, removed: 0, linkedToRoot: 0 },
+        lockfile,
+        resolutionPolicyViolations: [],
+      }
+    }
 
     // Wrap fetchPackage to:
     // 1. Wait for agent file downloads before checking the store

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -403,12 +403,12 @@ struct PnprLink<'a> {
     /// sending the raw CLI override — keeps a yaml `preferFrozenLockfile:
     /// false` honored on the pnpr path without `--no-prefer-frozen-lockfile`.
     prefer_frozen_lockfile: bool,
-    /// `--lockfile-only`. Unsupported on the pnpr path — the protocol
-    /// bundles resolution with file distribution, so there's no
-    /// resolve-only mode yet (see
-    /// [pnpm/pnpm#12146](https://github.com/pnpm/pnpm/issues/12146)).
-    /// `install_via_pnpr` errors when this is set rather than silently
-    /// fetching + linking.
+    /// `--lockfile-only`. Forwarded to `/v1/install` so the server
+    /// resolves only — returning the lockfile without fetching files —
+    /// after which `install_via_pnpr` writes the lockfile and skips
+    /// materialization, mirroring pnpm's resolve + write, fetch nothing,
+    /// link nothing. See
+    /// [pnpm/pnpm#12146](https://github.com/pnpm/pnpm/issues/12146).
     lockfile_only: bool,
     /// `--ignore-manifest-check`; forwarded so the server's frozen
     /// freshness check and the local materialization both skip the
@@ -427,23 +427,13 @@ struct PnprLink<'a> {
 /// them and streams back the missing files; writes the server-produced
 /// lockfile, then runs a frozen install to materialize `node_modules`
 /// from it — the equivalent of pnpm's `installFromPnpmRegistry` handing
-/// off to `headlessInstall`.
+/// off to `headlessInstall`. Under `--lockfile-only` it stops after
+/// writing the lockfile (fetch nothing, link nothing).
 async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
     state: &State,
     pnpr_server: &str,
     link: PnprLink<'_>,
 ) -> miette::Result<()> {
-    // `--lockfile-only` can't be honored on the pnpr path yet: `/v1/install`
-    // bundles resolution with file distribution, so the files are fetched
-    // before the client could skip linking. Error rather than silently
-    // fetching + linking. Tracked by
-    // [pnpm/pnpm#12146](https://github.com/pnpm/pnpm/issues/12146).
-    if link.lockfile_only {
-        return Err(miette::miette!(
-            "`--lockfile-only` is not supported with a pnprServer yet (https://github.com/pnpm/pnpm/issues/12146); unset pnprServer to run it locally."
-        ));
-    }
-
     let dependencies = state
         .manifest
         .dependencies([DependencyGroup::Prod])
@@ -483,6 +473,7 @@ async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
             frozen_lockfile: link.frozen_lockfile,
             prefer_frozen_lockfile: Some(link.prefer_frozen_lockfile),
             ignore_manifest_check: link.ignore_manifest_check,
+            lockfile_only: link.lockfile_only,
             trust_lockfile: link.trust_lockfile,
             minimum_release_age: state.config.minimum_release_age,
             minimum_release_age_exclude: state.config.minimum_release_age_exclude.clone(),
@@ -516,6 +507,14 @@ async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
             .save_to_path(&lockfile_dir.join(Lockfile::FILE_NAME))
             .map_err(|err| miette::miette!("{err}"))
             .wrap_err("writing the pnpr-resolved lockfile")?;
+    }
+
+    // `--lockfile-only`: the server resolved and returned the lockfile
+    // but fetched nothing; pnpm links nothing in this mode, so stop after
+    // writing the lockfile rather than running the materialization pass.
+    // See [pnpm/pnpm#12146](https://github.com/pnpm/pnpm/issues/12146).
+    if link.lockfile_only {
+        return Ok(());
     }
 
     Install {

--- a/pacquet/crates/cli/tests/pnpr_install.rs
+++ b/pacquet/crates/cli/tests/pnpr_install.rs
@@ -87,3 +87,37 @@ fn install_via_pnpr_links_node_modules() {
 
     drop((root, mock_instance));
 }
+
+#[test]
+fn install_via_pnpr_lockfile_only_writes_lockfile_without_linking() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    let pnpr_url = start_pnpr();
+
+    let manifest_path = workspace.join("package.json");
+    let package_json = serde_json::json!({
+        "dependencies": { "@foo/no-deps": "1.0.0" },
+    });
+    fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+    pacquet
+        .with_arg("install")
+        .with_arg("--pnpr-server")
+        .with_arg(&pnpr_url)
+        .with_arg("--lockfile-only")
+        .assert()
+        .success();
+
+    // `--lockfile-only` resolves and writes the lockfile but fetches
+    // nothing and links nothing.
+    assert!(workspace.join("pnpm-lock.yaml").exists(), "pnpr should write the lockfile");
+    assert!(!workspace.join("node_modules").exists(), "lockfile-only must not link node_modules");
+    assert!(
+        !store_dir.join("v11/index.db").exists(),
+        "lockfile-only must not populate the client store",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pacquet/crates/pnpr-client/src/lib.rs
+++ b/pacquet/crates/pnpr-client/src/lib.rs
@@ -69,6 +69,13 @@ pub struct InstallOptions<'a> {
     /// `ignoreManifestCheck`: skip the manifest ↔ lockfile freshness
     /// comparison during the frozen resolve.
     pub ignore_manifest_check: bool,
+    /// `lockfileOnly`: ask the server to resolve only — return the
+    /// lockfile without fetching tarballs or computing the file diff, so
+    /// the response carries no missing files. The caller writes the
+    /// lockfile and skips materialization, mirroring pnpm's
+    /// `--lockfile-only`. See
+    /// [pnpm/pnpm#12146](https://github.com/pnpm/pnpm/issues/12146).
+    pub lockfile_only: bool,
     /// The client's effective `trustLockfile`. When `true` the server
     /// skips verifying the input lockfile (it still reuses it for
     /// resolution), mirroring the local `--trust-lockfile` opt-out.
@@ -206,6 +213,7 @@ impl PnprClient {
             "frozenLockfile": opts.frozen_lockfile,
             "preferFrozenLockfile": opts.prefer_frozen_lockfile,
             "ignoreManifestCheck": opts.ignore_manifest_check,
+            "lockfileOnly": opts.lockfile_only,
             "trustLockfile": opts.trust_lockfile,
             "minimumReleaseAge": opts.minimum_release_age,
             "minimumReleaseAgeExclude": opts.minimum_release_age_exclude,
@@ -225,6 +233,19 @@ impl PnprClient {
         let ndjson = response.text().await?;
 
         let parsed = parse_install_response(&ndjson)?;
+
+        // `--lockfile-only`: pnpm fetches nothing and links nothing. A
+        // resolve-only server sends no `D`/`I` lines, but stay correct
+        // even against one that doesn't understand the flag by never
+        // touching the local store.
+        if opts.lockfile_only {
+            return Ok(InstallOutcome {
+                lockfile: parsed.lockfile,
+                stats: parsed.stats,
+                files_written: 0,
+                index_entries_written: 0,
+            });
+        }
 
         let files_written = self.download_files(opts.store_dir, &parsed.missing_files).await?;
 

--- a/pacquet/crates/pnpr-client/tests/integration.rs
+++ b/pacquet/crates/pnpr-client/tests/integration.rs
@@ -66,6 +66,7 @@ fn options<'a>(
         frozen_lockfile: false,
         prefer_frozen_lockfile: None,
         ignore_manifest_check: false,
+        lockfile_only: false,
         trust_lockfile: false,
         minimum_release_age: None,
         minimum_release_age_exclude: None,
@@ -109,6 +110,37 @@ async fn resolves_and_downloads_a_package() {
     assert!(
         store_keys.iter().any(|key| key.contains("@foo/no-deps@1.0.0")),
         "client store index should hold the package, got: {store_keys:?}",
+    );
+}
+
+#[tokio::test]
+async fn lockfile_only_resolves_without_fetching_files() {
+    let registry = TestRegistry::start();
+    let (pnpr_url, _storage) = start_pnpr().await;
+
+    let client_store = TempDir::new().unwrap();
+    let store = StoreDir::new(client_store.path().to_path_buf());
+    let client = PnprClient::new(pnpr_url);
+
+    // `--lockfile-only`: the server resolves and returns the lockfile but
+    // fetches nothing and serves no files, so the client store stays
+    // empty. Mirrors pnpm's resolve + write, fetch nothing, link nothing.
+    let mut opts = options(&store, &registry.url(), deps([("@foo/no-deps", "1.0.0")]));
+    opts.lockfile_only = true;
+    let outcome = client.install(opts).await.expect("lockfile-only install should succeed");
+
+    let packages = outcome.lockfile.packages.as_ref().expect("lockfile has packages");
+    assert!(
+        packages.keys().any(|key| key.to_string().starts_with("@foo/no-deps@1.0.0")),
+        "lockfile should still contain @foo/no-deps@1.0.0",
+    );
+    assert_eq!(outcome.files_written, 0, "lockfile-only should download no files");
+    assert_eq!(outcome.index_entries_written, 0, "lockfile-only should write no index entries");
+    assert!(
+        pacquet_store_dir::StoreIndex::open_readonly_in(&store)
+            .map(|index| index.keys().unwrap_or_default().is_empty())
+            .unwrap_or(true),
+        "client store index should stay empty after a lockfile-only install",
     );
 }
 

--- a/pnpr/crates/pnpr/src/install_accelerator.rs
+++ b/pnpr/crates/pnpr/src/install_accelerator.rs
@@ -210,26 +210,39 @@ pub(crate) async fn handle_install(runtime: &InstallAccelerator, body: Bytes) ->
 
     let packages = resolve::collect_packages(&lockfile, &config.registry);
 
-    if let Err(err) = resolve::fetch_uncached(config, &runtime.client, &packages).await {
-        return json_error(StatusCode::INTERNAL_SERVER_ERROR, &err.to_string());
-    }
+    // `--lockfile-only`: pnpm resolves and writes the lockfile but
+    // fetches nothing and links nothing. Skip the tarball fetch + the
+    // file-level diff and return just the lockfile; the client writes it
+    // and stops, so the response carries no `D`/`I` lines.
+    // See [pnpm/pnpm#12146](https://github.com/pnpm/pnpm/issues/12146).
+    let result = if request.lockfile_only {
+        diff::DiffResult {
+            missing_files: Vec::new(),
+            package_index: Vec::new(),
+            stats: diff::Stats { total_packages: packages.len() as u64, ..diff::Stats::default() },
+        }
+    } else {
+        if let Err(err) = resolve::fetch_uncached(config, &runtime.client, &packages).await {
+            return json_error(StatusCode::INTERNAL_SERVER_ERROR, &err.to_string());
+        }
 
-    let store = match StoreIndex::open_readonly_in(&config.store_dir) {
-        Ok(store) => store,
-        Err(err) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, &err.to_string()),
-    };
+        let store = match StoreIndex::open_readonly_in(&config.store_dir) {
+            Ok(store) => store,
+            Err(err) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, &err.to_string()),
+        };
 
-    let diff_packages: Vec<diff::ResolvedPackage> = packages
-        .iter()
-        .map(|pkg| diff::ResolvedPackage {
-            integrity: pkg.integrity.clone(),
-            pkg_id: pkg.pkg_id.clone(),
-        })
-        .collect();
+        let diff_packages: Vec<diff::ResolvedPackage> = packages
+            .iter()
+            .map(|pkg| diff::ResolvedPackage {
+                integrity: pkg.integrity.clone(),
+                pkg_id: pkg.pkg_id.clone(),
+            })
+            .collect();
 
-    let result = match diff::compute_diff(&store, &diff_packages, &request.store_integrities) {
-        Ok(result) => result,
-        Err(err) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, &err.to_string()),
+        match diff::compute_diff(&store, &diff_packages, &request.store_integrities) {
+            Ok(result) => result,
+            Err(err) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, &err.to_string()),
+        }
     };
 
     let mut ndjson: Vec<u8> = Vec::new();

--- a/pnpr/crates/pnpr/src/install_accelerator/protocol.rs
+++ b/pnpr/crates/pnpr/src/install_accelerator/protocol.rs
@@ -66,6 +66,14 @@ pub struct InstallRequest {
     /// comparison during the frozen resolve.
     #[serde(default)]
     pub ignore_manifest_check: bool,
+    /// `lockfileOnly`: resolve and return only the lockfile — skip the
+    /// tarball fetch and the file-level diff entirely. Mirrors pnpm's
+    /// `--lockfile-only` (resolve + write lockfile, fetch nothing, link
+    /// nothing); the response carries just the `L` line, no `D`/`I`
+    /// lines. See
+    /// [pnpm/pnpm#12146](https://github.com/pnpm/pnpm/issues/12146).
+    #[serde(default)]
+    pub lockfile_only: bool,
     /// The client's effective `trustLockfile`. When `true` the client
     /// opted out of lockfile verification, so the server skips the
     /// input-lockfile verify gate (it still reuses the lockfile for


### PR DESCRIPTION
## What

Lift the restriction tracked by #12146: `pacquet install --lockfile-only` (and the `lockfileOnly` setting) is now honored when a `pnprServer` / agent is configured. Previously pacquet **errored** rather than silently fetching + linking (added in #12144). The faithful pnpm behavior — **resolve + write `pnpm-lock.yaml`, fetch nothing, link nothing** — is now supported via a server-side resolve-only mode plus a defensive client.

## How

This implements **both** options the issue outlined: a server resolve-only mode *and* a client that skips materialization.

### Rust pnpr / pacquet (the issue's explicit scope)
- **`pnpr` server** (`install_accelerator.rs`, `protocol.rs`): new `lockfileOnly` request field. When set, the handler resolves and returns only the `L` line — skipping `fetch_uncached` (tarball fetch) and `compute_diff` (file diff), so no `D`/`I` lines are streamed.
- **`pacquet-pnpr-client`** (`lib.rs`): new `lockfile_only` option, forwarded to `/v1/install`. As a backstop, when set the client returns the lockfile immediately and never touches the local store — holding the guarantee even against a server that predates resolve-only.
- **`pacquet-cli`** (`install.rs`): removed the error; threads the flag through and returns right after writing the lockfile, skipping the materialization `Install`.

### TypeScript `@pnpm/agent.*` client (client-side only, per maintainer guidance — the agent **server** is intentionally untouched)
- **`@pnpm/agent.client`** (`fetchFromPnpmRegistry.ts`): new `lockfileOnly` option, sent to the server; ignores any `D`/`I` lines so the store stays untouched even though the current TS agent server still streams them.
- **`@pnpm/installing.deps-installer`** (`installFromPnpmRegistry`): forwards `lockfileOnly` and returns after writing the lockfile, skipping the headless install.

## Tests

- **Rust**: `pacquet-pnpr-client` integration test `lockfile_only_resolves_without_fetching_files` (lockfile resolved, `files_written == 0`, `index_entries_written == 0`, client store index empty); `pacquet-cli` e2e test `install_via_pnpr_lockfile_only_writes_lockfile_without_linking` (lockfile written, no `node_modules`, no client store). All 219 tests in `pnpr` + `pacquet-pnpr-client` pass.
- **TS**: `agent/server` integration test asserting resolution happens but `indexEntries` is empty and no CAFS `files/` dir is written — the server streamed `D` lines that the client correctly ignored. All 5 integration tests pass.

## Notes

- The wire field is backward/forward compatible (unknown fields are ignored), so any client/server mix is safe: a resolve-only-aware server skips the work; an unaware one does it but the client ignores the result.
- Per the parity rule, the TS agent **server** was left as-is (maintainer decision); it remains correct because the lockfile-only guarantee is enforced client-side.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for --lockfile-only in agent and pnpr-server modes: resolve and write the lockfile without fetching package files or creating node_modules links.
* **Tests**
  * Added integration and end-to-end tests verifying lockfile resolution while skipping file downloads, store index writes, and node_modules creation.
* **Documentation**
  * Release notes updated to document lockfile-only behavior and compatibility notes with older agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->