### PR TITLE
fix: accept loose peer ranges in peers check

### DIFF
--- a/.changeset/loose-peers-check.md
+++ b/.changeset/loose-peers-check.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/deps.inspection.peers-checker": patch
+"pnpm": patch
+---
+
+Fixed `pnpm peers check` to accept loose peer dependency ranges such as `>=3.16.0 || >=4.0.0-` when the installed peer version satisfies the range [#12149](https://github.com/pnpm/pnpm/issues/12149).

--- a/deps/inspection/peers-checker/src/checkPeerDependencies.ts
+++ b/deps/inspection/peers-checker/src/checkPeerDependencies.ts
@@ -135,7 +135,7 @@ function extractVersion (ref: string, alias: string, packages: PackageSnapshots)
 
 function satisfies (version: string, range: string): boolean {
   if (range === '*') return true
-  return semver.satisfies(version, range, { includePrerelease: true })
+  return semver.satisfies(version, range, { includePrerelease: true, loose: true })
 }
 
 function filterPeerDependencyIssues (

--- a/deps/inspection/peers-checker/test/__fixtures__/with-loose-peer-range/package.json
+++ b/deps/inspection/peers-checker/test/__fixtures__/with-loose-peer-range/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "with-loose-peer-range",
+  "version": "1.0.0",
+  "dependencies": {
+    "@gorhom/bottom-sheet": "5.2.14",
+    "react-native-reanimated": "4.4.0"
+  }
+}

--- a/deps/inspection/peers-checker/test/__fixtures__/with-loose-peer-range/pnpm-lock.yaml
+++ b/deps/inspection/peers-checker/test/__fixtures__/with-loose-peer-range/pnpm-lock.yaml
@@ -1,0 +1,34 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@gorhom/bottom-sheet':
+        specifier: 5.2.14
+        version: 5.2.14(react-native-reanimated@4.4.0)
+      react-native-reanimated:
+        specifier: 4.4.0
+        version: 4.4.0
+
+packages:
+
+  '@gorhom/bottom-sheet@5.2.14':
+    resolution: {integrity: sha512-uLQFlDjp9z+jrOFcMSEldPqL5JdaXL3vXOh+juhwoNvXgTsEorJLjHTugXu+YccAG/0KJnShzKCrb71MHBsvJg==}
+    peerDependencies:
+      react-native-reanimated: '>=3.16.0 || >=4.0.0-'
+
+  react-native-reanimated@4.4.0:
+    resolution: {integrity: sha512-0XbC1SpF3JZOz5QfmTEx3vt8VkmkTlS05CBIOKEg5q5ZSNlGtlacntlhj5CrfZlN1ciHAeoliJouTC2cLGKbDA==}
+
+snapshots:
+
+  '@gorhom/bottom-sheet@5.2.14(react-native-reanimated@4.4.0)':
+    dependencies:
+      react-native-reanimated: 4.4.0
+
+  react-native-reanimated@4.4.0: {}

--- a/deps/inspection/peers-checker/test/checkPeerDependencies.test.ts
+++ b/deps/inspection/peers-checker/test/checkPeerDependencies.test.ts
@@ -58,6 +58,19 @@ test('reports no issues for satisfied peer dependencies', async () => {
   expect(Object.keys(projectIssues.missing)).toHaveLength(0)
 })
 
+test('reports no issues for satisfied loose peer dependency ranges', async () => {
+  const fixture = f.find('with-loose-peer-range')
+  const issues = await checkPeerDependencies([fixture], {
+    lockfileDir: fixture,
+    checkWantedLockfileOnly: true,
+  })
+
+  const projectIssues = issues['.']
+  expect(projectIssues).toBeDefined()
+  expect(Object.keys(projectIssues.bad)).toHaveLength(0)
+  expect(Object.keys(projectIssues.missing)).toHaveLength(0)
+})
+
 test('respects peerDependencyRules.allowAny', async () => {
   const fixture = f.find('with-unmet-peers')
   const issues = await checkPeerDependencies([fixture], {


### PR DESCRIPTION
## What

Fixes `pnpm peers check` so it accepts loose semver peer ranges such as `>=3.16.0 || >=4.0.0-` when the installed peer version satisfies the range.

The peer checker now keeps the existing `includePrerelease: true` behavior and also enables semver loose parsing for peer range satisfaction.

## Why

`@gorhom/bottom-sheet@5.2.14` declares `react-native-reanimated` as `>=3.16.0 || >=4.0.0-`. With strict semver parsing, `react-native-reanimated@4.4.0` was reported as unmet even though loose parsing accepts the range.

Closes #12149.

## Tests

- [x] `PATH=/tmp/pnpm-12149-bin:$PATH pnpm --filter @pnpm/deps.inspection.peers-checker test test/checkPeerDependencies.test.ts -t "loose"` — regression test passes
- [x] `PATH=/tmp/pnpm-12149-bin:$PATH pnpm --filter @pnpm/deps.inspection.peers-checker test` — 7 passed
- [x] `./node_modules/.bin/cspell .changeset/loose-peers-check.md deps/inspection/peers-checker/test/checkPeerDependencies.test.ts --no-progress` — 0 issues
- [x] `git diff --check` — no whitespace errors

## AI assistance

OpenAI Codex helped reproduce the bug, draft the regression test, and prepare the initial patch. I reviewed the diff, verified the semver behavior, reran the targeted tests above, and take responsibility for the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm peers check` to properly validate loose peer dependency ranges. Installations with peer versions that satisfy the specified range now pass validation correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->