### PR TITLE
feat(pacquet): support pnpmfile custom resolver hooks (adapter, IPC, chain integration, force-refresh)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3835,6 +3835,8 @@ dependencies = [
  "async-trait",
  "derive_more",
  "pacquet-crypto-hash",
+ "pacquet-lockfile",
+ "pacquet-resolving-resolver-base",
  "serde_json",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,6 +3837,7 @@ dependencies = [
  "pacquet-crypto-hash",
  "pacquet-lockfile",
  "pacquet-resolving-resolver-base",
+ "serde",
  "serde_json",
  "tempfile",
  "tokio",
@@ -3990,6 +3991,7 @@ name = "pacquet-package-manager"
 version = "0.0.1"
 dependencies = [
  "async-recursion",
+ "async-trait",
  "chrono",
  "dashmap",
  "derive_more",

--- a/pacquet/crates/cli/src/lib.rs
+++ b/pacquet/crates/cli/src/lib.rs
@@ -26,7 +26,9 @@ pub async fn main() -> miette::Result<()> {
     // `configure_rayon_pool` for them (Copilot review on <https://github.com/pnpm/pacquet/pull/292>).
     let args = CliArgs::parse_from(argv);
     configure_rayon_pool();
-    args.run(&config_overrides).await
+    // Boxed for `clippy::large_futures`: the command future exceeds the
+    // lint's stack-size threshold (the limit trips on Windows first).
+    Box::pin(args.run(&config_overrides)).await
 }
 
 /// Size rayon's global pool at `2 × available_parallelism`. The link

--- a/pacquet/crates/cli/tests/custom_resolvers.rs
+++ b/pacquet/crates/cli/tests/custom_resolvers.rs
@@ -1,0 +1,148 @@
+//! Custom resolvers from a `.pnpmfile.cjs` `resolvers` export: chain
+//! precedence over the built-in resolvers, `shouldRefreshResolution`
+//! forcing re-resolution past the prefer-frozen fast path, and hook
+//! failures aborting the install. Mirrors pnpm's
+//! `installing/deps-installer/test/install/customResolvers.ts`.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::{fs, path::Path, process::Command};
+
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+}
+
+fn write_manifest(workspace: &Path) {
+    let manifest = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/dep-of-pkg-with-1-dep": "100.0.0",
+        },
+    });
+    fs::write(workspace.join("package.json"), manifest.to_string()).expect("write package.json");
+}
+
+/// A resolver that claims `@pnpm.e2e/dep-of-pkg-with-1-dep` and resolves
+/// it to `100.1.0` — a version the built-in npm resolver would never pick
+/// for the exact `100.0.0` specifier, so its presence in the result
+/// proves the custom resolver ran.
+fn overriding_pnpmfile(registry_url: &str, should_refresh: &str) -> String {
+    format!(
+        r"module.exports = {{
+  resolvers: [
+    {{
+      canResolve (wanted) {{
+        return wanted.alias === '@pnpm.e2e/dep-of-pkg-with-1-dep';
+      }},
+      async resolve () {{
+        const response = await fetch('{registry_url}@pnpm.e2e%2Fdep-of-pkg-with-1-dep');
+        const meta = await response.json();
+        const dist = meta.versions['100.1.0'].dist;
+        return {{
+          id: '@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0',
+          resolution: {{ tarball: dist.tarball, integrity: dist.integrity }},
+        }};
+      }},
+      shouldRefreshResolution () {{
+        return {should_refresh};
+      }},
+    }},
+  ],
+}}
+",
+    )
+}
+
+fn installed_version(workspace: &Path) -> String {
+    let manifest_path = workspace.join("node_modules/@pnpm.e2e/dep-of-pkg-with-1-dep/package.json");
+    let manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(manifest_path).expect("read installed manifest"))
+            .expect("parse installed manifest");
+    manifest["version"].as_str().expect("version is a string").to_string()
+}
+
+#[test]
+fn custom_resolver_takes_precedence_over_builtin_resolvers() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace);
+    fs::write(workspace.join(".pnpmfile.cjs"), overriding_pnpmfile(&mock_instance.url(), "false"))
+        .expect("write pnpmfile");
+
+    pacquet.with_arg("install").assert().success();
+
+    assert_eq!(installed_version(&workspace), "100.1.0");
+    let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read lockfile");
+    assert!(
+        lockfile.contains("@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0"),
+        "lockfile records the custom resolution: {lockfile}",
+    );
+
+    drop((root, mock_instance)); // cleanup
+}
+
+#[test]
+fn should_refresh_resolution_forces_re_resolution_past_the_frozen_path() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace);
+    // First install: the resolver implements only
+    // `shouldRefreshResolution`, so it never joins the resolver chain
+    // and the built-in npm resolver pins 100.0.0.
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        "module.exports = { resolvers: [{ shouldRefreshResolution: () => false }] }\n",
+    )
+    .expect("write pnpmfile");
+    pacquet.with_arg("install").assert().success();
+    assert_eq!(installed_version(&workspace), "100.0.0");
+
+    // Second install: manifest and lockfile are unchanged, so without
+    // the hook the install would go frozen and re-resolve nothing.
+    // `shouldRefreshResolution` returning true must force the
+    // fresh-resolve path, where the custom resolver now overrides the
+    // pinned version.
+    fs::write(workspace.join(".pnpmfile.cjs"), overriding_pnpmfile(&mock_instance.url(), "true"))
+        .expect("rewrite pnpmfile");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    assert_eq!(installed_version(&workspace), "100.1.0");
+    let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read lockfile");
+    assert!(
+        lockfile.contains("@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0"),
+        "lockfile records the refreshed resolution: {lockfile}",
+    );
+
+    drop((root, mock_instance)); // cleanup
+}
+
+#[test]
+fn failing_should_refresh_resolution_aborts_the_install() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace);
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        "module.exports = { resolvers: [{ shouldRefreshResolution: () => false }] }\n",
+    )
+    .expect("write pnpmfile");
+    pacquet.with_arg("install").assert().success();
+
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        "module.exports = { resolvers: [{ shouldRefreshResolution () { throw new Error('refresh check crashed'); } }] }\n",
+    )
+    .expect("rewrite pnpmfile");
+
+    let output = pacquet_at(&workspace).with_arg("install").assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr).into_owned();
+    assert!(stderr.contains("refresh check crashed"), "stderr: {stderr}");
+
+    drop((root, mock_instance)); // cleanup
+}

--- a/pacquet/crates/hooks/Cargo.toml
+++ b/pacquet/crates/hooks/Cargo.toml
@@ -12,8 +12,9 @@ repository.workspace  = true
 
 [dependencies]
 pacquet-crypto-hash             = { workspace = true }
+serde                           = { workspace = true }
 serde_json                      = { workspace = true }
-async-trait                     = "0.1"
+async-trait                     = { workspace = true }
 tokio                           = { workspace = true, features = ["rt", "process", "time", "io-util", "sync"] }
 derive_more                     = { workspace = true }
 pacquet-resolving-resolver-base = { workspace = true }

--- a/pacquet/crates/hooks/Cargo.toml
+++ b/pacquet/crates/hooks/Cargo.toml
@@ -11,11 +11,13 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
-pacquet-crypto-hash = { workspace = true }
-serde_json          = { workspace = true }
-async-trait         = "0.1"
-tokio               = { workspace = true, features = ["rt", "process", "time", "io-util", "sync"] }
-derive_more         = { workspace = true }
+pacquet-crypto-hash             = { workspace = true }
+serde_json                      = { workspace = true }
+async-trait                     = "0.1"
+tokio                           = { workspace = true, features = ["rt", "process", "time", "io-util", "sync"] }
+derive_more                     = { workspace = true }
+pacquet-resolving-resolver-base = { workspace = true }
+pacquet-lockfile                = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/pacquet/crates/hooks/src/custom_resolver_adapter.rs
+++ b/pacquet/crates/hooks/src/custom_resolver_adapter.rs
@@ -85,22 +85,16 @@ impl Resolver for CustomResolverAdapter {
         Box::pin(async move {
             let key = Self::cache_key(wanted_dependency);
 
-            let can = {
-                let cache = self.can_resolve_cache.lock().unwrap();
-                cache.get(&key).copied()
-            };
-
-            let can = match can {
-                Some(val) => val,
-                None => {
-                    let wanted_val = Self::wanted_to_value(wanted_dependency);
-                    let result = self.resolver.can_resolve(wanted_val).await.map_err(|err| {
-                        Box::new(std::io::Error::other(err.to_string())) as ResolveError
-                    })?;
-                    let mut cache = self.can_resolve_cache.lock().unwrap();
-                    cache.insert(key.clone(), result);
-                    result
-                }
+            let cached = self.can_resolve_cache.lock().unwrap().get(&key).copied();
+            let can = if let Some(cached) = cached {
+                cached
+            } else {
+                let wanted_val = Self::wanted_to_value(wanted_dependency);
+                let result = self.resolver.can_resolve(wanted_val).await.map_err(|err| {
+                    Box::new(std::io::Error::other(err.to_string())) as ResolveError
+                })?;
+                self.can_resolve_cache.lock().unwrap().insert(key, result);
+                result
             };
 
             if !can {
@@ -139,12 +133,29 @@ impl Resolver for CustomResolverAdapter {
                 resolve_err
             })?;
 
+            // pnpm spreads the hook's whole result (`{ ...result,
+            // resolvedVia: 'custom-resolver' }`), so a manifest the
+            // resolver returns must survive — without it the installer
+            // would re-fetch the tarball just to read `package.json`.
+            let manifest = match result.get("manifest") {
+                Some(manifest_val) => {
+                    Some(Arc::new(serde_json::from_value(manifest_val.clone()).map_err(|err| {
+                        let resolve_err: ResolveError = Box::new(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            format!("Custom resolver returned invalid manifest: {err}"),
+                        ));
+                        resolve_err
+                    })?))
+                }
+                None => None,
+            };
+
             Ok(Some(ResolveResult {
                 id: PkgResolutionId::from(id.to_string()),
                 name_ver: None,
                 latest: None,
                 published_at: None,
-                manifest: None,
+                manifest,
                 resolution,
                 resolved_via: "custom-resolver".to_string(),
                 normalized_bare_specifier: None,
@@ -162,3 +173,6 @@ impl Resolver for CustomResolverAdapter {
         Box::pin(async move { Ok(None) })
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/hooks/src/custom_resolver_adapter.rs
+++ b/pacquet/crates/hooks/src/custom_resolver_adapter.rs
@@ -1,5 +1,7 @@
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use serde_json::Value;
 
@@ -92,8 +94,8 @@ impl Resolver for CustomResolverAdapter {
                 Some(val) => val,
                 None => {
                     let wanted_val = Self::wanted_to_value(wanted_dependency);
-                    let result = self.resolver.can_resolve(wanted_val).await.map_err(|e| {
-                        Box::new(std::io::Error::other(e.to_string())) as ResolveError
+                    let result = self.resolver.can_resolve(wanted_val).await.map_err(|err| {
+                        Box::new(std::io::Error::other(err.to_string())) as ResolveError
                     })?;
                     let mut cache = self.can_resolve_cache.lock().unwrap();
                     cache.insert(key.clone(), result);
@@ -108,11 +110,10 @@ impl Resolver for CustomResolverAdapter {
             let wanted_val = Self::wanted_to_value(wanted_dependency);
             let opts_val = Self::opts_to_value(opts);
 
-            let result = self
-                .resolver
-                .resolve(wanted_val, opts_val)
-                .await
-                .map_err(|e| Box::new(std::io::Error::other(e.to_string())) as ResolveError)?;
+            let result =
+                self.resolver.resolve(wanted_val, opts_val).await.map_err(|err| {
+                    Box::new(std::io::Error::other(err.to_string())) as ResolveError
+                })?;
 
             let id = result.get("id").and_then(Value::as_str).ok_or_else(|| {
                 let err: ResolveError = Box::new(std::io::Error::new(
@@ -130,12 +131,12 @@ impl Resolver for CustomResolverAdapter {
                 err
             })?;
 
-            let resolution = serde_json::from_value(resolution_val.clone()).map_err(|e| {
-                let err: ResolveError = Box::new(std::io::Error::new(
+            let resolution = serde_json::from_value(resolution_val.clone()).map_err(|err| {
+                let resolve_err: ResolveError = Box::new(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
-                    format!("Custom resolver returned invalid resolution: {e}"),
+                    format!("Custom resolver returned invalid resolution: {err}"),
                 ));
-                err
+                resolve_err
             })?;
 
             Ok(Some(ResolveResult {

--- a/pacquet/crates/hooks/src/custom_resolver_adapter.rs
+++ b/pacquet/crates/hooks/src/custom_resolver_adapter.rs
@@ -69,6 +69,7 @@ impl CustomResolverAdapter {
             "lockfileDir": opts.lockfile_dir.to_string_lossy(),
             "projectDir": opts.project_dir.to_string_lossy(),
             "preferredVersions": Self::preferred_versions_to_value(&opts.preferred_versions),
+            "currentPkg": opts.current_pkg,
         })
     }
 }

--- a/pacquet/crates/hooks/src/custom_resolver_adapter.rs
+++ b/pacquet/crates/hooks/src/custom_resolver_adapter.rs
@@ -1,0 +1,162 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use serde_json::Value;
+
+use pacquet_resolving_resolver_base::{
+    LatestQuery, PkgResolutionId, PreferredVersions, ResolveError, ResolveFuture,
+    ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, VersionSelectorEntry,
+    WantedDependency,
+};
+
+use crate::CustomResolver;
+
+/// Adapts a [`CustomResolver`] (JSON-value-based, from a pnpmfile hook) to the
+/// [`Resolver`] trait (typed structs) so it can be inserted into the resolver
+/// chain. Mirrors `resolveFromCustomResolvers` in
+/// <https://github.com/pnpm/pnpm/blob/1627943d2a/resolving/default-resolver/src/index.ts#L66-L98>.
+pub struct CustomResolverAdapter {
+    resolver: Arc<dyn CustomResolver>,
+    can_resolve_cache: Mutex<HashMap<String, bool>>,
+}
+
+impl CustomResolverAdapter {
+    pub fn new(resolver: Arc<dyn CustomResolver>) -> Self {
+        Self { resolver, can_resolve_cache: Mutex::new(HashMap::new()) }
+    }
+
+    fn cache_key(wanted: &WantedDependency) -> String {
+        format!(
+            "{}@{}",
+            wanted.alias.as_deref().unwrap_or(""),
+            wanted.bare_specifier.as_deref().unwrap_or(""),
+        )
+    }
+
+    fn wanted_to_value(wanted: &WantedDependency) -> Value {
+        serde_json::json!({
+            "alias": wanted.alias,
+            "bareSpecifier": wanted.bare_specifier,
+            "injected": wanted.injected,
+            "optional": wanted.optional,
+            "prevSpecifier": wanted.prev_specifier,
+        })
+    }
+
+    fn preferred_versions_to_value(pv: &PreferredVersions) -> Value {
+        let mut map = serde_json::Map::new();
+        for (pkg_name, selectors) in pv {
+            let mut smap = serde_json::Map::new();
+            for (key, entry) in selectors {
+                let val = match entry {
+                    VersionSelectorEntry::Plain(typ) => {
+                        serde_json::to_value(typ).unwrap_or(Value::Null)
+                    }
+                    VersionSelectorEntry::Weighted(w) => serde_json::json!({
+                        "selectorType": w.selector_type,
+                        "weight": w.weight,
+                    }),
+                };
+                smap.insert(key.clone(), val);
+            }
+            map.insert(pkg_name.clone(), Value::Object(smap));
+        }
+        Value::Object(map)
+    }
+
+    fn opts_to_value(opts: &ResolveOptions) -> Value {
+        serde_json::json!({
+            "lockfileDir": opts.lockfile_dir.to_string_lossy(),
+            "projectDir": opts.project_dir.to_string_lossy(),
+            "preferredVersions": Self::preferred_versions_to_value(&opts.preferred_versions),
+        })
+    }
+}
+
+impl Resolver for CustomResolverAdapter {
+    fn resolve<'a>(
+        &'a self,
+        wanted_dependency: &'a WantedDependency,
+        opts: &'a ResolveOptions,
+    ) -> ResolveFuture<'a> {
+        Box::pin(async move {
+            let key = Self::cache_key(wanted_dependency);
+
+            let can = {
+                let cache = self.can_resolve_cache.lock().unwrap();
+                cache.get(&key).copied()
+            };
+
+            let can = match can {
+                Some(val) => val,
+                None => {
+                    let wanted_val = Self::wanted_to_value(wanted_dependency);
+                    let result = self.resolver.can_resolve(wanted_val).await.map_err(|e| {
+                        Box::new(std::io::Error::other(e.to_string())) as ResolveError
+                    })?;
+                    let mut cache = self.can_resolve_cache.lock().unwrap();
+                    cache.insert(key.clone(), result);
+                    result
+                }
+            };
+
+            if !can {
+                return Ok(None);
+            }
+
+            let wanted_val = Self::wanted_to_value(wanted_dependency);
+            let opts_val = Self::opts_to_value(opts);
+
+            let result = self
+                .resolver
+                .resolve(wanted_val, opts_val)
+                .await
+                .map_err(|e| Box::new(std::io::Error::other(e.to_string())) as ResolveError)?;
+
+            let id = result.get("id").and_then(Value::as_str).ok_or_else(|| {
+                let err: ResolveError = Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Custom resolver did not return an 'id' field",
+                ));
+                err
+            })?;
+
+            let resolution_val = result.get("resolution").ok_or_else(|| {
+                let err: ResolveError = Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Custom resolver did not return a 'resolution' field",
+                ));
+                err
+            })?;
+
+            let resolution = serde_json::from_value(resolution_val.clone()).map_err(|e| {
+                let err: ResolveError = Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Custom resolver returned invalid resolution: {e}"),
+                ));
+                err
+            })?;
+
+            Ok(Some(ResolveResult {
+                id: PkgResolutionId::from(id.to_string()),
+                name_ver: None,
+                latest: None,
+                published_at: None,
+                manifest: None,
+                resolution,
+                resolved_via: "custom-resolver".to_string(),
+                normalized_bare_specifier: None,
+                alias: wanted_dependency.alias.clone(),
+                policy_violation: None,
+            }))
+        })
+    }
+
+    fn resolve_latest<'a>(
+        &'a self,
+        _query: &'a LatestQuery,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveLatestFuture<'a> {
+        Box::pin(async move { Ok(None) })
+    }
+}

--- a/pacquet/crates/hooks/src/custom_resolver_adapter/tests.rs
+++ b/pacquet/crates/hooks/src/custom_resolver_adapter/tests.rs
@@ -1,0 +1,234 @@
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use serde_json::{Value, json};
+
+use async_trait::async_trait;
+use pacquet_resolving_resolver_base::{
+    CurrentPkg, PkgResolutionId, ResolveOptions, Resolver, WantedDependency,
+};
+
+use super::CustomResolverAdapter;
+use crate::{CustomResolver, HookError};
+
+struct ScriptedResolver {
+    can_resolve: bool,
+    response: Value,
+    can_resolve_calls: AtomicUsize,
+    seen_wanted: Mutex<Vec<Value>>,
+    seen_opts: Mutex<Vec<Value>>,
+}
+
+impl ScriptedResolver {
+    fn answering(response: Value) -> Self {
+        ScriptedResolver {
+            can_resolve: true,
+            response,
+            can_resolve_calls: AtomicUsize::new(0),
+            seen_wanted: Mutex::new(Vec::new()),
+            seen_opts: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl CustomResolver for ScriptedResolver {
+    async fn can_resolve(&self, wanted_dependency: Value) -> Result<bool, HookError> {
+        self.can_resolve_calls.fetch_add(1, Ordering::SeqCst);
+        self.seen_wanted.lock().unwrap().push(wanted_dependency);
+        Ok(self.can_resolve)
+    }
+
+    async fn resolve(&self, _: Value, opts: Value) -> Result<Value, HookError> {
+        self.seen_opts.lock().unwrap().push(opts);
+        Ok(self.response.clone())
+    }
+
+    async fn should_refresh_resolution(
+        &self,
+        _: &pacquet_lockfile::PackageKey,
+        _: Value,
+    ) -> Result<bool, HookError> {
+        Ok(false)
+    }
+}
+
+fn wanted(alias: &str, bare_specifier: &str) -> WantedDependency {
+    WantedDependency {
+        alias: Some(alias.to_string()),
+        bare_specifier: Some(bare_specifier.to_string()),
+        ..WantedDependency::default()
+    }
+}
+
+fn valid_response() -> Value {
+    json!({
+        "id": "foo@1.0.0",
+        "resolution": { "tarball": "https://example.com/foo-1.0.0.tgz" },
+    })
+}
+
+#[tokio::test]
+async fn returns_typed_result_for_valid_response() {
+    let adapter =
+        CustomResolverAdapter::new(Arc::new(ScriptedResolver::answering(valid_response())));
+
+    let result = adapter
+        .resolve(&wanted("foo", "custom:foo"), &ResolveOptions::default())
+        .await
+        .unwrap()
+        .expect("custom resolver claims the dependency");
+
+    assert_eq!(result.id, PkgResolutionId::from("foo@1.0.0"));
+    assert_eq!(result.resolved_via, "custom-resolver");
+    assert_eq!(result.alias.as_deref(), Some("foo"));
+    assert!(result.manifest.is_none());
+}
+
+#[tokio::test]
+async fn returns_none_when_can_resolve_is_false() {
+    let resolver = Arc::new(ScriptedResolver {
+        can_resolve: false,
+        ..ScriptedResolver::answering(valid_response())
+    });
+    let adapter = CustomResolverAdapter::new(Arc::clone(&resolver) as Arc<dyn CustomResolver>);
+
+    let result =
+        adapter.resolve(&wanted("foo", "custom:foo"), &ResolveOptions::default()).await.unwrap();
+
+    assert!(result.is_none());
+    assert!(resolver.seen_opts.lock().unwrap().is_empty(), "resolve must not be called");
+}
+
+#[tokio::test]
+async fn caches_can_resolve_per_alias_and_specifier() {
+    let resolver = Arc::new(ScriptedResolver::answering(valid_response()));
+    let adapter = CustomResolverAdapter::new(Arc::clone(&resolver) as Arc<dyn CustomResolver>);
+    let opts = ResolveOptions::default();
+
+    adapter.resolve(&wanted("foo", "custom:foo"), &opts).await.unwrap();
+    adapter.resolve(&wanted("foo", "custom:foo"), &opts).await.unwrap();
+    assert_eq!(resolver.can_resolve_calls.load(Ordering::SeqCst), 1);
+
+    // pnpm's cache key is `alias@bareSpecifier`
+    // (`getCustomResolverCacheKey`), so a different specifier misses.
+    adapter.resolve(&wanted("foo", "custom:other"), &opts).await.unwrap();
+    assert_eq!(resolver.can_resolve_calls.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn errors_when_id_is_missing() {
+    let adapter = CustomResolverAdapter::new(Arc::new(ScriptedResolver::answering(json!({
+        "resolution": { "tarball": "https://example.com/foo-1.0.0.tgz" },
+    }))));
+
+    let err = adapter
+        .resolve(&wanted("foo", "custom:foo"), &ResolveOptions::default())
+        .await
+        .expect_err("missing id must fail");
+    assert!(err.to_string().contains("'id'"), "got: {err}");
+}
+
+#[tokio::test]
+async fn errors_when_resolution_is_missing() {
+    let adapter = CustomResolverAdapter::new(Arc::new(ScriptedResolver::answering(
+        json!({ "id": "foo@1.0.0" }),
+    )));
+
+    let err = adapter
+        .resolve(&wanted("foo", "custom:foo"), &ResolveOptions::default())
+        .await
+        .expect_err("missing resolution must fail");
+    assert!(err.to_string().contains("'resolution'"), "got: {err}");
+}
+
+#[tokio::test]
+async fn errors_when_resolution_has_invalid_shape() {
+    let adapter = CustomResolverAdapter::new(Arc::new(ScriptedResolver::answering(json!({
+        "id": "foo@1.0.0",
+        "resolution": "not-an-object",
+    }))));
+
+    let err = adapter
+        .resolve(&wanted("foo", "custom:foo"), &ResolveOptions::default())
+        .await
+        .expect_err("invalid resolution must fail");
+    assert!(err.to_string().contains("invalid resolution"), "got: {err}");
+}
+
+#[tokio::test]
+async fn manifest_passes_through() {
+    let adapter = CustomResolverAdapter::new(Arc::new(ScriptedResolver::answering(json!({
+        "id": "foo@1.0.0",
+        "resolution": { "tarball": "https://example.com/foo-1.0.0.tgz" },
+        "manifest": { "name": "foo", "version": "1.0.0" },
+    }))));
+
+    let result = adapter
+        .resolve(&wanted("foo", "custom:foo"), &ResolveOptions::default())
+        .await
+        .unwrap()
+        .expect("resolved");
+
+    let manifest = result.manifest.expect("manifest survives the adapter");
+    assert_eq!(*manifest, json!({ "name": "foo", "version": "1.0.0" }));
+}
+
+#[tokio::test]
+async fn sends_upstream_payload_shapes() {
+    let resolver = Arc::new(ScriptedResolver::answering(valid_response()));
+    let adapter = CustomResolverAdapter::new(Arc::clone(&resolver) as Arc<dyn CustomResolver>);
+    let wanted_dependency = WantedDependency {
+        alias: Some("foo".to_string()),
+        bare_specifier: Some("custom:foo".to_string()),
+        injected: Some(true),
+        prev_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let opts = ResolveOptions {
+        project_dir: "/repo/pkg".into(),
+        lockfile_dir: "/repo".into(),
+        current_pkg: Some(CurrentPkg {
+            id: PkgResolutionId::from("foo@1.0.0"),
+            name: Some("foo".to_string()),
+            version: Some("1.0.0".to_string()),
+            resolution: serde_json::from_value(
+                json!({ "tarball": "https://example.com/foo-1.0.0.tgz" }),
+            )
+            .unwrap(),
+            published_at: None,
+        }),
+        ..ResolveOptions::default()
+    };
+
+    adapter.resolve(&wanted_dependency, &opts).await.unwrap();
+
+    let seen_wanted = resolver.seen_wanted.lock().unwrap();
+    assert_eq!(
+        seen_wanted.first().unwrap(),
+        &json!({
+            "alias": "foo",
+            "bareSpecifier": "custom:foo",
+            "injected": true,
+            "optional": null,
+            "prevSpecifier": "^1.0.0",
+        }),
+    );
+    let seen_opts = resolver.seen_opts.lock().unwrap();
+    assert_eq!(
+        seen_opts.first().unwrap(),
+        &json!({
+            "lockfileDir": "/repo",
+            "projectDir": "/repo/pkg",
+            "preferredVersions": {},
+            "currentPkg": {
+                "id": "foo@1.0.0",
+                "name": "foo",
+                "version": "1.0.0",
+                "resolution": { "tarball": "https://example.com/foo-1.0.0.tgz" },
+            },
+        }),
+    );
+}

--- a/pacquet/crates/hooks/src/lib.rs
+++ b/pacquet/crates/hooks/src/lib.rs
@@ -3,6 +3,7 @@ use derive_more::Display;
 use serde_json::Value;
 use std::sync::Arc;
 
+pub mod custom_resolver_adapter;
 pub mod finder;
 pub mod node_runtime;
 pub mod worker;
@@ -117,6 +118,26 @@ pub trait PnpmfileHooks: Send + Sync {
     fn source_path(&self) -> Option<&std::path::Path> {
         None
     }
+
+    /// Get custom resolvers exported from the pnpmfile.
+    async fn get_custom_resolvers(&self) -> Result<Vec<Arc<dyn CustomResolver>>, HookError>;
+}
+
+/// Represents a custom resolver exported from a pnpmfile.
+#[async_trait]
+pub trait CustomResolver: Send + Sync {
+    /// Called during resolution to determine if this resolver should handle a dependency.
+    async fn can_resolve(&self, wanted_dependency: Value) -> Result<bool, HookError>;
+
+    /// Called to resolve a dependency that canResolve returned true for.
+    async fn resolve(&self, wanted_dependency: Value, opts: Value) -> Result<Value, HookError>;
+
+    /// Called on subsequent installs to determine if this dependency needs re-resolution.
+    async fn should_refresh_resolution(
+        &self,
+        dep_path: String,
+        pkg_snapshot: Value,
+    ) -> Result<bool, HookError>;
 }
 
 /// A no-op implementation of `PnpmfileHooks`.
@@ -139,5 +160,8 @@ impl PnpmfileHooks for NoopHooks {
     }
     async fn filter_log(&self, _: Value, _: HookContext) -> bool {
         true
+    }
+    async fn get_custom_resolvers(&self) -> Result<Vec<Arc<dyn CustomResolver>>, HookError> {
+        Ok(vec![])
     }
 }

--- a/pacquet/crates/hooks/src/lib.rs
+++ b/pacquet/crates/hooks/src/lib.rs
@@ -119,23 +119,50 @@ pub trait PnpmfileHooks: Send + Sync {
         None
     }
 
-    /// Get custom resolvers exported from the pnpmfile.
-    async fn get_custom_resolvers(&self) -> Result<Vec<Arc<dyn CustomResolver>>, HookError>;
+    /// Get custom resolvers exported from the pnpmfile's top-level
+    /// `resolvers` array. Mirrors pnpm's
+    /// [`requireHooks`](https://github.com/pnpm/pnpm/blob/1627943d2a/hooks/pnpmfile/src/requireHooks.ts#L222-L228)
+    /// merge of `resolvers` exports into `cookedHooks.customResolvers`.
+    async fn get_custom_resolvers(&self) -> Result<Vec<Arc<dyn CustomResolver>>, HookError> {
+        Ok(vec![])
+    }
 }
 
-/// Represents a custom resolver exported from a pnpmfile.
+/// A custom resolver exported from a pnpmfile. Mirrors pnpm's
+/// [`CustomResolver`](https://github.com/pnpm/pnpm/blob/1627943d2a/hooks/types/src/index.ts#L48-L87)
+/// interface, whose methods are all optional — the `has_*` accessors
+/// report which ones the underlying resolver actually implements, so
+/// callers can skip the corresponding calls the way pnpm skips absent
+/// methods.
 #[async_trait]
 pub trait CustomResolver: Send + Sync {
+    /// Whether the resolver implements `canResolve`.
+    fn has_can_resolve(&self) -> bool {
+        true
+    }
+
+    /// Whether the resolver implements `resolve`.
+    fn has_resolve(&self) -> bool {
+        true
+    }
+
+    /// Whether the resolver implements `shouldRefreshResolution`.
+    fn has_should_refresh_resolution(&self) -> bool {
+        true
+    }
+
     /// Called during resolution to determine if this resolver should handle a dependency.
     async fn can_resolve(&self, wanted_dependency: Value) -> Result<bool, HookError>;
 
-    /// Called to resolve a dependency that canResolve returned true for.
+    /// Called to resolve a dependency that `canResolve` returned true for.
     async fn resolve(&self, wanted_dependency: Value, opts: Value) -> Result<Value, HookError>;
 
-    /// Called on subsequent installs to determine if this dependency needs re-resolution.
+    /// Called on subsequent installs to determine if this dependency needs
+    /// re-resolution. Invoked for every package in the lockfile regardless
+    /// of `canResolve`; a `true` for any package forces full re-resolution.
     async fn should_refresh_resolution(
         &self,
-        dep_path: String,
+        dep_path: &pacquet_lockfile::PackageKey,
         pkg_snapshot: Value,
     ) -> Result<bool, HookError>;
 }
@@ -160,8 +187,5 @@ impl PnpmfileHooks for NoopHooks {
     }
     async fn filter_log(&self, _: Value, _: HookContext) -> bool {
         true
-    }
-    async fn get_custom_resolvers(&self) -> Result<Vec<Arc<dyn CustomResolver>>, HookError> {
-        Ok(vec![])
     }
 }

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -186,4 +186,64 @@ impl crate::PnpmfileHooks for NodeJsHooks {
     fn source_path(&self) -> Option<&std::path::Path> {
         Some(&self.file)
     }
+
+    async fn get_custom_resolvers(&self) -> Result<Vec<Arc<dyn crate::CustomResolver>>, HookError> {
+        let worker = self.worker().await?;
+        let count = worker.get_resolver_count().await?;
+        let mut resolvers = Vec::with_capacity(count);
+        for index in 0..count {
+            resolvers.push(Arc::new(NodeJsCustomResolver { worker: Arc::clone(&worker), index })
+                as Arc<dyn crate::CustomResolver>);
+        }
+        Ok(resolvers)
+    }
+}
+
+pub struct NodeJsCustomResolver {
+    worker: Arc<NodeWorker>,
+    index: usize,
+}
+
+#[async_trait]
+impl crate::CustomResolver for NodeJsCustomResolver {
+    async fn can_resolve(&self, wanted_dependency: Value) -> Result<bool, HookError> {
+        let res = self
+            .worker
+            .call_resolver(
+                self.index,
+                "canResolve",
+                serde_json::json!([wanted_dependency]),
+                Arc::new(|_| {}),
+            )
+            .await?;
+        Ok(res.as_bool().unwrap_or(false))
+    }
+
+    async fn resolve(&self, wanted_dependency: Value, opts: Value) -> Result<Value, HookError> {
+        self.worker
+            .call_resolver(
+                self.index,
+                "resolve",
+                serde_json::json!([wanted_dependency, opts]),
+                Arc::new(|_| {}),
+            )
+            .await
+    }
+
+    async fn should_refresh_resolution(
+        &self,
+        dep_path: String,
+        pkg_snapshot: Value,
+    ) -> Result<bool, HookError> {
+        let res = self
+            .worker
+            .call_resolver(
+                self.index,
+                "shouldRefreshResolution",
+                serde_json::json!([dep_path, pkg_snapshot]),
+                Arc::new(|_| {}),
+            )
+            .await?;
+        Ok(res.as_bool().unwrap_or(false))
+    }
 }

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -189,23 +189,38 @@ impl crate::PnpmfileHooks for NodeJsHooks {
 
     async fn get_custom_resolvers(&self) -> Result<Vec<Arc<dyn crate::CustomResolver>>, HookError> {
         let worker = self.worker().await?;
-        let count = worker.get_resolver_count().await?;
-        let mut resolvers = Vec::with_capacity(count);
-        for index in 0..count {
-            resolvers.push(Arc::new(NodeJsCustomResolver { worker: Arc::clone(&worker), index })
-                as Arc<dyn crate::CustomResolver>);
-        }
-        Ok(resolvers)
+        let capabilities = worker.get_resolver_capabilities().await?;
+        Ok(capabilities
+            .into_iter()
+            .enumerate()
+            .map(|(index, capabilities)| {
+                Arc::new(NodeJsCustomResolver { worker: Arc::clone(&worker), index, capabilities })
+                    as Arc<dyn crate::CustomResolver>
+            })
+            .collect())
     }
 }
 
 pub struct NodeJsCustomResolver {
     worker: Arc<NodeWorker>,
     index: usize,
+    capabilities: crate::worker::ResolverCapabilities,
 }
 
 #[async_trait]
 impl crate::CustomResolver for NodeJsCustomResolver {
+    fn has_can_resolve(&self) -> bool {
+        self.capabilities.can_resolve
+    }
+
+    fn has_resolve(&self) -> bool {
+        self.capabilities.resolve
+    }
+
+    fn has_should_refresh_resolution(&self) -> bool {
+        self.capabilities.should_refresh_resolution
+    }
+
     async fn can_resolve(&self, wanted_dependency: Value) -> Result<bool, HookError> {
         let res = self
             .worker
@@ -232,7 +247,7 @@ impl crate::CustomResolver for NodeJsCustomResolver {
 
     async fn should_refresh_resolution(
         &self,
-        dep_path: String,
+        dep_path: &pacquet_lockfile::PackageKey,
         pkg_snapshot: Value,
     ) -> Result<bool, HookError> {
         let res = self
@@ -240,7 +255,7 @@ impl crate::CustomResolver for NodeJsCustomResolver {
             .call_resolver(
                 self.index,
                 "shouldRefreshResolution",
-                serde_json::json!([dep_path, pkg_snapshot]),
+                serde_json::json!([dep_path.to_string(), pkg_snapshot]),
                 Arc::new(|_| {}),
             )
             .await?;

--- a/pacquet/crates/hooks/src/worker.rs
+++ b/pacquet/crates/hooks/src/worker.rs
@@ -37,6 +37,17 @@ const HOOK_TIMEOUT: Duration = Duration::from_secs(30);
 /// Callback invoked for each `context.log(...)` a hook emits while it runs.
 pub type LogFn = Arc<dyn Fn(String) + Send + Sync>;
 
+/// Which optional methods one custom resolver in the pnpmfile's
+/// `resolvers` array implements. Mirrors the optional methods of pnpm's
+/// `CustomResolver` interface (`hooks/types/src/index.ts`).
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolverCapabilities {
+    pub can_resolve: bool,
+    pub resolve: bool,
+    pub should_refresh_resolution: bool,
+}
+
 struct Pending {
     log: LogFn,
     done: oneshot::Sender<Result<Value, String>>,
@@ -148,15 +159,16 @@ impl NodeWorker {
         .await
     }
 
-    /// Get the number of custom resolvers exported by the pnpmfile.
-    pub async fn get_resolver_count(&self) -> Result<usize, HookError> {
-        self.request(
-            "resolverCount",
-            serde_json::json!({ "target": "resolverCount" }),
-            Arc::new(|_| {}),
-        )
-        .await
-        .map(|value| value.as_u64().unwrap_or(0) as usize)
+    /// Get the capabilities of every custom resolver exported by the
+    /// pnpmfile's `resolvers` array, in array order. Lets callers skip
+    /// per-dependency IPC round trips for methods a resolver does not
+    /// implement, mirroring pnpm's optional-method checks
+    /// (`if (!customResolver.canResolve || !customResolver.resolve) continue`).
+    pub async fn get_resolver_capabilities(&self) -> Result<Vec<ResolverCapabilities>, HookError> {
+        let value = self
+            .request("resolvers", serde_json::json!({ "target": "resolvers" }), Arc::new(|_| {}))
+            .await?;
+        serde_json::from_value(value).map_err(|err| self.exec_err(err.to_string()))
     }
 
     /// Send one request `body` (an object the worker dispatches on) and
@@ -169,13 +181,19 @@ impl NodeWorker {
         self.pending.lock().await.insert(id, Pending { log, done });
 
         body["id"] = serde_json::json!(id);
-        let mut line =
-            serde_json::to_string(&body).map_err(|err| self.exec_err(err.to_string()))?;
-        line.push('\n');
-        {
+        let send_result = async {
+            let mut line = serde_json::to_string(&body).map_err(|err| err.to_string())?;
+            line.push('\n');
             let mut stdin = self.stdin.lock().await;
-            stdin.write_all(line.as_bytes()).await.map_err(|err| self.exec_err(err.to_string()))?;
-            stdin.flush().await.map_err(|err| self.exec_err(err.to_string()))?;
+            stdin.write_all(line.as_bytes()).await.map_err(|err| err.to_string())?;
+            stdin.flush().await.map_err(|err| err.to_string())
+        }
+        .await;
+        if let Err(message) = send_result {
+            // The reader task can never answer a request that was not
+            // sent, so drop the entry here or it leaks until shutdown.
+            self.pending.lock().await.remove(&id);
+            return Err(self.exec_err(message));
         }
 
         match timeout(HOOK_TIMEOUT, rx).await {
@@ -242,21 +260,24 @@ async function handle(line) {{
   try {{
     const fn = mod && mod.hooks && mod.hooks[req.hook];
     const context = {{ log: (m) => send({{ log: String(m) }}) }};
-    if (req.target === 'resolverCount') {{
+    if (req.target === 'resolvers') {{
       const resolvers = mod && mod.resolvers;
-      send({{ ok: (Array.isArray(resolvers) ? resolvers.length : 0) }});
+      send({{ ok: (Array.isArray(resolvers) ? resolvers.map((resolver) => ({{
+        canResolve: typeof resolver.canResolve === 'function',
+        resolve: typeof resolver.resolve === 'function',
+        shouldRefreshResolution: typeof resolver.shouldRefreshResolution === 'function',
+      }})) : []) }});
       return;
     }}
     if (req.target === 'resolver') {{
       const resolvers = mod && mod.resolvers;
       const resolver = Array.isArray(resolvers) ? resolvers[req.index] : null;
-      const fn = resolver && resolver[req.method];
-      if (typeof fn !== 'function') {{
+      if (!resolver || typeof resolver[req.method] !== 'function') {{
         send({{ ok: null }});
         return;
       }}
       const args = req.payload || [];
-      const res = await fn(...args);
+      const res = await resolver[req.method](...args);
       send({{ ok: res === undefined ? null : res }});
       return;
     }}

--- a/pacquet/crates/hooks/src/worker.rs
+++ b/pacquet/crates/hooks/src/worker.rs
@@ -21,7 +21,7 @@ use std::{
     path::Path,
     process::Stdio,
     sync::{
-        Arc,
+        Arc, Mutex as StdMutex,
         atomic::{AtomicU64, Ordering},
     },
 };
@@ -53,7 +53,26 @@ struct Pending {
     done: oneshot::Sender<Result<Value, String>>,
 }
 
-type PendingMap = Arc<Mutex<HashMap<u64, Pending>>>;
+/// Pending requests keyed by id. A `std` mutex (never held across an
+/// await) so [`PendingEntryGuard::drop`] can clean up synchronously
+/// when a caller's future is cancelled.
+type PendingMap = Arc<StdMutex<HashMap<u64, Pending>>>;
+
+/// Removes the pending entry on drop. Covers every exit from
+/// [`NodeWorker::request`] — send failure, timeout, and cancellation of
+/// the caller's future — so a request the worker never answers cannot
+/// leak its entry. Removal is idempotent: a delivered reply has already
+/// removed the entry in [`dispatch_line`].
+struct PendingEntryGuard {
+    pending: PendingMap,
+    id: u64,
+}
+
+impl Drop for PendingEntryGuard {
+    fn drop(&mut self) {
+        self.pending.lock().unwrap().remove(&self.id);
+    }
+}
 
 /// A handle to a running Node worker process loaded with one pnpmfile.
 pub struct NodeWorker {
@@ -94,16 +113,16 @@ impl NodeWorker {
         let stdin = child.stdin.take().expect("worker stdin is piped");
         let stdout = child.stdout.take().expect("worker stdout is piped");
 
-        let pending: PendingMap = Arc::new(Mutex::new(HashMap::new()));
+        let pending: PendingMap = Arc::new(StdMutex::new(HashMap::new()));
         let pending_reader = Arc::clone(&pending);
         tokio::spawn(async move {
             let mut lines = BufReader::new(stdout).lines();
             while let Ok(Some(line)) = lines.next_line().await {
-                dispatch_line(&pending_reader, &line).await;
+                dispatch_line(&pending_reader, &line);
             }
             // The worker exited: fail every still-pending request so callers
             // don't hang waiting for a response that will never arrive.
-            for (_, pending) in pending_reader.lock().await.drain() {
+            for (_, pending) in pending_reader.lock().unwrap().drain() {
                 let _ = pending.done.send(Err("pnpmfile worker exited".to_string()));
             }
         });
@@ -178,32 +197,24 @@ impl NodeWorker {
     async fn request(&self, label: &str, mut body: Value, log: LogFn) -> Result<Value, HookError> {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let (done, rx) = oneshot::channel();
-        self.pending.lock().await.insert(id, Pending { log, done });
+        self.pending.lock().unwrap().insert(id, Pending { log, done });
+        let _pending_guard = PendingEntryGuard { pending: Arc::clone(&self.pending), id };
 
         body["id"] = serde_json::json!(id);
-        let send_result = async {
-            let mut line = serde_json::to_string(&body).map_err(|err| err.to_string())?;
-            line.push('\n');
+        let mut line =
+            serde_json::to_string(&body).map_err(|err| self.exec_err(err.to_string()))?;
+        line.push('\n');
+        {
             let mut stdin = self.stdin.lock().await;
-            stdin.write_all(line.as_bytes()).await.map_err(|err| err.to_string())?;
-            stdin.flush().await.map_err(|err| err.to_string())
-        }
-        .await;
-        if let Err(message) = send_result {
-            // The reader task can never answer a request that was not
-            // sent, so drop the entry here or it leaks until shutdown.
-            self.pending.lock().await.remove(&id);
-            return Err(self.exec_err(message));
+            stdin.write_all(line.as_bytes()).await.map_err(|err| self.exec_err(err.to_string()))?;
+            stdin.flush().await.map_err(|err| self.exec_err(err.to_string()))?;
         }
 
         match timeout(HOOK_TIMEOUT, rx).await {
             Ok(Ok(Ok(value))) => Ok(value),
             Ok(Ok(Err(message))) => Err(self.exec_err(message)),
             Ok(Err(_)) => Err(self.exec_err("pnpmfile worker dropped the response")),
-            Err(_) => {
-                self.pending.lock().await.remove(&id);
-                Err(HookError::Timeout(label.to_string(), HOOK_TIMEOUT.as_secs()))
-            }
+            Err(_) => Err(HookError::Timeout(label.to_string(), HOOK_TIMEOUT.as_secs())),
         }
     }
 }
@@ -211,18 +222,19 @@ impl NodeWorker {
 /// Route one line from the worker to its pending request: forward `log` lines
 /// to the call's logger (the entry stays until the result arrives) and resolve
 /// the call on `ok`/`err`.
-async fn dispatch_line(pending: &PendingMap, line: &str) {
+fn dispatch_line(pending: &PendingMap, line: &str) {
     let Ok(message) = serde_json::from_str::<Value>(line) else { return };
     let Some(id) = message.get("id").and_then(Value::as_u64) else { return };
 
     if let Some(log) = message.get("log").and_then(Value::as_str) {
-        if let Some(entry) = pending.lock().await.get(&id) {
-            (entry.log)(log.to_string());
+        let log_fn = pending.lock().unwrap().get(&id).map(|entry| Arc::clone(&entry.log));
+        if let Some(log_fn) = log_fn {
+            log_fn(log.to_string());
         }
         return;
     }
 
-    let Some(entry) = pending.lock().await.remove(&id) else { return };
+    let Some(entry) = pending.lock().unwrap().remove(&id) else { return };
     let result = match message.get("err").and_then(Value::as_str) {
         Some(err) => Err(err.to_string()),
         None => Ok(message.get("ok").cloned().unwrap_or(Value::Null)),
@@ -313,3 +325,6 @@ async function handle(line) {{
 "#,
     )
 }
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/hooks/src/worker.rs
+++ b/pacquet/crates/hooks/src/worker.rs
@@ -126,6 +126,39 @@ impl NodeWorker {
             .unwrap_or(false)
     }
 
+    /// Call `method` on the custom resolver at `index` in the pnpmfile's
+    /// `resolvers` array, forwarding any `context.log(...)` to `log`.
+    pub async fn call_resolver(
+        &self,
+        index: usize,
+        method: &str,
+        payload: Value,
+        log: LogFn,
+    ) -> Result<Value, HookError> {
+        self.request(
+            method,
+            serde_json::json!({
+                "target": "resolver",
+                "index": index,
+                "method": method,
+                "payload": payload,
+            }),
+            log,
+        )
+        .await
+    }
+
+    /// Get the number of custom resolvers exported by the pnpmfile.
+    pub async fn get_resolver_count(&self) -> Result<usize, HookError> {
+        self.request(
+            "resolverCount",
+            serde_json::json!({ "target": "resolverCount" }),
+            Arc::new(|_| {}),
+        )
+        .await
+        .map(|value| value.as_u64().unwrap_or(0) as usize)
+    }
+
     /// Send one request `body` (an object the worker dispatches on) and
     /// await its reply, stamping in the request id and routing any
     /// `context.log(...)` lines to `log`. `label` names the request in a
@@ -209,6 +242,24 @@ async function handle(line) {{
   try {{
     const fn = mod && mod.hooks && mod.hooks[req.hook];
     const context = {{ log: (m) => send({{ log: String(m) }}) }};
+    if (req.target === 'resolverCount') {{
+      const resolvers = mod && mod.resolvers;
+      send({{ ok: (Array.isArray(resolvers) ? resolvers.length : 0) }});
+      return;
+    }}
+    if (req.target === 'resolver') {{
+      const resolvers = mod && mod.resolvers;
+      const resolver = Array.isArray(resolvers) ? resolvers[req.index] : null;
+      const fn = resolver && resolver[req.method];
+      if (typeof fn !== 'function') {{
+        send({{ ok: null }});
+        return;
+      }}
+      const args = req.payload || [];
+      const res = await fn(...args);
+      send({{ ok: res === undefined ? null : res }});
+      return;
+    }}
     if (req.hook === 'readPackage') {{
       const pkg = req.payload;
       if (typeof fn !== 'function') {{ send({{ ok: pkg }}); return; }}

--- a/pacquet/crates/hooks/src/worker/tests.rs
+++ b/pacquet/crates/hooks/src/worker/tests.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+use tempfile::TempDir;
+use tokio::time::{Duration, timeout};
+
+use super::NodeWorker;
+
+#[tokio::test]
+async fn cancelled_request_removes_its_pending_entry() {
+    let tmp = TempDir::new().expect("temp dir");
+    let pnpmfile_path = tmp.path().join(".pnpmfile.cjs");
+    std::fs::write(
+        &pnpmfile_path,
+        "module.exports = { hooks: { readPackage: () => new Promise(() => {}) } }\n",
+    )
+    .expect("write pnpmfile");
+    let worker = NodeWorker::spawn(&pnpmfile_path).await.expect("spawn worker");
+
+    let call = worker.call("readPackage", serde_json::json!({}), Arc::new(|_| {}));
+    let cancelled = timeout(Duration::from_millis(500), call).await;
+    assert!(cancelled.is_err(), "the never-resolving hook must outlive the local timeout");
+
+    assert!(
+        worker.pending.lock().unwrap().is_empty(),
+        "a cancelled request must not leak its pending entry",
+    );
+}

--- a/pacquet/crates/hooks/tests/node_hooks.rs
+++ b/pacquet/crates/hooks/tests/node_hooks.rs
@@ -543,3 +543,137 @@ async fn update_config_without_hook_returns_config_unchanged() {
 
     assert_eq!(updated, config, "a pnpmfile without updateConfig leaves config unchanged");
 }
+
+fn write_custom_resolvers_pnpmfile(dir: &std::path::Path) -> std::path::PathBuf {
+    let pnpmfile_path = dir.join(".pnpmfile.cjs");
+    std::fs::write(
+        &pnpmfile_path,
+        r"
+module.exports = {
+  resolvers: [
+    {
+      idPrefix: 'custom',
+      canResolve (wanted) {
+        return typeof wanted.bareSpecifier === 'string' && wanted.bareSpecifier.startsWith('custom:');
+      },
+      resolve (wanted, opts) {
+        return {
+          id: `${this.idPrefix}/${wanted.alias}@1.0.0`,
+          resolution: { tarball: `https://example.com/${wanted.alias}-1.0.0.tgz` },
+          lockfileDir: opts.lockfileDir,
+        };
+      },
+      shouldRefreshResolution (depPath, pkgSnapshot) {
+        return depPath.startsWith('refresh-me@') && pkgSnapshot.resolution != null;
+      },
+    },
+    {
+      shouldRefreshResolution () {
+        throw new Error('refresh check crashed');
+      },
+    },
+  ],
+}
+",
+    )
+    .expect("write pnpmfile");
+    pnpmfile_path
+}
+
+#[tokio::test]
+async fn get_custom_resolvers_reports_per_resolver_capabilities() {
+    let tmp = TempDir::new().expect("temp dir");
+    let hooks =
+        pacquet_hooks::node_runtime::NodeJsHooks::new(write_custom_resolvers_pnpmfile(tmp.path()));
+
+    let resolvers = hooks.get_custom_resolvers().await.expect("load resolvers");
+
+    assert_eq!(resolvers.len(), 2);
+    assert!(resolvers[0].has_can_resolve());
+    assert!(resolvers[0].has_resolve());
+    assert!(resolvers[0].has_should_refresh_resolution());
+    assert!(!resolvers[1].has_can_resolve());
+    assert!(!resolvers[1].has_resolve());
+    assert!(resolvers[1].has_should_refresh_resolution());
+}
+
+#[tokio::test]
+async fn get_custom_resolvers_is_empty_without_resolvers_export() {
+    let tmp = TempDir::new().expect("temp dir");
+    let pnpmfile_path = tmp.path().join(".pnpmfile.cjs");
+    std::fs::write(&pnpmfile_path, "module.exports = { hooks: {} }").expect("write pnpmfile");
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks::new(pnpmfile_path);
+
+    let resolvers = hooks.get_custom_resolvers().await.expect("load resolvers");
+
+    assert!(resolvers.is_empty());
+}
+
+#[tokio::test]
+async fn custom_resolver_round_trips_can_resolve_and_resolve() {
+    let tmp = TempDir::new().expect("temp dir");
+    let hooks =
+        pacquet_hooks::node_runtime::NodeJsHooks::new(write_custom_resolvers_pnpmfile(tmp.path()));
+    let resolvers = hooks.get_custom_resolvers().await.expect("load resolvers");
+    let wanted = serde_json::json!({ "alias": "foo", "bareSpecifier": "custom:foo" });
+
+    assert!(resolvers[0].can_resolve(wanted.clone()).await.expect("canResolve"));
+    assert!(
+        !resolvers[0]
+            .can_resolve(serde_json::json!({ "alias": "bar", "bareSpecifier": "^1.0.0" }))
+            .await
+            .expect("canResolve"),
+    );
+
+    let result = resolvers[0]
+        .resolve(wanted, serde_json::json!({ "lockfileDir": "/repo" }))
+        .await
+        .expect("resolve");
+    // `custom/` prefix comes from `this.idPrefix`: methods must be
+    // invoked with the resolver object as `this`, like pnpm does.
+    assert_eq!(result["id"], "custom/foo@1.0.0");
+    assert_eq!(result["resolution"]["tarball"], "https://example.com/foo-1.0.0.tgz");
+    assert_eq!(result["lockfileDir"], "/repo", "resolve opts reach the hook");
+}
+
+#[tokio::test]
+async fn custom_resolver_should_refresh_resolution_receives_dep_path_and_snapshot() {
+    let tmp = TempDir::new().expect("temp dir");
+    let hooks =
+        pacquet_hooks::node_runtime::NodeJsHooks::new(write_custom_resolvers_pnpmfile(tmp.path()));
+    let resolvers = hooks.get_custom_resolvers().await.expect("load resolvers");
+    let snapshot = serde_json::json!({ "resolution": { "integrity": "sha512-x" } });
+
+    let matching: pacquet_lockfile::PackageKey =
+        "refresh-me@1.0.0".parse().expect("valid dep path");
+    let other: pacquet_lockfile::PackageKey = "other@1.0.0".parse().expect("valid dep path");
+
+    assert!(
+        resolvers[0]
+            .should_refresh_resolution(&matching, snapshot.clone())
+            .await
+            .expect("shouldRefreshResolution"),
+    );
+    assert!(
+        !resolvers[0]
+            .should_refresh_resolution(&other, snapshot)
+            .await
+            .expect("shouldRefreshResolution"),
+    );
+}
+
+#[tokio::test]
+async fn custom_resolver_errors_propagate() {
+    let tmp = TempDir::new().expect("temp dir");
+    let hooks =
+        pacquet_hooks::node_runtime::NodeJsHooks::new(write_custom_resolvers_pnpmfile(tmp.path()));
+    let resolvers = hooks.get_custom_resolvers().await.expect("load resolvers");
+    let dep_path: pacquet_lockfile::PackageKey = "any@1.0.0".parse().expect("valid dep path");
+
+    let err = resolvers[1]
+        .should_refresh_resolution(&dep_path, serde_json::json!({}))
+        .await
+        .expect_err("throwing hook must surface as an error");
+
+    assert!(err.to_string().contains("refresh check crashed"), "got: {err}");
+}

--- a/pacquet/crates/package-manager/Cargo.toml
+++ b/pacquet/crates/package-manager/Cargo.toml
@@ -75,6 +75,7 @@ miette          = { workspace = true }
 [dev-dependencies]
 pacquet-testing-utils = { workspace = true }
 
+async-trait       = { workspace = true }
 node-semver       = { workspace = true }
 dunce             = { workspace = true }
 insta             = { workspace = true }

--- a/pacquet/crates/package-manager/src/check_custom_resolver_force_resolve.rs
+++ b/pacquet/crates/package-manager/src/check_custom_resolver_force_resolve.rs
@@ -1,0 +1,94 @@
+//! Ask the pnpmfile's custom resolvers whether any lockfile entry must
+//! be re-resolved. Port of pnpm's
+//! [`checkCustomResolverForceResolve`](https://github.com/pnpm/pnpm/blob/1627943d2a/installing/deps-installer/src/install/checkCustomResolverForceResolve.ts).
+
+use std::{path::Path, sync::Arc};
+
+use futures_util::{StreamExt, stream::FuturesUnordered};
+use serde_json::Value;
+
+use pacquet_hooks::{CustomResolver, HookError, finder};
+use pacquet_lockfile::{Lockfile, PackageKey, SnapshotEntry};
+
+/// Load the pnpmfile at `lockfile_dir` (if any) and report whether its
+/// custom resolvers force re-resolution of `lockfile`. Used by the
+/// install dispatch to keep the frozen-path optimization from skipping
+/// a forced re-resolve — pnpm folds the hook's verdict into
+/// `needsFullResolution`, which blocks `isFrozenInstallPossible`.
+pub(crate) async fn force_resolve_from_pnpmfile(
+    lockfile: &Lockfile,
+    lockfile_dir: &Path,
+) -> Result<bool, HookError> {
+    let Some(hook) = finder::load_pnpmfile(lockfile_dir) else {
+        return Ok(false);
+    };
+    let custom_resolvers = hook.get_custom_resolvers().await?;
+    check_custom_resolver_force_resolve(&custom_resolvers, lockfile).await
+}
+
+/// Whether any custom resolver's `shouldRefreshResolution` returns true
+/// for any package in `lockfile`. The hook is called independently of
+/// `canResolve` — each resolver does its own filtering. The first error
+/// from a hook propagates and aborts the install, mirroring pnpm.
+pub(crate) async fn check_custom_resolver_force_resolve(
+    custom_resolvers: &[Arc<dyn CustomResolver>],
+    lockfile: &Lockfile,
+) -> Result<bool, HookError> {
+    let Some(snapshots) = lockfile.snapshots.as_ref() else {
+        return Ok(false);
+    };
+    let hooks: Vec<&Arc<dyn CustomResolver>> = custom_resolvers
+        .iter()
+        .filter(|resolver| resolver.has_should_refresh_resolution())
+        .collect();
+    if hooks.is_empty() {
+        return Ok(false);
+    }
+
+    // Fire every (package, hook) check up front so the Node worker can
+    // interleave the async hooks, mirroring upstream's `anyTrue` over
+    // eagerly created promises; the first `true` wins and the rest are
+    // dropped.
+    let mut checks: FuturesUnordered<_> = snapshots
+        .iter()
+        .flat_map(|(dep_path, entry)| {
+            let snapshot_json = merged_package_snapshot_json(lockfile, dep_path, entry);
+            hooks.iter().map(move |hook| {
+                let snapshot_json = snapshot_json.clone();
+                async move { hook.should_refresh_resolution(dep_path, snapshot_json).await }
+            })
+        })
+        .collect();
+    while let Some(refresh) = checks.next().await {
+        if refresh? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// The hook receives pnpm's in-memory `PackageSnapshot` shape: the
+/// `packages:` entry (resolution, engines, ...) merged with the
+/// `snapshots:` entry (dependencies, optional, ...) for the dep path.
+fn merged_package_snapshot_json(
+    lockfile: &Lockfile,
+    dep_path: &PackageKey,
+    entry: &SnapshotEntry,
+) -> Value {
+    let mut merged = serde_json::Map::new();
+    if let Some(Value::Object(fields)) = lockfile
+        .packages
+        .as_ref()
+        .and_then(|packages| packages.get(&dep_path.without_peer()))
+        .and_then(|metadata| serde_json::to_value(metadata).ok())
+    {
+        merged.extend(fields);
+    }
+    if let Ok(Value::Object(fields)) = serde_json::to_value(entry) {
+        merged.extend(fields);
+    }
+    Value::Object(merged)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/package-manager/src/check_custom_resolver_force_resolve/tests.rs
+++ b/pacquet/crates/package-manager/src/check_custom_resolver_force_resolve/tests.rs
@@ -1,0 +1,205 @@
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use pacquet_hooks::{CustomResolver, HookError};
+use pacquet_lockfile::{Lockfile, PackageKey};
+
+use super::check_custom_resolver_force_resolve;
+
+struct MockResolver {
+    has_should_refresh_resolution: bool,
+    refresh_outcome: Result<bool, HookError>,
+    calls: Mutex<Vec<(String, Value)>>,
+    call_count: AtomicUsize,
+}
+
+impl MockResolver {
+    fn refreshing(refresh: bool) -> Self {
+        MockResolver {
+            has_should_refresh_resolution: true,
+            refresh_outcome: Ok(refresh),
+            calls: Mutex::new(Vec::new()),
+            call_count: AtomicUsize::new(0),
+        }
+    }
+
+    fn without_hook() -> Self {
+        MockResolver { has_should_refresh_resolution: false, ..Self::refreshing(false) }
+    }
+
+    fn failing(message: &str) -> Self {
+        MockResolver {
+            refresh_outcome: Err(HookError::Execution {
+                pnpmfile: ".pnpmfile.cjs".to_string(),
+                message: message.to_string(),
+            }),
+            ..Self::refreshing(false)
+        }
+    }
+}
+
+#[async_trait]
+impl CustomResolver for MockResolver {
+    fn has_should_refresh_resolution(&self) -> bool {
+        self.has_should_refresh_resolution
+    }
+
+    async fn can_resolve(&self, _: Value) -> Result<bool, HookError> {
+        Ok(false)
+    }
+
+    async fn resolve(&self, _: Value, _: Value) -> Result<Value, HookError> {
+        Ok(Value::Null)
+    }
+
+    async fn should_refresh_resolution(
+        &self,
+        dep_path: &PackageKey,
+        pkg_snapshot: Value,
+    ) -> Result<bool, HookError> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        self.calls.lock().unwrap().push((dep_path.to_string(), pkg_snapshot));
+        self.refresh_outcome.clone()
+    }
+}
+
+fn lockfile(value: Value) -> Lockfile {
+    serde_json::from_value(value).expect("valid lockfile JSON")
+}
+
+fn lockfile_with_one_package() -> Lockfile {
+    lockfile(json!({
+        "lockfileVersion": "9.0",
+        "packages": {
+            "test-pkg@1.0.0": {
+                "resolution": {
+                    "tarball": "http://example.com/test-pkg-1.0.0.tgz",
+                    "integrity": "sha512-7vPSqv9MKvOTcGZSjm9ZcMnxiTYbXrAJZHzAi3GUv/tSZdLZE6richEuZ+EHAJRm6q2eOBBdc6TIuQfRGCQTzg==",
+                },
+            },
+        },
+        "snapshots": {
+            "test-pkg@1.0.0": {},
+        },
+    }))
+}
+
+fn resolvers(items: Vec<MockResolver>) -> Vec<Arc<dyn CustomResolver>> {
+    items.into_iter().map(|item| Arc::new(item) as Arc<dyn CustomResolver>).collect()
+}
+
+#[tokio::test]
+async fn returns_false_when_no_custom_resolvers() {
+    let result =
+        check_custom_resolver_force_resolve(&[], &lockfile_with_one_package()).await.unwrap();
+    assert!(!result);
+}
+
+#[tokio::test]
+async fn returns_false_when_lockfile_has_no_snapshots() {
+    let empty = lockfile(json!({ "lockfileVersion": "9.0" }));
+    let result = check_custom_resolver_force_resolve(
+        &resolvers(vec![MockResolver::refreshing(true)]),
+        &empty,
+    )
+    .await
+    .unwrap();
+    assert!(!result);
+}
+
+#[tokio::test]
+async fn skips_resolvers_without_the_hook() {
+    let resolver = Arc::new(MockResolver::without_hook());
+    let list: Vec<Arc<dyn CustomResolver>> = vec![Arc::clone(&resolver) as _];
+
+    let result =
+        check_custom_resolver_force_resolve(&list, &lockfile_with_one_package()).await.unwrap();
+
+    assert!(!result);
+    assert_eq!(resolver.call_count.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn returns_false_when_hook_returns_false() {
+    let result = check_custom_resolver_force_resolve(
+        &resolvers(vec![MockResolver::refreshing(false)]),
+        &lockfile_with_one_package(),
+    )
+    .await
+    .unwrap();
+    assert!(!result);
+}
+
+#[tokio::test]
+async fn returns_true_when_hook_returns_true() {
+    let result = check_custom_resolver_force_resolve(
+        &resolvers(vec![MockResolver::refreshing(true)]),
+        &lockfile_with_one_package(),
+    )
+    .await
+    .unwrap();
+    assert!(result);
+}
+
+#[tokio::test]
+async fn returns_true_when_any_resolver_among_multiple_returns_true() {
+    let result = check_custom_resolver_force_resolve(
+        &resolvers(vec![MockResolver::refreshing(false), MockResolver::refreshing(true)]),
+        &lockfile_with_one_package(),
+    )
+    .await
+    .unwrap();
+    assert!(result);
+}
+
+#[tokio::test]
+async fn propagates_hook_errors() {
+    let result = check_custom_resolver_force_resolve(
+        &resolvers(vec![
+            MockResolver::refreshing(false),
+            MockResolver::failing("resolver crashed"),
+        ]),
+        &lockfile_with_one_package(),
+    )
+    .await;
+    let err = result.expect_err("hook error must propagate");
+    assert!(err.to_string().contains("resolver crashed"), "got: {err}");
+}
+
+#[tokio::test]
+async fn passes_dep_path_and_merged_package_snapshot() {
+    let resolver = Arc::new(MockResolver::refreshing(false));
+    let list: Vec<Arc<dyn CustomResolver>> = vec![Arc::clone(&resolver) as _];
+    let lockfile = lockfile(json!({
+        "lockfileVersion": "9.0",
+        "packages": {
+            "test-pkg@1.0.0": {
+                "resolution": {
+                    "tarball": "http://example.com/test-pkg-1.0.0.tgz",
+                    "integrity": "sha512-7vPSqv9MKvOTcGZSjm9ZcMnxiTYbXrAJZHzAi3GUv/tSZdLZE6richEuZ+EHAJRm6q2eOBBdc6TIuQfRGCQTzg==",
+                },
+            },
+        },
+        "snapshots": {
+            "test-pkg@1.0.0(peer@2.0.0)": {
+                "dependencies": { "peer": "2.0.0" },
+            },
+        },
+    }));
+
+    check_custom_resolver_force_resolve(&list, &lockfile).await.unwrap();
+
+    let calls = resolver.calls.lock().unwrap();
+    let (dep_path, snapshot) = calls.first().expect("hook called once");
+    assert_eq!(dep_path, "test-pkg@1.0.0(peer@2.0.0)");
+    // The `packages:` entry (resolution) and the `snapshots:` entry
+    // (dependencies) arrive merged, like pnpm's in-memory
+    // `PackageSnapshot`.
+    assert_eq!(snapshot["resolution"]["tarball"], json!("http://example.com/test-pkg-1.0.0.tgz"));
+    assert_eq!(snapshot["dependencies"]["peer"], json!("2.0.0"));
+}

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -244,6 +244,14 @@ pub enum InstallError {
     #[diagnostic(transparent)]
     WithFreshLockfile(#[error(source)] InstallWithFreshLockfileError),
 
+    /// A custom resolver hook failed (loading the pnpmfile's resolvers
+    /// or running `shouldRefreshResolution`) while deciding whether the
+    /// frozen-path optimization may run. Mirrors pnpm, where a throwing
+    /// hook aborts the install.
+    #[display("{_0}")]
+    #[diagnostic(code(PNPMFILE_FAIL))]
+    CustomResolverForceResolve(#[error(not(source))] pacquet_hooks::HookError),
+
     /// `--no-runtime` (or `config.skip_runtimes`) is honored only on
     /// the frozen-lockfile path today, where the runtime filter runs
     /// against the loaded lockfile's `packages:` map. A non-frozen
@@ -823,7 +831,24 @@ where
                     &catalogs,
                     ignore_manifest_check,
                 ) {
-                    Ok(()) => true,
+                    // Even an up-to-date lockfile may not go frozen: a
+                    // custom resolver's `shouldRefreshResolution` can
+                    // force the fresh-resolve path. pnpm folds the
+                    // hook's verdict into `needsFullResolution`, which
+                    // blocks `isFrozenInstallPossible`. A lockfile
+                    // synthesized from the current snapshot skips the
+                    // check (upstream gates on
+                    // `existsNonEmptyWantedLockfile`). A throwing hook
+                    // aborts the install.
+                    Ok(()) => {
+                        lockfile_synthesized_from_current
+                            || !crate::check_custom_resolver_force_resolve::force_resolve_from_pnpmfile(
+                                lockfile,
+                                &workspace_root,
+                            )
+                            .await
+                            .map_err(InstallError::CustomResolverForceResolve)?
+                    }
                     Err(FreshnessCheckError::Stale(_) | FreshnessCheckError::NoImporter { .. }) => {
                         false
                     }
@@ -930,7 +955,13 @@ where
             }
             update_workspace_state(
                 &workspace_root,
-                &build_workspace_state(config, node_linker, included, &project_manifests),
+                &build_workspace_state(
+                    &workspace_root,
+                    config,
+                    node_linker,
+                    included,
+                    &project_manifests,
+                ),
             )
             .map_err(InstallError::WriteWorkspaceState)?;
             Reporter::emit(&LogEvent::Summary(SummaryLog { level: LogLevel::Debug, prefix }));
@@ -1268,7 +1299,13 @@ where
         // committed install.
         update_workspace_state(
             &workspace_root,
-            &build_workspace_state(config, node_linker, included, &project_manifests),
+            &build_workspace_state(
+                &workspace_root,
+                config,
+                node_linker,
+                included,
+                &project_manifests,
+            ),
         )
         .map_err(InstallError::WriteWorkspaceState)?;
 
@@ -1806,6 +1843,7 @@ fn build_projects_map(
 /// only iterates fields present in the serialized object, so an
 /// absent key is silently skipped rather than treated as a drift.
 pub(crate) fn build_workspace_state(
+    workspace_root: &Path,
     config: &Config,
     node_linker: NodeLinker,
     included: IncludedDependencies,
@@ -1814,10 +1852,7 @@ pub(crate) fn build_workspace_state(
     WorkspaceState {
         last_validated_timestamp: now_millis(),
         projects: build_projects_map(project_manifests),
-        // Pacquet doesn't run pnpmfiles yet; record the empty list so
-        // pnpm's `patchesOrHooksAreModified` doesn't trip on a missing
-        // field.
-        pnpmfiles: Vec::new(),
+        pnpmfiles: crate::optimistic_repeat_install::current_pnpmfiles(workspace_root),
         // Pacquet has no `--filter` yet (issue <https://github.com/pnpm/pacquet/issues/299> stage 2). Hard-code
         // `false` so pnpm doesn't treat the install as partial and
         // skip the cache.

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -1060,8 +1060,10 @@ mod build_workspace_state_tests {
     /// timestamp.
     #[test]
     fn empty_project_list_produces_empty_projects_map() {
+        let dir = tempdir().unwrap();
         let config = Config::new();
         let state = build_workspace_state(
+            dir.path(),
             &config,
             pacquet_config::NodeLinker::default(),
             IncludedDependencies::default(),
@@ -1093,6 +1095,7 @@ mod build_workspace_state_tests {
 
         let config = Config::new();
         let state = build_workspace_state(
+            dir.path(),
             &config,
             pacquet_config::NodeLinker::default(),
             IncludedDependencies::default(),
@@ -1124,7 +1127,9 @@ mod build_workspace_state_tests {
             "@pnpm/pacquet".to_string(),
             ConfigDependency::VersionWithIntegrity("0.2.2-14".to_string()),
         )]));
+        let dir = tempdir().unwrap();
         let state = build_workspace_state(
+            dir.path(),
             &config,
             pacquet_config::NodeLinker::default(),
             IncludedDependencies::default(),

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -696,18 +696,45 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             full_metadata,
             retry_opts: crate::retry_config::retry_opts_from_config(config),
         };
+        let pnpmfile_hook = finder::load_pnpmfile(lockfile_dir);
+        let custom_resolvers_raw: Vec<Arc<dyn pacquet_hooks::CustomResolver>> =
+            if let Some(ref hook) = pnpmfile_hook {
+                hook.get_custom_resolvers().await.map_err(|err| {
+                    tracing::error!(
+                        target: "pacquet::install",
+                        "Failed to get custom resolvers from pnpmfile: {err}",
+                    );
+                    InstallWithFreshLockfileError::CustomResolverHook(err)
+                })?
+            } else {
+                vec![]
+            };
+
         // Order mirrors upstream's chain at
         // <https://github.com/pnpm/pnpm/blob/1627943d2a/resolving/default-resolver/src/index.ts#L128-L147>:
-        // npm → jsr (folded into npm) → git → tarball → localScheme →
-        // node → deno → bun → namedRegistry → localPath. The
-        // local-resolver split is required by named-registry: a
+        // custom resolvers → npm → jsr (folded into npm) → git →
+        // tarball → localScheme → node → deno → bun → namedRegistry →
+        // localPath. Custom resolvers join only when they implement
+        // both `canResolve` and `resolve` (upstream skips the others).
+        // The local-resolver split is required by named-registry: a
         // `<alias>:@scope/pkg` specifier carries an embedded `/`,
         // which the path-shape detector
         // (`contains_path_sep` in `parse_bare_specifier.rs`) would
         // otherwise claim and prevent the named-registry resolver
         // from running.
-        let inner_resolver: Box<dyn Resolver> = Box::new(DefaultResolver::new(vec![
-            Box::new(ArcResolver(Arc::clone(&npm_resolver))),
+        let mut chain: Vec<Box<dyn Resolver>> = Vec::with_capacity(custom_resolvers_raw.len() + 9);
+        chain.extend(
+            custom_resolvers_raw
+                .iter()
+                .filter(|custom| custom.has_can_resolve() && custom.has_resolve())
+                .map(|custom| {
+                    Box::new(pacquet_hooks::custom_resolver_adapter::CustomResolverAdapter::new(
+                        Arc::clone(custom),
+                    )) as Box<dyn Resolver>
+                }),
+        );
+        chain.extend([
+            Box::new(ArcResolver(Arc::clone(&npm_resolver))) as Box<dyn Resolver>,
             Box::new(git_resolver),
             Box::new(tarball_resolver),
             Box::new(local_scheme_resolver),
@@ -716,7 +743,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             Box::new(bun_resolver),
             Box::new(named_registry_resolver),
             Box::new(local_path_resolver),
-        ]));
+        ]);
+        let inner_resolver: Box<dyn Resolver> = Box::new(DefaultResolver::new(chain));
 
         // Wrap the resolver chain so each tarball-shaped result fires a
         // background download into `tarball_mem_cache` while the
@@ -962,7 +990,6 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 .collect();
         let peers_suffix_max_length =
             usize::try_from(config.peers_suffix_max_length).unwrap_or(usize::MAX);
-        let pnpmfile_hook = finder::load_pnpmfile(lockfile_dir);
         // Kept past the resolver hand-off (which consumes `pnpmfile_hook`) so
         // the `afterAllResolved` hook can transform the lockfile before it is
         // written.
@@ -979,37 +1006,6 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         let after_all_resolved_log = pnpmfile_path
             .as_ref()
             .map(|from| hook_log_fn::<Reporter>(lockfile_dir, from, "afterAllResolved"));
-
-        // Upstream chain priority:
-        // <https://github.com/pnpm/pnpm/blob/1627943d2a/resolving/default-resolver/src/index.ts#L128-L134>.
-        let custom_resolvers_raw: Vec<Arc<dyn pacquet_hooks::CustomResolver>> =
-            if let Some(ref hook) = pnpmfile_hook {
-                hook.get_custom_resolvers().await.map_err(|err| {
-                    tracing::error!(
-                        target: "pacquet::install",
-                        "Failed to get custom resolvers from pnpmfile: {err}",
-                    );
-                    InstallWithFreshLockfileError::CustomResolverHook(err)
-                })?
-            } else {
-                vec![]
-            };
-
-        let resolver: Box<dyn Resolver> = if custom_resolvers_raw.is_empty() {
-            resolver
-        } else {
-            let mut chain: Vec<Box<dyn Resolver>> =
-                Vec::with_capacity(custom_resolvers_raw.len() + 1);
-            for cr in &custom_resolvers_raw {
-                chain.push(Box::new(
-                    pacquet_hooks::custom_resolver_adapter::CustomResolverAdapter::new(Arc::clone(
-                        cr,
-                    )),
-                ));
-            }
-            chain.push(resolver);
-            Box::new(DefaultResolver::new(chain))
-        };
 
         // Call preResolution hook before resolution starts (mirrors pnpm's behavior in install/index.ts)
         if let Some(ref hook) = pnpmfile_hook {
@@ -1060,10 +1056,13 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         };
 
         // A throwing hook propagates and aborts.
-        if let Some(snapshots) = wanted_lockfile.as_ref().and_then(|lf| lf.snapshots.as_ref())
-            && should_refresh_resolution(&custom_resolvers_raw, snapshots)
-                .await
-                .map_err(InstallWithFreshLockfileError::CustomResolverForceResolve)?
+        if let Some(lockfile) = wanted_lockfile
+            && crate::check_custom_resolver_force_resolve::check_custom_resolver_force_resolve(
+                &custom_resolvers_raw,
+                lockfile,
+            )
+            .await
+            .map_err(InstallWithFreshLockfileError::CustomResolverForceResolve)?
         {
             update_reuse_scope = pacquet_resolving_deps_resolver::UpdateReuseScope::None;
         }
@@ -1996,22 +1995,6 @@ fn compute_package_extensions_checksum(config: &Config) -> Option<String> {
         config.package_extensions.as_ref().filter(|extensions| !extensions.is_empty())?;
     let value = serde_json::to_value(extensions).ok()?;
     pacquet_graph_hasher::hash_object_nullable_with_prefix(&value)
-}
-
-/// A throwing hook propagates and aborts.
-async fn should_refresh_resolution(
-    custom_resolvers: &[Arc<dyn pacquet_hooks::CustomResolver>],
-    snapshots: &HashMap<pacquet_lockfile::PackageKey, pacquet_lockfile::SnapshotEntry>,
-) -> Result<bool, pacquet_hooks::HookError> {
-    for resolver in custom_resolvers {
-        for (dep_path, snapshot) in snapshots.iter() {
-            let snapshot_val = serde_json::to_value(snapshot).unwrap_or_default();
-            if resolver.should_refresh_resolution(dep_path.to_string(), snapshot_val).await? {
-                return Ok(true);
-            }
-        }
-    }
-    Ok(false)
 }
 
 /// [`Resolver`] adapter that delegates to a shared `Arc<dyn Resolver>`.

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -354,6 +354,20 @@ pub enum InstallWithFreshLockfileError {
     #[display("Failed to serialize lockfile for the afterAllResolved hook: {_0}")]
     #[diagnostic(code(pacquet_package_manager::after_all_resolved_serialize))]
     AfterAllResolvedSerialize(#[error(source)] serde_json::Error),
+
+    /// The pnpmfile's `getCustomResolvers` hook threw while loading custom
+    /// resolvers. Mirrors pnpm, where a throwing custom-resolver hook
+    /// aborts the install.
+    #[display("{_0}")]
+    #[diagnostic(code(PNPMFILE_FAIL))]
+    CustomResolverHook(#[error(not(source))] pacquet_hooks::HookError),
+
+    /// A custom resolver's `shouldRefreshResolution` hook threw while
+    /// checking whether to force re-resolution. Mirrors pnpm, where a
+    /// throwing hook aborts the install.
+    #[display("{_0}")]
+    #[diagnostic(code(PNPMFILE_FAIL))]
+    CustomResolverForceResolve(#[error(not(source))] pacquet_hooks::HookError),
 }
 
 impl From<crate::install_frozen_lockfile::HoistedLinkerError> for InstallWithFreshLockfileError {
@@ -966,6 +980,37 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             .as_ref()
             .map(|from| hook_log_fn::<Reporter>(lockfile_dir, from, "afterAllResolved"));
 
+        // Upstream chain priority:
+        // <https://github.com/pnpm/pnpm/blob/1627943d2a/resolving/default-resolver/src/index.ts#L128-L134>.
+        let custom_resolvers_raw: Vec<Arc<dyn pacquet_hooks::CustomResolver>> =
+            if let Some(ref hook) = pnpmfile_hook {
+                hook.get_custom_resolvers().await.map_err(|err| {
+                    tracing::error!(
+                        target: "pacquet::install",
+                        "Failed to get custom resolvers from pnpmfile: {err}",
+                    );
+                    InstallWithFreshLockfileError::CustomResolverHook(err)
+                })?
+            } else {
+                vec![]
+            };
+
+        let resolver: Box<dyn Resolver> = if custom_resolvers_raw.is_empty() {
+            resolver
+        } else {
+            let mut chain: Vec<Box<dyn Resolver>> =
+                Vec::with_capacity(custom_resolvers_raw.len() + 1);
+            for cr in &custom_resolvers_raw {
+                chain.push(Box::new(
+                    pacquet_hooks::custom_resolver_adapter::CustomResolverAdapter::new(Arc::clone(
+                        cr,
+                    )),
+                ));
+            }
+            chain.push(resolver);
+            Box::new(DefaultResolver::new(chain))
+        };
+
         // Call preResolution hook before resolution starts (mirrors pnpm's behavior in install/index.ts)
         if let Some(ref hook) = pnpmfile_hook {
             let wanted_lockfile_json = wanted_lockfile.map_or_else(
@@ -1003,6 +1048,26 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             .await;
         }
 
+        // `pacquet update` must re-resolve its targets to highest-in-range,
+        // so suppress reuse for them (and their subtrees). Custom resolvers
+        // may widen this to `None` via `shouldRefreshResolution`.
+        let mut update_reuse_scope = match &update_seed_policy {
+            UpdateSeedPolicy::KeepAll => pacquet_resolving_deps_resolver::UpdateReuseScope::All,
+            UpdateSeedPolicy::DropAll => pacquet_resolving_deps_resolver::UpdateReuseScope::None,
+            UpdateSeedPolicy::DropOnly(names) => {
+                pacquet_resolving_deps_resolver::UpdateReuseScope::Except(names.clone())
+            }
+        };
+
+        // A throwing hook propagates and aborts.
+        if let Some(snapshots) = wanted_lockfile.as_ref().and_then(|lf| lf.snapshots.as_ref())
+            && should_refresh_resolution(&custom_resolvers_raw, snapshots)
+                .await
+                .map_err(InstallWithFreshLockfileError::CustomResolverForceResolve)?
+        {
+            update_reuse_scope = pacquet_resolving_deps_resolver::UpdateReuseScope::None;
+        }
+
         let workspace_opts = pacquet_resolving_deps_resolver::WorkspaceResolveOptions {
             dedupe_peers: config.dedupe_peers,
             dedupe_injected_deps: config.dedupe_injected_deps,
@@ -1030,17 +1095,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 })
                 .cloned()
                 .map(Arc::new),
-            // `pacquet update` must re-resolve its targets to highest-
-            // in-range, so suppress reuse for them (and their subtrees).
-            update_reuse_scope: match &update_seed_policy {
-                UpdateSeedPolicy::KeepAll => pacquet_resolving_deps_resolver::UpdateReuseScope::All,
-                UpdateSeedPolicy::DropAll => {
-                    pacquet_resolving_deps_resolver::UpdateReuseScope::None
-                }
-                UpdateSeedPolicy::DropOnly(names) => {
-                    pacquet_resolving_deps_resolver::UpdateReuseScope::Except(names.clone())
-                }
-            },
+            update_reuse_scope,
             auto_install_peers: config.auto_install_peers,
         };
         let modules_basename = config.modules_dir.file_name().map_or_else(
@@ -1941,6 +1996,22 @@ fn compute_package_extensions_checksum(config: &Config) -> Option<String> {
         config.package_extensions.as_ref().filter(|extensions| !extensions.is_empty())?;
     let value = serde_json::to_value(extensions).ok()?;
     pacquet_graph_hasher::hash_object_nullable_with_prefix(&value)
+}
+
+/// A throwing hook propagates and aborts.
+async fn should_refresh_resolution(
+    custom_resolvers: &[Arc<dyn pacquet_hooks::CustomResolver>],
+    snapshots: &HashMap<pacquet_lockfile::PackageKey, pacquet_lockfile::SnapshotEntry>,
+) -> Result<bool, pacquet_hooks::HookError> {
+    for resolver in custom_resolvers {
+        for (dep_path, snapshot) in snapshots.iter() {
+            let snapshot_val = serde_json::to_value(snapshot).unwrap_or_default();
+            if resolver.should_refresh_resolution(dep_path.to_string(), snapshot_val).await? {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
 }
 
 /// [`Resolver`] adapter that delegates to a shared `Arc<dyn Resolver>`.

--- a/pacquet/crates/package-manager/src/lib.rs
+++ b/pacquet/crates/package-manager/src/lib.rs
@@ -4,6 +4,7 @@ mod build_resolution_verifiers;
 mod build_sequence;
 mod build_snapshot;
 mod catalog_mode;
+mod check_custom_resolver_force_resolve;
 mod create_symlink_layout;
 mod create_virtual_dir_by_snapshot;
 mod create_virtual_store;

--- a/pacquet/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pacquet/crates/package-manager/src/optimistic_repeat_install.rs
@@ -27,9 +27,12 @@
 //! dependency-relevant content still matches the lockfile, upstream's
 //! [`assertWantedLockfileUpToDate`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/status/src/checkDepsStatus.ts#L483-L561)
 //! still reports up-to-date (a `touch package.json`, a `scripts` edit, or
-//! an `npm pkg set/delete` rewrite must not trigger a full install). The
-//! pnpmfile branch of `patchesOrHooksAreModified` and the
-//! `isLocalFileDepUpdated` branch of `linkedPackagesAreUpToDate` are NOT
+//! an `npm pkg set/delete` rewrite must not trigger a full install), and
+//! the pnpmfile branch of `patchesOrHooksAreModified` (an added, removed,
+//! or edited workspace pnpmfile invalidates the fast path; plugin
+//! pnpmfiles from config dependencies are covered by the
+//! `config_dependencies` comparison instead of the mtime check). The
+//! `isLocalFileDepUpdated` branch of `linkedPackagesAreUpToDate` is NOT
 //! ported here. When this function returns `Decision::Skipped` the caller
 //! proceeds with the full install path, which still has its own freshness
 //! guards (`check_lockfile_freshness`, the no-op short-circuit). Remaining
@@ -203,6 +206,15 @@ pub fn check_optimistic_repeat_install(check: &OptimisticRepeatInstallCheck<'_>)
         return Decision::Skipped { reason: "a patch file is newer than the last validation" };
     }
 
+    // A pnpmfile added, removed, or edited in place can change
+    // resolution (readPackage rewrites, custom resolvers, a
+    // `shouldRefreshResolution` verdict) without touching any manifest,
+    // so it must defeat the mtime fast path. Upstream catches this in
+    // the pnpmfile branch of `patchesOrHooksAreModified`.
+    if pnpmfiles_modified_since(workspace_root, &state.pnpmfiles, state.last_validated_timestamp) {
+        return Decision::Skipped { reason: "a pnpmfile changed since the last validation" };
+    }
+
     // The fast-path conclusion. Upstream walks every manifest and
     // returns `upToDate: true` when none have an mtime newer than
     // `workspaceState.lastValidatedTimestamp`. The walk has to
@@ -242,6 +254,7 @@ pub fn check_optimistic_repeat_install(check: &OptimisticRepeatInstallCheck<'_>)
             // content check, so it degrades rather than fails.
             if is_workspace_install {
                 let new_state = crate::install::build_workspace_state(
+                    workspace_root,
                     config,
                     node_linker,
                     included,
@@ -967,6 +980,40 @@ fn patches_modified_since(workspace_root: &Path, config: &Config, cutoff_ms: i64
         };
         let Ok(elapsed) = modified.duration_since(SystemTime::UNIX_EPOCH) else {
             return false;
+        };
+        let modified_ms = i64::try_from(elapsed.as_millis()).unwrap_or(i64::MAX);
+        modified_ms > cutoff_ms
+    })
+}
+
+/// The pnpmfile list recorded in the workspace state and compared by
+/// the freshness check: today just the workspace pnpmfile.
+/// Config-dependency plugin pnpmfiles are tracked via the
+/// `config_dependencies` comparison instead. pnpm records every loaded
+/// pnpmfile (`resolvedPnpmfilePaths`, plugins included).
+pub(crate) fn current_pnpmfiles(workspace_root: &Path) -> Vec<String> {
+    pacquet_hooks::finder::find_pnpmfile(workspace_root)
+        .map(|path| path.to_string_lossy().into_owned())
+        .into_iter()
+        .collect()
+}
+
+/// Mirrors the pnpmfile branch of upstream's
+/// [`patchesOrHooksAreModified`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/status/src/checkDepsStatus.ts#L692-L703):
+/// the recorded pnpmfile list must match the current one, every
+/// recorded pnpmfile must still exist, and none may be newer than the
+/// last validation.
+fn pnpmfiles_modified_since(workspace_root: &Path, previous: &[String], cutoff_ms: i64) -> bool {
+    let current = current_pnpmfiles(workspace_root);
+    if current != previous {
+        return true;
+    }
+    current.iter().any(|path| {
+        let Ok(modified) = fs::metadata(path).and_then(|metadata| metadata.modified()) else {
+            return true;
+        };
+        let Ok(elapsed) = modified.duration_since(SystemTime::UNIX_EPOCH) else {
+            return true;
         };
         let modified_ms = i64::try_from(elapsed.as_millis()).unwrap_or(i64::MAX);
         modified_ms > cutoff_ms

--- a/pacquet/crates/resolving-resolver-base/src/lib.rs
+++ b/pacquet/crates/resolving-resolver-base/src/lib.rs
@@ -28,8 +28,8 @@ mod verifier;
 
 pub use publish_time::parse_packument_timestamp;
 pub use resolve::{
-    DIRECT_DEP_SELECTOR_WEIGHT, DependencyManifest, EXISTING_VERSION_SELECTOR_WEIGHT, LatestInfo,
-    LatestQuery, PkgResolutionId, PreferredVersions, ResolveError, ResolveFuture,
+    CurrentPkg, DIRECT_DEP_SELECTOR_WEIGHT, DependencyManifest, EXISTING_VERSION_SELECTOR_WEIGHT,
+    LatestInfo, LatestQuery, PkgResolutionId, PreferredVersions, ResolveError, ResolveFuture,
     ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, SharedDependencyManifest,
     UpdateBehavior, VersionSelectorEntry, VersionSelectorType, VersionSelectorWithWeight,
     VersionSelectors, WantedDependency, WorkspacePackage, WorkspacePackages,

--- a/pacquet/crates/resolving-resolver-base/src/resolve.rs
+++ b/pacquet/crates/resolving-resolver-base/src/resolve.rs
@@ -190,12 +190,26 @@ pub enum UpdateBehavior {
     Latest,
 }
 
+/// Previously-resolved entry from the lockfile, threaded so resolvers
+/// can short-circuit when the install is not requesting an update. Mirrors
+/// upstream's
+/// [`CurrentPkg`](https://github.com/pnpm/pnpm/blob/3687b0e180/resolving/resolver-base/src/index.ts#L274-L275).
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct CurrentPkg {
+    pub name: String,
+    pub version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_dependencies: Option<BTreeMap<String, String>>,
+}
+
 /// Options the dispatcher hands a resolver per-resolve. Mirrors pnpm's
 /// [`ResolveOptions`](https://github.com/pnpm/pnpm/blob/3687b0e180/resolving/resolver-base/src/index.ts#L277-L302).
 #[derive(Debug, Default, Clone)]
 pub struct ResolveOptions {
     pub project_dir: PathBuf,
     pub lockfile_dir: PathBuf,
+    /// Previously-resolved lockfile entry. Mirrors upstream's `currentPkg` field.
+    pub current_pkg: Option<CurrentPkg>,
     /// Lockfile + manifest preferred-versions seed the npm picker biases
     /// toward (so pins that still satisfy their range survive a
     /// re-resolve). Held behind [`Arc`] because the tree walker clones

--- a/pacquet/crates/resolving-resolver-base/src/resolve.rs
+++ b/pacquet/crates/resolving-resolver-base/src/resolve.rs
@@ -193,13 +193,20 @@ pub enum UpdateBehavior {
 /// Previously-resolved entry from the lockfile, threaded so resolvers
 /// can short-circuit when the install is not requesting an update. Mirrors
 /// upstream's
-/// [`CurrentPkg`](https://github.com/pnpm/pnpm/blob/3687b0e180/resolving/resolver-base/src/index.ts#L274-L275).
-#[derive(Debug, Default, Clone, Serialize)]
+/// [`currentPkg`](https://github.com/pnpm/pnpm/blob/3687b0e180/resolving/resolver-base/src/index.ts#L303-L309)
+/// field of `ResolveOptions`; the serialized form is the `currentPkg`
+/// payload custom resolvers receive.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CurrentPkg {
-    pub name: String,
-    pub version: String,
+    pub id: PkgResolutionId,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub peer_dependencies: Option<BTreeMap<String, String>>,
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    pub resolution: LockfileResolution,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub published_at: Option<String>,
 }
 
 /// Options the dispatcher hands a resolver per-resolve. Mirrors pnpm's


### PR DESCRIPTION
Port pnpm's custom resolver hooks to the Rust pacquet engine: a pnpmfile can export a top-level `resolvers` array whose entries override built-in dependency resolution and force re-resolution when needed. See pnpm/pnpm#10389 for the TypeScript-side feature request that motivated this port.

## What's included

- **Hook contract** — `CustomResolver` trait (`canResolve` / `resolve` / `shouldRefreshResolution`) mirroring `hooks/types/src/index.ts`. All three methods are optional upstream, so the Node worker reports per-resolver capability flags in one IPC round trip and pacquet skips calls a resolver doesn't implement (mirrors pnpm's `if (!customResolver.canResolve || !customResolver.resolve) continue` and `checkCustomResolverForceResolve`'s hook filter).
- **Node IPC** — the long-lived pnpmfile worker gained `resolvers` (capabilities) and `resolver` (method invocation) requests. Methods are invoked with `this` bound to the resolver object, like pnpm. Pending-request cleanup is cancellation-safe via an RAII guard.
- **Adapter & chain integration** — `CustomResolverAdapter` bridges the JSON hook contract to the typed `Resolver` trait. Custom resolvers are built into the inner resolver chain ahead of the built-ins (upstream chain priority), inside the prefetching/observing wrappers so their tarball results get resolve-time prefetch and pnpr streaming. `canResolve` results are memoized keyed `alias@bareSpecifier`, exactly like pnpm's `getCustomResolverCacheKey`. A resolver-returned `manifest` passes through (pnpm spreads the whole hook result). Payloads match upstream: `prevSpecifier`, and resolve opts carry `lockfileDir` / `projectDir` / `preferredVersions` / `currentPkg`.
- **`shouldRefreshResolution` semantics** — port of `checkCustomResolverForceResolve`: the hook receives the merged packages+snapshots entry (pnpm's in-memory `PackageSnapshot`), checks run concurrently with first-true/first-error short-circuit, and a throwing hook aborts the install (`PNPMFILE_FAIL`). A `true` verdict defeats both up-to-date optimizations, as documented in the hook's contract:
  - the prefer-frozen dispatch consults the hook (pnpm: `forceResolutionFromHook` → `needsFullResolution` blocks `isFrozenInstallPossible`) and routes to the fresh-resolve path with lockfile reuse disabled (`UpdateReuseScope::None`);
  - the optimistic repeat-install fast path now ports the pnpmfile branch of `patchesOrHooksAreModified`: the workspace state records the loaded pnpmfile list, and an added/removed/edited pnpmfile invalidates the mtime check.
- **`CurrentPkg`** — added to `ResolveOptions`, matching upstream's `currentPkg` shape `{id, name?, version?, resolution, publishedAt?}` (camelCase).

## Tests

- Adapter unit tests: missing `id`/`resolution`, invalid shapes, `canResolve` memoization, payload shapes, manifest passthrough.
- `check_custom_resolver_force_resolve` unit tests: port of upstream's `checkCustomResolverForceResolve.ts` suite (capability filter, true/false/error propagation, merged snapshot payload).
- Node IPC integration tests against a real pnpmfile: capabilities, `this` binding, round trips, error propagation, cancellation cleanup.
- CLI e2e tests against the mock registry: custom resolver precedence over the npm resolver, `shouldRefreshResolution` re-resolving past an up-to-date lockfile, and a throwing hook failing the install.

## Known gaps / follow-ups

- `ResolveOptions.current_pkg` is never populated yet — pacquet's deps-resolver doesn't thread lockfile-reuse info into per-dependency resolve options the way pnpm's package-requester does, so resolvers currently receive `currentPkg: null`. The contract and serialization are in place for when that threading lands.
- Custom resolution shapes outside pacquet's typed `LockfileResolution` enum (e.g. `{type: 'custom:cdn', ...}`) are rejected with a clear error, whereas pnpm's structural typing passes them through. Supporting arbitrary resolution shapes in the typed lockfile is a separate effort.
- Custom **fetcher** hooks (`CustomFetcher`) are not part of this PR.

---
Description updated by an agent (Claude Code, claude-fable-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * pnpmfiles can provide custom resolvers that run before built-in resolvers and are prepended to the resolver chain.
  * Install now queries custom resolvers to decide when package resolutions must be refreshed.
  * Node-backed hooks can enumerate and invoke custom resolvers at runtime.
  * Resolver options can include information about prior resolutions to avoid unnecessary updates.

* **Bug Fixes / Reliability**
  * Errors from custom resolvers are surfaced during install, preventing silent failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
