### PR TITLE
chore: update lockfile, Node.js, pnpm, and pacquet versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "jest": "catalog:",
     "keyv": "catalog:",
     "lcov-result-merger": "catalog:",
+    "node": "catalog:",
     "rimraf": "catalog:",
     "shx": "catalog:",
     "typescript": "catalog:"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "jest": "catalog:",
     "keyv": "catalog:",
     "lcov-result-merger": "catalog:",
-    "node": "catalog:",
     "rimraf": "catalog:",
     "shx": "catalog:",
     "typescript": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -751,9 +751,6 @@ catalogs:
     nock:
       specifier: 13.3.4
       version: 13.3.4
-    node:
-      specifier: runtime:^26.3.0
-      version: 26.3.0
     normalize-newline:
       specifier: 5.0.0
       version: 5.0.0
@@ -1135,7 +1132,7 @@ importers:
         specifier: 'catalog:'
         version: 5.0.1
       node:
-        specifier: 'catalog:'
+        specifier: runtime:26.3.0
         version: runtime:26.3.0
       rimraf:
         specifier: 'catalog:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ importers:
   .:
     configDependencies:
       '@pnpm/pacquet':
-        specifier: 0.2.13
-        version: 0.2.13
+        specifier: 0.2.14
+        version: 0.2.14
     packageManagerDependencies:
       '@pnpm/exe':
         specifier: 11.5.1
@@ -18,33 +18,33 @@ importers:
 
 packages:
 
-  '@pacquet/darwin-arm64@0.2.13':
-    resolution: {integrity: sha512-ZxG1RmDEBq4uFSh76JCgCBMRR0vIXOi6PjU51I3gUZsu6DS418/sIzlzEJbhEpCI8wz4Oao8f8v60e0KJCLW9Q==}
+  '@pacquet/darwin-arm64@0.2.14':
+    resolution: {integrity: sha512-ItfGB23f9OrLInb0kWxmbbzeVG+lFaeDYlhHaPYceCOFKmhEK1L5obJshxH/nvduJeMAwOpiRvD4wjSUTNzBUw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pacquet/darwin-x64@0.2.13':
-    resolution: {integrity: sha512-cxjbLhH+KO4CkH3jMTLKiW8EDS737L3qSoDDKnQkvkXq0BXpibQnWS8iR5HpDNYECAIc0k8jBz+TW2TmoH2zAg==}
+  '@pacquet/darwin-x64@0.2.14':
+    resolution: {integrity: sha512-3qXyCn0KnN2ASVixXxayYPEf7BxBQEJpc/FGkegPpSYVfX1s2O1w/Fvlqd0/ht/ZvanTGFTxRu+FV+E3/f5h5g==}
     cpu: [x64]
     os: [darwin]
 
-  '@pacquet/linux-arm64@0.2.13':
-    resolution: {integrity: sha512-O+dsnlLd3i1sfjiXaZ9O0onGLK+oZq1Q63XXGz4+xWnEnMvHgniTqVVPcTp3r/TsQ/k1ugtsEOP0YD/IQ/CsBw==}
+  '@pacquet/linux-arm64@0.2.14':
+    resolution: {integrity: sha512-FccL0FiBnf5VPgUdvgzfcmikWGXp2M5b/OdV27tMpFEVASXe5HelDoYnxc8avMtn2nNYQfk38p2BR5C2sXXcRA==}
     cpu: [arm64]
     os: [linux]
 
-  '@pacquet/linux-x64@0.2.13':
-    resolution: {integrity: sha512-401FBexWX69Ct1Ukn6arA4ChXI0SOJS3GNQKgUegMN7/2ClfdRUD9JfcKgXmr3JXyVTQDVhzqrTPtNgq1qeZ4Q==}
+  '@pacquet/linux-x64@0.2.14':
+    resolution: {integrity: sha512-eyQ1iZZWJhtE7fSnMUEth1Om5eYkBxyh7yW8yBt1lqePwPf0yqCRkr8bzL8xCPZ5l21kI++YvvCJDIDbksCjJA==}
     cpu: [x64]
     os: [linux]
 
-  '@pacquet/win32-arm64@0.2.13':
-    resolution: {integrity: sha512-L7+ofB8oEVoP5b1xAqOuLmhProA7h8LBUXs7gIwhHyr5BRaFvKVKtQDJh2uWhpmakOvknHiSS8ykVIR/CnQDfw==}
+  '@pacquet/win32-arm64@0.2.14':
+    resolution: {integrity: sha512-gwvMR42hq+rUf5pDTy2F2WKmGge/RA6O+3yTB7IoqOqGiv7I7Hytz5PfHpUiuyVZsSVSKMUkzKKn+gG+mpmnuw==}
     cpu: [arm64]
     os: [win32]
 
-  '@pacquet/win32-x64@0.2.13':
-    resolution: {integrity: sha512-qsyoNg1dxSoIFAAVgS5/iZ855uBswDrDOOilpgVC/cK/+E03pLy2Ga4vOzmYWrevkOMclj9XYnrRTD8K1me7Pw==}
+  '@pacquet/win32-x64@0.2.14':
+    resolution: {integrity: sha512-I1qNGvba9oloOABRSpCXOt+vnYXH9yMA2omeqXzLhxltNPCQj46/sAc0eSx1VakLUCacTAKieozhm3Ympjm7LQ==}
     cpu: [x64]
     os: [win32]
 
@@ -79,8 +79,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/pacquet@0.2.13':
-    resolution: {integrity: sha512-8BG3Cy3uAXlh1ODHKNTEJE7ADBsF6CIdaOXZA9nvccrM2e3R+Jm1XJwRIckgoeyU766dCjRAKfW2JGeC/BaTAA==}
+  '@pnpm/pacquet@0.2.14':
+    resolution: {integrity: sha512-f4KcNbZbHAJy71iUI4p/SOcA7LGgcCRXx4h5SSMIi8CQIjpC1zSh3vpJcnuSsEMZB2jRJBSpF7J0YEy7hEEfHg==}
 
   '@pnpm/win-arm64@11.5.1':
     resolution: {integrity: sha512-FFKV7aMWx6o/2hd8GiSieVzVltXHjG1wtvEhoJfatsTfGri+UYI6DPlKn6Pg7tDwXEQB8V7vX+4ibjHBmW+fkg==}
@@ -159,22 +159,22 @@ packages:
 
 snapshots:
 
-  '@pacquet/darwin-arm64@0.2.13':
+  '@pacquet/darwin-arm64@0.2.14':
     optional: true
 
-  '@pacquet/darwin-x64@0.2.13':
+  '@pacquet/darwin-x64@0.2.14':
     optional: true
 
-  '@pacquet/linux-arm64@0.2.13':
+  '@pacquet/linux-arm64@0.2.14':
     optional: true
 
-  '@pacquet/linux-x64@0.2.13':
+  '@pacquet/linux-x64@0.2.14':
     optional: true
 
-  '@pacquet/win32-arm64@0.2.13':
+  '@pacquet/win32-arm64@0.2.14':
     optional: true
 
-  '@pacquet/win32-x64@0.2.13':
+  '@pacquet/win32-x64@0.2.14':
     optional: true
 
   '@pnpm/exe@11.5.1':
@@ -205,14 +205,14 @@ snapshots:
   '@pnpm/macos-arm64@11.5.1':
     optional: true
 
-  '@pnpm/pacquet@0.2.13':
+  '@pnpm/pacquet@0.2.14':
     optionalDependencies:
-      '@pacquet/darwin-arm64': 0.2.13
-      '@pacquet/darwin-x64': 0.2.13
-      '@pacquet/linux-arm64': 0.2.13
-      '@pacquet/linux-x64': 0.2.13
-      '@pacquet/win32-arm64': 0.2.13
-      '@pacquet/win32-x64': 0.2.13
+      '@pacquet/darwin-arm64': 0.2.14
+      '@pacquet/darwin-x64': 0.2.14
+      '@pacquet/linux-arm64': 0.2.14
+      '@pacquet/linux-x64': 0.2.14
+      '@pacquet/win32-arm64': 0.2.14
+      '@pacquet/win32-x64': 0.2.14
 
   '@pnpm/win-arm64@11.5.1':
     optional: true
@@ -751,6 +751,9 @@ catalogs:
     nock:
       specifier: 13.3.4
       version: 13.3.4
+    node:
+      specifier: runtime:^26.3.0
+      version: 26.3.0
     normalize-newline:
       specifier: 5.0.0
       version: 5.0.0
@@ -1132,7 +1135,7 @@ importers:
         specifier: 'catalog:'
         version: 5.0.1
       node:
-        specifier: runtime:26.3.0
+        specifier: 'catalog:'
         version: runtime:26.3.0
       rimraf:
         specifier: 'catalog:'
@@ -18152,7 +18155,7 @@ snapshots:
   '@jest/console@30.4.1':
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       chalk: 4.1.2
       jest-message-util: 30.4.1
       jest-util: 30.4.1
@@ -18166,7 +18169,7 @@ snapshots:
       '@jest/test-result': 30.4.1
       '@jest/transform': 30.4.1(@babel/types@7.29.7)
       '@jest/types': 30.4.1
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
@@ -18174,7 +18177,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
       jest-changed-files: 30.4.1
-      jest-config: 30.4.2(@babel/types@7.29.7)(@types/node@22.19.19)
+      jest-config: 30.4.2(@babel/types@7.29.7)(@types/node@25.9.1)
       jest-haste-map: 30.4.1
       jest-message-util: 30.4.1
       jest-regex-util: 30.4.0
@@ -18203,14 +18206,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       jest-mock: 30.3.0
 
   '@jest/environment@30.4.1':
     dependencies:
       '@jest/fake-timers': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       jest-mock: 30.4.1
 
   '@jest/expect-utils@30.3.0':
@@ -18239,7 +18242,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
       '@sinonjs/fake-timers': 15.4.0
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       jest-message-util: 30.3.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
@@ -18248,7 +18251,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.4.1
       '@sinonjs/fake-timers': 15.4.0
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       jest-message-util: 30.4.1
       jest-mock: 30.4.1
       jest-util: 30.4.1
@@ -18275,12 +18278,12 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       jest-regex-util: 30.0.1
 
   '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       jest-regex-util: 30.4.0
 
   '@jest/reporters@30.4.1(@babel/types@7.29.7)':
@@ -18291,7 +18294,7 @@ snapshots:
       '@jest/transform': 30.4.1(@babel/types@7.29.7)
       '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -18413,7 +18416,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -18423,7 +18426,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -19893,7 +19896,7 @@ snapshots:
 
   '@types/isexe@2.0.4':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -20029,7 +20032,7 @@ snapshots:
 
   '@types/touch@3.1.5':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
 
   '@types/treeify@1.0.3': {}
 
@@ -22609,7 +22612,7 @@ snapshots:
       '@jest/expect': 30.4.1
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -22682,6 +22685,38 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@30.4.2(@babel/types@7.29.7)(@types/node@25.9.1):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.4.0
+      '@jest/test-sequencer': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.4.1(@babel/core@7.29.7)(@babel/types@7.29.7)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 11.1.0
+      graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
+      jest-circus: 30.4.2(@babel/types@7.29.7)
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-runner: 30.4.2(@babel/types@7.29.7)
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      parse-json: 5.2.0
+      pretty-format: 30.4.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.9.1
+    transitivePeerDependencies:
+      - '@babel/types'
+      - babel-plugin-macros
+      - supports-color
+
   jest-diff@30.3.0:
     dependencies:
       '@jest/diff-sequences': 30.3.0
@@ -22713,7 +22748,7 @@ snapshots:
       '@jest/environment': 30.4.1
       '@jest/fake-timers': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       jest-mock: 30.4.1
       jest-util: 30.4.1
       jest-validate: 30.4.1
@@ -22739,7 +22774,7 @@ snapshots:
   jest-haste-map@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
@@ -22754,7 +22789,7 @@ snapshots:
   jest-haste-map@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
@@ -22813,13 +22848,13 @@ snapshots:
   jest-mock@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       jest-util: 30.3.0
 
   jest-mock@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       jest-util: 30.4.1
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -22873,7 +22908,7 @@ snapshots:
       '@jest/test-result': 30.4.1
       '@jest/transform': 30.4.1(@babel/types@7.29.7)
       '@jest/types': 30.4.1
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -22903,7 +22938,7 @@ snapshots:
       '@jest/test-result': 30.4.1
       '@jest/transform': 30.4.1(@babel/types@7.29.7)
       '@jest/types': 30.4.1
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -22986,7 +23021,7 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
@@ -22995,7 +23030,7 @@ snapshots:
   jest-util@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
@@ -23023,7 +23058,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -23039,7 +23074,7 @@ snapshots:
 
   jest-worker@30.3.0:
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       '@ungap/structured-clone': 1.3.1
       jest-util: 30.3.0
       merge-stream: 2.0.0
@@ -23047,7 +23082,7 @@ snapshots:
 
   jest-worker@30.4.1:
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       '@ungap/structured-clone': 1.3.1
       jest-util: 30.4.1
       merge-stream: 2.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -234,7 +234,6 @@ catalog:
   msgpackr: 1.11.8
   nm-prune: ^5.0.0
   nock: 13.3.4
-  node: runtime:^26.3.0
   normalize-newline: 5.0.0
   normalize-package-data: ^8.0.0
   normalize-path: ^3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -234,6 +234,7 @@ catalog:
   msgpackr: 1.11.8
   nm-prune: ^5.0.0
   nock: 13.3.4
+  node: runtime:^26.3.0
   normalize-newline: 5.0.0
   normalize-package-data: ^8.0.0
   normalize-path: ^3.0.0
@@ -327,7 +328,7 @@ catalogMode: strict
 cleanupUnusedCatalogs: true
 
 configDependencies:
-  '@pnpm/pacquet': 0.2.13
+  '@pnpm/pacquet': 0.2.14
 
 enableGlobalVirtualStore: true
 


### PR DESCRIPTION
This automated PR refreshes the project's pinned versions:

- Updates the lockfile to the latest compatible versions of dependencies.
- Bumps Node.js to the latest 26.x release, propagated into the CI, release, and benchmark workflows via the meta-updater.
- Bumps pnpm to the latest release (`packageManager` and `devEngines.packageManager`).
- Bumps the `@pnpm/pacquet` config dependency to its latest release.

Created by the update-lockfile workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package management tooling dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->