### PR TITLE
fix(deps-installer): keep catalog-referencing overrides in sync on update

### DIFF
--- a/.changeset/update-catalog-overrides-sync.md
+++ b/.changeset/update-catalog-overrides-sync.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+`pnpm update` now keeps lockfile `overrides` that resolve through a catalog in sync with the catalog. Previously, when an override referenced a catalog (e.g. `overrides: { foo: 'catalog:' }`) and `pnpm update` bumped that catalog entry, the lockfile's `catalogs` advanced while the resolved `overrides` kept the old version. The resulting lockfile was internally inconsistent, so a later `pnpm install --frozen-lockfile` failed with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.

--- a/installing/deps-installer/package.json
+++ b/installing/deps-installer/package.json
@@ -64,6 +64,7 @@
     "@pnpm/building.after-install": "workspace:*",
     "@pnpm/building.during-install": "workspace:*",
     "@pnpm/building.policy": "workspace:*",
+    "@pnpm/catalogs.config": "workspace:*",
     "@pnpm/catalogs.protocol-parser": "workspace:*",
     "@pnpm/catalogs.resolver": "workspace:*",
     "@pnpm/catalogs.types": "workspace:*",

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -4,9 +4,11 @@ import { linkBins, linkBinsOfPackages } from '@pnpm/bins.linker'
 import { buildSelectedPkgs } from '@pnpm/building.after-install'
 import { buildModules, type DepsStateCache, linkBinsOfDependencies } from '@pnpm/building.during-install'
 import { createAllowBuildFunction, isBuildExplicitlyDisallowed } from '@pnpm/building.policy'
+import { mergeCatalogs } from '@pnpm/catalogs.config'
 import { parseCatalogProtocol } from '@pnpm/catalogs.protocol-parser'
 import { type CatalogResultMatcher, matchCatalogResolveResult, resolveFromCatalog } from '@pnpm/catalogs.resolver'
 import type { Catalogs } from '@pnpm/catalogs.types'
+import { parseOverrides } from '@pnpm/config.parse-overrides'
 import {
   LAYOUT_VERSION,
   LOCKFILE_MAJOR_VERSION,
@@ -1659,6 +1661,18 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
 
   if (opts.updateLockfileMinorVersion) {
     newLockfile.lockfileVersion = LOCKFILE_VERSION
+  }
+
+  // `pnpm update` may bump catalog entries during resolution. Overrides that
+  // reference a catalog (e.g. `overrides: { foo: 'catalog:' }`) were resolved
+  // against the pre-update catalog when the install options were extended, so
+  // re-resolve them against the updated catalog. Otherwise lockfile `overrides`
+  // keeps pointing at the old version while `catalogs` advances, and a later
+  // `--frozen-lockfile` install fails with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+  if (updatedCatalogs != null && opts.overrides != null && Object.keys(opts.overrides).length > 0) {
+    newLockfile.overrides = createOverridesMapFromParsed(
+      parseOverrides(opts.overrides, mergeCatalogs(opts.catalogs ?? {}, updatedCatalogs))
+    )
   }
 
   const depsStateCache: DepsStateCache = {}

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -1655,24 +1655,26 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     stage: 'resolution_done',
   })
 
+  // `pnpm update` may bump catalog entries during resolution. Overrides that
+  // reference a catalog (e.g. `overrides: { foo: 'catalog:' }`) were resolved
+  // against the pre-update catalog when the install options were extended, so
+  // re-resolve them against the updated catalog. Done before `afterAllResolved`
+  // so that hook still sees (and can amend) the final overrides. Otherwise
+  // lockfile `overrides` keeps pointing at the old version while `catalogs`
+  // advances, and a later `--frozen-lockfile` install fails with
+  // ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+  if (updatedCatalogs != null && opts.overrides != null && Object.keys(opts.overrides).length > 0) {
+    newLockfile.overrides = createOverridesMapFromParsed(
+      parseOverrides(opts.overrides, mergeCatalogs(opts.catalogs, updatedCatalogs))
+    )
+  }
+
   newLockfile = ((opts.hooks?.afterAllResolved) != null)
     ? await pipeWith(async (f, res) => f(await res), opts.hooks.afterAllResolved as any)(newLockfile) as LockfileObject // eslint-disable-line
     : newLockfile
 
   if (opts.updateLockfileMinorVersion) {
     newLockfile.lockfileVersion = LOCKFILE_VERSION
-  }
-
-  // `pnpm update` may bump catalog entries during resolution. Overrides that
-  // reference a catalog (e.g. `overrides: { foo: 'catalog:' }`) were resolved
-  // against the pre-update catalog when the install options were extended, so
-  // re-resolve them against the updated catalog. Otherwise lockfile `overrides`
-  // keeps pointing at the old version while `catalogs` advances, and a later
-  // `--frozen-lockfile` install fails with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
-  if (updatedCatalogs != null && opts.overrides != null && Object.keys(opts.overrides).length > 0) {
-    newLockfile.overrides = createOverridesMapFromParsed(
-      parseOverrides(opts.overrides, mergeCatalogs(opts.catalogs ?? {}, updatedCatalogs))
-    )
   }
 
   const depsStateCache: DepsStateCache = {}

--- a/installing/deps-installer/test/catalogs.ts
+++ b/installing/deps-installer/test/catalogs.ts
@@ -1659,6 +1659,74 @@ describe('update', () => {
     expect(Object.keys(lockfile.snapshots)).toEqual(['@pnpm.e2e/foo@1.3.0'])
   })
 
+  test('overrides that reference a catalog are updated in the lockfile when the catalog is updated', async () => {
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:',
+      },
+    }])
+
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs: {
+        default: { '@pnpm.e2e/foo': '1.0.0' },
+      },
+      // An override that resolves through the catalog. A scoped selector is
+      // used so the override does not shadow the direct `catalog:` dependency
+      // above (an unscoped override would replace its specifier and drop it
+      // from the catalog). The resolved value recorded in lockfile "overrides"
+      // must track the catalog as the catalog is updated.
+      overrides: {
+        '@pnpm.e2e/foobar>@pnpm.e2e/foo': 'catalog:',
+      },
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Widen the catalog range so a later update can bump it, while 1.0.0 stays
+    // locked for now.
+    mutateOpts.catalogs.default['@pnpm.e2e/foo'] = '^1.0.0'
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    expect(readLockfile().catalogs.default).toEqual({
+      '@pnpm.e2e/foo': { specifier: '^1.0.0', version: '1.0.0' },
+    })
+    expect(readLockfile().overrides).toEqual({ '@pnpm.e2e/foobar>@pnpm.e2e/foo': '^1.0.0' })
+
+    const { updatedCatalogs } = await addDependenciesToPackage(
+      projects['project1' as ProjectId],
+      ['@pnpm.e2e/foo'],
+      {
+        ...mutateOpts,
+        dir: path.join(options.lockfileDir, 'project1'),
+        update: true,
+      })
+
+    expect(updatedCatalogs).toEqual({
+      default: { '@pnpm.e2e/foo': '^1.3.0' },
+    })
+
+    const lockfile = readLockfile()
+    expect(lockfile.catalogs).toEqual({
+      default: { '@pnpm.e2e/foo': { specifier: '^1.3.0', version: '1.3.0' } },
+    })
+
+    // The override referencing the catalog must be updated to match the new
+    // catalog. Otherwise lockfile "overrides" points at the old version while
+    // "catalogs" points at the new one, and a later frozen install fails with
+    // ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+    expect(lockfile.overrides).toEqual({ '@pnpm.e2e/foobar>@pnpm.e2e/foo': '^1.3.0' })
+
+    // The updated catalog is written back to pnpm-workspace.yaml, so a
+    // subsequent frozen install reads the bumped catalog. It must not fail.
+    mutateOpts.catalogs.default['@pnpm.e2e/foo'] = '^1.3.0'
+    await expect(
+      mutateModules(installProjects(projects), { ...mutateOpts, frozenLockfile: true })
+    ).resolves.toBeDefined()
+  })
+
   test('update works on named catalog', async () => {
     const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
       name: 'project1',

--- a/installing/deps-installer/tsconfig.json
+++ b/installing/deps-installer/tsconfig.json
@@ -40,6 +40,9 @@
       "path": "../../building/policy"
     },
     {
+      "path": "../../catalogs/config"
+    },
+    {
       "path": "../../catalogs/protocol-parser"
     },
     {

--- a/pacquet/crates/cli/tests/catalog.rs
+++ b/pacquet/crates/cli/tests/catalog.rs
@@ -68,6 +68,12 @@ fn catalog_snapshot(workspace: &Path, name: &str) -> (String, String) {
     (entry.specifier.clone(), entry.version.clone())
 }
 
+fn lockfile_override(workspace: &Path, selector: &str) -> Option<String> {
+    let lockfile: Lockfile =
+        serde_saphyr::from_str(&read(workspace, "pnpm-lock.yaml")).expect("parse pnpm-lock.yaml");
+    lockfile.overrides.as_ref().and_then(|overrides| overrides.get(selector).cloned())
+}
+
 fn run_ok(workspace: &Path, args: &[&str]) {
     let output = pacquet(workspace, args).output().expect("run pacquet");
     assert!(
@@ -209,6 +215,55 @@ fn update_latest_named_catalog_bumps_the_entry() {
         !lockfile.contains("specifier: 1.0.0"),
         "the lockfile catalog snapshot should have been bumped off 1.0.0:\n{lockfile}",
     );
+
+    drop((root, anchor));
+}
+
+/// `update --latest` bumping a catalog that an override resolves through
+/// must keep `pnpm-lock.yaml`'s `overrides` in sync with the bumped
+/// catalog. A scoped selector is used so the override does not shadow the
+/// direct `catalog:` dependency. If the override is not re-resolved against
+/// the bumped catalog, lockfile `overrides` lags `catalogs` and the
+/// follow-up `--frozen-lockfile` install fails with an overrides/catalogs
+/// mismatch. Ported from pnpm's "overrides that reference a catalog are
+/// updated in the lockfile when the catalog is updated".
+#[test]
+fn update_latest_keeps_catalog_referencing_override_in_sync() {
+    let (root, workspace, anchor) = setup();
+    write_manifest(&workspace, &format!(r#"{{ "{FOO}": "catalog:" }}"#));
+    let override_selector = format!("@pnpm.e2e/foobar>{FOO}");
+    append_workspace_yaml(
+        &workspace,
+        &format!(
+            "catalogMode: prefer\ncatalog:\n  '{FOO}': '^1.0.0'\noverrides:\n  '{override_selector}': 'catalog:'\n",
+        ),
+    );
+
+    run_ok(&workspace, &["install", "--lockfile-only"]);
+
+    // The override resolves through the catalog, so it records the catalog's
+    // specifier rather than a literal version.
+    let (initial_spec, _) = catalog_snapshot(&workspace, FOO);
+    assert_eq!(
+        lockfile_override(&workspace, &override_selector).as_deref(),
+        Some(initial_spec.as_str()),
+        "override should track the catalog specifier before the update",
+    );
+
+    run_ok(&workspace, &["update", "--latest", "--lockfile-only", FOO]);
+
+    let (bumped_spec, _) = catalog_snapshot(&workspace, FOO);
+    assert_ne!(bumped_spec, initial_spec, "update --latest should bump the catalog entry");
+    assert_eq!(
+        lockfile_override(&workspace, &override_selector).as_deref(),
+        Some(bumped_spec.as_str()),
+        "lockfile override must be re-resolved against the bumped catalog",
+    );
+
+    // The bumped catalog is written back to pnpm-workspace.yaml, so a
+    // follow-up frozen install reads it and must not fail with an
+    // overrides/catalogs mismatch.
+    run_ok(&workspace, &["install", "--frozen-lockfile"]);
 
     drop((root, anchor));
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5646,6 +5646,9 @@ importers:
       '@pnpm/building.policy':
         specifier: workspace:*
         version: link:../../building/policy
+      '@pnpm/catalogs.config':
+        specifier: workspace:*
+        version: link:../../catalogs/config
       '@pnpm/catalogs.protocol-parser':
         specifier: workspace:*
         version: link:../../catalogs/protocol-parser


### PR DESCRIPTION
## Summary

`pnpm update` can leave `pnpm.overrides` that reference a [catalog](https://pnpm.io/catalogs) stale in the lockfile. When an override uses `catalog:` (e.g. `overrides: { foo: 'catalog:' }`) and `pnpm update` bumps that catalog entry, the lockfile's `catalogs` section advances but the resolved `overrides` keep the old version, so the lockfile is internally inconsistent and a later `pnpm install --frozen-lockfile` fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. Re-running a non-frozen `pnpm install` reconciles it, which is why it currently "needs a second install".

## Reproduction

https://github.com/why-reproductions-are-required/pnpm-update-catalog-overrides

```sh
pnpm install --frozen-lockfile   # passes: lockfile is consistent
pnpm update --latest             # bumps the catalog: is-positive ^1.0.0 -> ^3.1.0
pnpm install --frozen-lockfile   # FAILS: ERR_PNPM_LOCKFILE_CONFIG_MISMATCH ("overrides")
```

Reproduces on pnpm 11.x (verified on 11.5.1).

## Root cause

`opts.parsedOverrides` is resolved once, against the pre-update catalog, when install options are extended (`extendInstallOptions.ts`). `pnpm update` then bumps the catalog during resolution (`updatedCatalogs`) and rewrites the lockfile's `catalogs` section, but the `overrides` map written to the lockfile is never re-resolved against the bumped catalog.

## Fix

After resolution, when `updatedCatalogs` is present and overrides are configured, re-resolve the overrides against the catalog merged with `updatedCatalogs` and write the result to `newLockfile.overrides` (before the `afterAllResolved` hook, so a pnpmfile hook can still amend them). This matches what a subsequent install computes (it reads the post-update catalog), so the lockfile is frozen-valid in one pass.

## Test

`installing/deps-installer/test/catalogs.ts` -> "overrides that reference a catalog are updated in the lockfile when the catalog is updated": a `catalog:` dependency plus a scoped override that resolves through the catalog; after an `update` that bumps the catalog, the lockfile `overrides` now track it and a follow-up frozen install passes. Fails before the fix, passes after.

## Known limitation (follow-up issue)

This fixes the lockfile **metadata** (`overrides`), which covers the common case where overrides reference a `catalog:` that is bumped (including overrides on direct `catalog:` dependencies that are themselves updated). It does **not** yet cover an **active override on a transitive dependency**: because the resolution `readPackageHook` is built from the pre-update `parsedOverrides` (and `updatedCatalogs` is only known after `resolveDependencies`), an override that forces a transitive dependency can still be applied with the old catalog value during resolution while the metadata records the new value, leaving the resolved graph out of sync. Fixing that requires re-resolving against the updated catalog. Tracked in #12159.

## pacquet parity

No pacquet change needed yet: pacquet has no lockfile `catalogs` section and no catalog-bump-on-`update` (`updatedCatalogs`), so the stale-overrides condition cannot arise. When pacquet ports catalog-updating-during-`update`, the override re-resolution must be ported alongside it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where lockfile `overrides` that reference catalogs could become unsynchronized after `pnpm update`, which could later cause `pnpm install --frozen-lockfile` to fail with a lockfile mismatch.
  - Catalog-backed overrides are now re-resolved when catalogs update, keeping lockfile `catalogs` and `overrides` aligned.

- **Tests**
  - Added regression coverage to verify catalog updates keep `overrides` synchronized and that subsequent `--frozen-lockfile` installs succeed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->