### PR TITLE
perf(pnpr): shrink the abbreviated packuments served to clients

### DIFF
--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -228,8 +228,10 @@ pub fn abbreviate_packument(packument: &Value) -> Value {
 ///   pnpr serves unstripped, so dropping it from the abbreviated form
 ///   is safe.
 /// * `shasum` — the legacy sha1 hash, redundant once `integrity` (SRI)
-///   is present. Kept when `integrity` is absent (pre-2017 publishes)
-///   so pnpm's `getIntegrity` fallback still has a hash.
+///   is present. "Present" mirrors pnpm's `getIntegrity` truthiness
+///   check (`if (dist.integrity)`): a non-empty string. An absent,
+///   empty, or non-string `integrity` keeps `shasum` so pnpm's
+///   sha1 fallback still has a hash (pre-2017 publishes).
 ///
 /// `dist.signatures` (the ECDSA registry signatures) is deliberately
 /// preserved: it binds `name@version:integrity` to the upstream
@@ -242,7 +244,8 @@ fn trim_dist_fields(version: &mut serde_json::Map<String, Value>) {
     dist.remove("npm-signature");
     dist.remove("fileCount");
     dist.remove("unpackedSize");
-    if dist.get("integrity").is_some_and(|integrity| !integrity.is_null()) {
+    if dist.get("integrity").and_then(Value::as_str).is_some_and(|integrity| !integrity.is_empty())
+    {
         dist.remove("shasum");
     }
 }

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -222,6 +222,11 @@ pub fn abbreviate_packument(packument: &Value) -> Value {
 /// * `npm-signature` — the legacy PGP detached signature. npm stopped
 ///   populating it years ago in favour of the ECDSA `signatures`, and
 ///   nothing in pnpm or pacquet reads it.
+/// * `fileCount` — read nowhere in pnpm or pacquet.
+/// * `unpackedSize` — only `pnpm view` reads it, and that command
+///   fetches the *full* metadata document (`fullMetadata: true`) which
+///   pnpr serves unstripped, so dropping it from the abbreviated form
+///   is safe.
 /// * `shasum` — the legacy sha1 hash, redundant once `integrity` (SRI)
 ///   is present. Kept when `integrity` is absent (pre-2017 publishes)
 ///   so pnpm's `getIntegrity` fallback still has a hash.
@@ -235,6 +240,8 @@ fn trim_dist_fields(version: &mut serde_json::Map<String, Value>) {
         return;
     };
     dist.remove("npm-signature");
+    dist.remove("fileCount");
+    dist.remove("unpackedSize");
     if dist.get("integrity").is_some_and(|integrity| !integrity.is_null()) {
         dist.remove("shasum");
     }

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -142,26 +142,27 @@ pub fn extract_version_manifest(
 }
 
 /// Top-level packument fields *copied verbatim* into the abbreviated
-/// (`application/vnd.npm.install-v1+json`) form. Mirrors verdaccio's
-/// `convertAbbreviatedManifest` (packages/store/src/storage.ts).
-/// `time` and `readme` go beyond the npm spec but verdaccio keeps
-/// them — `time` specifically for pnpm's `minimumReleaseAge` check.
+/// (`application/vnd.npm.install-v1+json`) form. `time` goes beyond
+/// the npm spec but the pnpm/pacquet resolvers read it for the
+/// `minimumReleaseAge` check, so it stays.
 ///
-/// Two fields aren't here because verdaccio synthesizes them rather
-/// than copying:
-///   * `modified`        — extracted from `time.modified` (real npm
-///     packuments don't have it at the top level)
-///   * `readmeFilename`  — always the empty string
-///
-/// pacquet reads `meta.modified` in its version-pick heuristics
-/// (`pick_package_from_meta.rs`) and as a freshness check
-/// (`pick_package.rs`); omitting it pushes the resolver onto a
-/// slower fallback path.
-const ABBREVIATED_TOP_FIELDS: &[&str] = &["name", "dist-tags", "time", "_id", "_rev", "readme"];
+/// `modified` isn't here because it's synthesized rather than copied:
+/// it's extracted from `time.modified` (real npm packuments nest it
+/// there). pacquet reads `meta.modified` in its version-pick
+/// heuristics (`pick_package_from_meta.rs`) and as a freshness check
+/// (`pick_package.rs`); omitting it pushes the resolver onto a slower
+/// fallback path.
+const ABBREVIATED_TOP_FIELDS: &[&str] = &["name", "dist-tags", "time"];
 
-/// Per-version fields preserved in the abbreviated form. Mirrors
-/// verdaccio's `convertAbbreviatedManifest` and the npm spec at
-/// <https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#abbreviated-version-object>.
+/// Per-version fields preserved in the abbreviated form — a subset of
+/// the npm spec's abbreviated version object
+/// (<https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#abbreviated-version-object>).
+/// Fields neither the pnpm nor the pacquet resolver reads are dropped
+/// to shrink the document: `funding`, `acceptDependencies`,
+/// `_hasShrinkwrap`, and `devDependencies` (a dependency's dev
+/// dependencies are never installed). `dist.shasum` is dropped
+/// per-version by [`drop_redundant_shasum`] when `dist.integrity` is
+/// present.
 const ABBREVIATED_VERSION_FIELDS: &[&str] = &[
     "name",
     "version",
@@ -169,18 +170,15 @@ const ABBREVIATED_VERSION_FIELDS: &[&str] = &[
     "bin",
     "dist",
     "engines",
-    "funding",
     "directories",
     "dependencies",
-    "devDependencies",
     "peerDependencies",
     "optionalDependencies",
     "bundleDependencies",
     "cpu",
     "os",
+    "libc",
     "peerDependenciesMeta",
-    "acceptDependencies",
-    "_hasShrinkwrap",
     "hasInstallScript",
 ];
 
@@ -197,13 +195,10 @@ pub fn abbreviate_packument(packument: &Value) -> Value {
         }
         // Synthesize `modified` from `time.modified` — npm packuments
         // store it nested and pacquet's resolver reads it at the top
-        // level. Matches verdaccio's `modified: manifest.time.modified`.
+        // level.
         if let Some(time_modified) = obj.get("time").and_then(|time| time.get("modified")) {
             out.insert("modified".to_string(), time_modified.clone());
         }
-        // verdaccio hardcodes `readmeFilename: ''`. Match it for
-        // wire-shape parity with clients that key on its presence.
-        out.insert("readmeFilename".to_string(), Value::String(String::new()));
         if let Some(versions) = obj.get("versions").and_then(Value::as_object) {
             let mut abbreviated_versions = serde_json::Map::with_capacity(versions.len());
             for (version_id, version_value) in versions {
@@ -214,12 +209,25 @@ pub fn abbreviate_packument(packument: &Value) -> Value {
                         trimmed.insert(field.to_string(), value.clone());
                     }
                 }
+                drop_redundant_shasum(&mut trimmed);
                 abbreviated_versions.insert(version_id.clone(), Value::Object(trimmed));
             }
             out.insert("versions".to_string(), Value::Object(abbreviated_versions));
         }
     }
     Value::Object(out)
+}
+
+/// Drop the legacy `dist.shasum` (sha1) when `dist.integrity` (SRI) is
+/// present. The pnpm and pacquet resolvers prefer `integrity` and only
+/// fall back to `shasum` when `integrity` is absent (pre-2017
+/// publishes), so shipping both is a redundant hash on every version.
+fn drop_redundant_shasum(version: &mut serde_json::Map<String, Value>) {
+    if let Some(dist) = version.get_mut("dist").and_then(Value::as_object_mut)
+        && dist.get("integrity").is_some_and(|integrity| !integrity.is_null())
+    {
+        dist.remove("shasum");
+    }
 }
 
 #[cfg(test)]

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -160,9 +160,8 @@ const ABBREVIATED_TOP_FIELDS: &[&str] = &["name", "dist-tags", "time"];
 /// Fields neither the pnpm nor the pacquet resolver reads are dropped
 /// to shrink the document: `funding`, `acceptDependencies`,
 /// `_hasShrinkwrap`, and `devDependencies` (a dependency's dev
-/// dependencies are never installed). `dist.shasum` is dropped
-/// per-version by [`drop_redundant_shasum`] when `dist.integrity` is
-/// present.
+/// dependencies are never installed). Redundant `dist` subfields are
+/// trimmed per-version by [`trim_dist_fields`].
 const ABBREVIATED_VERSION_FIELDS: &[&str] = &[
     "name",
     "version",
@@ -209,7 +208,7 @@ pub fn abbreviate_packument(packument: &Value) -> Value {
                         trimmed.insert(field.to_string(), value.clone());
                     }
                 }
-                drop_redundant_shasum(&mut trimmed);
+                trim_dist_fields(&mut trimmed);
                 abbreviated_versions.insert(version_id.clone(), Value::Object(trimmed));
             }
             out.insert("versions".to_string(), Value::Object(abbreviated_versions));
@@ -218,14 +217,25 @@ pub fn abbreviate_packument(packument: &Value) -> Value {
     Value::Object(out)
 }
 
-/// Drop the legacy `dist.shasum` (sha1) when `dist.integrity` (SRI) is
-/// present. The pnpm and pacquet resolvers prefer `integrity` and only
-/// fall back to `shasum` when `integrity` is absent (pre-2017
-/// publishes), so shipping both is a redundant hash on every version.
-fn drop_redundant_shasum(version: &mut serde_json::Map<String, Value>) {
-    if let Some(dist) = version.get_mut("dist").and_then(Value::as_object_mut)
-        && dist.get("integrity").is_some_and(|integrity| !integrity.is_null())
-    {
+/// Trim `dist` subfields the resolver and installer never read:
+///
+/// * `npm-signature` — the legacy PGP detached signature. npm stopped
+///   populating it years ago in favour of the ECDSA `signatures`, and
+///   nothing in pnpm or pacquet reads it.
+/// * `shasum` — the legacy sha1 hash, redundant once `integrity` (SRI)
+///   is present. Kept when `integrity` is absent (pre-2017 publishes)
+///   so pnpm's `getIntegrity` fallback still has a hash.
+///
+/// `dist.signatures` (the ECDSA registry signatures) is deliberately
+/// preserved: it binds `name@version:integrity` to the upstream
+/// registry's key and is the input to a potential client-side
+/// install-time verification on the pnpr path.
+fn trim_dist_fields(version: &mut serde_json::Map<String, Value>) {
+    let Some(dist) = version.get_mut("dist").and_then(Value::as_object_mut) else {
+        return;
+    };
+    dist.remove("npm-signature");
+    if dist.get("integrity").is_some_and(|integrity| !integrity.is_null()) {
         dist.remove("shasum");
     }
 }

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -126,6 +126,8 @@ fn abbreviation_drops_fields_the_resolver_ignores() {
                     "tarball": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
                     "integrity": "sha512-abc",
                     "shasum": "deadbeef",
+                    "fileCount": 12,
+                    "unpackedSize": 34567,
                     "signatures": [{ "keyid": "SHA256:xyz", "sig": "base64sig" }],
                     "npm-signature": "-----BEGIN PGP SIGNATURE-----"
                 }
@@ -162,8 +164,11 @@ fn abbreviation_drops_fields_the_resolver_ignores() {
     // `shasum` dropped because `integrity` is present.
     assert_eq!(version["dist"]["integrity"], "sha512-abc");
     assert!(version["dist"].get("shasum").is_none());
-    // Legacy PGP signature dropped; ECDSA registry signatures kept.
+    // Legacy PGP signature and unused size fields dropped; ECDSA
+    // registry signatures kept.
     assert!(version["dist"].get("npm-signature").is_none());
+    assert!(version["dist"].get("fileCount").is_none());
+    assert!(version["dist"].get("unpackedSize").is_none());
     assert_eq!(version["dist"]["signatures"][0]["keyid"], "SHA256:xyz");
 }
 

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -125,7 +125,9 @@ fn abbreviation_drops_fields_the_resolver_ignores() {
                 "dist": {
                     "tarball": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
                     "integrity": "sha512-abc",
-                    "shasum": "deadbeef"
+                    "shasum": "deadbeef",
+                    "signatures": [{ "keyid": "SHA256:xyz", "sig": "base64sig" }],
+                    "npm-signature": "-----BEGIN PGP SIGNATURE-----"
                 }
             }
         }
@@ -160,6 +162,9 @@ fn abbreviation_drops_fields_the_resolver_ignores() {
     // `shasum` dropped because `integrity` is present.
     assert_eq!(version["dist"]["integrity"], "sha512-abc");
     assert!(version["dist"].get("shasum").is_none());
+    // Legacy PGP signature dropped; ECDSA registry signatures kept.
+    assert!(version["dist"].get("npm-signature").is_none());
+    assert_eq!(version["dist"]["signatures"][0]["keyid"], "SHA256:xyz");
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -1,4 +1,4 @@
-use super::{extract_version_manifest, rewrite_tarball_urls};
+use super::{abbreviate_packument, extract_version_manifest, rewrite_tarball_urls};
 use crate::package_name::PackageName;
 use serde_json::json;
 
@@ -97,4 +97,90 @@ fn extract_returns_none_for_unknown_version() {
     let name = PackageName::parse("foo").unwrap();
     assert!(extract_version_manifest(&doc, &name, "9.9.9", "http://reg").is_none());
     assert!(extract_version_manifest(&doc, &name, "latest", "http://reg").is_none());
+}
+
+#[test]
+fn abbreviation_drops_fields_the_resolver_ignores() {
+    let doc = json!({
+        "name": "foo",
+        "dist-tags": { "latest": "1.0.0" },
+        "time": { "modified": "2020-01-01T00:00:00.000Z", "1.0.0": "2019-01-01T00:00:00.000Z" },
+        "_id": "foo",
+        "_rev": "1-abc",
+        "readme": "# foo\nlots of prose",
+        "versions": {
+            "1.0.0": {
+                "name": "foo",
+                "version": "1.0.0",
+                "dependencies": { "bar": "^1.0.0" },
+                "devDependencies": { "jest": "^29.0.0" },
+                "peerDependencies": { "react": "*" },
+                "os": ["linux"],
+                "cpu": ["x64"],
+                "libc": ["glibc"],
+                "funding": { "url": "https://example.com" },
+                "acceptDependencies": { "bar": "^1.0.0" },
+                "_hasShrinkwrap": false,
+                "hasInstallScript": true,
+                "dist": {
+                    "tarball": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
+                    "integrity": "sha512-abc",
+                    "shasum": "deadbeef"
+                }
+            }
+        }
+    });
+
+    let out = abbreviate_packument(&doc);
+
+    // Top-level: prose and registry bookkeeping gone, `modified`
+    // synthesized from `time.modified`, `time` retained.
+    assert!(out.get("readme").is_none());
+    assert!(out.get("readmeFilename").is_none());
+    assert!(out.get("_id").is_none());
+    assert!(out.get("_rev").is_none());
+    assert_eq!(out["modified"], "2020-01-01T00:00:00.000Z");
+    assert!(out.get("time").is_some());
+
+    let version = &out["versions"]["1.0.0"];
+    // Resolver-relevant fields kept.
+    assert_eq!(version["name"], "foo");
+    assert_eq!(version["dependencies"]["bar"], "^1.0.0");
+    assert_eq!(version["peerDependencies"]["react"], "*");
+    assert_eq!(version["hasInstallScript"], true);
+    // Platform-filtering fields kept for optional-dep selection (#9950).
+    assert_eq!(version["os"][0], "linux");
+    assert_eq!(version["cpu"][0], "x64");
+    assert_eq!(version["libc"][0], "glibc");
+    // Ignored fields dropped.
+    assert!(version.get("devDependencies").is_none());
+    assert!(version.get("funding").is_none());
+    assert!(version.get("acceptDependencies").is_none());
+    assert!(version.get("_hasShrinkwrap").is_none());
+    // `shasum` dropped because `integrity` is present.
+    assert_eq!(version["dist"]["integrity"], "sha512-abc");
+    assert!(version["dist"].get("shasum").is_none());
+}
+
+#[test]
+fn abbreviation_keeps_shasum_when_integrity_absent() {
+    let doc = json!({
+        "name": "legacy",
+        "versions": {
+            "0.0.1": {
+                "name": "legacy",
+                "version": "0.0.1",
+                "dist": {
+                    "tarball": "https://registry.npmjs.org/legacy/-/legacy-0.0.1.tgz",
+                    "shasum": "deadbeef"
+                }
+            }
+        }
+    });
+
+    let out = abbreviate_packument(&doc);
+
+    let dist = &out["versions"]["0.0.1"]["dist"];
+    assert!(dist.get("integrity").is_none());
+    assert_eq!(dist["shasum"], "deadbeef");
 }

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -194,3 +194,28 @@ fn abbreviation_keeps_shasum_when_integrity_absent() {
     assert!(dist.get("integrity").is_none());
     assert_eq!(dist["shasum"], "deadbeef");
 }
+
+#[test]
+fn abbreviation_keeps_shasum_when_integrity_is_empty_or_non_string() {
+    // pnpm's `getIntegrity` falls back to `shasum` unless `integrity`
+    // is a truthy (non-empty) string, so an empty or malformed
+    // `integrity` must not strip the sha1 fallback.
+    let doc = json!({
+        "name": "weird",
+        "versions": {
+            "1.0.0": {
+                "version": "1.0.0",
+                "dist": { "tarball": "x/weird-1.0.0.tgz", "integrity": "", "shasum": "deadbeef" }
+            },
+            "2.0.0": {
+                "version": "2.0.0",
+                "dist": { "tarball": "x/weird-2.0.0.tgz", "integrity": false, "shasum": "cafe" }
+            }
+        }
+    });
+
+    let out = abbreviate_packument(&doc);
+
+    assert_eq!(out["versions"]["1.0.0"]["dist"]["shasum"], "deadbeef");
+    assert_eq!(out["versions"]["2.0.0"]["dist"]["shasum"], "cafe");
+}

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -148,7 +148,7 @@ fn abbreviation_drops_fields_the_resolver_ignores() {
     assert_eq!(version["dependencies"]["bar"], "^1.0.0");
     assert_eq!(version["peerDependencies"]["react"], "*");
     assert_eq!(version["hasInstallScript"], true);
-    // Platform-filtering fields kept for optional-dep selection (#9950).
+    // Platform-filtering fields kept for optional-dep selection (`#9950`).
     assert_eq!(version["os"][0], "linux");
     assert_eq!(version["cpu"][0], "x64");
     assert_eq!(version["libc"][0], "glibc");

--- a/pnpr/crates/pnpr/tests/registry_mock.rs
+++ b/pnpr/crates/pnpr/tests/registry_mock.rs
@@ -138,12 +138,15 @@ async fn abbreviated_accept_header_strips_packument() {
     // `_uplinks`, `_distfiles` that the abbreviated form must drop.
     assert_eq!(doc["name"], "@foo/no-deps");
     assert_eq!(doc["dist-tags"]["latest"], "1.0.0");
-    // verdaccio always synthesizes these two; pacquet's resolver
-    // reads `meta.modified` for version-pick freshness checks
-    // (`pick_package_from_meta.rs`), so dropping them quietly
-    // would slow the install on a real npm packument.
+    // `modified` is synthesized from `time.modified`; pacquet's
+    // resolver reads `meta.modified` for version-pick freshness checks
+    // (`pick_package_from_meta.rs`), so dropping it quietly would slow
+    // the install on a real npm packument.
     assert_eq!(doc["modified"], doc["time"]["modified"]);
-    assert_eq!(doc["readmeFilename"], "");
+    // README prose is never read during resolution and is the
+    // dominant per-packument bloat — the abbreviated form drops it.
+    assert!(doc.get("readme").is_none(), "abbreviated form should drop readme");
+    assert!(doc.get("readmeFilename").is_none(), "abbreviated form should drop readmeFilename");
     assert!(doc.get("_attachments").is_none(), "abbreviated form should drop _attachments");
     assert!(doc.get("_uplinks").is_none(), "abbreviated form should drop _uplinks");
     assert!(doc.get("_distfiles").is_none(), "abbreviated form should drop _distfiles");


### PR DESCRIPTION
## What

When pnpr proxies a registry, trim the `application/vnd.npm.install-v1+json` packument down to only the fields the pnpm and pacquet resolvers actually read, so clients download, parse, and cache less metadata.

Only the abbreviated path (`Accept: application/vnd.npm.install-v1+json`) is affected; full-document clients are untouched.

### Dropped (never read during resolution)

- **top-level:** `readme`, `readmeFilename`, `_id`, `_rev` — `readme` is the dominant per-packument bloat (full README text) and npm's own abbreviated format never carried it.
- **per-version:** `funding`, `devDependencies`, `acceptDependencies`, `_hasShrinkwrap`. A dependency's `devDependencies` are never installed, so the resolver has no use for them.
- **per-version `dist["npm-signature"]`** — npm's deprecated PGP detached signature. npm stopped populating it years ago and nothing in pnpm or pacquet reads it.
- **per-version `dist.fileCount`** — read nowhere in pnpm or pacquet.
- **per-version `dist.unpackedSize`** — read only by `pnpm view`, which fetches the full metadata document (`fullMetadata: true`) that pnpr serves unstripped.
- **per-version `dist.shasum` when `dist.integrity` is present.** Both pnpm (`getIntegrity`) and pacquet prefer SRI `integrity` and only fall back to the legacy sha1 `shasum` when `integrity` is absent, so shipping both is a redundant hash on every version. `shasum` is **kept** when `integrity` is absent (pre-2017 publishes) so the `getIntegrity` fallback still has a hash.

### Deliberately kept

- **`time`** (top-level publish timestamps). npm's own abbreviated form omits it, but pnpr retains it because pnpm/pacquet read it for the `minimumReleaseAge` check.
- **`dist.signatures`** (ECDSA registry signatures). It binds `name@version:integrity` to the upstream registry's signing key and survives pnpr's `dist.tarball` rewriting (the signature covers the triple, not the URL). Nothing verifies it at install time today — `pnpm audit signatures` fetches its own *full* metadata — but keeping it leaves the door open to an optional client-side install-time registry-signature check, which is most valuable precisely on the pnpr path (an extra trust hop).
- **`dist.attestations`** — read by pacquet's `trustPolicy` verifier.

### Fixed along the way

Per-version **`libc`** is now forwarded alongside `os`/`cpu` — it was previously stripped. pnpm reads `libc` for optional-dependency platform filtering ([#9950](https://github.com/pnpm/pnpm/issues/9950)), so omitting it produced wrong installs through pnpr.

## Impact (measured)

Compact JSON size of the abbreviated packument, before vs. after this PR, on real registry metadata:

| Package | Versions | Before | After | Reduction |
|---|---:|---:|---:|---:|
| typescript | 3760 | 8379 KB | 1985 KB | **76%** |
| webpack | 875 | 1974 KB | 824 KB | **58%** |
| @types/node | 2336 | 2249 KB | 995 KB | **55%** |
| chalk | 43 | 46 KB | 21 KB | **53%** |
| react | 2817 | 2735 KB | 1509 KB | **44%** |
| express | 288 | 331 KB | 240 KB | **27%** |
| lodash | 117 | 67 KB | 49 KB | **26%** |
| **aggregate** | | **15.4 MB** | **5.5 MB** | **64%** |

Where the savings come from (react, % of the before size):

| Field dropped | Share |
|---|---:|
| `dist["npm-signature"]` | 36.0% |
| `dist.shasum` (integrity present) | 5.2% |
| `dist.unpackedSize` | 2.1% |
| `dist.fileCount` | 1.4% |
| `funding` / `devDependencies` / etc. | <0.1% |

`dist["npm-signature"]` dominates. (`dist.signatures`, kept, is a further ~18% that this PR intentionally leaves in place.)

**Methodology note:** the table simulates the per-version and `dist` trims against npm's *already-abbreviated* metadata, which does not contain top-level `readme`/`_id`/`_rev`. pnpr fetches the *full* upstream document and abbreviates it, so the real reduction is at least the figures above **plus** the full README text that is additionally dropped at the top level.

The win lands on the proxy/registry path (where the client still resolves locally); it does not affect the `/v1/install` accelerator path, where the client never receives a packument.

## Follow-up

Dropping `dist.tarball` (a further ~8% on react) is tracked separately in [#12164](https://github.com/pnpm/pnpm/issues/12164) — it first needs pnpm and pacquet to reconstruct the URL when it is absent.

## Safety

- Verified against the pnpm TS resolver: none of the dropped fields are read during resolution; `getIntegrity` returns `integrity` outright when present; `dist.signatures` / `npm-signature` / `unpackedSize` are consumed only by commands (`audit signatures`, `view`) that fetch their own full metadata, which pnpr serves unstripped.
- pacquet's `PackageVersion` has `#[serde(default)]` on `dev_dependencies` and ignores `shasum` / signature / size fields, so a pacquet-as-client deserialization stays valid.

## Tests

- New unit tests in `upstream/tests.rs`: one asserts every dropped field is gone (incl. `npm-signature`, `fileCount`, `unpackedSize`, and `shasum`-when-`integrity`-present) while `os`/`cpu`/`libc`, `time`, and `dist.signatures` survive; another asserts `shasum` is kept when `integrity` is absent.
- Updated `registry_mock.rs` to assert `readme`/`readmeFilename` are dropped.
- All pnpr lib + integration tests pass; clippy and dylint clean.

No changeset (pnpr is a Rust binary, not a published npm package).

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized package manifest format to reduce size by removing unnecessary internal fields and streamlining distribution metadata.

* **Tests**
  * Added comprehensive test coverage for manifest optimization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->