### PR TITLE
ci(pnpr): benchmark the install accelerator under injected network latency

### DIFF
--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -80,6 +80,20 @@ jobs:
       # the realistic CI case. Running both tools in one hyperfine
       # invocation also yields the pnpr-vs-direct ratio per scenario.
       BENCHMARK_TARGETS: ${{ github.ref_name == 'main' && 'pacquet@HEAD pnpr@HEAD' || 'pacquet@HEAD pacquet@main pnpr@HEAD pnpr@main' }}
+      # Round-trip latency (ms) injected so both install strategies cross
+      # the same network they would in production: between the client and
+      # each `pnpr@<rev>` server (`PNPR_LATENCY_MS`), and between the
+      # direct (`pacquet@<rev>`) client and the registry
+      # (`REGISTRY_LATENCY_MS`). Equal values make the pnpr-vs-direct ratio
+      # fair — pnpr's win then comes from fewer round trips, not a faster
+      # link. `pnpr@<rev>` targets keep a direct (fast) registry link,
+      # modeling a warm, colocated server. The `pnpr` Bencher testbed
+      # (pnpr@HEAD vs pnpr@main) is thus sensitive to protocol
+      # round-trip-count changes. Lower `REGISTRY_LATENCY_MS` if the
+      # cold-store scenarios' direct refetch waterfall strains the
+      # per-step timeouts.
+      PNPR_LATENCY_MS: 50
+      REGISTRY_LATENCY_MS: 50
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -201,7 +215,7 @@ jobs:
         # warm server), and a failure surfaces fast enough to iterate on.
         timeout-minutes: 15
         run: |
-          just integrated-benchmark --scenario=isolated-linker.fresh-restore.cold-cache.cold-store --registry=verdaccio $BENCHMARK_TARGETS
+          just integrated-benchmark --scenario=isolated-linker.fresh-restore.cold-cache.cold-store --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} $BENCHMARK_TARGETS
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE.json
 
@@ -214,7 +228,7 @@ jobs:
         # server, as in every scenario).
         timeout-minutes: 15
         run: |
-          just integrated-benchmark --scenario=isolated-linker.fresh-restore.hot-cache.hot-store --registry=verdaccio $BENCHMARK_TARGETS
+          just integrated-benchmark --scenario=isolated-linker.fresh-restore.hot-cache.hot-store --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} $BENCHMARK_TARGETS
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE.json
 
@@ -228,7 +242,7 @@ jobs:
         # safety net the other steps document.
         timeout-minutes: 35
         run: |
-          just integrated-benchmark --scenario=isolated-linker.fresh-install.cold-cache.cold-store --registry=verdaccio $BENCHMARK_TARGETS
+          just integrated-benchmark --scenario=isolated-linker.fresh-install.cold-cache.cold-store --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} $BENCHMARK_TARGETS
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE.json
 
@@ -239,7 +253,7 @@ jobs:
         # ample headroom across all four commands.
         timeout-minutes: 25
         run: |
-          just integrated-benchmark --scenario=isolated-linker.fresh-install.hot-cache.hot-store --registry=verdaccio $BENCHMARK_TARGETS
+          just integrated-benchmark --scenario=isolated-linker.fresh-install.hot-cache.hot-store --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} $BENCHMARK_TARGETS
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE.json
 

--- a/pacquet/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pacquet/tasks/integrated-benchmark/src/cli_args.rs
@@ -41,6 +41,26 @@ pub struct CliArgs {
     #[clap(long)]
     pub with_pnpm: bool,
 
+    /// Round-trip latency, in milliseconds, to inject between the pacquet
+    /// client and the pnpr server, so `pnpr@<rev>` targets are measured
+    /// as the remote service pnpr is in production rather than a loopback
+    /// peer. Applied as half the value in each direction. `0` disables
+    /// injection; non-pnpr targets are unaffected.
+    #[clap(long, default_value_t = 0)]
+    pub pnpr_latency_ms: u64,
+
+    /// Round-trip latency, in milliseconds, to inject between the client
+    /// and the *registry* for the direct (`pacquet@<rev>` / `pnpm@<rev>` /
+    /// `--with-pnpm`) targets, so a direct install crosses the same
+    /// network a pnpr install does. Set this equal to `--pnpr-latency-ms`
+    /// for a fair pnpr-vs-direct comparison. `pnpr@<rev>` targets keep a
+    /// direct (fast) registry link — that models a warm, colocated server,
+    /// so pnpr's advantage shows up as fewer round trips rather than a
+    /// faster backend. `0` disables injection; ignored with
+    /// `--registry=npm` (already remote).
+    #[clap(long, default_value_t = 0)]
+    pub registry_latency_ms: u64,
+
     /// Build each target without running the benchmark.
     #[clap(long)]
     pub build_only: bool,

--- a/pacquet/tasks/integrated-benchmark/src/latency_proxy.rs
+++ b/pacquet/tasks/integrated-benchmark/src/latency_proxy.rs
@@ -1,0 +1,148 @@
+//! A latency-injecting TCP proxy, used to front a pnpr server so the
+//! benchmark measures it as the *remote* service it is in production
+//! rather than a loopback peer.
+//!
+//! pnpr's round-trip cost is invisible on localhost (RTT ≈ 0), which is
+//! exactly the cost that matters once the server is across a network. The
+//! proxy reintroduces it: a chunk read at time `t` is forwarded no
+//! earlier than `t + one_way_delay`, in each direction independently. A
+//! request → response exchange therefore pays the delay twice — one full
+//! round trip — while a single large transfer pays it once at the front
+//! and then streams, matching how TCP behaves over a link with latency.
+//!
+//! It is deliberately dependency-free (std threads + blocking sockets):
+//! the integrated-benchmark orchestrator drives everything synchronously,
+//! so a thread-per-direction proxy slots in without dragging an async
+//! runtime into the benchmark path.
+
+use std::{
+    io::{Read as _, Write as _},
+    net::{Shutdown, SocketAddr, TcpListener, TcpStream},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
+    thread::{self, JoinHandle},
+    time::{Duration, Instant},
+};
+
+/// A running proxy. Drop stops accepting new connections and joins the
+/// accept thread; the benchmark holds it alongside the pnpr server guard
+/// for the life of the run.
+pub struct LatencyProxy {
+    pub addr: SocketAddr,
+    stop: Arc<AtomicBool>,
+    accept_thread: Option<JoinHandle<()>>,
+}
+
+impl LatencyProxy {
+    /// Front `upstream` with a proxy that delays each direction by
+    /// `one_way_delay`. Returns the local address callers should connect
+    /// to instead of `upstream`.
+    pub fn spawn(upstream: SocketAddr, one_way_delay: Duration) -> std::io::Result<LatencyProxy> {
+        let listener = TcpListener::bind(("127.0.0.1", 0))?;
+        let addr = listener.local_addr()?;
+        listener.set_nonblocking(true)?;
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let accept_stop = Arc::clone(&stop);
+        let accept_thread =
+            thread::spawn(move || accept_loop(&listener, upstream, one_way_delay, &accept_stop));
+
+        Ok(LatencyProxy { addr, stop, accept_thread: Some(accept_thread) })
+    }
+}
+
+impl Drop for LatencyProxy {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.accept_thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn accept_loop(
+    listener: &TcpListener,
+    upstream: SocketAddr,
+    one_way_delay: Duration,
+    stop: &AtomicBool,
+) {
+    while !stop.load(Ordering::SeqCst) {
+        match listener.accept() {
+            Ok((inbound, _)) => {
+                thread::spawn(move || handle_connection(inbound, upstream, one_way_delay));
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(5));
+            }
+            // A real accept error (listener closed) ends the proxy; the
+            // benchmark is the only client and is already tearing down.
+            Err(_) => break,
+        }
+    }
+}
+
+/// Bridge one accepted connection to `upstream`, delaying both
+/// directions. Runs the server→client pump on this thread and the
+/// client→server pump on a spawned one, so the connection's threads end
+/// together when either side closes.
+fn handle_connection(inbound: TcpStream, upstream: SocketAddr, one_way_delay: Duration) {
+    let Ok(outbound) = TcpStream::connect(upstream) else { return };
+    let _ = inbound.set_nodelay(true);
+    let _ = outbound.set_nodelay(true);
+
+    let (Ok(client_read), Ok(server_write)) = (inbound.try_clone(), outbound.try_clone()) else {
+        return;
+    };
+
+    let up = thread::spawn(move || pump(client_read, server_write, one_way_delay));
+    pump(outbound, inbound, one_way_delay);
+    let _ = up.join();
+}
+
+/// Copy `src` → `dst`, holding each chunk back until `one_way_delay` has
+/// elapsed since it was read. A reader thread stamps and queues chunks so
+/// the source is never blocked by the delay — back-to-back chunks all
+/// shift by the same delay and then stream out, rather than each paying
+/// it serially.
+fn pump(mut src: TcpStream, mut dst: TcpStream, one_way_delay: Duration) {
+    let (tx, rx) = mpsc::channel::<(Instant, Vec<u8>)>();
+
+    let reader = thread::spawn(move || {
+        let mut buf = vec![0u8; 32 * 1024];
+        loop {
+            match src.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    let release = Instant::now() + one_way_delay;
+                    if tx.send((release, buf[..n].to_vec())).is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    while let Ok((release, bytes)) = rx.recv() {
+        let now = Instant::now();
+        if release > now {
+            thread::sleep(release - now);
+        }
+        if dst.write_all(&bytes).is_err() {
+            break;
+        }
+    }
+
+    // Drop the receiver before joining so that if we broke out early (a
+    // write error), the reader's next `tx.send` fails and it stops
+    // promptly, rather than buffering the rest of the source into a queue
+    // no one drains while `join` blocks.
+    drop(rx);
+    let _ = dst.shutdown(Shutdown::Write);
+    let _ = reader.join();
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/tasks/integrated-benchmark/src/latency_proxy/tests.rs
+++ b/pacquet/tasks/integrated-benchmark/src/latency_proxy/tests.rs
@@ -1,0 +1,41 @@
+use super::LatencyProxy;
+use std::{
+    io::{Read as _, Write as _},
+    net::{TcpListener, TcpStream},
+    thread,
+    time::{Duration, Instant},
+};
+
+/// A request → response exchange through the proxy pays the one-way
+/// delay in each direction, so its round trip is ≈ `2 × one_way`.
+#[test]
+fn injects_round_trip_latency() {
+    // Upstream: read the request, echo a fixed reply.
+    let upstream = TcpListener::bind(("127.0.0.1", 0)).expect("bind upstream");
+    let upstream_addr = upstream.local_addr().expect("upstream addr");
+    thread::spawn(move || {
+        let (mut socket, _) = upstream.accept().expect("accept");
+        let mut buf = [0u8; 64];
+        let read = socket.read(&mut buf).expect("read request");
+        assert_eq!(&buf[..read], b"ping");
+        socket.write_all(b"pong").expect("write reply");
+    });
+
+    let one_way = Duration::from_millis(60);
+    let proxy = LatencyProxy::spawn(upstream_addr, one_way).expect("spawn proxy");
+
+    let mut client = TcpStream::connect(proxy.addr).expect("connect to proxy");
+    let start = Instant::now();
+    client.write_all(b"ping").expect("send request");
+    let mut reply = [0u8; 64];
+    let read = client.read(&mut reply).expect("read reply");
+    let elapsed = start.elapsed();
+
+    assert_eq!(&reply[..read], b"pong");
+    // ≈ 120 ms expected; assert the delay is clearly present without
+    // pinning an exact figure (scheduling adds slack on the high side).
+    assert!(
+        elapsed >= Duration::from_millis(100),
+        "round trip {elapsed:?} should reflect the injected ~120ms latency",
+    );
+}

--- a/pacquet/tasks/integrated-benchmark/src/main.rs
+++ b/pacquet/tasks/integrated-benchmark/src/main.rs
@@ -3,6 +3,7 @@
 
 mod cli_args;
 mod fixtures;
+mod latency_proxy;
 mod verify;
 mod work_env;
 mod workspace_manifest;
@@ -23,6 +24,8 @@ async fn main() {
         hyperfine_options,
         work_env,
         with_pnpm,
+        pnpr_latency_ms,
+        registry_latency_ms,
         build_only,
         targets,
     } = clap::Parser::parse();
@@ -116,6 +119,9 @@ async fn main() {
         scenario,
         hyperfine_options,
         fixture_dir,
+        pnpr_latency_ms,
+        registry_latency_ms,
+        registry_port,
     };
     if build_only {
         env.build();

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -3,6 +3,7 @@ use crate::{
         BenchmarkScenario, Cleanup, HyperfineOptions, RegistryMode, TargetKind, TargetSpec,
     },
     fixtures::{LOCKFILE, PACKAGE_JSON},
+    latency_proxy::LatencyProxy,
     verify::executor,
     workspace_manifest::MinimalWorkspaceManifest,
 };
@@ -16,7 +17,7 @@ use std::{
     fmt,
     fs::{self, File},
     io::Write,
-    net::TcpStream,
+    net::{Ipv4Addr, SocketAddr, TcpStream},
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
     thread,
@@ -35,10 +36,20 @@ pub struct WorkEnv {
     pub scenario: Option<BenchmarkScenario>,
     pub hyperfine_options: HyperfineOptions,
     pub fixture_dir: Option<PathBuf>,
+    /// Round-trip latency (ms) to inject between the client and each
+    /// `pnpr@<rev>` target's server. `0` leaves the server on loopback.
+    pub pnpr_latency_ms: u64,
+    /// Round-trip latency (ms) to inject between the direct targets and
+    /// the registry. `0` leaves the registry on loopback. Ignored in
+    /// `--registry=npm` mode (already remote).
+    pub registry_latency_ms: u64,
+    /// Port the local registry listens on, used as the latency proxy's
+    /// upstream when `registry_latency_ms > 0`.
+    pub registry_port: u16,
 }
 
 impl WorkEnv {
-    const INIT_PROXY_CACHE: BenchId<'static> = BenchId::Static(".init-proxy-cache");
+    const INIT_PROXY_CACHE: BenchId<'static> = BenchId::Static(INIT_PROXY_CACHE_ID);
     const SYSTEM_PNPM: BenchId<'static> = BenchId::Static("pnpm");
 
     fn root(&self) -> &'_ Path {
@@ -53,10 +64,6 @@ impl WorkEnv {
     /// requested, the system-pnpm sibling.
     fn benchmarked_ids(&self) -> impl Iterator<Item = BenchId<'_>> + '_ {
         self.target_ids().chain(self.with_pnpm.then_some(WorkEnv::SYSTEM_PNPM))
-    }
-
-    fn registry(&self) -> &'_ str {
-        &self.registry
     }
 
     fn repository(&self) -> &'_ Path {
@@ -159,7 +166,7 @@ impl WorkEnv {
         }
     }
 
-    fn init(&self) {
+    fn init(&self, direct_registry: &str) {
         let scenario = self.scenario.expect("scenario set when init() is reached");
         eprintln!("Initializing...");
         // The proxy-cache populator only runs against a local
@@ -177,11 +184,12 @@ impl WorkEnv {
         for id in id_list {
             eprintln!("ID: {id}");
             let dir = self.bench_dir(id);
+            let registry = self.registry_for(id, direct_registry);
             fs::create_dir_all(&dir).expect("create directory for the revision");
             create_package_json(&dir, self.fixture_dir.as_deref());
-            create_pnpm_workspace(&dir, self.fixture_dir.as_deref(), self.registry(), scenario);
+            create_pnpm_workspace(&dir, self.fixture_dir.as_deref(), registry, scenario);
             create_install_script(&dir, scenario, &WorkEnv::install_command(id), id.is_pnpr());
-            create_npmrc(&dir, self.registry(), scenario);
+            create_npmrc(&dir, registry, scenario);
             may_create_lockfile(&dir, scenario, self.fixture_dir.as_deref());
             save_pristine_copies(&dir);
         }
@@ -426,23 +434,83 @@ impl WorkEnv {
         // (readiness wait, `.pnpr-env` write), so an early failure unwinds
         // through `PnprServer::drop` and kills the process instead of
         // leaking an orphaned server.
-        let server = PnprServer { process };
+        let mut server = PnprServer { process, latency_proxy: None };
 
         wait_for_pnpr_ready(port);
 
-        fs::write(
-            bench_dir.join(".pnpr-env"),
-            format!("export PNPR_SERVER=http://127.0.0.1:{port}\n"),
-        )
-        .expect("write .pnpr-env");
+        // With `--pnpr-latency-ms`, the client reaches the server through
+        // a latency-injecting proxy instead of directly, so the benchmark
+        // measures pnpr as the remote service it is in production. The
+        // proxy guard rides along in `PnprServer` so it's torn down with
+        // the server.
+        let client_url = if self.pnpr_latency_ms > 0 {
+            let upstream = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+            let one_way = Duration::from_millis(self.pnpr_latency_ms) / 2;
+            let proxy = LatencyProxy::spawn(upstream, one_way).expect("spawn pnpr latency proxy");
+            let proxy_url = format!("http://{}", proxy.addr);
+            eprintln!(
+                "Injecting {}ms round-trip latency in front of {id}'s server (proxy at {})",
+                self.pnpr_latency_ms, proxy.addr,
+            );
+            server.latency_proxy = Some(proxy);
+            proxy_url
+        } else {
+            format!("http://127.0.0.1:{port}")
+        };
+
+        fs::write(bench_dir.join(".pnpr-env"), format!("export PNPR_SERVER={client_url}\n"))
+            .expect("write .pnpr-env");
 
         server
     }
 
     pub fn run(&self) {
-        self.init();
+        // Front the registry with a latency proxy for the direct targets,
+        // when requested. The guard lives for the whole run so installs
+        // (in `benchmark`) cross it; the URL is baked into the direct
+        // targets' config during `init`. `pnpr@<rev>` targets keep the
+        // real (fast) registry — see [`Self::registry_for`].
+        let registry_proxy = self.start_registry_proxy();
+        let direct_registry = registry_proxy
+            .as_ref()
+            .map(|proxy| format!("http://{}/", proxy.addr))
+            .unwrap_or_else(|| self.registry.clone());
+
+        self.init(&direct_registry);
         self.build();
         self.benchmark();
+        drop(registry_proxy);
+    }
+
+    /// Start a latency proxy in front of the registry, or `None` when no
+    /// latency is requested, the registry is already remote (`npm` mode),
+    /// or no direct target would use it.
+    fn start_registry_proxy(&self) -> Option<LatencyProxy> {
+        if self.registry_latency_ms == 0 || matches!(self.registry_mode, RegistryMode::Npm) {
+            return None;
+        }
+        let has_direct_target =
+            self.targets.iter().any(|target| target.kind != TargetKind::Pnpr) || self.with_pnpm;
+        if !has_direct_target {
+            return None;
+        }
+        let upstream = SocketAddr::from((Ipv4Addr::LOCALHOST, self.registry_port));
+        let one_way = Duration::from_millis(self.registry_latency_ms) / 2;
+        let proxy = LatencyProxy::spawn(upstream, one_way).expect("spawn registry latency proxy");
+        eprintln!(
+            "Injecting {}ms round-trip latency in front of the registry for direct targets (proxy at {})",
+            self.registry_latency_ms, proxy.addr,
+        );
+        Some(proxy)
+    }
+
+    /// The registry a given bench id resolves against. Direct targets use
+    /// `direct_registry` (the latency proxy when injection is on); pnpr
+    /// targets and the proxy-cache populator keep the real registry — the
+    /// pnpr server's upstream stays fast, and warming the proxy cache is
+    /// untimed setup.
+    fn registry_for<'a>(&'a self, id: BenchId, direct_registry: &'a str) -> &'a str {
+        if id.is_pnpr() || id.is_proxy_cache_populator() { &self.registry } else { direct_registry }
     }
 }
 
@@ -450,10 +518,19 @@ impl WorkEnv {
 /// target. Killed on drop so it never outlives the benchmark run.
 struct PnprServer {
     process: Child,
+    /// The latency proxy fronting this server, when `--pnpr-latency-ms`
+    /// is set. Dropped (stopping the proxy) alongside the server.
+    latency_proxy: Option<LatencyProxy>,
 }
 
 impl Drop for PnprServer {
     fn drop(&mut self) {
+        // Drop the proxy first (it stops accepting new connections and
+        // joins its accept loop), then kill the server. By the time a
+        // server is torn down the benchmark has finished, so there are no
+        // in-flight connections to drain; this is just tidy teardown
+        // order, not a guarantee that existing connections are flushed.
+        self.latency_proxy = None;
         let pid = self.process.id();
         let _ = self.process.kill();
         let _ = self.process.wait();
@@ -778,10 +855,20 @@ impl<'a> From<&'a TargetSpec> for BenchId<'a> {
     }
 }
 
+/// Static bench id of the proxy-cache populator — the one id that warms
+/// the registry's on-disk cache rather than being benchmarked.
+const INIT_PROXY_CACHE_ID: &str = ".init-proxy-cache";
+
 impl BenchId<'_> {
     /// Whether this bench id drives the client through a pnpr server.
     fn is_pnpr(self) -> bool {
         matches!(self, BenchId::PnprRevision(_))
+    }
+
+    /// Whether this is the proxy-cache populator (untimed setup that
+    /// warms the registry cache), which always uses the real registry.
+    fn is_proxy_cache_populator(self) -> bool {
+        matches!(self, BenchId::Static(name) if name == INIT_PROXY_CACHE_ID)
     }
 }
 


### PR DESCRIPTION
## What

The pnpr install accelerator is a **remote** server, but the integrated benchmark ran it on **loopback** (RTT ≈ 0), which hides the round-trip cost that dominates a real install — and that pnpr exists to reduce. This injects network latency so the benchmark measures pnpr as the remote service it is in production.

## How

A dependency-free, synchronous latency-injecting TCP proxy (`latency_proxy`) plus two knobs on `integrated-benchmark`:

- **`--pnpr-latency-ms`** — fronts each `pnpr@<rev>` server, so the client↔server link pays the given round trip (half each direction).
- **`--registry-latency-ms`** — fronts the registry for the direct (`pacquet`/`pnpm`/`--with-pnpm`) targets, so a direct install crosses the same network.

`pnpr@<rev>` targets keep a **direct (fast) registry link** — that models a warm, colocated server, so pnpr's advantage shows up as **fewer round trips, not a faster backend**:

```
direct target:  client → [latency proxy] → registry
pnpr target:     client → [latency proxy] → pnpr server → (direct) → registry
```

The workflow sets both equal (`50ms`) so the in-run pnpr-vs-direct ratio is fair and the `pnpr` Bencher testbed (pnpr@HEAD vs pnpr@main) becomes **sensitive to protocol round-trip-count changes** — which is what makes the upcoming protocol work (collapsing the 3-round-trip handshake/install/files flow) measurable on main. See #12165 for that plan.

## Notes

- **Latency only, no bandwidth cap.** The public registry is CDN-backed and CI runners are fast, so install time is latency/round-trip bound, not throughput bound — a bandwidth cap would be overly pessimistic. A high-ceiling, opt-in bandwidth knob can follow if a slow-link scenario is ever wanted.
- Both flags **default to `0`** (current behavior unchanged); the registry proxy is also skipped in `--registry=npm` mode (already remote).
- The proxy is unit-tested (a round trip through it reflects the injected latency). `cargo check`/`clippy`/`fmt`/`dylint` clean.
- One caveat the proxy does **not** model: TLS-handshake round trips and HTTP/2 multiplexing of a real CDN — it reproduces propagation delay, the dominant and relevant factor here, not a byte-exact replica of registry.npmjs.org.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable latency injection for integrated benchmarks to simulate network delays for server and registry paths.
  * New CLI options to set PNPR and registry latency (milliseconds) for benchmark runs.
  * Benchmark workflow now runs with explicit latency parameters for more realistic performance testing.

* **Tests**
  * Added an integration test validating injected round-trip latency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->