### PR TITLE
perf(pnpr): coarsen packument time precision to shrink abbreviated responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,6 +3209,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bcrypt",
+ "chrono",
  "clap",
  "dashmap",
  "derive_more",

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 use chrono::{DateTime, Duration, Utc};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
-use pacquet_resolving_resolver_base::{Resolver, WantedDependency};
+use pacquet_resolving_resolver_base::{Resolver, WantedDependency, parse_packument_timestamp};
 use std::{path::PathBuf, sync::Arc};
 
 /// One importer's input to [`fn@resolve_workspace`].
@@ -278,9 +278,8 @@ where
             };
             if let Ok(Some(result)) = resolver.resolve(&wanted, &direct_opts).await
                 && let Some(published_at) = result.published_at.as_deref()
-                && let Ok(parsed) = DateTime::parse_from_rfc3339(published_at)
+                && let Some(parsed) = parse_packument_timestamp(published_at)
             {
-                let parsed = parsed.with_timezone(&Utc);
                 newest = Some(newest.map_or(parsed, |current| current.max(parsed)));
             }
         }

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -28,7 +28,7 @@ use pacquet_lockfile::{LockfileResolution, PkgName};
 use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pacquet_registry::{Approver, NpmUser, Package, PackageDistribution, PackageVersion};
 use pacquet_resolving_resolver_base::{
-    ResolutionVerification, ResolutionVerifier, VerifyCtx, VerifyFuture,
+    ResolutionVerification, ResolutionVerifier, VerifyCtx, VerifyFuture, parse_packument_timestamp,
 };
 use pipe_trait::Pipe;
 use serde_json::Value as JsonValue;
@@ -453,13 +453,12 @@ impl NpmResolutionVerifier {
                 ),
             });
         };
-        let Ok(parsed) = DateTime::parse_from_rfc3339(&published) else {
+        let Some(parsed) = parse_packument_timestamp(&published) else {
             return Some(ResolutionVerification::Err {
                 code: MINIMUM_RELEASE_AGE_VIOLATION_CODE,
                 reason: "publish timestamp is not a valid date".to_string(),
             });
         };
-        let parsed = parsed.with_timezone(&Utc);
         if parsed > cutoff {
             return Some(ResolutionVerification::Err {
                 code: MINIMUM_RELEASE_AGE_VIOLATION_CODE,
@@ -596,8 +595,8 @@ impl NpmResolutionVerifier {
             return Ok(None);
         };
         let Some(modified) = meta.modified else { return Ok(None) };
-        let Ok(parsed) = DateTime::parse_from_rfc3339(&modified) else { return Ok(None) };
-        if parsed.with_timezone(&Utc) >= cutoff {
+        let Some(parsed) = parse_packument_timestamp(&modified) else { return Ok(None) };
+        if parsed >= cutoff {
             return Ok(None);
         }
         if !meta.version_tarballs.as_ref().is_some_and(|map| map.contains_key(version)) {

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -36,7 +36,7 @@ use pacquet_registry::{Package, PackageVersion};
 use pacquet_resolving_resolver_base::{
     LatestInfo, LatestQuery, ResolutionPolicyViolation, ResolveError, ResolveFuture,
     ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, UpdateBehavior, WantedDependency,
-    WorkspacePackages,
+    WorkspacePackages, parse_packument_timestamp,
 };
 
 use crate::{
@@ -682,7 +682,7 @@ fn detect_min_release_age_violation(
             _ => {}
         }
     }
-    let parsed = DateTime::parse_from_rfc3339(timestamp).ok()?.with_timezone(&Utc);
+    let parsed = parse_packument_timestamp(timestamp)?;
     if parsed <= cutoff {
         return None;
     }

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -63,7 +63,7 @@ use miette::Diagnostic;
 use pacquet_config::version_policy::{PackageVersionPolicy, PolicyMatch};
 use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pacquet_registry::{Package, PackageVersion};
-use pacquet_resolving_resolver_base::VersionSelectors;
+use pacquet_resolving_resolver_base::{VersionSelectors, parse_packument_timestamp};
 use tokio::sync::Semaphore;
 
 use crate::{
@@ -1077,8 +1077,8 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
     // upgrade — better to spend one extra fetch than to silently
     // bypass the maturity check.
     if let Some(modified_str) = meta.modified.as_deref()
-        && let Ok(modified) = chrono::DateTime::parse_from_rfc3339(modified_str)
-        && modified.with_timezone(&Utc) <= cutoff
+        && let Some(modified) = parse_packument_timestamp(modified_str)
+        && modified <= cutoff
     {
         return Ok(UpgradeOutcome { meta, upgraded: false });
     }

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -38,7 +38,7 @@ use node_semver::{Range, Version};
 use pacquet_config::version_policy::{PackageVersionPolicy, PolicyMatch};
 use pacquet_registry::{Package, PackageVersion};
 use pacquet_resolving_resolver_base::{
-    VersionSelectorEntry, VersionSelectorType, VersionSelectors,
+    VersionSelectorEntry, VersionSelectorType, VersionSelectors, parse_packument_timestamp,
 };
 
 /// Discriminator for [`RegistryPackageSpec::spec_type`]. Mirrors
@@ -190,7 +190,7 @@ where
                 // version published exactly at the cutoff is mature,
                 // so `modified == cutoff` (which means no version is
                 // newer than the cutoff) is also safe to shortcut.
-                let modified_date = meta.modified.as_deref().and_then(parse_iso_8601);
+                let modified_date = meta.modified.as_deref().and_then(parse_packument_timestamp);
                 match modified_date {
                     Some(date) if date <= cutoff => meta,
                     _ => {
@@ -380,7 +380,7 @@ pub fn filter_pkg_metadata_by_publish_date(
         let mature = time
             .get(version)
             .and_then(serde_json::Value::as_str)
-            .and_then(parse_iso_8601)
+            .and_then(parse_packument_timestamp)
             .map(|date| date <= cutoff)
             .unwrap_or(false);
         let trusted = trusted_versions
@@ -604,10 +604,6 @@ fn min_satisfying<Raw: AsRef<str>>(versions: &[Raw], range: &str) -> Option<Stri
         }
     }
     best.map(|(_, raw)| raw)
-}
-
-fn parse_iso_8601(input: &str) -> Option<chrono::DateTime<chrono::Utc>> {
-    chrono::DateTime::parse_from_rfc3339(input).ok().map(|date| date.with_timezone(&chrono::Utc))
 }
 
 fn has_unpublished_versions(meta: &Package) -> bool {

--- a/pacquet/crates/resolving-npm-resolver/src/trust_checks.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/trust_checks.rs
@@ -33,6 +33,7 @@ use miette::Diagnostic;
 use node_semver::Version;
 use pacquet_config::version_policy::{PackageVersionPolicy, PolicyMatch};
 use pacquet_registry::{Package, PackageVersion};
+use pacquet_resolving_resolver_base::parse_packument_timestamp;
 
 /// Rank of supply-chain evidence on a single version. Variants are
 /// declared weakest-first so the derived `Ord` matches `trust_rank`.
@@ -144,11 +145,11 @@ pub fn fail_if_trust_downgraded(
                 name = meta.name,
             ),
         })?;
-    let version_date = DateTime::parse_from_rfc3339(published_at)
-        .map_err(|err| TrustViolation::TrustCheckFailed {
-            reason: format!("publish timestamp is not a valid date: {err}"),
-        })?
-        .with_timezone(&Utc);
+    let version_date = parse_packument_timestamp(published_at).ok_or_else(|| {
+        TrustViolation::TrustCheckFailed {
+            reason: "publish timestamp is not a valid date".to_string(),
+        }
+    })?;
 
     // Ignore-after cutoff: a version old enough to be "settled"
     // gets a pass.
@@ -233,9 +234,8 @@ fn detect_strongest_trust_evidence_before(
         let Some(ts) = meta.published_at(version) else {
             continue;
         };
-        let parsed = match DateTime::parse_from_rfc3339(ts) {
-            Ok(parsed) => parsed.with_timezone(&Utc),
-            Err(_) => continue,
+        let Some(parsed) = parse_packument_timestamp(ts) else {
+            continue;
         };
         if parsed >= before_date {
             continue;

--- a/pacquet/crates/resolving-resolver-base/src/lib.rs
+++ b/pacquet/crates/resolving-resolver-base/src/lib.rs
@@ -22,9 +22,11 @@
 //! [`pacquet_lockfile::LockfileResolution`]; a resolver result *also*
 //! carries one).
 
+mod publish_time;
 mod resolve;
 mod verifier;
 
+pub use publish_time::parse_packument_timestamp;
 pub use resolve::{
     DIRECT_DEP_SELECTOR_WEIGHT, DependencyManifest, EXISTING_VERSION_SELECTOR_WEIGHT, LatestInfo,
     LatestQuery, PkgResolutionId, PreferredVersions, ResolveError, ResolveFuture,

--- a/pacquet/crates/resolving-resolver-base/src/publish_time.rs
+++ b/pacquet/crates/resolving-resolver-base/src/publish_time.rs
@@ -1,0 +1,30 @@
+//! Lenient parsing of npm registry publish timestamps.
+
+use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
+
+/// Parse a publish timestamp from registry metadata into a UTC
+/// instant, or `None` when the string is not a recognized form.
+///
+/// npm stamps full RFC 3339 (`2024-03-15T09:42:13.123Z`), but pnpr
+/// coarsens those timestamps to shrink the abbreviated packument it
+/// serves: seconds come off every entry (`2024-03-15T09:42Z`), and
+/// entries older than a week lose the time-of-day entirely
+/// (`2024-03-15`, read as midnight UTC). pnpm's JavaScript consumers
+/// accept all three through `new Date(...)`; this is the matching
+/// tolerance for pacquet, whose [`DateTime::parse_from_rfc3339`] alone
+/// rejects the two shorter forms.
+pub fn parse_packument_timestamp(input: &str) -> Option<DateTime<Utc>> {
+    if let Ok(parsed) = DateTime::parse_from_rfc3339(input) {
+        return Some(parsed.with_timezone(&Utc));
+    }
+    if let Ok(naive) = NaiveDateTime::parse_from_str(input, "%Y-%m-%dT%H:%MZ") {
+        return Some(Utc.from_utc_datetime(&naive));
+    }
+    if let Ok(date) = NaiveDate::parse_from_str(input, "%Y-%m-%d") {
+        return Some(Utc.from_utc_datetime(&date.and_hms_opt(0, 0, 0)?));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/resolving-resolver-base/src/publish_time/tests.rs
+++ b/pacquet/crates/resolving-resolver-base/src/publish_time/tests.rs
@@ -1,0 +1,42 @@
+use super::parse_packument_timestamp;
+use chrono::{TimeZone, Utc};
+
+#[test]
+fn parses_full_rfc3339_with_and_without_fraction() {
+    assert_eq!(
+        parse_packument_timestamp("2024-03-15T09:42:13.123Z"),
+        Some(
+            Utc.with_ymd_and_hms(2024, 3, 15, 9, 42, 13).unwrap()
+                + chrono::Duration::milliseconds(123)
+        ),
+    );
+    assert_eq!(
+        parse_packument_timestamp("2024-03-15T09:42:13Z"),
+        Some(Utc.with_ymd_and_hms(2024, 3, 15, 9, 42, 13).unwrap()),
+    );
+}
+
+#[test]
+fn parses_minute_precision_without_seconds() {
+    assert_eq!(
+        parse_packument_timestamp("2024-03-15T09:42Z"),
+        Some(Utc.with_ymd_and_hms(2024, 3, 15, 9, 42, 0).unwrap()),
+    );
+}
+
+#[test]
+fn parses_bare_date_as_midnight_utc() {
+    assert_eq!(
+        parse_packument_timestamp("2024-03-15"),
+        Some(Utc.with_ymd_and_hms(2024, 3, 15, 0, 0, 0).unwrap()),
+    );
+}
+
+#[test]
+fn rejects_unrecognized_forms() {
+    // No zone on a time-bearing string is ambiguous (local vs UTC).
+    assert_eq!(parse_packument_timestamp("2024-03-15T09:42"), None);
+    assert_eq!(parse_packument_timestamp("2024-13-99"), None);
+    assert_eq!(parse_packument_timestamp("garbage"), None);
+    assert_eq!(parse_packument_timestamp(""), None);
+}

--- a/pnpr/crates/pnpr/Cargo.toml
+++ b/pnpr/crates/pnpr/Cargo.toml
@@ -35,6 +35,7 @@ pacquet-tarball                 = { workspace = true }
 axum                            = { workspace = true }
 base64                          = { workspace = true }
 bcrypt                          = { workspace = true }
+chrono                          = { workspace = true }
 clap                            = { workspace = true }
 dashmap                         = { workspace = true }
 derive_more                     = { workspace = true }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -23,6 +23,7 @@ use axum::{
     response::{IntoResponse, Response},
     routing::{delete, get, post},
 };
+use chrono::Utc;
 use indexmap::IndexMap;
 use serde_json::{Value, json};
 use std::{sync::Arc, time::Duration};
@@ -1464,7 +1465,7 @@ fn packument_response(
     let mut doc: Value = serde_json::from_slice(bytes)?;
     rewrite_tarball_urls(&mut doc, name, &config.public_url);
     let (body, content_type) = if abbreviated {
-        let trimmed = abbreviate_packument(&doc);
+        let trimmed = abbreviate_packument(&doc, Utc::now());
         (serde_json::to_vec(&trimmed)?, ABBREVIATED_CONTENT_TYPE)
     } else {
         (serde_json::to_vec(&doc)?, "application/json")

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -2,6 +2,7 @@ use crate::{
     error::{RegistryError, Result},
     package_name::PackageName,
 };
+use chrono::{DateTime, Duration, Timelike, Utc};
 use pacquet_network::ThrottledClient;
 use reqwest::StatusCode;
 use serde_json::Value;
@@ -142,17 +143,28 @@ pub fn extract_version_manifest(
 }
 
 /// Top-level packument fields *copied verbatim* into the abbreviated
-/// (`application/vnd.npm.install-v1+json`) form. `time` goes beyond
-/// the npm spec but the pnpm/pacquet resolvers read it for the
-/// `minimumReleaseAge` check, so it stays.
+/// (`application/vnd.npm.install-v1+json`) form.
 ///
-/// `modified` isn't here because it's synthesized rather than copied:
-/// it's extracted from `time.modified` (real npm packuments nest it
+/// `time` isn't here because it's coarsened rather than copied — see
+/// [`coarsen_time_map`]. It goes beyond the npm spec but the
+/// pnpm/pacquet resolvers read it for the `minimumReleaseAge` check,
+/// so it stays (in a shrunken form).
+///
+/// `modified` isn't here either because it's synthesized: it's
+/// extracted from `time.modified` (real npm packuments nest it
 /// there). pacquet reads `meta.modified` in its version-pick
 /// heuristics (`pick_package_from_meta.rs`) and as a freshness check
 /// (`pick_package.rs`); omitting it pushes the resolver onto a slower
 /// fallback path.
-const ABBREVIATED_TOP_FIELDS: &[&str] = &["name", "dist-tags", "time"];
+const ABBREVIATED_TOP_FIELDS: &[&str] = &["name", "dist-tags"];
+
+/// Age past which a `time` entry loses its time-of-day in the
+/// abbreviated form, keeping only the (rounded-up) bare date.
+/// `minimumReleaseAge` cutoffs sit in the recent past (days, not
+/// weeks), so a week-old entry rounded up to the next day is still
+/// unambiguously on the mature side of any realistic cutoff. See
+/// [`coarsen_time_map`].
+const TIME_PRECISION_HORIZON_DAYS: i64 = 7;
 
 /// Per-version fields preserved in the abbreviated form — a subset of
 /// the npm spec's abbreviated version object
@@ -184,7 +196,7 @@ const ABBREVIATED_VERSION_FIELDS: &[&str] = &[
 /// Strip a parsed packument down to the abbreviated install-v1 form.
 /// Should be called *after* `rewrite_tarball_urls` so the returned
 /// document's `dist.tarball` URLs already point at this server.
-pub fn abbreviate_packument(packument: &Value) -> Value {
+pub fn abbreviate_packument(packument: &Value, now: DateTime<Utc>) -> Value {
     let mut out = serde_json::Map::new();
     if let Some(obj) = packument.as_object() {
         for &field in ABBREVIATED_TOP_FIELDS {
@@ -192,11 +204,15 @@ pub fn abbreviate_packument(packument: &Value) -> Value {
                 out.insert(field.to_string(), value.clone());
             }
         }
-        // Synthesize `modified` from `time.modified` — npm packuments
-        // store it nested and pacquet's resolver reads it at the top
-        // level.
-        if let Some(time_modified) = obj.get("time").and_then(|time| time.get("modified")) {
-            out.insert("modified".to_string(), time_modified.clone());
+        // Coarsen `time`, then synthesize `modified` from the
+        // coarsened map — npm packuments nest `modified` under `time`
+        // and pacquet's resolver reads it at the top level.
+        if let Some(time) = obj.get("time").and_then(Value::as_object) {
+            let time = coarsen_time_map(time, now);
+            if let Some(modified) = time.get("modified") {
+                out.insert("modified".to_string(), modified.clone());
+            }
+            out.insert("time".to_string(), Value::Object(time));
         }
         if let Some(versions) = obj.get("versions").and_then(Value::as_object) {
             let mut abbreviated_versions = serde_json::Map::with_capacity(versions.len());
@@ -247,6 +263,54 @@ fn trim_dist_fields(version: &mut serde_json::Map<String, Value>) {
     if dist.get("integrity").and_then(Value::as_str).is_some_and(|integrity| !integrity.is_empty())
     {
         dist.remove("shasum");
+    }
+}
+
+/// Shrink a packument `time` map by dropping precision the resolvers
+/// don't need: seconds come off every timestamp, and entries older
+/// than [`TIME_PRECISION_HORIZON_DAYS`] lose the time-of-day entirely
+/// (down to the bare `YYYY-MM-DD`). Responses go out uncompressed, so
+/// every character dropped is a byte off the wire.
+///
+/// Both reduced forms stay parseable by pnpm (`new Date`) and pacquet
+/// ([`pacquet_resolving_resolver_base::parse_packument_timestamp`]).
+/// Values are rounded *up* (see [`coarsen_timestamp`]) so the
+/// maturity- and trust-checks that read them stay fail-safe.
+/// Non-timestamp entries (the reserved `unpublished` object) and any
+/// value pnpr can't parse as RFC 3339 pass through untouched.
+fn coarsen_time_map(
+    time: &serde_json::Map<String, Value>,
+    now: DateTime<Utc>,
+) -> serde_json::Map<String, Value> {
+    let horizon = now - Duration::days(TIME_PRECISION_HORIZON_DAYS);
+    let mut out = serde_json::Map::with_capacity(time.len());
+    for (key, value) in time {
+        let coarsened = value.as_str().and_then(|raw| coarsen_timestamp(raw, horizon));
+        out.insert(key.clone(), coarsened.map_or_else(|| value.clone(), Value::String));
+    }
+    out
+}
+
+/// Re-render one RFC 3339 timestamp at reduced precision, **rounding
+/// up**: a bare date (the next day, unless already midnight) when it
+/// predates `horizon`, otherwise the next whole minute (unless already
+/// on a minute boundary). Rounding up keeps the coarsened value at or
+/// after the real publish time, so `minimumReleaseAge` and trust
+/// checks can only ever read a version as *newer* than it is — the
+/// fail-safe direction (a too-new version is never coarsened into
+/// looking mature). Returns `None` for strings that aren't RFC 3339 so
+/// the caller keeps the original verbatim.
+fn coarsen_timestamp(raw: &str, horizon: DateTime<Utc>) -> Option<String> {
+    let parsed = DateTime::parse_from_rfc3339(raw).ok()?.with_timezone(&Utc);
+    if parsed < horizon {
+        let date = parsed.date_naive();
+        let rounded =
+            if parsed == date.and_hms_opt(0, 0, 0)?.and_utc() { date } else { date.succ_opt()? };
+        Some(rounded.format("%Y-%m-%d").to_string())
+    } else {
+        let minute = parsed.with_second(0)?.with_nanosecond(0)?;
+        let rounded = if parsed == minute { minute } else { minute + Duration::minutes(1) };
+        Some(rounded.format("%Y-%m-%dT%H:%MZ").to_string())
     }
 }
 

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -1,6 +1,13 @@
 use super::{abbreviate_packument, extract_version_manifest, rewrite_tarball_urls};
 use crate::package_name::PackageName;
+use chrono::{DateTime, TimeZone, Utc};
 use serde_json::json;
+
+/// Fixed "current time" for abbreviation tests so the `time`-map
+/// coarsening (which buckets entries by age) is deterministic.
+fn now() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2024, 3, 20, 12, 0, 0).unwrap()
+}
 
 #[test]
 fn rewrites_npm_form_tarball() {
@@ -135,16 +142,19 @@ fn abbreviation_drops_fields_the_resolver_ignores() {
         }
     });
 
-    let out = abbreviate_packument(&doc);
+    let out = abbreviate_packument(&doc, now());
 
     // Top-level: prose and registry bookkeeping gone, `modified`
-    // synthesized from `time.modified`, `time` retained.
+    // synthesized from `time.modified`, `time` retained. Both `time`
+    // entries predate the week-old horizon, so they coarsen to bare
+    // dates.
     assert!(out.get("readme").is_none());
     assert!(out.get("readmeFilename").is_none());
     assert!(out.get("_id").is_none());
     assert!(out.get("_rev").is_none());
-    assert_eq!(out["modified"], "2020-01-01T00:00:00.000Z");
-    assert!(out.get("time").is_some());
+    assert_eq!(out["modified"], "2020-01-01");
+    assert_eq!(out["time"]["modified"], "2020-01-01");
+    assert_eq!(out["time"]["1.0.0"], "2019-01-01");
 
     let version = &out["versions"]["1.0.0"];
     // Resolver-relevant fields kept.
@@ -188,7 +198,7 @@ fn abbreviation_keeps_shasum_when_integrity_absent() {
         }
     });
 
-    let out = abbreviate_packument(&doc);
+    let out = abbreviate_packument(&doc, now());
 
     let dist = &out["versions"]["0.0.1"]["dist"];
     assert!(dist.get("integrity").is_none());
@@ -214,8 +224,49 @@ fn abbreviation_keeps_shasum_when_integrity_is_empty_or_non_string() {
         }
     });
 
-    let out = abbreviate_packument(&doc);
+    let out = abbreviate_packument(&doc, now());
 
     assert_eq!(out["versions"]["1.0.0"]["dist"]["shasum"], "deadbeef");
     assert_eq!(out["versions"]["2.0.0"]["dist"]["shasum"], "cafe");
+}
+
+#[test]
+fn coarsens_time_entries_by_age() {
+    // `now()` is 2024-03-20T12:00Z; the horizon is one week earlier
+    // (2024-03-13T12:00Z). Values are rounded *up* so the coarsened
+    // timestamp never predates the real publish time.
+    let doc = json!({
+        "name": "foo",
+        "time": {
+            // Older than a week: rounded up to the next day...
+            "modified": "2024-03-01T08:15:30.500Z",
+            "1.0.0": "2023-12-25T23:59:59.000Z",
+            // ...unless already exactly midnight, which stays put.
+            "2.0.0": "2024-01-10T00:00:00.000Z",
+            // Within the last week: rounded up to the next minute...
+            "1.1.0": "2024-03-19T08:30:45.123Z",
+            // ...unless already on a minute boundary.
+            "1.2.0": "2024-03-18T06:15:00.000Z",
+            // The reserved `unpublished` object passes through verbatim.
+            "unpublished": { "time": "2024-03-18T00:00:00.000Z", "versions": ["0.9.0"] },
+            // An unparsable value is left untouched.
+            "0.0.1": "not a date"
+        },
+        "versions": {
+            "1.0.0": { "version": "1.0.0", "dist": { "tarball": "x/foo-1.0.0.tgz" } }
+        }
+    });
+
+    let out = abbreviate_packument(&doc, now());
+    let time = &out["time"];
+
+    assert_eq!(time["modified"], "2024-03-02");
+    assert_eq!(time["1.0.0"], "2023-12-26");
+    assert_eq!(time["2.0.0"], "2024-01-10");
+    assert_eq!(time["1.1.0"], "2024-03-19T08:31Z");
+    assert_eq!(time["1.2.0"], "2024-03-18T06:15Z");
+    assert_eq!(time["unpublished"]["versions"][0], "0.9.0");
+    assert_eq!(time["0.0.1"], "not a date");
+    // Synthesized top-level `modified` mirrors the coarsened entry.
+    assert_eq!(out["modified"], "2024-03-02");
 }


### PR DESCRIPTION
## What

pnpr copies the full `time` map from npm metadata into the abbreviated packument it serves. Those responses go out **uncompressed** (pnpr's `tower-http` has only the `trace` feature, no compression layer), so the verbatim, full-precision timestamps are pure wire cost. This PR coarsens them:

- **Seconds dropped from every entry** → `2024-03-15T09:42Z`
- **Time-of-day dropped from entries older than 7 days** → `2024-03-15` (bare date)
- The reserved `unpublished` object and any non-RFC-3339 value pass through untouched
- The synthesized top-level `modified` is taken from the coarsened map

Values are **rounded up** (to the next minute / next day, leaving values already on the boundary untouched), so a coarsened timestamp is never *earlier* than the real publish time. That keeps `minimumReleaseAge`, the abbreviated-`modified` shortcut, and the trust checks fail-safe: they can only ever read a version as *newer* than it is, so a too-new version is never coarsened into looking mature. The 7-day horizon also keeps full-ish precision where maturity cutoffs actually live (days, not weeks in the past).

## Why it's safe for both stacks

Both reduced forms are already accepted by pnpm's lenient `new Date(...)`. pacquet, however, parsed **strict RFC 3339 only** (`chrono::DateTime::parse_from_rfc3339`), which rejects bare dates and minute-precision strings. So this PR also adds a shared `parse_packument_timestamp` in `resolving-resolver-base` that accepts:

- full RFC 3339 (`2024-03-15T09:42:13.123Z`)
- minute precision (`2024-03-15T09:42Z`)
- bare date (`2024-03-15`, read as midnight UTC)

and routes every existing publish-timestamp parse site through it (`create_npm_resolution_verifier`, `npm_resolver`, `pick_package`, `pick_package_from_meta`, `trust_checks`, and the deps-resolver's `resolve_workspace`). This is also a parity fix — it brings pacquet in line with pnpm's existing leniency.

## Size impact

Measured by running the real `abbreviate_packument` over freshly-fetched full packuments (uncompressed bytes):

| package | versions | `time` block | gzipped `time` |
|---|--:|--:|--:|
| typescript | 3760 | −29.5% (178 KB → 126 KB) | −51.2% |
| @types/node | 2336 | −37.7% (87 KB → 54 KB) | −56.8% |
| aws-sdk | 1966 | −37.7% (73 KB → 46 KB) | −55.6% |
| lodash | 117 | −39.1% | −57.0% |

The whole abbreviated response shrinks ~1–3% today (the per-version dependency data dominates), i.e. ~5–53 KB per request on big packages. The `time` block is the high-entropy part of a packument, so the saving *grows* under compression (−40–57% of the block gzipped) — complementary to adding an HTTP compression layer later, not redundant with it.

## Caveat

`resolutionMode: time-based` / `publishedBy` resolutions *through pnpr* become day-accurate (not second-accurate) for packages older than 7 days — a version right at a chosen snapshot boundary could be coarsened across it. `minimumReleaseAge` and trust checks are fail-safe by construction (rounding up).

## Tests

- New parser unit tests in `resolving-resolver-base` (full / minute / bare-date / rejected forms)
- `coarsens_time_entries_by_age` in pnpr covers age bucketing, round-up, on-boundary passthrough, `unpublished` + unparsable passthrough
- Green: 225 (resolver-base + pnpr) and 318 (npm-resolver + deps-resolver); `clippy --deny warnings`, `fmt`, `taplo`, `typos`, and `dylint` all clean

No changeset — pacquet/pnpr-only (Rust); the TypeScript pnpm consumer already handled these forms.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple timestamp formats in package metadata handling, improving compatibility with various npm registry timestamp formats.
  * Implemented timestamp precision reduction in abbreviated package responses.

* **Refactor**
  * Unified timestamp parsing logic across package resolvers for improved consistency and reliability in time-based dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->