### PR TITLE
feat(pnpr): gzip-compress package metadata over the wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +543,23 @@ name = "command-extra"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1b4fe32ea3f2a8d975b6c5cdd3f02ac358f471ca24dbb18d7a4ca58b3193d2d"
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "console"
@@ -4459,12 +4488,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ reflink-copy = { version = "0.1.29" }
 junction = { version = "2.0.0" }
 libc = { version = "0.2.186" }
 reqwest = { version = "0.13", default-features = false, features = [
+  "gzip",
   "hickory-dns",
   "json",
   "rustls",
@@ -141,7 +142,7 @@ tabled             = { version = "0.17" }
 tar                = { version = "0.4.46" }
 text-block-macros  = { version = "0.2.0" }
 tower              = { version = "0.5.3" }
-tower-http         = { version = "0.6.11", features = ["trace"] }
+tower-http         = { version = "0.6.11", features = ["compression-gzip", "trace"] }
 tracing            = { version = "0.1.44" }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tokio              = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "io-util", "net", "signal", "sync"] }

--- a/pacquet/crates/network/src/lib.rs
+++ b/pacquet/crates/network/src/lib.rs
@@ -360,6 +360,13 @@ fn default_client_builder(settings: &NetworkSettings) -> reqwest::ClientBuilder 
     default_headers.insert(USER_AGENT, user_agent);
     Client::builder()
         .http1_only()
+        // Request gzip and transparently decompress it. Packuments are the
+        // largest payloads pulled during resolution and registries serve
+        // them gzipped; tarballs are unaffected (no `Content-Encoding`, so
+        // store-integrity verification still sees the raw `.tgz`). Defaults
+        // to on with reqwest's `gzip` feature, but set explicitly so the
+        // intent is visible and survives a change to that default.
+        .gzip(true)
         .default_headers(default_headers)
         .connect_timeout(settings.fetch_timeout)
         .timeout(settings.fetch_timeout)

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -27,7 +27,13 @@ use chrono::Utc;
 use indexmap::IndexMap;
 use serde_json::{Value, json};
 use std::{sync::Arc, time::Duration};
-use tower_http::trace::TraceLayer;
+use tower_http::{
+    compression::{
+        CompressionLayer,
+        predicate::{DefaultPredicate, NotForContentType, Predicate as _},
+    },
+    trace::TraceLayer,
+};
 use tracing::Span;
 
 /// MIME the npm registry uses for the abbreviated install-v1 form.
@@ -121,6 +127,25 @@ pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
         // Scoped tarball delete: `DELETE /@scope/name/-/<basename-version>.tgz/-rev/<rev>`
         .route("/{a}/{b}/{c}/{d}/{e}/{f}", delete(delete_six_segments))
         .layer(DefaultBodyLimit::max(MAX_PUBLISH_BODY_BYTES))
+        // gzip metadata responses for clients that send `Accept-Encoding:
+        // gzip`, matching how a real (CDN-fronted) registry serves
+        // packuments — pnpr is commonly hit directly with no proxy in
+        // front, so the application is the only layer that can compress.
+        // Scoped to JSON: the binary endpoints are excluded so we never
+        // re-gzip an already-compressed payload — tarballs
+        // (`application/octet-stream`, already `.tgz`), the install
+        // accelerator's file stream (`application/x-pnpm-install`, already
+        // gzipped), and its NDJSON resolve response
+        // (`application/x-ndjson`). Already-`Content-Encoding` responses
+        // are skipped by the layer regardless.
+        .layer(
+            CompressionLayer::new().compress_when(
+                DefaultPredicate::new()
+                    .and(NotForContentType::const_new("application/octet-stream"))
+                    .and(NotForContentType::const_new("application/x-pnpm-install"))
+                    .and(NotForContentType::const_new("application/x-ndjson")),
+            ),
+        )
         // One structured access record per HTTP request: a span
         // carrying method + URI plus a single `finished processing
         // request` event on the response with status and latency.

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -2,9 +2,11 @@ use axum::{
     body::{Body, to_bytes},
     http::{Request, StatusCode},
 };
+use flate2::read::GzDecoder;
 use pnpr::{Config, router};
 use serde_json::{Value, json};
 use std::{
+    io::Read as _,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     time::Duration,
 };
@@ -564,4 +566,126 @@ async fn ping_endpoint_returns_json_empty_object() {
     let body_bytes = body_bytes(response.into_body()).await;
     let body: Value = serde_json::from_slice(&body_bytes).unwrap();
     assert_eq!(body, json!({}));
+}
+
+fn foo_packument(upstream_url: &str) -> Value {
+    json!({
+        "name": "foo",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "foo",
+                "version": "1.0.0",
+                "dist": {
+                    "tarball": format!("{upstream_url}/foo/-/foo-1.0.0.tgz"),
+                    "shasum": "deadbeef",
+                },
+            },
+        },
+    })
+}
+
+#[tokio::test]
+async fn packument_is_gzipped_for_clients_that_accept_it() {
+    let mut upstream = mockito::Server::new_async().await;
+    let mock = upstream
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(foo_packument(&upstream.url()).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let app = router(config_for(&upstream.url(), tmp.path().to_path_buf()));
+
+    let response = app
+        .oneshot(
+            Request::get("/foo").header("accept-encoding", "gzip").body(Body::empty()).unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("content-encoding").and_then(|value| value.to_str().ok()),
+        Some("gzip"),
+        "a packument should be gzipped when the client accepts gzip",
+    );
+
+    // Decoding yields the same rewritten JSON a plain request would return.
+    let gzipped = body_bytes(response.into_body()).await;
+    let mut decoded = Vec::new();
+    GzDecoder::new(&gzipped[..]).read_to_end(&mut decoded).expect("decode gzip");
+    let body: Value = serde_json::from_slice(&decoded).unwrap();
+    assert_eq!(
+        body["versions"]["1.0.0"]["dist"]["tarball"],
+        "http://example.test/foo/-/foo-1.0.0.tgz",
+    );
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn packument_is_not_gzipped_without_accept_encoding() {
+    let mut upstream = mockito::Server::new_async().await;
+    let mock = upstream
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(foo_packument(&upstream.url()).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let app = router(config_for(&upstream.url(), tmp.path().to_path_buf()));
+
+    let response = app.oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("content-encoding").is_none(),
+        "no Accept-Encoding means the packument is served uncompressed",
+    );
+    let body: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(body["name"], "foo");
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn tarball_is_not_gzipped_even_when_accepted() {
+    let mut upstream = mockito::Server::new_async().await;
+    let bytes = b"fake-tarball-bytes-long-enough-to-clear-the-compression-size-floor";
+    let mock = upstream
+        .mock("GET", "/foo/-/foo-1.0.0.tgz")
+        .with_status(200)
+        .with_header("content-type", "application/octet-stream")
+        .with_body(bytes)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let app = router(config_for(&upstream.url(), tmp.path().to_path_buf()));
+
+    // Tarballs are already `.tgz` (gzip); the layer must not re-compress
+    // them even when the client offers `Accept-Encoding: gzip`.
+    let response = app
+        .oneshot(
+            Request::get("/foo/-/foo-1.0.0.tgz")
+                .header("accept-encoding", "gzip")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("content-encoding").is_none(),
+        "tarballs must not be re-gzipped",
+    );
+    assert_eq!(body_bytes(response.into_body()).await, bytes);
+
+    mock.assert_async().await;
 }


### PR DESCRIPTION
Closes #12169.

## What

Package metadata (packuments) now travels gzip-compressed between pacquet and pnpr — matching how a real, CDN-fronted registry serves it. Previously **neither** side used gzip for metadata: pacquet fetched packuments uncompressed from *every* registry (unlike pnpm-TS, which gets gzip transparently via undici), and pnpr served them uncompressed. Packuments are the largest payloads pulled during resolution and gzip ~5–10×, so this was a real resolution-time cost — and it's especially visible on the frozen-install lockfile-verification path, which fetches *full* packuments.

Both halves are needed and land together (server-only would be a no-op for pacquet, which never asked for gzip):

## Client (pacquet)

Enable reqwest's `gzip` feature → it sends `Accept-Encoding: gzip` and transparently decompresses.
- **Tarballs unaffected:** served as `application/octet-stream` with no `Content-Encoding`, so reqwest leaves them alone — store-integrity verification is unchanged.
- **`/v1/files` unaffected:** that stream is already gzipped with an explicit `Content-Encoding: gzip`; reqwest now auto-decompresses it, and the pnpr-client's existing gzip-magic-byte check already handles the decompressed case.

## Server (pnpr)

Add a `tower-http` `CompressionLayer`, **scoped to JSON** via `NotForContentType` so it compresses packuments / version manifests / dist-tags / search but never re-gzips an already-compressed payload — tarballs (`application/octet-stream`), the file stream (`application/x-pnpm-install`), or the resolve NDJSON (`application/x-ndjson`).

On the architecture question of *why in the app vs. a CDN/nginx:* pnpr's common shape is a warm server hit **directly** over a LAN/CI network with no proxy in front — there the application is the only layer that can compress. Where a CDN/nginx *is* present, the `Content-Encoding: gzip` is simply passed through (no double compression), or origin compression is disabled by config.

## Tests

`pnpr/crates/pnpr/tests/server.rs` asserts a packument is gzipped when `Accept-Encoding: gzip` is sent, served plain otherwise, and a tarball is never re-gzipped. End-to-end coverage comes for free from the existing suites: the pnpr-client integration tests (the pnpr server's own resolver fetches gzipped packuments) and the `pacquet add` e2e tests (direct-client resolution) both pass with the feature on.

## Notes

- Enabling the gzip features pulls `async-compression` (+ `compression-codecs`/`-core`) transitively via reqwest/tower-http — standard, MIT/Apache crates.
- A future optimization (not here): cache the *compressed* packument bytes so a hot server doesn't re-gzip the same metadata per request.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responses now support gzip compression to reduce bandwidth; compression is skipped for already-compressed package tarballs and similar payloads.
  * Client requests properly advertise gzip handling so compressed metadata is served when supported.

* **Tests**
  * Added tests verifying gzip behavior: metadata is compressed when requested, uncompressed when not, and tarballs are never double-compressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->