### PR TITLE
perf(ci): cache benchmark binaries per commit instead of rebuilding

### DIFF
--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -123,6 +123,18 @@ jobs:
           subsection 'Inspecting branches...'
           git branch
 
+      - name: Resolve benchmark revisions
+        id: revs
+        shell: bash
+        # The benchmark binaries are cached per *resolved commit* below, so
+        # `main` is reused across PRs (its SHA is stable until main moves)
+        # and a same-HEAD re-run reuses HEAD too — instead of recompiling
+        # every revision on every run. Needs the local `main` ref that the
+        # previous step made visible.
+        run: |
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "main_sha=$(git rev-parse main)" >> "$GITHUB_OUTPUT"
+
       - name: Cache pnpm-registry storage
         # Persists pnpm-registry's `--storage` dir across CI runs so
         # cold-cache benchmark scenarios don't refetch ~2.3k unscoped
@@ -141,19 +153,51 @@ jobs:
         timeout-minutes: 1
         continue-on-error: true
 
-      - name: Cache Rust builds
+      # Cargo download + the orchestrator's own build target. Deliberately
+      # does NOT cache the multi-GB `bench-work-env/*/pacquet/target` dirs —
+      # restoring those reliably blew the (former 1-minute) timeout, so the
+      # cache silently missed and every run built cold. The compiled
+      # revision *binaries* are cached separately, per commit, below.
+      - name: Cache Rust deps
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          key: integrated-benchmark-builds-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-${{ github.run_id }}
+          key: integrated-benchmark-deps-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-${{ github.run_id }}
           restore-keys: |
-            integrated-benchmark-builds-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-
-            integrated-benchmark-builds-${{ matrix.os }}-
+            integrated-benchmark-deps-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-
+            integrated-benchmark-deps-${{ matrix.os }}-
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-            bench-work-env/*/pacquet/target
-        timeout-minutes: 1
+        timeout-minutes: 3
+        continue-on-error: true
+
+      # Prebuilt revision binaries, keyed on the resolved commit. A
+      # `pnpr@<rev>` build also produces the `pacquet` client binary, and
+      # the orchestrator's `--reuse-prebuilt-binaries` copies it to the
+      # same-revision `pacquet@<rev>` target — so caching the two pnpr
+      # binaries covers all four targets. `main` is a near-certain hit on
+      # PRs (stable SHA), and a same-HEAD re-run hits HEAD too; a fresh HEAD
+      # is the only thing that compiles. Restored into the paths the
+      # orchestrator builds into, so it skips the clone + `cargo build`.
+      - name: Cache pnpr@main binaries
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          key: integrated-benchmark-bin-${{ matrix.os }}-${{ steps.revs.outputs.main_sha }}-${{ hashFiles('rust-toolchain.toml') }}
+          path: |
+            bench-work-env/pnpr@main/pacquet/target/release/pacquet
+            bench-work-env/pnpr@main/pacquet/target/release/pnpr
+        timeout-minutes: 2
+        continue-on-error: true
+
+      - name: Cache pnpr@HEAD binaries
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          key: integrated-benchmark-bin-${{ matrix.os }}-${{ steps.revs.outputs.head_sha }}-${{ hashFiles('rust-toolchain.toml') }}
+          path: |
+            bench-work-env/pnpr@HEAD/pacquet/target/release/pacquet
+            bench-work-env/pnpr@HEAD/pacquet/target/release/pnpr
+        timeout-minutes: 2
         continue-on-error: true
 
       - name: Install Rust Toolchain
@@ -203,7 +247,7 @@ jobs:
         # binaries the boot step needs. More builds than the pacquet-only
         # bench, hence the larger timeout.
         timeout-minutes: 25
-        run: just integrated-benchmark --build-only $BENCHMARK_TARGETS
+        run: just integrated-benchmark --reuse-prebuilt-binaries --build-only $BENCHMARK_TARGETS
 
       - name: 'Benchmark: Isolated linker: fresh restore, cold cache + cold store'
         shell: bash
@@ -215,7 +259,7 @@ jobs:
         # warm server), and a failure surfaces fast enough to iterate on.
         timeout-minutes: 15
         run: |
-          just integrated-benchmark --scenario=isolated-linker.fresh-restore.cold-cache.cold-store --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} $BENCHMARK_TARGETS
+          just integrated-benchmark --reuse-prebuilt-binaries --scenario=isolated-linker.fresh-restore.cold-cache.cold-store --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} $BENCHMARK_TARGETS
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE.json
 
@@ -228,7 +272,7 @@ jobs:
         # server, as in every scenario).
         timeout-minutes: 15
         run: |
-          just integrated-benchmark --scenario=isolated-linker.fresh-restore.hot-cache.hot-store --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} $BENCHMARK_TARGETS
+          just integrated-benchmark --reuse-prebuilt-binaries --scenario=isolated-linker.fresh-restore.hot-cache.hot-store --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} $BENCHMARK_TARGETS
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE.json
 
@@ -242,7 +286,7 @@ jobs:
         # safety net the other steps document.
         timeout-minutes: 35
         run: |
-          just integrated-benchmark --scenario=isolated-linker.fresh-install.cold-cache.cold-store --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} $BENCHMARK_TARGETS
+          just integrated-benchmark --reuse-prebuilt-binaries --scenario=isolated-linker.fresh-install.cold-cache.cold-store --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} $BENCHMARK_TARGETS
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE.json
 
@@ -253,7 +297,7 @@ jobs:
         # ample headroom across all four commands.
         timeout-minutes: 25
         run: |
-          just integrated-benchmark --scenario=isolated-linker.fresh-install.hot-cache.hot-store --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} $BENCHMARK_TARGETS
+          just integrated-benchmark --reuse-prebuilt-binaries --scenario=isolated-linker.fresh-install.hot-cache.hot-store --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} $BENCHMARK_TARGETS
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE.json
 

--- a/pacquet/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pacquet/tasks/integrated-benchmark/src/cli_args.rs
@@ -65,6 +65,13 @@ pub struct CliArgs {
     #[clap(long)]
     pub build_only: bool,
 
+    /// Skip cloning + building a target whose output binary is already
+    /// present, e.g. restored from a per-commit CI cache. A `pnpr@<rev>`
+    /// build also yields the `pacquet` client binary, so a same-revision
+    /// `pacquet@<rev>` reuses it rather than recompiling the commit.
+    #[clap(long)]
+    pub reuse_prebuilt_binaries: bool,
+
     /// Targets to benchmark. Each is `pacquet@<rev>`, `pnpm@<rev>`, or
     /// `pnpr@<rev>` (a pacquet client driven through a pnpr server).
     #[clap(required = true)]

--- a/pacquet/tasks/integrated-benchmark/src/main.rs
+++ b/pacquet/tasks/integrated-benchmark/src/main.rs
@@ -26,6 +26,7 @@ async fn main() {
         with_pnpm,
         pnpr_latency_ms,
         registry_latency_ms,
+        reuse_prebuilt_binaries,
         build_only,
         targets,
     } = clap::Parser::parse();
@@ -122,6 +123,7 @@ async fn main() {
         pnpr_latency_ms,
         registry_latency_ms,
         registry_port,
+        reuse_prebuilt_binaries,
     };
     if build_only {
         env.build();

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -46,6 +46,10 @@ pub struct WorkEnv {
     /// Port the local registry listens on, used as the latency proxy's
     /// upstream when `registry_latency_ms > 0`.
     pub registry_port: u16,
+    /// Skip the clone + `cargo build` for a target whose output binary is
+    /// already present — i.e. restored from a per-commit CI cache. Off by
+    /// default so a local run always rebuilds.
+    pub reuse_prebuilt_binaries: bool,
 }
 
 impl WorkEnv {
@@ -202,9 +206,34 @@ impl WorkEnv {
         }
     }
 
+    /// Output binary a `pacquet@<rev>` target runs.
+    fn pacquet_binary(&self, revision: &str) -> PathBuf {
+        self.pacquet_source_dir(revision).join("target").join("release").join("pacquet")
+    }
+
+    /// The `pacquet` client binary a `pnpr@<rev>` build produces (the pnpr
+    /// target builds `--bin=pacquet --bin=pnpr`).
+    fn pnpr_pacquet_binary(&self, revision: &str) -> PathBuf {
+        self.pnpr_source_dir(revision).join("target").join("release").join("pacquet")
+    }
+
+    /// The `pnpr` server binary a `pnpr@<rev>` build produces.
+    fn pnpr_server_binary(&self, revision: &str) -> PathBuf {
+        self.pnpr_source_dir(revision).join("target").join("release").join("pnpr")
+    }
+
     pub fn build(&self) {
         eprintln!("Building...");
-        for target in &self.targets {
+        // Build `pnpr@<rev>` targets first: a pnpr build also produces the
+        // `pacquet` client binary, so a same-revision `pacquet@<rev>` can
+        // reuse it (see [`Self::build_pacquet`]) instead of compiling the
+        // identical commit a second time.
+        let pnpr_first = self
+            .targets
+            .iter()
+            .filter(|target| target.kind == TargetKind::Pnpr)
+            .chain(self.targets.iter().filter(|target| target.kind != TargetKind::Pnpr));
+        for target in pnpr_first {
             match target.kind {
                 TargetKind::Pacquet => self.build_pacquet(&target.rev),
                 TargetKind::Pnpm => self.build_pnpm(&target.rev),
@@ -214,6 +243,35 @@ impl WorkEnv {
     }
 
     fn build_pacquet(&self, revision: &str) {
+        let dest = self.pacquet_binary(revision);
+
+        // Restored from the per-commit CI binary cache: nothing to build.
+        if self.reuse_prebuilt_binaries && dest.is_file() {
+            eprintln!("Revision: {revision:?} (pacquet) — reusing prebuilt binary");
+            return;
+        }
+
+        // The same commit's `pnpr@<revision>` target (built first) already
+        // produced an identical `pacquet` client binary; copy it rather
+        // than compiling the revision twice.
+        if self
+            .targets
+            .iter()
+            .any(|target| target.kind == TargetKind::Pnpr && target.rev == revision)
+        {
+            let from_pnpr = self.pnpr_pacquet_binary(revision);
+            if from_pnpr.is_file() {
+                eprintln!(
+                    "Revision: {revision:?} (pacquet) — reusing the binary from the pnpr@{revision} build",
+                );
+                if let Some(parent) = dest.parent() {
+                    fs::create_dir_all(parent).expect("create pacquet target/release dir");
+                }
+                fs::copy(&from_pnpr, &dest).expect("copy pacquet binary from the pnpr build");
+                return;
+            }
+        }
+
         eprintln!("Revision: {revision:?} (pacquet)");
 
         let repository = self.repository();
@@ -247,6 +305,15 @@ impl WorkEnv {
     /// spawned later, at benchmark time, from
     /// `<bench_dir>/pacquet/target/release/pnpr`.
     fn build_pnpr(&self, revision: &str) {
+        // Restored from the per-commit CI binary cache: nothing to build.
+        if self.reuse_prebuilt_binaries
+            && self.pnpr_pacquet_binary(revision).is_file()
+            && self.pnpr_server_binary(revision).is_file()
+        {
+            eprintln!("Revision: {revision:?} (pnpr) — reusing prebuilt binaries");
+            return;
+        }
+
         eprintln!("Revision: {revision:?} (pnpr)");
 
         let repository = self.repository();


### PR DESCRIPTION
## Problem

The integrated-benchmark's **"Precompile benchmark revisions"** step takes ~14 minutes on essentially every run. Two compounding causes:

1. **The build cache never restores.** "Cache Rust builds" cached `~/.cargo` + the **multi-GB** `bench-work-env/*/pacquet/target` dirs under a **`timeout-minutes: 1`** restore. A restore that large doesn't finish in 60s, and `continue-on-error: true` swallows the timeout — so the cache silently misses and all four targets build cold every run.
2. **The same commit is compiled twice.** `pacquet@HEAD` and `pnpr@HEAD` resolve to the *same* commit but build in separate clones, so the `pacquet` binary is compiled twice (likewise for `main`).

## Fix: cache compiled binaries per resolved commit

Cache the *binaries* (a few MB, restore in seconds, no eviction risk) keyed on the **resolved commit SHA**, and skip rebuilding when they're present.

**Orchestrator (`work_env.rs` / `cli_args.rs`):**
- New `--reuse-prebuilt-binaries` flag → skip the clone + `cargo build` for a target whose output binary already exists (restored from cache). Off by default, so local runs are unchanged.
- Targets build **pnpr-first**: a `pnpr@<rev>` build also produces the `pacquet` client binary, so a same-revision `pacquet@<rev>` **reuses it by copy** instead of recompiling the commit. (This also guarantees the direct and accelerated rows use a byte-identical client.)

**Workflow:**
- Resolve the HEAD/main SHAs, then cache the two `pnpr@<rev>` binaries keyed on the commit — they cover all four targets via the dedup-copy.
- `main` is a near-certain hit on PRs (stable SHA until main moves); a same-HEAD re-run hits HEAD too. Only a **fresh HEAD** compiles.
- Drop the giant `bench-work-env/*/pacquet/target` cache; keep a cargo-deps + orchestrator-target cache with a realistic **3-minute** timeout.

## Impact

- Fresh-HEAD run: compiles **one** workspace once (~half the old work), since `main` is cached and the `pacquet@HEAD` binary is copied from the `pnpr@HEAD` build.
- Re-run / stable main: cached binaries restored → **compilation skipped entirely** (~seconds).

## Validation

- Local smoke test of the skip + dedup path (pre-placed binaries → `reusing prebuilt binaries` for pnpr, `reusing the binary from the pnpr@HEAD build` for pacquet, executable bit preserved, no `cargo`/`git` invoked).
- `cargo build` / `clippy` / `fmt` / `dylint` clean; the crate's tests pass. The real end-to-end timing proof is this workflow's own run.

## Notes

- Cross-event reuse (a `main`-push pre-populating PRs' `main` cache) isn't wired up — the bench dir is named by rev string (`pnpr@main`), not SHA, so `main` is instead built once by the first PR after `main` moves and reused by the rest. A neutral SHA-keyed cache location could bridge that later if wanted.
- The unquoted `$BENCHMARK_TARGETS` shellcheck notes are pre-existing and intentional (it must word-split into multiple target args).

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--reuse-prebuilt-binaries` CLI flag to skip rebuilding binaries when already cached locally, reducing redundant builds and improving benchmark performance.

* **Chores**
  * Enhanced integrated benchmark workflow with improved caching strategy, introducing separate cache layers for prebuilt binaries to accelerate benchmark runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->