### PR TITLE
fix(pacquet): preserve executable mode on copy fallback

### DIFF
--- a/pacquet/crates/package-manager/src/link_file.rs
+++ b/pacquet/crates/package-manager/src/link_file.rs
@@ -214,11 +214,11 @@ fn try_import<Reporter: self::Reporter>(
                 log_method_once::<Reporter>(logged, LOG_FLAG_HARDLINK, WireImportMethod::Hardlink);
                 Ok(())
             }
-            Err(error) if is_cross_device(&error) => fs::copy(source_file, target_link)
-                .inspect(|_| {
+            Err(error) if is_cross_device(&error) => {
+                copy_file(source_file, target_link).inspect(|_| {
                     log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
                 })
-                .map(drop),
+            }
             Err(error) => Err(error),
         },
         PackageImportMethod::Clone => {
@@ -230,12 +230,39 @@ fn try_import<Reporter: self::Reporter>(
             static CLONE_OR_COPY_STATE: AtomicU8 = AtomicU8::new(LINK_STATE_CLONE);
             clone_or_copy_link::<Reporter>(logged, &CLONE_OR_COPY_STATE, source_file, target_link)
         }
-        PackageImportMethod::Copy => fs::copy(source_file, target_link)
-            .inspect(|_| {
-                log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
-            })
-            .map(drop),
+        PackageImportMethod::Copy => copy_file(source_file, target_link).inspect(|_| {
+            log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
+        }),
     }
+}
+
+fn copy_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
+    fs::copy(source_file, target_link)?;
+    preserve_mode_after_copy(source_file, target_link)
+}
+
+#[cfg(unix)]
+fn preserve_mode_after_copy(source_file: &Path, target_link: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut mode = fs::metadata(source_file)?.permissions().mode();
+    if source_file_is_executable_cas_path(source_file) {
+        mode |= 0o111;
+    }
+    fs::set_permissions(target_link, fs::Permissions::from_mode(mode))
+}
+
+#[cfg(not(unix))]
+fn preserve_mode_after_copy(_source_file: &Path, _target_link: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn source_file_is_executable_cas_path(source_file: &Path) -> bool {
+    source_file
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with("-exec"))
 }
 
 /// EXDEV = "cross-device link not permitted". Linux / macOS / BSD all
@@ -323,11 +350,9 @@ fn auto_link<Reporter: self::Reporter>(
                 }
             },
             _ => {
-                return fs::copy(source, target)
-                    .inspect(|_| {
-                        log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
-                    })
-                    .map(drop);
+                return copy_file(source, target).inspect(|_| {
+                    log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
+                });
             }
         }
     }
@@ -358,11 +383,9 @@ fn clone_or_copy_link<Reporter: self::Reporter>(
                 }
             },
             _ => {
-                return fs::copy(source, target)
-                    .inspect(|_| {
-                        log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
-                    })
-                    .map(drop);
+                return copy_file(source, target).inspect(|_| {
+                    log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
+                });
             }
         }
     }

--- a/pacquet/crates/package-manager/src/link_file/tests.rs
+++ b/pacquet/crates/package-manager/src/link_file/tests.rs
@@ -45,6 +45,24 @@ fn copy_materializes_the_file_contents() {
     let _ = (src_ino, dst_ino);
 }
 
+#[test]
+#[cfg(unix)]
+fn copy_restores_executable_mode_from_cas_suffix() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "src-exec", b"#!/usr/bin/env node\n");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o644)).unwrap();
+    let dst = tmp.path().join("nested/dst.txt");
+    fs::create_dir_all(dst.parent().unwrap()).unwrap();
+
+    link_file::<SilentReporter>(&AtomicU8::new(0), PackageImportMethod::Copy, &src, &dst)
+        .expect("copy should restore executable CAS mode");
+
+    let dst_mode = fs::metadata(&dst).unwrap().permissions().mode() & 0o777;
+    assert_eq!(dst_mode, 0o755, "copied executable file must stay executable");
+}
+
 /// Hardlinking in the same directory on the same filesystem works on
 /// every mainstream OS the project supports. We verify the post-link
 /// inodes match (on unix) or that the contents match (otherwise).


### PR DESCRIPTION
## Summary

Fixes #12171.

Pacquet stores executable CAFS entries under paths ending in `-exec`, but copy-tier imports could still materialize those files without executable bits. That leaves packages such as `@esbuild/linux-x64` with a non-executable native binary when the install falls back to copying.

This routes all copy-tier imports through one helper. On Unix, the helper reapplies the source mode after copying and defensively restores executable bits when the CAFS source path has the `-exec` suffix.

## Tests

- `cargo fmt --package pacquet-package-manager`
- `cargo test -p pacquet-package-manager link_file`
- `cargo clippy -p pacquet-package-manager --lib --tests -- --deny warnings`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed hardlink import failures across different filesystems with automatic fallback to file copying
* Improved file permission and executable bit preservation during package imports
* Enhanced permission consistency across all package import methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->