### PR TITLE
fix: make peer-dependent deduplication deterministic

### DIFF
--- a/.changeset/quiet-peers-settle.md
+++ b/.changeset/quiet-peers-settle.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Made peer-dependent deduplication deterministic. When a peer-suffixed package variant was a subset of two or more mutually incompatible larger variants, the variant it collapsed into depended on the order importers were resolved in, which varies between machines. This could resolve the same workspace to different lockfiles on different platforms and make `pnpm dedupe --check` alternate between passing and failing.

--- a/installing/deps-resolver/src/resolvePeers.ts
+++ b/installing/deps-resolver/src/resolvePeers.ts
@@ -265,7 +265,16 @@ function deduplicateDepPaths<T extends PartialResolvedPackage> (
   duplicates: Array<Set<DepPath>>,
   depGraph: GenericDependenciesGraphWithResolvedChildren<T>
 ): DeduplicateDepPathsResult {
-  const depCountSorter = (depPath1: DepPath, depPath2: DepPath) => nodeDepsCount(depGraph[depPath1]) - nodeDepsCount(depGraph[depPath2])
+  // The dep paths arrive in resolution order, which varies between platforms.
+  // Tie-break equal dependency counts on the dep path itself so the chosen
+  // collapse target is the same everywhere — when a variant is a subset of
+  // several incompatible larger variants, the winner must not hinge on
+  // iteration order, or the lockfile becomes machine-dependent.
+  const depCountSorter = (depPath1: DepPath, depPath2: DepPath) => {
+    const countDiff = nodeDepsCount(depGraph[depPath1]) - nodeDepsCount(depGraph[depPath2])
+    if (countDiff !== 0) return countDiff
+    return depPath1 < depPath2 ? -1 : depPath1 > depPath2 ? 1 : 0
+  }
   const depPathsMap: Record<DepPath, DepPath> = {}
   const remainingDuplicates: Array<Set<DepPath>> = []
 

--- a/installing/deps-resolver/test/dedupeDepPaths.test.ts
+++ b/installing/deps-resolver/test/dedupeDepPaths.test.ts
@@ -111,3 +111,79 @@ test('packages are not deduplicated when versions do not match', async () => {
   expect(dependenciesByProjectId.project1.get('foo')).not.toEqual(dependenciesByProjectId.project3.get('foo'))
   expect(dependenciesByProjectId.project3.get('foo')).toEqual(dependenciesByProjectId.project4.get('foo'))
 })
+
+// When a peer-suffixed variant is a subset of two mutually incompatible larger
+// variants, the dedupe pass has to pick which one to collapse it into. That
+// choice must not depend on the order the importers happen to be processed in —
+// otherwise the same workspace resolves to different lockfiles on different
+// machines, and `pnpm dedupe --check` flips between pass and fail.
+test('peer-dependent deduplication does not depend on importer order', async () => {
+  const fooPkg: PartialResolvedPackage = {
+    name: 'foo',
+    version: '1.0.0',
+    pkgIdWithPatchHash: 'foo/1.0.0' as PkgIdWithPatchHash,
+    id: '' as PkgResolutionId,
+    peerDependencies: {
+      bar: { version: '1.0.0', optional: true },
+      baz: { version: '1.0.0', optional: true },
+      qux: { version: '1.0.0', optional: true },
+    },
+  }
+  const purePeer = (name: string): PartialResolvedPackage => ({
+    name,
+    version: '1.0.0',
+    pkgIdWithPatchHash: `${name}/1.0.0` as PkgIdWithPatchHash,
+    peerDependencies: {},
+    id: '' as PkgResolutionId,
+  })
+
+  // project-subset resolves foo(bar); project-baz resolves foo(bar)(baz);
+  // project-qux resolves foo(bar)(qux). foo(bar) is a subset of both of the
+  // larger variants, which are themselves incompatible with each other.
+  const makeProject = (id: string, aliases: string[]) => ({
+    directNodeIdsByAlias: new Map(aliases.map((alias) => [alias, `>${id}>${alias}>` as NodeId])),
+    topParents: [],
+    rootDir: '' as ProjectRootDir,
+    id: id as PkgResolutionId,
+  })
+  const projectSubset = makeProject('project-subset', ['foo', 'bar'])
+  const projectBaz = makeProject('project-baz', ['foo', 'bar', 'baz'])
+  const projectQux = makeProject('project-qux', ['foo', 'bar', 'qux'])
+
+  const buildTree = () => new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>(([
+    ['>project-subset>foo>' as NodeId, fooPkg],
+    ['>project-subset>bar>' as NodeId, purePeer('bar')],
+    ['>project-baz>foo>' as NodeId, fooPkg],
+    ['>project-baz>bar>' as NodeId, purePeer('bar')],
+    ['>project-baz>baz>' as NodeId, purePeer('baz')],
+    ['>project-qux>foo>' as NodeId, fooPkg],
+    ['>project-qux>bar>' as NodeId, purePeer('bar')],
+    ['>project-qux>qux>' as NodeId, purePeer('qux')],
+  ] satisfies Array<[NodeId, PartialResolvedPackage]>).map(([path, resolvedPackage]) => [path, {
+    children: {},
+    installable: {},
+    resolvedPackage,
+    depth: 0,
+  } as DependenciesTreeNode<PartialResolvedPackage>]))
+
+  const resolveSubsetFoo = async (projects: Array<ReturnType<typeof makeProject>>) => {
+    const { dependenciesByProjectId } = await resolvePeers({
+      allPeerDepNames: new Set(['bar', 'baz', 'qux']),
+      projects,
+      resolvedImporters: {},
+      dependenciesTree: buildTree(),
+      dedupePeerDependents: true,
+      virtualStoreDir: '',
+      virtualStoreDirMaxLength: 120,
+      lockfileDir: '',
+      peersSuffixMaxLength: 1000,
+      workspaceProjectIds: new Set(),
+    })
+    return dependenciesByProjectId['project-subset'].get('foo')
+  }
+
+  const bazFirst = await resolveSubsetFoo([projectSubset, projectBaz, projectQux])
+  const quxFirst = await resolveSubsetFoo([projectSubset, projectQux, projectBaz])
+
+  expect(bazFirst).toBe(quxFirst)
+})

--- a/installing/deps-resolver/test/dedupeDepPaths.test.ts
+++ b/installing/deps-resolver/test/dedupeDepPaths.test.ts
@@ -185,5 +185,7 @@ test('peer-dependent deduplication does not depend on importer order', async () 
   const bazFirst = await resolveSubsetFoo([projectSubset, projectBaz, projectQux])
   const quxFirst = await resolveSubsetFoo([projectSubset, projectQux, projectBaz])
 
+  expect(bazFirst).toBeDefined()
+  expect(quxFirst).toBeDefined()
   expect(bazFirst).toBe(quxFirst)
 })

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -925,6 +925,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         let workspace_opts = pacquet_resolving_deps_resolver::WorkspaceResolveOptions {
             dedupe_peers: config.dedupe_peers,
             dedupe_injected_deps: config.dedupe_injected_deps,
+            dedupe_peer_dependents: config.dedupe_peer_dependents,
             exclude_links_from_lockfile: config.exclude_links_from_lockfile,
             lockfile_dir: lockfile_dir.to_path_buf(),
             peers_suffix_max_length,

--- a/pacquet/crates/resolving-deps-resolver/src/dedupe_injected_deps.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/dedupe_injected_deps.rs
@@ -157,11 +157,17 @@ fn make_link_dep_path(source_root: &Path, target_root: &Path, lockfile_dir: &Pat
     DepPath::from(format!("link:{rel_posix}"))
 }
 
-/// Remove graph nodes no importer reaches after dedupe, mirroring
+/// Remove graph nodes no importer reaches after a dedupe pass, mirroring
 /// pnpm's [`pruneSharedLockfile`](https://github.com/pnpm/pnpm/blob/39101f5e37/lockfile/pruner/src/index.ts).
-/// The deduped `file:` snapshot would otherwise remain in
-/// `merged_graph` and surface in `pnpm-lock.yaml` as an orphan.
-fn prune_unreachable(graph: &mut DependenciesGraph, direct_by_importer: &DirectByImporter) {
+/// A snapshot that loses all references — an injected `file:` rewritten
+/// to `link:`, or a peer-variant collapsed by
+/// [`fn@crate::dedupe_peer_dependents::dedupe_peer_dependents`] — would
+/// otherwise remain in the graph and surface in `pnpm-lock.yaml` as an
+/// orphan, since pacquet has no unified post-resolve lockfile pruner.
+pub(crate) fn prune_unreachable(
+    graph: &mut DependenciesGraph,
+    direct_by_importer: &DirectByImporter,
+) {
     let mut reachable: HashSet<DepPath> = HashSet::new();
     let mut stack: Vec<DepPath> =
         direct_by_importer.values().flat_map(|direct| direct.values().cloned()).collect();

--- a/pacquet/crates/resolving-deps-resolver/src/dedupe_peer_dependents.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/dedupe_peer_dependents.rs
@@ -1,0 +1,205 @@
+//! Port of pnpm's `dedupePeerDependents` collapse, the
+//! [tail block of `resolvePeers`](https://github.com/pnpm/pnpm/blob/7f91ba4045/installing/deps-resolver/src/resolvePeers.ts#L214-L222)
+//! and its helpers
+//! [`deduplicateAll`](https://github.com/pnpm/pnpm/blob/7f91ba4045/installing/deps-resolver/src/resolvePeers.ts#L235-L257)
+//! /
+//! [`deduplicateDepPaths`](https://github.com/pnpm/pnpm/blob/7f91ba4045/installing/deps-resolver/src/resolvePeers.ts#L264-L310).
+//!
+//! Runs after [`fn@crate::dedupe_injected_deps::dedupe_injected_deps`]
+//! in the multi-importer [`fn@crate::resolve_peers_workspace`] pass. When
+//! the same
+//! `pkgIdWithPatchHash` resolved into several peer-suffixed variants
+//! that differ only by which optional peers they picked up, a smaller
+//! variant whose children + resolved peers are a subset of a larger,
+//! compatible variant collapses into it: every reference to the smaller
+//! depPath (graph child edges and importer direct deps) is rewritten to
+//! the larger one, and the orphaned variant drops out of the lockfile.
+//!
+//! The collapse target is chosen by a total order over `(dep count, dep
+//! path)` so it never depends on the order importers were resolved in —
+//! the determinism fix from
+//! [pnpm/pnpm#12179](https://github.com/pnpm/pnpm/pull/12179). A variant
+//! that is a subset of two mutually incompatible larger variants of
+//! equal size would otherwise collapse into whichever happened to be
+//! visited first, producing machine-dependent lockfiles.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use pacquet_deps_path::DepPath;
+
+use crate::{
+    dedupe_injected_deps::{DirectByImporter, prune_unreachable},
+    dependencies_graph::{DependenciesGraph, DependenciesGraphNode},
+};
+
+/// Collapse peer-dependent duplicate variants in `graph` into their
+/// largest compatible sibling, rewriting every collapsed depPath in the
+/// graph's child edges and in each importer's `direct` map.
+pub fn dedupe_peer_dependents(
+    graph: &mut DependenciesGraph,
+    direct_by_importer: &mut DirectByImporter,
+) {
+    let duplicates = collect_duplicates(graph);
+    if duplicates.is_empty() {
+        return;
+    }
+    let dep_paths_map = deduplicate_all(graph, duplicates);
+    if dep_paths_map.is_empty() {
+        return;
+    }
+    for direct in direct_by_importer.values_mut() {
+        for dep_path in direct.values_mut() {
+            if let Some(target) = dep_paths_map.get(dep_path) {
+                *dep_path = target.clone();
+            }
+        }
+    }
+    // The collapsed variants now have no incoming edge (every graph child
+    // edge and importer direct dep was rewritten above). Drop them so they
+    // don't surface in the lockfile as orphans.
+    prune_unreachable(graph, direct_by_importer);
+}
+
+/// Group the graph's depPaths by their `pkgIdWithPatchHash` and keep the
+/// groups with more than one variant. Mirrors upstream's
+/// [`depPathsByPkgId` filtered to `size > 1`](https://github.com/pnpm/pnpm/blob/7f91ba4045/installing/deps-resolver/src/resolvePeers.ts#L215);
+/// pacquet reconstructs the grouping from the finished graph (each node
+/// carries its `resolved_package_id`) instead of threading a parallel
+/// map through the walk.
+///
+/// Groups are keyed through a `BTreeMap` only to make the outer order
+/// stable for readers — group order does not affect the collapse, since
+/// each `pkgIdWithPatchHash` group is processed independently. The order
+/// *within* a group is left as the graph yields it; determinism comes
+/// from the total-order sorter in [`deduplicate_dep_paths`], the fix this
+/// module exists to port.
+fn collect_duplicates(graph: &DependenciesGraph) -> Vec<Vec<DepPath>> {
+    let mut by_pkg: BTreeMap<&str, Vec<DepPath>> = BTreeMap::new();
+    for (dep_path, node) in graph {
+        by_pkg.entry(node.resolved_package_id.as_str()).or_default().push(dep_path.clone());
+    }
+    by_pkg.into_values().filter(|variants| variants.len() > 1).collect()
+}
+
+/// Run [`deduplicate_dep_paths`] in rounds: after each round, rewrite the
+/// graph's child edges through the collapse map so the next round can see
+/// newly-compatible variants, then recurse on the duplicates that didn't
+/// collapse. Mirrors upstream's
+/// [`deduplicateAll`](https://github.com/pnpm/pnpm/blob/7f91ba4045/installing/deps-resolver/src/resolvePeers.ts#L235-L257).
+fn deduplicate_all(
+    graph: &mut DependenciesGraph,
+    duplicates: Vec<Vec<DepPath>>,
+) -> HashMap<DepPath, DepPath> {
+    let duplicates_count = duplicates.len();
+    let (dep_paths_map, remaining_duplicates) = deduplicate_dep_paths(&duplicates, graph);
+    if remaining_duplicates.len() == duplicates_count {
+        return dep_paths_map;
+    }
+    for node in graph.values_mut() {
+        for child_dep_path in node.children.values_mut() {
+            if let Some(target) = dep_paths_map.get(child_dep_path) {
+                *child_dep_path = target.clone();
+            }
+        }
+    }
+    if dep_paths_map.is_empty() {
+        return dep_paths_map;
+    }
+    let mut merged = dep_paths_map;
+    for (collapsed, target) in deduplicate_all(graph, remaining_duplicates) {
+        merged.insert(collapsed, target);
+    }
+    merged
+}
+
+/// One round of greedy collapse over each duplicate group. Mirrors
+/// upstream's
+/// [`deduplicateDepPaths`](https://github.com/pnpm/pnpm/blob/7f91ba4045/installing/deps-resolver/src/resolvePeers.ts#L264-L310).
+///
+/// Returns the `collapsed → target` map plus the groups that still hold
+/// more than one un-collapsed variant, for the next round.
+fn deduplicate_dep_paths(
+    duplicates: &[Vec<DepPath>],
+    graph: &DependenciesGraph,
+) -> (HashMap<DepPath, DepPath>, Vec<Vec<DepPath>>) {
+    // Total order over `(dep count, dep path)`: the dep-count sort alone
+    // is not a total order, so a variant that is a subset of several
+    // incompatible larger variants of equal size would collapse into
+    // whichever the unstable position happened to surface first. The
+    // dep-path tie-break makes the winner machine-independent
+    // (pnpm/pnpm#12179).
+    let dep_count_sorter = |dep_path1: &DepPath, dep_path2: &DepPath| {
+        node_deps_count(&graph[dep_path1])
+            .cmp(&node_deps_count(&graph[dep_path2]))
+            .then_with(|| dep_path1.cmp(dep_path2))
+    };
+
+    let mut dep_paths_map: HashMap<DepPath, DepPath> = HashMap::new();
+    let mut remaining_duplicates: Vec<Vec<DepPath>> = Vec::new();
+
+    for dep_paths in duplicates {
+        let mut unresolved: HashSet<DepPath> = dep_paths.iter().cloned().collect();
+        let mut current = dep_paths.clone();
+        current.sort_by(dep_count_sorter);
+
+        while let Some(largest) = current.pop() {
+            let mut next = Vec::new();
+            while let Some(candidate) = current.pop() {
+                if is_compatible_and_has_more_deps(graph, &largest, &candidate) {
+                    dep_paths_map.insert(candidate.clone(), largest.clone());
+                    unresolved.remove(&largest);
+                    unresolved.remove(&candidate);
+                } else {
+                    next.push(candidate);
+                }
+            }
+            current = next;
+            current.sort_by(dep_count_sorter);
+        }
+
+        if !unresolved.is_empty() {
+            let mut leftover: Vec<DepPath> = unresolved.into_iter().collect();
+            leftover.sort();
+            remaining_duplicates.push(leftover);
+        }
+    }
+
+    (dep_paths_map, remaining_duplicates)
+}
+
+/// Number of edges a variant carries: its child dependencies plus the
+/// peers it resolved against its ancestors. Mirrors upstream's
+/// [`nodeDepsCount`](https://github.com/pnpm/pnpm/blob/7f91ba4045/installing/deps-resolver/src/resolvePeers.ts#L231-L233).
+fn node_deps_count(node: &DependenciesGraphNode) -> usize {
+    node.children.len() + node.resolved_peer_names.len()
+}
+
+/// Whether `larger` can absorb `smaller`: it must have at least as many
+/// deps, every one of `smaller`'s child depPaths must appear among
+/// `larger`'s children, and every peer `smaller` resolved must also be
+/// resolved by `larger`. Mirrors upstream's
+/// [`isCompatibleAndHasMoreDeps`](https://github.com/pnpm/pnpm/blob/7f91ba4045/installing/deps-resolver/src/resolvePeers.ts#L312-L329).
+fn is_compatible_and_has_more_deps(
+    graph: &DependenciesGraph,
+    larger: &DepPath,
+    smaller: &DepPath,
+) -> bool {
+    let larger_node = &graph[larger];
+    let smaller_node = &graph[smaller];
+    if node_deps_count(larger_node) < node_deps_count(smaller_node) {
+        return false;
+    }
+
+    let larger_children: HashSet<&DepPath> = larger_node.children.values().collect();
+    if !smaller_node.children.values().all(|child| larger_children.contains(child)) {
+        return false;
+    }
+
+    smaller_node
+        .resolved_peer_names
+        .iter()
+        .all(|peer| larger_node.resolved_peer_names.contains(peer))
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/resolving-deps-resolver/src/dedupe_peer_dependents/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/dedupe_peer_dependents/tests.rs
@@ -1,0 +1,208 @@
+use super::{DirectByImporter, dedupe_peer_dependents, deduplicate_dep_paths};
+use crate::dependencies_graph::{DependenciesGraph, DependenciesGraphNode};
+use pacquet_deps_path::DepPath;
+use pacquet_lockfile::{DirectoryResolution, LockfileResolution};
+use pacquet_resolving_resolver_base::{PkgResolutionId, ResolveResult};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
+
+fn dp(raw: &str) -> DepPath {
+    DepPath::from(raw.to_string())
+}
+
+fn make_node(
+    pkg_id: &str,
+    dep_path: &str,
+    children: &[(&str, &str)],
+    resolved_peers: &[&str],
+) -> DependenciesGraphNode {
+    DependenciesGraphNode {
+        dep_path: dp(dep_path),
+        resolved_package_id: pkg_id.to_string(),
+        resolve_result: Arc::new(ResolveResult {
+            id: PkgResolutionId::from(pkg_id.to_string()),
+            name_ver: None,
+            latest: None,
+            published_at: None,
+            manifest: None,
+            resolution: LockfileResolution::Directory(DirectoryResolution {
+                directory: "stub".to_string(),
+            }),
+            resolved_via: "registry".to_string(),
+            normalized_bare_specifier: None,
+            alias: None,
+            policy_violation: None,
+        }),
+        children: children.iter().map(|(alias, child)| (alias.to_string(), dp(child))).collect(),
+        peer_dependencies: BTreeMap::new(),
+        transitive_peer_dependencies: HashSet::new(),
+        resolved_peer_names: resolved_peers.iter().map(|peer| peer.to_string()).collect(),
+        depth: 0,
+        installable: true,
+        is_pure: resolved_peers.is_empty(),
+        optional: false,
+    }
+}
+
+const SUBSET: &str = "foo@1.0.0(bar@1.0.0)";
+const BAZ_VARIANT: &str = "foo@1.0.0(bar@1.0.0)(baz@1.0.0)";
+const QUX_VARIANT: &str = "foo@1.0.0(bar@1.0.0)(qux@1.0.0)";
+
+/// `foo` resolved into three peer-suffixed variants: `foo(bar)`,
+/// `foo(bar)(baz)`, and `foo(bar)(qux)`. The subset `foo(bar)` is a
+/// subset of both larger variants, which are incompatible with each
+/// other, so the collapse target is a real choice.
+fn build_graph() -> DependenciesGraph {
+    let mut graph = DependenciesGraph::new();
+    for (id, dep_path) in
+        [("bar@1.0.0", "bar@1.0.0"), ("baz@1.0.0", "baz@1.0.0"), ("qux@1.0.0", "qux@1.0.0")]
+    {
+        graph.insert(dp(dep_path), make_node(id, dep_path, &[], &[]));
+    }
+    graph.insert(dp(SUBSET), make_node("foo@1.0.0", SUBSET, &[("bar", "bar@1.0.0")], &["bar"]));
+    graph.insert(
+        dp(BAZ_VARIANT),
+        make_node(
+            "foo@1.0.0",
+            BAZ_VARIANT,
+            &[("bar", "bar@1.0.0"), ("baz", "baz@1.0.0")],
+            &["bar", "baz"],
+        ),
+    );
+    graph.insert(
+        dp(QUX_VARIANT),
+        make_node(
+            "foo@1.0.0",
+            QUX_VARIANT,
+            &[("bar", "bar@1.0.0"), ("qux", "qux@1.0.0")],
+            &["bar", "qux"],
+        ),
+    );
+    graph
+}
+
+/// The subset variant must collapse into the same larger variant no
+/// matter the order the two equal-sized larger variants are presented in
+/// — the determinism guarantee the total-order tie-break exists to
+/// provide. Without the dep-path tie-break, swapping the two would flip
+/// which one wins the collapse (pnpm/pnpm#12179).
+#[test]
+fn collapse_target_is_independent_of_variant_order() {
+    let graph = build_graph();
+
+    let (baz_first, _) =
+        deduplicate_dep_paths(&[vec![dp(SUBSET), dp(BAZ_VARIANT), dp(QUX_VARIANT)]], &graph);
+    let (qux_first, _) =
+        deduplicate_dep_paths(&[vec![dp(SUBSET), dp(QUX_VARIANT), dp(BAZ_VARIANT)]], &graph);
+
+    // `foo(bar)(qux)` wins because it is the lexically-greater of the two
+    // equal-count variants and the sorter pops the greatest first.
+    assert_eq!(baz_first.get(&dp(SUBSET)), Some(&dp(QUX_VARIANT)));
+    assert_eq!(baz_first.get(&dp(SUBSET)), qux_first.get(&dp(SUBSET)));
+}
+
+/// End to end over [`dedupe_peer_dependents`]: an importer that resolved
+/// `foo` to the subset variant has its direct dep rewritten to the
+/// collapse target, and the now-orphaned subset snapshot is pruned from
+/// the graph while both larger variants remain.
+#[test]
+fn rewrites_importer_direct_dep_and_prunes_orphan() {
+    let mut graph = build_graph();
+    let mut direct: DirectByImporter = BTreeMap::new();
+    direct.insert("project-subset".to_string(), BTreeMap::from([("foo".to_string(), dp(SUBSET))]));
+    direct
+        .insert("project-baz".to_string(), BTreeMap::from([("foo".to_string(), dp(BAZ_VARIANT))]));
+    direct
+        .insert("project-qux".to_string(), BTreeMap::from([("foo".to_string(), dp(QUX_VARIANT))]));
+
+    dedupe_peer_dependents(&mut graph, &mut direct);
+
+    assert_eq!(direct["project-subset"]["foo"], dp(QUX_VARIANT));
+    assert_eq!(direct["project-baz"]["foo"], dp(BAZ_VARIANT));
+    assert_eq!(direct["project-qux"]["foo"], dp(QUX_VARIANT));
+    assert!(!graph.contains_key(&dp(SUBSET)), "collapsed variant should be pruned");
+    assert!(graph.contains_key(&dp(BAZ_VARIANT)));
+    assert!(graph.contains_key(&dp(QUX_VARIANT)));
+}
+
+/// Port of pnpm's `packages are not deduplicated when versions do not
+/// match`
+/// ([dedupeDepPaths.test.ts](https://github.com/pnpm/pnpm/blob/7f91ba4045/installing/deps-resolver/test/dedupeDepPaths.test.ts#L8)).
+/// `foo` has an optional `baz` peer and a required `bar` peer pinned to
+/// two different majors. The variant without `baz` collapses into the
+/// one with `baz` *of the same `bar` major*, but never across `bar`
+/// majors — so the two majors stay distinct.
+#[test]
+fn does_not_collapse_across_incompatible_peer_versions() {
+    let bar1 = "foo@1.0.0(bar@1.0.0)";
+    let bar1_baz = "foo@1.0.0(bar@1.0.0)(baz@1.0.0)";
+    let bar2 = "foo@1.0.0(bar@2.0.0)";
+    let bar2_baz = "foo@1.0.0(bar@2.0.0)(baz@2.0.0)";
+
+    let mut graph = DependenciesGraph::new();
+    for (id, dep_path) in [
+        ("bar@1.0.0", "bar@1.0.0"),
+        ("bar@2.0.0", "bar@2.0.0"),
+        ("baz@1.0.0", "baz@1.0.0"),
+        ("baz@2.0.0", "baz@2.0.0"),
+    ] {
+        graph.insert(dp(dep_path), make_node(id, dep_path, &[], &[]));
+    }
+    graph.insert(dp(bar1), make_node("foo@1.0.0", bar1, &[("bar", "bar@1.0.0")], &["bar"]));
+    graph.insert(dp(bar2), make_node("foo@1.0.0", bar2, &[("bar", "bar@2.0.0")], &["bar"]));
+    graph.insert(
+        dp(bar1_baz),
+        make_node(
+            "foo@1.0.0",
+            bar1_baz,
+            &[("bar", "bar@1.0.0"), ("baz", "baz@1.0.0")],
+            &["bar", "baz"],
+        ),
+    );
+    graph.insert(
+        dp(bar2_baz),
+        make_node(
+            "foo@1.0.0",
+            bar2_baz,
+            &[("bar", "bar@2.0.0"), ("baz", "baz@2.0.0")],
+            &["bar", "baz"],
+        ),
+    );
+
+    let mut direct: DirectByImporter = BTreeMap::new();
+    direct.insert("project1".to_string(), BTreeMap::from([("foo".to_string(), dp(bar1))]));
+    direct.insert("project2".to_string(), BTreeMap::from([("foo".to_string(), dp(bar1_baz))]));
+    direct.insert("project3".to_string(), BTreeMap::from([("foo".to_string(), dp(bar2))]));
+    direct.insert("project4".to_string(), BTreeMap::from([("foo".to_string(), dp(bar2_baz))]));
+
+    dedupe_peer_dependents(&mut graph, &mut direct);
+
+    assert_eq!(direct["project1"]["foo"], direct["project2"]["foo"]);
+    assert_ne!(direct["project1"]["foo"], direct["project3"]["foo"]);
+    assert_eq!(direct["project3"]["foo"], direct["project4"]["foo"]);
+}
+
+/// A package whose two variants are mutually incompatible (neither's
+/// children/peers subset the other) must not collapse — both survive and
+/// no remap happens.
+#[test]
+fn incompatible_variants_do_not_collapse() {
+    let mut graph = build_graph();
+    // Drop the subset so only the two incompatible variants remain.
+    graph.remove(&dp(SUBSET));
+
+    let mut direct: DirectByImporter = BTreeMap::new();
+    direct
+        .insert("project-baz".to_string(), BTreeMap::from([("foo".to_string(), dp(BAZ_VARIANT))]));
+    direct
+        .insert("project-qux".to_string(), BTreeMap::from([("foo".to_string(), dp(QUX_VARIANT))]));
+
+    dedupe_peer_dependents(&mut graph, &mut direct);
+
+    assert_eq!(direct["project-baz"]["foo"], dp(BAZ_VARIANT));
+    assert_eq!(direct["project-qux"]["foo"], dp(QUX_VARIANT));
+    assert!(graph.contains_key(&dp(BAZ_VARIANT)));
+    assert!(graph.contains_key(&dp(QUX_VARIANT)));
+}

--- a/pacquet/crates/resolving-deps-resolver/src/lib.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/lib.rs
@@ -65,6 +65,7 @@
 //!   `pacquet-lockfile-preferred-versions` crate.
 
 mod dedupe_injected_deps;
+mod dedupe_peer_dependents;
 mod dependencies_graph;
 mod hoist_peers;
 mod lockfile_reuse;

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -43,6 +43,7 @@
 
 use crate::{
     dedupe_injected_deps::dedupe_injected_deps,
+    dedupe_peer_dependents::dedupe_peer_dependents,
     dependencies_graph::{
         DependenciesGraph, DependenciesGraphNode, MissingPeer, ParentPackageRef,
         PeerDependencyIssue, PeerDependencyIssues,
@@ -225,6 +226,7 @@ pub fn resolve_peers_workspace(
     importers: &[ImporterPeerInput],
     lockfile_dir: &Path,
     dedupe_injected_deps_enabled: bool,
+    dedupe_peer_dependents_enabled: bool,
     opts: ResolvePeersOptions,
 ) -> WorkspaceResolvePeersResult {
     let mut walker = Walker {
@@ -277,6 +279,13 @@ pub fn resolve_peers_workspace(
             &importer_root_dirs,
             lockfile_dir,
         );
+    }
+
+    // Runs after the injected-deps dedupe (matching upstream's ordering)
+    // so a `file:`→`link:` rewrite is already reflected in the graph
+    // before peer-dependent variants collapse.
+    if dedupe_peer_dependents_enabled {
+        dedupe_peer_dependents(&mut graph, &mut direct_dependencies_by_importer);
     }
 
     WorkspaceResolvePeersResult {

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -51,6 +51,12 @@ pub struct WorkspaceResolveOptions {
     /// snapshot's children are a subset of the target project's own
     /// direct deps.
     pub dedupe_injected_deps: bool,
+    /// `true` enables [`fn@crate::resolve_peers_workspace`]'s peer-
+    /// dependent dedupe pass — peer-suffixed variants of one package
+    /// that are a subset of a larger compatible variant collapse into
+    /// it. Mirrors pnpm's `dedupePeerDependents` setting (default
+    /// `true`).
+    pub dedupe_peer_dependents: bool,
     /// Threaded into [`ResolvePeersOptions::exclude_links_from_lockfile`]
     /// for the workspace-wide peer pass. Per-importer
     /// [`ResolvePeersOptions::modules_dir`] comes from each
@@ -134,6 +140,7 @@ where
     let WorkspaceResolveOptions {
         dedupe_peers,
         dedupe_injected_deps,
+        dedupe_peer_dependents,
         exclude_links_from_lockfile,
         lockfile_dir,
         peers_suffix_max_length,
@@ -227,6 +234,7 @@ where
         &per_importer_inputs,
         &lockfile_dir,
         dedupe_injected_deps,
+        dedupe_peer_dependents,
         peer_opts,
     );
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -127,6 +127,7 @@ fn workspace_opts(pick_lowest_direct: bool, time_based: bool) -> WorkspaceResolv
     WorkspaceResolveOptions {
         dedupe_peers: false,
         dedupe_injected_deps: false,
+        dedupe_peer_dependents: false,
         exclude_links_from_lockfile: false,
         lockfile_dir: std::path::PathBuf::from("/lockfile-dir"),
         peers_suffix_max_length: 1000,


### PR DESCRIPTION
## Problem

`pnpm dedupe` deduplicates peer-dependent packages: when the same package resolves into several variants that differ only by their peer suffix, it collapses the smaller variants into a compatible larger one. The variant a given subset collapses into is **not deterministic** — it depends on the order importers happen to be resolved in, which differs between platforms (and V8 versions). As a result the same workspace can resolve to different lockfiles on different machines, and `pnpm dedupe --check` can pass on one machine and fail on another for an unchanged workspace.

### Where it happens

The peer-dependent dedupe runs in `resolvePeers`, over the duplicate variants collected per package id:

- The duplicates are read straight off a `Map<PkgIdWithPatchHash, Set<DepPath>>`: [`resolvePeers.ts#L214-L222`](https://github.com/pnpm/pnpm/blob/69cfcb7417/installing/deps-resolver/src/resolvePeers.ts#L214-L222).
- That set is populated in resolution order — each variant is `add`ed as it is resolved: [`resolvePeers.ts#L667-L671`](https://github.com/pnpm/pnpm/blob/69cfcb7417/installing/deps-resolver/src/resolvePeers.ts#L667-L671). Iterating importers in a different order inserts the variants in a different order.

The collapse itself is `deduplicateDepPaths` ([`resolvePeers.ts#L264-L301`](https://github.com/pnpm/pnpm/blob/69cfcb7417/installing/deps-resolver/src/resolvePeers.ts#L264-L301)). It sorts the variants by dependency count and greedily collapses each compatible smaller variant into the current largest one:

```ts
const depCountSorter = (depPath1: DepPath, depPath2: DepPath) =>
  nodeDepsCount(depGraph[depPath1]) - nodeDepsCount(depGraph[depPath2])
...
let currentDepPaths = [...depPaths].sort(depCountSorter)
while (currentDepPaths.length) {
  const depPath1 = currentDepPaths.pop()!        // largest by dep count
  ...
    if (isCompatibleAndHasMoreDeps(depGraph, depPath1, depPath2)) {
      depPathsMap[depPath2] = depPath1            // collapse depPath2 -> depPath1
```

- `depCountSorter`: [`resolvePeers.ts#L268`](https://github.com/pnpm/pnpm/blob/69cfcb7417/installing/deps-resolver/src/resolvePeers.ts#L268)
- greedy collapse loop: [`resolvePeers.ts#L272-L291`](https://github.com/pnpm/pnpm/blob/69cfcb7417/installing/deps-resolver/src/resolvePeers.ts#L272-L291)
- `nodeDepsCount`: [`resolvePeers.ts#L231-L233`](https://github.com/pnpm/pnpm/blob/69cfcb7417/installing/deps-resolver/src/resolvePeers.ts#L231-L233)
- `isCompatibleAndHasMoreDeps`: [`resolvePeers.ts#L303-L320`](https://github.com/pnpm/pnpm/blob/69cfcb7417/installing/deps-resolver/src/resolvePeers.ts#L303-L320)

### Why the result is order-dependent

`depCountSorter` compares only the dependency count, so it is **not a total order**: two variants with the same count are treated as equal and `Array.prototype.sort` (stable) leaves them in their original — insertion-order — position. `[...depPaths]` takes that order from the `Set`, which was filled in resolution order.

That only matters when a variant is a subset of **two or more mutually incompatible larger variants of equal size**, because then there is a real choice of collapse target. Concretely, take a package `foo` with three optional peers `bar`, `baz`, `qux`, consumed by three importers:

| importer | resolved variant | dep count |
| --- | --- | --- |
| A | `foo(bar)` | 1 |
| B | `foo(bar)(baz)` | 2 |
| C | `foo(bar)(qux)` | 2 |

`foo(bar)` is a subset of both `foo(bar)(baz)` and `foo(bar)(qux)`, which are incompatible with each other. The dedupe pops the highest-count variant first and collapses `foo(bar)` into it:

- importers resolved in order A, B, C → set is `{foo(bar), foo(bar)(baz), foo(bar)(qux)}` → pops `foo(bar)(qux)` first → **A collapses to `foo(bar)(qux)`**.
- importers resolved in order A, C, B → set is `{foo(bar), foo(bar)(qux), foo(bar)(baz)}` → pops `foo(bar)(baz)` first → **A collapses to `foo(bar)(baz)`**.

Same inputs, different lockfile.

Note this is specifically the *choice of collapse target*, not peer-suffix ordering. The suffix string itself is already order-independent because [`createPeerDepGraphHash`](https://github.com/pnpm/pnpm/blob/69cfcb7417/deps/path/src/index.ts#L197-L213) sorts the peer ids before joining ([`deps/path/src/index.ts#L208`](https://github.com/pnpm/pnpm/blob/69cfcb7417/deps/path/src/index.ts#L208)). The non-determinism here is entirely in which variant wins the collapse.

### Symptom

A workspace with this shape (a package that picks up a peer-of-a-peer in some importers but not others, where the partial variant can collapse into more than one fuller variant) resolves to different `pnpm-lock.yaml` outputs on different platforms. CI that runs `pnpm dedupe --check` then flips between passing and failing depending on which machine generated the committed lockfile vs. which machine runs the check.

## Fix

Make `depCountSorter` a total order by tie-breaking equal dependency counts on the dep path string. The chosen collapse target is then the same regardless of the set's insertion order, so the dedupe result no longer depends on importer/resolution order.

```ts
const depCountSorter = (depPath1: DepPath, depPath2: DepPath) => {
  const countDiff = nodeDepsCount(depGraph[depPath1]) - nodeDepsCount(depGraph[depPath2])
  if (countDiff !== 0) return countDiff
  return depPath1 < depPath2 ? -1 : depPath1 > depPath2 ? 1 : 0
}
```

## Test

Added a unit test in `installing/deps-resolver/test/dedupeDepPaths.test.ts` that builds the three-importer scenario above and resolves it twice with the two larger importers swapped, asserting the subset variant collapses to the same target both times. Before the fix the two runs return `foo(bar)(baz)` and `foo(bar)(qux)`; after the fix they agree.

## Notes

This bug lives in the `dedupePeerDependents` collapse, which the Rust port under `pacquet/` has not yet ported (its `resolve_peers_workspace` only runs the injected-deps dedupe), so there is no matching change there. When that pass is ported, the sorter should carry the same total-order tie-break.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional workspace-level deduplication step for peer-dependent variants.

* **Bug Fixes**
  * Peer-dependent deduplication now produces deterministic outcomes across platforms and importer ordering, preventing inconsistent lockfiles and `pnpm dedupe --check` mismatches.

* **Tests**
  * Added tests verifying deterministic deduplication behavior regardless of importer order.

* **Documentation**
  * Updated release notes documenting the deterministic peer deduplication patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->