### PR TITLE
fix(deploy): avoid hard-linking workspace deps to source

### DIFF
--- a/.changeset/fresh-shoes-deploy.md
+++ b/.changeset/fresh-shoes-deploy.md
@@ -1,0 +1,10 @@
+---
+"pnpm": patch
+"@pnpm/fetching.directory-fetcher": patch
+"@pnpm/fetching.fetcher-base": patch
+"@pnpm/installing.client": patch
+"@pnpm/releasing.commands": patch
+"@pnpm/store.connection-manager": patch
+---
+
+Fix `pnpm deploy` from shared lockfiles so deployed workspace package dependencies are cloned or copied instead of hard-linked back to the original workspace source files.

--- a/fetching/directory-fetcher/src/index.ts
+++ b/fetching/directory-fetcher/src/index.ts
@@ -3,7 +3,11 @@ import path from 'node:path'
 import util from 'node:util'
 
 import { pkgRequiresBuild } from '@pnpm/building.pkg-requires-build'
-import type { DirectoryFetcher, DirectoryFetcherOptions } from '@pnpm/fetching.fetcher-base'
+import type {
+  DirectoryFetcher,
+  DirectoryFetcherOptions,
+  LocalDirPackageImportMethod,
+} from '@pnpm/fetching.fetcher-base'
 import { packlist } from '@pnpm/fs.packlist'
 import { logger } from '@pnpm/logger'
 import type { FilesMap } from '@pnpm/store.cafs-types'
@@ -14,6 +18,7 @@ const directoryFetcherLogger = logger('directory-fetcher')
 
 export interface CreateDirectoryFetcherOptions {
   includeOnlyPackageFiles?: boolean
+  localDirPackageImportMethod?: LocalDirPackageImportMethod
   resolveSymlinks?: boolean
 }
 
@@ -21,7 +26,10 @@ export function createDirectoryFetcher (
   opts?: CreateDirectoryFetcherOptions
 ): { directory: DirectoryFetcher } {
   const readFileStat: ReadFileStat = opts?.resolveSymlinks === true ? realFileStat : fileStat
-  const fetchFromDir = opts?.includeOnlyPackageFiles ? fetchPackageFilesFromDir : fetchAllFilesFromDir.bind(null, readFileStat)
+  const packageImportMethod = opts?.localDirPackageImportMethod ?? 'hardlink'
+  const fetchFromDir = opts?.includeOnlyPackageFiles
+    ? fetchPackageFilesFromDir.bind(null, packageImportMethod)
+    : fetchAllFilesFromDir.bind(null, readFileStat, packageImportMethod)
 
   const directoryFetcher: DirectoryFetcher = (cafs, resolution, opts) => {
     // Use path.resolve so absolute directories (e.g. cross-drive Windows paths
@@ -42,21 +50,23 @@ export interface FetchResult {
   local: true
   filesMap: FilesMap
   filesStats?: Record<string, Stats | null>
-  packageImportMethod: 'hardlink'
+  packageImportMethod: LocalDirPackageImportMethod
   manifest: DependencyManifest
   requiresBuild: boolean
 }
 
 export async function fetchFromDir (dir: string, opts: FetchFromDirOptions): Promise<FetchResult> {
+  const packageImportMethod = opts.localDirPackageImportMethod ?? 'hardlink'
   if (opts.includeOnlyPackageFiles) {
-    return fetchPackageFilesFromDir(dir)
+    return fetchPackageFilesFromDir(packageImportMethod, dir)
   }
   const readFileStat: ReadFileStat = opts?.resolveSymlinks === true ? realFileStat : fileStat
-  return fetchAllFilesFromDir(readFileStat, dir)
+  return fetchAllFilesFromDir(readFileStat, packageImportMethod, dir)
 }
 
 async function fetchAllFilesFromDir (
   readFileStat: ReadFileStat,
+  packageImportMethod: LocalDirPackageImportMethod,
   dir: string
 ): Promise<FetchResult> {
   const { filesMap, filesStats } = await _fetchAllFilesFromDir(readFileStat, dir)
@@ -69,7 +79,7 @@ async function fetchAllFilesFromDir (
     local: true,
     filesMap,
     filesStats,
-    packageImportMethod: 'hardlink',
+    packageImportMethod,
     manifest,
     requiresBuild,
   }
@@ -147,7 +157,10 @@ async function fileStat (filePath: string): Promise<FileStatResult | null> {
   }
 }
 
-async function fetchPackageFilesFromDir (dir: string): Promise<FetchResult> {
+async function fetchPackageFilesFromDir (
+  packageImportMethod: LocalDirPackageImportMethod,
+  dir: string
+): Promise<FetchResult> {
   const files = await packlist(dir)
   const filesMap = new Map<string, string>(files.map((file) => [file, path.join(dir, file)]))
   // In a regular pnpm workspace it will probably never happen that a dependency has no package.json file.
@@ -158,7 +171,7 @@ async function fetchPackageFilesFromDir (dir: string): Promise<FetchResult> {
   return {
     local: true,
     filesMap,
-    packageImportMethod: 'hardlink',
+    packageImportMethod,
     manifest,
     requiresBuild,
   }

--- a/fetching/directory-fetcher/test/index.ts
+++ b/fetching/directory-fetcher/test/index.ts
@@ -62,6 +62,21 @@ test('fetch including all files', async () => {
   ])
 })
 
+test('fetch can override the local directory package import method', async () => {
+  process.chdir(f.find('simple-pkg'))
+  const fetcher = createDirectoryFetcher({ localDirPackageImportMethod: 'clone-or-copy' })
+
+  // eslint-disable-next-line
+  const fetchResult = await fetcher.directory({} as any, {
+    directory: '.',
+    type: 'directory',
+  }, {
+    lockfileDir: process.cwd(),
+  })
+
+  expect(fetchResult.packageImportMethod).toBe('clone-or-copy')
+})
+
 test('fetch a directory that has no package.json', async () => {
   process.chdir(f.find('no-manifest'))
   const fetcher = createDirectoryFetcher()

--- a/fetching/fetcher-base/src/index.ts
+++ b/fetching/fetcher-base/src/index.ts
@@ -64,10 +64,12 @@ export interface DirectoryFetcherOptions {
   readManifest?: boolean
 }
 
+export type LocalDirPackageImportMethod = 'hardlink' | 'clone-or-copy'
+
 export interface DirectoryFetcherResult {
   local: true
   filesMap: FilesMap
-  packageImportMethod: 'hardlink'
+  packageImportMethod: LocalDirPackageImportMethod
   manifest?: DependencyManifest
   requiresBuild: boolean
 }

--- a/installing/client/src/index.ts
+++ b/installing/client/src/index.ts
@@ -2,7 +2,12 @@ import { NODE_EXTRAS_IGNORE_PATTERN } from '@pnpm/engine.runtime.node-resolver'
 import { PnpmError } from '@pnpm/error'
 import { createBinaryFetcher } from '@pnpm/fetching.binary-fetcher'
 import { createDirectoryFetcher } from '@pnpm/fetching.directory-fetcher'
-import type { BinaryFetcher, DirectoryFetcher, GitFetcher } from '@pnpm/fetching.fetcher-base'
+import type {
+  BinaryFetcher,
+  DirectoryFetcher,
+  GitFetcher,
+  LocalDirPackageImportMethod,
+} from '@pnpm/fetching.fetcher-base'
 import { createGitFetcher } from '@pnpm/fetching.git-fetcher'
 import { createTarballFetcher, type TarballFetchers } from '@pnpm/fetching.tarball-fetcher'
 import type { FetchFromRegistry, GetAuthHeader, RetryTimeoutOptions } from '@pnpm/fetching.types'
@@ -41,6 +46,7 @@ export type ClientOptions = {
   includeOnlyPackageFiles?: boolean
   preserveAbsolutePaths?: boolean
   fetchMinSpeedKiBps?: number
+  localDirPackageImportMethod?: LocalDirPackageImportMethod
 } & ResolverFactoryOptions & DispatcherOptions
   & Pick<ResolutionVerifierFactoryOptions,
   | 'minimumReleaseAge'
@@ -135,13 +141,28 @@ type Fetchers = {
 function createFetchers (
   fetchFromRegistry: FetchFromRegistry,
   getAuthHeader: GetAuthHeader,
-  opts: Pick<ClientOptions, 'retry' | 'gitShallowHosts' | 'resolveSymlinksInInjectedDirs' | 'unsafePerm' | 'userAgent' | 'includeOnlyPackageFiles' | 'offline' | 'fetchMinSpeedKiBps' | 'storeIndex'>
+  opts: Pick<ClientOptions,
+  | 'retry'
+  | 'gitShallowHosts'
+  | 'resolveSymlinksInInjectedDirs'
+  | 'unsafePerm'
+  | 'userAgent'
+  | 'includeOnlyPackageFiles'
+  | 'offline'
+  | 'fetchMinSpeedKiBps'
+  | 'storeIndex'
+  | 'localDirPackageImportMethod'
+  >
 ): Fetchers {
   const tarballFetchers = createTarballFetcher(fetchFromRegistry, getAuthHeader, opts)
   return {
     ...tarballFetchers,
     ...createGitFetcher(opts),
-    ...createDirectoryFetcher({ resolveSymlinks: opts.resolveSymlinksInInjectedDirs, includeOnlyPackageFiles: opts.includeOnlyPackageFiles }),
+    ...createDirectoryFetcher({
+      resolveSymlinks: opts.resolveSymlinksInInjectedDirs,
+      includeOnlyPackageFiles: opts.includeOnlyPackageFiles,
+      localDirPackageImportMethod: opts.localDirPackageImportMethod,
+    }),
     ...createBinaryFetcher({
       fetch: fetchFromRegistry,
       fetchFromRemoteTarball: tarballFetchers.remoteTarball,

--- a/releasing/commands/src/deploy/deploy.ts
+++ b/releasing/commands/src/deploy/deploy.ts
@@ -273,6 +273,7 @@ async function deployFromSharedLockfile (
       rootProjectManifestDir: deployDir,
       dir: deployDir,
       lockfileDir: deployDir,
+      localDirPackageImportMethod: 'clone-or-copy',
       workspaceDir: undefined,
       virtualStoreDir: undefined,
       modulesDir: undefined,

--- a/releasing/commands/test/deploy/shared-lockfile.test.ts
+++ b/releasing/commands/test/deploy/shared-lockfile.test.ts
@@ -47,6 +47,80 @@ function readPackageJson (manifestDir: string): unknown {
   return JSON.parse(manifestText)
 }
 
+test('deploy with a shared lockfile copies workspace package files instead of hard-linking to source', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: {
+        name: 'root',
+        private: true,
+      },
+    },
+    {
+      location: path.join('packages', 'foo'),
+      package: {
+        name: 'foo',
+        version: '1.0.0',
+      },
+    },
+    {
+      location: path.join('packages', 'bar'),
+      package: {
+        name: 'bar',
+        version: '1.0.0',
+        dependencies: {
+          foo: 'workspace:*',
+        },
+      },
+    },
+  ])
+
+  const {
+    allProjects,
+    allProjectsGraph,
+    selectedProjectsGraph,
+  } = await filterProjectsBySelectorObjectsFromDir(process.cwd(), [{ namePattern: 'bar' }])
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    allProjects,
+    allProjectsGraph,
+    selectedProjectsGraph: allProjectsGraph,
+    dir: process.cwd(),
+    recursive: true,
+    lockfileDir: process.cwd(),
+    workspaceDir: process.cwd(),
+  })
+
+  await deploy.handler({
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    dev: false,
+    production: true,
+    recursive: true,
+    selectedProjectsGraph,
+    sharedWorkspaceLockfile: true,
+    lockfileDir: process.cwd(),
+    workspaceDir: process.cwd(),
+  }, [path.resolve('deploy')])
+
+  const virtualStoreDir = path.resolve('deploy', 'node_modules', '.pnpm')
+  const fooName = fs.readdirSync(virtualStoreDir).find(name => name.startsWith('foo@'))
+  expect(fooName).toBeDefined()
+  const deployedFooManifest = path.join(virtualStoreDir, fooName!, 'node_modules', 'foo', 'package.json')
+
+  fs.writeFileSync(path.resolve('packages', 'foo', 'package.json'), JSON.stringify({
+    name: 'foo',
+    version: '9.9.9',
+  }, undefined, 2))
+
+  expect(JSON.parse(fs.readFileSync(deployedFooManifest, 'utf-8'))).toMatchObject({
+    name: 'foo',
+    version: '1.0.0',
+  })
+})
+
 test('deploy with a shared lockfile after full install', async () => {
   const projectNames = ['project-1', 'project-2', 'project-3', 'project-4', 'project-5'] as const
 

--- a/store/connection-manager/src/createNewStoreController.ts
+++ b/store/connection-manager/src/createNewStoreController.ts
@@ -61,7 +61,10 @@ export type CreateNewStoreControllerOptions = CreateResolverOptions & Pick<Confi
   cafsLocker?: CafsLocker
   ignoreFile?: (filename: string) => boolean
   fetchFullMetadata?: boolean
-} & Partial<Pick<Config, 'deployAllFiles' | 'strictStorePkgContentCheck'>> & Pick<ClientOptions, 'resolveSymlinksInInjectedDirs'>
+} & Partial<Pick<Config, 'deployAllFiles' | 'strictStorePkgContentCheck'>> & Pick<ClientOptions,
+| 'localDirPackageImportMethod'
+| 'resolveSymlinksInInjectedDirs'
+>
 
 export async function createNewStoreController (
   opts: CreateNewStoreControllerOptions
@@ -114,6 +117,7 @@ export async function createNewStoreController (
     ),
     gitShallowHosts: opts.gitShallowHosts,
     resolveSymlinksInInjectedDirs: opts.resolveSymlinksInInjectedDirs,
+    localDirPackageImportMethod: opts.localDirPackageImportMethod,
     includeOnlyPackageFiles: !opts.deployAllFiles,
     saveWorkspaceProtocol: opts.saveWorkspaceProtocol,
     preserveAbsolutePaths: opts.preserveAbsolutePaths,


### PR DESCRIPTION
## Summary

- Fix `pnpm deploy` from shared lockfiles so deployed workspace package dependencies are cloned or copied instead of hard-linked back to the original workspace source files.
- Set the inner deploy install to use `clone-or-copy` for package imports, keeping the deploy output self-contained.
- Make an explicit store-level `packageImportMethod` override local directory fetcher defaults such as the `hardlink` hint.

Closes #12176.

## Test plan

- [x] `pnpm --filter @pnpm/releasing.commands test test/deploy/shared-lockfile.test.ts` — passed, 10 tests
- [x] `pnpm --filter @pnpm/store.create-cafs-store test` — passed
- [x] `git diff --check` — passed

## Notes

The default install behavior is unchanged when `packageImportMethod` is not set. This only changes precedence when an import method is explicitly provided, which `deploy` now uses to avoid hard-linking local workspace package files into the deploy directory.

## AI assistance

OpenAI Codex helped reproduce the deploy hard-linking issue and draft the patch. I reviewed the diff, checked the package import method precedence change, reran the tests above, and take responsibility for the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm deploy` with shared lockfiles to properly handle workspace package dependencies. Deployed packages are now copied or cloned instead of hard-linked to source files, ensuring deployed artifacts remain independent and isolated from the original workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->