### PR TITLE
feat(pnpr): forward uplink auth token and custom headers to upstreams

### DIFF
--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -9,6 +9,7 @@ use pacquet_env_replace::{EnvVar, SystemEnv, env_replace_lossy};
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderName, HeaderValue};
 use serde::Deserialize;
 use std::{
+    fmt,
     net::SocketAddr,
     path::{Path, PathBuf},
     sync::Arc,
@@ -323,12 +324,33 @@ impl LogLevel {
 /// parse-time shape lives in `UplinkFile`; `resolve_uplink` turns
 /// one into the other. Verdaccio fields pnpr doesn't model yet
 /// (timeouts, agent options, `maxage`) are accepted and dropped.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct UplinkConfig {
     pub url: String,
     /// Auth + custom headers, fully resolved and ready to attach to
     /// every request pnpr makes to this uplink.
     pub headers: HeaderMap,
+}
+
+impl fmt::Debug for UplinkConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UplinkConfig")
+            .field("url", &self.url)
+            .field("headers", &RedactedHeaders(&self.headers))
+            .finish()
+    }
+}
+
+/// Wraps a [`HeaderMap`] so its `Debug` lists header names with values
+/// redacted. Uplink headers carry credentials (an `Authorization`, or
+/// an API key in a custom header), and those must never reach a log
+/// line, span, or diagnostic dump.
+pub(crate) struct RedactedHeaders<'a>(pub(crate) &'a HeaderMap);
+
+impl fmt::Debug for RedactedHeaders<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map().entries(self.0.keys().map(|name| (name.as_str(), "<redacted>"))).finish()
+    }
 }
 
 /// Disk shape of one `uplinks:` entry. Mirrors verdaccio's uplink

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -320,7 +320,7 @@ impl LogLevel {
 /// [`Self::headers`] is resolved once, at config load, from the YAML
 /// `auth:` block (an `Authorization` header derived from
 /// `type`/`token`/`token_env`) merged with the `headers:` map. The
-/// parse-time shape lives in [`UplinkFile`]; [`resolve_uplink`] turns
+/// parse-time shape lives in `UplinkFile`; `resolve_uplink` turns
 /// one into the other. Verdaccio fields pnpr doesn't model yet
 /// (timeouts, agent options, `maxage`) are accepted and dropped.
 #[derive(Debug, Clone)]
@@ -412,7 +412,7 @@ fn resolve_uplink<Sys: EnvVar>(
             resolve_uplink_token::<Sys>(auth).ok_or_else(|| RegistryError::InvalidConfig {
                 reason: format!(
                     "uplink {name:?} has an auth block but no token could be resolved \
-                     (set auth.token or point auth.token_env at a set env var)"
+                     (set auth.token or point auth.token_env at a set env var)",
                 ),
             })?;
         let value = match auth.r#type {

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -465,10 +465,14 @@ fn resolve_uplink<Sys: EnvVar>(
 /// `token` wins; otherwise read the env var named by `token_env`.
 fn resolve_uplink_token<Sys: EnvVar>(auth: &UplinkAuthFile) -> Option<String> {
     if let Some(token) = &auth.token {
-        return Some(token.clone());
+        return non_empty_token(token);
     }
     let var_name = auth.token_env.as_ref()?.var_name()?;
-    Sys::var(var_name)
+    Sys::var(var_name).and_then(|token| non_empty_token(&token))
+}
+
+fn non_empty_token(token: &str) -> Option<String> {
+    (!token.trim().is_empty()).then(|| token.to_string())
 }
 
 /// Per-package routing and access rules. `access` / `publish` are

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 use indexmap::IndexMap;
 use object_store::ObjectStore;
-use pacquet_env_replace::{SystemEnv, env_replace_lossy};
+use pacquet_env_replace::{EnvVar, SystemEnv, env_replace_lossy};
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderName, HeaderValue};
 use serde::Deserialize;
 use std::{
     net::SocketAddr,
@@ -313,12 +314,139 @@ impl LogLevel {
     }
 }
 
-/// Verdaccio-shaped uplink declaration. Only `url` is honored —
-/// other fields verdaccio supports (auth headers, timeouts, agent
-/// options) are not implemented yet.
-#[derive(Debug, Clone, Deserialize)]
+/// Runtime uplink declaration: the upstream `url` plus the request
+/// headers pnpr attaches to every fetch it makes to that uplink.
+///
+/// [`Self::headers`] is resolved once, at config load, from the YAML
+/// `auth:` block (an `Authorization` header derived from
+/// `type`/`token`/`token_env`) merged with the `headers:` map. The
+/// parse-time shape lives in [`UplinkFile`]; [`resolve_uplink`] turns
+/// one into the other. Verdaccio fields pnpr doesn't model yet
+/// (timeouts, agent options, `maxage`) are accepted and dropped.
+#[derive(Debug, Clone)]
 pub struct UplinkConfig {
     pub url: String,
+    /// Auth + custom headers, fully resolved and ready to attach to
+    /// every request pnpr makes to this uplink.
+    pub headers: HeaderMap,
+}
+
+/// Disk shape of one `uplinks:` entry. Mirrors verdaccio's uplink
+/// config for the subset pnpr implements: `url`, an `auth:` block,
+/// and a free-form `headers:` map. Resolved into [`UplinkConfig`] by
+/// [`resolve_uplink`].
+#[derive(Debug, Deserialize)]
+struct UplinkFile {
+    url: String,
+    #[serde(default)]
+    auth: Option<UplinkAuthFile>,
+    #[serde(default)]
+    headers: IndexMap<String, String>,
+}
+
+/// The YAML `auth:` block on an uplink. `token` takes priority over
+/// `token_env`; either resolves to the credential placed in the
+/// `Authorization` header, encoded per [`UplinkAuthType`].
+#[derive(Debug, Deserialize)]
+struct UplinkAuthFile {
+    r#type: UplinkAuthType,
+    #[serde(default)]
+    token: Option<String>,
+    #[serde(default)]
+    token_env: Option<TokenEnv>,
+}
+
+/// How the resolved token is encoded into the `Authorization` header:
+/// `bearer` → `Bearer <token>`, `basic` → `Basic <token>` (the token
+/// is used verbatim, matching verdaccio's assumption that a `basic`
+/// token is already a base64 `user:pass`).
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum UplinkAuthType {
+    Bearer,
+    Basic,
+}
+
+/// Verdaccio's `token_env`: either the boolean `true` (read the
+/// default `NPM_TOKEN` env var) or a string naming the env var to
+/// read. `false` reads nothing.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum TokenEnv {
+    Flag(bool),
+    Named(String),
+}
+
+impl TokenEnv {
+    /// Default env var name verdaccio reads for `token_env: true`.
+    const DEFAULT_VAR: &'static str = "NPM_TOKEN";
+
+    /// The env var name to read, or `None` for `token_env: false`.
+    fn var_name(&self) -> Option<&str> {
+        match self {
+            TokenEnv::Flag(true) => Some(Self::DEFAULT_VAR),
+            TokenEnv::Flag(false) => None,
+            TokenEnv::Named(name) => Some(name),
+        }
+    }
+}
+
+/// Resolve one parsed [`UplinkFile`] into a runtime [`UplinkConfig`],
+/// baking the `auth:` credential and `headers:` map into a single
+/// [`HeaderMap`]. Reads env vars (for `token_env`) through `Sys` so
+/// the resolution is testable.
+///
+/// The auth-derived `Authorization` header is inserted first, then the
+/// custom `headers:` are merged on top — so a custom `Authorization`
+/// entry overrides the one derived from `auth:`, matching verdaccio's
+/// merge order. A configured `auth:` block that resolves to no token,
+/// an unknown header name, or a non-ASCII header value is a config
+/// error rather than a silent unauthenticated request.
+fn resolve_uplink<Sys: EnvVar>(
+    name: &str,
+    file: UplinkFile,
+) -> Result<UplinkConfig, RegistryError> {
+    let mut headers = HeaderMap::new();
+    if let Some(auth) = &file.auth {
+        let token =
+            resolve_uplink_token::<Sys>(auth).ok_or_else(|| RegistryError::InvalidConfig {
+                reason: format!(
+                    "uplink {name:?} has an auth block but no token could be resolved \
+                     (set auth.token or point auth.token_env at a set env var)"
+                ),
+            })?;
+        let value = match auth.r#type {
+            UplinkAuthType::Bearer => format!("Bearer {token}"),
+            UplinkAuthType::Basic => format!("Basic {token}"),
+        };
+        let value = HeaderValue::from_str(&value).map_err(|_| RegistryError::InvalidConfig {
+            reason: format!("uplink {name:?} auth token is not a valid header value"),
+        })?;
+        headers.insert(AUTHORIZATION, value);
+    }
+    for (raw_name, raw_value) in &file.headers {
+        let header_name = HeaderName::from_bytes(raw_name.as_bytes()).map_err(|_| {
+            RegistryError::InvalidConfig {
+                reason: format!("uplink {name:?} has an invalid header name {raw_name:?}"),
+            }
+        })?;
+        let header_value =
+            HeaderValue::from_str(raw_value).map_err(|_| RegistryError::InvalidConfig {
+                reason: format!("uplink {name:?} header {raw_name:?} has an invalid value"),
+            })?;
+        headers.insert(header_name, header_value);
+    }
+    Ok(UplinkConfig { url: file.url, headers })
+}
+
+/// Pick the credential for an uplink's `auth:` block: an explicit
+/// `token` wins; otherwise read the env var named by `token_env`.
+fn resolve_uplink_token<Sys: EnvVar>(auth: &UplinkAuthFile) -> Option<String> {
+    if let Some(token) = &auth.token {
+        return Some(token.clone());
+    }
+    let var_name = auth.token_env.as_ref()?.var_name()?;
+    Sys::var(var_name)
 }
 
 /// Per-package routing and access rules. `access` / `publish` are
@@ -384,7 +512,7 @@ struct ConfigFile {
     #[serde(default)]
     backend: Option<BackendFile>,
     #[serde(default)]
-    uplinks: IndexMap<String, UplinkConfig>,
+    uplinks: IndexMap<String, UplinkFile>,
     #[serde(default)]
     packages: IndexMap<String, PackageAccess>,
     #[serde(default)]
@@ -468,7 +596,10 @@ impl Config {
         let mut uplinks = IndexMap::new();
         uplinks.insert(
             "npmjs".to_string(),
-            UplinkConfig { url: "https://registry.npmjs.org".to_string() },
+            UplinkConfig {
+                url: "https://registry.npmjs.org".to_string(),
+                headers: HeaderMap::new(),
+            },
         );
         let mut packages = IndexMap::new();
         packages.insert(
@@ -643,12 +774,20 @@ impl Config {
         let auth = build_auth_config(&file.auth, base_dir);
         let logs = build_log_config(file.log.as_ref());
         let policies = build_policies(&file.packages)?;
+        let uplinks = file
+            .uplinks
+            .into_iter()
+            .map(|(name, uplink)| {
+                let resolved = resolve_uplink::<SystemEnv>(&name, uplink)?;
+                Ok((name, resolved))
+            })
+            .collect::<Result<IndexMap<_, _>, RegistryError>>()?;
         Ok(Self {
             listen,
             public_url,
             storage,
             cache_storage,
-            uplinks: file.uplinks,
+            uplinks,
             packages: file.packages,
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
             policies,

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML, HostedStoreConfig, LogFormat,
-    LogLevel, TokenEnv, UplinkAuthFile, UplinkAuthType, UplinkFile, config_file_in, pattern_matches,
-    resolve_relative, resolve_uplink,
+    LogLevel, TokenEnv, UplinkAuthFile, UplinkAuthType, UplinkFile, config_file_in,
+    pattern_matches, resolve_relative, resolve_uplink,
 };
 use crate::{error::RegistryError, policy::Identity};
 use indexmap::IndexMap;

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -22,6 +22,7 @@ impl EnvVar for FakeEnv {
         match name {
             "NPM_TOKEN" => Some("default-env-token".to_string()),
             "CUSTOM_TOKEN" => Some("custom-env-token".to_string()),
+            "EMPTY_TOKEN" => Some(String::new()),
             _ => None,
         }
     }
@@ -127,6 +128,30 @@ fn uplink_auth_without_resolvable_token_is_a_config_error() {
     };
     let err = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
         .expect_err("missing token must error");
+    assert!(matches!(err, RegistryError::InvalidConfig { .. }));
+}
+
+#[test]
+fn uplink_auth_with_empty_literal_token_is_a_config_error() {
+    let auth = UplinkAuthFile {
+        r#type: UplinkAuthType::Bearer,
+        token: Some(String::new()),
+        token_env: None,
+    };
+    let err = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
+        .expect_err("an empty token must error");
+    assert!(matches!(err, RegistryError::InvalidConfig { .. }));
+}
+
+#[test]
+fn uplink_auth_with_empty_env_token_is_a_config_error() {
+    let auth = UplinkAuthFile {
+        r#type: UplinkAuthType::Bearer,
+        token: None,
+        token_env: Some(TokenEnv::Named("EMPTY_TOKEN".to_string())),
+    };
+    let err = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
+        .expect_err("an empty env token must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
 }
 

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -3,8 +3,7 @@ use super::{
     LogLevel, TokenEnv, UplinkAuthFile, UplinkAuthType, UplinkFile, config_file_in, pattern_matches,
     resolve_relative, resolve_uplink,
 };
-use crate::error::RegistryError;
-use crate::policy::Identity;
+use crate::{error::RegistryError, policy::Identity};
 use indexmap::IndexMap;
 use pacquet_env_replace::EnvVar;
 use reqwest::header::AUTHORIZATION;

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -132,6 +132,46 @@ fn uplink_auth_without_resolvable_token_is_a_config_error() {
 }
 
 #[test]
+fn uplink_token_env_false_resolves_no_token_and_is_a_config_error() {
+    let auth = UplinkAuthFile {
+        r#type: UplinkAuthType::Bearer,
+        token: None,
+        token_env: Some(TokenEnv::Flag(false)),
+    };
+    let err = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
+        .expect_err("token_env: false reads nothing, so an auth block must error");
+    assert!(matches!(err, RegistryError::InvalidConfig { .. }));
+}
+
+#[test]
+fn uplink_auth_token_with_control_char_is_a_config_error() {
+    let auth = UplinkAuthFile {
+        r#type: UplinkAuthType::Bearer,
+        token: Some("bad\ntoken".to_string()),
+        token_env: None,
+    };
+    let err = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
+        .expect_err("a token that is not a valid header value must error");
+    assert!(matches!(err, RegistryError::InvalidConfig { .. }));
+}
+
+#[test]
+fn uplink_invalid_custom_header_name_is_a_config_error() {
+    let headers = IndexMap::from_iter([("bad header".to_string(), "value".to_string())]);
+    let err = resolve_uplink::<FakeEnv>("npmjs", uplink_file(None, headers))
+        .expect_err("a header name with a space must error");
+    assert!(matches!(err, RegistryError::InvalidConfig { .. }));
+}
+
+#[test]
+fn uplink_invalid_custom_header_value_is_a_config_error() {
+    let headers = IndexMap::from_iter([("x-custom".to_string(), "bad\nvalue".to_string())]);
+    let err = resolve_uplink::<FakeEnv>("npmjs", uplink_file(None, headers))
+        .expect_err("a header value with a control char must error");
+    assert!(matches!(err, RegistryError::InvalidConfig { .. }));
+}
+
+#[test]
 fn from_yaml_str_resolves_uplink_auth_and_headers() {
     let yaml = r#"
 uplinks:
@@ -150,6 +190,19 @@ packages:
     let uplink = &config.uplinks["npmjs"];
     assert_eq!(uplink.headers.get(AUTHORIZATION).unwrap().to_str().unwrap(), "Bearer secret-token");
     assert_eq!(uplink.headers.get("x-org").unwrap().to_str().unwrap(), "acme");
+}
+
+#[test]
+fn from_yaml_str_tolerates_unresolved_env_var_references() {
+    let yaml = r#"
+storage: ${PNPR_UNSET_VAR_FOR_TEST}./store
+packages:
+  '**':
+    proxy: npmjs
+"#;
+    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
+        .expect("an unresolved ${VAR} is replaced with empty, not an error");
+    assert!(config.storage.ends_with("store"));
 }
 
 fn user(name: &str) -> Identity {

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1,12 +1,156 @@
 use super::{
     BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML, HostedStoreConfig, LogFormat,
-    LogLevel, config_file_in, pattern_matches, resolve_relative,
+    LogLevel, TokenEnv, UplinkAuthFile, UplinkAuthType, UplinkFile, config_file_in, pattern_matches,
+    resolve_relative, resolve_uplink,
 };
+use crate::error::RegistryError;
 use crate::policy::Identity;
+use indexmap::IndexMap;
+use pacquet_env_replace::EnvVar;
+use reqwest::header::AUTHORIZATION;
 use std::{
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     path::{Path, PathBuf},
 };
+
+/// Test [`EnvVar`] provider with a fixed set of variables, so
+/// `token_env` resolution can be exercised without touching the real
+/// process environment.
+struct FakeEnv;
+
+impl EnvVar for FakeEnv {
+    fn var(name: &str) -> Option<String> {
+        match name {
+            "NPM_TOKEN" => Some("default-env-token".to_string()),
+            "CUSTOM_TOKEN" => Some("custom-env-token".to_string()),
+            _ => None,
+        }
+    }
+}
+
+fn uplink_file(auth: Option<UplinkAuthFile>, headers: IndexMap<String, String>) -> UplinkFile {
+    UplinkFile { url: "https://upstream.test/".to_string(), auth, headers }
+}
+
+fn auth_header(uplink: &super::UplinkConfig) -> Option<&str> {
+    uplink.headers.get(AUTHORIZATION).map(|value| value.to_str().unwrap())
+}
+
+#[test]
+fn uplink_bearer_token_becomes_bearer_authorization() {
+    let auth = UplinkAuthFile {
+        r#type: UplinkAuthType::Bearer,
+        token: Some("abc123".to_string()),
+        token_env: None,
+    };
+    let uplink = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
+        .expect("bearer token resolves");
+    assert_eq!(auth_header(&uplink), Some("Bearer abc123"));
+}
+
+#[test]
+fn uplink_basic_token_becomes_basic_authorization_verbatim() {
+    let auth = UplinkAuthFile {
+        r#type: UplinkAuthType::Basic,
+        token: Some("dXNlcjpwYXNz".to_string()),
+        token_env: None,
+    };
+    let uplink = resolve_uplink::<FakeEnv>("priv", uplink_file(Some(auth), IndexMap::new()))
+        .expect("basic token resolves");
+    assert_eq!(auth_header(&uplink), Some("Basic dXNlcjpwYXNz"));
+}
+
+#[test]
+fn uplink_token_env_true_reads_npm_token() {
+    let auth = UplinkAuthFile {
+        r#type: UplinkAuthType::Bearer,
+        token: None,
+        token_env: Some(TokenEnv::Flag(true)),
+    };
+    let uplink = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
+        .expect("token_env: true reads NPM_TOKEN");
+    assert_eq!(auth_header(&uplink), Some("Bearer default-env-token"));
+}
+
+#[test]
+fn uplink_token_env_named_reads_that_var() {
+    let auth = UplinkAuthFile {
+        r#type: UplinkAuthType::Bearer,
+        token: None,
+        token_env: Some(TokenEnv::Named("CUSTOM_TOKEN".to_string())),
+    };
+    let uplink = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
+        .expect("named token_env reads that var");
+    assert_eq!(auth_header(&uplink), Some("Bearer custom-env-token"));
+}
+
+#[test]
+fn uplink_literal_token_beats_token_env() {
+    let auth = UplinkAuthFile {
+        r#type: UplinkAuthType::Bearer,
+        token: Some("literal".to_string()),
+        token_env: Some(TokenEnv::Named("CUSTOM_TOKEN".to_string())),
+    };
+    let uplink = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
+        .expect("literal token wins");
+    assert_eq!(auth_header(&uplink), Some("Bearer literal"));
+}
+
+#[test]
+fn uplink_custom_headers_are_forwarded() {
+    let headers = IndexMap::from_iter([("x-custom".to_string(), "value".to_string())]);
+    let uplink = resolve_uplink::<FakeEnv>("npmjs", uplink_file(None, headers))
+        .expect("custom headers resolve");
+    assert_eq!(uplink.headers.get("x-custom").unwrap().to_str().unwrap(), "value");
+    assert!(auth_header(&uplink).is_none());
+}
+
+#[test]
+fn uplink_custom_authorization_header_overrides_auth_block() {
+    let auth = UplinkAuthFile {
+        r#type: UplinkAuthType::Bearer,
+        token: Some("from-auth".to_string()),
+        token_env: None,
+    };
+    let headers =
+        IndexMap::from_iter([("authorization".to_string(), "Basic override".to_string())]);
+    let uplink = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), headers))
+        .expect("custom header overrides auth-derived one");
+    assert_eq!(auth_header(&uplink), Some("Basic override"));
+}
+
+#[test]
+fn uplink_auth_without_resolvable_token_is_a_config_error() {
+    let auth = UplinkAuthFile {
+        r#type: UplinkAuthType::Bearer,
+        token: None,
+        token_env: Some(TokenEnv::Named("UNSET_VAR".to_string())),
+    };
+    let err = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
+        .expect_err("missing token must error");
+    assert!(matches!(err, RegistryError::InvalidConfig { .. }));
+}
+
+#[test]
+fn from_yaml_str_resolves_uplink_auth_and_headers() {
+    let yaml = r#"
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    auth:
+      type: bearer
+      token: secret-token
+    headers:
+      X-Org: acme
+packages:
+  '**':
+    proxy: npmjs
+"#;
+    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+    let uplink = &config.uplinks["npmjs"];
+    assert_eq!(uplink.headers.get(AUTHORIZATION).unwrap().to_str().unwrap(), "Bearer secret-token");
+    assert_eq!(uplink.headers.get("x-org").unwrap().to_str().unwrap(), "acme");
+}
 
 fn user(name: &str) -> Identity {
     Identity::User { username: name.to_string() }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -140,7 +140,9 @@ pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
     let upstreams: IndexMap<String, Upstream> = config
         .uplinks
         .iter()
-        .map(|(name, uplink)| (name.clone(), Upstream::new(uplink.url.clone())))
+        .map(|(name, uplink)| {
+            (name.clone(), Upstream::new(uplink.url.clone(), uplink.headers.clone()))
+        })
         .collect();
     let state = AppState {
         inner: Arc::new(AppInner {

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -5,6 +5,7 @@ use crate::{
 use chrono::{DateTime, Duration, Timelike, Utc};
 use pacquet_network::ThrottledClient;
 use reqwest::StatusCode;
+use reqwest::header::HeaderMap;
 use serde_json::Value;
 use std::sync::Arc;
 
@@ -18,6 +19,9 @@ use std::sync::Arc;
 pub struct Upstream {
     client: Arc<ThrottledClient>,
     base: String,
+    /// Resolved per-uplink request headers (auth + custom) attached to
+    /// every fetch. Empty for an uplink with no `auth:`/`headers:`.
+    headers: HeaderMap,
 }
 
 #[derive(Debug)]
@@ -29,8 +33,8 @@ pub enum FetchOutcome<Payload> {
 }
 
 impl Upstream {
-    pub fn new(base: String) -> Self {
-        Self { client: Arc::new(ThrottledClient::new_for_installs()), base }
+    pub fn new(base: String, headers: HeaderMap) -> Self {
+        Self { client: Arc::new(ThrottledClient::new_for_installs()), base, headers }
     }
 
     pub async fn fetch_packument(&self, name: &PackageName) -> Result<FetchOutcome<Vec<u8>>> {
@@ -51,6 +55,7 @@ impl Upstream {
         let client = self.client.acquire_for_url(&url).await;
         let response = client
             .get(&url)
+            .headers(self.headers.clone())
             .send()
             .await
             .map_err(|source| RegistryError::Upstream { url: url.clone(), source })?;
@@ -65,6 +70,7 @@ impl Upstream {
         let client = self.client.acquire_for_url(url).await;
         let response = client
             .get(url)
+            .headers(self.headers.clone())
             .send()
             .await
             .map_err(|source| RegistryError::Upstream { url: url.to_string(), source })?;

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -1,4 +1,5 @@
 use crate::{
+    config::RedactedHeaders,
     error::{RegistryError, Result},
     package_name::PackageName,
 };
@@ -6,7 +7,7 @@ use chrono::{DateTime, Duration, Timelike, Utc};
 use pacquet_network::ThrottledClient;
 use reqwest::{StatusCode, header::HeaderMap};
 use serde_json::Value;
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 /// Wraps a shared [`ThrottledClient`] (so the registry inherits pnpm's
 /// tuned reqwest defaults: `User-Agent: pnpm`, HTTP/1.1, hickory DNS,
@@ -14,13 +15,23 @@ use std::sync::Arc;
 /// routing if it's ever wired in later) and adds the small bit of
 /// glue specific to a proxy: building the upstream URL and fishing
 /// the packument or tarball response out of it.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Upstream {
     client: Arc<ThrottledClient>,
     base: String,
     /// Resolved per-uplink request headers (auth + custom) attached to
     /// every fetch. Empty for an uplink with no `auth:`/`headers:`.
     headers: HeaderMap,
+}
+
+impl fmt::Debug for Upstream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Upstream")
+            .field("client", &self.client)
+            .field("base", &self.base)
+            .field("headers", &RedactedHeaders(&self.headers))
+            .finish()
+    }
 }
 
 #[derive(Debug)]

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -4,8 +4,7 @@ use crate::{
 };
 use chrono::{DateTime, Duration, Timelike, Utc};
 use pacquet_network::ThrottledClient;
-use reqwest::StatusCode;
-use reqwest::header::HeaderMap;
+use reqwest::{StatusCode, header::HeaderMap};
 use serde_json::Value;
 use std::sync::Arc;
 

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -1,12 +1,89 @@
-use super::{abbreviate_packument, extract_version_manifest, rewrite_tarball_urls};
+use super::{
+    FetchOutcome, Upstream, abbreviate_packument, extract_version_manifest, rewrite_tarball_urls,
+};
 use crate::package_name::PackageName;
 use chrono::{DateTime, TimeZone, Utc};
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use serde_json::json;
 
 /// Fixed "current time" for abbreviation tests so the `time`-map
 /// coarsening (which buckets entries by age) is deterministic.
 fn now() -> DateTime<Utc> {
     Utc.with_ymd_and_hms(2024, 3, 20, 12, 0, 0).unwrap()
+}
+
+/// Build a header map carrying a bearer `Authorization` plus one
+/// custom header — the resolved per-uplink set an [`Upstream`] is
+/// expected to attach to every request.
+fn auth_and_custom_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer secret-token"));
+    headers.insert("x-org", HeaderValue::from_static("acme"));
+    headers
+}
+
+#[tokio::test]
+async fn fetch_packument_forwards_configured_headers() {
+    let mut server = mockito::Server::new_async().await;
+    // The mock only matches when both headers are present, so an
+    // `Ok` outcome proves they rode along on the request.
+    let mock = server
+        .mock("GET", "/foo")
+        .match_header("authorization", "Bearer secret-token")
+        .match_header("x-org", "acme")
+        .with_status(200)
+        .with_body(json!({ "name": "foo" }).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let upstream = Upstream::new(server.url(), auth_and_custom_headers());
+    let name = PackageName::parse("foo").unwrap();
+    let outcome = upstream.fetch_packument(&name).await.unwrap();
+
+    assert!(matches!(outcome, FetchOutcome::Ok(_)));
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn fetch_tarball_response_forwards_configured_headers() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/foo/-/foo-1.0.0.tgz")
+        .match_header("authorization", "Bearer secret-token")
+        .match_header("x-org", "acme")
+        .with_status(200)
+        .with_body("tarball-bytes")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let upstream = Upstream::new(server.url(), auth_and_custom_headers());
+    let name = PackageName::parse("foo").unwrap();
+    let outcome = upstream.fetch_tarball_response(&name, "foo-1.0.0.tgz").await.unwrap();
+
+    assert!(matches!(outcome, FetchOutcome::Ok(_)));
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn fetch_packument_sends_no_authorization_when_headers_empty() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/foo")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(200)
+        .with_body(json!({ "name": "foo" }).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let upstream = Upstream::new(server.url(), HeaderMap::new());
+    let name = PackageName::parse("foo").unwrap();
+    let outcome = upstream.fetch_packument(&name).await.unwrap();
+
+    assert!(matches!(outcome, FetchOutcome::Ok(_)));
+    mock.assert_async().await;
 }
 
 #[test]

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -78,6 +78,33 @@ async fn packument_is_proxied_cached_and_rewritten() {
 }
 
 #[tokio::test]
+async fn uplink_auth_and_custom_headers_are_forwarded_upstream() {
+    let mut upstream = mockito::Server::new_async().await;
+    // The mock only matches when both headers are present, so a passing
+    // request proves the resolved per-uplink headers reached upstream.
+    let mock = upstream
+        .mock("GET", "/foo")
+        .match_header("authorization", "Bearer secret-token")
+        .match_header("x-org", "acme")
+        .with_status(200)
+        .with_body(json!({ "name": "foo", "versions": {} }).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for(&upstream.url(), tmp.path().to_path_buf());
+    let uplink = config.uplinks.get_mut("npmjs").expect("default `npmjs` uplink");
+    uplink.headers.insert("authorization", "Bearer secret-token".parse().unwrap());
+    uplink.headers.insert("x-org", "acme".parse().unwrap());
+    let app = router(config);
+
+    let response = app.oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn scoped_packument_is_served() {
     let mut upstream = mockito::Server::new_async().await;
     let packument = json!({ "name": "@types/node", "versions": {} });


### PR DESCRIPTION
pnpr now attaches a per-uplink `Authorization` header (derived from the verdaccio-shaped `auth:` block) plus any operator-supplied custom `headers:` on every packument and tarball request it makes to an upstream registry. This unblocks proxying private upstreams (CodeArtifact, GitHub Packages, authed npm Enterprise, private verdaccio) that previously returned 401/403.

`auth` supports `type: bearer | basic`, an inline `token`, and verdaccio's `token_env` (`true` -> `NPM_TOKEN`, or a named var); an inline `token` takes priority. A custom `headers.Authorization` overrides the auth-derived one, matching verdaccio's merge order. Tokens/headers resolve once at config load through the existing `EnvVar` seam, so a missing token or invalid header value fails fast as an `InvalidConfig` error rather than a silent unauthenticated request.

Implements the "Forward auth.token / custom headers to uplinks" item under Uplinks & caching in the pnpr-verdaccio-parity tracking issue.

Ref: https://github.com/pnpm/pnpm/issues/11973

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-uplink custom HTTP headers are supported and forwarded to upstream requests; auth headers are derived from configured auth settings and redacted in diagnostics.

* **Bug Fixes**
  * Invalid or unresolvable tokens and malformed header names/values now surface as configuration errors; unresolved YAML env refs are tolerated (treated as empty).

* **Tests**
  * Added unit and integration tests for auth resolution, header precedence, validation, and forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->