### PR TITLE
fix(sbom): add recursiveByDefault so --filter works in workspaces

### DIFF
--- a/.changeset/sbom-filter-workspace-fix.md
+++ b/.changeset/sbom-filter-workspace-fix.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/deps.compliance.commands": patch
+"pnpm": patch
+---
+
+Fixed `pnpm sbom --filter` being silently ignored in workspaces. The sbom command was missing `recursiveByDefault`, so the `--filter` flag never populated the workspace project graph. The handler always used the workspace root's metadata for the SBOM root component regardless of the filter.

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -69,6 +69,8 @@ export const shorthands: Record<string, string> = {
 
 export const commandNames = ['sbom']
 
+export const recursiveByDefault = true
+
 export function help (): string {
   return renderHelp({
     description: 'Generate a Software Bill of Materials (SBOM) for the project.',


### PR DESCRIPTION
## Summary

`pnpm sbom --filter <pkg>` was silently ignored in workspaces. The sbom command was missing the `recursiveByDefault` export that other workspace-aware commands (like `audit`) have.

Without it, the `--filter` flag was accepted but the recursive code path that populates `selectedProjectsGraph` never ran. The SBOM always used the workspace root's name/version for the root component and walked all importers.

**Reproduction:** run `pnpm sbom --sbom-format cyclonedx --filter <workspace-pkg>` in any workspace. The root component in the output is the workspace root, not the filtered package. Component count drops (some filtering happens at the lockfile walker level), but root component metadata is wrong.

**Fix:** one-line addition of `export const recursiveByDefault = true` to the sbom command module, matching `audit`.

---
Written by an agent (Claude Code, claude-opus-4-6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm sbom --filter` command in workspaces—the filter flag is now properly applied instead of being ignored.
  * Corrected SBOM root component metadata selection to accurately reflect filtered workspace projects instead of always defaulting to the workspace root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->