### PR TITLE
fix: don't catalog runtime: dependencies under strict catalog mode

### DIFF
--- a/.changeset/runtime-not-cataloged.md
+++ b/.changeset/runtime-not-cataloged.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+Don't promote a `runtime:` dependency (such as the Node.js version from `devEngines.runtime` or `pnpm runtime set`) into a catalog when `catalogMode` is `strict` or `prefer`. A `runtime:` dependency round-trips to `devEngines.runtime`, which only recognizes the `runtime:` protocol; cataloging it rewrote the manifest entry to `catalog:`, which broke that round-trip, stranded it in `devDependencies`, and left `devEngines.runtime` untouched.

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -792,6 +792,12 @@ export async function mutateModules (
 
       if (opts.catalogMode !== 'manual') {
         for (const wantedDep of wantedDeps) {
+          // A `runtime:` specifier (e.g. node from `devEngines.runtime` or
+          // `pnpm runtime set`) round-trips to `devEngines.runtime` through the
+          // manifest writer, which only recognizes the `runtime:` protocol.
+          // Promoting it into a catalog rewrites the entry to `catalog:`, which
+          // breaks that round-trip and strands it in `devDependencies`.
+          if (wantedDep.bareSpecifier?.startsWith('runtime:')) continue
           const perDepCatalogName = getPerDepCatalogName(wantedDep, opts.saveCatalogName)
           const catalogBareSpecifier = `catalog:${perDepCatalogName === 'default' ? '' : perDepCatalogName}`
           const catalog = resolveFromCatalog(opts.catalogs, { ...wantedDep, bareSpecifier: catalogBareSpecifier })

--- a/pnpm/test/install/nodeRuntime.ts
+++ b/pnpm/test/install/nodeRuntime.ts
@@ -2,6 +2,8 @@ import fs from 'node:fs'
 
 import { expect, test } from '@jest/globals'
 import { prepare } from '@pnpm/prepare'
+import { readYamlFileSync } from 'read-yaml-file'
+import { writeYamlFileSync } from 'write-yaml-file'
 
 import { execPnpm } from '../utils/index.js'
 
@@ -12,4 +14,40 @@ test('installing a CLI tool that requires a specific version of Node.js to be in
   await execPnpm(['add', '@pnpm.e2e/cli-with-node-engine@1.0.0'])
   await execPnpm(['exec', 'cli-with-node-engine'])
   expect(fs.readFileSync('node-version', 'utf8')).toBe('v22.19.0')
+})
+
+test('a devEngines.runtime is never promoted into a catalog under catalogMode=strict', async () => {
+  const project = prepare({
+    devEngines: {
+      runtime: {
+        name: 'node',
+        version: '24.0.0',
+        onFail: 'download',
+      },
+    },
+  })
+  writeYamlFileSync('pnpm-workspace.yaml', { catalogMode: 'strict' })
+
+  await execPnpm(['install'])
+
+  // The runtime resolves and installs as usual.
+  project.isExecutable('.bin/node')
+
+  // It is not turned into a catalog entry...
+  const workspaceManifest = readYamlFileSync<{ catalog?: unknown, catalogs?: unknown }>('pnpm-workspace.yaml')
+  expect(workspaceManifest.catalog).toBeUndefined()
+  expect(workspaceManifest.catalogs).toBeUndefined()
+
+  // ...and stays in devEngines.runtime instead of leaking into devDependencies.
+  const manifest = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+  expect(manifest.devEngines.runtime).toMatchObject({ name: 'node', version: '24.0.0' })
+  expect(manifest.devDependencies?.node).toBeUndefined()
+
+  const lockfile = project.readLockfile()
+  expect(lockfile.importers['.'].devDependencies).toStrictEqual({
+    node: {
+      specifier: 'runtime:24.0.0',
+      version: 'runtime:24.0.0',
+    },
+  })
 })


### PR DESCRIPTION
## Problem

In a workspace with `catalogMode: strict`, `pnpm runtime set node <major>` (run by the `update-lockfile` workflow) is implemented on top of `pnpm add node@runtime:<major> --save-dev`. Strict catalog mode auto-promotes every newly added dependency into the catalog, so the runtime pseudo-dependency was:

1. written into the catalog as `node: runtime:^X.Y.Z`, and
2. rewritten in the manifest to `node: catalog:`.

Because the manifest entry then read `catalog:` instead of `runtime:<version>`, the `runtime:` ↔ `devEngines.runtime` round-trip never fired: `devEngines.runtime` was left stale and `node: catalog:` leaked into `devDependencies` permanently. This is what produced the unexpected `node` catalog entry in #12157.

## Fix

A `runtime:` specifier is not a registry dependency and has no business in a package catalog. Skip `runtime:` specifiers in the catalog auto-save loop (`deps-installer/src/install/index.ts`) so that under `catalogMode` `strict`/`prefer` a runtime is never promoted into a catalog and never rewritten to `catalog:`. It stays `runtime:<version>` and round-trips to `devEngines.runtime` through the existing manifest writer, exactly as without strict catalog mode.

## Test

Added an e2e test (`pnpm/test/install/nodeRuntime.ts`): with `devEngines.runtime` (`onFail: download`) and `catalogMode: strict`, `pnpm install` installs the runtime, creates no catalog entry, keeps `devEngines.runtime` intact, leaves nothing stranded in `devDependencies`, and the lockfile keeps `node: runtime:24.0.0`.

## pacquet parity

This adjusts pnpm's `catalogMode` strict/prefer auto-save behavior for `runtime:` specifiers. If pacquet implements strict-catalog auto-save together with the `devEngines.runtime` ↔ dependency bridge, it needs the same guard. Flagging for a follow-up on the pacquet side.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime dependencies from being incorrectly promoted into catalogs when using strict or prefer catalog modes, ensuring they continue to function properly.

* **Tests**
  * Added test coverage verifying runtime dependencies are handled correctly in strict catalog mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->