### PR TITLE
feat(pnpr): separate the proxied upstream cache from published packages

### DIFF
--- a/pnpr/crates/pnpr/config.yaml
+++ b/pnpr/crates/pnpr/config.yaml
@@ -1,5 +1,12 @@
-# path to a directory with all packages
+# path to a directory with the authoritative packages — those published
+# to this server and anything served in static mode. This is the source
+# of truth; back it up and keep it on a durable volume.
 storage: ./storage
+# path to the disposable proxy cache: the mirror of upstream registries
+# plus the install-accelerator store. Safe to wipe at any time. Defaults
+# to a `.pnpr-cache` subdirectory of `storage`; point it at a separate,
+# ephemeral volume to keep cached upstream content off the durable disk.
+#cache: ./cache
 secret: pnpm-registry-mock-secret-key-32
 
 auth:

--- a/pnpr/crates/pnpr/src/cache.rs
+++ b/pnpr/crates/pnpr/src/cache.rs
@@ -69,7 +69,7 @@ impl TarballWrite {
 ///   served in static mode. Served as-is and never overwritten by an
 ///   upstream refresh, so a hosted version can't be masked or lost.
 ///   Operators back this up and put it on a durable volume.
-/// * `cache` — the disposable mirror of upstream registries. Safe to
+/// * `cached` — the disposable mirror of upstream registries. Safe to
 ///   wipe at any time; it self-heals on the next request. Operators can
 ///   keep it on scratch/ephemeral disk.
 ///
@@ -90,12 +90,12 @@ impl TarballWrite {
 #[derive(Debug, Clone)]
 pub struct Cache {
     hosted: Store,
-    cache: Store,
+    cached: Store,
 }
 
 impl Cache {
     pub fn new(hosted_root: PathBuf, cache_root: PathBuf) -> Self {
-        Self { hosted: Store::new(hosted_root), cache: Store::new(cache_root) }
+        Self { hosted: Store::new(hosted_root), cached: Store::new(cache_root) }
     }
 
     /// The hosted store's root, used by the local search scan (which
@@ -135,7 +135,7 @@ impl Cache {
     /// of the just-removed version.
     pub async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
         let hosted = self.hosted.remove_tarball(name, filename).await?;
-        let cached = self.cache.remove_tarball(name, filename).await?;
+        let cached = self.cached.remove_tarball(name, filename).await?;
         Ok(hosted || cached)
     }
 
@@ -144,7 +144,7 @@ impl Cache {
     /// can't resurface after the package is gone.
     pub async fn remove_package(&self, name: &PackageName) -> Result<bool> {
         let hosted = self.hosted.remove_package(name).await?;
-        let cached = self.cache.remove_package(name).await?;
+        let cached = self.cached.remove_package(name).await?;
         Ok(hosted || cached)
     }
 
@@ -157,17 +157,17 @@ impl Cache {
         name: &PackageName,
         ttl: Duration,
     ) -> Result<Option<Vec<u8>>> {
-        self.cache.read_fresh_packument(name, ttl).await
+        self.cached.read_fresh_packument(name, ttl).await
     }
 
     /// Read whatever cached upstream packument is on disk, fresh or
     /// stale. Used as a fallback when the upstream is unreachable.
     pub async fn read_cached_packument(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
-        self.cache.read_packument_any_age(name).await
+        self.cached.read_packument_any_age(name).await
     }
 
     pub async fn write_cached_packument(&self, name: &PackageName, bytes: &[u8]) -> Result<()> {
-        self.cache.write_packument(name, bytes).await
+        self.cached.write_packument(name, bytes).await
     }
 
     /// Create and open a per-request temp file for a proxied tarball.
@@ -179,7 +179,7 @@ impl Cache {
         name: &PackageName,
         filename: &str,
     ) -> Result<TarballWrite> {
-        self.cache.open_tarball_tmp(name, filename).await
+        self.cached.open_tarball_tmp(name, filename).await
     }
 
     // --- Composed (hosted-first) ----------------------------------------
@@ -196,7 +196,7 @@ impl Cache {
         if let Some(hit) = self.hosted.open_tarball(name, filename).await? {
             return Ok(Some(hit));
         }
-        self.cache.open_tarball(name, filename).await
+        self.cached.open_tarball(name, filename).await
     }
 
     /// Atomically promote a tmp tarball written by the publish flow to

--- a/pnpr/crates/pnpr/src/cache.rs
+++ b/pnpr/crates/pnpr/src/cache.rs
@@ -128,11 +128,15 @@ impl Cache {
         self.hosted.reserve_tarball_paths(name, filename).await
     }
 
-    /// Remove a single tarball file from the hosted store. The
+    /// Remove a single tarball file from both stores. The
     /// partial-unpublish flow calls this after PUT'ing the modified
-    /// packument back.
-    pub async fn remove_hosted_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
-        self.hosted.remove_tarball(name, filename).await
+    /// packument back; clearing the proxied mirror too stops
+    /// [`Self::open_tarball`]'s cache fallback from serving a stale copy
+    /// of the just-removed version.
+    pub async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
+        let hosted = self.hosted.remove_tarball(name, filename).await?;
+        let cached = self.cache.remove_tarball(name, filename).await?;
+        Ok(hosted || cached)
     }
 
     /// Remove the package from both stores. Unpublish must purge the

--- a/pnpr/crates/pnpr/src/cache.rs
+++ b/pnpr/crates/pnpr/src/cache.rs
@@ -19,30 +19,11 @@ const PACKUMENT_FILE: &str = "package.json";
 /// and dest sit in the same directory (they do).
 static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-/// Verdaccio-shaped on-disk storage for packuments and tarballs:
-///
-/// ```text
-/// <root>/
-///   <package>/
-///     package.json
-///     <basename>-<version>.tgz
-/// ```
-///
-/// For scoped packages the package directory is `<root>/@scope/<name>/`.
-/// Tarballs sit flat alongside `package.json` — no `-/` subdirectory.
-/// This is the layout `@pnpm/registry-mock` (and verdaccio itself)
-/// publishes, so a populated verdaccio storage can be served directly
-/// in static mode.
-#[derive(Debug, Clone)]
-pub struct Cache {
-    root: PathBuf,
-}
-
-/// Handle returned from [`Cache::open_tarball_tmp`]. The caller writes
-/// to `file` (and on success calls [`Self::finalize`] to atomically
-/// promote the temp file to the final cache path); dropping the
-/// handle without calling [`Self::finalize`] is treated as abandon —
-/// callers that hit an error mid-write should call [`Self::abandon`]
+/// Handle returned from [`Cache::open_cached_tarball_tmp`]. The caller
+/// writes to `file` (and on success calls [`Self::finalize`] to
+/// atomically promote the temp file to the final cache path); dropping
+/// the handle without calling [`Self::finalize`] is treated as abandon
+/// — callers that hit an error mid-write should call [`Self::abandon`]
 /// to actively remove the leftover temp file.
 pub struct TarballWrite {
     pub file: fs::File,
@@ -80,14 +61,171 @@ impl TarballWrite {
     }
 }
 
+/// Verdaccio-shaped on-disk storage split into two physically separate
+/// roots with different durability guarantees:
+///
+/// * `published` — the authoritative source of truth: packages
+///   published to this server and the content served in static mode.
+///   Served as-is and never overwritten by an upstream refresh, so a
+///   published version can't be masked or lost. Operators back this up
+///   and put it on a durable volume.
+/// * `cache` — the disposable mirror of upstream registries. Safe to
+///   wipe at any time; it self-heals on the next request. Operators can
+///   keep it on scratch/ephemeral disk.
+///
+/// Both roots use the same on-disk layout:
+///
+/// ```text
+/// <root>/
+///   <package>/
+///     package.json
+///     <basename>-<version>.tgz
+/// ```
+///
+/// For scoped packages the package directory is `<root>/@scope/<name>/`.
+/// Tarballs sit flat alongside `package.json` — no `-/` subdirectory.
+/// This is the layout `@pnpm/registry-mock` (and verdaccio itself)
+/// publishes, so a populated verdaccio storage can be served directly
+/// in static mode.
+#[derive(Debug, Clone)]
+pub struct Cache {
+    published: Store,
+    cache: Store,
+}
+
 impl Cache {
-    pub fn new(root: PathBuf) -> Self {
+    pub fn new(published_root: PathBuf, cache_root: PathBuf) -> Self {
+        Self { published: Store::new(published_root), cache: Store::new(cache_root) }
+    }
+
+    /// The authoritative store's root, used by the local search scan
+    /// (which indexes published/static packages only, never the proxy
+    /// mirror).
+    pub fn published_root(&self) -> &Path {
+        &self.published.root
+    }
+
+    // --- Authoritative (published) store --------------------------------
+
+    /// Read the authoritative packument for `name`, fresh or stale.
+    /// Authoritative content has no TTL — it is the source of truth.
+    pub async fn read_published_packument(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
+        self.published.read_packument_any_age(name).await
+    }
+
+    pub async fn write_published_packument(&self, name: &PackageName, bytes: &[u8]) -> Result<()> {
+        self.published.write_packument(name, bytes).await
+    }
+
+    /// Reserve a tmp/final path pair for a tarball published to this
+    /// server. The publish flow streams the decode + hash + write
+    /// through `std::fs` inside `spawn_blocking` and only needs the
+    /// paths; finalize with [`Self::finalize_tarball_slot`].
+    pub async fn reserve_published_tarball(
+        &self,
+        name: &PackageName,
+        filename: &str,
+    ) -> Result<TarballSlot> {
+        self.published.reserve_tarball_paths(name, filename).await
+    }
+
+    /// Remove a single tarball file from the authoritative store. The
+    /// partial-unpublish flow calls this after PUT'ing the modified
+    /// packument back.
+    pub async fn remove_published_tarball(
+        &self,
+        name: &PackageName,
+        filename: &str,
+    ) -> Result<bool> {
+        self.published.remove_tarball(name, filename).await
+    }
+
+    /// Remove the package from both stores. Unpublish must purge the
+    /// authoritative copy *and* any proxied mirror, so a stale cached
+    /// copy can't resurface after the package is gone.
+    pub async fn remove_package(&self, name: &PackageName) -> Result<bool> {
+        let published = self.published.remove_package(name).await?;
+        let cached = self.cache.remove_package(name).await?;
+        Ok(published || cached)
+    }
+
+    // --- Disposable (proxy) cache store ---------------------------------
+
+    /// Read a cached upstream packument if it exists and is newer than
+    /// `now - ttl`.
+    pub async fn read_fresh_cached_packument(
+        &self,
+        name: &PackageName,
+        ttl: Duration,
+    ) -> Result<Option<Vec<u8>>> {
+        self.cache.read_fresh_packument(name, ttl).await
+    }
+
+    /// Read whatever cached upstream packument is on disk, fresh or
+    /// stale. Used as a fallback when the upstream is unreachable.
+    pub async fn read_cached_packument(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
+        self.cache.read_packument_any_age(name).await
+    }
+
+    pub async fn write_cached_packument(&self, name: &PackageName, bytes: &[u8]) -> Result<()> {
+        self.cache.write_packument(name, bytes).await
+    }
+
+    /// Create and open a per-request temp file for a proxied tarball.
+    /// The caller streams bytes into [`TarballWrite::file`] and calls
+    /// [`TarballWrite::finalize`] (or [`TarballWrite::abandon`]) when
+    /// the upstream response ends.
+    pub async fn open_cached_tarball_tmp(
+        &self,
+        name: &PackageName,
+        filename: &str,
+    ) -> Result<TarballWrite> {
+        self.cache.open_tarball_tmp(name, filename).await
+    }
+
+    // --- Composed (published-first) -------------------------------------
+
+    /// Open a tarball for streaming, preferring the authoritative store
+    /// over the proxy mirror. Returns the open file plus its size (for
+    /// `Content-Length`). `Ok(None)` means neither store has it, so the
+    /// caller can fall through to the upstream fetch.
+    pub async fn open_tarball(
+        &self,
+        name: &PackageName,
+        filename: &str,
+    ) -> Result<Option<(fs::File, u64)>> {
+        if let Some(hit) = self.published.open_tarball(name, filename).await? {
+            return Ok(Some(hit));
+        }
+        self.cache.open_tarball(name, filename).await
+    }
+
+    /// Atomically promote a tmp tarball written by the publish flow to
+    /// its final path. Mirrors what [`TarballWrite::finalize`] does,
+    /// minus the `sync_all` (the blocking task that wrote the file
+    /// already synced it). Store-agnostic: the slot already carries its
+    /// final path.
+    pub async fn finalize_tarball_slot(&self, slot: TarballSlot) -> Result<()> {
+        if let Some(parent) = slot.final_path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        fs::rename(&slot.tmp_path, &slot.final_path).await?;
+        Ok(())
+    }
+}
+
+/// One verdaccio-shaped on-disk store rooted at a single directory.
+#[derive(Debug, Clone)]
+struct Store {
+    root: PathBuf,
+}
+
+impl Store {
+    fn new(root: PathBuf) -> Self {
         Self { root }
     }
 
-    /// Read a cached packument if it exists and is newer than
-    /// `now - ttl`.
-    pub async fn read_fresh_packument(
+    async fn read_fresh_packument(
         &self,
         name: &PackageName,
         ttl: Duration,
@@ -106,10 +244,7 @@ impl Cache {
         Ok(Some(fs::read(&path).await?))
     }
 
-    /// Read whatever packument is on disk, fresh or stale. Used in
-    /// static mode (TTL doesn't apply) and as a fallback when the
-    /// upstream is unreachable.
-    pub async fn read_packument_any_age(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
+    async fn read_packument_any_age(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
         let path = self.packument_path(name);
         match fs::read(&path).await {
             Ok(bytes) => Ok(Some(bytes)),
@@ -118,14 +253,12 @@ impl Cache {
         }
     }
 
-    pub async fn write_packument(&self, name: &PackageName, bytes: &[u8]) -> Result<()> {
+    async fn write_packument(&self, name: &PackageName, bytes: &[u8]) -> Result<()> {
         let path = self.packument_path(name);
         write_atomic(&path, bytes).await
     }
 
-    /// Open the cached tarball file for streaming, if it exists.
-    /// Returns the open file plus its size (for `Content-Length`).
-    pub async fn open_tarball(
+    async fn open_tarball(
         &self,
         name: &PackageName,
         filename: &str,
@@ -140,15 +273,7 @@ impl Cache {
         Ok(Some((file, len)))
     }
 
-    /// Create and open a per-request temp file for a tarball. The
-    /// caller streams bytes into [`TarballWrite::file`] and calls
-    /// [`TarballWrite::finalize`] (or [`TarballWrite::abandon`]) when
-    /// the upstream response ends.
-    pub async fn open_tarball_tmp(
-        &self,
-        name: &PackageName,
-        filename: &str,
-    ) -> Result<TarballWrite> {
+    async fn open_tarball_tmp(&self, name: &PackageName, filename: &str) -> Result<TarballWrite> {
         let final_path = self.tarball_path(name, filename);
         if let Some(parent) = final_path.parent() {
             fs::create_dir_all(parent).await?;
@@ -158,11 +283,7 @@ impl Cache {
         Ok(TarballWrite { file, tmp_path, final_path })
     }
 
-    /// Reserve a tmp/final path pair for a tarball write without
-    /// opening the file. Used by the publish flow, which streams the
-    /// decode + hash + write through `std::fs` inside
-    /// `spawn_blocking` and only needs the paths.
-    pub async fn reserve_tarball_paths(
+    async fn reserve_tarball_paths(
         &self,
         name: &PackageName,
         filename: &str,
@@ -175,22 +296,10 @@ impl Cache {
         Ok(TarballSlot { tmp_path, final_path })
     }
 
-    /// Atomically promote a tmp tarball written by the publish flow to
-    /// its final cache path. Mirrors what [`TarballWrite::finalize`]
-    /// does, minus the `sync_all` (the blocking task that wrote the
-    /// file already synced it).
-    pub async fn finalize_tarball_slot(&self, slot: TarballSlot) -> Result<()> {
-        if let Some(parent) = slot.final_path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
-        fs::rename(&slot.tmp_path, &slot.final_path).await?;
-        Ok(())
-    }
-
     /// Remove the entire package directory. Returns `Ok(false)` if it
     /// didn't exist (treat as a no-op success, matching what verdaccio
     /// does on a duplicate DELETE).
-    pub async fn remove_package(&self, name: &PackageName) -> Result<bool> {
+    async fn remove_package(&self, name: &PackageName) -> Result<bool> {
         let dir = self.package_dir(name);
         match fs::remove_dir_all(&dir).await {
             Ok(()) => Ok(true),
@@ -203,7 +312,7 @@ impl Cache {
     /// is already gone; the pnpm unpublish flow always issues a DELETE
     /// after the packument-update PUT, and a benign 404 here would
     /// surface as a real error to the caller.
-    pub async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
+    async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
         let path = self.tarball_path(name, filename);
         match fs::remove_file(&path).await {
             Ok(()) => Ok(true),

--- a/pnpr/crates/pnpr/src/cache.rs
+++ b/pnpr/crates/pnpr/src/cache.rs
@@ -64,11 +64,11 @@ impl TarballWrite {
 /// Verdaccio-shaped on-disk storage split into two physically separate
 /// roots with different durability guarantees:
 ///
-/// * `published` — the authoritative source of truth: packages
-///   published to this server and the content served in static mode.
-///   Served as-is and never overwritten by an upstream refresh, so a
-///   published version can't be masked or lost. Operators back this up
-///   and put it on a durable volume.
+/// * `hosted` — the authoritative source of truth: packages this
+///   server hosts directly (published through its API) plus the content
+///   served in static mode. Served as-is and never overwritten by an
+///   upstream refresh, so a hosted version can't be masked or lost.
+///   Operators back this up and put it on a durable volume.
 /// * `cache` — the disposable mirror of upstream registries. Safe to
 ///   wipe at any time; it self-heals on the next request. Operators can
 ///   keep it on scratch/ephemeral disk.
@@ -89,64 +89,59 @@ impl TarballWrite {
 /// in static mode.
 #[derive(Debug, Clone)]
 pub struct Cache {
-    published: Store,
+    hosted: Store,
     cache: Store,
 }
 
 impl Cache {
-    pub fn new(published_root: PathBuf, cache_root: PathBuf) -> Self {
-        Self { published: Store::new(published_root), cache: Store::new(cache_root) }
+    pub fn new(hosted_root: PathBuf, cache_root: PathBuf) -> Self {
+        Self { hosted: Store::new(hosted_root), cache: Store::new(cache_root) }
     }
 
-    /// The authoritative store's root, used by the local search scan
-    /// (which indexes published/static packages only, never the proxy
-    /// mirror).
-    pub fn published_root(&self) -> &Path {
-        &self.published.root
+    /// The hosted store's root, used by the local search scan (which
+    /// indexes hosted/static packages only, never the proxy mirror).
+    pub fn hosted_root(&self) -> &Path {
+        &self.hosted.root
     }
 
-    // --- Authoritative (published) store --------------------------------
+    // --- Authoritative (hosted) store -----------------------------------
 
     /// Read the authoritative packument for `name`, fresh or stale.
-    /// Authoritative content has no TTL — it is the source of truth.
-    pub async fn read_published_packument(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
-        self.published.read_packument_any_age(name).await
+    /// Hosted content has no TTL — it is the source of truth.
+    pub async fn read_hosted_packument(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
+        self.hosted.read_packument_any_age(name).await
     }
 
-    pub async fn write_published_packument(&self, name: &PackageName, bytes: &[u8]) -> Result<()> {
-        self.published.write_packument(name, bytes).await
+    pub async fn write_hosted_packument(&self, name: &PackageName, bytes: &[u8]) -> Result<()> {
+        self.hosted.write_packument(name, bytes).await
     }
 
-    /// Reserve a tmp/final path pair for a tarball published to this
-    /// server. The publish flow streams the decode + hash + write
-    /// through `std::fs` inside `spawn_blocking` and only needs the
-    /// paths; finalize with [`Self::finalize_tarball_slot`].
-    pub async fn reserve_published_tarball(
+    /// Reserve a tmp/final path pair for a tarball this server hosts.
+    /// The publish flow streams the decode + hash + write through
+    /// `std::fs` inside `spawn_blocking` and only needs the paths;
+    /// finalize with [`Self::finalize_tarball_slot`].
+    pub async fn reserve_hosted_tarball(
         &self,
         name: &PackageName,
         filename: &str,
     ) -> Result<TarballSlot> {
-        self.published.reserve_tarball_paths(name, filename).await
+        self.hosted.reserve_tarball_paths(name, filename).await
     }
 
-    /// Remove a single tarball file from the authoritative store. The
+    /// Remove a single tarball file from the hosted store. The
     /// partial-unpublish flow calls this after PUT'ing the modified
     /// packument back.
-    pub async fn remove_published_tarball(
-        &self,
-        name: &PackageName,
-        filename: &str,
-    ) -> Result<bool> {
-        self.published.remove_tarball(name, filename).await
+    pub async fn remove_hosted_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
+        self.hosted.remove_tarball(name, filename).await
     }
 
     /// Remove the package from both stores. Unpublish must purge the
-    /// authoritative copy *and* any proxied mirror, so a stale cached
-    /// copy can't resurface after the package is gone.
+    /// hosted copy *and* any proxied mirror, so a stale cached copy
+    /// can't resurface after the package is gone.
     pub async fn remove_package(&self, name: &PackageName) -> Result<bool> {
-        let published = self.published.remove_package(name).await?;
+        let hosted = self.hosted.remove_package(name).await?;
         let cached = self.cache.remove_package(name).await?;
-        Ok(published || cached)
+        Ok(hosted || cached)
     }
 
     // --- Disposable (proxy) cache store ---------------------------------
@@ -183,10 +178,10 @@ impl Cache {
         self.cache.open_tarball_tmp(name, filename).await
     }
 
-    // --- Composed (published-first) -------------------------------------
+    // --- Composed (hosted-first) ----------------------------------------
 
-    /// Open a tarball for streaming, preferring the authoritative store
-    /// over the proxy mirror. Returns the open file plus its size (for
+    /// Open a tarball for streaming, preferring the hosted store over
+    /// the proxy mirror. Returns the open file plus its size (for
     /// `Content-Length`). `Ok(None)` means neither store has it, so the
     /// caller can fall through to the upstream fetch.
     pub async fn open_tarball(
@@ -194,7 +189,7 @@ impl Cache {
         name: &PackageName,
         filename: &str,
     ) -> Result<Option<(fs::File, u64)>> {
-        if let Some(hit) = self.published.open_tarball(name, filename).await? {
+        if let Some(hit) = self.hosted.open_tarball(name, filename).await? {
             return Ok(Some(hit));
         }
         self.cache.open_tarball(name, filename).await

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -52,10 +52,19 @@ pub struct Config {
     /// `dist.tarball` URLs in served packuments so tarball requests
     /// flow through this server.
     pub public_url: String,
-    /// Directory under which packuments and tarballs live.
-    /// In proxy mode this doubles as the cache; with no matching
-    /// `proxy:` rule it is the source of truth.
+    /// Directory under which authoritative packuments and tarballs
+    /// live: packages published to this server and the content served
+    /// in static mode. This is the source of truth — it is never
+    /// overwritten by an upstream refresh, so operators back it up and
+    /// keep it on a durable volume.
     pub storage: PathBuf,
+    /// Directory under which the disposable proxy cache lives —
+    /// the mirror of upstream registries plus the install-accelerator
+    /// store. Safe to wipe at any time; it self-heals on the next
+    /// request. Defaults to a `.pnpr-cache` subdirectory of
+    /// [`Self::storage`]; set the YAML `cache:` key (or `--cache`) to
+    /// an absolute path to put it on separate, ephemeral disk.
+    pub cache_storage: PathBuf,
     /// Named upstream npm registries. Referenced by name from
     /// [`PackageAccess::proxy`].
     pub uplinks: IndexMap<String, UplinkConfig>,
@@ -279,6 +288,10 @@ impl AccessSpec {
 struct ConfigFile {
     #[serde(default = "default_storage_string")]
     storage: String,
+    /// Disposable proxy-cache root. Not a verdaccio key — when omitted
+    /// it defaults to a `.pnpr-cache` subdirectory of `storage`.
+    #[serde(default)]
+    cache: Option<String>,
     #[serde(default)]
     uplinks: IndexMap<String, UplinkConfig>,
     #[serde(default)]
@@ -355,6 +368,7 @@ impl Config {
         Self {
             listen,
             public_url: format!("http://{listen}"),
+            cache_storage: default_cache_dir(&storage),
             storage,
             uplinks,
             packages,
@@ -371,6 +385,7 @@ impl Config {
         Self {
             listen,
             public_url: format!("http://{listen}"),
+            cache_storage: default_cache_dir(&storage),
             storage,
             uplinks: IndexMap::new(),
             packages: IndexMap::new(),
@@ -483,6 +498,11 @@ impl Config {
         let file: ConfigFile = serde_saphyr::from_str(&substituted)
             .map_err(|err| RegistryError::InvalidConfig { reason: err.to_string() })?;
         let storage = resolve_relative(&file.storage, base_dir);
+        let cache_storage = file
+            .cache
+            .as_deref()
+            .map(|raw| resolve_relative(raw, base_dir))
+            .unwrap_or_else(|| default_cache_dir(&storage));
         let public_url = public_url.unwrap_or_else(|| format!("http://{listen}"));
         let auth = build_auth_config(&file.auth, base_dir);
         let logs = build_log_config(file.log.as_ref());
@@ -491,6 +511,7 @@ impl Config {
             listen,
             public_url,
             storage,
+            cache_storage,
             uplinks: file.uplinks,
             packages: file.packages,
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
@@ -608,6 +629,17 @@ fn resolve_relative(raw: &str, base_dir: &Path) -> PathBuf {
 
 fn default_storage_string() -> String {
     "./storage".to_string()
+}
+
+/// The disposable proxy cache lives under a hidden `.pnpr-cache`
+/// subdirectory of `storage` by default. Nesting it under `storage`
+/// keeps a `--storage`-only deployment self-contained, while the dot
+/// prefix keeps the local search scan (which walks `<storage>/<pkg>`)
+/// from treating it as a package. Operators who want the cache on a
+/// separate, wipe-able volume point the `cache:` key at an absolute
+/// path instead.
+pub fn default_cache_dir(storage: &Path) -> PathBuf {
+    storage.join(".pnpr-cache")
 }
 
 /// Match a verdaccio package pattern against a package name.

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -108,6 +108,28 @@ fn from_yaml_str_absolute_storage_is_left_alone() {
 }
 
 #[test]
+fn cache_storage_defaults_to_subdir_of_storage() {
+    let yaml = "storage: /var/lib/pnpr\nuplinks: {}\npackages: {}\n";
+    let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
+    assert_eq!(config.cache_storage, PathBuf::from("/var/lib/pnpr/.pnpr-cache"));
+}
+
+#[test]
+fn explicit_cache_key_overrides_the_default() {
+    let yaml = "storage: /var/lib/pnpr\ncache: /scratch/pnpr\nuplinks: {}\npackages: {}\n";
+    let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
+    assert_eq!(config.storage, PathBuf::from("/var/lib/pnpr"));
+    assert_eq!(config.cache_storage, PathBuf::from("/scratch/pnpr"));
+}
+
+#[test]
+fn relative_cache_key_is_resolved_against_base_dir() {
+    let yaml = "storage: ./store\ncache: ./cache\nuplinks: {}\npackages: {}\n";
+    let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
+    assert_eq!(config.cache_storage, PathBuf::from("/etc/pnpr/./cache"));
+}
+
+#[test]
 fn from_yaml_str_ignores_unknown_sections() {
     // Sections we don't implement (`auth`, `web`, `plugins`, etc.)
     // must parse silently so existing config files work untouched.

--- a/pnpr/crates/pnpr/src/install_accelerator.rs
+++ b/pnpr/crates/pnpr/src/install_accelerator.rs
@@ -107,8 +107,8 @@ impl InstallAccelerator {
     }
 
     fn build(config: &RegistryConfig) -> InstallAccelerator {
-        let store_dir = config.storage.join("pnpr-store");
-        let cache_dir = config.storage.join("pnpr-cache");
+        let store_dir = config.cache_storage.join("pnpr-store");
+        let cache_dir = config.cache_storage.join("pnpr-cache");
         // Best-effort: a real failure here (e.g. a permission problem)
         // resurfaces with a precise error on the first store/cache write
         // during resolution, so there's nothing actionable to report yet.

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -8,7 +8,6 @@
 //! See <https://github.com/pnpm/pnpm> for the parent project.
 
 mod auth;
-mod cache;
 mod config;
 mod error;
 mod install_accelerator;
@@ -17,6 +16,7 @@ mod policy;
 mod publish;
 mod search;
 mod server;
+mod storage;
 mod streaming;
 mod upstream;
 

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -23,7 +23,7 @@ mod upstream;
 pub use auth::{AuthState, TokenStore, UserStore, identify};
 pub use config::{
     AuthConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML, HtpasswdConfig, LogConfig, LogFormat,
-    LogLevel, MaxUsers, PackageAccess, TokensConfig, UplinkConfig,
+    LogLevel, MaxUsers, PackageAccess, TokensConfig, UplinkConfig, default_cache_dir,
 };
 pub use error::{RegistryError, Result};
 pub use policy::{AccessList, AccessToken, Identity, PackagePolicies, PackagePolicy};

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use pnpr::{Config, ConfigSource, LogConfig, LogFormat, serve};
+use pnpr::{Config, ConfigSource, LogConfig, LogFormat, default_cache_dir, serve};
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
 use tracing_subscriber::EnvFilter;
 
@@ -19,9 +19,18 @@ struct Args {
 
     /// Override the storage path from the loaded config (bundled or
     /// `-c`). Useful for tests and benchmarks that want their own
-    /// cache directory without writing a custom YAML.
+    /// storage directory without writing a custom YAML. Unless
+    /// `--cache` is also given, the disposable proxy cache is
+    /// re-derived as a subdirectory of this path.
     #[arg(long)]
     storage: Option<PathBuf>,
+
+    /// Override the proxy-cache path — the disposable mirror of
+    /// upstream registries plus the install-accelerator store. Point
+    /// it at separate, ephemeral disk to keep published packages and
+    /// cached upstream content on different volumes.
+    #[arg(long)]
+    cache: Option<PathBuf>,
 
     /// URL clients should use to reach this server. Used when
     /// rewriting `dist.tarball` URLs in served packuments. Defaults
@@ -59,7 +68,14 @@ async fn main() -> miette::Result<()> {
                 config.auth.tokens.file = Some(storage.join("tokens.db"));
             }
         }
+        // Keep the cache co-located under the overridden storage dir so a
+        // `--storage`-only run stays self-contained, unless the caller
+        // pins the cache explicitly below.
+        config.cache_storage = default_cache_dir(&storage);
         config.storage = storage;
+    }
+    if let Some(cache) = args.cache {
+        config.cache_storage = cache;
     }
     if let Some(ttl_secs) = args.packument_ttl_secs {
         config.packument_ttl = Duration::from_secs(ttl_secs);

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -88,7 +88,7 @@ pub fn router(config: Config) -> Router {
 /// by [`serve`] to wire the persistent file-backed stores, and by
 /// tests that want to override the bcrypt cost or pre-seed users.
 pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
-    let cache = Cache::new(config.storage.clone());
+    let cache = Cache::new(config.storage.clone(), config.cache_storage.clone());
     let upstreams: IndexMap<String, Upstream> = config
         .uplinks
         .iter()
@@ -583,7 +583,7 @@ async fn serve_tarball(
     };
     let upstream_len = response.content_length();
 
-    let write = match state.inner.cache.open_tarball_tmp(&name, filename).await {
+    let write = match state.inner.cache.open_cached_tarball_tmp(&name, filename).await {
         Ok(w) => w,
         Err(err) => {
             tracing::warn!(?err, package = %name.as_str(), %filename, "tarball cache tmp-open failed; streaming without cache");
@@ -879,7 +879,7 @@ async fn publish_package(
     // would mask every upstream version + dist-tag on subsequent
     // reads. `update_dist_tag` already does the same fallback —
     // we just mirror it here.
-    let existing_bytes = match state.inner.cache.read_packument_any_age(&name).await {
+    let existing_bytes = match state.inner.cache.read_published_packument(&name).await {
         Ok(Some(bytes)) => Some(bytes),
         Ok(None) => match load_packument_bytes(state, &name).await {
             PackumentLoad::Ok(bytes) => Some(bytes),
@@ -913,7 +913,7 @@ async fn publish_package(
     // disk.
     let mut written_slots = Vec::with_capacity(prepared.len());
     for (attachment, canonical, dist) in prepared {
-        let slot = match state.inner.cache.reserve_tarball_paths(&name, &canonical).await {
+        let slot = match state.inner.cache.reserve_published_tarball(&name, &canonical).await {
             Ok(slot) => slot,
             Err(err) => {
                 cleanup_tmp_slots(written_slots).await;
@@ -950,7 +950,7 @@ async fn publish_package(
         }
     }
 
-    if let Err(err) = state.inner.cache.write_packument(&name, &merged_bytes).await {
+    if let Err(err) = state.inner.cache.write_published_packument(&name, &merged_bytes).await {
         return error_response(&err);
     }
 
@@ -1001,11 +1001,16 @@ async fn serve_search(state: &AppState, headers: &HeaderMap, query_string: &str)
             .expect("static-shape response always builds");
     };
     let size = crate::search::parse_size(query_string, 20);
-    let mut body =
-        match crate::search::run_local_search(&state.inner.config.storage, &text, size).await {
-            Ok(body) => body,
-            Err(err) => return error_response(&err),
-        };
+    let mut body = match crate::search::run_local_search(
+        state.inner.cache.published_root(),
+        &text,
+        size,
+    )
+    .await
+    {
+        Ok(body) => body,
+        Err(err) => return error_response(&err),
+    };
 
     // Augment with an upstream packument lookup for the exact query
     // name. Without this, freshly-prepared registry-mock storage
@@ -1116,7 +1121,7 @@ async fn update_packument(
         Ok(b) => b,
         Err(err) => return error_response(&RegistryError::Json(err)),
     };
-    if let Err(err) = state.inner.cache.write_packument(&name, &bytes).await {
+    if let Err(err) = state.inner.cache.write_published_packument(&name, &bytes).await {
         return error_response(&err);
     }
     let body = json!({ "ok": true });
@@ -1172,7 +1177,7 @@ async fn delete_tarball(
     if let Err(err) = enforce_access(state, headers, name.as_str(), Action::Publish) {
         return error_response(&err);
     }
-    if let Err(err) = state.inner.cache.remove_tarball(&name, &canonical).await {
+    if let Err(err) = state.inner.cache.remove_published_tarball(&name, &canonical).await {
         return error_response(&err);
     }
     let body = json!({ "ok": true });
@@ -1267,18 +1272,19 @@ where
         return error_response(&err);
     }
 
-    // Read whatever is on disk; we need the current packument even
-    // in proxy mode so the cached copy on disk gets the new tag.
-    // In static mode that's the only source.
-    let mut packument: Value = match state.inner.cache.read_packument_any_age(&name).await {
+    // Start from the authoritative packument if we have one. A
+    // dist-tag change is an authoritative override, so it is written
+    // back to the published store (below) regardless of whether the
+    // package originated locally or from upstream.
+    let mut packument: Value = match state.inner.cache.read_published_packument(&name).await {
         Ok(Some(bytes)) => match serde_json::from_slice(&bytes) {
             Ok(v) => v,
             Err(err) => return error_response(&RegistryError::Json(err)),
         },
         Ok(None) => {
-            // No cached packument — try to pull one from upstream
-            // so first-time dist-tag changes work against a fresh
-            // proxy cache.
+            // Nothing published yet — pull the current packument
+            // (cache or upstream) so a first dist-tag change against
+            // a proxied package starts from its real version list.
             match load_packument_bytes(state, &name).await {
                 PackumentLoad::Ok(bytes) => match serde_json::from_slice(&bytes) {
                     Ok(v) => v,
@@ -1331,7 +1337,7 @@ where
         Ok(b) => b,
         Err(err) => return error_response(&RegistryError::Json(err)),
     };
-    if let Err(err) = state.inner.cache.write_packument(&name, &new_bytes).await {
+    if let Err(err) = state.inner.cache.write_published_packument(&name, &new_bytes).await {
         return error_response(&err);
     }
     let body = json!({ "ok": true });
@@ -1437,8 +1443,22 @@ enum PackumentLoad {
 /// the cache when configured. The same logic backs both the packument
 /// and the version-manifest endpoints.
 async fn load_packument_bytes(state: &AppState, name: &PackageName) -> PackumentLoad {
+    // A locally-published or static-served packument is authoritative:
+    // serve it as-is and never overwrite it with an upstream refresh,
+    // so published versions can't be masked or lost.
+    match state.inner.cache.read_published_packument(name).await {
+        Ok(Some(bytes)) => return PackumentLoad::Ok(bytes),
+        Ok(None) => {}
+        Err(err) => {
+            tracing::warn!(?err, package = %name.as_str(), "published packument read failed")
+        }
+    }
+
     let Some(upstream) = resolve_upstream(state, name) else {
-        return match state.inner.cache.read_packument_any_age(name).await {
+        // Nothing published and no upstream to proxy. The only thing
+        // left is a leftover cache entry (e.g. a `proxy:` rule was
+        // removed after the package was mirrored).
+        return match state.inner.cache.read_cached_packument(name).await {
             Ok(Some(bytes)) => PackumentLoad::Ok(bytes),
             Ok(None) => PackumentLoad::NotFound,
             Err(err) => PackumentLoad::Err(err),
@@ -1446,7 +1466,7 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
     };
 
     let ttl = state.inner.config.packument_ttl;
-    match state.inner.cache.read_fresh_packument(name, ttl).await {
+    match state.inner.cache.read_fresh_cached_packument(name, ttl).await {
         Ok(Some(bytes)) => return PackumentLoad::Ok(bytes),
         Ok(None) => {}
         Err(err) => tracing::warn!(?err, package = %name.as_str(), "cache read failed"),
@@ -1454,7 +1474,7 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
 
     match upstream.fetch_packument(name).await {
         Ok(FetchOutcome::Ok(bytes)) => {
-            if let Err(err) = state.inner.cache.write_packument(name, &bytes).await {
+            if let Err(err) = state.inner.cache.write_cached_packument(name, &bytes).await {
                 tracing::warn!(?err, package = %name.as_str(), "packument cache write failed");
             }
             PackumentLoad::Ok(bytes)
@@ -1462,7 +1482,7 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
         Ok(FetchOutcome::NotFound) => PackumentLoad::NotFound,
         Err(err) => {
             tracing::warn!(?err, package = %name.as_str(), "upstream packument fetch failed");
-            match state.inner.cache.read_packument_any_age(name).await {
+            match state.inner.cache.read_cached_packument(name).await {
                 Ok(Some(bytes)) => PackumentLoad::Ok(bytes),
                 Ok(None) => PackumentLoad::Err(err),
                 Err(cache_err) => PackumentLoad::Err(cache_err),

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1,6 +1,5 @@
 use crate::{
     auth::{AuthState, UpsertOutcome, identify},
-    cache::Cache,
     config::Config,
     error::RegistryError,
     package_name::PackageName,
@@ -9,6 +8,7 @@ use crate::{
         PendingAttachment, extract_attachments, iso_from_unix_millis, merge_manifest, now_iso,
         stream_decode_verify_and_write,
     },
+    storage::Storage,
     streaming,
     upstream::{
         FetchOutcome, Upstream, abbreviate_packument, extract_version_manifest,
@@ -57,7 +57,7 @@ struct AppState {
 }
 
 struct AppInner {
-    cache: Cache,
+    storage: Storage,
     /// One [`Upstream`] per declared uplink, keyed by the same name
     /// used in [`Config::uplinks`]. Built once at router construction
     /// time so each request avoids re-allocating a `ThrottledClient`.
@@ -88,7 +88,7 @@ pub fn router(config: Config) -> Router {
 /// by [`serve`] to wire the persistent file-backed stores, and by
 /// tests that want to override the bcrypt cost or pre-seed users.
 pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
-    let cache = Cache::new(config.storage.clone(), config.cache_storage.clone());
+    let storage = Storage::new(config.storage.clone(), config.cache_storage.clone());
     let upstreams: IndexMap<String, Upstream> = config
         .uplinks
         .iter()
@@ -96,7 +96,7 @@ pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
         .collect();
     let state = AppState {
         inner: Arc::new(AppInner {
-            cache,
+            storage,
             upstreams,
             config,
             auth,
@@ -564,7 +564,7 @@ async fn serve_tarball(
         return error_response(&err);
     }
 
-    match state.inner.cache.open_tarball(&name, filename).await {
+    match state.inner.storage.open_tarball(&name, filename).await {
         Ok(Some((file, len))) => return tarball_response(streaming::stream_file(file), Some(len)),
         Ok(None) => {}
         Err(err) => {
@@ -583,7 +583,7 @@ async fn serve_tarball(
     };
     let upstream_len = response.content_length();
 
-    let write = match state.inner.cache.open_cached_tarball_tmp(&name, filename).await {
+    let write = match state.inner.storage.open_cached_tarball_tmp(&name, filename).await {
         Ok(w) => w,
         Err(err) => {
             tracing::warn!(?err, package = %name.as_str(), %filename, "tarball cache tmp-open failed; streaming without cache");
@@ -879,7 +879,7 @@ async fn publish_package(
     // would mask every upstream version + dist-tag on subsequent
     // reads. `update_dist_tag` already does the same fallback —
     // we just mirror it here.
-    let existing_bytes = match state.inner.cache.read_hosted_packument(&name).await {
+    let existing_bytes = match state.inner.storage.read_hosted_packument(&name).await {
         Ok(Some(bytes)) => Some(bytes),
         Ok(None) => match load_packument_bytes(state, &name).await {
             PackumentLoad::Ok(bytes) => Some(bytes),
@@ -913,7 +913,7 @@ async fn publish_package(
     // disk.
     let mut written_slots = Vec::with_capacity(prepared.len());
     for (attachment, canonical, dist) in prepared {
-        let slot = match state.inner.cache.reserve_hosted_tarball(&name, &canonical).await {
+        let slot = match state.inner.storage.reserve_hosted_tarball(&name, &canonical).await {
             Ok(slot) => slot,
             Err(err) => {
                 cleanup_tmp_slots(written_slots).await;
@@ -945,12 +945,12 @@ async fn publish_package(
     }
 
     for slot in written_slots {
-        if let Err(err) = state.inner.cache.finalize_tarball_slot(slot).await {
+        if let Err(err) = state.inner.storage.finalize_tarball_slot(slot).await {
             return error_response(&err);
         }
     }
 
-    if let Err(err) = state.inner.cache.write_hosted_packument(&name, &merged_bytes).await {
+    if let Err(err) = state.inner.storage.write_hosted_packument(&name, &merged_bytes).await {
         return error_response(&err);
     }
 
@@ -967,7 +967,7 @@ async fn publish_package(
 /// already wrote. Errors are swallowed: the caller is already
 /// returning an error response, and a leftover `*.tmp.*` file is
 /// harmless beyond a small amount of disk.
-async fn cleanup_tmp_slots(slots: Vec<crate::cache::TarballSlot>) {
+async fn cleanup_tmp_slots(slots: Vec<crate::storage::TarballSlot>) {
     for slot in slots {
         let _ = tokio::fs::remove_file(&slot.tmp_path).await;
     }
@@ -1002,7 +1002,8 @@ async fn serve_search(state: &AppState, headers: &HeaderMap, query_string: &str)
     };
     let size = crate::search::parse_size(query_string, 20);
     let mut body =
-        match crate::search::run_local_search(state.inner.cache.hosted_root(), &text, size).await {
+        match crate::search::run_local_search(state.inner.storage.hosted_root(), &text, size).await
+        {
             Ok(body) => body,
             Err(err) => return error_response(&err),
         };
@@ -1116,7 +1117,7 @@ async fn update_packument(
         Ok(b) => b,
         Err(err) => return error_response(&RegistryError::Json(err)),
     };
-    if let Err(err) = state.inner.cache.write_hosted_packument(&name, &bytes).await {
+    if let Err(err) = state.inner.storage.write_hosted_packument(&name, &bytes).await {
         return error_response(&err);
     }
     let body = json!({ "ok": true });
@@ -1138,7 +1139,7 @@ async fn delete_package(state: &AppState, headers: &HeaderMap, raw_name: &str) -
     if let Err(err) = enforce_access(state, headers, name.as_str(), Action::Publish) {
         return error_response(&err);
     }
-    if let Err(err) = state.inner.cache.remove_package(&name).await {
+    if let Err(err) = state.inner.storage.remove_package(&name).await {
         return error_response(&err);
     }
     let body = json!({ "ok": true });
@@ -1172,7 +1173,7 @@ async fn delete_tarball(
     if let Err(err) = enforce_access(state, headers, name.as_str(), Action::Publish) {
         return error_response(&err);
     }
-    if let Err(err) = state.inner.cache.remove_tarball(&name, &canonical).await {
+    if let Err(err) = state.inner.storage.remove_tarball(&name, &canonical).await {
         return error_response(&err);
     }
     let body = json!({ "ok": true });
@@ -1271,7 +1272,7 @@ where
     // dist-tag change is an authoritative override, so it is written
     // back to the hosted store (below) regardless of whether the
     // package originated locally or from upstream.
-    let mut packument: Value = match state.inner.cache.read_hosted_packument(&name).await {
+    let mut packument: Value = match state.inner.storage.read_hosted_packument(&name).await {
         Ok(Some(bytes)) => match serde_json::from_slice(&bytes) {
             Ok(v) => v,
             Err(err) => return error_response(&RegistryError::Json(err)),
@@ -1332,7 +1333,7 @@ where
         Ok(b) => b,
         Err(err) => return error_response(&RegistryError::Json(err)),
     };
-    if let Err(err) = state.inner.cache.write_hosted_packument(&name, &new_bytes).await {
+    if let Err(err) = state.inner.storage.write_hosted_packument(&name, &new_bytes).await {
         return error_response(&err);
     }
     let body = json!({ "ok": true });
@@ -1441,7 +1442,7 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
     // A hosted packument — published here or static-served — is
     // authoritative: serve it as-is and never overwrite it with an
     // upstream refresh, so hosted versions can't be masked or lost.
-    match state.inner.cache.read_hosted_packument(name).await {
+    match state.inner.storage.read_hosted_packument(name).await {
         Ok(Some(bytes)) => return PackumentLoad::Ok(bytes),
         Ok(None) => {}
         Err(err) => {
@@ -1453,7 +1454,7 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
         // Nothing published and no upstream to proxy. The only thing
         // left is a leftover cache entry (e.g. a `proxy:` rule was
         // removed after the package was mirrored).
-        return match state.inner.cache.read_cached_packument(name).await {
+        return match state.inner.storage.read_cached_packument(name).await {
             Ok(Some(bytes)) => PackumentLoad::Ok(bytes),
             Ok(None) => PackumentLoad::NotFound,
             Err(err) => PackumentLoad::Err(err),
@@ -1461,7 +1462,7 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
     };
 
     let ttl = state.inner.config.packument_ttl;
-    match state.inner.cache.read_fresh_cached_packument(name, ttl).await {
+    match state.inner.storage.read_fresh_cached_packument(name, ttl).await {
         Ok(Some(bytes)) => return PackumentLoad::Ok(bytes),
         Ok(None) => {}
         Err(err) => tracing::warn!(?err, package = %name.as_str(), "cache read failed"),
@@ -1469,7 +1470,7 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
 
     match upstream.fetch_packument(name).await {
         Ok(FetchOutcome::Ok(bytes)) => {
-            if let Err(err) = state.inner.cache.write_cached_packument(name, &bytes).await {
+            if let Err(err) = state.inner.storage.write_cached_packument(name, &bytes).await {
                 tracing::warn!(?err, package = %name.as_str(), "packument cache write failed");
             }
             PackumentLoad::Ok(bytes)
@@ -1477,7 +1478,7 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
         Ok(FetchOutcome::NotFound) => PackumentLoad::NotFound,
         Err(err) => {
             tracing::warn!(?err, package = %name.as_str(), "upstream packument fetch failed");
-            match state.inner.cache.read_cached_packument(name).await {
+            match state.inner.storage.read_cached_packument(name).await {
                 Ok(Some(bytes)) => PackumentLoad::Ok(bytes),
                 Ok(None) => PackumentLoad::Err(err),
                 Err(cache_err) => PackumentLoad::Err(cache_err),

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1172,7 +1172,7 @@ async fn delete_tarball(
     if let Err(err) = enforce_access(state, headers, name.as_str(), Action::Publish) {
         return error_response(&err);
     }
-    if let Err(err) = state.inner.cache.remove_hosted_tarball(&name, &canonical).await {
+    if let Err(err) = state.inner.cache.remove_tarball(&name, &canonical).await {
         return error_response(&err);
     }
     let body = json!({ "ok": true });

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -879,7 +879,7 @@ async fn publish_package(
     // would mask every upstream version + dist-tag on subsequent
     // reads. `update_dist_tag` already does the same fallback —
     // we just mirror it here.
-    let existing_bytes = match state.inner.cache.read_published_packument(&name).await {
+    let existing_bytes = match state.inner.cache.read_hosted_packument(&name).await {
         Ok(Some(bytes)) => Some(bytes),
         Ok(None) => match load_packument_bytes(state, &name).await {
             PackumentLoad::Ok(bytes) => Some(bytes),
@@ -913,7 +913,7 @@ async fn publish_package(
     // disk.
     let mut written_slots = Vec::with_capacity(prepared.len());
     for (attachment, canonical, dist) in prepared {
-        let slot = match state.inner.cache.reserve_published_tarball(&name, &canonical).await {
+        let slot = match state.inner.cache.reserve_hosted_tarball(&name, &canonical).await {
             Ok(slot) => slot,
             Err(err) => {
                 cleanup_tmp_slots(written_slots).await;
@@ -950,7 +950,7 @@ async fn publish_package(
         }
     }
 
-    if let Err(err) = state.inner.cache.write_published_packument(&name, &merged_bytes).await {
+    if let Err(err) = state.inner.cache.write_hosted_packument(&name, &merged_bytes).await {
         return error_response(&err);
     }
 
@@ -1001,16 +1001,11 @@ async fn serve_search(state: &AppState, headers: &HeaderMap, query_string: &str)
             .expect("static-shape response always builds");
     };
     let size = crate::search::parse_size(query_string, 20);
-    let mut body = match crate::search::run_local_search(
-        state.inner.cache.published_root(),
-        &text,
-        size,
-    )
-    .await
-    {
-        Ok(body) => body,
-        Err(err) => return error_response(&err),
-    };
+    let mut body =
+        match crate::search::run_local_search(state.inner.cache.hosted_root(), &text, size).await {
+            Ok(body) => body,
+            Err(err) => return error_response(&err),
+        };
 
     // Augment with an upstream packument lookup for the exact query
     // name. Without this, freshly-prepared registry-mock storage
@@ -1121,7 +1116,7 @@ async fn update_packument(
         Ok(b) => b,
         Err(err) => return error_response(&RegistryError::Json(err)),
     };
-    if let Err(err) = state.inner.cache.write_published_packument(&name, &bytes).await {
+    if let Err(err) = state.inner.cache.write_hosted_packument(&name, &bytes).await {
         return error_response(&err);
     }
     let body = json!({ "ok": true });
@@ -1177,7 +1172,7 @@ async fn delete_tarball(
     if let Err(err) = enforce_access(state, headers, name.as_str(), Action::Publish) {
         return error_response(&err);
     }
-    if let Err(err) = state.inner.cache.remove_published_tarball(&name, &canonical).await {
+    if let Err(err) = state.inner.cache.remove_hosted_tarball(&name, &canonical).await {
         return error_response(&err);
     }
     let body = json!({ "ok": true });
@@ -1274,9 +1269,9 @@ where
 
     // Start from the authoritative packument if we have one. A
     // dist-tag change is an authoritative override, so it is written
-    // back to the published store (below) regardless of whether the
+    // back to the hosted store (below) regardless of whether the
     // package originated locally or from upstream.
-    let mut packument: Value = match state.inner.cache.read_published_packument(&name).await {
+    let mut packument: Value = match state.inner.cache.read_hosted_packument(&name).await {
         Ok(Some(bytes)) => match serde_json::from_slice(&bytes) {
             Ok(v) => v,
             Err(err) => return error_response(&RegistryError::Json(err)),
@@ -1337,7 +1332,7 @@ where
         Ok(b) => b,
         Err(err) => return error_response(&RegistryError::Json(err)),
     };
-    if let Err(err) = state.inner.cache.write_published_packument(&name, &new_bytes).await {
+    if let Err(err) = state.inner.cache.write_hosted_packument(&name, &new_bytes).await {
         return error_response(&err);
     }
     let body = json!({ "ok": true });
@@ -1443,10 +1438,10 @@ enum PackumentLoad {
 /// the cache when configured. The same logic backs both the packument
 /// and the version-manifest endpoints.
 async fn load_packument_bytes(state: &AppState, name: &PackageName) -> PackumentLoad {
-    // A locally-published or static-served packument is authoritative:
-    // serve it as-is and never overwrite it with an upstream refresh,
-    // so published versions can't be masked or lost.
-    match state.inner.cache.read_published_packument(name).await {
+    // A hosted packument — published here or static-served — is
+    // authoritative: serve it as-is and never overwrite it with an
+    // upstream refresh, so hosted versions can't be masked or lost.
+    match state.inner.cache.read_hosted_packument(name).await {
         Ok(Some(bytes)) => return PackumentLoad::Ok(bytes),
         Ok(None) => {}
         Err(err) => {

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -19,7 +19,7 @@ const PACKUMENT_FILE: &str = "package.json";
 /// and dest sit in the same directory (they do).
 static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-/// Handle returned from [`Cache::open_cached_tarball_tmp`]. The caller
+/// Handle returned from [`Storage::open_cached_tarball_tmp`]. The caller
 /// writes to `file` (and on success calls [`Self::finalize`] to
 /// atomically promote the temp file to the final cache path); dropping
 /// the handle without calling [`Self::finalize`] is treated as abandon
@@ -33,7 +33,7 @@ pub struct TarballWrite {
 
 /// A reserved (tmp_path, final_path) pair for a tarball write. The
 /// publish flow writes the tarball to `tmp_path` inside a blocking
-/// task, then renames via [`Cache::finalize_tarball_slot`].
+/// task, then renames via [`Storage::finalize_tarball_slot`].
 #[derive(Debug)]
 pub struct TarballSlot {
     pub tmp_path: PathBuf,
@@ -88,12 +88,12 @@ impl TarballWrite {
 /// publishes, so a populated verdaccio storage can be served directly
 /// in static mode.
 #[derive(Debug, Clone)]
-pub struct Cache {
+pub struct Storage {
     hosted: Store,
     cached: Store,
 }
 
-impl Cache {
+impl Storage {
     pub fn new(hosted_root: PathBuf, cache_root: PathBuf) -> Self {
         Self { hosted: Store::new(hosted_root), cached: Store::new(cache_root) }
     }

--- a/pnpr/crates/pnpr/src/streaming.rs
+++ b/pnpr/crates/pnpr/src/streaming.rs
@@ -10,7 +10,7 @@
 //!   final cache path on stream completion. On upstream error or
 //!   client disconnect the temp file is removed.
 
-use crate::cache::TarballWrite;
+use crate::storage::TarballWrite;
 use axum::body::{Body, Bytes};
 use futures_util::{
     Stream,

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -202,6 +202,57 @@ async fn authenticated_publish_writes_manifest_and_tarball() {
     );
 }
 
+/// Published packages are the source of truth: they live in the
+/// authoritative `storage` root, never in the disposable proxy cache,
+/// and survive a full wipe of that cache.
+#[tokio::test]
+async fn published_package_survives_wiping_the_proxy_cache() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let bytes = b"durable-tarball-bytes";
+    let body = sample_publish_body("durable-pkg", "1.0.0", bytes);
+    let request = Request::put("/durable-pkg")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    assert_eq!(app.clone().oneshot(request).await.unwrap().status(), StatusCode::CREATED);
+
+    // The artifacts land in the authoritative root, not the cache.
+    assert!(storage.join("durable-pkg/package.json").exists());
+    assert!(storage.join("durable-pkg/durable-pkg-1.0.0.tgz").exists());
+    assert!(
+        !storage.join(".pnpr-cache/durable-pkg").exists(),
+        "published package must not be written into the disposable proxy cache",
+    );
+
+    // Blow away the entire proxy cache, the way an operator reclaiming
+    // disk (or a fresh container on an ephemeral cache volume) would.
+    let cache_root = storage.join(".pnpr-cache");
+    std::fs::create_dir_all(&cache_root).unwrap();
+    std::fs::remove_dir_all(&cache_root).unwrap();
+
+    // The package is still served, tarball and all.
+    let response = app
+        .clone()
+        .oneshot(Request::get("/durable-pkg").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let served = body_json(response.into_body()).await;
+    assert_eq!(served["versions"]["1.0.0"]["version"], "1.0.0");
+
+    let response = app
+        .oneshot(Request::get("/durable-pkg/-/durable-pkg-1.0.0.tgz").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_bytes(response.into_body()).await, bytes);
+}
+
 #[tokio::test]
 async fn publish_followed_by_dist_tag_set_works() {
     let tmp = TempDir::new().unwrap();
@@ -844,9 +895,10 @@ async fn search_augments_with_upstream_when_local_misses_exact_name() {
     );
     assert_eq!(body["total"], names.len());
 
-    // The augment also caches the packument; subsequent search hits
-    // disk without another upstream call.
-    let on_disk = tmp.path().join("ghost-pkg/package.json");
+    // The augment also caches the packument in the disposable proxy
+    // cache, so a subsequent search reuses it without another upstream
+    // call.
+    let on_disk = tmp.path().join(".pnpr-cache").join("ghost-pkg/package.json");
     assert!(on_disk.exists(), "augment must cache the fetched packument");
 }
 

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -253,6 +253,37 @@ async fn published_package_survives_wiping_the_proxy_cache() {
     assert_eq!(body_bytes(response.into_body()).await, bytes);
 }
 
+/// When the same tarball filename exists in both stores, `open_tarball`
+/// serves the hosted copy — a stale proxied copy can't shadow it.
+#[tokio::test]
+async fn hosted_tarball_is_preferred_over_a_cached_copy() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let hosted_bytes = b"hosted-bytes";
+    let body = sample_publish_body("pref-pkg", "1.0.0", hosted_bytes);
+    let request = Request::put("/pref-pkg")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    assert_eq!(app.clone().oneshot(request).await.unwrap().status(), StatusCode::CREATED);
+
+    // Plant a divergent proxied copy with the same filename.
+    let cached = storage.join(".pnpr-cache").join("pref-pkg");
+    std::fs::create_dir_all(&cached).unwrap();
+    std::fs::write(cached.join("pref-pkg-1.0.0.tgz"), b"stale-proxied-bytes").unwrap();
+
+    let response = app
+        .oneshot(Request::get("/pref-pkg/-/pref-pkg-1.0.0.tgz").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_bytes(response.into_body()).await, hosted_bytes);
+}
+
 #[tokio::test]
 async fn publish_followed_by_dist_tag_set_works() {
     let tmp = TempDir::new().unwrap();

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -1020,6 +1020,47 @@ async fn unpublish_partial_writes_modified_packument() {
     assert_eq!(response.status(), StatusCode::CREATED);
 }
 
+/// Deleting a hosted tarball must also drop any proxied copy with the
+/// same filename, so `open_tarball`'s cache fallback can't keep serving
+/// the just-removed version.
+#[tokio::test]
+async fn unpublish_tarball_also_clears_the_proxied_copy() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let body = sample_publish_body("blend-pkg", "1.0.0", b"hosted-bytes");
+    let request = Request::put("/blend-pkg")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    assert_eq!(app.clone().oneshot(request).await.unwrap().status(), StatusCode::CREATED);
+
+    // Plant a stale proxied copy of the same tarball in the cache root,
+    // as a `proxy:` rule would have left behind.
+    let cached = storage.join(".pnpr-cache").join("blend-pkg");
+    std::fs::create_dir_all(&cached).unwrap();
+    std::fs::write(cached.join("blend-pkg-1.0.0.tgz"), b"stale-proxied-bytes").unwrap();
+
+    let request = Request::delete("/blend-pkg/-/blend-pkg-1.0.0.tgz/-rev/anything")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    assert_eq!(app.clone().oneshot(request).await.unwrap().status(), StatusCode::CREATED);
+
+    assert!(!storage.join("blend-pkg/blend-pkg-1.0.0.tgz").exists());
+    assert!(!cached.join("blend-pkg-1.0.0.tgz").exists(), "proxied copy must be removed too");
+
+    // With both stores cleared and no upstream, the version is gone.
+    let response = app
+        .oneshot(Request::get("/blend-pkg/-/blend-pkg-1.0.0.tgz").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
 #[tokio::test]
 async fn unpublish_force_removes_entire_package() {
     let tmp = TempDir::new().unwrap();

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -181,7 +181,8 @@ async fn tarball_streaming_finalizes_cache_with_no_tmp_leftover() {
     // By the time the client's stream ends (rx sees None), the tee
     // task has already called finalize, so the cache file is in
     // place at the canonical path and no `.tmp.*` siblings remain.
-    let package_dir = cache_dir.join("big");
+    // Proxied tarballs land in the disposable cache root.
+    let package_dir = cache_dir.join(".pnpr-cache").join("big");
     let entries: Vec<String> = std::fs::read_dir(&package_dir)
         .unwrap()
         .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
@@ -377,8 +378,8 @@ async fn concurrent_tarball_fetches_settle_to_one_cache_file() {
     // `finalize` (rename is last-writer-wins on POSIX, and both
     // wrote identical content). Exactly one `.tgz` file in the
     // package dir, no `.tmp.*` survivors thanks to the unique-tmp
-    // suffix.
-    let dir = cache_dir.join("foo");
+    // suffix. Proxied tarballs live in the disposable cache root.
+    let dir = cache_dir.join(".pnpr-cache").join("foo");
     let entries: Vec<String> = std::fs::read_dir(&dir)
         .unwrap()
         .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
@@ -401,8 +402,8 @@ async fn cache_tmp_open_failure_falls_back_to_uncached_stream() {
         .await;
 
     // Point `cache_dir` at a regular file so `create_dir_all` inside
-    // `open_tarball_tmp` fails. The handler should still stream the
-    // body to the client and skip the cache write.
+    // `open_cached_tarball_tmp` fails. The handler should still stream
+    // the body to the client and skip the cache write.
     let tmp = TempDir::new().unwrap();
     let blocked = tmp.path().join("not-a-dir");
     std::fs::write(&blocked, b"already a file").unwrap();
@@ -417,7 +418,7 @@ async fn cache_tmp_open_failure_falls_back_to_uncached_stream() {
     assert_eq!(body_bytes(response.into_body()).await, bytes);
 
     // The cache path under the not-a-dir should not exist.
-    let cache_path = blocked.join("foo").join("foo-1.0.0.tgz");
+    let cache_path = blocked.join(".pnpr-cache").join("foo").join("foo-1.0.0.tgz");
     assert!(!cache_path.exists());
 }
 
@@ -493,7 +494,7 @@ async fn upstream_stream_error_clears_cache() {
     // should happen quickly — poll for it so the test fails fast on
     // success and gives a 1s budget for the worst case (heavy CI
     // load).
-    assert!(await_no_tgz(&cache_dir.join("foo"), Duration::from_secs(1)).await);
+    assert!(await_no_tgz(&cache_dir.join(".pnpr-cache").join("foo"), Duration::from_secs(1)).await);
 }
 
 #[tokio::test]
@@ -525,7 +526,7 @@ async fn client_disconnect_mid_stream_clears_cache() {
     // `write.abandon()` runs. Poll for the abandon so the test
     // doesn't depend on a fixed sleep budget under heavy CI load.
     drop(response);
-    assert!(await_no_tgz(&cache_dir.join("big"), Duration::from_secs(1)).await);
+    assert!(await_no_tgz(&cache_dir.join(".pnpr-cache").join("big"), Duration::from_secs(1)).await);
 }
 
 /// Poll `dir` until it contains no `.tgz` files *and* no `.tmp.*`

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -294,6 +294,55 @@ async fn packument_is_refetched_after_ttl_expires() {
     mock.assert_async().await;
 }
 
+/// A hosted packument is authoritative: even with a proxy upstream
+/// configured, a divergent upstream packument, and an expired TTL, the
+/// hosted copy is served verbatim and the upstream is never contacted.
+/// This is the guarantee that published versions can't be masked or
+/// lost by a proxy refresh.
+#[tokio::test]
+async fn hosted_packument_is_never_overwritten_by_upstream() {
+    let mut upstream = mockito::Server::new_async().await;
+    let upstream_mock = upstream
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_body(json!({ "name": "foo", "versions": { "9.9.9": {} } }).to_string())
+        .expect(0)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+
+    // Seed the hosted store directly, as a publish (or static fixture)
+    // would have. The hosted root is `config.storage` == tmp.
+    let hosted = json!({
+        "name": "foo",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "1.0.0": { "name": "foo", "version": "1.0.0", "dist": {
+                "tarball": "http://example.test/foo/-/foo-1.0.0.tgz", "shasum": "abc"
+            }},
+        },
+    });
+    std::fs::create_dir_all(tmp.path().join("foo")).unwrap();
+    std::fs::write(tmp.path().join("foo/package.json"), hosted.to_string()).unwrap();
+
+    let mut config = config_for(&upstream.url(), tmp.path().to_path_buf());
+    // Zero TTL: if the hosted copy were treated as a cache entry, this
+    // would force an immediate upstream refetch.
+    config.packument_ttl = Duration::from_millis(0);
+    let app = router(config);
+
+    let response = app.oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    let versions: Vec<&str> =
+        body["versions"].as_object().unwrap().keys().map(String::as_str).collect();
+    assert_eq!(versions, vec!["1.0.0"], "hosted packument must win over upstream's 9.9.9");
+
+    // The upstream was never hit — the hosted copy short-circuits the proxy.
+    upstream_mock.assert_async().await;
+}
+
 #[tokio::test]
 async fn stale_packument_is_served_when_upstream_fails() {
     let mut upstream = mockito::Server::new_async().await;


### PR DESCRIPTION
## What

Splits pnpr's on-disk storage into two physically separate roots so the disposable proxy cache and the authoritative **hosted** packages no longer share a lifecycle.

Closes #12194.

### Before

Proxied upstream packuments/tarballs and locally-published packages were written to the same `<storage>/<pkg>/` tree through a single `Cache` abstraction, with no marker distinguishing them. Consequences:

- No safe way to clear the proxy cache — deleting a package dir removed hosted packages too.
- Hosted packages shared a lifecycle with disposable cache; a naive "clear the cache" could wipe the source of truth.
- Backups and upgrades had to treat the entire (reconstructible) mirror as precious data.

### After

| | `storage` (hosted) | `cache` (proxy) |
|---|---|---|
| Holds | packages this server hosts directly (published via its API) + static-served content | proxied upstream mirror + install-accelerator store |
| Durability | source of truth, never overwritten by an upstream refresh | safe to wipe anytime; self-heals on next request |
| Default | `./storage` | `<storage>/.pnpr-cache` |
| Override | `storage:` / `--storage` | `cache:` / `--cache` (point at a separate ephemeral volume) |

- A new `Storage` type wraps two `Store` roots — `hosted` (authoritative) and `cached` (disposable). Reads prefer the hosted store; a hosted/static packument is served as-is and never refreshed over.
- Publish, unpublish, packument PUTs and dist-tag changes write to the hosted store; upstream refreshes write only to the cache.
- Removal clears both stores — full unpublish *and* partial (single-tarball) unpublish — so a stale proxied copy can't resurface via the tarball-read fallback.
- The install-accelerator CAS + verdict DB move under the cache root.

### Naming

- Internally the two roots are the `hosted` / `cached` fields of the `Storage` type (`hosted`/`proxy` is the registry-server convention, e.g. Sonatype Nexus).
- The user-facing YAML keys stay `storage:` / `cache:` (nouns that name directories, the clearest register for a setting), which also keeps verdaccio-shaped configs working.

### Server / deployment

- Put `storage` on a durable, backed-up volume and `cache` on scratch/ephemeral disk (or just leave the default subdir).
- **Upgrades retain hosted packages trivially**: point the new server at the same `storage`; the cache can start cold.
- **DR**: back up only `storage`.

### Migration note

Existing proxy deployments have proxied packuments sitting in the old `storage` root. After upgrading they are treated as hosted (never refreshed). Operators who want them to resume refreshing should clear the old storage dir or move cached content out; new proxied content caches correctly into `.pnpr-cache`. The separation is forward-looking.

## Tests

New tests:
- `hosted_packument_is_never_overwritten_by_upstream` — with a proxy upstream, a divergent upstream packument and a zero TTL, the hosted copy is still served and the upstream is never contacted (the "published versions can't be masked or lost" invariant).
- `hosted_tarball_is_preferred_over_a_cached_copy` — `open_tarball` serves the hosted copy when both stores hold the same filename.
- `published_package_survives_wiping_the_proxy_cache` — a hosted package survives a full `.pnpr-cache` wipe and is never written into it.
- `unpublish_tarball_also_clears_the_proxied_copy` — partial unpublish removes the proxied copy too.
- Config: default cache-dir derivation, explicit `cache:` key, relative-path resolution.

Plus: updated the existing proxy-cache path assertions to the new cache root. Full pnpr suite green (229 tests), `cargo check --workspace` clean, clippy + rustfmt + typos clean.

pnpr-only change — no pacquet port or changeset needed.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Separated cache and package storage—cache is now isolated in a `.pnpr-cache` subdirectory by default, keeping published packages durable.
  * Added `--cache` CLI flag to configure cache location independently from package storage.

* **Tests**
  * Added integration tests validating cache isolation and package persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
