### PR TITLE
test(registry-mock): read uplinked packuments from pnpr's proxy cache dir

### DIFF
--- a/testing/registry-mock/src/index.ts
+++ b/testing/registry-mock/src/index.ts
@@ -58,14 +58,21 @@ export async function addUser (opts: AddUserOptions): Promise<AddUserResult> {
   })
 }
 
+// pnpr keeps proxied upstream packages in a cache mirror separate from hosted
+// (fixture) packages — a `.pnpr-cache` subdirectory of the storage root.
+const PROXY_CACHE_DIR = '.pnpr-cache'
+
+type Packument = { versions: Record<string, { dist: { integrity: string } }> }
+
 /**
  * Reads a package version's tarball integrity from the registry storage that
  * the test harness built from the fixtures. The storage path is published as
  * `PNPM_REGISTRY_MOCK_STORAGE` by the with-registry jest globalSetup.
  *
- * Uplinked packages (proxied from the upstream registry) are written to
- * storage lazily on first request, so the read is retried briefly while the
- * packument is still being written.
+ * Hosted (fixture) packuments live at `<storage>/<pkg>/package.json`; upstream
+ * packages are proxied into `<storage>/.pnpr-cache/<pkg>/package.json`, written
+ * lazily on first request — so both are tried and the read is retried while the
+ * cache write is still in flight.
  */
 export function getIntegrity (pkgName: string, pkgVersion: string): string {
   const storage = process.env.PNPM_REGISTRY_MOCK_STORAGE
@@ -75,30 +82,44 @@ export function getIntegrity (pkgName: string, pkgVersion: string): string {
       'Tests that call getIntegrity must run under the with-registry jest preset.'
     )
   }
-  const filePath = path.join(storage, pkgName, 'package.json')
+  const candidatePaths = [
+    path.join(storage, pkgName, 'package.json'),
+    path.join(storage, PROXY_CACHE_DIR, pkgName, 'package.json'),
+  ]
   const maxRetries = 4
   let delay = 200 // milliseconds
-  let content: { versions: Record<string, { dist: { integrity: string } }> } | undefined
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    try {
-      content = JSON.parse(fs.readFileSync(filePath, 'utf8'))
-      break
-    } catch (err: unknown) {
-      if (attempt === maxRetries || !isTransientReadError(err)) {
-        throw err
-      }
-      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delay)
-      delay *= 2
+    const content = readPackument(candidatePaths)
+    if (content) {
+      return content.versions[pkgVersion].dist.integrity
     }
+    if (attempt === maxRetries) break
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delay)
+    delay *= 2
   }
-  if (!content) {
-    throw new Error(`Failed to read package.json for ${pkgName}@${pkgVersion} after ${maxRetries} attempts`)
-  }
-  return content.versions[pkgVersion].dist.integrity
+  throw new Error(`Failed to read package.json for ${pkgName}@${pkgVersion} after ${maxRetries} attempts`)
 }
 
-function isTransientReadError (err: unknown): boolean {
-  if (!err || typeof err !== 'object') return false
-  if (err instanceof SyntaxError && err.message.endsWith('Unexpected end of JSON input')) return true
-  return (err as NodeJS.ErrnoException).code === 'ENOENT'
+// Returns the first readable packument among the candidates, or `undefined` when
+// none is ready yet (missing file or partial write) so the caller retries.
+// Re-throws any other read/parse error so genuine failures surface immediately.
+function readPackument (candidatePaths: string[]): Packument | undefined {
+  for (const filePath of candidatePaths) {
+    let raw: string
+    try {
+      raw = fs.readFileSync(filePath, 'utf8')
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue
+      throw err
+    }
+    try {
+      return JSON.parse(raw) as Packument
+    } catch (err: unknown) {
+      if (err instanceof SyntaxError && err.message.endsWith('Unexpected end of JSON input')) {
+        return undefined
+      }
+      throw err
+    }
+  }
+  return undefined
 }


### PR DESCRIPTION
## What

`getIntegrity` (in `@pnpm/testing.registry-mock`) now resolves a package version's tarball integrity from **either** the hosted location (`<storage>/<pkg>/package.json`) **or** pnpr's proxy cache (`<storage>/.pnpr-cache/<pkg>/package.json`), keeping the existing retry for the lazy/in-flight cache write.

## Why

#12195 (`feat(pnpr): separate the proxied upstream cache from published packages`) moved proxied upstream packuments out of the storage root into a `.pnpr-cache` subdirectory, but the `getIntegrity` test helper still only read the hosted `<storage>/<pkg>/package.json` path.

As a result, every test that resolves integrity for a package **uplinked from the real npm registry** failed with `ENOENT` and `main` has been red since:

```
ENOENT: no such file or directory, open '/tmp/pnpm-registry-mock-storage-XXXX/express/package.json'
  at getIntegrity (testing/registry-mock/src/index.ts)
```

- `store/commands/test/store/storeAdd.ts` → `pnpm store add express@4.16.3`
- `store/commands/test/store/storePrune.ts` → `remove packages that are used by project that no longer exist` (`is-negative`)

Fixture/hosted packages (e.g. `@foo/no-deps`) were unaffected because they live in the hosted store; only the upstream-proxied packages moved.

## Verification

- Reproduced directly: pnpr serves the `express`/`is-negative` packuments (HTTP 200) and writes them to `<storage>/.pnpr-cache/<pkg>/package.json`, not `<storage>/<pkg>/package.json`.
- With the fix, both previously-failing suites pass: `storeAdd.ts` + `storePrune.ts` → **18/18**.
- `@pnpm/testing.registry-mock` is `private: true`, so no changeset is required.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry mock stability when handling upstream-proxied packages with enhanced retry logic, exponential backoff, and better transient error handling.

* **Chores**
  * Refactored package integrity verification to support additional cache mirror directories and multiple source locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->