### PR TITLE
fix: preserve fetch overrides for package-manager-only manifests

### DIFF
--- a/.changeset/fetch-dollar-overrides.md
+++ b/.changeset/fetch-dollar-overrides.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Do not resolve `$` override references against a root manifest that has no direct dependencies. This keeps commands such as `pnpm fetch` working when Docker layers include only a lockfile, `pnpm-workspace.yaml`, and a package-manager-only `package.json` [#12160](https://github.com/pnpm/pnpm/issues/12160).

--- a/config/reader/src/getOptionsFromRootManifest.ts
+++ b/config/reader/src/getOptionsFromRootManifest.ts
@@ -31,7 +31,7 @@ export function getOptionsFromPnpmSettings (manifestDir: string | undefined, pnp
     assertValidOverrides(settings.overrides)
     if (Object.keys(settings.overrides).length === 0) {
       delete settings.overrides
-    } else if (manifest) {
+    } else if (manifestHasDirectDependencies(manifest)) {
       settings.overrides = mapValues(createVersionReferencesReplacer(manifest), settings.overrides)
     }
   }
@@ -99,6 +99,14 @@ function createVersionReferencesReplacer (manifest: ProjectManifest): (spec: str
     ...manifest.optionalDependencies,
   }
   return replaceVersionReferences.bind(null, allDeps)
+}
+
+function manifestHasDirectDependencies (manifest?: ProjectManifest): manifest is ProjectManifest {
+  return Boolean(
+    Object.keys(manifest?.devDependencies ?? {}).length > 0 ||
+    Object.keys(manifest?.dependencies ?? {}).length > 0 ||
+    Object.keys(manifest?.optionalDependencies ?? {}).length > 0
+  )
 }
 
 function replaceVersionReferences (dep: Record<string, string>, spec: string): string {

--- a/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -85,3 +85,17 @@ test('getOptionsFromPnpmSettings() rejects non-object overrides values', () => {
     message: 'The overrides field should be an object, but got array',
   }))
 })
+
+test('getOptionsFromPnpmSettings() preserves version references when the manifest has no direct dependencies', () => {
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    overrides: {
+      react: '$react',
+    },
+  }, {
+    packageManager: 'pnpm@11.5.0',
+  })
+
+  expect(options.overrides).toStrictEqual({
+    react: '$react',
+  })
+})

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -474,6 +474,31 @@ test('camelCase settings from pnpm-workspace.yaml are read into typed Config pro
   })
 })
 
+test('workspace overrides with $ references do not fail for a package-manager-only manifest', async () => {
+  prepare({
+    packageManager: 'pnpm@11.5.0',
+  })
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    overrides: {
+      react: '$react',
+    },
+  })
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    packageManager: {
+      name: 'pnpm',
+      version: '11.5.0',
+    },
+    workspaceDir: process.cwd(),
+  })
+
+  expect(config.overrides).toStrictEqual({
+    react: '$react',
+  })
+})
+
 test('workspace-specific settings are read into typed Config properties', async () => {
   prepareEmpty()
 


### PR DESCRIPTION
## Summary

- Preserve `$` override references when the root manifest has no direct dependencies.
- Continue resolving `$foo` references from direct dependencies when they exist.
- Add regression coverage for the `pnpm fetch` / package-manager-only manifest case.

Closes #12160.

## Test plan

- [x] `PATH="$PWD/pnpm/artifacts/exe:$PATH" pnpm --filter @pnpm/config.reader run test test/getOptionsFromRootManifest.test.ts test/index.ts --runInBand` — passed, 2 suites, 129 tests, 1 skipped
- [x] `PATH="$PWD/pnpm/artifacts/exe:$PATH" pnpm --filter @pnpm/config.reader run test --runInBand` — passed, 12 suites, 209 tests, 1 skipped
- [x] `git diff --check` — passed

## AI assistance

OpenAI Codex helped reproduce the fetch override issue and draft the patch. I reviewed the diff, checked the package-manager-only fetch override behavior, reran the tests above, and take responsibility for the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `$` override references to work correctly in Docker environments with minimal manifests, ensuring `pnpm fetch` functions properly without full package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->