### PR TITLE
perf(pnpr): stream the /v1/install response instead of buffering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3336,8 +3336,10 @@ name = "pacquet-pnpr-client"
 version = "0.0.1"
 dependencies = [
  "base64 0.22.1",
+ "bytes",
  "derive_more",
  "flate2",
+ "futures-util",
  "mockito",
  "pacquet-config",
  "pacquet-lockfile",

--- a/pacquet/crates/pnpr-client/Cargo.toml
+++ b/pacquet/crates/pnpr-client/Cargo.toml
@@ -16,8 +16,10 @@ pacquet-lockfile              = { workspace = true }
 pacquet-lockfile-verification = { workspace = true }
 pacquet-store-dir             = { workspace = true }
 base64                        = { workspace = true }
+bytes                         = { workspace = true }
 derive_more                   = { workspace = true }
 flate2                        = { workspace = true }
+futures-util                  = { workspace = true }
 reqwest                       = { workspace = true }
 serde                         = { workspace = true }
 serde_json                    = { workspace = true }

--- a/pacquet/crates/pnpr-client/src/lib.rs
+++ b/pacquet/crates/pnpr-client/src/lib.rs
@@ -6,17 +6,17 @@
 //! 1. reads the integrities already in the local store index,
 //! 2. `POST`s them with the dependencies to `/v1/install`, asking the
 //!    server to inline the file contents it's missing (`inlineFiles`),
-//! 3. parses the single combined response — a length-prefixed JSON header
-//!    (lockfile, stats, store-index entries, or verification violations)
-//!    followed by the missing files' bytes,
-//! 4. writes those bytes straight into the local CAFS *by digest* (no
-//!    re-hashing) and writes the forwarded store-index entries, and
+//! 3. parses the combined response as it streams in — a length-prefixed
+//!    JSON header (lockfile, stats, store-index entries, or verification
+//!    violations) followed by the missing files' bytes,
+//! 4. writes each file straight into the local CAFS *by digest* (no
+//!    re-hashing) as its frame arrives — so disk writes overlap the
+//!    network transfer — and writes the forwarded store-index entries, and
 //! 5. returns the resolved lockfile for a headless install.
 //!
 //! The whole exchange is one round trip — no handshake, no follow-up
 //! `/v1/files` fetch. See
-//! [pnpm/pnpm#12165](https://github.com/pnpm/pnpm/issues/12165). The
-//! response is buffered rather than truly streamed, a tracked follow-up.
+//! [pnpm/pnpm#12165](https://github.com/pnpm/pnpm/issues/12165).
 
 use std::{
     collections::{BTreeMap, HashSet},
@@ -24,14 +24,17 @@ use std::{
 };
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use bytes::{Bytes, BytesMut};
 use derive_more::{Display, Error, From};
 use flate2::read::GzDecoder;
+use futures_util::{Stream, StreamExt as _};
 use pacquet_config::TrustPolicy;
 use pacquet_lockfile::Lockfile;
 use pacquet_lockfile_verification::{RenderedViolation, VerifyError};
 use pacquet_store_dir::{StoreDir, StoreIndex, StoreIndexWriter, decode_package_files_index};
 use reqwest::Client;
 use serde::Deserialize;
+use tokio::task::JoinSet;
 
 /// Dependency map (`name` -> `version range`).
 pub type DepMap = BTreeMap<String, String>;
@@ -249,23 +252,153 @@ impl PnprClient {
             return Err(PnprClientError::Server(format!("/v1/install returned {status}: {body}")));
         }
 
-        let raw = response.bytes().await?;
-        let parsed = parse_inline_response(&decompress(&raw)?)?;
+        // reqwest's `gzip` feature transparently decodes the body and
+        // strips `Content-Encoding`, so the stream yields the plaintext
+        // framing we parse incrementally — writing each missing file into
+        // the CAFS as its frame arrives, overlapping disk with network.
+        // If the header survives (a proxy or config left the body encoded),
+        // fall back to buffering the whole response and gzip-decoding it.
+        if response.headers().get(reqwest::header::CONTENT_ENCODING).is_some() {
+            let raw = response.bytes().await?;
+            let parsed = parse_inline_response(&decompress(&raw)?)?;
+            let files_written = write_files_payload(opts.store_dir, &parsed.files_payload)?;
+            let index_entries_written =
+                write_index_entries(opts.store_dir, parsed.index_entries, &present).await;
+            return Ok(InstallOutcome {
+                lockfile: parsed.lockfile,
+                stats: parsed.stats,
+                files_written,
+                index_entries_written,
+            });
+        }
 
-        // The server inlines only the files the client is missing; a
-        // `--lockfile-only` resolve and a verification pass both carry an
-        // empty file payload, so this writes nothing in those cases.
-        let files_written = write_files_payload(opts.store_dir, &parsed.files_payload)?;
-        let index_entries_written =
-            write_index_entries(opts.store_dir, parsed.index_entries, &present).await;
-
-        Ok(InstallOutcome {
-            lockfile: parsed.lockfile,
-            stats: parsed.stats,
-            files_written,
-            index_entries_written,
-        })
+        let stream = response.bytes_stream().map(|chunk| chunk.map_err(PnprClientError::from));
+        consume_stream(stream, opts.store_dir, &present).await
     }
+}
+
+/// Read the framed install response from `stream`, writing each missing
+/// file into the CAFS as its frame arrives so disk writes overlap the
+/// network transfer. `stream` yields the plaintext (already gzip-decoded)
+/// body — `[u32 header len][header][u32 prefix len][{}][file frames][64
+/// zero]` — the same byte sequence [`parse_inline_response`] reads from a
+/// buffered body.
+async fn consume_stream<Source>(
+    stream: Source,
+    store_dir: &StoreDir,
+    present: &HashSet<&str>,
+) -> Result<InstallOutcome, PnprClientError>
+where
+    Source: Stream<Item = Result<Bytes, PnprClientError>> + Unpin,
+{
+    let mut reader = StreamBuf::new(stream);
+
+    let header_len = read_u32_be(&reader.read_exact(4).await?) as usize;
+    let header_bytes = reader.read_exact(header_len).await?;
+    let header: InlineHeader = serde_json::from_slice(&header_bytes)
+        .map_err(|err| PnprClientError::Protocol(err.to_string()))?;
+
+    if let Some(violations) = header.violations.filter(|list| !list.is_empty()) {
+        return Err(PnprClientError::Verification(build_verify_error(violations)));
+    }
+    let lockfile = header
+        .lockfile
+        .ok_or_else(|| PnprClientError::Protocol("install response had no lockfile".to_string()))?;
+    let stats = header.stats;
+
+    let mut index_entries = Vec::with_capacity(header.index_entries.len());
+    for entry in header.index_entries {
+        let raw =
+            BASE64.decode(&entry.b64).map_err(|err| PnprClientError::Protocol(err.to_string()))?;
+        index_entries.push((entry.key, raw));
+    }
+
+    // Skip the files-payload prefix: a `[u32 json_len][json]` (always
+    // `{}`) that precedes the file frames.
+    let prefix_len = read_u32_be(&reader.read_exact(4).await?) as usize;
+    reader.read_exact(prefix_len).await?;
+
+    let mut writes: JoinSet<Result<(), PnprClientError>> = JoinSet::new();
+    let mut files_written = 0;
+    loop {
+        let digest_bytes = reader.read_exact(64).await?;
+        if digest_bytes.iter().all(|byte| *byte == 0) {
+            break; // end-of-stream marker
+        }
+        let meta = reader.read_exact(5).await?;
+        let size = read_u32_be(&meta[..4]) as usize;
+        let executable = meta[4] & 0x01 != 0;
+        let content = reader.read_exact(size).await?;
+        let digest = hex_encode(&digest_bytes);
+
+        if writes.len() >= MAX_INFLIGHT_WRITES {
+            join_one(&mut writes, &mut files_written).await?;
+        }
+        let store_dir = store_dir.clone();
+        writes.spawn_blocking(move || write_cas_file(&store_dir, &digest, executable, &content));
+    }
+    while !writes.is_empty() {
+        join_one(&mut writes, &mut files_written).await?;
+    }
+
+    let index_entries_written = write_index_entries(store_dir, index_entries, present).await;
+    Ok(InstallOutcome { lockfile, stats, files_written, index_entries_written })
+}
+
+/// Max in-flight CAS writes. Writing each frame on the blocking pool while
+/// the next frames stream in overlaps disk with network; the cap bounds
+/// how much file content is held in memory at once.
+const MAX_INFLIGHT_WRITES: usize = 16;
+
+/// Await one finished CAS write, propagating its error and counting the
+/// success. A no-op when the set is empty.
+async fn join_one(
+    writes: &mut JoinSet<Result<(), PnprClientError>>,
+    files_written: &mut usize,
+) -> Result<(), PnprClientError> {
+    if let Some(joined) = writes.join_next().await {
+        joined
+            .map_err(|err| PnprClientError::Protocol(format!("CAFS write task failed: {err}")))??;
+        *files_written += 1;
+    }
+    Ok(())
+}
+
+/// A byte-stream cursor that yields exact-length slices, pulling more
+/// chunks from the underlying stream as needed.
+struct StreamBuf<Source> {
+    stream: Source,
+    buf: BytesMut,
+}
+
+impl<Source> StreamBuf<Source>
+where
+    Source: Stream<Item = Result<Bytes, PnprClientError>> + Unpin,
+{
+    fn new(stream: Source) -> Self {
+        StreamBuf { stream, buf: BytesMut::new() }
+    }
+
+    /// Read exactly `n` bytes, pulling chunks until satisfied. Errors when
+    /// the stream ends before `n` bytes are available (a truncated body).
+    async fn read_exact(&mut self, n: usize) -> Result<Bytes, PnprClientError> {
+        while self.buf.len() < n {
+            match self.stream.next().await {
+                Some(Ok(chunk)) => self.buf.extend_from_slice(&chunk),
+                Some(Err(err)) => return Err(err),
+                None => {
+                    return Err(PnprClientError::Protocol(
+                        "install response ended mid-frame".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(self.buf.split_to(n).freeze())
+    }
+}
+
+fn read_u32_be(bytes: &[u8]) -> u32 {
+    u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
 }
 
 /// Decompress a `Content-Encoding: gzip` body unless the HTTP stack

--- a/pacquet/crates/pnpr-client/src/tests.rs
+++ b/pacquet/crates/pnpr-client/src/tests.rs
@@ -1,4 +1,10 @@
-use super::{PnprClientError, VerifyError, parse_inline_response};
+use std::collections::HashSet;
+
+use bytes::Bytes;
+use pacquet_store_dir::StoreDir;
+use tempfile::TempDir;
+
+use super::{PnprClientError, VerifyError, consume_stream, hex_encode, parse_inline_response};
 
 /// Frame a JSON header into a complete inline install payload with an
 /// empty file section (the `{}` prefix plus the end-of-stream marker),
@@ -57,4 +63,67 @@ fn header_without_a_lockfile_is_a_protocol_error() {
     let Err(PnprClientError::Protocol(_)) = parse_inline_response(&payload) else {
         panic!("expected a Protocol error");
     };
+}
+
+/// One `[64-byte digest][u32 size][1-byte exec][content]` file frame, the
+/// shape the server emits per missing file.
+fn file_frame(digest: &[u8; 64], executable: bool, content: &[u8]) -> Vec<u8> {
+    let mut frame = Vec::new();
+    frame.extend_from_slice(digest);
+    frame.extend_from_slice(&(content.len() as u32).to_be_bytes());
+    frame.push(u8::from(executable));
+    frame.extend_from_slice(content);
+    frame
+}
+
+/// Frame a header plus file frames the way the server streams them: the
+/// length-prefixed header, the `{}` files-payload prefix, the frames, and
+/// the 64-zero end marker.
+fn streaming_payload(header_json: &str, frames: &[Vec<u8>]) -> Vec<u8> {
+    let header = header_json.as_bytes();
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&(header.len() as u32).to_be_bytes());
+    payload.extend_from_slice(header);
+    payload.extend_from_slice(&2u32.to_be_bytes());
+    payload.extend_from_slice(b"{}");
+    for frame in frames {
+        payload.extend_from_slice(frame);
+    }
+    payload.extend_from_slice(&[0u8; 64]);
+    payload
+}
+
+/// The streaming consumer reassembles frames split across arbitrary chunk
+/// boundaries and writes each file into the CAFS by digest. Feeding the
+/// body 3 bytes at a time stresses the cross-chunk reassembly that a
+/// single-buffer parse never exercises.
+#[tokio::test]
+async fn consume_stream_reassembles_frames_split_across_chunks() {
+    let store = TempDir::new().expect("temp store");
+    let store_dir = StoreDir::new(store.path().to_path_buf());
+
+    let digest_a = [0x11u8; 64];
+    let digest_b = [0x22u8; 64];
+    let content_a = b"console.log('a')".to_vec();
+    let content_b = b"module.exports = 42".to_vec();
+    let payload = streaming_payload(
+        r#"{"lockfile":{"lockfileVersion":"9.0"},"stats":{},"indexEntries":[]}"#,
+        &[file_frame(&digest_a, false, &content_a), file_frame(&digest_b, true, &content_b)],
+    );
+
+    let chunks: Vec<Result<Bytes, PnprClientError>> =
+        payload.chunks(3).map(|chunk| Ok(Bytes::copy_from_slice(chunk))).collect();
+    let present = HashSet::new();
+    let outcome = consume_stream(futures_util::stream::iter(chunks), &store_dir, &present)
+        .await
+        .expect("streaming consume should succeed");
+
+    assert_eq!(outcome.files_written, 2);
+
+    let path_a =
+        store_dir.cas_file_path_by_mode(&hex_encode(&digest_a), 0o644).expect("digest a path");
+    let path_b =
+        store_dir.cas_file_path_by_mode(&hex_encode(&digest_b), 0o755).expect("digest b path");
+    assert_eq!(std::fs::read(&path_a).expect("read a"), content_a);
+    assert_eq!(std::fs::read(&path_b).expect("read b"), content_b);
 }

--- a/pnpr/crates/pnpr/src/install_accelerator.rs
+++ b/pnpr/crates/pnpr/src/install_accelerator.rs
@@ -536,7 +536,7 @@ fn package_name(pkg_id: &str) -> Option<&str> {
 const FILES_GZIP_LEVEL: u32 = 6;
 
 /// Content type of the install response: a length-prefixed JSON header
-/// followed by the [`build_files_payload`] binary frames, gzip-compressed.
+/// followed by the binary file frames, gzip-compressed.
 const INLINE_CONTENT_TYPE: &str = "application/x-pnpr-install-inline";
 
 /// Build the single-response body: the lockfile, stats, and store-index
@@ -700,8 +700,11 @@ impl std::io::Write for ChannelWriter {
     }
 }
 
-/// Frame a JSON `header` and an already-built [`build_files_payload`]
-/// byte buffer into one length-prefixed, gzip-compressed body.
+/// Frame a JSON `header` and an already-built files-payload byte buffer
+/// (see [`empty_files_payload`]) into one length-prefixed, gzip-compressed
+/// body. The streaming success path emits the same framing incrementally
+/// in [`stream_install_body`]; this buffered form serves the small
+/// metadata-only responses ([`violation_response`]).
 fn finish_inline_response(header: &serde_json::Value, files_payload: &[u8]) -> Response {
     let header_bytes = serde_json::to_vec(header).unwrap_or_else(|_| b"{}".to_vec());
     let Ok(header_len) = u32::try_from(header_bytes.len()) else {

--- a/pnpr/crates/pnpr/src/install_accelerator.rs
+++ b/pnpr/crates/pnpr/src/install_accelerator.rs
@@ -316,7 +316,7 @@ pub(crate) async fn handle_install(
     }
 
     let stats_json = stats_json(&result.stats);
-    inline_response(runtime, &lockfile, &stats_json, result)
+    inline_response(runtime, &lockfile, &stats_json, result).await
 }
 
 fn stats_json(stats: &diff::Stats) -> serde_json::Value {
@@ -550,7 +550,13 @@ const INLINE_CONTENT_TYPE: &str = "application/x-pnpr-install-inline";
 /// are still being read and sent. The *decompressed* byte sequence is
 /// identical to a buffered `[u32 header len][header][file frames]`
 /// response, so a client that buffers-then-parses is unaffected.
-fn inline_response(
+///
+/// The whole file manifest is validated ([`validate_files`]) before the
+/// `200` is committed: once the response is streaming, a per-file failure
+/// can only truncate the body, not return a status. Validating up front
+/// keeps a store inconsistency (a missing or oversized file) an
+/// actionable `4xx`/`5xx` instead of a client-side protocol error.
+async fn inline_response(
     runtime: &InstallAccelerator,
     lockfile: &Lockfile,
     stats_json: &serde_json::Value,
@@ -579,7 +585,60 @@ fn inline_response(
     let files: Vec<(String, bool)> =
         result.missing_files.into_iter().map(|file| (file.digest, file.executable)).collect();
 
-    stream_install_body(runtime.store_dir.clone(), header_len, header_bytes, files)
+    let store_dir = runtime.store_dir.clone();
+    let validated =
+        match tokio::task::spawn_blocking(move || validate_files(&store_dir, &files)).await {
+            Ok(Ok(validated)) => validated,
+            Ok(Err((status, message))) => return json_error(status, &message),
+            Err(err) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, &err.to_string()),
+        };
+
+    stream_install_body(header_len, header_bytes, validated)
+}
+
+/// A missing file the diff resolved to a concrete, readable CAS path —
+/// the validated unit [`stream_install_body`] frames. Carrying the
+/// pre-decoded digest bytes and the resolved path means the streaming
+/// task only does the content read, with nothing left that can fail with
+/// a status code.
+struct ValidatedFile {
+    path: PathBuf,
+    /// The 64 raw digest bytes, ready to write into the frame header.
+    digest_bytes: [u8; 64],
+    executable: bool,
+}
+
+/// Resolve, decode, and stat every missing file so a store inconsistency
+/// surfaces as a status code before the streamed `200` starts. Returns the
+/// first failure as a `(status, message)` ready for [`json_error`]. Runs
+/// on the blocking pool (one `stat` per file); the files were just written
+/// by this request's fetch, so they're warm.
+fn validate_files(
+    store_dir: &StoreDir,
+    files: &[(String, bool)],
+) -> Result<Vec<ValidatedFile>, (StatusCode, String)> {
+    let mut validated = Vec::with_capacity(files.len());
+    for (digest, executable) in files {
+        let mode = if *executable { 0o755 } else { 0o644 };
+        let path = store_dir.cas_file_path_by_mode(digest, mode).ok_or_else(|| {
+            (StatusCode::INTERNAL_SERVER_ERROR, format!("could not resolve file path: {digest}"))
+        })?;
+        let digest_bytes = hex_to_bytes(digest)
+            .ok_or_else(|| (StatusCode::BAD_REQUEST, format!("invalid digest: {digest}")))?;
+        let metadata = std::fs::metadata(&path)
+            .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, format!("{digest}: {err}")))?;
+        // The wire framing encodes the size as a u32; npm files never
+        // approach 4 GiB, but reject cleanly here rather than truncate the
+        // stream later.
+        if u32::try_from(metadata.len()).is_err() {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("{digest}: file too large for the protocol"),
+            ));
+        }
+        validated.push(ValidatedFile { path, digest_bytes, executable: *executable });
+    }
+    Ok(validated)
 }
 
 /// Backpressure budget for the install-body channel. Each item is one
@@ -595,27 +654,25 @@ const STREAM_CHANNEL: usize = 16;
 /// streams smoothly while keeping sync-flush boundaries rare.
 const STREAM_FLUSH_THRESHOLD: usize = 256 * 1024;
 
-/// Spawn the blocking encoder that reads each missing file from the store
-/// and gzip-streams the framed body into an mpsc channel, and wrap the
-/// channel's receiver as the response body. File reads and gzip happen on
-/// a blocking thread; `blocking_send` provides backpressure.
+/// Spawn the blocking encoder that reads each validated file from the
+/// store and gzip-streams the framed body into an mpsc channel, and wrap
+/// the channel's receiver as the response body. File reads and gzip happen
+/// on a blocking thread; `blocking_send` provides backpressure.
 fn stream_install_body(
-    store_dir: StoreDir,
     header_len: u32,
     header_bytes: Vec<u8>,
-    files: Vec<(String, bool)>,
+    files: Vec<ValidatedFile>,
 ) -> Response {
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<Bytes, std::io::Error>>(STREAM_CHANNEL);
 
     tokio::task::spawn_blocking(move || {
         let mut encoder = GzEncoder::new(ChannelWriter { tx }, Compression::new(FILES_GZIP_LEVEL));
-        if let Err(err) =
-            write_install_frames(&mut encoder, &store_dir, header_len, &header_bytes, &files)
-        {
-            // Headers (200) are already on the wire, so a mid-stream read
-            // failure can't become a 500. Drop the encoder without the end
-            // marker; the client reports a truncated-stream protocol error
-            // — the same failure class the buffered path raised as a 500.
+        if let Err(err) = write_install_frames(&mut encoder, header_len, &header_bytes, &files) {
+            // The manifest was validated before the 200, so reaching here
+            // means a file became unreadable *after* its stat — a race on
+            // the (immutable) CAS that can't be turned into a status now
+            // the body is on the wire. Drop the encoder without the end
+            // marker; the client reports a truncated-stream protocol error.
             tracing::error!(%err, "install response stream aborted");
             return;
         }
@@ -635,37 +692,29 @@ fn stream_install_body(
 
 /// Write the framed install body into `encoder`: the length-prefixed JSON
 /// header, the `{}` files-payload prefix, one
-/// `[64-byte digest][u32 size][1-byte exec][content]` frame per missing
-/// file (read from the store by digest), and the 64-zero end marker.
+/// `[64-byte digest][u32 size][1-byte exec][content]` frame per validated
+/// file, and the 64-zero end marker.
 fn write_install_frames(
     encoder: &mut GzEncoder<ChannelWriter>,
-    store_dir: &StoreDir,
     header_len: u32,
     header_bytes: &[u8],
-    files: &[(String, bool)],
+    files: &[ValidatedFile],
 ) -> std::io::Result<()> {
     encoder.write_all(&header_len.to_be_bytes())?;
     encoder.write_all(header_bytes)?;
     encoder.write_all(&empty_files_payload_prefix())?;
 
     let mut since_flush = 0;
-    for (digest, executable) in files {
-        let mode = if *executable { 0o755 } else { 0o644 };
-        let path = store_dir.cas_file_path_by_mode(digest, mode).ok_or_else(|| {
-            std::io::Error::other(format!("could not resolve file path: {digest}"))
-        })?;
-        let content = std::fs::read(&path)?;
-        let digest_bytes = hex_to_bytes(digest)
-            .ok_or_else(|| std::io::Error::other(format!("invalid digest: {digest}")))?;
-        // The wire framing encodes the size as a u32; npm files never
-        // approach 4 GiB, but fail cleanly rather than truncate the stream.
-        let content_len = u32::try_from(content.len()).map_err(|_| {
-            std::io::Error::other(format!("{digest}: file too large for the protocol"))
-        })?;
+    for file in files {
+        let content = std::fs::read(&file.path)?;
+        // Validated as `<= u32::MAX` by `validate_files`; an immutable CAS
+        // file can't have grown past it since, so this never fails.
+        let content_len = u32::try_from(content.len())
+            .map_err(|_| std::io::Error::other("file too large for the protocol"))?;
 
-        encoder.write_all(&digest_bytes)?;
+        encoder.write_all(&file.digest_bytes)?;
         encoder.write_all(&content_len.to_be_bytes())?;
-        encoder.write_all(&[u8::from(*executable)])?;
+        encoder.write_all(&[u8::from(file.executable)])?;
         encoder.write_all(&content)?;
 
         since_flush += 69 + content.len();

--- a/pnpr/crates/pnpr/src/install_accelerator.rs
+++ b/pnpr/crates/pnpr/src/install_accelerator.rs
@@ -32,8 +32,11 @@
 //! `pnpm-workspace.yaml` + member manifests) and letting pacquet's
 //! install path discover and resolve every importer. The client also
 //! forwards its per-registry credentials, so private dependencies resolve
-//! and fetch as the caller. Responses are buffered rather than truly
-//! streamed.
+//! and fetch as the caller. The file-bearing response is streamed: once
+//! resolution, verification, and authorization are done, the header is
+//! sent and each missing file is read from the store and gzip-emitted as
+//! it goes, so the client writes into its own CAFS while the rest are
+//! still in flight.
 
 mod diff;
 mod grant_table;
@@ -65,6 +68,7 @@ use axum::{
 };
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use flate2::{Compression, write::GzEncoder};
+use futures_util::stream;
 use indexmap::IndexMap;
 use pacquet_config::Config as PacquetConfig;
 use pacquet_lockfile::Lockfile;
@@ -312,7 +316,7 @@ pub(crate) async fn handle_install(
     }
 
     let stats_json = stats_json(&result.stats);
-    inline_response(runtime, &lockfile, &stats_json, &result)
+    inline_response(runtime, &lockfile, &stats_json, result)
 }
 
 fn stats_json(stats: &diff::Stats) -> serde_json::Value {
@@ -539,11 +543,18 @@ const INLINE_CONTENT_TYPE: &str = "application/x-pnpr-install-inline";
 /// entries in a length-prefixed JSON header, followed by the contents of
 /// the files the client is missing as binary frames — so the client
 /// materializes everything from one round trip.
+///
+/// The body is streamed, not buffered: the header is sent first, then
+/// each missing file is read from the store and gzip-emitted as it goes,
+/// so the client can start writing files into its own CAFS while the rest
+/// are still being read and sent. The *decompressed* byte sequence is
+/// identical to a buffered `[u32 header len][header][file frames]`
+/// response, so a client that buffers-then-parses is unaffected.
 fn inline_response(
     runtime: &InstallAccelerator,
     lockfile: &Lockfile,
     stats_json: &serde_json::Value,
-    result: &diff::DiffResult,
+    result: diff::DiffResult,
 ) -> Response {
     let index_entries: Vec<serde_json::Value> = result
         .package_index
@@ -561,13 +572,132 @@ fn inline_response(
         "indexEntries": index_entries,
     });
 
-    let files = result.missing_files.iter().map(|file| (file.digest.as_str(), file.executable));
-    let files_payload = match build_files_payload(&runtime.store_dir, files) {
-        Ok(payload) => payload,
-        Err((status, message)) => return json_error(status, &message),
+    let header_bytes = serde_json::to_vec(&header).unwrap_or_else(|_| b"{}".to_vec());
+    let Ok(header_len) = u32::try_from(header_bytes.len()) else {
+        return json_error(StatusCode::INTERNAL_SERVER_ERROR, "install header too large");
     };
+    let files: Vec<(String, bool)> =
+        result.missing_files.into_iter().map(|file| (file.digest, file.executable)).collect();
 
-    finish_inline_response(&header, &files_payload)
+    stream_install_body(runtime.store_dir.clone(), header_len, header_bytes, files)
+}
+
+/// Backpressure budget for the install-body channel. Each item is one
+/// chunk of gzipped output; 16 caps how far the blocking encoder runs
+/// ahead of the client before `blocking_send` throttles it to the
+/// client's read rate.
+const STREAM_CHANNEL: usize = 16;
+
+/// Flush the gzip encoder after this many input bytes so compressed
+/// output reaches the client promptly instead of waiting for the whole
+/// payload, bounding time-to-first-file. Flushing per-frame would hurt
+/// the ratio on a package full of tiny files; a 256 KiB granularity
+/// streams smoothly while keeping sync-flush boundaries rare.
+const STREAM_FLUSH_THRESHOLD: usize = 256 * 1024;
+
+/// Spawn the blocking encoder that reads each missing file from the store
+/// and gzip-streams the framed body into an mpsc channel, and wrap the
+/// channel's receiver as the response body. File reads and gzip happen on
+/// a blocking thread; `blocking_send` provides backpressure.
+fn stream_install_body(
+    store_dir: StoreDir,
+    header_len: u32,
+    header_bytes: Vec<u8>,
+    files: Vec<(String, bool)>,
+) -> Response {
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<Bytes, std::io::Error>>(STREAM_CHANNEL);
+
+    tokio::task::spawn_blocking(move || {
+        let mut encoder = GzEncoder::new(ChannelWriter { tx }, Compression::new(FILES_GZIP_LEVEL));
+        if let Err(err) =
+            write_install_frames(&mut encoder, &store_dir, header_len, &header_bytes, &files)
+        {
+            // Headers (200) are already on the wire, so a mid-stream read
+            // failure can't become a 500. Drop the encoder without the end
+            // marker; the client reports a truncated-stream protocol error
+            // — the same failure class the buffered path raised as a 500.
+            tracing::error!(%err, "install response stream aborted");
+            return;
+        }
+        if let Err(err) = encoder.finish() {
+            tracing::error!(%err, "install response gzip finish failed");
+        }
+    });
+
+    let stream = stream::unfold(rx, |mut rx| async move { rx.recv().await.map(|item| (item, rx)) });
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, INLINE_CONTENT_TYPE)
+        .header(header::CONTENT_ENCODING, "gzip")
+        .body(Body::from_stream(stream))
+        .expect("streaming response is always valid")
+}
+
+/// Write the framed install body into `encoder`: the length-prefixed JSON
+/// header, the `{}` files-payload prefix, one
+/// `[64-byte digest][u32 size][1-byte exec][content]` frame per missing
+/// file (read from the store by digest), and the 64-zero end marker.
+fn write_install_frames(
+    encoder: &mut GzEncoder<ChannelWriter>,
+    store_dir: &StoreDir,
+    header_len: u32,
+    header_bytes: &[u8],
+    files: &[(String, bool)],
+) -> std::io::Result<()> {
+    encoder.write_all(&header_len.to_be_bytes())?;
+    encoder.write_all(header_bytes)?;
+    encoder.write_all(&empty_files_payload_prefix())?;
+
+    let mut since_flush = 0;
+    for (digest, executable) in files {
+        let mode = if *executable { 0o755 } else { 0o644 };
+        let path = store_dir.cas_file_path_by_mode(digest, mode).ok_or_else(|| {
+            std::io::Error::other(format!("could not resolve file path: {digest}"))
+        })?;
+        let content = std::fs::read(&path)?;
+        let digest_bytes = hex_to_bytes(digest)
+            .ok_or_else(|| std::io::Error::other(format!("invalid digest: {digest}")))?;
+        // The wire framing encodes the size as a u32; npm files never
+        // approach 4 GiB, but fail cleanly rather than truncate the stream.
+        let content_len = u32::try_from(content.len()).map_err(|_| {
+            std::io::Error::other(format!("{digest}: file too large for the protocol"))
+        })?;
+
+        encoder.write_all(&digest_bytes)?;
+        encoder.write_all(&content_len.to_be_bytes())?;
+        encoder.write_all(&[u8::from(*executable)])?;
+        encoder.write_all(&content)?;
+
+        since_flush += 69 + content.len();
+        if since_flush >= STREAM_FLUSH_THRESHOLD {
+            encoder.flush()?;
+            since_flush = 0;
+        }
+    }
+
+    encoder.write_all(&[0u8; 64])?;
+    Ok(())
+}
+
+/// `std::io::Write` sink that forwards each write to the install body's
+/// mpsc channel. Used from a blocking task, so `blocking_send` is the
+/// right primitive — it parks the thread (applying backpressure) until
+/// the async receiver drains a slot, or errors once the client hangs up.
+struct ChannelWriter {
+    tx: tokio::sync::mpsc::Sender<Result<Bytes, std::io::Error>>,
+}
+
+impl std::io::Write for ChannelWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.tx.blocking_send(Ok(Bytes::copy_from_slice(buf))).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "client disconnected")
+        })?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 /// Frame a JSON `header` and an already-built [`build_files_payload`]
@@ -696,51 +826,6 @@ fn merge_policies(
         }
     }
     merged
-}
-
-/// The binary file frames the install response embeds: a 2-byte `{}` JSON
-/// header (length-prefixed) followed by one
-/// `[64-byte digest][u32 size][1-byte exec][content]` frame per file,
-/// terminated by 64 zero bytes. Reads each file's content from the store
-/// by digest; an `Err` is a ready-made error response.
-fn build_files_payload<'a>(
-    store_dir: &StoreDir,
-    files: impl Iterator<Item = (&'a str, bool)>,
-) -> Result<Vec<u8>, (StatusCode, String)> {
-    let mut payload = empty_files_payload_prefix();
-    for (digest, executable) in files {
-        let mode = if executable { 0o755 } else { 0o644 };
-        let Some(path) = store_dir.cas_file_path_by_mode(digest, mode) else {
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "could not resolve file path".to_string(),
-            ));
-        };
-        let content = match std::fs::read(&path) {
-            Ok(content) => content,
-            Err(err) => {
-                return Err((StatusCode::INTERNAL_SERVER_ERROR, format!("{digest}: {err}")));
-            }
-        };
-        let Some(digest_bytes) = hex_to_bytes(digest) else {
-            return Err((StatusCode::BAD_REQUEST, "invalid digest".to_string()));
-        };
-        // The wire framing encodes the size as a u32; a >4 GiB file would
-        // truncate. npm files never approach this, but fail cleanly rather
-        // than corrupt the stream.
-        let Ok(content_len) = u32::try_from(content.len()) else {
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("{digest}: file too large for the protocol"),
-            ));
-        };
-        payload.extend_from_slice(&digest_bytes);
-        payload.extend_from_slice(&content_len.to_be_bytes());
-        payload.push(u8::from(executable));
-        payload.extend_from_slice(&content);
-    }
-    payload.extend_from_slice(&[0u8; 64]);
-    Ok(payload)
 }
 
 /// The leading 2-byte `{}` JSON header every files payload starts with.

--- a/pnpr/crates/pnpr/src/install_accelerator/tests.rs
+++ b/pnpr/crates/pnpr/src/install_accelerator/tests.rs
@@ -9,11 +9,12 @@ use std::collections::HashSet;
 
 use axum::http::StatusCode;
 use pacquet_network::AuthHeaders;
+use pacquet_store_dir::StoreDir;
 use tempfile::TempDir;
 
 use super::{
     InstallAccelerator, authorize_served_packages, authorize_upstream_package, deny_local_policy,
-    diff::PackageIndexEntry, protocol::InstallRequest,
+    diff::PackageIndexEntry, protocol::InstallRequest, validate_files,
 };
 use crate::policy::{AccessList, Identity, PackagePolicies, PackagePolicy};
 
@@ -351,4 +352,60 @@ async fn without_a_forwarded_credential_the_local_policy_still_applies() {
     .await;
 
     assert_eq!(denied.map(|response| response.status()), Some(StatusCode::UNAUTHORIZED));
+}
+
+/// A valid 128-hex-char digest whose first two chars shard the CAS path.
+fn digest(byte: &str) -> String {
+    byte.repeat(64)
+}
+
+/// Write `content` at the non-executable CAS path for `digest` so a later
+/// `validate_files` finds it.
+fn write_cas(store_dir: &StoreDir, digest: &str, content: &[u8]) {
+    let path = store_dir.cas_file_path_by_mode(digest, 0o644).expect("resolvable digest");
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, content).unwrap();
+}
+
+/// A present, readable file resolves to a `ValidatedFile` carrying its CAS
+/// path and decoded digest bytes.
+#[test]
+fn validate_files_accepts_a_present_file() {
+    let tmp = TempDir::new().unwrap();
+    let store_dir = StoreDir::new(tmp.path().to_path_buf());
+    let digest = digest("ab");
+    write_cas(&store_dir, &digest, b"console.log(1)");
+
+    let validated = validate_files(&store_dir, &[(digest, false)]).expect("present file");
+    assert_eq!(validated.len(), 1);
+    assert_eq!(validated[0].digest_bytes, [0xab; 64]);
+    assert!(!validated[0].executable);
+    assert_eq!(std::fs::read(&validated[0].path).unwrap(), b"console.log(1)");
+}
+
+/// A digest the diff produced but whose file is absent from the store
+/// fails *before* the streamed `200`, as a `500` — not a truncated body.
+/// This is the regression the up-front manifest validation guards against.
+#[test]
+fn validate_files_rejects_a_missing_store_file() {
+    let tmp = TempDir::new().unwrap();
+    let store_dir = StoreDir::new(tmp.path().to_path_buf());
+
+    let Err((status, _)) = validate_files(&store_dir, &[(digest("cd"), false)]) else {
+        panic!("a missing store file must fail validation");
+    };
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+/// A digest that resolves to a CAS path but isn't 64 bytes of hex is a
+/// `400`, decoded up front rather than mid-stream.
+#[test]
+fn validate_files_rejects_a_malformed_digest() {
+    let tmp = TempDir::new().unwrap();
+    let store_dir = StoreDir::new(tmp.path().to_path_buf());
+
+    let Err((status, _)) = validate_files(&store_dir, &[("abc".to_string(), false)]) else {
+        panic!("a malformed digest must fail validation");
+    };
+    assert_eq!(status, StatusCode::BAD_REQUEST);
 }


### PR DESCRIPTION
## What

Makes the pnpr install-accelerator response **stream** instead of being fully buffered on both ends, so the server's file-read, the network transfer, and the client's CAFS write overlap instead of running as three serial phases.

This is the first of the optimizations identified while investigating why the pnpr accelerator showed ~no install-time win over a local install: the previous protocol bought a hash-skip but gave back the local path's fetch/extract/link pipelining by buffering the whole response, and the two roughly cancelled.

## How

**Server (`pnpr/crates/pnpr`)** — `inline_response` no longer reads every missing file into one buffer and gzips the whole thing before sending. Once resolution, verification, and authorization are done, a `spawn_blocking` task gzip-encodes the header, then reads each missing file from the store and emits its `[64-byte digest][u32 size][1-byte exec][content]` frame incrementally into a bounded mpsc channel that backs the response body. `blocking_send` applies backpressure; the encoder flushes every 256 KiB to bound time-to-first-file without per-frame sync-flush overhead.

The **decompressed byte sequence is byte-identical** to the previous framing, so any client that buffers-then-parses — **including the TypeScript pnpm CLI client (`pnpr/client`), which is untouched** — keeps working. Chunked gzip is transparent to it.

**Client (pacquet, `pacquet/crates/pnpr-client`)** — `consume_stream` reads `response.bytes_stream()` (reqwest's `gzip` feature decodes transparently), parses the header, then writes each file frame into the CAFS via concurrent `spawn_blocking` tasks (≤16 in flight) **as the frames arrive**, overlapping disk with network. A small `StreamBuf` reassembles frames across chunk boundaries. The buffered `parse_inline_response` path is kept as a defensive fallback for a still-`Content-Encoding`-tagged body.

Net effect: the server reads file *N+1* while the wire carries file *N* while the client writes file *N-1*.

## Scope

This implements the **transfer → write** overlap. The further **write → link** overlap (starting materialization before all files land — pacquet runs linking as a separate frozen `Install` pass after `PnprClient::install` returns) is a larger change left as a follow-up.

The TypeScript pnpm CLI client is intentionally not changed; the server streams transparently to it, so it can adopt an incremental consumer later for the same win without a protocol change.

## Tests

- New unit test feeds the response 3 bytes at a time to stress `StreamBuf` cross-chunk frame reassembly + CAFS writes.
- Existing end-to-end tests against a real pnpr server (multi-file package, warm-store dedup, lockfile-only, verification) still pass: 15 client tests, 291 server tests.
- `cargo check`/`clippy -D warnings`/`fmt`/`cargo doc -D warnings`/Dylint (Perfectionist) all clean.

No changeset: this touches only the pnpr server (Rust) and the pacquet client (Rust); there is no published-TS-package surface change.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming file delivery for installations — packages parsed and written incrementally as data arrives, improving responsiveness and reducing memory usage.

* **Tests**
  * Added tests for streaming reassembly across chunked network input.
  * Added validation tests covering present/missing/invalid file digests and appropriate error responses.

* **Chores**
  * Updated crate dependency list to include a workspace-managed bytes dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->