### PR TITLE
perf(pnpr): feed server file maps into pacquet linker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3343,6 +3343,7 @@ dependencies = [
  "pacquet-lockfile",
  "pacquet-lockfile-verification",
  "pacquet-store-dir",
+ "pacquet-tarball",
  "pacquet-testing-utils",
  "pnpr",
  "reqwest 0.13.3",

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -462,7 +462,7 @@ async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
     // server-side now — both for reused entries (the input-lockfile
     // verifier) and freshly-resolved ones (the resolver's pick-time
     // gate, since the policy is wired into the server's config).
-    let outcome = match PnprClient::new(pnpr_server)
+    let mut outcome = match PnprClient::new(pnpr_server)
         .install(InstallOptions {
             store_dir: &state.config.store_dir,
             dependencies,
@@ -525,10 +525,12 @@ async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
     // writing the lockfile rather than running the materialization pass.
     // See [pnpm/pnpm#12146](https://github.com/pnpm/pnpm/issues/12146).
     if link.lockfile_only {
+        outcome.finish_index_writes().await;
         return Ok(());
     }
 
-    Install {
+    let pnpr_prefetch = std::mem::take(&mut outcome.prefetch);
+    let link_result = Install {
         tarball_mem_cache: std::sync::Arc::clone(&state.tarball_mem_cache),
         http_client: &state.http_client,
         http_client_arc: std::sync::Arc::clone(&state.http_client),
@@ -557,9 +559,11 @@ async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
         update_seed_policy: UpdateSeedPolicy::KeepAll,
         auth_override: None,
     }
-    .run::<Reporter>()
-    .await
-    .wrap_err("linking dependencies resolved via the pnpr server")?;
+    .run_with_prefetched_cas_paths::<Reporter>(Some(pnpr_prefetch))
+    .await;
+
+    outcome.finish_index_writes().await;
+    link_result.wrap_err("linking dependencies resolved via the pnpr server")?;
 
     Ok(())
 }

--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -157,6 +157,7 @@ pub struct CreateVirtualStore<'a> {
     /// Tarball downloads and CAS writes still happen for both
     /// linkers; only the slot-materialization step differs.
     pub node_linker: NodeLinker,
+    pub prefetched_from_pnpr: Option<&'a PrefetchResult>,
 }
 
 /// Error type of [`CreateVirtualStore`].
@@ -176,6 +177,28 @@ pub enum CreateVirtualStoreError {
     )]
     #[diagnostic(code(pacquet_package_manager::missing_packages_section))]
     MissingPackagesSection,
+}
+
+fn merge_prefetch_results(
+    mut local: PrefetchResult,
+    from_pnpr: Option<&PrefetchResult>,
+) -> PrefetchResult {
+    let Some(from_pnpr) = from_pnpr else { return local };
+
+    local.cas_paths.extend(
+        from_pnpr.cas_paths.iter().map(|(key, value)| (key.clone(), std::sync::Arc::clone(value))),
+    );
+    local.manifests.extend(
+        from_pnpr.manifests.iter().map(|(key, value)| (key.clone(), std::sync::Arc::clone(value))),
+    );
+    local.side_effects_maps.extend(
+        from_pnpr
+            .side_effects_maps
+            .iter()
+            .map(|(key, value)| (key.clone(), std::sync::Arc::clone(value))),
+    );
+
+    local
 }
 
 impl<'a> CreateVirtualStore<'a> {
@@ -201,6 +224,7 @@ impl<'a> CreateVirtualStore<'a> {
             skipped,
             workspace_root,
             node_linker,
+            prefetched_from_pnpr,
         } = self;
 
         let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
@@ -508,18 +532,29 @@ impl<'a> CreateVirtualStore<'a> {
         cache_key_refs.sort_unstable();
         cache_key_refs.dedup();
         let cache_keys: Vec<String> = cache_key_refs.into_iter().map(String::from).collect();
+        let local_cache_keys = match prefetched_from_pnpr {
+            Some(prefetched) => cache_keys
+                .iter()
+                .filter(|key| !prefetched.cas_paths.contains_key(key.as_str()))
+                .cloned()
+                .collect(),
+            None => cache_keys,
+        };
         let PrefetchResult {
             cas_paths: prefetched,
             manifests: prefetched_manifests,
             side_effects_maps: prefetched_side_effects,
-        } = prefetch_cas_paths(
-            store_index.clone(),
-            store_dir,
-            cache_keys,
-            config.verify_store_integrity,
-            SharedVerifiedFilesCache::clone(&verified_files_cache),
-        )
-        .await;
+        } = merge_prefetch_results(
+            prefetch_cas_paths(
+                store_index.clone(),
+                store_dir,
+                local_cache_keys,
+                config.verify_store_integrity,
+                SharedVerifiedFilesCache::clone(&verified_files_cache),
+            )
+            .await,
+            prefetched_from_pnpr,
+        );
 
         // Partition snapshots by whether the prefetch covered them. The
         // warm batch — every snapshot whose tarball is already in the

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -32,7 +32,7 @@ use pacquet_reporter::{
     Stage, StageLog, SummaryLog,
 };
 use pacquet_resolving_npm_resolver::InMemoryPackageMetaCache;
-use pacquet_tarball::MemCache;
+use pacquet_tarball::{MemCache, PrefetchResult};
 use pacquet_workspace_state::{
     ProjectEntry, UpdateWorkspaceStateError, WorkspaceState, now_millis, update_workspace_state,
 };
@@ -350,6 +350,14 @@ where
 {
     /// Execute the subroutine.
     pub async fn run<Reporter: self::Reporter + 'static>(self) -> Result<(), InstallError> {
+        self.run_with_prefetched_cas_paths::<Reporter>(None).await
+    }
+
+    /// Execute the subroutine with package file maps supplied by the pnpr accelerator.
+    pub async fn run_with_prefetched_cas_paths<Reporter: self::Reporter + 'static>(
+        self,
+        prefetched_from_pnpr: Option<PrefetchResult>,
+    ) -> Result<(), InstallError> {
         let Install {
             tarball_mem_cache,
             resolved_packages,
@@ -864,6 +872,7 @@ where
                 supported_architectures: supported_architectures.as_ref(),
                 skip_runtimes,
                 node_linker,
+                prefetched_from_pnpr: prefetched_from_pnpr.as_ref(),
             }
             .run::<Reporter>()
             .await

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -26,6 +26,7 @@ use pacquet_patching::{
 };
 use pacquet_reporter::{IgnoredScriptsLog, LogEvent, LogLevel, Reporter, Stage, StageLog};
 use pacquet_store_dir::StoreIndexWriter;
+use pacquet_tarball::PrefetchResult;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     ffi::OsStr,
@@ -140,6 +141,7 @@ where
     /// exists yet). Upstream's `nodeLinker: 'pnp'` is also
     /// out-of-scope for [#438](https://github.com/pnpm/pacquet/issues/438); tracked separately.
     pub node_linker: NodeLinker,
+    pub prefetched_from_pnpr: Option<&'a PrefetchResult>,
 }
 
 /// Error type of [`InstallFrozenLockfile`].
@@ -276,6 +278,7 @@ where
             supported_architectures,
             skip_runtimes,
             node_linker,
+            prefetched_from_pnpr,
         } = self;
         let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
         // Cloned so the iterator can be reused below for hoist's
@@ -595,6 +598,7 @@ where
             skipped: &skipped,
             workspace_root,
             node_linker,
+            prefetched_from_pnpr,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1266,6 +1266,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             skipped: &skipped,
             workspace_root: lockfile_dir,
             node_linker,
+            prefetched_from_pnpr: None,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/pnpr-client/Cargo.toml
+++ b/pacquet/crates/pnpr-client/Cargo.toml
@@ -15,6 +15,7 @@ pacquet-config                = { workspace = true }
 pacquet-lockfile              = { workspace = true }
 pacquet-lockfile-verification = { workspace = true }
 pacquet-store-dir             = { workspace = true }
+pacquet-tarball               = { workspace = true }
 base64                        = { workspace = true }
 derive_more                   = { workspace = true }
 flate2                        = { workspace = true }

--- a/pacquet/crates/pnpr-client/src/lib.rs
+++ b/pacquet/crates/pnpr-client/src/lib.rs
@@ -21,6 +21,7 @@
 use std::{
     collections::{BTreeMap, HashSet},
     io::Read as _,
+    sync::Arc,
 };
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
@@ -29,9 +30,14 @@ use flate2::read::GzDecoder;
 use pacquet_config::TrustPolicy;
 use pacquet_lockfile::Lockfile;
 use pacquet_lockfile_verification::{RenderedViolation, VerifyError};
-use pacquet_store_dir::{StoreDir, StoreIndex, StoreIndexWriter, decode_package_files_index};
+use pacquet_store_dir::{
+    PackageFilesIndex, StoreDir, StoreIndex, StoreIndexWriter, build_file_maps_from_index,
+    decode_package_files_index,
+};
+use pacquet_tarball::PrefetchResult;
 use reqwest::Client;
 use serde::Deserialize;
+use tokio::task::JoinHandle;
 
 /// Dependency map (`name` -> `version range`).
 pub type DepMap = BTreeMap<String, String>;
@@ -105,10 +111,34 @@ pub struct InstallOutcome {
     /// The resolved lockfile, ready for a headless install.
     pub lockfile: Lockfile,
     pub stats: Stats,
+    /// Server-provided package file maps ready for pacquet's warm-batch materializer.
+    pub prefetch: PrefetchResult,
     /// Number of inlined file entries written into the local CAFS.
     pub files_written: usize,
     /// Number of store-index entries written to the local index.
     pub index_entries_written: usize,
+    index_write_task: Option<JoinHandle<usize>>,
+}
+
+impl InstallOutcome {
+    pub async fn finish_index_writes(&mut self) -> usize {
+        let Some(task) = self.index_write_task.take() else {
+            return self.index_entries_written;
+        };
+        let written = match task.await {
+            Ok(written) => written,
+            Err(error) => {
+                tracing::warn!(
+                    target: "pacquet::pnpr_client",
+                    ?error,
+                    "pnpr store-index writer task failed",
+                );
+                0
+            }
+        };
+        self.index_entries_written = written;
+        written
+    }
 }
 
 /// Resolution statistics from the response header. Field names mirror
@@ -256,14 +286,18 @@ impl PnprClient {
         // `--lockfile-only` resolve and a verification pass both carry an
         // empty file payload, so this writes nothing in those cases.
         let files_written = write_files_payload(opts.store_dir, &parsed.files_payload)?;
-        let index_entries_written =
-            write_index_entries(opts.store_dir, parsed.index_entries, &present).await;
+        let index_entries = decode_index_entries(parsed.index_entries);
+        let prefetch = build_prefetch_from_index_entries(opts.store_dir, &index_entries);
+        let (index_entries_written, index_write_task) =
+            queue_index_entries(opts.store_dir, index_entries, &present);
 
         Ok(InstallOutcome {
             lockfile: parsed.lockfile,
             stats: parsed.stats,
+            prefetch,
             files_written,
             index_entries_written,
+            index_write_task,
         })
     }
 }
@@ -489,32 +523,89 @@ fn set_executable(_path: &std::path::Path, _executable: bool) -> std::io::Result
     Ok(())
 }
 
-/// Write the forwarded store-index entries, skipping keys already
-/// present. Each entry's raw msgpackr-records buffer is decoded and
-/// re-queued through the writer, whose blocking drain is awaited so the
-/// rows are flushed before they're reported as written.
-async fn write_index_entries(
+fn decode_index_entries(entries: Vec<(String, Vec<u8>)>) -> Vec<(String, PackageFilesIndex)> {
+    let mut decoded = Vec::with_capacity(entries.len());
+    for (key, raw) in entries {
+        match decode_package_files_index(&raw) {
+            Ok(value) => decoded.push((key, value)),
+            Err(error) => tracing::debug!(
+                target: "pacquet::pnpr_client",
+                ?key,
+                ?error,
+                "skipping undecodable pnpr package_index row",
+            ),
+        }
+    }
+    decoded
+}
+
+fn build_prefetch_from_index_entries(
     store_dir: &StoreDir,
-    entries: Vec<(String, Vec<u8>)>,
+    entries: &[(String, PackageFilesIndex)],
+) -> PrefetchResult {
+    let mut result = PrefetchResult::default();
+    for (key, entry) in entries {
+        let mut entry = entry.clone();
+        let manifest = entry.manifest.take().map(Arc::new);
+        let verify_result = build_file_maps_from_index(store_dir, entry);
+        if !verify_result.passed {
+            continue;
+        }
+        if let Some(manifest) = manifest {
+            result.manifests.insert(key.clone(), manifest);
+        }
+        if let Some(side_effects_maps) = verify_result.side_effects_maps
+            && !side_effects_maps.is_empty()
+        {
+            result.side_effects_maps.insert(key.clone(), Arc::new(side_effects_maps));
+        }
+        result.cas_paths.insert(key.clone(), Arc::new(verify_result.files_map));
+    }
+    result
+}
+
+/// Queue the forwarded store-index entries, skipping keys already
+/// present. The blocking writer drains in the background so the current
+/// install can start materializing from the in-memory prefetch maps.
+fn queue_index_entries(
+    store_dir: &StoreDir,
+    entries: Vec<(String, PackageFilesIndex)>,
     present: &HashSet<&str>,
-) -> usize {
-    let to_write: Vec<(String, Vec<u8>)> =
+) -> (usize, Option<JoinHandle<usize>>) {
+    let to_write: Vec<(String, PackageFilesIndex)> =
         entries.into_iter().filter(|(key, _)| !present.contains(key.as_str())).collect();
     if to_write.is_empty() {
-        return 0;
+        return (0, None);
     }
 
     let (writer, writer_task) = StoreIndexWriter::spawn(store_dir);
-    let mut written = 0;
-    for (key, raw) in &to_write {
-        if let Ok(decoded) = decode_package_files_index(raw) {
-            writer.queue(key.clone(), decoded);
-            written += 1;
-        }
+    let queued = to_write.len();
+    for (key, decoded) in to_write {
+        writer.queue(key, decoded);
     }
-    drop(writer);
-    let _ = writer_task.await;
-    written
+    let task = tokio::spawn(async move {
+        drop(writer);
+        match writer_task.await {
+            Ok(Ok(())) => queued,
+            Ok(Err(error)) => {
+                tracing::warn!(
+                    target: "pacquet::pnpr_client",
+                    ?error,
+                    "pnpr store-index writer failed",
+                );
+                0
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "pacquet::pnpr_client",
+                    ?error,
+                    "pnpr store-index writer join failed",
+                );
+                0
+            }
+        }
+    });
+    (queued, Some(task))
 }
 
 fn read_store_keys(store_dir: &StoreDir) -> Vec<String> {

--- a/pacquet/crates/pnpr-client/tests/integration.rs
+++ b/pacquet/crates/pnpr-client/tests/integration.rs
@@ -157,7 +157,8 @@ async fn a_forwarded_credential_resolves_a_private_package() {
     auth.insert(nerf_key(&registry.url()), format!("Bearer {token}"));
     opts.auth_headers = auth;
 
-    let outcome = client.install(opts).await.expect("forwarded credential should resolve it");
+    let mut outcome = client.install(opts).await.expect("forwarded credential should resolve it");
+    outcome.finish_index_writes().await;
     let packages = outcome.lockfile.packages.as_ref().expect("lockfile has packages");
     assert!(
         packages.keys().any(|key| key.to_string().starts_with("@pnpm.e2e/needs-auth@1.0.0")),
@@ -198,10 +199,11 @@ async fn resolves_and_downloads_a_package() {
     let store = StoreDir::new(client_store.path().to_path_buf());
     let client = PnprClient::new(pnpr_url);
 
-    let outcome = client
+    let mut outcome = client
         .install(options(&store, &registry.url(), deps([("@foo/no-deps", "1.0.0")])))
         .await
         .expect("install should succeed");
+    outcome.finish_index_writes().await;
 
     let packages = outcome.lockfile.packages.as_ref().expect("lockfile has packages");
     assert!(
@@ -239,7 +241,8 @@ async fn lockfile_only_resolves_without_fetching_files() {
     // empty. Mirrors pnpm's resolve + write, fetch nothing, link nothing.
     let mut opts = options(&store, &registry.url(), deps([("@foo/no-deps", "1.0.0")]));
     opts.lockfile_only = true;
-    let outcome = client.install(opts).await.expect("lockfile-only install should succeed");
+    let mut outcome = client.install(opts).await.expect("lockfile-only install should succeed");
+    outcome.finish_index_writes().await;
 
     let packages = outcome.lockfile.packages.as_ref().expect("lockfile has packages");
     assert!(
@@ -265,16 +268,18 @@ async fn warm_store_skips_already_present_files() {
     let store = StoreDir::new(client_store.path().to_path_buf());
     let client = PnprClient::new(pnpr_url);
 
-    let cold = client
+    let mut cold = client
         .install(options(&store, &registry.url(), deps([("@foo/no-deps", "1.0.0")])))
         .await
         .expect("cold install");
+    cold.finish_index_writes().await;
     assert!(cold.files_written >= 1);
 
-    let warm = client
+    let mut warm = client
         .install(options(&store, &registry.url(), deps([("@foo/no-deps", "1.0.0")])))
         .await
         .expect("warm install");
+    warm.finish_index_writes().await;
 
     assert!(warm.stats.already_in_store >= 1, "package should be recognized as cached");
     assert_eq!(warm.files_written, 0, "warm run should download no files");
@@ -290,7 +295,7 @@ async fn resolves_a_multi_file_package() {
     let store = StoreDir::new(client_store.path().to_path_buf());
     let client = PnprClient::new(pnpr_url);
 
-    let outcome = client
+    let mut outcome = client
         .install(options(
             &store,
             &registry.url(),
@@ -298,6 +303,7 @@ async fn resolves_a_multi_file_package() {
         ))
         .await
         .expect("install should succeed");
+    outcome.finish_index_writes().await;
 
     let packages = outcome.lockfile.packages.as_ref().expect("lockfile has packages");
     assert!(
@@ -318,17 +324,19 @@ async fn verifies_and_accepts_a_clean_input_lockfile() {
     let client = PnprClient::new(pnpr_url);
 
     // A first install with no lockfile produces a valid resolved one.
-    let first = client
+    let mut first = client
         .install(options(&store, &registry.url(), deps([("@foo/no-deps", "1.0.0")])))
         .await
         .expect("first install");
+    first.finish_index_writes().await;
 
     // Sending it back as the input lockfile makes the server verify it
     // under the (default, policy-free) client policy before resolving;
     // a clean lockfile passes and the install succeeds.
     let mut opts = options(&store, &registry.url(), deps([("@foo/no-deps", "1.0.0")]));
     opts.lockfile = Some(first.lockfile.clone());
-    let second = client.install(opts).await.expect("verified-input install should succeed");
+    let mut second = client.install(opts).await.expect("verified-input install should succeed");
+    second.finish_index_writes().await;
     assert!(second.lockfile.packages.is_some(), "resolution still produced a lockfile");
 }
 
@@ -341,10 +349,11 @@ async fn rejects_an_input_lockfile_that_violates_the_clients_policy() {
     let store = StoreDir::new(client_store.path().to_path_buf());
     let client = PnprClient::new(pnpr_url);
 
-    let first = client
+    let mut first = client
         .install(options(&store, &registry.url(), deps([("@foo/no-deps", "1.0.0")])))
         .await
         .expect("first install");
+    first.finish_index_writes().await;
 
     // Re-send the same lockfile under a ~100-year minimumReleaseAge: no
     // real publish time can satisfy it, so the server rejects the input
@@ -372,10 +381,11 @@ async fn trust_lockfile_makes_the_server_skip_verification() {
     let store = StoreDir::new(client_store.path().to_path_buf());
     let client = PnprClient::new(pnpr_url);
 
-    let first = client
+    let mut first = client
         .install(options(&store, &registry.url(), deps([("@foo/no-deps", "1.0.0")])))
         .await
         .expect("first install");
+    first.finish_index_writes().await;
 
     // Same policy that `rejects_an_input_lockfile_that_violates_the_clients_policy`
     // trips on, but with the client's `trustLockfile` opt-out set: the
@@ -387,7 +397,8 @@ async fn trust_lockfile_makes_the_server_skip_verification() {
     opts.minimum_release_age_ignore_missing_time = false;
     opts.trust_lockfile = true;
 
-    let outcome = client.install(opts).await.expect("trustLockfile should skip verification");
+    let mut outcome = client.install(opts).await.expect("trustLockfile should skip verification");
+    outcome.finish_index_writes().await;
     assert!(outcome.lockfile.packages.is_some(), "install still resolved a lockfile");
 }
 

--- a/pacquet/crates/store-dir/src/store_index.rs
+++ b/pacquet/crates/store-dir/src/store_index.rs
@@ -751,7 +751,7 @@ pub fn pick_store_index_key(
 /// value half of each `package_index` row.
 ///
 /// Mirrors pnpm v11's `PackageFilesIndex` from `store/cafs/src/checkPkgFilesIntegrity.ts`.
-#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PackageFilesIndex {
     /// Subset of the tarball's `package.json` that pnpm keeps on hand to avoid
@@ -788,7 +788,7 @@ pub struct PackageFilesIndex {
 /// Value of [`PackageFilesIndex::files`]. Mirrors pnpm v11's
 /// [`PackageFileInfo`](https://github.com/pnpm/pnpm/blob/1819226b51/store/cafs-types/src/index.ts)
 /// field-for-field so that the msgpack payload interops.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CafsFileInfo {
     /// Content-addressed digest of the file — raw hex (no `sha512-` prefix),
@@ -834,7 +834,7 @@ fn serialize_checked_at<Serializer: serde::Serializer>(
 /// the bespoke encoder in `msgpackr_records.rs` (it iterates the
 /// map in sorted-key order). The derived serde `Serialize` impl
 /// is unused on the write path.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SideEffectsDiff {
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

- build pacquet prefetch maps directly from pnpr server-sent package index rows
- pass those maps into the frozen install path so materialization can skip duplicate SQLite prefetch work
- persist forwarded store-index rows in the background and flush them after pnpr linking

## Verification

- cargo check -p pacquet-store-dir -p pacquet-pnpr-client -p pacquet-package-manager -p pacquet-cli
- cargo test -p pacquet-pnpr-client
- cargo test -p pacquet-cli --test pnpr_install
- git diff --check
- pre-push hook passed, including cargo fmt --all -- --check, cargo doc, cargo dylint, and taplo format --check

---
Written by an agent (Codex, GPT-5).
