### PR TITLE
feat(lockfile): write pnpm-lock.yaml byte-for-byte identical to pnpm

### DIFF
--- a/pacquet/crates/cli/tests/catalog.rs
+++ b/pacquet/crates/cli/tests/catalog.rs
@@ -90,7 +90,7 @@ fn add_strict_catalogs_a_new_dependency() {
         "lockfile missing the resolved catalog entry:\n{lockfile}",
     );
     assert!(
-        lockfile.contains(r#"specifier: "catalog:""#),
+        lockfile.contains(r"specifier: 'catalog:'"),
         "importer specifier not catalog:\n{lockfile}",
     );
 

--- a/pacquet/crates/cli/tests/snapshots/add__should_install_all_dependencies.snap
+++ b/pacquet/crates/cli/tests/snapshots/add__should_install_all_dependencies.snap
@@ -1,6 +1,5 @@
 ---
 source: pacquet/crates/cli/tests/add.rs
-assertion_line: 31
 expression: get_all_folders(&workspace)
 ---
 [
@@ -21,6 +20,7 @@ expression: get_all_folders(&workspace)
     "node_modules/.pnpm/@pnpm.e2e+hello-world-js-bin@1.0.0/node_modules/@pnpm.e2e/hello-world-js-bin/node_modules",
     "node_modules/.pnpm/@pnpm.e2e+hello-world-js-bin@1.0.0/node_modules/@pnpm.e2e/hello-world-js-bin/node_modules/.bin",
     "node_modules/.pnpm/node_modules",
+    "node_modules/.pnpm/node_modules/.bin",
     "node_modules/.pnpm/node_modules/@pnpm.e2e",
     "node_modules/.pnpm/node_modules/@pnpm.e2e/hello-world-js-bin",
     "node_modules/@pnpm.e2e",

--- a/pacquet/crates/cli/tests/snapshots/add__should_symlink_correctly.snap
+++ b/pacquet/crates/cli/tests/snapshots/add__should_symlink_correctly.snap
@@ -1,6 +1,5 @@
 ---
 source: pacquet/crates/cli/tests/add.rs
-assertion_line: 68
 expression: get_all_folders(&workspace)
 ---
 [
@@ -21,6 +20,7 @@ expression: get_all_folders(&workspace)
     "node_modules/.pnpm/@pnpm.e2e+hello-world-js-bin@1.0.0/node_modules/@pnpm.e2e/hello-world-js-bin/node_modules",
     "node_modules/.pnpm/@pnpm.e2e+hello-world-js-bin@1.0.0/node_modules/@pnpm.e2e/hello-world-js-bin/node_modules/.bin",
     "node_modules/.pnpm/node_modules",
+    "node_modules/.pnpm/node_modules/.bin",
     "node_modules/.pnpm/node_modules/@pnpm.e2e",
     "node_modules/.pnpm/node_modules/@pnpm.e2e/hello-world-js-bin",
     "node_modules/@pnpm.e2e",

--- a/pacquet/crates/cli/tests/snapshots/install__should_install_dependencies.snap
+++ b/pacquet/crates/cli/tests/snapshots/install__should_install_dependencies.snap
@@ -21,6 +21,7 @@ expression: "(workspace_folders, store_files)"
         "node_modules/.pnpm/@pnpm.e2e+hello-world-js-bin@1.0.0/node_modules/@pnpm.e2e/hello-world-js-bin/node_modules",
         "node_modules/.pnpm/@pnpm.e2e+hello-world-js-bin@1.0.0/node_modules/@pnpm.e2e/hello-world-js-bin/node_modules/.bin",
         "node_modules/.pnpm/node_modules",
+        "node_modules/.pnpm/node_modules/.bin",
         "node_modules/.pnpm/node_modules/@pnpm.e2e",
         "node_modules/.pnpm/node_modules/@pnpm.e2e/hello-world-js-bin",
         "node_modules/@pnpm.e2e",

--- a/pacquet/crates/cli/tests/tarball_url_dependency.rs
+++ b/pacquet/crates/cli/tests/tarball_url_dependency.rs
@@ -72,10 +72,15 @@ fn package_integrity(lockfile: &str, package_key: &str) -> Option<String> {
         })
         // `integrity:` appears either on its own line (block style) or inside
         // the single-line `resolution: {integrity: ..., tarball: ...}` flow map,
-        // so extract the value up to the next `,` / `}` / end-of-line.
+        // so extract the value up to the next `,` / `}` / end-of-line. Match
+        // only the YAML key token (start-of-line, indent, `{`, or `,` before
+        // it) so a tarball URL/path containing the substring can't masquerade
+        // as the field and hide a genuinely missing `integrity`.
         .find_map(|line| {
-            let start = line.find("integrity:")? + "integrity:".len();
-            let rest = line[start..].trim_start();
+            let key_at = line.match_indices("integrity:").find(|(idx, _)| {
+                matches!(line[..*idx].chars().next_back(), None | Some(' ' | '{' | ','))
+            })?;
+            let rest = line[key_at.0 + "integrity:".len()..].trim_start();
             let end = rest.find([',', '}']).unwrap_or(rest.len());
             Some(rest[..end].trim().to_string())
         })

--- a/pacquet/crates/cli/tests/tarball_url_dependency.rs
+++ b/pacquet/crates/cli/tests/tarball_url_dependency.rs
@@ -70,7 +70,15 @@ fn package_integrity(lockfile: &str, package_key: &str) -> Option<String> {
             !trimmed.starts_with("snapshots:")
                 && (!trimmed.ends_with(':') || (line.len() - trimmed.len()) > header_indent)
         })
-        .find_map(|line| line.trim().strip_prefix("integrity:").map(|rest| rest.trim().to_string()))
+        // `integrity:` appears either on its own line (block style) or inside
+        // the single-line `resolution: {integrity: ..., tarball: ...}` flow map,
+        // so extract the value up to the next `,` / `}` / end-of-line.
+        .find_map(|line| {
+            let start = line.find("integrity:")? + "integrity:".len();
+            let rest = line[start..].trim_start();
+            let end = rest.find([',', '}']).unwrap_or(rest.len());
+            Some(rest[..end].trim().to_string())
+        })
 }
 
 /// A remote-tarball dependency keeps its integrity when an unrelated

--- a/pacquet/crates/lockfile/src/lib.rs
+++ b/pacquet/crates/lockfile/src/lib.rs
@@ -18,6 +18,7 @@ mod serialize_yaml;
 mod snapshot_dep_ref;
 mod snapshot_entry;
 mod yaml_documents;
+mod yaml_emit;
 
 pub use catalog_snapshots::*;
 pub use comver::*;

--- a/pacquet/crates/lockfile/src/project_snapshot.rs
+++ b/pacquet/crates/lockfile/src/project_snapshot.rs
@@ -7,26 +7,32 @@ use std::collections::HashMap;
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectSnapshot {
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "crate::serialize_yaml::sorted_map_opt"
-    )]
+    /// Direct-dependency specifiers, keyed by alias. The v9 lockfile file
+    /// format does not carry a top-level `specifiers` map — each specifier is
+    /// inlined next to its resolved version in the dependency blocks (see
+    /// [`ResolvedDependencySpec`]) — so this field is never serialized. pnpm's
+    /// in-memory `ProjectSnapshot` keeps it for catalog-snapshot construction,
+    /// and pacquet does the same; it also still deserializes from older
+    /// lockfiles that recorded it.
+    #[serde(default, skip_serializing)]
     pub specifiers: Option<HashMap<String, String>>,
     #[serde(
         skip_serializing_if = "Option::is_none",
         serialize_with = "crate::serialize_yaml::sorted_map_opt"
     )]
     pub dependencies: Option<ResolvedDependencyMap>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "crate::serialize_yaml::sorted_map_opt"
-    )]
-    pub optional_dependencies: Option<ResolvedDependencyMap>,
+    // Field order mirrors the v9 importer block pnpm writes: `dependencies`,
+    // then `devDependencies`, then `optionalDependencies`.
     #[serde(
         skip_serializing_if = "Option::is_none",
         serialize_with = "crate::serialize_yaml::sorted_map_opt"
     )]
     pub dev_dependencies: Option<ResolvedDependencyMap>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serialize_yaml::sorted_map_opt"
+    )]
+    pub optional_dependencies: Option<ResolvedDependencyMap>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dependencies_meta: Option<serde_json::Value>, // TODO: DependenciesMeta
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/pacquet/crates/lockfile/src/resolution.rs
+++ b/pacquet/crates/lockfile/src/resolution.rs
@@ -271,6 +271,70 @@ impl LockfileResolution {
             | LockfileResolution::Variations(_) => None,
         }
     }
+
+    /// Convert an in-memory resolution into the form written to the lockfile.
+    ///
+    /// For a registry tarball whose URL is reconstructible from `name`,
+    /// `version`, and `registry`, the URL is dropped and only `{integrity}` is
+    /// kept — pnpm derives the tarball URL on demand. The URL is preserved when
+    /// `include_tarball_url` is set, when it is a `file:` tarball, when it is
+    /// git-hosted, or when it does not match the derived URL (e.g. private
+    /// registries with non-standard tarball paths). Non-tarball resolutions and
+    /// integrity-less tarballs pass through unchanged.
+    ///
+    /// Port of pnpm's
+    /// [`toLockfileResolution`](https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/utils/src/toLockfileResolution.ts).
+    pub fn to_lockfile_form(
+        &self,
+        name: &str,
+        version: &str,
+        registry: &str,
+        include_tarball_url: bool,
+    ) -> LockfileResolution {
+        let LockfileResolution::Tarball(tarball) = self else { return self.clone() };
+        let Some(integrity) = tarball.integrity.as_ref() else { return self.clone() };
+
+        let git_hosted =
+            tarball.git_hosted == Some(true) || is_git_hosted_tarball_url(&tarball.tarball);
+        let keep_url = || {
+            LockfileResolution::Tarball(TarballResolution {
+                tarball: tarball.tarball.clone(),
+                integrity: Some(integrity.clone()),
+                git_hosted: git_hosted.then_some(true),
+                path: tarball.path.clone(),
+            })
+        };
+
+        if include_tarball_url || tarball.tarball.starts_with("file:") || git_hosted {
+            return keep_url();
+        }
+        let expected = npm_tarball_url(name, version, registry);
+        let actual = tarball.tarball.replace("%2f", "/");
+        if remove_protocol(&expected) != remove_protocol(&actual) {
+            return keep_url();
+        }
+        LockfileResolution::Registry(RegistryResolution { integrity: integrity.clone() })
+    }
+}
+
+/// Derive the canonical npm registry tarball URL for `name@version`. Port of
+/// the [`get-npm-tarball-url`](https://www.npmjs.com/package/get-npm-tarball-url)
+/// package pnpm uses.
+fn npm_tarball_url(name: &str, version: &str, registry: &str) -> String {
+    let registry =
+        if registry.ends_with('/') { registry.to_string() } else { format!("{registry}/") };
+    let scopeless = match name.strip_prefix('@') {
+        Some(scoped) => scoped.split_once('/').map_or(name, |(_, bare)| bare),
+        None => name,
+    };
+    let version = version.split_once('+').map_or(version, |(base, _)| base);
+    format!("{registry}{name}/-/{scopeless}-{version}.tgz")
+}
+
+/// Strip the URL scheme (everything up to and including `://`). Port of pnpm's
+/// `removeProtocol` (`url.split('://')[1]`).
+fn remove_protocol(url: &str) -> &str {
+    url.split_once("://").map_or(url, |(_, rest)| rest)
 }
 
 /// Intermediate helper type for serde.

--- a/pacquet/crates/lockfile/src/resolution/tests.rs
+++ b/pacquet/crates/lockfile/src/resolution/tests.rs
@@ -14,6 +14,26 @@ fn integrity(integrity_str: &str) -> Integrity {
     integrity_str.parse().expect("parse integrity string")
 }
 
+/// Render a resolution exactly as it appears under a `packages:` entry, then
+/// dedent the `resolution:` block. Exercises the real write path: the deep key
+/// sort and the single-line-vs-block decision both depend on the `resolution`
+/// key and its enclosing `packages` context, so a bare top-level serialization
+/// would not reflect what pnpm writes.
+fn render_resolution(resolution: &LockfileResolution) -> String {
+    let document = serde_json::json!({
+        "packages": {
+            "p@1.0.0": { "resolution": serde_json::to_value(resolution).unwrap() },
+        },
+    });
+    serialize_yaml::to_string(&document)
+        .unwrap()
+        .lines()
+        .skip_while(|line| !line.trim_start().starts_with("resolution:"))
+        .map(|line| line.strip_prefix("    ").unwrap_or(line))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 #[test]
 fn deserialize_tarball_resolution() {
     eprintln!("CASE: without integrity");
@@ -147,12 +167,9 @@ fn serialize_tarball_resolution() {
         git_hosted: None,
         path: None,
     });
-    let received = serialize_yaml::to_string(&resolution).unwrap();
-    let received = received.trim();
+    let received = render_resolution(&resolution);
     eprintln!("RECEIVED:\n{received}");
-    let expected = text_block! {
-        "tarball: file:ts-pipe-compose-0.2.1.tgz"
-    };
+    let expected = "resolution: {tarball: file:ts-pipe-compose-0.2.1.tgz}";
     assert_eq!(received, expected);
 
     eprintln!("CASE: with integrity");
@@ -162,13 +179,9 @@ fn serialize_tarball_resolution() {
         git_hosted: None,
         path: None,
     });
-    let received = serialize_yaml::to_string(&resolution).unwrap();
-    let received = received.trim();
+    let received = render_resolution(&resolution);
     eprintln!("RECEIVED:\n{received}");
-    let expected = text_block! {
-        "tarball: file:ts-pipe-compose-0.2.1.tgz"
-        "integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
-    };
+    let expected = "resolution: {integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==, tarball: file:ts-pipe-compose-0.2.1.tgz}";
     assert_eq!(received, expected);
 }
 
@@ -200,14 +213,9 @@ fn serialize_tarball_resolution_with_path() {
         git_hosted: Some(true),
         path: Some("packages/sub".to_string()),
     });
-    let received = serialize_yaml::to_string(&resolution).unwrap();
-    let received = received.trim();
+    let received = render_resolution(&resolution);
     eprintln!("RECEIVED:\n{received}");
-    let expected = text_block! {
-        "tarball: https://codeload.github.com/foo/bar/tar.gz/abc1234"
-        "gitHosted: true"
-        "path: packages/sub"
-    };
+    let expected = "resolution: {gitHosted: true, path: packages/sub, tarball: https://codeload.github.com/foo/bar/tar.gz/abc1234}";
     assert_eq!(received, expected);
 }
 
@@ -219,14 +227,9 @@ fn serialize_tarball_resolution_with_git_hosted() {
         git_hosted: Some(true),
         path: None,
     });
-    let received = serialize_yaml::to_string(&resolution).unwrap();
-    let received = received.trim();
+    let received = render_resolution(&resolution);
     eprintln!("RECEIVED:\n{received}");
-    let expected = text_block! {
-        "tarball: https://codeload.github.com/foo/bar/tar.gz/abc1234"
-        "integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
-        "gitHosted: true"
-    };
+    let expected = "resolution: {gitHosted: true, integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==, tarball: https://codeload.github.com/foo/bar/tar.gz/abc1234}";
     assert_eq!(received, expected);
 }
 
@@ -252,12 +255,9 @@ fn serialize_registry_resolution() {
             "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==",
         ),
     });
-    let received = serialize_yaml::to_string(&resolution).unwrap();
-    let received = received.trim();
+    let received = render_resolution(&resolution);
     eprintln!("RECEIVED:\n{received}");
-    let expected = text_block! {
-        "integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
-    };
+    let expected = "resolution: {integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==}";
     assert_eq!(received, expected);
 }
 
@@ -280,13 +280,9 @@ fn serialize_directory_resolution() {
     let resolution = LockfileResolution::Directory(DirectoryResolution {
         directory: "ts-pipe-compose-0.2.1/package".to_string(),
     });
-    let received = serialize_yaml::to_string(&resolution).unwrap();
-    let received = received.trim();
+    let received = render_resolution(&resolution);
     eprintln!("RECEIVED:\n{received}");
-    let expected = text_block! {
-        "type: directory"
-        "directory: ts-pipe-compose-0.2.1/package"
-    };
+    let expected = "resolution: {directory: ts-pipe-compose-0.2.1/package, type: directory}";
     assert_eq!(received, expected);
 }
 
@@ -331,14 +327,9 @@ fn serialize_git_resolution() {
         commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
         path: None,
     });
-    let received = serialize_yaml::to_string(&resolution).unwrap();
-    let received = received.trim();
+    let received = render_resolution(&resolution);
     eprintln!("RECEIVED:\n{received}");
-    let expected = text_block! {
-        "type: git"
-        "repo: https://github.com/ksxnodemodules/ts-pipe-compose.git"
-        "commit: e63c09e460269b0c535e4c34debf69bb91d57b22"
-    };
+    let expected = "resolution: {commit: e63c09e460269b0c535e4c34debf69bb91d57b22, repo: https://github.com/ksxnodemodules/ts-pipe-compose.git, type: git}";
     assert_eq!(received, expected);
 }
 
@@ -349,15 +340,9 @@ fn serialize_git_resolution_with_path() {
         commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
         path: Some("packages/sub".to_string()),
     });
-    let received = serialize_yaml::to_string(&resolution).unwrap();
-    let received = received.trim();
+    let received = render_resolution(&resolution);
     eprintln!("RECEIVED:\n{received}");
-    let expected = text_block! {
-        "type: git"
-        "repo: https://github.com/ksxnodemodules/ts-pipe-compose.git"
-        "commit: e63c09e460269b0c535e4c34debf69bb91d57b22"
-        "path: packages/sub"
-    };
+    let expected = "resolution: {commit: e63c09e460269b0c535e4c34debf69bb91d57b22, path: packages/sub, repo: https://github.com/ksxnodemodules/ts-pipe-compose.git, type: git}";
     assert_eq!(received, expected);
 }
 
@@ -433,17 +418,17 @@ fn serialize_binary_resolution_tarball() {
         archive: BinaryArchive::Tarball,
         prefix: None,
     });
-    let received = serialize_yaml::to_string(&resolution).unwrap();
-    let received = received.trim();
+    let received = render_resolution(&resolution);
     eprintln!("RECEIVED:\n{received}");
-    // Field order follows the struct declaration; `prefix: None`
-    // skips serialization.
+    // Binary resolutions render in block style (excluded from the single-line
+    // rule) with keys deep-sorted; `prefix: None` skips serialization.
     let expected = text_block! {
-        "type: binary"
-        "url: https://nodejs.org/dist/v22.0.0/node-v22.0.0-darwin-arm64.tar.gz"
-        "integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
-        "bin: bin/node"
-        "archive: tarball"
+        "resolution:"
+        "  archive: tarball"
+        "  bin: bin/node"
+        "  integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
+        "  type: binary"
+        "  url: https://nodejs.org/dist/v22.0.0/node-v22.0.0-darwin-arm64.tar.gz"
     };
     assert_eq!(received, expected);
 }
@@ -514,21 +499,21 @@ fn serialize_variations_resolution() {
             }],
         }],
     });
-    let received = serialize_yaml::to_string(&resolution).unwrap();
-    let received = received.trim();
+    let received = render_resolution(&resolution);
     eprintln!("RECEIVED:\n{received}");
     let expected = text_block! {
-        "type: variations"
-        "variants:"
-        "- resolution:"
-        "    type: binary"
-        "    url: https://nodejs.org/dist/v22.0.0/node-v22.0.0-darwin-arm64.tar.gz"
-        "    integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
-        "    bin: bin/node"
-        "    archive: tarball"
-        "  targets:"
-        "  - os: darwin"
-        "    cpu: arm64"
+        "resolution:"
+        "  type: variations"
+        "  variants:"
+        "    - resolution:"
+        "        archive: tarball"
+        "        bin: bin/node"
+        "        integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
+        "        type: binary"
+        "        url: https://nodejs.org/dist/v22.0.0/node-v22.0.0-darwin-arm64.tar.gz"
+        "      targets:"
+        "        - cpu: arm64"
+        "          os: darwin"
     };
     assert_eq!(received, expected);
 }

--- a/pacquet/crates/lockfile/src/save_lockfile.rs
+++ b/pacquet/crates/lockfile/src/save_lockfile.rs
@@ -19,7 +19,7 @@ pub enum SaveLockfileError {
 
     #[display("Failed to serialize lockfile to YAML: {_0}")]
     #[diagnostic(code(pacquet_lockfile::serialize_yaml))]
-    SerializeYaml(serde_saphyr::ser::Error),
+    SerializeYaml(serde_json::Error),
 
     #[display("Failed to write lockfile content: {_0}")]
     #[diagnostic(code(pacquet_lockfile::write_file))]

--- a/pacquet/crates/lockfile/src/save_lockfile/tests.rs
+++ b/pacquet/crates/lockfile/src/save_lockfile/tests.rs
@@ -32,14 +32,14 @@ const LOCKFILE_YAML: &str = text_block! {
     ""
     "packages:"
     ""
-    "  react@17.0.2:"
-    "    resolution: {integrity: sha512-TIE61hcgbI/SlJh/0c1sT1SZbBlpg7WiZcs65WPJhoIZQPhH1SCpcGA7LgrVXT15lwN3HV4GQM/MJ9aKEn3Qfg==}"
-    "    engines: {node: '>=0.10.0'}"
-    ""
     "  react-dom@17.0.2:"
     "    resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}"
     "    peerDependencies:"
     "      react: 17.0.2"
+    ""
+    "  react@17.0.2:"
+    "    resolution: {integrity: sha512-TIE61hcgbI/SlJh/0c1sT1SZbBlpg7WiZcs65WPJhoIZQPhH1SCpcGA7LgrVXT15lwN3HV4GQM/MJ9aKEn3Qfg==}"
+    "    engines: {node: '>=0.10.0'}"
     ""
     "  typescript@5.1.6:"
     "    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}"
@@ -48,11 +48,11 @@ const LOCKFILE_YAML: &str = text_block! {
     ""
     "snapshots:"
     ""
-    "  react@17.0.2: {}"
-    ""
     "  react-dom@17.0.2(react@17.0.2):"
     "    dependencies:"
     "      react: 17.0.2"
+    ""
+    "  react@17.0.2: {}"
     ""
     "  typescript@5.1.6: {}"
 };
@@ -82,6 +82,25 @@ fn round_trip_parse_save_parse_preserves_lockfile() {
     let reparsed: Lockfile = serde_saphyr::from_str(&saved_bytes).expect("reparse lockfile");
 
     assert_eq!(original, reparsed);
+}
+
+/// Byte-for-byte parity: parsing a pnpm-authored v9 lockfile and saving it
+/// reproduces the exact bytes pnpm wrote. [`LOCKFILE_YAML`] is laid out the way
+/// pnpm's `js-yaml` dumper writes it — blank lines between top-level and
+/// section entries, single-quoted ambiguous scalars, single-line
+/// `resolution` / `engines`, and priority-then-lexical key ordering — so an
+/// exact match proves pacquet's writer matches pnpm's formatting.
+#[test]
+fn save_reproduces_pnpm_authored_bytes() {
+    let original: Lockfile = serde_saphyr::from_str(LOCKFILE_YAML).expect("parse fixture lockfile");
+
+    let tmp = tempdir().expect("create tempdir");
+    let path = tmp.path().join("pnpm-lock.yaml");
+    original.save_to_path(&path).expect("save lockfile");
+
+    let saved_bytes = std::fs::read_to_string(&path).expect("read saved lockfile");
+    // `text_block!` omits the trailing newline; the writer appends one.
+    assert_eq!(saved_bytes, format!("{LOCKFILE_YAML}\n"));
 }
 
 /// A workspace lockfile with multiple importers, one of which has a

--- a/pacquet/crates/lockfile/src/serialize_yaml.rs
+++ b/pacquet/crates/lockfile/src/serialize_yaml.rs
@@ -1,29 +1,20 @@
-//! Serializer options that match pnpm's lockfile YAML formatting.
+//! Canonical key ordering for lockfile maps, plus the YAML serialization entry
+//! point.
 //!
-//! pnpm's `pnpm-lock.yaml` is emitted by `js-yaml` with default options, which
-//! keeps long single-line scalars (notably `integrity: sha512-…` hashes) as
-//! plain scalars. `serde_saphyr` defaults to folding long single-line strings
-//! into block style (`>-`), so we explicitly disable that to preserve byte-
-//! level parity with what pnpm produces.
+//! The byte-level YAML rendering lives in [`crate::yaml_emit`], a port of the
+//! `@zkochan/js-yaml` dumper pnpm uses for `pnpm-lock.yaml`. This module keeps
+//! the `serialize_with` helpers that canonicalize map key order before that
+//! rendering runs.
 
 use serde::{
     Serialize,
     ser::{SerializeMap, Serializer},
 };
-use serde_saphyr::{SerializerOptions, ser, ser_options, to_string_with_options};
 use std::{collections::HashMap, fmt::Display};
 
-/// Serializer options matching pnpm's lockfile output.
-fn options() -> SerializerOptions {
-    ser_options! {
-        prefer_block_scalars: false,
-    }
-}
-
-/// Serialize `value` to a YAML string with options that match pnpm's lockfile
-/// formatting.
-pub(crate) fn to_string<Value: Serialize>(value: &Value) -> Result<String, ser::Error> {
-    to_string_with_options(value, options())
+/// Serialize `value` to a YAML string matching pnpm's lockfile formatting.
+pub(crate) fn to_string<Value: Serialize>(value: &Value) -> Result<String, serde_json::Error> {
+    crate::yaml_emit::to_string(value)
 }
 
 /// Serialize a [`HashMap`] with its entries emitted in canonical key order.

--- a/pacquet/crates/lockfile/src/yaml_emit.rs
+++ b/pacquet/crates/lockfile/src/yaml_emit.rs
@@ -342,7 +342,7 @@ fn write_scalar(string: &str, level: usize, single_line: bool, inblock: bool) ->
             format!(
                 "|{}{}",
                 block_header(string),
-                drop_ending_newline(&indent_string(string, indent))
+                drop_ending_newline(&indent_string(string, indent)),
             )
         }
     }
@@ -397,27 +397,27 @@ const CHAR_LEFT_CURLY_BRACKET: u32 = 0x7B; // {
 const CHAR_RIGHT_CURLY_BRACKET: u32 = 0x7D; // }
 const CHAR_BOM: u32 = 0xFEFF;
 
-fn is_whitespace(c: u32) -> bool {
-    c == CHAR_SPACE || c == CHAR_TAB
+fn is_whitespace(code: u32) -> bool {
+    code == CHAR_SPACE || code == CHAR_TAB
 }
 
-fn is_printable(c: u32) -> bool {
-    (0x00020..=0x00007E).contains(&c)
-        || ((0x000A1..=0x00D7FF).contains(&c) && c != 0x2028 && c != 0x2029)
-        || ((0x0E000..=0x00FFFD).contains(&c) && c != CHAR_BOM)
-        || (0x10000..=0x10FFFF).contains(&c)
+fn is_printable(code: u32) -> bool {
+    (0x00020..=0x00007E).contains(&code)
+        || ((0x000A1..=0x00D7FF).contains(&code) && code != 0x2028 && code != 0x2029)
+        || ((0x0E000..=0x00FFFD).contains(&code) && code != CHAR_BOM)
+        || (0x10000..=0x10FFFF).contains(&code)
 }
 
-fn is_ns_char_or_whitespace(c: u32) -> bool {
-    is_printable(c) && c != CHAR_BOM && c != CHAR_CARRIAGE_RETURN && c != CHAR_LINE_FEED
+fn is_ns_char_or_whitespace(code: u32) -> bool {
+    is_printable(code) && code != CHAR_BOM && code != CHAR_CARRIAGE_RETURN && code != CHAR_LINE_FEED
 }
 
-fn is_plain_safe_first(c: u32) -> bool {
-    is_printable(c)
-        && c != CHAR_BOM
-        && !is_whitespace(c)
+fn is_plain_safe_first(code: u32) -> bool {
+    is_printable(code)
+        && code != CHAR_BOM
+        && !is_whitespace(code)
         && !matches!(
-            c,
+            code,
             0x2D | // -
             0x3F | // ?
             CHAR_COLON
@@ -437,39 +437,40 @@ fn is_plain_safe_first(c: u32) -> bool {
             0x22 | // "
             0x25 | // %
             0x40 | // @
-            0x60 // `
+            0x60, // `
         )
 }
 
-fn is_plain_safe_last(c: u32) -> bool {
-    !is_whitespace(c) && c != CHAR_COLON
+fn is_plain_safe_last(code: u32) -> bool {
+    !is_whitespace(code) && code != CHAR_COLON
 }
 
-fn is_plain_safe(c: u32, prev: Option<u32>, inblock: bool) -> bool {
-    let c_is_ns_or_ws = is_ns_char_or_whitespace(c);
-    let c_is_ns = c_is_ns_or_ws && !is_whitespace(c);
+fn is_plain_safe(code: u32, prev: Option<u32>, inblock: bool) -> bool {
+    let code_is_ns_or_ws = is_ns_char_or_whitespace(code);
+    let code_is_ns = code_is_ns_or_ws && !is_whitespace(code);
     let base = if inblock {
-        c_is_ns_or_ws
+        code_is_ns_or_ws
     } else {
-        c_is_ns_or_ws
-            && c != CHAR_COMMA
-            && c != CHAR_LEFT_SQUARE_BRACKET
-            && c != CHAR_RIGHT_SQUARE_BRACKET
-            && c != CHAR_LEFT_CURLY_BRACKET
-            && c != CHAR_RIGHT_CURLY_BRACKET
+        code_is_ns_or_ws
+            && code != CHAR_COMMA
+            && code != CHAR_LEFT_SQUARE_BRACKET
+            && code != CHAR_RIGHT_SQUARE_BRACKET
+            && code != CHAR_LEFT_CURLY_BRACKET
+            && code != CHAR_RIGHT_CURLY_BRACKET
     };
     let prev_is_colon = prev == Some(CHAR_COLON);
-    let prev_is_ns = prev.is_some_and(|p| is_ns_char_or_whitespace(p) && !is_whitespace(p));
+    let prev_is_ns =
+        prev.is_some_and(|prev| is_ns_char_or_whitespace(prev) && !is_whitespace(prev));
     // change to true on '[^ ]#'
-    if prev_is_ns && c == CHAR_SHARP {
+    if prev_is_ns && code == CHAR_SHARP {
         return true;
     }
     // change to true on ':[^ ]'
-    if prev_is_colon && c_is_ns {
+    if prev_is_colon && code_is_ns {
         return true;
     }
     // ns-plain-char: a non-`#` base character that isn't the `: ` sequence.
-    base && c != CHAR_SHARP && (!prev_is_colon || c_is_ns)
+    base && code != CHAR_SHARP && (!prev_is_colon || code_is_ns)
 }
 
 /// Mirrors the fork's `escapeString` (with `escapeSeq` table and hex fallback).
@@ -490,21 +491,21 @@ fn escape_string(string: &str) -> String {
 
 fn escape_sequence(code: u32) -> Option<&'static str> {
     Some(match code {
-        0x00 => "\\0",
-        0x07 => "\\a",
-        0x08 => "\\b",
-        0x09 => "\\t",
-        0x0A => "\\n",
-        0x0B => "\\v",
-        0x0C => "\\f",
-        0x0D => "\\r",
-        0x1B => "\\e",
-        0x22 => "\\\"",
-        0x5C => "\\\\",
-        0x85 => "\\N",
-        0xA0 => "\\_",
-        0x2028 => "\\L",
-        0x2029 => "\\P",
+        0x00 => r"\0",
+        0x07 => r"\a",
+        0x08 => r"\b",
+        0x09 => r"\t",
+        0x0A => r"\n",
+        0x0B => r"\v",
+        0x0C => r"\f",
+        0x0D => r"\r",
+        0x1B => r"\e",
+        0x22 => r#"\""#,
+        0x5C => r"\\",
+        0x85 => r"\N",
+        0xA0 => r"\_",
+        0x2028 => r"\L",
+        0x2029 => r"\P",
         _ => return None,
     })
 }
@@ -617,16 +618,16 @@ fn resolves_int(string: &str) -> bool {
         }
         index += 1;
         match bytes[index] {
-            b'b' => return digits_match(&bytes[index + 1..], |c| matches!(c, b'0' | b'1')),
-            b'x' => return digits_match(&bytes[index + 1..], |c| c.is_ascii_hexdigit()),
-            b'o' => return digits_match(&bytes[index + 1..], |c| matches!(c, b'0'..=b'7')),
+            b'b' => return digits_match(&bytes[index + 1..], |byte| matches!(byte, b'0' | b'1')),
+            b'x' => return digits_match(&bytes[index + 1..], |byte| byte.is_ascii_hexdigit()),
+            b'o' => return digits_match(&bytes[index + 1..], |byte| matches!(byte, b'0'..=b'7')),
             _ => {}
         }
     }
     if bytes[index] == b'_' {
         return false;
     }
-    digits_match(&bytes[index..], |c| c.is_ascii_digit())
+    digits_match(&bytes[index..], |byte| byte.is_ascii_digit())
 }
 
 /// A run of `_`-separated digits accepted by `predicate`, with at least one
@@ -672,20 +673,21 @@ fn float_matches(string: &str) -> bool {
         }
         let (mantissa, exponent) = split_exponent(after_dot);
         return !mantissa.is_empty()
-            && mantissa.bytes().all(|b| b.is_ascii_digit() || b == b'_')
+            && mantissa.bytes().all(|byte| byte.is_ascii_digit() || byte == b'_')
             && exponent_ok(exponent);
     }
     let mut cursor = body;
     let first = cursor.as_bytes().first().copied();
-    if !first.is_some_and(|b| b.is_ascii_digit()) {
+    if !first.is_some_and(|byte| byte.is_ascii_digit()) {
         return false;
     }
     // [0-9][0-9_]*
-    let int_len = cursor.bytes().take_while(|b| b.is_ascii_digit() || *b == b'_').count();
+    let int_len = cursor.bytes().take_while(|byte| byte.is_ascii_digit() || *byte == b'_').count();
     cursor = &cursor[int_len..];
     // (\.[0-9_]*)?
     if let Some(rest) = cursor.strip_prefix('.') {
-        let frac_len = rest.bytes().take_while(|b| b.is_ascii_digit() || *b == b'_').count();
+        let frac_len =
+            rest.bytes().take_while(|byte| byte.is_ascii_digit() || *byte == b'_').count();
         cursor = &rest[frac_len..];
     }
     // ([eE][-+]?[0-9]+)? — and nothing left over.
@@ -716,7 +718,7 @@ fn exponent_consumes_all(tail: &str) -> bool {
         return false;
     };
     let rest = rest.strip_prefix(['-', '+']).unwrap_or(rest);
-    !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit())
+    !rest.is_empty() && rest.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 /// Port of `type/timestamp.js`'s `resolveYamlTimestamp` (date and full forms).
@@ -736,187 +738,92 @@ fn matches_date(string: &str) -> bool {
 
 fn matches_timestamp(string: &str) -> bool {
     let bytes = string.as_bytes();
-    let mut i = 0;
-    let take_digits = |bytes: &[u8], i: &mut usize, min: usize, max: usize| -> bool {
-        let start = *i;
-        while *i < bytes.len() && *i - start < max && bytes[*i].is_ascii_digit() {
-            *i += 1;
+    let mut index = 0;
+    let take_digits = |bytes: &[u8], index: &mut usize, min: usize, max: usize| -> bool {
+        let start = *index;
+        while *index < bytes.len() && *index - start < max && bytes[*index].is_ascii_digit() {
+            *index += 1;
         }
-        *i - start >= min
+        *index - start >= min
     };
-    if !take_digits(bytes, &mut i, 4, 4) {
+    if !take_digits(bytes, &mut index, 4, 4) {
         return false;
     }
-    if bytes.get(i) != Some(&b'-') {
+    if bytes.get(index) != Some(&b'-') {
         return false;
     }
-    i += 1;
-    if !take_digits(bytes, &mut i, 1, 2) {
+    index += 1;
+    if !take_digits(bytes, &mut index, 1, 2) {
         return false;
     }
-    if bytes.get(i) != Some(&b'-') {
+    if bytes.get(index) != Some(&b'-') {
         return false;
     }
-    i += 1;
-    if !take_digits(bytes, &mut i, 1, 2) {
+    index += 1;
+    if !take_digits(bytes, &mut index, 1, 2) {
         return false;
     }
     // (?:[Tt]|[ \t]+)
-    match bytes.get(i) {
-        Some(b'T' | b't') => i += 1,
+    match bytes.get(index) {
+        Some(b'T' | b't') => index += 1,
         Some(b' ' | b'\t') => {
-            while matches!(bytes.get(i), Some(b' ' | b'\t')) {
-                i += 1;
+            while matches!(bytes.get(index), Some(b' ' | b'\t')) {
+                index += 1;
             }
         }
         _ => return false,
     }
-    if !take_digits(bytes, &mut i, 1, 2) {
+    if !take_digits(bytes, &mut index, 1, 2) {
         return false;
     }
-    if bytes.get(i) != Some(&b':') {
+    if bytes.get(index) != Some(&b':') {
         return false;
     }
-    i += 1;
-    if !take_digits(bytes, &mut i, 2, 2) {
+    index += 1;
+    if !take_digits(bytes, &mut index, 2, 2) {
         return false;
     }
-    if bytes.get(i) != Some(&b':') {
+    if bytes.get(index) != Some(&b':') {
         return false;
     }
-    i += 1;
-    if !take_digits(bytes, &mut i, 2, 2) {
+    index += 1;
+    if !take_digits(bytes, &mut index, 2, 2) {
         return false;
     }
     // (?:\.([0-9]*))?
-    if bytes.get(i) == Some(&b'.') {
-        i += 1;
-        while matches!(bytes.get(i), Some(b) if b.is_ascii_digit()) {
-            i += 1;
+    if bytes.get(index) == Some(&b'.') {
+        index += 1;
+        while matches!(bytes.get(index), Some(byte) if byte.is_ascii_digit()) {
+            index += 1;
         }
     }
     // (?:[ \t]*(Z|([-+])([0-9][0-9]?)(?::([0-9][0-9]))?))?
-    while matches!(bytes.get(i), Some(b' ' | b'\t')) {
-        i += 1;
+    while matches!(bytes.get(index), Some(b' ' | b'\t')) {
+        index += 1;
     }
-    if i == bytes.len() {
+    if index == bytes.len() {
         return true;
     }
-    match bytes.get(i) {
+    match bytes.get(index) {
         Some(b'Z') => {
-            i += 1;
+            index += 1;
         }
         Some(b'-' | b'+') => {
-            i += 1;
-            if !take_digits(bytes, &mut i, 1, 2) {
+            index += 1;
+            if !take_digits(bytes, &mut index, 1, 2) {
                 return false;
             }
-            if bytes.get(i) == Some(&b':') {
-                i += 1;
-                if !take_digits(bytes, &mut i, 2, 2) {
+            if bytes.get(index) == Some(&b':') {
+                index += 1;
+                if !take_digits(bytes, &mut index, 2, 2) {
                     return false;
                 }
             }
         }
         _ => return false,
     }
-    i == bytes.len()
+    index == bytes.len()
 }
 
 #[cfg(test)]
-mod tests {
-    use super::to_string;
-    use serde_json::json;
-
-    #[test]
-    fn version_like_floats_are_single_quoted() {
-        // `9.0` resolves as a YAML float, so it must be quoted; `11.5.2` and
-        // `1.0.0` are plain strings.
-        let yaml = to_string(&json!({ "a": "9.0", "b": "11.5.2", "c": "1.0.0" })).unwrap();
-        // Top-level entries are blank-line separated.
-        assert_eq!(yaml, "a: '9.0'\n\nb: 11.5.2\n\nc: 1.0.0\n");
-    }
-
-    #[test]
-    fn leading_indicator_and_at_force_single_quotes() {
-        let yaml = to_string(&json!({
-            "node": ">=10",
-            "name": "@scope/pkg@1.0.0",
-        }))
-        .unwrap();
-        // Keys are sorted (`name` before `node`).
-        assert_eq!(yaml, "name: '@scope/pkg@1.0.0'\n\nnode: '>=10'\n");
-    }
-
-    #[test]
-    fn booleans_and_numbers_render_plain() {
-        let yaml = to_string(&json!({ "hasBin": true, "max": 1000 })).unwrap();
-        assert_eq!(yaml, "hasBin: true\n\nmax: 1000\n");
-    }
-
-    #[test]
-    fn ambiguous_words_are_quoted() {
-        let yaml = to_string(&json!({ "a": "true", "b": "null", "c": "yes", "d": "no" })).unwrap();
-        // `true`/`null` are reserved words and get quoted; `yes`/`no` are plain
-        // in the core schema (no legacy-bool resolving), matching pnpm's
-        // noCompatMode dumper.
-        assert_eq!(yaml, "a: 'true'\n\nb: 'null'\n\nc: yes\n\nd: no\n");
-    }
-
-    #[test]
-    fn blank_lines_between_top_level_and_named_section_entries() {
-        let yaml = to_string(&json!({
-            "lockfileVersion": "9.0",
-            "packages": {
-                "a@1.0.0": { "x": 1 },
-                "b@2.0.0": { "y": 2 },
-            },
-        }))
-        .unwrap();
-        assert_eq!(
-            yaml,
-            "lockfileVersion: '9.0'\n\npackages:\n\n  a@1.0.0:\n    x: 1\n\n  b@2.0.0:\n    y: 2\n"
-        );
-    }
-
-    #[test]
-    fn single_line_keys_render_flow() {
-        let yaml = to_string(&json!({
-            "resolution": { "integrity": "sha512-abc" },
-            "engines": { "node": ">=10" },
-            "cpu": ["x64"],
-            "os": ["darwin", "linux"],
-        }))
-        .unwrap();
-        // Keys are sorted (cpu, engines, os, resolution); array elements keep
-        // their order.
-        assert_eq!(
-            yaml,
-            "cpu: [x64]\n\nengines: {node: '>=10'}\n\nos: [darwin, linux]\n\nresolution: {integrity: sha512-abc}\n"
-        );
-    }
-
-    #[test]
-    fn variations_resolution_renders_block_not_flow() {
-        // `resolution` is single-line except when its `type` is variations/binary.
-        let yaml = to_string(&json!({
-            "resolution": { "type": "variations", "variants": ["a"] },
-        }))
-        .unwrap();
-        assert_eq!(yaml, "resolution:\n  type: variations\n  variants:\n    - a\n");
-    }
-
-    #[test]
-    fn nan_resolves_as_float() {
-        assert!(super::resolves_float(".nan"));
-        assert!(super::resolves_float("-.inf"));
-        assert!(super::resolves_float("3.14"));
-        assert!(!super::resolves_float("3.14.15"));
-    }
-
-    #[test]
-    fn timestamp_strings_are_quoted() {
-        let yaml = to_string(&json!({ "t": "2021-01-01" })).unwrap();
-        assert_eq!(yaml, "t: '2021-01-01'\n");
-    }
-}
+mod tests;

--- a/pacquet/crates/lockfile/src/yaml_emit.rs
+++ b/pacquet/crates/lockfile/src/yaml_emit.rs
@@ -1,0 +1,922 @@
+//! Byte-for-byte port of the YAML dumper pnpm uses for `pnpm-lock.yaml`.
+//!
+//! pnpm serializes its lockfile with [`@zkochan/js-yaml`], a fork of `js-yaml`
+//! carrying lockfile-specific rendering rules that no general-purpose Rust YAML
+//! serializer reproduces:
+//!
+//! - **`blankLines`** — a blank line separates the entries of the top-level map
+//!   and of the `packages:` / `importers:` / `snapshots:` maps.
+//! - **single-line keys** — `cpu`, `engines`, `os`, `libc`, and `resolution`
+//!   (unless its `type` is `variations`/`binary`) render in flow style on one
+//!   line; everything else renders in block style.
+//! - **single-quote scalar style** — ambiguous scalars (`'9.0'`, `'>=10'`,
+//!   `'@scope/name@1.0.0'`) are single-quoted, matching `js-yaml`'s default
+//!   `quotingType`, not double-quoted.
+//! - **`lineWidth: -1`, `noRefs: true`, `noCompatMode: true`** — no line
+//!   wrapping, no anchors/aliases, no legacy-bool/base-60 quoting.
+//!
+//! The input is first lowered to a [`serde_json::Value`] (the crate enables
+//! `serde_json/preserve_order`, so map order is retained), then its keys are
+//! reordered by [`sort_lockfile_keys`] — a port of pnpm's `sortLockfileKeys`,
+//! so the byte output is independent of pacquet's struct field order — and
+//! finally rendered by a faithful translation of the fork's `dumper.js`.
+//!
+//! [`@zkochan/js-yaml`]: https://github.com/zkochan/js-yaml
+
+use serde_json::{Map, Value};
+use std::cmp::Ordering;
+
+/// Keys whose collection value always renders on a single line (flow style).
+/// Mirrors the fork's `SINGLE_LINE_KEYS`.
+const SINGLE_LINE_KEYS: [&str; 4] = ["cpu", "engines", "os", "libc"];
+
+/// One indentation level, in spaces (`js-yaml`'s default `indent`).
+const INDENT: usize = 2;
+
+/// Per-package / per-snapshot key priority. Mirrors `ORDERED_KEYS` in pnpm's
+/// [`sortLockfileKeys`](https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/fs/src/sortLockfileKeys.ts).
+const ORDERED_KEYS: [&str; 20] = [
+    "resolution",
+    "id",
+    "name",
+    "version",
+    "engines",
+    "cpu",
+    "os",
+    "libc",
+    "deprecated",
+    "hasBin",
+    "prepare",
+    "requiresBuild",
+    "bundleDependencies",
+    "peerDependencies",
+    "peerDependenciesMeta",
+    "dependencies",
+    "optionalDependencies",
+    "transitivePeerDependencies",
+    "dev",
+    "optional",
+];
+
+/// Top-level key priority. Mirrors `ROOT_KEYS` in pnpm's `sortLockfileKeys`.
+const ROOT_KEYS: [&str; 9] = [
+    "lockfileVersion",
+    "settings",
+    "catalogs",
+    "overrides",
+    "packageExtensionsChecksum",
+    "pnpmfileChecksum",
+    "patchedDependencies",
+    "importers",
+    "packages",
+];
+
+/// Serialize `value` to a YAML string matching pnpm's lockfile formatting.
+pub(crate) fn to_string<Value: serde::Serialize>(
+    value: &Value,
+) -> Result<String, serde_json::Error> {
+    let value = sort_lockfile_keys(serde_json::to_value(value)?);
+    let mut dump = render(&value, 0, true, true, None, false);
+    dump.push('\n');
+    Ok(dump)
+}
+
+/// Reorder a lockfile document's keys to match pnpm's on-write ordering. Port
+/// of pnpm's
+/// [`sortLockfileKeys`](https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/fs/src/sortLockfileKeys.ts):
+/// `importers` / `packages` / `snapshots` / `catalogs` / `time` /
+/// `patchedDependencies` are sorted by their direct keys, each section's
+/// entries are deep-sorted (by the priority map for packages/snapshots, by the
+/// root priority for importers, lexically for catalogs), and finally the root
+/// keys are ordered by priority.
+fn sort_lockfile_keys(value: Value) -> Value {
+    let Value::Object(mut root) = value else { return value };
+
+    for (section, priority) in [
+        ("importers", &ROOT_KEYS[..]),
+        ("packages", &ORDERED_KEYS[..]),
+        ("snapshots", &ORDERED_KEYS[..]),
+    ] {
+        if let Some(Value::Object(map)) = root.remove(section) {
+            let sorted = map_values(sort_direct_keys(map), |entry| match entry {
+                Value::Object(inner) => Value::Object(sort_by_priority(inner, priority, true)),
+                other => other,
+            });
+            root.insert(section.to_string(), Value::Object(sorted));
+        }
+    }
+
+    if let Some(Value::Object(catalogs)) = root.remove("catalogs") {
+        let sorted = map_values(sort_direct_keys(catalogs), sort_deep_keys);
+        root.insert("catalogs".to_string(), Value::Object(sorted));
+    }
+
+    for section in ["time", "patchedDependencies"] {
+        if let Some(Value::Object(map)) = root.remove(section) {
+            root.insert(section.to_string(), Value::Object(sort_direct_keys(map)));
+        }
+    }
+
+    Value::Object(sort_by_priority(root, &ROOT_KEYS, false))
+}
+
+/// Plain code-unit key comparison, matching pnpm's `lexCompare`.
+fn lex_cmp(left: &str, right: &str) -> Ordering {
+    left.cmp(right)
+}
+
+/// Mirror of pnpm's `compareWithPriority`: prioritized keys come first in
+/// priority order, the rest follow in `lexCompare` order.
+fn priority_cmp(priority: &[&str], left: &str, right: &str) -> Ordering {
+    let rank = |key: &str| priority.iter().position(|entry| *entry == key);
+    match (rank(left), rank(right)) {
+        (Some(left), Some(right)) => left.cmp(&right),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => lex_cmp(left, right),
+    }
+}
+
+fn map_values(map: Map<String, Value>, transform: impl Fn(Value) -> Value) -> Map<String, Value> {
+    map.into_iter().map(|(key, value)| (key, transform(value))).collect()
+}
+
+fn sort_direct_keys(map: Map<String, Value>) -> Map<String, Value> {
+    sort_map(map, &lex_cmp, false)
+}
+
+fn sort_deep_keys(value: Value) -> Value {
+    sort_value(value, &lex_cmp)
+}
+
+fn sort_by_priority(map: Map<String, Value>, priority: &[&str], deep: bool) -> Map<String, Value> {
+    sort_map(map, &|left, right| priority_cmp(priority, left, right), deep)
+}
+
+fn sort_map(
+    map: Map<String, Value>,
+    compare: &dyn Fn(&str, &str) -> Ordering,
+    deep: bool,
+) -> Map<String, Value> {
+    let mut entries: Vec<(String, Value)> = map.into_iter().collect();
+    entries.sort_by(|(left, _), (right, _)| compare(left, right));
+    entries
+        .into_iter()
+        .map(|(key, value)| (key, if deep { sort_value(value, compare) } else { value }))
+        .collect()
+}
+
+/// Recursively sort the keys of every nested object with `compare`, recursing
+/// through arrays without reordering their elements. Mirrors the `deep` option
+/// of the `sort-keys` package pnpm uses.
+fn sort_value(value: Value, compare: &dyn Fn(&str, &str) -> Ordering) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(sort_map(map, compare, true)),
+        Value::Array(items) => {
+            Value::Array(items.into_iter().map(|item| sort_value(item, compare)).collect())
+        }
+        other => other,
+    }
+}
+
+/// Render one node. Mirrors the fork's `writeNode`.
+///
+/// - `level` — current indentation depth.
+/// - `block` — whether block style is permitted here (`false` inside flow).
+/// - `compact` — whether the first child of a block collection omits its
+///   leading newline (the collection sits on the same line as its key).
+/// - `object_key` — the map key this value is bound to, driving the
+///   single-line and blank-line decisions.
+/// - `force_single_line` — propagated `singleLineOnly`: forces single-line
+///   scalar styling for keys and for values nested in a single-line map.
+fn render(
+    value: &Value,
+    level: usize,
+    block: bool,
+    compact: bool,
+    object_key: Option<&str>,
+    force_single_line: bool,
+) -> String {
+    match value {
+        Value::Object(map) => {
+            let single_line = is_single_line_map(object_key, map);
+            if block && !map.is_empty() && !single_line {
+                let double_line = level == 0
+                    || matches!(object_key, Some("packages" | "importers" | "snapshots"));
+                write_block_mapping(map, level, compact, double_line)
+            } else {
+                write_flow_mapping(map, level, single_line)
+            }
+        }
+        Value::Array(seq) => {
+            let single_line = object_key.is_some_and(is_single_line_key);
+            if block && !seq.is_empty() && !single_line {
+                write_block_sequence(seq, level, compact)
+            } else {
+                write_flow_sequence(seq, level)
+            }
+        }
+        Value::String(string) => write_scalar(string, level, force_single_line, block),
+        Value::Bool(boolean) => if *boolean { "true" } else { "false" }.to_string(),
+        Value::Number(number) => number.to_string(),
+        Value::Null => "null".to_string(),
+    }
+}
+
+fn is_single_line_key(key: &str) -> bool {
+    SINGLE_LINE_KEYS.contains(&key)
+}
+
+/// Whether a map value renders on a single line. `resolution` is single-line
+/// except for the nested `variations`/`binary` shapes (detected by the `type`
+/// discriminator pnpm's tagged resolutions carry).
+fn is_single_line_map(object_key: Option<&str>, map: &serde_json::Map<String, Value>) -> bool {
+    match object_key {
+        Some(key) if is_single_line_key(key) => true,
+        Some("resolution") => {
+            !matches!(map.get("type").and_then(Value::as_str), Some("variations" | "binary"))
+        }
+        _ => false,
+    }
+}
+
+/// `generateNextLine`: a newline (doubled when `double_line`) plus this level's
+/// indent.
+fn next_line(level: usize, double_line: bool) -> String {
+    let mut line = String::from("\n");
+    if double_line {
+        line.push('\n');
+    }
+    line.extend(std::iter::repeat_n(' ', INDENT * level));
+    line
+}
+
+fn write_block_mapping(
+    map: &serde_json::Map<String, Value>,
+    level: usize,
+    compact: bool,
+    double_line: bool,
+) -> String {
+    let mut result = String::new();
+    for (key, value) in map {
+        if !compact || !result.is_empty() {
+            result.push_str(&next_line(level, double_line));
+        }
+        result.push_str(&write_scalar(key, level + 1, true, true));
+        let rendered = render(value, level + 1, true, false, Some(key), false);
+        result.push(':');
+        if !rendered.starts_with('\n') {
+            result.push(' ');
+        }
+        result.push_str(&rendered);
+    }
+    if result.is_empty() { "{}".to_string() } else { result }
+}
+
+fn write_block_sequence(seq: &[Value], level: usize, compact: bool) -> String {
+    let mut result = String::new();
+    for value in seq {
+        let rendered = render(value, level + 1, true, true, None, false);
+        if !compact || !result.is_empty() {
+            result.push_str(&next_line(level, false));
+        }
+        result.push('-');
+        if !rendered.starts_with('\n') {
+            result.push(' ');
+        }
+        result.push_str(&rendered);
+    }
+    if result.is_empty() { "[]".to_string() } else { result }
+}
+
+fn write_flow_mapping(
+    map: &serde_json::Map<String, Value>,
+    level: usize,
+    single_line: bool,
+) -> String {
+    let mut result = String::new();
+    for (key, value) in map {
+        if !result.is_empty() {
+            result.push_str(", ");
+        }
+        result.push_str(&write_scalar(key, level, single_line, false));
+        result.push_str(": ");
+        result.push_str(&render(value, level, false, false, None, single_line));
+    }
+    format!("{{{result}}}")
+}
+
+fn write_flow_sequence(seq: &[Value], level: usize) -> String {
+    let mut result = String::new();
+    for value in seq {
+        if !result.is_empty() {
+            result.push_str(", ");
+        }
+        result.push_str(&render(value, level, false, false, None, false));
+    }
+    format!("[{result}]")
+}
+
+/// Scalar styles, mirroring the fork's `STYLE_*` constants. `Folded` never
+/// occurs here because `lineWidth` is `-1`.
+enum ScalarStyle {
+    Plain,
+    Single,
+    Double,
+    Literal,
+}
+
+/// Render a string scalar. Mirrors the fork's `writeScalar` under the lockfile
+/// options (`quotingType` single, `noCompatMode`, `lineWidth: -1`,
+/// `forceQuotes` off).
+fn write_scalar(string: &str, level: usize, single_line: bool, inblock: bool) -> String {
+    if string.is_empty() {
+        return "''".to_string();
+    }
+    match choose_scalar_style(string, single_line, inblock) {
+        ScalarStyle::Plain => string.to_string(),
+        ScalarStyle::Single => format!("'{}'", string.replace('\'', "''")),
+        ScalarStyle::Double => format!("\"{}\"", escape_string(string)),
+        ScalarStyle::Literal => {
+            let indent = INDENT * level.max(1);
+            format!(
+                "|{}{}",
+                block_header(string),
+                drop_ending_newline(&indent_string(string, indent))
+            )
+        }
+    }
+}
+
+/// Mirrors the fork's `chooseScalarStyle` under lockfile options.
+fn choose_scalar_style(string: &str, single_line_only: bool, inblock: bool) -> ScalarStyle {
+    let chars: Vec<u32> = string.chars().map(u32::from).collect();
+    let mut plain = is_plain_safe_first(chars[0]) && is_plain_safe_last(chars[chars.len() - 1]);
+    let mut has_line_break = false;
+    let mut prev: Option<u32> = None;
+
+    if single_line_only {
+        for &char in &chars {
+            if !is_printable(char) {
+                return ScalarStyle::Double;
+            }
+            plain = plain && is_plain_safe(char, prev, inblock);
+            prev = Some(char);
+        }
+    } else {
+        for &char in &chars {
+            if char == CHAR_LINE_FEED {
+                has_line_break = true;
+            } else if !is_printable(char) {
+                return ScalarStyle::Double;
+            }
+            plain = plain && is_plain_safe(char, prev, inblock);
+            prev = Some(char);
+        }
+    }
+
+    if !has_line_break {
+        if plain && !resolves_implicitly(string) {
+            return ScalarStyle::Plain;
+        }
+        return ScalarStyle::Single;
+    }
+    ScalarStyle::Literal
+}
+
+const CHAR_TAB: u32 = 0x09;
+const CHAR_LINE_FEED: u32 = 0x0A;
+const CHAR_CARRIAGE_RETURN: u32 = 0x0D;
+const CHAR_SPACE: u32 = 0x20;
+const CHAR_SHARP: u32 = 0x23; // #
+const CHAR_COLON: u32 = 0x3A; // :
+const CHAR_COMMA: u32 = 0x2C; // ,
+const CHAR_LEFT_SQUARE_BRACKET: u32 = 0x5B; // [
+const CHAR_RIGHT_SQUARE_BRACKET: u32 = 0x5D; // ]
+const CHAR_LEFT_CURLY_BRACKET: u32 = 0x7B; // {
+const CHAR_RIGHT_CURLY_BRACKET: u32 = 0x7D; // }
+const CHAR_BOM: u32 = 0xFEFF;
+
+fn is_whitespace(c: u32) -> bool {
+    c == CHAR_SPACE || c == CHAR_TAB
+}
+
+fn is_printable(c: u32) -> bool {
+    (0x00020..=0x00007E).contains(&c)
+        || ((0x000A1..=0x00D7FF).contains(&c) && c != 0x2028 && c != 0x2029)
+        || ((0x0E000..=0x00FFFD).contains(&c) && c != CHAR_BOM)
+        || (0x10000..=0x10FFFF).contains(&c)
+}
+
+fn is_ns_char_or_whitespace(c: u32) -> bool {
+    is_printable(c) && c != CHAR_BOM && c != CHAR_CARRIAGE_RETURN && c != CHAR_LINE_FEED
+}
+
+fn is_plain_safe_first(c: u32) -> bool {
+    is_printable(c)
+        && c != CHAR_BOM
+        && !is_whitespace(c)
+        && !matches!(
+            c,
+            0x2D | // -
+            0x3F | // ?
+            CHAR_COLON
+                | CHAR_COMMA
+                | CHAR_LEFT_SQUARE_BRACKET
+                | CHAR_RIGHT_SQUARE_BRACKET
+                | CHAR_LEFT_CURLY_BRACKET
+                | CHAR_RIGHT_CURLY_BRACKET
+                | CHAR_SHARP
+                | 0x26 | // &
+            0x2A | // *
+            0x21 | // !
+            0x7C | // |
+            0x3D | // =
+            0x3E | // >
+            0x27 | // '
+            0x22 | // "
+            0x25 | // %
+            0x40 | // @
+            0x60 // `
+        )
+}
+
+fn is_plain_safe_last(c: u32) -> bool {
+    !is_whitespace(c) && c != CHAR_COLON
+}
+
+fn is_plain_safe(c: u32, prev: Option<u32>, inblock: bool) -> bool {
+    let c_is_ns_or_ws = is_ns_char_or_whitespace(c);
+    let c_is_ns = c_is_ns_or_ws && !is_whitespace(c);
+    let base = if inblock {
+        c_is_ns_or_ws
+    } else {
+        c_is_ns_or_ws
+            && c != CHAR_COMMA
+            && c != CHAR_LEFT_SQUARE_BRACKET
+            && c != CHAR_RIGHT_SQUARE_BRACKET
+            && c != CHAR_LEFT_CURLY_BRACKET
+            && c != CHAR_RIGHT_CURLY_BRACKET
+    };
+    let prev_is_colon = prev == Some(CHAR_COLON);
+    let prev_is_ns = prev.is_some_and(|p| is_ns_char_or_whitespace(p) && !is_whitespace(p));
+    // change to true on '[^ ]#'
+    if prev_is_ns && c == CHAR_SHARP {
+        return true;
+    }
+    // change to true on ':[^ ]'
+    if prev_is_colon && c_is_ns {
+        return true;
+    }
+    // ns-plain-char: a non-`#` base character that isn't the `: ` sequence.
+    base && c != CHAR_SHARP && (!prev_is_colon || c_is_ns)
+}
+
+/// Mirrors the fork's `escapeString` (with `escapeSeq` table and hex fallback).
+fn escape_string(string: &str) -> String {
+    let mut result = String::new();
+    for ch in string.chars() {
+        let code = u32::from(ch);
+        if let Some(seq) = escape_sequence(code) {
+            result.push_str(seq);
+        } else if is_printable(code) {
+            result.push(ch);
+        } else {
+            result.push_str(&encode_hex(code));
+        }
+    }
+    result
+}
+
+fn escape_sequence(code: u32) -> Option<&'static str> {
+    Some(match code {
+        0x00 => "\\0",
+        0x07 => "\\a",
+        0x08 => "\\b",
+        0x09 => "\\t",
+        0x0A => "\\n",
+        0x0B => "\\v",
+        0x0C => "\\f",
+        0x0D => "\\r",
+        0x1B => "\\e",
+        0x22 => "\\\"",
+        0x5C => "\\\\",
+        0x85 => "\\N",
+        0xA0 => "\\_",
+        0x2028 => "\\L",
+        0x2029 => "\\P",
+        _ => return None,
+    })
+}
+
+fn encode_hex(code: u32) -> String {
+    let hex = format!("{code:X}");
+    let (handle, width) = if code <= 0xFF {
+        ('x', 2)
+    } else if code <= 0xFFFF {
+        ('u', 4)
+    } else {
+        ('U', 8)
+    };
+    format!("\\{handle}{:0>width$}", hex, width = width)
+}
+
+fn block_header(string: &str) -> String {
+    let indicator = if needs_indent_indicator(string) { INDENT.to_string() } else { String::new() };
+    let bytes = string.as_bytes();
+    let clip = bytes.last() == Some(&b'\n');
+    let keep = clip && (bytes.get(bytes.len().wrapping_sub(2)) == Some(&b'\n') || string == "\n");
+    let chomp = if keep {
+        "+"
+    } else if clip {
+        ""
+    } else {
+        "-"
+    };
+    format!("{indicator}{chomp}\n")
+}
+
+fn needs_indent_indicator(string: &str) -> bool {
+    let trimmed = string.trim_start_matches('\n');
+    trimmed.starts_with(' ')
+}
+
+fn drop_ending_newline(string: &str) -> String {
+    string.strip_suffix('\n').unwrap_or(string).to_string()
+}
+
+fn indent_string(string: &str, spaces: usize) -> String {
+    let indent: String = std::iter::repeat_n(' ', spaces).collect();
+    let mut result = String::new();
+    for line in split_keep_newlines(string) {
+        if !line.is_empty() && line != "\n" {
+            result.push_str(&indent);
+        }
+        result.push_str(line);
+    }
+    result
+}
+
+/// Split into lines that keep their trailing `\n`, mirroring the manual scan in
+/// the fork's `indentString`.
+fn split_keep_newlines(string: &str) -> Vec<&str> {
+    let mut lines = Vec::new();
+    let mut start = 0;
+    let bytes = string.as_bytes();
+    while start < bytes.len() {
+        match string[start..].find('\n') {
+            Some(offset) => {
+                lines.push(&string[start..start + offset + 1]);
+                start += offset + 1;
+            }
+            None => {
+                lines.push(&string[start..]);
+                start = bytes.len();
+            }
+        }
+    }
+    lines
+}
+
+/// Whether a plain scalar would be reinterpreted as a non-string type and so
+/// must be quoted. Mirrors `testImplicitResolving` over the default schema's
+/// implicit types: null, bool, int, float, timestamp, merge.
+fn resolves_implicitly(string: &str) -> bool {
+    resolves_null(string)
+        || resolves_bool(string)
+        || resolves_int(string)
+        || resolves_float(string)
+        || resolves_timestamp(string)
+        || string == "<<"
+}
+
+fn resolves_null(string: &str) -> bool {
+    matches!(string, "~" | "null" | "Null" | "NULL")
+}
+
+fn resolves_bool(string: &str) -> bool {
+    matches!(string, "true" | "True" | "TRUE" | "false" | "False" | "FALSE")
+}
+
+/// Port of `type/int.js`'s `resolveYamlInteger`.
+fn resolves_int(string: &str) -> bool {
+    let bytes = string.as_bytes();
+    if bytes.is_empty() {
+        return false;
+    }
+    let mut index = 0;
+    if matches!(bytes[index], b'-' | b'+') {
+        index += 1;
+    }
+    if index >= bytes.len() {
+        return false;
+    }
+    if bytes[index] == b'0' {
+        if index + 1 == bytes.len() {
+            return true;
+        }
+        index += 1;
+        match bytes[index] {
+            b'b' => return digits_match(&bytes[index + 1..], |c| matches!(c, b'0' | b'1')),
+            b'x' => return digits_match(&bytes[index + 1..], |c| c.is_ascii_hexdigit()),
+            b'o' => return digits_match(&bytes[index + 1..], |c| matches!(c, b'0'..=b'7')),
+            _ => {}
+        }
+    }
+    if bytes[index] == b'_' {
+        return false;
+    }
+    digits_match(&bytes[index..], |c| c.is_ascii_digit())
+}
+
+/// A run of `_`-separated digits accepted by `predicate`, with at least one
+/// digit and no trailing `_`. Mirrors the per-base loops in `resolveYamlInteger`.
+fn digits_match(bytes: &[u8], predicate: impl Fn(u8) -> bool) -> bool {
+    let mut has_digits = false;
+    let mut last = 0u8;
+    for &byte in bytes {
+        last = byte;
+        if byte == b'_' {
+            continue;
+        }
+        if !predicate(byte) {
+            return false;
+        }
+        has_digits = true;
+    }
+    has_digits && last != b'_'
+}
+
+/// Port of `type/float.js`'s `YAML_FLOAT_PATTERN` test (with the trailing-`_`
+/// guard).
+fn resolves_float(string: &str) -> bool {
+    if string.ends_with('_') {
+        return false;
+    }
+    float_matches(string)
+}
+
+fn float_matches(string: &str) -> bool {
+    // [-+]?.inf and .nan special forms.
+    let unsigned = string.strip_prefix(['-', '+']).unwrap_or(string);
+    if matches!(unsigned, ".inf" | ".Inf" | ".INF") || matches!(string, ".nan" | ".NaN" | ".NAN") {
+        return true;
+    }
+
+    let body = string.strip_prefix(['-', '+']).unwrap_or(string);
+    // Form A: [0-9][0-9_]* (\.[0-9_]*)? ([eE][-+]?[0-9]+)?
+    // Form B: \.[0-9_]+ ([eE][-+]?[0-9]+)?  (no leading sign per the pattern).
+    if let Some(after_dot) = body.strip_prefix('.') {
+        if string.starts_with(['-', '+']) {
+            return false;
+        }
+        let (mantissa, exponent) = split_exponent(after_dot);
+        return !mantissa.is_empty()
+            && mantissa.bytes().all(|b| b.is_ascii_digit() || b == b'_')
+            && exponent_ok(exponent);
+    }
+    let mut cursor = body;
+    let first = cursor.as_bytes().first().copied();
+    if !first.is_some_and(|b| b.is_ascii_digit()) {
+        return false;
+    }
+    // [0-9][0-9_]*
+    let int_len = cursor.bytes().take_while(|b| b.is_ascii_digit() || *b == b'_').count();
+    cursor = &cursor[int_len..];
+    // (\.[0-9_]*)?
+    if let Some(rest) = cursor.strip_prefix('.') {
+        let frac_len = rest.bytes().take_while(|b| b.is_ascii_digit() || *b == b'_').count();
+        cursor = &rest[frac_len..];
+    }
+    // ([eE][-+]?[0-9]+)? — and nothing left over.
+    exponent_consumes_all(cursor)
+}
+
+/// Split a float mantissa from its optional `[eE]...` exponent.
+fn split_exponent(string: &str) -> (&str, Option<&str>) {
+    match string.find(['e', 'E']) {
+        Some(index) => (&string[..index], Some(&string[index..])),
+        None => (string, None),
+    }
+}
+
+/// Whether an optional exponent tail (`""` or `[eE][-+]?[0-9]+`) is valid.
+fn exponent_ok(exponent: Option<&str>) -> bool {
+    match exponent {
+        None | Some("") => true,
+        Some(tail) => exponent_consumes_all(tail),
+    }
+}
+
+fn exponent_consumes_all(tail: &str) -> bool {
+    if tail.is_empty() {
+        return true;
+    }
+    let Some(rest) = tail.strip_prefix(['e', 'E']) else {
+        return false;
+    };
+    let rest = rest.strip_prefix(['-', '+']).unwrap_or(rest);
+    !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// Port of `type/timestamp.js`'s `resolveYamlTimestamp` (date and full forms).
+fn resolves_timestamp(string: &str) -> bool {
+    matches_date(string) || matches_timestamp(string)
+}
+
+fn matches_date(string: &str) -> bool {
+    let bytes = string.as_bytes();
+    bytes.len() == 10
+        && bytes[..4].iter().all(u8::is_ascii_digit)
+        && bytes[4] == b'-'
+        && bytes[5..7].iter().all(u8::is_ascii_digit)
+        && bytes[7] == b'-'
+        && bytes[8..10].iter().all(u8::is_ascii_digit)
+}
+
+fn matches_timestamp(string: &str) -> bool {
+    let bytes = string.as_bytes();
+    let mut i = 0;
+    let take_digits = |bytes: &[u8], i: &mut usize, min: usize, max: usize| -> bool {
+        let start = *i;
+        while *i < bytes.len() && *i - start < max && bytes[*i].is_ascii_digit() {
+            *i += 1;
+        }
+        *i - start >= min
+    };
+    if !take_digits(bytes, &mut i, 4, 4) {
+        return false;
+    }
+    if bytes.get(i) != Some(&b'-') {
+        return false;
+    }
+    i += 1;
+    if !take_digits(bytes, &mut i, 1, 2) {
+        return false;
+    }
+    if bytes.get(i) != Some(&b'-') {
+        return false;
+    }
+    i += 1;
+    if !take_digits(bytes, &mut i, 1, 2) {
+        return false;
+    }
+    // (?:[Tt]|[ \t]+)
+    match bytes.get(i) {
+        Some(b'T' | b't') => i += 1,
+        Some(b' ' | b'\t') => {
+            while matches!(bytes.get(i), Some(b' ' | b'\t')) {
+                i += 1;
+            }
+        }
+        _ => return false,
+    }
+    if !take_digits(bytes, &mut i, 1, 2) {
+        return false;
+    }
+    if bytes.get(i) != Some(&b':') {
+        return false;
+    }
+    i += 1;
+    if !take_digits(bytes, &mut i, 2, 2) {
+        return false;
+    }
+    if bytes.get(i) != Some(&b':') {
+        return false;
+    }
+    i += 1;
+    if !take_digits(bytes, &mut i, 2, 2) {
+        return false;
+    }
+    // (?:\.([0-9]*))?
+    if bytes.get(i) == Some(&b'.') {
+        i += 1;
+        while matches!(bytes.get(i), Some(b) if b.is_ascii_digit()) {
+            i += 1;
+        }
+    }
+    // (?:[ \t]*(Z|([-+])([0-9][0-9]?)(?::([0-9][0-9]))?))?
+    while matches!(bytes.get(i), Some(b' ' | b'\t')) {
+        i += 1;
+    }
+    if i == bytes.len() {
+        return true;
+    }
+    match bytes.get(i) {
+        Some(b'Z') => {
+            i += 1;
+        }
+        Some(b'-' | b'+') => {
+            i += 1;
+            if !take_digits(bytes, &mut i, 1, 2) {
+                return false;
+            }
+            if bytes.get(i) == Some(&b':') {
+                i += 1;
+                if !take_digits(bytes, &mut i, 2, 2) {
+                    return false;
+                }
+            }
+        }
+        _ => return false,
+    }
+    i == bytes.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::to_string;
+    use serde_json::json;
+
+    #[test]
+    fn version_like_floats_are_single_quoted() {
+        // `9.0` resolves as a YAML float, so it must be quoted; `11.5.2` and
+        // `1.0.0` are plain strings.
+        let yaml = to_string(&json!({ "a": "9.0", "b": "11.5.2", "c": "1.0.0" })).unwrap();
+        // Top-level entries are blank-line separated.
+        assert_eq!(yaml, "a: '9.0'\n\nb: 11.5.2\n\nc: 1.0.0\n");
+    }
+
+    #[test]
+    fn leading_indicator_and_at_force_single_quotes() {
+        let yaml = to_string(&json!({
+            "node": ">=10",
+            "name": "@scope/pkg@1.0.0",
+        }))
+        .unwrap();
+        // Keys are sorted (`name` before `node`).
+        assert_eq!(yaml, "name: '@scope/pkg@1.0.0'\n\nnode: '>=10'\n");
+    }
+
+    #[test]
+    fn booleans_and_numbers_render_plain() {
+        let yaml = to_string(&json!({ "hasBin": true, "max": 1000 })).unwrap();
+        assert_eq!(yaml, "hasBin: true\n\nmax: 1000\n");
+    }
+
+    #[test]
+    fn ambiguous_words_are_quoted() {
+        let yaml = to_string(&json!({ "a": "true", "b": "null", "c": "yes", "d": "no" })).unwrap();
+        // `true`/`null` are reserved words and get quoted; `yes`/`no` are plain
+        // in the core schema (no legacy-bool resolving), matching pnpm's
+        // noCompatMode dumper.
+        assert_eq!(yaml, "a: 'true'\n\nb: 'null'\n\nc: yes\n\nd: no\n");
+    }
+
+    #[test]
+    fn blank_lines_between_top_level_and_named_section_entries() {
+        let yaml = to_string(&json!({
+            "lockfileVersion": "9.0",
+            "packages": {
+                "a@1.0.0": { "x": 1 },
+                "b@2.0.0": { "y": 2 },
+            },
+        }))
+        .unwrap();
+        assert_eq!(
+            yaml,
+            "lockfileVersion: '9.0'\n\npackages:\n\n  a@1.0.0:\n    x: 1\n\n  b@2.0.0:\n    y: 2\n"
+        );
+    }
+
+    #[test]
+    fn single_line_keys_render_flow() {
+        let yaml = to_string(&json!({
+            "resolution": { "integrity": "sha512-abc" },
+            "engines": { "node": ">=10" },
+            "cpu": ["x64"],
+            "os": ["darwin", "linux"],
+        }))
+        .unwrap();
+        // Keys are sorted (cpu, engines, os, resolution); array elements keep
+        // their order.
+        assert_eq!(
+            yaml,
+            "cpu: [x64]\n\nengines: {node: '>=10'}\n\nos: [darwin, linux]\n\nresolution: {integrity: sha512-abc}\n"
+        );
+    }
+
+    #[test]
+    fn variations_resolution_renders_block_not_flow() {
+        // `resolution` is single-line except when its `type` is variations/binary.
+        let yaml = to_string(&json!({
+            "resolution": { "type": "variations", "variants": ["a"] },
+        }))
+        .unwrap();
+        assert_eq!(yaml, "resolution:\n  type: variations\n  variants:\n    - a\n");
+    }
+
+    #[test]
+    fn nan_resolves_as_float() {
+        assert!(super::resolves_float(".nan"));
+        assert!(super::resolves_float("-.inf"));
+        assert!(super::resolves_float("3.14"));
+        assert!(!super::resolves_float("3.14.15"));
+    }
+
+    #[test]
+    fn timestamp_strings_are_quoted() {
+        let yaml = to_string(&json!({ "t": "2021-01-01" })).unwrap();
+        assert_eq!(yaml, "t: '2021-01-01'\n");
+    }
+}

--- a/pacquet/crates/lockfile/src/yaml_emit/tests.rs
+++ b/pacquet/crates/lockfile/src/yaml_emit/tests.rs
@@ -1,0 +1,94 @@
+use super::{resolves_float, to_string};
+use serde_json::json;
+
+#[test]
+fn version_like_floats_are_single_quoted() {
+    // `9.0` resolves as a YAML float, so it must be quoted; `11.5.2` and
+    // `1.0.0` are plain strings.
+    let yaml = to_string(&json!({ "a": "9.0", "b": "11.5.2", "c": "1.0.0" })).unwrap();
+    // Top-level entries are blank-line separated.
+    assert_eq!(yaml, "a: '9.0'\n\nb: 11.5.2\n\nc: 1.0.0\n");
+}
+
+#[test]
+fn leading_indicator_and_at_force_single_quotes() {
+    let yaml = to_string(&json!({
+        "node": ">=10",
+        "name": "@scope/pkg@1.0.0",
+    }))
+    .unwrap();
+    // Keys are sorted (`name` before `node`).
+    assert_eq!(yaml, "name: '@scope/pkg@1.0.0'\n\nnode: '>=10'\n");
+}
+
+#[test]
+fn booleans_and_numbers_render_plain() {
+    let yaml = to_string(&json!({ "hasBin": true, "max": 1000 })).unwrap();
+    assert_eq!(yaml, "hasBin: true\n\nmax: 1000\n");
+}
+
+#[test]
+fn ambiguous_words_are_quoted() {
+    let yaml = to_string(&json!({ "a": "true", "b": "null", "c": "yes", "d": "no" })).unwrap();
+    // `true`/`null` are reserved words and get quoted; `yes`/`no` are plain in
+    // the core schema (no legacy-bool resolving), matching pnpm's noCompatMode
+    // dumper.
+    assert_eq!(yaml, "a: 'true'\n\nb: 'null'\n\nc: yes\n\nd: no\n");
+}
+
+#[test]
+fn blank_lines_between_top_level_and_named_section_entries() {
+    let yaml = to_string(&json!({
+        "lockfileVersion": "9.0",
+        "packages": {
+            "a@1.0.0": { "x": 1 },
+            "b@2.0.0": { "y": 2 },
+        },
+    }))
+    .unwrap();
+    assert_eq!(
+        yaml,
+        "lockfileVersion: '9.0'\n\npackages:\n\n  a@1.0.0:\n    x: 1\n\n  b@2.0.0:\n    y: 2\n",
+    );
+}
+
+#[test]
+fn single_line_keys_render_flow() {
+    let yaml = to_string(&json!({
+        "resolution": { "integrity": "sha512-abc" },
+        "engines": { "node": ">=10" },
+        "cpu": ["x64"],
+        "os": ["darwin", "linux"],
+    }))
+    .unwrap();
+    // Keys are sorted (cpu, engines, os, resolution); array elements keep their
+    // order.
+    assert_eq!(
+        yaml,
+        "cpu: [x64]\n\nengines: {node: '>=10'}\n\nos: [darwin, linux]\n\nresolution: {integrity: sha512-abc}\n",
+    );
+}
+
+#[test]
+fn variations_resolution_renders_block_not_flow() {
+    // `resolution` is single-line except when its `type` is variations/binary.
+    let yaml = to_string(&json!({
+        "resolution": { "type": "variations", "variants": ["a"] },
+    }))
+    .unwrap();
+    assert_eq!(yaml, "resolution:\n  type: variations\n  variants:\n    - a\n");
+}
+
+#[test]
+fn nan_resolves_as_float() {
+    assert!(resolves_float(".nan"));
+    assert!(resolves_float("-.inf"));
+    assert!(resolves_float("3.14"));
+    assert!(!resolves_float("3.14.15"));
+}
+
+#[test]
+fn timestamp_strings_are_quoted() {
+    let yaml = to_string(&json!({ "t": "2021-01-01" })).unwrap();
+    assert_eq!(yaml, "t: '2021-01-01'\n");
+}

--- a/pacquet/crates/package-manager/src/build_snapshot/tests.rs
+++ b/pacquet/crates/package-manager/src/build_snapshot/tests.rs
@@ -29,6 +29,7 @@ fn make_package(name: &str, version: &str) -> PackageVersion {
         peer_dependencies: None,
         optional_dependencies: None,
         peer_dependencies_meta: None,
+        other: Default::default(),
         npm_user: None,
         deprecated: None,
     }

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -105,6 +105,15 @@ pub struct GraphToLockfileOptions<'a> {
     /// the resolved specifier + version for every `catalog:` direct
     /// dependency. Empty for projects with no catalogs.
     pub catalogs: &'a Catalogs,
+    /// Default registry URL, used to decide whether a resolved registry
+    /// package's tarball URL is reconstructible (and so droppable from the
+    /// lockfile in favor of bare `{integrity}`). Mirrors the `registry`
+    /// argument pnpm threads into
+    /// [`toLockfileResolution`](https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/utils/src/toLockfileResolution.ts).
+    pub registry: &'a str,
+    /// When `true`, registry tarball URLs are kept in the lockfile even when
+    /// reconstructible. Mirrors pnpm's `lockfileIncludeTarballUrl` setting.
+    pub lockfile_include_tarball_url: bool,
 }
 
 /// Build a [`Lockfile`] from the resolver's [`DependenciesGraph`] plus
@@ -136,10 +145,17 @@ pub fn dependencies_graph_to_lockfile(opts: GraphToLockfileOptions<'_>) -> Lockf
         ignored_optional_dependencies,
         package_extensions_checksum,
         catalogs,
+        registry,
+        lockfile_include_tarball_url,
     } = opts;
 
     let optional_overrides = compute_corrected_optional(&importer_inputs, graph);
-    let (packages, snapshots) = build_packages_and_snapshots(graph, &optional_overrides);
+    let (packages, snapshots) = build_packages_and_snapshots(
+        graph,
+        &optional_overrides,
+        registry,
+        lockfile_include_tarball_url,
+    );
 
     let mut importers: HashMap<String, ProjectSnapshot> =
         HashMap::with_capacity(importer_inputs.len());
@@ -436,6 +452,8 @@ fn is_remote_http_tarball(tarball: &str) -> bool {
 fn build_packages_and_snapshots(
     graph: &DependenciesGraph,
     optional_overrides: &HashMap<DepPath, bool>,
+    registry: &str,
+    lockfile_include_tarball_url: bool,
 ) -> (HashMap<PackageKey, PackageMetadata>, HashMap<PackageKey, SnapshotEntry>) {
     let mut packages: HashMap<PackageKey, PackageMetadata> = HashMap::new();
     let mut snapshots: HashMap<PackageKey, SnapshotEntry> = HashMap::new();
@@ -447,7 +465,9 @@ fn build_packages_and_snapshots(
         let snapshot = build_snapshot_entry(node, graph, optional_overrides);
         snapshots.insert(snapshot_key, snapshot);
 
-        packages.entry(metadata_key).or_insert_with(|| build_package_metadata(node));
+        packages.entry(metadata_key).or_insert_with_key(|key| {
+            build_package_metadata(node, key, registry, lockfile_include_tarball_url)
+        });
     }
 
     (packages, snapshots)
@@ -463,7 +483,12 @@ fn build_packages_and_snapshots(
 /// for the per-package half (excludes the per-snapshot fields
 /// `dependencies` / `optionalDependencies` / `transitivePeerDependencies` /
 /// `optional` / `patched`, which go on the snapshot below).
-fn build_package_metadata(node: &DependenciesGraphNode) -> PackageMetadata {
+fn build_package_metadata(
+    node: &DependenciesGraphNode,
+    metadata_key: &PackageKey,
+    registry: &str,
+    lockfile_include_tarball_url: bool,
+) -> PackageMetadata {
     let manifest = node.resolve_result.manifest.as_deref();
 
     let engines = manifest
@@ -496,8 +521,15 @@ fn build_package_metadata(node: &DependenciesGraphNode) -> PackageMetadata {
 
     let (peer_dependencies, peer_dependencies_meta) = build_peer_dep_blocks(node);
 
+    let resolution = node.resolve_result.resolution.to_lockfile_form(
+        &metadata_key.name.to_string(),
+        &metadata_key.suffix.version().to_string(),
+        registry,
+        lockfile_include_tarball_url,
+    );
+
     PackageMetadata {
-        resolution: node.resolve_result.resolution.clone(),
+        resolution,
         engines,
         cpu,
         os,

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -48,6 +48,8 @@ fn single_importer_opts<'a>(
         ignored_optional_dependencies,
         package_extensions_checksum: None,
         catalogs: &EMPTY_CATALOGS,
+        registry: "https://registry.npmjs.org",
+        lockfile_include_tarball_url: false,
     }
 }
 
@@ -217,6 +219,8 @@ fn dedupe_peers_round_trips_through_lockfile_settings() {
         ignored_optional_dependencies: None,
         package_extensions_checksum: None,
         catalogs: &EMPTY_CATALOGS,
+        registry: "https://registry.npmjs.org",
+        lockfile_include_tarball_url: false,
     });
     let on_settings = on.settings.as_ref().expect("settings written");
     assert_eq!(on_settings.dedupe_peers, Some(true));
@@ -240,6 +244,8 @@ fn dedupe_peers_round_trips_through_lockfile_settings() {
         ignored_optional_dependencies: None,
         package_extensions_checksum: None,
         catalogs: &EMPTY_CATALOGS,
+        registry: "https://registry.npmjs.org",
+        lockfile_include_tarball_url: false,
     });
     let off_settings = off.settings.as_ref().expect("settings written");
     assert_eq!(off_settings.dedupe_peers, None);
@@ -888,6 +894,8 @@ fn multi_importer_workspace_writes_per_project_lockfile_entries() {
         ignored_optional_dependencies: None,
         package_extensions_checksum: None,
         catalogs: &EMPTY_CATALOGS,
+        registry: "https://registry.npmjs.org",
+        lockfile_include_tarball_url: false,
     });
 
     let a_snap = lockfile.importers.get("packages/a").expect("importer a");
@@ -1013,6 +1021,8 @@ fn multi_importer_pruner_marks_shared_dep_non_optional_when_any_importer_reaches
         ignored_optional_dependencies: None,
         package_extensions_checksum: None,
         catalogs: &EMPTY_CATALOGS,
+        registry: "https://registry.npmjs.org",
+        lockfile_include_tarball_url: false,
     });
 
     let snapshots = lockfile.snapshots.as_ref().expect("snapshots map");
@@ -1167,6 +1177,8 @@ fn workspace_sibling_link_renders_per_importer_with_link_ref() {
         ignored_optional_dependencies: None,
         package_extensions_checksum: None,
         catalogs: &EMPTY_CATALOGS,
+        registry: "https://registry.npmjs.org",
+        lockfile_include_tarball_url: false,
     });
 
     // Importer a points at b via a link: ref carrying the relative

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1332,6 +1332,24 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         // adapter shape); `hoisted_locations` carries the walker's
         // placements so `.modules.yaml` round-trips them.
         let (hoisted_dependencies, hoisted_locations) = if is_hoisted {
+            // The hoisted walker runs the installability check, which
+            // consults `engines.node`. Detect the host node version (as the
+            // frozen path does) whenever a package carries an installability
+            // constraint, so the engine check resolves against a real version
+            // instead of erroring on an empty one. Skip the `node --version`
+            // probe entirely when nothing constrains it.
+            let host_node = if built_lockfile
+                .packages
+                .as_ref()
+                .is_some_and(crate::any_installability_constraint)
+            {
+                tokio::task::spawn_blocking(crate::InstallabilityHost::detect)
+                    .await
+                    .ok()
+                    .map(|host| (host.node_detected, host.node_version))
+            } else {
+                None
+            };
             let output = crate::install_frozen_lockfile::run_hoisted_linker::<Reporter>(
                 crate::install_frozen_lockfile::HoistedLinkerInputs {
                     config,
@@ -1345,11 +1363,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                     dependency_groups: &dependency_groups,
                     walker_lockfile_dir: lockfile_dir,
                     symlink_workspace_root: symlink_root,
-                    // No installability host was probed on the fresh
-                    // path (the resolver's `PackageVersion` carries no
-                    // engine/cpu/os/libc constraints), so the walker
-                    // falls back to its default host triple.
-                    host_node: None,
+                    host_node: host_node.as_ref(),
                     supported_architectures,
                     cas_paths_by_pkg_id,
                     logged_methods,

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1700,6 +1700,8 @@ fn build_fresh_lockfile(
         ignored_optional_dependencies: config.ignored_optional_dependencies.clone(),
         package_extensions_checksum: compute_package_extensions_checksum(config),
         catalogs,
+        registry: &config.registry,
+        lockfile_include_tarball_url: config.lockfile_include_tarball_url,
     })
 }
 

--- a/pacquet/crates/registry/src/package/tests.rs
+++ b/pacquet/crates/registry/src/package/tests.rs
@@ -21,6 +21,7 @@ pub fn package_version_should_include_peers() {
         peer_dependencies: Some(peer_dependencies),
         optional_dependencies: None,
         peer_dependencies_meta: None,
+        other: Default::default(),
         npm_user: None,
         deprecated: None,
     };
@@ -44,6 +45,7 @@ pub fn serialized_according_to_params() {
         peer_dependencies: None,
         optional_dependencies: None,
         peer_dependencies_meta: None,
+        other: Default::default(),
         npm_user: None,
         deprecated: None,
     };
@@ -101,6 +103,7 @@ fn package_with_versions(name: &str, versions: &[&str], latest: &str) -> Package
                     peer_dependencies: None,
                     optional_dependencies: None,
                     peer_dependencies_meta: None,
+                    other: Default::default(),
                     npm_user: None,
                     deprecated: None,
                 },

--- a/pacquet/crates/registry/src/package_version.rs
+++ b/pacquet/crates/registry/src/package_version.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{NetworkError, PackageTag, RegistryError, package_distribution::PackageDistribution};
 
-#[derive(Debug, Clone, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PackageVersion {
     pub name: String,
@@ -84,7 +84,18 @@ pub struct PackageVersion {
         skip_serializing_if = "Option::is_none"
     )]
     pub deprecated: Option<String>,
+
+    /// Every other field of the registry's per-version manifest, captured
+    /// verbatim. pnpm's resolver returns the whole picked manifest, and the
+    /// lockfile writer reads `engines` / `cpu` / `os` / `libc` / `bin` /
+    /// `bundleDependencies` off it to populate the `packages:` entry. Keeping a
+    /// flatten catch-all (rather than a typed field per key) mirrors that
+    /// passthrough and tolerates the historical shape variance npm serves.
+    #[serde(flatten)]
+    pub other: HashMap<String, serde_json::Value>,
 }
+
+impl Eq for PackageVersion {}
 
 /// Deserialize a `Record<string, string>`-shaped dependency map while
 /// tolerating historical npm registry entries whose values are objects

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -994,6 +994,7 @@ fn project_trust_package_version(version: &PackageVersion) -> PackageVersion {
         peer_dependencies_meta: None,
         npm_user,
         deprecated: None,
+        other: HashMap::new(),
     }
 }
 

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
@@ -29,6 +29,7 @@ fn make_pkg_version(name: &str, version: &str, deprecated: Option<&str>) -> Pack
         peer_dependencies: None,
         optional_dependencies: None,
         peer_dependencies_meta: None,
+        other: Default::default(),
         npm_user: None,
         deprecated: deprecated.map(str::to_string),
     }


### PR DESCRIPTION
## What

Makes pacquet generate and write `pnpm-lock.yaml` **byte-for-byte identical** to the pnpm CLI.

pnpm's lockfile bytes are produced by [`@zkochan/js-yaml`](https://github.com/zkochan/js-yaml), a fork of js-yaml with lockfile-specific rendering rules that no general-purpose Rust YAML serializer reproduces. pacquet was using `serde-saphyr`, which diverged on quoting, blank lines, flow-vs-block style, and key ordering — plus several data-model gaps. This ports the relevant dumper behavior directly.

## Changes (all in `pacquet/crates/`)

- **New `lockfile/src/yaml_emit.rs`** — a faithful port of the `@zkochan/js-yaml` lockfile dumper: blank lines between top-level / `packages:` / `importers:` / `snapshots:` entries; single-line flow for `cpu`/`engines`/`os`/`libc`/`resolution` (block for `variations`/`binary`); single-quote scalar style (`'9.0'`, `'>=10'`, `'@scope/x@1.0.0'`); `lineWidth: -1`; and the scalar-style chooser with the implicit-type resolvers (null/bool/int/float/timestamp/merge) that decide when a plain scalar must be quoted. `serialize_yaml::to_string` now delegates here.
- **Port of pnpm's `sortLockfileKeys`** (deep priority + lexical key sort) into the emitter, so byte order is independent of pacquet's struct field order. Notably `react-dom@x` sorts **before** `react@x` (because `-` < `@`), matching pnpm's `lexCompare`.
- **Registry resolution → `{integrity}` only** — dropping the reconstructible tarball URL. Port of `toLockfileResolution` + `get-npm-tarball-url`, applied at lockfile-build time; the URL is kept for `file:`, git-hosted, and non-standard tarballs.
- **No importer `specifiers:` block** — v9 inlines `{specifier, version}`.
- **engines/cpu/os/libc/hasBin populated** — the registry `PackageVersion` struct now keeps the picked manifest's extra fields via a `#[serde(flatten)]` catch-all instead of dropping them.
- **Importer block field order** is `dependencies` → `devDependencies` → `optionalDependencies`.
- **Fresh hoisted-install node detection** — populating `engines` activates the hoisted dep-graph walker's installability check, so the fresh-install hoisted path now detects the host node version (it previously passed `host_node: None`, which would throw `ERR_PNPM_INVALID_NODE_VERSION` once `engines.node` was present).

## Verification

Diffed `pacquet install --lockfile-only` against real `pnpm install --lockfile-only` on several projects (registry deps, scoped names like `@types/node`, dev/optional groups, platform packages like `fsevents`, peer deps like `react-dom`) — `0` byte differences. Added emitter unit tests and a byte-for-byte round-trip test that re-serializes a pnpm-authored v9 fixture and asserts the exact bytes. Full `cargo nextest run --workspace` is green (3008 passed); also rebaselined a few CLI snapshots/assertions to the now-correct pnpm format (the hoisted `node_modules/.pnpm/node_modules/.bin` dir, flow `resolution:` parsing, single-quoted `specifier: 'catalog:'`).

## Out of scope

One remaining content difference is **not** a format/field issue: pacquet's peer resolver auto-resolves *optional* peers (e.g. `debug`'s `supports-color`), adding `(supports-color@7.2.0)` peer suffixes that pnpm omits. That's a dependency-graph/peer-resolution behavior, pre-existing and untouched here — a separate fix in the resolver.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent Node.js version detection during fresh-lockfile installs when needed.

* **Improvements**
  * Lockfile serialization now produces byte-for-byte pnpm v9-compatible YAML (including quoting/formatting).
  * Lockfile generation can omit or preserve tarball URLs and better preserves integrity metadata.
  * Registry responses now retain unknown/extra fields for forward-compatible round-tripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->