### PR TITLE
fix(install): persist revoked builds to .modules.yaml (#12221)

### DIFF
--- a/.changeset/fix-approve-builds-stash-revocation.md
+++ b/.changeset/fix-approve-builds-stash-revocation.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Fixed `pnpm approve-builds` reporting "no packages awaiting approval" when a build-script dependency whose approval was revoked (e.g. after `git stash` drops the `allowBuilds` from `pnpm-workspace.yaml`) is re-added. The revoked packages are now correctly recorded in `.modules.yaml` so `approve-builds` can find them. [#12221](https://github.com/pnpm/pnpm/issues/12221)

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -38,7 +38,7 @@ import {
   type WantedDependency,
 } from '@pnpm/installing.deps-resolver'
 import { extendProjectsWithTargetDirs, headlessInstall, type InstallationResultStats } from '@pnpm/installing.deps-restorer'
-import { writeModulesManifest } from '@pnpm/installing.modules-yaml'
+import { readModulesManifest, type StrictModules, writeModulesManifest } from '@pnpm/installing.modules-yaml'
 import {
   type CatalogSnapshots,
   cleanGitBranchLockfiles,
@@ -493,10 +493,12 @@ export async function mutateModules (
     await cleanGitBranchLockfiles(ctx.lockfileDir)
   }
 
-  let ignoredBuilds = result.ignoredBuilds
+  const ignoredBuildsFromInstall = result.ignoredBuilds
+  let ignoredBuilds = ignoredBuildsFromInstall
   if (!opts.ignoreScripts && ignoredBuilds?.size) {
     ignoredBuilds = await runUnignoredDependencyBuilds(opts, ignoredBuilds, ctx.wantedLockfile, allowBuild)
   }
+  let revokedBuilds = false
   // Detect packages whose build approval was revoked between the previous
   // and current install. A package is considered revoked when it was
   // previously allowed (true) but is now undecided (undefined). Packages
@@ -519,8 +521,26 @@ export async function mutateModules (
         if (allowBuild?.(depPath) === undefined) {
           ignoredBuilds ??= new Set()
           ignoredBuilds.add(depPath)
+          revokedBuilds = true
         }
       }
+    }
+  }
+  if (revokedBuilds && !opts.lockfileOnly && opts.enableModulesDir) {
+    // The install path already wrote .modules.yaml with the current
+    // install's state, but it captured ignoredBuilds before the revocation
+    // scan above added to it. Re-read the manifest from disk so we only
+    // update ignoredBuilds and don't clobber fields (hoistedDependencies,
+    // pendingBuilds, etc.) the install just wrote. The current computed
+    // set is authoritative — runUnignoredDependencyBuilds may have removed
+    // entries (for packages it successfully rebuilt) that the on-disk
+    // manifest still records, and those must not be re-introduced.
+    const writtenManifest = await readModulesManifest(ctx.rootModulesDir)
+    if (writtenManifest) {
+      // writeModulesManifest converts ignoredBuilds to an array before
+      // serializing, so a Set is fine here.
+      writtenManifest.ignoredBuilds = ignoredBuilds
+      await writeModulesManifest(ctx.rootModulesDir, writtenManifest as StrictModules)
     }
   }
   ignoredScriptsLogger.debug({

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -493,8 +493,7 @@ export async function mutateModules (
     await cleanGitBranchLockfiles(ctx.lockfileDir)
   }
 
-  const ignoredBuildsFromInstall = result.ignoredBuilds
-  let ignoredBuilds = ignoredBuildsFromInstall
+  let ignoredBuilds = result.ignoredBuilds
   if (!opts.ignoreScripts && ignoredBuilds?.size) {
     ignoredBuilds = await runUnignoredDependencyBuilds(opts, ignoredBuilds, ctx.wantedLockfile, allowBuild)
   }

--- a/pnpm/test/install/lifecycleScripts.ts
+++ b/pnpm/test/install/lifecycleScripts.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
+import { parse } from '@pnpm/deps.path'
 import { prepare } from '@pnpm/prepare'
 import type { PackageManifest, ProjectManifest } from '@pnpm/types'
 import { readWorkspaceManifest } from '@pnpm/workspace.workspace-manifest-reader'
@@ -406,4 +407,39 @@ test('--allow-build flag should error when conflicting with allowBuilds: false',
 
   expect(result.status).toBe(1)
   expect(result.stdout.toString()).toContain('The following dependencies are ignored by the root project, but are allowed to be built by the current command: @pnpm.e2e/install-script-example')
+})
+
+test('approve-builds works after stashing and re-adding a dependency (#12221)', async () => {
+  const project = prepare({})
+
+  const pkgName = '@pnpm.e2e/pre-and-postinstall-scripts-example'
+
+  const firstAdd = execPnpmSync(['add', `${pkgName}@1.0.0`])
+  expect(firstAdd.status).toBe(1)
+  expect(firstAdd.stdout.toString()).toContain('Ignored build scripts:')
+
+  const firstApprove = execPnpmSync(['approve-builds', '--all'])
+  expect(firstApprove.status).toBe(0)
+
+  const wsManifest = await readWorkspaceManifest(process.cwd())
+  expect((wsManifest!.allowBuilds as Record<string, unknown>)[pkgName]).toBe(true)
+
+  fs.rmSync('package.json', { force: true })
+  fs.rmSync('pnpm-workspace.yaml', { force: true })
+  fs.rmSync('pnpm-lock.yaml', { force: true })
+
+  fs.writeFileSync('package.json', '{}')
+  writeYamlFileSync('pnpm-workspace.yaml', {})
+
+  const secondAdd = execPnpmSync(['add', `${pkgName}@1.0.0`])
+  expect(secondAdd.status).toBe(1)
+  expect(secondAdd.stdout.toString()).toContain('Ignored build scripts:')
+
+  const modulesManifest = project.readModulesManifest()
+  expect(modulesManifest?.ignoredBuilds).toBeDefined()
+  expect(Array.from(modulesManifest!.ignoredBuilds!).some((dp) => parse(dp).name === pkgName)).toBe(true)
+
+  const secondApprove = execPnpmSync(['approve-builds', '--all'])
+  expect(secondApprove.status).toBe(0)
+  expect(secondApprove.stdout.toString()).not.toContain('No packages awaiting approval')
 })

--- a/pnpm/test/install/lifecycleScripts.ts
+++ b/pnpm/test/install/lifecycleScripts.ts
@@ -422,7 +422,7 @@ test('approve-builds works after stashing and re-adding a dependency (#12221)', 
   expect(firstApprove.status).toBe(0)
 
   const wsManifest = await readWorkspaceManifest(process.cwd())
-  expect((wsManifest!.allowBuilds as Record<string, unknown>)[pkgName]).toBe(true)
+  expect(wsManifest!.allowBuilds?.[pkgName]).toBe(true)
 
   fs.rmSync('package.json', { force: true })
   fs.rmSync('pnpm-workspace.yaml', { force: true })


### PR DESCRIPTION
## Summary

Fix `pnpm approve-builds` reporting "no packages awaiting approval" when a build-script dependency whose approval was revoked (e.g. after `git stash` drops `allowBuilds` from `pnpm-workspace.yaml`) is re-added.

## Root cause

The revocation detection in `mutateModules` populates `ignoredBuilds` in memory, but the install path's `writeModulesManifest` had already run, so `.modules.yaml` never recorded the revoked packages. `pnpm approve-builds` reads `.modules.yaml` to find pending approvals, finds nothing, and reports "no packages awaiting approval".

## Fix

After the revocation scan, re-read the manifest from disk and write back the updated `ignoredBuilds`. This only touches the `ignoredBuilds` field so the install's other state (`hoistedDependencies`, `pendingBuilds`, etc.) is preserved.

## Test

Added a regression test in `pnpm/test/install/lifecycleScripts.ts` that simulates the stash scenario: install a build-script package, approve it, remove the config files while keeping `node_modules`, re-add the package, then verify `approve-builds` still works. The test fails without the fix and passes with it.

Fixes #12221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `approve-builds` to correctly handle revoked build-script approvals when a dependency is stashed/removed and later re-added, so it no longer incorrectly reports “no packages awaiting approval.”
  * Improved install post-processing to properly reconcile `ignoredBuilds` and persist the corrected ignored/revoked state in `.modules.yaml`.

* **Tests**
  * Added an end-to-end test covering deleting and recreating workspace/lock files, then re-running `approve-builds --all` to confirm approvals are reapplied.

* **Chores**
  * Added a changeset documenting the patch fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->