### PR TITLE
perf: run lockfile verification concurrently with frozen install

### DIFF
--- a/.changeset/parallel-lockfile-verification.md
+++ b/.changeset/parallel-lockfile-verification.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"@pnpm/installing.deps-restorer": patch
+"pnpm": patch
+---
+
+Sped up `pnpm install` with a frozen lockfile by running lockfile verification (the policy revalidation gate added for `minimumReleaseAge`/`trustPolicy` and the tarball-URL anti-tamper check) concurrently with fetching and linking instead of blocking the whole install on it. Dependency lifecycle scripts are still held back until verification succeeds, so no script runs on an unverified lockfile: if verification fails the install aborts before any dependency build, and if linking finishes first the install waits for the verification verdict before completing.

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -359,9 +359,17 @@ export async function mutateModules (
   // attaching their own verifiers). The threat model is a lockfile that
   // someone else resolved — committed to the repo, restored from a CI
   // cache, etc. — bypassing the local resolver's policy filters; the local
-  // resolver's own filters already cover fresh resolution. We run this
-  // exactly once, right after the lockfile is loaded from disk, before any
-  // path branches.
+  // resolver's own filters already cover fresh resolution.
+  //
+  // The verification is kicked off here, right after the lockfile is loaded,
+  // but not awaited inline — it would otherwise block every later install
+  // stage on per-entry registry round trips. Its synchronous prologue (cache
+  // lookup, lockfile hashing, candidate collection) runs now against the
+  // pristine lockfile, so the async fan-out reads a stable snapshot even
+  // while the install mutates `ctx.wantedLockfile` concurrently. The verdict
+  // is reconciled with the install in `settleInstall`: a failure aborts the
+  // install even mid-flight, and an install that finishes first is held back
+  // until the verdict arrives.
   //
   // Skipped when we already know pacquet will run the install: pacquet's
   // frozen-install path applies the same resolver-policy gate (port of
@@ -384,6 +392,7 @@ export async function mutateModules (
     !ctx.lockfileHadConflicts &&
     ctx.existsNonEmptyWantedLockfile &&
     (opts.frozenLockfile === true || opts.frozenLockfileIfExists === true)
+  let verifyLockfilePromise: Promise<void> | undefined
   if (!willDelegateToPacquet && !opts.trustLockfile) {
     const cacheActive = opts.cacheDir != null && opts.resolutionVerifiers.length > 0
     const wantedLockfilePath = cacheActive
@@ -392,20 +401,22 @@ export async function mutateModules (
         mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
       }))
       : undefined
-    try {
-      await verifyLockfileResolutions(ctx.wantedLockfile, opts.resolutionVerifiers, {
-        cacheDir: opts.cacheDir,
-        lockfilePath: wantedLockfilePath,
-      })
-    } catch (err) {
-      // verifyLockfileResolutions is the one throw site in this function
-      // that's part of normal user-facing operation (a rejected lockfile);
-      // other throws here are unexpected. Detach the reporter listener so
-      // long-lived processes don't leak it on every rejected install.
-      detachReporter()
-      throw err
-    }
+    verifyLockfilePromise = verifyLockfileResolutions(ctx.wantedLockfile, opts.resolutionVerifiers, {
+      cacheDir: opts.cacheDir,
+      lockfilePath: wantedLockfilePath,
+    })
+    // Keep the rejection from going unhandled in the window before
+    // `settleInstall` awaits the verdict — a preResolution hook or the
+    // install kickoff below could throw and bail out before we get there.
+    verifyLockfilePromise.catch(() => {})
   }
+
+  // Gate passed down to the build phase: fetching and linking overlap with
+  // verification, but no dependency lifecycle script may run until the verdict
+  // is in. Awaiting the promise here throws if verification failed, aborting
+  // before any script executes. `settleInstall` is the catch-all that still
+  // reconciles the verdict on paths that never reach the build phase.
+  const verifyLockfile = verifyLockfilePromise && (() => verifyLockfilePromise)
 
   if (opts.hooks.preResolution) {
     for (const preResolution of opts.hooks.preResolution) {
@@ -451,7 +462,7 @@ export async function mutateModules (
     }
   }
 
-  const result = await _install()
+  const result = await settleInstall(_install(), verifyLockfilePromise)
 
   // @ts-expect-error
   if (global['verifiedFileIntegrity'] > 1000) {
@@ -515,6 +526,27 @@ export async function mutateModules (
     readonly depsRequiringBuild?: DepPath[]
     readonly ignoredBuilds: IgnoredBuilds | undefined
     readonly resolutionPolicyViolations?: ResolutionPolicyViolation[]
+  }
+
+  // Reconcile the install with the lockfile verification that runs alongside
+  // it. A verification rejection aborts as soon as it happens, even while the
+  // install is still in flight; otherwise the install's result (or error) is
+  // surfaced only after the verdict confirms the lockfile. detachReporter
+  // mirrors the success path's cleanup so a long-lived process doesn't leak
+  // the stream listener on a rejected install.
+  async function settleInstall (
+    install: Promise<InnerInstallResult>,
+    verification: Promise<void> | undefined
+  ): Promise<InnerInstallResult> {
+    if (verification == null) return install
+    try {
+      await Promise.race([install, verification])
+      await verification
+      return await install
+    } catch (err) {
+      detachReporter()
+      throw err
+    }
   }
 
   async function _install (): Promise<InnerInstallResult> {
@@ -853,6 +885,7 @@ export async function mutateModules (
       scriptsOpts,
       updateLockfileMinorVersion: true,
       patchedDependencies: patchGroups,
+      verifyLockfile,
     })
 
     return {
@@ -1042,6 +1075,7 @@ Note that in CI environments, this setting is enabled by default.`,
         pruneVirtualStore,
         wantedLockfile: maybeOpts.ignorePackageManifest ? undefined : ctx.wantedLockfile,
         useLockfile: opts.useLockfile && ctx.wantedLockfileIsModified,
+        verifyLockfile,
       })
       if (
         opts.useLockfile && opts.saveLockfile && opts.mergeGitBranchLockfiles ||
@@ -1324,6 +1358,7 @@ type InstallFunction = (
     scriptsOpts: RunLifecycleHooksConcurrentlyOptions
     currentLockfileIsUpToDate: boolean
     hoistWorkspacePackages?: boolean
+    verifyLockfile?: () => Promise<void>
   }
 ) => Promise<InstallFunctionResult>
 
@@ -1627,6 +1662,8 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
             ...makeNodeRequireOption(path.join(opts.lockfileDir, '.pnp.cjs')),
           }
         }
+        // Dependency lifecycle scripts must not run on an unverified lockfile.
+        await opts.verifyLockfile?.()
         ignoredBuilds = (await buildModules(dependenciesGraph, rootNodes, {
           allowBuild: opts.allowBuild,
           childConcurrency: opts.childConcurrency,

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -1825,6 +1825,10 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
         }
       }
       const projectsToBeBuilt = projectsWithTargetDirs.filter(({ mutation }) => mutation === 'install') as ProjectToBeInstalled[]
+      // The projects' own lifecycle scripts import dependency code linked
+      // from the lockfile, so they are held to the same gate as dependency
+      // builds — also when no new dep paths made the buildModules branch run.
+      await opts.verifyLockfile?.()
       await runLifecycleHooksConcurrently(['preinstall', 'install', 'postinstall', 'preprepare', 'prepare', 'postprepare'],
         projectsToBeBuilt,
         opts.childConcurrency,

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -529,18 +529,24 @@ export async function mutateModules (
   }
 
   // Reconcile the install with the lockfile verification that runs alongside
-  // it. A verification rejection aborts as soon as it happens, even while the
-  // install is still in flight; otherwise the install's result (or error) is
-  // surfaced only after the verdict confirms the lockfile. detachReporter
-  // mirrors the success path's cleanup so a long-lived process doesn't leak
-  // the stream listener on a rejected install.
+  // it. The verification verdict is awaited first so it takes precedence and
+  // aborts as soon as it fails, even while the install is still in flight —
+  // matching the original sequencing where verification gated the install, so
+  // a rejected lockfile surfaces its own error rather than whatever the
+  // concurrent install happened to throw. Only once verification passes is the
+  // install's result (or error) surfaced. detachReporter mirrors the success
+  // path's cleanup so a long-lived process doesn't leak the stream listener on
+  // a rejected install.
   async function settleInstall (
     install: Promise<InnerInstallResult>,
     verification: Promise<void> | undefined
   ): Promise<InnerInstallResult> {
     if (verification == null) return install
+    // Handle the install's eventual rejection up front so a fail-fast
+    // verification throw below doesn't leave the still-running install
+    // unhandled.
+    install.catch(() => {})
     try {
-      await Promise.race([install, verification])
       await verification
       return await install
     } catch (err) {

--- a/installing/deps-installer/test/install/trustLockfile.ts
+++ b/installing/deps-installer/test/install/trustLockfile.ts
@@ -1,7 +1,10 @@
+import fs from 'node:fs'
+
 import { expect, test } from '@jest/globals'
-import { install } from '@pnpm/installing.deps-installer'
+import { addDependenciesToPackage, install } from '@pnpm/installing.deps-installer'
 import { prepareEmpty } from '@pnpm/prepare'
 import type { ResolutionVerifier } from '@pnpm/resolving.resolver-base'
+import { rimrafSync } from '@zkochan/rimraf'
 
 import { testDefaults } from '../utils/index.js'
 
@@ -52,4 +55,28 @@ test('install skips lockfile verification when trustLockfile is true even if a v
       })
     )
   ).resolves.toBeDefined()
+})
+
+test('dependency lifecycle scripts do not run when lockfile verification fails', async () => {
+  prepareEmpty()
+
+  const pkgName = '@pnpm.e2e/pre-and-postinstall-scripts-example'
+  const { updatedManifest: manifest } = await addDependenciesToPackage({},
+    [`${pkgName}@1.0.0`],
+    testDefaults({ fastUnpack: false, allowBuilds: { [pkgName]: true } })
+  )
+  rimrafSync('node_modules')
+
+  await expect(
+    install(manifest, testDefaults({
+      fastUnpack: false,
+      frozenLockfile: true,
+      allowBuilds: { [pkgName]: true },
+      resolutionVerifiers: [rejectingVerifier],
+    }))
+  ).rejects.toMatchObject({ code: 'ERR_PNPM_TEST_REJECT' })
+
+  // The postinstall script is what writes this file; its absence proves the
+  // build phase was gated behind the (failed) verification.
+  expect(fs.existsSync(`node_modules/${pkgName}/generated-by-postinstall.js`)).toBeFalsy()
 })

--- a/installing/deps-installer/test/install/trustLockfile.ts
+++ b/installing/deps-installer/test/install/trustLockfile.ts
@@ -80,3 +80,41 @@ test('dependency lifecycle scripts do not run when lockfile verification fails',
   // build phase was gated behind the (failed) verification.
   expect(fs.existsSync(`node_modules/${pkgName}/generated-by-postinstall.js`)).toBeFalsy()
 })
+
+test('project lifecycle scripts do not run when lockfile verification fails even without a modules dir', async () => {
+  prepareEmpty()
+
+  // Rejects only after the install has had ample time to reach the project
+  // lifecycle hooks: an instantly-rejecting verifier would abort the install
+  // before the hooks are even attempted, hiding a missing gate.
+  const slowRejectingVerifier: ResolutionVerifier = {
+    ...rejectingVerifier,
+    verify: async (resolution, pkg) => {
+      await new Promise((resolve) => setTimeout(resolve, 4000))
+      return rejectingVerifier.verify(resolution, pkg)
+    },
+  }
+
+  const manifest = {
+    dependencies: { 'is-positive': '1.0.0' },
+    scripts: {
+      postinstall: 'node -e "require(\'fs\').writeFileSync(\'created-by-project-postinstall\', \'\')"',
+    },
+  }
+  await install(manifest, testDefaults())
+  rimrafSync('node_modules')
+  rimrafSync('created-by-project-postinstall')
+
+  // `enableModulesDir: false` skips the dependency build phase entirely, so
+  // the project's own hooks are the only script-execution path left — they
+  // must still wait for the verification verdict.
+  await expect(
+    install(manifest, testDefaults({
+      frozenLockfile: true,
+      enableModulesDir: false,
+      resolutionVerifiers: [slowRejectingVerifier],
+    }))
+  ).rejects.toMatchObject({ code: 'ERR_PNPM_TEST_REJECT' })
+
+  expect(fs.existsSync('created-by-project-postinstall')).toBeFalsy()
+})

--- a/installing/deps-restorer/src/index.ts
+++ b/installing/deps-restorer/src/index.ts
@@ -185,6 +185,13 @@ export interface HeadlessOptions {
   supportedArchitectures?: SupportedArchitectures
   hoistWorkspacePackages?: boolean
   modulesFile?: Modules | null
+  /**
+   * Awaited right before dependency lifecycle scripts run. Lets the caller
+   * overlap lockfile verification with fetching and linking while still
+   * guaranteeing no dependency script executes on an unverified lockfile:
+   * the returned promise rejects when verification failed.
+   */
+  verifyLockfile?: () => Promise<void>
 }
 
 export interface InstallationResultStats {
@@ -573,6 +580,8 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
         ...makeNodeRequireOption(path.join(opts.lockfileDir, '.pnp.cjs')),
       }
     }
+    // Dependency lifecycle scripts must not run on an unverified lockfile.
+    await opts.verifyLockfile?.()
     ignoredBuilds = (await buildModules(graph, Array.from(directNodes), {
       allowBuild,
       childConcurrency: opts.childConcurrency,

--- a/installing/deps-restorer/src/index.ts
+++ b/installing/deps-restorer/src/index.ts
@@ -715,6 +715,10 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
   summaryLogger.debug({ prefix: lockfileDir })
 
   if (!opts.ignoreScripts && !opts.ignorePackageManifest && !skipPostImportLinking) {
+    // The projects' own lifecycle scripts import dependency code linked from
+    // the lockfile, so they are held to the same gate as dependency builds —
+    // also on the `enableModulesDir: false` path that skips buildModules.
+    await opts.verifyLockfile?.()
     await runLifecycleHooksConcurrently(
       ['preinstall', 'install', 'postinstall', 'preprepare', 'prepare', 'postprepare'],
       projectsToBeBuilt,

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -522,6 +522,17 @@ async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
         && !link.lockfile_only
         && let Some(lockfile) = state.lockfile.as_ref()
     {
+        let prefetcher = TarballPrefetcher::new(
+            state.config,
+            &state.http_client,
+            &state.tarball_mem_cache,
+            None,
+            &lockfile_dir.to_string_lossy(),
+        )
+        .await;
+        prefetcher.prefetch_lockfile(lockfile, state.config);
+        tokio::task::yield_now().await;
+
         let lockfile_verification_override: Option<LockfileVerificationOverride<'_>> =
             if link.trust_lockfile {
                 None
@@ -567,15 +578,17 @@ async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
             resolution_observer: None,
         };
 
-        match lockfile_verification_override {
+        let result = match lockfile_verification_override {
             Some(lockfile_verification_override) => {
                 install
                     .run_with_lockfile_verification::<Reporter>(lockfile_verification_override)
                     .await
             }
             None => install.run::<Reporter>().await,
-        }
-        .wrap_err("restoring dependencies from the local lockfile via pnpr verification")?;
+        };
+        result.wrap_err("restoring dependencies from the local lockfile via pnpr verification")?;
+
+        prefetcher.shutdown().await;
 
         return Ok(());
     }

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -530,7 +530,7 @@ async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
             &lockfile_dir.to_string_lossy(),
         )
         .await;
-        prefetcher.prefetch_lockfile(lockfile, state.config);
+        prefetcher.prefetch_lockfile(lockfile, state.config).await;
         tokio::task::yield_now().await;
 
         let lockfile_verification_override: Option<LockfileVerificationOverride<'_>> =
@@ -586,6 +586,11 @@ async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
             }
             None => install.run::<Reporter>().await,
         };
+        // On failure the prefetcher is dropped, not shut down: shutdown
+        // waits for every in-flight prefetch download (each task holds a
+        // store-index writer handle), which would hold the fail-fast
+        // abort hostage to the remaining transfers. The index rows are
+        // best-effort — a dropped row only costs a later re-download.
         result.wrap_err("restoring dependencies from the local lockfile via pnpr verification")?;
 
         prefetcher.shutdown().await;

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -3,9 +3,12 @@ use clap::{Args, ValueEnum};
 use miette::Context;
 use pacquet_config::NodeLinker;
 use pacquet_lockfile::{Lockfile, LockfileResolution};
-use pacquet_package_manager::{Install, TarballPrefetcher, UpdateSeedPolicy};
+use pacquet_package_manager::{
+    Install, InstallFrozenLockfileError, LockfileVerificationOverride, TarballPrefetcher,
+    UpdateSeedPolicy,
+};
 use pacquet_package_manifest::DependencyGroup;
-use pacquet_pnpr_client::{PnprClient, PnprClientError, ResolveOptions};
+use pacquet_pnpr_client::{PnprClient, PnprClientError, ResolveOptions, VerifyLockfileOptions};
 use pacquet_reporter::Reporter;
 
 const BENCHMARK_PNPR_SERVER_REGISTRY_ENV: &str = "PACQUET_BENCHMARK_PNPR_SERVER_REGISTRY";
@@ -514,6 +517,68 @@ async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
     let client = PnprClient::new(pnpr_server);
     let lockfile_dir =
         state.manifest.path().parent().expect("manifest path always has a parent dir");
+
+    if link.frozen_lockfile
+        && !link.lockfile_only
+        && let Some(lockfile) = state.lockfile.as_ref()
+    {
+        let lockfile_verification_override: Option<LockfileVerificationOverride<'_>> =
+            if link.trust_lockfile {
+                None
+            } else {
+                let verify_opts = VerifyLockfileOptions::from_resolve_options(&opts)
+                    .expect("frozen pnpr verification requires the loaded lockfile");
+                let verify_client = PnprClient::new(pnpr_server);
+                Some(Box::pin(async move {
+                    match verify_client.verify_lockfile(verify_opts).await {
+                        Ok(()) => Ok(()),
+                        Err(PnprClientError::Verification(verify_err)) => {
+                            Err(InstallFrozenLockfileError::LockfileVerification(verify_err))
+                        }
+                        Err(err) => Err(InstallFrozenLockfileError::ExternalLockfileVerification(
+                            err.to_string(),
+                        )),
+                    }
+                }) as LockfileVerificationOverride<'_>)
+            };
+
+        let install = Install {
+            tarball_mem_cache: std::sync::Arc::clone(&state.tarball_mem_cache),
+            http_client: &state.http_client,
+            http_client_arc: std::sync::Arc::clone(&state.http_client),
+            config: state.config,
+            manifest: &state.manifest,
+            lockfile: Some(lockfile),
+            lockfile_path: link.lockfile_path,
+            dependency_groups: link.dependency_groups,
+            frozen_lockfile: true,
+            prefer_frozen_lockfile: None,
+            ignore_manifest_check: link.ignore_manifest_check,
+            skip_runtimes: link.skip_runtimes,
+            trust_lockfile: true,
+            update_checksums: false,
+            is_full_install: true,
+            resolved_packages: &state.resolved_packages,
+            supported_architectures: link.supported_architectures,
+            node_linker: link.node_linker,
+            lockfile_only: false,
+            update_seed_policy: UpdateSeedPolicy::KeepAll,
+            auth_override: None,
+            resolution_observer: None,
+        };
+
+        match lockfile_verification_override {
+            Some(lockfile_verification_override) => {
+                install
+                    .run_with_lockfile_verification::<Reporter>(lockfile_verification_override)
+                    .await
+            }
+            None => install.run::<Reporter>().await,
+        }
+        .wrap_err("restoring dependencies from the local lockfile via pnpr verification")?;
+
+        return Ok(());
+    }
 
     // Under `--lockfile-only` nothing is materialized, so skip the
     // prefetcher entirely and consume the stream with a no-op callback.

--- a/pacquet/crates/cli/tests/pnpr_install.rs
+++ b/pacquet/crates/cli/tests/pnpr_install.rs
@@ -16,6 +16,8 @@ use pacquet_testing_utils::{
 use std::{
     fs,
     net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream},
+    path::Path,
+    process::Command,
     thread,
     time::Duration,
 };
@@ -61,6 +63,10 @@ fn wait_until_ready(addr: SocketAddr) {
     panic!("pnpr server never became ready at {addr}");
 }
 
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+}
+
 #[test]
 fn install_via_pnpr_links_node_modules() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -85,6 +91,47 @@ fn install_via_pnpr_links_node_modules() {
     // The client store was populated by the frozen install fetching tarballs
     // directly from the registry after pnpr returned the lockfile.
     assert!(store_dir.join("v11/index.db").exists(), "client store index should exist");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn frozen_install_via_pnpr_verifies_the_local_lockfile_without_resolving() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let pnpr_url = start_pnpr();
+
+    let manifest_path = workspace.join("package.json");
+    let package_json = serde_json::json!({
+        "dependencies": { "@foo/no-deps": "1.0.0" },
+    });
+    fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+    pacquet.with_arg("install").with_arg("--pnpr-server").with_arg(&pnpr_url).assert().success();
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+
+    let mut verifier = mockito::Server::new();
+    let verify_mock = verifier
+        .mock("POST", "/v1/verify-lockfile")
+        .with_status(200)
+        .with_header("content-type", "application/x-ndjson")
+        .with_body("{\"type\":\"done\"}\n")
+        .expect(1)
+        .create();
+
+    pacquet_at(&workspace)
+        .with_arg("install")
+        .with_arg("--frozen-lockfile")
+        .with_arg("--pnpr-server")
+        .with_arg(verifier.url())
+        .assert()
+        .success();
+
+    verify_mock.assert();
+    let symlink_path = workspace.join("node_modules/@foo/no-deps");
+    assert!(is_symlink_or_junction(&symlink_path).unwrap(), "direct dep should be symlinked");
 
     drop((root, mock_instance));
 }

--- a/pacquet/crates/cli/tests/pnpr_install.rs
+++ b/pacquet/crates/cli/tests/pnpr_install.rs
@@ -96,10 +96,10 @@ fn install_via_pnpr_links_node_modules() {
 }
 
 #[test]
-fn frozen_install_via_pnpr_verifies_the_local_lockfile_without_resolving() {
+fn frozen_install_via_pnpr_verifies_the_local_lockfile_without_resolving_or_redownloading() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
-    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let AddMockedRegistry { npmrc_path, mock_instance, .. } = npmrc_info;
 
     let pnpr_url = start_pnpr();
 
@@ -121,6 +121,27 @@ fn frozen_install_via_pnpr_verifies_the_local_lockfile_without_resolving() {
         .expect(1)
         .create();
 
+    // The first install warmed the store, so the frozen restore must not
+    // fetch a single tarball: point the registry at a server that rejects
+    // every request. Registry resolutions derive their tarball URLs from
+    // the configured registry at install time, so the swap is transparent
+    // to the lockfile.
+    let mut silent_registry = mockito::Server::new();
+    let no_downloads = silent_registry.mock("GET", mockito::Matcher::Any).expect(0).create();
+    let npmrc = fs::read_to_string(&npmrc_path)
+        .expect("read .npmrc")
+        .lines()
+        .map(|line| {
+            if line.starts_with("registry=") {
+                format!("registry={}/", silent_registry.url())
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, npmrc).expect("rewrite .npmrc");
+
     pacquet_at(&workspace)
         .with_arg("install")
         .with_arg("--frozen-lockfile")
@@ -130,6 +151,7 @@ fn frozen_install_via_pnpr_verifies_the_local_lockfile_without_resolving() {
         .success();
 
     verify_mock.assert();
+    no_downloads.assert();
     let symlink_path = workspace.join("node_modules/@foo/no-deps");
     assert!(is_symlink_or_junction(&symlink_path).unwrap(), "direct dep should be symlinked");
 

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1109,7 +1109,11 @@ where
             if fresh_result.can_record_lockfile_verification
                 && let Some(lockfile) = fresh_result.wanted_lockfile.as_ref()
             {
-                let lockfile_path = workspace_root.join(Lockfile::FILE_NAME);
+                // Record under the same path the verification gates key
+                // their cache on, so the next install's stat shortcut hits.
+                let lockfile_path = derived_lockfile_path
+                    .clone()
+                    .unwrap_or_else(|| workspace_root.join(Lockfile::FILE_NAME));
                 record_lockfile_verified(
                     Some(&config.cache_dir),
                     &lockfile_path,

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -391,7 +391,7 @@ pub enum InstallError {
     ConfigConflictLockfileOnlyWithNoLockfile,
 }
 
-impl<DependencyGroupList> Install<'_, DependencyGroupList>
+impl<'a, DependencyGroupList> Install<'a, DependencyGroupList>
 where
     DependencyGroupList: IntoIterator<Item = DependencyGroup>,
 {

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1,8 +1,8 @@
 use crate::{
     BuildVerifiersError, HoistedDependencies, InstallFrozenLockfile, InstallFrozenLockfileError,
     InstallWithFreshLockfile, InstallWithFreshLockfileError, LockfileVerificationOverride,
-    OptimisticRepeatInstallCheck, ResolvedPackages, UpdateSeedPolicy,
-    build_resolution_verifiers, check_optimistic_repeat_install,
+    OptimisticRepeatInstallCheck, ResolvedPackages, UpdateSeedPolicy, build_resolution_verifiers,
+    check_optimistic_repeat_install,
     optimistic_repeat_install::Decision as OptimisticRepeatInstallDecision,
 };
 use derive_more::{Display, Error};

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -671,23 +671,6 @@ where
         let lockfile_synthesized_from_current = synthesized_lockfile.is_some();
         let lockfile = lockfile.or(synthesized_lockfile.as_ref());
 
-        // Lockfile-verification gate: re-apply `minimumReleaseAge` /
-        // `trustPolicy='no-downgrade'` to every entry in the loaded
-        // `pnpm-lock.yaml` before any resolver or fetcher runs.
-        // Mirrors upstream's wiring at
-        // <https://github.com/pnpm/pnpm/blob/2a9bd897bf/installing/deps-installer/src/install/index.ts#L355-L383>.
-        // `lockfile.is_none()` (writable-lockfile path) skips the
-        // gate entirely — fresh local resolution is already filtered
-        // by the resolver's per-version gate (`minimumReleaseAge` via
-        // `ResolveResult::policy_violation`, `trustPolicy='no-downgrade'`
-        // via the npm resolver's `fail_if_trust_downgraded_for_pick`).
-        // `trust_lockfile` (the OR of yaml's
-        // `trustLockfile` and the `--trust-lockfile` CLI flag,
-        // resolved in [`crate::cli_args::install::InstallArgs::run`])
-        // is the opt-out for environments where the install can
-        // treat the on-disk lockfile as already-trusted (see [#11860]).
-        //
-        // [#11860]: <https://github.com/pnpm/pnpm/issues/11860>
         // One per-install packument cache shared with both the
         // lockfile-verifier (below) and the resolver in
         // `install_with_fresh_lockfile` (further down). The
@@ -704,11 +687,17 @@ where
         // so the per-entry registry round trips overlap the download;
         // every other path (fresh resolve, the lockfile-only / up-to-date
         // short-circuits) verifies eagerly via [`verify_lockfile_eagerly`]
-        // before it proceeds. `trust_lockfile` (or no active resolution
-        // policy) leaves the list empty, making every gate a no-op — fresh
-        // local resolution is already filtered by the resolver's own
-        // per-version gate. The list is built whenever a policy could
-        // apply, independent of whether a lockfile is loaded, so the
+        // before it proceeds. `trust_lockfile` (the OR of yaml's
+        // `trustLockfile` and the `--trust-lockfile` CLI flag, resolved in
+        // [`crate::cli_args::install::InstallArgs::run`]; the opt-out for
+        // environments that treat the on-disk lockfile as already-trusted,
+        // see [#11860]) or no active resolution policy leaves the list
+        // empty, making every gate a no-op — fresh local resolution is
+        // already filtered by the resolver's own per-version gate
+        // (`minimumReleaseAge` via `ResolveResult::policy_violation`,
+        // `trustPolicy='no-downgrade'` via the npm resolver's
+        // `fail_if_trust_downgraded_for_pick`). The list is built whenever
+        // a policy could apply, independent of whether a lockfile is loaded, so the
         // fresh-resolve path can record the freshly written lockfile as
         // already-verified (see `record_lockfile_verified` below). Mirrors
         // pnpm's wiring at

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -34,6 +34,7 @@ use pacquet_reporter::{
     Stage, StageLog, SummaryLog,
 };
 use pacquet_resolving_npm_resolver::InMemoryPackageMetaCache;
+use pacquet_resolving_resolver_base::ResolutionVerifier;
 use pacquet_tarball::MemCache;
 use pacquet_workspace_state::{
     ProjectEntry, UpdateWorkspaceStateError, WorkspaceState, now_millis, update_workspace_state,
@@ -44,6 +45,34 @@ use std::{
     sync::{Arc, atomic::AtomicU8},
     time::SystemTime,
 };
+
+/// Run the lockfile verification fan-out to completion, blocking the
+/// caller on the verdict. Used by the install paths that have no fetch
+/// to overlap verification with (fresh resolve, the lockfile-only and
+/// up-to-date short-circuits); the frozen materialization path instead
+/// runs verification concurrently with the fetch inside
+/// [`InstallFrozenLockfile`]. A no-op when `verifiers` is empty.
+async fn verify_lockfile_eagerly<Reporter: pacquet_reporter::Reporter>(
+    lockfile: &Lockfile,
+    verifiers: &[Arc<dyn ResolutionVerifier>],
+    lockfile_path: Option<&Path>,
+    cache_dir: &Path,
+) -> Result<(), InstallError> {
+    if verifiers.is_empty() {
+        return Ok(());
+    }
+    verify_lockfile_resolutions::<Reporter>(
+        lockfile,
+        verifiers,
+        &VerifyLockfileResolutionsOptions {
+            concurrency: None,
+            lockfile_path,
+            cache_dir: Some(cache_dir),
+        },
+    )
+    .await
+    .map_err(InstallError::LockfileVerification)
+}
 
 /// This subroutine does everything `pacquet install` is supposed to do.
 #[must_use]
@@ -643,31 +672,44 @@ where
         // install short-circuit the verifier's own fetch chain, and
         // vice versa. Mirrors pnpm's `installing/client` wiring.
         let meta_cache = Arc::new(InMemoryPackageMetaCache::default());
-        let resolution_verifiers = build_resolution_verifiers(
-            config,
-            Arc::clone(&http_client_arc),
-            Some(Arc::clone(&meta_cache)
-                as Arc<dyn pacquet_resolving_npm_resolver::PackageMetaCache>),
-            auth_override.clone(),
-            None,
-        )
-        .map_err(InstallError::BuildVerifiers)?;
-
-        if let Some(loaded_lockfile) = lockfile.filter(|_| !trust_lockfile) {
-            let derived_lockfile_path = lockfile_path
-                .map_or_else(|| workspace_root.join(Lockfile::FILE_NAME), Path::to_path_buf);
-            verify_lockfile_resolutions::<Reporter>(
-                loaded_lockfile,
-                &resolution_verifiers,
-                &VerifyLockfileResolutionsOptions {
-                    concurrency: None,
-                    lockfile_path: Some(&derived_lockfile_path),
-                    cache_dir: Some(&config.cache_dir),
-                },
+        // Resolution verifiers re-apply `minimumReleaseAge` /
+        // `trustPolicy='no-downgrade'` (plus the tarball-URL anti-tamper
+        // check) to every entry in the loaded `pnpm-lock.yaml`. They are
+        // built here — cheap, no I/O — but the verification fan-out itself
+        // is dispatched per path below: on the frozen materialization path
+        // it runs concurrently with the fetch (see [`InstallFrozenLockfile`])
+        // so the per-entry registry round trips overlap the download;
+        // every other path (fresh resolve, the lockfile-only / up-to-date
+        // short-circuits) verifies eagerly via [`verify_lockfile_eagerly`]
+        // before it proceeds. `trust_lockfile` (or no active resolution
+        // policy) leaves the list empty, making every gate a no-op — fresh
+        // local resolution is already filtered by the resolver's own
+        // per-version gate. The list is built whenever a policy could
+        // apply, independent of whether a lockfile is loaded, so the
+        // fresh-resolve path can record the freshly written lockfile as
+        // already-verified (see `record_lockfile_verified` below). Mirrors
+        // pnpm's wiring at
+        // <https://github.com/pnpm/pnpm/blob/2a9bd897bf/installing/deps-installer/src/install/index.ts#L355-L383>
+        // and its concurrent verification + build gate.
+        //
+        // [#11860]: <https://github.com/pnpm/pnpm/issues/11860>
+        let resolution_verifiers = if trust_lockfile {
+            Vec::new()
+        } else {
+            build_resolution_verifiers(
+                config,
+                Arc::clone(&http_client_arc),
+                Some(Arc::clone(&meta_cache)
+                    as Arc<dyn pacquet_resolving_npm_resolver::PackageMetaCache>),
+                auth_override.clone(),
+                None,
             )
-            .await
-            .map_err(InstallError::LockfileVerification)?;
-        }
+            .map_err(InstallError::BuildVerifiers)?
+        };
+        let derived_lockfile_path = lockfile.map(|_| {
+            lockfile_path
+                .map_or_else(|| workspace_root.join(Lockfile::FILE_NAME), Path::to_path_buf)
+        });
 
         // `pnpm:context` carries the directories pnpm's reporter prints
         // in the install header. `currentLockfileExists` mirrors
@@ -803,6 +845,15 @@ where
             // Re-persist it so a brand-new project still lands a file, then
             // return without touching `node_modules`.
             let lockfile = lockfile.expect("frozen dispatch verified lockfile is present");
+            // This path materializes nothing, so there's no fetch to overlap;
+            // verify eagerly to keep the gate before the early return.
+            verify_lockfile_eagerly::<Reporter>(
+                lockfile,
+                &resolution_verifiers,
+                derived_lockfile_path.as_deref(),
+                &config.cache_dir,
+            )
+            .await?;
             if config.lockfile {
                 lockfile
                     .save_to_path(&workspace_root.join(Lockfile::FILE_NAME))
@@ -833,6 +884,15 @@ where
             && wanted_lockfile == current
             && is_modules_yaml_consistent(&config.modules_dir, config, node_linker, included)
         {
+            // Nothing to materialize means no fetch to overlap; verify
+            // eagerly before the up-to-date early return.
+            verify_lockfile_eagerly::<Reporter>(
+                wanted_lockfile,
+                &resolution_verifiers,
+                derived_lockfile_path.as_deref(),
+                &config.cache_dir,
+            )
+            .await?;
             Reporter::emit(&LogEvent::Pnpm(PnpmLog {
                 level: LogLevel::Info,
                 message: "Lockfile is up to date, resolution step is skipped".to_string(),
@@ -874,6 +934,8 @@ where
                 packages: packages.as_ref(),
                 snapshots: snapshots.as_ref(),
                 lockfile,
+                resolution_verifiers: &resolution_verifiers,
+                lockfile_path: derived_lockfile_path.as_deref(),
                 current_lockfile: current_lockfile.as_ref(),
                 current_snapshots: current_lockfile
                     .as_ref()
@@ -892,7 +954,16 @@ where
             }
             .run::<Reporter>()
             .await
-            .map_err(InstallError::FrozenLockfile)?;
+            // Surface a verification failure as the same top-level
+            // `LockfileVerification` variant the eager paths use, rather
+            // than nesting it under `FrozenLockfile` — the concurrent gate
+            // is the same gate, just run alongside the fetch.
+            .map_err(|error| match error {
+                InstallFrozenLockfileError::LockfileVerification(verify_error) => {
+                    InstallError::LockfileVerification(verify_error)
+                }
+                other => InstallError::FrozenLockfile(other),
+            })?;
 
             (
                 frozen_result.hoisted_dependencies,
@@ -901,6 +972,22 @@ where
                 None,
             )
         } else {
+            // Re-verify the existing lockfile before the fresh resolve,
+            // matching the pre-resolution gate: a committed lockfile that
+            // bypassed the policy locally is caught here even though the
+            // resolver re-resolves from it. No-op when there's no lockfile
+            // (state 4) or verification is disabled. The fresh path's own
+            // resolution is the slow part, so this stays a blocking gate.
+            if let Some(loaded_lockfile) = lockfile {
+                verify_lockfile_eagerly::<Reporter>(
+                    loaded_lockfile,
+                    &resolution_verifiers,
+                    derived_lockfile_path.as_deref(),
+                    &config.cache_dir,
+                )
+                .await?;
+            }
+
             // Flag combinations the fresh-lockfile path doesn't honor
             // yet are validated here, after the dispatch decision so an
             // auto-frozen install (state 2 of [`Install::run`]) doesn't

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1,8 +1,8 @@
 use crate::{
     BuildVerifiersError, HoistedDependencies, InstallFrozenLockfile, InstallFrozenLockfileError,
-    InstallWithFreshLockfile, InstallWithFreshLockfileError, OptimisticRepeatInstallCheck,
-    ResolvedPackages, UpdateSeedPolicy, build_resolution_verifiers,
-    check_optimistic_repeat_install,
+    InstallWithFreshLockfile, InstallWithFreshLockfileError, LockfileVerificationOverride,
+    OptimisticRepeatInstallCheck, ResolvedPackages, UpdateSeedPolicy,
+    build_resolution_verifiers, check_optimistic_repeat_install,
     optimistic_repeat_install::Decision as OptimisticRepeatInstallDecision,
 };
 use derive_more::{Display, Error};
@@ -72,6 +72,15 @@ async fn verify_lockfile_eagerly<Reporter: pacquet_reporter::Reporter>(
     )
     .await
     .map_err(InstallError::LockfileVerification)
+}
+
+fn map_frozen_lockfile_error(error: InstallFrozenLockfileError) -> InstallError {
+    match error {
+        InstallFrozenLockfileError::LockfileVerification(verify_error) => {
+            InstallError::LockfileVerification(verify_error)
+        }
+        other => InstallError::FrozenLockfile(other),
+    }
 }
 
 /// This subroutine does everything `pacquet install` is supposed to do.
@@ -388,6 +397,20 @@ where
 {
     /// Execute the subroutine.
     pub async fn run<Reporter: self::Reporter + 'static>(self) -> Result<(), InstallError> {
+        self.run_inner::<Reporter>(None).await
+    }
+
+    pub async fn run_with_lockfile_verification<Reporter: self::Reporter + 'static>(
+        self,
+        lockfile_verification_override: LockfileVerificationOverride<'a>,
+    ) -> Result<(), InstallError> {
+        self.run_inner::<Reporter>(Some(lockfile_verification_override)).await
+    }
+
+    async fn run_inner<Reporter: self::Reporter + 'static>(
+        self,
+        lockfile_verification_override: Option<LockfileVerificationOverride<'a>>,
+    ) -> Result<(), InstallError> {
         let Install {
             tarball_mem_cache,
             resolved_packages,
@@ -847,13 +870,17 @@ where
             let lockfile = lockfile.expect("frozen dispatch verified lockfile is present");
             // This path materializes nothing, so there's no fetch to overlap;
             // verify eagerly to keep the gate before the early return.
-            verify_lockfile_eagerly::<Reporter>(
-                lockfile,
-                &resolution_verifiers,
-                derived_lockfile_path.as_deref(),
-                &config.cache_dir,
-            )
-            .await?;
+            if let Some(lockfile_verification_override) = lockfile_verification_override {
+                lockfile_verification_override.await.map_err(map_frozen_lockfile_error)?;
+            } else {
+                verify_lockfile_eagerly::<Reporter>(
+                    lockfile,
+                    &resolution_verifiers,
+                    derived_lockfile_path.as_deref(),
+                    &config.cache_dir,
+                )
+                .await?;
+            }
             if config.lockfile {
                 lockfile
                     .save_to_path(&workspace_root.join(Lockfile::FILE_NAME))
@@ -886,13 +913,17 @@ where
         {
             // Nothing to materialize means no fetch to overlap; verify
             // eagerly before the up-to-date early return.
-            verify_lockfile_eagerly::<Reporter>(
-                wanted_lockfile,
-                &resolution_verifiers,
-                derived_lockfile_path.as_deref(),
-                &config.cache_dir,
-            )
-            .await?;
+            if let Some(lockfile_verification_override) = lockfile_verification_override {
+                lockfile_verification_override.await.map_err(map_frozen_lockfile_error)?;
+            } else {
+                verify_lockfile_eagerly::<Reporter>(
+                    wanted_lockfile,
+                    &resolution_verifiers,
+                    derived_lockfile_path.as_deref(),
+                    &config.cache_dir,
+                )
+                .await?;
+            }
             Reporter::emit(&LogEvent::Pnpm(PnpmLog {
                 level: LogLevel::Info,
                 message: "Lockfile is up to date, resolution step is skipped".to_string(),
@@ -935,6 +966,7 @@ where
                 snapshots: snapshots.as_ref(),
                 lockfile,
                 resolution_verifiers: &resolution_verifiers,
+                lockfile_verification_override,
                 lockfile_path: derived_lockfile_path.as_deref(),
                 current_lockfile: current_lockfile.as_ref(),
                 current_snapshots: current_lockfile
@@ -958,12 +990,7 @@ where
             // `LockfileVerification` variant the eager paths use, rather
             // than nesting it under `FrozenLockfile` — the concurrent gate
             // is the same gate, just run alongside the fetch.
-            .map_err(|error| match error {
-                InstallFrozenLockfileError::LockfileVerification(verify_error) => {
-                    InstallError::LockfileVerification(verify_error)
-                }
-                other => InstallError::FrozenLockfile(other),
-            })?;
+            .map_err(map_frozen_lockfile_error)?;
 
             (
                 frozen_result.hoisted_dependencies,
@@ -978,7 +1005,9 @@ where
             // resolver re-resolves from it. No-op when there's no lockfile
             // (state 4) or verification is disabled. The fresh path's own
             // resolution is the slow part, so this stays a blocking gate.
-            if let Some(loaded_lockfile) = lockfile {
+            if let Some(lockfile_verification_override) = lockfile_verification_override {
+                lockfile_verification_override.await.map_err(map_frozen_lockfile_error)?;
+            } else if let Some(loaded_lockfile) = lockfile {
                 verify_lockfile_eagerly::<Reporter>(
                     loaded_lockfile,
                     &resolution_verifiers,

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -18,6 +18,9 @@ use pacquet_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
 use pacquet_lockfile::{
     Lockfile, PackageKey, PackageMetadata, Prefix, ProjectSnapshot, SnapshotEntry,
 };
+use pacquet_lockfile_verification::{
+    VerifyError, VerifyLockfileResolutionsOptions, verify_lockfile_resolutions,
+};
 use pacquet_modules_yaml::{Host, read_modules_manifest};
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::DependencyGroup;
@@ -25,6 +28,7 @@ use pacquet_patching::{
     ExtendedPatchInfo, PatchKeyConflictError, ResolvePatchedDependenciesError, get_patch_info,
 };
 use pacquet_reporter::{IgnoredScriptsLog, LogEvent, LogLevel, Reporter, Stage, StageLog};
+use pacquet_resolving_resolver_base::ResolutionVerifier;
 use pacquet_store_dir::StoreIndexWriter;
 use pacquet_tarball::{MemCache, SharedReportedProgressKeys};
 use std::{
@@ -62,6 +66,18 @@ where
     /// direct deps plus the full `packages` / `snapshots` maps in
     /// one borrow). Isolated installs ignore the field.
     pub lockfile: &'a Lockfile,
+    /// Resolution verifiers to re-apply to every lockfile entry. Run
+    /// concurrently with the fetch phase ([`crate::CreateVirtualStore`])
+    /// and awaited before any dependency lifecycle script executes, so a
+    /// rejected lockfile aborts before [`crate::BuildModules`] runs. Empty
+    /// when verification is disabled (`trustLockfile`), in which case the
+    /// gate is a no-op. The non-blocking sequencing mirrors pnpm's
+    /// concurrent `verifyLockfileResolutions` + `verifyLockfile` build gate.
+    pub resolution_verifiers: &'a [Arc<dyn ResolutionVerifier>],
+    /// Absolute path of the lockfile being verified, for the on-disk
+    /// verification cache. `None` disables the cache (and is set when
+    /// there are no verifiers to run).
+    pub lockfile_path: Option<&'a Path>,
     /// The previous install's persisted current lockfile, threaded
     /// through to the hoisted walker for `prev_graph` (orphan
     /// diff). Mirrors upstream's
@@ -154,6 +170,9 @@ where
 /// Error type of [`InstallFrozenLockfile`].
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum InstallFrozenLockfileError {
+    #[diagnostic(transparent)]
+    LockfileVerification(#[error(source)] VerifyError),
+
     #[diagnostic(transparent)]
     CreateVirtualStore(#[error(source)] CreateVirtualStoreError),
 
@@ -275,6 +294,8 @@ where
             packages,
             snapshots,
             lockfile,
+            resolution_verifiers,
+            lockfile_path,
             current_lockfile,
             current_snapshots,
             current_packages,
@@ -592,35 +613,64 @@ where
         // leaves every warm package reported as `found_in_store`.
         let progress_reported = SharedReportedProgressKeys::default();
 
+        // Run lockfile verification concurrently with the fetch instead of
+        // blocking the install on it: the per-entry registry round trips
+        // overlap `CreateVirtualStore`'s downloads. `try_join!` fails fast,
+        // so a rejected lockfile aborts the fetch in flight, and a verdict
+        // is always reached before linking and the build phase below — no
+        // dependency lifecycle script runs on an unverified lockfile. A
+        // no-op when `resolution_verifiers` is empty (`trustLockfile`).
+        let verify_fut = async {
+            if resolution_verifiers.is_empty() {
+                return Ok(());
+            }
+            verify_lockfile_resolutions::<Reporter>(
+                lockfile,
+                resolution_verifiers,
+                &VerifyLockfileResolutionsOptions {
+                    concurrency: None,
+                    lockfile_path,
+                    cache_dir: Some(&config.cache_dir),
+                },
+            )
+            .await
+            .map_err(InstallFrozenLockfileError::LockfileVerification)
+        };
+        let create_virtual_store_fut = async {
+            CreateVirtualStore {
+                http_client,
+                config,
+                packages,
+                snapshots,
+                current_snapshots,
+                current_packages,
+                layout: &layout,
+                logged_methods,
+                requester,
+                store_index_writer: &store_index_writer,
+                allow_build_policy: &allow_build_policy,
+                skipped: &skipped,
+                workspace_root,
+                node_linker,
+                progress_reported: &progress_reported,
+                tarball_mem_cache,
+                #[cfg(test)]
+                link_concurrency_probe: None,
+            }
+            .run::<Reporter>()
+            .await
+            .map_err(InstallFrozenLockfileError::CreateVirtualStore)
+        };
         let phase_start = std::time::Instant::now();
-        let CreateVirtualStoreOutput {
-            package_manifests,
-            side_effects_maps_by_snapshot,
-            fetch_failed,
-            cas_paths_by_pkg_id,
-        } = CreateVirtualStore {
-            http_client,
-            config,
-            packages,
-            snapshots,
-            current_snapshots,
-            current_packages,
-            layout: &layout,
-            logged_methods,
-            requester,
-            store_index_writer: &store_index_writer,
-            allow_build_policy: &allow_build_policy,
-            skipped: &skipped,
-            workspace_root,
-            node_linker,
-            progress_reported: &progress_reported,
-            tarball_mem_cache,
-            #[cfg(test)]
-            link_concurrency_probe: None,
-        }
-        .run::<Reporter>()
-        .await
-        .map_err(InstallFrozenLockfileError::CreateVirtualStore)?;
+        let (
+            (),
+            CreateVirtualStoreOutput {
+                package_manifests,
+                side_effects_maps_by_snapshot,
+                fetch_failed,
+                cas_paths_by_pkg_id,
+            },
+        ) = tokio::try_join!(verify_fut, create_virtual_store_fut)?;
         tracing::info!(
             target: "pacquet::install::phase",
             phase = "create_virtual_store",

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -34,9 +34,14 @@ use pacquet_tarball::{MemCache, SharedReportedProgressKeys};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     ffi::OsStr,
+    future::Future,
     path::{Path, PathBuf},
+    pin::Pin,
     sync::{Arc, atomic::AtomicU8},
 };
+
+pub type LockfileVerificationOverride<'a> =
+    Pin<Box<dyn Future<Output = Result<(), InstallFrozenLockfileError>> + Send + 'a>>;
 
 /// This subroutine installs dependencies from a frozen lockfile.
 ///
@@ -74,6 +79,7 @@ where
     /// gate is a no-op. The non-blocking sequencing mirrors pnpm's
     /// concurrent `verifyLockfileResolutions` + `verifyLockfile` build gate.
     pub resolution_verifiers: &'a [Arc<dyn ResolutionVerifier>],
+    pub lockfile_verification_override: Option<LockfileVerificationOverride<'a>>,
     /// Absolute path of the lockfile being verified, for the on-disk
     /// verification cache. `None` disables the cache (and is set when
     /// there are no verifiers to run).
@@ -172,6 +178,10 @@ where
 pub enum InstallFrozenLockfileError {
     #[diagnostic(transparent)]
     LockfileVerification(#[error(source)] VerifyError),
+
+    #[display("external lockfile verification failed: {_0}")]
+    #[diagnostic(code(pacquet_package_manager::external_lockfile_verification))]
+    ExternalLockfileVerification(#[error(not(source))] String),
 
     #[diagnostic(transparent)]
     CreateVirtualStore(#[error(source)] CreateVirtualStoreError),
@@ -295,6 +305,7 @@ where
             snapshots,
             lockfile,
             resolution_verifiers,
+            lockfile_verification_override,
             lockfile_path,
             current_lockfile,
             current_snapshots,
@@ -621,6 +632,9 @@ where
         // dependency lifecycle script runs on an unverified lockfile. A
         // no-op when `resolution_verifiers` is empty (`trustLockfile`).
         let verify_fut = async {
+            if let Some(lockfile_verification_override) = lockfile_verification_override {
+                return lockfile_verification_override.await;
+            }
             if resolution_verifiers.is_empty() {
                 return Ok(());
             }

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -79,10 +79,13 @@ where
     /// gate is a no-op. The non-blocking sequencing mirrors pnpm's
     /// concurrent `verifyLockfileResolutions` + `verifyLockfile` build gate.
     pub resolution_verifiers: &'a [Arc<dyn ResolutionVerifier>],
+    /// When set, replaces the local `resolution_verifiers` fan-out as the
+    /// trust verdict — used by the pnpr client to delegate verification to
+    /// the server's `/v1/verify-lockfile` while the fetch runs locally. The
+    /// same concurrent sequencing and build gate apply.
     pub lockfile_verification_override: Option<LockfileVerificationOverride<'a>>,
     /// Absolute path of the lockfile being verified, for the on-disk
-    /// verification cache. `None` disables the cache (and is set when
-    /// there are no verifiers to run).
+    /// verification cache. `None` disables the cache.
     pub lockfile_path: Option<&'a Path>,
     /// The previous install's persisted current lockfile, threaded
     /// through to the hoisted walker for `prev_graph` (orphan

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -629,11 +629,11 @@ where
 
         // Run lockfile verification concurrently with the fetch instead of
         // blocking the install on it: the per-entry registry round trips
-        // overlap `CreateVirtualStore`'s downloads. `try_join!` fails fast,
-        // so a rejected lockfile aborts the fetch in flight, and a verdict
-        // is always reached before linking and the build phase below — no
-        // dependency lifecycle script runs on an unverified lockfile. A
-        // no-op when `resolution_verifiers` is empty (`trustLockfile`).
+        // overlap `CreateVirtualStore`'s downloads. A rejected lockfile
+        // aborts the fetch in flight, and a verdict is always reached
+        // before linking and the build phase below — no dependency
+        // lifecycle script runs on an unverified lockfile. A no-op when
+        // `resolution_verifiers` is empty (`trustLockfile`).
         let verify_fut = async {
             if let Some(lockfile_verification_override) = lockfile_verification_override {
                 return lockfile_verification_override.await;
@@ -679,15 +679,32 @@ where
             .map_err(InstallFrozenLockfileError::CreateVirtualStore)
         };
         let phase_start = std::time::Instant::now();
-        let (
-            (),
-            CreateVirtualStoreOutput {
-                package_manifests,
-                side_effects_maps_by_snapshot,
-                fetch_failed,
-                cas_paths_by_pkg_id,
-            },
-        ) = tokio::try_join!(verify_fut, create_virtual_store_fut)?;
+        // The verification verdict takes precedence over a concurrent fetch
+        // error — a plain `try_join!` would surface whichever error lands
+        // first, letting an unrelated fetch failure mask a rejected
+        // lockfile. A verification failure still aborts the fetch in
+        // flight (the select drops `create_virtual_store_fut`); a fetch
+        // failure waits for the verdict and only surfaces once the
+        // lockfile is known trusted. Mirrors pnpm's `settleInstall`.
+        let CreateVirtualStoreOutput {
+            package_manifests,
+            side_effects_maps_by_snapshot,
+            fetch_failed,
+            cas_paths_by_pkg_id,
+        } = {
+            let mut verify_fut = std::pin::pin!(verify_fut);
+            let mut create_virtual_store_fut = std::pin::pin!(create_virtual_store_fut);
+            tokio::select! {
+                verify = &mut verify_fut => {
+                    verify?;
+                    create_virtual_store_fut.await?
+                }
+                output = &mut create_virtual_store_fut => {
+                    verify_fut.await?;
+                    output?
+                }
+            }
+        };
         tracing::info!(
             target: "pacquet::install::phase",
             phase = "create_virtual_store",

--- a/pacquet/crates/package-manager/src/tarball_prefetch.rs
+++ b/pacquet/crates/package-manager/src/tarball_prefetch.rs
@@ -15,19 +15,54 @@
 //! `CacheValue::Available` hit, or a brief park on the per-URL `Notify`
 //! while the prefetch finishes).
 
-use crate::retry_config::retry_opts_from_config;
+use crate::{
+    install_package_by_snapshot::tarball_url_and_integrity, retry_config::retry_opts_from_config,
+};
 use dashmap::DashSet;
 use pacquet_config::Config;
-use pacquet_lockfile::{Lockfile, LockfileResolution, PackageKey};
+use pacquet_lockfile::{Lockfile, LockfileResolution};
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_reporter::SilentReporter;
 use pacquet_store_dir::{
     SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir, StoreIndex, StoreIndexError,
-    StoreIndexWriter,
+    StoreIndexWriter, store_index_key,
 };
 use pacquet_tarball::{DownloadTarballToStore, MemCache, RetryOpts};
 use ssri::Integrity;
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
+
+/// One registry lockfile entry [`TarballPrefetcher::prefetch_lockfile`]
+/// may spawn a download for, staged so the whole batch can be filtered
+/// through a single store-index existence probe first.
+struct PendingPrefetch {
+    store_key: String,
+    package_id: String,
+    package_url: String,
+    integrity: String,
+}
+
+/// Drop every pending entry whose `(integrity, package_id)` row already
+/// exists in `index.db`, with one batched existence probe. Best-effort:
+/// no readable index keeps every entry pending, so the store stays the
+/// only authority over what actually downloads.
+async fn without_store_hits(
+    index: Option<SharedReadonlyStoreIndex>,
+    pending: Vec<PendingPrefetch>,
+) -> Vec<PendingPrefetch> {
+    let Some(index) = index else {
+        return pending;
+    };
+    let keys: Vec<String> = pending.iter().map(|entry| entry.store_key.clone()).collect();
+    let hits = tokio::task::spawn_blocking(move || {
+        let Ok(guard) = index.lock() else {
+            return HashSet::new();
+        };
+        guard.contains_many(&keys).unwrap_or_default()
+    })
+    .await
+    .unwrap_or_default();
+    pending.into_iter().filter(|entry| !hits.contains(&entry.store_key)).collect()
+}
 
 /// One background tarball download. Every field is owned (an `Arc`
 /// clone or a `Copy` scalar) so the spawned task captures an
@@ -241,23 +276,47 @@ impl TarballPrefetcher {
         });
     }
 
-    pub fn prefetch_lockfile(&self, lockfile: &Lockfile, config: &Config) {
+    /// Fire a background download for every registry-resolved entry of a
+    /// frozen lockfile that isn't already in the store, so the fetch
+    /// starts before the trust verdict arrives. Registry resolutions
+    /// only: they are the one shape the materialization pass reuses from
+    /// the shared mem cache (see the dispatch in
+    /// [`crate::InstallPackageBySnapshot`]).
+    ///
+    /// Entries with an `index.db` row are filtered out with one batched
+    /// existence probe rather than spawned: the materialization pass
+    /// already covers warm entries with its own batched verified lookup
+    /// ([`pacquet_tarball::prefetch_cas_paths`]), so spawning them here
+    /// would only duplicate that work per key — on a fully warm store it
+    /// turns the whole prefetch into a no-op. A row whose CAS files have
+    /// gone missing is skipped here too; the materialization pass's
+    /// per-snapshot cache-miss fallback re-downloads it.
+    pub async fn prefetch_lockfile(&self, lockfile: &Lockfile, config: &Config) {
         let Some(packages) = lockfile.packages.as_ref() else {
             return;
         };
+        let mut pending = Vec::with_capacity(packages.len());
         for (package_key, metadata) in packages {
-            let LockfileResolution::Registry(registry_resolution) = &metadata.resolution else {
+            if !matches!(&metadata.resolution, LockfileResolution::Registry(_)) {
                 continue;
-            };
+            }
+            let (tarball_url, integrity) =
+                tarball_url_and_integrity(&metadata.resolution, package_key, config)
+                    .expect("registry resolutions always carry an integrity");
+            let package_id = package_key.without_peer().to_string();
+            let integrity = integrity.to_string();
+            pending.push(PendingPrefetch {
+                store_key: store_index_key(&integrity, &package_id),
+                package_id,
+                package_url: tarball_url.into_owned(),
+                integrity,
+            });
+        }
+        for entry in without_store_hits(self.store_index.clone(), pending).await {
+            let PendingPrefetch { package_id, package_url, integrity, .. } = entry;
             // The lockfile records no dist size hints, so the downloads
             // queue without a work estimate.
-            self.prefetch(
-                package_key.without_peer().to_string(),
-                registry_tarball_url(package_key, config),
-                &registry_resolution.integrity.to_string(),
-                None,
-                None,
-            );
+            self.prefetch(package_id, package_url, &integrity, None, None);
         }
     }
 
@@ -286,10 +345,5 @@ impl TarballPrefetcher {
     }
 }
 
-fn registry_tarball_url(package_key: &PackageKey, config: &Config) -> String {
-    let registry = config.registry.strip_suffix('/').unwrap_or(&config.registry);
-    let name = &package_key.name;
-    let version = package_key.suffix.version();
-    let bare_name = name.bare.as_str();
-    format!("{registry}/{name}/-/{bare_name}-{version}.tgz")
-}
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/package-manager/src/tarball_prefetch.rs
+++ b/pacquet/crates/package-manager/src/tarball_prefetch.rs
@@ -249,10 +249,14 @@ impl TarballPrefetcher {
             let LockfileResolution::Registry(registry_resolution) = &metadata.resolution else {
                 continue;
             };
+            // The lockfile records no dist size hints, so the downloads
+            // queue without a work estimate.
             self.prefetch(
                 package_key.without_peer().to_string(),
                 registry_tarball_url(package_key, config),
                 &registry_resolution.integrity.to_string(),
+                None,
+                None,
             );
         }
     }

--- a/pacquet/crates/package-manager/src/tarball_prefetch.rs
+++ b/pacquet/crates/package-manager/src/tarball_prefetch.rs
@@ -18,6 +18,7 @@
 use crate::retry_config::retry_opts_from_config;
 use dashmap::DashSet;
 use pacquet_config::Config;
+use pacquet_lockfile::{Lockfile, LockfileResolution, PackageKey};
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_reporter::SilentReporter;
 use pacquet_store_dir::{
@@ -240,6 +241,22 @@ impl TarballPrefetcher {
         });
     }
 
+    pub fn prefetch_lockfile(&self, lockfile: &Lockfile, config: &Config) {
+        let Some(packages) = lockfile.packages.as_ref() else {
+            return;
+        };
+        for (package_key, metadata) in packages {
+            let LockfileResolution::Registry(registry_resolution) = &metadata.resolution else {
+                continue;
+            };
+            self.prefetch(
+                package_key.without_peer().to_string(),
+                registry_tarball_url(package_key, config),
+                &registry_resolution.integrity.to_string(),
+            );
+        }
+    }
+
     /// Drain the store-index writer. Call after the materialization
     /// install has returned: by then every prefetch download has
     /// finished (the install awaited each tarball's mem-cache slot) and
@@ -263,4 +280,12 @@ impl TarballPrefetcher {
             ),
         }
     }
+}
+
+fn registry_tarball_url(package_key: &PackageKey, config: &Config) -> String {
+    let registry = config.registry.strip_suffix('/').unwrap_or(&config.registry);
+    let name = &package_key.name;
+    let version = package_key.suffix.version();
+    let bare_name = name.bare.as_str();
+    format!("{registry}/{name}/-/{bare_name}-{version}.tgz")
 }

--- a/pacquet/crates/package-manager/src/tarball_prefetch/tests.rs
+++ b/pacquet/crates/package-manager/src/tarball_prefetch/tests.rs
@@ -1,0 +1,64 @@
+use super::{PendingPrefetch, without_store_hits};
+use pacquet_store_dir::{CafsFileInfo, PackageFilesIndex, StoreIndex, store_index_key};
+use std::collections::HashMap;
+use tempfile::tempdir;
+
+fn sample_index() -> PackageFilesIndex {
+    let mut files = HashMap::new();
+    files.insert(
+        "package.json".to_string(),
+        CafsFileInfo {
+            checked_at: Some(1_700_000_000_000),
+            digest: "abc".to_string(),
+            mode: 0o644,
+            size: 123,
+        },
+    );
+    PackageFilesIndex {
+        manifest: None,
+        requires_build: Some(false),
+        algo: "sha512".to_string(),
+        files,
+        side_effects: None,
+    }
+}
+
+fn pending(package_id: &str, integrity: &str) -> PendingPrefetch {
+    PendingPrefetch {
+        store_key: store_index_key(integrity, package_id),
+        package_id: package_id.to_string(),
+        package_url: format!("https://registry.example.com/{package_id}.tgz"),
+        integrity: integrity.to_string(),
+    }
+}
+
+#[tokio::test]
+async fn without_store_hits_drops_entries_with_an_index_row() {
+    let store = tempdir().unwrap();
+    let warm = pending("@foo/warm@1.0.0", "sha512-aGVsbG8=");
+    let cold = pending("@foo/cold@1.0.0", "sha512-d29ybGQ=");
+    {
+        let idx = StoreIndex::open(store.path()).unwrap();
+        idx.set(&warm.store_key, &sample_index()).unwrap();
+    }
+    let index = StoreIndex::open_readonly(store.path())
+        .map(|idx| std::sync::Arc::new(std::sync::Mutex::new(idx)))
+        .ok();
+    assert!(index.is_some(), "readonly index should open after a write");
+
+    let remaining = without_store_hits(index, vec![warm, cold]).await;
+
+    let remaining_ids: Vec<&str> =
+        remaining.iter().map(|entry| entry.package_id.as_str()).collect();
+    assert_eq!(remaining_ids, ["@foo/cold@1.0.0"]);
+}
+
+#[tokio::test]
+async fn without_store_hits_keeps_everything_when_no_index_is_readable() {
+    let warm = pending("@foo/warm@1.0.0", "sha512-aGVsbG8=");
+    let cold = pending("@foo/cold@1.0.0", "sha512-d29ybGQ=");
+
+    let remaining = without_store_hits(None, vec![warm, cold]).await;
+
+    assert_eq!(remaining.len(), 2);
+}

--- a/pacquet/crates/pnpr-client/src/lib.rs
+++ b/pacquet/crates/pnpr-client/src/lib.rs
@@ -35,6 +35,7 @@ pub struct PnprClient {
 }
 
 /// Inputs for a single-project resolution.
+#[derive(Clone)]
 pub struct ResolveOptions {
     pub dependencies: DepMap,
     pub dev_dependencies: DepMap,
@@ -79,6 +80,46 @@ pub struct ResolveOptions {
     pub trust_policy: TrustPolicy,
     pub trust_policy_exclude: Option<Vec<String>>,
     pub trust_policy_ignore_after: Option<u64>,
+}
+
+/// Inputs for `/v1/verify-lockfile`, the resolution-free trust verdict
+/// used by frozen restores that already know the local lockfile is fresh.
+#[derive(Clone)]
+pub struct VerifyLockfileOptions {
+    pub registry: String,
+    pub named_registries: DepMap,
+    pub auth_headers: DepMap,
+    pub authorization: Option<String>,
+    pub overrides: Option<serde_json::Value>,
+    pub lockfile: Lockfile,
+    pub trust_lockfile: bool,
+    pub minimum_release_age: Option<u64>,
+    pub minimum_release_age_exclude: Option<Vec<String>>,
+    pub minimum_release_age_ignore_missing_time: bool,
+    pub trust_policy: TrustPolicy,
+    pub trust_policy_exclude: Option<Vec<String>>,
+    pub trust_policy_ignore_after: Option<u64>,
+}
+
+impl VerifyLockfileOptions {
+    #[must_use]
+    pub fn from_resolve_options(opts: &ResolveOptions) -> Option<Self> {
+        Some(Self {
+            registry: opts.registry.clone(),
+            named_registries: opts.named_registries.clone(),
+            auth_headers: opts.auth_headers.clone(),
+            authorization: opts.authorization.clone(),
+            overrides: opts.overrides.clone(),
+            lockfile: opts.lockfile.clone()?,
+            trust_lockfile: opts.trust_lockfile,
+            minimum_release_age: opts.minimum_release_age,
+            minimum_release_age_exclude: opts.minimum_release_age_exclude.clone(),
+            minimum_release_age_ignore_missing_time: opts.minimum_release_age_ignore_missing_time,
+            trust_policy: opts.trust_policy,
+            trust_policy_exclude: opts.trust_policy_exclude.clone(),
+            trust_policy_ignore_after: opts.trust_policy_ignore_after,
+        })
+    }
 }
 
 /// Result of [`PnprClient::resolve`].
@@ -202,6 +243,69 @@ impl PnprClient {
         self.resolve_streaming(opts, |_| {}).await
     }
 
+    /// Ask the server to verify a lockfile under the client's registry
+    /// and policy settings, without resolving or echoing the lockfile
+    /// back.
+    pub async fn verify_lockfile(
+        &self,
+        opts: VerifyLockfileOptions,
+    ) -> Result<(), PnprClientError> {
+        let request = serde_json::json!({
+            "registry": opts.registry,
+            "namedRegistries": opts.named_registries,
+            "authHeaders": opts.auth_headers,
+            "overrides": opts.overrides,
+            "lockfile": opts.lockfile,
+            "trustLockfile": opts.trust_lockfile,
+            "minimumReleaseAge": opts.minimum_release_age,
+            "minimumReleaseAgeExclude": opts.minimum_release_age_exclude,
+            "minimumReleaseAgeIgnoreMissingTime": opts.minimum_release_age_ignore_missing_time,
+            "trustPolicy": opts.trust_policy,
+            "trustPolicyExclude": opts.trust_policy_exclude,
+            "trustPolicyIgnoreAfter": opts.trust_policy_ignore_after,
+        });
+
+        let mut post =
+            self.http.post(format!("{}v1/verify-lockfile", self.base_url)).json(&request);
+        if let Some(authorization) = opts.authorization.as_deref() {
+            post = post.header("authorization", authorization);
+        }
+        let response = post.send().await?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(PnprClientError::Server(format!(
+                "/v1/verify-lockfile returned {status}: {body}",
+            )));
+        }
+
+        let mut stream = response.bytes_stream();
+        let mut buf: Vec<u8> = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            buf.extend_from_slice(&chunk?);
+            while let Some(newline) = buf.iter().position(|&byte| byte == b'\n') {
+                let line: Vec<u8> = buf.drain(..=newline).collect();
+                let line = &line[..line.len() - 1];
+                if line.is_empty() {
+                    continue;
+                }
+                match parse_verify_frame(line)? {
+                    VerifyFrame::Done => return Ok(()),
+                    VerifyFrame::Error { message } => {
+                        return Err(PnprClientError::Server(message));
+                    }
+                    VerifyFrame::Violations { violations } => {
+                        return Err(PnprClientError::Verification(build_verify_error(violations)));
+                    }
+                }
+            }
+        }
+
+        Err(PnprClientError::Protocol(
+            "/v1/verify-lockfile stream ended without a terminal frame".to_string(),
+        ))
+    }
+
     /// Resolve a single project, invoking `on_package` once per resolved
     /// tarball as its `package` frame streams in — *before* the full
     /// lockfile arrives — so the caller can begin fetching each tarball
@@ -302,6 +406,10 @@ fn parse_frame(line: &[u8]) -> Result<Frame, PnprClientError> {
     serde_json::from_slice(line).map_err(|err| PnprClientError::Protocol(err.to_string()))
 }
 
+fn parse_verify_frame(line: &[u8]) -> Result<VerifyFrame, PnprClientError> {
+    serde_json::from_slice(line).map_err(|err| PnprClientError::Protocol(err.to_string()))
+}
+
 /// One NDJSON frame from `/v1/resolve`. `package` frames stream as the
 /// server resolves; exactly one terminal frame (`done` / `error` /
 /// `violations`) closes the response.
@@ -335,6 +443,14 @@ enum Frame {
     Violations {
         violations: Vec<WireViolation>,
     },
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum VerifyFrame {
+    Done,
+    Error { message: String },
+    Violations { violations: Vec<WireViolation> },
 }
 
 #[derive(Deserialize)]

--- a/pacquet/crates/pnpr-client/tests/integration.rs
+++ b/pacquet/crates/pnpr-client/tests/integration.rs
@@ -14,7 +14,7 @@ use std::{
     time::Duration,
 };
 
-use pacquet_pnpr_client::{PnprClient, PnprClientError, ResolveOptions};
+use pacquet_pnpr_client::{PnprClient, PnprClientError, ResolveOptions, VerifyLockfileOptions};
 use pacquet_testing_utils::registry::TestRegistry;
 use tempfile::TempDir;
 use tokio::net::TcpListener;
@@ -297,6 +297,55 @@ async fn rejects_an_input_lockfile_that_violates_the_clients_policy() {
     opts.minimum_release_age_ignore_missing_time = false;
 
     let Err(PnprClientError::Verification(verify_err)) = client.resolve(opts).await else {
+        panic!("expected a verification error rejecting the input lockfile");
+    };
+    assert!(
+        verify_err.to_string().contains("minimumReleaseAge"),
+        "expected a minimumReleaseAge breakdown, got: {verify_err}",
+    );
+}
+
+#[tokio::test]
+async fn verify_lockfile_endpoint_accepts_a_clean_input_lockfile() {
+    let registry = TestRegistry::start();
+    let (pnpr_url, _storage) = start_pnpr().await;
+
+    let client = PnprClient::new(pnpr_url);
+
+    let first = client
+        .resolve(options(&registry.url(), deps([("@foo/no-deps", "1.0.0")])))
+        .await
+        .expect("first install");
+
+    let mut opts = options(&registry.url(), deps([("@foo/no-deps", "1.0.0")]));
+    opts.lockfile = Some(first.lockfile);
+    let verify_opts =
+        VerifyLockfileOptions::from_resolve_options(&opts).expect("lockfile is present");
+
+    client.verify_lockfile(verify_opts).await.expect("lockfile should verify");
+}
+
+#[tokio::test]
+async fn verify_lockfile_endpoint_rejects_policy_violation() {
+    let registry = TestRegistry::start();
+    let (pnpr_url, _storage) = start_pnpr().await;
+
+    let client = PnprClient::new(pnpr_url);
+
+    let first = client
+        .resolve(options(&registry.url(), deps([("@foo/no-deps", "1.0.0")])))
+        .await
+        .expect("first install");
+
+    let mut opts = options(&registry.url(), deps([("@foo/no-deps", "1.0.0")]));
+    opts.lockfile = Some(first.lockfile);
+    opts.minimum_release_age = Some(60 * 24 * 365 * 100);
+    opts.minimum_release_age_ignore_missing_time = false;
+    let verify_opts =
+        VerifyLockfileOptions::from_resolve_options(&opts).expect("lockfile is present");
+
+    let Err(PnprClientError::Verification(verify_err)) = client.verify_lockfile(verify_opts).await
+    else {
         panic!("expected a verification error rejecting the input lockfile");
     };
     assert!(

--- a/pacquet/crates/pnpr-client/tests/integration.rs
+++ b/pacquet/crates/pnpr-client/tests/integration.rs
@@ -354,6 +354,51 @@ async fn verify_lockfile_endpoint_rejects_policy_violation() {
     );
 }
 
+/// The verification fan-out fetches each entry's packument, so a gated
+/// package verifies only when `/v1/verify-lockfile` forwards the
+/// client's credential map — and fails closed when it doesn't. Each
+/// verify call targets a fresh pnpr so neither the whole-lockfile
+/// verdict cache nor the metadata mirror warmed by an earlier call can
+/// satisfy it without exercising the forwarded credential.
+#[tokio::test]
+async fn verify_lockfile_endpoint_forwards_credentials() {
+    let registry = TestRegistry::start();
+    let token = register_token(&registry.url(), "needs-auth-verifier").await;
+    let (resolve_pnpr_url, _resolve_storage) = start_pnpr().await;
+
+    let mut resolve_opts = options(&registry.url(), deps([("@pnpm.e2e/needs-auth", "1.0.0")]));
+    let mut auth = BTreeMap::new();
+    auth.insert(nerf_key(&registry.url()), format!("Bearer {token}"));
+    resolve_opts.auth_headers = auth;
+    let first = PnprClient::new(resolve_pnpr_url)
+        .resolve(resolve_opts.clone())
+        .await
+        .expect("authed install");
+
+    // An active policy makes the verifier fetch the gated packument.
+    resolve_opts.lockfile = Some(first.lockfile);
+    resolve_opts.minimum_release_age = Some(1);
+    resolve_opts.minimum_release_age_ignore_missing_time = false;
+    let verify_opts =
+        VerifyLockfileOptions::from_resolve_options(&resolve_opts).expect("lockfile is present");
+
+    let (authed_pnpr_url, _authed_storage) = start_pnpr().await;
+    PnprClient::new(authed_pnpr_url)
+        .verify_lockfile(verify_opts)
+        .await
+        .expect("forwarded credential should let the gated entry verify");
+
+    let mut anonymous_opts = resolve_opts.clone();
+    anonymous_opts.auth_headers = BTreeMap::new();
+    let anonymous_verify_opts =
+        VerifyLockfileOptions::from_resolve_options(&anonymous_opts).expect("lockfile is present");
+    let (anonymous_pnpr_url, _anonymous_storage) = start_pnpr().await;
+    assert!(
+        PnprClient::new(anonymous_pnpr_url).verify_lockfile(anonymous_verify_opts).await.is_err(),
+        "without the credential the gated entry's metadata fetch must fail closed",
+    );
+}
+
 #[tokio::test]
 async fn trust_lockfile_makes_the_server_skip_verification() {
     let registry = TestRegistry::start();

--- a/pacquet/crates/store-dir/src/store_index.rs
+++ b/pacquet/crates/store-dir/src/store_index.rs
@@ -4,7 +4,7 @@ use miette::Diagnostic;
 use rusqlite::{Connection, OpenFlags};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     sync::{
         Arc, Mutex,
@@ -565,6 +565,32 @@ impl StoreIndex {
             for row in rows {
                 let row = row.map_err(|source| StoreIndexError::Read { source })?;
                 out.push(row);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Batched existence probe: the subset of `keys` that have a row in
+    /// `package_index`. Same chunked `WHERE key IN` shape (and SQL-injection
+    /// posture) as [`Self::get_many_raw`], but selects only the key column,
+    /// so no row data is copied — for callers that decide *whether* to do
+    /// work per key and leave reading the row to a later pass.
+    pub fn contains_many(&self, keys: &[String]) -> Result<HashSet<String>, StoreIndexError> {
+        let mut out = HashSet::with_capacity(keys.len());
+        if keys.is_empty() {
+            return Ok(out);
+        }
+        for chunk in keys.chunks(GET_MANY_CHUNK) {
+            let placeholders = std::iter::repeat_n("?", chunk.len()).collect::<Vec<_>>().join(",");
+            let sql = format!("SELECT key FROM package_index WHERE key IN ({placeholders})");
+            let mut stmt =
+                self.conn.prepare(&sql).map_err(|source| StoreIndexError::Read { source })?;
+            let params = rusqlite::params_from_iter(chunk.iter().map(String::as_str));
+            let rows = stmt
+                .query_map(params, |row| row.get::<_, String>(0))
+                .map_err(|source| StoreIndexError::Read { source })?;
+            for key in rows {
+                out.insert(key.map_err(|source| StoreIndexError::Read { source })?);
             }
         }
         Ok(out)

--- a/pacquet/crates/store-dir/src/store_index/tests.rs
+++ b/pacquet/crates/store-dir/src/store_index/tests.rs
@@ -242,6 +242,49 @@ fn get_many_mixed_hit_and_miss_returns_only_hits() {
     }
 }
 
+#[test]
+fn contains_many_returns_only_present_keys() {
+    let dir = tempdir().unwrap();
+    let idx = StoreIndex::open(dir.path()).unwrap();
+    let payload = sample_index();
+    let hit_keys: Vec<String> =
+        (0..3).map(|index| store_index_key("sha512-h", &format!("hit{index}@1.0.0"))).collect();
+    let miss_keys: Vec<String> =
+        (0..3).map(|index| store_index_key("sha512-m", &format!("miss{index}@1.0.0"))).collect();
+    for key in &hit_keys {
+        idx.set(key, &payload).unwrap();
+    }
+
+    let mut all_keys = hit_keys.clone();
+    all_keys.extend(miss_keys.clone());
+    let out = idx.contains_many(&all_keys).unwrap();
+
+    assert_eq!(out.len(), hit_keys.len());
+    for key in &hit_keys {
+        assert!(out.contains(key), "hit key missing from result: {key}");
+    }
+    for key in &miss_keys {
+        assert!(!out.contains(key), "miss key present in result: {key}");
+    }
+}
+
+#[test]
+fn contains_many_handles_empty_input_and_more_keys_than_chunk_size() {
+    let dir = tempdir().unwrap();
+    let idx = StoreIndex::open(dir.path()).unwrap();
+    assert!(idx.contains_many(&[]).unwrap().is_empty());
+
+    let payload = sample_index();
+    let keys: Vec<String> = (0..(GET_MANY_CHUNK + 7))
+        .map(|index| store_index_key("sha512-x", &format!("pkg{index}@1.0.0")))
+        .collect();
+    for key in &keys {
+        idx.set(key, &payload).unwrap();
+    }
+    let out = idx.contains_many(&keys).unwrap();
+    assert_eq!(out.len(), keys.len());
+}
+
 /// A row whose bytes don't decode (corruption, foreign writer) must
 /// be skipped without failing the batch. `load_cached_cas_paths`
 /// already does `.ok()?` on the per-key path, treating decode

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -17,6 +17,10 @@
 //!   ([pnpm/pnpm#12234](https://github.com/pnpm/pnpm/issues/12234)),
 //!   then fetches the rest in parallel like a normal install
 //!   ([pnpm/pnpm#12230](https://github.com/pnpm/pnpm/issues/12230)).
+//! * `POST /v1/verify-lockfile` — verify an already-fresh client
+//!   lockfile under the same policy without resolving. A frozen restore
+//!   can start local fetch/materialization immediately and only use this
+//!   endpoint as the trust verdict.
 //!
 //! pnpr is a stateless resolver: it stores no tarballs and serves no file
 //! content. The client fetches every tarball directly from the registry
@@ -293,6 +297,39 @@ pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response 
     ndjson_stream_response(rx)
 }
 
+/// Handle `POST /v1/verify-lockfile`: verify the client's input
+/// lockfile under the client's policy, returning only a terminal NDJSON
+/// verdict frame. The client already knows the lockfile is fresh for
+/// the current manifests, so this endpoint deliberately does not
+/// resolve or echo the lockfile back.
+pub(crate) async fn handle_verify_lockfile(runtime: &Resolver, body: Bytes) -> Response {
+    let request: ResolveRequest = match serde_json::from_slice(&body) {
+        Ok(request) => request,
+        Err(err) => return json_error(StatusCode::BAD_REQUEST, &err.to_string()),
+    };
+
+    let Some(input_lockfile) = request.lockfile.as_ref() else {
+        return json_error(StatusCode::BAD_REQUEST, "`lockfile` is required");
+    };
+
+    if request.trust_lockfile {
+        return ndjson_single_frame(&verify_done_frame());
+    }
+
+    let config = runtime.config_for(&request);
+    let request_auth = Arc::new(AuthHeaders::from_map(
+        request.auth_headers.iter().map(|(uri, value)| (uri.clone(), value.clone())).collect(),
+    ));
+
+    match verify_input_lockfile(runtime, config, &request_auth, input_lockfile).await {
+        Ok(()) => ndjson_single_frame(&verify_done_frame()),
+        Err(VerifyFailure::Internal(response)) => response,
+        Err(VerifyFailure::Violations(violations)) => {
+            ndjson_single_frame(&violations_frame(&violations))
+        }
+    }
+}
+
 const MAX_RESOLUTION_CACHE_ENTRIES: usize = 1024;
 
 fn cached_resolution(
@@ -505,6 +542,11 @@ fn error_frame(message: &str) -> Vec<u8> {
 fn violations_frame(violations: &[serde_json::Value]) -> Vec<u8> {
     let frame = serde_json::json!({ "type": "violations", "violations": violations });
     ndjson_line(&frame)
+        .unwrap_or_else(|_| br#"{"type":"error","message":"verification failed"}"#.to_vec())
+}
+
+fn verify_done_frame() -> Vec<u8> {
+    ndjson_line(&serde_json::json!({ "type": "done" }))
         .unwrap_or_else(|_| br#"{"type":"error","message":"verification failed"}"#.to_vec())
 }
 

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -322,7 +322,10 @@ pub(crate) async fn handle_verify_lockfile(runtime: &Resolver, body: Bytes) -> R
     ));
 
     match verify_input_lockfile(runtime, config, &request_auth, input_lockfile).await {
-        Ok(()) => ndjson_single_frame(&verify_done_frame()),
+        // The dist stats the verifier observed feed `/v1/resolve`'s sized
+        // `package` frames; this endpoint's client prefetches from its own
+        // lockfile before the verdict arrives, so only the verdict is sent.
+        Ok(_) => ndjson_single_frame(&verify_done_frame()),
         Err(VerifyFailure::Internal(response)) => response,
         Err(VerifyFailure::Violations(violations)) => {
             ndjson_single_frame(&violations_frame(&violations))

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -161,6 +161,7 @@ pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
         // is the capability handshake (404 on a plain registry).
         .route("/-/pnpr", get(serve_pnpr_handshake))
         .route("/v1/resolve", post(serve_resolve))
+        .route("/v1/verify-lockfile", post(serve_verify_lockfile))
         .route("/{name}", get(get_packument_unscoped).put(put_one_segment))
         .route("/{first}/{second}", get(get_two_segments).put(put_two_segments))
         .route(
@@ -182,7 +183,7 @@ pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
         // front, so the application is the only layer that can compress.
         // Scoped to JSON: tarballs (`application/octet-stream`, already
         // `.tgz`) are excluded so we never re-gzip an already-compressed
-        // payload. The `/v1/resolve` NDJSON stream
+        // payload. The pnpr resolver NDJSON streams
         // (`application/x-ndjson`) is excluded too: gzip-buffering it
         // would defeat the point of streaming — frames must flush to the
         // client as each package resolves, not wait for the encoder.
@@ -1775,4 +1776,10 @@ async fn serve_resolve(State(state): State<AppState>, body: axum::body::Bytes) -
     let runtime =
         crate::resolver::Resolver::get_or_init(&state.inner.resolver, &state.inner.config);
     crate::resolver::handle_resolve(runtime, body).await
+}
+
+async fn serve_verify_lockfile(State(state): State<AppState>, body: axum::body::Bytes) -> Response {
+    let runtime =
+        crate::resolver::Resolver::get_or_init(&state.inner.resolver, &state.inner.config);
+    crate::resolver::handle_verify_lockfile(runtime, body).await
 }


### PR DESCRIPTION
## Problem

`pnpm install` with a frozen lockfile got noticeably slower because lockfile verification blocks every later install stage. The verification gate (the `minimumReleaseAge`/`trustPolicy` policy revalidation plus the tarball-URL anti-tamper check) issues a registry round trip per lockfile entry, and the whole install waited for it to finish before any fetching or linking could begin.

## Change (pnpm / TypeScript)

Run lockfile verification **concurrently** with fetching and linking instead of blocking on it, while keeping two guarantees intact:

1. **No lifecycle script runs on an unverified lockfile.** A `verifyLockfile` gate is threaded into both `buildModules` call sites — `headlessInstall` (frozen path) and `_installInContext` (full-resolution path) — and awaited immediately before any dependency lifecycle script runs. The projects' own `preinstall`/`postinstall` hooks are held to the same gate at both `runLifecycleHooksConcurrently` call sites, covering the `enableModulesDir: false` path that skips the build phase. If verification failed, the gate throws before a single script executes.
2. **The verdict is always reconciled.** `settleInstall(_install(), verifyLockfilePromise)` awaits the verification verdict first so it takes precedence and fails fast (even mid-install), then surfaces the install's result/error. This also covers paths that skip the build phase entirely (`ignoreScripts`, `lockfileOnly`, empty lockfile).

Verification's synchronous prologue (cache lookup, lockfile hash, candidate collection) still runs against the pristine lockfile before `_install()` mutates `ctx.wantedLockfile`, so the concurrent async fan-out reads a stable snapshot — no data race.

The verification verdict deliberately takes precedence over a concurrent install error: `pnpm add`'s full-resolution path can throw its own generic "resolution-policy violations produced but no handler wired" for the same underlying violation, and `settleInstall` makes sure the specific `minimumReleaseAge`/`trustPolicy` error is what surfaces.

## Change (pacquet / Rust)

Same optimization ported to `pacquet/crates/package-manager/`. `Install::run` builds the resolution verifiers up front but dispatches the verification fan-out per path:

- **Frozen materialization path:** verification runs concurrently with `CreateVirtualStore` (the fetch), settled with a `select!` so the verdict takes precedence: a rejected lockfile aborts the fetch in flight (fail-fast), while a fetch failure waits for the verdict and only surfaces once the lockfile is known trusted — an unrelated fetch error can't mask a rejected lockfile. The verdict is always reached before linking and `BuildModules`, so no dependency lifecycle script runs on an unverified lockfile.
- **Lockfile-only / up-to-date short-circuits and the fresh-resolve path:** keep an eager blocking gate — they have no fetch to overlap.

A verification failure surfaces as the same `InstallError::LockfileVerification` variant regardless of which path produced it.

On the pnpr client, a frozen restore now skips resolution entirely: tarball downloads start from the local lockfile at t=0 (filtered through one batched store-index existence probe, so a warm store prefetches nothing) while the server delivers only the trust verdict via the new `POST /v1/verify-lockfile` endpoint, concurrently with the fetch.

## Tests

- pnpm: `test/install/trustLockfile.ts` covers the rejection itself, the `trustLockfile` opt-out, and both script gates — a dependency `postinstall` never runs when verification fails, and the projects' own lifecycle hooks never run either, asserted on the `enableModulesDir: false` path with a *slow*-rejecting verifier (an instantly-rejecting one aborts the install before the hooks are attempted, which would hide a missing gate). Existing verification/lifecycle/`minimumReleaseAge` suites pass.
- pacquet: existing `frozen_lockfile_gate_rejects_under_huge_minimum_release_age` (unit) and `install_fails_under_huge_minimum_release_age` (CLI) assert the frozen install aborts with no virtual-store materialization on verification failure — proving the fail-fast settle cancels the fetch. New: `without_store_hits` + `StoreIndex::contains_many` unit tests pin the warm-store prefetch filter, and the frozen pnpr CLI test swaps the registry for a zero-expectation server before the restore, proving a warm-store frozen restore makes no registry requests.
- pnpr client/server: integration tests cover `/v1/verify-lockfile` accepting a clean lockfile, rejecting a policy violation, honoring `trustLockfile`, and forwarding the client's credential map (each verify call targets a fresh pnpr so no verdict/metadata cache can satisfy it without exercising the credential).
- clippy / `cargo doc -D warnings` / rustfmt / eslint clean; package-manager, lockfile-verification, store-dir, pnpr-client, and CLI pnpr-install suites all pass.

## Behavioral nuance

On a *rejected* lockfile, fetching/linking may now have partially populated the store/`node_modules` before the abort (previously nothing ran, since verification went first). The command still fails with the same error code and no lifecycle scripts run.

---
Written by agents (Claude Code: claude-opus-4-8, claude-fable-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side lockfile verification endpoint for external verification
  * Lockfile-driven tarball prefetch to speed local-frozen installs

* **Improvements**
  * Lockfile verification runs concurrently with fetching/linking
  * Dependency and project lifecycle scripts are delayed until verification succeeds
  * Frozen-lockfile installs can verify locally without re-resolving or redownloading

* **Tests**
  * New end-to-end and unit tests covering verification gating, prefetching, and store-index batching
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

