### PR TITLE
chore: update pacquet version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-branch": "pn pretest && pn lint && git remote set-branches --add origin main && git fetch origin main && pn test-pkgs-branch",
     "ci:test-branch": "pn prepare-fixtures && pn test-pkgs-branch",
     "test-pkgs-branch": "pn remove-temp-dir && pn --workspace-concurrency=1 --filter=...[origin/main] --no-sort --if-present .test",
-    "compile-only": "tsgo --build workspace/workspace-manifest-reader workspace/projects-reader && pnx node@runtime:26.3.0 __utils__/scripts/src/typecheck-only.ts && pn -F=pnpm compile",
+    "compile-only": "tsgo --build workspace/workspace-manifest-reader workspace/projects-reader && pnx node@runtime:^26.3.0 __utils__/scripts/src/typecheck-only.ts && pn -F=pnpm compile",
     "compile": "pn compile-only && pn update-manifests",
     "build:pacquet": "cargo build --release --bin pacquet",
     "make-lcov": "shx mkdir -p coverage && lcov-result-merger './packages/*/coverage/lcov.info' 'coverage/lcov.info'",
@@ -66,7 +66,7 @@
     },
     "runtime": {
       "name": "node",
-      "version": "26.3.0",
+      "version": "^26.3.0",
       "onFail": "download"
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-branch": "pn pretest && pn lint && git remote set-branches --add origin main && git fetch origin main && pn test-pkgs-branch",
     "ci:test-branch": "pn prepare-fixtures && pn test-pkgs-branch",
     "test-pkgs-branch": "pn remove-temp-dir && pn --workspace-concurrency=1 --filter=...[origin/main] --no-sort --if-present .test",
-    "compile-only": "tsgo --build workspace/workspace-manifest-reader workspace/projects-reader && pnx node@runtime:^26.3.0 __utils__/scripts/src/typecheck-only.ts && pn -F=pnpm compile",
+    "compile-only": "tsgo --build workspace/workspace-manifest-reader workspace/projects-reader && pnx node@runtime:26.3.0 __utils__/scripts/src/typecheck-only.ts && pn -F=pnpm compile",
     "compile": "pn compile-only && pn update-manifests",
     "build:pacquet": "cargo build --release --bin pacquet",
     "make-lcov": "shx mkdir -p coverage && lcov-result-merger './packages/*/coverage/lcov.info' 'coverage/lcov.info'",
@@ -66,7 +66,7 @@
     },
     "runtime": {
       "name": "node",
-      "version": "^26.3.0",
+      "version": "26.3.0",
       "onFail": "download"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1132,7 +1132,7 @@ importers:
         specifier: 'catalog:'
         version: 5.0.1
       node:
-        specifier: runtime:^26.3.0
+        specifier: runtime:26.3.0
         version: runtime:26.3.0
       rimraf:
         specifier: 'catalog:'
@@ -15351,6 +15351,7 @@ packages:
             - cpu: x64
               os: linux
               libc: musl
+    version: 26.3.0
     hasBin: true
 
   nopt@1.0.10:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ importers:
   .:
     configDependencies:
       '@pnpm/pacquet':
-        specifier: 0.2.14
-        version: 0.2.14
+        specifier: 0.11.1
+        version: 0.11.1
     packageManagerDependencies:
       '@pnpm/exe':
         specifier: 11.5.2
@@ -18,33 +18,33 @@ importers:
 
 packages:
 
-  '@pacquet/darwin-arm64@0.2.14':
-    resolution: {integrity: sha512-ItfGB23f9OrLInb0kWxmbbzeVG+lFaeDYlhHaPYceCOFKmhEK1L5obJshxH/nvduJeMAwOpiRvD4wjSUTNzBUw==}
+  '@pacquet/darwin-arm64@0.11.1':
+    resolution: {integrity: sha512-BuXwCsOvaZgEttK7VBZi4AADHRN+JofG3X5c+hklkTGrb2S3EiSQvY5eqfAekrZaRt9jd62KQDyvzAKRnSaEng==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pacquet/darwin-x64@0.2.14':
-    resolution: {integrity: sha512-3qXyCn0KnN2ASVixXxayYPEf7BxBQEJpc/FGkegPpSYVfX1s2O1w/Fvlqd0/ht/ZvanTGFTxRu+FV+E3/f5h5g==}
+  '@pacquet/darwin-x64@0.11.1':
+    resolution: {integrity: sha512-Zq7uBkJdDihDfOicYFswF+yZSCEMCJByYH2H1Ik1cINC9HYBfBPp1x6EoVSFUUQghxVPwiaBjfDogCJEpZc2QA==}
     cpu: [x64]
     os: [darwin]
 
-  '@pacquet/linux-arm64@0.2.14':
-    resolution: {integrity: sha512-FccL0FiBnf5VPgUdvgzfcmikWGXp2M5b/OdV27tMpFEVASXe5HelDoYnxc8avMtn2nNYQfk38p2BR5C2sXXcRA==}
+  '@pacquet/linux-arm64@0.11.1':
+    resolution: {integrity: sha512-4W3mJkC8ngzF04xEHvf8TAxaOeT9jzKtNp+8GJ1L1q/F0CNsMoiVEP+gB3fDwktcPyqJKU50UWlCQA7lACbaFg==}
     cpu: [arm64]
     os: [linux]
 
-  '@pacquet/linux-x64@0.2.14':
-    resolution: {integrity: sha512-eyQ1iZZWJhtE7fSnMUEth1Om5eYkBxyh7yW8yBt1lqePwPf0yqCRkr8bzL8xCPZ5l21kI++YvvCJDIDbksCjJA==}
+  '@pacquet/linux-x64@0.11.1':
+    resolution: {integrity: sha512-BGo9N02QUx6BhEZkuT1uFkEAzfDR7yZy1Cf6Ry0sTXVie593WLiSktNPFIGd1b3QGKXpgQylsXIigA5LC/P1/g==}
     cpu: [x64]
     os: [linux]
 
-  '@pacquet/win32-arm64@0.2.14':
-    resolution: {integrity: sha512-gwvMR42hq+rUf5pDTy2F2WKmGge/RA6O+3yTB7IoqOqGiv7I7Hytz5PfHpUiuyVZsSVSKMUkzKKn+gG+mpmnuw==}
+  '@pacquet/win32-arm64@0.11.1':
+    resolution: {integrity: sha512-nDivP7M/GozAcqIJQQmgnpBAXgrQpVYuQIMhNbryNFkYYZsvHgnbbIhUpYRvosCn10XSYESNxh70wz5vAx/3WQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@pacquet/win32-x64@0.2.14':
-    resolution: {integrity: sha512-I1qNGvba9oloOABRSpCXOt+vnYXH9yMA2omeqXzLhxltNPCQj46/sAc0eSx1VakLUCacTAKieozhm3Ympjm7LQ==}
+  '@pacquet/win32-x64@0.11.1':
+    resolution: {integrity: sha512-5bl8i0jkWltwwhBmAqNDumh8uPdk1NBiHqCJfC4F+A3QZt6YQnFmszLkXu/uG1mzpO41dSUfEhQy/h4t2Y0Eaw==}
     cpu: [x64]
     os: [win32]
 
@@ -79,8 +79,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/pacquet@0.2.14':
-    resolution: {integrity: sha512-f4KcNbZbHAJy71iUI4p/SOcA7LGgcCRXx4h5SSMIi8CQIjpC1zSh3vpJcnuSsEMZB2jRJBSpF7J0YEy7hEEfHg==}
+  '@pnpm/pacquet@0.11.1':
+    resolution: {integrity: sha512-4785guig8RpbPh5HCQFeyV6jyO7F6gPs/HxbcX9c6DK2ATwF7Awc24JCddOpxWIpzgiieBWyqhAKjTdCLK9E0A==}
 
   '@pnpm/win-arm64@11.5.2':
     resolution: {integrity: sha512-+VJCDoH/pRzLXBikwjvxgAnGfQufT8EALBX8cfSmrwD40JABUZvgPtjBjde7OwEoK/XwtlH8w+ZceFV0K3/YHQ==}
@@ -159,22 +159,22 @@ packages:
 
 snapshots:
 
-  '@pacquet/darwin-arm64@0.2.14':
+  '@pacquet/darwin-arm64@0.11.1':
     optional: true
 
-  '@pacquet/darwin-x64@0.2.14':
+  '@pacquet/darwin-x64@0.11.1':
     optional: true
 
-  '@pacquet/linux-arm64@0.2.14':
+  '@pacquet/linux-arm64@0.11.1':
     optional: true
 
-  '@pacquet/linux-x64@0.2.14':
+  '@pacquet/linux-x64@0.11.1':
     optional: true
 
-  '@pacquet/win32-arm64@0.2.14':
+  '@pacquet/win32-arm64@0.11.1':
     optional: true
 
-  '@pacquet/win32-x64@0.2.14':
+  '@pacquet/win32-x64@0.11.1':
     optional: true
 
   '@pnpm/exe@11.5.2':
@@ -205,14 +205,14 @@ snapshots:
   '@pnpm/macos-arm64@11.5.2':
     optional: true
 
-  '@pnpm/pacquet@0.2.14':
+  '@pnpm/pacquet@0.11.1':
     optionalDependencies:
-      '@pacquet/darwin-arm64': 0.2.14
-      '@pacquet/darwin-x64': 0.2.14
-      '@pacquet/linux-arm64': 0.2.14
-      '@pacquet/linux-x64': 0.2.14
-      '@pacquet/win32-arm64': 0.2.14
-      '@pacquet/win32-x64': 0.2.14
+      '@pacquet/darwin-arm64': 0.11.1
+      '@pacquet/darwin-x64': 0.11.1
+      '@pacquet/linux-arm64': 0.11.1
+      '@pacquet/linux-x64': 0.11.1
+      '@pacquet/win32-arm64': 0.11.1
+      '@pacquet/win32-x64': 0.11.1
 
   '@pnpm/win-arm64@11.5.2':
     optional: true
@@ -1132,7 +1132,7 @@ importers:
         specifier: 'catalog:'
         version: 5.0.1
       node:
-        specifier: runtime:26.3.0
+        specifier: runtime:^26.3.0
         version: runtime:26.3.0
       rimraf:
         specifier: 'catalog:'
@@ -15351,7 +15351,6 @@ packages:
             - cpu: x64
               os: linux
               libc: musl
-    version: 26.3.0
     hasBin: true
 
   nopt@1.0.10:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -327,7 +327,7 @@ catalogMode: strict
 cleanupUnusedCatalogs: true
 
 configDependencies:
-  '@pnpm/pacquet': 0.2.14
+  '@pnpm/pacquet': 0.11.1
 
 enableGlobalVirtualStore: true
 


### PR DESCRIPTION
This automated PR refreshes the project's pinned versions:

- Updates the lockfile to the latest compatible versions of dependencies.
- Bumps Node.js to the latest 26.x release, propagated into the CI, release, and benchmark workflows via the meta-updater.
- Bumps pnpm to the latest release (`packageManager` and `devEngines.packageManager`).
- Bumps the `@pnpm/pacquet` config dependency to its latest release.

Created by the update-lockfile workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency versions to improve stability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->