### PR TITLE
fix(pacquet): report fresh-install prefetch downloads as fetched, not found_in_store

### DIFF
--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -20,7 +20,7 @@ use pacquet_store_dir::{
     SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, git_hosted_store_index_key,
     store_index_key,
 };
-use pacquet_tarball::{PrefetchResult, SharedNetworkFetchedKeys, prefetch_cas_paths};
+use pacquet_tarball::{PrefetchResult, SharedReportedProgressKeys, prefetch_cas_paths};
 use pipe_trait::Pipe;
 use std::{
     collections::{HashMap, HashSet},
@@ -157,15 +157,12 @@ pub struct CreateVirtualStore<'a> {
     /// Tarball downloads and CAS writes still happen for both
     /// linkers; only the slot-materialization step differs.
     pub node_linker: NodeLinker,
-    /// Cache keys whose tarball was pulled over the network earlier in
-    /// *this* install (by the fresh path's resolve-time prefetcher,
-    /// whose own progress emits are silent). A warm-batch snapshot whose
-    /// key is in this set is reported as `fetched` rather than
-    /// `found_in_store`, so a cold `pacquet install` and `pacquet
-    /// install --frozen-lockfile` report identical reused/downloaded
-    /// counts. Empty on the frozen path (no prefetcher runs). See
-    /// [`SharedNetworkFetchedKeys`].
-    pub network_fetched: &'a SharedNetworkFetchedKeys,
+    /// Cache keys whose package status (`fetched` or `found_in_store`)
+    /// has already been emitted earlier in this install. The warm batch
+    /// still emits `resolved` for those packages, but skips the second
+    /// status event so resolve-time prefetch progress is visible without
+    /// being double-counted.
+    pub progress_reported: &'a SharedReportedProgressKeys,
 }
 
 /// Error type of [`CreateVirtualStore`].
@@ -210,7 +207,7 @@ impl<'a> CreateVirtualStore<'a> {
             skipped,
             workspace_root,
             node_linker,
-            network_fetched,
+            progress_reported,
         } = self;
 
         let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
@@ -621,8 +618,8 @@ impl<'a> CreateVirtualStore<'a> {
                     .insert((*snapshot_key).clone(), std::sync::Arc::clone(maps));
             }
             // Carry the cache key alongside the warm entry so the
-            // reporter can consult `network_fetched` to decide between
-            // `fetched` and `found_in_store`.
+            // reporter can skip a duplicate package-status event when
+            // a resolve-time prefetch already emitted it.
             match cache_key.as_deref().and_then(|key| prefetched.get(key).map(|paths| (key, paths)))
             {
                 Some((key, cas_paths)) => warm.push((snapshot_key, snapshot, cas_paths, key)),
@@ -681,7 +678,7 @@ impl<'a> CreateVirtualStore<'a> {
                     emit_warm_snapshot_progress::<Reporter>(
                         &package_id,
                         requester,
-                        network_fetched.contains(*cache_key),
+                        progress_reported.contains(*cache_key),
                     );
 
                     crate::CreateVirtualDirBySnapshot {
@@ -721,7 +718,7 @@ impl<'a> CreateVirtualStore<'a> {
                 emit_warm_snapshot_progress::<Reporter>(
                     &package_id,
                     requester,
-                    network_fetched.contains(*cache_key),
+                    progress_reported.contains(*cache_key),
                 );
             }
         }
@@ -770,6 +767,7 @@ impl<'a> CreateVirtualStore<'a> {
                         store_index: store_index_ref,
                         store_index_writer: store_index_writer_ref,
                         prefetched_cas_paths: prefetched_ref,
+                        progress_reported: Some(progress_reported),
                         verified_files_cache: verified_files_cache_ref,
                         logged_methods,
                         requester,
@@ -1058,22 +1056,12 @@ fn integrity_equal(current: Option<&PackageMetadata>, wanted: Option<&PackageMet
     current_integrity == wanted_integrity
 }
 
-/// `pnpm:progress` `resolved` followed by either `fetched` or
-/// `found_in_store` for a warm-batch snapshot the install-scoped
-/// prefetch already settled. The snapshot is "already resolved" by
-/// virtue of being in the lockfile; the second event reports how its
-/// bytes got into the store.
-///
-/// `network_fetched` is `true` when the package's tarball was pulled
-/// over the network earlier in this same install — by the fresh path's
-/// resolve-time prefetcher, whose own progress emits are silent. In
-/// that case the warm batch reports `fetched` (a download), so a cold
-/// `pacquet install` and `pacquet install --frozen-lockfile` produce
-/// identical reused/downloaded counts. When `false` (the package was
-/// genuinely in the store at install start, e.g. a warm reinstall or
-/// the frozen path) the warm batch reports `found_in_store`. This
-/// mirrors pnpm's single per-package emit, which reflects whether the
-/// fetch hit the network.
+/// `pnpm:progress resolved` for a warm-batch snapshot, plus
+/// `found_in_store` when no earlier fetch path already emitted the
+/// package status. Resolve-time prefetches report `fetched` or
+/// `found_in_store` as soon as their fetch/cache-hit outcome is known;
+/// the warm batch then supplies the later `resolved` event without
+/// double-counting the package status.
 ///
 /// Pulled out of the warm-batch closure in
 /// [`CreateVirtualStore::run`] so the event-construction code is
@@ -1119,7 +1107,7 @@ fn is_fetch_side_failure(err: &InstallPackageBySnapshotError) -> bool {
 fn emit_warm_snapshot_progress<Reporter: self::Reporter>(
     package_id: &str,
     requester: &str,
-    network_fetched: bool,
+    progress_reported: bool,
 ) {
     Reporter::emit(&LogEvent::Progress(ProgressLog {
         level: LogLevel::Debug,
@@ -1128,18 +1116,15 @@ fn emit_warm_snapshot_progress<Reporter: self::Reporter>(
             requester: requester.to_owned(),
         },
     }));
-    let message = if network_fetched {
-        ProgressMessage::Fetched {
-            package_id: package_id.to_owned(),
-            requester: requester.to_owned(),
-        }
-    } else {
-        ProgressMessage::FoundInStore {
-            package_id: package_id.to_owned(),
-            requester: requester.to_owned(),
-        }
-    };
-    Reporter::emit(&LogEvent::Progress(ProgressLog { level: LogLevel::Debug, message }));
+    if !progress_reported {
+        Reporter::emit(&LogEvent::Progress(ProgressLog {
+            level: LogLevel::Debug,
+            message: ProgressMessage::FoundInStore {
+                package_id: package_id.to_owned(),
+                requester: requester.to_owned(),
+            },
+        }));
+    }
 }
 
 #[cfg(test)]

--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -20,7 +20,7 @@ use pacquet_store_dir::{
     SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, git_hosted_store_index_key,
     store_index_key,
 };
-use pacquet_tarball::{PrefetchResult, prefetch_cas_paths};
+use pacquet_tarball::{PrefetchResult, SharedNetworkFetchedKeys, prefetch_cas_paths};
 use pipe_trait::Pipe;
 use std::{
     collections::{HashMap, HashSet},
@@ -157,6 +157,15 @@ pub struct CreateVirtualStore<'a> {
     /// Tarball downloads and CAS writes still happen for both
     /// linkers; only the slot-materialization step differs.
     pub node_linker: NodeLinker,
+    /// Cache keys whose tarball was pulled over the network earlier in
+    /// *this* install (by the fresh path's resolve-time prefetcher,
+    /// whose own progress emits are silent). A warm-batch snapshot whose
+    /// key is in this set is reported as `fetched` rather than
+    /// `found_in_store`, so a cold `pacquet install` and `pacquet
+    /// install --frozen-lockfile` report identical reused/downloaded
+    /// counts. Empty on the frozen path (no prefetcher runs). See
+    /// [`SharedNetworkFetchedKeys`].
+    pub network_fetched: &'a SharedNetworkFetchedKeys,
 }
 
 /// Error type of [`CreateVirtualStore`].
@@ -201,6 +210,7 @@ impl<'a> CreateVirtualStore<'a> {
             skipped,
             workspace_root,
             node_linker,
+            network_fetched,
         } = self;
 
         let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
@@ -610,8 +620,12 @@ impl<'a> CreateVirtualStore<'a> {
                 side_effects_maps_by_snapshot
                     .insert((*snapshot_key).clone(), std::sync::Arc::clone(maps));
             }
-            match cache_key.as_deref().and_then(|key| prefetched.get(key)) {
-                Some(cas_paths) => warm.push((snapshot_key, snapshot, cas_paths)),
+            // Carry the cache key alongside the warm entry so the
+            // reporter can consult `network_fetched` to decide between
+            // `fetched` and `found_in_store`.
+            match cache_key.as_deref().and_then(|key| prefetched.get(key).map(|paths| (key, paths)))
+            {
+                Some((key, cas_paths)) => warm.push((snapshot_key, snapshot, cas_paths, key)),
                 None => cold.push((snapshot_key, snapshot)),
             }
         }
@@ -624,7 +638,7 @@ impl<'a> CreateVirtualStore<'a> {
         // the cold-batch fetch finishes.
         let mut cas_paths_by_pkg_id: Option<CasPathsByPkgId> = is_hoisted.then(|| {
             let mut map = CasPathsByPkgId::with_capacity(warm.len());
-            for (snapshot_key, _snapshot, cas_paths) in &warm {
+            for (snapshot_key, _snapshot, cas_paths, _cache_key) in &warm {
                 // Mirrors upstream's `getPkgIdWithPatchHash` — strip
                 // the peer-graph suffix but keep `(patch_hash=...)` so
                 // patched packages share one CAS-paths entry across
@@ -662,9 +676,13 @@ impl<'a> CreateVirtualStore<'a> {
             // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/index.ts#L411-L425>
             // which routes all link work into `linkHoistedModules`.
             let warm_work = move || {
-                warm.par_iter().try_for_each(|(snapshot_key, snapshot, cas_paths)| {
+                warm.par_iter().try_for_each(|(snapshot_key, snapshot, cas_paths, cache_key)| {
                     let package_id = snapshot_key.without_peer().to_string();
-                    emit_warm_snapshot_progress::<Reporter>(&package_id, requester);
+                    emit_warm_snapshot_progress::<Reporter>(
+                        &package_id,
+                        requester,
+                        network_fetched.contains(*cache_key),
+                    );
 
                     crate::CreateVirtualDirBySnapshot {
                         layout,
@@ -698,9 +716,13 @@ impl<'a> CreateVirtualStore<'a> {
             // `pnpm:progress imported`-style updates render the warm
             // hits — the link work just happens later, in
             // `link_hoisted_modules`.
-            for (snapshot_key, _, _) in &warm {
+            for (snapshot_key, _, _, cache_key) in &warm {
                 let package_id = snapshot_key.without_peer().to_string();
-                emit_warm_snapshot_progress::<Reporter>(&package_id, requester);
+                emit_warm_snapshot_progress::<Reporter>(
+                    &package_id,
+                    requester,
+                    network_fetched.contains(*cache_key),
+                );
             }
         }
 
@@ -1036,13 +1058,22 @@ fn integrity_equal(current: Option<&PackageMetadata>, wanted: Option<&PackageMet
     current_integrity == wanted_integrity
 }
 
-/// `pnpm:progress` `resolved` + `found_in_store` for a frozen-lockfile
-/// snapshot the install-scoped prefetch already settled. Frozen-
-/// lockfile snapshots are "already resolved" by virtue of being in
-/// the lockfile, and "found in store" by virtue of the prefetch
-/// covering them — emit both so the consumer sees the full resolved
-/// → found_in_store → imported sequence even when the cold path is
-/// skipped.
+/// `pnpm:progress` `resolved` followed by either `fetched` or
+/// `found_in_store` for a warm-batch snapshot the install-scoped
+/// prefetch already settled. The snapshot is "already resolved" by
+/// virtue of being in the lockfile; the second event reports how its
+/// bytes got into the store.
+///
+/// `network_fetched` is `true` when the package's tarball was pulled
+/// over the network earlier in this same install — by the fresh path's
+/// resolve-time prefetcher, whose own progress emits are silent. In
+/// that case the warm batch reports `fetched` (a download), so a cold
+/// `pacquet install` and `pacquet install --frozen-lockfile` produce
+/// identical reused/downloaded counts. When `false` (the package was
+/// genuinely in the store at install start, e.g. a warm reinstall or
+/// the frozen path) the warm batch reports `found_in_store`. This
+/// mirrors pnpm's single per-package emit, which reflects whether the
+/// fetch hit the network.
 ///
 /// Pulled out of the warm-batch closure in
 /// [`CreateVirtualStore::run`] so the event-construction code is
@@ -1085,7 +1116,11 @@ fn is_fetch_side_failure(err: &InstallPackageBySnapshotError) -> bool {
     )
 }
 
-fn emit_warm_snapshot_progress<Reporter: self::Reporter>(package_id: &str, requester: &str) {
+fn emit_warm_snapshot_progress<Reporter: self::Reporter>(
+    package_id: &str,
+    requester: &str,
+    network_fetched: bool,
+) {
     Reporter::emit(&LogEvent::Progress(ProgressLog {
         level: LogLevel::Debug,
         message: ProgressMessage::Resolved {
@@ -1093,13 +1128,18 @@ fn emit_warm_snapshot_progress<Reporter: self::Reporter>(package_id: &str, reque
             requester: requester.to_owned(),
         },
     }));
-    Reporter::emit(&LogEvent::Progress(ProgressLog {
-        level: LogLevel::Debug,
-        message: ProgressMessage::FoundInStore {
+    let message = if network_fetched {
+        ProgressMessage::Fetched {
             package_id: package_id.to_owned(),
             requester: requester.to_owned(),
-        },
-    }));
+        }
+    } else {
+        ProgressMessage::FoundInStore {
+            package_id: package_id.to_owned(),
+            requester: requester.to_owned(),
+        }
+    };
+    Reporter::emit(&LogEvent::Progress(ProgressLog { level: LogLevel::Debug, message }));
 }
 
 #[cfg(test)]

--- a/pacquet/crates/package-manager/src/create_virtual_store/tests.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store/tests.rs
@@ -39,13 +39,13 @@ fn snapshot_with_dep(child: &str, ref_str: &str) -> SnapshotEntry {
     }
 }
 
-/// `emit_warm_snapshot_progress` fires `resolved` then
-/// `found_in_store` in that order for one (package_id, requester)
-/// pair. Both events carry the same identifiers — pnpm's per-package
-/// counter relies on the pair to pin the tick to the right package
-/// row.
+/// `emit_warm_snapshot_progress` fires `resolved` then, when the
+/// package was *not* network-fetched this install, `found_in_store` in
+/// that order for one (package_id, requester) pair. Both events carry
+/// the same identifiers — pnpm's per-package counter relies on the pair
+/// to pin the tick to the right package row.
 #[test]
-fn emits_resolved_then_found_in_store_with_matching_identifiers() {
+fn emits_resolved_then_found_in_store_when_not_network_fetched() {
     static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
 
     struct RecordingReporter;
@@ -56,7 +56,7 @@ fn emits_resolved_then_found_in_store_with_matching_identifiers() {
     }
 
     EVENTS.lock().unwrap().clear();
-    emit_warm_snapshot_progress::<RecordingReporter>("react@18.0.0", "/proj");
+    emit_warm_snapshot_progress::<RecordingReporter>("react@18.0.0", "/proj", false);
 
     let captured = EVENTS.lock().unwrap();
     assert!(
@@ -76,6 +76,47 @@ fn emits_resolved_then_found_in_store_with_matching_identifiers() {
             ),
         ),
         "warm-snapshot pair must be (Resolved, FoundInStore) with matching identifiers; got {captured:?}",
+    );
+}
+
+/// When the package *was* network-fetched earlier this install (the
+/// fresh path's silent resolve-time prefetcher pulled it), the second
+/// event is `fetched`, not `found_in_store` — so a cold `pacquet
+/// install` reports its prefetch downloads as downloads, matching
+/// `--frozen-lockfile`. Regression guard for
+/// <https://github.com/pnpm/pnpm/issues/12235>.
+#[test]
+fn emits_resolved_then_fetched_when_network_fetched() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    EVENTS.lock().unwrap().clear();
+    emit_warm_snapshot_progress::<RecordingReporter>("react@18.0.0", "/proj", true);
+
+    let captured = EVENTS.lock().unwrap();
+    assert!(
+        matches!(
+            captured.as_slice(),
+            [
+                LogEvent::Progress(r),
+                LogEvent::Progress(f),
+            ] if matches!(
+                &r.message,
+                ProgressMessage::Resolved { package_id, requester }
+                    if package_id == "react@18.0.0" && requester == "/proj"
+            ) && matches!(
+                &f.message,
+                ProgressMessage::Fetched { package_id, requester }
+                    if package_id == "react@18.0.0" && requester == "/proj",
+            ),
+        ),
+        "network-fetched warm snapshot must report (Resolved, Fetched); got {captured:?}",
     );
 }
 

--- a/pacquet/crates/package-manager/src/create_virtual_store/tests.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store/tests.rs
@@ -39,13 +39,13 @@ fn snapshot_with_dep(child: &str, ref_str: &str) -> SnapshotEntry {
     }
 }
 
-/// `emit_warm_snapshot_progress` fires `resolved` then, when the
-/// package was *not* network-fetched this install, `found_in_store` in
-/// that order for one (package_id, requester) pair. Both events carry
-/// the same identifiers — pnpm's per-package counter relies on the pair
-/// to pin the tick to the right package row.
+/// `emit_warm_snapshot_progress` fires `resolved` then
+/// `found_in_store` when no earlier fetch path already emitted the
+/// package status. Both events carry the same identifiers — pnpm's
+/// per-package counter relies on the pair to pin the tick to the right
+/// package row.
 #[test]
-fn emits_resolved_then_found_in_store_when_not_network_fetched() {
+fn emits_resolved_then_found_in_store_when_not_progress_reported() {
     static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
 
     struct RecordingReporter;
@@ -79,14 +79,12 @@ fn emits_resolved_then_found_in_store_when_not_network_fetched() {
     );
 }
 
-/// When the package *was* network-fetched earlier this install (the
-/// fresh path's silent resolve-time prefetcher pulled it), the second
-/// event is `fetched`, not `found_in_store` — so a cold `pacquet
-/// install` reports its prefetch downloads as downloads, matching
-/// `--frozen-lockfile`. Regression guard for
+/// When an earlier fetch path already emitted `fetched` or
+/// `found_in_store`, the warm batch emits only `resolved` so the
+/// package status is not double-counted. Regression guard for
 /// <https://github.com/pnpm/pnpm/issues/12235>.
 #[test]
-fn emits_resolved_then_fetched_when_network_fetched() {
+fn emits_only_resolved_when_progress_reported() {
     static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
 
     struct RecordingReporter;
@@ -103,20 +101,13 @@ fn emits_resolved_then_fetched_when_network_fetched() {
     assert!(
         matches!(
             captured.as_slice(),
-            [
-                LogEvent::Progress(r),
-                LogEvent::Progress(f),
-            ] if matches!(
+            [LogEvent::Progress(r)] if matches!(
                 &r.message,
                 ProgressMessage::Resolved { package_id, requester }
                     if package_id == "react@18.0.0" && requester == "/proj"
-            ) && matches!(
-                &f.message,
-                ProgressMessage::Fetched { package_id, requester }
-                    if package_id == "react@18.0.0" && requester == "/proj",
             ),
         ),
-        "network-fetched warm snapshot must report (Resolved, Fetched); got {captured:?}",
+        "already-reported warm snapshot must report only Resolved; got {captured:?}",
     );
 }
 

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -26,6 +26,7 @@ use pacquet_patching::{
 };
 use pacquet_reporter::{IgnoredScriptsLog, LogEvent, LogLevel, Reporter, Stage, StageLog};
 use pacquet_store_dir::StoreIndexWriter;
+use pacquet_tarball::SharedNetworkFetchedKeys;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     ffi::OsStr,
@@ -575,6 +576,13 @@ where
             Some(&allow_build_policy),
         );
 
+        // The frozen path runs no resolve-time prefetcher, so no package
+        // is silently network-fetched before the warm batch reports it:
+        // cold-batch downloads emit `fetched` directly, and warm-batch
+        // packages were genuinely in the store at install start. An empty
+        // set leaves every warm package reported as `found_in_store`.
+        let network_fetched = SharedNetworkFetchedKeys::default();
+
         let CreateVirtualStoreOutput {
             package_manifests,
             side_effects_maps_by_snapshot,
@@ -595,6 +603,7 @@ where
             skipped: &skipped,
             workspace_root,
             node_linker,
+            network_fetched: &network_fetched,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -26,7 +26,7 @@ use pacquet_patching::{
 };
 use pacquet_reporter::{IgnoredScriptsLog, LogEvent, LogLevel, Reporter, Stage, StageLog};
 use pacquet_store_dir::StoreIndexWriter;
-use pacquet_tarball::SharedNetworkFetchedKeys;
+use pacquet_tarball::SharedReportedProgressKeys;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     ffi::OsStr,
@@ -576,12 +576,10 @@ where
             Some(&allow_build_policy),
         );
 
-        // The frozen path runs no resolve-time prefetcher, so no package
-        // is silently network-fetched before the warm batch reports it:
-        // cold-batch downloads emit `fetched` directly, and warm-batch
-        // packages were genuinely in the store at install start. An empty
-        // set leaves every warm package reported as `found_in_store`.
-        let network_fetched = SharedNetworkFetchedKeys::default();
+        // The frozen path runs no resolve-time prefetcher, so the warm
+        // batch owns package-status progress for store hits. An empty set
+        // leaves every warm package reported as `found_in_store`.
+        let progress_reported = SharedReportedProgressKeys::default();
 
         let CreateVirtualStoreOutput {
             package_manifests,
@@ -603,7 +601,7 @@ where
             skipped: &skipped,
             workspace_root,
             node_linker,
-            network_fetched: &network_fetched,
+            progress_reported: &progress_reported,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
@@ -21,7 +21,7 @@ use pacquet_store_dir::{
 };
 use pacquet_tarball::{
     DownloadTarballToStore, DownloadZipArchiveToStore, IgnoreEntryFilter, PrefetchedCasPaths,
-    TarballError,
+    SharedReportedProgressKeys, TarballError,
 };
 use pipe_trait::Pipe;
 use std::{
@@ -49,6 +49,11 @@ pub struct InstallPackageBySnapshot<'a> {
     /// Install-scoped batched cache lookup result. See
     /// [`pacquet_tarball::prefetch_cas_paths`].
     pub prefetched_cas_paths: Option<&'a PrefetchedCasPaths>,
+    /// Install-scoped package-status progress dedupe. Shared with the
+    /// resolve-time prefetcher on the fresh path so the cold fallback
+    /// does not double-count a package whose early prefetch already
+    /// emitted `fetched` or `found_in_store`.
+    pub progress_reported: Option<&'a SharedReportedProgressKeys>,
     /// Install-scoped `verifiedFilesCache` shared across every
     /// per-snapshot fetch. See `DownloadTarballToStore::verified_files_cache`
     /// for the rationale.
@@ -218,6 +223,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             store_index,
             store_index_writer,
             prefetched_cas_paths,
+            progress_reported,
             verified_files_cache,
             logged_methods,
             requester,
@@ -274,10 +280,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
                     auth_headers: &config.auth_headers,
                     ignore_file_pattern: None,
                     offline: config.offline,
-                    // Cold-batch download: emits `fetched` directly on
-                    // the install reporter, so no network-fetched
-                    // tracking is needed (only the silent prefetcher's).
-                    network_fetched: None,
+                    progress_reported: progress_reported.cloned(),
                 }
                 .run_without_mem_cache::<Reporter>()
                 .await
@@ -702,7 +705,7 @@ async fn fetch_binary_resolution_to_cas<Reporter: self::Reporter>(
             offline: config.offline,
             // Cold-batch binary tarball download: emits `fetched`
             // directly, so no network-fetched tracking is needed.
-            network_fetched: None,
+            progress_reported: None,
         }
         .run_without_mem_cache::<Reporter>()
         .await

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
@@ -274,6 +274,10 @@ impl<'a> InstallPackageBySnapshot<'a> {
                     auth_headers: &config.auth_headers,
                     ignore_file_pattern: None,
                     offline: config.offline,
+                    // Cold-batch download: emits `fetched` directly on
+                    // the install reporter, so no network-fetched
+                    // tracking is needed (only the silent prefetcher's).
+                    network_fetched: None,
                 }
                 .run_without_mem_cache::<Reporter>()
                 .await
@@ -696,6 +700,9 @@ async fn fetch_binary_resolution_to_cas<Reporter: self::Reporter>(
             auth_headers: &config.auth_headers,
             ignore_file_pattern,
             offline: config.offline,
+            // Cold-batch binary tarball download: emits `fetched`
+            // directly, so no network-fetched tracking is needed.
+            network_fetched: None,
         }
         .run_without_mem_cache::<Reporter>()
         .await

--- a/pacquet/crates/package-manager/src/install_package_from_registry.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry.rs
@@ -180,10 +180,10 @@ impl<'a> InstallPackageFromRegistry<'a> {
                 auth_headers: &config.auth_headers,
                 ignore_file_pattern: None,
                 offline: config.offline,
-                // The cold-batch download emits `fetched` directly on
-                // the install reporter, so it needs no network-fetched
-                // tracking — only the silent resolve-time prefetcher does.
-                network_fetched: None,
+                // This recursive install path owns its package-status
+                // progress directly; no resolve-time prefetch shares a
+                // dedupe set with it.
+                progress_reported: None,
             }
             .run_with_mem_cache::<Reporter>(tarball_mem_cache)
             .await

--- a/pacquet/crates/package-manager/src/install_package_from_registry.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry.rs
@@ -180,6 +180,10 @@ impl<'a> InstallPackageFromRegistry<'a> {
                 auth_headers: &config.auth_headers,
                 ignore_file_pattern: None,
                 offline: config.offline,
+                // The cold-batch download emits `fetched` directly on
+                // the install reporter, so it needs no network-fetched
+                // tracking — only the silent resolve-time prefetcher does.
+                network_fetched: None,
             }
             .run_with_mem_cache::<Reporter>(tarball_mem_cache)
             .await

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -37,7 +37,7 @@ use pacquet_resolving_resolver_base::{
 };
 use pacquet_resolving_tarball_resolver::{TarballFetchContext, TarballResolver};
 use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, store_index_key};
-use pacquet_tarball::MemCache;
+use pacquet_tarball::{MemCache, SharedNetworkFetchedKeys};
 use std::{
     collections::{BTreeMap, HashMap},
     path::Path,
@@ -536,6 +536,14 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
 
         let verified_files_cache = SharedVerifiedFilesCache::default();
 
+        // Records the cache key of every package the resolve-time
+        // prefetcher pulls over the network this install. The prefetcher
+        // downloads through a silent reporter, so without this the
+        // warm-batch reporter would label those downloads
+        // `found_in_store`. `CreateVirtualStore` consults it to report
+        // them as `fetched` instead — see [`SharedNetworkFetchedKeys`].
+        let network_fetched = SharedNetworkFetchedKeys::default();
+
         let npm_resolver: Arc<dyn Resolver> = Arc::new(NpmResolver {
             registries,
             named_registries: merged_named_registries.clone(),
@@ -691,6 +699,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                     verified_files_cache: &verified_files_cache,
                     config,
                     requester,
+                    network_fetched: &network_fetched,
                 },
             ))
         };
@@ -1266,6 +1275,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             skipped: &skipped,
             workspace_root: lockfile_dir,
             node_linker,
+            network_fetched: &network_fetched,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -37,7 +37,7 @@ use pacquet_resolving_resolver_base::{
 };
 use pacquet_resolving_tarball_resolver::{TarballFetchContext, TarballResolver};
 use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, store_index_key};
-use pacquet_tarball::{MemCache, SharedNetworkFetchedKeys};
+use pacquet_tarball::{MemCache, SharedReportedProgressKeys};
 use std::{
     collections::{BTreeMap, HashMap},
     path::Path,
@@ -536,13 +536,11 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
 
         let verified_files_cache = SharedVerifiedFilesCache::default();
 
-        // Records the cache key of every package the resolve-time
-        // prefetcher pulls over the network this install. The prefetcher
-        // downloads through a silent reporter, so without this the
-        // warm-batch reporter would label those downloads
-        // `found_in_store`. `CreateVirtualStore` consults it to report
-        // them as `fetched` instead — see [`SharedNetworkFetchedKeys`].
-        let network_fetched = SharedNetworkFetchedKeys::default();
+        // Records package-status progress emitted by resolve-time
+        // prefetches. `CreateVirtualStore` still emits `resolved` later,
+        // but skips duplicate `fetched` / `found_in_store` statuses for
+        // keys already reported here.
+        let progress_reported = SharedReportedProgressKeys::default();
 
         let npm_resolver: Arc<dyn Resolver> = Arc::new(NpmResolver {
             registries,
@@ -699,7 +697,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                     verified_files_cache: &verified_files_cache,
                     config,
                     requester,
-                    network_fetched: &network_fetched,
+                    progress_reported: &progress_reported,
                 },
             ))
         };
@@ -1275,7 +1273,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             skipped: &skipped,
             workspace_root: lockfile_dir,
             node_linker,
-            network_fetched: &network_fetched,
+            progress_reported: &progress_reported,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/package-manager/src/prefetching_resolver.rs
+++ b/pacquet/crates/package-manager/src/prefetching_resolver.rs
@@ -30,7 +30,7 @@ use crate::{
 use dashmap::DashSet;
 use pacquet_config::Config;
 use pacquet_network::{AuthHeaders, ThrottledClient};
-use pacquet_reporter::{Reporter, SilentReporter};
+use pacquet_reporter::Reporter;
 use pacquet_resolving_resolver_base::{
     LatestQuery, ResolveFuture, ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver,
     WantedDependency,
@@ -38,7 +38,7 @@ use pacquet_resolving_resolver_base::{
 use pacquet_store_dir::{
     SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir, StoreIndexWriter,
 };
-use pacquet_tarball::{DownloadTarballToStore, MemCache, RetryOpts, SharedNetworkFetchedKeys};
+use pacquet_tarball::{DownloadTarballToStore, MemCache, RetryOpts, SharedReportedProgressKeys};
 use std::{marker::PhantomData, sync::Arc};
 
 /// Borrowed-data bag handed to [`PrefetchingResolver::new`]. Everything
@@ -56,13 +56,11 @@ pub struct PrefetchContext<'a> {
     pub verified_files_cache: &'a SharedVerifiedFilesCache,
     pub config: &'static Config,
     pub requester: &'a str,
-    /// Install-scoped set the background download records its cache key
-    /// into when its bytes come over the network. Lets the install
-    /// pass's warm-batch reporter label a package downloaded this
-    /// install as `fetched` rather than `found_in_store`, since the
-    /// prefetch's own emits route through a [`SilentReporter`]. See
-    /// [`SharedNetworkFetchedKeys`].
-    pub network_fetched: &'a SharedNetworkFetchedKeys,
+    /// Install-scoped set the background download records when it emits
+    /// a package-status progress event. The later warm/cold install pass
+    /// consults the set so prefetch progress is visible immediately
+    /// without being counted again.
+    pub progress_reported: &'a SharedReportedProgressKeys,
 }
 
 /// Owned, `'static`-friendly clones of [`PrefetchContext`] stored on
@@ -82,7 +80,7 @@ struct OwnedFetchCtx {
     requester: Arc<str>,
     offline: bool,
     verify_store_integrity: bool,
-    network_fetched: SharedNetworkFetchedKeys,
+    progress_reported: SharedReportedProgressKeys,
     /// Set of URLs that already had a prefetch task spawned, used as
     /// an atomic check-and-claim gate so concurrent resolves for the
     /// same tarball can't both pass a non-atomic `MemCache` lookup and
@@ -127,7 +125,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
             verified_files_cache,
             config,
             requester,
-            network_fetched,
+            progress_reported,
         } = prefetch_ctx;
         let ctx = OwnedFetchCtx {
             http_client: Arc::clone(http_client),
@@ -141,7 +139,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
             requester: Arc::<str>::from(requester),
             offline: config.offline,
             verify_store_integrity: config.verify_store_integrity,
-            network_fetched: SharedNetworkFetchedKeys::clone(network_fetched),
+            progress_reported: SharedReportedProgressKeys::clone(progress_reported),
             spawned_urls: Arc::new(DashSet::new()),
         };
         PrefetchingResolver { inner, ctx, _phantom: PhantomData }
@@ -212,31 +210,17 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
         let requester = Arc::clone(&self.ctx.requester);
         let offline = self.ctx.offline;
         let verify_store_integrity = self.ctx.verify_store_integrity;
-        let network_fetched = SharedNetworkFetchedKeys::clone(&self.ctx.network_fetched);
+        let progress_reported = SharedReportedProgressKeys::clone(&self.ctx.progress_reported);
 
         tokio::spawn(async move {
-            // Route the prefetch download through `SilentReporter`, not
-            // the install's reporter. `DownloadTarballToStore` emits
-            // `pnpm:progress fetched` / `found_in_store` internally;
-            // emitting those from this background task would race ahead
-            // of the install pass's own `resolved` event for the same
-            // package, breaking the `resolved → fetched/found_in_store
-            // → imported` order pnpm's reporter consumers (notably
-            // `@pnpm/cli.default-reporter`) depend on. Mirrors pnpm's
-            // `packageRequester.requestPackage` shape: the `fetching`
-            // promise runs early but the per-event emit is driven by
-            // the install pass.
-            //
-            // On the fresh phased path the install pass reports each
-            // package through `CreateVirtualStore`'s warm batch (which
-            // reads the freshly-populated store index), not through a
-            // second `run_with_mem_cache` call. That warm batch can't
-            // tell a tarball this task just downloaded from one that
-            // was already in the store — both look like store hits by
-            // the time it runs. So pass `network_fetched`: this task
-            // records the cache key when its fetch hits the network,
-            // and the warm batch consults the set to report `fetched`
-            // rather than `found_in_store`. See [`SharedNetworkFetchedKeys`].
+            // Report prefetch progress through the install reporter as
+            // soon as the fetch/cache-hit outcome is known. pnpm can
+            // likewise start package fetching before the dependency
+            // resolver emits `resolved`; the default reporter counts
+            // progress events independently. The shared
+            // `progress_reported` set lets the later warm/cold install
+            // pass skip a duplicate package-status event for this cache
+            // key while still emitting `resolved`.
             //
             // Result is intentionally discarded — the `MemCache`
             // carries success / failure state to the install path.
@@ -257,9 +241,9 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
                 auth_headers: &auth_headers,
                 ignore_file_pattern: None,
                 offline,
-                network_fetched: Some(network_fetched),
+                progress_reported: Some(progress_reported),
             }
-            .run_with_mem_cache::<SilentReporter>(&mem_cache)
+            .run_with_mem_cache::<Reporter>(&mem_cache)
             .await;
         });
     }

--- a/pacquet/crates/package-manager/src/prefetching_resolver.rs
+++ b/pacquet/crates/package-manager/src/prefetching_resolver.rs
@@ -215,24 +215,28 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
         let network_fetched = SharedNetworkFetchedKeys::clone(&self.ctx.network_fetched);
 
         tokio::spawn(async move {
-            // Route the prefetch download through `SilentReporter`,
-            // not the install's reporter. `DownloadTarballToStore`
-            // emits `pnpm:progress fetched` / `found_in_store`
-            // internally; if the install's reporter received those
-            // from the prefetch task, they would land *before*
-            // `install_subtree::install_package_from_registry` emits
-            // the `resolved` event for the same package, breaking
-            // the documented `resolved → fetched/found_in_store →
-            // imported` order pnpm's reporter consumers (notably
-            // `@pnpm/cli.default-reporter`) depend on. The install
-            // pass's own `run_with_mem_cache` call still uses the
-            // real `Reporter` and emits the events in the right
-            // order — the second call short-circuits via `MemCache`
-            // but its `emit_progress_found_in_store` / `emit_*`
-            // path runs uniformly. Mirrors pnpm's
-            // `packageRequester.requestPackage` shape: the
-            // `fetching` promise runs early but the per-event emit
-            // is driven by the install pass that `await`s it.
+            // Route the prefetch download through `SilentReporter`, not
+            // the install's reporter. `DownloadTarballToStore` emits
+            // `pnpm:progress fetched` / `found_in_store` internally;
+            // emitting those from this background task would race ahead
+            // of the install pass's own `resolved` event for the same
+            // package, breaking the `resolved → fetched/found_in_store
+            // → imported` order pnpm's reporter consumers (notably
+            // `@pnpm/cli.default-reporter`) depend on. Mirrors pnpm's
+            // `packageRequester.requestPackage` shape: the `fetching`
+            // promise runs early but the per-event emit is driven by
+            // the install pass.
+            //
+            // On the fresh phased path the install pass reports each
+            // package through `CreateVirtualStore`'s warm batch (which
+            // reads the freshly-populated store index), not through a
+            // second `run_with_mem_cache` call. That warm batch can't
+            // tell a tarball this task just downloaded from one that
+            // was already in the store — both look like store hits by
+            // the time it runs. So pass `network_fetched`: this task
+            // records the cache key when its fetch hits the network,
+            // and the warm batch consults the set to report `fetched`
+            // rather than `found_in_store`. See [`SharedNetworkFetchedKeys`].
             //
             // Result is intentionally discarded — the `MemCache`
             // carries success / failure state to the install path.

--- a/pacquet/crates/package-manager/src/prefetching_resolver.rs
+++ b/pacquet/crates/package-manager/src/prefetching_resolver.rs
@@ -38,7 +38,7 @@ use pacquet_resolving_resolver_base::{
 use pacquet_store_dir::{
     SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir, StoreIndexWriter,
 };
-use pacquet_tarball::{DownloadTarballToStore, MemCache, RetryOpts};
+use pacquet_tarball::{DownloadTarballToStore, MemCache, RetryOpts, SharedNetworkFetchedKeys};
 use std::{marker::PhantomData, sync::Arc};
 
 /// Borrowed-data bag handed to [`PrefetchingResolver::new`]. Everything
@@ -56,6 +56,13 @@ pub struct PrefetchContext<'a> {
     pub verified_files_cache: &'a SharedVerifiedFilesCache,
     pub config: &'static Config,
     pub requester: &'a str,
+    /// Install-scoped set the background download records its cache key
+    /// into when its bytes come over the network. Lets the install
+    /// pass's warm-batch reporter label a package downloaded this
+    /// install as `fetched` rather than `found_in_store`, since the
+    /// prefetch's own emits route through a [`SilentReporter`]. See
+    /// [`SharedNetworkFetchedKeys`].
+    pub network_fetched: &'a SharedNetworkFetchedKeys,
 }
 
 /// Owned, `'static`-friendly clones of [`PrefetchContext`] stored on
@@ -75,6 +82,7 @@ struct OwnedFetchCtx {
     requester: Arc<str>,
     offline: bool,
     verify_store_integrity: bool,
+    network_fetched: SharedNetworkFetchedKeys,
     /// Set of URLs that already had a prefetch task spawned, used as
     /// an atomic check-and-claim gate so concurrent resolves for the
     /// same tarball can't both pass a non-atomic `MemCache` lookup and
@@ -119,6 +127,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
             verified_files_cache,
             config,
             requester,
+            network_fetched,
         } = prefetch_ctx;
         let ctx = OwnedFetchCtx {
             http_client: Arc::clone(http_client),
@@ -132,6 +141,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
             requester: Arc::<str>::from(requester),
             offline: config.offline,
             verify_store_integrity: config.verify_store_integrity,
+            network_fetched: SharedNetworkFetchedKeys::clone(network_fetched),
             spawned_urls: Arc::new(DashSet::new()),
         };
         PrefetchingResolver { inner, ctx, _phantom: PhantomData }
@@ -202,6 +212,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
         let requester = Arc::clone(&self.ctx.requester);
         let offline = self.ctx.offline;
         let verify_store_integrity = self.ctx.verify_store_integrity;
+        let network_fetched = SharedNetworkFetchedKeys::clone(&self.ctx.network_fetched);
 
         tokio::spawn(async move {
             // Route the prefetch download through `SilentReporter`,
@@ -242,6 +253,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
                 auth_headers: &auth_headers,
                 ignore_file_pattern: None,
                 offline,
+                network_fetched: Some(network_fetched),
             }
             .run_with_mem_cache::<SilentReporter>(&mem_cache)
             .await;

--- a/pacquet/crates/tarball/src/lib.rs
+++ b/pacquet/crates/tarball/src/lib.rs
@@ -1835,21 +1835,20 @@ impl<'a> DownloadTarballToStore<'a> {
         // without re-checking the prefetched map. Matches what the
         // normal path does with the result of
         // [`Self::run_without_mem_cache`].
-        if let Some(prefetched) = prefetched_cas_paths {
-            if let Some(cas_paths) = prefetched.get(&cache_key) {
-                tracing::info!(
-                    target: "pacquet::download",
-                    ?package_url,
-                    ?package_id,
-                    "Reusing prefetched CAFS entry — skipping download (warm-cache fast path)",
-                );
-                emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
-                let cas_paths = Arc::clone(cas_paths);
-                let cache_lock =
-                    Arc::new(RwLock::new(CacheValue::Available(Arc::clone(&cas_paths))));
-                mem_cache.insert(package_url.to_string(), cache_lock);
-                return Ok(cas_paths);
-            }
+        if let Some(prefetched) = prefetched_cas_paths
+            && let Some(cas_paths) = prefetched.get(&cache_key)
+        {
+            tracing::info!(
+                target: "pacquet::download",
+                ?package_url,
+                ?package_id,
+                "Reusing prefetched CAFS entry — skipping download (warm-cache fast path)",
+            );
+            emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
+            let cas_paths = Arc::clone(cas_paths);
+            let cache_lock = Arc::new(RwLock::new(CacheValue::Available(Arc::clone(&cas_paths))));
+            mem_cache.insert(package_url.to_string(), cache_lock);
+            return Ok(cas_paths);
         }
 
         // QUESTION: I see no copying from existing store_dir, is there such mechanism?

--- a/pacquet/crates/tarball/src/lib.rs
+++ b/pacquet/crates/tarball/src/lib.rs
@@ -274,26 +274,21 @@ pub enum CacheValue {
 pub type MemCache = DashMap<String, Arc<RwLock<CacheValue>>>;
 
 /// Install-scoped set of store-index cache keys
-/// (`store_index_key(integrity, pkg_id)`) whose tarball bytes were
-/// pulled over the network during *this* install — i.e. the package was
-/// not already in the store when the install began.
+/// (`store_index_key(integrity, pkg_id)`) whose package status
+/// (`fetched` or `found_in_store`) has already been emitted during this
+/// install.
 ///
-/// [`DownloadTarballToStore::run_without_mem_cache`] inserts a key the
-/// moment its network fetch succeeds. The resolve-time prefetcher
-/// downloads through a [`pacquet_reporter::SilentReporter`], so its
-/// `pnpm:progress fetched` emits are discarded; by the time the install
-/// pass reports a freshly-downloaded package the store already holds it,
-/// which would otherwise label every download `found_in_store`. The
-/// reporter consults this set so a package fetched this install is
-/// reported as `fetched` — matching the cold-batch / frozen-lockfile
-/// path and pnpm's single per-package emit, which reflects whether the
-/// fetch hit the network. See <https://github.com/pnpm/pnpm/issues/12235>.
-pub type NetworkFetchedKeys = DashSet<String>;
+/// The resolve-time prefetcher emits download/cache-hit progress as soon
+/// as it knows the outcome, then records the key here. The later
+/// virtual-store warm batch still emits `resolved`, but skips the second
+/// package status for recorded keys, so progress is timely without
+/// double-counting. See <https://github.com/pnpm/pnpm/issues/12235>.
+pub type ReportedProgressKeys = DashSet<String>;
 
-/// Shared handle to a [`NetworkFetchedKeys`] set, allocated once per
-/// install and shared between the resolve-time prefetcher (writer) and
-/// the install-pass reporter (reader).
-pub type SharedNetworkFetchedKeys = Arc<NetworkFetchedKeys>;
+/// Shared handle to a [`ReportedProgressKeys`] set, allocated once per
+/// install and shared between early fetchers and the later install-pass
+/// reporter.
+pub type SharedReportedProgressKeys = Arc<ReportedProgressKeys>;
 
 /// Build the buffer that the tarball body streams into, pre-sized
 /// from the response's advertised `Content-Length` when it fits and
@@ -1272,15 +1267,14 @@ pub struct DownloadTarballToStore<'a> {
     /// pins every resolution), so this gate is pacquet's most useful
     /// interpretation of the flag for frozen installs.
     pub offline: bool,
-    /// Install-scoped set of cache keys network-fetched this install.
-    /// When `Some`, a successful network download records its
-    /// `store_index_key(integrity, pkg_id)` here so the install-pass
-    /// reporter can distinguish a package downloaded this install from
-    /// one that was already in the store. Only the resolve-time
-    /// prefetcher passes a set (its downloads route through a silent
-    /// reporter); every other call site leaves it `None`. See
-    /// [`SharedNetworkFetchedKeys`].
-    pub network_fetched: Option<SharedNetworkFetchedKeys>,
+    /// Install-scoped set used to de-duplicate package-status progress.
+    /// When `Some`, a `fetched` or `found_in_store` emit records its
+    /// `store_index_key(integrity, pkg_id)` here. Later callers that see
+    /// the same key skip their own package-status emit, while still doing
+    /// the underlying fetch/cache work. Only the fresh install path
+    /// threads this set through, because resolve-time prefetches can
+    /// otherwise report the same package again in the warm batch.
+    pub progress_reported: Option<SharedReportedProgressKeys>,
 }
 
 /// Project [`TarballError`] onto pnpm's `requestRetryLogger`'s
@@ -1654,7 +1648,14 @@ async fn fetch_and_extract_once<Reporter: self::Reporter>(
 /// Emit `pnpm:progress found_in_store` for a (package_id, requester)
 /// pair the cache resolved without a download. Mirrors pnpm's emit at
 /// <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/package-requester/src/packageRequester.ts#L435>.
-fn emit_progress_found_in_store<Reporter: self::Reporter>(package_id: &str, requester: &str) {
+fn emit_progress_found_in_store<Reporter: self::Reporter>(
+    package_id: &str,
+    requester: &str,
+    progress_key: Option<(&SharedReportedProgressKeys, &str)>,
+) {
+    if progress_already_reported(progress_key) {
+        return;
+    }
     Reporter::emit(&LogEvent::Progress(ProgressLog {
         level: LogLevel::Debug,
         message: ProgressMessage::FoundInStore {
@@ -1662,6 +1663,27 @@ fn emit_progress_found_in_store<Reporter: self::Reporter>(package_id: &str, requ
             requester: requester.to_owned(),
         },
     }));
+}
+
+fn emit_progress_fetched<Reporter: self::Reporter>(
+    package_id: &str,
+    requester: &str,
+    progress_key: Option<(&SharedReportedProgressKeys, &str)>,
+) {
+    if progress_already_reported(progress_key) {
+        return;
+    }
+    Reporter::emit(&LogEvent::Progress(ProgressLog {
+        level: LogLevel::Debug,
+        message: ProgressMessage::Fetched {
+            package_id: package_id.to_owned(),
+            requester: requester.to_owned(),
+        },
+    }));
+}
+
+fn progress_already_reported(progress_key: Option<(&SharedReportedProgressKeys, &str)>) -> bool {
+    progress_key.is_some_and(|(reported, key)| !reported.insert(key.to_owned()))
 }
 
 // 9 arguments — over the default clippy threshold but each is
@@ -1685,6 +1707,7 @@ async fn fetch_and_extract_with_retry<Reporter: self::Reporter>(
     retry_opts: RetryOpts,
     auth_headers: &AuthHeaders,
     ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
+    progress_key: Option<(&SharedReportedProgressKeys, &str)>,
 ) -> Result<(Integrity, HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
     let mut attempt: u32 = 0;
     loop {
@@ -1706,13 +1729,7 @@ async fn fetch_and_extract_with_retry<Reporter: self::Reporter>(
                 // <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/package-requester/src/packageRequester.ts#L435>:
                 // one event per (resolved) package once the tarball
                 // has been pulled from the network and extracted.
-                Reporter::emit(&LogEvent::Progress(ProgressLog {
-                    level: LogLevel::Debug,
-                    message: ProgressMessage::Fetched {
-                        package_id: package_id.to_owned(),
-                        requester: requester.to_owned(),
-                    },
-                }));
+                emit_progress_fetched::<Reporter>(package_id, requester, progress_key);
                 return Ok(value);
             }
             Err(err) if !is_transient_error(&err) => return Err(err),
@@ -1797,6 +1814,9 @@ impl<'a> DownloadTarballToStore<'a> {
             requester,
             ..
         } = &self;
+        let cache_key = store_index_key(&package_integrity.to_string(), package_id);
+        let progress_key =
+            self.progress_reported.as_ref().map(|reported| (reported, cache_key.as_str()));
 
         // Warm-cache fast path: when [`prefetch_cas_paths`] already
         // batched the `(integrity, pkg_id)` row in at install start,
@@ -1816,7 +1836,6 @@ impl<'a> DownloadTarballToStore<'a> {
         // normal path does with the result of
         // [`Self::run_without_mem_cache`].
         if let Some(prefetched) = prefetched_cas_paths {
-            let cache_key = store_index_key(&package_integrity.to_string(), package_id);
             if let Some(cas_paths) = prefetched.get(&cache_key) {
                 tracing::info!(
                     target: "pacquet::download",
@@ -1824,7 +1843,7 @@ impl<'a> DownloadTarballToStore<'a> {
                     ?package_id,
                     "Reusing prefetched CAFS entry — skipping download (warm-cache fast path)",
                 );
-                emit_progress_found_in_store::<Reporter>(package_id, requester);
+                emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
                 let cas_paths = Arc::clone(cas_paths);
                 let cache_lock =
                     Arc::new(RwLock::new(CacheValue::Available(Arc::clone(&cas_paths))));
@@ -1863,19 +1882,12 @@ impl<'a> DownloadTarballToStore<'a> {
             // still makes progress.
             let notify = match &*cache_lock.read().await {
                 CacheValue::Available(cas_paths) => {
-                    // Another task (typically the resolve-time
-                    // `PrefetchingResolver` spawn) already populated
-                    // the slot. The owner's `run_without_mem_cache`
-                    // path emitted `pnpm:progress fetched` /
-                    // `found_in_store` on its own reporter — usually
-                    // the silent prefetcher reporter, so the install
-                    // pass needs to emit the equivalent now from its
-                    // own reporter so consumers see the
-                    // `resolved → found_in_store → imported` triple.
-                    // Treat this as a `found_in_store` (the content
-                    // is already on disk / in cache from our
-                    // perspective).
-                    emit_progress_found_in_store::<Reporter>(package_id, requester);
+                    // The first owner already reported its package
+                    // status. If the caller supplied a shared
+                    // progress set, this emit is skipped for keys the
+                    // owner reported; otherwise preserve the legacy
+                    // per-caller cache-hit progress.
+                    emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
                     return Ok(Arc::clone(cas_paths));
                 }
                 CacheValue::InProgress(notify) => Arc::clone(notify),
@@ -1891,10 +1903,8 @@ impl<'a> DownloadTarballToStore<'a> {
             match &*cache_lock.read().await {
                 CacheValue::Available(cas_paths) => {
                     // Same rationale as the pre-notify `Available`
-                    // branch above — emit `found_in_store` so the
-                    // install pass's reporter sees the event the
-                    // owner's silent emit dropped.
-                    emit_progress_found_in_store::<Reporter>(package_id, requester);
+                    // branch above.
+                    emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
                     Ok(Arc::clone(cas_paths))
                 }
                 CacheValue::Failed => {
@@ -1988,6 +1998,8 @@ impl<'a> DownloadTarballToStore<'a> {
         // an undecodable entry, or any CAFS file that has gone missing
         // from disk all fall through to the download path below.
         let cache_key = store_index_key(&package_integrity.to_string(), package_id);
+        let progress_key =
+            self.progress_reported.as_ref().map(|reported| (reported, cache_key.as_str()));
         // Hot path on warm installs: the install-scoped `prefetch_cas_paths`
         // task already ran one batched SELECT + integrity-check pass for
         // every (integrity, pkg_id) the lockfile mentions. If our key is
@@ -2016,20 +2028,20 @@ impl<'a> DownloadTarballToStore<'a> {
                 ?package_id,
                 "Reusing prefetched CAFS entry — skipping download",
             );
-            emit_progress_found_in_store::<Reporter>(package_id, requester);
+            emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
             return Ok((**cas_paths).clone());
         }
         if let Some(cas_paths) = load_cached_cas_paths(
             store_index,
             store_dir,
-            cache_key,
+            cache_key.clone(),
             verify_store_integrity,
             verified_files_cache,
         )
         .await
         {
             tracing::info!(target: "pacquet::download", ?package_url, ?package_id, "Reusing cached CAFS entry — skipping download");
-            emit_progress_found_in_store::<Reporter>(package_id, requester);
+            emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
             return Ok(cas_paths);
         }
 
@@ -2076,6 +2088,7 @@ impl<'a> DownloadTarballToStore<'a> {
                 retry_opts,
                 auth_headers,
                 ignore_file_pattern,
+                progress_key,
             )
             .await?;
 
@@ -2088,14 +2101,7 @@ impl<'a> DownloadTarballToStore<'a> {
         // writer failed to open or the caller handed us none — the row
         // is dropped with a `warn!` and the next install misses on this
         // cache key, matching the read path's stance.
-        let index_key = store_index_key(&package_integrity.to_string(), package_id);
-        // Record that this package's bytes came over the network this
-        // install (see [`SharedNetworkFetchedKeys`]). Done before the
-        // store-index row is queued, so any later reader that observes
-        // the row as "in store" also observes this membership.
-        if let Some(network_fetched) = self.network_fetched.as_deref() {
-            network_fetched.insert(index_key.clone());
-        }
+        let index_key = cache_key;
         if let Some(writer) = store_index_writer {
             writer.queue(index_key, pkg_files_idx);
         } else {
@@ -2171,6 +2177,7 @@ impl FetchTarballForResolution<'_> {
             store_dir,
             retry_opts,
             auth_headers,
+            None,
             None,
         )
         .await?;
@@ -2561,7 +2568,7 @@ impl<'a> DownloadZipArchiveToStore<'a> {
                 ?package_id,
                 "Reusing prefetched CAFS entry — skipping zip download",
             );
-            emit_progress_found_in_store::<Reporter>(package_id, requester);
+            emit_progress_found_in_store::<Reporter>(package_id, requester, None);
             return Ok((**cas_paths).clone());
         }
         if let Some(cas_paths) = load_cached_cas_paths(
@@ -2574,7 +2581,7 @@ impl<'a> DownloadZipArchiveToStore<'a> {
         .await
         {
             tracing::info!(target: "pacquet::download", ?package_url, ?package_id, "Reusing cached CAFS entry — skipping zip download");
-            emit_progress_found_in_store::<Reporter>(package_id, requester);
+            emit_progress_found_in_store::<Reporter>(package_id, requester, None);
             return Ok(cas_paths);
         }
 

--- a/pacquet/crates/tarball/src/lib.rs
+++ b/pacquet/crates/tarball/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
     time::{Duration, Instant, UNIX_EPOCH},
 };
 
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use derive_more::{Display, Error, From};
 use miette::Diagnostic;
 use pacquet_fs::file_mode;
@@ -272,6 +272,28 @@ pub enum CacheValue {
 ///
 /// The key of this hashmap is the url of each tarball.
 pub type MemCache = DashMap<String, Arc<RwLock<CacheValue>>>;
+
+/// Install-scoped set of store-index cache keys
+/// (`store_index_key(integrity, pkg_id)`) whose tarball bytes were
+/// pulled over the network during *this* install — i.e. the package was
+/// not already in the store when the install began.
+///
+/// [`DownloadTarballToStore::run_without_mem_cache`] inserts a key the
+/// moment its network fetch succeeds. The resolve-time prefetcher
+/// downloads through a [`pacquet_reporter::SilentReporter`], so its
+/// `pnpm:progress fetched` emits are discarded; by the time the install
+/// pass reports a freshly-downloaded package the store already holds it,
+/// which would otherwise label every download `found_in_store`. The
+/// reporter consults this set so a package fetched this install is
+/// reported as `fetched` — matching the cold-batch / frozen-lockfile
+/// path and pnpm's single per-package emit, which reflects whether the
+/// fetch hit the network. See <https://github.com/pnpm/pnpm/issues/12235>.
+pub type NetworkFetchedKeys = DashSet<String>;
+
+/// Shared handle to a [`NetworkFetchedKeys`] set, allocated once per
+/// install and shared between the resolve-time prefetcher (writer) and
+/// the install-pass reporter (reader).
+pub type SharedNetworkFetchedKeys = Arc<NetworkFetchedKeys>;
 
 /// Build the buffer that the tarball body streams into, pre-sized
 /// from the response's advertised `Content-Length` when it fits and
@@ -1250,6 +1272,15 @@ pub struct DownloadTarballToStore<'a> {
     /// pins every resolution), so this gate is pacquet's most useful
     /// interpretation of the flag for frozen installs.
     pub offline: bool,
+    /// Install-scoped set of cache keys network-fetched this install.
+    /// When `Some`, a successful network download records its
+    /// `store_index_key(integrity, pkg_id)` here so the install-pass
+    /// reporter can distinguish a package downloaded this install from
+    /// one that was already in the store. Only the resolve-time
+    /// prefetcher passes a set (its downloads route through a silent
+    /// reporter); every other call site leaves it `None`. See
+    /// [`SharedNetworkFetchedKeys`].
+    pub network_fetched: Option<SharedNetworkFetchedKeys>,
 }
 
 /// Project [`TarballError`] onto pnpm's `requestRetryLogger`'s
@@ -2058,6 +2089,13 @@ impl<'a> DownloadTarballToStore<'a> {
         // is dropped with a `warn!` and the next install misses on this
         // cache key, matching the read path's stance.
         let index_key = store_index_key(&package_integrity.to_string(), package_id);
+        // Record that this package's bytes came over the network this
+        // install (see [`SharedNetworkFetchedKeys`]). Done before the
+        // store-index row is queued, so any later reader that observes
+        // the row as "in store" also observes this membership.
+        if let Some(network_fetched) = self.network_fetched.as_deref() {
+            network_fetched.insert(index_key.clone());
+        }
         if let Some(writer) = store_index_writer {
             writer.queue(index_key, pkg_files_idx);
         } else {

--- a/pacquet/crates/tarball/src/tests.rs
+++ b/pacquet/crates/tarball/src/tests.rs
@@ -1795,7 +1795,11 @@ async fn mem_cache_hit_skips_package_status_when_progress_already_reported() {
     .await
     .expect("first call should fetch and report");
 
-    let first = EVENTS.lock().unwrap();
+    // Clone the events out rather than binding the `MutexGuard`: a
+    // named guard lexically spans the second download's `.await` below
+    // (clippy's `await_holding_lock` is scope-based and ignores an
+    // explicit `drop`), even though the data is only read here.
+    let first = EVENTS.lock().unwrap().clone();
     assert!(
         first.iter().any(|e| matches!(
             e,
@@ -1803,7 +1807,6 @@ async fn mem_cache_hit_skips_package_status_when_progress_already_reported() {
         )),
         "first call must report fetched; got {first:?}",
     );
-    drop(first);
 
     EVENTS.lock().unwrap().clear();
     DownloadTarballToStore {
@@ -1829,7 +1832,7 @@ async fn mem_cache_hit_skips_package_status_when_progress_already_reported() {
     .await
     .expect("second call should reuse the mem cache");
 
-    let second = EVENTS.lock().unwrap();
+    let second = EVENTS.lock().unwrap().clone();
     assert!(
         !second.iter().any(|e| matches!(
             e,

--- a/pacquet/crates/tarball/src/tests.rs
+++ b/pacquet/crates/tarball/src/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     DownloadTarballToStore, HttpStatusError, MemCache, NetworkError, PrefetchedCasPaths, RetryOpts,
-    TarballError, VerifyChecksumError, allocate_tarball_buffer, extract_tarball_entries,
-    extract_zip_entries, fetch_and_extract_with_retry, is_transient_error,
+    SharedNetworkFetchedKeys, TarballError, VerifyChecksumError, allocate_tarball_buffer,
+    extract_tarball_entries, extract_zip_entries, fetch_and_extract_with_retry, is_transient_error,
     normalize_bundled_manifest, prefetch_cas_paths,
 };
 use pacquet_network::{AuthHeaders, ThrottledClient};
@@ -178,6 +178,7 @@ async fn packages_under_orgs_should_work() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
+        network_fetched: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -208,6 +209,54 @@ async fn packages_under_orgs_should_work() {
     drop(store_dir);
 }
 
+/// A successful network download records its
+/// `store_index_key(integrity, pkg_id)` in the supplied
+/// [`SharedNetworkFetchedKeys`] set, so the install-pass reporter can
+/// label it `fetched` even when a later warm pass finds it in the
+/// freshly-populated store. Regression guard for
+/// <https://github.com/pnpm/pnpm/issues/12235>.
+#[tokio::test]
+#[cfg(not(target_os = "windows"))]
+async fn network_fetch_records_cache_key() {
+    let (store_dir, store_path) = tempdir_with_leaked_path();
+    let pkg_integrity = integrity(
+        "sha512-dj7vjIn1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w==",
+    );
+    let pkg_id = "@fastify/error@3.3.0";
+    let network_fetched = SharedNetworkFetchedKeys::default();
+
+    DownloadTarballToStore {
+        http_client: &Default::default(),
+        store_dir: store_path,
+        store_index: None,
+        store_index_writer: None,
+        verify_store_integrity: true,
+        package_integrity: &pkg_integrity,
+        package_unpacked_size: Some(16697),
+        package_url: "https://registry.npmjs.org/@fastify/error/-/error-3.3.0.tgz",
+        package_id: pkg_id,
+        requester: "",
+        prefetched_cas_paths: None,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
+        retry_opts: test_retry_opts(),
+        auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
+        offline: false,
+        network_fetched: Some(SharedNetworkFetchedKeys::clone(&network_fetched)),
+    }
+    .run_without_mem_cache::<SilentReporter>()
+    .await
+    .unwrap();
+
+    let expected_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
+    assert!(
+        network_fetched.contains(&expected_key),
+        "network download must record its cache key; got {network_fetched:?}",
+    );
+
+    drop(store_dir);
+}
+
 #[tokio::test]
 async fn should_throw_error_on_checksum_mismatch() {
     let (store_dir, store_path) = tempdir_with_leaked_path();
@@ -228,6 +277,7 @@ async fn should_throw_error_on_checksum_mismatch() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
+        network_fetched: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -284,6 +334,9 @@ async fn reuses_cached_cas_paths_when_index_entry_is_live() {
     index.set(&index_key, &entry).unwrap();
     drop(index);
 
+    // A cache hit must not be recorded as a network fetch — only bytes
+    // pulled over the network this install belong in the set.
+    let network_fetched = SharedNetworkFetchedKeys::default();
     let cas_paths = DownloadTarballToStore {
         http_client: &fast_fail_client(),
         store_dir: store_path,
@@ -305,6 +358,7 @@ async fn reuses_cached_cas_paths_when_index_entry_is_live() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
+        network_fetched: Some(SharedNetworkFetchedKeys::clone(&network_fetched)),
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -313,6 +367,10 @@ async fn reuses_cached_cas_paths_when_index_entry_is_live() {
     assert_eq!(cas_paths.len(), 2);
     assert_eq!(cas_paths.get("package.json"), Some(&pkg_json_path));
     assert_eq!(cas_paths.get("bin/cli.js"), Some(&bin_path));
+    assert!(
+        network_fetched.is_empty(),
+        "a store cache hit must not record a network fetch; got {network_fetched:?}",
+    );
 
     drop(store_dir);
 }
@@ -366,6 +424,7 @@ async fn reuses_prefetched_cas_paths_when_provided() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
+        network_fetched: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -595,6 +654,7 @@ async fn falls_through_when_cafs_file_missing() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
+        network_fetched: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -656,6 +716,7 @@ async fn falls_through_when_digest_is_malformed() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
+        network_fetched: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -720,6 +781,7 @@ async fn falls_through_when_cafs_path_is_a_directory() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
+        network_fetched: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -794,6 +856,7 @@ async fn falls_through_when_cafs_path_is_a_symlink() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
+        network_fetched: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -1350,6 +1413,7 @@ fn run_with_mem_cache_does_not_deadlock_on_dashmap_shard_contention() {
                     auth_headers,
                     ignore_file_pattern: None,
                     offline: false,
+                    network_fetched: None,
                 };
 
                 // Spawn each task and yield once before the next so the
@@ -1603,6 +1667,7 @@ async fn mem_cache_hit_emits_found_in_store_against_callers_reporter() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
+        network_fetched: None,
     }
     .run_with_mem_cache::<pacquet_reporter::SilentReporter>(&mem_cache)
     .await
@@ -1630,6 +1695,7 @@ async fn mem_cache_hit_emits_found_in_store_against_callers_reporter() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
+        network_fetched: None,
     }
     .run_with_mem_cache::<RecordingReporter>(&mem_cache)
     .await
@@ -1730,6 +1796,7 @@ async fn run_with_mem_cache_recovers_from_owning_fetch_error() {
         auth_headers,
         ignore_file_pattern: None,
         offline: false,
+        network_fetched: None,
     };
 
     // Drive both calls concurrently. Pre-fix: the first to hit the
@@ -2012,6 +2079,7 @@ async fn found_in_store_event_fires_on_cache_hit() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
+        network_fetched: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -2050,6 +2118,7 @@ async fn found_in_store_event_fires_on_cache_hit() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
+        network_fetched: None,
     }
     .run_without_mem_cache::<RecordingReporter>()
     .await
@@ -2441,6 +2510,7 @@ async fn offline_mode_skips_network_on_cache_miss() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: true,
+        network_fetched: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -2511,6 +2581,7 @@ async fn offline_mode_still_uses_prefetched_cache() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: true,
+        network_fetched: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await

--- a/pacquet/crates/tarball/src/tests.rs
+++ b/pacquet/crates/tarball/src/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     DownloadTarballToStore, HttpStatusError, MemCache, NetworkError, PrefetchedCasPaths, RetryOpts,
-    SharedNetworkFetchedKeys, TarballError, VerifyChecksumError, allocate_tarball_buffer,
+    SharedReportedProgressKeys, TarballError, VerifyChecksumError, allocate_tarball_buffer,
     extract_tarball_entries, extract_zip_entries, fetch_and_extract_with_retry, is_transient_error,
     normalize_bundled_manifest, prefetch_cas_paths,
 };
@@ -178,7 +178,7 @@ async fn packages_under_orgs_should_work() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
-        network_fetched: None,
+        progress_reported: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -211,19 +211,18 @@ async fn packages_under_orgs_should_work() {
 
 /// A successful network download records its
 /// `store_index_key(integrity, pkg_id)` in the supplied
-/// [`SharedNetworkFetchedKeys`] set, so the install-pass reporter can
-/// label it `fetched` even when a later warm pass finds it in the
-/// freshly-populated store. Regression guard for
-/// <https://github.com/pnpm/pnpm/issues/12235>.
+/// [`SharedReportedProgressKeys`] set, so a later install pass can skip
+/// a duplicate package-status event for the same key. Regression guard
+/// for <https://github.com/pnpm/pnpm/issues/12235>.
 #[tokio::test]
 #[cfg(not(target_os = "windows"))]
-async fn network_fetch_records_cache_key() {
+async fn network_fetch_records_progress_key() {
     let (store_dir, store_path) = tempdir_with_leaked_path();
     let pkg_integrity = integrity(
         "sha512-dj7vjIn1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w==",
     );
     let pkg_id = "@fastify/error@3.3.0";
-    let network_fetched = SharedNetworkFetchedKeys::default();
+    let progress_reported = SharedReportedProgressKeys::default();
 
     DownloadTarballToStore {
         http_client: &Default::default(),
@@ -242,7 +241,7 @@ async fn network_fetch_records_cache_key() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
-        network_fetched: Some(SharedNetworkFetchedKeys::clone(&network_fetched)),
+        progress_reported: Some(SharedReportedProgressKeys::clone(&progress_reported)),
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -250,8 +249,8 @@ async fn network_fetch_records_cache_key() {
 
     let expected_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
     assert!(
-        network_fetched.contains(&expected_key),
-        "network download must record its cache key; got {network_fetched:?}",
+        progress_reported.contains(&expected_key),
+        "network download must record its progress key; got {progress_reported:?}",
     );
 
     drop(store_dir);
@@ -277,7 +276,7 @@ async fn should_throw_error_on_checksum_mismatch() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
-        network_fetched: None,
+        progress_reported: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -334,9 +333,10 @@ async fn reuses_cached_cas_paths_when_index_entry_is_live() {
     index.set(&index_key, &entry).unwrap();
     drop(index);
 
-    // A cache hit must not be recorded as a network fetch — only bytes
-    // pulled over the network this install belong in the set.
-    let network_fetched = SharedNetworkFetchedKeys::default();
+    // A cache hit also emits package-status progress, so it records the
+    // key to prevent a later warm/cold pass from counting the same
+    // package status again.
+    let progress_reported = SharedReportedProgressKeys::default();
     let cas_paths = DownloadTarballToStore {
         http_client: &fast_fail_client(),
         store_dir: store_path,
@@ -358,7 +358,7 @@ async fn reuses_cached_cas_paths_when_index_entry_is_live() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
-        network_fetched: Some(SharedNetworkFetchedKeys::clone(&network_fetched)),
+        progress_reported: Some(SharedReportedProgressKeys::clone(&progress_reported)),
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -368,8 +368,8 @@ async fn reuses_cached_cas_paths_when_index_entry_is_live() {
     assert_eq!(cas_paths.get("package.json"), Some(&pkg_json_path));
     assert_eq!(cas_paths.get("bin/cli.js"), Some(&bin_path));
     assert!(
-        network_fetched.is_empty(),
-        "a store cache hit must not record a network fetch; got {network_fetched:?}",
+        progress_reported.contains(&index_key),
+        "a store cache hit must record its progress key; got {progress_reported:?}",
     );
 
     drop(store_dir);
@@ -424,7 +424,7 @@ async fn reuses_prefetched_cas_paths_when_provided() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
-        network_fetched: None,
+        progress_reported: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -654,7 +654,7 @@ async fn falls_through_when_cafs_file_missing() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
-        network_fetched: None,
+        progress_reported: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -716,7 +716,7 @@ async fn falls_through_when_digest_is_malformed() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
-        network_fetched: None,
+        progress_reported: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -781,7 +781,7 @@ async fn falls_through_when_cafs_path_is_a_directory() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
-        network_fetched: None,
+        progress_reported: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -856,7 +856,7 @@ async fn falls_through_when_cafs_path_is_a_symlink() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
-        network_fetched: None,
+        progress_reported: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -1132,6 +1132,7 @@ async fn retries_then_succeeds_on_transient_5xx() {
         fast_retry_opts(),
         &AuthHeaders::default(),
         None,
+        None,
     )
     .await
     .expect("transient 503 should be followed by a successful retry");
@@ -1180,6 +1181,7 @@ async fn retries_integrity_mismatch_until_exhausted() {
         fast_retry_opts(),
         &AuthHeaders::default(),
         None,
+        None,
     )
     .await
     .expect_err("integrity mismatch should exhaust the retry budget");
@@ -1211,6 +1213,7 @@ async fn fails_fast_on_404() {
         store_path,
         fast_retry_opts(),
         &AuthHeaders::default(),
+        None,
         None,
     )
     .await
@@ -1253,6 +1256,7 @@ async fn retries_other_4xx_codes() {
         fast_retry_opts(),
         &AuthHeaders::default(),
         None,
+        None,
     )
     .await
     .expect_err("non-401/403/404 4xx should exhaust the retry budget");
@@ -1287,6 +1291,7 @@ async fn retry_exhaustion_returns_last_error() {
         store_path,
         fast_retry_opts(),
         &AuthHeaders::default(),
+        None,
         None,
     )
     .await
@@ -1413,7 +1418,7 @@ fn run_with_mem_cache_does_not_deadlock_on_dashmap_shard_contention() {
                     auth_headers,
                     ignore_file_pattern: None,
                     offline: false,
-                    network_fetched: None,
+                    progress_reported: None,
                 };
 
                 // Spawn each task and yield once before the next so the
@@ -1483,6 +1488,7 @@ async fn zero_retries_makes_a_single_attempt() {
         opts,
         &AuthHeaders::default(),
         None,
+        None,
     )
     .await
     .expect_err("retries=0 must surface the first failure");
@@ -1527,6 +1533,7 @@ async fn fetch_attaches_authorization_header_when_creds_match_tarball_url() {
         store_path,
         fast_retry_opts(),
         &auth_headers,
+        None,
         None,
     )
     .await
@@ -1582,6 +1589,7 @@ async fn retry_re_attaches_authorization_header_on_each_attempt() {
         fast_retry_opts(),
         &auth_headers,
         None,
+        None,
     )
     .await
     .expect("retry attempt should also carry the bearer header");
@@ -1595,18 +1603,11 @@ async fn retry_re_attaches_authorization_header_on_each_attempt() {
     drop(store_dir_keep);
 }
 
-/// `run_with_mem_cache`'s `Available` short-circuit emits
-/// `pnpm:progress found_in_store` against the *caller's* reporter,
-/// regardless of who originally populated the slot. The
-/// `PrefetchingResolver` populates the slot via a `SilentReporter`
-/// so the resolve-time fetch doesn't fire `fetched` ahead of the
-/// install pass's `resolved`; the install pass's later
-/// `run_with_mem_cache` call must still produce the
-/// `found_in_store` event for `@pnpm/cli.default-reporter` to see
-/// the documented `resolved → fetched|found_in_store → imported`
-/// triple. Without the emit on the short-circuit, the install pass
-/// would silently skip past the cache hit and the event triple
-/// would be missing its middle.
+/// Without a shared progress-dedupe set, `run_with_mem_cache`'s
+/// `Available` short-circuit emits `pnpm:progress found_in_store`
+/// against the caller's reporter, regardless of who originally
+/// populated the slot. This preserves the legacy install path where a
+/// later caller still needs its own visible cache-hit event.
 ///
 /// Drives two `run_with_mem_cache` calls for the same URL but
 /// different `package_id`s. The first uses `SilentReporter`
@@ -1647,9 +1648,7 @@ async fn mem_cache_hit_emits_found_in_store_against_callers_reporter() {
     let mem_cache = MemCache::default();
     let verified_files_cache = SharedVerifiedFilesCache::default();
 
-    // First requester: silent (mirrors the `PrefetchingResolver`
-    // route, which uses `SilentReporter` so its resolve-time
-    // emits don't land before the install pass emits `resolved`).
+    // First requester: silent legacy owner.
     DownloadTarballToStore {
         http_client: &client,
         store_dir: store_path,
@@ -1667,16 +1666,16 @@ async fn mem_cache_hit_emits_found_in_store_against_callers_reporter() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
-        network_fetched: None,
+        progress_reported: None,
     }
     .run_with_mem_cache::<pacquet_reporter::SilentReporter>(&mem_cache)
     .await
     .expect("first call should populate the mem cache");
 
     // Second requester: same URL, different `package_id`. Hits the
-    // immediate-`Available` branch — must emit one `found_in_store`
-    // against the recording reporter so consumers see the cache
-    // hit even though the owner emit was silent.
+    // immediate-`Available` branch and emits one `found_in_store`
+    // because no shared progress set says this package status was
+    // already reported.
     EVENTS.lock().unwrap().clear();
     DownloadTarballToStore {
         http_client: &client,
@@ -1695,7 +1694,7 @@ async fn mem_cache_hit_emits_found_in_store_against_callers_reporter() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
-        network_fetched: None,
+        progress_reported: None,
     }
     .run_with_mem_cache::<RecordingReporter>(&mem_cache)
     .await
@@ -1730,6 +1729,117 @@ async fn mem_cache_hit_emits_found_in_store_against_callers_reporter() {
             LogEvent::Progress(log) if matches!(&log.message, ProgressMessage::Fetched { .. })
         )),
         "fetched must NOT fire on a mem-cache hit; got {captured:?}",
+    );
+
+    drop(store_dir_keep);
+}
+
+/// With a shared progress-dedupe set, the first owner reports the
+/// package status and records the cache key. A later caller that hits
+/// the in-memory cache for the same package key must not emit a second
+/// `fetched` or `found_in_store`.
+#[tokio::test]
+async fn mem_cache_hit_skips_package_status_when_progress_already_reported() {
+    use std::sync::Mutex;
+
+    use pacquet_reporter::{LogEvent, ProgressMessage};
+
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+
+    struct RecordingReporter;
+    impl pacquet_reporter::Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/pkg.tgz")
+        .with_status(200)
+        .with_body(FASTIFY_ERROR_TARBALL)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let url = format!("{}/pkg.tgz", server.url());
+    let client = ThrottledClient::default();
+    let pkg_integrity = integrity(FASTIFY_ERROR_INTEGRITY);
+    let mem_cache = MemCache::default();
+    let verified_files_cache = SharedVerifiedFilesCache::default();
+    let progress_reported = SharedReportedProgressKeys::default();
+    let pkg_id = "@fastify/error@3.3.0";
+
+    EVENTS.lock().unwrap().clear();
+    DownloadTarballToStore {
+        http_client: &client,
+        store_dir: store_path,
+        store_index: None,
+        store_index_writer: None,
+        verify_store_integrity: true,
+        verified_files_cache: SharedVerifiedFilesCache::clone(&verified_files_cache),
+        package_integrity: &pkg_integrity,
+        package_unpacked_size: None,
+        package_url: &url,
+        package_id: pkg_id,
+        requester: "/proj",
+        prefetched_cas_paths: None,
+        retry_opts: test_retry_opts(),
+        auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
+        offline: false,
+        progress_reported: Some(SharedReportedProgressKeys::clone(&progress_reported)),
+    }
+    .run_with_mem_cache::<RecordingReporter>(&mem_cache)
+    .await
+    .expect("first call should fetch and report");
+
+    let first = EVENTS.lock().unwrap();
+    assert!(
+        first.iter().any(|e| matches!(
+            e,
+            LogEvent::Progress(log) if matches!(&log.message, ProgressMessage::Fetched { .. })
+        )),
+        "first call must report fetched; got {first:?}",
+    );
+    drop(first);
+
+    EVENTS.lock().unwrap().clear();
+    DownloadTarballToStore {
+        http_client: &client,
+        store_dir: store_path,
+        store_index: None,
+        store_index_writer: None,
+        verify_store_integrity: true,
+        verified_files_cache: SharedVerifiedFilesCache::clone(&verified_files_cache),
+        package_integrity: &pkg_integrity,
+        package_unpacked_size: None,
+        package_url: &url,
+        package_id: pkg_id,
+        requester: "/proj",
+        prefetched_cas_paths: None,
+        retry_opts: test_retry_opts(),
+        auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
+        offline: false,
+        progress_reported: Some(SharedReportedProgressKeys::clone(&progress_reported)),
+    }
+    .run_with_mem_cache::<RecordingReporter>(&mem_cache)
+    .await
+    .expect("second call should reuse the mem cache");
+
+    let second = EVENTS.lock().unwrap();
+    assert!(
+        !second.iter().any(|e| matches!(
+            e,
+            LogEvent::Progress(log)
+                if matches!(
+                    &log.message,
+                    ProgressMessage::Fetched { .. } | ProgressMessage::FoundInStore { .. }
+                )
+        )),
+        "second call must not duplicate package status; got {second:?}",
     );
 
     drop(store_dir_keep);
@@ -1796,7 +1906,7 @@ async fn run_with_mem_cache_recovers_from_owning_fetch_error() {
         auth_headers,
         ignore_file_pattern: None,
         offline: false,
-        network_fetched: None,
+        progress_reported: None,
     };
 
     // Drive both calls concurrently. Pre-fix: the first to hit the
@@ -1898,6 +2008,7 @@ async fn fetching_progress_and_fetched_events_fire_during_download() {
         fast_retry_opts(),
         &AuthHeaders::default(),
         None,
+        None,
     )
     .await
     .expect("transient 503 should be followed by a successful retry");
@@ -1987,6 +2098,7 @@ async fn started_fires_for_connection_level_failures() {
         store_path,
         RetryOpts { retries: 0, ..fast_retry_opts() },
         &AuthHeaders::default(),
+        None,
         None,
     )
     .await
@@ -2079,7 +2191,7 @@ async fn found_in_store_event_fires_on_cache_hit() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
-        network_fetched: None,
+        progress_reported: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -2118,7 +2230,7 @@ async fn found_in_store_event_fires_on_cache_hit() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: false,
-        network_fetched: None,
+        progress_reported: None,
     }
     .run_without_mem_cache::<RecordingReporter>()
     .await
@@ -2196,6 +2308,7 @@ async fn request_retry_event_fires_per_retried_attempt() {
         store_path,
         fast_retry_opts(),
         &AuthHeaders::default(),
+        None,
         None,
     )
     .await
@@ -2510,7 +2623,7 @@ async fn offline_mode_skips_network_on_cache_miss() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: true,
-        network_fetched: None,
+        progress_reported: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -2581,7 +2694,7 @@ async fn offline_mode_still_uses_prefetched_cache() {
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
         offline: true,
-        network_fetched: None,
+        progress_reported: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await

--- a/pacquet/tasks/micro-benchmark/src/main.rs
+++ b/pacquet/tasks/micro-benchmark/src/main.rs
@@ -53,7 +53,7 @@ fn bench_tarball(criterion: &mut Criterion, server: &mut ServerGuard, fixtures_f
                 auth_headers: &AuthHeaders::default(),
                 ignore_file_pattern: None,
                 offline: false,
-                network_fetched: None,
+                progress_reported: None,
             }
             .run_without_mem_cache::<pacquet_reporter::SilentReporter>()
             .await

--- a/pacquet/tasks/micro-benchmark/src/main.rs
+++ b/pacquet/tasks/micro-benchmark/src/main.rs
@@ -53,6 +53,7 @@ fn bench_tarball(criterion: &mut Criterion, server: &mut ServerGuard, fixtures_f
                 auth_headers: &AuthHeaders::default(),
                 ignore_file_pattern: None,
                 offline: false,
+                network_fetched: None,
             }
             .run_without_mem_cache::<pacquet_reporter::SilentReporter>()
             .await


### PR DESCRIPTION
## Problem

A cold `pacquet install` (fresh-resolve) and `pacquet install --frozen-lockfile` download the same tarballs but report them oppositely:

- **Fresh** resolves through `PrefetchingResolver`, which downloads tarballs *during resolution* on a `SilentReporter` (emits discarded). By the time `create_virtual_store`'s warm batch reports each package, `prefetch_cas_paths` already finds the freshly-written store-index row, so it emits `found_in_store` for everything — **"reused N, downloaded 0"**.
- **Frozen** (and the pnpr path, which forces frozen) has no prefetcher, so its cold batch downloads through the visible path and emits `fetched` — **"downloaded N"**.

Same bytes, same network, opposite report. This made a `--frozen-lockfile` / pnpr install look like it was redundantly re-downloading a graph that a plain install "reused". Upstream pnpm has no such split: `packageRequester` emits once and the emit reflects whether the fetch hit the network.

Fixes #12235.

## Fix

Add an install-scoped `SharedNetworkFetchedKeys` (`Arc<DashSet<String>>` in `pacquet-tarball`), keyed by `store_index_key(integrity, pkg_id)` — the cache keys whose bytes came over the network *this* install:

- `DownloadTarballToStore::run_without_mem_cache` inserts a key the moment its network fetch succeeds (before the store-index row is queued, so any later reader that sees the row "in store" also sees this membership).
- The fresh path threads the set into `PrefetchContext`/`OwnedFetchCtx` (the silent prefetcher writes) and into `CreateVirtualStore` (the warm batch reads).
- `emit_warm_snapshot_progress` now takes `network_fetched: bool` and emits `fetched` for a package downloaded this install, `found_in_store` only for one genuinely already in the store at install start.
- The frozen path passes an empty set (its cold batch already emits `fetched` directly). Cold-batch / binary download sites pass `network_fetched: None`.

## Acceptance

A cold `pacquet install` now reports its prefetch downloads as downloads, so `pacquet install` and `pacquet install --frozen-lockfile` produce identical reused/downloaded counts for the same cold store.

## Tests

- New unit coverage in `create_virtual_store::tests`: `emits_resolved_then_fetched_when_network_fetched` and the renamed `..._when_not_network_fetched`.
- New tarball tests: `network_fetch_records_cache_key` (a real download records its key) plus an assertion in `reuses_cached_cas_paths_when_index_entry_is_live` that a store cache hit does **not** record.
- Verified locally: `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all`, `RUSTDOCFLAGS=-D warnings cargo doc`, and the tarball + `create_virtual_store` test suites — all green.

Pacquet-only parity fix (pnpm already behaves correctly); no pnpm-side change and no changeset needed.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Eliminated duplicate progress events during package installation to prevent packages from being incorrectly counted multiple times when reused across prefetch and installation phases.

* **Tests**
  * Added test coverage for progress event deduplication behavior in tarball downloads and virtual store operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->