### PR TITLE
chore(husky): reject bare #NNN issue refs in commit messages

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,2 @@
+node .husky/reject-bare-issue-refs.mjs "$1"
 pnpm commitlint --edit --config=commitlint.config.cjs

--- a/.husky/reject-bare-issue-refs.mjs
+++ b/.husky/reject-bare-issue-refs.mjs
@@ -1,0 +1,82 @@
+// Rejects commit messages that contain a bare `#NNN` issue/PR reference.
+//
+// A "bare" reference is a `#` immediately followed by digits that is NOT
+// qualified by an `owner/repo` prefix (e.g. `pnpm/pnpm#123`) and is NOT part
+// of an absolute URL.
+//
+// Rationale lives in the error message below and in CLAUDE.md.
+
+import { readFileSync } from 'node:fs'
+
+const msgPath = process.argv[2]
+if (!msgPath) {
+  console.error('reject-bare-issue-refs: missing commit message file path argument')
+  process.exit(1)
+}
+
+const raw = readFileSync(msgPath, 'utf8')
+
+// Drop git comment lines (those starting with `#`). Git strips them from the
+// final message anyway, so a bare `#NNN` on such a line is never committed.
+const message = raw
+  .split('\n')
+  .filter((line) => !line.trimStart().startsWith('#'))
+  .join('\n')
+
+// Match `#` + digits where the char before `#` is not part of a repo slug or
+// URL path. That keeps `pnpm/pnpm#123` and `github.com/pnpm/pnpm/...` allowed
+// while catching bare `#123`, `(#123)`, `fixes #123`, etc.
+const bareRefRegExp = /(^|[^\w./-])#(\d+)/g
+
+const offenders = new Set()
+let match
+while ((match = bareRefRegExp.exec(message)) !== null) {
+  offenders.add(`#${match[2]}`)
+}
+
+if (offenders.size === 0) {
+  process.exit(0)
+}
+
+const list = [...offenders].join(', ')
+
+console.error(`
+✖ Commit message rejected: bare issue/PR reference(s) found: ${list}
+
+A bare "#NNN" reference is ambiguous and frequently wrong. Use one of the
+unambiguous forms instead, or remove the reference.
+
+WHY THIS IS BLOCKED
+  GitHub silently turns any "#NNN" into a link to issue/PR NNN of THIS repo.
+  That makes "#NNN" dangerous in two common ways:
+
+    1. It is sometimes meant as a list item ("#1", "#2", "#3" pointing at
+       numbered items in the body). GitHub will instead link it to unrelated
+       issues #1, #2, #3 of this repo.
+
+    2. It is sometimes meant as issue NNN of a DIFFERENT repository. GitHub
+       will instead link it to issue NNN of this repo — a completely
+       different ticket.
+
+HOW TO FIX (address the root cause — see which case you are in)
+
+  • Referencing an issue/PR in THIS repo?
+      Qualify it:        pnpm/pnpm#NNN
+      or use a URL:      https://github.com/pnpm/pnpm/issues/NNN
+
+  • Referencing an issue/PR in ANOTHER repo?
+      Qualify it:        owner/repo#NNN
+      or use a URL:      https://github.com/owner/repo/issues/NNN
+
+  • Enumerating list items (1st, 2nd, 3rd ...)?
+      Don't use "#". Write "item 1", "(1)", "1." or rephrase so the number
+      cannot be read as an issue reference.
+
+Qualified syntax and absolute URLs are always safe — even for this repo — so
+this rule is applied to every "#NNN". Always prefer them.
+
+DO NOT bypass this check with --no-verify, by editing/deleting this hook, or
+with any suppression file. Fix the reference in the commit message instead.
+`)
+
+process.exit(1)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,18 @@ Follow the [Conventional Commits](https://www.conventionalcommits.org/) specific
 -   `test`: adding missing tests
 -   `chore`: changes to build process or auxiliary tools
 
+### Install the git hooks before committing
+
+The git hooks in `.husky/` (including the `commit-msg` check described below) only run once husky has wired them into git. A fresh clone does **not** have them active until installed. **Before making any commit, ensure the hooks are installed** by running one of:
+
+```bash
+pnpm install      # runs the "prepare": "husky" script as part of install
+# or, if dependencies are already installed, register the hooks on their own:
+pnpm exec husky
+```
+
+You can confirm the hooks are active with `git config core.hooksPath` (it should point at husky's directory) and by checking that `.husky/_/` exists. Do not commit with hooks uninstalled — that silently skips every check, including the bare `#NNN` rejection below.
+
 ### Never use bare `#NNN` issue/PR references
 
 **Do not write a bare `#NNN` (a `#` followed by digits) anywhere in a commit message.** A `commit-msg` hook (`.husky/reject-bare-issue-refs.mjs`) rejects them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,19 @@ Follow the [Conventional Commits](https://www.conventionalcommits.org/) specific
 -   `test`: adding missing tests
 -   `chore`: changes to build process or auxiliary tools
 
+### Never use bare `#NNN` issue/PR references
+
+**Do not write a bare `#NNN` (a `#` followed by digits) anywhere in a commit message.** A `commit-msg` hook (`.husky/reject-bare-issue-refs.mjs`) rejects them.
+
+GitHub turns any `#NNN` into a link to issue/PR `NNN` of *this* repo, which is almost never what a bare reference means. This is a frequent AI mistake in two forms:
+
+-   Using `#1`, `#2`, `#3`, … to enumerate items in a list. GitHub instead links them to unrelated issues `#1`, `#2`, `#3` of this repo. **Fix:** don't use `#` for enumeration — write `item 1`, `(1)`, `1.`, or rephrase.
+-   Referring to issue `#NNN` of a *different* repository. GitHub instead links it to issue `NNN` of this repo. **Fix:** use qualified syntax `owner/repo#NNN` or an absolute URL `https://github.com/owner/repo/issues/NNN`.
+
+For references to issues/PRs in **this** repo, also use the qualified form `pnpm/pnpm#NNN` or the absolute URL `https://github.com/pnpm/pnpm/issues/NNN`. Qualified syntax and absolute URLs are always unambiguous, so this rule is applied to every `#NNN` without exception.
+
+**Address the root cause when the hook fires.** Rewrite the reference into the correct unambiguous form. Never bypass the check with `git commit --no-verify`, by editing or deleting the hook, or with any suppression file.
+
 ## Changesets (TypeScript only)
 
 If your changes affect published packages, you MUST create a changeset file in the `.changeset` directory. The changeset file should describe the change and specify the packages that are affected with the pending version bump types: patch, minor, or major.


### PR DESCRIPTION
## What

Adds a `commit-msg` git hook that **rejects commit messages containing a bare `#`+digits issue/PR reference** (e.g. `#123`), and documents the rule in `AGENTS.md` (symlinked as `CLAUDE.md`).

## Why

GitHub auto-links any bare `#`+number to an issue/PR **of this repo**, which is almost never what such a reference means. This is a frequent AI mistake in two forms:

- **List enumeration** — using `#1`, `#2`, `#3` to point at numbered items in the body. GitHub instead links them to unrelated issues of this repo.
- **Cross-repo references** — meaning issue N of a *different* repo. GitHub instead links it to issue N of this repo.

Qualified `owner/repo#NNN` syntax and absolute URLs are always unambiguous, so the rule is a safe blanket policy — it applies even to references that legitimately point at this repo.

## How

- `.husky/reject-bare-issue-refs.mjs` — scans the commit message (git comment lines are stripped first, matching git's own behavior) and rejects bare references while allowing qualified forms (`owner/repo#NNN`) and absolute URLs. On failure it prints a clear, instructive error explaining which case applies and how to fix it.
- `.husky/commit-msg` — runs the check before `commitlint`.
- `AGENTS.md` — documents the rule, instructs addressing the root cause (never bypass with `--no-verify`/suppression files), and reminds agents to install the git hooks (`pnpm install` / `pnpm exec husky`) before committing.

## Notes

- Pacquet parity: out of scope — this is repo tooling, not part of pacquet's `install`/`add`/`update`/`remove` surface.
- No changeset: no published package is affected.

---
Written by an agent (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic commit message validation that rejects bare issue references (such as `#123`) and requires qualified references (e.g., `org/repo#123`) or full URLs to prevent GitHub mis-linking issues.

* **Documentation**
  * Updated developer documentation with Git hooks installation requirements and new commit message conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->