### PR TITLE
feat(pnpr): revalidate stale packuments with conditional GET to upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ privatePackages/store
 
 ## Verdaccio storage
 storage
+# ...but not the pnpr crate's `storage` source module (the bare rule above
+# is unanchored and would otherwise swallow this source directory).
+!/pnpr/crates/pnpr/src/storage/
+!/pnpr/crates/pnpr/src/storage/**
 
 yarn.lock
 

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -8,11 +8,11 @@ use crate::{
         PendingAttachment, extract_attachments, iso_from_unix_millis, merge_manifest, now_iso,
         stream_decode_verify_and_write,
     },
-    storage::Storage,
+    storage::{CachedPackument, Storage},
     streaming,
     upstream::{
-        FetchOutcome, PackumentFetch, Upstream, abbreviate_packument, extract_version_manifest,
-        rewrite_tarball_urls,
+        CacheValidators, FetchOutcome, PackumentFetch, Upstream, abbreviate_packument,
+        extract_version_manifest, rewrite_tarball_urls,
     },
 };
 use axum::{
@@ -1598,27 +1598,25 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
     // reverse. The conditional GET on the stale path keeps a high `ttl`
     // cheap (a `304` refreshes the entry without re-downloading it).
     let ttl = state.inner.config.packument_ttl;
-    let cached = match state.inner.storage.read_cached_packument_entry(name, ttl).await {
-        Ok(entry) => entry,
+    // A fresh entry serves immediately (and moves its bytes out — a
+    // packument can be multiple MB). A stale entry yields only its
+    // validators; its body stays on disk until a `304`/error path below
+    // actually needs it, so the common stale→`200` refresh never reads it.
+    let validators = match state.inner.storage.read_cached_packument_entry(name, ttl).await {
+        Ok(Some(CachedPackument::Fresh(bytes))) => {
+            record_cache_status("hit");
+            return PackumentLoad::Ok(bytes);
+        }
+        Ok(Some(CachedPackument::Stale(validators))) => validators,
+        Ok(None) => CacheValidators::default(),
         Err(err) => {
             tracing::warn!(?err, package = %name.as_str(), "cache read failed");
-            None
+            CacheValidators::default()
         }
-    };
-    // Move the bytes out on a fresh hit instead of cloning — a packument
-    // can be multiple MB. `cached` is rebound to whatever's left (the
-    // stale entry, or `None`) for the revalidation path below.
-    let cached = match cached {
-        Some(entry) if entry.fresh => {
-            record_cache_status("hit");
-            return PackumentLoad::Ok(entry.bytes);
-        }
-        other => other,
     };
 
     // Revalidate conditionally when we hold a stale copy: the upstream
     // can answer `304` and save us re-downloading an unchanged packument.
-    let validators = cached.as_ref().map(|entry| entry.validators.clone()).unwrap_or_default();
     match upstream.fetch_packument(name, &validators).await {
         Ok(PackumentFetch::Modified(fetched)) => {
             if let Err(err) = state
@@ -1632,36 +1630,36 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
             record_cache_status("miss");
             PackumentLoad::Ok(fetched.bytes)
         }
-        Ok(PackumentFetch::NotModified) => match cached {
-            // Re-write the unchanged bytes to bump the cache mtime, so
-            // the entry is fresh again and we don't revalidate on every
-            // request until the next TTL window.
-            Some(entry) => {
-                if let Err(err) = state
-                    .inner
-                    .storage
-                    .write_cached_packument(name, &entry.bytes, &entry.validators)
-                    .await
-                {
-                    tracing::warn!(?err, package = %name.as_str(), "packument cache refresh failed");
+        // `304` confirmed our stale copy is current: read it now (deferred
+        // until here), re-write it to bump the cache mtime so it's fresh
+        // again until the next TTL window, and serve it.
+        Ok(PackumentFetch::NotModified) => {
+            match state.inner.storage.read_cached_packument(name).await {
+                Ok(Some(bytes)) => {
+                    if let Err(err) =
+                        state.inner.storage.write_cached_packument(name, &bytes, &validators).await
+                    {
+                        tracing::warn!(?err, package = %name.as_str(), "packument cache refresh failed");
+                    }
+                    record_cache_status("revalidated");
+                    PackumentLoad::Ok(bytes)
                 }
-                record_cache_status("revalidated");
-                PackumentLoad::Ok(entry.bytes)
+                // The entry vanished between the freshness check and here (cache
+                // wiped concurrently). Rare; treat as a miss-shaped not-found
+                // rather than serving an empty body.
+                Ok(None) => PackumentLoad::NotFound,
+                Err(err) => PackumentLoad::Err(err),
             }
-            // A `304` with nothing cached can't normally happen — we only
-            // send validators when we have a stale copy. Treat it as a
-            // missing packument rather than serving an empty body.
-            None => PackumentLoad::NotFound,
-        },
+        }
         Ok(PackumentFetch::NotFound) => PackumentLoad::NotFound,
         Err(err) => {
             tracing::warn!(?err, package = %name.as_str(), "upstream packument fetch failed");
-            match cached {
-                Some(entry) => {
+            match state.inner.storage.read_cached_packument(name).await {
+                Ok(Some(bytes)) => {
                     record_cache_status("stale");
-                    PackumentLoad::Ok(entry.bytes)
+                    PackumentLoad::Ok(bytes)
                 }
-                None => PackumentLoad::Err(err),
+                _ => PackumentLoad::Err(err),
             }
         }
     }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1659,7 +1659,12 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
                     record_cache_status("stale");
                     PackumentLoad::Ok(bytes)
                 }
-                _ => PackumentLoad::Err(err),
+                // No cache to fall back on: surface the upstream failure.
+                Ok(None) => PackumentLoad::Err(err),
+                // The cache itself is unreadable: surface that I/O error
+                // rather than the upstream one — it's the more actionable
+                // failure when both go wrong.
+                Err(cache_err) => PackumentLoad::Err(cache_err),
             }
         }
     }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1581,7 +1581,9 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
         // removed after the package was mirrored).
         return match state.inner.storage.read_cached_packument(name).await {
             Ok(Some(bytes)) => {
-                record_cache_status("hit");
+                // Served regardless of age — there's no upstream left to
+                // revalidate against — so this is not a fresh `hit`.
+                record_cache_status("orphaned");
                 PackumentLoad::Ok(bytes)
             }
             Ok(None) => PackumentLoad::NotFound,
@@ -1669,13 +1671,16 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
 /// request was served against the proxy cache, surfacing as a `cache=…`
 /// field on that request's access-log record:
 ///
-/// * `hit` — served from a fresh cache entry (or, with no upstream, a
-///   leftover mirror) without contacting the upstream.
+/// * `hit` — served from a fresh cache entry (within `packument_ttl`)
+///   without contacting the upstream.
 /// * `revalidated` — entry was stale; the upstream answered `304 Not
 ///   Modified`, so the cached body was reused.
 /// * `miss` — fetched a fresh body from the upstream.
 /// * `stale` — upstream was unreachable; a stale cached body was served
 ///   as a fallback.
+/// * `orphaned` — a leftover mirror served with no upstream left to
+///   revalidate against (its `proxy:` rule was removed after the package
+///   was mirrored). Served regardless of age, so distinct from `hit`.
 /// * `hosted` — served from the authoritative hosted store (a published
 ///   or static package), bypassing the proxy cache entirely.
 ///

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1603,12 +1603,16 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
             None
         }
     };
-    if let Some(entry) = &cached
-        && entry.fresh
-    {
-        record_cache_status("hit");
-        return PackumentLoad::Ok(entry.bytes.clone());
-    }
+    // Move the bytes out on a fresh hit instead of cloning — a packument
+    // can be multiple MB. `cached` is rebound to whatever's left (the
+    // stale entry, or `None`) for the revalidation path below.
+    let cached = match cached {
+        Some(entry) if entry.fresh => {
+            record_cache_status("hit");
+            return PackumentLoad::Ok(entry.bytes);
+        }
+        other => other,
+    };
 
     // Revalidate conditionally when we hold a stale copy: the upstream
     // can answer `304` and save us re-downloading an unchanged packument.

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -11,7 +11,7 @@ use crate::{
     storage::Storage,
     streaming,
     upstream::{
-        FetchOutcome, Upstream, abbreviate_packument, extract_version_manifest,
+        FetchOutcome, PackumentFetch, Upstream, abbreviate_packument, extract_version_manifest,
         rewrite_tarball_urls,
     },
 };
@@ -207,6 +207,9 @@ pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
                         "request",
                         method = %request.method(),
                         uri = %request.uri(),
+                        // Filled in by `record_cache_status` for packument
+                        // reads (e.g. `cache=hit`); stays absent otherwise.
+                        cache = tracing::field::Empty,
                     )
                 })
                 .on_request(())
@@ -1562,7 +1565,10 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
     // authoritative: serve it as-is and never overwrite it with an
     // upstream refresh, so hosted versions can't be masked or lost.
     match state.inner.storage.read_hosted_packument(name).await {
-        Ok(Some(bytes)) => return PackumentLoad::Ok(bytes),
+        Ok(Some(bytes)) => {
+            record_cache_status("hosted");
+            return PackumentLoad::Ok(bytes);
+        }
         Ok(None) => {}
         Err(err) => {
             tracing::warn!(?err, package = %name.as_str(), "published packument read failed")
@@ -1574,36 +1580,105 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
         // left is a leftover cache entry (e.g. a `proxy:` rule was
         // removed after the package was mirrored).
         return match state.inner.storage.read_cached_packument(name).await {
-            Ok(Some(bytes)) => PackumentLoad::Ok(bytes),
+            Ok(Some(bytes)) => {
+                record_cache_status("hit");
+                PackumentLoad::Ok(bytes)
+            }
             Ok(None) => PackumentLoad::NotFound,
             Err(err) => PackumentLoad::Err(err),
         };
     };
 
+    // Freshness window for the proxy cache: a cached packument younger
+    // than `ttl` is served straight from disk; older than `ttl` it's
+    // "stale" and revalidated against the upstream below. Lower = newer
+    // versions surface sooner but more upstream traffic; higher = the
+    // reverse. The conditional GET on the stale path keeps a high `ttl`
+    // cheap (a `304` refreshes the entry without re-downloading it).
     let ttl = state.inner.config.packument_ttl;
-    match state.inner.storage.read_fresh_cached_packument(name, ttl).await {
-        Ok(Some(bytes)) => return PackumentLoad::Ok(bytes),
-        Ok(None) => {}
-        Err(err) => tracing::warn!(?err, package = %name.as_str(), "cache read failed"),
+    let cached = match state.inner.storage.read_cached_packument_entry(name, ttl).await {
+        Ok(entry) => entry,
+        Err(err) => {
+            tracing::warn!(?err, package = %name.as_str(), "cache read failed");
+            None
+        }
+    };
+    if let Some(entry) = &cached
+        && entry.fresh
+    {
+        record_cache_status("hit");
+        return PackumentLoad::Ok(entry.bytes.clone());
     }
 
-    match upstream.fetch_packument(name).await {
-        Ok(FetchOutcome::Ok(bytes)) => {
-            if let Err(err) = state.inner.storage.write_cached_packument(name, &bytes).await {
+    // Revalidate conditionally when we hold a stale copy: the upstream
+    // can answer `304` and save us re-downloading an unchanged packument.
+    let validators = cached.as_ref().map(|entry| entry.validators.clone()).unwrap_or_default();
+    match upstream.fetch_packument(name, &validators).await {
+        Ok(PackumentFetch::Modified(fetched)) => {
+            if let Err(err) = state
+                .inner
+                .storage
+                .write_cached_packument(name, &fetched.bytes, &fetched.validators)
+                .await
+            {
                 tracing::warn!(?err, package = %name.as_str(), "packument cache write failed");
             }
-            PackumentLoad::Ok(bytes)
+            record_cache_status("miss");
+            PackumentLoad::Ok(fetched.bytes)
         }
-        Ok(FetchOutcome::NotFound) => PackumentLoad::NotFound,
+        Ok(PackumentFetch::NotModified) => match cached {
+            // Re-write the unchanged bytes to bump the cache mtime, so
+            // the entry is fresh again and we don't revalidate on every
+            // request until the next TTL window.
+            Some(entry) => {
+                if let Err(err) = state
+                    .inner
+                    .storage
+                    .write_cached_packument(name, &entry.bytes, &entry.validators)
+                    .await
+                {
+                    tracing::warn!(?err, package = %name.as_str(), "packument cache refresh failed");
+                }
+                record_cache_status("revalidated");
+                PackumentLoad::Ok(entry.bytes)
+            }
+            // A `304` with nothing cached can't normally happen — we only
+            // send validators when we have a stale copy. Treat it as a
+            // missing packument rather than serving an empty body.
+            None => PackumentLoad::NotFound,
+        },
+        Ok(PackumentFetch::NotFound) => PackumentLoad::NotFound,
         Err(err) => {
             tracing::warn!(?err, package = %name.as_str(), "upstream packument fetch failed");
-            match state.inner.storage.read_cached_packument(name).await {
-                Ok(Some(bytes)) => PackumentLoad::Ok(bytes),
-                Ok(None) => PackumentLoad::Err(err),
-                Err(cache_err) => PackumentLoad::Err(cache_err),
+            match cached {
+                Some(entry) => {
+                    record_cache_status("stale");
+                    PackumentLoad::Ok(entry.bytes)
+                }
+                None => PackumentLoad::Err(err),
             }
         }
     }
+}
+
+/// Tag the current `pnpr::access` request span with how a packument
+/// request was served against the proxy cache, surfacing as a `cache=…`
+/// field on that request's access-log record:
+///
+/// * `hit` — served from a fresh cache entry (or, with no upstream, a
+///   leftover mirror) without contacting the upstream.
+/// * `revalidated` — entry was stale; the upstream answered `304 Not
+///   Modified`, so the cached body was reused.
+/// * `miss` — fetched a fresh body from the upstream.
+/// * `stale` — upstream was unreachable; a stale cached body was served
+///   as a fallback.
+/// * `hosted` — served from the authoritative hosted store (a published
+///   or static package), bypassing the proxy cache entirely.
+///
+/// A no-op when called outside a request span (e.g. unit tests), so the
+/// field is simply absent on those records.
+fn record_cache_status(status: &'static str) {
+    Span::current().record("cache", status);
 }
 
 /// Parse the on-disk packument, rewrite `dist.tarball` URLs, and

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -11,8 +11,8 @@ use crate::{
     storage::{CachedPackument, Storage},
     streaming,
     upstream::{
-        CacheValidators, FetchOutcome, PackumentFetch, Upstream, abbreviate_packument,
-        extract_version_manifest, rewrite_tarball_urls,
+        CacheValidators, FetchOutcome, FetchedPackument, PackumentFetch, Upstream,
+        abbreviate_packument, extract_version_manifest, rewrite_tarball_urls,
     },
 };
 use axum::{
@@ -1619,16 +1619,7 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
     // can answer `304` and save us re-downloading an unchanged packument.
     match upstream.fetch_packument(name, &validators).await {
         Ok(PackumentFetch::Modified(fetched)) => {
-            if let Err(err) = state
-                .inner
-                .storage
-                .write_cached_packument(name, &fetched.bytes, &fetched.validators)
-                .await
-            {
-                tracing::warn!(?err, package = %name.as_str(), "packument cache write failed");
-            }
-            record_cache_status("miss");
-            PackumentLoad::Ok(fetched.bytes)
+            store_fetched_packument(state, name, fetched).await
         }
         // `304` confirmed our stale copy is current: read it now (deferred
         // until here), re-write it to bump the cache mtime so it's fresh
@@ -1644,10 +1635,18 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
                     record_cache_status("revalidated");
                     PackumentLoad::Ok(bytes)
                 }
-                // The entry vanished between the freshness check and here (cache
-                // wiped concurrently). Rare; treat as a miss-shaped not-found
-                // rather than serving an empty body.
-                Ok(None) => PackumentLoad::NotFound,
+                // The body vanished between the freshness check and this read
+                // (cache wiped concurrently). The upstream just confirmed the
+                // package exists, so re-fetch it unconditionally and self-heal
+                // rather than 404-ing a present package.
+                Ok(None) => match upstream.fetch_packument(name, &CacheValidators::default()).await
+                {
+                    Ok(PackumentFetch::Modified(fetched)) => {
+                        store_fetched_packument(state, name, fetched).await
+                    }
+                    Ok(_) => PackumentLoad::NotFound,
+                    Err(err) => PackumentLoad::Err(err),
+                },
                 Err(err) => PackumentLoad::Err(err),
             }
         }
@@ -1668,6 +1667,23 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
             }
         }
     }
+}
+
+/// Persist a freshly fetched packument to the proxy cache and return it,
+/// tagging the access record as a `miss`. A cache-write failure is logged
+/// but not fatal — the fetched bytes are still served.
+async fn store_fetched_packument(
+    state: &AppState,
+    name: &PackageName,
+    fetched: FetchedPackument,
+) -> PackumentLoad {
+    if let Err(err) =
+        state.inner.storage.write_cached_packument(name, &fetched.bytes, &fetched.validators).await
+    {
+        tracing::warn!(?err, package = %name.as_str(), "packument cache write failed");
+    }
+    record_cache_status("miss");
+    PackumentLoad::Ok(fetched.bytes)
 }
 
 /// Tag the current `pnpr::access` request span with how a packument

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -80,14 +80,19 @@ impl TarballWrite {
     }
 }
 
-/// A cached upstream packument read back from disk: its bytes, whether
-/// it's still within the TTL, and the conditional-GET validators stored
-/// alongside it.
+/// A cached upstream packument, read at a granularity that avoids loading
+/// the (potentially multi-MB) body when it isn't needed:
+///
+/// * `Fresh` — within the TTL; the body is read and ready to serve.
+/// * `Stale` — past the TTL; only the small conditional-GET validators
+///   are loaded. The body is left on disk and pulled on demand by the
+///   caller (via [`Storage::read_cached_packument`]) only if the upstream
+///   answers `304` or is unreachable — the common stale→`200` refresh
+///   discards the old body, so it's never read.
 #[derive(Debug)]
-pub struct CachedPackument {
-    pub bytes: Vec<u8>,
-    pub fresh: bool,
-    pub validators: CacheValidators,
+pub enum CachedPackument {
+    Fresh(Vec<u8>),
+    Stale(CacheValidators),
 }
 
 /// Verdaccio-shaped storage split into two stores with different
@@ -278,12 +283,12 @@ impl Storage {
 
     // --- Disposable (proxy) cache store ---------------------------------
 
-    /// Read the cached upstream packument together with its freshness
-    /// (against `ttl`) and stored conditional-GET validators. Returns
-    /// `Ok(None)` only when nothing is cached. A stale entry
-    /// (`fresh == false`) still comes back with its bytes and validators
-    /// so the caller can revalidate it conditionally and fall back to the
-    /// stale bytes if the upstream is unreachable.
+    /// Classify the cached upstream packument against `ttl`: a
+    /// [`CachedPackument::Fresh`] entry comes back with its body ready to
+    /// serve; a [`CachedPackument::Stale`] one comes back with only its
+    /// validators, deferring the (possibly large) body read to the caller
+    /// via [`Self::read_cached_packument`]. Returns `Ok(None)` when
+    /// nothing is cached.
     pub async fn read_cached_packument_entry(
         &self,
         name: &PackageName,
@@ -375,9 +380,14 @@ impl Store {
         };
         let mtime = metadata.modified().map_err(RegistryError::Io)?;
         let age = SystemTime::now().duration_since(mtime).unwrap_or(Duration::ZERO);
-        let bytes = fs::read(&path).await?;
-        let validators = self.read_validators(name).await;
-        Ok(Some(CachedPackument { bytes, fresh: age <= ttl, validators }))
+        if age <= ttl {
+            // Fresh: read the body to serve it; validators aren't needed.
+            Ok(Some(CachedPackument::Fresh(fs::read(&path).await?)))
+        } else {
+            // Stale: load only the validators for the conditional refetch.
+            // The body is read later, on demand, and only if needed.
+            Ok(Some(CachedPackument::Stale(self.read_validators(name).await)))
+        }
     }
 
     /// Best-effort read of the validator sidecar. A missing, unreadable,

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -4,6 +4,7 @@ use crate::{
     package_name::PackageName,
     s3::S3Store,
     streaming,
+    upstream::CacheValidators,
 };
 use axum::body::Body;
 use std::{
@@ -18,6 +19,13 @@ use std::{
 use tokio::{fs, io::AsyncWriteExt};
 
 const PACKUMENT_FILE: &str = "package.json";
+
+/// Sidecar holding the cached packument's conditional-GET validators
+/// (see [`CacheValidators`]). Lives next to [`PACKUMENT_FILE`] in the
+/// disposable cache store only; hosted packuments have no upstream to
+/// revalidate against. The leading dot keeps it out of the
+/// package-listing walk and any static-serve view.
+const PACKUMENT_META_FILE: &str = ".package.json.meta";
 
 /// Per-process counter feeding [`unique_tmp_path`] so two concurrent
 /// writes to the same path don't collide on the same temp filename.
@@ -70,6 +78,16 @@ impl TarballWrite {
         drop(self.file);
         let _ = fs::remove_file(&self.tmp_path).await;
     }
+}
+
+/// A cached upstream packument read back from disk: its bytes, whether
+/// it's still within the TTL, and the conditional-GET validators stored
+/// alongside it.
+#[derive(Debug)]
+pub struct CachedPackument {
+    pub bytes: Vec<u8>,
+    pub fresh: bool,
+    pub validators: CacheValidators,
 }
 
 /// Verdaccio-shaped storage split into two stores with different
@@ -260,24 +278,37 @@ impl Storage {
 
     // --- Disposable (proxy) cache store ---------------------------------
 
-    /// Read a cached upstream packument if it exists and is newer than
-    /// `now - ttl`.
-    pub async fn read_fresh_cached_packument(
+    /// Read the cached upstream packument together with its freshness
+    /// (against `ttl`) and stored conditional-GET validators. Returns
+    /// `Ok(None)` only when nothing is cached. A stale entry
+    /// (`fresh == false`) still comes back with its bytes and validators
+    /// so the caller can revalidate it conditionally and fall back to the
+    /// stale bytes if the upstream is unreachable.
+    pub async fn read_cached_packument_entry(
         &self,
         name: &PackageName,
         ttl: Duration,
-    ) -> Result<Option<Vec<u8>>> {
-        self.cached.read_fresh_packument(name, ttl).await
+    ) -> Result<Option<CachedPackument>> {
+        self.cached.read_packument_entry(name, ttl).await
     }
 
     /// Read whatever cached upstream packument is on disk, fresh or
-    /// stale. Used as a fallback when the upstream is unreachable.
+    /// stale. Used when there's no upstream left to revalidate against.
     pub async fn read_cached_packument(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
         self.cached.read_packument_any_age(name).await
     }
 
-    pub async fn write_cached_packument(&self, name: &PackageName, bytes: &[u8]) -> Result<()> {
-        self.cached.write_packument(name, bytes).await
+    /// Write a cached upstream packument and its validators, refreshing
+    /// the entry's freshness. Called both on a fresh upstream body and
+    /// on a `304` revalidation (re-written with the unchanged bytes to
+    /// bump the cache mtime).
+    pub async fn write_cached_packument(
+        &self,
+        name: &PackageName,
+        bytes: &[u8],
+        validators: &CacheValidators,
+    ) -> Result<()> {
+        self.cached.write_packument_with_meta(name, bytes, validators).await
     }
 
     /// Create and open a per-request temp file for a proxied tarball.
@@ -331,11 +362,11 @@ impl Store {
         Self { root }
     }
 
-    async fn read_fresh_packument(
+    async fn read_packument_entry(
         &self,
         name: &PackageName,
         ttl: Duration,
-    ) -> Result<Option<Vec<u8>>> {
+    ) -> Result<Option<CachedPackument>> {
         let path = self.packument_path(name);
         let metadata = match fs::metadata(&path).await {
             Ok(m) => m,
@@ -344,10 +375,19 @@ impl Store {
         };
         let mtime = metadata.modified().map_err(RegistryError::Io)?;
         let age = SystemTime::now().duration_since(mtime).unwrap_or(Duration::ZERO);
-        if age > ttl {
-            return Ok(None);
+        let bytes = fs::read(&path).await?;
+        let validators = self.read_validators(name).await;
+        Ok(Some(CachedPackument { bytes, fresh: age <= ttl, validators }))
+    }
+
+    /// Best-effort read of the validator sidecar. A missing, unreadable,
+    /// or malformed sidecar yields empty validators so the next refresh
+    /// falls back to an unconditional GET rather than failing.
+    async fn read_validators(&self, name: &PackageName) -> CacheValidators {
+        match fs::read(self.packument_meta_path(name)).await {
+            Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_default(),
+            Err(_) => CacheValidators::default(),
         }
-        Ok(Some(fs::read(&path).await?))
     }
 
     async fn read_packument_any_age(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
@@ -362,6 +402,31 @@ impl Store {
     async fn write_packument(&self, name: &PackageName, bytes: &[u8]) -> Result<()> {
         let path = self.packument_path(name);
         write_atomic(&path, bytes).await
+    }
+
+    /// Write the packument and persist (or clear) its validator sidecar.
+    /// The packument is written first so a sidecar never points at bytes
+    /// that aren't on disk yet. When `validators` is empty the sidecar is
+    /// removed, so a later read can't replay a stale `ETag` against fresh
+    /// bytes that no longer carry one.
+    async fn write_packument_with_meta(
+        &self,
+        name: &PackageName,
+        bytes: &[u8],
+        validators: &CacheValidators,
+    ) -> Result<()> {
+        write_atomic(&self.packument_path(name), bytes).await?;
+        let meta_path = self.packument_meta_path(name);
+        if validators.is_empty() {
+            match fs::remove_file(&meta_path).await {
+                Ok(()) => {}
+                Err(err) if err.kind() == ErrorKind::NotFound => {}
+                Err(err) => return Err(err.into()),
+            }
+        } else {
+            write_atomic(&meta_path, &serde_json::to_vec(validators)?).await?;
+        }
+        Ok(())
     }
 
     async fn open_tarball(
@@ -489,6 +554,10 @@ impl Store {
 
     fn packument_path(&self, name: &PackageName) -> PathBuf {
         self.package_dir(name).join(PACKUMENT_FILE)
+    }
+
+    fn packument_meta_path(&self, name: &PackageName) -> PathBuf {
+        self.package_dir(name).join(PACKUMENT_META_FILE)
     }
 
     fn tarball_path(&self, name: &PackageName, filename: &str) -> PathBuf {

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -592,3 +592,6 @@ pub(crate) fn unique_tmp_path(base: &Path) -> PathBuf {
         None => PathBuf::from(name),
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpr/crates/pnpr/src/storage/tests.rs
+++ b/pnpr/crates/pnpr/src/storage/tests.rs
@@ -1,0 +1,144 @@
+use super::*;
+use tempfile::TempDir;
+
+fn storage_in(tmp: &TempDir) -> Storage {
+    Storage::new(&HostedStoreConfig::Fs, tmp.path().join("storage"), tmp.path().join("cache"))
+}
+
+fn pkg(name: &str) -> PackageName {
+    PackageName::parse(name).unwrap()
+}
+
+fn validators(etag: Option<&str>, last_modified: Option<&str>) -> CacheValidators {
+    CacheValidators {
+        etag: etag.map(str::to_string),
+        last_modified: last_modified.map(str::to_string),
+    }
+}
+
+/// The cached-store sidecar path `write_cached_packument` maintains.
+fn sidecar_path(tmp: &TempDir, name: &str) -> PathBuf {
+    tmp.path().join("cache").join(name).join(PACKUMENT_META_FILE)
+}
+
+#[tokio::test]
+async fn cached_packument_round_trips_with_validators() {
+    let tmp = TempDir::new().unwrap();
+    let storage = storage_in(&tmp);
+    let name = pkg("foo");
+    let body = br#"{"name":"foo"}"#;
+
+    storage
+        .write_cached_packument(
+            &name,
+            body,
+            &validators(Some(r#""abc""#), Some("Wed, 21 Oct 2015 07:28:00 GMT")),
+        )
+        .await
+        .unwrap();
+
+    let entry = storage
+        .read_cached_packument_entry(&name, Duration::from_secs(60))
+        .await
+        .unwrap()
+        .expect("entry present");
+    assert_eq!(entry.bytes, body);
+    assert!(entry.fresh, "a just-written entry is within ttl");
+    assert_eq!(entry.validators.etag.as_deref(), Some(r#""abc""#));
+    assert_eq!(entry.validators.last_modified.as_deref(), Some("Wed, 21 Oct 2015 07:28:00 GMT"));
+}
+
+#[tokio::test]
+async fn missing_cached_packument_reads_as_none() {
+    let tmp = TempDir::new().unwrap();
+    let storage = storage_in(&tmp);
+    let entry =
+        storage.read_cached_packument_entry(&pkg("absent"), Duration::from_secs(60)).await.unwrap();
+    assert!(entry.is_none());
+}
+
+#[tokio::test]
+async fn empty_validators_remove_a_previously_written_sidecar() {
+    let tmp = TempDir::new().unwrap();
+    let storage = storage_in(&tmp);
+    let name = pkg("foo");
+
+    storage.write_cached_packument(&name, b"{}", &validators(Some(r#""v1""#), None)).await.unwrap();
+    assert!(sidecar_path(&tmp, "foo").exists(), "validators write a sidecar");
+
+    // A later refresh whose upstream sends no validators must drop the
+    // stale sidecar so the next read can't replay an outdated ETag.
+    storage.write_cached_packument(&name, b"{}", &CacheValidators::default()).await.unwrap();
+    assert!(!sidecar_path(&tmp, "foo").exists(), "empty validators remove the sidecar");
+
+    let entry =
+        storage.read_cached_packument_entry(&name, Duration::from_secs(60)).await.unwrap().unwrap();
+    assert!(entry.validators.is_empty());
+}
+
+#[tokio::test]
+async fn writing_without_validators_is_a_noop_when_no_sidecar_exists() {
+    let tmp = TempDir::new().unwrap();
+    let storage = storage_in(&tmp);
+    let name = pkg("foo");
+
+    // First write already carries no validators: removing the (absent)
+    // sidecar must be a benign no-op, not an error.
+    storage.write_cached_packument(&name, b"{}", &CacheValidators::default()).await.unwrap();
+    assert!(!sidecar_path(&tmp, "foo").exists());
+
+    let entry =
+        storage.read_cached_packument_entry(&name, Duration::from_secs(60)).await.unwrap().unwrap();
+    assert!(entry.validators.is_empty());
+}
+
+#[tokio::test]
+async fn malformed_sidecar_reads_as_empty_validators() {
+    let tmp = TempDir::new().unwrap();
+    let storage = storage_in(&tmp);
+    let name = pkg("foo");
+    storage.write_cached_packument(&name, b"{}", &validators(Some(r#""v1""#), None)).await.unwrap();
+
+    // A damaged sidecar must degrade to empty validators (forcing an
+    // unconditional refresh) rather than failing the read.
+    fs::write(sidecar_path(&tmp, "foo"), b"not json").await.unwrap();
+
+    let entry =
+        storage.read_cached_packument_entry(&name, Duration::from_secs(60)).await.unwrap().unwrap();
+    assert!(entry.validators.is_empty());
+}
+
+#[tokio::test]
+async fn entry_past_ttl_is_stale_but_keeps_bytes_and_validators() {
+    let tmp = TempDir::new().unwrap();
+    let storage = storage_in(&tmp);
+    let name = pkg("foo");
+    storage.write_cached_packument(&name, b"{}", &validators(Some(r#""v1""#), None)).await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let entry = storage
+        .read_cached_packument_entry(&name, Duration::from_millis(1))
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(!entry.fresh, "an entry older than ttl is stale");
+    // A stale entry still surfaces its bytes + validators so the caller
+    // can revalidate conditionally and fall back to the stale body.
+    assert_eq!(entry.bytes, b"{}");
+    assert_eq!(entry.validators.etag.as_deref(), Some(r#""v1""#));
+}
+
+#[tokio::test]
+async fn read_cached_packument_returns_bytes_regardless_of_age() {
+    let tmp = TempDir::new().unwrap();
+    let storage = storage_in(&tmp);
+    let name = pkg("foo");
+    storage
+        .write_cached_packument(&name, br#"{"v":1}"#, &CacheValidators::default())
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    let bytes = storage.read_cached_packument(&name).await.unwrap();
+    assert_eq!(bytes.as_deref(), Some(&br#"{"v":1}"#[..]));
+}

--- a/pnpr/crates/pnpr/src/storage/tests.rs
+++ b/pnpr/crates/pnpr/src/storage/tests.rs
@@ -21,31 +21,49 @@ fn sidecar_path(tmp: &TempDir, name: &str) -> PathBuf {
     tmp.path().join("cache").join(name).join(PACKUMENT_META_FILE)
 }
 
+/// Read an entry back as `Stale` so its validators can be inspected. The
+/// write is aged past a 1ms TTL with a short sleep.
+async fn read_stale_validators(storage: &Storage, name: &PackageName) -> CacheValidators {
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    match storage.read_cached_packument_entry(name, Duration::from_millis(1)).await.unwrap() {
+        Some(CachedPackument::Stale(validators)) => validators,
+        other => panic!("expected a stale entry, got {other:?}"),
+    }
+}
+
 #[tokio::test]
-async fn cached_packument_round_trips_with_validators() {
+async fn fresh_entry_returns_its_body() {
     let tmp = TempDir::new().unwrap();
     let storage = storage_in(&tmp);
     let name = pkg("foo");
     let body = br#"{"name":"foo"}"#;
 
+    storage.write_cached_packument(&name, body, &validators(Some(r#""abc""#), None)).await.unwrap();
+
+    match storage.read_cached_packument_entry(&name, Duration::from_secs(60)).await.unwrap() {
+        Some(CachedPackument::Fresh(bytes)) => assert_eq!(bytes, body),
+        other => panic!("expected a fresh entry, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn stale_entry_returns_its_validators() {
+    let tmp = TempDir::new().unwrap();
+    let storage = storage_in(&tmp);
+    let name = pkg("foo");
+
     storage
         .write_cached_packument(
             &name,
-            body,
+            b"{}",
             &validators(Some(r#""abc""#), Some("Wed, 21 Oct 2015 07:28:00 GMT")),
         )
         .await
         .unwrap();
 
-    let entry = storage
-        .read_cached_packument_entry(&name, Duration::from_secs(60))
-        .await
-        .unwrap()
-        .expect("entry present");
-    assert_eq!(entry.bytes, body);
-    assert!(entry.fresh, "a just-written entry is within ttl");
-    assert_eq!(entry.validators.etag.as_deref(), Some(r#""abc""#));
-    assert_eq!(entry.validators.last_modified.as_deref(), Some("Wed, 21 Oct 2015 07:28:00 GMT"));
+    let validators = read_stale_validators(&storage, &name).await;
+    assert_eq!(validators.etag.as_deref(), Some(r#""abc""#));
+    assert_eq!(validators.last_modified.as_deref(), Some("Wed, 21 Oct 2015 07:28:00 GMT"));
 }
 
 #[tokio::test]
@@ -71,9 +89,7 @@ async fn empty_validators_remove_a_previously_written_sidecar() {
     storage.write_cached_packument(&name, b"{}", &CacheValidators::default()).await.unwrap();
     assert!(!sidecar_path(&tmp, "foo").exists(), "empty validators remove the sidecar");
 
-    let entry =
-        storage.read_cached_packument_entry(&name, Duration::from_secs(60)).await.unwrap().unwrap();
-    assert!(entry.validators.is_empty());
+    assert!(read_stale_validators(&storage, &name).await.is_empty());
 }
 
 #[tokio::test]
@@ -87,9 +103,7 @@ async fn writing_without_validators_is_a_noop_when_no_sidecar_exists() {
     storage.write_cached_packument(&name, b"{}", &CacheValidators::default()).await.unwrap();
     assert!(!sidecar_path(&tmp, "foo").exists());
 
-    let entry =
-        storage.read_cached_packument_entry(&name, Duration::from_secs(60)).await.unwrap().unwrap();
-    assert!(entry.validators.is_empty());
+    assert!(read_stale_validators(&storage, &name).await.is_empty());
 }
 
 #[tokio::test]
@@ -103,29 +117,7 @@ async fn malformed_sidecar_reads_as_empty_validators() {
     // unconditional refresh) rather than failing the read.
     fs::write(sidecar_path(&tmp, "foo"), b"not json").await.unwrap();
 
-    let entry =
-        storage.read_cached_packument_entry(&name, Duration::from_secs(60)).await.unwrap().unwrap();
-    assert!(entry.validators.is_empty());
-}
-
-#[tokio::test]
-async fn entry_past_ttl_is_stale_but_keeps_bytes_and_validators() {
-    let tmp = TempDir::new().unwrap();
-    let storage = storage_in(&tmp);
-    let name = pkg("foo");
-    storage.write_cached_packument(&name, b"{}", &validators(Some(r#""v1""#), None)).await.unwrap();
-
-    tokio::time::sleep(Duration::from_millis(20)).await;
-    let entry = storage
-        .read_cached_packument_entry(&name, Duration::from_millis(1))
-        .await
-        .unwrap()
-        .unwrap();
-    assert!(!entry.fresh, "an entry older than ttl is stale");
-    // A stale entry still surfaces its bytes + validators so the caller
-    // can revalidate conditionally and fall back to the stale body.
-    assert_eq!(entry.bytes, b"{}");
-    assert_eq!(entry.validators.etag.as_deref(), Some(r#""v1""#));
+    assert!(read_stale_validators(&storage, &name).await.is_empty());
 }
 
 #[tokio::test]

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -5,7 +5,11 @@ use crate::{
 };
 use chrono::{DateTime, Duration, Timelike, Utc};
 use pacquet_network::ThrottledClient;
-use reqwest::{StatusCode, header::HeaderMap};
+use reqwest::{
+    StatusCode,
+    header::{self, HeaderMap, HeaderValue},
+};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{fmt, sync::Arc};
 
@@ -42,14 +46,97 @@ pub enum FetchOutcome<Payload> {
     NotFound,
 }
 
+/// Conditional-GET validators captured from an upstream packument
+/// response (its `ETag` / `Last-Modified`) and replayed on the next
+/// refresh as `If-None-Match` / `If-Modified-Since`. An upstream that
+/// emits neither leaves both `None`, and the refresh falls back to an
+/// unconditional GET.
+///
+/// Persisted verbatim in a sidecar next to the cached packument (see
+/// [`crate::storage`]); the field names double as the on-disk JSON keys.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct CacheValidators {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub etag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub last_modified: Option<String>,
+}
+
+impl CacheValidators {
+    pub fn is_empty(&self) -> bool {
+        self.etag.is_none() && self.last_modified.is_none()
+    }
+
+    fn from_headers(headers: &HeaderMap) -> Self {
+        let get =
+            |name| headers.get(name).and_then(|value| value.to_str().ok()).map(str::to_string);
+        Self { etag: get(header::ETAG), last_modified: get(header::LAST_MODIFIED) }
+    }
+}
+
+/// A packument fetched (or revalidated) against an upstream.
+#[derive(Debug)]
+pub struct FetchedPackument {
+    pub bytes: Vec<u8>,
+    pub validators: CacheValidators,
+}
+
+/// Outcome of a (possibly conditional) packument fetch.
+#[derive(Debug)]
+pub enum PackumentFetch {
+    /// Upstream returned a fresh body, along with its cache validators.
+    Modified(FetchedPackument),
+    /// Upstream answered `304 Not Modified`: the validators we sent are
+    /// still current, so the caller should keep serving its cached copy.
+    NotModified,
+    /// Upstream returned 404.
+    NotFound,
+}
+
 impl Upstream {
     pub fn new(base: String, headers: HeaderMap) -> Self {
         Self { client: Arc::new(ThrottledClient::new_for_installs()), base, headers }
     }
 
-    pub async fn fetch_packument(&self, name: &PackageName) -> Result<FetchOutcome<Vec<u8>>> {
+    /// Fetch a package's packument, conditionally when `validators`
+    /// carries an `ETag`/`Last-Modified`. A `304 Not Modified` short-
+    /// circuits to [`PackumentFetch::NotModified`] without a body, so the
+    /// caller can keep serving its cached copy — the bandwidth win on a
+    /// stale-but-current packument.
+    pub async fn fetch_packument(
+        &self,
+        name: &PackageName,
+        validators: &CacheValidators,
+    ) -> Result<PackumentFetch> {
         let url = format!("{}/{}", self.base.trim_end_matches('/'), name.as_str());
-        self.fetch(&url).await
+        let client = self.client.acquire_for_url(&url).await;
+        let mut request = client.get(&url).headers(self.headers.clone());
+        if let Some(etag) = &validators.etag
+            && let Ok(value) = HeaderValue::from_str(etag)
+        {
+            request = request.header(header::IF_NONE_MATCH, value);
+        }
+        if let Some(last_modified) = &validators.last_modified
+            && let Ok(value) = HeaderValue::from_str(last_modified)
+        {
+            request = request.header(header::IF_MODIFIED_SINCE, value);
+        }
+        let response = request
+            .send()
+            .await
+            .map_err(|source| RegistryError::Upstream { url: url.clone(), source })?;
+        match response.status() {
+            StatusCode::NOT_FOUND => return Ok(PackumentFetch::NotFound),
+            StatusCode::NOT_MODIFIED => return Ok(PackumentFetch::NotModified),
+            _ => {}
+        }
+        let response = check_status(response, &url).await?;
+        let validators = CacheValidators::from_headers(response.headers());
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|source| RegistryError::Upstream { url: url.clone(), source })?;
+        Ok(PackumentFetch::Modified(FetchedPackument { bytes: bytes.to_vec(), validators }))
     }
 
     /// Send the tarball request and return the streaming
@@ -74,25 +161,6 @@ impl Upstream {
         }
         let response = check_status(response, &url).await?;
         Ok(FetchOutcome::Ok(response))
-    }
-
-    async fn fetch(&self, url: &str) -> Result<FetchOutcome<Vec<u8>>> {
-        let client = self.client.acquire_for_url(url).await;
-        let response = client
-            .get(url)
-            .headers(self.headers.clone())
-            .send()
-            .await
-            .map_err(|source| RegistryError::Upstream { url: url.to_string(), source })?;
-        if response.status() == StatusCode::NOT_FOUND {
-            return Ok(FetchOutcome::NotFound);
-        }
-        let response = check_status(response, url).await?;
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|source| RegistryError::Upstream { url: url.to_string(), source })?;
-        Ok(FetchOutcome::Ok(bytes.to_vec()))
     }
 }
 

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -111,24 +111,33 @@ impl Upstream {
         let url = format!("{}/{}", self.base.trim_end_matches('/'), name.as_str());
         let client = self.client.acquire_for_url(&url).await;
         let mut request = client.get(&url).headers(self.headers.clone());
+        let mut sent_conditional = false;
         if let Some(etag) = &validators.etag
             && let Ok(value) = HeaderValue::from_str(etag)
         {
             request = request.header(header::IF_NONE_MATCH, value);
+            sent_conditional = true;
         }
         if let Some(last_modified) = &validators.last_modified
             && let Ok(value) = HeaderValue::from_str(last_modified)
         {
             request = request.header(header::IF_MODIFIED_SINCE, value);
+            sent_conditional = true;
         }
         let response = request
             .send()
             .await
             .map_err(|source| RegistryError::Upstream { url: url.clone(), source })?;
-        match response.status() {
-            StatusCode::NOT_FOUND => return Ok(PackumentFetch::NotFound),
-            StatusCode::NOT_MODIFIED => return Ok(PackumentFetch::NotModified),
-            _ => {}
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(PackumentFetch::NotFound);
+        }
+        // Only honor a `304` if we actually sent a conditional header. A
+        // `304` to an unconditional request is a misbehaving upstream and
+        // carries no body to serve, so let it fall through to
+        // `check_status` and surface as an upstream status error rather
+        // than reusing a (possibly nonexistent) cached copy.
+        if sent_conditional && response.status() == StatusCode::NOT_MODIFIED {
+            return Ok(PackumentFetch::NotModified);
         }
         let response = check_status(response, &url).await?;
         let validators = CacheValidators::from_headers(response.headers());

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -1,5 +1,6 @@
 use super::{
-    FetchOutcome, Upstream, abbreviate_packument, extract_version_manifest, rewrite_tarball_urls,
+    CacheValidators, FetchOutcome, PackumentFetch, Upstream, abbreviate_packument,
+    extract_version_manifest, rewrite_tarball_urls,
 };
 use crate::package_name::PackageName;
 use chrono::{DateTime, TimeZone, Utc};
@@ -39,9 +40,9 @@ async fn fetch_packument_forwards_configured_headers() {
 
     let upstream = Upstream::new(server.url(), auth_and_custom_headers());
     let name = PackageName::parse("foo").unwrap();
-    let outcome = upstream.fetch_packument(&name).await.unwrap();
+    let outcome = upstream.fetch_packument(&name, &CacheValidators::default()).await.unwrap();
 
-    assert!(matches!(outcome, FetchOutcome::Ok(_)));
+    assert!(matches!(outcome, PackumentFetch::Modified(_)));
     mock.assert_async().await;
 }
 
@@ -80,9 +81,71 @@ async fn fetch_packument_sends_no_authorization_when_headers_empty() {
 
     let upstream = Upstream::new(server.url(), HeaderMap::new());
     let name = PackageName::parse("foo").unwrap();
-    let outcome = upstream.fetch_packument(&name).await.unwrap();
+    let outcome = upstream.fetch_packument(&name, &CacheValidators::default()).await.unwrap();
 
-    assert!(matches!(outcome, FetchOutcome::Ok(_)));
+    assert!(matches!(outcome, PackumentFetch::Modified(_)));
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn fetch_packument_captures_validators_from_response() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_header("etag", r#""abc123""#)
+        .with_header("last-modified", "Wed, 21 Oct 2015 07:28:00 GMT")
+        .with_body(json!({ "name": "foo" }).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let upstream = Upstream::new(server.url(), HeaderMap::new());
+    let name = PackageName::parse("foo").unwrap();
+    let outcome = upstream.fetch_packument(&name, &CacheValidators::default()).await.unwrap();
+
+    let PackumentFetch::Modified(fetched) = outcome else { panic!("expected a body") };
+    assert_eq!(fetched.validators.etag.as_deref(), Some(r#""abc123""#));
+    assert_eq!(fetched.validators.last_modified.as_deref(), Some("Wed, 21 Oct 2015 07:28:00 GMT"));
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn fetch_packument_replays_validators_and_handles_304() {
+    let mut server = mockito::Server::new_async().await;
+    // The mock only matches when both conditional headers are present,
+    // so a `NotModified` outcome proves they rode along on the request.
+    let mock = server
+        .mock("GET", "/foo")
+        .match_header("if-none-match", r#""abc123""#)
+        .match_header("if-modified-since", "Wed, 21 Oct 2015 07:28:00 GMT")
+        .with_status(304)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let upstream = Upstream::new(server.url(), HeaderMap::new());
+    let name = PackageName::parse("foo").unwrap();
+    let validators = CacheValidators {
+        etag: Some(r#""abc123""#.to_string()),
+        last_modified: Some("Wed, 21 Oct 2015 07:28:00 GMT".to_string()),
+    };
+    let outcome = upstream.fetch_packument(&name, &validators).await.unwrap();
+
+    assert!(matches!(outcome, PackumentFetch::NotModified));
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn fetch_packument_maps_404_to_not_found() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server.mock("GET", "/foo").with_status(404).expect(1).create_async().await;
+
+    let upstream = Upstream::new(server.url(), HeaderMap::new());
+    let name = PackageName::parse("foo").unwrap();
+    let outcome = upstream.fetch_packument(&name, &CacheValidators::default()).await.unwrap();
+
+    assert!(matches!(outcome, PackumentFetch::NotFound));
     mock.assert_async().await;
 }
 

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -137,6 +137,30 @@ async fn fetch_packument_replays_validators_and_handles_304() {
 }
 
 #[tokio::test]
+async fn fetch_packument_304_without_validators_is_an_error() {
+    let mut server = mockito::Server::new_async().await;
+    // No conditional header is sent (empty validators), so a `304` here is
+    // a misbehaving upstream — there's no body and nothing to revalidate
+    // against. It must surface as an error, not a `NotModified` that the
+    // caller could mistake for "keep serving the cache".
+    let mock = server
+        .mock("GET", "/foo")
+        .match_header("if-none-match", mockito::Matcher::Missing)
+        .match_header("if-modified-since", mockito::Matcher::Missing)
+        .with_status(304)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let upstream = Upstream::new(server.url(), HeaderMap::new());
+    let name = PackageName::parse("foo").unwrap();
+    let result = upstream.fetch_packument(&name, &CacheValidators::default()).await;
+
+    assert!(result.is_err(), "an unconditional 304 must not be treated as NotModified");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn fetch_packument_maps_404_to_not_found() {
     let mut server = mockito::Server::new_async().await;
     let mock = server.mock("GET", "/foo").with_status(404).expect(1).create_async().await;

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -352,7 +352,13 @@ async fn stale_packument_is_revalidated_with_conditional_get() {
 
     let tmp = TempDir::new().unwrap();
     let mut config = config_for(&upstream.url(), tmp.path().to_path_buf());
-    config.packument_ttl = Duration::from_millis(50);
+    // A generous TTL: r2's `304` refresh rewrites the cache file, and r3 must
+    // see that entry as fresh. The margin has to comfortably exceed the wall
+    // time between r2's refresh-write and r3's freshness check, which can spike
+    // on a contended CI runner (and is subject to coarse filesystem mtime
+    // granularity on Windows). The r1->r2 sleep stays longer than the TTL so r2
+    // is still stale.
+    config.packument_ttl = Duration::from_millis(500);
     let app = router(config);
 
     let r1 = app.clone().oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
@@ -360,7 +366,7 @@ async fn stale_packument_is_revalidated_with_conditional_get() {
     let _ = body_bytes(r1.into_body()).await;
 
     // Wait past the TTL so the cached packument is stale and gets revalidated.
-    tokio::time::sleep(Duration::from_millis(120)).await;
+    tokio::time::sleep(Duration::from_millis(700)).await;
 
     let r2 = app.clone().oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
     assert_eq!(r2.status(), StatusCode::OK);

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -321,6 +321,61 @@ async fn packument_is_refetched_after_ttl_expires() {
     mock.assert_async().await;
 }
 
+/// A stale cached packument is revalidated with a conditional GET: the
+/// upstream's `ETag` is replayed as `If-None-Match`, and a `304` lets
+/// the server serve its cached copy without re-downloading the body. The
+/// `304` also refreshes the entry, so a third request inside the TTL is
+/// served straight from cache with no upstream call at all.
+#[tokio::test]
+async fn stale_packument_is_revalidated_with_conditional_get() {
+    let mut upstream = mockito::Server::new_async().await;
+    let packument = json!({ "name": "foo", "dist-tags": { "latest": "1.0.0" }, "versions": {} });
+    // First request (no validator yet): full body plus an ETag to store.
+    let full = upstream
+        .mock("GET", "/foo")
+        .match_header("if-none-match", mockito::Matcher::Missing)
+        .with_status(200)
+        .with_header("etag", r#""v1""#)
+        .with_body(packument.to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    // Revalidation: the stored ETag comes back as If-None-Match; upstream
+    // confirms it's unchanged with a bodyless 304.
+    let revalidate = upstream
+        .mock("GET", "/foo")
+        .match_header("if-none-match", r#""v1""#)
+        .with_status(304)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for(&upstream.url(), tmp.path().to_path_buf());
+    config.packument_ttl = Duration::from_millis(50);
+    let app = router(config);
+
+    let r1 = app.clone().oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(r1.status(), StatusCode::OK);
+    let _ = body_bytes(r1.into_body()).await;
+
+    // Wait past the TTL so the cached packument is stale and gets revalidated.
+    tokio::time::sleep(Duration::from_millis(120)).await;
+
+    let r2 = app.clone().oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(r2.status(), StatusCode::OK);
+    let body: Value = serde_json::from_slice(&body_bytes(r2.into_body()).await).unwrap();
+    assert_eq!(body["dist-tags"]["latest"], "1.0.0", "304 must serve the cached body");
+
+    // The 304 refreshed the entry, so this request is within the TTL and
+    // never reaches the upstream — both mocks asserting exactly one call.
+    let r3 = app.oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(r3.status(), StatusCode::OK);
+
+    full.assert_async().await;
+    revalidate.assert_async().await;
+}
+
 /// A hosted packument is authoritative: even with a proxy upstream
 /// configured, a divergent upstream packument, and an expired TTL, the
 /// hosted copy is served verbatim and the upstream is never contacted.


### PR DESCRIPTION
> Implements the **Conditional GET to upstream (ETag, `If-Modified-Since`)** item from the pnpr ↔ verdaccio backend-parity tracking issue #11973.

## What

Adds **conditional GET revalidation** of cached upstream packuments to pnpr's proxy, mirroring verdaccio's uplink revalidation.

When a cached packument goes stale past `packument_ttl`, pnpr no longer re-downloads the whole document. Instead it replays the upstream's `ETag` / `Last-Modified` as `If-None-Match` / `If-Modified-Since`; a `304 Not Modified` lets pnpr serve its cached copy without transferring the body.

## Why

pnpr caches each package's packument (the metadata JSON listing every version) for `packument_ttl` (default 5 min). Before this PR, the post-TTL refresh was an **unconditional GET** — pnpr re-downloaded the entire packument every time, even when nothing had changed upstream. Popular packages have multi-MB packuments, so this was wasted bandwidth on every refresh.

Conditional GET turns the common "stale but unchanged" case into a bodyless `304`, so a short TTL (fresh versions surface quickly) no longer costs a full re-download each cycle.

## How it works

```
pnpm client ──GET /pkg──▶ pnpr ──GET /pkg (If-None-Match)──▶ upstream
            ◀─200 + body──      ◀──── 304 / 200 ───────────
```

1. **Store validators.** On a `200` from the upstream, pnpr captures `ETag` / `Last-Modified` and persists them in a sidecar file, `.package.json.meta`, next to the cached `package.json` (disposable proxy-cache store only — hosted packages have no upstream to revalidate against).
2. **Revalidate on staleness.** When the cached entry is older than `packument_ttl`, pnpr reads back **only the validators** (not the body) and issues the GET with them attached. A fresh entry, by contrast, is read with its body and served immediately.
3. **Handle the response:**
   - `304 Not Modified` → read the stale body (deferred until now), re-write it to bump the cache mtime so the entry is fresh again for another TTL window, and serve it.
   - `200` → store the new body + new validators, serve them. The old stale body is never read.
   - `404` → not found.
   - upstream unreachable → fall back to the stale cached body.

A conditional `304` is only honored when a validator was actually sent; a `304` to an unconditional request (e.g. a cold cache) is treated as an upstream error rather than reused.

### Access-log `cache=` field

The per-request access record now carries a `cache=` field so operators can see how each packument read was served:

```
... finished processing request status=200 cache=hit         method=GET uri=/semver
... finished processing request status=200 cache=revalidated method=GET uri=/semver
... finished processing request status=200 cache=miss        method=GET uri=/semver
```

| value | meaning |
|---|---|
| `hosted` | served from the authoritative hosted store (a package published/static-served here); no upstream involved |
| `hit` | proxied package, fresh in cache; no upstream contact |
| `revalidated` | proxied, stale, upstream answered `304`; cached body reused (network, no body) |
| `miss` | proxied, fetched a fresh body from the upstream (network + full body) |
| `stale` | proxied, upstream unreachable; served the stale cached body as a fallback |
| `orphaned` | a leftover mirror served with no upstream left to revalidate against (its `proxy:` rule was removed after mirroring); served regardless of age, so distinct from `hit` |

## Changes

- **`upstream.rs`** — `fetch_packument` now takes `&CacheValidators` and sends the conditional headers; new `PackumentFetch` enum (`Modified { bytes, validators }` / `NotModified` / `NotFound`); validators captured from response headers. A `304` is mapped to `NotModified` only when a conditional header was actually sent.
- **`storage.rs`** — validators persisted in the `.package.json.meta` sidecar; `read_cached_packument_entry` classifies against the TTL (`age <= ttl`, from the cached file's mtime) and returns a `CachedPackument` enum: `Fresh(bytes)` (body read, ready to serve) or `Stale(validators)` (only the small validators read — the body is left on disk and pulled on demand). `write_cached_packument` writes/clears the sidecar atomically.
- **`server.rs`** — `load_packument_bytes` serves a fresh entry directly, revalidates a stale one, handles `304`/`200`/`404`/error (reading the stale body only on the `304`/error paths), and tags the access span via `record_cache_status`.
- **Tests** — storage-layer unit tests (validator round-trip, sidecar removal/no-op, malformed sidecar, fresh-vs-stale classification); upstream unit tests (capture validators, replay + `304`, unconditional-`304`-is-error, `404`); an integration test (`stale_packument_is_revalidated_with_conditional_get`) covering the miss → revalidate(304) → hit lifecycle.

## Design notes

- **Lazy body read.** A stale entry's (potentially multi-MB) body isn't read during the freshness check — only its validators are. The body is read on demand only on the `304`/upstream-error paths, so the common stale→`200` refresh (and every refresh against an upstream that doesn't emit validators) never reads or allocates the discarded body.
- **mtime bump on `304`.** pnpr re-writes the unchanged bytes to refresh the mtime rather than adding a `filetime`-style dependency to touch the file in place. Packuments are modest and it avoids a new dependency — happy to switch to a pure mtime bump if preferred.

## Scope

- Part of #11973 (pnpr ↔ verdaccio backend parity); ticks off the **Conditional GET to upstream (ETag, `If-Modified-Since`)** item.
- **No changeset** — changesets are for the TypeScript published packages; pnpr is the Rust registry server.
- **No pacquet parity port** — pnpr is a standalone registry server, separate from the pnpm-CLI ↔ pacquet sync rule.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace --document-private-items`
- `cargo dylint --all -- --all-targets --workspace`
- `cargo nextest run -p pnpr` — 284 passed

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented HTTP conditional request caching to reduce bandwidth usage when validating cached packages
  * Added cache telemetry with detailed state reporting (fresh, revalidated, stale, miss)
  * Enhanced stale cache handling to gracefully serve previously cached content when upstream validation fails

* **Tests**
  * Added integration test for conditional cache revalidation behavior
  * Added unit tests for cache storage and validator persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->