### PR TITLE
fix(pacquet): reuse in-flight prefetch on the cold-batch download (race fix)

### DIFF
--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -164,9 +164,12 @@ pub struct CreateVirtualStore<'a> {
     /// being double-counted.
     pub progress_reported: &'a SharedReportedProgressKeys,
     /// Install-scoped shared in-flight tarball cache, threaded into each
-    /// per-snapshot [`InstallPackageBySnapshot`]. `Some` on the pnpr
-    /// client path so the cold-batch download reuses the prefetcher's
-    /// background downloads instead of re-fetching; `None` otherwise.
+    /// per-snapshot [`InstallPackageBySnapshot`] so the cold-batch
+    /// download reuses a background prefetcher's in-flight download
+    /// instead of re-fetching. `Some` whenever a prefetcher is active —
+    /// the pnpr client's [`crate::TarballPrefetcher`] (frozen path) or
+    /// the fresh-resolve path's [`crate::PrefetchingResolver`] (closing
+    /// <https://github.com/pnpm/pnpm/issues/12241>); `None` otherwise.
     pub tarball_mem_cache: Option<&'a std::sync::Arc<MemCache>>,
 }
 

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
@@ -53,12 +53,14 @@ pub struct InstallPackageBySnapshot<'a> {
     /// registry/tarball download routes through
     /// [`DownloadTarballToStore::run_with_mem_cache`] so it parks on (or
     /// reuses) a download already in flight or completed for the same
-    /// URL — most importantly the background downloads fired by the pnpr
-    /// client's [`crate::TarballPrefetcher`], which otherwise this pass
-    /// would redundantly re-download. `None` keeps the standalone
-    /// `run_without_mem_cache` path (no in-flight cache to share, e.g.
-    /// the fresh-lockfile materialization whose downloads already
-    /// happened during resolution).
+    /// URL, rather than racing a second fetch of the same bytes. Both
+    /// background prefetchers feed it: the pnpr client's
+    /// [`crate::TarballPrefetcher`] (frozen materialization) and the
+    /// fresh-resolve path's [`crate::PrefetchingResolver`] (cold batch,
+    /// closing the race in
+    /// <https://github.com/pnpm/pnpm/issues/12241>). `None` keeps the
+    /// standalone `run_without_mem_cache` path for installs with no
+    /// prefetcher (e.g. a plain `--frozen-lockfile` without pnpr).
     pub tarball_mem_cache: Option<&'a Arc<MemCache>>,
     /// Install-scoped package-status progress dedupe. Shared with the
     /// resolve-time prefetcher on the fresh path so the cold fallback
@@ -295,17 +297,45 @@ impl<'a> InstallPackageBySnapshot<'a> {
                     progress_reported: progress_reported.cloned(),
                 };
                 // Reuse an in-flight or completed background download
-                // (e.g. the pnpr client's prefetcher) through the shared
-                // mem cache when one is provided; otherwise fetch
-                // standalone. The owned `HashMap` is cloned out of the
-                // shared `Arc` so the rest of this pass keeps its
-                // by-value contract.
+                // through the shared mem cache when one is provided;
+                // otherwise fetch standalone. The owned `HashMap` is
+                // cloned out of the shared `Arc` so the rest of this pass
+                // keeps its by-value contract.
+                //
+                // Restricted to registry resolutions: those are the only
+                // ones the background prefetchers populate under a key
+                // this pass also writes — the pnpr `TarballPrefetcher` and
+                // the resolve-time `PrefetchingResolver` both key by
+                // `name@version`, matching the materialization store-index
+                // row. A remote tarball, by contrast, resolves with no
+                // `name_ver`, so the prefetcher skips it; its only
+                // mem-cache entry comes from the resolver's
+                // download-to-resolve, keyed by `name@version`, whereas the
+                // lockfile (and this pass) address it by `name@<url>`.
+                // Reusing that entry would skip writing the `name@<url>`
+                // store-index row a later re-resolve needs to reuse the
+                // warm store, so remote tarballs must take the standalone
+                // path. See <https://github.com/pnpm/pnpm/issues/12241>.
                 let raw_cas_paths = match tarball_mem_cache {
-                    Some(mem_cache) => download
-                        .run_with_mem_cache::<Reporter>(mem_cache)
-                        .await
-                        .map(|cas_paths| (*cas_paths).clone()),
-                    None => download.run_without_mem_cache::<Reporter>().await,
+                    Some(mem_cache)
+                        if matches!(metadata.resolution, LockfileResolution::Registry(_)) =>
+                    {
+                        // `clone()` is cheap (refs + `Arc`s) and lets us
+                        // retry through `run_without_mem_cache` below if
+                        // the shared download failed.
+                        match download.clone().run_with_mem_cache::<Reporter>(mem_cache).await {
+                            Ok(cas_paths) => Ok((*cas_paths).clone()),
+                            // The prefetch is best-effort: if the sibling
+                            // download for this URL failed (transient
+                            // network, etc.), do our own retried fetch
+                            // rather than inheriting the failure.
+                            Err(TarballError::SiblingFetchFailed { .. }) => {
+                                download.run_without_mem_cache::<Reporter>().await
+                            }
+                            Err(err) => Err(err),
+                        }
+                    }
+                    _ => download.run_without_mem_cache::<Reporter>().await,
                 }
                 .map_err(InstallPackageBySnapshotError::DownloadTarball)?;
 

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
@@ -318,7 +318,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
                 // path. See <https://github.com/pnpm/pnpm/issues/12241>.
                 let raw_cas_paths = match tarball_mem_cache {
                     Some(mem_cache)
-                        if matches!(metadata.resolution, LockfileResolution::Registry(_)) =>
+                        if matches!(&metadata.resolution, LockfileResolution::Registry(_)) =>
                     {
                         // `clone()` is cheap (refs + `Arc`s) and lets us
                         // retry through `run_without_mem_cache` below if

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot/tests.rs
@@ -295,3 +295,260 @@ fn synthesize_runtime_manifest_preserves_scoped_name() {
     assert_eq!(parsed["name"], "@foo/bar");
     assert_eq!(parsed["version"], "1.2.3");
 }
+
+/// A dummy but parseable sha512 integrity for the registry-resolution
+/// fixtures below. The download never runs in these tests (the mem
+/// cache short-circuits, or `offline` blocks), so the exact digest is
+/// irrelevant — it only has to satisfy [`ssri::Integrity`]'s parser.
+const DUMMY_SHA512: &str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
+
+fn registry_metadata() -> pacquet_lockfile::PackageMetadata {
+    pacquet_lockfile::PackageMetadata {
+        resolution: LockfileResolution::Registry(pacquet_lockfile::RegistryResolution {
+            integrity: DUMMY_SHA512.parse().expect("parse integrity"),
+        }),
+        engines: None,
+        cpu: None,
+        os: None,
+        libc: None,
+        deprecated: None,
+        has_bin: None,
+        prepare: None,
+        bundled_dependencies: None,
+        peer_dependencies: None,
+        peer_dependencies_meta: None,
+    }
+}
+
+fn leaked_offline_config(
+    registry: &str,
+    store_dir: &std::path::Path,
+) -> &'static pacquet_config::Config {
+    let mut config = pacquet_config::Config::new();
+    config.registry = registry.to_string();
+    config.store_dir = store_dir.to_path_buf().into();
+    // Force the no-mem-cache download path to fail fast instead of
+    // reaching out to the network, so a regression that bypasses the
+    // mem cache surfaces deterministically as `NoOfflineTarball`.
+    config.offline = true;
+    config.leak()
+}
+
+/// On the fresh-resolve path the resolve-time prefetcher may already
+/// have a package's tarball download finished (or in flight) in the
+/// shared mem cache by the time the cold batch reaches it. The cold
+/// batch must reuse that download via the mem cache rather than racing
+/// a second fetch of the same bytes (<https://github.com/pnpm/pnpm/issues/12241>).
+///
+/// Seed the mem cache with a finished download keyed by the exact URL
+/// the registry resolution derives, then run the cold-batch installer
+/// with `tarball_mem_cache: Some(..)`. It must return the seeded CAS
+/// map without touching the network — proven here by `offline: true`,
+/// which makes any fall-through to the download path error out.
+#[tokio::test]
+async fn cold_batch_reuses_in_flight_prefetch_from_mem_cache() {
+    use pacquet_tarball::{CacheValue, MemCache};
+    use std::{
+        collections::HashMap,
+        path::PathBuf,
+        sync::{Arc, atomic::AtomicU8},
+    };
+
+    let store_tmp = tempfile::tempdir().expect("tempdir");
+    let config = leaked_offline_config("https://registry.test", store_tmp.path());
+
+    let package_key: PackageKey = "foo@1.0.0".parse().expect("parse key");
+    // Mirror `tarball_url_and_integrity`'s registry-URL derivation so
+    // the seeded mem-cache key matches what the installer looks up.
+    let tarball_url = "https://registry.test/foo/-/foo-1.0.0.tgz".to_string();
+
+    let seeded: HashMap<String, PathBuf> =
+        HashMap::from([("package.json".to_string(), store_tmp.path().join("blob"))]);
+    let mem_cache = Arc::new(MemCache::default());
+    mem_cache.insert(
+        tarball_url,
+        Arc::new(tokio::sync::RwLock::new(CacheValue::Available(Arc::new(seeded.clone())))),
+    );
+
+    let layout = crate::VirtualStoreLayout::legacy(store_tmp.path().join("vstore"), 120);
+    let allow_build_policy =
+        crate::AllowBuildPolicy::new(Default::default(), Default::default(), false);
+    let skipped = crate::SkippedSnapshots::new();
+    let logged_methods = AtomicU8::new(0);
+    let verified_files_cache = pacquet_store_dir::SharedVerifiedFilesCache::default();
+    let metadata = registry_metadata();
+    let snapshot = pacquet_lockfile::SnapshotEntry::default();
+
+    let cas_paths = super::InstallPackageBySnapshot {
+        http_client: &Default::default(),
+        config,
+        layout: &layout,
+        store_index: None,
+        store_index_writer: None,
+        prefetched_cas_paths: None,
+        progress_reported: None,
+        tarball_mem_cache: Some(&mem_cache),
+        verified_files_cache: &verified_files_cache,
+        logged_methods: &logged_methods,
+        requester: "/project",
+        package_key: &package_key,
+        metadata: &metadata,
+        snapshot: &snapshot,
+        allow_build_policy: &allow_build_policy,
+        skipped: &skipped,
+        workspace_root: store_tmp.path(),
+        // Hoisted skips slot materialization, so the test exercises
+        // only the download-coordination branch and gets the CAS map
+        // back directly.
+        node_linker: pacquet_config::NodeLinker::Hoisted,
+    }
+    .run::<pacquet_reporter::SilentReporter>()
+    .await
+    .expect("cold batch must reuse the prefetched download instead of fetching");
+
+    assert_eq!(cas_paths, seeded);
+
+    drop(store_tmp);
+}
+
+/// `tarball_mem_cache: None` is the no-prefetcher case (e.g. a plain
+/// `--frozen-lockfile` install without pnpr). That path must go straight
+/// to the download (here blocked by `offline: true`), never consulting a
+/// mem cache — the contrast that proves the coordination above is gated
+/// on `Some(..)`, not unconditional. A populated cache is supplied and
+/// must be ignored.
+#[tokio::test]
+async fn without_mem_cache_skips_coordination_and_downloads() {
+    use crate::InstallPackageBySnapshotError;
+    use pacquet_tarball::{CacheValue, MemCache, TarballError};
+    use std::{
+        collections::HashMap,
+        path::PathBuf,
+        sync::{Arc, atomic::AtomicU8},
+    };
+
+    let store_tmp = tempfile::tempdir().expect("tempdir");
+    let config = leaked_offline_config("https://registry.test", store_tmp.path());
+
+    let package_key: PackageKey = "foo@1.0.0".parse().expect("parse key");
+
+    // A populated mem cache that the `None` path must ignore.
+    let seeded: HashMap<String, PathBuf> =
+        HashMap::from([("package.json".to_string(), store_tmp.path().join("blob"))]);
+    let mem_cache = Arc::new(MemCache::default());
+    mem_cache.insert(
+        "https://registry.test/foo/-/foo-1.0.0.tgz".to_string(),
+        Arc::new(tokio::sync::RwLock::new(CacheValue::Available(Arc::new(seeded)))),
+    );
+
+    let layout = crate::VirtualStoreLayout::legacy(store_tmp.path().join("vstore"), 120);
+    let allow_build_policy =
+        crate::AllowBuildPolicy::new(Default::default(), Default::default(), false);
+    let skipped = crate::SkippedSnapshots::new();
+    let logged_methods = AtomicU8::new(0);
+    let verified_files_cache = pacquet_store_dir::SharedVerifiedFilesCache::default();
+    let metadata = registry_metadata();
+    let snapshot = pacquet_lockfile::SnapshotEntry::default();
+
+    let err = super::InstallPackageBySnapshot {
+        http_client: &Default::default(),
+        config,
+        layout: &layout,
+        store_index: None,
+        store_index_writer: None,
+        prefetched_cas_paths: None,
+        progress_reported: None,
+        tarball_mem_cache: None,
+        verified_files_cache: &verified_files_cache,
+        logged_methods: &logged_methods,
+        requester: "/project",
+        package_key: &package_key,
+        metadata: &metadata,
+        snapshot: &snapshot,
+        allow_build_policy: &allow_build_policy,
+        skipped: &skipped,
+        workspace_root: store_tmp.path(),
+        node_linker: pacquet_config::NodeLinker::Hoisted,
+    }
+    .run::<pacquet_reporter::SilentReporter>()
+    .await
+    .expect_err("None path must skip the mem cache and hit the offline-gated download");
+
+    assert!(
+        matches!(
+            err,
+            InstallPackageBySnapshotError::DownloadTarball(TarballError::NoOfflineTarball { .. }),
+        ),
+        "expected the offline download gate, got {err:?}",
+    );
+
+    drop(store_tmp);
+}
+
+/// The resolve-time prefetch is best-effort: if it failed (its mem-cache
+/// slot is [`CacheValue::Failed`]), the cold batch must not inherit the
+/// failure — it falls back to its own retried download. Proven here by
+/// seeding a `Failed` slot under `offline: true`: the only way to reach
+/// the offline gate (`NoOfflineTarball`) instead of surfacing
+/// `SiblingFetchFailed` is for the fallback to `run_without_mem_cache` to
+/// have run.
+#[tokio::test]
+async fn cold_batch_falls_back_when_prefetch_failed() {
+    use crate::InstallPackageBySnapshotError;
+    use pacquet_tarball::{CacheValue, MemCache, TarballError};
+    use std::sync::{Arc, atomic::AtomicU8};
+
+    let store_tmp = tempfile::tempdir().expect("tempdir");
+    let config = leaked_offline_config("https://registry.test", store_tmp.path());
+
+    let package_key: PackageKey = "foo@1.0.0".parse().expect("parse key");
+
+    let mem_cache = Arc::new(MemCache::default());
+    mem_cache.insert(
+        "https://registry.test/foo/-/foo-1.0.0.tgz".to_string(),
+        Arc::new(tokio::sync::RwLock::new(CacheValue::Failed)),
+    );
+
+    let layout = crate::VirtualStoreLayout::legacy(store_tmp.path().join("vstore"), 120);
+    let allow_build_policy =
+        crate::AllowBuildPolicy::new(Default::default(), Default::default(), false);
+    let skipped = crate::SkippedSnapshots::new();
+    let logged_methods = AtomicU8::new(0);
+    let verified_files_cache = pacquet_store_dir::SharedVerifiedFilesCache::default();
+    let metadata = registry_metadata();
+    let snapshot = pacquet_lockfile::SnapshotEntry::default();
+
+    let err = super::InstallPackageBySnapshot {
+        http_client: &Default::default(),
+        config,
+        layout: &layout,
+        store_index: None,
+        store_index_writer: None,
+        prefetched_cas_paths: None,
+        progress_reported: None,
+        tarball_mem_cache: Some(&mem_cache),
+        verified_files_cache: &verified_files_cache,
+        logged_methods: &logged_methods,
+        requester: "/project",
+        package_key: &package_key,
+        metadata: &metadata,
+        snapshot: &snapshot,
+        allow_build_policy: &allow_build_policy,
+        skipped: &skipped,
+        workspace_root: store_tmp.path(),
+        node_linker: pacquet_config::NodeLinker::Hoisted,
+    }
+    .run::<pacquet_reporter::SilentReporter>()
+    .await
+    .expect_err("a failed prefetch must fall back to a real download, here offline-gated");
+
+    assert!(
+        matches!(
+            err,
+            InstallPackageBySnapshotError::DownloadTarball(TarballError::NoOfflineTarball { .. }),
+        ),
+        "fallback must reach the offline download gate, not inherit SiblingFetchFailed; got {err:?}",
+    );
+
+    drop(store_tmp);
+}

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1291,11 +1291,17 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             workspace_root: lockfile_dir,
             node_linker,
             progress_reported: &progress_reported,
-            // The fresh path's downloads already resolve through the
-            // resolve-time prefetcher into the store; the cold batch
-            // dedups against on-disk state, so no shared in-flight cache
-            // is threaded here.
-            tarball_mem_cache: None,
+            // Share the resolve-time prefetcher's in-flight downloads with
+            // the cold batch. The `PrefetchingResolver` streams each
+            // tarball into `tarball_mem_cache` keyed by URL; the cold
+            // batch's only on-disk dedup is the store-index row, which the
+            // prefetcher's writer commits asynchronously. Without the
+            // shared cache a snapshot whose prefetch hasn't committed its
+            // row yet is classified cold and re-downloaded — the race in
+            // <https://github.com/pnpm/pnpm/issues/12241>. Routing the cold
+            // batch through the mem cache makes it reuse the in-flight
+            // download instead.
+            tarball_mem_cache: Some(&tarball_mem_cache),
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/tarball/src/lib.rs
+++ b/pacquet/crates/tarball/src/lib.rs
@@ -1160,6 +1160,12 @@ async fn load_cached_cas_paths(
 /// This subroutine downloads and extracts a tarball to the store directory.
 ///
 /// It returns a CAS map of files in the tarball.
+///
+/// `Clone` is cheap — every field is a reference, a `Copy` scalar, or an
+/// `Arc` — so a caller can keep a copy to retry through a different entry
+/// point (e.g. fall back to [`Self::run_without_mem_cache`] after a
+/// best-effort [`Self::run_with_mem_cache`] reports a sibling failure).
+#[derive(Clone)]
 #[must_use]
 pub struct DownloadTarballToStore<'a> {
     pub http_client: &'a ThrottledClient,


### PR DESCRIPTION
## What

Fixes the fresh-install double-download race in [#12241](https://github.com/pnpm/pnpm/issues/12241).

On pacquet's phased `CreateVirtualStore` install path, the same tarball could be downloaded twice: once by the resolve-time prefetcher (`PrefetchingResolver`, which spawns `run_with_mem_cache` into the shared `tarball_mem_cache`), and again by `CreateVirtualStore`'s cold batch. The cold batch called `InstallPackageBySnapshot` → `run_without_mem_cache`, which consults the store index and the prefetched-CAS map but **never the `tarball_mem_cache`/`Notify`** — so if the prefetch's store-index row hadn't committed yet, the package was classified cold and re-downloaded, potentially while the prefetch was still streaming the same bytes.

It was never a correctness bug (content-addressed, idempotent writes), but it wasted network/CPU and (since #12236) could render the byte-progress gauge twice.

## How

- Thread the install-scoped `tarball_mem_cache` into `CreateVirtualStore` and `InstallPackageBySnapshot`.
- The cold-batch tarball/registry download now routes through `run_with_mem_cache` **when the mem cache is present** (fresh path). It picks up an already-finished prefetch (`CacheValue::Available`) immediately, or briefly parks on the per-URL `Notify` for an in-flight one — exactly the coordination the `prefetching_resolver` module doc already describes.
- The frozen-lockfile path has no prefetcher, so it passes `None` and keeps the existing `run_without_mem_cache` path byte-for-byte.

### Honoring the "no perf regression" constraints from the issue
- No blanket barrier — the cold batch blocks only on the *specific* in-flight download, and only when it would otherwise re-download.
- Frozen-lockfile path unchanged; the warm rayon fast path is untouched.
- In the fresh path the cold batch now *reuses* the prefetch instead of re-downloading — a net win. The only added cost is one deep clone of the per-package CAS map (the same clone `run_without_mem_cache` already pays on a prefetched-CAS hit), which is negligible next to a re-download.

## Tests

Two deterministic, network-free tests in `install_package_by_snapshot/tests.rs`:
- `cold_batch_reuses_in_flight_prefetch_from_mem_cache` — seeds the mem cache with a finished download under `offline: true`; the cold batch returns the seeded CAS map without touching the network. Verified to **fail** when the fix is reverted (`ERR_PACQUET_NO_OFFLINE_TARBALL`).
- `frozen_path_does_not_consult_mem_cache` — proves the `None` path still goes straight to the (offline-gated) download.

`just`-equivalent checks run locally: `cargo nextest run -p pacquet-package-manager -p pacquet-tarball` (all green), clippy `--all-targets -D warnings`, fmt, typos, and `cargo doc -D warnings` all clean. The pre-push Rust hook (fmt/doc/dylint/taplo) passed on push.

## Notes

This is a pacquet-internal race; pnpm's TypeScript install architecture (piscina pool + `fetching` promises) doesn't have the equivalent bug, so no pnpm-side port is needed. Per project convention, pacquet-only changes don't carry a changeset.

The CI integrated-benchmark (loopback registry, Linux) shows **no regression** across every fresh scenario — `pacquet@HEAD` ≈ `pacquet@main` within noise:

| Scenario | pacquet@HEAD | pacquet@main |
|---|---|---|
| fresh restore, cold cache + cold store | 10.050 s | 10.031 s |
| fresh restore, hot cache + hot store | 658.8 ms | 697.4 ms |
| fresh install, cold cache + cold store | 5.228 s | 5.235 s |
| fresh install, hot cache + hot store | 1.364 s | 1.379 s |
| fresh install, cold cache + hot store (resolution-only) | 4.973 s | 5.025 s |

(The loopback registry runs at ~GB/s, so the avoided re-download is nearly free here and the win isn't visible — but the constraint that matters, *no regression*, holds. The micro-benchmark `tarball/download_dependency` is likewise flat: 7.7 ms → 7.9 ms.)

### Follow-up fixes after rebasing on #12245

#12245 landed the shared `tarball_mem_cache` infrastructure (frozen/pnpr path → `Some`, fresh path → `None`). This PR now just flips the fresh path to `Some`, plus two safety refinements found via CI:

- **Coordinate only registry resolutions.** The `PrefetchingResolver` skips remote tarballs (they resolve with no `name_ver`); their only mem-cache entry comes from the resolver's download-to-resolve, keyed `name@version`, while the lockfile/materialization address them by `name@<url>`. Reusing that entry would skip writing the `name@<url>` store-index row a later re-resolve needs — which regressed `remote_tarball_reresolves_from_warm_store_without_refetch`.
- **Fall back on a failed prefetch.** The prefetch is best-effort; on `SiblingFetchFailed` the cold batch now does its own retried download instead of inheriting the failure, so a transient prefetch error can't fail the install.

Closes #12241

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate tarball downloads by reusing in-memory fetch state for registry resolutions and falling back when a prefetch fails.
  * Avoids unnecessary redownloads during fresh-lockfile installs by sharing resolve-time downloads with the installation pipeline.

* **Tests**
  * Added integration tests covering tarball fetch coordination, offline behavior, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->