### PR TITLE
fix(package-manager): stop pnpr install re-downloading prefetched tarballs

### DIFF
--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -20,7 +20,7 @@ use pacquet_store_dir::{
     SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, git_hosted_store_index_key,
     store_index_key,
 };
-use pacquet_tarball::{PrefetchResult, SharedReportedProgressKeys, prefetch_cas_paths};
+use pacquet_tarball::{MemCache, PrefetchResult, SharedReportedProgressKeys, prefetch_cas_paths};
 use pipe_trait::Pipe;
 use std::{
     collections::{HashMap, HashSet},
@@ -163,6 +163,11 @@ pub struct CreateVirtualStore<'a> {
     /// status event so resolve-time prefetch progress is visible without
     /// being double-counted.
     pub progress_reported: &'a SharedReportedProgressKeys,
+    /// Install-scoped shared in-flight tarball cache, threaded into each
+    /// per-snapshot [`InstallPackageBySnapshot`]. `Some` on the pnpr
+    /// client path so the cold-batch download reuses the prefetcher's
+    /// background downloads instead of re-fetching; `None` otherwise.
+    pub tarball_mem_cache: Option<&'a std::sync::Arc<MemCache>>,
 }
 
 /// Error type of [`CreateVirtualStore`].
@@ -208,6 +213,7 @@ impl<'a> CreateVirtualStore<'a> {
             workspace_root,
             node_linker,
             progress_reported,
+            tarball_mem_cache,
         } = self;
 
         let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
@@ -767,6 +773,7 @@ impl<'a> CreateVirtualStore<'a> {
                         store_index: store_index_ref,
                         store_index_writer: store_index_writer_ref,
                         prefetched_cas_paths: prefetched_ref,
+                        tarball_mem_cache,
                         progress_reported: Some(progress_reported),
                         verified_files_cache: verified_files_cache_ref,
                         logged_methods,

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -872,6 +872,7 @@ where
                 supported_architectures: supported_architectures.as_ref(),
                 skip_runtimes,
                 node_linker,
+                tarball_mem_cache: Some(&tarball_mem_cache),
             }
             .run::<Reporter>()
             .await

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -26,12 +26,12 @@ use pacquet_patching::{
 };
 use pacquet_reporter::{IgnoredScriptsLog, LogEvent, LogLevel, Reporter, Stage, StageLog};
 use pacquet_store_dir::StoreIndexWriter;
-use pacquet_tarball::SharedReportedProgressKeys;
+use pacquet_tarball::{MemCache, SharedReportedProgressKeys};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     ffi::OsStr,
     path::{Path, PathBuf},
-    sync::atomic::AtomicU8,
+    sync::{Arc, atomic::AtomicU8},
 };
 
 /// This subroutine installs dependencies from a frozen lockfile.
@@ -141,6 +141,14 @@ where
     /// exists yet). Upstream's `nodeLinker: 'pnp'` is also
     /// out-of-scope for [#438](https://github.com/pnpm/pacquet/issues/438); tracked separately.
     pub node_linker: NodeLinker,
+
+    /// Install-scoped shared in-flight tarball cache, threaded down to
+    /// [`crate::CreateVirtualStore`]'s cold-batch downloads. `Some` on
+    /// the pnpr client path so the materialization reuses the
+    /// [`crate::TarballPrefetcher`]'s background downloads instead of
+    /// re-fetching every tarball; `None` for installs without a shared
+    /// prefetch in flight.
+    pub tarball_mem_cache: Option<&'a Arc<MemCache>>,
 }
 
 /// Error type of [`InstallFrozenLockfile`].
@@ -277,6 +285,7 @@ where
             supported_architectures,
             skip_runtimes,
             node_linker,
+            tarball_mem_cache,
         } = self;
         let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
         // Cloned so the iterator can be reused below for hoist's
@@ -602,6 +611,7 @@ where
             workspace_root,
             node_linker,
             progress_reported: &progress_reported,
+            tarball_mem_cache,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
@@ -20,8 +20,8 @@ use pacquet_store_dir::{
     git_hosted_store_index_key,
 };
 use pacquet_tarball::{
-    DownloadTarballToStore, DownloadZipArchiveToStore, IgnoreEntryFilter, PrefetchedCasPaths,
-    SharedReportedProgressKeys, TarballError,
+    DownloadTarballToStore, DownloadZipArchiveToStore, IgnoreEntryFilter, MemCache,
+    PrefetchedCasPaths, SharedReportedProgressKeys, TarballError,
 };
 use pipe_trait::Pipe;
 use std::{
@@ -49,6 +49,17 @@ pub struct InstallPackageBySnapshot<'a> {
     /// Install-scoped batched cache lookup result. See
     /// [`pacquet_tarball::prefetch_cas_paths`].
     pub prefetched_cas_paths: Option<&'a PrefetchedCasPaths>,
+    /// Install-scoped shared in-flight tarball cache. When present, the
+    /// registry/tarball download routes through
+    /// [`DownloadTarballToStore::run_with_mem_cache`] so it parks on (or
+    /// reuses) a download already in flight or completed for the same
+    /// URL — most importantly the background downloads fired by the pnpr
+    /// client's [`crate::TarballPrefetcher`], which otherwise this pass
+    /// would redundantly re-download. `None` keeps the standalone
+    /// `run_without_mem_cache` path (no in-flight cache to share, e.g.
+    /// the fresh-lockfile materialization whose downloads already
+    /// happened during resolution).
+    pub tarball_mem_cache: Option<&'a Arc<MemCache>>,
     /// Install-scoped package-status progress dedupe. Shared with the
     /// resolve-time prefetcher on the fresh path so the cold fallback
     /// does not double-count a package whose early prefetch already
@@ -223,6 +234,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             store_index,
             store_index_writer,
             prefetched_cas_paths,
+            tarball_mem_cache,
             progress_reported,
             verified_files_cache,
             logged_methods,
@@ -263,7 +275,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             LockfileResolution::Tarball(_) | LockfileResolution::Registry(_) => {
                 let (tarball_url, integrity) =
                     tarball_url_and_integrity(&metadata.resolution, package_key, config)?;
-                let raw_cas_paths = DownloadTarballToStore {
+                let download = DownloadTarballToStore {
                     http_client,
                     store_dir: &config.store_dir,
                     store_index: store_index.cloned(),
@@ -281,9 +293,20 @@ impl<'a> InstallPackageBySnapshot<'a> {
                     ignore_file_pattern: None,
                     offline: config.offline,
                     progress_reported: progress_reported.cloned(),
+                };
+                // Reuse an in-flight or completed background download
+                // (e.g. the pnpr client's prefetcher) through the shared
+                // mem cache when one is provided; otherwise fetch
+                // standalone. The owned `HashMap` is cloned out of the
+                // shared `Arc` so the rest of this pass keeps its
+                // by-value contract.
+                let raw_cas_paths = match tarball_mem_cache {
+                    Some(mem_cache) => download
+                        .run_with_mem_cache::<Reporter>(mem_cache)
+                        .await
+                        .map(|cas_paths| (*cas_paths).clone()),
+                    None => download.run_without_mem_cache::<Reporter>().await,
                 }
-                .run_without_mem_cache::<Reporter>()
-                .await
                 .map_err(InstallPackageBySnapshotError::DownloadTarball)?;
 
                 // Run the git-hosted prepare+packlist pass for

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1291,6 +1291,11 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             workspace_root: lockfile_dir,
             node_linker,
             progress_reported: &progress_reported,
+            // The fresh path's downloads already resolve through the
+            // resolve-time prefetcher into the store; the cold batch
+            // dedups against on-disk state, so no shared in-flight cache
+            // is threaded here.
+            tarball_mem_cache: None,
         }
         .run::<Reporter>()
         .await


### PR DESCRIPTION
## Problem

On the pnpr client path the resolve-time `TarballPrefetcher` fires a background download for every `package` frame into the shared `MemCache`, but the frozen materialization install (`InstallPackageBySnapshot`) fetched each registry/tarball through `run_without_mem_cache` — so it never consulted that cache. The two fan-outs ran concurrently with **no in-flight coordination**: the materializer only avoided a second download when the prefetch had already finished writing the tarball to the store before the materializer reached it.

On a fresh install of a ~1300-package fixture this re-downloaded **~48% of tarballs**:

| | downloads | transfer | download phase |
|---|---|---|---|
| before | 1933 (625 dups) | 107 MB | dribbled to ~15s |
| **after** | **1308 (0 dups)** | **66 MB** | **saturates the link, ~2-5s** |

The redundant fetches also thrashed the network/extract slots, so the download phase never saturated the link.

## Fix

Thread the install-scoped `tarball_mem_cache` down through `InstallFrozenLockfile` → `CreateVirtualStore` → `InstallPackageBySnapshot`, and route the registry/tarball branch through `run_with_mem_cache` when a cache is provided. The frozen path passes `Some` (materializer parks on / reuses the prefetcher's in-flight download); the fresh-lockfile path passes `None` and keeps `run_without_mem_cache` (its downloads already resolve through the resolve-time prefetcher into the store and dedup against on-disk state).

## Scope / caveat

This removes redundant work; it does **not** by itself make pnpr faster than a local install on a fast/low-latency registry. There the dominant cost is the remote resolve round-trip plus the serial `resolve → write-lockfile → materialize` barrier, not the tarball bytes. Measured wall-clock on a fast CDN: interleaved pnpr-on ~16.2s vs off ~14.4s (the gap narrowed ~1-2s but did not close). The bigger lever — letting materialization start before the full resolve stream lands — is a separate change.

## Known follow-up: progress label

Because the materializer now consumes the prefetcher's downloads and the prefetcher reports through `SilentReporter`, a fresh pnpr install emits `pnpm:progress found_in_store` for the prefetched packages instead of `fetched` (it labels freshly-downloaded tarballs as "reused"). **Label-only** — no double-count, no missing event — but it should be corrected so the summary line is accurate. Two viable fixes, both more invasive than this PR:

1. **Share one `SharedReportedProgressKeys`** between the prefetcher (emitting `fetched` via the real reporter) and the materializer, so the cache-hit `found_in_store` is deduped away. Requires plumbing the set from the CLI through `Install`, whose struct literal has ~70 construction sites.
2. **Carry a `network_fetched` flag on `CacheValue::Available`** (set by the owner when `run_without_mem_cache` actually hit the network) so the waiting cache-hit reports `fetched` vs `found_in_store` correctly. Requires changing `run_without_mem_cache`'s return type (~16 call sites).

## Tests

All 51 frozen/snapshot + `install_package_by_snapshot` tests pass, plus both `pnpr_install` integration tests (`install_via_pnpr_links_node_modules` exercises the changed path). `cargo clippy` clean.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Installation process optimized with shared tarball download caching, reducing redundant network requests by reusing previously-fetched packages across different installation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->