### PR TITLE
fix(pnpr): parse /v1/resolve NDJSON stream in the TypeScript client

### DIFF
--- a/.changeset/pnpr-client-ndjson-resolve.md
+++ b/.changeset/pnpr-client-ndjson-resolve.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/pnpr.client": patch
+"pnpm": patch
+---
+
+The pnpr client now reads the `POST /v1/resolve` response as an `application/x-ndjson` stream, matching the server's streaming protocol [#12234](https://github.com/pnpm/pnpm/issues/12234). It parses the terminal `done` / `error` / `violations` frame instead of expecting a single buffered JSON object.

--- a/pnpr/client/src/resolveViaPnprServer.ts
+++ b/pnpr/client/src/resolveViaPnprServer.ts
@@ -136,19 +136,25 @@ export async function resolveViaPnprServer (
   }
 }
 
+type TerminalFrame = Extract<ResolveFrame, { type: 'done' | 'error' | 'violations' }>
+
 /**
  * Parse the NDJSON `/v1/resolve` body and return its single terminal
  * frame. `package` frames are skipped — this client fetches tarballs the
  * normal way after resolution rather than overlapping fetch with the
- * stream. Throws if the stream carries no terminal frame.
+ * stream. Throws on an unknown frame type (so a protocol mismatch fails
+ * fast here rather than as a confusing lockfile error downstream) or if
+ * the stream carries no terminal frame.
  */
-function parseTerminalFrame (body: string): Extract<ResolveFrame, { type: 'done' | 'error' | 'violations' }> {
+function parseTerminalFrame (body: string): TerminalFrame {
   for (const line of body.split('\n')) {
     if (line.trim() === '') continue
     const frame = JSON.parse(line) as ResolveFrame
-    if (frame.type !== 'package') {
+    if (frame.type === 'package') continue
+    if (frame.type === 'done' || frame.type === 'error' || frame.type === 'violations') {
       return frame
     }
+    throw new Error(`pnpr server /v1/resolve stream emitted an unknown frame type: ${String((frame as { type: unknown }).type)}`)
   }
   throw new Error('pnpr server /v1/resolve stream ended without a terminal frame')
 }

--- a/pnpr/client/src/resolveViaPnprServer.ts
+++ b/pnpr/client/src/resolveViaPnprServer.ts
@@ -64,20 +64,28 @@ export interface ResolveViaPnprServerResult {
   stats: ResponseMetadata['stats']
 }
 
-interface ResolveResponse {
-  lockfile: LockfileFile
-  stats: ResponseMetadata['stats']
-  violations?: Array<{ name: string, version: string, code: string, reason: string }>
-}
+interface Violation { name: string, version: string, code: string, reason: string }
+
+/**
+ * One NDJSON frame from `POST /v1/resolve`. `package` frames stream as
+ * the server resolves; exactly one terminal frame (`done` / `error` /
+ * `violations`) closes the response.
+ */
+type ResolveFrame =
+  | { type: 'package', id: string, name: string, version: string, integrity: string, tarball: string }
+  | { type: 'done', lockfile: LockfileFile, stats: ResponseMetadata['stats'] }
+  | { type: 'error', message: string }
+  | { type: 'violations', violations: Violation[] }
 
 /**
  * Resolve a project against a pnpr server and return the resolved
  * lockfile.
  *
- * `POST /v1/resolve` answers with one gzipped JSON object carrying the
- * server-resolved, server-verified lockfile (and stats). pnpr serves no
- * file content — the caller fetches every tarball itself, in parallel,
- * like a normal install
+ * `POST /v1/resolve` answers with an `application/x-ndjson` stream: one
+ * `package` frame per resolved tarball as the server's tree walk yields
+ * it, then exactly one terminal frame — `done` (full lockfile + stats),
+ * `error`, or `violations`. pnpr serves no file content — the caller
+ * fetches every tarball itself, in parallel, like a normal install
  * ([pnpm/pnpm#12230](https://github.com/pnpm/pnpm/issues/12230)).
  */
 export async function resolveViaPnprServer (
@@ -107,10 +115,14 @@ export async function resolveViaPnprServer (
   })
 
   const body = await postResolve(opts.registryUrl, requestBody, opts.authorization)
-  const response = JSON.parse(body.toString('utf-8')) as ResolveResponse
 
-  if (response.violations != null && response.violations.length > 0) {
-    const rendered = response.violations
+  const terminal = parseTerminalFrame(body.toString('utf-8'))
+
+  if (terminal.type === 'error') {
+    throw new Error(terminal.message)
+  }
+  if (terminal.type === 'violations') {
+    const rendered = terminal.violations
       .map((violation) => `  ${violation.name}@${violation.version}: ${violation.reason}`)
       .join('\n')
     throw new Error(`pnpr server rejected the lockfile under the verification policy:\n${rendered}`)
@@ -119,9 +131,26 @@ export async function resolveViaPnprServer (
   return {
     // The server speaks the on-disk lockfile format; convert it to the
     // in-memory `LockfileObject` the rest of pnpm consumes.
-    lockfile: convertToLockfileObject(response.lockfile),
-    stats: response.stats,
+    lockfile: convertToLockfileObject(terminal.lockfile),
+    stats: terminal.stats,
   }
+}
+
+/**
+ * Parse the NDJSON `/v1/resolve` body and return its single terminal
+ * frame. `package` frames are skipped — this client fetches tarballs the
+ * normal way after resolution rather than overlapping fetch with the
+ * stream. Throws if the stream carries no terminal frame.
+ */
+function parseTerminalFrame (body: string): Extract<ResolveFrame, { type: 'done' | 'error' | 'violations' }> {
+  for (const line of body.split('\n')) {
+    if (line.trim() === '') continue
+    const frame = JSON.parse(line) as ResolveFrame
+    if (frame.type !== 'package') {
+      return frame
+    }
+  }
+  throw new Error('pnpr server /v1/resolve stream ended without a terminal frame')
 }
 
 const REQUEST_TIMEOUT = 600_000 // 10 minutes — server-side resolution can be slow on first run


### PR DESCRIPTION
## Problem

The [main CI Test job](https://github.com/pnpm/pnpm/actions/runs/27063513575/job/79880441632) was failing — 8 tests in `pnpm/test/install/pnpmRegistry.ts` errored with:

```
[ERROR] Unexpected non-whitespace character after JSON at position 264 (line 2 column 1)
```

## Cause

Commit c199198e94 (#12237, *"perf(pnpr): stream /v1/resolve"*) changed the Rust pnpr server's `POST /v1/resolve` endpoint to stream **NDJSON** — one `package` frame per resolved tarball, then a terminal `done` / `error` / `violations` frame (`application/x-ndjson`, excluded from the gzip layer). The pacquet (Rust) client was updated to read the stream, but the parallel **TypeScript** pnpr client (`pnpr/client/src/resolveViaPnprServer.ts`) still parsed the whole response body as a single JSON object, so `JSON.parse` choked on the second NDJSON line.

This is exactly the pnpm↔pacquet drift the contributor guide warns about: the streaming change landed on the Rust side but the equivalent TypeScript change was missed.

## Fix

`pnpr/client/src/resolveViaPnprServer.ts`:

- Replaced the single-object response type with an NDJSON `ResolveFrame` union (`package` / `done` / `error` / `violations`) matching the server's frame shapes and the Rust client's `Frame` enum.
- Added `parseTerminalFrame`, which splits the body on newlines, skips `package` frames, and acts on the terminal frame — throwing on `error`, rendering `violations` into the existing policy-rejection message, and returning the lockfile + stats on `done`.

The `package` frames are intentionally skipped here; this client fetches tarballs the normal way after resolution. The fetch-overlap optimization those frames enable remains a pacquet-only feature for now.

## Verification

Built the `pnpr` / `pnpr-prepare` binaries, rebuilt the pnpm bundle, and ran `pnpm/test/install/pnpmRegistry.ts` — **11/11 pass** (was 8 failing).

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * pnpr client now consumes resolve responses as an NDJSON stream for more reliable, memory-efficient handling.
  * Terminal frames (success, error, violations) are recognized and surfaced to users so failures and policy violations are reported clearly.
  * Malformed or incomplete streams now fail fast, improving error visibility and overall resolve robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->