### PR TITLE
fix(config): restore globalconfig lookup

### DIFF
--- a/.changeset/fix-config-globalconfig.md
+++ b/.changeset/fix-config-globalconfig.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.commands": patch
+"pnpm": patch
+---
+
+Fixed `pnpm config get globalconfig` to return the global `config.yaml` path again [pnpm/pnpm#11962](https://github.com/pnpm/pnpm/issues/11962).

--- a/.changeset/fix-config-globalconfig.md
+++ b/.changeset/fix-config-globalconfig.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/config.commands": patch
+"@pnpm/config.reader": patch
 "pnpm": patch
 ---
 

--- a/config/commands/src/configGet.ts
+++ b/config/commands/src/configGet.ts
@@ -1,4 +1,7 @@
+import path from 'node:path'
+
 import { isIniConfigKey, types } from '@pnpm/config.reader'
+import { GLOBAL_CONFIG_YAML_FILENAME } from '@pnpm/constants'
 import { getObjectValueByPropertyPath } from '@pnpm/object.property-path'
 import { isCamelCase } from '@pnpm/text.naming-cases'
 import camelcase from 'camelcase'
@@ -34,6 +37,9 @@ function lookupConfig (opts: ConfigCommandOptions, key: string, isScopedKey: boo
       }
     }
     return { value: opts.authConfig[key] }
+  }
+  if (key === 'globalconfig') {
+    return { value: path.join(opts.configDir, GLOBAL_CONFIG_YAML_FILENAME) }
   }
   const kebabKey = isCamelCase(key) ? kebabCase(key) : key
   // Resolve typed keys from Config — check explicitly set values first,

--- a/config/commands/src/configGet.ts
+++ b/config/commands/src/configGet.ts
@@ -1,7 +1,4 @@
-import path from 'node:path'
-
-import { isIniConfigKey, types } from '@pnpm/config.reader'
-import { GLOBAL_CONFIG_YAML_FILENAME } from '@pnpm/constants'
+import { getGlobalConfigPath, isIniConfigKey, types } from '@pnpm/config.reader'
 import { getObjectValueByPropertyPath } from '@pnpm/object.property-path'
 import { isCamelCase } from '@pnpm/text.naming-cases'
 import camelcase from 'camelcase'
@@ -39,7 +36,7 @@ function lookupConfig (opts: ConfigCommandOptions, key: string, isScopedKey: boo
     return { value: opts.authConfig[key] }
   }
   if (key === 'globalconfig') {
-    return { value: path.join(opts.configDir, GLOBAL_CONFIG_YAML_FILENAME) }
+    return { value: getGlobalConfigPath(opts.configDir) }
   }
   const kebabKey = isCamelCase(key) ? kebabCase(key) : key
   // Resolve typed keys from Config — check explicitly set values first,

--- a/config/commands/test/configGet.test.ts
+++ b/config/commands/test/configGet.test.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import { describe, expect, test } from '@jest/globals'
 import { config } from '@pnpm/config.commands'
 
@@ -267,7 +269,20 @@ test('config get with scoped registry key that does not exist', async () => {
   expect(getOutputString(getResult)).toBe('undefined')
 })
 
-// globalconfig and npm-globalconfig tests removed — pnpm no longer exposes these npm-compat properties
+test('config get globalconfig returns the global config.yaml path', async () => {
+  const configDir = path.join(process.cwd(), 'global-config')
+  const getResult = await config.handler(createConfigCommandOpts({
+    dir: process.cwd(),
+    cliOptions: {},
+    configDir,
+    global: true,
+    authConfig: {},
+  }), ['get', 'globalconfig'])
+
+  expect(getOutputString(getResult)).toBe(path.join(configDir, 'config.yaml'))
+})
+
+// npm-globalconfig tests removed — pnpm no longer exposes these npm-compat properties
 
 describe('does not traverse the prototype chain (#10296)', () => {
   test.each([

--- a/config/commands/test/configGet.test.ts
+++ b/config/commands/test/configGet.test.ts
@@ -282,8 +282,6 @@ test('config get globalconfig returns the global config.yaml path', async () => 
   expect(getOutputString(getResult)).toBe(path.join(configDir, 'config.yaml'))
 })
 
-// npm-globalconfig tests removed — pnpm no longer exposes these npm-compat properties
-
 describe('does not traverse the prototype chain (#10296)', () => {
   test.each([
     'constructor',

--- a/config/reader/src/dirs.ts
+++ b/config/reader/src/dirs.ts
@@ -1,6 +1,12 @@
 import os from 'node:os'
 import path from 'node:path'
 
+import { GLOBAL_CONFIG_YAML_FILENAME } from '@pnpm/constants'
+
+export function getGlobalConfigPath (configDir: string): string {
+  return path.join(configDir, GLOBAL_CONFIG_YAML_FILENAME)
+}
+
 export function getCacheDir (
   opts: {
     env: NodeJS.ProcessEnv

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -36,7 +36,7 @@ import type {
 } from './Config.js'
 import { isConfigFileKey } from './configFileKey.js'
 import { extractAndRemoveDependencyBuildOptions, hasDependencyBuildOptions } from './dependencyBuildOptions.js'
-import { getCacheDir, getConfigDir, getDataDir, getStateDir } from './dirs.js'
+import { getCacheDir, getConfigDir, getDataDir, getGlobalConfigPath, getStateDir } from './dirs.js'
 import { parseEnvVars } from './env.js'
 import { getNetworkConfigs } from './getNetworkConfigs.js'
 import { getOptionsFromPnpmSettings } from './getOptionsFromRootManifest.js'
@@ -52,6 +52,7 @@ import { types } from './types.js'
 export { types }
 
 export { getDefaultWorkspaceConcurrency, getWorkspaceConcurrency } from './concurrency.js'
+export { getGlobalConfigPath } from './dirs.js'
 export { getDefaultCreds, getNetworkConfigs, type NetworkConfigs } from './getNetworkConfigs.js'
 export { getOptionsFromPnpmSettings, type OptionsFromRootManifest } from './getOptionsFromRootManifest.js'
 export type { Creds } from './parseCreds.js'
@@ -305,7 +306,7 @@ export async function getConfig (opts: {
       }
     }
     if (ignoredKeys.length > 0) {
-      const globalYamlConfigPath = path.join(configDir, GLOBAL_CONFIG_YAML_FILENAME)
+      const globalYamlConfigPath = getGlobalConfigPath(configDir)
       warnings.push(`The following settings cannot be set in the global config file ("${globalYamlConfigPath}") and were ignored: ${ignoredKeys.map(k => `"${k}"`).join(', ')}. Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies`)
     }
     addSettingsFromWorkspaceManifestToConfig(pnpmConfig, {

--- a/pnpm/test/config/get.ts
+++ b/pnpm/test/config/get.ts
@@ -290,3 +290,18 @@ test('pnpm config get shows settings from global config.yaml', () => {
   expect(configGet('packageExtensions')).toBe('undefined')
   expect(configGet('package-extensions')).toBe('undefined')
 })
+
+test('the path from "config get globalconfig" is the file that pnpm actually reads global settings from', () => {
+  prepare()
+
+  const XDG_CONFIG_HOME = path.resolve('.config')
+  const env = { XDG_CONFIG_HOME }
+  const configGet = (key: string) =>
+    execPnpmSync(['config', 'get', key], { expectSuccess: true, env }).stdout.toString().trim()
+
+  const globalConfigPath = configGet('globalconfig')
+  fs.mkdirSync(path.dirname(globalConfigPath), { recursive: true })
+  fs.writeFileSync(globalConfigPath, 'dlxCacheMaxAge: 4321\n')
+
+  expect(configGet('dlx-cache-max-age')).toBe('4321')
+})

--- a/pnpm/test/config/get.ts
+++ b/pnpm/test/config/get.ts
@@ -276,6 +276,7 @@ test('pnpm config get shows settings from global config.yaml', () => {
   expect(configGet('dangerously-allow-all-builds')).toBe('true')
   expect(configGet('dlxCacheMaxAge')).toBe('1234')
   expect(configGet('dlx-cache-max-age')).toBe('1234')
+  expect(configGet('globalconfig')).toBe(path.join(configDir, 'config.yaml'))
 
   // doesn't list CLI options
   expect(configGet('dev')).toBe('undefined')


### PR DESCRIPTION
## Summary

- restore `pnpm config get globalconfig` to return the current global `config.yaml` path
- keep `npm-globalconfig` unsupported
- add unit and CLI e2e coverage for the v11 global config location

Fixes pnpm/pnpm#11962.

## Tests

- `node --input-type=module -e "..."` direct regression check before fix: printed `undefined`
- `.\node_modules\.bin\tsgo.cmd --build config\commands`
- `..\..\node_modules\.bin\jest.cmd configGet.test.ts --runInBand`
- `.\node_modules\.bin\eslint.cmd config\commands\src\configGet.ts config\commands\test\configGet.test.ts pnpm\test\config\get.ts`
- `.\node_modules\.bin\tsgo.cmd --build pnpm`
- `node bundle.ts` with package env vars
- `..\node_modules\.bin\jest.cmd test/config/get.ts --runInBand --config ..\__utils__\jest-config\config.js --rootDir .`
- pre-push hook: TypeScript build, spellcheck, meta-updater, and lint passed; the hook reported `cargo` and `taplo` unavailable, so Rust/TOML checks were skipped by the hook.

---
Written by an agent (OpenAI Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm config get globalconfig` now correctly returns the path to the global config.yaml file.

* **Tests**
  * Added and updated tests to ensure the `globalconfig` path is accurate and that values written to that file are read by pnpm, improving reliability of global config lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->