### PR TITLE
perf(pacquet): speed up lockfile verification repeats

### DIFF
--- a/pacquet/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
+++ b/pacquet/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
@@ -245,9 +245,18 @@ async fn run_fan_out(
     let semaphore = Arc::new(Semaphore::new(limit));
     let mut futures = FuturesUnordered::new();
     for candidate in candidates {
+        let verifiers: Vec<Arc<dyn ResolutionVerifier>> = verifiers
+            .iter()
+            .filter_map(|verifier| {
+                let ctx = VerifyCtx { name: &candidate.name, version: &candidate.version };
+                verifier.might_verify(&candidate.resolution, ctx).then(|| Arc::clone(verifier))
+            })
+            .collect();
+        if verifiers.is_empty() {
+            continue;
+        }
+
         let semaphore = Arc::clone(&semaphore);
-        let verifiers: Vec<Arc<dyn ResolutionVerifier>> =
-            verifiers.iter().map(Arc::clone).collect();
         futures.push(async move {
             // Holding the permit across every verifier .await keeps
             // the effective in-flight count bounded by the semaphore.

--- a/pacquet/crates/lockfile-verification/src/verify_lockfile_resolutions/tests.rs
+++ b/pacquet/crates/lockfile-verification/src/verify_lockfile_resolutions/tests.rs
@@ -402,6 +402,53 @@ async fn one_packages_entry_yields_one_verification() {
     assert_eq!(CALLS.load(Ordering::SeqCst), 1);
 }
 
+#[tokio::test]
+async fn uninterested_verifier_skips_candidate_fan_out() {
+    static CALLS: AtomicUsize = AtomicUsize::new(0);
+    CALLS.store(0, Ordering::SeqCst);
+
+    struct Uninterested {
+        policy: serde_json::Map<String, serde_json::Value>,
+    }
+    impl ResolutionVerifier for Uninterested {
+        fn might_verify(&self, _resolution: &LockfileResolution, _ctx: VerifyCtx<'_>) -> bool {
+            false
+        }
+
+        fn verify<'a>(
+            &'a self,
+            _resolution: &'a LockfileResolution,
+            _ctx: VerifyCtx<'a>,
+        ) -> VerifyFuture<'a> {
+            CALLS.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { ResolutionVerification::Ok })
+        }
+
+        fn policy(&self) -> &serde_json::Map<String, serde_json::Value> {
+            &self.policy
+        }
+
+        fn can_trust_past_check(
+            &self,
+            _cached: &serde_json::Map<String, serde_json::Value>,
+        ) -> bool {
+            true
+        }
+    }
+
+    let lockfile = parse(SINGLE_PKG_LOCKFILE);
+    let verifier: Arc<dyn ResolutionVerifier> =
+        Arc::new(Uninterested { policy: serde_json::Map::new() });
+    verify_lockfile_resolutions::<SilentReporter>(
+        &lockfile,
+        &[verifier],
+        &VerifyLockfileResolutionsOptions::default(),
+    )
+    .await
+    .expect("all-ok");
+    assert_eq!(CALLS.load(Ordering::SeqCst), 0);
+}
+
 /// End-to-end cache wiring: a successful first run records the
 /// verification; a second run against the same lockfile +
 /// trustworthy verifier policies hits the cache and never invokes

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -19,7 +19,8 @@ use pacquet_lockfile::{
     LoadLockfileError, Lockfile, SaveLockfileError, StalenessReason, satisfies_package_manifest,
 };
 use pacquet_lockfile_verification::{
-    VerifyError, VerifyLockfileResolutionsOptions, verify_lockfile_resolutions,
+    VerifyError, VerifyLockfileResolutionsOptions, record_lockfile_verified,
+    verify_lockfile_resolutions,
 };
 use pacquet_modules_yaml::{
     Host, IncludedDependencies, LayoutVersion, Modules, NodeLinker as ModulesNodeLinker,
@@ -631,21 +632,21 @@ where
         // install short-circuit the verifier's own fetch chain, and
         // vice versa. Mirrors pnpm's `installing/client` wiring.
         let meta_cache = Arc::new(InMemoryPackageMetaCache::default());
+        let resolution_verifiers = build_resolution_verifiers(
+            config,
+            Arc::clone(&http_client_arc),
+            Some(Arc::clone(&meta_cache)
+                as Arc<dyn pacquet_resolving_npm_resolver::PackageMetaCache>),
+            auth_override.clone(),
+        )
+        .map_err(InstallError::BuildVerifiers)?;
 
         if let Some(loaded_lockfile) = lockfile.filter(|_| !trust_lockfile) {
             let derived_lockfile_path = lockfile_path
                 .map_or_else(|| workspace_root.join(Lockfile::FILE_NAME), Path::to_path_buf);
-            let verifiers = build_resolution_verifiers(
-                config,
-                Arc::clone(&http_client_arc),
-                Some(Arc::clone(&meta_cache)
-                    as Arc<dyn pacquet_resolving_npm_resolver::PackageMetaCache>),
-                auth_override.clone(),
-            )
-            .map_err(InstallError::BuildVerifiers)?;
             verify_lockfile_resolutions::<Reporter>(
                 loaded_lockfile,
-                &verifiers,
+                &resolution_verifiers,
                 &VerifyLockfileResolutionsOptions {
                     concurrency: None,
                     lockfile_path: Some(&derived_lockfile_path),
@@ -984,6 +985,18 @@ where
             .run::<Reporter>()
             .await
             .map_err(InstallError::WithFreshLockfile)?;
+
+            if fresh_result.can_record_lockfile_verification
+                && let Some(lockfile) = fresh_result.wanted_lockfile.as_ref()
+            {
+                let lockfile_path = workspace_root.join(Lockfile::FILE_NAME);
+                record_lockfile_verified(
+                    Some(&config.cache_dir),
+                    &lockfile_path,
+                    lockfile,
+                    &resolution_verifiers,
+                );
+            }
 
             (
                 fresh_result.hoisted_dependencies,

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -5977,6 +5977,135 @@ async fn optimistic_repeat_install_round_trips_on_single_project_install() {
     drop((dir, mock_instance));
 }
 
+#[tokio::test]
+async fn fresh_install_records_lockfile_verification_for_mtime_bypassed_noop() {
+    let mock_instance = TestRegistry::start();
+
+    let dir = tempdir().unwrap();
+    let cache_dir = dir.path().join("cache");
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    std::fs::create_dir_all(&project_root).expect("create project root");
+    let manifest_path = project_root.join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path.clone()).unwrap();
+    manifest
+        .add_dependency("@pnpm.e2e/hello-world-js-bin", "1.0.0", DependencyGroup::Prod)
+        .unwrap();
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.cache_dir = cache_dir.clone();
+    config.store_dir = store_dir.clone().into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    config.registry = mock_instance.url();
+    let config = config.leak();
+
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        lockfile: None,
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        is_full_install: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+        auth_override: None,
+        resolution_observer: None,
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("first install must succeed");
+
+    let lockfile_path = project_root.join(Lockfile::FILE_NAME);
+    let wanted_lockfile =
+        Lockfile::load_wanted_from_dir(&project_root).expect("load wanted lockfile").unwrap();
+
+    drop(mock_instance);
+
+    std::thread::sleep(std::time::Duration::from_millis(20));
+    let manifest_text = std::fs::read_to_string(&manifest_path).expect("read package.json");
+    std::fs::write(&manifest_path, manifest_text).expect("refresh package.json mtime");
+    let touched_manifest = PackageManifest::from_path(manifest_path).expect("reload manifest");
+
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let mut second_config = Config::new();
+    second_config.cache_dir = cache_dir;
+    second_config.store_dir = store_dir.into();
+    second_config.modules_dir = modules_dir;
+    second_config.virtual_store_dir = virtual_store_dir;
+    second_config.registry = "http://127.0.0.1:9/".to_string();
+    let second_config = second_config.leak();
+
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config: second_config,
+        manifest: &touched_manifest,
+        lockfile: Some(&wanted_lockfile),
+        lockfile_path: Some(&lockfile_path),
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        is_full_install: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+        auth_override: None,
+        resolution_observer: None,
+    }
+    .run::<RecordingReporter>()
+    .await
+    .expect("second install must no-op without contacting the stopped registry");
+
+    let captured = EVENTS.lock().unwrap();
+    assert!(
+        captured.iter().any(|event| matches!(
+            event,
+            LogEvent::Pnpm(log)
+                if log.message == "Lockfile is up to date, resolution step is skipped"
+        )),
+        "second install must reach the modules/current-lockfile no-op path; got {captured:#?}",
+    );
+    assert!(
+        !captured.iter().any(|event| matches!(event, LogEvent::LockfileVerification(_))),
+        "verification cache hit must skip the lockfile-verification fan-out; got {captured:#?}",
+    );
+
+    drop(dir);
+}
+
 /// `packageExtensions` adds entries to a dependency's manifest at
 /// resolve time and the resulting lockfile records the merged shape.
 ///

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -6038,9 +6038,15 @@ async fn fresh_install_records_lockfile_verification_for_mtime_bypassed_noop() {
 
     drop(mock_instance);
 
-    std::thread::sleep(std::time::Duration::from_millis(20));
     let manifest_text = std::fs::read_to_string(&manifest_path).expect("read package.json");
     std::fs::write(&manifest_path, manifest_text).expect("refresh package.json mtime");
+    let forced_mtime = std::time::SystemTime::now() + std::time::Duration::from_secs(2);
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&manifest_path)
+        .expect("open package.json")
+        .set_times(std::fs::FileTimes::new().set_modified(forced_mtime))
+        .expect("force package.json mtime");
     let touched_manifest = PackageManifest::from_path(manifest_path).expect("reload manifest");
 
     static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -386,6 +386,12 @@ pub struct InstallWithFreshLockfileResult {
     /// `config.lockfile=false`). The caller mirrors the same gate when
     /// deciding whether to persist the current-lockfile.
     pub wanted_lockfile: Option<Lockfile>,
+    /// `true` when the wanted lockfile written to disk is the same
+    /// typed lockfile returned in [`Self::wanted_lockfile`]. A
+    /// non-null `afterAllResolved` hook result can mutate fields the
+    /// typed model tracks, so the caller must not record a verification
+    /// cache entry for that case.
+    pub can_record_lockfile_verification: bool,
 }
 
 impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> {
@@ -1082,17 +1088,17 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                 &direct_by_importer,
                 &catalogs,
             );
-            let wanted_lockfile = if config.lockfile {
-                save_wanted_lockfile(
+            let (wanted_lockfile, can_record_lockfile_verification) = if config.lockfile {
+                let can_record_lockfile_verification = save_wanted_lockfile(
                     &built_lockfile,
                     &lockfile_dir.join(Lockfile::FILE_NAME),
                     after_all_resolved_hook.as_ref(),
                     after_all_resolved_log.clone(),
                 )
                 .await?;
-                Some(built_lockfile)
+                (Some(built_lockfile), can_record_lockfile_verification)
             } else {
-                None
+                (None, false)
             };
 
             // Close the store-index writer cleanly even though no rows
@@ -1122,6 +1128,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                 hoisted_dependencies: HoistedDependencies::new(),
                 hoisted_locations: BTreeMap::new(),
                 wanted_lockfile,
+                can_record_lockfile_verification,
             });
         }
 
@@ -1560,18 +1567,18 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         // safety property — a manifest-write failure must not leave a
         // current-lockfile pointing at an incomplete install — needs
         // `.modules.yaml` to land first.
-        let wanted_lockfile = if config.lockfile {
+        let (wanted_lockfile, can_record_lockfile_verification) = if config.lockfile {
             let target = lockfile_dir.join(Lockfile::FILE_NAME);
-            save_wanted_lockfile(
+            let can_record_lockfile_verification = save_wanted_lockfile(
                 &built_lockfile,
                 &target,
                 after_all_resolved_hook.as_ref(),
                 after_all_resolved_log.clone(),
             )
             .await?;
-            Some(built_lockfile)
+            (Some(built_lockfile), can_record_lockfile_verification)
         } else {
-            None
+            (None, false)
         };
 
         // Mirrors upstream `link.ts:167-170`: `importing_done` fires once
@@ -1589,6 +1596,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             hoisted_dependencies,
             hoisted_locations,
             wanted_lockfile,
+            can_record_lockfile_verification,
         })
     }
 }
@@ -1682,11 +1690,12 @@ async fn save_wanted_lockfile(
     target: &Path,
     hook: Option<&Arc<dyn pacquet_hooks::PnpmfileHooks>>,
     log: Option<pacquet_hooks::LogFn>,
-) -> Result<(), InstallWithFreshLockfileError> {
+) -> Result<bool, InstallWithFreshLockfileError> {
     let Some(hook) = hook else {
-        return built_lockfile
+        built_lockfile
             .save_to_path(target)
-            .map_err(InstallWithFreshLockfileError::SaveWantedLockfile);
+            .map_err(InstallWithFreshLockfileError::SaveWantedLockfile)?;
+        return Ok(true);
     };
 
     let value = serde_json::to_value(built_lockfile)
@@ -1704,7 +1713,8 @@ async fn save_wanted_lockfile(
     } else {
         pacquet_lockfile::save_value_to_path(&result, target)
     }
-    .map_err(InstallWithFreshLockfileError::SaveWantedLockfile)
+    .map_err(InstallWithFreshLockfileError::SaveWantedLockfile)?;
+    Ok(result.is_null())
 }
 
 /// Build the [`Lockfile`] for `<lockfile_dir>/pnpm-lock.yaml` from the

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -227,6 +227,19 @@ pub fn create_npm_resolution_verifier(
 }
 
 impl ResolutionVerifier for NpmResolutionVerifier {
+    fn might_verify(&self, resolution: &LockfileResolution, ctx: VerifyCtx<'_>) -> bool {
+        let Some(tarball_url) = npm_registry_tarball(resolution) else {
+            return false;
+        };
+        if tarball_url.is_some() {
+            return true;
+        }
+        self.age_check_active()
+            && !is_excluded(self.minimum_release_age_exclude.as_ref(), ctx.name, ctx.version)
+            || self.trust_check_active()
+                && !is_excluded(self.trust_policy_exclude.as_ref(), ctx.name, ctx.version)
+    }
+
     fn verify<'a>(
         &'a self,
         resolution: &'a LockfileResolution,
@@ -314,6 +327,14 @@ impl NpmResolutionVerifier {
             return ResolutionVerification::Ok;
         }
 
+        let age_applies = self.age_check_active()
+            && !is_excluded(self.minimum_release_age_exclude.as_ref(), ctx.name, ctx.version);
+        let trust_applies = self.trust_check_active()
+            && !is_excluded(self.trust_policy_exclude.as_ref(), ctx.name, ctx.version);
+        if tarball_url.is_none() && !age_applies && !trust_applies {
+            return ResolutionVerification::Ok;
+        }
+
         let registry = self.pick_registry(ctx.name, tarball_url);
 
         // A registry entry that pins an explicit tarball URL must point at
@@ -330,10 +351,6 @@ impl NpmResolutionVerifier {
             return violation;
         }
 
-        let age_applies = self.age_check_active()
-            && !is_excluded(self.minimum_release_age_exclude.as_ref(), ctx.name, ctx.version);
-        let trust_applies = self.trust_check_active()
-            && !is_excluded(self.trust_policy_exclude.as_ref(), ctx.name, ctx.version);
         if !age_applies && !trust_applies {
             return ResolutionVerification::Ok;
         }

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -199,13 +199,28 @@ async fn verifies_tarball_url_when_no_policy_active() {
         git_hosted: None,
         path: None,
     });
-    let result = verifier
-        .verify(&resolution, ctx(&"aged-pkg".parse::<PkgName>().expect("parse"), "1.0.0"))
-        .await;
+    let name: PkgName = "aged-pkg".parse().expect("parse");
+    assert!(verifier.might_verify(&resolution, ctx(&name, "1.0.0")));
+    let result = verifier.verify(&resolution, ctx(&name, "1.0.0")).await;
     let ResolutionVerification::Err { code, .. } = result else {
         panic!("expected Err, got {result:?}");
     };
     assert_eq!(code, "TARBALL_URL_MISMATCH");
+}
+
+#[tokio::test]
+async fn registry_resolution_with_no_active_policy_skips_metadata_lookup() {
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let _meta_mock = server.mock("GET", "/acme").expect(0).create_async().await;
+
+    let opts = default_opts(&registry);
+    let verifier = create_npm_resolution_verifier(opts);
+    let name: PkgName = "acme".parse().expect("parse");
+    assert!(!verifier.might_verify(&registry_resolution(), ctx(&name, "1.0.0")));
+    let result = verifier.verify(&registry_resolution(), ctx(&name, "1.0.0")).await;
+
+    assert_eq!(result, ResolutionVerification::Ok);
 }
 
 /// `minimum_release_age = 0` keeps the age check inactive. The bogus

--- a/pacquet/crates/resolving-resolver-base/src/verifier.rs
+++ b/pacquet/crates/resolving-resolver-base/src/verifier.rs
@@ -89,6 +89,14 @@ pub type VerifyFuture<'a> = Pin<Box<dyn Future<Output = ResolutionVerification> 
 /// Mirrors pnpm's
 /// [`ResolutionVerifier`](https://github.com/pnpm/pnpm/blob/3687b0e180/resolving/resolver-base/src/index.ts#L113-L131).
 pub trait ResolutionVerifier: Send + Sync {
+    /// Cheap synchronous filter used before the runner allocates the
+    /// verifier future. Returning `false` must be equivalent to
+    /// `verify(...)` returning [`ResolutionVerification::Ok`] for the
+    /// same entry.
+    fn might_verify(&self, _resolution: &LockfileResolution, _ctx: VerifyCtx<'_>) -> bool {
+        true
+    }
+
     fn verify<'a>(
         &'a self,
         resolution: &'a LockfileResolution,


### PR DESCRIPTION
## Summary

- record successful fresh lockfile verification results so mtime-bypassed no-op installs can reuse the verification cache
- add a synchronous verifier interest check before lockfile-verification fan-out allocates async work
- skip npm metadata verification for ordinary registry entries when no tarball URL, age policy, or trust policy applies

## Testing

- `cargo test -p pacquet-lockfile-verification verify_lockfile_resolutions::tests::`
- `cargo test -p pacquet-resolving-npm-resolver create_npm_resolution_verifier::tests::`
- `cargo test -p pacquet-package-manager install::tests::`
- push hooks: pnpm compile/lint, `cargo fmt --all -- --check`, Rust docs, dylint, taplo format check

Did not rerun the external vlt benchmark harness locally.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fresh installs now record lockfile verification status so subsequent installs can skip redundant verification.

* **Performance**
  * Verification pre-filters applicable checks to avoid unnecessary verifier work and metadata lookups, skipping irrelevant candidates.

* **Tests**
  * New tests validate that uninterested verifiers are skipped and that lockfile verification is bypassed when cached/no-op conditions apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->