### PR TITLE
chore: update lockfile, Node.js, pnpm, and pacquet versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-branch": "pn pretest && pn lint && git remote set-branches --add origin main && git fetch origin main && pn test-pkgs-branch",
     "ci:test-branch": "pn prepare-fixtures && pn test-pkgs-branch",
     "test-pkgs-branch": "pn remove-temp-dir && pn --workspace-concurrency=1 --filter=...[origin/main] --no-sort --if-present .test",
-    "compile-only": "tsgo --build workspace/workspace-manifest-reader workspace/projects-reader && pnx node@runtime:26.3.0 __utils__/scripts/src/typecheck-only.ts && pn -F=pnpm compile",
+    "compile-only": "tsgo --build workspace/workspace-manifest-reader workspace/projects-reader && pnx node@runtime:^26.3.0 __utils__/scripts/src/typecheck-only.ts && pn -F=pnpm compile",
     "compile": "pn compile-only && pn update-manifests",
     "build:pacquet": "cargo build --release --bin pacquet",
     "make-lcov": "shx mkdir -p coverage && lcov-result-merger './packages/*/coverage/lcov.info' 'coverage/lcov.info'",
@@ -70,7 +70,7 @@
     },
     "runtime": {
       "name": "node",
-      "version": "26.3.0",
+      "version": "^26.3.0",
       "onFail": "download"
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-branch": "pn pretest && pn lint && git remote set-branches --add origin main && git fetch origin main && pn test-pkgs-branch",
     "ci:test-branch": "pn prepare-fixtures && pn test-pkgs-branch",
     "test-pkgs-branch": "pn remove-temp-dir && pn --workspace-concurrency=1 --filter=...[origin/main] --no-sort --if-present .test",
-    "compile-only": "tsgo --build workspace/workspace-manifest-reader workspace/projects-reader && pnx node@runtime:^26.3.0 __utils__/scripts/src/typecheck-only.ts && pn -F=pnpm compile",
+    "compile-only": "tsgo --build workspace/workspace-manifest-reader workspace/projects-reader && pnx node@runtime:26.3.0 __utils__/scripts/src/typecheck-only.ts && pn -F=pnpm compile",
     "compile": "pn compile-only && pn update-manifests",
     "build:pacquet": "cargo build --release --bin pacquet",
     "make-lcov": "shx mkdir -p coverage && lcov-result-merger './packages/*/coverage/lcov.info' 'coverage/lcov.info'",
@@ -61,16 +61,16 @@
     "shx": "catalog:",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.5.3",
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "11.5.2",
+      "version": "11.5.3",
       "onFail": "download"
     },
     "runtime": {
       "name": "node",
-      "version": "^26.3.0",
+      "version": "26.3.0",
       "onFail": "download"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1139,7 +1139,7 @@ importers:
         specifier: 'catalog:'
         version: 5.0.1
       node:
-        specifier: runtime:26.3.0
+        specifier: runtime:^26.3.0
         version: runtime:26.3.0
       rimraf:
         specifier: 'catalog:'
@@ -15397,7 +15397,6 @@ packages:
             - cpu: x64
               os: linux
               libc: musl
-    version: 26.3.0
     hasBin: true
 
   nopt@1.0.10:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,89 +6,89 @@ importers:
   .:
     configDependencies:
       '@pnpm/pacquet':
-        specifier: 0.11.1
-        version: 0.11.1
+        specifier: 0.11.2
+        version: 0.11.2
     packageManagerDependencies:
       '@pnpm/exe':
-        specifier: 11.5.2
-        version: 11.5.2
+        specifier: 11.5.3
+        version: 11.5.3
       pnpm:
-        specifier: 11.5.2
-        version: 11.5.2
+        specifier: 11.5.3
+        version: 11.5.3
 
 packages:
 
-  '@pacquet/darwin-arm64@0.11.1':
-    resolution: {integrity: sha512-BuXwCsOvaZgEttK7VBZi4AADHRN+JofG3X5c+hklkTGrb2S3EiSQvY5eqfAekrZaRt9jd62KQDyvzAKRnSaEng==}
+  '@pacquet/darwin-arm64@0.11.2':
+    resolution: {integrity: sha512-sYhnOfaEj+JG16urdtGPLDQfdRnlCqJwzGw5i5lr43cLKr1Yem8GvgMuAPB8H2sB7NIplYH5xCPA6eUlf1mkLA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pacquet/darwin-x64@0.11.1':
-    resolution: {integrity: sha512-Zq7uBkJdDihDfOicYFswF+yZSCEMCJByYH2H1Ik1cINC9HYBfBPp1x6EoVSFUUQghxVPwiaBjfDogCJEpZc2QA==}
+  '@pacquet/darwin-x64@0.11.2':
+    resolution: {integrity: sha512-Ji1fLXo2wCzFVOBkzYx/F8Hdh54mOllPBqYxuyIBRXaCgdqh0mRjgdxmiZgrBHDM7Le5uYcidRc+UNeNN9uGug==}
     cpu: [x64]
     os: [darwin]
 
-  '@pacquet/linux-arm64@0.11.1':
-    resolution: {integrity: sha512-4W3mJkC8ngzF04xEHvf8TAxaOeT9jzKtNp+8GJ1L1q/F0CNsMoiVEP+gB3fDwktcPyqJKU50UWlCQA7lACbaFg==}
+  '@pacquet/linux-arm64@0.11.2':
+    resolution: {integrity: sha512-O5rl/NkVTZUdMF1RH1z+FHfLS3I+IswBoZflczpO49GA2QudcpDTsZNioAyJhCzImfPr38chnhXUDkuRZx7xYg==}
     cpu: [arm64]
     os: [linux]
 
-  '@pacquet/linux-x64@0.11.1':
-    resolution: {integrity: sha512-BGo9N02QUx6BhEZkuT1uFkEAzfDR7yZy1Cf6Ry0sTXVie593WLiSktNPFIGd1b3QGKXpgQylsXIigA5LC/P1/g==}
+  '@pacquet/linux-x64@0.11.2':
+    resolution: {integrity: sha512-ZnWbgVilERjffmd46Of0oTcjbHNcgk24YluRI8pfeZM5kI7SF6lyW4IFgVkBvWvJCCynj5ieRg5iIHiPu3M5LQ==}
     cpu: [x64]
     os: [linux]
 
-  '@pacquet/win32-arm64@0.11.1':
-    resolution: {integrity: sha512-nDivP7M/GozAcqIJQQmgnpBAXgrQpVYuQIMhNbryNFkYYZsvHgnbbIhUpYRvosCn10XSYESNxh70wz5vAx/3WQ==}
+  '@pacquet/win32-arm64@0.11.2':
+    resolution: {integrity: sha512-WDYis3Sfa4iviqFenInQTLghYkL3CDbzszvrbc7RJEr8r3XjxicaY67hjl6ztzUUyCfBCJ7t0Bbfv258JeJr2w==}
     cpu: [arm64]
     os: [win32]
 
-  '@pacquet/win32-x64@0.11.1':
-    resolution: {integrity: sha512-5bl8i0jkWltwwhBmAqNDumh8uPdk1NBiHqCJfC4F+A3QZt6YQnFmszLkXu/uG1mzpO41dSUfEhQy/h4t2Y0Eaw==}
+  '@pacquet/win32-x64@0.11.2':
+    resolution: {integrity: sha512-CQbIxqLK7tUvZB2TYECo9kuc+Jc064QctrUr2gjbpBE1Q/EnshfPStssgp+de/hdLcxtpsTxh0eAbkIqG4OR7g==}
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@11.5.2':
-    resolution: {integrity: sha512-4UFnP2rhNu1xjAQ+I1GdIUUEtCJuTYJlbpiWSFA4POAID3Lpt+2vrjImWO7eOJ7iCY3vpc4TFe2IW3sAolW4Kg==}
+  '@pnpm/exe@11.5.3':
+    resolution: {integrity: sha512-eb8921VsrlLhIf6z/6lopFZ25MH60qgybvPBMHH17s8AAcfh5ipBAHBpxZ3PKNNpJ7v8aZZdZkccDBjwfsUjsA==}
     hasBin: true
 
-  '@pnpm/linux-arm64@11.5.2':
-    resolution: {integrity: sha512-MbJySnu2y9cCBqlODLjUlZ87JnRC3Inq40rvGHWJSrSQ0PnuHeSw2NDMnLI8Hf9hCY+ooussRc5iiR4IAkjUvg==}
+  '@pnpm/linux-arm64@11.5.3':
+    resolution: {integrity: sha512-3UebCq+4osz5/p6GNfH8iEepCUchGDS778ShcIHkJioCUV/QnmLI3IT0MYOymwc+p5/+ECZlUYEfON2FH2seOg==}
     cpu: [arm64]
     os: [linux]
 
-  '@pnpm/linux-x64@11.5.2':
-    resolution: {integrity: sha512-g6g2BGpQA47wUACy6B1MdeSHPtnl6x4AeCg0IOWQ7xXorEtC+VRiSHhLpA5kByFGeSwyYh/nLc7mLul5DAaELw==}
+  '@pnpm/linux-x64@11.5.3':
+    resolution: {integrity: sha512-fqAhjHjTcu16uryQb1JSbvGThaYp32vuu52teL4FhBaXC1fsgcqWoOEQgFnGfJKXAQO8jEKDb/1BiScQFV+O9g==}
     cpu: [x64]
     os: [linux]
 
-  '@pnpm/linuxstatic-arm64@11.5.2':
-    resolution: {integrity: sha512-xTxs9BLxYW39BPNGnmvYCUBnMPWm4mzmzujmdYbpRxDnBXrx55qPR5K/3LSohX7VrmsdDrYxuH6AmG1AaOlIfA==}
+  '@pnpm/linuxstatic-arm64@11.5.3':
+    resolution: {integrity: sha512-z+bw8dIFhFL4Ou82Emjmdd6YndIg2R/KSbx+b5quD9v44V3cZ6OBMdddshCxzq/YEWsB6lCs/86ThbmWojJ7Vw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/linuxstatic-x64@11.5.2':
-    resolution: {integrity: sha512-RGmmc/SoGLD90gmOHcU85UEKNoNRstLvizli4wzDASmETz/VeqJOqU5nD1YBgjzcP72sUMS352dh4bmzTfKyvQ==}
+  '@pnpm/linuxstatic-x64@11.5.3':
+    resolution: {integrity: sha512-05FvuSx6G1c+ZNs4j/TQldy09YFkfXkvq+MgFplEFIUguLShQi88gkvBBSt1v2RiIPdnjn/kHN7FmyL++RiXZw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/macos-arm64@11.5.2':
-    resolution: {integrity: sha512-gW3A2jRlC3SJRw8qX2SAzjMIu9o98daTSqCKzeeYcjF/uEbtbz3dn4HqYrYffBnenKbc4hsgZQmNOHAvUKIlSg==}
+  '@pnpm/macos-arm64@11.5.3':
+    resolution: {integrity: sha512-nyQs/0yUZAHszkEGdDvOz964aPPzrMw+PGh6yIEYNMEzZfxSLEzD4No1qHj7AOplYmSB9tRazHp7o6einjE6pA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/pacquet@0.11.1':
-    resolution: {integrity: sha512-4785guig8RpbPh5HCQFeyV6jyO7F6gPs/HxbcX9c6DK2ATwF7Awc24JCddOpxWIpzgiieBWyqhAKjTdCLK9E0A==}
+  '@pnpm/pacquet@0.11.2':
+    resolution: {integrity: sha512-MjsAWpW5K1xOaaspquMhk5j9sjpADLH3c3hxq07VVZwS9uu1W6gzMBHxlhy1NX/+ZacqMhfyScvgQqymCc1znQ==}
 
-  '@pnpm/win-arm64@11.5.2':
-    resolution: {integrity: sha512-+VJCDoH/pRzLXBikwjvxgAnGfQufT8EALBX8cfSmrwD40JABUZvgPtjBjde7OwEoK/XwtlH8w+ZceFV0K3/YHQ==}
+  '@pnpm/win-arm64@11.5.3':
+    resolution: {integrity: sha512-7DOlug2CLCuRdWTar5ljDQNpvLLphJXqb3nDw2Vx+9vUhHjbfJRFrjZ+fYj5APoUUZv1esMaiAql4dNEqYVo1Q==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/win-x64@11.5.2':
-    resolution: {integrity: sha512-zgglREh75RbFgV/E0tNRS03ElX+hJOV43KRSSeaboxtj3ei1rrguxOgOCXUs/GsizoHVsuD+qXGABE4Kc4GMCg==}
+  '@pnpm/win-x64@11.5.3':
+    resolution: {integrity: sha512-hnIv1nVlTjEr7H415bVEfNVH65sfHClvuWd35fkR1WLVut+dHBSKqQNeDd4auJCeFtiSSVvIingsNS63abAWUQ==}
     cpu: [x64]
     os: [win32]
 
@@ -152,72 +152,72 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  pnpm@11.5.2:
-    resolution: {integrity: sha512-ccYx44IGbvwlYl1c8CkHXeB7YbN/bic1D72Esb2lhkyMGWetwoB3a0XDCnFcA1mjvgj+9C1bsJ4rmQKZeWkpFg==}
+  pnpm@11.5.3:
+    resolution: {integrity: sha512-esHJGTQcITo03A0Cr7cUPFwmrCbujEeC3uqCG4rGTSE0oIH9iUHa5uKbu0j1jfwrf7zuzMB8svCdIZ00Kklp7Q==}
     engines: {node: '>=22.13'}
     hasBin: true
 
 snapshots:
 
-  '@pacquet/darwin-arm64@0.11.1':
+  '@pacquet/darwin-arm64@0.11.2':
     optional: true
 
-  '@pacquet/darwin-x64@0.11.1':
+  '@pacquet/darwin-x64@0.11.2':
     optional: true
 
-  '@pacquet/linux-arm64@0.11.1':
+  '@pacquet/linux-arm64@0.11.2':
     optional: true
 
-  '@pacquet/linux-x64@0.11.1':
+  '@pacquet/linux-x64@0.11.2':
     optional: true
 
-  '@pacquet/win32-arm64@0.11.1':
+  '@pacquet/win32-arm64@0.11.2':
     optional: true
 
-  '@pacquet/win32-x64@0.11.1':
+  '@pacquet/win32-x64@0.11.2':
     optional: true
 
-  '@pnpm/exe@11.5.2':
+  '@pnpm/exe@11.5.3':
     dependencies:
       '@reflink/reflink': 0.1.19
       detect-libc: 2.1.2
     optionalDependencies:
-      '@pnpm/linux-arm64': 11.5.2
-      '@pnpm/linux-x64': 11.5.2
-      '@pnpm/linuxstatic-arm64': 11.5.2
-      '@pnpm/linuxstatic-x64': 11.5.2
-      '@pnpm/macos-arm64': 11.5.2
-      '@pnpm/win-arm64': 11.5.2
-      '@pnpm/win-x64': 11.5.2
+      '@pnpm/linux-arm64': 11.5.3
+      '@pnpm/linux-x64': 11.5.3
+      '@pnpm/linuxstatic-arm64': 11.5.3
+      '@pnpm/linuxstatic-x64': 11.5.3
+      '@pnpm/macos-arm64': 11.5.3
+      '@pnpm/win-arm64': 11.5.3
+      '@pnpm/win-x64': 11.5.3
 
-  '@pnpm/linux-arm64@11.5.2':
+  '@pnpm/linux-arm64@11.5.3':
     optional: true
 
-  '@pnpm/linux-x64@11.5.2':
+  '@pnpm/linux-x64@11.5.3':
     optional: true
 
-  '@pnpm/linuxstatic-arm64@11.5.2':
+  '@pnpm/linuxstatic-arm64@11.5.3':
     optional: true
 
-  '@pnpm/linuxstatic-x64@11.5.2':
+  '@pnpm/linuxstatic-x64@11.5.3':
     optional: true
 
-  '@pnpm/macos-arm64@11.5.2':
+  '@pnpm/macos-arm64@11.5.3':
     optional: true
 
-  '@pnpm/pacquet@0.11.1':
+  '@pnpm/pacquet@0.11.2':
     optionalDependencies:
-      '@pacquet/darwin-arm64': 0.11.1
-      '@pacquet/darwin-x64': 0.11.1
-      '@pacquet/linux-arm64': 0.11.1
-      '@pacquet/linux-x64': 0.11.1
-      '@pacquet/win32-arm64': 0.11.1
-      '@pacquet/win32-x64': 0.11.1
+      '@pacquet/darwin-arm64': 0.11.2
+      '@pacquet/darwin-x64': 0.11.2
+      '@pacquet/linux-arm64': 0.11.2
+      '@pacquet/linux-x64': 0.11.2
+      '@pacquet/win32-arm64': 0.11.2
+      '@pacquet/win32-x64': 0.11.2
 
-  '@pnpm/win-arm64@11.5.2':
+  '@pnpm/win-arm64@11.5.3':
     optional: true
 
-  '@pnpm/win-x64@11.5.2':
+  '@pnpm/win-x64@11.5.3':
     optional: true
 
   '@reflink/reflink-darwin-arm64@0.1.19':
@@ -257,7 +257,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  pnpm@11.5.2: {}
+  pnpm@11.5.3: {}
 
 ---
 lockfileVersion: '9.0'
@@ -1139,7 +1139,7 @@ importers:
         specifier: 'catalog:'
         version: 5.0.1
       node:
-        specifier: runtime:^26.3.0
+        specifier: runtime:26.3.0
         version: runtime:26.3.0
       rimraf:
         specifier: 'catalog:'
@@ -15397,6 +15397,7 @@ packages:
             - cpu: x64
               os: linux
               libc: musl
+    version: 26.3.0
     hasBin: true
 
   nopt@1.0.10:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -329,7 +329,7 @@ catalogMode: strict
 cleanupUnusedCatalogs: true
 
 configDependencies:
-  '@pnpm/pacquet': 0.11.1
+  '@pnpm/pacquet': 0.11.2
 
 enableGlobalVirtualStore: true
 


### PR DESCRIPTION
This automated PR refreshes the project's pinned versions:

- Updates the lockfile to the latest compatible versions of dependencies.
- Bumps Node.js to the latest 26.x release, propagated into the CI, release, and benchmark workflows via the meta-updater.
- Bumps pnpm to the latest release (`packageManager` and `devEngines.packageManager`).
- Bumps the `@pnpm/pacquet` config dependency to its latest release.

Created by the update-lockfile workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project package manager to pnpm 11.5.3 to align tooling across environments.
  * Bumped workspace tooling dependency `@pnpm/pacquet` to 0.11.2 to pick up the latest fixes and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->