### PR TITLE
feat: deprecate $ version references in overrides

### DIFF
--- a/.changeset/dollar-overrides-deprecation.md
+++ b/.changeset/dollar-overrides-deprecation.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Using the `$` version reference syntax in `overrides` (e.g. `"react": "$react"`) now prints a deprecation warning. The syntax still works, but [catalogs](https://pnpm.io/catalogs) are the recommended way to keep an overridden version in sync with the rest of the workspace. Reference a catalog entry with the `catalog:` protocol instead.

--- a/config/reader/src/getOptionsFromRootManifest.ts
+++ b/config/reader/src/getOptionsFromRootManifest.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 
 import { envReplace } from '@pnpm/config.env-replace'
 import { PnpmError } from '@pnpm/error'
+import { globalWarn } from '@pnpm/logger'
 import type {
   AllowedDeprecatedVersions,
   PackageExtension,
@@ -31,8 +32,11 @@ export function getOptionsFromPnpmSettings (manifestDir: string | undefined, pnp
     assertValidOverrides(settings.overrides)
     if (Object.keys(settings.overrides).length === 0) {
       delete settings.overrides
-    } else if (manifest) {
-      settings.overrides = mapValues(createVersionReferencesReplacer(manifest), settings.overrides)
+    } else {
+      warnAboutDeprecatedVersionReferences(settings.overrides)
+      if (manifest) {
+        settings.overrides = mapValues(createVersionReferencesReplacer(manifest), settings.overrides)
+      }
     }
   }
   if (pnpmSettings.patchedDependencies) {
@@ -90,6 +94,16 @@ function replaceEnvInStringValues (value: unknown): unknown {
     out[k] = typeof v === 'string' ? envReplace(v, process.env) : v
   }
   return out
+}
+
+function warnAboutDeprecatedVersionReferences (overrides: Record<string, string>): void {
+  const selectors = Object.keys(overrides).filter((selector) => overrides[selector][0] === '$')
+  if (selectors.length === 0) return
+  globalWarn(
+    `The "$" version reference syntax in overrides is deprecated (used by: ${selectors.join(', ')}). ` +
+    'Define the version in a catalog and reference it with the "catalog:" protocol instead. ' +
+    'See https://pnpm.io/catalogs'
+  )
 }
 
 function createVersionReferencesReplacer (manifest: ProjectManifest): (spec: string) => string {

--- a/config/reader/test/deprecatedVersionReferences.test.ts
+++ b/config/reader/test/deprecatedVersionReferences.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('@pnpm/logger', () => ({
+  globalWarn: jest.fn(),
+}))
+
+const { globalWarn } = await import('@pnpm/logger')
+const { getOptionsFromPnpmSettings } = await import('../lib/getOptionsFromRootManifest.js')
+
+beforeEach(() => {
+  jest.mocked(globalWarn).mockClear()
+})
+
+test('getOptionsFromPnpmSettings() warns about deprecated "$" version references and still resolves them', () => {
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    overrides: {
+      foo: '$foo',
+    },
+  }, {
+    dependencies: {
+      foo: '^1.0.0',
+    },
+  })
+  expect(options.overrides).toStrictEqual({ foo: '^1.0.0' })
+  expect(globalWarn).toHaveBeenCalledTimes(1)
+  const warning = jest.mocked(globalWarn).mock.calls[0][0]
+  expect(warning).toContain('deprecated')
+  expect(warning).toContain('foo')
+  expect(warning).toContain('catalog:')
+})
+
+test('getOptionsFromPnpmSettings() does not warn when no "$" version references are used', () => {
+  getOptionsFromPnpmSettings(process.cwd(), {
+    overrides: {
+      foo: '^1.0.0',
+      bar: 'catalog:',
+    },
+  }, {
+    dependencies: {
+      foo: '^1.0.0',
+    },
+  })
+  expect(globalWarn).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## What

Using the `$` version reference syntax in `overrides` (e.g. `"react": "$react"`) now prints a deprecation warning. The syntax still resolves exactly as before — this only adds a warning that nudges users toward [catalogs](https://pnpm.io/catalogs).

```
The "$" version reference syntax in overrides is deprecated (used by: react). Define the version in a catalog and reference it with the "catalog:" protocol instead. See https://pnpm.io/catalogs
```

## Why

The `$react` syntax resolves the override against the root manifest's direct dependencies. This makes it fragile — for example, `pnpm fetch` with a minimal `package.json` (only `packageManager`) crashes with `ERR_PNPM_CANNOT_RESOLVE_OVERRIDE_VERSION`, even though the lockfile already has everything (pnpm/pnpm#12160).

Catalogs cover the same "maintain the version in one place" use case without that fragility: a `catalog:` reference is self-contained (the version lives in the catalog, not in the direct deps), and catalogs are already supported inside `overrides`. The plan is deprecate now, remove in a future major.

## Changes

- `@pnpm/config.reader`: emit a `globalWarn` when any override value uses the `$` syntax (in `getOptionsFromRootManifest.ts`). Resolution behavior is unchanged.
- Tests covering the warning and the no-warning case.
- Changeset (patch).

Docs were updated separately in the `pnpm.io` repo (the `overrides` section now documents the `catalog:` approach instead of `$`).

## Parity note (pacquet)

No pacquet-side change is needed: pacquet's `config-parse-overrides` does not implement `$` version-reference resolution at all yet, so there is nothing to deprecate there. When pacquet ports the `$` syntax, this deprecation warning should be ported alongside it.

## Follow-ups (not in this PR)

- Optionally make `$` resolution lazy/skipped on the `pnpm fetch` path so existing `$` users stop hitting the crash in pnpm/pnpm#12160 during the deprecation window.
- Eventually remove `$` support in a major release.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Documented deprecation of `$` version reference syntax in pnpm overrides; users are encouraged to adopt `catalog:` protocol instead for maintaining synchronized override versions.

* **New Features**
  * System now emits warnings when deprecated `$` syntax is detected in overrides, guiding users toward the recommended migration path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->