### PR TITLE
chore: add .pr_agent.toml to configure Qodo reviews

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,34 @@
+[github_app]
+# Commands run automatically when a PR is opened.
+pr_commands = [
+    "/agentic_describe",
+    "/agentic_review",
+]
+
+# Re-run commands when new commits are pushed to the PR.
+handle_push_trigger = true
+
+# Commands run automatically on push (requires handle_push_trigger = true).
+push_commands = [
+    "/agentic_review",
+]
+
+[config]
+# Skip automated reviews on bot-authored PRs (e.g. dependency bumps).
+# Qodo auto-detects most bots; these are listed explicitly to be safe.
+ignore_pr_authors = [
+    "dependabot[bot]",
+    "renovate[bot]",
+]
+
+# Optional: also skip reviews on chore/ci PRs by title (regex list).
+# Left commented so maintainers can opt in. Note that bot dependency bumps
+# are already covered by ignore_pr_authors above.
+# ignore_pr_title = ["^chore", "^ci"]
+
+[review_agent]
+# Extra instructions for the Issues Agent (bug, security, performance detection).
+# issues_user_guidelines = "Flag unhandled rejections in async code and missing error handling around filesystem and network calls"
+
+# Extra instructions for the Compliance Agent (rule checking).
+# compliance_user_guidelines = "Ensure changes to dependency resolution and lockfile handling preserve backward compatibility"


### PR DESCRIPTION
As discussed with a maintainer, this adds a `.pr_agent.toml` so Qodo runs an agentic review in addition to the summary it already posts.

What it configures:
- On PR open: `/agentic_describe` + `/agentic_review`
- On push: `/agentic_review` (enabled via `handle_push_trigger`)
- Skips bot-authored PRs (dependabot, renovate) to cut noise. Qodo auto-detects most bots; these are listed explicitly to be safe.
- Commented-out `ignore_pr_title` and `review_agent` user-guideline keys so maintainers can tweak later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added PR automation configuration file with settings for automated commands on PR open, push trigger handling, and bot account exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->