### PR TITLE
docs: clarify store trust boundary

### DIFF
--- a/.changeset/store-discl.md
+++ b/.changeset/store-discl.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/cli.common-cli-options-help": patch
+"@pnpm/installing.commands": patch
+"pnpm": patch
+---
+
+Clarified in CLI help that the pnpm store is trusted shared state and store integrity checks are corruption detection, not a tamper boundary for untrusted store writers.

--- a/cli/common-cli-options-help/src/index.ts
+++ b/cli/common-cli-options-help/src/index.ts
@@ -16,7 +16,7 @@ export const OPTIONS = {
     name: '--prefer-offline',
   },
   storeDir: {
-    description: 'The directory in which all the packages are saved on the disk',
+    description: 'The directory in which all packages are saved on disk. Use a shared store only with trusted users and jobs',
     name: '--store-dir <dir>',
   },
   virtualStoreDir: {

--- a/installing/commands/src/install.ts
+++ b/installing/commands/src/install.ts
@@ -218,7 +218,7 @@ by any dependencies, so it is an emulation of a flat node_modules',
             name: '--ignore-workspace',
           },
           {
-            description: "If false, doesn't check whether packages in the store were mutated",
+            description: 'If false, skips store integrity checks. These checks detect accidental corruption, not tampering by untrusted users with write access to the store',
             name: '--[no-]verify-store-integrity',
           },
           {

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -387,7 +387,9 @@ pub struct Config {
     /// true to hoist them for you.
     pub shamefully_hoist: bool,
 
-    /// The location where all the packages are saved on the disk.
+    /// The location where all packages are saved on disk. Share a
+    /// writable store only between mutually trusted users, jobs, and
+    /// processes.
     #[default(_code = "default_store_dir::<Host>()")]
     pub store_dir: StoreDir,
 
@@ -792,6 +794,9 @@ pub struct Config {
     /// lookup skips that verification entirely and trusts the index — a
     /// missing blob is discovered lazily at link time instead.
     ///
+    /// This is corruption detection for a trusted store, not a tamper
+    /// boundary for a store writable by untrusted users or jobs.
+    ///
     /// Matches pnpm's `verifyStoreIntegrity` camelCase key in
     /// `pnpm-workspace.yaml` (same `true` default as pnpm's
     /// `installing/deps-installer/src/install/extendInstallOptions.ts`).
@@ -1152,6 +1157,8 @@ pub struct Config {
     /// verification gate to memoize past results in
     /// `<cache_dir>/lockfile-verified.jsonl`, and by the npm verifier
     /// to mirror full-metadata responses for conditional GETs.
+    /// Share a writable cache only between mutually trusted users,
+    /// jobs, and processes.
     ///
     /// Mirrors pnpm's
     /// [`cacheDir`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/Config.ts#L159);

--- a/pacquet/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/pacquet/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -270,6 +270,10 @@ fn build_side_effects_maps(
 /// fails, so operators can see *which* package file invalidated the
 /// store-index row in the log.
 ///
+/// **Trust boundary.** This verification is for corruption detection
+/// in a trusted local store. It is not a tamper boundary for a store
+/// writable by untrusted users or jobs.
+///
 /// **Locking discipline.** The fast path (`is_modified == false`, i.e.
 /// the file's mtime is within 100 ms of the recorded `checked_at`)
 /// runs lock-free — it never touches the file's bytes and never

--- a/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -168,8 +168,9 @@ function verifyFile (
     }
     return passed
   }
-  // If a file was not edited, we are skipping integrity check.
-  // We assume that nobody will manually remove a file in the store and create a new one.
+  // Fast path for trusted stores: if metadata says the file is unchanged, skip the
+  // digest read. Store integrity verification detects corruption; it does not make
+  // a store writable by untrusted users safe.
   return true
 }
 


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Docs: clarify pnpm store trust boundary and integrity-check semantics
<code>📝 Documentation</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary

- clarify `--store-dir` help that a shared store is trusted shared state
- clarify `--verify-store-integrity` help and CAFS comments that integrity checks detect corruption, not tampering by untrusted store writers
- mirror the trust-boundary notes in pacquet config and store-dir docs, including `cacheDir`

## Verification

- `git diff --check`
- `pnpm exec eslint cli/common-cli-options-help/src/index.ts installing/commands/src/install.ts store/cafs/src/checkPkgFilesIntegrity.ts`
- `cargo fmt --all -- --check`
- pre-push hook passed, including pnpm compile/lint/spellcheck/meta checks, cargo doc, cargo dylint, and taplo format

---
Written by an agent (Codex, GPT-5).

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Clarify that a shared pnpm store is trusted shared state (CLI/config/docs).
• Document that store integrity checks detect accidental corruption, not tampering.
• Mirror the same trust-boundary guidance for pacquet store/cache configuration.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  U(["Developer / CI"]) --> CLI["pnpm CLI help"] --> Store[("Shared store")]
  CLI --> Verify["Integrity checks"] --> Store
  U --> Pacquet["pacquet config docs"] --> Store
  Pacquet --> Cache[("Shared cache")]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Add a dedicated “Security / Threat model” doc page</b></summary>

- ➕ Centralizes the trust-boundary guidance instead of duplicating it across help/docs/comments
- ➕ Provides a natural place to explain multi-user/CI hardening recommendations
- ➖ Less likely to be read at the point of use compared to inline CLI/config docs
- ➖ Requires additional doc plumbing and cross-linking

</details>

<details>
<summary><b>2. Runtime warnings for risky configurations</b></summary>

- ➕ Prevents misconfiguration by surfacing trust-boundary risk during execution
- ➕ More actionable than passive documentation
- ➖ Introduces behavioral changes and potential noise/false positives
- ➖ Requires reliable detection of “shared/untrusted” scenarios

</details>

**Recommendation:** The PR’s approach (inline clarifications in CLI help, config docs, and integrity-check comments) is the best low-risk improvement because it reaches users where the decisions are made. Consider a follow-up security/threat-model doc (and optionally runtime warnings) if misuse remains common or high-impact.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Documentation</strong> (6)</summary>

<blockquote>
<details>
<summary><strong>store-discl.md</strong> <code>Add changeset noting store trust-boundary clarification</code> <code>+7/-0</code></summary>

<br/>

>Add changeset noting store trust-boundary clarification
>
><pre>
>• Introduces a patch changeset for the affected packages. Summarizes the updated guidance: shared store is trusted state and integrity checks are for corruption detection, not protection against malicious writers.
></pre>
>
><a href='https://github.com/pnpm/pnpm/pull/12268/files#diff-05f1bbced8734008b480df3b8b0ee70195093166aafa9e37720d749ae89b6722'>.changeset/store-discl.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>index.ts</strong> <code>Clarify --store-dir help as trusted shared state</code> <code>+1/-1</code></summary>

<br/>

>Clarify --store-dir help as trusted shared state
>
><pre>
>• Updates the &#x27;--store-dir&#x27; option description to warn that a shared store should only be used among trusted users and jobs. Makes the trust boundary explicit in CLI help output.
></pre>
>
><a href='https://github.com/pnpm/pnpm/pull/12268/files#diff-22044afff21c741a1952844423af001441a7fd22a5b4d372f3b1daade27a3b5a'>cli/common-cli-options-help/src/index.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>install.ts</strong> <code>Clarify --[no-]verify-store-integrity help semantics</code> <code>+1/-1</code></summary>

<br/>

>Clarify --[no-]verify-store-integrity help semantics
>
><pre>
>• Expands the option description to state that integrity checks detect accidental corruption rather than tampering by untrusted store writers. Clarifies what security guarantees users should not assume.
></pre>
>
><a href='https://github.com/pnpm/pnpm/pull/12268/files#diff-0259ff02d6afc89aa607b0eb6f7d76a79328cffdc46428e9101546f105fab53f'>installing/commands/src/install.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>lib.rs</strong> <code>Mirror store/cache trust-boundary guidance in config docs</code> <code>+8/-1</code></summary>

<br/>

>Mirror store/cache trust-boundary guidance in config docs
>
><pre>
>• Updates Rust doc comments for &#x27;store_dir&#x27; to recommend sharing writable stores only among mutually trusted users/jobs/processes. Adds similar trust notes for integrity verification and for &#x27;cache_dir&#x27; sharing expectations.
></pre>
>
><a href='https://github.com/pnpm/pnpm/pull/12268/files#diff-7fea9940cc266d951c41a5aeb8e96913af8dc080384cd1eeadee8982db2ed0a2'>pacquet/crates/config/src/lib.rs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>check_pkg_files_integrity.rs</strong> <code>Document integrity verification trust boundary in store-dir crate</code> <code>+4/-0</code></summary>

<br/>

>Document integrity verification trust boundary in store-dir crate
>
><pre>
>• Adds a clear doc comment stating integrity verification is corruption detection for trusted local stores. Explicitly notes it is not a tamper boundary when untrusted users/jobs can write to the store.
></pre>
>
><a href='https://github.com/pnpm/pnpm/pull/12268/files#diff-9e364d7d8c1c6a2e8373256643bba61823259dd33655e5b74aa1b4bbfc488a97'>pacquet/crates/store-dir/src/check_pkg_files_integrity.rs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>checkPkgFilesIntegrity.ts</strong> <code>Clarify CAFS fast-path assumptions for trusted stores</code> <code>+3/-2</code></summary>

<br/>

>Clarify CAFS fast-path assumptions for trusted stores
>
><pre>
>• Rewords the fast-path comment to explain skipping digest reads relies on trusted-store assumptions. Explicitly distinguishes corruption detection from protection against malicious store writers.
></pre>
>
><a href='https://github.com/pnpm/pnpm/pull/12268/files#diff-ec19433e5df26db9621d2526a538932427ee0016692dc4ef59ebc3816da0c329'>store/cafs/src/checkPkgFilesIntegrity.ts</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that store integrity checks detect accidental corruption in the store rather than tampering by untrusted users or processes.
  * Added guidance that shared package stores should only be used with mutually trusted users, jobs, and processes.
  * Updated help text for store configuration options and related command flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->