### PR TITLE
docs: document threat model and trust boundaries in security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,3 +13,43 @@
 Submit your findings here: https://github.com/pnpm/pnpm/security/advisories
 
 **We do not operate a bounty program.**
+
+## Threat Model and Scope
+
+pnpm's security boundary is **filesystem permissions**. We assume that the store
+directory, the project directory, `node_modules`, the lockfile, and pnpm's
+configuration files are only writable by parties the user already trusts. A
+report that assumes an attacker who already has write access to any of these
+locations is **out of scope** — at that point the trust boundary has already
+been crossed and the attacker can achieve code execution regardless of pnpm's
+behavior.
+
+In particular:
+
+- **The content-addressable store is not a security boundary against a
+  write-capable local adversary.** The integrity hashes recorded for each file
+  live inside the store itself (e.g. `<storeDir>/v3/files/index.db`), in the same
+  trust domain as the files they describe. Anyone who can modify a file in the
+  store can also modify its recorded hash. Integrity verification therefore
+  exists to detect **accidental corruption** (interrupted writes, bit-rot,
+  partially fetched tarballs), not to defend against tampering by someone who can
+  already write to the store. Optimizations such as the `mtime` fast path do not
+  weaken this guarantee, because the guarantee was never tampering resistance.
+
+- **The store must not be shared among mutually-untrusting users.** A store
+  writable by an untrusted party is equivalent to letting that party write
+  arbitrary code into your `node_modules`. If you share a store across users or
+  CI jobs, restrict write access to trusted identities via filesystem
+  permissions.
+
+The following are examples of reports we consider **out of scope**:
+
+- Tampering with store, lockfile, `node_modules`, or config files that the
+  attacker can already write to.
+- Bypassing store integrity checks given pre-existing write access to the store.
+- Attacks that require the user to run pnpm with a maliciously crafted local
+  project or environment that they did not obtain from a trusted source.
+
+If you believe a report falls outside these assumptions — for example, a way to
+bypass a trust boundary that pnpm *does* enforce — please include the exact
+privilege the attacker starts with and how pnpm escalates it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,13 @@ Submit your findings here: https://github.com/pnpm/pnpm/security/advisories
 
 **We do not operate a bounty program.**
 
+### pacquet and pnpr
+
+The Rust port (`pacquet/`) and the resolver server (`pnpr/`) are **not
+production ready** and are under active development. Do not report security
+issues in them through the security advisory process — open a
+[regular issue](https://github.com/pnpm/pnpm/issues) in this repository instead.
+
 ## Threat Model and Scope
 
 pnpm's security boundary is **filesystem permissions**. We assume that the store


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Document threat model and trust boundaries in SECURITY.md
<code>📝 Documentation</code> <code>🕐 Less than 10 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## What

Adds a **Threat Model and Scope** section to `SECURITY.md`.

## Why

We periodically receive reports premised on an attacker who *already* has write access to the store directory (or the lockfile, `node_modules`, or config files) — most recently a report claiming the CAFS `mtime` fast path lets such an attacker bypass integrity verification. These are not vulnerabilities: once a party can write to those locations, the trust boundary has already been crossed and they can achieve code execution regardless of any hash check. The integrity hashes themselves live inside the store (`index.db`), in the same trust domain as the files they describe, so always hashing would not prevent the attack either — the check is corruption detection, not tamper resistance.

This section makes the trust boundary (filesystem permissions) explicit so such reports can be closed by pointing at policy rather than re-arguing each time.

## Contents

- States that pnpm's security boundary is filesystem permissions.
- Explains why the content-addressable store is not a tamper boundary against a write-capable local adversary.
- Notes the store must not be shared among mutually-untrusting users.
- Lists concrete out-of-scope examples and asks in-scope reports to state the starting privilege and escalation.

---
Written by an agent (Claude Code, claude-opus-4-8).

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add a Threat Model and Scope section defining pnpm’s filesystem trust boundary.
• Clarify that store integrity checks detect corruption, not tamper resistance.
• Route pacquet/pnpr security reports to regular GitHub issues.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  R["Security reporter"] --> P["SECURITY.md policy"] --> S{{"In scope?"}}
  S -->|"No: attacker already writes"| O["Out of scope"]
  S -->|"Yes: boundary bypass"| A["Security advisory"]
  P --> X["pacquet/pnpr reports"] --> I["Regular issues"]

  subgraph Legend
    direction LR
    _doc["Policy doc"] ~~~ _dec{{"Decision"}} ~~~ _proc["Process endpoint"]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Separate threat model document (e.g., docs/security/threat-model.md)</b></summary>

- ➕ Allows more detail (examples, diagrams, FAQs) without bloating SECURITY.md
- ➕ Easier to evolve over time with versioned rationale and references
- ➖ Reporters may not read it unless SECURITY.md prominently links to it
- ➖ Splits policy across files, increasing the chance of inconsistent guidance

</details>

<details>
<summary><b>2. Add an FAQ section focused on common out-of-scope reports</b></summary>

- ➕ Directly targets recurring misunderstandings with quick answers
- ➕ Can reduce back-and-forth by giving copy-pastable responses
- ➖ Still needs an explicit threat model to avoid subjective judgments
- ➖ FAQs can become long and harder to maintain

</details>

**Recommendation:** Keeping the threat model and trust-boundary clarification inside SECURITY.md is the right primary approach because it’s the first document reporters are directed to. Consider adding a short link to a longer-form threat model doc only if the section grows significantly or if repeated edge cases warrant expanded guidance.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Documentation</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>SECURITY.md</strong> <code>Define threat model, trust boundary, and reporting scope</code> <code>+47/-0</code></summary>

<br/>

>Define threat model, trust boundary, and reporting scope
>
><pre>
>• Adds a Threat Model and Scope section that makes filesystem permissions the explicit security boundary and marks reports assuming pre-existing write access as out of scope. Clarifies that the content-addressable store integrity mechanism is for corruption detection (not tamper resistance) and warns against sharing the store among untrusted users. Also routes pacquet/pnpr security reports to regular GitHub issues instead of advisories.
></pre>
>
><a href='https://github.com/pnpm/pnpm/pull/12269/files#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7'>SECURITY.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>