### PR TITLE
fix(deps-resolver): align pacquet peer parent contexts

### DIFF
--- a/.github/workflows/pacquet-codecov.yml
+++ b/.github/workflows/pacquet-codecov.yml
@@ -105,7 +105,7 @@ jobs:
           name: codecov
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/pacquet/crates/cli/tests/install.rs
+++ b/pacquet/crates/cli/tests/install.rs
@@ -413,6 +413,93 @@ fn peer_shared_through_a_diamond_is_resolved_consistently() {
     drop((root, mock_instance)); // cleanup
 }
 
+#[test]
+fn peer_dependencies_resolve_from_aliased_subdependencies() {
+    let lockfile = install_with_peer_alias_deps(serde_json::json!({
+        "@pnpm.e2e/abc-parent-with-aliases": "1.0.0",
+    }));
+
+    assert!(
+        lockfile.contains("@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.1)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.1)"),
+        "aliased subdependencies should satisfy abc's peers; lockfile:\n{lockfile}",
+    );
+}
+
+#[test]
+fn peer_dependency_resolves_from_aliased_direct_dependency() {
+    let lockfile = install_with_peer_alias_deps(serde_json::json!({
+        "peer-a": "npm:@pnpm.e2e/peer-a@1.0.0",
+        "@pnpm.e2e/abc": "1.0.0",
+    }));
+
+    assert!(
+        lockfile.contains("@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.0)"),
+        "aliased direct dependency should satisfy abc's peer-a; lockfile:\n{lockfile}",
+    );
+}
+
+#[test]
+fn peer_dependency_resolves_from_alias_that_differs_from_real_name() {
+    let lockfile = install_with_peer_alias_deps(serde_json::json!({
+        "@pnpm.e2e/peer-b": "npm:@pnpm.e2e/peer-a@1.0.0",
+        "@pnpm.e2e/abc": "1.0.0",
+    }));
+
+    assert!(
+        lockfile.contains("@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.0)(@pnpm.e2e/peer-a@1.0.0)"),
+        "abc's snapshot key should keep both peer-a contributions; lockfile:\n{lockfile}",
+    );
+    assert!(
+        lockfile.contains("'@pnpm.e2e/peer-a': 1.0.0"),
+        "real peer name should be linked in abc's snapshot dependencies; lockfile:\n{lockfile}",
+    );
+    assert!(
+        lockfile.contains("'@pnpm.e2e/peer-b': '@pnpm.e2e/peer-a@1.0.0'"),
+        "alias peer name should also be linked to the aliased provider; lockfile:\n{lockfile}",
+    );
+}
+
+#[test]
+fn peer_dependency_prefers_highest_version_among_aliases_of_same_package() {
+    let lockfile = install_with_peer_alias_deps(serde_json::json!({
+        "peer-c3": "npm:@pnpm.e2e/peer-c@1.0.0",
+        "peer-c2": "npm:@pnpm.e2e/peer-c@1.0.1",
+        "peer-c1": "npm:@pnpm.e2e/peer-c@2.0.0",
+        "@pnpm.e2e/abc": "1.0.0",
+    }));
+
+    assert!(
+        lockfile.contains("@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-c@2.0.0)"),
+        "highest aliased peer-c version should satisfy abc's peer-c; lockfile:\n{lockfile}",
+    );
+}
+
+#[test]
+fn peer_dependency_prefers_non_aliased_provider_over_alias() {
+    let lockfile = install_with_peer_alias_deps(serde_json::json!({
+        "@pnpm.e2e/peer-c": "1.0.0",
+        "peer-c": "npm:@pnpm.e2e/peer-c@2.0.0",
+        "@pnpm.e2e/abc": "1.0.0",
+    }));
+
+    assert!(
+        lockfile.contains("@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-c@1.0.0)"),
+        "non-aliased peer-c should win over the aliased provider; lockfile:\n{lockfile}",
+    );
+}
+
+#[test]
+fn peer_dependency_prefers_highest_aliased_subdependency_version() {
+    let lockfile = install_with_peer_alias_deps(serde_json::json!({
+        "@pnpm.e2e/abc-parent-with-aliases-of-same-pkg": "1.0.0",
+    }));
+
+    assert!(
+        lockfile.contains("@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-c@2.0.0)"),
+        "highest aliased peer-c subdependency should satisfy abc's peer-c; lockfile:\n{lockfile}",
+    );
+}
+
 /// `catalog:` on a direct dep should be dereferenced through
 /// `pnpm-workspace.yaml`'s `catalog` section before the npm resolver
 /// sees it. The fetched virtual-store entry is the catalog's resolved
@@ -837,6 +924,35 @@ fn compatible_existing_peer_contexts_survive_writable_lockfile_regeneration() {
     );
 
     drop((root, mock_instance)); // cleanup
+}
+
+fn install_with_peer_alias_deps(dependencies: serde_json::Value) -> String {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("autoInstallPeers: false\n");
+    workspace_yaml.push_str("strictPeerDependencies: false\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": dependencies }).to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_arg("install").assert().success();
+    let lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+
+    drop((root, mock_instance));
+    lockfile
 }
 
 /// A fresh `pacquet` command rooted at `workspace`, for tests that run the

--- a/pacquet/crates/cli/tests/install.rs
+++ b/pacquet/crates/cli/tests/install.rs
@@ -939,6 +939,7 @@ fn install_with_peer_alias_deps(dependencies: serde_json::Value) -> String {
     }
     workspace_yaml.push_str("autoInstallPeers: false\n");
     workspace_yaml.push_str("strictPeerDependencies: false\n");
+    workspace_yaml.push_str("peersSuffixMaxLength: 1000\n");
     fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
 
     fs::write(

--- a/pacquet/crates/cli/tests/install.rs
+++ b/pacquet/crates/cli/tests/install.rs
@@ -374,9 +374,9 @@ fn auto_install_peers_hoists_missing_peers_at_importer() {
 ///
 /// This is the scenario behind the pnpm regression in
 /// [pnpm/pnpm#12079](https://github.com/pnpm/pnpm/issues/12079). pacquet
-/// resolves it consistently — `bump_occurrence_on_shadow` always prefers
-/// the node's own child over an inherited same-version instance, so it
-/// never reuses the root-level `ts@2.0.0` parser for the nested plugin.
+/// resolves it consistently by switching from the inherited same-version
+/// parser to the node's own child when that inherited parser carries a
+/// conflicting peer context.
 /// Mirrors the upstream coverage in
 /// [`installing/deps-installer/test/install/peerDependencies.ts`](https://github.com/pnpm/pnpm/blob/762e80be49/installing/deps-installer/test/install/peerDependencies.ts).
 #[test]

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -1485,7 +1485,9 @@ impl<'tree> Walker<'tree> {
                 .get(parent_node_id)
                 .is_some_and(|node| node.resolved_package_id == current_pkg_id);
             if same_pkg {
-                children.extend(self.realize_children(parent_node_id));
+                for (alias, child_node_id) in self.realize_children(parent_node_id) {
+                    children.entry(alias).or_insert(child_node_id);
+                }
             }
         }
         children

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -731,13 +731,17 @@ impl<'tree> Walker<'tree> {
         let mut child_parent_refs = parent_parent_refs.clone();
         let mut new_parent_refs = ParentRefs::new();
         for (alias, child_node_id) in &children_map {
-            if !self.tree.all_peer_dep_names.contains(alias) {
-                continue;
-            }
+            let alias_is_peer_relevant = self.tree.all_peer_dep_names.contains(alias);
             let Some(child_tree) = self.tree.dependencies_tree.get(child_node_id) else { continue };
             let Some(child_pkg) = self.tree.packages.get(&child_tree.resolved_package_id) else {
                 continue;
             };
+            if !alias_is_peer_relevant {
+                let (child_name, _) = pkg_name_version(&child_pkg.result);
+                if !self.tree.all_peer_dep_names.contains(&child_name) {
+                    continue;
+                }
+            }
             insert_parent_ref(
                 &mut new_parent_refs,
                 alias,

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -259,8 +259,22 @@ pub fn resolve_peers_workspace(
         walker.opts.modules_dir = importer.modules_dir.clone();
         let importer_parents = walker.build_importer_parents_from(&importer.direct);
         let parent_chain_names: Vec<String> = Vec::new();
+        let parent_node_ids: Vec<NodeId> = Vec::new();
+        let parent_pkg_ids_chain: Vec<String> = Vec::new();
+        let importer_parent_dep_paths = walker.parent_dep_paths_from_refs(&importer_parents);
         for dep in &importer.direct {
-            walker.resolve_node(dep.node_id.clone(), &importer_parents, &parent_chain_names, 0);
+            walker
+                .parent_pkgs_of_node
+                .insert(dep.node_id.clone(), importer_parent_dep_paths.clone());
+        }
+        for dep in &importer.direct {
+            walker.resolve_node(
+                dep.node_id.clone(),
+                &importer_parents,
+                &parent_chain_names,
+                &parent_node_ids,
+                &parent_pkg_ids_chain,
+            );
         }
         let issues = std::mem::take(&mut walker.issues);
         if !issues.bad.is_empty() || !issues.missing.is_empty() {
@@ -320,11 +334,6 @@ struct ParentRef {
     node_id: Option<NodeId>,
     /// Local install name in `node_modules`. May differ from the
     /// package's real name for npm-alias entries.
-    ///
-    /// Recorded for upstream parity but not read in this slice.
-    /// Reserved for the npm-alias cache-validation path
-    /// (pnpm/pnpm#11907).
-    #[allow(dead_code, reason = "future npm-alias cache validation")]
     alias: Option<String>,
     /// Depth at which this parent was added. Threaded into
     /// [`ParentPkgInfo`] so [`Walker::parent_packages_match`] can
@@ -369,14 +378,14 @@ struct Walker<'tree> {
     /// is a cycle — the recursion bottoms out with a `name@version`
     /// peer-id and the original visit drives the actual graph insert.
     in_progress: HashSet<NodeId>,
-    /// Peer edges whose target `NodeId` had no `DepPath` yet at the
+    /// Graph edges whose target `NodeId` had no `DepPath` yet at the
     /// time we built the parent's `graph_children` map — typically
-    /// because the peer is a later sibling direct dep that the walker
+    /// because the target is a later sibling direct dep that the walker
     /// hasn't reached yet. `walk()` drains this list once every direct
-    /// dep is walked and patches the recorded entries with the now-
-    /// known peer `DepPath`. Without this post-pass the install layer
+    /// dep is walked and patches the recorded entries with the now-known
+    /// `DepPath`. Without this post-pass the install layer
     /// would walk the parent's `children` map and find no symlink edge
-    /// for the peer, leaving the package without the peer in its slot.
+    /// for the child, leaving the package without it in its slot.
     pending_peer_edges: Vec<PendingPeerEdge>,
     /// Set of `pkgIdWithPatchHash` values whose full subtree resolved
     /// with zero external peers and zero missing peers. A revisit of
@@ -450,13 +459,13 @@ struct PeersCacheItem {
     missing_peers: HashMap<String, MissingPeerInfo>,
 }
 
-/// One `parent → peer` edge whose peer target wasn't walked yet at the
+/// One `parent → child` edge whose target wasn't walked yet at the
 /// time the parent's `graph_children` was built. Patched up by
 /// [`Walker::patch_pending_peer_edges`] after the main walk completes.
 struct PendingPeerEdge {
     parent_dep_path: DepPath,
-    peer_alias: String,
-    peer_node_id: NodeId,
+    child_alias: String,
+    child_node_id: NodeId,
 }
 
 /// Per-`NodeId` data captured during the walk so the post-walk
@@ -512,14 +521,26 @@ impl<'tree> Walker<'tree> {
     fn walk(mut self) -> ResolvePeersResult {
         let importer_parents = self.build_importer_parents();
         let parent_chain_names: Vec<String> = Vec::new();
+        let parent_node_ids: Vec<NodeId> = Vec::new();
+        let parent_pkg_ids_chain: Vec<String> = Vec::new();
         let mut direct_by_alias = BTreeMap::new();
         // Clone direct deps into an owned `Vec` so the recursion
         // below can mutate `self.tree` (realising lazy children)
         // without conflicting with this loop's borrow of
         // `self.tree.direct`.
         let direct: Vec<DirectDep> = self.tree.direct.clone();
+        let importer_parent_dep_paths = self.parent_dep_paths_from_refs(&importer_parents);
         for dep in &direct {
-            self.resolve_node(dep.node_id.clone(), &importer_parents, &parent_chain_names, 0);
+            self.parent_pkgs_of_node.insert(dep.node_id.clone(), importer_parent_dep_paths.clone());
+        }
+        for dep in &direct {
+            self.resolve_node(
+                dep.node_id.clone(),
+                &importer_parents,
+                &parent_chain_names,
+                &parent_node_ids,
+                &parent_pkg_ids_chain,
+            );
         }
         self.patch_pending_peer_edges();
         // Recompute depPaths so each resolved peer carries its full
@@ -549,7 +570,7 @@ impl<'tree> Walker<'tree> {
     /// surfaced via [`PeerDependencyIssues::missing`].
     fn patch_pending_peer_edges(&mut self) {
         for edge in std::mem::take(&mut self.pending_peer_edges) {
-            let Some(peer_dep_path) = self.node_dep_paths.get(&edge.peer_node_id).cloned() else {
+            let Some(child_dep_path) = self.node_dep_paths.get(&edge.child_node_id).cloned() else {
                 continue;
             };
             if let Some(node) = self.graph.get_mut(&edge.parent_dep_path) {
@@ -557,7 +578,7 @@ impl<'tree> Walker<'tree> {
                 // if a later walk of the same `dep_path` already
                 // populated the edge (e.g. via the cycle path), we
                 // don't want to overwrite a more specific entry.
-                node.children.entry(edge.peer_alias).or_insert(peer_dep_path);
+                node.children.entry(edge.child_alias).or_insert(child_dep_path);
             }
         }
     }
@@ -594,21 +615,18 @@ impl<'tree> Walker<'tree> {
             };
             let parent_node_id = remap_link_node_id(&self.opts, &direct.alias, &pkg.result)
                 .unwrap_or_else(|| direct.node_id.clone());
-            insert_parent_ref(&mut refs, &direct.alias, parent_node_id, pkg, self.tree);
+            insert_parent_ref(&mut refs, &direct.alias, parent_node_id, pkg, tree_node.depth);
         }
         refs
     }
 
-    #[allow(
-        clippy::only_used_in_recursion,
-        reason = "`depth` is kept for upstream parity with `currentDepth`"
-    )]
     fn resolve_node(
         &mut self,
         node_id: NodeId,
         parent_parent_refs: &ParentRefs,
         parent_chain_names: &[String],
-        depth: i32,
+        parent_node_ids: &[NodeId],
+        parent_pkg_ids_chain: &[String],
     ) -> NodeOutput {
         // `purePkgs` fast-path. When the subtree below this
         // `pkgIdWithPatchHash` resolved with zero external peers and
@@ -646,8 +664,12 @@ impl<'tree> Walker<'tree> {
             }
             let pkg_peer_dependencies_empty =
                 self.tree.packages[&pkg_id].peer_dependencies.is_empty();
-            if self.pure_pkgs.contains(&pkg_id) && pkg_peer_dependencies_empty {
-                let dep_path = DepPath::from(pkg_id);
+            let bare_dep_path = DepPath::from(pkg_id.clone());
+            if self.pure_pkgs.contains(&pkg_id)
+                && pkg_peer_dependencies_empty
+                && self.graph.get(&bare_dep_path).is_some_and(|node| node.depth <= tree_node_depth)
+            {
+                let dep_path = bare_dep_path;
                 self.node_dep_paths.insert(node_id.clone(), dep_path.clone());
                 // Lower the existing graph entry's `depth` if this
                 // occurrence reached the package shallower than the
@@ -697,42 +719,50 @@ impl<'tree> Walker<'tree> {
         let pkg = self.tree.packages[&tree_node.resolved_package_id].clone();
         let (pkg_name, _pkg_version) = pkg_name_version(&pkg.result);
 
+        let mut current_parent_node_ids = parent_node_ids.to_vec();
+        current_parent_node_ids.push(node_id.clone());
+        let mut child_parent_pkg_ids_chain = parent_pkg_ids_chain.to_vec();
+        if !child_parent_pkg_ids_chain.contains(&pkg.id) {
+            child_parent_pkg_ids_chain.push(pkg.id.clone());
+        }
+
         // Build the ParentRefs map that descendants of this node see:
-        // parent's view + this node's own children, restricted to
-        // names that are declared as peers somewhere in the install.
-        // The `occurrence` counter follows upstream's shadowing rule:
-        // adding a same-name parent whose `(pkg_id, version)` doesn't
-        // match the existing entry bumps `occurrence` and replaces
-        // the entry. `parentPackagesMatch` keys off the counter to
-        // reject cache hits when shadowing differs.
+        // parent's view + this node's own peer-relevant children.
         let mut child_parent_refs = parent_parent_refs.clone();
-        let child_depth = depth + 1;
+        let mut new_parent_refs = ParentRefs::new();
         for (alias, child_node_id) in &children_map {
+            if !self.tree.all_peer_dep_names.contains(alias) {
+                continue;
+            }
             let Some(child_tree) = self.tree.dependencies_tree.get(child_node_id) else { continue };
             let Some(child_pkg) = self.tree.packages.get(&child_tree.resolved_package_id) else {
                 continue;
             };
-            let (child_real_name, child_version) = pkg_name_version(&child_pkg.result);
-            // Only peer-relevant aliases need to land in `parentRefs`.
-            // Pnpm filters with `allPeerDepNames` to keep the propagated
-            // map small.
-            let alias_relevant = self.tree.all_peer_dep_names.contains(alias);
-            let real_relevant = self.tree.all_peer_dep_names.contains(&child_real_name);
-            if !alias_relevant && !real_relevant {
-                continue;
-            }
-            let parent_ref = ParentRef {
-                version: child_version,
-                node_id: Some(child_node_id.clone()),
-                alias: (alias != &child_real_name).then(|| alias.clone()),
-                depth: child_depth,
-                occurrence: 0,
-            };
-            if alias_relevant {
-                bump_occurrence_on_shadow(&mut child_parent_refs, alias, &parent_ref);
-            }
-            if real_relevant && alias != &child_real_name {
-                bump_occurrence_on_shadow(&mut child_parent_refs, &child_real_name, &parent_ref);
+            insert_parent_ref(
+                &mut new_parent_refs,
+                alias,
+                child_node_id.clone(),
+                child_pkg,
+                child_tree.depth,
+            );
+        }
+        let mut child_parent_refs_with_new = child_parent_refs.clone();
+        child_parent_refs_with_new.extend(new_parent_refs.clone());
+        for (name, mut new_parent_ref) in new_parent_refs {
+            if let Some(existing) = child_parent_refs.get(&name) {
+                if !self.parent_refs_match(existing, &new_parent_ref)
+                    || self.inherited_parent_pkg_breaks_peer_diamond(
+                        &child_parent_refs_with_new,
+                        existing,
+                        &new_parent_ref,
+                        &children_map,
+                    )
+                {
+                    new_parent_ref.occurrence = existing.occurrence + 1;
+                    child_parent_refs.insert(name, new_parent_ref);
+                }
+            } else {
+                child_parent_refs.insert(name, new_parent_ref);
             }
         }
 
@@ -810,19 +840,12 @@ impl<'tree> Walker<'tree> {
                 child_node_id.clone(),
                 &child_parent_refs,
                 &child_chain_names,
-                depth + 1,
+                &current_parent_node_ids,
+                &child_parent_pkg_ids_chain,
             );
             child_dep_paths.insert(alias.clone(), child_output.dep_path);
             for (peer_alias, peer_node_id) in child_output.external_resolved_peers {
-                if children_map.values().any(|id| id == &peer_node_id) {
-                    // Resolved against one of *this node's* children —
-                    // not external from this node's perspective.
-                    // Compare by NodeId (not alias) because `children`
-                    // is keyed by install alias while `peer_alias` can
-                    // be the resolved package's real name (the
-                    // [`ParentRefs`] map indexes parents under both
-                    // alias and real name when they differ). An
-                    // alias-only check misses npm-aliased children.
+                if children_map.contains_key(&peer_alias) {
                     continue;
                 }
                 external_from_children.insert(peer_alias, peer_node_id);
@@ -832,10 +855,8 @@ impl<'tree> Walker<'tree> {
             }
         }
 
-        // Resolve this node's own peer requirements against the
-        // ParentRefs visible at this node — that is, the ones its
-        // parent passed in, *not* the augmented child view (a node
-        // does not satisfy its own peers from its own children).
+        // Resolve this node's own peer requirements against the augmented
+        // ParentRefs visible at this node, including peer-relevant children.
         let mut own_resolved_peers: HashMap<String, NodeId> = HashMap::new();
         let mut own_missing_peers: HashMap<String, MissingPeerInfo> = HashMap::new();
         for (peer_name, peer_dep) in &pkg.peer_dependencies {
@@ -843,7 +864,7 @@ impl<'tree> Walker<'tree> {
                 &pkg_name,
                 peer_name,
                 peer_dep,
-                parent_parent_refs,
+                &child_parent_refs,
                 &child_chain_names,
                 &mut own_resolved_peers,
                 &mut own_missing_peers,
@@ -899,26 +920,22 @@ impl<'tree> Walker<'tree> {
         // install layer drives off `graph_children`, so skipping the
         // edge entirely would leave the peer un-symlinked in the
         // parent's slot.
-        let mut graph_children = child_dep_paths.clone();
+        let mut graph_children = BTreeMap::new();
+        for (alias, child_node_id) in
+            self.previously_resolved_children(parent_node_ids, parent_pkg_ids_chain, &pkg.id)
+        {
+            self.add_graph_child_or_pending(&mut graph_children, &dep_path, alias, child_node_id);
+        }
+        for (alias, child_dep_path) in child_dep_paths {
+            graph_children.insert(alias, child_dep_path);
+        }
         for (peer_alias, peer_node_id) in &all_resolved_peers {
-            if let Some(peer_dep_path) = self.node_dep_paths.get(peer_node_id) {
-                graph_children.insert(peer_alias.clone(), peer_dep_path.clone());
-            } else if let Some(link_dep_path) = link_node_id_as_dep_path(peer_node_id) {
-                // Mirrors upstream's
-                // [`pathsByNodeId.get(childNodeId) ?? (childNodeId as unknown as DepPath)`](https://github.com/pnpm/pnpm/blob/094aa6e57b/installing/deps-resolver/src/resolvePeers.ts#L164)
-                // fallback in `resolveChildren`. `topParents` linked-dep
-                // NodeIds never enter the tree, so `node_dep_paths` is
-                // empty for them; the `link:<rel>` NodeId is itself a
-                // valid DepPath, so the snapshot's child edge can use
-                // it verbatim.
-                graph_children.insert(peer_alias.clone(), link_dep_path);
-            } else {
-                self.pending_peer_edges.push(PendingPeerEdge {
-                    parent_dep_path: dep_path.clone(),
-                    peer_alias: peer_alias.clone(),
-                    peer_node_id: peer_node_id.clone(),
-                });
-            }
+            self.add_graph_child_or_pending(
+                &mut graph_children,
+                &dep_path,
+                peer_alias.clone(),
+                peer_node_id.clone(),
+            );
         }
 
         // Compute transitive peer set: peers visible in this subtree
@@ -948,7 +965,9 @@ impl<'tree> Walker<'tree> {
         // is symlinked at the descendant that declares it, so it must
         // not appear in this node's dependencies. Carries NodeIds so the
         // rebuild can resolve each to its corrected final depPath.
-        let mut record_edges: BTreeMap<String, NodeId> = children_map.clone();
+        let mut record_edges =
+            self.previously_resolved_children(parent_node_ids, parent_pkg_ids_chain, &pkg.id);
+        record_edges.extend(children_map.clone());
         for (peer_alias, peer_node_id) in &own_resolved_peers {
             record_edges.insert(peer_alias.clone(), peer_node_id.clone());
         }
@@ -1007,17 +1026,9 @@ impl<'tree> Walker<'tree> {
 
         self.in_progress.remove(&node_id);
 
-        // External resolved peers reported up: this node's collected
-        // peers minus any that map to this node's own children
-        // (already covered by the children's depPaths). Filter by
-        // NodeId rather than alias for the same reason as the
-        // `external_from_children` filter above — `children` is keyed
-        // by install alias while peers may be keyed by the resolved
-        // package's real name.
-        let own_child_ids: HashSet<&NodeId> = children_map.values().collect();
         let external_to_report: HashMap<String, NodeId> = all_resolved_peers
             .into_iter()
-            .filter(|(_, peer_node_id)| !own_child_ids.contains(peer_node_id))
+            .filter(|(peer_alias, _)| !children_map.contains_key(peer_alias))
             .collect();
 
         NodeOutput {
@@ -1457,6 +1468,156 @@ impl<'tree> Walker<'tree> {
         realized
     }
 
+    fn previously_resolved_children(
+        &mut self,
+        parent_node_ids: &[NodeId],
+        parent_pkg_ids_chain: &[String],
+        current_pkg_id: &str,
+    ) -> BTreeMap<String, NodeId> {
+        let mut children = BTreeMap::new();
+        if !parent_pkg_ids_chain.iter().any(|pkg_id| pkg_id == current_pkg_id) {
+            return children;
+        }
+        for parent_node_id in parent_node_ids.iter().rev() {
+            let same_pkg = self
+                .tree
+                .dependencies_tree
+                .get(parent_node_id)
+                .is_some_and(|node| node.resolved_package_id == current_pkg_id);
+            if same_pkg {
+                children.extend(self.realize_children(parent_node_id));
+            }
+        }
+        children
+    }
+
+    fn add_graph_child_or_pending(
+        &mut self,
+        graph_children: &mut BTreeMap<String, DepPath>,
+        parent_dep_path: &DepPath,
+        alias: String,
+        node_id: NodeId,
+    ) {
+        if let Some(dep_path) = self.node_dep_paths.get(&node_id) {
+            graph_children.insert(alias, dep_path.clone());
+        } else if let Some(link_dep_path) = link_node_id_as_dep_path(&node_id) {
+            // Mirrors upstream's
+            // [`pathsByNodeId.get(childNodeId) ?? (childNodeId as unknown as DepPath)`](https://github.com/pnpm/pnpm/blob/094aa6e57b/installing/deps-resolver/src/resolvePeers.ts#L164)
+            // fallback in `resolveChildren`. `topParents` linked-dep
+            // NodeIds never enter the tree, so `node_dep_paths` is
+            // empty for them; the `link:<rel>` NodeId is itself a
+            // valid DepPath, so the snapshot's child edge can use
+            // it verbatim.
+            graph_children.insert(alias, link_dep_path);
+        } else {
+            self.pending_peer_edges.push(PendingPeerEdge {
+                parent_dep_path: parent_dep_path.clone(),
+                child_alias: alias,
+                child_node_id: node_id,
+            });
+        }
+    }
+
+    fn parent_refs_match(&self, current: &ParentRef, new: &ParentRef) -> bool {
+        if current.version != new.version || current.alias != new.alias {
+            return false;
+        }
+        let Some(current_name) = self.parent_ref_package_name(current) else {
+            return true;
+        };
+        let Some(new_name) = self.parent_ref_package_name(new) else {
+            return true;
+        };
+        current_name == new_name
+    }
+
+    fn parent_ref_package_name(&self, parent_ref: &ParentRef) -> Option<String> {
+        let node_id = parent_ref.node_id.as_ref()?;
+        let tree_node = self.tree.dependencies_tree.get(node_id)?;
+        let pkg = self.tree.packages.get(&tree_node.resolved_package_id)?;
+        Some(pkg_name_version(&pkg.result).0)
+    }
+
+    fn inherited_parent_pkg_breaks_peer_diamond(
+        &self,
+        parent_refs: &ParentRefs,
+        inherited_parent_pkg: &ParentRef,
+        own_child_parent_pkg: &ParentRef,
+        children: &BTreeMap<String, NodeId>,
+    ) -> bool {
+        let (Some(inherited_node_id), Some(own_child_node_id)) =
+            (inherited_parent_pkg.node_id.as_ref(), own_child_parent_pkg.node_id.as_ref())
+        else {
+            return false;
+        };
+        if inherited_node_id == own_child_node_id {
+            return false;
+        }
+        let Some(inherited_context) = self.parent_pkgs_of_node.get(inherited_node_id) else {
+            return false;
+        };
+        let Some(parent_pkg) = self
+            .tree
+            .dependencies_tree
+            .get(own_child_node_id)
+            .and_then(|node| self.tree.packages.get(&node.resolved_package_id))
+        else {
+            return false;
+        };
+        let (parent_pkg_name, _) = pkg_name_version(&parent_pkg.result);
+
+        let mut conflicting_peers = HashSet::new();
+        for peer_name in parent_pkg.peer_dependencies.keys() {
+            if !self.tree.all_peer_dep_names.contains(peer_name) {
+                continue;
+            }
+            let Some(inherited_peer) = inherited_context.get(peer_name) else { continue };
+            let Some(current_peer) = parent_refs.get(peer_name) else { continue };
+            if self.parent_peer_differs(current_peer, inherited_peer) {
+                conflicting_peers.insert(peer_name.clone());
+            }
+        }
+        if conflicting_peers.is_empty() {
+            return false;
+        }
+
+        for child_node_id in children.values() {
+            let Some(child_pkg) = self
+                .tree
+                .dependencies_tree
+                .get(child_node_id)
+                .and_then(|node| self.tree.packages.get(&node.resolved_package_id))
+            else {
+                continue;
+            };
+            if !child_pkg.peer_dependencies.contains_key(&parent_pkg_name) {
+                continue;
+            }
+            if conflicting_peers.iter().any(|peer| child_pkg.peer_dependencies.contains_key(peer)) {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn parent_peer_differs(
+        &self,
+        current_peer: &ParentRef,
+        inherited_peer: &ParentPkgInfo,
+    ) -> bool {
+        if let Some(inherited_pkg_id) = inherited_peer.pkg_id.as_ref() {
+            let Some(current_node_id) = current_peer.node_id.as_ref() else {
+                return true;
+            };
+            return self
+                .tree
+                .dependencies_tree
+                .get(current_node_id)
+                .is_none_or(|node| node.resolved_package_id != *inherited_pkg_id);
+        }
+        inherited_peer.version.as_ref() != Some(&current_peer.version)
+    }
+
     /// Build the `(peer_name → ParentPkgInfo)` snapshot that gets
     /// stored on [`Self::parent_pkgs_of_node`] for each child the
     /// caller is about to descend into. Mirrors upstream's
@@ -1480,11 +1641,12 @@ impl<'tree> Walker<'tree> {
                 .as_ref()
                 .and_then(|nid| self.tree.dependencies_tree.get(nid))
                 .map(|tn| tn.resolved_package_id.clone());
+            let version = pkg_id.is_none().then(|| parent_ref.version.clone());
             out.insert(
                 name.clone(),
                 ParentPkgInfo {
                     pkg_id,
-                    version: Some(parent_ref.version.clone()),
+                    version,
                     depth: parent_ref.depth,
                     occurrence: parent_ref.occurrence,
                 },
@@ -1501,7 +1663,9 @@ impl<'tree> Walker<'tree> {
     /// A cache item matches when, for every cached resolved peer:
     ///
     /// 1. The current `parent_refs` has a counterpart entry for the
-    ///    same name with a real `NodeId`.
+    ///    same name with a real `NodeId`, unless the package declares
+    ///    that cached peer as optional and the current context has no
+    ///    provider for it.
     /// 2. Either the two `NodeId`s are equal, OR they map to the
     ///    same already-computed [`DepPath`] in
     ///    [`Self::node_dep_paths`], OR the two tree-nodes' resolved
@@ -1517,8 +1681,15 @@ impl<'tree> Walker<'tree> {
         let cache_items = self.peers_cache.get(pkg_id)?;
         cache_items.iter().find(|item| {
             for (name, cached_node_id) in &item.resolved_peers {
-                let Some(current_ref) = parent_refs.get(name) else { return false };
-                let Some(current_node_id) = current_ref.node_id.as_ref() else { return false };
+                let Some(current_ref) = parent_refs.get(name) else {
+                    if self.peer_dependency_is_optional(pkg_id, name) {
+                        continue;
+                    }
+                    return false;
+                };
+                let Some(current_node_id) = current_ref.node_id.as_ref() else {
+                    return false;
+                };
                 if current_node_id == cached_node_id {
                     continue;
                 }
@@ -1562,6 +1733,14 @@ impl<'tree> Walker<'tree> {
         })
     }
 
+    fn peer_dependency_is_optional(&self, pkg_id: &str, peer_name: &str) -> bool {
+        self.tree
+            .packages
+            .get(pkg_id)
+            .and_then(|pkg| pkg.peer_dependencies.get(peer_name))
+            .is_some_and(|peer| peer.optional)
+    }
+
     /// Compare two `NodeId`s' recorded parent peer contexts. Mirrors
     /// upstream's
     /// [`parentPackagesMatch`](https://github.com/pnpm/pnpm/blob/c86c423bdc/installing/deps-resolver/src/resolvePeers.ts#L701-L731):
@@ -1587,11 +1766,9 @@ impl<'tree> Walker<'tree> {
             && parent_pkgs_have_single_occurrence(current_parents);
         for (name, cached_info) in cached_parents {
             let Some(current_info) = current_parents.get(name) else { return false };
-            // Version-only match: when both sides recorded a
-            // `version`, pure version equality is enough (covers
-            // `link:` parents whose nodeIds don't index into the
-            // dependencies tree).
-            if cached_info.version.is_some() && current_info.version.is_some() {
+            // Version-only match covers `link:` parents whose nodeIds
+            // don't index into the dependencies tree.
+            if cached_info.version.is_some() || current_info.version.is_some() {
                 if cached_info.version == current_info.version {
                     continue;
                 }
@@ -1620,10 +1797,10 @@ fn parent_pkgs_have_single_occurrence(parents: &HashMap<String, ParentPkgInfo>) 
     parents.values().all(|info| info.occurrence == 0)
 }
 
-/// Reproduce upstream's `Map<NodeId, ParentRef>` dual-keying: each
-/// parent is recorded by its install alias *and* its real name when
-/// the two differ. Mirrors
-/// [`updateParentRefs`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolvePeers.ts#L1035-L1044).
+/// Reproduce upstream's parent-ref dual-keying: each parent is recorded
+/// by its install alias *and* its real name when the two differ.
+/// Mirrors
+/// [`toPkgByName`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolvePeers.ts#L1015-L1033).
 ///
 /// `parent_node_id` is the [`NodeId`] the parent should appear under
 /// in the [`ParentRefs`] map. For most parents this is just
@@ -1635,26 +1812,40 @@ fn insert_parent_ref(
     direct_alias: &str,
     parent_node_id: NodeId,
     pkg: &ResolvedPackage,
-    tree: &ResolvedTree,
+    depth: i32,
 ) {
     let (real_name, version) = pkg_name_version(&pkg.result);
-    let alias_relevant = tree.all_peer_dep_names.contains(direct_alias);
-    let real_relevant = tree.all_peer_dep_names.contains(&real_name);
-    if !alias_relevant && !real_relevant {
-        return;
-    }
     let parent_ref = ParentRef {
         version,
         node_id: Some(parent_node_id),
         alias: (direct_alias != real_name).then(|| direct_alias.to_string()),
-        depth: 0,
+        depth,
         occurrence: 0,
     };
-    if alias_relevant {
-        refs.insert(direct_alias.to_string(), parent_ref.clone());
+    update_parent_refs(refs, direct_alias, &parent_ref);
+    if direct_alias != real_name {
+        update_parent_refs(refs, &real_name, &parent_ref);
     }
-    if real_relevant && direct_alias != real_name {
-        refs.insert(real_name, parent_ref);
+}
+
+fn update_parent_refs(refs: &mut ParentRefs, new_alias: &str, parent_ref: &ParentRef) {
+    if let Some(existing) = refs.get(new_alias) {
+        let existing_has_alias = existing.alias.as_deref().is_some_and(|alias| alias != new_alias);
+        if !existing_has_alias {
+            return;
+        }
+        let new_has_alias = parent_ref.alias.as_deref().is_some_and(|alias| alias != new_alias);
+        if new_has_alias && version_gte(&existing.version, &parent_ref.version) {
+            return;
+        }
+    }
+    refs.insert(new_alias.to_string(), parent_ref.clone());
+}
+
+fn version_gte(left: &str, right: &str) -> bool {
+    match (Version::parse(left), Version::parse(right)) {
+        (Ok(left), Ok(right)) => left >= right,
+        _ => left >= right,
     }
 }
 
@@ -1698,26 +1889,6 @@ fn remap_link_node_id(
     let rel = pathdiff::diff_paths(&target, lockfile_dir)?;
     let rel = rel.display().to_string().replace('\\', "/");
     Some(NodeId::leaf(&format!("link:{rel}")))
-}
-
-/// Insert `parent_ref` under `name` in `refs`, bumping `occurrence`
-/// when shadowing an existing entry whose `(pkg_id, version)` differs.
-/// Mirrors upstream's
-/// [`addParentPkg` shadowing arm](https://github.com/pnpm/pnpm/blob/c86c423bdc/installing/deps-resolver/src/resolvePeers.ts#L430-L439):
-/// when a same-name parent gets added at a deeper depth and doesn't
-/// match the existing record, the new entry replaces with a higher
-/// `occurrence` so [`Walker::parent_packages_match`] can flag the
-/// shadowing.
-fn bump_occurrence_on_shadow(refs: &mut ParentRefs, name: &str, parent_ref: &ParentRef) {
-    let next = match refs.get(name) {
-        Some(existing) if existing.node_id == parent_ref.node_id => {
-            // Identical entry — keep the existing occurrence value.
-            return;
-        }
-        Some(existing) => ParentRef { occurrence: existing.occurrence + 1, ..parent_ref.clone() },
-        None => parent_ref.clone(),
-    };
-    refs.insert(name.to_string(), next);
 }
 
 /// Build the `parents` chain attached to a peer issue. Upstream uses

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -1770,10 +1770,12 @@ impl<'tree> Walker<'tree> {
             && parent_pkgs_have_single_occurrence(current_parents);
         for (name, cached_info) in cached_parents {
             let Some(current_info) = current_parents.get(name) else { return false };
-            // Version-only match covers `link:` parents whose nodeIds
-            // don't index into the dependencies tree.
-            if cached_info.version.is_some() || current_info.version.is_some() {
-                if cached_info.version == current_info.version {
+            // Version-only match covers `link:` parents only when
+            // both recorded contexts are version-only.
+            if let (Some(cached_version), Some(current_version)) =
+                (&cached_info.version, &current_info.version)
+            {
+                if cached_version == current_version {
                     continue;
                 }
                 return false;

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -891,16 +891,10 @@ impl<'tree> Walker<'tree> {
         let dep_path = if all_resolved_peers.is_empty() {
             DepPath::from(pkg.id.clone())
         } else {
-            let mut peer_ids: Vec<PeerId> = all_resolved_peers
+            let peer_ids: Vec<PeerId> = all_resolved_peers
                 .iter()
                 .map(|(peer_alias, peer_node_id)| self.build_peer_id(peer_alias, peer_node_id))
                 .collect();
-            // Sorting happens inside `create_peer_dep_graph_hash`, but
-            // we deduplicate by stringified form here to mirror
-            // upstream's `Map<alias, NodeId>` semantics (each peer
-            // contributes at most once).
-            peer_ids.sort_by_key(PeerId::as_segment);
-            peer_ids.dedup_by_key(|p| p.as_segment());
             let suffix = create_peer_dep_graph_hash(&peer_ids, self.opts.peers_suffix_max_length);
             DepPath::from(format!("{}{}", pkg.id, suffix))
         };
@@ -1210,7 +1204,7 @@ impl<'tree> Walker<'tree> {
                 if peers.is_empty() {
                     continue;
                 }
-                let mut peer_ids: Vec<PeerId> = peers
+                let peer_ids: Vec<PeerId> = peers
                     .iter()
                     .map(|(peer_alias, peer_node_id)| {
                         self.final_peer_id(
@@ -1222,8 +1216,6 @@ impl<'tree> Walker<'tree> {
                         )
                     })
                     .collect();
-                peer_ids.sort_by_key(PeerId::as_segment);
-                peer_ids.dedup_by_key(|peer_id| peer_id.as_segment());
                 let suffix =
                     create_peer_dep_graph_hash(&peer_ids, self.opts.peers_suffix_max_length);
                 let pkg_id = &self.tree.dependencies_tree[node_id].resolved_package_id;

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -613,6 +613,12 @@ impl<'tree> Walker<'tree> {
             let Some(pkg) = self.tree.packages.get(&tree_node.resolved_package_id) else {
                 continue;
             };
+            let (real_name, _) = pkg_name_version(&pkg.result);
+            if !self.tree.all_peer_dep_names.contains(&direct.alias)
+                && !self.tree.all_peer_dep_names.contains(&real_name)
+            {
+                continue;
+            }
             let parent_node_id = remap_link_node_id(&self.opts, &direct.alias, &pkg.result)
                 .unwrap_or_else(|| direct.node_id.clone());
             insert_parent_ref(&mut refs, &direct.alias, parent_node_id, pkg, tree_node.depth);

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -144,6 +144,60 @@ fn own_peer_is_resolved_from_peer_relevant_child() {
 }
 
 #[test]
+fn own_peer_is_resolved_from_aliased_child_real_name() {
+    let peer_c = NodeId::leaf("peer-c@2.0.0");
+    let consumer = NodeId::next();
+    let parent = NodeId::next();
+
+    let mut parent_children = BTreeMap::new();
+    parent_children.insert("consumer".to_string(), consumer.clone());
+    parent_children.insert("peer-c1".to_string(), peer_c.clone());
+
+    let mut tree = ResolvedTree {
+        direct: vec![DirectDep {
+            alias: "parent".to_string(),
+            node_id: parent.clone(),
+            id: "parent@1.0.0".to_string(),
+        }],
+        packages: HashMap::from([
+            ("peer-c@2.0.0".to_string(), package("peer-c", "2.0.0", &[], true)),
+            (
+                "consumer@1.0.0".to_string(),
+                package_with_peer_dependencies(
+                    "consumer",
+                    "1.0.0",
+                    &[("peer-c", "*", false)],
+                    false,
+                ),
+            ),
+            ("parent@1.0.0".to_string(), package("parent", "1.0.0", &[], false)),
+        ]),
+        dependencies_tree: HashMap::from([
+            (peer_c, tree_node("peer-c@2.0.0", BTreeMap::new(), 1)),
+            (consumer, tree_node("consumer@1.0.0", BTreeMap::new(), 1)),
+            (parent, tree_node("parent@1.0.0", parent_children, 0)),
+        ]),
+        all_peer_dep_names: HashSet::from(["peer-c".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+
+    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+    let dep_path = DepPath::from("consumer@1.0.0(peer-c@2.0.0)");
+
+    assert!(
+        result.graph.contains_key(&dep_path),
+        "consumer should resolve peer-c from the peer-c1 alias child: {:#?}",
+        result.graph.keys().collect::<Vec<_>>(),
+    );
+    assert_eq!(
+        result.graph[&dep_path].children.get("peer-c"),
+        Some(&DepPath::from("peer-c@2.0.0")),
+    );
+}
+
+#[test]
 fn cached_optional_peer_resolution_bubbles_to_later_parent_without_provider() {
     let types = NodeId::leaf("types@1.0.0");
     let config_from_core = NodeId::next();

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -198,6 +198,55 @@ fn own_peer_is_resolved_from_aliased_child_real_name() {
 }
 
 #[test]
+fn importer_parent_refs_skip_direct_deps_irrelevant_by_alias_and_real_name() {
+    let alias_relevant = NodeId::leaf("alias-real@1.0.0");
+    let real_name_relevant = NodeId::leaf("peer-c@2.0.0");
+    let irrelevant = NodeId::leaf("unused@1.0.0");
+
+    let mut tree = ResolvedTree {
+        direct: vec![
+            DirectDep {
+                alias: "alias-peer".to_string(),
+                node_id: alias_relevant.clone(),
+                id: "alias-real@1.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "peer-c1".to_string(),
+                node_id: real_name_relevant.clone(),
+                id: "peer-c@2.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "unused".to_string(),
+                node_id: irrelevant.clone(),
+                id: "unused@1.0.0".to_string(),
+            },
+        ],
+        packages: HashMap::from([
+            ("alias-real@1.0.0".to_string(), package("alias-real", "1.0.0", &[], true)),
+            ("peer-c@2.0.0".to_string(), package("peer-c", "2.0.0", &[], true)),
+            ("unused@1.0.0".to_string(), package("unused", "1.0.0", &[], true)),
+        ]),
+        dependencies_tree: HashMap::from([
+            (alias_relevant, tree_node("alias-real@1.0.0", BTreeMap::new(), 0)),
+            (real_name_relevant, tree_node("peer-c@2.0.0", BTreeMap::new(), 0)),
+            (irrelevant, tree_node("unused@1.0.0", BTreeMap::new(), 0)),
+        ]),
+        all_peer_dep_names: HashSet::from(["alias-peer".to_string(), "peer-c".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+    let walker = walker_for_tests(&mut tree);
+
+    let refs = walker.build_importer_parents_from(&walker.tree.direct);
+
+    assert!(refs.contains_key("alias-peer"));
+    assert!(refs.contains_key("peer-c1"));
+    assert!(refs.contains_key("peer-c"));
+    assert!(!refs.contains_key("unused"));
+}
+
+#[test]
 fn cached_optional_peer_resolution_bubbles_to_later_parent_without_provider() {
     let types = NodeId::leaf("types@1.0.0");
     let config_from_core = NodeId::next();

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1,5 +1,6 @@
-use super::{ResolvePeersOptions, resolve_peers, satisfies_with_prereleases};
+use super::{ResolvePeersOptions, Walker, resolve_peers, satisfies_with_prereleases};
 use crate::{
+    dependencies_graph::{DependenciesGraph, PeerDependencyIssues},
     node_id::NodeId,
     resolved_tree::{
         DependenciesTreeNode, DirectDep, PeerDep, ResolvedPackage, ResolvedTree, TreeChildren,
@@ -270,12 +271,65 @@ fn same_package_child_replaces_inherited_parent_when_peer_diamond_conflicts() {
     );
 }
 
+#[test]
+fn previously_resolved_children_prefers_closest_same_package_ancestor() {
+    let far_parent = NodeId::next();
+    let close_parent = NodeId::next();
+    let far_child = NodeId::leaf("shared@1.0.0");
+    let close_child = NodeId::leaf("shared@2.0.0");
+
+    let mut far_children = BTreeMap::new();
+    far_children.insert("shared".to_string(), far_child);
+    let mut close_children = BTreeMap::new();
+    close_children.insert("shared".to_string(), close_child.clone());
+
+    let mut tree = ResolvedTree {
+        direct: Vec::new(),
+        packages: HashMap::from([("loop@1.0.0".to_string(), package("loop", "1.0.0", &[], false))]),
+        dependencies_tree: HashMap::from([
+            (far_parent.clone(), tree_node("loop@1.0.0", far_children, 0)),
+            (close_parent.clone(), tree_node("loop@1.0.0", close_children, 2)),
+        ]),
+        all_peer_dep_names: HashSet::new(),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+    let mut walker = walker_for_tests(&mut tree);
+
+    let children = walker.previously_resolved_children(
+        &[far_parent, close_parent],
+        &["loop@1.0.0".to_string()],
+        "loop@1.0.0",
+    );
+
+    assert_eq!(children.get("shared"), Some(&close_child));
+}
+
 fn tree_node(pkg_id: &str, children: BTreeMap<String, NodeId>, depth: i32) -> DependenciesTreeNode {
     DependenciesTreeNode {
         resolved_package_id: pkg_id.to_string(),
         children: TreeChildren::Realized(children),
         depth,
         installable: true,
+    }
+}
+
+fn walker_for_tests(tree: &mut ResolvedTree) -> Walker<'_> {
+    Walker {
+        tree,
+        opts: ResolvePeersOptions::default(),
+        graph: DependenciesGraph::new(),
+        issues: PeerDependencyIssues::default(),
+        node_dep_paths: HashMap::new(),
+        node_external_peers: HashMap::new(),
+        node_missing_peers: HashMap::new(),
+        in_progress: HashSet::new(),
+        pending_peer_edges: Vec::new(),
+        pure_pkgs: HashSet::new(),
+        peers_cache: HashMap::new(),
+        parent_pkgs_of_node: HashMap::new(),
+        node_records: HashMap::new(),
     }
 }
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1,4 +1,18 @@
-use super::satisfies_with_prereleases;
+use super::{ResolvePeersOptions, resolve_peers, satisfies_with_prereleases};
+use crate::{
+    node_id::NodeId,
+    resolved_tree::{
+        DependenciesTreeNode, DirectDep, PeerDep, ResolvedPackage, ResolvedTree, TreeChildren,
+    },
+};
+use pacquet_deps_path::DepPath;
+use pacquet_lockfile::{LockfileResolution, PkgName, PkgNameVer, TarballResolution};
+use pacquet_resolving_resolver_base::ResolveResult;
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    str::FromStr,
+    sync::Arc,
+};
 
 #[test]
 fn satisfies_handles_basic_ranges() {
@@ -23,4 +37,300 @@ fn satisfies_accepts_prerelease_against_non_prerelease_range() {
     assert!(satisfies_with_prereleases("1.2.3-beta.0", "^1.2.0"));
     // Out-of-range prereleases still fail.
     assert!(!satisfies_with_prereleases("19.0.0-rc.1", "^18.0.0"));
+}
+
+#[test]
+fn same_package_child_does_not_shadow_inherited_parent_and_bubbles_by_name() {
+    let x1 = NodeId::leaf("x@1.0.0");
+    let x2 = NodeId::leaf("x@2.0.0");
+    let p_root = NodeId::next();
+    let p_child = NodeId::next();
+    let plugin = NodeId::next();
+    let mid = NodeId::next();
+
+    let mut mid_children = BTreeMap::new();
+    mid_children.insert("p".to_string(), p_child.clone());
+    mid_children.insert("plugin".to_string(), plugin.clone());
+    mid_children.insert("x".to_string(), x2.clone());
+
+    let mut tree = ResolvedTree {
+        direct: vec![
+            DirectDep { alias: "x".to_string(), node_id: x1.clone(), id: "x@1.0.0".to_string() },
+            DirectDep {
+                alias: "p".to_string(),
+                node_id: p_root.clone(),
+                id: "p@1.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "mid".to_string(),
+                node_id: mid.clone(),
+                id: "mid@1.0.0".to_string(),
+            },
+        ],
+        packages: HashMap::from([
+            ("x@1.0.0".to_string(), package("x", "1.0.0", &[], true)),
+            ("x@2.0.0".to_string(), package("x", "2.0.0", &[], true)),
+            ("p@1.0.0".to_string(), package("p", "1.0.0", &[("x", "*")], false)),
+            ("plugin@1.0.0".to_string(), package("plugin", "1.0.0", &[("p", "*")], false)),
+            ("mid@1.0.0".to_string(), package("mid", "1.0.0", &[], false)),
+        ]),
+        dependencies_tree: HashMap::from([
+            (x1, tree_node("x@1.0.0", BTreeMap::new(), 0)),
+            (x2, tree_node("x@2.0.0", BTreeMap::new(), 1)),
+            (p_root, tree_node("p@1.0.0", BTreeMap::new(), 0)),
+            (p_child, tree_node("p@1.0.0", BTreeMap::new(), 1)),
+            (plugin, tree_node("plugin@1.0.0", BTreeMap::new(), 1)),
+            (mid, tree_node("mid@1.0.0", mid_children, 0)),
+        ]),
+        all_peer_dep_names: HashSet::from(["p".to_string(), "x".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+
+    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+
+    assert_eq!(result.direct_dependencies_by_alias.get("mid"), Some(&DepPath::from("mid@1.0.0")));
+    assert!(
+        result.graph.contains_key(&DepPath::from("plugin@1.0.0(p@1.0.0(x@1.0.0))")),
+        "plugin should resolve p from the inherited root context: {:#?}",
+        result.graph.keys().collect::<Vec<_>>(),
+    );
+    assert!(
+        !result.graph.contains_key(&DepPath::from("plugin@1.0.0(p@1.0.0(x@2.0.0))")),
+        "same-package child p must not shadow inherited p: {:#?}",
+        result.graph.keys().collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn own_peer_is_resolved_from_peer_relevant_child() {
+    let types = NodeId::leaf("types@1.0.0");
+    let consumer = NodeId::next();
+
+    let mut consumer_children = BTreeMap::new();
+    consumer_children.insert("types".to_string(), types.clone());
+
+    let mut tree = ResolvedTree {
+        direct: vec![DirectDep {
+            alias: "consumer".to_string(),
+            node_id: consumer.clone(),
+            id: "consumer@1.0.0".to_string(),
+        }],
+        packages: HashMap::from([
+            ("types@1.0.0".to_string(), package("types", "1.0.0", &[], true)),
+            (
+                "consumer@1.0.0".to_string(),
+                package_with_peer_dependencies("consumer", "1.0.0", &[("types", "*", true)], false),
+            ),
+        ]),
+        dependencies_tree: HashMap::from([
+            (types, tree_node("types@1.0.0", BTreeMap::new(), 1)),
+            (consumer, tree_node("consumer@1.0.0", consumer_children, 0)),
+        ]),
+        all_peer_dep_names: HashSet::from(["types".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+
+    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+    let dep_path = DepPath::from("consumer@1.0.0(types@1.0.0)");
+
+    assert_eq!(result.direct_dependencies_by_alias.get("consumer"), Some(&dep_path));
+    assert_eq!(result.graph[&dep_path].children.get("types"), Some(&DepPath::from("types@1.0.0")));
+    assert!(result.graph[&dep_path].resolved_peer_names.contains("types"));
+}
+
+#[test]
+fn cached_optional_peer_resolution_bubbles_to_later_parent_without_provider() {
+    let types = NodeId::leaf("types@1.0.0");
+    let config_from_core = NodeId::next();
+    let config_from_cli = NodeId::next();
+    let core = NodeId::next();
+    let cli = NodeId::next();
+
+    let mut core_children = BTreeMap::new();
+    core_children.insert("config".to_string(), config_from_core.clone());
+    core_children.insert("types".to_string(), types.clone());
+
+    let mut cli_children = BTreeMap::new();
+    cli_children.insert("config".to_string(), config_from_cli.clone());
+
+    let mut tree = ResolvedTree {
+        direct: vec![
+            DirectDep {
+                alias: "core".to_string(),
+                node_id: core.clone(),
+                id: "core@1.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "cli".to_string(),
+                node_id: cli.clone(),
+                id: "cli@1.0.0".to_string(),
+            },
+        ],
+        packages: HashMap::from([
+            ("types@1.0.0".to_string(), package("types", "1.0.0", &[], true)),
+            (
+                "config@1.0.0".to_string(),
+                package_with_peer_dependencies("config", "1.0.0", &[("types", "*", true)], false),
+            ),
+            ("core@1.0.0".to_string(), package("core", "1.0.0", &[], false)),
+            ("cli@1.0.0".to_string(), package("cli", "1.0.0", &[], false)),
+        ]),
+        dependencies_tree: HashMap::from([
+            (types, tree_node("types@1.0.0", BTreeMap::new(), 1)),
+            (config_from_core, tree_node("config@1.0.0", BTreeMap::new(), 1)),
+            (config_from_cli, tree_node("config@1.0.0", BTreeMap::new(), 1)),
+            (core, tree_node("core@1.0.0", core_children, 0)),
+            (cli, tree_node("cli@1.0.0", cli_children, 0)),
+        ]),
+        all_peer_dep_names: HashSet::from(["types".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+
+    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+    let config_dep_path = DepPath::from("config@1.0.0(types@1.0.0)");
+    let cli_dep_path = DepPath::from("cli@1.0.0(types@1.0.0)");
+
+    assert_eq!(result.direct_dependencies_by_alias.get("core"), Some(&DepPath::from("core@1.0.0")));
+    assert_eq!(result.direct_dependencies_by_alias.get("cli"), Some(&cli_dep_path));
+    assert_eq!(result.graph[&cli_dep_path].children.get("config"), Some(&config_dep_path));
+    assert!(result.graph[&cli_dep_path].resolved_peer_names.contains("types"));
+}
+
+#[test]
+fn same_package_child_replaces_inherited_parent_when_peer_diamond_conflicts() {
+    let ts1 = NodeId::leaf("ts@1.0.0");
+    let ts2 = NodeId::leaf("ts@2.0.0");
+    let parser_root = NodeId::next();
+    let parser_child = NodeId::next();
+    let plugin = NodeId::next();
+    let bundle = NodeId::next();
+
+    let mut bundle_children = BTreeMap::new();
+    bundle_children.insert("parser".to_string(), parser_child.clone());
+    bundle_children.insert("plugin".to_string(), plugin.clone());
+    bundle_children.insert("ts".to_string(), ts1.clone());
+
+    let mut tree = ResolvedTree {
+        direct: vec![
+            DirectDep { alias: "ts".to_string(), node_id: ts2.clone(), id: "ts@2.0.0".to_string() },
+            DirectDep {
+                alias: "parser".to_string(),
+                node_id: parser_root.clone(),
+                id: "parser@1.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "bundle".to_string(),
+                node_id: bundle.clone(),
+                id: "bundle@1.0.0".to_string(),
+            },
+        ],
+        packages: HashMap::from([
+            ("ts@1.0.0".to_string(), package("ts", "1.0.0", &[], true)),
+            ("ts@2.0.0".to_string(), package("ts", "2.0.0", &[], true)),
+            ("parser@1.0.0".to_string(), package("parser", "1.0.0", &[("ts", "*")], false)),
+            (
+                "plugin@1.0.0".to_string(),
+                package("plugin", "1.0.0", &[("parser", "*"), ("ts", "*")], false),
+            ),
+            ("bundle@1.0.0".to_string(), package("bundle", "1.0.0", &[], false)),
+        ]),
+        dependencies_tree: HashMap::from([
+            (ts1, tree_node("ts@1.0.0", BTreeMap::new(), 1)),
+            (ts2, tree_node("ts@2.0.0", BTreeMap::new(), 0)),
+            (parser_root, tree_node("parser@1.0.0", BTreeMap::new(), 0)),
+            (parser_child, tree_node("parser@1.0.0", BTreeMap::new(), 1)),
+            (plugin, tree_node("plugin@1.0.0", BTreeMap::new(), 1)),
+            (bundle, tree_node("bundle@1.0.0", bundle_children, 0)),
+        ]),
+        all_peer_dep_names: HashSet::from(["parser".to_string(), "ts".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+
+    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+    let consistent = DepPath::from("plugin@1.0.0(parser@1.0.0(ts@1.0.0))(ts@1.0.0)");
+    let inconsistent = DepPath::from("plugin@1.0.0(parser@1.0.0(ts@2.0.0))(ts@1.0.0)");
+
+    assert!(
+        result.graph.contains_key(&consistent),
+        "plugin should use the nested parser context: {:#?}",
+        result.graph.keys().collect::<Vec<_>>(),
+    );
+    assert!(
+        !result.graph.contains_key(&inconsistent),
+        "plugin must not mix the root parser context with nested ts: {:#?}",
+        result.graph.keys().collect::<Vec<_>>(),
+    );
+}
+
+fn tree_node(pkg_id: &str, children: BTreeMap<String, NodeId>, depth: i32) -> DependenciesTreeNode {
+    DependenciesTreeNode {
+        resolved_package_id: pkg_id.to_string(),
+        children: TreeChildren::Realized(children),
+        depth,
+        installable: true,
+    }
+}
+
+fn package(
+    name: &str,
+    version: &str,
+    peer_dependencies: &[(&str, &str)],
+    is_leaf: bool,
+) -> ResolvedPackage {
+    let peer_dependencies: Vec<_> =
+        peer_dependencies.iter().map(|(name, version)| (*name, *version, false)).collect();
+    package_with_peer_dependencies(name, version, &peer_dependencies, is_leaf)
+}
+
+fn package_with_peer_dependencies(
+    name: &str,
+    version: &str,
+    peer_dependencies: &[(&str, &str, bool)],
+    is_leaf: bool,
+) -> ResolvedPackage {
+    let peer_dependencies = peer_dependencies
+        .iter()
+        .map(|(name, version, optional)| {
+            ((*name).to_string(), PeerDep { version: (*version).to_string(), optional: *optional })
+        })
+        .collect();
+    ResolvedPackage {
+        id: format!("{name}@{version}"),
+        result: Arc::new(resolve_result(name, version)),
+        peer_dependencies,
+        optional: false,
+        is_leaf,
+    }
+}
+
+fn resolve_result(name: &str, version: &str) -> ResolveResult {
+    let name_ver = PkgNameVer::new(
+        PkgName::parse(name).unwrap(),
+        node_semver::Version::from_str(version).unwrap(),
+    );
+    ResolveResult {
+        id: (&name_ver).into(),
+        name_ver: Some(name_ver),
+        latest: Some(version.to_string()),
+        published_at: None,
+        manifest: None,
+        resolution: LockfileResolution::Tarball(TarballResolution {
+            tarball: format!("https://registry.example/{name}-{version}.tgz"),
+            integrity: None,
+            git_hosted: None,
+            path: None,
+        }),
+        resolved_via: "npm-registry".to_string(),
+        normalized_bare_specifier: None,
+        alias: Some(name.to_string()),
+        policy_violation: None,
+    }
 }


### PR DESCRIPTION
## Summary

- align pacquet peer parent context handling with pnpm for same-package child providers and peer diamonds
- keep optional cached peer resolutions bubbling to later parents without an explicit provider, matching the jest-config and @types/node case
- preserve pnpm's duplicated peer-suffix segments for aliased providers that resolve to the same package
- include aliased child providers when their real package name is peer-relevant, not only when the install alias is peer-relevant
- limit importer-seeded peer parent refs to alias/real names that can affect peer resolution, reducing clone overhead
- add focused resolver tests for the issue 12272 lockfile mismatch and related diamond/alias-provider behavior
- port the six related pnpm CLI alias-peer install cases to Pacquet CLI tests
- pin the alias-peer CLI test peer suffix length so exact lockfile suffix assertions are independent of global config
- update the Pacquet coverage upload to codecov-action v6.0.2 so it uses Codecov's current signing-key configuration

Fixes pnpm/pnpm#12272.

## Verification

- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo dylint --all -- --all-targets --workspace`
- `cargo test --locked -p pacquet-resolving-deps-resolver`
- `cargo test --locked -p pacquet-resolving-deps-resolver resolve_peers::tests::own_peer_is_resolved_from_aliased_child_real_name -- --nocapture`
- `cargo test --locked -p pacquet-resolving-deps-resolver importer_parent_refs_skip_direct_deps_irrelevant_by_alias_and_real_name -- --nocapture`
- `cargo test --locked -p pacquet-cli --test install peer_dependenc -- --nocapture`
- `cargo test --locked -p pacquet-cli --test install -- --nocapture`
- `cargo test --locked -p pacquet-cli --test install peer_shared_through_a_diamond_is_resolved_consistently -- --nocapture`
- `pnpm --filter @pnpm/installing.deps-installer test test/install/peerDependencies.ts -t "in a subdependency, when there are several aliased dependencies of the same package"`
- `cargo build --locked --bin pacquet`
- paired lockfile-only repro with `jest@30.4.2`, `@babel/core@7.29.7`, and `autoInstallPeers: true`; `diff -u` between pnpm and pacquet lockfiles exited 0
- pre-push hook passed, including TS build/lint, spellcheck, Rust docs, dylint, and taplo checks

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer dependency resolution in complex/diamond scenarios, across inherited vs own contexts, and when dependencies use npm-style aliases; prefers appropriate providers and higher alias versions. Better handling of optional peers when no provider exists.

* **Tests**
  * Added end-to-end and unit tests for peer resolution, alias scenarios, inheritance vs own-context behavior, and edge cases; added a helper to run installs with aliased deps.

* **Chores**
  * Updated Codecov action to v6.0.2.

* **Refactor**
  * Reorganized peer-resolution internals for more consistent, deterministic outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->