### PR TITLE
fix(pacquet): render workspace self-dependency as bare link:

### DIFF
--- a/pacquet/crates/resolving-npm-resolver/src/resolve_from_workspace.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/resolve_from_workspace.rs
@@ -323,9 +323,10 @@ fn pathdiff_string(base: &Path, target: &Path) -> Option<String> {
     for component in target_components {
         out.push(component.as_os_str());
     }
-    if out.as_os_str().is_empty() {
-        out.push(".");
-    }
+    // `base == target` (a workspace package depending on itself) yields an
+    // empty relative path, which must stay empty: pnpm renders the id as
+    // `link:` (bare), matching `path.relative(projectDir, projectDir) === ''`
+    // — not `link:.`.
     Some(out.display().to_string())
 }
 

--- a/pacquet/crates/resolving-npm-resolver/src/resolve_from_workspace/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/resolve_from_workspace/tests.rs
@@ -96,6 +96,37 @@ fn workspace_star_resolves_to_link_against_highest_version() {
     assert_eq!(result.alias.as_deref(), Some("foo"));
 }
 
+/// A workspace package depending on itself (`project_dir == the resolved
+/// package's `root_dir`) renders as a bare `link:` — the relative path is
+/// empty, matching pnpm's `link:${path.relative(projectDir, projectDir)}`
+/// (`''`), not `link:.`.
+#[test]
+fn workspace_self_dependency_renders_as_bare_link() {
+    let mut versions: WorkspacePackagesByVersion = BTreeMap::new();
+    versions.insert(
+        "1.0.0".to_string(),
+        WorkspacePackage {
+            root_dir: Path::new("/repo/packages/self").to_path_buf(),
+            manifest: json!({ "name": "self", "version": "1.0.0" }),
+        },
+    );
+    let mut packages: WorkspacePackages = BTreeMap::new();
+    packages.insert("self".to_string(), versions);
+
+    let opts = ResolveFromWorkspaceOptions {
+        project_dir: Path::new("/repo/packages/self"),
+        lockfile_dir: Path::new("/repo"),
+        registry: "https://registry.npmjs.org/",
+        default_tag: "latest",
+        workspace_packages: Some(&packages),
+        inject_workspace_packages: false,
+    };
+    let result = try_resolve_from_workspace(&wanted("self", "workspace:*"), &opts)
+        .expect("ok")
+        .expect("some");
+    assert_eq!(result.id.as_str(), "link:");
+}
+
 #[test]
 fn workspace_caret_range_picks_lower_when_pinned_range_excludes_higher() {
     let packages = build_packages();


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix workspace self-deps to render as bare `link:` (not `link:.`)
<code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## What

Part of the lockfile-parity work (pnpm/pnpm#12266 — self-contained format fixes). A workspace package that depends on itself (`a: workspace:*` where `a` is the package) rendered as `version: link:.` in the lockfile; pnpm renders bare `version: 'link:'`.

## How

`resolve_from_workspace::pathdiff_string` pushed a `.` when the relative path between the importer and the resolved package directory was empty. For a self-dependency, `project_dir == the package's root_dir`, so the relative path is empty — pnpm renders the id as `link:` (`` `link:${path.relative(projectDir, projectDir)}` `` → `link:` + `''`), not `link:.`.

Dropping the `.`-for-empty fallback makes the relative path stay empty, matching `path.relative`. The empty case only arises for self-deps (the only time `base == target`), so non-self workspace links are unaffected, and the `directory` resolution field isn't serialized for `link:` deps.

## Verification

- A minimal `workspace:*` self-dep is now byte-identical to pnpm 11.5.2.
- On the pnpm monorepo, all 204 `link:.` self-links are removed (lockfile diff vs fresh pnpm: **2,167 → 1,759**).
- New regression test `workspace_self_dependency_renders_as_bare_link`, verified to fail without the fix.
- All 234 `pacquet-resolving-npm-resolver` tests pass; clippy + fmt clean.

Refs pnpm/pnpm#12266.

---
Written by an agent (Claude Code, claude-opus-4-8).

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Stop forcing <b><i>.</i></b> for empty workspace relative paths to match pnpm <b><i>link:</i></b>.
• Fix lockfile IDs for workspace packages that depend on themselves.
• Add regression test asserting self-dependency renders as bare <b><i>link:</i></b>.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["resolve_from_workspace"] --> B["pathdiff_string"] --> C["Workspace link id"] --> D["Lockfile output"]
  E["tests.rs"] --> F["workspace_self_dependency test"] --> C
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Special-case self-dependency at call site</b></summary>

- ➕ Avoids changing general path diff behavior
- ➕ Makes the self-dep rule explicit where IDs are constructed
- ➖ Duplicates logic already implied by `path.relative(base, base) == &#x27;&#x27;`
- ➖ Risk of missing other `base == target` call sites in the future

</details>

<details>
<summary><b>2. Use a dedicated pathdiff utility/crate with empty-path semantics</b></summary>

- ➕ Standardizes semantics and edge-case handling
- ➕ Reduces custom path manipulation code
- ➖ Adds dependency/complexity for a very small behavioral tweak
- ➖ Still needs explicit decision about empty path serialization

</details>

**Recommendation:** Keep the PR’s approach: dropping the `.` fallback makes `pathdiff_string` align with pnpm/Node’s `path.relative` semantics and fixes the issue at the source with minimal surface area. The added regression test is sufficient to prevent reintroducing `link:.` for `base == target`.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>resolve_from_workspace.rs</strong> <code>Stop rewriting empty relative paths to &#x27;.&#x27; for workspace links</code> <code>+4/-3</code></summary>

<br/>

>Stop rewriting empty relative paths to &#x27;.&#x27; for workspace links
>
><pre>
>• Removes the fallback that converted an empty computed relative path into &#x27;.&#x27;. This allows self-dependencies (where &#x27;base == target&#x27;) to render as bare &#x27;link:&#x27; to match pnpm’s lockfile behavior.
></pre>
>
><a href='https://github.com/pnpm/pnpm/pull/12276/files#diff-88de71d9581ad3b2d79b97d3a71909577812242a36f5d6e4aead67a044275f56'>pacquet/crates/resolving-npm-resolver/src/resolve_from_workspace.rs</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>tests.rs</strong> <code>Add regression test for self-dependency rendering as bare &#x27;link:&#x27;</code> <code>+31/-0</code></summary>

<br/>

>Add regression test for self-dependency rendering as bare &#x27;link:&#x27;
>
><pre>
>• Introduces &#x27;workspace_self_dependency_renders_as_bare_link&#x27;, building a minimal workspace package map where &#x27;project_dir&#x27; equals the package &#x27;root_dir&#x27;. Asserts the resolved id is exactly &#x27;link:&#x27; (not &#x27;link:.&#x27;).
></pre>
>
><a href='https://github.com/pnpm/pnpm/pull/12276/files#diff-ccceb8ad8f7c76b8b7bd3b0c5d9328e6ba962bf0149a6837026abd218ead7b16'>pacquet/crates/resolving-npm-resolver/src/resolve_from_workspace/tests.rs</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace self-dependency resolution to align with pnpm's behavior
  * Bare link identifiers in workspace packages now correctly render with empty relative paths instead of default fallback values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->