### PR TITLE
perf: lazily load README when embedding publish manifest

### DIFF
--- a/.changeset/lazy-readme-embed.md
+++ b/.changeset/lazy-readme-embed.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/releasing.exportable-manifest": patch
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+Avoid reading `README.md` from disk when publishing if the publish manifest already provides a `readme` field. The README is now only read lazily, inside `createExportableManifest`, when it is actually needed.

--- a/releasing/commands/src/publish/pack.ts
+++ b/releasing/commands/src/publish/pack.ts
@@ -352,14 +352,6 @@ function preventBundledDependenciesWithoutHoistedNodeLinker (nodeLinker: Config[
   }
 }
 
-async function readReadmeFile (projectDir: string): Promise<string | undefined> {
-  const files = await fs.promises.readdir(projectDir)
-  const readmePath = files.find(name => /readme\.md$/i.test(name))
-  const readmeFile = readmePath ? await fs.promises.readFile(path.join(projectDir, readmePath), 'utf8') : undefined
-
-  return readmeFile
-}
-
 async function packPkg (opts: {
   destFile: string
   filesMap: Record<string, string>
@@ -405,11 +397,11 @@ async function createPublishManifest (opts: {
   skipManifestObfuscation?: boolean
 }): Promise<ExportedManifest> {
   const { projectDir, embedReadme, modulesDir, manifest, catalogs, hooks, skipManifestObfuscation } = opts
-  const readmeFile = embedReadme ? await readReadmeFile(projectDir) : undefined
   return createExportableManifest(projectDir, manifest, {
     catalogs,
     hooks,
-    readmeFile,
+    embedReadme,
+    projectDir,
     modulesDir,
     skipManifestObfuscation,
   })

--- a/releasing/commands/src/publish/pack.ts
+++ b/releasing/commands/src/publish/pack.ts
@@ -401,7 +401,6 @@ async function createPublishManifest (opts: {
     catalogs,
     hooks,
     embedReadme,
-    projectDir,
     modulesDir,
     skipManifestObfuscation,
   })

--- a/releasing/exportable-manifest/src/index.ts
+++ b/releasing/exportable-manifest/src/index.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import path from 'node:path'
 
 import { type CatalogResolver, resolveFromCatalog } from '@pnpm/catalogs.resolver'
@@ -29,7 +30,16 @@ export interface MakePublishManifestOptions {
   hooks?: Hooks
   modulesDir?: string
   skipManifestObfuscation?: boolean
-  readmeFile?: string
+  embedReadme?: boolean
+  projectDir?: string
+}
+
+async function readReadmeFile (projectDir: string): Promise<string | undefined> {
+  const files = await fs.promises.readdir(projectDir)
+  const readmePath = files.find(name => /readme\.md$/i.test(name))
+  const readmeFile = readmePath ? await fs.promises.readFile(path.join(projectDir, readmePath), 'utf8') : undefined
+
+  return readmeFile
 }
 
 export async function createExportableManifest (
@@ -72,8 +82,8 @@ export async function createExportableManifest (
 
   overridePublishConfig(publishManifest)
 
-  if (opts?.readmeFile) {
-    publishManifest.readme ??= opts.readmeFile
+  if (opts?.embedReadme && opts.projectDir) {
+    publishManifest.readme ??= await readReadmeFile(opts.projectDir)
   }
 
   for (const hook of opts?.hooks?.beforePacking ?? []) {

--- a/releasing/exportable-manifest/src/index.ts
+++ b/releasing/exportable-manifest/src/index.ts
@@ -34,11 +34,12 @@ export interface MakePublishManifestOptions {
 }
 
 async function readReadmeFile (projectDir: string): Promise<string | undefined> {
-  const files = await fs.promises.readdir(projectDir)
-  const readmePath = files.find(name => /readme\.md$/i.test(name))
-  const readmeFile = readmePath ? await fs.promises.readFile(path.join(projectDir, readmePath), 'utf8') : undefined
-
-  return readmeFile
+  const entries = await fs.promises.readdir(projectDir, { withFileTypes: true })
+  // Only embed a regular README.md file. A symlink could point outside the
+  // project and leak its target's contents into the published manifest.
+  const readmeEntry = entries.find((entry) => entry.isFile() && /^readme\.md$/i.test(entry.name))
+  if (readmeEntry == null) return undefined
+  return fs.promises.readFile(path.join(projectDir, readmeEntry.name), 'utf8')
 }
 
 export async function createExportableManifest (

--- a/releasing/exportable-manifest/src/index.ts
+++ b/releasing/exportable-manifest/src/index.ts
@@ -31,7 +31,6 @@ export interface MakePublishManifestOptions {
   modulesDir?: string
   skipManifestObfuscation?: boolean
   embedReadme?: boolean
-  projectDir?: string
 }
 
 async function readReadmeFile (projectDir: string): Promise<string | undefined> {
@@ -82,10 +81,10 @@ export async function createExportableManifest (
 
   overridePublishConfig(publishManifest)
 
-  if (publishManifest.readme == null && opts?.embedReadme && opts.projectDir) {
-    const readme = await readReadmeFile(opts.projectDir)
+  if (publishManifest.readme == null && opts?.embedReadme) {
+    const readme = await readReadmeFile(dir)
     if (readme != null) {
-      publishManifest.readme ??= readme
+      publishManifest.readme = readme
     }
   }
 

--- a/releasing/exportable-manifest/src/index.ts
+++ b/releasing/exportable-manifest/src/index.ts
@@ -82,8 +82,11 @@ export async function createExportableManifest (
 
   overridePublishConfig(publishManifest)
 
-  if (opts?.embedReadme && opts.projectDir) {
-    publishManifest.readme ??= await readReadmeFile(opts.projectDir)
+  if (publishManifest.readme == null && opts?.embedReadme && opts.projectDir) {
+    const readme = await readReadmeFile(opts.projectDir)
+    if (readme != null) {
+      publishManifest.readme ??= readme
+    }
   }
 
   for (const hook of opts?.hooks?.beforePacking ?? []) {

--- a/releasing/exportable-manifest/test/index.test.ts
+++ b/releasing/exportable-manifest/test/index.test.ts
@@ -1,4 +1,6 @@
 /// <reference path="../../../__typings__/index.d.ts"/>
+import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
@@ -119,15 +121,18 @@ test('skipManifestObfuscation does not mutate the original manifest', async () =
     },
   }
 
-  expect(await createExportableManifest(process.cwd(), manifest, {
-    ...defaultOpts,
-    skipManifestObfuscation: true,
-    readmeFile: 'readme content',
-  })).toStrictEqual({
-    name: 'foo',
-    version: '1.0.0',
-    main: './dist/index.js',
-    readme: 'readme content',
+  await withTempProjectReadme('readme content', async (projectDir) => {
+    expect(await createExportableManifest(process.cwd(), manifest, {
+      ...defaultOpts,
+      skipManifestObfuscation: true,
+      embedReadme: true,
+      projectDir,
+    })).toStrictEqual({
+      name: 'foo',
+      version: '1.0.0',
+      main: './dist/index.js',
+      readme: 'readme content',
+    })
   })
 
   expect(manifest).toStrictEqual({
@@ -140,15 +145,31 @@ test('skipManifestObfuscation does not mutate the original manifest', async () =
 })
 
 test('readme added to published manifest', async () => {
-  expect(await createExportableManifest(process.cwd(), {
-    name: 'foo',
-    version: '1.0.0',
-  }, { ...defaultOpts, readmeFile: 'readme content' })).toStrictEqual({
-    name: 'foo',
-    version: '1.0.0',
-    readme: 'readme content',
+  await withTempProjectReadme('readme content', async (projectDir) => {
+    expect(await createExportableManifest(process.cwd(), {
+      name: 'foo',
+      version: '1.0.0',
+    }, {
+      ...defaultOpts,
+      embedReadme: true,
+      projectDir,
+    })).toStrictEqual({
+      name: 'foo',
+      version: '1.0.0',
+      readme: 'readme content',
+    })
   })
 })
+
+async function withTempProjectReadme<T> (readmeContent: string, fn: (projectDir: string) => Promise<T>): Promise<T> {
+  const projectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pnpm-readme-'))
+  try {
+    await fs.promises.writeFile(path.join(projectDir, 'README.md'), readmeContent, 'utf8')
+    return await fn(projectDir)
+  } finally {
+    await fs.promises.rm(projectDir, { recursive: true, force: true })
+  }
+}
 
 test('workspace deps are replaced', async () => {
   const manifest: ProjectManifest = {

--- a/releasing/exportable-manifest/test/index.test.ts
+++ b/releasing/exportable-manifest/test/index.test.ts
@@ -122,7 +122,7 @@ test('skipManifestObfuscation does not mutate the original manifest', async () =
   }
 
   await withTempProjectReadme('readme content', async (projectDir) => {
-    expect(await createExportableManifest(process.cwd(), manifest, {
+    expect(await createExportableManifest(projectDir, manifest, {
       ...defaultOpts,
       skipManifestObfuscation: true,
       embedReadme: true,
@@ -146,7 +146,7 @@ test('skipManifestObfuscation does not mutate the original manifest', async () =
 
 test('readme added to published manifest', async () => {
   await withTempProjectReadme('readme content', async (projectDir) => {
-    expect(await createExportableManifest(process.cwd(), {
+    expect(await createExportableManifest(projectDir, {
       name: 'foo',
       version: '1.0.0',
     }, {

--- a/releasing/exportable-manifest/test/index.test.ts
+++ b/releasing/exportable-manifest/test/index.test.ts
@@ -159,7 +159,7 @@ test('readme added to published manifest', async () => {
   })
 })
 
-test('readme is not embedded when README.md is a symlink pointing outside the project', async () => {
+;(process.platform === 'win32' ? test.skip : test)('readme is not embedded when README.md is a symlink pointing outside the project', async () => {
   const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pnpm-readme-'))
   try {
     const secretFile = path.join(tmpDir, 'secret.txt')

--- a/releasing/exportable-manifest/test/index.test.ts
+++ b/releasing/exportable-manifest/test/index.test.ts
@@ -126,7 +126,6 @@ test('skipManifestObfuscation does not mutate the original manifest', async () =
       ...defaultOpts,
       skipManifestObfuscation: true,
       embedReadme: true,
-      projectDir,
     })).toStrictEqual({
       name: 'foo',
       version: '1.0.0',
@@ -152,7 +151,6 @@ test('readme added to published manifest', async () => {
     }, {
       ...defaultOpts,
       embedReadme: true,
-      projectDir,
     })).toStrictEqual({
       name: 'foo',
       version: '1.0.0',

--- a/releasing/exportable-manifest/test/index.test.ts
+++ b/releasing/exportable-manifest/test/index.test.ts
@@ -159,6 +159,30 @@ test('readme added to published manifest', async () => {
   })
 })
 
+test('readme is not embedded when README.md is a symlink pointing outside the project', async () => {
+  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pnpm-readme-'))
+  try {
+    const secretFile = path.join(tmpDir, 'secret.txt')
+    await fs.promises.writeFile(secretFile, 'secret content', 'utf8')
+    const projectDir = path.join(tmpDir, 'project')
+    await fs.promises.mkdir(projectDir)
+    await fs.promises.symlink(secretFile, path.join(projectDir, 'README.md'))
+
+    expect(await createExportableManifest(projectDir, {
+      name: 'foo',
+      version: '1.0.0',
+    }, {
+      ...defaultOpts,
+      embedReadme: true,
+    })).toStrictEqual({
+      name: 'foo',
+      version: '1.0.0',
+    })
+  } finally {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true })
+  }
+})
+
 async function withTempProjectReadme<T> (readmeContent: string, fn: (projectDir: string) => Promise<T>): Promise<T> {
   const projectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pnpm-readme-'))
   try {


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Perf: lazily read README only when embedding publish manifest needs it
<code>✨ Enhancement</code> <code>🧪 Tests</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

Even with the embedReadme configuration enabled, unnecessary file read operations are reduced.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Move README file I/O into exportable-manifest and guard it behind need-based checks.
• Avoid reading README.md when publish manifest already contains a readme field.
• Update exportable-manifest tests to validate README embedding via a temp project directory.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  Pack["publish/pack.ts"] --> Exportable["createExportableManifest"] --> Gate{"Embed README needed?"}
  Gate -->|"no"| Out["Exported manifest"]
  Gate -->|"yes"| Readme["readReadmeFile"] --> Disk["README.md (projectDir)"] --> Out
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Keep caller-side reading but make it conditional on manifest contents</b></summary>

- ➕ No API change to exportable-manifest options (no new embedReadme/projectDir fields)
- ➕ Avoids adding filesystem dependency/behavior inside exportable-manifest
- ➖ Caller must duplicate logic to know whether publish manifest will already have readme after overrides
- ➖ Harder to keep consistent across all call sites and future transformations

</details>

<details>
<summary><b>2. Pass a lazy loader callback (e.g. getReadme(): Promise)</b></summary>

- ➕ Preserves laziness without exporting projectDir through options
- ➕ Keeps filesystem details in the caller while avoiding eager reads
- ➖ More complex public API (functions in options), potentially harder to serialize/debug
- ➖ Still requires every caller to wire the callback correctly

</details>

**Recommendation:** The chosen approach (move README reading into createExportableManifest and gate it with `publishManifest.readme ??=`) is the simplest and most robust: it performs I/O only when the manifest actually needs a readme and keeps the decision co-located with publish-manifest construction. Ensure all callers that set `embedReadme` also provide `projectDir` (or consider defaulting `projectDir` to the `dir` parameter internally if they’re intended to match).

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>pack.ts</strong> <code>Stop eager README reads; pass embedReadme + projectDir to manifest builder</code> <code>+2/-10</code></summary>

<br/>

>Stop eager README reads; pass embedReadme + projectDir to manifest builder
>
><pre>
>• Removes the pack-layer README discovery/read and instead forwards &#x27;embedReadme&#x27; and &#x27;projectDir&#x27; into &#x27;createExportableManifest&#x27;. This defers README I/O until the manifest builder can determine whether it’s actually needed.
></pre>
>
><a href='https://github.com/pnpm/pnpm/pull/12278/files#diff-c5762820789e33dc0ee2d6dbd554980e2729aa4829245f71aaa162e5c843a30a'>releasing/commands/src/publish/pack.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>index.ts</strong> <code>Lazy README embedding inside createExportableManifest</code> <code>+13/-3</code></summary>

<br/>

>Lazy README embedding inside createExportableManifest
>
><pre>
>• Extends &#x27;MakePublishManifestOptions&#x27; with &#x27;embedReadme&#x27; and &#x27;projectDir&#x27;, adds a local &#x27;readReadmeFile()&#x27; helper, and sets &#x27;publishManifest.readme&#x27; via &#x27;??=&#x27; only when embedding is requested and the field is missing. This avoids unnecessary filesystem reads when readme is already present.
></pre>
>
><a href='https://github.com/pnpm/pnpm/pull/12278/files#diff-fc41c34cc8e82a0c97b2aeea1733ff76f7ff67f8b210b7f2f4a9a3747c87ec33'>releasing/exportable-manifest/src/index.ts</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>index.test.ts</strong> <code>Update README embedding tests to use temp project README files</code> <code>+37/-16</code></summary>

<br/>

>Update README embedding tests to use temp project README files
>
><pre>
>• Replaces string-injection of README content with a temp directory containing a real README.md file. Adds a helper to create/cleanup the temp project dir and updates assertions to use the new &#x27;embedReadme&#x27;/&#x27;projectDir&#x27; options.
></pre>
>
><a href='https://github.com/pnpm/pnpm/pull/12278/files#diff-51e227624dec98512e99007861a8afb97bfb7d461efe3fa8c0434a4395fa755b'>releasing/exportable-manifest/test/index.test.ts</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved README embedding during package publishing: README inclusion is now controlled by an `embedReadme` option, and when enabled it is discovered from `README.md` in the provided project directory.
  * Publishing avoids unnecessary disk reads when the publish manifest already contains a `readme` value.
* **Tests**
  * Updated manifest/publishing tests to create a temporary project directory with a real `README.md`, enable `embedReadme`, and verify the embedded `readme` is present in the resulting manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->