### PR TITLE
fix(pacquet): apply overrides during fresh resolution

### DIFF
--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -6112,6 +6112,140 @@ async fn fresh_install_records_lockfile_verification_for_mtime_bypassed_noop() {
     drop(dir);
 }
 
+#[tokio::test]
+async fn fresh_lockfile_applies_overrides_to_direct_dependencies() {
+    let (_dir, lockfile) = fresh_lockfile_only_with_overrides(
+        &[("@pnpm.e2e/foo", "^100.0.0")],
+        &[("@pnpm.e2e/foo@^100.0.0", "100.0.0")],
+        None,
+    )
+    .await;
+
+    assert_package_present(&lockfile, "@pnpm.e2e/foo@100.0.0");
+    assert_package_absent(&lockfile, "@pnpm.e2e/foo@100.1.0");
+}
+
+#[tokio::test]
+async fn fresh_lockfile_applies_overrides_to_transitive_dependencies() {
+    let (_dir, lockfile) = fresh_lockfile_only_with_overrides(
+        &[("@pnpm.e2e/has-foo-100.0.0-range-dep", "1.0.0")],
+        &[("@pnpm.e2e/foo@^100.0.0", "100.0.0")],
+        None,
+    )
+    .await;
+
+    assert_package_present(&lockfile, "@pnpm.e2e/has-foo-100.0.0-range-dep@1.0.0");
+    assert_package_present(&lockfile, "@pnpm.e2e/foo@100.0.0");
+    assert_package_absent(&lockfile, "@pnpm.e2e/foo@100.1.0");
+}
+
+#[tokio::test]
+async fn fresh_lockfile_resolves_catalog_protocol_in_overrides() {
+    let (_dir, lockfile) = fresh_lockfile_only_with_overrides(
+        &[("@pnpm.e2e/foo", "^100.0.0")],
+        &[("@pnpm.e2e/foo@^100.0.0", "catalog:")],
+        Some("catalog:\n  '@pnpm.e2e/foo': '100.0.0'\n"),
+    )
+    .await;
+
+    assert_package_present(&lockfile, "@pnpm.e2e/foo@100.0.0");
+    assert_package_absent(&lockfile, "@pnpm.e2e/foo@100.1.0");
+    assert_eq!(
+        lockfile
+            .overrides
+            .as_ref()
+            .and_then(|overrides| overrides.get("@pnpm.e2e/foo@^100.0.0"))
+            .map(String::as_str),
+        Some("100.0.0"),
+    );
+}
+
+async fn fresh_lockfile_only_with_overrides(
+    dependencies: &[(&str, &str)],
+    overrides: &[(&str, &str)],
+    workspace_yaml: Option<&str>,
+) -> (tempfile::TempDir, Lockfile) {
+    let mock_instance = TestRegistry::start();
+
+    let dir = tempdir().unwrap();
+    if let Some(workspace_yaml) = workspace_yaml {
+        std::fs::write(dir.path().join("pnpm-workspace.yaml"), workspace_yaml).unwrap();
+    }
+    let store_dir = dir.path().join("pacquet-store");
+    let modules_dir = dir.path().join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    for (name, spec) in dependencies {
+        manifest.add_dependency(name, spec, DependencyGroup::Prod).unwrap();
+    }
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir;
+    config.virtual_store_dir = virtual_store_dir;
+    config.registry = mock_instance.url();
+    if !overrides.is_empty() {
+        let mut map = indexmap::IndexMap::new();
+        for (selector, spec) in overrides {
+            map.insert((*selector).to_string(), (*spec).to_string());
+        }
+        config.overrides = Some(map);
+    }
+    let config = config.leak();
+
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        lockfile: None,
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: Some(false),
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        is_full_install: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: true,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+        auth_override: None,
+        resolution_observer: None,
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("lockfile-only install should succeed");
+
+    let lockfile_path = dir.path().join(Lockfile::FILE_NAME);
+    let content = std::fs::read_to_string(lockfile_path).expect("read lockfile");
+    let lockfile = serde_saphyr::from_str(&content).expect("parse lockfile");
+    (dir, lockfile)
+}
+
+fn assert_package_present(lockfile: &Lockfile, key: &str) {
+    let key: pacquet_lockfile::PackageKey = key.parse().unwrap();
+    assert!(
+        lockfile.packages.as_ref().is_some_and(|packages| packages.contains_key(&key)),
+        "expected packages to contain {key}",
+    );
+}
+
+fn assert_package_absent(lockfile: &Lockfile, key: &str) {
+    let key: pacquet_lockfile::PackageKey = key.parse().unwrap();
+    assert!(
+        lockfile.packages.as_ref().is_none_or(|packages| !packages.contains_key(&key)),
+        "expected packages not to contain {key}",
+    );
+}
+
 /// `packageExtensions` adds entries to a dependency's manifest at
 /// resolve time and the resulting lockfile records the merged shape.
 ///

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -3,11 +3,12 @@ use crate::{
     GraphToLockfileOptions, HoistedDependencies, ImporterLockfileInput,
     InstallPackageFromRegistryError, LinkVirtualStoreBins, LinkVirtualStoreBinsError,
     PrefetchContext, PrefetchingResolver, SkippedSnapshots, SymlinkDirectDependencies,
-    SymlinkDirectDependenciesError, VersionPolicyError, VirtualStoreLayout,
+    SymlinkDirectDependenciesError, VersionPolicyError, VersionsOverrider, VirtualStoreLayout,
     dependencies_graph_to_lockfile, store_init::init_store_dir_best_effort,
 };
 use dashmap::DashMap;
 use derive_more::{Display, Error};
+use indexmap::IndexMap;
 use miette::Diagnostic;
 use pacquet_catalogs_types::Catalogs;
 use pacquet_cmd_shim::{Host, LinkBinsError, link_bins};
@@ -22,7 +23,7 @@ use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_reporter::{HookLog, LogEvent, LogLevel, Reporter, Stage, StageLog};
 use pacquet_resolving_default_resolver::DefaultResolver;
 use pacquet_resolving_deps_resolver::{
-    ResolveDependencyTreeError, ResolveImporterError, ResolveImporterOptions,
+    ManifestHook, ResolveDependencyTreeError, ResolveImporterError, ResolveImporterOptions,
 };
 use pacquet_resolving_git_resolver::{GitResolver, RealGitProbe, RealGitRunner};
 use pacquet_resolving_local_resolver::{
@@ -314,6 +315,11 @@ pub enum InstallWithFreshLockfileError {
     InvalidPackageExtensionSelector(
         #[error(source)] crate::package_extender::InvalidPackageExtensionSelector,
     ),
+
+    /// A value in `pnpm.overrides` couldn't be parsed before the
+    /// fresh resolver's read-package hook was built.
+    #[diagnostic(transparent)]
+    InvalidOverrides(#[error(source)] pacquet_config_parse_overrides::ParseOverridesError),
 
     /// The first writer of a shared `(name, version)` slot dropped its
     /// completion signal without sending `true`. In practice this only
@@ -770,6 +776,69 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             .transpose()
             .map_err(InstallWithFreshLockfileError::TrustPolicyExclude)?;
 
+        let parsed_overrides = parse_config_overrides(config, &catalogs)?;
+        let resolved_overrides = parsed_overrides.as_deref().map(resolved_overrides_map);
+
+        // Build pnpm's built-in read-package hook chain for manifests
+        // that fresh resolution consumes. The order matches
+        // `createReadPackageHook`: packageExtensions first, overrides
+        // after that. The pnpmfile readPackage hook is still threaded
+        // separately and runs after this built-in hook in the resolver.
+        let package_extender = match config.package_extensions.as_ref() {
+            Some(extensions) => {
+                let extender = crate::PackageExtender::new(extensions)
+                    .map_err(InstallWithFreshLockfileError::InvalidPackageExtensionSelector)?;
+                (!extender.is_empty()).then(|| Arc::new(extender))
+            }
+            None => None,
+        };
+        let versions_overrider = parsed_overrides
+            .as_ref()
+            .map(|parsed| Arc::new(VersionsOverrider::new(parsed, lockfile_dir)));
+
+        let mut effective_importer_manifests_holder = BTreeMap::new();
+        if package_extender.is_some()
+            || versions_overrider.as_ref().is_some_and(|overrider| !overrider.is_empty())
+        {
+            for (id, manifest) in &importer_manifests {
+                let mut cloned = (*manifest).clone();
+                if let Some(extender) = package_extender.as_ref() {
+                    extender.apply(cloned.value_mut());
+                }
+                if let Some(overrider) = versions_overrider.as_ref() {
+                    let manifest_dir = cloned.path().parent().map(Path::to_path_buf);
+                    overrider.apply(&mut cloned, manifest_dir.as_deref());
+                }
+                effective_importer_manifests_holder.insert(id.clone(), cloned);
+            }
+        }
+        let importer_manifests: BTreeMap<String, &PackageManifest> =
+            if effective_importer_manifests_holder.is_empty() {
+                importer_manifests
+            } else {
+                effective_importer_manifests_holder
+                    .iter()
+                    .map(|(id, manifest)| (id.clone(), manifest))
+                    .collect()
+            };
+
+        let package_extensions_hook: Option<ManifestHook> =
+            package_extender.as_ref().map(|extender| {
+                let extender = Arc::clone(extender);
+                Arc::new(move |manifest| extender.apply_to_arc(manifest)) as ManifestHook
+            });
+        let overrides_hook: Option<ManifestHook> =
+            versions_overrider.as_ref().and_then(|overrider| {
+                if overrider.is_empty() {
+                    None
+                } else {
+                    let overrider = Arc::clone(overrider);
+                    Some(Arc::new(move |manifest| overrider.apply_to_arc(manifest, None))
+                        as ManifestHook)
+                }
+            });
+        let manifest_hook = compose_manifest_hooks(package_extensions_hook, overrides_hook);
+
         // Seed `allPreferredVersions` from every importer's manifest +
         // the wanted lockfile's snapshots (when an existing one is
         // present and is being rewritten). Mirrors upstream's
@@ -843,23 +912,6 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         let patched_dependency_hashes = config
             .patched_dependency_hashes()
             .map_err(InstallWithFreshLockfileError::CalcPatchHashes)?;
-
-        // Build the `packageExtensions` hook once per install. The
-        // closure captures an `Arc<PackageExtender>` so every importer
-        // and every concurrent resolve clones the same grouped-by-name
-        // lookup table. `None` when no extensions are configured so the
-        // resolver hot path skips the per-resolve dispatch.
-        //
-        // An invalid `@<range>` in any selector surfaces here, before
-        // the resolver runs — same intent as upstream's TypeError out
-        // of `semver.satisfies`, but lifted to install start so the
-        // user sees the bad selector before any tarballs are fetched.
-        let package_extensions_hook = match config.package_extensions.as_ref() {
-            Some(extensions) => crate::PackageExtender::new(extensions)
-                .map_err(InstallWithFreshLockfileError::InvalidPackageExtensionSelector)?
-                .into_manifest_hook(),
-            None => None,
-        };
 
         // Loop per workspace project. Each importer gets its own
         // resolve_importer call with its own `project_dir` so
@@ -943,7 +995,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             exclude_links_from_lockfile: config.exclude_links_from_lockfile,
             lockfile_dir: lockfile_dir.to_path_buf(),
             peers_suffix_max_length,
-            manifest_hook: package_extensions_hook.clone(),
+            manifest_hook: manifest_hook.clone(),
             pnpmfile_hook,
             read_package_log,
             pick_lowest_direct,
@@ -951,17 +1003,15 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             // Hand the resolver the prior lockfile so it can reuse
             // already-resolved subtrees instead of re-resolving from the
             // registry (see pacquet/plans/LOCKFILE_RESOLUTION_REUSE.md).
-            // Withhold it when `packageExtensions` drifted: a changed
-            // extension rewrites packages' dependency sets, so the recorded
-            // subtree is stale — pnpm likewise invalidates the lockfile on a
-            // settings change. (`overrides` are applied to the manifest
-            // before the importer-level reuse gate re-checks the specifier;
-            // a follow-up should also guard transitive reuse against
-            // overrides drift.)
+            // Withhold it when packageExtensions or overrides drifted:
+            // both settings rewrite package dependency sets, so the
+            // recorded subtree is stale. pnpm likewise invalidates the
+            // lockfile on these settings changes.
             wanted_lockfile: wanted_lockfile
                 .filter(|lockfile| {
                     lockfile.package_extensions_checksum
                         == compute_package_extensions_checksum(config)
+                        && overrides_match(lockfile.overrides.as_ref(), resolved_overrides.as_ref())
                 })
                 .cloned()
                 .map(Arc::new),
@@ -1039,7 +1089,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                     modules_dir: Some(importer_modules_dir),
                     peers_suffix_max_length,
                     catalog_server: false,
-                    manifest_hook: package_extensions_hook.clone(),
+                    manifest_hook: manifest_hook.clone(),
                     pnpmfile_hook: None,
                 }
             },
@@ -1107,15 +1157,16 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         // there is no `node_modules`, `.modules.yaml`, or current
         // lockfile — matching pnpm's lockfileOnly resolve pass.
         if lockfile_only {
-            let built_lockfile = build_fresh_lockfile(
+            let built_lockfile = build_fresh_lockfile(FreshLockfileBuildOptions {
                 config,
-                &importer_manifests,
-                &merged_graph,
-                &direct_by_importer,
-                &catalogs,
-                pnpmfile_checksum.as_deref(),
-                patched_dependency_hashes.as_ref(),
-            );
+                importer_manifests: &importer_manifests,
+                graph: &merged_graph,
+                direct_by_importer: &direct_by_importer,
+                resolved_overrides: resolved_overrides.clone(),
+                catalogs: &catalogs,
+                pnpmfile_checksum: pnpmfile_checksum.as_deref(),
+                patched_dependency_hashes: patched_dependency_hashes.as_ref(),
+            });
             let (wanted_lockfile, can_record_lockfile_verification) = if config.lockfile {
                 let can_record_lockfile_verification = save_wanted_lockfile(
                     &built_lockfile,
@@ -1239,15 +1290,16 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         // [`Self::wanted_lockfile`], which is the *previous* run's
         // lockfile threaded in for preferred-versions seeding.
         let phase_start = std::time::Instant::now();
-        let built_lockfile = build_fresh_lockfile(
+        let built_lockfile = build_fresh_lockfile(FreshLockfileBuildOptions {
             config,
-            &importer_manifests,
-            &merged_graph,
-            &direct_by_importer,
-            &catalogs,
-            pnpmfile_checksum.as_deref(),
-            patched_dependency_hashes.as_ref(),
-        );
+            importer_manifests: &importer_manifests,
+            graph: &merged_graph,
+            direct_by_importer: &direct_by_importer,
+            resolved_overrides: resolved_overrides.clone(),
+            catalogs: &catalogs,
+            pnpmfile_checksum: pnpmfile_checksum.as_deref(),
+            patched_dependency_hashes: patched_dependency_hashes.as_ref(),
+        });
         tracing::info!(
             target: "pacquet::install::phase",
             phase = "build_fresh_lockfile",
@@ -1749,6 +1801,60 @@ async fn save_wanted_lockfile(
     Ok(result.is_null())
 }
 
+fn parse_config_overrides(
+    config: &Config,
+    catalogs: &Catalogs,
+) -> Result<
+    Option<Vec<pacquet_config_parse_overrides::VersionOverride>>,
+    InstallWithFreshLockfileError,
+> {
+    match config.overrides.as_ref() {
+        Some(map) if !map.is_empty() => {
+            pacquet_config_parse_overrides::parse_overrides_iter(map.iter(), catalogs)
+                .map(Some)
+                .map_err(InstallWithFreshLockfileError::InvalidOverrides)
+        }
+        _ => Ok(None),
+    }
+}
+
+fn resolved_overrides_map(
+    parsed: &[pacquet_config_parse_overrides::VersionOverride],
+) -> IndexMap<String, String> {
+    parsed.iter().map(|entry| (entry.selector.clone(), entry.new_bare_specifier.clone())).collect()
+}
+
+fn overrides_match(
+    lockfile: Option<&IndexMap<String, String>>,
+    config: Option<&IndexMap<String, String>>,
+) -> bool {
+    let lockfile = lockfile.filter(|map| !map.is_empty());
+    let config = config.filter(|map| !map.is_empty());
+    match (lockfile, config) {
+        (None, None) => true,
+        (Some(lockfile), Some(config)) => {
+            lockfile.len() == config.len()
+                && lockfile.iter().all(|(key, value)| {
+                    config.get(key).is_some_and(|config_value| config_value == value)
+                })
+        }
+        _ => false,
+    }
+}
+
+fn compose_manifest_hooks(
+    first: Option<ManifestHook>,
+    second: Option<ManifestHook>,
+) -> Option<ManifestHook> {
+    match (first, second) {
+        (None, None) => None,
+        (Some(hook), None) | (None, Some(hook)) => Some(hook),
+        (Some(first), Some(second)) => {
+            Some(Arc::new(move |manifest| second(first(manifest))) as ManifestHook)
+        }
+    }
+}
+
 /// Build the [`Lockfile`] for `<lockfile_dir>/pnpm-lock.yaml` from the
 /// merged resolver graph + per-importer direct-deps maps.
 ///
@@ -1757,18 +1863,29 @@ async fn save_wanted_lockfile(
 /// then the
 /// [`writeLockfiles`](https://github.com/pnpm/pnpm/blob/094aa6e57b/lockfile/fs/src/write.ts#L133)
 /// fan-out, with [`dependencies_graph_to_lockfile()`] doing the wire-shape lifting.
-fn build_fresh_lockfile(
-    config: &Config,
-    importer_manifests: &BTreeMap<String, &PackageManifest>,
-    graph: &pacquet_resolving_deps_resolver::DependenciesGraph,
-    direct_by_importer: &BTreeMap<
-        String,
-        BTreeMap<String, pacquet_resolving_deps_resolver::DepPath>,
-    >,
-    catalogs: &pacquet_catalogs_types::Catalogs,
-    pnpmfile_checksum: Option<&str>,
-    patched_dependency_hashes: Option<&BTreeMap<String, String>>,
-) -> Lockfile {
+struct FreshLockfileBuildOptions<'a> {
+    config: &'a Config,
+    importer_manifests: &'a BTreeMap<String, &'a PackageManifest>,
+    graph: &'a pacquet_resolving_deps_resolver::DependenciesGraph,
+    direct_by_importer:
+        &'a BTreeMap<String, BTreeMap<String, pacquet_resolving_deps_resolver::DepPath>>,
+    resolved_overrides: Option<IndexMap<String, String>>,
+    catalogs: &'a pacquet_catalogs_types::Catalogs,
+    pnpmfile_checksum: Option<&'a str>,
+    patched_dependency_hashes: Option<&'a BTreeMap<String, String>>,
+}
+
+fn build_fresh_lockfile(opts: FreshLockfileBuildOptions<'_>) -> Lockfile {
+    let FreshLockfileBuildOptions {
+        config,
+        importer_manifests,
+        graph,
+        direct_by_importer,
+        resolved_overrides,
+        catalogs,
+        pnpmfile_checksum,
+        patched_dependency_hashes,
+    } = opts;
     let mut importers = BTreeMap::new();
     for (id, manifest) in importer_manifests {
         let direct = direct_by_importer.get(id).cloned().unwrap_or_default();
@@ -1787,10 +1904,7 @@ fn build_fresh_lockfile(
         peers_suffix_max_length: (config.peers_suffix_max_length
             != pacquet_config::default_peers_suffix_max_length())
         .then_some(config.peers_suffix_max_length),
-        overrides: config
-            .overrides
-            .as_ref()
-            .map(|map| map.iter().map(|(key, value)| (key.clone(), value.clone())).collect()),
+        overrides: resolved_overrides,
         ignored_optional_dependencies: config.ignored_optional_dependencies.clone(),
         patched_dependencies: patched_dependency_hashes.cloned(),
         package_extensions_checksum: compute_package_extensions_checksum(config),

--- a/pacquet/crates/package-manager/src/overrides.rs
+++ b/pacquet/crates/package-manager/src/overrides.rs
@@ -4,13 +4,13 @@
 //! Pacquet port of upstream's
 //! [`createVersionsOverrider`](https://github.com/pnpm/pnpm/blob/0d88df854f/hooks/read-package-hook/src/createVersionsOverrider.ts).
 //! Upstream's hook is a `readPackageHook` that fires on every manifest
-//! read during resolution; in pacquet's frozen-lockfile-only world the
-//! same hook only matters for the root project's manifest, since
-//! that's the only manifest the freshness check inspects. The shape of
-//! the rewrite — generic vs. parent-scoped overrides, `-` deletion,
-//! `link:` / `file:` local targets, range intersection via semver — is
-//! preserved so the lockfile written by pnpm (post-override
-//! specifiers) lines up with the manifest the freshness check sees.
+//! read during resolution. Pacquet uses the same rewrite both for
+//! frozen-lockfile freshness checks and for the fresh resolver's
+//! manifest hook. The shape of the rewrite — generic vs.
+//! parent-scoped overrides, `-` deletion, `link:` / `file:` local
+//! targets, range intersection via semver — is preserved so the
+//! resolved dependency graph and lockfile match pnpm's post-override
+//! manifest view.
 //!
 //! What's intentionally **not** ported yet:
 //! - `peerDependencies` mutation. Upstream promotes a peer to
@@ -30,26 +30,29 @@ use node_semver::{Range, Version};
 use pacquet_config_parse_overrides::{PackageSelector, VersionOverride};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use serde_json::Value;
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 /// In-memory hook that applies the parsed `pnpm.overrides` set to a
 /// manifest. Cheap to construct — partitioning the overrides into the
 /// parent-scoped vs. generic buckets happens once, and each call to
 /// [`Self::apply`] walks the dep maps in place.
-pub struct VersionsOverrider<'a> {
+pub struct VersionsOverrider {
     /// Overrides whose key carries a `parent>child` shape — only
     /// applied when the manifest being rewritten matches the parent
     /// half (name + optional range).
-    parent_scoped: Vec<ResolvedOverride<'a>>,
+    parent_scoped: Vec<ResolvedOverride>,
     /// Generic overrides (no parent half). Apply to every manifest.
-    generic: Vec<ResolvedOverride<'a>>,
+    generic: Vec<ResolvedOverride>,
 }
 
 /// `VersionOverride` augmented with a pre-parsed `LocalTarget` for
 /// the local-protocol forms. Splitting once at construction time
 /// avoids re-parsing the prefix on every manifest read.
-struct ResolvedOverride<'a> {
-    inner: &'a VersionOverride,
+struct ResolvedOverride {
+    inner: VersionOverride,
     local_target: Option<LocalTarget>,
 }
 
@@ -74,15 +77,15 @@ struct LocalTarget {
     specified_via_relative_path: bool,
 }
 
-impl<'a> VersionsOverrider<'a> {
+impl VersionsOverrider {
     /// Build the hook from the parsed overrides set produced by
     /// [`pacquet_config_parse_overrides::parse_overrides`].
-    pub fn new(overrides: &'a [VersionOverride], root_dir: &Path) -> Self {
+    pub fn new(overrides: &[VersionOverride], root_dir: &Path) -> Self {
         let mut parent_scoped = Vec::new();
         let mut generic = Vec::new();
         for override_entry in overrides {
             let resolved = ResolvedOverride {
-                inner: override_entry,
+                inner: override_entry.clone(),
                 local_target: parse_local_target(&override_entry.new_bare_specifier, root_dir),
             };
             if override_entry.parent_pkg.is_some() {
@@ -92,6 +95,11 @@ impl<'a> VersionsOverrider<'a> {
             }
         }
         VersionsOverrider { parent_scoped, generic }
+    }
+
+    /// `true` when the hook has no entries and can be skipped.
+    pub fn is_empty(&self) -> bool {
+        self.parent_scoped.is_empty() && self.generic.is_empty()
     }
 
     /// Apply the override set to `manifest` in place. `manifest_dir`
@@ -104,27 +112,12 @@ impl<'a> VersionsOverrider<'a> {
     /// Mirrors upstream's `(manifest, dir) => { ... }` body returned
     /// by `createVersionsOverrider`.
     pub fn apply(&self, manifest: &mut PackageManifest, manifest_dir: Option<&Path>) {
-        let manifest_name = manifest.value().get("name").and_then(Value::as_str).map(str::to_owned);
-        let manifest_version =
-            manifest.value().get("version").and_then(Value::as_str).map(str::to_owned);
+        self.apply_to_value(manifest.value_mut(), manifest_dir);
+    }
 
-        // Mirrors upstream's `versionOverrides.filter(({ parentPkg }) => ...)`
-        // restricting the parent-scoped set to those whose `parentPkg`
-        // matches *this* manifest.
-        let applicable_parent_scoped: Vec<&ResolvedOverride<'_>> = self
-            .parent_scoped
-            .iter()
-            .filter(|entry| {
-                let Some(parent) = entry.inner.parent_pkg.as_ref() else { return false };
-                let name_matches = manifest_name.as_deref() == Some(parent.name.as_str());
-                let range_matches = match (parent.bare_specifier.as_deref(), &manifest_version) {
-                    (None, _) => true,
-                    (Some(_), None) => false,
-                    (Some(range), Some(version)) => semver_satisfies(version, range),
-                };
-                name_matches && range_matches
-            })
-            .collect();
+    /// Apply the override set to a manifest JSON value in place.
+    pub fn apply_to_value(&self, manifest: &mut Value, manifest_dir: Option<&Path>) {
+        let applicable_parent_scoped = self.applicable_parent_scoped(manifest);
 
         // Upstream's `overrideDepsOfPkg` mutates the four dep buckets
         // (`dependencies`, `optionalDependencies`, `devDependencies`,
@@ -134,20 +127,70 @@ impl<'a> VersionsOverrider<'a> {
         for group in
             [DependencyGroup::Prod, DependencyGroup::Optional, DependencyGroup::Dev].iter().copied()
         {
-            self.override_group(
-                manifest.value_mut(),
-                group,
-                &applicable_parent_scoped,
-                manifest_dir,
-            );
+            self.override_group(manifest, group, &applicable_parent_scoped, manifest_dir);
         }
+    }
+
+    /// Apply overrides to the resolver's shared manifest value,
+    /// cloning only when at least one configured override can rewrite
+    /// the manifest.
+    pub fn apply_to_arc(&self, manifest: Arc<Value>, manifest_dir: Option<&Path>) -> Arc<Value> {
+        if self.is_empty() || !self.has_applicable_override(&manifest) {
+            return manifest;
+        }
+        let mut cloned = (*manifest).clone();
+        self.apply_to_value(&mut cloned, manifest_dir);
+        Arc::new(cloned)
+    }
+
+    fn applicable_parent_scoped<'b>(&'b self, manifest: &Value) -> Vec<&'b ResolvedOverride> {
+        let manifest_name = manifest.get("name").and_then(Value::as_str);
+        let manifest_version = manifest.get("version").and_then(Value::as_str);
+
+        self.parent_scoped
+            .iter()
+            .filter(|entry| {
+                let Some(parent) = entry.inner.parent_pkg.as_ref() else { return false };
+                let name_matches = manifest_name == Some(parent.name.as_str());
+                let range_matches = match (parent.bare_specifier.as_deref(), manifest_version) {
+                    (None, _) => true,
+                    (Some(_), None) => false,
+                    (Some(range), Some(version)) => semver_satisfies(version, range),
+                };
+                name_matches && range_matches
+            })
+            .collect()
+    }
+
+    fn has_applicable_override(&self, value: &Value) -> bool {
+        let applicable_parent_scoped = self.applicable_parent_scoped(value);
+        [DependencyGroup::Prod, DependencyGroup::Optional, DependencyGroup::Dev]
+            .iter()
+            .copied()
+            .any(|group| self.group_has_override(value, group, &applicable_parent_scoped))
+    }
+
+    fn group_has_override(
+        &self,
+        value: &Value,
+        group: DependencyGroup,
+        applicable_parent_scoped: &[&ResolvedOverride],
+    ) -> bool {
+        let key: &'static str = group.into();
+        let Some(map) = value.get(key).and_then(Value::as_object) else { return false };
+
+        map.iter().any(|(name, spec)| {
+            spec.as_str().is_some_and(|spec| {
+                self.choose_override(applicable_parent_scoped, name, spec).is_some()
+            })
+        })
     }
 
     fn override_group(
         &self,
         value: &mut Value,
         group: DependencyGroup,
-        applicable_parent_scoped: &[&ResolvedOverride<'_>],
+        applicable_parent_scoped: &[&ResolvedOverride],
         manifest_dir: Option<&Path>,
     ) {
         let key: &'static str = group.into();
@@ -161,10 +204,7 @@ impl<'a> VersionsOverrider<'a> {
             .collect();
 
         for (name, spec) in entries {
-            let Some(chosen) = self
-                .pick_most_specific(applicable_parent_scoped, &name, &spec)
-                .or_else(|| self.pick_most_specific_generic(&name, &spec))
-            else {
+            let Some(chosen) = self.choose_override(applicable_parent_scoped, &name, &spec) else {
                 continue;
             };
 
@@ -183,13 +223,23 @@ impl<'a> VersionsOverrider<'a> {
         }
     }
 
-    fn pick_most_specific<'b>(
+    fn choose_override<'b>(
         &'b self,
-        candidates: &[&'b ResolvedOverride<'a>],
+        applicable_parent_scoped: &[&'b ResolvedOverride],
         dep_name: &str,
         dep_spec: &str,
-    ) -> Option<&'b ResolvedOverride<'a>> {
-        let mut matching: Vec<&'b ResolvedOverride<'a>> = candidates
+    ) -> Option<&'b ResolvedOverride> {
+        self.pick_most_specific(applicable_parent_scoped, dep_name, dep_spec)
+            .or_else(|| self.pick_most_specific_generic(dep_name, dep_spec))
+    }
+
+    fn pick_most_specific<'b>(
+        &'b self,
+        candidates: &[&'b ResolvedOverride],
+        dep_name: &str,
+        dep_spec: &str,
+    ) -> Option<&'b ResolvedOverride> {
+        let mut matching: Vec<&'b ResolvedOverride> = candidates
             .iter()
             .copied()
             .filter(|entry| matches_target(&entry.inner.target_pkg, dep_name, dep_spec))
@@ -202,8 +252,8 @@ impl<'a> VersionsOverrider<'a> {
         &self,
         dep_name: &str,
         dep_spec: &str,
-    ) -> Option<&ResolvedOverride<'a>> {
-        let mut matching: Vec<&ResolvedOverride<'a>> = self
+    ) -> Option<&ResolvedOverride> {
+        let mut matching: Vec<&ResolvedOverride> = self
             .generic
             .iter()
             .filter(|entry| matches_target(&entry.inner.target_pkg, dep_name, dep_spec))
@@ -225,7 +275,7 @@ fn matches_target(target: &PackageSelector, dep_name: &str, dep_spec: &str) -> b
 /// `sort((a, b) => isIntersectingRange(b.targetPkg.bareSpecifier ?? '', a.targetPkg.bareSpecifier ?? '') ? -1 : 1)[0]`.
 /// The intuition is `b ⊃ a ⇒ a sorts before b`, so a narrower target
 /// like `foo@1.2.3` wins over the broader `foo@^1`.
-fn sort_by_specificity(matching: &mut [&ResolvedOverride<'_>]) {
+fn sort_by_specificity(matching: &mut [&ResolvedOverride]) {
     matching.sort_by(|lhs, rhs| {
         let lhs_spec = lhs.inner.target_pkg.bare_specifier.as_deref().unwrap_or("");
         let rhs_spec = rhs.inner.target_pkg.bare_specifier.as_deref().unwrap_or("");


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix fresh lockfile resolution to apply pnpm.overrides (including catalog:)
<code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>🕐 40+ Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Apply <b><i>pnpm.overrides</i></b> via a resolver manifest-hook during fresh resolution.
• Invalidate lockfile reuse when recorded overrides differ from current config.
• Add lockfile-only tests covering direct, transitive, and <b><i>catalog:</i></b> override resolution.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  C["Config (overrides)"] --> I["InstallWithFreshLockfile"] --> H["Manifest hook chain"] --> R["Deps resolver"] --> G["Dependency graph"] --> B["Build fresh lockfile"] --> L[("pnpm-lock.yaml")]
  K["Catalogs"] --> I
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The approach mirrors pnpm’s built-in read-package hook order (packageExtensions → overrides) and applies overrides at the correct layer (manifest read during resolution), ensuring both chosen versions and the resulting lockfile match pnpm semantics. Resolved overrides are persisted (including `catalog:` expansion) and lockfile reuse is safely invalidated on overrides drift, which is the right correctness tradeoff.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>overrides.rs</strong> <code>Make VersionsOverrider Arc-friendly and support hook-style application</code> <code>+104/-54</code></summary>

<br/>

>Make VersionsOverrider Arc-friendly and support hook-style application
>
><pre>
>• Refactors &#x27;VersionsOverrider&#x27; to own override entries (no lifetime), adds &#x27;is_empty&#x27;, and introduces &#x27;apply_to_arc&#x27;/&#x27;apply_to_value&#x27; so the resolver can cheaply apply overrides to shared manifest values with clone-on-write behavior. Tidies internal selection logic via &#x27;choose_override&#x27; and extracts parent-scope matching into a helper.
></pre>
>
><a href='https://github.com/pnpm/pnpm/pull/12283/files#diff-55d1198d547315cfb3e5022a34ec9db3c17998b553adaa219e5754ff0b50efaf'>pacquet/crates/package-manager/src/overrides.rs</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>install_with_fresh_lockfile.rs</strong> <code>Compose overrides into fresh resolver manifest hook and lockfile reuse checks</code> <code>+174/-60</code></summary>

<br/>

>Compose overrides into fresh resolver manifest hook and lockfile reuse checks
>
><pre>
>• Parses and resolves &#x27;config.overrides&#x27; (including catalogs), builds a composed manifest-hook chain (packageExtensions then overrides), and applies it during fresh resolution. Also gates reuse of an existing wanted lockfile on overrides equality and writes the resolved overrides map into newly built lockfiles via refactored build options.
></pre>
>
><a href='https://github.com/pnpm/pnpm/pull/12283/files#diff-046eb13d65950951e377846c8a970256f4ead3071c9c71ac13246efa1520cf0b'>pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>tests.rs</strong> <code>Add fresh lockfile-only override resolution tests</code> <code>+134/-0</code></summary>

<br/>

>Add fresh lockfile-only override resolution tests
>
><pre>
>• Adds async tests verifying that fresh lockfile generation applies overrides to direct and transitive dependencies. Includes a &#x27;catalog:&#x27; override case and asserts the lockfile records the resolved override value, plus shared helpers for creating a temp project/config and checking lockfile contents.
></pre>
>
><a href='https://github.com/pnpm/pnpm/pull/12283/files#diff-d65401e072dbf60d86e0cef0f67eb4dfaf10fbdcd5d7258faf99decaa56564ba'>pacquet/crates/package-manager/src/install/tests.rs</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>