### PR TITLE
docs(pnpr): document frozen short-circuit response shape

### DIFF
--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -237,8 +237,12 @@ pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response 
         };
     }
 
-    // Short-circuit paths that produce the whole lockfile without an
-    // incremental tree walk: nothing to stream, so emit only `done`.
+    // Short-circuit paths produce the whole lockfile without an
+    // incremental tree walk, so emit only `done`. Keep these paths
+    // frame-free unless the protocol lets the client consume `done`
+    // without waiting for synthetic package frames: the benchmarked
+    // pnpm/pnpm#12259 experiment regressed hot-store installs because
+    // prefetch had little useful work to overlap.
     if let Some(lockfile) = resolve::fresh_frozen_input_lockfile(config, &request) {
         return ndjson_single_frame(&done_frame(&lockfile));
     }


### PR DESCRIPTION
## Summary

- document that pnpr frozen/cache short-circuit responses intentionally emit only `done`
- record why synthetic package frames should not be reintroduced unless the protocol can deliver `done` without waiting on them

## Reason

The package-frame streaming experiment in https://github.com/pnpm/pnpm/pull/12259 regressed hot-store pnpr installs. It helped cold-store rows slightly, but hot-store rows paid extra sort/serialize/transfer/parse overhead before `done`, with little useful prefetch work to overlap.

## Verification

- `git diff --check HEAD~1..HEAD`
- pre-push hook passed while pushing `f39d6cc20d`

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal documentation for resolver behavior regarding short-circuit paths and frame emission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->