### PR TITLE
fix(bins.resolver): reject reserved manifest bin names (GHSA-4gxm-v5v7-fqc4)

### DIFF
--- a/.changeset/strange-bin-segments.md
+++ b/.changeset/strange-bin-segments.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/bins.resolver": patch
+"pnpm": patch
+---
+
+Reject reserved manifest `bin` names (`""`, `"."`, `".."`, and scoped forms such as `@scope/..`) when resolving a package's bins. These names previously passed the bin-name guard and, when joined to the global bin directory during global remove/update/add operations, could resolve to the global bin directory itself or its parent and have it recursively deleted.

--- a/bins/resolver/src/index.ts
+++ b/bins/resolver/src/index.ts
@@ -66,7 +66,13 @@ function commandsFromBin (bin: PackageBin, pkgName: string, pkgPath: string): Co
     const binName = commandName[0] === '@'
       ? commandName.slice(commandName.indexOf('/') + 1)
       : commandName
-    // Validate: must be safe (no path traversal) - only allow URL-safe chars or $
+    // Validate: must be safe (no path traversal). Reject empty and the
+    // filesystem-relative names "." and ".." (these survive encodeURIComponent
+    // unchanged but resolve to the bin directory itself or its parent when
+    // joined to a target dir), then only allow URL-safe chars or $.
+    if (binName === '' || binName === '.' || binName === '..') {
+      continue
+    }
     if (binName !== encodeURIComponent(binName) && binName !== '$') {
       continue
     }

--- a/bins/resolver/test/index.ts
+++ b/bins/resolver/test/index.ts
@@ -147,6 +147,26 @@ test('skip scoped bin names with path traversal', async () => {
   ])
 })
 
+test('skip reserved bin names', async () => {
+  expect(
+    await getBinsFromPackageManifest({
+      name: 'malicious',
+      version: '1.0.0',
+      bin: {
+        '': './empty.js',
+        '.': './dot.js',
+        '..': './dot-dot.js',
+        '@scope/..': './scoped-dot-dot.js',
+        good: './good',
+      },
+    }, process.cwd())).toStrictEqual([
+    {
+      name: 'good',
+      path: path.resolve('good'),
+    },
+  ])
+})
+
 test('skip directories.bin with path traversal', async () => {
   // Security test: malicious packages can try to escape the package root
   // using directories.bin to chmod files at arbitrary locations

--- a/global/commands/test/globalRemove.test.ts
+++ b/global/commands/test/globalRemove.test.ts
@@ -1,0 +1,47 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { expect, jest, test } from '@jest/globals'
+
+const removeBin = jest.fn<(cmd: string) => Promise<void>>().mockResolvedValue(undefined)
+
+jest.unstable_mockModule('@pnpm/bins.remover', () => ({ removeBin }))
+
+const { handleGlobalRemove } = await import('../src/globalRemove.js')
+
+// A malicious global package whose manifest declares reserved bin keys must not
+// reach the deletion sink: `path.join(globalBinDir, '.')` is the bin directory
+// itself and `path.join(globalBinDir, '..')` is its parent, so removing either
+// would wipe out unrelated files. Only the safe `good` shim may be deleted.
+test('global remove ignores reserved manifest bin names', async () => {
+  const globalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'global-remove-'))
+  const globalBinDir = path.join(globalDir, 'bin')
+  const installDir = path.join(globalDir, 'install')
+  const depDir = path.join(installDir, 'node_modules', 'evil')
+  fs.mkdirSync(depDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(installDir, 'package.json'),
+    JSON.stringify({ name: 'global', version: '1.0.0', dependencies: { evil: '1.0.0' } })
+  )
+  fs.writeFileSync(
+    path.join(depDir, 'package.json'),
+    JSON.stringify({
+      name: 'evil',
+      version: '1.0.0',
+      bin: {
+        '': './empty.js',
+        '.': './dot.js',
+        '..': './dot-dot.js',
+        '@scope/..': './scoped-dot-dot.js',
+        good: './good.js',
+      },
+    })
+  )
+  fs.symlinkSync(installDir, path.join(globalDir, 'hash'))
+
+  await handleGlobalRemove({ globalPkgDir: globalDir, bin: globalBinDir }, ['evil'])
+
+  expect(removeBin).toHaveBeenCalledTimes(1)
+  expect(removeBin).toHaveBeenCalledWith(path.join(globalBinDir, 'good'))
+})

--- a/pacquet/crates/cmd-shim/src/bin_resolver.rs
+++ b/pacquet/crates/cmd-shim/src/bin_resolver.rs
@@ -171,11 +171,15 @@ fn commands_from_bin(bin: &Value, pkg_name: Option<&str>, pkg_path: &Path) -> Ve
 ///
 /// `encodeURIComponent` leaves the following bytes unescaped:
 /// `A-Z a-z 0-9 - _ . ! ~ * ' ( )`.
+///
+/// `.` and `..` survive `encodeURIComponent` unchanged but resolve to the bin
+/// directory itself or its parent when joined to a target dir, so they are
+/// rejected explicitly.
 fn is_safe_bin_name(name: &str) -> bool {
     if name == "$" {
         return true;
     }
-    if name.is_empty() {
+    if name.is_empty() || name == "." || name == ".." {
         return false;
     }
     name.bytes().all(|byte| {

--- a/pacquet/crates/cmd-shim/src/bin_resolver/tests.rs
+++ b/pacquet/crates/cmd-shim/src/bin_resolver/tests.rs
@@ -362,6 +362,28 @@ fn empty_bin_key_is_rejected() {
     assert_eq!(commands[0].name, "good");
 }
 
+/// The relative names `.` and `..` survive the URL-safe guard's character
+/// set (`.` is unescaped by `encodeURIComponent`) but resolve to the bin
+/// directory itself or its parent when joined to a target dir, so
+/// `is_safe_bin_name` must reject them. Scoped forms like `@scope/..`
+/// collapse to `..` after the scope strip and must be rejected too.
+#[test]
+fn reserved_relative_bin_names_are_rejected() {
+    let manifest = json!({
+        "name": "malicious",
+        "version": "1.0.0",
+        "bin": {
+            ".": "dot.js",
+            "..": "dotdot.js",
+            "@scope/..": "scoped-dotdot.js",
+            "good": "good.js",
+        },
+    });
+    let commands = get_bins_from_package_manifest::<Host>(&manifest, Path::new("/p"));
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].name, "good");
+}
+
 /// [`lexical_normalize`] drops `.` (CurDir) segments. This is a direct
 /// test on the helper. The integration-style test below covers the same
 /// arm via `directories.bin`, but a direct assertion makes the CurDir


### PR DESCRIPTION
## Summary

Manifest `bin` object keys such as `""`, `"."`, `".."`, and scoped forms like `@scope/..` (which strips to `..`) passed pnpm's bin-name guard. The guard at `bins/resolver/src/index.ts` only required `binName === encodeURIComponent(binName)`, and `encodeURIComponent` leaves `.` unchanged — so these names were accepted.

When a package carrying such a key is installed globally, later **global remove / update / add-replacement** flows re-derive the name from the installed manifest (`scanGlobalPackages` → `getInstalledBinNames` → `getBinsFromPackageManifest`) and pass `path.join(globalBinDir, binName)` to `removeBin` (a recursive `rimraf`):

- `"."` → resolves to the global bin directory itself
- `".."` → resolves to its **parent**

So a malicious package could cause pnpm to recursively delete the global bin directory or its parent.

## Fix

- `bins/resolver/src/index.ts` rejects empty, `.`, and `..` bin names after scope stripping, before the URL-safe check.
- `pacquet/crates/cmd-shim/src/bin_resolver.rs` mirrors the same rejection (`is_safe_bin_name` already rejected empty; `.`/`..` slipped through because `.` is in the URL-safe byte set). Per the monorepo sync rule, this is the shared resolver/linker boundary pacquet's dependency-management commands also use.

## Tests

- `bins/resolver/test/index.ts` — covers `""`, `.`, `..`, and `@scope/..`.
- `global/commands/test/globalRemove.test.ts` — drives the **real** resolver/scan path against a temp global install and asserts the deletion sink only ever receives `path.join(globalBinDir, "good")` (without the fix it would call `removeBin` four times).
- `pacquet/crates/cmd-shim/src/bin_resolver/tests.rs` — parity coverage for `.`, `..`, and `@scope/..`.

## Notes

This addresses advisory `GHSA-4gxm-v5v7-fqc4` / `CAND-PNPM-085`. Opened as a **draft** so disclosure timing can be decided before this is made visible — note that a draft PR on the public repo is still publicly visible.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability in bin resolution that could enable unintended deletion of the bin directory and parent directories during global package operations. Reserved bin names (empty string, `.`, `..`, and scoped variants) are now properly rejected.

* **Tests**
  * Added test coverage to verify reserved bin names are correctly filtered during package bin resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->