### PR TITLE
test: expect the trust-aware warning for project .npmrc registry env placeholders

### DIFF
--- a/pnpm/test/getConfig.test.ts
+++ b/pnpm/test/getConfig.test.ts
@@ -49,7 +49,7 @@ afterEach(() => {
   jest.mocked(console.warn).mockRestore()
 })
 
-test('console a warning when the .npmrc has an env variable that does not exist', async () => {
+test('console a warning when the project .npmrc sets a request destination from an env variable', async () => {
   prepare()
 
   fs.writeFileSync('.npmrc', 'registry=${ENV_VAR_123}', 'utf8')
@@ -61,7 +61,7 @@ test('console a warning when the .npmrc has an env variable that does not exist'
     excludeReporter: false,
   })
 
-  expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to replace env in config: ${ENV_VAR_123}'))
+  expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Ignored project-level request destination "registry"'))
 })
 
 describe('calcPnpmfilePathsOfPluginDeps', () => {


### PR DESCRIPTION
## What

Updates `pnpm/test/getConfig.test.ts` to expect the new warning emitted when a project-level `.npmrc` sets `registry` from an environment variable placeholder.

## Why

pnpm/pnpm#12291 made env expansion trust-aware: a project `.npmrc` no longer expands `${...}` placeholders in request destinations. `registry=${ENV_VAR_123}` now produces `Ignored project-level request destination "registry" ...` instead of `Failed to replace env in config: ...`, which is the warning this test still asserted. The equivalent test in `config/reader/test/index.ts` was updated in that PR, but this parallel test in the `pnpm` package was missed, so it fails on main.

The test name is also updated, since the warning no longer depends on whether the env variable exists.

No changeset: test-only change.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for `.npmrc` environment variable handling to better reflect expected behavior when request destinations are set via environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->