### PR TITLE
fix(exec): skip deps auto-install without manifest

### DIFF
--- a/.changeset/deps-status-no-manifest.md
+++ b/.changeset/deps-status-no-manifest.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/exec.commands": patch
+"pnpm": patch
+---
+
+Avoid running dependency-status auto-install when the dependency status is unavailable without a project manifest.

--- a/exec/commands/src/runDepsStatusCheck.ts
+++ b/exec/commands/src/runDepsStatusCheck.ts
@@ -18,7 +18,8 @@ export async function runDepsStatusCheck (opts: RunDepsStatusCheckOptions): Prom
   opts.ignoredWorkspaceStateSettings = ignoredWorkspaceStateSettings
 
   const { upToDate, issue, workspaceState } = await checkDepsStatus(opts)
-  if (upToDate) return
+  if (upToDate === true) return
+  if (upToDate === undefined && opts.allProjects == null && opts.rootProjectManifest == null) return
 
   const command = ['install', ...createInstallArgs(workspaceState?.settings)]
   const install = runPnpmCli.bind(null, command, { cwd: opts.dir, reporter: opts.reporter })

--- a/exec/commands/test/runDepsStatusCheck.test.ts
+++ b/exec/commands/test/runDepsStatusCheck.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import type { checkDepsStatus as checkDepsStatusFn } from '@pnpm/deps.status'
+import type { runPnpmCli as runPnpmCliFn } from '@pnpm/exec.pnpm-cli-runner'
+
+const checkDepsStatus = jest.fn<typeof checkDepsStatusFn>()
+const runPnpmCli = jest.fn<typeof runPnpmCliFn>()
+
+jest.unstable_mockModule('@pnpm/deps.status', () => ({
+  checkDepsStatus,
+}))
+
+jest.unstable_mockModule('@pnpm/exec.pnpm-cli-runner', () => ({
+  runPnpmCli,
+}))
+
+jest.unstable_mockModule('@pnpm/logger', () => ({
+  globalWarn: jest.fn(),
+}))
+
+jest.unstable_mockModule('@inquirer/prompts', () => ({
+  confirm: jest.fn(),
+}))
+
+const { runDepsStatusCheck } = await import('../src/runDepsStatusCheck.js')
+
+beforeEach(() => {
+  checkDepsStatus.mockReset()
+  runPnpmCli.mockReset()
+})
+
+test('does not install when dependency status is unavailable without a project manifest', async () => {
+  checkDepsStatus.mockResolvedValue({
+    upToDate: undefined,
+    issue: 'No package manifest found. Skipping check.',
+    workspaceState: undefined,
+  })
+
+  await runDepsStatusCheck({
+    dir: process.cwd(),
+    excludeLinksFromLockfile: false,
+    linkWorkspacePackages: false,
+    preferWorkspacePackages: false,
+    pnpmfile: [],
+    rootProjectManifestDir: process.cwd(),
+    verifyDepsBeforeRun: 'install',
+  })
+
+  expect(runPnpmCli).not.toHaveBeenCalled()
+})
+
+test('installs when dependency status is unavailable for an unexpected reason', async () => {
+  checkDepsStatus.mockResolvedValue({
+    upToDate: undefined,
+    issue: 'Cannot verify dependency status',
+    workspaceState: undefined,
+  })
+
+  await runDepsStatusCheck({
+    dir: process.cwd(),
+    excludeLinksFromLockfile: false,
+    linkWorkspacePackages: false,
+    pnpmfile: [],
+    preferWorkspacePackages: false,
+    rootProjectManifest: {
+      name: 'root',
+    },
+    rootProjectManifestDir: process.cwd(),
+    verifyDepsBeforeRun: 'install',
+  })
+
+  expect(runPnpmCli).toHaveBeenCalledWith(['install'], {
+    cwd: process.cwd(),
+    reporter: undefined,
+  })
+})


### PR DESCRIPTION
## Summary

- Skip the dependency-status auto-install path only when dependency status was intentionally skipped outside a project manifest.
- Preserve the existing fallback behavior for unexpected `upToDate: undefined` results when a project manifest exists.
- Add regression coverage for both the no-manifest skip and unexpected-unknown fallback cases.
- Add a changeset for `@pnpm/exec.commands` and `pnpm`.

## Why

When dependency status cannot be evaluated because there is no root project manifest and the command is not recursive, `checkDepsStatus()` already returns `upToDate: undefined` after warning that the check is skipped. The consumer only returned early for `true`, so this intentional skip fell through to the auto-install path and could surface `ERR_PNPM_NO_PKG_MANIFEST` outside a project directory.

This keeps the install/error/warn/prompt path for other unknown-status results, matching the existing fallback behavior.

Closes pnpm/pnpm#12240.

## Checks

- `volta run --node 22.22.2 corepack pnpm install --frozen-lockfile`
- `volta run --node 22.22.2 corepack pnpm run lint` from `exec/commands`
- `NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" volta run --node 22.22.2 corepack pnpm exec jest test/runDepsStatusCheck.test.ts test/createInstallArgs.test.ts --runInBand` from `exec/commands`
- `volta run --node 22.22.2 corepack pnpm exec tsgo --build --pretty false` from `exec/commands`
- pnpm pre-push hook completed: `pnpm run compile-only && pnpm run lint --quiet`; Rust checks skipped because this PR does not touch `pacquet/` or `pnpr/`.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined dependency auto-install logic to skip installs when no project manifest is present, but still run install/verification when a manifest exists and dependency status cannot be determined.

* **Tests**
  * Added tests for dependency-status unavailability covering both missing-manifest and manifest-present scenarios.

* **Chores**
  * Updated release metadata to target patch releases and clarified auto-install behavior when project manifest is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->