### PR TITLE
fix: validate staged tarball filenames

### DIFF
--- a/.changeset/stale-stage-tarballs.md
+++ b/.changeset/stale-stage-tarballs.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+Reject invalid package names and versions from staged tarball manifests before deriving filenames for `pnpm stage download`.

--- a/releasing/commands/src/stage/download.ts
+++ b/releasing/commands/src/stage/download.ts
@@ -1,10 +1,13 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
+import { PnpmError } from '@pnpm/error'
+
+import { createTarballFilename } from '../tarball/safeTarballFilename.js'
 import { summarizeTarball } from '../tarball/summarizeTarball.js'
 import { createStageContext } from './context.js'
 import { requireStageId } from './parsing.js'
-import { normalizePackageName, renderTarballSummary } from './rendering.js'
+import { renderTarballSummary } from './rendering.js'
 import { stageRequest } from './request.js'
 import type { StageOptions } from './types.js'
 
@@ -18,9 +21,14 @@ export async function stageDownload (opts: StageOptions, params: string[]): Prom
   })
   const tarballData = Buffer.from(await response.arrayBuffer())
   const summary = await summarizeTarball(tarballData)
-  const filename = `${normalizePackageName(summary.name)}-${summary.version}-${stageId}.tgz`
+  const filename = createTarballFilename({ name: summary.name, version: summary.version, suffix: stageId })
   const downloadedSummary = { ...summary, filename }
-  await fs.writeFile(path.resolve(opts.dir ?? process.cwd(), filename), tarballData)
+  const downloadDir = path.resolve(opts.dir ?? process.cwd())
+  const outputPath = path.resolve(downloadDir, filename)
+  if (path.dirname(outputPath) !== downloadDir) {
+    throw new PnpmError('INVALID_TARBALL_FILENAME', `Invalid tarball filename "${filename}".`)
+  }
+  await fs.writeFile(outputPath, tarballData)
 
   if (opts.json) return JSON.stringify({ [summary.name]: downloadedSummary }, null, 2)
   return `${renderTarballSummary(downloadedSummary)}\n${filename}`

--- a/releasing/commands/src/stage/rendering.ts
+++ b/releasing/commands/src/stage/rendering.ts
@@ -1,6 +1,8 @@
 import type { PublishSummary } from '../tarball/publishSummary.js'
 import type { StageItem } from './types.js'
 
+export { normalizePackageName } from '../tarball/safeTarballFilename.js'
+
 export function renderStageItem (item: StageItem): string {
   const { id, packageName, version, tag, createdAt, actor, actorType, shasum, ...rest } = item
   return renderKeyValues({
@@ -44,10 +46,6 @@ export function renderStagePublishSummary (
     return `+ ${id} (staged with id ${summary.stageId})`
   }
   return `+ ${id} (staged)`
-}
-
-export function normalizePackageName (name: string): string {
-  return name.replace('@', '').replace('/', '-')
 }
 
 function renderKeyValues (values: Record<string, unknown>): string {

--- a/releasing/commands/src/tarball/safeTarballFilename.ts
+++ b/releasing/commands/src/tarball/safeTarballFilename.ts
@@ -1,0 +1,30 @@
+import path from 'node:path'
+
+import { PnpmError } from '@pnpm/error'
+import { valid } from 'semver'
+import validateNpmPackageName from 'validate-npm-package-name'
+
+interface CreateTarballFilenameOptions {
+  name: string
+  version: string
+  suffix?: string
+}
+
+export function createTarballFilename ({ name, version, suffix }: CreateTarballFilenameOptions): string {
+  if (!validateNpmPackageName(name).validForOldPackages) {
+    throw new PnpmError('INVALID_PACKAGE_NAME', `Invalid package name "${name}".`)
+  }
+  if (!valid(version)) {
+    throw new PnpmError('INVALID_PACKAGE_VERSION', `Invalid package version "${version}".`)
+  }
+
+  const filename = `${normalizePackageName(name)}-${version}${suffix == null ? '' : `-${suffix}`}.tgz`
+  if (path.basename(filename) !== filename || path.win32.basename(filename) !== filename) {
+    throw new PnpmError('INVALID_TARBALL_FILENAME', `Invalid tarball filename "${filename}".`)
+  }
+  return filename
+}
+
+export function normalizePackageName (name: string): string {
+  return name.replace('@', '').replace('/', '-')
+}

--- a/releasing/commands/src/tarball/summarizeTarball.ts
+++ b/releasing/commands/src/tarball/summarizeTarball.ts
@@ -5,6 +5,7 @@ import { PnpmError } from '@pnpm/error'
 import tar from 'tar-stream'
 
 import { extractBundledDependencies, type PublishSummary } from './publishSummary.js'
+import { createTarballFilename } from './safeTarballFilename.js'
 
 interface TarballManifest {
   _id?: string
@@ -80,7 +81,7 @@ export async function summarizeTarball (tarballData: Buffer): Promise<PublishSum
     unpackedSize,
     shasum: createHash('sha1').update(tarballData).digest('hex'),
     integrity: `sha512-${createHash('sha512').update(tarballData).digest('base64')}`,
-    filename: `${normalizePackageName(manifest.name)}-${manifest.version}.tgz`,
+    filename: createTarballFilename({ name: manifest.name, version: manifest.version }),
     files,
     entryCount,
     bundled: bundled.size > 0 ? Array.from(bundled).sort() : extractBundledDependencies(manifest),
@@ -93,8 +94,4 @@ function maybeGunzip (tarballData: Buffer): Buffer {
   } catch {
     return tarballData
   }
-}
-
-function normalizePackageName (name: string): string {
-  return name.replace('@', '').replace('/', '-')
 }

--- a/releasing/commands/test/stage.test.ts
+++ b/releasing/commands/test/stage.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { describe, expect, test } from '@jest/globals'
 import { prepare } from '@pnpm/prepare'
 import { pack, stage } from '@pnpm/releasing.commands'
+import tar from 'tar-stream'
 import { temporaryDirectory } from 'tempy'
 
 import { DEFAULT_OPTS } from './publish/utils/index.js'
@@ -279,6 +280,76 @@ describe('stage command', () => {
     }
   })
 
+  test('stage download rejects traversal through tarball manifest version', async () => {
+    const outsideBase = `stage-download-outside-version-${process.pid}-${Date.now()}`
+    const tarballData = await createPackageTarball({
+      name: '@scope/stage-download-version',
+      version: `1.0.0/../../${outsideBase}`,
+    })
+    const registry = await createRegistry((request) => {
+      if (request.method === 'GET' && request.url.pathname === `/-/stage/${STAGE_ID}/tarball`) {
+        return {
+          body: tarballData,
+          headers: { 'content-type': 'application/octet-stream' },
+        }
+      }
+      return { status: 404, body: { error: 'not found' } }
+    })
+    const downloadDir = temporaryDirectory()
+    const outsidePath = path.resolve(downloadDir, '..', `${outsideBase}-${STAGE_ID}.tgz`)
+    await fs.promises.rm(outsidePath, { force: true })
+    try {
+      await expect(stage.handler({
+        ...stageOpts(registry.url),
+        argv: { original: ['stage', 'download'] },
+        dir: downloadDir,
+      }, ['download', STAGE_ID])).rejects.toMatchObject({
+        code: 'ERR_PNPM_INVALID_PACKAGE_VERSION',
+      })
+
+      expect(fs.existsSync(outsidePath)).toBe(false)
+      expect(fs.readdirSync(downloadDir)).toStrictEqual([])
+    } finally {
+      await fs.promises.rm(outsidePath, { force: true })
+      await registry.close()
+    }
+  })
+
+  test('stage download rejects traversal through tarball manifest package name', async () => {
+    const outsideBase = `stage-download-outside-name-${process.pid}-${Date.now()}`
+    const tarballData = await createPackageTarball({
+      name: `@scope/../../${outsideBase}`,
+      version: '1.0.0',
+    })
+    const registry = await createRegistry((request) => {
+      if (request.method === 'GET' && request.url.pathname === `/-/stage/${STAGE_ID}/tarball`) {
+        return {
+          body: tarballData,
+          headers: { 'content-type': 'application/octet-stream' },
+        }
+      }
+      return { status: 404, body: { error: 'not found' } }
+    })
+    const downloadDir = temporaryDirectory()
+    const outsidePath = path.resolve(downloadDir, '..', `${outsideBase}-1.0.0-${STAGE_ID}.tgz`)
+    await fs.promises.rm(outsidePath, { force: true })
+    try {
+      await expect(stage.handler({
+        ...stageOpts(registry.url),
+        argv: { original: ['stage', 'download'] },
+        dir: downloadDir,
+      }, ['download', STAGE_ID])).rejects.toMatchObject({
+        code: 'ERR_PNPM_INVALID_PACKAGE_NAME',
+      })
+
+      expect(fs.existsSync(outsidePath)).toBe(false)
+      expect(fs.readdirSync(downloadDir)).toStrictEqual([])
+    } finally {
+      await fs.promises.rm(outsidePath, { force: true })
+      await registry.close()
+    }
+  })
+
   test('stage publish --dry-run reports that packages would be staged', async () => {
     const pkgName = '@scope/stage-publish-dry-run'
     prepare({ name: pkgName, version: '1.0.0' })
@@ -341,6 +412,23 @@ async function createRegistry (handler: RegistryHandler): Promise<{ close: () =>
     requests,
     url: `http://127.0.0.1:${address.port}/`,
   }
+}
+
+function createPackageTarball (manifest: { name: string, version: string }): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const pack = tar.pack()
+    const chunks: Buffer[] = []
+    pack.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)))
+    pack.on('error', reject)
+    pack.on('end', () => resolve(Buffer.concat(chunks)))
+    pack.entry({ name: 'package/package.json' }, JSON.stringify(manifest), (err?: Error | null) => {
+      if (err) {
+        reject(err)
+        return
+      }
+      pack.finalize()
+    })
+  })
 }
 
 function headerValue (value: http.IncomingHttpHeaders[string]): string | undefined {


### PR DESCRIPTION
## Summary

- validate package names and versions from staged tarball manifests before deriving tarball filenames
- constrain `pnpm stage download` output paths to the selected download directory
- add regression coverage for traversal-bearing manifest metadata

Pacquet is not changed because it does not implement the stage/release command surface.

## Validation

- `./node_modules/.bin/tsgo --build releasing/commands/tsconfig.json`
- `./node_modules/.bin/eslint releasing/commands/src/stage/download.ts releasing/commands/src/stage/rendering.ts releasing/commands/src/tarball/summarizeTarball.ts releasing/commands/src/tarball/safeTarballFilename.ts releasing/commands/test/stage.test.ts`
- `PNPR_PREPARE_BIN=/Users/zoltan/.cargo_shared_target/debug/pnpr-prepare PNPR_BIN=/Users/zoltan/.cargo_shared_target/debug/pnpr NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" ../../node_modules/.bin/jest test/stage.test.ts -t "stage download" --runInBand`
- `PNPR_PREPARE_BIN=/Users/zoltan/.cargo_shared_target/debug/pnpr-prepare PNPR_BIN=/Users/zoltan/.cargo_shared_target/debug/pnpr NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" ../../node_modules/.bin/jest test/stage.test.ts --runInBand`
- `git diff --check -- releasing/commands/src/stage/download.ts releasing/commands/src/stage/rendering.ts releasing/commands/src/tarball/summarizeTarball.ts releasing/commands/src/tarball/safeTarballFilename.ts releasing/commands/test/stage.test.ts .changeset/stale-stage-tarballs.md pnpm-lock.yaml`

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm stage download` now validates package names and versions from staged tarball manifests before downloading
  * Added path traversal protection to ensure downloaded files remain within the intended directory

* **Tests**
  * Expanded test coverage for staged tarball download security validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->