### PR TITLE
fix: record the global virtual store dir in .modules.yaml during the post-install build step

### DIFF
--- a/.changeset/gvs-build-step-virtual-store-dir.md
+++ b/.changeset/gvs-build-step-virtual-store-dir.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/building.after-install": patch
+"pnpm": patch
+---
+
+Fixed `pnpm install` repeatedly prompting to remove and reinstall `node_modules` in a workspace package when `enableGlobalVirtualStore` is enabled. The post-install build step recorded a per-project `node_modules/.pnpm` virtual store directory in `node_modules/.modules.yaml`, overwriting the global `<storeDir>/links` value the install step had written. The next install then detected a virtual-store mismatch (`ERR_PNPM_UNEXPECTED_VIRTUAL_STORE`). The build step now derives the same global virtual store directory as the install step [#12307](https://github.com/pnpm/pnpm/issues/12307).

--- a/building/after-install/src/extendBuildOptions.ts
+++ b/building/after-install/src/extendBuildOptions.ts
@@ -50,6 +50,7 @@ export type StrictBuildOptions = {
   allowBuilds?: Record<string, boolean | string>
   enableGlobalVirtualStore?: boolean
   globalVirtualStoreDir?: string
+  virtualStoreDir?: string
   virtualStoreDirMaxLength: number
   peersSuffixMaxLength: number
   strictStorePkgContentCheck: boolean
@@ -109,5 +110,15 @@ export async function extendBuildOptions (
     storeDir: defaultOpts.storeDir,
   }
   extendedOpts.registries = normalizeRegistries(extendedOpts.registries)
+  // Mirror extendInstallOptions: under a global virtual store, the virtual
+  // store directory is `<storeDir>/links`, not the per-project
+  // `node_modules/.pnpm`. Without this, getContext() in the build step
+  // defaults virtualStoreDir to the local `.pnpm` and writeModulesManifest
+  // overwrites the correct value the install step recorded — which makes the
+  // next install in that project detect a virtual-store mismatch and prompt
+  // to purge node_modules.
+  if (extendedOpts.enableGlobalVirtualStore && extendedOpts.virtualStoreDir == null) {
+    extendedOpts.virtualStoreDir = extendedOpts.globalVirtualStoreDir ?? path.join(extendedOpts.storeDir, 'links')
+  }
   return extendedOpts
 }

--- a/pnpm/test/install/globalVirtualStore.ts
+++ b/pnpm/test/install/globalVirtualStore.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
-import { prepare } from '@pnpm/prepare'
+import { prepare, preparePackages } from '@pnpm/prepare'
 import { readYamlFileSync } from 'read-yaml-file'
 import { writeYamlFileSync } from 'write-yaml-file'
 
@@ -106,4 +106,46 @@ test('warm GVS reinstall skips internal linking', async () => {
   expect(fs.existsSync(path.resolve('node_modules/.pnpm/node_modules/@pnpm.e2e/dep-of-pkg-with-1-dep'))).toBeTruthy()
   expect(fs.existsSync(path.resolve('node_modules/.bin/hello-world-js-bin'))).toBeTruthy()
   expect(fs.existsSync(path.resolve('node_modules/.pnpm/lock.yaml'))).toBeTruthy()
+})
+
+test('the post-install build step preserves the global virtual store directory of a workspace package', async () => {
+  // A workspace package that is also its own workspace root (its own
+  // pnpm-workspace.yaml and lockfile). The root install runs a per-project
+  // build pass that must not overwrite the package's recorded global virtual
+  // store directory with the local node_modules/.pnpm — otherwise the next
+  // install in that package detects a virtual-store mismatch and prompts to
+  // purge node_modules.
+  const storeDir = path.resolve('store')
+  const globalVirtualStoreDir = path.join(storeDir, 'v11/links')
+  preparePackages([
+    {
+      location: 'libs/common',
+      package: {
+        name: '@repro/common',
+        dependencies: {
+          '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+        },
+      },
+    },
+  ])
+  writeYamlFileSync(path.resolve('pnpm-workspace.yaml'), {
+    packages: ['libs/*'],
+    enableGlobalVirtualStore: true,
+    sharedWorkspaceLockfile: false,
+    storeDir,
+  })
+  writeYamlFileSync(path.resolve('libs/common/pnpm-workspace.yaml'), {
+    enableGlobalVirtualStore: true,
+    storeDir,
+  })
+
+  await execPnpm(['install'])
+
+  const modulesManifestPath = path.resolve('libs/common/node_modules/.modules.yaml')
+  const modules = readYamlFileSync<{ virtualStoreDir: string }>(modulesManifestPath)
+  expect(path.resolve('libs/common/node_modules', modules.virtualStoreDir)).toBe(globalVirtualStoreDir)
+
+  // A subsequent install in the package must be a no-op, not a virtual-store
+  // mismatch that aborts (in a non-TTY shell) or prompts to purge node_modules.
+  await execPnpm(['install', '--dir', path.resolve('libs/common')])
 })


### PR DESCRIPTION
Fixes pnpm/pnpm#12307.

Under `enableGlobalVirtualStore`, running `pnpm install` in a workspace package kept prompting to remove and reinstall `node_modules` (or, in a non-TTY shell, failing with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`), even when nothing changed.

### Root cause

During an install, each project's `node_modules/.modules.yaml` is written twice:

1. The install/link step records the correct global virtual store directory — `extendInstallOptions` sets `virtualStoreDir` to `<storeDir>/links` when GVS is enabled.
2. The post-install build step (`buildProjects` / `buildSelectedPkgs`) calls `getContext()` and rewrites `.modules.yaml`. Its options come from `extendBuildOptions`, which — unlike `extendInstallOptions` — never set `virtualStoreDir` for GVS, so `getContext()` fell back to the per-project `node_modules/.pnpm` default and overwrote the value the install step had recorded.

The next install then recomputes `<storeDir>/links`, compares it to the recorded `node_modules/.pnpm`, fails the virtual-store check with `ERR_PNPM_UNEXPECTED_VIRTUAL_STORE`, and — because a plain install runs with `forceNewModules` — prompts to purge `node_modules`.

### Fix

Make `extendBuildOptions` GVS-aware, mirroring `extendInstallOptions`: when `enableGlobalVirtualStore` is set and `virtualStoreDir` is unset, derive it from `globalVirtualStoreDir` (falling back to `<storeDir>/links`). Both build consumers flow their options through `extendBuildOptions` into `getContext`, so this single change makes the build step record the same virtual-store path the install step wrote.

### Tests

Added an e2e regression test (`pnpm/test/install/globalVirtualStore.ts`) covering a workspace package that is also its own workspace root: after the install it asserts the package's `.modules.yaml` records the global virtual store directory, and that a subsequent install is a clean no-op rather than a purge prompt.

### pacquet

Not affected. pacquet resolves the virtual store directory through a single `Config::effective_virtual_store_dir()` helper at its one `.modules.yaml` write site, so it has no equivalent install-vs-build asymmetry (already covered by existing config and modules-yaml tests).

---
Written by an agent (Claude Code, claude-opus-4-8).