### PR TITLE
perf(pacquet): parse packuments off the reactor and release the network permit before CPU work

### DIFF
--- a/pacquet/crates/resolving-npm-resolver/src/errors.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/errors.rs
@@ -52,4 +52,14 @@ pub enum FetchMetadataError {
         #[error(not(source))]
         pkg_name: String,
     },
+
+    /// The blocking task that deserializes a packument body panicked
+    /// or was cancelled by runtime shutdown.
+    #[display("Failed to parse metadata from {url}: {error}")]
+    #[diagnostic(code(pacquet_resolving_npm_resolver::parse_task))]
+    ParseTask {
+        url: String,
+        #[error(source)]
+        error: tokio::task::JoinError,
+    },
 }

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
@@ -109,7 +109,7 @@ pub async fn fetch_full_metadata(
     // path segment, not two.
     let url = to_registry_url(opts.registry, pkg_name);
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
-    let (_client, response) = send_with_retry(opts.http_client, &url, opts.retry_opts, |client| {
+    let (client, response) = send_with_retry(opts.http_client, &url, opts.retry_opts, |client| {
         let mut request = client.get(&url).header(header::ACCEPT, accept);
         if let Some(value) = opts.auth_headers.for_url(&url) {
             request = request.header(header::AUTHORIZATION, value);
@@ -139,8 +139,19 @@ pub async fn fetch_full_metadata(
         .text()
         .await
         .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
-    let meta: Package = serde_json::from_str(&raw_body)
-        .map_err(|error| FetchMetadataError::Decode { url: url.clone(), error })?;
+    // Body fully buffered — release the connection and its
+    // network-concurrency permit, then parse off the reactor: a
+    // multi-MB packument parse would otherwise pin a tokio worker
+    // and stall every socket it pumps (see
+    // `fetch_full_metadata_cached` for the cold-install numbers).
+    drop(client);
+    let task_url = url.clone();
+    let meta = tokio::task::spawn_blocking(move || {
+        serde_json::from_str::<Package>(&raw_body)
+            .map_err(|error| FetchMetadataError::Decode { url: task_url, error })
+    })
+    .await
+    .map_err(|error| FetchMetadataError::ParseTask { url, error })??;
     Ok(FetchFullMetadataOutcome::Modified(Box::new(meta)))
 }
 

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -121,7 +121,7 @@ pub async fn fetch_full_metadata_cached(
 
     let url = to_registry_url(opts.registry, pkg_name);
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
-    let (_client, response) = send_with_retry(opts.http_client, &url, opts.retry_opts, |client| {
+    let (client, response) = send_with_retry(opts.http_client, &url, opts.retry_opts, |client| {
         let mut request = client.get(&url).header(header::ACCEPT, accept);
         if let Some(value) = opts.auth_headers.for_url(&url) {
             request = request.header(header::AUTHORIZATION, value);
@@ -140,6 +140,9 @@ pub async fn fetch_full_metadata_cached(
     .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
 
     if response.status() == StatusCode::NOT_MODIFIED {
+        // No body to stream — release the connection and its
+        // network-concurrency permit before the mirror disk read.
+        drop(client);
         let Some(path) = mirror_path else {
             // 304 without an existing cache to fall back on — the
             // registry over-reached on `If-None-Match: <stale>`.
@@ -166,35 +169,56 @@ pub async fn fetch_full_metadata_cached(
         .text()
         .await
         .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
-    let meta: Package = serde_json::from_str(&raw_body)
-        .map_err(|error| FetchMetadataError::Decode { url: url.clone(), error })?;
 
-    if let Some(path) = mirror_path.as_deref() {
-        match prepare_json_for_disk(&meta, etag.as_deref(), Some(&raw_body)) {
-            Ok(json) => {
-                if let Err(error) = save_meta(path, &json) {
-                    // Fire-and-forget — a read-only cache dir or a
-                    // shared-store contention shouldn't fail the
-                    // install. The user just won't see the warm-cache
-                    // speedup next time.
+    // Body fully buffered — release the connection and its
+    // network-concurrency permit before the CPU-bound parse so the
+    // semaphore keeps bounding *sockets*, not parses. Same
+    // buffer-then-release shape as the tarball pipeline in
+    // `pacquet-tarball`.
+    drop(client);
+
+    // Deserialize and persist the mirror off the reactor. Packuments
+    // run to several megabytes for high-release-cadence packages
+    // (`@fluentui/*`, `@types/node`, ...); parsing one inline pins a
+    // tokio worker for hundreds of milliseconds and stalls every
+    // socket that worker pumps — on a cold babylon install the
+    // inline parses held the metadata phase to a third of pnpm's
+    // throughput.
+    let task_url = url.clone();
+    let meta = tokio::task::spawn_blocking(move || -> Result<Package, FetchMetadataError> {
+        let meta: Package = serde_json::from_str(&raw_body)
+            .map_err(|error| FetchMetadataError::Decode { url: task_url, error })?;
+
+        if let Some(path) = mirror_path.as_deref() {
+            match prepare_json_for_disk(&meta, etag.as_deref(), Some(&raw_body)) {
+                Ok(json) => {
+                    if let Err(error) = save_meta(path, &json) {
+                        // Fire-and-forget — a read-only cache dir or a
+                        // shared-store contention shouldn't fail the
+                        // install. The user just won't see the warm-cache
+                        // speedup next time.
+                        tracing::debug!(
+                            target: "pacquet_resolving_npm_resolver::cache",
+                            ?error,
+                            path = %path.display(),
+                            "could not persist mirror; bypassing cache write",
+                        );
+                    }
+                }
+                Err(error) => {
                     tracing::debug!(
                         target: "pacquet_resolving_npm_resolver::cache",
                         ?error,
                         path = %path.display(),
-                        "could not persist mirror; bypassing cache write",
+                        "could not serialize mirror entry; bypassing cache write",
                     );
                 }
             }
-            Err(error) => {
-                tracing::debug!(
-                    target: "pacquet_resolving_npm_resolver::cache",
-                    ?error,
-                    path = %path.display(),
-                    "could not serialize mirror entry; bypassing cache write",
-                );
-            }
         }
-    }
+        Ok(meta)
+    })
+    .await
+    .map_err(|error| FetchMetadataError::ParseTask { url, error })??;
 
     meta.pipe(Ok)
 }


### PR DESCRIPTION
## Why

Follow-up to pnpm/pnpm#12315's investigation: the one variation where pacquet still trailed pnpm on [benchmarks.vlt.sh](https://benchmarks.vlt.sh/) was `clean` babylon (34.3 s vs 30.1 s on the 2026-06-10 run).

A Linux-side profile (strace + download/linkat timelines in a container) localized the gap to the **resolution phase**, not store-write/linking as initially suspected:

- Cold `--lockfile-only` resolves: pacquet 44 s vs pnpm 17.7 s, with pacquet at ~30% of one core — network-throughput-bound, not CPU (warm-metadata resolves: pacquet 9.8 s vs pnpm 18.7 s, i.e. pacquet's CPU side is already 2× faster).
- Same bytes on both sides (~520–600 MB of packuments, ~1,480 docs), similar socket counts and syscall counts — yet a third of pnpm's effective throughput, with a 15-second dead zone in the download timeline while the `@fluentui/*` subtree resolved.

Root cause: `fetch_full_metadata_cached` parsed every packument body **inline on the tokio worker that buffered it** — while still **holding its network-concurrency permit** — and then wrote the multi-MB metadata mirror to disk synchronously on the same worker. High-release-cadence packages ship multi-megabyte packuments; a burst of them pinned every reactor worker in serde for hundreds of milliseconds at a time, stalling the sockets those workers pump and parking the concurrency semaphore's permits on CPU work. The tarball pipeline already avoids exactly this ("body fully buffered; release the network permit before the CPU-bound work" + `spawn_blocking`); the packument path never got the same treatment.

## What

In both metadata fetchers (`fetch_full_metadata_cached`, `fetch_full_metadata`):

- drop the request guard as soon as the body is buffered, so the semaphore goes back to bounding *sockets*;
- deserialize the packument and persist the mirror inside one `spawn_blocking`, keeping the reactor free to pump the remaining transfers;
- a 304 releases the guard before the mirror disk read for the same reason.

New `FetchMetadataError::ParseTask` variant carries a `JoinError` from the blocking task.

## Validation

- Linux container A/B (cold babylon full installs over WAN, interleaved): median ~38.0 s (main) → ~32.7 s (patched), patched winning 5 of 6 paired rounds; cold `--lockfile-only` 44 s → 24 s in the back-to-back pair.
- Real vlt.sh harness on a GitHub `ubuntu-24.04-arm` runner, `clean` variation, pnpm and patched pacquet in the same hyperfine session (the runner's network was degraded during the run — both tools ~2× slower than the official numbers — which makes the *relative* result the meaningful one): **babylon: pacquet 54.8 s vs pnpm 59.2 s** — flipped from −14 % behind (official run) to ahead under identical conditions. astro `clean` stayed within noise (pacquet already led it officially). All hyperfine runs exited 0.
- `cargo nextest run` for `pacquet-resolving-npm-resolver` (234), `pacquet-package-manager` + `pacquet-cli` (740) all pass; clippy `-D warnings`, dylint, fmt clean.

## Profile notes for future work (not addressed here)

The extract+link phase still shows heavy scheduler churn relative to pnpm (~100 k involuntary context switches vs ~750; `sched_yield` storms from the rayon pools): tokio workers + the dedicated CAS-write pool + the global rayon pool + up to 2×cores blocking threads can leave ~5×cores runnable threads on the box. Wall-clock impact is currently hidden behind network time, but it's the next candidate if the gap reopens on faster runners.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when parsing npm package metadata fails, with a new error type to capture failures during deserialization.

* **Performance**
  * Optimized metadata fetching to release network resources earlier, preventing resource exhaustion when processing large package metadata by offloading JSON parsing to a separate task queue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->