### PR TITLE
fix: prevent a pinned locked peer provider from leaking to sibling nodes

### DIFF
--- a/.changeset/locked-peer-pin-no-sibling-leak.md
+++ b/.changeset/locked-peer-pin-no-sibling-leak.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fixed nondeterministic lockfile output that made `pnpm dedupe --check` fail intermittently in CI. When a locked peer provider was pinned for a dependency that has no child dependencies of its own, the pinned provider leaked into the shared parent scope, so siblings resolved after it could pick up an optional peer they should not see. Which siblings were affected depended on resolution order, which varies with network timing.

--- a/installing/deps-resolver/src/resolvePeers.ts
+++ b/installing/deps-resolver/src/resolvePeers.ts
@@ -481,6 +481,14 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
     }
   }
   if (node.lockedPeerContext != null && ctx.resolvedPeerProviderPaths != null) {
+    // Pinning writes into parentPkgs, and a childless node shares the object
+    // with its parent, so siblings processed later would see the pinned
+    // provider too. Copy first to keep the pin scoped to this node — sibling
+    // order follows resolution order, so a leak makes the lockfile depend on
+    // network timing.
+    if (parentPkgs === parentParentPkgs) {
+      parentPkgs = { ...parentParentPkgs }
+    }
     for (const [peerName, previousPeerDepPath] of Object.entries(node.lockedPeerContext)) {
       const peerNodeId = ctx.nodeIdsByPreviousDepPath.get(previousPeerDepPath)
       const peerDependency = resolvedPackage.peerDependencies[peerName]

--- a/installing/deps-resolver/src/resolvePeers.ts
+++ b/installing/deps-resolver/src/resolvePeers.ts
@@ -481,14 +481,6 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
     }
   }
   if (node.lockedPeerContext != null && ctx.resolvedPeerProviderPaths != null) {
-    // Pinning writes into parentPkgs, and a childless node shares the object
-    // with its parent, so siblings processed later would see the pinned
-    // provider too. Copy first to keep the pin scoped to this node — sibling
-    // order follows resolution order, so a leak makes the lockfile depend on
-    // network timing.
-    if (parentPkgs === parentParentPkgs) {
-      parentPkgs = { ...parentParentPkgs }
-    }
     for (const [peerName, previousPeerDepPath] of Object.entries(node.lockedPeerContext)) {
       const peerNodeId = ctx.nodeIdsByPreviousDepPath.get(previousPeerDepPath)
       const peerDependency = resolvedPackage.peerDependencies[peerName]
@@ -519,6 +511,15 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
       ctx.pathsByNodeIdPromises.set(peerNodeId, peerPathPromise)
       ctx.pathsByNodeId.set(peerNodeId, previousPeerDepPath)
       peerPathPromise.resolve(previousPeerDepPath)
+      // Pinning writes into parentPkgs, and a childless node shares the object
+      // with its parent, so siblings processed later would see the pinned
+      // provider too. Copy before the first write to keep the pin scoped to
+      // this node — sibling order follows resolution order, so a leak makes the
+      // lockfile depend on network timing. Done here, not before the loop, so a
+      // pass whose guards skip every entry never allocates.
+      if (parentPkgs === parentParentPkgs) {
+        parentPkgs = { ...parentParentPkgs }
+      }
       parentPkgs[peerName] = lockedPeer
     }
   }

--- a/installing/deps-resolver/test/resolvePeers.ts
+++ b/installing/deps-resolver/test/resolvePeers.ts
@@ -1025,6 +1025,78 @@ describe('locked peer provider preferences', () => {
     expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
   })
 
+  test('a provider pinned for a childless consumer does not leak to the consumer\'s siblings', async () => {
+    const victimNodeId = '>wrapper/1.0.0>victim/1.0.0>' as NodeId
+    const victimPkg = {
+      name: 'victim',
+      pkgIdWithPatchHash: 'victim/1.0.0' as PkgIdWithPatchHash,
+      version: '1.0.0',
+      peerDependencies: {
+        peer: { version: '>=1', optional: true },
+      },
+      id: '' as PkgResolutionId,
+    }
+    // The two orders simulate the dependency tree arriving in different
+    // resolution orders (network timing). The victim's resolution must not
+    // depend on whether it is processed before or after the consumer whose
+    // locked context pins the provider.
+    const wrapperChildrenVariants: ChildrenMap[] = [
+      { consumer: consumerNodeId, victim: victimNodeId },
+      { victim: victimNodeId, consumer: consumerNodeId },
+    ]
+    for (const wrapperChildren of wrapperChildrenVariants) {
+      const dependenciesTree = new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+        [retainerNodeId, {
+          children: { peer: retainedPeerNodeId },
+          installable: true,
+          resolvedPackage: retainerPkg,
+          depth: 0,
+        }],
+        [retainedPeerNodeId, {
+          children: {},
+          installable: true,
+          previousDepPath: 'peer/2.0.0' as DepPath,
+          resolvedPackage: peer2Pkg,
+          depth: 1,
+        }],
+        [wrapperNodeId, {
+          children: wrapperChildren,
+          installable: true,
+          resolvedPackage: wrapperPkg,
+          depth: 0,
+        }],
+        [consumerNodeId, {
+          children: {},
+          installable: true,
+          lockedPeerContext: { peer: 'peer/2.0.0' as DepPath },
+          resolvedPackage: consumerPkg,
+          depth: 1,
+        }],
+        [victimNodeId, {
+          children: {},
+          installable: true,
+          resolvedPackage: victimPkg,
+          depth: 1,
+        }],
+      ])
+      const resolutionOpts = options(dependenciesTree, new Map([
+        ['retainer', retainerNodeId],
+        ['wrapper', wrapperNodeId],
+      ]))
+      // eslint-disable-next-line no-await-in-loop
+      const initial = await resolvePeers(resolutionOpts)
+      // eslint-disable-next-line no-await-in-loop
+      const preferred = await resolvePeers({
+        ...resolutionOpts,
+        resolvedPeerProviderPaths: initial.pathsByNodeId,
+      })
+
+      expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeTruthy()
+      expect(preferred.dependenciesGraph['victim/1.0.0' as DepPath]).toBeTruthy()
+      expect(preferred.dependenciesGraph['victim/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+    }
+  })
+
   test('does not reuse a locked provider outside the current peer range', async () => {
     const resolutionOpts = options(createTree(undefined, true, '^1.0.0'), new Map([
       ['peer', currentPeerNodeId],


### PR DESCRIPTION
## Problem

`pnpm dedupe --check` fails intermittently in CI on a large workspace, while running `pnpm dedupe` locally on the same commit reports no changes. The diff that dedupe prints when it fails shows a dependency instance flipping an *optional* peer in its suffix between runs, for example `next@16.2.6(@opentelemetry/api@1.9.1)...` versus `next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)...`. Both variants legitimately exist in the lockfile (the flipping package itself never appears in the added/removed package list, only its dependents do); what changes between runs is which variant a dependent gets linked against.

The failures correlate with cache state: runs that download even a few packages (cold CI cache) can fail, runs that reuse everything (warm local cache) pass. That pointed at resolution order, since the dependency tree's child-map insertion order follows async resolution completion order.

## Root cause

The locked-peer-context pinning introduced in pnpm/pnpm#12083 ([`1c73e8303c`](https://github.com/pnpm/pnpm/commit/1c73e8303c6eefca27e9803b94e8c063eb32cfa8)) mutates `parentPkgs` when it reuses a provider recorded in the lockfile:

- [`resolvePeers.ts#L514`](https://github.com/pnpm/pnpm/blob/52be454d5708f5d2b7a000bed8a2a3be167bab08/installing/deps-resolver/src/resolvePeers.ts#L514): `parentPkgs[peerName] = lockedPeer`

That write is intended to be scoped to the node being resolved. It isn't, because a node with no child dependencies never copies `parentPkgs` — it aliases its parent's object:

- [`resolvePeers.ts#L451-L456`](https://github.com/pnpm/pnpm/blob/52be454d5708f5d2b7a000bed8a2a3be167bab08/installing/deps-resolver/src/resolvePeers.ts#L451-L456)

Childless nodes are common in exactly the pinning scenario: peer dependencies are stripped from a snapshot's `dependencies` when building the tree, so any package whose dependencies are all peers has zero children. When such a node pins a provider, the provider lands in the parent's `parentPkgs` and becomes visible to every sibling resolved after it. A sibling with an optional peer of that name then resolves the peer it was never supposed to see, and gets a different dep path.

Whether a given sibling runs before or after the leaking node depends on the iteration order of the children map, which is insertion order, which is network completion order. Hence: deterministic-looking locally, flaky in CI.

## Reproduction

The added unit test (`installing/deps-resolver/test/resolvePeers.ts`, "a provider pinned for a childless consumer does not leak to the consumer's siblings") resolves the same tree twice, with the childless pinning consumer and a sibling (`victim`, which has an optional peer on the pinned provider) in both insertion orders. Before the fix, the consumer-first order produces `victim/1.0.0(peer/2.0.0)` while the victim-first order produces `victim/1.0.0` — the output depends on sibling order. After the fix both orders produce `victim/1.0.0`.

## Fix

Copy `parentPkgs` before the pinning loop when it aliases the parent's object, so the pin stays scoped to the node and its own subtree.

## Verification

- New test fails before the fix and passes after; full `@pnpm/installing.deps-resolver` suite passes (109 tests).
- The guards from pnpm/pnpm#12083 still hold: both "wins over a locked context" tests in `installing/deps-installer/test/install/peerDependencies.ts` pass, and `pnpm/test/install/preferLockedPeerContexts.ts` passes against a freshly rebuilt bundle.
- `@pnpm/installing.dedupe.check` tests pass.

No pacquet change is needed: its lockfile-reuse path rebuilds children from the manifest and lets the peer pass derive each instance's context (see the pacquet section of [`1c73e8303c`](https://github.com/pnpm/pnpm/commit/1c73e8303c6eefca27e9803b94e8c063eb32cfa8)), so it has no pinning write to leak. This fix brings the TypeScript side back in line with what pacquet already produces.

---
Written by an agent (Claude Code, claude-fable-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent CI failures of `pnpm dedupe --check` caused by nondeterministic lockfile generation.
  * Improved peer dependency resolution isolation so pinned peer providers no longer leak into sibling package resolutions.
* **Tests**
  * Added a regression test ensuring pinned peer provider instances remain scoped and do not appear in sibling dependency-tree variants.
* **Chores**
  * Updated patch versions for the involved packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->