### PR TITLE
feat(audit): add option to stop --fix from excluding packages from minimum release age

### DIFF
--- a/.changeset/four-weeks-like.md
+++ b/.changeset/four-weeks-like.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/deps.compliance.commands": minor
+---
+
+Add the ability to stop audit --fix from adding packages to minimum release age exclusion

--- a/deps/compliance/commands/src/audit/audit.ts
+++ b/deps/compliance/commands/src/audit/audit.ts
@@ -62,6 +62,7 @@ export function rcOptionsTypes (): Record<string, unknown> {
     // For fix, use String instead of a list of allowed string values.
     // Otherwise, an unexpected value will get coerced to true because of the Boolean type.
     fix: [String, Boolean],
+    'frozen-minimum-release-age-exclude': Boolean,
     'ignore-registry-errors': Boolean,
     ignore: [String, Array],
     'ignore-unfixable': Boolean,
@@ -145,6 +146,10 @@ export function help (): string {
             name: '--ignore-unfixable',
           },
           {
+            description: 'Prevent --fix from adding entries to minimumReleaseAgeExclude. Patched versions newer than minimumReleaseAge will not be installable until they mature.',
+            name: '--frozen-minimum-release-age-exclude',
+          },
+          {
             description: 'Show vulnerabilities and select which ones to fix interactively',
             name: '--interactive',
             shortAlias: '-i',
@@ -159,6 +164,7 @@ export function help (): string {
 
 export type AuditOptions = Pick<UniversalOptions, 'dir'> & {
   fix?: boolean | 'override' | 'update'
+  frozenMinimumReleaseAgeExclude?: boolean
   ignoreRegistryErrors?: boolean
   interactive?: boolean
   json?: boolean

--- a/deps/compliance/commands/src/audit/fix.ts
+++ b/deps/compliance/commands/src/audit/fix.ts
@@ -14,7 +14,7 @@ export async function fix (auditReport: AuditReport, opts: AuditOptions): Promis
   const fixableAdvisories = getFixableAdvisories(Object.values(auditReport.advisories), opts.auditConfig?.ignoreGhsas)
   const vulnOverrides = createOverrides(fixableAdvisories)
   if (Object.values(vulnOverrides).length === 0) return { vulnOverrides, addedAgeExcludes: [] }
-  const addedAgeExcludes = opts.minimumReleaseAge ? createMinimumReleaseAgeExcludes(fixableAdvisories) : []
+  const addedAgeExcludes = opts.minimumReleaseAge && !opts.frozenMinimumReleaseAgeExclude ? createMinimumReleaseAgeExcludes(fixableAdvisories) : []
   await writeSettings({
     updatedOverrides: vulnOverrides,
     addedMinimumReleaseAgeExcludes: addedAgeExcludes.length > 0 ? addedAgeExcludes : undefined,

--- a/deps/compliance/commands/src/audit/fixWithUpdate.ts
+++ b/deps/compliance/commands/src/audit/fixWithUpdate.ts
@@ -92,7 +92,7 @@ export async function fixWithUpdate (auditReport: AuditReport, opts: FixWithUpda
 
   // Add minimum patched versions to minimumReleaseAgeExclude so the resolver
   // can install them even when minimumReleaseAge would otherwise block them.
-  const addedAgeExcludes = opts.minimumReleaseAge ? createMinimumReleaseAgeExcludes(Object.values(auditReport.advisories)) : []
+  const addedAgeExcludes = opts.minimumReleaseAge && !opts.frozenMinimumReleaseAgeExclude ? createMinimumReleaseAgeExcludes(Object.values(auditReport.advisories)) : []
   const updateOpts = { ...opts } as Record<string, unknown>
   if (addedAgeExcludes.length > 0) {
     const existing = (updateOpts.minimumReleaseAgeExclude as string[] | undefined) ?? []

--- a/deps/compliance/commands/test/audit/fixWithUpdate.ts
+++ b/deps/compliance/commands/test/audit/fixWithUpdate.ts
@@ -316,6 +316,67 @@ The remaining vulnerabilities are:
     }
   })
 
+  test('minimum-release-age limited vulnerability remains unresolved', async () => {
+    const tmp = f.prepare('update-min-release-age')
+
+    const pkgId = '@pnpm.e2e/bravo-dep@1.0.0' as DepPath
+
+    const { manifest: originalManifest } = await readProjectManifest(tmp)
+    expect(originalManifest).toBeTruthy()
+    expect(originalManifest.dependencies).toBeDefined()
+    expect(originalManifest.dependencies?.['@pnpm.e2e/bravo-dep']).toBe('^1.0.0')
+
+    const originalLockfile = await readWantedLockfile(tmp, { ignoreIncompatible: true })
+    expect(originalLockfile).toBeTruthy()
+    expect(originalLockfile!.packages).toBeDefined()
+    expect(originalLockfile!.packages![pkgId]).toBeDefined()
+
+    const mockResponse = await loadJsonFile<Record<string, Record<string, string>[]>>(join(tmp, 'responses', 'min-release-age-vulnerability.json'))
+    expect(mockResponse).toBeTruthy()
+
+    getMockAgent().get(MOCK_REGISTRY)
+      .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+      .reply(200, mockResponse)
+
+    const { exitCode, output } = await audit.handler({
+      ...MOCK_REGISTRY_OPTS,
+      dir: tmp,
+      rootProjectManifestDir: tmp,
+      auditLevel: 'moderate',
+      fix: 'update',
+      lockfileOnly: true,
+      frozenMinimumReleaseAgeExclude: true,
+      // The mock registry publishes the vulnerable bravo-dep@1.0.0 at
+      // 2022-02-01 and the patched 1.0.1 at 2022-02-22. Place the maturity
+      // cutoff between the two so only the patched version is blocked.
+      minimumReleaseAge: (Date.now() - new Date('2022-02-10T00:00:00.000Z').getTime()) / (60 * 1000),
+    })
+
+    expect(output).toBe(`${chalk.green(0)} vulnerabilities were fixed, ${chalk.red(1)} vulnerability remains.
+
+The remaining vulnerabilities are:
+- (${chalk.bold.red('high')}) "${chalk.bold.red('Title: mock vulnerability in @pnpm.e2e/bravo-dep')}" ${chalk.blue('@pnpm.e2e/bravo-dep')}
+`)
+    expect(exitCode).toBe(1)
+
+    // The manifest should remain unchanged
+    const { manifest } = await readProjectManifest(tmp)
+    expect(manifest).toBeTruthy()
+    expect(manifest.dependencies).toBeDefined()
+    expect(manifest.dependencies?.['@pnpm.e2e/bravo-dep']).toBe('^1.0.0')
+
+    // The lockfile should remain unchanged
+    const lockfile = await readWantedLockfile(tmp, { ignoreIncompatible: true })
+    expect(lockfile).toBeTruthy()
+    expect(lockfile!.packages).toBeDefined()
+    const packagesArray = Object.keys(lockfile!.packages!)
+
+    // All packages should remain the same
+    for (const pkgId of Object.keys(originalLockfile!.packages!)) {
+      expect(packagesArray).toContain(pkgId)
+    }
+  })
+
   test('vulnerable package with multiple versions is updated', async () => {
     await addDistTag({ package: 'form-data', version: '4.0.4', distTag: 'latest' })
 

--- a/deps/compliance/commands/test/audit/fixtures/update-min-release-age/package.json
+++ b/deps/compliance/commands/test/audit/fixtures/update-min-release-age/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "update-min-release-age",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pnpm.e2e/bravo-dep": "^1.0.0"
+  }
+}

--- a/deps/compliance/commands/test/audit/fixtures/update-min-release-age/pnpm-lock.yaml
+++ b/deps/compliance/commands/test/audit/fixtures/update-min-release-age/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@pnpm.e2e/bravo-dep':
+        specifier: ^1.0.0
+        version: 1.0.0
+
+packages:
+
+  '@pnpm.e2e/bravo-dep@1.0.0':
+    resolution: {integrity: sha512-XA8bN2HiHVbGzk+6G5lrLLtpt2A9CqmViNkgtLIOLTqsIbcGDFA4F/2LQ7Nak5Q7Ki1llODitpfEjsvVXf+n1g==}
+
+snapshots:
+
+  '@pnpm.e2e/bravo-dep@1.0.0': {}

--- a/deps/compliance/commands/test/audit/fixtures/update-min-release-age/responses/min-release-age-vulnerability.json
+++ b/deps/compliance/commands/test/audit/fixtures/update-min-release-age/responses/min-release-age-vulnerability.json
@@ -1,0 +1,35 @@
+{
+  "@pnpm.e2e/bravo-dep": [
+    {
+      "findings": [
+        {
+          "version": "1.0.0",
+          "paths": [
+            ".>@pnpm.e2e/bravo-dep"
+          ]
+        }
+      ],
+      "metadata": null,
+      "vulnerable_versions": "<1.0.1",
+      "module_name": "@pnpm.e2e/bravo-dep",
+      "severity": "high",
+      "github_advisory_id": "GHSA-mock-mock-mock",
+      "cves": [],
+      "access": "public",
+      "patched_versions": ">=1.0.1",
+      "updated": "2025-12-19T19:00:00.000Z",
+      "recommendation": "Upgrade to version 1.0.1 or later",
+      "cwe": "",
+      "found_by": null,
+      "deleted": null,
+      "id": 123456,
+      "references": "",
+      "created": "2025-12-19T19:00:00.000Z",
+      "reported_by": null,
+      "title": "Title: mock vulnerability in @pnpm.e2e/bravo-dep",
+      "npm_advisory_id": null,
+      "overview": "Overview: mock vulnerability in @pnpm.e2e/bravo-dep",
+      "url": "https://example.com"
+    }
+  ]
+}


### PR DESCRIPTION
Adding overrides to the minimum release age is a solid default policy for updating packages due to vulnerabilities. However, to support workflows that desire manual management of these exclusions, this PR adds an option to prevent --fix from automatically applying them. 

Semi-related https://github.com/pnpm/pnpm/issues/10263

---
I'm a bit unsure about the option name `--frozen-minimum-release-age-exclude `. The option from https://github.com/pnpm/pnpm/pull/11339,  `--bypass-minimum-release-age`, might be more fitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag to the audit command to prevent automatically adding packages to the "minimum release age" exclusion when fixing vulnerabilities.

* **Tests**
  * Added tests and fixtures verifying that vulnerabilities subject to minimum-release-age remain unchanged when the flag is used.

* **Chores**
  * Updated CLI help and release notes entries to document the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->