### PR TITLE
perf(pacquet): lazy packument hydration, sharded meta cache, and an indexed metadata mirror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,6 +4135,7 @@ dependencies = [
  "ssri",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ rayon = { version = "1.12.0" }
 rmp-serde = { version = "1.3.0" }
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = { version = "1.0.150", features = ["preserve_order"] }
+serde_json = { version = "1.0.150", features = ["preserve_order", "raw_value"] }
 serde-saphyr = { version = "0.0.27" }
 # 0.11 removes the LowerHex impl on Output; revisit after upstream/consumers catch up
 sha2               = { version = "0.10.9" }

--- a/pacquet/crates/cli/src/cli_args/outdated.rs
+++ b/pacquet/crates/cli/src/cli_args/outdated.rs
@@ -146,7 +146,7 @@ pub async fn collect_outdated(
                 current,
                 target: target.version.clone(),
                 deprecated,
-                homepage: package.homepage.clone(),
+                homepage: package.homepage,
             })
         });
 
@@ -156,11 +156,11 @@ pub async fn collect_outdated(
 /// Resolve the [`TargetVersion`] to a concrete published version, or
 /// `None` when the registry has no matching version (no `latest` tag, no
 /// in-range version, or a non-semver range).
-fn resolve_target<'a>(
-    package: &'a Package,
+fn resolve_target(
+    package: &Package,
     range: &str,
     target_version: TargetVersion,
-) -> Option<&'a PackageVersion> {
+) -> Option<std::sync::Arc<PackageVersion>> {
     match target_version {
         TargetVersion::Latest => {
             let tag = package.dist_tag("latest")?;

--- a/pacquet/crates/registry/Cargo.toml
+++ b/pacquet/crates/registry/Cargo.toml
@@ -20,6 +20,7 @@ node-semver = { workspace = true }
 pipe-trait  = { workspace = true }
 serde       = { workspace = true }
 serde_json  = { workspace = true }
+tracing     = { workspace = true }
 ssri        = { workspace = true }
 tokio       = { workspace = true }
 miette      = { workspace = true }

--- a/pacquet/crates/registry/src/lib.rs
+++ b/pacquet/crates/registry/src/lib.rs
@@ -2,11 +2,13 @@ mod package;
 mod package_distribution;
 mod package_tag;
 mod package_version;
+mod package_versions;
 
 pub use package::Package;
 pub use package_distribution::{AttestationsDist, PackageDistribution, ProvenanceMeta};
 pub use package_tag::PackageTag;
 pub use package_version::{Approver, NpmUser, PackageVersion, TrustedPublisher};
+pub use package_versions::PackageVersions;
 
 use derive_more::{Display, Error, From};
 use miette::Diagnostic;

--- a/pacquet/crates/registry/src/package.rs
+++ b/pacquet/crates/registry/src/package.rs
@@ -145,9 +145,12 @@ impl Package {
     #[must_use]
     pub fn pinned_version(&self, version_range: &str) -> Option<Arc<PackageVersion>> {
         let range: node_semver::Range = version_range.parse().unwrap(); // TODO: this step should have happened in PackageManifest
-        // Match on the version *strings* so only the winning manifest
-        // hydrates from its raw fragment.
-        let highest = self
+        // Match on the version *strings* so only winning manifests
+        // hydrate from their raw fragments. Walk the candidates from
+        // highest to lowest: an undecodable fragment behaves as if
+        // the version were absent, so the next-best match wins
+        // instead of the lookup reporting no match at all.
+        let mut satisfying = self
             .versions
             .keys()
             .filter_map(|key| {
@@ -156,15 +159,18 @@ impl Package {
                     .filter(|version| version.satisfies(&range))
                     .map(|version| (version, key))
             })
-            .max_by(|(left, _), (right, _)| left.partial_cmp(right).unwrap())?;
-        self.versions.get(highest.1)
+            .collect::<Vec<_>>();
+        satisfying.sort_by(|(left, _), (right, _)| right.partial_cmp(left).unwrap());
+        satisfying.into_iter().find_map(|(_, key)| self.versions.get(key))
     }
 
+    /// Manifest under `dist-tags.latest`. `None` when the tag is
+    /// absent, names a version the packument doesn't carry, or the
+    /// version's fragment fails to decode — registry-served data must
+    /// not be able to panic the process.
     #[must_use]
-    pub fn latest(&self) -> Arc<PackageVersion> {
-        let version =
-            self.dist_tags.get("latest").expect("latest tag is expected but not found for package");
-        self.versions.get(version).expect("manifest of the latest version should decode")
+    pub fn latest(&self) -> Option<Arc<PackageVersion>> {
+        self.versions.get(self.dist_tags.get("latest")?)
     }
 }
 

--- a/pacquet/crates/registry/src/package.rs
+++ b/pacquet/crates/registry/src/package.rs
@@ -7,14 +7,16 @@ use pacquet_network::{AuthHeaders, ThrottledClient};
 use pipe_trait::Pipe;
 use serde::{Deserialize, Serialize};
 
-use crate::{NetworkError, RegistryError, package_version::PackageVersion};
+use crate::{
+    NetworkError, RegistryError, package_version::PackageVersion, package_versions::PackageVersions,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Package {
     pub name: String,
     #[serde(rename = "dist-tags")]
     pub dist_tags: HashMap<String, String>,
-    pub versions: HashMap<String, PackageVersion>,
+    pub versions: PackageVersions,
 
     /// Per-version publish timestamps as the npm registry reports
     /// them. Each key is either a version string (value: ISO-8601
@@ -141,26 +143,28 @@ impl Package {
     }
 
     #[must_use]
-    pub fn pinned_version(&self, version_range: &str) -> Option<&PackageVersion> {
+    pub fn pinned_version(&self, version_range: &str) -> Option<Arc<PackageVersion>> {
         let range: node_semver::Range = version_range.parse().unwrap(); // TODO: this step should have happened in PackageManifest
-        let mut satisfied_versions = self
+        // Match on the version *strings* so only the winning manifest
+        // hydrates from its raw fragment.
+        let highest = self
             .versions
-            .values()
-            .filter(|version| version.version.satisfies(&range))
-            .collect::<Vec<&PackageVersion>>();
-
-        satisfied_versions.sort_by(|a, b| a.version.partial_cmp(&b.version).unwrap());
-
-        // Optimization opportunity:
-        // We can store this in a cache to remove filter operation and make this a O(1) operation.
-        satisfied_versions.last().copied()
+            .keys()
+            .filter_map(|key| {
+                key.parse::<node_semver::Version>()
+                    .ok()
+                    .filter(|version| version.satisfies(&range))
+                    .map(|version| (version, key))
+            })
+            .max_by(|(left, _), (right, _)| left.partial_cmp(right).unwrap())?;
+        self.versions.get(highest.1)
     }
 
     #[must_use]
-    pub fn latest(&self) -> &PackageVersion {
+    pub fn latest(&self) -> Arc<PackageVersion> {
         let version =
             self.dist_tags.get("latest").expect("latest tag is expected but not found for package");
-        self.versions.get(version).unwrap()
+        self.versions.get(version).expect("manifest of the latest version should decode")
     }
 }
 

--- a/pacquet/crates/registry/src/package/tests.rs
+++ b/pacquet/crates/registry/src/package/tests.rs
@@ -145,7 +145,7 @@ fn package_equality_compares_by_name_only() {
 fn latest_returns_version_pointed_to_by_dist_tag() {
     let pkg = package_with_versions("acme", &["1.0.0", "2.0.0", "3.0.0"], "2.0.0");
     let latest = pkg.latest();
-    assert_eq!(latest.version.to_string(), "2.0.0");
+    assert_eq!(latest.expect("latest manifest decodes").version.to_string(), "2.0.0");
 }
 
 /// `pinned_version` picks the highest version inside the given

--- a/pacquet/crates/registry/src/package_versions.rs
+++ b/pacquet/crates/registry/src/package_versions.rs
@@ -83,11 +83,13 @@ impl PackageVersions {
     /// Typed manifest for `version`, hydrating the raw fragment on
     /// first access. `None` when the version is absent *or* its
     /// fragment fails to decode.
+    #[must_use]
     pub fn get(&self, version: &str) -> Option<Arc<PackageVersion>> {
         self.slots.get(version)?.hydrate(version)
     }
 
     /// Whether the packument lists `version`. Never hydrates.
+    #[must_use]
     pub fn contains_key(&self, version: &str) -> bool {
         self.slots.contains_key(version)
     }
@@ -97,10 +99,12 @@ impl PackageVersions {
         self.slots.keys()
     }
 
+    #[must_use]
     pub fn len(&self) -> usize {
         self.slots.len()
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.slots.is_empty()
     }
@@ -117,6 +121,7 @@ impl PackageVersions {
     /// move as fragments — nothing hydrates. Used by the
     /// publish-date filter, which decides on the packument's `time`
     /// map rather than the manifests.
+    #[must_use]
     pub fn filtered(&self, mut keep: impl FnMut(&str) -> bool) -> PackageVersions {
         PackageVersions {
             slots: self

--- a/pacquet/crates/registry/src/package_versions.rs
+++ b/pacquet/crates/registry/src/package_versions.rs
@@ -58,8 +58,8 @@ enum FragmentSource {
 
 impl FragmentSource {
     /// The fragment's JSON text: borrowed for [`FragmentSource::Raw`],
-    /// read from disk for [`FragmentSource::FileSpan`], absent for
-    /// [`FragmentSource::None`] or on a read failure.
+    /// read from the shared buffer for [`FragmentSource::BufferSpan`],
+    /// absent for [`FragmentSource::None`] or invalid spans.
     fn json(&self) -> Option<Cow<'_, str>> {
         match self {
             FragmentSource::Raw(raw) => Some(Cow::Borrowed(raw.get())),
@@ -292,7 +292,15 @@ impl Serialize for PackageVersions {
             if let Some(json) = slot.source.json() {
                 match serde_json::from_str::<&RawValue>(&json) {
                     Ok(raw) => map.serialize_entry(version, raw)?,
-                    Err(_) => continue,
+                    Err(error) => {
+                        tracing::warn!(
+                            target: "pacquet_registry",
+                            %error,
+                            version,
+                            "skipping registry version with a corrupt fragment during serialization",
+                        );
+                        continue;
+                    }
                 }
                 continue;
             }

--- a/pacquet/crates/registry/src/package_versions.rs
+++ b/pacquet/crates/registry/src/package_versions.rs
@@ -16,6 +16,7 @@
 //! version entries they don't pick.
 
 use std::{
+    borrow::Cow,
     collections::HashMap,
     sync::{Arc, OnceLock},
 };
@@ -32,19 +33,62 @@ pub struct PackageVersions {
 
 #[derive(Debug)]
 struct VersionSlot {
-    /// Raw JSON fragment as served by the registry. `None` only for
-    /// slots constructed from an already-typed manifest (tests, the
-    /// publish-date filter's slot moves).
-    raw: Option<Arc<RawValue>>,
+    source: FragmentSource,
     /// Hydration cache. `Some(None)` records a fragment that failed
     /// to decode so the parse error is paid (and warned about) once.
     parsed: OnceLock<Option<Arc<PackageVersion>>>,
 }
 
+/// Where a version's JSON fragment lives until it is hydrated.
+#[derive(Debug, Clone)]
+enum FragmentSource {
+    /// Raw JSON fragment as served by the registry (the serde parse
+    /// of a packument body captures these).
+    Raw(Arc<RawValue>),
+    /// Byte span inside an indexed on-disk metadata mirror, whose
+    /// contents the loader read into one shared buffer. Hydration
+    /// parses the span in place — no per-fragment file I/O (the pick
+    /// paths can probe many candidate fragments per package, so
+    /// open-per-hydration measured slower than one sequential read).
+    BufferSpan { buffer: Arc<Vec<u8>>, offset: u64, len: u32 },
+    /// No fragment — the slot was constructed from an already-typed
+    /// manifest (tests, the publish-date filter's slot moves).
+    None,
+}
+
+impl FragmentSource {
+    /// The fragment's JSON text: borrowed for [`FragmentSource::Raw`],
+    /// read from disk for [`FragmentSource::FileSpan`], absent for
+    /// [`FragmentSource::None`] or on a read failure.
+    fn json(&self) -> Option<Cow<'_, str>> {
+        match self {
+            FragmentSource::Raw(raw) => Some(Cow::Borrowed(raw.get())),
+            FragmentSource::BufferSpan { buffer, offset, len } => {
+                let start = usize::try_from(*offset).ok()?;
+                let end = start.checked_add(*len as usize)?;
+                let bytes = buffer.get(start..end)?;
+                match std::str::from_utf8(bytes) {
+                    Ok(json) => Some(Cow::Borrowed(json)),
+                    Err(error) => {
+                        tracing::warn!(
+                            target: "pacquet_registry",
+                            %error,
+                            offset,
+                            "metadata mirror fragment is not valid UTF-8",
+                        );
+                        None
+                    }
+                }
+            }
+            FragmentSource::None => None,
+        }
+    }
+}
+
 impl Clone for VersionSlot {
     fn clone(&self) -> Self {
         VersionSlot {
-            raw: self.raw.clone(),
+            source: self.source.clone(),
             parsed: match self.parsed.get() {
                 Some(value) => OnceLock::from(value.clone()),
                 None => OnceLock::new(),
@@ -55,14 +99,17 @@ impl Clone for VersionSlot {
 
 impl VersionSlot {
     fn from_parsed(manifest: PackageVersion) -> Self {
-        VersionSlot { raw: None, parsed: OnceLock::from(Some(Arc::new(manifest))) }
+        VersionSlot {
+            source: FragmentSource::None,
+            parsed: OnceLock::from(Some(Arc::new(manifest))),
+        }
     }
 
     fn hydrate(&self, version: &str) -> Option<Arc<PackageVersion>> {
         self.parsed
             .get_or_init(|| {
-                let raw = self.raw.as_ref()?;
-                match serde_json::from_str::<PackageVersion>(raw.get()) {
+                let json = self.source.json()?;
+                match serde_json::from_str::<PackageVersion>(&json) {
                     Ok(parsed) => Some(Arc::new(parsed)),
                     Err(error) => {
                         tracing::warn!(
@@ -134,6 +181,68 @@ impl PackageVersions {
     }
 }
 
+/// Constructors and accessors for the indexed on-disk mirror format
+/// (see `pacquet-resolving-npm-resolver`'s `mirror` module, which owns
+/// the file layout).
+impl PackageVersions {
+    /// Build a map whose fragments are byte spans inside `buffer`
+    /// (the indexed mirror file's contents). Nothing parses until a
+    /// version hydrates.
+    #[must_use]
+    pub fn from_buffer_spans(
+        buffer: &Arc<Vec<u8>>,
+        spans: impl IntoIterator<Item = (String, u64, u32)>,
+    ) -> Self {
+        PackageVersions {
+            slots: spans
+                .into_iter()
+                .map(|(version, offset, len)| {
+                    (
+                        version,
+                        VersionSlot {
+                            source: FragmentSource::BufferSpan {
+                                buffer: Arc::clone(buffer),
+                                offset,
+                                len,
+                            },
+                            parsed: OnceLock::new(),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    /// Iterate every version's JSON fragment text, for the mirror
+    /// writer. Raw fragments borrow; slots holding only a typed
+    /// manifest re-serialize it; file-span slots read their span.
+    /// A slot whose fragment can be neither borrowed nor produced is
+    /// skipped with a warning — the mirror then simply omits that
+    /// version, which reads back as "absent" (the same contract as an
+    /// undecodable fragment).
+    pub fn fragments(&self) -> impl Iterator<Item = (&String, Cow<'_, str>)> {
+        self.slots.iter().filter_map(|(version, slot)| {
+            if let Some(json) = slot.source.json() {
+                return Some((version, json));
+            }
+            if let Some(Some(parsed)) = slot.parsed.get() {
+                match serde_json::to_string(parsed.as_ref()) {
+                    Ok(json) => return Some((version, Cow::Owned(json))),
+                    Err(error) => {
+                        tracing::warn!(
+                            target: "pacquet_registry",
+                            %error,
+                            version,
+                            "failed to re-serialize a typed manifest for the metadata mirror",
+                        );
+                    }
+                }
+            }
+            None
+        })
+    }
+}
+
 impl From<HashMap<String, PackageVersion>> for PackageVersions {
     fn from(versions: HashMap<String, PackageVersion>) -> Self {
         PackageVersions {
@@ -158,7 +267,13 @@ impl<'de> Deserialize<'de> for PackageVersions {
             slots: raw_map
                 .into_iter()
                 .map(|(version, raw)| {
-                    (version, VersionSlot { raw: Some(Arc::from(raw)), parsed: OnceLock::new() })
+                    (
+                        version,
+                        VersionSlot {
+                            source: FragmentSource::Raw(Arc::from(raw)),
+                            parsed: OnceLock::new(),
+                        },
+                    )
                 })
                 .collect(),
         })
@@ -170,17 +285,23 @@ impl Serialize for PackageVersions {
         use serde::ser::SerializeMap;
         let mut map = serializer.serialize_map(Some(self.slots.len()))?;
         for (version, slot) in &self.slots {
-            match (&slot.raw, slot.parsed.get()) {
-                // Raw fragments round-trip verbatim — re-serializing a
-                // hydrated manifest would reorder keys and drop nothing
-                // but risks shape drift; the wire bytes are canonical.
-                (Some(raw), _) => map.serialize_entry(version, raw.as_ref())?,
-                (None, Some(Some(parsed))) => map.serialize_entry(version, parsed.as_ref())?,
-                // Unreachable by construction (a slot always has a raw
-                // fragment or a pre-set parsed manifest); skip rather
-                // than panic inside a serializer.
-                (None, _) => {}
+            // Fragments round-trip verbatim — re-serializing a hydrated
+            // manifest would reorder keys; the wire bytes are canonical.
+            // File-span fragments read their span here (rare: only a
+            // file-loaded packument being re-serialized).
+            if let Some(json) = slot.source.json() {
+                match serde_json::from_str::<&RawValue>(&json) {
+                    Ok(raw) => map.serialize_entry(version, raw)?,
+                    Err(_) => continue,
+                }
+                continue;
             }
+            if let Some(Some(parsed)) = slot.parsed.get() {
+                map.serialize_entry(version, parsed.as_ref())?;
+            }
+            // A slot with neither a readable fragment nor a typed
+            // manifest serializes as absent rather than panicking
+            // inside the serializer.
         }
         map.end()
     }

--- a/pacquet/crates/registry/src/package_versions.rs
+++ b/pacquet/crates/registry/src/package_versions.rs
@@ -1,0 +1,185 @@
+//! Lazily-hydrated view of a packument's `versions` map.
+//!
+//! Hydrating every version of a multi-thousand-release packument into
+//! typed [`PackageVersion`]s dominated resolve CPU: the maps, strings,
+//! and `serde_json::Value` trees behind each version are built, hashed,
+//! and dropped even though a pick consults only the version *strings*
+//! plus the handful of manifests it actually considers. Each version
+//! therefore stays as the raw JSON fragment serde captured — an
+//! [`Arc<RawValue>`], shared rather than copied — until someone asks
+//! for the typed form, and the hydrated manifest is cached per slot so
+//! repeated lookups parse once.
+//!
+//! A fragment that fails to decode behaves as if the version were
+//! absent from the packument (with a `tracing::warn`), mirroring the
+//! tolerance of JavaScript package managers, which never validate
+//! version entries they don't pick.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, OnceLock},
+};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::value::RawValue;
+
+use crate::package_version::PackageVersion;
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageVersions {
+    slots: HashMap<String, VersionSlot>,
+}
+
+#[derive(Debug)]
+struct VersionSlot {
+    /// Raw JSON fragment as served by the registry. `None` only for
+    /// slots constructed from an already-typed manifest (tests, the
+    /// publish-date filter's slot moves).
+    raw: Option<Arc<RawValue>>,
+    /// Hydration cache. `Some(None)` records a fragment that failed
+    /// to decode so the parse error is paid (and warned about) once.
+    parsed: OnceLock<Option<Arc<PackageVersion>>>,
+}
+
+impl Clone for VersionSlot {
+    fn clone(&self) -> Self {
+        VersionSlot {
+            raw: self.raw.clone(),
+            parsed: match self.parsed.get() {
+                Some(value) => OnceLock::from(value.clone()),
+                None => OnceLock::new(),
+            },
+        }
+    }
+}
+
+impl VersionSlot {
+    fn from_parsed(manifest: PackageVersion) -> Self {
+        VersionSlot { raw: None, parsed: OnceLock::from(Some(Arc::new(manifest))) }
+    }
+
+    fn hydrate(&self, version: &str) -> Option<Arc<PackageVersion>> {
+        self.parsed
+            .get_or_init(|| {
+                let raw = self.raw.as_ref()?;
+                match serde_json::from_str::<PackageVersion>(raw.get()) {
+                    Ok(parsed) => Some(Arc::new(parsed)),
+                    Err(error) => {
+                        tracing::warn!(
+                            target: "pacquet_registry",
+                            %error,
+                            version,
+                            "skipping registry version with an undecodable manifest",
+                        );
+                        None
+                    }
+                }
+            })
+            .clone()
+    }
+}
+
+impl PackageVersions {
+    /// Typed manifest for `version`, hydrating the raw fragment on
+    /// first access. `None` when the version is absent *or* its
+    /// fragment fails to decode.
+    pub fn get(&self, version: &str) -> Option<Arc<PackageVersion>> {
+        self.slots.get(version)?.hydrate(version)
+    }
+
+    /// Whether the packument lists `version`. Never hydrates.
+    pub fn contains_key(&self, version: &str) -> bool {
+        self.slots.contains_key(version)
+    }
+
+    /// Version strings, in `HashMap` order. Never hydrates.
+    pub fn keys(&self) -> impl Iterator<Item = &String> {
+        self.slots.keys()
+    }
+
+    pub fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.slots.is_empty()
+    }
+
+    /// Iterate `(version, manifest)` pairs, hydrating every fragment.
+    /// Undecodable fragments are skipped. Full walks defeat the lazy
+    /// representation, so this belongs only on cold paths (the trust
+    /// verifier's history scan, tests).
+    pub fn iter(&self) -> impl Iterator<Item = (&String, Arc<PackageVersion>)> {
+        self.slots.iter().filter_map(|(version, slot)| Some((version, slot.hydrate(version)?)))
+    }
+
+    /// Filtered copy keeping only the versions `keep` accepts. Slots
+    /// move as fragments — nothing hydrates. Used by the
+    /// publish-date filter, which decides on the packument's `time`
+    /// map rather than the manifests.
+    pub fn filtered(&self, mut keep: impl FnMut(&str) -> bool) -> PackageVersions {
+        PackageVersions {
+            slots: self
+                .slots
+                .iter()
+                .filter(|(version, _)| keep(version))
+                .map(|(version, slot)| (version.clone(), slot.clone()))
+                .collect(),
+        }
+    }
+}
+
+impl From<HashMap<String, PackageVersion>> for PackageVersions {
+    fn from(versions: HashMap<String, PackageVersion>) -> Self {
+        PackageVersions {
+            slots: versions
+                .into_iter()
+                .map(|(version, manifest)| (version, VersionSlot::from_parsed(manifest)))
+                .collect(),
+        }
+    }
+}
+
+impl FromIterator<(String, PackageVersion)> for PackageVersions {
+    fn from_iter<Iter: IntoIterator<Item = (String, PackageVersion)>>(iter: Iter) -> Self {
+        iter.into_iter().collect::<HashMap<_, _>>().into()
+    }
+}
+
+impl<'de> Deserialize<'de> for PackageVersions {
+    fn deserialize<Deser: Deserializer<'de>>(deserializer: Deser) -> Result<Self, Deser::Error> {
+        let raw_map = HashMap::<String, Box<RawValue>>::deserialize(deserializer)?;
+        Ok(PackageVersions {
+            slots: raw_map
+                .into_iter()
+                .map(|(version, raw)| {
+                    (version, VersionSlot { raw: Some(Arc::from(raw)), parsed: OnceLock::new() })
+                })
+                .collect(),
+        })
+    }
+}
+
+impl Serialize for PackageVersions {
+    fn serialize<Ser: Serializer>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error> {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(self.slots.len()))?;
+        for (version, slot) in &self.slots {
+            match (&slot.raw, slot.parsed.get()) {
+                // Raw fragments round-trip verbatim — re-serializing a
+                // hydrated manifest would reorder keys and drop nothing
+                // but risks shape drift; the wire bytes are canonical.
+                (Some(raw), _) => map.serialize_entry(version, raw.as_ref())?,
+                (None, Some(Some(parsed))) => map.serialize_entry(version, parsed.as_ref())?,
+                // Unreachable by construction (a slot always has a raw
+                // fragment or a pre-set parsed manifest); skip rather
+                // than panic inside a serializer.
+                (None, _) => {}
+            }
+        }
+        map.end()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/registry/src/package_versions/tests.rs
+++ b/pacquet/crates/registry/src/package_versions/tests.rs
@@ -93,3 +93,36 @@ fn filtered_keeps_slots_without_hydration() {
     assert_eq!(filtered.len(), 1);
     assert!(filtered.get("1.0.0").is_some());
 }
+
+/// `pinned_version` walks satisfying candidates from highest to
+/// lowest, so an undecodable winner falls back to the next match
+/// instead of reporting no match for the whole range.
+#[test]
+fn pinned_version_falls_back_past_undecodable_highest() {
+    let package = parse_package(
+        r#"{
+            "name": "foo",
+            "dist-tags": {},
+            "versions": {
+                "1.0.0": {"name": "foo", "version": "1.0.0", "dist": {"integrity": "sha512-a", "tarball": "https://r/foo-1.0.0.tgz"}},
+                "1.9.0": {"corrupt": "fragment"}
+            }
+        }"#,
+    );
+    let pinned = package.pinned_version("^1.0.0").expect("fall back to 1.0.0");
+    assert_eq!(pinned.version.to_string(), "1.0.0");
+}
+
+/// `latest` degrades to `None` on registry data it can't use — a
+/// dangling dist-tag or an undecodable manifest — instead of
+/// panicking.
+#[test]
+fn latest_returns_none_for_dangling_or_undecodable_tag() {
+    let undecodable = parse_package(
+        r#"{"name": "foo", "dist-tags": {"latest": "2.0.0"}, "versions": {"2.0.0": {"corrupt": true}}}"#,
+    );
+    assert!(undecodable.latest().is_none());
+    let dangling =
+        parse_package(r#"{"name": "foo", "dist-tags": {"latest": "9.9.9"}, "versions": {}}"#);
+    assert!(dangling.latest().is_none());
+}

--- a/pacquet/crates/registry/src/package_versions/tests.rs
+++ b/pacquet/crates/registry/src/package_versions/tests.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+
+use crate::{Package, PackageVersion};
+
+fn parse_package(json: &str) -> Package {
+    serde_json::from_str(json).expect("parse package")
+}
+
+#[test]
+fn hydrates_only_requested_versions_and_caches_them() {
+    let package = parse_package(
+        r#"{
+            "name": "foo",
+            "dist-tags": {"latest": "2.0.0"},
+            "versions": {
+                "1.0.0": {"name": "foo", "version": "1.0.0", "dist": {"integrity": "sha512-a", "tarball": "https://r/foo-1.0.0.tgz"}},
+                "2.0.0": {"name": "foo", "version": "2.0.0", "dist": {"integrity": "sha512-b", "tarball": "https://r/foo-2.0.0.tgz"}}
+            }
+        }"#,
+    );
+
+    assert_eq!(package.versions.len(), 2);
+    assert!(package.versions.contains_key("1.0.0"));
+    let picked = package.versions.get("2.0.0").expect("hydrate 2.0.0");
+    assert_eq!(picked.version.to_string(), "2.0.0");
+    // Second lookup returns the cached Arc.
+    let again = package.versions.get("2.0.0").expect("cached 2.0.0");
+    assert!(std::sync::Arc::ptr_eq(&picked, &again));
+}
+
+#[test]
+fn undecodable_fragment_behaves_as_absent() {
+    let package = parse_package(
+        r#"{
+            "name": "foo",
+            "dist-tags": {},
+            "versions": {
+                "1.0.0": {"name": "foo", "version": "1.0.0", "dist": {"integrity": "sha512-a", "tarball": "https://r/foo-1.0.0.tgz"}},
+                "9.9.9": {"this is": "not a version manifest"}
+            }
+        }"#,
+    );
+
+    // The key is listed (key scans never hydrate)...
+    assert!(package.versions.contains_key("9.9.9"));
+    // ...but hydration fails closed to "absent" instead of erroring.
+    assert!(package.versions.get("9.9.9").is_none());
+    assert!(package.versions.get("1.0.0").is_some());
+    assert_eq!(package.versions.iter().count(), 1);
+}
+
+#[test]
+fn serializes_raw_fragments_verbatim() {
+    let json = r#"{
+        "name": "foo",
+        "dist-tags": {},
+        "versions": {
+            "1.0.0": {"name": "foo", "version": "1.0.0", "dist": {"integrity": "sha512-a", "tarball": "https://r/foo-1.0.0.tgz"}, "extraKeyTheStructDoesNotType": [1, 2, {"deep": true}]}
+        }
+    }"#;
+    let package = parse_package(json);
+    let round_tripped = serde_json::to_string(&package).expect("serialize package");
+    let reparsed: serde_json::Value = serde_json::from_str(&round_tripped).unwrap();
+    let original: serde_json::Value = serde_json::from_str(json).unwrap();
+    assert_eq!(reparsed["versions"], original["versions"]);
+}
+
+#[test]
+fn eager_construction_from_typed_manifests_round_trips() {
+    let manifest: PackageVersion = serde_json::from_str(
+        r#"{"name": "foo", "version": "1.0.0", "dist": {"integrity": "sha512-a", "tarball": "https://r/foo-1.0.0.tgz"}}"#,
+    )
+    .unwrap();
+    let versions: crate::PackageVersions = HashMap::from([("1.0.0".to_string(), manifest)]).into();
+    assert_eq!(versions.get("1.0.0").unwrap().version.to_string(), "1.0.0");
+    let json = serde_json::to_string(&versions).unwrap();
+    assert!(json.contains("\"1.0.0\""));
+}
+
+#[test]
+fn filtered_keeps_slots_without_hydration() {
+    let package = parse_package(
+        r#"{
+            "name": "foo",
+            "dist-tags": {},
+            "versions": {
+                "1.0.0": {"name": "foo", "version": "1.0.0", "dist": {"integrity": "sha512-a", "tarball": "https://r/foo-1.0.0.tgz"}},
+                "2.0.0": {"name": "foo", "version": "2.0.0", "dist": {"integrity": "sha512-b", "tarball": "https://r/foo-2.0.0.tgz"}}
+            }
+        }"#,
+    );
+    let filtered = package.versions.filtered(|version| version == "1.0.0");
+    assert_eq!(filtered.len(), 1);
+    assert!(filtered.get("1.0.0").is_some());
+}

--- a/pacquet/crates/registry/src/package_versions/tests.rs
+++ b/pacquet/crates/registry/src/package_versions/tests.rs
@@ -74,7 +74,7 @@ fn eager_construction_from_typed_manifests_round_trips() {
     let versions: crate::PackageVersions = HashMap::from([("1.0.0".to_string(), manifest)]).into();
     assert_eq!(versions.get("1.0.0").unwrap().version.to_string(), "1.0.0");
     let json = serde_json::to_string(&versions).unwrap();
-    assert!(json.contains("\"1.0.0\""));
+    assert!(json.contains(r#""1.0.0""#));
 }
 
 #[test]

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -989,7 +989,7 @@ fn project_trust_meta(meta: &Package) -> Package {
     let versions = meta
         .versions
         .iter()
-        .map(|(version, manifest)| (version.clone(), project_trust_package_version(manifest)))
+        .map(|(version, manifest)| (version.clone(), project_trust_package_version(&manifest)))
         .collect();
     Package {
         name: meta.name.clone(),

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -12,9 +12,9 @@
 //! to a plain GET — the same behavior callers got before Phase 5
 //! from [`crate::fetch_full_metadata()`].
 //!
-//! The cache layout matches pnpm's so a pnpm-populated mirror is
-//! usable from pacquet (and vice versa). The two-line NDJSON shape
-//! lives in [`crate::mirror`].
+//! The directory layout matches pnpm's; the file format is pacquet's
+//! own indexed shape (see [`crate::mirror`]) so warm loads hydrate
+//! only the version fragments a pick consults.
 
 use std::path::Path;
 
@@ -28,7 +28,7 @@ use crate::{
     fetch_full_metadata::{ACCEPT_ABBREVIATED_DOC, ACCEPT_FULL_DOC},
     mirror::{
         ABBREVIATED_META_DIR, FULL_META_DIR, get_pkg_mirror_path, load_meta_async,
-        load_meta_headers_async, prepare_json_for_disk, save_meta,
+        load_meta_headers_async, save_meta_indexed,
     },
     registry_url::to_registry_url,
 };
@@ -190,29 +190,20 @@ pub async fn fetch_full_metadata_cached(
             .map_err(|error| FetchMetadataError::Decode { url: task_url, error })?;
 
         if let Some(path) = mirror_path.as_deref() {
-            match prepare_json_for_disk(&meta, etag.as_deref(), Some(&raw_body)) {
-                Ok(json) => {
-                    if let Err(error) = save_meta(path, &json) {
-                        // Fire-and-forget — a read-only cache dir or a
-                        // shared-store contention shouldn't fail the
-                        // install. The user just won't see the warm-cache
-                        // speedup next time.
-                        tracing::debug!(
-                            target: "pacquet_resolving_npm_resolver::cache",
-                            ?error,
-                            path = %path.display(),
-                            "could not persist mirror; bypassing cache write",
-                        );
-                    }
-                }
-                Err(error) => {
-                    tracing::debug!(
-                        target: "pacquet_resolving_npm_resolver::cache",
-                        ?error,
-                        path = %path.display(),
-                        "could not serialize mirror entry; bypassing cache write",
-                    );
-                }
+            // The lazily-parsed `meta` still borrows every version
+            // fragment from `raw_body`, so the indexed write streams
+            // the registry's own bytes — no re-serialization.
+            if let Err(error) = save_meta_indexed(path, &meta, etag.as_deref()) {
+                // Fire-and-forget — a read-only cache dir or a
+                // shared-store contention shouldn't fail the
+                // install. The user just won't see the warm-cache
+                // speedup next time.
+                tracing::debug!(
+                    target: "pacquet_resolving_npm_resolver::cache",
+                    ?error,
+                    path = %path.display(),
+                    "could not persist mirror; bypassing cache write",
+                );
             }
         }
         Ok(meta)

--- a/pacquet/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/mirror.rs
@@ -5,14 +5,32 @@
 //! the verifier needs to share the resolver's metadata mirror:
 //!
 //! - [`get_pkg_mirror_path`] — `<cache_dir>/<meta_dir>/<registry-encoded>/<encoded-name>.jsonl`.
-//! - [`prepare_json_for_disk`] — two-line NDJSON shape (header line +
-//!   body line) the registry-metadata cache uses.
-//! - [`load_meta_headers`] — read just the first line (etag, modified)
-//!   to feed conditional GETs without paying for the body parse.
-//! - [`load_meta`] — read both lines and reconstruct a [`Package`]
-//!   with its etag back-filled.
-//! - [`save_meta`] — atomic write via temp + rename so a torn write
-//!   never leaks a half-formed mirror to the next install.
+//! - [`load_meta_headers`] — read just the headers record (etag,
+//!   modified) to feed conditional GETs without touching the rest.
+//! - [`load_meta`] — read the headers + index records and reconstruct
+//!   a [`Package`] whose versions hydrate from byte spans on demand.
+//! - [`save_meta_indexed`] — atomic write via temp + rename so a torn
+//!   write never leaks a half-formed mirror to the next install.
+//!
+//! ## File layout
+//!
+//! Pacquet's own indexed format (this cache is no longer byte-shared
+//! with other package managers):
+//!
+//! ```text
+//! pacquet-meta-v1 <headers_len> <index_len>\n
+//! <headers JSON>           # MetaHeaders: etag, modified
+//! <index JSON>             # MirrorIndex: name, dist-tags, time,
+//!                          #   homepage, versions: [version, off, len]
+//! <fragments>              # concatenated raw per-version JSON
+//! ```
+//!
+//! Offsets in the index are relative to the fragment section; the
+//! loader rebases them so each version's slot can read its span
+//! directly. A warm pick therefore costs the two leading records plus
+//! one span read per version it actually hydrates — never the whole
+//! body. Files in the older two-line NDJSON shape read as cache
+//! misses and are rewritten in this format on the next 200.
 //!
 //! Plus the constants and name-encoding rules:
 //!
@@ -26,16 +44,20 @@
 //!   produces).
 
 use std::{
+    collections::HashMap,
     fmt::Write as _,
     fs::{self, File, OpenOptions},
     io::{self, Read, Write},
     path::{Path, PathBuf},
-    sync::atomic::{AtomicU64, Ordering},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_registry::Package;
+use pacquet_registry::{Package, PackageVersions};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -83,6 +105,9 @@ pub enum SaveMetaError {
         #[error(source)]
         error: io::Error,
     },
+    #[display("{_0}")]
+    #[diagnostic(transparent)]
+    Encode(#[error(source)] EncodeMetaError),
     #[display("Failed to rename mirror temp {temp:?} → {target:?}: {error}")]
     #[diagnostic(code(pacquet_resolving_npm_resolver::mirror::rename))]
     Rename {
@@ -164,31 +189,127 @@ pub fn encode_pkg_name(pkg_name: &str) -> String {
     format!("{pkg_name}_{digest:x}")
 }
 
-/// Serialize the cache record for disk. Two-line NDJSON: the first
-/// line is the [`MetaHeaders`] JSON, the second is the registry
-/// response body — verbatim when the caller supplies `raw_body`, else
-/// re-serialized from the parsed `meta`. Mirrors pnpm's
-/// [`prepareJsonForDisk`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L575-L580).
+/// Magic + format version. The trailing space separates it from the
+/// two record lengths on the same line.
+const MIRROR_MAGIC: &str = "pacquet-meta-v1";
+
+/// Top-level packument fields persisted in the mirror's index record.
+/// Everything else a registry serves at the top level is neither read
+/// back by the resolver nor part of [`Package`], so the index keeps
+/// only what reconstruction needs. Version fragments live after this
+/// record as `(version, offset, len)` spans relative to the fragment
+/// section.
+#[derive(Debug, Serialize, Deserialize)]
+struct MirrorIndex {
+    name: String,
+    #[serde(default, rename = "distTags")]
+    dist_tags: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    time: Option<HashMap<String, serde_json::Value>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    homepage: Option<String>,
+    versions: Vec<(String, u64, u32)>,
+}
+
+/// Error from [`save_meta_indexed`]'s record-encoding step.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display("Failed to encode mirror records: {_0}")]
+#[diagnostic(code(pacquet_resolving_npm_resolver::mirror::encode))]
+pub struct EncodeMetaError(#[error(source)] serde_json::Error);
+
+/// Atomically persist `meta` at `pkg_mirror` in the indexed format.
 ///
-/// Passing `raw_body` is the fast path on a 200 response where the
-/// caller already has the response bytes — round-tripping through
-/// the parsed shape risks dropping registry-specific fields the
-/// pacquet `Package` shape doesn't model (and would diff a later
-/// install's cache against pnpm's byte-for-byte). The `meta` /
-/// `raw_body` fallback is only for tests that build the record from
-/// a typed value.
-pub fn prepare_json_for_disk(
+/// Version fragments come from [`PackageVersions::fragments`] — for a
+/// freshly-fetched packument these borrow the raw bytes the registry
+/// served, so the write is one buffered pass with no re-serialization.
+/// The cold-install cost is therefore the same one temp-file +
+/// `rename` per package as the previous format.
+pub fn save_meta_indexed(
+    pkg_mirror: &Path,
     meta: &Package,
     etag: Option<&str>,
-    raw_body: Option<&str>,
-) -> Result<String, serde_json::Error> {
-    let modified = meta.modified.clone();
-    let headers = serde_json::to_string(&MetaHeaders { etag: etag.map(str::to_string), modified })?;
-    let body = match raw_body {
-        Some(text) => text.to_string(),
-        None => serde_json::to_string(meta)?,
+) -> Result<(), SaveMetaError> {
+    let headers = serde_json::to_string(&MetaHeaders {
+        etag: etag.map(str::to_string),
+        modified: meta.modified.clone(),
+    })
+    .map_err(|error| SaveMetaError::Encode(EncodeMetaError(error)))?;
+
+    let mut fragment_bytes = Vec::new();
+    let mut spans = Vec::with_capacity(meta.versions.len());
+    for (version, json) in meta.versions.fragments() {
+        let offset = fragment_bytes.len() as u64;
+        let len = u32::try_from(json.len()).unwrap_or(u32::MAX);
+        if len as usize != json.len() {
+            // A single >4 GiB version manifest is not a thing the npm
+            // registry produces; skip it rather than corrupt the index.
+            continue;
+        }
+        fragment_bytes.extend_from_slice(json.as_bytes());
+        spans.push((version.clone(), offset, len));
+    }
+
+    let index = serde_json::to_string(&MirrorIndex {
+        name: meta.name.clone(),
+        dist_tags: meta.dist_tags.clone(),
+        time: meta.time.clone(),
+        homepage: meta.homepage.clone(),
+        versions: spans,
+    })
+    .map_err(|error| SaveMetaError::Encode(EncodeMetaError(error)))?;
+
+    let mut contents = String::with_capacity(headers.len() + index.len() + 64);
+    let _ = writeln!(contents, "{MIRROR_MAGIC} {} {}", headers.len(), index.len());
+    contents.push_str(&headers);
+    contents.push_str(&index);
+    let mut bytes = contents.into_bytes();
+    bytes.extend_from_slice(&fragment_bytes);
+    save_meta(pkg_mirror, &bytes)
+}
+
+/// Parse the `pacquet-meta-v1 <headers_len> <index_len>` line.
+/// `None` for anything else — including the previous NDJSON format,
+/// which thereby reads as a cache miss and gets rewritten on the next
+/// 200 response.
+fn parse_mirror_magic(line: &str) -> Option<(usize, usize)> {
+    let rest = line.strip_prefix(MIRROR_MAGIC)?.strip_prefix(' ')?;
+    let (headers_len, index_len) = rest.split_once(' ')?;
+    Some((headers_len.parse().ok()?, index_len.parse().ok()?))
+}
+
+/// Read the headers record off an indexed mirror without touching the
+/// index or fragment sections. `None` for anything unreadable —
+/// including the previous NDJSON format, which thereby reads as a
+/// cache miss.
+fn read_mirror_headers(file: &mut File) -> Option<MetaHeaders> {
+    // Magic + two decimal lengths fit well inside this; the headers
+    // record is ~100 bytes of etag + timestamp.
+    let mut buf = [0u8; 1024];
+    let mut filled = 0usize;
+    while filled < buf.len() {
+        let n = file.read(&mut buf[filled..]).ok()?;
+        if n == 0 {
+            break;
+        }
+        filled += n;
+    }
+    let chunk = &buf[..filled];
+    let newline = chunk.iter().position(|&byte| byte == b'\n')?;
+    let line = std::str::from_utf8(&chunk[..newline]).ok()?;
+    let (headers_len, _) = parse_mirror_magic(line)?;
+    let headers_start = newline + 1;
+    let headers_end = headers_start.checked_add(headers_len)?;
+    let headers_json: std::borrow::Cow<'_, [u8]> = if headers_end <= chunk.len() {
+        std::borrow::Cow::Borrowed(&chunk[headers_start..headers_end])
+    } else {
+        // Headers record larger than the probe buffer — read the rest.
+        let mut rest = vec![0u8; headers_end - chunk.len()];
+        file.read_exact(&mut rest).ok()?;
+        let mut whole = chunk[headers_start..].to_vec();
+        whole.extend_from_slice(&rest);
+        std::borrow::Cow::Owned(whole)
     };
-    Ok(format!("{headers}\n{body}"))
+    serde_json::from_slice(&headers_json).ok()
 }
 
 /// Read just the first line (headers JSON) of a mirror file. The
@@ -202,18 +323,7 @@ pub fn prepare_json_for_disk(
 /// catch-and-return-null.
 pub fn load_meta_headers(pkg_mirror: &Path) -> Option<MetaHeaders> {
     let mut file = File::open(pkg_mirror).ok()?;
-    // Upstream uses a 1 KB buffer; the headers JSON is typically
-    // ~100 bytes. We match the upstream choice so a hand-edited
-    // mirror behaves the same on both stacks.
-    let mut buf = [0u8; 1024];
-    let bytes_read = file.read(&mut buf).ok()?;
-    if bytes_read == 0 {
-        return None;
-    }
-    let chunk = &buf[..bytes_read];
-    let newline = chunk.iter().position(|&b| b == b'\n')?;
-    let line = std::str::from_utf8(&chunk[..newline]).ok()?;
-    serde_json::from_str(line).ok()
+    read_mirror_headers(&mut file)
 }
 
 /// Read the full mirror file and reconstruct a [`Package`] with its
@@ -225,12 +335,44 @@ pub fn load_meta_headers(pkg_mirror: &Path) -> Option<MetaHeaders> {
 /// `null`; we match that contract because the caller's response to
 /// "couldn't read" is the same as "no cache".
 pub fn load_meta(pkg_mirror: &Path) -> Option<Package> {
-    let data = fs::read_to_string(pkg_mirror).ok()?;
-    let newline = data.find('\n')?;
-    let headers: MetaHeaders = serde_json::from_str(&data[..newline]).ok()?;
-    let mut meta: Package = serde_json::from_str(&data[newline + 1..]).ok()?;
-    meta.etag = headers.etag;
-    Some(meta)
+    let contents = fs::read(pkg_mirror).ok()?;
+    let newline = contents.iter().position(|&byte| byte == b'\n')?;
+    let line = std::str::from_utf8(&contents[..newline]).ok()?;
+    let (headers_len, index_len) = parse_mirror_magic(line)?;
+    let headers_start = newline + 1;
+    let index_start = headers_start.checked_add(headers_len)?;
+    let fragment_base = index_start.checked_add(index_len)?;
+    if fragment_base > contents.len() {
+        return None;
+    }
+    let headers: MetaHeaders =
+        serde_json::from_slice(&contents[headers_start..index_start]).ok()?;
+    let index: MirrorIndex = serde_json::from_slice(&contents[index_start..fragment_base]).ok()?;
+
+    // Rebase the relative spans and reject any that fall outside the
+    // file — a truncated or hand-edited mirror reads as a miss rather
+    // than handing out garbage fragments later.
+    let file_size = contents.len() as u64;
+    let buffer = Arc::new(contents);
+    let mut spans = Vec::with_capacity(index.versions.len());
+    for (version, offset, len) in index.versions {
+        let absolute = (fragment_base as u64).checked_add(offset)?;
+        if absolute.checked_add(u64::from(len))? > file_size {
+            return None;
+        }
+        spans.push((version, absolute, len));
+    }
+
+    Some(Package {
+        name: index.name,
+        dist_tags: index.dist_tags,
+        versions: PackageVersions::from_buffer_spans(&buffer, spans),
+        time: index.time,
+        modified: headers.modified,
+        etag: headers.etag,
+        homepage: index.homepage,
+        mutex: Arc::default(),
+    })
 }
 
 /// Async sibling of [`load_meta`]. The body is a blocking
@@ -278,7 +420,7 @@ pub async fn load_meta_headers_async(pkg_mirror: Option<&Path>) -> Option<MetaHe
 ///
 /// The rename is the only atomic step; an observer sees either the
 /// old contents or the new ones, never a torn body line.
-pub fn save_meta(pkg_mirror: &Path, json: &str) -> Result<(), SaveMetaError> {
+pub fn save_meta(pkg_mirror: &Path, contents: &[u8]) -> Result<(), SaveMetaError> {
     let dir = pkg_mirror.parent().unwrap_or_else(|| Path::new("."));
     fs::create_dir_all(dir)
         .map_err(|error| SaveMetaError::CreateDir { dir: dir.to_path_buf(), error })?;
@@ -289,7 +431,7 @@ pub fn save_meta(pkg_mirror: &Path, json: &str) -> Result<(), SaveMetaError> {
             .create_new(true)
             .open(&temp)
             .map_err(|error| SaveMetaError::WriteTemp { temp: temp.clone(), error })?;
-        file.write_all(json.as_bytes())
+        file.write_all(contents)
             .map_err(|error| SaveMetaError::WriteTemp { temp: temp.clone(), error })?;
     }
     fs::rename(&temp, pkg_mirror).map_err(|error| {

--- a/pacquet/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/mirror.rs
@@ -297,6 +297,13 @@ fn read_mirror_headers(file: &mut File) -> Option<MetaHeaders> {
     let newline = chunk.iter().position(|&byte| byte == b'\n')?;
     let line = std::str::from_utf8(&chunk[..newline]).ok()?;
     let (headers_len, _) = parse_mirror_magic(line)?;
+    // The headers record is ~100 bytes of etag + timestamp. Bound the
+    // declared length before allocating from it so a corrupted or
+    // hostile mirror can't trigger an arbitrarily large allocation.
+    const MAX_HEADERS_LEN: usize = 64 * 1024;
+    if headers_len > MAX_HEADERS_LEN {
+        return None;
+    }
     let headers_start = newline + 1;
     let headers_end = headers_start.checked_add(headers_len)?;
     let headers_json: std::borrow::Cow<'_, [u8]> = if headers_end <= chunk.len() {

--- a/pacquet/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -5,8 +5,8 @@ use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 
 use super::{
-    ABBREVIATED_META_DIR, FULL_META_DIR, MetaHeaders, encode_pkg_name, get_pkg_mirror_path,
-    get_registry_name, load_meta, load_meta_headers, prepare_json_for_disk, save_meta,
+    ABBREVIATED_META_DIR, FULL_META_DIR, encode_pkg_name, get_pkg_mirror_path, get_registry_name,
+    load_meta, load_meta_headers, save_meta_indexed,
 };
 
 /// Lower-case names pass through unchanged. Matches upstream's
@@ -101,52 +101,62 @@ fn fixture_package() -> Package {
     serde_json::from_value(body).expect("deserialize fixture Package")
 }
 
-/// `prepare_json_for_disk` produces a two-line NDJSON document. Line
-/// one is `MetaHeaders`; line two is the raw body verbatim when
-/// supplied (the fast path on a 200 response).
-#[test]
-fn prepare_json_for_disk_two_line_shape() {
-    let pkg = fixture_package();
-    let raw = r#"{"name":"acme"}"#;
-    let json = prepare_json_for_disk(&pkg, Some(r#""abc""#), Some(raw)).expect("serialize");
-    let mut lines = json.split('\n');
-    let header_line = lines.next().expect("header line present");
-    let body_line = lines.next().expect("body line present");
-    let headers: MetaHeaders = serde_json::from_str(header_line).expect("parse header");
-    assert_eq!(headers.etag.as_deref(), Some(r#""abc""#));
-    assert_eq!(headers.modified.as_deref(), Some("2025-01-15T12:00:00.000Z"));
-    assert_eq!(body_line, raw, "raw body line wins over re-serialization");
-}
-
-/// Save → `load_meta_headers` reads back only the first line (etag,
-/// modified) without parsing the multi-megabyte body — fast path
-/// for the conditional GET decision.
+/// Save → `load_meta_headers` reads back only the headers record
+/// (etag, modified) without touching the index or fragments — fast
+/// path for the conditional GET decision.
 #[test]
 fn load_meta_headers_round_trip() {
     let dir = TempDir::new().expect("tmp dir");
     let mirror = dir.path().join("nested").join("lodash.jsonl");
     let pkg = fixture_package();
-    let json =
-        prepare_json_for_disk(&pkg, Some(r#"W/"abc""#), Some(r#"{"name":"acme"}"#)).expect("ser");
-    save_meta(&mirror, &json).expect("save");
+    save_meta_indexed(&mirror, &pkg, Some(r#"W/"abc""#)).expect("save");
     let headers = load_meta_headers(&mirror).expect("read headers back");
     assert_eq!(headers.etag.as_deref(), Some(r#"W/"abc""#));
     assert_eq!(headers.modified.as_deref(), Some("2025-01-15T12:00:00.000Z"));
 }
 
-/// Save → `load_meta` reconstructs the full Package with the etag
-/// back-filled. The cached fetcher uses this on a 304 response.
+/// Save → `load_meta` reconstructs the Package: scalars from the
+/// index record, etag back-filled from the headers record, and
+/// version manifests hydrating from their byte spans. The cached
+/// fetcher uses this on a 304 response.
 #[test]
-fn load_meta_round_trip_backfills_etag() {
+fn load_meta_round_trip_hydrates_versions_from_spans() {
     let dir = TempDir::new().expect("tmp dir");
     let mirror = dir.path().join("acme.jsonl");
     let pkg = fixture_package();
-    let json = prepare_json_for_disk(&pkg, Some(r#"W/"abc""#), None).expect("ser");
-    save_meta(&mirror, &json).expect("save");
+    save_meta_indexed(&mirror, &pkg, Some(r#"W/"abc""#)).expect("save");
     let loaded = load_meta(&mirror).expect("read full back");
     assert_eq!(loaded.name, "acme");
     assert_eq!(loaded.etag.as_deref(), Some(r#"W/"abc""#));
     assert_eq!(loaded.published_at("1.0.0"), Some("2025-01-10T08:30:00.000Z"));
+    assert_eq!(loaded.dist_tag("latest"), Some("1.0.0"));
+    let manifest = loaded.versions.get("1.0.0").expect("hydrate from file span");
+    assert_eq!(manifest.dist.tarball, "https://registry/acme-1.0.0.tgz");
+}
+
+/// A truncated mirror — spans pointing past the end of the file —
+/// reads as a cache miss instead of handing out garbage fragments.
+#[test]
+fn load_meta_rejects_truncated_fragments() {
+    let dir = TempDir::new().expect("tmp dir");
+    let mirror = dir.path().join("acme.jsonl");
+    let pkg = fixture_package();
+    save_meta_indexed(&mirror, &pkg, None).expect("save");
+    let full = std::fs::read(&mirror).expect("read mirror");
+    std::fs::write(&mirror, &full[..full.len() - 10]).expect("truncate");
+    assert!(load_meta(&mirror).is_none());
+}
+
+/// Files in the previous two-line NDJSON format read as cache misses
+/// (the fetcher then refetches and rewrites in the indexed format).
+#[test]
+fn previous_ndjson_format_reads_as_cache_miss() {
+    let dir = TempDir::new().expect("tmp dir");
+    let mirror = dir.path().join("acme.jsonl");
+    std::fs::write(&mirror, "{\"etag\":\"W/abc\"}\n{\"name\":\"acme\",\"versions\":{}}")
+        .expect("write old format");
+    assert!(load_meta_headers(&mirror).is_none());
+    assert!(load_meta(&mirror).is_none());
 }
 
 /// Missing file → `None` from both readers. The fetcher's lookup
@@ -160,8 +170,7 @@ fn load_helpers_return_none_on_missing_file() {
     assert!(load_meta(&mirror).is_none());
 }
 
-/// Malformed mirror (no newline separator) → `None`. Mirrors
-/// upstream's catch-and-return-null on JSON.parse errors.
+/// Malformed mirror (no newline separator) → `None`.
 #[test]
 fn load_helpers_return_none_on_malformed_mirror() {
     let dir = TempDir::new().expect("tmp dir");
@@ -171,22 +180,17 @@ fn load_helpers_return_none_on_malformed_mirror() {
     assert!(load_meta(&mirror).is_none());
 }
 
-/// `save_meta` overwrites an existing mirror file atomically — the
+/// `save_meta_indexed` overwrites an existing mirror atomically — an
 /// observer sees either the old contents or the new ones, never a
-/// torn body.
+/// torn record.
 #[test]
 fn save_meta_overwrites_existing_mirror() {
     let dir = TempDir::new().expect("tmp dir");
     let mirror = dir.path().join("acme.jsonl");
     let pkg = fixture_package();
 
-    let first =
-        prepare_json_for_disk(&pkg, Some(r#"W/"old""#), Some(r#"{"name":"acme"}"#)).expect("ser");
-    save_meta(&mirror, &first).expect("first save");
-
-    let second =
-        prepare_json_for_disk(&pkg, Some(r#"W/"new""#), Some(r#"{"name":"acme"}"#)).expect("ser");
-    save_meta(&mirror, &second).expect("second save");
+    save_meta_indexed(&mirror, &pkg, Some(r#"W/"old""#)).expect("first save");
+    save_meta_indexed(&mirror, &pkg, Some(r#"W/"new""#)).expect("second save");
 
     let headers = load_meta_headers(&mirror).expect("read headers");
     assert_eq!(headers.etag.as_deref(), Some(r#"W/"new""#));

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -534,7 +534,7 @@ fn default_tag_spec(alias: &str, default_tag: &str) -> RegistryPackageSpec {
 /// full packument (with all versions) on every pick.
 pub(crate) struct PickedFromRegistry {
     pub(crate) meta: std::sync::Arc<Package>,
-    pub(crate) version: PackageVersion,
+    pub(crate) version: std::sync::Arc<PackageVersion>,
 }
 
 /// Input bundle for [`build_resolve_result`]. Grouped so the

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -304,7 +304,7 @@ pub struct PickPackageOptions<'a> {
 #[derive(Debug)]
 pub struct PickPackageResult {
     pub meta: Arc<Package>,
-    pub picked_package: Option<PackageVersion>,
+    pub picked_package: Option<Arc<PackageVersion>>,
 }
 
 /// Failure modes for [`pick_package`]. Distinguishes the pure-pick
@@ -743,7 +743,7 @@ fn pick_matching_version_fast(
     picker_opts: &PickerOpts<'_>,
     spec: &RegistryPackageSpec,
     meta: &Package,
-) -> Result<Option<PackageVersion>, PickPackageFromMetaError> {
+) -> Result<Option<Arc<PackageVersion>>, PickPackageFromMetaError> {
     if picker_opts.published_by.is_some() {
         pick_respecting_min_release_age(picker_opts, spec, meta)
     } else {
@@ -761,7 +761,7 @@ fn pick_matching_version_final(
     picker_opts: &PickerOpts<'_>,
     spec: &RegistryPackageSpec,
     meta: &Package,
-) -> Result<Option<PackageVersion>, PickPackageFromMetaError> {
+) -> Result<Option<Arc<PackageVersion>>, PickPackageFromMetaError> {
     match pick_matching_version_fast(picker_opts, spec, meta) {
         Ok(picked) => Ok(picked),
         Err(PickPackageFromMetaError::MissingTime { pkg_name })
@@ -791,7 +791,7 @@ fn pick_respecting_min_release_age(
     picker_opts: &PickerOpts<'_>,
     spec: &RegistryPackageSpec,
     meta: &Package,
-) -> Result<Option<PackageVersion>, PickPackageFromMetaError> {
+) -> Result<Option<Arc<PackageVersion>>, PickPackageFromMetaError> {
     run_picker(picker_opts, spec, |target_spec| {
         let highest = pick_package_from_meta(
             pick_version_by_version_range,
@@ -828,7 +828,7 @@ fn pick_ignoring_release_age(
     picker_opts: &PickerOpts<'_>,
     spec: &RegistryPackageSpec,
     meta: &Package,
-) -> Result<Option<PackageVersion>, PickPackageFromMetaError> {
+) -> Result<Option<Arc<PackageVersion>>, PickPackageFromMetaError> {
     run_picker(picker_opts, spec, |target_spec| {
         if picker_opts.pick_lowest_version {
             pick_package_from_meta(
@@ -856,9 +856,10 @@ fn run_picker<PickOne>(
     picker_opts: &PickerOpts<'_>,
     spec: &RegistryPackageSpec,
     pick_one: PickOne,
-) -> Result<Option<PackageVersion>, PickPackageFromMetaError>
+) -> Result<Option<Arc<PackageVersion>>, PickPackageFromMetaError>
 where
-    PickOne: Fn(&RegistryPackageSpec) -> Result<Option<PackageVersion>, PickPackageFromMetaError>,
+    PickOne:
+        Fn(&RegistryPackageSpec) -> Result<Option<Arc<PackageVersion>>, PickPackageFromMetaError>,
 {
     let current = pick_one(spec)?;
     if !picker_opts.include_latest_tag {
@@ -878,7 +879,10 @@ where
 /// as "no pick" so a single satisfying option wins by default.
 /// Mirrors upstream's
 /// [`pickMax`](https://github.com/pnpm/pnpm/blob/f657b5cb44/resolving/npm-resolver/src/pickPackage.ts#L95-L102).
-fn pick_max(lhs: Option<PackageVersion>, rhs: Option<PackageVersion>) -> Option<PackageVersion> {
+fn pick_max(
+    lhs: Option<Arc<PackageVersion>>,
+    rhs: Option<Arc<PackageVersion>>,
+) -> Option<Arc<PackageVersion>> {
     match (lhs, rhs) {
         (None, rhs) => rhs,
         (lhs, None) => lhs,

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -51,7 +51,6 @@
 //! 3-5× behind pnpm on the `alotta-files` benchmark.
 
 use std::{
-    collections::HashMap,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
@@ -172,31 +171,26 @@ pub fn shared_picked_manifest_cache() -> PickedManifestCache {
     Arc::new(DashMap::new())
 }
 
-/// Default thread-safe [`PackageMetaCache`] backed by a [`Mutex`]
-/// guarding a [`HashMap`]. A consumer that already has its own
-/// shared map can implement the trait directly instead of using
-/// this.
+/// Default thread-safe [`PackageMetaCache`] backed by a sharded
+/// [`DashMap`]. A consumer that already has its own shared map can
+/// implement the trait directly instead of using this.
+///
+/// Every resolve edge consults the cache before anything else, so on
+/// a large graph the map takes tens of thousands of lookups from all
+/// runtime workers at once — a single `Mutex<HashMap>` here was the
+/// top contention point of a warm-resolve time profile.
 #[derive(Debug, Default)]
 pub struct InMemoryPackageMetaCache {
-    inner: Mutex<HashMap<String, Arc<Package>>>,
+    inner: DashMap<String, Arc<Package>>,
 }
 
 impl PackageMetaCache for InMemoryPackageMetaCache {
     fn get(&self, key: &str) -> Option<Arc<Package>> {
-        // Mirror the rest of the codebase (e.g. `build_modules.rs`):
-        // recover from poisoning instead of escalating an unrelated
-        // panic into a hard install-wide failure. The cache is a
-        // plain HashMap of `Arc<Package>` — no broken invariants
-        // can survive across a poisoned lock.
-        self.inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .get(key)
-            .map(Arc::clone)
+        self.inner.get(key).map(|entry| Arc::clone(entry.value()))
     }
 
     fn set(&self, key: String, meta: Arc<Package>) {
-        self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner).insert(key, meta);
+        self.inner.insert(key, meta);
     }
 }
 

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -70,7 +70,7 @@ use crate::{
     FetchMetadataError, fetch_full_metadata, fetch_full_metadata_cached,
     mirror::{
         ABBREVIATED_META_DIR, FULL_META_DIR, get_pkg_mirror_path, load_meta_async,
-        prepare_json_for_disk, save_meta,
+        save_meta_indexed,
     },
     pick_package_from_meta::{
         PickPackageFromMetaError, PickPackageFromMetaOptions, RegistryPackageSpec,
@@ -964,9 +964,8 @@ pub fn persist_meta_to_mirror(
 ) -> Result<(), MirrorPersistError> {
     let path = get_pkg_mirror_path(cache_dir, meta_dir, registry, &meta.name)
         .map_err(|error| MirrorPersistError::EncodePath { error: error.to_string() })?;
-    let json = prepare_json_for_disk(meta, meta.etag.as_deref(), None)
-        .map_err(|error| MirrorPersistError::Serialize { error: error.to_string() })?;
-    save_meta(&path, &json).map_err(|error| MirrorPersistError::Write { error: error.to_string() })
+    save_meta_indexed(&path, meta, meta.etag.as_deref())
+        .map_err(|error| MirrorPersistError::Write { error: error.to_string() })
 }
 
 /// Failure modes for [`persist_meta_to_mirror`]. Each variant
@@ -1116,19 +1115,7 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
 /// the upgrade fetch. Mirrors upstream's
 /// [`persistUpgradedMeta`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L507-L524).
 fn persist_upgraded_to_mirror(pkg_mirror: &Path, meta: &Package) {
-    let json = match prepare_json_for_disk(meta, meta.etag.as_deref(), None) {
-        Ok(json) => json,
-        Err(error) => {
-            tracing::debug!(
-                target: "pacquet_resolving_npm_resolver::pick_package",
-                ?error,
-                path = %pkg_mirror.display(),
-                "could not serialize upgraded meta; skipping persist",
-            );
-            return;
-        }
-    };
-    if let Err(error) = save_meta(pkg_mirror, &json) {
+    if let Err(error) = save_meta_indexed(pkg_mirror, meta, meta.etag.as_deref()) {
         tracing::debug!(
             target: "pacquet_resolving_npm_resolver::pick_package",
             ?error,

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -139,7 +139,7 @@ pub enum PickPackageFromMetaError {
 ///
 /// Returns:
 ///
-/// - `Ok(Some(version))` — the picked version's cloned manifest.
+/// - `Ok(Some(version))` — the picked version's (shared) manifest.
 /// - `Ok(None)` — no version satisfies the spec. The orchestrator
 ///   layer above propagates this as "resolver returned nothing,"
 ///   not as an error.
@@ -149,7 +149,7 @@ pub fn pick_package_from_meta<PickFn>(
     opts: &PickPackageFromMetaOptions<'_>,
     meta: &Package,
     spec: &RegistryPackageSpec,
-) -> Result<Option<PackageVersion>, PickPackageFromMetaError>
+) -> Result<Option<Arc<PackageVersion>>, PickPackageFromMetaError>
 where
     PickFn: Fn(&PickVersionByVersionRangeOptions<'_>) -> Option<String>,
 {
@@ -227,14 +227,15 @@ where
     };
 
     let Some(version) = picked_version else { return Ok(None) };
-    let Some(manifest) = meta_ref.versions.get(&version).cloned() else { return Ok(None) };
-    let mut manifest = manifest;
-    if !meta_ref.name.is_empty() {
+    let Some(manifest) = meta_ref.versions.get(&version) else { return Ok(None) };
+    if !meta_ref.name.is_empty() && manifest.name != meta_ref.name {
         // GitHub registry quirk: a scoped package can be published as
         // `@owner/foo` while the per-version `name` is just `foo`.
         // Match upstream's shim that pins the manifest name to the
         // packument-level name.
-        manifest.name.clone_from(&meta_ref.name);
+        let mut pinned = (*manifest).clone();
+        pinned.name.clone_from(&meta_ref.name);
+        return Ok(Some(Arc::new(pinned)));
     }
     Ok(Some(manifest))
 }
@@ -303,8 +304,7 @@ pub fn pick_version_by_version_range(
     // pickPackageFromMeta.ts#L194-L201.
     if let Some(ref picked) = max_pick {
         let picked_meta = opts.meta.versions.get(picked);
-        let picked_is_deprecated =
-            picked_meta.and_then(|version| version.deprecated.as_ref()).is_some();
+        let picked_is_deprecated = picked_meta.is_some_and(|version| version.deprecated.is_some());
         if picked_is_deprecated && all_versions.len() > 1 {
             let non_deprecated: Vec<&str> = opts
                 .meta
@@ -374,8 +374,9 @@ pub fn filter_pkg_metadata_by_publish_date(
          caller must check before invoking",
     );
 
-    let mut versions_within_date = std::collections::HashMap::new();
-    for (version, manifest) in &meta.versions {
+    // Decide on version strings + the `time` map alone; slots move as
+    // raw fragments, so the filter never hydrates a manifest.
+    let versions_within_date = meta.versions.filtered(|version| {
         let mature = time
             .get(version)
             .and_then(serde_json::Value::as_str)
@@ -383,10 +384,8 @@ pub fn filter_pkg_metadata_by_publish_date(
             .is_some_and(|date| date <= cutoff);
         let trusted =
             trusted_versions.is_some_and(|allow| allow.iter().any(|allowed| allowed == version));
-        if mature || trusted {
-            versions_within_date.insert(version.clone(), manifest.clone());
-        }
-    }
+        mature || trusted
+    });
 
     let mut dist_tags_within_date = std::collections::HashMap::new();
     for (tag, version) in &meta.dist_tags {
@@ -410,12 +409,10 @@ pub fn filter_pkg_metadata_by_publish_date(
                 Some((ref best, best_raw)) => {
                     let best_deprecated = versions_within_date
                         .get(best_raw)
-                        .and_then(|manifest| manifest.deprecated.as_ref())
-                        .is_some();
+                        .is_some_and(|manifest| manifest.deprecated.is_some());
                     let candidate_deprecated = versions_within_date
                         .get(candidate_raw)
-                        .and_then(|manifest| manifest.deprecated.as_ref())
-                        .is_some();
+                        .is_some_and(|manifest| manifest.deprecated.is_some());
                     let candidate_wins = (candidate > *best
                         && best_deprecated == candidate_deprecated)
                         || (best_deprecated && !candidate_deprecated);

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -364,6 +364,7 @@ pub fn pick_lowest_version_by_version_range(
 /// branch in [`pick_package_from_meta`]) only invokes this with full
 /// metadata. The abbreviated-metadata path takes the `meta.modified`
 /// shortcut above and never reaches this function.
+#[must_use]
 pub fn filter_pkg_metadata_by_publish_date(
     meta: &Package,
     cutoff: chrono::DateTime<chrono::Utc>,

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -213,31 +213,73 @@ where
         return Err(PickPackageFromMetaError::NoVersions { pkg_name: spec.name.clone() });
     }
 
-    let picked_version: Option<String> = match spec.spec_type {
-        RegistryPackageSpecType::Version => Some(spec.fetch_spec.clone()),
-        RegistryPackageSpecType::Tag => meta_ref.dist_tag(&spec.fetch_spec).map(str::to_string),
-        RegistryPackageSpecType::Range => {
-            pick_version_by_range(&PickVersionByVersionRangeOptions {
-                meta: meta_ref,
-                version_range: &spec.fetch_spec,
-                preferred_version_selectors: opts.preferred_version_selectors,
-                published_by: opts.published_by,
-            })
-        }
-    };
+    // An undecodable fragment behaves as if the version were absent
+    // (the `PackageVersions` contract), so a pick whose winner fails
+    // to hydrate retries against the remaining versions instead of
+    // reporting "no match" while satisfying candidates exist. The
+    // owned filtered clone only materializes on that (rare) path.
+    let mut undecodable_excluded: Option<Package> = None;
+    loop {
+        let meta_now: &Package = undecodable_excluded.as_ref().unwrap_or(meta_ref);
+        let picked_version: Option<String> = match spec.spec_type {
+            RegistryPackageSpecType::Version => Some(spec.fetch_spec.clone()),
+            RegistryPackageSpecType::Tag => meta_now.dist_tag(&spec.fetch_spec).map(str::to_string),
+            RegistryPackageSpecType::Range => {
+                pick_version_by_range(&PickVersionByVersionRangeOptions {
+                    meta: meta_now,
+                    version_range: &spec.fetch_spec,
+                    preferred_version_selectors: opts.preferred_version_selectors,
+                    published_by: opts.published_by,
+                })
+            }
+        };
 
-    let Some(version) = picked_version else { return Ok(None) };
-    let Some(manifest) = meta_ref.versions.get(&version) else { return Ok(None) };
-    if !meta_ref.name.is_empty() && manifest.name != meta_ref.name {
-        // GitHub registry quirk: a scoped package can be published as
-        // `@owner/foo` while the per-version `name` is just `foo`.
-        // Match upstream's shim that pins the manifest name to the
-        // packument-level name.
-        let mut pinned = (*manifest).clone();
-        pinned.name.clone_from(&meta_ref.name);
-        return Ok(Some(Arc::new(pinned)));
+        let Some(version) = picked_version else { return Ok(None) };
+        let Some(manifest) = meta_now.versions.get(&version) else {
+            if !meta_now.versions.contains_key(&version) {
+                // The picked string names a version the packument
+                // doesn't carry (a dangling dist-tag, an exact spec
+                // for an unpublished version) — nothing to retry.
+                return Ok(None);
+            }
+            undecodable_excluded = Some(without_version(meta_now, &version));
+            continue;
+        };
+        if !meta_now.name.is_empty() && manifest.name != meta_now.name {
+            // GitHub registry quirk: a scoped package can be published as
+            // `@owner/foo` while the per-version `name` is just `foo`.
+            // Match upstream's shim that pins the manifest name to the
+            // packument-level name.
+            let mut pinned = (*manifest).clone();
+            pinned.name.clone_from(&meta_now.name);
+            return Ok(Some(Arc::new(pinned)));
+        }
+        return Ok(Some(manifest));
     }
-    Ok(Some(manifest))
+}
+
+/// Clone `meta` minus one version — the retry step when a picked
+/// version's fragment turns out to be undecodable. Slots move without
+/// hydrating.
+fn without_version(meta: &Package, version: &str) -> Package {
+    Package {
+        name: meta.name.clone(),
+        // Tags pointing at the removed version go with it — the
+        // latest-tag fast path would otherwise re-pick the version
+        // this clone exists to exclude.
+        dist_tags: meta
+            .dist_tags
+            .iter()
+            .filter(|(_, target)| *target != version)
+            .map(|(tag, target)| (tag.clone(), target.clone()))
+            .collect(),
+        versions: meta.versions.filtered(|candidate| candidate != version),
+        time: meta.time.clone(),
+        modified: meta.modified.clone(),
+        etag: meta.etag.clone(),
+        homepage: meta.homepage.clone(),
+        mutex: Arc::default(),
+    }
 }
 
 /// Per-call inputs to the range-picker pluggable. Mirrors upstream's

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
@@ -551,3 +551,54 @@ fn lowest_picker_with_published_by_drops_immature_min() {
     .expect("ok");
     assert_eq!(picked.map(|version| version.version.to_string()).as_deref(), Some("1.1.0"));
 }
+
+/// A range pick whose winning version carries an undecodable manifest
+/// fragment retries against the remaining versions — the undecodable
+/// entry behaves as if it were absent from the packument.
+#[test]
+fn pick_from_meta_skips_undecodable_winner_and_retries() {
+    let pkg: Package = serde_json::from_str(
+        r#"{
+            "name": "acme",
+            "dist-tags": {"latest": "1.2.0"},
+            "versions": {
+                "1.0.0": {"name": "acme", "version": "1.0.0", "dist": {"integrity": "sha512-a", "tarball": "https://r/acme-1.0.0.tgz"}},
+                "1.2.0": {"corrupt": "fragment"}
+            }
+        }"#,
+    )
+    .expect("parse package");
+    let picked = pick_package_from_meta(
+        pick_version_by_version_range,
+        &PickPackageFromMetaOptions::default(),
+        &pkg,
+        &spec("acme", "^1.0.0", RegistryPackageSpecType::Range),
+    )
+    .expect("ok");
+    assert_eq!(picked.map(|version| version.version.to_string()).as_deref(), Some("1.0.0"));
+}
+
+/// An exact-version spec naming an undecodable manifest yields no
+/// match (there is no other candidate to retry) rather than looping
+/// or erroring.
+#[test]
+fn pick_from_meta_returns_none_for_undecodable_exact_version() {
+    let pkg: Package = serde_json::from_str(
+        r#"{
+            "name": "acme",
+            "dist-tags": {},
+            "versions": {
+                "1.2.0": {"corrupt": "fragment"}
+            }
+        }"#,
+    )
+    .expect("parse package");
+    let picked = pick_package_from_meta(
+        pick_version_by_version_range,
+        &PickPackageFromMetaOptions::default(),
+        &pkg,
+        &spec("acme", "1.2.0", RegistryPackageSpecType::Version),
+    )
+    .expect("ok");
+    assert!(picked.is_none());
+}

--- a/pacquet/crates/resolving-npm-resolver/src/trust_checks.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/trust_checks.rs
@@ -175,7 +175,7 @@ pub fn fail_if_trust_downgraded(
         return Ok(());
     };
 
-    let current = get_trust_evidence(manifest);
+    let current = get_trust_evidence(&manifest);
     let current_rank = current.map_or(0u8, trust_rank);
     let prior_rank = trust_rank(strongest_prior);
     if current_rank < prior_rank {
@@ -221,7 +221,7 @@ fn detect_strongest_trust_evidence_before(
     exclude_prerelease: bool,
 ) -> Option<TrustEvidence> {
     let mut best: Option<TrustEvidence> = None;
-    for (version, manifest) in &meta.versions {
+    for (version, manifest) in meta.versions.iter() {
         if exclude_prerelease && is_prerelease(version) {
             continue;
         }
@@ -240,7 +240,7 @@ fn detect_strongest_trust_evidence_before(
         if parsed >= before_date {
             continue;
         }
-        let Some(evidence) = get_trust_evidence(manifest) else {
+        let Some(evidence) = get_trust_evidence(&manifest) else {
             continue;
         };
         // Keep the highest-ranked evidence seen so far. Don't short-

--- a/pacquet/crates/resolving-npm-resolver/src/trust_checks.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/trust_checks.rs
@@ -170,7 +170,7 @@ pub fn fail_if_trust_downgraded(
 
     let exclude_prerelease = !is_prerelease(version);
     let Some(strongest_prior) =
-        detect_strongest_trust_evidence_before(meta, version_date, exclude_prerelease)
+        detect_strongest_trust_evidence_before(meta, version_date, exclude_prerelease)?
     else {
         return Ok(());
     };
@@ -215,13 +215,18 @@ fn pretty_print_trust_evidence(evidence: Option<TrustEvidence>) -> &'static str 
 /// strongest [`TrustEvidence`] seen. Prereleases are filtered out
 /// when the current version is *not* itself a prerelease — matches
 /// upstream's `semver.prerelease(version, true)` guard.
+///
+/// Fails closed: a prior version whose manifest is listed but does
+/// not decode makes the scan error rather than skip — skipping could
+/// hide the strongest prior evidence and let a trust downgrade pass
+/// undetected.
 fn detect_strongest_trust_evidence_before(
     meta: &Package,
     before_date: DateTime<Utc>,
     exclude_prerelease: bool,
-) -> Option<TrustEvidence> {
+) -> Result<Option<TrustEvidence>, TrustViolation> {
     let mut best: Option<TrustEvidence> = None;
-    for (version, manifest) in meta.versions.iter() {
+    for version in meta.versions.keys() {
         if exclude_prerelease && is_prerelease(version) {
             continue;
         }
@@ -240,6 +245,14 @@ fn detect_strongest_trust_evidence_before(
         if parsed >= before_date {
             continue;
         }
+        let Some(manifest) = meta.versions.get(version) else {
+            return Err(TrustViolation::TrustCheckFailed {
+                reason: format!(
+                    "undecodable version object for version {version} of {name} in metadata",
+                    name = meta.name,
+                ),
+            });
+        };
         let Some(evidence) = get_trust_evidence(&manifest) else {
             continue;
         };
@@ -251,11 +264,11 @@ fn detect_strongest_trust_evidence_before(
         if best.is_none_or(|current| trust_rank(evidence) > trust_rank(current)) {
             best = Some(evidence);
             if evidence == TrustEvidence::StagedPublish {
-                return best;
+                return Ok(best);
             }
         }
     }
-    best
+    Ok(best)
 }
 
 /// `_npmUser.approver` (a staged publish) outranks everything; failing

--- a/pacquet/crates/resolving-npm-resolver/src/trust_checks/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/trust_checks/tests.rs
@@ -422,6 +422,30 @@ fn prior_version_missing_time_does_not_mask_trust_history() {
     assert!(matches!(err, TrustViolation::TrustDowngrade { .. }), "got {err:?}");
 }
 
+/// A prior version whose manifest fragment does not decode fails the
+/// check closed (`TrustCheckFailed`) instead of being skipped — the
+/// skipped fragment could be the strongest prior evidence, and
+/// passing without it would let a downgrade through undetected.
+#[test]
+fn undecodable_prior_version_fails_closed() {
+    let body = serde_json::json!({
+        "name": "acme",
+        "dist-tags": {},
+        "time": {
+            "1.0.0": "2025-01-01T00:00:00.000Z",
+            "1.1.0": "2025-02-01T00:00:00.000Z",
+        },
+        "versions": {
+            "1.0.0": { "corrupt": "fragment" },
+            "1.1.0": version_json("acme", "1.1.0", Evidence::None),
+        },
+    });
+    let meta: Package = serde_json::from_value(body).expect("deserialize fixture Package");
+    let err = fail_if_trust_downgraded(&meta, "1.1.0", &TrustCheckOptions::default())
+        .expect_err("undecodable prior manifest must fail the trust check");
+    assert!(matches!(err, TrustViolation::TrustCheckFailed { .. }), "got {err:?}");
+}
+
 mod get_trust_evidence {
     use pacquet_registry::PackageVersion;
 


### PR DESCRIPTION
## Why

Profiling a warm babylon resolve (metadata mirrors hot, ~520 MB across 1,476 packuments) showed the dominant cost was not I/O but **hydration**: every version of every packument was deserialized into typed manifests — maps, strings, and `serde_json::Value` trees built, hashed, and dropped — even though a pick consults only the version *strings* plus the handful of manifests it actually considers. typescript ships 3,800 versions; a pick needs one. The `#[serde(flatten)]` catch-all on `PackageVersion` compounded it by routing the whole struct through serde's buffering deserializer. The same hydration cost was paid on cold resolves inside the `spawn_blocking` parses from pnpm/pnpm#12318.

## What

Three changes, applied in profile-driven order:

**1. Lazy packument hydration** (`df6f70eb57`). `Package::versions` becomes a `PackageVersions` map whose entries hold the raw JSON fragment serde captured (`Arc<RawValue>`, shared not copied) and hydrate into `Arc<PackageVersion>` on first access, cached per slot. Key scans never hydrate; `pinned_version` hydrates only the winner; the publish-date filter moves slots without touching manifests; undecodable fragments degrade to "version absent" (matching the JS implementation's tolerance); serialization re-emits raw fragments verbatim. Picked manifests travel as `Arc<PackageVersion>`. Enables serde_json's `raw_value` feature (already a workspace dep).

**2. Sharded in-memory packument cache** (`4c28c6679e`). Every resolve edge consults the shared meta cache, and its single `Mutex<HashMap>` was the top mutex-wait site in the profile; it is now the same `DashMap` shape the crate's other shared maps use. Honest note: wall time was unchanged by this alone — the post-hydration profile shows the warm resolve is critical-path-bound, not lock-bound — but the contention disappears and the cache no longer serializes workers under load.

**3. Indexed on-disk metadata mirror** (`126a416ae8`, maintainer-approved cache-format break). The two-line NDJSON mirror (headers + verbatim body) becomes:

```
pacquet-meta-v1 <headers_len> <index_len>\n
<headers JSON>     etag, modified
<index JSON>       name, dist-tags, time, homepage, versions: [version, offset, len]
<fragments>        concatenated raw per-version JSON
```

The loader reads the file once and hands `PackageVersions` byte spans into that buffer — no structural re-scan, hydration parses a slice in place. The writer streams the registry's own bytes (fragments borrow from the lazily-parsed response body), so the **cold-install cost stays one temp-file + rename per package**. Old-format files read as cache misses and are rewritten on the next 200. A span-per-fragment `pread` variant was tried first and measured *worse* (sys 0.4 s → 4.5 s; the pick paths probe many candidate fragments per package), hence the single-buffer design.

## Measurements (warm babylon `--lockfile-only` resolve, 10-core M-series)

| build | wall | notes |
|---|---|---|
| before this PR | ~9.1 s | malloc/free + `deserialize_any` dominate the profile |
| + lazy hydration | ~7.7–8 s | parse microbench 3–3.8× (`typescript` 36.1→9.5 ms) |
| + indexed mirror | **~5.5–6.7 s** | sys 0.4 s; no whole-body scan |

Cold resolves keep the same hydration savings inside the parse tasks; cold write volume and syscall pattern are unchanged.

## Evaluated and deliberately not included

Consolidating the install-phase thread pools (tokio + global rayon + the dedicated CAS-write pool + capped blocking threads show ~100k involuntary context switches on cold installs vs ~750 for the pnpm CLI). After the resolution fixes, repeated container A/Bs show no measurable wall-clock cost from the churn — it hides entirely behind network time — and history warns that speculative concurrency reshuffles here regress badly (see the #11903 prefetch revert). Deferred until a benchmark shows it on the critical path.

## Tests

New `package_versions` unit tests (hydrate-on-demand + Arc-identity caching, undecodable-fragment-as-absent, verbatim raw round-trip incl. unknown keys, eager construction, hydration-free filtering) and rewritten `mirror` tests (headers/index/fragment round-trip, span hydration, truncation → cache miss, old-format → cache miss, atomic overwrite). Full suites green: `pacquet-registry` (23), `pacquet-resolving-npm-resolver` (235), `pacquet-package-manager` + `pacquet-cli` (768); workspace clippy `-D warnings` (pedantic set), dylint, fmt.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added lazy, fragment-backed package version storage and an indexed on-disk mirror format for metadata.
  * Enabled additional JSON features to improve handling of raw fragments.

* **Bug Fixes**
  * Safer handling of undecodable or truncated version data — failures are treated as absent without crashing.
  * Stronger mirror validation and atomic writes to avoid corrupt reads.

* **Performance**
  * Reduced memory churn and faster, shared version selection during resolution.

* **Tests**
  * Expanded tests for hydration, fallback selection, trust checks, and mirror behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->