### PR TITLE
fix: shorten CAFS temp directory names

### DIFF
--- a/.changeset/short-pipes-dance.md
+++ b/.changeset/short-pipes-dance.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/store.create-cafs-store": patch
+"pnpm": patch
+---
+
+Create shorter CAFS temporary package directories to leave room for lifecycle scripts that create IPC socket paths under TMPDIR.

--- a/fetching/git-fetcher/test/index.ts
+++ b/fetching/git-fetcher/test/index.ts
@@ -47,6 +47,15 @@ beforeEach(() => {
   jest.mocked(globalWarn).mockClear()
 })
 
+test('uses short CAFS temp directories for git package preparation', async () => {
+  const storeDir = temporaryDirectory()
+  const tmpDir = await createCafsStore(storeDir).tempDir()
+
+  expect(path.dirname(tmpDir)).toBe(path.join(storeDir, 'tmp'))
+  expect(path.basename(tmpDir)).toMatch(/^_tmp_[a-zA-Z0-9]{6}$/)
+  expect(path.basename(tmpDir).length).toBeLessThanOrEqual(11)
+})
+
 test('fetch', async () => {
   const storeDir = temporaryDirectory()
   const fetch = createGitFetcher({ storeIndex: createStoreIndex(storeDir) }).git

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9306,9 +9306,6 @@ importers:
       memoize:
         specifier: 'catalog:'
         version: 11.0.0
-      path-temp:
-        specifier: 'catalog:'
-        version: 3.0.0
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'

--- a/store/create-cafs-store/package.json
+++ b/store/create-cafs-store/package.json
@@ -48,7 +48,6 @@
     "@pnpm/store.cafs": "workspace:*",
     "@pnpm/store.controller-types": "workspace:*",
     "memoize": "catalog:",
-    "path-temp": "catalog:",
     "ramda": "catalog:"
   },
   "peerDependencies": {

--- a/store/create-cafs-store/src/index.ts
+++ b/store/create-cafs-store/src/index.ts
@@ -14,7 +14,6 @@ import type {
   ImportPackageFunctionAsync,
 } from '@pnpm/store.controller-types'
 import memoize from 'memoize'
-import { pathTemp } from 'path-temp'
 
 export { type CafsLocker }
 
@@ -140,9 +139,8 @@ export function createCafsStore (
     storeDir,
     importPackage,
     tempDir: async () => {
-      const tmpDir = pathTemp(baseTempDir)
-      await fs.mkdir(tmpDir, { recursive: true })
-      return tmpDir
+      await fs.mkdir(baseTempDir, { recursive: true })
+      return fs.mkdtemp(path.join(baseTempDir, '_tmp_'))
     },
   }
 }


### PR DESCRIPTION
## Summary
- use `fs.mkdtemp()` with a short `_tmp_` prefix for CAFS temporary package directories
- remove `path-temp` from `@pnpm/store.create-cafs-store`
- add git-fetcher regression coverage for short CAFS temp directories during git package preparation
- add a patch changeset for `@pnpm/store.create-cafs-store` and `pnpm`

## Why
This leaves more Unix socket path budget for lifecycle tools that create IPC sockets under `TMPDIR` during git-hosted dependency preparation.

Closes pnpm/pnpm#12222.

## Pacquet
No pacquet change is included because the Rust git fetcher already uses `tempfile::tempdir()` instead of the TypeScript CAFS `path-temp` suffix changed here.

## Tests
- `pnpm --filter pnpm compile`
- `pnpm --filter @pnpm/store.create-cafs-store test`
- `pnpm --filter @pnpm/exec.prepare-package test`
- `pnpm --filter @pnpm/fetching.git-fetcher test`
- pre-push hook completed: compile-only, spellcheck, meta-updater, TypeScript lint, cargo fmt, cargo doc; optional `cargo-dylint` and `taplo` were not installed and were skipped by the hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Reduced temporary package directory path lengths to provide sufficient space for lifecycle script IPC socket generation under `TMPDIR`.

* **Tests**
  * Added Jest coverage to validate the temporary CAFS directory location, naming pattern, and maximum directory name length.

* **Chores**
  * Updated package dependency configuration and version metadata to support the improved temporary directory behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->