### PR TITLE
fix(view): update dist tarball `unpackedSize` to compute value as power of 10

### DIFF
--- a/.changeset/sweet-groups-float.md
+++ b/.changeset/sweet-groups-float.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/deps.inspection.commands": patch
+---
+
+Update value shown in the view command output for the `unpackedSize`.

--- a/deps/inspection/commands/src/view/index.ts
+++ b/deps/inspection/commands/src/view/index.ts
@@ -202,7 +202,7 @@ export async function handler (
 
 function formatBytes (bytes: number): string {
   if (bytes === 0) return '0 B'
-  const k = 1024
+  const k = 1000
   const sizes = ['B', 'kB', 'MB', 'GB', 'TB', 'PB']
   const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1)
   return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + ' ' + sizes[i]


### PR DESCRIPTION
With this change the size shown matches the value shown by `npm` and https://npmx.dev. It also matches the units shown at https://en.wikipedia.org/wiki/Byte#Multiple-byte_units

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file size display format in the view command output to use decimal-based calculations for improved consistency and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->