### PR TITLE
fix(pacquet): close four lockfile-parity gaps (importer peer+dev merge, peer-vs-own-dep, peer overrides, optional-peer hoist)

### DIFF
--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -555,7 +555,7 @@ fn peer_suffixed_dep_path_splits_into_distinct_snapshot_and_package_keys() {
     react_dom_children.insert("react".to_string(), DepPath::from("react@17.0.2".to_string()));
     let mut react_dom_peers = BTreeMap::new();
     react_dom_peers
-        .insert("react".to_string(), PeerDep { version: "17.0.2".to_string(), optional: false });
+        .insert("react".to_string(), PeerDep { version: "17.0.2".to_string(), optional: false, meta_only: false });
     let react_dom_dep_path = DepPath::from("react-dom@17.0.2(react@17.0.2)".to_string());
     let react_dom = DependenciesGraphNode {
         dep_path: react_dom_dep_path.clone(),

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -554,8 +554,10 @@ fn peer_suffixed_dep_path_splits_into_distinct_snapshot_and_package_keys() {
     let mut react_dom_children = BTreeMap::new();
     react_dom_children.insert("react".to_string(), DepPath::from("react@17.0.2".to_string()));
     let mut react_dom_peers = BTreeMap::new();
-    react_dom_peers
-        .insert("react".to_string(), PeerDep { version: "17.0.2".to_string(), optional: false, meta_only: false });
+    react_dom_peers.insert(
+        "react".to_string(),
+        PeerDep { version: "17.0.2".to_string(), optional: false, meta_only: false },
+    );
     let react_dom_dep_path = DepPath::from("react-dom@17.0.2(react@17.0.2)".to_string());
     let react_dom = DependenciesGraphNode {
         dep_path: react_dom_dep_path.clone(),

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1041,6 +1041,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                     pacquet_resolving_deps_resolver::UpdateReuseScope::Except(names.clone())
                 }
             },
+            auto_install_peers: config.auto_install_peers,
         };
         let modules_basename = config.modules_dir.file_name().map_or_else(
             || std::ffi::OsString::from("node_modules"),

--- a/pacquet/crates/package-manager/src/overrides.rs
+++ b/pacquet/crates/package-manager/src/overrides.rs
@@ -267,13 +267,10 @@ impl VersionsOverrider {
                     peers.insert(name, Value::String(new_spec));
                 }
             } else {
-                if !value.get("dependencies").is_some_and(Value::is_object) {
-                    if let Some(root) = value.as_object_mut() {
-                        root.insert(
-                            "dependencies".to_string(),
-                            Value::Object(serde_json::Map::new()),
-                        );
-                    }
+                if !value.get("dependencies").is_some_and(Value::is_object)
+                    && let Some(root) = value.as_object_mut()
+                {
+                    root.insert("dependencies".to_string(), Value::Object(serde_json::Map::new()));
                 }
                 if let Some(deps) = value.get_mut("dependencies").and_then(Value::as_object_mut) {
                     deps.insert(name, Value::String(new_spec));

--- a/pacquet/crates/package-manager/src/overrides.rs
+++ b/pacquet/crates/package-manager/src/overrides.rs
@@ -12,16 +12,6 @@
 //! resolved dependency graph and lockfile match pnpm's post-override
 //! manifest view.
 //!
-//! What's intentionally **not** ported yet:
-//! - `peerDependencies` mutation. Upstream promotes a peer to
-//!   `dependencies` when the new specifier isn't a valid peer range,
-//!   and writes a valid peer-range spec back to `peerDependencies`.
-//!   Pacquet's freshness check doesn't read `peerDependencies` and
-//!   pacquet has no peer install yet, so a frozen install on a repo
-//!   with peer overrides doesn't need the rewrite to stay correct
-//!   today. When peer install lands, the peer arm gets ported with
-//!   it.
-//!
 //! The hook never touches the on-disk `package.json` — mutation
 //! happens through [`pacquet_package_manifest::PackageManifest::value_mut`]
 //! on the in-memory `Value` only.
@@ -121,16 +111,12 @@ impl VersionsOverrider {
     pub fn apply_to_value(&self, manifest: &mut Value, manifest_dir: Option<&Path>) {
         let applicable_parent_scoped = self.applicable_parent_scoped(manifest);
 
-        // Upstream's `overrideDepsOfPkg` mutates the four dep buckets
-        // (`dependencies`, `optionalDependencies`, `devDependencies`,
-        // and the `peerDependencies → dependencies` migration).
-        // Pacquet today skips the peer arm — see the module-level doc
-        // for why.
         for group in
             [DependencyGroup::Prod, DependencyGroup::Optional, DependencyGroup::Dev].iter().copied()
         {
             self.override_group(manifest, group, &applicable_parent_scoped, manifest_dir);
         }
+        self.override_peer_group(manifest, &applicable_parent_scoped, manifest_dir);
     }
 
     /// Apply overrides to the resolver's shared manifest value,
@@ -167,10 +153,15 @@ impl VersionsOverrider {
 
     fn has_applicable_override(&self, value: &Value) -> bool {
         let applicable_parent_scoped = self.applicable_parent_scoped(value);
-        [DependencyGroup::Prod, DependencyGroup::Optional, DependencyGroup::Dev]
-            .iter()
-            .copied()
-            .any(|group| self.group_has_override(value, group, &applicable_parent_scoped))
+        [
+            DependencyGroup::Prod,
+            DependencyGroup::Optional,
+            DependencyGroup::Dev,
+            DependencyGroup::Peer,
+        ]
+        .iter()
+        .copied()
+        .any(|group| self.group_has_override(value, group, &applicable_parent_scoped))
     }
 
     fn group_has_override(
@@ -225,6 +216,70 @@ impl VersionsOverrider {
         }
     }
 
+    /// The `peerDependencies` arm of upstream's
+    /// [`overrideDepsOfPkg`](https://github.com/pnpm/pnpm/blob/01b3d45ddb/hooks/read-package-hook/src/createVersionsOverrider.ts#L68-L129):
+    /// a matched peer is deleted on `-`, rewritten in place when the
+    /// override value is a valid peer range, and otherwise written
+    /// into `dependencies` (the peer entry stays as declared, and the
+    /// concrete `link:` / `file:` / alias spec is installed as a
+    /// regular dependency).
+    fn override_peer_group(
+        &self,
+        value: &mut Value,
+        applicable_parent_scoped: &[&ResolvedOverride],
+        manifest_dir: Option<&Path>,
+    ) {
+        let entries: Vec<(String, String)> = value
+            .get("peerDependencies")
+            .and_then(Value::as_object)
+            .map(|map| {
+                map.iter()
+                    .filter_map(|(name, spec)| {
+                        spec.as_str().map(|spec_str| (name.clone(), spec_str.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        for (name, spec) in entries {
+            let Some(chosen) = self.choose_override(applicable_parent_scoped, &name, &spec) else {
+                continue;
+            };
+
+            if chosen.inner.new_bare_specifier == "-" {
+                if let Some(peers) = value.get_mut("peerDependencies").and_then(Value::as_object_mut)
+                {
+                    peers.remove(&name);
+                }
+                continue;
+            }
+
+            let new_spec = chosen.local_target.as_ref().map_or_else(
+                || chosen.inner.new_bare_specifier.clone(),
+                |target| resolve_local_override_spec(target, manifest_dir),
+            );
+
+            if is_valid_peer_range(&new_spec) {
+                if let Some(peers) = value.get_mut("peerDependencies").and_then(Value::as_object_mut)
+                {
+                    peers.insert(name, Value::String(new_spec));
+                }
+            } else {
+                if !value.get("dependencies").is_some_and(Value::is_object) {
+                    if let Some(root) = value.as_object_mut() {
+                        root.insert(
+                            "dependencies".to_string(),
+                            Value::Object(serde_json::Map::new()),
+                        );
+                    }
+                }
+                if let Some(deps) = value.get_mut("dependencies").and_then(Value::as_object_mut) {
+                    deps.insert(name, Value::String(new_spec));
+                }
+            }
+        }
+    }
+
     fn choose_override<'b>(
         &'b self,
         applicable_parent_scoped: &[&'b ResolvedOverride],
@@ -262,6 +317,14 @@ impl VersionsOverrider {
         sort_by_specificity(&mut matching);
         matching.into_iter().next()
     }
+}
+
+/// Mirrors upstream's
+/// [`isValidPeerRange`](https://github.com/pnpm/pnpm/blob/01b3d45ddb/deps/peer-range/src/index.ts):
+/// a parseable semver range, or any expression containing a
+/// `workspace:` / `catalog:` segment.
+fn is_valid_peer_range(spec: &str) -> bool {
+    Range::parse(spec).is_ok() || spec.contains("workspace:") || spec.contains("catalog:")
 }
 
 /// Mirrors upstream's `targetPkg.name === name && isIntersectingRange(targetPkg.bareSpecifier, bareSpecifier)`.

--- a/pacquet/crates/package-manager/src/overrides.rs
+++ b/pacquet/crates/package-manager/src/overrides.rs
@@ -247,7 +247,8 @@ impl VersionsOverrider {
             };
 
             if chosen.inner.new_bare_specifier == "-" {
-                if let Some(peers) = value.get_mut("peerDependencies").and_then(Value::as_object_mut)
+                if let Some(peers) =
+                    value.get_mut("peerDependencies").and_then(Value::as_object_mut)
                 {
                     peers.remove(&name);
                 }
@@ -260,7 +261,8 @@ impl VersionsOverrider {
             );
 
             if is_valid_peer_range(&new_spec) {
-                if let Some(peers) = value.get_mut("peerDependencies").and_then(Value::as_object_mut)
+                if let Some(peers) =
+                    value.get_mut("peerDependencies").and_then(Value::as_object_mut)
                 {
                     peers.insert(name, Value::String(new_spec));
                 }

--- a/pacquet/crates/package-manager/src/overrides/tests.rs
+++ b/pacquet/crates/package-manager/src/overrides/tests.rs
@@ -276,3 +276,73 @@ fn override_for_missing_dep_does_not_add_entry() {
     assert!(manifest.value().get("dependencies").unwrap().get("foo").is_none());
     assert_eq!(dep_spec(&manifest, "dependencies", "bar"), Some("^1"));
 }
+
+#[test]
+fn override_with_valid_peer_range_rewrites_peer_dependencies() {
+    let overrides = parsed(&[("ajv@>=7.0.0-alpha.0 <8.18.0", ">=8.18.0")]);
+    let overrider = VersionsOverrider::new(&overrides, Path::new("/workspace"));
+
+    let mut manifest = manifest_from_value(json!({
+        "name": "schema-validator",
+        "version": "1.0.0",
+        "peerDependencies": { "ajv": "^8.12.0" },
+    }));
+    overrider.apply(&mut manifest, Some(Path::new("/workspace")));
+
+    assert_eq!(dep_spec(&manifest, "peerDependencies", "ajv"), Some(">=8.18.0"));
+    assert_eq!(dep_spec(&manifest, "dependencies", "ajv"), None);
+}
+
+#[test]
+fn override_with_non_peer_range_lands_in_dependencies_and_keeps_the_peer() {
+    let overrides = parsed(&[("istanbul-reports", "npm:@zkochan/istanbul-reports")]);
+    let overrider = VersionsOverrider::new(&overrides, Path::new("/workspace"));
+
+    let mut manifest = manifest_from_value(json!({
+        "name": "reporter-host",
+        "version": "1.0.0",
+        "peerDependencies": { "istanbul-reports": "^3.0.0" },
+    }));
+    overrider.apply(&mut manifest, Some(Path::new("/workspace")));
+
+    assert_eq!(
+        dep_spec(&manifest, "dependencies", "istanbul-reports"),
+        Some("npm:@zkochan/istanbul-reports"),
+    );
+    assert_eq!(dep_spec(&manifest, "peerDependencies", "istanbul-reports"), Some("^3.0.0"));
+}
+
+#[test]
+fn dash_override_deletes_the_peer_dependency() {
+    let overrides = parsed(&[("unwanted-peer", "-")]);
+    let overrider = VersionsOverrider::new(&overrides, Path::new("/workspace"));
+
+    let mut manifest = manifest_from_value(json!({
+        "name": "my-app",
+        "version": "1.0.0",
+        "peerDependencies": { "unwanted-peer": "^1.0.0", "kept": "^2.0.0" },
+    }));
+    overrider.apply(&mut manifest, Some(Path::new("/workspace")));
+
+    assert_eq!(dep_spec(&manifest, "peerDependencies", "unwanted-peer"), None);
+    assert_eq!(dep_spec(&manifest, "peerDependencies", "kept"), Some("^2.0.0"));
+}
+
+#[test]
+fn apply_to_arc_clones_when_only_a_peer_matches() {
+    let overrides = parsed(&[("ajv@<8.18.0", ">=8.18.0")]);
+    let overrider = VersionsOverrider::new(&overrides, Path::new("/workspace"));
+
+    let original = std::sync::Arc::new(json!({
+        "name": "schema-validator",
+        "version": "1.0.0",
+        "peerDependencies": { "ajv": "^8.12.0" },
+    }));
+    let updated = overrider.apply_to_arc(std::sync::Arc::clone(&original), None);
+
+    assert!(!std::sync::Arc::ptr_eq(&original, &updated), "peer-only match must clone");
+    assert_eq!(
+        updated.get("peerDependencies").and_then(|peers| peers.get("ajv")).and_then(Value::as_str),
+        Some(">=8.18.0"),
+    );
+}

--- a/pacquet/crates/resolving-deps-resolver/src/dependencies_graph.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/dependencies_graph.rs
@@ -76,6 +76,13 @@ pub struct PeerDependencyIssues {
 pub struct MissingPeer {
     pub wanted_range: String,
     pub optional: bool,
+    /// `true` when the requiring package declares the peer only via
+    /// `peerDependenciesMeta`. Pacquet-internal (upstream's issue item
+    /// has no such field): the importer hoist loop uses it to keep
+    /// meta-only peers out of the optional-peer hoist, mirroring
+    /// upstream's `getMissingPeers`, which feeds the hoist from
+    /// `peerDependencies` entries only.
+    pub meta_only: bool,
     /// Chain of `(name, version)` from the root importer down to the
     /// parent that declared the peer requirement. Mirrors upstream's
     /// `parents: ParentPackages`.

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -1867,14 +1867,9 @@ fn extract_peer_dependencies(
             {
                 continue;
             }
-            peers
-                .entry(name.clone())
-                .and_modify(|entry| entry.optional = true)
-                .or_insert_with(|| PeerDep {
-                    version: "*".to_string(),
-                    optional: true,
-                    meta_only: true,
-                });
+            peers.entry(name.clone()).and_modify(|entry| entry.optional = true).or_insert_with(
+                || PeerDep { version: "*".to_string(), optional: true, meta_only: true },
+            );
         }
     }
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -1854,7 +1854,7 @@ fn extract_peer_dependencies(
             if let Some(range_str) = range.as_str() {
                 peers.insert(
                     name.clone(),
-                    PeerDep { version: range_str.to_string(), optional: false },
+                    PeerDep { version: range_str.to_string(), optional: false, meta_only: false },
                 );
             }
         }
@@ -1870,7 +1870,11 @@ fn extract_peer_dependencies(
             peers
                 .entry(name.clone())
                 .and_modify(|entry| entry.optional = true)
-                .or_insert_with(|| PeerDep { version: "*".to_string(), optional: true });
+                .or_insert_with(|| PeerDep {
+                    version: "*".to_string(),
+                    optional: true,
+                    meta_only: true,
+                });
         }
     }
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -296,6 +296,14 @@ pub(crate) fn importer_injected_dependency_names(manifest: &PackageManifest) -> 
 /// `peerDependencies`) tagged with the right `optional` / `injected`
 /// flags and with `catalog:` specifiers resolved.
 ///
+/// An alias declared in several groups yields one spec, merged the way
+/// pnpm spreads the groups in
+/// [`getWantedDependencies`](https://github.com/pnpm/pnpm/blob/01b3d45ddb/installing/deps-resolver/src/getWantedDependencies.ts#L32-L43):
+/// `peerDependencies` first (when `auto_install_peers`), then
+/// `dependencies` < `devDependencies` < `optionalDependencies`, a later
+/// group's range replacing an earlier one — so an importer's own regular
+/// dep (e.g. a `workspace:*` devDependency) wins over its peer range.
+///
 /// Shared by [`fn@crate::resolve_importer`] (which walks them) and the
 /// `time-based` cutoff pre-pass in [`fn@crate::resolve_workspace`]
 /// (which only needs the resolved direct-dep publish dates), so both
@@ -312,13 +320,20 @@ pub(crate) fn importer_direct_wanted_specs<DependencyGroupList>(
 where
     DependencyGroupList: IntoIterator<Item = DependencyGroup>,
 {
-    let mut groups: Vec<DependencyGroup> = dependency_groups.into_iter().collect();
-    if auto_install_peers && !groups.contains(&DependencyGroup::Peer) {
+    let included: Vec<DependencyGroup> = dependency_groups.into_iter().collect();
+    let mut groups: Vec<DependencyGroup> = Vec::new();
+    if auto_install_peers || included.contains(&DependencyGroup::Peer) {
         groups.push(DependencyGroup::Peer);
     }
+    groups.extend(
+        [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional]
+            .into_iter()
+            .filter(|group| included.contains(group)),
+    );
     let optional_names = importer_optional_dependency_names(manifest);
     let injected_names = importer_injected_dependency_names(manifest);
-    let mut wanted: Vec<WantedSpec> = Vec::new();
+    let mut order: Vec<&str> = Vec::new();
+    let mut ranges: HashMap<&str, &str> = HashMap::new();
     for (name, range) in manifest.dependencies(groups) {
         if !crate::is_valid_dependency_alias(name) {
             return Err(ResolveDependencyTreeError::InvalidDependencyName {
@@ -326,10 +341,21 @@ where
                 alias: name.to_string(),
             });
         }
-        let optional = optional_names.contains(name);
-        let injected = injected_names.contains(name);
-        wanted.push((name.to_string(), range.to_string(), optional, injected));
+        if ranges.insert(name, range).is_none() {
+            order.push(name);
+        }
     }
+    let wanted: Vec<WantedSpec> = order
+        .into_iter()
+        .map(|name| {
+            (
+                name.to_string(),
+                ranges[name].to_string(),
+                optional_names.contains(name),
+                injected_names.contains(name),
+            )
+        })
+        .collect();
     resolve_catalog_specifiers(wanted, catalogs)
 }
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -100,6 +100,9 @@ pub struct ResolveDependencyTreeOptions {
     /// calls. `None` leaves hook logging a no-op. See
     /// [`WorkspaceTreeCtx::with_read_package_log`].
     pub read_package_log: Option<pacquet_hooks::LogFn>,
+    /// The install's `autoInstallPeers` setting. See
+    /// [`WorkspaceTreeCtx::with_auto_install_peers`].
+    pub auto_install_peers: bool,
 }
 
 impl std::fmt::Debug for ResolveDependencyTreeOptions {
@@ -110,6 +113,7 @@ impl std::fmt::Debug for ResolveDependencyTreeOptions {
             .field("manifest_hook", &self.manifest_hook.as_ref().map(|_| "<hook>"))
             .field("pnpmfile_hook", &self.pnpmfile_hook.as_ref().map(|_| "<hook>"))
             .field("read_package_log", &self.read_package_log.as_ref().map(|_| "<log>"))
+            .field("auto_install_peers", &self.auto_install_peers)
             .finish()
     }
 }
@@ -236,7 +240,8 @@ where
         .with_patched_dependencies(opts.patched_dependencies)
         .with_manifest_hook(opts.manifest_hook)
         .with_pnpmfile_hook(opts.pnpmfile_hook)
-        .with_read_package_log(opts.read_package_log);
+        .with_read_package_log(opts.read_package_log)
+        .with_auto_install_peers(opts.auto_install_peers);
     let optional_names = importer_optional_dependency_names(manifest);
     let injected_names = importer_injected_dependency_names(manifest);
     let mut wanted: Vec<WantedSpec> = Vec::new();
@@ -499,6 +504,12 @@ pub struct WorkspaceTreeCtx {
     /// pnpmfile path. `None` leaves hook logging a no-op. See
     /// [`WorkspaceTreeCtx::with_read_package_log`].
     read_package_log: Option<pacquet_hooks::LogFn>,
+    /// The install's `autoInstallPeers` setting. When `true`,
+    /// [`fn@resolve_node`] drops a resolved package's `dependencies`
+    /// entries that are shadowed by its own `peerDependencies`, so the
+    /// peer edge supplies the package instead. See
+    /// [`omit_peer_shadowed_dependencies`].
+    auto_install_peers: bool,
 }
 
 impl Default for WorkspaceTreeCtx {
@@ -518,6 +529,7 @@ impl Default for WorkspaceTreeCtx {
             subtree_reusable: Mutex::new(HashMap::new()),
             pnpmfile_hook: None,
             read_package_log: None,
+            auto_install_peers: false,
         }
     }
 }
@@ -587,6 +599,13 @@ impl WorkspaceTreeCtx {
     #[must_use]
     pub fn with_read_package_log(mut self, read_package_log: Option<pacquet_hooks::LogFn>) -> Self {
         self.read_package_log = read_package_log;
+        self
+    }
+
+    /// Set the install's `autoInstallPeers` flag. See the field doc.
+    #[must_use]
+    pub fn with_auto_install_peers(mut self, auto_install_peers: bool) -> Self {
+        self.auto_install_peers = auto_install_peers;
         self
     }
 
@@ -775,6 +794,19 @@ impl TreeCtx {
                 "with_read_package_log called after the workspace ctx was shared via Arc::clone",
             )
             .read_package_log = read_package_log;
+        self
+    }
+
+    /// Set the install's `autoInstallPeers` flag on the underlying
+    /// [`WorkspaceTreeCtx`]. Like [`Self::with_pnpmfile_hook`], panics if
+    /// it has already been shared via `Arc::clone`.
+    #[must_use]
+    pub fn with_auto_install_peers(mut self, auto_install_peers: bool) -> Self {
+        Arc::get_mut(&mut self.workspace)
+            .expect(
+                "with_auto_install_peers called after the workspace ctx was shared via Arc::clone",
+            )
+            .auto_install_peers = auto_install_peers;
         self
     }
 
@@ -998,6 +1030,12 @@ where
                 .await
                 .map_err(ResolveDependencyTreeError::PnpmfileHook)?;
             result_inner.manifest = Some(updated);
+        }
+
+        if ctx.workspace.auto_install_peers
+            && let Some(manifest) = result_inner.manifest.take()
+        {
+            result_inner.manifest = Some(omit_peer_shadowed_dependencies(manifest));
         }
 
         let result = result.expect("Some-guarded above");
@@ -1778,17 +1816,23 @@ fn render_parent(result: &pacquet_resolving_resolver_base::ResolveResult) -> Str
 /// Extract `peerDependencies` from a resolved package's manifest, with
 /// `peerDependenciesMeta[name].optional` folded onto each entry.
 /// Mirrors upstream's
-/// [`peerDependenciesWithoutOwn`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1791-L1815):
-/// names also present in `dependencies` or `optionalDependencies` are
-/// skipped because those edges already supply the same package
-/// directly.
+/// [`peerDependenciesWithoutOwn`](https://github.com/pnpm/pnpm/blob/01b3d45ddb/installing/deps-resolver/src/resolveDependencies.ts#L1840-L1864):
+/// the package's own name plus names also present in `dependencies` or
+/// `optionalDependencies` are skipped because those edges already
+/// supply the same package directly. Under `autoInstallPeers`,
+/// [`omit_peer_shadowed_dependencies`] has already dropped
+/// peer-shadowed names from `dependencies`, so those peers survive
+/// here. A `peerDependenciesMeta` entry without a matching
+/// `peerDependencies` entry only counts when `optional: true` —
+/// upstream treats it as an optional `"*"` peer and ignores
+/// non-optional meta-only entries.
 fn extract_peer_dependencies(
     result: &pacquet_resolving_resolver_base::ResolveResult,
 ) -> BTreeMap<String, PeerDep> {
     let Some(manifest) = result.manifest.as_ref() else { return BTreeMap::new() };
     let mut peers: BTreeMap<String, PeerDep> = BTreeMap::new();
 
-    let own_deps: HashSet<String> = ["dependencies", "optionalDependencies"]
+    let mut own_deps: HashSet<String> = ["dependencies", "optionalDependencies"]
         .iter()
         .flat_map(|key| {
             manifest
@@ -1798,6 +1842,9 @@ fn extract_peer_dependencies(
                 .flat_map(|map| map.keys().cloned())
         })
         .collect();
+    if let Some(name) = manifest.get("name").and_then(Value::as_str) {
+        own_deps.insert(name.to_string());
+    }
 
     if let Some(map) = manifest.get("peerDependencies").and_then(Value::as_object) {
         for (name, range) in map {
@@ -1815,21 +1862,52 @@ fn extract_peer_dependencies(
 
     if let Some(meta) = manifest.get("peerDependenciesMeta").and_then(Value::as_object) {
         for (name, info) in meta {
-            if own_deps.contains(name) {
+            if own_deps.contains(name)
+                || info.get("optional").and_then(Value::as_bool) != Some(true)
+            {
                 continue;
             }
-            let optional = info.get("optional").and_then(Value::as_bool).unwrap_or(false);
-            // peerDependenciesMeta can declare a peer without a
-            // matching peerDependencies entry — upstream treats those
-            // as version "*". Mirror that shape.
             peers
                 .entry(name.clone())
-                .and_modify(|entry| entry.optional = entry.optional || optional)
-                .or_insert_with(|| PeerDep { version: "*".to_string(), optional });
+                .and_modify(|entry| entry.optional = true)
+                .or_insert_with(|| PeerDep { version: "*".to_string(), optional: true });
         }
     }
 
     peers
+}
+
+/// Drop a resolved package's `dependencies` entries that are shadowed
+/// by its own `peerDependencies`, so the peer edge (satisfied from an
+/// ancestor or auto-installed at the importer) supplies the package
+/// instead of a nested copy. Only applies under `autoInstallPeers` —
+/// mirrors upstream's dependencies-omit in
+/// [`resolveDependencies.ts`](https://github.com/pnpm/pnpm/blob/01b3d45ddb/installing/deps-resolver/src/resolveDependencies.ts#L1527-L1542).
+/// (The non-`autoInstallPeers` arm there omits only peers resolvable
+/// from the parent scope; pacquet's per-package children cache has no
+/// parent context, so that arm is not ported and the own dependency
+/// keeps winning, which matches upstream whenever the peer is not in
+/// scope.)
+fn omit_peer_shadowed_dependencies(manifest: Arc<Value>) -> Arc<Value> {
+    let shadowed: Vec<String> = {
+        let Some(peers) = manifest.get("peerDependencies").and_then(Value::as_object) else {
+            return manifest;
+        };
+        let Some(deps) = manifest.get("dependencies").and_then(Value::as_object) else {
+            return manifest;
+        };
+        deps.keys().filter(|name| peers.contains_key(*name)).cloned().collect()
+    };
+    if shadowed.is_empty() {
+        return manifest;
+    }
+    let mut updated = (*manifest).clone();
+    if let Some(deps) = updated.get_mut("dependencies").and_then(Value::as_object_mut) {
+        for name in &shadowed {
+            deps.remove(name);
+        }
+    }
+    Arc::new(updated)
 }
 
 /// `true` when the package has no `dependencies`, `optionalDependencies`,

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -299,17 +299,14 @@ where
     let initial_wanted =
         importer_direct_wanted_specs(manifest, dependency_groups, auto_install_peers, &catalogs)?;
     let mut direct = extend_tree(&ctx, resolver, initial_wanted, importer_id).await?;
-    // The optional-peer hoist must only consider versions that were
-    // already in scope before this run — the wanted lockfile + manifests
-    // — mirroring upstream's static
-    // [`ctx.allPreferredVersions`](https://github.com/pnpm/pnpm/blob/894ea6af2c/installing/deps-resolver/src/resolveDependencies.ts#L340-L342).
-    // Feeding freshly-resolved transitive versions into that decision
-    // would hoist an optional peer (e.g. `debug`'s `supports-color`)
-    // against a deep-tree provider pnpm never sees, resolving the peer
-    // where pnpm leaves it bare. The required-peer hoist keeps using the
-    // run-extended map below: a required peer is auto-installed either
-    // way, and reusing an in-tree version matches pnpm's picker dedup.
-    let optional_hoist_preferred_versions = all_preferred_versions.clone();
+    // Both hoists read the run-extended preferred-versions map:
+    // upstream folds every resolved package's version into
+    // `ctx.allPreferredVersions`
+    // ([`resolveDependencies.ts#L1483-L1488`](https://github.com/pnpm/pnpm/blob/01b3d45ddb/installing/deps-resolver/src/resolveDependencies.ts#L1483-L1488))
+    // and consults it for the optional hoist after each wave. What
+    // keeps e.g. `debug`'s `supports-color` from being hoisted against
+    // a deep-tree provider is not the map but the missing-peer set:
+    // meta-only peers never enter it (see `partition_missing_peers`).
     update_preferred_versions_with_ctx(&ctx, &mut all_preferred_versions);
 
     let mut parent_pkg_aliases: HashSet<String> =
@@ -383,10 +380,8 @@ where
         if all_missing_optional_peers.is_empty() {
             break;
         }
-        let hoisted_optional = get_hoistable_optional_peers(
-            &all_missing_optional_peers,
-            &optional_hoist_preferred_versions,
-        );
+        let hoisted_optional =
+            get_hoistable_optional_peers(&all_missing_optional_peers, &all_preferred_versions);
         if hoisted_optional.is_empty() {
             break;
         }
@@ -443,9 +438,17 @@ fn partition_missing_peers(
             .map(|entry| entry.wanted_range.as_str())
             .collect();
         if required_ranges.is_empty() {
+            // Meta-only peers don't feed the optional hoist: upstream's
+            // resolution-stage `getMissingPeers` reads `peerDependencies`
+            // entries only, so a peer declared solely via
+            // `peerDependenciesMeta` is never auto-resolved against an
+            // in-tree version.
             let mut seen: BTreeSet<String> = BTreeSet::new();
             let mut ordered: Vec<String> = Vec::new();
             for entry in entries {
+                if entry.meta_only {
+                    continue;
+                }
                 if seen.insert(entry.wanted_range.clone()) {
                     ordered.push(entry.wanted_range.clone());
                 }

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -229,7 +229,8 @@ where
     let workspace = Arc::new(
         WorkspaceTreeCtx::default()
             .with_manifest_hook(opts.manifest_hook.clone())
-            .with_pnpmfile_hook(opts.pnpmfile_hook.clone()),
+            .with_pnpmfile_hook(opts.pnpmfile_hook.clone())
+            .with_auto_install_peers(opts.auto_install_peers),
     );
     resolve_importer_with_workspace(
         resolver,

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -723,17 +723,16 @@ async fn auto_install_does_not_hoist_when_root_already_has_dep() {
     );
 }
 
-/// An *optional* peer that is only available deep in the freshly
-/// resolved tree (brought by a sibling, not pinned in the wanted
-/// lockfile) must NOT be hoisted, so the consumer's depPath stays bare.
-/// `getHoistableOptionalPeers` reads upstream's static
-/// `ctx.allPreferredVersions` (lockfile + manifests, empty on a fresh
-/// install) — never the run-resolved versions. Feeding the latter in
-/// would resolve the optional peer where pnpm leaves it unresolved, and
-/// non-deterministically at that (the result would depend on resolution
-/// order). Regression test for <https://github.com/pnpm/pnpm/issues/12266>.
+/// An optional peer with a real `peerDependencies` entry whose
+/// provider is resolved anywhere in the tree (here: deep under a
+/// sibling) IS hoisted: upstream folds every run-resolved version into
+/// `ctx.allPreferredVersions` and `getHoistableOptionalPeers` resolves
+/// the peer against it after the wave (verified against pnpm 11.6.0 —
+/// the `eslint` + `cosmiconfig-typescript-loader` shape, where
+/// `eslint` gains `(jiti@x)`). For
+/// <https://github.com/pnpm/pnpm/issues/12266>.
 #[tokio::test]
-async fn optional_peer_only_in_resolved_tree_is_not_hoisted() {
+async fn optional_peer_with_real_entry_is_hoisted_from_resolved_tree() {
     let mut table = HashMap::new();
     table.insert(
         ("needs-opt".to_string(), "1.0.0".to_string()),
@@ -748,9 +747,6 @@ async fn optional_peer_only_in_resolved_tree_is_not_hoisted() {
             }),
         ),
     );
-    // `provider` pulls `opt@1.0.0` deep in the tree — a sibling of
-    // `needs-opt`, not an ancestor, so `opt` is out of `needs-opt`'s
-    // resolution scope.
     table.insert(
         ("provider".to_string(), "1.0.0".to_string()),
         fake_result(
@@ -777,11 +773,66 @@ async fn optional_peer_only_in_resolved_tree_is_not_hoisted() {
         .await
         .unwrap();
 
-    // `opt` must not be hoisted to the importer, and `needs-opt`'s
-    // optional peer must stay unresolved — bare `needs-opt@1.0.0`.
     let direct: Vec<&str> =
         result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
-    assert!(!direct.contains(&"opt"), "optional peer `opt` must not be hoisted: {direct:?}");
+    assert!(direct.contains(&"opt"), "optional peer `opt` must be hoisted: {direct:?}");
+    assert_eq!(
+        result.peers_result.direct_dependencies_by_alias.get("needs-opt"),
+        Some(&DepPath::from("needs-opt@1.0.0(opt@1.0.0)".to_string())),
+    );
+}
+
+/// A peer declared only via `peerDependenciesMeta` (no
+/// `peerDependencies` entry — the `debug` / `supports-color` shape) is
+/// NOT hoisted even when a provider is resolved in the tree: upstream's
+/// `getMissingPeers` feeds the hoist from `peerDependencies` entries
+/// only (verified against pnpm 11.6.0 — `debug` + `concurrently` leaves
+/// `debug@4.4.3` bare). For
+/// <https://github.com/pnpm/pnpm/issues/12266>.
+#[tokio::test]
+async fn meta_only_optional_peer_is_not_hoisted() {
+    let mut table = HashMap::new();
+    table.insert(
+        ("needs-opt".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "needs-opt",
+            "1.0.0",
+            serde_json::json!({
+                "name": "needs-opt",
+                "version": "1.0.0",
+                "peerDependenciesMeta": { "opt": { "optional": true } },
+            }),
+        ),
+    );
+    table.insert(
+        ("provider".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "provider",
+            "1.0.0",
+            serde_json::json!({
+                "name": "provider",
+                "version": "1.0.0",
+                "dependencies": { "opt": "1.0.0" },
+            }),
+        ),
+    );
+    table.insert(
+        ("opt".to_string(), "1.0.0".to_string()),
+        fake_result("opt", "1.0.0", serde_json::json!({ "name": "opt", "version": "1.0.0" })),
+    );
+    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let (_tmp, manifest) = fake_manifest(serde_json::json!({
+        "needs-opt": "1.0.0",
+        "provider": "1.0.0",
+    }));
+
+    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
+        .await
+        .unwrap();
+
+    let direct: Vec<&str> =
+        result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
+    assert!(!direct.contains(&"opt"), "meta-only peer `opt` must not be hoisted: {direct:?}");
     assert_eq!(
         result.peers_result.direct_dependencies_by_alias.get("needs-opt"),
         Some(&DepPath::from("needs-opt@1.0.0".to_string())),

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -504,6 +504,8 @@ struct MissingPeerInfo {
     range: String,
     #[allow(dead_code, reason = "future peersCache validation")]
     optional: bool,
+    /// See [`crate::dependencies_graph::MissingPeer::meta_only`].
+    meta_only: bool,
 }
 
 /// Output of [`Walker::resolve_node`] — the per-node result the parent
@@ -817,6 +819,7 @@ impl Walker<'_> {
                 self.issues.missing.entry(peer_name.clone()).or_default().push(MissingPeer {
                     wanted_range: info.range.clone(),
                     optional: info.optional,
+                    meta_only: info.meta_only,
                     parents: parents_from_chain(parent_chain_names, &pkg_name),
                 });
             }
@@ -1063,16 +1066,18 @@ impl Walker<'_> {
         let raw_range = peer_dep.version.as_str();
         let range_for_match = raw_range.strip_prefix("workspace:").unwrap_or(raw_range);
         let optional = peer_dep.optional;
+        let meta_only = peer_dep.meta_only;
 
         match parent_refs.get(peer_name) {
             None => {
                 missing.insert(
                     peer_name.to_string(),
-                    MissingPeerInfo { range: range_for_match.to_string(), optional },
+                    MissingPeerInfo { range: range_for_match.to_string(), optional, meta_only },
                 );
                 self.issues.missing.entry(peer_name.to_string()).or_default().push(MissingPeer {
                     wanted_range: range_for_match.to_string(),
                     optional,
+                    meta_only,
                     parents: parents_from_chain(chain, pkg_name),
                 });
             }

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -456,7 +456,10 @@ fn package_with_peer_dependencies(
     let peer_dependencies = peer_dependencies
         .iter()
         .map(|(name, version, optional)| {
-            ((*name).to_string(), PeerDep { version: (*version).to_string(), optional: *optional, meta_only: false })
+            (
+                (*name).to_string(),
+                PeerDep { version: (*version).to_string(), optional: *optional, meta_only: false },
+            )
         })
         .collect();
     ResolvedPackage {

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -456,7 +456,7 @@ fn package_with_peer_dependencies(
     let peer_dependencies = peer_dependencies
         .iter()
         .map(|(name, version, optional)| {
-            ((*name).to_string(), PeerDep { version: (*version).to_string(), optional: *optional })
+            ((*name).to_string(), PeerDep { version: (*version).to_string(), optional: *optional, meta_only: false })
         })
         .collect();
     ResolvedPackage {

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -105,6 +105,13 @@ pub struct WorkspaceResolveOptions {
     /// calls, pre-bound to the install's reporter. `None` leaves hook
     /// logging a no-op.
     pub read_package_log: Option<pacquet_hooks::LogFn>,
+
+    /// The install's `autoInstallPeers` setting, threaded onto the
+    /// shared [`WorkspaceTreeCtx`] so the tree walk drops
+    /// peer-shadowed `dependencies` entries the way pnpm does. The
+    /// per-importer [`crate::ResolveImporterOptions::auto_install_peers`]
+    /// must agree with this value.
+    pub auto_install_peers: bool,
 }
 
 /// Result of [`fn@resolve_workspace`]. The combined
@@ -151,6 +158,7 @@ where
         time_based,
         wanted_lockfile,
         update_reuse_scope,
+        auto_install_peers,
     } = opts;
     let workspace = Arc::new(
         WorkspaceTreeCtx::default()
@@ -158,7 +166,8 @@ where
             .with_wanted_lockfile(wanted_lockfile)
             .with_update_reuse_scope(update_reuse_scope)
             .with_pnpmfile_hook(pnpmfile_hook)
-            .with_read_package_log(read_package_log),
+            .with_read_package_log(read_package_log)
+            .with_auto_install_peers(auto_install_peers),
     );
 
     // Build every importer's options up front so the `time-based`

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -108,9 +108,10 @@ pub struct WorkspaceResolveOptions {
 
     /// The install's `autoInstallPeers` setting, threaded onto the
     /// shared [`WorkspaceTreeCtx`] so the tree walk drops
-    /// peer-shadowed `dependencies` entries the way pnpm does. The
-    /// per-importer [`crate::ResolveImporterOptions::auto_install_peers`]
-    /// must agree with this value.
+    /// peer-shadowed `dependencies` entries the way pnpm does. Also
+    /// overrides every per-importer
+    /// [`crate::ResolveImporterOptions::auto_install_peers`] — the
+    /// setting is workspace-wide, like pnpm's `autoInstallPeers`.
     pub auto_install_peers: bool,
 }
 
@@ -172,8 +173,18 @@ where
 
     // Build every importer's options up front so the `time-based`
     // pre-pass and the resolve loop see the same per-importer wiring.
-    let importer_opts: Vec<ResolveImporterOptions> =
-        importers.iter().map(&mut per_importer_options).collect();
+    // `auto_install_peers` is workspace-wide (one setting per install,
+    // like pnpm's `autoInstallPeers`), so the workspace-level value
+    // overrides whatever the per-importer callback set — the importer
+    // hoist loop and the tree walk's shadow pruning must agree.
+    let importer_opts: Vec<ResolveImporterOptions> = importers
+        .iter()
+        .map(&mut per_importer_options)
+        .map(|mut opts| {
+            opts.auto_install_peers = auto_install_peers;
+            opts
+        })
+        .collect();
 
     // The `minimumReleaseAge` cutoff is set uniformly on every
     // importer's `base_opts.published_by` by the install layer; it is

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -142,6 +142,7 @@ fn workspace_opts(pick_lowest_direct: bool, time_based: bool) -> WorkspaceResolv
         time_based,
         wanted_lockfile: None,
         update_reuse_scope: crate::UpdateReuseScope::All,
+        auto_install_peers: false,
     }
 }
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolved_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolved_tree.rs
@@ -172,6 +172,13 @@ pub struct PeerDep {
     /// is set — a missing peer with `optional` true is recorded as an
     /// issue but does not block resolution.
     pub optional: bool,
+    /// `true` when the peer exists only via `peerDependenciesMeta`
+    /// (no `peerDependencies` entry). Upstream's resolution-stage
+    /// [`getMissingPeers`](https://github.com/pnpm/pnpm/blob/01b3d45ddb/installing/deps-resolver/src/resolveDependencies.ts#L1773-L1782)
+    /// reads `peerDependencies` only, so a meta-only peer never feeds
+    /// the optional-peer hoist — it still resolves in the peer pass
+    /// when a provider is genuinely in scope.
+    pub meta_only: bool,
 }
 
 /// One per-occurrence node in the dependencies tree. Mirrors upstream's

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -2509,3 +2509,85 @@ mod optional_propagation {
         );
     }
 }
+
+mod importer_wanted_specs {
+    use super::{DependencyGroup, PackageManifest};
+    use crate::resolve_dependency_tree::importer_direct_wanted_specs;
+    use pretty_assertions::assert_eq;
+
+    fn manifest_with(groups: serde_json::Value) -> (tempfile::TempDir, PackageManifest) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("package.json");
+        let mut json = serde_json::json!({ "name": "root", "version": "0.0.0" });
+        json.as_object_mut().unwrap().extend(groups.as_object().unwrap().clone());
+        std::fs::write(&path, serde_json::to_string(&json).unwrap()).expect("write package.json");
+        let manifest = PackageManifest::from_path(path).expect("parse package.json");
+        (tmp, manifest)
+    }
+
+    const ALL_GROUPS: [DependencyGroup; 3] =
+        [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional];
+
+    #[test]
+    fn regular_dep_wins_over_own_peer_with_auto_install_peers() {
+        let (_tmp, manifest) = manifest_with(serde_json::json!({
+            "devDependencies": { "foo": "workspace:*" },
+            "peerDependencies": { "foo": "^1.0.0" },
+        }));
+        let wanted = importer_direct_wanted_specs(
+            &manifest,
+            ALL_GROUPS,
+            true,
+            &pacquet_catalogs_types::Catalogs::new(),
+        )
+        .unwrap();
+        assert_eq!(wanted, vec![("foo".to_string(), "workspace:*".to_string(), false, false)]);
+    }
+
+    #[test]
+    fn peer_only_dep_is_wanted_with_auto_install_peers() {
+        let (_tmp, manifest) = manifest_with(serde_json::json!({
+            "peerDependencies": { "peer-only": "^2.0.0" },
+        }));
+        let wanted = importer_direct_wanted_specs(
+            &manifest,
+            ALL_GROUPS,
+            true,
+            &pacquet_catalogs_types::Catalogs::new(),
+        )
+        .unwrap();
+        assert_eq!(wanted, vec![("peer-only".to_string(), "^2.0.0".to_string(), false, false)]);
+    }
+
+    #[test]
+    fn peer_only_dep_is_not_wanted_without_auto_install_peers() {
+        let (_tmp, manifest) = manifest_with(serde_json::json!({
+            "dependencies": { "regular": "^1.0.0" },
+            "peerDependencies": { "peer-only": "^2.0.0" },
+        }));
+        let wanted = importer_direct_wanted_specs(
+            &manifest,
+            ALL_GROUPS,
+            false,
+            &pacquet_catalogs_types::Catalogs::new(),
+        )
+        .unwrap();
+        assert_eq!(wanted, vec![("regular".to_string(), "^1.0.0".to_string(), false, false)]);
+    }
+
+    #[test]
+    fn later_regular_group_range_replaces_earlier_one() {
+        let (_tmp, manifest) = manifest_with(serde_json::json!({
+            "dependencies": { "foo": "^1.0.0" },
+            "optionalDependencies": { "foo": "^2.0.0" },
+        }));
+        let wanted = importer_direct_wanted_specs(
+            &manifest,
+            ALL_GROUPS,
+            false,
+            &pacquet_catalogs_types::Catalogs::new(),
+        )
+        .unwrap();
+        assert_eq!(wanted, vec![("foo".to_string(), "^2.0.0".to_string(), true, false)]);
+    }
+}

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -2549,6 +2549,10 @@ mod importer_wanted_specs {
     use crate::resolve_dependency_tree::importer_direct_wanted_specs;
     use pretty_assertions::assert_eq;
 
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "test helpers take owned literal fixtures by value to keep call sites clean"
+    )]
     fn manifest_with(groups: serde_json::Value) -> (tempfile::TempDir, PackageManifest) {
         let tmp = tempfile::tempdir().expect("tempdir");
         let path = tmp.path().join("package.json");

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -123,6 +123,7 @@ async fn walks_dependencies_and_builds_flat_tree() {
             manifest_hook: None,
             pnpmfile_hook: None,
             read_package_log: None,
+            auto_install_peers: false,
         },
     )
     .await
@@ -193,6 +194,7 @@ async fn dedupes_when_the_same_package_appears_in_two_subtrees() {
             manifest_hook: None,
             pnpmfile_hook: None,
             read_package_log: None,
+            auto_install_peers: false,
         },
     )
     .await
@@ -279,6 +281,7 @@ async fn workspace_link_node_is_short_circuited_in_tree() {
             manifest_hook: None,
             pnpmfile_hook: None,
             read_package_log: None,
+            auto_install_peers: false,
         },
     )
     .await
@@ -321,6 +324,7 @@ async fn declined_specifier_surfaces_spec_not_supported_error() {
             manifest_hook: None,
             pnpmfile_hook: None,
             read_package_log: None,
+            auto_install_peers: false,
         },
     )
     .await
@@ -366,6 +370,7 @@ async fn transitive_dep_with_traversal_alias_is_rejected() {
             manifest_hook: None,
             pnpmfile_hook: None,
             read_package_log: None,
+            auto_install_peers: false,
         },
     )
     .await
@@ -445,6 +450,7 @@ mod block_exotic_subdeps {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -488,6 +494,7 @@ mod block_exotic_subdeps {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -532,6 +539,7 @@ mod block_exotic_subdeps {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -578,6 +586,7 @@ mod block_exotic_subdeps {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -621,6 +630,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -674,6 +684,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -725,6 +736,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -779,6 +791,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -904,6 +917,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -1006,6 +1020,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -1103,6 +1118,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -1178,6 +1194,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -1261,6 +1278,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -1311,6 +1329,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -1409,6 +1428,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -1505,6 +1525,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -1613,6 +1634,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -1683,6 +1705,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -1794,6 +1817,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -1903,6 +1927,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -2014,6 +2039,7 @@ mod peers {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -2108,6 +2134,7 @@ mod patched_dependencies {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -2157,6 +2184,7 @@ mod patched_dependencies {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -2192,6 +2220,7 @@ mod patched_dependencies {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -2243,6 +2272,7 @@ mod patched_dependencies {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -2318,6 +2348,7 @@ mod optional_propagation {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -2374,6 +2405,7 @@ mod optional_propagation {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -2440,6 +2472,7 @@ mod optional_propagation {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -2494,6 +2527,7 @@ mod optional_propagation {
                 manifest_hook: None,
                 pnpmfile_hook: None,
                 read_package_log: None,
+                auto_install_peers: false,
             },
         )
         .await
@@ -2589,5 +2623,138 @@ mod importer_wanted_specs {
         )
         .unwrap();
         assert_eq!(wanted, vec![("foo".to_string(), "^2.0.0".to_string(), true, false)]);
+    }
+}
+
+mod peer_own_dep_shadowing {
+    use super::{
+        DependencyGroup, HashMap, Mutex, ResolveDependencyTreeOptions, ResolveOptions,
+        StubResolver, fake_manifest, fake_result, resolve_dependency_tree,
+    };
+
+    fn opts(auto_install_peers: bool) -> ResolveDependencyTreeOptions {
+        ResolveDependencyTreeOptions {
+            base_opts: ResolveOptions::default(),
+            patched_dependencies: None,
+            manifest_hook: None,
+            pnpmfile_hook: None,
+            read_package_log: None,
+            auto_install_peers,
+        }
+    }
+
+    fn parser_table() -> HashMap<(String, String), pacquet_resolving_resolver_base::ResolveResult>
+    {
+        let mut table = HashMap::new();
+        table.insert(
+            ("parser".to_string(), "^1.0.0".to_string()),
+            fake_result(
+                "parser",
+                "1.0.0",
+                serde_json::json!({
+                    "name": "parser",
+                    "version": "1.0.0",
+                    "dependencies": { "types": "^1.0.0" },
+                    "peerDependencies": { "types": "*" },
+                }),
+            ),
+        );
+        table.insert(
+            ("types".to_string(), "^1.0.0".to_string()),
+            fake_result(
+                "types",
+                "1.0.0",
+                serde_json::json!({ "name": "types", "version": "1.0.0" }),
+            ),
+        );
+        table
+    }
+
+    #[tokio::test]
+    async fn auto_install_peers_keeps_the_peer_and_drops_the_own_dep() {
+        let resolver = StubResolver { table: parser_table(), calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) = fake_manifest(serde_json::json!({ "parser": "^1.0.0" }));
+
+        let tree = resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod],
+            opts(true),
+        )
+        .await
+        .unwrap();
+
+        let parser = tree.packages.get("parser@1.0.0").expect("parser resolved");
+        assert!(
+            parser.peer_dependencies.contains_key("types"),
+            "the peer survives when it also appears in the package's own dependencies",
+        );
+        assert!(
+            !tree.packages.contains_key("types@1.0.0"),
+            "the peer-shadowed own dependency is not walked as a child",
+        );
+    }
+
+    #[tokio::test]
+    async fn without_auto_install_peers_the_own_dep_wins() {
+        let resolver = StubResolver { table: parser_table(), calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) = fake_manifest(serde_json::json!({ "parser": "^1.0.0" }));
+
+        let tree = resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod],
+            opts(false),
+        )
+        .await
+        .unwrap();
+
+        let parser = tree.packages.get("parser@1.0.0").expect("parser resolved");
+        assert!(
+            !parser.peer_dependencies.contains_key("types"),
+            "the peer is dropped when the package supplies the name itself",
+        );
+        assert!(tree.packages.contains_key("types@1.0.0"), "the own dependency is walked");
+    }
+
+    #[tokio::test]
+    async fn non_optional_meta_only_entry_is_not_a_peer() {
+        let mut table = HashMap::new();
+        table.insert(
+            ("pkg".to_string(), "^1.0.0".to_string()),
+            fake_result(
+                "pkg",
+                "1.0.0",
+                serde_json::json!({
+                    "name": "pkg",
+                    "version": "1.0.0",
+                    "peerDependenciesMeta": {
+                        "ghost": {},
+                        "wanted-optional": { "optional": true },
+                    },
+                }),
+            ),
+        );
+        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) = fake_manifest(serde_json::json!({ "pkg": "^1.0.0" }));
+
+        let tree = resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod],
+            opts(false),
+        )
+        .await
+        .unwrap();
+
+        let pkg = tree.packages.get("pkg@1.0.0").expect("pkg resolved");
+        assert!(
+            !pkg.peer_dependencies.contains_key("ghost"),
+            "a peerDependenciesMeta entry without optional: true and without a peerDependencies entry is ignored",
+        );
+        let optional_peer =
+            pkg.peer_dependencies.get("wanted-optional").expect("optional meta-only peer kept");
+        assert!(optional_peer.optional);
+        assert_eq!(optional_peer.version, "*");
     }
 }

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -2643,8 +2643,7 @@ mod peer_own_dep_shadowing {
         }
     }
 
-    fn parser_table() -> HashMap<(String, String), pacquet_resolving_resolver_base::ResolveResult>
-    {
+    fn parser_table() -> HashMap<(String, String), pacquet_resolving_resolver_base::ResolveResult> {
         let mut table = HashMap::new();
         table.insert(
             ("parser".to_string(), "^1.0.0".to_string()),
@@ -2675,14 +2674,10 @@ mod peer_own_dep_shadowing {
         let resolver = StubResolver { table: parser_table(), calls: Mutex::new(Vec::new()) };
         let (_tmp, manifest) = fake_manifest(serde_json::json!({ "parser": "^1.0.0" }));
 
-        let tree = resolve_dependency_tree(
-            &resolver,
-            &manifest,
-            [DependencyGroup::Prod],
-            opts(true),
-        )
-        .await
-        .unwrap();
+        let tree =
+            resolve_dependency_tree(&resolver, &manifest, [DependencyGroup::Prod], opts(true))
+                .await
+                .unwrap();
 
         let parser = tree.packages.get("parser@1.0.0").expect("parser resolved");
         assert!(
@@ -2700,14 +2695,10 @@ mod peer_own_dep_shadowing {
         let resolver = StubResolver { table: parser_table(), calls: Mutex::new(Vec::new()) };
         let (_tmp, manifest) = fake_manifest(serde_json::json!({ "parser": "^1.0.0" }));
 
-        let tree = resolve_dependency_tree(
-            &resolver,
-            &manifest,
-            [DependencyGroup::Prod],
-            opts(false),
-        )
-        .await
-        .unwrap();
+        let tree =
+            resolve_dependency_tree(&resolver, &manifest, [DependencyGroup::Prod], opts(false))
+                .await
+                .unwrap();
 
         let parser = tree.packages.get("parser@1.0.0").expect("parser resolved");
         assert!(
@@ -2738,14 +2729,10 @@ mod peer_own_dep_shadowing {
         let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
         let (_tmp, manifest) = fake_manifest(serde_json::json!({ "pkg": "^1.0.0" }));
 
-        let tree = resolve_dependency_tree(
-            &resolver,
-            &manifest,
-            [DependencyGroup::Prod],
-            opts(false),
-        )
-        .await
-        .unwrap();
+        let tree =
+            resolve_dependency_tree(&resolver, &manifest, [DependencyGroup::Prod], opts(false))
+                .await
+                .unwrap();
 
         let pkg = tree.packages.get("pkg@1.0.0").expect("pkg resolved");
         assert!(


### PR DESCRIPTION
## Summary

Four lockfile-parity fixes for pacquet, continuing https://github.com/pnpm/pnpm/issues/12266. Measured on the monorepo itself (fresh state, `install --lockfile-only`, back-to-back against the live registry vs **pnpm 11.6.0**), the real-lockfile document diff drops from **806 to 461 changed lines**. Two consecutive pacquet runs are byte-identical before and after.

### 1. Importer's regular dep wins over its own peer range (`fix(deps-resolver)`)

An importer that declares the same alias in both `peerDependencies` and a regular group (e.g. `@pnpm/logger`: `workspace:*` devDependency + `catalog:` peer — 67 importers in this repo) resolved both specs, and the peer's registry resolution overwrote the workspace link in the importers section (`version: 1001.0.1` instead of `link:../../core/logger`, 182 diff lines). `importer_direct_wanted_specs` now merges the groups the way pnpm spreads them in [`getWantedDependencies`](https://github.com/pnpm/pnpm/blob/01b3d45ddb/installing/deps-resolver/src/getWantedDependencies.ts#L32-L43): peers first, then `dependencies` < `devDependencies` < `optionalDependencies`, one wanted spec per alias. The `@pnpm/logger` resolution tallies now match pnpm's exactly.

### 2. A package's peer survives when it also lists the name as a dependency (`fix(deps-resolver)`)

Under `autoInstallPeers`, pnpm removes peer-shadowed names from a resolved package's `dependencies` **before** extracting peers ([resolveDependencies.ts#L1527-L1542](https://github.com/pnpm/pnpm/blob/01b3d45ddb/installing/deps-resolver/src/resolveDependencies.ts#L1527-L1542)), so the peer edge supplies the package and the depPath carries the suffix. pacquet did the inverse (dropped the peer, walked the own dep), so `@babel/parser` — whose packageExtensions-added `@babel/types` peer is also its regular dependency — lost its `(@babel/types@7.29.7)` suffix and its `peerDependencies:` block. Also aligns `extract_peer_dependencies` with [`peerDependenciesWithoutOwn`](https://github.com/pnpm/pnpm/blob/01b3d45ddb/installing/deps-resolver/src/resolveDependencies.ts#L1840-L1864): the package's own name counts as an own dep, and a `peerDependenciesMeta`-only entry becomes a peer only when `optional: true`. The non-`autoInstallPeers` arm (omit only peers resolvable from the parent scope) is not ported — pacquet's per-package children cache has no parent context; behavior there matches pnpm whenever the peer is not in scope.

### 3. Overrides apply to `peerDependencies` (`fix(package-manager)`)

Ports the peer arm of [`overrideDepsOfPkg`](https://github.com/pnpm/pnpm/blob/01b3d45ddb/hooks/read-package-hook/src/createVersionsOverrider.ts#L68-L129): a matched peer is deleted on `-`, rewritten in place when the override value is a valid peer range, otherwise written into `dependencies` while the declared peer stays. Fixes e.g. `ajv@>=7.0.0-alpha.0 <8.18.0 → >=8.18.0` not rewriting peer ranges and `@yarnpkg/libzip` losing its `(@yarnpkg/fslib@3.x)` suffix.

### 4. Optional-peer hoist: run-extended preferred versions, meta-only peers excluded (`fix(deps-resolver)`)

Corrects the model from pnpm/pnpm#12267. pnpm folds **every run-resolved version** into `ctx.allPreferredVersions` ([resolveDependencies.ts#L1483-L1488](https://github.com/pnpm/pnpm/blob/01b3d45ddb/installing/deps-resolver/src/resolveDependencies.ts#L1483-L1488), since pnpm/pnpm#7812) and `getHoistableOptionalPeers` reads that map after each wave — so an optional peer with a **real `peerDependencies` entry** (eslint's `jiti`) resolves against a provider anywhere in the freshly resolved tree. What keeps `debug`'s `supports-color` bare is not a static map but the missing-peer set: [`getMissingPeers`](https://github.com/pnpm/pnpm/blob/01b3d45ddb/installing/deps-resolver/src/resolveDependencies.ts#L1773-L1782) iterates `peerDependencies` only, so a **meta-only** peer never feeds the hoist. Both behaviors verified empirically against pnpm 11.6.0 (`eslint` + `cosmiconfig-typescript-loader` hoists `jiti@2.6.1`; `debug` + `concurrently` stays bare). pacquet's static-snapshot approach got the meta-only case right by the wrong mechanism and under-hoisted every real-entry optional peer — the missing `(jiti@2.6.1)`, `(typanion@3.14.0)`, `(conventional-commits-parser@6.4.0)`, `(@types/node@…)` suffixes and their cascades on the monorepo. The 12267-era regression test asserted the anti-pnpm behavior for the real-entry shape and was inverted; a new test pins the meta-only shape.

## Verification

- New unit tests in `pacquet-resolving-deps-resolver` (importer group merge ×4, peer-vs-own-dep shadowing ×3, optional-peer hoist real-entry/meta-only ×2) and `pacquet-package-manager` (peer overrides ×4).
- Full workspace suite: 3218 tests pass; clippy `--deny warnings` clean; rustfmt + typos clean.
- Whole-monorepo lockfile diff vs fresh pnpm 11.6.0: 806 → 461 changed lines; `@pnpm/logger`, `jiti`, `typanion`, `@babel/types`, `ajv` categories eliminated. Two consecutive pacquet runs byte-identical.

## Remaining gaps (tracked in pnpm/pnpm#12266)

The surviving 461 lines are dominated by a hoisted optional-peer **version-pick** divergence (`@types/node` 22.19.21 vs 25.9.3, `spdx-expression-parse` 4.0.0 vs 3.0.1 — pacquet also emits duplicate suffix variants of the same snapshot), plus small items: `es-abstract`/`varint` version picks, the array-form `engines` quirk, and the env-lockfile document's missing `packageManagerDependencies` block and `libc:` fields.

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for peer dependency overrides compatible with pnpm configuration.
  * Added auto-install peers configuration option for automatic peer dependency resolution.

* **Improvements**
  * Enhanced peer dependency hoisting logic for optional and metadata-only peer entries.
  * Improved peer dependency resolution and metadata handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->