### PR TITLE
fix: resolve musl pacquet binary on musl-based systems

### DIFF
--- a/installing/commands/package.json
+++ b/installing/commands/package.json
@@ -88,6 +88,7 @@
     "@zkochan/table": "catalog:",
     "chalk": "catalog:",
     "ci-info": "catalog:",
+    "detect-libc": "catalog:",
     "get-npm-tarball-url": "catalog:",
     "is-subdir": "catalog:",
     "load-json-file": "catalog:",

--- a/installing/commands/src/runPacquet.ts
+++ b/installing/commands/src/runPacquet.ts
@@ -8,6 +8,7 @@ import type { Writable } from 'node:stream'
 import { PnpmError } from '@pnpm/error'
 import { logger, streamParser } from '@pnpm/logger'
 import chalk from 'chalk'
+import { MUSL, familySync as getLibcFamilySync } from 'detect-libc'
 
 // The runtime `streamParser` is a `Transform` stream (split2 + JSON.parse).
 // Its public typing only exposes `on`/`removeListener`, so we narrow to the
@@ -178,7 +179,8 @@ export function makeRunPacquet (opts: MakeRunPacquetOpts): (callOpts?: RunPacque
 function resolvePacquetBin (lockfileDir: string, packageName: 'pacquet' | '@pnpm/pacquet'): string {
   const ext = process.platform === 'win32' ? '.exe' : ''
   const pacquetPkg = fs.realpathSync(path.join(lockfileDir, 'node_modules/.pnpm-config', packageName, 'package.json'))
-  return createRequire(pacquetPkg).resolve(`@pacquet/${process.platform}-${process.arch}/pacquet${ext}`)
+  const libc = process.platform === 'linux' && getLibcFamilySync() === MUSL ? '-musl' : ''
+  return createRequire(pacquetPkg).resolve(`@pacquet/${process.platform}-${process.arch}${libc}/pacquet${ext}`)
 }
 
 /**

--- a/installing/commands/src/runPacquet.ts
+++ b/installing/commands/src/runPacquet.ts
@@ -8,7 +8,7 @@ import type { Writable } from 'node:stream'
 import { PnpmError } from '@pnpm/error'
 import { logger, streamParser } from '@pnpm/logger'
 import chalk from 'chalk'
-import { MUSL, familySync as getLibcFamilySync } from 'detect-libc'
+import { familySync as getLibcFamilySync, MUSL } from 'detect-libc'
 
 // The runtime `streamParser` is a `Transform` stream (split2 + JSON.parse).
 // Its public typing only exposes `on`/`removeListener`, so we narrow to the

--- a/installing/commands/src/runPacquet.ts
+++ b/installing/commands/src/runPacquet.ts
@@ -179,8 +179,18 @@ export function makeRunPacquet (opts: MakeRunPacquetOpts): (callOpts?: RunPacque
 function resolvePacquetBin (lockfileDir: string, packageName: 'pacquet' | '@pnpm/pacquet'): string {
   const ext = process.platform === 'win32' ? '.exe' : ''
   const pacquetPkg = fs.realpathSync(path.join(lockfileDir, 'node_modules/.pnpm-config', packageName, 'package.json'))
+  return createRequire(pacquetPkg).resolve(`${pacquetPlatformPkgName()}/pacquet${ext}`)
+}
+
+/**
+ * Name of the `@pacquet/<platform>-<arch>[-musl]` package that holds the
+ * native pacquet binary for the host. On linux the binary packages are
+ * split by libc and only the matching one is installed, so spawning and
+ * signature verification must agree on this exact name.
+ */
+export function pacquetPlatformPkgName (): string {
   const libc = process.platform === 'linux' && getLibcFamilySync() === MUSL ? '-musl' : ''
-  return createRequire(pacquetPkg).resolve(`@pacquet/${process.platform}-${process.arch}${libc}/pacquet${ext}`)
+  return `@pacquet/${process.platform}-${process.arch}${libc}`
 }
 
 /**

--- a/installing/commands/src/verifyPacquetIdentity.ts
+++ b/installing/commands/src/verifyPacquetIdentity.ts
@@ -11,6 +11,8 @@ import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
 import type { CreateFetchFromRegistryOptions, RetryTimeoutOptions } from '@pnpm/network.fetch'
 import type { Registries, RegistryConfig } from '@pnpm/types'
 
+import { pacquetPlatformPkgName } from './runPacquet.js'
+
 export interface VerifyPacquetIdentityOptions extends CreateFetchFromRegistryOptions {
   lockfileDir: string
   rootDir: string
@@ -93,7 +95,7 @@ async function collectPacquetPackagesToVerify (
 
   // Only the host's platform binary is ever spawned, so that's the one whose
   // identity matters. If it isn't in the lockfile, pacquet couldn't run here.
-  const platformPkgName = `@pacquet/${process.platform}-${process.arch}`
+  const platformPkgName = pacquetPlatformPkgName()
   const platformVersion = envLockfile.snapshots[shimKey]?.optionalDependencies?.[platformPkgName]
   if (platformVersion == null) return undefined
   const platformKey = `${platformPkgName}@${platformVersion}`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5405,6 +5405,9 @@ importers:
       ci-info:
         specifier: 'catalog:'
         version: 4.4.0
+      detect-libc:
+        specifier: 'catalog:'
+        version: 2.1.2
       get-npm-tarball-url:
         specifier: 'catalog:'
         version: 2.1.0


### PR DESCRIPTION
Builds off of #12316 to fix the resolution of the pacquet binary to use. With this fix in place #12049 can be closed as it works for me on my alpine system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux compatibility by detecting the system libc (glibc vs musl) and automatically selecting the correct native binary package. This prevents incorrect binary selection on musl-based distributions and improves reliability without manual configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->