### PR TITLE
fix: allow steady downloads past fetch timeout

### DIFF
--- a/.changeset/steady-fetch-timeouts.md
+++ b/.changeset/steady-fetch-timeouts.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/network.fetch": patch
+"pnpm": patch
+---
+
+Allow downloads that keep receiving body data to run longer than `fetchTimeout`.

--- a/network/fetch/src/dispatcher.ts
+++ b/network/fetch/src/dispatcher.ts
@@ -7,7 +7,7 @@ import { PnpmError } from '@pnpm/error'
 import type { TlsConfig } from '@pnpm/types'
 import { LRUCache } from 'lru-cache'
 import { SocksClient } from 'socks'
-import { Agent, type Dispatcher, getGlobalDispatcher, ProxyAgent, setGlobalDispatcher } from 'undici'
+import { Agent, type Dispatcher, getGlobalDispatcher, MockAgent, ProxyAgent, setGlobalDispatcher } from 'undici'
 
 const DEFAULT_MAX_SOCKETS = 50
 const KEEP_ALIVE_TIMEOUT = 30_000 // 30 seconds
@@ -128,6 +128,11 @@ export function getDispatcher (uri: string, opts: DispatcherOptions): Dispatcher
     return undefined
   }
 
+  const globalMockDispatcher = getGlobalMockDispatcherForTimeoutOnly(opts)
+  if (globalMockDispatcher) {
+    return globalMockDispatcher
+  }
+
   const parsedUri = new URL(uri)
 
   if ((opts.httpProxy || opts.httpsProxy) && !checkNoProxy(parsedUri, opts)) {
@@ -158,6 +163,28 @@ function needsCustomDispatcher (opts: DispatcherOptions): boolean {
     opts.strictSsl === false ||
     hasClientCertificates(opts.clientCertificates) ||
     opts.maxSockets
+  )
+}
+
+function getGlobalMockDispatcherForTimeoutOnly (opts: DispatcherOptions): Dispatcher | undefined {
+  if (!hasOnlyTimeoutCustomization(opts)) return undefined
+  const globalDispatcher = getGlobalDispatcher()
+  return globalDispatcher instanceof MockAgent ? globalDispatcher : undefined
+}
+
+function hasOnlyTimeoutCustomization (opts: DispatcherOptions): boolean {
+  return Boolean(
+    typeof opts.timeout === 'number' &&
+    opts.timeout > 0 &&
+    !opts.httpProxy &&
+    !opts.httpsProxy &&
+    !opts.ca &&
+    !opts.cert &&
+    !opts.key &&
+    !opts.localAddress &&
+    opts.strictSsl !== false &&
+    !hasClientCertificates(opts.clientCertificates) &&
+    !opts.maxSockets
   )
 }
 

--- a/network/fetch/src/dispatcher.ts
+++ b/network/fetch/src/dispatcher.ts
@@ -148,6 +148,7 @@ function hasClientCertificates (certs?: ClientCertificates): boolean {
 
 function needsCustomDispatcher (opts: DispatcherOptions): boolean {
   return Boolean(
+    (typeof opts.timeout === 'number' && opts.timeout > 0) ||
     opts.httpProxy ||
     opts.httpsProxy ||
     opts.ca ||
@@ -158,6 +159,21 @@ function needsCustomDispatcher (opts: DispatcherOptions): boolean {
     hasClientCertificates(opts.clientCertificates) ||
     opts.maxSockets
   )
+}
+
+function getTimeoutKey (opts: DispatcherOptions): string {
+  return typeof opts.timeout === 'number' && opts.timeout > 0 ? opts.timeout.toString() : '>no-timeout<'
+}
+
+function getAgentTimeoutOptions (opts: DispatcherOptions): Pick<Agent.Options, 'bodyTimeout' | 'connectTimeout' | 'headersTimeout'> {
+  if (typeof opts.timeout !== 'number' || opts.timeout <= 0) {
+    return {}
+  }
+  return {
+    bodyTimeout: opts.timeout,
+    connectTimeout: opts.timeout + 1,
+    headersTimeout: opts.timeout,
+  }
 }
 
 function parseProxyUrl (proxy: string, protocol: string): URL {
@@ -204,6 +220,7 @@ function getProxyDispatcher (parsedUri: URL, opts: DispatcherOptions): Dispatche
     `https:${isHttps.toString()}`,
     `local-address:${opts.localAddress ?? '>no-local-address<'}`,
     `max-sockets:${(opts.maxSockets ?? DEFAULT_MAX_SOCKETS).toString()}`,
+    `timeout:${getTimeoutKey(opts)}`,
     `strict-ssl:${isHttps ? Boolean(opts.strictSsl).toString() : '>no-strict-ssl<'}`,
     `ca:${(isHttps && ca?.toString()) || '-'}`,
     `cert:${(isHttps && cert?.toString()) || '-'}`,
@@ -238,6 +255,7 @@ function createHttpProxyDispatcher (
     token: proxyUrl.username
       ? `Basic ${Buffer.from(`${decodeURIComponent(proxyUrl.username)}:${decodeURIComponent(proxyUrl.password)}`).toString('base64')}`
       : undefined,
+    ...getAgentTimeoutOptions(opts),
     connections: opts.maxSockets ?? DEFAULT_MAX_SOCKETS,
     keepAliveTimeout: KEEP_ALIVE_TIMEOUT,
     keepAliveMaxTimeout: KEEP_ALIVE_MAX_TIMEOUT,
@@ -269,6 +287,7 @@ function createSocksDispatcher (
   const proxyPort = parseInt(proxyUrl.port, 10) || (socksType === 4 ? 1080 : 1080)
 
   return new Agent({
+    ...getAgentTimeoutOptions(opts),
     connections: opts.maxSockets ?? DEFAULT_MAX_SOCKETS,
     keepAliveTimeout: KEEP_ALIVE_TIMEOUT,
     keepAliveMaxTimeout: KEEP_ALIVE_MAX_TIMEOUT,
@@ -325,6 +344,7 @@ function getNonProxyDispatcher (parsedUri: URL, opts: DispatcherOptions): Dispat
     `https:${isHttps.toString()}`,
     `local-address:${opts.localAddress ?? '>no-local-address<'}`,
     `max-sockets:${(opts.maxSockets ?? DEFAULT_MAX_SOCKETS).toString()}`,
+    `timeout:${getTimeoutKey(opts)}`,
     `strict-ssl:${isHttps ? Boolean(opts.strictSsl).toString() : '>no-strict-ssl<'}`,
     `ca:${(isHttps && ca?.toString()) || '-'}`,
     `cert:${(isHttps && cert?.toString()) || '-'}`,
@@ -335,13 +355,9 @@ function getNonProxyDispatcher (parsedUri: URL, opts: DispatcherOptions): Dispat
     return DISPATCHER_CACHE.get(key)!
   }
 
-  const connectTimeout = typeof opts.timeout !== 'number' || opts.timeout === 0
-    ? 0
-    : opts.timeout + 1
-
   const agent = new Agent({
+    ...getAgentTimeoutOptions(opts),
     connections: opts.maxSockets ?? DEFAULT_MAX_SOCKETS,
-    connectTimeout,
     keepAliveTimeout: KEEP_ALIVE_TIMEOUT,
     keepAliveMaxTimeout: KEEP_ALIVE_MAX_TIMEOUT,
     connect: isHttps

--- a/network/fetch/src/dispatcher.ts
+++ b/network/fetch/src/dispatcher.ts
@@ -166,6 +166,12 @@ function needsCustomDispatcher (opts: DispatcherOptions): boolean {
   )
 }
 
+// Because the default `fetchTimeout` is non-zero, a timeout alone now forces a
+// custom dispatcher (see needsCustomDispatcher). That would bypass a MockAgent
+// installed globally via setGlobalDispatcher, breaking every test that relies on
+// mocked responses without opting out of the timeout. When timeout is the only
+// customization, defer to the global MockAgent instead: mocked responses never
+// hit the network, so socket-level timeouts are meaningless there anyway.
 function getGlobalMockDispatcherForTimeoutOnly (opts: DispatcherOptions): Dispatcher | undefined {
   if (!hasOnlyTimeoutCustomization(opts)) return undefined
   const globalDispatcher = getGlobalDispatcher()

--- a/network/fetch/src/fetch.ts
+++ b/network/fetch/src/fetch.ts
@@ -43,12 +43,11 @@ export async function fetch (url: RequestInfo, opts: RequestInit = {}): Promise<
     return await new Promise((resolve, reject) => {
       op.attempt(async (attempt) => {
         const urlString = typeof url === 'string' ? url : url.href ?? url.toString()
-        const { retry: _retry, timeout, dispatcher, ...fetchOpts } = opts
-        const signal = timeout ? AbortSignal.timeout(timeout) : undefined
+        const { retry: _retry, timeout: _timeout, dispatcher, ...fetchOpts } = opts
         try {
           // undici's Response type differs slightly from globalThis.Response (iterator types),
           // requiring the double cast. This is a known TypeScript/undici compatibility issue.
-          const res = await undiciFetch(urlString, { ...fetchOpts, signal, dispatcher } as Parameters<typeof undiciFetch>[1]) as unknown as Response
+          const res = await undiciFetch(urlString, { ...fetchOpts, dispatcher } as Parameters<typeof undiciFetch>[1]) as unknown as Response
           // A retry on 409 sometimes helps when making requests to the Bit registry.
           if ((res.status >= 500 && res.status < 600) || [408, 409, 420, 429].includes(res.status)) {
             throw new ResponseError(res)

--- a/network/fetch/src/fetchFromRegistry.ts
+++ b/network/fetch/src/fetchFromRegistry.ts
@@ -21,12 +21,14 @@ export interface FetchWithDispatcherOptions extends RequestInit {
 }
 
 export function fetchWithDispatcher (url: string | URL, opts: FetchWithDispatcherOptions): Promise<Response> {
+  const { dispatcherOptions, ...fetchOpts } = opts
   const dispatcher = getDispatcher(url.toString(), {
-    ...opts.dispatcherOptions,
-    strictSsl: opts.dispatcherOptions.strictSsl ?? true,
+    ...dispatcherOptions,
+    timeout: opts.timeout ?? dispatcherOptions.timeout,
+    strictSsl: dispatcherOptions.strictSsl ?? true,
   })
   return fetch(url, {
-    ...opts,
+    ...fetchOpts,
     dispatcher,
   })
 }
@@ -108,7 +110,7 @@ export function createFetchFromRegistry (defaultOpts: CreateFetchFromRegistryOpt
         method: opts?.method,
         redirect: 'manual',
         retry: opts?.retry,
-        timeout: opts?.timeout ?? 60000,
+        timeout: opts?.timeout ?? defaultOpts.timeout ?? 60000,
       })
       if (!isRedirect(response.status) || redirects >= MAX_FOLLOWED_REDIRECTS) {
         return response

--- a/network/fetch/test/dispatcher.test.ts
+++ b/network/fetch/test/dispatcher.test.ts
@@ -49,6 +49,16 @@ describe('getDispatcher', () => {
     expect(d1).not.toBe(d2)
   })
 
+  test('returns a dispatcher when timeout is set', () => {
+    expect(getDispatcher('https://registry.npmjs.org/foo', { timeout: 60_000 })).toBeDefined()
+  })
+
+  test('different timeouts produce different dispatchers', () => {
+    const d1 = getDispatcher('https://registry.npmjs.org/foo', { timeout: 30_000 })
+    const d2 = getDispatcher('https://registry.npmjs.org/foo', { timeout: 60_000 })
+    expect(d1).not.toBe(d2)
+  })
+
   test('clearDispatcherCache clears cached dispatchers', () => {
     const opts: DispatcherOptions = { strictSsl: false }
     const d1 = getDispatcher('https://registry.npmjs.org/foo', opts)

--- a/network/fetch/test/fetchFromRegistry.test.ts
+++ b/network/fetch/test/fetchFromRegistry.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs'
 import http from 'node:http'
 import path from 'node:path'
 
-import { expect, test } from '@jest/globals'
+import { afterEach, expect, test } from '@jest/globals'
 import { clearDispatcherCache, createDispatchedFetch, createFetchFromRegistry } from '@pnpm/network.fetch'
 import { ProxyServer } from 'https-proxy-server-express'
 import { type Dispatcher, getGlobalDispatcher, MockAgent, setGlobalDispatcher } from 'undici'
@@ -42,6 +42,10 @@ function getMockAgent (): MockAgent {
 
 const CERTS_DIR = path.join(import.meta.dirname, '__certs__')
 
+afterEach(() => {
+  clearDispatcherCache()
+})
+
 test('fetchFromRegistry', async () => {
   // This test uses real network - no mock needed
   const fetchFromRegistry = createFetchFromRegistry({})
@@ -76,7 +80,7 @@ test('authorization headers are removed before redirection if the target is on a
       method: 'GET',
     }).reply(200, { ok: true }, { headers: { 'content-type': 'application/json' } })
 
-    const fetchFromRegistry = createFetchFromRegistry({})
+    const fetchFromRegistry = createFetchFromRegistry({ timeout: 0 })
     const res = await fetchFromRegistry(
       'http://registry.pnpm.io/is-positive',
       { authHeaderValue: 'Bearer 123' }
@@ -104,7 +108,7 @@ test('authorization headers are not removed before redirection if the target is 
       headers: { authorization: 'Bearer 123' },
     }).reply(200, { ok: true }, { headers: { 'content-type': 'application/json' } })
 
-    const fetchFromRegistry = createFetchFromRegistry({})
+    const fetchFromRegistry = createFetchFromRegistry({ timeout: 0 })
     const res = await fetchFromRegistry(
       'http://registry.pnpm.io/is-positive',
       { authHeaderValue: 'Bearer 123' }
@@ -210,7 +214,7 @@ test('redirect to protocol-relative URL', async () => {
       method: 'GET',
     }).reply(200, { ok: true }, { headers: { 'content-type': 'application/json' } })
 
-    const fetchFromRegistry = createFetchFromRegistry({})
+    const fetchFromRegistry = createFetchFromRegistry({ timeout: 0 })
     const res = await fetchFromRegistry(
       'http://registry.pnpm.io/foo'
     )
@@ -235,7 +239,7 @@ test('redirect to relative URL', async () => {
       method: 'GET',
     }).reply(200, { ok: true }, { headers: { 'content-type': 'application/json' } })
 
-    const fetchFromRegistry = createFetchFromRegistry({})
+    const fetchFromRegistry = createFetchFromRegistry({ timeout: 0 })
     const res = await fetchFromRegistry(
       'http://registry.pnpm.io/bar/baz'
     )
@@ -265,7 +269,7 @@ test('redirect to relative URL when request pkg.pr.new link', async () => {
       method: 'GET',
     }).reply(200, { ok: true }, { headers: { 'content-type': 'application/json' } })
 
-    const fetchFromRegistry = createFetchFromRegistry({})
+    const fetchFromRegistry = createFetchFromRegistry({ timeout: 0 })
     const res = await fetchFromRegistry(
       'https://pkg.pr.new/vue@14175'
     )
@@ -285,7 +289,7 @@ test('redirect without location header throws error', async () => {
       method: 'GET',
     }).reply(302, 'found')
 
-    const fetchFromRegistry = createFetchFromRegistry({})
+    const fetchFromRegistry = createFetchFromRegistry({ timeout: 0 })
     await expect(fetchFromRegistry(
       'http://registry.pnpm.io/missing-location'
     )).rejects.toThrow(/Redirect location header missing/)
@@ -309,6 +313,30 @@ test('createDispatchedFetch returns a fetch bound to the given dispatcher option
   } finally {
     await teardownMockAgent()
   }
+})
+
+test('fetch timeout allows steady body progress past the timeout window', async () => {
+  const body = await new Promise<string>((resolve, reject) => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' })
+      res.write('a')
+      setTimeout(() => res.write('b'), 50)
+      setTimeout(() => res.end('c'), 100)
+    })
+    server.listen(0, () => {
+      const { port } = server.address() as { port: number }
+      const fetchFromRegistry = createFetchFromRegistry({})
+      fetchFromRegistry(`http://127.0.0.1:${port}/slow`, {
+        retry: { retries: 0 },
+        timeout: 80,
+      }).then(
+        (res) => res.text(),
+        reject
+      ).then(resolve, reject).finally(() => server.close())
+    })
+  })
+
+  expect(body).toBe('abc')
 })
 
 test('abbreviated metadata Accept header is not sent on write requests', async () => {

--- a/network/fetch/test/fetchFromRegistry.test.ts
+++ b/network/fetch/test/fetchFromRegistry.test.ts
@@ -92,6 +92,24 @@ test('authorization headers are removed before redirection if the target is on a
   }
 })
 
+test('default timeout still allows MockAgent to intercept requests', async () => {
+  setupMockAgent()
+  try {
+    const mockPool = getMockAgent().get('http://registry.pnpm.io')
+    mockPool.intercept({
+      path: '/is-positive',
+      method: 'GET',
+    }).reply(200, { ok: true }, { headers: { 'content-type': 'application/json' } })
+
+    const fetchFromRegistry = createFetchFromRegistry({})
+    const res = await fetchFromRegistry('http://registry.pnpm.io/is-positive')
+
+    expect(await res.json()).toStrictEqual({ ok: true })
+  } finally {
+    await teardownMockAgent()
+  }
+})
+
 test('authorization headers are not removed before redirection if the target is on the same host', async () => {
   setupMockAgent()
   try {

--- a/network/fetch/test/fetchFromRegistry.test.ts
+++ b/network/fetch/test/fetchFromRegistry.test.ts
@@ -357,6 +357,32 @@ test('fetch timeout allows steady body progress past the timeout window', async 
   expect(body).toBe('abc')
 })
 
+test('fetch timeout fails when response headers stall', async () => {
+  const response = new Promise<Response>((resolve, reject) => {
+    const sockets = new Set<import('node:net').Socket>()
+    const server = http.createServer(() => {})
+    server.on('connection', (socket) => {
+      sockets.add(socket)
+      socket.on('close', () => sockets.delete(socket))
+    })
+    server.listen(0, () => {
+      const { port } = server.address() as { port: number }
+      const fetchFromRegistry = createFetchFromRegistry({})
+      fetchFromRegistry(`http://127.0.0.1:${port}/stalled`, {
+        retry: { retries: 0 },
+        timeout: 50,
+      }).then(resolve, reject).finally(() => {
+        for (const socket of sockets) {
+          socket.destroy()
+        }
+        server.close()
+      })
+    })
+  })
+
+  await expect(response).rejects.toThrow()
+})
+
 test('abbreviated metadata Accept header is not sent on write requests', async () => {
   const receivedHeaders = await new Promise<http.IncomingHttpHeaders>((resolve, reject) => {
     const server = http.createServer((req, res) => {

--- a/network/fetch/test/fetchFromRegistry.test.ts
+++ b/network/fetch/test/fetchFromRegistry.test.ts
@@ -330,9 +330,9 @@ test('fetch timeout allows steady body progress past the timeout window', async 
         retry: { retries: 0 },
         timeout: 80,
       }).then(
-        (res) => res.text(),
+        async (res) => resolve(await res.text()),
         reject
-      ).then(resolve, reject).finally(() => server.close())
+      ).finally(() => server.close())
     })
   })
 

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -932,10 +932,10 @@ pub struct Config {
     #[default(_code = "pacquet_network::default_network_concurrency()")]
     pub network_concurrency: usize,
 
-    /// Per-request network timeout in milliseconds. Mirrors pnpm's
-    /// `fetchTimeout` (default `60000` — 60 s, see
-    /// [`pacquet_network::DEFAULT_FETCH_TIMEOUT_MS`]). Applied as both
-    /// the response and connect deadline of the reqwest client.
+    /// Network timeout in milliseconds. Mirrors pnpm's `fetchTimeout`
+    /// (default `60000` — 60 s, see
+    /// [`pacquet_network::DEFAULT_FETCH_TIMEOUT_MS`]). Applied to
+    /// connection setup and stalled response-body reads.
     #[default(_code = "default_fetch_timeout()")]
     pub fetch_timeout: u64,
 

--- a/pacquet/crates/network/src/lib.rs
+++ b/pacquet/crates/network/src/lib.rs
@@ -65,10 +65,9 @@ pub struct NetworkSettings {
     /// semaphore size. Default: [`default_network_concurrency`].
     pub network_concurrency: usize,
 
-    /// Per-request total deadline, applied as both reqwest's response
-    /// timeout and its connect timeout — mirroring pnpm, whose
-    /// `AbortSignal.timeout(fetchTimeout)` bounds the whole request and
-    /// whose undici `connectTimeout` is `fetchTimeout + 1`. Default:
+    /// Timeout for establishing a connection and for each stalled body
+    /// read. Steady downloads may take longer than this as long as each
+    /// read makes progress within the window. Default:
     /// [`DEFAULT_FETCH_TIMEOUT_MS`].
     pub fetch_timeout: Duration,
 
@@ -203,14 +202,12 @@ impl ThrottledClient {
     /// runs hundreds of fetches in seconds) but well below the
     /// typical edge keepalive.
     ///
-    /// [`NetworkSettings::fetch_timeout`] is the per-request deadline,
-    /// not the socket inactivity timeout. A default `reqwest::Client`
-    /// has no deadlines at all, so a stalled upstream hangs the install
-    /// indefinitely. It is applied as both the response timeout and the
-    /// connect timeout, mirroring pnpm — whose `AbortSignal.timeout`
-    /// bounds the whole fetch and whose undici `connectTimeout` is
-    /// `fetchTimeout + 1`. Default: [`DEFAULT_FETCH_TIMEOUT_MS`] (60s),
-    /// matching pnpm's `fetchTimeout`.
+    /// [`NetworkSettings::fetch_timeout`] applies to connection setup and
+    /// stalled reads, not the total body lifetime. A default
+    /// `reqwest::Client` has no read deadline, so a stalled upstream can
+    /// hang the install indefinitely, while a total response timeout cuts
+    /// off large tarballs that are still making progress. Default:
+    /// [`DEFAULT_FETCH_TIMEOUT_MS`] (60s), matching pnpm's `fetchTimeout`.
     ///
     /// `hickory_dns(true)` swaps reqwest's default resolver
     /// (tokio's `lookup_host`, which calls the platform's blocking
@@ -385,9 +382,8 @@ impl ThrottledClient {
 /// route through this helper so a single source of truth governs
 /// timeouts, HTTP-version, resolver, and the User-Agent header.
 ///
-/// `settings.fetch_timeout` drives both the per-request response
-/// timeout and the connect timeout (matching pnpm's `AbortSignal`
-/// total deadline and undici `connectTimeout = fetchTimeout + 1`).
+/// `settings.fetch_timeout` drives both connection setup and the maximum
+/// gap between body chunks.
 /// `settings.user_agent` is sent verbatim; a value that cannot be
 /// encoded as an HTTP header falls back to [`DEFAULT_USER_AGENT`].
 fn default_client_builder(settings: &NetworkSettings) -> reqwest::ClientBuilder {
@@ -406,7 +402,7 @@ fn default_client_builder(settings: &NetworkSettings) -> reqwest::ClientBuilder 
         .gzip(true)
         .default_headers(default_headers)
         .connect_timeout(settings.fetch_timeout)
-        .timeout(settings.fetch_timeout)
+        .read_timeout(settings.fetch_timeout)
         .pool_idle_timeout(Duration::from_secs(4))
         .hickory_dns(true)
 }

--- a/pacquet/crates/network/src/tests.rs
+++ b/pacquet/crates/network/src/tests.rs
@@ -663,7 +663,8 @@ async fn fetch_timeout_allows_steady_body_progress_past_total_timeout() {
     let server = thread::spawn(move || {
         let (mut stream, _) = listener.accept().expect("accept test request");
         let mut request = [0_u8; 1024];
-        stream.read(&mut request).expect("read test request");
+        let bytes_read = stream.read(&mut request).expect("read test request");
+        assert!(bytes_read > 0, "test request should not be empty");
         stream
             .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 3\r\nConnection: close\r\n\r\n")
             .expect("write response headers");

--- a/pacquet/crates/network/src/tests.rs
+++ b/pacquet/crates/network/src/tests.rs
@@ -20,6 +20,7 @@ use super::{
 };
 use crate::proxy::{percent_decode_str, strip_userinfo};
 use reqwest::Url;
+use std::time::Duration;
 
 fn list(entries: &[&str]) -> NoProxySetting {
     NoProxySetting::List(entries.iter().map(|s| (*s).to_string()).collect())
@@ -635,7 +636,7 @@ fn for_installs_honors_custom_network_settings() {
     // builder rather than being ignored.
     let settings = NetworkSettings {
         network_concurrency: 4,
-        fetch_timeout: std::time::Duration::from_secs(5),
+        fetch_timeout: Duration::from_secs(5),
         user_agent: "pnpm/9.9.9 npm/? node/? darwin arm64".to_string(),
     };
     let client = ThrottledClient::for_installs(
@@ -646,6 +647,52 @@ fn for_installs_honors_custom_network_settings() {
     )
     .expect("custom network settings build");
     assert_eq!(client.semaphore.available_permits(), 4);
+}
+
+#[tokio::test]
+async fn fetch_timeout_allows_steady_body_progress_past_total_timeout() {
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        thread,
+        time::{Duration as StdDuration, Instant},
+    };
+
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind local test server");
+    let addr = listener.local_addr().expect("read local test server address");
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept test request");
+        let mut request = [0_u8; 1024];
+        stream.read(&mut request).expect("read test request");
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 3\r\nConnection: close\r\n\r\n")
+            .expect("write response headers");
+        stream.flush().expect("flush response headers");
+        for chunk in [b"a", b"b", b"c"] {
+            thread::sleep(StdDuration::from_millis(50));
+            stream.write_all(chunk).expect("write response chunk");
+            stream.flush().expect("flush response chunk");
+        }
+    });
+
+    let settings =
+        NetworkSettings { fetch_timeout: Duration::from_millis(80), ..NetworkSettings::default() };
+    let client = ThrottledClient::for_installs(
+        &ProxyConfig::default(),
+        &TlsConfig::default(),
+        &PerRegistryTls::default(),
+        &settings,
+    )
+    .expect("custom network settings build");
+    let guard = client.acquire().await;
+    let started_at = Instant::now();
+    let resp =
+        guard.get(format!("http://{addr}/slow")).send().await.expect("receive response headers");
+    let body = resp.text().await.expect("read response body");
+    server.join().expect("test server exits cleanly");
+
+    assert!(started_at.elapsed() >= Duration::from_millis(120), "request completed too quickly");
+    assert_eq!(body, "abc");
 }
 
 #[test]

--- a/pacquet/crates/network/src/tests.rs
+++ b/pacquet/crates/network/src/tests.rs
@@ -666,18 +666,18 @@ async fn fetch_timeout_allows_steady_body_progress_past_total_timeout() {
         let bytes_read = stream.read(&mut request).expect("read test request");
         assert!(bytes_read > 0, "test request should not be empty");
         stream
-            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 3\r\nConnection: close\r\n\r\n")
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\n")
             .expect("write response headers");
         stream.flush().expect("flush response headers");
-        for chunk in [b"a", b"b", b"c"] {
-            thread::sleep(StdDuration::from_millis(50));
+        for chunk in [b"a", b"b", b"c", b"d", b"e"] {
+            thread::sleep(StdDuration::from_millis(100));
             stream.write_all(chunk).expect("write response chunk");
             stream.flush().expect("flush response chunk");
         }
     });
 
     let settings =
-        NetworkSettings { fetch_timeout: Duration::from_millis(80), ..NetworkSettings::default() };
+        NetworkSettings { fetch_timeout: Duration::from_millis(300), ..NetworkSettings::default() };
     let client = ThrottledClient::for_installs(
         &ProxyConfig::default(),
         &TlsConfig::default(),
@@ -692,8 +692,8 @@ async fn fetch_timeout_allows_steady_body_progress_past_total_timeout() {
     let body = resp.text().await.expect("read response body");
     server.join().expect("test server exits cleanly");
 
-    assert!(started_at.elapsed() >= Duration::from_millis(120), "request completed too quickly");
-    assert_eq!(body, "abc");
+    assert!(started_at.elapsed() >= Duration::from_millis(400), "request completed too quickly");
+    assert_eq!(body, "abcde");
 }
 
 #[test]

--- a/pnpm/test/install/misc.ts
+++ b/pnpm/test/install/misc.ts
@@ -505,10 +505,12 @@ test('CI mode: frozen-lockfile can be overridden via updateConfig hook', async (
   await execPnpm(['install'], { env: { CI: 'true' } })
 })
 
-test('installation succeeds with a low fetch timeout while the registry responds', async () => {
+test('installation fails with a timeout error', async () => {
   prepare()
 
-  await execPnpm(['add', 'typescript@2.4.2', '--fetch-timeout=1', '--fetch-retries=0'])
+  await expect(
+    execPnpm(['add', 'typescript@2.4.2', '--fetch-timeout=1', '--fetch-retries=0'])
+  ).rejects.toThrow()
 })
 
 test('installation fails when the stored package name and version do not match the meta of the installed package', async () => {

--- a/pnpm/test/install/misc.ts
+++ b/pnpm/test/install/misc.ts
@@ -505,12 +505,10 @@ test('CI mode: frozen-lockfile can be overridden via updateConfig hook', async (
   await execPnpm(['install'], { env: { CI: 'true' } })
 })
 
-test('installation fails with a timeout error', async () => {
+test('installation succeeds with a low fetch timeout while the registry responds', async () => {
   prepare()
 
-  await expect(
-    execPnpm(['add', 'typescript@2.4.2', '--fetch-timeout=1', '--fetch-retries=0'])
-  ).rejects.toThrow()
+  await execPnpm(['add', 'typescript@2.4.2', '--fetch-timeout=1', '--fetch-retries=0'])
 })
 
 test('installation fails when the stored package name and version do not match the meta of the installed package', async () => {

--- a/pnpm/test/install/misc.ts
+++ b/pnpm/test/install/misc.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs'
+import http from 'node:http'
+import type { AddressInfo, Socket } from 'node:net'
 import path from 'node:path'
 
 import { afterAll, expect, test } from '@jest/globals'
@@ -507,10 +509,34 @@ test('CI mode: frozen-lockfile can be overridden via updateConfig hook', async (
 
 test('installation fails with a timeout error', async () => {
   prepare()
+  const sockets = new Set<Socket>()
+  const server = http.createServer(() => {})
+  server.on('connection', (socket) => {
+    sockets.add(socket)
+    socket.on('close', () => sockets.delete(socket))
+  })
 
-  await expect(
-    execPnpm(['add', 'typescript@2.4.2', '--fetch-timeout=1', '--fetch-retries=0'])
-  ).rejects.toThrow()
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const { port } = server.address() as AddressInfo
+
+  try {
+    await expect(
+      execPnpm([
+        'add',
+        'typescript@2.4.2',
+        `--registry=http://127.0.0.1:${port}/`,
+        '--fetch-timeout=50',
+        '--fetch-retries=0',
+      ])
+    ).rejects.toThrow()
+  } finally {
+    for (const socket of sockets) {
+      socket.destroy()
+    }
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => err ? reject(err) : resolve())
+    })
+  }
 })
 
 test('installation fails when the stored package name and version do not match the meta of the installed package', async () => {


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#12334.

`fetchTimeout` now limits connection setup and stalled response-body reads instead of aborting the whole download while bytes are still arriving. The TypeScript fetch path moves the timeout into Undici dispatcher options (`connectTimeout`, `headersTimeout`, and `bodyTimeout`) and includes timeout values in dispatcher cache keys. The pacquet client mirrors that behavior by using reqwest `read_timeout` rather than a total response timeout.

## Checks

- `git diff --check`
- `pnpm exec tsgo --build worker/tsconfig.json network/fetch/tsconfig.json`
- `pnpm exec eslint "src/**/*.ts" "test/**/*.ts"` from `network/fetch`
- `NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" pnpm exec jest` from `network/fetch` (44 tests)
- `cargo fmt --check --all`
- `cargo check -p pacquet-network --all-targets --locked`
- `cargo test -p pacquet-network fetch_timeout_allows_steady_body_progress_past_total_timeout --locked`

---
Written by an agent for Federicorao (GPT-5).
