### PR TITLE
fix(pacquet): share a subtree's peer context across importers + record array-form engines

### DIFF
--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -522,16 +522,29 @@ fn build_package_metadata(
 
     let engines = manifest
         .and_then(|m| m.get("engines"))
-        .and_then(Value::as_object)
-        .map(|map| {
-            map.iter()
-                .filter_map(|(name, value)| {
-                    let range = value.as_str()?;
-                    if range == "*" {
-                        return None;
-                    }
-                    Some((name.clone(), range.to_string()))
-                })
+        .and_then(|value| match value {
+            Value::Object(map) => Some(
+                map.iter()
+                    .filter_map(|(name, value)| Some((name.clone(), value.as_str()?)))
+                    .collect::<Vec<(String, &str)>>(),
+            ),
+            // Array-form `engines` (e.g. `["node >= 0.2.0"]`) records
+            // index-keyed entries, the shape upstream's
+            // `Object.entries(engines)` yields for an array.
+            Value::Array(items) => Some(
+                items
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, value)| Some((index.to_string(), value.as_str()?)))
+                    .collect(),
+            ),
+            _ => None,
+        })
+        .map(|entries| {
+            entries
+                .into_iter()
+                .filter(|(_, range)| *range != "*")
+                .map(|(name, range)| (name, range.to_string()))
                 .collect::<HashMap<String, String>>()
         })
         .filter(|map| !map.is_empty());

--- a/pacquet/crates/resolving-deps-resolver/src/lib.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/lib.rs
@@ -95,8 +95,8 @@ pub use resolve_importer::{
     resolve_importer_with_workspace,
 };
 pub use resolve_peers::{
-    ImporterPeerInput, ResolvePeersOptions, ResolvePeersResult, WorkspaceResolvePeersResult,
-    resolve_peers, resolve_peers_workspace,
+    HoistMissingScope, ImporterPeerInput, ResolvePeersOptions, ResolvePeersResult,
+    WorkspaceResolvePeersResult, resolve_peers, resolve_peers_workspace,
 };
 pub use resolve_workspace::{
     ResolveWorkspaceResult, WorkspaceImporter, WorkspaceResolveOptions, resolve_workspace,

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -510,6 +510,20 @@ pub struct WorkspaceTreeCtx {
     /// peer edge supplies the package instead. See
     /// [`omit_peer_shadowed_dependencies`].
     auto_install_peers: bool,
+    /// `pkg id → importer id` of the importer whose walk first resolved
+    /// each package. Mirrors the ownership implied by upstream's
+    /// per-`pkgId` shared subtree records
+    /// ([`missingPeersOfChildrenByPkgId`](https://github.com/pnpm/pnpm/blob/a751c7f27d/installing/deps-resolver/src/resolveDependencies.ts#L193)):
+    /// a package revisited under a later importer does not recompute
+    /// its children's missing-peer report, so that importer's
+    /// peer-hoist must not see missing peers declared inside a
+    /// subtree first resolved elsewhere. Consumed via
+    /// [`crate::HoistMissingScope`].
+    first_importer_by_pkg: Mutex<HashMap<String, String>>,
+    /// Per package: the missing-peer names reported by the first
+    /// peer-walk that visited it (the walk of the importer that
+    /// claimed the package). Consumed via [`crate::HoistMissingScope`].
+    first_walk_missing_by_pkg: Mutex<HashMap<String, HashSet<String>>>,
 }
 
 impl Default for WorkspaceTreeCtx {
@@ -530,6 +544,8 @@ impl Default for WorkspaceTreeCtx {
             pnpmfile_hook: None,
             read_package_log: None,
             auto_install_peers: false,
+            first_importer_by_pkg: Mutex::new(HashMap::new()),
+            first_walk_missing_by_pkg: Mutex::new(HashMap::new()),
         }
     }
 }
@@ -576,6 +592,30 @@ impl WorkspaceTreeCtx {
     /// The prior `pnpm-lock.yaml` to reuse resolutions from, if any.
     pub fn wanted_lockfile(&self) -> Option<&Arc<pacquet_lockfile::Lockfile>> {
         self.wanted_lockfile.as_ref()
+    }
+
+    /// Snapshot of `pkg id → first-resolving importer id`. See the
+    /// field doc.
+    #[must_use]
+    pub fn first_importer_by_pkg(&self) -> HashMap<String, String> {
+        lock_recoverable(&self.first_importer_by_pkg).clone()
+    }
+
+    /// Record a walk's per-package missing-peer names; the first walk
+    /// to visit a package wins. See the `first_walk_missing_by_pkg`
+    /// field doc.
+    pub fn record_first_walk_missing(&self, missing_by_pkg: &HashMap<String, HashSet<String>>) {
+        let mut record = lock_recoverable(&self.first_walk_missing_by_pkg);
+        for (pkg_id, names) in missing_by_pkg {
+            record.entry(pkg_id.clone()).or_insert_with(|| names.clone());
+        }
+    }
+
+    /// Snapshot of the per-package first-walk missing-peer names. See
+    /// the `first_walk_missing_by_pkg` field doc.
+    #[must_use]
+    pub fn first_walk_missing_by_pkg(&self) -> HashMap<String, HashSet<String>> {
+        lock_recoverable(&self.first_walk_missing_by_pkg).clone()
     }
 
     /// Set which dependencies `pacquet update` excludes from reuse. See
@@ -672,6 +712,10 @@ pub struct TreeCtx {
     /// recursive call. `None` when no patches are configured for this
     /// install.
     patched_dependencies: Option<Arc<PatchGroupRecord>>,
+    /// The importer this per-importer context walks for. Recorded into
+    /// [`WorkspaceTreeCtx`]'s `first_importer_by_pkg` when a package is
+    /// first resolved.
+    importer_id: String,
 }
 
 impl TreeCtx {
@@ -687,6 +731,7 @@ impl TreeCtx {
             base_opts,
             workspace: Arc::new(WorkspaceTreeCtx::default()),
             patched_dependencies: None,
+            importer_id: pacquet_lockfile::Lockfile::ROOT_IMPORTER_KEY.to_string(),
         }
     }
 
@@ -701,6 +746,7 @@ impl TreeCtx {
             base_opts,
             workspace,
             patched_dependencies: None,
+            importer_id: pacquet_lockfile::Lockfile::ROOT_IMPORTER_KEY.to_string(),
         }
     }
 
@@ -744,6 +790,14 @@ impl TreeCtx {
     #[must_use]
     pub fn workspace(&self) -> &Arc<WorkspaceTreeCtx> {
         &self.workspace
+    }
+
+    /// Set the importer this context walks for. See [`TreeCtx`]'s
+    /// `importer_id` field.
+    #[must_use]
+    pub fn with_importer_id(mut self, importer_id: &str) -> Self {
+        self.importer_id = importer_id.to_string();
+        self
     }
 
     /// Attach the install's `patchedDependencies` map. When `Some`,
@@ -1145,6 +1199,9 @@ where
                     is_leaf,
                 },
             );
+            lock_recoverable(&ctx.workspace.first_importer_by_pkg)
+                .entry(id.clone())
+                .or_insert_with(|| ctx.importer_id.clone());
             is_revisit = false;
         }
     }
@@ -1491,6 +1548,9 @@ where
                     is_leaf,
                 },
             );
+            lock_recoverable(&ctx.workspace.first_importer_by_pkg)
+                .entry(id.clone())
+                .or_insert_with(|| ctx.importer_id.clone());
             is_revisit = false;
         }
     }

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -290,9 +290,11 @@ where
         exclude_links_from_lockfile,
         lockfile_dir: lockfile_dir.clone(),
         modules_dir: modules_dir.clone(),
+        hoist_missing_scope: None,
     };
 
     let ctx = TreeCtx::with_workspace(workspace, base_opts)
+        .with_importer_id(importer_id)
         .with_patched_dependencies(patched_dependencies)
         .with_resolution_mode(pick_lowest_direct, subdep_published_by);
 
@@ -313,10 +315,25 @@ where
         direct.iter().map(|dep| dep.alias.clone()).collect();
     let mut all_missing_optional_peers: BTreeMap<String, Vec<String>> = BTreeMap::new();
 
+    // The hoist input must not see missing peers declared inside a
+    // subtree first resolved under an earlier importer — upstream
+    // reuses the first walk's children report there, so those peers
+    // never reach a later importer's hoist. The final per-importer
+    // pass below keeps the unscoped options so warnings stay complete.
+    let hoist_peers_opts = || {
+        let mut opts = peers_opts();
+        opts.hoist_missing_scope = Some(crate::resolve_peers::HoistMissingScope {
+            importer_id: importer_id.to_string(),
+            first_importer_by_pkg: ctx.workspace().first_importer_by_pkg(),
+            first_walk_missing_by_pkg: ctx.workspace().first_walk_missing_by_pkg(),
+        });
+        opts
+    };
     loop {
         loop {
             let mut snapshot = ctx.snapshot(direct.clone());
-            let peers_result = resolve_peers(&mut snapshot, peers_opts());
+            let peers_result = resolve_peers(&mut snapshot, hoist_peers_opts());
+            ctx.workspace().record_first_walk_missing(&peers_result.missing_names_by_pkg);
 
             let (missing_required, fresh_optional) = partition_missing_peers(
                 &peers_result.peer_dependency_issues.missing,

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -320,13 +320,18 @@ where
     // reuses the first walk's children report there, so those peers
     // never reach a later importer's hoist. The final per-importer
     // pass below keeps the unscoped options so warnings stay complete.
+    // Snapshotted once per importer: suppression only consults entries
+    // recorded by earlier importers (everything this importer's own
+    // loop adds is self-claimed and exempt), so the maps cannot change
+    // in a way the loop observes.
+    let hoist_missing_scope = Arc::new(crate::resolve_peers::HoistMissingScope {
+        importer_id: importer_id.to_string(),
+        first_importer_by_pkg: ctx.workspace().first_importer_by_pkg(),
+        first_walk_missing_by_pkg: ctx.workspace().first_walk_missing_by_pkg(),
+    });
     let hoist_peers_opts = || {
         let mut opts = peers_opts();
-        opts.hoist_missing_scope = Some(crate::resolve_peers::HoistMissingScope {
-            importer_id: importer_id.to_string(),
-            first_importer_by_pkg: ctx.workspace().first_importer_by_pkg(),
-            first_walk_missing_by_pkg: ctx.workspace().first_walk_missing_by_pkg(),
-        });
+        opts.hoist_missing_scope = Some(Arc::clone(&hoist_missing_scope));
         opts
     };
     loop {

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -143,8 +143,12 @@ pub struct ResolvePeersOptions {
     /// ([`missingPeersOfChildrenByPkgId`](https://github.com/pnpm/pnpm/blob/a751c7f27d/installing/deps-resolver/src/resolveDependencies.ts#L193)) —
     /// only the package's *own* peers are re-evaluated per occurrence.
     /// The final workspace-wide pass leaves this `None` so warnings
-    /// still cover every importer.
-    pub hoist_missing_scope: Option<HoistMissingScope>,
+    /// still cover every importer. Held by `Arc`: the maps inside are
+    /// per-importer snapshots shared across every hoist-loop
+    /// iteration — the entries relevant to suppression (those of
+    /// earlier importers) cannot change while one importer's loop
+    /// runs.
+    pub hoist_missing_scope: Option<std::sync::Arc<HoistMissingScope>>,
 }
 
 /// See [`ResolvePeersOptions::hoist_missing_scope`].

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -133,6 +133,54 @@ pub struct ResolvePeersOptions {
     /// to compose `<modules_dir>/<alias>` as the remap target.
     /// `None` disables the remap.
     pub modules_dir: Option<std::path::PathBuf>,
+
+    /// When `Some`, missing-peer issues declared inside a subtree
+    /// whose root package was first resolved under a *different*
+    /// importer are not emitted. The peer-hoist loop sets this so its
+    /// input matches upstream, where a revisited package's children
+    /// keep the missing-peer report computed under the first
+    /// resolver's alias chain
+    /// ([`missingPeersOfChildrenByPkgId`](https://github.com/pnpm/pnpm/blob/a751c7f27d/installing/deps-resolver/src/resolveDependencies.ts#L193)) —
+    /// only the package's *own* peers are re-evaluated per occurrence.
+    /// The final workspace-wide pass leaves this `None` so warnings
+    /// still cover every importer.
+    pub hoist_missing_scope: Option<HoistMissingScope>,
+}
+
+/// See [`ResolvePeersOptions::hoist_missing_scope`].
+#[derive(Debug, Clone)]
+pub struct HoistMissingScope {
+    /// The importer whose hoist input is being computed.
+    pub importer_id: String,
+    /// `pkg id → first-resolving importer id`, from
+    /// [`crate::WorkspaceTreeCtx::first_importer_by_pkg`].
+    pub first_importer_by_pkg: HashMap<String, String>,
+    /// Per package: the missing-peer names reported by the first walk
+    /// that visited it, from
+    /// [`crate::WorkspaceTreeCtx::first_walk_missing_by_pkg`]. A
+    /// missing peer inside a foreign-claimed subtree is suppressed
+    /// only when the claimer's walk did *not* report it missing —
+    /// i.e. that context satisfied it, which is what upstream's
+    /// shared children report filtered out at walk time. Misses the
+    /// first walker could not satisfy stay visible to every importer
+    /// (and each hoists its own copy).
+    pub first_walk_missing_by_pkg: HashMap<String, std::collections::HashSet<String>>,
+}
+
+impl HoistMissingScope {
+    /// `true` when a miss of `peer_name` declared under the given
+    /// ancestor chain is covered by another importer's shared walk.
+    fn suppresses(&self, ancestor_pkg_ids: &[String], peer_name: &str) -> bool {
+        ancestor_pkg_ids.iter().any(|pkg_id| {
+            self.first_importer_by_pkg.get(pkg_id).is_some_and(|owner| {
+                *owner != self.importer_id
+                    && self
+                        .first_walk_missing_by_pkg
+                        .get(pkg_id)
+                        .is_some_and(|missing| !missing.contains(peer_name))
+            })
+        })
+    }
 }
 
 impl Default for ResolvePeersOptions {
@@ -143,6 +191,7 @@ impl Default for ResolvePeersOptions {
             exclude_links_from_lockfile: false,
             lockfile_dir: None,
             modules_dir: None,
+            hoist_missing_scope: None,
         }
     }
 }
@@ -154,6 +203,12 @@ pub struct ResolvePeersResult {
     pub graph: DependenciesGraph,
     pub direct_dependencies_by_alias: BTreeMap<String, DepPath>,
     pub peer_dependency_issues: PeerDependencyIssues,
+    /// Per resolved package: the union of missing-peer names its
+    /// occurrences reported in this walk. The hoist loop persists the
+    /// first walk's map per package so later importers can tell which
+    /// misses the first resolver's context already satisfied. See
+    /// [`HoistMissingScope`].
+    pub missing_names_by_pkg: HashMap<String, std::collections::HashSet<String>>,
 }
 
 /// One importer's input to the multi-importer [`fn@resolve_peers_workspace`]
@@ -555,10 +610,20 @@ impl Walker<'_> {
                 .insert(dep.alias.clone(), self.final_dep_path_of(&dep.node_id, &final_dep_paths));
         }
         let graph = self.build_final_graph(&final_dep_paths);
+        let mut missing_names_by_pkg: HashMap<String, std::collections::HashSet<String>> =
+            HashMap::new();
+        for (node_id, missing) in &self.node_missing_peers {
+            let Some(tree_node) = self.tree.dependencies_tree.get(node_id) else { continue };
+            missing_names_by_pkg
+                .entry(tree_node.resolved_package_id.clone())
+                .or_default()
+                .extend(missing.keys().cloned());
+        }
         ResolvePeersResult {
             graph,
             direct_dependencies_by_alias: direct_by_alias,
             peer_dependency_issues: self.issues,
+            missing_names_by_pkg,
         }
     }
 
@@ -814,14 +879,24 @@ impl Walker<'_> {
             // parent chain so each occurrence of the package shows up
             // in the diagnostic, mirroring upstream's behaviour at the
             // cache-hit branch. Without this, the first walk's parent
-            // chain would be the only one ever reported.
-            for (peer_name, info) in &missing {
-                self.issues.missing.entry(peer_name.clone()).or_default().push(MissingPeer {
-                    wanted_range: info.range.clone(),
-                    optional: info.optional,
-                    meta_only: info.meta_only,
-                    parents: parents_from_chain(parent_chain_names, &pkg_name),
-                });
+            // chain would be the only one ever reported. The cached
+            // summary blends the node's own peers with its subtree's,
+            // so under a hoist scope the foreignness of the node
+            // itself counts too.
+            {
+                let mut chain_with_self = parent_pkg_ids_chain.to_vec();
+                chain_with_self.push(pkg.id.clone());
+                for (peer_name, info) in &missing {
+                    if self.missing_issue_suppressed(&chain_with_self, peer_name) {
+                        continue;
+                    }
+                    self.issues.missing.entry(peer_name.clone()).or_default().push(MissingPeer {
+                        wanted_range: info.range.clone(),
+                        optional: info.optional,
+                        meta_only: info.meta_only,
+                        parents: parents_from_chain(parent_chain_names, &pkg_name),
+                    });
+                }
             }
             self.node_dep_paths.insert(node_id.clone(), dep_path.clone());
             self.node_external_peers.insert(node_id.clone(), resolved.clone());
@@ -883,6 +958,7 @@ impl Walker<'_> {
                 peer_dep,
                 &child_parent_refs,
                 &child_chain_names,
+                parent_pkg_ids_chain,
                 &mut own_resolved_peers,
                 &mut own_missing_peers,
             );
@@ -1053,6 +1129,18 @@ impl Walker<'_> {
         clippy::too_many_arguments,
         reason = "splitting these into a struct would only obscure the call site"
     )]
+    /// `true` when a missing-peer issue for `peer_name` under the
+    /// given ancestor chain must not be emitted for the hoist input.
+    /// See [`ResolvePeersOptions::hoist_missing_scope`].
+    fn missing_issue_suppressed(&self, ancestor_pkg_ids: &[String], peer_name: &str) -> bool {
+        let Some(scope) = self.opts.hoist_missing_scope.as_ref() else { return false };
+        scope.suppresses(ancestor_pkg_ids, peer_name)
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "internal walker helper threading per-node context, mirrors the resolve_node parameter set"
+    )]
     fn resolve_one_peer(
         &mut self,
         pkg_name: &str,
@@ -1060,6 +1148,7 @@ impl Walker<'_> {
         peer_dep: &PeerDep,
         parent_refs: &ParentRefs,
         chain: &[String],
+        ancestor_pkg_ids: &[String],
         resolved: &mut HashMap<String, NodeId>,
         missing: &mut HashMap<String, MissingPeerInfo>,
     ) {
@@ -1074,12 +1163,16 @@ impl Walker<'_> {
                     peer_name.to_string(),
                     MissingPeerInfo { range: range_for_match.to_string(), optional, meta_only },
                 );
-                self.issues.missing.entry(peer_name.to_string()).or_default().push(MissingPeer {
-                    wanted_range: range_for_match.to_string(),
-                    optional,
-                    meta_only,
-                    parents: parents_from_chain(chain, pkg_name),
-                });
+                if !self.missing_issue_suppressed(ancestor_pkg_ids, peer_name) {
+                    self.issues.missing.entry(peer_name.to_string()).or_default().push(
+                        MissingPeer {
+                            wanted_range: range_for_match.to_string(),
+                            optional,
+                            meta_only,
+                            parents: parents_from_chain(chain, pkg_name),
+                        },
+                    );
+                }
             }
             Some(parent) => {
                 if !satisfies_with_prereleases(&parent.version, range_for_match) {

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -248,6 +248,7 @@ where
         // ImporterPeerInput's modules_dir into walker.opts before each
         // importer's walk.
         modules_dir: None,
+        hoist_missing_scope: None,
     };
     let peers = resolve_peers_workspace(
         &mut merged_tree,

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -291,3 +291,197 @@ async fn lowest_direct_applies_no_publish_cutoff() {
         "no time-based cutoff in lowest-direct mode",
     );
 }
+
+/// A package shared across importers keeps the peer context of the
+/// importer that resolved it first: pnpm reuses the first walk's
+/// children missing-peer report, so a later importer never hoists an
+/// optional peer declared inside that shared subtree, and the
+/// workspace-wide peer pass shares the first importer's variant
+/// (verified against pnpm 11.6.0 — root + pkg-a both depending on
+/// `@pnpm/meta-updater` keep root's `@types/node` context while a
+/// third importer pins a higher version).
+#[tokio::test]
+async fn shared_subtree_keeps_first_importers_optional_peer_context() {
+    let mut table = HashMap::new();
+    table.insert(
+        ("shared".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "shared",
+            "1.0.0",
+            None,
+            serde_json::json!({
+                "name": "shared",
+                "version": "1.0.0",
+                "dependencies": { "mid": "1.0.0" },
+            }),
+        ),
+    );
+    table.insert(
+        ("mid".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "mid",
+            "1.0.0",
+            None,
+            serde_json::json!({
+                "name": "mid",
+                "version": "1.0.0",
+                "peerDependencies": { "opt": "*" },
+                "peerDependenciesMeta": { "opt": { "optional": true } },
+            }),
+        ),
+    );
+    for version in ["18.0.0", "25.0.0"] {
+        table.insert(
+            ("opt".to_string(), version.to_string()),
+            fake_result(
+                "opt",
+                version,
+                None,
+                serde_json::json!({ "name": "opt", "version": version }),
+            ),
+        );
+    }
+    // `carrier` puts `opt@25.0.0` into the run-resolved preferred
+    // versions during the root importer's walk — deep enough that it
+    // is not in any peer scope — so a later hoist would pick it as the
+    // max satisfying version.
+    table.insert(
+        ("carrier".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "carrier",
+            "1.0.0",
+            None,
+            serde_json::json!({
+                "name": "carrier",
+                "version": "1.0.0",
+                "dependencies": { "opt": "25.0.0" },
+            }),
+        ),
+    );
+    let resolver = RecordingResolver { table, seen: Mutex::new(HashMap::new()) };
+    let (tmp_root, root_manifest) = fake_manifest(
+        serde_json::json!({ "shared": "1.0.0", "opt": "18.0.0", "carrier": "1.0.0" }),
+    );
+    let (tmp_a, a_manifest) = fake_manifest(serde_json::json!({ "shared": "1.0.0" }));
+    let importers = [
+        WorkspaceImporter { id: ".".to_string(), manifest: &root_manifest },
+        WorkspaceImporter { id: "pkg-a".to_string(), manifest: &a_manifest },
+    ];
+    let dirs = [tmp_root.path(), tmp_a.path()];
+
+    let mut opts = workspace_opts(false, false);
+    opts.auto_install_peers = true;
+    let mut next = 0;
+    let result = resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |_| {
+        let dir = dirs[next].to_path_buf();
+        next += 1;
+        let mut opts = importer_opts(dir, None);
+        opts.auto_install_peers = true;
+        opts
+    })
+    .await
+    .unwrap();
+
+    let root_direct = result.peers.direct_dependencies_by_importer.get(".").expect("root importer");
+    assert_eq!(
+        root_direct.get("shared").map(std::string::ToString::to_string),
+        Some("shared@1.0.0(opt@18.0.0)".to_string()),
+    );
+    let a_direct =
+        result.peers.direct_dependencies_by_importer.get("pkg-a").expect("pkg-a importer");
+    assert_eq!(
+        a_direct.get("shared").map(std::string::ToString::to_string),
+        Some("shared@1.0.0(opt@18.0.0)".to_string()),
+        "pkg-a shares the first importer's variant instead of hoisting the higher version",
+    );
+}
+
+/// The reverse of the sharing case above: when the first importer's
+/// walk could NOT satisfy the optional peer either (it only hoisted it
+/// later), the miss stays visible to every importer — each hoists its
+/// own copy, so the shared subtree carries the peer suffix under both
+/// (pnpm 11.6.0 behaviour for e.g. `clipanion`'s `typanion` under
+/// importers that share `@yarnpkg/*` chains with the root).
+#[tokio::test]
+async fn shared_subtree_miss_unsatisfied_by_first_importer_still_hoists() {
+    let mut table = HashMap::new();
+    table.insert(
+        ("top".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "top",
+            "1.0.0",
+            None,
+            serde_json::json!({
+                "name": "top",
+                "version": "1.0.0",
+                "dependencies": { "mid": "1.0.0", "carrier": "1.0.0" },
+            }),
+        ),
+    );
+    table.insert(
+        ("mid".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "mid",
+            "1.0.0",
+            None,
+            serde_json::json!({
+                "name": "mid",
+                "version": "1.0.0",
+                "peerDependencies": { "opt": "*" },
+                "peerDependenciesMeta": { "opt": { "optional": true } },
+            }),
+        ),
+    );
+    table.insert(
+        ("carrier".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "carrier",
+            "1.0.0",
+            None,
+            serde_json::json!({
+                "name": "carrier",
+                "version": "1.0.0",
+                "dependencies": { "opt": "25.0.0" },
+            }),
+        ),
+    );
+    table.insert(
+        ("opt".to_string(), "25.0.0".to_string()),
+        fake_result(
+            "opt",
+            "25.0.0",
+            None,
+            serde_json::json!({ "name": "opt", "version": "25.0.0" }),
+        ),
+    );
+    let resolver = RecordingResolver { table, seen: Mutex::new(HashMap::new()) };
+    let (tmp_root, root_manifest) = fake_manifest(serde_json::json!({ "top": "1.0.0" }));
+    let (tmp_a, a_manifest) = fake_manifest(serde_json::json!({ "top": "1.0.0" }));
+    let importers = [
+        WorkspaceImporter { id: ".".to_string(), manifest: &root_manifest },
+        WorkspaceImporter { id: "pkg-a".to_string(), manifest: &a_manifest },
+    ];
+    let dirs = [tmp_root.path(), tmp_a.path()];
+
+    let mut opts = workspace_opts(false, false);
+    opts.auto_install_peers = true;
+    let mut next = 0;
+    let result = resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |_| {
+        let dir = dirs[next].to_path_buf();
+        next += 1;
+        let mut opts = importer_opts(dir, None);
+        opts.auto_install_peers = true;
+        opts
+    })
+    .await
+    .unwrap();
+
+    for importer in [".", "pkg-a"] {
+        let direct = result.peers.direct_dependencies_by_importer.get(importer).expect("importer");
+        assert_eq!(
+            direct.get("top").map(std::string::ToString::to_string),
+            Some("top@1.0.0(opt@25.0.0)".to_string()),
+            "{importer} hoists the peer the first walk could not satisfy",
+        );
+    }
+}

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -2055,6 +2055,7 @@ mod peers {
                 exclude_links_from_lockfile: true,
                 lockfile_dir: Some(lockfile_dir),
                 modules_dir: Some(modules_dir),
+                hoist_missing_scope: None,
             },
         );
 


### PR DESCRIPTION
## Summary

Two more lockfile-parity fixes for pacquet, continuing https://github.com/pnpm/pnpm/issues/12266. Measured on the monorepo (fresh state, `install --lockfile-only`, back-to-back vs **pnpm 11.6.0**), the real-lockfile document diff drops from **445 to 128 changed lines**, and the divergent importer entries drop from ~30 to **2**.

### 1. Shared subtrees keep the first importer's peer context (`fix(deps-resolver)`)

The dominant remaining divergence was which `@types/node` a hoisted optional peer binds to. Root cause (established with a three-importer repro on `@pnpm/meta-updater`, behavior verified against pnpm 11.6.0 in four configurations): pnpm computes a package subtree's missing-peer report **once**, under the importer whose walk first resolves it ([`missingPeersOfChildrenByPkgId`](https://github.com/pnpm/pnpm/blob/a751c7f27d/installing/deps-resolver/src/resolveDependencies.ts#L193)). An importer revisiting the package reuses that report, so:

- a peer the first context **satisfied** (root's direct `@types/node@22.x`) never reaches a later importer's optional-peer hoist — the later importer's occurrence ends up sharing the first context's suffixed variant; while
- a peer the first context **could not satisfy either** (`clipanion`'s `typanion` under a root that only hoists it later) stays visible to every importer, and each hoists its own copy.

pacquet re-walked each importer's tree from scratch, so an importer without `@types/node` hoisted the max-satisfying `25.x` for a subtree the root had already resolved against `22.x`, forking snapshots into duplicate suffix variants (two `@pnpm/cli-utils@…` entries, etc.).

The walk now records per package the claiming importer and the missing-peer names of that first peer walk; the per-importer hoist input drops a miss declared under a foreign-claimed ancestor only when the claiming walk did not report it missing. The final workspace-wide peer pass stays unscoped, so per-project missing-peer warnings are unchanged. Two regression tests cover both directions (suppressed satisfied-miss; visible unsatisfied-miss), each verified to fail without the fix.

### 2. Array-form `engines` (`fix(lockfile)`)

`jsonparse@1.3.1` declares `"engines": ["node >= 0.2.0"]`; pnpm records `engines: {'0': node >= 0.2.0}` (the `Object.entries` shape for an array). pacquet read the field via `as_object` only and dropped it.

## Verification

- New tests in `pacquet-resolving-deps-resolver` (111 total) + full `pacquet-package-manager` suite (462); clippy `--deny warnings`, rustfmt, typos clean.
- Whole-monorepo diff vs fresh pnpm 11.6.0: 445 → 128 changed lines. The earlier minimal repros (`@pnpm/meta-updater` shared across importers; `eslint`+`cosmiconfig-typescript-loader`; `debug`+`concurrently`) all match pnpm byte-for-byte.

## Remaining gaps (tracked in pnpm/pnpm#12266)

- `jest`'s `@types/node` under `__utils__/eslint-config` and `@cyclonedx`'s `spdx-expression-parse` under `deps/compliance/sbom`: pacquet's sequential, lexically-ordered importer processing makes the peer-less importer the first claimer of the shared subtree, where pnpm's concurrent importer resolution lets a peer-satisfying importer win the race. Needs a look at pnpm's project ordering.
- Per-level preferred-version folding in the picker ([`resolveDependencies.ts#L717-L733`](https://github.com/pnpm/pnpm/blob/a751c7f27d/installing/deps-resolver/src/resolveDependencies.ts#L717-L733)): pnpm biases child resolutions toward versions already resolved at the parent level (`varint` `~5.0.0` → sibling-pinned `5.0.0`; `es-abstract`; the `spdx-expression-parse` 3-vs-4 pick). pacquet's picker seed is static.
- Env-lockfile document: missing `packageManagerDependencies` block and `libc:` fields on platform packages.

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Extend engine constraint parsing to accept both object and array formats
  * Improve peer-dependency resolution tracking and hoisting behavior across workspace importers, including suppression of certain missing-peer diagnostics

* **Tests**
  * Added tests covering optional peer-dependency hoisting for shared subtrees across multiple workspace importers

* **Style**
  * Adjusted code formatting in module imports
<!-- end of auto-generated comment: release notes by coderabbit.ai -->