### PR TITLE
fix(default-reporter): erase trailing characters on progress line

### DIFF
--- a/.changeset/erase-progress-line-remnants.md
+++ b/.changeset/erase-progress-line-remnants.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Fixed the progress line showing leftover characters from external processes that write to the terminal between progress updates (e.g. an SSH passphrase prompt would leave a fragment like `added 0sa':`). Each rendered line is now followed by an ANSI "erase to end of line" sequence so any remnants are cleared [#12350](https://github.com/pnpm/pnpm/issues/12350).
+Fixed the progress line showing leftover characters from external processes that write to the terminal between progress updates (e.g. an SSH passphrase prompt would leave a fragment like `added 0sa':`). The interactive reporter now redraws each frame in place, erasing to the end of the display before reprinting, so any such remnants are cleared [#12350](https://github.com/pnpm/pnpm/issues/12350).

--- a/.changeset/erase-progress-line-remnants.md
+++ b/.changeset/erase-progress-line-remnants.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/cli.default-reporter": patch
+"pnpm": patch
+---
+
+Fixed the progress line showing leftover characters from external processes that write to the terminal between progress updates (e.g. an SSH passphrase prompt would leave a fragment like `added 0sa':`). Each rendered line is now followed by an ANSI "erase to end of line" sequence so any remnants are cleared [#12350](https://github.com/pnpm/pnpm/issues/12350).

--- a/cli/default-reporter/package.json
+++ b/cli/default-reporter/package.json
@@ -46,7 +46,6 @@
     "@pnpm/installing.dedupe.types": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@pnpm/util.lex-comparator": "catalog:",
-    "ansi-diff": "catalog:",
     "boxen": "catalog:",
     "chalk": "catalog:",
     "cli-truncate": "catalog:",

--- a/cli/default-reporter/src/index.ts
+++ b/cli/default-reporter/src/index.ts
@@ -1,7 +1,6 @@
 import type { Config, ConfigContext } from '@pnpm/config.reader'
 import type * as logs from '@pnpm/core-loggers'
 import type { LogLevel, StreamParser } from '@pnpm/logger'
-import createDiffer from 'ansi-diff'
 import * as Rx from 'rxjs'
 import { filter, map, mergeAll } from 'rxjs/operators'
 
@@ -13,10 +12,11 @@ import { formatWarn } from './reporterForClient/utils/formatWarn.js'
 
 export { formatWarn }
 
-// ANSI "erase to end of line". Appended after each rendered line so that
-// remnants from external processes (e.g. SSH passphrase prompts) that write to
-// the terminal between progress updates don't bleed into the progress line.
-const ERASE_EOL = '\x1b[K'
+// ANSI "erase from cursor to end of display". Emitted before reprinting each
+// frame so that anything an external process (e.g. an SSH passphrase prompt)
+// wrote to the terminal between progress updates is cleared instead of bleeding
+// into the progress output.
+const ERASE_TO_END_OF_DISPLAY = '\x1b[0J'
 
 export function initDefaultReporter (
   opts: {
@@ -70,10 +70,6 @@ export function initDefaultReporter (
       subscription.unsubscribe()
     }
   }
-  const diff = createDiffer({
-    height: proc.stdout.rows,
-    outputMaxWidth,
-  })
   const subscription = output$
     .subscribe({
       complete () {}, // eslint-disable-line:no-empty
@@ -85,16 +81,35 @@ export function initDefaultReporter (
   const write = opts.useStderr
     ? proc.stderr.write.bind(proc.stderr)
     : proc.stdout.write.bind(proc.stdout)
+  let prevRows = 0
   function logUpdate (view: string) {
     // A new line should always be appended in case a prompt needs to appear.
     // Without a new line the prompt will be joined with the previous output.
     // An example of such prompt may be seen by running: pnpm update --interactive
     if (!view.endsWith(EOL)) view += EOL
-    write(diff.update(view).toString().replaceAll('\n', `${ERASE_EOL}\n`))
+    // Redraw the whole frame in place: move the cursor back to the top of the
+    // previous frame, erase everything below it, then reprint. Doing this in a
+    // single write keeps the redraw atomic (no flicker) and guarantees any
+    // characters written by an external process in between are cleared.
+    const moveToFrameTop = prevRows > 0 ? `\x1b[${prevRows}A` : ''
+    write(`${moveToFrameTop}${ERASE_TO_END_OF_DISPLAY}${view}`)
+    prevRows = countRows(view)
   }
   return () => {
     subscription.unsubscribe()
   }
+}
+
+// Number of terminal rows a frame occupies. The frame always ends with a
+// newline, so this also equals how far below the frame's top the cursor rests
+// after printing it. Lines are assumed not to soft-wrap, matching how the
+// progress output is width-constrained before it reaches here.
+function countRows (frame: string): number {
+  let rows = 0
+  for (let i = 0; i < frame.length; i++) {
+    if (frame.charCodeAt(i) === 10 /* \n */) rows++
+  }
+  return rows
 }
 
 export function toOutput$ (

--- a/cli/default-reporter/src/index.ts
+++ b/cli/default-reporter/src/index.ts
@@ -87,11 +87,13 @@ export function initDefaultReporter (
     // Without a new line the prompt will be joined with the previous output.
     // An example of such prompt may be seen by running: pnpm update --interactive
     if (!view.endsWith(EOL)) view += EOL
-    // Redraw the whole frame in place: move the cursor back to the top of the
-    // previous frame, erase everything below it, then reprint. Doing this in a
-    // single write keeps the redraw atomic (no flicker) and guarantees any
-    // characters written by an external process in between are cleared.
-    const moveToFrameTop = prevRows > 0 ? `\x1b[${prevRows}A` : ''
+    // Redraw the whole frame in place: return the cursor to the top-left of the
+    // previous frame, erase everything below it, then reprint. The `\r` resets
+    // the column to 0 (cursor-up alone keeps the column) so the redraw starts
+    // cleanly even when an external process left the cursor mid-line. Doing it
+    // in a single write keeps the redraw atomic (no flicker) and clears any
+    // characters an external process wrote in between.
+    const moveToFrameTop = prevRows > 0 ? `\x1b[${prevRows}A\r` : '\r'
     write(`${moveToFrameTop}${ERASE_TO_END_OF_DISPLAY}${view}`)
     prevRows = countRows(view)
   }

--- a/cli/default-reporter/src/index.ts
+++ b/cli/default-reporter/src/index.ts
@@ -13,6 +13,11 @@ import { formatWarn } from './reporterForClient/utils/formatWarn.js'
 
 export { formatWarn }
 
+// ANSI "erase to end of line". Appended after each rendered line so that
+// remnants from external processes (e.g. SSH passphrase prompts) that write to
+// the terminal between progress updates don't bleed into the progress line.
+const ERASE_EOL = '\x1b[K'
+
 export function initDefaultReporter (
   opts: {
     useStderr?: boolean
@@ -85,10 +90,7 @@ export function initDefaultReporter (
     // Without a new line the prompt will be joined with the previous output.
     // An example of such prompt may be seen by running: pnpm update --interactive
     if (!view.endsWith(EOL)) view += EOL
-    // Erase to end of line on every line so that remnants from external
-    // processes (e.g. SSH passphrase prompts) don't bleed through.
-    const ERASE_EOL = '\x1b[K'
-    write(diff.update(view).split('\n').join(`${ERASE_EOL}\n`))
+    write(diff.update(view).toString().replaceAll('\n', `${ERASE_EOL}\n`))
   }
   return () => {
     subscription.unsubscribe()

--- a/cli/default-reporter/src/index.ts
+++ b/cli/default-reporter/src/index.ts
@@ -85,7 +85,10 @@ export function initDefaultReporter (
     // Without a new line the prompt will be joined with the previous output.
     // An example of such prompt may be seen by running: pnpm update --interactive
     if (!view.endsWith(EOL)) view += EOL
-    write(diff.update(view))
+    // Erase to end of line on every line so that remnants from external
+    // processes (e.g. SSH passphrase prompts) don't bleed through.
+    const ERASE_EOL = '\x1b[K'
+    write(diff.update(view).split('\n').join(`${ERASE_EOL}\n`))
   }
   return () => {
     subscription.unsubscribe()

--- a/cli/default-reporter/src/reporterForClient/reportLockfileVerification.ts
+++ b/cli/default-reporter/src/reporterForClient/reportLockfileVerification.ts
@@ -24,8 +24,8 @@ export function reportLockfileVerification (
 ): Rx.Observable<Rx.Observable<{ msg: string }>> {
   const expectedDir = opts.workspaceDir ?? opts.cwd
   // A single inner observable so the `done` message overwrites the
-  // transient `started` message in ansi-diff mode. In appendOnly mode
-  // both lines are printed.
+  // transient `started` message when the reporter redraws in place. In
+  // appendOnly mode both lines are printed.
   return Rx.of(lockfileVerification$.pipe(
     map((log) => {
       const path_ = formatLockfilePath(log.lockfilePath, opts.cwd, expectedDir)

--- a/cli/default-reporter/test/cli.ts
+++ b/cli/default-reporter/test/cli.ts
@@ -16,10 +16,10 @@ test('pnpm-render bin renders ndjson piped from stdin', async () => {
 
   const stdout = await runBin(['install'], lines.map((line) => JSON.stringify(line)).join('\n') + '\n')
 
-  // ansi-diff intersperses cursor-movement escapes when the rendered string
-  // changes (e.g. "1" → "2"), so we can't substring-match the final value
-  // without terminal emulation. Verifying that any progress line rendered is
-  // enough to prove the bin wired stdin → reporter correctly.
+  // The reporter intersperses cursor-movement escapes when redrawing each
+  // frame, so we can't substring-match the final value without terminal
+  // emulation. Verifying that any progress line rendered is enough to prove
+  // the bin wired stdin → reporter correctly.
   expect(stdout).toContain('Progress: resolved')
 })
 

--- a/cli/default-reporter/test/reportingLockfileVerification.ts
+++ b/cli/default-reporter/test/reportingLockfileVerification.ts
@@ -19,7 +19,7 @@ test('prints lockfile verification in-progress and completion messages', async (
   })
 
   // Subscribe before emitting so we capture both the started and the
-  // done frame in ansi-diff mode.
+  // done frame in the interactive (non-append-only) reporter.
   const frames = firstValueFrom(output$.pipe(take(2), toArray()))
 
   const lockfilePath = path.join(cwd, 'pnpm-lock.yaml')

--- a/pacquet/crates/default-reporter/src/lib.rs
+++ b/pacquet/crates/default-reporter/src/lib.rs
@@ -144,6 +144,10 @@ impl Sink {
                 if self.prev_rows > 0 {
                     let _ = write!(buf, "\x1b[{}A", self.prev_rows);
                 }
+                // Reset the column to 0 (cursor-up alone keeps the column) so the
+                // redraw starts cleanly even when an external process left the
+                // cursor mid-line.
+                buf.push('\r');
                 buf.push_str("\x1b[0J");
                 buf.push_str(&frame);
                 buf.push('\n');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -539,9 +539,6 @@ catalogs:
     amaro:
       specifier: ^1.1.9
       version: 1.1.10
-    ansi-diff:
-      specifier: ^1.2.0
-      version: 1.2.0
     archy:
       specifier: ^1.0.0
       version: 1.0.0
@@ -2292,9 +2289,6 @@ importers:
       '@pnpm/util.lex-comparator':
         specifier: 'catalog:'
         version: 4.0.1
-      ansi-diff:
-        specifier: 'catalog:'
-        version: 1.2.0
       boxen:
         specifier: 'catalog:'
         version: '@zkochan/boxen@5.1.2'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -159,7 +159,6 @@ catalog:
   '@zkochan/table': ^2.0.1
   adm-zip: ^0.5.17
   amaro: ^1.1.9
-  ansi-diff: ^1.2.0
   archy: ^1.0.0
   better-path-resolve: 2.0.0
   bin-links: ^6.0.2


### PR DESCRIPTION
External processes like SSH passphrase prompts can write to the terminal between progress updates. The previous renderer used `ansi-diff`, which only overwrites the characters it knows changed, so leftover characters from the external output stayed visible on the progress line — e.g. `added 0sa':`, where `sa':` is a fragment of `Enter passphrase for key '.../.ssh/id_rsa':`.

Closes https://github.com/pnpm/pnpm/issues/12350

## Summary

The interactive (non-append-only) reporter now redraws the whole frame in place on each update instead of incrementally diffing it:

- return the cursor to the top-left of the previous frame (`ESC[<rows>A` followed by a carriage return, so the redraw starts at column 0 even if an external process left the cursor mid-line),
- erase from there to the end of the display (`ESC[0J`),
- reprint the frame — all in a single atomic write, so there is no flicker.

Because the whole region is erased on every frame, any characters an external process wrote in between are cleared. This matches pacquet's `Output::Frame` rendering (the column-reset hardening was applied to both stacks). The now-unused `ansi-diff` dependency has been removed.

## Test plan

- [ ] Run `pnpm install` in a project with a git+ssh dependency that triggers a passphrase prompt
- [ ] Verify the progress line displays cleanly without leftover characters
- [x] `pnpm --filter @pnpm/cli.default-reporter test` passes