### PR TITLE
fix(deps-resolver): make shared children resolution deterministic

### DIFF
--- a/.changeset/deterministic-shared-children-resolution.md
+++ b/.changeset/deterministic-shared-children-resolution.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Made shared package child resolution deterministic when the same package is reached through multiple contexts. pnpm now chooses the shallowest occurrence, then importer order, then parent path, instead of letting request timing decide the child context and missing-peer report [pnpm/pnpm#12358](https://github.com/pnpm/pnpm/issues/12358).

--- a/installing/deps-resolver/src/resolveDependencies.ts
+++ b/installing/deps-resolver/src/resolveDependencies.ts
@@ -49,6 +49,7 @@ import type {
   SupportedArchitectures,
   TrustPolicy,
 } from '@pnpm/types'
+import { lexCompare } from '@pnpm/util.lex-comparator'
 import normalizePath from 'normalize-path'
 import pDefer from 'p-defer'
 import { pathExists } from 'path-exists'
@@ -166,7 +167,12 @@ export interface ResolutionContext {
   resolvedPkgsById: ResolvedPkgsById
   resolvePeersFromWorkspaceRoot?: boolean
   outdatedDependencies: Record<PkgResolutionId, string>
+  packageResolutionBarrier: PackageResolutionBarrier
   childrenByParentId: ChildrenByParentId
+  childrenResolutionByPkgId: Record<PkgResolutionId, ChildrenResolution>
+  childrenResolutionId: number
+  importerResolutionOrder: Record<string, number>
+  nodeResolutionContextByNodeId: Map<NodeId, NodeResolutionContext>
   patchedDependencies?: PatchGroupRecord
   pendingNodes: PendingNode[]
   wantedLockfile: LockfileObject
@@ -210,6 +216,30 @@ export interface ResolutionContext {
   blockExoticSubdeps?: boolean
 }
 
+interface PackageResolutionBarrier {
+  activeByDepth: Map<number, number>
+  waiters: Array<() => void>
+}
+
+interface ChildrenResolutionOwner {
+  depth: number
+  importerOrder: number
+  parentPath: PkgResolutionId[]
+}
+
+interface ChildrenResolution {
+  id: number
+  owner: ChildrenResolutionOwner
+  missingPeersOfChildren?: MissingPeersOfChildren
+}
+
+interface NodeResolutionContext {
+  depth: number
+  installable: boolean
+  parentIds: PkgResolutionId[]
+  pkgId: PkgResolutionId
+}
+
 export interface MissingPeerInfo {
   range: string
   optional: boolean
@@ -238,6 +268,7 @@ export interface PkgAddress extends PkgAddressOrLinkBase {
   rootDir: string
   missingPeers: MissingPeers
   missingPeersOfChildren?: MissingPeersOfChildren
+  childrenResolutionId?: number
   publishedAt?: string
   saveCatalogName?: string
   lockedPeerContext?: LockedPeerContext
@@ -962,6 +993,7 @@ async function resolveDependenciesOfDependency (
 
   const postponedResolution = resolveChildren.bind(null, ctx, {
     parentPkg: resolveDependencyResult,
+    childrenResolutionId: resolveDependencyResult.childrenResolutionId!,
     dependencyLockfile: extendedWantedDep.infoFromLockfile?.dependencyLockfile,
     parentDepth: options.currentDepth,
     parentIds: [...options.parentIds, resolveDependencyResult.pkgId],
@@ -974,7 +1006,18 @@ async function resolveDependenciesOfDependency (
   return {
     resolveDependencyResult,
     postponedResolution: async (postponedResolutionOpts) => {
+      if (!isCurrentChildrenResolution(ctx, resolveDependencyResult.pkgId, resolveDependencyResult.childrenResolutionId)) {
+        setDependencyTreeNodeWithCurrentChildren(ctx, {
+          parentDepth: options.currentDepth,
+          parentIds: [...options.parentIds, resolveDependencyResult.pkgId],
+          parentPkg: resolveDependencyResult,
+        })
+        return resolveMissingPeersFromCurrentChildrenResolution(ctx, resolveDependencyResult.pkgId, postponedResolutionOpts.parentPkgAliases)
+      }
       const { missingPeers, resolvedPeers } = await postponedResolution(postponedResolutionOpts)
+      if (!isCurrentChildrenResolution(ctx, resolveDependencyResult.pkgId, resolveDependencyResult.childrenResolutionId)) {
+        return resolveMissingPeersFromCurrentChildrenResolution(ctx, resolveDependencyResult.pkgId, postponedResolutionOpts.parentPkgAliases)
+      }
       if (resolveDependencyResult.missingPeersOfChildren) {
         resolveDependencyResult.missingPeersOfChildren.resolved = true
         resolveDependencyResult.missingPeersOfChildren.resolve(missingPeers)
@@ -1008,10 +1051,242 @@ function filterMissingPeers (
   }
 }
 
+function startPackageResolution (ctx: ResolutionContext, depth: number): () => void {
+  const activeCount = ctx.packageResolutionBarrier.activeByDepth.get(depth) ?? 0
+  ctx.packageResolutionBarrier.activeByDepth.set(depth, activeCount + 1)
+  let finished = false
+  return () => {
+    if (finished) return
+    finished = true
+    const nextActiveCount = (ctx.packageResolutionBarrier.activeByDepth.get(depth) ?? 1) - 1
+    if (nextActiveCount > 0) {
+      ctx.packageResolutionBarrier.activeByDepth.set(depth, nextActiveCount)
+    } else {
+      ctx.packageResolutionBarrier.activeByDepth.delete(depth)
+    }
+    const waiters = ctx.packageResolutionBarrier.waiters.splice(0)
+    for (const resolve of waiters) {
+      resolve()
+    }
+  }
+}
+
+async function waitForPackageResolutionTurn (ctx: ResolutionContext, depth: number): Promise<void> {
+  if (!hasActivePackageResolutionBeforeDepth(ctx, depth)) return
+  await new Promise<void>((resolve) => ctx.packageResolutionBarrier.waiters.push(resolve))
+  return waitForPackageResolutionTurn(ctx, depth)
+}
+
+function hasActivePackageResolutionBeforeDepth (ctx: ResolutionContext, depth: number): boolean {
+  for (const [activeDepth, activeCount] of ctx.packageResolutionBarrier.activeByDepth) {
+    if (activeDepth < depth && activeCount > 0) return true
+  }
+  return false
+}
+
+function claimChildrenResolution (
+  ctx: ResolutionContext,
+  opts: {
+    currentDepth: number
+    parentIds: PkgResolutionId[]
+    pkgId: PkgResolutionId
+  }
+): { id: number, isOwner: boolean, missingPeersOfChildren?: MissingPeersOfChildren } {
+  const owner = {
+    depth: opts.currentDepth,
+    importerOrder: ctx.importerResolutionOrder[opts.parentIds[0]] ?? Number.MAX_SAFE_INTEGER,
+    parentPath: opts.parentIds,
+  }
+  const existing = ctx.childrenResolutionByPkgId[opts.pkgId]
+  if (existing == null || compareChildrenResolutionOwners(owner, existing.owner) < 0) {
+    const previousMissingPeersOfChildren = existing?.missingPeersOfChildren
+    const missingPeersOfChildren = ctx.hoistPeers && !opts.parentIds.includes(opts.pkgId)
+      ? createMissingPeersOfChildren()
+      : undefined
+    const resolution = {
+      id: ++ctx.childrenResolutionId,
+      owner,
+      missingPeersOfChildren,
+    }
+    ctx.childrenResolutionByPkgId[opts.pkgId] = resolution
+    if (missingPeersOfChildren) {
+      ctx.missingPeersOfChildrenByPkgId[opts.pkgId] = {
+        depth: owner.depth,
+        missingPeersOfChildren,
+      }
+    }
+    if (previousMissingPeersOfChildren) {
+      if (missingPeersOfChildren) {
+        missingPeersOfChildren.get().then((missingPeers) => {
+          previousMissingPeersOfChildren.resolved = true
+          previousMissingPeersOfChildren.resolve(missingPeers)
+        }, previousMissingPeersOfChildren.reject)
+      } else {
+        previousMissingPeersOfChildren.resolved = true
+        previousMissingPeersOfChildren.resolve({})
+      }
+    }
+    return {
+      id: resolution.id,
+      isOwner: true,
+      missingPeersOfChildren,
+    }
+  }
+
+  let missingPeersOfChildren!: MissingPeersOfChildren | undefined
+  if (
+    ctx.hoistPeers &&
+    !opts.parentIds.includes(opts.pkgId) &&
+    existing.missingPeersOfChildren &&
+    (
+      existing.owner.depth >= opts.currentDepth ||
+      existing.missingPeersOfChildren.resolved
+    )
+  ) {
+    missingPeersOfChildren = existing.missingPeersOfChildren
+  }
+  return {
+    id: existing.id,
+    isOwner: false,
+    missingPeersOfChildren,
+  }
+}
+
+function compareChildrenResolutionOwners (owner1: ChildrenResolutionOwner, owner2: ChildrenResolutionOwner): number {
+  if (owner1.depth !== owner2.depth) return owner1.depth - owner2.depth
+  if (owner1.importerOrder !== owner2.importerOrder) return owner1.importerOrder - owner2.importerOrder
+  const pathLength = Math.min(owner1.parentPath.length, owner2.parentPath.length)
+  for (let i = 0; i < pathLength; i++) {
+    const result = lexCompare(owner1.parentPath[i], owner2.parentPath[i])
+    if (result !== 0) return result
+  }
+  return owner1.parentPath.length - owner2.parentPath.length
+}
+
+function createMissingPeersOfChildren (): MissingPeersOfChildren {
+  const p = pDefer<MissingPeers>()
+  return {
+    resolve: p.resolve,
+    reject: p.reject,
+    get: pShare(p.promise),
+  }
+}
+
+function isCurrentChildrenResolution (
+  ctx: ResolutionContext,
+  pkgId: PkgResolutionId,
+  childrenResolutionId?: number
+): boolean {
+  return childrenResolutionId != null && ctx.childrenResolutionByPkgId[pkgId]?.id === childrenResolutionId
+}
+
+async function resolveMissingPeersFromCurrentChildrenResolution (
+  ctx: ResolutionContext,
+  pkgId: PkgResolutionId,
+  parentPkgAliases: ParentPkgAliases
+): Promise<PeersResolutionResult> {
+  const missingPeersOfChildren = ctx.childrenResolutionByPkgId[pkgId]?.missingPeersOfChildren
+  if (missingPeersOfChildren == null) {
+    return {
+      missingPeers: {},
+      resolvedPeers: {},
+    }
+  }
+  const missingPeers = await missingPeersOfChildren.get()
+  return filterMissingPeers({ missingPeers, resolvedPeers: {} }, parentPkgAliases)
+}
+
+function setDependencyTreeNodeWithCurrentChildren (
+  ctx: ResolutionContext,
+  {
+    parentDepth,
+    parentIds,
+    parentPkg,
+  }: {
+    parentDepth: number
+    parentIds: PkgResolutionId[]
+    parentPkg: PkgAddress
+  }
+): void {
+  ctx.dependenciesTree.set(parentPkg.nodeId, {
+    children: () => buildTree(ctx, parentPkg.pkgId, parentIds, ctx.childrenByParentId[parentPkg.pkgId] ?? [], parentDepth + 1, parentPkg.installable),
+    depth: parentDepth,
+    installable: parentPkg.installable,
+    lockedPeerContext: parentPkg.lockedPeerContext,
+    previousDepPath: parentPkg.previousDepPath,
+    resolvedPackage: ctx.resolvedPkgsById[parentPkg.pkgId],
+  })
+  ctx.nodeResolutionContextByNodeId.set(parentPkg.nodeId, {
+    depth: parentDepth,
+    installable: parentPkg.installable,
+    parentIds,
+    pkgId: parentPkg.pkgId,
+  })
+}
+
+function updateChildrenResolutionNodes (
+  ctx: ResolutionContext,
+  pkgId: PkgResolutionId,
+  currentNodeId: NodeId
+): void {
+  for (const [nodeId, nodeContext] of ctx.nodeResolutionContextByNodeId) {
+    if (nodeId === currentNodeId || nodeContext.pkgId !== pkgId) continue
+    const node = ctx.dependenciesTree.get(nodeId)
+    if (node == null || node.depth === -1) continue
+    node.children = () => buildTree(ctx, pkgId, nodeContext.parentIds, ctx.childrenByParentId[pkgId] ?? [], nodeContext.depth + 1, nodeContext.installable)
+  }
+}
+
+export function buildTree (
+  ctx: {
+    childrenByParentId: ChildrenByParentId
+    dependenciesTree: DependenciesTree<ResolvedPackage>
+    resolvedPkgsById: ResolvedPkgsById
+    skipped: Set<PkgResolutionId>
+  },
+  parentId: PkgResolutionId,
+  parentIds: PkgResolutionId[],
+  children: Array<{ alias: string, id: PkgResolutionId }>,
+  depth: number,
+  installable: boolean
+): Record<string, NodeId> {
+  const childrenNodeIds: Record<string, NodeId> = {}
+  for (const child of children) {
+    if (child.id.startsWith('link:')) {
+      childrenNodeIds[child.alias] = child.id as unknown as NodeId
+      continue
+    }
+    if (parentIdsContainSequence(parentIds, parentId, child.id) || parentId === child.id) {
+      continue
+    }
+    if (ctx.resolvedPkgsById[child.id].isLeaf) {
+      childrenNodeIds[child.alias] = child.id as unknown as NodeId
+      continue
+    }
+    const childNodeId = nextNodeId()
+    childrenNodeIds[child.alias] = childNodeId
+    installable = installable || !ctx.skipped.has(child.id)
+    ctx.dependenciesTree.set(childNodeId, {
+      children: () => buildTree(ctx,
+        child.id,
+        [...parentIds, child.id],
+        ctx.childrenByParentId[child.id],
+        depth + 1,
+        installable
+      ),
+      depth,
+      installable,
+      resolvedPackage: ctx.resolvedPkgsById[child.id],
+    })
+  }
+  return childrenNodeIds
+}
+
 async function resolveChildren (
   ctx: ResolutionContext,
   {
     parentPkg,
+    childrenResolutionId,
     parentIds,
     dependencyLockfile,
     parentDepth,
@@ -1021,6 +1296,7 @@ async function resolveChildren (
     supportedArchitectures,
   }: {
     parentPkg: PkgAddress
+    childrenResolutionId: number
     parentIds: PkgResolutionId[]
     dependencyLockfile: PackageSnapshot | undefined
     parentDepth: number
@@ -1040,6 +1316,17 @@ async function resolveChildren (
     publishedBy?: Date
   }
 ): Promise<PeersResolutionResult> {
+  if (!isCurrentChildrenResolution(ctx, parentPkg.pkgId, childrenResolutionId)) {
+    setDependencyTreeNodeWithCurrentChildren(ctx, {
+      parentDepth,
+      parentIds,
+      parentPkg,
+    })
+    return {
+      missingPeers: {},
+      resolvedPeers: {},
+    }
+  }
   const currentResolvedDependencies = (dependencyLockfile != null)
     ? {
       ...dependencyLockfile.dependencies,
@@ -1078,6 +1365,14 @@ async function resolveChildren (
       parentIds,
     }
   )
+  if (!isCurrentChildrenResolution(ctx, parentPkg.pkgId, childrenResolutionId)) {
+    setDependencyTreeNodeWithCurrentChildren(ctx, {
+      parentDepth,
+      parentIds,
+      parentPkg,
+    })
+    return resolvingPeers
+  }
   ctx.childrenByParentId[parentPkg.pkgId] = pkgAddresses.map((child) => ({
     alias: child.alias,
     id: child.pkgId,
@@ -1101,6 +1396,13 @@ async function resolveChildren (
     previousDepPath: parentPkg.previousDepPath,
     resolvedPackage: ctx.resolvedPkgsById[parentPkg.pkgId],
   })
+  ctx.nodeResolutionContextByNodeId.set(parentPkg.nodeId, {
+    depth: parentDepth,
+    installable: parentPkg.installable,
+    parentIds,
+    pkgId: parentPkg.pkgId,
+  })
+  updateChildrenResolutionNodes(ctx, parentPkg.pkgId, parentPkg.nodeId)
   return resolvingPeers
 }
 
@@ -1368,386 +1670,378 @@ async function resolveDependency (
     }
   }
 
-  // Normalize the `preferredVersion` (singular) and `preferredVersions`
-  // (plural) options. If the singular option is passed through, it'll be used
-  // instead of the plural option.
-  const preferredVersions = !options.updateRequested && options.preferredVersion != null
-    ? getExactSinglePreferredVersions(wantedDependency, options.preferredVersion)
-    : options.preferredVersions
-
+  const finishPackageResolution = startPackageResolution(ctx, options.currentDepth)
   try {
-    const calcSpecifier = options.currentDepth === 0
-    if (!options.update && currentPkg.version && currentPkg.pkgId?.endsWith(`@${currentPkg.version}`) && !calcSpecifier) {
-      wantedDependency.bareSpecifier = replaceVersionInBareSpecifier(wantedDependency.bareSpecifier, currentPkg.version, ctx.namedRegistryPrefixes)
-    }
-    pkgResponse = await ctx.storeController.requestPackage(wantedDependency, {
-      allowBuild: ctx.allowBuild,
-      alwaysTryWorkspacePackages: ctx.linkWorkspacePackagesDepth >= options.currentDepth,
-      currentPkg: currentPkg
-        ? {
-          id: currentPkg.pkgId,
-          name: currentPkg.name,
-          resolution: currentPkg.resolution,
-          version: currentPkg.version,
-          publishedAt: currentPkg.pkgId ? ctx.wantedLockfile.time?.[currentPkg.pkgId] : undefined,
-        }
-        : undefined,
-      expectedPkg: currentPkg,
-      defaultTag: ctx.defaultTag,
-      ignoreScripts: ctx.ignoreScripts,
-      publishedBy: options.publishedBy,
-      publishedByExclude: ctx.publishedByExclude,
-      pickLowestVersion: options.pickLowestVersion,
-      downloadPriority: -options.currentDepth,
-      lockfileDir: ctx.lockfileDir,
-      preferredVersions,
-      preferWorkspacePackages: ctx.preferWorkspacePackages,
-      projectDir: (
-        options.currentDepth > 0 &&
-        !wantedDependency.bareSpecifier.startsWith('file:')
-      )
-        ? ctx.lockfileDir
-        : options.parentPkg.rootDir,
-      skipFetch: ctx.dryRun,
-      trustPolicy: ctx.trustPolicy,
-      trustPolicyExclude: ctx.trustPolicyExclude,
-      trustPolicyIgnoreAfter: ctx.trustPolicyIgnoreAfter,
-      update: options.update,
-      updateChecksums: options.updateChecksums,
-      workspacePackages: ctx.workspacePackages,
-      supportedArchitectures: options.supportedArchitectures,
-      onFetchError: (err: any) => { // eslint-disable-line
-        err.prefix = options.prefix
-        err.pkgsStack = getPkgsInfoFromIds(options.parentIds, ctx.resolvedPkgsById)
-        return err
-      },
-      injectWorkspacePackages: ctx.injectWorkspacePackages,
-      calcSpecifier,
-      pinnedVersion: options.pinnedVersion,
-    })
-  } catch (err: any) { // eslint-disable-line
-    const wantedDependencyDetails = {
-      name: wantedDependency.alias,
-      bareSpecifier: wantedDependency.bareSpecifier,
-      version: wantedDependency.alias ? wantedDependency.bareSpecifier : undefined,
-    }
-    if (wantedDependency.optional && err.code !== 'ERR_PNPM_TRUST_DOWNGRADE') {
-      skippedOptionalDependencyLogger.debug({
-        details: err.toString(),
-        package: wantedDependencyDetails,
-        parents: getPkgsInfoFromIds(options.parentIds, ctx.resolvedPkgsById),
-        prefix: options.prefix,
-        reason: 'resolution_failure',
+    await waitForPackageResolutionTurn(ctx, options.currentDepth)
+
+    // Normalize the `preferredVersion` (singular) and `preferredVersions`
+    // (plural) options. If the singular option is passed through, it'll be used
+    // instead of the plural option.
+    const preferredVersions = !options.updateRequested && options.preferredVersion != null
+      ? getExactSinglePreferredVersions(wantedDependency, options.preferredVersion)
+      : options.preferredVersions
+
+    try {
+      const calcSpecifier = options.currentDepth === 0
+      if (!options.update && currentPkg.version && currentPkg.pkgId?.endsWith(`@${currentPkg.version}`) && !calcSpecifier) {
+        wantedDependency.bareSpecifier = replaceVersionInBareSpecifier(wantedDependency.bareSpecifier, currentPkg.version, ctx.namedRegistryPrefixes)
+      }
+      pkgResponse = await ctx.storeController.requestPackage(wantedDependency, {
+        allowBuild: ctx.allowBuild,
+        alwaysTryWorkspacePackages: ctx.linkWorkspacePackagesDepth >= options.currentDepth,
+        currentPkg: currentPkg
+          ? {
+            id: currentPkg.pkgId,
+            name: currentPkg.name,
+            resolution: currentPkg.resolution,
+            version: currentPkg.version,
+            publishedAt: currentPkg.pkgId ? ctx.wantedLockfile.time?.[currentPkg.pkgId] : undefined,
+          }
+          : undefined,
+        expectedPkg: currentPkg,
+        defaultTag: ctx.defaultTag,
+        ignoreScripts: ctx.ignoreScripts,
+        publishedBy: options.publishedBy,
+        publishedByExclude: ctx.publishedByExclude,
+        pickLowestVersion: options.pickLowestVersion,
+        downloadPriority: -options.currentDepth,
+        lockfileDir: ctx.lockfileDir,
+        preferredVersions,
+        preferWorkspacePackages: ctx.preferWorkspacePackages,
+        projectDir: (
+          options.currentDepth > 0 &&
+          !wantedDependency.bareSpecifier.startsWith('file:')
+        )
+          ? ctx.lockfileDir
+          : options.parentPkg.rootDir,
+        skipFetch: ctx.dryRun,
+        trustPolicy: ctx.trustPolicy,
+        trustPolicyExclude: ctx.trustPolicyExclude,
+        trustPolicyIgnoreAfter: ctx.trustPolicyIgnoreAfter,
+        update: options.update,
+        updateChecksums: options.updateChecksums,
+        workspacePackages: ctx.workspacePackages,
+        supportedArchitectures: options.supportedArchitectures,
+        onFetchError: (err: any) => { // eslint-disable-line
+          err.prefix = options.prefix
+          err.pkgsStack = getPkgsInfoFromIds(options.parentIds, ctx.resolvedPkgsById)
+          return err
+        },
+        injectWorkspacePackages: ctx.injectWorkspacePackages,
+        calcSpecifier,
+        pinnedVersion: options.pinnedVersion,
       })
+    } catch (err: any) { // eslint-disable-line
+      const wantedDependencyDetails = {
+        name: wantedDependency.alias,
+        bareSpecifier: wantedDependency.bareSpecifier,
+        version: wantedDependency.alias ? wantedDependency.bareSpecifier : undefined,
+      }
+      if (wantedDependency.optional && err.code !== 'ERR_PNPM_TRUST_DOWNGRADE') {
+        skippedOptionalDependencyLogger.debug({
+          details: err.toString(),
+          package: wantedDependencyDetails,
+          parents: getPkgsInfoFromIds(options.parentIds, ctx.resolvedPkgsById),
+          prefix: options.prefix,
+          reason: 'resolution_failure',
+        })
+        return null
+      }
+      err.package = wantedDependencyDetails
+      err.prefix = options.prefix
+      err.pkgsStack = getPkgsInfoFromIds(options.parentIds, ctx.resolvedPkgsById)
+      throw err
+    }
+
+    dependencyResolvedLogger.debug({
+      resolution: pkgResponse.body.id,
+      wanted: {
+        dependentId: options.parentPkg.pkgId,
+        name: wantedDependency.alias,
+        rawSpec: wantedDependency.bareSpecifier,
+      },
+    })
+
+    // Resolver-inline policy violations (e.g. minimumReleaseAge) flow up
+    // here; collect them onto the shared context so resolveDependencyTree
+    // can hand the full set to the install command between
+    // resolveDependencyTree and resolvePeers.
+    if (pkgResponse.body.policyViolation) {
+      ctx.resolutionPolicyViolations.push(pkgResponse.body.policyViolation)
+    }
+
+    // Check if exotic dependencies are disallowed in subdependencies
+    if (
+      ctx.blockExoticSubdeps &&
+      options.currentDepth > 0 &&
+      pkgResponse.body.resolvedVia != null && // This is already coming from the lockfile, we skip the check in this case for now. Should be fixed later.
+      isExoticDep(pkgResponse.body.resolvedVia)
+    ) {
+      const error = new PnpmError(
+        'EXOTIC_SUBDEP',
+        `Exotic dependency "${wantedDependency.alias ?? wantedDependency.bareSpecifier}" (resolved via ${pkgResponse.body.resolvedVia}) is not allowed in subdependencies when blockExoticSubdeps is enabled`
+      )
+      error.prefix = options.prefix
+      error.pkgsStack = getPkgsInfoFromIds(options.parentIds, ctx.resolvedPkgsById)
+      throw error
+    }
+
+    if (ctx.allPreferredVersions && pkgResponse.body.manifest?.version) {
+      if (!ctx.allPreferredVersions[pkgResponse.body.manifest.name]) {
+        ctx.allPreferredVersions[pkgResponse.body.manifest.name] = {}
+      }
+      ctx.allPreferredVersions[pkgResponse.body.manifest.name][pkgResponse.body.manifest.version] = 'version'
+    }
+
+    if (
+      !pkgResponse.body.updated &&
+      options.currentDepth === Math.max(0, options.updateDepth) &&
+      depIsLinked && !ctx.force && !options.proceed
+    ) {
       return null
     }
-    err.package = wantedDependencyDetails
-    err.prefix = options.prefix
-    err.pkgsStack = getPkgsInfoFromIds(options.parentIds, ctx.resolvedPkgsById)
-    throw err
-  }
 
-  dependencyResolvedLogger.debug({
-    resolution: pkgResponse.body.id,
-    wanted: {
-      dependentId: options.parentPkg.pkgId,
-      name: wantedDependency.alias,
-      rawSpec: wantedDependency.bareSpecifier,
-    },
-  })
-
-  // Resolver-inline policy violations (e.g. minimumReleaseAge) flow up
-  // here; collect them onto the shared context so resolveDependencyTree
-  // can hand the full set to the install command between
-  // resolveDependencyTree and resolvePeers.
-  if (pkgResponse.body.policyViolation) {
-    ctx.resolutionPolicyViolations.push(pkgResponse.body.policyViolation)
-  }
-
-  // Check if exotic dependencies are disallowed in subdependencies
-  if (
-    ctx.blockExoticSubdeps &&
-    options.currentDepth > 0 &&
-    pkgResponse.body.resolvedVia != null && // This is already coming from the lockfile, we skip the check in this case for now. Should be fixed later.
-    isExoticDep(pkgResponse.body.resolvedVia)
-  ) {
-    const error = new PnpmError(
-      'EXOTIC_SUBDEP',
-      `Exotic dependency "${wantedDependency.alias ?? wantedDependency.bareSpecifier}" (resolved via ${pkgResponse.body.resolvedVia}) is not allowed in subdependencies when blockExoticSubdeps is enabled`
-    )
-    error.prefix = options.prefix
-    error.pkgsStack = getPkgsInfoFromIds(options.parentIds, ctx.resolvedPkgsById)
-    throw error
-  }
-
-  if (ctx.allPreferredVersions && pkgResponse.body.manifest?.version) {
-    if (!ctx.allPreferredVersions[pkgResponse.body.manifest.name]) {
-      ctx.allPreferredVersions[pkgResponse.body.manifest.name] = {}
-    }
-    ctx.allPreferredVersions[pkgResponse.body.manifest.name][pkgResponse.body.manifest.version] = 'version'
-  }
-
-  if (
-    !pkgResponse.body.updated &&
-    options.currentDepth === Math.max(0, options.updateDepth) &&
-    depIsLinked && !ctx.force && !options.proceed
-  ) {
-    return null
-  }
-
-  if (pkgResponse.body.isLocal) {
-    if (!pkgResponse.body.manifest) {
-      // This should actually never happen because the local-resolver returns a manifest
-      // even if no real manifest exists in the filesystem.
-      throw new PnpmError('MISSING_PACKAGE_JSON', `Can't install ${wantedDependency.bareSpecifier}: Missing package.json file`)
-    }
-    return {
-      alias: wantedDependency.alias ?? pkgResponse.body.alias ?? pkgResponse.body.manifest.name ?? path.basename(pkgResponse.body.resolution.directory),
-      dev: wantedDependency.dev,
-      isLinkedDependency: true,
-      name: pkgResponse.body.manifest.name,
-      optional: wantedDependency.optional,
-      pkgId: pkgResponse.body.id,
-      resolution: pkgResponse.body.resolution,
-      version: pkgResponse.body.manifest.version,
-      normalizedBareSpecifier: pkgResponse.body.normalizedBareSpecifier,
-      pkg: pkgResponse.body.manifest,
-    }
-  }
-
-  let prepare!: boolean
-  let hasBin!: boolean
-  let pkg: PackageManifest = getManifestFromResponse(pkgResponse, wantedDependency, currentPkg)
-  if (!pkg.dependencies) {
-    pkg.dependencies = {}
-  }
-  if (ctx.readPackageHook != null) {
-    pkg = await ctx.readPackageHook(pkg)
-  }
-  if (pkg.peerDependencies && pkg.dependencies) {
-    if (ctx.autoInstallPeers) {
-      pkg = {
-        ...pkg,
-        dependencies: omit(Object.keys(pkg.peerDependencies), pkg.dependencies),
+    if (pkgResponse.body.isLocal) {
+      if (!pkgResponse.body.manifest) {
+        // This should actually never happen because the local-resolver returns a manifest
+        // even if no real manifest exists in the filesystem.
+        throw new PnpmError('MISSING_PACKAGE_JSON', `Can't install ${wantedDependency.bareSpecifier}: Missing package.json file`)
       }
-    } else {
-      pkg = {
-        ...pkg,
-        dependencies: omit(
-          Object.keys(pkg.peerDependencies).filter((peerDep) => options.parentPkgAliases[peerDep]),
-          pkg.dependencies
-        ),
-      }
-    }
-  }
-  if (pkg.engines?.runtime != null) {
-    convertEnginesRuntimeToDependencies(pkg, 'engines', 'dependencies')
-  }
-  if (!pkg.name) { // TODO: don't fail on optional dependencies
-    throw new PnpmError('MISSING_PACKAGE_NAME', `Can't install ${wantedDependency.bareSpecifier}: Missing package name`)
-  }
-  let pkgIdWithPatchHash = (pkgResponse.body.id.startsWith(`${pkg.name}@`) ? pkgResponse.body.id : `${pkg.name}@${pkgResponse.body.id}`) as PkgIdWithPatchHash
-  const patch = getPatchInfo(ctx.patchedDependencies, pkg.name, pkg.version)
-  if (patch) {
-    ctx.appliedPatches.add(patch.key)
-    pkgIdWithPatchHash = `${pkgIdWithPatchHash}(patch_hash=${patch.hash})` as PkgIdWithPatchHash
-  }
-
-  // We are building the dependency tree only until there are new packages
-  // or the packages repeat in a unique order.
-  // This is needed later during peer dependencies resolution.
-  //
-  // So we resolve foo > bar > qar > foo
-  // But we stop on foo > bar > qar > foo > qar
-  // In the second example, there's no reason to walk qar again
-  // when qar is included the first time, the dependencies of foo
-  // are already resolved and included as parent dependencies of qar.
-  // So during peers resolution, qar cannot possibly get any new or different
-  // peers resolved, after the first occurrence.
-  //
-  // However, in the next example we would analyze the second qar as well,
-  // because zoo is a new parent package:
-  // foo > bar > qar > zoo > qar
-  if (
-    parentIdsContainSequence(
-      options.parentIds,
-      options.parentPkg.pkgId,
-      pkgResponse.body.id
-    ) || pkgResponse.body.id === options.parentPkg.pkgId
-  ) {
-    return null
-  }
-
-  if (
-    !options.update && (currentPkg.dependencyLockfile != null) && currentPkg.depPath &&
-    !pkgResponse.body.updated &&
-    // peerDependencies field is also used for transitive peer dependencies which should not be linked
-    // That's why we cannot omit reading package.json of such dependencies.
-    // This can be removed if we implement something like peerDependenciesMeta.transitive: true
-    (currentPkg.dependencyLockfile.peerDependencies == null)
-  ) {
-    hasBin = currentPkg.dependencyLockfile.hasBin === true
-    pkg = {
-      ...nameVerFromPkgSnapshot(currentPkg.depPath, currentPkg.dependencyLockfile),
-      ...omitDepsFields(currentPkg.dependencyLockfile),
-      ...pkg,
-    }
-  } else {
-    prepare = Boolean(
-      pkgResponse.body.resolvedVia === 'git-repository' &&
-      typeof pkg.scripts?.prepare === 'string'
-    )
-
-    if (
-      currentPkg.dependencyLockfile?.deprecated &&
-      !pkgResponse.body.updated && !pkg.deprecated
-    ) {
-      pkg.deprecated = currentPkg.dependencyLockfile.deprecated
-    }
-    hasBin = (currentPkg.dependencyLockfile?.hasBin != null && !pkg.bin)
-      ? currentPkg.dependencyLockfile.hasBin
-      : Boolean((pkg.bin && !(pkg.bin === '' || Object.keys(pkg.bin).length === 0)) ?? pkg.directories?.bin)
-  }
-  if (options.currentDepth === 0 && pkgResponse.body.latest && pkgResponse.body.latest !== pkg.version) {
-    ctx.outdatedDependencies[pkgResponse.body.id] = pkgResponse.body.latest
-  }
-
-  if (pkg.peerDependencies != null) {
-    for (const name in pkg.peerDependencies) {
-      ctx.allPeerDepNames.add(name)
-    }
-  }
-  if (pkg.peerDependenciesMeta != null) {
-    for (const name in pkg.peerDependenciesMeta) {
-      ctx.allPeerDepNames.add(name)
-    }
-  }
-  // In case of leaf dependencies (dependencies that have no prod deps or peer deps),
-  // we only ever need to analyze one leaf dep in a graph, so the nodeId can be short and stateless.
-  const nodeId = pkgIsLeaf(pkg) ? pkgResponse.body.id as unknown as NodeId : nextNodeId()
-
-  const parentIsInstallable = options.parentPkg.installable === undefined || options.parentPkg.installable
-  const installable = parentIsInstallable && pkgResponse.body.isInstallable !== false
-  const isNew = !ctx.resolvedPkgsById[pkgResponse.body.id]
-  const parentImporterId = options.parentIds[0]
-  const currentIsOptional = wantedDependency.optional || options.parentPkg.optional
-
-  if (isNew) {
-    if (
-      pkg.deprecated &&
-      (!ctx.allowedDeprecatedVersions[pkg.name] || !semver.satisfies(pkg.version, ctx.allowedDeprecatedVersions[pkg.name]))
-    ) {
-      // Report deprecated packages only on first occurrence.
-      deprecationLogger.debug({
-        deprecated: pkg.deprecated,
-        depth: options.currentDepth,
+      return {
+        alias: wantedDependency.alias ?? pkgResponse.body.alias ?? pkgResponse.body.manifest.name ?? path.basename(pkgResponse.body.resolution.directory),
+        dev: wantedDependency.dev,
+        isLinkedDependency: true,
+        name: pkgResponse.body.manifest.name,
+        optional: wantedDependency.optional,
         pkgId: pkgResponse.body.id,
-        pkgName: pkg.name,
-        pkgVersion: pkg.version,
-        prefix: options.prefix,
-      })
-    }
-    if (pkgResponse.body.isInstallable === false || !parentIsInstallable) {
-      ctx.skipped.add(pkgResponse.body.id)
-    }
-    progressLogger.debug({
-      packageId: pkgResponse.body.id,
-      requester: ctx.lockfileDir,
-      status: 'resolved',
-    })
-
-    // WARN: It is very important to keep this sync
-    // Otherwise, deprecation messages for the same package might get written several times
-    ctx.resolvedPkgsById[pkgResponse.body.id] = getResolvedPackage({
-      dependencyLockfile: currentPkg.dependencyLockfile,
-      pkgIdWithPatchHash,
-      force: ctx.force,
-      hasBin,
-      patch,
-      pkg,
-      pkgResponse,
-      prepare,
-      wantedDependency,
-      parentImporterId,
-      optional: currentIsOptional,
-    })
-  } else {
-    ctx.resolvedPkgsById[pkgResponse.body.id].prod = ctx.resolvedPkgsById[pkgResponse.body.id].prod || !wantedDependency.dev && !wantedDependency.optional
-    ctx.resolvedPkgsById[pkgResponse.body.id].dev = ctx.resolvedPkgsById[pkgResponse.body.id].dev || wantedDependency.dev
-    ctx.resolvedPkgsById[pkgResponse.body.id].optional = ctx.resolvedPkgsById[pkgResponse.body.id].optional && currentIsOptional
-    if (ctx.resolvedPkgsById[pkgResponse.body.id].fetching == null && pkgResponse.fetching != null) {
-      ctx.resolvedPkgsById[pkgResponse.body.id].fetching = pkgResponse.fetching
-      ctx.resolvedPkgsById[pkgResponse.body.id].filesIndexFile = pkgResponse.filesIndexFile!
+        resolution: pkgResponse.body.resolution,
+        version: pkgResponse.body.manifest.version,
+        normalizedBareSpecifier: pkgResponse.body.normalizedBareSpecifier,
+        pkg: pkgResponse.body.manifest,
+      }
     }
 
-    if (ctx.dependenciesTree.has(nodeId)) {
-      ctx.dependenciesTree.get(nodeId)!.depth = Math.min(ctx.dependenciesTree.get(nodeId)!.depth, options.currentDepth)
+    let prepare!: boolean
+    let hasBin!: boolean
+    let pkg: PackageManifest = getManifestFromResponse(pkgResponse, wantedDependency, currentPkg)
+    if (!pkg.dependencies) {
+      pkg.dependencies = {}
+    }
+    if (ctx.readPackageHook != null) {
+      pkg = await ctx.readPackageHook(pkg)
+    }
+    if (pkg.peerDependencies && pkg.dependencies) {
+      if (ctx.autoInstallPeers) {
+        pkg = {
+          ...pkg,
+          dependencies: omit(Object.keys(pkg.peerDependencies), pkg.dependencies),
+        }
+      } else {
+        pkg = {
+          ...pkg,
+          dependencies: omit(
+            Object.keys(pkg.peerDependencies).filter((peerDep) => options.parentPkgAliases[peerDep]),
+            pkg.dependencies
+          ),
+        }
+      }
+    }
+    if (pkg.engines?.runtime != null) {
+      convertEnginesRuntimeToDependencies(pkg, 'engines', 'dependencies')
+    }
+    if (!pkg.name) { // TODO: don't fail on optional dependencies
+      throw new PnpmError('MISSING_PACKAGE_NAME', `Can't install ${wantedDependency.bareSpecifier}: Missing package name`)
+    }
+    let pkgIdWithPatchHash = (pkgResponse.body.id.startsWith(`${pkg.name}@`) ? pkgResponse.body.id : `${pkg.name}@${pkgResponse.body.id}`) as PkgIdWithPatchHash
+    const patch = getPatchInfo(ctx.patchedDependencies, pkg.name, pkg.version)
+    if (patch) {
+      ctx.appliedPatches.add(patch.key)
+      pkgIdWithPatchHash = `${pkgIdWithPatchHash}(patch_hash=${patch.hash})` as PkgIdWithPatchHash
+    }
+
+    // We are building the dependency tree only until there are new packages
+    // or the packages repeat in a unique order.
+    // This is needed later during peer dependencies resolution.
+    //
+    // So we resolve foo > bar > qar > foo
+    // But we stop on foo > bar > qar > foo > qar
+    // In the second example, there's no reason to walk qar again
+    // when qar is included the first time, the dependencies of foo
+    // are already resolved and included as parent dependencies of qar.
+    // So during peers resolution, qar cannot possibly get any new or different
+    // peers resolved, after the first occurrence.
+    //
+    // However, in the next example we would analyze the second qar as well,
+    // because zoo is a new parent package:
+    // foo > bar > qar > zoo > qar
+    if (
+      parentIdsContainSequence(
+        options.parentIds,
+        options.parentPkg.pkgId,
+        pkgResponse.body.id
+      ) || pkgResponse.body.id === options.parentPkg.pkgId
+    ) {
+      return null
+    }
+
+    if (
+      !options.update && (currentPkg.dependencyLockfile != null) && currentPkg.depPath &&
+      !pkgResponse.body.updated &&
+      // peerDependencies field is also used for transitive peer dependencies which should not be linked
+      // That's why we cannot omit reading package.json of such dependencies.
+      // This can be removed if we implement something like peerDependenciesMeta.transitive: true
+      (currentPkg.dependencyLockfile.peerDependencies == null)
+    ) {
+      hasBin = currentPkg.dependencyLockfile.hasBin === true
+      pkg = {
+        ...nameVerFromPkgSnapshot(currentPkg.depPath, currentPkg.dependencyLockfile),
+        ...omitDepsFields(currentPkg.dependencyLockfile),
+        ...pkg,
+      }
     } else {
-      ctx.pendingNodes.push({
-        alias: wantedDependency.alias ?? pkgResponse.body.alias ?? pkg.name,
-        depth: options.currentDepth,
-        parentIds: options.parentIds,
-        installable,
-        lockedPeerContext: currentPkg.lockedPeerContext,
-        previousDepPath: currentPkg.depPath,
-        nodeId,
-        resolvedPackage: ctx.resolvedPkgsById[pkgResponse.body.id],
-      })
-    }
-  }
+      prepare = Boolean(
+        pkgResponse.body.resolvedVia === 'git-repository' &&
+        typeof pkg.scripts?.prepare === 'string'
+      )
 
-  const rootDir = pkgResponse.body.resolution.type === 'directory'
-    ? path.resolve(ctx.lockfileDir, (pkgResponse.body.resolution as DirectoryResolution).directory)
-    : options.prefix
-  let missingPeersOfChildren!: MissingPeersOfChildren | undefined
-  if (ctx.hoistPeers && !options.parentIds.includes(pkgResponse.body.id)) {
-    if (ctx.missingPeersOfChildrenByPkgId[pkgResponse.body.id]) {
-      // This if condition is used to avoid a dead lock.
-      // There might be a better way to hoist peer dependencies during resolution
-      // but it would probably require a big rewrite of the resolution algorithm.
       if (
-        ctx.missingPeersOfChildrenByPkgId[pkgResponse.body.id].depth >= options.currentDepth ||
-        ctx.missingPeersOfChildrenByPkgId[pkgResponse.body.id].missingPeersOfChildren.resolved
+        currentPkg.dependencyLockfile?.deprecated &&
+        !pkgResponse.body.updated && !pkg.deprecated
       ) {
-        missingPeersOfChildren = ctx.missingPeersOfChildrenByPkgId[pkgResponse.body.id].missingPeersOfChildren
+        pkg.deprecated = currentPkg.dependencyLockfile.deprecated
       }
-    } else {
-      const p = pDefer<MissingPeers>()
-      missingPeersOfChildren = {
-        resolve: p.resolve,
-        reject: p.reject,
-        get: pShare(p.promise),
-      }
-      ctx.missingPeersOfChildrenByPkgId[pkgResponse.body.id] = {
-        depth: options.currentDepth,
-        missingPeersOfChildren,
+      hasBin = (currentPkg.dependencyLockfile?.hasBin != null && !pkg.bin)
+        ? currentPkg.dependencyLockfile.hasBin
+        : Boolean((pkg.bin && !(pkg.bin === '' || Object.keys(pkg.bin).length === 0)) ?? pkg.directories?.bin)
+    }
+    if (options.currentDepth === 0 && pkgResponse.body.latest && pkgResponse.body.latest !== pkg.version) {
+      ctx.outdatedDependencies[pkgResponse.body.id] = pkgResponse.body.latest
+    }
+
+    if (pkg.peerDependencies != null) {
+      for (const name in pkg.peerDependencies) {
+        ctx.allPeerDepNames.add(name)
       }
     }
-  }
+    if (pkg.peerDependenciesMeta != null) {
+      for (const name in pkg.peerDependenciesMeta) {
+        ctx.allPeerDepNames.add(name)
+      }
+    }
+    // In case of leaf dependencies (dependencies that have no prod deps or peer deps),
+    // we only ever need to analyze one leaf dep in a graph, so the nodeId can be short and stateless.
+    const nodeId = pkgIsLeaf(pkg) ? pkgResponse.body.id as unknown as NodeId : nextNodeId()
 
-  const resolvedPkg = ctx.resolvedPkgsById[pkgResponse.body.id]
+    const parentIsInstallable = options.parentPkg.installable === undefined || options.parentPkg.installable
+    const installable = parentIsInstallable && pkgResponse.body.isInstallable !== false
+    const packageIsNew = !ctx.resolvedPkgsById[pkgResponse.body.id]
+    const parentImporterId = options.parentIds[0]
+    const currentIsOptional = wantedDependency.optional || options.parentPkg.optional
+    const childrenResolution = claimChildrenResolution(ctx, {
+      currentDepth: options.currentDepth,
+      parentIds: options.parentIds,
+      pkgId: pkgResponse.body.id,
+    })
+    const isNew = childrenResolution.isOwner
 
-  return {
-    alias: wantedDependency.alias ?? pkgResponse.body.alias ?? pkg.name,
-    depIsLinked,
-    resolvedVia: pkgResponse.body.resolvedVia,
-    isNew,
-    nodeId,
-    normalizedBareSpecifier: pkgResponse.body.normalizedBareSpecifier,
-    missingPeersOfChildren,
-    pkgId: pkgResponse.body.id,
-    rootDir,
-    missingPeers: getMissingPeers(pkg),
-    optional: resolvedPkg.optional,
-    version: resolvedPkg.version,
-    saveCatalogName: wantedDependency.saveCatalogName,
+    if (packageIsNew) {
+      if (
+        pkg.deprecated &&
+        (!ctx.allowedDeprecatedVersions[pkg.name] || !semver.satisfies(pkg.version, ctx.allowedDeprecatedVersions[pkg.name]))
+      ) {
+        // Report deprecated packages only on first occurrence.
+        deprecationLogger.debug({
+          deprecated: pkg.deprecated,
+          depth: options.currentDepth,
+          pkgId: pkgResponse.body.id,
+          pkgName: pkg.name,
+          pkgVersion: pkg.version,
+          prefix: options.prefix,
+        })
+      }
+      if (pkgResponse.body.isInstallable === false || !parentIsInstallable) {
+        ctx.skipped.add(pkgResponse.body.id)
+      }
+      progressLogger.debug({
+        packageId: pkgResponse.body.id,
+        requester: ctx.lockfileDir,
+        status: 'resolved',
+      })
 
-    // Next fields are actually only needed when isNew = true
-    installable,
-    isLinkedDependency: undefined,
-    pkg,
-    updated: pkgResponse.body.updated,
-    publishedAt: pkgResponse.body.publishedAt,
+      // WARN: It is very important to keep this sync
+      // Otherwise, deprecation messages for the same package might get written several times
+      ctx.resolvedPkgsById[pkgResponse.body.id] = getResolvedPackage({
+        dependencyLockfile: currentPkg.dependencyLockfile,
+        pkgIdWithPatchHash,
+        force: ctx.force,
+        hasBin,
+        patch,
+        pkg,
+        pkgResponse,
+        prepare,
+        wantedDependency,
+        parentImporterId,
+        optional: currentIsOptional,
+      })
+    } else {
+      ctx.resolvedPkgsById[pkgResponse.body.id].prod = ctx.resolvedPkgsById[pkgResponse.body.id].prod || !wantedDependency.dev && !wantedDependency.optional
+      ctx.resolvedPkgsById[pkgResponse.body.id].dev = ctx.resolvedPkgsById[pkgResponse.body.id].dev || wantedDependency.dev
+      ctx.resolvedPkgsById[pkgResponse.body.id].optional = ctx.resolvedPkgsById[pkgResponse.body.id].optional && currentIsOptional
+      if (ctx.resolvedPkgsById[pkgResponse.body.id].fetching == null && pkgResponse.fetching != null) {
+        ctx.resolvedPkgsById[pkgResponse.body.id].fetching = pkgResponse.fetching
+        ctx.resolvedPkgsById[pkgResponse.body.id].filesIndexFile = pkgResponse.filesIndexFile!
+      }
+
+      if (!isNew) {
+        if (ctx.dependenciesTree.has(nodeId)) {
+          ctx.dependenciesTree.get(nodeId)!.depth = Math.min(ctx.dependenciesTree.get(nodeId)!.depth, options.currentDepth)
+        } else {
+          ctx.pendingNodes.push({
+            alias: wantedDependency.alias ?? pkgResponse.body.alias ?? pkg.name,
+            depth: options.currentDepth,
+            parentIds: options.parentIds,
+            installable,
+            lockedPeerContext: currentPkg.lockedPeerContext,
+            previousDepPath: currentPkg.depPath,
+            nodeId,
+            resolvedPackage: ctx.resolvedPkgsById[pkgResponse.body.id],
+          })
+        }
+      }
+    }
+
+    const rootDir = pkgResponse.body.resolution.type === 'directory'
+      ? path.resolve(ctx.lockfileDir, (pkgResponse.body.resolution as DirectoryResolution).directory)
+      : options.prefix
+    const missingPeersOfChildren = childrenResolution.missingPeersOfChildren
+
+    const resolvedPkg = ctx.resolvedPkgsById[pkgResponse.body.id]
+
+    return {
+      alias: wantedDependency.alias ?? pkgResponse.body.alias ?? pkg.name,
+      depIsLinked,
+      resolvedVia: pkgResponse.body.resolvedVia,
+      isNew,
+      nodeId,
+      normalizedBareSpecifier: pkgResponse.body.normalizedBareSpecifier,
+      missingPeersOfChildren,
+      childrenResolutionId: childrenResolution.id,
+      pkgId: pkgResponse.body.id,
+      rootDir,
+      missingPeers: getMissingPeers(pkg),
+      optional: resolvedPkg.optional,
+      version: resolvedPkg.version,
+      saveCatalogName: wantedDependency.saveCatalogName,
+
+      // Next fields are actually only needed when isNew = true
+      installable,
+      isLinkedDependency: undefined,
+      pkg,
+      updated: pkgResponse.body.updated,
+      publishedAt: pkgResponse.body.publishedAt,
+    }
+  } finally {
+    finishPackageResolution()
   }
 }
 

--- a/installing/deps-resolver/src/resolveDependencyTree.ts
+++ b/installing/deps-resolver/src/resolveDependencyTree.ts
@@ -23,9 +23,9 @@ import type {
 import { partition } from 'ramda'
 
 import type { WantedDependency } from './getNonDevWantedDependencies.js'
-import { nextNodeId, type NodeId } from './nextNodeId.js'
-import { parentIdsContainSequence } from './parentIdsContainSequence.js'
+import type { NodeId } from './nextNodeId.js'
 import {
+  buildTree,
   type ChildrenByParentId,
   type DependenciesTree,
   type ImporterToResolve,
@@ -226,6 +226,14 @@ export async function resolveDependencyTree<T> (
     allPeerDepNames: new Set(),
     maximumPublishedBy: publishedBy,
     publishedByExclude,
+    packageResolutionBarrier: {
+      activeByDepth: new Map(),
+      waiters: [],
+    },
+    childrenResolutionByPkgId: {},
+    childrenResolutionId: 0,
+    importerResolutionOrder: Object.fromEntries(importers.map(({ id }, index) => [id, index])),
+    nodeResolutionContextByNodeId: new Map(),
     trustPolicy: opts.trustPolicy,
     trustPolicyExclude: opts.trustPolicyExclude ? createPackageVersionPolicyOrThrow(opts.trustPolicyExclude, 'trustPolicyExclude') : undefined,
     trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
@@ -358,51 +366,6 @@ export async function resolveDependencyTree<T> (
     allPeerDepNames: ctx.allPeerDepNames,
     resolutionPolicyViolations: ctx.resolutionPolicyViolations,
   }
-}
-
-function buildTree (
-  ctx: {
-    childrenByParentId: ChildrenByParentId
-    dependenciesTree: DependenciesTree<ResolvedPackage>
-    resolvedPkgsById: ResolvedPkgsById
-    skipped: Set<PkgResolutionId>
-  },
-  parentId: PkgResolutionId,
-  parentIds: PkgResolutionId[],
-  children: Array<{ alias: string, id: PkgResolutionId }>,
-  depth: number,
-  installable: boolean
-): Record<string, NodeId> {
-  const childrenNodeIds: Record<string, NodeId> = {}
-  for (const child of children) {
-    if (child.id.startsWith('link:')) {
-      childrenNodeIds[child.alias] = child.id as unknown as NodeId
-      continue
-    }
-    if (parentIdsContainSequence(parentIds, parentId, child.id) || parentId === child.id) {
-      continue
-    }
-    if (ctx.resolvedPkgsById[child.id].isLeaf) {
-      childrenNodeIds[child.alias] = child.id as unknown as NodeId
-      continue
-    }
-    const childNodeId = nextNodeId()
-    childrenNodeIds[child.alias] = childNodeId
-    installable = installable || !ctx.skipped.has(child.id)
-    ctx.dependenciesTree.set(childNodeId, {
-      children: () => buildTree(ctx,
-        child.id,
-        [...parentIds, child.id],
-        ctx.childrenByParentId[child.id],
-        depth + 1,
-        installable
-      ),
-      depth,
-      installable,
-      resolvedPackage: ctx.resolvedPkgsById[child.id],
-    })
-  }
-  return childrenNodeIds
 }
 
 /**

--- a/installing/deps-resolver/test/resolveDependencyTree.test.ts
+++ b/installing/deps-resolver/test/resolveDependencyTree.test.ts
@@ -1,0 +1,208 @@
+import { expect, test } from '@jest/globals'
+import type { LockfileObject } from '@pnpm/lockfile.types'
+import type { PreferredVersions } from '@pnpm/resolving.resolver-base'
+import type { PackageResponse, StoreController } from '@pnpm/store.controller-types'
+import type { PackageManifest, PkgResolutionId, ProjectId, ProjectRootDir } from '@pnpm/types'
+
+import { type ImporterToResolveGeneric, type ResolveDependenciesOptions, resolveDependencyTree } from '../lib/resolveDependencyTree.js'
+
+test('shared package children are resolved from the deterministic shallowest context', async () => {
+  const requestLog: Array<{
+    alias: string
+    bareSpecifier: string
+    resolvedId: string
+  }> = []
+  const storeController = createStoreController(async (wantedDependency, options) => {
+    if (wantedDependency.alias === 'shared' && !hasPreferredVersion(options.preferredVersions, 'provider', '1.0.0')) {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+    const alias = wantedDependency.alias!
+    const bareSpecifier = wantedDependency.bareSpecifier!
+    const version = pickVersion(alias, bareSpecifier, options.preferredVersions)
+    const resolvedId = `${alias}@${version}`
+    requestLog.push({
+      alias,
+      bareSpecifier,
+      resolvedId,
+    })
+    return createPackageResponse(resolvedId)
+  })
+  const lockfile = createLockfile()
+
+  const result = await resolveDependencyTree([
+    {
+      id: '.' as ProjectId,
+      manifest: {
+        name: 'root',
+        version: '0.0.0',
+        dependencies: {
+          a: '1.0.0',
+          c: '1.0.0',
+        },
+      },
+      modulesDir: '/project/node_modules',
+      rootDir: '/project' as ProjectRootDir,
+      updatePackageManifest: false,
+      wantedDependencies: [
+        {
+          alias: 'a',
+          bareSpecifier: '1.0.0',
+          dev: false,
+          optional: false,
+          updateDepth: 0,
+        },
+        {
+          alias: 'c',
+          bareSpecifier: '1.0.0',
+          dev: false,
+          optional: false,
+          updateDepth: 0,
+        },
+      ],
+    } satisfies ImporterToResolveGeneric<object>,
+  ], {
+    allowedDeprecatedVersions: {},
+    allowUnusedPatches: false,
+    currentLockfile: lockfile,
+    dryRun: false,
+    engineStrict: false,
+    force: false,
+    forceFullResolution: false,
+    hooks: {},
+    lockfileDir: '/project',
+    pnpmVersion: '0.0.0',
+    registries: {
+      default: 'https://registry.npmjs.org/',
+    },
+    storeController,
+    tag: 'latest',
+    virtualStoreDir: '/project/node_modules/.pnpm',
+    globalVirtualStoreDir: '/project/node_modules/.pnpm/global',
+    virtualStoreDirMaxLength: 120,
+    wantedLockfile: lockfile,
+    workspacePackages: new Map(),
+    peersSuffixMaxLength: 1000,
+    dedupePeerDependents: true,
+  } satisfies ResolveDependenciesOptions)
+
+  expect(requestLog
+    .filter(({ alias, bareSpecifier }) => alias === 'provider' && bareSpecifier === '*')
+    .map(({ resolvedId }) => resolvedId)
+  ).toStrictEqual(['provider@2.0.0'])
+
+  const sharedChildren = Array.from(result.dependenciesTree.values())
+    .filter(({ resolvedPackage }) => resolvedPackage.name === 'shared')
+    .map((node) => typeof node.children === 'function' ? node.children() : node.children)
+
+  expect(sharedChildren).toHaveLength(2)
+  expect(sharedChildren.map(({ provider }) => provider)).toStrictEqual([
+    'provider@2.0.0',
+    'provider@2.0.0',
+  ])
+})
+
+function hasPreferredVersion (preferredVersions: PreferredVersions, alias: string, version: string): boolean {
+  return Boolean(preferredVersions[alias]?.[version])
+}
+
+function pickVersion (alias: string, bareSpecifier: string, preferredVersions: PreferredVersions): string {
+  if (alias === 'provider' && bareSpecifier === '*') {
+    return hasPreferredVersion(preferredVersions, alias, '1.0.0') ? '1.0.0' : '2.0.0'
+  }
+  return bareSpecifier
+}
+
+function createLockfile (): LockfileObject {
+  return {
+    lockfileVersion: '9.0',
+    importers: {
+      ['.' as ProjectId]: {
+        specifiers: {},
+      },
+    },
+    packages: {},
+  }
+}
+
+function createPackageResponse (pkgId: string): PackageResponse {
+  const manifest = manifests[pkgId]
+  return {
+    body: {
+      id: pkgId as PkgResolutionId,
+      isLocal: false,
+      manifest,
+      resolution: {
+        tarball: `https://registry.npmjs.org/${manifest.name}/-/${manifest.name}-${manifest.version}.tgz`,
+      },
+      updated: false,
+    },
+    fetching: async () => ({
+      files: {
+        filesMap: new Map(),
+        requiresBuild: false,
+        resolvedFrom: 'remote',
+      },
+    }),
+    filesIndexFile: `${pkgId}-index.json`,
+  }
+}
+
+function createStoreController (
+  requestPackage: StoreController['requestPackage']
+): StoreController {
+  return {
+    requestPackage,
+    fetchPackage: () => {
+      throw new Error('fetchPackage should not be called')
+    },
+    getFilesIndexFilePath: () => ({
+      filesIndexFile: '',
+      target: '',
+    }),
+    importPackage: async () => ({ isBuilt: false, importMethod: undefined }),
+    close: async () => undefined,
+    prune: async () => undefined,
+    upload: async () => undefined,
+    clearResolutionCache: () => undefined,
+  }
+}
+
+const manifests: Record<string, PackageManifest> = {
+  'a@1.0.0': {
+    name: 'a',
+    version: '1.0.0',
+    dependencies: {
+      provider: '1.0.0',
+      b: '1.0.0',
+    },
+  },
+  'b@1.0.0': {
+    name: 'b',
+    version: '1.0.0',
+    dependencies: {
+      shared: '1.0.0',
+    },
+  },
+  'c@1.0.0': {
+    name: 'c',
+    version: '1.0.0',
+    dependencies: {
+      shared: '1.0.0',
+    },
+  },
+  'provider@1.0.0': {
+    name: 'provider',
+    version: '1.0.0',
+  },
+  'provider@2.0.0': {
+    name: 'provider',
+    version: '2.0.0',
+  },
+  'shared@1.0.0': {
+    name: 'shared',
+    version: '1.0.0',
+    dependencies: {
+      provider: '*',
+    },
+  },
+}

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -493,6 +493,21 @@ pub(crate) type WantedSpec = (String, String, bool, bool);
 /// `optionalDependencies` sections.
 type ChildSpec = (String, String, bool);
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ChildrenOwner {
+    depth: i32,
+    importer_order: usize,
+    parent_path: Vec<String>,
+    importer_id: String,
+}
+
+impl ChildrenOwner {
+    fn wins_over(&self, other: &Self) -> bool {
+        (&self.depth, &self.importer_order, &self.parent_path)
+            < (&other.depth, &other.importer_order, &other.parent_path)
+    }
+}
+
 /// Workspace-shared maps. Every per-importer [`TreeCtx`] in a
 /// multi-importer install holds an `Arc<WorkspaceTreeCtx>` so the
 /// resolver's per-`pkgIdWithPatchHash` dedup (`packages`,
@@ -517,6 +532,8 @@ pub struct WorkspaceTreeCtx {
         Mutex<HashMap<WantedKey, Arc<pacquet_resolving_resolver_base::ResolveResult>>>,
     children_specs_by_id: Mutex<HashMap<String, Arc<Vec<ChildSpec>>>>,
     children_by_id: Mutex<HashMap<String, Arc<Vec<crate::resolved_tree::ChildEdge>>>>,
+    children_owner_by_id: Mutex<HashMap<String, ChildrenOwner>>,
+    node_parent_ids_by_id: Mutex<HashMap<NodeId, Arc<Vec<String>>>>,
     manifest_hook: Option<ManifestHook>,
     /// The previous `pnpm-lock.yaml` the install started from, when one
     /// exists. Consulted by `resolve_node` to reuse an already-resolved
@@ -553,19 +570,16 @@ pub struct WorkspaceTreeCtx {
     /// point doesn't thread registries (then `currentPkg` is withheld
     /// for `Registry`-shaped entries rather than sent without a URL).
     registries: HashMap<String, String>,
-    /// `pkg id → importer id` of the importer whose walk first resolved
-    /// each package. Mirrors the ownership implied by upstream's
+    /// `pkg id → importer id` of the importer whose occurrence owns
+    /// that package's shared children context. Ownership is chosen by
+    /// `(depth, importer order, parent path)`, mirroring upstream's
     /// per-`pkgId` shared subtree records
     /// ([`missingPeersOfChildrenByPkgId`](https://github.com/pnpm/pnpm/blob/a751c7f27d/installing/deps-resolver/src/resolveDependencies.ts#L193)):
-    /// a package revisited under a later importer does not recompute
-    /// its children's missing-peer report, so that importer's
-    /// peer-hoist must not see missing peers declared inside a
-    /// subtree first resolved elsewhere. Consumed via
-    /// [`crate::HoistMissingScope`].
+    /// a non-owner occurrence reuses the owner occurrence's children
+    /// and missing-peer report. Consumed via [`crate::HoistMissingScope`].
     first_importer_by_pkg: Mutex<HashMap<String, String>>,
-    /// Per package: the missing-peer names reported by the first
-    /// peer-walk that visited it (the walk of the importer that
-    /// claimed the package). Consumed via [`crate::HoistMissingScope`].
+    /// Per package: the missing-peer names reported under the current
+    /// children-owner context. Consumed via [`crate::HoistMissingScope`].
     first_walk_missing_by_pkg: Mutex<HashMap<String, HashSet<String>>>,
 }
 
@@ -580,6 +594,8 @@ impl Default for WorkspaceTreeCtx {
             resolved_by_wanted: Mutex::new(HashMap::new()),
             children_specs_by_id: Mutex::new(HashMap::new()),
             children_by_id: Mutex::new(HashMap::new()),
+            children_owner_by_id: Mutex::new(HashMap::new()),
+            node_parent_ids_by_id: Mutex::new(HashMap::new()),
             manifest_hook: None,
             wanted_lockfile: None,
             update_reuse_scope: UpdateReuseScope::All,
@@ -638,25 +654,39 @@ impl WorkspaceTreeCtx {
         self.wanted_lockfile.as_ref()
     }
 
-    /// Snapshot of `pkg id → first-resolving importer id`. See the
-    /// field doc.
+    /// Snapshot of `pkg id → children-owner importer id`. See the field doc.
     #[must_use]
     pub fn first_importer_by_pkg(&self) -> HashMap<String, String> {
         lock_recoverable(&self.first_importer_by_pkg).clone()
     }
 
-    /// Record a walk's per-package missing-peer names; the first walk
-    /// to visit a package wins. See the `first_walk_missing_by_pkg`
-    /// field doc.
-    pub fn record_first_walk_missing(&self, missing_by_pkg: &HashMap<String, HashSet<String>>) {
+    /// Record a walk's per-package missing-peer names when the current
+    /// importer owns that package's shared children context. See the
+    /// `first_walk_missing_by_pkg` field doc.
+    pub fn record_first_walk_missing(
+        &self,
+        importer_id: &str,
+        missing_by_pkg: &HashMap<String, HashSet<String>>,
+    ) {
+        let owners = lock_recoverable(&self.children_owner_by_id).clone();
         let mut record = lock_recoverable(&self.first_walk_missing_by_pkg);
+        for (pkg_id, owner) in &owners {
+            if owner.importer_id == importer_id {
+                record.insert(
+                    pkg_id.clone(),
+                    missing_by_pkg.get(pkg_id).cloned().unwrap_or_default(),
+                );
+            }
+        }
         for (pkg_id, names) in missing_by_pkg {
-            record.entry(pkg_id.clone()).or_insert_with(|| names.clone());
+            if owners.get(pkg_id).is_none_or(|owner| owner.importer_id != importer_id) {
+                record.entry(pkg_id.clone()).or_insert_with(|| names.clone());
+            }
         }
     }
 
-    /// Snapshot of the per-package first-walk missing-peer names. See
-    /// the `first_walk_missing_by_pkg` field doc.
+    /// Snapshot of the per-package owner-context missing-peer names.
+    /// See the `first_walk_missing_by_pkg` field doc.
     #[must_use]
     pub fn first_walk_missing_by_pkg(&self) -> HashMap<String, HashSet<String>> {
         lock_recoverable(&self.first_walk_missing_by_pkg).clone()
@@ -764,9 +794,10 @@ pub struct TreeCtx {
     /// install.
     patched_dependencies: Option<Arc<PatchGroupRecord>>,
     /// The importer this per-importer context walks for. Recorded into
-    /// [`WorkspaceTreeCtx`]'s `first_importer_by_pkg` when a package is
-    /// first resolved.
+    /// [`WorkspaceTreeCtx`]'s `first_importer_by_pkg` when one of its
+    /// occurrences owns a package's shared children context.
     importer_id: String,
+    importer_order: usize,
 }
 
 impl TreeCtx {
@@ -783,6 +814,7 @@ impl TreeCtx {
             workspace: Arc::new(WorkspaceTreeCtx::default()),
             patched_dependencies: None,
             importer_id: pacquet_lockfile::Lockfile::ROOT_IMPORTER_KEY.to_string(),
+            importer_order: 0,
         }
     }
 
@@ -798,6 +830,7 @@ impl TreeCtx {
             workspace,
             patched_dependencies: None,
             importer_id: pacquet_lockfile::Lockfile::ROOT_IMPORTER_KEY.to_string(),
+            importer_order: 0,
         }
     }
 
@@ -848,6 +881,15 @@ impl TreeCtx {
     #[must_use]
     pub fn with_importer_id(mut self, importer_id: &str) -> Self {
         self.importer_id = importer_id.to_string();
+        self
+    }
+
+    /// Set this importer's position in the workspace input order.
+    /// Child-subtree ownership uses it after depth, matching pnpm's
+    /// deterministic `(depth, importer order, parent path)` tie-break.
+    #[must_use]
+    pub fn with_importer_order(mut self, importer_order: usize) -> Self {
+        self.importer_order = importer_order;
         self
     }
 
@@ -1220,11 +1262,9 @@ where
     // flag so a single non-optional path flips it back to `false`.
     // Mirrors upstream's
     // [`resolvedPkgsById[...].optional = ... && currentIsOptional`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1630)
-    // arm. The `is_revisit` flag flows into the children handling
-    // below: a revisit can produce a [`TreeChildren::Lazy`] node
-    // because the first visit already populated
-    // [`WorkspaceTreeCtx`]'s `children_by_id` for this pkg, and revisits don't
-    // discover new transitive packages.
+    // arm. Child traversal is claimed separately below, so a later
+    // deterministically-better occurrence can replace the shared
+    // `children_by_id` entry without rewriting the package envelope.
     // Leaves (no deps / optional deps / peers / peerDependenciesMeta)
     // reuse the package id as their `NodeId`, collapsing every parent
     // edge onto one tree node. Non-leaves still get a fresh per-
@@ -1251,12 +1291,10 @@ where
     let is_leaf = is_link || pkg_is_leaf(&result);
     let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };
 
-    let is_revisit;
     {
         let mut packages = lock_recoverable(&ctx.workspace.packages);
         if let Some(existing) = packages.get_mut(&id) {
             existing.optional = existing.optional && current_is_optional;
-            is_revisit = true;
         } else {
             let peer_dependencies =
                 if is_link { BTreeMap::new() } else { extract_peer_dependencies(&result) };
@@ -1278,39 +1316,25 @@ where
                     is_leaf,
                 },
             );
-            lock_recoverable(&ctx.workspace.first_importer_by_pkg)
-                .entry(id.clone())
-                .or_insert_with(|| ctx.importer_id.clone());
-            is_revisit = false;
         }
     }
 
     let next_ancestors: Vec<String> =
         ancestor_ids.iter().cloned().chain(std::iter::once(id.clone())).collect();
+    let next_ancestors = Arc::new(next_ancestors);
+    let children_owner = claim_children_owner(ctx, &id, depth, ancestor_ids);
 
-    // **Revisit short-circuit (lazy children).** The first walk of
-    // this package populated `children_by_id[id]` with the resolved
-    // child pkg_ids — revisits skip the per-child recursion and
-    // emit a [`TreeChildren::Lazy`] entry instead. The peer-resolver's
-    // `realize_children` walks the cached `children_by_id` to
-    // allocate per-occurrence `NodeId`s on demand, applying the same
-    // `parent_ids` cycle-break upstream's `buildTree` does. Mirrors
-    // upstream's
-    // [`isNew` skip](https://github.com/pnpm/pnpm/blob/c86c423bdc/installing/deps-resolver/src/resolveDependencies.ts#L1584):
-    // a second visit doesn't rebuild the subtree.
-    //
-    // First visits still walk eagerly so `children_by_id`,
-    // `packages`, `all_peer_dep_names`, and the per-pkg resolver
-    // caches get populated for every transitive package — without
-    // that pass, lazy revisits would have nothing to expand.
+    // Only the deterministic children owner walks this package's
+    // manifest children. Other occurrences stay lazy and expand from
+    // `children_by_id`, applying their own `parent_ids` cycle break.
     let children = if is_link {
         // Linked nodes don't walk their manifest's deps — see the
         // `is_link` comment block above. Empty `Realized` map matches
         // upstream's `children: {}` for the `isLinkedDependency`
         // branch.
         crate::resolved_tree::TreeChildren::Realized(BTreeMap::new())
-    } else if is_revisit {
-        crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::new(next_ancestors.clone()) }
+    } else if !children_owner.owns_children {
+        crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::clone(&next_ancestors) }
     } else {
         // Look up cached children specs first; only walk the manifest on
         // a miss. The cache value is held by `Arc` so revisits clone the
@@ -1350,7 +1374,7 @@ where
                 };
                 let child_prior = prior_children_snapshot
                     .and_then(|snapshot| prior_child_key(snapshot, child_name, child_range));
-                let next_ancestors = next_ancestors.clone();
+                let next_ancestors = Arc::clone(&next_ancestors);
                 async move {
                     resolve_node(
                         ctx,
@@ -1366,29 +1390,31 @@ where
             })
             .pipe(future::try_join_all)
             .await?;
-        // Build the realized `(alias → NodeId)` map for THIS
-        // occurrence and the per-pkg `children_by_id` entry future
-        // revisits will reuse. `children_by_id` records the resolved
-        // child pkg ids (not NodeIds) plus the `optional` flag so
-        // lazy realisation can thread `current_is_optional` correctly.
-        let mut realized: BTreeMap<String, NodeId> = BTreeMap::new();
-        let mut by_id: Vec<crate::resolved_tree::ChildEdge> = Vec::new();
-        // Build a spec → optional map to look up each child's `optional` flag.
-        let optional_by_alias: HashMap<&str, bool> =
-            child_specs.iter().map(|(name, _, optional)| (name.as_str(), *optional)).collect();
-        for dep in child_results.into_iter().flatten() {
-            let optional = optional_by_alias.get(dep.alias.as_str()).copied().unwrap_or(false);
-            by_id.push(crate::resolved_tree::ChildEdge {
-                alias: dep.alias.clone(),
-                pkg_id: dep.id.clone(),
-                optional,
-            });
-            realized.insert(dep.alias, dep.node_id);
+        if is_current_children_owner(ctx, &id, &children_owner.owner) {
+            // Build the realized `(alias → NodeId)` map for THIS
+            // occurrence and the per-pkg `children_by_id` entry future
+            // revisits will reuse. `children_by_id` records the resolved
+            // child pkg ids (not NodeIds) plus the `optional` flag so
+            // lazy realisation can thread `current_is_optional` correctly.
+            let mut realized: BTreeMap<String, NodeId> = BTreeMap::new();
+            let mut by_id: Vec<crate::resolved_tree::ChildEdge> = Vec::new();
+            // Build a spec → optional map to look up each child's `optional` flag.
+            let optional_by_alias: HashMap<&str, bool> =
+                child_specs.iter().map(|(name, _, optional)| (name.as_str(), *optional)).collect();
+            for dep in child_results.into_iter().flatten() {
+                let optional = optional_by_alias.get(dep.alias.as_str()).copied().unwrap_or(false);
+                by_id.push(crate::resolved_tree::ChildEdge {
+                    alias: dep.alias.clone(),
+                    pkg_id: dep.id.clone(),
+                    optional,
+                });
+                realized.insert(dep.alias, dep.node_id);
+            }
+            lock_recoverable(&ctx.workspace.children_by_id).insert(id.clone(), Arc::new(by_id));
+            crate::resolved_tree::TreeChildren::Realized(realized)
+        } else {
+            crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::clone(&next_ancestors) }
         }
-        lock_recoverable(&ctx.workspace.children_by_id)
-            .entry(id.clone())
-            .or_insert_with(|| Arc::new(by_id));
-        crate::resolved_tree::TreeChildren::Realized(realized)
     };
 
     // Repeat-visit leaves collapse onto one tree node; keep the
@@ -1402,6 +1428,7 @@ where
     // short-circuits them in `resolve_node`. Mirrors upstream's
     // `depth: -1` on the `isLinkedDependency` arm.
     let node_depth = if is_link { -1 } else { depth };
+    remember_node_parent_ids(ctx, &node_id, Arc::clone(&next_ancestors));
     lock_recoverable(&ctx.workspace.dependencies_tree)
         .entry(node_id.clone())
         .and_modify(|node| {
@@ -1415,6 +1442,9 @@ where
             depth: node_depth,
             installable: true,
         });
+    if children_owner.owns_children && is_current_children_owner(ctx, &id, &children_owner.owner) {
+        make_non_owner_nodes_lazy(ctx, &id, &node_id);
+    }
 
     Ok(Some(DirectDep { alias, node_id, id }))
 }
@@ -1436,6 +1466,65 @@ fn landed_on_prior_entry(prior_key: &PkgNameVerPeer, resolved_pkg_id: &str) -> b
 struct ReusedNode {
     key: PkgNameVerPeer,
     result: pacquet_resolving_resolver_base::ResolveResult,
+}
+
+struct ChildrenOwnerClaim {
+    owner: ChildrenOwner,
+    owns_children: bool,
+}
+
+fn claim_children_owner(
+    ctx: &TreeCtx,
+    pkg_id: &str,
+    depth: i32,
+    ancestor_ids: &[String],
+) -> ChildrenOwnerClaim {
+    let owner = ChildrenOwner {
+        depth,
+        importer_order: ctx.importer_order,
+        parent_path: ancestor_ids.to_vec(),
+        importer_id: ctx.importer_id.clone(),
+    };
+    let owns_children = {
+        let mut owners = lock_recoverable(&ctx.workspace.children_owner_by_id);
+        match owners.get(pkg_id) {
+            Some(existing) if !owner.wins_over(existing) => false,
+            _ => {
+                owners.insert(pkg_id.to_string(), owner.clone());
+                true
+            }
+        }
+    };
+    if owns_children {
+        lock_recoverable(&ctx.workspace.first_importer_by_pkg)
+            .insert(pkg_id.to_string(), owner.importer_id.clone());
+    }
+    ChildrenOwnerClaim { owner, owns_children }
+}
+
+fn is_current_children_owner(ctx: &TreeCtx, pkg_id: &str, owner: &ChildrenOwner) -> bool {
+    lock_recoverable(&ctx.workspace.children_owner_by_id)
+        .get(pkg_id)
+        .is_some_and(|current| current == owner)
+}
+
+fn remember_node_parent_ids(ctx: &TreeCtx, node_id: &NodeId, parent_ids: Arc<Vec<String>>) {
+    lock_recoverable(&ctx.workspace.node_parent_ids_by_id).insert(node_id.clone(), parent_ids);
+}
+
+fn make_non_owner_nodes_lazy(ctx: &TreeCtx, pkg_id: &str, owner_node_id: &NodeId) {
+    let parent_ids_by_node = lock_recoverable(&ctx.workspace.node_parent_ids_by_id).clone();
+    let mut tree = lock_recoverable(&ctx.workspace.dependencies_tree);
+    for (node_id, node) in tree.iter_mut() {
+        if node_id == owner_node_id || node.resolved_package_id != pkg_id {
+            continue;
+        }
+        let Some(parent_ids) = parent_ids_by_node.get(node_id) else {
+            continue;
+        };
+        node.children =
+            crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::clone(parent_ids) };
+    }
 }
 
 /// Decide whether the current edge can reuse the prior lockfile's
@@ -1621,12 +1710,10 @@ where
     let is_leaf = child_refs.is_empty() && peer_dependencies.is_empty();
     let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };
 
-    let is_revisit;
     {
         let mut packages = lock_recoverable(&ctx.workspace.packages);
         if let Some(existing) = packages.get_mut(&id) {
             existing.optional = existing.optional && current_is_optional;
-            is_revisit = true;
         } else {
             {
                 let mut all_peers = lock_recoverable(&ctx.workspace.all_peer_dep_names);
@@ -1644,19 +1731,15 @@ where
                     is_leaf,
                 },
             );
-            lock_recoverable(&ctx.workspace.first_importer_by_pkg)
-                .entry(id.clone())
-                .or_insert_with(|| ctx.importer_id.clone());
-            is_revisit = false;
         }
     }
 
     let next_ancestors: Vec<String> =
         ancestor_ids.iter().cloned().chain(std::iter::once(id.clone())).collect();
+    let next_ancestors = Arc::new(next_ancestors);
+    let children_owner = claim_children_owner(ctx, &id, depth, ancestor_ids);
 
-    let children = if is_revisit {
-        crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::new(next_ancestors.clone()) }
-    } else {
+    let children = if children_owner.owns_children {
         let child_results = child_refs
             .iter()
             .map(|(child_alias, child_key)| {
@@ -1669,7 +1752,7 @@ where
                     bare_specifier: Some(child_key.suffix.without_peer().to_string()),
                     ..WantedDependency::default()
                 };
-                let next_ancestors = next_ancestors.clone();
+                let next_ancestors = Arc::clone(&next_ancestors);
                 let child_key = child_key.clone();
                 async move {
                     resolve_node(
@@ -1686,27 +1769,32 @@ where
             })
             .pipe(future::try_join_all)
             .await?;
-        let mut realized: BTreeMap<String, NodeId> = BTreeMap::new();
-        let mut by_id: Vec<crate::resolved_tree::ChildEdge> = Vec::new();
-        let optional_by_alias: HashMap<&str, bool> = child_refs
-            .iter()
-            .map(|(alias, _)| (alias.as_str(), is_optional_child(snapshot, alias)))
-            .collect();
-        for dep in child_results.into_iter().flatten() {
-            let optional = optional_by_alias.get(dep.alias.as_str()).copied().unwrap_or(false);
-            by_id.push(crate::resolved_tree::ChildEdge {
-                alias: dep.alias.clone(),
-                pkg_id: dep.id.clone(),
-                optional,
-            });
-            realized.insert(dep.alias, dep.node_id);
+        if is_current_children_owner(ctx, &id, &children_owner.owner) {
+            let mut realized: BTreeMap<String, NodeId> = BTreeMap::new();
+            let mut by_id: Vec<crate::resolved_tree::ChildEdge> = Vec::new();
+            let optional_by_alias: HashMap<&str, bool> = child_refs
+                .iter()
+                .map(|(alias, _)| (alias.as_str(), is_optional_child(snapshot, alias)))
+                .collect();
+            for dep in child_results.into_iter().flatten() {
+                let optional = optional_by_alias.get(dep.alias.as_str()).copied().unwrap_or(false);
+                by_id.push(crate::resolved_tree::ChildEdge {
+                    alias: dep.alias.clone(),
+                    pkg_id: dep.id.clone(),
+                    optional,
+                });
+                realized.insert(dep.alias, dep.node_id);
+            }
+            lock_recoverable(&ctx.workspace.children_by_id).insert(id.clone(), Arc::new(by_id));
+            crate::resolved_tree::TreeChildren::Realized(realized)
+        } else {
+            crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::clone(&next_ancestors) }
         }
-        lock_recoverable(&ctx.workspace.children_by_id)
-            .entry(id.clone())
-            .or_insert_with(|| Arc::new(by_id));
-        crate::resolved_tree::TreeChildren::Realized(realized)
+    } else {
+        crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::clone(&next_ancestors) }
     };
 
+    remember_node_parent_ids(ctx, &node_id, Arc::clone(&next_ancestors));
     lock_recoverable(&ctx.workspace.dependencies_tree)
         .entry(node_id.clone())
         .and_modify(|node| {
@@ -1720,6 +1808,9 @@ where
             depth,
             installable: true,
         });
+    if children_owner.owns_children && is_current_children_owner(ctx, &id, &children_owner.owner) {
+        make_non_owner_nodes_lazy(ctx, &id, &node_id);
+    }
 
     Ok(Some(DirectDep { alias, node_id, id }))
 }

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -235,6 +235,7 @@ where
     resolve_importer_with_workspace(
         resolver,
         pacquet_lockfile::Lockfile::ROOT_IMPORTER_KEY,
+        0,
         manifest,
         dependency_groups,
         opts,
@@ -252,6 +253,7 @@ where
 pub async fn resolve_importer_with_workspace<DependencyGroupList, Chain>(
     resolver: &Chain,
     importer_id: &str,
+    importer_order: usize,
     manifest: &PackageManifest,
     dependency_groups: DependencyGroupList,
     opts: ResolveImporterOptions,
@@ -295,6 +297,7 @@ where
 
     let ctx = TreeCtx::with_workspace(workspace, base_opts)
         .with_importer_id(importer_id)
+        .with_importer_order(importer_order)
         .with_patched_dependencies(patched_dependencies)
         .with_resolution_mode(pick_lowest_direct, subdep_published_by);
 
@@ -316,29 +319,28 @@ where
     let mut all_missing_optional_peers: BTreeMap<String, Vec<String>> = BTreeMap::new();
 
     // The hoist input must not see missing peers declared inside a
-    // subtree first resolved under an earlier importer — upstream
-    // reuses the first walk's children report there, so those peers
-    // never reach a later importer's hoist. The final per-importer
-    // pass below keeps the unscoped options so warnings stay complete.
-    // Snapshotted once per importer: suppression only consults entries
-    // recorded by earlier importers (everything this importer's own
-    // loop adds is self-claimed and exempt), so the maps cannot change
-    // in a way the loop observes.
-    let hoist_missing_scope = Arc::new(crate::resolve_peers::HoistMissingScope {
-        importer_id: importer_id.to_string(),
-        first_importer_by_pkg: ctx.workspace().first_importer_by_pkg(),
-        first_walk_missing_by_pkg: ctx.workspace().first_walk_missing_by_pkg(),
-    });
+    // subtree owned by another importer's shared children context —
+    // upstream reuses the owner walk's children report there, so those
+    // peers never reach a non-owner importer's hoist. The final
+    // per-importer pass below keeps the unscoped options so warnings
+    // stay complete.
+    // Snapshotted per peer pass because auto-hoisting can extend the
+    // tree and move children ownership to a shallower occurrence.
     let hoist_peers_opts = || {
         let mut opts = peers_opts();
-        opts.hoist_missing_scope = Some(Arc::clone(&hoist_missing_scope));
+        opts.hoist_missing_scope = Some(Arc::new(crate::resolve_peers::HoistMissingScope {
+            importer_id: importer_id.to_string(),
+            first_importer_by_pkg: ctx.workspace().first_importer_by_pkg(),
+            first_walk_missing_by_pkg: ctx.workspace().first_walk_missing_by_pkg(),
+        }));
         opts
     };
     loop {
         loop {
             let mut snapshot = ctx.snapshot(direct.clone());
             let peers_result = resolve_peers(&mut snapshot, hoist_peers_opts());
-            ctx.workspace().record_first_walk_missing(&peers_result.missing_names_by_pkg);
+            ctx.workspace()
+                .record_first_walk_missing(importer_id, &peers_result.missing_names_by_pkg);
 
             let (missing_required, fresh_optional) = partition_missing_peers(
                 &peers_result.peer_dependency_issues.missing,

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -135,19 +135,17 @@ pub struct ResolvePeersOptions {
     pub modules_dir: Option<std::path::PathBuf>,
 
     /// When `Some`, missing-peer issues declared inside a subtree
-    /// whose root package was first resolved under a *different*
-    /// importer are not emitted. The peer-hoist loop sets this so its
-    /// input matches upstream, where a revisited package's children
-    /// keep the missing-peer report computed under the first
-    /// resolver's alias chain
+    /// whose root package's shared children context is owned by a
+    /// *different* importer are not emitted. The peer-hoist loop sets
+    /// this so its input matches upstream, where a non-owner package
+    /// occurrence keeps the missing-peer report computed under the
+    /// owner occurrence's alias chain
     /// ([`missingPeersOfChildrenByPkgId`](https://github.com/pnpm/pnpm/blob/a751c7f27d/installing/deps-resolver/src/resolveDependencies.ts#L193)) —
     /// only the package's *own* peers are re-evaluated per occurrence.
     /// The final workspace-wide pass leaves this `None` so warnings
     /// still cover every importer. Held by `Arc`: the maps inside are
     /// per-importer snapshots shared across every hoist-loop
-    /// iteration — the entries relevant to suppression (those of
-    /// earlier importers) cannot change while one importer's loop
-    /// runs.
+    /// iteration.
     pub hoist_missing_scope: Option<std::sync::Arc<HoistMissingScope>>,
 }
 
@@ -156,17 +154,17 @@ pub struct ResolvePeersOptions {
 pub struct HoistMissingScope {
     /// The importer whose hoist input is being computed.
     pub importer_id: String,
-    /// `pkg id → first-resolving importer id`, from
+    /// `pkg id → children-owner importer id`, from
     /// [`crate::WorkspaceTreeCtx::first_importer_by_pkg`].
     pub first_importer_by_pkg: HashMap<String, String>,
-    /// Per package: the missing-peer names reported by the first walk
-    /// that visited it, from
+    /// Per package: the missing-peer names reported under the current
+    /// children-owner context, from
     /// [`crate::WorkspaceTreeCtx::first_walk_missing_by_pkg`]. A
     /// missing peer inside a foreign-claimed subtree is suppressed
-    /// only when the claimer's walk did *not* report it missing —
+    /// only when the owner's walk did *not* report it missing —
     /// i.e. that context satisfied it, which is what upstream's
     /// shared children report filtered out at walk time. Misses the
-    /// first walker could not satisfy stay visible to every importer
+    /// owner walk could not satisfy stay visible to every importer
     /// (and each hoists its own copy).
     pub first_walk_missing_by_pkg: HashMap<String, std::collections::HashSet<String>>,
 }
@@ -208,10 +206,10 @@ pub struct ResolvePeersResult {
     pub direct_dependencies_by_alias: BTreeMap<String, DepPath>,
     pub peer_dependency_issues: PeerDependencyIssues,
     /// Per resolved package: the union of missing-peer names its
-    /// occurrences reported in this walk. The hoist loop persists the
-    /// first walk's map per package so later importers can tell which
-    /// misses the first resolver's context already satisfied. See
-    /// [`HoistMissingScope`].
+    /// occurrences' children reported in this walk. The hoist loop
+    /// persists the owner-context map per package so non-owner importers
+    /// can tell which descendant misses the owner resolver's context
+    /// already satisfied. See [`HoistMissingScope`].
     pub missing_names_by_pkg: HashMap<String, std::collections::HashSet<String>>,
 }
 
@@ -261,6 +259,7 @@ pub fn resolve_peers(tree: &mut ResolvedTree, opts: ResolvePeersOptions) -> Reso
         node_dep_paths: HashMap::new(),
         node_external_peers: HashMap::new(),
         node_missing_peers: HashMap::new(),
+        node_missing_peers_of_children: HashMap::new(),
         in_progress: HashSet::new(),
         pending_peer_edges: Vec::new(),
         pure_pkgs: HashSet::new(),
@@ -297,6 +296,7 @@ pub fn resolve_peers_workspace(
         node_dep_paths: HashMap::new(),
         node_external_peers: HashMap::new(),
         node_missing_peers: HashMap::new(),
+        node_missing_peers_of_children: HashMap::new(),
         in_progress: HashSet::new(),
         pending_peer_edges: Vec::new(),
         pure_pkgs: HashSet::new(),
@@ -433,6 +433,9 @@ struct Walker<'tree> {
     /// Peers each node and its subtree declared but couldn't find.
     /// Indexed by `NodeId`; value's keys are peer aliases.
     node_missing_peers: HashMap<NodeId, HashMap<String, MissingPeerInfo>>,
+    /// Peers each node's children declared but couldn't find.
+    /// Indexed by `NodeId`; value's keys are peer aliases.
+    node_missing_peers_of_children: HashMap<NodeId, HashMap<String, MissingPeerInfo>>,
     /// Stack of nodes currently being walked. Re-entry on a node here
     /// is a cycle — the recursion bottoms out with a `name@version`
     /// peer-id and the original visit drives the actual graph insert.
@@ -511,11 +514,13 @@ struct ParentPkgInfo {
 /// `missing_peers` is the set of unmet peer requirements the original
 /// walk surfaced — when a cache item carries a missing peer that the
 /// current parent context *does* provide, the contexts are
-/// incompatible and the item must be rejected.
+/// incompatible and the item must be rejected. `missing_peers_of_children`
+/// is the subset upstream exposes as the package's children report.
 struct PeersCacheItem {
     dep_path: DepPath,
     resolved_peers: HashMap<String, NodeId>,
     missing_peers: HashMap<String, MissingPeerInfo>,
+    missing_peers_of_children: HashMap<String, MissingPeerInfo>,
 }
 
 /// One `parent → child` edge whose target wasn't walked yet at the
@@ -616,7 +621,7 @@ impl Walker<'_> {
         let graph = self.build_final_graph(&final_dep_paths);
         let mut missing_names_by_pkg: HashMap<String, std::collections::HashSet<String>> =
             HashMap::new();
-        for (node_id, missing) in &self.node_missing_peers {
+        for (node_id, missing) in &self.node_missing_peers_of_children {
             let Some(tree_node) = self.tree.dependencies_tree.get(node_id) else { continue };
             missing_names_by_pkg
                 .entry(tree_node.resolved_package_id.clone())
@@ -879,6 +884,7 @@ impl Walker<'_> {
             let dep_path = cached.dep_path.clone();
             let resolved = cached.resolved_peers.clone();
             let missing = cached.missing_peers.clone();
+            let missing_of_children = cached.missing_peers_of_children.clone();
             // Re-emit the missing-peer issues against the current
             // parent chain so each occurrence of the package shows up
             // in the diagnostic, mirroring upstream's behaviour at the
@@ -905,6 +911,7 @@ impl Walker<'_> {
             self.node_dep_paths.insert(node_id.clone(), dep_path.clone());
             self.node_external_peers.insert(node_id.clone(), resolved.clone());
             self.node_missing_peers.insert(node_id.clone(), missing.clone());
+            self.node_missing_peers_of_children.insert(node_id.clone(), missing_of_children);
             // Same depth tie-break as the `purePkgs` fast path and the
             // non-fast `entry(...).and_modify(...)` write below — a
             // shallower revisit through the cache must still lower the
@@ -978,7 +985,7 @@ impl Walker<'_> {
         all_resolved_peers.remove(&pkg_name);
 
         // Same for missing peers (children + own).
-        let mut all_missing_peers = missing_from_children;
+        let mut all_missing_peers = missing_from_children.clone();
         for (peer_alias, info) in &own_missing_peers {
             all_missing_peers.insert(peer_alias.clone(), info.clone());
         }
@@ -1003,6 +1010,7 @@ impl Walker<'_> {
         self.node_dep_paths.insert(node_id.clone(), dep_path.clone());
         self.node_external_peers.insert(node_id.clone(), all_resolved_peers.clone());
         self.node_missing_peers.insert(node_id.clone(), all_missing_peers.clone());
+        self.node_missing_peers_of_children.insert(node_id.clone(), missing_from_children.clone());
 
         // The children's depPath edges become this node's graph children.
         // Resolved peers become extra edges, aliased by peer name. If a
@@ -1087,6 +1095,7 @@ impl Walker<'_> {
                 dep_path: dep_path.clone(),
                 resolved_peers: all_resolved_peers.clone(),
                 missing_peers: all_missing_peers.clone(),
+                missing_peers_of_children: missing_from_children,
             });
         }
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -144,6 +144,57 @@ fn own_peer_is_resolved_from_peer_relevant_child() {
 }
 
 #[test]
+fn missing_names_by_pkg_records_only_children_context_missing_peers() {
+    let parent = NodeId::next();
+    let child = NodeId::next();
+
+    let mut parent_children = BTreeMap::new();
+    parent_children.insert("child".to_string(), child.clone());
+
+    let mut tree = ResolvedTree {
+        direct: vec![DirectDep {
+            alias: "parent".to_string(),
+            node_id: parent.clone(),
+            id: "parent@1.0.0".to_string(),
+        }],
+        packages: HashMap::from([
+            (
+                "parent@1.0.0".to_string(),
+                package_with_peer_dependencies(
+                    "parent",
+                    "1.0.0",
+                    &[("own-peer", "*", false)],
+                    false,
+                ),
+            ),
+            (
+                "child@1.0.0".to_string(),
+                package_with_peer_dependencies(
+                    "child",
+                    "1.0.0",
+                    &[("child-peer", "*", false)],
+                    false,
+                ),
+            ),
+        ]),
+        dependencies_tree: HashMap::from([
+            (parent, tree_node("parent@1.0.0", parent_children, 0)),
+            (child, tree_node("child@1.0.0", BTreeMap::new(), 1)),
+        ]),
+        all_peer_dep_names: HashSet::from(["own-peer".to_string(), "child-peer".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+
+    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+    let parent_missing = result.missing_names_by_pkg.get("parent@1.0.0").unwrap();
+
+    assert!(parent_missing.contains("child-peer"));
+    assert!(!parent_missing.contains("own-peer"));
+}
+
+#[test]
 fn own_peer_is_resolved_from_aliased_child_real_name() {
     let peer_c = NodeId::leaf("peer-c@2.0.0");
     let consumer = NodeId::next();
@@ -427,6 +478,7 @@ fn walker_for_tests(tree: &mut ResolvedTree) -> Walker<'_> {
         node_dep_paths: HashMap::new(),
         node_external_peers: HashMap::new(),
         node_missing_peers: HashMap::new(),
+        node_missing_peers_of_children: HashMap::new(),
         in_progress: HashSet::new(),
         pending_peer_edges: Vec::new(),
         pure_pkgs: HashSet::new(),

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -213,7 +213,9 @@ where
     };
 
     let mut per_importer_inputs: Vec<ImporterPeerInput> = Vec::with_capacity(importers.len());
-    for (importer, mut importer_opts) in importers.iter().zip(importer_opts) {
+    for (importer_order, (importer, mut importer_opts)) in
+        importers.iter().zip(importer_opts).enumerate()
+    {
         importer_opts.pick_lowest_direct = pick_lowest_direct;
         importer_opts.subdep_published_by = subdep_published_by;
         let project_dir = importer_opts.base_opts.project_dir.clone();
@@ -221,6 +223,7 @@ where
         let ResolveImporterResult { resolved_tree, .. } = resolve_importer_with_workspace(
             resolver,
             &importer.id,
+            importer_order,
             importer.manifest,
             dependency_groups.iter().copied(),
             importer_opts,

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str::FromStr, sync::Mutex};
+use std::{collections::HashMap, str::FromStr, sync::Mutex, time::Duration};
 
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_resolving_resolver_base::{
@@ -31,6 +31,40 @@ impl Resolver for StubResolver {
         self.calls.lock().unwrap().push(key.clone());
         let result = self.table.get(&key).cloned();
         Box::pin(async move { Ok::<_, ResolveError>(result) })
+    }
+
+    fn resolve_latest<'a>(
+        &'a self,
+        _query: &'a LatestQuery,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveLatestFuture<'a> {
+        Box::pin(async { Ok(None) })
+    }
+}
+
+struct DelayedAliasResolver {
+    table: HashMap<(String, String), ResolveResult>,
+    delayed_alias: String,
+}
+
+impl Resolver for DelayedAliasResolver {
+    fn resolve<'a>(
+        &'a self,
+        wanted: &'a WantedDependency,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveFuture<'a> {
+        let key = (
+            wanted.alias.clone().unwrap_or_default(),
+            wanted.bare_specifier.clone().unwrap_or_default(),
+        );
+        let result = self.table.get(&key).cloned();
+        let should_delay = key.0 == self.delayed_alias;
+        Box::pin(async move {
+            if should_delay {
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+            Ok::<_, ResolveError>(result)
+        })
     }
 
     fn resolve_latest<'a>(
@@ -141,6 +175,85 @@ async fn walks_dependencies_and_builds_flat_tree() {
     let bar_tree_node = tree.dependencies_tree.get(bar_node_id).unwrap();
     assert_eq!(bar_tree_node.resolved_package_id, "bar@2.3.0");
     assert!(tree.policy_violations.is_empty());
+}
+
+#[tokio::test]
+async fn shallower_revisit_takes_over_shared_children_context() {
+    let mut table = HashMap::new();
+    table.insert(
+        ("a".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "a",
+            "1.0.0",
+            serde_json::json!({
+                "name": "a",
+                "version": "1.0.0",
+                "dependencies": { "cycle": "1.0.0" }
+            }),
+        ),
+    );
+    table.insert(
+        ("cycle".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "cycle",
+            "1.0.0",
+            serde_json::json!({
+                "name": "cycle",
+                "version": "1.0.0",
+                "dependencies": { "shared": "1.0.0" }
+            }),
+        ),
+    );
+    table.insert(
+        ("c".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "c",
+            "1.0.0",
+            serde_json::json!({
+                "name": "c",
+                "version": "1.0.0",
+                "dependencies": { "shared": "1.0.0" }
+            }),
+        ),
+    );
+    table.insert(
+        ("shared".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "shared",
+            "1.0.0",
+            serde_json::json!({
+                "name": "shared",
+                "version": "1.0.0",
+                "dependencies": { "cycle": "1.0.0" }
+            }),
+        ),
+    );
+    let resolver = DelayedAliasResolver { table, delayed_alias: "c".to_string() };
+    let (_tmp, manifest) = fake_manifest(serde_json::json!({
+        "a": "1.0.0",
+        "c": "1.0.0"
+    }));
+
+    let tree = resolve_dependency_tree(
+        &resolver,
+        &manifest,
+        [DependencyGroup::Prod],
+        ResolveDependencyTreeOptions {
+            base_opts: ResolveOptions::default(),
+            patched_dependencies: None,
+            manifest_hook: None,
+            pnpmfile_hook: None,
+            read_package_log: None,
+            auto_install_peers: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    let shared_children = tree.children_by_id.get("shared@1.0.0").expect("shared children");
+    assert_eq!(shared_children.len(), 1);
+    assert_eq!(shared_children[0].alias, "cycle");
+    assert_eq!(shared_children[0].pkg_id, "cycle@1.0.0");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Make shared package child resolution deterministic by choosing the owner by depth, importer order, and parent path instead of async completion timing.
- Keep non-owner and stale occurrences lazy while reusing the current owner children and missing-peer context.
- Port the same behavior to pacquet and add TypeScript plus Rust regression coverage.

## Verification

- `pnpm --filter @pnpm/installing.deps-resolver test test/resolveDependencyTree.test.ts`
- `cargo test -p pacquet-resolving-deps-resolver`
- Pre-push hook: TypeScript typecheck, pnpm bundle, lint, spellcheck, meta lint, cargo fmt, cargo doc, cargo dylint, taplo format check

Fixes pnpm/pnpm#12358

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared package children are resolved deterministically (shallowest → importer order → parent path), making dependency selection predictable.

* **Bug Fixes**
  * Missing-peer reporting stabilized so warnings are consistent and tied to the owning importer context.

* **Tests**
  * Added tests validating deterministic shared-child resolution and preferred-version behavior.

* **Documentation**
  * Added changelog entry documenting the deterministic child-resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->