### PR TITLE
fix(pacquet): byte-identical lockfile — generation-once owner records + cycle-closing edges

### DIFF
--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -581,9 +581,16 @@ pub struct WorkspaceTreeCtx {
     /// a non-owner occurrence reuses the owner occurrence's children
     /// and missing-peer report. Consumed via [`crate::HoistMissingScope`].
     first_importer_by_pkg: Mutex<HashMap<String, String>>,
-    /// Per package: the missing-peer names reported under the current
-    /// children-owner context. Consumed via [`crate::HoistMissingScope`].
-    first_walk_missing_by_pkg: Mutex<HashMap<String, HashSet<String>>>,
+    /// Per package: the missing-peer names reported by the *initial*
+    /// peer walk of the current children-owner generation, plus the
+    /// owner that recorded them (`None` while only a non-owner's
+    /// provisional walk has been seen). Mirrors upstream's
+    /// once-per-generation `missingPeersOfChildren` promise: later
+    /// hoist waves of the same owner never refresh the record, so a
+    /// peer the owner only satisfied by hoisting stays visible to
+    /// every other importer's hoist. Consumed via
+    /// [`crate::HoistMissingScope`].
+    first_walk_missing_by_pkg: Mutex<HashMap<String, (Option<ChildrenOwner>, HashSet<String>)>>,
 }
 
 impl Default for WorkspaceTreeCtx {
@@ -663,9 +670,11 @@ impl WorkspaceTreeCtx {
         lock_recoverable(&self.first_importer_by_pkg).clone()
     }
 
-    /// Record a walk's per-package missing-peer names when the current
-    /// importer owns that package's shared children context. See the
-    /// `first_walk_missing_by_pkg` field doc.
+    /// Record a walk's per-package missing-peer names. The owning
+    /// importer's report is written once per ownership generation —
+    /// its own later hoist waves never refresh it — and replaces any
+    /// provisional report a non-owner's earlier walk left behind. See
+    /// the `first_walk_missing_by_pkg` field doc.
     pub fn record_first_walk_missing(
         &self,
         importer_id: &str,
@@ -674,16 +683,22 @@ impl WorkspaceTreeCtx {
         let owners = lock_recoverable(&self.children_owner_by_id).clone();
         let mut record = lock_recoverable(&self.first_walk_missing_by_pkg);
         for (pkg_id, owner) in &owners {
-            if owner.importer_id == importer_id {
+            if owner.importer_id != importer_id {
+                continue;
+            }
+            let recorded_by_current_owner = record
+                .get(pkg_id)
+                .is_some_and(|(recorded_by, _)| recorded_by.as_ref() == Some(owner));
+            if !recorded_by_current_owner {
                 record.insert(
                     pkg_id.clone(),
-                    missing_by_pkg.get(pkg_id).cloned().unwrap_or_default(),
+                    (Some(owner.clone()), missing_by_pkg.get(pkg_id).cloned().unwrap_or_default()),
                 );
             }
         }
         for (pkg_id, names) in missing_by_pkg {
             if owners.get(pkg_id).is_none_or(|owner| owner.importer_id != importer_id) {
-                record.entry(pkg_id.clone()).or_insert_with(|| names.clone());
+                record.entry(pkg_id.clone()).or_insert_with(|| (None, names.clone()));
             }
         }
     }
@@ -692,7 +707,10 @@ impl WorkspaceTreeCtx {
     /// See the `first_walk_missing_by_pkg` field doc.
     #[must_use]
     pub fn first_walk_missing_by_pkg(&self) -> HashMap<String, HashSet<String>> {
-        lock_recoverable(&self.first_walk_missing_by_pkg).clone()
+        lock_recoverable(&self.first_walk_missing_by_pkg)
+            .iter()
+            .map(|(pkg_id, (_, names))| (pkg_id.clone(), names.clone()))
+            .collect()
     }
 
     /// Set which dependencies `pacquet update` excludes from reuse. See

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -590,7 +590,15 @@ pub struct WorkspaceTreeCtx {
     /// peer the owner only satisfied by hoisting stays visible to
     /// every other importer's hoist. Consumed via
     /// [`crate::HoistMissingScope`].
-    first_walk_missing_by_pkg: Mutex<HashMap<String, (Option<ChildrenOwner>, HashSet<String>)>>,
+    first_walk_missing_by_pkg: Mutex<HashMap<String, OwnerMissingRecord>>,
+}
+
+/// One [`WorkspaceTreeCtx::first_walk_missing_by_pkg`] entry: the
+/// missing-peer names plus the owner generation that recorded them
+/// (`None` for a non-owner's provisional report).
+struct OwnerMissingRecord {
+    recorded_by: Option<ChildrenOwner>,
+    names: HashSet<String>,
 }
 
 impl Default for WorkspaceTreeCtx {
@@ -686,19 +694,24 @@ impl WorkspaceTreeCtx {
             if owner.importer_id != importer_id {
                 continue;
             }
-            let recorded_by_current_owner = record
-                .get(pkg_id)
-                .is_some_and(|(recorded_by, _)| recorded_by.as_ref() == Some(owner));
+            let recorded_by_current_owner =
+                record.get(pkg_id).is_some_and(|entry| entry.recorded_by.as_ref() == Some(owner));
             if !recorded_by_current_owner {
                 record.insert(
                     pkg_id.clone(),
-                    (Some(owner.clone()), missing_by_pkg.get(pkg_id).cloned().unwrap_or_default()),
+                    OwnerMissingRecord {
+                        recorded_by: Some(owner.clone()),
+                        names: missing_by_pkg.get(pkg_id).cloned().unwrap_or_default(),
+                    },
                 );
             }
         }
         for (pkg_id, names) in missing_by_pkg {
             if owners.get(pkg_id).is_none_or(|owner| owner.importer_id != importer_id) {
-                record.entry(pkg_id.clone()).or_insert_with(|| (None, names.clone()));
+                record.entry(pkg_id.clone()).or_insert_with(|| OwnerMissingRecord {
+                    recorded_by: None,
+                    names: names.clone(),
+                });
             }
         }
     }
@@ -709,7 +722,7 @@ impl WorkspaceTreeCtx {
     pub fn first_walk_missing_by_pkg(&self) -> HashMap<String, HashSet<String>> {
         lock_recoverable(&self.first_walk_missing_by_pkg)
             .iter()
-            .map(|(pkg_id, (_, names))| (pkg_id.clone(), names.clone()))
+            .map(|(pkg_id, entry)| (pkg_id.clone(), entry.names.clone()))
             .collect()
     }
 
@@ -1357,8 +1370,13 @@ where
 
     let id = build_pkg_id_with_patch_hash(ctx, &result).await?;
 
-    // Cycle break — see the doc comment above.
-    if ancestor_ids.iter().any(|prev| prev == &id) {
+    // Cycle break — see the doc comment above. A direct self-edge and
+    // the second lap of a longer cycle are dropped; the first re-entry
+    // is kept so the cycle-closing edge reaches the lockfile snapshot,
+    // mirroring upstream's `buildTree` gate.
+    if ancestor_ids.last().is_some_and(|parent| {
+        *parent == id || parent_ids_contain_sequence(ancestor_ids, parent, &id)
+    }) {
         return Ok(NodeSeed::Done(None));
     }
 
@@ -1632,6 +1650,31 @@ where
     }
 
     Ok(Some(DirectDep { alias, node_id, id }))
+}
+
+/// Whether the `parent → child` edge closes a dependency cycle's
+/// *second* lap. Mirrors upstream's
+/// [`parentIdsContainSequence`](https://github.com/pnpm/pnpm/blob/d2b42c2dfc/installing/deps-resolver/src/parentIdsContainSequence.ts):
+/// the first re-entry of a cycle is kept (so the cycle-closing
+/// dependency edge appears in the tree and the lockfile snapshot,
+/// with [`fn@crate::resolve_peers`]'s previously-resolved-children
+/// merge restoring the pruned edge on the repeated node); only the
+/// repeat of the full `parent … child` sequence is dropped.
+pub(crate) fn parent_ids_contain_sequence(
+    pkg_ids: &[String],
+    pkg_id1: &str,
+    pkg_id2: &str,
+) -> bool {
+    let Some(pkg1_index) = pkg_ids.iter().position(|id| id == pkg_id1) else {
+        return false;
+    };
+    if pkg1_index == pkg_ids.len() - 1 {
+        return false;
+    }
+    let Some(pkg2_index) = pkg_ids.iter().rposition(|id| id == pkg_id2) else {
+        return false;
+    };
+    pkg1_index < pkg2_index && pkg2_index != pkg_ids.len() - 1
 }
 
 /// Whether a freshly resolved node landed back on its previously
@@ -2089,7 +2132,9 @@ where
     let id = build_pkg_id_with_patch_hash(ctx, &result).await?;
 
     // Cycle break — same as the fresh path.
-    if ancestor_ids.iter().any(|prev| prev == &id) {
+    if ancestor_ids.last().is_some_and(|parent| {
+        *parent == id || parent_ids_contain_sequence(ancestor_ids, parent, &id)
+    }) {
         return Ok(None);
     }
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
@@ -35,3 +35,61 @@ fn matches_a_name_prefixed_file_id() {
     assert!(landed_on_prior_entry(&key("foo@file:packages/foo"), "foo@file:packages/foo"));
     assert!(!landed_on_prior_entry(&key("foo@file:packages/foo"), "file:packages/foo"));
 }
+
+/// The owning importer's missing-peer record is written once per
+/// ownership generation: its own later passes (post-hoist, when the
+/// peer is no longer missing) must not refresh it — mirroring
+/// upstream's once-per-generation `missingPeersOfChildren` promise —
+/// while an ownership change starts a fresh record and an owner's
+/// report replaces a non-owner's provisional one.
+#[test]
+fn owner_missing_record_is_written_once_per_generation() {
+    use super::{ChildrenOwner, WorkspaceTreeCtx, lock_recoverable};
+    use std::collections::{HashMap, HashSet};
+
+    let ctx = WorkspaceTreeCtx::default();
+    let owner = ChildrenOwner {
+        depth: 1,
+        importer_order: 0,
+        parent_path: vec!["root-dep@1.0.0".to_string()],
+        importer_id: ".".to_string(),
+    };
+    lock_recoverable(&ctx.children_owner_by_id).insert("pkg@1.0.0".to_string(), owner.clone());
+
+    let miss = |names: &[&str]| {
+        let mut map: HashMap<String, HashSet<String>> = HashMap::new();
+        map.insert("pkg@1.0.0".to_string(), names.iter().map(|name| (*name).to_string()).collect());
+        map
+    };
+
+    // A non-owner's provisional report lands first.
+    ctx.record_first_walk_missing("pkg-a", &miss(&["peer"]));
+    assert_eq!(
+        ctx.first_walk_missing_by_pkg().get("pkg@1.0.0"),
+        Some(&miss(&["peer"]).remove("pkg@1.0.0").unwrap()),
+    );
+
+    // The owner's initial walk replaces it.
+    ctx.record_first_walk_missing(".", &miss(&["peer", "other-peer"]));
+    let recorded = ctx.first_walk_missing_by_pkg();
+    assert_eq!(recorded.get("pkg@1.0.0").map(HashSet::len), Some(2));
+
+    // The owner's later (post-hoist) pass no longer reports the miss —
+    // the generation's record must keep the initial misses.
+    ctx.record_first_walk_missing(".", &miss(&[]));
+    let recorded = ctx.first_walk_missing_by_pkg();
+    assert!(
+        recorded.get("pkg@1.0.0").is_some_and(|names| names.contains("peer")),
+        "the owner's post-hoist pass must not refresh the generation's record",
+    );
+
+    // An ownership change starts a fresh record.
+    let new_owner = ChildrenOwner { depth: 0, ..owner };
+    lock_recoverable(&ctx.children_owner_by_id).insert("pkg@1.0.0".to_string(), new_owner);
+    ctx.record_first_walk_missing(".", &miss(&[]));
+    assert_eq!(
+        ctx.first_walk_missing_by_pkg().get("pkg@1.0.0").map(HashSet::len),
+        Some(0),
+        "a new ownership generation records afresh",
+    );
+}

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -1545,7 +1545,15 @@ impl Walker<'_> {
         let child_depth = depth + 1;
         let mut realized: BTreeMap<String, NodeId> = BTreeMap::new();
         for edge in children_spec.iter() {
-            if parent_ids.iter().any(|ancestor_id| ancestor_id == &edge.pkg_id) {
+            // Same cycle gate as the eager walk: keep the first
+            // re-entry, drop a direct self-edge or a second lap.
+            if pkg_id == edge.pkg_id
+                || crate::resolve_dependency_tree::parent_ids_contain_sequence(
+                    &parent_ids,
+                    &pkg_id,
+                    &edge.pkg_id,
+                )
+            {
                 continue;
             }
             // Reuse the first walk's classification (persisted on

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -3060,3 +3060,74 @@ mod level_preferred_versions {
         );
     }
 }
+
+mod cycle_edges {
+    use super::{
+        DependencyGroup, HashMap, Mutex, ResolveDependencyTreeOptions, ResolveOptions,
+        StubResolver, fake_manifest, fake_result, resolve_dependency_tree,
+    };
+    use crate::resolve_peers::{ResolvePeersOptions, resolve_peers};
+
+    /// A two-package cycle keeps its closing edge: pnpm's `buildTree`
+    /// gate drops only the *second* lap of a cycle, so `b`'s snapshot
+    /// still lists `a` (upstream restores the repeated node's pruned
+    /// children via the previously-resolved-children merge).
+    #[tokio::test]
+    async fn cycle_closing_edge_reaches_the_graph() {
+        let mut table = HashMap::new();
+        table.insert(
+            ("a".to_string(), "1.0.0".to_string()),
+            fake_result(
+                "a",
+                "1.0.0",
+                serde_json::json!({
+                    "name": "a",
+                    "version": "1.0.0",
+                    "dependencies": { "b": "1.0.0" },
+                }),
+            ),
+        );
+        table.insert(
+            ("b".to_string(), "1.0.0".to_string()),
+            fake_result(
+                "b",
+                "1.0.0",
+                serde_json::json!({
+                    "name": "b",
+                    "version": "1.0.0",
+                    "dependencies": { "a": "1.0.0" },
+                }),
+            ),
+        );
+        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) = fake_manifest(serde_json::json!({ "a": "1.0.0" }));
+
+        let mut tree = resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod],
+            ResolveDependencyTreeOptions {
+                base_opts: ResolveOptions::default(),
+                patched_dependencies: None,
+                manifest_hook: None,
+                pnpmfile_hook: None,
+                read_package_log: None,
+                auto_install_peers: false,
+            },
+        )
+        .await
+        .unwrap();
+        let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+
+        let a_node =
+            result.graph.get(&crate::DepPath::from("a@1.0.0".to_string())).expect("a in graph");
+        assert!(a_node.children.contains_key("b"), "a keeps its b edge");
+        let b_node =
+            result.graph.get(&crate::DepPath::from("b@1.0.0".to_string())).expect("b in graph");
+        assert!(
+            b_node.children.contains_key("a"),
+            "the cycle-closing edge b -> a must reach the graph: {:?}",
+            b_node.children.keys().collect::<Vec<_>>(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The final two resolution-level parity fixes for https://github.com/pnpm/pnpm/issues/12266. With both applied, `pacquet install --lockfile-only` on this monorepo produces a real-lockfile document that is **byte-identical** to fresh **pnpm 11.6.0** output (back-to-back against the live registry, deterministic across runs) — down from ~3,200 changed lines when the umbrella issue was opened.

### 1. Owner missing-peer records are written once per ownership generation

The pacquet side of #12362 overwrote the owner-keyed first-walk record on every owner pass. Once the owning importer hoisted a peer into its own scope (e.g. `typanion` under `@yarnpkg/core`, owned by `hooks/read-package-hook`), the record went empty and every other importer's hoist of that peer was suppressed — pnpm's once-per-generation `missingPeersOfChildren` promise keeps the owner walk's *initial* misses visible instead, and each importer hoists its own copy. The record now stores the recording owner: the owning importer writes once per ownership generation (later post-hoist passes never refresh it), an ownership change records afresh, and an owner's report replaces a non-owner's provisional one. Restores the `(typanion@3.14.0)` / `(@babel/types@7.29.7)` suffixes (11 → 3 lines).

### 2. A cycle's closing edge survives the first re-entry

pacquet's cycle break dropped the edge at the first re-entry of an ancestor package, losing snapshot lines like `es-abstract: 1.24.2` under `arraybuffer.prototype.slice@1.0.4`. pnpm's `buildTree` gate ([parentIdsContainSequence](https://github.com/pnpm/pnpm/blob/d2b42c2dfc/installing/deps-resolver/src/parentIdsContainSequence.ts)) only drops a direct self-edge and the *second* lap of the full `parent … child` sequence; the repeated node's pruned back-edge is restored on its graph entry by the previously-resolved-children merge — already ported in pacquet's peer pass, but dead code until this gate. Ported to the seed walk, the lockfile-reuse walk, and the lazy realization (3 → 0 lines).

## Verification

- New regression tests: `owner_missing_record_is_written_once_per_generation` and `cycle_closing_edge_reaches_the_graph` (both verified to fail without their fixes); full `resolving-deps-resolver` (127), `package-manager` + `cli` (781) suites pass; clippy `--deny warnings`, rustfmt clean.
- Whole-monorepo: **0 changed lines** vs fresh pnpm 11.6.0, byte-identical across consecutive runs.

## What remains on the umbrella

Only the env-lockfile document (doc 1), which the issue originally scoped out: pacquet's first document lacks the `packageManagerDependencies` block and the `libc:` fields on the `@pacquet/linux-*` platform packages.

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved circular dependency detection to preserve critical dependency edges while preventing infinite loops.
  * Enhanced missing peer dependency tracking across different resolution contexts for more accurate dependency resolution.

* **Tests**
  * Added test coverage for peer dependency recording behavior and circular dependency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->