### PR TITLE
fix(pacquet): repair partial virtual-store dirs via completion marker

### DIFF
--- a/pacquet/crates/package-manager/src/import_indexed_dir.rs
+++ b/pacquet/crates/package-manager/src/import_indexed_dir.rs
@@ -85,6 +85,13 @@ pub enum ImportIndexedDirError {
         #[error(source)]
         error: io::Error,
     },
+    #[display("failed to place completion marker {from:?} at {to:?}: {error}")]
+    PlaceMarker {
+        from: PathBuf,
+        to: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
 }
 
 /// Materialize an indexed package's files into `dir_path`, the way
@@ -141,9 +148,31 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
         // Fresh target — populate it. Both linkers take this path on
         // first install.
         (None, _) => populate_dir::<Reporter>(logged_methods, import_method, dir_path, cas_paths),
-        // Existing target with force=false — pnpm's pre-existence
-        // short-circuit. The isolated linker relies on this: each
-        // virtual-store slot is populated exactly once.
+        // Existing directory with force=false — pnpm's pre-existence
+        // short-circuit, but keyed on the *completion marker*, not the
+        // mere existence of the directory (`pkgExistsAtTargetDir` in
+        // `fs/indexed-pkg-importer/src/index.ts`, which checks for
+        // `package.json`). A directory that exists but lacks the marker
+        // is a partial result from an interrupted import — `populate_dir`
+        // writes the marker last (see below), so its absence proves the
+        // earlier import never finished. Repair it by re-running
+        // `populate_dir`, which is non-destructive and EEXIST-tolerant:
+        // it links only the files still missing and leaves a sibling
+        // importer's work intact. This matches pnpm's `safeToSkip`
+        // (global-virtual-store) branch, which likewise re-links into an
+        // existing directory rather than destructively replacing it.
+        // Ported from pnpm commit cbfeeef328 (pnpm/pnpm#12204).
+        (Some(file_type), false) if file_type.is_dir() => {
+            if marker_present(dir_path, cas_paths) {
+                Ok(())
+            } else {
+                populate_dir::<Reporter>(logged_methods, import_method, dir_path, cas_paths)
+            }
+        }
+        // Existing non-directory dirent with force=false. A stale symlink
+        // or file occupying the slot is left as-is, matching the prior
+        // short-circuit; the force=true path below is the only one that
+        // clobbers a non-directory dirent.
         (Some(_), false) => Ok(()),
         // Existing non-directory dirent with force=true. The hoisted
         // linker call shape won't produce this in practice, but
@@ -205,8 +234,15 @@ fn populate_dir<Reporter: self::Reporter>(
             .map_err(|error| ImportIndexedDirError::CreateDir { dirname: abs, error })?;
     }
 
+    // pnpm writes the completion marker (`package.json`) last, so a
+    // crash mid-import leaves a directory the next install recognises as
+    // incomplete (`tryImportIndexedDir` in
+    // `fs/indexed-pkg-importer/src/importIndexedDir.ts`). Link every
+    // other file first, in parallel, then place the marker.
+    let marker = marker_file(cas_paths);
     cas_paths
         .par_iter()
+        .filter(|(cleaned_entry, _)| Some(cleaned_entry.as_str()) != marker)
         .try_for_each(|(cleaned_entry, store_path)| {
             // Targets are guaranteed fresh: `populate_dir` only runs
             // against a freshly-mkdir'd `dir_path` (the caller in
@@ -223,7 +259,85 @@ fn populate_dir<Reporter: self::Reporter>(
                 &dir_path.join(cleaned_entry),
             )
         })
-        .map_err(ImportIndexedDirError::LinkFile)
+        .map_err(ImportIndexedDirError::LinkFile)?;
+
+    if let Some(marker) = marker {
+        import_marker_atomic::<Reporter>(
+            logged_methods,
+            import_method,
+            &cas_paths[marker],
+            &dir_path.join(marker),
+        )?;
+    }
+    Ok(())
+}
+
+/// Pick the completion-marker filename out of an indexed file map,
+/// mirroring pnpm's `pickFileFromFilesMap`
+/// (`fs/indexed-pkg-importer/src/index.ts`): prefer `package.json` (the
+/// worker synthesises one for every package), and otherwise fall back to
+/// a single file so old store entries indexed before the synthetic
+/// `package.json` still get a marker. pnpm's fallback is the map's
+/// first-by-insertion-order key; pacquet's `cas_paths` is a `HashMap`
+/// with no stable order, so we take the lexicographically smallest key —
+/// deterministic, and good enough since the gate
+/// ([`marker_present`]) and the marker write
+/// ([`populate_dir`]) both consult this same function. Returns `None`
+/// only for an empty map, where there is nothing to import or gate on.
+fn marker_file(cas_paths: &HashMap<String, PathBuf>) -> Option<&str> {
+    const PACKAGE_JSON: &str = "package.json";
+    if cas_paths.contains_key(PACKAGE_JSON) {
+        return Some(PACKAGE_JSON);
+    }
+    cas_paths.keys().map(String::as_str).min()
+}
+
+/// Whether `dir_path` already holds the completion marker for this file
+/// map. An empty map has no marker to check, so it counts as present —
+/// there is nothing to import, matching the prior "directory exists ⇒
+/// done" short-circuit for that degenerate case.
+fn marker_present(dir_path: &Path, cas_paths: &HashMap<String, PathBuf>) -> bool {
+    match marker_file(cas_paths) {
+        Some(marker) => dir_path.join(marker).exists(),
+        None => true,
+    }
+}
+
+/// Import the completion marker so it appears atomically: link it into a
+/// private temp sibling, then rename it onto the marker path. pnpm uses
+/// its `importFileAtomic` for `package.json` (a temp-file + rename on the
+/// copy path; the raw syscall on the already-atomic hardlink/reflink
+/// paths). pacquet's `Auto` / `CloneOrCopy` methods pick their tier at
+/// runtime, so rather than predict whether this import will copy, always
+/// stage-and-rename — one extra rename per package, and the marker can
+/// never be observed half-written. A concurrent importer that placed the
+/// marker first surfaces as `AlreadyExists` (Windows) or is replaced
+/// atomically (POSIX `rename`); either way the content is
+/// content-addressed, so the result is equivalent and we drop our temp.
+fn import_marker_atomic<Reporter: self::Reporter>(
+    logged_methods: &AtomicU8,
+    import_method: PackageImportMethod,
+    store_path: &Path,
+    marker_path: &Path,
+) -> Result<(), ImportIndexedDirError> {
+    let temp = pick_stage_path(marker_path);
+    import_into_fresh_target::<Reporter>(logged_methods, import_method, store_path, &temp)
+        .map_err(ImportIndexedDirError::LinkFile)?;
+    match fs::rename(&temp, marker_path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            let _ = fs::remove_file(&temp);
+            Ok(())
+        }
+        Err(error) => {
+            let _ = fs::remove_file(&temp);
+            Err(ImportIndexedDirError::PlaceMarker {
+                from: temp,
+                to: marker_path.to_path_buf(),
+                error,
+            })
+        }
+    }
 }
 
 fn stage_and_swap<Reporter: self::Reporter>(

--- a/pacquet/crates/package-manager/src/import_indexed_dir.rs
+++ b/pacquet/crates/package-manager/src/import_indexed_dir.rs
@@ -123,9 +123,10 @@ pub enum ImportIndexedDirError {
 /// (hardlink → reflink → copy, etc.), and the per-method
 /// `pnpm:package-import-method` log is emitted via `logged_methods`
 /// the first time each tier is used in this install. The pre-flight
-/// `fs::metadata` short-circuit lives on `link_file()` for callers
-/// without a freshness guarantee — `populate_dir` already gates on
-/// the directory being fresh, so it skips that stat.
+/// `fs::metadata` short-circuit lives on `link_file()`; `populate_dir`
+/// skips it and relies on `import_into_fresh_target`'s EEXIST tolerance,
+/// which is what keeps a marker-repair re-link over a partial directory
+/// correct.
 pub fn import_indexed_dir<Reporter: self::Reporter>(
     logged_methods: &AtomicU8,
     import_method: PackageImportMethod,
@@ -148,20 +149,11 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
         // Fresh target — populate it. Both linkers take this path on
         // first install.
         (None, _) => populate_dir::<Reporter>(logged_methods, import_method, dir_path, cas_paths),
-        // Existing directory with force=false — pnpm's pre-existence
-        // short-circuit, but keyed on the *completion marker*, not the
-        // mere existence of the directory (`pkgExistsAtTargetDir` in
-        // `fs/indexed-pkg-importer/src/index.ts`, which checks for
-        // `package.json`). A directory that exists but lacks the marker
-        // is a partial result from an interrupted import — `populate_dir`
-        // writes the marker last (see below), so its absence proves the
-        // earlier import never finished. Repair it by re-running
-        // `populate_dir`, which is non-destructive and EEXIST-tolerant:
-        // it links only the files still missing and leaves a sibling
-        // importer's work intact. This matches pnpm's `safeToSkip`
-        // (global-virtual-store) branch, which likewise re-links into an
-        // existing directory rather than destructively replacing it.
-        // Ported from pnpm commit cbfeeef328 (pnpm/pnpm#12204).
+        // Short-circuit only when the completion marker is present
+        // (pnpm's `pkgExistsAtTargetDir`, which checks `package.json`),
+        // not on mere directory existence. A marker-less directory is a
+        // partial import; repair it by re-running the non-destructive
+        // `populate_dir`. Ported from pnpm/pnpm#12204 (cbfeeef328).
         (Some(file_type), false) if file_type.is_dir() => {
             if marker_present(dir_path, cas_paths) {
                 Ok(())
@@ -169,10 +161,7 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
                 populate_dir::<Reporter>(logged_methods, import_method, dir_path, cas_paths)
             }
         }
-        // Existing non-directory dirent with force=false. A stale symlink
-        // or file occupying the slot is left as-is, matching the prior
-        // short-circuit; the force=true path below is the only one that
-        // clobbers a non-directory dirent.
+        // A non-directory dirent is left as-is; only force=true clobbers it.
         (Some(_), false) => Ok(()),
         // Existing non-directory dirent with force=true. The hoisted
         // linker call shape won't produce this in practice, but
@@ -234,24 +223,18 @@ fn populate_dir<Reporter: self::Reporter>(
             .map_err(|error| ImportIndexedDirError::CreateDir { dirname: abs, error })?;
     }
 
-    // pnpm writes the completion marker (`package.json`) last, so a
-    // crash mid-import leaves a directory the next install recognises as
-    // incomplete (`tryImportIndexedDir` in
-    // `fs/indexed-pkg-importer/src/importIndexedDir.ts`). Link every
-    // other file first, in parallel, then place the marker.
+    // Link every other file first, then place the marker last, so an
+    // interrupted import leaves a directory the next install recognises
+    // as incomplete (pnpm's `tryImportIndexedDir`).
     let marker = marker_file(cas_paths);
     cas_paths
         .par_iter()
         .filter(|(cleaned_entry, _)| Some(cleaned_entry.as_str()) != marker)
         .try_for_each(|(cleaned_entry, store_path)| {
-            // Targets are guaranteed fresh: `populate_dir` only runs
-            // against a freshly-mkdir'd `dir_path` (the caller in
-            // `import_indexed_dir` gates on the directory not existing,
-            // or staged it as a new sibling). Skipping the pre-flight
-            // `fs::metadata` saves one `stat` syscall per file — ~170k
-            // on the alotta-files fixture — without losing the
-            // no-op-on-existing-target contract that `link_file` exposes
-            // to other callers.
+            // No pre-flight stat: `import_into_fresh_target` tolerates an
+            // existing target (the repair branch re-links over a partial
+            // directory), so the stat would be pure overhead — ~170k saved
+            // syscalls on the alotta-files fixture.
             import_into_fresh_target::<Reporter>(
                 logged_methods,
                 import_method,
@@ -272,18 +255,12 @@ fn populate_dir<Reporter: self::Reporter>(
     Ok(())
 }
 
-/// Pick the completion-marker filename out of an indexed file map,
-/// mirroring pnpm's `pickFileFromFilesMap`
-/// (`fs/indexed-pkg-importer/src/index.ts`): prefer `package.json` (the
-/// worker synthesises one for every package), and otherwise fall back to
-/// a single file so old store entries indexed before the synthetic
-/// `package.json` still get a marker. pnpm's fallback is the map's
-/// first-by-insertion-order key; pacquet's `cas_paths` is a `HashMap`
-/// with no stable order, so we take the lexicographically smallest key —
-/// deterministic, and good enough since the gate
-/// ([`marker_present`]) and the marker write
-/// ([`populate_dir`]) both consult this same function. Returns `None`
-/// only for an empty map, where there is nothing to import or gate on.
+/// The completion-marker filename, mirroring pnpm's `pickFileFromFilesMap`:
+/// `package.json` when present, else a fallback file for old store entries
+/// indexed before the synthetic manifest. pnpm picks the first inserted
+/// key; `cas_paths` is unordered, so we pick the lexicographically
+/// smallest one instead — deterministic, which is all the gate and the
+/// write need. `None` only for an empty map.
 fn marker_file(cas_paths: &HashMap<String, PathBuf>) -> Option<&str> {
     const PACKAGE_JSON: &str = "package.json";
     if cas_paths.contains_key(PACKAGE_JSON) {
@@ -292,10 +269,8 @@ fn marker_file(cas_paths: &HashMap<String, PathBuf>) -> Option<&str> {
     cas_paths.keys().map(String::as_str).min()
 }
 
-/// Whether `dir_path` already holds the completion marker for this file
-/// map. An empty map has no marker to check, so it counts as present —
-/// there is nothing to import, matching the prior "directory exists ⇒
-/// done" short-circuit for that degenerate case.
+/// Whether `dir_path` holds the completion marker. An empty map has no
+/// marker, so it counts as present — there is nothing to import.
 fn marker_present(dir_path: &Path, cas_paths: &HashMap<String, PathBuf>) -> bool {
     match marker_file(cas_paths) {
         Some(marker) => dir_path.join(marker).exists(),
@@ -303,17 +278,13 @@ fn marker_present(dir_path: &Path, cas_paths: &HashMap<String, PathBuf>) -> bool
     }
 }
 
-/// Import the completion marker so it appears atomically: link it into a
-/// private temp sibling, then rename it onto the marker path. pnpm uses
-/// its `importFileAtomic` for `package.json` (a temp-file + rename on the
-/// copy path; the raw syscall on the already-atomic hardlink/reflink
-/// paths). pacquet's `Auto` / `CloneOrCopy` methods pick their tier at
-/// runtime, so rather than predict whether this import will copy, always
-/// stage-and-rename — one extra rename per package, and the marker can
-/// never be observed half-written. A concurrent importer that placed the
-/// marker first surfaces as `AlreadyExists` (Windows) or is replaced
-/// atomically (POSIX `rename`); either way the content is
-/// content-addressed, so the result is equivalent and we drop our temp.
+/// Place the marker atomically (pnpm's `importFileAtomic`): link it into a
+/// private temp sibling, then rename onto `marker_path` so it is never
+/// observed half-written. pacquet picks its import tier at runtime, so it
+/// always stages rather than predicting whether the import will copy. A
+/// concurrent importer that placed the marker first surfaces as
+/// `AlreadyExists` or is replaced atomically; the content is
+/// content-addressed either way, so we just drop our temp.
 fn import_marker_atomic<Reporter: self::Reporter>(
     logged_methods: &AtomicU8,
     import_method: PackageImportMethod,

--- a/pacquet/crates/package-manager/src/import_indexed_dir/tests.rs
+++ b/pacquet/crates/package-manager/src/import_indexed_dir/tests.rs
@@ -59,10 +59,11 @@ fn fresh_target_links_files() {
 }
 
 /// Default opts (isolated linker) must short-circuit when the target
-/// already exists. This is the load-bearing invariant for the virtual
-/// store: each slot is populated exactly once and never re-imported.
-/// A regression here would cause the isolated linker to do redundant
-/// work and possibly clobber working state.
+/// already holds the completion marker (`package.json`). This is the
+/// load-bearing invariant for the virtual store: a fully-imported slot
+/// is never re-imported. The gate keys on the marker, not on mere
+/// directory existence — a marker-less partial directory is repaired
+/// instead (see [`partial_dir_without_marker_is_repaired`]).
 #[test]
 fn existing_target_short_circuits_under_default_opts() {
     let tmp = tempdir().unwrap();
@@ -532,4 +533,141 @@ fn concurrent_force_imports_into_different_targets_do_not_collide() {
     assert_eq!(fs::read(target_b.join("package.json")).unwrap(), b"two");
     assert!(!target_a.join("stale.txt").exists());
     assert!(!target_b.join("stale.txt").exists());
+}
+
+/// Core of the pnpm/pnpm#12204 port (commit cbfeeef328): a directory
+/// left behind by an interrupted import — present, holding some files,
+/// but missing the `package.json` completion marker — is *repaired* on
+/// the next default-opts import, not treated as complete. The repair is
+/// non-destructive (a sibling importer's unrelated file survives) and
+/// EEXIST-tolerant (an already-linked file is left in place).
+#[test]
+fn partial_dir_without_marker_is_repaired() {
+    let tmp = tempdir().unwrap();
+    let src_root = tmp.path().join("cas");
+    fs::create_dir_all(&src_root).unwrap();
+    let pkg_json = write_source(&src_root, "package.json", b"v1");
+    let code = write_source(&src_root, "index.js", b"codev1");
+    let cas = cas_map(&[("package.json", pkg_json), ("lib/index.js", code)]);
+
+    // An interrupted import: the directory and one non-marker file were
+    // written, then the process died before the marker was placed. A
+    // second, unrelated file stands in for a concurrent importer's work.
+    let target = tmp.path().join("pkg");
+    fs::create_dir_all(target.join("lib")).unwrap();
+    fs::write(target.join("lib/index.js"), b"codev1").unwrap();
+    fs::write(target.join("leftover.txt"), b"keep me").unwrap();
+    assert!(!target.join("package.json").exists(), "precondition: marker absent");
+
+    import_indexed_dir::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Copy,
+        &target,
+        &cas,
+        ImportIndexedDirOpts::default(),
+    )
+    .expect("a marker-less partial directory must be repaired, not skipped");
+
+    // The marker is now present, the already-linked file is intact, and
+    // the unrelated sibling file was not destroyed.
+    assert_eq!(fs::read(target.join("package.json")).unwrap(), b"v1");
+    assert_eq!(fs::read(target.join("lib/index.js")).unwrap(), b"codev1");
+    assert_eq!(fs::read(target.join("leftover.txt")).unwrap(), b"keep me");
+}
+
+/// The mirror of [`partial_dir_without_marker_is_repaired`]: once the
+/// marker is present the import is skipped wholesale, even if other
+/// files are missing. This matches pnpm's `pkgExistsAtTargetDir`, which
+/// checks only the marker — writing it last is what makes its presence a
+/// sound completeness signal, so a marker-present-but-otherwise-partial
+/// directory is not a state a finished import can produce.
+#[test]
+fn existing_marker_short_circuits_even_when_other_files_missing() {
+    let tmp = tempdir().unwrap();
+    let src_root = tmp.path().join("cas");
+    fs::create_dir_all(&src_root).unwrap();
+    let pkg_json = write_source(&src_root, "package.json", b"vNEW");
+    let code = write_source(&src_root, "index.js", b"code");
+    let cas = cas_map(&[("package.json", pkg_json), ("lib/index.js", code)]);
+
+    let target = tmp.path().join("pkg");
+    fs::create_dir_all(&target).unwrap();
+    fs::write(target.join("package.json"), b"vOLD").unwrap();
+
+    import_indexed_dir::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Copy,
+        &target,
+        &cas,
+        ImportIndexedDirOpts::default(),
+    )
+    .expect("marker present should short-circuit");
+
+    assert_eq!(fs::read(target.join("package.json")).unwrap(), b"vOLD", "marker untouched");
+    assert!(!target.join("lib/index.js").exists(), "skipped import must not link other files");
+}
+
+/// When the file map has no `package.json` (an old store entry indexed
+/// before the synthetic manifest), the marker falls back to the
+/// lexicographically smallest filename. A directory missing that file is
+/// still recognised as incomplete and repaired.
+#[test]
+fn fallback_marker_repairs_when_no_package_json() {
+    let tmp = tempdir().unwrap();
+    let src_root = tmp.path().join("cas");
+    fs::create_dir_all(&src_root).unwrap();
+    let a = write_source(&src_root, "a.txt", b"A");
+    let b = write_source(&src_root, "b.txt", b"B");
+    // No package.json: marker is "a.txt" (lexicographically smallest).
+    let cas = cas_map(&[("a.txt", a), ("b.txt", b)]);
+
+    // Partial: the non-marker file is present, the marker ("a.txt") is not.
+    let target = tmp.path().join("pkg");
+    fs::create_dir_all(&target).unwrap();
+    fs::write(target.join("b.txt"), b"B").unwrap();
+
+    import_indexed_dir::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Copy,
+        &target,
+        &cas,
+        ImportIndexedDirOpts::default(),
+    )
+    .expect("missing fallback marker must trigger repair");
+
+    assert_eq!(fs::read(target.join("a.txt")).unwrap(), b"A");
+    assert_eq!(fs::read(target.join("b.txt")).unwrap(), b"B");
+}
+
+/// A successful fresh import must place the marker and leave no staging
+/// temp behind: the marker is imported into a private temp sibling and
+/// renamed onto `package.json`, so a leaked `*_pacquet-stage_*` file
+/// would mean the rename never happened.
+#[test]
+fn fresh_import_places_marker_and_leaks_no_temp() {
+    let tmp = tempdir().unwrap();
+    let src_root = tmp.path().join("cas");
+    fs::create_dir_all(&src_root).unwrap();
+    let pkg_json = write_source(&src_root, "package.json", b"{}");
+    let code = write_source(&src_root, "index.js", b"code");
+    let cas = cas_map(&[("package.json", pkg_json), ("index.js", code)]);
+
+    let target = tmp.path().join("pkg");
+    import_indexed_dir::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Copy,
+        &target,
+        &cas,
+        ImportIndexedDirOpts::default(),
+    )
+    .expect("fresh import should succeed");
+
+    assert!(target.join("package.json").exists(), "marker must be placed");
+    for entry in walkdir::WalkDir::new(&target) {
+        let path = entry.unwrap().into_path();
+        assert!(
+            !path.file_name().and_then(|n| n.to_str()).is_some_and(|n| n.contains("pacquet-stage")),
+            "marker staging temp leaked at {path:?}",
+        );
+    }
 }

--- a/pacquet/crates/package-manager/src/import_indexed_dir/tests.rs
+++ b/pacquet/crates/package-manager/src/import_indexed_dir/tests.rs
@@ -58,12 +58,10 @@ fn fresh_target_links_files() {
     assert_eq!(fs::read(target.join("lib/index.js")).unwrap(), b"beta");
 }
 
-/// Default opts (isolated linker) must short-circuit when the target
-/// already holds the completion marker (`package.json`). This is the
-/// load-bearing invariant for the virtual store: a fully-imported slot
-/// is never re-imported. The gate keys on the marker, not on mere
-/// directory existence — a marker-less partial directory is repaired
-/// instead (see [`partial_dir_without_marker_is_repaired`]).
+/// Default opts (isolated linker) short-circuit when the target holds the
+/// completion marker — the load-bearing invariant that a fully-imported
+/// virtual-store slot is never re-imported. A marker-less directory is
+/// repaired instead (see [`partial_dir_without_marker_is_repaired`]).
 #[test]
 fn existing_target_short_circuits_under_default_opts() {
     let tmp = tempdir().unwrap();
@@ -535,12 +533,9 @@ fn concurrent_force_imports_into_different_targets_do_not_collide() {
     assert!(!target_b.join("stale.txt").exists());
 }
 
-/// Core of the pnpm/pnpm#12204 port (commit cbfeeef328): a directory
-/// left behind by an interrupted import — present, holding some files,
-/// but missing the `package.json` completion marker — is *repaired* on
-/// the next default-opts import, not treated as complete. The repair is
-/// non-destructive (a sibling importer's unrelated file survives) and
-/// EEXIST-tolerant (an already-linked file is left in place).
+/// Core of the pnpm/pnpm#12204 port (commit cbfeeef328): a marker-less
+/// partial directory is repaired, not treated as complete, and the repair
+/// is non-destructive.
 #[test]
 fn partial_dir_without_marker_is_repaired() {
     let tmp = tempdir().unwrap();
@@ -550,9 +545,8 @@ fn partial_dir_without_marker_is_repaired() {
     let code = write_source(&src_root, "index.js", b"codev1");
     let cas = cas_map(&[("package.json", pkg_json), ("lib/index.js", code)]);
 
-    // An interrupted import: the directory and one non-marker file were
-    // written, then the process died before the marker was placed. A
-    // second, unrelated file stands in for a concurrent importer's work.
+    // Interrupted import: one non-marker file written, marker not yet
+    // placed. `leftover.txt` stands in for a concurrent importer's work.
     let target = tmp.path().join("pkg");
     fs::create_dir_all(target.join("lib")).unwrap();
     fs::write(target.join("lib/index.js"), b"codev1").unwrap();
@@ -568,19 +562,14 @@ fn partial_dir_without_marker_is_repaired() {
     )
     .expect("a marker-less partial directory must be repaired, not skipped");
 
-    // The marker is now present, the already-linked file is intact, and
-    // the unrelated sibling file was not destroyed.
     assert_eq!(fs::read(target.join("package.json")).unwrap(), b"v1");
     assert_eq!(fs::read(target.join("lib/index.js")).unwrap(), b"codev1");
     assert_eq!(fs::read(target.join("leftover.txt")).unwrap(), b"keep me");
 }
 
-/// The mirror of [`partial_dir_without_marker_is_repaired`]: once the
-/// marker is present the import is skipped wholesale, even if other
-/// files are missing. This matches pnpm's `pkgExistsAtTargetDir`, which
-/// checks only the marker — writing it last is what makes its presence a
-/// sound completeness signal, so a marker-present-but-otherwise-partial
-/// directory is not a state a finished import can produce.
+/// Mirror of [`partial_dir_without_marker_is_repaired`]: a present marker
+/// short-circuits the whole import, even with other files missing (pnpm's
+/// `pkgExistsAtTargetDir` checks only the marker).
 #[test]
 fn existing_marker_short_circuits_even_when_other_files_missing() {
     let tmp = tempdir().unwrap();
@@ -607,19 +596,17 @@ fn existing_marker_short_circuits_even_when_other_files_missing() {
     assert!(!target.join("lib/index.js").exists(), "skipped import must not link other files");
 }
 
-/// When the file map has no `package.json` (an old store entry indexed
-/// before the synthetic manifest), the marker falls back to the
-/// lexicographically smallest filename. A directory missing that file is
-/// still recognised as incomplete and repaired.
+/// With no `package.json`, the marker falls back to the lexicographically
+/// smallest filename, and a directory missing it is still repaired.
 #[test]
 fn fallback_marker_repairs_when_no_package_json() {
     let tmp = tempdir().unwrap();
     let src_root = tmp.path().join("cas");
     fs::create_dir_all(&src_root).unwrap();
-    let a = write_source(&src_root, "a.txt", b"A");
-    let b = write_source(&src_root, "b.txt", b"B");
+    let a_txt = write_source(&src_root, "a.txt", b"A");
+    let b_txt = write_source(&src_root, "b.txt", b"B");
     // No package.json: marker is "a.txt" (lexicographically smallest).
-    let cas = cas_map(&[("a.txt", a), ("b.txt", b)]);
+    let cas = cas_map(&[("a.txt", a_txt), ("b.txt", b_txt)]);
 
     // Partial: the non-marker file is present, the marker ("a.txt") is not.
     let target = tmp.path().join("pkg");
@@ -639,10 +626,8 @@ fn fallback_marker_repairs_when_no_package_json() {
     assert_eq!(fs::read(target.join("b.txt")).unwrap(), b"B");
 }
 
-/// A successful fresh import must place the marker and leave no staging
-/// temp behind: the marker is imported into a private temp sibling and
-/// renamed onto `package.json`, so a leaked `*_pacquet-stage_*` file
-/// would mean the rename never happened.
+/// A fresh import places the marker and leaves no staging temp behind (a
+/// leaked `*_pacquet-stage_*` file would mean the rename never happened).
 #[test]
 fn fresh_import_places_marker_and_leaks_no_temp() {
     let tmp = tempdir().unwrap();
@@ -663,6 +648,38 @@ fn fresh_import_places_marker_and_leaks_no_temp() {
     .expect("fresh import should succeed");
 
     assert!(target.join("package.json").exists(), "marker must be placed");
+    for entry in walkdir::WalkDir::new(&target) {
+        let path = entry.unwrap().into_path();
+        assert!(
+            !path.file_name().and_then(|n| n.to_str()).is_some_and(|n| n.contains("pacquet-stage")),
+            "marker staging temp leaked at {path:?}",
+        );
+    }
+}
+
+/// Marker-only map into a non-existent target: with the non-marker loop
+/// empty, the target must still be created before the marker is staged
+/// into it.
+#[test]
+fn marker_only_map_creates_target_and_places_marker() {
+    let tmp = tempdir().unwrap();
+    let src_root = tmp.path().join("cas");
+    fs::create_dir_all(&src_root).unwrap();
+    let pkg_json = write_source(&src_root, "package.json", b"{}");
+    let cas = cas_map(&[("package.json", pkg_json)]);
+
+    let target = tmp.path().join("pkg");
+    import_indexed_dir::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Copy,
+        &target,
+        &cas,
+        ImportIndexedDirOpts::default(),
+    )
+    .expect("marker-only import into a non-existent target should succeed");
+
+    assert!(target.is_dir(), "target directory must be created");
+    assert_eq!(fs::read(target.join("package.json")).unwrap(), b"{}", "marker must be placed");
     for entry in walkdir::WalkDir::new(&target) {
         let path = entry.unwrap().into_path();
         assert!(


### PR DESCRIPTION
## What

Ports pnpm/pnpm#12204 (commit cbfeeef328) to pacquet: repair partial virtual-store directories instead of treating them as complete.

## Why

pacquet's `import_indexed_dir` short-circuited on **directory existence**, so a directory left behind by an interrupted import was treated as complete forever, and `populate_dir` linked files in parallel with no ordering guarantee — a crash could leave a partial directory that no later install would repair.

## How

- Gate the `force=false` directory branch on the `package.json` **completion marker** (mirroring pnpm's `pkgExistsAtTargetDir`), not on mere directory existence. A marker-less partial directory is repaired via `populate_dir`, which is non-destructive and EEXIST-tolerant.
- Write the marker **last and atomically** (stage into a temp sibling → rename), so its presence is a sound completeness signal and it can never be observed half-written.

Deliberately does **not** transliterate pnpm's `tryExclusiveImport`/stage-and-swap: pacquet's `populate_dir` is already non-destructive, so the destructive-empty race that guard defends against cannot arise. `force=false` corresponds to pnpm's additive `safeToSkip`/global-virtual-store branch.

## Tests

4 new tests in `import_indexed_dir/tests.rs` (partial repair, marker short-circuit, fallback marker, no temp leaked). `cargo fmt --check`, `clippy --deny warnings`, and all 18 `import_indexed_dir` tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete package installations; partial directories are now automatically repaired instead of being treated as complete.
  * Enhanced import verification to ensure proper tracking of completed operations.

* **Tests**
  * Added test coverage for partial directory recovery and marker placement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->