### PR TITLE
fix(pacquet): poll frozen install verifier first

### DIFF
--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -702,14 +702,18 @@ where
         } = {
             let mut verify_fut = std::pin::pin!(verify_fut);
             let mut create_virtual_store_fut = std::pin::pin!(create_virtual_store_fut);
+            // `select!` randomizes branch polling by default. Poll the
+            // materialization side first so the verifier's metadata fan-out
+            // does not nondeterministically win the first network permits.
             tokio::select! {
-                verify = &mut verify_fut => {
-                    verify?;
-                    create_virtual_store_fut.await?
-                }
+                biased;
                 output = &mut create_virtual_store_fut => {
                     verify_fut.await?;
                     output?
+                }
+                verify = &mut verify_fut => {
+                    verify?;
+                    create_virtual_store_fut.await?
                 }
             }
         };

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -703,17 +703,17 @@ where
             let mut verify_fut = std::pin::pin!(verify_fut);
             let mut create_virtual_store_fut = std::pin::pin!(create_virtual_store_fut);
             // `select!` randomizes branch polling by default. Poll the
-            // materialization side first so the verifier's metadata fan-out
-            // does not nondeterministically win the first network permits.
+            // verifier first so cold frozen restores do not leave the
+            // verification fan-out as a nondeterministic tail after fetches.
             tokio::select! {
                 biased;
-                output = &mut create_virtual_store_fut => {
-                    verify_fut.await?;
-                    output?
-                }
                 verify = &mut verify_fut => {
                     verify?;
                     create_virtual_store_fut.await?
+                }
+                output = &mut create_virtual_store_fut => {
+                    verify_fut.await?;
+                    output?
                 }
             }
         };


### PR DESCRIPTION
## Summary

- make frozen install's concurrent verification/materialization `select!` deterministic by polling the lockfile verifier first
- keep lockfile verification overlapped with fetches while preserving verification-error precedence
- leave the integrated benchmark harness unchanged

## Benchmark

The benchmark harness looks correct; I did not change it. The first materialization-first variant regressed `Scenario: Isolated linker: fresh restore, cold cache + cold store` for direct pacquet while pnpr stayed neutral.

Latest integrated benchmark run for that scenario:

- `pacquet@HEAD`: 4.088 +/- 0.185, min 3.864, max 4.447, median 4.023
- `pacquet@main`: 3.974 +/- 0.074, min 3.887, max 4.118, median 3.961
- `pnpr@HEAD`: 2.163 +/- 0.155
- `pnpr@main`: 2.200 +/- 0.122

This recovers most of the materialization-first regression (`pacquet@HEAD` was 4.302 +/- 0.181 in the first run), but it is still not a clear direct-pacquet stability win over main. This PR stays draft for that reason.

## Testing

- `cargo test -p pacquet-package-manager frozen_lockfile_gate_rejects_under_huge_minimum_release_age`
- `cargo test -p pacquet-package-manager frozen_install_silently_swallows_unreachable_optional_tarball`
- `cargo test -p pacquet-package-manager frozen_install_propagates_non_optional_fetch_failure`
- `cargo clippy --locked -p pacquet-package-manager --all-targets -- --deny warnings`
- pre-push hook completed, including TypeScript compile/lint/spellcheck plus Rust fmt/doc/dylint and Taplo checks
- CI checks are passing after rerunning a transient coverage failure caused by `rust-lld` terminating with signal 7 during the first attempt

---
Written by an agent (Codex, GPT-5).