### PR TITLE
chore: allow selecting git-wt PR agent

### DIFF
--- a/.git-wt/pr-hook
+++ b/.git-wt/pr-hook
@@ -1,14 +1,38 @@
 #!/bin/sh
-# Invoked by @zkochan/git-wt's `wt` shell function after `wt <pr-number>`
-# creates a worktree and cds into it. Silently no-ops for contributors who
-# don't have claude installed.
-command -v claude >/dev/null 2>&1 || exit 0
-exec claude --dangerously-skip-permissions "Review and fix PR #$PR_NUMBER. Steps:
+# Invoked by @zkochan/git-wt after `git wt <pr-number>` creates a worktree.
+# Silently no-ops for contributors who don't have the requested agent installed.
+case "${1:-}" in
+  '')
+    AGENT_CLI=claude
+    ;;
+  *[!0-9]*)
+    AGENT_CLI=$1
+    ;;
+  *)
+    AGENT_CLI=${2:-claude}
+    ;;
+esac
+
+command -v "$AGENT_CLI" >/dev/null 2>&1 || exit 0
+
+PROMPT="Review and fix PR #$PR_NUMBER. Steps:
 1. Use gh to read the PR description, diff, and all review comments (both PR-level and inline).
 2. Understand the intent of the PR and what each change does.
 3. Resolve any conflicts with the base branch by running './shell/resolve-pr-conflicts.sh $PR_NUMBER'. This force-fetches the base branch (avoiding stale refs), rebases, and auto-resolves lockfile conflicts. If it prints MANUAL_RESOLUTION_NEEDED, read the listed conflicted files, resolve the conflict markers, run 'git add' on each resolved file, then run './shell/resolve-pr-conflicts.sh $PR_NUMBER --continue' to finish the rebase and push. Do NOT skip this step. Do NOT assume the branch is up to date.
 4. Address every review comment — fix the code as requested or as appropriate.
 5. Look for any other bugs, issues, or style problems in the changed code and fix those too.
-6. Run the relevant tests to verify your fixes work (check CLAUDE.md for how to run tests).
+6. Run the relevant tests to verify your fixes work.
 7. Give me a summary of what you found and what you changed, including any conflicts you resolved.
 Do NOT push. Leave all non-merge changes unstaged for me to review."
+
+case "$AGENT_CLI" in
+  claude)
+    exec "$AGENT_CLI" --dangerously-skip-permissions "$PROMPT"
+    ;;
+  codex)
+    exec "$AGENT_CLI" --dangerously-bypass-approvals-and-sandbox "$PROMPT"
+    ;;
+  *)
+    exec "$AGENT_CLI" "$PROMPT"
+    ;;
+esac

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,11 +145,12 @@ Passing a number is interpreted as a PR number. The PR is fetched via
 `git fetch origin pull/<number>/head` into a local branch named `pr-<number>`, so it works
 for both same-repo branches and forks.
 
-If [Claude Code](https://www.anthropic.com/claude-code) is installed on your system, `wt
-<pr-number>` will additionally launch a Claude review of the PR via the tracked hook at
-`.git-wt/pr-hook`. The hook silently no-ops if `claude` isn't on your `PATH`, so contributors
-who don't use Claude aren't affected. Requires `@zkochan/git-wt` ≥ 0.0.3, which is the
-version that introduced the per-repo hook lookup.
+For PR worktrees, `git wt <pr-number>` will additionally launch an agent review of the PR via
+the tracked hook at `.git-wt/pr-hook`. The hook defaults to
+[Claude Code](https://www.anthropic.com/claude-code), but you can pass another agent CLI name
+after the PR number, for example `git wt 10000 codex`. The hook silently no-ops if the
+requested CLI isn't on your `PATH`, so contributors who don't use an agent aren't affected.
+Requires a version of `@zkochan/git-wt` with per-repo hook lookup.
 
 If you only need the worktree path (e.g. to open it in an editor) without switching directories,
 invoke `git-wt` directly — it's also exposed as a native git subcommand:


### PR DESCRIPTION
## Summary

- allow the git-wt PR hook to choose an agent CLI from an optional positional argument
- keep claude as the default and add codex-specific launch flags
- document git wt <pr-number> codex usage

## Verification

- sh -n .git-wt/pr-hook
- shellcheck .git-wt/pr-hook
- git diff --check
- PR_NUMBER=123 ./.git-wt/pr-hook true
- PR_NUMBER=123 ./.git-wt/pr-hook 123 true
- pre-push hook passed, including TypeScript builds, bundle, lint, spellcheck, and metadata checks

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing documentation to describe flexible agent CLI selection for automated code reviews in PR worktrees.

* **Chores**
  * Enhanced the PR review hook to support multiple agent CLIs instead of a single hardcoded option, with automatic fallback behavior when the requested CLI is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->