### PR TITLE
fix(pacquet): match pnpm lockfile resolution

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -9,6 +9,7 @@ extend-exclude = [
 
 [default.extend-words]
 cafs = "cafs"
+ect  = "ect"
 pn   = "pn"
 
 [default.extend-identifiers]

--- a/hooks/read-package-hook/src/createReadPackageHook.ts
+++ b/hooks/read-package-hook/src/createReadPackageHook.ts
@@ -11,6 +11,34 @@ import { createOptionalDependenciesRemover } from './createOptionalDependenciesR
 import { createPackageExtender } from './createPackageExtender.js'
 import { createVersionsOverrider, type VersionOverrideWithoutRawSelector } from './createVersionsOverrider.js'
 
+type PackageExtensionField = 'dependencies' | 'optionalDependencies' | 'peerDependencies' | 'peerDependenciesMeta'
+
+const PACKAGE_EXTENSION_FIELDS: PackageExtensionField[] = [
+  'dependencies',
+  'optionalDependencies',
+  'peerDependencies',
+  'peerDependenciesMeta',
+]
+
+export function getEffectivePackageExtensions (
+  {
+    ignoreCompatibilityDb,
+    packageExtensions,
+  }: {
+    ignoreCompatibilityDb?: boolean
+    packageExtensions?: Record<string, PackageExtension>
+  }
+): Record<string, PackageExtension> | undefined {
+  const effectivePackageExtensions: Record<string, PackageExtension> = {}
+  if (!ignoreCompatibilityDb) {
+    mergePackageExtensions(effectivePackageExtensions, compatPackageExtensions)
+  }
+  if (!isEmpty(packageExtensions ?? {})) {
+    mergePackageExtensions(effectivePackageExtensions, Object.entries(packageExtensions!))
+  }
+  return isEmpty(effectivePackageExtensions) ? undefined : effectivePackageExtensions
+}
+
 export function createReadPackageHook (
   {
     ignoreCompatibilityDb,
@@ -29,11 +57,12 @@ export function createReadPackageHook (
   }
 ): ReadPackageHook | undefined {
   const hooks: ReadPackageHook[] = []
-  if (!ignoreCompatibilityDb) {
-    hooks.push(createPackageExtender(Object.fromEntries(compatPackageExtensions)))
-  }
-  if (!isEmpty(packageExtensions ?? {})) {
-    hooks.push(createPackageExtender(packageExtensions!))
+  const effectivePackageExtensions = getEffectivePackageExtensions({
+    ignoreCompatibilityDb,
+    packageExtensions,
+  })
+  if (effectivePackageExtensions != null) {
+    hooks.push(createPackageExtender(effectivePackageExtensions))
   }
   if (Array.isArray(readPackageHook)) {
     hooks.push(...readPackageHook)
@@ -54,4 +83,38 @@ export function createReadPackageHook (
     ? hooks[0]
     : ((pkg: PackageManifest | ProjectManifest, dir: string) => pipeWith(async (f, res) => f(await res, dir), hooks as any)(pkg, dir)) as ReadPackageHook // eslint-disable-line @typescript-eslint/no-explicit-any
   return readPackageAndExtend
+}
+
+function mergePackageExtensions (
+  target: Record<string, PackageExtension>,
+  entries: Iterable<[string, PackageExtension]>
+): void {
+  for (const [selector, packageExtension] of entries) {
+    target[selector] = mergePackageExtension(target[selector], packageExtension)
+  }
+}
+
+function mergePackageExtension (
+  previous: PackageExtension | undefined,
+  next: PackageExtension
+): PackageExtension {
+  if (previous == null) return clonePackageExtension(next)
+  const merged = clonePackageExtension(previous)
+  for (const field of PACKAGE_EXTENSION_FIELDS) {
+    if (next[field] == null) continue
+    merged[field] = {
+      ...next[field],
+      ...merged[field],
+    } as never
+  }
+  return merged
+}
+
+function clonePackageExtension (packageExtension: PackageExtension): PackageExtension {
+  const cloned: PackageExtension = {}
+  for (const field of PACKAGE_EXTENSION_FIELDS) {
+    if (packageExtension[field] == null) continue
+    cloned[field] = { ...packageExtension[field] } as never
+  }
+  return cloned
 }

--- a/hooks/read-package-hook/src/index.ts
+++ b/hooks/read-package-hook/src/index.ts
@@ -1,1 +1,1 @@
-export { createReadPackageHook } from './createReadPackageHook.js'
+export { createReadPackageHook, getEffectivePackageExtensions } from './createReadPackageHook.js'

--- a/hooks/read-package-hook/test/createReadPackageHook.ts
+++ b/hooks/read-package-hook/test/createReadPackageHook.ts
@@ -1,7 +1,7 @@
 import { expect, jest, test } from '@jest/globals'
 import type { ReadPackageHook } from '@pnpm/types'
 
-import { createReadPackageHook } from '../lib/createReadPackageHook.js'
+import { createReadPackageHook, getEffectivePackageExtensions } from '../lib/createReadPackageHook.js'
 
 test('createReadPackageHook() is passing directory to all hooks', async () => {
   const hook1 = jest.fn(((manifest) => manifest) as ReadPackageHook)
@@ -46,6 +46,15 @@ test('createReadPackageHook() runs the custom hook before the version overrider'
   expect(updatedManifest).toStrictEqual({
     dependencies: {
       react: '16',
+    },
+  })
+})
+
+test('getEffectivePackageExtensions() merges duplicate compatibility selectors', () => {
+  expect(getEffectivePackageExtensions({})?.['gatsby-core-utils@<2.14.0-next.1']).toStrictEqual({
+    dependencies: {
+      '@babel/runtime': '^7.14.8',
+      got: '8.3.2',
     },
   })
 })

--- a/installing/deps-installer/test/install/peerDependencies.ts
+++ b/installing/deps-installer/test/install/peerDependencies.ts
@@ -2111,6 +2111,25 @@ test('dedupePeers: version-only peer suffixes without nested dep paths', async (
   expect(lockfile.settings.dedupePeers).toBe(true)
 })
 
+test('transitive pending peer uses provider final suffix in lockfile', async () => {
+  const project = prepareEmpty()
+
+  await install({
+    dependencies: {
+      '@pnpm.e2e/final-peer-a': '1.0.0',
+      '@pnpm.e2e/final-peer-c': '1.0.0',
+    },
+  }, testDefaults())
+
+  const lockfile = project.readLockfile()
+  const snapshots = Object.keys(lockfile.snapshots)
+  const expected = '@pnpm.e2e/final-peer-x@1.0.0(@pnpm.e2e/final-peer-b@1.0.0(@pnpm.e2e/final-peer-a@1.0.0(@pnpm.e2e/final-peer-c@1.0.0)))'
+  const provisional = '@pnpm.e2e/final-peer-x@1.0.0(@pnpm.e2e/final-peer-b@1.0.0(@pnpm.e2e/final-peer-a@1.0.0))'
+
+  expect(snapshots).toContain(expected)
+  expect(snapshots).not.toContain(provisional)
+})
+
 test('a newly added top-level peer provider wins over a locked context', async () => {
   await addDistTag({ package: '@pnpm.e2e/peer-c', version: '1.0.0', distTag: 'latest' })
   const project = prepareEmpty()

--- a/installing/deps-resolver/test/resolvePeers.ts
+++ b/installing/deps-resolver/test/resolvePeers.ts
@@ -126,6 +126,96 @@ test('resolve peer dependencies of cyclic dependencies', async () => {
   ])
 })
 
+test('transitive pending peer uses provider final suffix', async () => {
+  const aPkg = {
+    name: 'a',
+    pkgIdWithPatchHash: 'a@1.0.0' as PkgIdWithPatchHash,
+    version: '1.0.0',
+    peerDependencies: {
+      c: { version: '1.0.0' },
+    },
+    id: '' as PkgResolutionId,
+  }
+  const bPkg = {
+    name: 'b',
+    pkgIdWithPatchHash: 'b@1.0.0' as PkgIdWithPatchHash,
+    version: '1.0.0',
+    peerDependencies: {
+      a: { version: '1.0.0' },
+    },
+    id: '' as PkgResolutionId,
+  }
+  const cPkg = {
+    name: 'c',
+    pkgIdWithPatchHash: 'c@1.0.0' as PkgIdWithPatchHash,
+    version: '1.0.0',
+    peerDependencies: {} as PeerDependencies,
+    id: '' as PkgResolutionId,
+  }
+  const xPkg = {
+    name: 'x',
+    pkgIdWithPatchHash: 'x@1.0.0' as PkgIdWithPatchHash,
+    version: '1.0.0',
+    peerDependencies: {
+      b: { version: '1.0.0' },
+    },
+    id: '' as PkgResolutionId,
+  }
+
+  const { dependenciesGraph } = await resolvePeers({
+    allPeerDepNames: new Set(['a', 'b', 'c']),
+    projects: [
+      {
+        directNodeIdsByAlias: new Map([
+          ['a', '>a@1.0.0>' as NodeId],
+          ['c', '>c@1.0.0>' as NodeId],
+        ]),
+        topParents: [],
+        rootDir: '' as ProjectRootDir,
+        id: '',
+      },
+    ],
+    resolvedImporters: {},
+    dependenciesTree: new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+      ['>a@1.0.0>' as NodeId, {
+        children: {
+          b: '>a@1.0.0>b@1.0.0>' as NodeId,
+          x: '>a@1.0.0>x@1.0.0>' as NodeId,
+        },
+        installable: true,
+        resolvedPackage: aPkg,
+        depth: 0,
+      }],
+      ['>a@1.0.0>b@1.0.0>' as NodeId, {
+        children: {},
+        installable: true,
+        resolvedPackage: bPkg,
+        depth: 1,
+      }],
+      ['>a@1.0.0>x@1.0.0>' as NodeId, {
+        children: {},
+        installable: true,
+        resolvedPackage: xPkg,
+        depth: 1,
+      }],
+      ['>c@1.0.0>' as NodeId, {
+        children: {},
+        installable: true,
+        resolvedPackage: cPkg,
+        depth: 0,
+      }],
+    ]),
+    virtualStoreDir: '',
+    lockfileDir: '',
+    virtualStoreDirMaxLength: 120,
+    peersSuffixMaxLength: 1000,
+    workspaceProjectIds: new Set(),
+  })
+
+  expect(Object.keys(dependenciesGraph)).toContain('x@1.0.0(b@1.0.0(a@1.0.0(c@1.0.0)))')
+  expect(Object.keys(dependenciesGraph)).not.toContain('x@1.0.0(b@1.0.0(a@1.0.0))')
+})
+
 test('when a package is referenced twice in the dependencies graph and one of the times it cannot resolve its peers, still try to resolve it in the other occurrence', async () => {
   const fooPkg = {
     name: 'foo',

--- a/pacquet/crates/cli/tests/install.rs
+++ b/pacquet/crates/cli/tests/install.rs
@@ -441,6 +441,41 @@ fn peer_shared_through_a_diamond_is_resolved_consistently() {
 }
 
 #[test]
+fn transitive_pending_peer_uses_provider_final_suffix_in_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/final-peer-a": "1.0.0",
+            "@pnpm.e2e/final-peer-c": "1.0.0",
+        },
+    });
+    fs::write(&manifest_path, package_json_content.to_string()).expect("write to package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    let lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    let expected = "@pnpm.e2e/final-peer-x@1.0.0(@pnpm.e2e/final-peer-b@1.0.0(@pnpm.e2e/final-peer-a@1.0.0(@pnpm.e2e/final-peer-c@1.0.0)))";
+    let provisional =
+        "@pnpm.e2e/final-peer-x@1.0.0(@pnpm.e2e/final-peer-b@1.0.0(@pnpm.e2e/final-peer-a@1.0.0))";
+
+    assert!(
+        lockfile.contains(expected),
+        "transitive peer must use the provider's final peer suffix; lockfile:\n{lockfile}",
+    );
+    assert!(
+        !lockfile.contains(provisional),
+        "lockfile must not keep the provider's provisional peer suffix; lockfile:\n{lockfile}",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn peer_dependencies_resolve_from_aliased_subdependencies() {
     let lockfile = install_with_peer_alias_deps(serde_json::json!({
         "@pnpm.e2e/abc-parent-with-aliases": "1.0.0",

--- a/pacquet/crates/config/src/env_overlay.rs
+++ b/pacquet/crates/config/src/env_overlay.rs
@@ -162,6 +162,7 @@ impl WorkspaceSettings {
         json_field!(prefer_workspace_packages, "PREFER_WORKSPACE_PACKAGES");
         json_field!(dedupe_injected_deps, "DEDUPE_INJECTED_DEPS");
         json_field!(strict_peer_dependencies, "STRICT_PEER_DEPENDENCIES");
+        json_field!(ignore_compatibility_db, "IGNORE_COMPATIBILITY_DB");
         json_field!(resolve_peers_from_workspace_root, "RESOLVE_PEERS_FROM_WORKSPACE_ROOT");
         json_field!(block_exotic_subdeps, "BLOCK_EXOTIC_SUBDEPS");
         json_field!(verify_store_integrity, "VERIFY_STORE_INTEGRITY");

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -801,6 +801,11 @@ pub struct Config {
     /// If this is enabled, commands will fail if there is a missing or invalid peer dependency in the tree.
     pub strict_peer_dependencies: bool,
 
+    /// When true, skip pnpm's built-in compatibility database from
+    /// `@yarnpkg/extensions`. Default `false` so known broken package
+    /// manifests are patched during resolution.
+    pub ignore_compatibility_db: bool,
+
     /// When enabled, dependencies of the root workspace project are used to resolve peer
     /// dependencies of any projects in the workspace. It is a useful feature as you can install
     /// your peer dependencies only in the root of the workspace, and you can be sure that all

--- a/pacquet/crates/config/src/workspace_yaml.rs
+++ b/pacquet/crates/config/src/workspace_yaml.rs
@@ -169,6 +169,7 @@ pub struct WorkspaceSettings {
     pub prefer_workspace_packages: Option<bool>,
     pub dedupe_injected_deps: Option<bool>,
     pub strict_peer_dependencies: Option<bool>,
+    pub ignore_compatibility_db: Option<bool>,
     pub resolve_peers_from_workspace_root: Option<bool>,
     pub block_exotic_subdeps: Option<bool>,
     pub verify_store_integrity: Option<bool>,
@@ -603,6 +604,7 @@ impl WorkspaceSettings {
         self.prefer_workspace_packages = None;
         self.dedupe_injected_deps = None;
         self.strict_peer_dependencies = None;
+        self.ignore_compatibility_db = None;
         self.resolve_peers_from_workspace_root = None;
         self.block_exotic_subdeps = None;
         self.hoisting_limits = None;
@@ -732,7 +734,7 @@ impl WorkspaceSettings {
             hoist_workspace_packages,
             hoisting_limits, external_dependencies,
             dedupe_peer_dependents, dedupe_peers, dedupe_direct_deps, dedupe_injected_deps,
-            strict_peer_dependencies,
+            strict_peer_dependencies, ignore_compatibility_db,
             resolve_peers_from_workspace_root, verify_store_integrity, frozen_store,
             block_exotic_subdeps,
             link_workspace_packages,

--- a/pacquet/crates/config/src/workspace_yaml/tests.rs
+++ b/pacquet/crates/config/src/workspace_yaml/tests.rs
@@ -33,6 +33,18 @@ packages:
 }
 
 #[test]
+fn parses_ignore_compatibility_db_from_yaml_and_applies() {
+    let settings: WorkspaceSettings =
+        serde_saphyr::from_str("ignoreCompatibilityDb: true\n").unwrap();
+    assert_eq!(settings.ignore_compatibility_db, Some(true));
+
+    let mut config = Config::new();
+    assert!(!config.ignore_compatibility_db);
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+    assert!(config.ignore_compatibility_db);
+}
+
+#[test]
 fn swallows_unknown_top_level_keys() {
     let yaml = r#"
 catalog:

--- a/pacquet/crates/package-manager/src/compat_package_extensions.json
+++ b/pacquet/crates/package-manager/src/compat_package_extensions.json
@@ -1,0 +1,1602 @@
+[
+  [
+    "@tailwindcss/aspect-ratio@<0.2.1",
+    {
+      "peerDependencies": {
+        "tailwindcss": "^2.0.2"
+      }
+    }
+  ],
+  [
+    "@tailwindcss/line-clamp@<0.2.1",
+    {
+      "peerDependencies": {
+        "tailwindcss": "^2.0.2"
+      }
+    }
+  ],
+  [
+    "@fullhuman/postcss-purgecss@3.1.3 || 3.1.3-alpha.0",
+    {
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    }
+  ],
+  [
+    "@samverschueren/stream-to-observable@<0.3.1",
+    {
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        },
+        "zenObservable": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "any-observable@<0.5.1",
+    {
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        },
+        "zenObservable": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "@pm2/agent@<1.0.4",
+    {
+      "dependencies": {
+        "debug": "*"
+      }
+    }
+  ],
+  [
+    "debug@<4.2.0",
+    {
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "got@<11",
+    {
+      "dependencies": {
+        "@types/responselike": "^1.0.0",
+        "@types/keyv": "^3.1.1"
+      }
+    }
+  ],
+  [
+    "cacheable-lookup@<4.1.2",
+    {
+      "dependencies": {
+        "@types/keyv": "^3.1.1"
+      }
+    }
+  ],
+  [
+    "http-link-dataloader@*",
+    {
+      "peerDependencies": {
+        "graphql": "^0.13.1 || ^14.0.0"
+      }
+    }
+  ],
+  [
+    "typescript-language-server@*",
+    {
+      "dependencies": {
+        "vscode-jsonrpc": "^5.0.1",
+        "vscode-languageserver-protocol": "^3.15.0"
+      }
+    }
+  ],
+  [
+    "postcss-syntax@*",
+    {
+      "peerDependenciesMeta": {
+        "postcss-html": {
+          "optional": true
+        },
+        "postcss-jsx": {
+          "optional": true
+        },
+        "postcss-less": {
+          "optional": true
+        },
+        "postcss-markdown": {
+          "optional": true
+        },
+        "postcss-scss": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "jss-plugin-rule-value-function@<=10.1.1",
+    {
+      "dependencies": {
+        "tiny-warning": "^1.0.2"
+      }
+    }
+  ],
+  [
+    "ink-select-input@<4.1.0",
+    {
+      "peerDependencies": {
+        "react": "^16.8.2"
+      }
+    }
+  ],
+  [
+    "license-webpack-plugin@<2.3.18",
+    {
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "snowpack@>=3.3.0",
+    {
+      "dependencies": {
+        "node-gyp": "^7.1.0"
+      }
+    }
+  ],
+  [
+    "promise-inflight@*",
+    {
+      "peerDependenciesMeta": {
+        "bluebird": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "reactcss@*",
+    {
+      "peerDependencies": {
+        "react": "*"
+      }
+    }
+  ],
+  [
+    "react-color@<=2.19.0",
+    {
+      "peerDependencies": {
+        "react": "*"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-i18n@*",
+    {
+      "dependencies": {
+        "ramda": "^0.24.1"
+      }
+    }
+  ],
+  [
+    "useragent@^2.0.0",
+    {
+      "dependencies": {
+        "request": "^2.88.0",
+        "yamlparser": "0.0.x",
+        "semver": "5.5.x"
+      }
+    }
+  ],
+  [
+    "@apollographql/apollo-tools@<=0.5.2",
+    {
+      "peerDependencies": {
+        "graphql": "^14.2.1 || ^15.0.0"
+      }
+    }
+  ],
+  [
+    "material-table@^2.0.0",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.11.2"
+      }
+    }
+  ],
+  [
+    "@babel/parser@*",
+    {
+      "dependencies": {
+        "@babel/types": "^7.8.3"
+      }
+    }
+  ],
+  [
+    "fork-ts-checker-webpack-plugin@<=6.3.4",
+    {
+      "peerDependencies": {
+        "eslint": ">= 6",
+        "typescript": ">= 2.7",
+        "webpack": ">= 4",
+        "vue-template-compiler": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        },
+        "vue-template-compiler": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "rc-animate@<=3.1.1",
+    {
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    }
+  ],
+  [
+    "react-bootstrap-table2-paginator@*",
+    {
+      "dependencies": {
+        "classnames": "^2.2.6"
+      }
+    }
+  ],
+  [
+    "react-draggable@<=4.4.3",
+    {
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    }
+  ],
+  [
+    "apollo-upload-client@<14",
+    {
+      "peerDependencies": {
+        "graphql": "14 - 15"
+      }
+    }
+  ],
+  [
+    "react-instantsearch-core@<=6.7.0",
+    {
+      "peerDependencies": {
+        "algoliasearch": ">= 3.1 < 5"
+      }
+    }
+  ],
+  [
+    "react-instantsearch-dom@<=6.7.0",
+    {
+      "dependencies": {
+        "react-fast-compare": "^3.0.0"
+      }
+    }
+  ],
+  [
+    "ws@<7.2.1",
+    {
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "react-portal@<4.2.2",
+    {
+      "peerDependencies": {
+        "react-dom": "^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0"
+      }
+    }
+  ],
+  [
+    "react-scripts@<=4.0.1",
+    {
+      "peerDependencies": {
+        "react": "*"
+      }
+    }
+  ],
+  [
+    "testcafe@<=1.10.1",
+    {
+      "dependencies": {
+        "@babel/plugin-transform-for-of": "^7.12.1",
+        "@babel/runtime": "^7.12.5"
+      }
+    }
+  ],
+  [
+    "testcafe-legacy-api@<=4.2.0",
+    {
+      "dependencies": {
+        "testcafe-hammerhead": "^17.0.1",
+        "read-file-relative": "^1.2.0"
+      }
+    }
+  ],
+  [
+    "@google-cloud/firestore@<=4.9.3",
+    {
+      "dependencies": {
+        "protobufjs": "^6.8.6"
+      }
+    }
+  ],
+  [
+    "gatsby-source-apiserver@*",
+    {
+      "dependencies": {
+        "babel-polyfill": "^6.26.0"
+      }
+    }
+  ],
+  [
+    "@webpack-cli/package-utils@<=1.0.1-alpha.4",
+    {
+      "dependencies": {
+        "cross-spawn": "^7.0.3"
+      }
+    }
+  ],
+  [
+    "gatsby-remark-prismjs@<3.3.28",
+    {
+      "dependencies": {
+        "lodash": "^4"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-favicon@*",
+    {
+      "peerDependencies": {
+        "webpack": "*"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-sharp@<=4.6.0-next.3",
+    {
+      "dependencies": {
+        "debug": "^4.3.1"
+      }
+    }
+  ],
+  [
+    "gatsby-react-router-scroll@<=5.6.0-next.0",
+    {
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      }
+    }
+  ],
+  [
+    "@rebass/forms@*",
+    {
+      "dependencies": {
+        "@styled-system/should-forward-prop": "^5.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.6"
+      }
+    }
+  ],
+  [
+    "rebass@*",
+    {
+      "peerDependencies": {
+        "react": "^16.8.6"
+      }
+    }
+  ],
+  [
+    "@ant-design/react-slick@<=0.28.3",
+    {
+      "peerDependencies": {
+        "react": ">=16.0.0"
+      }
+    }
+  ],
+  [
+    "mqtt@<4.2.7",
+    {
+      "dependencies": {
+        "duplexify": "^4.1.1"
+      }
+    }
+  ],
+  [
+    "vue-cli-plugin-vuetify@<=2.0.3",
+    {
+      "dependencies": {
+        "semver": "^6.3.0"
+      },
+      "peerDependenciesMeta": {
+        "sass-loader": {
+          "optional": true
+        },
+        "vuetify-loader": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "vue-cli-plugin-vuetify@<=2.0.4",
+    {
+      "dependencies": {
+        "null-loader": "^3.0.0"
+      }
+    }
+  ],
+  [
+    "vue-cli-plugin-vuetify@>=2.4.3",
+    {
+      "peerDependencies": {
+        "vue": "*"
+      }
+    }
+  ],
+  [
+    "@vuetify/cli-plugin-utils@<=0.0.4",
+    {
+      "dependencies": {
+        "semver": "^6.3.0"
+      },
+      "peerDependenciesMeta": {
+        "sass-loader": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "@vue/cli-plugin-typescript@<=5.0.0-alpha.0",
+    {
+      "dependencies": {
+        "babel-loader": "^8.1.0"
+      }
+    }
+  ],
+  [
+    "@vue/cli-plugin-typescript@<=5.0.0-beta.0",
+    {
+      "dependencies": {
+        "@babel/core": "^7.12.16"
+      },
+      "peerDependencies": {
+        "vue-template-compiler": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vue-template-compiler": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "cordova-ios@<=6.3.0",
+    {
+      "dependencies": {
+        "underscore": "^1.9.2"
+      }
+    }
+  ],
+  [
+    "cordova-lib@<=10.0.1",
+    {
+      "dependencies": {
+        "underscore": "^1.9.2"
+      }
+    }
+  ],
+  [
+    "git-node-fs@*",
+    {
+      "peerDependencies": {
+        "js-git": "^0.7.8"
+      },
+      "peerDependenciesMeta": {
+        "js-git": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "consolidate@<0.16.0",
+    {
+      "peerDependencies": {
+        "mustache": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mustache": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "consolidate@<=0.16.0",
+    {
+      "peerDependencies": {
+        "velocityjs": "^2.0.1",
+        "tinyliquid": "^0.2.34",
+        "liquid-node": "^3.0.1",
+        "jade": "^1.11.0",
+        "then-jade": "*",
+        "dust": "^0.3.0",
+        "dustjs-helpers": "^1.7.4",
+        "dustjs-linkedin": "^2.7.5",
+        "swig": "^1.4.2",
+        "swig-templates": "^2.0.3",
+        "razor-tmpl": "^1.3.1",
+        "atpl": ">=0.7.6",
+        "liquor": "^0.0.5",
+        "twig": "^1.15.2",
+        "ejs": "^3.1.5",
+        "eco": "^1.1.0-rc-3",
+        "jazz": "^0.0.18",
+        "jqtpl": "~1.1.0",
+        "hamljs": "^0.6.2",
+        "hamlet": "^0.3.3",
+        "whiskers": "^0.4.0",
+        "haml-coffee": "^1.14.1",
+        "hogan.js": "^3.0.2",
+        "templayed": ">=0.2.3",
+        "handlebars": "^4.7.6",
+        "underscore": "^1.11.0",
+        "lodash": "^4.17.20",
+        "pug": "^3.0.0",
+        "then-pug": "*",
+        "qejs": "^3.0.5",
+        "walrus": "^0.10.1",
+        "mustache": "^4.0.1",
+        "just": "^0.1.8",
+        "ect": "^0.5.9",
+        "mote": "^0.2.0",
+        "toffee": "^0.3.6",
+        "dot": "^1.1.3",
+        "bracket-template": "^1.1.5",
+        "ractive": "^1.3.12",
+        "nunjucks": "^3.2.2",
+        "htmling": "^0.0.8",
+        "babel-core": "^6.26.3",
+        "plates": "~0.4.11",
+        "react-dom": "^16.13.1",
+        "react": "^16.13.1",
+        "arc-templates": "^0.5.3",
+        "vash": "^0.13.0",
+        "slm": "^2.0.0",
+        "marko": "^3.14.4",
+        "teacup": "^2.0.0",
+        "coffee-script": "^1.12.7",
+        "squirrelly": "^5.1.0",
+        "twing": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "velocityjs": {
+          "optional": true
+        },
+        "tinyliquid": {
+          "optional": true
+        },
+        "liquid-node": {
+          "optional": true
+        },
+        "jade": {
+          "optional": true
+        },
+        "then-jade": {
+          "optional": true
+        },
+        "dust": {
+          "optional": true
+        },
+        "dustjs-helpers": {
+          "optional": true
+        },
+        "dustjs-linkedin": {
+          "optional": true
+        },
+        "swig": {
+          "optional": true
+        },
+        "swig-templates": {
+          "optional": true
+        },
+        "razor-tmpl": {
+          "optional": true
+        },
+        "atpl": {
+          "optional": true
+        },
+        "liquor": {
+          "optional": true
+        },
+        "twig": {
+          "optional": true
+        },
+        "ejs": {
+          "optional": true
+        },
+        "eco": {
+          "optional": true
+        },
+        "jazz": {
+          "optional": true
+        },
+        "jqtpl": {
+          "optional": true
+        },
+        "hamljs": {
+          "optional": true
+        },
+        "hamlet": {
+          "optional": true
+        },
+        "whiskers": {
+          "optional": true
+        },
+        "haml-coffee": {
+          "optional": true
+        },
+        "hogan.js": {
+          "optional": true
+        },
+        "templayed": {
+          "optional": true
+        },
+        "handlebars": {
+          "optional": true
+        },
+        "underscore": {
+          "optional": true
+        },
+        "lodash": {
+          "optional": true
+        },
+        "pug": {
+          "optional": true
+        },
+        "then-pug": {
+          "optional": true
+        },
+        "qejs": {
+          "optional": true
+        },
+        "walrus": {
+          "optional": true
+        },
+        "mustache": {
+          "optional": true
+        },
+        "just": {
+          "optional": true
+        },
+        "ect": {
+          "optional": true
+        },
+        "mote": {
+          "optional": true
+        },
+        "toffee": {
+          "optional": true
+        },
+        "dot": {
+          "optional": true
+        },
+        "bracket-template": {
+          "optional": true
+        },
+        "ractive": {
+          "optional": true
+        },
+        "nunjucks": {
+          "optional": true
+        },
+        "htmling": {
+          "optional": true
+        },
+        "babel-core": {
+          "optional": true
+        },
+        "plates": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "arc-templates": {
+          "optional": true
+        },
+        "vash": {
+          "optional": true
+        },
+        "slm": {
+          "optional": true
+        },
+        "marko": {
+          "optional": true
+        },
+        "teacup": {
+          "optional": true
+        },
+        "coffee-script": {
+          "optional": true
+        },
+        "squirrelly": {
+          "optional": true
+        },
+        "twing": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "vue-loader@<=16.3.3",
+    {
+      "peerDependencies": {
+        "@vue/compiler-sfc": "^3.0.8",
+        "webpack": "^4.1.0 || ^5.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "vue-loader@^16.7.0",
+    {
+      "peerDependencies": {
+        "@vue/compiler-sfc": "^3.0.8",
+        "vue": "^3.2.13"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "scss-parser@<=1.0.5",
+    {
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    }
+  ],
+  [
+    "query-ast@<1.0.5",
+    {
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    }
+  ],
+  [
+    "redux-thunk@<=2.3.0",
+    {
+      "peerDependencies": {
+        "redux": "^4.0.0"
+      }
+    }
+  ],
+  [
+    "skypack@<=0.3.2",
+    {
+      "dependencies": {
+        "tar": "^6.1.0"
+      }
+    }
+  ],
+  [
+    "@npmcli/metavuln-calculator@<2.0.0",
+    {
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.1"
+      }
+    }
+  ],
+  [
+    "bin-links@<2.3.0",
+    {
+      "dependencies": {
+        "mkdirp-infer-owner": "^1.0.2"
+      }
+    }
+  ],
+  [
+    "rollup-plugin-polyfill-node@<=0.8.0",
+    {
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
+      }
+    }
+  ],
+  [
+    "snowpack@<3.8.6",
+    {
+      "dependencies": {
+        "magic-string": "^0.25.7"
+      }
+    }
+  ],
+  [
+    "elm-webpack-loader@*",
+    {
+      "dependencies": {
+        "temp": "^0.9.4"
+      }
+    }
+  ],
+  [
+    "winston-transport@<=4.4.0",
+    {
+      "dependencies": {
+        "logform": "^2.2.0"
+      }
+    }
+  ],
+  [
+    "jest-vue-preprocessor@*",
+    {
+      "dependencies": {
+        "@babel/core": "7.8.7",
+        "@babel/template": "7.8.6"
+      },
+      "peerDependencies": {
+        "pug": "^2.0.4"
+      },
+      "peerDependenciesMeta": {
+        "pug": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "redux-persist@*",
+    {
+      "peerDependencies": {
+        "react": ">=16"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "sodium@>=3",
+    {
+      "dependencies": {
+        "node-gyp": "^3.8.0"
+      }
+    }
+  ],
+  [
+    "babel-plugin-graphql-tag@<=3.1.0",
+    {
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    }
+  ],
+  [
+    "@playwright/test@<=1.14.1",
+    {
+      "dependencies": {
+        "jest-matcher-utils": "^26.4.2"
+      }
+    }
+  ],
+  [
+    "babel-plugin-remove-graphql-queries@<3.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "babel-preset-gatsby-package@<1.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "create-gatsby@<1.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-admin@<0.24.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-cli@<3.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-core-utils@<2.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8",
+        "got": "8.3.2"
+      }
+    }
+  ],
+  [
+    "gatsby-design-tokens@<3.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-legacy-polyfills@<1.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-benchmark-reporting@<1.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-graphql-config@<0.23.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-image@<1.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-mdx@<2.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-netlify-cms@<5.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-no-sourcemaps@<3.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-page-creator@<3.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-preact@<5.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-preload-fonts@<2.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-schema-snapshot@<2.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-styletron@<6.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-subfont@<3.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-utils@<1.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-recipes@<0.25.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-source-shopify@<5.6.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-source-wikipedia@<3.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-transformer-screenshot@<3.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-worker@<0.5.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-gatsby-cloud@<=3.1.0-next.0",
+    {
+      "dependencies": {
+        "gatsby-core-utils": "^2.13.0-next.0"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-gatsby-cloud@<=3.2.0-next.1",
+    {
+      "peerDependencies": {
+        "webpack": "*"
+      }
+    }
+  ],
+  [
+    "babel-plugin-remove-graphql-queries@<=3.14.0-next.1",
+    {
+      "dependencies": {
+        "gatsby-core-utils": "^2.8.0-next.1"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-netlify@3.13.0-next.1",
+    {
+      "dependencies": {
+        "gatsby-core-utils": "^2.13.0-next.0"
+      }
+    }
+  ],
+  [
+    "clipanion-v3-codemod@<=0.2.0",
+    {
+      "peerDependencies": {
+        "jscodeshift": "^0.11.0"
+      }
+    }
+  ],
+  [
+    "react-live@*",
+    {
+      "peerDependencies": {
+        "react-dom": "*",
+        "react": "*"
+      }
+    }
+  ],
+  [
+    "webpack@<4.44.1",
+    {
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        },
+        "webpack-command": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "webpack@<5.0.0-beta.23",
+    {
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "webpack-dev-server@<3.10.2",
+    {
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "@docusaurus/responsive-loader@<1.5.0",
+    {
+      "peerDependenciesMeta": {
+        "sharp": {
+          "optional": true
+        },
+        "jimp": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "eslint-module-utils@*",
+    {
+      "peerDependenciesMeta": {
+        "eslint-import-resolver-node": {
+          "optional": true
+        },
+        "eslint-import-resolver-typescript": {
+          "optional": true
+        },
+        "eslint-import-resolver-webpack": {
+          "optional": true
+        },
+        "@typescript-eslint/parser": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "eslint-plugin-import@*",
+    {
+      "peerDependenciesMeta": {
+        "@typescript-eslint/parser": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "critters-webpack-plugin@<3.0.2",
+    {
+      "peerDependenciesMeta": {
+        "html-webpack-plugin": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "terser@<=5.10.0",
+    {
+      "dependencies": {
+        "acorn": "^8.5.0"
+      }
+    }
+  ],
+  [
+    "babel-preset-react-app@10.0.x <10.0.2",
+    {
+      "dependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.16.7"
+      }
+    }
+  ],
+  [
+    "eslint-config-react-app@*",
+    {
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "@vue/eslint-config-typescript@<11.0.0",
+    {
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "unplugin-vue2-script-setup@<0.9.1",
+    {
+      "peerDependencies": {
+        "@vue/composition-api": "^1.4.3",
+        "@vue/runtime-dom": "^3.2.26"
+      }
+    }
+  ],
+  [
+    "@cypress/snapshot@*",
+    {
+      "dependencies": {
+        "debug": "^3.2.7"
+      }
+    }
+  ],
+  [
+    "auto-relay@<=0.14.0",
+    {
+      "peerDependencies": {
+        "reflect-metadata": "^0.1.13"
+      }
+    }
+  ],
+  [
+    "vue-template-babel-compiler@<1.2.0",
+    {
+      "peerDependencies": {
+        "vue-template-compiler": "^2.6.0"
+      }
+    }
+  ],
+  [
+    "@parcel/transformer-image@<2.5.0",
+    {
+      "peerDependencies": {
+        "@parcel/core": "*"
+      }
+    }
+  ],
+  [
+    "@parcel/transformer-js@<2.5.0",
+    {
+      "peerDependencies": {
+        "@parcel/core": "*"
+      }
+    }
+  ],
+  [
+    "parcel@*",
+    {
+      "peerDependenciesMeta": {
+        "@parcel/core": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "react-scripts@*",
+    {
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    }
+  ],
+  [
+    "focus-trap-react@^8.0.0",
+    {
+      "dependencies": {
+        "tabbable": "^5.3.2"
+      }
+    }
+  ],
+  [
+    "react-rnd@<10.3.7",
+    {
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    }
+  ],
+  [
+    "connect-mongo@<5.0.0",
+    {
+      "peerDependencies": {
+        "express-session": "^1.17.1"
+      }
+    }
+  ],
+  [
+    "vue-i18n@<9",
+    {
+      "peerDependencies": {
+        "vue": "^2"
+      }
+    }
+  ],
+  [
+    "vue-router@<4",
+    {
+      "peerDependencies": {
+        "vue": "^2"
+      }
+    }
+  ],
+  [
+    "unified@<10",
+    {
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      }
+    }
+  ],
+  [
+    "react-github-btn@<=1.3.0",
+    {
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    }
+  ],
+  [
+    "react-dev-utils@*",
+    {
+      "peerDependencies": {
+        "typescript": ">=2.7",
+        "webpack": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "@asyncapi/react-component@<=1.0.0-next.39",
+    {
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    }
+  ],
+  [
+    "xo@*",
+    {
+      "peerDependencies": {
+        "webpack": ">=1.11.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "babel-plugin-remove-graphql-queries@<=4.20.0-next.0",
+    {
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-page-creator@<=4.20.0-next.1",
+    {
+      "dependencies": {
+        "fs-extra": "^10.1.0"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-utils@<=3.14.0-next.1",
+    {
+      "dependencies": {
+        "fastq": "^1.13.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.0.0"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-mdx@<3.1.0-next.1",
+    {
+      "dependencies": {
+        "mkdirp": "^1.0.4"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-mdx@^2",
+    {
+      "peerDependencies": {
+        "gatsby": "^3.0.0-next"
+      }
+    }
+  ],
+  [
+    "fdir@<=5.2.0",
+    {
+      "peerDependencies": {
+        "picomatch": "2.x"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "babel-plugin-transform-typescript-metadata@<=0.3.2",
+    {
+      "peerDependencies": {
+        "@babel/core": "^7",
+        "@babel/traverse": "^7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/traverse": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "graphql-compose@>=9.0.10",
+    {
+      "peerDependencies": {
+        "graphql": "^14.2.0 || ^15.0.0 || ^16.0.0"
+      }
+    }
+  ],
+  [
+    "vite-plugin-vuetify@<=1.0.2",
+    {
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    }
+  ],
+  [
+    "webpack-plugin-vuetify@<=2.0.1",
+    {
+      "peerDependencies": {
+        "vue": "^3.2.6"
+      }
+    }
+  ],
+  [
+    "eslint-import-resolver-vite@<2.0.1",
+    {
+      "dependencies": {
+        "debug": "^4.3.4",
+        "resolve": "^1.22.8"
+      }
+    }
+  ],
+  [
+    "notistack@^3.0.0",
+    {
+      "dependencies": {
+        "csstype": "^3.0.10"
+      }
+    }
+  ],
+  [
+    "@fastify/type-provider-typebox@^5.0.0",
+    {
+      "peerDependencies": {
+        "fastify": "^5.0.0"
+      }
+    }
+  ],
+  [
+    "@fastify/type-provider-typebox@^4.0.0",
+    {
+      "peerDependencies": {
+        "fastify": "^4.0.0"
+      }
+    }
+  ]
+]

--- a/pacquet/crates/package-manager/src/compat_package_extensions.rs
+++ b/pacquet/crates/package-manager/src/compat_package_extensions.rs
@@ -1,18 +1,21 @@
 use crate::PackageExtender;
 use indexmap::IndexMap;
 use pacquet_config::{PackageExtension, PeerDependencyMeta};
-use std::{collections::BTreeMap, sync::OnceLock};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, OnceLock},
+};
 
 static COMPAT_PACKAGE_EXTENSIONS: OnceLock<IndexMap<String, PackageExtension>> = OnceLock::new();
-static COMPAT_PACKAGE_EXTENDER: OnceLock<PackageExtender> = OnceLock::new();
+static COMPAT_PACKAGE_EXTENDER: OnceLock<Arc<PackageExtender>> = OnceLock::new();
 
-pub(crate) fn compat_package_extender() -> PackageExtender {
-    COMPAT_PACKAGE_EXTENDER
-        .get_or_init(|| {
+pub(crate) fn compat_package_extender() -> Arc<PackageExtender> {
+    Arc::clone(COMPAT_PACKAGE_EXTENDER.get_or_init(|| {
+        Arc::new(
             PackageExtender::new(compat_package_extensions())
-                .expect("@yarnpkg/extensions compatibility DB selectors are valid")
-        })
-        .clone()
+                .expect("@yarnpkg/extensions compatibility DB selectors are valid"),
+        )
+    }))
 }
 
 fn compat_package_extensions() -> &'static IndexMap<String, PackageExtension> {

--- a/pacquet/crates/package-manager/src/compat_package_extensions.rs
+++ b/pacquet/crates/package-manager/src/compat_package_extensions.rs
@@ -1,0 +1,73 @@
+use crate::PackageExtender;
+use indexmap::IndexMap;
+use pacquet_config::{PackageExtension, PeerDependencyMeta};
+use std::{collections::BTreeMap, sync::OnceLock};
+
+static COMPAT_PACKAGE_EXTENSIONS: OnceLock<IndexMap<String, PackageExtension>> = OnceLock::new();
+static COMPAT_PACKAGE_EXTENDER: OnceLock<PackageExtender> = OnceLock::new();
+
+pub(crate) fn compat_package_extender() -> PackageExtender {
+    COMPAT_PACKAGE_EXTENDER
+        .get_or_init(|| {
+            PackageExtender::new(compat_package_extensions())
+                .expect("@yarnpkg/extensions compatibility DB selectors are valid")
+        })
+        .clone()
+}
+
+fn compat_package_extensions() -> &'static IndexMap<String, PackageExtension> {
+    COMPAT_PACKAGE_EXTENSIONS.get_or_init(|| {
+        let entries: Vec<(String, PackageExtension)> =
+            serde_json::from_str(include_str!("compat_package_extensions.json"))
+                .expect("@yarnpkg/extensions compatibility DB JSON is valid");
+        let mut extensions = IndexMap::new();
+        for (selector, extension) in entries {
+            merge_package_extension_entry(&mut extensions, selector, extension);
+        }
+        extensions
+    })
+}
+
+fn merge_package_extension_entry(
+    extensions: &mut IndexMap<String, PackageExtension>,
+    selector: String,
+    extension: PackageExtension,
+) {
+    match extensions.get_mut(&selector) {
+        Some(previous) => merge_package_extension(previous, &extension),
+        None => {
+            extensions.insert(selector, extension);
+        }
+    }
+}
+
+fn merge_package_extension(previous: &mut PackageExtension, next: &PackageExtension) {
+    merge_string_map(&mut previous.dependencies, next.dependencies.as_ref());
+    merge_string_map(&mut previous.optional_dependencies, next.optional_dependencies.as_ref());
+    merge_string_map(&mut previous.peer_dependencies, next.peer_dependencies.as_ref());
+    merge_peer_meta_map(&mut previous.peer_dependencies_meta, next.peer_dependencies_meta.as_ref());
+}
+
+fn merge_string_map(
+    previous: &mut Option<BTreeMap<String, String>>,
+    next: Option<&BTreeMap<String, String>>,
+) {
+    let Some(next) = next else { return };
+    let mut merged = next.clone();
+    if let Some(previous) = previous.take() {
+        merged.extend(previous);
+    }
+    *previous = Some(merged);
+}
+
+fn merge_peer_meta_map(
+    previous: &mut Option<BTreeMap<String, PeerDependencyMeta>>,
+    next: Option<&BTreeMap<String, PeerDependencyMeta>>,
+) {
+    let Some(next) = next else { return };
+    let mut merged = next.clone();
+    if let Some(previous) = previous.take() {
+        merged.extend(previous);
+    }
+    *previous = Some(merged);
+}

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -341,14 +341,14 @@ fn build_importer(
 }
 
 /// Map each direct-dep alias to the manifest group it appears in.
-/// `dependencies` wins over `devDependencies` wins over
-/// `optionalDependencies` when an alias is duplicated across groups —
+/// `optionalDependencies` wins over `dependencies` wins over
+/// `devDependencies` when an alias is duplicated across groups —
 /// mirrors upstream's
 /// [`getAliasToDependencyTypeMap`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/index.ts#L500-L511)
 /// (first-write-wins over `DEPENDENCIES_FIELDS`).
 fn manifest_alias_to_group(manifest: &PackageManifest) -> HashMap<String, DependencyGroup> {
     let mut out: HashMap<String, DependencyGroup> = HashMap::new();
-    for group in [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional] {
+    for group in [DependencyGroup::Optional, DependencyGroup::Prod, DependencyGroup::Dev] {
         for (alias, _) in manifest.dependencies([group]) {
             out.entry(alias.to_string()).or_insert(group);
         }
@@ -357,7 +357,7 @@ fn manifest_alias_to_group(manifest: &PackageManifest) -> HashMap<String, Depend
 }
 
 /// Look up the user-written specifier for `alias` in the manifest's
-/// `dependencies` / `devDependencies` / `optionalDependencies` /
+/// `optionalDependencies` / `dependencies` / `devDependencies` /
 /// `peerDependencies` maps in pnpm's
 /// [`DEPENDENCIES_FIELDS`](https://github.com/pnpm/pnpm/blob/097983fbca/packages/types/src/misc.ts)
 /// precedence order. Returns `None` for a peer-only entry that was
@@ -365,9 +365,9 @@ fn manifest_alias_to_group(manifest: &PackageManifest) -> HashMap<String, Depend
 /// such entries don't go into the importer's `specifiers` map.
 fn read_manifest_specifier(manifest: &PackageManifest, alias: &str) -> Option<String> {
     for group in [
+        DependencyGroup::Optional,
         DependencyGroup::Prod,
         DependencyGroup::Dev,
-        DependencyGroup::Optional,
         DependencyGroup::Peer,
     ] {
         let group_key: &str = group.into();

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -387,6 +387,39 @@ fn dev_and_optional_direct_deps_split_into_distinct_importer_sections() {
     assert_eq!(packages[&fsevents_key].os.as_deref(), Some(["darwin".to_string()].as_slice()));
 }
 
+#[test]
+fn duplicate_manifest_alias_uses_pnpm_dependency_field_precedence() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "fixture",
+        "version": "1.0.0",
+        "devDependencies": { "duplicated": "^1.0.0" },
+        "optionalDependencies": { "duplicated": "^1.0.0" },
+    }));
+
+    let duplicated = make_node(
+        "duplicated",
+        "1.0.0",
+        json!({ "name": "duplicated", "version": "1.0.0" }),
+        BTreeMap::new(),
+        BTreeMap::new(),
+        HashSet::new(),
+    );
+    let mut graph = DependenciesGraph::new();
+    graph.insert(duplicated.dep_path.clone(), duplicated);
+
+    let mut direct = BTreeMap::new();
+    direct.insert("duplicated".to_string(), DepPath::from("duplicated@1.0.0".to_string()));
+
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, false, false, None, None,
+    ));
+
+    let importer = lockfile.root_project().expect("root importer");
+    assert!(importer.dev_dependencies.is_none(), "optionalDependencies wins over devDependencies");
+    let opt = importer.optional_dependencies.as_ref().expect("optional deps");
+    assert!(opt.contains_key(&PkgName::parse("duplicated").unwrap()));
+}
+
 /// A `catalog:` dependency resolved through an `npm:` alias still records a
 /// `catalogs:` snapshot entry — `{ specifier: npm:@zkochan/js-yaml@0.0.11,
 /// version: 0.0.11 }`. The importer stores the aliased dep as

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1421,13 +1421,8 @@ pub(crate) fn check_lockfile_settings_drift(
 ) -> Result<(), FreshnessCheckError> {
     let overrides_map: Option<std::collections::HashMap<String, String>> =
         parsed_overrides.map(pacquet_config_parse_overrides::create_overrides_map_from_parsed);
-    let package_extensions_checksum = config
-        .package_extensions
-        .as_ref()
-        .filter(|extensions| !extensions.is_empty())
-        .and_then(|extensions| serde_json::to_value(extensions).ok())
-        .as_ref()
-        .and_then(pacquet_graph_hasher::hash_object_nullable_with_prefix);
+    let package_extensions_checksum =
+        crate::install_with_fresh_lockfile::compute_package_extensions_checksum(config);
     // `calcPatchHashes(opts.patchedDependencies)` — reading the patch
     // files here lets `check_lockfile_settings` catch an edited patch
     // whose hash (and thus its `(patch_hash=...)` depPath suffix) drifted

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -4282,6 +4282,75 @@ async fn fresh_install_writes_pnpm_lock_yaml_with_expected_shape() {
     drop((dir, mock_instance));
 }
 
+#[tokio::test]
+async fn fresh_install_uses_final_peer_suffix_for_transitive_pending_peer() {
+    let mock_instance = TestRegistry::start();
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path.clone()).unwrap();
+    manifest.add_dependency("@pnpm.e2e/final-peer-a", "1.0.0", DependencyGroup::Prod).unwrap();
+    manifest.add_dependency("@pnpm.e2e/final-peer-c", "1.0.0", DependencyGroup::Prod).unwrap();
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir;
+    config.registry = mock_instance.url();
+    let config = config.leak();
+
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        lockfile: MaybeLazyLockfile::Loaded(None),
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        is_full_install: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+        auth_override: None,
+        resolution_observer: None,
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("install should succeed");
+
+    let content =
+        std::fs::read_to_string(dir.path().join(Lockfile::FILE_NAME)).expect("read pnpm-lock.yaml");
+    let expected = "@pnpm.e2e/final-peer-x@1.0.0(@pnpm.e2e/final-peer-b@1.0.0(@pnpm.e2e/final-peer-a@1.0.0(@pnpm.e2e/final-peer-c@1.0.0)))";
+    let provisional =
+        "@pnpm.e2e/final-peer-x@1.0.0(@pnpm.e2e/final-peer-b@1.0.0(@pnpm.e2e/final-peer-a@1.0.0))";
+
+    assert!(
+        content.contains(expected),
+        "transitive peer must use the provider's final peer suffix; lockfile:\n{content}",
+    );
+    assert!(
+        !content.contains(provisional),
+        "lockfile must not keep the provider's provisional peer suffix; lockfile:\n{content}",
+    );
+
+    drop((dir, mock_instance));
+}
+
 /// Manifest-declared dependency groups land in the matching importer
 /// section in the lockfile. Mirrors upstream's
 /// ["packages are placed in devDependencies even if they are present as
@@ -6848,6 +6917,94 @@ fn assert_package_absent(lockfile: &Lockfile, key: &str) {
         lockfile.packages.as_ref().is_none_or(|packages| !packages.contains_key(&key)),
         "expected packages not to contain {key}",
     );
+}
+
+#[tokio::test]
+async fn fresh_install_applies_builtin_compatibility_db_to_dependency_manifest() {
+    let (_dir, lockfile) = fresh_lockfile_only_with_compatibility_db(false).await;
+    let metadata = lockfile
+        .packages
+        .as_ref()
+        .and_then(|packages| packages.get(&"debug@4.0.0".parse().unwrap()))
+        .expect("debug package metadata recorded");
+    assert_eq!(
+        metadata
+            .peer_dependencies_meta
+            .as_ref()
+            .and_then(|meta| meta.get("supports-color"))
+            .map(|meta| meta.optional),
+        Some(true),
+    );
+    assert_eq!(lockfile.package_extensions_checksum, None);
+}
+
+#[tokio::test]
+async fn fresh_install_skips_builtin_compatibility_db_when_ignored() {
+    let (_dir, lockfile) = fresh_lockfile_only_with_compatibility_db(true).await;
+    let metadata = lockfile
+        .packages
+        .as_ref()
+        .and_then(|packages| packages.get(&"debug@4.0.0".parse().unwrap()))
+        .expect("debug package metadata recorded");
+    assert!(metadata.peer_dependencies_meta.is_none());
+    assert_eq!(lockfile.package_extensions_checksum, None);
+}
+
+async fn fresh_lockfile_only_with_compatibility_db(
+    ignore_compatibility_db: bool,
+) -> (tempfile::TempDir, Lockfile) {
+    let mock_instance = TestRegistry::start();
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let modules_dir = dir.path().join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    manifest.add_dependency("debug", "4.0.0", DependencyGroup::Prod).unwrap();
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir;
+    config.virtual_store_dir = virtual_store_dir;
+    config.registry = mock_instance.url();
+    config.ignore_compatibility_db = ignore_compatibility_db;
+    let config = config.leak();
+
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        lockfile: MaybeLazyLockfile::Loaded(None),
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: Some(false),
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        is_full_install: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: true,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+        auth_override: None,
+        resolution_observer: None,
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("lockfile-only install should succeed");
+
+    let lockfile_path = dir.path().join(Lockfile::FILE_NAME);
+    let content = std::fs::read_to_string(lockfile_path).expect("read lockfile");
+    let lockfile = serde_saphyr::from_str(&content).expect("parse lockfile");
+    (dir, lockfile)
 }
 
 /// `packageExtensions` adds entries to a dependency's manifest at

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -66,6 +66,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         dedupe_direct_deps: true,
         dedupe_injected_deps: false,
         strict_peer_dependencies: false,
+        ignore_compatibility_db: false,
         resolve_peers_from_workspace_root: false,
         block_exotic_subdeps: false,
         verify_store_integrity: true,

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -843,7 +843,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         let compat_package_extender = if config.ignore_compatibility_db {
             None
         } else {
-            Some(Arc::new(crate::compat_package_extensions::compat_package_extender()))
+            Some(crate::compat_package_extensions::compat_package_extender())
         };
         let package_extender = match config.package_extensions.as_ref() {
             Some(extensions) => {

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -840,6 +840,11 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // `createReadPackageHook`: packageExtensions first, overrides
         // after that. The pnpmfile readPackage hook is still threaded
         // separately and runs after this built-in hook in the resolver.
+        let compat_package_extender = if config.ignore_compatibility_db {
+            None
+        } else {
+            Some(Arc::new(crate::compat_package_extensions::compat_package_extender()))
+        };
         let package_extender = match config.package_extensions.as_ref() {
             Some(extensions) => {
                 let extender = crate::PackageExtender::new(extensions)
@@ -848,16 +853,21 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             }
             None => None,
         };
+        let package_extensions_checksum = compute_package_extensions_checksum(config);
         let versions_overrider = parsed_overrides
             .as_ref()
             .map(|parsed| Arc::new(VersionsOverrider::new(parsed, lockfile_dir)));
 
         let mut effective_importer_manifests_holder = BTreeMap::new();
-        if package_extender.is_some()
+        if compat_package_extender.is_some()
+            || package_extender.is_some()
             || versions_overrider.as_ref().is_some_and(|overrider| !overrider.is_empty())
         {
             for (id, manifest) in &importer_manifests {
                 let mut cloned = (*manifest).clone();
+                if let Some(extender) = compat_package_extender.as_ref() {
+                    extender.apply(cloned.value_mut());
+                }
                 if let Some(extender) = package_extender.as_ref() {
                     extender.apply(cloned.value_mut());
                 }
@@ -878,6 +888,11 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                     .collect()
             };
 
+        let compat_package_extensions_hook: Option<ManifestHook> =
+            compat_package_extender.as_ref().map(|extender| {
+                let extender = Arc::clone(extender);
+                Arc::new(move |manifest| extender.apply_to_arc(manifest)) as ManifestHook
+            });
         let package_extensions_hook: Option<ManifestHook> =
             package_extender.as_ref().map(|extender| {
                 let extender = Arc::clone(extender);
@@ -893,7 +908,10 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                         as ManifestHook)
                 }
             });
-        let manifest_hook = compose_manifest_hooks(package_extensions_hook, overrides_hook);
+        let manifest_hook = compose_manifest_hooks(
+            compose_manifest_hooks(compat_package_extensions_hook, package_extensions_hook),
+            overrides_hook,
+        );
 
         // Seed `allPreferredVersions` from every importer's manifest +
         // the wanted lockfile's snapshots (when an existing one is
@@ -1071,6 +1089,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             dedupe_peers: config.dedupe_peers,
             dedupe_injected_deps: config.dedupe_injected_deps,
             dedupe_peer_dependents: config.dedupe_peer_dependents,
+            resolve_peers_from_workspace_root: config.resolve_peers_from_workspace_root,
             exclude_links_from_lockfile: config.exclude_links_from_lockfile,
             lockfile_dir: lockfile_dir.to_path_buf(),
             peers_suffix_max_length,
@@ -1088,8 +1107,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             // lockfile on these settings changes.
             wanted_lockfile: wanted_lockfile
                 .filter(|lockfile| {
-                    lockfile.package_extensions_checksum
-                        == compute_package_extensions_checksum(config)
+                    lockfile.package_extensions_checksum == package_extensions_checksum
                         && overrides_match(lockfile.overrides.as_ref(), resolved_overrides.as_ref())
                 })
                 .cloned()
@@ -1985,15 +2003,7 @@ fn build_fresh_lockfile(opts: FreshLockfileBuildOptions<'_>) -> Lockfile {
     })
 }
 
-/// Hash `Config::package_extensions` into the prefixed sha256 string
-/// pnpm writes to `pnpm-lock.yaml#packageExtensionsChecksum`.
-/// Mirrors upstream's
-/// [`hashObjectNullableWithPrefix(opts.packageExtensions)`](https://github.com/pnpm/pnpm/blob/39101f5e37/installing/deps-installer/src/install/index.ts#L545)
-/// call at install time. Returns `None` when no extensions are
-/// configured so the field is omitted from the on-disk lockfile, the
-/// same way pnpm omits `packageExtensionsChecksum` when the input is
-/// `undefined` or `{}`.
-fn compute_package_extensions_checksum(config: &Config) -> Option<String> {
+pub(crate) fn compute_package_extensions_checksum(config: &Config) -> Option<String> {
     let extensions =
         config.package_extensions.as_ref().filter(|extensions| !extensions.is_empty())?;
     let value = serde_json::to_value(extensions).ok()?;

--- a/pacquet/crates/package-manager/src/lib.rs
+++ b/pacquet/crates/package-manager/src/lib.rs
@@ -5,6 +5,7 @@ mod build_sequence;
 mod build_snapshot;
 mod catalog_mode;
 mod check_custom_resolver_force_resolve;
+mod compat_package_extensions;
 mod create_symlink_layout;
 mod create_virtual_dir_by_snapshot;
 mod create_virtual_store;

--- a/pacquet/crates/resolving-deps-resolver/src/dedupe_peer_dependents.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/dedupe_peer_dependents.rs
@@ -25,7 +25,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use pacquet_deps_path::DepPath;
+use pacquet_deps_path::{DepPath, index_of_dep_path_suffix};
 
 use crate::{
     dedupe_injected_deps::{DirectByImporter, prune_unreachable},
@@ -95,9 +95,17 @@ fn deduplicate_all(
     if remaining_duplicates.len() == duplicates_count {
         return dep_paths_map;
     }
+    let collapsed_target_peer_info = collapsed_target_peer_info(graph, dep_paths_map.values());
     for node in graph.values_mut() {
+        let parent_peer_names = compatible_peer_names_for_parent(node);
         for child_dep_path in node.children.values_mut() {
-            if let Some(target) = dep_paths_map.get(child_dep_path) {
+            if let Some(target) = dep_paths_map.get(child_dep_path)
+                && collapsed_target_matches_parent(
+                    &collapsed_target_peer_info,
+                    target,
+                    &parent_peer_names,
+                )
+            {
                 *child_dep_path = target.clone();
             }
         }
@@ -199,6 +207,137 @@ fn is_compatible_and_has_more_deps(
         .resolved_peer_names
         .iter()
         .all(|peer| larger_node.resolved_peer_names.contains(peer))
+}
+
+fn collapsed_target_matches_parent(
+    collapsed_target_peer_info: &HashMap<DepPath, CollapsedTargetPeerInfo>,
+    target: &DepPath,
+    parent_peer_names: &HashSet<String>,
+) -> bool {
+    let Some(info) = collapsed_target_peer_info.get(target) else {
+        return true;
+    };
+    info.peer_names.iter().all(|name| {
+        parent_peer_names.contains(name)
+            || info.transitive_peer_dependencies.contains(name)
+            || info.peer_child_is_compatible_with_parent(name, parent_peer_names)
+    })
+}
+
+fn collapsed_target_peer_info<'a>(
+    graph: &DependenciesGraph,
+    targets: impl Iterator<Item = &'a DepPath>,
+) -> HashMap<DepPath, CollapsedTargetPeerInfo> {
+    targets
+        .filter_map(|target| {
+            let node = graph.get(target)?;
+            Some((
+                target.clone(),
+                CollapsedTargetPeerInfo {
+                    package_name: package_name_from_pkg_id(&node.resolved_package_id),
+                    peer_names: dep_path_peer_names(target),
+                    transitive_peer_dependencies: node.transitive_peer_dependencies.clone(),
+                    child_peer_names: child_peer_names(node),
+                },
+            ))
+        })
+        .collect()
+}
+
+struct CollapsedTargetPeerInfo {
+    package_name: String,
+    peer_names: HashSet<String>,
+    transitive_peer_dependencies: HashSet<String>,
+    child_peer_names: HashMap<String, HashSet<String>>,
+}
+
+impl CollapsedTargetPeerInfo {
+    fn peer_child_is_compatible_with_parent(
+        &self,
+        name: &str,
+        parent_peer_names: &HashSet<String>,
+    ) -> bool {
+        self.child_peer_names.get(name).is_some_and(|peer_names| {
+            peer_names.is_empty()
+                || (peer_names.contains(&self.package_name)
+                    && peer_names.iter().all(|peer_name| {
+                        peer_name == &self.package_name
+                            || parent_peer_names.contains(peer_name)
+                            || self.transitive_peer_dependencies.contains(peer_name)
+                    }))
+        })
+    }
+}
+
+fn child_peer_names(node: &DependenciesGraphNode) -> HashMap<String, HashSet<String>> {
+    node.children.iter().map(|(alias, child)| (alias.clone(), dep_path_peer_names(child))).collect()
+}
+
+fn compatible_peer_names_for_parent(node: &DependenciesGraphNode) -> HashSet<String> {
+    let mut names = dep_path_peer_names(&node.dep_path);
+    names.insert(package_name_from_pkg_id(&node.resolved_package_id));
+    names
+}
+
+fn package_name_from_pkg_id(pkg_id: &str) -> String {
+    pkg_id.rfind('@').map_or_else(|| pkg_id.to_string(), |index| pkg_id[..index].to_string())
+}
+
+fn dep_path_peer_names(dep_path: &DepPath) -> HashSet<String> {
+    let mut names = HashSet::new();
+    collect_peer_names(dep_path.as_str(), &mut names);
+    names
+}
+
+fn collect_peer_names(raw: &str, names: &mut HashSet<String>) {
+    let suffix = index_of_dep_path_suffix(raw);
+    let Some(peers_index) = suffix.peers_index else { return };
+    let peers_end = suffix.patch_hash_index.unwrap_or(raw.len());
+    let Some(segments) = split_peer_suffix_segments(&raw[peers_index..peers_end]) else {
+        return;
+    };
+    for segment in segments {
+        if let Some(name) = peer_segment_name(&segment) {
+            names.insert(name.to_string());
+        }
+        collect_peer_names(&segment, names);
+    }
+}
+
+fn split_peer_suffix_segments(suffix: &str) -> Option<Vec<String>> {
+    let bytes = suffix.as_bytes();
+    let mut segments = Vec::new();
+    let mut depth = 0i32;
+    let mut start = None;
+    for (idx, byte) in bytes.iter().enumerate() {
+        match byte {
+            b'(' => {
+                if depth == 0 {
+                    start = Some(idx + 1);
+                }
+                depth += 1;
+            }
+            b')' => {
+                depth -= 1;
+                if depth < 0 {
+                    return None;
+                }
+                if depth == 0 {
+                    let start = start.take()?;
+                    segments.push(suffix[start..idx].to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    (depth == 0).then_some(segments)
+}
+
+fn peer_segment_name(segment: &str) -> Option<&str> {
+    let head_end = segment.find('(').unwrap_or(segment.len());
+    let head = &segment[..head_end];
+    let version_at = head.rfind('@')?;
+    (version_at > 0).then_some(&head[..version_at])
 }
 
 #[cfg(test)]

--- a/pacquet/crates/resolving-deps-resolver/src/dedupe_peer_dependents/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/dedupe_peer_dependents/tests.rs
@@ -184,6 +184,50 @@ fn does_not_collapse_across_incompatible_peer_versions() {
     assert_eq!(direct["project3"]["foo"], direct["project4"]["foo"]);
 }
 
+#[test]
+fn direct_dep_collapses_but_parent_edge_keeps_incompatible_peer_variant() {
+    let subset = "foo@1.0.0(bar@1.0.0)";
+    let larger = "foo@1.0.0(bar@1.0.0)(baz@1.0.0)";
+    let baz = "baz@1.0.0(qux@1.0.0)";
+    let consumer = "consumer@1.0.0(foo@1.0.0(bar@1.0.0))(bar@1.0.0)";
+
+    let mut graph = DependenciesGraph::new();
+    for (id, dep_path) in [("bar@1.0.0", "bar@1.0.0"), ("qux@1.0.0", "qux@1.0.0")] {
+        graph.insert(dp(dep_path), make_node(id, dep_path, &[], &[]));
+    }
+    graph.insert(dp(baz), make_node("baz@1.0.0", baz, &[("qux", "qux@1.0.0")], &["qux"]));
+    graph.insert(dp(subset), make_node("foo@1.0.0", subset, &[("bar", "bar@1.0.0")], &["bar"]));
+    graph.insert(
+        dp(larger),
+        make_node("foo@1.0.0", larger, &[("bar", "bar@1.0.0"), ("baz", baz)], &["bar", "baz"]),
+    );
+    graph.insert(
+        dp(consumer),
+        make_node(
+            "consumer@1.0.0",
+            consumer,
+            &[("foo", subset), ("bar", "bar@1.0.0")],
+            &["foo", "bar"],
+        ),
+    );
+
+    let mut direct: DirectByImporter = BTreeMap::new();
+    direct.insert("project-subset".to_string(), BTreeMap::from([("foo".to_string(), dp(subset))]));
+    direct.insert("project-larger".to_string(), BTreeMap::from([("foo".to_string(), dp(larger))]));
+    direct.insert(
+        "project-consumer".to_string(),
+        BTreeMap::from([("consumer".to_string(), dp(consumer))]),
+    );
+
+    dedupe_peer_dependents(&mut graph, &mut direct);
+
+    assert_eq!(direct["project-subset"]["foo"], dp(larger));
+    assert_eq!(direct["project-larger"]["foo"], dp(larger));
+    assert_eq!(graph[&dp(consumer)].children["foo"], dp(subset));
+    assert!(graph.contains_key(&dp(subset)));
+    assert!(graph.contains_key(&dp(larger)));
+}
+
 /// A package whose two variants are mutually incompatible (neither's
 /// children/peers subset the other) must not collapse — both survive and
 /// no remap happens.

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -439,20 +439,21 @@ where
 /// mode (the default) every occurrence shares the same pair, so the
 /// dedup is unchanged.
 ///
-/// `project_dir` is part of the key only for project-relative
-/// specifiers (`link:` / `file:` / `workspace:`). A non-injected
+/// `project_dir` is part of the key for any specifier that can produce
+/// a project-relative resolution. This includes explicit local
+/// specifiers (`link:` / `file:` / `workspace:`) and normal semver
+/// specifiers in workspace mode, because `linkWorkspacePackages` can
+/// replace the registry pick with a workspace package. A non-injected
 /// workspace dep resolves through
 /// [`resolve_from_local_package`](https://github.com/pnpm/pnpm/blob/ef87f3ccff/resolving/npm-resolver/src/index.ts#L908-L951)
 /// to a `link:<path>` whose `<path>` is computed *relative to the
 /// consuming importer's directory*. Without `project_dir` in the key,
-/// the first importer to resolve `(@scope/lib, workspace:*)` would
+/// the first importer to resolve `(@scope/lib, ^1.0.0)` would
 /// seed the workspace-wide cache with its own relative path and every
 /// other importer would reuse it verbatim — e.g. a root resolving to
 /// `link:packages/lib` would hand `packages/app` the same string,
 /// which from `packages/app` points at the non-existent
-/// `packages/app/packages/lib`. Registry specifiers are
-/// importer-independent, so they keep `None` and stay shared across
-/// importers (the cross-importer dedup the cache exists for).
+/// `packages/app/packages/lib`.
 type WantedKey = (
     Option<String>,
     Option<String>,
@@ -472,10 +473,14 @@ type WantedKey = (
 /// [`resolve_from_local_package`](https://github.com/pnpm/pnpm/blob/ef87f3ccff/resolving/npm-resolver/src/index.ts#L908-L951)
 /// derives from `project_dir`. Such resolutions must not be shared
 /// across importers in [`WantedKey`].
-fn is_project_relative_specifier(bare_specifier: Option<&str>) -> bool {
-    bare_specifier.is_some_and(|spec| {
+fn project_relative_cache_scope(
+    wanted: &WantedDependency,
+    opts: &ResolveOptions,
+) -> Option<PathBuf> {
+    (wanted.bare_specifier.as_deref().is_some_and(|spec| {
         spec.starts_with("link:") || spec.starts_with("file:") || spec.starts_with("workspace:")
-    })
+    }) || (opts.always_try_workspace_packages && opts.workspace_packages.is_some()))
+    .then(|| opts.project_dir.clone())
 }
 
 /// One spec carried through [`extend_tree`] and the importer-side
@@ -1305,8 +1310,7 @@ where
     // is never reused by another. See [`WantedKey`]. The prior key
     // joins so two edges that share a specifier but recorded different
     // versions never share a `currentPkg`-dependent result.
-    let project_scope = is_project_relative_specifier(wanted.bare_specifier.as_deref())
-        .then(|| ctx.base_opts.project_dir.clone());
+    let project_scope = project_relative_cache_scope(&wanted, opts);
     // The overlay's view for this edge joins the cache key: the same
     // range can legitimately pick different versions under levels
     // that resolved different siblings. The view keeps each candidate
@@ -1859,8 +1863,7 @@ where
                 // it reuses this entry outright; otherwise it misses
                 // into its own bucket and re-picks from the warm
                 // metadata caches.
-                let project_scope = is_project_relative_specifier(wanted.bare_specifier.as_deref())
-                    .then(|| ctx.base_opts.project_dir.clone());
+                let project_scope = project_relative_cache_scope(&wanted, opts);
                 let cache_key: WantedKey = (
                     wanted.alias.clone(),
                     wanted.bare_specifier.clone(),
@@ -2103,15 +2106,12 @@ where
     let result = Arc::new(result);
 
     // A reused node carries the synthesized registry resolution into the
-    // same per-wanted cache a fresh resolve would populate, so a later
-    // fresh-resolve of the identical wanted dep short-circuits to it.
-    // `try_reuse_node` only reproduces registry resolutions, which are
-    // importer-independent, so the project scope is always `None` here —
-    // computed through the same helper to stay in lockstep with the
-    // fresh-resolve key shape.
+    // same per-wanted cache bucket a fresh resolve would populate, so a
+    // later fresh-resolve of the identical wanted dep short-circuits to
+    // it without occupying an importer-independent bucket that normal
+    // workspace-mode semver specs must avoid.
     let opts = ctx.opts_for_depth(depth);
-    let project_scope = is_project_relative_specifier(wanted.bare_specifier.as_deref())
-        .then(|| ctx.base_opts.project_dir.clone());
+    let project_scope = project_relative_cache_scope(&wanted, opts);
     let cache_key: WantedKey = (
         wanted.alias.clone(),
         wanted.bare_specifier.clone(),

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -47,7 +47,7 @@ use pacquet_resolving_resolver_base::{
     PreferredVersions, ResolveOptions, Resolver, VersionSelectorEntry, VersionSelectorType,
 };
 use std::{
-    collections::{BTreeMap, BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     sync::Arc,
 };
 
@@ -418,6 +418,8 @@ impl ImporterHoistState {
         self.all_missing_optional_peers.clear();
         loop {
             let mut snapshot = self.ctx.snapshot(self.direct.clone());
+            let original_node_ids: HashSet<crate::NodeId> =
+                snapshot.dependencies_tree.keys().cloned().collect();
             let peers_result = {
                 let mut opts = self.peers_opts();
                 // Re-snapshotted per peer pass because auto-hoisting
@@ -439,6 +441,12 @@ impl ImporterHoistState {
                 &peers_result.peer_dependency_issues.missing,
                 &self.parent_pkg_aliases,
                 self.auto_install_peers_from_highest_match,
+            );
+            self.append_resolved_peer_providers(
+                &peers_result.resolved_peer_providers_by_alias,
+                &snapshot,
+                &original_node_ids,
+                &missing_required,
             );
             for (name, ranges) in fresh_optional {
                 let bucket = self.all_missing_optional_peers.entry(name).or_default();
@@ -495,6 +503,36 @@ impl ImporterHoistState {
             update_preferred_versions_with_ctx(&self.ctx, &mut self.all_preferred_versions);
         }
         Ok(())
+    }
+
+    fn append_resolved_peer_providers(
+        &mut self,
+        providers: &BTreeMap<String, crate::NodeId>,
+        snapshot: &ResolvedTree,
+        original_node_ids: &HashSet<crate::NodeId>,
+        missing_required: &BTreeMap<String, MissingPeerInfo>,
+    ) {
+        if !self.auto_install_peers {
+            return;
+        }
+        for (alias, node_id) in providers {
+            if self.parent_pkg_aliases.contains(alias) || missing_required.contains_key(alias) {
+                continue;
+            }
+            if !original_node_ids.contains(node_id) {
+                continue;
+            }
+            let Some(tree_node) = snapshot.dependencies_tree.get(node_id) else { continue };
+            if !snapshot.packages.contains_key(&tree_node.resolved_package_id) {
+                continue;
+            }
+            self.direct.push(DirectDep {
+                alias: alias.clone(),
+                node_id: node_id.clone(),
+                id: tree_node.resolved_package_id.clone(),
+            });
+            self.parent_pkg_aliases.insert(alias.clone());
+        }
     }
 
     /// Hoist this round's missing optional peers; `true` when any were
@@ -566,7 +604,7 @@ impl ImporterHoistState {
 /// component, keyed by peer name with the deduplicated range list the
 /// outer loop's [`get_hoistable_optional_peers`] needs.
 fn partition_missing_peers(
-    missing: &std::collections::HashMap<String, Vec<MissingPeer>>,
+    missing: &HashMap<String, Vec<MissingPeer>>,
     parent_pkg_aliases: &HashSet<String>,
     auto_install_peers_from_highest_match: bool,
 ) -> (BTreeMap<String, MissingPeerInfo>, BTreeMap<String, Vec<String>>) {

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -782,12 +782,12 @@ async fn optional_peer_with_real_entry_is_hoisted_from_resolved_tree() {
     );
 }
 
-/// A peer declared only via `peerDependenciesMeta` (no
-/// `peerDependencies` entry — the `debug` / `supports-color` shape) is
-/// NOT hoisted even when a provider is resolved in the tree: upstream's
-/// `getMissingPeers` feeds the hoist from `peerDependencies` entries
-/// only (verified against pnpm 11.6.0 — `debug` + `concurrently` leaves
-/// `debug@4.4.3` bare). For
+/// A peer declared only via `peerDependenciesMeta` on a direct package
+/// (no `peerDependencies` entry — the `debug` / `supports-color`
+/// shape) is NOT hoisted even when a provider is resolved in the tree:
+/// upstream's direct-package `getMissingPeers` feeds the hoist from
+/// `peerDependencies` entries only (verified against pnpm 11.6.0 —
+/// `debug` + `concurrently` leaves `debug@4.4.3` bare). For
 /// <https://github.com/pnpm/pnpm/issues/12266>.
 #[tokio::test]
 async fn meta_only_optional_peer_is_not_hoisted() {
@@ -836,6 +836,125 @@ async fn meta_only_optional_peer_is_not_hoisted() {
     assert_eq!(
         result.peers_result.direct_dependencies_by_alias.get("needs-opt"),
         Some(&DepPath::from("needs-opt@1.0.0".to_string())),
+    );
+}
+
+#[tokio::test]
+async fn real_peer_provider_from_direct_child_is_appended_as_hidden_direct_dep() {
+    let mut table = HashMap::new();
+    table.insert(
+        ("host".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "host",
+            "1.0.0",
+            serde_json::json!({
+                "name": "host",
+                "version": "1.0.0",
+                "dependencies": {
+                    "peer-user": "1.0.0",
+                    "provider": "1.0.0",
+                },
+            }),
+        ),
+    );
+    table.insert(
+        ("peer-user".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "peer-user",
+            "1.0.0",
+            serde_json::json!({
+                "name": "peer-user",
+                "version": "1.0.0",
+                "peerDependencies": { "provider": "^1.0.0" },
+            }),
+        ),
+    );
+    table.insert(
+        ("provider".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "provider",
+            "1.0.0",
+            serde_json::json!({ "name": "provider", "version": "1.0.0" }),
+        ),
+    );
+    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let (_tmp, manifest) = fake_manifest(serde_json::json!({ "host": "1.0.0" }));
+
+    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.peers_result.direct_dependencies_by_alias.get("provider"),
+        Some(&DepPath::from("provider@1.0.0".to_string())),
+        "provider should be available to the importer peer pass without being a manifest dep",
+    );
+    assert!(
+        result
+            .peers_result
+            .graph
+            .contains_key(&DepPath::from("peer-user@1.0.0(provider@1.0.0)".to_string())),
+        "peer-user should resolve provider from host's child dependency",
+    );
+}
+
+#[tokio::test]
+async fn meta_only_peer_provider_from_direct_child_is_not_appended_as_hidden_direct_dep() {
+    let mut table = HashMap::new();
+    table.insert(
+        ("host".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "host",
+            "1.0.0",
+            serde_json::json!({
+                "name": "host",
+                "version": "1.0.0",
+                "dependencies": {
+                    "peer-user": "1.0.0",
+                    "provider": "1.0.0",
+                },
+            }),
+        ),
+    );
+    table.insert(
+        ("peer-user".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "peer-user",
+            "1.0.0",
+            serde_json::json!({
+                "name": "peer-user",
+                "version": "1.0.0",
+                "peerDependenciesMeta": { "provider": { "optional": true } },
+            }),
+        ),
+    );
+    table.insert(
+        ("provider".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "provider",
+            "1.0.0",
+            serde_json::json!({ "name": "provider", "version": "1.0.0" }),
+        ),
+    );
+    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let (_tmp, manifest) = fake_manifest(serde_json::json!({ "host": "1.0.0" }));
+
+    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
+        .await
+        .unwrap();
+
+    let direct: Vec<&str> =
+        result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
+    assert!(
+        !direct.contains(&"provider"),
+        "meta-only peers must not feed auto-installed hidden direct deps: {direct:?}",
+    );
+    assert!(
+        result
+            .peers_result
+            .graph
+            .contains_key(&DepPath::from("peer-user@1.0.0(provider@1.0.0)".to_string())),
+        "meta-only peers still resolve in the final peer graph when provider is in scope",
     );
 }
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -663,7 +663,7 @@ impl Walker<'_> {
                 &parent_pkg_ids_chain,
             );
             for (peer_alias, peer_node_id) in output.auto_install_resolved_peers {
-                self.resolved_peer_providers_by_alias.entry(peer_alias).or_insert(peer_node_id);
+                self.resolved_peer_providers_by_alias.insert(peer_alias, peer_node_id);
             }
         }
         self.patch_pending_peer_edges();

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -54,10 +54,13 @@ use crate::{
     },
 };
 use node_semver::{Range, Version};
-use pacquet_deps_path::{DepPath, PeerId, create_peer_dep_graph_hash, link_path_to_peer_version};
+use pacquet_deps_path::{
+    DepPath, PeerId, create_peer_dep_graph_hash, index_of_dep_path_suffix,
+    link_path_to_peer_version,
+};
 use pacquet_resolving_resolver_base::ResolveResult;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -88,6 +91,13 @@ use std::{
 fn link_node_id_as_dep_path(node_id: &NodeId) -> Option<DepPath> {
     let NodeId::Leaf(id) = node_id else { return None };
     id.starts_with("link:").then(|| DepPath::from(id.to_string()))
+}
+
+fn node_id_sort_key(node_id: &NodeId) -> String {
+    match node_id {
+        NodeId::Counter(value) => format!("0:{value:020}"),
+        NodeId::Leaf(value) => format!("1:{value}"),
+    }
 }
 
 fn pkg_name_version(result: &ResolveResult) -> (String, String) {
@@ -204,6 +214,11 @@ impl Default for ResolvePeersOptions {
 pub struct ResolvePeersResult {
     pub graph: DependenciesGraph,
     pub direct_dependencies_by_alias: BTreeMap<String, DepPath>,
+    /// Real peer providers that were resolved from inside the walked
+    /// dependency tree. The auto-install-peers loop appends these to
+    /// the importer's hidden direct-dep set, matching pnpm's
+    /// resolver-stage `resolvedPeers` handling.
+    pub resolved_peer_providers_by_alias: BTreeMap<String, NodeId>,
     pub peer_dependency_issues: PeerDependencyIssues,
     /// Per resolved package: the union of missing-peer names its
     /// occurrences' children reported in this walk. The hoist loop
@@ -260,12 +275,14 @@ pub fn resolve_peers(tree: &mut ResolvedTree, opts: ResolvePeersOptions) -> Reso
         node_external_peers: HashMap::new(),
         node_missing_peers: HashMap::new(),
         node_missing_peers_of_children: HashMap::new(),
+        resolved_peer_providers_by_alias: BTreeMap::new(),
         in_progress: HashSet::new(),
         pending_peer_edges: Vec::new(),
         pure_pkgs: HashSet::new(),
         peers_cache: HashMap::new(),
         parent_pkgs_of_node: HashMap::new(),
         node_records: HashMap::new(),
+        next_record_order: 0,
     };
     walker.walk()
 }
@@ -286,6 +303,7 @@ pub fn resolve_peers_workspace(
     lockfile_dir: &Path,
     dedupe_injected_deps_enabled: bool,
     dedupe_peer_dependents_enabled: bool,
+    resolve_peers_from_workspace_root: bool,
     opts: ResolvePeersOptions,
 ) -> WorkspaceResolvePeersResult {
     let mut walker = Walker {
@@ -297,12 +315,14 @@ pub fn resolve_peers_workspace(
         node_external_peers: HashMap::new(),
         node_missing_peers: HashMap::new(),
         node_missing_peers_of_children: HashMap::new(),
+        resolved_peer_providers_by_alias: BTreeMap::new(),
         in_progress: HashSet::new(),
         pending_peer_edges: Vec::new(),
         pure_pkgs: HashSet::new(),
         peers_cache: HashMap::new(),
         parent_pkgs_of_node: HashMap::new(),
         node_records: HashMap::new(),
+        next_record_order: 0,
     };
 
     let mut direct_dependencies_by_importer: BTreeMap<String, BTreeMap<String, DepPath>> =
@@ -310,13 +330,29 @@ pub fn resolve_peers_workspace(
     let mut peer_dependency_issues_by_importer: BTreeMap<String, PeerDependencyIssues> =
         BTreeMap::new();
     let mut importer_root_dirs: BTreeMap<String, PathBuf> = BTreeMap::new();
+    let root_importer = resolve_peers_from_workspace_root
+        .then(|| importers.iter().find(|importer| importer.id == "."))
+        .flatten();
+    let root_parents = root_importer.map(|importer| {
+        let previous_modules_dir = walker.opts.modules_dir.clone();
+        walker.opts.modules_dir.clone_from(&importer.modules_dir);
+        let parents = walker.build_importer_parents_from(&importer.direct);
+        walker.opts.modules_dir = previous_modules_dir;
+        parents
+    });
     for importer in importers {
         importer_root_dirs.insert(importer.id.clone(), importer.root_dir.clone());
         // Swap the per-importer `modules_dir` in before the walk so
         // the `excludeLinksFromLockfile` link-remap inside
         // `resolve_node` uses the correct importer-scoped target.
         walker.opts.modules_dir.clone_from(&importer.modules_dir);
-        let importer_parents = walker.build_importer_parents_from(&importer.direct);
+        let importer_parents = if root_importer.is_some_and(|root| root.id != importer.id) {
+            let mut refs = root_parents.clone().unwrap_or_default();
+            refs.extend(walker.build_importer_parents_from(&importer.direct));
+            refs
+        } else {
+            walker.build_importer_parents_from(&importer.direct)
+        };
         let parent_chain_names: Vec<String> = Vec::new();
         let parent_node_ids: Vec<NodeId> = Vec::new();
         let parent_pkg_ids_chain: Vec<String> = Vec::new();
@@ -415,6 +451,12 @@ struct ParentRef {
 /// the real name.
 type ParentRefs = HashMap<String, ParentRef>;
 
+#[derive(Clone, Copy)]
+struct FinalPeerContext<'a> {
+    scc_of: &'a HashMap<NodeId, usize>,
+    cyclic_peer_names: &'a HashSet<String>,
+}
+
 struct Walker<'tree> {
     tree: &'tree mut ResolvedTree,
     opts: ResolvePeersOptions,
@@ -436,6 +478,11 @@ struct Walker<'tree> {
     /// Peers each node's children declared but couldn't find.
     /// Indexed by `NodeId`; value's keys are peer aliases.
     node_missing_peers_of_children: HashMap<NodeId, HashMap<String, MissingPeerInfo>>,
+    /// Resolver-stage real peer providers seen while walking the tree.
+    /// This intentionally excludes `peerDependenciesMeta`-only entries:
+    /// pnpm's auto-install pass is fed by `getMissingPeers`, which reads
+    /// real `peerDependencies` entries only.
+    resolved_peer_providers_by_alias: BTreeMap<String, NodeId>,
     /// Stack of nodes currently being walked. Re-entry on a node here
     /// is a cycle — the recursion bottoms out with a `name@version`
     /// peer-id and the original visit drives the actual graph insert.
@@ -488,6 +535,7 @@ struct Walker<'tree> {
     /// the post-walk [`Walker::build_final_dep_paths`] /
     /// [`Walker::build_final_graph`] pass. See [`NodeRecord`].
     node_records: HashMap<NodeId, NodeRecord>,
+    next_record_order: u64,
 }
 
 /// Per-peer-name snapshot stored on [`Walker::parent_pkgs_of_node`].
@@ -519,6 +567,7 @@ struct ParentPkgInfo {
 struct PeersCacheItem {
     dep_path: DepPath,
     resolved_peers: HashMap<String, NodeId>,
+    auto_install_resolved_peers: HashMap<String, NodeId>,
     missing_peers: HashMap<String, MissingPeerInfo>,
     missing_peers_of_children: HashMap<String, MissingPeerInfo>,
 }
@@ -550,10 +599,12 @@ struct NodeRecord {
     /// edges) but holding `NodeIds`, so the rebuild can map each edge to
     /// its final depPath.
     edges: BTreeMap<String, NodeId>,
+    peer_edges: HashSet<String>,
     transitive_peer_dependencies: HashSet<String>,
     depth: i32,
     installable: bool,
     is_pure: bool,
+    order: u64,
 }
 
 /// Sentinel for "this node's subtree is still missing peer `X`". The
@@ -580,6 +631,10 @@ struct NodeOutput {
     /// Excludes peers resolved against this node's own children (those
     /// are absorbed into the children's depPaths).
     external_resolved_peers: HashMap<String, NodeId>,
+    /// Real `peerDependencies` resolved anywhere in this node's
+    /// subtree. This mirrors the dependency-resolution phase's
+    /// `resolvedPeers` bag that feeds pnpm's auto-install-peers loop.
+    auto_install_resolved_peers: HashMap<String, NodeId>,
     missing_peers: HashMap<String, MissingPeerInfo>,
 }
 
@@ -600,13 +655,16 @@ impl Walker<'_> {
             self.parent_pkgs_of_node.insert(dep.node_id.clone(), importer_parent_dep_paths.clone());
         }
         for dep in &direct {
-            self.resolve_node(
+            let output = self.resolve_node(
                 dep.node_id.clone(),
                 &importer_parents,
                 &parent_chain_names,
                 &parent_node_ids,
                 &parent_pkg_ids_chain,
             );
+            for (peer_alias, peer_node_id) in output.auto_install_resolved_peers {
+                self.resolved_peer_providers_by_alias.entry(peer_alias).or_insert(peer_node_id);
+            }
         }
         self.patch_pending_peer_edges();
         // Recompute depPaths so each resolved peer carries its full
@@ -619,6 +677,7 @@ impl Walker<'_> {
                 .insert(dep.alias.clone(), self.final_dep_path_of(&dep.node_id, &final_dep_paths));
         }
         let graph = self.build_final_graph(&final_dep_paths);
+        let resolved_peer_providers_by_alias = self.resolved_peer_providers_by_alias;
         let mut missing_names_by_pkg: HashMap<String, std::collections::HashSet<String>> =
             HashMap::new();
         for (node_id, missing) in &self.node_missing_peers_of_children {
@@ -631,6 +690,7 @@ impl Walker<'_> {
         ResolvePeersResult {
             graph,
             direct_dependencies_by_alias: direct_by_alias,
+            resolved_peer_providers_by_alias,
             peer_dependency_issues: self.issues,
             missing_names_by_pkg,
         }
@@ -745,6 +805,7 @@ impl Walker<'_> {
                 return NodeOutput {
                     dep_path,
                     external_resolved_peers: HashMap::new(),
+                    auto_install_resolved_peers: HashMap::new(),
                     missing_peers: HashMap::new(),
                 };
             }
@@ -772,6 +833,7 @@ impl Walker<'_> {
                 return NodeOutput {
                     dep_path,
                     external_resolved_peers: HashMap::new(),
+                    auto_install_resolved_peers: HashMap::new(),
                     missing_peers: HashMap::new(),
                 };
             }
@@ -790,6 +852,7 @@ impl Walker<'_> {
             return NodeOutput {
                 dep_path: DepPath::from(pkg.id.clone()),
                 external_resolved_peers: HashMap::new(),
+                auto_install_resolved_peers: HashMap::new(),
                 missing_peers: HashMap::new(),
             };
         }
@@ -817,17 +880,13 @@ impl Walker<'_> {
         let mut child_parent_refs = parent_parent_refs.clone();
         let mut new_parent_refs = ParentRefs::new();
         for (alias, child_node_id) in &children_map {
-            let alias_is_peer_relevant = self.tree.all_peer_dep_names.contains(alias);
+            if !self.tree.all_peer_dep_names.contains(alias) {
+                continue;
+            }
             let Some(child_tree) = self.tree.dependencies_tree.get(child_node_id) else { continue };
             let Some(child_pkg) = self.tree.packages.get(&child_tree.resolved_package_id) else {
                 continue;
             };
-            if !alias_is_peer_relevant {
-                let (child_name, _) = pkg_name_version(&child_pkg.result);
-                if !self.tree.all_peer_dep_names.contains(&child_name) {
-                    continue;
-                }
-            }
             insert_parent_ref(
                 &mut new_parent_refs,
                 alias,
@@ -883,6 +942,7 @@ impl Walker<'_> {
         if let Some(cached) = self.find_hit(&child_parent_refs, &pkg.id) {
             let dep_path = cached.dep_path.clone();
             let resolved = cached.resolved_peers.clone();
+            let auto_install_resolved_peers = cached.auto_install_resolved_peers.clone();
             let missing = cached.missing_peers.clone();
             let missing_of_children = cached.missing_peers_of_children.clone();
             // Re-emit the missing-peer issues against the current
@@ -925,6 +985,7 @@ impl Walker<'_> {
             return NodeOutput {
                 dep_path,
                 external_resolved_peers: resolved,
+                auto_install_resolved_peers,
                 missing_peers: missing,
             };
         }
@@ -936,9 +997,11 @@ impl Walker<'_> {
         // its parent — i.e., this node's child). Those are not external
         // *to this node* — they're internal here — so filter them out.
         let mut external_from_children: HashMap<String, NodeId> = HashMap::new();
+        let mut auto_install_resolved_peers: HashMap<String, NodeId> = HashMap::new();
         let mut missing_from_children: HashMap<String, MissingPeerInfo> = HashMap::new();
         let mut child_dep_paths: BTreeMap<String, DepPath> = BTreeMap::new();
-        for (alias, child_node_id) in &children_map {
+        let child_entries = ordered_child_entries(&children_map, &child_parent_refs);
+        for (alias, child_node_id) in &child_entries {
             let child_output = self.resolve_node(
                 child_node_id.clone(),
                 &child_parent_refs,
@@ -947,6 +1010,9 @@ impl Walker<'_> {
                 &child_parent_pkg_ids_chain,
             );
             child_dep_paths.insert(alias.clone(), child_output.dep_path);
+            for (peer_alias, peer_node_id) in child_output.auto_install_resolved_peers {
+                auto_install_resolved_peers.insert(peer_alias, peer_node_id);
+            }
             for (peer_alias, peer_node_id) in child_output.external_resolved_peers {
                 if children_map.contains_key(&peer_alias) {
                     continue;
@@ -973,6 +1039,11 @@ impl Walker<'_> {
                 &mut own_resolved_peers,
                 &mut own_missing_peers,
             );
+            if !peer_dep.meta_only
+                && let Some(peer_node_id) = own_resolved_peers.get(peer_name)
+            {
+                auto_install_resolved_peers.insert(peer_name.clone(), peer_node_id.clone());
+            }
         }
 
         // Combine all resolved peers (this node's own + descendants').
@@ -1070,14 +1141,19 @@ impl Walker<'_> {
         for (peer_alias, peer_node_id) in &own_resolved_peers {
             record_edges.insert(peer_alias.clone(), peer_node_id.clone());
         }
+        let peer_edges = own_resolved_peers.keys().cloned().collect();
+        let record_order = self.next_record_order;
+        self.next_record_order += 1;
         self.node_records.insert(
             node_id.clone(),
             NodeRecord {
                 edges: record_edges,
+                peer_edges,
                 transitive_peer_dependencies: transitive_peer_dependencies.clone(),
                 depth: tree_node.depth,
                 installable: tree_node.installable,
                 is_pure,
+                order: record_order,
             },
         );
 
@@ -1094,6 +1170,7 @@ impl Walker<'_> {
             self.peers_cache.entry(pkg.id.clone()).or_default().push(PeersCacheItem {
                 dep_path: dep_path.clone(),
                 resolved_peers: all_resolved_peers.clone(),
+                auto_install_resolved_peers: auto_install_resolved_peers.clone(),
                 missing_peers: all_missing_peers.clone(),
                 missing_peers_of_children: missing_from_children,
             });
@@ -1134,6 +1211,7 @@ impl Walker<'_> {
         NodeOutput {
             dep_path,
             external_resolved_peers: external_to_report,
+            auto_install_resolved_peers,
             missing_peers: all_missing_peers,
         }
     }
@@ -1251,19 +1329,10 @@ impl Walker<'_> {
         PeerId::Pair { name, version }
     }
 
-    /// Resolve `node_id` to the depPath the rebuilt graph should key /
-    /// reference it by. Prefers the corrected `final_dep_paths` entry,
-    /// falls back to the provisional `node_dep_paths` value (correct for
-    /// peerless nodes, whose depPath is just their `pkgIdWithPatchHash`),
-    /// then to a bare `link:` id, then to the package id.
-    fn final_dep_path_of(
-        &self,
-        node_id: &NodeId,
-        final_dep_paths: &HashMap<NodeId, DepPath>,
-    ) -> DepPath {
-        if let Some(dep_path) = final_dep_paths.get(node_id) {
-            return dep_path.clone();
-        }
+    /// Resolve `node_id` to the depPath computed during the main walk.
+    /// Peerless nodes are already final at this point; nodes with peers
+    /// may still be missing a pending peer provider's own final suffix.
+    fn provisional_dep_path_of(&self, node_id: &NodeId) -> DepPath {
         if let Some(dep_path) = self.node_dep_paths.get(node_id) {
             return dep_path.clone();
         }
@@ -1272,6 +1341,20 @@ impl Walker<'_> {
         }
         let pkg_id = &self.tree.dependencies_tree[node_id].resolved_package_id;
         DepPath::from(self.tree.packages[pkg_id].id.clone())
+    }
+
+    /// Resolve `node_id` to the depPath the rebuilt graph should key /
+    /// reference it by. Prefers the corrected `final_dep_paths` entry
+    /// and falls back to the provisional value for peerless nodes.
+    fn final_dep_path_of(
+        &self,
+        node_id: &NodeId,
+        final_dep_paths: &HashMap<NodeId, DepPath>,
+    ) -> DepPath {
+        if let Some(dep_path) = final_dep_paths.get(node_id) {
+            return dep_path.clone();
+        }
+        self.provisional_dep_path_of(node_id)
     }
 
     /// One resolved-peer slot of `node_id`'s suffix, computed against the
@@ -1283,11 +1366,12 @@ impl Walker<'_> {
     /// peers carry their full depPath, which is the parity fix.
     fn final_peer_id(
         &self,
+        node_id: &NodeId,
         peer_alias: &str,
         peer_node_id: &NodeId,
-        node_scc: usize,
-        scc_of: &HashMap<NodeId, usize>,
-        final_dep_paths: &HashMap<NodeId, DepPath>,
+        context: FinalPeerContext<'_>,
+        final_dep_paths: &mut HashMap<NodeId, DepPath>,
+        visiting: &mut HashSet<NodeId>,
     ) -> PeerId {
         if let NodeId::Leaf(id) = peer_node_id
             && let Some(rel) = id.strip_prefix("link:")
@@ -1306,10 +1390,23 @@ impl Walker<'_> {
         if self.opts.dedupe_peers && self.tree.dependencies_tree.contains_key(peer_node_id) {
             return pair();
         }
-        if scc_of.get(peer_node_id) == Some(&node_scc) {
+        if context
+            .scc_of
+            .get(node_id)
+            .is_some_and(|node_scc| context.scc_of.get(peer_node_id) == Some(node_scc))
+        {
             return pair();
         }
-        PeerId::DepPath(self.final_dep_path_of(peer_node_id, final_dep_paths))
+        if context.cyclic_peer_names.contains(peer_alias) {
+            return pair();
+        }
+        PeerId::DepPath(self.final_dep_path_for_node(
+            peer_node_id,
+            context.scc_of,
+            context.cyclic_peer_names,
+            final_dep_paths,
+            visiting,
+        ))
     }
 
     /// Recompute every node's depPath with its resolved peers' *full*
@@ -1319,37 +1416,153 @@ impl Walker<'_> {
     /// equivalent of pnpm's deferred `calculateDepPath` + `analyzeGraph`
     /// cycle detection.
     fn build_final_dep_paths(&self) -> HashMap<NodeId, DepPath> {
-        let (sccs, scc_of) = self.peer_sccs();
+        let (_, scc_of) = self.peer_sccs();
+        let cyclic_peer_names = self.cyclic_peer_names();
         let mut final_dep_paths: HashMap<NodeId, DepPath> = HashMap::new();
-        // SCCs come out of Tarjan in reverse-topological order, so a
-        // node's cross-SCC peers are already finalized when we reach it.
-        for (scc_index, scc) in sccs.iter().enumerate() {
-            for node_id in scc {
-                let Some(peers) = self.node_external_peers.get(node_id) else { continue };
-                if peers.is_empty() {
-                    continue;
-                }
-                let peer_ids: Vec<PeerId> = peers
-                    .iter()
-                    .map(|(peer_alias, peer_node_id)| {
-                        self.final_peer_id(
-                            peer_alias,
-                            peer_node_id,
-                            scc_index,
-                            &scc_of,
-                            &final_dep_paths,
-                        )
-                    })
-                    .collect();
-                let suffix =
-                    create_peer_dep_graph_hash(&peer_ids, self.opts.peers_suffix_max_length);
-                let pkg_id = &self.tree.dependencies_tree[node_id].resolved_package_id;
-                let dep_path =
-                    DepPath::from(format!("{}{}", self.tree.packages[pkg_id].id, suffix));
-                final_dep_paths.insert(node_id.clone(), dep_path);
-            }
+        let mut visiting = HashSet::new();
+        let mut node_ids: Vec<NodeId> = self.node_external_peers.keys().cloned().collect();
+        node_ids.sort_by_key(node_id_sort_key);
+        for node_id in node_ids {
+            self.final_dep_path_for_node(
+                &node_id,
+                &scc_of,
+                &cyclic_peer_names,
+                &mut final_dep_paths,
+                &mut visiting,
+            );
         }
         final_dep_paths
+    }
+
+    fn final_dep_path_for_node(
+        &self,
+        node_id: &NodeId,
+        scc_of: &HashMap<NodeId, usize>,
+        cyclic_peer_names: &HashSet<String>,
+        final_dep_paths: &mut HashMap<NodeId, DepPath>,
+        visiting: &mut HashSet<NodeId>,
+    ) -> DepPath {
+        if let Some(dep_path) = final_dep_paths.get(node_id) {
+            return dep_path.clone();
+        }
+        let Some(peers) = self.node_external_peers.get(node_id) else {
+            return self.provisional_dep_path_of(node_id);
+        };
+        if peers.is_empty() {
+            return self.provisional_dep_path_of(node_id);
+        }
+        if !visiting.insert(node_id.clone()) {
+            return self.provisional_dep_path_of(node_id);
+        }
+        let peer_ids: Vec<PeerId> = peers
+            .iter()
+            .map(|(peer_alias, peer_node_id)| {
+                self.final_peer_id(
+                    node_id,
+                    peer_alias,
+                    peer_node_id,
+                    FinalPeerContext { scc_of, cyclic_peer_names },
+                    final_dep_paths,
+                    visiting,
+                )
+            })
+            .collect();
+        let suffix = create_peer_dep_graph_hash(&peer_ids, self.opts.peers_suffix_max_length);
+        let pkg_id = &self.tree.dependencies_tree[node_id].resolved_package_id;
+        let dep_path = DepPath::from(format!("{}{}", self.tree.packages[pkg_id].id, suffix));
+        final_dep_paths.insert(node_id.clone(), dep_path.clone());
+        visiting.remove(node_id);
+        dep_path
+    }
+
+    fn cyclic_peer_names(&self) -> HashSet<String> {
+        let mut graph: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+        for (node_id, peers) in &self.node_external_peers {
+            if peers.is_empty() {
+                continue;
+            }
+            let tree_node = &self.tree.dependencies_tree[node_id];
+            let pkg = &self.tree.packages[&tree_node.resolved_package_id];
+            let (name, _) = pkg_name_version(&pkg.result);
+            let edges = graph.entry(name).or_default();
+            for peer_alias in peers.keys() {
+                edges.insert(peer_alias.clone());
+            }
+        }
+        let peer_names: Vec<String> =
+            graph.values().flat_map(|edges| edges.iter().cloned()).collect();
+        for peer_name in peer_names {
+            graph.entry(peer_name).or_default();
+        }
+
+        struct PeerNameTarjan<'a> {
+            graph: &'a BTreeMap<String, BTreeSet<String>>,
+            index_of: HashMap<String, u32>,
+            low_of: HashMap<String, u32>,
+            on_stack: HashSet<String>,
+            tarjan_stack: Vec<String>,
+            cyclic: HashSet<String>,
+            next_index: u32,
+        }
+
+        impl PeerNameTarjan<'_> {
+            fn strongconnect(&mut self, name: &str) {
+                self.index_of.insert(name.to_string(), self.next_index);
+                self.low_of.insert(name.to_string(), self.next_index);
+                self.next_index += 1;
+                self.on_stack.insert(name.to_string());
+                self.tarjan_stack.push(name.to_string());
+
+                if let Some(neighbors) = self.graph.get(name) {
+                    for child in neighbors {
+                        if !self.index_of.contains_key(child) {
+                            self.strongconnect(child);
+                            let name_low = self.low_of[name];
+                            let child_low = self.low_of[child];
+                            self.low_of.insert(name.to_string(), name_low.min(child_low));
+                        } else if self.on_stack.contains(child) {
+                            let name_low = self.low_of[name];
+                            let child_index = self.index_of[child];
+                            self.low_of.insert(name.to_string(), name_low.min(child_index));
+                        }
+                    }
+                }
+
+                if self.low_of[name] == self.index_of[name] {
+                    let mut component = Vec::new();
+                    while let Some(member) = self.tarjan_stack.pop() {
+                        self.on_stack.remove(&member);
+                        let is_root = member == name;
+                        component.push(member);
+                        if is_root {
+                            break;
+                        }
+                    }
+                    let self_loop = component.first().is_some_and(|member| {
+                        self.graph.get(member).is_some_and(|edges| edges.contains(member))
+                    });
+                    if component.len() > 1 || self_loop {
+                        self.cyclic.extend(component);
+                    }
+                }
+            }
+        }
+
+        let mut tarjan = PeerNameTarjan {
+            graph: &graph,
+            index_of: HashMap::new(),
+            low_of: HashMap::new(),
+            on_stack: HashSet::new(),
+            tarjan_stack: Vec::new(),
+            cyclic: HashSet::new(),
+            next_index: 0,
+        };
+        for name in graph.keys() {
+            if !tarjan.index_of.contains_key(name) {
+                tarjan.strongconnect(name);
+            }
+        }
+        tarjan.cyclic
     }
 
     /// Strongly-connected components of the peer graph (node → resolved
@@ -1357,20 +1570,26 @@ impl Walker<'_> {
     /// peers can't close a cycle). Iterative Tarjan, returning the SCCs
     /// in reverse-topological order plus a `NodeId → SCC index` map.
     fn peer_sccs(&self) -> (Vec<Vec<NodeId>>, HashMap<NodeId, usize>) {
-        let participants: HashSet<&NodeId> = self
+        let mut participants: Vec<NodeId> = self
             .node_external_peers
             .iter()
             .filter(|(_, peers)| !peers.is_empty())
-            .map(|(node_id, _)| node_id)
+            .map(|(node_id, _)| node_id.clone())
             .collect();
+        participants.sort_by_key(node_id_sort_key);
+        participants.dedup();
+        let participant_set: HashSet<NodeId> = participants.iter().cloned().collect();
         let neighbors = |node_id: &NodeId| -> Vec<NodeId> {
-            self.node_external_peers
+            let mut out: Vec<NodeId> = self
+                .node_external_peers
                 .get(node_id)
                 .into_iter()
                 .flat_map(|peers| peers.values())
-                .filter(|peer| participants.contains(*peer))
+                .filter(|peer| participant_set.contains(*peer))
                 .cloned()
-                .collect()
+                .collect();
+            out.sort_by_key(node_id_sort_key);
+            out
         };
 
         let mut index_of: HashMap<NodeId, u32> = HashMap::new();
@@ -1384,11 +1603,11 @@ impl Walker<'_> {
         // Explicit DFS stack of (node, neighbors, cursor) so deep peer
         // graphs don't overflow the call stack.
         for root in &participants {
-            if index_of.contains_key(*root) {
+            if index_of.contains_key(root) {
                 continue;
             }
             let mut work: Vec<(NodeId, Vec<NodeId>, usize)> =
-                vec![((*root).clone(), neighbors(root), 0)];
+                vec![(root.clone(), neighbors(root), 0)];
             while let Some((node_id, succ, cursor)) = work.last_mut() {
                 if *cursor == 0 {
                     index_of.insert(node_id.clone(), next_index);
@@ -1462,46 +1681,237 @@ impl Walker<'_> {
                 .or_insert(tree_node.depth);
         }
 
-        let mut graph = DependenciesGraph::new();
+        let mut record_dep_paths: HashMap<NodeId, DepPath> = HashMap::new();
+        let mut record_resolved_peer_names: HashMap<NodeId, HashSet<String>> = HashMap::new();
+        let mut variants_by_pkg_id: HashMap<String, Vec<(DepPath, HashSet<String>)>> =
+            HashMap::new();
+        let mut transitive_peer_dependencies_by_dep_path: HashMap<DepPath, HashSet<String>> =
+            HashMap::new();
         for (node_id, record) in &self.node_records {
             let dep_path = self.final_dep_path_of(node_id, final_dep_paths);
-            let depth = min_depth.get(&dep_path).copied().unwrap_or(record.depth);
             let pkg_id = self.tree.dependencies_tree[node_id].resolved_package_id.clone();
-            let pkg = &self.tree.packages[&pkg_id];
-            let children: BTreeMap<String, DepPath> = record
-                .edges
-                .iter()
-                .map(|(alias, edge_node_id)| {
-                    (alias.clone(), self.final_dep_path_of(edge_node_id, final_dep_paths))
-                })
-                .collect();
             let resolved_peer_names: HashSet<String> = self
                 .node_external_peers
                 .get(node_id)
                 .map(|peers| peers.keys().cloned().collect())
                 .unwrap_or_default();
-            graph
-                .entry(dep_path.clone())
-                .and_modify(|node| {
-                    if node.depth > depth {
-                        node.depth = depth;
+            record_dep_paths.insert(node_id.clone(), dep_path.clone());
+            record_resolved_peer_names.insert(node_id.clone(), resolved_peer_names.clone());
+            let variant_peer_names: HashSet<String> =
+                peer_segment_names(&dep_path).unwrap_or_default().into_iter().collect();
+            variants_by_pkg_id.entry(pkg_id).or_default().push((dep_path, variant_peer_names));
+            transitive_peer_dependencies_by_dep_path
+                .entry(record_dep_paths[node_id].clone())
+                .or_default()
+                .extend(record.transitive_peer_dependencies.iter().cloned());
+        }
+        for variants in variants_by_pkg_id.values_mut() {
+            variants.sort_by(|(left_dep_path, left_peers), (right_dep_path, right_peers)| {
+                right_peers
+                    .len()
+                    .cmp(&left_peers.len())
+                    .then_with(|| left_dep_path.cmp(right_dep_path))
+            });
+        }
+
+        let mut graph = DependenciesGraph::new();
+        let mut graph_order: HashMap<DepPath, u64> = HashMap::new();
+        let mut synthetic_nodes: HashMap<DepPath, DependenciesGraphNode> = HashMap::new();
+        for (node_id, record) in &self.node_records {
+            let dep_path = record_dep_paths[node_id].clone();
+            let depth = min_depth.get(&dep_path).copied().unwrap_or(record.depth);
+            let pkg_id = self.tree.dependencies_tree[node_id].resolved_package_id.clone();
+            let pkg = &self.tree.packages[&pkg_id];
+            let mut children: BTreeMap<String, DepPath> = BTreeMap::new();
+            for (alias, edge_node_id) in &record.edges {
+                let is_peer_edge =
+                    record.peer_edges.contains(alias) || pkg.peer_dependencies.contains_key(alias);
+                let (edge_dep_path, synthetic_node) = if is_peer_edge {
+                    self.final_peer_edge_dep_path(
+                        node_id,
+                        edge_node_id,
+                        final_dep_paths,
+                        &record_resolved_peer_names,
+                        &variants_by_pkg_id,
+                    )
+                } else {
+                    (self.final_dep_path_of(edge_node_id, final_dep_paths), None)
+                };
+                if let Some(node) = synthetic_node {
+                    transitive_peer_dependencies_by_dep_path
+                        .entry(node.dep_path.clone())
+                        .or_default()
+                        .extend(node.transitive_peer_dependencies.iter().cloned());
+                    synthetic_nodes.entry(node.dep_path.clone()).or_insert(node);
+                }
+                children.insert(alias.clone(), edge_dep_path);
+            }
+            let resolved_peer_names =
+                record_resolved_peer_names.get(node_id).cloned().unwrap_or_default();
+            let mut candidate = DependenciesGraphNode {
+                dep_path: dep_path.clone(),
+                resolved_package_id: pkg_id.clone(),
+                resolve_result: Arc::clone(&pkg.result),
+                children,
+                peer_dependencies: pkg.peer_dependencies.clone(),
+                transitive_peer_dependencies: record.transitive_peer_dependencies.clone(),
+                resolved_peer_names,
+                depth,
+                installable: record.installable,
+                is_pure: record.is_pure,
+                optional: pkg.optional,
+            };
+            match graph.entry(dep_path.clone()) {
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    graph_order.insert(dep_path.clone(), record.order);
+                    entry.insert(candidate);
+                }
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    let existing = entry.get();
+                    let existing_order =
+                        graph_order.get(&dep_path).copied().unwrap_or(record.order);
+                    let replace = candidate.depth < existing.depth
+                        || (candidate.depth == existing.depth && record.order < existing_order);
+                    if replace {
+                        candidate
+                            .transitive_peer_dependencies
+                            .extend(existing.transitive_peer_dependencies.iter().cloned());
+                        merge_preferred_child_edges(
+                            &mut candidate,
+                            existing.children.clone(),
+                            &transitive_peer_dependencies_by_dep_path,
+                        );
+                        graph_order.insert(dep_path.clone(), record.order);
+                        entry.insert(candidate);
+                    } else {
+                        let existing = entry.get_mut();
+                        existing
+                            .transitive_peer_dependencies
+                            .extend(candidate.transitive_peer_dependencies);
+                        merge_preferred_child_edges(
+                            existing,
+                            candidate.children,
+                            &transitive_peer_dependencies_by_dep_path,
+                        );
                     }
-                })
-                .or_insert(DependenciesGraphNode {
-                    dep_path,
-                    resolved_package_id: pkg_id.clone(),
-                    resolve_result: Arc::clone(&pkg.result),
-                    children,
-                    peer_dependencies: pkg.peer_dependencies.clone(),
-                    transitive_peer_dependencies: record.transitive_peer_dependencies.clone(),
-                    resolved_peer_names,
-                    depth,
-                    installable: record.installable,
-                    is_pure: record.is_pure,
-                    optional: pkg.optional,
-                });
+                }
+            }
+        }
+        for (dep_path, node) in synthetic_nodes {
+            graph.entry(dep_path).or_insert(node);
         }
         graph
+    }
+
+    fn final_peer_edge_dep_path(
+        &self,
+        consumer_node_id: &NodeId,
+        provider_node_id: &NodeId,
+        final_dep_paths: &HashMap<NodeId, DepPath>,
+        record_resolved_peer_names: &HashMap<NodeId, HashSet<String>>,
+        variants_by_pkg_id: &HashMap<String, Vec<(DepPath, HashSet<String>)>>,
+    ) -> (DepPath, Option<DependenciesGraphNode>) {
+        let original = self.final_dep_path_of(provider_node_id, final_dep_paths);
+        let Some(provider_tree_node) = self.tree.dependencies_tree.get(provider_node_id) else {
+            return (original, None);
+        };
+        let Some(consumer_tree_node) = self.tree.dependencies_tree.get(consumer_node_id) else {
+            return (original, None);
+        };
+        let Some(consumer_pkg) = self.tree.packages.get(&consumer_tree_node.resolved_package_id)
+        else {
+            return (original, None);
+        };
+        let mut available_peer_names = HashSet::new();
+        if let Some(consumer_record) = self.node_records.get(consumer_node_id) {
+            available_peer_names.extend(consumer_record.peer_edges.iter().cloned());
+            for alias in consumer_record.edges.keys() {
+                if self.tree.all_peer_dep_names.contains(alias) {
+                    available_peer_names.insert(alias.clone());
+                }
+            }
+        }
+        available_peer_names.insert(pkg_name_version(&consumer_pkg.result).0);
+
+        let Some(variants) = variants_by_pkg_id.get(&provider_tree_node.resolved_package_id) else {
+            return (original, None);
+        };
+        if variants
+            .iter()
+            .find(|(dep_path, _)| dep_path == &original)
+            .is_some_and(|(_, peer_names)| peer_names.is_subset(&available_peer_names))
+        {
+            return (original, None);
+        }
+        let unavailable = unavailable_peer_segment_names(&original, &available_peer_names);
+        if unavailable.is_some_and(|names| {
+            !names.is_empty()
+                && self.node_records.get(provider_node_id).is_some_and(|record| {
+                    names.iter().all(|name| record.transitive_peer_dependencies.contains(name))
+                })
+        }) {
+            return (original, None);
+        }
+        if let Some(trimmed) = dep_path_with_allowed_peer_segments(&original, &available_peer_names)
+        {
+            if variants.iter().any(|(dep_path, _)| dep_path == &trimmed) {
+                return (trimmed, None);
+            }
+            if let Some(node) = self.synthetic_peer_variant_node(
+                provider_node_id,
+                trimmed.clone(),
+                &available_peer_names,
+                final_dep_paths,
+                record_resolved_peer_names,
+            ) {
+                return (trimmed, Some(node));
+            }
+        }
+        variants
+            .iter()
+            .find(|(_, peer_names)| peer_names.is_subset(&available_peer_names))
+            .map(|(dep_path, _)| (dep_path.clone(), None))
+            .unwrap_or((original, None))
+    }
+
+    fn synthetic_peer_variant_node(
+        &self,
+        provider_node_id: &NodeId,
+        dep_path: DepPath,
+        available_peer_names: &HashSet<String>,
+        final_dep_paths: &HashMap<NodeId, DepPath>,
+        record_resolved_peer_names: &HashMap<NodeId, HashSet<String>>,
+    ) -> Option<DependenciesGraphNode> {
+        let record = self.node_records.get(provider_node_id)?;
+        let tree_node = self.tree.dependencies_tree.get(provider_node_id)?;
+        let pkg = self.tree.packages.get(&tree_node.resolved_package_id)?;
+        let mut children = BTreeMap::new();
+        for (alias, edge_node_id) in &record.edges {
+            if record.peer_edges.contains(alias) && !available_peer_names.contains(alias) {
+                continue;
+            }
+            children.insert(alias.clone(), self.final_dep_path_of(edge_node_id, final_dep_paths));
+        }
+        let resolved_peer_names: HashSet<String> = record_resolved_peer_names
+            .get(provider_node_id)
+            .into_iter()
+            .flat_map(|names| names.iter())
+            .filter(|name| available_peer_names.contains(*name))
+            .cloned()
+            .collect();
+        Some(DependenciesGraphNode {
+            dep_path,
+            resolved_package_id: tree_node.resolved_package_id.clone(),
+            resolve_result: Arc::clone(&pkg.result),
+            children,
+            peer_dependencies: pkg.peer_dependencies.clone(),
+            transitive_peer_dependencies: record.transitive_peer_dependencies.clone(),
+            resolved_peer_names,
+            depth: record.depth,
+            installable: record.installable,
+            is_pure: false,
+            optional: pkg.optional,
+        })
     }
 
     /// Realize the `(alias → NodeId)` children of `node_id` if it's
@@ -1790,9 +2200,7 @@ impl Walker<'_> {
     /// A cache item matches when, for every cached resolved peer:
     ///
     /// 1. The current `parent_refs` has a counterpart entry for the
-    ///    same name with a real `NodeId`, unless the package declares
-    ///    that cached peer as optional and the current context has no
-    ///    provider for it.
+    ///    same name with a real `NodeId`.
     /// 2. Either the two `NodeId`s are equal, OR they map to the
     ///    same already-computed [`DepPath`] in
     ///    [`Self::node_dep_paths`], OR the two tree-nodes' resolved
@@ -1809,9 +2217,6 @@ impl Walker<'_> {
         cache_items.iter().find(|item| {
             for (name, cached_node_id) in &item.resolved_peers {
                 let Some(current_ref) = parent_refs.get(name) else {
-                    if self.peer_dependency_is_optional(pkg_id, name) {
-                        continue;
-                    }
                     return false;
                 };
                 let Some(current_node_id) = current_ref.node_id.as_ref() else {
@@ -1857,14 +2262,6 @@ impl Walker<'_> {
             }
             true
         })
-    }
-
-    fn peer_dependency_is_optional(&self, pkg_id: &str, peer_name: &str) -> bool {
-        self.tree
-            .packages
-            .get(pkg_id)
-            .and_then(|pkg| pkg.peer_dependencies.get(peer_name))
-            .is_some_and(|peer| peer.optional)
     }
 
     /// Compare two `NodeId`s' recorded parent peer contexts. Mirrors
@@ -1925,6 +2322,191 @@ fn parent_pkgs_have_single_occurrence(parents: &HashMap<String, ParentPkgInfo>) 
     parents.values().all(|info| info.occurrence == 0)
 }
 
+fn merge_preferred_child_edges(
+    target: &mut DependenciesGraphNode,
+    children: BTreeMap<String, DepPath>,
+    transitive_peer_dependencies_by_dep_path: &HashMap<DepPath, HashSet<String>>,
+) {
+    let available_peer_names =
+        available_peer_names_for_dep_path(&target.dep_path, &target.resolve_result);
+    for (alias, candidate_dep_path) in children {
+        match target.children.entry(alias) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(candidate_dep_path);
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                let preferred = child_dep_path_is_preferred(
+                    entry.get(),
+                    &candidate_dep_path,
+                    &available_peer_names,
+                    transitive_peer_dependencies_by_dep_path,
+                );
+                if preferred {
+                    entry.insert(candidate_dep_path);
+                }
+            }
+        }
+    }
+}
+
+fn available_peer_names_for_dep_path(
+    dep_path: &DepPath,
+    resolve_result: &ResolveResult,
+) -> HashSet<String> {
+    let mut names: HashSet<String> =
+        peer_segment_names(dep_path).unwrap_or_default().into_iter().collect();
+    names.insert(pkg_name_version(resolve_result).0);
+    names
+}
+
+fn child_dep_path_is_preferred(
+    current: &DepPath,
+    candidate: &DepPath,
+    available_peer_names: &HashSet<String>,
+    transitive_peer_dependencies_by_dep_path: &HashMap<DepPath, HashSet<String>>,
+) -> bool {
+    if current == candidate {
+        return false;
+    }
+    let current_unavailable = unavailable_non_transitive_peer_segment_names(
+        current,
+        available_peer_names,
+        transitive_peer_dependencies_by_dep_path,
+    )
+    .unwrap_or_default();
+    let candidate_unavailable = unavailable_non_transitive_peer_segment_names(
+        candidate,
+        available_peer_names,
+        transitive_peer_dependencies_by_dep_path,
+    )
+    .unwrap_or_default();
+    if candidate_unavailable.len() != current_unavailable.len() {
+        return candidate_unavailable.len() < current_unavailable.len();
+    }
+    if !candidate_unavailable.is_empty() {
+        return false;
+    }
+    let current_peer_count =
+        available_peer_segment_count(current, available_peer_names).unwrap_or(0);
+    let candidate_peer_count =
+        available_peer_segment_count(candidate, available_peer_names).unwrap_or(0);
+    candidate_peer_count > current_peer_count
+}
+
+fn available_peer_segment_count(
+    dep_path: &DepPath,
+    available_peer_names: &HashSet<String>,
+) -> Option<usize> {
+    let names = peer_segment_names(dep_path)?;
+    Some(names.into_iter().filter(|name| available_peer_names.contains(name)).count())
+}
+
+fn unavailable_non_transitive_peer_segment_names(
+    dep_path: &DepPath,
+    available_peer_names: &HashSet<String>,
+    transitive_peer_dependencies_by_dep_path: &HashMap<DepPath, HashSet<String>>,
+) -> Option<Vec<String>> {
+    let transitive_peer_dependencies = transitive_peer_dependencies_by_dep_path.get(dep_path);
+    let names = peer_segment_names(dep_path)?;
+    Some(
+        names
+            .into_iter()
+            .filter(|name| {
+                !available_peer_names.contains(name)
+                    && transitive_peer_dependencies
+                        .is_none_or(|transitive| !transitive.contains(name))
+            })
+            .collect(),
+    )
+}
+
+fn dep_path_with_allowed_peer_segments(
+    dep_path: &DepPath,
+    allowed_peer_names: &HashSet<String>,
+) -> Option<DepPath> {
+    let raw = dep_path.as_str();
+    let suffix = index_of_dep_path_suffix(raw);
+    let peers_index = suffix.peers_index?;
+    let peers_end = suffix.patch_hash_index.unwrap_or(raw.len());
+    let segments = split_peer_suffix_segments(&raw[peers_index..peers_end])?;
+    let mut kept = Vec::new();
+    for segment in &segments {
+        let name = peer_segment_name(segment)?;
+        if allowed_peer_names.contains(name) {
+            kept.push(segment.as_str());
+        }
+    }
+    if kept.is_empty() || kept.len() == segments.len() {
+        return None;
+    }
+    let mut out = raw[..peers_index].to_string();
+    for segment in kept {
+        out.push('(');
+        out.push_str(segment);
+        out.push(')');
+    }
+    if peers_end < raw.len() {
+        out.push_str(&raw[peers_end..]);
+    }
+    Some(DepPath::from(out))
+}
+
+fn unavailable_peer_segment_names(
+    dep_path: &DepPath,
+    available_peer_names: &HashSet<String>,
+) -> Option<Vec<String>> {
+    let names = peer_segment_names(dep_path)?;
+    Some(names.into_iter().filter(|name| !available_peer_names.contains(name)).collect())
+}
+
+fn peer_segment_names(dep_path: &DepPath) -> Option<Vec<String>> {
+    let raw = dep_path.as_str();
+    let suffix = index_of_dep_path_suffix(raw);
+    let peers_index = suffix.peers_index?;
+    let peers_end = suffix.patch_hash_index.unwrap_or(raw.len());
+    let segments = split_peer_suffix_segments(&raw[peers_index..peers_end])?;
+    segments.iter().map(|segment| peer_segment_name(segment).map(str::to_string)).collect()
+}
+
+fn split_peer_suffix_segments(suffix: &str) -> Option<Vec<String>> {
+    let bytes = suffix.as_bytes();
+    let mut segments = Vec::new();
+    let mut depth = 0i32;
+    let mut start = None;
+    for (idx, byte) in bytes.iter().enumerate() {
+        match byte {
+            b'(' => {
+                if depth == 0 {
+                    start = Some(idx + 1);
+                }
+                depth += 1;
+            }
+            b')' => {
+                depth -= 1;
+                if depth < 0 {
+                    return None;
+                }
+                if depth == 0 {
+                    let start = start.take()?;
+                    segments.push(suffix[start..idx].to_string());
+                }
+            }
+            _ if depth == 0 => return None,
+            _ => {}
+        }
+    }
+    (depth == 0).then_some(segments)
+}
+
+fn peer_segment_name(segment: &str) -> Option<&str> {
+    let version_separator = if let Some(unscoped) = segment.strip_prefix('@') {
+        1 + unscoped.find('@')?
+    } else {
+        segment.find('@')?
+    };
+    Some(&segment[..version_separator])
+}
+
 /// Reproduce upstream's parent-ref dual-keying: each parent is recorded
 /// by its install alias *and* its real name when the two differ.
 /// Mirrors
@@ -1968,6 +2550,22 @@ fn update_parent_refs(refs: &mut ParentRefs, new_alias: &str, parent_ref: &Paren
         }
     }
     refs.insert(new_alias.to_string(), parent_ref.clone());
+}
+
+fn ordered_child_entries(
+    children: &BTreeMap<String, NodeId>,
+    parent_refs: &ParentRefs,
+) -> Vec<(String, NodeId)> {
+    let mut out = Vec::with_capacity(children.len());
+    for repeated in [true, false] {
+        for (alias, node_id) in children {
+            if parent_refs.contains_key(alias) != repeated {
+                continue;
+            }
+            out.push((alias.clone(), node_id.clone()));
+        }
+    }
+    out
 }
 
 fn version_gte(left: &str, right: &str) -> bool {

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -249,6 +249,55 @@ fn transitive_pending_peer_uses_provider_final_suffix() {
 }
 
 #[test]
+fn resolved_peer_providers_from_direct_outputs_are_last_write_wins() {
+    let first_peer = NodeId::leaf("peer@1.0.0");
+    let second_peer = NodeId::leaf("peer@2.0.0");
+    let first = NodeId::next();
+    let second = NodeId::next();
+
+    let mut first_children = BTreeMap::new();
+    first_children.insert("peer".to_string(), first_peer.clone());
+
+    let mut second_children = BTreeMap::new();
+    second_children.insert("peer".to_string(), second_peer.clone());
+
+    let mut tree = ResolvedTree {
+        direct: vec![
+            DirectDep {
+                alias: "first".to_string(),
+                node_id: first.clone(),
+                id: "first@1.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "second".to_string(),
+                node_id: second.clone(),
+                id: "second@1.0.0".to_string(),
+            },
+        ],
+        packages: HashMap::from([
+            ("peer@1.0.0".to_string(), package("peer", "1.0.0", &[], true)),
+            ("peer@2.0.0".to_string(), package("peer", "2.0.0", &[], true)),
+            ("first@1.0.0".to_string(), package("first", "1.0.0", &[("peer", "*")], false)),
+            ("second@1.0.0".to_string(), package("second", "1.0.0", &[("peer", "*")], false)),
+        ]),
+        dependencies_tree: HashMap::from([
+            (first_peer, tree_node("peer@1.0.0", BTreeMap::new(), 1)),
+            (second_peer.clone(), tree_node("peer@2.0.0", BTreeMap::new(), 1)),
+            (first, tree_node("first@1.0.0", first_children, 0)),
+            (second, tree_node("second@1.0.0", second_children, 0)),
+        ]),
+        all_peer_dep_names: HashSet::from(["peer".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+
+    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+
+    assert_eq!(result.resolved_peer_providers_by_alias.get("peer"), Some(&second_peer));
+}
+
+#[test]
 fn peer_name_cycle_collapses_provider_suffixes() {
     let loader = NodeId::next();
     let webpack_cli = NodeId::next();

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1,4 +1,4 @@
-use super::{ResolvePeersOptions, Walker, resolve_peers, satisfies_with_prereleases};
+use super::{NodeRecord, ResolvePeersOptions, Walker, resolve_peers, satisfies_with_prereleases};
 use crate::{
     dependencies_graph::{DependenciesGraph, PeerDependencyIssues},
     node_id::NodeId,
@@ -144,6 +144,176 @@ fn own_peer_is_resolved_from_peer_relevant_child() {
 }
 
 #[test]
+fn non_peer_alias_child_does_not_resolve_by_real_package_name() {
+    let provider = NodeId::leaf("peer@1.0.0");
+    let plugin = NodeId::next();
+    let consumer = NodeId::next();
+
+    let mut consumer_children = BTreeMap::new();
+    consumer_children.insert("not-peer".to_string(), provider.clone());
+    consumer_children.insert("plugin".to_string(), plugin.clone());
+
+    let mut tree = ResolvedTree {
+        direct: vec![DirectDep {
+            alias: "consumer".to_string(),
+            node_id: consumer.clone(),
+            id: "consumer@1.0.0".to_string(),
+        }],
+        packages: HashMap::from([
+            ("consumer@1.0.0".to_string(), package("consumer", "1.0.0", &[], false)),
+            ("peer@1.0.0".to_string(), package("peer", "1.0.0", &[], true)),
+            ("plugin@1.0.0".to_string(), package("plugin", "1.0.0", &[("peer", "*")], false)),
+        ]),
+        dependencies_tree: HashMap::from([
+            (provider, tree_node("peer@1.0.0", BTreeMap::new(), 1)),
+            (plugin, tree_node("plugin@1.0.0", BTreeMap::new(), 1)),
+            (consumer, tree_node("consumer@1.0.0", consumer_children, 0)),
+        ]),
+        all_peer_dep_names: HashSet::from(["peer".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+
+    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+
+    assert!(
+        result.graph.contains_key(&DepPath::from("plugin@1.0.0")),
+        "plugin should not resolve peer by provider's real package name: {:#?}",
+        result.graph.keys().collect::<Vec<_>>(),
+    );
+    assert!(
+        !result.graph.contains_key(&DepPath::from("plugin@1.0.0(peer@1.0.0)")),
+        "non-peer alias `not-peer` must not satisfy peer `peer`: {:#?}",
+        result.graph.keys().collect::<Vec<_>>(),
+    );
+    assert!(result.peer_dependency_issues.missing.contains_key("peer"));
+}
+
+#[test]
+fn transitive_pending_peer_uses_provider_final_suffix() {
+    let c_node_id = NodeId::leaf("c@1.0.0");
+    let a_node_id = NodeId::next();
+    let b_node_id = NodeId::next();
+    let x_node_id = NodeId::next();
+
+    let mut a_children = BTreeMap::new();
+    a_children.insert("b".to_string(), b_node_id.clone());
+    a_children.insert("x".to_string(), x_node_id.clone());
+
+    let mut tree = ResolvedTree {
+        direct: vec![
+            DirectDep {
+                alias: "a".to_string(),
+                node_id: a_node_id.clone(),
+                id: "a@1.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "c".to_string(),
+                node_id: c_node_id.clone(),
+                id: "c@1.0.0".to_string(),
+            },
+        ],
+        packages: HashMap::from([
+            ("a@1.0.0".to_string(), package("a", "1.0.0", &[("c", "*")], false)),
+            ("b@1.0.0".to_string(), package("b", "1.0.0", &[("a", "*")], false)),
+            ("c@1.0.0".to_string(), package("c", "1.0.0", &[], true)),
+            ("x@1.0.0".to_string(), package("x", "1.0.0", &[("b", "*")], false)),
+        ]),
+        dependencies_tree: HashMap::from([
+            (a_node_id, tree_node("a@1.0.0", a_children, 0)),
+            (b_node_id, tree_node("b@1.0.0", BTreeMap::new(), 1)),
+            (c_node_id, tree_node("c@1.0.0", BTreeMap::new(), 0)),
+            (x_node_id, tree_node("x@1.0.0", BTreeMap::new(), 1)),
+        ]),
+        all_peer_dep_names: HashSet::from(["a".to_string(), "b".to_string(), "c".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+
+    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+    let expected = DepPath::from("x@1.0.0(b@1.0.0(a@1.0.0(c@1.0.0)))");
+    let provisional = DepPath::from("x@1.0.0(b@1.0.0(a@1.0.0))");
+
+    assert!(
+        result.graph.contains_key(&expected),
+        "x must use b's final peer suffix: {:#?}",
+        result.graph.keys().collect::<Vec<_>>(),
+    );
+    assert!(
+        !result.graph.contains_key(&provisional),
+        "x must not keep b's provisional peer suffix: {:#?}",
+        result.graph.keys().collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn peer_name_cycle_collapses_provider_suffixes() {
+    let loader = NodeId::next();
+    let webpack_cli = NodeId::next();
+    let webpack = NodeId::next();
+
+    let mut tree = ResolvedTree {
+        direct: vec![
+            DirectDep {
+                alias: "source-map-loader".to_string(),
+                node_id: loader.clone(),
+                id: "source-map-loader@1.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "webpack-cli".to_string(),
+                node_id: webpack_cli.clone(),
+                id: "webpack-cli@6.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "webpack".to_string(),
+                node_id: webpack.clone(),
+                id: "webpack@5.0.0".to_string(),
+            },
+        ],
+        packages: HashMap::from([
+            (
+                "source-map-loader@1.0.0".to_string(),
+                package("source-map-loader", "1.0.0", &[("webpack", "*")], false),
+            ),
+            (
+                "webpack-cli@6.0.0".to_string(),
+                package("webpack-cli", "6.0.0", &[("webpack", "*")], false),
+            ),
+            (
+                "webpack@5.0.0".to_string(),
+                package("webpack", "5.0.0", &[("webpack-cli", "*")], false),
+            ),
+        ]),
+        dependencies_tree: HashMap::from([
+            (loader, tree_node("source-map-loader@1.0.0", BTreeMap::new(), 0)),
+            (webpack_cli, tree_node("webpack-cli@6.0.0", BTreeMap::new(), 0)),
+            (webpack, tree_node("webpack@5.0.0", BTreeMap::new(), 0)),
+        ]),
+        all_peer_dep_names: HashSet::from(["webpack".to_string(), "webpack-cli".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+
+    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+
+    assert_eq!(
+        result.direct_dependencies_by_alias.get("source-map-loader"),
+        Some(&DepPath::from("source-map-loader@1.0.0(webpack@5.0.0)")),
+    );
+    assert_eq!(
+        result.direct_dependencies_by_alias.get("webpack-cli"),
+        Some(&DepPath::from("webpack-cli@6.0.0(webpack@5.0.0)")),
+    );
+    assert_eq!(
+        result.direct_dependencies_by_alias.get("webpack"),
+        Some(&DepPath::from("webpack@5.0.0(webpack-cli@6.0.0)")),
+    );
+}
+
+#[test]
 fn missing_names_by_pkg_records_only_children_context_missing_peers() {
     let parent = NodeId::next();
     let child = NodeId::next();
@@ -195,7 +365,7 @@ fn missing_names_by_pkg_records_only_children_context_missing_peers() {
 }
 
 #[test]
-fn own_peer_is_resolved_from_aliased_child_real_name() {
+fn own_peer_is_not_resolved_from_aliased_child_real_name() {
     let peer_c = NodeId::leaf("peer-c@2.0.0");
     let consumer = NodeId::next();
     let parent = NodeId::next();
@@ -235,17 +405,15 @@ fn own_peer_is_resolved_from_aliased_child_real_name() {
     };
 
     let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
-    let dep_path = DepPath::from("consumer@1.0.0(peer-c@2.0.0)");
+    let dep_path = DepPath::from("consumer@1.0.0");
 
     assert!(
         result.graph.contains_key(&dep_path),
-        "consumer should resolve peer-c from the peer-c1 alias child: {:#?}",
+        "consumer should not resolve peer-c from a child installed as peer-c1: {:#?}",
         result.graph.keys().collect::<Vec<_>>(),
     );
-    assert_eq!(
-        result.graph[&dep_path].children.get("peer-c"),
-        Some(&DepPath::from("peer-c@2.0.0")),
-    );
+    assert!(!result.graph[&dep_path].children.contains_key("peer-c"));
+    assert!(result.peer_dependency_issues.missing.contains_key("peer-c"));
 }
 
 #[test]
@@ -298,7 +466,7 @@ fn importer_parent_refs_skip_direct_deps_irrelevant_by_alias_and_real_name() {
 }
 
 #[test]
-fn cached_optional_peer_resolution_bubbles_to_later_parent_without_provider() {
+fn cached_optional_peer_resolution_does_not_match_later_parent_without_provider() {
     let types = NodeId::leaf("types@1.0.0");
     let config_from_core = NodeId::next();
     let config_from_cli = NodeId::next();
@@ -348,13 +516,54 @@ fn cached_optional_peer_resolution_bubbles_to_later_parent_without_provider() {
     };
 
     let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
-    let config_dep_path = DepPath::from("config@1.0.0(types@1.0.0)");
-    let cli_dep_path = DepPath::from("cli@1.0.0(types@1.0.0)");
+    let config_with_types = DepPath::from("config@1.0.0(types@1.0.0)");
+    let config_without_types = DepPath::from("config@1.0.0");
+    let cli_dep_path = DepPath::from("cli@1.0.0");
 
     assert_eq!(result.direct_dependencies_by_alias.get("core"), Some(&DepPath::from("core@1.0.0")));
     assert_eq!(result.direct_dependencies_by_alias.get("cli"), Some(&cli_dep_path));
-    assert_eq!(result.graph[&cli_dep_path].children.get("config"), Some(&config_dep_path));
-    assert!(result.graph[&cli_dep_path].resolved_peer_names.contains("types"));
+    assert!(result.graph.contains_key(&config_with_types));
+    assert!(result.graph.contains_key(&config_without_types));
+    assert_eq!(result.graph[&cli_dep_path].children.get("config"), Some(&config_without_types));
+    assert!(!result.graph[&cli_dep_path].resolved_peer_names.contains("types"));
+}
+
+#[test]
+fn same_leaf_node_under_multiple_aliases_preserves_every_edge() {
+    let shared = NodeId::leaf("shared@1.0.0");
+    let parent = NodeId::next();
+
+    let mut parent_children = BTreeMap::new();
+    parent_children.insert("alpha".to_string(), shared.clone());
+    parent_children.insert("beta".to_string(), shared.clone());
+
+    let mut tree = ResolvedTree {
+        direct: vec![DirectDep {
+            alias: "parent".to_string(),
+            node_id: parent.clone(),
+            id: "parent@1.0.0".to_string(),
+        }],
+        packages: HashMap::from([
+            ("shared@1.0.0".to_string(), package("shared", "1.0.0", &[], true)),
+            ("parent@1.0.0".to_string(), package("parent", "1.0.0", &[], false)),
+        ]),
+        dependencies_tree: HashMap::from([
+            (shared, tree_node("shared@1.0.0", BTreeMap::new(), 1)),
+            (parent, tree_node("parent@1.0.0", parent_children, 0)),
+        ]),
+        all_peer_dep_names: HashSet::new(),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+
+    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+    let parent_dep_path = DepPath::from("parent@1.0.0");
+    let shared_dep_path = DepPath::from("shared@1.0.0");
+    let parent_node = result.graph.get(&parent_dep_path).expect("parent graph node");
+
+    assert_eq!(parent_node.children.get("alpha"), Some(&shared_dep_path));
+    assert_eq!(parent_node.children.get("beta"), Some(&shared_dep_path));
 }
 
 #[test]
@@ -460,6 +669,388 @@ fn previously_resolved_children_prefers_closest_same_package_ancestor() {
     assert_eq!(children.get("shared"), Some(&close_child));
 }
 
+#[test]
+fn final_graph_keeps_first_equal_depth_payload_and_unions_transitive_peers() {
+    let first = NodeId::next();
+    let second = NodeId::next();
+    let first_child = NodeId::leaf("child-a@1.0.0");
+    let second_child = NodeId::leaf("child-b@1.0.0");
+    let final_dep_path = DepPath::from("same@1.0.0(peer@1.0.0)");
+
+    let mut tree = ResolvedTree {
+        direct: Vec::new(),
+        packages: HashMap::from([
+            ("same@1.0.0".to_string(), package("same", "1.0.0", &[("peer", "*")], false)),
+            ("child-a@1.0.0".to_string(), package("child-a", "1.0.0", &[], true)),
+            ("child-b@1.0.0".to_string(), package("child-b", "1.0.0", &[], true)),
+        ]),
+        dependencies_tree: HashMap::from([
+            (first.clone(), tree_node("same@1.0.0", BTreeMap::new(), 1)),
+            (second.clone(), tree_node("same@1.0.0", BTreeMap::new(), 1)),
+            (first_child.clone(), tree_node("child-a@1.0.0", BTreeMap::new(), 2)),
+            (second_child.clone(), tree_node("child-b@1.0.0", BTreeMap::new(), 2)),
+        ]),
+        all_peer_dep_names: HashSet::from(["peer".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+    let mut walker = walker_for_tests(&mut tree);
+    walker.node_dep_paths.insert(first.clone(), final_dep_path.clone());
+    walker.node_dep_paths.insert(second.clone(), final_dep_path.clone());
+    walker.node_dep_paths.insert(first_child.clone(), DepPath::from("child-a@1.0.0"));
+    walker.node_dep_paths.insert(second_child.clone(), DepPath::from("child-b@1.0.0"));
+    walker.node_records.insert(
+        second.clone(),
+        NodeRecord {
+            edges: BTreeMap::from([("peer".to_string(), second_child)]),
+            peer_edges: HashSet::new(),
+            transitive_peer_dependencies: HashSet::from(["debug".to_string()]),
+            depth: 1,
+            installable: true,
+            is_pure: false,
+            order: 1,
+        },
+    );
+    walker.node_records.insert(
+        first.clone(),
+        NodeRecord {
+            edges: BTreeMap::from([("peer".to_string(), first_child)]),
+            peer_edges: HashSet::new(),
+            transitive_peer_dependencies: HashSet::new(),
+            depth: 1,
+            installable: true,
+            is_pure: false,
+            order: 0,
+        },
+    );
+
+    let graph = walker.build_final_graph(&HashMap::from([
+        (first, final_dep_path.clone()),
+        (second, final_dep_path.clone()),
+    ]));
+
+    assert_eq!(graph[&final_dep_path].children.get("peer"), Some(&DepPath::from("child-a@1.0.0")));
+    assert!(graph[&final_dep_path].transitive_peer_dependencies.contains("debug"));
+}
+
+#[test]
+fn final_graph_duplicate_parent_prefers_child_variant_matching_parent_peers() {
+    let first = NodeId::next();
+    let second = NodeId::next();
+    let first_child = NodeId::next();
+    let second_child = NodeId::next();
+    let parent_dep_path = DepPath::from(
+        "consumer@1.0.0(webpack-cli@6.0.1)(webpack-dev-server@5.2.2)(webpack@5.107.2)",
+    );
+    let analyzer_child_dep_path = DepPath::from(
+        "webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.2)(webpack@5.107.2)",
+    );
+    let matching_child_dep_path =
+        DepPath::from("webpack-cli@6.0.1(webpack-dev-server@5.2.2)(webpack@5.107.2)");
+
+    let mut tree = ResolvedTree {
+        direct: Vec::new(),
+        packages: HashMap::from([(
+            "consumer@1.0.0".to_string(),
+            package("consumer", "1.0.0", &[], false),
+        )]),
+        dependencies_tree: HashMap::from([
+            (first.clone(), tree_node("consumer@1.0.0", BTreeMap::new(), 1)),
+            (second.clone(), tree_node("consumer@1.0.0", BTreeMap::new(), 1)),
+        ]),
+        all_peer_dep_names: HashSet::new(),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+    let mut walker = walker_for_tests(&mut tree);
+    walker.node_dep_paths.insert(first.clone(), parent_dep_path.clone());
+    walker.node_dep_paths.insert(second.clone(), parent_dep_path.clone());
+    walker.node_records.insert(
+        first.clone(),
+        NodeRecord {
+            edges: BTreeMap::from([("webpack-cli".to_string(), first_child.clone())]),
+            peer_edges: HashSet::new(),
+            transitive_peer_dependencies: HashSet::new(),
+            depth: 1,
+            installable: true,
+            is_pure: false,
+            order: 0,
+        },
+    );
+    walker.node_records.insert(
+        second.clone(),
+        NodeRecord {
+            edges: BTreeMap::from([("webpack-cli".to_string(), second_child.clone())]),
+            peer_edges: HashSet::new(),
+            transitive_peer_dependencies: HashSet::new(),
+            depth: 1,
+            installable: true,
+            is_pure: false,
+            order: 1,
+        },
+    );
+
+    let graph = walker.build_final_graph(&HashMap::from([
+        (first, parent_dep_path.clone()),
+        (second, parent_dep_path.clone()),
+        (first_child, analyzer_child_dep_path),
+        (second_child, matching_child_dep_path.clone()),
+    ]));
+
+    assert_eq!(graph[&parent_dep_path].children.get("webpack-cli"), Some(&matching_child_dep_path));
+}
+
+#[test]
+fn final_graph_peer_edge_uses_provider_variant_without_unavailable_extra_peers() {
+    let provider_analyzer = NodeId::next();
+    let provider_bare = NodeId::next();
+    let consumer = NodeId::next();
+
+    let provider_analyzer_dep_path = DepPath::from(
+        "webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.2)(webpack@5.107.2)",
+    );
+    let provider_middle_dep_path =
+        DepPath::from("webpack-cli@6.0.1(webpack-dev-server@5.2.2)(webpack@5.107.2)");
+    let provider_bare_dep_path = DepPath::from("webpack-cli@6.0.1(webpack@5.107.2)");
+    let consumer_dep_path = DepPath::from(
+        "@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.2)(webpack@5.107.2)",
+    );
+
+    let mut tree = ResolvedTree {
+        direct: Vec::new(),
+        packages: HashMap::from([
+            (
+                "webpack-cli@6.0.1".to_string(),
+                package(
+                    "webpack-cli",
+                    "6.0.1",
+                    &[
+                        ("webpack", "*"),
+                        ("webpack-dev-server", "*"),
+                        ("webpack-bundle-analyzer", "*"),
+                    ],
+                    false,
+                ),
+            ),
+            (
+                "@webpack-cli/serve@3.0.1".to_string(),
+                package(
+                    "@webpack-cli/serve",
+                    "3.0.1",
+                    &[("webpack", "*"), ("webpack-cli", "*"), ("webpack-dev-server", "*")],
+                    false,
+                ),
+            ),
+        ]),
+        dependencies_tree: HashMap::from([
+            (provider_analyzer.clone(), tree_node("webpack-cli@6.0.1", BTreeMap::new(), 0)),
+            (provider_bare.clone(), tree_node("webpack-cli@6.0.1", BTreeMap::new(), 0)),
+            (consumer.clone(), tree_node("@webpack-cli/serve@3.0.1", BTreeMap::new(), 1)),
+        ]),
+        all_peer_dep_names: HashSet::from([
+            "webpack".to_string(),
+            "webpack-cli".to_string(),
+            "webpack-dev-server".to_string(),
+            "webpack-bundle-analyzer".to_string(),
+        ]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+    let mut walker = walker_for_tests(&mut tree);
+    walker.node_records.insert(
+        provider_analyzer.clone(),
+        NodeRecord {
+            edges: BTreeMap::new(),
+            peer_edges: HashSet::new(),
+            transitive_peer_dependencies: HashSet::new(),
+            depth: 0,
+            installable: true,
+            is_pure: false,
+            order: 0,
+        },
+    );
+    walker.node_records.insert(
+        provider_bare.clone(),
+        NodeRecord {
+            edges: BTreeMap::new(),
+            peer_edges: HashSet::new(),
+            transitive_peer_dependencies: HashSet::new(),
+            depth: 0,
+            installable: true,
+            is_pure: false,
+            order: 1,
+        },
+    );
+    walker.node_records.insert(
+        consumer.clone(),
+        NodeRecord {
+            edges: BTreeMap::from([("webpack-cli".to_string(), provider_analyzer.clone())]),
+            peer_edges: HashSet::from(["webpack-dev-server".to_string(), "webpack".to_string()]),
+            transitive_peer_dependencies: HashSet::new(),
+            depth: 1,
+            installable: true,
+            is_pure: false,
+            order: 2,
+        },
+    );
+    walker.node_external_peers.insert(
+        provider_analyzer.clone(),
+        HashMap::from([
+            ("webpack-bundle-analyzer".to_string(), NodeId::leaf("webpack-bundle-analyzer@4.10.2")),
+            ("webpack-dev-server".to_string(), NodeId::leaf("webpack-dev-server@5.2.2")),
+            ("webpack".to_string(), NodeId::leaf("webpack@5.107.2")),
+        ]),
+    );
+    walker.node_external_peers.insert(
+        provider_bare.clone(),
+        HashMap::from([("webpack".to_string(), NodeId::leaf("webpack@5.107.2"))]),
+    );
+    walker.node_external_peers.insert(
+        consumer.clone(),
+        HashMap::from([
+            ("webpack-bundle-analyzer".to_string(), NodeId::leaf("webpack-bundle-analyzer@4.10.2")),
+            ("webpack-cli".to_string(), provider_analyzer.clone()),
+            ("webpack-dev-server".to_string(), NodeId::leaf("webpack-dev-server@5.2.2")),
+            ("webpack".to_string(), NodeId::leaf("webpack@5.107.2")),
+        ]),
+    );
+
+    let graph = walker.build_final_graph(&HashMap::from([
+        (provider_analyzer, provider_analyzer_dep_path),
+        (provider_bare, provider_bare_dep_path),
+        (consumer, consumer_dep_path.clone()),
+    ]));
+
+    assert_eq!(
+        graph[&consumer_dep_path].children.get("webpack-cli"),
+        Some(&provider_middle_dep_path),
+    );
+}
+
+#[test]
+fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
+    let provider = NodeId::next();
+    let consumer = NodeId::next();
+
+    let provider_dep_path = DepPath::from(
+        "webpack-dev-server@5.2.2(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@5.0.10)(webpack-cli@6.0.1)(webpack@5.107.2)",
+    );
+    let trimmed_provider_dep_path =
+        DepPath::from("webpack-dev-server@5.2.2(webpack-cli@6.0.1)(webpack@5.107.2)");
+    let consumer_dep_path = DepPath::from(
+        "webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.2)(webpack@5.107.2)",
+    );
+
+    let mut tree = ResolvedTree {
+        direct: Vec::new(),
+        packages: HashMap::from([
+            (
+                "webpack-dev-server@5.2.2".to_string(),
+                package(
+                    "webpack-dev-server",
+                    "5.2.2",
+                    &[("webpack", "*"), ("webpack-cli", "*")],
+                    false,
+                ),
+            ),
+            (
+                "webpack-cli@6.0.1".to_string(),
+                package(
+                    "webpack-cli",
+                    "6.0.1",
+                    &[
+                        ("webpack", "*"),
+                        ("webpack-bundle-analyzer", "*"),
+                        ("webpack-dev-server", "*"),
+                    ],
+                    false,
+                ),
+            ),
+        ]),
+        dependencies_tree: HashMap::from([
+            (provider.clone(), tree_node("webpack-dev-server@5.2.2", BTreeMap::new(), 1)),
+            (consumer.clone(), tree_node("webpack-cli@6.0.1", BTreeMap::new(), 0)),
+        ]),
+        all_peer_dep_names: HashSet::from([
+            "bufferutil".to_string(),
+            "tslib".to_string(),
+            "utf-8-validate".to_string(),
+            "webpack".to_string(),
+            "webpack-cli".to_string(),
+            "webpack-dev-server".to_string(),
+            "webpack-bundle-analyzer".to_string(),
+        ]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+    let mut walker = walker_for_tests(&mut tree);
+    walker.node_records.insert(
+        provider.clone(),
+        NodeRecord {
+            edges: BTreeMap::new(),
+            peer_edges: HashSet::new(),
+            transitive_peer_dependencies: HashSet::from([
+                "bufferutil".to_string(),
+                "tslib".to_string(),
+                "utf-8-validate".to_string(),
+            ]),
+            depth: 1,
+            installable: true,
+            is_pure: false,
+            order: 0,
+        },
+    );
+    walker.node_records.insert(
+        consumer.clone(),
+        NodeRecord {
+            edges: BTreeMap::from([("webpack-dev-server".to_string(), provider.clone())]),
+            peer_edges: HashSet::from([
+                "webpack".to_string(),
+                "webpack-bundle-analyzer".to_string(),
+                "webpack-dev-server".to_string(),
+            ]),
+            transitive_peer_dependencies: HashSet::new(),
+            depth: 0,
+            installable: true,
+            is_pure: false,
+            order: 1,
+        },
+    );
+    walker.node_external_peers.insert(
+        provider.clone(),
+        HashMap::from([
+            ("bufferutil".to_string(), NodeId::leaf("bufferutil@4.1.0")),
+            ("tslib".to_string(), NodeId::leaf("tslib@2.8.1")),
+            ("utf-8-validate".to_string(), NodeId::leaf("utf-8-validate@5.0.10")),
+            ("webpack-cli".to_string(), consumer.clone()),
+            ("webpack".to_string(), NodeId::leaf("webpack@5.107.2")),
+        ]),
+    );
+    walker.node_external_peers.insert(
+        consumer.clone(),
+        HashMap::from([
+            ("webpack-bundle-analyzer".to_string(), NodeId::leaf("webpack-bundle-analyzer@4.10.2")),
+            ("webpack-dev-server".to_string(), provider.clone()),
+            ("webpack".to_string(), NodeId::leaf("webpack@5.107.2")),
+        ]),
+    );
+
+    let graph = walker.build_final_graph(&HashMap::from([
+        (provider, provider_dep_path.clone()),
+        (consumer, consumer_dep_path.clone()),
+    ]));
+
+    assert_eq!(
+        graph[&consumer_dep_path].children.get("webpack-dev-server"),
+        Some(&provider_dep_path),
+    );
+    assert!(!graph.contains_key(&trimmed_provider_dep_path));
+}
+
 fn tree_node(pkg_id: &str, children: BTreeMap<String, NodeId>, depth: i32) -> DependenciesTreeNode {
     DependenciesTreeNode {
         resolved_package_id: pkg_id.to_string(),
@@ -479,12 +1070,14 @@ fn walker_for_tests(tree: &mut ResolvedTree) -> Walker<'_> {
         node_external_peers: HashMap::new(),
         node_missing_peers: HashMap::new(),
         node_missing_peers_of_children: HashMap::new(),
+        resolved_peer_providers_by_alias: BTreeMap::new(),
         in_progress: HashSet::new(),
         pending_peer_edges: Vec::new(),
         pure_pkgs: HashSet::new(),
         peers_cache: HashMap::new(),
         parent_pkgs_of_node: HashMap::new(),
         node_records: HashMap::new(),
+        next_record_order: 0,
     }
 }
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -54,6 +54,10 @@ pub struct WorkspaceResolveOptions {
     /// it. Mirrors pnpm's `dedupePeerDependents` setting (default
     /// `true`).
     pub dedupe_peer_dependents: bool,
+    /// When true, non-root importers can resolve peers from the
+    /// workspace root's direct dependencies. Mirrors pnpm's
+    /// `resolvePeersFromWorkspaceRoot` setting.
+    pub resolve_peers_from_workspace_root: bool,
     /// Threaded into [`ResolvePeersOptions::exclude_links_from_lockfile`]
     /// for the workspace-wide peer pass. Per-importer
     /// [`ResolvePeersOptions::modules_dir`] comes from each
@@ -151,6 +155,7 @@ where
         dedupe_peers,
         dedupe_injected_deps,
         dedupe_peer_dependents,
+        resolve_peers_from_workspace_root,
         exclude_links_from_lockfile,
         lockfile_dir,
         peers_suffix_max_length,
@@ -286,6 +291,7 @@ where
         &lockfile_dir,
         dedupe_injected_deps,
         dedupe_peer_dependents,
+        resolve_peers_from_workspace_root,
         peer_opts,
     );
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -8,10 +8,11 @@
 use std::{collections::HashMap, str::FromStr, sync::Mutex};
 
 use chrono::{DateTime, TimeZone, Utc};
+use pacquet_lockfile::{DirectoryResolution, LockfileResolution};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_resolving_resolver_base::{
-    LatestQuery, PreferredVersions, ResolveError, ResolveFuture, ResolveLatestFuture,
-    ResolveOptions, ResolveResult, Resolver, WantedDependency,
+    LatestQuery, PkgResolutionId, PreferredVersions, ResolveError, ResolveFuture,
+    ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, WantedDependency,
 };
 use pretty_assertions::assert_eq;
 
@@ -48,6 +49,55 @@ impl Resolver for RecordingResolver {
             .insert(alias.clone(), (opts.pick_lowest_version, opts.published_by));
         let result = self.table.get(&(alias, range)).cloned();
         Box::pin(async move { Ok::<_, ResolveError>(result) })
+    }
+
+    fn resolve_latest<'a>(
+        &'a self,
+        _query: &'a LatestQuery,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveLatestFuture<'a> {
+        Box::pin(async { Ok(None) })
+    }
+}
+
+struct ProjectRelativeWorkspaceResolver {
+    target_dir: std::path::PathBuf,
+}
+
+impl Resolver for ProjectRelativeWorkspaceResolver {
+    fn resolve<'a>(
+        &'a self,
+        wanted: &'a WantedDependency,
+        opts: &'a ResolveOptions,
+    ) -> ResolveFuture<'a> {
+        let alias = wanted.alias.clone().unwrap_or_default();
+        let range = wanted.bare_specifier.clone().unwrap_or_default();
+        let target_dir = self.target_dir.clone();
+        let project_dir = opts.project_dir.clone();
+        Box::pin(async move {
+            if alias != "shared" || range != "^1.0.0" {
+                return Ok(None);
+            }
+            let rel = pathdiff::diff_paths(&target_dir, &project_dir)
+                .expect("target can be relativized")
+                .display()
+                .to_string()
+                .replace('\\', "/");
+            Ok(Some(ResolveResult {
+                id: PkgResolutionId::from(format!("link:{rel}")),
+                name_ver: None,
+                latest: None,
+                published_at: None,
+                manifest: Some(std::sync::Arc::new(
+                    serde_json::json!({ "name": "shared", "version": "1.0.0" }),
+                )),
+                resolution: LockfileResolution::Directory(DirectoryResolution { directory: rel }),
+                resolved_via: "workspace".to_string(),
+                normalized_bare_specifier: None,
+                alias: Some(alias),
+                policy_violation: None,
+            }))
+        })
     }
 
     fn resolve_latest<'a>(
@@ -132,6 +182,7 @@ fn workspace_opts(pick_lowest_direct: bool, time_based: bool) -> WorkspaceResolv
         dedupe_peers: false,
         dedupe_injected_deps: false,
         dedupe_peer_dependents: false,
+        resolve_peers_from_workspace_root: false,
         exclude_links_from_lockfile: false,
         lockfile_dir: std::path::PathBuf::from("/lockfile-dir"),
         peers_suffix_max_length: 1000,
@@ -145,6 +196,127 @@ fn workspace_opts(pick_lowest_direct: bool, time_based: bool) -> WorkspaceResolv
         auto_install_peers: false,
         registries: HashMap::new(),
     }
+}
+
+#[tokio::test]
+async fn workspace_link_results_are_cached_per_importer_project_dir() {
+    let (_a_tmp, a_manifest) = fake_manifest(serde_json::json!({ "shared": "^1.0.0" }));
+    let (_b_tmp, b_manifest) = fake_manifest(serde_json::json!({ "shared": "^1.0.0" }));
+    let resolver = ProjectRelativeWorkspaceResolver {
+        target_dir: std::path::PathBuf::from("/repo/packages/shared"),
+    };
+    let importers = vec![
+        WorkspaceImporter { id: "packages/a".to_string(), manifest: &a_manifest },
+        WorkspaceImporter { id: "apps/b".to_string(), manifest: &b_manifest },
+    ];
+
+    let result = resolve_workspace(
+        &resolver,
+        &importers,
+        &[DependencyGroup::Prod],
+        workspace_opts(false, false),
+        |importer| {
+            let project_dir = match importer.id.as_str() {
+                "packages/a" => std::path::PathBuf::from("/repo/packages/a"),
+                "apps/b" => std::path::PathBuf::from("/repo/apps/b"),
+                _ => unreachable!("unexpected importer"),
+            };
+            let mut opts = importer_opts(project_dir, None);
+            opts.base_opts.always_try_workspace_packages = true;
+            opts.base_opts.workspace_packages = Some(std::collections::BTreeMap::default());
+            opts
+        },
+    )
+    .await
+    .expect("resolve workspace");
+
+    assert_eq!(
+        result.peers.direct_dependencies_by_importer["packages/a"]["shared"].as_str(),
+        "link:../shared",
+    );
+    assert_eq!(
+        result.peers.direct_dependencies_by_importer["apps/b"]["shared"].as_str(),
+        "link:../../packages/shared",
+    );
+}
+
+#[tokio::test]
+async fn workspace_root_direct_deps_resolve_child_importer_peers() {
+    let (_root_tmp, root_manifest) = fake_manifest(serde_json::json!({
+        "typescript": "~5.9.3",
+    }));
+    let (_app_tmp, app_manifest) = fake_manifest(serde_json::json!({
+        "rollup": "^4.0.0",
+        "plugin": "^1.0.0",
+    }));
+    let mut table = HashMap::new();
+    table.insert(
+        ("typescript".to_string(), "~5.9.3".to_string()),
+        fake_result(
+            "typescript",
+            "5.9.3",
+            None,
+            serde_json::json!({ "name": "typescript", "version": "5.9.3" }),
+        ),
+    );
+    table.insert(
+        ("typescript".to_string(), "5.9.3".to_string()),
+        fake_result(
+            "typescript",
+            "5.9.3",
+            None,
+            serde_json::json!({ "name": "typescript", "version": "5.9.3" }),
+        ),
+    );
+    table.insert(
+        ("rollup".to_string(), "^4.0.0".to_string()),
+        fake_result(
+            "rollup",
+            "4.0.0",
+            None,
+            serde_json::json!({ "name": "rollup", "version": "4.0.0" }),
+        ),
+    );
+    table.insert(
+        ("plugin".to_string(), "^1.0.0".to_string()),
+        fake_result(
+            "plugin",
+            "1.0.0",
+            None,
+            serde_json::json!({
+                "name": "plugin",
+                "version": "1.0.0",
+                "peerDependencies": {
+                    "rollup": "^4.0.0",
+                    "typescript": "^5.0.0"
+                }
+            }),
+        ),
+    );
+    let resolver = RecordingResolver { table, seen: Mutex::new(HashMap::new()) };
+    let importers = vec![
+        WorkspaceImporter { id: ".".to_string(), manifest: &root_manifest },
+        WorkspaceImporter { id: "packages/app".to_string(), manifest: &app_manifest },
+    ];
+    let mut opts = workspace_opts(false, false);
+    opts.resolve_peers_from_workspace_root = true;
+
+    let result =
+        resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+            let project_dir = match importer.id.as_str() {
+                "." => std::path::PathBuf::from("/repo"),
+                "packages/app" => std::path::PathBuf::from("/repo/packages/app"),
+                _ => unreachable!("unexpected importer"),
+            };
+            importer_opts(project_dir, None)
+        })
+        .await
+        .expect("resolve workspace");
+
+    assert_eq!(
+        result.peers.direct_dependencies_by_importer["packages/app"]["plugin"].as_str(),
+        "plugin@1.0.0(rollup@4.0.0)(typescript@5.9.3)",
+    );
 }
 
 /// time-based: the subdep cutoff is the newest direct-dep publication
@@ -293,16 +465,15 @@ async fn lowest_direct_applies_no_publish_cutoff() {
     );
 }
 
-/// A package shared across importers keeps the peer context of the
-/// importer that resolved it first: pnpm reuses the first walk's
-/// children missing-peer report, so a later importer never hoists an
-/// optional peer declared inside that shared subtree, and the
-/// workspace-wide peer pass shares the first importer's variant
-/// (verified against pnpm 11.6.0 — root + pkg-a both depending on
-/// `@pnpm/meta-updater` keep root's `@types/node` context while a
-/// third importer pins a higher version).
+/// A package shared across importers keeps the children missing-peer
+/// report from the importer that resolved it first, so a later importer
+/// never hoists an optional peer declared inside that shared subtree.
+/// The final workspace-wide peer pass still uses each importer's actual
+/// provider context, so an importer without the provider gets the
+/// peerless variant instead of reusing the first importer's suffixed
+/// variant.
 #[tokio::test]
-async fn shared_subtree_keeps_first_importers_optional_peer_context() {
+async fn shared_subtree_owner_context_suppresses_later_optional_hoist() {
     let mut table = HashMap::new();
     table.insert(
         ("shared".to_string(), "1.0.0".to_string()),
@@ -392,8 +563,8 @@ async fn shared_subtree_keeps_first_importers_optional_peer_context() {
         result.peers.direct_dependencies_by_importer.get("pkg-a").expect("pkg-a importer");
     assert_eq!(
         a_direct.get("shared").map(std::string::ToString::to_string),
-        Some("shared@1.0.0(opt@18.0.0)".to_string()),
-        "pkg-a shares the first importer's variant instead of hoisting the higher version",
+        Some("shared@1.0.0".to_string()),
+        "pkg-a must not hoist opt, but it also must not reuse root's opt provider",
     );
 }
 

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -609,9 +609,61 @@ fn cached_range(range: &str) -> Option<Arc<Range>> {
         // not on the guard.
         return entry.value().clone();
     }
-    let parsed = Range::parse(range).ok().map(Arc::new);
+    let normalized = normalize_partial_lte_comparators(range);
+    let parsed = Range::parse(&normalized).ok().map(Arc::new);
     RANGE_CACHE.insert(range.to_string(), parsed.clone());
     parsed
+}
+
+fn normalize_partial_lte_comparators(range: &str) -> String {
+    let tokens: Vec<&str> = range.split_whitespace().collect();
+    let mut normalized = Vec::with_capacity(tokens.len());
+    let mut cursor = 0;
+    while cursor < tokens.len() {
+        let token = tokens[cursor];
+        if token == "<="
+            && let Some(version) = tokens.get(cursor + 1)
+            && let Some(comparator) = partial_lte_upper_bound(version)
+        {
+            normalized.push(comparator);
+            cursor += 2;
+            continue;
+        }
+        if let Some(version) = token.strip_prefix("<=")
+            && let Some(comparator) = partial_lte_upper_bound(version)
+        {
+            normalized.push(comparator);
+            cursor += 1;
+            continue;
+        }
+        normalized.push(token.to_string());
+        cursor += 1;
+    }
+    normalized.join(" ")
+}
+
+fn partial_lte_upper_bound(version: &str) -> Option<String> {
+    if version.contains('-') || version.contains('+') || version.contains('*') {
+        return None;
+    }
+    let parts: Vec<&str> = version.split('.').collect();
+    match parts.as_slice() {
+        [major] if is_digits(major) => {
+            let major: u64 = major.parse().ok()?;
+            let next_major = major.checked_add(1)?;
+            Some(format!("<{next_major}.0.0-0"))
+        }
+        [major, minor] if is_digits(major) && is_digits(minor) => {
+            let minor: u64 = minor.parse().ok()?;
+            let next_minor = minor.checked_add(1)?;
+            Some(format!("<{major}.{next_minor}.0-0"))
+        }
+        _ => None,
+    }
+}
+
+fn is_digits(value: &str) -> bool {
+    !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 /// Check whether `version` satisfies `range` under node-semver's

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
@@ -113,6 +113,29 @@ fn version_range_falls_back_when_latest_out_of_range() {
     assert_eq!(pick_version_by_version_range(&opts).as_deref(), Some("1.1.0"));
 }
 
+#[test]
+fn version_range_lte_partial_allows_entire_major() {
+    let pkg = make_package(
+        "@jest/environment",
+        &[("26.6.2", None), ("27.0.0", None), ("27.5.1", None), ("28.0.0", None)],
+        &[("latest", "28.0.0")],
+    );
+    let opts = PickVersionByVersionRangeOptions {
+        meta: &pkg,
+        version_range: ">=24 <=27",
+        preferred_version_selectors: None,
+        published_by: None,
+    };
+
+    assert_eq!(pick_version_by_version_range(&opts).as_deref(), Some("27.5.1"));
+}
+
+#[test]
+fn partial_lte_upper_bound_returns_none_on_overflow() {
+    assert_eq!(super::partial_lte_upper_bound(&u64::MAX.to_string()), None);
+    assert_eq!(super::partial_lte_upper_bound(&format!("1.{}", u64::MAX)), None);
+}
+
 /// `*` is a special case: `semver.satisfies` rejects prereleases, so
 /// upstream short-circuits to return `latest` for `*` regardless.
 /// See pnpm/pnpm#865.

--- a/pacquet/plans/TEST_PORTING.md
+++ b/pacquet/plans/TEST_PORTING.md
@@ -866,9 +866,15 @@ lockfile-parity peer fixes (pnpm/pnpm#12266, pnpm/pnpm#12267).
 - [x] `should return from where the bad peer dependency is resolved` — `bad_peer_inside_subtree_records_resolved_from_parent`.
 - [x] `should find peer dependency conflicts` — covered by `bad_peer_version_is_reported`.
 - [x] `a peer's own peer is shared with a sibling that peer-depends both` — ported as `peers_own_peer_shared_with_sibling_that_peer_depends_both`.
+- [x] `transitive pending peer uses provider final suffix` — ported as `transitive_pending_peer_uses_provider_final_suffix`.
 - [x] Walk-ancestor suffix propagation (no direct upstream case — pacquet-specific manifestation of the deferred `calculateDepPath`) — `ancestor_peer_carries_its_own_suffix`.
 - [x] Optional peer not hoisted from the run-resolved tree (resolveRootDependencies behavior behind `getHoistableOptionalPeers`) — `optional_peer_only_in_resolved_tree_is_not_hoisted`.
 - [x] `build_final_graph` min-depth tie-break across `pure_pkgs`/`find_hit` revisits (pacquet-specific) — `shallower_pure_pkgs_revisit_lowers_graph_depth`.
+
+### High-level install / CLI peer lockfile coverage
+
+- [x] `TypeScript repo: installing/deps-installer/test/install/peerDependencies.ts` `transitive pending peer uses provider final suffix in lockfile` — package-manager port added as `fresh_install_uses_final_peer_suffix_for_transitive_pending_peer`.
+- [x] `TypeScript repo: pnpm/test/install/peerDependencies.ts` `transitive pending peer uses provider final suffix in lockfile` — CLI port added as `transitive_pending_peer_uses_provider_final_suffix_in_lockfile`.
 
 ### `resolvePeers.ts` — not yet ported
 

--- a/pnpm/test/install/peerDependencies.ts
+++ b/pnpm/test/install/peerDependencies.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@jest/globals'
+import { prepare } from '@pnpm/prepare'
+
+import { execPnpm } from '../utils/index.js'
+
+test('transitive pending peer uses provider final suffix in lockfile', async () => {
+  const project = prepare({
+    dependencies: {
+      '@pnpm.e2e/final-peer-a': '1.0.0',
+      '@pnpm.e2e/final-peer-c': '1.0.0',
+    },
+  })
+
+  await execPnpm(['install'])
+
+  const lockfile = project.readLockfile()
+  const snapshots = Object.keys(lockfile.snapshots)
+  const expected = '@pnpm.e2e/final-peer-x@1.0.0(@pnpm.e2e/final-peer-b@1.0.0(@pnpm.e2e/final-peer-a@1.0.0(@pnpm.e2e/final-peer-c@1.0.0)))'
+  const provisional = '@pnpm.e2e/final-peer-x@1.0.0(@pnpm.e2e/final-peer-b@1.0.0(@pnpm.e2e/final-peer-a@1.0.0))'
+
+  expect(snapshots).toContain(expected)
+  expect(snapshots).not.toContain(provisional)
+})

--- a/pnpr/.fixtures/packages/@pnpm.e2e/final-peer-a/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/final-peer-a/1.0.0/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@pnpm.e2e/final-peer-a",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pnpm.e2e/final-peer-b": "1.0.0",
+    "@pnpm.e2e/final-peer-x": "1.0.0"
+  },
+  "peerDependencies": {
+    "@pnpm.e2e/final-peer-c": "*"
+  }
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/final-peer-b/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/final-peer-b/1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@pnpm.e2e/final-peer-b",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@pnpm.e2e/final-peer-a": "*"
+  }
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/final-peer-c/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/final-peer-c/1.0.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pnpm.e2e/final-peer-c",
+  "version": "1.0.0"
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/final-peer-x/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/final-peer-x/1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@pnpm.e2e/final-peer-x",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@pnpm.e2e/final-peer-b": "*"
+  }
+}


### PR DESCRIPTION
## Summary
- Match pacquet peer-resolution and lockfile output to pnpm for transitive optional peer variants.
- Apply pnpm's Yarn compatibility package extensions in pacquet, with `ignoreCompatibilityDb` support.
- Add regression coverage on both the pnpm resolver test and pacquet resolver/install paths.

Fixes pnpm/pnpm#12330.

## Verification
- `pnpm --filter @pnpm/installing.deps-resolver test test/resolvePeers.ts -t "transitive pending peer uses provider final suffix"`
- `cargo test -p pacquet-resolving-deps-resolver`
- `cargo test -p pacquet-config parses_ignore_compatibility_db_from_yaml_and_applies`
- `cargo test -p pacquet-package-manager compatibility_db`
- `cargo test -p pacquet-package-manager duplicate_manifest_alias_uses_pnpm_dependency_field_precedence`
- `cargo test -p pacquet-resolving-npm-resolver version_range_lte_partial_allows_entire_major`
- `cargo build --release -p pacquet-cli`
- Babylon fixture lockfile SHA-256 matched pnpm: `73db2a62f695f50a3816575c84b8bc82f9106051cb3d3698ccde9754aa890b26`
- Pre-push hook passed for `codex/fix-12330-lockfile-parity`

Note: `just ready` was attempted separately, but its repo-wide `typos` step currently fails on existing changelog/hash false positives outside this PR.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ignore_compatibility_db config option
  * Added resolve_peers_from_workspace_root workspace option
  * Integrated built-in compatibility package-extensions DB and exposed getEffectivePackageExtensions

* **Improvements**
  * More accurate and deterministic peer dependency resolution, deduplication, and depPath finalization
  * Lockfile stability and checksum handling improvements when package-extensions are applied
  * Enhanced semver range handling for partial "<=" comparators

* **Tests**
  * Many new tests and fixtures covering peer-resolution, lockfile, workspace, and transitive peer scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->