### PR TITLE
test: fix CI resource usage

### DIFF
--- a/__utils__/jest-config/with-registry/globalSetup.js
+++ b/__utils__/jest-config/with-registry/globalSetup.js
@@ -44,18 +44,38 @@ export default async () => {
   )
 
   let killed = false
+  let closed = false
+  const serverClosed = new Promise((resolve) => {
+    server.on('close', () => {
+      closed = true
+      if (!killed) {
+        console.log('Error: The registry server was killed!')
+        process.exit(1)
+      }
+      resolve()
+    })
+  })
   server.on('error', (err) => {
     console.log(err)
   })
-  server.on('close', () => {
-    if (!killed) {
-      console.log('Error: The registry server was killed!')
-      process.exit(1)
-    }
-  })
-  global.killServer = () => {
+  global.killServer = async () => {
     killed = true
-    return kill(server.pid)
+    if (closed) return
+    if (server.pid != null) {
+      try {
+        await kill(server.pid)
+      } catch (err) {
+        if (!closed) throw err
+      }
+    } else {
+      server.kill()
+    }
+    await Promise.race([
+      serverClosed,
+      scheduler.wait(10_000).then(() => {
+        throw new Error('Timed out waiting for pnpr to exit')
+      }),
+    ])
   }
 
   await waitForServerOnline()

--- a/installing/deps-installer/package.json
+++ b/installing/deps-installer/package.json
@@ -167,6 +167,7 @@
     "node": ">=22.13"
   },
   "jest": {
+    "collectCoverage": false,
     "preset": "@pnpm/jest-config/with-registry"
   }
 }

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -187,6 +187,7 @@
     "node": ">=22.13"
   },
   "jest": {
+    "collectCoverage": false,
     "preset": "@pnpm/jest-config/with-registry"
   },
   "preferGlobal": true,

--- a/pnpm/test/verifyDepsBeforeRun/multiProjectWorkspace.ts
+++ b/pnpm/test/verifyDepsBeforeRun/multiProjectWorkspace.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { expect, test } from '@jest/globals'
+import { expect, jest, test } from '@jest/globals'
 import { preparePackages } from '@pnpm/prepare'
 import type { ProjectManifest } from '@pnpm/types'
 import { loadWorkspaceState } from '@pnpm/workspace.state'
@@ -10,6 +10,8 @@ import { writeYamlFileSync } from 'write-yaml-file'
 import { execPnpm, execPnpmSync, pnpmBinLocation } from '../utils/index.js'
 
 const CONFIG = ['--config.verify-deps-before-run=error'] as const
+
+jest.setTimeout(15 * 60 * 1000)
 
 test('single dependency', async () => {
   const checkEnv = 'node --eval "assert.strictEqual(process.env.pnpm_config_verify_deps_before_run, \'false\')"'


### PR DESCRIPTION
## Summary

- disable Jest coverage for the heavy `@pnpm/installing.deps-installer` and `pnpm` e2e packages
- wait for the `pnpr` registry child process to close before Jest force-exits
- give `verifyDepsBeforeRun/multiProjectWorkspace.ts` a file-local timeout for slow Windows CI runs

## Verification

- `pnpm --filter @pnpm/installing.deps-installer test`
- `pnpm --filter pnpm compile`
- `CI=true PNPM_REGISTRY_MOCK_PORT=7769 NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" pnpm exec jest --runTestsByPath test/verifyDepsBeforeRun/multiProjectWorkspace.ts --runInBand`
- `node --check __utils__/jest-config/with-registry/globalSetup.js`
- `git diff --check`
- pre-push hook: compile, spellcheck, meta-updater check, quiet ESLint

## Notes

The first bad main SHA observed was `1310ab53c484d866ec587f0afeb54ce1d456322d`, the merge commit for `pnpm/pnpm#12364`. This patch keeps the merged work in place and targets the CI/test-infra fallout.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled code coverage collection in test environments.

* **Tests**
  * Improved test registry server shutdown handling with timeout protection.
  * Adjusted test timeout configuration for workspace tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->