### PR TITLE
feat(link): support `--trust-lockfile` flag on `pnpm link` to match other commands

### DIFF
--- a/.changeset/hot-schools-speak.md
+++ b/.changeset/hot-schools-speak.md
@@ -1,5 +1,5 @@
 ---
-"@pnpm/installing.commands": minor
+"@pnpm/installing.commands": patch
 ---
 
 Added support for the `--trust-lockfile` flag on `pnpm link`

--- a/.changeset/hot-schools-speak.md
+++ b/.changeset/hot-schools-speak.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/installing.commands": minor
+---
+
+Added support for the `--trust-lockfile` flag on `pnpm link`

--- a/installing/commands/src/link.ts
+++ b/installing/commands/src/link.ts
@@ -58,6 +58,7 @@ export function cliOptionsTypes (): Record<string, unknown> {
     'save-exact',
     'save-optional',
     'save-prefix',
+    'trust-lockfile',
     'unsafe-perm',
   ], allTypes)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `pnpm link` / `pnpm ln` command now supports the `--trust-lockfile` flag, allowing you to control how the lockfile is trusted during the linking process.

* **Chores**
  * Updated release metadata to reflect the change version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->