### PR TITLE
feat(pnpr): per-uplink proxy settings

### DIFF
--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -352,10 +352,6 @@ pub struct UplinkConfig {
 }
 
 impl UplinkConfig {
-    /// Verdaccio's `maxage` default (`2m`). Applied per-uplink only when
-    /// the YAML sets `maxage` but the value can't carry through `None`;
-    /// an unset `maxage` instead defers to [`Config::packument_ttl`].
-    pub const DEFAULT_MAXAGE: Duration = Duration::from_mins(2);
     /// Verdaccio's `timeout` default (`30s`).
     pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
     /// Verdaccio's `max_fails` default (`2`).
@@ -570,7 +566,10 @@ fn parse_interval(raw: &str) -> Option<Duration> {
     }
     // A bare number is seconds, matching verdaccio (`interval * 1000` ms).
     if let Ok(seconds) = raw.parse::<f64>() {
-        return (seconds.is_finite() && seconds >= 0.0).then(|| Duration::from_secs_f64(seconds));
+        // `try_from_secs_f64` rejects negative, non-finite, and
+        // out-of-range values, so an absurd config (`"1e30"`) surfaces as
+        // a config error rather than panicking pnpr at startup.
+        return Duration::try_from_secs_f64(seconds).ok();
     }
     let mut total_seconds = 0f64;
     let bytes = raw.as_bytes();
@@ -603,7 +602,9 @@ fn parse_interval(raw: &str) -> Option<Duration> {
         };
         total_seconds += seconds;
     }
-    total_seconds.is_finite().then(|| Duration::from_secs_f64(total_seconds))
+    // Fallible conversion so an overflowing compound (`"999999999999w"`)
+    // is rejected as unparsable rather than panicking.
+    Duration::try_from_secs_f64(total_seconds).ok()
 }
 
 /// Pick the credential for an uplink's `auth:` block: an explicit

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -417,15 +417,51 @@ struct UplinkFile {
     /// [`resolve_uplink`]. Kept as raw strings here so an unparsable
     /// value surfaces as a config error rather than a serde failure.
     #[serde(default)]
-    maxage: Option<String>,
+    maxage: Option<Interval>,
     #[serde(default)]
-    timeout: Option<String>,
+    timeout: Option<Interval>,
     #[serde(default)]
     max_fails: Option<u32>,
     #[serde(default)]
-    fail_timeout: Option<String>,
+    fail_timeout: Option<Interval>,
     #[serde(default)]
     cache: Option<bool>,
+}
+
+/// A verdaccio interval scalar as written in YAML: either a string
+/// (`"2m"`, `"30s"`) or a bare number (a count of seconds). Both YAML
+/// shapes are accepted — verdaccio configs use either — and kept as the
+/// raw string so [`parse_interval`] handles them uniformly and an
+/// unparsable value surfaces as a precise config error.
+#[derive(Debug, Clone)]
+struct Interval(String);
+
+impl<'de> Deserialize<'de> for Interval {
+    fn deserialize<De>(deserializer: De) -> Result<Self, De::Error>
+    where
+        De: serde::Deserializer<'de>,
+    {
+        struct IntervalVisitor;
+        impl serde::de::Visitor<'_> for IntervalVisitor {
+            type Value = Interval;
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(r#"an interval string like "2m" or a number of seconds"#)
+            }
+            fn visit_str<DeError>(self, value: &str) -> Result<Interval, DeError> {
+                Ok(Interval(value.to_string()))
+            }
+            fn visit_i64<DeError>(self, value: i64) -> Result<Interval, DeError> {
+                Ok(Interval(value.to_string()))
+            }
+            fn visit_u64<DeError>(self, value: u64) -> Result<Interval, DeError> {
+                Ok(Interval(value.to_string()))
+            }
+            fn visit_f64<DeError>(self, value: f64) -> Result<Interval, DeError> {
+                Ok(Interval(value.to_string()))
+            }
+        }
+        deserializer.deserialize_any(IntervalVisitor)
+    }
 }
 
 /// The YAML `auth:` block on an uplink. `token` takes priority over
@@ -525,10 +561,10 @@ fn resolve_uplink<Sys: EnvVar>(
     // config error (named for the offending field) rather than silently
     // falling back to the default.
     let parse_field = |field: &str,
-                       raw: &Option<String>|
+                       raw: &Option<Interval>|
      -> Result<Option<Duration>, RegistryError> {
         raw.as_ref()
-            .map(|value| {
+            .map(|Interval(value)| {
                 parse_interval(value).ok_or_else(|| RegistryError::InvalidConfig {
                     reason: format!("uplink {name:?} has an invalid {field} interval {value:?}"),
                 })

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -312,21 +312,71 @@ impl LogLevel {
     }
 }
 
-/// Runtime uplink declaration: the upstream `url` plus the request
-/// headers pnpr attaches to every fetch it makes to that uplink.
+/// Runtime uplink declaration: the upstream `url`, the request headers
+/// pnpr attaches to every fetch it makes to that uplink, and the
+/// verdaccio per-uplink tuning knobs (`maxage`, `timeout`, `max_fails`,
+/// `fail_timeout`, `cache`).
 ///
 /// [`Self::headers`] is resolved once, at config load, from the YAML
 /// `auth:` block (an `Authorization` header derived from
 /// `type`/`token`/`token_env`) merged with the `headers:` map. The
 /// parse-time shape lives in `UplinkFile`; `resolve_uplink` turns
 /// one into the other. Verdaccio fields pnpr doesn't model yet
-/// (timeouts, agent options, `maxage`) are accepted and dropped.
+/// (agent options, `strict_ssl`, ...) are accepted and dropped.
 #[derive(Clone)]
 pub struct UplinkConfig {
     pub url: String,
     /// Auth + custom headers, fully resolved and ready to attach to
     /// every request pnpr makes to this uplink.
     pub headers: HeaderMap,
+    /// Per-uplink packument freshness window (verdaccio's `maxage`).
+    /// `None` when the YAML omits it — the proxy then falls back to the
+    /// global [`Config::packument_ttl`], so the existing
+    /// `--packument-ttl-secs` flag still governs uplinks that don't set
+    /// their own.
+    pub maxage: Option<Duration>,
+    /// Per-request deadline for every fetch to this uplink (verdaccio's
+    /// `timeout`). Defaults to [`Self::DEFAULT_TIMEOUT`].
+    pub timeout: Duration,
+    /// Consecutive failures before the uplink is treated as down
+    /// (verdaccio's `max_fails`). Defaults to [`Self::DEFAULT_MAX_FAILS`].
+    pub max_fails: u32,
+    /// How long a down uplink stays down before pnpr retries it
+    /// (verdaccio's `fail_timeout`). Defaults to
+    /// [`Self::DEFAULT_FAIL_TIMEOUT`].
+    pub fail_timeout: Duration,
+    /// Whether tarballs fetched from this uplink are written to the local
+    /// mirror (verdaccio's `cache`). `false` streams them through
+    /// uncached. Defaults to `true`.
+    pub cache: bool,
+}
+
+impl UplinkConfig {
+    /// Verdaccio's `maxage` default (`2m`). Applied per-uplink only when
+    /// the YAML sets `maxage` but the value can't carry through `None`;
+    /// an unset `maxage` instead defers to [`Config::packument_ttl`].
+    pub const DEFAULT_MAXAGE: Duration = Duration::from_mins(2);
+    /// Verdaccio's `timeout` default (`30s`).
+    pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+    /// Verdaccio's `max_fails` default (`2`).
+    pub const DEFAULT_MAX_FAILS: u32 = 2;
+    /// Verdaccio's `fail_timeout` default (`5m`).
+    pub const DEFAULT_FAIL_TIMEOUT: Duration = Duration::from_mins(5);
+
+    /// Build a bare uplink with just a URL and headers, all tuning knobs
+    /// at their verdaccio defaults. Used by the programmatic
+    /// [`Config::proxy`] constructor and tests.
+    pub(crate) fn with_defaults(url: String, headers: HeaderMap) -> Self {
+        Self {
+            url,
+            headers,
+            maxage: None,
+            timeout: Self::DEFAULT_TIMEOUT,
+            max_fails: Self::DEFAULT_MAX_FAILS,
+            fail_timeout: Self::DEFAULT_FAIL_TIMEOUT,
+            cache: true,
+        }
+    }
 }
 
 impl fmt::Debug for UplinkConfig {
@@ -334,6 +384,11 @@ impl fmt::Debug for UplinkConfig {
         f.debug_struct("UplinkConfig")
             .field("url", &self.url)
             .field("headers", &RedactedHeaders(&self.headers))
+            .field("maxage", &self.maxage)
+            .field("timeout", &self.timeout)
+            .field("max_fails", &self.max_fails)
+            .field("fail_timeout", &self.fail_timeout)
+            .field("cache", &self.cache)
             .finish()
     }
 }
@@ -361,6 +416,20 @@ struct UplinkFile {
     auth: Option<UplinkAuthFile>,
     #[serde(default)]
     headers: IndexMap<String, String>,
+    /// Verdaccio interval strings (`"2m"`, `"30s"`, `"1h30m"`) or a bare
+    /// number of seconds; parsed by [`parse_interval`] in
+    /// [`resolve_uplink`]. Kept as raw strings here so an unparsable
+    /// value surfaces as a config error rather than a serde failure.
+    #[serde(default)]
+    maxage: Option<String>,
+    #[serde(default)]
+    timeout: Option<String>,
+    #[serde(default)]
+    max_fails: Option<u32>,
+    #[serde(default)]
+    fail_timeout: Option<String>,
+    #[serde(default)]
+    cache: Option<bool>,
 }
 
 /// The YAML `auth:` block on an uplink. `token` takes priority over
@@ -455,7 +524,86 @@ fn resolve_uplink<Sys: EnvVar>(
             })?;
         headers.insert(header_name, header_value);
     }
-    Ok(UplinkConfig { url: file.url, headers })
+
+    // Parse the verdaccio interval knobs, turning a typo'd value into a
+    // config error (named for the offending field) rather than silently
+    // falling back to the default.
+    let parse_field = |field: &str,
+                       raw: &Option<String>|
+     -> Result<Option<Duration>, RegistryError> {
+        raw.as_ref()
+            .map(|value| {
+                parse_interval(value).ok_or_else(|| RegistryError::InvalidConfig {
+                    reason: format!("uplink {name:?} has an invalid {field} interval {value:?}"),
+                })
+            })
+            .transpose()
+    };
+    let maxage = parse_field("maxage", &file.maxage)?;
+    let timeout = parse_field("timeout", &file.timeout)?.unwrap_or(UplinkConfig::DEFAULT_TIMEOUT);
+    let fail_timeout = parse_field("fail_timeout", &file.fail_timeout)?
+        .unwrap_or(UplinkConfig::DEFAULT_FAIL_TIMEOUT);
+
+    Ok(UplinkConfig {
+        url: file.url,
+        headers,
+        maxage,
+        timeout,
+        max_fails: file.max_fails.unwrap_or(UplinkConfig::DEFAULT_MAX_FAILS),
+        fail_timeout,
+        cache: file.cache.unwrap_or(true),
+    })
+}
+
+/// Parse a verdaccio-style interval string into a [`Duration`].
+///
+/// Accepts the suffixes verdaccio's `parseInterval` understands —
+/// `ms`, `s`, `m`, `h`, `d`, `w` — optionally chained without or with
+/// whitespace (`"1h30m"`, `"2m 30s"`), and a bare number, which (like
+/// verdaccio) is read as **seconds**. A trailing number with no suffix
+/// is also seconds. Returns `None` for anything unparsable so the
+/// caller can surface a precise config error.
+fn parse_interval(raw: &str) -> Option<Duration> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    // A bare number is seconds, matching verdaccio (`interval * 1000` ms).
+    if let Ok(seconds) = raw.parse::<f64>() {
+        return (seconds.is_finite() && seconds >= 0.0).then(|| Duration::from_secs_f64(seconds));
+    }
+    let mut total_seconds = 0f64;
+    let bytes = raw.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index].is_ascii_whitespace() {
+            index += 1;
+            continue;
+        }
+        let number_start = index;
+        while index < bytes.len() && (bytes[index].is_ascii_digit() || bytes[index] == b'.') {
+            index += 1;
+        }
+        if index == number_start {
+            return None;
+        }
+        let number: f64 = raw[number_start..index].parse().ok()?;
+        let unit_start = index;
+        while index < bytes.len() && bytes[index].is_ascii_alphabetic() {
+            index += 1;
+        }
+        let seconds = match &raw[unit_start..index] {
+            "ms" => number / 1000.0,
+            "s" | "" => number,
+            "m" => number * 60.0,
+            "h" => number * 3600.0,
+            "d" => number * 86_400.0,
+            "w" => number * 604_800.0,
+            _ => return None,
+        };
+        total_seconds += seconds;
+    }
+    total_seconds.is_finite().then(|| Duration::from_secs_f64(total_seconds))
 }
 
 /// Pick the credential for an uplink's `auth:` block: an explicit
@@ -607,10 +755,7 @@ impl Config {
         let mut uplinks = IndexMap::new();
         uplinks.insert(
             "npmjs".to_string(),
-            UplinkConfig {
-                url: "https://registry.npmjs.org".to_string(),
-                headers: HeaderMap::new(),
-            },
+            UplinkConfig::with_defaults("https://registry.npmjs.org".to_string(), HeaderMap::new()),
         );
         let mut packages = IndexMap::new();
         packages.insert(

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML, HostedStoreConfig, LogFormat,
-    LogLevel, TokenEnv, UplinkAuthFile, UplinkAuthType, UplinkFile, config_file_in,
-    pattern_matches, resolve_relative, resolve_uplink,
+    LogLevel, TokenEnv, UplinkAuthFile, UplinkAuthType, UplinkConfig, UplinkFile, config_file_in,
+    parse_interval, pattern_matches, resolve_relative, resolve_uplink,
 };
 use crate::{error::RegistryError, policy::Identity};
 use indexmap::IndexMap;
@@ -29,7 +29,16 @@ impl EnvVar for FakeEnv {
 }
 
 fn uplink_file(auth: Option<UplinkAuthFile>, headers: IndexMap<String, String>) -> UplinkFile {
-    UplinkFile { url: "https://upstream.test/".to_string(), auth, headers }
+    UplinkFile {
+        url: "https://upstream.test/".to_string(),
+        auth,
+        headers,
+        maxage: None,
+        timeout: None,
+        max_fails: None,
+        fail_timeout: None,
+        cache: None,
+    }
 }
 
 fn auth_header(uplink: &super::UplinkConfig) -> Option<&str> {
@@ -1170,6 +1179,74 @@ packages:
         assert!(access.allows(&user("bob")), "{yaml}");
         assert!(!access.allows(&user("carol")), "{yaml}");
     }
+}
+
+#[test]
+fn parse_interval_handles_suffixes_compounds_and_bare_numbers() {
+    use std::time::Duration;
+    assert_eq!(parse_interval("30s"), Some(Duration::from_secs(30)));
+    assert_eq!(parse_interval("2m"), Some(Duration::from_mins(2)));
+    assert_eq!(parse_interval("5m"), Some(Duration::from_mins(5)));
+    assert_eq!(parse_interval("1h"), Some(Duration::from_hours(1)));
+    assert_eq!(parse_interval("1d"), Some(Duration::from_hours(24)));
+    assert_eq!(parse_interval("1w"), Some(Duration::from_hours(168)));
+    assert_eq!(parse_interval("500ms"), Some(Duration::from_millis(500)));
+    // Compound, with and without whitespace.
+    assert_eq!(parse_interval("1h30m"), Some(Duration::from_mins(90)));
+    assert_eq!(parse_interval("2m 30s"), Some(Duration::from_secs(150)));
+    // A bare number is seconds, matching verdaccio's `interval * 1000` ms.
+    assert_eq!(parse_interval("45"), Some(Duration::from_secs(45)));
+    // A trailing suffix-less number is also seconds.
+    assert_eq!(parse_interval("1m15"), Some(Duration::from_secs(75)));
+}
+
+#[test]
+fn parse_interval_rejects_garbage() {
+    assert_eq!(parse_interval(""), None);
+    assert_eq!(parse_interval("   "), None);
+    assert_eq!(parse_interval("soon"), None);
+    assert_eq!(parse_interval("2x"), None);
+    assert_eq!(parse_interval("m30"), None);
+}
+
+#[test]
+fn resolve_uplink_defaults_knobs_to_verdaccio_values() {
+    let uplink = resolve_uplink::<FakeEnv>("npmjs", uplink_file(None, IndexMap::new())).unwrap();
+    // An unset `maxage` defers to the global packument TTL (`None` here),
+    // while the rest fall back to verdaccio's documented defaults.
+    assert_eq!(uplink.maxage, None);
+    assert_eq!(uplink.timeout, UplinkConfig::DEFAULT_TIMEOUT);
+    assert_eq!(uplink.max_fails, UplinkConfig::DEFAULT_MAX_FAILS);
+    assert_eq!(uplink.fail_timeout, UplinkConfig::DEFAULT_FAIL_TIMEOUT);
+    assert!(uplink.cache);
+}
+
+#[test]
+fn resolve_uplink_parses_explicit_knobs() {
+    use std::time::Duration;
+    let mut file = uplink_file(None, IndexMap::new());
+    file.maxage = Some("10m".to_string());
+    file.timeout = Some("45s".to_string());
+    file.max_fails = Some(5);
+    file.fail_timeout = Some("1m".to_string());
+    file.cache = Some(false);
+    let uplink = resolve_uplink::<FakeEnv>("npmjs", file).unwrap();
+    assert_eq!(uplink.maxage, Some(Duration::from_mins(10)));
+    assert_eq!(uplink.timeout, Duration::from_secs(45));
+    assert_eq!(uplink.max_fails, 5);
+    assert_eq!(uplink.fail_timeout, Duration::from_mins(1));
+    assert!(!uplink.cache);
+}
+
+#[test]
+fn resolve_uplink_rejects_an_unparsable_interval() {
+    let mut file = uplink_file(None, IndexMap::new());
+    file.maxage = Some("whenever".to_string());
+    let err = resolve_uplink::<FakeEnv>("npmjs", file).unwrap_err();
+    assert!(
+        matches!(err, RegistryError::InvalidConfig { reason } if reason.contains("maxage")),
+        "expected an InvalidConfig naming the offending field",
+    );
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML, HostedStoreConfig, LogFormat,
-    LogLevel, TokenEnv, UplinkAuthFile, UplinkAuthType, UplinkConfig, UplinkFile, config_file_in,
-    parse_interval, pattern_matches, resolve_relative, resolve_uplink,
+    BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML, HostedStoreConfig, Interval,
+    LogFormat, LogLevel, TokenEnv, UplinkAuthFile, UplinkAuthType, UplinkConfig, UplinkFile,
+    config_file_in, parse_interval, pattern_matches, resolve_relative, resolve_uplink,
 };
 use crate::{error::RegistryError, policy::Identity};
 use indexmap::IndexMap;
@@ -223,6 +223,28 @@ packages:
     let uplink = &config.uplinks["npmjs"];
     assert_eq!(uplink.headers.get(AUTHORIZATION).unwrap().to_str().unwrap(), "Bearer secret-token");
     assert_eq!(uplink.headers.get("x-org").unwrap().to_str().unwrap(), "acme");
+}
+
+#[test]
+fn from_yaml_str_accepts_string_and_bare_number_intervals() {
+    use std::time::Duration;
+    // `maxage` is a string, `timeout` a bare number (verdaccio accepts
+    // both); the bare number must read as seconds rather than failing to
+    // deserialize against the `Option<String>`-shaped field.
+    let yaml = r"
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    maxage: 10m
+    timeout: 45
+packages:
+  '**':
+    proxy: npmjs
+";
+    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+    let uplink = &config.uplinks["npmjs"];
+    assert_eq!(uplink.maxage, Some(Duration::from_mins(10)));
+    assert_eq!(uplink.timeout, Duration::from_secs(45));
 }
 
 #[test]
@@ -1225,10 +1247,10 @@ fn resolve_uplink_defaults_knobs_to_verdaccio_values() {
 fn resolve_uplink_parses_explicit_knobs() {
     use std::time::Duration;
     let mut file = uplink_file(None, IndexMap::new());
-    file.maxage = Some("10m".to_string());
-    file.timeout = Some("45s".to_string());
+    file.maxage = Some(Interval("10m".to_string()));
+    file.timeout = Some(Interval("45s".to_string()));
     file.max_fails = Some(5);
-    file.fail_timeout = Some("1m".to_string());
+    file.fail_timeout = Some(Interval("1m".to_string()));
     file.cache = Some(false);
     let uplink = resolve_uplink::<FakeEnv>("npmjs", file).unwrap();
     assert_eq!(uplink.maxage, Some(Duration::from_mins(10)));
@@ -1241,7 +1263,7 @@ fn resolve_uplink_parses_explicit_knobs() {
 #[test]
 fn resolve_uplink_rejects_an_unparsable_interval() {
     let mut file = uplink_file(None, IndexMap::new());
-    file.maxage = Some("whenever".to_string());
+    file.maxage = Some(Interval("whenever".to_string()));
     let err = resolve_uplink::<FakeEnv>("npmjs", file).unwrap_err();
     assert!(
         matches!(err, RegistryError::InvalidConfig { reason } if reason.contains("maxage")),

--- a/pnpr/crates/pnpr/src/error.rs
+++ b/pnpr/crates/pnpr/src/error.rs
@@ -19,6 +19,18 @@ pub enum RegistryError {
         body: String,
     },
 
+    /// The uplink's circuit breaker is open: it reached `max_fails`
+    /// consecutive failures and is still inside its `fail_timeout`
+    /// cooldown, so pnpr short-circuits the request instead of hammering
+    /// a known-down upstream. The packument path turns this into a
+    /// stale-cache fallback; with nothing cached it surfaces as 503.
+    #[display("Upstream {uplink} is temporarily unavailable (circuit open)")]
+    #[from(skip)]
+    UpstreamUnavailable {
+        #[error(not(source))]
+        uplink: String,
+    },
+
     #[display("Package name {name:?} is not a valid npm package name")]
     InvalidPackageName {
         #[error(not(source))]
@@ -170,6 +182,7 @@ impl RegistryError {
                 }
             }
             RegistryError::UpstreamStatus { .. } => StatusCode::BAD_GATEWAY,
+            RegistryError::UpstreamUnavailable { .. } => StatusCode::SERVICE_UNAVAILABLE,
             RegistryError::InvalidPackageName { .. }
             | RegistryError::InvalidTarballName { .. }
             | RegistryError::InvalidPolicyPattern { .. }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -157,8 +157,11 @@ pub fn router(config: Config) -> Router {
 pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
     let storage =
         Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone());
-    let upstreams: IndexMap<String, Upstream> =
-        config.uplinks.iter().map(|(name, uplink)| (name.clone(), Upstream::new(uplink))).collect();
+    let upstreams: IndexMap<String, Upstream> = config
+        .uplinks
+        .iter()
+        .map(|(name, uplink)| (name.clone(), Upstream::new(name, uplink)))
+        .collect();
     let state = AppState {
         inner: Arc::new(AppInner {
             storage,

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -157,13 +157,8 @@ pub fn router(config: Config) -> Router {
 pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
     let storage =
         Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone());
-    let upstreams: IndexMap<String, Upstream> = config
-        .uplinks
-        .iter()
-        .map(|(name, uplink)| {
-            (name.clone(), Upstream::new(uplink.url.clone(), uplink.headers.clone()))
-        })
-        .collect();
+    let upstreams: IndexMap<String, Upstream> =
+        config.uplinks.iter().map(|(name, uplink)| (name.clone(), Upstream::new(uplink))).collect();
     let state = AppState {
         inner: Arc::new(AppInner {
             storage,
@@ -667,6 +662,12 @@ async fn serve_tarball(
         Err(err) => return error_response(&err),
     };
     let upstream_len = response.content_length();
+
+    // `cache: false` uplinks (verdaccio) are mirror-less: stream the
+    // tarball straight to the client without writing it to disk.
+    if !upstream.caches() {
+        return tarball_response(Body::from_stream(response.bytes_stream()), upstream_len);
+    }
 
     let write = match state.inner.storage.open_cached_tarball_tmp(&name, filename).await {
         Ok(w) => w,
@@ -1810,7 +1811,11 @@ async fn load_packument_bytes(state: &AppState, name: &PackageName) -> Packument
     // versions surface sooner but more upstream traffic; higher = the
     // reverse. The conditional GET on the stale path keeps a high `ttl`
     // cheap (a `304` refreshes the entry without re-downloading it).
-    let ttl = state.inner.config.packument_ttl;
+    //
+    // The uplink's per-uplink `maxage` (verdaccio) wins when set;
+    // otherwise the global `packument_ttl` (the `--packument-ttl-secs`
+    // flag) applies.
+    let ttl = upstream.maxage().unwrap_or(state.inner.config.packument_ttl);
     // A fresh entry serves immediately (and moves its bytes out — a
     // packument can be multiple MB). A stale entry yields only its
     // validators; its body stays on disk until a `304`/error path below

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -13,10 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{
     fmt,
-    sync::{
-        Arc, Mutex,
-        atomic::{AtomicU32, Ordering},
-    },
+    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 
@@ -31,6 +28,10 @@ use std::{
 pub struct Upstream {
     client: Arc<ThrottledClient>,
     base: String,
+    /// The configured uplink name (the YAML `uplinks:` key). Surfaced in
+    /// client-facing errors so an open circuit names the uplink rather
+    /// than leaking its upstream URL.
+    name: String,
     /// Resolved per-uplink request headers (auth + custom) attached to
     /// every fetch. Empty for an uplink with no `auth:`/`headers:`.
     headers: HeaderMap,
@@ -54,6 +55,7 @@ impl fmt::Debug for Upstream {
         f.debug_struct("Upstream")
             .field("client", &self.client)
             .field("base", &self.base)
+            .field("name", &self.name)
             .field("headers", &RedactedHeaders(&self.headers))
             .field("timeout", &self.timeout)
             .field("maxage", &self.maxage)
@@ -68,47 +70,81 @@ impl fmt::Debug for Upstream {
 /// requests short-circuit, until `fail_timeout` elapses since the last
 /// failure — a single probe is then allowed through, and its success
 /// resets the breaker or its failure restarts the cooldown.
+///
+/// The counter, the cooldown timestamp, and the half-open probe permit
+/// live behind one [`Mutex`] so a threshold check and its timestamp can
+/// never be observed half-updated. The lock is held only for trivial
+/// field reads/writes (never across the network request), so contention
+/// is negligible; a poisoned lock is recovered rather than propagated as
+/// a panic, keeping a failing uplink from taking the registry down.
 #[derive(Debug)]
 struct CircuitBreaker {
     max_fails: u32,
     fail_timeout: Duration,
-    failed_requests: AtomicU32,
-    last_failure: Mutex<Option<Instant>>,
+    state: Mutex<BreakerState>,
+}
+
+#[derive(Debug, Default)]
+struct BreakerState {
+    failed_requests: u32,
+    last_failure: Option<Instant>,
+    /// A half-open probe is in flight. While set, further callers are
+    /// short-circuited so a recovering upstream sees one probe rather
+    /// than a stampede. Cleared whenever the probe resolves (success,
+    /// failure, or an authoritative non-availability answer).
+    probe_in_flight: bool,
 }
 
 impl CircuitBreaker {
     fn new(max_fails: u32, fail_timeout: Duration) -> Self {
-        Self {
-            max_fails,
-            fail_timeout,
-            failed_requests: AtomicU32::new(0),
-            last_failure: Mutex::new(None),
-        }
+        Self { max_fails, fail_timeout, state: Mutex::new(BreakerState::default()) }
     }
 
-    /// Whether a request to this uplink should be attempted. Available
-    /// while under `max_fails` consecutive failures, or once the
-    /// `fail_timeout` cooldown has elapsed since the last failure.
+    /// Recover the guard from a poisoned lock instead of panicking: the
+    /// breaker only ever holds plain counters, so the worst a poisoned
+    /// guard carries is a stale failure count, never an invariant break.
+    fn lock(&self) -> std::sync::MutexGuard<'_, BreakerState> {
+        self.state.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Try to admit one request. Returns `true` while under `max_fails`
+    /// consecutive failures (or when the breaker is disabled), and once
+    /// the `fail_timeout` cooldown has elapsed admits exactly one probe —
+    /// later callers stay short-circuited until that probe resolves.
     /// `max_fails == 0` disables the breaker entirely.
-    fn is_available(&self) -> bool {
-        if self.max_fails == 0 || self.failed_requests.load(Ordering::Relaxed) < self.max_fails {
+    fn try_acquire(&self) -> bool {
+        let mut state = self.lock();
+        if self.max_fails == 0 || state.failed_requests < self.max_fails {
             return true;
         }
-        let last_failure = *self.last_failure.lock().expect("circuit breaker poisoned");
-        match last_failure {
-            Some(at) => at.elapsed() >= self.fail_timeout,
-            None => true,
+        // Tripped: stay open until the cooldown since the last failure
+        // lapses. (`failed_requests >= max_fails` always implies a
+        // recorded `last_failure`, so the `None` arm is unreachable; it
+        // fails open for safety.)
+        let cooled_down = state.last_failure.is_none_or(|at| at.elapsed() >= self.fail_timeout);
+        if !cooled_down || state.probe_in_flight {
+            return false;
         }
+        state.probe_in_flight = true;
+        true
     }
 
     fn record_success(&self) {
-        self.failed_requests.store(0, Ordering::Relaxed);
-        *self.last_failure.lock().expect("circuit breaker poisoned") = None;
+        *self.lock() = BreakerState::default();
     }
 
     fn record_failure(&self) {
-        self.failed_requests.fetch_add(1, Ordering::Relaxed);
-        *self.last_failure.lock().expect("circuit breaker poisoned") = Some(Instant::now());
+        let mut state = self.lock();
+        state.failed_requests = state.failed_requests.saturating_add(1);
+        state.last_failure = Some(Instant::now());
+        state.probe_in_flight = false;
+    }
+
+    /// Release a half-open probe without counting it for or against the
+    /// breaker. Used for authoritative client answers (a non-404 4xx)
+    /// that say nothing about the uplink's availability.
+    fn record_neutral(&self) {
+        self.lock().probe_in_flight = false;
     }
 }
 
@@ -168,13 +204,15 @@ pub enum PackumentFetch {
 }
 
 impl Upstream {
-    /// Build an uplink client from its resolved [`UplinkConfig`], baking
-    /// in the per-uplink `timeout`/`maxage`/`cache` knobs and arming the
+    /// Build an uplink client from its name (the YAML `uplinks:` key) and
+    /// resolved [`UplinkConfig`], baking in the per-uplink
+    /// `timeout`/`maxage`/`cache` knobs and arming the
     /// `max_fails`/`fail_timeout` circuit breaker.
-    pub fn new(config: &UplinkConfig) -> Self {
+    pub fn new(name: &str, config: &UplinkConfig) -> Self {
         Self {
             client: Arc::new(ThrottledClient::new_for_installs()),
             base: config.url.clone(),
+            name: name.to_string(),
             headers: config.headers.clone(),
             timeout: config.timeout,
             maxage: config.maxage,
@@ -284,10 +322,10 @@ impl Upstream {
     /// breaker is open, so callers never pay a request to a known-down
     /// uplink.
     fn ensure_available(&self) -> Result<()> {
-        if self.breaker.is_available() {
+        if self.breaker.try_acquire() {
             return Ok(());
         }
-        Err(RegistryError::UpstreamUnavailable { uplink: self.base.clone() })
+        Err(RegistryError::UpstreamUnavailable { uplink: self.name.clone() })
     }
 
     /// Send a built request, mapping a transport error to
@@ -300,15 +338,21 @@ impl Upstream {
     }
 
     /// Pass a successful response through; map any non-success status to
-    /// [`RegistryError::UpstreamStatus`] and count it against the breaker
-    /// (a 5xx/4xx-other upstream is a failure; a 404 is handled by the
-    /// callers before reaching here).
+    /// [`RegistryError::UpstreamStatus`]. Only a `5xx` counts against the
+    /// breaker — a non-404 `4xx` is an authoritative client error (auth,
+    /// rate-limit, bad request), not an availability signal, so it must
+    /// not open the circuit and mask the real status behind a `503`. The
+    /// `404`/`304` paths are handled by the callers before reaching here.
     async fn checked(&self, response: reqwest::Response, url: &str) -> Result<reqwest::Response> {
-        if response.status().is_success() {
+        let status = response.status();
+        if status.is_success() {
             return Ok(response);
         }
-        self.breaker.record_failure();
-        let status = response.status();
+        if status.is_server_error() {
+            self.breaker.record_failure();
+        } else {
+            self.breaker.record_neutral();
+        }
         let body = response.text().await.unwrap_or_default();
         Err(RegistryError::UpstreamStatus { url: url.to_string(), status: status.as_u16(), body })
     }

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -1,9 +1,9 @@
 use crate::{
-    config::RedactedHeaders,
+    config::{RedactedHeaders, UplinkConfig},
     error::{RegistryError, Result},
     package_name::PackageName,
 };
-use chrono::{DateTime, Duration, Timelike, Utc};
+use chrono::{DateTime, Timelike, Utc};
 use pacquet_network::ThrottledClient;
 use reqwest::{
     StatusCode,
@@ -11,14 +11,22 @@ use reqwest::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{fmt, sync::Arc};
+use std::{
+    fmt,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU32, Ordering},
+    },
+    time::{Duration, Instant},
+};
 
 /// Wraps a shared [`ThrottledClient`] (so the registry inherits pnpm's
 /// tuned reqwest defaults: `User-Agent: pnpm`, HTTP/1.1, hickory DNS,
 /// pool/timeout tuning, concurrency semaphore, and per-registry TLS
-/// routing if it's ever wired in later) and adds the small bit of
-/// glue specific to a proxy: building the upstream URL and fishing
-/// the packument or tarball response out of it.
+/// routing if it's ever wired in later) and adds the per-uplink glue a
+/// proxy needs: building the upstream URL, applying verdaccio's
+/// `timeout`/`max_fails`/`fail_timeout` knobs, and fishing the packument
+/// or tarball response out of it.
 #[derive(Clone)]
 pub struct Upstream {
     client: Arc<ThrottledClient>,
@@ -26,6 +34,19 @@ pub struct Upstream {
     /// Resolved per-uplink request headers (auth + custom) attached to
     /// every fetch. Empty for an uplink with no `auth:`/`headers:`.
     headers: HeaderMap,
+    /// Per-request deadline (verdaccio's `timeout`).
+    timeout: Duration,
+    /// Per-uplink packument freshness window (verdaccio's `maxage`), or
+    /// `None` to defer to the global [`crate::config::Config::packument_ttl`].
+    maxage: Option<Duration>,
+    /// Whether tarballs from this uplink are written to the local mirror
+    /// (verdaccio's `cache`).
+    cache: bool,
+    /// Shared failure tracker implementing verdaccio's
+    /// `max_fails`/`fail_timeout` circuit breaker. Behind an [`Arc`] so
+    /// every clone of this `Upstream` (the registry holds one per uplink
+    /// and clones it per request) updates the same counters.
+    breaker: Arc<CircuitBreaker>,
 }
 
 impl fmt::Debug for Upstream {
@@ -34,7 +55,60 @@ impl fmt::Debug for Upstream {
             .field("client", &self.client)
             .field("base", &self.base)
             .field("headers", &RedactedHeaders(&self.headers))
+            .field("timeout", &self.timeout)
+            .field("maxage", &self.maxage)
+            .field("cache", &self.cache)
+            .field("breaker", &self.breaker)
             .finish()
+    }
+}
+
+/// Verdaccio's `max_fails` / `fail_timeout` circuit breaker. After
+/// `max_fails` consecutive failures the uplink is considered down and
+/// requests short-circuit, until `fail_timeout` elapses since the last
+/// failure — a single probe is then allowed through, and its success
+/// resets the breaker or its failure restarts the cooldown.
+#[derive(Debug)]
+struct CircuitBreaker {
+    max_fails: u32,
+    fail_timeout: Duration,
+    failed_requests: AtomicU32,
+    last_failure: Mutex<Option<Instant>>,
+}
+
+impl CircuitBreaker {
+    fn new(max_fails: u32, fail_timeout: Duration) -> Self {
+        Self {
+            max_fails,
+            fail_timeout,
+            failed_requests: AtomicU32::new(0),
+            last_failure: Mutex::new(None),
+        }
+    }
+
+    /// Whether a request to this uplink should be attempted. Available
+    /// while under `max_fails` consecutive failures, or once the
+    /// `fail_timeout` cooldown has elapsed since the last failure.
+    /// `max_fails == 0` disables the breaker entirely.
+    fn is_available(&self) -> bool {
+        if self.max_fails == 0 || self.failed_requests.load(Ordering::Relaxed) < self.max_fails {
+            return true;
+        }
+        let last_failure = *self.last_failure.lock().expect("circuit breaker poisoned");
+        match last_failure {
+            Some(at) => at.elapsed() >= self.fail_timeout,
+            None => true,
+        }
+    }
+
+    fn record_success(&self) {
+        self.failed_requests.store(0, Ordering::Relaxed);
+        *self.last_failure.lock().expect("circuit breaker poisoned") = None;
+    }
+
+    fn record_failure(&self) {
+        self.failed_requests.fetch_add(1, Ordering::Relaxed);
+        *self.last_failure.lock().expect("circuit breaker poisoned") = Some(Instant::now());
     }
 }
 
@@ -94,8 +168,32 @@ pub enum PackumentFetch {
 }
 
 impl Upstream {
-    pub fn new(base: String, headers: HeaderMap) -> Self {
-        Self { client: Arc::new(ThrottledClient::new_for_installs()), base, headers }
+    /// Build an uplink client from its resolved [`UplinkConfig`], baking
+    /// in the per-uplink `timeout`/`maxage`/`cache` knobs and arming the
+    /// `max_fails`/`fail_timeout` circuit breaker.
+    pub fn new(config: &UplinkConfig) -> Self {
+        Self {
+            client: Arc::new(ThrottledClient::new_for_installs()),
+            base: config.url.clone(),
+            headers: config.headers.clone(),
+            timeout: config.timeout,
+            maxage: config.maxage,
+            cache: config.cache,
+            breaker: Arc::new(CircuitBreaker::new(config.max_fails, config.fail_timeout)),
+        }
+    }
+
+    /// Per-uplink packument freshness window (`maxage`), or `None` to
+    /// defer to the global [`crate::config::Config::packument_ttl`].
+    pub fn maxage(&self) -> Option<Duration> {
+        self.maxage
+    }
+
+    /// Whether tarballs from this uplink should be written to the local
+    /// mirror (`cache: true`). When `false` the caller streams the body
+    /// straight through without caching it.
+    pub fn caches(&self) -> bool {
+        self.cache
     }
 
     /// Fetch a package's packument, conditionally when `validators`
@@ -103,14 +201,18 @@ impl Upstream {
     /// circuits to [`PackumentFetch::NotModified`] without a body, so the
     /// caller can keep serving its cached copy — the bandwidth win on a
     /// stale-but-current packument.
+    ///
+    /// Returns [`RegistryError::UpstreamUnavailable`] without hitting the
+    /// network when the circuit breaker is open.
     pub async fn fetch_packument(
         &self,
         name: &PackageName,
         validators: &CacheValidators,
     ) -> Result<PackumentFetch> {
+        self.ensure_available()?;
         let url = format!("{}/{}", self.base.trim_end_matches('/'), name.as_str());
         let client = self.client.acquire_for_url(&url).await;
-        let mut request = client.get(&url).headers(self.headers.clone());
+        let mut request = client.get(&url).timeout(self.timeout).headers(self.headers.clone());
         let mut sent_conditional = false;
         if let Some(etag) = &validators.etag
             && let Ok(value) = HeaderValue::from_str(etag)
@@ -124,27 +226,28 @@ impl Upstream {
             request = request.header(header::IF_MODIFIED_SINCE, value);
             sent_conditional = true;
         }
-        let response = request
-            .send()
-            .await
-            .map_err(|source| RegistryError::Upstream { url: url.clone(), source })?;
+        let response = self.run(request, &url).await?;
         if response.status() == StatusCode::NOT_FOUND {
+            // A 404 is an authoritative answer, not an uplink failure.
+            self.breaker.record_success();
             return Ok(PackumentFetch::NotFound);
         }
         // Only honor a `304` if we actually sent a conditional header. A
         // `304` to an unconditional request is a misbehaving upstream and
-        // carries no body to serve, so let it fall through to
-        // `check_status` and surface as an upstream status error rather
-        // than reusing a (possibly nonexistent) cached copy.
+        // carries no body to serve, so let it fall through to `checked`
+        // and surface as an upstream status error rather than reusing a
+        // (possibly nonexistent) cached copy.
         if sent_conditional && response.status() == StatusCode::NOT_MODIFIED {
+            self.breaker.record_success();
             return Ok(PackumentFetch::NotModified);
         }
-        let response = check_status(response, &url).await?;
+        let response = self.checked(response, &url).await?;
         let validators = CacheValidators::from_headers(response.headers());
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|source| RegistryError::Upstream { url: url.clone(), source })?;
+        let bytes = response.bytes().await.map_err(|source| {
+            self.breaker.record_failure();
+            RegistryError::Upstream { url: url.clone(), source }
+        })?;
+        self.breaker.record_success();
         Ok(PackumentFetch::Modified(FetchedPackument { bytes: bytes.to_vec(), validators }))
     }
 
@@ -152,34 +255,63 @@ impl Upstream {
     /// [`reqwest::Response`] so the caller can pipe the body straight
     /// to the client without buffering. Status and 404 handling
     /// happen here before any bytes are forwarded.
+    ///
+    /// Returns [`RegistryError::UpstreamUnavailable`] without hitting the
+    /// network when the circuit breaker is open.
     pub async fn fetch_tarball_response(
         &self,
         name: &PackageName,
         filename: &str,
     ) -> Result<FetchOutcome<reqwest::Response>> {
+        self.ensure_available()?;
         let url = format!("{}/{}/-/{}", self.base.trim_end_matches('/'), name.as_str(), filename);
         let client = self.client.acquire_for_url(&url).await;
-        let response = client
-            .get(&url)
-            .headers(self.headers.clone())
-            .send()
-            .await
-            .map_err(|source| RegistryError::Upstream { url: url.clone(), source })?;
+        let request = client.get(&url).timeout(self.timeout).headers(self.headers.clone());
+        let response = self.run(request, &url).await?;
         if response.status() == StatusCode::NOT_FOUND {
+            self.breaker.record_success();
             return Ok(FetchOutcome::NotFound);
         }
-        let response = check_status(response, &url).await?;
+        let response = self.checked(response, &url).await?;
+        // Success here covers only headers; a mid-stream body failure is
+        // the caller's to observe. Recording success on a clean status is
+        // what verdaccio does too.
+        self.breaker.record_success();
         Ok(FetchOutcome::Ok(response))
     }
-}
 
-async fn check_status(response: reqwest::Response, url: &str) -> Result<reqwest::Response> {
-    let status = response.status();
-    if status.is_success() {
-        return Ok(response);
+    /// Fail fast with [`RegistryError::UpstreamUnavailable`] when the
+    /// breaker is open, so callers never pay a request to a known-down
+    /// uplink.
+    fn ensure_available(&self) -> Result<()> {
+        if self.breaker.is_available() {
+            return Ok(());
+        }
+        Err(RegistryError::UpstreamUnavailable { uplink: self.base.clone() })
     }
-    let body = response.text().await.unwrap_or_default();
-    Err(RegistryError::UpstreamStatus { url: url.to_string(), status: status.as_u16(), body })
+
+    /// Send a built request, mapping a transport error to
+    /// [`RegistryError::Upstream`] and counting it against the breaker.
+    async fn run(&self, request: reqwest::RequestBuilder, url: &str) -> Result<reqwest::Response> {
+        request.send().await.map_err(|source| {
+            self.breaker.record_failure();
+            RegistryError::Upstream { url: url.to_string(), source }
+        })
+    }
+
+    /// Pass a successful response through; map any non-success status to
+    /// [`RegistryError::UpstreamStatus`] and count it against the breaker
+    /// (a 5xx/4xx-other upstream is a failure; a 404 is handled by the
+    /// callers before reaching here).
+    async fn checked(&self, response: reqwest::Response, url: &str) -> Result<reqwest::Response> {
+        if response.status().is_success() {
+            return Ok(response);
+        }
+        self.breaker.record_failure();
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        Err(RegistryError::UpstreamStatus { url: url.to_string(), status: status.as_u16(), body })
+    }
 }
 
 /// Rewrite every `dist.tarball` in `value` to a URL served by *this*
@@ -374,7 +506,7 @@ fn coarsen_time_map(
     time: &serde_json::Map<String, Value>,
     now: DateTime<Utc>,
 ) -> serde_json::Map<String, Value> {
-    let horizon = now - Duration::days(TIME_PRECISION_HORIZON_DAYS);
+    let horizon = now - chrono::Duration::days(TIME_PRECISION_HORIZON_DAYS);
     let mut out = serde_json::Map::with_capacity(time.len());
     for (key, value) in time {
         let coarsened = value.as_str().and_then(|raw| coarsen_timestamp(raw, horizon));
@@ -401,7 +533,7 @@ fn coarsen_timestamp(raw: &str, horizon: DateTime<Utc>) -> Option<String> {
         Some(rounded.format("%Y-%m-%d").to_string())
     } else {
         let minute = parsed.with_second(0)?.with_nanosecond(0)?;
-        let rounded = if parsed == minute { minute } else { minute + Duration::minutes(1) };
+        let rounded = if parsed == minute { minute } else { minute + chrono::Duration::minutes(1) };
         Some(rounded.format("%Y-%m-%dT%H:%MZ").to_string())
     }
 }

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -71,12 +71,20 @@ impl fmt::Debug for Upstream {
 /// failure — a single probe is then allowed through, and its success
 /// resets the breaker or its failure restarts the cooldown.
 ///
-/// The counter, the cooldown timestamp, and the half-open probe permit
-/// live behind one [`Mutex`] so a threshold check and its timestamp can
-/// never be observed half-updated. The lock is held only for trivial
-/// field reads/writes (never across the network request), so contention
-/// is negligible; a poisoned lock is recovered rather than propagated as
-/// a panic, keeping a failing uplink from taking the registry down.
+/// The half-open probe is gated by the cooldown window itself: admitting
+/// a probe advances `last_failure` to now, so concurrent callers in that
+/// window stay short-circuited and a recovering upstream sees one probe
+/// rather than a stampede. Crucially this can't *stick* — a probe whose
+/// request is cancelled or dropped before it reports back simply lets the
+/// window lapse, after which the next caller probes. A sticky in-flight
+/// flag would deadlock the breaker on a cancelled request.
+///
+/// The counter and the timestamp live behind one [`Mutex`] so a threshold
+/// check and its timestamp can never be observed half-updated. The lock
+/// is held only for trivial field reads/writes (never across the network
+/// request), so contention is negligible; a poisoned lock is recovered
+/// rather than propagated as a panic, keeping a failing uplink from
+/// taking the registry down.
 #[derive(Debug)]
 struct CircuitBreaker {
     max_fails: u32,
@@ -88,11 +96,6 @@ struct CircuitBreaker {
 struct BreakerState {
     failed_requests: u32,
     last_failure: Option<Instant>,
-    /// A half-open probe is in flight. While set, further callers are
-    /// short-circuited so a recovering upstream sees one probe rather
-    /// than a stampede. Cleared whenever the probe resolves (success,
-    /// failure, or an authoritative non-availability answer).
-    probe_in_flight: bool,
 }
 
 impl CircuitBreaker {
@@ -108,10 +111,11 @@ impl CircuitBreaker {
     }
 
     /// Try to admit one request. Returns `true` while under `max_fails`
-    /// consecutive failures (or when the breaker is disabled), and once
-    /// the `fail_timeout` cooldown has elapsed admits exactly one probe —
-    /// later callers stay short-circuited until that probe resolves.
-    /// `max_fails == 0` disables the breaker entirely.
+    /// consecutive failures (or when the breaker is disabled). Once the
+    /// `fail_timeout` cooldown has elapsed it admits one probe per window:
+    /// the admitting caller advances the cooldown, so concurrent callers
+    /// stay short-circuited until the next window opens. `max_fails == 0`
+    /// disables the breaker entirely.
     fn try_acquire(&self) -> bool {
         let mut state = self.lock();
         if self.max_fails == 0 || state.failed_requests < self.max_fails {
@@ -122,10 +126,14 @@ impl CircuitBreaker {
         // recorded `last_failure`, so the `None` arm is unreachable; it
         // fails open for safety.)
         let cooled_down = state.last_failure.is_none_or(|at| at.elapsed() >= self.fail_timeout);
-        if !cooled_down || state.probe_in_flight {
+        if !cooled_down {
             return false;
         }
-        state.probe_in_flight = true;
+        // Admit this probe and re-arm the cooldown so the next caller is
+        // held back for another `fail_timeout`. If the probe never reports
+        // back (cancelled mid-request), the window simply lapses and the
+        // following caller probes — the breaker can't deadlock.
+        state.last_failure = Some(Instant::now());
         true
     }
 
@@ -137,14 +145,6 @@ impl CircuitBreaker {
         let mut state = self.lock();
         state.failed_requests = state.failed_requests.saturating_add(1);
         state.last_failure = Some(Instant::now());
-        state.probe_in_flight = false;
-    }
-
-    /// Release a half-open probe without counting it for or against the
-    /// breaker. Used for authoritative client answers (a non-404 4xx)
-    /// that say nothing about the uplink's availability.
-    fn record_neutral(&self) {
-        self.lock().probe_in_flight = false;
     }
 }
 
@@ -340,9 +340,10 @@ impl Upstream {
     /// Pass a successful response through; map any non-success status to
     /// [`RegistryError::UpstreamStatus`]. Only a `5xx` counts against the
     /// breaker — a non-404 `4xx` is an authoritative client error (auth,
-    /// rate-limit, bad request), not an availability signal, so it must
-    /// not open the circuit and mask the real status behind a `503`. The
-    /// `404`/`304` paths are handled by the callers before reaching here.
+    /// rate-limit, bad request), not an availability signal, so it leaves
+    /// the breaker untouched rather than opening the circuit and masking
+    /// the real status behind a `503`. The `404`/`304` paths are handled
+    /// by the callers before reaching here.
     async fn checked(&self, response: reqwest::Response, url: &str) -> Result<reqwest::Response> {
         let status = response.status();
         if status.is_success() {
@@ -350,8 +351,6 @@ impl Upstream {
         }
         if status.is_server_error() {
             self.breaker.record_failure();
-        } else {
-            self.breaker.record_neutral();
         }
         let body = response.text().await.unwrap_or_default();
         Err(RegistryError::UpstreamStatus { url: url.to_string(), status: status.as_u16(), body })

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -483,33 +483,27 @@ fn circuit_breaker_reopens_once_cooldown_elapses() {
 }
 
 #[test]
-fn circuit_breaker_admits_only_one_half_open_probe() {
-    // Once cooled down, exactly one caller is let through to probe the
-    // upstream; concurrent callers stay short-circuited until the probe
-    // resolves, so a recovering upstream isn't stampeded.
-    let breaker = CircuitBreaker::new(1, Duration::ZERO);
+fn circuit_breaker_admits_one_probe_per_cooldown_window() {
+    // A short but non-zero cooldown so we can drive the half-open window
+    // deterministically with a sleep.
+    let cooldown = Duration::from_millis(40);
+    let breaker = CircuitBreaker::new(1, cooldown);
     breaker.record_failure();
-    assert!(breaker.try_acquire(), "the first caller after cooldown gets the probe");
-    assert!(!breaker.try_acquire(), "a second concurrent caller is held back");
-    // The probe fails: the cooldown restarts and the next caller (after it
-    // lapses again, instantly here) gets a fresh probe.
-    breaker.record_failure();
-    assert!(breaker.try_acquire(), "a failed probe frees the slot for the next probe");
-    // A successful probe instead closes the breaker entirely.
+    assert!(!breaker.try_acquire(), "still cooling down right after the failure");
+
+    std::thread::sleep(cooldown + Duration::from_millis(20));
+    assert!(breaker.try_acquire(), "the first caller after the cooldown probes");
+    assert!(!breaker.try_acquire(), "admitting the probe re-armed the window; others wait");
+
+    // A probe that never reports back (cancelled mid-request) must not
+    // stick the breaker open forever: once the window lapses the next
+    // caller probes again.
+    std::thread::sleep(cooldown + Duration::from_millis(20));
+    assert!(breaker.try_acquire(), "an abandoned probe self-heals after the cooldown");
+
+    // A successful probe closes the breaker entirely.
     breaker.record_success();
     assert!(breaker.try_acquire(), "a closed breaker admits everyone");
-}
-
-#[test]
-fn circuit_breaker_neutral_releases_probe_without_counting() {
-    // A non-availability answer (a non-404 4xx) must neither trip nor
-    // reset the breaker, but it does release the half-open probe.
-    let breaker = CircuitBreaker::new(1, Duration::ZERO);
-    breaker.record_failure();
-    assert!(breaker.try_acquire(), "cooled-down breaker hands out a probe");
-    assert!(!breaker.try_acquire(), "probe in flight holds others back");
-    breaker.record_neutral();
-    assert!(breaker.try_acquire(), "a neutral answer frees the probe slot");
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -1,11 +1,18 @@
 use super::{
-    CacheValidators, FetchOutcome, PackumentFetch, Upstream, abbreviate_packument,
+    CacheValidators, CircuitBreaker, FetchOutcome, PackumentFetch, Upstream, abbreviate_packument,
     extract_version_manifest, rewrite_tarball_urls,
 };
-use crate::package_name::PackageName;
+use crate::{config::UplinkConfig, error::RegistryError, package_name::PackageName};
 use chrono::{DateTime, TimeZone, Utc};
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use serde_json::json;
+use std::time::Duration;
+
+/// Build an [`Upstream`] pointing at `url` with `headers`, all per-uplink
+/// tuning knobs at their verdaccio defaults.
+fn upstream(url: String, headers: HeaderMap) -> Upstream {
+    Upstream::new(&UplinkConfig::with_defaults(url, headers))
+}
 
 /// Fixed "current time" for abbreviation tests so the `time`-map
 /// coarsening (which buckets entries by age) is deterministic.
@@ -38,7 +45,7 @@ async fn fetch_packument_forwards_configured_headers() {
         .create_async()
         .await;
 
-    let upstream = Upstream::new(server.url(), auth_and_custom_headers());
+    let upstream = upstream(server.url(), auth_and_custom_headers());
     let name = PackageName::parse("foo").unwrap();
     let outcome = upstream.fetch_packument(&name, &CacheValidators::default()).await.unwrap();
 
@@ -59,7 +66,7 @@ async fn fetch_tarball_response_forwards_configured_headers() {
         .create_async()
         .await;
 
-    let upstream = Upstream::new(server.url(), auth_and_custom_headers());
+    let upstream = upstream(server.url(), auth_and_custom_headers());
     let name = PackageName::parse("foo").unwrap();
     let outcome = upstream.fetch_tarball_response(&name, "foo-1.0.0.tgz").await.unwrap();
 
@@ -79,7 +86,7 @@ async fn fetch_packument_sends_no_authorization_when_headers_empty() {
         .create_async()
         .await;
 
-    let upstream = Upstream::new(server.url(), HeaderMap::new());
+    let upstream = upstream(server.url(), HeaderMap::new());
     let name = PackageName::parse("foo").unwrap();
     let outcome = upstream.fetch_packument(&name, &CacheValidators::default()).await.unwrap();
 
@@ -100,7 +107,7 @@ async fn fetch_packument_captures_validators_from_response() {
         .create_async()
         .await;
 
-    let upstream = Upstream::new(server.url(), HeaderMap::new());
+    let upstream = upstream(server.url(), HeaderMap::new());
     let name = PackageName::parse("foo").unwrap();
     let outcome = upstream.fetch_packument(&name, &CacheValidators::default()).await.unwrap();
 
@@ -124,7 +131,7 @@ async fn fetch_packument_replays_validators_and_handles_304() {
         .create_async()
         .await;
 
-    let upstream = Upstream::new(server.url(), HeaderMap::new());
+    let upstream = upstream(server.url(), HeaderMap::new());
     let name = PackageName::parse("foo").unwrap();
     let validators = CacheValidators {
         etag: Some(r#""abc123""#.to_string()),
@@ -152,7 +159,7 @@ async fn fetch_packument_304_without_validators_is_an_error() {
         .create_async()
         .await;
 
-    let upstream = Upstream::new(server.url(), HeaderMap::new());
+    let upstream = upstream(server.url(), HeaderMap::new());
     let name = PackageName::parse("foo").unwrap();
     let result = upstream.fetch_packument(&name, &CacheValidators::default()).await;
 
@@ -165,7 +172,7 @@ async fn fetch_packument_maps_404_to_not_found() {
     let mut server = mockito::Server::new_async().await;
     let mock = server.mock("GET", "/foo").with_status(404).expect(1).create_async().await;
 
-    let upstream = Upstream::new(server.url(), HeaderMap::new());
+    let upstream = upstream(server.url(), HeaderMap::new());
     let name = PackageName::parse("foo").unwrap();
     let outcome = upstream.fetch_packument(&name, &CacheValidators::default()).await.unwrap();
 
@@ -434,4 +441,69 @@ fn coarsens_time_entries_by_age() {
     assert_eq!(time["0.0.1"], "not a date");
     // Synthesized top-level `modified` mirrors the coarsened entry.
     assert_eq!(out["modified"], "2024-03-02");
+}
+
+/// Build an [`Upstream`] pointing at `url` with a circuit breaker armed
+/// at `max_fails` and a long cooldown, so a test can drive it to the
+/// open state and observe the short-circuit before the cooldown lapses.
+fn breaking_upstream(url: String, max_fails: u32) -> Upstream {
+    Upstream::new(&UplinkConfig {
+        url,
+        headers: HeaderMap::new(),
+        maxage: None,
+        timeout: UplinkConfig::DEFAULT_TIMEOUT,
+        max_fails,
+        fail_timeout: Duration::from_mins(5),
+        cache: true,
+    })
+}
+
+#[test]
+fn circuit_breaker_opens_after_max_fails_and_resets_on_success() {
+    let breaker = CircuitBreaker::new(2, Duration::from_mins(5));
+    assert!(breaker.is_available());
+    breaker.record_failure();
+    assert!(breaker.is_available(), "one failure is under the threshold");
+    breaker.record_failure();
+    assert!(!breaker.is_available(), "two failures trip the breaker for the cooldown");
+    breaker.record_success();
+    assert!(breaker.is_available(), "a success clears the failure count");
+}
+
+#[test]
+fn circuit_breaker_reopens_once_cooldown_elapses() {
+    // A zero cooldown means a tripped breaker is immediately retryable —
+    // the half-open probe path.
+    let breaker = CircuitBreaker::new(1, Duration::ZERO);
+    breaker.record_failure();
+    assert!(breaker.is_available(), "a zero fail_timeout lets the next probe through");
+}
+
+#[test]
+fn circuit_breaker_disabled_when_max_fails_is_zero() {
+    let breaker = CircuitBreaker::new(0, Duration::from_mins(5));
+    breaker.record_failure();
+    breaker.record_failure();
+    assert!(breaker.is_available(), "max_fails == 0 disables the breaker");
+}
+
+#[tokio::test]
+async fn open_circuit_short_circuits_without_hitting_the_upstream() {
+    let mut server = mockito::Server::new_async().await;
+    // `max_fails: 1` trips after the first 500; the breaker must then
+    // short-circuit, so the upstream is hit exactly once.
+    let mock = server.mock("GET", "/foo").with_status(500).expect(1).create_async().await;
+
+    let upstream = breaking_upstream(server.url(), 1);
+    let name = PackageName::parse("foo").unwrap();
+
+    let first = upstream.fetch_packument(&name, &CacheValidators::default()).await;
+    assert!(matches!(first, Err(RegistryError::UpstreamStatus { status: 500, .. })));
+
+    let second = upstream.fetch_packument(&name, &CacheValidators::default()).await;
+    assert!(
+        matches!(second, Err(RegistryError::UpstreamUnavailable { .. })),
+        "the open breaker must short-circuit the second request",
+    );
+    mock.assert_async().await;
 }

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 /// Build an [`Upstream`] pointing at `url` with `headers`, all per-uplink
 /// tuning knobs at their verdaccio defaults.
 fn upstream(url: String, headers: HeaderMap) -> Upstream {
-    Upstream::new(&UplinkConfig::with_defaults(url, headers))
+    Upstream::new("npmjs", &UplinkConfig::with_defaults(url, headers))
 }
 
 /// Fixed "current time" for abbreviation tests so the `time`-map
@@ -447,27 +447,30 @@ fn coarsens_time_entries_by_age() {
 /// at `max_fails` and a long cooldown, so a test can drive it to the
 /// open state and observe the short-circuit before the cooldown lapses.
 fn breaking_upstream(url: String, max_fails: u32) -> Upstream {
-    Upstream::new(&UplinkConfig {
-        url,
-        headers: HeaderMap::new(),
-        maxage: None,
-        timeout: UplinkConfig::DEFAULT_TIMEOUT,
-        max_fails,
-        fail_timeout: Duration::from_mins(5),
-        cache: true,
-    })
+    Upstream::new(
+        "npmjs",
+        &UplinkConfig {
+            url,
+            headers: HeaderMap::new(),
+            maxage: None,
+            timeout: UplinkConfig::DEFAULT_TIMEOUT,
+            max_fails,
+            fail_timeout: Duration::from_mins(5),
+            cache: true,
+        },
+    )
 }
 
 #[test]
 fn circuit_breaker_opens_after_max_fails_and_resets_on_success() {
     let breaker = CircuitBreaker::new(2, Duration::from_mins(5));
-    assert!(breaker.is_available());
+    assert!(breaker.try_acquire());
     breaker.record_failure();
-    assert!(breaker.is_available(), "one failure is under the threshold");
+    assert!(breaker.try_acquire(), "one failure is under the threshold");
     breaker.record_failure();
-    assert!(!breaker.is_available(), "two failures trip the breaker for the cooldown");
+    assert!(!breaker.try_acquire(), "two failures trip the breaker for the cooldown");
     breaker.record_success();
-    assert!(breaker.is_available(), "a success clears the failure count");
+    assert!(breaker.try_acquire(), "a success clears the failure count");
 }
 
 #[test]
@@ -476,7 +479,37 @@ fn circuit_breaker_reopens_once_cooldown_elapses() {
     // the half-open probe path.
     let breaker = CircuitBreaker::new(1, Duration::ZERO);
     breaker.record_failure();
-    assert!(breaker.is_available(), "a zero fail_timeout lets the next probe through");
+    assert!(breaker.try_acquire(), "a zero fail_timeout lets the next probe through");
+}
+
+#[test]
+fn circuit_breaker_admits_only_one_half_open_probe() {
+    // Once cooled down, exactly one caller is let through to probe the
+    // upstream; concurrent callers stay short-circuited until the probe
+    // resolves, so a recovering upstream isn't stampeded.
+    let breaker = CircuitBreaker::new(1, Duration::ZERO);
+    breaker.record_failure();
+    assert!(breaker.try_acquire(), "the first caller after cooldown gets the probe");
+    assert!(!breaker.try_acquire(), "a second concurrent caller is held back");
+    // The probe fails: the cooldown restarts and the next caller (after it
+    // lapses again, instantly here) gets a fresh probe.
+    breaker.record_failure();
+    assert!(breaker.try_acquire(), "a failed probe frees the slot for the next probe");
+    // A successful probe instead closes the breaker entirely.
+    breaker.record_success();
+    assert!(breaker.try_acquire(), "a closed breaker admits everyone");
+}
+
+#[test]
+fn circuit_breaker_neutral_releases_probe_without_counting() {
+    // A non-availability answer (a non-404 4xx) must neither trip nor
+    // reset the breaker, but it does release the half-open probe.
+    let breaker = CircuitBreaker::new(1, Duration::ZERO);
+    breaker.record_failure();
+    assert!(breaker.try_acquire(), "cooled-down breaker hands out a probe");
+    assert!(!breaker.try_acquire(), "probe in flight holds others back");
+    breaker.record_neutral();
+    assert!(breaker.try_acquire(), "a neutral answer frees the probe slot");
 }
 
 #[test]
@@ -484,7 +517,7 @@ fn circuit_breaker_disabled_when_max_fails_is_zero() {
     let breaker = CircuitBreaker::new(0, Duration::from_mins(5));
     breaker.record_failure();
     breaker.record_failure();
-    assert!(breaker.is_available(), "max_fails == 0 disables the breaker");
+    assert!(breaker.try_acquire(), "max_fails == 0 disables the breaker");
 }
 
 #[tokio::test]
@@ -505,5 +538,26 @@ async fn open_circuit_short_circuits_without_hitting_the_upstream() {
         matches!(second, Err(RegistryError::UpstreamUnavailable { .. })),
         "the open breaker must short-circuit the second request",
     );
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn client_error_status_does_not_open_the_circuit() {
+    let mut server = mockito::Server::new_async().await;
+    // A 401 is an authoritative answer, not an availability failure: even
+    // at `max_fails: 1` it must not trip the breaker, so the upstream is
+    // reached on both requests rather than masked behind a 503.
+    let mock = server.mock("GET", "/foo").with_status(401).expect(2).create_async().await;
+
+    let upstream = breaking_upstream(server.url(), 1);
+    let name = PackageName::parse("foo").unwrap();
+
+    for _ in 0..2 {
+        let result = upstream.fetch_packument(&name, &CacheValidators::default()).await;
+        assert!(
+            matches!(result, Err(RegistryError::UpstreamStatus { status: 401, .. })),
+            "a 4xx must surface verbatim, not as a circuit-open 503",
+        );
+    }
     mock.assert_async().await;
 }

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -824,3 +824,83 @@ async fn tarball_is_not_gzipped_even_when_accepted() {
 
     mock.assert_async().await;
 }
+
+/// A per-uplink `maxage` shorter than the global `packument_ttl` governs
+/// freshness: with a generous global TTL the second request would be a
+/// cache hit, but `maxage: 0` forces a revalidation, so the upstream is
+/// hit twice.
+#[tokio::test]
+async fn per_uplink_maxage_overrides_global_packument_ttl() {
+    let mut upstream = mockito::Server::new_async().await;
+    let packument = json!({ "name": "foo", "versions": {} });
+    let mock = upstream
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_body(packument.to_string())
+        .expect(2)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for(&upstream.url(), tmp.path().to_path_buf());
+    // Global TTL stays generous (a minute); the per-uplink maxage of zero
+    // is what must take effect and make every read stale.
+    config.packument_ttl = Duration::from_mins(1);
+    config.uplinks.get_mut("npmjs").expect("default `npmjs` uplink").maxage =
+        Some(Duration::from_millis(0));
+    let app = router(config);
+
+    let r1 = app.clone().oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(r1.status(), StatusCode::OK);
+    let _ = body_bytes(r1.into_body()).await;
+
+    let r2 = app.oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(r2.status(), StatusCode::OK);
+
+    mock.assert_async().await;
+}
+
+/// A `cache: false` uplink streams tarballs through without writing them
+/// to the local mirror: a second request re-fetches from the upstream
+/// (so the mock is hit twice) and no `.tgz` is left in the cache dir.
+#[tokio::test]
+async fn cache_false_uplink_streams_tarball_without_mirroring() {
+    let mut upstream = mockito::Server::new_async().await;
+    let bytes = b"uncached-tarball-bytes";
+    let mock = upstream
+        .mock("GET", "/foo/-/foo-1.0.0.tgz")
+        .with_status(200)
+        .with_body(bytes)
+        .expect(2)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let cache_dir = tmp.path().to_path_buf();
+    let mut config = config_for(&upstream.url(), cache_dir.clone());
+    config.uplinks.get_mut("npmjs").expect("default `npmjs` uplink").cache = false;
+    let app = router(config);
+
+    for _ in 0..2 {
+        let response = app
+            .clone()
+            .oneshot(Request::get("/foo/-/foo-1.0.0.tgz").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body_bytes(response.into_body()).await, bytes);
+    }
+
+    // Nothing was mirrored: the package dir either doesn't exist or holds
+    // no `.tgz`. Both requests therefore went to the upstream.
+    let package_dir = cache_dir.join(".pnpr-cache").join("foo");
+    let cached_tarballs = std::fs::read_dir(&package_dir).map_or(0, |entries| {
+        entries
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_name().to_string_lossy().ends_with(".tgz"))
+            .count()
+    });
+    assert_eq!(cached_tarballs, 0, "a cache:false uplink must not write tarballs to the mirror");
+
+    mock.assert_async().await;
+}


### PR DESCRIPTION
## Summary

Adds verdaccio's per-uplink tuning knobs to pnpr's proxy uplinks, parsed from the same `config.yaml` shape verdaccio uses. Previously these fields were accepted and silently dropped; now each uplink can be tuned independently.

This is scoped to **pnpr** (the registry proxy) — no pnpm/pacquet CLI parity work is involved.

Part of the verdaccio-parity tracking issue pnpm/pnpm#11973 — ticks the **"Per-uplink timeouts, `max_fails`, `fail_timeout`, `cache: false`"** item under _Uplinks & caching_.

## Settings

| Key | Default | Behavior |
|-----|---------|----------|
| `maxage` | falls back to global `packument_ttl` | Per-uplink packument freshness window. When set, it overrides the global `--packument-ttl-secs`; when omitted, the global value still applies. |
| `timeout` | `30s` | Per-request deadline applied to every upstream fetch (packument and tarball). |
| `max_fails` | `2` | Consecutive failures before the uplink's circuit breaker opens. |
| `fail_timeout` | `5m` | Cooldown an open breaker stays open before a single probe is allowed through. |
| `cache` | `true` | When `false`, tarballs stream straight through to the client without being written to the local mirror. |

## Behavior notes

- **Circuit breaker** — after `max_fails` consecutive failures, requests to the uplink short-circuit with `503 Service Unavailable` (surfaced as `UpstreamUnavailable`) instead of hammering a known-down upstream. Once `fail_timeout` lapses, one probe is allowed through: success resets the breaker, failure restarts the cooldown. A 404/304/200 counts as success; transport errors and 5xx count as failures. On the packument path an open breaker degrades gracefully to the stale-cache fallback. `max_fails: 0` disables the breaker.
- **Interval format** — values accept verdaccio's syntax: suffixed (`2m`, `30s`, `1h30m`, `2m 30s`), or a bare number read as seconds. An unparseable value is a named `InvalidConfig` error (naming the offending field) rather than a silent fallback to the default.
- Defaults match verdaccio exactly (`timeout 30s`, `max_fails 2`, `fail_timeout 5m`, `cache true`).

## Testing

- **Unit** — interval parsing (suffixes/compound/bare/garbage), uplink resolution (defaults + explicit knobs + invalid-interval error), and the circuit breaker (opens after `max_fails`, resets on success, reopens after cooldown, disabled at `0`).
- **Integration** — `maxage` overriding the global TTL (forces a revalidation that would otherwise be a cache hit), an open circuit hitting the upstream exactly once, and a `cache: false` uplink streaming a tarball without writing it to the mirror.
- Full gate green: `cargo fmt`, `clippy --deny warnings`, rustdoc (`-D warnings`), `dylint`, and all 297 pnpr tests.

## Squash commit message

```
feat(pnpr): per-uplink verdaccio settings (maxage, timeout, max_fails, fail_timeout, cache)

Add verdaccio's per-uplink tuning knobs to pnpr's proxy uplinks, parsed
from the same config.yaml shape verdaccio uses:

- maxage:       per-uplink packument freshness window; overrides the
                global packument_ttl when set, otherwise defers to it.
- timeout:      per-request deadline applied to every upstream fetch
                (default 30s).
- max_fails /   circuit breaker: after max_fails consecutive failures the
  fail_timeout  uplink short-circuits with a 503 until the fail_timeout
                cooldown lapses, then one probe per window is allowed
                through (defaults 2 / 5m). max_fails: 0 disables it.
- cache:        when false, tarballs stream through without being written
                to the local mirror (default true).

Interval values accept verdaccio's format ("2m", "30s", "1h30m", or a
bare number of seconds, as either a YAML string or a numeric scalar);
an unparsable or out-of-range value is a named InvalidConfig error
rather than a silent fallback or a panic. Defaults match verdaccio
(timeout 30s, max_fails 2, fail_timeout 5m, cache true).

Circuit breaker behavior:
- Only a 5xx or transport error counts as a failure; a non-404 4xx
  (auth / rate-limit / bad request) surfaces verbatim and never opens
  the circuit.
- The half-open probe is gated on the cooldown window, so exactly one
  probe runs per fail_timeout and a cancelled or dropped probe cannot
  stick the breaker open.
- An open breaker reports the configured uplink name, not its upstream
  URL, so the 503 does not disclose internal endpoints.

Part of the verdaccio-parity tracking issue pnpm/pnpm#11973.

Co-authored-by: Claude <noreply@anthropic.com>
```

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended uplink configuration with timeout, failure threshold, and failure timeout controls
  * Per-uplink cache freshness TTL now overrides global packument settings
  * Uplink availability tracked with automatic circuit breaker for improved reliability
  * Tarballs now stream without local mirroring when uplink cache is disabled

* **Bug Fixes**
  * Unavailable upstreams now return 503 Service Unavailable status

* **Tests**
  * Added comprehensive test coverage for uplink configuration and circuit breaker behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
