### PR TITLE
test: shard deps-installer integration tests

### DIFF
--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -333,6 +333,7 @@ const yamlTextFormat = createFormat<string>({
   },
 })
 
+const depsInstallerTestShardCount = 5
 const registryMockPortForCore = 7769
 
 async function updateManifest (workspaceDir: string, manifest: ProjectManifest, dir: string, nextTag: string): Promise<ProjectManifest> {
@@ -368,7 +369,8 @@ async function updateManifest (workspaceDir: string, manifest: ProjectManifest, 
       if (manifest.name === '@pnpm/installing.deps-installer') {
       // @pnpm/installing.deps-installer tests currently works only with port 7769 due to the usage of
       // the next package: pkg-with-tarball-dep-from-registry
-        scripts['.test'] = `cross-env PNPM_REGISTRY_MOCK_PORT=${registryMockPortForCore} NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" jest`
+        scripts['.test'] = Array.from({ length: depsInstallerTestShardCount }, (_, index) => `pn .test:shard --shard=${index + 1}/${depsInstallerTestShardCount}`).join(' && ')
+        scripts['.test:shard'] = `cross-env PNPM_REGISTRY_MOCK_PORT=${registryMockPortForCore} NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" jest`
       } else {
         scripts['.test'] = 'cross-env NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" jest'
       }

--- a/installing/deps-installer/package.json
+++ b/installing/deps-installer/package.json
@@ -53,7 +53,8 @@
     "test": "pn compile && pn .test",
     "prepublishOnly": "tsgo --build",
     "compile": "tsgo --build && pn lint --fix",
-    ".test": "cross-env PNPM_REGISTRY_MOCK_PORT=7769 NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
+    ".test": "pn .test:shard --shard=1/5 && pn .test:shard --shard=2/5 && pn .test:shard --shard=3/5 && pn .test:shard --shard=4/5 && pn .test:shard --shard=5/5",
+    ".test:shard": "cross-env PNPM_REGISTRY_MOCK_PORT=7769 NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
   },
   "dependencies": {
     "@inquirer/prompts": "catalog:",


### PR DESCRIPTION
## Summary

- run `@pnpm/installing.deps-installer` Jest tests in five sequential shards
- keep each shard in a fresh Node/Jest process while preserving the existing registry setup
- update `.meta-updater` so the generated package manifest stays in sync

## Context

The failed Ubuntu Node 22 job in https://github.com/pnpm/pnpm/actions/runs/27464325216/job/81186212640 still OOMed in `@pnpm/installing.deps-installer` after coverage was disabled. Windows Node 22 in the same run failed with the same deps-installer heap OOM. Splitting the suite by process lifetime gives the runner heap room without changing test assertions.

## Verification

- `cargo build -p pnpr-fixtures --bin pnpr-prepare -p pnpr --bin pnpr`
- `CI=true pnpm --filter @pnpm/installing.deps-installer test`
- `pnpm meta-updater --test`
- `git diff --check`
- pre-push hook: compile, spellcheck, meta-updater check, quiet ESLint

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified test script execution to run across multiple shards instead of a single invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->