### PR TITLE
fix(setup): allow @pnpm/exe build during `pnpm setup`

### DIFF
--- a/.changeset/fix-setup-allow-pnpm-exe-build.md
+++ b/.changeset/fix-setup-allow-pnpm-exe-build.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/pm.commands": patch
+"pnpm": patch
+---
+
+Fixed `pnpm setup` halting on 11.6.0's per-package build-script consent prompt for `@pnpm/exe` itself, which looked like a supply-chain warning for pnpm's own install path. The internal `pnpm add -g file:<dir>` invocation now passes `--allow-build=@pnpm/exe` so the prompt is skipped for pnpm's own binary placement. [pnpm/pnpm#12377](https://github.com/pnpm/pnpm/issues/12377)

--- a/engine/pm/commands/src/setup/setup.ts
+++ b/engine/pm/commands/src/setup/setup.ts
@@ -84,7 +84,12 @@ function installCliGlobally (execPath: string, pnpmHomeDir: string): void {
 
   try {
     const binDir = path.join(pnpmHomeDir, 'bin')
-    const { status, error } = spawnSync(execPath, ['add', '-g', `file:${execDir}`], {
+    // The pnpm executable itself is the "build script" trigger here — the
+    // global install of `@pnpm/exe` needs to place the binary. Allow that
+    // explicitly so 11.6.0's per-package build-script consent prompt doesn't
+    // halt `pnpm setup` waiting on user input (and doesn't read like a
+    // supply-chain warning for pnpm's own install path).
+    const { status, error } = spawnSync(execPath, ['add', '-g', '--allow-build=@pnpm/exe', `file:${execDir}`], {
       stdio: 'inherit',
       env: {
         ...process.env,


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#12377.

`pnpm setup` internally runs `pnpm add -g file:<execDir>` to place the pnpm binary. 11.6.0 added a per-package build-script consent prompt for any package that ships a postinstall (or similar) script, so this internal install now halts on the `@pnpm/exe` build prompt. To an unsuspecting user the prompt reads like a supply-chain warning about pnpm's own install path (reporter screenshot in the issue captures the user reaction: "It feels like someone has pushed postinstall script malware to pnpm").

`pnpm self-update` doesn't go through this code path, which is why it doesn't prompt — only `pnpm setup` does.

Pass `--allow-build=@pnpm/exe` to the internal `pnpm add` invocation so the binary-placement build runs without prompting.

## Test commands

The setup command isn't unit-tested in CI (it mutates global system state), but the change is a single-arg addition to an already-tested `spawnSync` call. The `--allow-build=<pkg>` flag itself is covered by existing tests at `pnpm/test/install/lifecycleScripts.ts:170-185`.

## Notes

Same reporter as pnpm/pnpm#12379 (which I fixed in pnpm/pnpm#12380) — both are 11.6.0 regressions hitting Windows users running fresh installs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where `pnpm setup` would hang with a build-script consent prompt on version 11.6.0, preventing successful installation completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
