### PR TITLE
fix(pacquet): refresh lockfile when catalogs change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3868,6 +3868,7 @@ dependencies = [
  "derive_more",
  "indexmap 2.14.0",
  "node-semver",
+ "pacquet-catalogs-types",
  "pacquet-crypto-hash",
  "pacquet-diagnostics",
  "pacquet-package-manifest",

--- a/pacquet/crates/cli/tests/catalog.rs
+++ b/pacquet/crates/cli/tests/catalog.rs
@@ -4,6 +4,7 @@
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
+use pacquet_lockfile::Lockfile;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use pretty_assertions::assert_eq;
@@ -53,6 +54,18 @@ fn dep_spec(workspace: &Path, name: &str) -> Option<String> {
 
 fn read(workspace: &Path, file: &str) -> String {
     fs::read_to_string(workspace.join(file)).unwrap_or_else(|_| panic!("read {file}"))
+}
+
+fn catalog_snapshot(workspace: &Path, name: &str) -> (String, String) {
+    let lockfile: Lockfile =
+        serde_saphyr::from_str(&read(workspace, "pnpm-lock.yaml")).expect("parse pnpm-lock.yaml");
+    let entry = lockfile
+        .catalogs
+        .as_ref()
+        .and_then(|catalogs| catalogs.get("default"))
+        .and_then(|catalog| catalog.get(name))
+        .unwrap_or_else(|| panic!("missing default catalog snapshot entry for {name}"));
+    (entry.specifier.clone(), entry.version.clone())
 }
 
 fn run_ok(workspace: &Path, args: &[&str]) {
@@ -219,6 +232,30 @@ fn update_latest_no_save_leaves_the_catalog_untouched() {
         workspace_yaml.contains(&format!("'{FOO}': 1.0.0")),
         "--no-save must not rewrite the catalog entry:\n{workspace_yaml}",
     );
+
+    drop((root, anchor));
+}
+
+#[test]
+fn install_reruns_when_catalog_entry_changes() {
+    let (root, workspace, anchor) = setup();
+    write_manifest(&workspace, &format!(r#"{{ "{FOO}": "catalog:" }}"#));
+    append_workspace_yaml(&workspace, &format!("catalog:\n  '{FOO}': 1.0.0\n"));
+
+    run_ok(&workspace, &["install"]);
+    assert_eq!(catalog_snapshot(&workspace, FOO), ("1.0.0".to_string(), "1.0.0".to_string()));
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        workspace_yaml.replace(&format!("'{FOO}': 1.0.0"), &format!("'{FOO}': 2.0.0")),
+    )
+    .expect("rewrite pnpm-workspace.yaml catalog entry");
+
+    run_ok(&workspace, &["install"]);
+    assert_eq!(catalog_snapshot(&workspace, FOO), ("2.0.0".to_string(), "2.0.0".to_string()));
 
     drop((root, anchor));
 }

--- a/pacquet/crates/lockfile/Cargo.toml
+++ b/pacquet/crates/lockfile/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
+pacquet-catalogs-types   = { workspace = true }
 pacquet-crypto-hash      = { workspace = true }
 pacquet-diagnostics      = { workspace = true }
 pacquet-package-manifest = { workspace = true }

--- a/pacquet/crates/lockfile/src/freshness.rs
+++ b/pacquet/crates/lockfile/src/freshness.rs
@@ -17,8 +17,20 @@
 
 use crate::{Lockfile, ProjectSnapshot};
 use derive_more::{Display, Error};
+use pacquet_catalogs_types::Catalogs;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+#[derive(Clone, Copy)]
+pub struct LockfileSettingsCheck<'a> {
+    pub catalogs: &'a Catalogs,
+    pub overrides: Option<&'a HashMap<String, String>>,
+    pub package_extensions_checksum: Option<&'a str>,
+    pub ignored_optional_dependencies: Option<&'a [String]>,
+    pub patched_dependencies: Option<&'a BTreeMap<String, String>>,
+    pub inject_workspace_packages: bool,
+    pub peers_suffix_max_length: u64,
+}
 
 /// Why an importer's lockfile entry doesn't satisfy the on-disk
 /// `package.json`. Mirrors the discriminated cases upstream's
@@ -29,6 +41,13 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 #[derive(Debug, Display, Error, PartialEq)]
 #[non_exhaustive]
 pub enum StalenessReason {
+    /// A catalog entry recorded in the lockfile's `catalogs:` snapshot
+    /// no longer matches the current workspace catalog config. Mirrors
+    /// upstream's `getOutdatedLockfileSetting` first branch, which
+    /// returns `'catalogs'` when `allCatalogsAreUpToDate` fails.
+    #[display("`catalogs` in the lockfile don't match the current config")]
+    CatalogsChanged { lockfile: Option<crate::CatalogSnapshots>, config: Catalogs },
+
     /// The lockfile has no `importers["."]` (or whatever id) entry,
     /// so we can't even start the comparison. Mirrors upstream's
     /// "no importer" reason at
@@ -233,11 +252,11 @@ impl SpecDiff {
 
 /// Verify that lockfile-level settings the install pipeline reads
 /// from `pnpm-workspace.yaml` haven't drifted since the lockfile
-/// was written. Today this covers `overrides`,
+/// was written. Today this covers `catalogs`, `overrides`,
 /// `packageExtensionsChecksum`, `ignoredOptionalDependencies`,
 /// `patchedDependencies`, and the relevant `settings.*` keys (umbrella
 /// [#434] slice 7); the variants below will grow as more upstream
-/// settings land (`catalogs`, `pnpmfileChecksum`, etc.).
+/// settings land (`pnpmfileChecksum`, etc.).
 ///
 /// Mirrors upstream's
 /// [`getOutdatedLockfileSetting`](https://github.com/pnpm/pnpm/blob/606f53e78f/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts).
@@ -258,6 +277,43 @@ pub fn check_lockfile_settings(
     inject_workspace_packages: bool,
     peers_suffix_max_length: u64,
 ) -> Result<(), StalenessReason> {
+    check_lockfile_settings_with_catalogs(
+        lockfile,
+        LockfileSettingsCheck {
+            catalogs: &Catalogs::new(),
+            overrides,
+            package_extensions_checksum,
+            ignored_optional_dependencies,
+            patched_dependencies,
+            inject_workspace_packages,
+            peers_suffix_max_length,
+        },
+    )
+}
+
+/// Catalog-aware variant of [`check_lockfile_settings`] used by install paths
+/// that have already loaded `pnpm-workspace.yaml`.
+pub fn check_lockfile_settings_with_catalogs(
+    lockfile: &Lockfile,
+    check: LockfileSettingsCheck<'_>,
+) -> Result<(), StalenessReason> {
+    let LockfileSettingsCheck {
+        catalogs,
+        overrides,
+        package_extensions_checksum,
+        ignored_optional_dependencies,
+        patched_dependencies,
+        inject_workspace_packages,
+        peers_suffix_max_length,
+    } = check;
+
+    if !all_catalogs_are_up_to_date(catalogs, lockfile.catalogs.as_ref()) {
+        return Err(StalenessReason::CatalogsChanged {
+            lockfile: lockfile.catalogs.clone(),
+            config: catalogs.clone(),
+        });
+    }
+
     // Upstream checks `overrides` before `ignoredOptionalDependencies`,
     // so an install that changed both surfaces the overrides drift
     // first — preserving that for parity with pnpm error reports.
@@ -359,6 +415,18 @@ pub fn check_lockfile_settings(
     Ok(())
 }
 
+fn all_catalogs_are_up_to_date(
+    catalogs_config: &Catalogs,
+    snapshot: Option<&crate::CatalogSnapshots>,
+) -> bool {
+    snapshot.iter().flat_map(|catalogs| catalogs.iter()).all(|(catalog_name, catalog)| {
+        catalog.iter().all(|(alias, entry)| {
+            catalogs_config.get(catalog_name).and_then(|catalog| catalog.get(alias))
+                == Some(&entry.specifier)
+        })
+    })
+}
+
 /// Verify the on-disk `package.json` is still satisfied by the
 /// lockfile's importer entry for the same project. Returns `Ok(())`
 /// when the lockfile is up-to-date; returns `Err(StalenessReason)`
@@ -380,11 +448,11 @@ pub fn check_lockfile_settings(
 ///
 /// Mirrors upstream's
 /// [`satisfiesPackageManifest`](https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/verification/src/satisfiesPackageManifest.ts).
-/// Scoped to what pacquet supports today: no catalogs (#?), no
-/// `auto-install-peers` pre-pass (pacquet has no separate
-/// auto-install-peers mode), no `excludeLinksFromLockfile` (`link:`
-/// resolutions aren't supported yet — [#431] territory), and no
-/// version-range-satisfies check (covered in pnpm's
+/// Scoped to what pacquet supports today: no `auto-install-peers`
+/// pre-pass (pacquet has no separate auto-install-peers mode), no
+/// `excludeLinksFromLockfile` (`link:` resolutions aren't supported
+/// yet — [#431] territory), and no version-range-satisfies check
+/// (covered in pnpm's
 /// `localTarballDepsAreUpToDate` for file: / tarball deps; out of
 /// scope here).
 ///

--- a/pacquet/crates/lockfile/src/freshness/tests.rs
+++ b/pacquet/crates/lockfile/src/freshness/tests.rs
@@ -1,7 +1,12 @@
-use super::{StalenessReason, check_lockfile_settings, satisfies_package_manifest};
+use super::{
+    LockfileSettingsCheck, StalenessReason, check_lockfile_settings,
+    check_lockfile_settings_with_catalogs, satisfies_package_manifest,
+};
 use crate::Lockfile;
+use pacquet_catalogs_types::Catalogs;
 use pacquet_package_manifest::PackageManifest;
 use pretty_assertions::assert_eq;
+use std::collections::BTreeMap;
 use tempfile::tempdir;
 use text_block_macros::text_block;
 
@@ -15,6 +20,18 @@ fn manifest_from_json(json: &str) -> (tempfile::TempDir, PackageManifest) {
     std::fs::write(&path, json).expect("write package.json");
     let manifest = PackageManifest::from_path(path).expect("parse package.json");
     (tmp, manifest)
+}
+
+fn settings_check(catalogs: &Catalogs) -> LockfileSettingsCheck<'_> {
+    LockfileSettingsCheck {
+        catalogs,
+        overrides: None,
+        package_extensions_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        inject_workspace_packages: false,
+        peers_suffix_max_length: crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+    }
 }
 
 /// Single-importer lockfile + matching manifest passes the check.
@@ -578,6 +595,93 @@ fn importer_empty_dev_dependencies_equivalent_to_absent() {
     }"#,
     );
     assert!(satisfies_package_manifest(importer, &manifest, ".", &|_: &str| false).is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// `catalogs` drift — pacquet's mirror of upstream's
+// `getOutdatedLockfileSetting` first check
+// ---------------------------------------------------------------------------
+
+#[test]
+fn check_settings_passes_when_catalog_snapshot_matches_config() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "catalogs:"
+        "  default:"
+        "    react:"
+        "      specifier: ^18.2.0"
+        "      version: 18.2.0"
+    })
+    .expect("parse lockfile with catalogs");
+    let catalogs = Catalogs::from([(
+        "default".to_string(),
+        BTreeMap::from([("react".to_string(), "^18.2.0".to_string())]),
+    )]);
+    assert!(check_lockfile_settings_with_catalogs(&lockfile, settings_check(&catalogs)).is_ok());
+}
+
+#[test]
+fn check_settings_ignores_catalog_config_entries_absent_from_snapshot() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+    })
+    .expect("parse lockfile without catalog snapshot");
+    let catalogs = Catalogs::from([(
+        "default".to_string(),
+        BTreeMap::from([("react".to_string(), "^18.2.0".to_string())]),
+    )]);
+    assert!(check_lockfile_settings_with_catalogs(&lockfile, settings_check(&catalogs)).is_ok());
+}
+
+#[test]
+fn check_settings_returns_drift_when_catalog_snapshot_specifier_changes() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "catalogs:"
+        "  default:"
+        "    react:"
+        "      specifier: ^18.2.0"
+        "      version: 18.2.0"
+    })
+    .expect("parse lockfile with catalogs");
+    let catalogs = Catalogs::from([(
+        "default".to_string(),
+        BTreeMap::from([("react".to_string(), "^19.0.0".to_string())]),
+    )]);
+    let err = check_lockfile_settings_with_catalogs(&lockfile, settings_check(&catalogs))
+        .expect_err("changed catalog entry must surface drift");
+    let StalenessReason::CatalogsChanged { lockfile: snapshot, config } = err else {
+        panic!("expected CatalogsChanged");
+    };
+    assert_eq!(
+        snapshot
+            .as_ref()
+            .and_then(|catalogs| catalogs.get("default"))
+            .and_then(|catalog| catalog.get("react"))
+            .map(|entry| entry.specifier.as_str()),
+        Some("^18.2.0"),
+    );
+    assert_eq!(
+        config.get("default").and_then(|catalog| catalog.get("react")).map(String::as_str),
+        Some("^19.0.0"),
+    );
+}
+
+#[test]
+fn check_settings_returns_drift_when_catalog_snapshot_entry_is_removed_from_config() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "catalogs:"
+        "  default:"
+        "    react:"
+        "      specifier: ^18.2.0"
+        "      version: 18.2.0"
+    })
+    .expect("parse lockfile with catalogs");
+    let catalogs = Catalogs::from([("default".to_string(), BTreeMap::new())]);
+    let err = check_lockfile_settings_with_catalogs(&lockfile, settings_check(&catalogs))
+        .expect_err("removed catalog entry must surface drift");
+    assert!(matches!(err, StalenessReason::CatalogsChanged { .. }));
 }
 
 // ---------------------------------------------------------------------------

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -978,6 +978,7 @@ where
                     config,
                     node_linker,
                     included,
+                    &catalogs,
                     &project_manifests,
                 ),
             )
@@ -1129,7 +1130,7 @@ where
                 dependency_groups,
                 logged_methods: &logged_methods,
                 requester: &prefix,
-                catalogs,
+                catalogs: catalogs.clone(),
                 lockfile_dir: &workspace_root,
                 workspace_packages,
                 update_checksums,
@@ -1322,6 +1323,7 @@ where
                 config,
                 node_linker,
                 included,
+                &catalogs,
                 &project_manifests,
             ),
         )
@@ -1368,7 +1370,7 @@ fn check_lockfile_freshness(
     ignore_manifest_check: bool,
 ) -> Result<(), FreshnessCheckError> {
     let parsed_overrides_opt = parse_config_overrides(config, catalogs)?;
-    check_lockfile_settings_drift(lockfile, config, parsed_overrides_opt.as_deref())?;
+    check_lockfile_settings_drift(lockfile, config, catalogs, parsed_overrides_opt.as_deref())?;
 
     if ignore_manifest_check {
         return Ok(());
@@ -1417,6 +1419,7 @@ pub(crate) fn parse_config_overrides(
 pub(crate) fn check_lockfile_settings_drift(
     lockfile: &Lockfile,
     config: &Config,
+    catalogs: &Catalogs,
     parsed_overrides: Option<&[pacquet_config_parse_overrides::VersionOverride]>,
 ) -> Result<(), FreshnessCheckError> {
     let overrides_map: Option<std::collections::HashMap<String, String>> =
@@ -1429,14 +1432,17 @@ pub(crate) fn check_lockfile_settings_drift(
     // from what the lockfile recorded.
     let patched_dependency_hashes =
         config.patched_dependency_hashes().map_err(FreshnessCheckError::CalcPatchHashes)?;
-    pacquet_lockfile::check_lockfile_settings(
+    pacquet_lockfile::check_lockfile_settings_with_catalogs(
         lockfile,
-        overrides_map.as_ref(),
-        package_extensions_checksum.as_deref(),
-        config.ignored_optional_dependencies.as_deref(),
-        patched_dependency_hashes.as_ref(),
-        config.inject_workspace_packages,
-        config.peers_suffix_max_length,
+        pacquet_lockfile::LockfileSettingsCheck {
+            catalogs,
+            overrides: overrides_map.as_ref(),
+            package_extensions_checksum: package_extensions_checksum.as_deref(),
+            ignored_optional_dependencies: config.ignored_optional_dependencies.as_deref(),
+            patched_dependencies: patched_dependency_hashes.as_ref(),
+            inject_workspace_packages: config.inject_workspace_packages,
+            peers_suffix_max_length: config.peers_suffix_max_length,
+        },
     )
     .map_err(FreshnessCheckError::Stale)
 }
@@ -1924,6 +1930,7 @@ pub(crate) fn build_workspace_state(
     config: &Config,
     node_linker: NodeLinker,
     included: IncludedDependencies,
+    catalogs: &Catalogs,
     project_manifests: &[(std::path::PathBuf, &PackageManifest)],
 ) -> WorkspaceState {
     WorkspaceState {
@@ -1941,7 +1948,12 @@ pub(crate) fn build_workspace_state(
         // produces. Keeping the construction in one place guarantees
         // adding a field on one side doesn't silently flip the other
         // into "drift" on the next install.
-        settings: crate::optimistic_repeat_install::current_settings(config, node_linker, included),
+        settings: crate::optimistic_repeat_install::current_settings_with_catalogs(
+            config,
+            node_linker,
+            included,
+            catalogs,
+        ),
     }
 }
 

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -1067,6 +1067,7 @@ mod build_workspace_state_tests {
             &config,
             pacquet_config::NodeLinker::default(),
             IncludedDependencies::default(),
+            &BTreeMap::default(),
             &[],
         );
         assert!(state.projects.is_empty());
@@ -1099,6 +1100,7 @@ mod build_workspace_state_tests {
             &config,
             pacquet_config::NodeLinker::default(),
             IncludedDependencies::default(),
+            &BTreeMap::default(),
             &project_manifests,
         );
 
@@ -1133,6 +1135,7 @@ mod build_workspace_state_tests {
             &config,
             pacquet_config::NodeLinker::default(),
             IncludedDependencies::default(),
+            &BTreeMap::default(),
             &[],
         );
         assert_eq!(state.config_dependencies, config.config_dependencies);

--- a/pacquet/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pacquet/crates/package-manager/src/optimistic_repeat_install.rs
@@ -117,7 +117,8 @@ pub struct OptimisticRepeatInstallCheck<'a> {
     /// previous install materialized — and `pnpm-lock.yaml` is
     /// regenerated from it before the check reports up-to-date.
     pub lockfile: MaybeLazyLockfile<'a>,
-    /// Workspace catalogs, for resolving `catalog:` values inside
+    /// Catalogs from the workspace manifest or an `updateConfig`
+    /// pnpmfile hook, for resolving `catalog:` values inside
     /// `pnpm.overrides` before the lockfile settings comparison.
     pub catalogs: &'a Catalogs,
 }
@@ -135,6 +136,7 @@ pub fn check_optimistic_repeat_install(check: &OptimisticRepeatInstallCheck<'_>)
         included,
         project_manifests,
         is_workspace_install,
+        catalogs,
         ..
     } = check;
     if !config.optimistic_repeat_install {
@@ -152,6 +154,10 @@ pub fn check_optimistic_repeat_install(check: &OptimisticRepeatInstallCheck<'_>)
 
     if !settings_match(&state, config, node_linker, included) {
         return Decision::Skipped { reason: "settings drift" };
+    }
+
+    if !catalogs_cache_matches(state.settings.catalogs.as_ref(), catalogs) {
+        return Decision::Skipped { reason: "catalogs cache outdated" };
     }
 
     if !project_structure_matches(&state, project_manifests) {
@@ -259,6 +265,7 @@ pub fn check_optimistic_repeat_install(check: &OptimisticRepeatInstallCheck<'_>)
                     config,
                     node_linker,
                     included,
+                    catalogs,
                     project_manifests,
                 );
                 if let Err(error) = update_workspace_state(workspace_root, &new_state) {
@@ -411,9 +418,12 @@ fn modified_manifests_match_lockfile(
 
     let parsed_overrides = crate::install::parse_config_overrides(config, catalogs)
         .map_err(|_| "pnpm.overrides cannot be parsed")?;
-    if let Err(error) =
-        crate::install::check_lockfile_settings_drift(wanted, config, parsed_overrides.as_deref())
-    {
+    if let Err(error) = crate::install::check_lockfile_settings_drift(
+        wanted,
+        config,
+        catalogs,
+        parsed_overrides.as_deref(),
+    ) {
         tracing::debug!(target: "pacquet::install", %error, "repeat-install content check: lockfile settings drift");
         return Err("a lockfile setting drifted from the current configuration");
     }
@@ -747,11 +757,16 @@ fn settings_match(
         && recorded.prefer_workspace_packages == live.prefer_workspace_packages
         && recorded.production == live.production
         && recorded.public_hoist_pattern == live.public_hoist_pattern
-    // Deliberately *not* compared. pnpm leaves the first group
+    // Deliberately *not* compared in this generic settings loop. pnpm
+    // ignores `catalogs` here (`ignoredSettings.add('catalogs')`), then
+    // checks it separately. Pacquet mirrors that split in
+    // `check_optimistic_repeat_install` so catalogs from either
+    // `pnpm-workspace.yaml` or an `updateConfig` hook can invalidate
+    // the cache.
+    //
+    // The remaining omitted keys are left out because pnpm leaves them
     // `undefined` by default, so omitting them here still matches pnpm's
     // all-key freshness check (`undefined == undefined`):
-    //   catalogs                    (pnpm always ignores; see
-    //                                ignoredSettings.add('catalogs'))
     //   minimumReleaseAgeStrict     (pnpm sets it only when the user
     //                                explicitly sets minimumReleaseAge)
     //   minimumReleaseAgeExclude
@@ -873,6 +888,37 @@ pub(crate) fn current_settings(
         public_hoist_pattern: config.public_hoist_pattern.clone(),
         ..Default::default()
     }
+}
+
+pub(crate) fn current_settings_with_catalogs(
+    config: &Config,
+    node_linker: NodeLinker,
+    included: IncludedDependencies,
+    catalogs: &Catalogs,
+) -> WorkspaceStateSettings {
+    let mut settings = current_settings(config, node_linker, included);
+    settings.catalogs = Some(catalogs_to_json(catalogs));
+    settings
+}
+
+fn catalogs_cache_matches(recorded: Option<&serde_json::Value>, current: &Catalogs) -> bool {
+    let recorded = recorded.cloned().map_or_else(empty_json_object, filter_null_object_values);
+    let current = filter_null_object_values(catalogs_to_json(current));
+    recorded == current
+}
+
+fn catalogs_to_json(catalogs: &Catalogs) -> serde_json::Value {
+    serde_json::to_value(catalogs).expect("Catalogs serialize to a JSON object")
+}
+
+fn empty_json_object() -> serde_json::Value {
+    serde_json::Value::Object(serde_json::Map::new())
+}
+
+fn filter_null_object_values(value: serde_json::Value) -> serde_json::Value {
+    let serde_json::Value::Object(mut map) = value else { return value };
+    map.retain(|_, value| !value.is_null());
+    serde_json::Value::Object(map)
 }
 
 fn link_workspace_packages_to_json(value: LinkWorkspacePackages) -> serde_json::Value {

--- a/pacquet/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pacquet/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -1,6 +1,8 @@
 use super::{
     Decision, OptimisticRepeatInstallCheck, check_optimistic_repeat_install, current_settings,
+    current_settings_with_catalogs,
 };
+use pacquet_catalogs_types::Catalogs;
 use pacquet_config::Config;
 use pacquet_lockfile::{Lockfile, MaybeLazyLockfile};
 use pacquet_modules_yaml::IncludedDependencies;
@@ -24,16 +26,44 @@ fn check(
     node_linker: pacquet_config::NodeLinker,
     project_manifests: &[(std::path::PathBuf, &PackageManifest)],
 ) -> Decision {
+    check_with_catalogs(
+        workspace_root,
+        config,
+        node_linker,
+        project_manifests,
+        false,
+        &BTreeMap::default(),
+    )
+}
+
+fn check_with_catalogs(
+    workspace_root: &std::path::Path,
+    config: &Config,
+    node_linker: pacquet_config::NodeLinker,
+    project_manifests: &[(std::path::PathBuf, &PackageManifest)],
+    is_workspace_install: bool,
+    catalogs: &Catalogs,
+) -> Decision {
     check_optimistic_repeat_install(&OptimisticRepeatInstallCheck {
         workspace_root,
         config,
         node_linker,
         included: isolated_included(),
         project_manifests,
-        is_workspace_install: false,
+        is_workspace_install,
         lockfile: MaybeLazyLockfile::Loaded(None),
-        catalogs: &BTreeMap::default(),
+        catalogs,
     })
+}
+
+fn check_workspace(
+    workspace_root: &std::path::Path,
+    config: &Config,
+    node_linker: pacquet_config::NodeLinker,
+    project_manifests: &[(std::path::PathBuf, &PackageManifest)],
+    catalogs: &Catalogs,
+) -> Decision {
+    check_with_catalogs(workspace_root, config, node_linker, project_manifests, true, catalogs)
 }
 
 /// Write an empty `pnpm-lock.yaml` to satisfy the single-project
@@ -992,8 +1022,6 @@ fn returns_up_to_date_when_state_carries_unported_pnpm_settings() {
         current_settings(config, pacquet_config::NodeLinker::Isolated, isolated_included());
     // Populate fields pacquet records but `settings_match` does not
     // compare, to prove a difference on them keeps the fast path.
-    // `catalogs` is always ignored by pnpm itself; pacquet mirrors that.
-    settings.catalogs = Some(serde_json::json!({"default": {"react": "^18.0.0"}}));
     // `workspacePackagePatterns` is recorded by pnpm from
     // pnpm-workspace.yaml's `packages:` field, which pacquet
     // tracks via `WorkspaceManifest.packages` instead of this
@@ -1014,6 +1042,99 @@ fn returns_up_to_date_when_state_carries_unported_pnpm_settings() {
         &[(workspace_root.to_path_buf(), &manifest)],
     );
     assert_eq!(decision, Decision::UpToDate);
+}
+
+#[test]
+fn returns_outdated_when_workspace_catalog_cache_changes() {
+    let dir = tempdir().unwrap();
+    let workspace_root = dir.path();
+    let manifest_path = workspace_root.join("package.json");
+    fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
+    let manifest = PackageManifest::from_path(manifest_path).unwrap();
+    write_empty_lockfile(workspace_root);
+
+    let mut config = Config::new();
+    config.modules_dir = workspace_root.join("node_modules");
+    fs::create_dir_all(&config.modules_dir).unwrap();
+    let config = config.leak();
+
+    let recorded_catalogs = Catalogs::from([(
+        "default".to_string(),
+        BTreeMap::from([("react".to_string(), "^18.0.0".to_string())]),
+    )]);
+    let settings = current_settings_with_catalogs(
+        config,
+        pacquet_config::NodeLinker::Isolated,
+        isolated_included(),
+        &recorded_catalogs,
+    );
+
+    let mut projects = BTreeMap::new();
+    projects.insert(
+        workspace_root.to_string_lossy().into_owned(),
+        ProjectEntry { name: Some("root".into()), version: Some("1.0.0".into()) },
+    );
+    write_state(workspace_root, now_millis() + 60_000, settings, projects);
+
+    let current_catalogs = Catalogs::from([(
+        "default".to_string(),
+        BTreeMap::from([("react".to_string(), "^19.0.0".to_string())]),
+    )]);
+    let decision = check_workspace(
+        workspace_root,
+        config,
+        pacquet_config::NodeLinker::Isolated,
+        &[(workspace_root.to_path_buf(), &manifest)],
+        &current_catalogs,
+    );
+    assert_eq!(decision, Decision::Skipped { reason: "catalogs cache outdated" });
+}
+
+#[test]
+fn returns_outdated_when_single_project_catalog_cache_changes() {
+    let dir = tempdir().unwrap();
+    let workspace_root = dir.path();
+    let manifest_path = workspace_root.join("package.json");
+    fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
+    let manifest = PackageManifest::from_path(manifest_path).unwrap();
+    write_empty_lockfile(workspace_root);
+
+    let mut config = Config::new();
+    config.modules_dir = workspace_root.join("node_modules");
+    fs::create_dir_all(&config.modules_dir).unwrap();
+    let config = config.leak();
+
+    let recorded_catalogs = Catalogs::from([(
+        "default".to_string(),
+        BTreeMap::from([("react".to_string(), "^18.0.0".to_string())]),
+    )]);
+    let settings = current_settings_with_catalogs(
+        config,
+        pacquet_config::NodeLinker::Isolated,
+        isolated_included(),
+        &recorded_catalogs,
+    );
+
+    let mut projects = BTreeMap::new();
+    projects.insert(
+        workspace_root.to_string_lossy().into_owned(),
+        ProjectEntry { name: Some("root".into()), version: Some("1.0.0".into()) },
+    );
+    write_state(workspace_root, now_millis() + 60_000, settings, projects);
+
+    let current_catalogs = Catalogs::from([(
+        "default".to_string(),
+        BTreeMap::from([("react".to_string(), "^19.0.0".to_string())]),
+    )]);
+    let decision = check_with_catalogs(
+        workspace_root,
+        config,
+        pacquet_config::NodeLinker::Isolated,
+        &[(workspace_root.to_path_buf(), &manifest)],
+        false,
+        &current_catalogs,
+    );
+    assert_eq!(decision, Decision::Skipped { reason: "catalogs cache outdated" });
 }
 
 /// `allowBuilds` is the one field where pnpm and pacquet round-trip


### PR DESCRIPTION
## Summary

- detect catalog drift between `pnpm-workspace.yaml` and the lockfile `catalogs:` snapshot
- record and compare catalogs in pacquet's workspace-state fast path so plain `pacquet install` does not skip after catalog edits
- add lockfile, repeat-install, and CLI regression coverage for catalog changes

## Tests

- `cargo test -p pacquet-lockfile check_settings_`
- `cargo test -p pacquet-package-manager returns_outdated_when_workspace_catalog_cache_changes`
- `cargo test -p pacquet-cli --test catalog install_reruns_when_catalog_entry_changes`
- `cargo test -p pacquet-package-manager returns_up_to_date_when_state_carries_unported_pnpm_settings`
- `cargo test -p pacquet-package-manager build_workspace_state_tests`
- `cargo check --locked -p pacquet-lockfile -p pacquet-package-manager -p pacquet-cli --all-targets`
- pre-push hook: TypeScript compile/lint/spellcheck/meta checks, Rust fmt/doc/dylint, taplo format check

No changeset: pacquet Rust-only change.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end and unit tests covering catalog-aware install behavior and cache drift.

* **Bug Fixes**
  * Lockfile freshness now considers workspace catalog configuration.
  * Repeat/optimistic reinstall paths detect catalog cache changes and trigger accurate re-resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->