### PR TITLE
fix(pacquet): preserve deprecated lockfile metadata on reuse

### DIFF
--- a/pacquet/crates/cli/tests/install.rs
+++ b/pacquet/crates/cli/tests/install.rs
@@ -441,6 +441,54 @@ fn peer_shared_through_a_diamond_is_resolved_consistently() {
 }
 
 #[test]
+fn install_preserves_deprecated_lockfile_metadata_when_reusing_resolution() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/deprecated": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_arg("install").assert().success();
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let first = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert!(
+        first.contains("deprecated: This package is deprecated."),
+        "fresh lockfile should record deprecation metadata:\n{first}",
+    );
+
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/deprecated": "1.0.0",
+                "@pnpm.e2e/foo": "100.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("extend package.json");
+
+    new_pacquet_command(&workspace).with_arg("install").assert().success();
+    let second = fs::read_to_string(&lockfile_path).expect("re-read pnpm-lock.yaml");
+    assert!(
+        second.contains("deprecated: This package is deprecated."),
+        "lockfile reuse should preserve deprecation metadata:\n{second}",
+    );
+
+    drop((root, mock_instance)); // cleanup
+}
+
+#[test]
 fn transitive_pending_peer_uses_provider_final_suffix_in_lockfile() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pacquet/crates/resolving-deps-resolver/src/lockfile_reuse.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/lockfile_reuse.rs
@@ -244,6 +244,9 @@ fn synthesize_manifest(
     if let Some(libc) = metadata.libc.as_ref() {
         manifest.insert("libc".to_string(), string_array(libc));
     }
+    if let Some(deprecated) = metadata.deprecated.as_ref() {
+        manifest.insert("deprecated".to_string(), Value::String(deprecated.clone()));
+    }
     // `has_bin: Some(true)` round-trips as a truthy `bin` so the
     // bundled-manifest bin linker sees a non-empty bin set; the exact
     // bin paths live in the store-index bundled manifest the install

--- a/pacquet/crates/resolving-deps-resolver/src/lockfile_reuse/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/lockfile_reuse/tests.rs
@@ -127,6 +127,23 @@ fn synthesized_manifest_carries_peer_metadata() {
 }
 
 #[test]
+fn synthesized_manifest_carries_deprecated_metadata() {
+    let key: PkgNameVerPeer = "left-pad@1.3.0".parse().expect("parse key");
+    let mut metadata = registry_metadata();
+    metadata.deprecated = Some("use String.prototype.padStart()".to_string());
+    let mut lockfile = empty_lockfile();
+    lockfile.packages = Some(HashMap::from([(key.clone(), metadata)]));
+
+    let result =
+        synthesize_reused_result(&lockfile, &key, "left-pad").expect("registry dep is reusable");
+    let manifest = result.manifest.expect("synthesized manifest");
+    assert_eq!(
+        manifest.get("deprecated").and_then(serde_json::Value::as_str),
+        Some("use String.prototype.padStart()"),
+    );
+}
+
+#[test]
 fn does_not_reuse_non_registry_resolutions() {
     let key: PkgNameVerPeer = "pkg-from-tarball@1.0.0".parse().expect("parse key");
     let mut metadata = registry_metadata();


### PR DESCRIPTION
## Summary

- Preserve `deprecated` metadata when pacquet synthesizes a reused registry manifest from an existing lockfile entry.
- Add reuse-layer and CLI install regressions covering deprecated lockfile metadata across a re-install.

## Tests

- `cargo test -p pacquet-resolving-deps-resolver lockfile_reuse`
- `cargo test -p pacquet-cli --test install install_preserves_deprecated_lockfile_metadata_when_reusing_resolution`
- Pre-push hook completed successfully, including TypeScript compile/lint, Rust docs, dylint, and taplo checks.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deprecated package metadata not being preserved when reusing lockfile resolutions during subsequent installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->