### PR TITLE
test: recycle the registry-test worker to fix Jest OOM

### DIFF
--- a/__utils__/jest-config/with-registry/jest-preset.js
+++ b/__utils__/jest-config/with-registry/jest-preset.js
@@ -7,6 +7,15 @@ export default {
   // Unfortunately, this means that if two such tests will run at the same time,
   // they may break each other.
   maxWorkers: 1,
+  // Recycle the test worker once its heap crosses this limit. Under
+  // `--experimental-vm-modules` Jest's VM module registry is never released
+  // between test files, so a long-running process climbs to Node's ~4 GB
+  // old-space ceiling and dies with an out-of-memory FATAL ERROR. Setting a
+  // limit is also what keeps `maxWorkers: 1` from collapsing to in-band
+  // execution (see `shouldRunInBand`): a recyclable worker is spawned instead,
+  // still serial, so the leaked memory is reclaimed between files without
+  // reintroducing the dist-tag races `maxWorkers: 1` prevents.
+  workerIdleMemoryLimit: '1500MB',
   // Force Jest to exit after globalTeardown completes.  The Verdaccio server
   // and lifecycle child-processes spawned during tests may leave ref'd handles
   // that prevent the process from exiting on its own.


### PR DESCRIPTION
## What

Fixes the JavaScript heap **out-of-memory** crash in the `@pnpm/installing.deps-installer` test job (and any other suite using the `with-registry` Jest preset):

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] @pnpm/installing.deps-installer .test
```

## Root cause

The `with-registry` preset sets `maxWorkers: 1` so that registry-mutating tests (dist-tag changes) don't race each other. Jest's `shouldRunInBand` treats `maxWorkers <= 1` as a signal to run **in-band in the main process** — *unless* `workerIdleMemoryLimit` is set:

```js
return (
  // When specifying a memory limit, workers should be used
  !workerIdleMemoryLimit &&
  (oneWorkerOrLess || oneTestOrLess || ...)
)
```

Running in-band means every test file shares one long-lived process. Under `--experimental-vm-modules`, Jest's VM module registry is never released between files, so the process grows until it hits Node's default ~4 GB old-space ceiling and dies.

Sharding the file selection (e.g. `--shard=1/5`) does **not** help: each shard still runs all of its files in a single in-band process.

## Fix

Set `workerIdleMemoryLimit` in the shared `with-registry` preset. This:

1. Flips `shouldRunInBand` to `false`, so Jest runs a worker instead of executing in-band — still a single, serial worker (`maxWorkers: 1` is preserved), so the dist-tag races stay prevented.
2. Recycles that worker once its heap crosses the limit, reclaiming the leaked VM-module memory between files.

## Validation

Ran the `deps-installer` shard that OOMs in CI locally:

- **Before:** the process climbed to ~4 GB and crashed.
- **After:** `Test Suites: 16 passed`, `Tests: 6 skipped, 128 passed`, no OOM. The run logs *"A worker process has failed to exit gracefully and has been force exited"*, confirming execution moved off the in-band path onto a worker.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test worker memory management to enhance stability during test execution and reduce memory-related crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->