### PR TITLE
fix(pacquet): preserve exec bit on copy fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3804,6 +3804,7 @@ dependencies = [
  "miette 7.6.0",
  "pacquet-diagnostics",
  "pacquet-executor",
+ "pacquet-fs",
  "pacquet-package-manifest",
  "pacquet-reporter",
  "pacquet-store-dir",

--- a/pacquet/crates/fs/src/file_mode.rs
+++ b/pacquet/crates/fs/src/file_mode.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{io, path::Path};
 
 /// Bit mask to filter executable bits (`--x--x--x`).
 pub const EXEC_MASK: u32 = 0b001_001_001;
@@ -15,6 +15,16 @@ pub const EXEC_MODE: u32 = 0b111_101_101;
 #[must_use]
 pub fn is_executable(mode: u32) -> bool {
     mode & EXEC_MASK != 0
+}
+
+/// Whether a CAS file path encodes "executable" via the `-exec` suffix
+/// pnpm's CAFS layout uses (see `pacquet_store_dir::StoreDir::cas_file_path`).
+/// Reading the suffix is cheaper than a `stat` and is the only reliable
+/// signal once a blob has been copied out of the store, where the on-disk
+/// mode may have lost its exec bit on a copy / reflink fallback.
+#[must_use]
+pub fn cas_path_is_executable(path: &Path) -> bool {
+    path.file_name().and_then(|name| name.to_str()).is_some_and(|name| name.ends_with("-exec"))
 }
 
 /// Set file mode to 777 on POSIX platforms such as Linux or macOS,

--- a/pacquet/crates/fs/src/file_mode/tests.rs
+++ b/pacquet/crates/fs/src/file_mode/tests.rs
@@ -1,4 +1,5 @@
-use super::{EXEC_MASK, EXEC_MODE, is_executable};
+use super::{EXEC_MASK, EXEC_MODE, cas_path_is_executable, is_executable};
+use std::path::Path;
 
 /// Sanity-pin the two on-disk constants. The mask is `--x--x--x`
 /// and the canonical executable mode is `rwxr-xr-x` — these
@@ -19,6 +20,20 @@ fn is_executable_matches_any_exec_bit() {
     assert!(is_executable(0o755));
     assert!(is_executable(0o050)); // group-only — still executable
     assert!(is_executable(0o001)); // other-only — still executable
+}
+
+/// Only a trailing `-exec` segment on the file name marks a CAS path
+/// executable. The suffix must be exactly the file-name tail pnpm's
+/// CAFS layout writes — a `-exec` elsewhere in the path, or a name that
+/// merely contains the substring, does not count.
+#[test]
+fn cas_path_is_executable_matches_trailing_suffix() {
+    assert!(cas_path_is_executable(Path::new("files/1b/59d9-exec")));
+    assert!(!cas_path_is_executable(Path::new("files/1b/59d9")));
+    // `-exec` only in a parent directory, not the file name.
+    assert!(!cas_path_is_executable(Path::new("files-exec/1b/59d9")));
+    // Substring, not a trailing segment.
+    assert!(!cas_path_is_executable(Path::new("files/1b/59d9-executable")));
 }
 
 /// `make_file_executable` flips the exec bits on a freshly

--- a/pacquet/crates/git-fetcher/Cargo.toml
+++ b/pacquet/crates/git-fetcher/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace  = true
 [dependencies]
 pacquet-diagnostics      = { workspace = true }
 pacquet-executor         = { workspace = true }
+pacquet-fs               = { workspace = true }
 pacquet-package-manifest = { workspace = true }
 pacquet-reporter         = { workspace = true }
 pacquet-store-dir        = { workspace = true }

--- a/pacquet/crates/git-fetcher/src/cas_io.rs
+++ b/pacquet/crates/git-fetcher/src/cas_io.rs
@@ -15,6 +15,7 @@
 //!   import.
 
 use crate::error::GitFetcherError;
+use pacquet_fs::file_mode::{cas_path_is_executable, is_executable};
 use pacquet_store_dir::{CafsFileInfo, StoreDir};
 use std::{
     collections::HashMap,
@@ -110,7 +111,7 @@ pub(crate) fn materialize_into(
         if cas_path_is_executable(cas_path) {
             use std::os::unix::fs::PermissionsExt;
             let mut perms = fs::metadata(&target).map_err(GitFetcherError::Io)?.permissions();
-            perms.set_mode(perms.mode() | 0o111);
+            perms.set_mode(perms.mode() | pacquet_fs::file_mode::EXEC_MASK);
             fs::set_permissions(&target, perms).map_err(GitFetcherError::Io)?;
         }
     }
@@ -144,7 +145,7 @@ pub(crate) fn import_into_cas(
         // `cas_file_path_by_mode` exactly like a tarball entry would.
         let bytes = fs::read(&source).map_err(GitFetcherError::Io)?;
         let size = bytes.len() as u64;
-        let executable = (mode & 0o111) != 0;
+        let executable = is_executable(mode);
         let (cas_path, hash) =
             store_dir.write_cas_file(&bytes, executable).map_err(map_write_cas)?;
         cas_paths.insert(rel.clone(), cas_path);
@@ -178,14 +179,6 @@ fn file_mode_from(meta: &fs::Metadata) -> u32 {
 #[cfg(not(unix))]
 fn file_mode_from(_meta: &fs::Metadata) -> u32 {
     0o644
-}
-
-/// `true` when a CAS file path encodes "executable" via the `-exec`
-/// suffix pnpm's CAFS layout uses. Cheaper than reading filesystem
-/// metadata, and matches the write-side encoding in
-/// [`pacquet_store_dir::StoreDir::cas_file_path`].
-fn cas_path_is_executable(path: &Path) -> bool {
-    path.file_name().and_then(|n| n.to_str()).is_some_and(|n| n.ends_with("-exec"))
 }
 
 /// Synthesize the [`PackageFilesIndex::files`](pacquet_store_dir::PackageFilesIndex::files)

--- a/pacquet/crates/package-manager/src/link_file.rs
+++ b/pacquet/crates/package-manager/src/link_file.rs
@@ -214,11 +214,11 @@ fn try_import<Reporter: self::Reporter>(
                 log_method_once::<Reporter>(logged, LOG_FLAG_HARDLINK, WireImportMethod::Hardlink);
                 Ok(())
             }
-            Err(error) if is_cross_device(&error) => fs::copy(source_file, target_link)
-                .inspect(|_| {
+            Err(error) if is_cross_device(&error) => {
+                copy_file(source_file, target_link).inspect(|()| {
                     log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
                 })
-                .map(drop),
+            }
             Err(error) => Err(error),
         },
         PackageImportMethod::Clone => {
@@ -230,12 +230,33 @@ fn try_import<Reporter: self::Reporter>(
             static CLONE_OR_COPY_STATE: AtomicU8 = AtomicU8::new(LINK_STATE_CLONE);
             clone_or_copy_link::<Reporter>(logged, &CLONE_OR_COPY_STATE, source_file, target_link)
         }
-        PackageImportMethod::Copy => fs::copy(source_file, target_link)
-            .inspect(|_| {
-                log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
-            })
-            .map(drop),
+        PackageImportMethod::Copy => copy_file(source_file, target_link).inspect(|()| {
+            log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
+        }),
     }
+}
+
+/// `fs::copy` plus exec-bit restoration for the copy fallback tier.
+///
+/// `fs::copy` already carries a regular file's mode across on Unix, but
+/// a CAS entry's executable bit can be lost when a copy / reflink
+/// fallback materializes it (observed on overlayfs), leaving a native
+/// binary at `0o644`. The CAS encodes executability purely in the
+/// `-exec` path suffix, so that suffix is the source of truth: when it
+/// is present we re-add the exec bits, mirroring `git-fetcher`'s
+/// `materialize_into`. Non-executable files are left exactly as
+/// `fs::copy` produced them — we never widen their mode and never pay a
+/// `set_permissions` syscall for them.
+fn copy_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
+    fs::copy(source_file, target_link)?;
+    #[cfg(unix)]
+    if pacquet_fs::file_mode::cas_path_is_executable(source_file) {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(target_link)?.permissions();
+        perms.set_mode(perms.mode() | pacquet_fs::file_mode::EXEC_MASK);
+        fs::set_permissions(target_link, perms)?;
+    }
+    Ok(())
 }
 
 /// EXDEV = "cross-device link not permitted". Linux / macOS / BSD all
@@ -323,11 +344,9 @@ fn auto_link<Reporter: self::Reporter>(
                 }
             },
             _ => {
-                return fs::copy(source, target)
-                    .inspect(|_| {
-                        log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
-                    })
-                    .map(drop);
+                return copy_file(source, target).inspect(|()| {
+                    log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
+                });
             }
         }
     }
@@ -358,11 +377,9 @@ fn clone_or_copy_link<Reporter: self::Reporter>(
                 }
             },
             _ => {
-                return fs::copy(source, target)
-                    .inspect(|_| {
-                        log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
-                    })
-                    .map(drop);
+                return copy_file(source, target).inspect(|()| {
+                    log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
+                });
             }
         }
     }

--- a/pacquet/crates/package-manager/src/link_file/tests.rs
+++ b/pacquet/crates/package-manager/src/link_file/tests.rs
@@ -45,6 +45,49 @@ fn copy_materializes_the_file_contents() {
     let _ = (src_ino, dst_ino);
 }
 
+/// A CAS entry stored as executable carries the `-exec` suffix in its
+/// store path. Copying it out must land an executable file even when
+/// the copy tier dropped the exec bit (overlayfs etc.) — the suffix is
+/// the source of truth, so the copied binary ends up `0o755`.
+#[test]
+#[cfg(unix)]
+fn copy_restores_executable_mode_from_cas_suffix() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "1b59d9-exec", b"#!/usr/bin/env node\n");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o644)).unwrap();
+    let dst = tmp.path().join("nested/dst");
+    fs::create_dir_all(dst.parent().unwrap()).unwrap();
+
+    link_file::<SilentReporter>(&AtomicU8::new(0), PackageImportMethod::Copy, &src, &dst)
+        .expect("copy should restore executable CAS mode");
+
+    let dst_mode = fs::metadata(&dst).unwrap().permissions().mode() & 0o777;
+    assert_eq!(dst_mode, 0o755, "copied executable file must stay executable");
+}
+
+/// A non-executable CAS entry has no `-exec` suffix, so the copy must
+/// leave its mode untouched. Guards against widening permissions on the
+/// restrictive end — a `0o600` source stays `0o600`, never `0o711`.
+#[test]
+#[cfg(unix)]
+fn copy_does_not_widen_non_exec_mode() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "1b59d9", b"private data\n");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o600)).unwrap();
+    let dst = tmp.path().join("nested/dst");
+    fs::create_dir_all(dst.parent().unwrap()).unwrap();
+
+    link_file::<SilentReporter>(&AtomicU8::new(0), PackageImportMethod::Copy, &src, &dst)
+        .expect("copy should succeed");
+
+    let dst_mode = fs::metadata(&dst).unwrap().permissions().mode() & 0o777;
+    assert_eq!(dst_mode, 0o600, "non-executable file must not gain exec bits");
+}
+
 /// Hardlinking in the same directory on the same filesystem works on
 /// every mainstream OS the project supports. We verify the post-link
 /// inodes match (on unix) or that the contents match (otherwise).


### PR DESCRIPTION
## Summary

Fixes #12171.

pacquet stores executable CAFS entries under paths ending in `-exec`, but the copy fallback tier in `link_file.rs` materialized them without the executable bit. When hardlink/reflink isn't available and the install falls back to `fs::copy` (e.g. overlayfs on CI), a native binary such as `@esbuild/linux-x64/bin/esbuild` lands at `0o644` and fails to spawn with `EACCES`.

This routes all copy-tier imports through one `copy_file` helper. On Unix, when the CAS source path ends with `-exec`, it OR-s the exec bits onto the copied file, mirroring `git-fetcher`'s existing `materialize_into`. Non-executable files are left exactly as `fs::copy` produced them.

#12177 (closed) took the same direction but re-read and re-applied the source's full mode to every copied file. This version only touches files the store marked executable (`-exec` suffix), so it never widens a restrictive mode (e.g. `0o600` → `0o711`) and adds no `set_permissions` syscall on the non-exec majority. Rather than duplicate that logic, the `-exec` check now lives in a shared `pacquet_fs::file_mode::cas_path_is_executable` that both copy paths call, replacing the private copy in `cas_io.rs`.

This is a pacquet-only bug. pnpm preserves the exec bit on its own copy path, so no pnpm-side change is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Executable file permissions are now properly preserved during package import operations. Files marked as executable in the package cache are correctly restored with appropriate executable permissions when copied to the system, while non-executable files retain their original permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->