### PR TITLE
test(deps-installer): isolate the heavy deepRecursive test in its own process

### DIFF
--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -333,7 +333,6 @@ const yamlTextFormat = createFormat<string>({
   },
 })
 
-const depsInstallerTestShardCount = 5
 const registryMockPortForCore = 7769
 
 async function updateManifest (workspaceDir: string, manifest: ProjectManifest, dir: string, nextTag: string): Promise<ProjectManifest> {
@@ -369,8 +368,19 @@ async function updateManifest (workspaceDir: string, manifest: ProjectManifest, 
       if (manifest.name === '@pnpm/installing.deps-installer') {
       // @pnpm/installing.deps-installer tests currently works only with port 7769 due to the usage of
       // the next package: pkg-with-tarball-dep-from-registry
-        scripts['.test'] = Array.from({ length: depsInstallerTestShardCount }, (_, index) => `pn .test:shard --shard=${index + 1}/${depsInstallerTestShardCount}`).join(' && ')
-        scripts['.test:shard'] = `cross-env PNPM_REGISTRY_MOCK_PORT=${registryMockPortForCore} NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" jest`
+      //
+      // deepRecursive resolves @teambit/bit's enormous circular/peer graph and
+      // needs ~3.6 GB on its own — enough to fit Node's default ~4 GB heap, but
+      // not with the memory the other test files leave behind in the same
+      // process (Jest's `--experimental-vm-modules` registry isn't reclaimed
+      // between files). Run it in a dedicated jest process (`.test:heavy`) so it
+      // gets the whole heap to itself, and run the rest (`.test:rest`) in a
+      // separate process with it excluded.
+        const heavyTestPath = 'test/install/deepRecursive.ts'
+        const testEnv = `cross-env PNPM_REGISTRY_MOCK_PORT=${registryMockPortForCore} NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169"`
+        scripts['.test'] = 'pn .test:heavy && pn .test:rest'
+        scripts['.test:heavy'] = `${testEnv} jest ${heavyTestPath}`
+        scripts['.test:rest'] = `${testEnv} jest "^(?!.*deepRecursive)"`
       } else {
         scripts['.test'] = 'cross-env NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" jest'
       }

--- a/__utils__/jest-config/with-registry/jest-preset.js
+++ b/__utils__/jest-config/with-registry/jest-preset.js
@@ -7,15 +7,6 @@ export default {
   // Unfortunately, this means that if two such tests will run at the same time,
   // they may break each other.
   maxWorkers: 1,
-  // Recycle the test worker once its heap crosses this limit. Under
-  // `--experimental-vm-modules` Jest's VM module registry is never released
-  // between test files, so a long-running process climbs to Node's ~4 GB
-  // old-space ceiling and dies with an out-of-memory FATAL ERROR. Setting a
-  // limit is also what keeps `maxWorkers: 1` from collapsing to in-band
-  // execution (see `shouldRunInBand`): a recyclable worker is spawned instead,
-  // still serial, so the leaked memory is reclaimed between files without
-  // reintroducing the dist-tag races `maxWorkers: 1` prevents.
-  workerIdleMemoryLimit: '1500MB',
   // Force Jest to exit after globalTeardown completes.  The Verdaccio server
   // and lifecycle child-processes spawned during tests may leave ref'd handles
   // that prevent the process from exiting on its own.

--- a/installing/deps-installer/package.json
+++ b/installing/deps-installer/package.json
@@ -53,8 +53,9 @@
     "test": "pn compile && pn .test",
     "prepublishOnly": "tsgo --build",
     "compile": "tsgo --build && pn lint --fix",
-    ".test": "pn .test:shard --shard=1/5 && pn .test:shard --shard=2/5 && pn .test:shard --shard=3/5 && pn .test:shard --shard=4/5 && pn .test:shard --shard=5/5",
-    ".test:shard": "cross-env PNPM_REGISTRY_MOCK_PORT=7769 NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
+    ".test": "pn .test:heavy && pn .test:rest",
+    ".test:heavy": "cross-env PNPM_REGISTRY_MOCK_PORT=7769 NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest test/install/deepRecursive.ts",
+    ".test:rest": "cross-env PNPM_REGISTRY_MOCK_PORT=7769 NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest \"^(?!.*deepRecursive)\""
   },
   "dependencies": {
     "@inquirer/prompts": "catalog:",


### PR DESCRIPTION
## Problem

`@pnpm/installing.deps-installer` OOMs in CI (`FATAL ERROR: Reached heap limit Allocation failed`) in the shard that runs `test/install/deepRecursive.ts`, which resolves `@teambit/bit@0.0.745` — an enormous circular + peer-dependency graph — from the live registry.

## Root cause (reproduced in a CI-faithful container)

I couldn't reproduce this on macOS/Node-24 (it uses less heap there, and my default heap is actually *smaller* than CI's). Reproduced it in a `linux/amd64` + `node:22.13.0` container (CI's exact platform, default heap **4144 MB**, matching CI):

| Environment | `deepRecursive` peak RSS | Default heap |
|---|---|---|
| macOS / Node 24 / arm64 | ~3.19 GB | 3192 MB |
| **Linux / Node 22 / amd64 (= CI)** | **~3.6 GB** | **4144 MB** |

So `deepRecursive` needs ~3.6 GB on CI — it **fits** the default 4 GB heap on its own (passes), but **not** with the memory the other ~14 test files in its shard leave behind in the same jest process (jest's `--experimental-vm-modules` registry isn't reclaimed between files). That overflow is the OOM. There is **no recent code regression** — peak memory is unchanged across the last 30 commits; the live graph simply grew until `deepRecursive` + accumulation crossed 4 GB.

## Fix

Run `deepRecursive` in a **dedicated jest process** (`.test:heavy`) so it gets the whole default heap to itself, and run the rest (`.test:rest`) in a separate process with it excluded (negative-lookahead path pattern). The two runs cover every test file exactly once (verified: 1 + 75 = 76).

Crucially, **no `--max-old-space-size` bump** — every run stays within Node's default ~4 GB, matching the budget pnpm has in production. `deepRecursive` alone passing at the default heap was confirmed in the container.

Because `deepRecursive` was the sole culprit, the two earlier OOM workarounds are **reverted** as unnecessary:
- the 5-way sharding of the deps-installer suite, and
- `workerIdleMemoryLimit` in the `with-registry` jest preset.

## Caveat

`deepRecursive`'s ~3.6 GB leaves ~0.5 GB of margin under the 4 GB default. Since it resolves a *live, growing* graph, if it later exceeds 4 GB on its own that's a real pnpm problem (it would OOM in production too), to be fixed by reducing resolver memory — not by raising the limit.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test execution infrastructure with optimized test partitioning strategy for improved performance and resource efficiency
  * Streamlined Jest configuration settings for improved test execution stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->