### PR TITLE
ci: run clippy as a single-OS job and add it to the pre-push hook

### DIFF
--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -70,11 +70,11 @@ jobs:
         with:
           persist-credentials: false
 
-      # The clippy --all-targets pass plus the nextest build hold two
-      # full sets of debug artifacts in target/, which no longer fits
-      # in the hosted runner's free disk — the linker dies with ENOSPC
-      # / SIGBUS mid-build. Drop the preinstalled toolchains this job
-      # never uses (~25 GB) before compiling anything.
+      # The nextest build holds a full set of debug artifacts in
+      # target/, which no longer fits in the hosted runner's free disk —
+      # the linker dies with ENOSPC / SIGBUS mid-build. Drop the
+      # preinstalled toolchains this job never uses (~25 GB) before
+      # compiling anything.
       - name: Free up runner disk space
         if: runner.os == 'Linux'
         run: |
@@ -84,7 +84,6 @@ jobs:
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
         with:
-          clippy: true
           save-cache: ${{ github.ref_name == 'main' }}
 
       - name: Install pnpm (for compatibility check)
@@ -104,9 +103,6 @@ jobs:
             ${{ env.HOME }}/.local/share/pnpm/store/v11
         timeout-minutes: 1
         continue-on-error: true
-
-      - name: Clippy
-        run: cargo clippy --locked --workspace --all-targets -- -D warnings
 
       - name: Install just
         uses: taiki-e/install-action@873c7452cadb7c034694a1282227095d93fbdf92 # v2.79.14
@@ -130,6 +126,35 @@ jobs:
           unset XDG_DATA_HOME
 
           just test
+
+  clippy:
+    name: Clippy
+    # Clippy lints the same source on every platform, so one OS is
+    # enough — running the full `--all-targets` workspace lint across the
+    # whole test matrix just triples the cost. Mirrors the single-OS doc,
+    # format, and dylint jobs. (Platform-gated `#[cfg]` blocks are still
+    # type-checked per-OS by the test job's build.)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # `clippy --all-targets` over the whole workspace holds a full set
+      # of debug artifacts in target/; drop the preinstalled toolchains
+      # this job never uses (~25 GB) so the linker doesn't hit ENOSPC.
+      - name: Free up runner disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h /
+
+      - name: Install Rust Toolchain
+        uses: ./.github/actions/rustup
+        with:
+          clippy: true
+
+      - name: Clippy
+        run: cargo clippy --locked --workspace --all-targets -- -D warnings
 
   doc:
     name: Doc

--- a/pacquet/AGENTS.md
+++ b/pacquet/AGENTS.md
@@ -380,8 +380,9 @@ are part of the public contract, not implementation detail. See
 - Reference the upstream pnpm commit/PR you ported from, when applicable.
 - Run `just ready` before pushing.
 - The repo-wide husky `pre-push` hook runs `pacquet/scripts/pre-push-rust.sh`,
-  which checks `rustfmt`, `taplo`, `cargo doc` (with
-  `RUSTDOCFLAGS=-D warnings`), and `cargo dylint`. Make sure your environment
+  which checks `rustfmt`, `taplo`, `cargo clippy` (with `--all-targets -D
+  warnings`), `cargo doc` (with `RUSTDOCFLAGS=-D warnings`), and `cargo
+  dylint`. Make sure your environment
   can run cargo (the hook needs it) before pushing; `cargo-dylint` is
   detected at runtime and skipped with a warning if not installed.
 

--- a/pacquet/scripts/pre-push-rust.sh
+++ b/pacquet/scripts/pre-push-rust.sh
@@ -15,6 +15,16 @@ if command -v cargo >/dev/null 2>&1; then
         failed=1
     fi
 
+    # Mirror the CI clippy gate. `--all-targets` is the load-bearing flag:
+    # without it clippy skips the test and bench crates, so a lint that
+    # only fires in an integration test slips past `cargo clippy -p <crate>`
+    # and surfaces for the first time in CI.
+    yellow '▸ cargo clippy --all-targets --workspace -- -D warnings'
+    if ! cargo clippy --all-targets --workspace -- -D warnings; then
+        red '✗ cargo clippy reported lints — fix the findings (or `just lint`) and commit.'
+        failed=1
+    fi
+
     yellow '▸ RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --all-features'
     if ! RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace --all-features --quiet; then
         red '✗ cargo doc reported warnings — fix the rustdoc diagnostics and commit.'

--- a/pnpr/crates/pnpr/tests/batch_publish.rs
+++ b/pnpr/crates/pnpr/tests/batch_publish.rs
@@ -31,18 +31,18 @@ async fn body_json(body: Body) -> Value {
     serde_json::from_slice(&body_bytes(body).await).expect("body parses as JSON")
 }
 
-fn put_json(path: &str, body: Value) -> Request<Body> {
+fn put_json(path: &str, body: &Value) -> Request<Body> {
     Request::put(path)
         .header("content-type", "application/json")
-        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .body(Body::from(serde_json::to_vec(body).unwrap()))
         .unwrap()
 }
 
-fn put_json_with_token(path: &str, body: Value, token: &str) -> Request<Body> {
+fn put_json_with_token(path: &str, body: &Value, token: &str) -> Request<Body> {
     Request::put(path)
         .header("content-type", "application/json")
         .header("Authorization", format!("Bearer {token}"))
-        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .body(Body::from(serde_json::to_vec(body).unwrap()))
         .unwrap()
 }
 
@@ -56,7 +56,7 @@ async fn add_user_and_get_token(app: axum::Router, username: &str, password: &st
         "type": "user",
         "roles": [],
     });
-    let response = app.oneshot(put_json(&path, body)).await.unwrap();
+    let response = app.oneshot(put_json(&path, &body)).await.unwrap();
     assert_eq!(response.status(), StatusCode::CREATED);
     let payload = body_json(response.into_body()).await;
     payload["token"].as_str().expect("token in response").to_string()
@@ -106,8 +106,11 @@ async fn batch_publish_writes_every_package_in_one_request() {
             publish_doc("batch-b", "2.0.0", bytes_b),
         ],
     });
-    let response =
-        app.clone().oneshot(put_json_with_token("/-/pnpm/v1/publish", body, &token)).await.unwrap();
+    let response = app
+        .clone()
+        .oneshot(put_json_with_token("/-/pnpm/v1/publish", &body, &token))
+        .await
+        .unwrap();
     assert_eq!(response.status(), StatusCode::CREATED);
     let payload = body_json(response.into_body()).await;
     assert_eq!(payload["ok"], true);
@@ -175,8 +178,11 @@ async fn batch_publish_supports_scoped_packages_with_libnpmpublish_attachment_na
             },
         }],
     });
-    let response =
-        app.clone().oneshot(put_json_with_token("/-/pnpm/v1/publish", body, &token)).await.unwrap();
+    let response = app
+        .clone()
+        .oneshot(put_json_with_token("/-/pnpm/v1/publish", &body, &token))
+        .await
+        .unwrap();
     assert_eq!(response.status(), StatusCode::CREATED);
 
     // On disk: canonical `<basename>-<version>.tgz` under the scope dir.
@@ -215,7 +221,7 @@ async fn anonymous_batch_publish_is_rejected() {
     let app = router(static_config(storage.clone()));
 
     let body = json!({ "packages": [publish_doc("anon-batch", "1.0.0", b"bytes")] });
-    let response = app.oneshot(put_json("/-/pnpm/v1/publish", body)).await.unwrap();
+    let response = app.oneshot(put_json("/-/pnpm/v1/publish", &body)).await.unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     assert!(!storage.join("anon-batch").exists());
 }
@@ -236,7 +242,7 @@ async fn batch_publish_rolls_back_every_package_when_one_fails_integrity() {
 
     let body = json!({ "packages": [good, bad] });
     let response =
-        app.oneshot(put_json_with_token("/-/pnpm/v1/publish", body, &token)).await.unwrap();
+        app.oneshot(put_json_with_token("/-/pnpm/v1/publish", &body, &token)).await.unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     let body_text = String::from_utf8(body_bytes(response.into_body()).await).unwrap();
     assert!(body_text.contains("EINTEGRITY"), "error should carry EINTEGRITY: {body_text}");
@@ -270,7 +276,7 @@ async fn batch_publish_rejects_duplicate_package_names() {
         ],
     });
     let response =
-        app.oneshot(put_json_with_token("/-/pnpm/v1/publish", body, &token)).await.unwrap();
+        app.oneshot(put_json_with_token("/-/pnpm/v1/publish", &body, &token)).await.unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     let body_text = String::from_utf8(body_bytes(response.into_body()).await).unwrap();
     assert!(body_text.contains("duplicate package"), "got: {body_text}");
@@ -286,7 +292,7 @@ async fn batch_publish_rejects_bodies_without_a_packages_array() {
     for body in [json!({}), json!({ "packages": [] }), json!({ "packages": "nope" }), json!([])] {
         let response = app
             .clone()
-            .oneshot(put_json_with_token("/-/pnpm/v1/publish", body.clone(), &token))
+            .oneshot(put_json_with_token("/-/pnpm/v1/publish", &body, &token))
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST, "body: {body}");
@@ -301,7 +307,7 @@ async fn batch_publish_rejects_entries_without_a_name() {
 
     let body = json!({ "packages": [{ "versions": {} }] });
     let response =
-        app.oneshot(put_json_with_token("/-/pnpm/v1/publish", body, &token)).await.unwrap();
+        app.oneshot(put_json_with_token("/-/pnpm/v1/publish", &body, &token)).await.unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
@@ -317,14 +323,14 @@ async fn batch_publish_merges_with_previously_published_versions() {
     let first = json!({ "packages": [publish_doc("merge-pkg", "1.0.0", b"v1")] });
     let response = app
         .clone()
-        .oneshot(put_json_with_token("/-/pnpm/v1/publish", first, &token))
+        .oneshot(put_json_with_token("/-/pnpm/v1/publish", &first, &token))
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::CREATED);
 
     let second = json!({ "packages": [publish_doc("merge-pkg", "2.0.0", b"v2")] });
     let response =
-        app.oneshot(put_json_with_token("/-/pnpm/v1/publish", second, &token)).await.unwrap();
+        app.oneshot(put_json_with_token("/-/pnpm/v1/publish", &second, &token)).await.unwrap();
     assert_eq!(response.status(), StatusCode::CREATED);
 
     let packument: Value =


### PR DESCRIPTION
## What

After pnpm/pnpm#12299 merged, the Pacquet CI `Clippy` step failed on `main` with a `clippy::needless_pass_by_value` lint in a pnpr integration test. This PR fixes that lint and closes the two process gaps that let it reach `main`.

## Why it slipped through

- **Clippy wasn't in the pre-push hook.** `pacquet/scripts/pre-push-rust.sh` ran `rustfmt`, `taplo`, `cargo doc`, and `cargo dylint` — but never `cargo clippy`. So a clippy lint could only be caught in CI.
- **A local `cargo clippy -p <crate>` doesn't catch it.** The failing lint only fires under `--all-targets` (it's in a `tests/` crate). Without that flag, integration-test lints are invisible locally.

## Changes

1. **Fix the lint** (`pnpr/crates/pnpr/tests/batch_publish.rs`): the `put_json` / `put_json_with_token` test helpers took the JSON body by value but only borrowed it for `serde_json::to_vec`. Take `&Value` instead (also drops an unnecessary `body.clone()`).

2. **Add clippy to the pre-push hook** with the load-bearing `--all-targets --workspace -- -D warnings`, so the same lint CI runs is enforced before a push.

3. **Run clippy as its own single-OS job.** Clippy was a step inside the three-OS `Lint and Test` matrix, so it ran once per OS (windows + ubuntu + macos) even though it lints the same platform-independent source each time. Move it to a dedicated `ubuntu-latest` job, mirroring the existing single-OS `doc`, `format`, and `dylint` jobs. Platform-gated `#[cfg]` blocks are still type-checked per-OS by the matrix test build.

4. Update the `pacquet/AGENTS.md` description of what the hook checks.

## Verification

Locally, all pre-push Rust gates pass on this branch: `cargo fmt --check`, `cargo clippy --all-targets --workspace -- -D warnings`, `cargo doc -D warnings`, and `cargo dylint`. The `batch_publish` integration tests still pass (8/8).

## Notes

- No changeset: this only touches pnpr test code, CI, the git hook, and docs — no published package change.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized code quality checks in CI pipeline with dedicated Clippy job
  * Added Clippy linting to pre-push development workflow

* **Documentation**
  * Updated development workflow documentation to reflect Clippy requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->