### PR TITLE
fix(installing.commands): show only package names in interactive checkbox summary

### DIFF
--- a/.changeset/fix-interactive-prompt-summary.md
+++ b/.changeset/fix-interactive-prompt-summary.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.commands": patch
+"@pnpm/deps.compliance.commands": patch
+"pnpm": patch
+---
+
+Fix garbled summary line after submitting `pnpm update -i` and `pnpm audit --fix -i`. The interactive checkbox prompt previously printed every selected choice's full table row (label, current/target versions, workspace, URL) joined by commas, producing a wall of text after pressing Enter. The summary now lists only the selected package names (or vulnerability keys) by setting an explicit `short` per choice; the in-progress selection UI is unchanged.

--- a/deps/compliance/commands/src/audit/audit.ts
+++ b/deps/compliance/commands/src/audit/audit.ts
@@ -468,7 +468,7 @@ async function interactiveAuditFix (auditReport: AuditReport): Promise<AuditRepo
     return auditReport
   }
 
-  const flatChoices: Array<Separator | { name: string; value: string; disabled?: boolean | string }> = []
+  const flatChoices: Array<Separator | { name: string; value: string; short: string; disabled?: boolean | string }> = []
   for (const group of choiceGroups) {
     flatChoices.push(new Separator(chalk.bold(`── ${group.message} ──`)))
     for (const choice of group.choices) {
@@ -478,6 +478,11 @@ async function interactiveAuditFix (auditReport: AuditReport): Promise<AuditRepo
         flatChoices.push({
           name: choice.message,
           value: choice.value,
+          // Same shape as the update prompt: `name` is the rendered table
+          // row, but the post-submission line uses `short` per choice.
+          // Without this, every selected row's full table dump is comma-
+          // joined back to stdout.
+          short: choice.value,
         })
       }
     }

--- a/installing/commands/src/update/index.ts
+++ b/installing/commands/src/update/index.ts
@@ -228,7 +228,7 @@ async function interactiveUpdate (
     return 'All of your dependencies are already up to date inside the specified ranges. Use the --latest option to update the ranges in package.json'
   }
 
-  const flatChoices: Array<Separator | { name: string; value: string; disabled?: boolean | string }> = []
+  const flatChoices: Array<Separator | { name: string; value: string; short: string; disabled?: boolean | string }> = []
   for (const group of choiceGroups) {
     flatChoices.push(new Separator(chalk.bold(`── ${group.message} ──`)))
     for (const choice of group.choices) {
@@ -238,6 +238,11 @@ async function interactiveUpdate (
         flatChoices.push({
           name: choice.message,
           value: choice.value,
+          // `name` is the rendered table row (label + versions + workspace + url)
+          // that lays out a single choice during selection. After submission
+          // @inquirer/prompts comma-joins each choice's `short`, which without
+          // this defaults to `name` and dumps the whole table back to stdout.
+          short: choice.value,
         })
       }
     }

--- a/installing/commands/test/update/interactive.ts
+++ b/installing/commands/test/update/interactive.ts
@@ -116,10 +116,12 @@ test('interactively update', async () => {
     {
       name: `is-negative                                                  1.0.0 ❯ 1.0.${chalk.greenBright.bold('1')}                 `,
       value: 'is-negative',
+      short: 'is-negative',
     },
     {
       name: `micromatch                                                   3.0.0 ❯ 3.${chalk.yellowBright.bold('1.10')}                `,
       value: 'micromatch',
+      short: 'micromatch',
     },
   ])
   expect(mockCheckbox).toHaveBeenCalledWith(
@@ -165,14 +167,17 @@ test('interactively update', async () => {
     {
       name: `is-negative                                                  1.0.1 ❯ ${chalk.redBright.bold('2.1.0')}                 `,
       value: 'is-negative',
+      short: 'is-negative',
     },
     {
       name: `is-positive                                                  2.0.0 ❯ ${chalk.redBright.bold('3.1.0')}                 `,
       value: 'is-positive',
+      short: 'is-positive',
     },
     {
       name: `micromatch                                                   3.0.0 ❯ ${chalk.redBright.bold('4.0.0')}                 `,
       value: 'micromatch',
+      short: 'micromatch',
     },
   ])
   expect(mockCheckbox).toHaveBeenCalledWith(
@@ -311,6 +316,7 @@ test('interactively update should ignore dependencies from the ignoreDependencie
       {
         name: `micromatch                                                   3.0.0 ❯ 3.${chalk.yellowBright.bold('1.10')}                `,
         value: 'micromatch',
+        short: 'micromatch',
       },
     ]
   )


### PR DESCRIPTION
Closes pnpm/pnpm#12386. Regression introduced by pnpm/pnpm#11942 when `enquirer` was replaced with `@inquirer/prompts`.

`@inquirer/prompts`'s `checkbox` defaults the post-submission summary line to `selected.map(c => c.short ?? c.name).join(', ')`. The update and audit prompts pass the rendered table row as `name` (label + current/target versions + workspace + URL) so the choice list lays out cleanly during selection, but with no explicit `short` per choice that same long string was being comma-joined back to stdout after pressing Enter — exactly the "garbled wall of text" the report shows.

The fix is to set `short` to the choice's `value` for both prompts: the bare package name for `pnpm update -i` and `module_name@vulnerable_versions` for `pnpm audit --fix -i`. The selection UI is unchanged.

```diff
- ✔ Choose which packages to update (...)
-   ...
- Enter to start updating. Ctrl-c to cancel. @angular-devkit/build-angular  21.2.14 ❯ 21.2.15  my-workspace  https://github.com/angular/angular-cli
-    , @angular-devkit/core  21.2.14 ❯ 21.2.15  my-workspace  ...
+ ✔ Choose which packages to update (...) @angular-devkit/build-angular, @angular-devkit/core, @angular-devkit/schematics, ...
```

This matches Option A in the issue (show selected package names). Option B (show nothing) is also reachable through `theme.style.renderSelectedChoices`, but Option A keeps confirmation feedback for what was selected and is the smallest delta.

Files touched:

- `installing/commands/src/update/index.ts`
- `deps/compliance/commands/src/audit/audit.ts`
- `installing/commands/test/update/interactive.ts` — updated the existing `toStrictEqual` choice fixtures to include the new `short` field. The unrelated `pnpm audit --fix -i` test (`deps/compliance/commands/test/audit/interactiveFix.ts`) only filters by `c.value`, so it's untouched.

Changeset: patch bump for `@pnpm/installing.commands`, `@pnpm/deps.compliance.commands`, and `pnpm`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed verbose summary output displayed after running interactive commands like `pnpm update -i` and `pnpm audit --fix -i`. The summary now shows a concise list of selected packages or vulnerabilities instead of excessive row-by-row details, improving readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->