### PR TITLE
fix: sync pacquet lockfile output with pnpm

### DIFF
--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -311,11 +311,9 @@ impl CliArgs {
                 // for a single-package repo. Owned so it doesn't hold a
                 // borrow of `cfg` across the `&mut` `updateConfig` pass.
                 let config_root = cfg.workspace_dir.clone().unwrap_or_else(|| dir.clone());
-                let package_manager_version = package_manager_version_to_sync(
-                    &config_root.join("package.json"),
-                    &config_root,
-                )
-                .wrap_err("read package manager policy")?;
+                let package_manager_to_sync =
+                    package_manager_to_sync(&config_root.join("package.json"), &config_root)
+                        .wrap_err("read package manager policy")?;
                 // Resolve + install configurational dependencies, then run
                 // their `updateConfig` plugin hooks, before the main
                 // install. The env lockfile must land at the top of
@@ -325,11 +323,12 @@ impl CliArgs {
                 // it. Mirrors pnpm running both at config-finalization.
                 match reporter {
                     ReporterType::Ndjson => {
-                        if let Some(pnpm_version) = package_manager_version.as_deref() {
+                        if let Some(pm) = package_manager_to_sync.as_ref() {
                             config_deps::sync_package_manager_dependencies(
                                 cfg,
                                 &config_root,
-                                pnpm_version,
+                                &pm.specifier,
+                                &pm.version,
                                 frozen_lockfile,
                             )
                             .await?;
@@ -348,11 +347,12 @@ impl CliArgs {
                         args.run::<NdjsonReporter>(state).await?;
                     }
                     ReporterType::Silent => {
-                        if let Some(pnpm_version) = package_manager_version.as_deref() {
+                        if let Some(pm) = package_manager_to_sync.as_ref() {
                             config_deps::sync_package_manager_dependencies(
                                 cfg,
                                 &config_root,
-                                pnpm_version,
+                                &pm.specifier,
+                                &pm.version,
                                 frozen_lockfile,
                             )
                             .await?;
@@ -422,10 +422,16 @@ struct WantedPackageManager {
     on_fail: Option<String>,
 }
 
-fn package_manager_version_to_sync(
+#[derive(Debug, PartialEq, Eq)]
+struct PackageManagerToSync {
+    specifier: String,
+    version: String,
+}
+
+fn package_manager_to_sync(
     manifest_path: &Path,
     root_dir: &Path,
-) -> miette::Result<Option<String>> {
+) -> miette::Result<Option<PackageManagerToSync>> {
     let Some(manifest) = read_manifest_json(manifest_path)? else {
         return Ok(None);
     };
@@ -442,9 +448,11 @@ fn package_manager_version_to_sync(
     if let Some(version) =
         source_version.filter(|version| version_satisfies(version, wanted_version))
     {
-        return Ok(Some(version));
+        return Ok(Some(PackageManagerToSync { specifier: wanted_version.to_string(), version }));
     }
-    Ok(exact_version(wanted_version).filter(|version| version_satisfies(version, wanted_version)))
+    Ok(exact_version(wanted_version)
+        .filter(|version| version_satisfies(version, wanted_version))
+        .map(|version| PackageManagerToSync { specifier: wanted_version.to_string(), version }))
 }
 
 fn read_manifest_json(path: &Path) -> miette::Result<Option<Value>> {

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -25,7 +25,12 @@ use pacquet_package_manifest::PackageManifest;
 use pacquet_reporter::{NdjsonReporter, Reporter, SilentReporter};
 use remove::RemoveArgs;
 use run::RunArgs;
-use std::path::PathBuf;
+use serde_json::Value;
+use std::{
+    fs,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
 use store::StoreCommand;
 use update::UpdateArgs;
 
@@ -306,6 +311,11 @@ impl CliArgs {
                 // for a single-package repo. Owned so it doesn't hold a
                 // borrow of `cfg` across the `&mut` `updateConfig` pass.
                 let config_root = cfg.workspace_dir.clone().unwrap_or_else(|| dir.clone());
+                let package_manager_version = package_manager_version_to_sync(
+                    &config_root.join("package.json"),
+                    &config_root,
+                )
+                .wrap_err("read package manager policy")?;
                 // Resolve + install configurational dependencies, then run
                 // their `updateConfig` plugin hooks, before the main
                 // install. The env lockfile must land at the top of
@@ -315,6 +325,15 @@ impl CliArgs {
                 // it. Mirrors pnpm running both at config-finalization.
                 match reporter {
                     ReporterType::Ndjson => {
+                        if let Some(pnpm_version) = package_manager_version.as_deref() {
+                            config_deps::sync_package_manager_dependencies(
+                                cfg,
+                                &config_root,
+                                pnpm_version,
+                                frozen_lockfile,
+                            )
+                            .await?;
+                        }
                         config_deps::install_config_deps::<NdjsonReporter>(
                             cfg,
                             &config_root,
@@ -329,6 +348,15 @@ impl CliArgs {
                         args.run::<NdjsonReporter>(state).await?;
                     }
                     ReporterType::Silent => {
+                        if let Some(pnpm_version) = package_manager_version.as_deref() {
+                            config_deps::sync_package_manager_dependencies(
+                                cfg,
+                                &config_root,
+                                pnpm_version,
+                                frozen_lockfile,
+                            )
+                            .await?;
+                        }
                         config_deps::install_config_deps::<SilentReporter>(
                             cfg,
                             &config_root,
@@ -384,6 +412,164 @@ impl CliArgs {
 
         Ok(())
     }
+}
+
+#[derive(Debug)]
+struct WantedPackageManager {
+    name: String,
+    version: Option<String>,
+    from_dev_engines: bool,
+    on_fail: Option<String>,
+}
+
+fn package_manager_version_to_sync(
+    manifest_path: &Path,
+    root_dir: &Path,
+) -> miette::Result<Option<String>> {
+    let Some(manifest) = read_manifest_json(manifest_path)? else {
+        return Ok(None);
+    };
+    let Some(pm) = wanted_package_manager(&manifest) else {
+        return Ok(None);
+    };
+    let Some(wanted_version) = pm.version.as_deref() else {
+        return Ok(None);
+    };
+    if pm.name != "pnpm" || !should_persist_package_manager_lockfile(&pm) {
+        return Ok(None);
+    }
+    let source_version = current_source_pnpm_version().or_else(|| pnpm_version_from(root_dir));
+    if let Some(version) =
+        source_version.filter(|version| version_satisfies(version, wanted_version))
+    {
+        return Ok(Some(version));
+    }
+    Ok(exact_version(wanted_version).filter(|version| version_satisfies(version, wanted_version)))
+}
+
+fn read_manifest_json(path: &Path) -> miette::Result<Option<Value>> {
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).into_diagnostic(),
+    };
+    serde_json::from_str(&content).into_diagnostic().map(Some)
+}
+
+fn wanted_package_manager(manifest: &Value) -> Option<WantedPackageManager> {
+    if let Some(mut pm) = parse_dev_engines_package_manager(manifest) {
+        if pm.version.as_deref().is_some_and(|version| node_semver::Range::parse(version).is_err())
+        {
+            pm.version = None;
+        }
+        return Some(pm);
+    }
+    let package_manager = manifest.get("packageManager")?.as_str()?;
+    let (name, version) = parse_package_manager(package_manager);
+    let version = version.and_then(|version| exact_version(&version));
+    Some(WantedPackageManager { name, version, from_dev_engines: false, on_fail: None })
+}
+
+fn parse_dev_engines_package_manager(manifest: &Value) -> Option<WantedPackageManager> {
+    let value = manifest.get("devEngines")?.get("packageManager")?;
+    if let Some(items) = value.as_array() {
+        if items.is_empty() {
+            return None;
+        }
+        let index = items
+            .iter()
+            .position(|item| item.get("name").and_then(Value::as_str) == Some("pnpm"))
+            .unwrap_or(0);
+        let item = &items[index];
+        let on_fail =
+            item.get("onFail").and_then(Value::as_str).map(ToString::to_string).or_else(|| {
+                Some(if index == items.len() - 1 { "error" } else { "ignore" }.to_string())
+            });
+        return package_manager_from_engine(item, true, on_fail);
+    }
+    package_manager_from_engine(
+        value,
+        true,
+        value.get("onFail").and_then(Value::as_str).map(ToString::to_string),
+    )
+}
+
+fn package_manager_from_engine(
+    value: &Value,
+    from_dev_engines: bool,
+    on_fail: Option<String>,
+) -> Option<WantedPackageManager> {
+    Some(WantedPackageManager {
+        name: value.get("name")?.as_str()?.to_string(),
+        version: value.get("version").and_then(Value::as_str).map(ToString::to_string),
+        from_dev_engines,
+        on_fail,
+    })
+}
+
+fn parse_package_manager(package_manager: &str) -> (String, Option<String>) {
+    let Some((name, reference)) = package_manager.split_once('@') else {
+        return (package_manager.to_string(), None);
+    };
+    if reference.contains(':') {
+        return (name.to_string(), None);
+    }
+    (
+        name.to_string(),
+        Some(reference.split_once('+').map_or(reference, |(version, _)| version).to_string()),
+    )
+}
+
+fn should_persist_package_manager_lockfile(pm: &WantedPackageManager) -> bool {
+    if pm.on_fail.as_deref().unwrap_or("download") == "ignore" {
+        return false;
+    }
+    if pm.from_dev_engines {
+        return true;
+    }
+    pm.version
+        .as_deref()
+        .and_then(|version| node_semver::Version::parse(version).ok())
+        .is_some_and(|version| version.major >= 12)
+}
+
+fn current_source_pnpm_version() -> Option<String> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir.ancestors().find_map(pnpm_version_from)
+}
+
+fn pnpm_version_from(root_dir: &Path) -> Option<String> {
+    let path = root_dir.join("pnpm").join("package.json");
+    let value = read_manifest_json(&path).ok()??;
+    value.get("version").and_then(Value::as_str).map(ToString::to_string)
+}
+
+fn exact_version(version: &str) -> Option<String> {
+    let parsed = node_semver::Version::parse(version).ok()?;
+    (parsed.to_string() == version).then(|| version.to_string())
+}
+
+fn version_satisfies(version: &str, wanted_range: &str) -> bool {
+    let Ok(version) = node_semver::Version::parse(version) else {
+        return false;
+    };
+    let Ok(range) = node_semver::Range::parse(wanted_range) else {
+        return false;
+    };
+    if version.satisfies(&range) {
+        return true;
+    }
+    if version.pre_release.is_empty() {
+        return false;
+    }
+    let base = node_semver::Version {
+        major: version.major,
+        minor: version.minor,
+        patch: version.patch,
+        pre_release: Vec::new(),
+        build: version.build,
+    };
+    base.satisfies(&range)
 }
 
 #[cfg(test)]

--- a/pacquet/crates/cli/src/cli_args/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/tests.rs
@@ -1,5 +1,6 @@
-use super::{CliArgs, CliCommand};
+use super::{CliArgs, CliCommand, package_manager_to_sync};
 use clap::Parser;
+use tempfile::TempDir;
 
 /// `--recursive` / `-r` defaults to `false` when absent. Mirrors
 /// pnpm, where `recursive` is unset unless the flag (or a recursive
@@ -72,4 +73,25 @@ fn filter_flag_split_across_subcommand_keeps_only_subcommand_side() {
     let parsed = CliArgs::try_parse_from(["pacquet", "-F", "a", "install", "-F", "b"])
         .expect("parses split -F");
     assert_eq!(parsed.filter, ["b"], "global-side `a` is dropped");
+}
+
+#[test]
+fn package_manager_to_sync_preserves_dev_engine_specifier() {
+    let root = TempDir::new().expect("tmp dir");
+    let manifest_path = root.path().join("package.json");
+    std::fs::write(
+        &manifest_path,
+        r#"{"devEngines":{"packageManager":{"name":"pnpm","version":">=0.0.0","onFail":"download"}}}"#,
+    )
+    .expect("write manifest");
+
+    let package_manager = package_manager_to_sync(&manifest_path, root.path())
+        .expect("read policy")
+        .expect("sync package manager");
+
+    assert_eq!(package_manager.specifier, ">=0.0.0");
+    assert_eq!(
+        package_manager.version,
+        super::current_source_pnpm_version().expect("source pnpm version"),
+    );
 }

--- a/pacquet/crates/cli/src/config_deps.rs
+++ b/pacquet/crates/cli/src/config_deps.rs
@@ -12,7 +12,9 @@
 use miette::{IntoDiagnostic, Result, WrapErr};
 use pacquet_catalogs_config::get_catalogs_from_workspace_manifest;
 use pacquet_config::{Config, WorkspaceSettings};
-use pacquet_env_installer::{ConfigDepsInstallOptions, resolve_and_install_config_deps};
+use pacquet_env_installer::{
+    ConfigDepsInstallOptions, resolve_and_install_config_deps, resolve_package_manager_integrities,
+};
 use pacquet_graph_hasher::{detect_node_version, host_arch, host_libc, host_platform};
 use pacquet_hooks::{HookContext, LogFn, finder};
 use pacquet_network::{NetworkSettings, RetryOpts, ThrottledClient};
@@ -49,6 +51,23 @@ pub async fn install_config_deps<Reporter: self::Reporter>(
     resolve_and_install::<Reporter>(config, config_dependencies, root_dir, frozen_lockfile).await
 }
 
+/// Resolve `pnpm` / `@pnpm/exe` into the env lockfile's
+/// `packageManagerDependencies` block before the wanted lockfile is
+/// loaded.
+pub async fn sync_package_manager_dependencies(
+    config: &Config,
+    root_dir: &Path,
+    pnpm_version: &str,
+    frozen_lockfile: bool,
+) -> Result<()> {
+    let context = EnvInstallerContext::new(config)?;
+    let options = context.options(root_dir, frozen_lockfile);
+    resolve_package_manager_integrities(pnpm_version, &context.resolver, &options)
+        .await
+        .map_err(miette::Report::new)
+        .wrap_err("resolve package manager dependencies")
+}
+
 /// Add a single config dependency: resolve + install it (merged with any
 /// already-declared config deps), then write the clean specifier into
 /// `pnpm-workspace.yaml`'s `configDependencies` block. Backs
@@ -79,76 +98,108 @@ async fn resolve_and_install<Reporter: self::Reporter>(
     root_dir: &Path,
     frozen_lockfile: bool,
 ) -> Result<()> {
-    let http_client = Arc::new(
-        ThrottledClient::for_installs(
-            &config.proxy,
-            &config.tls,
-            &config.tls_by_uri,
-            &NetworkSettings {
-                network_concurrency: config.network_concurrency,
-                fetch_timeout: Duration::from_millis(config.fetch_timeout),
-                user_agent: config.user_agent.clone(),
-            },
-        )
-        .into_diagnostic()
-        .wrap_err("create the network client for configurational dependencies")?,
-    );
+    let context = EnvInstallerContext::new(config)?;
+    let options = context.options(root_dir, frozen_lockfile);
 
-    let registries: HashMap<String, String> = config.resolved_registries().into_iter().collect();
-
-    let retry_opts = RetryOpts {
-        retries: config.fetch_retries,
-        factor: config.fetch_retry_factor,
-        min_timeout: Duration::from_millis(config.fetch_retry_mintimeout),
-        max_timeout: Duration::from_millis(config.fetch_retry_maxtimeout),
-    };
-
-    let resolver = NpmResolver {
-        registries: registries.clone(),
-        named_registries: HashMap::new(),
-        http_client: Arc::clone(&http_client),
-        auth_headers: Arc::clone(&config.auth_headers),
-        meta_cache: Arc::new(InMemoryPackageMetaCache::default()),
-        fetch_locker: shared_packument_fetch_locker(),
-        picked_manifest_cache: shared_picked_manifest_cache(),
-        cache_dir: Some(config.cache_dir.clone()),
-        offline: config.offline,
-        prefer_offline: config.prefer_offline,
-        ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
-        full_metadata: false,
-        retry_opts,
-    };
-
-    // `DownloadTarballToStore` needs a `&'static StoreDir`; the config
-    // (and thus its store dir) is itself leaked for the process
-    // lifetime, but we only hold a borrowed `&Config` here so the
-    // caller keeps the unique `&mut Config` for the `updateConfig`
-    // pass. Leak a clone to recover the `'static` borrow — a single
-    // small, one-per-install allocation in a short-lived CLI process.
-    let store_dir: &'static StoreDir = Box::leak(Box::new(config.store_dir.clone()));
-    let node_version = detect_node_version().unwrap_or_else(|| "0.0.0".to_string());
-    let options = ConfigDepsInstallOptions {
-        root_dir,
-        store_dir,
-        http_client: &http_client,
-        auth_headers: config.auth_headers.as_ref(),
-        registries: &registries,
-        verify_store_integrity: config.verify_store_integrity,
-        offline: config.offline,
-        package_import_method: config.package_import_method,
-        retry_opts,
-        frozen_lockfile,
-        supported_architectures: None,
-        current_node_version: &node_version,
-        current_os: host_platform(),
-        current_cpu: host_arch(),
-        current_libc: host_libc(),
-    };
-
-    resolve_and_install_config_deps::<Reporter>(config_dependencies, &resolver, &options)
+    resolve_and_install_config_deps::<Reporter>(config_dependencies, &context.resolver, &options)
         .await
         .map_err(miette::Report::new)
         .wrap_err("install configurational dependencies")
+}
+
+struct EnvInstallerContext {
+    http_client: Arc<ThrottledClient>,
+    auth_headers: Arc<pacquet_network::AuthHeaders>,
+    registries: HashMap<String, String>,
+    retry_opts: RetryOpts,
+    store_dir: &'static StoreDir,
+    node_version: String,
+    verify_store_integrity: bool,
+    offline: bool,
+    package_import_method: pacquet_config::PackageImportMethod,
+    resolver: NpmResolver<InMemoryPackageMetaCache>,
+}
+
+impl EnvInstallerContext {
+    fn new(config: &Config) -> Result<Self> {
+        let http_client = Arc::new(
+            ThrottledClient::for_installs(
+                &config.proxy,
+                &config.tls,
+                &config.tls_by_uri,
+                &NetworkSettings {
+                    network_concurrency: config.network_concurrency,
+                    fetch_timeout: Duration::from_millis(config.fetch_timeout),
+                    user_agent: config.user_agent.clone(),
+                },
+            )
+            .into_diagnostic()
+            .wrap_err("create the network client for configurational dependencies")?,
+        );
+
+        let registries: HashMap<String, String> =
+            config.resolved_registries().into_iter().collect();
+        let retry_opts = RetryOpts {
+            retries: config.fetch_retries,
+            factor: config.fetch_retry_factor,
+            min_timeout: Duration::from_millis(config.fetch_retry_mintimeout),
+            max_timeout: Duration::from_millis(config.fetch_retry_maxtimeout),
+        };
+        let auth_headers = Arc::clone(&config.auth_headers);
+        let resolver = NpmResolver {
+            registries: registries.clone(),
+            named_registries: HashMap::new(),
+            http_client: Arc::clone(&http_client),
+            auth_headers: Arc::clone(&auth_headers),
+            meta_cache: Arc::new(InMemoryPackageMetaCache::default()),
+            fetch_locker: shared_packument_fetch_locker(),
+            picked_manifest_cache: shared_picked_manifest_cache(),
+            cache_dir: Some(config.cache_dir.clone()),
+            offline: config.offline,
+            prefer_offline: config.prefer_offline,
+            ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
+            full_metadata: false,
+            filter_metadata: false,
+            retry_opts,
+        };
+
+        Ok(Self {
+            http_client,
+            auth_headers,
+            registries,
+            retry_opts,
+            store_dir: Box::leak(Box::new(config.store_dir.clone())),
+            node_version: detect_node_version().unwrap_or_else(|| "0.0.0".to_string()),
+            verify_store_integrity: config.verify_store_integrity,
+            offline: config.offline,
+            package_import_method: config.package_import_method,
+            resolver,
+        })
+    }
+
+    fn options<'a>(
+        &'a self,
+        root_dir: &'a Path,
+        frozen_lockfile: bool,
+    ) -> ConfigDepsInstallOptions<'a> {
+        ConfigDepsInstallOptions {
+            root_dir,
+            store_dir: self.store_dir,
+            http_client: &self.http_client,
+            auth_headers: &self.auth_headers,
+            registries: &self.registries,
+            verify_store_integrity: self.verify_store_integrity,
+            offline: self.offline,
+            package_import_method: self.package_import_method,
+            retry_opts: self.retry_opts,
+            frozen_lockfile,
+            supported_architectures: None,
+            current_node_version: &self.node_version,
+            current_os: host_platform(),
+            current_cpu: host_arch(),
+            current_libc: host_libc(),
+        }
+    }
 }
 
 /// Run the `updateConfig` pnpmfile hooks contributed by config-dependency

--- a/pacquet/crates/cli/src/config_deps.rs
+++ b/pacquet/crates/cli/src/config_deps.rs
@@ -57,12 +57,13 @@ pub async fn install_config_deps<Reporter: self::Reporter>(
 pub async fn sync_package_manager_dependencies(
     config: &Config,
     root_dir: &Path,
+    wanted_specifier: &str,
     pnpm_version: &str,
     frozen_lockfile: bool,
 ) -> Result<()> {
     let context = EnvInstallerContext::new(config)?;
     let options = context.options(root_dir, frozen_lockfile);
-    resolve_package_manager_integrities(pnpm_version, &context.resolver, &options)
+    resolve_package_manager_integrities(wanted_specifier, pnpm_version, &context.resolver, &options)
         .await
         .map_err(miette::Report::new)
         .wrap_err("resolve package manager dependencies")

--- a/pacquet/crates/env-installer/src/lib.rs
+++ b/pacquet/crates/env-installer/src/lib.rs
@@ -16,11 +16,13 @@
 
 mod errors;
 mod install_config_deps;
+mod manifest_lockfile;
 mod options;
 mod parse_integrity;
 mod prune;
 mod resolve_and_install_config_deps;
 mod resolve_optional_subdeps;
+mod resolve_package_manager_integrities;
 
 pub use errors::ConfigDepError;
 pub use install_config_deps::install_config_deps;
@@ -29,6 +31,9 @@ pub use parse_integrity::{NormalizedConfigDep, NormalizedSubdep, parse_integrity
 pub use prune::prune_env_lockfile;
 pub use resolve_and_install_config_deps::resolve_and_install_config_deps;
 pub use resolve_optional_subdeps::resolve_optional_subdeps;
+pub use resolve_package_manager_integrities::{
+    is_package_manager_resolved, resolve_package_manager_integrities,
+};
 
 #[cfg(test)]
 mod tests;

--- a/pacquet/crates/env-installer/src/manifest_lockfile.rs
+++ b/pacquet/crates/env-installer/src/manifest_lockfile.rs
@@ -1,0 +1,113 @@
+use pacquet_lockfile::{PackageMetadata, PeerDependencyMeta};
+use pacquet_resolving_resolver_base::ResolveResult;
+use serde_json::Value;
+use std::collections::HashMap;
+
+pub(crate) fn package_metadata(
+    name: &str,
+    version: &str,
+    result: &ResolveResult,
+    registry: &str,
+    lockfile_include_tarball_url: bool,
+) -> PackageMetadata {
+    let manifest = result.manifest.as_deref();
+    PackageMetadata {
+        resolution: result.resolution.to_lockfile_form(
+            name,
+            version,
+            registry,
+            lockfile_include_tarball_url,
+        ),
+        version: None,
+        engines: read_engines(manifest),
+        cpu: read_string_list(manifest, "cpu"),
+        os: read_string_list(manifest, "os"),
+        libc: read_string_list(manifest, "libc"),
+        deprecated: manifest
+            .and_then(|m| m.get("deprecated"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        has_bin: manifest_has_bin(manifest),
+        prepare: None,
+        bundled_dependencies: read_string_list(manifest, "bundledDependencies")
+            .or_else(|| read_string_list(manifest, "bundleDependencies")),
+        peer_dependencies: read_string_map(manifest, "peerDependencies"),
+        peer_dependencies_meta: read_peer_dependencies_meta(manifest),
+    }
+}
+
+pub(crate) fn read_dependency_map(manifest: Option<&Value>, key: &str) -> HashMap<String, String> {
+    read_string_map(manifest, key).unwrap_or_default()
+}
+
+fn read_engines(manifest: Option<&Value>) -> Option<HashMap<String, String>> {
+    let entries: Vec<(String, String)> = match manifest?.get("engines")? {
+        Value::Object(map) => map
+            .iter()
+            .filter_map(|(name, value)| {
+                let range = value.as_str()?;
+                (range != "*").then(|| (name.clone(), range.to_string()))
+            })
+            .collect(),
+        Value::Array(items) => items
+            .iter()
+            .enumerate()
+            .filter_map(|(index, value)| {
+                let range = value.as_str()?;
+                (range != "*").then(|| (index.to_string(), range.to_string()))
+            })
+            .collect(),
+        _ => return None,
+    };
+    (!entries.is_empty()).then(|| entries.into_iter().collect())
+}
+
+fn read_string_map(manifest: Option<&Value>, key: &str) -> Option<HashMap<String, String>> {
+    let out: HashMap<String, String> = manifest?
+        .get(key)?
+        .as_object()?
+        .iter()
+        .filter_map(|(name, value)| Some((name.clone(), value.as_str()?.to_string())))
+        .collect();
+    (!out.is_empty()).then_some(out)
+}
+
+fn read_string_list(manifest: Option<&Value>, key: &str) -> Option<Vec<String>> {
+    match manifest?.get(key)? {
+        Value::String(value) if !value.is_empty() => Some(vec![value.clone()]),
+        Value::Array(items) => {
+            let out: Vec<String> =
+                items.iter().filter_map(Value::as_str).map(ToString::to_string).collect();
+            (!out.is_empty()).then_some(out)
+        }
+        _ => None,
+    }
+}
+
+fn manifest_has_bin(manifest: Option<&Value>) -> Option<bool> {
+    let present = match manifest?.get("bin")? {
+        Value::String(value) => !value.is_empty(),
+        Value::Object(map) => !map.is_empty(),
+        _ => false,
+    };
+    present.then_some(true)
+}
+
+fn read_peer_dependencies_meta(
+    manifest: Option<&Value>,
+) -> Option<HashMap<String, PeerDependencyMeta>> {
+    let out: HashMap<String, PeerDependencyMeta> = manifest?
+        .get("peerDependenciesMeta")?
+        .as_object()?
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .as_object()?
+                .get("optional")?
+                .as_bool()
+                .filter(|optional| *optional)
+                .map(|_| (name.clone(), PeerDependencyMeta { optional: true }))
+        })
+        .collect();
+    (!out.is_empty()).then_some(out)
+}

--- a/pacquet/crates/env-installer/src/prune.rs
+++ b/pacquet/crates/env-installer/src/prune.rs
@@ -3,9 +3,8 @@
 //! [`pruneEnvLockfile`](https://github.com/pnpm/pnpm/blob/31858c544b/installing/env-installer/src/pruneEnvLockfile.ts),
 //! which runs the env document through the shared lockfile pruner.
 //!
-//! The env document's reachability graph is shallow — config (and
-//! package-manager) deps plus one level of their optional subdeps — so
-//! this walks that graph directly instead of porting the general
+//! The env document is smaller than a normal project lockfile, so this
+//! walks the snapshot graph directly instead of porting the general
 //! `pruneSharedLockfile`.
 
 use pacquet_lockfile::{EnvLockfile, PackageKey};
@@ -15,6 +14,7 @@ use std::collections::HashSet;
 /// `importers["."]`.
 pub fn prune_env_lockfile(env: &mut EnvLockfile) {
     let mut reachable: HashSet<PackageKey> = HashSet::new();
+    let mut pending: Vec<PackageKey> = Vec::new();
 
     if let Some(importer) = env.importers.get(EnvLockfile::ROOT_IMPORTER_KEY) {
         let direct = importer
@@ -25,21 +25,24 @@ pub fn prune_env_lockfile(env: &mut EnvLockfile) {
             let Ok(key) = format!("{name}@{}", spec.version).parse::<PackageKey>() else {
                 continue;
             };
-            // Pull in one level of optional subdeps before moving the
-            // key, so the borrow on `env.snapshots` ends first.
-            if let Some(snapshot) = env.snapshots.get(&key)
-                && let Some(optionals) = snapshot.optional_dependencies.as_ref()
-            {
-                for (subdep_name, dep_ref) in optionals {
-                    if let Some(ver_peer) = dep_ref.ver_peer()
-                        && let Ok(subkey) =
-                            format!("{subdep_name}@{ver_peer}").parse::<PackageKey>()
-                    {
-                        reachable.insert(subkey);
-                    }
+            pending.push(key);
+        }
+    }
+
+    while let Some(key) = pending.pop() {
+        if !reachable.insert(key.clone()) {
+            continue;
+        }
+        let Some(snapshot) = env.snapshots.get(&key) else {
+            continue;
+        };
+        for deps in [&snapshot.dependencies, &snapshot.optional_dependencies].into_iter().flatten()
+        {
+            for (subdep_name, dep_ref) in deps {
+                if let Some(subkey) = dep_ref.resolve(subdep_name) {
+                    pending.push(subkey);
                 }
             }
-            reachable.insert(key);
         }
     }
 

--- a/pacquet/crates/env-installer/src/resolve_optional_subdeps.rs
+++ b/pacquet/crates/env-installer/src/resolve_optional_subdeps.rs
@@ -6,9 +6,11 @@
 //! resolved version drift between machines even with a stable parent
 //! integrity, breaking the lockfile's reproducibility promise.
 
-use crate::{ConfigDepError, options::ConfigDepsInstallOptions};
+use crate::{
+    ConfigDepError, manifest_lockfile::package_metadata, options::ConfigDepsInstallOptions,
+};
 use pacquet_lockfile::{
-    EnvLockfile, PackageKey, PackageMetadata, PkgName, PkgVerPeer, SnapshotDepRef, SnapshotEntry,
+    EnvLockfile, PackageKey, PkgName, PkgVerPeer, SnapshotDepRef, SnapshotEntry,
 };
 use pacquet_resolving_resolver_base::{ResolveOptions, Resolver, WantedDependency};
 use std::collections::HashMap;
@@ -47,6 +49,7 @@ pub async fn resolve_optional_subdeps(
         let wanted = WantedDependency {
             alias: Some(subdep_name.clone()),
             bare_specifier: Some(subdep_spec.to_string()),
+            optional: Some(true),
             ..WantedDependency::default()
         };
         let resolve_opts = ResolveOptions {
@@ -89,28 +92,9 @@ pub async fn resolve_optional_subdeps(
                 message: format!("Resolved optionalDependency {subdep_name}@{subdep_version} has an unparsable key"),
             })?;
 
-        let manifest = result.manifest.as_deref();
         env_lockfile.packages.insert(
             pkg_key.clone(),
-            PackageMetadata {
-                resolution: result.resolution.to_lockfile_form(
-                    subdep_name,
-                    &subdep_version,
-                    registry,
-                    false,
-                ),
-                version: None,
-                engines: None,
-                cpu: platform_field(manifest, "cpu"),
-                os: platform_field(manifest, "os"),
-                libc: platform_field(manifest, "libc"),
-                deprecated: None,
-                has_bin: None,
-                prepare: None,
-                bundled_dependencies: None,
-                peer_dependencies: None,
-                peer_dependencies_meta: None,
-            },
+            package_metadata(subdep_name, &subdep_version, &result, registry, false),
         );
         env_lockfile
             .snapshots
@@ -130,18 +114,6 @@ pub async fn resolve_optional_subdeps(
     }
 
     Ok((!resolved.is_empty()).then_some(resolved))
-}
-
-/// `os` / `cpu` / `libc` from a resolved manifest, as a non-empty
-/// `Vec<String>` or `None`. Mirrors pnpm's `pickPlatformFields`.
-fn platform_field(manifest: Option<&serde_json::Value>, key: &str) -> Option<Vec<String>> {
-    let values: Vec<String> = manifest?
-        .get(key)?
-        .as_array()?
-        .iter()
-        .filter_map(|value| value.as_str().map(str::to_string))
-        .collect();
-    (!values.is_empty()).then_some(values)
 }
 
 pub(crate) fn resolution_has_integrity(resolution: &pacquet_lockfile::LockfileResolution) -> bool {

--- a/pacquet/crates/env-installer/src/resolve_package_manager_integrities.rs
+++ b/pacquet/crates/env-installer/src/resolve_package_manager_integrities.rs
@@ -1,0 +1,195 @@
+use crate::{
+    ConfigDepError,
+    manifest_lockfile::{package_metadata, read_dependency_map},
+    options::ConfigDepsInstallOptions,
+    prune::prune_env_lockfile,
+    resolve_optional_subdeps::resolution_has_integrity,
+};
+use pacquet_lockfile::{
+    EnvLockfile, PackageKey, PkgName, PkgVerPeer, SnapshotDepRef, SnapshotEntry,
+    SpecifierAndResolution,
+};
+use pacquet_resolving_resolver_base::{ResolveOptions, ResolveResult, Resolver, WantedDependency};
+use std::{collections::HashMap, path::PathBuf};
+
+const PACKAGE_MANAGER_DEPS: [&str; 2] = ["pnpm", "@pnpm/exe"];
+
+pub async fn resolve_package_manager_integrities(
+    pnpm_version: &str,
+    resolver: &dyn Resolver,
+    opts: &ConfigDepsInstallOptions<'_>,
+) -> Result<(), ConfigDepError> {
+    let mut env_lockfile = EnvLockfile::read(opts.root_dir)
+        .map_err(ConfigDepError::ReadLockfile)?
+        .unwrap_or_else(EnvLockfile::create);
+    if is_package_manager_resolved(&env_lockfile, pnpm_version) {
+        return Ok(());
+    }
+    if opts.frozen_lockfile {
+        return Err(ConfigDepError::FrozenLockfileOutdated {
+            message: r#"Cannot update packageManagerDependencies with "frozen-lockfile" because the lockfile is not up to date"#.to_string(),
+        });
+    }
+
+    let mut package_manager_dependencies = std::collections::BTreeMap::new();
+    let mut resolved = Vec::new();
+    for name in PACKAGE_MANAGER_DEPS {
+        let package = resolve_dep(name, pnpm_version, false, resolver, opts).await?;
+        package_manager_dependencies.insert(
+            name.to_string(),
+            SpecifierAndResolution {
+                specifier: pnpm_version.to_string(),
+                version: package.version.clone(),
+            },
+        );
+        resolved.push(package);
+    }
+
+    env_lockfile.root_importer_mut().package_manager_dependencies =
+        Some(package_manager_dependencies);
+
+    let mut seen = std::collections::HashSet::new();
+    while let Some(package) = resolved.pop() {
+        if !seen.insert(package.key.clone()) {
+            if !package.optional
+                && let Some(snapshot) = env_lockfile.snapshots.get_mut(&package.key)
+            {
+                snapshot.optional = false;
+            }
+            continue;
+        }
+        let registry = opts.pick_registry(&package.name);
+        env_lockfile.packages.insert(
+            package.key.clone(),
+            package_metadata(&package.name, &package.version, &package.result, registry, false),
+        );
+
+        let manifest = package.result.manifest.as_deref();
+        let mut dependencies = HashMap::new();
+        for (alias, specifier) in read_dependency_map(manifest, "dependencies") {
+            let child = resolve_dep(&alias, &specifier, false, resolver, opts).await?;
+            dependencies.insert(snapshot_dep_name(&alias)?, child.snapshot_ref(&alias)?);
+            resolved.push(child);
+        }
+
+        let mut optional_dependencies = HashMap::new();
+        for (alias, specifier) in read_dependency_map(manifest, "optionalDependencies") {
+            let child = resolve_dep(&alias, &specifier, true, resolver, opts).await?;
+            optional_dependencies.insert(snapshot_dep_name(&alias)?, child.snapshot_ref(&alias)?);
+            resolved.push(child);
+        }
+
+        env_lockfile.snapshots.insert(
+            package.key,
+            SnapshotEntry {
+                dependencies: (!dependencies.is_empty()).then_some(dependencies),
+                optional_dependencies: (!optional_dependencies.is_empty())
+                    .then_some(optional_dependencies),
+                optional: package.optional,
+                ..SnapshotEntry::default()
+            },
+        );
+    }
+
+    prune_env_lockfile(&mut env_lockfile);
+    env_lockfile.write(opts.root_dir).map_err(ConfigDepError::WriteLockfile)
+}
+
+#[must_use]
+pub fn is_package_manager_resolved(env_lockfile: &EnvLockfile, pnpm_version: &str) -> bool {
+    let Some(pm_deps) = env_lockfile
+        .importers
+        .get(EnvLockfile::ROOT_IMPORTER_KEY)
+        .and_then(|importer| importer.package_manager_dependencies.as_ref())
+    else {
+        return false;
+    };
+    PACKAGE_MANAGER_DEPS
+        .iter()
+        .all(|name| pm_deps.get(*name).is_some_and(|dep| dep.version == pnpm_version))
+}
+
+struct EnvPackage {
+    name: String,
+    version: String,
+    key: PackageKey,
+    optional: bool,
+    result: ResolveResult,
+}
+
+impl EnvPackage {
+    fn snapshot_ref(&self, alias: &str) -> Result<SnapshotDepRef, ConfigDepError> {
+        if alias == self.name {
+            let ver_peer =
+                self.version.parse::<PkgVerPeer>().map_err(|_| ConfigDepError::BadConfigDep {
+                    message: format!(
+                        "Resolved package manager dependency version {} is not valid",
+                        self.version,
+                    ),
+                })?;
+            Ok(SnapshotDepRef::Plain(ver_peer))
+        } else {
+            format!("{}@{}", self.name, self.version).parse().map(SnapshotDepRef::Alias).map_err(
+                |_| ConfigDepError::BadConfigDep {
+                    message: format!(
+                        "Resolved package manager dependency {}@{} has an unparsable alias reference",
+                        self.name, self.version,
+                    ),
+                },
+            )
+        }
+    }
+}
+
+async fn resolve_dep(
+    alias: &str,
+    specifier: &str,
+    optional: bool,
+    resolver: &dyn Resolver,
+    opts: &ConfigDepsInstallOptions<'_>,
+) -> Result<EnvPackage, ConfigDepError> {
+    let wanted = WantedDependency {
+        alias: Some(alias.to_string()),
+        bare_specifier: Some(specifier.to_string()),
+        optional: optional.then_some(true),
+        ..WantedDependency::default()
+    };
+    let resolve_opts = ResolveOptions {
+        project_dir: PathBuf::from(opts.root_dir),
+        lockfile_dir: PathBuf::from(opts.root_dir),
+        ..ResolveOptions::default()
+    };
+    let result = resolver
+        .resolve(&wanted, &resolve_opts)
+        .await
+        .map_err(|error| ConfigDepError::Resolve { spec: format!("{alias}@{specifier}"), error })?
+        .ok_or_else(|| no_integrity(alias, specifier))?;
+    if !resolution_has_integrity(&result.resolution) {
+        return Err(no_integrity(alias, specifier));
+    }
+    let name_ver = result.name_ver.as_ref().ok_or_else(|| no_integrity(alias, specifier))?;
+    let name = name_ver.name.to_string();
+    let version = name_ver.suffix.to_string();
+    let key = format!("{name}@{version}").parse::<PackageKey>().map_err(|_| {
+        ConfigDepError::BadConfigDep {
+            message: format!(
+                "Resolved package manager dependency {name}@{version} has an unparsable lockfile key",
+            ),
+        }
+    })?;
+    Ok(EnvPackage { name, version, key, optional, result })
+}
+
+fn no_integrity(alias: &str, specifier: &str) -> ConfigDepError {
+    ConfigDepError::BadConfigDep {
+        message: format!(
+            "Cannot resolve {alias}@{specifier} as a package manager dependency because it has no integrity",
+        ),
+    }
+}
+
+fn snapshot_dep_name(alias: &str) -> Result<PkgName, ConfigDepError> {
+    alias.parse().map_err(|_| ConfigDepError::BadConfigDep {
+        message: format!("Resolved package manager dependency name {alias} is invalid"),
+    })
+}

--- a/pacquet/crates/env-installer/src/resolve_package_manager_integrities.rs
+++ b/pacquet/crates/env-installer/src/resolve_package_manager_integrities.rs
@@ -109,13 +109,14 @@ pub fn is_package_manager_resolved(
     else {
         return false;
     };
-    PACKAGE_MANAGER_DEPS.iter().all(|name| {
-        pm_deps.get(*name).is_some_and(|dep| {
-            dep.specifier == wanted_specifier
-                && dep.version == pnpm_version
-                && package_manager_entry_exists(env_lockfile, name, &dep.version)
+    pm_deps.len() == PACKAGE_MANAGER_DEPS.len()
+        && PACKAGE_MANAGER_DEPS.iter().all(|name| {
+            pm_deps.get(*name).is_some_and(|dep| {
+                dep.specifier == wanted_specifier
+                    && dep.version == pnpm_version
+                    && package_manager_entry_exists(env_lockfile, name, &dep.version)
+            })
         })
-    })
 }
 
 fn package_manager_entry_exists(env_lockfile: &EnvLockfile, name: &str, version: &str) -> bool {

--- a/pacquet/crates/env-installer/src/resolve_package_manager_integrities.rs
+++ b/pacquet/crates/env-installer/src/resolve_package_manager_integrities.rs
@@ -15,6 +15,7 @@ use std::{collections::HashMap, path::PathBuf};
 const PACKAGE_MANAGER_DEPS: [&str; 2] = ["pnpm", "@pnpm/exe"];
 
 pub async fn resolve_package_manager_integrities(
+    wanted_specifier: &str,
     pnpm_version: &str,
     resolver: &dyn Resolver,
     opts: &ConfigDepsInstallOptions<'_>,
@@ -22,7 +23,7 @@ pub async fn resolve_package_manager_integrities(
     let mut env_lockfile = EnvLockfile::read(opts.root_dir)
         .map_err(ConfigDepError::ReadLockfile)?
         .unwrap_or_else(EnvLockfile::create);
-    if is_package_manager_resolved(&env_lockfile, pnpm_version) {
+    if is_package_manager_resolved(&env_lockfile, wanted_specifier, pnpm_version) {
         return Ok(());
     }
     if opts.frozen_lockfile {
@@ -38,7 +39,7 @@ pub async fn resolve_package_manager_integrities(
         package_manager_dependencies.insert(
             name.to_string(),
             SpecifierAndResolution {
-                specifier: pnpm_version.to_string(),
+                specifier: wanted_specifier.to_string(),
                 version: package.version.clone(),
             },
         );
@@ -96,7 +97,11 @@ pub async fn resolve_package_manager_integrities(
 }
 
 #[must_use]
-pub fn is_package_manager_resolved(env_lockfile: &EnvLockfile, pnpm_version: &str) -> bool {
+pub fn is_package_manager_resolved(
+    env_lockfile: &EnvLockfile,
+    wanted_specifier: &str,
+    pnpm_version: &str,
+) -> bool {
     let Some(pm_deps) = env_lockfile
         .importers
         .get(EnvLockfile::ROOT_IMPORTER_KEY)
@@ -104,9 +109,20 @@ pub fn is_package_manager_resolved(env_lockfile: &EnvLockfile, pnpm_version: &st
     else {
         return false;
     };
-    PACKAGE_MANAGER_DEPS
-        .iter()
-        .all(|name| pm_deps.get(*name).is_some_and(|dep| dep.version == pnpm_version))
+    PACKAGE_MANAGER_DEPS.iter().all(|name| {
+        pm_deps.get(*name).is_some_and(|dep| {
+            dep.specifier == wanted_specifier
+                && dep.version == pnpm_version
+                && package_manager_entry_exists(env_lockfile, name, &dep.version)
+        })
+    })
+}
+
+fn package_manager_entry_exists(env_lockfile: &EnvLockfile, name: &str, version: &str) -> bool {
+    let Ok(key) = format!("{name}@{version}").parse::<PackageKey>() else {
+        return false;
+    };
+    env_lockfile.packages.contains_key(&key) && env_lockfile.snapshots.contains_key(&key)
 }
 
 struct EnvPackage {

--- a/pacquet/crates/env-installer/src/tests.rs
+++ b/pacquet/crates/env-installer/src/tests.rs
@@ -330,6 +330,20 @@ async fn resolves_package_manager_dependencies_graph() {
     assert!(!env.snapshots[&libc_key].optional);
     assert!(is_package_manager_resolved(&env, "^100.0.0", "100.0.0"));
     assert!(!is_package_manager_resolved(&env, "~100.0.0", "100.0.0"));
+
+    let mut env_with_extra_pm_dep = env.clone();
+    env_with_extra_pm_dep
+        .importers
+        .get_mut(EnvLockfile::ROOT_IMPORTER_KEY)
+        .unwrap()
+        .package_manager_dependencies
+        .as_mut()
+        .unwrap()
+        .insert(
+            "yarn".to_string(),
+            SpecifierAndResolution { specifier: "1.0.0".to_string(), version: "1.0.0".to_string() },
+        );
+    assert!(!is_package_manager_resolved(&env_with_extra_pm_dep, "^100.0.0", "100.0.0",));
 }
 
 #[tokio::test]

--- a/pacquet/crates/env-installer/src/tests.rs
+++ b/pacquet/crates/env-installer/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ConfigDepError, ConfigDepsInstallOptions, prune_env_lockfile, resolve_and_install_config_deps,
-    resolve_package_manager_integrities,
+    ConfigDepError, ConfigDepsInstallOptions, is_package_manager_resolved, prune_env_lockfile,
+    resolve_and_install_config_deps, resolve_package_manager_integrities,
 };
 use pacquet_lockfile::{
     EnvLockfile, LockfileResolution, PackageKey, PackageMetadata, RegistryResolution,
@@ -288,6 +288,7 @@ async fn resolves_package_manager_dependencies_graph() {
         }));
 
     resolve_package_manager_integrities(
+        "^100.0.0",
         "100.0.0",
         &resolver,
         &options(&harness, root.path(), false),
@@ -300,7 +301,9 @@ async fn resolves_package_manager_dependencies_graph() {
         .package_manager_dependencies
         .as_ref()
         .expect("package manager deps recorded");
+    assert_eq!(pm_deps["pnpm"].specifier, "^100.0.0");
     assert_eq!(pm_deps["pnpm"].version, "100.0.0");
+    assert_eq!(pm_deps["@pnpm/exe"].specifier, "^100.0.0");
     assert_eq!(pm_deps["@pnpm/exe"].version, "100.0.0");
 
     let pnpm_key: PackageKey = "pnpm@100.0.0".parse().unwrap();
@@ -325,6 +328,8 @@ async fn resolves_package_manager_dependencies_graph() {
     );
     assert!(env.snapshots[&platform_key].optional);
     assert!(!env.snapshots[&libc_key].optional);
+    assert!(is_package_manager_resolved(&env, "^100.0.0", "100.0.0"));
+    assert!(!is_package_manager_resolved(&env, "~100.0.0", "100.0.0"));
 }
 
 #[tokio::test]

--- a/pacquet/crates/env-installer/src/tests.rs
+++ b/pacquet/crates/env-installer/src/tests.rs
@@ -1,5 +1,6 @@
 use crate::{
     ConfigDepError, ConfigDepsInstallOptions, prune_env_lockfile, resolve_and_install_config_deps,
+    resolve_package_manager_integrities,
 };
 use pacquet_lockfile::{
     EnvLockfile, LockfileResolution, PackageKey, PackageMetadata, RegistryResolution,
@@ -11,12 +12,15 @@ use pacquet_resolving_npm_resolver::{
     InMemoryPackageMetaCache, NpmResolver, shared_packument_fetch_locker,
     shared_picked_manifest_cache,
 };
-use pacquet_resolving_resolver_base::{ResolveOptions, Resolver, WantedDependency};
+use pacquet_resolving_resolver_base::{
+    LatestInfo, LatestQuery, PkgResolutionId, ResolveFuture, ResolveLatestFuture, ResolveOptions,
+    ResolveResult, Resolver, WantedDependency,
+};
 use pacquet_store_dir::StoreDir;
 use pacquet_testing_utils::registry::TestRegistry;
 use pacquet_workspace_state::ConfigDependency;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     path::Path,
     sync::{Arc, Mutex},
 };
@@ -61,6 +65,7 @@ fn build_resolver(registry: &str) -> (NpmResolver<InMemoryPackageMetaCache>, Tem
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
     (resolver, cache_dir)
@@ -116,6 +121,72 @@ fn options<'a>(
 
 fn clean_spec(version: &str) -> ConfigDependency {
     ConfigDependency::VersionWithIntegrity(version.to_string())
+}
+
+#[derive(Default)]
+struct FixtureResolver {
+    packages: HashMap<(String, String), serde_json::Value>,
+}
+
+impl FixtureResolver {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn package(mut self, manifest: serde_json::Value) -> Self {
+        let name = manifest["name"].as_str().expect("fixture package name").to_string();
+        let version = manifest["version"].as_str().expect("fixture package version").to_string();
+        self.packages.insert((name, version), manifest);
+        self
+    }
+}
+
+impl Resolver for FixtureResolver {
+    fn resolve<'a>(
+        &'a self,
+        wanted_dependency: &'a WantedDependency,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveFuture<'a> {
+        Box::pin(async move {
+            let Some(alias) = wanted_dependency.alias.as_deref() else {
+                return Ok(None);
+            };
+            let Some(specifier) = wanted_dependency.bare_specifier.as_deref() else {
+                return Ok(None);
+            };
+            let Some(manifest) =
+                self.packages.get(&(alias.to_string(), specifier.to_string())).cloned()
+            else {
+                return Ok(None);
+            };
+            let name = manifest["name"].as_str().expect("fixture package name").to_string();
+            let version =
+                manifest["version"].as_str().expect("fixture package version").to_string();
+            let id = format!("{name}@{version}");
+            Ok(Some(ResolveResult {
+                id: PkgResolutionId::from(id.as_str()),
+                name_ver: Some(id.parse().expect("fixture name/version parses")),
+                latest: Some(version),
+                published_at: None,
+                manifest: Some(Arc::new(manifest)),
+                resolution: LockfileResolution::Registry(RegistryResolution {
+                    integrity: ssri::Integrity::from(id.as_bytes()),
+                }),
+                resolved_via: "npm-registry".to_string(),
+                normalized_bare_specifier: Some(specifier.to_string()),
+                alias: Some(alias.to_string()),
+                policy_violation: None,
+            }))
+        })
+    }
+
+    fn resolve_latest<'a>(
+        &'a self,
+        _query: &'a LatestQuery,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveLatestFuture<'a> {
+        Box::pin(async { Ok(Some(LatestInfo::default())) })
+    }
 }
 
 #[tokio::test]
@@ -182,6 +253,78 @@ async fn records_optional_subdeps_with_platform_fields() {
     let metadata = env.packages.get(&only_linux).expect("platform subdep recorded in packages");
     assert_eq!(metadata.os.as_deref(), Some(["linux".to_string()].as_slice()));
     assert_eq!(metadata.cpu.as_deref(), Some(["x64".to_string()].as_slice()));
+    assert_eq!(metadata.libc.as_deref(), Some(["glibc".to_string()].as_slice()));
+}
+
+#[tokio::test]
+async fn resolves_package_manager_dependencies_graph() {
+    let harness = harness();
+    let root = TempDir::new().unwrap();
+    let resolver = FixtureResolver::new()
+        .package(serde_json::json!({
+            "name": "pnpm",
+            "version": "100.0.0",
+            "bin": "bin/pnpm.cjs",
+            "engines": { "node": ">=22.0.0" },
+        }))
+        .package(serde_json::json!({
+            "name": "@pnpm/exe",
+            "version": "100.0.0",
+            "bin": { "pnpm": "bin/pnpm.cjs" },
+            "dependencies": { "detect-libc": "2.0.0" },
+            "optionalDependencies": { "@pnpm/linuxstatic-x64": "100.0.0" },
+        }))
+        .package(serde_json::json!({
+            "name": "detect-libc",
+            "version": "2.0.0",
+            "engines": { "node": ">=8" },
+        }))
+        .package(serde_json::json!({
+            "name": "@pnpm/linuxstatic-x64",
+            "version": "100.0.0",
+            "cpu": ["x64"],
+            "os": ["linux"],
+            "libc": "musl",
+        }));
+
+    resolve_package_manager_integrities(
+        "100.0.0",
+        &resolver,
+        &options(&harness, root.path(), false),
+    )
+    .await
+    .unwrap();
+
+    let env = EnvLockfile::read(root.path()).unwrap().expect("env lockfile written");
+    let pm_deps = env.importers[EnvLockfile::ROOT_IMPORTER_KEY]
+        .package_manager_dependencies
+        .as_ref()
+        .expect("package manager deps recorded");
+    assert_eq!(pm_deps["pnpm"].version, "100.0.0");
+    assert_eq!(pm_deps["@pnpm/exe"].version, "100.0.0");
+
+    let pnpm_key: PackageKey = "pnpm@100.0.0".parse().unwrap();
+    let exe_key: PackageKey = "@pnpm/exe@100.0.0".parse().unwrap();
+    let libc_key: PackageKey = "detect-libc@2.0.0".parse().unwrap();
+    let platform_key: PackageKey = "@pnpm/linuxstatic-x64@100.0.0".parse().unwrap();
+
+    assert_eq!(env.packages[&pnpm_key].has_bin, Some(true));
+    assert_eq!(env.packages[&pnpm_key].engines.as_ref().unwrap()["node"], ">=22.0.0");
+    assert_eq!(env.packages[&exe_key].has_bin, Some(true));
+    assert_eq!(env.packages[&platform_key].libc.as_deref(), Some(["musl".to_string()].as_slice()));
+
+    let exe_snapshot = &env.snapshots[&exe_key];
+    let detect_libc_name = "detect-libc".parse().unwrap();
+    let platform_name = "@pnpm/linuxstatic-x64".parse().unwrap();
+    let detect_libc_ref =
+        exe_snapshot.dependencies.as_ref().unwrap()[&detect_libc_name].to_string();
+    assert_eq!(detect_libc_ref, "2.0.0");
+    assert_eq!(
+        exe_snapshot.optional_dependencies.as_ref().unwrap()[&platform_name].to_string(),
+        "100.0.0",
+    );
+    assert!(env.snapshots[&platform_key].optional);
+    assert!(!env.snapshots[&libc_key].optional);
 }
 
 #[tokio::test]

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -149,6 +149,7 @@ async fn resolve_via_mock(
         prefer_offline: false,
         ignore_missing_time_field: true,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
     let wanted = WantedDependency {

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -612,6 +612,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             // demand it. Mirrors upstream's
             // [`fullMetadata`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/store/connection-manager/src/createNewStoreController.ts#L69-L74).
             full_metadata,
+            filter_metadata: full_metadata,
             retry_opts: crate::retry_config::retry_opts_from_config(config),
         });
         let git_resolver = GitResolver::new(
@@ -694,6 +695,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
             // Same rationale as `NpmResolver.full_metadata` above.
             full_metadata,
+            filter_metadata: full_metadata,
             retry_opts: crate::retry_config::retry_opts_from_config(config),
         };
         let pnpmfile_hook = finder::load_pnpmfile(lockfile_dir);

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -701,6 +701,7 @@ impl NpmResolutionVerifier {
                     auth_headers: &self.auth_headers,
                     cache_dir: self.cache_dir.as_deref(),
                     full_metadata: false,
+                    filter_metadata: false,
                     retry_opts: self.retry_opts,
                 };
                 match fetch_full_metadata_cached(&name.to_string(), &opts).await {
@@ -860,6 +861,7 @@ impl NpmResolutionVerifier {
             // The verifier reads `time` and trust evidence per-version,
             // both of which the abbreviated form drops. Always full.
             full_metadata: true,
+            filter_metadata: false,
             retry_opts: self.retry_opts,
         };
         fetch_full_metadata_cached(&name.to_string(), &opts).await.map_err(|err| err.to_string())

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -27,8 +27,9 @@ use crate::{
     FetchMetadataError,
     fetch_full_metadata::{ACCEPT_ABBREVIATED_DOC, ACCEPT_FULL_DOC},
     mirror::{
-        ABBREVIATED_META_DIR, FULL_META_DIR, get_pkg_mirror_path, load_meta_async,
-        load_meta_headers_async, save_meta_indexed,
+        ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, clear_meta,
+        get_pkg_mirror_path, load_meta_async, load_meta_headers_async, save_meta_indexed,
+        save_meta_ndjson,
     },
     registry_url::to_registry_url,
 };
@@ -56,6 +57,9 @@ pub struct FetchFullMetadataCachedOptions<'a> {
     /// [`fetchAbbreviatedMetadataCached`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/fetchFullMetadataCached.ts#L47-L53)
     /// dispatch.
     pub full_metadata: bool,
+    /// When full metadata is requested, use pnpm's filtered metadata
+    /// mirror and persist the filtered packument shape.
+    pub filter_metadata: bool,
     pub(crate) retry_opts: RetryOpts,
 }
 
@@ -95,7 +99,11 @@ pub async fn fetch_full_metadata_cached(
     pkg_name: &str,
     opts: &FetchFullMetadataCachedOptions<'_>,
 ) -> Result<Package, FetchMetadataError> {
-    let meta_dir = if opts.full_metadata { FULL_META_DIR } else { ABBREVIATED_META_DIR };
+    let meta_dir = if opts.full_metadata {
+        if opts.filter_metadata { FULL_FILTERED_META_DIR } else { FULL_META_DIR }
+    } else {
+        ABBREVIATED_META_DIR
+    };
     // Encoding the mirror path can fail only on a malformed registry
     // URL (no host, unparsable). Either case is a config bug; we
     // log and proceed without a cache so the user still gets metadata
@@ -187,15 +195,27 @@ pub async fn fetch_full_metadata_cached(
     // inline parses held the metadata phase to a third of pnpm's
     // throughput.
     let task_url = url.clone();
+    let should_filter_metadata = opts.full_metadata && opts.filter_metadata;
     let meta = tokio::task::spawn_blocking(move || -> Result<Package, FetchMetadataError> {
-        let meta: Package = serde_json::from_str(&raw_body)
-            .map_err(|error| FetchMetadataError::Decode { url: task_url, error })?;
+        let mut meta: Package = serde_json::from_str(&raw_body)
+            .map_err(|error| FetchMetadataError::Decode { url: task_url.clone(), error })?;
+        if should_filter_metadata {
+            meta = clear_meta(&meta).map_err(|error| FetchMetadataError::Decode {
+                url: task_url.clone(),
+                error: error.into_inner(),
+            })?;
+        }
 
         if let Some(path) = mirror_path.as_deref() {
-            // The lazily-parsed `meta` still borrows every version
-            // fragment from `raw_body`, so the indexed write streams
-            // the registry's own bytes — no re-serialization.
-            if let Err(error) = save_meta_indexed(path, &meta, etag.as_deref()) {
+            // A filtered full response is written in pnpm's NDJSON
+            // shape. Other responses keep pacquet's indexed mirror
+            // layout for lazy version hydration.
+            let save_result = if should_filter_metadata {
+                save_meta_ndjson(path, &meta, etag.as_deref())
+            } else {
+                save_meta_indexed(path, &meta, etag.as_deref())
+            };
+            if let Err(error) = save_result {
                 // Fire-and-forget — a read-only cache dir or a
                 // shared-store contention shouldn't fail the
                 // install. The user just won't see the warm-cache

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
@@ -2,7 +2,9 @@ use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use tempfile::TempDir;
 
 use super::{FetchFullMetadataCachedOptions, fetch_full_metadata_cached};
-use crate::mirror::{FULL_META_DIR, get_pkg_mirror_path, load_meta, load_meta_headers};
+use crate::mirror::{
+    FULL_FILTERED_META_DIR, FULL_META_DIR, get_pkg_mirror_path, load_meta, load_meta_headers,
+};
 
 const PACKAGE_BODY: &str = r#"{
     "name": "acme",
@@ -51,6 +53,7 @@ async fn cold_cache_writes_mirror_on_200() {
         auth_headers: &auth_headers,
         cache_dir: Some(cache.path()),
         full_metadata: true,
+        filter_metadata: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -63,6 +66,53 @@ async fn cold_cache_writes_mirror_on_200() {
     assert!(mirror_path.exists(), "mirror file written");
     let headers = load_meta_headers(&mirror_path).expect("headers readable");
     assert_eq!(headers.etag.as_deref(), Some(r#"W/"fresh""#));
+}
+
+#[tokio::test]
+async fn filtered_full_cache_writes_filtered_mirror_on_200() {
+    let mut server = mockito::Server::new_async().await;
+    let filtered_body = PACKAGE_BODY.replace(
+        r#""dist": {"#,
+        r#""readme": "drop me", "scripts": { "preinstall": "node build.js" }, "dist": {"#,
+    );
+    let mock = server
+        .mock("GET", "/acme")
+        .match_header("accept", "application/json; q=1.0, */*")
+        .with_status(200)
+        .with_header("etag", r#"W/"fresh""#)
+        .with_body(filtered_body)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let cache = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let opts = FetchFullMetadataCachedOptions {
+        registry: &registry,
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        cache_dir: Some(cache.path()),
+        full_metadata: true,
+        filter_metadata: true,
+        retry_opts: no_retry_opts(),
+    };
+
+    let pkg = fetch_full_metadata_cached("acme", &opts).await.expect("200 -> ok");
+    assert_eq!(pkg.name, "acme");
+    mock.assert_async().await;
+
+    let mirror_path = get_pkg_mirror_path(cache.path(), FULL_FILTERED_META_DIR, &registry, "acme")
+        .expect("filtered path");
+    assert!(mirror_path.exists(), "filtered mirror file written");
+    let unfiltered_path =
+        get_pkg_mirror_path(cache.path(), FULL_META_DIR, &registry, "acme").expect("full path");
+    assert!(!unfiltered_path.exists(), "unfiltered mirror must not be written");
+    let persisted = load_meta(&mirror_path).expect("mirror readable");
+    let manifest = persisted.versions.get("1.0.0").expect("manifest");
+    assert!(!manifest.other.contains_key("readme"));
+    assert!(!manifest.other.contains_key("scripts"));
 }
 
 /// Warm cache + matching `If-None-Match` → 304 → response served
@@ -99,6 +149,7 @@ async fn warm_cache_serves_from_mirror_on_304() {
         auth_headers: &auth_headers,
         cache_dir: Some(cache.path()),
         full_metadata: true,
+        filter_metadata: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -145,6 +196,7 @@ async fn a_304_renews_the_mirror_mtime() {
         auth_headers: &auth_headers,
         cache_dir: Some(cache.path()),
         full_metadata: true,
+        filter_metadata: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -205,6 +257,7 @@ async fn stale_cache_refreshes_mirror_on_200() {
         auth_headers: &auth_headers,
         cache_dir: Some(cache.path()),
         full_metadata: true,
+        filter_metadata: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -243,6 +296,7 @@ async fn no_cache_dir_skips_mirror_io() {
         auth_headers: &auth_headers,
         cache_dir: None,
         full_metadata: true,
+        filter_metadata: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -282,6 +336,7 @@ async fn read_only_cache_dir_does_not_fail_the_call() {
         auth_headers: &auth_headers,
         cache_dir: Some(cache.path()),
         full_metadata: true,
+        filter_metadata: false,
         retry_opts: no_retry_opts(),
     };
 

--- a/pacquet/crates/resolving-npm-resolver/src/lib.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/lib.rs
@@ -48,7 +48,7 @@ pub use fetch_full_metadata::{
     FetchFullMetadataOptions, FetchFullMetadataOutcome, fetch_full_metadata,
 };
 pub use fetch_full_metadata_cached::{FetchFullMetadataCachedOptions, fetch_full_metadata_cached};
-pub use mirror::{ABBREVIATED_META_DIR, FULL_META_DIR};
+pub use mirror::{ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR};
 pub use named_registry::{
     BUILTIN_NAMED_REGISTRIES, MergeNamedRegistriesError, build_named_registry_prefixes,
     merge_named_registries, pick_registry_for_version,

--- a/pacquet/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/mirror.rs
@@ -9,13 +9,13 @@
 //!   modified) to feed conditional GETs without touching the rest.
 //! - [`load_meta`] — read the headers + index records and reconstruct
 //!   a [`Package`] whose versions hydrate from byte spans on demand.
-//! - [`save_meta_indexed`] — atomic write via temp + rename so a torn
-//!   write never leaks a half-formed mirror to the next install.
+//! - [`save_meta_indexed`] / [`save_meta_ndjson`] — atomic write via
+//!   temp + rename so a torn write never leaks a half-formed mirror to
+//!   the next install.
 //!
 //! ## File layout
 //!
-//! Pacquet's own indexed format (this cache is no longer byte-shared
-//! with other package managers):
+//! Pacquet's indexed format:
 //!
 //! ```text
 //! pacquet-meta-v1 <headers_len> <index_len>\n
@@ -29,13 +29,15 @@
 //! loader rebases them so each version's slot can read its span
 //! directly. A warm pick therefore costs the two leading records plus
 //! one span read per version it actually hydrates — never the whole
-//! body. Files in the older two-line NDJSON shape read as cache
-//! misses and are rewritten in this format on the next 200.
+//! body.
+//!
+//! pnpm's two-line NDJSON format is also readable and is used when
+//! writing filtered full metadata.
 //!
 //! Plus the constants and name-encoding rules:
 //!
-//! - [`FULL_META_DIR`] / [`ABBREVIATED_META_DIR`] — directory slugs
-//!   pnpm and pacquet share.
+//! - [`FULL_META_DIR`] / [`FULL_FILTERED_META_DIR`] /
+//!   [`ABBREVIATED_META_DIR`] — directory slugs pnpm and pacquet share.
 //! - [`encode_pkg_name`] — mixed-case package names get a sha256 hex
 //!   suffix so case-insensitive filesystems (HFS+, NTFS by default)
 //!   can't collide two distinct package names onto one mirror file.
@@ -59,6 +61,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_registry::{Package, PackageVersions};
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 
 /// Mirror directory for the **abbreviated** metadata cache. Mirrors
@@ -70,6 +73,11 @@ pub const ABBREVIATED_META_DIR: &str = "v11/metadata";
 /// upstream's
 /// [`FULL_META_DIR`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/core/constants/src/index.ts#L22).
 pub const FULL_META_DIR: &str = "v11/metadata-full";
+
+/// Mirror directory for the filtered full metadata cache. Mirrors
+/// upstream's
+/// [`FULL_FILTERED_META_DIR`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/core/constants/src/index.ts#L23).
+pub const FULL_FILTERED_META_DIR: &str = "v11/metadata-full-filtered";
 
 /// Cached headers persisted as the mirror's first line. The cached
 /// metadata fetcher feeds these into `If-None-Match` /
@@ -217,6 +225,12 @@ struct MirrorIndex {
 #[diagnostic(code(pacquet_resolving_npm_resolver::mirror::encode))]
 pub struct EncodeMetaError(#[error(source)] serde_json::Error);
 
+impl EncodeMetaError {
+    pub(crate) fn into_inner(self) -> serde_json::Error {
+        self.0
+    }
+}
+
 /// Atomically persist `meta` at `pkg_mirror` in the indexed format.
 ///
 /// Version fragments come from [`PackageVersions::fragments`] — for a
@@ -231,7 +245,7 @@ pub fn save_meta_indexed(
 ) -> Result<(), SaveMetaError> {
     let headers = serde_json::to_string(&MetaHeaders {
         etag: etag.map(str::to_string),
-        modified: meta.modified.clone(),
+        modified: meta_modified(meta),
     })
     .map_err(|error| SaveMetaError::Encode(EncodeMetaError(error)))?;
 
@@ -267,20 +281,110 @@ pub fn save_meta_indexed(
     save_meta(pkg_mirror, &bytes)
 }
 
+/// Atomically persist `meta` at `pkg_mirror` in pnpm's two-line
+/// NDJSON mirror format.
+pub fn save_meta_ndjson(
+    pkg_mirror: &Path,
+    meta: &Package,
+    etag: Option<&str>,
+) -> Result<(), SaveMetaError> {
+    let headers = serde_json::to_vec(&MetaHeaders {
+        etag: etag.map(str::to_string),
+        modified: meta_modified(meta),
+    })
+    .map_err(|error| SaveMetaError::Encode(EncodeMetaError(error)))?;
+    let mut body_meta = meta.clone();
+    body_meta.etag = None;
+    let body = serde_json::to_vec(&body_meta)
+        .map_err(|error| SaveMetaError::Encode(EncodeMetaError(error)))?;
+
+    let mut bytes = Vec::with_capacity(headers.len() + 1 + body.len());
+    bytes.extend_from_slice(&headers);
+    bytes.push(b'\n');
+    bytes.extend_from_slice(&body);
+    save_meta(pkg_mirror, &bytes)
+}
+
+/// Strip full packuments down to the fields pnpm keeps when
+/// `filterMetadata` is enabled.
+pub fn clear_meta(meta: &Package) -> Result<Package, EncodeMetaError> {
+    const VERSION_KEYS: &[&str] = &[
+        "name",
+        "version",
+        "bin",
+        "directories",
+        "devDependencies",
+        "optionalDependencies",
+        "dependencies",
+        "peerDependencies",
+        "dist",
+        "engines",
+        "peerDependenciesMeta",
+        "cpu",
+        "os",
+        "libc",
+        "deprecated",
+        "bundleDependencies",
+        "bundledDependencies",
+        "hasInstallScript",
+        "_npmUser",
+    ];
+
+    let mut versions = Map::new();
+    for (version, json) in meta.versions.fragments() {
+        let info: Value = serde_json::from_str(&json).map_err(EncodeMetaError)?;
+        let Value::Object(info) = info else {
+            continue;
+        };
+        let mut filtered = Map::new();
+        for key in VERSION_KEYS {
+            if let Some(value) = info.get(*key) {
+                filtered.insert((*key).to_string(), value.clone());
+            }
+        }
+        versions.insert(version.clone(), Value::Object(filtered));
+    }
+
+    let mut pkg = Map::new();
+    pkg.insert("name".to_string(), Value::String(meta.name.clone()));
+    pkg.insert(
+        "dist-tags".to_string(),
+        serde_json::to_value(&meta.dist_tags).map_err(EncodeMetaError)?,
+    );
+    pkg.insert("versions".to_string(), Value::Object(versions));
+    if let Some(time) = meta.time.as_ref() {
+        pkg.insert("time".to_string(), serde_json::to_value(time).map_err(EncodeMetaError)?);
+    }
+    if let Some(modified) = meta.modified.as_ref() {
+        pkg.insert("modified".to_string(), Value::String(modified.clone()));
+    }
+
+    let mut cleared: Package =
+        serde_json::from_value(Value::Object(pkg)).map_err(EncodeMetaError)?;
+    cleared.etag.clone_from(&meta.etag);
+    Ok(cleared)
+}
+
+fn meta_modified(meta: &Package) -> Option<String> {
+    meta.modified.clone().or_else(|| {
+        meta.time
+            .as_ref()
+            .and_then(|time| time.get("modified"))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    })
+}
+
 /// Parse the `pacquet-meta-v1 <headers_len> <index_len>` line.
-/// `None` for anything else — including the previous NDJSON format,
-/// which thereby reads as a cache miss and gets rewritten on the next
-/// 200 response.
+/// `None` for anything else, including pnpm's NDJSON format.
 fn parse_mirror_magic(line: &str) -> Option<(usize, usize)> {
     let rest = line.strip_prefix(MIRROR_MAGIC)?.strip_prefix(' ')?;
     let (headers_len, index_len) = rest.split_once(' ')?;
     Some((headers_len.parse().ok()?, index_len.parse().ok()?))
 }
 
-/// Read the headers record off an indexed mirror without touching the
-/// index or fragment sections. `None` for anything unreadable —
-/// including the previous NDJSON format, which thereby reads as a
-/// cache miss.
+/// Read the headers record without touching the full metadata body.
+/// `None` for anything unreadable.
 fn read_mirror_headers(file: &mut File) -> Option<MetaHeaders> {
     // Magic + two decimal lengths fit well inside this; the headers
     // record is ~100 bytes of etag + timestamp.
@@ -296,7 +400,9 @@ fn read_mirror_headers(file: &mut File) -> Option<MetaHeaders> {
     let chunk = &buf[..filled];
     let newline = chunk.iter().position(|&byte| byte == b'\n')?;
     let line = std::str::from_utf8(&chunk[..newline]).ok()?;
-    let (headers_len, _) = parse_mirror_magic(line)?;
+    let Some((headers_len, _)) = parse_mirror_magic(line) else {
+        return serde_json::from_str(line).ok();
+    };
     // The headers record is ~100 bytes of etag + timestamp. Bound the
     // declared length before allocating from it so a corrupted or
     // hostile mirror can't trigger an arbitrarily large allocation.
@@ -345,7 +451,12 @@ pub fn load_meta(pkg_mirror: &Path) -> Option<Package> {
     let contents = fs::read(pkg_mirror).ok()?;
     let newline = contents.iter().position(|&byte| byte == b'\n')?;
     let line = std::str::from_utf8(&contents[..newline]).ok()?;
-    let (headers_len, index_len) = parse_mirror_magic(line)?;
+    let Some((headers_len, index_len)) = parse_mirror_magic(line) else {
+        let headers: MetaHeaders = serde_json::from_slice(&contents[..newline]).ok()?;
+        let mut meta: Package = serde_json::from_slice(&contents[newline + 1..]).ok()?;
+        meta.etag = headers.etag;
+        return Some(meta);
+    };
     let headers_start = newline + 1;
     let index_start = headers_start.checked_add(headers_len)?;
     let fragment_base = index_start.checked_add(index_len)?;

--- a/pacquet/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/mirror.rs
@@ -455,6 +455,7 @@ pub fn load_meta(pkg_mirror: &Path) -> Option<Package> {
         let headers: MetaHeaders = serde_json::from_slice(&contents[..newline]).ok()?;
         let mut meta: Package = serde_json::from_slice(&contents[newline + 1..]).ok()?;
         meta.etag = headers.etag;
+        meta.modified = meta.modified.or(headers.modified);
         return Some(meta);
     };
     let headers_start = newline + 1;

--- a/pacquet/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -154,11 +154,13 @@ fn load_meta_rejects_truncated_fragments() {
 fn pnpm_ndjson_format_reads_as_cache_hit() {
     let dir = TempDir::new().expect("tmp dir");
     let mirror = dir.path().join("acme.jsonl");
+    let mut pkg = fixture_package();
+    pkg.modified = None;
     std::fs::write(
         &mirror,
         format!(
             "{{\"etag\":\"W/abc\",\"modified\":\"2025-01-15T12:00:00.000Z\"}}\n{}",
-            serde_json::to_string(&fixture_package()).expect("serialize fixture"),
+            serde_json::to_string(&pkg).expect("serialize fixture"),
         ),
     )
     .expect("write pnpm format");
@@ -166,6 +168,7 @@ fn pnpm_ndjson_format_reads_as_cache_hit() {
     assert_eq!(headers.etag.as_deref(), Some("W/abc"));
     let meta = load_meta(&mirror).expect("read meta");
     assert_eq!(meta.etag.as_deref(), Some("W/abc"));
+    assert_eq!(meta.modified.as_deref(), Some("2025-01-15T12:00:00.000Z"));
     assert_eq!(meta.published_at("1.0.0"), Some("2025-01-10T08:30:00.000Z"));
 }
 

--- a/pacquet/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -5,8 +5,8 @@ use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 
 use super::{
-    ABBREVIATED_META_DIR, FULL_META_DIR, encode_pkg_name, get_pkg_mirror_path, get_registry_name,
-    load_meta, load_meta_headers, save_meta_indexed,
+    ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, encode_pkg_name,
+    get_pkg_mirror_path, get_registry_name, load_meta, load_meta_headers, save_meta_indexed,
 };
 
 /// Lower-case names pass through unchanged. Matches upstream's
@@ -76,6 +76,7 @@ fn get_pkg_mirror_path_composes_full_path() {
 #[test]
 fn constants_match_upstream() {
     assert_eq!(FULL_META_DIR, "v11/metadata-full");
+    assert_eq!(FULL_FILTERED_META_DIR, "v11/metadata-full-filtered");
     assert_eq!(ABBREVIATED_META_DIR, "v11/metadata");
 }
 
@@ -147,16 +148,25 @@ fn load_meta_rejects_truncated_fragments() {
     assert!(load_meta(&mirror).is_none());
 }
 
-/// Files in the previous two-line NDJSON format read as cache misses
-/// (the fetcher then refetches and rewrites in the indexed format).
+/// Files in pnpm's two-line NDJSON format are readable so pnpm and
+/// pacquet share the same metadata mirror.
 #[test]
-fn previous_ndjson_format_reads_as_cache_miss() {
+fn pnpm_ndjson_format_reads_as_cache_hit() {
     let dir = TempDir::new().expect("tmp dir");
     let mirror = dir.path().join("acme.jsonl");
-    std::fs::write(&mirror, "{\"etag\":\"W/abc\"}\n{\"name\":\"acme\",\"versions\":{}}")
-        .expect("write old format");
-    assert!(load_meta_headers(&mirror).is_none());
-    assert!(load_meta(&mirror).is_none());
+    std::fs::write(
+        &mirror,
+        format!(
+            "{{\"etag\":\"W/abc\",\"modified\":\"2025-01-15T12:00:00.000Z\"}}\n{}",
+            serde_json::to_string(&fixture_package()).expect("serialize fixture"),
+        ),
+    )
+    .expect("write pnpm format");
+    let headers = load_meta_headers(&mirror).expect("read headers");
+    assert_eq!(headers.etag.as_deref(), Some("W/abc"));
+    let meta = load_meta(&mirror).expect("read meta");
+    assert_eq!(meta.etag.as_deref(), Some("W/abc"));
+    assert_eq!(meta.published_at("1.0.0"), Some("2025-01-10T08:30:00.000Z"));
 }
 
 /// Missing file → `None` from both readers. The fetcher's lookup

--- a/pacquet/crates/resolving-npm-resolver/src/named_registry_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/named_registry_resolver.rs
@@ -86,6 +86,9 @@ pub struct NamedRegistryResolver<Cache: PackageMetaCache> {
     /// [`PickPackageContext::full_metadata`]. Mirrors upstream's
     /// [`ctx.fullMetadata`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L175).
     pub full_metadata: bool,
+    /// When full metadata is forced, read and write pnpm's filtered
+    /// full-metadata mirror.
+    pub filter_metadata: bool,
     /// Retry budget threaded through to
     /// [`PickPackageContext::retry_opts`]. Same `fetch-retries`-sourced
     /// budget the sibling [`crate::NpmResolver`] uses.
@@ -225,6 +228,7 @@ impl<Cache: PackageMetaCache + 'static> NamedRegistryResolver<Cache> {
             prefer_offline: self.prefer_offline,
             ignore_missing_time_field: self.ignore_missing_time_field,
             full_metadata: self.full_metadata,
+            filter_metadata: self.filter_metadata,
             retry_opts: self.retry_opts,
         };
 

--- a/pacquet/crates/resolving-npm-resolver/src/named_registry_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/named_registry_resolver/tests.rs
@@ -82,6 +82,7 @@ fn build_resolver(
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
     (resolver, cache_dir)

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -120,6 +120,9 @@ pub struct NpmResolver<Cache: PackageMetaCache> {
     /// [`PickPackageContext::full_metadata`]. Mirrors upstream's
     /// [`ctx.fullMetadata`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L175).
     pub full_metadata: bool,
+    /// When full metadata is forced, read and write pnpm's filtered
+    /// full-metadata mirror.
+    pub filter_metadata: bool,
     /// Retry budget threaded through to
     /// [`PickPackageContext::retry_opts`]. Sourced from the install's
     /// `fetch-retries` config.
@@ -391,6 +394,7 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             prefer_offline: self.prefer_offline,
             ignore_missing_time_field: self.ignore_missing_time_field,
             full_metadata: self.full_metadata,
+            filter_metadata: self.filter_metadata,
             retry_opts: self.retry_opts,
         };
 

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -77,6 +77,7 @@ fn build_resolver_with_registries(
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
     (resolver, cache_dir)
@@ -599,6 +600,7 @@ async fn shared_manifest_cache_does_not_leak_across_registries() {
             prefer_offline: false,
             ignore_missing_time_field: false,
             full_metadata: false,
+            filter_metadata: false,
             retry_opts: RetryOpts::default(),
         };
         (resolver, cache_dir)

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -401,8 +401,9 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     // is the install-wide bias. Either being `true` forces the full
     // packument.
     let full_metadata = opts.optional || ctx.full_metadata;
+    let use_filtered_full_metadata = full_metadata && ctx.filter_metadata;
     let meta_dir = if full_metadata {
-        if ctx.filter_metadata { FULL_FILTERED_META_DIR } else { FULL_META_DIR }
+        if use_filtered_full_metadata { FULL_FILTERED_META_DIR } else { FULL_META_DIR }
     } else {
         ABBREVIATED_META_DIR
     };
@@ -419,14 +420,16 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     // shares one cache across all `pick_package` calls, so the key
     // has to do the scoping itself.
     //
-    // The `:full` suffix mirrors upstream's
+    // The full-mode suffix mirrors upstream's
     // [cache-key shape](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L206):
     // a later call with `opts.optional = true` must not satisfy
     // itself with the abbreviated cache entry an earlier call
     // populated (the abbreviated form drops `libc`/`cpu`/`os` from
-    // some shapes).
+    // some shapes). Filtered full metadata gets its own suffix
+    // because pacquet stores it in a distinct on-disk mirror shape.
     let cache_key = if full_metadata {
-        format!("{}\x00{}:full", opts.registry, spec.name)
+        let suffix = if use_filtered_full_metadata { ":full:filtered" } else { ":full" };
+        format!("{}\x00{}{suffix}", opts.registry, spec.name)
     } else {
         format!("{}\x00{}", opts.registry, spec.name)
     };
@@ -439,6 +442,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             opts,
             &picker_opts,
             full_metadata,
+            use_filtered_full_metadata,
             &cache_key,
             pkg_mirror.as_deref(),
             cached,
@@ -481,6 +485,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             opts,
             &picker_opts,
             full_metadata,
+            use_filtered_full_metadata,
             &cache_key,
             pkg_mirror.as_deref(),
             cached,
@@ -518,7 +523,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             let meta = upgrade.meta;
             if upgrade.upgraded && !opts.dry_run {
                 if let Some(path) = pkg_mirror.as_deref() {
-                    persist_upgraded_to_mirror(path, &meta, ctx.filter_metadata);
+                    persist_upgraded_to_mirror(path, &meta, use_filtered_full_metadata);
                 }
                 ctx.meta_cache.set(cache_key.clone(), Arc::clone(&meta));
             }
@@ -614,7 +619,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         auth_headers: ctx.auth_headers,
         cache_dir: ctx.cache_dir,
         full_metadata,
-        filter_metadata: ctx.filter_metadata,
+        filter_metadata: use_filtered_full_metadata,
         retry_opts: ctx.retry_opts,
     };
 
@@ -660,7 +665,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         && !opts.dry_run
         && let Some(path) = pkg_mirror.as_deref()
     {
-        persist_upgraded_to_mirror(path, &meta, ctx.filter_metadata);
+        persist_upgraded_to_mirror(path, &meta, use_filtered_full_metadata);
     }
 
     // Divergence from upstream worth flagging: pnpm's pickPackage
@@ -699,6 +704,7 @@ async fn handle_cache_hit<Cache: PackageMetaCache>(
     opts: &PickPackageOptions<'_>,
     picker_opts: &PickerOpts<'_>,
     full_metadata: bool,
+    use_filtered_full_metadata: bool,
     cache_key: &str,
     pkg_mirror: Option<&Path>,
     cached: Arc<Package>,
@@ -712,7 +718,7 @@ async fn handle_cache_hit<Cache: PackageMetaCache>(
         // fetch on its next install. Matches upstream's
         // [`persistUpgradedMeta`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L507-L524).
         if let Some(path) = pkg_mirror {
-            persist_upgraded_to_mirror(path, &meta, ctx.filter_metadata);
+            persist_upgraded_to_mirror(path, &meta, use_filtered_full_metadata);
         }
         ctx.meta_cache.set(cache_key.to_string(), Arc::clone(&meta));
     }

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -69,8 +69,8 @@ use crate::{
     FetchFullMetadataCachedOptions, FetchFullMetadataOptions, FetchFullMetadataOutcome,
     FetchMetadataError, fetch_full_metadata, fetch_full_metadata_cached,
     mirror::{
-        ABBREVIATED_META_DIR, FULL_META_DIR, get_pkg_mirror_path, load_meta_async,
-        save_meta_indexed,
+        ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, clear_meta,
+        get_pkg_mirror_path, load_meta_async, save_meta_indexed, save_meta_ndjson,
     },
     pick_package_from_meta::{
         PickPackageFromMetaError, PickPackageFromMetaOptions, RegistryPackageSpec,
@@ -237,6 +237,9 @@ pub struct PickPackageContext<'a, Cache: PackageMetaCache> {
     /// `false`; the verifier-time fetcher sets it `true` because
     /// it needs `time` and trust evidence for every entry.
     pub full_metadata: bool,
+    /// When full metadata is forced, use pnpm's filtered full-metadata
+    /// mirror and filtered packument shape.
+    pub filter_metadata: bool,
     /// Retry budget for the picker's metadata fetches. Sourced from
     /// the same `fetch-retries` config the verifier and tarball paths
     /// use, so a registry flap during a pick retries (and a user who
@@ -398,7 +401,11 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     // is the install-wide bias. Either being `true` forces the full
     // packument.
     let full_metadata = opts.optional || ctx.full_metadata;
-    let meta_dir = if full_metadata { FULL_META_DIR } else { ABBREVIATED_META_DIR };
+    let meta_dir = if full_metadata {
+        if ctx.filter_metadata { FULL_FILTERED_META_DIR } else { FULL_META_DIR }
+    } else {
+        ABBREVIATED_META_DIR
+    };
 
     let pkg_mirror = ctx
         .cache_dir
@@ -511,7 +518,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             let meta = upgrade.meta;
             if upgrade.upgraded && !opts.dry_run {
                 if let Some(path) = pkg_mirror.as_deref() {
-                    persist_upgraded_to_mirror(path, &meta);
+                    persist_upgraded_to_mirror(path, &meta, ctx.filter_metadata);
                 }
                 ctx.meta_cache.set(cache_key.clone(), Arc::clone(&meta));
             }
@@ -607,6 +614,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         auth_headers: ctx.auth_headers,
         cache_dir: ctx.cache_dir,
         full_metadata,
+        filter_metadata: ctx.filter_metadata,
         retry_opts: ctx.retry_opts,
     };
 
@@ -652,7 +660,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         && !opts.dry_run
         && let Some(path) = pkg_mirror.as_deref()
     {
-        persist_upgraded_to_mirror(path, &meta);
+        persist_upgraded_to_mirror(path, &meta, ctx.filter_metadata);
     }
 
     // Divergence from upstream worth flagging: pnpm's pickPackage
@@ -704,7 +712,7 @@ async fn handle_cache_hit<Cache: PackageMetaCache>(
         // fetch on its next install. Matches upstream's
         // [`persistUpgradedMeta`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L507-L524).
         if let Some(path) = pkg_mirror {
-            persist_upgraded_to_mirror(path, &meta);
+            persist_upgraded_to_mirror(path, &meta, ctx.filter_metadata);
         }
         ctx.meta_cache.set(cache_key.to_string(), Arc::clone(&meta));
     }
@@ -1114,8 +1122,25 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
 /// and the install proceeds — the next install simply re-triggers
 /// the upgrade fetch. Mirrors upstream's
 /// [`persistUpgradedMeta`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L507-L524).
-fn persist_upgraded_to_mirror(pkg_mirror: &Path, meta: &Package) {
-    if let Err(error) = save_meta_indexed(pkg_mirror, meta, meta.etag.as_deref()) {
+fn persist_upgraded_to_mirror(pkg_mirror: &Path, meta: &Package, filter_metadata: bool) {
+    let save_result = if filter_metadata {
+        let meta_for_cache = match clear_meta(meta) {
+            Ok(meta_for_cache) => meta_for_cache,
+            Err(error) => {
+                tracing::debug!(
+                    target: "pacquet_resolving_npm_resolver::pick_package",
+                    ?error,
+                    path = %pkg_mirror.display(),
+                    "could not filter upgraded mirror metadata",
+                );
+                return;
+            }
+        };
+        save_meta_ndjson(pkg_mirror, &meta_for_cache, meta.etag.as_deref())
+    } else {
+        save_meta_indexed(pkg_mirror, meta, meta.etag.as_deref())
+    };
+    if let Err(error) = save_result {
         tracing::debug!(
             target: "pacquet_resolving_npm_resolver::pick_package",
             ?error,

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -777,6 +777,63 @@ async fn cache_key_separates_abbreviated_from_full() {
     full_mock.assert_async().await;
 }
 
+#[tokio::test]
+async fn cache_key_separates_filtered_full_from_unfiltered_full() {
+    let mut server = mockito::Server::new_async().await;
+    let full_mock = server
+        .mock("GET", "/acme")
+        .match_header("accept", "application/json; q=1.0, */*")
+        .with_status(200)
+        .with_body(PACKAGE_BODY)
+        .expect(2)
+        .create_async()
+        .await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+    let unfiltered_ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: true,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+    let filtered_ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: true,
+        filter_metadata: true,
+        retry_opts: RetryOpts::default(),
+    };
+
+    let _ = pick_package(&unfiltered_ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
+        .await
+        .expect("unfiltered full");
+    let _ = pick_package(&filtered_ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
+        .await
+        .expect("filtered full");
+
+    assert!(meta_cache.get(&format!("{registry}\x00acme:full")).is_some());
+    assert!(meta_cache.get(&format!("{registry}\x00acme:full:filtered")).is_some());
+    full_mock.assert_async().await;
+}
+
 /// `published_by` active + abbreviated cache lacking `time` +
 /// `modified` after the cutoff → re-fetch full metadata so the
 /// maturity check runs on real timestamps. Persisting the upgrade

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -10,7 +10,9 @@ use super::{
     PickPackageOptions, persist_meta_to_mirror, pick_package, shared_packument_fetch_locker,
 };
 use crate::{
-    mirror::{ABBREVIATED_META_DIR, FULL_META_DIR, get_pkg_mirror_path, load_meta},
+    mirror::{
+        ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, get_pkg_mirror_path, load_meta,
+    },
     pick_package_from_meta::{RegistryPackageSpec, RegistryPackageSpecType},
 };
 
@@ -106,6 +108,7 @@ async fn cold_pick_fetches_and_picks_max_in_range() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -123,6 +126,42 @@ async fn cold_pick_fetches_and_picks_max_in_range() {
     // landed.
     let key = format!("{registry}\x00acme");
     assert!(meta_cache.get(&key).is_some(), "in-memory cache populated");
+}
+
+#[tokio::test]
+async fn filtered_full_metadata_reads_pnpm_jsonl_mirror_for_lowest_pick() {
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = "https://registry.example.test/";
+    let mirror_path =
+        get_pkg_mirror_path(cache_dir.path(), FULL_FILTERED_META_DIR, registry, "acme")
+            .expect("path");
+    std::fs::create_dir_all(mirror_path.parent().expect("mirror parent")).expect("mkdir");
+    std::fs::write(&mirror_path, format!("{{\"etag\":\"W/filtered\"}}\n{PACKAGE_BODY}"))
+        .expect("write pnpm jsonl mirror");
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: true,
+        filter_metadata: true,
+        retry_opts: RetryOpts::default(),
+    };
+
+    let mut opts = default_opts(registry);
+    opts.pick_lowest_version = true;
+
+    let result = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &opts).await.expect("ok");
+    assert_eq!(result.picked_package.expect("picked").version.to_string(), "1.0.0");
 }
 
 /// Warm in-memory cache: no network call, picker reads the cached
@@ -155,6 +194,7 @@ async fn warm_in_memory_cache_skips_network() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -193,6 +233,7 @@ async fn offline_with_mirror_picks_from_disk() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -224,6 +265,7 @@ async fn offline_without_mirror_errors() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -261,6 +303,7 @@ async fn version_spec_with_mirror_takes_fast_path() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -326,6 +369,7 @@ async fn version_spec_missing_in_mirror_fetches() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -367,6 +411,7 @@ async fn dry_run_skips_in_memory_cache() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -406,6 +451,7 @@ async fn pick_lowest_version_picks_min() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -490,6 +536,7 @@ async fn in_memory_cache_does_not_leak_across_registries() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -533,6 +580,7 @@ async fn invalid_package_name_errors_synchronously() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -601,6 +649,7 @@ async fn default_pick_targets_abbreviated_endpoint_and_mirror() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -651,6 +700,7 @@ async fn optional_opt_forces_full_metadata_endpoint() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -708,6 +758,7 @@ async fn cache_key_separates_abbreviated_from_full() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -776,6 +827,7 @@ async fn published_by_triggers_upgrade_when_modified_after_cutoff() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -843,6 +895,7 @@ async fn published_by_skips_upgrade_when_modified_equals_cutoff() {
         prefer_offline: false,
         ignore_missing_time_field: true,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -889,6 +942,7 @@ async fn published_by_exclude_skips_upgrade_for_abbreviated_meta_without_time() 
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -972,6 +1026,7 @@ async fn published_by_excluded_package_bypasses_mtime_shortcut_and_revalidates()
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 
@@ -1035,6 +1090,7 @@ async fn concurrent_picks_for_same_key_share_one_network_fetch() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
 

--- a/pacquet/crates/resolving-npm-resolver/tests/chain.rs
+++ b/pacquet/crates/resolving-npm-resolver/tests/chain.rs
@@ -48,6 +48,7 @@ fn named_registry_resolver(
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        filter_metadata: false,
         retry_opts: RetryOpts::default(),
     }
 }


### PR DESCRIPTION
## Summary
- resolve `pnpm` and `@pnpm/exe` package manager dependencies into the env lockfile with metadata needed for parity
- make pacquet honor the filtered full-metadata mirror and pnpm JSONL metadata cache files
- add regression coverage for package manager dependency graphs, filtered metadata caches, and JSONL mirrors

## Verification
- `cargo test -p pacquet-resolving-npm-resolver mirror`
- `cargo test -p pacquet-resolving-npm-resolver pick_package`
- `cargo test -p pacquet-resolving-npm-resolver fetch_full_metadata_cached`
- `cargo test -p pacquet-env-installer`
- `cargo build --bin pacquet`
- manual pnpm-vs-pacquet lockfile comparison in `/Volumes/src/pnpm/pnpm/lockfile-test`
- final `git push` pre-push hook passed

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * During installation, Pacquet can now optionally synchronize pnpm “package manager dependencies” from the workspace `package.json` policy, including when frozen-lockfile mode is enabled.
* **Improvements**
  * More accurate lockfile generation and resolution for optional dependencies, including platform metadata (such as `libc`) and package-manager metadata.
  * Enhanced resolver mirror support, including pnpm-style JSONL mirrors and filtered full-metadata caching/persistence.
* **Bug Fixes**
  * Improved lockfile pruning/traversal to generate smaller lockfiles without missing optional dependency reachability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->