### PR TITLE
fix(publish): forward strictSsl to libnpmpublish so self-signed registries work

### DIFF
--- a/.changeset/fix-publish-strict-ssl.md
+++ b/.changeset/fix-publish-strict-ssl.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+Fixed `pnpm publish` ignoring `strictSsl: false` when publishing to registries with self-signed certificates. The `strictSSL` option is now forwarded to `libnpmpublish` / `npm-registry-fetch` so that `strict-ssl=false` in `.npmrc` or `strictSsl: false` in `pnpm-workspace.yaml` is respected during publish, the same way it is for `pnpm install` [pnpm/pnpm#12012](https://github.com/pnpm/pnpm/issues/12012).

--- a/releasing/commands/src/publish/publishPackedPkg.ts
+++ b/releasing/commands/src/publish/publishPackedPkg.ts
@@ -160,6 +160,7 @@ export async function createPublishOptions (
     provenance,
     provenanceFile,
     registry,
+    strictSSL: options.strictSsl, // npm-registry-fetch defaults to true; must be set explicitly to honour strictSsl: false
     userAgent,
     // Signal to the registry that the client supports web-based authentication.
     // Without this, the registry would never offer the web auth flow and would

--- a/releasing/commands/test/publish/publishConfigAccess.test.ts
+++ b/releasing/commands/test/publish/publishConfigAccess.test.ts
@@ -32,6 +32,24 @@ afterAll(() => {
   process.env['NPM_ID_TOKEN'] = savedNpmIdToken
 })
 
+describe('createPublishOptions: strictSSL', () => {
+  test('forwards strictSsl: false as strictSSL to npm-registry-fetch', async () => {
+    const opts = await createPublishOptions(
+      { name: 'pkg', version: '1.0.0' },
+      { ...baseOpts(), strictSsl: false }
+    )
+    expect(opts.strictSSL).toBe(false)
+  })
+
+  test('strictSSL is absent when strictSsl is not set', async () => {
+    const opts = await createPublishOptions(
+      { name: 'pkg', version: '1.0.0' },
+      baseOpts()
+    )
+    expect(opts.strictSSL).toBeUndefined()
+  })
+})
+
 describe('createPublishOptions: access', () => {
   test('falls back to publishConfig.access when --access is not set', async () => {
     const opts = await createPublishOptions(


### PR DESCRIPTION
## Summary

- `pnpm publish` was silently ignoring `strict-ssl=false` (from `.npmrc`) and `strictSsl: false` (from `pnpm-workspace.yaml`) when publishing to registries that use self-signed certificates, causing a `UNABLE_TO_VERIFY_LEAF_SIGNATURE` error after a long timeout.
- The root cause: `createPublishOptions` in `publishPackedPkg.ts` never included `strictSSL` in the options object forwarded to `libnpmpublish`. Since `npm-registry-fetch` (used internally by `libnpmpublish`) defaults `strictSSL` to `true`, the option had to be passed explicitly.
- Fix: map `options.strictSsl → strictSSL` in `publishOptions`, matching the same behaviour that already works for `pnpm install`.

## Test plan

- [ ] New unit tests in `publishConfigAccess.test.ts` verify that `strictSsl: false` maps to `strictSSL: false` in the publish options object, and that `strictSSL` is absent when `strictSsl` is not set.
- [ ] Manual verification requires a registry with a self-signed certificate (e.g. Sonatype Nexus) — see the reproduction steps in the linked issue.

Fixes [pnpm/pnpm#12012](https://github.com/pnpm/pnpm/issues/12012).

---
Written by an agent (Claude Code, claude-sonnet-4-6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm publish` to respect `strictSsl: false` configuration for registries with self-signed certificates.

* **Tests**
  * Added test coverage for strict SSL configuration handling in publish options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->