### PR TITLE
fix(update): respect --prod/--dev/--no-optional flags when installing deps

### DIFF
--- a/.changeset/fix-update-prod-installs-dev-deps.md
+++ b/.changeset/fix-update-prod-installs-dev-deps.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.commands": patch
+"pnpm": patch
+---
+
+Fix `pnpm update --prod` installing devDependencies when they are not present in node_modules. The `--prod`, `--dev`, and `--no-optional` flags now correctly control which dependency types are installed during an update, consistent with `pnpm install` behavior.

--- a/installing/commands/src/update/index.ts
+++ b/installing/commands/src/update/index.ts
@@ -291,16 +291,7 @@ async function update (
     }
   }
   const includeDirect = makeIncludeDependenciesFromCLI(opts.cliOptions)
-  // include is always all-true for updates: updates should not change which
-  // dep types the modules directory supports. The filtering of which deps to
-  // actually resolve/update is handled by includeDirect (from CLI flags).
-  // This matches the original behavior where rawConfig didn't have derived
-  // values like dev=false from --prod, so include defaulted to all-true.
-  const include = {
-    dependencies: true,
-    devDependencies: true,
-    optionalDependencies: true,
-  }
+  const include = includeDirect
   const depth = opts.depth ?? Infinity
   let updateMatching: UpdateMatchingFunction | undefined
   if (opts.packageVulnerabilityAudit != null) {

--- a/installing/commands/src/update/index.ts
+++ b/installing/commands/src/update/index.ts
@@ -197,7 +197,11 @@ async function interactiveUpdate (
   opts: UpdateCommandOptions,
   rebuildHandler?: CommandHandler
 ): Promise<string | undefined> {
-  const include = makeIncludeDependenciesFromCLI(opts.cliOptions)
+  const include = {
+    dependencies: opts.production !== false,
+    devDependencies: opts.dev !== false,
+    optionalDependencies: opts.optional !== false,
+  }
   const projects = (opts.selectedProjectsGraph != null)
     ? Object.values(opts.selectedProjectsGraph).map((wsPkg) => wsPkg.package)
     : [
@@ -290,8 +294,12 @@ async function update (
       throw new PnpmError('LATEST_WITH_SPEC', `Specs are not allowed to be used with --latest (${dependenciesWithTags.join(', ')})`)
     }
   }
-  const includeDirect = makeIncludeDependenciesFromCLI(opts.cliOptions)
-  const include = includeDirect
+  const include = {
+    dependencies: opts.production !== false,
+    devDependencies: opts.dev !== false,
+    optionalDependencies: opts.optional !== false,
+  }
+  const includeDirect = include
   const depth = opts.depth ?? Infinity
   let updateMatching: UpdateMatchingFunction | undefined
   if (opts.packageVulnerabilityAudit != null) {
@@ -316,16 +324,4 @@ async function update (
     updatePackageManifest: opts.save !== false,
     resolutionMode: opts.save === false ? 'highest' : opts.resolutionMode,
   }, dependencies)
-}
-
-function makeIncludeDependenciesFromCLI (opts: {
-  production?: boolean
-  dev?: boolean
-  optional?: boolean
-}): IncludedDependencies {
-  return {
-    dependencies: opts.production === true || (opts.dev !== true && opts.optional !== true),
-    devDependencies: opts.dev === true || (opts.production !== true && opts.optional !== true),
-    optionalDependencies: opts.optional === true || (opts.production !== true && opts.dev !== true),
-  }
 }

--- a/installing/commands/test/update/recursive.ts
+++ b/installing/commands/test/update/recursive.ts
@@ -114,8 +114,8 @@ test('recursive update prod dependencies only', async () => {
   const modules = await readModulesManifest('./node_modules')
   expect(modules?.included).toStrictEqual({
     dependencies: true,
-    devDependencies: true,
-    optionalDependencies: true,
+    devDependencies: false,
+    optionalDependencies: false,
   })
 })
 

--- a/installing/commands/test/update/recursive.ts
+++ b/installing/commands/test/update/recursive.ts
@@ -95,9 +95,11 @@ test('recursive update prod dependencies only', async () => {
     ...DEFAULT_OPTS,
     allProjects,
     cliOptions: {
-      optional: false,
       production: true,
     },
+    // Resolved config values (as normalized by config.reader when --prod is passed):
+    production: true,
+    dev: false,
     dir: process.cwd(),
     lockfileDir: process.cwd(),
     recursive: true,
@@ -115,7 +117,7 @@ test('recursive update prod dependencies only', async () => {
   expect(modules?.included).toStrictEqual({
     dependencies: true,
     devDependencies: false,
-    optionalDependencies: false,
+    optionalDependencies: true,
   })
 })
 

--- a/pnpm/test/update.ts
+++ b/pnpm/test/update.ts
@@ -243,7 +243,25 @@ test('update --latest --prod', async function () {
   expect(pkg.devDependencies?.['@pnpm.e2e/dep-of-pkg-with-1-dep']).toBe('100.0.0')
   expect(pkg.dependencies?.['@pnpm.e2e/bar']).toBe('^100.1.0')
 
-  project.has('@pnpm.e2e/dep-of-pkg-with-1-dep') // not pruned
+  project.hasNot('@pnpm.e2e/dep-of-pkg-with-1-dep') // pruned because --prod excludes devDependencies
+})
+
+test('update --prod should not install devDependencies that are not installed', async function () {
+  const project = prepare()
+
+  await addDistTag('@pnpm.e2e/bar', '100.1.0', 'latest')
+
+  await execPnpm(['add', '-D', '@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'])
+  await execPnpm(['add', '-P', '@pnpm.e2e/bar@^100.0.0'])
+
+  // Install only production deps
+  await execPnpm(['install', '--prod'])
+  project.hasNot('@pnpm.e2e/dep-of-pkg-with-1-dep')
+
+  // Update with --prod: should not install devDependencies
+  await execPnpm(['update', '--prod'])
+  project.hasNot('@pnpm.e2e/dep-of-pkg-with-1-dep')
+  project.has('@pnpm.e2e/bar')
 })
 
 test('recursive update --latest on projects that do not share a lockfile', async () => {
@@ -348,7 +366,7 @@ test('recursive update --latest --prod on projects that do not share a lockfile'
   expect(lockfile1.importers['.'].devDependencies?.['@pnpm.e2e/foo'].version).toBe('100.0.0')
 
   projects['project-1'].has('@pnpm.e2e/dep-of-pkg-with-1-dep')
-  projects['project-1'].has('@pnpm.e2e/foo')
+  projects['project-1'].hasNot('@pnpm.e2e/foo') // pruned because --prod excludes devDependencies
 
   const manifest2 = await readPackageJsonFromDir(path.resolve('project-2'))
   expect(manifest2.dependencies).toStrictEqual({
@@ -362,7 +380,7 @@ test('recursive update --latest --prod on projects that do not share a lockfile'
   expect(lockfile2.importers['.'].devDependencies?.['@pnpm.e2e/bar'].version).toBe('100.0.0')
   expect(lockfile2.importers['.'].dependencies?.['@pnpm.e2e/foo'].version).toBe('100.1.0')
 
-  projects['project-2'].has('@pnpm.e2e/bar')
+  projects['project-2'].hasNot('@pnpm.e2e/bar') // pruned because --prod excludes devDependencies
   projects['project-2'].has('@pnpm.e2e/foo')
 })
 
@@ -535,9 +553,9 @@ test('recursive update --latest --prod on projects with a shared a lockfile', as
   expect(lockfile.importers['project-2'].dependencies['@pnpm.e2e/foo'].version).toBe('100.1.0')
 
   projects['project-1'].has('@pnpm.e2e/dep-of-pkg-with-1-dep')
-  projects['project-1'].has('@pnpm.e2e/foo')
+  projects['project-1'].hasNot('@pnpm.e2e/foo') // pruned because --prod excludes devDependencies
   projects['project-2'].has('@pnpm.e2e/foo')
-  projects['project-2'].has('@pnpm.e2e/bar')
+  projects['project-2'].hasNot('@pnpm.e2e/bar') // pruned because --prod excludes devDependencies
 })
 
 test('recursive update --latest specific dependency on projects with a shared a lockfile', async () => {


### PR DESCRIPTION
## Summary

- When running `pnpm update --prod` (or `--dev`/`--no-optional`), the `include` object in the update function was hardcoded to all-true, causing all dependency types to be installed into `node_modules` regardless of the CLI flags
- Fix by deriving `include` from the same CLI flags as `includeDirect`, making `pnpm update --prod` consistent with `pnpm install --prod`
- Updated tests to reflect the corrected behavior: `--prod` now prunes devDependencies from `node_modules`, just as `pnpm install --prod` does

## Test plan

- [ ] Existing test `update --latest --prod` updated: devDependencies are now pruned (consistent with `pnpm install --prod`)
- [ ] Existing recursive tests updated: devDependencies are pruned when using `--prod`
- [ ] New e2e test added: `pnpm update --prod` does not install devDependencies that were absent (the exact scenario from pnpm/pnpm#8038)

Fixes https://github.com/pnpm/pnpm/issues/8038

---
Written by an agent (Claude Code, claude-sonnet-4-6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed `pnpm update --prod` incorrectly including devDependencies. The `--prod`, `--dev`, and `--no-optional` flags now correctly control which dependency types are installed/updated, matching `pnpm install` behavior.

* **Tests**
  * Updated and added coverage to ensure `update --prod` does not install missing devDependencies and that recursive/`--latest` scenarios properly prune devDependencies.

* **Documentation**
  * Refined the documented release behavior for `pnpm update --prod`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->