### PR TITLE
test(pnpm): enforce minimumReleaseAge during --fix-lockfile

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,7 @@ import * as regexpPlugin from "eslint-plugin-regexp";
 
 export default [
     {
-        ignores: ["**/fixtures", "**/__fixtures__", "**/node_modules", "**/lib"],
+        ignores: ["**/fixtures", "**/__fixtures__", "**/node_modules", "**/lib", ".claude/**"],
     },
     ...eslintConfig,
     regexpPlugin.configs['flat/recommended'],

--- a/pnpm/test/install/minimumReleaseAge.ts
+++ b/pnpm/test/install/minimumReleaseAge.ts
@@ -392,4 +392,57 @@ describe('lockfile minimumReleaseAge verification', () => {
     expect(output).toContain('ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION')
     expect(output).toMatch(/is-odd@0\.1\.2/)
   })
+
+  test('--fix-lockfile enforces minimumReleaseAge on existing lockfile entries', () => {
+    // Reproduces the scenario from https://github.com/pnpm/pnpm/issues/10361:
+    // a lockfile entry that was installed while the package was immature (possibly
+    // under a minimumReleaseAgeExclude) must still be rejected by the verifier when
+    // --fix-lockfile is run without an exclude covering it. The fix-lockfile path
+    // must not bypass the lockfile verification step.
+    prepare({
+      dependencies: { 'is-odd': '0.1.2' },
+    })
+    execPnpmSync([PUBLIC_REGISTRY, 'install'], { expectSuccess: true })
+
+    // Turn on an extreme minimumReleaseAge (no exclude list) so every locked
+    // entry is considered immature.
+    writeYamlFileSync('pnpm-workspace.yaml', {
+      minimumReleaseAge: IMMATURE_FOR_EVERYTHING,
+      minimumReleaseAgeStrict: true,
+    })
+
+    const result = execPnpmSync(
+      [PUBLIC_REGISTRY, 'install', '--fix-lockfile'],
+      omitMinReleaseAgeEnv
+    )
+
+    expect(result.status).toBe(1)
+    const output = `${result.stdout.toString()}\n${result.stderr.toString()}`
+    expect(output).toContain('ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION')
+    expect(output).toMatch(/is-odd@0\.1\.2/)
+  })
+
+  test('--fix-lockfile respects minimumReleaseAgeExclude for entries in the exclude list', () => {
+    // When minimumReleaseAgeExclude covers the immature lockfile entries, --fix-lockfile
+    // should succeed (the verifier accepts excluded entries).
+    prepare({
+      dependencies: { 'is-odd': '0.1.2' },
+    })
+    execPnpmSync([PUBLIC_REGISTRY, 'install'], { expectSuccess: true })
+
+    writeYamlFileSync('pnpm-workspace.yaml', {
+      minimumReleaseAge: IMMATURE_FOR_EVERYTHING,
+      minimumReleaseAgeStrict: true,
+      // is-odd is version-qualified to exercise the exact-version exclude path
+      // (the `name@version` form that issue 10361 relies on); the transitive
+      // deps stay name-only because their resolved versions shift across npm
+      // republishes.
+      minimumReleaseAgeExclude: ['is-odd@0.1.2', 'is-buffer', 'is-number', 'kind-of'],
+    })
+
+    execPnpmSync(
+      [PUBLIC_REGISTRY, 'install', '--fix-lockfile'],
+      { ...omitMinReleaseAgeEnv, expectSuccess: true }
+    )
+  })
 })


### PR DESCRIPTION
## Summary

- Adds two e2e tests confirming `--fix-lockfile` correctly enforces `minimumReleaseAge` on existing lockfile entries (same as `--frozen-lockfile` does)
- Fixes ESLint pre-push hook failure caused by Claude worktree files in `.claude/worktrees/` not being excluded from linting

## Background

[Issue pnpm/pnpm#10361](https://github.com/pnpm/pnpm/issues/10361) reports that `minimumReleaseAgeExclude` is "not respected" during `pnpm install --fix-lockfile`. After investigating the code, the lockfile verification (`verifyLockfileResolutions`) does run during `--fix-lockfile` and does enforce `minimumReleaseAge`. The likely explanation for the user's observation is that their package (`next@14.2.35`) had matured past the 14-day cutoff by the time they ran `--fix-lockfile` — mature packages are correctly allowed by the policy.

The two new tests document and protect this behavior:

1. **`--fix-lockfile` enforces `minimumReleaseAge` on existing lockfile entries** — installs with an immature package in the lockfile (no exclude list) must fail with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`, confirming the lockfile verifier runs even when `--fix-lockfile` is used.

2. **`--fix-lockfile` respects `minimumReleaseAgeExclude` for entries in the exclude list** — installs succeed when immature packages are covered by the exclude list.

## Test plan

- [x] New e2e tests pass locally (`NODE_OPTIONS=... jest pnpm/test/install/minimumReleaseAge.ts`)
- [x] All 14 tests in the file pass (12 pre-existing + 2 new)
- [x] Pre-push lint/compile hook passes

---
Written by an agent (Claude Code, claude-sonnet-4-6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated ESLint configuration to exclude a specific directory from linting checks.

* **Tests**
  * Added Jest coverage for `pnpm install --fix-lockfile` under strict minimum release age rules, verifying failure when no exclusions are set and success when immature packages and related entries are excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->