### PR TITLE
test(deps-installer): make the parallel custom-resolver check deterministic

### DIFF
--- a/installing/deps-installer/test/install/checkCustomResolverForceResolve.ts
+++ b/installing/deps-installer/test/install/checkCustomResolverForceResolve.ts
@@ -124,18 +124,25 @@ describe('checkCustomResolverForceResolve', () => {
   })
 
   test('runs checks in parallel', async () => {
-    const callOrder: string[] = []
+    const PKG_COUNT = 3
+    const started: string[] = []
+    // Each hook blocks until every hook has started. This only unblocks if the
+    // checks run concurrently; were they awaited one at a time, the first hook
+    // would wait forever for siblings that never start and the test would hang.
+    let releaseAllStarted!: () => void
+    const allStarted = new Promise<void>(resolve => {
+      releaseAllStarted = resolve
+    })
     const resolver: CustomResolver = {
       shouldRefreshResolution: async (depPath) => {
-        const delays: Record<string, number> = { 'pkg1@1.0.0': 30, 'pkg2@1.0.0': 20 }
-        const delay = delays[depPath] ?? 10
-        await new Promise(resolve => setTimeout(resolve, delay))
-        callOrder.push(depPath)
+        started.push(depPath)
+        if (started.length === PKG_COUNT) releaseAllStarted()
+        await allStarted
         return false
       },
     }
 
-    await checkCustomResolverForceResolve(
+    const result = await checkCustomResolverForceResolve(
       [resolver],
       lockfileWithPackages({
         'pkg1@1.0.0': {
@@ -150,8 +157,8 @@ describe('checkCustomResolverForceResolve', () => {
       })
     )
 
-    // If parallel, pkg3 finishes first (10ms), then pkg2 (20ms), then pkg1 (30ms)
-    expect(callOrder).toEqual(['pkg3@1.0.0', 'pkg2@1.0.0', 'pkg1@1.0.0'])
+    expect(result).toBe(false)
+    expect([...started].sort()).toEqual(['pkg1@1.0.0', 'pkg2@1.0.0', 'pkg3@1.0.0'])
   })
 
   test('passes depPath and pkgSnapshot to shouldRefreshResolution', async () => {


### PR DESCRIPTION
## Problem

Every Windows CI job on `main` was failing at the `@pnpm/installing.deps-installer` test step. The culprit is the `checkCustomResolverForceResolve › runs checks in parallel` unit test, which raced three real `setTimeout` delays (10/20/30 ms) and asserted their exact completion order:

```
- "pkg3@1.0.0",
  "pkg2@1.0.0",
  "pkg1@1.0.0",
+ "pkg3@1.0.0",   ← pkg3 finished LAST, not first
```

Timer scheduling jitter on Windows runners reorders sub-50 ms timers, so a 10 ms timeout is not guaranteed to resolve before a 20/30 ms one. Ubuntu happened to win the race; Windows flaked, and the single failed test tanked the whole suite via `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL`.

(The earlier `deepRecursive.ts` heap OOM that affected the same step was already fixed by pnpm/pnpm#12388 — `deepRecursive` now passes in its isolated process.)

## Fix

Replace the timer race with a **start-barrier**: each hook blocks until every hook has started, then all release together. This is fully deterministic — no timers, no ordering assumptions — and it's a *stronger* assertion than before: it would hang and fail if the checks ever became serial (the first hook would wait forever for siblings that never start).

## Verification

- All 14 tests in the file pass locally.
- Temporarily reverting `checkCustomResolverForceResolve` to await each hook serially makes the new test time out and fail, confirming it still guards the parallelism contract.

Test-only change: no changeset (no published output affected) and no pacquet port (TS-only CLI test infra).

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test robustness for dependency resolution scenarios by replacing timing-based assertions with concurrent execution verification, ensuring more reliable and stable test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->