### PR TITLE
fix(setup): skip `@pnpm/exe` build scripts during global self-install

### DIFF
--- a/.changeset/setup-skip-exe-build-scripts.md
+++ b/.changeset/setup-skip-exe-build-scripts.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/engine.pm.commands": patch
+"pnpm": patch
+---
+
+`pnpm setup` no longer prompts to approve build scripts for `@pnpm/exe` when installing the standalone executable. pnpm links the platform-specific binary itself, so the package's install scripts are skipped during the global self-install [#12377](https://github.com/pnpm/pnpm/issues/12377).

--- a/engine/pm/commands/src/setup/setup.ts
+++ b/engine/pm/commands/src/setup/setup.ts
@@ -84,7 +84,15 @@ function installCliGlobally (execPath: string, pnpmHomeDir: string): void {
 
   try {
     const binDir = path.join(pnpmHomeDir, 'bin')
-    const { status, error } = spawnSync(execPath, ['add', '-g', `file:${execDir}`], {
+    // @pnpm/exe ships a `preinstall`/`prepare` pair (setup.js/prepare.js) that
+    // hardlinks the platform-specific binary out of its optional platform
+    // packages. None of that applies here: this `file:` dependency is the
+    // standalone executable itself (its binary is already present), the
+    // platform packages aren't installed alongside it, and the SEA host may
+    // have no `node` to run the scripts at all. Skipping them avoids a build
+    // approval prompt for pnpm's own install. See
+    // https://github.com/pnpm/pnpm/issues/12377.
+    const { status, error } = spawnSync(execPath, ['add', '-g', '--ignore-scripts', `file:${execDir}`], {
       stdio: 'inherit',
       env: {
         ...process.env,

--- a/engine/pm/commands/test/setup/setup.test.ts
+++ b/engine/pm/commands/test/setup/setup.test.ts
@@ -1,9 +1,24 @@
+import os from 'node:os'
+import path from 'node:path'
+
 import { expect, jest, test } from '@jest/globals'
 import { PnpmError } from '@pnpm/error'
 import type { PathExtenderReport } from '@pnpm/os.env.path-extender'
 
 jest.unstable_mockModule('@pnpm/os.env.path-extender', () => ({
   addDirToEnvPath: jest.fn(),
+}))
+
+const actualCliMeta = await import('@pnpm/cli.meta')
+jest.unstable_mockModule('@pnpm/cli.meta', () => ({
+  ...actualCliMeta,
+  detectIfCurrentPkgIsExecutable: jest.fn(() => false),
+}))
+
+const actualChildProcess = await import('node:child_process')
+jest.unstable_mockModule('node:child_process', () => ({
+  ...actualChildProcess,
+  spawnSync: jest.fn(() => ({ status: 0 })),
 }))
 
 const actualFs = await import('node:fs')
@@ -19,6 +34,8 @@ jest.unstable_mockModule('fs', () => {
 })
 
 const { addDirToEnvPath } = await import('@pnpm/os.env.path-extender')
+const { detectIfCurrentPkgIsExecutable } = await import('@pnpm/cli.meta')
+const { spawnSync } = await import('node:child_process')
 const { setup } = await import('@pnpm/engine.pm.commands')
 
 test('setup makes no changes', async () => {
@@ -82,4 +99,26 @@ test('hint is added to ERR_PNPM_BAD_SHELL_SECTION error object', async () => {
     err = _err
   }
   expect(err?.hint).toBe('If you want to override the existing configuration section, use the --force option')
+})
+
+test('global install of the standalone executable skips its build scripts', async () => {
+  jest.mocked(addDirToEnvPath).mockReturnValue(Promise.resolve<PathExtenderReport>({
+    oldSettings: 'PNPM_HOME=dir',
+    newSettings: 'PNPM_HOME=dir',
+  }))
+  jest.mocked(detectIfCurrentPkgIsExecutable).mockReturnValue(true)
+  const tmpDir = actualFs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-setup-test-'))
+  const execPath = path.join(tmpDir, 'pnpm')
+  const originalExecPath = process.execPath
+  Object.defineProperty(process, 'execPath', { value: execPath, configurable: true })
+  try {
+    await setup.handler({ pnpmHomeDir: path.join(tmpDir, 'home') })
+  } finally {
+    Object.defineProperty(process, 'execPath', { value: originalExecPath, configurable: true })
+    actualFs.rmSync(tmpDir, { recursive: true, force: true })
+  }
+  expect(spawnSync).toHaveBeenCalledTimes(1)
+  const args = jest.mocked(spawnSync).mock.calls[0][1] as string[]
+  expect(args).toContain('--ignore-scripts')
+  expect(args).toEqual(['add', '-g', '--ignore-scripts', `file:${tmpDir}`])
 })


### PR DESCRIPTION
## Problem

Closes https://github.com/pnpm/pnpm/issues/12377.

When `pnpm setup` runs from the standalone executable, it installs pnpm into the global directory via `pnpm add -g file:<execDir>`. The `@pnpm/exe` `package.json` shipped alongside the binary carries `preinstall`/`prepare` scripts (`setup.js`/`prepare.js`), so the install prints a build-approval prompt for `@pnpm/exe` — pnpm asking to allow building *itself*, which understandably reads as "someone pushed postinstall malware to pnpm." (`pnpm self-update` doesn't show this because it auto-trusts `@pnpm/exe` and links the platform binary itself.)

## Fix

Pass `--ignore-scripts` to the `pnpm add -g` invocation in `installCliGlobally`. Those scripts have no job on this path anyway:

- the binary is already present (it *is* the standalone executable);
- the optional platform packages (`@pnpm/macos-arm64`, …) aren't installed next to the `file:` dependency, so `setup.js` would only `ERR_MODULE_NOT_FOUND`;
- a Node-less SEA host has no `node` to run the scripts at all;
- pnpm already performs the platform-binary hardlinking itself via `linkExePlatformBinary`.

With `--ignore-scripts`, `@pnpm/exe` is never added to the `ignoredBuilds` set (`building/during-install/src/index.ts`), so no prompt or warning is emitted — and no script is run, so nothing can fail.

## Test

Added a regression test that forces the SEA install branch and asserts the spawned arguments are exactly `['add', '-g', '--ignore-scripts', 'file:<dir>']`.

## Notes

`setup` is a TypeScript-only command (not in pacquet's install/add/update/remove surface), so no pacquet-side port is needed.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * `pnpm setup` no longer prompts to approve build scripts when installing the standalone executable, streamlining the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->