### PR TITLE
docs: configure AI review security and performance guidance

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,25 +3,4 @@ reviews:
   path_instructions:
     - path: "**/*"
       instructions: |
-        Review pull requests with a security-first lens. Security vulnerabilities are the first priority. Actively look for vulnerabilities introduced or exposed by the diff, especially:
-        - unsafe handling of package manifests, lockfiles, tarballs, registry responses, lifecycle scripts, configDependencies, patches, and workspace links;
-        - path traversal, symlink/hardlink, archive extraction, arbitrary file read/write/delete, TOCTOU, and permissions mistakes;
-        - command injection, shell argument construction, environment-variable trust, executable resolution, script execution policy, and privilege boundary mistakes;
-        - registry, network, and auth mistakes including token leakage, proxy handling, redirect behavior, TLS assumptions, cache poisoning, integrity/hash verification, and downgrade or confusion attacks;
-        - Rust memory, concurrency, and unsafe FFI issues in pacquet, including panic-on-untrusted-input denial of service.
-
-        Treat attacker-controlled inputs broadly: package metadata, tarball contents, lockfiles, workspace manifests, .npmrc/environment config, registry responses, git URLs, filesystem paths, and script names. Surface plausible security issues even when they are edge cases, but explain the exploit path and impact clearly. Do not report generic security advice unless it is tied to changed code.
-
-        Use pnpm's published security advisories as regression themes. Pay extra attention to recurring issue classes from past pnpm advisories:
-        - repo-controlled `.npmrc` and `pnpm-workspace.yaml` must not expand victim environment secrets into registry URLs, auth headers, proxy settings, token helpers, or other outbound requests;
-        - user-level npm auth credentials must not be bound to a repository-selected registry unless the registry scope and trust boundary are explicit;
-        - lifecycle/build-script approval gates must cover all dependency sources and phases, including git dependencies, fetch/prepare/prepack/prepublish paths, `allowBuilds`, ignored-build reporting, explicit denials, and pacquet parity;
-        - opaque dependency identities such as git, URL, tarball, file, directory, patch, and alias locators must remain byte-for-byte exact where used for trust decisions; do not normalize away attacker-controlled suffixes or confuse them with registry peer suffixes;
-        - lockfile entries for remote dynamic dependencies, GitHub/git dependencies, tarballs, commits, and integrity fields must preserve enough immutable integrity data to reject changed content and avoid unsafe defaults or missing-field bypasses;
-        - treat lockfile fields and git metadata as untrusted input, especially `resolution.commit`, refs, and URLs; prevent command/argument injection and avoid passing attacker-controlled values as executable flags;
-        - path handling must reject traversal and root escape in bin names, `directories.bin`, transitive aliases, patch files, tar/zip entries, symlink/hardlink targets, file/git dependencies, Windows path separators, executable shims, permission changes, and delete/write destinations;
-        - cache/store/global-metadata keys must include all trust-relevant inputs so overrides, scripts policy, registry metadata, and lockfile state cannot poison later installs or other workspaces;
-        - archive extraction and package identity code must match npm/registry semantics for duplicate tar entries, stripped path components, symlinks, permissions, and manifest selection;
-        - path-shortening, hashing, cache naming, and content-addressing code must use collision-resistant identifiers and verify collisions cannot redirect dependencies or overwrite package contents.
-
-        After security, treat performance as the second review priority. pnpm, pacquet, and pnpr must stay fast. Look for non-optimal code that could add latency, CPU work, memory pressure, lock contention, unnecessary I/O, excessive logging, redundant parsing/serialization, repeated filesystem scans, avoidable network round trips, poor cache behavior, missed streaming/batching opportunities, or slower hot paths in install/add/update/remove, resolution, fetching, linking, lockfile handling, store access, tarball extraction, and pnpr server paths. Flag performance risks when the changed code is likely to run on common workflows, large workspaces, many dependencies, or repeated requests. Prefer concrete evidence from the diff and explain the likely scale or hot path affected.
+        Apply the "AI Review Guidance" section in AGENTS.md. Security vulnerabilities are the first review priority; performance regressions in pnpm, pacquet, and pnpr are the second priority. Surface only issues tied to changed code, and explain the exploit path, impact, or hot path affected.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  path_instructions:
+    - path: "**/*"
+      instructions: |
+        Review pull requests with a security-first lens. Security vulnerabilities are the first priority. Actively look for vulnerabilities introduced or exposed by the diff, especially:
+        - unsafe handling of package manifests, lockfiles, tarballs, registry responses, lifecycle scripts, configDependencies, patches, and workspace links;
+        - path traversal, symlink/hardlink, archive extraction, arbitrary file read/write/delete, TOCTOU, and permissions mistakes;
+        - command injection, shell argument construction, environment-variable trust, executable resolution, script execution policy, and privilege boundary mistakes;
+        - registry, network, and auth mistakes including token leakage, proxy handling, redirect behavior, TLS assumptions, cache poisoning, integrity/hash verification, and downgrade or confusion attacks;
+        - Rust memory, concurrency, and unsafe FFI issues in pacquet, including panic-on-untrusted-input denial of service.
+
+        Treat attacker-controlled inputs broadly: package metadata, tarball contents, lockfiles, workspace manifests, .npmrc/environment config, registry responses, git URLs, filesystem paths, and script names. Surface plausible security issues even when they are edge cases, but explain the exploit path and impact clearly. Do not report generic security advice unless it is tied to changed code.
+
+        Use pnpm's published security advisories as regression themes. Pay extra attention to recurring issue classes from past pnpm advisories:
+        - repo-controlled `.npmrc` and `pnpm-workspace.yaml` must not expand victim environment secrets into registry URLs, auth headers, proxy settings, token helpers, or other outbound requests;
+        - user-level npm auth credentials must not be bound to a repository-selected registry unless the registry scope and trust boundary are explicit;
+        - lifecycle/build-script approval gates must cover all dependency sources and phases, including git dependencies, fetch/prepare/prepack/prepublish paths, `allowBuilds`, ignored-build reporting, explicit denials, and pacquet parity;
+        - opaque dependency identities such as git, URL, tarball, file, directory, patch, and alias locators must remain byte-for-byte exact where used for trust decisions; do not normalize away attacker-controlled suffixes or confuse them with registry peer suffixes;
+        - lockfile entries for remote dynamic dependencies, GitHub/git dependencies, tarballs, commits, and integrity fields must preserve enough immutable integrity data to reject changed content and avoid unsafe defaults or missing-field bypasses;
+        - treat lockfile fields and git metadata as untrusted input, especially `resolution.commit`, refs, and URLs; prevent command/argument injection and avoid passing attacker-controlled values as executable flags;
+        - path handling must reject traversal and root escape in bin names, `directories.bin`, transitive aliases, patch files, tar/zip entries, symlink/hardlink targets, file/git dependencies, Windows path separators, executable shims, permission changes, and delete/write destinations;
+        - cache/store/global-metadata keys must include all trust-relevant inputs so overrides, scripts policy, registry metadata, and lockfile state cannot poison later installs or other workspaces;
+        - archive extraction and package identity code must match npm/registry semantics for duplicate tar entries, stripped path components, symlinks, permissions, and manifest selection;
+        - path-shortening, hashing, cache naming, and content-addressing code must use collision-resistant identifiers and verify collisions cannot redirect dependencies or overwrite package contents.
+
+        After security, treat performance as the second review priority. pnpm, pacquet, and pnpr must stay fast. Look for non-optimal code that could add latency, CPU work, memory pressure, lock contention, unnecessary I/O, excessive logging, redundant parsing/serialization, repeated filesystem scans, avoidable network round trips, poor cache behavior, missed streaming/batching opportunities, or slower hot paths in install/add/update/remove, resolution, fetching, linking, lockfile handling, store access, tarball extraction, and pnpr server paths. Flag performance risks when the changed code is likely to run on common workflows, large workspaces, many dependencies, or repeated requests. Prefer concrete evidence from the diff and explain the likely scale or hot path affected.

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -30,29 +30,8 @@ ignore_pr_authors = [
 comments_location_policy = "both"
 inline_comments_severity_threshold = 2
 issues_user_guidelines = """
-Review pull requests with a security-first lens. Security vulnerabilities are the first priority. Actively look for vulnerabilities introduced or exposed by the diff, especially:
-- unsafe handling of package manifests, lockfiles, tarballs, registry responses, lifecycle scripts, configDependencies, patches, and workspace links;
-- path traversal, symlink/hardlink, archive extraction, arbitrary file read/write/delete, TOCTOU, and permissions mistakes;
-- command injection, shell argument construction, environment-variable trust, executable resolution, script execution policy, and privilege boundary mistakes;
-- registry, network, and auth mistakes including token leakage, proxy handling, redirect behavior, TLS assumptions, cache poisoning, integrity/hash verification, and downgrade or confusion attacks;
-- Rust memory, concurrency, and unsafe FFI issues in pacquet, including panic-on-untrusted-input denial of service.
-
-Treat attacker-controlled inputs broadly: package metadata, tarball contents, lockfiles, workspace manifests, .npmrc/environment config, registry responses, git URLs, filesystem paths, and script names. Surface plausible security issues even when they are edge cases, but explain the exploit path and impact clearly. Do not report generic security advice unless it is tied to changed code.
-
-Use pnpm's published security advisories as regression themes. Pay extra attention to recurring issue classes from past pnpm advisories:
-- repo-controlled `.npmrc` and `pnpm-workspace.yaml` must not expand victim environment secrets into registry URLs, auth headers, proxy settings, token helpers, or other outbound requests;
-- user-level npm auth credentials must not be bound to a repository-selected registry unless the registry scope and trust boundary are explicit;
-- lifecycle/build-script approval gates must cover all dependency sources and phases, including git dependencies, fetch/prepare/prepack/prepublish paths, `allowBuilds`, ignored-build reporting, explicit denials, and pacquet parity;
-- opaque dependency identities such as git, URL, tarball, file, directory, patch, and alias locators must remain byte-for-byte exact where used for trust decisions; do not normalize away attacker-controlled suffixes or confuse them with registry peer suffixes;
-- lockfile entries for remote dynamic dependencies, GitHub/git dependencies, tarballs, commits, and integrity fields must preserve enough immutable integrity data to reject changed content and avoid unsafe defaults or missing-field bypasses;
-- treat lockfile fields and git metadata as untrusted input, especially `resolution.commit`, refs, and URLs; prevent command/argument injection and avoid passing attacker-controlled values as executable flags;
-- path handling must reject traversal and root escape in bin names, `directories.bin`, transitive aliases, patch files, tar/zip entries, symlink/hardlink targets, file/git dependencies, Windows path separators, executable shims, permission changes, and delete/write destinations;
-- cache/store/global-metadata keys must include all trust-relevant inputs so overrides, scripts policy, registry metadata, and lockfile state cannot poison later installs or other workspaces;
-- archive extraction and package identity code must match npm/registry semantics for duplicate tar entries, stripped path components, symlinks, permissions, and manifest selection;
-- path-shortening, hashing, cache naming, and content-addressing code must use collision-resistant identifiers and verify collisions cannot redirect dependencies or overwrite package contents.
-
-After security, treat performance as the second review priority. pnpm, pacquet, and pnpr must stay fast. Look for non-optimal code that could add latency, CPU work, memory pressure, lock contention, unnecessary I/O, excessive logging, redundant parsing/serialization, repeated filesystem scans, avoidable network round trips, poor cache behavior, missed streaming/batching opportunities, or slower hot paths in install/add/update/remove, resolution, fetching, linking, lockfile handling, store access, tarball extraction, and pnpr server paths. Flag performance risks when the changed code is likely to run on common workflows, large workspaces, many dependencies, or repeated requests. Prefer concrete evidence from the diff and explain the likely scale or hot path affected.
+Apply the "AI Review Guidance" section in AGENTS.md. Security vulnerabilities are the first review priority; performance regressions in pnpm, pacquet, and pnpr are the second priority. Surface only issues tied to changed code, and explain the exploit path, impact, or hot path affected.
 """
 compliance_user_guidelines = """
-Enforce pnpm's security-sensitive and performance-sensitive contracts during review: do not allow weakening of integrity checks, lockfile/store invariants, script/build approval gates, token redaction, path normalization, pnpm/pacquet behavior parity for install/add/update/remove changes, or avoidable slowdowns in hot paths.
+Enforce the security-sensitive and performance-sensitive contracts described in AGENTS.md's "AI Review Guidance" section.
 """

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -27,8 +27,32 @@ ignore_pr_authors = [
 # ignore_pr_title = ["^chore", "^ci"]
 
 [review_agent]
-# Extra instructions for the Issues Agent (bug, security, performance detection).
-# issues_user_guidelines = "Flag unhandled rejections in async code and missing error handling around filesystem and network calls"
+comments_location_policy = "both"
+inline_comments_severity_threshold = 2
+issues_user_guidelines = """
+Review pull requests with a security-first lens. Security vulnerabilities are the first priority. Actively look for vulnerabilities introduced or exposed by the diff, especially:
+- unsafe handling of package manifests, lockfiles, tarballs, registry responses, lifecycle scripts, configDependencies, patches, and workspace links;
+- path traversal, symlink/hardlink, archive extraction, arbitrary file read/write/delete, TOCTOU, and permissions mistakes;
+- command injection, shell argument construction, environment-variable trust, executable resolution, script execution policy, and privilege boundary mistakes;
+- registry, network, and auth mistakes including token leakage, proxy handling, redirect behavior, TLS assumptions, cache poisoning, integrity/hash verification, and downgrade or confusion attacks;
+- Rust memory, concurrency, and unsafe FFI issues in pacquet, including panic-on-untrusted-input denial of service.
 
-# Extra instructions for the Compliance Agent (rule checking).
-# compliance_user_guidelines = "Ensure changes to dependency resolution and lockfile handling preserve backward compatibility"
+Treat attacker-controlled inputs broadly: package metadata, tarball contents, lockfiles, workspace manifests, .npmrc/environment config, registry responses, git URLs, filesystem paths, and script names. Surface plausible security issues even when they are edge cases, but explain the exploit path and impact clearly. Do not report generic security advice unless it is tied to changed code.
+
+Use pnpm's published security advisories as regression themes. Pay extra attention to recurring issue classes from past pnpm advisories:
+- repo-controlled `.npmrc` and `pnpm-workspace.yaml` must not expand victim environment secrets into registry URLs, auth headers, proxy settings, token helpers, or other outbound requests;
+- user-level npm auth credentials must not be bound to a repository-selected registry unless the registry scope and trust boundary are explicit;
+- lifecycle/build-script approval gates must cover all dependency sources and phases, including git dependencies, fetch/prepare/prepack/prepublish paths, `allowBuilds`, ignored-build reporting, explicit denials, and pacquet parity;
+- opaque dependency identities such as git, URL, tarball, file, directory, patch, and alias locators must remain byte-for-byte exact where used for trust decisions; do not normalize away attacker-controlled suffixes or confuse them with registry peer suffixes;
+- lockfile entries for remote dynamic dependencies, GitHub/git dependencies, tarballs, commits, and integrity fields must preserve enough immutable integrity data to reject changed content and avoid unsafe defaults or missing-field bypasses;
+- treat lockfile fields and git metadata as untrusted input, especially `resolution.commit`, refs, and URLs; prevent command/argument injection and avoid passing attacker-controlled values as executable flags;
+- path handling must reject traversal and root escape in bin names, `directories.bin`, transitive aliases, patch files, tar/zip entries, symlink/hardlink targets, file/git dependencies, Windows path separators, executable shims, permission changes, and delete/write destinations;
+- cache/store/global-metadata keys must include all trust-relevant inputs so overrides, scripts policy, registry metadata, and lockfile state cannot poison later installs or other workspaces;
+- archive extraction and package identity code must match npm/registry semantics for duplicate tar entries, stripped path components, symlinks, permissions, and manifest selection;
+- path-shortening, hashing, cache naming, and content-addressing code must use collision-resistant identifiers and verify collisions cannot redirect dependencies or overwrite package contents.
+
+After security, treat performance as the second review priority. pnpm, pacquet, and pnpr must stay fast. Look for non-optimal code that could add latency, CPU work, memory pressure, lock contention, unnecessary I/O, excessive logging, redundant parsing/serialization, repeated filesystem scans, avoidable network round trips, poor cache behavior, missed streaming/batching opportunities, or slower hot paths in install/add/update/remove, resolution, fetching, linking, lockfile handling, store access, tarball extraction, and pnpr server paths. Flag performance risks when the changed code is likely to run on common workflows, large workspaces, many dependencies, or repeated requests. Prefer concrete evidence from the diff and explain the likely scale or hot path affected.
+"""
+compliance_user_guidelines = """
+Enforce pnpm's security-sensitive and performance-sensitive contracts during review: do not allow weakening of integrity checks, lockfile/store invariants, script/build approval gates, token redaction, path normalization, pnpm/pacquet behavior parity for install/add/update/remove changes, or avoidable slowdowns in hot paths.
+"""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,33 @@ pnpm run lint
 
 Do not dismiss a failing test as a "pre-existing" failure that is unrelated to your changes. Every test failure must be investigated and fixed. If a test was already broken before your changes, fix it as part of your work — do not silently skip it or treat it as acceptable.
 
+## AI Review Guidance
+
+When reviewing pull requests, use a security-first lens. Security vulnerabilities are the first priority. Actively look for vulnerabilities introduced or exposed by the diff, especially:
+
+- unsafe handling of package manifests, lockfiles, tarballs, registry responses, lifecycle scripts, configDependencies, patches, and workspace links;
+- path traversal, symlink/hardlink, archive extraction, arbitrary file read/write/delete, TOCTOU, and permissions mistakes;
+- command injection, shell argument construction, environment-variable trust, executable resolution, script execution policy, and privilege boundary mistakes;
+- registry, network, and auth mistakes including token leakage, proxy handling, redirect behavior, TLS assumptions, cache poisoning, integrity/hash verification, and downgrade or confusion attacks;
+- Rust memory, concurrency, and unsafe FFI issues in pacquet, including panic-on-untrusted-input denial of service.
+
+Treat attacker-controlled inputs broadly: package metadata, tarball contents, lockfiles, workspace manifests, `.npmrc`/environment config, registry responses, git URLs, filesystem paths, and script names. Surface plausible security issues even when they are edge cases, but explain the exploit path and impact clearly. Do not report generic security advice unless it is tied to changed code.
+
+Use pnpm's published security advisories as regression themes. Pay extra attention to recurring issue classes from past pnpm advisories:
+
+- repo-controlled `.npmrc` and `pnpm-workspace.yaml` must not expand victim environment secrets into registry URLs, auth headers, proxy settings, token helpers, or other outbound requests;
+- user-level npm auth credentials must not be bound to a repository-selected registry unless the registry scope and trust boundary are explicit;
+- lifecycle/build-script approval gates must cover all dependency sources and phases, including git dependencies, fetch/prepare/prepack/prepublish paths, `allowBuilds`, ignored-build reporting, explicit denials, and pacquet parity;
+- opaque dependency identities such as git, URL, tarball, file, directory, patch, and alias locators must remain byte-for-byte exact where used for trust decisions; do not normalize away attacker-controlled suffixes or confuse them with registry peer suffixes;
+- lockfile entries for remote dynamic dependencies, GitHub/git dependencies, tarballs, commits, and integrity fields must preserve enough immutable integrity data to reject changed content and avoid unsafe defaults or missing-field bypasses;
+- treat lockfile fields and git metadata as untrusted input, especially `resolution.commit`, refs, and URLs; prevent command/argument injection and avoid passing attacker-controlled values as executable flags;
+- path handling must reject traversal and root escape in bin names, `directories.bin`, transitive aliases, patch files, tar/zip entries, symlink/hardlink targets, file/git dependencies, Windows path separators, executable shims, permission changes, and delete/write destinations;
+- cache/store/global-metadata keys must include all trust-relevant inputs so overrides, scripts policy, registry metadata, and lockfile state cannot poison later installs or other workspaces;
+- archive extraction and package identity code must match npm/registry semantics for duplicate tar entries, stripped path components, symlinks, permissions, and manifest selection;
+- path-shortening, hashing, cache naming, and content-addressing code must use collision-resistant identifiers and verify collisions cannot redirect dependencies or overwrite package contents.
+
+After security, treat performance as the second review priority. pnpm, pacquet, and pnpr must stay fast. Look for non-optimal code that could add latency, CPU work, memory pressure, lock contention, unnecessary I/O, excessive logging, redundant parsing/serialization, repeated filesystem scans, avoidable network round trips, poor cache behavior, missed streaming/batching opportunities, or slower hot paths in install/add/update/remove, resolution, fetching, linking, lockfile handling, store access, tarball extraction, and pnpr server paths. Flag performance risks when the changed code is likely to run on common workflows, large workspaces, many dependencies, or repeated requests. Prefer concrete evidence from the diff and explain the likely scale or hot path affected.
+
 ## Code Reuse and Avoiding Duplication
 
 **Before writing new code, always analyze the existing codebase for similar functionality.** This is a large monorepo with many shared utilities — duplication is a real risk.


### PR DESCRIPTION
## Summary

- add shared AI review guidance to `AGENTS.md`, with security first and pnpm/pacquet/pnpr performance second
- configure Qodo to apply that shared guidance through `.pr_agent.toml`
- configure CodeRabbit to apply the same guidance through `.coderabbit.yaml`
- include pnpm published advisory patterns as regression themes for both review tools

## Validation

- `taplo lint --no-auto-config --no-schema .pr_agent.toml`
- Ruby YAML parse check for `.coderabbit.yaml`
- `git diff --check`
- pre-push hook: TypeScript build, pnpm compile/bundle, spellcheck, metadata lint, TypeScript lint

No changeset is needed because this only changes repository review-tool configuration and agent review guidance.

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review tool configuration with security-first guidance and prioritization for performance regressions
  * Enhanced review agent settings, including comment placement policy and an inline severity threshold

<!-- end of auto-generated comment: release notes by coderabbit.ai -->