### PR TITLE
ci: resolve merged PRs for Bencher uploads

### DIFF
--- a/.github/workflows/ci-performance-bencher-upload.yml
+++ b/.github/workflows/ci-performance-bencher-upload.yml
@@ -34,18 +34,28 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          github_error() {
+            local message=$1
+            message=${message//'%'/'%25'}
+            message=${message//$'\r'/'%0D'}
+            message=${message//$'\n'/'%0A'}
+            echo "::error::$message"
+          }
+
           if [ "$EVENT_NAME" = "pull_request" ]; then
             if [[ -n "${TRIGGER_PR:-}" ]]; then
               pr="$TRIGGER_PR"
             else
               pr=$(
-                gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate --jq '.[]' \
-                  | jq -s --arg sha "$HEAD_SHA" \
-                      '[.[] | select(.head.sha == $sha) | .number] | unique'
+                gh api "repos/$REPO/commits/$HEAD_SHA/pulls?per_page=100" \
+                  -H "Accept: application/vnd.github+json" \
+                  --paginate --jq '.[]' \
+                  | jq -s --arg branch "$HEAD_BRANCH" \
+                      'if $branch == "" then [.[] | .number] else [.[] | select(.head.ref == $branch) | .number] end | unique'
               )
               count=$(echo "$pr" | jq 'length')
               if [[ "$count" == "0" ]]; then
-                echo "::error::no open PR matches head_sha=$HEAD_SHA in $REPO"
+                github_error "no PR matches head_sha=$HEAD_SHA branch=$HEAD_BRANCH in $REPO"
                 exit 1
               fi
               if [[ "$count" != "1" ]]; then


### PR DESCRIPTION
## Summary

Fixes the CI performance uploader fallback for same-repository `pull_request` workflow runs that complete after their PR has already been merged. GitHub can omit `workflow_run.pull_requests[0].number` in that case, so the fallback now uses the targeted, paginated `commits/{sha}/pulls` endpoint and filters by `HEAD_BRANCH` when GitHub provides one.

When no PR matches, the workflow still emits a GitHub Actions error annotation, but escapes dynamic message content before writing the workflow command.

## Validation

- `actionlint .github/workflows/ci-performance-bencher-upload.yml`
- Full `Resolve Bencher branch` shell block syntax check with `bash -n`
- Workflow command escaping smoke test for `%`, CR, and LF
- Live paginated targeted lookup for merged PR 12404 head SHA resolved exactly one PR when `HEAD_BRANCH=bench-tests`
- Synthetic empty-`HEAD_BRANCH` jq smoke test preserved all candidates so the existing ambiguity check can handle the case
- `git diff --check`
- pre-push hook passed during `git push`

---
Written by an agent (Codex, GPT-5).