### PR TITLE
fix(lockfile): wait for stream close before returning

### DIFF
--- a/.changeset/slow-windows-lockfile-streams.md
+++ b/.changeset/slow-windows-lockfile-streams.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/lockfile.fs": patch
+"pnpm": patch
+---
+
+Wait for early-exited lockfile read streams to close before rewriting lockfiles.

--- a/lockfile/fs/src/yamlDocuments.ts
+++ b/lockfile/fs/src/yamlDocuments.ts
@@ -1,4 +1,4 @@
-import { createReadStream } from 'node:fs'
+import { createReadStream, type ReadStream } from 'node:fs'
 import util from 'node:util'
 
 import stripBom from 'strip-bom'
@@ -32,29 +32,43 @@ export async function streamReadFirstYamlDocument (filePath: string): Promise<st
       if (buffer.length >= YAML_DOCUMENT_START.length) break
     }
     if (!buffer.startsWith(YAML_DOCUMENT_START)) {
-      stream.destroy()
+      await closeStream(stream)
       return null
     }
     // Phase 2: find the second "---" separator
+    let firstDocument: string | undefined
     while (true) {
       const sep = buffer.indexOf(YAML_DOCUMENT_SEPARATOR, YAML_DOCUMENT_START.length)
       if (sep !== -1) {
-        stream.destroy()
-        return buffer.slice(YAML_DOCUMENT_START.length, sep)
+        firstDocument = buffer.slice(YAML_DOCUMENT_START.length, sep)
+        break
       }
       const chunk = await chunks.next() // eslint-disable-line no-await-in-loop
       if (chunk.done) break
       // Normalize CRLF (Windows) to LF so the separator search matches on Windows-checked-out files.
       buffer = (buffer + chunk.value).replace(/\r\n/g, '\n')
     }
+    if (firstDocument != null) {
+      await closeStream(stream)
+      return firstDocument
+    }
   } catch (err: unknown) {
+    await closeStream(stream)
     if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') {
       return null
     }
     throw err
   }
-  stream.destroy()
+  await closeStream(stream)
   return null
+}
+
+async function closeStream (stream: ReadStream): Promise<void> {
+  if (stream.closed) return
+  await new Promise<void>((resolve) => {
+    stream.once('close', resolve)
+    stream.destroy()
+  })
 }
 
 /**

--- a/lockfile/fs/test/yamlDocuments.test.ts
+++ b/lockfile/fs/test/yamlDocuments.test.ts
@@ -26,6 +26,19 @@ describe('streamReadFirstYamlDocument', () => {
     expect(result).toBeNull()
   })
 
+  test('closes a non-env lockfile before returning null', async () => {
+    const dir = temporaryDirectory()
+    const filePath = path.join(dir, 'test.yaml')
+    const tempFilePath = `${filePath}.tmp`
+    fs.writeFileSync(filePath, 'lockfileVersion: 9.0\n')
+    fs.writeFileSync(tempFilePath, 'lockfileVersion: 9.0\nimporters: {}\n')
+
+    const result = await streamReadFirstYamlDocument(filePath)
+
+    expect(result).toBeNull()
+    fs.renameSync(tempFilePath, filePath)
+  })
+
   test('returns null for a non-existent file', async () => {
     const dir = temporaryDirectory()
     const result = await streamReadFirstYamlDocument(path.join(dir, 'nonexistent.yaml'))


### PR DESCRIPTION
## Summary
- wait for early-exited lockfile read streams to close before returning
- add a regression test that immediately renames over a non-env lockfile after `streamReadFirstYamlDocument()` returns
- add a patch changeset for `@pnpm/lockfile.fs` and `pnpm`

Fixes the Windows `EPERM` repro from https://github.com/pnpm/pnpm/actions/runs/27505503206/job/81298623383.

## Tests
- `pnpm --filter @pnpm/lockfile.fs test`
- `PNPM_REGISTRY_MOCK_PORT=7769 NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" pnpm exec jest test/install/dedupe.ts -t "uses the lockfile written by pacquet for post-install checks"`
- pre-push hook ran pnpm compile/bundle/lint metadata checks while pushing `fix-win-tests`

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a resource cleanup issue in lockfile reading operations where file handles were not properly released in certain code paths. File handles are now correctly closed in all scenarios, including early-exit cases. This prevents subsequent file system operations on lockfiles from failing due to retained open file streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->