### PR TITLE
feat(pacquet/add): `--save-prefix`

### DIFF
--- a/pacquet/crates/cli/src/cli_args/add.rs
+++ b/pacquet/crates/cli/src/cli_args/add.rs
@@ -3,6 +3,7 @@ use clap::Args;
 use miette::Context;
 use pacquet_package_manager::Add;
 use pacquet_package_manifest::DependencyGroup;
+use pacquet_registry::PinnedVersion;
 use pacquet_reporter::Reporter;
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
 use std::path::{Path, PathBuf};
@@ -78,6 +79,12 @@ pub struct AddArgs {
     /// the default semver range operator.
     #[clap(short = 'E', long = "save-exact")]
     pub save_exact: bool,
+    /// Configure the prefix used for the saved version range: `^` (the default)
+    /// allows same-major updates, `~` allows patch-level updates, and an empty
+    /// string pins the exact version. `--save-exact` takes precedence. Mirrors
+    /// pnpm's `--save-prefix`.
+    #[clap(long = "save-prefix", value_name = "prefix")]
+    pub save_prefix: Option<String>,
     /// Save the new dependency to the default catalog: `catalog:` is written
     /// to `package.json` and the specifier to `pnpm-workspace.yaml`'s
     /// `catalog:` block. Shorthand for `--save-catalog-name=default`.
@@ -158,10 +165,16 @@ impl AddArgs {
             .or_else(|| self.save_catalog.then(|| "default".to_string()))
             .or_else(|| state.config.save_catalog_name.clone());
 
+        // Collapse the `--save-exact` / `--save-prefix` flags into the pinned
+        // version that decides the saved range, mirroring pnpm's
+        // `getPinnedVersion`.
+        let pinned_version =
+            PinnedVersion::from_save_options(self.save_exact, self.save_prefix.as_deref());
+
         add_package::<Reporter, _, _>(
             state,
             &self.package_name,
-            self.save_exact,
+            pinned_version,
             save_catalog_name,
             self.lockfile_only,
             supported_architectures,
@@ -180,7 +193,7 @@ impl AddArgs {
 pub(crate) async fn add_package<Reporter, ListDependencyGroups, DependencyGroupList>(
     mut state: State,
     package_name: &str,
-    save_exact: bool,
+    pinned_version: PinnedVersion,
     save_catalog_name: Option<String>,
     lockfile_only: bool,
     supported_architectures: Option<pacquet_package_is_installable::SupportedArchitectures>,
@@ -209,7 +222,7 @@ where
         lockfile_path: lockfile_path.as_deref(),
         list_dependency_groups,
         package_name,
-        save_exact,
+        pinned_version,
         save_catalog_name,
         resolved_packages,
         supported_architectures,

--- a/pacquet/crates/cli/src/cli_args/add.rs
+++ b/pacquet/crates/cli/src/cli_args/add.rs
@@ -79,10 +79,7 @@ pub struct AddArgs {
     /// the default semver range operator.
     #[clap(short = 'E', long = "save-exact")]
     pub save_exact: bool,
-    /// Configure the prefix used for the saved version range: `^` (the default)
-    /// allows same-major updates, `~` allows patch-level updates, and an empty
-    /// string pins the exact version. `--save-exact` takes precedence. Mirrors
-    /// pnpm's `--save-prefix`.
+    /// The prefix of the saved version range: `^` (default), `~`, or empty for an exact version.
     #[clap(long = "save-prefix", value_name = "prefix")]
     pub save_prefix: Option<String>,
     /// Save the new dependency to the default catalog: `catalog:` is written

--- a/pacquet/crates/cli/src/cli_args/dlx.rs
+++ b/pacquet/crates/cli/src/cli_args/dlx.rs
@@ -11,6 +11,7 @@ use pacquet_crypto_hash::create_short_hash;
 use pacquet_fs::force_symlink_dir;
 use pacquet_package_is_installable::SupportedArchitectures;
 use pacquet_package_manifest::DependencyGroup;
+use pacquet_registry::PinnedVersion;
 use pacquet_reporter::Reporter;
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
 use serde_json::{Value, json};
@@ -299,7 +300,8 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
         add_package::<Reporter, _, _>(
             state,
             pkg,
-            false,
+            // dlx records the default caret range; the spec is throwaway.
+            PinnedVersion::default(),
             // dlx never catalogs.
             None,
             // dlx must download to run the bin, so never lockfile-only.

--- a/pacquet/crates/cli/tests/add.rs
+++ b/pacquet/crates/cli/tests/add.rs
@@ -164,6 +164,16 @@ fn save_exact_overrides_save_prefix() {
 }
 
 #[test]
+fn save_prefix_arbitrary_value_falls_back_to_caret() {
+    let (root, dir, anchor) =
+        exec_pacquet_in_temp_cwd(["add", "@pnpm.e2e/hello-world-js-bin", "--save-prefix=foo"]);
+    let spec = prod_spec(&dir, "@pnpm.e2e/hello-world-js-bin");
+    eprintln!("SPEC: {spec}");
+    assert_eq!(spec, "^1.0.0");
+    drop((root, anchor)); // cleanup
+}
+
+#[test]
 fn should_add_dev_dependency() {
     let (root, dir, anchor) =
         exec_pacquet_in_temp_cwd(["add", "@pnpm.e2e/hello-world-js-bin", "--save-dev"]);

--- a/pacquet/crates/cli/tests/add.rs
+++ b/pacquet/crates/cli/tests/add.rs
@@ -174,6 +174,18 @@ fn save_exact_writes_exact_version() {
 }
 
 #[test]
+fn add_prerelease_resolved_version_keeps_no_prefix() {
+    // `@pnpm.e2e/beta-version`'s only published version is the prerelease
+    // `1.0.0-beta.0`, so `latest` resolves to it. A prerelease range is
+    // written verbatim, with no `^`, matching pnpm.
+    let (root, dir, anchor) = exec_pacquet_in_temp_cwd(["add", "@pnpm.e2e/beta-version"]);
+    let spec = prod_spec(&dir, "@pnpm.e2e/beta-version");
+    eprintln!("SPEC: {spec}");
+    assert_eq!(spec, "1.0.0-beta.0");
+    drop((root, anchor)); // cleanup
+}
+
+#[test]
 fn save_prefix_arbitrary_value_falls_back_to_caret() {
     let (root, dir, anchor) =
         exec_pacquet_in_temp_cwd(["add", "@pnpm.e2e/hello-world-js-bin", "--save-prefix=foo"]);

--- a/pacquet/crates/cli/tests/add.rs
+++ b/pacquet/crates/cli/tests/add.rs
@@ -112,6 +112,58 @@ fn should_add_to_package_json() {
     drop((root, anchor)); // cleanup
 }
 
+fn prod_spec(dir: &std::path::Path, name: &str) -> String {
+    let manifest = PackageManifest::from_path(dir.join("package.json")).unwrap();
+    let (_, spec) = manifest
+        .dependencies([DependencyGroup::Prod])
+        .find(|(key, _)| *key == name)
+        .unwrap_or_else(|| panic!("{name} should be in dependencies"));
+    spec.to_string()
+}
+
+#[test]
+fn save_prefix_defaults_to_caret() {
+    let (root, dir, anchor) = exec_pacquet_in_temp_cwd(["add", "@pnpm.e2e/hello-world-js-bin"]);
+    let spec = prod_spec(&dir, "@pnpm.e2e/hello-world-js-bin");
+    eprintln!("SPEC: {spec}");
+    assert_eq!(spec, "^1.0.0");
+    drop((root, anchor)); // cleanup
+}
+
+#[test]
+fn save_prefix_tilde_writes_tilde_range() {
+    let (root, dir, anchor) =
+        exec_pacquet_in_temp_cwd(["add", "@pnpm.e2e/hello-world-js-bin", "--save-prefix=~"]);
+    let spec = prod_spec(&dir, "@pnpm.e2e/hello-world-js-bin");
+    eprintln!("SPEC: {spec}");
+    assert_eq!(spec, "~1.0.0");
+    drop((root, anchor)); // cleanup
+}
+
+#[test]
+fn save_prefix_empty_writes_exact_version() {
+    let (root, dir, anchor) =
+        exec_pacquet_in_temp_cwd(["add", "@pnpm.e2e/hello-world-js-bin", "--save-prefix="]);
+    let spec = prod_spec(&dir, "@pnpm.e2e/hello-world-js-bin");
+    eprintln!("SPEC: {spec}");
+    assert_eq!(spec, "1.0.0");
+    drop((root, anchor)); // cleanup
+}
+
+#[test]
+fn save_exact_overrides_save_prefix() {
+    let (root, dir, anchor) = exec_pacquet_in_temp_cwd([
+        "add",
+        "@pnpm.e2e/hello-world-js-bin",
+        "--save-prefix=~",
+        "--save-exact",
+    ]);
+    let spec = prod_spec(&dir, "@pnpm.e2e/hello-world-js-bin");
+    eprintln!("SPEC: {spec}");
+    assert_eq!(spec, "1.0.0");
+    drop((root, anchor)); // cleanup
+}
+
 #[test]
 fn should_add_dev_dependency() {
     let (root, dir, anchor) =

--- a/pacquet/crates/cli/tests/add.rs
+++ b/pacquet/crates/cli/tests/add.rs
@@ -164,6 +164,16 @@ fn save_exact_overrides_save_prefix() {
 }
 
 #[test]
+fn save_exact_writes_exact_version() {
+    let (root, dir, anchor) =
+        exec_pacquet_in_temp_cwd(["add", "@pnpm.e2e/hello-world-js-bin", "--save-exact"]);
+    let spec = prod_spec(&dir, "@pnpm.e2e/hello-world-js-bin");
+    eprintln!("SPEC: {spec}");
+    assert_eq!(spec, "1.0.0");
+    drop((root, anchor)); // cleanup
+}
+
+#[test]
 fn save_prefix_arbitrary_value_falls_back_to_caret() {
     let (root, dir, anchor) =
         exec_pacquet_in_temp_cwd(["add", "@pnpm.e2e/hello-world-js-bin", "--save-prefix=foo"]);

--- a/pacquet/crates/cli/tests/add.rs
+++ b/pacquet/crates/cli/tests/add.rs
@@ -5,6 +5,7 @@ use pacquet_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
     fs::{get_all_folders, get_filenames_in_folder},
 };
+use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
 #[cfg(unix)]
 use std::fs;
@@ -59,8 +60,6 @@ fn should_install_all_dependencies() {
 #[test]
 #[cfg(unix)]
 pub fn should_symlink_correctly() {
-    use pipe_trait::Pipe;
-
     let (root, workspace, anchor) =
         exec_pacquet_in_temp_cwd(["add", "@pnpm.e2e/hello-world-js-bin-parent"]);
 
@@ -113,7 +112,7 @@ fn should_add_to_package_json() {
 }
 
 fn prod_spec(dir: &std::path::Path, name: &str) -> String {
-    let manifest = PackageManifest::from_path(dir.join("package.json")).unwrap();
+    let manifest = dir.join("package.json").pipe(PackageManifest::from_path).unwrap();
     let (_, spec) = manifest
         .dependencies([DependencyGroup::Prod])
         .find(|(key, _)| *key == name)

--- a/pacquet/crates/package-manager/src/add.rs
+++ b/pacquet/crates/package-manager/src/add.rs
@@ -13,7 +13,7 @@ use pacquet_config::Config;
 use pacquet_lockfile::{Lockfile, MaybeLazyLockfile};
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest, PackageManifestError};
-use pacquet_registry::{PackageTag, PackageVersion};
+use pacquet_registry::{PackageTag, PackageVersion, PinnedVersion};
 use pacquet_reporter::{LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, Reporter};
 use pacquet_resolving_npm_resolver::pick_registry_for_package;
 use pacquet_tarball::MemCache;
@@ -36,7 +36,11 @@ where
     pub lockfile_path: Option<&'a std::path::Path>,
     pub list_dependency_groups: ListDependencyGroups, // must be a function because it is called multiple times
     pub package_name: &'a str, // may carry a `@<version>` suffix; TODO: multiple arguments, name this `packages`
-    pub save_exact: bool,      // TODO: add `save-exact` to `.npmrc`, merge configs, and remove this
+    /// How the freshly-resolved version is pinned into the manifest range,
+    /// derived from `--save-exact` / `--save-prefix`. See
+    /// [`PinnedVersion::from_save_options`].
+    // TODO: read `save-exact` / `save-prefix` from `.npmrc`, merge configs, and derive this there.
+    pub pinned_version: PinnedVersion,
     /// `--save-catalog-name=<name>` (with `--save-catalog` a shorthand for
     /// `default`), or the `saveCatalogName` config default. When `Some`,
     /// the added dependency is written as `catalog:` / `catalog:<name>`
@@ -104,7 +108,7 @@ where
             lockfile_path,
             list_dependency_groups,
             package_name,
-            save_exact,
+            pinned_version,
             save_catalog_name,
             resolved_packages,
             supported_architectures,
@@ -163,7 +167,7 @@ where
                     )
                     .await
                     .expect("resolve latest tag"); // TODO: properly propagate this error
-                    latest.serialize(save_exact)
+                    latest.serialize(pinned_version)
                 }
             },
         };

--- a/pacquet/crates/package-manager/src/add/tests.rs
+++ b/pacquet/crates/package-manager/src/add/tests.rs
@@ -3,6 +3,7 @@ use crate::ResolvedPackages;
 use pacquet_config::Config;
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_registry::PinnedVersion;
 use pacquet_reporter::SilentReporter;
 use std::sync::Arc;
 use tempfile::tempdir;
@@ -74,7 +75,7 @@ async fn add_routes_scoped_packages_to_configured_scoped_registry() {
         lockfile_path: None,
         list_dependency_groups: || [DependencyGroup::Prod],
         package_name: "@private/foo",
-        save_exact: true,
+        pinned_version: PinnedVersion::Patch,
         save_catalog_name: None,
         supported_architectures: None,
         lockfile_only: true,

--- a/pacquet/crates/package-manager/src/update.rs
+++ b/pacquet/crates/package-manager/src/update.rs
@@ -13,7 +13,7 @@ use pacquet_config::{CatalogMode, Config, matcher::create_matcher};
 use pacquet_lockfile::{Lockfile, MaybeLazyLockfile};
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest, PackageManifestError};
-use pacquet_registry::{PackageTag, PackageVersion};
+use pacquet_registry::{PackageTag, PackageVersion, PinnedVersion};
 use pacquet_reporter::{LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, Reporter};
 use pacquet_resolving_npm_resolver::pick_registry_for_package;
 use pacquet_tarball::MemCache;
@@ -204,6 +204,10 @@ impl Update<'_> {
             lockfile_only,
         } = self;
 
+        // `pacquet update` has no `--save-prefix` flag yet, so `save_exact`
+        // alone selects between an exact pin and the default caret range.
+        let pinned_version = PinnedVersion::from_save_options(save_exact, None);
+
         let selectors: Vec<ParsedSelector> =
             packages.iter().map(|input| parse_update_param(input)).collect();
 
@@ -273,7 +277,7 @@ impl Update<'_> {
                 }
                 if latest {
                     let version = fetch_latest(name, http_client, config).await?;
-                    rewrites.push((name.clone(), *group, version.serialize(save_exact)));
+                    rewrites.push((name.clone(), *group, version.serialize(pinned_version)));
                 }
                 drop_names.insert(name.clone());
             }
@@ -373,7 +377,7 @@ impl Update<'_> {
                     drop_names.insert(name.clone());
                     if latest {
                         let version = fetch_latest(name, http_client, config).await?;
-                        rewrites.push((name.clone(), *group, version.serialize(save_exact)));
+                        rewrites.push((name.clone(), *group, version.serialize(pinned_version)));
                     } else if let Some(spec) = selectors
                         .iter()
                         .find(|sel| matcher_one(&sel.pattern).matches(name))

--- a/pacquet/crates/registry/src/lib.rs
+++ b/pacquet/crates/registry/src/lib.rs
@@ -3,12 +3,14 @@ mod package_distribution;
 mod package_tag;
 mod package_version;
 mod package_versions;
+mod pinned_version;
 
 pub use package::Package;
 pub use package_distribution::{AttestationsDist, PackageDistribution, ProvenanceMeta};
 pub use package_tag::PackageTag;
 pub use package_version::{Approver, NpmUser, PackageVersion, TrustedPublisher};
 pub use package_versions::PackageVersions;
+pub use pinned_version::PinnedVersion;
 
 use derive_more::{Display, Error, From};
 use miette::Diagnostic;

--- a/pacquet/crates/registry/src/package/tests.rs
+++ b/pacquet/crates/registry/src/package/tests.rs
@@ -56,6 +56,32 @@ pub fn serialized_according_to_params() {
     assert_eq!(version.serialize(PinnedVersion::None), "^3.2.1");
 }
 
+/// A prerelease resolved version is written to the manifest verbatim,
+/// with no range prefix, regardless of the pinned version. Mirrors pnpm's
+/// `createVersionSpecFromResolvedVersion` prerelease branch
+/// (<https://github.com/pnpm/pnpm/blob/086c5e91e8/pkg-manifest/utils/test/updateProjectManifestObject.test.ts#L122-L140>).
+#[test]
+pub fn serialize_keeps_prerelease_version_without_prefix() {
+    let version = PackageVersion {
+        name: String::new(),
+        version: Version::parse("2.1.0-rc.1").unwrap(),
+        dist: PackageDistribution::default(),
+        dependencies: None,
+        dev_dependencies: None,
+        peer_dependencies: None,
+        optional_dependencies: None,
+        peer_dependencies_meta: None,
+        other: HashMap::default(),
+        npm_user: None,
+        deprecated: None,
+    };
+
+    assert_eq!(version.serialize(PinnedVersion::Major), "2.1.0-rc.1");
+    assert_eq!(version.serialize(PinnedVersion::Minor), "2.1.0-rc.1");
+    assert_eq!(version.serialize(PinnedVersion::Patch), "2.1.0-rc.1");
+    assert_eq!(version.serialize(PinnedVersion::None), "2.1.0-rc.1");
+}
+
 /// [`Package::fetch_from_registry`] must attach the registry-keyed
 /// `Authorization` header on every metadata GET, even for the
 /// abbreviated install-v1 endpoint. `mockito::Matcher::Exact`

--- a/pacquet/crates/registry/src/package/tests.rs
+++ b/pacquet/crates/registry/src/package/tests.rs
@@ -4,7 +4,7 @@ use node_semver::Version;
 use pretty_assertions::assert_eq;
 
 use super::{AuthHeaders, Package, PackageVersion, ThrottledClient};
-use crate::package_distribution::PackageDistribution;
+use crate::{PinnedVersion, package_distribution::PackageDistribution};
 
 #[test]
 pub fn package_version_should_include_peers() {
@@ -50,8 +50,10 @@ pub fn serialized_according_to_params() {
         deprecated: None,
     };
 
-    assert_eq!(version.serialize(true), "3.2.1");
-    assert_eq!(version.serialize(false), "^3.2.1");
+    assert_eq!(version.serialize(PinnedVersion::Patch), "3.2.1");
+    assert_eq!(version.serialize(PinnedVersion::Minor), "~3.2.1");
+    assert_eq!(version.serialize(PinnedVersion::Major), "^3.2.1");
+    assert_eq!(version.serialize(PinnedVersion::None), "^3.2.1");
 }
 
 /// [`Package::fetch_from_registry`] must attach the registry-keyed

--- a/pacquet/crates/registry/src/package_version.rs
+++ b/pacquet/crates/registry/src/package_version.rs
@@ -307,6 +307,12 @@ impl PackageVersion {
 
     #[must_use]
     pub fn serialize(&self, pinned_version: PinnedVersion) -> String {
+        // A prerelease resolved version is written verbatim, ignoring the
+        // pinned prefix, matching pnpm's `createVersionSpecFromResolvedVersion`
+        // at <https://github.com/pnpm/pnpm/blob/086c5e91e8/pkg-manifest/utils/src/updateProjectManifestObject.ts#L29-L45>.
+        if !self.version.pre_release.is_empty() {
+            return self.version.to_string();
+        }
         format!("{0}{1}", pinned_version.range_prefix(), self.version)
     }
 }

--- a/pacquet/crates/registry/src/package_version.rs
+++ b/pacquet/crates/registry/src/package_version.rs
@@ -4,7 +4,10 @@ use pacquet_network::{AuthHeaders, ThrottledClient};
 use pipe_trait::Pipe;
 use serde::{Deserialize, Serialize};
 
-use crate::{NetworkError, PackageTag, RegistryError, package_distribution::PackageDistribution};
+use crate::{
+    NetworkError, PackageTag, PinnedVersion, RegistryError,
+    package_distribution::PackageDistribution,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -303,9 +306,8 @@ impl PackageVersion {
     }
 
     #[must_use]
-    pub fn serialize(&self, save_exact: bool) -> String {
-        let prefix = if save_exact { "" } else { "^" };
-        format!("{0}{1}", prefix, self.version)
+    pub fn serialize(&self, pinned_version: PinnedVersion) -> String {
+        format!("{0}{1}", pinned_version.range_prefix(), self.version)
     }
 }
 

--- a/pacquet/crates/registry/src/pinned_version.rs
+++ b/pacquet/crates/registry/src/pinned_version.rs
@@ -7,7 +7,7 @@
 /// [`PinnedVersion::Major`]; the `--save-exact` / `--save-prefix` interpreter
 /// in [`PinnedVersion::from_save_options`] never produces it, matching pnpm's
 /// `getPinnedVersion`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum PinnedVersion {
     /// Save with a caret range (`^version`), allowing same-major updates.
     /// pnpm's default.

--- a/pacquet/crates/registry/src/pinned_version.rs
+++ b/pacquet/crates/registry/src/pinned_version.rs
@@ -1,0 +1,57 @@
+/// How a resolved version is pinned into a manifest's version range when a
+/// dependency is added or updated.
+///
+/// Mirrors pnpm's `PinnedVersion` string-literal union
+/// (<https://github.com/pnpm/pnpm/blob/086c5e91e8/core/types/src/misc.ts#L71-L75>).
+/// [`PinnedVersion::None`] is part of that union and behaves like
+/// [`PinnedVersion::Major`]; the `--save-exact` / `--save-prefix` interpreter
+/// in [`PinnedVersion::from_save_options`] never produces it, matching pnpm's
+/// `getPinnedVersion`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PinnedVersion {
+    /// Save with a caret range (`^version`), allowing same-major updates.
+    /// pnpm's default.
+    #[default]
+    Major,
+    /// Save with a tilde range (`~version`), allowing patch-level updates.
+    Minor,
+    /// Save the exact resolved version with no range operator.
+    Patch,
+    /// Equivalent to [`PinnedVersion::Major`] when turned into a range.
+    None,
+}
+
+impl PinnedVersion {
+    /// Interpret the `--save-exact` and `--save-prefix` flags into a
+    /// [`PinnedVersion`].
+    ///
+    /// `--save-exact` (or an empty `--save-prefix`) pins the exact version,
+    /// `~` allows patch-level updates, and anything else (including an absent
+    /// prefix, the default) allows same-major updates. Mirrors pnpm's
+    /// `getPinnedVersion`
+    /// (<https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/commands/src/getPinnedVersion.ts>).
+    #[must_use]
+    pub fn from_save_options(save_exact: bool, save_prefix: Option<&str>) -> Self {
+        if save_exact || save_prefix == Some("") {
+            return PinnedVersion::Patch;
+        }
+        if save_prefix == Some("~") { PinnedVersion::Minor } else { PinnedVersion::Major }
+    }
+
+    /// The range operator prepended to the resolved version when serializing
+    /// it into a manifest specifier.
+    ///
+    /// Mirrors pnpm's `createVersionSpecFromResolvedVersion`
+    /// (<https://github.com/pnpm/pnpm/blob/086c5e91e8/pkg-manifest/utils/src/updateProjectManifestObject.ts#L29-L45>).
+    #[must_use]
+    pub fn range_prefix(self) -> &'static str {
+        match self {
+            PinnedVersion::Major | PinnedVersion::None => "^",
+            PinnedVersion::Minor => "~",
+            PinnedVersion::Patch => "",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/registry/src/pinned_version/tests.rs
+++ b/pacquet/crates/registry/src/pinned_version/tests.rs
@@ -1,0 +1,29 @@
+use super::PinnedVersion;
+
+/// Mirrors pnpm's `getPinnedVersion()` test
+/// (<https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/commands/test/getPinnedVersion.ts>).
+#[test]
+fn from_save_options_matches_pnpm_get_pinned_version() {
+    assert_eq!(PinnedVersion::from_save_options(true, None), PinnedVersion::Patch);
+    assert_eq!(PinnedVersion::from_save_options(false, Some("")), PinnedVersion::Patch);
+    assert_eq!(PinnedVersion::from_save_options(false, Some("~")), PinnedVersion::Minor);
+    assert_eq!(PinnedVersion::from_save_options(false, Some("^")), PinnedVersion::Major);
+}
+
+/// An absent `--save-prefix` falls through to the default caret range, and
+/// `--save-exact` wins over any `--save-prefix` value.
+#[test]
+fn from_save_options_default_and_precedence() {
+    assert_eq!(PinnedVersion::from_save_options(false, None), PinnedVersion::Major);
+    assert_eq!(PinnedVersion::default(), PinnedVersion::Major);
+    assert_eq!(PinnedVersion::from_save_options(true, Some("~")), PinnedVersion::Patch);
+    assert_eq!(PinnedVersion::from_save_options(true, Some("^")), PinnedVersion::Patch);
+}
+
+#[test]
+fn range_prefix_maps_each_variant() {
+    assert_eq!(PinnedVersion::Major.range_prefix(), "^");
+    assert_eq!(PinnedVersion::None.range_prefix(), "^");
+    assert_eq!(PinnedVersion::Minor.range_prefix(), "~");
+    assert_eq!(PinnedVersion::Patch.range_prefix(), "");
+}


### PR DESCRIPTION
Implements `pacquet add --save-prefix` in Rust, mirroring `pnpm add --save-prefix`.

## What it does

`--save-prefix` configures the semver range operator written to the manifest for a freshly added dependency:

- `^` (default) → `^1.2.3`, allows same-major updates
- `~` → `~1.2.3`, allows patch-level updates
- empty string → `1.2.3`, pins the exact version

`--save-exact` still takes precedence over `--save-prefix`.

## Implementation

Mirrors pnpm's decomposition: `(saveExact, savePrefix)` collapse into a single pinned version via [`getPinnedVersion`](https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/commands/src/getPinnedVersion.ts), which then maps to a range operator via [`createVersionSpecFromResolvedVersion`](https://github.com/pnpm/pnpm/blob/086c5e91e8/pkg-manifest/utils/src/updateProjectManifestObject.ts#L29-L45).

- New `PinnedVersion` enum in `pacquet-registry` (port of pnpm's `PinnedVersion` union) carrying the flag interpreter (`from_save_options`) and the range-operator mapping (`range_prefix`).
- `PackageVersion::serialize` now takes a `PinnedVersion` instead of a bare `save_exact` bool.
- The `--save-prefix` clap flag is added to `pacquet add` and threaded through `Add` / `add_package` / `dlx`. It stays an `Option<String>` (not a `ValueEnum`) because pnpm's `save-prefix` is a free-form `String`, so restricting accepted values would diverge from upstream.
- `pacquet update` keeps its existing behavior by deriving the pinned version from its own `save_exact` flag (it has no `--save-prefix` flag yet).

## Tests

- Unit tests for `from_save_options` (mirroring pnpm's `getPinnedVersion()` test) and `range_prefix`.
- `serialize` unit asserts covering each variant.
- CLI integration tests for `pacquet add`: default → `^1.0.0`, `--save-prefix=~` → `~1.0.0`, `--save-prefix=` → `1.0.0`, and `--save-prefix=~ --save-exact` → `1.0.0` (precedence).

---
Written by an agent (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--save-prefix` option to `pacquet add` for controlling dependency version ranges in package.json (caret `^`, tilde `~`, or exact). Default uses caret range.
  * `--save-exact` now works together with `--save-prefix` for combined version pinning control.

* **Tests**
  * Added comprehensive test coverage for version range behavior with various `--save-prefix` and `--save-exact` combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->