### PR TITLE
ci: structure CI check names

### DIFF
--- a/.github/workflows/ci-performance-bencher-upload.yml
+++ b/.github/workflows/ci-performance-bencher-upload.yml
@@ -7,7 +7,7 @@ on:
   # workflow_run, validates artifact metadata, then performs the authenticated
   # upload from trusted workflow code.
   workflow_run:
-    workflows: ["CI", "Pacquet CI"]
+    workflows: ["CI", "TS CI", "Pacquet CI", "Rust CI"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: TS CI
 
 on: [push, pull_request]
 
@@ -12,7 +12,7 @@ jobs:
     # Exception: chore/update-lockfile PRs (created by automation with GITHUB_TOKEN, which doesn't trigger push events)
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository || github.head_ref == 'chore/update-lockfile' }}
 
-    name: Compile & Lint
+    name: TS CI / Compile & Lint
     runs-on: ubuntu-latest
 
     steps:
@@ -40,24 +40,36 @@ jobs:
         retention-days: 1
 
   test-smoke:
-    name: ubuntu-latest / Node.js 24
+    name: TS CI / Test / ubuntu
     needs: compile-and-lint
     uses: ./.github/workflows/test.yml
     with:
       node: '24.0.0'
+      node_major: '24'
       platform: ubuntu-latest
       garnet: true
     secrets:
       GARNET_API_TOKEN: ${{ secrets.GARNET_API_TOKEN }}
 
   test:
-    name: ${{ matrix.platform }} / Node.js ${{ matrix.node }}
+    name: TS CI / Test / ${{ matrix.platform_label }}
     needs: test-smoke
     strategy:
       fail-fast: false
       matrix:
         node: ['22.13.0', '24.0.0', '26.3.0']
         platform: [ubuntu-latest, windows-latest]
+        include:
+          - node: '22.13.0'
+            node_major: '22'
+          - node: '24.0.0'
+            node_major: '24'
+          - node: '26.3.0'
+            node_major: '26'
+          - platform: ubuntu-latest
+            platform_label: ubuntu
+          - platform: windows-latest
+            platform_label: windows
         exclude:
           - node: '24.0.0'
             platform: ubuntu-latest
@@ -70,4 +82,5 @@ jobs:
     uses: ./.github/workflows/test.yml
     with:
       node: ${{ matrix.node }}
+      node_major: ${{ matrix.node_major }}
       platform: ${{ matrix.platform }}

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -1,12 +1,11 @@
-name: Pacquet CI
+name: Rust CI
 
-# Despite the name, this workflow covers every Rust crate in the
-# repo — pacquet and pnpr alike. They share the same cargo
-# workspace, so `just test`, dylint, doc, etc. all see both stacks
-# in one pass; running two workflows would just duplicate the work.
-# The in-workflow change detector intentionally includes `pnpr/**`
-# for the same reason. Keep path filtering out of the workflow
-# trigger so required checks are created and can report skipped.
+# This workflow covers every Rust crate in the repo — pacquet and
+# pnpr alike. They share the same cargo workspace, so `just test`,
+# dylint, doc, etc. all see both stacks in one pass; running two
+# workflows would just duplicate the work. Keep path filtering out
+# of the workflow trigger so required checks are created and can
+# report skipped.
 
 permissions:
   contents: read
@@ -26,7 +25,7 @@ concurrency:
 
 jobs:
   changes:
-    name: Detect Rust CI changes
+    name: Rust CI / Detect Changes
     runs-on: ubuntu-latest
     outputs:
       rust: ${{ steps.manual.outputs.rust || steps.filter.outputs.rust }}
@@ -65,7 +64,7 @@ jobs:
               - '.github/workflows/pacquet-ci.yml'
 
   test:
-    name: Lint and Test
+    name: Rust CI / Test / ${{ matrix.os_label }}
     needs: changes
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') }}
     strategy:
@@ -73,8 +72,11 @@ jobs:
       matrix:
         include:
           - os: windows-latest
+            os_label: windows
           - os: ubuntu-latest
+            os_label: ubuntu
           - os: macos-latest
+            os_label: macos
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -190,7 +192,7 @@ jobs:
           retention-days: 14
 
   clippy:
-    name: Clippy
+    name: Rust CI / Clippy
     needs: changes
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') }}
     # Clippy lints the same source on every platform, so one OS is
@@ -221,7 +223,7 @@ jobs:
         run: cargo clippy --locked --workspace --all-targets -- -D warnings
 
   doc:
-    name: Doc
+    name: Rust CI / Doc
     needs: changes
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') }}
     runs-on: ubuntu-latest
@@ -241,7 +243,7 @@ jobs:
         run: cargo doc --no-deps --workspace --document-private-items
 
   typos:
-    name: Spell Check
+    name: Rust CI / Spell Check
     needs: changes
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') }}
     runs-on: ubuntu-latest
@@ -255,7 +257,7 @@ jobs:
           files: pacquet pnpr
 
   deny:
-    name: Cargo Deny
+    name: Rust CI / Cargo Deny
     needs: changes
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') }}
     runs-on: ubuntu-latest
@@ -282,7 +284,7 @@ jobs:
         run: cargo deny check
 
   format:
-    name: Format
+    name: Rust CI / Format
     needs: changes
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') }}
     runs-on: ubuntu-latest
@@ -307,7 +309,7 @@ jobs:
       - run: taplo format --check
 
   dylint:
-    name: Dylint
+    name: Rust CI / Dylint
     needs: changes
     if: ${{ always() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.result != 'success') }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       node:
         required: true
         type: string
+      node_major:
+        required: true
+        type: string
       platform:
         required: true
         type: string
@@ -22,7 +25,7 @@ permissions:
 
 jobs:
   test:
-    name: Test
+    name: Node ${{ inputs.node_major }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.platform }}-${{ inputs.node }}
       cancel-in-progress: true


### PR DESCRIPTION
## Summary

- rename the shared Rust workflow from `Pacquet CI` to `Rust CI` because it covers both pacquet and pnpr
- prefix Rust job names with `Rust CI /` so required-check contexts are globally scannable
- rename TypeScript workflow contexts to `TS CI / ...`
- make test matrix labels compact and stable: platform plus Node major only
- keep the Bencher upload workflow listening to both old and new workflow names during the migration

## Branch protection migration

After this PR runs once, the required-check picker should expose the new contexts, for example:

- `TS CI / Compile & Lint`
- `TS CI / Test / ubuntu / Node 24`
- `TS CI / Test / windows / Node 22`
- `Rust CI / Dylint`
- `Rust CI / Test / macos`
- `Rust CI / Clippy`

Required checks using old names like `Compile & Lint`, `Dylint`, or `ubuntu-latest / Node.js 24 / Test` will need to be switched to the new names before this can merge without an admin bypass.

## Checks

- `actionlint .github/workflows/ci.yml .github/workflows/test.yml .github/workflows/pacquet-ci.yml .github/workflows/ci-performance-bencher-upload.yml`
- `git diff --check`
- pre-push hook: `pnpm run compile-only` and `pnpm run lint --quiet`

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow and job display names to follow a consistent **“Rust CI / …”** naming convention across CI-related checks.
  * Enhanced the reusable test workflow to accept a **Node major** parameter, improving test job labeling and readability in run history.
  * Expanded CI triggers and test matrix metadata (including platform/OS labels) so job names more clearly reflect the executed environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->