### PR TITLE
fix(ci): refresh update-lockfile install state

### DIFF
--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -58,7 +58,9 @@ jobs:
         pnpm runtime set node 26
 
         # Refresh the whole lockfile to the latest compatible dependency versions.
-        rm pnpm-lock.yaml
+        # Remove node_modules too so pnpm cannot reuse node_modules/.pnpm/lock.yaml
+        # as the missing wanted lockfile and skip resolution.
+        rm -rf node_modules pnpm-lock.yaml
         pnpm install
 
         # Propagate the new Node.js version into the GitHub Actions workflows,


### PR DESCRIPTION
The update-lockfile workflow currently removes only pnpm-lock.yaml before running pnpm install. With the current repeat-install/current-lockfile behavior, pnpm can reuse node_modules/.pnpm/lock.yaml as the missing wanted lockfile, skip resolution, and then delegate to pacquet in frozen mode. Pacquet then fails because pnpm-lock.yaml is physically absent.

This removes node_modules together with pnpm-lock.yaml before the refresh install, so the workflow starts from a clean install state and must regenerate the lockfile instead of restoring from the current lockfile.

Verification:
- git diff --check
- git push pre-push hook passed: compile-only, pnpm package compile, spellcheck, meta-updater test, and quiet lint

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency resolution in the build workflow to ensure stale dependencies don't cause inconsistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->