### PR TITLE
fix(package-manager): preserve range operator on pacquet update --latest

### DIFF
--- a/pacquet/crates/cli/tests/update.rs
+++ b/pacquet/crates/cli/tests/update.rs
@@ -137,15 +137,51 @@ fn update_latest_rewrites_manifest() {
     drop((root, anchor));
 }
 
-/// `--save-exact` writes the bumped version without a range operator.
+/// `--latest` keeps the range operator the dependency already used, even
+/// when `--save-exact` is passed: a pre-existing pin takes precedence over
+/// the config default, matching pnpm's `calcRange`. (`pnpm update --latest
+/// --save-exact` on `^1.0.0` writes `^<latest>`, not the exact version.)
 #[test]
-fn update_latest_save_exact() {
+fn update_latest_save_exact_preserves_existing_caret() {
     let (root, workspace, anchor) = setup();
 
     write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
     pacquet(&workspace, ["install"]).assert().success();
 
     pacquet(&workspace, ["update", "--latest", "--save-exact"]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^101.0.0"));
+
+    drop((root, anchor));
+}
+
+/// `--latest` preserves a tilde range instead of widening it to the default
+/// caret — the gap this fix closes. Ports the prefix-preservation half of
+/// pnpm's `calcRange`.
+#[test]
+fn update_latest_preserves_tilde() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "~100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["update", "--latest"]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("~101.0.0"));
+
+    drop((root, anchor));
+}
+
+/// `--latest` preserves an exact pin (no range operator) without needing
+/// `--save-exact`.
+#[test]
+fn update_latest_preserves_exact() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["update", "--latest"]).assert().success();
 
     assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("101.0.0"));
 

--- a/pacquet/crates/package-manager/src/update.rs
+++ b/pacquet/crates/package-manager/src/update.rs
@@ -15,7 +15,7 @@ use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest, PackageManifestError};
 use pacquet_registry::{PackageTag, PackageVersion, PinnedVersion};
 use pacquet_reporter::{LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, Reporter};
-use pacquet_resolving_npm_resolver::pick_registry_for_package;
+use pacquet_resolving_npm_resolver::{pick_registry_for_package, which_version_is_pinned};
 use pacquet_tarball::MemCache;
 use pacquet_workspace_manifest_writer::{UpdateWorkspaceManifestError, update_workspace_manifest};
 use std::{collections::HashSet, sync::Arc};
@@ -39,10 +39,12 @@ const DIRECT_GROUPS: [DependencyGroup; 3] =
 ///   pnpm only rewrites the manifest for deps marked `updateSpec`, which
 ///   compatible updates are not.
 /// * **`--latest`**: each matched *direct* dependency's `latest` tag is
-///   fetched and written into `package.json` (`^<version>`, or the exact
-///   version under `--save-exact`), exactly as `pacquet add` records a
-///   freshly-added range. The follow-up install then resolves the new
-///   range. Mirrors pnpm's `updateToLatest` + `updateSpec` path.
+///   fetched and written into `package.json`, reusing the range operator
+///   the dependency already pinned (`^` stays `^`, `~` stays `~`, an exact
+///   pin stays exact) and falling back to the configured default
+///   otherwise — pnpm's `calcRange` precedence. The follow-up install then
+///   resolves the new range. Mirrors pnpm's `updateToLatest` + `updateSpec`
+///   path.
 ///
 /// Selector handling mirrors pnpm's
 /// [`update`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/commands/src/update/index.ts#L282-L328):
@@ -72,7 +74,10 @@ pub struct Update<'a> {
     /// `package.json`.
     pub latest: bool,
     /// `--save-exact` / `-E`: write the resolved version without a range
-    /// operator when rewriting the manifest under `--latest`.
+    /// operator when rewriting the manifest under `--latest`. Only applies
+    /// to dependencies whose current specifier has no recoverable pin; an
+    /// existing `^`/`~`/exact range is preserved over this default, matching
+    /// pnpm's `calcRange`.
     pub save_exact: bool,
     /// `--save` (default) / `--no-save`. When `false`, the manifest is
     /// not persisted: the `--latest` / versioned-selector range rewrites
@@ -208,6 +213,13 @@ impl Update<'_> {
         // alone selects between an exact pin and the default caret range.
         let pinned_version = PinnedVersion::from_save_options(save_exact, None);
 
+        // Under `--latest`, the resolved version is written back with the
+        // range operator the dependency already used; only a specifier with
+        // no recoverable pin (a tag, a `catalog:` reference, a multi-comparator
+        // range) falls back to the configured default. Mirrors pnpm's
+        // `calcRange` precedence: `whichVersionIsPinned(prev) ?? default`.
+        let latest_pin = |prev: &str| which_version_is_pinned(prev).unwrap_or(pinned_version);
+
         let selectors: Vec<ParsedSelector> =
             packages.iter().map(|input| parse_update_param(input)).collect();
 
@@ -271,13 +283,13 @@ impl Update<'_> {
             let is_ignored =
                 |name: &str| ignore_matcher.as_ref().is_some_and(|matcher| matcher.matches(name));
 
-            for (name, group, _) in &direct {
+            for (name, group, prev) in &direct {
                 if is_ignored(name) {
                     continue;
                 }
                 if latest {
                     let version = fetch_latest(name, http_client, config).await?;
-                    rewrites.push((name.clone(), *group, version.serialize(pinned_version)));
+                    rewrites.push((name.clone(), *group, version.serialize(latest_pin(prev))));
                 }
                 drop_names.insert(name.clone());
             }
@@ -342,10 +354,10 @@ impl Update<'_> {
             // manifest, mirroring pnpm's `matchDependencies` + `updateSpec`.
             let patterns: Vec<String> = selectors.iter().map(|sel| sel.pattern.clone()).collect();
             let matcher = create_matcher(&patterns);
-            let matched_direct: Vec<(String, DependencyGroup)> = direct
+            let matched_direct: Vec<(String, DependencyGroup, String)> = direct
                 .iter()
                 .filter(|(name, _, _)| matcher.matches(name))
-                .map(|(name, group, _)| (name.clone(), *group))
+                .map(|(name, group, prev)| (name.clone(), *group, prev.clone()))
                 .collect();
 
             if matched_direct.is_empty() {
@@ -373,11 +385,11 @@ impl Update<'_> {
                 }
                 UpdateSeedPolicy::DropOnly(drop_names)
             } else {
-                for (name, group) in &matched_direct {
+                for (name, group, prev) in &matched_direct {
                     drop_names.insert(name.clone());
                     if latest {
                         let version = fetch_latest(name, http_client, config).await?;
-                        rewrites.push((name.clone(), *group, version.serialize(pinned_version)));
+                        rewrites.push((name.clone(), *group, version.serialize(latest_pin(prev))));
                     } else if let Some(spec) = selectors
                         .iter()
                         .find(|sel| matcher_one(&sel.pattern).matches(name))

--- a/pacquet/crates/resolving-npm-resolver/src/lib.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/lib.rs
@@ -36,6 +36,7 @@ mod registry_url;
 mod resolve_from_workspace;
 mod trust_checks;
 mod violation_codes;
+mod which_version_is_pinned;
 mod workspace_pref_to_npm;
 
 pub use create_npm_resolution_verifier::{
@@ -80,4 +81,5 @@ pub use trust_checks::{
     TrustCheckOptions, TrustEvidence, TrustViolation, fail_if_trust_downgraded, get_trust_evidence,
 };
 pub use violation_codes::{MINIMUM_RELEASE_AGE_VIOLATION_CODE, TRUST_DOWNGRADE_VIOLATION_CODE};
+pub use which_version_is_pinned::which_version_is_pinned;
 pub use workspace_pref_to_npm::{InvalidWorkspaceSpecError, workspace_pref_to_npm};

--- a/pacquet/crates/resolving-npm-resolver/src/which_version_is_pinned.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/which_version_is_pinned.rs
@@ -1,0 +1,197 @@
+//! Detect the range operator a specifier already pins to, so an update can
+//! preserve it.
+
+use pacquet_registry::PinnedVersion;
+
+/// Classify the range operator an existing specifier pins to.
+///
+/// Ports pnpm's
+/// [`whichVersionIsPinned`](https://github.com/pnpm/pnpm/blob/29ab905c21/resolving/npm-resolver/src/whichVersionIsPinned.ts).
+/// Returns the [`PinnedVersion`] the specifier already uses, or `None` when
+/// the specifier carries no single recoverable pin (a `catalog:` reference,
+/// a tag, a multi-comparator range, or junk). Callers fall back to the
+/// configured default in that case, mirroring `calcRange`'s
+/// `whichVersionIsPinned(prev) ?? whichVersionIsPinned(bare) ?? default`
+/// precedence
+/// (<https://github.com/pnpm/pnpm/blob/681b593eb2/resolving/npm-resolver/src/index.ts#L806-L814>).
+///
+/// A `catalog:` reference carries no pin of its own — the pin lives in the
+/// catalog entry it points to — so it returns `None` even when the catalog
+/// name happens to parse as a version (e.g. `catalog:express4-21`), matching
+/// the upstream guard.
+#[must_use]
+pub fn which_version_is_pinned(spec: &str) -> Option<PinnedVersion> {
+    if spec.starts_with("catalog:") {
+        return None;
+    }
+    // Strip a protocol prefix up to the first ':' (`npm:`, `jsr:`,
+    // `workspace:`, ...), then an alias up to and including the last '@'
+    // (`foo@...`, `@scope/foo@...`), leaving the bare range.
+    let spec = match spec.find(':') {
+        Some(index) => &spec[index + 1..],
+        None => spec,
+    };
+    let spec = match spec.rfind('@') {
+        Some(index) => &spec[index + 1..],
+        None => spec,
+    };
+    if spec == "*" {
+        return Some(PinnedVersion::None);
+    }
+
+    let mut comparator = None;
+    let bytes = spec.as_bytes();
+    let mut pos = 0;
+    while pos < bytes.len() {
+        let Some((next, end)) = next_comparator(bytes, pos) else { break };
+        if comparator.is_some() {
+            // More than one comparator (a range like `>=1 <2`): no single pin.
+            return None;
+        }
+        comparator = Some(next);
+        pos = end;
+    }
+
+    let comparator = comparator?;
+    match comparator.operator {
+        Some(Operator::Tilde) => Some(PinnedVersion::Minor),
+        Some(Operator::Caret) => Some(PinnedVersion::Major),
+        Some(Operator::Other) => None,
+        None if comparator.has_patch => Some(PinnedVersion::Patch),
+        None if comparator.has_minor => Some(PinnedVersion::Minor),
+        None if comparator.has_major => Some(PinnedVersion::Major),
+        None => None,
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Operator {
+    Caret,
+    Tilde,
+    /// Any other comparison operator (`>=`, `<`, `=`, `~>`, ...). pnpm's
+    /// `switch` leaves these unhandled, so they fall through to `None`.
+    Other,
+}
+
+struct Comparator {
+    operator: Option<Operator>,
+    has_major: bool,
+    has_minor: bool,
+    has_patch: bool,
+}
+
+/// Scan forward from `from` for the next single version comparator,
+/// mirroring one iteration of semver-utils' `reSemverRange` global match
+/// (the engine `whichVersionIsPinned` relies on). Returns the parsed
+/// comparator and the byte offset just past it, or `None` if no comparator
+/// remains. A comparator requires a numeric major component; an operator
+/// without one (`^abc`) and separators (`||`, `-`) are skipped, just as a
+/// non-matching prefix is skipped by `exec`.
+fn next_comparator(bytes: &[u8], from: usize) -> Option<(Comparator, usize)> {
+    let mut start = from;
+    while start < bytes.len() {
+        if let Some(found) = try_comparator(bytes, start) {
+            return Some(found);
+        }
+        start += 1;
+    }
+    None
+}
+
+fn try_comparator(bytes: &[u8], at: usize) -> Option<(Comparator, usize)> {
+    let len = bytes.len();
+    let mut idx = at;
+
+    // Operator: `(~?[<>]?|^?)=?`.
+    let mut operator = if idx < len && bytes[idx] == b'^' {
+        idx += 1;
+        Some(Operator::Caret)
+    } else {
+        let tilde = idx < len && bytes[idx] == b'~';
+        if tilde {
+            idx += 1;
+        }
+        let angle = idx < len && (bytes[idx] == b'<' || bytes[idx] == b'>');
+        if angle {
+            idx += 1;
+        }
+        match (tilde, angle) {
+            (true, false) => Some(Operator::Tilde),
+            (false, false) => None,
+            _ => Some(Operator::Other),
+        }
+    };
+    if idx < len && bytes[idx] == b'=' {
+        // `^=`, `~=`, `>=`, or a bare `=` — none are a plain caret/tilde pin.
+        idx += 1;
+        operator = Some(Operator::Other);
+    }
+
+    // Optional whitespace, then an optional `v`.
+    while idx < len && bytes[idx].is_ascii_whitespace() {
+        idx += 1;
+    }
+    if idx < len && bytes[idx] == b'v' {
+        idx += 1;
+    }
+
+    // Major: one or more digits, required.
+    let major_start = idx;
+    while idx < len && bytes[idx].is_ascii_digit() {
+        idx += 1;
+    }
+    if idx == major_start {
+        return None;
+    }
+
+    // Optional `.minor` and `.patch`, each `x`, `*`, or digits.
+    let mut has_minor = false;
+    if idx < len
+        && bytes[idx] == b'.'
+        && let Some(end) = match_minor_or_patch(bytes, idx + 1)
+    {
+        has_minor = true;
+        idx = end;
+    }
+    let mut has_patch = false;
+    if idx < len
+        && bytes[idx] == b'.'
+        && let Some(end) = match_minor_or_patch(bytes, idx + 1)
+    {
+        has_patch = true;
+        idx = end;
+    }
+
+    // Optional prerelease/build tail: `[-+][0-9A-Za-z.-]+`.
+    if idx < len && (bytes[idx] == b'-' || bytes[idx] == b'+') {
+        let tail_start = idx + 1;
+        let mut end = tail_start;
+        while end < len
+            && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'.' || bytes[end] == b'-')
+        {
+            end += 1;
+        }
+        if end > tail_start {
+            idx = end;
+        }
+    }
+
+    Some((Comparator { operator, has_major: true, has_minor, has_patch }, idx))
+}
+
+/// Match a single `x`, `*`, or run of digits — the minor/patch alternative
+/// `(x|\*|[0-9]+)`. Returns the byte offset just past it, or `None`.
+fn match_minor_or_patch(bytes: &[u8], at: usize) -> Option<usize> {
+    let len = bytes.len();
+    if at < len && (bytes[at] == b'x' || bytes[at] == b'*') {
+        return Some(at + 1);
+    }
+    let mut end = at;
+    while end < len && bytes[end].is_ascii_digit() {
+        end += 1;
+    }
+    (end > at).then_some(end)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/resolving-npm-resolver/src/which_version_is_pinned/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/which_version_is_pinned/tests.rs
@@ -1,0 +1,58 @@
+use super::which_version_is_pinned;
+use pacquet_registry::PinnedVersion;
+
+/// Ports pnpm's `whichVersionIsPinned` test table
+/// (<https://github.com/pnpm/pnpm/blob/29ab905c21/resolving/npm-resolver/test/whichVersionIsPinned.test.ts>),
+/// extended with the parseRange edge cases pnpm derives the same results
+/// for (verified against the upstream implementation).
+#[test]
+fn matches_pnpm_which_version_is_pinned() {
+    use PinnedVersion::{Major, Minor, None as NoneVariant, Patch};
+    let cases: &[(&str, Option<PinnedVersion>)] = &[
+        ("^1.0.0", Some(Major)),
+        ("~1.0.0", Some(Minor)),
+        ("1.0.0", Some(Patch)),
+        ("*", Some(NoneVariant)),
+        ("workspace:^1.0.0", Some(Major)),
+        ("npm:foo@1.0.0", Some(Patch)),
+        ("npm:@foo/foo@1.0.0", Some(Patch)),
+        ("npm:foo@^1.0.0", Some(Major)),
+        ("npm:@foo/foo@^1.0.0", Some(Major)),
+        ("npm:@pnpm.e2e/qar@100.0.0", Some(Patch)),
+        ("jsr:@foo/foo@1.0.0", Some(Patch)),
+        ("jsr:foo@^1.0.0", Some(Major)),
+        // A `catalog:` reference carries no pin of its own, even when the
+        // catalog name parses as a version.
+        ("catalog:", None),
+        ("catalog:default", None),
+        ("catalog:foo", None),
+        ("catalog:express4-21", None),
+        // Partial versions report the most specific component present.
+        ("~1.2.3", Some(Minor)),
+        ("1.2", Some(Minor)),
+        ("1", Some(Major)),
+        ("1.x", Some(Minor)),
+        ("1.2.x", Some(Patch)),
+        ("1.2.0", Some(Patch)),
+        ("0.0.0", Some(Patch)),
+        ("^0", Some(Major)),
+        ("^0.0.1", Some(Major)),
+        ("~1", Some(Minor)),
+        ("v1.2.3", Some(Patch)),
+        ("1.2.3-alpha.1", Some(Patch)),
+        // Anything that is not a single caret/tilde/exact pin yields None.
+        (">=1.0.0", None),
+        (">=1.0.0 <2.0.0", None),
+        ("1.0.0 || 2.0.0", None),
+        ("1.0.0 - 2.0.0", None),
+        ("=1.2.3", None),
+        ("~>1.2.3", None),
+        ("workspace:~", None),
+        ("x", None),
+        ("latest", None),
+        ("", None),
+    ];
+    for (spec, expected) in cases {
+        assert_eq!(which_version_is_pinned(spec), *expected, "spec: {spec:?}");
+    }
+}


### PR DESCRIPTION
## What

Closes the prefix gap in `pacquet update --latest`: it always wrote the resolved version with the configured default range operator (caret, or exact under `--save-exact`), silently widening a tilde or exact dependency to a caret. For example, `express: ~4.21.2` became `express: ^<latest>` instead of `~<latest>`.

This is the pacquet side of the same class of bug fixed for the TypeScript CLI in pnpm/pnpm#12416 (catalog version-range policy). The pnpm CLI does not have this gap on plain `--latest` because its resolver runs `calcRange`; pacquet had no equivalent.

## Fix

Port pnpm's `calcRange` precedence: the range operator the dependency already pinned wins over the configured default.

- Add `which_version_is_pinned` to the `pacquet-resolving-npm-resolver` crate — a faithful port of pnpm's [`whichVersionIsPinned`](https://github.com/pnpm/pnpm/blob/29ab905c21/resolving/npm-resolver/src/whichVersionIsPinned.ts), including the `catalog:` guard (a catalog name that parses as a version, e.g. `catalog:express4-21`, returns `None`). It reproduces semver-utils' `parseRange` single-comparator semantics without pulling in the `regex` crate.
- `update.rs` consults it when serializing each `--latest` rewrite: `which_version_is_pinned(prev) ?? configured default`.

## Precedence note (verified against pnpm 11.6.0)

An existing pin now takes precedence over `--save-exact` too — this matches pnpm exactly. Empirically:

```
# package.json: { "is-positive": "^1.0.0", "is-odd": "~1.0.0" }
pnpm update --latest --save-exact
# => { "is-positive": "^3.1.0", "is-odd": "~3.0.1" }   # operators preserved, --save-exact ignored
```

`--save-exact` / the default only apply to a dependency whose current specifier has no recoverable pin. The existing `update_latest_save_exact` test asserted the opposite (exact wins) — it was incorrect per pnpm semantics and is corrected here.

## Tests

- `which_version_is_pinned` unit table ported from pnpm's `whichVersionIsPinned.test.ts`, plus the parseRange edge cases pnpm derives the same results for (operators, partial versions, multi-comparator ranges, `catalog:` refs, junk) — all verified against the upstream implementation.
- Integration tests: `update --latest` preserves `~` and exact pins; `update --latest --save-exact` preserves an existing caret.

## Scope / follow-ups (not in this PR)

- **`add` re-add** (`pacquet add <existing-dep>` with no version) has a broader divergence: it bumps to `latest` and uses the default operator, whereas pnpm keeps the existing range untouched. That is a separate semantic gap, not just a prefix issue.
- **Catalog `--latest` under the default `manual` catalog mode**: the catalog-reconciliation block is skipped, so a `catalog:` dependency's `--latest` rewrite is written directly to the manifest. Preserving the catalog entry's own operator (and the `catalog:` reference) on `--latest` is follow-up work, tracked separately from this fix.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * `pacquet update --latest` now correctly preserves existing version range operators (`^` caret, `~` tilde, and exact pins) in your dependencies when updating to the latest version, maintaining your preferred version constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->