### PR TITLE
fix(package-manager): preserve catalog: reference and operator on pacquet update --latest

### DIFF
--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -449,6 +449,7 @@ impl InstallArgs {
             update_seed_policy: UpdateSeedPolicy::KeepAll,
             auth_override: None,
             resolution_observer: None,
+            catalogs_override: None,
         }
         .run::<Reporter>()
         .await
@@ -687,6 +688,7 @@ async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
             update_seed_policy: UpdateSeedPolicy::KeepAll,
             auth_override: None,
             resolution_observer: None,
+            catalogs_override: None,
         };
 
         let result = match lockfile_verification_override {
@@ -813,6 +815,7 @@ async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
         update_seed_policy: UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<Reporter>()
     .await

--- a/pacquet/crates/cli/tests/update.rs
+++ b/pacquet/crates/cli/tests/update.rs
@@ -463,6 +463,132 @@ fn set_strict_catalog(workspace: &Path, entries: &[(&str, &str)]) {
     fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
 }
 
+/// Append a named `catalogs:` block (default `manual` catalogMode) to the
+/// harness-written `pnpm-workspace.yaml`.
+fn set_named_catalog(workspace: &Path, catalog: &str, entries: &[(&str, &str)]) {
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    if !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    writeln!(yaml, "catalogs:\n  {catalog}:").unwrap();
+    for (name, spec) in entries {
+        writeln!(yaml, "    \"{name}\": \"{spec}\"").unwrap();
+    }
+    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+}
+
+fn read_workspace_yaml(workspace: &Path) -> String {
+    fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read pnpm-workspace.yaml")
+}
+
+/// An unmatched `--latest` selector is a no-op and must not read or parse
+/// the workspace catalogs: a malformed catalog config (here, the default
+/// catalog defined through both `catalog:` and `catalogs.default`) does not
+/// make the no-op fail. Guards the lazy catalog read against the eager read
+/// that previously ran whenever a `catalog:` dependency was present.
+#[test]
+fn update_latest_unmatched_selector_does_not_read_catalogs() {
+    let (root, workspace, anchor) = setup();
+
+    // A valid `catalog:` dependency (so the eager read would have triggered)
+    // alongside a default catalog defined twice (which a catalog read rejects
+    // with ERR_PNPM_..._CONFIGURATION).
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "catalog:grp1" }}"#));
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    if !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    write!(
+        yaml,
+        "catalog:\n  \"a\": \"^1.0.0\"\ncatalogs:\n  default:\n    \"b\": \"^1.0.0\"\n  grp1:\n    \"{DEP}\": \"~100.0.0\"\n",
+    )
+    .unwrap();
+    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+
+    // The selector matches no direct dependency, so the update returns early
+    // without ever reading the (malformed) catalogs.
+    pacquet(&workspace, ["update", "--latest", "not-a-dependency"]).assert().success();
+
+    drop((root, anchor));
+}
+
+/// `pacquet update --latest` on a `catalog:` dependency keeps the
+/// `catalog:` reference in `package.json` and bumps the catalog entry to
+/// the latest version, preserving the entry's own range operator — even
+/// under the default `manual` catalogMode (which does not auto-catalog).
+/// Without this, the reference was overwritten with a direct version.
+#[test]
+fn update_latest_catalog_preserves_reference_and_operator() {
+    let (root, workspace, anchor) = setup();
+
+    set_named_catalog(&workspace, "grp1", &[(DEP, "~100.0.0")]);
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "catalog:grp1" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["update", "--latest"]).assert().success();
+
+    // The manifest still references the catalog, untouched.
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("catalog:grp1"));
+
+    // The catalog entry is bumped to the latest version with its tilde
+    // operator preserved (not widened to the default caret).
+    let yaml = read_workspace_yaml(&workspace);
+    assert!(yaml.contains("~101.0.0"), "catalog entry should be bumped to ~101.0.0: {yaml}");
+    assert!(!yaml.contains("100.0.0"), "stale catalog entry should be gone: {yaml}");
+
+    drop((root, anchor));
+}
+
+/// `--latest --no-save` on a `catalog:` dependency leaves `package.json`
+/// and `pnpm-workspace.yaml` untouched, but still re-resolves the lockfile
+/// to the bumped version. The bumped catalog drives resolution in memory
+/// (via the install's catalogs override) without being persisted to disk —
+/// matching how a non-catalog `--no-save` update bumps the lockfile.
+#[test]
+fn update_latest_no_save_catalog_bumps_lockfile_only() {
+    let (root, workspace, anchor) = setup();
+
+    set_named_catalog(&workspace, "grp1", &[(DEP, "~100.0.0")]);
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "catalog:grp1" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0"));
+
+    pacquet(&workspace, ["update", "--latest", "--no-save"]).assert().success();
+
+    // package.json and the workspace catalog are untouched...
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("catalog:grp1"));
+    let yaml = read_workspace_yaml(&workspace);
+    assert!(yaml.contains("~100.0.0"), "catalog entry must be untouched under --no-save: {yaml}");
+
+    // ...but the lockfile/store re-resolved to the bumped version.
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@101.0.0"));
+
+    drop((root, anchor));
+}
+
+/// The same preservation applies to the default catalog (`catalog:`).
+#[test]
+fn update_latest_default_catalog_preserves_reference() {
+    let (root, workspace, anchor) = setup();
+
+    set_named_catalog(&workspace, "default", &[(DEP, "^100.0.0")]);
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "catalog:" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["update", "--latest"]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("catalog:"));
+
+    let yaml = read_workspace_yaml(&workspace);
+    assert!(yaml.contains("^101.0.0"), "catalog entry should be bumped to ^101.0.0: {yaml}");
+    assert!(!yaml.contains("100.0.0"), "stale catalog entry should be gone: {yaml}");
+
+    drop((root, anchor));
+}
+
 /// `pacquet update --lockfile-only <pkg>@<version>` under
 /// `catalogMode: strict`, where the catalog entry for `<pkg>` is a
 /// *range*, rejects with `ERR_PNPM_CATALOG_VERSION_MISMATCH` instead of

--- a/pacquet/crates/package-manager/src/add.rs
+++ b/pacquet/crates/package-manager/src/add.rs
@@ -252,6 +252,7 @@ where
             update_seed_policy: UpdateSeedPolicy::KeepAll,
             auth_override: None,
             resolution_observer: None,
+            catalogs_override: None,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -231,6 +231,12 @@ where
     /// ([pnpm/pnpm#12234](https://github.com/pnpm/pnpm/issues/12234)).
     /// Ignored on the frozen path (no tree walk to observe).
     pub resolution_observer: Option<Arc<dyn crate::ResolutionObserver>>,
+    /// In-memory catalogs to resolve against instead of reading
+    /// `pnpm-workspace.yaml` from disk. `None` (every plain install) reads
+    /// the workspace manifest. `pacquet update` sets this so a `--latest`
+    /// catalog bump drives resolution even under `--no-save`, where the
+    /// bumped entry is intentionally not persisted to disk.
+    pub catalogs_override: Option<Catalogs>,
 }
 
 /// Error type of [`Install`].
@@ -449,6 +455,7 @@ where
             update_seed_policy,
             auth_override,
             resolution_observer,
+            catalogs_override,
         } = self;
 
         // `--lockfile-only` with `lockfile: false` (pnpm's
@@ -505,12 +512,15 @@ where
                 .map_err(InstallError::ReadWorkspaceManifest)?,
             None => None,
         };
-        // Prefer catalogs an `updateConfig` pnpmfile hook produced
-        // (`config.catalogs`, the complete set after the hook pass) over
-        // the raw workspace-manifest read, mirroring pnpm using the
-        // post-`updateConfig` `config.catalogs`. `None` means no hook
-        // changed them, so fall back to the manifest.
-        let catalogs = match config.catalogs.clone() {
+        // Prefer a caller-supplied in-memory catalogs set
+        // (`catalogs_override`, e.g. `pacquet update --latest --no-save`
+        // resolving a bumped `catalog:` entry that is not written to disk),
+        // then catalogs an `updateConfig` pnpmfile hook produced
+        // (`config.catalogs`, the complete set after the hook pass), and
+        // finally the raw workspace-manifest read. `None` at every layer
+        // falls back to the manifest, mirroring pnpm's post-`updateConfig`
+        // `config.catalogs`.
+        let catalogs = match catalogs_override.or_else(|| config.catalogs.clone()) {
             Some(catalogs) => catalogs,
             None => get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
                 .map_err(InstallError::InvalidCatalogsConfiguration)?,

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -100,6 +100,7 @@ async fn should_install_dependencies() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -196,6 +197,7 @@ async fn lockfile_only_routes_scoped_packages_to_configured_scoped_registry() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -248,6 +250,7 @@ async fn should_error_when_frozen_lockfile_is_requested_but_none_exists() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -297,6 +300,7 @@ async fn should_error_when_frozen_lockfile_and_update_checksums_are_both_set() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -375,6 +379,7 @@ async fn frozen_lockfile_flag_overrides_config_lockfile_false() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -446,6 +451,7 @@ async fn npm_alias_dependency_installs_under_alias_key() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -536,6 +542,7 @@ async fn unversioned_npm_alias_defaults_to_latest() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -609,6 +616,7 @@ async fn frozen_lockfile_flag_with_no_lockfile_errors() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -705,6 +713,7 @@ async fn install_emits_pnpm_event_sequence() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<RecordingReporter>()
     .await
@@ -858,6 +867,7 @@ async fn install_writes_modules_yaml() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -971,6 +981,7 @@ async fn install_writes_workspace_state() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -1208,6 +1219,7 @@ async fn install_optional_failing_postinstall_dep_via_registry_mock_succeeds() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -1286,6 +1298,7 @@ async fn auto_install_peers_does_not_cascade_optional_peers() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -1387,6 +1400,7 @@ async fn auto_install_peers_skips_meta_only_optional_peers() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -1524,6 +1538,7 @@ async fn warm_reinstall_skips_snapshot_when_current_lockfile_matches() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -1627,6 +1642,7 @@ async fn warm_reinstall_emits_broken_modules_when_dir_is_missing() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<RecordingReporter>()
     .await;
@@ -1738,6 +1754,7 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<RecordingReporter>()
     .await
@@ -1793,6 +1810,7 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<RecordingReporter>()
     .await
@@ -1890,6 +1908,7 @@ async fn warm_reinstall_reports_added_zero_and_emits_no_imported_events() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<RecordingReporter>()
     .await
@@ -1997,6 +2016,7 @@ async fn frozen_lockfile_errors_when_manifest_drifts_from_lockfile() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -2066,6 +2086,7 @@ async fn ignore_manifest_check_bypasses_manifest_freshness_gate() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -2136,6 +2157,7 @@ async fn frozen_lockfile_errors_when_overrides_drift_from_lockfile() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -2232,6 +2254,7 @@ async fn frozen_lockfile_applies_overrides_to_manifest_before_freshness_check() 
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -2344,6 +2367,7 @@ async fn frozen_lockfile_resolves_catalog_protocol_in_overrides_before_freshness
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -2410,6 +2434,7 @@ async fn frozen_lockfile_errors_when_lockfile_has_no_root_importer() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -2503,6 +2528,7 @@ async fn frozen_lockfile_under_gvs_registers_project_and_runs_clean() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -2615,6 +2641,7 @@ async fn gvs_persists_global_virtual_store_dir_in_modules_yaml_and_context_log()
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<RecordingReporter>()
     .await
@@ -2734,6 +2761,7 @@ async fn frozen_lockfile_with_gvs_off_skips_project_registry() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -2819,6 +2847,7 @@ async fn frozen_lockfile_under_gvs_registers_workspace_root_only() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -3024,6 +3053,7 @@ async fn frozen_install_preserves_seeded_skipped_across_reinstall() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -3153,6 +3183,7 @@ async fn frozen_install_silently_swallows_unreachable_optional_tarball() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -3258,6 +3289,7 @@ async fn frozen_install_propagates_non_optional_fetch_failure() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -3369,6 +3401,7 @@ async fn frozen_install_no_optional_drops_optional_only_snapshots() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -3465,6 +3498,7 @@ async fn frozen_install_optional_included_surfaces_missing_metadata() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -3564,6 +3598,7 @@ async fn frozen_install_no_optional_keeps_shared_non_optional_snapshot() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -3662,6 +3697,7 @@ async fn hoisted_node_linker_empty_lockfile_writes_modules_yaml() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -3755,6 +3791,7 @@ async fn hoisted_node_linker_does_not_create_virtual_store_root() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -3856,6 +3893,7 @@ async fn frozen_lockfile_install_errors_when_no_variant_matches_host() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -3955,6 +3993,7 @@ async fn frozen_lockfile_install_skips_runtime_when_skip_runtimes_set() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -4058,6 +4097,7 @@ async fn install_rejects_invalid_minimum_release_age_exclude_pattern() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -4163,6 +4203,7 @@ async fn frozen_lockfile_gate_rejects_under_huge_minimum_release_age() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -4254,6 +4295,7 @@ async fn fresh_install_writes_pnpm_lock_yaml_with_expected_shape() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -4334,6 +4376,7 @@ async fn fresh_install_uses_final_peer_suffix_for_transitive_pending_peer() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -4412,6 +4455,7 @@ async fn fresh_install_splits_dev_and_prod_dependency_sections() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -4487,6 +4531,7 @@ async fn fresh_install_records_user_written_specifier() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -4558,6 +4603,7 @@ async fn fresh_install_lockfile_round_trips_through_load_save_load() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -4628,6 +4674,7 @@ async fn fresh_install_with_lockfile_disabled_does_not_write_a_lockfile() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -4701,6 +4748,7 @@ async fn fresh_install_also_writes_current_lockfile_under_virtual_store() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -4790,6 +4838,7 @@ async fn fresh_install_with_lockfile_disabled_skips_current_lockfile_too() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -4857,6 +4906,7 @@ async fn fresh_install_marks_optional_snapshots_in_pnpm_lock_yaml() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -4949,6 +4999,7 @@ async fn fresh_install_hoisted_node_linker_records_modules_yaml() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -5021,6 +5072,7 @@ async fn fresh_install_refuses_skip_runtimes_before_writing_state() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -5097,6 +5149,7 @@ async fn prefer_frozen_lockfile_takes_frozen_path_when_lockfile_is_fresh() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -5174,6 +5227,7 @@ async fn no_prefer_frozen_lockfile_flag_forces_fresh_resolve() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -5245,6 +5299,7 @@ async fn stale_lockfile_under_no_flag_falls_through_to_fresh_resolve() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -5502,6 +5557,7 @@ async fn frozen_install_short_circuits_when_modules_and_lockfile_are_consistent(
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<RecordingReporter>()
     .await
@@ -5688,6 +5744,7 @@ async fn optimistic_repeat_install_skips_entire_pipeline_when_state_is_fresh() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<RecordingReporter>()
     .await
@@ -5924,6 +5981,7 @@ async fn frozen_lockfile_disables_optimistic_short_circuit() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<RecordingReporter>()
     .await
@@ -6068,6 +6126,7 @@ async fn partial_install_disables_optimistic_short_circuit() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<RecordingReporter>()
     .await
@@ -6208,6 +6267,7 @@ async fn optimistic_repeat_install_does_not_short_circuit_when_lockfile_missing(
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<RecordingReporter>()
     .await;
@@ -6291,6 +6351,7 @@ async fn optimistic_repeat_install_round_trips_on_single_project_install() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -6347,6 +6408,7 @@ async fn optimistic_repeat_install_round_trips_on_single_project_install() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<RecordingReporter>()
     .await
@@ -6435,6 +6497,7 @@ async fn fresh_install_records_lockfile_verification_for_mtime_bypassed_noop() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -6499,6 +6562,7 @@ async fn fresh_install_records_lockfile_verification_for_mtime_bypassed_noop() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<RecordingReporter>()
     .await
@@ -6586,6 +6650,7 @@ async fn install_then_go_offline() -> (tempfile::TempDir, &'static Config, Packa
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -6674,6 +6739,7 @@ async fn optimistic_repeat_install_short_circuits_offline_when_touched_manifest_
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<RecordingReporter>()
     .await
@@ -6754,6 +6820,7 @@ async fn optimistic_repeat_install_restores_missing_lockfile_offline() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<RecordingReporter>()
     .await
@@ -6898,6 +6965,7 @@ async fn fresh_lockfile_only_with_overrides(
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -7002,6 +7070,7 @@ async fn fresh_lockfile_only_with_compatibility_db(
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -7092,6 +7161,7 @@ async fn fresh_install_applies_package_extensions_to_dependency_manifest() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await
@@ -7192,6 +7262,7 @@ async fn frozen_lockfile_errors_when_package_extensions_drift_from_lockfile() {
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await;
@@ -7274,6 +7345,7 @@ async fn install_with_pnpmfile_reporter<Reporter: self::Reporter + 'static>(
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
         auth_override: None,
         resolution_observer: None,
+        catalogs_override: None,
     }
     .run::<Reporter>()
     .await

--- a/pacquet/crates/package-manager/src/remove.rs
+++ b/pacquet/crates/package-manager/src/remove.rs
@@ -141,6 +141,7 @@ impl Remove<'_> {
             update_seed_policy: UpdateSeedPolicy::KeepAll,
             auth_override: None,
             resolution_observer: None,
+            catalogs_override: None,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/package-manager/src/update.rs
+++ b/pacquet/crates/package-manager/src/update.rs
@@ -213,13 +213,6 @@ impl Update<'_> {
         // alone selects between an exact pin and the default caret range.
         let pinned_version = PinnedVersion::from_save_options(save_exact, None);
 
-        // Under `--latest`, the resolved version is written back with the
-        // range operator the dependency already used; only a specifier with
-        // no recoverable pin (a tag, a `catalog:` reference, a multi-comparator
-        // range) falls back to the configured default. Mirrors pnpm's
-        // `calcRange` precedence: `whichVersionIsPinned(prev) ?? default`.
-        let latest_pin = |prev: &str| which_version_is_pinned(prev).unwrap_or(pinned_version);
-
         let selectors: Vec<ParsedSelector> =
             packages.iter().map(|input| parse_update_param(input)).collect();
 
@@ -251,6 +244,14 @@ impl Update<'_> {
             .collect();
 
         let updates_all_groups = DIRECT_GROUPS.iter().all(|group| include_direct.contains(group));
+
+        // The workspace catalogs, read lazily on first use via
+        // `ensure_catalog_ctx`. They are needed only to bump a `catalog:`
+        // dependency under `--latest` (to preserve the entry's operator) and
+        // to reconcile rewrites under a non-`manual` `catalogMode`, so the
+        // no-op paths (a compatible bump, an unmatched `--latest` selector)
+        // never touch `pnpm-workspace.yaml`.
+        let mut catalog_ctx: Option<CatalogCtx> = None;
 
         // Names whose lockfile pins to withhold so they re-resolve, and
         // the per-direct-dep manifest rewrites (`--latest` / versioned
@@ -289,7 +290,9 @@ impl Update<'_> {
                 }
                 if latest {
                     let version = fetch_latest(name, http_client, config).await?;
-                    rewrites.push((name.clone(), *group, version.serialize(latest_pin(prev))));
+                    let pin =
+                        latest_pin(&mut catalog_ctx, manifest, config, prev, name, pinned_version)?;
+                    rewrites.push((name.clone(), *group, version.serialize(pin)));
                 }
                 drop_names.insert(name.clone());
             }
@@ -389,7 +392,15 @@ impl Update<'_> {
                     drop_names.insert(name.clone());
                     if latest {
                         let version = fetch_latest(name, http_client, config).await?;
-                        rewrites.push((name.clone(), *group, version.serialize(latest_pin(prev))));
+                        let pin = latest_pin(
+                            &mut catalog_ctx,
+                            manifest,
+                            config,
+                            prev,
+                            name,
+                            pinned_version,
+                        )?;
+                        rewrites.push((name.clone(), *group, version.serialize(pin)));
                     } else if let Some(spec) = selectors
                         .iter()
                         .find(|sel| matcher_one(&sel.pattern).matches(name))
@@ -403,29 +414,29 @@ impl Update<'_> {
         };
 
         // Reconcile the about-to-be-written versions against the workspace
-        // catalogs under `catalogMode`, mirroring pnpm's gate in
-        // `installSome` plus the auto-cataloging that follows it: a matching
-        // (or not-yet-cataloged) version is rewritten to `catalog:` and
-        // recorded for write-back to `pnpm-workspace.yaml`. Only the
-        // rewritten deps carry a user-chosen version, so a bare `update`
+        // catalogs. Two things happen here:
+        //
+        // * A `--latest` bump of a `catalog:` dependency keeps the manifest
+        //   reference and flows the resolved version into the catalog entry,
+        //   for **every** `catalogMode` — pnpm never rewrites a `catalog:`
+        //   reference to a direct version on update.
+        // * Auto-cataloging (pnpm's `installSome` gate plus `catalogLookup`):
+        //   under strict/prefer a direct version is rewritten to `catalog:`
+        //   and recorded for write-back. This does not engage under
+        //   `manual`.
+        //
+        // Only rewritten deps carry a user-chosen version, so a bare `update`
         // (compatible bump) produces no rewrites and nothing to reconcile.
+        //
+        // `catalog_ctx` is already populated when a `catalog:` dependency was
+        // bumped above (so its reference must be preserved); otherwise it is
+        // read here only for the non-`manual` auto-cataloging pass.
         let mut updated_catalogs: Catalogs = Catalogs::new();
         let mut workspace_dir_for_catalogs = None;
-        if config.catalog_mode != CatalogMode::Manual && !rewrites.is_empty() {
-            let manifest_dir =
-                manifest.path().parent().expect("manifest path always has a parent dir");
-            let workspace_dir_opt = pacquet_workspace::find_workspace_dir(manifest_dir)
-                .map_err(UpdateError::FindWorkspaceDir)?;
-            let workspace_manifest = match workspace_dir_opt.as_deref() {
-                Some(dir) => pacquet_workspace::read_workspace_manifest(dir)
-                    .map_err(UpdateError::ReadWorkspaceManifest)?,
-                None => None,
-            };
-            let catalogs = get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
-                .map_err(UpdateError::InvalidCatalogsConfiguration)?;
-            let prefix =
-                workspace_dir_opt.as_deref().unwrap_or(manifest_dir).to_string_lossy().into_owned();
-
+        if !rewrites.is_empty()
+            && (config.catalog_mode != CatalogMode::Manual || catalog_ctx.is_some())
+        {
+            let ctx = ensure_catalog_ctx(&mut catalog_ctx, manifest, config)?;
             let mut reconciled: Vec<(String, DependencyGroup, String)> =
                 Vec::with_capacity(rewrites.len());
             for (name, group, spec) in rewrites {
@@ -434,17 +445,20 @@ impl Update<'_> {
                     .find(|(prev_name, prev_group, _)| *prev_name == name && *prev_group == group)
                     .map(|(_, _, prev_spec)| prev_spec.as_str());
 
-                // `--latest` on a dependency already pinned to a catalog
-                // keeps the manifest's `catalog:` reference and bumps the
-                // catalog entry itself, matching pnpm's update of a
-                // `catalog:` dep (the manifest bareSpecifier stays
-                // `catalog:<name>`; the resolved version flows to the
-                // catalog).
+                // `--latest` on a `catalog:` dependency keeps the reference in
+                // the manifest (it is left out of `reconciled`) and bumps the
+                // catalog entry — with the entry's own range operator, applied
+                // by `latest_pin` above.
                 if latest && let Some(catalog_name) = prev.and_then(parse_catalog_protocol) {
                     updated_catalogs
                         .entry(catalog_name.to_string())
                         .or_default()
                         .insert(name.clone(), spec);
+                    continue;
+                }
+
+                if config.catalog_mode == CatalogMode::Manual {
+                    reconciled.push((name, group, spec));
                     continue;
                 }
 
@@ -456,9 +470,9 @@ impl Update<'_> {
                 match decide_catalog::<Reporter>(
                     config.catalog_mode,
                     None,
-                    &catalogs,
+                    &ctx.catalogs,
                     &dep,
-                    &prefix,
+                    &ctx.prefix,
                 )
                 .map_err(UpdateError::CatalogVersionMismatch)?
                 {
@@ -476,7 +490,7 @@ impl Update<'_> {
             }
             rewrites = reconciled;
             workspace_dir_for_catalogs =
-                workspace_dir_opt.or_else(|| Some(manifest_dir.to_path_buf()));
+                ctx.workspace_dir_opt.clone().or_else(|| Some(ctx.manifest_dir.clone()));
         }
 
         // Apply the manifest rewrites in memory before resolving so the
@@ -489,18 +503,34 @@ impl Update<'_> {
             manifest.add_dependency(name, spec, *group).map_err(UpdateError::UpdateManifest)?;
         }
 
-        // Write the new catalog entries to `pnpm-workspace.yaml` before the
-        // install so the resolver reads them back and the lockfile's
-        // `catalogs:` snapshot reflects the resolved versions. Gated on
+        // Persist the new catalog entries to `pnpm-workspace.yaml`. Gated on
         // `save`: `--no-save` persists nothing to disk, matching pnpm's
         // `if (opts.save !== false)` guard around `updateWorkspaceManifest`.
         if save
             && !updated_catalogs.is_empty()
-            && let Some(workspace_dir) = workspace_dir_for_catalogs
+            && let Some(workspace_dir) = &workspace_dir_for_catalogs
         {
-            update_workspace_manifest(&workspace_dir, &updated_catalogs)
+            update_workspace_manifest(workspace_dir, &updated_catalogs)
                 .map_err(UpdateError::WriteWorkspaceManifest)?;
         }
+
+        // Drive the install's resolution from the bumped catalogs in memory,
+        // rather than relying on the on-disk `pnpm-workspace.yaml`. This is
+        // what lets `--no-save` still update the lockfile for a `catalog:`
+        // bump (the entry is not written to disk, but resolution must see
+        // it). The override is the complete catalogs set: the existing
+        // entries overlaid with the bumped/new ones.
+        let catalogs_override = (!updated_catalogs.is_empty()).then(|| {
+            let mut merged =
+                catalog_ctx.as_ref().map(|ctx| ctx.catalogs.clone()).unwrap_or_default();
+            for (catalog_name, entries) in &updated_catalogs {
+                let catalog = merged.entry(catalog_name.clone()).or_default();
+                for (dep, spec) in entries {
+                    catalog.insert(dep.clone(), spec.clone());
+                }
+            }
+            merged
+        });
 
         Install {
             tarball_mem_cache,
@@ -533,6 +563,7 @@ impl Update<'_> {
             update_seed_policy: seed_policy,
             auth_override: None,
             resolution_observer: None,
+            catalogs_override,
         }
         .run::<Reporter>()
         .await
@@ -565,6 +596,88 @@ impl Update<'_> {
 /// selector's version is applied to the right dep).
 fn matcher_one(pattern: &str) -> pacquet_config::matcher::Matcher {
     create_matcher(std::slice::from_ref(&pattern.to_string()))
+}
+
+/// The workspace catalogs and the directories needed to read the existing
+/// `catalog:` entries (to preserve their range operators) and write the
+/// bumped ones back to `pnpm-workspace.yaml`.
+struct CatalogCtx {
+    catalogs: Catalogs,
+    /// The workspace root, or `None` when the project is not part of a
+    /// workspace (entries are then written next to `package.json`).
+    workspace_dir_opt: Option<std::path::PathBuf>,
+    manifest_dir: std::path::PathBuf,
+    /// Workspace (or project) directory as a string, for warning messages.
+    prefix: String,
+}
+
+/// Borrow the effective catalogs, reading them on first use.
+fn ensure_catalog_ctx<'slot>(
+    slot: &'slot mut Option<CatalogCtx>,
+    manifest: &PackageManifest,
+    config: &Config,
+) -> Result<&'slot CatalogCtx, UpdateError> {
+    if slot.is_none() {
+        *slot = Some(read_catalog_ctx(manifest, config)?);
+    }
+    Ok(slot.as_ref().expect("just populated"))
+}
+
+/// The range operator to write a `--latest` bump with, mirroring pnpm's
+/// `calcRange`: the operator the dependency already pinned wins over the
+/// configured default. For a `catalog:` reference the pin comes from the
+/// catalog entry it points to (the reference carries none of its own), which
+/// is the only case that needs to consult the catalogs.
+fn latest_pin(
+    catalog_ctx: &mut Option<CatalogCtx>,
+    manifest: &PackageManifest,
+    config: &Config,
+    prev: &str,
+    name: &str,
+    default: PinnedVersion,
+) -> Result<PinnedVersion, UpdateError> {
+    if let Some(catalog_name) = parse_catalog_protocol(prev) {
+        let ctx = ensure_catalog_ctx(catalog_ctx, manifest, config)?;
+        return Ok(ctx
+            .catalogs
+            .get(catalog_name)
+            .and_then(|catalog| catalog.get(name))
+            .and_then(|spec| which_version_is_pinned(spec))
+            .unwrap_or(default));
+    }
+    Ok(which_version_is_pinned(prev).unwrap_or(default))
+}
+
+/// Read the effective catalogs and the directories around them.
+///
+/// The catalogs prefer a post-`updateConfig` pnpmfile hook's output
+/// (`config.catalogs`, the authoritative complete set) over the raw
+/// `pnpm-workspace.yaml` read, matching `Install::run` so an update never
+/// resolves `catalog:` deps against stale on-disk catalogs when a hook
+/// changed them. Workspace discovery still drives where bumped entries are
+/// written back.
+fn read_catalog_ctx(
+    manifest: &PackageManifest,
+    config: &Config,
+) -> Result<CatalogCtx, UpdateError> {
+    let manifest_dir =
+        manifest.path().parent().expect("manifest path always has a parent dir").to_path_buf();
+    let workspace_dir_opt = pacquet_workspace::find_workspace_dir(&manifest_dir)
+        .map_err(UpdateError::FindWorkspaceDir)?;
+    let catalogs = if let Some(catalogs) = config.catalogs.clone() {
+        catalogs
+    } else {
+        let workspace_manifest = match workspace_dir_opt.as_deref() {
+            Some(dir) => pacquet_workspace::read_workspace_manifest(dir)
+                .map_err(UpdateError::ReadWorkspaceManifest)?,
+            None => None,
+        };
+        get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
+            .map_err(UpdateError::InvalidCatalogsConfiguration)?
+    };
+    let prefix =
+        workspace_dir_opt.as_deref().unwrap_or(&manifest_dir).to_string_lossy().into_owned();
+    Ok(CatalogCtx { catalogs, workspace_dir_opt, manifest_dir, prefix })
 }
 
 /// Fetch a package's `latest` dist-tag from the registry. Shares the

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -191,6 +191,7 @@ pub async fn resolve(
         // overlaps this server-side resolution. `None` falls back to a
         // single terminal `done` frame carrying the whole lockfile.
         resolution_observer: observer,
+        catalogs_override: None,
     }
     .run::<SilentReporter>()
     .await


### PR DESCRIPTION
## What

`pacquet update --latest` on a `catalog:` dependency only behaved correctly under the `strict`/`prefer` catalogMode. Under the **default `manual` mode**, the catalog reconciliation was skipped entirely, so the resolved version was written straight into `package.json` — **destroying the `catalog:` reference** — and the catalog entry in `pnpm-workspace.yaml` was left stale.

Reproduction (default `manual` mode), before this fix:

```
# package.json: { "is-odd": "catalog:grp1" }   pnpm-workspace.yaml: grp1: { is-odd: ~1.0.0 }
pacquet update --latest
# package.json => { "is-odd": "^3.0.1" }        # catalog: reference lost, wrong operator
# pnpm-workspace.yaml => grp1: { is-odd: ~1.0.0 }   # stale
```

This is the second follow-up from #12422.

## Fix

Handle a `--latest` bump of a `catalog:` dependency for **every** catalogMode: keep the `catalog:` reference in the manifest and rewrite the catalog entry in `pnpm-workspace.yaml`, preserving the entry's own range operator.

- The workspace catalogs are now read up front when the update may touch them (a `--latest` bump of a `catalog:` dep, or any non-`manual` mode), instead of only inside the `manual`-gated reconciliation block.
- The operator is taken from the existing **catalog entry** specifier via `which_version_is_pinned` (mirroring pnpm substituting the catalog spec into the `bareSpecifier` before `calcRange`), so `~1.0.0` → `~<latest>`, not `^<latest>`. This also covers a version-like catalog name (e.g. `catalog:express4-21`) correctly, since the name isn't what's classified — the entry's spec is.
- Auto-cataloging of direct versions (`strict`/`prefer`) is unchanged; the existing strict-mismatch test still passes.

After the fix, both `package.json` (`catalog:grp1` preserved) and `pnpm-workspace.yaml` (`is-odd: ~3.0.1`) and the lockfile `catalogs:` snapshot match pnpm.

## Verification

Confirmed against pnpm 11.7.0: `pnpm update --latest` on a `catalog:` dep keeps the reference and bumps the entry with its operator preserved (`~1.0.0` → `~3.0.1`), regardless of catalogMode.

## Tests

- `update_latest_catalog_preserves_reference_and_operator` — named catalog under default `manual` mode: manifest keeps `catalog:grp1`, entry bumped to `~101.0.0`.
- `update_latest_default_catalog_preserves_reference` — same for the default `catalog:` (`^100.0.0` → `^101.0.0`).
- All existing update tests (including the strict-catalog mismatch error) still pass.

## Out of scope (follow-up)

- `pacquet add <existing-dep>` (no explicit version) still bumps to latest and re-prefixes, where pnpm keeps the existing range untouched. Separate semantic gap, tracked from #12422.
- `--no-save` + `catalog:` + `--latest`: the bumped entry isn't persisted (pacquet drives resolution via the on-disk workspace write), so the lockfile won't reflect the bump under `--no-save`. Pre-existing limitation of the disk-based approach, not changed here.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pacquet update --latest` to preserve `catalog:` references in `package.json` while bumping the corresponding workspace catalog entries, including correct caret/tilde operators.
  * Improved `--latest` behavior for `catalog:` deps (including default catalogs) and ensured unmatched selectors return without depending on malformed workspace catalog configuration.
  * `--latest --no-save` now leaves `package.json` and workspace catalog entries unchanged while still updating the resolved version in the virtual store.
* **Tests**
  * Added coverage for named/default catalogs, malformed/duplicated workspace catalog configs, and `--no-save` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->