### PR TITLE
fix(package-manager): keep the existing range when re-adding a dependency (pacquet)

### DIFF
--- a/pacquet/crates/cli/tests/add.rs
+++ b/pacquet/crates/cli/tests/add.rs
@@ -185,6 +185,81 @@ fn add_prerelease_resolved_version_keeps_no_prefix() {
     drop((root, anchor)); // cleanup
 }
 
+/// `pacquet add <existing-dep>` without a version keeps the dependency's
+/// declared range verbatim instead of bumping it to `^<latest>`, matching
+/// `pnpm add <existing>`. The latest published version is `101.0.0`, which a
+/// bump would have written.
+#[test]
+fn add_existing_dependency_without_version_keeps_tilde_range() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    std::fs::write(
+        workspace.join("package.json"),
+        r#"{ "name": "p", "version": "1.0.0", "dependencies": { "@pnpm.e2e/dep-of-pkg-with-1-dep": "~100.0.0" } }"#,
+    )
+    .unwrap();
+
+    pacquet
+        .with_args(["add", "@pnpm.e2e/dep-of-pkg-with-1-dep", "--lockfile-only"])
+        .assert()
+        .success();
+
+    assert_eq!(prod_spec(&workspace, "@pnpm.e2e/dep-of-pkg-with-1-dep"), "~100.0.0");
+    drop((root, npmrc_info)); // cleanup
+}
+
+/// The same applies to an exact pin: a re-add keeps it exact rather than
+/// widening it to the default caret.
+#[test]
+fn add_existing_dependency_without_version_keeps_exact_pin() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    std::fs::write(
+        workspace.join("package.json"),
+        r#"{ "name": "p", "version": "1.0.0", "dependencies": { "@pnpm.e2e/dep-of-pkg-with-1-dep": "100.0.0" } }"#,
+    )
+    .unwrap();
+
+    pacquet
+        .with_args(["add", "@pnpm.e2e/dep-of-pkg-with-1-dep", "--lockfile-only"])
+        .assert()
+        .success();
+
+    assert_eq!(prod_spec(&workspace, "@pnpm.e2e/dep-of-pkg-with-1-dep"), "100.0.0");
+    drop((root, npmrc_info)); // cleanup
+}
+
+/// When the same package exists in more than one dependency bucket with
+/// different specs, a versionless re-add preserves the specifier of the
+/// *targeted* group (here `--save-dev`), not whichever group happens to be
+/// scanned first, and leaves the other bucket untouched.
+#[test]
+fn add_existing_dependency_preserves_target_group_specifier() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    std::fs::write(
+        workspace.join("package.json"),
+        r#"{ "name": "p", "version": "1.0.0", "dependencies": { "@pnpm.e2e/dep-of-pkg-with-1-dep": "~100.0.0" }, "devDependencies": { "@pnpm.e2e/dep-of-pkg-with-1-dep": "^100.0.0" } }"#,
+    )
+    .unwrap();
+
+    pacquet
+        .with_args(["add", "@pnpm.e2e/dep-of-pkg-with-1-dep", "--save-dev", "--lockfile-only"])
+        .assert()
+        .success();
+
+    let manifest = PackageManifest::from_path(workspace.join("package.json")).unwrap();
+    let group_spec = |group| {
+        manifest
+            .dependencies([group])
+            .find(|(key, _)| *key == "@pnpm.e2e/dep-of-pkg-with-1-dep")
+            .map(|(_, spec)| spec.to_string())
+    };
+    assert_eq!(group_spec(DependencyGroup::Dev).as_deref(), Some("^100.0.0"));
+    assert_eq!(group_spec(DependencyGroup::Prod).as_deref(), Some("~100.0.0"));
+    drop((root, npmrc_info)); // cleanup
+}
+
 #[test]
 fn save_prefix_arbitrary_value_falls_back_to_caret() {
     let (root, dir, anchor) =

--- a/pacquet/crates/package-manager/src/add.rs
+++ b/pacquet/crates/package-manager/src/add.rs
@@ -7,7 +7,6 @@ use miette::Diagnostic;
 use pacquet_catalogs_config::{
     InvalidCatalogsConfigurationError, get_catalogs_from_workspace_manifest,
 };
-use pacquet_catalogs_protocol_parser::parse_catalog_protocol;
 use pacquet_catalogs_types::Catalogs;
 use pacquet_config::Config;
 use pacquet_lockfile::{Lockfile, MaybeLazyLockfile};
@@ -90,6 +89,16 @@ pub enum AddError {
 
     #[diagnostic(transparent)]
     Install(#[error(source)] InstallError),
+
+    /// Fetching a brand-new dependency's `latest` tag from the registry
+    /// failed while resolving the version to add.
+    #[display("Failed to resolve the latest version of {name}: {error}")]
+    #[diagnostic(code(pacquet_package_manager::add_resolve_latest))]
+    ResolveLatest {
+        name: String,
+        #[error(source)]
+        error: pacquet_registry::RegistryError,
+    },
 }
 
 impl<ListDependencyGroups, DependencyGroupList> Add<'_, ListDependencyGroups, DependencyGroupList>
@@ -135,41 +144,45 @@ where
         let prefix =
             workspace_dir_opt.as_deref().unwrap_or(&manifest_dir).to_string_lossy().into_owned();
 
-        // The dependency's current manifest specifier, so a re-add of a
-        // `catalog:` dependency keeps its catalog reference.
+        // The dependency's current specifier *in the group(s) this add
+        // targets*, so a re-add keeps the existing range / `catalog:`
+        // reference of the bucket being written. Scanning only the target
+        // groups (rather than every group) avoids preserving a different
+        // group's specifier when the same package exists in more than one
+        // bucket with different specs.
         let prev_specifier = manifest
-            .dependencies([
-                DependencyGroup::Prod,
-                DependencyGroup::Dev,
-                DependencyGroup::Optional,
-                DependencyGroup::Peer,
-            ])
+            .dependencies(list_dependency_groups())
             .find(|(name, _)| *name == package_name)
             .map(|(_, spec)| spec.to_string());
 
-        // The bare specifier to reconcile against the catalogs: the
-        // explicit `@<version>`, the preserved `catalog:` reference on a
-        // re-add, or otherwise the freshly-fetched `latest` range.
-        let bare_specifier = match explicit_spec {
-            Some(spec) => spec.to_string(),
-            None => match prev_specifier.as_deref() {
-                Some(prev) if parse_catalog_protocol(prev).is_some() => prev.to_string(),
-                _ => {
-                    let registries: std::collections::HashMap<String, String> =
-                        config.resolved_registries().into_iter().collect();
-                    let registry = pick_registry_for_package(&registries, package_name, None);
-                    let latest = PackageVersion::fetch_from_registry(
-                        package_name,
-                        PackageTag::Latest,
-                        http_client,
-                        &registry,
-                        &config.auth_headers,
-                    )
-                    .await
-                    .expect("resolve latest tag"); // TODO: properly propagate this error
-                    latest.serialize(pinned_version)
-                }
-            },
+        // The bare specifier to reconcile against the catalogs:
+        // - an explicit `@<version>` is used as given;
+        // - a re-add with no version keeps the dependency's current
+        //   specifier verbatim (a `catalog:` reference, a range, or an
+        //   exact pin), matching pnpm — `pnpm add <existing>` without a
+        //   version leaves the declared range untouched;
+        // - a brand-new dependency fetches and pins the `latest` range.
+        let bare_specifier = match (explicit_spec, prev_specifier.as_deref()) {
+            (Some(spec), _) => spec.to_string(),
+            (None, Some(prev)) => prev.to_string(),
+            (None, None) => {
+                let registries: std::collections::HashMap<String, String> =
+                    config.resolved_registries().into_iter().collect();
+                let registry = pick_registry_for_package(&registries, package_name, None);
+                let latest = PackageVersion::fetch_from_registry(
+                    package_name,
+                    PackageTag::Latest,
+                    http_client,
+                    &registry,
+                    &config.auth_headers,
+                )
+                .await
+                .map_err(|error| AddError::ResolveLatest {
+                    name: package_name.to_string(),
+                    error,
+                })?;
+                latest.serialize(pinned_version)
+            }
         };
 
         let mut updated_catalogs = Catalogs::new();


### PR DESCRIPTION
## What

`pacquet add <existing-dep>` with no version always fetched the `latest` version and rewrote the manifest to `^<latest>`, discarding the dependency's declared range. pnpm leaves the range untouched in that case — only a brand-new dependency (or an explicit `@<version>`, or `--latest`) changes it.

Before (default `manual` mode):

```
# package.json: { "is-odd": "~1.0.0" }
pacquet add is-odd
# => { "is-odd": "^3.0.1" }   # range discarded + bumped
```

This is the last follow-up from the prefix-preservation series (#12422, #12423).

## Fix

Keep the dependency's current specifier verbatim on a re-add with no explicit version, for any specifier kind — a range, an exact pin, or a `catalog:` reference (the catalog case was already special-cased; this generalizes it). A new dependency still fetches and pins the `latest` range.

```rust
let bare_specifier = match (explicit_spec, prev_specifier.as_deref()) {
    (Some(spec), _) => spec.to_string(),       // explicit @<version>
    (None, Some(prev)) => prev.to_string(),    // re-add: keep declared spec
    (None, None) => /* fetch + pin latest */,  // brand-new dependency
};
```

## Verification

Confirmed against pnpm 11.7.0:

| existing spec | `pnpm add <dep>` | `pacquet add <dep>` (after fix) |
|---|---|---|
| `~1.0.0` | `~1.0.0` | `~1.0.0` |
| `^1.0.0` | `^1.0.0` | `^1.0.0` |
| `1.0.0` | `1.0.0` | `1.0.0` |
| (new dep) | `^3.0.1` | `^3.0.1` |

## Tests

- `add_existing_dependency_without_version_keeps_tilde_range`
- `add_existing_dependency_without_version_keeps_exact_pin`

(The latest published version `101.0.0` is what a bump would have written, so a tilde/exact assertion is a clean discriminator.) Full add suite (14) and package-manager suite (486) pass; clippy/dylint/doc/fmt clean.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `pacquet add` to preserve an existing dependency’s version specifier verbatim when re-adding without an explicit version (including tilde ranges and exact pins), keeping the targeted dependency bucket consistent.
  * Improved error handling for failures while resolving the registry `latest` tag.

* **Tests**
  * Added CLI integration tests for `pacquet add <existing-dep> --lockfile-only` when the user omits a version, including scenarios with tilde ranges, exact pins, and separate dependency/devDependency specs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->