### PR TITLE
fix(package-manager): resolve explicit add specifier to a concrete version (pacquet)

### DIFF
--- a/pacquet/crates/cli/tests/add.rs
+++ b/pacquet/crates/cli/tests/add.rs
@@ -260,6 +260,69 @@ fn add_existing_dependency_preserves_target_group_specifier() {
     drop((root, npmrc_info)); // cleanup
 }
 
+/// `add <pkg>@<range>` records the range resolved to a concrete version
+/// with the input's operator, matching pnpm. `^100.0.0` resolves to the
+/// highest in-range version (100.1.0; 101.0.0 is a different major), so the
+/// manifest gets `^100.1.0` — not the verbatim `^100.0.0`.
+#[test]
+fn add_explicit_range_resolves_to_concrete_version() {
+    let (root, dir, anchor) = exec_pacquet_in_temp_cwd([
+        "add",
+        "@pnpm.e2e/dep-of-pkg-with-1-dep@^100.0.0",
+        "--lockfile-only",
+    ]);
+    assert_eq!(prod_spec(&dir, "@pnpm.e2e/dep-of-pkg-with-1-dep"), "^100.1.0");
+    drop((root, anchor)); // cleanup
+}
+
+/// A dist-tag spec resolves to that tag's version, pinned with the default
+/// caret (the tag carries no operator). `latest` is 101.0.0.
+#[test]
+fn add_explicit_dist_tag_resolves_with_caret() {
+    let (root, dir, anchor) = exec_pacquet_in_temp_cwd([
+        "add",
+        "@pnpm.e2e/dep-of-pkg-with-1-dep@latest",
+        "--lockfile-only",
+    ]);
+    assert_eq!(prod_spec(&dir, "@pnpm.e2e/dep-of-pkg-with-1-dep"), "^101.0.0");
+    drop((root, anchor)); // cleanup
+}
+
+/// On a re-add with an explicit version, the existing entry's operator wins
+/// over the spec's (pnpm's calcSpecifier precedence): a `~`-pinned entry
+/// re-added with `@^100.0.0` stays tilde, resolved to the concrete version.
+#[test]
+fn add_explicit_range_respects_existing_operator() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    std::fs::write(
+        workspace.join("package.json"),
+        r#"{ "name": "p", "version": "1.0.0", "dependencies": { "@pnpm.e2e/dep-of-pkg-with-1-dep": "~100.0.0" } }"#,
+    )
+    .unwrap();
+
+    pacquet
+        .with_args(["add", "@pnpm.e2e/dep-of-pkg-with-1-dep@^100.0.0", "--lockfile-only"])
+        .assert()
+        .success();
+
+    assert_eq!(prod_spec(&workspace, "@pnpm.e2e/dep-of-pkg-with-1-dep"), "~100.1.0");
+    drop((root, npmrc_info)); // cleanup
+}
+
+/// An `npm:` alias specifier is written verbatim — never resolved (which
+/// would risk dropping the aliased target name).
+#[test]
+fn add_npm_alias_spec_is_kept_verbatim() {
+    let (root, dir, anchor) = exec_pacquet_in_temp_cwd([
+        "add",
+        "my-alias@npm:@pnpm.e2e/dep-of-pkg-with-1-dep@^100.0.0",
+        "--lockfile-only",
+    ]);
+    assert_eq!(prod_spec(&dir, "my-alias"), "npm:@pnpm.e2e/dep-of-pkg-with-1-dep@^100.0.0");
+    drop((root, anchor)); // cleanup
+}
+
 #[test]
 fn save_prefix_arbitrary_value_falls_back_to_caret() {
     let (root, dir, anchor) =

--- a/pacquet/crates/package-manager/src/add.rs
+++ b/pacquet/crates/package-manager/src/add.rs
@@ -12,9 +12,12 @@ use pacquet_config::Config;
 use pacquet_lockfile::{Lockfile, MaybeLazyLockfile};
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest, PackageManifestError};
-use pacquet_registry::{PackageTag, PackageVersion, PinnedVersion};
+use pacquet_registry::{Package, PackageTag, PackageVersion, PinnedVersion};
 use pacquet_reporter::{LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, Reporter};
-use pacquet_resolving_npm_resolver::pick_registry_for_package;
+use pacquet_resolving_npm_resolver::{
+    PickVersionByVersionRangeOptions, RegistryPackageSpecType, parse_bare_specifier,
+    pick_registry_for_package, pick_version_by_version_range, which_version_is_pinned,
+};
 use pacquet_tarball::MemCache;
 use pacquet_workspace_manifest_writer::{UpdateWorkspaceManifestError, update_workspace_manifest};
 
@@ -156,14 +159,27 @@ where
             .map(|(_, spec)| spec.to_string());
 
         // The bare specifier to reconcile against the catalogs:
-        // - an explicit `@<version>` is used as given;
+        // - an explicit `@<version>` is resolved to a concrete version and
+        //   recorded with the range operator it (or the existing entry)
+        //   pins, mirroring pnpm — `pnpm add foo@^7` records `^7.8.4`, not
+        //   `^7`. Specifiers that are not a plain registry range/tag/version
+        //   for this package (protocols, `npm:` aliases) stay verbatim;
         // - a re-add with no version keeps the dependency's current
         //   specifier verbatim (a `catalog:` reference, a range, or an
         //   exact pin), matching pnpm — `pnpm add <existing>` without a
         //   version leaves the declared range untouched;
         // - a brand-new dependency fetches and pins the `latest` range.
         let bare_specifier = match (explicit_spec, prev_specifier.as_deref()) {
-            (Some(spec), _) => spec.to_string(),
+            (Some(spec), prev) => resolve_explicit_registry_spec(
+                package_name,
+                spec,
+                prev,
+                config,
+                http_client,
+                pinned_version,
+            )
+            .await?
+            .unwrap_or_else(|| spec.to_string()),
             (None, Some(prev)) => prev.to_string(),
             (None, None) => {
                 let registries: std::collections::HashMap<String, String> =
@@ -300,6 +316,73 @@ where
 
         Ok(())
     }
+}
+
+/// Resolve an explicit `add <name>@<spec>` registry specifier to the
+/// manifest range pnpm would record: the spec resolved to a concrete
+/// version, carrying the range operator the existing entry pins (or, failing
+/// that, the spec's own operator, or the configured default) — mirroring
+/// pnpm's `calcSpecifier`. So `pnpm add foo@^7` records `^7.8.4`, not `^7`.
+///
+/// Returns `Ok(None)` — meaning "write the specifier verbatim" — for
+/// anything that is not a plain registry range/tag/version for
+/// `package_name` itself: non-registry protocols (`git:`/`file:`/
+/// `workspace:`/URLs, which [`parse_bare_specifier`] rejects), `npm:`
+/// aliases (resolving them risks dropping the aliased target), and
+/// specifiers that don't resolve against the packument.
+async fn resolve_explicit_registry_spec(
+    package_name: &str,
+    spec: &str,
+    prev_specifier: Option<&str>,
+    config: &Config,
+    http_client: &ThrottledClient,
+    pinned_version: PinnedVersion,
+) -> Result<Option<String>, AddError> {
+    if spec.starts_with("npm:") {
+        return Ok(None);
+    }
+    let registries: std::collections::HashMap<String, String> =
+        config.resolved_registries().into_iter().collect();
+    let registry = pick_registry_for_package(&registries, package_name, None);
+    let Some(spec_parsed) = parse_bare_specifier(spec, Some(package_name), "latest", &registry)
+    else {
+        return Ok(None);
+    };
+    // Defensive: anything that aliases to a different name (only `npm:`
+    // can, already returned above) is kept verbatim.
+    if spec_parsed.name != package_name {
+        return Ok(None);
+    }
+
+    let package =
+        Package::fetch_from_registry(package_name, http_client, &registry, &config.auth_headers)
+            .await
+            .map_err(|error| AddError::ResolveLatest { name: package_name.to_string(), error })?;
+
+    let resolved = match spec_parsed.spec_type {
+        RegistryPackageSpecType::Tag => {
+            package.dist_tag(&spec_parsed.fetch_spec).map(str::to_string)
+        }
+        RegistryPackageSpecType::Version | RegistryPackageSpecType::Range => {
+            pick_version_by_version_range(&PickVersionByVersionRangeOptions {
+                meta: &package,
+                version_range: &spec_parsed.fetch_spec,
+                preferred_version_selectors: None,
+                published_by: None,
+            })
+        }
+    };
+    let Some(resolved) = resolved.and_then(|version| package.versions.get(&version)) else {
+        return Ok(None);
+    };
+
+    // pnpm's calcSpecifier precedence: the existing entry's operator wins
+    // over the spec's, which wins over the configured default.
+    let pin = prev_specifier
+        .and_then(which_version_is_pinned)
+        .or_else(|| which_version_is_pinned(spec))
+        .unwrap_or(pinned_version);
+    Ok(Some(resolved.serialize(pin)))
 }
 
 /// Split a `pacquet add` argument into its package name and optional


### PR DESCRIPTION
## What

`pacquet add <name>@<spec>` wrote the specifier **verbatim**, so `add foo@^7` recorded `^7` and `add foo@^7.0.0` kept `^7.0.0`. pnpm resolves the specifier to a concrete version and records it with the range operator the spec (or the existing entry) pins — `pnpm add foo@^7` records `^7.8.4`.

The installed/locked version was already correct; only the recorded manifest range differed. This is the last divergence in the prefix-preservation series (#12422, #12423, #12425).

## Fix

Port pnpm's `calcSpecifier` for the explicit-spec path of `add`:

1. Resolve the spec against the packument — dist-tag lookup for a tag, highest-in-range pick (`pick_version_by_version_range`) for a range/version.
2. Serialize the resolved version with the pin from `whichVersionIsPinned(prevSpecifier) ?? whichVersionIsPinned(spec) ?? configured default`.

Verified against pnpm 11.7.0:

| `add` arg | result |
|---|---|
| `foo@^7.0.0` | `^7.8.4` |
| `foo@7` | `^7.8.4` |
| `foo@~7.0.0` | `~7.0.x` |
| `foo@7.0.0` | `7.0.0` |
| `foo@latest` | `^<latest>` |
| existing `~6.0.0` + `foo@^7.0.0` | `~7.8.4` (existing operator wins) |

### Kept verbatim (not resolved)

Specifiers that aren't a plain registry range/tag/version for the package itself stay untouched:
- non-registry protocols — `git:`/`file:`/`workspace:`/URLs (`parse_bare_specifier` returns `None`);
- `npm:` aliases — resolving them would risk dropping the aliased target name (corrupting the dependency), so they're written as-is.

## Tests

- `add_explicit_range_resolves_to_concrete_version` (`^100.0.0` → `^100.1.0`)
- `add_explicit_dist_tag_resolves_with_caret` (`latest` → `^101.0.0`)
- `add_explicit_range_respects_existing_operator` (existing `~100.0.0` + `@^100.0.0` → `~100.1.0`)
- `add_npm_alias_spec_is_kept_verbatim` (`npm:<dep>@^100.0.0` stays verbatim)

Full add suite (19) and package-manager suite (486) pass; clippy/dylint/doc/fmt clean.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of explicit version range and dist-tag specifiers in `pacquet add` to respect existing operator precedence and resolve to concrete versions.
  * Ensured npm: alias specifiers are preserved verbatim without resolution.

* **Tests**
  * Added integration tests verifying specifier resolution behavior for version ranges, dist-tags, and re-adding dependencies with operator precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->