### PR TITLE
feat(default-reporter): render pnpm-identical visual install output in pacquet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3499,6 +3499,7 @@ dependencies = [
  "pacquet-cmd-shim",
  "pacquet-config",
  "pacquet-crypto-hash",
+ "pacquet-default-reporter",
  "pacquet-diagnostics",
  "pacquet-env-installer",
  "pacquet-executor",
@@ -3619,6 +3620,18 @@ dependencies = [
  "pretty_assertions",
  "reqwest 0.13.4",
  "tokio",
+]
+
+[[package]]
+name = "pacquet-default-reporter"
+version = "0.0.1"
+dependencies = [
+ "insta",
+ "libc",
+ "owo-colors",
+ "pacquet-reporter",
+ "pretty_assertions",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ pacquet-network                           = { path = "pacquet/crates/network" }
 pacquet-config                            = { path = "pacquet/crates/config" }
 pacquet-config-dir                        = { path = "pacquet/crates/config-dir" }
 pacquet-config-parse-overrides            = { path = "pacquet/crates/config-parse-overrides" }
+pacquet-default-reporter                  = { path = "pacquet/crates/default-reporter" }
 pacquet-executor                          = { path = "pacquet/crates/executor" }
 pacquet-exportable-manifest               = { path = "pacquet/crates/exportable-manifest" }
 pacquet-directory-fetcher                 = { path = "pacquet/crates/directory-fetcher" }

--- a/pacquet/crates/cli/Cargo.toml
+++ b/pacquet/crates/cli/Cargo.toml
@@ -27,6 +27,7 @@ pacquet-hooks                             = { workspace = true }
 pacquet-lockfile                          = { workspace = true }
 pacquet-network                           = { workspace = true }
 pacquet-config                            = { workspace = true }
+pacquet-default-reporter                  = { workspace = true }
 pacquet-package-manifest                  = { workspace = true }
 pacquet-package-manager                   = { workspace = true }
 pacquet-package-is-installable            = { workspace = true }

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -97,16 +97,17 @@ pub struct CliArgs {
 
 /// Selectable rendering strategy for log events.
 ///
-/// Mirrors the names pnpm uses for `--reporter` (`default`, `ndjson`,
-/// `silent`, `append-only`). `append-only` is not a separate variant yet:
-/// `default` falls back to its append-only rendering automatically when
-/// stdout is not a TTY, matching pnpm's behaviour.
+/// Mirrors the names pnpm uses for `--reporter` (`default`, `append-only`,
+/// `ndjson`, `silent`).
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum ReporterType {
     /// pnpm-style visual output (progress line, packages diff, lifecycle
     /// output, `Done in ...`). The default; renders in place on a TTY and
-    /// append-only otherwise.
+    /// falls back to append-only when stdout is not a TTY.
     Default,
+    /// Like `default` but forces the append-only rendering even on a TTY —
+    /// one line per update, no cursor movement.
+    AppendOnly,
     /// Newline-delimited JSON in pnpm's wire format on stderr.
     Ndjson,
     /// No progress output.
@@ -159,6 +160,7 @@ impl CliArgs {
     /// file seed + `--config.<key>` overrides). Workspace-filtered and
     /// recursive installs always take the full path.
     pub fn finished_via_install_fast_path(&self, config_overrides: &ConfigOverrides) -> bool {
+        let started_at = now_millis();
         let CliCommand::Install(install_args) = &self.command else {
             return false;
         };
@@ -174,9 +176,20 @@ impl CliArgs {
             return false;
         };
         config_overrides.apply(&mut config);
-        pacquet_default_reporter::set_cwd(dir.to_string_lossy().into_owned());
+        configure_default_reporter(self.reporter, &dir);
         let emit = reporter_emit(self.reporter);
-        install_args.finished_via_up_to_date_fast_path(&dir, &config, emit)
+        let finished = install_args.finished_via_up_to_date_fast_path(&dir, &config, emit);
+        if finished {
+            // The fast path returns from `main` before `run` reaches its
+            // end-of-command emit, so the `Done in ...` footer must be emitted
+            // here too to match the non-fast-path output.
+            emit(&LogEvent::ExecutionTime(ExecutionTimeLog {
+                level: LogLevel::Debug,
+                started_at,
+                ended_at: now_millis(),
+            }));
+        }
+        finished
     }
 
     /// Execute the command. `config_overrides` carries `--config.<key>=<value>`
@@ -203,10 +216,10 @@ impl CliArgs {
         // The default reporter renders paths relative to the install root and
         // its `Done in ...` footer over the whole command; seed both before any
         // event can fire.
-        pacquet_default_reporter::set_cwd(dir.to_string_lossy().into_owned());
+        configure_default_reporter(reporter, &dir);
         let started_at = now_millis();
         let is_install_family = matches!(
-            command,
+            &command,
             CliCommand::Add(_)
                 | CliCommand::Update(_)
                 | CliCommand::Remove(_)
@@ -264,14 +277,14 @@ impl CliArgs {
                 PackageManifest::init(&manifest_path()).wrap_err("initialize package.json")?;
             }
             CliCommand::Add(args) => match reporter {
-                ReporterType::Default => {
+                ReporterType::Default | ReporterType::AppendOnly => {
                     Box::pin(args.run::<DefaultReporter>(state(false)?)).await?;
                 }
                 ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(state(false)?)).await?,
                 ReporterType::Silent => Box::pin(args.run::<SilentReporter>(state(false)?)).await?,
             },
             CliCommand::Update(args) => match reporter {
-                ReporterType::Default => {
+                ReporterType::Default | ReporterType::AppendOnly => {
                     Box::pin(args.run::<DefaultReporter>(state(false)?)).await?;
                 }
                 ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(state(false)?)).await?,
@@ -288,7 +301,7 @@ impl CliArgs {
                 }
             }
             CliCommand::Remove(args) => match reporter {
-                ReporterType::Default => {
+                ReporterType::Default | ReporterType::AppendOnly => {
                     Box::pin(args.run::<DefaultReporter>(state(false)?)).await?;
                 }
                 ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(state(false)?)).await?,
@@ -359,7 +372,9 @@ impl CliArgs {
                 // monomorphized install futures would otherwise each reserve
                 // their full size in this frame.
                 match reporter {
-                    ReporterType::Default => Box::pin(pipeline.run::<DefaultReporter>()).await?,
+                    ReporterType::Default | ReporterType::AppendOnly => {
+                        Box::pin(pipeline.run::<DefaultReporter>()).await?;
+                    }
                     ReporterType::Ndjson => Box::pin(pipeline.run::<NdjsonReporter>()).await?,
                     ReporterType::Silent => Box::pin(pipeline.run::<SilentReporter>()).await?,
                 }
@@ -386,7 +401,7 @@ impl CliArgs {
                 }
             }
             CliCommand::Dlx(args) => match reporter {
-                ReporterType::Default => {
+                ReporterType::Default | ReporterType::AppendOnly => {
                     Box::pin(args.run::<DefaultReporter>(&dir, config()?)).await?;
                 }
                 ReporterType::Ndjson => {
@@ -472,9 +487,20 @@ impl InstallPipeline {
 /// the event-emission sites that aren't already generic over `Reporter`.
 fn reporter_emit(reporter: ReporterType) -> fn(&LogEvent) {
     match reporter {
-        ReporterType::Default => DefaultReporter::emit,
+        ReporterType::Default | ReporterType::AppendOnly => DefaultReporter::emit,
         ReporterType::Ndjson => NdjsonReporter::emit,
         ReporterType::Silent => SilentReporter::emit,
+    }
+}
+
+/// Seed the process-global default-reporter state that can't be recovered
+/// from events: the project root (for relative paths) and, for
+/// `--reporter=append-only`, the forced append-only mode. Idempotent; safe to
+/// call from both the fast path and the main run.
+fn configure_default_reporter(reporter: ReporterType, dir: &Path) {
+    pacquet_default_reporter::set_cwd(dir.to_string_lossy().into_owned());
+    if matches!(reporter, ReporterType::AppendOnly) {
+        pacquet_default_reporter::force_append_only();
     }
 }
 

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -20,9 +20,12 @@ use install::InstallArgs;
 use miette::{Context, IntoDiagnostic};
 use outdated::{OutdatedArgs, OutdatedOutcome};
 use pacquet_config::{Config, Host};
+use pacquet_default_reporter::DefaultReporter;
 use pacquet_executor::execute_shell;
 use pacquet_package_manifest::PackageManifest;
-use pacquet_reporter::{NdjsonReporter, Reporter, SilentReporter};
+use pacquet_reporter::{
+    ExecutionTimeLog, LogEvent, LogLevel, NdjsonReporter, Reporter, SilentReporter,
+};
 use remove::RemoveArgs;
 use run::RunArgs;
 use serde_json::Value;
@@ -66,7 +69,7 @@ pub struct CliArgs {
     pub recursive: bool,
 
     /// Reporter output format.
-    #[clap(long, value_enum, default_value_t = ReporterType::Silent, global = true)]
+    #[clap(long, value_enum, default_value_t = ReporterType::Default, global = true)]
     pub reporter: ReporterType,
 
     /// `--filter` / `-F` workspace selectors. Each occurrence adds one
@@ -95,13 +98,15 @@ pub struct CliArgs {
 /// Selectable rendering strategy for log events.
 ///
 /// Mirrors the names pnpm uses for `--reporter` (`default`, `ndjson`,
-/// `silent`, `append-only`). Only the variants pacquet currently supports
-/// are listed; the others land alongside the default-reporter spawn-and-
-/// pipe (tracked under [#344]).
-///
-/// [#344]: https://github.com/pnpm/pacquet/issues/344
+/// `silent`, `append-only`). `append-only` is not a separate variant yet:
+/// `default` falls back to its append-only rendering automatically when
+/// stdout is not a TTY, matching pnpm's behaviour.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum ReporterType {
+    /// pnpm-style visual output (progress line, packages diff, lifecycle
+    /// output, `Done in ...`). The default; renders in place on a TTY and
+    /// append-only otherwise.
+    Default,
     /// Newline-delimited JSON in pnpm's wire format on stderr.
     Ndjson,
     /// No progress output.
@@ -169,10 +174,8 @@ impl CliArgs {
             return false;
         };
         config_overrides.apply(&mut config);
-        let emit = match self.reporter {
-            ReporterType::Ndjson => NdjsonReporter::emit as fn(&pacquet_reporter::LogEvent),
-            ReporterType::Silent => SilentReporter::emit as fn(&pacquet_reporter::LogEvent),
-        };
+        pacquet_default_reporter::set_cwd(dir.to_string_lossy().into_owned());
+        let emit = reporter_emit(self.reporter);
         install_args.finished_via_up_to_date_fast_path(&dir, &config, emit)
     }
 
@@ -197,6 +200,19 @@ impl CliArgs {
         let dir = dunce::canonicalize(&dir)
             .into_diagnostic()
             .wrap_err_with(|| format!("canonicalizing the `--dir` argument: {}", dir.display()))?;
+        // The default reporter renders paths relative to the install root and
+        // its `Done in ...` footer over the whole command; seed both before any
+        // event can fire.
+        pacquet_default_reporter::set_cwd(dir.to_string_lossy().into_owned());
+        let started_at = now_millis();
+        let is_install_family = matches!(
+            command,
+            CliCommand::Add(_)
+                | CliCommand::Update(_)
+                | CliCommand::Remove(_)
+                | CliCommand::Install(_)
+                | CliCommand::Dlx(_),
+        );
         let manifest_path = || dir.join("package.json");
         // Resolve `.npmrc` / `pnpm-workspace.yaml` from the canonicalized
         // `--dir` rather than the process cwd, matching pnpm 11 (which
@@ -248,12 +264,18 @@ impl CliArgs {
                 PackageManifest::init(&manifest_path()).wrap_err("initialize package.json")?;
             }
             CliCommand::Add(args) => match reporter {
-                ReporterType::Ndjson => args.run::<NdjsonReporter>(state(false)?).await?,
-                ReporterType::Silent => args.run::<SilentReporter>(state(false)?).await?,
+                ReporterType::Default => {
+                    Box::pin(args.run::<DefaultReporter>(state(false)?)).await?;
+                }
+                ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(state(false)?)).await?,
+                ReporterType::Silent => Box::pin(args.run::<SilentReporter>(state(false)?)).await?,
             },
             CliCommand::Update(args) => match reporter {
-                ReporterType::Ndjson => args.run::<NdjsonReporter>(state(false)?).await?,
-                ReporterType::Silent => args.run::<SilentReporter>(state(false)?).await?,
+                ReporterType::Default => {
+                    Box::pin(args.run::<DefaultReporter>(state(false)?)).await?;
+                }
+                ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(state(false)?)).await?,
+                ReporterType::Silent => Box::pin(args.run::<SilentReporter>(state(false)?)).await?,
             },
             // `outdated` is a read-only query: it prints a report to
             // stdout and never installs, so it has no reporter-typed
@@ -266,8 +288,11 @@ impl CliArgs {
                 }
             }
             CliCommand::Remove(args) => match reporter {
-                ReporterType::Ndjson => args.run::<NdjsonReporter>(state(false)?).await?,
-                ReporterType::Silent => args.run::<SilentReporter>(state(false)?).await?,
+                ReporterType::Default => {
+                    Box::pin(args.run::<DefaultReporter>(state(false)?)).await?;
+                }
+                ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(state(false)?)).await?,
+                ReporterType::Silent => Box::pin(args.run::<SilentReporter>(state(false)?)).await?,
             },
             CliCommand::Install(args) => {
                 // CLI overrides for `offline` / `prefer_offline` live
@@ -321,55 +346,22 @@ impl CliArgs {
                 // lockfile, and `updateConfig` must mutate `cfg` (still
                 // `&'static mut`) before it's frozen and the install reads
                 // it. Mirrors pnpm running both at config-finalization.
+                let pipeline = InstallPipeline {
+                    args,
+                    cfg,
+                    config_root,
+                    package_manager_to_sync,
+                    manifest_path: manifest_path(),
+                    require_lockfile,
+                    frozen_lockfile,
+                };
+                // Boxed for `clippy::large_stack_frames`: the three
+                // monomorphized install futures would otherwise each reserve
+                // their full size in this frame.
                 match reporter {
-                    ReporterType::Ndjson => {
-                        if let Some(pm) = package_manager_to_sync.as_ref() {
-                            config_deps::sync_package_manager_dependencies(
-                                cfg,
-                                &config_root,
-                                &pm.specifier,
-                                &pm.version,
-                                frozen_lockfile,
-                            )
-                            .await?;
-                        }
-                        config_deps::install_config_deps::<NdjsonReporter>(
-                            cfg,
-                            &config_root,
-                            frozen_lockfile,
-                        )
-                        .await?;
-                        config_deps::run_update_config_hooks::<NdjsonReporter>(cfg, &config_root)
-                            .await?;
-                        let cfg: &'static Config = cfg;
-                        let state = State::init(manifest_path(), cfg, require_lockfile)
-                            .wrap_err("initialize the state")?;
-                        args.run::<NdjsonReporter>(state).await?;
-                    }
-                    ReporterType::Silent => {
-                        if let Some(pm) = package_manager_to_sync.as_ref() {
-                            config_deps::sync_package_manager_dependencies(
-                                cfg,
-                                &config_root,
-                                &pm.specifier,
-                                &pm.version,
-                                frozen_lockfile,
-                            )
-                            .await?;
-                        }
-                        config_deps::install_config_deps::<SilentReporter>(
-                            cfg,
-                            &config_root,
-                            frozen_lockfile,
-                        )
-                        .await?;
-                        config_deps::run_update_config_hooks::<SilentReporter>(cfg, &config_root)
-                            .await?;
-                        let cfg: &'static Config = cfg;
-                        let state = State::init(manifest_path(), cfg, require_lockfile)
-                            .wrap_err("initialize the state")?;
-                        args.run::<SilentReporter>(state).await?;
-                    }
+                    ReporterType::Default => Box::pin(pipeline.run::<DefaultReporter>()).await?,
+                    ReporterType::Ndjson => Box::pin(pipeline.run::<NdjsonReporter>()).await?,
+                    ReporterType::Silent => Box::pin(pipeline.run::<SilentReporter>()).await?,
                 }
             }
             CliCommand::Test => {
@@ -394,8 +386,15 @@ impl CliArgs {
                 }
             }
             CliCommand::Dlx(args) => match reporter {
-                ReporterType::Ndjson => args.run::<NdjsonReporter>(&dir, config()?).await?,
-                ReporterType::Silent => args.run::<SilentReporter>(&dir, config()?).await?,
+                ReporterType::Default => {
+                    Box::pin(args.run::<DefaultReporter>(&dir, config()?)).await?;
+                }
+                ReporterType::Ndjson => {
+                    Box::pin(args.run::<NdjsonReporter>(&dir, config()?)).await?;
+                }
+                ReporterType::Silent => {
+                    Box::pin(args.run::<SilentReporter>(&dir, config()?)).await?;
+                }
             },
             CliCommand::Start => {
                 // Runs an arbitrary command specified in the package's start property of its scripts
@@ -410,8 +409,77 @@ impl CliArgs {
             CliCommand::Store(command) => command.run(|| config().map(|m| &*m))?,
         }
 
+        // The `Done in ...` footer covers the whole command, mirroring pnpm's
+        // `pnpm:execution-time` emit in `main.ts`. Only the install-family
+        // commands drive the visual reporter, so the rest stay silent.
+        if is_install_family {
+            reporter_emit(reporter)(&LogEvent::ExecutionTime(ExecutionTimeLog {
+                level: LogLevel::Debug,
+                started_at,
+                ended_at: now_millis(),
+            }));
+        }
+
         Ok(())
     }
+}
+
+/// The reporter-generic body of `pacquet install`: it threads one `Reporter`
+/// type through config-dependency sync, the `updateConfig` hooks, and the
+/// install itself. Lifting it out of the dispatch keeps the three
+/// `ReporterType` arms to a single line each.
+struct InstallPipeline {
+    args: InstallArgs,
+    cfg: &'static mut Config,
+    config_root: PathBuf,
+    package_manager_to_sync: Option<PackageManagerToSync>,
+    manifest_path: PathBuf,
+    require_lockfile: bool,
+    frozen_lockfile: bool,
+}
+
+impl InstallPipeline {
+    async fn run<Reporter: self::Reporter + 'static>(self) -> miette::Result<()> {
+        let InstallPipeline {
+            args,
+            cfg,
+            config_root,
+            package_manager_to_sync,
+            manifest_path,
+            require_lockfile,
+            frozen_lockfile,
+        } = self;
+        if let Some(pm) = package_manager_to_sync.as_ref() {
+            config_deps::sync_package_manager_dependencies(
+                cfg,
+                &config_root,
+                &pm.specifier,
+                &pm.version,
+                frozen_lockfile,
+            )
+            .await?;
+        }
+        config_deps::install_config_deps::<Reporter>(cfg, &config_root, frozen_lockfile).await?;
+        config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
+        let cfg: &'static Config = cfg;
+        let state =
+            State::init(manifest_path, cfg, require_lockfile).wrap_err("initialize the state")?;
+        args.run::<Reporter>(state).await
+    }
+}
+
+/// Resolve a [`ReporterType`] to the monomorphized `emit` of its sink, for
+/// the event-emission sites that aren't already generic over `Reporter`.
+fn reporter_emit(reporter: ReporterType) -> fn(&LogEvent) {
+    match reporter {
+        ReporterType::Default => DefaultReporter::emit,
+        ReporterType::Ndjson => NdjsonReporter::emit,
+        ReporterType::Silent => SilentReporter::emit,
+    }
+}
+
+fn now_millis() -> u128 {
+    std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map_or(0, |d| d.as_millis())
 }
 
 #[derive(Debug)]

--- a/pacquet/crates/cli/src/lib.rs
+++ b/pacquet/crates/cli/src/lib.rs
@@ -20,6 +20,9 @@ pub fn main() -> miette::Result<()> {
     // would otherwise error out as "unexpected argument". Each extracted
     // token is layered onto `Config` after `.npmrc` / yaml run.
     let (config_overrides, argv) = ConfigOverrides::extract(std::env::args_os());
+    // The default reporter's `Done in ... using pacquet v<version>` footer needs
+    // the version before the first event (including the fast path's).
+    pacquet_default_reporter::set_package_version(pacquet_config::PACQUET_VERSION);
     let args = CliArgs::parse_from(argv);
     // An up-to-date `pacquet install` finishes here, without paying for
     // the runtime, the HTTP client, or any worker threads.

--- a/pacquet/crates/cli/tests/run.rs
+++ b/pacquet/crates/cli/tests/run.rs
@@ -332,12 +332,11 @@ fn run_finds_local_bin_on_path() {
     drop(root);
 }
 
-/// With a non-silent reporter (e.g. `--reporter=ndjson`), `pacquet run`
-/// echoes `$ <script>` to stderr before spawning the script —
+/// With a non-silent reporter (the default, or e.g. `--reporter=ndjson`),
+/// `pacquet run` echoes `$ <script>` to stderr before spawning the script —
 /// matching pnpm's `runLifecycleHook.ts:110`
-/// (`process.stderr.write(chalk.dim($ ${...})...)`). The default Silent
-/// reporter (no human-facing reporter exists in pacquet yet) suppresses
-/// it.
+/// (`process.stderr.write(chalk.dim($ ${...})...)`). Only `--reporter=silent`
+/// suppresses it.
 #[cfg(unix)]
 #[test]
 fn run_echoes_script_to_stderr_when_reporter_not_silent() {

--- a/pacquet/crates/default-reporter/Cargo.toml
+++ b/pacquet/crates/default-reporter/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name                  = "pacquet-default-reporter"
+version               = "0.0.1"
+publish               = false
+authors.workspace     = true
+description.workspace = true
+edition.workspace     = true
+homepage.workspace    = true
+keywords.workspace    = true
+license.workspace     = true
+repository.workspace  = true
+
+[dependencies]
+pacquet-reporter = { workspace = true }
+
+libc       = { workspace = true }
+owo-colors = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+insta             = { workspace = true }
+pretty_assertions = { workspace = true }
+
+[lints]
+workspace = true

--- a/pacquet/crates/default-reporter/src/colors.rs
+++ b/pacquet/crates/default-reporter/src/colors.rs
@@ -1,0 +1,51 @@
+//! chalk → owo-colors mapping used by the renderers.
+//!
+//! Every styling decision goes through a [`Colors`] whose `enabled` flag is
+//! resolved once (stdout is a TTY and `NO_COLOR` is unset). Disabled, every
+//! method returns the text unchanged, so the same render code produces the
+//! plain output pnpm emits when piped. Tests construct `Colors { enabled }`
+//! directly to assert both forms deterministically without touching a real
+//! terminal.
+
+use owo_colors::OwoColorize;
+
+/// Palette wrapper. Mirrors the chalk colors `@pnpm/cli.default-reporter`
+/// uses; method names match the chalk style they replace.
+#[derive(Debug, Clone, Copy)]
+pub struct Colors {
+    pub enabled: bool,
+}
+
+macro_rules! paint {
+    ($name:ident, $method:ident) => {
+        pub fn $name(&self, text: &str) -> String {
+            if self.enabled { text.$method().to_string() } else { text.to_string() }
+        }
+    };
+}
+
+impl Colors {
+    paint!(cyan_bright, bright_cyan);
+    paint!(cyan, cyan);
+    paint!(green, green);
+    paint!(red, red);
+    paint!(yellow, yellow);
+    // chalk's `grey`/`gray` — ANSI bright-black.
+    paint!(grey, bright_black);
+    paint!(magenta_bright, bright_magenta);
+
+    /// The `[WARN]` label: yellow-on-yellow brackets around black-on-yellow
+    /// `WARN`, matching `formatWarn`.
+    #[must_use]
+    pub fn warn_label(&self) -> String {
+        if !self.enabled {
+            return "[WARN]".to_string();
+        }
+        format!(
+            "{}{}{}",
+            "[".yellow().on_yellow(),
+            "WARN".black().on_yellow(),
+            "]".yellow().on_yellow(),
+        )
+    }
+}

--- a/pacquet/crates/default-reporter/src/format.rs
+++ b/pacquet/crates/default-reporter/src/format.rs
@@ -1,0 +1,193 @@
+//! Small formatting helpers ported from the JS libraries the pnpm reporter
+//! relies on (`pretty-bytes`, `pretty-ms`, `cli-truncate`, `normalize-path`)
+//! and from `utils/formatPrefix.ts` / `utils/zooming.ts`.
+
+/// `outputConstants.ts` `PREFIX_MAX_LENGTH`.
+pub const PREFIX_MAX_LENGTH: usize = 40;
+
+/// Port of `pretty-bytes` with `{ minimumFractionDigits: 2,
+/// maximumFractionDigits: 2 }` — base-1000 units, always two decimals, a
+/// space before the unit. `0` short-circuits to `"0 B"` like the library.
+#[must_use]
+pub fn pretty_bytes(n: u64) -> String {
+    const UNITS: [&str; 9] = ["B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+    if n == 0 {
+        return "0 B".to_string();
+    }
+    let mut value = n as f64;
+    let mut idx = 0;
+    while value >= 1000.0 && idx < UNITS.len() - 1 {
+        value /= 1000.0;
+        idx += 1;
+    }
+    format!("{value:.2} {}", UNITS[idx])
+}
+
+/// Port of `pretty-ms` for the magnitudes the reporter renders (sub-second
+/// through hours). Sub-second values render as `"<n>ms"`; larger values split
+/// into `d`/`h`/`m`/`s`, the seconds component carrying one decimal (trailing
+/// `.0` trimmed), joined by spaces.
+#[must_use]
+pub fn pretty_ms(ms: u128) -> String {
+    if ms < 1000 {
+        return format!("{ms}ms");
+    }
+    let mut secs = ms as f64 / 1000.0;
+    let days = (secs / 86_400.0).floor();
+    secs -= days * 86_400.0;
+    let hours = (secs / 3_600.0).floor();
+    secs -= hours * 3_600.0;
+    let mins = (secs / 60.0).floor();
+    secs -= mins * 60.0;
+
+    let mut parts = Vec::new();
+    if days > 0.0 {
+        parts.push(format!("{}d", days as u64));
+    }
+    if hours > 0.0 {
+        parts.push(format!("{}h", hours as u64));
+    }
+    if mins > 0.0 {
+        parts.push(format!("{}m", mins as u64));
+    }
+    let secs_rounded = (secs * 10.0).round() / 10.0;
+    if secs_rounded > 0.0 {
+        if (secs_rounded.fract()).abs() < f64::EPSILON {
+            parts.push(format!("{}s", secs_rounded as u64));
+        } else {
+            parts.push(format!("{secs_rounded:.1}s"));
+        }
+    }
+    if parts.is_empty() {
+        parts.push("0s".to_string());
+    }
+    parts.join(" ")
+}
+
+/// Visible width of a string, skipping ANSI CSI escape sequences (so a
+/// colored cell counts as its glyphs only). Counts `char`s, which matches
+/// pnpm's reliance on `string-length` for the ASCII-dominant lines it lays
+/// out.
+#[must_use]
+pub fn visible_width(text: &str) -> usize {
+    let mut width = 0;
+    let mut chars = text.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' {
+            // Skip until the terminating letter of the CSI sequence.
+            for esc in chars.by_ref() {
+                if esc.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            width += 1;
+        }
+    }
+    width
+}
+
+/// Port of `cli-truncate(line, max)` for the plain (no embedded ANSI) script
+/// lines the lifecycle reporter cuts. Appends `...` when the line is shortened,
+/// matching cli-truncate's default end position.
+#[must_use]
+pub fn cut_line(line: &str, max: isize) -> String {
+    if max <= 0 {
+        return String::new();
+    }
+    let max = max as usize;
+    if line.chars().count() <= max {
+        return line.to_string();
+    }
+    let keep = max.saturating_sub(1);
+    let mut out: String = line.chars().take(keep).collect();
+    out.push('…');
+    out
+}
+
+/// Port of `normalize-path`: backslashes to forward slashes.
+#[must_use]
+pub fn normalize(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+/// Forward-slash relative path from `base` to `target`. Handles the
+/// under-root case the lifecycle prefix needs and the upward (`..`) case
+/// workspace zooming can hit.
+#[must_use]
+pub fn relative(base: &str, target: &str) -> String {
+    let from: Vec<&str> = split_components(base);
+    let to: Vec<&str> = split_components(target);
+    let mut shared = 0;
+    while shared < from.len() && shared < to.len() && from[shared] == to[shared] {
+        shared += 1;
+    }
+    let mut parts: Vec<&str> = Vec::new();
+    parts.extend(std::iter::repeat_n("..", from.len() - shared));
+    parts.extend_from_slice(&to[shared..]);
+    parts.join("/")
+}
+
+fn split_components(path: &str) -> Vec<&str> {
+    path.split(['/', '\\']).filter(|component| !component.is_empty()).collect()
+}
+
+/// `formatPrefixNoTrim`: relative path, normalized, `"."` for the cwd itself.
+#[must_use]
+pub fn format_prefix_no_trim(cwd: &str, prefix: &str) -> String {
+    let rel = relative(cwd, prefix);
+    if rel.is_empty() { ".".to_string() } else { normalize(&rel) }
+}
+
+/// `formatPrefix`: like [`format_prefix_no_trim`] but trims an
+/// over-`PREFIX_MAX_LENGTH` path to a `...` + trailing-segment form.
+#[must_use]
+pub fn format_prefix(cwd: &str, prefix: &str) -> String {
+    let prefix = format_prefix_no_trim(cwd, prefix);
+    let chars: Vec<char> = prefix.chars().collect();
+    if chars.len() <= PREFIX_MAX_LENGTH {
+        return prefix;
+    }
+    let short: String = chars[chars.len() - (PREFIX_MAX_LENGTH - 3)..].iter().collect();
+    match short.find('/') {
+        Some(sep) if sep > 0 => format!("...{}", &short[sep..]),
+        _ => format!("...{short}"),
+    }
+}
+
+/// `zooming.ts` `zoomOut`: a fixed-width `<prefix> | <line>` gutter so a
+/// monorepo project's output is attributable.
+#[must_use]
+pub fn zoom_out(current_prefix: &str, log_prefix: &str, line: &str) -> String {
+    let prefix = format_prefix(current_prefix, log_prefix);
+    let padded = pad_end(&prefix, PREFIX_MAX_LENGTH);
+    format!("{padded} | {line}")
+}
+
+fn pad_end(text: &str, width: usize) -> String {
+    let len = text.chars().count();
+    if len >= width {
+        return text.to_string();
+    }
+    let mut out = text.to_string();
+    out.extend(std::iter::repeat_n(' ', width - len));
+    out
+}
+
+/// `highlightLastFolder`: greys everything up to and including the final
+/// path separator, leaving the last segment at default color.
+#[must_use]
+pub fn highlight_last_folder(path: &str, colors: &crate::colors::Colors) -> String {
+    match path.rfind('/') {
+        Some(idx) => format!("{}{}", colors.grey(&path[..=idx]), &path[idx + 1..]),
+        None => path.to_string(),
+    }
+}
+
+/// `path.relative` membership test used by the lifecycle "collapsed" rule and
+/// the broken-modules path: whether `needle` appears as a path segment run in
+/// `haystack`, separator-agnostic.
+#[must_use]
+pub fn contains_path(haystack: &str, needle: &str) -> bool {
+    normalize(haystack).contains(&normalize(needle))
+}

--- a/pacquet/crates/default-reporter/src/format.rs
+++ b/pacquet/crates/default-reporter/src/format.rs
@@ -184,9 +184,12 @@ pub fn highlight_last_folder(path: &str, colors: &crate::colors::Colors) -> Stri
     }
 }
 
-/// `path.relative` membership test used by the lifecycle "collapsed" rule and
-/// the broken-modules path: whether `needle` appears as a path segment run in
-/// `haystack`, separator-agnostic.
+/// Substring containment after slash-normalization, used by the lifecycle
+/// "collapsed" rule. Ports pnpm's `wd.includes(NODE_MODULES)` /
+/// `wd.includes(TMP_DIR_IN_STORE)` checks in `reportLifecycleScripts.ts`,
+/// which are plain `String.includes` calls — segment-aware matching would
+/// diverge from pnpm. The needles pnpm passes (`/node_modules/`, `tmp/_tmp_`)
+/// already carry their own separators, so substring matching is sufficient.
 #[must_use]
 pub fn contains_path(haystack: &str, needle: &str) -> bool {
     normalize(haystack).contains(&normalize(needle))

--- a/pacquet/crates/default-reporter/src/lib.rs
+++ b/pacquet/crates/default-reporter/src/lib.rs
@@ -1,0 +1,143 @@
+//! pnpm-identical visual reporter for pacquet.
+//!
+//! [`DefaultReporter`] is a [`pacquet_reporter::Reporter`] sink that renders
+//! the same terminal output `@pnpm/cli.default-reporter` produces for
+//! `install` / `add` / `update` / `remove`: a live progress line, a
+//! packages-diff summary, lifecycle script output, and a `Done in ...` footer.
+//!
+//! The trait's `emit` is a static method, so all state lives behind a
+//! process-global mutex. Each event is folded into a [`ReporterState`] (see
+//! [`state`]) that recomputes the frame; the sink writes it in place (TTY) or
+//! appends it line by line (non-TTY).
+//!
+//! Two values the renderer can't recover from events are injected once at
+//! startup: [`set_cwd`] (the project root, for relative paths and workspace
+//! zooming) and [`set_package_version`] (rendered in the `Done in ...` line).
+
+pub mod colors;
+pub mod format;
+pub mod state;
+
+use std::{
+    fmt::Write as _,
+    io::{IsTerminal, Write},
+    sync::{LazyLock, Mutex, OnceLock},
+};
+
+use pacquet_reporter::{LogEvent, Reporter};
+
+use crate::{
+    colors::Colors,
+    state::{Output, ReporterState},
+};
+
+static CWD: OnceLock<String> = OnceLock::new();
+static PACKAGE_VERSION: OnceLock<String> = OnceLock::new();
+
+/// Set the project root the reporter renders paths relative to. Call once
+/// before the first event; ignored if already set.
+pub fn set_cwd(cwd: impl Into<String>) {
+    let _ = CWD.set(cwd.into());
+}
+
+/// Set the version rendered in the `Done in ... using pacquet v<version>`
+/// footer. Call once before the first event; ignored if already set.
+pub fn set_package_version(version: impl Into<String>) {
+    let _ = PACKAGE_VERSION.set(version.into());
+}
+
+pub(crate) fn package_version() -> &'static str {
+    PACKAGE_VERSION.get().map(String::as_str).unwrap_or(env!("CARGO_PKG_VERSION"))
+}
+
+fn cwd() -> String {
+    CWD.get().cloned().unwrap_or_else(|| {
+        std::env::current_dir().map(|path| path.to_string_lossy().into_owned()).unwrap_or_default()
+    })
+}
+
+/// `--reporter=default`: renders pnpm-style visual output to stdout.
+pub struct DefaultReporter;
+
+impl Reporter for DefaultReporter {
+    fn emit(event: &LogEvent) {
+        let mut sink = SINK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let output = sink.state.handle(event);
+        sink.write(output);
+    }
+}
+
+static SINK: LazyLock<Mutex<Sink>> = LazyLock::new(|| Mutex::new(Sink::new()));
+
+struct Sink {
+    state: ReporterState,
+    columns: usize,
+    prev_rows: usize,
+}
+
+impl Sink {
+    fn new() -> Self {
+        let is_tty = std::io::stdout().is_terminal();
+        let columns = if is_tty { terminal_columns().unwrap_or(80) } else { 80 };
+        // pnpm's `outputMaxWidth`: `columns - 2` on a TTY, else 80.
+        let width = if is_tty { columns.saturating_sub(2) } else { 80 };
+        let colors = Colors { enabled: is_tty && std::env::var_os("NO_COLOR").is_none() };
+        let state = ReporterState::new(cwd(), width, colors, !is_tty);
+        Sink { state, columns, prev_rows: 0 }
+    }
+
+    fn write(&mut self, output: Output) {
+        let mut out = std::io::stdout().lock();
+        match output {
+            Output::None => return,
+            Output::Lines(lines) => {
+                for line in lines {
+                    let _ = writeln!(out, "{line}");
+                }
+            }
+            Output::Frame(frame) => {
+                let mut buf = String::new();
+                if self.prev_rows > 0 {
+                    let _ = write!(buf, "\x1b[{}A", self.prev_rows);
+                }
+                buf.push_str("\x1b[0J");
+                buf.push_str(&frame);
+                buf.push('\n');
+                let _ = out.write_all(buf.as_bytes());
+                self.prev_rows = count_rows(&frame, self.columns);
+            }
+        }
+        let _ = out.flush();
+    }
+}
+
+/// Terminal rows a frame occupies, accounting for soft-wrapping at
+/// `columns`. Used to know how far to move the cursor up before redrawing.
+fn count_rows(frame: &str, columns: usize) -> usize {
+    if columns == 0 {
+        return frame.split('\n').count();
+    }
+    frame
+        .split('\n')
+        .map(|line| {
+            let width = format::visible_width(line);
+            if width == 0 { 1 } else { width.div_ceil(columns) }
+        })
+        .sum()
+}
+
+#[cfg(unix)]
+fn terminal_columns() -> Option<usize> {
+    // SAFETY: `winsize` is plain-old-data; `ioctl` only writes into it and we
+    // check the return code before reading.
+    unsafe {
+        let mut ws: libc::winsize = std::mem::zeroed();
+        (libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, &mut ws) == 0 && ws.ws_col > 0)
+            .then_some(ws.ws_col as usize)
+    }
+}
+
+#[cfg(not(unix))]
+fn terminal_columns() -> Option<usize> {
+    None
+}

--- a/pacquet/crates/default-reporter/src/lib.rs
+++ b/pacquet/crates/default-reporter/src/lib.rs
@@ -22,9 +22,10 @@ use std::{
     fmt::Write as _,
     io::{IsTerminal, Write},
     sync::{LazyLock, Mutex, OnceLock},
+    time::{Duration, Instant},
 };
 
-use pacquet_reporter::{LogEvent, Reporter};
+use pacquet_reporter::{FetchingProgressMessage, LogEvent, Reporter};
 
 use crate::{
     colors::Colors,
@@ -33,6 +34,7 @@ use crate::{
 
 static CWD: OnceLock<String> = OnceLock::new();
 static PACKAGE_VERSION: OnceLock<String> = OnceLock::new();
+static FORCE_APPEND_ONLY: OnceLock<bool> = OnceLock::new();
 
 /// Set the project root the reporter renders paths relative to. Call once
 /// before the first event; ignored if already set.
@@ -50,6 +52,12 @@ pub(crate) fn package_version() -> &'static str {
     PACKAGE_VERSION.get().map(String::as_str).unwrap_or(env!("CARGO_PKG_VERSION"))
 }
 
+/// Force append-only rendering regardless of whether stdout is a TTY,
+/// backing `--reporter=append-only`. Call once before the first event.
+pub fn force_append_only() {
+    let _ = FORCE_APPEND_ONLY.set(true);
+}
+
 fn cwd() -> String {
     CWD.get().cloned().unwrap_or_else(|| {
         std::env::current_dir().map(|path| path.to_string_lossy().into_owned()).unwrap_or_default()
@@ -63,7 +71,22 @@ impl Reporter for DefaultReporter {
     fn emit(event: &LogEvent) {
         let mut sink = SINK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let output = sink.state.handle(event);
-        sink.write(output);
+        sink.write(output, is_coalesceable(event));
+    }
+}
+
+/// Whether an event is a high-volume progress update that may be dropped
+/// under throttling, mirroring pnpm's `throttleProgress` on the progress
+/// stream. Per-package `pnpm:progress` and streaming `in_progress` download
+/// ticks coalesce; everything else (stats, summary, lifecycle, stage markers,
+/// the footer) renders immediately.
+fn is_coalesceable(event: &LogEvent) -> bool {
+    match event {
+        LogEvent::Progress(_) => true,
+        LogEvent::FetchingProgress(log) => {
+            matches!(log.message, FetchingProgressMessage::InProgress { .. })
+        }
+        _ => false,
     }
 }
 
@@ -73,23 +96,44 @@ struct Sink {
     state: ReporterState,
     columns: usize,
     prev_rows: usize,
+    throttle: Duration,
+    last_write: Option<Instant>,
 }
 
 impl Sink {
     fn new() -> Self {
         let is_tty = std::io::stdout().is_terminal();
+        let append_only = !is_tty || FORCE_APPEND_ONLY.get().copied().unwrap_or(false);
         let columns = if is_tty { terminal_columns().unwrap_or(80) } else { 80 };
         // pnpm's `outputMaxWidth`: `columns - 2` on a TTY, else 80.
         let width = if is_tty { columns.saturating_sub(2) } else { 80 };
         let colors = Colors { enabled: is_tty && std::env::var_os("NO_COLOR").is_none() };
-        let state = ReporterState::new(cwd(), width, colors, !is_tty);
-        Sink { state, columns, prev_rows: 0 }
+        let state = ReporterState::new(cwd(), width, colors, append_only);
+        // pnpm's `throttleProgress`: 200ms in place, 1000ms append-only.
+        let throttle =
+            if append_only { Duration::from_secs(1) } else { Duration::from_millis(200) };
+        Sink { state, columns, prev_rows: 0, throttle, last_write: None }
     }
 
-    fn write(&mut self, output: Output) {
+    fn write(&mut self, output: Output, coalesceable: bool) {
+        // Drop a high-volume progress redraw if the throttle window hasn't
+        // elapsed. State is already folded, so the next non-coalesceable
+        // event (stats, summary, importing-done, the footer) renders the
+        // latest counts.
+        if coalesceable && self.last_write.is_some_and(|last| last.elapsed() < self.throttle) {
+            return;
+        }
+        let wrote = self.write_output(output);
+        if wrote {
+            self.last_write = Some(Instant::now());
+        }
+    }
+
+    /// Returns whether anything was written.
+    fn write_output(&mut self, output: Output) -> bool {
         let mut out = std::io::stdout().lock();
         match output {
-            Output::None => return,
+            Output::None => return false,
             Output::Lines(lines) => {
                 for line in lines {
                     let _ = writeln!(out, "{line}");
@@ -108,6 +152,7 @@ impl Sink {
             }
         }
         let _ = out.flush();
+        true
     }
 }
 
@@ -141,3 +186,6 @@ fn terminal_columns() -> Option<usize> {
 fn terminal_columns() -> Option<usize> {
     None
 }
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/default-reporter/src/state.rs
+++ b/pacquet/crates/default-reporter/src/state.rs
@@ -1,0 +1,1056 @@
+//! Event-folding renderer: the in-process equivalent of
+//! `@pnpm/cli.default-reporter`'s `RxJS` graph. Each [`LogEvent`] is folded into
+//! [`ReporterState`], which recomputes the terminal frame. The frame model
+//! (fixed blocks pinned below scrolling non-fixed blocks) ports
+//! `mergeOutputs.ts`; the per-channel rendering ports the matching
+//! `reporterForClient/report*.ts` module.
+
+use std::{collections::HashMap, fmt::Write as _};
+
+use pacquet_reporter::{
+    AddedRoot, ContextLog, DependencyType, ExecutionTimeLog, FetchingProgressMessage,
+    IgnoredScriptsLog, InstallingConfigDepsLog, InstallingConfigDepsStatus, LifecycleMessage,
+    LifecycleStdio, LockfileVerificationMessage, LogEvent, LogLevel, PackageImportMethod,
+    PackageManifestMessage, ProgressMessage, RemovedRoot, RequestRetryLog, SkippedOptionalPackage,
+    Stage, StatsMessage,
+};
+use serde_json::Value;
+
+use crate::{
+    colors::Colors,
+    format::{
+        contains_path, cut_line, format_prefix, format_prefix_no_trim, highlight_last_folder,
+        normalize, pretty_bytes, pretty_ms, relative, visible_width, zoom_out,
+    },
+};
+
+/// What [`ReporterState::handle`] asks the sink to do after folding one event.
+pub enum Output {
+    /// Nothing changed; the sink writes nothing.
+    None,
+    /// The full recomputed frame (in-place mode).
+    Frame(String),
+    /// Lines to append verbatim (append-only mode).
+    Lines(Vec<String>),
+}
+
+/// Lazily-assigned block indices for one logical output stream — its
+/// non-fixed (`block`) and fixed (`fixed`) slots in the frame, matching the
+/// per-inner-observable `currentBlockNo` / `currentFixedBlockNo` of
+/// `mergeOutputs.ts`.
+#[derive(Debug, Default, Clone)]
+struct BlockSlot {
+    block: Option<usize>,
+    fixed: Option<usize>,
+}
+
+/// The frame buffer: scrolling `blocks` rendered above pinned `fixed_blocks`,
+/// or — in append-only mode — a list of `pending` lines to print as they
+/// arrive. Ports `mergeOutputs.ts`.
+#[derive(Debug)]
+struct Frame {
+    append_only: bool,
+    blocks: Vec<Option<String>>,
+    fixed_blocks: Vec<Option<String>>,
+    next_block: usize,
+    next_fixed: usize,
+    pending: Vec<String>,
+}
+
+impl Frame {
+    fn new(append_only: bool) -> Self {
+        Frame {
+            append_only,
+            blocks: Vec::new(),
+            fixed_blocks: Vec::new(),
+            next_block: 0,
+            next_fixed: 0,
+            pending: Vec::new(),
+        }
+    }
+
+    fn emit(&mut self, slot: &mut BlockSlot, msg: String, fixed: bool) {
+        if self.append_only {
+            self.pending.push(msg);
+            return;
+        }
+        if fixed {
+            let idx = *slot.fixed.get_or_insert_with(|| {
+                let assigned = self.next_fixed;
+                self.next_fixed += 1;
+                assigned
+            });
+            if self.fixed_blocks.len() <= idx {
+                self.fixed_blocks.resize(idx + 1, None);
+            }
+            self.fixed_blocks[idx] = Some(msg);
+        } else {
+            if let Some(f) = slot.fixed.take() {
+                self.fixed_blocks[f] = None;
+            }
+            let idx = *slot.block.get_or_insert_with(|| {
+                let assigned = self.next_block;
+                self.next_block += 1;
+                assigned
+            });
+            if self.blocks.len() <= idx {
+                self.blocks.resize(idx + 1, None);
+            }
+            self.blocks[idx] = Some(msg);
+        }
+    }
+
+    fn render(&self) -> String {
+        let non_fixed: Vec<&str> = self.blocks.iter().filter_map(|b| b.as_deref()).collect();
+        let fixed: Vec<&str> = self.fixed_blocks.iter().filter_map(|b| b.as_deref()).collect();
+        let non_fixed_part = non_fixed.join("\n");
+        if fixed.is_empty() {
+            return non_fixed_part;
+        }
+        let fixed_part = fixed.join("\n");
+        if non_fixed_part.is_empty() {
+            return fixed_part;
+        }
+        format!("{non_fixed_part}\n{fixed_part}")
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct ProgressStats {
+    resolved: u64,
+    reused: u64,
+    fetched: u64,
+    imported: u64,
+}
+
+#[derive(Debug, Default)]
+struct ProgressEntry {
+    stats: ProgressStats,
+    slot: BlockSlot,
+}
+
+/// One dependency added or removed, ready to render. Ports `PackageDiff` in
+/// `pkgsDiff.ts`.
+#[derive(Debug, Clone)]
+struct PackageDiff {
+    added: bool,
+    from: Option<String>,
+    name: String,
+    real_name: Option<String>,
+    version: Option<String>,
+    latest: Option<String>,
+}
+
+/// The five dependency buckets, in summary render order. Ports the
+/// `PkgsDiff` record + `propertyByDependencyType`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DepKind {
+    Prod,
+    Optional,
+    Peer,
+    Dev,
+    NodeModulesOnly,
+}
+
+const SUMMARY_ORDER: [DepKind; 5] =
+    [DepKind::Prod, DepKind::Optional, DepKind::Peer, DepKind::Dev, DepKind::NodeModulesOnly];
+
+impl DepKind {
+    fn header(self) -> &'static str {
+        match self {
+            DepKind::Prod => "dependencies",
+            DepKind::Optional => "optionalDependencies",
+            DepKind::Peer => "peerDependencies",
+            DepKind::Dev => "devDependencies",
+            DepKind::NodeModulesOnly => "node_modules",
+        }
+    }
+
+    fn from_dependency_type(dt: Option<DependencyType>) -> Self {
+        match dt {
+            Some(DependencyType::Prod) => DepKind::Prod,
+            Some(DependencyType::Dev) => DepKind::Dev,
+            Some(DependencyType::Optional) => DepKind::Optional,
+            None => DepKind::NodeModulesOnly,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct LifecycleEntry {
+    collapsed: bool,
+    label: Option<String>,
+    output: Vec<String>,
+    script: String,
+    status: String,
+    start: Option<std::time::Instant>,
+}
+
+#[derive(Debug)]
+struct BigTarball {
+    size: u64,
+    slot: BlockSlot,
+}
+
+/// The whole renderer state. One instance lives behind the sink's mutex in
+/// production; tests construct it directly.
+pub struct ReporterState {
+    cwd: String,
+    width: usize,
+    colors: Colors,
+    append_only: bool,
+    frame: Frame,
+    last_frame: Option<String>,
+
+    progress: HashMap<String, ProgressEntry>,
+
+    context: Option<ContextLog>,
+    import_method: Option<PackageImportMethod>,
+    context_slot: BlockSlot,
+    context_rendered: bool,
+
+    stats_added: Option<u64>,
+    stats_removed: Option<u64>,
+    stats_slot: BlockSlot,
+
+    diff: HashMap<&'static str, HashMap<String, PackageDiff>>,
+    manifest_initial: Option<Value>,
+    manifest_updated: Option<Value>,
+    summary_slot: BlockSlot,
+    summary_rendered: bool,
+
+    lifecycle: HashMap<String, LifecycleEntry>,
+    lifecycle_slots: HashMap<String, BlockSlot>,
+    lifecycle_colors: HashMap<String, usize>,
+    color_wheel: usize,
+
+    big: HashMap<String, BigTarball>,
+
+    config_deps_slot: BlockSlot,
+    lockfile_verification_slot: BlockSlot,
+    exec_slot: BlockSlot,
+
+    warnings_counter: usize,
+    collapsed_warn_slot: BlockSlot,
+}
+
+const MAX_SHOWN_WARNINGS: usize = 5;
+
+/// `reportLifecycleScripts.ts` color wheel.
+const COLOR_WHEEL: [fn(&Colors, &str) -> String; 6] = [
+    |colors, text| colors.cyan(text),
+    |colors, text| colors.magenta_bright(text),
+    // chalk's `blue` has no dedicated helper here; bright_cyan is the closest
+    // already-mapped tone and keeps the wheel visually distinct.
+    |colors, text| colors.cyan_bright(text),
+    |colors, text| colors.yellow(text),
+    |colors, text| colors.green(text),
+    |colors, text| colors.red(text),
+];
+
+impl ReporterState {
+    #[must_use]
+    pub fn new(cwd: String, width: usize, colors: Colors, append_only: bool) -> Self {
+        let mut diff = HashMap::new();
+        for kind in SUMMARY_ORDER {
+            diff.insert(diff_key(kind), HashMap::new());
+        }
+        ReporterState {
+            cwd,
+            width,
+            colors,
+            append_only,
+            frame: Frame::new(append_only),
+            last_frame: None,
+            progress: HashMap::new(),
+            context: None,
+            import_method: None,
+            context_slot: BlockSlot::default(),
+            context_rendered: false,
+            stats_added: None,
+            stats_removed: None,
+            stats_slot: BlockSlot::default(),
+            diff,
+            manifest_initial: None,
+            manifest_updated: None,
+            summary_slot: BlockSlot::default(),
+            summary_rendered: false,
+            lifecycle: HashMap::new(),
+            lifecycle_slots: HashMap::new(),
+            lifecycle_colors: HashMap::new(),
+            color_wheel: 0,
+            big: HashMap::new(),
+            config_deps_slot: BlockSlot::default(),
+            lockfile_verification_slot: BlockSlot::default(),
+            exec_slot: BlockSlot::default(),
+            warnings_counter: 0,
+            collapsed_warn_slot: BlockSlot::default(),
+        }
+    }
+
+    pub fn handle(&mut self, event: &LogEvent) -> Output {
+        match event {
+            LogEvent::Context(log) => self.on_context(log),
+            LogEvent::PackageImportMethod(log) => {
+                self.import_method = Some(log.method);
+                self.maybe_render_context();
+            }
+            LogEvent::Progress(log) => self.on_progress(&log.message),
+            LogEvent::Stage(log) => self.on_stage(&log.prefix, log.stage),
+            LogEvent::FetchingProgress(log) => self.on_fetching(&log.message),
+            LogEvent::Stats(log) => self.on_stats(&log.message),
+            LogEvent::Root(log) => self.on_root(&log.message),
+            LogEvent::PackageManifest(log) => self.on_manifest(&log.message),
+            LogEvent::Summary(_) => self.on_summary(),
+            LogEvent::Lifecycle(log) => self.on_lifecycle(&log.message),
+            LogEvent::IgnoredScripts(log) => self.on_ignored_scripts(log),
+            LogEvent::SkippedOptionalDependency(log) => {
+                let pkg = match &log.package {
+                    SkippedOptionalPackage::Installed { id, .. } => id.clone(),
+                    SkippedOptionalPackage::ResolutionFailure { bare_specifier, .. } => {
+                        bare_specifier.clone()
+                    }
+                };
+                self.push_warning(&format!("Skipping optional dependency {pkg}"));
+            }
+            LogEvent::InstallingConfigDeps(log) => self.on_config_deps(log),
+            LogEvent::LockfileVerification(log) => self.on_lockfile_verification(&log.message),
+            LogEvent::RequestRetry(log) => self.on_request_retry(log),
+            LogEvent::Pnpm(log) => self.on_pnpm(log.level, &log.message, &log.prefix),
+            LogEvent::ExecutionTime(log) => self.on_execution_time(log),
+            // Debug-only / non-rendered channels in pnpm's default reporter.
+            LogEvent::Hook(_) | LogEvent::BrokenModules(_) => {}
+        }
+        self.finish()
+    }
+
+    fn finish(&mut self) -> Output {
+        if self.append_only {
+            let lines = std::mem::take(&mut self.frame.pending);
+            if lines.is_empty() { Output::None } else { Output::Lines(lines) }
+        } else {
+            let frame = self.frame.render();
+            if self.last_frame.as_deref() == Some(frame.as_str()) {
+                Output::None
+            } else {
+                self.last_frame = Some(frame.clone());
+                Output::Frame(frame)
+            }
+        }
+    }
+
+    // --- context (reportContext.ts) ---------------------------------------
+
+    fn on_context(&mut self, log: &ContextLog) {
+        self.context = Some(log.clone());
+        self.maybe_render_context();
+    }
+
+    fn maybe_render_context(&mut self) {
+        if self.context_rendered {
+            return;
+        }
+        let (Some(ctx), Some(method)) = (self.context.as_ref(), self.import_method) else {
+            return;
+        };
+        if ctx.current_lockfile_exists {
+            self.context_rendered = true;
+            return;
+        }
+        let method = match method {
+            PackageImportMethod::Copy => "copied",
+            PackageImportMethod::Clone => "cloned",
+            PackageImportMethod::Hardlink => "hard linked",
+        };
+        let virtual_store = normalize(&relative(&self.cwd, &ctx.virtual_store_dir));
+        let msg = format!(
+            "Packages are {method} from the content-addressable store to the virtual store.\n  \
+             Content-addressable store is at: {}\n  Virtual store is at:             {}",
+            ctx.store_dir, virtual_store,
+        );
+        self.context_rendered = true;
+        let mut slot = std::mem::take(&mut self.context_slot);
+        self.frame.emit(&mut slot, msg, false);
+        self.context_slot = slot;
+    }
+
+    // --- progress (reportProgress.ts) -------------------------------------
+
+    fn on_progress(&mut self, message: &ProgressMessage) {
+        let requester = match message {
+            ProgressMessage::Resolved { requester, .. }
+            | ProgressMessage::Fetched { requester, .. }
+            | ProgressMessage::FoundInStore { requester, .. }
+            | ProgressMessage::Imported { requester, .. } => requester.clone(),
+        };
+        let entry = self.progress.entry(requester.clone()).or_default();
+        match message {
+            ProgressMessage::Resolved { .. } => entry.stats.resolved += 1,
+            ProgressMessage::Fetched { .. } => entry.stats.fetched += 1,
+            ProgressMessage::FoundInStore { .. } => entry.stats.reused += 1,
+            ProgressMessage::Imported { .. } => entry.stats.imported += 1,
+        }
+        let msg = self.progress_message(&requester, false);
+        let mut slot = std::mem::take(&mut self.progress.get_mut(&requester).unwrap().slot);
+        self.frame.emit(&mut slot, msg, true);
+        self.progress.get_mut(&requester).unwrap().slot = slot;
+    }
+
+    fn progress_message(&self, requester: &str, done: bool) -> String {
+        let stats = self.progress.get(requester).map(|entry| entry.stats).unwrap_or_default();
+        let hl = |count: u64| self.colors.cyan_bright(&count.to_string());
+        let mut msg = format!(
+            "Progress: resolved {}, reused {}, downloaded {}, added {}",
+            hl(stats.resolved),
+            hl(stats.reused),
+            hl(stats.fetched),
+            hl(stats.imported),
+        );
+        if done {
+            msg.push_str(", done");
+        }
+        if requester != self.cwd {
+            msg = zoom_out(&self.cwd, requester, &msg);
+        }
+        msg
+    }
+
+    fn on_stage(&mut self, prefix: &str, stage: Stage) {
+        if stage != Stage::ImportingDone {
+            return;
+        }
+        if !self.progress.contains_key(prefix) {
+            return;
+        }
+        let msg = self.progress_message(prefix, true);
+        let mut slot = std::mem::take(&mut self.progress.get_mut(prefix).unwrap().slot);
+        self.frame.emit(&mut slot, msg, false);
+        self.progress.get_mut(prefix).unwrap().slot = slot;
+    }
+
+    // --- big tarballs (reportBigTarballsProgress.ts) ----------------------
+
+    fn on_fetching(&mut self, message: &FetchingProgressMessage) {
+        const BIG_TARBALL_SIZE: u64 = 1024 * 1024 * 5;
+        match message {
+            FetchingProgressMessage::Started { attempt, package_id, size } => {
+                let Some(size) = size else { return };
+                if *size < BIG_TARBALL_SIZE || *attempt != 1 {
+                    return;
+                }
+                let mut entry = BigTarball { size: *size, slot: BlockSlot::default() };
+                let msg = self.downloading_message(package_id, 0, *size);
+                self.frame.emit(&mut entry.slot, msg, true);
+                self.big.insert(package_id.clone(), entry);
+            }
+            FetchingProgressMessage::InProgress { downloaded, package_id } => {
+                let Some(entry) = self.big.get(package_id) else { return };
+                let size = entry.size;
+                let done = *downloaded == size;
+                let msg = self.downloading_message(package_id, *downloaded, size);
+                let mut slot = std::mem::take(&mut self.big.get_mut(package_id).unwrap().slot);
+                self.frame.emit(&mut slot, msg, !done);
+                self.big.get_mut(package_id).unwrap().slot = slot;
+            }
+        }
+    }
+
+    fn downloading_message(&self, package_id: &str, downloaded: u64, size: u64) -> String {
+        let done = downloaded == size;
+        let suffix = if done { ", done" } else { "" };
+        format!(
+            "Downloading {package_id}: {}/{}{suffix}",
+            self.colors.cyan_bright(&pretty_bytes(downloaded)),
+            self.colors.cyan_bright(&pretty_bytes(size)),
+        )
+    }
+
+    // --- stats (reportStats.ts) -------------------------------------------
+
+    fn on_stats(&mut self, message: &StatsMessage) {
+        let prefix = match message {
+            StatsMessage::Added { prefix, added } => {
+                self.stats_added = Some(*added);
+                prefix.clone()
+            }
+            StatsMessage::Removed { prefix, removed } => {
+                self.stats_removed = Some(*removed);
+                prefix.clone()
+            }
+        };
+        if prefix != self.cwd {
+            return;
+        }
+        let added = self.stats_added.unwrap_or(0);
+        let removed = self.stats_removed.unwrap_or(0);
+        if added == 0 && removed == 0 {
+            // The "Already up to date" line is emitted by pacquet as a
+            // `pnpm` log; rendering it here too would duplicate it.
+            return;
+        }
+        let mut msg = String::from("Packages:");
+        if added > 0 {
+            msg.push(' ');
+            msg.push_str(&self.colors.green(&format!("+{added}")));
+        }
+        if removed > 0 {
+            msg.push(' ');
+            msg.push_str(&self.colors.red(&format!("-{removed}")));
+        }
+        msg.push('\n');
+        msg.push_str(&self.pluses_and_minuses(self.width, added, removed));
+        let mut slot = std::mem::take(&mut self.stats_slot);
+        self.frame.emit(&mut slot, msg, false);
+        self.stats_slot = slot;
+    }
+
+    fn pluses_and_minuses(&self, max_width: usize, added: u64, removed: u64) -> String {
+        if max_width == 0 {
+            return String::new();
+        }
+        let changes = added + removed;
+        let (added_chars, removed_chars) = if changes > max_width as u64 {
+            if added == 0 {
+                (0, max_width)
+            } else if removed == 0 {
+                (max_width, 0)
+            } else {
+                let ratio = max_width as f64 / changes as f64;
+                let added_chars = ((added as f64 * ratio).floor() as usize)
+                    .max(1)
+                    .min(max_width.saturating_sub(1));
+                (added_chars, max_width - added_chars)
+            }
+        } else {
+            (added as usize, removed as usize)
+        };
+        let mut out = String::new();
+        for _ in 0..added_chars {
+            out.push_str(&self.colors.green("+"));
+        }
+        for _ in 0..removed_chars {
+            out.push_str(&self.colors.red("-"));
+        }
+        out
+    }
+
+    // --- summary (reportSummary.ts + pkgsDiff.ts) -------------------------
+
+    fn on_root(&mut self, message: &pacquet_reporter::RootMessage) {
+        use pacquet_reporter::RootMessage;
+        let (added, kind, name, version, real_name, from, latest) = match message {
+            RootMessage::Added { added, .. } => added_fields(added),
+            RootMessage::Removed { removed, .. } => removed_fields(removed),
+        };
+        let key = diff_key(kind);
+        let opposite_key = format!("{}{}", if added { '-' } else { '+' }, name);
+        if let Some(prev) = self.diff.get(key).and_then(|b| b.get(&opposite_key))
+            && prev.version == version
+        {
+            self.diff.get_mut(key).unwrap().remove(&opposite_key);
+            return;
+        }
+        let entry = PackageDiff { added, from, name: name.clone(), real_name, version, latest };
+        self.diff
+            .get_mut(key)
+            .unwrap()
+            .insert(format!("{}{name}", if added { '+' } else { '-' }), entry);
+    }
+
+    fn on_manifest(&mut self, message: &PackageManifestMessage) {
+        match message {
+            PackageManifestMessage::Initial { initial, .. } => {
+                self.manifest_initial = Some(initial.clone());
+            }
+            PackageManifestMessage::Updated { updated, .. } => {
+                self.manifest_updated = Some(updated.clone());
+            }
+        }
+    }
+
+    fn on_summary(&mut self) {
+        if self.summary_rendered {
+            return;
+        }
+        self.summary_rendered = true;
+        self.apply_manifest_diff();
+        let msg = self.render_summary();
+        let mut slot = std::mem::take(&mut self.summary_slot);
+        self.frame.emit(&mut slot, msg, false);
+        self.summary_slot = slot;
+    }
+
+    fn apply_manifest_diff(&mut self) {
+        let (Some(initial), Some(updated)) =
+            (self.manifest_initial.as_ref(), self.manifest_updated.as_ref())
+        else {
+            return;
+        };
+        let initial = remove_optional_from_prod(initial);
+        let updated = remove_optional_from_prod(updated);
+        for kind in [DepKind::Peer, DepKind::Prod, DepKind::Optional, DepKind::Dev] {
+            let prop = kind.header();
+            let initial_deps = manifest_dep_versions(&initial, prop);
+            let updated_deps = manifest_dep_versions(&updated, prop);
+            let bucket = self.diff.get_mut(diff_key(kind)).unwrap();
+            for (name, version) in &initial_deps {
+                if !updated_deps.contains_key(name) {
+                    bucket.entry(format!("-{name}")).or_insert_with(|| PackageDiff {
+                        added: false,
+                        from: None,
+                        name: name.clone(),
+                        real_name: None,
+                        version: Some(version.clone()),
+                        latest: None,
+                    });
+                }
+            }
+            for (name, version) in &updated_deps {
+                if !initial_deps.contains_key(name) {
+                    bucket.entry(format!("+{name}")).or_insert_with(|| PackageDiff {
+                        added: true,
+                        from: None,
+                        name: name.clone(),
+                        real_name: None,
+                        version: Some(version.clone()),
+                        latest: None,
+                    });
+                }
+            }
+        }
+    }
+
+    fn render_summary(&self) -> String {
+        let mut msg = String::new();
+        for kind in SUMMARY_ORDER {
+            let bucket = &self.diff[diff_key(kind)];
+            if bucket.is_empty() {
+                continue;
+            }
+            let mut diffs: Vec<&PackageDiff> = bucket.values().collect();
+            diffs.sort_by(|a, b| {
+                a.name.cmp(&b.name).then(u8::from(a.added).cmp(&u8::from(b.added)))
+            });
+            msg.push('\n');
+            msg.push_str(&self.colors.cyan_bright(&format!("{}:", kind.header())));
+            msg.push('\n');
+            let lines: Vec<String> = diffs.iter().map(|diff| self.diff_line(diff)).collect();
+            msg.push_str(&lines.join("\n"));
+            msg.push('\n');
+        }
+        msg
+    }
+
+    fn diff_line(&self, pkg: &PackageDiff) -> String {
+        let mut result = if pkg.added { self.colors.green("+") } else { self.colors.red("-") };
+        match &pkg.real_name {
+            Some(real) if *real != pkg.name => {
+                let _ = write!(result, " {} <- {real}", pkg.name);
+            }
+            _ => {
+                let _ = write!(result, " {}", pkg.name);
+            }
+        }
+        if let Some(version) = &pkg.version {
+            result.push(' ');
+            result.push_str(&self.colors.grey(version));
+            if let Some(latest) = &pkg.latest
+                && latest != version
+            {
+                result.push(' ');
+                result.push_str(&self.colors.grey(&format!("({latest} is available)")));
+            }
+        }
+        if let Some(from) = &pkg.from {
+            let rel = relative(&self.cwd, from);
+            let shown = if rel.is_empty() { from.clone() } else { rel };
+            result.push(' ');
+            result.push_str(&self.colors.grey(&format!("<- {shown}")));
+        }
+        result
+    }
+
+    // --- lifecycle (reportLifecycleScripts.ts) ----------------------------
+
+    fn on_lifecycle(&mut self, message: &LifecycleMessage) {
+        if self.append_only {
+            let msg = self.stream_lifecycle(message);
+            let mut slot = BlockSlot::default();
+            self.frame.emit(&mut slot, msg, false);
+            return;
+        }
+        let (stage, dep_path, wd) = lifecycle_ids(message);
+        let key = format!("{stage}:{dep_path}");
+        let collapsed = contains_path(wd, "/node_modules/") || contains_path(wd, "tmp/_tmp_");
+        let running = self.format_indented_status(&self.colors.magenta_bright("Running..."));
+        let now = std::time::Instant::now();
+        self.lifecycle.entry(key.clone()).or_insert_with(|| LifecycleEntry {
+            collapsed,
+            label: None,
+            output: Vec::new(),
+            script: String::new(),
+            status: running,
+            start: Some(now),
+        });
+        let exit = matches!(message, LifecycleMessage::Exit { .. });
+        let msg = if self.lifecycle[&key].collapsed {
+            self.render_collapsed(&key, message, dep_path, wd)
+        } else {
+            self.render_script(&key, message)
+        };
+        if exit {
+            self.lifecycle.remove(&key);
+        }
+        let mut slot = self.lifecycle_slots.remove(&key).unwrap_or_default();
+        self.frame.emit(&mut slot, msg, false);
+        self.lifecycle_slots.insert(key, slot);
+    }
+
+    fn update_lifecycle_cache(&mut self, key: &str, message: &LifecycleMessage) {
+        match message {
+            LifecycleMessage::Script { stage, wd, script, .. } => {
+                let prefix =
+                    format!("{} {}", format_prefix(&self.cwd, wd), self.colors.cyan_bright(stage));
+                let max = self.width as isize - visible_width(&prefix) as isize - 2;
+                let line = format!("{prefix}$ {}", cut_line(script, max));
+                self.lifecycle.get_mut(key).unwrap().script = line;
+            }
+            LifecycleMessage::Exit { exit_code, wd, .. } => {
+                let time = self
+                    .lifecycle
+                    .get(key)
+                    .and_then(|e| e.start)
+                    .map(|start| pretty_ms(start.elapsed().as_millis()))
+                    .unwrap_or_default();
+                let status = if *exit_code == 0 {
+                    self.format_indented_status(
+                        &self.colors.magenta_bright(&format!("Done in {time}")),
+                    )
+                } else {
+                    self.format_indented_status(
+                        &self.colors.red(&format!("Failed in {time} at {wd}")),
+                    )
+                };
+                self.lifecycle.get_mut(key).unwrap().status = status;
+            }
+            LifecycleMessage::Stdio { line, stdio, .. } => {
+                let formatted = self.format_indented_output(line, *stdio);
+                self.lifecycle.get_mut(key).unwrap().output.push(formatted);
+            }
+        }
+    }
+
+    fn render_script(&mut self, key: &str, message: &LifecycleMessage) -> String {
+        self.update_lifecycle_cache(key, message);
+        let entry = &self.lifecycle[key];
+        let exit_nonzero =
+            matches!(message, LifecycleMessage::Exit { exit_code, .. } if *exit_code != 0);
+        let mut lines = vec![entry.script.clone()];
+        if !exit_nonzero && entry.output.len() > 10 {
+            lines.push(format!("[{} lines collapsed]", entry.output.len() - 10));
+            lines.extend(entry.output[entry.output.len() - 10..].iter().cloned());
+        } else {
+            lines.extend(entry.output.iter().cloned());
+        }
+        lines.push(entry.status.clone());
+        lines.join("\n")
+    }
+
+    fn render_collapsed(
+        &mut self,
+        key: &str,
+        message: &LifecycleMessage,
+        dep_path: &str,
+        wd: &str,
+    ) -> String {
+        if self.lifecycle[key].label.is_none() {
+            let mut label =
+                highlight_last_folder(&format_prefix_no_trim(&self.cwd, wd), &self.colors);
+            let stage = lifecycle_ids(message).0;
+            if contains_path(wd, "tmp/_tmp_") {
+                let _ = write!(label, " [{dep_path}]");
+            }
+            let _ = write!(label, ": Running {stage} script");
+            self.lifecycle.get_mut(key).unwrap().label = Some(label);
+        }
+        let label = self.lifecycle[key].label.clone().unwrap();
+        let LifecycleMessage::Exit { exit_code, optional, .. } = message else {
+            self.update_lifecycle_cache(key, message);
+            return format!("{label}...");
+        };
+        let time = self
+            .lifecycle
+            .get(key)
+            .and_then(|e| e.start)
+            .map(|start| pretty_ms(start.elapsed().as_millis()))
+            .unwrap_or_default();
+        if *exit_code == 0 {
+            return format!("{label}, done in {time}");
+        }
+        if *optional {
+            return format!("{label}, failed in {time} (skipped as optional)");
+        }
+        format!("{label}, failed in {time}\n{}", self.render_script(key, message))
+    }
+
+    fn stream_lifecycle(&mut self, message: &LifecycleMessage) -> String {
+        let (stage, _dep_path, wd) = lifecycle_ids(message);
+        let prefix = self.lifecycle_prefix(wd, stage);
+        match message {
+            LifecycleMessage::Exit { exit_code, .. } => {
+                if *exit_code == 0 {
+                    format!("{prefix}: Done")
+                } else {
+                    format!("{prefix}: Failed")
+                }
+            }
+            LifecycleMessage::Script { script, .. } => format!("{prefix}$ {script}"),
+            LifecycleMessage::Stdio { line, stdio, .. } => {
+                let line = match stdio {
+                    LifecycleStdio::Stderr => self.colors.grey(line),
+                    LifecycleStdio::Stdout => line.clone(),
+                };
+                format!("{prefix}: {line}")
+            }
+        }
+    }
+
+    fn lifecycle_prefix(&mut self, wd: &str, stage: &str) -> String {
+        let idx = if let Some(idx) = self.lifecycle_colors.get(wd) {
+            *idx
+        } else {
+            let idx = self.color_wheel % COLOR_WHEEL.len();
+            self.lifecycle_colors.insert(wd.to_string(), idx);
+            self.color_wheel += 1;
+            idx
+        };
+        let painted = COLOR_WHEEL[idx](&self.colors, &format_prefix(&self.cwd, wd));
+        format!("{painted} {}", self.colors.cyan_bright(stage))
+    }
+
+    fn format_indented_status(&self, status: &str) -> String {
+        format!("{} {status}", self.colors.magenta_bright("└─"))
+    }
+
+    fn format_indented_output(&self, line: &str, stdio: LifecycleStdio) -> String {
+        let cut = cut_line(line, self.width as isize - 2);
+        let line = match stdio {
+            LifecycleStdio::Stderr => self.colors.grey(&cut),
+            LifecycleStdio::Stdout => cut,
+        };
+        format!("{} {line}", self.colors.magenta_bright("│"))
+    }
+
+    // --- misc one-liners --------------------------------------------------
+
+    fn on_ignored_scripts(&mut self, log: &IgnoredScriptsLog) {
+        if log.package_names.is_empty() {
+            return;
+        }
+        let list = log.package_names.join(", ");
+        self.push_block(format!(
+            "Ignored build scripts: {list}.\nRun \"pnpm approve-builds\" to pick which dependencies should be allowed to run scripts.",
+        ));
+    }
+
+    fn on_config_deps(&mut self, log: &InstallingConfigDepsLog) {
+        let msg = match log.status {
+            InstallingConfigDepsStatus::Started => "Installing config dependencies...".to_string(),
+            InstallingConfigDepsStatus::Done => {
+                let list = log
+                    .deps
+                    .iter()
+                    .map(|dep| format!("{}@{}", dep.name, dep.version))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("Installed config dependencies: {list}")
+            }
+        };
+        let mut slot = std::mem::take(&mut self.config_deps_slot);
+        self.frame.emit(&mut slot, msg, false);
+        self.config_deps_slot = slot;
+    }
+
+    fn on_lockfile_verification(&mut self, message: &LockfileVerificationMessage) {
+        let msg = match message {
+            LockfileVerificationMessage::Cached { lockfile_path, .. } => {
+                let path = self.lockfile_path_suffix(lockfile_path.as_deref());
+                format!(
+                    "{} Lockfile{path} passes supply-chain policies (previously verified)",
+                    self.colors.green("✓"),
+                )
+            }
+            LockfileVerificationMessage::Started { entries, lockfile_path } => {
+                let path = self.lockfile_path_suffix(lockfile_path.as_deref());
+                format!(
+                    "{} Verifying lockfile{path} against supply-chain policies ({})...",
+                    self.colors.cyan("?"),
+                    entries_label(*entries),
+                )
+            }
+            LockfileVerificationMessage::Done { entries, elapsed_ms, lockfile_path } => {
+                let path = self.lockfile_path_suffix(lockfile_path.as_deref());
+                format!(
+                    "{} Lockfile{path} passes supply-chain policies ({} in {})",
+                    self.colors.green("✓"),
+                    entries_label(*entries),
+                    pretty_ms(u128::from(*elapsed_ms)),
+                )
+            }
+            LockfileVerificationMessage::Failed { entries, elapsed_ms, lockfile_path } => {
+                let path = self.lockfile_path_suffix(lockfile_path.as_deref());
+                format!(
+                    "{} Lockfile{path} failed supply-chain policy check ({} in {})",
+                    self.colors.red("✗"),
+                    entries_label(*entries),
+                    pretty_ms(u128::from(*elapsed_ms)),
+                )
+            }
+        };
+        let mut slot = std::mem::take(&mut self.lockfile_verification_slot);
+        self.frame.emit(&mut slot, msg, false);
+        self.lockfile_verification_slot = slot;
+    }
+
+    fn lockfile_path_suffix(&self, lockfile_path: Option<&str>) -> String {
+        let Some(path) = lockfile_path else { return String::new() };
+        let from_expected = relative(&self.cwd, path);
+        let is_direct_child = !from_expected.contains('/') && !from_expected.starts_with("..");
+        if is_direct_child {
+            return String::new();
+        }
+        format!(" at {}", normalize(&relative(&self.cwd, path)))
+    }
+
+    fn on_request_retry(&mut self, log: &RequestRetryLog) {
+        let left = log.max_retries.saturating_sub(log.attempt);
+        let msg = format!(
+            "{} {} error ({}) {} {}\nWill retry in {}. {left} retries left.",
+            log.method,
+            log.url,
+            log.error.message,
+            "—",
+            log.attempt,
+            pretty_ms(u128::from(log.timeout)),
+        );
+        self.push_warning(&msg);
+    }
+
+    fn on_pnpm(&mut self, level: LogLevel, message: &str, prefix: &str) {
+        match level {
+            LogLevel::Debug => {}
+            LogLevel::Warn => self.push_warning(message),
+            LogLevel::Error => self.push_block(message.to_string()),
+            LogLevel::Info => {
+                if prefix.is_empty() || prefix == self.cwd {
+                    self.push_block(message.to_string());
+                }
+            }
+        }
+    }
+
+    fn on_execution_time(&mut self, log: &ExecutionTimeLog) {
+        let elapsed = log.ended_at.saturating_sub(log.started_at);
+        let msg =
+            format!("Done in {} using pacquet v{}", pretty_ms(elapsed), crate::package_version());
+        let mut slot = std::mem::take(&mut self.exec_slot);
+        self.frame.emit(&mut slot, msg, true);
+        self.exec_slot = slot;
+    }
+
+    /// A warning, honoring pnpm's "only show the first
+    /// [`MAX_SHOWN_WARNINGS`], then collapse the rest into a count" rule.
+    fn push_warning(&mut self, message: &str) {
+        self.warnings_counter += 1;
+        if self.append_only || self.warnings_counter <= MAX_SHOWN_WARNINGS {
+            self.push_block(format!("{} {message}", self.colors.warn_label()));
+            return;
+        }
+        let extra = self.warnings_counter - MAX_SHOWN_WARNINGS;
+        let msg = format!("{} {extra} other warnings", self.colors.warn_label());
+        let mut slot = std::mem::take(&mut self.collapsed_warn_slot);
+        self.frame.emit(&mut slot, msg, false);
+        self.collapsed_warn_slot = slot;
+    }
+
+    fn push_block(&mut self, message: String) {
+        let mut slot = BlockSlot::default();
+        self.frame.emit(&mut slot, message, false);
+    }
+}
+
+fn diff_key(kind: DepKind) -> &'static str {
+    match kind {
+        DepKind::Prod => "prod",
+        DepKind::Optional => "optional",
+        DepKind::Peer => "peer",
+        DepKind::Dev => "dev",
+        DepKind::NodeModulesOnly => "nodeModulesOnly",
+    }
+}
+
+type RootFields =
+    (bool, DepKind, String, Option<String>, Option<String>, Option<String>, Option<String>);
+
+fn added_fields(added: &AddedRoot) -> RootFields {
+    (
+        true,
+        DepKind::from_dependency_type(added.dependency_type),
+        added.name.clone(),
+        added.version.clone().or_else(|| added.id.clone()),
+        Some(added.real_name.clone()),
+        added.linked_from.clone(),
+        added.latest.clone(),
+    )
+}
+
+fn removed_fields(removed: &RemovedRoot) -> RootFields {
+    (
+        false,
+        DepKind::from_dependency_type(removed.dependency_type),
+        removed.name.clone(),
+        removed.version.clone(),
+        None,
+        None,
+        None,
+    )
+}
+
+fn lifecycle_ids(message: &LifecycleMessage) -> (&str, &str, &str) {
+    match message {
+        LifecycleMessage::Script { stage, dep_path, wd, .. }
+        | LifecycleMessage::Stdio { stage, dep_path, wd, .. }
+        | LifecycleMessage::Exit { stage, dep_path, wd, .. } => (stage, dep_path, wd),
+    }
+}
+
+fn entries_label(entries: u64) -> String {
+    if entries == 1 { "1 entry".to_string() } else { format!("{entries} entries") }
+}
+
+fn remove_optional_from_prod(manifest: &Value) -> Value {
+    let mut manifest = manifest.clone();
+    let optional: Vec<String> = manifest
+        .get("optionalDependencies")
+        .and_then(Value::as_object)
+        .map(|obj| obj.keys().cloned().collect())
+        .unwrap_or_default();
+    if let Some(deps) = manifest.get_mut("dependencies").and_then(Value::as_object_mut) {
+        for name in optional {
+            deps.remove(&name);
+        }
+    }
+    manifest
+}
+
+fn manifest_dep_versions(manifest: &Value, prop: &str) -> HashMap<String, String> {
+    manifest
+        .get(prop)
+        .and_then(Value::as_object)
+        .map(|obj| {
+            obj.iter()
+                .map(|(name, value)| (name.clone(), value.as_str().unwrap_or_default().to_string()))
+                .collect()
+        })
+        .unwrap_or_default()
+}

--- a/pacquet/crates/default-reporter/src/tests.rs
+++ b/pacquet/crates/default-reporter/src/tests.rs
@@ -1,0 +1,35 @@
+use pacquet_reporter::{
+    FetchingProgressLog, FetchingProgressMessage, LogLevel, ProgressLog, ProgressMessage, StatsLog,
+    StatsMessage,
+};
+
+use super::{LogEvent, is_coalesceable};
+
+#[test]
+fn progress_and_in_progress_downloads_coalesce() {
+    let progress = LogEvent::Progress(ProgressLog {
+        level: LogLevel::Debug,
+        message: ProgressMessage::Resolved {
+            package_id: "foo".to_string(),
+            requester: "/repo".to_string(),
+        },
+    });
+    let downloading = LogEvent::FetchingProgress(FetchingProgressLog {
+        level: LogLevel::Debug,
+        message: FetchingProgressMessage::InProgress {
+            downloaded: 1,
+            package_id: "foo".to_string(),
+        },
+    });
+    assert!(is_coalesceable(&progress));
+    assert!(is_coalesceable(&downloading));
+}
+
+#[test]
+fn stats_renders_immediately() {
+    let stats = LogEvent::Stats(StatsLog {
+        level: LogLevel::Debug,
+        message: StatsMessage::Added { prefix: "/repo".to_string(), added: 1 },
+    });
+    assert!(!is_coalesceable(&stats));
+}

--- a/pacquet/crates/default-reporter/tests/render.rs
+++ b/pacquet/crates/default-reporter/tests/render.rs
@@ -1,0 +1,318 @@
+//! Frame-level tests: drive sequences of `LogEvent`s through `ReporterState`
+//! and assert the rendered output, matching what `@pnpm/cli.default-reporter`
+//! produces for the same events. Colors are constructed off for readable
+//! plain-text assertions and on for the ANSI-specific ones.
+
+use pacquet_default_reporter::{
+    colors::Colors,
+    state::{Output, ReporterState},
+};
+use pacquet_reporter::{
+    AddedRoot, ContextLog, DependencyType, ExecutionTimeLog, LifecycleLog, LifecycleMessage,
+    LifecycleStdio, LogEvent, LogLevel, PackageImportMethod, PackageImportMethodLog, PnpmLog,
+    ProgressLog, ProgressMessage, RootLog, RootMessage, Stage, StageLog, StatsLog, StatsMessage,
+    SummaryLog,
+};
+
+const CWD: &str = "/repo";
+
+fn state(colors: bool) -> ReporterState {
+    ReporterState::new(CWD.to_string(), 80, Colors { enabled: colors }, false)
+}
+
+/// Feed events through the in-place renderer and return the last full frame.
+fn render(state: &mut ReporterState, events: Vec<LogEvent>) -> String {
+    let mut last = String::new();
+    for event in events {
+        if let Output::Frame(frame) = state.handle(&event) {
+            last = frame;
+        }
+    }
+    last
+}
+
+fn progress(status: &str) -> LogEvent {
+    let requester = CWD.to_string();
+    let package_id = "registry.npmjs.org/foo/1.0.0".to_string();
+    let message = match status {
+        "resolved" => ProgressMessage::Resolved { package_id, requester },
+        "fetched" => ProgressMessage::Fetched { package_id, requester },
+        "found_in_store" => ProgressMessage::FoundInStore { package_id, requester },
+        "imported" => ProgressMessage::Imported {
+            method: PackageImportMethod::Hardlink,
+            requester,
+            to: "/repo/node_modules/foo".to_string(),
+        },
+        other => panic!("unknown status {other}"),
+    };
+    LogEvent::Progress(ProgressLog { level: LogLevel::Debug, message })
+}
+
+fn importing_done() -> LogEvent {
+    LogEvent::Stage(StageLog {
+        level: LogLevel::Debug,
+        prefix: CWD.to_string(),
+        stage: Stage::ImportingDone,
+    })
+}
+
+fn added_root(name: &str, version: &str, dt: DependencyType) -> LogEvent {
+    LogEvent::Root(RootLog {
+        level: LogLevel::Debug,
+        message: RootMessage::Added {
+            prefix: CWD.to_string(),
+            added: AddedRoot {
+                name: name.to_string(),
+                real_name: name.to_string(),
+                version: Some(version.to_string()),
+                dependency_type: Some(dt),
+                id: None,
+                latest: None,
+                linked_from: None,
+            },
+        },
+    })
+}
+
+fn summary() -> LogEvent {
+    LogEvent::Summary(SummaryLog { level: LogLevel::Debug, prefix: CWD.to_string() })
+}
+
+#[test]
+fn progress_line_counts_each_status() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![
+            progress("resolved"),
+            progress("resolved"),
+            progress("resolved"),
+            progress("found_in_store"),
+            progress("found_in_store"),
+            progress("imported"),
+        ],
+    );
+    assert_eq!(frame, "Progress: resolved 3, reused 2, downloaded 0, added 1");
+}
+
+#[test]
+fn importing_done_appends_done_suffix() {
+    let mut reporter = state(false);
+    let frame =
+        render(&mut reporter, vec![progress("resolved"), progress("imported"), importing_done()]);
+    assert_eq!(frame, "Progress: resolved 1, reused 0, downloaded 0, added 1, done");
+}
+
+#[test]
+fn stats_render_packages_line_and_bar() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![
+            LogEvent::Stats(StatsLog {
+                level: LogLevel::Debug,
+                message: StatsMessage::Added { prefix: CWD.to_string(), added: 5 },
+            }),
+            LogEvent::Stats(StatsLog {
+                level: LogLevel::Debug,
+                message: StatsMessage::Removed { prefix: CWD.to_string(), removed: 2 },
+            }),
+        ],
+    );
+    assert_eq!(frame, "Packages: +5 -2\n+++++--");
+}
+
+#[test]
+fn stats_bar_is_colored_when_enabled() {
+    let mut reporter = state(true);
+    let frame = render(
+        &mut reporter,
+        vec![LogEvent::Stats(StatsLog {
+            level: LogLevel::Debug,
+            message: StatsMessage::Added { prefix: CWD.to_string(), added: 1 },
+        })],
+    );
+    // green "+1" header, then a single green "+" bar char.
+    assert_eq!(frame, "Packages: \u{1b}[32m+1\u{1b}[39m\n\u{1b}[32m+\u{1b}[39m");
+}
+
+#[test]
+fn summary_groups_by_dependency_type_in_order() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![
+            added_root("bar", "2.0.0", DependencyType::Dev),
+            added_root("foo", "1.0.0", DependencyType::Prod),
+            summary(),
+        ],
+    );
+    assert_eq!(frame, "\ndependencies:\n+ foo 1.0.0\n\ndevDependencies:\n+ bar 2.0.0\n");
+}
+
+#[test]
+fn context_block_renders_when_no_current_lockfile() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![
+            LogEvent::Context(ContextLog {
+                level: LogLevel::Debug,
+                current_lockfile_exists: false,
+                store_dir: "/store".to_string(),
+                virtual_store_dir: "/repo/node_modules/.pnpm".to_string(),
+            }),
+            LogEvent::PackageImportMethod(PackageImportMethodLog {
+                level: LogLevel::Debug,
+                method: PackageImportMethod::Hardlink,
+            }),
+        ],
+    );
+    assert_eq!(
+        frame,
+        "Packages are hard linked from the content-addressable store to the virtual store.\n  \
+         Content-addressable store is at: /store\n  Virtual store is at:             node_modules/.pnpm",
+    );
+}
+
+#[test]
+fn context_block_suppressed_when_lockfile_exists() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![
+            LogEvent::Context(ContextLog {
+                level: LogLevel::Debug,
+                current_lockfile_exists: true,
+                store_dir: "/store".to_string(),
+                virtual_store_dir: "/repo/node_modules/.pnpm".to_string(),
+            }),
+            LogEvent::PackageImportMethod(PackageImportMethodLog {
+                level: LogLevel::Debug,
+                method: PackageImportMethod::Hardlink,
+            }),
+        ],
+    );
+    assert_eq!(frame, "");
+}
+
+#[test]
+fn execution_time_renders_done_footer() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![LogEvent::ExecutionTime(ExecutionTimeLog {
+            level: LogLevel::Debug,
+            started_at: 1000,
+            ended_at: 3500,
+        })],
+    );
+    assert!(frame.starts_with("Done in 2.5s using pacquet v"), "got: {frame}");
+}
+
+#[test]
+fn already_up_to_date_pnpm_log_renders() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![LogEvent::Pnpm(PnpmLog {
+            level: LogLevel::Info,
+            message: "Already up to date".to_string(),
+            prefix: CWD.to_string(),
+        })],
+    );
+    assert_eq!(frame, "Already up to date");
+}
+
+#[test]
+fn full_install_frame_orders_blocks_like_pnpm() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![
+            progress("resolved"),
+            progress("found_in_store"),
+            progress("imported"),
+            LogEvent::Stats(StatsLog {
+                level: LogLevel::Debug,
+                message: StatsMessage::Added { prefix: CWD.to_string(), added: 1 },
+            }),
+            added_root("foo", "1.0.0", DependencyType::Prod),
+            summary(),
+            importing_done(),
+            LogEvent::ExecutionTime(ExecutionTimeLog {
+                level: LogLevel::Debug,
+                started_at: 0,
+                ended_at: 1200,
+            }),
+        ],
+    );
+    assert_eq!(
+        frame,
+        "Packages: +1\n+\n\ndependencies:\n+ foo 1.0.0\n\n\
+         Progress: resolved 1, reused 1, downloaded 0, added 1, done\n\
+         Done in 1.2s using pacquet v0.0.1",
+    );
+}
+
+#[test]
+fn warnings_collapse_after_five() {
+    let mut reporter = state(false);
+    let warn = || {
+        LogEvent::Pnpm(PnpmLog {
+            level: LogLevel::Warn,
+            message: "something".to_string(),
+            prefix: CWD.to_string(),
+        })
+    };
+    let events: Vec<LogEvent> = (0..6).map(|_| warn()).collect();
+    let frame = render(&mut reporter, events);
+    // Five "[WARN] something" lines, then the collapsed count.
+    let lines: Vec<&str> = frame.lines().collect();
+    assert_eq!(lines.len(), 6);
+    assert_eq!(lines[0], "[WARN] something");
+    assert_eq!(lines[5], "[WARN] 1 other warnings");
+}
+
+#[test]
+fn append_only_emits_lines_not_frames() {
+    let mut reporter = ReporterState::new(CWD.to_string(), 80, Colors { enabled: false }, true);
+    let out = reporter.handle(&progress("resolved"));
+    match out {
+        Output::Lines(lines) => {
+            assert_eq!(lines, vec!["Progress: resolved 1, reused 0, downloaded 0, added 0"]);
+        }
+        _ => panic!("append-only should emit Lines"),
+    }
+}
+
+#[test]
+fn lifecycle_script_output_is_grouped_and_indented() {
+    let mut reporter = state(false);
+    let dep_path = "foo@1.0.0";
+    let wd = "/repo/deps/foo"; // not under node_modules → not collapsed
+    let events = vec![
+        LogEvent::Lifecycle(LifecycleLog {
+            level: LogLevel::Debug,
+            message: LifecycleMessage::Script {
+                dep_path: dep_path.to_string(),
+                optional: false,
+                script: "node build.js".to_string(),
+                stage: "postinstall".to_string(),
+                wd: wd.to_string(),
+            },
+        }),
+        LogEvent::Lifecycle(LifecycleLog {
+            level: LogLevel::Debug,
+            message: LifecycleMessage::Stdio {
+                dep_path: dep_path.to_string(),
+                line: "building".to_string(),
+                stage: "postinstall".to_string(),
+                stdio: LifecycleStdio::Stdout,
+                wd: wd.to_string(),
+            },
+        }),
+    ];
+    let frame = render(&mut reporter, events);
+    assert_eq!(frame, "deps/foo postinstall$ node build.js\n│ building\n└─ Running...");
+}

--- a/pacquet/crates/package-manager/src/create_symlink_layout.rs
+++ b/pacquet/crates/package-manager/src/create_symlink_layout.rs
@@ -75,6 +75,7 @@ pub fn create_symlink_layout(
             &layout.slot_dir(&target).join("node_modules").join(&target_name_str),
             &virtual_node_modules_dir.join(&alias_name_str),
         )
+        .map(drop)
     })
 }
 

--- a/pacquet/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/pacquet/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -436,13 +436,22 @@ fn link_one_importer<Reporter: self::Reporter>(
     entries.par_iter().try_for_each(|entry| -> Result<(), SymlinkDirectDependenciesError> {
         let ResolvedEntry { name, spec, group, name_str, target } = entry;
 
-        symlink_package(target, &modules_dir.join(name_str)).map_err(|source| {
+        let outcome = symlink_package(target, &modules_dir.join(name_str)).map_err(|source| {
             SymlinkDirectDependenciesError::SymlinkPackage {
                 importer_id: importer_id.to_string(),
                 name: name_str.clone(),
                 source,
             }
         })?;
+
+        // Only a freshly-created symlink is a `pnpm:root added`. A symlink
+        // already pointing at the target is "reused", and pnpm skips the
+        // event for it (`if ((await symlinkDependency(...)).reused) return`
+        // at linkDirectDeps.ts:127-129), so a `pacquet add <new>` summary
+        // lists only the new dependency, not every already-linked one.
+        if outcome.reused {
+            return Ok(());
+        }
 
         // `pnpm:root added` mirrors pnpm's emit at
         // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/linking/direct-dep-linker/src/linkDirectDeps.ts#L131>:

--- a/pacquet/crates/package-manager/src/symlink_direct_dependencies/tests.rs
+++ b/pacquet/crates/package-manager/src/symlink_direct_dependencies/tests.rs
@@ -379,6 +379,92 @@ fn empty_importers_is_a_no_op() {
     drop(dir);
 }
 
+/// A symlink already pointing at its target is "reused", and a reused
+/// symlink is NOT a `pnpm:root added` — so a re-link (e.g. `pacquet add`
+/// over an already-installed project) emits an event only for genuinely
+/// new dependencies, not every previously-linked one. Mirrors pnpm's
+/// `if ((await symlinkDependency(...)).reused) return` at
+/// <https://github.com/pnpm/pnpm/blob/39101f5e37/installing/linking/direct-dep-linker/src/linkDirectDeps.ts#L127-L129>.
+#[test]
+fn reused_symlinks_do_not_emit_pnpm_root_added() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let dir = tempdir().unwrap();
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = modules_dir;
+    config.virtual_store_dir = virtual_store_dir.clone();
+    let config = config.leak();
+
+    let target = virtual_store_dir.join("fastify@4.0.0").join("node_modules").join("fastify");
+    fs::create_dir_all(&target).expect("create symlink target");
+
+    let mut prod = ResolvedDependencyMap::new();
+    prod.insert(
+        "fastify".parse().expect("parse fastify pkg name"),
+        ResolvedDependencySpec {
+            specifier: "^4.0.0".to_string(),
+            version: "4.0.0".parse::<pacquet_lockfile::PkgVerPeer>().unwrap().into(),
+        },
+    );
+    let project_snapshot =
+        ProjectSnapshot { dependencies: Some(prod), ..ProjectSnapshot::default() };
+    let mut importers = HashMap::new();
+    importers.insert(Lockfile::ROOT_IMPORTER_KEY.to_string(), project_snapshot);
+    let layout = crate::VirtualStoreLayout::legacy(
+        config.virtual_store_dir.clone(),
+        config.virtual_store_dir_max_length as usize,
+    );
+    let link = || {
+        SymlinkDirectDependencies {
+            config,
+            layout: &layout,
+            importers: &importers,
+            dependency_groups: [DependencyGroup::Prod],
+            workspace_root: &project_root,
+            skipped: &SkippedSnapshots::default(),
+            link_only: false,
+            public_hoist_targets: None,
+        }
+        .run::<RecordingReporter>()
+        .expect("symlink should succeed");
+    };
+
+    // First link: the symlink is created, so one `pnpm:root added`.
+    link();
+    assert_eq!(count_added(&EVENTS), 1, "the first link of a new dep emits one added event");
+
+    // Second link over the now-existing symlink: reused, so no event.
+    EVENTS.lock().unwrap().clear();
+    link();
+    assert_eq!(count_added(&EVENTS), 0, "re-linking a reused symlink emits no added event");
+
+    drop(dir);
+}
+
+fn count_added(events: &Mutex<Vec<LogEvent>>) -> usize {
+    events
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|event| {
+            matches!(event, LogEvent::Root(RootLog { message: RootMessage::Added { .. }, .. }))
+        })
+        .count()
+}
+
 /// Two importers under one workspace root each produce their own
 /// `pnpm:root added` event with the importer's `rootDir` as the
 /// event prefix. Mirrors upstream's per-project emit at

--- a/pacquet/crates/package-manager/src/symlink_package.rs
+++ b/pacquet/crates/package-manager/src/symlink_package.rs
@@ -1,6 +1,6 @@
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_fs::force_symlink_dir;
+use pacquet_fs::{ForceSymlinkOutcome, force_symlink_dir};
 use std::{
     io,
     path::{Path, PathBuf},
@@ -43,10 +43,14 @@ pub enum SymlinkPackageError {
 /// `pacquet_fs::symlink_dir`, which left stale symlinks in place
 /// across re-installs that retargeted a dependency — a divergence
 /// from upstream's overwrite-by-default behavior.
+/// Returns the [`ForceSymlinkOutcome`], so callers can mirror pnpm's
+/// `if ((await symlinkDependency(...)).reused) return` — the direct-dependency
+/// linker only emits a `pnpm:root added` event for symlinks it actually
+/// created, not for ones already pointing at the target.
 pub fn symlink_package(
     symlink_target: &Path,
     symlink_path: &Path,
-) -> Result<(), SymlinkPackageError> {
+) -> Result<ForceSymlinkOutcome, SymlinkPackageError> {
     // `force_symlink_dir` handles missing parent dirs via its own
     // `NotFound` retry that calls `create_dir_all` once and reissues
     // the symlink syscall. Pre-creating the parent here would just
@@ -60,6 +64,5 @@ pub fn symlink_package(
             symlink_path: symlink_path.to_path_buf(),
             error,
         }
-    })?;
-    Ok(())
+    })
 }

--- a/pacquet/crates/reporter/src/lib.rs
+++ b/pacquet/crates/reporter/src/lib.rs
@@ -223,6 +223,15 @@ pub enum LogEvent {
     /// Emit site: <https://github.com/pnpm/pnpm/blob/3b12eb27de/hooks/pnpmfile/src/requireHooks.ts#L244-L249>.
     #[serde(rename = "pnpm:hook")]
     Hook(HookLog),
+
+    /// Total command wall-clock time (`pnpm:execution-time`). Emitted once
+    /// per CLI run after the command finishes; the default reporter renders
+    /// it as the `Done in <time> using <pkg> v<version>` footer.
+    ///
+    /// Upstream: <https://github.com/pnpm/pnpm/blob/086c5e91e8/core/core-loggers/src/executionTimeLogger.ts>.
+    /// Emit site: <https://github.com/pnpm/pnpm/blob/086c5e91e8/pnpm/src/main.ts>.
+    #[serde(rename = "pnpm:execution-time")]
+    ExecutionTime(ExecutionTimeLog),
 }
 
 /// `pnpm:context` payload.
@@ -806,6 +815,17 @@ pub struct HookLog {
     pub hook: String,
     pub message: String,
     pub prefix: String,
+}
+
+/// `pnpm:execution-time` payload. `started_at` / `ended_at` are
+/// Unix-epoch milliseconds; the reporter renders their difference. Field
+/// names match pnpm's wire shape (`startedAt` / `endedAt`).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutionTimeLog {
+    pub level: LogLevel,
+    pub started_at: u128,
+    pub ended_at: u128,
 }
 
 /// Severity level on the [bunyan]-shaped envelope.


### PR DESCRIPTION
## What

Adds a new **`pacquet-default-reporter`** crate that renders the same terminal output as pnpm's `@pnpm/cli.default-reporter` for `install` / `add` / `update` / `remove`, and makes it pacquet's **default** reporter (it previously defaulted to `silent`).

Covered: the context block, the live `Progress: resolved/reused/downloaded/added` line, `Packages: +X -Y` with the `+++---` bar, `Already up to date`, the `dependencies:` / `devDependencies:` diff summary, big-tarball download lines, lifecycle build-script output (color wheel, `│` indent, collapsing, `└─ Done in`), and a `Done in …` footer.

## How

The reporter is a `pacquet_reporter::Reporter` sink whose state lives behind a process-global mutex (the trait's `emit` is a static method). Each existing `pnpm:*` `LogEvent` is folded into a `ReporterState` that recomputes the terminal frame — this replaces pnpm's RxJS observable graph, which only exists because pnpm's reporter is a separate process reading a log stream. The frame model (fixed progress/footer blocks pinned below scrolling blocks) ports `mergeOutputs.ts`; each channel renderer ports the matching `reporterForClient/report*.ts`.

It renders in place on a TTY (cursor-up + clear redraw) and falls back to append-only output off-TTY, matching pnpm. Colors go through `owo-colors`, gated so `NO_COLOR` and non-TTY disable them like chalk. Terminal width comes from a `TIOCGWINSZ` ioctl. **No new third-party dependencies** — `owo-colors`, `libc`, and `serde_json` were already in the workspace.

A new `pnpm:execution-time` channel was added to `pacquet-reporter` to drive the footer.

## Parity note

The footer reads `Done in … using pacquet v<version>` rather than `using pnpm v…` — printing "pnpm" in pacquet's own output would misreport the tool identity. This is the only intentional text difference; everything else matches pnpm's output.

## Testing

- 13 frame-level tests drive `LogEvent` sequences through the renderer and assert exact output (progress, stats bar, summary ordering, context, lifecycle, append-only, warning collapse, execution time).
- Verified against the live registry: `pacquet install` produces pnpm-matching frames both piped (append-only) and under a pty (in-place, colored).
- `cargo fmt`/`clippy --all-targets`/`cargo doc -D warnings`/Dylint (Perfectionist) and `typos` pass; reporter and CLI `run`/`init`/`install` test files pass.

This is a pacquet-only change, so no changeset is included.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a pnpm-style default visual terminal reporter with progress coalescing, stats bars, dependency summaries, and colorized formatting.
  * Added per-command execution-time reporting after commands complete.

* **Behavior Changes**
  * The default reporter is now enabled by default for improved out-of-the-box terminal output.

* **Bug Fixes**
  * Prevented duplicate “root added” messages when direct-dependency symlinks are reused.

* **Tests**
  * Added rendering/coalescing coverage for the new reporter and added a symlink reuse test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->