### PR TITLE
fix: warnings in `store|config` should be printed to `stderr`

### DIFF
--- a/.changeset/store-use-stderr.md
+++ b/.changeset/store-use-stderr.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Reporter output (warnings, progress) for `pnpm store` and `pnpm config` subcommands now goes to stderr instead of stdout. This fixes scripts that capture their stdout (e.g. `PNPM_STORE=$(pnpm store path)`, `pnpm config list --json | jq`) from getting warnings mixed into the result.

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -36,6 +36,13 @@ import { syncEnvLockfile } from './syncEnvLockfile.js'
 
 export const REPORTER_INITIALIZED = Symbol('reporterInitialized')
 
+// Commands whose reporter output (warnings, progress) must go to stderr so that
+// their stdout stays a clean, machine-readable value. For example, `pnpm store
+// path` is meant to be captured with `STORE=$(pnpm store path)` and `pnpm config
+// list --json` to be piped into `jq`; a warning mixed into stdout would corrupt
+// both.
+const COMMANDS_WITH_STDERR_REPORTER = new Set(['dlx', 'create', 'config', 'set', 'get', 'sbom', 'with', 'store'])
+
 loudRejection()
 
 function isRootOnlyPatterns (patterns: string[]): boolean {
@@ -139,9 +146,9 @@ export async function main (inputArgv: string[]): Promise<void> {
     // `cmd === 'config'` at this layer, so list them explicitly — users can
     // hit the #10684 crash via any of these three entry points.
     ;({ config, context } = await installConfigDepsAndLoadHooks(config, context, {
-      tolerateConfigDependenciesErrors: isConfigCommand
+      tolerateConfigDependenciesErrors: isConfigCommand,
     }) as { config: typeof config, context: ConfigContext })
-    if (isDlxOrCreateCommand || isConfigCommand || cmd === 'sbom' || cmd === 'with' || cmd === 'store') {
+    if (cmd != null && COMMANDS_WITH_STDERR_REPORTER.has(cmd)) {
       config.useStderr = true
     }
     config.argv = argv

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -95,6 +95,7 @@ export async function main (inputArgv: string[]): Promise<void> {
     // we don't need the write permission to it. Related issue: #2700
     const globalDirShouldAllowWrite = cmd !== 'root'
     const isDlxOrCreateCommand = cmd === 'dlx' || cmd === 'create'
+    const isConfigCommand = cmd === 'config' || cmd === 'set' || cmd === 'get'
     if (cmd === 'link' && cliParams.length === 0) {
       cliOptions.global = true
     }
@@ -138,9 +139,9 @@ export async function main (inputArgv: string[]): Promise<void> {
     // `cmd === 'config'` at this layer, so list them explicitly — users can
     // hit the #10684 crash via any of these three entry points.
     ;({ config, context } = await installConfigDepsAndLoadHooks(config, context, {
-      tolerateConfigDependenciesErrors: cmd === 'config' || cmd === 'set' || cmd === 'get',
+      tolerateConfigDependenciesErrors: isConfigCommand
     }) as { config: typeof config, context: ConfigContext })
-    if (isDlxOrCreateCommand || cmd === 'sbom' || cmd === 'with') {
+    if (isDlxOrCreateCommand || isConfigCommand || cmd === 'sbom' || cmd === 'with' || cmd === 'store') {
       config.useStderr = true
     }
     config.argv = argv


### PR DESCRIPTION
Closes https://github.com/pnpm/pnpm/issues/12432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated reporter output for the `store` command so warnings/progress are sent to **stderr** instead of **stdout**, avoiding contamination of captured output in automation.
  * Extended the same stdout/stderr reporter routing to `config`-related subcommands (`config`, `set`, `get`) for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->