### PR TITLE
fix: detect reverted catalog entries on install

### DIFF
--- a/.changeset/twelve-catalogs-revert.md
+++ b/.changeset/twelve-catalogs-revert.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/catalogs.config": patch
+"@pnpm/installing.commands": patch
+"pnpm": patch
+---
+
+Fix `pnpm install` reporting "Already up to date" after a catalog entry in `pnpm-workspace.yaml` was reverted to a previous version. After an update modified a catalog, the workspace state cache stored the pre-update catalog versions, so reverting the entry back to its original version was not detected as an outdated state [#12418](https://github.com/pnpm/pnpm/issues/12418).

--- a/catalogs/config/src/index.ts
+++ b/catalogs/config/src/index.ts
@@ -1,1 +1,2 @@
 export { getCatalogsFromWorkspaceManifest } from './getCatalogsFromWorkspaceManifest.js'
+export { mergeCatalogs } from './mergeCatalogs.js'

--- a/catalogs/config/src/mergeCatalogs.ts
+++ b/catalogs/config/src/mergeCatalogs.ts
@@ -6,14 +6,34 @@ import type { Catalog, Catalogs } from '@pnpm/catalogs.types'
  * changes produced by an install (`updatedCatalogs`) back into the catalogs
  * read at startup, so the result reflects what was actually written to
  * `pnpm-workspace.yaml`.
+ *
+ * Catalog and dependency names originate from `pnpm-workspace.yaml`, so the
+ * result is built from null-prototype records and entries are copied with
+ * `Object.defineProperty`. A name like `__proto__` then becomes an ordinary
+ * own property instead of mutating a prototype.
  */
 export function mergeCatalogs (...catalogsList: Array<Catalogs | undefined>): Catalogs {
-  const result: Record<string, Record<string, string | undefined>> = {}
+  const result = Object.create(null) as Record<string, Catalog>
   for (const catalogs of catalogsList) {
     if (catalogs == null) continue
-    for (const [catalogName, catalog] of Object.entries(catalogs)) {
+    for (const catalogName of Object.keys(catalogs)) {
+      const catalog = catalogs[catalogName]
       if (catalog == null) continue
-      result[catalogName] = { ...result[catalogName], ...(catalog as Catalog) }
+      const target: Record<string, string | undefined> = result[catalogName] ?? Object.create(null)
+      for (const dependencyName of Object.keys(catalog)) {
+        Object.defineProperty(target, dependencyName, {
+          value: catalog[dependencyName],
+          writable: true,
+          enumerable: true,
+          configurable: true,
+        })
+      }
+      Object.defineProperty(result, catalogName, {
+        value: target,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      })
     }
   }
   return result

--- a/catalogs/config/src/mergeCatalogs.ts
+++ b/catalogs/config/src/mergeCatalogs.ts
@@ -1,0 +1,20 @@
+import type { Catalog, Catalogs } from '@pnpm/catalogs.types'
+
+/**
+ * Deep-merges catalog definitions, later arguments taking precedence over
+ * earlier ones at the individual entry level. Use it to fold the catalog
+ * changes produced by an install (`updatedCatalogs`) back into the catalogs
+ * read at startup, so the result reflects what was actually written to
+ * `pnpm-workspace.yaml`.
+ */
+export function mergeCatalogs (...catalogsList: Array<Catalogs | undefined>): Catalogs {
+  const result: Record<string, Record<string, string | undefined>> = {}
+  for (const catalogs of catalogsList) {
+    if (catalogs == null) continue
+    for (const [catalogName, catalog] of Object.entries(catalogs)) {
+      if (catalog == null) continue
+      result[catalogName] = { ...result[catalogName], ...(catalog as Catalog) }
+    }
+  }
+  return result
+}

--- a/catalogs/config/test/mergeCatalogs.test.ts
+++ b/catalogs/config/test/mergeCatalogs.test.ts
@@ -39,3 +39,15 @@ test('skips nullish catalog arguments and nullish named catalogs', () => {
     default: { foo: '1.0.0' },
   })
 })
+
+test('treats dangerous catalog and dependency names as ordinary own properties', () => {
+  // Catalogs parsed from YAML/JSON can carry `__proto__` as an own property,
+  // unlike an object literal where `{ __proto__: ... }` sets the prototype.
+  const malicious = JSON.parse('{"__proto__":{"polluted":"yes"},"default":{"__proto__":"1.0.0","constructor":"2.0.0"}}')
+  const merged = mergeCatalogs(malicious)
+  expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+  expect(Object.prototype.hasOwnProperty.call(merged, '__proto__')).toBe(true)
+  expect(Object.prototype.hasOwnProperty.call(merged.default, '__proto__')).toBe(true)
+  expect((merged.default as Record<string, unknown>).__proto__).toBe('1.0.0')
+  expect((merged.default as Record<string, unknown>).constructor).toBe('2.0.0')
+})

--- a/catalogs/config/test/mergeCatalogs.test.ts
+++ b/catalogs/config/test/mergeCatalogs.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@jest/globals'
+import { mergeCatalogs } from '@pnpm/catalogs.config'
+
+test('returns an empty catalog when nothing is passed', () => {
+  expect(mergeCatalogs()).toEqual({})
+  expect(mergeCatalogs(undefined, undefined)).toEqual({})
+})
+
+test('later entries override earlier ones at the dependency level', () => {
+  expect(mergeCatalogs(
+    {
+      default: { foo: '1.0.0', bar: '1.0.0' },
+      named: { baz: '1.0.0' },
+    },
+    {
+      default: { foo: '2.0.0' },
+    }
+  )).toEqual({
+    default: { foo: '2.0.0', bar: '1.0.0' },
+    named: { baz: '1.0.0' },
+  })
+})
+
+test('adds catalog entries that did not exist in the base', () => {
+  expect(mergeCatalogs(
+    { default: { foo: '1.0.0' } },
+    { default: { bar: '1.0.0' }, named: { baz: '1.0.0' } }
+  )).toEqual({
+    default: { foo: '1.0.0', bar: '1.0.0' },
+    named: { baz: '1.0.0' },
+  })
+})
+
+test('skips nullish catalog arguments and nullish named catalogs', () => {
+  expect(mergeCatalogs(
+    undefined,
+    { default: { foo: '1.0.0' }, named: undefined }
+  )).toEqual({
+    default: { foo: '1.0.0' },
+  })
+})

--- a/installing/commands/package.json
+++ b/installing/commands/package.json
@@ -35,6 +35,7 @@
     "@inquirer/prompts": "catalog:",
     "@pnpm/building.after-install": "workspace:*",
     "@pnpm/building.policy": "workspace:*",
+    "@pnpm/catalogs.config": "workspace:*",
     "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/cli.command": "workspace:*",
     "@pnpm/cli.common-cli-options-help": "workspace:*",

--- a/installing/commands/src/installDeps.ts
+++ b/installing/commands/src/installDeps.ts
@@ -1,6 +1,8 @@
 import path from 'node:path'
 
 import { buildProjects } from '@pnpm/building.after-install'
+import { mergeCatalogs } from '@pnpm/catalogs.config'
+import type { Catalogs } from '@pnpm/catalogs.types'
 import type { CommandHandler } from '@pnpm/cli.command'
 import {
   readProjectManifestOnly,
@@ -426,7 +428,7 @@ export async function installDeps (
     if (!opts.lockfileOnly) {
       await updateWorkspaceState({
         allProjects,
-        settings: opts,
+        settings: withUpdatedCatalogs(opts, updatedCatalogs),
         workspaceDir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
         pnpmfiles: opts.pnpmfile,
         filteredInstall: allProjects.length !== Object.keys(opts.selectedProjectsGraph ?? {}).length,
@@ -485,7 +487,7 @@ export async function installDeps (
       selectedProjectsGraph,
       workspaceDir: opts.workspaceDir, // Otherwise TypeScript doesn't understand that is not undefined
       runPacquet,
-    }, 'install')
+    }, 'install', updatedCatalogs)
 
     if (opts.ignoreScripts) return
 
@@ -508,7 +510,7 @@ export async function installDeps (
     if (!opts.lockfileOnly) {
       await updateWorkspaceState({
         allProjects,
-        settings: opts,
+        settings: withUpdatedCatalogs(opts, updatedCatalogs),
         workspaceDir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
         pnpmfiles: opts.pnpmfile,
         filteredInstall: allProjects.length !== Object.keys(opts.selectedProjectsGraph ?? {}).length,
@@ -528,20 +530,36 @@ async function recursiveInstallThenUpdateWorkspaceState (
   allProjects: Project[],
   params: string[],
   opts: RecursiveOptions & WorkspaceStateSettings,
-  cmdFullName: CommandFullName
+  cmdFullName: CommandFullName,
+  updatedCatalogs?: Catalogs
 ): Promise<boolean | string> {
   const recursiveResult = await recursive(allProjects, params, opts, cmdFullName)
   if (!opts.lockfileOnly) {
     await updateWorkspaceState({
       allProjects,
-      settings: opts,
+      settings: withUpdatedCatalogs(opts, updatedCatalogs, recursiveResult.updatedCatalogs),
       workspaceDir: opts.workspaceDir,
       pnpmfiles: opts.pnpmfile,
       filteredInstall: allProjects.length !== Object.keys(opts.selectedProjectsGraph ?? {}).length,
       configDependencies: opts.configDependencies,
     })
   }
-  return recursiveResult
+  return recursiveResult.passed
+}
+
+/**
+ * Folds the catalog entries written to `pnpm-workspace.yaml` during this
+ * install into the catalogs read at startup. The workspace state cache records
+ * these so a later install detects when a catalog entry was reverted; without
+ * this, the cache would keep the stale pre-install catalogs and report
+ * "Already up to date" even though the manifest changed.
+ */
+function withUpdatedCatalogs<T extends { catalogs?: Catalogs }> (
+  settings: T,
+  ...updatedCatalogs: Array<Catalogs | undefined>
+): T {
+  if (updatedCatalogs.every((catalogs) => catalogs == null)) return settings
+  return { ...settings, catalogs: mergeCatalogs(settings.catalogs, ...updatedCatalogs) }
 }
 
 function severityStringToNumber (severity: VulnerabilitySeverity): number {

--- a/installing/commands/src/recursive.ts
+++ b/installing/commands/src/recursive.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 
+import { mergeCatalogs } from '@pnpm/catalogs.config'
 import type { Catalogs } from '@pnpm/catalogs.types'
 import type { CommandHandler } from '@pnpm/cli.command'
 import {
@@ -469,8 +470,10 @@ export async function recursive (
         if (opts.save !== false) {
           await writeProjectManifest(newManifest)
           if (newCatalogsAddition) {
-            updatedCatalogs ??= {}
-            Object.assign(updatedCatalogs, newCatalogsAddition)
+            // Per-project additions are partial maps keyed by catalog name then
+            // dependency. Merge at the dependency level so two projects updating
+            // different entries of the same catalog don't clobber each other.
+            updatedCatalogs = mergeCatalogs(updatedCatalogs, newCatalogsAddition)
           }
         }
         if (ignoredBuilds?.size) {

--- a/installing/commands/src/recursive.ts
+++ b/installing/commands/src/recursive.ts
@@ -144,21 +144,31 @@ export type RecursiveOptions = CreateStoreControllerOptions & Pick<Config,
 
 export type CommandFullName = 'install' | 'add' | 'remove' | 'update' | 'import'
 
+export interface RecursiveResult {
+  passed: boolean | string
+  /**
+   * Catalog entries written to `pnpm-workspace.yaml` during this install.
+   * The caller folds these into the catalogs recorded in the workspace state
+   * cache so that reverting a catalog entry is detected as an outdated state.
+   */
+  updatedCatalogs?: Catalogs
+}
+
 export async function recursive (
   allProjects: Project[],
   params: string[],
   opts: RecursiveOptions,
   cmdFullName: CommandFullName
-): Promise<boolean | string> {
+): Promise<RecursiveResult> {
   if (allProjects.length === 0) {
     // It might make sense to throw an exception in this case
-    return false
+    return { passed: false }
   }
 
   const pkgs = Object.values(opts.selectedProjectsGraph).map((wsPkg) => wsPkg.package)
 
   if (pkgs.length === 0) {
-    return false
+    return { passed: false }
   }
   const manifestsByPath = getManifestsByPath(allProjects)
 
@@ -225,7 +235,7 @@ export async function recursive (
     const calculatedRepositoryRoot = await fs.realpath(calculateRepositoryRoot(opts.workspaceDir, importers.map(x => x.rootDir)))
     const isFromWorkspace = isSubdir.bind(null, calculatedRepositoryRoot)
     importers = await pFilter(importers, async ({ rootDirRealPath }) => isFromWorkspace(rootDirRealPath))
-    if (importers.length === 0) return true
+    if (importers.length === 0) return { passed: true }
     let mutation: 'install' | 'installSome' | 'uninstallSome'
     switch (cmdFullName) {
       case 'remove':
@@ -341,7 +351,7 @@ export async function recursive (
       await Promise.all(promises)
     }
     await handleIgnoredBuilds(opts, ignoredBuilds)
-    return true
+    return { passed: true, updatedCatalogs }
   }
 
   const pkgPaths = (Object.keys(opts.selectedProjectsGraph) as ProjectRootDir[]).sort()
@@ -527,7 +537,7 @@ export async function recursive (
       'None of the specified packages were found in the dependencies of any of the projects.')
   }
 
-  return true
+  return { passed: true, updatedCatalogs }
 }
 
 function calculateRepositoryRoot (

--- a/installing/commands/tsconfig.json
+++ b/installing/commands/tsconfig.json
@@ -28,6 +28,9 @@
       "path": "../../building/policy"
     },
     {
+      "path": "../../catalogs/config"
+    },
+    {
       "path": "../../catalogs/types"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5246,6 +5246,9 @@ importers:
       '@pnpm/building.policy':
         specifier: workspace:*
         version: link:../../building/policy
+      '@pnpm/catalogs.config':
+        specifier: workspace:*
+        version: link:../../catalogs/config
       '@pnpm/catalogs.types':
         specifier: workspace:*
         version: link:../../catalogs/types

--- a/pnpm/test/catalogUpToDate.ts
+++ b/pnpm/test/catalogUpToDate.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@jest/globals'
+import { prepare } from '@pnpm/prepare'
+import { addDistTag } from '@pnpm/testing.registry-mock'
+import type { ProjectManifest } from '@pnpm/types'
+import { writeYamlFileSync } from 'write-yaml-file'
+
+import { execPnpm } from './utils/index.js'
+
+test('reverting a catalog entry after updating it is detected as an outdated state (#12418)', async () => {
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
+
+  const manifest: ProjectManifest = {
+    name: 'test-catalog-up-to-date',
+    version: '0.0.0',
+    private: true,
+    dependencies: {
+      '@pnpm.e2e/foo': 'catalog:',
+    },
+  }
+  const project = prepare(manifest)
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['.'],
+    catalog: {
+      '@pnpm.e2e/foo': '100.0.0',
+    },
+  })
+
+  await execPnpm(['install'])
+  expect(project.readCurrentLockfile().importers['.'].dependencies?.['@pnpm.e2e/foo'].version).toBe('100.0.0')
+
+  await execPnpm(['update', '@pnpm.e2e/foo', '--latest'])
+  expect(project.readCurrentLockfile().importers['.'].dependencies?.['@pnpm.e2e/foo'].version).toBe('100.1.0')
+
+  // Restore the catalog entry to the version it had before the update. A
+  // subsequent install must notice that the workspace state is no longer up to
+  // date and reinstall the previous version instead of reporting
+  // "Already up to date".
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['.'],
+    catalog: {
+      '@pnpm.e2e/foo': '100.0.0',
+    },
+  })
+
+  await execPnpm(['install'])
+  expect(project.readCurrentLockfile().importers['.'].dependencies?.['@pnpm.e2e/foo'].version).toBe('100.0.0')
+})


### PR DESCRIPTION
## Problem

Closes https://github.com/pnpm/pnpm/issues/12418.

When `pnpm update` (or `add`) bumps a **catalog** version in `pnpm-workspace.yaml`, the install correctly writes the new version to the manifest, lockfile, and `node_modules` — but it saved the **workspace-state cache** (`node_modules/.pnpm-workspace-state-v1.json`) using the *pre-update* in-memory config, which was read at process start, before the manifest was rewritten.

So after an update the cache held the **old** catalog version. Reverting the catalog entry back to that old version and running `pnpm install` then compared the freshly-read config (old) against the cache (also old) → they matched → **"Already up to date"**, even though `node_modules` still had the updated version.

### Reproduction

```yaml
# pnpm-workspace.yaml
packages: ['.']
catalog:
  is-positive: 1.0.0
```

```jsonc
// package.json
{ "dependencies": { "is-positive": "catalog:" } }
```

```
pnpm install                       # installs is-positive 1.0.0
pnpm update is-positive --latest   # catalog -> 3.1.0, installs 3.1.0
# revert catalog back to 1.0.0 in pnpm-workspace.yaml
pnpm install                       # BUG: "Already up to date", still 3.1.0
```

## Fix

The post-install catalogs (`updatedCatalogs`, already computed and written to the manifest) are now folded into the catalogs recorded in the workspace state, so the cache reflects what is actually on disk.

- `@pnpm/catalogs.config` — new `mergeCatalogs()` helper (deep two-level merge, later entries win).
- `@pnpm/installing.commands` — wrap the settings passed to `updateWorkspaceState` with the merged catalogs at every save site (single-project add, install, and the recursive path including the `linkWorkspacePackages` branch); `recursive()` now returns the catalogs it wrote so the workspace-recursive path can persist them.

## pacquet parity

No pacquet change needed — pacquet already handles this correctly. Its `update` threads the post-update catalogs into the install via `catalogs_override`, and `build_workspace_state` derives the stored catalogs from that same value, so its cache already records the new versions. This fix brings the TypeScript CLI to parity with pacquet's behavior.

## Tests

- New e2e regression `pnpm/test/catalogUpToDate.ts` (matches the manually reproduced broken behavior).
- Unit tests for `mergeCatalogs`.
- Verified `saveCatalog`, `addRecursive`/`importRecursive`/`miscRecursive`, `update`/`remove`/`import` command suites, `deps/status`, and `verifyDepsBeforeRun` e2e all pass.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm install` incorrectly reporting “Already up to date” after a `pnpm-workspace.yaml` catalog entry is reverted to an earlier version. Workspace state is now correctly detected as changed, ensuring the dependency version is reconciled.
* **Improvements**
  * Improved how catalog updates are carried through recursive installs so catalog entries merge correctly without clobbering unrelated dependency entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->