### PR TITLE
feat(ecosystem-e2e): ecosystem test harness across pnpm/pacquet and node_modules layouts

### DIFF
--- a/.github/workflows/ecosystem-e2e.yml
+++ b/.github/workflows/ecosystem-e2e.yml
@@ -51,11 +51,12 @@ jobs:
           pnpm --filter pnpm run compile
 
       - name: Wrap the built pnpm bundle as an executable
-        # The harness takes a single executable for --pnpm; the bundle is a
-        # plain .cjs that needs `node`. Wrap it so the run tests this repo's
-        # pnpm, not the one provisioned by pnpm/setup.
+        # The harness takes a single executable for --pnpm; the launcher is a
+        # .cjs that needs `node`. Wrap the repo's bin entry (which loads
+        # dist/pnpm.mjs) so the run tests this repo's pnpm, not the one
+        # provisioned by pnpm/setup.
         run: |
-          printf '#!/usr/bin/env bash\nexec node "%s/pnpm/dist/pnpm.cjs" "$@"\n' "$PWD" > pnpm-built
+          printf '#!/usr/bin/env bash\nexec node "%s/pnpm/bin/pnpm.cjs" "$@"\n' "$PWD" > pnpm-built
           chmod +x pnpm-built
 
       - name: Run ecosystem E2E

--- a/.github/workflows/ecosystem-e2e.yml
+++ b/.github/workflows/ecosystem-e2e.yml
@@ -24,6 +24,9 @@ jobs:
   ecosystem-e2e:
     name: Ecosystem E2E / ${{ matrix.stack }}
     runs-on: ubuntu-latest
+    # Bound the blast radius: a hung build or serve subprocess can't pin a
+    # runner indefinitely.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ecosystem-e2e.yml
+++ b/.github/workflows/ecosystem-e2e.yml
@@ -1,0 +1,78 @@
+name: Ecosystem E2E
+
+# Installs real-world JS stacks (Next.js, Vite, …) with both the pnpm CLI
+# and pacquet, under both the default isolated layout and the global virtual
+# store, then builds each app. The binary axis catches pnpm↔pacquet parity
+# gaps; the layout axis catches breakage introduced by the global virtual
+# store. Runs on a daily cron rather than per-PR — the installs are slow and
+# track upstream framework releases, so a red cell is investigated, not
+# treated as a merge blocker.
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ecosystem-e2e:
+    name: Ecosystem E2E / ${{ matrix.stack }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # One stack per job so a slow or flaky stack can't mask the others
+        # and each gets its own log artifact.
+        stack: [next, vite-react, angular, astro, sveltekit, nuxt, react-router]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/setup@b1cac37306e39c21283b9dd6cb0ac288fb35ba6b
+
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/rustup
+
+      - name: Build pacquet
+        run: cargo build --release --bin pacquet
+
+      - name: Build the pnpm CLI bundle
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter pnpm run compile
+
+      - name: Wrap the built pnpm bundle as an executable
+        # The harness takes a single executable for --pnpm; the bundle is a
+        # plain .cjs that needs `node`. Wrap it so the run tests this repo's
+        # pnpm, not the one provisioned by pnpm/setup.
+        run: |
+          printf '#!/usr/bin/env bash\nexec node "%s/pnpm/dist/pnpm.cjs" "$@"\n' "$PWD" > pnpm-built
+          chmod +x pnpm-built
+
+      - name: Run ecosystem E2E
+        run: |
+          cargo run --release -p pacquet-ecosystem-e2e -- \
+            --pnpm "$PWD/pnpm-built" \
+            --pacquet "$PWD/target/release/pacquet" \
+            --binary both \
+            --layout both \
+            --stack ${{ matrix.stack }} \
+            --work-dir "$RUNNER_TEMP/ecosystem-e2e-work"
+
+      - name: Upload cell logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ecosystem-e2e-logs-${{ matrix.stack }}
+          path: ${{ runner.temp }}/ecosystem-e2e-work/**/*.log
+          retention-days: 7
+          if-no-files-found: ignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3675,6 +3675,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pacquet-ecosystem-e2e"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "serde_json",
+ "which 8.0.2",
+]
+
+[[package]]
 name = "pacquet-engine-runtime-bun-resolver"
 version = "0.0.1"
 dependencies = [

--- a/pacquet/tasks/ecosystem-e2e/Cargo.toml
+++ b/pacquet/tasks/ecosystem-e2e/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name                  = "pacquet-ecosystem-e2e"
+version               = "0.0.0"
+publish               = false
+authors.workspace     = true
+description.workspace = true
+edition.workspace     = true
+homepage.workspace    = true
+keywords.workspace    = true
+license.workspace     = true
+repository.workspace  = true
+
+[[bin]]
+name = "ecosystem-e2e"
+path = "src/main.rs"
+
+[dependencies]
+clap       = { workspace = true }
+serde_json = { workspace = true }
+which      = { workspace = true }
+
+[lints]
+workspace = true

--- a/pacquet/tasks/ecosystem-e2e/README.md
+++ b/pacquet/tasks/ecosystem-e2e/README.md
@@ -18,10 +18,10 @@ It exists for two reasons specific to this repo:
 
 Every run is the cross product of three axes:
 
-```
+```text
 binary:  pnpm | pacquet            (--binary)
 layout:  isolated | global-virtual-store   (--layout)
-stack:   next | vite-react | …     (--stack, defaults to all)
+stack:   next | vite-react | ...   (--stack, defaults to all)
 ```
 
 Each cell runs four stages, stopping at the first failure:

--- a/pacquet/tasks/ecosystem-e2e/README.md
+++ b/pacquet/tasks/ecosystem-e2e/README.md
@@ -1,0 +1,71 @@
+# ecosystem-e2e
+
+Installs real-world JavaScript stacks with both the pnpm CLI and pacquet,
+across both `node_modules` layouts, then builds each app to prove the
+produced layout actually works.
+
+It exists for two reasons specific to this repo:
+
+- **pacquet parity** — pacquet is a Rust port of pnpm. A real framework that
+  installs and builds under pnpm but not under pacquet is a far better parity
+  signal than any unit test.
+- **global virtual store** — the global virtual store relocates where
+  dependencies physically live, the same class of change that forced Yarn to
+  build ecosystem tests for Plug'n'Play. Running real stacks under it is the
+  only way to find tools that break on the new layout.
+
+## The grid
+
+Every run is the cross product of three axes:
+
+```
+binary:  pnpm | pacquet            (--binary)
+layout:  isolated | global-virtual-store   (--layout)
+stack:   next | vite-react | …     (--stack, defaults to all)
+```
+
+Each cell runs four stages, stopping at the first failure:
+
+1. **prepare** — scaffold the project once (with `pnpm dlx`, no install), copy
+   it into the cell, write a `pnpm-workspace.yaml` pinning an isolated
+   store/cache and the layout.
+2. **install** — `<binary> install`.
+3. **build** — run the project's build script with `node_modules/.bin` on
+   `PATH`, no package manager involved, so the build can't re-install and mask
+   the install under test. Proves the layout resolves at **bundle time**.
+4. **serve** — boot the production server, poll it over HTTP until it answers,
+   and require a non-error (`2xx`/`3xx`) response, then kill it. Proves the
+   layout works at **runtime** — request-time `require`, SSR, native addons —
+   which a build alone does not exercise. Stacks without a server skip this
+   stage; `--skip-serve` skips it everywhere for quick iteration.
+
+## Run it
+
+From the repo root:
+
+```sh
+# Whole grid, every stack (pacquet must be built: cargo build --release --bin pacquet)
+cargo run -p pacquet-ecosystem-e2e -- --pacquet ./target/release/pacquet
+
+# Just pnpm, one stack, both layouts
+cargo run -p pacquet-ecosystem-e2e -- --binary pnpm --stack vite-react
+
+# Iterate without re-scaffolding
+cargo run -p pacquet-ecosystem-e2e -- --stack vite-react --keep
+```
+
+Exit code is non-zero if any cell fails. Per-cell logs are written to
+`<work-dir>/cells/<cell-id>/cell.log`.
+
+## Adding a stack
+
+Append a `Stack` to `STACKS` in `src/stacks.rs`. Pin the generator to a major
+version — an unpinned `@latest` turns an upstream framework release into a red
+cell that looks like a pnpm/pacquet regression. Bump pins deliberately.
+
+## CI
+
+`.github/workflows/ecosystem-e2e.yml` runs the grid on a daily cron (one job
+per stack) against this repo's built pnpm bundle and a freshly built pacquet.
+A red cell is something to investigate, not a merge blocker — hence cron, not
+per-PR.

--- a/pacquet/tasks/ecosystem-e2e/src/cli_args.rs
+++ b/pacquet/tasks/ecosystem-e2e/src/cli_args.rs
@@ -1,0 +1,119 @@
+use clap::{Parser, ValueEnum};
+use std::path::PathBuf;
+
+/// Install real-world JavaScript stacks with pnpm and pacquet across
+/// `node_modules` layouts, then build each app to prove the produced layout
+/// actually works. The cross product of `--binary` × `--layout` × stacks is
+/// the grid: the binary axis catches pnpm↔pacquet parity gaps, the layout
+/// axis catches breakage introduced by the global virtual store.
+#[derive(Debug, Parser)]
+pub struct CliArgs {
+    /// Path to the pnpm executable. Always required: pnpm scaffolds every
+    /// stack (via `pnpm dlx`) regardless of which binary installs it.
+    #[clap(long, default_value = "pnpm")]
+    pub pnpm: String,
+
+    /// Path to the pacquet executable. Only required when `--binary`
+    /// includes pacquet.
+    #[clap(long, default_value = "pacquet")]
+    pub pacquet: String,
+
+    /// Which package managers perform the install.
+    #[clap(long, value_enum, default_value_t = BinaryChoice::Both)]
+    pub binary: BinaryChoice,
+
+    /// Which `node_modules` layouts to exercise.
+    #[clap(long, value_enum, default_value_t = LayoutChoice::Both)]
+    pub layout: LayoutChoice,
+
+    /// Restrict the run to stacks whose name matches (repeatable). Defaults
+    /// to every known stack.
+    #[clap(long = "stack")]
+    pub stacks: Vec<String>,
+
+    /// Directory holding the scaffolded templates and per-cell work trees.
+    /// Wiped at the start of every run unless `--keep` is passed.
+    #[clap(long, default_value = "ecosystem-e2e-work")]
+    pub work_dir: PathBuf,
+
+    /// Keep the work directory from a previous run instead of wiping it, so
+    /// already-scaffolded templates can be reused while iterating locally.
+    #[clap(long)]
+    pub keep: bool,
+
+    /// Stop after the build stage instead of booting and probing each app.
+    /// The serve stage is what proves the layout works at runtime, so this
+    /// is for quick iteration only.
+    #[clap(long)]
+    pub skip_serve: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum BinaryChoice {
+    Pnpm,
+    Pacquet,
+    Both,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum LayoutChoice {
+    Isolated,
+    GlobalVirtualStore,
+    Both,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Binary {
+    Pnpm,
+    Pacquet,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Layout {
+    Isolated,
+    GlobalVirtualStore,
+}
+
+impl Binary {
+    pub fn label(self) -> &'static str {
+        match self {
+            Binary::Pnpm => "pnpm",
+            Binary::Pacquet => "pacquet",
+        }
+    }
+}
+
+impl Layout {
+    pub fn label(self) -> &'static str {
+        match self {
+            Layout::Isolated => "isolated",
+            Layout::GlobalVirtualStore => "global-virtual-store",
+        }
+    }
+
+    /// Value written for `enableGlobalVirtualStore` in the cell's
+    /// `pnpm-workspace.yaml`.
+    pub fn enable_global_virtual_store(self) -> bool {
+        matches!(self, Layout::GlobalVirtualStore)
+    }
+}
+
+impl BinaryChoice {
+    pub fn expand(self) -> Vec<Binary> {
+        match self {
+            BinaryChoice::Pnpm => vec![Binary::Pnpm],
+            BinaryChoice::Pacquet => vec![Binary::Pacquet],
+            BinaryChoice::Both => vec![Binary::Pnpm, Binary::Pacquet],
+        }
+    }
+}
+
+impl LayoutChoice {
+    pub fn expand(self) -> Vec<Layout> {
+        match self {
+            LayoutChoice::Isolated => vec![Layout::Isolated],
+            LayoutChoice::GlobalVirtualStore => vec![Layout::GlobalVirtualStore],
+            LayoutChoice::Both => vec![Layout::Isolated, Layout::GlobalVirtualStore],
+        }
+    }
+}

--- a/pacquet/tasks/ecosystem-e2e/src/main.rs
+++ b/pacquet/tasks/ecosystem-e2e/src/main.rs
@@ -44,7 +44,7 @@ fn main() -> ExitCode {
         let scaffold_log = template_root.join(format!("{}.scaffold.log", stack.name));
         eprintln!("== scaffolding {} ({}) ==", stack.name, stack.description);
         let template_project =
-            match scaffold_template(&args.pnpm, stack, &template_root, &scaffold_log) {
+            match scaffold_template(&args.pnpm, stack, &template_root, &scaffold_log, args.keep) {
                 Ok(path) => path,
                 Err(message) => {
                     // A failed scaffold dooms every cell of this stack; record

--- a/pacquet/tasks/ecosystem-e2e/src/main.rs
+++ b/pacquet/tasks/ecosystem-e2e/src/main.rs
@@ -1,0 +1,141 @@
+#![cfg_attr(dylint_lib = "perfectionist", feature(register_tool))]
+#![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
+
+mod cli_args;
+mod runner;
+mod stacks;
+
+use cli_args::{Binary, CliArgs};
+use runner::{Cell, Outcome, run_cell, scaffold_template};
+use std::{fs, path::Path, process::ExitCode};
+use which::which;
+
+fn main() -> ExitCode {
+    let args: CliArgs = clap::Parser::parse();
+
+    let binaries = args.binary.expand();
+    let layouts = args.layout.expand();
+    let selected = match stacks::select(&args.stacks) {
+        Ok(stacks) => stacks,
+        Err(unknown) => {
+            eprintln!("Unknown stack {unknown:?}. Known stacks: {}", known_stack_names());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    ensure_program(&args.pnpm);
+    if binaries.contains(&Binary::Pacquet) {
+        ensure_program(&args.pacquet);
+    }
+
+    let work_dir = &args.work_dir;
+    if !args.keep && work_dir.exists() {
+        fs::remove_dir_all(work_dir).unwrap_or_else(|error| panic!("wipe {work_dir:?}: {error}"));
+    }
+    let template_root = work_dir.join("templates");
+    let cells_root = work_dir.join("cells");
+    fs::create_dir_all(&template_root)
+        .unwrap_or_else(|error| panic!("create {template_root:?}: {error}"));
+    fs::create_dir_all(&cells_root)
+        .unwrap_or_else(|error| panic!("create {cells_root:?}: {error}"));
+
+    let mut report: Vec<(String, Outcome)> = Vec::new();
+    for stack in &selected {
+        let scaffold_log = template_root.join(format!("{}.scaffold.log", stack.name));
+        eprintln!("== scaffolding {} ({}) ==", stack.name, stack.description);
+        let template_project =
+            match scaffold_template(&args.pnpm, stack, &template_root, &scaffold_log) {
+                Ok(path) => path,
+                Err(message) => {
+                    // A failed scaffold dooms every cell of this stack; record
+                    // them all so the report stays a complete grid.
+                    eprintln!("   scaffold FAILED: {message}");
+                    for &binary in &binaries {
+                        for &layout in &layouts {
+                            let cell = Cell { stack, binary, layout };
+                            report.push((
+                                cell.id(),
+                                Outcome {
+                                    passed: false,
+                                    duration_secs: 0.0,
+                                    stage: "scaffold",
+                                    message: message.clone(),
+                                    log_path: scaffold_log.clone(),
+                                },
+                            ));
+                        }
+                    }
+                    continue;
+                }
+            };
+
+        for &binary in &binaries {
+            for &layout in &layouts {
+                let cell = Cell { stack, binary, layout };
+                let id = cell.id();
+                eprintln!("== running {id} ==");
+                let outcome = run_cell(
+                    &cell,
+                    &template_project,
+                    &cells_root,
+                    &args.pnpm,
+                    &args.pacquet,
+                    !args.skip_serve,
+                );
+                eprintln!(
+                    "   {} in {:.1}s{}",
+                    if outcome.passed { "PASS" } else { "FAIL" },
+                    outcome.duration_secs,
+                    if outcome.passed {
+                        String::new()
+                    } else {
+                        format!(" at {}: {}", outcome.stage, outcome.message)
+                    },
+                );
+                report.push((id, outcome));
+            }
+        }
+    }
+
+    print_report(&report);
+    if report.iter().all(|(_, outcome)| outcome.passed) {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}
+
+fn print_report(report: &[(String, Outcome)]) {
+    println!("\n=== Ecosystem E2E results ===");
+    let id_width = report.iter().map(|(id, _)| id.len()).max().unwrap_or(0).max(4);
+    for (id, outcome) in report {
+        let detail = if outcome.passed {
+            String::new()
+        } else {
+            format!("[{}] {} (log: {})", outcome.stage, outcome.message, outcome.log_path.display())
+        };
+        println!(
+            "{:<id_width$}  {:<4}  {:>6.1}s  {detail}",
+            id,
+            if outcome.passed { "PASS" } else { "FAIL" },
+            outcome.duration_secs,
+        );
+    }
+    let failed = report.iter().filter(|(_, outcome)| !outcome.passed).count();
+    println!("\n{} cell(s), {failed} failed", report.len());
+}
+
+fn ensure_program(program: &str) {
+    if Path::new(program).is_file() {
+        return;
+    }
+    match which(program) {
+        Ok(_) => {}
+        Err(which::Error::CannotFindBinaryPath) => panic!("Cannot find {program:?} in $PATH"),
+        Err(error) => panic!("resolving {program:?}: {error}"),
+    }
+}
+
+fn known_stack_names() -> String {
+    stacks::STACKS.iter().map(|stack| stack.name).collect::<Vec<_>>().join(", ")
+}

--- a/pacquet/tasks/ecosystem-e2e/src/runner.rs
+++ b/pacquet/tasks/ecosystem-e2e/src/runner.rs
@@ -58,7 +58,7 @@ pub fn scaffold_template(
     fs::create_dir_all(&template_dir)
         .map_err(|error| format!("create {template_dir:?}: {error}"))?;
     for command in stack.scaffold {
-        let mut process = Command::new(pnpm);
+        let mut process = sandboxed_command(pnpm);
         process.current_dir(&template_dir).arg("dlx").arg(command.spec).args(command.args);
         run(
             &format!("pnpm dlx {} {}", command.spec, command.args.join(" ")),
@@ -106,7 +106,7 @@ pub fn run_cell(
         Binary::Pnpm => pnpm,
         Binary::Pacquet => pacquet,
     };
-    let mut install = Command::new(install_binary);
+    let mut install = sandboxed_command(install_binary);
     install.current_dir(&project_dir).arg("install");
     if let Some(failed) = outcome("install", run("install", &mut install, &log_path)) {
         return failed;
@@ -189,9 +189,52 @@ fn run_build_script(project_dir: &Path, script_name: &str, log_path: &Path) -> R
         .and_then(serde_json::Value::as_str)
         .ok_or_else(|| format!("no `{script_name}` script in {manifest_path:?}"))?;
 
-    let mut process = Command::new("sh");
+    let mut process = sandboxed_command("sh");
     process.current_dir(project_dir).arg("-c").arg(script).env("PATH", bin_path(project_dir)?);
     run(&format!("run {script_name}: {script}"), &mut process, log_path)
+}
+
+/// Environment variables an install/build/serve subprocess legitimately
+/// needs. Everything else is scrubbed, so a lifecycle script from an
+/// untrusted package can't read ambient CI secrets (`GITHUB_TOKEN`, npm auth
+/// tokens, etc.). Build/serve callers override `PATH` with a
+/// `node_modules/.bin`-prefixed one; the rest inherit it from here.
+const ENV_PASSTHROUGH: &[&str] = &[
+    "PATH",
+    "HOME",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TERM",
+    "USER",
+    "LOGNAME",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+    "NODE_EXTRA_CA_CERTS",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+];
+
+/// A [`Command`] whose environment is scrubbed down to [`ENV_PASSTHROUGH`].
+/// Used for every launch that runs third-party code — scaffolding,
+/// installs, and the build/serve scripts — so unattended lifecycle scripts
+/// can't exfiltrate secrets from the parent environment.
+fn sandboxed_command(program: &str) -> Command {
+    let mut command = Command::new(program);
+    command.env_clear();
+    for key in ENV_PASSTHROUGH {
+        if let Some(value) = std::env::var_os(key) {
+            command.env(key, value);
+        }
+    }
+    command
 }
 
 /// `PATH` with the project's `node_modules/.bin` prepended, so locally
@@ -228,7 +271,7 @@ fn run_serve(project_dir: &Path, serve: &Serve, log_path: &Path) -> Result<(), S
     let _ =
         writeln!(log, "\n$ serve: {command} (probe http://127.0.0.1:{port}{})", serve.ready_path);
 
-    let mut child = Command::new("sh")
+    let mut child = sandboxed_command("sh")
         .current_dir(project_dir)
         .arg("-c")
         // `exec` replaces the shell with the server so the spawned PID is the

--- a/pacquet/tasks/ecosystem-e2e/src/runner.rs
+++ b/pacquet/tasks/ecosystem-e2e/src/runner.rs
@@ -1,0 +1,333 @@
+use crate::{
+    cli_args::{Binary, Layout},
+    stacks::{PROJECT_DIR, Serve, Stack},
+};
+use std::{
+    ffi::OsString,
+    fs::{self, File, OpenOptions},
+    io::{Read, Write},
+    net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+/// One grid cell: a stack installed by a binary under a layout.
+#[derive(Debug)]
+pub struct Cell<'stack> {
+    pub stack: &'stack Stack,
+    pub binary: Binary,
+    pub layout: Layout,
+}
+
+#[derive(Debug)]
+pub struct Outcome {
+    pub passed: bool,
+    pub duration_secs: f64,
+    pub stage: &'static str,
+    pub message: String,
+    pub log_path: PathBuf,
+}
+
+impl Cell<'_> {
+    pub fn id(&self) -> String {
+        format!("{}--{}--{}", self.stack.name, self.binary.label(), self.layout.label())
+    }
+}
+
+/// Scaffold a stack into `<template_root>/<stack>` once, without installing
+/// dependencies. The generated tree is later copied into each cell.
+pub fn scaffold_template(
+    pnpm: &str,
+    stack: &Stack,
+    template_root: &Path,
+    log_path: &Path,
+) -> Result<PathBuf, String> {
+    let template_dir = template_root.join(stack.name);
+    fs::create_dir_all(&template_dir)
+        .map_err(|error| format!("create {template_dir:?}: {error}"))?;
+    for command in stack.scaffold {
+        let mut process = Command::new(pnpm);
+        process.current_dir(&template_dir).arg("dlx").arg(command.spec).args(command.args);
+        run(
+            &format!("pnpm dlx {} {}", command.spec, command.args.join(" ")),
+            &mut process,
+            log_path,
+        )?;
+    }
+    let project_dir = template_dir.join(PROJECT_DIR);
+    if !project_dir.is_dir() {
+        return Err(format!("scaffold did not produce {project_dir:?}"));
+    }
+    Ok(project_dir)
+}
+
+/// Install and build a single cell. Returns whichever stage failed first.
+pub fn run_cell(
+    cell: &Cell,
+    template_project: &Path,
+    cells_root: &Path,
+    pnpm: &str,
+    pacquet: &str,
+    serve: bool,
+) -> Outcome {
+    let started = Instant::now();
+    let cell_dir = cells_root.join(cell.id());
+    let project_dir = cell_dir.join(PROJECT_DIR);
+    let log_path = cell_dir.join("cell.log");
+
+    let outcome = |stage: &'static str, result: Result<(), String>| -> Option<Outcome> {
+        result.err().map(|message| Outcome {
+            passed: false,
+            duration_secs: started.elapsed().as_secs_f64(),
+            stage,
+            message,
+            log_path: log_path.clone(),
+        })
+    };
+
+    if let Some(failed) =
+        outcome("prepare", prepare_cell(template_project, &cell_dir, &project_dir, cell))
+    {
+        return failed;
+    }
+
+    let install_binary = match cell.binary {
+        Binary::Pnpm => pnpm,
+        Binary::Pacquet => pacquet,
+    };
+    let mut install = Command::new(install_binary);
+    install.current_dir(&project_dir).arg("install");
+    if let Some(failed) = outcome("install", run("install", &mut install, &log_path)) {
+        return failed;
+    }
+
+    if let Some(failed) =
+        outcome("build", run_build_script(&project_dir, cell.stack.build_script, &log_path))
+    {
+        return failed;
+    }
+
+    let serve_spec = serve.then_some(cell.stack.serve.as_ref()).flatten();
+    if let Some(spec) = serve_spec
+        && let Some(failed) = outcome("serve", run_serve(&project_dir, spec, &log_path))
+    {
+        return failed;
+    }
+
+    Outcome {
+        passed: true,
+        duration_secs: started.elapsed().as_secs_f64(),
+        stage: "done",
+        message: String::new(),
+        log_path,
+    }
+}
+
+fn prepare_cell(
+    template_project: &Path,
+    cell_dir: &Path,
+    project_dir: &Path,
+    cell: &Cell,
+) -> Result<(), String> {
+    fs::create_dir_all(cell_dir).map_err(|error| format!("create {cell_dir:?}: {error}"))?;
+    if project_dir.exists() {
+        fs::remove_dir_all(project_dir)
+            .map_err(|error| format!("clean {project_dir:?}: {error}"))?;
+    }
+    copy_tree(template_project, project_dir)?;
+    write_workspace_yaml(cell_dir, project_dir, cell.layout)
+}
+
+/// Pin the store and cache inside the cell so pnpm and pacquet never share a
+/// store, and so every cell starts cold. The explicit
+/// `enableGlobalVirtualStore` matters under CI: CI defaults it to `false`,
+/// but an explicit value in `pnpm-workspace.yaml` is respected.
+///
+/// `dangerouslyAllowAllBuilds` lets dependency build scripts run unattended
+/// (esbuild, etc.) so the build stage exercises a real, fully-built
+/// `node_modules` instead of stopping at an approval prompt. That is the
+/// point of an ecosystem run, not a security stance — these are throwaway
+/// projects scaffolded from pinned generators.
+fn write_workspace_yaml(cell_dir: &Path, project_dir: &Path, layout: Layout) -> Result<(), String> {
+    let store_dir = cell_dir.join("store");
+    let cache_dir = cell_dir.join("cache");
+    let contents = format!(
+        "enableGlobalVirtualStore: {}\ndangerouslyAllowAllBuilds: true\nstoreDir: {}\ncacheDir: {}\n",
+        layout.enable_global_virtual_store(),
+        store_dir.display(),
+        cache_dir.display(),
+    );
+    let path = project_dir.join("pnpm-workspace.yaml");
+    fs::write(&path, contents).map_err(|error| format!("write {path:?}: {error}"))
+}
+
+/// Run a `package.json` script with `node_modules/.bin` on `PATH`, without
+/// going through any package manager. The install is the thing under test;
+/// the build is just a layout-agnostic check that the produced
+/// `node_modules` is usable, so it must not let pnpm or pacquet re-install
+/// and mask the result.
+fn run_build_script(project_dir: &Path, script_name: &str, log_path: &Path) -> Result<(), String> {
+    let manifest_path = project_dir.join("package.json");
+    let manifest_text = fs::read_to_string(&manifest_path)
+        .map_err(|error| format!("read {manifest_path:?}: {error}"))?;
+    let manifest: serde_json::Value = serde_json::from_str(&manifest_text)
+        .map_err(|error| format!("parse {manifest_path:?}: {error}"))?;
+    let script = manifest
+        .get("scripts")
+        .and_then(|scripts| scripts.get(script_name))
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| format!("no `{script_name}` script in {manifest_path:?}"))?;
+
+    let mut process = Command::new("sh");
+    process.current_dir(project_dir).arg("-c").arg(script).env("PATH", bin_path(project_dir)?);
+    run(&format!("run {script_name}: {script}"), &mut process, log_path)
+}
+
+/// `PATH` with the project's `node_modules/.bin` prepended, so locally
+/// installed binaries (next, vite, …) resolve ahead of anything global.
+fn bin_path(project_dir: &Path) -> Result<OsString, String> {
+    let bin_dir = project_dir.join("node_modules").join(".bin");
+    match std::env::var_os("PATH") {
+        Some(existing) => {
+            let mut entries = vec![bin_dir];
+            entries.extend(std::env::split_paths(&existing));
+            std::env::join_paths(entries).map_err(|error| format!("compose PATH: {error}"))
+        }
+        None => Ok(bin_dir.into_os_string()),
+    }
+}
+
+/// Start the built app, poll it over HTTP until it serves a non-error
+/// response, then tear it down. Proves the produced `node_modules` works at
+/// runtime, not just at bundle time. The server is always killed before
+/// returning, whatever the outcome.
+fn run_serve(project_dir: &Path, serve: &Serve, log_path: &Path) -> Result<(), String> {
+    let port = pick_free_port()?;
+    let command = serve
+        .command
+        .iter()
+        .map(|token| token.replace("{port}", &port.to_string()))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let mut log = OpenOptions::new()
+        .append(true)
+        .open(log_path)
+        .map_err(|error| format!("open log {log_path:?}: {error}"))?;
+    let _ =
+        writeln!(log, "\n$ serve: {command} (probe http://127.0.0.1:{port}{})", serve.ready_path);
+
+    let mut child = Command::new("sh")
+        .current_dir(project_dir)
+        .arg("-c")
+        // `exec` replaces the shell with the server so the spawned PID is the
+        // server itself, killable directly without a leftover shell wrapper.
+        .arg(format!("exec {command}"))
+        .env("PATH", bin_path(project_dir)?)
+        // Servers that take their port via env rather than a flag (nitro,
+        // react-router-serve, …) honor these; for the rest the explicit
+        // `{port}` flag wins and PORT is harmless.
+        .env("PORT", port.to_string())
+        .env("HOST", "127.0.0.1")
+        .stdin(Stdio::null())
+        .stdout(clone_handle(&log, log_path)?)
+        .stderr(clone_handle(&log, log_path)?)
+        .spawn()
+        .map_err(|error| format!("spawn server `{command}`: {error}"))?;
+
+    let result = wait_until_serving(&mut child, port, serve);
+    let _ = child.kill();
+    let _ = child.wait();
+    result
+}
+
+fn wait_until_serving(
+    child: &mut std::process::Child,
+    port: u16,
+    serve: &Serve,
+) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(serve.timeout_secs);
+    loop {
+        if let Ok(Some(status)) = child.try_wait() {
+            return Err(format!("server exited before serving ({status})"));
+        }
+        match probe(port, serve.ready_path) {
+            // Any HTTP reply means the server booted; a non-error status means
+            // it actually served the route through the installed layout.
+            Ok(code) if (200..400).contains(&code) => return Ok(()),
+            Ok(code) => return Err(format!("server answered HTTP {code} at {}", serve.ready_path)),
+            Err(error) if Instant::now() >= deadline => {
+                return Err(format!("not serving within {}s (last: {error})", serve.timeout_secs));
+            }
+            Err(_) => {}
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+}
+
+/// Issue one `GET` and return the HTTP status code, or an error if the
+/// server isn't accepting connections / didn't answer with a status line.
+fn probe(port: u16, path: &str) -> Result<u16, String> {
+    let address = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+    let mut stream = TcpStream::connect_timeout(&address, Duration::from_secs(2))
+        .map_err(|error| format!("connect: {error}"))?;
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
+    let request = format!("GET {path} HTTP/1.0\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n");
+    stream.write_all(request.as_bytes()).map_err(|error| format!("write request: {error}"))?;
+    let mut response = String::new();
+    stream.read_to_string(&mut response).map_err(|error| format!("read response: {error}"))?;
+    let status_line = response.lines().next().ok_or("empty response")?;
+    status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|code| code.parse().ok())
+        .ok_or_else(|| format!("unparsable status line: {status_line:?}"))
+}
+
+fn pick_free_port() -> Result<u16, String> {
+    let listener =
+        TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).map_err(|error| format!("bind: {error}"))?;
+    listener.local_addr().map(|addr| addr.port()).map_err(|error| format!("local_addr: {error}"))
+}
+
+fn run(label: &str, command: &mut Command, log_path: &Path) -> Result<(), String> {
+    let mut log = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .map_err(|error| format!("open log {log_path:?}: {error}"))?;
+    let _ = writeln!(log, "\n$ {label}");
+    let stdout = clone_handle(&log, log_path)?;
+    let stderr = clone_handle(&log, log_path)?;
+    let status = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr))
+        .status()
+        .map_err(|error| format!("spawn `{label}`: {error}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("`{label}` exited with {status} (see {})", log_path.display()))
+    }
+}
+
+fn clone_handle(log: &File, log_path: &Path) -> Result<File, String> {
+    log.try_clone().map_err(|error| format!("clone log handle {log_path:?}: {error}"))
+}
+
+fn copy_tree(from: &Path, to: &Path) -> Result<(), String> {
+    let status = Command::new("cp")
+        .arg("-R")
+        .arg(from)
+        .arg(to)
+        .status()
+        .map_err(|error| format!("spawn cp: {error}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("cp -R {from:?} {to:?} exited with {status}"))
+    }
+}

--- a/pacquet/tasks/ecosystem-e2e/src/runner.rs
+++ b/pacquet/tasks/ecosystem-e2e/src/runner.rs
@@ -85,6 +85,9 @@ pub fn run_cell(
     let cell_dir = cells_root.join(cell.id());
     let project_dir = cell_dir.join(PROJECT_DIR);
     let log_path = cell_dir.join("cell.log");
+    // Start each run with a fresh log so reruns (notably under `--keep`) don't
+    // interleave with stale output.
+    let _ = fs::remove_file(&log_path);
 
     let outcome = |stage: &'static str, result: Result<(), String>| -> Option<Outcome> {
         result.err().map(|message| Outcome {
@@ -197,8 +200,8 @@ fn run_build_script(project_dir: &Path, script_name: &str, log_path: &Path) -> R
 /// Environment variables an install/build/serve subprocess legitimately
 /// needs. Everything else is scrubbed, so a lifecycle script from an
 /// untrusted package can't read ambient CI secrets (`GITHUB_TOKEN`, npm auth
-/// tokens, etc.). Build/serve callers override `PATH` with a
-/// `node_modules/.bin`-prefixed one; the rest inherit it from here.
+/// tokens, etc.) out of the environment. Build/serve callers override `PATH`
+/// with a `node_modules/.bin`-prefixed one; the rest inherit it from here.
 const ENV_PASSTHROUGH: &[&str] = &[
     "PATH",
     "HOME",
@@ -225,7 +228,7 @@ const ENV_PASSTHROUGH: &[&str] = &[
 /// A [`Command`] whose environment is scrubbed down to [`ENV_PASSTHROUGH`].
 /// Used for every launch that runs third-party code — scaffolding,
 /// installs, and the build/serve scripts — so unattended lifecycle scripts
-/// can't exfiltrate secrets from the parent environment.
+/// can't read ambient secrets out of the parent environment.
 fn sandboxed_command(program: &str) -> Command {
     let mut command = Command::new(program);
     command.env_clear();
@@ -257,26 +260,28 @@ fn bin_path(project_dir: &Path) -> Result<OsString, String> {
 /// returning, whatever the outcome.
 fn run_serve(project_dir: &Path, serve: &Serve, log_path: &Path) -> Result<(), String> {
     let port = pick_free_port()?;
-    let command = serve
-        .command
-        .iter()
-        .map(|token| token.replace("{port}", &port.to_string()))
-        .collect::<Vec<_>>()
-        .join(" ");
+    let args: Vec<String> =
+        serve.command.iter().map(|token| token.replace("{port}", &port.to_string())).collect();
+    let (program, rest) = args.split_first().ok_or("serve command is empty")?;
+    // Run the argv directly off the project's `.bin` instead of joining it
+    // into a `sh -c` string, so tokens keep their boundaries and don't need
+    // shell quoting. The spawned PID is the server itself, so it's killable.
+    let program_path = project_dir.join("node_modules").join(".bin").join(program);
 
     let mut log = OpenOptions::new()
         .append(true)
         .open(log_path)
         .map_err(|error| format!("open log {log_path:?}: {error}"))?;
-    let _ =
-        writeln!(log, "\n$ serve: {command} (probe http://127.0.0.1:{port}{})", serve.ready_path);
+    let _ = writeln!(
+        log,
+        "\n$ serve: {} (probe http://127.0.0.1:{port}{})",
+        args.join(" "),
+        serve.ready_path,
+    );
 
-    let mut child = sandboxed_command("sh")
+    let mut child = sandboxed_command(&program_path.to_string_lossy())
         .current_dir(project_dir)
-        .arg("-c")
-        // `exec` replaces the shell with the server so the spawned PID is the
-        // server itself, killable directly without a leftover shell wrapper.
-        .arg(format!("exec {command}"))
+        .args(rest)
         .env("PATH", bin_path(project_dir)?)
         // Servers that take their port via env rather than a flag (nitro,
         // react-router-serve, etc.) honor these; for the rest the explicit
@@ -287,7 +292,7 @@ fn run_serve(project_dir: &Path, serve: &Serve, log_path: &Path) -> Result<(), S
         .stdout(clone_handle(&log, log_path)?)
         .stderr(clone_handle(&log, log_path)?)
         .spawn()
-        .map_err(|error| format!("spawn server `{command}`: {error}"))?;
+        .map_err(|error| format!("spawn server `{}`: {error}", args.join(" ")))?;
 
     let result = wait_until_serving(&mut child, port, serve);
     let _ = child.kill();

--- a/pacquet/tasks/ecosystem-e2e/src/runner.rs
+++ b/pacquet/tasks/ecosystem-e2e/src/runner.rs
@@ -186,7 +186,7 @@ fn run_build_script(project_dir: &Path, script_name: &str, log_path: &Path) -> R
 }
 
 /// `PATH` with the project's `node_modules/.bin` prepended, so locally
-/// installed binaries (next, vite, …) resolve ahead of anything global.
+/// installed binaries (next, vite, etc.) resolve ahead of anything global.
 fn bin_path(project_dir: &Path) -> Result<OsString, String> {
     let bin_dir = project_dir.join("node_modules").join(".bin");
     match std::env::var_os("PATH") {
@@ -227,7 +227,7 @@ fn run_serve(project_dir: &Path, serve: &Serve, log_path: &Path) -> Result<(), S
         .arg(format!("exec {command}"))
         .env("PATH", bin_path(project_dir)?)
         // Servers that take their port via env rather than a flag (nitro,
-        // react-router-serve, …) honor these; for the rest the explicit
+        // react-router-serve, etc.) honor these; for the rest the explicit
         // `{port}` flag wins and PORT is harmless.
         .env("PORT", port.to_string())
         .env("HOST", "127.0.0.1")

--- a/pacquet/tasks/ecosystem-e2e/src/runner.rs
+++ b/pacquet/tasks/ecosystem-e2e/src/runner.rs
@@ -5,7 +5,7 @@ use crate::{
 use std::{
     ffi::OsString,
     fs::{self, File, OpenOptions},
-    io::{Read, Write},
+    io::{BufRead, BufReader, Write},
     net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream},
     path::{Path, PathBuf},
     process::{Command, Stdio},
@@ -38,13 +38,23 @@ impl Cell<'_> {
 
 /// Scaffold a stack into `<template_root>/<stack>` once, without installing
 /// dependencies. The generated tree is later copied into each cell.
+///
+/// With `reuse`, an already-scaffolded template (a `<stack>/app` directory
+/// holding a `package.json`) is returned untouched — re-running a generator
+/// into a non-empty directory typically fails. Without it, the caller is
+/// expected to have wiped the work dir, so scaffolding starts clean.
 pub fn scaffold_template(
     pnpm: &str,
     stack: &Stack,
     template_root: &Path,
     log_path: &Path,
+    reuse: bool,
 ) -> Result<PathBuf, String> {
     let template_dir = template_root.join(stack.name);
+    let project_dir = template_dir.join(PROJECT_DIR);
+    if reuse && project_dir.join("package.json").is_file() {
+        return Ok(project_dir);
+    }
     fs::create_dir_all(&template_dir)
         .map_err(|error| format!("create {template_dir:?}: {error}"))?;
     for command in stack.scaffold {
@@ -56,7 +66,6 @@ pub fn scaffold_template(
             log_path,
         )?;
     }
-    let project_dir = template_dir.join(PROJECT_DIR);
     if !project_dir.is_dir() {
         return Err(format!("scaffold did not produce {project_dir:?}"));
     }
@@ -253,15 +262,20 @@ fn wait_until_serving(
         if let Ok(Some(status)) = child.try_wait() {
             return Err(format!("server exited before serving ({status})"));
         }
-        match probe(port, serve.ready_path) {
-            // Any HTTP reply means the server booted; a non-error status means
-            // it actually served the route through the installed layout.
+        // A 2xx/3xx means the server served the route through the installed
+        // layout. A connection error or an HTTP error status is retried until
+        // the deadline — many dev servers briefly refuse connections or answer
+        // 4xx/5xx while warming up.
+        let observation = match probe(port, serve.ready_path) {
             Ok(code) if (200..400).contains(&code) => return Ok(()),
-            Ok(code) => return Err(format!("server answered HTTP {code} at {}", serve.ready_path)),
-            Err(error) if Instant::now() >= deadline => {
-                return Err(format!("not serving within {}s (last: {error})", serve.timeout_secs));
-            }
-            Err(_) => {}
+            Ok(code) => format!("HTTP {code} at {}", serve.ready_path),
+            Err(error) => error,
+        };
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "not serving within {}s (last: {observation})",
+                serve.timeout_secs,
+            ));
         }
         thread::sleep(Duration::from_millis(500));
     }
@@ -269,6 +283,8 @@ fn wait_until_serving(
 
 /// Issue one `GET` and return the HTTP status code, or an error if the
 /// server isn't accepting connections / didn't answer with a status line.
+/// Only the status line is read; the body is left unread and the connection
+/// dropped.
 fn probe(port: u16, path: &str) -> Result<u16, String> {
     let address = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
     let mut stream = TcpStream::connect_timeout(&address, Duration::from_secs(2))
@@ -276,9 +292,10 @@ fn probe(port: u16, path: &str) -> Result<u16, String> {
     let _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
     let request = format!("GET {path} HTTP/1.0\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n");
     stream.write_all(request.as_bytes()).map_err(|error| format!("write request: {error}"))?;
-    let mut response = String::new();
-    stream.read_to_string(&mut response).map_err(|error| format!("read response: {error}"))?;
-    let status_line = response.lines().next().ok_or("empty response")?;
+    let mut status_line = String::new();
+    BufReader::new(stream)
+        .read_line(&mut status_line)
+        .map_err(|error| format!("read response: {error}"))?;
     status_line
         .split_whitespace()
         .nth(1)

--- a/pacquet/tasks/ecosystem-e2e/src/stacks.rs
+++ b/pacquet/tasks/ecosystem-e2e/src/stacks.rs
@@ -122,7 +122,7 @@ pub const STACKS: &[Stack] = &[
         name: "astro",
         description: "Astro minimal project (astro build + astro preview)",
         scaffold: &[ScaffoldCommand {
-            spec: "create-astro@latest",
+            spec: "create-astro@5",
             args: &[
                 "app",
                 "--template",
@@ -145,7 +145,7 @@ pub const STACKS: &[Stack] = &[
         name: "sveltekit",
         description: "SvelteKit minimal project (vite build + vite preview)",
         scaffold: &[ScaffoldCommand {
-            spec: "sv@latest",
+            spec: "sv@0.16",
             args: &[
                 "create",
                 "app",
@@ -176,7 +176,7 @@ pub const STACKS: &[Stack] = &[
         name: "nuxt",
         description: "Nuxt project (nuxt build + nuxi preview, port via env)",
         scaffold: &[ScaffoldCommand {
-            spec: "nuxi@latest",
+            spec: "nuxi@3",
             args: &[
                 "init",
                 "app",
@@ -195,7 +195,7 @@ pub const STACKS: &[Stack] = &[
         name: "react-router",
         description: "React Router 7 framework project (build + react-router-serve, port via env)",
         scaffold: &[ScaffoldCommand {
-            spec: "create-react-router@latest",
+            spec: "create-react-router@7",
             args: &["app", "--no-install", "--no-git-init", "--yes"],
         }],
         build_script: "build",

--- a/pacquet/tasks/ecosystem-e2e/src/stacks.rs
+++ b/pacquet/tasks/ecosystem-e2e/src/stacks.rs
@@ -1,0 +1,218 @@
+/// A real-world JavaScript stack to install and build.
+///
+/// `scaffold` generates the project on disk *without* installing
+/// dependencies — it runs once per stack (the generated files are identical
+/// across binaries and layouts) and the result is copied into each grid
+/// cell, where the binary-under-test performs the actual install. Every
+/// scaffold command is run through `pnpm dlx`, so the first token is the
+/// package spec to fetch and the rest are its arguments.
+#[derive(Debug, Clone, Copy)]
+pub struct Stack {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub scaffold: &'static [ScaffoldCommand],
+    /// `package.json` script that builds the app once dependencies exist.
+    pub build_script: &'static str,
+    /// How to boot and probe the built app. A passing build only proves the
+    /// layout resolves at bundle time; serving proves the layout works at
+    /// runtime — request-time `require`, SSR, native addons. `None` skips
+    /// the serve stage for stacks without a server.
+    pub serve: Option<Serve>,
+}
+
+/// Boots the built app and confirms it serves a non-error HTTP response.
+#[derive(Debug, Clone, Copy)]
+pub struct Serve {
+    /// Command tokens run with `node_modules/.bin` on `PATH` to start the
+    /// production server. The literal token `{port}` is replaced with a
+    /// free port picked at run time.
+    pub command: &'static [&'static str],
+    /// HTTP path polled until the server answers (e.g. `/`).
+    pub ready_path: &'static str,
+    /// How long to wait for the server to start answering before failing.
+    pub timeout_secs: u64,
+}
+
+/// One `pnpm dlx <spec> <args...>` invocation. `dir` is the project
+/// directory name the generator should create; it is passed verbatim as one
+/// of `args` (the harness substitutes nothing — keep the literal `app`).
+#[derive(Debug, Clone, Copy)]
+pub struct ScaffoldCommand {
+    pub spec: &'static str,
+    pub args: &'static [&'static str],
+}
+
+/// Directory name every generator scaffolds into, inside a cell.
+pub const PROJECT_DIR: &str = "app";
+
+/// Stacks are pinned to a major version on purpose: an unpinned generator
+/// tracking `@latest` turns an upstream framework change into a red cell
+/// that looks like a pnpm/pacquet regression. Bump these deliberately.
+pub const STACKS: &[Stack] = &[
+    Stack {
+        name: "next",
+        description: "Next.js app-router project (next build)",
+        scaffold: &[ScaffoldCommand {
+            spec: "create-next-app@15",
+            args: &[
+                "app",
+                "--ts",
+                "--app",
+                "--no-eslint",
+                "--no-tailwind",
+                "--no-src-dir",
+                "--no-turbopack",
+                "--no-import-alias",
+                "--use-pnpm",
+                "--skip-install",
+            ],
+        }],
+        build_script: "build",
+        serve: Some(Serve {
+            command: &["next", "start", "--port", "{port}", "--hostname", "127.0.0.1"],
+            ready_path: "/",
+            timeout_secs: 60,
+        }),
+    },
+    Stack {
+        name: "vite-react",
+        description: "Vite + React + TypeScript project (vite build)",
+        scaffold: &[ScaffoldCommand {
+            spec: "create-vite@6",
+            args: &["app", "--template", "react-ts"],
+        }],
+        build_script: "build",
+        serve: Some(Serve {
+            command: &[
+                "vite",
+                "preview",
+                "--port",
+                "{port}",
+                "--strictPort",
+                "--host",
+                "127.0.0.1",
+            ],
+            ready_path: "/",
+            timeout_secs: 30,
+        }),
+    },
+    Stack {
+        name: "angular",
+        description: "Angular CLI project (ng build + ng serve dev server)",
+        scaffold: &[ScaffoldCommand {
+            spec: "@angular/cli@19",
+            args: &[
+                "new",
+                "app",
+                "--defaults",
+                "--skip-install",
+                "--skip-git",
+                "--package-manager",
+                "pnpm",
+            ],
+        }],
+        build_script: "build",
+        serve: Some(Serve {
+            command: &["ng", "serve", "--port", "{port}", "--host", "127.0.0.1"],
+            ready_path: "/",
+            timeout_secs: 120,
+        }),
+    },
+    Stack {
+        name: "astro",
+        description: "Astro minimal project (astro build + astro preview)",
+        scaffold: &[ScaffoldCommand {
+            spec: "create-astro@latest",
+            args: &[
+                "app",
+                "--template",
+                "minimal",
+                "--no-install",
+                "--no-git",
+                "--skip-houston",
+                "--typescript",
+                "strict",
+            ],
+        }],
+        build_script: "build",
+        serve: Some(Serve {
+            command: &["astro", "preview", "--port", "{port}", "--host", "127.0.0.1"],
+            ready_path: "/",
+            timeout_secs: 30,
+        }),
+    },
+    Stack {
+        name: "sveltekit",
+        description: "SvelteKit minimal project (vite build + vite preview)",
+        scaffold: &[ScaffoldCommand {
+            spec: "sv@latest",
+            args: &[
+                "create",
+                "app",
+                "--template",
+                "minimal",
+                "--types",
+                "ts",
+                "--no-add-ons",
+                "--no-install",
+            ],
+        }],
+        build_script: "build",
+        serve: Some(Serve {
+            command: &[
+                "vite",
+                "preview",
+                "--port",
+                "{port}",
+                "--strictPort",
+                "--host",
+                "127.0.0.1",
+            ],
+            ready_path: "/",
+            timeout_secs: 30,
+        }),
+    },
+    Stack {
+        name: "nuxt",
+        description: "Nuxt project (nuxt build + nuxi preview, port via env)",
+        scaffold: &[ScaffoldCommand {
+            spec: "nuxi@latest",
+            args: &[
+                "init",
+                "app",
+                "--template",
+                "minimal",
+                "--packageManager",
+                "pnpm",
+                "--no-install",
+                "--no-gitInit",
+            ],
+        }],
+        build_script: "build",
+        serve: Some(Serve { command: &["nuxi", "preview"], ready_path: "/", timeout_secs: 60 }),
+    },
+    Stack {
+        name: "react-router",
+        description: "React Router 7 framework project (build + react-router-serve, port via env)",
+        scaffold: &[ScaffoldCommand {
+            spec: "create-react-router@latest",
+            args: &["app", "--no-install", "--no-git-init", "--yes"],
+        }],
+        build_script: "build",
+        serve: Some(Serve {
+            command: &["react-router-serve", "./build/server/index.js"],
+            ready_path: "/",
+            timeout_secs: 30,
+        }),
+    },
+];
+
+pub fn select(names: &[String]) -> Result<Vec<&'static Stack>, &str> {
+    if names.is_empty() {
+        return Ok(STACKS.iter().collect());
+    }
+    names
+        .iter()
+        .map(|name| STACKS.iter().find(|stack| stack.name == name).ok_or(name.as_str()))
+        .collect()
+}


### PR DESCRIPTION
## What

Adds `pacquet/tasks/ecosystem-e2e`, a Yarn-PnP-style ecosystem test harness, plus a daily-cron workflow. It installs, builds, and **serves** real framework scaffolds across the cross product of:

- **binary**: pnpm CLI · pacquet
- **layout**: default isolated · global virtual store (`enableGlobalVirtualStore`)
- **stack**: Next.js, Vite (React), Angular, Astro, SvelteKit, Nuxt, React Router 7

## Why

Two reasons specific to this repo:

1. **pacquet parity** — a real framework that installs/builds/serves under the pnpm CLI but not under pacquet is a far stronger parity signal than a unit test.
2. **Global virtual store** — GVS relocates where dependencies physically live (the same class of change that drove Yarn to build ecosystem tests for Plug'n'Play). Running real stacks under it is the only way to find tools that break on the new layout.

## How a cell works

`scaffold (once, via pnpm dlx) → copy into cell → write pnpm-workspace.yaml pinning an isolated store/cache + the layout → <binary> install → build → serve`.

The **serve** stage boots the production server and probes it over HTTP (raw `TcpStream`, no new deps), requiring a non-error response, then tears it down. So a green cell means the produced `node_modules` works **at runtime**, not just at bundle time — request-time `require`, SSR, native addons. The build/serve stages run with `node_modules/.bin` on `PATH` rather than through a package manager, so they can't re-install and mask the install under test.

## It already found a real GVS bug

The wider run surfaced a recurring global-virtual-store failure class — a package that executes code by absolute path out of the `links/` store can't resolve a transitive dependency only wired into the project's local `.pnpm` tree. Reproduces identically on the pnpm CLI and pacquet:

- **Angular** fails at `build` — `Cannot find module 'tslib'` from `@angular/build`'s esbuild/babel workers (CJS).
- **Nuxt** fails at `install` — the `nuxt prepare` postinstall runs `@nuxt/devtools` and can't `import 'unstorage'` (ESM).

Five of seven stacks pass GVS cleanly. Tracked in https://github.com/pnpm/pnpm/issues/12437.

## Running it

```sh
cargo build --release --bin pacquet
cargo run -p pacquet-ecosystem-e2e -- --pacquet ./target/release/pacquet   # whole grid
cargo run -p pacquet-ecosystem-e2e -- --binary pnpm --stack vite-react --keep
```

## Notes

- Runs on a **daily cron** (one job per stack), not per-PR: installs are slow and track upstream framework releases, so a red cell is investigated, not a merge blocker.
- Generators are **pinned** to a major so an upstream release doesn't masquerade as a pnpm/pacquet regression.
- Tooling crate only (`publish = false`), so no changeset.
- Follow-ups: auto-file an issue per red cell; process-group teardown for servers that fork persistent workers; widen to a workspace/monorepo stack.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an automated ecosystem end-to-end test workflow that runs daily (and can be triggered manually) across multiple JavaScript stacks: Next, Vite-React, Angular, Astro, SvelteKit, Nuxt, and React Router.
  * Executes a matrix of installer/virtual-store layout combinations, validates build outcomes, optionally serves and health-checks apps, prints an overall pass/fail summary, and uploads per-stack logs.

* **Documentation**
  * Added documentation for the ecosystem E2E grid, including local execution, the multi-stage lifecycle, log handling, and how to add new stacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->