### PR TITLE
fix(ecosystem-e2e): absolute /bin/sh for build, build binaries once in CI

### DIFF
--- a/.github/workflows/ecosystem-e2e.yml
+++ b/.github/workflows/ecosystem-e2e.yml
@@ -2,11 +2,11 @@ name: Ecosystem E2E
 
 # Installs real-world JS stacks (Next.js, Vite, …) with both the pnpm CLI
 # and pacquet, under both the default isolated layout and the global virtual
-# store, then builds each app. The binary axis catches pnpm↔pacquet parity
-# gaps; the layout axis catches breakage introduced by the global virtual
-# store. Runs on a daily cron rather than per-PR — the installs are slow and
-# track upstream framework releases, so a red cell is investigated, not
-# treated as a merge blocker.
+# store, then builds and serves each app. The binary axis catches pnpm↔pacquet
+# parity gaps; the layout axis catches breakage introduced by the global
+# virtual store. Runs on a daily cron rather than per-PR — the installs are
+# slow and track upstream framework releases, so a red cell is investigated,
+# not treated as a merge blocker.
 
 permissions:
   contents: read
@@ -21,18 +21,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ecosystem-e2e:
-    name: Ecosystem E2E / ${{ matrix.stack }}
+  # Compile pacquet, the harness, and the pnpm bundle once, then share them
+  # with every stack job — building them per stack would repeat the same
+  # multi-minute Rust and bundle builds across the whole matrix.
+  build:
+    name: Ecosystem E2E / Build
     runs-on: ubuntu-latest
-    # Bound the blast radius: a hung build or serve subprocess can't pin a
-    # runner indefinitely.
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        # One stack per job so a slow or flaky stack can't mask the others
-        # and each gets its own log artifact.
-        stack: [next, vite-react, angular, astro, sveltekit, nuxt, react-router]
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -45,26 +40,67 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/rustup
 
-      - name: Build pacquet
-        run: cargo build --release --bin pacquet
+      - name: Build pacquet and the harness
+        run: cargo build --release --bin pacquet --bin ecosystem-e2e
 
       - name: Build the pnpm CLI bundle
         run: |
           pnpm install --frozen-lockfile
           pnpm --filter pnpm run compile
 
+      - name: Upload build outputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ecosystem-e2e-build
+          path: |
+            target/release/pacquet
+            target/release/ecosystem-e2e
+            pnpm/dist
+          retention-days: 1
+          if-no-files-found: error
+
+  ecosystem-e2e:
+    name: Ecosystem E2E / ${{ matrix.stack }}
+    needs: build
+    runs-on: ubuntu-latest
+    # Bound the blast radius: a hung build or serve subprocess can't pin a
+    # runner indefinitely.
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        # One stack per job so a slow or flaky stack can't mask the others
+        # and each gets its own log artifact.
+        stack: [next, vite-react, angular, astro, sveltekit, nuxt, react-router]
+    steps:
+      # The pnpm shim launches the repo's committed `pnpm/bin/pnpm.cjs`, so the
+      # checkout is still needed alongside the downloaded `pnpm/dist` bundle.
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download build outputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ecosystem-e2e-build
+          path: .
+
+      - name: Restore executable bits
+        # Artifacts don't preserve the executable bit.
+        run: chmod +x target/release/pacquet target/release/ecosystem-e2e
+
       - name: Wrap the built pnpm bundle as an executable
         # The harness takes a single executable for --pnpm; the launcher is a
         # .cjs that needs `node`. Wrap the repo's bin entry (which loads
-        # dist/pnpm.mjs) so the run tests this repo's pnpm, not the one
-        # provisioned by pnpm/setup.
+        # dist/pnpm.mjs) so the run tests this repo's pnpm, not a system one.
         run: |
           printf '#!/usr/bin/env bash\nexec node "%s/pnpm/bin/pnpm.cjs" "$@"\n' "$PWD" > pnpm-built
           chmod +x pnpm-built
 
       - name: Run ecosystem E2E
         run: |
-          cargo run --release -p pacquet-ecosystem-e2e -- \
+          ./target/release/ecosystem-e2e \
             --pnpm "$PWD/pnpm-built" \
             --pacquet "$PWD/target/release/pacquet" \
             --binary both \

--- a/pacquet/tasks/ecosystem-e2e/src/runner.rs
+++ b/pacquet/tasks/ecosystem-e2e/src/runner.rs
@@ -192,7 +192,12 @@ fn run_build_script(project_dir: &Path, script_name: &str, log_path: &Path) -> R
         .and_then(serde_json::Value::as_str)
         .ok_or_else(|| format!("no `{script_name}` script in {manifest_path:?}"))?;
 
-    let mut process = sandboxed_command("sh");
+    // Absolute `/bin/sh`, not `sh`: the child's PATH is prepended with the
+    // project's `node_modules/.bin`, and Rust resolves a bare program name
+    // against that child PATH — a dependency shipping a `.bin/sh` would
+    // otherwise run in place of the system shell. The script the shell runs
+    // still resolves framework bins from `.bin` via that PATH.
+    let mut process = sandboxed_command("/bin/sh");
     process.current_dir(project_dir).arg("-c").arg(script).env("PATH", bin_path(project_dir)?);
     run(&format!("run {script_name}: {script}"), &mut process, log_path)
 }


### PR DESCRIPTION
Follow-up to the ecosystem-E2E harness (pnpm/pnpm#12439), addressing two post-merge points.

## 1. Run the build script via absolute `/bin/sh` (security/correctness)

The build stage sets the child `PATH` to prepend the project's `node_modules/.bin`, and Rust resolves a bare program name (`Command::new("sh")`) against that **child** `PATH` — verified empirically. So a dependency shipping a `.bin/sh` would run in place of the system shell, running unintended code and masking the build's pass/fail.

Fix: spawn the orchestrating shell as absolute `/bin/sh` so `PATH` can't redirect it. The script it runs still resolves framework bins from `.bin` through the prepended `PATH` (unchanged). The serve stage was already safe — it spawns its program by absolute `.bin` path.

## 2. Build pnpm and pacquet once, not per stack (CI cost)

The stack matrix rebuilt the pacquet release binary and the pnpm bundle in each of its seven jobs. This adds a single `build` job that compiles pacquet, the harness, and the pnpm bundle once and uploads them as an artifact; the per-stack jobs download it and run. The multi-minute Rust + bundle builds now happen once per run instead of seven times, and the stack jobs no longer need a Rust toolchain.

Verified locally: the build stage still runs through `/bin/sh`, and the harness builds/lints/dylints clean.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build script execution robustness by using absolute shell paths to prevent unintended dependency resolution during script execution.

* **Chores**
  * Optimized CI workflow to compile and cache build artifacts once, then reuse across test matrix runs for faster feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->