### PR TITLE
feat(sbom): add --exclude-peers to omit peer dependencies

### DIFF
--- a/.changeset/sbom-exclude-peers.md
+++ b/.changeset/sbom-exclude-peers.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/deps.compliance.sbom": minor
+"@pnpm/deps.compliance.commands": minor
+"pnpm": minor
+---
+
+Added `--exclude-peers` to `pnpm sbom`. With `auto-install-peers` (the default), peer dependencies resolve into the lockfile and are otherwise indistinguishable from the package's own dependencies. The flag drops peer dependencies (and any transitive subtree reachable only through them) from the SBOM. CycloneDX 1.7 has no scope or relationship that expresses "consumer-provided peer", so omission is the only spec-clean handling. The flag name matches `pnpm list --exclude-peers`; note the SBOM flag prunes a peer's exclusive subtree, which is stricter than `pnpm list` (which only hides leaf peers).

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -346,8 +346,11 @@ async function buildSharedContext (opts: SbomCommandOptions): Promise<SharedCont
       // throwing) for an importer whose manifest is gone (e.g. a stale lockfile),
       // and skips the installability check that would otherwise abort the SBOM.
       const lockfileRoot = await realpath(lockfileDir)
+      // Bound the fan-out: a large workspace can have many importers, and
+      // reading every manifest at once would spike open file descriptors.
+      const limitManifestReads = pLimit(16)
       await Promise.all(
-        Object.keys(lockfile.importers).map(async (importerId) => {
+        Object.keys(lockfile.importers).map((importerId) => limitManifestReads(async () => {
           // A crafted lockfile could carry an importer key that escapes the
           // project, via `..` segments or a symlinked directory. Canonicalize
           // with realpath and skip anything resolving outside the project root,
@@ -364,7 +367,7 @@ async function buildSharedContext (opts: SbomCommandOptions): Promise<SharedCont
           if (importerManifest) {
             byImporter[importerId] = peerNamesFromManifest(importerManifest)
           }
-        })
+        }))
       )
     }
     excludePeerNamesByImporter = byImporter

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -306,7 +306,7 @@ interface SharedContext {
   /** Workspace package manifests keyed by lockfile importer id, read once from the
    * project graph so split mode does not re-read them for every emitted SBOM. */
   workspaceManifestsByImporterId: Map<string, ManifestLike>
-  excludePeerNamesByImporter?: Record<string, Set<string>>
+  excludePeerNamesByImporter?: Map<string, Set<string>>
 }
 
 async function buildSharedContext (opts: SbomCommandOptions): Promise<SharedContext> {
@@ -330,13 +330,15 @@ async function buildSharedContext (opts: SbomCommandOptions): Promise<SharedCont
   // auto-install-peers they resolve into the importer's `dependencies` with no
   // distinguishing marker. Map every walked importer to its peer names so the
   // collector can drop them.
-  let excludePeerNamesByImporter: Record<string, Set<string>> | undefined
+  // Keyed by a Map, not a plain object: importer ids come from the lockfile
+  // (attacker-controlled in an untrusted clone), and a key like `__proto__`
+  // would corrupt a plain object's prototype.
+  let excludePeerNamesByImporter: Map<string, Set<string>> | undefined
   if (opts.excludePeers) {
-    const byImporter: Record<string, Set<string>> = {}
+    const byImporter = new Map<string, Set<string>>()
     if (opts.selectedProjectsGraph) {
       for (const [projectDir, { package: project }] of Object.entries(opts.selectedProjectsGraph)) {
-        byImporter[getLockfileImporterId(lockfileDir, projectDir)] =
-          peerNamesFromManifest(project.manifest)
+        byImporter.set(getLockfileImporterId(lockfileDir, projectDir), peerNamesFromManifest(project.manifest))
       }
     } else {
       // No project graph was selected, so collectSbomComponents walks every
@@ -363,9 +365,18 @@ async function buildSharedContext (opts: SbomCommandOptions): Promise<SharedCont
           }
           const rel = path.relative(lockfileRoot, importerDir)
           if (rel !== '' && (rel.startsWith('..') || path.isAbsolute(rel))) return
-          const importerManifest = await safeReadProjectManifestOnly(importerDir)
+          // safeReadProjectManifestOnly tolerates a missing manifest but still
+          // throws on a malformed one (parse error). In an untrusted clone a
+          // single junk package.json must not abort the whole SBOM, so skip it
+          // (fail-open: an unparseable importer's peers just aren't filtered).
+          let importerManifest: ProjectManifest | null
+          try {
+            importerManifest = await safeReadProjectManifestOnly(importerDir)
+          } catch {
+            return
+          }
           if (importerManifest) {
-            byImporter[importerId] = peerNamesFromManifest(importerManifest)
+            byImporter.set(importerId, peerNamesFromManifest(importerManifest))
           }
         }))
       )

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import { realpath } from 'node:fs/promises'
 import path from 'node:path'
 
 import { FILTERING } from '@pnpm/cli.common-cli-options-help'
@@ -19,7 +20,8 @@ import {
 import { PnpmError } from '@pnpm/error'
 import { getLockfileImporterId, readWantedLockfile } from '@pnpm/lockfile.fs'
 import { getStorePath } from '@pnpm/store.path'
-import type { ProjectId } from '@pnpm/types'
+import type { ProjectId, ProjectManifest } from '@pnpm/types'
+import { safeReadProjectManifestOnly } from '@pnpm/workspace.project-manifest-reader'
 import pLimit from 'p-limit'
 import { pick } from 'ramda'
 import { renderHelp } from 'render-help'
@@ -33,6 +35,7 @@ export type SbomCommandOptions = {
   sbomSupplier?: string
   out?: string
   split?: boolean
+  excludePeers?: boolean
 } & Pick<
   Config,
   | 'dev'
@@ -72,6 +75,7 @@ export const cliOptionsTypes = (): Record<string, unknown> => ({
   'lockfile-only': Boolean,
   out: String,
   split: Boolean,
+  'exclude-peers': Boolean,
 })
 
 export const shorthands: Record<string, string> = {
@@ -135,6 +139,10 @@ export function help (): string {
           {
             description: 'Generate a separate SBOM for each matched workspace package. Outputs NDJSON to stdout, or files when combined with --out.',
             name: '--split',
+          },
+          {
+            description: 'Exclude peer dependencies (and their exclusive transitive subtrees)',
+            name: '--exclude-peers',
           },
         ],
       },
@@ -298,6 +306,7 @@ interface SharedContext {
   /** Workspace package manifests keyed by lockfile importer id, read once from the
    * project graph so split mode does not re-read them for every emitted SBOM. */
   workspaceManifestsByImporterId: Map<string, ManifestLike>
+  excludePeerNamesByImporter?: Record<string, Set<string>>
 }
 
 async function buildSharedContext (opts: SbomCommandOptions): Promise<SharedContext> {
@@ -315,6 +324,52 @@ async function buildSharedContext (opts: SbomCommandOptions): Promise<SharedCont
   const rootManifestDir = opts.rootProjectManifestDir ?? opts.dir
   const rootManifest = opts.rootProjectManifest ?? await readProjectManifestOnly(rootManifestDir)
 
+  const lockfileDir = opts.lockfileDir ?? opts.dir
+
+  // peerDependencies are identified from the manifest, not the lockfile: with
+  // auto-install-peers they resolve into the importer's `dependencies` with no
+  // distinguishing marker. Map every walked importer to its peer names so the
+  // collector can drop them.
+  let excludePeerNamesByImporter: Record<string, Set<string>> | undefined
+  if (opts.excludePeers) {
+    const byImporter: Record<string, Set<string>> = {}
+    if (opts.selectedProjectsGraph) {
+      for (const [projectDir, { package: project }] of Object.entries(opts.selectedProjectsGraph)) {
+        byImporter[getLockfileImporterId(lockfileDir, projectDir)] =
+          peerNamesFromManifest(project.manifest)
+      }
+    } else {
+      // No project graph was selected, so collectSbomComponents walks every
+      // importer in the lockfile. Resolve each importer's own manifest so peers
+      // in workspace packages are dropped too, not only those in the directory
+      // pnpm ran in. safeReadProjectManifestOnly returns null (rather than
+      // throwing) for an importer whose manifest is gone (e.g. a stale lockfile),
+      // and skips the installability check that would otherwise abort the SBOM.
+      const lockfileRoot = await realpath(lockfileDir)
+      await Promise.all(
+        Object.keys(lockfile.importers).map(async (importerId) => {
+          // A crafted lockfile could carry an importer key that escapes the
+          // project, via `..` segments or a symlinked directory. Canonicalize
+          // with realpath and skip anything resolving outside the project root,
+          // so a manifest is never read from outside the tree.
+          let importerDir: string
+          try {
+            importerDir = await realpath(path.resolve(lockfileDir, importerId))
+          } catch {
+            return
+          }
+          const rel = path.relative(lockfileRoot, importerDir)
+          if (rel !== '' && (rel.startsWith('..') || path.isAbsolute(rel))) return
+          const importerManifest = await safeReadProjectManifestOnly(importerDir)
+          if (importerManifest) {
+            byImporter[importerId] = peerNamesFromManifest(importerManifest)
+          }
+        })
+      )
+    }
+    excludePeerNamesByImporter = byImporter
+  }
+
   let storeDir: string | undefined
   if (!opts.lockfileOnly) {
     storeDir = await getStorePath({
@@ -324,7 +379,6 @@ async function buildSharedContext (opts: SbomCommandOptions): Promise<SharedCont
     })
   }
 
-  const lockfileDir = opts.lockfileDir ?? opts.dir
   const workspaceManifestsByImporterId = new Map<string, ManifestLike>()
   for (const graph of [opts.allProjectsGraph, opts.selectedProjectsGraph]) {
     if (!graph) continue
@@ -335,7 +389,7 @@ async function buildSharedContext (opts: SbomCommandOptions): Promise<SharedCont
 
   const rootLicense = await resolveRootLicense(rootManifest, rootManifestDir)
 
-  return { lockfile, rootManifest, rootManifestDir, rootLicense, storeDir, workspaceManifestsByImporterId }
+  return { lockfile, rootManifest, rootManifestDir, rootLicense, storeDir, workspaceManifestsByImporterId, excludePeerNamesByImporter }
 }
 
 async function generateSbomForProject (
@@ -417,6 +471,7 @@ async function generateSbomForProject (
     virtualStoreDirMaxLength: opts.virtualStoreDirMaxLength,
     workspacePackages,
     resolvedWorkspaceDeps,
+    excludePeerNamesByImporter: ctx.excludePeerNamesByImporter,
   })
 
   const output = serialOpts.format === 'cyclonedx'
@@ -431,6 +486,19 @@ async function generateSbomForProject (
     : serializeSpdx(result, { compact })
 
   return { output, exitCode: 0, rootName, rootVersion }
+}
+
+function peerNamesFromManifest (manifest: ProjectManifest): Set<string> {
+  // A name declared as both a peer and a regular dependency is a real dependency
+  // the package pulls in itself, so keep it.
+  const regular = new Set([
+    ...Object.keys(manifest.dependencies ?? {}),
+    ...Object.keys(manifest.devDependencies ?? {}),
+    ...Object.keys(manifest.optionalDependencies ?? {}),
+  ])
+  return new Set(
+    Object.keys(manifest.peerDependencies ?? {}).filter((name) => !regular.has(name))
+  )
 }
 
 function validateSbomType (value: string | undefined): SbomComponentType {

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -336,17 +336,25 @@ async function buildSharedContext (opts: SbomCommandOptions): Promise<SharedCont
   let excludePeerNamesByImporter: Map<string, Set<string>> | undefined
   if (opts.excludePeers) {
     const byImporter = new Map<string, Set<string>>()
-    if (opts.selectedProjectsGraph) {
-      for (const [projectDir, { package: project }] of Object.entries(opts.selectedProjectsGraph)) {
-        byImporter.set(getLockfileImporterId(lockfileDir, projectDir), peerNamesFromManifest(project.manifest))
+    // Prefer the in-memory project graph(s): no extra filesystem reads, and
+    // reading from both graphs (not only the selected subset) covers the extra
+    // workspace packages collectSbomComponents reaches through `link:` deps, so
+    // their peers are filtered too in a filtered run.
+    const graphs = [opts.allProjectsGraph, opts.selectedProjectsGraph].filter(Boolean)
+    if (graphs.length > 0) {
+      for (const graph of graphs) {
+        for (const [projectDir, { package: project }] of Object.entries(graph!)) {
+          byImporter.set(getLockfileImporterId(lockfileDir, projectDir), peerNamesFromManifest(project.manifest))
+        }
       }
     } else {
-      // No project graph was selected, so collectSbomComponents walks every
-      // importer in the lockfile. Resolve each importer's own manifest so peers
-      // in workspace packages are dropped too, not only those in the directory
-      // pnpm ran in. safeReadProjectManifestOnly returns null (rather than
-      // throwing) for an importer whose manifest is gone (e.g. a stale lockfile),
-      // and skips the installability check that would otherwise abort the SBOM.
+      // No project graph (e.g. a single-package repo or `--lockfile-only`
+      // outside a workspace), so collectSbomComponents walks every importer in
+      // the lockfile. Resolve each importer's own manifest from disk so peers in
+      // workspace packages are dropped too, not only those in the directory pnpm
+      // ran in. safeReadProjectManifestOnly returns null (rather than throwing)
+      // for an importer whose manifest is gone (e.g. a stale lockfile), and skips
+      // the installability check that would otherwise abort the SBOM.
       const lockfileRoot = await realpath(lockfileDir)
       // Bound the fan-out: a large workspace can have many importers, and
       // reading every manifest at once would spike open file descriptors.

--- a/deps/compliance/commands/test/sbom/fixtures/with-peer-and-real-dep/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/with-peer-and-real-dep/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sbom-peer-and-real-dep",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "is-positive": "3.1.0"
+  }
+}

--- a/deps/compliance/commands/test/sbom/fixtures/with-peer-and-real-dep/packages/pkg-a/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/with-peer-and-real-dep/packages/pkg-a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sbom-peer-only-pkg",
+  "version": "1.0.0",
+  "dependencies": {},
+  "peerDependencies": {
+    "is-odd": "3.0.1"
+  }
+}

--- a/deps/compliance/commands/test/sbom/fixtures/with-peer-and-real-dep/packages/pkg-b/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/with-peer-and-real-dep/packages/pkg-b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "sbom-real-dep-pkg",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-odd": "3.0.1"
+  }
+}

--- a/deps/compliance/commands/test/sbom/fixtures/with-peer-and-real-dep/pnpm-lock.yaml
+++ b/deps/compliance/commands/test/sbom/fixtures/with-peer-and-real-dep/pnpm-lock.yaml
@@ -1,0 +1,49 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      is-positive:
+        specifier: 3.1.0
+        version: 3.1.0
+
+  packages/pkg-a:
+    dependencies:
+      is-odd:
+        specifier: 3.0.1
+        version: 3.0.1
+
+  packages/pkg-b:
+    dependencies:
+      is-odd:
+        specifier: 3.0.1
+        version: 3.0.1
+
+packages:
+
+  is-number@6.0.0:
+    resolution: {integrity: sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==}
+    engines: {node: '>=0.10.0'}
+
+  is-odd@3.0.1:
+    resolution: {integrity: sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==}
+    engines: {node: '>=4'}
+
+  is-positive@3.1.0:
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
+    engines: {node: '>=0.10.0'}
+
+snapshots:
+
+  is-number@6.0.0: {}
+
+  is-odd@3.0.1:
+    dependencies:
+      is-number: 6.0.0
+
+  is-positive@3.1.0: {}

--- a/deps/compliance/commands/test/sbom/fixtures/with-peer-and-real-dep/pnpm-workspace.yaml
+++ b/deps/compliance/commands/test/sbom/fixtures/with-peer-and-real-dep/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/deps/compliance/commands/test/sbom/fixtures/with-peer-dependency/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/with-peer-dependency/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "sbom-with-peer-dep",
+  "version": "1.0.0",
+  "description": "Test fixture with a peer dependency",
+  "license": "MIT",
+  "dependencies": {
+    "is-positive": "3.1.0"
+  },
+  "peerDependencies": {
+    "is-odd": "3.0.1"
+  }
+}

--- a/deps/compliance/commands/test/sbom/fixtures/with-peer-dependency/pnpm-lock.yaml
+++ b/deps/compliance/commands/test/sbom/fixtures/with-peer-dependency/pnpm-lock.yaml
@@ -1,0 +1,40 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      is-odd:
+        specifier: 3.0.1
+        version: 3.0.1
+      is-positive:
+        specifier: 3.1.0
+        version: 3.1.0
+
+packages:
+
+  is-number@6.0.0:
+    resolution: {integrity: sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==}
+    engines: {node: '>=0.10.0'}
+
+  is-odd@3.0.1:
+    resolution: {integrity: sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==}
+    engines: {node: '>=4'}
+
+  is-positive@3.1.0:
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
+    engines: {node: '>=0.10.0'}
+
+snapshots:
+
+  is-number@6.0.0: {}
+
+  is-odd@3.0.1:
+    dependencies:
+      is-number: 6.0.0
+
+  is-positive@3.1.0: {}

--- a/deps/compliance/commands/test/sbom/fixtures/with-peer-workspace-link/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/with-peer-workspace-link/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "sbom-peer-workspace-link-root",
+  "version": "0.0.0",
+  "private": true
+}

--- a/deps/compliance/commands/test/sbom/fixtures/with-peer-workspace-link/packages/app-a/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/with-peer-workspace-link/packages/app-a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/app-a",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-positive": "3.1.0",
+    "peer-lib": "workspace:*"
+  }
+}

--- a/deps/compliance/commands/test/sbom/fixtures/with-peer-workspace-link/packages/peer-lib/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/with-peer-workspace-link/packages/peer-lib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "peer-lib",
+  "version": "0.1.0",
+  "dependencies": {},
+  "peerDependencies": {
+    "is-odd": "3.0.1"
+  }
+}

--- a/deps/compliance/commands/test/sbom/fixtures/with-peer-workspace-link/pnpm-workspace.yaml
+++ b/deps/compliance/commands/test/sbom/fixtures/with-peer-workspace-link/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/deps/compliance/commands/test/sbom/fixtures/with-peer-workspace/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/with-peer-workspace/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sbom-peer-workspace",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "is-positive": "3.1.0"
+  }
+}

--- a/deps/compliance/commands/test/sbom/fixtures/with-peer-workspace/packages/pkg-a/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/with-peer-workspace/packages/pkg-a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pkg-a",
+  "version": "1.0.0",
+  "dependencies": {},
+  "peerDependencies": {
+    "is-odd": "3.0.1"
+  }
+}

--- a/deps/compliance/commands/test/sbom/fixtures/with-peer-workspace/pnpm-lock.yaml
+++ b/deps/compliance/commands/test/sbom/fixtures/with-peer-workspace/pnpm-lock.yaml
@@ -1,0 +1,43 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      is-positive:
+        specifier: 3.1.0
+        version: 3.1.0
+
+  packages/pkg-a:
+    dependencies:
+      is-odd:
+        specifier: 3.0.1
+        version: 3.0.1
+
+packages:
+
+  is-number@6.0.0:
+    resolution: {integrity: sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==}
+    engines: {node: '>=0.10.0'}
+
+  is-odd@3.0.1:
+    resolution: {integrity: sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==}
+    engines: {node: '>=4'}
+
+  is-positive@3.1.0:
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
+    engines: {node: '>=0.10.0'}
+
+snapshots:
+
+  is-number@6.0.0: {}
+
+  is-odd@3.0.1:
+    dependencies:
+      is-number: 6.0.0
+
+  is-positive@3.1.0: {}

--- a/deps/compliance/commands/test/sbom/fixtures/with-peer-workspace/pnpm-workspace.yaml
+++ b/deps/compliance/commands/test/sbom/fixtures/with-peer-workspace/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/deps/compliance/commands/test/sbom/index.ts
+++ b/deps/compliance/commands/test/sbom/index.ts
@@ -264,6 +264,30 @@ test('pnpm sbom --exclude-peers drops peers declared in workspace sub-packages',
   expect(componentNames).not.toContain('is-number')
 })
 
+test('pnpm sbom --exclude-peers tolerates a malformed importer manifest', async () => {
+  const workspaceDir = tempDir()
+  f.copy('with-peer-workspace', workspaceDir)
+  // Simulate an untrusted/broken importer: a sub-package with unparsable JSON.
+  // The peer scan reads every importer manifest, and one bad file must not
+  // abort the whole SBOM.
+  fs.writeFileSync(path.join(workspaceDir, 'packages/pkg-a/package.json'), '{ not valid json')
+
+  const { output, exitCode } = await sbom.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    sbomFormat: 'cyclonedx',
+    lockfileOnly: true,
+    excludePeers: true,
+  })
+
+  expect(exitCode).toBe(0)
+  const parsed = JSON.parse(output)
+  const componentNames = parsed.components.map((c: { name: string }) => c.name)
+  expect(componentNames).toContain('is-positive')
+})
+
 test('pnpm sbom marks dev-only components with scope "excluded" (cyclonedx)', async () => {
   const workspaceDir = tempDir()
   f.copy('with-dev-dependency', workspaceDir)

--- a/deps/compliance/commands/test/sbom/index.ts
+++ b/deps/compliance/commands/test/sbom/index.ts
@@ -313,6 +313,56 @@ test('pnpm sbom --exclude-peers keeps a package that is a peer in one importer a
   expect(componentNames).toContain('is-number')
 })
 
+test('pnpm sbom --exclude-peers drops peers reached through a workspace link in a filtered run', async () => {
+  const workspaceDir = tempDir()
+  f.copy('with-peer-workspace-link', workspaceDir)
+
+  const { allProjects, allProjectsGraph, selectedProjectsGraph } =
+    await filterProjectsBySelectorObjectsFromDir(workspaceDir, [])
+
+  const storeDir = path.join(workspaceDir, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+    allProjects,
+    allProjectsGraph,
+    selectedProjectsGraph,
+  })
+
+  const appADir = path.join(workspaceDir, 'packages/app-a')
+  const filteredGraph = Object.fromEntries(
+    Object.entries(selectedProjectsGraph).filter(([p]) => p === appADir)
+  )
+
+  // Filtered to app-a, which links peer-lib. peer-lib's auto-installed peer
+  // (is-odd) is walked through that link, so its peer names must be filtered
+  // too — not only the selected app-a's. The graph the peers are read from must
+  // therefore cover the whole workspace, not just the selected subset.
+  const { output, exitCode } = await sbom.handler({
+    ...DEFAULT_OPTS,
+    dir: appADir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    sbomFormat: 'cyclonedx',
+    storeDir: path.resolve(storeDir, STORE_VERSION),
+    selectedProjectsGraph: filteredGraph,
+    allProjectsGraph,
+    excludePeers: true,
+  })
+
+  expect(exitCode).toBe(0)
+  const parsed = JSON.parse(output)
+  const componentNames = parsed.components.map((c: { name: string }) => c.name)
+  expect(componentNames).toContain('is-positive') // app-a's own dependency
+  expect(componentNames).toContain('peer-lib') // the linked workspace package
+  expect(componentNames).not.toContain('is-odd') // peer-lib's peer
+  expect(componentNames).not.toContain('is-number') // only reachable through is-odd
+})
+
 test('pnpm sbom marks dev-only components with scope "excluded" (cyclonedx)', async () => {
   const workspaceDir = tempDir()
   f.copy('with-dev-dependency', workspaceDir)

--- a/deps/compliance/commands/test/sbom/index.ts
+++ b/deps/compliance/commands/test/sbom/index.ts
@@ -188,6 +188,82 @@ test('pnpm sbom --prod excludes devDependencies', async () => {
   expect(componentNames).not.toContain('typescript')
 })
 
+test('pnpm sbom includes peer dependencies by default', async () => {
+  const workspaceDir = tempDir()
+  f.copy('with-peer-dependency', workspaceDir)
+
+  const { output, exitCode } = await sbom.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    sbomFormat: 'cyclonedx',
+    lockfileOnly: true,
+  })
+
+  expect(exitCode).toBe(0)
+
+  const parsed = JSON.parse(output)
+  const componentNames = parsed.components.map((c: { name: string }) => c.name)
+  expect(componentNames).toContain('is-positive')
+  expect(componentNames).toContain('is-odd')
+  expect(componentNames).toContain('is-number')
+})
+
+test('pnpm sbom --exclude-peers drops peers and their exclusive subtrees', async () => {
+  const workspaceDir = tempDir()
+  f.copy('with-peer-dependency', workspaceDir)
+
+  const { output, exitCode } = await sbom.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    sbomFormat: 'cyclonedx',
+    lockfileOnly: true,
+    excludePeers: true,
+  })
+
+  expect(exitCode).toBe(0)
+
+  const parsed = JSON.parse(output)
+  const componentNames = parsed.components.map((c: { name: string }) => c.name)
+  expect(componentNames).toContain('is-positive')
+  // is-odd is the peer; is-number is only reachable through is-odd
+  expect(componentNames).not.toContain('is-odd')
+  expect(componentNames).not.toContain('is-number')
+
+  // The dropped peer must not linger in the root's dependency graph either
+  const rootRef = parsed.metadata.component['bom-ref']
+  const rootDeps = parsed.dependencies.find((d: { ref: string }) => d.ref === rootRef)
+  expect(rootDeps.dependsOn).not.toContain('pkg:npm/is-odd@3.0.1')
+})
+
+test('pnpm sbom --exclude-peers drops peers declared in workspace sub-packages', async () => {
+  const workspaceDir = tempDir()
+  f.copy('with-peer-workspace', workspaceDir)
+
+  // No --filter, so no selectedProjectsGraph: every importer is walked. The
+  // peer (is-odd) is declared in packages/pkg-a, not the directory pnpm runs in.
+  const { output, exitCode } = await sbom.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    sbomFormat: 'cyclonedx',
+    lockfileOnly: true,
+    excludePeers: true,
+  })
+
+  expect(exitCode).toBe(0)
+
+  const parsed = JSON.parse(output)
+  const componentNames = parsed.components.map((c: { name: string }) => c.name)
+  expect(componentNames).toContain('is-positive')
+  expect(componentNames).not.toContain('is-odd')
+  expect(componentNames).not.toContain('is-number')
+})
+
 test('pnpm sbom marks dev-only components with scope "excluded" (cyclonedx)', async () => {
   const workspaceDir = tempDir()
   f.copy('with-dev-dependency', workspaceDir)

--- a/deps/compliance/commands/test/sbom/index.ts
+++ b/deps/compliance/commands/test/sbom/index.ts
@@ -288,6 +288,31 @@ test('pnpm sbom --exclude-peers tolerates a malformed importer manifest', async 
   expect(componentNames).toContain('is-positive')
 })
 
+test('pnpm sbom --exclude-peers keeps a package that is a peer in one importer and a real dep in another', async () => {
+  const workspaceDir = tempDir()
+  // pkg-a declares is-odd as a peer (excluded); pkg-b declares it as a real
+  // dependency (kept). The importers must be walked independently, or excluding
+  // pkg-a's peer would also drop pkg-b's real dependency.
+  f.copy('with-peer-and-real-dep', workspaceDir)
+
+  const { output, exitCode } = await sbom.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    sbomFormat: 'cyclonedx',
+    lockfileOnly: true,
+    excludePeers: true,
+  })
+
+  expect(exitCode).toBe(0)
+  const parsed = JSON.parse(output)
+  const componentNames = parsed.components.map((c: { name: string }) => c.name)
+  // Present because pkg-b depends on it directly; only pkg-a's peer edge is cut.
+  expect(componentNames).toContain('is-odd')
+  expect(componentNames).toContain('is-number')
+})
+
 test('pnpm sbom marks dev-only components with scope "excluded" (cyclonedx)', async () => {
   const workspaceDir = tempDir()
   f.copy('with-dev-dependency', workspaceDir)

--- a/deps/compliance/sbom/src/collectComponents.ts
+++ b/deps/compliance/sbom/src/collectComponents.ts
@@ -54,6 +54,8 @@ export async function collectSbomComponents (opts: CollectSbomComponentsOptions)
   const depTypes = detectDepTypes(opts.lockfile)
   const importerIds = opts.includedImporterIds ?? Object.keys(opts.lockfile.importers) as ProjectId[]
 
+
+
   const componentsMap = new Map<string, SbomComponent>()
   const relationships: SbomRelationship[] = []
   const rootPurl = `pkg:npm/${encodePurlName(opts.rootName)}@${opts.rootVersion}`
@@ -64,11 +66,12 @@ export async function collectSbomComponents (opts: CollectSbomComponentsOptions)
       : resolveWorkspaceDeps(opts.lockfile, importerIds, opts.include))
   const allImporterIds = [...importerIds, ...workspaceDeps.additionalImporterIds]
 
-  const importerWalkers = lockfileWalkerGroupImporterSteps(
-    opts.lockfile,
-    allImporterIds,
-    { include: opts.include }
-  )
+  // When excluding peers, walk each importer with its own `walked` set so one
+  // importer's peer can't suppress another's real dependency.
+  const importerWalkers = opts.excludePeerNamesByImporter
+    ? allImporterIds.flatMap((importerId) =>
+      lockfileWalkerGroupImporterSteps(opts.lockfile, [importerId], { include: opts.include }))
+    : lockfileWalkerGroupImporterSteps(opts.lockfile, allImporterIds, { include: opts.include })
 
   const importerIdSet = new Set<string>(importerIds)
 

--- a/deps/compliance/sbom/src/collectComponents.ts
+++ b/deps/compliance/sbom/src/collectComponents.ts
@@ -45,7 +45,7 @@ export interface CollectSbomComponentsOptions {
   resolvedWorkspaceDeps?: ReturnType<typeof resolveWorkspaceDeps>
   // With auto-install-peers, peers resolve into the importer's `dependencies`
   // and are indistinguishable from real deps in the lockfile.
-  excludePeerNamesByImporter?: Record<string, Set<string>>
+  excludePeerNamesByImporter?: Map<string, Set<string>>
 }
 
 const IMPORTER_WALK_CONCURRENCY = 8
@@ -141,7 +141,7 @@ export async function collectSbomComponents (opts: CollectSbomComponentsOptions)
         if (!info) return
         parentPurl = buildPurl({ name: info.name, version: info.version })
       }
-      const peerNames = opts.excludePeerNamesByImporter?.[importerId]
+      const peerNames = opts.excludePeerNamesByImporter?.get(importerId)
       const filteredStep = (peerNames?.size)
         ? {
           ...step,

--- a/deps/compliance/sbom/src/collectComponents.ts
+++ b/deps/compliance/sbom/src/collectComponents.ts
@@ -54,8 +54,6 @@ export async function collectSbomComponents (opts: CollectSbomComponentsOptions)
   const depTypes = detectDepTypes(opts.lockfile)
   const importerIds = opts.includedImporterIds ?? Object.keys(opts.lockfile.importers) as ProjectId[]
 
-
-
   const componentsMap = new Map<string, SbomComponent>()
   const relationships: SbomRelationship[] = []
   const rootPurl = `pkg:npm/${encodePurlName(opts.rootName)}@${opts.rootVersion}`
@@ -141,9 +139,15 @@ export async function collectSbomComponents (opts: CollectSbomComponentsOptions)
       let parentPurl = rootPurl
       if (!importerIdSet.has(importerId as ProjectId)) {
         const info = opts.workspacePackages?.[importerId as ProjectId]
+        // A reachable workspace importer with no resolved package info (e.g. its
+        // manifest could not be read) is skipped entirely; walking it would
+        // misattribute its dependencies to the root component.
         if (!info) return
         parentPurl = buildPurl({ name: info.name, version: info.version })
       }
+      // Drop this importer's peer entries before walking. With the per-importer
+      // walk above, this prunes a peer's exclusive subtree without hiding a
+      // package that is also a real dependency here or in another importer.
       const peerNames = opts.excludePeerNamesByImporter?.get(importerId)
       const filteredStep = (peerNames?.size)
         ? {

--- a/deps/compliance/sbom/src/collectComponents.ts
+++ b/deps/compliance/sbom/src/collectComponents.ts
@@ -43,6 +43,9 @@ export interface CollectSbomComponentsOptions {
   virtualStoreDirMaxLength?: number
   workspacePackages?: Record<ProjectId, WorkspacePackageInfo>
   resolvedWorkspaceDeps?: ReturnType<typeof resolveWorkspaceDeps>
+  // With auto-install-peers, peers resolve into the importer's `dependencies`
+  // and are indistinguishable from real deps in the lockfile.
+  excludePeerNamesByImporter?: Record<string, Set<string>>
 }
 
 const IMPORTER_WALK_CONCURRENCY = 8
@@ -135,14 +138,21 @@ export async function collectSbomComponents (opts: CollectSbomComponentsOptions)
       let parentPurl = rootPurl
       if (!importerIdSet.has(importerId as ProjectId)) {
         const info = opts.workspacePackages?.[importerId as ProjectId]
-        // A reachable workspace importer with no resolved package info (e.g. its
-        // manifest could not be read) is skipped entirely; walking it would
-        // misattribute its dependencies to the root component.
         if (!info) return
         parentPurl = buildPurl({ name: info.name, version: info.version })
       }
+      const peerNames = opts.excludePeerNamesByImporter?.[importerId]
+      const filteredStep = (peerNames?.size)
+        ? {
+          ...step,
+          dependencies: step.dependencies.filter((dep) => {
+            const { name } = nameVerFromPkgSnapshot(dep.depPath, dep.pkgSnapshot)
+            return !name || !peerNames.has(name)
+          }),
+        }
+        : step
       await walkStep(
-        step,
+        filteredStep,
         parentPurl,
         depTypes,
         componentsMap,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -970,7 +970,7 @@ catalogs:
       version: 5.0.0
     tinyglobby:
       specifier: ^0.2.16
-      version: 0.2.17
+      version: 0.2.16
     touch:
       specifier: 3.1.1
       version: 3.1.1
@@ -1473,7 +1473,7 @@ importers:
         version: 7.5.16
       tinyglobby:
         specifier: 'catalog:'
-        version: 0.2.17
+        version: 0.2.16
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -1712,7 +1712,7 @@ importers:
         version: 2.0.0
       tinyglobby:
         specifier: 'catalog:'
-        version: 0.2.17
+        version: 0.2.16
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -2075,7 +2075,7 @@ importers:
         version: 3.0.1
       tinyglobby:
         specifier: 'catalog:'
-        version: 0.2.17
+        version: 0.2.16
     devDependencies:
       '@pnpm/cache.api':
         specifier: workspace:*
@@ -7535,7 +7535,7 @@ importers:
         version: 5.0.0
       tinyglobby:
         specifier: 'catalog:'
-        version: 0.2.17
+        version: 0.2.16
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -8411,7 +8411,7 @@ importers:
         version: 3.0.0
       tinyglobby:
         specifier: 'catalog:'
-        version: 0.2.17
+        version: 0.2.16
       validate-npm-package-name:
         specifier: 'catalog:'
         version: 7.0.2
@@ -9900,7 +9900,7 @@ importers:
         version: 4.1.0
       tinyglobby:
         specifier: 'catalog:'
-        version: 0.2.17
+        version: 0.2.16
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -16691,6 +16691,10 @@ packages:
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -25014,6 +25018,11 @@ snapshots:
       - react-native-b4a
 
   tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:


### PR DESCRIPTION
With `auto-install-peers` (default since v8), peer dependencies resolve into
the lockfile indistinguishably from a package's own deps, so `pnpm sbom` lists
them as the package's components. For a published-library SBOM that's wrong —
peers are supplied by the consumer. `--exclude-peers` drops them, plus any
transitive subtree reachable only through them.

peerDependencies come from the manifest (the lockfile carries no marker). The
collector filters those names at each importer's top level, so a peer's
exclusive subtree is never walked while a package also reached via a real dep
stays. With no `--filter`, every importer is walked, so each importer's own
manifest is resolved (via `safeReadProjectManifestOnly`, which tolerates a
missing manifest) and peers in workspace sub-packages are dropped too.

The flag name matches `pnpm list --exclude-peers`; the SBOM behavior is
stricter, pruning the exclusive subtree rather than only hiding leaf peers.
CycloneDX 1.7 has no scope or relationship for "consumer-provided peer", so
omission is the only spec-clean handling.

Known limitation: an aliased peer (`"x": "npm:real@1"` in `peerDependencies`)
is not excluded, since matching is by resolved package name. Aliased peer deps
are vanishingly rare in practice.

## Tests

Single-project (peer + exclusive subtree dropped, absent from `dependsOn`,
real deps kept), workspace (peer declared in a sub-package dropped when run at
the root with no filter), and default-includes-peers.

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--exclude-peers` option to `pnpm sbom` to omit peer dependencies (and any subtrees reachable only through them) from the generated SBOM.

* **Bug Fixes**
  * Improved lockfile-only SBOM generation by pruning peer-only dependency trees and removing dropped peer references from the root dependency graph.
  * Ensures peer packages declared within workspace sub-packages are also excluded when `--exclude-peers` is enabled.

* **Tests**
  * Added test coverage for peer dependency exclusion, including workspaces and additional peer fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->