### PR TITLE
feat(sbom): add issue-tracker external reference from package bugs

### DIFF
--- a/.changeset/sbom-issue-tracker-ref.md
+++ b/.changeset/sbom-issue-tracker-ref.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/deps.compliance.sbom": patch
+"@pnpm/deps.compliance.commands": patch
+"pnpm": patch
+---
+
+`pnpm sbom` now emits a CycloneDX `issue-tracker` external reference for components (and the root) whose `package.json` declares a `bugs` URL. Email-only `bugs` entries are skipped, since the reference requires a URL.

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -8,6 +8,7 @@ import { type Config, type ConfigContext, types as allTypes } from '@pnpm/config
 import { WANTED_LOCKFILE } from '@pnpm/constants'
 import { isSpdxLicenseExpression, resolveLicenseFromDir } from '@pnpm/deps.compliance.license-resolver'
 import {
+  bugsUrlFromField,
   collectSbomComponents,
   resolveWorkspaceDeps,
   type SbomComponentType,
@@ -377,6 +378,8 @@ async function generateSbomForProject (
     ?? (singleProject ? extractRepository(rootManifest) : undefined)
   const rootDescription = manifest.description
     ?? (singleProject ? rootManifest.description : undefined)
+  const rootBugsUrl = bugsUrlFromField(manifest.bugs)
+    ?? (singleProject ? bugsUrlFromField(rootManifest.bugs) : undefined)
 
   const lockfileDir = opts.lockfileDir ?? opts.dir
   const includedImporterIds = opts.selectedProjectsGraph
@@ -407,6 +410,7 @@ async function generateSbomForProject (
     rootDescription,
     rootAuthor,
     rootRepository,
+    rootBugsUrl,
     sbomType: serialOpts.sbomType,
     include,
     registries: opts.registries,

--- a/deps/compliance/sbom/src/collectComponents.ts
+++ b/deps/compliance/sbom/src/collectComponents.ts
@@ -33,6 +33,7 @@ export interface CollectSbomComponentsOptions {
   rootDescription?: string
   rootAuthor?: string
   rootRepository?: string
+  rootBugsUrl?: string
   sbomType?: SbomComponentType
   include?: { [dependenciesField in DependenciesField]: boolean }
   registries: Registries
@@ -163,6 +164,7 @@ export async function collectSbomComponents (opts: CollectSbomComponentsOptions)
       description: opts.rootDescription,
       author: opts.rootAuthor,
       repository: opts.rootRepository,
+      bugsUrl: opts.rootBugsUrl,
     },
     components: Array.from(componentsMap.values()),
     relationships,
@@ -195,7 +197,7 @@ async function walkStep (
       const resolution = pkgSnapshotToResolution(depPath, pkgSnapshot, opts.registries)
       const tarballUrl = (resolution as TarballResolution).tarball ?? gitDownloadUrl(resolution)
 
-      let metadata: { license?: string, description?: string, author?: string, homepage?: string, repository?: string } = {}
+      let metadata: { license?: string, description?: string, author?: string, homepage?: string, repository?: string, bugsUrl?: string } = {}
       if (metadataOpts) {
         metadata = await getPkgMetadata(depPath, pkgSnapshot, opts.registries, metadataOpts)
       }

--- a/deps/compliance/sbom/src/getPkgMetadata.ts
+++ b/deps/compliance/sbom/src/getPkgMetadata.ts
@@ -14,6 +14,7 @@ export interface PkgMetadata {
   author?: string
   homepage?: string
   repository?: string
+  bugsUrl?: string
 }
 
 export interface GetPkgMetadataOptions {
@@ -64,6 +65,7 @@ async function extractMetadata (manifest: PackageManifest, files: Map<string, st
     author: parseAuthorField(manifest.author),
     homepage: manifest.homepage,
     repository: parseRepositoryField(manifest.repository),
+    bugsUrl: bugsUrlFromField(manifest.bugs),
   }
 }
 
@@ -94,4 +96,27 @@ function parseRepositoryField (field: unknown): string | undefined {
     return (field as { url: string }).url
   }
   return undefined
+}
+
+// `bugs` may be a URL string, a bare email, or `{ url, email }`. The CycloneDX
+// issue-tracker reference expects a URL, so parse the candidate and keep it only
+// when it is a well-formed http(s) URL — dropping email-only bug contacts and
+// malformed values like "https://". Exported so the command's root-package
+// handling uses the same rule.
+export function bugsUrlFromField (field: unknown): string | undefined {
+  let candidate: string | undefined
+  if (typeof field === 'string') {
+    candidate = field.trim()
+  } else if (field && typeof field === 'object' && 'url' in field) {
+    const value = (field as { url?: unknown }).url
+    if (typeof value === 'string') candidate = value.trim()
+  }
+  if (!candidate) return undefined
+  let parsed: URL
+  try {
+    parsed = new URL(candidate)
+  } catch {
+    return undefined
+  }
+  return (parsed.protocol === 'http:' || parsed.protocol === 'https:') ? candidate : undefined
 }

--- a/deps/compliance/sbom/src/getPkgMetadata.ts
+++ b/deps/compliance/sbom/src/getPkgMetadata.ts
@@ -119,6 +119,11 @@ export function bugsUrlFromField (field: unknown): string | undefined {
     return undefined
   }
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return undefined
+  // Drop any embedded credentials: an SBOM is a shareable/published artifact,
+  // so a `bugs` URL like `https://user:token@tracker/...` must not leak the
+  // secret into externalReferences[].url. The tracker URL itself is still useful.
+  parsed.username = ''
+  parsed.password = ''
   // Emit the normalized URL, not the raw input: `new URL` strips CR/LF/tab and
   // percent-encodes spaces and control characters, so a crafted `bugs` value
   // can't push raw whitespace or control chars into the CycloneDX

--- a/deps/compliance/sbom/src/getPkgMetadata.ts
+++ b/deps/compliance/sbom/src/getPkgMetadata.ts
@@ -118,5 +118,10 @@ export function bugsUrlFromField (field: unknown): string | undefined {
   } catch {
     return undefined
   }
-  return (parsed.protocol === 'http:' || parsed.protocol === 'https:') ? candidate : undefined
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return undefined
+  // Emit the normalized URL, not the raw input: `new URL` strips CR/LF/tab and
+  // percent-encodes spaces and control characters, so a crafted `bugs` value
+  // can't push raw whitespace or control chars into the CycloneDX
+  // `externalReferences[].url` (whose format is an `iri-reference`).
+  return parsed.href
 }

--- a/deps/compliance/sbom/src/index.ts
+++ b/deps/compliance/sbom/src/index.ts
@@ -1,4 +1,5 @@
 export { collectSbomComponents, type CollectSbomComponentsOptions, gitDownloadUrl, resolveWorkspaceDeps, type WorkspacePackageInfo } from './collectComponents.js'
+export { bugsUrlFromField } from './getPkgMetadata.js'
 export { integrityToHashes } from './integrity.js'
 export { buildPurl, encodePurlName } from './purl.js'
 export { type CycloneDxOptions, serializeCycloneDx } from './serializeCycloneDx.js'

--- a/deps/compliance/sbom/src/serializeCycloneDx.ts
+++ b/deps/compliance/sbom/src/serializeCycloneDx.ts
@@ -96,6 +96,13 @@ export function serializeCycloneDx (result: SbomResult, opts?: CycloneDxOptions)
       })
     }
 
+    if (comp.bugsUrl) {
+      externalRefs.push({
+        type: 'issue-tracker',
+        url: comp.bugsUrl,
+      })
+    }
+
     if (externalRefs.length > 0) {
       cdxComp.externalReferences = externalRefs
     }
@@ -142,11 +149,15 @@ export function serializeCycloneDx (result: SbomResult, opts?: CycloneDxOptions)
   if (rootComponent.description) {
     rootCdxComponent.description = rootComponent.description
   }
+  const rootExternalRefs: Array<Record<string, unknown>> = []
   if (rootComponent.repository) {
-    rootCdxComponent.externalReferences = [{
-      type: 'vcs',
-      url: rootComponent.repository,
-    }]
+    rootExternalRefs.push({ type: 'vcs', url: rootComponent.repository })
+  }
+  if (rootComponent.bugsUrl) {
+    rootExternalRefs.push({ type: 'issue-tracker', url: rootComponent.bugsUrl })
+  }
+  if (rootExternalRefs.length > 0) {
+    rootCdxComponent.externalReferences = rootExternalRefs
   }
 
   const toolComponents: Array<Record<string, unknown>> = []

--- a/deps/compliance/sbom/src/types.ts
+++ b/deps/compliance/sbom/src/types.ts
@@ -13,6 +13,7 @@ export interface SbomComponent {
   author?: string
   homepage?: string
   repository?: string
+  bugsUrl?: string
 }
 
 export interface SbomRelationship {
@@ -29,6 +30,7 @@ export interface SbomResult {
     description?: string
     author?: string
     repository?: string
+    bugsUrl?: string
   }
   components: SbomComponent[]
   relationships: SbomRelationship[]

--- a/deps/compliance/sbom/test/getPkgMetadata.test.ts
+++ b/deps/compliance/sbom/test/getPkgMetadata.test.ts
@@ -135,12 +135,20 @@ describe('getPkgMetadata', () => {
 })
 
 describe('bugsUrlFromField', () => {
-  it('keeps well-formed http(s) URLs, including uppercase schemes', () => {
+  it('keeps well-formed http(s) URLs and normalizes the scheme', () => {
     expect(bugsUrlFromField('https://github.com/a/b/issues')).toBe('https://github.com/a/b/issues')
     expect(bugsUrlFromField('http://example.com/bugs')).toBe('http://example.com/bugs')
-    expect(bugsUrlFromField('HTTPS://github.com/a/b/issues')).toBe('HTTPS://github.com/a/b/issues')
+    // Uppercase scheme is accepted and normalized to lowercase by `new URL`.
+    expect(bugsUrlFromField('HTTPS://github.com/a/b/issues')).toBe('https://github.com/a/b/issues')
     expect(bugsUrlFromField('  https://github.com/a/b/issues  ')).toBe('https://github.com/a/b/issues')
     expect(bugsUrlFromField({ url: 'https://github.com/a/b/issues' })).toBe('https://github.com/a/b/issues')
+  })
+
+  it('normalizes away control characters and whitespace instead of emitting them raw', () => {
+    // `new URL` strips CR/LF/tab and percent-encodes spaces, so a crafted value
+    // can't push raw whitespace or control chars into the SBOM url field.
+    expect(bugsUrlFromField('https://example.com/\r\nSet-Cookie: x')).toBe('https://example.com/Set-Cookie:%20x')
+    expect(bugsUrlFromField('https://example.com/a b')).toBe('https://example.com/a%20b')
   })
 
   it('drops malformed URLs, non-http schemes, emails, and missing values', () => {

--- a/deps/compliance/sbom/test/getPkgMetadata.test.ts
+++ b/deps/compliance/sbom/test/getPkgMetadata.test.ts
@@ -7,7 +7,7 @@ import type { PackageFilesIndex } from '@pnpm/store.cafs'
 import { gitHostedStoreIndexKey, StoreIndex, storeIndexKey } from '@pnpm/store.index'
 import type { DepPath } from '@pnpm/types'
 
-import { getPkgMetadata } from '../lib/getPkgMetadata.js'
+import { bugsUrlFromField, getPkgMetadata } from '../lib/getPkgMetadata.js'
 
 const DEFAULT_REGISTRIES = {
   default: 'https://registry.npmjs.org/',
@@ -131,5 +131,24 @@ describe('getPkgMetadata', () => {
     )
 
     expect(result).toEqual({})
+  })
+})
+
+describe('bugsUrlFromField', () => {
+  it('keeps well-formed http(s) URLs, including uppercase schemes', () => {
+    expect(bugsUrlFromField('https://github.com/a/b/issues')).toBe('https://github.com/a/b/issues')
+    expect(bugsUrlFromField('http://example.com/bugs')).toBe('http://example.com/bugs')
+    expect(bugsUrlFromField('HTTPS://github.com/a/b/issues')).toBe('HTTPS://github.com/a/b/issues')
+    expect(bugsUrlFromField('  https://github.com/a/b/issues  ')).toBe('https://github.com/a/b/issues')
+    expect(bugsUrlFromField({ url: 'https://github.com/a/b/issues' })).toBe('https://github.com/a/b/issues')
+  })
+
+  it('drops malformed URLs, non-http schemes, emails, and missing values', () => {
+    expect(bugsUrlFromField('https://')).toBeUndefined()
+    expect(bugsUrlFromField('not a url')).toBeUndefined()
+    expect(bugsUrlFromField('bugs@example.com')).toBeUndefined()
+    expect(bugsUrlFromField('mailto:bugs@example.com')).toBeUndefined()
+    expect(bugsUrlFromField({ email: 'bugs@example.com' })).toBeUndefined()
+    expect(bugsUrlFromField(undefined)).toBeUndefined()
   })
 })

--- a/deps/compliance/sbom/test/getPkgMetadata.test.ts
+++ b/deps/compliance/sbom/test/getPkgMetadata.test.ts
@@ -151,6 +151,12 @@ describe('bugsUrlFromField', () => {
     expect(bugsUrlFromField('https://example.com/a b')).toBe('https://example.com/a%20b')
   })
 
+  it('strips embedded credentials so the SBOM does not leak them', () => {
+    expect(bugsUrlFromField('https://user:token@tracker.example/a/b/issues')).toBe('https://tracker.example/a/b/issues')
+    expect(bugsUrlFromField('https://only-user@tracker.example/x')).toBe('https://tracker.example/x')
+    expect(bugsUrlFromField({ url: 'https://u:p@tracker.example/i' })).toBe('https://tracker.example/i')
+  })
+
   it('drops malformed URLs, non-http schemes, emails, and missing values', () => {
     expect(bugsUrlFromField('https://')).toBeUndefined()
     expect(bugsUrlFromField('not a url')).toBeUndefined()

--- a/deps/compliance/sbom/test/serializeCycloneDx.test.ts
+++ b/deps/compliance/sbom/test/serializeCycloneDx.test.ts
@@ -236,6 +236,33 @@ describe('serializeCycloneDx', () => {
     expect(distRef).toBeUndefined()
   })
 
+  it('should emit an issue-tracker external reference from bugsUrl', () => {
+    const result = makeSbomResult()
+    result.components[0].bugsUrl = 'https://github.com/lodash/lodash/issues'
+    result.rootComponent.bugsUrl = 'https://github.com/acme/sbom-app/issues'
+    const parsed = JSON.parse(serializeCycloneDx(result))
+
+    const lodashRef = parsed.components[0].externalReferences.find(
+      (r: { type: string }) => r.type === 'issue-tracker'
+    )
+    expect(lodashRef.url).toBe('https://github.com/lodash/lodash/issues')
+
+    const rootRef = parsed.metadata.component.externalReferences.find(
+      (r: { type: string }) => r.type === 'issue-tracker'
+    )
+    expect(rootRef.url).toBe('https://github.com/acme/sbom-app/issues')
+  })
+
+  it('should omit the issue-tracker reference when bugsUrl is absent', () => {
+    const result = makeSbomResult()
+    const parsed = JSON.parse(serializeCycloneDx(result))
+
+    const ref = parsed.components[0].externalReferences?.find(
+      (r: { type: string }) => r.type === 'issue-tracker'
+    )
+    expect(ref).toBeUndefined()
+  })
+
   it('should use license.id for known SPDX identifiers', () => {
     const result = makeSbomResult()
     const parsed = JSON.parse(serializeCycloneDx(result))


### PR DESCRIPTION
`pnpm sbom`'s CycloneDX output already emits `website` (homepage) and `vcs`
(repository) external references, but not the issue tracker, even though
`package.json` commonly declares one via `bugs`. This adds a CycloneDX
`issue-tracker` external reference for each component (and the root) that has a
`bugs` URL.

`bugs` can be a URL string, a bare email, or `{ url, email }`. Only http(s)
URLs are emitted; email-only bug contacts are skipped, since the reference
requires a URL. Like `homepage`/`repository`, the value comes from package
metadata, so it appears only when the store is read (not under
`--lockfile-only`).

## Tests

Serializer unit tests assert the `issue-tracker` ref is emitted for a component
and the root when `bugsUrl` is set, and omitted otherwise.

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm sbom` now includes CycloneDX `issue-tracker` external references for both the root and dependency components when their manifests define a valid HTTP(S) `bugs` URL.
* **Bug Fixes**
  * `bugs` entries that can’t be converted into a valid URL (including email-only or non-HTTP(S) values) are skipped to avoid invalid references.
* **Tests**
  * Added Jest coverage to verify `issue-tracker` emission when `bugsUrl` is present and omission when it’s not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->