### PR TITLE
ci: require a single aggregate gate job per workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
     # Skip pull_request events from PRs in the same repo. This prevents
     # duplicate build jobs from running when creating a PR in the original repo.
     # Exception: chore/update-lockfile PRs (created by automation with GITHUB_TOKEN, which doesn't trigger push events)
+    #
+    # KEEP IN SYNC with the `success` job's name expression below: it must
+    # use this exact condition to give the skipped duplicate run a
+    # different name, so it never reports the required `TS CI / Success`.
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository || github.head_ref == 'chore/update-lockfile' }}
 
     name: TS CI / Compile & Lint
@@ -84,3 +88,29 @@ jobs:
       node: ${{ matrix.node }}
       node_major: ${{ matrix.node_major }}
       platform: ${{ matrix.platform }}
+
+  # Single aggregate gate — the only TS CI context branch protection needs
+  # to require. The Test matrix changes shape per branch (see the excludes
+  # above) and the jobs skip on same-repo PR events, so requiring the
+  # individual per-combination contexts is brittle. This job always runs
+  # and fails only if a dependency actually failed or was cancelled —
+  # skipped dependencies count as a pass.
+  #
+  # The name is `TS CI / Success` on every run that does real work, but a
+  # different name on the same-repo pull_request run that `compile-and-lint`
+  # skips for deduplication. Otherwise that skipped run would report a
+  # green `TS CI / Success` and satisfy branch protection before the real
+  # push run finished — letting a PR merge without CI. The name condition
+  # is `compile-and-lint`'s `if:` verbatim and MUST stay in sync with it.
+  success:
+    name: ${{ (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository || github.head_ref == 'chore/update-lockfile') && 'TS CI / Success' || 'TS CI / Success (skipped duplicate)' }}
+    if: ${{ always() }}
+    needs:
+      - compile-and-lint
+      - test-smoke
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any dependency failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -3,9 +3,9 @@ name: Rust CI
 # This workflow covers every Rust crate in the repo — pacquet and
 # pnpr alike. They share the same cargo workspace, so `just test`,
 # dylint, doc, etc. all see both stacks in one pass; running two
-# workflows would just duplicate the work. Keep path filtering out
-# of the workflow trigger so required checks are created and can
-# report skipped.
+# workflows would just duplicate the work. Path filtering stays out
+# of the workflow trigger so the `success` gate always runs; branch
+# protection requires only that gate, which folds in every job below.
 
 permissions:
   contents: read
@@ -399,3 +399,29 @@ jobs:
         env:
           RUSTFLAGS: '-D warnings'
         run: cargo dylint --all -- --all-targets --workspace
+
+  # Single aggregate gate — the only Rust CI context branch protection
+  # needs to require. Listing the individual jobs as required checks does
+  # not work: most of them skip on non-Rust PRs, and a matrix job skipped
+  # at the job level never expands its `${{ matrix.* }}` name, so the
+  # per-OS contexts it would report never appear and the PR blocks forever
+  # waiting for them. This job always runs (it reports under a static name
+  # in every state) and fails only if a dependency actually failed or was
+  # cancelled — skipped dependencies count as a pass.
+  success:
+    name: Rust CI / Success
+    if: ${{ always() }}
+    needs:
+      - changes
+      - test
+      - clippy
+      - doc
+      - typos
+      - deny
+      - format
+      - dylint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any dependency failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1


### PR DESCRIPTION
## Problem

PRs that touch no Rust files (e.g. pnpm/pnpm#12287) get stuck as **not mergeable**, blocked on required checks that are never reported.

Branch protection requires the individual Rust CI Test jobs:

- `Rust CI / Test / ubuntu`
- `Rust CI / Test / windows`
- `Rust CI / Test / macos`

These come from a single **matrix** job gated to skip on non-Rust PRs. When a matrix job is skipped *at the job level*, GitHub does **not** expand the matrix — it reports a single check under the literal, unexpanded name:

```
Rust CI / Test / ${{ matrix.os_label }}   (skipping)
```

So the three required per-OS contexts never appear, and the PR waits on them forever.

## Fix

Add one static-named aggregate gate per workflow — the canonical pattern for required matrix checks:

- **`Rust CI / Success`** — `needs` every Rust job (`changes`, `test`, `clippy`, `doc`, `typos`, `deny`, `format`, `dylint`).
- **`TS CI / Success`** — `needs` `compile-and-lint`, `test-smoke`, `test`.

Each runs with `if: ${{ always() }}` so it reports under a static name in every state, and fails only when a dependency actually **failed or was cancelled** (`contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')`). Skipped dependencies count as a pass — a skipped job means "not applicable to this PR". No third-party action is used, keeping the merge gate's supply-chain surface minimal.

### The TS CI same-repo bypass, and how the gate avoids it

TS CI runs on **both** `push` and `pull_request`. On a same-repo PR the `pull_request` run skips `compile-and-lint` (the dedup `if:` guard), cascading skips to the whole matrix. A naive gate would report a green `TS CI / Success` on that skipped run and satisfy branch protection **before the real `push` run finished** — letting a PR merge without CI actually running.

To prevent this, the gate's **name** is `TS CI / Success` only on runs that do real work, and a *different* name (`TS CI / Success (skipped duplicate)`) on the same-repo `pull_request` run that gets deduplicated:

```yaml
name: ${{ (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository || github.head_ref == 'chore/update-lockfile') && 'TS CI / Success' || 'TS CI / Success (skipped duplicate)' }}
```

The condition is `compile-and-lint`'s `if:` verbatim, so the required `TS CI / Success` context is emitted only by real runs (same-repo `push`, fork `pull_request`, `chore/update-lockfile` PRs, `main` push). Forks keep working (their real run is the `pull_request` event). The two spots carry a comment noting the name and the `if:` must stay in sync.

Rust CI needs no such guard: its `push` trigger is restricted to `main`, so a PR produces a single run with no concurrent run to shadow it.

## Required follow-up (branch protection)

One-time change on `main`, landed in lockstep with the merge. Replace the per-job contexts:

- ~~`Rust CI / Clippy`, `Rust CI / Dylint`, `Rust CI / Doc`, `Rust CI / Spell Check`, `Rust CI / Test / ubuntu`, `Rust CI / Test / windows`, `Rust CI / Test / macos`~~
- ~~`TS CI / Compile & Lint`, `TS CI / Test / windows / Node 22`, `TS CI / Test / ubuntu / Node 22`, `TS CI / Test / ubuntu / Node 24`, `TS CI / Test / ubuntu / Node 26`~~

with just:

- `Rust CI / Success`
- `TS CI / Success`

Note: the `Success` gates also fold in jobs that were not previously required individually (`Cargo Deny`, `Format`), so a failure in those will now block merge too.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Continuous Integration pipeline reliability with unified, always-running success gates that aggregate results across Rust and TypeScript checks.
  * Updated workflow trigger/comment behavior and required-gate alignment to prevent duplicate runs from incorrectly blocking branch protection.
  * Success gating now treats skipped dependency checks as passing, while still failing when any required check fails or is cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->