### PR TITLE
feat(pacquet): add --ignore-scripts to install

### DIFF
--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -321,6 +321,9 @@ impl CliArgs {
                 cfg.offline = cfg.offline || args.offline;
                 cfg.prefer_offline = cfg.prefer_offline || args.prefer_offline;
                 cfg.frozen_store = cfg.frozen_store || args.frozen_store;
+                // `--ignore-scripts` enables (never toggles off) the
+                // config value, matching the "enable" CLI flags above.
+                cfg.ignore_scripts = cfg.ignore_scripts || args.ignore_scripts;
                 cfg.workspace_concurrency =
                     args.resolve_workspace_concurrency(cfg.workspace_concurrency);
                 // Network overrides: a passed `--network-concurrency` /

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -140,6 +140,19 @@ pub struct InstallArgs {
     #[clap(long = "no-runtime")]
     pub no_runtime: bool,
 
+    /// Don't run lifecycle scripts of the project or its dependencies.
+    /// Dependency build scripts that would otherwise be reported as
+    /// ignored are skipped silently, so the install doesn't fail with
+    /// `ERR_PNPM_IGNORED_BUILDS` under `strictDepBuilds`. Mirrors pnpm's
+    /// `--ignore-scripts`.
+    ///
+    /// Merged into `config.ignore_scripts` at the CLI dispatch in
+    /// `cli_args.rs` (it only ever enables, never toggles a yaml `true`
+    /// back off), so the install reads it from the config like every
+    /// other build-script setting.
+    #[clap(long = "ignore-scripts")]
+    pub ignore_scripts: bool,
+
     /// Override `nodeLinker` from `pnpm-workspace.yaml` /
     /// `.npmrc`. Mirrors upstream pnpm's `--node-linker` flag.
     /// `None` (flag not passed) leaves the config's value
@@ -334,6 +347,9 @@ impl InstallArgs {
             no_prefer_frozen_lockfile,
             ignore_manifest_check,
             no_runtime,
+            // Read from `config.ignore_scripts` (the CLI flag was already
+            // merged in by the dispatch in `cli_args.rs`), not from here.
+            ignore_scripts: _,
             node_linker,
             offline: _,
             // Read from `config.frozen_store` (the CLI flag was already

--- a/pacquet/crates/cli/tests/lifecycle_scripts.rs
+++ b/pacquet/crates/cli/tests/lifecycle_scripts.rs
@@ -612,6 +612,55 @@ mod dependency_build_scripts {
         drop((root, mock_instance));
     }
 
+    /// `pacquet install --ignore-scripts` must exit 0 even under the
+    /// default `strictDepBuilds`, with no `allowBuilds`: `--ignore-scripts`
+    /// suppresses every dependency build, so nothing is reported as an
+    /// ignored build and the strict gate never fires. The dependency is
+    /// still materialized, but its lifecycle scripts do not run. Mirrors
+    /// pnpm's `--ignore-scripts`, which leaves `ignoredBuilds` empty.
+    #[test]
+    fn install_ignore_scripts_does_not_fail_under_strict_dep_builds() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        let manifest_path = workspace.join("package.json");
+        let package_json = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+            },
+        });
+        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+        // No `allowBuilds` and `strictDepBuilds` defaults to true: a plain
+        // `pacquet install` would fail with `ERR_PNPM_IGNORED_BUILDS`.
+        // `--ignore-scripts` must make it exit 0 instead.
+        let output = pacquet
+            .with_args(["install", "--ignore-scripts"])
+            .output()
+            .expect("run pacquet install --ignore-scripts");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eprintln!("pacquet install --ignore-scripts stdout:\n{stdout}\nstderr:\n{stderr}");
+        assert!(output.status.success(), "install --ignore-scripts must exit zero");
+        assert!(
+            !format!("{stdout}{stderr}").contains("ERR_PNPM_IGNORED_BUILDS"),
+            "--ignore-scripts must not report ignored builds",
+        );
+
+        // The dependency is materialized, but its blocked lifecycle
+        // scripts did not run.
+        let pkg_dir = workspace.join(
+            "node_modules/.pnpm/@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+             /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
+        );
+        assert!(pkg_dir.join("package.json").exists(), "dependency should be materialized");
+        assert!(!pkg_dir.join("generated-by-preinstall.js").exists());
+        assert!(!pkg_dir.join("generated-by-postinstall.js").exists());
+
+        drop((root, mock_instance));
+    }
+
     /// With `strictDepBuilds: false`, an ignored build is a non-fatal
     /// warning printed to stdout and the install exits 0 — mirroring
     /// pnpm's `reportIgnoredBuilds` box.
@@ -951,6 +1000,29 @@ mod project_scripts {
         assert!(
             !workspace.join("order.txt").exists(),
             "named install (`add`) must not run the project's own lifecycle scripts",
+        );
+
+        drop((root, mock_instance));
+    }
+
+    /// `--ignore-scripts` suppresses the project's own lifecycle scripts:
+    /// none of them run, so `order.txt` is never created. Mirrors pnpm,
+    /// which skips the project lifecycle hooks alongside dependency build
+    /// scripts under `ignoreScripts`.
+    #[test]
+    fn ignore_scripts_skips_project_lifecycle_scripts() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        fs::write(workspace.join("package.json"), project_with_lifecycle_scripts().to_string())
+            .expect("write package.json");
+
+        pacquet.with_args(["install", "--ignore-scripts"]).assert().success();
+
+        assert!(
+            !workspace.join("order.txt").exists(),
+            "no project lifecycle script should run under --ignore-scripts",
         );
 
         drop((root, mock_instance));

--- a/pacquet/crates/config/src/env_overlay.rs
+++ b/pacquet/crates/config/src/env_overlay.rs
@@ -179,6 +179,7 @@ impl WorkspaceSettings {
         json_field!(allow_builds, "ALLOW_BUILDS");
         json_field!(dangerously_allow_all_builds, "DANGEROUSLY_ALLOW_ALL_BUILDS");
         json_field!(strict_dep_builds, "STRICT_DEP_BUILDS");
+        json_field!(ignore_scripts, "IGNORE_SCRIPTS");
         enum_field!(scripts_prepend_node_path, "SCRIPTS_PREPEND_NODE_PATH", ScriptsPrependNodePath);
         json_field!(enable_pre_post_scripts, "ENABLE_PRE_POST_SCRIPTS");
         tri_string_field!(script_shell, "SCRIPT_SHELL");

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1021,6 +1021,19 @@ pub struct Config {
     #[default(true)]
     pub strict_dep_builds: bool,
 
+    /// `ignoreScripts` (`--ignore-scripts`). When `true`, no lifecycle
+    /// scripts run — neither dependency build scripts
+    /// (`preinstall`/`install`/`postinstall`) nor the project's own
+    /// lifecycle scripts. Dependency builds that would otherwise be
+    /// reported as ignored are not collected, so the install does not
+    /// fail with `ERR_PNPM_IGNORED_BUILDS` under `strictDepBuilds`.
+    /// Mirrors pnpm's `ignoreScripts`: the during-install build loop
+    /// skips its allow-build gate entirely when set, leaving
+    /// `ignoredBuilds` empty
+    /// (<https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L137-L150>).
+    /// Default `false`.
+    pub ignore_scripts: bool,
+
     /// `scriptsPrependNodePath` from `pnpm-workspace.yaml`. Controls
     /// whether `dirname(node_execpath)` is prepended to `PATH` when
     /// running lifecycle scripts. Default `Never` to match pnpm's

--- a/pacquet/crates/config/src/workspace_yaml.rs
+++ b/pacquet/crates/config/src/workspace_yaml.rs
@@ -247,6 +247,12 @@ pub struct WorkspaceSettings {
     /// fails instead of only warning. Default `true`.
     pub strict_dep_builds: Option<bool>,
 
+    /// `ignoreScripts` from `pnpm-workspace.yaml`. When `true`, no
+    /// lifecycle scripts run and ignored dependency builds aren't
+    /// collected. See [`Config::ignore_scripts`]. The `--ignore-scripts`
+    /// CLI flag ORs on top of this. Default `false`.
+    pub ignore_scripts: Option<bool>,
+
     /// `scriptsPrependNodePath` from `pnpm-workspace.yaml`. Tri-state
     /// — yaml accepts `true` / `false` / `"warn-only"`. Custom serde
     /// shape, see [`ScriptsPrependNodePath`]'s `Deserialize` impl.
@@ -840,6 +846,9 @@ impl WorkspaceSettings {
         }
         if let Some(v) = self.strict_dep_builds {
             config.strict_dep_builds = v;
+        }
+        if let Some(v) = self.ignore_scripts {
+            config.ignore_scripts = v;
         }
         if let Some(v) = self.scripts_prepend_node_path {
             config.scripts_prepend_node_path = v;

--- a/pacquet/crates/config/src/workspace_yaml/tests.rs
+++ b/pacquet/crates/config/src/workspace_yaml/tests.rs
@@ -126,6 +126,21 @@ fetchRetryMaxtimeout: 4000
     assert_eq!(config.fetch_retry_maxtimeout, 4000);
 }
 
+/// `ignoreScripts` parses from `pnpm-workspace.yaml` as a camelCase
+/// key and `apply_to` pushes it onto [`Config::ignore_scripts`], so
+/// `ignoreScripts: true` in the workspace manifest suppresses lifecycle
+/// scripts the same way the `--ignore-scripts` CLI flag does.
+#[test]
+fn parses_ignore_scripts_from_yaml_and_applies() {
+    let settings: WorkspaceSettings = serde_saphyr::from_str("ignoreScripts: true\n").unwrap();
+    assert_eq!(settings.ignore_scripts, Some(true));
+
+    let mut config = Config::new();
+    assert!(!config.ignore_scripts, "default is false");
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+    assert!(config.ignore_scripts);
+}
+
 /// `networkConcurrency` / `fetchTimeout` / `userAgent` parse from
 /// `pnpm-workspace.yaml` as camelCase keys and `apply_to` pushes them
 /// onto the `Config`, matching pnpm.

--- a/pacquet/crates/package-manager/src/build_modules.rs
+++ b/pacquet/crates/package-manager/src/build_modules.rs
@@ -415,6 +415,17 @@ pub struct BuildModules<'a> {
     /// live in the writable project store.
     pub frozen_store: bool,
 
+    /// Mirrors `config.ignore_scripts`. When `true`, no lifecycle
+    /// script runs and the allow-build gate is bypassed entirely, so a
+    /// package not in `allowBuilds` is *not* added to the returned
+    /// ignored-builds set — matching pnpm, where the during-install
+    /// loop skips its `ignoredBuilds.add(...)` branch under
+    /// `ignoreScripts`
+    /// (<https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L137-L150>).
+    /// Patches still apply, since pnpm applies a patch even when scripts
+    /// are suppressed.
+    pub ignore_scripts: bool,
+
     /// Mirrors `config.package_import_method`. Used by the
     /// side-effects-cache `is_built` gate to re-materialize a cached
     /// build's output into the already-linked slot — the warm link
@@ -461,6 +472,7 @@ impl BuildModules<'_> {
             pkg_root_by_key,
             gather_ancestor_bin_paths,
             frozen_store,
+            ignore_scripts,
             import_method,
             logged_methods,
         } = self;
@@ -607,6 +619,7 @@ impl BuildModules<'_> {
                         scripts_prepend_node_path,
                         unsafe_perm,
                         frozen_store,
+                        ignore_scripts,
                         import_method,
                         logged_methods,
                     )
@@ -661,6 +674,7 @@ fn build_one_snapshot<Reporter: self::Reporter>(
     scripts_prepend_node_path: ScriptsPrependNodePath,
     unsafe_perm: bool,
     frozen_store: bool,
+    ignore_scripts: bool,
     import_method: PackageImportMethod,
     logged_methods: &std::sync::atomic::AtomicU8,
 ) -> Result<(), BuildModulesError> {
@@ -692,8 +706,15 @@ fn build_one_snapshot<Reporter: self::Reporter>(
     // false` (NOT early-return), so the patch still gets applied
     // even when scripts are disallowed. Matches upstream's
     // `ignoreScripts = true; break` pattern.
-    let mut should_run_scripts = requires_build;
-    if requires_build {
+    //
+    // Under `ignore_scripts` the whole gate is bypassed: scripts never
+    // run and the package is *not* recorded as an ignored build, so the
+    // install doesn't fail with `ERR_PNPM_IGNORED_BUILDS`. The patch
+    // application below still runs (a patch is applied even when scripts
+    // are suppressed). Mirrors pnpm's top-level
+    // `let ignoreScripts = Boolean(buildDepOpts.ignoreScripts); if (!ignoreScripts) { ... }`.
+    let mut should_run_scripts = requires_build && !ignore_scripts;
+    if should_run_scripts {
         let dep_path = metadata_key.to_string();
         match allow_build_policy.check(&dep_path) {
             Some(false) => {

--- a/pacquet/crates/package-manager/src/build_modules/tests.rs
+++ b/pacquet/crates/package-manager/src/build_modules/tests.rs
@@ -353,6 +353,7 @@ fn build_modules_collects_ignored_builds() {
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store: false,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }
@@ -365,6 +366,66 @@ fn build_modules_collects_ignored_builds() {
         vec!["aaa@2.0.0".to_string(), "zzz@1.0.0".to_string()],
         "ignored set must be sorted lexicographically: {ignored:?}",
     );
+}
+
+/// Under `ignore_scripts`, the same default-deny build candidates that
+/// `build_modules_collects_ignored_builds` reports as ignored are
+/// instead silently skipped: no script runs and the returned set is
+/// empty, so the install does not fail with `ERR_PNPM_IGNORED_BUILDS`.
+/// Mirrors pnpm leaving `ignoredBuilds` empty when `ignoreScripts` is
+/// set.
+#[test]
+fn ignore_scripts_skips_build_without_collecting_ignored() {
+    let snapshots = HashMap::from([
+        (key("zzz", "1.0.0"), SnapshotEntry::default()),
+        (key("aaa", "2.0.0"), SnapshotEntry::default()),
+    ]);
+    let importers = root_importers(&[("zzz", "1.0.0"), ("aaa", "2.0.0")]);
+    let policy = AllowBuildPolicy::default(); // empty → default-deny
+
+    let virtual_store_dir = tempdir().expect("create temp dir");
+    let modules_dir = tempdir().expect("create temp dir");
+    let lockfile_dir = tempdir().expect("create temp dir");
+
+    create_buildable_pkg(virtual_store_dir.path(), &key("zzz", "1.0.0"));
+    create_buildable_pkg(virtual_store_dir.path(), &key("aaa", "2.0.0"));
+
+    let ignored = BuildModules {
+        layout: &VirtualStoreLayout::legacy(
+            virtual_store_dir.path(),
+            pacquet_config::default_virtual_store_dir_max_length() as usize,
+        ),
+        modules_dir: modules_dir.path(),
+        lockfile_dir: lockfile_dir.path(),
+        snapshots: Some(&snapshots),
+        importers: &importers,
+        packages: None,
+        allow_build_policy: &policy,
+        side_effects_maps_by_snapshot: None,
+        requires_build_by_snapshot: None,
+        engine_name: None,
+        side_effects_cache: true,
+        side_effects_cache_write: false,
+        store_dir: None,
+        store_index_writer: None,
+        patches: None,
+
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        unsafe_perm: true,
+        child_concurrency: 1,
+        skipped: &SkippedSnapshots::default(),
+        pkg_root_by_key: None,
+        gather_ancestor_bin_paths: false,
+        frozen_store: false,
+        ignore_scripts: true,
+        import_method: PackageImportMethod::Auto,
+        logged_methods: &TEST_LOGGED_METHODS,
+    }
+    .run::<SilentReporter>()
+    .expect("run BuildModules");
+    dbg!(&ignored);
+
+    assert!(ignored.is_empty(), "ignore_scripts must not collect ignored builds: {ignored:?}");
 }
 
 #[test]
@@ -408,6 +469,7 @@ fn cached_requires_build_false_skips_package_dir_probe() {
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store: false,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }
@@ -479,6 +541,7 @@ fn build_modules_collects_ignored_builds_under_concurrency() {
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store: false,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }
@@ -543,6 +606,7 @@ fn build_modules_excludes_explicit_deny_from_ignored() {
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store: false,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }
@@ -630,6 +694,7 @@ fn do_not_fail_on_optional_dep_with_failing_postinstall() {
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store: false,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }
@@ -790,6 +855,7 @@ fn using_side_effects_cache_skips_rebuild() {
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store: false,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }
@@ -913,6 +979,7 @@ fn corrupt_side_effects_cache_falls_back_to_rebuild() {
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store: false,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }
@@ -1029,6 +1096,7 @@ fn materialization_failure_on_incomplete_slot_is_fatal() {
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store: false,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }
@@ -1094,6 +1162,7 @@ fn side_effects_cache_disabled_bypasses_the_gate() {
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store: false,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }
@@ -1158,6 +1227,7 @@ fn fail_when_failing_postinstall_is_required() {
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store: false,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }
@@ -1244,6 +1314,7 @@ fn frozen_backstop_run(
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }
@@ -1566,6 +1637,7 @@ async fn write_path_populates_side_effects_row() {
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store: false,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }
@@ -1684,6 +1756,7 @@ async fn write_path_disabled_skips_upload() {
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store: false,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }
@@ -1810,6 +1883,7 @@ async fn upload_error_does_not_interrupt_install() {
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store: false,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }
@@ -2047,6 +2121,7 @@ new file mode 100644
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store: false,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }
@@ -2160,6 +2235,7 @@ new file mode 100644
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store: false,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }
@@ -2244,6 +2320,7 @@ async fn missing_patch_file_path_errors_with_diagnostic() {
         pkg_root_by_key: None,
         gather_ancestor_bin_paths: false,
         frozen_store: false,
+        ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
     }

--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -474,7 +474,8 @@ impl CreateVirtualStore<'_> {
         type SnapshotWithCacheKey<'a> = (&'a PackageKey, &'a SnapshotEntry, Option<String>);
         let snapshot_entries: Vec<SnapshotWithCacheKey<'_>> = survivors
             .map(|(snapshot_key, snapshot)| {
-                snapshot_cache_key(snapshot_key, packages).map(|key| (snapshot_key, snapshot, key))
+                snapshot_cache_key(snapshot_key, packages, config.ignore_scripts)
+                    .map(|key| (snapshot_key, snapshot, key))
             })
             .collect::<Result<_, _>>()?;
 
@@ -500,7 +501,9 @@ impl CreateVirtualStore<'_> {
             // here.
             .filter(|(snapshot_key, _)| !skipped.contains(snapshot_key))
             .map(|(snapshot_key, snapshot)| {
-                let cache_key = snapshot_cache_key(snapshot_key, packages).ok().flatten();
+                let cache_key = snapshot_cache_key(snapshot_key, packages, config.ignore_scripts)
+                    .ok()
+                    .flatten();
                 (snapshot_key, snapshot, cache_key)
             })
             .collect();
@@ -1094,6 +1097,7 @@ fn link_slots_parallel<Reporter: self::Reporter>(
 fn snapshot_cache_key(
     snapshot_key: &PackageKey,
     packages: &HashMap<PackageKey, PackageMetadata>,
+    ignore_scripts: bool,
 ) -> Result<Option<String>, CreateVirtualStoreError> {
     let metadata_key = snapshot_key.without_peer();
     let metadata = packages.get(&metadata_key).ok_or_else(|| {
@@ -1110,10 +1114,10 @@ fn snapshot_cache_key(
             // row is written under `gitHostedStoreIndexKey(pkg_id,
             // built)` rather than the integrity-based key. Use the
             // same key shape here so the warm prefetch finds the
-            // row on a re-install. `built = true` matches the
-            // dispatcher's `!ignore_scripts` default — when ignore-
-            // scripts becomes configurable both sites flip together.
-            Ok(Some(git_hosted_store_index_key(&pkg_id, true)))
+            // row on a re-install. `built` tracks `!ignore_scripts`
+            // in lock-step with the dispatcher's write key, so the
+            // prefetch and write address the same slot.
+            Ok(Some(git_hosted_store_index_key(&pkg_id, !ignore_scripts)))
         }
         LockfileResolution::Tarball(t) => {
             let integrity = t
@@ -1152,8 +1156,10 @@ fn snapshot_cache_key(
             // lets the warm prefetch reuse a previous install's
             // clone + checkout + prepare + packlist work — without
             // this, every git install cold-paths regardless of
-            // whether the snapshot is already in `index.db`.
-            Ok(Some(git_hosted_store_index_key(&pkg_id, true)))
+            // whether the snapshot is already in `index.db`. `built`
+            // tracks `!ignore_scripts` to match the dispatcher's
+            // write key.
+            Ok(Some(git_hosted_store_index_key(&pkg_id, !ignore_scripts)))
         }
         // Runtime artifacts (Node.js / Bun / Deno): the per-archive
         // integrity is the warm-cache key, same shape as the

--- a/pacquet/crates/package-manager/src/create_virtual_store/tests.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store/tests.rs
@@ -389,7 +389,8 @@ fn snapshot_cache_key_for_git_resolution_uses_git_hosted_key() {
     let pkg = key("ts-pipe-compose", "0.2.1");
     let packages = HashMap::from([(pkg.clone(), git_metadata())]);
 
-    let received = snapshot_cache_key(&pkg, &packages).expect("snapshot_cache_key must not error");
+    let received =
+        snapshot_cache_key(&pkg, &packages, false).expect("snapshot_cache_key must not error");
     assert_eq!(
         received,
         Some(format!("{pkg}\tbuilt")),
@@ -405,7 +406,8 @@ fn snapshot_cache_key_for_git_hosted_tarball_uses_git_hosted_key() {
     let pkg = key("foo", "1.0.0");
     let packages = HashMap::from([(pkg.clone(), git_hosted_tarball_metadata())]);
 
-    let received = snapshot_cache_key(&pkg, &packages).expect("snapshot_cache_key must not error");
+    let received =
+        snapshot_cache_key(&pkg, &packages, false).expect("snapshot_cache_key must not error");
     assert_eq!(
         received,
         Some(format!("{pkg}\tbuilt")),
@@ -422,8 +424,8 @@ fn snapshot_cache_key_rejects_tarball_without_integrity() {
     let pkg = key("foo", "1.0.0");
     let packages = HashMap::from([(pkg.clone(), tarball_metadata_without_integrity())]);
 
-    let err =
-        snapshot_cache_key(&pkg, &packages).expect_err("missing integrity must reject upfront");
+    let err = snapshot_cache_key(&pkg, &packages, false)
+        .expect_err("missing integrity must reject upfront");
     assert!(
         matches!(
             &err,

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1394,7 +1394,11 @@ where
         // Skipped for partial installs (`pacquet add`): pnpm filters
         // to `mutation === 'install'` so a named install does not fire
         // the project's own scripts (see [`Install::is_full_install`]).
-        if is_full_install {
+        //
+        // Also skipped under `--ignore-scripts`: pnpm suppresses the
+        // project's own lifecycle scripts alongside dependency build
+        // scripts when `ignoreScripts` is set.
+        if is_full_install && !config.ignore_scripts {
             run_projects_lifecycle_scripts::<Reporter>(
                 &project_manifests,
                 config,

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -468,6 +468,7 @@ pub(crate) fn run_build_phase<Reporter: self::Reporter>(
         pkg_root_by_key: hoisted_pkg_root_by_key,
         gather_ancestor_bin_paths: is_hoisted,
         frozen_store: config.frozen_store,
+        ignore_scripts: config.ignore_scripts,
         import_method: config.package_import_method,
         logged_methods,
     }

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
@@ -368,19 +368,19 @@ impl InstallPackageBySnapshot<'_> {
                 if let LockfileResolution::Tarball(t) = &metadata.resolution
                     && t.git_hosted == Some(true)
                 {
-                    // `built = true` matches the dispatcher's default
-                    // (`ignore_scripts: false` everywhere). When
-                    // pacquet adds a configurable ignore-scripts mode
-                    // this `true` flips to `!ignore_scripts`, in lock-
-                    // step with the key shape `snapshot_cache_key`
-                    // produces — otherwise the prefetch and the write
-                    // would address different slots.
-                    let files_index_file = git_hosted_store_index_key(&package_id, true);
+                    // `built` tracks `!ignore_scripts`, in lock-step
+                    // with the key shape `snapshot_cache_key` produces —
+                    // otherwise the prefetch and the write would address
+                    // different slots. Under `--ignore-scripts` the
+                    // git-hosted `prepare` is suppressed too, matching
+                    // pnpm's `ignoreScripts`.
+                    let built = !config.ignore_scripts;
+                    let files_index_file = git_hosted_store_index_key(&package_id, built);
                     let GitFetchOutput { cas_paths, built: _built } = GitHostedTarballFetcher {
                         cas_paths: raw_cas_paths,
                         path: t.path.as_deref(),
                         allow_build: &allow_build_closure,
-                        ignore_scripts: false,
+                        ignore_scripts: config.ignore_scripts,
                         unsafe_perm: config.unsafe_perm,
                         user_agent: None,
                         scripts_prepend_node_path,
@@ -515,17 +515,18 @@ impl InstallPackageBySnapshot<'_> {
                 .await?
             }
             LockfileResolution::Git(git_resolution) => {
-                // Same `built = true` rationale as the git-hosted
-                // tarball branch above — key shape stays in lock-step
-                // with `snapshot_cache_key`.
-                let files_index_file = git_hosted_store_index_key(&package_id, true);
+                // Same `built = !ignore_scripts` rationale as the
+                // git-hosted tarball branch above — key shape stays in
+                // lock-step with `snapshot_cache_key`.
+                let built = !config.ignore_scripts;
+                let files_index_file = git_hosted_store_index_key(&package_id, built);
                 let GitFetchOutput { cas_paths, built: _built } = GitFetcher {
                     repo: &git_resolution.repo,
                     commit: &git_resolution.commit,
                     path: git_resolution.path.as_deref(),
                     git_shallow_hosts: &config.git_shallow_hosts,
                     allow_build: &allow_build_closure,
-                    ignore_scripts: false,
+                    ignore_scripts: config.ignore_scripts,
                     unsafe_perm: config.unsafe_perm,
                     user_agent: None,
                     scripts_prepend_node_path,

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -87,6 +87,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         allow_builds: Default::default(),
         dangerously_allow_all_builds: false,
         strict_dep_builds: true,
+        ignore_scripts: false,
         scripts_prepend_node_path: Default::default(),
         enable_pre_post_scripts: false,
         script_shell: None,


### PR DESCRIPTION
## What

Adds an `--ignore-scripts` flag to `pacquet install`, mirroring pnpm's flag of the same name.

## Why

Since #12436, `pacquet install` runs the dependency build phase on the fresh-lockfile path. A project with blocked build scripts (e.g. `sharp`, `esbuild`, `unrs-resolver`) therefore fails with `ERR_PNPM_IGNORED_BUILDS` (exit 1) under the default `strictDepBuilds`, with no way to install it short of approving every build. pnpm's answer is `--ignore-scripts`; pacquet had no equivalent (`pacquet install --ignore-scripts` exited 2 — unknown flag).

This is also what broke pacquet on the [vlt.sh benchmark](https://benchmarks.vlt.sh/): every fixture (`next`/`astro`/`svelte`/`vue`/`large`/`babylon`) has a package with a blocked build, so `pacquet install` exits 1, and the benchmark chart marks any non-zero exit as **DNF**. The benchmark's `pnpm` command already passes `--ignore-scripts`; the `pacquet` command couldn't, because the flag didn't exist. pacquet went DNF across the board starting with 0.11.8.

## How

Mirrors pnpm's `ignoreScripts` semantics:

- New `Config.ignore_scripts` field, fed by the `--ignore-scripts` CLI flag and merged enable-only at the Install dispatch in `cli_args.rs` (same pattern as `--frozen-store`).
- In the during-install build loop (`build_one_snapshot`), `ignore_scripts` bypasses the allow-build gate entirely: no script runs and **nothing is added to `ignored_builds`**, so the returned set is empty and the strict-mode `ERR_PNPM_IGNORED_BUILDS` never fires. Patches still apply (pnpm applies a patch even when scripts are suppressed).
- The project's own lifecycle scripts are skipped too (`is_full_install && !config.ignore_scripts`), matching pnpm.

This is pacquet catching up to pnpm, which already has `--ignore-scripts` — no pnpm-side change needed.

## Tests

- `build_modules::tests::ignore_scripts_skips_build_without_collecting_ignored` — unit test proving the ignored-builds set stays empty (discriminating: the old logic collected the packages).
- `lifecycle_scripts::dependency_build_scripts::install_ignore_scripts_does_not_fail_under_strict_dep_builds` — CLI test: install exits 0 under default strict mode, dependency materialized, scripts not run.
- `lifecycle_scripts::project_scripts::ignore_scripts_skips_project_lifecycle_scripts` — CLI test: the project's own lifecycle scripts don't run.

`just`-equivalent checks (fmt, clippy `-D warnings`, dylint, the affected nextest suites) all pass.

## Follow-up (separate repo)

The benchmark itself still needs a one-line change in [vltpkg/benchmarks](https://github.com/vltpkg/benchmarks) to add `--ignore-scripts` to `BENCH_INSTALL_PACQUET` in `scripts/variations/common.sh`, exactly as the `pnpm` command already does.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--ignore-scripts` CLI flag to suppress lifecycle scripts during installation.
  * Added `ignoreScripts` support in configuration sources (environment variable and workspace YAML).
* **Bug Fixes**
  * Skipping scripts now prevents `ERR_PNPM_IGNORED_BUILDS` under strict dependency build settings while still materializing dependencies.
  * Project lifecycle scripts are fully suppressed when ignore-scripts is enabled.
* **Tests**
  * Added coverage for dependency and project lifecycle suppression behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->