### PR TITLE
chore: auto-approve issue-free PRs and add product labels in Qodo

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -26,6 +26,24 @@ ignore_pr_authors = [
 # are already covered by ignore_pr_authors above.
 # ignore_pr_title = ["^chore", "^ci"]
 
+# Let the describe tool pick from the custom_labels set below.
+enable_custom_labels = true
+
+[pr_description]
+# Actually attach the chosen labels to the PR (not just list them in the body).
+publish_labels = true
+
+# Custom labels assigned by /agentic_describe based on which product the diff touches.
+# More than one may apply to a single PR.
+[custom_labels."product: pnpm"]
+description = "Changes affect the TypeScript pnpm CLI (any code outside pacquet/ and pnpr/)."
+
+[custom_labels."product: pacquet"]
+description = "Changes affect pacquet, the Rust port of the pnpm CLI (the pacquet/ directory)."
+
+[custom_labels."product: pnpr"]
+description = "Changes affect pnpr, the pnpm registry server (the pnpr/ directory and pacquet/crates/pnpr-* crates)."
+
 [review_agent]
 comments_location_policy = "both"
 inline_comments_severity_threshold = 2
@@ -35,3 +53,11 @@ Apply the "AI Review Guidance" section in AGENTS.md. Security vulnerabilities ar
 compliance_user_guidelines = """
 Enforce the security-sensitive and performance-sensitive contracts described in AGENTS.md's "AI Review Guidance" section.
 """
+
+[pr_reviewer]
+# Auto-approve a PR when the review finds no issues to fix.
+# enable_auto_approval is the required master switch (off by default);
+# auto_approve_for_no_suggestions approves when the review yields zero suggestions.
+# These only take effect from the config file on the default branch.
+enable_auto_approval = true
+auto_approve_for_no_suggestions = true


### PR DESCRIPTION
## What

Two changes to `.pr_agent.toml` (Qodo Merge config):

1. **Auto-approval when no issues are found.** Under `[pr_reviewer]`, enable `enable_auto_approval` + `auto_approve_for_no_suggestions`, so Qodo approves a PR when the review yields zero suggestions.
2. **Product labels.** Three custom labels assigned by `/agentic_describe` based on which stack the diff touches:
   - `product: pnpm` — the TypeScript pnpm CLI (anything outside `pacquet/` and `pnpr/`)
   - `product: pacquet` — the Rust port (`pacquet/`)
   - `product: pnpr` — the registry server (`pnpr/` and `pacquet/crates/pnpr-*`)

   More than one can apply to a single PR (e.g. a pnpm↔pacquet parity change).

## Notes

- Qodo's auto-approval and custom-label settings only take effect from the config file on the **default branch**, so they activate once this merges.
- The three labels must exist in the repo's GitHub label list (or Qodo needs label-create permission) to attach reliably.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal tooling configuration to enable custom PR labeling and auto-approval workflow for pull requests with no review suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->