### PR TITLE
perf(npm-resolver): cache meta in memory for exact version matches.

### DIFF
--- a/.changeset/npm-resolver-meta-cache.md
+++ b/.changeset/npm-resolver-meta-cache.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"pnpm": patch
+---
+
+The in-memory package metadata cache is now populated on the exact-version disk fast path, so repeated resolutions of the same package within one install no longer re-read and re-parse the on-disk metadata. In large monorepos this brings the time for adding a new package down from minutes to seconds. The in-memory cache key now also includes the registry, so a package of the same name served by two different registries in a single install can no longer share a cache slot and resolve the wrong tarball.

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -287,9 +287,14 @@ pub struct PickPackageOptions<'a> {
     /// either knob set to `true` makes the pick request full
     /// metadata.
     pub optional: bool,
-    /// `true` skips the on-disk exact-version fast path so a stale
-    /// disk packument can't satisfy the call without a conditional
-    /// registry request. Mirrors pnpm's `--update-checksums`.
+    /// `true` forces a conditional registry request so a stale disk
+    /// packument can't satisfy the call: the on-disk exact-version
+    /// fast path is skipped, and the in-memory cache is bypassed too.
+    /// The fast path now promotes disk-loaded packuments into the
+    /// in-memory cache, so an entry there can no longer be assumed to
+    /// come from this install's own fresh network fetch — on a shared
+    /// resolver it might be disk-sourced, which would short-circuit the
+    /// revalidation. Mirrors pnpm's `--update-checksums`.
     pub update_checksums: bool,
 }
 
@@ -427,8 +432,13 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         format!("{}\x00{}", opts.registry, spec.name)
     };
 
+    // updateChecksums must reach the conditional registry request below, so it
+    // can't be served from the in-memory cache — which may hold a disk-promoted
+    // entry rather than a fresh network fetch (see the `update_checksums` doc).
+    let use_mem_cache = !opts.update_checksums;
+
     // 1. In-memory cache.
-    if let Some(cached) = ctx.meta_cache.get(&cache_key) {
+    if use_mem_cache && let Some(cached) = ctx.meta_cache.get(&cache_key) {
         return handle_cache_hit(
             ctx,
             spec,
@@ -457,7 +467,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     // this re-check, every duplicate caller would still fall
     // through to the disk + network path even though they were
     // waiting precisely for the winner's fetch to complete.
-    if let Some(cached) = ctx.meta_cache.get(&cache_key) {
+    if use_mem_cache && let Some(cached) = ctx.meta_cache.get(&cache_key) {
         return handle_cache_hit(
             ctx,
             spec,

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -1087,3 +1087,58 @@ async fn concurrent_picks_for_same_key_share_one_network_fetch() {
     }
     mock.assert_async().await;
 }
+
+#[tokio::test]
+async fn update_checksums_bypasses_warm_in_memory_cache() {
+    let mut server = mockito::Server::new_async().await;
+    // Only the update_checksums revalidation should hit the network; the first,
+    // non-update_checksums pick is served from the on-disk mirror.
+    let mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let preloaded: pacquet_registry::Package =
+        serde_json::from_str(PACKAGE_BODY).expect("parse packument");
+    persist_meta_to_mirror(cache_dir.path(), ABBREVIATED_META_DIR, &registry, &preloaded)
+        .expect("warm mirror");
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+
+    // Normal pick takes the on-disk fast path and promotes the packument into
+    // the in-memory cache.
+    let first = pick_package(&ctx, &version_spec("acme", "1.0.0"), &default_opts(&registry))
+        .await
+        .expect("ok");
+    assert_eq!(first.picked_package.expect("picked").version.to_string(), "1.0.0");
+    assert!(meta_cache.get(&format!("{registry}\x00acme")).is_some(), "in-memory cache populated");
+
+    // update_checksums must still revalidate against the registry despite the
+    // warm in-memory cache holding a disk-sourced entry.
+    let update_opts = PickPackageOptions { update_checksums: true, ..default_opts(&registry) };
+    let second =
+        pick_package(&ctx, &version_spec("acme", "1.0.0"), &update_opts).await.expect("ok");
+    assert_eq!(second.picked_package.expect("picked").version.to_string(), "1.0.0");
+    mock.assert_async().await;
+}

--- a/resolving/npm-resolver/src/createNpmResolutionVerifier.ts
+++ b/resolving/npm-resolver/src/createNpmResolutionVerifier.ts
@@ -21,7 +21,7 @@ import {
 import { normalizeRegistryUrl } from './normalizeRegistryUrl.js'
 import { BUILTIN_NAMED_REGISTRIES } from './parseBareSpecifier.js'
 import type { PackageMetaCache } from './pickPackage.js'
-import { getPkgMirrorPath, loadMeta, warnMissingTimeFieldOnce } from './pickPackage.js'
+import { getPkgMetaCacheKey, getPkgMirrorPath, loadMeta, warnMissingTimeFieldOnce } from './pickPackage.js'
 import { failIfTrustDowngraded } from './trustChecks.js'
 import {
   MINIMUM_RELEASE_AGE_VIOLATION_CODE,
@@ -455,20 +455,13 @@ function fetchFullMetaForTrust (
   let cachedPromise = context.fullMetaForTrustCache.get(cacheKey)
   if (cachedPromise == null) {
     // Fast path: if the resolver already upgraded to full meta for this
-    // name during the same install (e.g. minimumReleaseAge active),
-    // reuse that document. Abbreviated meta is rejected here — it lacks
-    // per-version `time` and per-version trust evidence, both required
-    // by failIfTrustDowngraded.
-    //
-    // Limitation: the resolver's `metaCache` keys by `${name}:full` —
-    // it doesn't include the registry (pickPackage.ts cacheKey shape).
-    // If two registries serve packages of the same name in one install
-    // the resolver itself silently keeps the first fetch; the verifier
-    // here inherits that scope. The name check below is a defensive
-    // guard against accidental cache mixups; tightening this to a
-    // registry-qualified read needs the resolver's `metaCache` key
-    // shape to change first.
-    const shared = readSharedMetaForTrust(context.sharedMetaCache, name)
+    // (registry, name) during the same install (e.g. minimumReleaseAge
+    // active), reuse that document. Abbreviated meta is rejected here —
+    // it lacks per-version `time` and per-version trust evidence, both
+    // required by failIfTrustDowngraded. The read is registry-qualified
+    // (see `getPkgMetaCacheKey`), so a package of the same name served by
+    // a different registry can't be returned here.
+    const shared = readSharedMetaForTrust(context.sharedMetaCache, registry, name)
     if (shared != null) {
       cachedPromise = Promise.resolve(projectTrustMeta(shared))
     } else {
@@ -565,11 +558,12 @@ interface PublishedAtLookupContext {
    */
   cutoffMs: number
   /**
-   * Resolver-owned LRU (per-install) keyed by `${name}` (abbreviated)
-   * or `${name}:full` (full meta). When the resolver has already
-   * fetched a package during this install, the verifier reuses that
-   * packument instead of re-paying the disk/network round-trip — the
-   * fresh-install path otherwise fetches every entry twice. Optional:
+   * Resolver-owned LRU (per-install) keyed via `getPkgMetaCacheKey`
+   * (registry + name, with a `:full` suffix for full meta). When the
+   * resolver has already fetched a package during this install, the
+   * verifier reuses that packument instead of re-paying the disk/network
+   * round-trip — the fresh-install path otherwise fetches every entry
+   * twice. Optional:
    * the frozen-install path runs without a resolver and never
    * populates this cache, so the verifier's own fetch chain still
    * carries the cold case.
@@ -721,10 +715,9 @@ function fetchAbbreviatedMeta (
     // Fast path: the resolver's per-install LRU already holds this
     // packument from its own pickPackage pass — abbreviated or full.
     // Project it for the shortcut and skip the disk/network round-trip.
-    // Mismatch on `name` is the same risk the resolver carries today
-    // (its cache key omits the registry), so reuse is no less correct
-    // than the resolver's own get.
-    const shared = readSharedMeta(context.sharedMetaCache, name)
+    // The read is registry-qualified (see `getPkgMetaCacheKey`), so it
+    // can only return this registry's own packument.
+    const shared = readSharedMeta(context.sharedMetaCache, registry, name)
     if (shared != null) {
       cachedPromise = Promise.resolve(projectAbbreviatedMeta(shared))
     } else {
@@ -741,35 +734,35 @@ function fetchAbbreviatedMeta (
 
 function readSharedMeta (
   cache: PackageMetaCache | undefined,
+  registry: string,
   name: string
 ): PackageMeta | undefined {
   if (cache == null) return undefined
-  // Prefer the full entry — a `name:full` hit subsumes the abbreviated
-  // hit (full meta carries every field the abbreviated form does, plus
+  // Prefer the full entry — a `:full` hit subsumes the abbreviated hit
+  // (full meta carries every field the abbreviated form does, plus
   // `time` and per-version trust evidence the trust check needs). The
-  // resolver only populates `name:full` when the install ran with
-  // `minimumReleaseAge` configured, otherwise the bare `name` key holds
-  // the abbreviated form.
-  return validateSharedMeta(cache.get(`${name}:full`), name) ??
-    validateSharedMeta(cache.get(name), name)
+  // resolver only populates the `:full` key when the install ran with
+  // `minimumReleaseAge` configured, otherwise the bare key holds the
+  // abbreviated form.
+  return validateSharedMeta(cache.get(getPkgMetaCacheKey(registry, name, true)), name) ??
+    validateSharedMeta(cache.get(getPkgMetaCacheKey(registry, name, false)), name)
 }
 
 function readSharedMetaForTrust (
   cache: PackageMetaCache | undefined,
+  registry: string,
   name: string
 ): PackageMeta | undefined {
   if (cache == null) return undefined
   // Abbreviated meta is rejected for the trust check — it lacks
   // per-version `time` and per-version trust evidence.
-  return validateSharedMeta(cache.get(`${name}:full`), name)
+  return validateSharedMeta(cache.get(getPkgMetaCacheKey(registry, name, true)), name)
 }
 
-// Defensive guard against the resolver's `name`-only cache key
-// returning something unexpected. The known correctness gap (two
-// registries serving the same package name share one cache slot)
-// is inherited from the resolver itself — see the `pickPackage.ts`
-// cacheKey shape; the verifier can't be stricter than the resolver
-// without changing both. This name check at least catches accidental
+// Defensive guard against the resolver's `metaCache` returning an
+// unexpected entry. The cache key is registry-qualified (see
+// `getPkgMetaCacheKey`), so a package of the same name from another
+// registry can't be returned; this name check catches accidental
 // returns of a different package (cache corruption, factory misuse)
 // rather than silently feeding wrong data to the trust / age check.
 function validateSharedMeta (meta: PackageMeta | undefined, name: string): PackageMeta | undefined {

--- a/resolving/npm-resolver/src/createNpmResolutionVerifier.ts
+++ b/resolving/npm-resolver/src/createNpmResolutionVerifier.ts
@@ -738,14 +738,13 @@ function readSharedMeta (
   name: string
 ): PackageMeta | undefined {
   if (cache == null) return undefined
-  // Prefer the full entry — a `:full` hit subsumes the abbreviated hit
-  // (full meta carries every field the abbreviated form does, plus
-  // `time` and per-version trust evidence the trust check needs). The
-  // resolver only populates the `:full` key when the install ran with
-  // `minimumReleaseAge` configured, otherwise the bare key holds the
-  // abbreviated form.
-  return validateSharedMeta(cache.get(getPkgMetaCacheKey(registry, name, true)), name) ??
-    validateSharedMeta(cache.get(getPkgMetaCacheKey(registry, name, false)), name)
+  // Prefer a full entry — it carries every field the abbreviated form
+  // does, plus `time` and per-version trust evidence the trust check
+  // needs. The resolver only populates a full key when the install ran
+  // with `minimumReleaseAge` configured, otherwise the bare key holds
+  // the abbreviated form.
+  return readSharedFullMeta(cache, registry, name) ??
+    validateSharedMeta(cache.get(getPkgMetaCacheKey(registry, name, false, false)), name)
 }
 
 function readSharedMetaForTrust (
@@ -756,7 +755,20 @@ function readSharedMetaForTrust (
   if (cache == null) return undefined
   // Abbreviated meta is rejected for the trust check — it lacks
   // per-version `time` and per-version trust evidence.
-  return validateSharedMeta(cache.get(getPkgMetaCacheKey(registry, name, true)), name)
+  return readSharedFullMeta(cache, registry, name)
+}
+
+// The resolver keys full metadata as either filtered or unfiltered
+// depending on its own `filterMetadata` setting; the verifier doesn't
+// know which, and a filtered full packument keeps everything the
+// verifier reads (`time`, per-version `_npmUser`, `dist`), so try both.
+function readSharedFullMeta (
+  cache: PackageMetaCache,
+  registry: string,
+  name: string
+): PackageMeta | undefined {
+  return validateSharedMeta(cache.get(getPkgMetaCacheKey(registry, name, true, false)), name) ??
+    validateSharedMeta(cache.get(getPkgMetaCacheKey(registry, name, true, true)), name)
 }
 
 // Defensive guard against the resolver's `metaCache` returning an

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -281,6 +281,7 @@ export async function pickPackage (
         try {
           const pickedPackage = pickMatchingVersionFast(pickerOpts, spec, metaCachedInStore)
           if (pickedPackage) {
+            ctx.metaCache.set(cacheKey, metaCachedInStore)
             return {
               meta: metaCachedInStore,
               pickedPackage,

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -211,8 +211,11 @@ export async function pickPackage (
   const metaDir = fullMetadata
     ? (ctx.filterMetadata ? FULL_FILTERED_META_DIR : FULL_META_DIR)
     : ABBREVIATED_META_DIR
-  // Cache key includes fullMetadata to avoid returning abbreviated metadata when full metadata is requested.
-  const cacheKey = fullMetadata ? `${spec.name}:full` : spec.name
+  // Cache key includes the registry so a package of the same name served by two
+  // registries in one install can't share a slot (which would resolve the wrong
+  // tarball/integrity), and includes fullMetadata so a full-metadata request is
+  // never served the abbreviated form.
+  const cacheKey = getPkgMetaCacheKey(opts.registry, spec.name, fullMetadata)
   const pkgMirror = getPkgMirrorPath(ctx.cacheDir, metaDir, opts.registry, spec.name)
   const cachedMeta = ctx.metaCache.get(cacheKey)
   if (cachedMeta != null) {
@@ -586,6 +589,20 @@ export function encodePkgName (pkgName: string): string {
     return `${pkgName}_${createHexHash(pkgName)}`
   }
   return pkgName
+}
+
+/**
+ * Key for the in-memory `metaCache` holding a package's registry metadata. The
+ * registry is part of the key so that a package of the same name served by two
+ * registries in one install can't collide on a single slot (which would resolve
+ * the wrong tarball/integrity); `fullMetadata` keeps the abbreviated and full
+ * documents in distinct slots. `\x00` can't appear in a registry URL or a
+ * package name, so it's an unambiguous separator. The verifier reads this same
+ * cache and must build the key with this function.
+ */
+export function getPkgMetaCacheKey (registry: string, pkgName: string, fullMetadata: boolean): string {
+  const key = `${registry}\x00${pkgName}`
+  return fullMetadata ? `${key}:full` : key
 }
 
 /**

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -71,12 +71,14 @@ export interface PickPackageOptions extends PickPackageFromMetaOptions {
   includeLatestTag?: boolean
   optional?: boolean
   /**
-   * When true, skip the on-disk exact-version cache fast path so a
-   * stale on-disk packument can't satisfy the call without a
-   * conditional registry request. The in-memory cache is left alone:
-   * its entries can only be populated by this install's own fresh
-   * network fetches, so they're authoritative for second-and-onward
-   * lookups within the same install.
+   * When true, force a conditional registry request so a stale on-disk
+   * packument can't satisfy the call: the on-disk exact-version fast
+   * path is skipped, and the in-memory cache is bypassed too. The fast
+   * path now promotes disk-loaded packuments into the in-memory cache,
+   * so an entry there can no longer be assumed to come from this
+   * install's own fresh network fetch — on a shared or long-lived
+   * resolver it might be disk-sourced, which would short-circuit the
+   * revalidation updateChecksums exists to force.
    */
   updateChecksums?: boolean
 }
@@ -217,7 +219,10 @@ export async function pickPackage (
   // never served the abbreviated form.
   const cacheKey = getPkgMetaCacheKey(opts.registry, spec.name, fullMetadata)
   const pkgMirror = getPkgMirrorPath(ctx.cacheDir, metaDir, opts.registry, spec.name)
-  const cachedMeta = ctx.metaCache.get(cacheKey)
+  // updateChecksums must reach the conditional registry request below, so it
+  // can't be served from the in-memory cache — which may hold a disk-promoted
+  // entry rather than a fresh network fetch (see the updateChecksums doc).
+  const cachedMeta = opts.updateChecksums ? undefined : ctx.metaCache.get(cacheKey)
   if (cachedMeta != null) {
     // The in-memory cache may hold abbreviated metadata from an earlier call
     // that didn't need `time` (no publishedBy then). If this call has
@@ -599,10 +604,26 @@ export function encodePkgName (pkgName: string): string {
  * documents in distinct slots. `\x00` can't appear in a registry URL or a
  * package name, so it's an unambiguous separator. The verifier reads this same
  * cache and must build the key with this function.
+ *
+ * The registry is canonicalized to its origin plus a trailing-slashed path, so
+ * the resolver (which may pass a configured named-registry URL verbatim) and
+ * the verifier (which routes through trailing-slashed prefixes) converge on one
+ * key for the same logical registry instead of creating duplicate slots. Origin
+ * and path are preserved, so two registries that genuinely differ never collapse.
  */
 export function getPkgMetaCacheKey (registry: string, pkgName: string, fullMetadata: boolean): string {
-  const key = `${registry}\x00${pkgName}`
+  const key = `${canonicalizeRegistry(registry)}\x00${pkgName}`
   return fullMetadata ? `${key}:full` : key
+}
+
+function canonicalizeRegistry (registry: string): string {
+  try {
+    const parsed = new URL(registry)
+    const pathname = parsed.pathname.endsWith('/') ? parsed.pathname : `${parsed.pathname}/`
+    return `${parsed.origin}${pathname}`
+  } catch {
+    return registry
+  }
 }
 
 /**

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -215,9 +215,9 @@ export async function pickPackage (
     : ABBREVIATED_META_DIR
   // Cache key includes the registry so a package of the same name served by two
   // registries in one install can't share a slot (which would resolve the wrong
-  // tarball/integrity), and includes fullMetadata so a full-metadata request is
-  // never served the abbreviated form.
-  const cacheKey = getPkgMetaCacheKey(opts.registry, spec.name, fullMetadata)
+  // tarball/integrity), plus fullMetadata/filterMetadata so a request is never
+  // served a less-detailed or differently-stripped document than it asked for.
+  const cacheKey = getPkgMetaCacheKey(opts.registry, spec.name, fullMetadata, ctx.filterMetadata === true)
   const pkgMirror = getPkgMirrorPath(ctx.cacheDir, metaDir, opts.registry, spec.name)
   // updateChecksums must reach the conditional registry request below, so it
   // can't be served from the in-memory cache — which may hold a disk-promoted
@@ -600,10 +600,16 @@ export function encodePkgName (pkgName: string): string {
  * Key for the in-memory `metaCache` holding a package's registry metadata. The
  * registry is part of the key so that a package of the same name served by two
  * registries in one install can't collide on a single slot (which would resolve
- * the wrong tarball/integrity); `fullMetadata` keeps the abbreviated and full
- * documents in distinct slots. `\x00` can't appear in a registry URL or a
- * package name, so it's an unambiguous separator. The verifier reads this same
- * cache and must build the key with this function.
+ * the wrong tarball/integrity). `fullMetadata` and `filterMetadata` keep the
+ * abbreviated, full, and filtered-full documents in distinct slots, mirroring
+ * the on-disk `metaDir` split: a `filterMetadata` resolver stores a `clearMeta`-
+ * stripped packument, so it must not share a slot with an unfiltered full one
+ * (reachable only when a `metaCache` is shared across resolvers with different
+ * settings). `filterMetadata` only narrows the full slot — abbreviated metadata
+ * shares one on-disk mirror regardless, so its key carries no filtered variant.
+ * `\x00` can't appear in a registry URL or a package name, so it's an
+ * unambiguous separator. The verifier reads this same cache and must build the
+ * key with this function.
  *
  * The registry is canonicalized to its origin plus a trailing-slashed path, so
  * the resolver (which may pass a configured named-registry URL verbatim) and
@@ -611,9 +617,10 @@ export function encodePkgName (pkgName: string): string {
  * key for the same logical registry instead of creating duplicate slots. Origin
  * and path are preserved, so two registries that genuinely differ never collapse.
  */
-export function getPkgMetaCacheKey (registry: string, pkgName: string, fullMetadata: boolean): string {
+export function getPkgMetaCacheKey (registry: string, pkgName: string, fullMetadata: boolean, filterMetadata: boolean): string {
   const key = `${canonicalizeRegistry(registry)}\x00${pkgName}`
-  return fullMetadata ? `${key}:full` : key
+  if (!fullMetadata) return key
+  return filterMetadata ? `${key}:full:filtered` : `${key}:full`
 }
 
 function canonicalizeRegistry (registry: string): string {

--- a/resolving/npm-resolver/test/metaCache.test.ts
+++ b/resolving/npm-resolver/test/metaCache.test.ts
@@ -46,16 +46,24 @@ function createMetaCache (): PackageMetaCache {
 test('getPkgMetaCacheKey canonicalizes the registry so trailing-slash variants share one key', () => {
   // A configured named registry without a trailing slash and the verifier's
   // trailing-slashed prefix for the same registry must map to one cache slot.
-  expect(getPkgMetaCacheKey('https://reg.example.com', 'foo', false))
-    .toBe(getPkgMetaCacheKey('https://reg.example.com/', 'foo', false))
+  expect(getPkgMetaCacheKey('https://reg.example.com', 'foo', false, false))
+    .toBe(getPkgMetaCacheKey('https://reg.example.com/', 'foo', false, false))
 
   // Registries that genuinely differ by path are never collapsed.
-  expect(getPkgMetaCacheKey('https://reg.example.com/team-a/', 'foo', false))
-    .not.toBe(getPkgMetaCacheKey('https://reg.example.com/team-b/', 'foo', false))
+  expect(getPkgMetaCacheKey('https://reg.example.com/team-a/', 'foo', false, false))
+    .not.toBe(getPkgMetaCacheKey('https://reg.example.com/team-b/', 'foo', false, false))
 
   // Abbreviated and full documents keep distinct slots.
-  expect(getPkgMetaCacheKey(REGISTRY, 'foo', true))
-    .not.toBe(getPkgMetaCacheKey(REGISTRY, 'foo', false))
+  expect(getPkgMetaCacheKey(REGISTRY, 'foo', true, false))
+    .not.toBe(getPkgMetaCacheKey(REGISTRY, 'foo', false, false))
+
+  // Filtered and unfiltered full metadata keep distinct slots (clearMeta
+  // strips the filtered form), but filterMetadata is irrelevant to the
+  // abbreviated key.
+  expect(getPkgMetaCacheKey(REGISTRY, 'foo', true, true))
+    .not.toBe(getPkgMetaCacheKey(REGISTRY, 'foo', true, false))
+  expect(getPkgMetaCacheKey(REGISTRY, 'foo', false, true))
+    .toBe(getPkgMetaCacheKey(REGISTRY, 'foo', false, false))
 })
 
 test('updateChecksums bypasses the in-memory cache so a disk-promoted entry cannot skip revalidation', async () => {
@@ -80,7 +88,7 @@ test('updateChecksums bypasses the in-memory cache so a disk-promoted entry cann
   const first = await pickPackage(ctx, spec, { registry: REGISTRY, dryRun: false, preferredVersionSelectors: undefined })
   expect(first.pickedPackage?.version).toBe('1.0.0')
   expect(fetchedNames).toHaveLength(0)
-  expect(ctx.metaCache.has(getPkgMetaCacheKey(REGISTRY, 'foo', false))).toBe(true)
+  expect(ctx.metaCache.has(getPkgMetaCacheKey(REGISTRY, 'foo', false, false))).toBe(true)
 
   // updateChecksums must still hit the registry, even though the warm in-memory
   // cache now holds a disk-sourced entry for this package.

--- a/resolving/npm-resolver/test/metaCache.test.ts
+++ b/resolving/npm-resolver/test/metaCache.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@jest/globals'
+import { ABBREVIATED_META_DIR } from '@pnpm/constants'
+import type { PackageMeta } from '@pnpm/resolving.registry.types'
+import { temporaryDirectory } from 'tempy'
+
+import type { RegistryPackageSpec } from '../src/parseBareSpecifier.js'
+import {
+  getPkgMetaCacheKey,
+  getPkgMirrorPath,
+  type PackageMetaCache,
+  pickPackage,
+  prepareJsonForDisk,
+  saveMeta,
+} from '../src/pickPackage.js'
+
+const REGISTRY = 'https://registry.npmjs.org/'
+
+function fooMeta (): PackageMeta {
+  return {
+    name: 'foo',
+    'dist-tags': { latest: '1.0.0' },
+    versions: {
+      '1.0.0': {
+        name: 'foo',
+        version: '1.0.0',
+        dist: {
+          tarball: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
+          integrity: 'sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==',
+        },
+      },
+    },
+  } as unknown as PackageMeta
+}
+
+function createMetaCache (): PackageMetaCache {
+  const store = new Map<string, PackageMeta>()
+  return {
+    get: (key) => store.get(key),
+    set: (key, meta) => {
+      store.set(key, meta)
+    },
+    has: (key) => store.has(key),
+  }
+}
+
+test('getPkgMetaCacheKey canonicalizes the registry so trailing-slash variants share one key', () => {
+  // A configured named registry without a trailing slash and the verifier's
+  // trailing-slashed prefix for the same registry must map to one cache slot.
+  expect(getPkgMetaCacheKey('https://reg.example.com', 'foo', false))
+    .toBe(getPkgMetaCacheKey('https://reg.example.com/', 'foo', false))
+
+  // Registries that genuinely differ by path are never collapsed.
+  expect(getPkgMetaCacheKey('https://reg.example.com/team-a/', 'foo', false))
+    .not.toBe(getPkgMetaCacheKey('https://reg.example.com/team-b/', 'foo', false))
+
+  // Abbreviated and full documents keep distinct slots.
+  expect(getPkgMetaCacheKey(REGISTRY, 'foo', true))
+    .not.toBe(getPkgMetaCacheKey(REGISTRY, 'foo', false))
+})
+
+test('updateChecksums bypasses the in-memory cache so a disk-promoted entry cannot skip revalidation', async () => {
+  const meta = fooMeta()
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, REGISTRY, 'foo')
+  await saveMeta(pkgMirror, prepareJsonForDisk(meta, undefined))
+
+  const fetchedNames: string[] = []
+  const ctx = {
+    fetch: async (pkgName: string) => {
+      fetchedNames.push(pkgName)
+      return { meta, jsonText: JSON.stringify(meta), etag: undefined }
+    },
+    metaCache: createMetaCache(),
+    cacheDir,
+  }
+  const spec: RegistryPackageSpec = { type: 'version', name: 'foo', fetchSpec: '1.0.0' }
+
+  // A normal resolve takes the on-disk exact-version fast path: no network, and
+  // it promotes the disk-loaded packument into the in-memory cache.
+  const first = await pickPackage(ctx, spec, { registry: REGISTRY, dryRun: false, preferredVersionSelectors: undefined })
+  expect(first.pickedPackage?.version).toBe('1.0.0')
+  expect(fetchedNames).toHaveLength(0)
+  expect(ctx.metaCache.has(getPkgMetaCacheKey(REGISTRY, 'foo', false))).toBe(true)
+
+  // updateChecksums must still hit the registry, even though the warm in-memory
+  // cache now holds a disk-sourced entry for this package.
+  await pickPackage(ctx, spec, { registry: REGISTRY, dryRun: false, updateChecksums: true, preferredVersionSelectors: undefined })
+  expect(fetchedNames).toEqual(['foo'])
+})

--- a/resolving/npm-resolver/test/resolveNamedRegistry.test.ts
+++ b/resolving/npm-resolver/test/resolveNamedRegistry.test.ts
@@ -270,3 +270,46 @@ test('resolveFromNamedRegistry() throws when the specifier names an invalid scop
     code: 'ERR_PNPM_INVALID_NAMED_REGISTRY_PACKAGE_NAME',
   })
 })
+
+test('the same package name served by two registries does not collide in the in-memory metadata cache', async () => {
+  // Both registries serve `@acme/private`, but point at different tarballs.
+  interceptGhAcmePrivate(GH_REGISTRY)
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const enterpriseMeta = JSON.parse(JSON.stringify(ghAcmePrivateMeta))
+  for (const version of Object.values<any>(enterpriseMeta.versions)) {
+    version.dist.tarball = version.dist.tarball.replace('https://npm.pkg.github.com', 'https://npm.enterprise.example.com')
+  }
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  const slash = '%2F'
+  getMockAgent().get(ENTERPRISE_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: `/@acme${slash}private`, method: 'GET' })
+    .reply(200, enterpriseMeta)
+
+  const { resolveFromNamedRegistry } = createNpmResolver(fetch, () => undefined, {
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registries,
+    namedRegistries: { work: ENTERPRISE_REGISTRY },
+  })
+
+  // Resolving from the gh registry first populates the shared in-memory cache.
+  const ghResult = await resolveFromNamedRegistry({ alias: '@acme/private', bareSpecifier: 'gh:2.0.0' }, {})
+  expect(ghResult).toMatchObject({
+    id: '@acme/private@2.0.0',
+    resolution: {
+      tarball: 'https://npm.pkg.github.com/download/@acme/private/2.0.0/acme-private-2.0.0.tgz',
+    },
+  })
+
+  // Resolving the same name from the enterprise registry must use that
+  // registry's own metadata — not the cached gh packument, whose tarball would
+  // point at the wrong host (a cross-registry confusion bug if the in-memory
+  // cache key omitted the registry).
+  const workResult = await resolveFromNamedRegistry({ alias: '@acme/private', bareSpecifier: 'work:2.0.0' }, {})
+  expect(workResult).toMatchObject({
+    id: '@acme/private@2.0.0',
+    resolution: {
+      tarball: 'https://npm.enterprise.example.com/download/@acme/private/2.0.0/acme-private-2.0.0.tgz',
+    },
+  })
+})


### PR DESCRIPTION
## Summary

In `pickPackage()`, cache the parsed package metadata in memory after reading it
from disk for exact version matches. Without this, the same metadata was read
and parsed from disk repeatedly. In a large monorepo this brings the time for
adding a new package down from minutes to seconds.

While populating the in-memory cache on the exact-version disk fast path, the
cache key is now also scoped by the registry. The on-disk mirror was already
registry-qualified, but the in-memory `metaCache` key was only the package name
(plus a `:full` suffix). A package of the same name served by two registries in
one install (e.g. the default registry plus a `gh:`/named registry) could
collide on a single cache slot and resolve the wrong tarball/integrity. The
network-fetch path already populated this registry-blind cache, so the gap was
pre-existing — but having the disk fast path populate it too made the collision
reachable on the common warm-cache path. The cache key is now registry-qualified
end to end, including the verifier's shared-meta reads, which already documented
this as the prerequisite for a registry-qualified read.

## Squash Commit Body

```text
On the exact-version disk fast path in pickPackage(), promote the parsed
packument into the in-memory metaCache so later resolutions of the same package
in one install skip the disk read and parse. In large monorepos this brings
adding a package down from minutes to seconds.

The in-memory cache key is now registry-qualified via a shared
getPkgMetaCacheKey(registry, name, fullMetadata) helper. Previously the key was
only the package name (plus a `:full` suffix) while the on-disk mirror was
registry-qualified, so a package of the same name served by two registries in
one install could share one cache slot and resolve the wrong tarball/integrity.
The registry is threaded through createNpmResolutionVerifier's shared-meta reads
(readSharedMeta / readSharedMetaForTrust), which already noted that a
registry-qualified read required the resolver's metaCache key shape to change
first. Added a regression test that resolves the same package name from two
registries and asserts each gets its own tarball.

The Rust pacquet port already implements both behaviors (registry-scoped cache
key and disk-fast-path cache population), so no port is required.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port — pacquet already scopes its in-memory cache key by registry
  and populates it on the disk fast path, so no port was needed.
- [x] Added a changeset.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Fixed package metadata caching to be registry-qualified, preventing cache collisions when resolving the same package name from multiple registries in one install.
- Fixed checksum update behavior so `updateChecksums` always revalidates from the registry, bypassing both warm in-memory cache and the on-disk exact-version fast path.
- Improved cache warming by promoting disk-loaded exact-version metadata into the in-memory cache for faster subsequent resolutions.

## Tests
- Added coverage for registry-specific cache keys, disk-to-memory promotion behavior, and `updateChecksums` cache-bypass scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->