### PR TITLE
chore: add product labels in CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,3 +4,13 @@ reviews:
     - path: "**/*"
       instructions: |
         Apply the "AI Review Guidance" section in AGENTS.md. Security vulnerabilities are the first review priority; performance regressions in pnpm, pacquet, and pnpr are the second priority. Surface only issues tied to changed code, and explain the exploit path, impact, or hot path affected.
+  # Actually attach the chosen labels to the PR, not just suggest them in the walkthrough.
+  auto_apply_labels: true
+  # Custom labels assigned based on which product the diff touches. More than one may apply to a single PR.
+  labeling_instructions:
+    - label: "product: pnpm"
+      instructions: "Apply when changes affect the TypeScript pnpm CLI (any code outside pacquet/ and pnpr/)."
+    - label: "product: pacquet"
+      instructions: "Apply when changes affect pacquet, the Rust port of the pnpm CLI (the pacquet/ directory)."
+    - label: "product: pnpr"
+      instructions: "Apply when changes affect pnpr, the pnpm registry server (the pnpr/ directory and pacquet/crates/pnpr-* crates)."


### PR DESCRIPTION
Mirror the three product labels from the Qodo config (`.pr_agent.toml`) into CodeRabbit (`.coderabbit.yaml`):

- `product: pnpm` — changes to the TypeScript pnpm CLI (anything outside `pacquet/` and `pnpr/`)
- `product: pacquet` — changes to pacquet, the Rust port (the `pacquet/` directory)
- `product: pnpr` — changes to pnpr, the registry server (the `pnpr/` directory and `pacquet/crates/pnpr-*` crates)

CodeRabbit assigns these via `reviews.labeling_instructions`, and `auto_apply_labels: true` makes it actually attach the labels to the PR rather than only suggesting them in the walkthrough — the equivalent of Qodo's `publish_labels`.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR automation configuration to automatically apply product-specific labels based on affected components in pull requests, streamlining the labeling process for better organization and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->