### PR TITLE
ci: PR review automation (CodeRabbit approval + maintainer automerge)

### DIFF
--- a/.github/workflows/coderabbit-approval-notify.yml
+++ b/.github/workflows/coderabbit-approval-notify.yml
@@ -1,0 +1,40 @@
+name: CodeRabbit approval
+
+# Label and announce a PR when CodeRabbit submits an approving review.
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  on-coderabbit-approval:
+    if: >-
+      github.event.review.state == 'approved' &&
+      github.event.review.user.login == 'coderabbitai[bot]'
+    runs-on: ubuntu-latest
+    env:
+      # Webhook URL is optional; the Discord step is skipped when the secret is unset.
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      # PR fields are passed through the environment, never interpolated into a run script,
+      # so an attacker-controlled PR title cannot inject shell commands.
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+    steps:
+      - name: Add the reviewed label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "reviewed: coderabbit"
+
+      - name: Announce on Discord
+        if: ${{ env.DISCORD_WEBHOOK != '' }}
+        run: |
+          payload="$(jq -n \
+            --arg n "$PR_NUMBER" \
+            --arg t "$PR_TITLE" \
+            --arg u "$PR_URL" \
+            '{content: ("✅ CodeRabbit approved PR #" + $n + ": " + $t + "\n" + $u)}')"
+          curl -fsS -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"

--- a/.github/workflows/pr-review-automation.yml
+++ b/.github/workflows/pr-review-automation.yml
@@ -1,6 +1,7 @@
-name: CodeRabbit approval
+name: PR review automation
 
-# Label and announce a PR when CodeRabbit submits an approving review.
+# React to PR review submissions: announce CodeRabbit approvals and flag
+# maintainer-approved PRs for automerge.
 on:
   pull_request_review:
     types: [submitted]
@@ -38,3 +39,17 @@ jobs:
             --arg u "$PR_URL" \
             '{content: ("✅ CodeRabbit approved PR #" + $n + ": " + $t + "\n" + $u)}')"
           curl -fsS -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"
+
+  on-maintainer-approval:
+    if: >-
+      github.event.review.state == 'approved' &&
+      github.event.review.user.login == 'zkochan'
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Flag for automerge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "state: automerge"

--- a/.github/workflows/pr-review-automation.yml
+++ b/.github/workflows/pr-review-automation.yml
@@ -6,8 +6,8 @@ on:
   pull_request_review:
     types: [submitted]
 
-permissions:
-  pull-requests: write
+# No permissions by default; each job grants only what it needs.
+permissions: {}
 
 jobs:
   on-coderabbit-approval:
@@ -15,6 +15,8 @@ jobs:
       github.event.review.state == 'approved' &&
       github.event.review.user.login == 'coderabbitai[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     env:
       # Webhook URL is optional; the Discord step is skipped when the secret is unset.
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
@@ -33,18 +35,29 @@ jobs:
       - name: Announce on Discord
         if: ${{ env.DISCORD_WEBHOOK != '' }}
         run: |
+          # allowed_mentions parse:[] stops a PR title like "@everyone" from pinging the Discord server.
           payload="$(jq -n \
             --arg n "$PR_NUMBER" \
             --arg t "$PR_TITLE" \
             --arg u "$PR_URL" \
-            '{content: ("✅ CodeRabbit approved PR #" + $n + ": " + $t + "\n" + $u)}')"
-          curl -fsS -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"
+            '{content: ("✅ CodeRabbit approved PR #" + $n + ": " + $t + "\n" + $u), allowed_mentions: {parse: []}}')"
+          curl -fsS \
+            --connect-timeout 5 \
+            --max-time 20 \
+            --retry 3 \
+            --retry-all-errors \
+            --retry-delay 2 \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "$DISCORD_WEBHOOK"
 
   on-maintainer-approval:
     if: >-
       github.event.review.state == 'approved' &&
       github.event.review.user.login == 'zkochan'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:


### PR DESCRIPTION
Adds a GitHub Actions workflow (`.github/workflows/pr-review-automation.yml`) that reacts to PR review submissions. Two independent jobs on the same `pull_request_review` (`submitted`) trigger:

**1. CodeRabbit approval** — when `coderabbitai[bot]` submits an *approved* review:
- applies the informational label **`reviewed: coderabbit`** (already created on this repo; triggers nothing on its own), and
- posts a notice to Discord — *only if* a `DISCORD_WEBHOOK` secret is configured.

**2. Maintainer approval** — when `zkochan` submits an *approved* review:
- applies the existing **`state: automerge`** label.

### How it works
- `pull_request_review` runs in the base-repo context with the repo token and secrets, so it works for fork PRs too.
- Each job is gated on `review.state == 'approved'` plus the specific reviewer login.
- `permissions:` is narrowed to `pull-requests: write` (labels only).

### Security
PR fields (title, URL, number) are passed to the steps through the **environment**, never interpolated into a `run:` script, so an attacker-controlled PR title can't inject shell commands. The Discord payload is built with `jq` (proper JSON escaping). No PR code is checked out or executed — important because `pull_request_review` is a privileged trigger.

### Heads-up on `state: automerge`
I couldn't find anything in this repo that *consumes* `state: automerge` (no workflow, no Mergify/Kodiak config). If an external GitHub App reads it, zkochan's approval will trigger a real merge; if nothing reads it, the label is currently inert. Worth confirming the consumer exists.

The `zkochan` gate is hardcoded — if you'd rather key off a maintainers team or CODEOWNERS, that's an easy change.

### Required to enable the Discord notice (maintainer action)
The Discord step is a no-op until you add the webhook:
1. Create a Discord channel webhook (Channel → Integrations → Webhooks → New Webhook → Copy URL).
2. Add it as a repo secret: **Settings → Secrets and variables → Actions → New repository secret**, name `DISCORD_WEBHOOK`.

Until then the labels are applied and the Discord step is skipped cleanly.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow that reacts to pull request review submissions by applying appropriate labels and sending optional approval notifications when approvals come from designated reviewers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->