### PR TITLE
fix(ci): grant issues: write so the approval label step can run

### DIFF
--- a/.github/workflows/pr-review-automation.yml
+++ b/.github/workflows/pr-review-automation.yml
@@ -16,6 +16,9 @@ jobs:
       github.event.review.user.login == 'coderabbitai[bot]'
     runs-on: ubuntu-latest
     permissions:
+      # gh pr edit --add-label uses the GraphQL addLabelsToLabelable mutation,
+      # which is governed by issues: write even when the target is a PR.
+      issues: write
       pull-requests: write
     env:
       # Webhook URL is optional; the Discord step is skipped when the secret is unset.
@@ -57,6 +60,9 @@ jobs:
       github.event.review.user.login == 'zkochan'
     runs-on: ubuntu-latest
     permissions:
+      # gh pr edit --add-label uses the GraphQL addLabelsToLabelable mutation,
+      # which is governed by issues: write even when the target is a PR.
+      issues: write
       pull-requests: write
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Follow-up fix to the PR review automation merged in pnpm/pnpm#12462.

The workflow fails at runtime on the label step:

```
GraphQL: Resource not accessible by integration (addLabelsToLabelable)
Error: Process completed with exit code 1.
```

**Cause:** `gh pr edit --add-label` doesn't use the REST labels endpoint — it goes through the GraphQL `addLabelsToLabelable` mutation, which is governed by **`issues: write`** even when the target is a PR. The merged workflow granted only `pull-requests: write`, so the mutation is rejected.

(The `issues: write` fix was committed to the original branch *after* pnpm/pnpm#12462 had already merged, so it never landed — hence this separate PR.)

**Fix:** grant `issues: write` alongside `pull-requests: write` on each job. It stays job-scoped (not workflow-wide), so it remains least-privilege, and it matches the existing pattern in `pacquet-integrated-benchmark-comment.yml`.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to improve automation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->