### PR TITLE
chore: keep test fixtures out of GitHub's dependency graph

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,14 @@
 * text eol=lf
 
 *.tgz binary
+
+# Test fixtures embed package.json/lockfiles that name real packages purely as
+# test data, never as dependencies we install. Mark the fixture trees as
+# generated so GitHub's dependency graph (and therefore Dependabot alerts and
+# automatic security PRs) ignores them. This also collapses fixtures in diffs.
+# The `@pnpm/test-fixtures` helper package (__utils__/test-fixtures) is real
+# source, so it is intentionally not matched here.
+**/fixtures/** linguist-generated
+**/__fixtures__/** linguist-generated
+**/findPackages-fixtures/** linguist-generated
+pnpr/.fixtures/** linguist-generated


### PR DESCRIPTION
## Problem

Dependabot regularly opens noisy PRs (and raises alerts) to bump dependencies that exist in the repo **only as test-fixture data**, never as packages we actually install — for example the `js-cookie` bump in pnpm/pnpm#11840.

The cause: GitHub's dependency graph scans every `package.json`/lockfile in the repo, including the hundreds under fixture directories. Those fixtures reference real package names (`js-cookie`, `eslint`, `webpack`, …) purely to exercise install/resolution logic, so each one becomes a graph entry that Dependabot can alert and open security PRs for.

`exclude-paths` in `dependabot.yml` does **not** help here — it only suppresses *version* updates, not the *security* updates these PRs are.

## Fix

Mark the fixture trees as `linguist-generated` in `.gitattributes`:

```
**/fixtures/** linguist-generated
**/__fixtures__/** linguist-generated
**/findPackages-fixtures/** linguist-generated
pnpr/.fixtures/** linguist-generated
```

GitHub's dependency graph reuses Linguist's vendored/generated classification, so generated-marked manifests are excluded from the graph — and therefore from Dependabot alerts and automatic security-update PRs. As a bonus, fixtures collapse in diffs.

The `@pnpm/test-fixtures` helper package (`__utils__/test-fixtures`) is real source and is intentionally left unmarked. Verified with `git check-attr linguist-generated` that every fixture manifest is matched while real source, the root `package.json`, and the dist bundle are not.

Fixtures keep their `package.json` names and locations, so no test, loader, or build step changes.

## Verification needed after merge

GitHub documents directory-name and size/count exclusions for the dependency graph but does **not** explicitly document `.gitattributes`-based exclusion, so this should be confirmed on the default branch:

1. Check **Insights → Dependency graph** — fixture manifests should no longer appear.
2. Confirm a fixture-only alert (e.g. the pnpm/pnpm#11840 class) clears.

If the graph still lists them, the documented-certain fallback is to move fixtures under a vendored-named directory (e.g. `external/`), which GitHub excludes by name.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to mark fixture directories as generated content, improving GitHub's repository analysis and dependency tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->