### PR TITLE
ci: remove TS CI / Success aggregate gate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,6 @@ jobs:
     # Skip pull_request events from PRs in the same repo. This prevents
     # duplicate build jobs from running when creating a PR in the original repo.
     # Exception: chore/update-lockfile PRs (created by automation with GITHUB_TOKEN, which doesn't trigger push events)
-    #
-    # KEEP IN SYNC with the `success` job's name expression below: it must
-    # use this exact condition to give the skipped duplicate run a
-    # different name, so it never reports the required `TS CI / Success`.
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository || github.head_ref == 'chore/update-lockfile' }}
 
     name: TS CI / Compile & Lint
@@ -88,29 +84,3 @@ jobs:
       node: ${{ matrix.node }}
       node_major: ${{ matrix.node_major }}
       platform: ${{ matrix.platform }}
-
-  # Single aggregate gate — the only TS CI context branch protection needs
-  # to require. The Test matrix changes shape per branch (see the excludes
-  # above) and the jobs skip on same-repo PR events, so requiring the
-  # individual per-combination contexts is brittle. This job always runs
-  # and fails only if a dependency actually failed or was cancelled —
-  # skipped dependencies count as a pass.
-  #
-  # The name is `TS CI / Success` on every run that does real work, but a
-  # different name on the same-repo pull_request run that `compile-and-lint`
-  # skips for deduplication. Otherwise that skipped run would report a
-  # green `TS CI / Success` and satisfy branch protection before the real
-  # push run finished — letting a PR merge without CI. The name condition
-  # is `compile-and-lint`'s `if:` verbatim and MUST stay in sync with it.
-  success:
-    name: ${{ (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository || github.head_ref == 'chore/update-lockfile') && 'TS CI / Success' || 'TS CI / Success (skipped duplicate)' }}
-    if: ${{ always() }}
-    needs:
-      - compile-and-lint
-      - test-smoke
-      - test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fail if any dependency failed or was cancelled
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
-        run: exit 1


### PR DESCRIPTION
Removes the `success` aggregate gate job from the TS CI workflow, along with its comment block and the now-stale "KEEP IN SYNC with the `success` job" note on `compile-and-lint`.

> [!WARNING]
> If `TS CI / Success` is currently a **required status check** in branch protection, removing it will block merges (GitHub waits indefinitely for a context that never reports). Branch protection needs to be updated to require the actual jobs (e.g. `TS CI / Compile & Lint`, `TS CI / Test / *`) or drop the requirement.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed aggregate CI status check from the workflow, simplifying the pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->