### PR TITLE
fix(pacquet): resolve package-manager bootstrap through trusted registries

### DIFF
--- a/pacquet/crates/cli/src/config_deps.rs
+++ b/pacquet/crates/cli/src/config_deps.rs
@@ -61,7 +61,7 @@ pub async fn sync_package_manager_dependencies(
     pnpm_version: &str,
     frozen_lockfile: bool,
 ) -> Result<()> {
-    let context = EnvInstallerContext::new(config)?;
+    let context = EnvInstallerContext::for_package_manager(config)?;
     let options = context.options(root_dir, frozen_lockfile);
     resolve_package_manager_integrities(wanted_specifier, pnpm_version, &context.resolver, &options)
         .await
@@ -122,12 +122,48 @@ struct EnvInstallerContext {
 }
 
 impl EnvInstallerContext {
+    /// Context for resolving the project's `configDependencies`, using the
+    /// project's configured registries and network settings.
     fn new(config: &Config) -> Result<Self> {
+        Self::build(
+            config,
+            &config.proxy,
+            &config.tls,
+            &config.tls_by_uri,
+            config.resolved_registries(),
+            Arc::clone(&config.auth_headers),
+        )
+    }
+
+    /// Context for resolving the package manager pnpm auto-switches to
+    /// (`pnpm` / `@pnpm/exe`), routed through the trusted
+    /// [`PackageManagerBootstrap`](pacquet_config::PackageManagerBootstrap)
+    /// config instead of the repository-controlled project registries.
+    fn for_package_manager(config: &Config) -> Result<Self> {
+        let bootstrap = &config.package_manager_bootstrap;
+        Self::build(
+            config,
+            &bootstrap.proxy,
+            &bootstrap.tls,
+            &bootstrap.tls_by_uri,
+            bootstrap.resolved_registries(),
+            Arc::clone(&bootstrap.auth_headers),
+        )
+    }
+
+    fn build(
+        config: &Config,
+        proxy: &pacquet_network::ProxyConfig,
+        tls: &pacquet_network::TlsConfig,
+        tls_by_uri: &pacquet_network::PerRegistryTls,
+        registries: std::collections::BTreeMap<String, String>,
+        auth_headers: Arc<pacquet_network::AuthHeaders>,
+    ) -> Result<Self> {
         let http_client = Arc::new(
             ThrottledClient::for_installs(
-                &config.proxy,
-                &config.tls,
-                &config.tls_by_uri,
+                proxy,
+                tls,
+                tls_by_uri,
                 &NetworkSettings {
                     network_concurrency: config.network_concurrency,
                     fetch_timeout: Duration::from_millis(config.fetch_timeout),
@@ -135,18 +171,16 @@ impl EnvInstallerContext {
                 },
             )
             .into_diagnostic()
-            .wrap_err("create the network client for configurational dependencies")?,
+            .wrap_err("create the network client for env-installer dependencies")?,
         );
 
-        let registries: HashMap<String, String> =
-            config.resolved_registries().into_iter().collect();
+        let registries: HashMap<String, String> = registries.into_iter().collect();
         let retry_opts = RetryOpts {
             retries: config.fetch_retries,
             factor: config.fetch_retry_factor,
             min_timeout: Duration::from_millis(config.fetch_retry_mintimeout),
             max_timeout: Duration::from_millis(config.fetch_retry_maxtimeout),
         };
-        let auth_headers = Arc::clone(&config.auth_headers);
         let resolver = NpmResolver {
             registries: registries.clone(),
             named_registries: HashMap::new(),

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1433,6 +1433,40 @@ pub struct Config {
     /// fetchers via [`pacquet_network::AuthHeaders::for_url`]. Empty
     /// when no `.npmrc` was found or no auth keys were set.
     pub auth_headers: std::sync::Arc<pacquet_network::AuthHeaders>,
+
+    pub package_manager_bootstrap: PackageManagerBootstrap,
+}
+
+/// Registry + network configuration for resolving the package manager pnpm
+/// auto-switches to. Built only from sources outside the repository's
+/// control (builtin default, user `.npmrc`, `auth.ini`, URL-scoped env), so
+/// a malicious `pnpm-workspace.yaml` or project `.npmrc` cannot redirect the
+/// package-manager bytes to an attacker registry or proxy. Mirrors pnpm's
+/// `packageManagerRegistries` / `packageManagerNetworkConfig`. See
+/// GHSA-j2hc-m6cf-6jm8.
+#[derive(Debug, Clone, SmartDefault)]
+pub struct PackageManagerBootstrap {
+    /// Defaults to the public npm registry so a [`Config`] built without
+    /// [`Config::current`] never resolves against an empty registry.
+    #[default(_code = "default_registry()")]
+    pub registry: String,
+    /// Scoped registry routes (keyed by `@scope`), excluding `default`.
+    pub registries: BTreeMap<String, String>,
+    pub proxy: pacquet_network::ProxyConfig,
+    pub tls: pacquet_network::TlsConfig,
+    pub tls_by_uri: pacquet_network::PerRegistryTls,
+    pub auth_headers: std::sync::Arc<pacquet_network::AuthHeaders>,
+}
+
+impl PackageManagerBootstrap {
+    /// Registry map in pnpm's `Registries` shape: `default` plus the
+    /// configured scoped routes. Mirrors [`Config::resolved_registries`].
+    #[must_use]
+    pub fn resolved_registries(&self) -> BTreeMap<String, String> {
+        let mut registries = self.registries.clone();
+        registries.insert("default".to_string(), self.registry.clone());
+        registries
+    }
 }
 
 impl Config {
@@ -1820,6 +1854,11 @@ impl Config {
             (!auth.creds_by_scope_by_uri.is_empty()).then_some(auth)
         };
 
+        // Capture the trusted sources (everything but `project_source`) for
+        // [`PackageManagerBootstrap`] before the fold below consumes them.
+        let trusted_sources =
+            [env_scoped_source.clone(), auth_ini_source.clone(), user_source.clone()];
+
         // Fold high-priority-first: the first present source is the
         // base, each lower source fills the gaps it left
         // ([`NpmrcAuth::merge_under`]).
@@ -1829,6 +1868,13 @@ impl Config {
         for lower in sources {
             npmrc_auth.merge_under(lower);
         }
+
+        let mut trusted_sources = trusted_sources.into_iter().flatten();
+        let mut trusted_auth = trusted_sources.next().unwrap_or_default();
+        for lower in trusted_sources {
+            trusted_auth.merge_under(lower);
+        }
+        self.package_manager_bootstrap = build_package_manager_bootstrap::<Sys>(trusted_auth);
 
         npmrc_auth.apply_registry_and_warn(&mut self);
         // Proxy cascade fires unconditionally — even when no `.npmrc`
@@ -1959,9 +2005,16 @@ impl Config {
         global_virtual_store_dir_explicit |= env_settings.global_virtual_store_dir.is_some();
         store_dir_explicit |= env_settings.store_dir.is_some();
         env_settings.substitute_env_trusted::<Sys>();
+        // `PNPM_CONFIG_REGISTRY` comes from the environment, not the
+        // repository, so it overrides the bootstrap default registry too.
+        let env_registry_override = env_settings.registry.clone();
         let saved_workspace_dir = self.workspace_dir.clone();
         env_settings.apply_to(&mut self, start_dir);
         self.workspace_dir = saved_workspace_dir;
+        if let Some(registry) = env_registry_override {
+            self.package_manager_bootstrap.registry =
+                if registry.ends_with('/') { registry } else { format!("{registry}/") };
+        }
 
         // Build the per-URI auth-header lookup. Credentials were already
         // pinned to their source file's registry by `rescope_unscoped`,
@@ -2018,6 +2071,31 @@ impl Config {
     /// Persist the config data until the program terminates.
     pub fn leak(self) -> &'static mut Self {
         self.pipe(Box::new).pipe(Box::leak)
+    }
+}
+
+/// Build the [`PackageManagerBootstrap`] from the already-folded trusted
+/// sources, running them through the same registry/proxy/TLS/auth steps the
+/// full config uses so the bootstrap cascade matches the project cascade
+/// minus the repository-controlled sources.
+fn build_package_manager_bootstrap<Sys: EnvVar>(
+    mut trusted_auth: crate::npmrc_auth::NpmrcAuth,
+) -> PackageManagerBootstrap {
+    // The full-config fold already surfaced these sources' `${VAR}` warnings;
+    // drop the duplicates this second pass would log.
+    trusted_auth.warnings.clear();
+    let mut config = Config::default();
+    trusted_auth.apply_registry_and_warn(&mut config);
+    trusted_auth.apply_proxy_cascade::<Sys>(&mut config);
+    trusted_auth.apply_tls_and_local_address(&mut config);
+    trusted_auth.build_auth_headers(&mut config);
+    PackageManagerBootstrap {
+        registry: config.registry,
+        registries: config.registries,
+        proxy: config.proxy,
+        tls: config.tls,
+        tls_by_uri: config.tls_by_uri,
+        auth_headers: config.auth_headers,
     }
 }
 

--- a/pacquet/crates/config/src/npmrc_auth.rs
+++ b/pacquet/crates/config/src/npmrc_auth.rs
@@ -42,7 +42,7 @@ use std::{
 /// up.
 ///
 /// [#336]: https://github.com/pnpm/pacquet/issues/336
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub(crate) struct NpmrcAuth {
     pub registry: Option<String>,
     pub scoped_registries: BTreeMap<String, String>,

--- a/pacquet/crates/config/src/tests.rs
+++ b/pacquet/crates/config/src/tests.rs
@@ -1527,3 +1527,108 @@ fn resolved_minimum_release_age_treats_zero_as_disabled() {
     config.minimum_release_age = None;
     assert_eq!(config.resolved_minimum_release_age(), None);
 }
+
+const NPM_DEFAULT_REGISTRY: &str = "https://registry.npmjs.org/";
+
+/// A project `.npmrc` redirecting the default registry still drives normal
+/// installs, but must NOT steer package-manager bootstrap: that resolves
+/// through the trusted user-level registry instead. Regression test for
+/// GHSA-j2hc-m6cf-6jm8 (`packageManager` auto-switch registry confusion).
+#[test]
+pub fn package_manager_bootstrap_ignores_project_npmrc_registry() {
+    let auth = tempdir().expect("auth tempdir");
+    let user_file = auth.path().join("user-npmrc");
+    write_file(&user_file, "registry=https://trusted.example.com/\n");
+
+    let config = load_with_project_and_user("registry=https://attacker.example.com/\n", user_file);
+
+    assert_eq!(
+        config.registry, "https://attacker.example.com/",
+        "project registry drives normal installs",
+    );
+    assert_eq!(
+        config.package_manager_bootstrap.registry, "https://trusted.example.com/",
+        "package-manager bootstrap ignores the repository-controlled project .npmrc registry",
+    );
+    assert_eq!(
+        config.package_manager_bootstrap.resolved_registries().get("default").map(String::as_str),
+        Some("https://trusted.example.com/"),
+    );
+}
+
+/// A `pnpm-workspace.yaml` `registries:` block is repository-controlled, so
+/// it must not steer package-manager bootstrap either — neither the default
+/// nor a scoped route. Regression test for GHSA-j2hc-m6cf-6jm8.
+#[test]
+pub fn package_manager_bootstrap_ignores_workspace_yaml_registries() {
+    let auth = tempdir().expect("auth tempdir");
+    let user_file = auth.path().join("user-npmrc");
+    write_file(&user_file, "registry=https://trusted.example.com/\n");
+
+    let project = tempdir().expect("project tempdir");
+    fs::write(
+        project.path().join("pnpm-workspace.yaml"),
+        "registries:\n  default: https://attacker.example.com/\n  '@evil': https://attacker-scoped.example.com/\n",
+    )
+    .expect("write pnpm-workspace.yaml");
+    let config = Config { npmrc_auth_file: Some(user_file), ..Config::default() }
+        .current::<HostNoHome>(project.path())
+        .expect("load config");
+
+    assert_eq!(
+        config.registry, "https://attacker.example.com/",
+        "workspace yaml drives normal installs",
+    );
+    assert_eq!(
+        config.registries.get("@evil").map(String::as_str),
+        Some("https://attacker-scoped.example.com/"),
+    );
+    assert_eq!(
+        config.package_manager_bootstrap.registry, "https://trusted.example.com/",
+        "package-manager bootstrap ignores the workspace yaml default registry",
+    );
+    assert_eq!(
+        config.package_manager_bootstrap.registries.get("@evil"),
+        None,
+        "package-manager bootstrap ignores workspace yaml scoped registries",
+    );
+}
+
+/// With no trusted user-level registry configured, package-manager
+/// bootstrap falls back to the public npm registry — never the project's
+/// attacker-controlled registry.
+#[test]
+pub fn package_manager_bootstrap_defaults_to_npm_registry() {
+    let project = tempdir().expect("project tempdir");
+    write_file(&project.path().join(".npmrc"), "registry=https://attacker.example.com/\n");
+    let config = Config::default().current::<HostNoHome>(project.path()).expect("load config");
+
+    assert_eq!(config.registry, "https://attacker.example.com/");
+    assert_eq!(config.package_manager_bootstrap.registry, NPM_DEFAULT_REGISTRY);
+}
+
+/// A directly-constructed `PackageManagerBootstrap` (one not finalized
+/// through `Config::current`) still defaults to the public npm registry,
+/// never an empty registry the resolver would choke on.
+#[test]
+pub fn package_manager_bootstrap_default_registry_is_npm() {
+    assert_eq!(crate::PackageManagerBootstrap::default().registry, NPM_DEFAULT_REGISTRY);
+}
+
+/// `PNPM_CONFIG_REGISTRY` is user-controlled (not repository-controlled), so
+/// it overrides the package-manager bootstrap default registry too,
+/// mirroring pnpm's env/CLI `registry` handling.
+#[test]
+pub fn package_manager_bootstrap_honors_env_registry() {
+    let project = tempdir().expect("project tempdir");
+    write_file(&project.path().join(".npmrc"), "registry=https://attacker.example.com/\n");
+    set_fake_env(&[("PNPM_CONFIG_REGISTRY", "https://env.example.com/")]);
+
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(config.registry, "https://env.example.com/", "env registry drives normal installs");
+    assert_eq!(
+        config.package_manager_bootstrap.registry, "https://env.example.com/",
+        "env registry overrides the package-manager bootstrap default",
+    );
+}

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -126,6 +126,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         proxy: Default::default(),
         tls: Default::default(),
         tls_by_uri: Default::default(),
+        package_manager_bootstrap: Default::default(),
     }
 }
 


### PR DESCRIPTION
## What

Ports the GHSA-j2hc-m6cf-6jm8 fix ([pnpm/pnpm#12296](https://github.com/pnpm/pnpm/pull/12296)) to pacquet, keeping the two stacks in sync per the parity rule in `AGENTS.md`.

## Why

When pnpm auto-switches to the version requested by `packageManager` / `devEngines.packageManager`, the package-manager bytes (`pnpm` / `@pnpm/exe`) must be resolved through **trusted** registries only. The TypeScript CLI was fixed in #12296 (`config.packageManagerRegistries` / `packageManagerNetworkConfig`), but pacquet was never ported.

Pacquet's `sync_package_manager_dependencies` built its resolver from `config.resolved_registries()` — the **project/workspace** registries, which a malicious repository controls via the workspace `.npmrc` or a `pnpm-workspace.yaml` `registries:` block. That lets a repository point package-manager bootstrap resolution at an attacker-controlled registry.

Pacquet only *resolves* and writes integrity metadata into `pnpm-lock.yaml` here (it does not download/execute the bytes itself), so its standalone impact is lockfile poisoning rather than direct RCE — but the trust boundary must match pnpm regardless.

## How

- Add `Config::package_manager_bootstrap` (`PackageManagerBootstrap`), built in `Config::current()` from a **trusted-only** fold of the URL-scoped env, `auth.ini`, and user `.npmrc` sources. The project `.npmrc` and `pnpm-workspace.yaml` `registries:` are excluded. It reuses the existing registry/proxy/TLS/auth application logic so the bootstrap cascade stays identical to the project cascade minus the repository-controlled sources. `PNPM_CONFIG_REGISTRY` still overrides the bootstrap default because it is user-controlled (mirrors pnpm's env/CLI `registry` handling).
- Add `EnvInstallerContext::for_package_manager`, used only by the package-manager bootstrap path (`sync_package_manager_dependencies`). Project `configDependencies` resolution keeps the project registries via `EnvInstallerContext::new`, matching the narrow scope of the upstream TypeScript fix.

## Tests

New regression tests in `config/src/tests.rs`:

- `package_manager_bootstrap_ignores_project_npmrc_registry`
- `package_manager_bootstrap_ignores_workspace_yaml_registries`
- `package_manager_bootstrap_defaults_to_npm_registry`
- `package_manager_bootstrap_honors_env_registry`

Each asserts normal installs still follow the project/workspace/env registry while package-manager bootstrap stays on the trusted (or npm-default) registry.

Verified locally: `cargo fmt --check`, workspace `cargo clippy`/dylint (`-D warnings`), `cargo doc -D warnings`, and `cargo test` for `pacquet-config` (291) / `pacquet-env-installer` (12) / `pacquet-cli` cli_args (72) all pass.

> No changeset: pacquet-only change.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package-manager “bootstrap” registry/auth resolution to rely only on trusted user settings, preventing project or workspace registry settings from overriding bootstrap defaults.
  * Ensured `PNPM_CONFIG_REGISTRY` updates both the effective runtime registry and the bootstrap default registry.
  * Updated environment lockfile dependency syncing to initialize the resolver using the package-manager bootstrap networking/security/auth context.
* **Tests**
  * Added regression tests covering trusted-vs-repository registry precedence, default registry fallback, and `PNPM_CONFIG_REGISTRY` override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Suggested squash commit message body

```
Port the GHSA-j2hc-m6cf-6jm8 fix (pnpm/pnpm#12296) to pacquet.

When pnpm auto-switches to the version requested by `packageManager` /
`devEngines.packageManager`, the bootstrap (`pnpm` / `@pnpm/exe`) must be
resolved through trusted registries only. Pacquet was resolving it through
`config.resolved_registries()`, which a malicious repository controls via
the workspace `.npmrc` or `pnpm-workspace.yaml` `registries:` block.

Add `Config::package_manager_bootstrap`, built in `Config::current()` from a
trusted-only fold of the URL-scoped env, `auth.ini`, and user `.npmrc`
sources (the project `.npmrc` is excluded), reusing the existing
registry/proxy/TLS/auth application logic. It defaults to the public npm
registry, and `PNPM_CONFIG_REGISTRY` still overrides the default because it
is user-controlled.

`EnvInstallerContext::for_package_manager` routes only the package-manager
bootstrap path (`sync_package_manager_dependencies`) through this trusted
config; project `configDependencies` resolution keeps the project
registries, matching the narrow scope of the upstream TypeScript fix.
```
