### PR TITLE
fix: converge incremental install by refreshing stale transitive pins (alternative to #11502)

### DIFF
--- a/.changeset/refresh-stale-lockfile-pins.md
+++ b/.changeset/refresh-stale-lockfile-pins.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fixed a lockfile non-convergence bug where an incremental install kept a duplicate transitive dependency that a fresh install would not produce. When a package is reused from the lockfile, its child edges are taken verbatim and bypass the preferred-versions walk, so a transitive dependency could stay pinned to an older version even after a direct dependency resolved to a higher version that satisfies the same range. The resolver now refreshes such a stale pin to the higher direct-dependency version during resolution — so the older version is never resolved or fetched, and the incremental result converges to the fresh one.

--- a/installing/deps-installer/test/install/dedupe.ts
+++ b/installing/deps-installer/test/install/dedupe.ts
@@ -212,6 +212,89 @@ test('ignore version of root dependency when it is incompatible with the indirec
   expect(lockfile.packages).toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@101.0.0'])
 })
 
+test('refreshes a stale transitive pin to a higher direct-dependency version at resolution time', async () => {
+  // The stale transitive pin is refreshed during resolution, so the older
+  // version is never resolved or fetched (no post-resolution pruning).
+  const project = prepareEmpty()
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
+
+  const { updatedManifest: manifest } = await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0', '@pnpm.e2e/pkg-with-1-dep@100.0.0'],
+    testDefaults()
+  )
+
+  expect(project.readLockfile().packages).toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'])
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+
+  await addDependenciesToPackage(
+    manifest,
+    ['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0'],
+    testDefaults()
+  )
+
+  const lockfile = project.readLockfile()
+  expect(lockfile.packages).toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0'])
+  expect(lockfile.packages).not.toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'])
+})
+
+test('does not refresh an aliased transitive dependency', async () => {
+  // pkg-with-1-aliased-dep depends on `dep: npm:@pnpm.e2e/dep-of-pkg-with-1-dep@^100.0.0`.
+  // An `npm:` specifier is not a plain semver range, so the refresh skips
+  // the edge and the older version is kept (no misfire on aliases).
+  const project = prepareEmpty()
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
+
+  const { updatedManifest: manifest } = await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0', '@pnpm.e2e/pkg-with-1-aliased-dep@100.0.0'],
+    testDefaults()
+  )
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+
+  await addDependenciesToPackage(
+    manifest,
+    ['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0'],
+    testDefaults()
+  )
+
+  const lockfile = project.readLockfile()
+  expect(lockfile.packages).toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0'])
+  expect(lockfile.packages).toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'])
+})
+
+test('refreshing a stale transitive pin is idempotent', async () => {
+  const project = prepareEmpty()
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
+
+  const { updatedManifest: manifest } = await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0', '@pnpm.e2e/pkg-with-1-dep@100.0.0'],
+    testDefaults()
+  )
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+
+  const { updatedManifest: manifestWithBoth } = await addDependenciesToPackage(
+    manifest,
+    ['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0'],
+    testDefaults()
+  )
+
+  const convergedPackages = project.readLockfile().packages
+  expect(convergedPackages).not.toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'])
+
+  // A second install over the converged lockfile must not reintroduce or
+  // churn the refreshed edge.
+  await install(manifestWithBoth, testDefaults())
+  expect(project.readLockfile().packages).toStrictEqual(convergedPackages)
+})
+
 test('prefer dist-tag specified for top dependency', async () => {
   const project = prepareEmpty()
 

--- a/installing/deps-installer/test/install/multipleImporters.ts
+++ b/installing/deps-installer/test/install/multipleImporters.ts
@@ -1962,3 +1962,54 @@ require("fs").writeFileSync("created-by-prepare", "", "utf8")`)
 
   expect(fs.existsSync('project-1/created-by-prepare')).toBeTruthy()
 })
+
+test("a direct-dependency bump in one importer converges another importer's transitive pin", async () => {
+  preparePackages([
+    { location: 'project-1', package: { name: 'project-1' } },
+    { location: 'project-2', package: { name: 'project-2' } },
+  ])
+
+  const importers: MutatedProject[] = [
+    { mutation: 'install', rootDir: path.resolve('project-1') as ProjectRootDir },
+    { mutation: 'install', rootDir: path.resolve('project-2') as ProjectRootDir },
+  ]
+  // project-1 pulls dep-of-pkg-with-1-dep transitively (via pkg-with-1-dep);
+  // project-2 depends on it directly. Only project-2 ever bumps it.
+  const allProjects = (directDepOfVersion: string) => [
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'project-1',
+        version: '1.0.0',
+        dependencies: { '@pnpm.e2e/pkg-with-1-dep': '100.0.0' },
+      },
+      rootDir: path.resolve('project-1') as ProjectRootDir,
+    },
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'project-2',
+        version: '1.0.0',
+        dependencies: { '@pnpm.e2e/dep-of-pkg-with-1-dep': directDepOfVersion },
+      },
+      rootDir: path.resolve('project-2') as ProjectRootDir,
+    },
+  ]
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
+  await mutateModules(importers, testDefaults({ allProjects: allProjects('100.0.0') }))
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+  await mutateModules(importers, testDefaults({ allProjects: allProjects('100.1.0') }))
+
+  const lockfile = readYamlFileSync<any>(WANTED_LOCKFILE) // eslint-disable-line @typescript-eslint/no-explicit-any
+  // All importers' direct deps resolve before any transitive, so project-2's
+  // bumped 100.1.0 is in scope when project-1's transitive edge re-resolves.
+  // The refresh converges that edge to 100.1.0 too — matching a fresh install
+  // (no pin), where `^100.0.0` resolves to the latest 100.1.0 — and the stale
+  // 100.0.0 is pruned.
+  expect(lockfile.importers['project-2'].dependencies['@pnpm.e2e/dep-of-pkg-with-1-dep'].version).toBe('100.1.0')
+  expect(lockfile.snapshots['@pnpm.e2e/pkg-with-1-dep@100.0.0'].dependencies['@pnpm.e2e/dep-of-pkg-with-1-dep']).toBe('100.1.0')
+  expect(lockfile.packages).toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0'])
+  expect(lockfile.packages).not.toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'])
+})

--- a/installing/deps-resolver/src/resolveDependencies.ts
+++ b/installing/deps-resolver/src/resolveDependencies.ts
@@ -714,6 +714,7 @@ export async function resolveDependencies (
 ): Promise<ResolvedDependenciesResult> {
   const extendedWantedDeps = getDepsToResolve(wantedDependencies, ctx.wantedLockfile, {
     preferredDependencies: options.preferredDependencies,
+    preferredVersions,
     prefix: options.prefix,
     proceed: options.proceed || ctx.forceFullResolution,
     registries: ctx.registries,
@@ -1411,6 +1412,7 @@ function getDepsToResolve (
   wantedLockfile: LockfileObject,
   options: {
     preferredDependencies?: ResolvedDependencies
+    preferredVersions?: PreferredVersions
     prefix: string
     proceed: boolean
     registries: Registries
@@ -1430,6 +1432,7 @@ function getDepsToResolve (
   })
   for (const wantedDependency of wantedDependencies) {
     let reference = undefined as undefined | string
+    let preferredVersion = undefined as undefined | string
     let proceed = proceedAll
     if (wantedDependency.alias) {
       const satisfiesWanted = satisfiesWanted2Args.bind(null, wantedDependency)
@@ -1437,7 +1440,26 @@ function getDepsToResolve (
         resolvedDependencies[wantedDependency.alias] &&
         (satisfiesWanted(resolvedDependencies[wantedDependency.alias]) || resolvedDependencies[wantedDependency.alias].startsWith('file:'))
       ) {
-        reference = resolvedDependencies[wantedDependency.alias]
+        const pinnedRef = resolvedDependencies[wantedDependency.alias]
+        // Reusing a lockfile pin verbatim bypasses the preferred-versions
+        // walk, so a transitive edge stays on a stale lower version even
+        // when a direct dependency resolved to a higher version in range.
+        const pinned = pinnedRef.startsWith('file:')
+          ? undefined
+          : getPinnedNameVer(wantedLockfile, pinnedRef, wantedDependency.alias)
+        const higherDirectVersion = pinned == null
+          ? undefined
+          : findHigherDirectDepVersion(options.preferredVersions, pinned.name, pinned.version, wantedDependency.bareSpecifier)
+        if (higherDirectVersion != null) {
+          // `preferredVersion` (singular) overrides the
+          // EXISTING_VERSION_SELECTOR_WEIGHT stability bias that would
+          // otherwise re-pick the lower version. The lower version is then
+          // never resolved or fetched.
+          proceed = true
+          preferredVersion = higherDirectVersion
+        } else {
+          reference = pinnedRef
+        }
       } else if (
         // If dependencies that were used by the previous version of the package
         // satisfy the newer version's requirements, then pnpm tries to keep
@@ -1474,6 +1496,7 @@ function getDepsToResolve (
     }
     extendedWantedDeps.push({
       infoFromLockfile,
+      preferredVersion,
       proceed,
       wantedDependency,
     })
@@ -1504,6 +1527,51 @@ function referenceSatisfiesWantedSpec (
     return true
   }
   return semver.satisfies(version, wantedDep.bareSpecifier, true)
+}
+
+function getPinnedNameVer (
+  lockfile: LockfileObject,
+  reference: string,
+  alias: string
+): { name: string, version: string } | undefined {
+  const depPath = dp.refToRelative(reference, alias)
+  if (depPath === null) return undefined
+  const pkgSnapshot = lockfile.packages?.[depPath]
+  if (pkgSnapshot == null) return undefined
+  return nameVerFromPkgSnapshot(depPath, pkgSnapshot)
+}
+
+// The highest version a direct dependency (the only deterministic,
+// resolved-first anchor) resolved to that is higher than the
+// lockfile-pinned `pinnedVersion` and still satisfies the edge's range, or
+// `undefined` when none exists. Direct-dependency versions are marked with
+// DIRECT_DEP_SELECTOR_WEIGHT in preferredVersions.
+function findHigherDirectDepVersion (
+  preferredVersions: PreferredVersions | undefined,
+  pinnedName: string,
+  pinnedVersion: string,
+  bareSpecifier: string
+): string | undefined {
+  if (preferredVersions == null) return undefined
+  if (!semver.valid(pinnedVersion)) return undefined
+  if (semver.validRange(bareSpecifier) === null) return undefined
+  const selectors = preferredVersions[pinnedName]
+  if (selectors == null) return undefined
+  let best: string | undefined
+  for (const [candidate, selector] of Object.entries(selectors)) {
+    if (
+      typeof selector === 'object' &&
+      selector.selectorType === 'version' &&
+      selector.weight === DIRECT_DEP_SELECTOR_WEIGHT &&
+      semver.valid(candidate) &&
+      semver.gt(candidate, pinnedVersion) &&
+      semver.satisfies(candidate, bareSpecifier, true) &&
+      (best == null || semver.gt(candidate, best))
+    ) {
+      best = candidate
+    }
+  }
+  return best
 }
 
 export interface LockedPeerContext {

--- a/pacquet/crates/cli/tests/stale_pin_dedupe.rs
+++ b/pacquet/crates/cli/tests/stale_pin_dedupe.rs
@@ -1,0 +1,150 @@
+//! Refreshing a stale transitive pin to a higher direct-dependency
+//! version during resolution, so an incremental install converges to what
+//! a fresh install would produce. Mirrors the pnpm fix in
+//! `installing/deps-resolver/src/resolveDependencies.ts`.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::{fs, path::Path, process::Command};
+
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+}
+
+fn write_manifest(path: &Path, dep_of_version: &str) {
+    fs::write(
+        path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/dep-of-pkg-with-1-dep": dep_of_version,
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+}
+
+#[test]
+fn refreshes_stale_transitive_pin_to_higher_direct_dep_version() {
+    // Keep `root` (the TempDir) and the mock registry alive for the whole
+    // test — dropping them deletes the workspace / stops the registry.
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+
+    // First install pins the direct dep at 100.0.0, so the transitive
+    // `^100.0.0` edge prefers it: only 100.0.0 is recorded.
+    write_manifest(&manifest_path, "100.0.0");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0"),
+        "the first install records the pinned 100.0.0:\n{lockfile}",
+    );
+    assert!(
+        !lockfile.contains("@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0"),
+        "the first install must not yet contain 100.1.0:\n{lockfile}",
+    );
+
+    // Bump the direct dependency to 100.1.0. It still satisfies the
+    // transitive `^100.0.0`, so both edges must land on 100.1.0 and the
+    // stale 100.0.0 must be pruned.
+    write_manifest(&manifest_path, "100.1.0");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0"),
+        "the second install resolves the bumped 100.1.0:\n{lockfile}",
+    );
+    assert!(
+        !lockfile.contains("@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0"),
+        "the stale 100.0.0 transitive pin must be refreshed to 100.1.0, not kept:\n{lockfile}",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn refreshes_stale_transitive_pin_for_caret_range_direct_dep() {
+    // Same convergence, but the bumped direct dep uses a caret range
+    // (`^100.1.0`) — the spec `pnpm add` actually writes. The refresh
+    // relies on the resolved direct-dep version (100.1.0), not the spec
+    // string, so it must still redirect the transitive `^100.0.0` edge.
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+
+    write_manifest(&manifest_path, "100.0.0");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    write_manifest(&manifest_path, "^100.1.0");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0"),
+        "the bumped caret-range direct dep resolves 100.1.0:\n{lockfile}",
+    );
+    assert!(
+        !lockfile.contains("@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0"),
+        "the stale 100.0.0 transitive pin must be refreshed to 100.1.0, not kept:\n{lockfile}",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn does_not_refresh_an_aliased_transitive_dependency() {
+    // pkg-with-1-aliased-dep depends on
+    // `dep: npm:@pnpm.e2e/dep-of-pkg-with-1-dep@^100.0.0`. An `npm:` specifier
+    // is not a plain semver range, so the refresh skips the edge and the
+    // older version is kept (no misfire on aliases). Matches pnpm.
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+
+    let write = |dep_of_version: &str| {
+        fs::write(
+            &manifest_path,
+            serde_json::json!({
+                "dependencies": {
+                    "@pnpm.e2e/dep-of-pkg-with-1-dep": dep_of_version,
+                    "@pnpm.e2e/pkg-with-1-aliased-dep": "100.0.0",
+                }
+            })
+            .to_string(),
+        )
+        .expect("write package.json");
+    };
+
+    write("100.0.0");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    write("100.1.0");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0"),
+        "the bumped direct dep resolves 100.1.0:\n{lockfile}",
+    );
+    assert!(
+        lockfile.contains("@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0"),
+        "the aliased transitive edge keeps its 100.0.0 pin:\n{lockfile}",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -41,7 +41,9 @@ use crate::{
     node_id::NodeId,
     resolved_tree::{DependenciesTreeNode, DirectDep, PeerDep, ResolvedPackage, ResolvedTree},
 };
-use pacquet_lockfile::{PkgNameVerPeer, SnapshotEntry};
+use pacquet_lockfile::{
+    PkgName, PkgNameVerPeer, ProjectSnapshot, ResolvedDependencyMap, SnapshotDepRef, SnapshotEntry,
+};
 
 /// Which dependencies `pacquet update` excludes from lockfile-resolution
 /// reuse. An excluded package re-resolves to highest-in-range, and its
@@ -495,6 +497,10 @@ fn project_relative_cache_scope(
 /// meta from any manifest.
 pub(crate) type WantedSpec = (String, String, bool, bool);
 
+/// An importer's resolved direct-dependency versions, keyed by package
+/// name. See [`WorkspaceTreeCtx::direct_dep_versions`].
+type DirectDepVersions = HashMap<String, Vec<node_semver::Version>>;
+
 /// One entry in [`WorkspaceTreeCtx`]'s `children_specs_by_id` map —
 /// `(child_alias, child_range, child_optional)` triples extracted from
 /// a resolved package's manifest's `dependencies` plus
@@ -596,6 +602,23 @@ pub struct WorkspaceTreeCtx {
     /// every other importer's hoist. Consumed via
     /// [`crate::HoistMissingScope`].
     first_walk_missing_by_pkg: Mutex<HashMap<String, OwnerMissingRecord>>,
+    /// Per importer: direct-dep aliases whose manifest specifier differs
+    /// from the prior lockfile (new deps included). Gates the stale-pin
+    /// refresh's reuse-decline; only a changed direct dep can re-resolve
+    /// away from a transitive occurrence's pin. Keyed by importer: this
+    /// crate resolves importers sequentially (no workspace-wide
+    /// directs-before-transitives barrier), so a shared map would refresh
+    /// one importer's edges from another's direct deps order-dependently.
+    /// (pnpm has that barrier and so converges cross-importer; pacquet
+    /// stays per-importer to stay deterministic.)
+    changed_direct_deps: Mutex<HashMap<String, HashSet<PkgName>>>,
+    /// Per importer: the parsed resolved versions of its direct
+    /// dependencies, recorded once the direct-dep level finishes resolving.
+    /// The `DIRECT_DEP_SELECTOR_WEIGHT` versions pnpm folds into
+    /// `preferredVersions`; consulted by [`fn@higher_direct_dep_version`].
+    /// `Arc` so the hot child walk snapshots the importer's map with one
+    /// lock + refcount bump instead of locking per edge.
+    direct_dep_versions: Mutex<HashMap<String, Arc<DirectDepVersions>>>,
 }
 
 /// One [`WorkspaceTreeCtx::first_walk_missing_by_pkg`] entry: the
@@ -629,6 +652,8 @@ impl Default for WorkspaceTreeCtx {
             registries: HashMap::new(),
             first_importer_by_pkg: Mutex::new(HashMap::new()),
             first_walk_missing_by_pkg: Mutex::new(HashMap::new()),
+            changed_direct_deps: Mutex::new(HashMap::new()),
+            direct_dep_versions: Mutex::new(HashMap::new()),
         }
     }
 }
@@ -1066,6 +1091,7 @@ where
     } else {
         ReuseSource::Off
     };
+    record_changed_direct_deps(ctx, importer_id, &wanted);
     // Phase 1: resolve every direct dep before any subtree walk, so
     // the level's resolved versions seed the children's
     // preferred-versions overlay (upstream's per-level fold; the
@@ -1106,9 +1132,13 @@ where
         .await?;
     // The level chain extends any caller-seeded overlay so descendant
     // picks and cache keys keep honoring it.
+    let direct_versions = level_versions(ctx, &seeds);
+    // Recorded only now the level barrier has passed, so the subtree walk
+    // sees the resolved direct-dep versions.
+    record_direct_dep_versions(ctx, importer_id, &direct_versions);
     let children_overlay = PreferredVersionsOverlay::layer(
         ctx.base_opts.preferred_versions_overlay.clone(),
-        level_versions(ctx, &seeds),
+        direct_versions,
     );
     // Phase 2: walk each direct dep's children with the level overlay.
     let results = seeds
@@ -1254,7 +1284,14 @@ where
     // `synthesize_reused_result` is conservative: any shape it can't
     // faithfully reproduce (non-registry resolutions, missing metadata)
     // yields `None` here and the node falls through to a fresh resolve.
+    //
+    // Stale-pin refresh: a node depending on a changed direct dep is
+    // resolved fresh rather than reused, so its children walk against
+    // their manifest ranges where `walk_node_children` can redirect a
+    // stale pin onto the higher direct-dep version (reusing the subtree
+    // would keep the pin, leaving the lockfile non-convergent).
     if reuse.allows_reuse()
+        && !node_depends_on_changed_direct_dep(ctx, prior_key.as_ref())
         && let Some(reused) = try_reuse_node(ctx, &wanted, prior_key.as_ref())
     {
         return resolve_reused_node(
@@ -1543,17 +1580,42 @@ where
         // walk starts, so the level's resolved versions can feed the
         // grandchildren's preferred-versions overlay — upstream's
         // postponed-resolution barrier.
+        // Snapshot this importer's direct-dep versions once for the whole
+        // child fanout instead of locking per edge.
+        let direct_versions = lock_recoverable(&ctx.workspace.direct_dep_versions)
+            .get(&ctx.importer_id)
+            .map(Arc::clone);
         let child_seeds = child_specs
             .iter()
             .map(|(child_name, child_range, child_optional)| {
-                let child_wanted = WantedDependency {
+                let mut child_wanted = WantedDependency {
                     alias: Some(child_name.clone()),
                     bare_specifier: Some(child_range.clone()),
                     optional: Some(*child_optional),
                     ..WantedDependency::default()
                 };
-                let child_prior = prior_children_snapshot
+                let mut child_prior = prior_children_snapshot
                     .and_then(|snapshot| prior_child_key(snapshot, child_name, child_range));
+                // Stale-pin refresh: force the edge onto a higher in-range
+                // direct-dep version instead of reusing the pin, so the
+                // pinned version is never resolved or fetched. Mirrors
+                // pnpm's `getDepsToResolve` `preferredVersion` override.
+                let forced_version = child_prior
+                    .as_ref()
+                    .and_then(|key| key.suffix.version_semver().cloned())
+                    .zip(child_range.parse::<node_semver::Range>().ok())
+                    .and_then(|(pinned, range)| {
+                        higher_direct_dep_version(
+                            direct_versions.as_deref(),
+                            child_name,
+                            &pinned,
+                            &range,
+                        )
+                    });
+                if let Some(higher) = forced_version {
+                    child_wanted.bare_specifier = Some(higher.to_string());
+                    child_prior = None;
+                }
                 let next_ancestors = Arc::clone(&next_ancestors);
                 let pick_overlay = children_overlay.clone();
                 async move {
@@ -1899,6 +1961,106 @@ fn level_versions(ctx: &TreeCtx, seeds: &[NodeSeed]) -> BTreeMap<String, Vec<Str
         }
     }
     level
+}
+
+/// Record the importer direct deps whose manifest specifier differs from
+/// the prior lockfile's recorded specifier (a new dep counts as changed).
+/// See [`WorkspaceTreeCtx::changed_direct_deps`].
+fn record_changed_direct_deps(ctx: &TreeCtx, importer_id: &str, wanted: &[WantedSpec]) {
+    let prior = ctx
+        .workspace
+        .wanted_lockfile
+        .as_ref()
+        .and_then(|lockfile| lockfile.importers.get(importer_id));
+    let mut changed = lock_recoverable(&ctx.workspace.changed_direct_deps);
+    let bucket = changed.entry(importer_id.to_string()).or_default();
+    for (alias, spec, _optional, _injected) in wanted {
+        let unchanged = prior
+            .and_then(|importer| importer_dep_specifier(importer, alias))
+            .is_some_and(|recorded| recorded == spec);
+        if !unchanged && let Ok(name) = alias.parse::<PkgName>() {
+            bucket.insert(name);
+        }
+    }
+}
+
+/// The recorded specifier for direct-dep `alias` across the importer's
+/// prod / dev / optional dependency maps in the prior lockfile.
+fn importer_dep_specifier<'a>(importer: &'a ProjectSnapshot, alias: &str) -> Option<&'a str> {
+    let name: PkgName = alias.parse().ok()?;
+    let lookup = |map: Option<&'a ResolvedDependencyMap>| map.and_then(|deps| deps.get(&name));
+    lookup(importer.dependencies.as_ref())
+        .or_else(|| lookup(importer.optional_dependencies.as_ref()))
+        .or_else(|| lookup(importer.dev_dependencies.as_ref()))
+        .map(|dep| dep.specifier.as_str())
+}
+
+/// Store the importer's resolved (parsed) direct-dep versions for the
+/// per-edge stale-pin refresh. See [`WorkspaceTreeCtx::direct_dep_versions`].
+fn record_direct_dep_versions(
+    ctx: &TreeCtx,
+    importer_id: &str,
+    level: &BTreeMap<String, Vec<String>>,
+) {
+    let mut versions = lock_recoverable(&ctx.workspace.direct_dep_versions);
+    let by_name = Arc::make_mut(versions.entry(importer_id.to_string()).or_default());
+    for (name, level_versions) in level {
+        let bucket = by_name.entry(name.clone()).or_default();
+        for version in level_versions {
+            let Ok(parsed) = version.parse::<node_semver::Version>() else { continue };
+            if !bucket.contains(&parsed) {
+                bucket.push(parsed);
+            }
+        }
+    }
+}
+
+/// True when `snapshot` depends on one of this importer's changed direct
+/// deps (see [`WorkspaceTreeCtx::changed_direct_deps`]).
+fn reused_parent_has_changed_direct_child(ctx: &TreeCtx, snapshot: &SnapshotEntry) -> bool {
+    // Copy the (small) changed set out and drop the lock before scanning.
+    let importer_changed = {
+        let changed = lock_recoverable(&ctx.workspace.changed_direct_deps);
+        match changed.get(&ctx.importer_id) {
+            Some(set) if !set.is_empty() => set.clone(),
+            _ => return false,
+        }
+    };
+    let depends_on = |map: Option<&HashMap<PkgName, SnapshotDepRef>>| {
+        map.is_some_and(|deps| deps.keys().any(|name| importer_changed.contains(name)))
+    };
+    depends_on(snapshot.dependencies.as_ref())
+        || depends_on(snapshot.optional_dependencies.as_ref())
+}
+
+/// Reuse-decline gate: whether `prior_key`'s prior snapshot depends on a
+/// changed direct dep.
+fn node_depends_on_changed_direct_dep(ctx: &TreeCtx, prior_key: Option<&PkgNameVerPeer>) -> bool {
+    prior_key
+        .and_then(|key| ctx.workspace.wanted_lockfile.as_ref()?.snapshots.as_ref()?.get(key))
+        .is_some_and(|snapshot| reused_parent_has_changed_direct_child(ctx, snapshot))
+}
+
+/// The highest resolved direct-dependency version of `name` strictly
+/// above `pinned` that still satisfies `range`, or `None`. Anchored to
+/// direct deps (the deterministic, resolved-before-the-walk signal),
+/// mirroring pnpm's `findHigherDirectDepVersion`. `direct_versions` is the
+/// importer's snapshot, taken once per walk by [`fn@walk_node_children`].
+fn higher_direct_dep_version(
+    direct_versions: Option<&DirectDepVersions>,
+    name: &str,
+    pinned: &node_semver::Version,
+    range: &node_semver::Range,
+) -> Option<node_semver::Version> {
+    direct_versions?
+        .get(name)?
+        .iter()
+        // Plain semver satisfaction (not prerelease-inclusive), matching
+        // pnpm's `semver.satisfies(candidate, range, true)`: a prerelease
+        // direct dep only refreshes an edge whose range admits prereleases.
+        .filter(|&version| version > pinned && range.satisfies(version))
+        .max()
+        .cloned()
 }
 
 /// One reusable node: its prior-lockfile snapshot key plus the

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
@@ -80,3 +80,63 @@ fn owner_missing_record_is_written_once_per_generation() {
         "a new ownership generation records afresh",
     );
 }
+
+mod higher_direct_dep_version {
+    use std::collections::HashMap;
+
+    use node_semver::{Range, Version};
+
+    use super::super::{DirectDepVersions, higher_direct_dep_version};
+
+    fn direct(name: &str, versions: &[&str]) -> DirectDepVersions {
+        let parsed =
+            versions.iter().map(|raw| raw.parse::<Version>().expect("parse version")).collect();
+        HashMap::from([(name.to_string(), parsed)])
+    }
+
+    fn ver(raw: &str) -> Version {
+        raw.parse().expect("parse version")
+    }
+
+    fn range(raw: &str) -> Range {
+        raw.parse().expect("parse range")
+    }
+
+    #[test]
+    fn picks_the_highest_in_range_version_above_the_pin() {
+        let direct = direct("foo", &["1.1.0", "1.5.0", "2.0.0"]);
+        assert_eq!(
+            higher_direct_dep_version(Some(&direct), "foo", &ver("1.0.0"), &range("^1.0.0")),
+            Some(ver("1.5.0")),
+        );
+    }
+
+    #[test]
+    fn none_when_no_direct_version_is_higher() {
+        let direct = direct("foo", &["1.0.0"]);
+        assert!(
+            higher_direct_dep_version(Some(&direct), "foo", &ver("1.0.0"), &range("^1.0.0"))
+                .is_none(),
+        );
+    }
+
+    #[test]
+    fn does_not_refresh_a_prerelease_onto_a_stable_range() {
+        // Matches pnpm's `semver.satisfies(.., true)`: a prerelease does not
+        // satisfy a range that doesn't admit prereleases, so no refresh.
+        let direct = direct("foo", &["1.2.0-beta.1"]);
+        assert!(
+            higher_direct_dep_version(Some(&direct), "foo", &ver("1.0.0"), &range("^1.0.0"))
+                .is_none(),
+        );
+    }
+
+    #[test]
+    fn refreshes_a_prerelease_when_the_range_admits_it() {
+        let direct = direct("foo", &["1.2.0-beta.1"]);
+        assert_eq!(
+            higher_direct_dep_version(Some(&direct), "foo", &ver("1.0.0"), &range(">=1.2.0-0")),
+            Some(ver("1.2.0-beta.1")),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

A prototype alternative to the post-resolution dedupe pass in #11502. Instead of resolving a lower version, fetching it (and its subtree), then rewriting the edge and pruning the orphan, this dedupes **during resolution** so the lower version is never resolved or fetched.

## Background

On a fresh resolve pnpm already dedupes: every level of the tree walk seeds `preferredVersions` with the versions resolved in ancestor/sibling packages, and direct deps additionally get `DIRECT_DEP_SELECTOR_WEIGHT`. So a transitive `foo@^1.0.0` already prefers a `foo@1.1.0` that a direct dependency resolved to.

The duplicate that #11502 targets is purely a **lockfile-stickiness** artifact: a package that isn't being re-resolved (its manifest didn't change) has its child edges taken verbatim from the lockfile, bypassing the preferred-versions walk. That keeps a stale lower version pinned even though a direct dependency now resolves to a higher version in the same range — and because it's a normally-resolved package, its tarball gets fetched.

## Approach

In `getDepsToResolve`, when a child edge is about to be reused from its lockfile pin, check whether a **direct dependency** (the deterministic, resolved-first anchor, marked with `DIRECT_DEP_SELECTOR_WEIGHT`) already resolved to a higher version that satisfies the edge's range. If so, force the edge onto that version via `preferredVersion` (singular), which overrides the `EXISTING_VERSION_SELECTOR_WEIGHT` stability bias that would otherwise re-pick the lower version. The lower version is never resolved and never fetched — no wasted download, no post-resolution pruning.

## Comparison with #11502

| | #11502 (post-pass) | This PR (resolution-time) |
|---|---|---|
| Lower version fetched then discarded | yes | **no** — never resolved |
| Mechanism | new O(E) graph rewrite + prune | existing `preferredVersion` lever |
| Reachability-flag (`optional`/`prod`/`dev`) staleness | possible | n/a — normal resolution computes flags |
| New config / pacquet surface | a new setting | none — pure resolver behavior |
| Scope | direct↔transitive **and** transitive↔transitive | direct↔transitive only |

## Scope / limitations

By design this only dedupes a transitive against a **direct-dependency** version — the deterministic anchor, and the shape of every motivating case in #11502. It deliberately does **not** touch the transitive-vs-transitive case, which is the order-dependent one that motivated the original removal of automatic deduping (#11110).

This is a **behavior change** from the post-#11110 "keep already-installed versions" default, so it is opened as a **draft** for discussion: whether it should be the default or gated behind a setting, plus a wider installer sweep before shipping.

## Pacquet port (included)

The matching pacquet (Rust) port is in this PR. pacquet's full-subtree lockfile reuse (`resolve_reused_node`) is coarser than pnpm's per-edge reuse — it reuses a parent's children straight from the snapshot's exact pins and carries neither the resolved direct-dep versions nor the parent manifest's ranges the refresh needs. Three coordinated changes bridge that, mirroring pnpm's phase structure:

- Record, per importer, which direct deps changed vs. the prior lockfile (race-free) and the resolved direct-dep versions (after the direct-dep level barrier).
- Decline full-subtree reuse for a parent that depends on a changed direct dep, so it resolves fresh and walks its children against their real manifest ranges — where the range is available.
- In `walk_node_children`, force a child edge onto a higher direct-dep version when the recorded pin is below it and it still satisfies the edge's range. The lower version is never resolved or fetched.

Both maps are keyed by importer to match pnpm's per-importer `preferredVersions`. New pacquet tests (`stale_pin_dedupe.rs`) cover the exact-version and caret-range (`pnpm add`) cases; the resolver (143), package-manager (537), and reuse/dedupe/add/update/parity CLI suites pass, as do `fmt`/`clippy`/`doc`/`dylint`/`taplo`.

## Tests

- New `refreshes a stale transitive pin to a higher direct-dependency version at resolution time` (the exact scenario #11502 targeted; `100.0.0` is absent from the lockfile because it is never resolved).
- All existing pass locally: 117 deps-resolver tests, full `dedupe.ts`, `dedupeDirectDeps`/`dedupeInWorkspace`/`autoInstallPeers`, `update.ts`, `peerDependencies.ts`. The one `lockfile.ts` failure here is a pre-existing offline failure (it fetches a real `registry.npmjs.org` tarball).

---

🤖 This PR was prepared by Claude Code (model: Opus 4.8) on behalf of @zkochan.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a lockfile non-convergence issue during incremental installs where stale transitive pins could remain after direct dependency upgrades. Incremental installs now refresh those pins to match the newer direct-dependency resolution and prune the outdated entries.
  * Ensured aliased transitive dependencies are not refreshed incorrectly.
* **Tests**
  * Added Jest and Rust integration/regression tests covering exact and caret direct updates, multi-importer convergence, idempotency, and prerelease-aware higher-version selection.
* **Chores**
  * Published a patch changeset documenting and shipping the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Squash-merge commit message

```
fix: converge incremental install by refreshing stale transitive pins

When a package is reused from the lockfile, its child edges are taken
verbatim and bypass the preferred-versions walk, so a transitive
dependency can stay pinned to an older version even after a direct
dependency resolved to a higher version that satisfies the same range —
leaving the lockfile non-convergent (an incremental install keeps a
duplicate that a fresh install would not).

The resolver now refreshes such a stale pin to the higher
direct-dependency version during resolution, via `preferredVersion`
(singular), which overrides the EXISTING_VERSION_SELECTOR_WEIGHT stability
bias. The older version is never resolved or fetched, and the incremental
result converges to what a fresh install produces. The pick is anchored to
direct dependencies (which resolve first), so it restores the automatic
dedupe removed in pnpm/pnpm#11110 without reintroducing its
non-determinism, and unlike the post-pass in pnpm/pnpm#11502 it does not
over-fetch.

pacquet is ported in the same change. Its full-subtree lockfile reuse is
coarser than pnpm's per-edge reuse, so it records per importer which direct
deps changed and their resolved versions, declines full-subtree reuse for a
parent that depends on a changed direct dep, and forces the higher version
in the child walk. Range satisfaction uses plain semver (not
prerelease-inclusive), matching pnpm's semver.satisfies(.., true).
```

