### PR TITLE
feat(catalogs): inherit and override catalogs via workspace extends

### DIFF
--- a/.changeset/workspace-extends-catalogs.md
+++ b/.changeset/workspace-extends-catalogs.md
@@ -1,0 +1,12 @@
+---
+"@pnpm/workspace.workspace-manifest-reader": minor
+"@pnpm/catalogs.config": minor
+"@pnpm/installing.commands": minor
+"@pnpm/config.reader": patch
+"@pnpm/deps.status": patch
+"pnpm": minor
+---
+
+Added an `extends` field to `pnpm-workspace.yaml`. When `shared-workspace-lockfile` is `false` (a dedicated lockfile per project), a project may have its own `pnpm-workspace.yaml` that `extends` another workspace manifest (typically the workspace root) by path. The project then inherits the extended catalogs, may add or override catalog entries of its own, and resolves its `catalog:` dependencies against the merged catalogs — recording them in its own lockfile.
+
+Entries defined directly in the extending (child) manifest take precedence over the inherited ones, and `extends` is resolved recursively with circular references reported as errors [#10302](https://github.com/pnpm/pnpm/issues/10302).

--- a/.changeset/workspace-extends-catalogs.md
+++ b/.changeset/workspace-extends-catalogs.md
@@ -7,6 +7,17 @@
 "pnpm": minor
 ---
 
-Added an `extends` field to `pnpm-workspace.yaml`. When `sharedWorkspaceLockfile` is `false` (a dedicated lockfile per project), a project may have its own `pnpm-workspace.yaml` that `extends` another workspace manifest (typically the workspace root) by path. The project then inherits the extended catalogs, may add or override catalog entries of its own, and resolves its `catalog:` dependencies against the merged catalogs — recording them in its own lockfile.
+Added an `extends` field to `pnpm-workspace.yaml` that merges catalogs from other workspace manifests into the current one.
 
-Entries defined directly in the extending (child) manifest take precedence over the inherited ones, and `extends` is resolved recursively with circular references reported as errors [#10302](https://github.com/pnpm/pnpm/issues/10302).
+Each `extends` entry may be:
+
+- a directory that contains a `pnpm-workspace.yaml`,
+- a direct path to a `pnpm-workspace.yaml` file (relative, absolute, or outside the workspace),
+- a glob such as `packages/*` (every matching `pnpm-workspace.yaml` is merged; directories without one are skipped), or
+- a path prefixed with the `<root>` token, which resolves to the monorepo root — the nearest ancestor directory that has a `pnpm-workspace.yaml` — so a package can reference the root without counting `../` segments (`<root>`, `<root>/configs/base`).
+
+`extends` works in both directions (a root manifest can extend its packages, and a package manifest can extend the root) and is resolved recursively. Entries defined directly in the extending manifest win over inherited ones, manifests resolved later win over earlier ones, and circular references are reported as errors.
+
+One application: with `sharedWorkspaceLockfile: false` (a dedicated lockfile per project), a package can `extends: <root>` to inherit the root catalogs, add or override its own, resolve its `catalog:` dependencies against the merged result, and record them in its own lockfile.
+
+Related to [#10302](https://github.com/pnpm/pnpm/issues/10302).

--- a/.changeset/workspace-extends-catalogs.md
+++ b/.changeset/workspace-extends-catalogs.md
@@ -7,6 +7,6 @@
 "pnpm": minor
 ---
 
-Added an `extends` field to `pnpm-workspace.yaml`. When `shared-workspace-lockfile` is `false` (a dedicated lockfile per project), a project may have its own `pnpm-workspace.yaml` that `extends` another workspace manifest (typically the workspace root) by path. The project then inherits the extended catalogs, may add or override catalog entries of its own, and resolves its `catalog:` dependencies against the merged catalogs — recording them in its own lockfile.
+Added an `extends` field to `pnpm-workspace.yaml`. When `sharedWorkspaceLockfile` is `false` (a dedicated lockfile per project), a project may have its own `pnpm-workspace.yaml` that `extends` another workspace manifest (typically the workspace root) by path. The project then inherits the extended catalogs, may add or override catalog entries of its own, and resolves its `catalog:` dependencies against the merged catalogs — recording them in its own lockfile.
 
 Entries defined directly in the extending (child) manifest take precedence over the inherited ones, and `extends` is resolved recursively with circular references reported as errors [#10302](https://github.com/pnpm/pnpm/issues/10302).

--- a/catalogs/config/package.json
+++ b/catalogs/config/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/error": "workspace:*",
-    "@pnpm/workspace.workspace-manifest-reader": "workspace:*"
+    "@pnpm/workspace.workspace-manifest-reader": "workspace:*",
+    "tinyglobby": "catalog:"
   },
   "devDependencies": {
     "@jest/globals": "catalog:",

--- a/catalogs/config/package.json
+++ b/catalogs/config/package.json
@@ -32,13 +32,14 @@
     ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
   },
   "dependencies": {
-    "@pnpm/error": "workspace:*"
+    "@pnpm/catalogs.types": "workspace:*",
+    "@pnpm/error": "workspace:*",
+    "@pnpm/workspace.workspace-manifest-reader": "workspace:*"
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
     "@pnpm/catalogs.config": "workspace:*",
-    "@pnpm/catalogs.types": "workspace:*",
-    "@pnpm/workspace.workspace-manifest-reader": "workspace:*"
+    "write-yaml-file": "catalog:"
   },
   "engines": {
     "node": ">=22.13"

--- a/catalogs/config/src/getExtendedCatalogs.ts
+++ b/catalogs/config/src/getExtendedCatalogs.ts
@@ -1,0 +1,72 @@
+import path from 'node:path'
+
+import type { Catalogs } from '@pnpm/catalogs.types'
+import { PnpmError } from '@pnpm/error'
+import { readWorkspaceManifest, type WorkspaceManifest } from '@pnpm/workspace.workspace-manifest-reader'
+
+import { getCatalogsFromWorkspaceManifest } from './getCatalogsFromWorkspaceManifest.js'
+import { mergeCatalogs } from './mergeCatalogs.js'
+
+type ExtendableManifest = Pick<WorkspaceManifest, 'catalog' | 'catalogs' | 'extends'>
+
+/**
+ * Resolves the catalogs of a workspace manifest, merging in the catalogs of the
+ * workspace manifests it references through the `extends` field.
+ *
+ * The merge is performed so that the manifest doing the extending wins on
+ * conflicts: an entry defined both by the manifest and by one of the manifests
+ * it extends keeps the value from the extending manifest. When several manifests
+ * are extended, entries from manifests listed later override entries from
+ * manifests listed earlier.
+ *
+ * `extends` is resolved recursively, so an extended manifest may extend other
+ * manifests too. Circular references are detected and reported.
+ */
+export async function getExtendedCatalogs (
+  dir: string,
+  manifest: ExtendableManifest | undefined
+): Promise<Catalogs> {
+  return resolveExtendedCatalogs(dir, manifest, [])
+}
+
+async function resolveExtendedCatalogs (
+  dir: string,
+  manifest: ExtendableManifest | undefined,
+  ancestors: readonly string[]
+): Promise<Catalogs> {
+  const ownCatalogs = getCatalogsFromWorkspaceManifest(manifest)
+  const extendsPaths = normalizeExtends(manifest?.extends)
+  if (extendsPaths.length === 0) {
+    return ownCatalogs
+  }
+
+  const currentDir = path.resolve(dir)
+  if (ancestors.includes(currentDir)) {
+    throw new PnpmError(
+      'WORKSPACE_EXTENDS_CYCLE',
+      `Circular workspace "extends" reference detected. The workspace at "${currentDir}" eventually extends itself.`
+    )
+  }
+  const nextAncestors = [...ancestors, currentDir]
+
+  const extendedCatalogsList = await Promise.all(extendsPaths.map(async (extendsPath) => {
+    const extendedDir = path.resolve(dir, extendsPath)
+    const extendedManifest = await readWorkspaceManifest(extendedDir)
+    if (extendedManifest == null) {
+      throw new PnpmError(
+        'WORKSPACE_EXTENDS_NOT_FOUND',
+        `Cannot find a pnpm-workspace.yaml file in "${extendedDir}", which is referenced by the "extends" field of the workspace at "${currentDir}".`
+      )
+    }
+    return resolveExtendedCatalogs(extendedDir, extendedManifest, nextAncestors)
+  }))
+
+  // The extending manifest's own catalogs are merged last so they take
+  // precedence over the catalogs coming from the extended manifests.
+  return mergeCatalogs(...extendedCatalogsList, ownCatalogs)
+}
+
+function normalizeExtends (extendsField: string | string[] | undefined): string[] {
+  if (extendsField == null) return []
+  return Array.isArray(extendsField) ? extendsField : [extendsField]
+}

--- a/catalogs/config/src/getExtendedCatalogs.ts
+++ b/catalogs/config/src/getExtendedCatalogs.ts
@@ -1,26 +1,52 @@
+import fs from 'node:fs'
 import path from 'node:path'
 
 import type { Catalogs } from '@pnpm/catalogs.types'
 import { PnpmError } from '@pnpm/error'
 import { readWorkspaceManifest, type WorkspaceManifest } from '@pnpm/workspace.workspace-manifest-reader'
+import { glob } from 'tinyglobby'
 
 import { getCatalogsFromWorkspaceManifest } from './getCatalogsFromWorkspaceManifest.js'
 import { mergeCatalogs } from './mergeCatalogs.js'
 
 type ExtendableManifest = Pick<WorkspaceManifest, 'catalog' | 'catalogs' | 'extends'>
 
+const WORKSPACE_MANIFEST_FILENAME = 'pnpm-workspace.yaml'
+
+/**
+ * Placeholder, usable as a path prefix in `extends`, that resolves to the
+ * monorepo root: the nearest ancestor directory (above the extending manifest)
+ * that contains a `pnpm-workspace.yaml`. It lets a manifest reference the root
+ * without counting `../` segments, e.g. `<root>`, `<root>/configs/base`.
+ */
+const ROOT_TOKEN = '<root>'
+
+interface ExtendsTarget {
+  /** Directory that contains the `pnpm-workspace.yaml` to merge. */
+  dir: string
+  /** Whether the target came from a glob (missing manifests are skipped, not an error). */
+  fromGlob: boolean
+}
+
 /**
  * Resolves the catalogs of a workspace manifest, merging in the catalogs of the
  * workspace manifests it references through the `extends` field.
  *
+ * Each `extends` entry may be:
+ * - a directory that contains a `pnpm-workspace.yaml` (relative or absolute,
+ *   inside or outside the workspace),
+ * - a direct path to a `pnpm-workspace.yaml` file,
+ * - a glob such as `packages/*` (expanded to every matching `pnpm-workspace.yaml`;
+ *   matches without one are skipped), or
+ * - a path prefixed with the `<root>` token, which expands to the monorepo root.
+ *
  * The merge is performed so that the manifest doing the extending wins on
- * conflicts: an entry defined both by the manifest and by one of the manifests
- * it extends keeps the value from the extending manifest. When several manifests
- * are extended, entries from manifests listed later override entries from
- * manifests listed earlier.
+ * conflicts. When several manifests are extended, entries from manifests
+ * resolved later override entries from manifests resolved earlier (glob matches
+ * are ordered lexicographically).
  *
  * `extends` is resolved recursively, so an extended manifest may extend other
- * manifests too. Circular references are detected and reported.
+ * manifests too. Circular references are detected and reported as errors.
  */
 export async function getExtendedCatalogs (
   dir: string,
@@ -35,8 +61,8 @@ async function resolveExtendedCatalogs (
   ancestors: readonly string[]
 ): Promise<Catalogs> {
   const ownCatalogs = getCatalogsFromWorkspaceManifest(manifest)
-  const extendsPaths = normalizeExtends(manifest?.extends)
-  if (extendsPaths.length === 0) {
+  const extendsEntries = normalizeExtends(manifest?.extends)
+  if (extendsEntries.length === 0) {
     return ownCatalogs
   }
 
@@ -49,21 +75,125 @@ async function resolveExtendedCatalogs (
   }
   const nextAncestors = [...ancestors, currentDir]
 
-  const extendedCatalogsList = await Promise.all(extendsPaths.map(async (extendsPath) => {
-    const extendedDir = path.resolve(dir, extendsPath)
-    const extendedManifest = await readWorkspaceManifest(extendedDir)
+  const targetsPerEntry = await Promise.all(
+    extendsEntries.map(async (entry) => resolveExtendsEntry(entry, currentDir))
+  )
+  const targets = targetsPerEntry.flat()
+
+  const extendedCatalogsList = await Promise.all(targets.map(async (target) => {
+    const extendedManifest = await readWorkspaceManifest(target.dir)
     if (extendedManifest == null) {
+      // A glob simply matched fewer manifests; only an explicit reference to a
+      // missing manifest is an error.
+      if (target.fromGlob) return undefined
       throw new PnpmError(
         'WORKSPACE_EXTENDS_NOT_FOUND',
-        `Cannot find a pnpm-workspace.yaml file in "${extendedDir}", which is referenced by the "extends" field of the workspace at "${currentDir}".`
+        `Cannot find a ${WORKSPACE_MANIFEST_FILENAME} file in "${target.dir}", which is referenced by the "extends" field of the workspace at "${currentDir}".`
       )
     }
-    return resolveExtendedCatalogs(extendedDir, extendedManifest, nextAncestors)
+    return resolveExtendedCatalogs(target.dir, extendedManifest, nextAncestors)
   }))
 
   // The extending manifest's own catalogs are merged last so they take
   // precedence over the catalogs coming from the extended manifests.
   return mergeCatalogs(...extendedCatalogsList, ownCatalogs)
+}
+
+async function resolveExtendsEntry (entry: string, currentDir: string): Promise<ExtendsTarget[]> {
+  const expanded = expandRootToken(entry, currentDir)
+  if (isGlobPattern(expanded)) {
+    const dirs = await globManifestDirs(expanded, currentDir)
+    return dirs.map((dir) => ({ dir, fromGlob: true }))
+  }
+  const resolved = path.resolve(currentDir, expanded)
+  const dir = path.basename(resolved) === WORKSPACE_MANIFEST_FILENAME
+    ? path.dirname(resolved)
+    : resolved
+  return [{ dir, fromGlob: false }]
+}
+
+/**
+ * Expands a leading `<root>` token to the monorepo-root path. Anything after
+ * the token is kept as a path suffix, so `<root>/configs/base` points at
+ * `configs/base` under the root.
+ */
+function expandRootToken (entry: string, currentDir: string): string {
+  if (entry !== ROOT_TOKEN && !entry.startsWith(`${ROOT_TOKEN}/`)) {
+    return entry
+  }
+  const rootDir = findMonorepoRoot(currentDir)
+  const rest = entry.slice(ROOT_TOKEN.length).replace(/^\/+/, '')
+  const rootPosix = rootDir.split(path.sep).join('/')
+  return rest.length > 0 ? `${rootPosix}/${rest}` : rootPosix
+}
+
+/**
+ * Walks up from the extending manifest's directory and returns the nearest
+ * ancestor that contains a `pnpm-workspace.yaml` (the manifest's own directory
+ * is excluded, since it is the one referencing `<root>`).
+ */
+function findMonorepoRoot (currentDir: string): string {
+  let dir = path.dirname(currentDir)
+  let previous = currentDir
+  while (dir !== previous) {
+    if (fs.existsSync(path.join(dir, WORKSPACE_MANIFEST_FILENAME))) {
+      return dir
+    }
+    previous = dir
+    dir = path.dirname(dir)
+  }
+  throw new PnpmError(
+    'WORKSPACE_EXTENDS_ROOT_NOT_FOUND',
+    `Cannot resolve "${ROOT_TOKEN}" in the "extends" field of the workspace at "${currentDir}": no ancestor directory contains a ${WORKSPACE_MANIFEST_FILENAME} file.`
+  )
+}
+
+async function globManifestDirs (expandedPattern: string, currentDir: string): Promise<string[]> {
+  const pattern = ensureManifestSuffix(expandedPattern)
+  const { base, tail } = splitGlobBase(pattern, currentDir)
+  const matches = await glob([tail], {
+    cwd: base,
+    absolute: true,
+    expandDirectories: false,
+    dot: false,
+    ignore: ['**/node_modules/**'],
+  })
+  const dirs = matches.map((match) => path.dirname(path.resolve(match)))
+  // Deduplicate and order deterministically so later matches win predictably.
+  return Array.from(new Set(dirs)).sort()
+}
+
+/**
+ * Points a glob at `pnpm-workspace.yaml` files rather than directories: a
+ * pattern such as `packages/*` is suffixed so it matches the manifest inside
+ * each matched directory. A pattern that already ends in the manifest filename
+ * is left untouched.
+ */
+function ensureManifestSuffix (pattern: string): string {
+  const normalized = pattern.replace(/\/+$/, '')
+  return path.posix.basename(normalized) === WORKSPACE_MANIFEST_FILENAME
+    ? normalized
+    : `${normalized}/${WORKSPACE_MANIFEST_FILENAME}`
+}
+
+/**
+ * Splits a glob into a concrete base directory and the dynamic remainder.
+ * `path.resolve` consumes any `..` and absolute parts of the static prefix, so
+ * the remainder handed to the glob matcher never escapes its `cwd`.
+ */
+function splitGlobBase (pattern: string, currentDir: string): { base: string, tail: string } {
+  const segments = pattern.split('/')
+  let firstDynamic = segments.findIndex((segment) => isGlobPattern(segment))
+  if (firstDynamic < 0) {
+    firstDynamic = segments.length - 1
+  }
+  const baseSpec = segments.slice(0, firstDynamic).join('/') || '.'
+  const tail = segments.slice(firstDynamic).join('/')
+  return { base: path.resolve(currentDir, baseSpec), tail }
+}
+
+function isGlobPattern (value: string): boolean {
+  return /[*?{}[\]]/.test(value)
 }
 
 function normalizeExtends (extendsField: string | string[] | undefined): string[] {

--- a/catalogs/config/src/getExtendedCatalogs.ts
+++ b/catalogs/config/src/getExtendedCatalogs.ts
@@ -170,7 +170,15 @@ async function globManifestDirs (expandedPattern: string, currentDir: string): P
  * is left untouched.
  */
 function ensureManifestSuffix (pattern: string): string {
-  const normalized = pattern.replace(/\/+$/, '')
+  // Trim trailing slashes with a linear scan rather than a `/\/+$/` regex: the
+  // pattern comes from user input and the end-anchored quantifier would
+  // backtrack quadratically on a string of many slashes (a denial-of-service
+  // risk flagged by CodeQL).
+  let end = pattern.length
+  while (end > 0 && pattern.charCodeAt(end - 1) === 47 /* '/' */) {
+    end--
+  }
+  const normalized = pattern.slice(0, end)
   return path.posix.basename(normalized) === WORKSPACE_MANIFEST_FILENAME
     ? normalized
     : `${normalized}/${WORKSPACE_MANIFEST_FILENAME}`

--- a/catalogs/config/src/index.ts
+++ b/catalogs/config/src/index.ts
@@ -1,2 +1,3 @@
 export { getCatalogsFromWorkspaceManifest } from './getCatalogsFromWorkspaceManifest.js'
+export { getExtendedCatalogs } from './getExtendedCatalogs.js'
 export { mergeCatalogs } from './mergeCatalogs.js'

--- a/catalogs/config/test/getExtendedCatalogs.test.ts
+++ b/catalogs/config/test/getExtendedCatalogs.test.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import { getExtendedCatalogs } from '@pnpm/catalogs.config'
+import { writeYamlFileSync } from 'write-yaml-file'
+
+function createWorkspace (manifestsByDir: Record<string, unknown>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-extended-catalogs-'))
+  for (const [dir, manifest] of Object.entries(manifestsByDir)) {
+    const absoluteDir = path.join(root, dir)
+    fs.mkdirSync(absoluteDir, { recursive: true })
+    writeYamlFileSync(path.join(absoluteDir, 'pnpm-workspace.yaml'), manifest)
+  }
+  return root
+}
+
+test('returns the manifest own catalogs when there is no extends field', async () => {
+  const root = createWorkspace({ '.': { catalog: { foo: '^1.0.0' } } })
+
+  await expect(getExtendedCatalogs(root, { catalog: { foo: '^1.0.0' } })).resolves.toEqual({
+    default: { foo: '^1.0.0' },
+  })
+})
+
+test('returns an empty catalog for an undefined manifest', async () => {
+  const root = createWorkspace({ '.': {} })
+
+  await expect(getExtendedCatalogs(root, undefined)).resolves.toEqual({ default: undefined })
+})
+
+test('merges catalogs from the extended workspace manifest', async () => {
+  const root = createWorkspace({
+    '.': { catalog: { 'is-positive': '^3.1.0' } },
+    'packages/a': { catalog: { 'is-odd': '^3.0.1' } },
+  })
+
+  await expect(getExtendedCatalogs(path.join(root, 'packages/a'), {
+    catalog: { 'is-odd': '^3.0.1' },
+    extends: '../..',
+  })).resolves.toEqual({
+    default: { 'is-odd': '^3.0.1', 'is-positive': '^3.1.0' },
+  })
+})
+
+test('accepts an array in the extends field and supports named catalogs', async () => {
+  const root = createWorkspace({
+    base1: { catalogs: { tools: { eslint: '^9.0.0' } } },
+    base2: { catalog: { react: '^18.0.0' } },
+  })
+
+  await expect(getExtendedCatalogs(root, {
+    catalog: { lodash: '^4.0.0' },
+    extends: ['base1', 'base2'],
+  })).resolves.toEqual({
+    default: { react: '^18.0.0', lodash: '^4.0.0' },
+    tools: { eslint: '^9.0.0' },
+  })
+})
+
+test('the extending manifest catalogs take precedence over the extended ones', async () => {
+  const root = createWorkspace({
+    '.': { catalog: { foo: '^1.0.0' } },
+    'packages/a': {},
+  })
+
+  await expect(getExtendedCatalogs(path.join(root, 'packages/a'), { catalog: { foo: '^2.0.0' }, extends: '../..' })).resolves.toEqual({
+    default: { foo: '^2.0.0' },
+  })
+})
+
+test('manifests listed later in extends take precedence over earlier ones', async () => {
+  const root = createWorkspace({
+    a: { catalog: { foo: '^1.0.0' } },
+    b: { catalog: { foo: '^2.0.0' } },
+  })
+
+  await expect(getExtendedCatalogs(root, { extends: ['a', 'b'] })).resolves.toEqual({
+    default: { foo: '^2.0.0' },
+  })
+})
+
+test('extends is resolved recursively', async () => {
+  const root = createWorkspace({
+    a: { catalog: { a: '^1.0.0' }, extends: '../b' },
+    b: { catalog: { b: '^1.0.0' } },
+  })
+
+  await expect(getExtendedCatalogs(root, { extends: 'a' })).resolves.toEqual({
+    default: { a: '^1.0.0', b: '^1.0.0' },
+  })
+})
+
+test('throws when an extended workspace manifest cannot be found', async () => {
+  const root = createWorkspace({ '.': {} })
+
+  await expect(getExtendedCatalogs(root, { extends: 'packages/missing' })).rejects.toMatchObject({
+    code: 'ERR_PNPM_WORKSPACE_EXTENDS_NOT_FOUND',
+  })
+})
+
+test('throws when extends references form a cycle', async () => {
+  const root = createWorkspace({
+    a: { extends: '../b' },
+    b: { extends: '../a' },
+  })
+
+  await expect(getExtendedCatalogs(root, { extends: 'a' })).rejects.toMatchObject({
+    code: 'ERR_PNPM_WORKSPACE_EXTENDS_CYCLE',
+  })
+})

--- a/catalogs/config/test/getExtendedCatalogs.test.ts
+++ b/catalogs/config/test/getExtendedCatalogs.test.ts
@@ -110,3 +110,106 @@ test('throws when extends references form a cycle', async () => {
     code: 'ERR_PNPM_WORKSPACE_EXTENDS_CYCLE',
   })
 })
+
+test('the <root> token resolves to the nearest ancestor workspace', async () => {
+  const root = createWorkspace({
+    '.': { catalog: { 'is-positive': '^3.1.0' } },
+    'packages/a': { catalog: { 'is-odd': '^3.0.1' } },
+  })
+
+  await expect(getExtendedCatalogs(path.join(root, 'packages/a'), {
+    catalog: { 'is-odd': '^3.0.1' },
+    extends: '<root>',
+  })).resolves.toEqual({
+    default: { 'is-odd': '^3.0.1', 'is-positive': '^3.1.0' },
+  })
+})
+
+test('the <root> token works as a path prefix', async () => {
+  const root = createWorkspace({
+    '.': {},
+    'configs/base': { catalog: { react: '^18.0.0' } },
+    'packages/a': {},
+  })
+
+  await expect(getExtendedCatalogs(path.join(root, 'packages/a'), {
+    extends: '<root>/configs/base',
+  })).resolves.toEqual({
+    default: { react: '^18.0.0' },
+  })
+})
+
+test('throws when <root> has no ancestor workspace', async () => {
+  const root = createWorkspace({ '.': {} })
+
+  await expect(getExtendedCatalogs(root, { extends: '<root>' })).rejects.toMatchObject({
+    code: 'ERR_PNPM_WORKSPACE_EXTENDS_ROOT_NOT_FOUND',
+  })
+})
+
+test('a glob extends every matching workspace manifest and skips directories without one', async () => {
+  const root = createWorkspace({
+    'packages/a': { catalog: { a: '^1.0.0' } },
+    'packages/b': { catalog: { b: '^1.0.0' } },
+  })
+  fs.mkdirSync(path.join(root, 'packages/c-without-manifest'), { recursive: true })
+
+  await expect(getExtendedCatalogs(root, { extends: 'packages/*' })).resolves.toEqual({
+    default: { a: '^1.0.0', b: '^1.0.0' },
+  })
+})
+
+test('later glob matches win on conflicts', async () => {
+  const root = createWorkspace({
+    'packages/a': { catalog: { foo: '^1.0.0' } },
+    'packages/b': { catalog: { foo: '^2.0.0' } },
+  })
+
+  await expect(getExtendedCatalogs(root, { extends: 'packages/*' })).resolves.toEqual({
+    default: { foo: '^2.0.0' },
+  })
+})
+
+test('a glob with no matches contributes nothing', async () => {
+  const root = createWorkspace({ '.': { catalog: { foo: '^1.0.0' } } })
+
+  await expect(getExtendedCatalogs(root, {
+    catalog: { foo: '^1.0.0' },
+    extends: 'packages/*',
+  })).resolves.toEqual({ default: { foo: '^1.0.0' } })
+})
+
+test('extends accepts a direct path to a pnpm-workspace.yaml file', async () => {
+  const root = createWorkspace({
+    '.': { catalog: { foo: '^1.0.0' } },
+    'packages/a': {},
+  })
+
+  await expect(getExtendedCatalogs(path.join(root, 'packages/a'), {
+    extends: '../../pnpm-workspace.yaml',
+  })).resolves.toEqual({
+    default: { foo: '^1.0.0' },
+  })
+})
+
+test('extends accepts an absolute path to a manifest outside the workspace', async () => {
+  const external = createWorkspace({ '.': { catalog: { shared: '^1.0.0' } } })
+  const root = createWorkspace({ '.': {} })
+
+  await expect(getExtendedCatalogs(root, {
+    extends: path.join(external, 'pnpm-workspace.yaml'),
+  })).resolves.toEqual({
+    default: { shared: '^1.0.0' },
+  })
+})
+
+test('throws on a cycle between the root and a package (glob + <root>)', async () => {
+  const root = createWorkspace({
+    '.': { extends: 'packages/*' },
+    'packages/a': { extends: '<root>' },
+  })
+
+  await expect(getExtendedCatalogs(root, { extends: 'packages/*' })).rejects.toMatchObject({
+    code: 'ERR_PNPM_WORKSPACE_EXTENDS_CYCLE',
+  })
+})

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -3,7 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { stripVTControlCharacters } from 'node:util'
 
-import { getCatalogsFromWorkspaceManifest } from '@pnpm/catalogs.config'
+import { getCatalogsFromWorkspaceManifest, getExtendedCatalogs } from '@pnpm/catalogs.config'
 import { createMatcher } from '@pnpm/config.matcher'
 import { GLOBAL_CONFIG_YAML_FILENAME, GLOBAL_LAYOUT_VERSION } from '@pnpm/constants'
 import { PnpmError } from '@pnpm/error'
@@ -446,6 +446,9 @@ export async function getConfig (opts: {
           workspaceDir: pnpmConfig.workspaceDir,
           workspaceManifest,
         })
+        if (workspaceManifest.extends != null) {
+          pnpmConfig.catalogs = await getExtendedCatalogs(pnpmConfig.workspaceDir, workspaceManifest)
+        }
       }
     } else if (cliOptions['global']) {
       // For global installs, read settings from pnpm-workspace.yaml in the global package directory
@@ -457,6 +460,9 @@ export async function getConfig (opts: {
           workspaceDir: pnpmConfig.globalPkgDir,
           workspaceManifest,
         })
+        if (workspaceManifest.extends != null) {
+          pnpmConfig.catalogs = await getExtendedCatalogs(pnpmConfig.globalPkgDir, workspaceManifest)
+        }
       }
     }
   }

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -548,6 +548,33 @@ describe('minimumReleaseAgeStrict default', () => {
   })
 })
 
+test('config.catalogs merges catalogs from a workspace manifest referenced through extends (extending manifest wins)', async () => {
+  prepareEmpty()
+
+  fs.mkdirSync('base', { recursive: true })
+  writeYamlFileSync('base/pnpm-workspace.yaml', {
+    catalog: { 'is-positive': '^3.1.0', shared: '^1.0.0' },
+  })
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    extends: 'base',
+    catalog: { 'is-odd': '^3.0.1', shared: '^2.0.0' },
+  })
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+    workspaceDir: process.cwd(),
+  })
+
+  expect(config.catalogs).toEqual({
+    default: {
+      'is-odd': '^3.0.1',
+      'is-positive': '^3.1.0',
+      shared: '^2.0.0',
+    },
+  })
+})
+
 test('camelCase settings from pnpm-workspace.yaml are read into typed Config properties', async () => {
   prepareEmpty()
 

--- a/deps/status/src/checkDepsStatus.ts
+++ b/deps/status/src/checkDepsStatus.ts
@@ -308,10 +308,16 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
       const modulesDirStatsPromise = statModulesDir(project)
       // With a dedicated lockfile per project, a non-root project may have its
       // own pnpm-workspace.yaml whose catalogs (possibly extended from another
-      // workspace manifest) feed that project's lockfile. Editing it must
-      // invalidate the optimistic "nothing changed" exit below, so stat it
+      // workspace manifest) feed that project's lockfile. Editing or adding it
+      // must invalidate the optimistic "nothing changed" exit below, so stat it
       // alongside the project manifest. Shared-lockfile workspaces only honor
       // the root catalogs, so this extra stat is skipped there.
+      //
+      // Deletion is intentionally not caught here: a stat cannot distinguish a
+      // project that never had a workspace manifest from one that just lost it,
+      // and tracking prior presence would mean extending the persisted
+      // workspace-state shape (a cross-implementation contract). The next
+      // `pnpm install` re-resolves the affected project and self-heals.
       const workspaceManifestStatsPromise = !sharedWorkspaceLockfile && project.rootDir !== workspaceDir
         ? safeStat(path.join(project.rootDir, WORKSPACE_MANIFEST_FILENAME))
         : Promise.resolve(undefined)

--- a/deps/status/src/checkDepsStatus.ts
+++ b/deps/status/src/checkDepsStatus.ts
@@ -6,7 +6,7 @@ import { resolveFromCatalog } from '@pnpm/catalogs.resolver'
 import type { Catalogs } from '@pnpm/catalogs.types'
 import { parseOverrides } from '@pnpm/config.parse-overrides'
 import type { Config, ConfigContext } from '@pnpm/config.reader'
-import { MANIFEST_BASE_NAMES } from '@pnpm/constants'
+import { MANIFEST_BASE_NAMES, WORKSPACE_MANIFEST_FILENAME } from '@pnpm/constants'
 import { hashObjectNullableWithPrefix } from '@pnpm/crypto.object-hasher'
 import { PnpmError } from '@pnpm/error'
 import { arrayOfWorkspacePackagesToMap } from '@pnpm/installing.context'
@@ -306,6 +306,15 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
 
     const allManifestStats = await Promise.all(allProjects.map(async project => {
       const modulesDirStatsPromise = statModulesDir(project)
+      // With a dedicated lockfile per project, a non-root project may have its
+      // own pnpm-workspace.yaml whose catalogs (possibly extended from another
+      // workspace manifest) feed that project's lockfile. Editing it must
+      // invalidate the optimistic "nothing changed" exit below, so stat it
+      // alongside the project manifest. Shared-lockfile workspaces only honor
+      // the root catalogs, so this extra stat is skipped there.
+      const workspaceManifestStatsPromise = !sharedWorkspaceLockfile && project.rootDir !== workspaceDir
+        ? safeStat(path.join(project.rootDir, WORKSPACE_MANIFEST_FILENAME))
+        : Promise.resolve(undefined)
       const manifestStats = await statManifestFile(project.rootDir)
       if (!manifestStats) {
         // this error should not happen
@@ -315,6 +324,7 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
         project,
         manifestStats,
         modulesDirStats: await modulesDirStatsPromise,
+        workspaceManifestStats: await workspaceManifestStatsPromise,
       }
     }))
 
@@ -346,8 +356,9 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
     }
 
     const modifiedProjects = allManifestStats.filter(
-      ({ manifestStats }) =>
-        manifestStats.mtime.valueOf() > workspaceState.lastValidatedTimestamp
+      ({ manifestStats, workspaceManifestStats }) =>
+        manifestStats.mtime.valueOf() > workspaceState.lastValidatedTimestamp ||
+        (workspaceManifestStats != null && workspaceManifestStats.mtime.valueOf() > workspaceState.lastValidatedTimestamp)
     )
 
     if ((modifiedProjects.length === 0) && !lockfilesModified) {

--- a/deps/status/test/checkDepsStatus.test.ts
+++ b/deps/status/test/checkDepsStatus.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals'
 import type { CheckDepsStatusOptions } from '@pnpm/deps.status'
 import type { LockfileObject } from '@pnpm/lockfile.fs'
 import type { ProjectId, ProjectRootDir, ProjectRootDirRealPath } from '@pnpm/types'
@@ -1595,6 +1595,122 @@ describe('checkDepsStatus - treatLocalFileDepsAsOutdated', () => {
     }
     const result = await checkDepsStatus(opts)
 
+    expect(result.upToDate).toBe(true)
+  })
+})
+
+describe('checkDepsStatus - per-project workspace manifest (extends)', () => {
+  const settings = {
+    excludeLinksFromLockfile: false,
+    linkWorkspacePackages: true,
+    preferWorkspacePackages: true,
+  }
+
+  let workspaceDir: string
+  let rootDir: ProjectRootDir
+  let childDir: ProjectRootDir
+  let lastValidatedTimestamp: number
+  let beforeLastValidation: number
+  let afterLastValidation: number
+
+  beforeEach(async () => {
+    jest.resetModules()
+    jest.clearAllMocks()
+
+    lastValidatedTimestamp = Date.now() - 10_000
+    beforeLastValidation = lastValidatedTimestamp - 10_000
+    afterLastValidation = lastValidatedTimestamp + 1_000
+
+    workspaceDir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-extends-status-')))
+    rootDir = workspaceDir as ProjectRootDir
+    childDir = path.join(workspaceDir, 'packages/child') as ProjectRootDir
+    await fs.mkdir(childDir, { recursive: true })
+
+    // Real per-project lockfiles, untouched since the last install, so that
+    // `scanWantedLockfiles` (which uses fs.statSync directly) sees them as
+    // present and unmodified — only the child manifest can flip the result.
+    const old = beforeLastValidation / 1000
+    await Promise.all([workspaceDir, childDir].map(async (dir) => {
+      const lockfilePath = path.join(dir, 'pnpm-lock.yaml')
+      await fs.writeFile(lockfilePath, "lockfileVersion: '9.0'\n")
+      await fs.utimes(lockfilePath, old, old)
+    }))
+  })
+
+  afterEach(async () => {
+    await fs.rm(workspaceDir, { force: true, recursive: true })
+  })
+
+  function setup (childWorkspaceManifestMtime: number | undefined): void {
+    const mockWorkspaceState: WorkspaceState = {
+      lastValidatedTimestamp,
+      pnpmfiles: [],
+      settings,
+      projects: {
+        [rootDir]: { name: 'root', version: '1.0.0' },
+        [childDir]: { name: 'child', version: '1.0.0' },
+      },
+      filteredInstall: false,
+    }
+    jest.mocked(loadWorkspaceState).mockReturnValue(mockWorkspaceState)
+
+    jest.mocked(fsUtils.safeStat).mockImplementation(async (filePath: string) => {
+      if (filePath.endsWith('pnpm-workspace.yaml')) {
+        return childWorkspaceManifestMtime == null
+          ? undefined
+          : ({ mtime: new Date(childWorkspaceManifestMtime), mtimeMs: childWorkspaceManifestMtime } as Stats)
+      }
+      // node_modules and the wanted lockfile of a modified project are reported
+      // as absent; projects declare no dependencies, so a missing modules dir is
+      // not an issue, and a modified project surfaces as "not up to date".
+      return undefined
+    })
+    jest.mocked(statManifestFileUtils.statManifestFile).mockResolvedValue({
+      mtime: new Date(beforeLastValidation),
+      mtimeMs: beforeLastValidation,
+    } as Stats)
+  }
+
+  function makeOpts (sharedWorkspaceLockfile: boolean): CheckDepsStatusOptions {
+    return {
+      allProjects: [
+        {
+          rootDir,
+          rootDirRealPath: rootDir as unknown as ProjectRootDirRealPath,
+          manifest: { name: 'root', version: '1.0.0' },
+          writeProjectManifest: async () => {},
+        },
+        {
+          rootDir: childDir,
+          rootDirRealPath: childDir as unknown as ProjectRootDirRealPath,
+          manifest: { name: 'child', version: '1.0.0' },
+          writeProjectManifest: async () => {},
+        },
+      ],
+      workspaceDir,
+      rootProjectManifest: {},
+      rootProjectManifestDir: workspaceDir,
+      pnpmfile: [],
+      sharedWorkspaceLockfile,
+      ...settings,
+    }
+  }
+
+  it('takes the optimistic fast path when the child pnpm-workspace.yaml is unchanged', async () => {
+    setup(beforeLastValidation)
+    const result = await checkDepsStatus(makeOpts(false))
+    expect(result.upToDate).toBe(true)
+  })
+
+  it('is not up to date when a child pnpm-workspace.yaml changed (sharedWorkspaceLockfile: false)', async () => {
+    setup(afterLastValidation)
+    const result = await checkDepsStatus(makeOpts(false))
+    expect(result.upToDate).toBe(false)
+  })
+
+  it('ignores a changed child pnpm-workspace.yaml when sharedWorkspaceLockfile is true', async () => {
+    setup(afterLastValidation)
+    const result = await checkDepsStatus(makeOpts(true))
     expect(result.upToDate).toBe(true)
   })
 })

--- a/installing/commands/package.json
+++ b/installing/commands/package.json
@@ -82,6 +82,7 @@
     "@pnpm/workspace.projects-sorter": "workspace:*",
     "@pnpm/workspace.root-finder": "workspace:*",
     "@pnpm/workspace.state": "workspace:*",
+    "@pnpm/workspace.workspace-manifest-reader": "workspace:*",
     "@pnpm/workspace.workspace-manifest-writer": "workspace:*",
     "@yarnpkg/core": "catalog:",
     "@yarnpkg/lockfile": "catalog:",

--- a/installing/commands/src/recursive.ts
+++ b/installing/commands/src/recursive.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 
-import { mergeCatalogs } from '@pnpm/catalogs.config'
+import { getExtendedCatalogs, mergeCatalogs } from '@pnpm/catalogs.config'
 import type { Catalogs } from '@pnpm/catalogs.types'
 import type { CommandHandler } from '@pnpm/cli.command'
 import {
@@ -49,6 +49,7 @@ import type {
   ProjectsGraph,
 } from '@pnpm/types'
 import { sortProjects } from '@pnpm/workspace.projects-sorter'
+import { readWorkspaceManifest } from '@pnpm/workspace.workspace-manifest-reader'
 import { updateWorkspaceManifest } from '@pnpm/workspace.workspace-manifest-writer'
 import { isSubdir } from 'is-subdir'
 import pFilter from 'p-filter'
@@ -451,6 +452,16 @@ export async function recursive (
         }
 
         const localConfig = getProjectConfig(manifest) ?? {}
+        // With a dedicated lockfile per project, a project may define its own
+        // `pnpm-workspace.yaml` that extends the catalogs of another workspace
+        // manifest (typically the workspace root). Each project then resolves
+        // its `catalog:` dependencies against its own merged catalogs and
+        // records them in its own lockfile. Without `extends`, the project keeps
+        // using the workspace-wide catalogs from the config.
+        const projectWorkspaceManifest = await readWorkspaceManifest(rootDir)
+        const catalogs = projectWorkspaceManifest?.extends != null
+          ? await getExtendedCatalogs(rootDir, projectWorkspaceManifest)
+          : installOpts.catalogs
         const {
           updatedCatalogs: newCatalogsAddition,
           updatedManifest: newManifest,
@@ -462,6 +473,7 @@ export async function recursive (
             ...installOpts,
             ...localConfig,
             ...opts.allProjectsGraph[rootDir]?.package,
+            catalogs,
             bin: path.join(rootDir, 'node_modules', '.bin'),
             dir: rootDir,
             hooks,

--- a/installing/commands/tsconfig.json
+++ b/installing/commands/tsconfig.json
@@ -163,6 +163,9 @@
       "path": "../../workspace/state"
     },
     {
+      "path": "../../workspace/workspace-manifest-reader"
+    },
+    {
       "path": "../../workspace/workspace-manifest-writer"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2138,9 +2138,15 @@ importers:
 
   catalogs/config:
     dependencies:
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: link:../types
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../core/error
+      '@pnpm/workspace.workspace-manifest-reader':
+        specifier: workspace:*
+        version: link:../../workspace/workspace-manifest-reader
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -2148,12 +2154,9 @@ importers:
       '@pnpm/catalogs.config':
         specifier: workspace:*
         version: 'link:'
-      '@pnpm/catalogs.types':
-        specifier: workspace:*
-        version: link:../types
-      '@pnpm/workspace.workspace-manifest-reader':
-        specifier: workspace:*
-        version: link:../../workspace/workspace-manifest-reader
+      write-yaml-file:
+        specifier: 'catalog:'
+        version: 6.0.0
 
   catalogs/protocol-parser:
     devDependencies:
@@ -5393,6 +5396,9 @@ importers:
       '@pnpm/workspace.state':
         specifier: workspace:*
         version: link:../../workspace/state
+      '@pnpm/workspace.workspace-manifest-reader':
+        specifier: workspace:*
+        version: link:../../workspace/workspace-manifest-reader
       '@pnpm/workspace.workspace-manifest-writer':
         specifier: workspace:*
         version: link:../../workspace/workspace-manifest-writer

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2147,6 +2147,9 @@ importers:
       '@pnpm/workspace.workspace-manifest-reader':
         specifier: workspace:*
         version: link:../../workspace/workspace-manifest-reader
+      tinyglobby:
+        specifier: 'catalog:'
+        version: 0.2.17
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'

--- a/pnpm/test/catalogExtends.ts
+++ b/pnpm/test/catalogExtends.ts
@@ -1,0 +1,100 @@
+import { expect, jest, test } from '@jest/globals'
+import { preparePackages } from '@pnpm/prepare'
+import { addDistTag } from '@pnpm/testing.registry-mock'
+import { writeYamlFileSync } from 'write-yaml-file'
+
+import { execPnpm } from './utils/index.js'
+
+jest.setTimeout(5 * 60 * 1000)
+
+// A project may have its own pnpm-workspace.yaml that `extends` the workspace
+// root. With a dedicated lockfile per project (sharedWorkspaceLockfile: false),
+// the project resolves `catalog:` dependencies against its own catalogs merged
+// with the inherited ones and records them in its own lockfile.
+test('a child workspace extends the root catalog and writes a per-project lockfile', async () => {
+  await Promise.all([
+    addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' }),
+  ])
+
+  const projects = preparePackages([
+    {
+      location: '.',
+      package: { name: 'root', private: true },
+    },
+    {
+      location: 'packages/pkg-a',
+      package: {
+        name: 'pkg-a',
+        private: true,
+        dependencies: {
+          '@pnpm.e2e/foo': 'catalog:', // overridden by pkg-a's own catalog
+          '@pnpm.e2e/bar': 'catalog:', // defined only in pkg-a's catalog
+        },
+      },
+    },
+    {
+      location: 'packages/pkg-b',
+      package: {
+        name: 'pkg-b',
+        private: true,
+        dependencies: {
+          '@pnpm.e2e/foo': 'catalog:', // inherited from the root catalog
+        },
+      },
+    },
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['packages/*'],
+    sharedWorkspaceLockfile: false,
+    catalog: {
+      '@pnpm.e2e/foo': '100.0.0',
+    },
+  })
+  writeYamlFileSync('packages/pkg-a/pnpm-workspace.yaml', {
+    extends: '../..',
+    catalog: {
+      '@pnpm.e2e/foo': '100.1.0', // takes precedence over the inherited entry
+      '@pnpm.e2e/bar': '100.0.0',
+    },
+  })
+
+  await execPnpm(['install'])
+
+  // pkg-a wins the conflict for foo and keeps its own bar entry.
+  const pkgALockfile = projects['pkg-a'].readLockfile()
+  expect(pkgALockfile.catalogs?.default?.['@pnpm.e2e/foo']).toStrictEqual({
+    specifier: '100.1.0',
+    version: '100.1.0',
+  })
+  expect(pkgALockfile.catalogs?.default?.['@pnpm.e2e/bar']).toStrictEqual({
+    specifier: '100.0.0',
+    version: '100.0.0',
+  })
+
+  // pkg-b inherits foo from the root and does not leak pkg-a's bar entry.
+  const pkgBLockfile = projects['pkg-b'].readLockfile()
+  expect(pkgBLockfile.catalogs?.default?.['@pnpm.e2e/foo']).toStrictEqual({
+    specifier: '100.0.0',
+    version: '100.0.0',
+  })
+  expect(pkgBLockfile.catalogs?.default?.['@pnpm.e2e/bar']).toBeUndefined()
+
+  // Editing a child catalog is detected by the optimistic repeat-install fast
+  // path (it must not report "Already up to date").
+  writeYamlFileSync('packages/pkg-a/pnpm-workspace.yaml', {
+    extends: '../..',
+    catalog: {
+      '@pnpm.e2e/foo': '100.0.0', // reverted to match the root
+      '@pnpm.e2e/bar': '100.0.0',
+    },
+  })
+
+  await execPnpm(['install'])
+
+  expect(projects['pkg-a'].readLockfile().catalogs?.default?.['@pnpm.e2e/foo']).toStrictEqual({
+    specifier: '100.0.0',
+    version: '100.0.0',
+  })
+})

--- a/pnpm/test/catalogExtends.ts
+++ b/pnpm/test/catalogExtends.ts
@@ -98,3 +98,132 @@ test('a child workspace extends the root catalog and writes a per-project lockfi
     version: '100.0.0',
   })
 })
+
+// The `<root>` token lets a package reference the workspace root without
+// counting `../` segments. It resolves to the nearest ancestor directory that
+// has a pnpm-workspace.yaml.
+test('a child workspace extends the root through the <root> token', async () => {
+  await Promise.all([
+    addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' }),
+  ])
+
+  const projects = preparePackages([
+    {
+      location: '.',
+      package: { name: 'root', private: true },
+    },
+    {
+      location: 'packages/pkg-a',
+      package: {
+        name: 'pkg-a',
+        private: true,
+        dependencies: {
+          '@pnpm.e2e/foo': 'catalog:', // overridden by pkg-a's own catalog
+          '@pnpm.e2e/bar': 'catalog:', // defined only in pkg-a's catalog
+        },
+      },
+    },
+    {
+      location: 'packages/pkg-b',
+      package: {
+        name: 'pkg-b',
+        private: true,
+        dependencies: {
+          '@pnpm.e2e/foo': 'catalog:', // inherited from the root catalog
+        },
+      },
+    },
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['packages/*'],
+    sharedWorkspaceLockfile: false,
+    catalog: {
+      '@pnpm.e2e/foo': '100.0.0',
+    },
+  })
+  writeYamlFileSync('packages/pkg-a/pnpm-workspace.yaml', {
+    extends: '<root>',
+    catalog: {
+      '@pnpm.e2e/foo': '100.1.0', // takes precedence over the inherited entry
+      '@pnpm.e2e/bar': '100.0.0',
+    },
+  })
+
+  await execPnpm(['install'])
+
+  const pkgALockfile = projects['pkg-a'].readLockfile()
+  expect(pkgALockfile.catalogs?.default?.['@pnpm.e2e/foo']).toStrictEqual({
+    specifier: '100.1.0',
+    version: '100.1.0',
+  })
+  expect(pkgALockfile.catalogs?.default?.['@pnpm.e2e/bar']).toStrictEqual({
+    specifier: '100.0.0',
+    version: '100.0.0',
+  })
+
+  const pkgBLockfile = projects['pkg-b'].readLockfile()
+  expect(pkgBLockfile.catalogs?.default?.['@pnpm.e2e/foo']).toStrictEqual({
+    specifier: '100.0.0',
+    version: '100.0.0',
+  })
+})
+
+// `extends` is not limited to sharedWorkspaceLockfile: false. With the default
+// shared lockfile, a root manifest can extend its packages through a glob, so a
+// catalog entry defined in a package manifest becomes available workspace-wide.
+test('the root aggregates package catalogs through a glob (shared lockfile)', async () => {
+  await Promise.all([
+    addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' }),
+  ])
+
+  const projects = preparePackages([
+    {
+      location: '.',
+      package: {
+        name: 'root',
+        private: true,
+        dependencies: {
+          '@pnpm.e2e/bar': 'catalog:', // defined in a package manifest, inherited via the glob
+        },
+      },
+    },
+    {
+      location: 'packages/pkg-a',
+      package: {
+        name: 'pkg-a',
+        private: true,
+        dependencies: {
+          '@pnpm.e2e/foo': 'catalog:', // defined in the root catalog
+        },
+      },
+    },
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['packages/*'],
+    extends: 'packages/*',
+    catalog: {
+      '@pnpm.e2e/foo': '100.0.0',
+    },
+  })
+  writeYamlFileSync('packages/pkg-a/pnpm-workspace.yaml', {
+    catalog: {
+      '@pnpm.e2e/bar': '100.0.0',
+    },
+  })
+
+  await execPnpm(['install'])
+
+  const rootLockfile = projects['root'].readLockfile()
+  expect(rootLockfile.catalogs?.default?.['@pnpm.e2e/bar']).toStrictEqual({
+    specifier: '100.0.0',
+    version: '100.0.0',
+  })
+  expect(rootLockfile.catalogs?.default?.['@pnpm.e2e/foo']).toStrictEqual({
+    specifier: '100.0.0',
+    version: '100.0.0',
+  })
+})

--- a/workspace/workspace-manifest-reader/src/index.ts
+++ b/workspace/workspace-manifest-reader/src/index.ts
@@ -34,10 +34,16 @@ export interface WorkspaceManifest extends PnpmSettings {
   catalogs?: WorkspaceNamedCatalogs
 
   /**
-   * Paths to directories that contain their own `pnpm-workspace.yaml`. The
-   * catalogs defined in those workspace manifests are merged into this
-   * workspace. Catalog entries defined directly in this manifest take
+   * One or more references to other workspace manifests whose catalogs are
+   * merged into this one. Catalog entries defined directly in this manifest take
    * precedence over the ones coming from the extended manifests.
+   *
+   * Each reference may be a directory that contains a `pnpm-workspace.yaml`, a
+   * direct path to a `pnpm-workspace.yaml` file (relative, absolute, or outside
+   * the workspace), a glob such as `packages/*`, or a path prefixed with the
+   * `<root>` token, which resolves to the monorepo root (the nearest ancestor
+   * directory that contains a `pnpm-workspace.yaml`). References are resolved
+   * recursively and circular references are reported as errors.
    */
   extends?: string | string[]
 }

--- a/workspace/workspace-manifest-reader/src/index.ts
+++ b/workspace/workspace-manifest-reader/src/index.ts
@@ -32,6 +32,14 @@ export interface WorkspaceManifest extends PnpmSettings {
    * in this definition through the `catalog:<name>` specifier.
    */
   catalogs?: WorkspaceNamedCatalogs
+
+  /**
+   * Paths to directories that contain their own `pnpm-workspace.yaml`. The
+   * catalogs defined in those workspace manifests are merged into this
+   * workspace. Catalog entries defined directly in this manifest take
+   * precedence over the ones coming from the extended manifests.
+   */
+  extends?: string | string[]
 }
 
 export async function readWorkspaceManifest (dir: string, cfgFileName: ConfigFileName = WORKSPACE_MANIFEST_FILENAME): Promise<WorkspaceManifest | undefined> {
@@ -76,8 +84,22 @@ export function validateWorkspaceManifest (manifest: unknown): asserts manifest 
   assertValidWorkspaceManifestPackages(manifest)
   assertValidWorkspaceManifestCatalog(manifest)
   assertValidWorkspaceManifestCatalogs(manifest)
+  assertValidWorkspaceManifestExtends(manifest)
 
   checkWorkspaceManifestAssignability(manifest)
+}
+
+function assertValidWorkspaceManifestExtends (manifest: { packages?: readonly string[], extends?: unknown }): asserts manifest is { extends?: string | string[] } {
+  if (manifest.extends == null) {
+    return
+  }
+
+  const entries = Array.isArray(manifest.extends) ? manifest.extends : [manifest.extends]
+  for (const entry of entries) {
+    if (typeof entry !== 'string' || entry.length === 0) {
+      throw new InvalidWorkspaceManifestError('The "extends" field should be a non-empty string or an array of non-empty strings')
+    }
+  }
 }
 
 function assertValidWorkspaceManifestPackages (manifest: { packages?: unknown }): asserts manifest is { packages: string[] } {

--- a/workspace/workspace-manifest-reader/test/__fixtures__/extends-invalid/pnpm-workspace.yaml
+++ b/workspace/workspace-manifest-reader/test/__fixtures__/extends-invalid/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - "packages/**"
+
+extends:
+  - 123

--- a/workspace/workspace-manifest-reader/test/__fixtures__/extends-ok/pnpm-workspace.yaml
+++ b/workspace/workspace-manifest-reader/test/__fixtures__/extends-ok/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - "packages/**"
+
+extends:
+  - "packages/a"
+  - "packages/b"

--- a/workspace/workspace-manifest-reader/test/__fixtures__/extends-string-ok/pnpm-workspace.yaml
+++ b/workspace/workspace-manifest-reader/test/__fixtures__/extends-string-ok/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - "packages/**"
+
+extends: "packages/a"

--- a/workspace/workspace-manifest-reader/test/index.ts
+++ b/workspace/workspace-manifest-reader/test/index.ts
@@ -149,6 +149,28 @@ describe('readWorkspaceManifest() catalogs field', () => {
   })
 })
 
+describe('readWorkspaceManifest() extends field', () => {
+  test('works with an array of strings', async () => {
+    await expect(readWorkspaceManifest(path.join(import.meta.dirname, '__fixtures__/extends-ok'))).resolves.toEqual({
+      packages: ['packages/**'],
+      extends: ['packages/a', 'packages/b'],
+    })
+  })
+
+  test('works with a single string', async () => {
+    await expect(readWorkspaceManifest(path.join(import.meta.dirname, '__fixtures__/extends-string-ok'))).resolves.toEqual({
+      packages: ['packages/**'],
+      extends: 'packages/a',
+    })
+  })
+
+  test('throws on a non-string entry', async () => {
+    await expect(
+      readWorkspaceManifest(path.join(import.meta.dirname, '__fixtures__/extends-invalid'))
+    ).rejects.toThrow('The "extends" field should be a non-empty string or an array of non-empty strings')
+  })
+})
+
 describe('readWorkspaceManifest() reads default catalog defined alongside named catalogs', () => {
   test('works when implicit default catalog is configured alongside named catalogs', async () => {
     await expect(readWorkspaceManifest(path.join(import.meta.dirname, '__fixtures__/catalogs-ok'))).resolves.toEqual({


### PR DESCRIPTION
## What

Adds an `extends` field to `pnpm-workspace.yaml` that **merges catalogs from other workspace manifests** into the current one. Each `extends` entry may be:

- a **directory** that contains a `pnpm-workspace.yaml`,
- a **direct path to a `pnpm-workspace.yaml` file** — relative, absolute, or **outside the workspace** (e.g. a shared catalog file),
- a **glob** such as `packages/*` (every matching `pnpm-workspace.yaml` is merged; directories without one are skipped), or
- a path prefixed with the **`<root>` token**, which resolves to the **monorepo root** — the nearest ancestor directory that has a `pnpm-workspace.yaml` — so a package can reference the root without counting `../` segments (`<root>`, `<root>/configs/base`).

`extends` accepts a string or an array of strings and is resolved **recursively**. Precedence: entries defined directly in the extending manifest win over inherited ones, and manifests resolved later win over earlier ones (glob matches are ordered lexicographically). **Circular references are reported as errors.**

The resolver is **direction-agnostic** and the feature is **not limited to `sharedWorkspaceLockfile: false`** (see below).

## Why

Related to #10302.

Catalogs centralize dependency versions, but there was no way to **share or inherit** them between `pnpm-workspace.yaml` files. `extends` makes catalogs composable across manifests, which unlocks several setups:

- **Per-project lockfiles** (`sharedWorkspaceLockfile: false`): a package keeps its own `pnpm-workspace.yaml` that `extends: <root>`, inherits the root catalogs, adds/overrides its own, and records the merged result in **its own** lockfile. Previously only the root catalogs were ever read, so per-project catalog customization was impossible.
- **Root aggregation** (default shared lockfile): a root `pnpm-workspace.yaml` with `extends: packages/*` pulls catalog entries defined in package manifests up into the workspace-wide catalogs — this works with the default shared lockfile, i.e. `extends` is **not** gated on `sharedWorkspaceLockfile: false`.
- **Shared/external catalogs**: a manifest can `extends` a `pnpm-workspace.yaml` that lives outside the workspace (a shared config repo/dir), so multiple workspaces reuse one catalog definition.

### Relationship to #10302

#10302 asks for a **parent** workspace to `extends` a nested **child** workspace (aggregating the child's catalogs — and ideally its `packages`). This PR introduces the same `extends` field, focuses on **catalogs**, and is **direction-agnostic**:

- A **root** manifest with `extends: packages/*` (or `extends: ./child`) merges package/child catalogs into the workspace config (the catalog-sharing core of #10302).
- A **package** manifest with `extends: <root>` inherits and overrides the root catalogs for its own lockfile.

**Out of scope here:** inferring `packages:` from extended workspaces (the other half of #10302). That can be a follow-up. A design note is left on #10302.

## Reference forms

| `extends` value | Resolves to |
| --- | --- |
| `../..` or `./shared` | the `pnpm-workspace.yaml` in that directory |
| `../../pnpm-workspace.yaml`, `/abs/path/pnpm-workspace.yaml` | that file directly (may live outside the workspace) |
| `packages/*`, `configs/*/pnpm-workspace.yaml` | every matching `pnpm-workspace.yaml` (missing ones skipped) |
| `<root>`, `<root>/configs/base` | the monorepo root (nearest ancestor with a `pnpm-workspace.yaml`), used as a path prefix |

## How

- **`@pnpm/workspace.workspace-manifest-reader`** — adds and validates the `extends` field (non-empty string or array of non-empty strings).
- **`@pnpm/catalogs.config`** — `getExtendedCatalogs()` resolves `extends` recursively and merges catalogs with extender-wins precedence. It expands globs (via `tinyglobby`, ignoring `node_modules`), accepts directory and direct-file references, and resolves the `<root>` token by walking up to the nearest ancestor `pnpm-workspace.yaml`. Cycles and explicitly-referenced missing manifests are reported as errors.
- **`@pnpm/config.reader`** — when the discovered workspace manifest has `extends`, `config.catalogs` becomes the merged result, in **any** lockfile mode.
- **`@pnpm/installing.commands`** (`recursive.ts`) — on the dedicated-lockfile-per-project path, each project resolves against its own merged catalogs.
- **`@pnpm/deps.status`** (`checkDepsStatus.ts`) — a changed child `pnpm-workspace.yaml` invalidates the optimistic "Already up to date" fast path (when `sharedWorkspaceLockfile: false`).

The change is **additive and backward compatible**: without `extends`, behavior is unchanged.

## Example

```
workspace/
  pnpm-workspace.yaml          # sharedWorkspaceLockfile: false; catalog: { is-positive: ^3.1.0 }
  packages/
    pkg-a/
      pnpm-workspace.yaml      # extends: <root>; catalog: { is-odd: ^2.0.0, is-positive: 3.0.0 }
      package.json             # deps: { is-odd: "catalog:", is-positive: "catalog:" }
    pkg-b/
      pnpm-workspace.yaml      # extends: <root>; catalog: { is-even: ^1.0.0 }
      package.json             # deps: { is-even: "catalog:", is-positive: "catalog:" }
```

After `pnpm install`:

- `packages/pkg-a/pnpm-lock.yaml` → `is-positive` resolves to **3.0.0** (pkg-a overrides the root) and `is-odd` to `2.0.0`.
- `packages/pkg-b/pnpm-lock.yaml` → `is-positive` resolves to **3.1.0** (inherited from the root) and `is-even` to `1.0.0`; pkg-a's `is-odd` does **not** leak in.

Root aggregation with the default shared lockfile:

```
workspace/
  pnpm-workspace.yaml          # extends: packages/*; catalog: { foo: 100.0.0 }
  packages/pkg-a/
    pnpm-workspace.yaml        # catalog: { bar: 100.0.0 }
```

The single root lockfile's catalog snapshot then contains both `foo` (root) and `bar` (inherited from `pkg-a`).

## Tests

- **Unit**
  - `@pnpm/catalogs.config`: extender-wins/later-wins precedence, array & recursive `extends`, the `<root>` token (and `<root>`-not-found), glob expansion (match, skip-without-manifest, later-wins), direct-file and outside-the-workspace paths, missing-manifest errors, and a root↔package cycle (`packages/*` + `<root>`).
  - `@pnpm/workspace.workspace-manifest-reader`: `extends` parsing/validation.
  - `@pnpm/config.reader`: `config.catalogs` merges through `extends`.
  - `@pnpm/deps.status`: a changed child `pnpm-workspace.yaml` invalidates the fast path (ignored when `sharedWorkspaceLockfile: true`).
- **e2e** (`pnpm/test/catalogExtends.ts`): child→root via `../..`, child→root via the `<root>` token, and root→package aggregation through a `packages/*` glob with the default shared lockfile.

A changeset is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `extends` field support to `pnpm-workspace.yaml` for inheriting catalogs from other workspace manifests
  * Projects can now override inherited catalog entries with their own definitions
  * Recursive extends resolution with automatic circular reference detection and validation

* **Bug Fixes**
  * Fixed dependency status checks to account for per-project workspace manifest changes

* **Tests**
  * Comprehensive test coverage for catalog inheritance and override behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
