### PR TITLE
fix: enable CodeRabbit approvals via request_changes_workflow

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,13 +14,24 @@ reviews:
         Apply the "AI Review Guidance" section in AGENTS.md. Security vulnerabilities are the first review priority; performance regressions in pnpm, pacquet, and pnpr are the second priority. Surface only issues tied to changed code, and explain the exploit path, impact, or hot path affected.
   # Walkthrough poem adds no review value.
   poem: false
-  # Pre-merge checks are intentionally left unconfigured. Defining any check here
-  # turns on the whole pre-merge-checks subsystem, which replaces the auto-approve
-  # flow under Request Changes Workflow: CodeRabbit then emits a pre-merge-checks
-  # status block instead of approving once review threads are resolved, so PRs sit
-  # at REVIEW_REQUIRED even with all threads cleared and all checks green. We rely
-  # on the commit-msg hook plus the squash-title convention for title enforcement
-  # instead of a CodeRabbit title check.
+  # Required for CodeRabbit to submit approving reviews at all. With this off
+  # (the default — and what the dashboard toggle resolves to for this repo)
+  # CodeRabbit only comments and never approves. Declared in-repo so approvals
+  # don't depend on dashboard state.
+  request_changes_workflow: true
+  # Pre-merge checks are on by default (and in the dashboard), so they're disabled
+  # explicitly here: they add a status block without review value for this repo, and
+  # title enforcement is already covered by the commit-msg hook and the squash-title
+  # convention. "off" is quoted so YAML doesn't read it as the boolean false.
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
+    title:
+      mode: "off"
+    description:
+      mode: "off"
+    issue_assessment:
+      mode: "off"
   # Actually attach the chosen labels to the PR, not just suggest them in the walkthrough.
   auto_apply_labels: true
   # Custom labels assigned based on which product the diff touches. More than one may apply to a single PR.


### PR DESCRIPTION
## What

Declares `reviews.request_changes_workflow: true` in `.coderabbit.yaml` and explicitly disables `pre_merge_checks`.

## Why

CodeRabbit stopped approving PRs. Querying its **effective** config via the `@coderabbitai configuration` command revealed the actual cause:

```yaml
reviews:
  request_changes_workflow: false
  ...
  pre_merge_checks:
    docstrings: { mode: warning, threshold: 80 }
    title: { mode: warning, requirements: '' }
    description: { mode: warning }
    issue_assessment: { mode: warning }
```

- **`request_changes_workflow: false`** is dispositive — CodeRabbit submits an approving review *only* when this is `true`; otherwise it just comments and resolves threads. The dashboard toggle for this was believed to be on, but the effective config proves it isn't being applied (likely scope/inheritance — note `inheritance: false`). Declaring it in the repo config makes approvals deterministic and independent of dashboard state.
- **`pre_merge_checks` are enabled by default / via the dashboard**, not by our config — note `title.requirements` is now empty, proving the block we previously removed from `.coderabbit.yaml` was read and dropped, yet the checks persist. They add a status block without review value here, so they're explicitly set to `"off"` (quoted so YAML doesn't coerce it to boolean `false`). Title enforcement remains covered by the `commit-msg` hook and the squash-title convention.

This supersedes the earlier theory that removing the `pre_merge_checks` block (#12474) would restore approvals — the real blocker was `request_changes_workflow`.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to modify PR validation behavior and automated check processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->