### PR TITLE
refactor(rust): replace OnceLock with LazyLock where possible

### DIFF
--- a/pacquet/crates/fs/src/ensure_file.rs
+++ b/pacquet/crates/fs/src/ensure_file.rs
@@ -210,7 +210,7 @@ pub fn ensure_file(
 ///
 /// **Coordination contract.** Callers handing in the same `&Path`
 /// always receive the same `Mutex<()>`. The hasher is initialised
-/// once per process (`OnceLock<RandomState>`) so the path-to-stripe
+/// once per process (`LazyLock<RandomState>`) so the path-to-stripe
 /// mapping stays stable for the lifetime of the process; writers
 /// (`ensure_file`) and verifiers (`check_pkg_files_integrity`) of the
 /// same path are guaranteed to meet on the same lock and serialise.
@@ -225,9 +225,8 @@ pub fn ensure_file(
 /// `write_all` is still running.
 pub fn cas_write_lock(file_path: &Path) -> &'static Mutex<()> {
     use std::collections::hash_map::RandomState;
-    static BUILDER: std::sync::OnceLock<RandomState> = std::sync::OnceLock::new();
-    let builder = BUILDER.get_or_init(RandomState::new);
-    let mut hasher = builder.build_hasher();
+    static BUILDER: std::sync::LazyLock<RandomState> = std::sync::LazyLock::new(RandomState::new);
+    let mut hasher = BUILDER.build_hasher();
     std::hash::Hash::hash(file_path, &mut hasher);
     let stripe = (hasher.finish() as usize) & (NUM_CAS_LOCK_STRIPES - 1);
     &CAS_LOCK_STRIPES[stripe]

--- a/pacquet/crates/git-fetcher/src/prepare_package/tests.rs
+++ b/pacquet/crates/git-fetcher/src/prepare_package/tests.rs
@@ -6,18 +6,18 @@ use crate::error::PreparePackageError;
 use pacquet_executor::ScriptsPrependNodePath;
 use pacquet_reporter::SilentReporter;
 use serde_json::json;
-use std::{collections::HashMap, fs, path::Path, sync::OnceLock};
+use std::{collections::HashMap, fs, path::Path, sync::LazyLock};
 use tempfile::tempdir;
 
 /// A single process-wide empty env map shared across every test
-/// invocation. `OnceLock` avoids the per-call `Box::leak(Box::new(...))`
+/// invocation. `LazyLock` avoids the per-call `Box::leak(Box::new(...))`
 /// that an earlier version of this helper used — the leak was benign
 /// because the test binary exits quickly, but accumulating one fresh
 /// allocation per test isn't necessary when every site wants the same
 /// value.
 fn empty_env() -> &'static HashMap<String, String> {
-    static EMPTY_ENV: OnceLock<HashMap<String, String>> = OnceLock::new();
-    EMPTY_ENV.get_or_init(HashMap::new)
+    static EMPTY_ENV: LazyLock<HashMap<String, String>> = LazyLock::new(HashMap::new);
+    &EMPTY_ENV
 }
 
 fn write_manifest(dir: &Path, manifest: &serde_json::Value) {

--- a/pacquet/crates/graph-hasher/src/engine_name.rs
+++ b/pacquet/crates/graph-hasher/src/engine_name.rs
@@ -108,14 +108,15 @@ fn parse_node_version_output(stdout: &str) -> Option<u32> {
 ///
 /// Delegates to [`pacquet_detect_libc::detect()`] for the
 /// actual detection; see that function for the fallback chain. The
-/// result is cached after the first call via [`std::sync::OnceLock`].
+/// result is cached after the first call via [`std::sync::LazyLock`].
+#[must_use]
 pub fn host_libc() -> &'static str {
-    use std::sync::OnceLock;
+    use std::sync::LazyLock;
 
-    static CACHED: OnceLock<&'static str> = OnceLock::new();
-    CACHED.get_or_init(|| {
+    static CACHED: LazyLock<&'static str> = LazyLock::new(|| {
         pacquet_detect_libc::detect().map_or("unknown", pacquet_detect_libc::Implementation::as_str)
-    })
+    });
+    *CACHED
 }
 
 #[cfg(test)]

--- a/pacquet/crates/package-manager/src/compat_package_extensions.rs
+++ b/pacquet/crates/package-manager/src/compat_package_extensions.rs
@@ -1,20 +1,10 @@
 use crate::PackageExtender;
 use indexmap::IndexMap;
 use pacquet_config::{PackageExtension, PeerDependencyMeta};
-use std::{collections::BTreeMap, sync::OnceLock};
+use std::{collections::BTreeMap, sync::LazyLock};
 
-static COMPAT_PACKAGE_EXTENSIONS: OnceLock<IndexMap<String, PackageExtension>> = OnceLock::new();
-static COMPAT_PACKAGE_EXTENDER: OnceLock<PackageExtender> = OnceLock::new();
-
-pub(crate) fn compat_package_extender() -> &'static PackageExtender {
-    COMPAT_PACKAGE_EXTENDER.get_or_init(|| {
-        PackageExtender::new(compat_package_extensions())
-            .expect("@yarnpkg/extensions compatibility DB selectors are valid")
-    })
-}
-
-fn compat_package_extensions() -> &'static IndexMap<String, PackageExtension> {
-    COMPAT_PACKAGE_EXTENSIONS.get_or_init(|| {
+static COMPAT_PACKAGE_EXTENSIONS: LazyLock<IndexMap<String, PackageExtension>> =
+    LazyLock::new(|| {
         let entries: Vec<(String, PackageExtension)> =
             serde_json::from_str(include_str!("compat_package_extensions.json"))
                 .expect("@yarnpkg/extensions compatibility DB JSON is valid");
@@ -23,7 +13,15 @@ fn compat_package_extensions() -> &'static IndexMap<String, PackageExtension> {
             merge_package_extension_entry(&mut extensions, selector, extension);
         }
         extensions
-    })
+    });
+
+static COMPAT_PACKAGE_EXTENDER: LazyLock<PackageExtender> = LazyLock::new(|| {
+    PackageExtender::new(&COMPAT_PACKAGE_EXTENSIONS)
+        .expect("@yarnpkg/extensions compatibility DB selectors are valid")
+});
+
+pub(crate) fn compat_package_extender() -> &'static PackageExtender {
+    &COMPAT_PACKAGE_EXTENDER
 }
 
 fn merge_package_extension_entry(

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
@@ -718,7 +718,7 @@ fn node_extras_filter(path: &str) -> bool {
 /// keyed by `pkg.name`); everything else returns `None` and the
 /// full archive contents land in the CAS unfiltered.
 ///
-/// The filter is cached in a [`std::sync::OnceLock`] so per-snapshot
+/// The filter is cached in a [`std::sync::LazyLock`] so per-snapshot
 /// `Arc::clone`s share one trait object — `IgnoreEntryFilter` is
 /// a `dyn Fn`, so cheap to clone, and we don't want to allocate
 /// the Arc once per runtime install.
@@ -726,8 +726,7 @@ fn archive_filter_for(package_key: &PackageKey) -> Option<Arc<IgnoreEntryFilter>
     if package_key.name.scope.is_some() || package_key.name.bare != "node" {
         return None;
     }
-    static FILTER: std::sync::OnceLock<Arc<IgnoreEntryFilter>> = std::sync::OnceLock::new();
-    let filter = FILTER.get_or_init(|| {
+    static FILTER: std::sync::LazyLock<Arc<IgnoreEntryFilter>> = std::sync::LazyLock::new(|| {
         // `fn(&str) -> bool` implements `Fn(&str) -> bool + Send +
         // Sync`, so an `Arc<fn(...)>` unsizes to
         // `Arc<dyn Fn(...) + Send + Sync>` (the trait-object type
@@ -736,7 +735,7 @@ fn archive_filter_for(package_key: &PackageKey) -> Option<Arc<IgnoreEntryFilter>
         let inner: Arc<IgnoreEntryFilter> = Arc::new(node_extras_filter);
         inner
     });
-    Some(Arc::clone(filter))
+    Some(Arc::clone(&FILTER))
 }
 
 /// Fetch a [`BinaryResolution`] into the CAS, returning the

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -938,12 +938,11 @@ fn get_file_mtime(path: &Path) -> Option<DateTime<Utc>> {
 /// ordered eviction via `shift_remove_index(0)`, matching upstream's
 /// JS `Set` which iterates in insertion order.
 const MAX_WARNED_MISSING_TIME: usize = 1024;
-static WARNED_MISSING_TIME: std::sync::OnceLock<Mutex<indexmap::IndexSet<String>>> =
-    std::sync::OnceLock::new();
+static WARNED_MISSING_TIME: std::sync::LazyLock<Mutex<indexmap::IndexSet<String>>> =
+    std::sync::LazyLock::new(|| Mutex::new(indexmap::IndexSet::new()));
 
 fn warn_missing_time_once(pkg_name: &str) {
-    let lock = WARNED_MISSING_TIME.get_or_init(|| Mutex::new(indexmap::IndexSet::new()));
-    let mut warned = lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut warned = WARNED_MISSING_TIME.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     if warned.contains(pkg_name) {
         return;
     }

--- a/pacquet/crates/tarball/src/lib.rs
+++ b/pacquet/crates/tarball/src/lib.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     io::{Cursor, Read},
     path::{Component, PathBuf},
-    sync::{Arc, OnceLock},
+    sync::{Arc, LazyLock},
     time::{Duration, Instant, UNIX_EPOCH},
 };
 
@@ -43,8 +43,9 @@ use zune_inflate::{DeflateDecoder, DeflateOptions, errors::InflateDecodeErrors};
 ///
 /// [#269]: https://github.com/pnpm/pacquet/pull/269
 fn post_download_semaphore() -> &'static Semaphore {
-    static SEM: OnceLock<Semaphore> = OnceLock::new();
-    SEM.get_or_init(|| Semaphore::new(num_cpus::get().saturating_mul(2).max(4)))
+    static SEM: LazyLock<Semaphore> =
+        LazyLock::new(|| Semaphore::new(num_cpus::get().saturating_mul(2).max(4)));
+    &SEM
 }
 
 /// Dedicated rayon pool for the per-file CAS-write phase of extraction
@@ -65,8 +66,7 @@ fn post_download_semaphore() -> &'static Semaphore {
 /// Returns `None` if the pool can't be built, in which case the caller
 /// falls back to the global pool.
 fn cas_write_pool() -> Option<&'static rayon::ThreadPool> {
-    static POOL: OnceLock<Option<rayon::ThreadPool>> = OnceLock::new();
-    POOL.get_or_init(|| {
+    static POOL: LazyLock<Option<rayon::ThreadPool>> = LazyLock::new(|| {
         rayon::ThreadPoolBuilder::new()
             .num_threads(num_cpus::get().max(1))
             .thread_name(|index| format!("cas-write-{index}"))
@@ -79,8 +79,8 @@ fn cas_write_pool() -> Option<&'static rayon::ThreadPool> {
                 );
             })
             .ok()
-    })
-    .as_ref()
+    });
+    POOL.as_ref()
 }
 
 /// Reqwest's own [`std::fmt::Display`] for a request-stage failure renders as

--- a/pacquet/crates/testing-utils/src/env_guard.rs
+++ b/pacquet/crates/testing-utils/src/env_guard.rs
@@ -23,15 +23,15 @@
 use std::{
     env,
     ffi::{OsStr, OsString},
-    sync::{Mutex, MutexGuard, OnceLock},
+    sync::{LazyLock, Mutex, MutexGuard},
 };
 
 /// Serialization mutex for env-mutating tests. A single `Mutex<()>` —
 /// uncontended outside the handful of tests that need it, cheap when
 /// held.
 fn env_mutex() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
+    static LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+    &LOCK
 }
 
 /// Restore a named set of env vars on drop and hold the env-mutation

--- a/pacquet/crates/testing-utils/src/registry.rs
+++ b/pacquet/crates/testing-utils/src/registry.rs
@@ -1,7 +1,7 @@
 use pnpr::Config;
 use std::{
     net::{Ipv4Addr, TcpListener},
-    sync::OnceLock,
+    sync::LazyLock,
     thread,
 };
 
@@ -29,8 +29,9 @@ struct TestRegistryInstance {
 
 impl TestRegistryInstance {
     fn get() -> &'static Self {
-        static INSTANCE: OnceLock<TestRegistryInstance> = OnceLock::new();
-        INSTANCE.get_or_init(Self::start)
+        static INSTANCE: LazyLock<TestRegistryInstance> =
+            LazyLock::new(TestRegistryInstance::start);
+        &INSTANCE
     }
 
     fn start() -> Self {

--- a/pacquet/tasks/registry-mock/src/dirs.rs
+++ b/pacquet/tasks/registry-mock/src/dirs.rs
@@ -2,12 +2,12 @@ use pipe_trait::Pipe;
 use std::{
     path::{Path, PathBuf},
     process::Command,
-    sync::OnceLock,
+    sync::LazyLock,
 };
 
+#[must_use]
 pub fn workspace_root() -> &'static Path {
-    static WORKSPACE_ROOT: OnceLock<PathBuf> = OnceLock::new();
-    WORKSPACE_ROOT.get_or_init(|| {
+    static WORKSPACE_ROOT: LazyLock<PathBuf> = LazyLock::new(|| {
         let output = env!("CARGO")
             .pipe(Command::new)
             .arg("locate-project")
@@ -28,7 +28,8 @@ pub fn workspace_root() -> &'static Path {
             .parent()
             .expect("parent of root manifest")
             .to_path_buf()
-    })
+    });
+    WORKSPACE_ROOT.as_path()
 }
 
 /// The verdaccio-shaped storage built from the in-repo package fixtures
@@ -56,9 +57,9 @@ pub fn registry_mock_storage() -> &'static Path {
 ///
 /// The path can be overridden via the `PNPM_REGISTRY_STORAGE` env
 /// var. Defaults to `$HOME/.cache/pnpm-registry/storage`.
+#[must_use]
 pub fn runtime_storage() -> &'static Path {
-    static STORAGE: OnceLock<PathBuf> = OnceLock::new();
-    STORAGE.get_or_init(|| {
+    static STORAGE: LazyLock<PathBuf> = LazyLock::new(|| {
         std::env::var_os("PNPM_REGISTRY_STORAGE")
             .map(PathBuf::from)
             .or_else(|| {
@@ -66,5 +67,6 @@ pub fn runtime_storage() -> &'static Path {
                     .map(|home| home.join(".cache").join("pnpm-registry").join("storage"))
             })
             .expect("locate runtime storage dir: set PNPM_REGISTRY_STORAGE or ensure $HOME is set")
-    })
+    });
+    STORAGE.as_path()
 }

--- a/pacquet/tasks/registry-mock/src/registry_anchor.rs
+++ b/pacquet/tasks/registry-mock/src/registry_anchor.rs
@@ -6,7 +6,7 @@ use std::{
     fs::{self, File, OpenOptions, TryLockError},
     mem::forget,
     path::{Path, PathBuf},
-    sync::OnceLock,
+    sync::LazyLock,
 };
 use sysinfo::{Pid, Signal};
 
@@ -55,8 +55,9 @@ impl Drop for RegistryAnchor {
 
 impl RegistryAnchor {
     fn path() -> &'static Path {
-        static PATH: OnceLock<PathBuf> = OnceLock::new();
-        PATH.get_or_init(|| temp_dir().join("pacquet-registry-mock-anchor.json"))
+        static PATH: LazyLock<PathBuf> =
+            LazyLock::new(|| temp_dir().join("pacquet-registry-mock-anchor.json"));
+        PATH.as_path()
     }
 
     fn load() -> Self {
@@ -134,8 +135,7 @@ impl Drop for GuardFile {
 
 impl GuardFile {
     fn path() -> &'static File {
-        static PATH: OnceLock<File> = OnceLock::new();
-        PATH.get_or_init(|| {
+        static PATH: LazyLock<File> = LazyLock::new(|| {
             OpenOptions::new()
                 .read(true)
                 .write(true)
@@ -143,7 +143,8 @@ impl GuardFile {
                 .truncate(false)
                 .open(temp_dir().join("pacquet-registry-mock-anchor.lock"))
                 .expect("open the guard file")
-        })
+        });
+        &PATH
     }
 
     fn lock() -> Self {

--- a/pacquet/tasks/registry-mock/src/registry_info.rs
+++ b/pacquet/tasks/registry-mock/src/registry_info.rs
@@ -7,7 +7,7 @@ use std::{
     io::ErrorKind,
     mem::forget,
     path::{Path, PathBuf},
-    sync::OnceLock,
+    sync::LazyLock,
 };
 use sysinfo::{Pid, Signal};
 
@@ -34,8 +34,9 @@ pub struct PreparedRegistryInfo {
 
 impl PreparedRegistryInfo {
     fn path() -> &'static Path {
-        static PATH: OnceLock<PathBuf> = OnceLock::new();
-        PATH.get_or_init(|| temp_dir().join("pacquet-registry-mock-prepared-registry-info.json"))
+        static PATH: LazyLock<PathBuf> =
+            LazyLock::new(|| temp_dir().join("pacquet-registry-mock-prepared-registry-info.json"));
+        PATH.as_path()
     }
 
     pub fn try_load() -> Option<Self> {

--- a/pnpr/crates/pnpr-fixtures/src/lib.rs
+++ b/pnpr/crates/pnpr-fixtures/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
     io::{self, Write},
     path::{Path, PathBuf},
     sync::{
-        OnceLock,
+        LazyLock,
         atomic::{AtomicU64, Ordering},
     },
 };
@@ -20,9 +20,9 @@ const GENERATED_DIR: &str = "pnpr-fixtures";
 const COMPLETE_FILE: &str = ".complete";
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+#[must_use]
 pub fn ensure_storage() -> &'static Path {
-    static STORAGE: OnceLock<PathBuf> = OnceLock::new();
-    STORAGE.get_or_init(|| {
+    static STORAGE: LazyLock<PathBuf> = LazyLock::new(|| {
         let workspace = workspace_root();
         let packages = workspace.join(PACKAGES_DIR);
         let generated = target_dir(&workspace).join(GENERATED_DIR);
@@ -30,7 +30,8 @@ pub fn ensure_storage() -> &'static Path {
         let storage = generated.join("storage").join(&fingerprint);
         ensure_storage_for_fingerprint(&packages, &generated, &storage);
         storage
-    })
+    });
+    STORAGE.as_path()
 }
 
 #[must_use]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined internal lazy-initialization caching mechanisms across multiple modules for improved performance and maintainability.

* **Chores**
  * Added utility function attributes to highlight important results and encourage best practices in module usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->