### PR TITLE
docs: document --cpu, --os and --libc flags in pnpm install --help

### DIFF
--- a/.changeset/install-help-arch-flags.md
+++ b/.changeset/install-help-arch-flags.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.commands": patch
+"pnpm": patch
+---
+
+Document the `--cpu`, `--os` and `--libc` flags in the output of `pnpm install --help`. These flags were already supported but were only documented on the website [#12359](https://github.com/pnpm/pnpm/issues/12359).

--- a/installing/commands/src/install.ts
+++ b/installing/commands/src/install.ts
@@ -288,6 +288,18 @@ Install all optionalDependencies even when they don\'t satisfy the current envir
             description: 'Re-runs resolution: useful for printing out peer dependency issues',
             name: '--resolution-only',
           },
+          {
+            description: 'Override CPU architecture of native modules to install. Acceptable values are the same as the `cpu` field of `package.json` (from `process.arch`)',
+            name: '--cpu <arch>',
+          },
+          {
+            description: 'Override OS of native modules to install. Acceptable values are the same as the `os` field of `package.json` (from `process.platform`)',
+            name: '--os <os>',
+          },
+          {
+            description: 'Override libc of native modules to install. Acceptable values are the same as the `libc` field of `package.json`',
+            name: '--libc <libc>',
+          },
           ...UNIVERSAL_OPTIONS,
         ],
       },


### PR DESCRIPTION
## What

Add `--cpu`, `--os` and `--libc` to the options listed in `pnpm install --help`.

## Why

These flags were added in #9745 and already work (they're registered in `rcOptionsTypes`), but were only documented on the website, not in the CLI help. Wording matches the website docs.

Closes #12359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `--cpu`, `--os`, and `--libc` flags in the install command help output. These flags allow users to override native module installation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->