### PR TITLE
ci: label PRs approved by Qodo with 'reviewed: qodo'

### DIFF
--- a/.github/workflows/pr-review-automation.yml
+++ b/.github/workflows/pr-review-automation.yml
@@ -54,6 +54,25 @@ jobs:
             -d "$payload" \
             "$DISCORD_WEBHOOK"
 
+  on-qodo-approval:
+    if: >-
+      github.event.review.state == 'approved' &&
+      github.event.review.user.login == 'qodo-free-for-open-source-projects[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      # gh pr edit --add-label uses the GraphQL addLabelsToLabelable mutation,
+      # which is governed by issues: write even when the target is a PR.
+      issues: write
+      pull-requests: write
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Add the reviewed label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "reviewed: qodo"
+
   on-maintainer-approval:
     if: >-
       github.event.review.state == 'approved' &&


### PR DESCRIPTION
## What

Adds an `on-qodo-approval` job to `pr-review-automation.yml` that applies the `reviewed: qodo` label when `qodo-free-for-open-source-projects[bot]` submits an approving review.

## Why

The `reviewed: qodo` label already exists in the repo, but no automation applied it — the PR review automation only handled CodeRabbit approvals (`reviewed: coderabbit`) and maintainer approvals (`state: automerge`). Qodo approvals went unlabeled (e.g. https://github.com/pnpm/pnpm/pull/12482).

The new job mirrors the existing `on-coderabbit-approval` job: same `issues: write` / `pull-requests: write` permissions and the same `gh pr edit --add-label` step.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pull requests now automatically receive the "reviewed: qodo" label when reviewed by the qodo bot

<!-- end of auto-generated comment: release notes by coderabbit.ai -->