### PR TITLE
fix: avoid updating allowBuilds when workspace is ignored

### DIFF
--- a/.changeset/ignore-workspace-allow-builds.md
+++ b/.changeset/ignore-workspace-allow-builds.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.commands": patch
+"pnpm": patch
+---
+
+Fixed `pnpm install --ignore-workspace` overwriting the `allowBuilds` map in `pnpm-workspace.yaml`. The ignored builds of a package with a build script were auto-populated into `allowBuilds` even though `--ignore-workspace` was passed, clobbering committed `true`/`false` values with the `set this to true or false` placeholder [#12469](https://github.com/pnpm/pnpm/issues/12469).

--- a/config/reader/src/Config.ts
+++ b/config/reader/src/Config.ts
@@ -232,6 +232,7 @@ export interface Config extends OptionsFromRootManifest {
   dedupePeerDependents?: boolean
   dedupePeers?: boolean
   patchesDir?: string
+  ignoreWorkspace?: boolean
   ignoreWorkspaceCycles?: boolean
   disallowWorkspaceCycles?: boolean
   packGzipLevel?: number

--- a/installing/commands/src/handleIgnoredBuilds.ts
+++ b/installing/commands/src/handleIgnoredBuilds.ts
@@ -8,6 +8,7 @@ import { lexCompare } from '@pnpm/util.lex-comparator'
 
 export interface HandleIgnoredBuildsOpts {
   allowBuilds?: Record<string, boolean | string>
+  cliOptions?: Record<string, unknown>
   rootProjectManifestDir?: string
   workspaceDir?: string
   strictDepBuilds?: boolean
@@ -18,7 +19,9 @@ export async function handleIgnoredBuilds (
   ignoredBuilds: IgnoredBuilds | undefined
 ): Promise<void> {
   if (!ignoredBuilds?.size) return
-  await writeIgnoredBuildsToAllowBuilds(opts, ignoredBuilds)
+  if (!opts.cliOptions?.['ignore-workspace']) {
+    await writeIgnoredBuildsToAllowBuilds(opts, ignoredBuilds)
+  }
   if (opts.strictDepBuilds) {
     throw new IgnoredBuildsError(ignoredBuilds)
   }

--- a/installing/commands/src/handleIgnoredBuilds.ts
+++ b/installing/commands/src/handleIgnoredBuilds.ts
@@ -19,7 +19,6 @@ export async function handleIgnoredBuilds (
   ignoredBuilds: IgnoredBuilds | undefined
 ): Promise<void> {
   if (!ignoredBuilds?.size) return
-  // allowBuilds is persisted in pnpm-workspace.yaml, which --ignore-workspace must not touch.
   if (!opts.ignoreWorkspace) {
     await writeIgnoredBuildsToAllowBuilds(opts, ignoredBuilds)
   }

--- a/installing/commands/src/handleIgnoredBuilds.ts
+++ b/installing/commands/src/handleIgnoredBuilds.ts
@@ -8,7 +8,7 @@ import { lexCompare } from '@pnpm/util.lex-comparator'
 
 export interface HandleIgnoredBuildsOpts {
   allowBuilds?: Record<string, boolean | string>
-  cliOptions?: Record<string, unknown>
+  ignoreWorkspace?: boolean
   rootProjectManifestDir?: string
   workspaceDir?: string
   strictDepBuilds?: boolean
@@ -19,7 +19,8 @@ export async function handleIgnoredBuilds (
   ignoredBuilds: IgnoredBuilds | undefined
 ): Promise<void> {
   if (!ignoredBuilds?.size) return
-  if (!opts.cliOptions?.['ignore-workspace']) {
+  // allowBuilds is persisted in pnpm-workspace.yaml, which --ignore-workspace must not touch.
+  if (!opts.ignoreWorkspace) {
     await writeIgnoredBuildsToAllowBuilds(opts, ignoredBuilds)
   }
   if (opts.strictDepBuilds) {

--- a/installing/commands/src/installDeps.ts
+++ b/installing/commands/src/installDeps.ts
@@ -117,6 +117,7 @@ export type InstallDepsOptions = Pick<Config,
 | 'workspaceDir'
 | 'workspacePackagePatterns'
 | 'extraEnv'
+| 'ignoreWorkspace'
 | 'ignoreWorkspaceCycles'
 | 'disallowWorkspaceCycles'
 | 'configDependencies'

--- a/installing/commands/test/handleIgnoredBuilds.ts
+++ b/installing/commands/test/handleIgnoredBuilds.ts
@@ -22,7 +22,7 @@ test('handleIgnoredBuilds does not update pnpm-workspace.yaml when workspace is 
   const workspaceManifestBefore = fs.readFileSync(workspaceManifestFile, 'utf8')
 
   await handleIgnoredBuilds({
-    cliOptions: { 'ignore-workspace': true },
+    ignoreWorkspace: true,
     rootProjectManifestDir: process.cwd(),
   }, new Set(['esbuild@0.25.0' as DepPath]))
 

--- a/installing/commands/test/handleIgnoredBuilds.ts
+++ b/installing/commands/test/handleIgnoredBuilds.ts
@@ -1,0 +1,31 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import { prepareEmpty } from '@pnpm/prepare'
+import type { DepPath } from '@pnpm/types'
+import { readYamlFileSync } from 'read-yaml-file'
+import { writeYamlFileSync } from 'write-yaml-file'
+
+import { handleIgnoredBuilds } from '../lib/handleIgnoredBuilds.js'
+
+test('handleIgnoredBuilds does not update pnpm-workspace.yaml when workspace is ignored', async () => {
+  prepareEmpty()
+
+  const workspaceManifestFile = path.resolve('pnpm-workspace.yaml')
+  const workspaceManifest = {
+    allowBuilds: {
+      esbuild: false,
+    },
+  }
+  writeYamlFileSync(workspaceManifestFile, workspaceManifest)
+  const workspaceManifestBefore = fs.readFileSync(workspaceManifestFile, 'utf8')
+
+  await handleIgnoredBuilds({
+    cliOptions: { 'ignore-workspace': true },
+    rootProjectManifestDir: process.cwd(),
+  }, new Set(['esbuild@0.25.0' as DepPath]))
+
+  expect(fs.readFileSync(workspaceManifestFile, 'utf8')).toBe(workspaceManifestBefore)
+  expect(readYamlFileSync(workspaceManifestFile)).toStrictEqual(workspaceManifest)
+})

--- a/pnpm/test/install/lifecycleScripts.ts
+++ b/pnpm/test/install/lifecycleScripts.ts
@@ -333,6 +333,24 @@ test('auto-populated placeholders are merged with existing allowBuilds', async (
   expect(manifest?.allowBuilds?.['@pnpm.e2e/pre-and-postinstall-scripts-example']).toBe('set this to true or false')
 })
 
+test('install --ignore-workspace does not overwrite allowBuilds in pnpm-workspace.yaml', () => {
+  prepare({
+    dependencies: {
+      '@pnpm.e2e/pre-and-postinstall-scripts-example': '1.0.0',
+    },
+  })
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    allowBuilds: {
+      '@pnpm.e2e/pre-and-postinstall-scripts-example': false,
+    },
+  })
+  const manifestBefore = fs.readFileSync('pnpm-workspace.yaml', 'utf8')
+
+  execPnpmSync(['install', '--ignore-workspace'])
+
+  expect(fs.readFileSync('pnpm-workspace.yaml', 'utf8')).toBe(manifestBefore)
+})
+
 test('selective rebuild preserves ignoredBuilds for packages not being rebuilt', async () => {
   const project = prepare({})
   writeYamlFileSync('pnpm-workspace.yaml', {

--- a/pnpm/test/install/lifecycleScripts.ts
+++ b/pnpm/test/install/lifecycleScripts.ts
@@ -346,8 +346,13 @@ test('install --ignore-workspace does not overwrite allowBuilds in pnpm-workspac
   })
   const manifestBefore = fs.readFileSync('pnpm-workspace.yaml', 'utf8')
 
-  execPnpmSync(['install', '--ignore-workspace'])
+  const { status, stdout, stderr } = execPnpmSync(['install', '--ignore-workspace'])
 
+  // The build is ignored (--ignore-workspace skips the allowBuilds entry), so the
+  // install ends in ERR_PNPM_IGNORED_BUILDS — the same code path that would have
+  // written the placeholder. The manifest must stay untouched regardless.
+  expect(status).toBe(1)
+  expect(`${stdout}${stderr}`).toContain('ERR_PNPM_IGNORED_BUILDS')
   expect(fs.readFileSync('pnpm-workspace.yaml', 'utf8')).toBe(manifestBefore)
 })
 


### PR DESCRIPTION
## Summary

`pnpm install --ignore-workspace` was rewriting the `allowBuilds` map in `pnpm-workspace.yaml`. When a dependency has a build script, its ignored build was auto-populated into `allowBuilds` even though `--ignore-workspace` was passed, clobbering committed `true`/`false` values with the placeholder `set this to true or false` — and it did so even under `--frozen-lockfile`, which should never mutate the file.

This PR skips writing ignored builds into `allowBuilds` when the workspace is ignored, so `pnpm-workspace.yaml` is left untouched. The strict ignored-build failure (`ERR_PNPM_IGNORED_BUILDS`) is preserved.

Fixes pnpm/pnpm#12469

## Squash Commit Body

```text
pnpm install --ignore-workspace auto-populated ignored builds into the
allowBuilds map of pnpm-workspace.yaml, overwriting committed true/false
values with the "set this to true or false" placeholder — even under
--frozen-lockfile, which must stay read-only.

The ignore-workspace CLI flag is now a first-class Config field
(ignoreWorkspace, mirroring ignoreWorkspaceCycles) instead of being read
from the untyped cliOptions bag. handleIgnoredBuilds reads it directly and
skips writing to allowBuilds when the workspace is ignored. The strict
ignored-build failure is unchanged.

Closes pnpm/pnpm#12469
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  <!-- No pacquet port needed: pacquet has no allowBuilds placeholder
  auto-write feature (it errors with ERR_PNPM_IGNORED_BUILDS instead), so
  there is no equivalent code path to change. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-4-8).