### PR TITLE
fix(ci): run PR review automation for fork PRs via workflow_run

### DIFF
--- a/.github/workflows/pr-review-automation-privileged.yml
+++ b/.github/workflows/pr-review-automation-privileged.yml
@@ -32,8 +32,10 @@ jobs:
       issues: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Webhook URL is optional; the Discord step is skipped when the secret is unset.
-      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      # The webhook is optional; the Discord step is skipped when it is unset. Only
+      # a non-secret boolean is exposed job-wide — the secret itself is scoped to
+      # the Discord step. (Step-level env is not visible to that step's own `if`.)
+      HAS_DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK != '' }}
     steps:
       - name: Download the event artifact
         id: download
@@ -101,9 +103,10 @@ jobs:
         if: >-
           steps.event.outcome == 'success' &&
           steps.event.outputs.announce == 'true' &&
-          env.DISCORD_WEBHOOK != ''
+          env.HAS_DISCORD_WEBHOOK == 'true'
         env:
           PR_NUMBER: ${{ steps.event.outputs.pr_number }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |
           # PR title and URL are read as data and passed via jq --arg, never as code.
           # allowed_mentions parse:[] stops a PR title like "@everyone" from pinging the Discord server.

--- a/.github/workflows/pr-review-automation-privileged.yml
+++ b/.github/workflows/pr-review-automation-privileged.yml
@@ -25,6 +25,8 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
+      # Downloading an artifact from the triggering run requires actions: read.
+      actions: read
       # Adding a label via the issues REST API is governed by issues: write
       # even when the target is a PR.
       issues: write
@@ -71,7 +73,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Add the reviewed label
-        if: steps.download.outcome == 'success'
+        if: steps.event.outcome == 'success'
         env:
           PR_NUMBER: ${{ steps.event.outputs.pr_number }}
           LABEL: ${{ steps.event.outputs.label }}
@@ -82,7 +84,7 @@ jobs:
 
       - name: Announce on Discord
         if: >-
-          steps.download.outcome == 'success' &&
+          steps.event.outcome == 'success' &&
           steps.event.outputs.announce == 'true' &&
           env.DISCORD_WEBHOOK != ''
         env:

--- a/.github/workflows/pr-review-automation-privileged.yml
+++ b/.github/workflows/pr-review-automation-privileged.yml
@@ -1,0 +1,108 @@
+name: PR review automation (privileged)
+
+# Privileged follow-up to "PR review automation". A workflow_run trigger always
+# executes from the base repository's default branch with a write-scoped token
+# and access to secrets, even when the originating PR came from a fork (where the
+# pull_request_review run is denied both). This job performs only fixed,
+# repo-controlled actions — adding a known label and posting to Discord — on data
+# read from the artifact as inert files. It never checks out or executes PR content.
+on:
+  # zizmor: ignore[dangerous-triggers]
+  # The capture workflow runs with no token permissions and produces only inert
+  # data files. This workflow runs from the default branch via workflow_run,
+  # validates that data, then performs fixed repo-controlled actions (label +
+  # Discord) without ever checking out or executing PR content.
+  workflow_run:
+    workflows: ["PR review automation"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  act:
+    if: >-
+      github.event.workflow_run.event == 'pull_request_review' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      # Adding a label via the issues REST API is governed by issues: write
+      # even when the target is a PR.
+      issues: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Webhook URL is optional; the Discord step is skipped when the secret is unset.
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+    steps:
+      - name: Download the event artifact
+        id: download
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        # The capture job is skipped for non-approval reviews, leaving no artifact;
+        # tolerate its absence instead of failing the run.
+        continue-on-error: true
+        with:
+          name: pr-review-event
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: pr-review-event
+
+      - name: Parse the event
+        id: event
+        if: steps.download.outcome == 'success'
+        run: |
+          # The artifact is influenced by the fork PR; treat it as untrusted.
+          reviewer="$(cat pr-review-event/reviewer)"
+          pr_number="$(cat pr-review-event/pr_number)"
+          # Reject anything that is not a plain integer to keep it out of the API path.
+          if ! printf '%s' "$pr_number" | grep -qE '^[0-9]+$'; then
+            echo "Invalid PR number: $pr_number" >&2
+            exit 1
+          fi
+          case "$reviewer" in
+            'coderabbitai[bot]') label='reviewed: coderabbit'; announce=true ;;
+            'qodo-free-for-open-source-projects[bot]') label='reviewed: qodo'; announce=false ;;
+            'zkochan') label='state: automerge'; announce=false ;;
+            *) echo "Unexpected reviewer: $reviewer" >&2; exit 1 ;;
+          esac
+          {
+            echo "pr_number=$pr_number"
+            echo "label=$label"
+            echo "announce=$announce"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Add the reviewed label
+        if: steps.download.outcome == 'success'
+        env:
+          PR_NUMBER: ${{ steps.event.outputs.pr_number }}
+          LABEL: ${{ steps.event.outputs.label }}
+        run: |
+          # gh pr edit --add-label is broken (it errors on the deprecated Projects-v1
+          # GraphQL field), so add the label through the issues REST API instead.
+          gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" -f "labels[]=$LABEL"
+
+      - name: Announce on Discord
+        if: >-
+          steps.download.outcome == 'success' &&
+          steps.event.outputs.announce == 'true' &&
+          env.DISCORD_WEBHOOK != ''
+        env:
+          PR_NUMBER: ${{ steps.event.outputs.pr_number }}
+        run: |
+          # PR title and URL are read as data and passed via jq --arg, never as code.
+          # allowed_mentions parse:[] stops a PR title like "@everyone" from pinging the Discord server.
+          title="$(cat pr-review-event/title)"
+          url="$(cat pr-review-event/url)"
+          payload="$(jq -n \
+            --arg n "$PR_NUMBER" \
+            --arg t "$title" \
+            --arg u "$url" \
+            '{content: ("✅ CodeRabbit approved PR #" + $n + ": " + $t + "\n" + $u), allowed_mentions: {parse: []}}')"
+          curl -fsS \
+            --connect-timeout 5 \
+            --max-time 20 \
+            --retry 3 \
+            --retry-all-errors \
+            --retry-delay 2 \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "$DISCORD_WEBHOOK"

--- a/.github/workflows/pr-review-automation-privileged.yml
+++ b/.github/workflows/pr-review-automation-privileged.yml
@@ -28,9 +28,8 @@ jobs:
       # Downloading an artifact from the triggering run requires actions: read.
       actions: read
       # Adding a label via the issues REST API is governed by issues: write
-      # even when the target is a PR.
+      # even when the target is a PR. No other scope is needed.
       issues: write
-      pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Webhook URL is optional; the Discord step is skipped when the secret is unset.
@@ -47,6 +46,22 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: pr-review-event
+
+      - name: Distinguish a missing artifact from a failed download
+        if: steps.download.outcome != 'success'
+        env:
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          # No artifact is the expected, benign case: the capture job is skipped for
+          # non-approval reviews. But if the artifact does exist and we still failed
+          # to download it, the run would otherwise pass as a silent no-op — surface
+          # that as an error so a missed label/announcement is observable in CI.
+          artifacts="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/artifacts" --paginate --jq '.artifacts[].name')"
+          if printf '%s\n' "$artifacts" | grep -qx 'pr-review-event'; then
+            echo "::error::pr-review-event artifact exists but could not be downloaded"
+            exit 1
+          fi
+          echo "::notice::No pr-review-event artifact (non-approval review); nothing to do"
 
       - name: Parse the event
         id: event

--- a/.github/workflows/pr-review-automation.yml
+++ b/.github/workflows/pr-review-automation.yml
@@ -1,99 +1,45 @@
 name: PR review automation
 
-# React to PR review submissions: announce CodeRabbit approvals, tag PRs that the
-# AI reviewers approved, and flag maintainer-approved PRs for automerge.
+# Capture PR review approvals from the AI reviewers and the maintainer. This
+# workflow only records the event as an artifact; the privileged follow-up
+# (pr-review-automation-privileged.yml) adds the label and posts to Discord.
+#
+# The split exists because pull_request_review runs triggered by a forked PR are
+# given a read-only token and no secrets, so the label/Discord steps cannot run
+# here. A workflow_run-triggered companion runs in the base-repo context with the
+# permissions and secrets those steps need.
 on:
   pull_request_review:
     types: [submitted]
 
-# No permissions by default; each job grants only what it needs.
 permissions: {}
 
 jobs:
-  on-coderabbit-approval:
+  capture:
     if: >-
       github.event.review.state == 'approved' &&
-      github.event.review.user.login == 'coderabbitai[bot]'
+      contains(fromJSON('["coderabbitai[bot]", "qodo-free-for-open-source-projects[bot]", "zkochan"]'), github.event.review.user.login)
     runs-on: ubuntu-latest
-    permissions:
-      # Adding a label via the issues REST API is governed by issues: write
-      # even when the target is a PR.
-      issues: write
-      pull-requests: write
+    permissions: {}
     env:
-      # Webhook URL is optional; the Discord step is skipped when the secret is unset.
-      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-      # PR fields are passed through the environment, never interpolated into a run script,
+      # PR fields are written to inert files, never interpolated into a script,
       # so an attacker-controlled PR title cannot inject shell commands.
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_URL: ${{ github.event.pull_request.html_url }}
+      REVIEWER: ${{ github.event.review.user.login }}
     steps:
-      - name: Add the reviewed label
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Record the review event
         run: |
-          # gh pr edit --add-label is broken (it errors on the deprecated Projects-v1
-          # GraphQL field), so add the label through the issues REST API instead.
-          gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" -f "labels[]=reviewed: coderabbit"
+          mkdir -p pr-review-event
+          printf '%s' "$PR_NUMBER" > pr-review-event/pr_number
+          printf '%s' "$REVIEWER" > pr-review-event/reviewer
+          printf '%s' "$PR_TITLE" > pr-review-event/title
+          printf '%s' "$PR_URL" > pr-review-event/url
 
-      - name: Announce on Discord
-        if: ${{ env.DISCORD_WEBHOOK != '' }}
-        run: |
-          # allowed_mentions parse:[] stops a PR title like "@everyone" from pinging the Discord server.
-          payload="$(jq -n \
-            --arg n "$PR_NUMBER" \
-            --arg t "$PR_TITLE" \
-            --arg u "$PR_URL" \
-            '{content: ("✅ CodeRabbit approved PR #" + $n + ": " + $t + "\n" + $u), allowed_mentions: {parse: []}}')"
-          curl -fsS \
-            --connect-timeout 5 \
-            --max-time 20 \
-            --retry 3 \
-            --retry-all-errors \
-            --retry-delay 2 \
-            -H "Content-Type: application/json" \
-            -d "$payload" \
-            "$DISCORD_WEBHOOK"
-
-  on-qodo-approval:
-    if: >-
-      github.event.review.state == 'approved' &&
-      github.event.review.user.login == 'qodo-free-for-open-source-projects[bot]'
-    runs-on: ubuntu-latest
-    permissions:
-      # Adding a label via the issues REST API is governed by issues: write
-      # even when the target is a PR.
-      issues: write
-      pull-requests: write
-    env:
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-    steps:
-      - name: Add the reviewed label
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # gh pr edit --add-label is broken (it errors on the deprecated Projects-v1
-          # GraphQL field), so add the label through the issues REST API instead.
-          gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" -f "labels[]=reviewed: qodo"
-
-  on-maintainer-approval:
-    if: >-
-      github.event.review.state == 'approved' &&
-      github.event.review.user.login == 'zkochan'
-    runs-on: ubuntu-latest
-    permissions:
-      # Adding a label via the issues REST API is governed by issues: write
-      # even when the target is a PR.
-      issues: write
-      pull-requests: write
-    env:
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-    steps:
-      - name: Flag for automerge
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # gh pr edit --add-label is broken (it errors on the deprecated Projects-v1
-          # GraphQL field), so add the label through the issues REST API instead.
-          gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" -f "labels[]=state: automerge"
+      - name: Upload the event artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-review-event
+          path: pr-review-event/
+          retention-days: 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,6 +296,7 @@ try {
 
 ## Working with GitHub PRs, Issues, and Comments
 
+-   **Open every PR with the repository template.** `gh pr create` does not apply `.github/pull_request_template.md` automatically, so read that file and pass its filled-in contents as the PR body (`--body`/`--body-file`). Keep every section (Summary, Squash Commit Body, Checklist), fill them in for this change, mark the checklist items, and remove only the lines the template says are inapplicable.
 -   **Keep PR titles and descriptions current.** When pushing new changes to a PR, review the title and description and update them if they no longer accurately reflect what the PR does.
 -   **Reply to and resolve review conversations.** Once a review comment has been addressed, reply to the thread with a description of the resolution including the commit hash that fixed it, then mark the conversation as resolved.
 -   **Sign all agent-authored content.** When posting a comment, creating an issue, or opening a PR, append a footer to the message indicating that it was written by an agent. The footer must include the name of the agent and the name of the model used. Example:


### PR DESCRIPTION
## Summary

Approvals on PRs from forks never received the `reviewed: coderabbit` label or a Discord announcement (e.g. https://github.com/pnpm/pnpm/pull/12491). A `pull_request_review` run triggered by a forked PR is granted a read-only token and no secrets, so the label step failed with HTTP 403 and the Discord step had no webhook.

This splits the automation into the standard capture + privileged-act pattern:

- `pr-review-automation.yml` (`pull_request_review`) now runs with `permissions: {}` and only records the approval as an inert artifact — works for fork PRs because uploading needs no token scope or secrets.
- `pr-review-automation-privileged.yml` (new, `workflow_run`) runs from the default branch in base-repo context, where it has the write-scoped token and secrets. It downloads the artifact, validates the PR number, maps the reviewer to the right label, adds it, and posts the CodeRabbit announcement to Discord.

It also adds an agent instruction to open PRs using `.github/pull_request_template.md`, since `gh pr create` does not apply the template automatically.

Related to https://github.com/pnpm/pnpm/pull/12491 (the fork PR whose approval went unprocessed).

## Squash Commit Body

```text
Approvals on PRs from forks never got the `reviewed: coderabbit` label or a
Discord announcement. A pull_request_review run triggered by a forked PR is
granted a read-only token and no secrets, so the label step failed with HTTP
403 and the Discord step had no webhook.

Split the automation in two: the pull_request_review workflow now only records
the approval as an artifact (no token, no secrets), and a new workflow_run
companion runs from the default branch in base-repo context — where it has the
write-scoped token and secrets — to add the label and post to Discord.

The privileged half never checks out or executes PR content: it reads inert
data files, validates the PR number is an integer, maps the reviewer to a fixed
label, requests only actions:read + issues:write, surfaces a failed (vs absent)
artifact download instead of passing as a silent no-op, and scopes the Discord
webhook secret to the announce step.

Also documents that agents must open PRs using .github/pull_request_template.md,
since gh pr create does not apply it automatically.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. — CI/repo tooling only; no CLI surface, nothing to port to pacquet.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note. — Not applicable: changes only `.github/` workflows and `AGENTS.md`, no published package.
- [x] Added or updated tests. — Not applicable: GitHub Actions workflow; validated with `actionlint` and `zizmor`.
- [x] Updated the documentation if needed. — Updated `AGENTS.md` with the PR-template instruction.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined pull request review automation to capture only approved reviews from designated reviewer accounts.
  * Removed earlier automation that directly applied labels and sent approval announcements as part of the main workflow.
  * Added a privileged follow-up workflow that, after a successful capture, applies the computed label and optionally posts a Discord announcement for selected cases.
* **Documentation**
  * Updated agent contribution guidance to start each pull request using the repository’s pull request template and fully complete applicable sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->