### PR TITLE
fix(hoist): replace stale non-GVS symlinks when enable-global-virtual-store is toggled on

### DIFF
--- a/.changeset/gvs-replace-stale-hoisted-symlinks.md
+++ b/.changeset/gvs-replace-stale-hoisted-symlinks.md
@@ -4,5 +4,3 @@
 ---
 
 When `enable-global-virtual-store` is toggled on for a project that was previously installed without it, stale hoisted symlinks under `node_modules/.pnpm/node_modules` are now replaced instead of being left pointing at the old per-project virtual store location [#9739](https://github.com/pnpm/pnpm/issues/9739).
-</content>
-</invoke>

--- a/.changeset/gvs-replace-stale-hoisted-symlinks.md
+++ b/.changeset/gvs-replace-stale-hoisted-symlinks.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/installing.linking.hoist": patch
+"pnpm": patch
+---
+
+When `enable-global-virtual-store` is toggled on for a project that was previously installed without it, stale hoisted symlinks under `node_modules/.pnpm/node_modules` are now replaced instead of being left pointing at the old per-project virtual store location [#9739](https://github.com/pnpm/pnpm/issues/9739).
+</content>
+</invoke>

--- a/.changeset/gvs-replace-stale-hoisted-symlinks.md
+++ b/.changeset/gvs-replace-stale-hoisted-symlinks.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-When `enable-global-virtual-store` is toggled on for a project that was previously installed without it, stale hoisted symlinks under `node_modules/.pnpm/node_modules` are now replaced instead of being left pointing at the old per-project virtual store location [#9739](https://github.com/pnpm/pnpm/issues/9739).
+When `enableGlobalVirtualStore` is toggled on for a project that was previously installed without it, stale hoisted symlinks under `node_modules/.pnpm/node_modules` are now replaced instead of being left pointing at the old per-project virtual store location [#9739](https://github.com/pnpm/pnpm/issues/9739).

--- a/installing/linking/hoist/src/index.ts
+++ b/installing/linking/hoist/src/index.ts
@@ -276,7 +276,10 @@ async function symlinkHoistedDependencies<T extends string> (
     hoistedWorkspacePackages?: Record<string, HoistedWorkspaceProject>
   }
 ): Promise<void> {
-  const symlink = symlinkHoistedDependency.bind(null, opts)
+  const symlink = symlinkHoistedDependency.bind(null, {
+    virtualStoreDir: opts.virtualStoreDir,
+    internalPnpmDir: path.dirname(opts.privateHoistedModulesDir),
+  })
   const promises: Array<Promise<void>> = []
   for (const [hoistedDepNodeId, pkgAliases] of hoistedDependenciesByNodeId.entries()) {
     promises.push((async () => {
@@ -305,7 +308,7 @@ async function symlinkHoistedDependencies<T extends string> (
 }
 
 async function symlinkHoistedDependency (
-  opts: { virtualStoreDir: string },
+  opts: { virtualStoreDir: string, internalPnpmDir: string },
   depLocation: string,
   dest: string
 ): Promise<void> {
@@ -326,7 +329,7 @@ async function symlinkHoistedDependency (
     })
     return
   }
-  if (!isSubdir(opts.virtualStoreDir, existingSymlink)) {
+  if (!isSubdir(opts.virtualStoreDir, existingSymlink) && !isSubdir(opts.internalPnpmDir, existingSymlink)) {
     hoistLogger.debug({
       skipped: dest,
       existingSymlink,

--- a/pacquet/crates/cli/tests/hoist.rs
+++ b/pacquet/crates/cli/tests/hoist.rs
@@ -641,17 +641,6 @@ mod known_failures {
         ))
     }
 
-    fn external_symlink_introspection() -> KnownResult<()> {
-        Err(KnownFailure::new(
-            "Pacquet's `symlink_package` swallows EEXIST silently — the \
-             conservative path. Upstream additionally introspects the \
-             existing entry via `resolveLinkTarget` + `isSubdir` to \
-             distinguish a real directory (preserve), an external \
-             symlink (preserve), and a virtual-store-resident symlink \
-             (overwrite). That introspection isn't ported yet.",
-        ))
-    }
-
     /// Upstream: [`hoist.ts:24` "should hoist dependencies"](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/test/install/hoist.ts#L24).
     /// Repeats the install both as non-headless and as
     /// `frozenLockfile: true` to assert `hoistedDependencies` is
@@ -661,18 +650,6 @@ mod known_failures {
     #[test]
     fn should_hoist_dependencies_repeat_install_preserves_map() {
         allow_known_failure!(partial_install_persists_hoisted_map());
-    }
-
-    /// Upstream: [`hoist.ts:71` "public hoist should not override directories that are already in the root of node_modules"](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/test/install/hoist.ts#L71).
-    /// Tests that pre-existing real directories at the public hoist
-    /// target are preserved. Pacquet's `symlink_package` returns Ok
-    /// on `EEXIST` — the conservative path — but the upstream test
-    /// also covers the "external symlink" case which requires the
-    /// `resolveLinkTarget` + `isSubdir` introspection pacquet doesn't
-    /// yet do.
-    #[test]
-    fn public_hoist_preserves_existing_root_directories() {
-        allow_known_failure!(external_symlink_introspection());
     }
 
     /// Upstream: [`hoist.ts:121` "should remove hoisted dependencies"](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/test/install/hoist.ts#L121).

--- a/pacquet/crates/package-manager/src/hoist.rs
+++ b/pacquet/crates/package-manager/src/hoist.rs
@@ -432,13 +432,14 @@ struct BfsEntry<'a> {
 /// (`<virtual_store_dir>/<key.virtual_store_name>/`); the hoist code
 /// never has to branch on `enable_global_virtual_store` itself.
 ///
-/// Existing symlinks are left in place — `EEXIST` from the underlying
-/// [`pacquet_fs::symlink_dir`] is swallowed, mirroring upstream's
-/// `symlinkDir({ overwrite: false })`. The "overwrite a
-/// virtual-store-resident link" branch upstream additionally does
-/// (via `resolveLinkTarget` + `isSubdir`) is intentionally not
-/// ported — see the `external_symlink_introspection` `known_failure`
-/// reason.
+/// Existing symlinks are introspected — if the existing entry is a
+/// symlink pointing at a target inside the virtual store
+/// (`layout.package_store_dir()` — the GVS links dir or the local
+/// `.pnpm` dir) or inside the internal pnpm directory (the parent of
+/// `private_hoisted_modules_dir`), the stale symlink is replaced.
+/// External symlinks (or non-symlink occupants) are left in place.
+/// Mirrors upstream's `resolveLinkTarget` + `isSubdir` pattern in
+/// [`symlinkHoistedDependency`](https://github.com/pnpm/pnpm/blob/cbe1a171bd/installing/linking/hoist/src/index.ts#L310-L343).
 ///
 /// Two-phase to amortize directory creation:
 ///
@@ -549,7 +550,16 @@ pub fn symlink_hoisted_dependencies(
             let dest = target_dir_root.join(alias);
             match pacquet_fs::symlink_dir(dep_dir.as_path(), &dest) {
                 Ok(()) => Ok(()),
-                Err(error) if error.kind() == ErrorKind::AlreadyExists => Ok(()),
+                Err(ref error) if error.kind() == ErrorKind::AlreadyExists => {
+                    update_stale_hoist_symlink(
+                        dep_dir.as_path(),
+                        &dest,
+                        layout.package_store_dir(),
+                        private_hoisted_modules_dir.parent().expect(
+                            "private_hoisted_modules_dir (<vs>/node_modules) always has a parent",
+                        ),
+                    )
+                }
                 Err(error) => Err(crate::SymlinkPackageError::SymlinkDir {
                     symlink_target: dep_dir.as_path().to_path_buf(),
                     symlink_path: dest,
@@ -569,6 +579,48 @@ fn name_to_dir(name: &PkgName) -> std::path::PathBuf {
         Some(scope) => std::path::PathBuf::from(format!("@{scope}")).join(&name.bare),
         None => std::path::PathBuf::from(&name.bare),
     }
+}
+
+/// Read the existing symlink at `dest` and decide whether it should
+/// be replaced. If it points inside `package_store_dir` or
+/// `internal_pnpm_dir` (a pnpm-internal symlink — e.g., a stale link
+/// from a prior non-GVS install), remove it and create a new symlink
+/// to `dep_dir`. External symlinks are left in place.
+///
+/// Mirrors upstream's
+/// [`symlinkHoistedDependency`](https://github.com/pnpm/pnpm/blob/cbe1a171bd/installing/linking/hoist/src/index.ts#L310-L343)
+/// `isSubdir(virtualStoreDir, …) || isSubdir(internalPnpmDir, …)` guard.
+fn update_stale_hoist_symlink(
+    dep_dir: &std::path::Path,
+    dest: &std::path::Path,
+    package_store_dir: &std::path::Path,
+    internal_pnpm_dir: &std::path::Path,
+) -> Result<(), crate::SymlinkPackageError> {
+    let Ok(existing_raw) = pacquet_fs::read_symlink_dir(dest) else {
+        return Ok(());
+    };
+    let existing = if existing_raw.is_relative() {
+        dest.parent().unwrap_or_else(|| std::path::Path::new("")).join(&existing_raw)
+    } else {
+        existing_raw
+    };
+    if !pacquet_fs::is_subdir(package_store_dir, &existing)
+        && !pacquet_fs::is_subdir(internal_pnpm_dir, &existing)
+    {
+        return Ok(());
+    }
+    pacquet_fs::remove_symlink_dir(dest).map_err(|error| {
+        crate::SymlinkPackageError::SymlinkDir {
+            symlink_target: dep_dir.to_path_buf(),
+            symlink_path: dest.to_path_buf(),
+            error,
+        }
+    })?;
+    pacquet_fs::symlink_dir(dep_dir, dest).map_err(|error| crate::SymlinkPackageError::SymlinkDir {
+        symlink_target: dep_dir.to_path_buf(),
+        symlink_path: dest.to_path_buf(),
+        error,
+    })
 }
 
 #[cfg(test)]

--- a/pacquet/crates/package-manager/src/hoist.rs
+++ b/pacquet/crates/package-manager/src/hoist.rs
@@ -582,14 +582,19 @@ fn name_to_dir(name: &PkgName) -> std::path::PathBuf {
 }
 
 /// Read the existing symlink at `dest` and decide whether it should
-/// be replaced. If it points inside `package_store_dir` or
-/// `internal_pnpm_dir` (a pnpm-internal symlink — e.g., a stale link
-/// from a prior non-GVS install), remove it and create a new symlink
-/// to `dep_dir`. External symlinks are left in place.
+/// be replaced. If it already points at `dep_dir`, leave it untouched.
+/// If it points inside `package_store_dir` or `internal_pnpm_dir`
+/// (a pnpm-internal symlink — e.g., a stale link from a prior non-GVS
+/// install), remove it and create a new symlink to `dep_dir`. External
+/// symlinks (and non-symlink occupants) are left in place.
 ///
 /// Mirrors upstream's
 /// [`symlinkHoistedDependency`](https://github.com/pnpm/pnpm/blob/cbe1a171bd/installing/linking/hoist/src/index.ts#L310-L343)
 /// `isSubdir(virtualStoreDir, …) || isSubdir(internalPnpmDir, …)` guard.
+/// The already-correct fast path skips the unlink + recreate churn (and
+/// the transient missing-link window it opens) on warm reinstalls, the
+/// same way [`pacquet_fs::force_symlink_dir`] does — see its
+/// `existing_symlink_up_to_date` helper.
 fn update_stale_hoist_symlink(
     dep_dir: &std::path::Path,
     dest: &std::path::Path,
@@ -604,6 +609,9 @@ fn update_stale_hoist_symlink(
     } else {
         existing_raw
     };
+    if pacquet_fs::lexical_normalize(&existing) == pacquet_fs::lexical_normalize(dep_dir) {
+        return Ok(());
+    }
     if !pacquet_fs::is_subdir(package_store_dir, &existing)
         && !pacquet_fs::is_subdir(internal_pnpm_dir, &existing)
     {

--- a/pacquet/crates/package-manager/src/hoist/tests.rs
+++ b/pacquet/crates/package-manager/src/hoist/tests.rs
@@ -591,6 +591,36 @@ fn update_stale_hoist_symlink_preserves_regular_directory() {
     assert!(dest.is_dir(), "regular directory must be preserved");
 }
 
+#[cfg(unix)]
+#[test]
+fn update_stale_hoist_symlink_is_noop_when_already_correct() {
+    use std::os::unix::fs::MetadataExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let virtual_store_dir = dir.path().join("store/links");
+    std::fs::create_dir_all(&virtual_store_dir).unwrap();
+    let internal_pnpm_dir = dir.path().join("node_modules/.pnpm");
+    std::fs::create_dir_all(&internal_pnpm_dir).unwrap();
+    let private_hoisted = internal_pnpm_dir.join("node_modules");
+    std::fs::create_dir_all(&private_hoisted).unwrap();
+
+    let dep_dir = virtual_store_dir.join("@scope/name/1.0.0/hash/node_modules/@scope/name");
+    std::fs::create_dir_all(&dep_dir).unwrap();
+    let dest = private_hoisted.join("already-correct-dep");
+    pacquet_fs::symlink_dir(&dep_dir, &dest).unwrap();
+
+    let ino_before = std::fs::symlink_metadata(&dest).unwrap().ino();
+
+    super::update_stale_hoist_symlink(&dep_dir, &dest, &virtual_store_dir, &internal_pnpm_dir)
+        .expect("should leave an already-correct symlink untouched");
+
+    let ino_after = std::fs::symlink_metadata(&dest).unwrap().ino();
+    assert_eq!(
+        ino_before, ino_after,
+        "an already-correct symlink must not be unlinked and recreated",
+    );
+}
+
 /// Helper: extract the (alias, kind) pairs at a given snapshot key
 /// for assertion purposes. Sorted for stable comparison.
 fn kinds_for(map: &HoistedDependencies, key: &str) -> Vec<(String, HoistKind)> {

--- a/pacquet/crates/package-manager/src/hoist/tests.rs
+++ b/pacquet/crates/package-manager/src/hoist/tests.rs
@@ -474,6 +474,123 @@ fn build_hoist_graph_walks_dependencies() {
     assert!(!b_node.has_bin);
 }
 
+#[test]
+fn update_stale_hoist_symlink_replaces_virtual_store_resident_symlink() {
+    let dir = tempfile::tempdir().unwrap();
+    let virtual_store_dir = dir.path().join("store/links");
+    std::fs::create_dir_all(&virtual_store_dir).unwrap();
+    let internal_pnpm_dir = dir.path().join("node_modules/.pnpm");
+    std::fs::create_dir_all(&internal_pnpm_dir).unwrap();
+    let private_hoisted = internal_pnpm_dir.join("node_modules");
+    std::fs::create_dir_all(&private_hoisted).unwrap();
+
+    let dep_dir = virtual_store_dir.join("@scope/name/1.0.0/hash/node_modules/@scope/name");
+    std::fs::create_dir_all(&dep_dir).unwrap();
+    let dest = private_hoisted.join("stale-dep");
+
+    let stale_target = virtual_store_dir.join("old-dep/node_modules/old-dep");
+    std::fs::create_dir_all(stale_target.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(&stale_target).unwrap();
+    pacquet_fs::symlink_dir(&stale_target, &dest).unwrap();
+
+    super::update_stale_hoist_symlink(&dep_dir, &dest, &virtual_store_dir, &internal_pnpm_dir)
+        .expect("should replace virtual-store-resident symlink");
+
+    let new_target_raw = std::fs::read_link(&dest).unwrap();
+    let new_target_abs =
+        pacquet_fs::lexical_normalize(&dest.parent().unwrap().join(&new_target_raw));
+    assert!(
+        pacquet_fs::is_subdir(&virtual_store_dir, &new_target_abs),
+        "stale symlink should be replaced with new target under virtual store dir; \
+         readlink returned {new_target_raw:?} → {new_target_abs:?}, expected under {virtual_store_dir:?}",
+    );
+}
+
+#[test]
+fn update_stale_hoist_symlink_replaces_internal_pnpm_symlink() {
+    let dir = tempfile::tempdir().unwrap();
+    let virtual_store_dir = dir.path().join("store/links");
+    std::fs::create_dir_all(&virtual_store_dir).unwrap();
+    let internal_pnpm_dir = dir.path().join("node_modules/.pnpm");
+    std::fs::create_dir_all(&internal_pnpm_dir).unwrap();
+    let private_hoisted = internal_pnpm_dir.join("node_modules");
+    std::fs::create_dir_all(&private_hoisted).unwrap();
+
+    let dep_dir = virtual_store_dir.join("@scope/new-pkg/2.0.0/hash/node_modules/@scope/new-pkg");
+    std::fs::create_dir_all(&dep_dir).unwrap();
+    let dest = private_hoisted.join("stale-internal-dep");
+
+    let stale_target = internal_pnpm_dir.join("old-pkg/node_modules/old-pkg");
+    std::fs::create_dir_all(stale_target.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(&stale_target).unwrap();
+    pacquet_fs::symlink_dir(&stale_target, &dest).unwrap();
+
+    super::update_stale_hoist_symlink(&dep_dir, &dest, &virtual_store_dir, &internal_pnpm_dir)
+        .expect("should replace internal-pnpm-resident symlink");
+
+    let new_target_raw = std::fs::read_link(&dest).unwrap();
+    let new_target_abs =
+        pacquet_fs::lexical_normalize(&dest.parent().unwrap().join(&new_target_raw));
+    assert!(
+        pacquet_fs::is_subdir(&virtual_store_dir, &new_target_abs),
+        "stale symlink should be replaced with new target under virtual store dir; \
+         readlink returned {new_target_raw:?} → {new_target_abs:?}, expected under {virtual_store_dir:?}",
+    );
+}
+
+#[test]
+fn update_stale_hoist_symlink_preserves_external_symlink() {
+    let dir = tempfile::tempdir().unwrap();
+    let virtual_store_dir = dir.path().join("store/links");
+    std::fs::create_dir_all(&virtual_store_dir).unwrap();
+    let internal_pnpm_dir = dir.path().join("node_modules/.pnpm");
+    std::fs::create_dir_all(&internal_pnpm_dir).unwrap();
+    let private_hoisted = internal_pnpm_dir.join("node_modules");
+    std::fs::create_dir_all(&private_hoisted).unwrap();
+
+    let dep_dir = virtual_store_dir.join("@scope/name/1.0.0/hash/node_modules/@scope/name");
+    std::fs::create_dir_all(&dep_dir).unwrap();
+    let dest = private_hoisted.join("external-dep");
+
+    let external_target = dir.path().join("some-project/node_modules/external-pkg");
+    std::fs::create_dir_all(external_target.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(&external_target).unwrap();
+    pacquet_fs::symlink_dir(&external_target, &dest).unwrap();
+
+    super::update_stale_hoist_symlink(&dep_dir, &dest, &virtual_store_dir, &internal_pnpm_dir)
+        .expect("should preserve external symlink");
+
+    let target = std::fs::read_link(&dest).unwrap();
+    let target_abs = dest.parent().unwrap().join(&target);
+    assert!(
+        pacquet_fs::lexical_normalize(&target_abs)
+            == pacquet_fs::lexical_normalize(&external_target),
+        "external symlink must be preserved unchanged",
+    );
+}
+
+#[test]
+fn update_stale_hoist_symlink_preserves_regular_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let virtual_store_dir = dir.path().join("store/links");
+    std::fs::create_dir_all(&virtual_store_dir).unwrap();
+    let internal_pnpm_dir = dir.path().join("node_modules/.pnpm");
+    std::fs::create_dir_all(&internal_pnpm_dir).unwrap();
+    let private_hoisted = internal_pnpm_dir.join("node_modules");
+    std::fs::create_dir_all(&private_hoisted).unwrap();
+
+    let dep_dir = virtual_store_dir.join("@scope/name/1.0.0/hash/node_modules/@scope/name");
+    std::fs::create_dir_all(&dep_dir).unwrap();
+    let dest = private_hoisted.join("existing-dir-dep");
+
+    std::fs::create_dir(&dest).unwrap();
+
+    super::update_stale_hoist_symlink(&dep_dir, &dest, &virtual_store_dir, &internal_pnpm_dir)
+        .expect("should preserve directory");
+
+    assert!(dest.is_dir(), "regular directory must be preserved");
+}
+
 /// Helper: extract the (alias, kind) pairs at a given snapshot key
 /// for assertion purposes. Sorted for stable comparison.
 fn kinds_for(map: &HoistedDependencies, key: &str) -> Vec<(String, HoistKind)> {

--- a/pnpm/test/install/globalVirtualStore.ts
+++ b/pnpm/test/install/globalVirtualStore.ts
@@ -108,6 +108,45 @@ test('warm GVS reinstall skips internal linking', async () => {
   expect(fs.existsSync(path.resolve('node_modules/.pnpm/lock.yaml'))).toBeTruthy()
 })
 
+test('switching from non-GVS to GVS replaces stale hoisted symlinks', async () => {
+  prepare({
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+    },
+  })
+  const storeDir = path.resolve('store')
+
+  writeYamlFileSync(path.resolve('pnpm-workspace.yaml'), {
+    storeDir,
+    privateHoistPattern: '*',
+  })
+  await execPnpm(['install'])
+
+  const depOfPkgWith1Dep = path.resolve('node_modules/.pnpm/node_modules/@pnpm.e2e/dep-of-pkg-with-1-dep')
+  expect(fs.existsSync(depOfPkgWith1Dep)).toBeTruthy()
+  const oldTarget = path.resolve(path.dirname(depOfPkgWith1Dep), fs.readlinkSync(depOfPkgWith1Dep))
+  expect(oldTarget).toContain('.pnpm')
+
+  writeYamlFileSync(path.resolve('pnpm-workspace.yaml'), {
+    enableGlobalVirtualStore: true,
+    storeDir,
+    privateHoistPattern: '*',
+  })
+  await execPnpm(['install', '--config.confirmModulesPurge=false'])
+
+  const newTarget = path.resolve(path.dirname(depOfPkgWith1Dep), fs.readlinkSync(depOfPkgWith1Dep))
+  expect(newTarget).toContain(path.join(storeDir, 'v11', 'links'))
+
+  expect(fs.existsSync(path.resolve('node_modules/@pnpm.e2e/pkg-with-1-dep/package.json'))).toBeTruthy()
+  expect(fs.existsSync(path.resolve('node_modules/.pnpm/node_modules/@pnpm.e2e/dep-of-pkg-with-1-dep'))).toBeTruthy()
+
+  const globalVirtualStoreDir = path.join(storeDir, 'v11/links')
+  const files = fs.readdirSync(path.join(globalVirtualStoreDir, '@pnpm.e2e/pkg-with-1-dep/100.0.0'))
+  expect(files).toHaveLength(1)
+  expect(fs.existsSync(path.join(globalVirtualStoreDir, '@pnpm.e2e/pkg-with-1-dep/100.0.0', files[0], 'node_modules/@pnpm.e2e/pkg-with-1-dep/package.json'))).toBeTruthy()
+  expect(fs.existsSync(path.join(globalVirtualStoreDir, '@pnpm.e2e/pkg-with-1-dep/100.0.0', files[0], 'node_modules/@pnpm.e2e/dep-of-pkg-with-1-dep/package.json'))).toBeTruthy()
+})
+
 test('the post-install build step preserves the global virtual store directory of a workspace package', async () => {
   // A workspace package that is also its own workspace root (its own
   // pnpm-workspace.yaml and lockfile). The root install runs a per-project


### PR DESCRIPTION
## Summary

When `enable-global-virtual-store` is toggled on for a project that was previously installed without GVS, `symlinkHoistedDependency` silently skips replacing existing hoisted symlinks at `node_modules/.pnpm/node_modules/<dep>`. The `isSubdir(virtualStoreDir, existingSymlink)` check compares against `storeDir/links` (the GVS location), but stale symlinks from a prior non-GVS install point into `node_modules/.pnpm/` — a path that is NOT a subdir of `storeDir/links`. The symlink is classified as "external" and left untouched, causing TypeScript to follow stale paths that may be incomplete or inconsistent.

This aligns with the existing dual-check pattern already used by `safeIsInnerLink` in `installing/deps-resolver/src/safeIsInnerLink.ts:24-26`.

**Scope:** This fixes the stale-symlink transition bug. The broader TypeScript type inference issue (#9739) is also related to the GVS architectural limitation described in [#12437](https://github.com/pnpm/pnpm/issues/12437) — packages executing from the links store can't resolve transitive deps because Node's `node_modules` walk-up from `storeDir/links/<hash>/node_modules/<pkg>/` never reaches the project's `node_modules/`. That requires a separate architectural fix.

Related: #12437, #9618, #9696

## Squash Commit Body

```text
fix(hoist): replace stale non-GVS symlinks when enable-global-virtual-store is toggled on

When a project transitions from non-GVS to GVS mode, hoisted symlinks at
`node_modules/.pnpm/node_modules/<dep>` still pointed into
`node_modules/.pnpm/<depPath>/node_modules/<dep>`. The
`symlinkHoistedDependency` function only checked `isSubdir(virtualStoreDir, ...)`
— with GVS active, `virtualStoreDir` is `storeDir/links`, so these old symlinks
were classified as "external" and silently skipped.

Added `internalPnpmDir` (derived from `path.dirname(privateHoistedModulesDir)`)
as a second check. Symlinks under `node_modules/.pnpm/` are now recognized as
pnpm-internal and correctly replaced, matching the pattern in `safeIsInnerLink`.

The broader TypeScript type inference breakage (#9739) also has an architectural
dimension: when TypeScript follows a symlink to storeDir/links/<hash>/, Node's
module resolution walk-up never reaches node_modules/. This is the same root
cause as #12437 (packages from links store can't resolve transitive deps) and
requires a separate architectural fix.

Closes pnpm/pnpm#9739
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hoisted dependency symlink behavior when switching to Global Virtual Store, with safer handling of existing symlinks to ensure they’re correctly unlinked/relinked when their targets belong to the virtual store areas.

* **Tests**
  * Added Jest coverage for transitioning from non-Global Virtual Store to Global Virtual Store, verifying hoisted symlink targets update as expected and that `package.json` files appear in both `node_modules` and the versioned Global Virtual Store links directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->