### PR TITLE
test(exec): fix Windows failure in PnP require option test

### DIFF
--- a/exec/commands/test/exec.ts
+++ b/exec/commands/test/exec.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import { makeNodeRequireOption } from '@pnpm/exec.lifecycle'
 import { prepareEmpty } from '@pnpm/prepare'
 
 import { DEFAULT_OPTS } from './utils/index.js'
@@ -66,10 +67,11 @@ test('exec should merge node options with PnP require option', async () => {
     nodeOptions: '--max-old-space-size=4096',
   }, ['eslint'])
 
+  // The require path is quoted and backslash-escaped on Windows, so derive the
+  // expected value from the same helper exec uses instead of hardcoding it.
+  const { NODE_OPTIONS } = makeNodeRequireOption(pnpPath, { NODE_OPTIONS: '--max-old-space-size=4096' })
   expect(execa).toHaveBeenCalledWith('eslint', [], expect.objectContaining({
-    env: expect.objectContaining({
-      NODE_OPTIONS: `--max-old-space-size=4096 --require=${pnpPath}`,
-    }),
+    env: expect.objectContaining({ NODE_OPTIONS }),
   }))
 })
 


### PR DESCRIPTION
## Summary

The `exec should merge node options with PnP require option` test (added in #12430) is failing on the Windows CI runners on `main`, e.g. [run 27752731292](https://github.com/pnpm/pnpm/actions/runs/27752731292) (`TS CI / Test / windows / Node 26`).

The test hardcodes an **unquoted** expectation:

```ts
NODE_OPTIONS: `--max-old-space-size=4096 --require=${pnpPath}`
```

But #12430 made `makeNodeRequireOption` run the path through `quotePathIfNeeded`. On Windows the `.pnp.cjs` path contains backslashes, which match `/[\s"'\\]/`, so the path is wrapped in double quotes and backslash-escaped (`--require="D:\\a\\...\\.pnp.cjs"`) for Node's `NODE_OPTIONS` tokenizer. The quoting is intentional and correct — only the test's expectation was wrong. On POSIX the path has no special characters, so it's left unquoted and the test happened to pass there.

## Fix

Derive the expected `NODE_OPTIONS` from `makeNodeRequireOption` itself (the source of truth) instead of hardcoding the unquoted form, so the expectation matches the implementation's quoting on every platform. The test still guards the original regression (`nodeOptions` being dropped when the PnP require option is added): if `exec.handler` dropped `--max-old-space-size=4096`, the produced value would no longer equal the helper's output.

This is a test-only change — no published package behavior changes, so no changeset.

## Test plan

- [x] `pnpm --filter @pnpm/exec.commands run compile`
- [x] `test/exec.ts` passes locally (4/4) on macOS.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to use shared helper functions instead of hardcoded values, ensuring test expectations align with implementation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->