### PR TITLE
fix(ci): grant pull-requests: write so the review label step can label PRs

### DIFF
--- a/.github/workflows/pr-review-automation-privileged.yml
+++ b/.github/workflows/pr-review-automation-privileged.yml
@@ -27,9 +27,13 @@ jobs:
     permissions:
       # Downloading an artifact from the triggering run requires actions: read.
       actions: read
-      # Adding a label via the issues REST API is governed by issues: write
-      # even when the target is a PR. No other scope is needed.
+      # The POST /issues/{n}/labels endpoint is shared between issues and PRs,
+      # but the governing permission depends on the target: labeling a pull
+      # request needs pull-requests: write (issues: write only covers issues).
+      # The reviews this acts on are always on PRs, so pull-requests: write is
+      # the one that matters; issues: write is kept for completeness.
       issues: write
+      pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # The webhook is optional; the Discord step is skipped when it is unset. Only


### PR DESCRIPTION
## Problem

The PR-review-automation label never gets applied on approval. For example, on pnpm/pnpm#12499 qodo submitted an `APPROVED` review but no `reviewed: qodo` label appeared.

Tracing it:

1. qodo approved → the `capture` job in `pr-review-automation.yml` ran and uploaded the event artifact ✅
2. the privileged companion `pr-review-automation-privileged.yml` (`act` job, via `workflow_run`) downloaded the artifact, correctly resolved `label='reviewed: qodo'`, then **failed** at *Add the reviewed label*:

```
gh: Resource not accessible by integration (HTTP 403)
POST repos/pnpm/pnpm/issues/12499/labels   (LABEL: reviewed: qodo)
```

This isn't a default-permissions issue (`default_workflow_permissions` is already `write`) or a missing-label issue (all three labels exist). The privileged job has failed on **every** approval since the `workflow_run` refactor in pnpm/pnpm#12493 and has never successfully added a label.

## Root cause

The `act` job granted only `issues: write`. The endpoint `POST /issues/{n}/labels` is shared between issues and PRs, but the **governing permission depends on the target**: labeling a *pull request* requires `pull-requests: write`, not `issues: write`. The review targets here are always PRs, so the token was denied.

The old single-stage workflow granted both `issues: write` and `pull-requests: write`; the pnpm/pnpm#12493 refactor into the `workflow_run` companion dropped `pull-requests: write`. The inline comment asserting "issues: write … No other scope is needed" was incorrect.

## Fix

Add `pull-requests: write` to the `act` job and correct the comment. This unblocks all three labels that flow through the same step (`reviewed: qodo`, `reviewed: coderabbit`, `state: automerge`).

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation workflow configuration to properly manage permissions for pull request and issue handling processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->