### PR TITLE
fix(pacquet): preserve exec bit on clone/reflink import path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,7 @@ Defaults:
 
 -   **Do not write a comment** that restates what the code already says. If renaming a variable, splitting a helper, or moving a check to a more obvious place would carry the information, do that instead.
 -   **Do not repeat documentation** at call sites that already lives on the callee. If the function has a JSDoc, the call site shouldn't re-explain what calling it does. Update the JSDoc once; let every call site benefit.
+-   **Put a shared *why* in one place.** When the same rationale underlies several related functions — peers that delegate to a common helper, or a type and its methods — document it once at that common home and reference it from the rest, instead of re-deriving it in each. This is the call-site rule applied sideways across peers, not just upward to a callee.
 -   **JSDoc is for the function's contract** — preconditions, postconditions, edge cases, why the function exists. Not for re-narrating the body.
 -   **Do not record past implementation shape, refactor history, or "the previous code did X" framing.** That's what `git log` and `git blame` are for. Describe the current contract — what the code is and what it guarantees — not what it replaced. Phrasings like "used to", "previously", "the original X", or a parenthetical naming a removed type belong in the commit message, not in the source.
 

--- a/pacquet/AGENTS.md
+++ b/pacquet/AGENTS.md
@@ -297,6 +297,7 @@ Rust-specific defaults:
 
 -   **Doc comments (`///`, `//!`) document the contract.** Preconditions, postconditions, panics, the reason the function exists. They are not a re-narration of the body.
 -   **Do not restate at call sites what the callee's doc comment already says.** If `///` on the function says "no-op when …", the caller should not repeat that. Update the doc once; let every call site benefit.
+-   **Put a shared *why* in one place.** When the same rationale underlies several related functions — peers that delegate to a common helper, or a type and its methods — document it once at that common home and reference it from the rest, instead of re-deriving it in each. This is the call-site rule applied sideways across peers, not just upward to a callee.
 -   **Tests are documentation. Do not duplicate them in prose.** If a behavioral scenario, edge case, failure mode, or worked example is already captured by a test (its name, its setup, its assertions), do not also narrate it in the doc comment on the implementation. The doc comment should state the contract once; the test demonstrates the behavior. The same applies in reverse: a test's own doc comment should not re-explain what the asserts already say, only the *why* if it is not obvious.
 -   **`// SAFETY:`, `// TODO:`, and similar prefixes are the exception.** They signal hidden invariants or known follow-ups that a reader cannot recover from the code alone.
 

--- a/pacquet/crates/fs/src/ensure_file.rs
+++ b/pacquet/crates/fs/src/ensure_file.rs
@@ -42,7 +42,7 @@ const ENFILE: i32 = 23;
 /// the helper is a thin pass-through there — the trailing `op()`
 /// after the `cfg(unix)` block is the one and only attempt on that
 /// platform. Pacquet's Windows build path otherwise stays unchanged.
-fn retry_on_fd_pressure<Func, Value>(mut op: Func) -> io::Result<Value>
+pub(crate) fn retry_on_fd_pressure<Func, Value>(mut op: Func) -> io::Result<Value>
 where
     Func: FnMut() -> io::Result<Value>,
 {

--- a/pacquet/crates/fs/src/file_mode.rs
+++ b/pacquet/crates/fs/src/file_mode.rs
@@ -37,10 +37,12 @@ pub fn cas_path_is_executable(path: &Path) -> bool {
 pub fn restore_exec_bit_from_cas_suffix(cas_path: &Path, target: &Path) -> io::Result<()> {
     #[cfg(unix)]
     if cas_path_is_executable(cas_path) {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(target)?.permissions();
-        perms.set_mode(perms.mode() | EXEC_MASK);
-        std::fs::set_permissions(target, perms)?;
+        // Open once and chmod through the fd. A path-based
+        // `metadata()` + `set_permissions()` pair leaves a TOCTOU window where
+        // a concurrent writer could swap `target` between the two calls and
+        // redirect the chmod onto an unintended inode; binding both to one
+        // opened file closes it. Defense-in-depth on the install hot path.
+        make_file_executable(&std::fs::File::open(target)?)?;
     }
     #[cfg(not(unix))]
     let _ = (cas_path, target);

--- a/pacquet/crates/fs/src/file_mode.rs
+++ b/pacquet/crates/fs/src/file_mode.rs
@@ -25,6 +25,28 @@ pub fn cas_path_is_executable(path: &Path) -> bool {
     path.file_name().and_then(|name| name.to_str()).is_some_and(|name| name.ends_with("-exec"))
 }
 
+/// Re-add executable bits to `target` when the CAS source path carries the
+/// `-exec` suffix. The CAS encodes executability purely in that suffix (see
+/// [`cas_path_is_executable`]), so it is the source of truth: a `copy` or
+/// `reflink` that materializes a freshly-created `0o644` target — `fs::copy`
+/// on overlayfs, Linux `FICLONE` reflink always — would otherwise leave a
+/// native binary non-executable. Non-executable entries (no `-exec` suffix)
+/// are left untouched, so the mode is never widened and no `set_permissions`
+/// syscall is paid on the non-exec majority. On Windows this is a no-op
+/// because POSIX permission bits do not apply.
+pub fn restore_exec_bit_from_cas_suffix(cas_path: &Path, target: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    if cas_path_is_executable(cas_path) {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(target)?.permissions();
+        perms.set_mode(perms.mode() | EXEC_MASK);
+        std::fs::set_permissions(target, perms)?;
+    }
+    #[cfg(not(unix))]
+    let _ = (cas_path, target);
+    Ok(())
+}
+
 /// Set file mode to 777 on POSIX platforms such as Linux or macOS,
 /// or do nothing on Windows.
 #[cfg_attr(windows, allow(unused))]

--- a/pacquet/crates/fs/src/file_mode.rs
+++ b/pacquet/crates/fs/src/file_mode.rs
@@ -42,7 +42,12 @@ pub fn restore_exec_bit_from_cas_suffix(cas_path: &Path, target: &Path) -> io::R
         // a concurrent writer could swap `target` between the two calls and
         // redirect the chmod onto an unintended inode; binding both to one
         // opened file closes it. Defense-in-depth on the install hot path.
-        make_file_executable(&std::fs::File::open(target)?)?;
+        //
+        // Retry the open under fd-table exhaustion like every other open on
+        // the parallel import path: a transient `EMFILE`/`ENFILE` from a
+        // sibling rayon worker must not fail the install.
+        let file = crate::ensure_file::retry_on_fd_pressure(|| std::fs::File::open(target))?;
+        make_file_executable(&file)?;
     }
     #[cfg(not(unix))]
     let _ = (cas_path, target);

--- a/pacquet/crates/fs/src/file_mode.rs
+++ b/pacquet/crates/fs/src/file_mode.rs
@@ -49,8 +49,12 @@ pub fn restore_exec_bit_from_cas_suffix(cas_path: &Path, target: &Path) -> io::R
     Ok(())
 }
 
-/// Set file mode to 777 on POSIX platforms such as Linux or macOS,
-/// or do nothing on Windows.
+/// Add the executable bits (`u+x g+x o+x`) to `file`, a no-op on Windows.
+///
+/// Skips the `set_permissions` syscall (and the ctime bump it would cause) when
+/// every exec bit is already set, so re-asserting executability on an
+/// already-correct file — a copy or a macOS reflink that carried the store mode
+/// across — costs only the stat.
 #[cfg_attr(windows, allow(unused))]
 pub fn make_file_executable(file: &std::fs::File) -> io::Result<()> {
     #[cfg(unix)]
@@ -60,9 +64,10 @@ pub fn make_file_executable(file: &std::fs::File) -> io::Result<()> {
             os::unix::fs::{MetadataExt, PermissionsExt},
         };
         let mode = file.metadata()?.mode();
-        let mode = mode | EXEC_MASK;
-        let permissions = Permissions::from_mode(mode);
-        file.set_permissions(permissions)
+        if mode & EXEC_MASK == EXEC_MASK {
+            return Ok(());
+        }
+        file.set_permissions(Permissions::from_mode(mode | EXEC_MASK))
     };
 
     #[cfg(windows)]

--- a/pacquet/crates/fs/src/file_mode.rs
+++ b/pacquet/crates/fs/src/file_mode.rs
@@ -52,9 +52,8 @@ pub fn restore_exec_bit_from_cas_suffix(cas_path: &Path, target: &Path) -> io::R
 /// Add the executable bits (`u+x g+x o+x`) to `file`, a no-op on Windows.
 ///
 /// Skips the `set_permissions` syscall (and the ctime bump it would cause) when
-/// every exec bit is already set, so re-asserting executability on an
-/// already-correct file — a copy or a macOS reflink that carried the store mode
-/// across — costs only the stat.
+/// every exec bit is already set, so re-asserting executability on a file that
+/// already has it costs only the stat.
 #[cfg_attr(windows, allow(unused))]
 pub fn make_file_executable(file: &std::fs::File) -> io::Result<()> {
     #[cfg(unix)]

--- a/pacquet/crates/fs/src/file_mode/tests.rs
+++ b/pacquet/crates/fs/src/file_mode/tests.rs
@@ -36,6 +36,26 @@ fn make_file_executable_sets_exec_bits() {
     assert_eq!(mode & EXEC_MASK, EXEC_MASK, "all exec bits should be set, got {mode:o}");
 }
 
+/// The already-exec short-circuit must only fire when *every* exec bit is set:
+/// a partially-executable `0o744` still has to be filled to `0o755`, while an
+/// already-`0o755` file is left exactly as-is.
+#[cfg(unix)]
+#[test]
+fn make_file_executable_fills_partial_bits_and_preserves_full() {
+    use super::make_file_executable;
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
+    let file = tmp.as_file();
+
+    file.set_permissions(std::fs::Permissions::from_mode(0o744)).expect("seed 0o744");
+    make_file_executable(file).expect("fill partial exec bits");
+    assert_eq!(file.metadata().unwrap().permissions().mode() & 0o777, 0o755);
+
+    make_file_executable(file).expect("already executable");
+    assert_eq!(file.metadata().unwrap().permissions().mode() & 0o777, 0o755);
+}
+
 /// A CAS source ending in `-exec` re-adds the exec bits to a target that
 /// lost them (e.g. a `0o644` file a Linux `FICLONE` reflink just created).
 /// The suffix is the source of truth, so the target ends up `0o755`.

--- a/pacquet/crates/fs/src/file_mode/tests.rs
+++ b/pacquet/crates/fs/src/file_mode/tests.rs
@@ -36,9 +36,8 @@ fn make_file_executable_sets_exec_bits() {
     assert_eq!(mode & EXEC_MASK, EXEC_MASK, "all exec bits should be set, got {mode:o}");
 }
 
-/// The already-exec short-circuit must only fire when *every* exec bit is set:
-/// a partially-executable `0o744` still has to be filled to `0o755`, while an
-/// already-`0o755` file is left exactly as-is.
+/// The short-circuit keys on *all* exec bits being set, not merely one, so a
+/// partial `0o744` is still filled to `0o755`.
 #[cfg(unix)]
 #[test]
 fn make_file_executable_fills_partial_bits_and_preserves_full() {
@@ -56,9 +55,7 @@ fn make_file_executable_fills_partial_bits_and_preserves_full() {
     assert_eq!(file.metadata().unwrap().permissions().mode() & 0o777, 0o755);
 }
 
-/// A CAS source ending in `-exec` re-adds the exec bits to a target that
-/// lost them (e.g. a `0o644` file a Linux `FICLONE` reflink just created).
-/// The suffix is the source of truth, so the target ends up `0o755`.
+/// The `0o644` seed stands in for a target a reflink left non-executable.
 #[cfg(unix)]
 #[test]
 fn restore_exec_bit_adds_bits_for_exec_suffix() {
@@ -77,9 +74,8 @@ fn restore_exec_bit_adds_bits_for_exec_suffix() {
     assert_eq!(mode, 0o755, "exec-suffixed CAS entry must land executable, got {mode:o}");
 }
 
-/// A CAS source without the `-exec` suffix leaves the target mode
-/// untouched — restoration must never widen a restrictive mode, so a
-/// `0o600` file stays `0o600`.
+/// Restoration keys on the suffix, not the mode, so it must never widen a
+/// restrictive non-`-exec` target.
 #[cfg(unix)]
 #[test]
 fn restore_exec_bit_does_not_widen_non_exec_suffix() {

--- a/pacquet/crates/fs/src/file_mode/tests.rs
+++ b/pacquet/crates/fs/src/file_mode/tests.rs
@@ -35,3 +35,45 @@ fn make_file_executable_sets_exec_bits() {
     let mode = file.metadata().expect("stat").permissions().mode();
     assert_eq!(mode & EXEC_MASK, EXEC_MASK, "all exec bits should be set, got {mode:o}");
 }
+
+/// A CAS source ending in `-exec` re-adds the exec bits to a target that
+/// lost them (e.g. a `0o644` file a Linux `FICLONE` reflink just created).
+/// The suffix is the source of truth, so the target ends up `0o755`.
+#[cfg(unix)]
+#[test]
+fn restore_exec_bit_adds_bits_for_exec_suffix() {
+    use super::restore_exec_bit_from_cas_suffix;
+    use std::{fs, os::unix::fs::PermissionsExt};
+
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let cas_path = Path::new("files/1b/59d9-exec");
+    let target = tmp.path().join("dst");
+    fs::write(&target, b"#!/usr/bin/env node\n").expect("write target");
+    fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).expect("seed mode");
+
+    restore_exec_bit_from_cas_suffix(cas_path, &target).expect("restore exec bit");
+
+    let mode = fs::metadata(&target).expect("stat").permissions().mode() & 0o777;
+    assert_eq!(mode, 0o755, "exec-suffixed CAS entry must land executable, got {mode:o}");
+}
+
+/// A CAS source without the `-exec` suffix leaves the target mode
+/// untouched — restoration must never widen a restrictive mode, so a
+/// `0o600` file stays `0o600`.
+#[cfg(unix)]
+#[test]
+fn restore_exec_bit_does_not_widen_non_exec_suffix() {
+    use super::restore_exec_bit_from_cas_suffix;
+    use std::{fs, os::unix::fs::PermissionsExt};
+
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let cas_path = Path::new("files/1b/59d9");
+    let target = tmp.path().join("dst");
+    fs::write(&target, b"private data\n").expect("write target");
+    fs::set_permissions(&target, fs::Permissions::from_mode(0o600)).expect("seed mode");
+
+    restore_exec_bit_from_cas_suffix(cas_path, &target).expect("restore is a no-op here");
+
+    let mode = fs::metadata(&target).expect("stat").permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600, "non-exec CAS entry must not gain exec bits, got {mode:o}");
+}

--- a/pacquet/crates/git-fetcher/src/cas_io.rs
+++ b/pacquet/crates/git-fetcher/src/cas_io.rs
@@ -15,7 +15,9 @@
 //!   import.
 
 use crate::error::GitFetcherError;
-use pacquet_fs::file_mode::{cas_path_is_executable, is_executable};
+use pacquet_fs::file_mode::{
+    cas_path_is_executable, is_executable, restore_exec_bit_from_cas_suffix,
+};
 use pacquet_store_dir::{CafsFileInfo, StoreDir};
 use std::{
     collections::HashMap,
@@ -94,20 +96,7 @@ pub(crate) fn materialize_into(
             fs::create_dir_all(parent).map_err(GitFetcherError::Io)?;
         }
         fs::copy(cas_path, &target).map_err(GitFetcherError::Io)?;
-        // Carry the executable bit across. The CAS uses a `-exec`
-        // suffix on the file name to encode the bit (matches pnpm's
-        // CAFS layout), so reading it back from the path is the only
-        // reliable signal — `fs::copy` itself doesn't reset POSIX
-        // permissions, but we may need to *add* the bit if the CAS
-        // file's filesystem-level mode lost it during an earlier
-        // copy or hardlink path elsewhere.
-        #[cfg(unix)]
-        if cas_path_is_executable(cas_path) {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&target).map_err(GitFetcherError::Io)?.permissions();
-            perms.set_mode(perms.mode() | pacquet_fs::file_mode::EXEC_MASK);
-            fs::set_permissions(&target, perms).map_err(GitFetcherError::Io)?;
-        }
+        restore_exec_bit_from_cas_suffix(cas_path, &target).map_err(GitFetcherError::Io)?;
     }
     Ok(())
 }

--- a/pacquet/crates/git-fetcher/src/cas_io/tests.rs
+++ b/pacquet/crates/git-fetcher/src/cas_io/tests.rs
@@ -167,3 +167,35 @@ fn materialize_into_rejects_traversal() {
     assert!(!target.path().join("escape").exists());
     assert!(!target.path().parent().unwrap().join("escape").exists());
 }
+
+/// `materialize_into` restores the exec bit from the `-exec` CAS suffix
+/// even when the on-disk CAS file lost it (a prior copy/reflink fallback
+/// can leave it `0o644`). We strip the store file's exec bit first so the
+/// assertion proves restoration rather than `fs::copy`'s mode carry-over.
+/// A non-exec sibling must keep its restrictive mode — restoration never
+/// widens.
+#[cfg(unix)]
+#[test]
+fn materialize_into_restores_exec_bit_from_cas_suffix() {
+    use std::{fs, os::unix::fs::PermissionsExt};
+
+    let target = tempdir().unwrap();
+    let cas_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(cas_root.path().to_path_buf());
+
+    let (exec_cas, _) = store_dir.write_cas_file(b"#!/bin/sh\n", true).unwrap();
+    fs::set_permissions(&exec_cas, fs::Permissions::from_mode(0o644)).unwrap();
+    let (regular_cas, _) = store_dir.write_cas_file(b"data\n", false).unwrap();
+    fs::set_permissions(&regular_cas, fs::Permissions::from_mode(0o600)).unwrap();
+
+    let mut cas_paths: HashMap<String, _> = HashMap::new();
+    cas_paths.insert("bin/run".to_string(), exec_cas);
+    cas_paths.insert("README.md".to_string(), regular_cas);
+
+    materialize_into(&cas_paths, target.path()).unwrap();
+
+    let exec_mode = fs::metadata(target.path().join("bin/run")).unwrap().permissions().mode();
+    assert_eq!(exec_mode & 0o777, 0o755, "exec-suffixed CAS file must materialize as 0o755");
+    let regular_mode = fs::metadata(target.path().join("README.md")).unwrap().permissions().mode();
+    assert_eq!(regular_mode & 0o777, 0o600, "non-exec file must keep its restrictive mode");
+}

--- a/pacquet/crates/git-fetcher/src/cas_io/tests.rs
+++ b/pacquet/crates/git-fetcher/src/cas_io/tests.rs
@@ -168,12 +168,8 @@ fn materialize_into_rejects_traversal() {
     assert!(!target.path().parent().unwrap().join("escape").exists());
 }
 
-/// `materialize_into` restores the exec bit from the `-exec` CAS suffix
-/// even when the on-disk CAS file lost it (a prior copy/reflink fallback
-/// can leave it `0o644`). We strip the store file's exec bit first so the
-/// assertion proves restoration rather than `fs::copy`'s mode carry-over.
-/// A non-exec sibling must keep its restrictive mode — restoration never
-/// widens.
+/// Strip the store file's exec bit first so the assertion proves restoration,
+/// not `fs::copy`'s mode carry-over; the non-exec sibling pins the no-widen path.
 #[cfg(unix)]
 #[test]
 fn materialize_into_restores_exec_bit_from_cas_suffix() {

--- a/pacquet/crates/package-manager/src/link_file.rs
+++ b/pacquet/crates/package-manager/src/link_file.rs
@@ -253,7 +253,22 @@ fn copy_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
 /// redundant `set_permissions` per executable there.)
 fn clone_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
     reflink_copy::reflink(source_file, target_link)?;
-    pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link)
+    restore_after_reflink(source_file, target_link)
+}
+
+/// Restore the exec bit after a reflink that just created `target`, removing
+/// the partial file if restoration fails.
+///
+/// reflink does not overwrite (unlike `fs::copy`), so a target left at `0o644`
+/// by a failed restore would be adopted as-is by the next repair pass —
+/// `import_into_fresh_target` treats the EEXIST as a no-op and never re-runs
+/// restoration — silently completing the package with a non-executable binary.
+fn restore_after_reflink(source_file: &Path, target_link: &Path) -> io::Result<()> {
+    pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link).inspect_err(
+        |_| {
+            let _ = fs::remove_file(target_link);
+        },
+    )
 }
 
 /// EXDEV = "cross-device link not permitted". Linux / macOS / BSD all
@@ -324,7 +339,7 @@ fn auto_link<Reporter: self::Reporter>(
             // just-created file and mask the real error behind `AlreadyExists`.
             LINK_STATE_CLONE => match reflink_copy::reflink(source, target) {
                 Ok(()) => {
-                    pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix(source, target)?;
+                    restore_after_reflink(source, target)?;
                     log_method_once::<Reporter>(logged, LOG_FLAG_CLONE, WireImportMethod::Clone);
                     return Ok(());
                 }
@@ -374,7 +389,7 @@ fn clone_or_copy_link<Reporter: self::Reporter>(
             // here); the post-reflink restoration error is terminal.
             LINK_STATE_CLONE => match reflink_copy::reflink(source, target) {
                 Ok(()) => {
-                    pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix(source, target)?;
+                    restore_after_reflink(source, target)?;
                     log_method_once::<Reporter>(logged, LOG_FLAG_CLONE, WireImportMethod::Clone);
                     return Ok(());
                 }

--- a/pacquet/crates/package-manager/src/link_file.rs
+++ b/pacquet/crates/package-manager/src/link_file.rs
@@ -152,12 +152,14 @@ pub fn link_file<Reporter: self::Reporter>(
 /// runs against a directory it just created — that protection is
 /// unneeded.
 ///
-/// EEXIST from the import syscall is still treated as a no-op:
-/// concurrent installs (or a sibling rayon worker writing the same
-/// CAFS path) can occasionally race past the freshness guarantee,
-/// and the kernel's atomic-create error is the right way to detect
-/// the contention. The content is content-addressed so the existing
-/// dirent is equivalent.
+/// EEXIST from the import syscall means a concurrent install (or a
+/// sibling rayon worker writing the same CAFS path) raced past the
+/// freshness guarantee. The content is content-addressed so the
+/// existing dirent is equivalent — but a reflink the winner used
+/// drops the exec bit, so we re-assert it from the `-exec` suffix
+/// instead of adopting a possibly-`0o644` binary. That re-assertion
+/// also heals a target an earlier failed restore left non-executable,
+/// which is why the clone tier no longer deletes on restore failure.
 pub fn import_into_fresh_target<Reporter: self::Reporter>(
     logged: &AtomicU8,
     method: PackageImportMethod,
@@ -172,11 +174,20 @@ pub fn import_into_fresh_target<Reporter: self::Reporter>(
     // import layer — so there's nothing to gate on here.
     match try_import::<Reporter>(method, logged, source_file, target_link) {
         Ok(()) => Ok(()),
-        // Mirrors pnpm's `linkOrCopy`: on EEXIST, return without
-        // touching disk. A concurrent writer beat us to the target;
-        // contents are content-addressed so leaving theirs in place
-        // is equivalent.
-        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => Ok(()),
+        // A concurrent writer beat us to the target; its content is
+        // content-addressed and equivalent. pnpm's `linkOrCopy` returns
+        // here without touching disk, but pnpm's clone preserves the mode
+        // and pacquet's reflink does not — so re-assert the exec bit from
+        // the `-exec` suffix (idempotent, a no-op for non-exec entries)
+        // before adopting the dirent.
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link)
+                .map_err(|error| LinkFileError::Import {
+                    from: source_file.to_path_buf(),
+                    to: target_link.to_path_buf(),
+                    error,
+                })
+        }
         Err(error) => Err(LinkFileError::Import {
             from: source_file.to_path_buf(),
             to: target_link.to_path_buf(),
@@ -240,25 +251,10 @@ fn copy_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
 }
 
 /// `reflink_copy::reflink` for the clone tier, then exec-bit restoration via
-/// [`restore_after_reflink`].
+/// [`pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix`].
 fn clone_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
     reflink_copy::reflink(source_file, target_link)?;
-    restore_after_reflink(source_file, target_link)
-}
-
-/// Restore the exec bit after a reflink that just created `target`, removing
-/// the partial file if restoration fails.
-///
-/// reflink does not overwrite (unlike `fs::copy`), so a target left at `0o644`
-/// by a failed restore would be adopted as-is by the next repair pass —
-/// `import_into_fresh_target` treats the EEXIST as a no-op and never re-runs
-/// restoration — silently completing the package with a non-executable binary.
-fn restore_after_reflink(source_file: &Path, target_link: &Path) -> io::Result<()> {
-    pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link).inspect_err(
-        |_| {
-            let _ = fs::remove_file(target_link);
-        },
-    )
+    pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link)
 }
 
 /// EXDEV = "cross-device link not permitted". Linux / macOS / BSD all
@@ -329,7 +325,7 @@ fn auto_link<Reporter: self::Reporter>(
             // just-created file and mask the real error behind `AlreadyExists`.
             LINK_STATE_CLONE => match reflink_copy::reflink(source, target) {
                 Ok(()) => {
-                    restore_after_reflink(source, target)?;
+                    pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix(source, target)?;
                     log_method_once::<Reporter>(logged, LOG_FLAG_CLONE, WireImportMethod::Clone);
                     return Ok(());
                 }
@@ -379,7 +375,7 @@ fn clone_or_copy_link<Reporter: self::Reporter>(
             // here); the post-reflink restoration error is terminal.
             LINK_STATE_CLONE => match reflink_copy::reflink(source, target) {
                 Ok(()) => {
-                    restore_after_reflink(source, target)?;
+                    pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix(source, target)?;
                     log_method_once::<Reporter>(logged, LOG_FLAG_CLONE, WireImportMethod::Clone);
                     return Ok(());
                 }

--- a/pacquet/crates/package-manager/src/link_file.rs
+++ b/pacquet/crates/package-manager/src/link_file.rs
@@ -219,11 +219,9 @@ fn try_import<Reporter: self::Reporter>(
             }
             Err(error) => Err(error),
         },
-        PackageImportMethod::Clone => {
-            reflink_copy::reflink(source_file, target_link).inspect(|()| {
-                log_method_once::<Reporter>(logged, LOG_FLAG_CLONE, WireImportMethod::Clone);
-            })
-        }
+        PackageImportMethod::Clone => clone_file(source_file, target_link).inspect(|()| {
+            log_method_once::<Reporter>(logged, LOG_FLAG_CLONE, WireImportMethod::Clone);
+        }),
         PackageImportMethod::CloneOrCopy => {
             static CLONE_OR_COPY_STATE: AtomicU8 = AtomicU8::new(LINK_STATE_CLONE);
             clone_or_copy_link::<Reporter>(logged, &CLONE_OR_COPY_STATE, source_file, target_link)
@@ -236,25 +234,26 @@ fn try_import<Reporter: self::Reporter>(
 
 /// `fs::copy` plus exec-bit restoration for the copy fallback tier.
 ///
-/// `fs::copy` already carries a regular file's mode across on Unix, but
-/// a CAS entry's executable bit can be lost when a copy / reflink
-/// fallback materializes it (observed on overlayfs), leaving a native
-/// binary at `0o644`. The CAS encodes executability purely in the
-/// `-exec` path suffix, so that suffix is the source of truth: when it
-/// is present we re-add the exec bits, mirroring `git-fetcher`'s
-/// `materialize_into`. Non-executable files are left exactly as
-/// `fs::copy` produced them — we never widen their mode and never pay a
-/// `set_permissions` syscall for them.
+/// `fs::copy` carries a regular file's mode across on Unix, but a CAS
+/// entry's executable bit can still be lost on materialization (observed
+/// on overlayfs), so we re-add it from the `-exec` suffix via
+/// [`pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix`].
 fn copy_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
     fs::copy(source_file, target_link)?;
-    #[cfg(unix)]
-    if pacquet_fs::file_mode::cas_path_is_executable(source_file) {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(target_link)?.permissions();
-        perms.set_mode(perms.mode() | pacquet_fs::file_mode::EXEC_MASK);
-        fs::set_permissions(target_link, perms)?;
-    }
-    Ok(())
+    pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link)
+}
+
+/// `reflink_copy::reflink` plus exec-bit restoration for the clone tier.
+///
+/// Linux `reflink` uses `FICLONE`, which clones only the data into a
+/// freshly-created `0o644` target and drops the source's exec bit, so the
+/// same `-exec`-suffix restoration the copy tier does is required here.
+/// (macOS `clonefile` already carries the mode across, so the restoration
+/// leaves it unchanged — it still runs for platform parity, paying one
+/// redundant `set_permissions` per executable there.)
+fn clone_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
+    reflink_copy::reflink(source_file, target_link)?;
+    pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link)
 }
 
 /// EXDEV = "cross-device link not permitted". Linux / macOS / BSD all
@@ -318,8 +317,14 @@ fn auto_link<Reporter: self::Reporter>(
 ) -> io::Result<()> {
     loop {
         match state.load(Ordering::Relaxed) {
+            // Match on the reflink result alone: only a reflink failure means the
+            // tier is unusable on this FS pair and should downgrade. Restoration
+            // runs after reflink created the target, so its error is terminal
+            // (`?`) — downgrading on it would re-attempt hardlink against that
+            // just-created file and mask the real error behind `AlreadyExists`.
             LINK_STATE_CLONE => match reflink_copy::reflink(source, target) {
                 Ok(()) => {
+                    pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix(source, target)?;
                     log_method_once::<Reporter>(logged, LOG_FLAG_CLONE, WireImportMethod::Clone);
                     return Ok(());
                 }
@@ -365,8 +370,11 @@ fn clone_or_copy_link<Reporter: self::Reporter>(
 ) -> io::Result<()> {
     loop {
         match state.load(Ordering::Relaxed) {
+            // See `auto_link`: only the reflink itself may downgrade (to copy
+            // here); the post-reflink restoration error is terminal.
             LINK_STATE_CLONE => match reflink_copy::reflink(source, target) {
                 Ok(()) => {
+                    pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix(source, target)?;
                     log_method_once::<Reporter>(logged, LOG_FLAG_CLONE, WireImportMethod::Clone);
                     return Ok(());
                 }

--- a/pacquet/crates/package-manager/src/link_file.rs
+++ b/pacquet/crates/package-manager/src/link_file.rs
@@ -232,24 +232,15 @@ fn try_import<Reporter: self::Reporter>(
     }
 }
 
-/// `fs::copy` plus exec-bit restoration for the copy fallback tier.
-///
-/// `fs::copy` carries a regular file's mode across on Unix, but a CAS
-/// entry's executable bit can still be lost on materialization (observed
-/// on overlayfs), so we re-add it from the `-exec` suffix via
+/// `fs::copy` for the copy fallback tier, then exec-bit restoration via
 /// [`pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix`].
 fn copy_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
     fs::copy(source_file, target_link)?;
     pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link)
 }
 
-/// `reflink_copy::reflink` plus exec-bit restoration for the clone tier.
-///
-/// Linux `reflink` uses `FICLONE`, which clones only the data into a
-/// freshly-created `0o644` target and drops the source's exec bit, so the
-/// same `-exec`-suffix restoration the copy tier does is required here.
-/// (macOS `clonefile` already carries the mode across, so the restoration
-/// finds the bits already set and skips the chmod.)
+/// `reflink_copy::reflink` for the clone tier, then exec-bit restoration via
+/// [`restore_after_reflink`].
 fn clone_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
     reflink_copy::reflink(source_file, target_link)?;
     restore_after_reflink(source_file, target_link)

--- a/pacquet/crates/package-manager/src/link_file.rs
+++ b/pacquet/crates/package-manager/src/link_file.rs
@@ -249,8 +249,7 @@ fn copy_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
 /// freshly-created `0o644` target and drops the source's exec bit, so the
 /// same `-exec`-suffix restoration the copy tier does is required here.
 /// (macOS `clonefile` already carries the mode across, so the restoration
-/// leaves it unchanged — it still runs for platform parity, paying one
-/// redundant `set_permissions` per executable there.)
+/// finds the bits already set and skips the chmod.)
 fn clone_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
     reflink_copy::reflink(source_file, target_link)?;
     restore_after_reflink(source_file, target_link)

--- a/pacquet/crates/package-manager/src/link_file/tests.rs
+++ b/pacquet/crates/package-manager/src/link_file/tests.rs
@@ -2,7 +2,7 @@
 use super::LINK_STATE_COPY;
 use super::{
     LINK_STATE_CLONE, LINK_STATE_HARDLINK, LinkFileError, auto_link, clone_or_copy_link,
-    is_call_error, is_cross_device, link_file,
+    import_into_fresh_target, is_call_error, is_cross_device, link_file,
 };
 use pacquet_config::PackageImportMethod;
 use pacquet_reporter::SilentReporter;
@@ -85,6 +85,59 @@ fn copy_does_not_widen_non_exec_mode() {
 
     let dst_mode = fs::metadata(&dst).unwrap().permissions().mode() & 0o777;
     assert_eq!(dst_mode, 0o600, "non-executable file must not gain exec bits");
+}
+
+/// On EEXIST the import adopts the racing writer's dirent, but re-asserts
+/// the exec bit from the `-exec` suffix — so a target a prior failed
+/// restore left at `0o644` is healed rather than adopted broken. Driven
+/// through `Hardlink` for a deterministic EEXIST without needing reflink
+/// (copy-on-write) support on the test filesystem.
+#[test]
+#[cfg(unix)]
+fn eexist_restores_executable_mode_from_cas_suffix() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "1b59d9-exec", b"#!/usr/bin/env node\n");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o755)).unwrap();
+    let dst = write_source(tmp.path(), "dst", b"#!/usr/bin/env node\n");
+    fs::set_permissions(&dst, fs::Permissions::from_mode(0o644)).unwrap();
+
+    import_into_fresh_target::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Hardlink,
+        &src,
+        &dst,
+    )
+    .expect("EEXIST import should heal the exec bit");
+
+    let dst_mode = fs::metadata(&dst).unwrap().permissions().mode() & 0o777;
+    assert_eq!(dst_mode, 0o755, "stale 0o644 target must be restored to 0o755 on EEXIST");
+}
+
+/// The EEXIST exec-bit re-assertion must not widen a non-executable
+/// entry: a `-exec`-less source leaves an existing `0o600` target alone.
+#[test]
+#[cfg(unix)]
+fn eexist_does_not_widen_non_exec_mode() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "1b59d9", b"private data\n");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o644)).unwrap();
+    let dst = write_source(tmp.path(), "dst", b"private data\n");
+    fs::set_permissions(&dst, fs::Permissions::from_mode(0o600)).unwrap();
+
+    import_into_fresh_target::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Hardlink,
+        &src,
+        &dst,
+    )
+    .expect("EEXIST import should be a no-op for a non-exec entry");
+
+    let dst_mode = fs::metadata(&dst).unwrap().permissions().mode() & 0o777;
+    assert_eq!(dst_mode, 0o600, "non-exec EEXIST target must not gain exec bits");
 }
 
 /// Hardlinking in the same directory on the same filesystem works on


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

Fixes  pnpm/pnpm#12500. Follow-up to  pnpm/pnpm#12385.

pacquet stores executable CAFS entries under paths ending in `-exec`. Its
default `Auto` import method tries clone (reflink) → hardlink → copy.
pnpm/pnpm#12385 restored the exec bit on the copy tier, but the clone
(reflink) tier was left out and still dropped it.

On Linux `reflink_copy::reflink` uses `FICLONE`, which clones only the data
into a freshly-created `0o644` target, so a native binary such as
`@esbuild/linux-x64/bin/esbuild` (which has no `bin` field, so pacquet never
runs `ensure_executable_bits` to paper over it) lands non-executable and fails
to spawn with `EACCES`. macOS `clonefile` copies the mode, so the bug only
surfaces on filesystems where the Linux reflink path succeeds (e.g. CircleCI).
hardlink shares the store inode's `0o755` and copy was already fixed, so only
clone was affected.

The fix extracts the `-exec`-suffix restoration (previously duplicated in
`copy_file` and `git-fetcher`'s `materialize_into`) into a shared
`pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix`, and routes the clone
tier through it so reflinked binaries are re-marked `0o755`.

This is a pacquet-only bug. pnpm's TS importer clones with
`copyFileSync(COPYFILE_FICLONE_FORCE)`, which carries the mode across, so no
pnpm-side change is needed.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
On Linux reflink_copy::reflink uses FICLONE, which clones only the data into a
freshly-created 0o644 target, dropping the exec bit pacquet encodes in the
`-exec` CAS suffix. pnpm/pnpm#12385 restored it for the copy tier but left clone
out, so an undeclared executable like `@esbuild/linux-x64/bin/esbuild` failed
with EACCES. hardlink shares the store inode's 0o755 and copy was fixed, so only
clone was affected.

Extract the restoration (already duplicated in copy_file and git-fetcher's
materialize_into) into a shared
pacquet_fs::file_mode::restore_exec_bit_from_cas_suffix and route clone through
it. In auto_link / clone_or_copy_link only a reflink failure downgrades; the
post-reflink restoration error stays terminal, so it can't trigger a hardlink
retry against the just-created file that would mask it behind AlreadyExists.

Fixes pnpm/pnpm#12500.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Executable file permissions are restored when materializing and copying CAS entries marked with an executable `-exec` suffix, including clone/reflink flows.
* **Bug Fixes**
  * Prevents permission broadening for non-executable CAS entries.
  * Avoids redundant updates when executable bits are already correct.
  * Heals existing targets appropriately on `AlreadyExists` for executable `-exec` sources.
* **Tests**
  * Added Unix-only unit and integration tests covering exec-bit restoration and non-widening across materialize, copy, clone, and `AlreadyExists` scenarios.
* **Documentation**
  * Updated contributor guidance on documenting shared rationale once and referencing it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->