### PR TITLE
feat(pnpr): block vulnerable versions with local OSV index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4802,6 +4802,7 @@ dependencies = [
  "libsql",
  "miette 7.6.0",
  "mockito",
+ "node-semver",
  "object_store",
  "pacquet-config",
  "pacquet-config-dir",
@@ -4831,6 +4832,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wax",
+ "zip",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4799,6 +4799,7 @@ dependencies = [
  "getrandom 0.4.2",
  "home",
  "indexmap 2.14.0",
+ "libc",
  "libsql",
  "miette 7.6.0",
  "mockito",

--- a/pacquet/crates/package-manager/src/add.rs
+++ b/pacquet/crates/package-manager/src/add.rs
@@ -422,6 +422,7 @@ async fn resolve_explicit_registry_spec(
         dry_run: lockfile_only,
         optional: false,
         update_checksums: false,
+        blocked_versions: None,
     };
 
     let pick = pick_package(&ctx, &spec_parsed, &opts)

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -489,6 +489,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // The pnpr override when supplied, else the config's npmrc headers;
         // shared by every registry-touching resolver below.
         let auth_headers = auth_override.unwrap_or_else(|| Arc::clone(&config.auth_headers));
+        let package_version_guard =
+            resolution_observer.as_ref().and_then(|observer| observer.package_version_guard());
         let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
         // Materialise the caller's iterator into a `Vec` so the same
         // group set can be replayed into both the resolver (consumes
@@ -1160,6 +1162,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                         trust_policy,
                         trust_policy_exclude: trust_policy_exclude.clone(),
                         trust_policy_ignore_after: config.trust_policy_ignore_after,
+                        package_version_guard: package_version_guard.clone(),
                         project_dir,
                         lockfile_dir: lockfile_dir.to_path_buf(),
                         workspace_packages: workspace_packages.clone(),

--- a/pacquet/crates/package-manager/src/resolution_observer.rs
+++ b/pacquet/crates/package-manager/src/resolution_observer.rs
@@ -14,8 +14,8 @@ use crate::install_package_from_registry::{
 };
 use dashmap::DashSet;
 use pacquet_resolving_resolver_base::{
-    LatestQuery, ResolveFuture, ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver,
-    WantedDependency,
+    LatestQuery, PackageVersionGuard, ResolveFuture, ResolveLatestFuture, ResolveOptions,
+    ResolveResult, Resolver, WantedDependency,
 };
 use std::sync::Arc;
 
@@ -49,6 +49,10 @@ pub struct ResolvedPackageHint<'a> {
 /// Implemented by the pnpr server to stream fetch frames to the client.
 pub trait ResolutionObserver: Send + Sync {
     fn on_resolved(&self, hint: ResolvedPackageHint<'_>);
+
+    fn package_version_guard(&self) -> Option<Arc<dyn PackageVersionGuard>> {
+        None
+    }
 }
 
 /// Wraps an inner [`Resolver`], forwarding each tarball-shaped result to

--- a/pacquet/crates/resolving-npm-resolver/src/errors.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/errors.rs
@@ -63,3 +63,19 @@ pub enum FetchMetadataError {
         error: tokio::task::JoinError,
     },
 }
+
+/// Raised when an external [`crate::PackageVersionGuard`] rejects every
+/// version of a package that matched the request, leaving the picker no
+/// acceptable candidate. Distinct from "spec not supported": the spec is
+/// fine, but a policy (e.g. a vulnerability guard) blocked all matches.
+/// `reason` carries the guard's message for the last rejection.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display(
+    "Every version of {name} matching the request was rejected by the resolver guard ({reason})."
+)]
+#[diagnostic(code(pacquet_resolving_npm_resolver::all_versions_blocked))]
+pub struct AllVersionsBlockedError {
+    #[error(not(source))]
+    pub name: String,
+    pub reason: String,
+}

--- a/pacquet/crates/resolving-npm-resolver/src/errors.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/errors.rs
@@ -79,3 +79,19 @@ pub struct AllVersionsBlockedError {
     pub name: String,
     pub reason: String,
 }
+
+/// Raised when the resolver-time guard rejected so many candidates for a
+/// package that the re-pick safety limit was hit. Distinct from
+/// [`AllVersionsBlockedError`]: the picker stopped at the cap rather than
+/// proving every matching version is blocked.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display(
+    "Resolving {name} hit the resolver guard's {limit}-version re-pick limit; too many candidates were rejected ({reason})."
+)]
+#[diagnostic(code(pacquet_resolving_npm_resolver::guard_repick_limit))]
+pub struct GuardRepickLimitError {
+    #[error(not(source))]
+    pub name: String,
+    pub limit: usize,
+    pub reason: String,
+}

--- a/pacquet/crates/resolving-npm-resolver/src/errors.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/errors.rs
@@ -64,7 +64,7 @@ pub enum FetchMetadataError {
     },
 }
 
-/// Raised when an external [`crate::PackageVersionGuard`] rejects every
+/// Raised when an external `PackageVersionGuard` rejects every
 /// version of a package that matched the request, leaving the picker no
 /// acceptable candidate. Distinct from "spec not supported": the spec is
 /// fine, but a policy (e.g. a vulnerability guard) blocked all matches.

--- a/pacquet/crates/resolving-npm-resolver/src/named_registry_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/named_registry_resolver.rs
@@ -29,11 +29,14 @@ use pacquet_resolving_resolver_base::{
 };
 
 use crate::{
-    npm_resolver::{BuildResolveResult, PickedFromRegistry, build_resolve_result},
+    npm_resolver::{
+        BuildResolveResult, PickFromRegistryOptions, PickedFromRegistry, build_resolve_result,
+        pick_from_registry_with_guard,
+    },
     parse_bare_specifier::{
         NamedRegistryPackageSpec, parse_named_registry_specifier_to_registry_package_spec,
     },
-    pick_package::{PackageMetaCache, PickPackageContext, PickPackageOptions, pick_package},
+    pick_package::{PackageMetaCache, PickPackageContext},
     pick_package_from_meta::RegistryPackageSpec,
     violation_codes::MINIMUM_RELEASE_AGE_VIOLATION_CODE,
 };
@@ -199,20 +202,6 @@ impl<Cache: PackageMetaCache + 'static> NamedRegistryResolver<Cache> {
     ) -> Result<Option<PickedFromRegistry>, ResolveError> {
         let overlay_selectors =
             crate::preferred_overlay::overlay_merged_selectors(opts, &spec.name);
-        let pick_opts = PickPackageOptions {
-            registry,
-            preferred_version_selectors: overlay_selectors
-                .as_ref()
-                .or_else(|| opts.preferred_versions.get(&spec.name)),
-            published_by: opts.published_by,
-            published_by_exclude: opts.published_by_exclude.as_ref(),
-            pick_lowest_version: opts.pick_lowest_version,
-            include_latest_tag: opts.update == UpdateBehavior::Latest,
-            dry_run: opts.dry_run,
-            optional,
-            update_checksums: opts.update_checksums,
-        };
-
         let ctx = PickPackageContext {
             http_client: &self.http_client,
             auth_headers: &self.auth_headers,
@@ -227,15 +216,25 @@ impl<Cache: PackageMetaCache + 'static> NamedRegistryResolver<Cache> {
             retry_opts: self.retry_opts,
         };
 
-        let pick_result = pick_package(&ctx, spec, &pick_opts)
-            .await
-            .map_err(|err| Box::new(err) as ResolveError)?;
-
-        let Some(version) = pick_result.picked_package else {
-            return Ok(None);
-        };
-
-        Ok(Some(PickedFromRegistry { meta: pick_result.meta, version }))
+        pick_from_registry_with_guard(
+            &ctx,
+            PickFromRegistryOptions {
+                registry,
+                spec,
+                preferred_version_selectors: overlay_selectors
+                    .as_ref()
+                    .or_else(|| opts.preferred_versions.get(&spec.name)),
+                published_by: opts.published_by,
+                published_by_exclude: opts.published_by_exclude.as_ref(),
+                pick_lowest_version: opts.pick_lowest_version,
+                include_latest_tag: opts.update == UpdateBehavior::Latest,
+                dry_run: opts.dry_run,
+                optional,
+                update_checksums: opts.update_checksums,
+                package_version_guard: opts.package_version_guard.as_ref(),
+            },
+        )
+        .await
     }
 }
 

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -40,7 +40,7 @@ use pacquet_resolving_resolver_base::{
 };
 
 use crate::{
-    errors::AllVersionsBlockedError,
+    errors::{AllVersionsBlockedError, GuardRepickLimitError},
     named_registry::pick_registry_for_package,
     parse_bare_specifier::{parse_bare_specifier, parse_jsr_specifier_to_registry_package_spec},
     pick_package::{PackageMetaCache, PickPackageContext, PickPackageOptions, pick_package},
@@ -596,10 +596,15 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
                 // Each rejection re-runs the picker over the packument, so an
                 // unbounded run is O(versions²). Cap it well above any real
                 // run of consecutive rejected versions to bound the work a
-                // hostile packument can force, treating the cap as "no
-                // acceptable version".
+                // hostile packument can force. This is a safety cutoff, not
+                // proof every version is blocked, so report it as its own
+                // error rather than "all versions blocked".
                 if blocked_versions.len() >= GUARD_REPICK_LIMIT {
-                    return Err(all_versions_blocked(opts.spec, reason));
+                    return Err(Box::new(GuardRepickLimitError {
+                        name: opts.spec.name.clone(),
+                        limit: GUARD_REPICK_LIMIT,
+                        reason,
+                    }));
                 }
                 last_rejection = Some(reason);
             }

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -524,6 +524,11 @@ pub(crate) struct PickFromRegistryOptions<'a> {
         Option<&'a Arc<dyn pacquet_resolving_resolver_base::PackageVersionGuard>>,
 }
 
+/// Upper bound on guard rejections for one package before the resolver
+/// gives up. Far beyond any realistic run of consecutive blocked
+/// versions, so it only fires on a pathological/hostile packument.
+const GUARD_REPICK_LIMIT: usize = 1000;
+
 pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
     ctx: &PickPackageContext<'_, Cache>,
     opts: PickFromRegistryOptions<'_>,
@@ -586,6 +591,14 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
                 // already blocked, so it can't be excluded; stop rather than
                 // loop forever — every match really is blocked.
                 if !blocked_versions.insert(blocked_key) {
+                    return Err(all_versions_blocked(opts.spec, reason));
+                }
+                // Each rejection re-runs the picker over the packument, so an
+                // unbounded run is O(versions²). Cap it well above any real
+                // run of consecutive rejected versions to bound the work a
+                // hostile packument can force, treating the cap as "no
+                // acceptable version".
+                if blocked_versions.len() >= GUARD_REPICK_LIMIT {
                     return Err(all_versions_blocked(opts.spec, reason));
                 }
                 last_rejection = Some(reason);

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -575,17 +575,42 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
                     reason = %reason,
                     "package version rejected by resolver guard",
                 );
-                // A `false` return means the picker re-selected a version we
-                // already blocked, so filtering can't exclude it (e.g. the
-                // parsed version string doesn't match the packument key).
-                // Stop rather than loop forever — every match is blocked.
-                if !blocked_versions.insert(version_str) {
+                // Block by the *packument key*, which the next pick filters
+                // on. It usually equals the parsed manifest version, but a
+                // registry that serves a key differing from the manifest's
+                // `version` field would otherwise never get the candidate
+                // excluded — re-selecting it forever and wrongly reporting
+                // every version blocked when a lower one is still fine.
+                let blocked_key = blocked_packument_key(&pick_result.meta, &version, &version_str);
+                // A `false` return means the picker re-selected a key we
+                // already blocked, so it can't be excluded; stop rather than
+                // loop forever — every match really is blocked.
+                if !blocked_versions.insert(blocked_key) {
                     return Err(all_versions_blocked(opts.spec, reason));
                 }
                 last_rejection = Some(reason);
             }
         }
     }
+}
+
+/// The packument key for a picked version, so the guard loop can block the
+/// exact entry the next pick filters on. Fast-paths the common case where
+/// the parsed manifest version is itself the key; only falls back to
+/// locating the key by identity when a registry served a mismatched key.
+fn blocked_packument_key(
+    meta: &Package,
+    picked: &Arc<PackageVersion>,
+    version_str: &str,
+) -> String {
+    if meta.versions.contains_key(version_str) {
+        return version_str.to_string();
+    }
+    meta.versions
+        .keys()
+        .find(|key| meta.versions.get(key).is_some_and(|candidate| Arc::ptr_eq(&candidate, picked)))
+        .cloned()
+        .unwrap_or_else(|| version_str.to_string())
 }
 
 fn all_versions_blocked(spec: &RegistryPackageSpec, reason: String) -> ResolveError {

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -34,9 +34,9 @@ use pacquet_lockfile::{LockfileResolution, PkgName, PkgNameVer, TarballResolutio
 use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pacquet_registry::{Package, PackageVersion};
 use pacquet_resolving_resolver_base::{
-    LatestInfo, LatestQuery, ResolutionPolicyViolation, ResolveError, ResolveFuture,
-    ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, UpdateBehavior, WantedDependency,
-    WorkspacePackages, parse_packument_timestamp,
+    LatestInfo, LatestQuery, PackageVersionGuardDecision, ResolutionPolicyViolation, ResolveError,
+    ResolveFuture, ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, UpdateBehavior,
+    WantedDependency, WorkspacePackages, parse_packument_timestamp,
 };
 
 use crate::{
@@ -337,20 +337,6 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
     ) -> Result<Option<PickedFromRegistry>, ResolveError> {
         let overlay_selectors =
             crate::preferred_overlay::overlay_merged_selectors(opts, &spec.name);
-        let pick_opts = PickPackageOptions {
-            registry,
-            preferred_version_selectors: overlay_selectors
-                .as_ref()
-                .or_else(|| opts.preferred_versions.get(&spec.name)),
-            published_by: opts.published_by,
-            published_by_exclude: opts.published_by_exclude.as_ref(),
-            pick_lowest_version: opts.pick_lowest_version,
-            include_latest_tag: opts.update == UpdateBehavior::Latest,
-            dry_run: opts.dry_run,
-            optional,
-            update_checksums: opts.update_checksums,
-        };
-
         let ctx = PickPackageContext {
             http_client: &self.http_client,
             auth_headers: &self.auth_headers,
@@ -365,15 +351,25 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             retry_opts: self.retry_opts,
         };
 
-        let pick_result = pick_package(&ctx, spec, &pick_opts)
-            .await
-            .map_err(|err| Box::new(err) as ResolveError)?;
-
-        let Some(version) = pick_result.picked_package else {
-            return Ok(None);
-        };
-
-        Ok(Some(PickedFromRegistry { meta: pick_result.meta, version }))
+        pick_from_registry_with_guard(
+            &ctx,
+            PickFromRegistryOptions {
+                registry,
+                spec,
+                preferred_version_selectors: overlay_selectors
+                    .as_ref()
+                    .or_else(|| opts.preferred_versions.get(&spec.name)),
+                published_by: opts.published_by,
+                published_by_exclude: opts.published_by_exclude.as_ref(),
+                pick_lowest_version: opts.pick_lowest_version,
+                include_latest_tag: opts.update == UpdateBehavior::Latest,
+                dry_run: opts.dry_run,
+                optional,
+                update_checksums: opts.update_checksums,
+                package_version_guard: opts.package_version_guard.as_ref(),
+            },
+        )
+        .await
     }
 
     /// Latest-version companion. Mirrors upstream's
@@ -510,6 +506,69 @@ fn default_tag_spec(alias: &str, default_tag: &str) -> RegistryPackageSpec {
 pub(crate) struct PickedFromRegistry {
     pub(crate) meta: std::sync::Arc<Package>,
     pub(crate) version: std::sync::Arc<PackageVersion>,
+}
+
+pub(crate) struct PickFromRegistryOptions<'a> {
+    pub registry: &'a str,
+    pub spec: &'a RegistryPackageSpec,
+    pub preferred_version_selectors: Option<&'a pacquet_resolving_resolver_base::VersionSelectors>,
+    pub published_by: Option<DateTime<Utc>>,
+    pub published_by_exclude: Option<&'a PackageVersionPolicy>,
+    pub pick_lowest_version: bool,
+    pub include_latest_tag: bool,
+    pub dry_run: bool,
+    pub optional: bool,
+    pub update_checksums: bool,
+    pub package_version_guard:
+        Option<&'a Arc<dyn pacquet_resolving_resolver_base::PackageVersionGuard>>,
+}
+
+pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
+    ctx: &PickPackageContext<'_, Cache>,
+    opts: PickFromRegistryOptions<'_>,
+) -> Result<Option<PickedFromRegistry>, ResolveError> {
+    let mut blocked_versions = std::collections::HashSet::new();
+    loop {
+        let pick_opts = PickPackageOptions {
+            registry: opts.registry,
+            preferred_version_selectors: opts.preferred_version_selectors,
+            published_by: opts.published_by,
+            published_by_exclude: opts.published_by_exclude,
+            pick_lowest_version: opts.pick_lowest_version,
+            include_latest_tag: opts.include_latest_tag,
+            dry_run: opts.dry_run,
+            optional: opts.optional,
+            update_checksums: opts.update_checksums,
+            blocked_versions: (!blocked_versions.is_empty()).then_some(&blocked_versions),
+        };
+        let pick_result = pick_package(ctx, opts.spec, &pick_opts)
+            .await
+            .map_err(|err| Box::new(err) as ResolveError)?;
+
+        let Some(version) = pick_result.picked_package else {
+            return Ok(None);
+        };
+        let Some(guard) = opts.package_version_guard else {
+            return Ok(Some(PickedFromRegistry { meta: pick_result.meta, version }));
+        };
+
+        let version_str = version.version.to_string();
+        match guard.check(&opts.spec.name, &version_str).await? {
+            PackageVersionGuardDecision::Allow => {
+                return Ok(Some(PickedFromRegistry { meta: pick_result.meta, version }));
+            }
+            PackageVersionGuardDecision::Reject { reason } => {
+                tracing::debug!(
+                    target: "pacquet_resolving_npm_resolver",
+                    name = %opts.spec.name,
+                    version = %version_str,
+                    reason,
+                    "package version rejected by resolver guard",
+                );
+                blocked_versions.insert(version_str);
+            }
+        }
+    }
 }
 
 /// Input bundle for [`build_resolve_result`]. Grouped so the

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -565,7 +565,14 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
                     reason,
                     "package version rejected by resolver guard",
                 );
-                blocked_versions.insert(version_str);
+                // A `false` return means the picker re-selected a version we
+                // already blocked, so filtering can't exclude it (e.g. the
+                // parsed version string doesn't match the packument key).
+                // Stop rather than loop forever, treating the package as
+                // having no acceptable version.
+                if !blocked_versions.insert(version_str) {
+                    return Ok(None);
+                }
             }
         }
     }

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -40,6 +40,7 @@ use pacquet_resolving_resolver_base::{
 };
 
 use crate::{
+    errors::AllVersionsBlockedError,
     named_registry::pick_registry_for_package,
     parse_bare_specifier::{parse_bare_specifier, parse_jsr_specifier_to_registry_package_spec},
     pick_package::{PackageMetaCache, PickPackageContext, PickPackageOptions, pick_package},
@@ -528,6 +529,7 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
     opts: PickFromRegistryOptions<'_>,
 ) -> Result<Option<PickedFromRegistry>, ResolveError> {
     let mut blocked_versions = std::collections::HashSet::new();
+    let mut last_rejection: Option<String> = None;
     loop {
         let pick_opts = PickPackageOptions {
             registry: opts.registry,
@@ -546,7 +548,15 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
             .map_err(|err| Box::new(err) as ResolveError)?;
 
         let Some(version) = pick_result.picked_package else {
-            return Ok(None);
+            // No candidate left. With no prior guard rejection this is the
+            // ordinary "no matching version" outcome the resolver folds into
+            // Ok(None); once the guard has rejected every match, surface that
+            // as a distinct error instead of letting it read as an
+            // unsupported spec downstream.
+            return match last_rejection {
+                Some(reason) => Err(all_versions_blocked(opts.spec, reason)),
+                None => Ok(None),
+            };
         };
         let Some(guard) = opts.package_version_guard else {
             return Ok(Some(PickedFromRegistry { meta: pick_result.meta, version }));
@@ -562,20 +572,24 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
                     target: "pacquet_resolving_npm_resolver",
                     name = %opts.spec.name,
                     version = %version_str,
-                    reason,
+                    reason = %reason,
                     "package version rejected by resolver guard",
                 );
                 // A `false` return means the picker re-selected a version we
                 // already blocked, so filtering can't exclude it (e.g. the
                 // parsed version string doesn't match the packument key).
-                // Stop rather than loop forever, treating the package as
-                // having no acceptable version.
+                // Stop rather than loop forever — every match is blocked.
                 if !blocked_versions.insert(version_str) {
-                    return Ok(None);
+                    return Err(all_versions_blocked(opts.spec, reason));
                 }
+                last_rejection = Some(reason);
             }
         }
     }
+}
+
+fn all_versions_blocked(spec: &RegistryPackageSpec, reason: String) -> ResolveError {
+    Box::new(AllVersionsBlockedError { name: spec.name.clone(), reason })
 }
 
 /// Input bundle for [`build_resolve_result`]. Grouped so the

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -252,6 +252,33 @@ async fn package_version_guard_repopulates_latest_tag() {
 }
 
 #[tokio::test]
+async fn package_version_guard_blocking_every_version_errors() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock =
+        server.mock("GET", "/acme").with_status(200).with_body(PACKAGE_BODY).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let opts = ResolveOptions {
+        package_version_guard: Some(reject_versions(&["1.0.0", "1.1.0"])),
+        ..ResolveOptions::default()
+    };
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+
+    // Every matching version is rejected, so the resolver must surface a
+    // clear guard error rather than Ok(None) (which would read as an
+    // unsupported spec downstream).
+    let err = resolver.resolve(&wanted, &opts).await.expect_err("expected a guard error");
+    let message = err.to_string();
+    assert!(message.contains("acme"), "{message}");
+    assert!(message.contains("rejected by the resolver guard"), "{message}");
+}
+
+#[tokio::test]
 async fn workspace_path_form_falls_through_to_local_resolver() {
     let server = mockito::Server::new_async().await;
     let registry = format!("{}/", server.url());

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -248,6 +248,7 @@ async fn package_version_guard_repopulates_latest_tag() {
 
     let result = resolver.resolve(&wanted, &opts).await.unwrap().unwrap();
     assert_eq!(result.name_ver.as_ref().expect("name_ver").suffix.to_string(), "1.0.0");
+    assert_eq!(result.latest.as_deref(), Some("1.0.0"));
 }
 
 #[tokio::test]

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -278,6 +278,69 @@ async fn package_version_guard_blocking_every_version_errors() {
     assert!(message.contains("rejected by the resolver guard"), "{message}");
 }
 
+/// Packument whose `1.5.0+build` key carries a manifest `version` of
+/// `1.5.0` — i.e. the version-map key differs from the parsed manifest
+/// version, the case a malformed/malicious registry can produce.
+const MISMATCHED_KEY_BODY: &str = r#"{
+    "name": "acme",
+    "dist-tags": { "latest": "1.5.0+build" },
+    "modified": "2025-01-15T12:00:00.000Z",
+    "time": {
+        "1.0.0": "2024-01-10T08:30:00.000Z",
+        "1.5.0+build": "2024-12-10T08:30:00.000Z"
+    },
+    "versions": {
+        "1.0.0": {
+            "name": "acme",
+            "version": "1.0.0",
+            "dist": {
+                "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                "shasum": "0000000000000000000000000000000000000000",
+                "tarball": "https://registry/acme-1.0.0.tgz"
+            }
+        },
+        "1.5.0+build": {
+            "name": "acme",
+            "version": "1.5.0",
+            "dist": {
+                "integrity": "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+                "shasum": "1111111111111111111111111111111111111111",
+                "tarball": "https://registry/acme-1.5.0.tgz"
+            }
+        }
+    }
+}"#;
+
+#[tokio::test]
+async fn package_version_guard_blocks_the_packument_key_not_the_parsed_version() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(MISMATCHED_KEY_BODY)
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    // The guard rejects the parsed manifest version `1.5.0`, whose
+    // packument key is `1.5.0+build`. The repick must still exclude that
+    // entry and fall back to `1.0.0`, rather than wrongly reporting that
+    // every version is blocked.
+    let opts = ResolveOptions {
+        package_version_guard: Some(reject_versions(&["1.5.0"])),
+        ..ResolveOptions::default()
+    };
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().unwrap();
+    assert_eq!(result.name_ver.as_ref().expect("name_ver").suffix.to_string(), "1.0.0");
+}
+
 #[tokio::test]
 async fn workspace_path_form_falls_through_to_local_resolver() {
     let server = mockito::Server::new_async().await;

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -9,7 +9,8 @@ use pacquet_config::TrustPolicy;
 use pacquet_lockfile::LockfileResolution;
 use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pacquet_resolving_resolver_base::{
-    LatestQuery, ResolveOptions, Resolver, UpdateBehavior, WantedDependency, WorkspacePackage,
+    LatestQuery, PackageVersionGuard, PackageVersionGuardDecision, PackageVersionGuardFuture,
+    ResolveOptions, Resolver, UpdateBehavior, WantedDependency, WorkspacePackage,
     WorkspacePackages, WorkspacePackagesByVersion,
 };
 use pretty_assertions::assert_eq;
@@ -81,6 +82,29 @@ fn build_resolver_with_registries(
         retry_opts: RetryOpts::default(),
     };
     (resolver, cache_dir)
+}
+
+#[derive(Debug)]
+struct RejectVersions {
+    versions: HashSet<String>,
+}
+
+impl PackageVersionGuard for RejectVersions {
+    fn check<'a>(&'a self, _name: &'a str, version: &'a str) -> PackageVersionGuardFuture<'a> {
+        Box::pin(async move {
+            if self.versions.contains(version) {
+                Ok(PackageVersionGuardDecision::Reject { reason: format!("{version} is blocked") })
+            } else {
+                Ok(PackageVersionGuardDecision::Allow)
+            }
+        })
+    }
+}
+
+fn reject_versions(versions: &[&str]) -> Arc<dyn PackageVersionGuard> {
+    Arc::new(RejectVersions {
+        versions: versions.iter().map(|version| (*version).to_string()).collect(),
+    })
 }
 
 /// Packument body for `@jsr/foo__bar` — the npm-shaped name JSR
@@ -181,6 +205,49 @@ async fn range_specifier_picks_max_in_range() {
     assert_eq!(result.alias.as_deref(), Some("acme"));
     assert!(result.policy_violation.is_none());
     assert!(matches!(result.resolution, LockfileResolution::Tarball(_)));
+}
+
+#[tokio::test]
+async fn package_version_guard_excludes_rejected_versions_and_repicks() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock =
+        server.mock("GET", "/acme").with_status(200).with_body(PACKAGE_BODY).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let opts = ResolveOptions {
+        package_version_guard: Some(reject_versions(&["1.1.0"])),
+        ..ResolveOptions::default()
+    };
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().unwrap();
+    let name_ver = result.name_ver.as_ref().expect("name_ver");
+    assert_eq!(name_ver.suffix.to_string(), "1.0.0");
+    assert_eq!(result.latest.as_deref(), Some("1.0.0"));
+}
+
+#[tokio::test]
+async fn package_version_guard_repopulates_latest_tag() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock =
+        server.mock("GET", "/acme").with_status(200).with_body(PACKAGE_BODY).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let opts = ResolveOptions {
+        package_version_guard: Some(reject_versions(&["1.1.0"])),
+        ..ResolveOptions::default()
+    };
+    let wanted =
+        WantedDependency { alias: Some("acme".to_string()), ..WantedDependency::default() };
+
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().unwrap();
+    assert_eq!(result.name_ver.as_ref().expect("name_ver").suffix.to_string(), "1.0.0");
 }
 
 #[tokio::test]

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -51,6 +51,7 @@
 //! 3-5× behind pnpm on the `alotta-files` benchmark.
 
 use std::{
+    collections::HashSet,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
@@ -74,7 +75,8 @@ use crate::{
     },
     pick_package_from_meta::{
         PickPackageFromMetaError, PickPackageFromMetaOptions, RegistryPackageSpec,
-        RegistryPackageSpecType, pick_lowest_version_by_version_range, pick_package_from_meta,
+        RegistryPackageSpecType, filter_pkg_metadata_versions,
+        pick_lowest_version_by_version_range, pick_package_from_meta,
         pick_version_by_version_range,
     },
 };
@@ -296,6 +298,11 @@ pub struct PickPackageOptions<'a> {
     /// resolver it might be disk-sourced, which would short-circuit the
     /// revalidation. Mirrors pnpm's `--update-checksums`.
     pub update_checksums: bool,
+    /// Concrete versions to ignore while picking. Used by callers that
+    /// apply an external resolver-time guard: after the guard rejects a
+    /// candidate, the caller asks the normal picker to try again over
+    /// the same packument with that version filtered out.
+    pub blocked_versions: Option<&'a HashSet<String>>,
 }
 
 /// Outcome of a successful [`pick_package`] call. Mirrors
@@ -490,7 +497,8 @@ pub async fn pick_package<Cache: PackageMetaCache>(
 
         if ctx.offline {
             if let Some(meta) = meta_cached_in_store {
-                let picked = pick_matching_version_final(&picker_opts, spec, &meta)?;
+                let (meta, picked) =
+                    pick_from_meta(&picker_opts, spec, meta, opts.blocked_versions)?;
                 return Ok(PickPackageResult { meta, picked_package: picked });
             }
             return Err(PickPackageError::NoOfflineMeta {
@@ -516,9 +524,10 @@ pub async fn pick_package<Cache: PackageMetaCache>(
                 }
                 ctx.meta_cache.set(cache_key.clone(), Arc::clone(&meta));
             }
-            let picked = pick_matching_version_final(&picker_opts, spec, &meta)?;
+            let (picked_meta, picked) =
+                pick_from_meta(&picker_opts, spec, Arc::clone(&meta), opts.blocked_versions)?;
             if picked.is_some() {
-                return Ok(PickPackageResult { meta, picked_package: picked });
+                return Ok(PickPackageResult { meta: picked_meta, picked_package: picked });
             }
             // Fall through to fetch when disk had the meta but no
             // version satisfied the spec — the disk copy may be
@@ -547,7 +556,9 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             // upgrade abbreviated→full. Pacquet's fetcher is
             // always full so this branch shouldn't fire today,
             // but the swallow-and-fall-through matches upstream.
-            if let Ok(Some(picked)) = pick_matching_version_fast(&picker_opts, spec, meta) {
+            if let Ok((picked_meta, Some(picked))) =
+                pick_from_meta_fast(&picker_opts, spec, Arc::clone(meta), opts.blocked_versions)
+            {
                 // Promote the disk-loaded packument into the
                 // install-scoped in-memory cache so later resolves
                 // for the same `(registry, name)` skip the
@@ -560,10 +571,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
                 if !opts.dry_run {
                     ctx.meta_cache.set(cache_key.clone(), Arc::clone(meta));
                 }
-                return Ok(PickPackageResult {
-                    meta: Arc::clone(meta),
-                    picked_package: Some(picked),
-                });
+                return Ok(PickPackageResult { meta: picked_meta, picked_package: Some(picked) });
             }
         }
     }
@@ -585,7 +593,8 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             meta_cached_in_store = load_meta_async(pkg_mirror.as_deref()).await.map(Arc::new);
         }
         if let Some(ref meta) = meta_cached_in_store
-            && let Ok(Some(picked)) = pick_matching_version_fast(&picker_opts, spec, meta)
+            && let Ok((picked_meta, Some(picked))) =
+                pick_from_meta_fast(&picker_opts, spec, Arc::clone(meta), opts.blocked_versions)
         {
             // Same rationale as the version-spec fast path above —
             // promote the disk-loaded packument into the
@@ -593,7 +602,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             if !opts.dry_run {
                 ctx.meta_cache.set(cache_key.clone(), Arc::clone(meta));
             }
-            return Ok(PickPackageResult { meta: Arc::clone(meta), picked_package: Some(picked) });
+            return Ok(PickPackageResult { meta: picked_meta, picked_package: Some(picked) });
         }
     }
 
@@ -631,8 +640,9 @@ pub async fn pick_package<Cache: PackageMetaCache>(
                     pkg_name = %spec.name,
                     "metadata fetch failed; falling back to on-disk mirror",
                 );
-                let picked = pick_matching_version_final(&picker_opts, spec, &disk)?;
-                return Ok(PickPackageResult { meta: disk, picked_package: picked });
+                let (meta, picked) =
+                    pick_from_meta(&picker_opts, spec, disk, opts.blocked_versions)?;
+                return Ok(PickPackageResult { meta, picked_package: picked });
             }
             return Err(error.into());
         }
@@ -659,7 +669,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     if !opts.dry_run {
         ctx.meta_cache.set(cache_key, Arc::clone(&meta));
     }
-    let picked = pick_matching_version_final(&picker_opts, spec, &meta)?;
+    let (meta, picked) = pick_from_meta(&picker_opts, spec, meta, opts.blocked_versions)?;
     Ok(PickPackageResult { meta, picked_package: picked })
 }
 
@@ -700,7 +710,7 @@ async fn handle_cache_hit<Cache: PackageMetaCache>(
         }
         ctx.meta_cache.set(cache_key.to_string(), Arc::clone(&meta));
     }
-    let picked = pick_matching_version_final(picker_opts, spec, &meta)?;
+    let (meta, picked) = pick_from_meta(picker_opts, spec, meta, opts.blocked_versions)?;
     Ok(PickPackageResult { meta, picked_package: picked })
 }
 
@@ -735,6 +745,47 @@ fn pick_matching_version_fast(
     } else {
         pick_ignoring_release_age(picker_opts, spec, meta)
     }
+}
+
+fn pick_from_meta_fast(
+    picker_opts: &PickerOpts<'_>,
+    spec: &RegistryPackageSpec,
+    meta: Arc<Package>,
+    blocked_versions: Option<&HashSet<String>>,
+) -> Result<(Arc<Package>, Option<Arc<PackageVersion>>), PickPackageFromMetaError> {
+    let meta = filter_blocked_versions(meta, blocked_versions);
+    if meta.versions.is_empty() && blocked_versions.is_some_and(|blocked| !blocked.is_empty()) {
+        return Ok((meta, None));
+    }
+    let picked = pick_matching_version_fast(picker_opts, spec, &meta)?;
+    Ok((meta, picked))
+}
+
+fn pick_from_meta(
+    picker_opts: &PickerOpts<'_>,
+    spec: &RegistryPackageSpec,
+    meta: Arc<Package>,
+    blocked_versions: Option<&HashSet<String>>,
+) -> Result<(Arc<Package>, Option<Arc<PackageVersion>>), PickPackageFromMetaError> {
+    let meta = filter_blocked_versions(meta, blocked_versions);
+    if meta.versions.is_empty() && blocked_versions.is_some_and(|blocked| !blocked.is_empty()) {
+        return Ok((meta, None));
+    }
+    let picked = pick_matching_version_final(picker_opts, spec, &meta)?;
+    Ok((meta, picked))
+}
+
+fn filter_blocked_versions(
+    meta: Arc<Package>,
+    blocked_versions: Option<&HashSet<String>>,
+) -> Arc<Package> {
+    let Some(blocked_versions) = blocked_versions else {
+        return meta;
+    };
+    if blocked_versions.is_empty() {
+        return meta;
+    }
+    Arc::new(filter_pkg_metadata_versions(&meta, |version| !blocked_versions.contains(version)))
 }
 
 /// Picker used at terminal return sites where there's no further

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -75,6 +75,7 @@ fn default_opts(registry: &str) -> PickPackageOptions<'_> {
         dry_run: false,
         optional: false,
         update_checksums: false,
+        blocked_versions: None,
     }
 }
 

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -37,7 +37,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use node_semver::{Range, Version};
 use pacquet_config::version_policy::{PackageVersionPolicy, PolicyMatch};
-use pacquet_registry::{Package, PackageVersion};
+use pacquet_registry::{Package, PackageVersion, PackageVersions};
 use pacquet_resolving_resolver_base::{
     VersionSelectorEntry, VersionSelectorType, VersionSelectors, parse_packument_timestamp,
 };
@@ -400,9 +400,7 @@ pub fn filter_pkg_metadata_by_publish_date(
          caller must check before invoking",
     );
 
-    // Decide on version strings + the `time` map alone; slots move as
-    // raw fragments, so the filter never hydrates a manifest.
-    let versions_within_date = meta.versions.filtered(|version| {
+    filter_pkg_metadata_versions(meta, |version| {
         let mature = time
             .get(version)
             .and_then(serde_json::Value::as_str)
@@ -411,8 +409,36 @@ pub fn filter_pkg_metadata_by_publish_date(
         let trusted =
             trusted_versions.is_some_and(|allow| allow.iter().any(|allowed| allowed == version));
         mature || trusted
-    });
+    })
+}
 
+/// Filter a packument's versions by string while keeping dist-tags
+/// usable. Tags that still point at a kept version are preserved; tags
+/// whose target was removed are rewritten to the best remaining version
+/// in the same family, matching the publish-date filter's behavior.
+#[must_use]
+pub fn filter_pkg_metadata_versions(meta: &Package, mut keep: impl FnMut(&str) -> bool) -> Package {
+    // Decide on version strings alone; slots move as raw fragments, so
+    // the filter never hydrates a manifest.
+    let filtered_versions = meta.versions.filtered(|version| keep(version));
+    let dist_tags = repopulate_dist_tags(meta, &filtered_versions);
+
+    Package {
+        name: meta.name.clone(),
+        dist_tags,
+        versions: filtered_versions,
+        time: meta.time.clone(),
+        modified: meta.modified.clone(),
+        etag: meta.etag.clone(),
+        homepage: meta.homepage.clone(),
+        mutex: std::sync::Arc::clone(&meta.mutex),
+    }
+}
+
+fn repopulate_dist_tags(
+    meta: &Package,
+    filtered_versions: &PackageVersions,
+) -> std::collections::HashMap<String, String> {
     let mut dist_tags_within_date = std::collections::HashMap::new();
     // Candidate versions parsed once per filter call and shared by
     // every repopulated tag, with the deprecation flag resolved
@@ -423,14 +449,14 @@ pub fn filter_pkg_metadata_by_publish_date(
     // out-of-cutoff dist-tags.
     let mut parsed_candidates: Option<Vec<(Version, &String, OnceCell<bool>)>> = None;
     for (tag, version) in &meta.dist_tags {
-        if versions_within_date.contains_key(version) {
+        if filtered_versions.contains_key(version) {
             dist_tags_within_date.insert(tag.clone(), version.clone());
             continue;
         }
         let Ok(original) = Version::parse(version) else { continue };
         let original_is_prerelease = !original.pre_release.is_empty();
         let candidates = parsed_candidates.get_or_insert_with(|| {
-            versions_within_date
+            filtered_versions
                 .keys()
                 .filter_map(|raw| {
                     Version::parse(raw).ok().map(|parsed| (parsed, raw, OnceCell::new()))
@@ -438,7 +464,7 @@ pub fn filter_pkg_metadata_by_publish_date(
                 .collect()
         });
         let deprecated = |slot: &(Version, &String, OnceCell<bool>)| -> bool {
-            *slot.2.get_or_init(|| versions_within_date.is_deprecated(slot.1))
+            *slot.2.get_or_init(|| filtered_versions.is_deprecated(slot.1))
         };
         let mut best_index: Option<usize> = None;
         for (index, slot) in candidates.iter().enumerate() {
@@ -468,17 +494,7 @@ pub fn filter_pkg_metadata_by_publish_date(
             dist_tags_within_date.insert(tag.clone(), candidates[best].1.clone());
         }
     }
-
-    Package {
-        name: meta.name.clone(),
-        dist_tags: dist_tags_within_date,
-        versions: versions_within_date,
-        time: meta.time.clone(),
-        modified: meta.modified.clone(),
-        etag: meta.etag.clone(),
-        homepage: meta.homepage.clone(),
-        mutex: std::sync::Arc::clone(&meta.mutex),
-    }
+    dist_tags_within_date
 }
 
 /// Group versions by weight (highest weight first); each group is

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -414,8 +414,10 @@ pub fn filter_pkg_metadata_by_publish_date(
 
 /// Filter a packument's versions by string while keeping dist-tags
 /// usable. Tags that still point at a kept version are preserved; tags
-/// whose target was removed are rewritten to the best remaining version
-/// in the same family, matching the publish-date filter's behavior.
+/// whose target was removed are rewritten using the publish-date
+/// filter's dist-tag rules: `latest` may move to the best remaining
+/// version across any major, while other tags stay within the removed
+/// target's major/prerelease lane.
 #[must_use]
 pub fn filter_pkg_metadata_versions(meta: &Package, mut keep: impl FnMut(&str) -> bool) -> Package {
     // Decide on version strings alone; slots move as raw fragments, so

--- a/pacquet/crates/resolving-resolver-base/src/lib.rs
+++ b/pacquet/crates/resolving-resolver-base/src/lib.rs
@@ -29,11 +29,12 @@ mod verifier;
 pub use publish_time::parse_packument_timestamp;
 pub use resolve::{
     CurrentPkg, DIRECT_DEP_SELECTOR_WEIGHT, DependencyManifest, EXISTING_VERSION_SELECTOR_WEIGHT,
-    LatestInfo, LatestQuery, PkgResolutionId, PreferredVersions, PreferredVersionsOverlay,
-    ResolveError, ResolveFuture, ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver,
-    SharedDependencyManifest, UpdateBehavior, VersionSelectorEntry, VersionSelectorType,
-    VersionSelectorWithWeight, VersionSelectors, WantedDependency, WorkspacePackage,
-    WorkspacePackages, WorkspacePackagesByVersion,
+    LatestInfo, LatestQuery, PackageVersionGuard, PackageVersionGuardDecision,
+    PackageVersionGuardError, PackageVersionGuardFuture, PkgResolutionId, PreferredVersions,
+    PreferredVersionsOverlay, ResolveError, ResolveFuture, ResolveLatestFuture, ResolveOptions,
+    ResolveResult, Resolver, SharedDependencyManifest, UpdateBehavior, VersionSelectorEntry,
+    VersionSelectorType, VersionSelectorWithWeight, VersionSelectors, WantedDependency,
+    WorkspacePackage, WorkspacePackages, WorkspacePackagesByVersion,
 };
 pub use verifier::{
     ResolutionPolicyViolation, ResolutionVerification, ResolutionVerifier, VerifyCtx, VerifyFuture,

--- a/pacquet/crates/resolving-resolver-base/src/resolve.rs
+++ b/pacquet/crates/resolving-resolver-base/src/resolve.rs
@@ -225,6 +225,40 @@ pub type WorkspacePackagesByVersion = BTreeMap<String, WorkspacePackage>;
 /// [`WorkspacePackages`](https://github.com/pnpm/pnpm/blob/3687b0e180/resolving/resolver-base/src/index.ts#L246).
 pub type WorkspacePackages = BTreeMap<String, WorkspacePackagesByVersion>;
 
+/// Verdict returned by a resolver-time package-version guard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PackageVersionGuardDecision {
+    /// The candidate may be used.
+    Allow,
+    /// The candidate must be ignored and the resolver should try the
+    /// next matching version, when one exists.
+    Reject { reason: String },
+}
+
+/// Error from a package-version guard. Boxed so guard implementations
+/// can keep their own error shape.
+pub type PackageVersionGuardError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Boxed-future return type for [`PackageVersionGuard::check`].
+pub type PackageVersionGuardFuture<'a> = Pin<
+    Box<
+        dyn Future<Output = Result<PackageVersionGuardDecision, PackageVersionGuardError>>
+            + Send
+            + 'a,
+    >,
+>;
+
+/// Optional resolver-time policy that can reject a concrete
+/// `name@version` candidate before it is committed to the lockfile.
+///
+/// A guard is expected to be deterministic for the duration of one
+/// resolve call. Callers that consult external services should cache
+/// per `(name, version)` within that operation so repeated graph edges
+/// don't multiply network traffic.
+pub trait PackageVersionGuard: Send + Sync + std::fmt::Debug {
+    fn check<'a>(&'a self, name: &'a str, version: &'a str) -> PackageVersionGuardFuture<'a>;
+}
+
 /// Reload behavior the dispatcher passes per-resolve. Mirrors pnpm's
 /// [`ResolveOptions.update`](https://github.com/pnpm/pnpm/blob/3687b0e180/resolving/resolver-base/src/index.ts#L291)
 /// tri-state (`false | 'compatible' | 'latest'`).
@@ -316,6 +350,12 @@ pub struct ResolveOptions {
     /// resolution. Mirrors upstream's `dryRun` flag at the resolver
     /// boundary.
     pub dry_run: bool,
+    /// Optional guard that rejects concrete npm package versions after
+    /// the normal picker selects them. The npm resolvers then exclude
+    /// the rejected version and pick again, so a vulnerable or otherwise
+    /// disallowed high version can fall back to a lower safe version
+    /// instead of aborting the whole resolution.
+    pub package_version_guard: Option<Arc<dyn PackageVersionGuard>>,
     /// When `true`, reject exotic (git, tarball, file, ...) dependencies
     /// appearing anywhere below the importer. Direct dependencies are
     /// still allowed; only transitive deps are gated. The check

--- a/pnpr/crates/pnpr/Cargo.toml
+++ b/pnpr/crates/pnpr/Cargo.toml
@@ -45,6 +45,7 @@ futures-util                    = { workspace = true }
 getrandom                       = { workspace = true }
 home                            = { workspace = true }
 indexmap                        = { workspace = true }
+libc                            = { workspace = true }
 libsql                          = { workspace = true }
 miette                          = { workspace = true }
 node-semver                     = { workspace = true }

--- a/pnpr/crates/pnpr/Cargo.toml
+++ b/pnpr/crates/pnpr/Cargo.toml
@@ -47,6 +47,7 @@ home                            = { workspace = true }
 indexmap                        = { workspace = true }
 libsql                          = { workspace = true }
 miette                          = { workspace = true }
+node-semver                     = { workspace = true }
 object_store                    = { workspace = true }
 reqwest                         = { workspace = true }
 rusqlite                        = { workspace = true }
@@ -61,6 +62,7 @@ tower-http                      = { workspace = true }
 tracing                         = { workspace = true }
 tracing-subscriber              = { workspace = true, features = ["json"] }
 wax                             = { workspace = true }
+zip                             = { workspace = true }
 
 [dev-dependencies]
 mockito    = { workspace = true }

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -110,6 +110,15 @@ pub struct Config {
     /// switches both to a shared networked-SQLite database so several
     /// stateless pnpr replicas see a consistent set of accounts.
     pub backend: BackendConfig,
+    /// Optional local OSV database used by the resolver to reject known
+    /// vulnerable npm package versions without live API calls.
+    pub osv: OsvConfig,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct OsvConfig {
+    pub enabled: bool,
+    pub path: Option<PathBuf>,
 }
 
 /// The resolved hosted-store backend. The object-store client is built
@@ -719,6 +728,9 @@ struct ConfigFile {
     /// config (silently ignored there).
     #[serde(default)]
     backend: Option<BackendFile>,
+    /// pnpr-only local OSV database settings.
+    #[serde(default)]
+    osv: OsvFile,
     #[serde(default)]
     uplinks: IndexMap<String, UplinkFile>,
     #[serde(default)]
@@ -777,6 +789,15 @@ struct TokensFile {
     file: Option<String>,
 }
 
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OsvFile {
+    #[serde(default)]
+    enabled: bool,
+    #[serde(default)]
+    path: Option<String>,
+}
+
 impl Config {
     /// Default `listen` when one isn't supplied by the caller.
     pub const DEFAULT_LISTEN: &'static str = "127.0.0.1:4873";
@@ -812,6 +833,7 @@ impl Config {
             logs: LogConfig::default(),
             hosted_store: HostedStoreConfig::Fs,
             backend: BackendConfig::Local,
+            osv: OsvConfig::default(),
         }
     }
 
@@ -832,6 +854,7 @@ impl Config {
             logs: LogConfig::default(),
             hosted_store: HostedStoreConfig::Fs,
             backend: BackendConfig::Local,
+            osv: OsvConfig::default(),
         }
     }
 
@@ -966,6 +989,7 @@ impl Config {
         let auth = build_auth_config(&file.auth, base_dir);
         let logs = build_log_config(file.log.as_ref());
         let policies = build_policies(&file.packages)?;
+        let osv = build_osv_config(&file.osv, base_dir);
         let uplinks = file
             .uplinks
             .into_iter()
@@ -987,6 +1011,7 @@ impl Config {
             logs,
             hosted_store,
             backend,
+            osv,
         })
     }
 
@@ -1028,6 +1053,13 @@ fn build_auth_config(file: &AuthFile, base_dir: &Path) -> AuthConfig {
             max_users: file.htpasswd.max_users.map_or(MaxUsers::Unlimited, MaxUsers::from_yaml),
         },
         tokens: TokensConfig { file: tokens_file },
+    }
+}
+
+fn build_osv_config(file: &OsvFile, base_dir: &Path) -> OsvConfig {
+    OsvConfig {
+        enabled: file.enabled,
+        path: file.path.as_deref().map(|path| resolve_relative(path, base_dir)),
     }
 }
 

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -382,6 +382,24 @@ fn relative_cache_key_is_resolved_against_base_dir() {
 }
 
 #[test]
+fn osv_config_defaults_off_and_resolves_relative_path() {
+    let defaulted = Config::from_yaml_str(
+        "uplinks: {}\npackages: {}\n",
+        Path::new("/etc/pnpr"),
+        listen(),
+        None,
+    )
+    .unwrap();
+    assert!(!defaulted.osv.enabled);
+    assert_eq!(defaulted.osv.path, None);
+
+    let yaml = "osv:\n  enabled: true\n  path: ./osv/npm/all.zip\nuplinks: {}\npackages: {}\n";
+    let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
+    assert!(config.osv.enabled);
+    assert_eq!(config.osv.path, Some(PathBuf::from("/etc/pnpr/./osv/npm/all.zip")));
+}
+
+#[test]
 fn hosted_store_defaults_to_fs_without_an_s3_block() {
     let yaml = "storage: /var/lib/pnpr\nuplinks: {}\npackages: {}\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -28,8 +28,8 @@ pub use auth::{
 };
 pub use config::{
     AuthConfig, BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML, HostedStoreConfig,
-    HtpasswdConfig, LibsqlSettings, LogConfig, LogFormat, LogLevel, MaxUsers, PackageAccess,
-    TokensConfig, UplinkConfig, default_cache_dir,
+    HtpasswdConfig, LibsqlSettings, LogConfig, LogFormat, LogLevel, MaxUsers, OsvConfig,
+    PackageAccess, TokensConfig, UplinkConfig, default_cache_dir,
 };
 pub use error::{RegistryError, Result};
 pub use journal::recover_publish_journal;

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -34,4 +34,6 @@ pub use config::{
 pub use error::{RegistryError, Result};
 pub use journal::recover_publish_journal;
 pub use policy::{AccessList, AccessToken, Identity, PackagePolicies, PackagePolicy};
-pub use server::{router, router_with_auth, serve, serve_listener};
+pub use server::{
+    router, router_with_auth, serve, serve_listener, try_router, try_router_with_auth,
+};

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -42,6 +42,15 @@ struct Args {
     /// refetched. When omitted, the loaded config's value wins.
     #[arg(long)]
     packument_ttl_secs: Option<u64>,
+
+    /// Enable local OSV npm vulnerability checks. Requires a local OSV
+    /// npm database zip at --osv-db or <cache>/osv/npm/all.zip.
+    #[arg(long)]
+    osv: bool,
+
+    /// Path to the local OSV npm database zip or extracted JSON directory.
+    #[arg(long)]
+    osv_db: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -79,6 +88,12 @@ async fn main() -> miette::Result<()> {
     }
     if let Some(ttl_secs) = args.packument_ttl_secs {
         config.packument_ttl = Duration::from_secs(ttl_secs);
+    }
+    if args.osv {
+        config.osv.enabled = true;
+    }
+    if let Some(osv_db) = args.osv_db {
+        config.osv.path = Some(osv_db);
     }
     init_logging(&config.logs);
     log_config_source(&source);

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -603,7 +603,7 @@ fn osv_violations_for_lockfile(index: &OsvIndex, lockfile: &Lockfile) -> Vec<ser
         return Vec::new();
     };
 
-    let mut seen = std::collections::BTreeSet::new();
+    let mut seen = std::collections::HashSet::new();
     let mut violations = Vec::new();
     for (package_key, snapshot) in packages {
         if !is_osv_checkable_resolution(&snapshot.resolution) {
@@ -611,21 +611,25 @@ fn osv_violations_for_lockfile(index: &OsvIndex, lockfile: &Lockfile) -> Vec<ser
         }
         let name = package_key.name.to_string();
         let version = package_key.suffix.version().to_string();
+        let ids = index.vulnerability_ids(&name, &version);
+        if ids.is_empty() {
+            continue;
+        }
+        // Dedup only the rare vulnerable hits — several lockfile keys can
+        // share one name@version via peer suffixes — so the common
+        // (non-vulnerable) entry never pays for the set.
         if !seen.insert((name.clone(), version.clone())) {
             continue;
         }
-        let ids = index.vulnerability_ids(&name, &version);
-        if !ids.is_empty() {
-            violations.push(serde_json::json!({
-                "name": name,
-                "version": version,
-                "code": OSV_VULNERABILITY_CODE,
-                "reason": format!(
-                    "is listed in the local OSV database as vulnerable ({})",
-                    ids.join(", "),
-                ),
-            }));
-        }
+        violations.push(serde_json::json!({
+            "name": name,
+            "version": version,
+            "code": OSV_VULNERABILITY_CODE,
+            "reason": format!(
+                "is listed in the local OSV database as vulnerable ({})",
+                ids.join(", "),
+            ),
+        }));
     }
     violations
 }
@@ -649,11 +653,12 @@ fn is_osv_checkable_resolution(resolution: &LockfileResolution) -> bool {
 }
 
 /// Whether a tarball URL uses an http(s) scheme — the only schemes a
-/// registry artifact is served over. Case-insensitive so a tampered
-/// uppercase scheme can't slip past.
+/// registry artifact is served over. Case-insensitive (so a tampered
+/// uppercase scheme can't slip past) without allocating a lowercased copy.
 fn is_http_tarball_url(url: &str) -> bool {
-    let lower = url.to_ascii_lowercase();
-    lower.starts_with("https://") || lower.starts_with("http://")
+    let bytes = url.as_bytes();
+    bytes.get(..8).is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"https://"))
+        || bytes.get(..7).is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"http://"))
 }
 
 /// Serialize one frame to a newline-terminated NDJSON line.

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -280,16 +280,10 @@ pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response 
         && let Some(lockfile) =
             cached_resolution(&runtime.resolution_cache, runtime.resolution_cache_ttl, key)
     {
-        // A cached lockfile is only stored after passing the OSV check, so a
-        // hit is clean unless the OSV database changed since; re-check and fall
-        // through to a fresh resolve when it now flags a vulnerability.
-        let osv_clean = runtime
-            .osv_index
-            .as_ref()
-            .is_none_or(|index| osv_violations_for_lockfile(index, &lockfile).is_empty());
-        if osv_clean {
-            return ndjson_single_frame(&done_frame(&lockfile));
-        }
+        // The OSV index is immutable for this resolver instance and a lockfile
+        // is only stored after passing the OSV check, so a cache hit is already
+        // OSV-clean — no per-package re-scan needed on this warm path.
+        return ndjson_single_frame(&done_frame(&lockfile));
     }
 
     // Streaming resolve. Run it in a detached task that pushes one

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -73,7 +73,7 @@ use pacquet_resolving_resolver_base::{PackageVersionGuard, ResolutionVerifier};
 use pacquet_store_dir::StoreDir;
 use sha2::{Digest, Sha256};
 
-pub(crate) use self::osv::{OsvIndex, load_osv_index};
+pub(crate) use self::osv::{OsvIndex, format_advisory_ids, load_osv_index};
 
 use self::{protocol::ResolveRequest, verdict_cache::VerdictCache};
 
@@ -611,7 +611,22 @@ fn osv_violations_for_lockfile(index: &OsvIndex, lockfile: &Lockfile) -> Vec<ser
         }
         let name = package_key.name.to_string();
         let version = package_key.suffix.version().to_string();
-        let ids = index.vulnerability_ids(&name, &version);
+        let mut ids = index.vulnerability_ids(&name, &version);
+        // For a tarball resolution the fetched artifact's identity is its
+        // URL, not the lockfile key. Under `trustLockfile` a tampered
+        // lockfile could key a safe `name@version` while pointing the
+        // tarball at a vulnerable artifact, so also screen the version in
+        // the tarball filename. This is additive — a mismatch alone is
+        // never a violation (custom registries may name tarballs
+        // differently), only an actually-vulnerable version is.
+        if let LockfileResolution::Tarball(tarball) = &snapshot.resolution
+            && let Some(url_version) = tarball_url_version(&tarball.tarball, &name)
+            && url_version != version
+        {
+            ids.extend(index.vulnerability_ids(&name, url_version));
+            ids.sort_unstable();
+            ids.dedup();
+        }
         if ids.is_empty() {
             continue;
         }
@@ -627,11 +642,24 @@ fn osv_violations_for_lockfile(index: &OsvIndex, lockfile: &Lockfile) -> Vec<ser
             "code": OSV_VULNERABILITY_CODE,
             "reason": format!(
                 "is listed in the local OSV database as vulnerable ({})",
-                ids.join(", "),
+                format_advisory_ids(&ids),
             ),
         }));
     }
     violations
+}
+
+/// Best-effort extraction of the version from a registry tarball URL of
+/// the conventional `<unscoped-name>-<version>.tgz` shape. Returns `None`
+/// for non-standard naming so a legitimate custom registry isn't
+/// misjudged. Never parses the URL strictly — the lockfile is untrusted.
+fn tarball_url_version<'a>(url: &'a str, name: &str) -> Option<&'a str> {
+    let last = url.rsplit('/').next()?;
+    let last = last.split(['?', '#']).next().unwrap_or(last);
+    let stem = last.strip_suffix(".tgz")?;
+    let unscoped = name.rsplit('/').next().unwrap_or(name);
+    let version = stem.strip_prefix(unscoped)?.strip_prefix('-')?;
+    (!version.is_empty()).then_some(version)
 }
 
 fn is_osv_checkable_resolution(resolution: &LockfileResolution) -> bool {

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -60,7 +60,7 @@ use axum::{
 };
 use indexmap::IndexMap;
 use pacquet_config::Config as PacquetConfig;
-use pacquet_lockfile::{Lockfile, LockfileResolution};
+use pacquet_lockfile::{Lockfile, LockfileResolution, is_git_hosted_tarball_url};
 use pacquet_lockfile_verification::{collect_resolution_policy_violations, hash_lockfile};
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_package_manager::{
@@ -633,20 +633,27 @@ fn osv_violations_for_lockfile(index: &OsvIndex, lockfile: &Lockfile) -> Vec<ser
 fn is_osv_checkable_resolution(resolution: &LockfileResolution) -> bool {
     match resolution {
         LockfileResolution::Registry(_) => true,
+        // A frozen lockfile is attacker-controlled, so gate on the tarball
+        // URL rather than the tamper-prone `git_hosted` flag or strict URL
+        // parsing — otherwise `gitHosted: true` or a barely-malformed URL
+        // would let a vulnerable package opt out of the OSV scan. Mirrors
+        // the npm verifier's URL-based gate.
         LockfileResolution::Tarball(tarball) => {
-            if tarball.git_hosted == Some(true) {
-                return false;
-            }
-            reqwest::Url::parse(&tarball.tarball).is_ok_and(|url| {
-                let scheme = url.scheme();
-                scheme == "http" || scheme == "https"
-            })
+            is_http_tarball_url(&tarball.tarball) && !is_git_hosted_tarball_url(&tarball.tarball)
         }
         LockfileResolution::Directory(_)
         | LockfileResolution::Git(_)
         | LockfileResolution::Binary(_)
         | LockfileResolution::Variations(_) => false,
     }
+}
+
+/// Whether a tarball URL uses an http(s) scheme — the only schemes a
+/// registry artifact is served over. Case-insensitive so a tampered
+/// uppercase scheme can't slip past.
+fn is_http_tarball_url(url: &str) -> bool {
+    let lower = url.to_ascii_lowercase();
+    lower.starts_with("https://") || lower.starts_with("http://")
 }
 
 /// Serialize one frame to a newline-terminated NDJSON line.

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -656,10 +656,21 @@ fn osv_violations_for_lockfile(index: &OsvIndex, lockfile: &Lockfile) -> Vec<ser
 fn tarball_url_version<'a>(url: &'a str, name: &str) -> Option<&'a str> {
     let last = url.rsplit('/').next()?;
     let last = last.split(['?', '#']).next().unwrap_or(last);
-    let stem = last.strip_suffix(".tgz")?;
+    let stem = strip_tarball_suffix(last)?;
     let unscoped = name.rsplit('/').next().unwrap_or(name);
     let version = stem.strip_prefix(unscoped)?.strip_prefix('-')?;
     (!version.is_empty()).then_some(version)
+}
+
+/// Strip a `.tgz` / `.tar.gz` tarball suffix case-insensitively, so a
+/// tampered lockfile can't dodge the URL-version cross-check with a
+/// `.TGZ` or `.tar.gz` variant. Returns `None` for any other suffix.
+fn strip_tarball_suffix(name: &str) -> Option<&str> {
+    [".tar.gz", ".tgz"].into_iter().find_map(|suffix| {
+        let head_len = name.len().checked_sub(suffix.len())?;
+        let (head, tail) = (name.get(..head_len)?, name.get(head_len..)?);
+        tail.eq_ignore_ascii_case(suffix).then_some(head)
+    })
 }
 
 fn is_osv_checkable_resolution(resolution: &LockfileResolution) -> bool {

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -39,6 +39,7 @@
 //! forwards its per-registry credentials, so private dependencies resolve
 //! as the caller.
 
+pub(crate) mod osv;
 mod protocol;
 mod resolve;
 mod verdict_cache;
@@ -68,9 +69,11 @@ use pacquet_package_manager::{
 use pacquet_resolving_npm_resolver::{
     InMemoryPackageMetaCache, ObservedDistStats, PackageMetaCache, observed_dist_stats_sink,
 };
-use pacquet_resolving_resolver_base::ResolutionVerifier;
+use pacquet_resolving_resolver_base::{PackageVersionGuard, ResolutionVerifier};
 use pacquet_store_dir::StoreDir;
 use sha2::{Digest, Sha256};
+
+pub(crate) use self::osv::{OsvIndex, load_osv_index};
 
 use self::{protocol::ResolveRequest, verdict_cache::VerdictCache};
 
@@ -102,6 +105,7 @@ pub(crate) struct Resolver {
     /// only if the database couldn't be opened — verification then runs
     /// every time (uncached) rather than failing the server.
     verdict_cache: Option<VerdictCache>,
+    osv_index: Option<Arc<OsvIndex>>,
 }
 
 struct CachedResolution {
@@ -113,11 +117,12 @@ impl Resolver {
     pub(crate) fn get_or_init<'a>(
         cell: &'a OnceLock<Resolver>,
         config: &RegistryConfig,
+        osv_index: Option<Arc<OsvIndex>>,
     ) -> &'a Resolver {
-        cell.get_or_init(|| Resolver::build(config))
+        cell.get_or_init(|| Resolver::build(config, osv_index))
     }
 
-    fn build(config: &RegistryConfig) -> Resolver {
+    fn build(config: &RegistryConfig, osv_index: Option<Arc<OsvIndex>>) -> Resolver {
         let store_dir = config.cache_storage.join("pnpr-store");
         let cache_dir = config.cache_storage.join("pnpr-cache");
         // Best-effort: a real failure here (e.g. a permission problem)
@@ -134,6 +139,7 @@ impl Resolver {
             resolution_cache_ttl: config.packument_ttl,
             configs: Mutex::new(HashMap::new()),
             verdict_cache,
+            osv_index,
         }
     }
 
@@ -215,6 +221,8 @@ pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response 
 
     // Resolve against the client's registries, not the server's own.
     let config = runtime.config_for(&request);
+    let package_version_guard =
+        runtime.osv_index.as_ref().map(|index| Arc::clone(index) as Arc<dyn PackageVersionGuard>);
 
     // The caller's forwarded upstream credentials, threaded through
     // resolve/verify but kept out of the interned `config` so it never
@@ -251,6 +259,12 @@ pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response 
     // fetched, so there's nothing to add and the response is the bare
     // `done` frame.
     if let Some(lockfile) = resolve::fresh_frozen_input_lockfile(config, &request) {
+        if let Some(osv_index) = runtime.osv_index.as_ref() {
+            let violations = osv_violations_for_lockfile(osv_index, &lockfile);
+            if !violations.is_empty() {
+                return ndjson_single_frame(&violations_frame(&violations));
+            }
+        }
         let mut frames = verified_dist_stats
             .map(|sizes| frozen_package_frames(config, &lockfile, &sizes))
             .unwrap_or_default();
@@ -266,7 +280,14 @@ pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response 
         && let Some(lockfile) =
             cached_resolution(&runtime.resolution_cache, runtime.resolution_cache_ttl, key)
     {
-        return ndjson_single_frame(&done_frame(&lockfile));
+        if let Some(osv_index) = runtime.osv_index.as_ref() {
+            let violations = osv_violations_for_lockfile(osv_index, &lockfile);
+            if violations.is_empty() {
+                return ndjson_single_frame(&done_frame(&lockfile));
+            }
+        } else {
+            return ndjson_single_frame(&done_frame(&lockfile));
+        }
     }
 
     // Streaming resolve. Run it in a detached task that pushes one
@@ -274,14 +295,24 @@ pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response 
     // observer, then a terminal `done` / `error` frame. The response
     // body drains the channel as frames arrive.
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
-    let observer: Arc<dyn pacquet_package_manager::ResolutionObserver> =
-        Arc::new(StreamObserver { tx: tx.clone() });
+    let observer: Arc<dyn pacquet_package_manager::ResolutionObserver> = Arc::new(StreamObserver {
+        tx: tx.clone(),
+        package_version_guard: package_version_guard.clone(),
+    });
     let client = Arc::clone(&runtime.client);
     let cache = Arc::clone(&runtime.resolution_cache);
     let cache_ttl = runtime.resolution_cache_ttl;
+    let final_osv_index = runtime.osv_index.clone();
     tokio::spawn(async move {
         match resolve::resolve(config, &client, &request, &request_auth, Some(observer)).await {
             Ok(lockfile) => {
+                if let Some(osv_index) = final_osv_index.as_ref() {
+                    let violations = osv_violations_for_lockfile(osv_index, &lockfile);
+                    if !violations.is_empty() {
+                        let _ = tx.send(violations_frame(&violations));
+                        return;
+                    }
+                }
                 if let Some(key) = resolution_cache_key {
                     store_resolution(&cache, cache_ttl, key, &lockfile);
                 }
@@ -311,7 +342,7 @@ pub(crate) async fn handle_verify_lockfile(runtime: &Resolver, body: Bytes) -> R
     };
 
     if request.trust_lockfile {
-        return ndjson_single_frame(&verify_done_frame());
+        return verify_done_or_osv_violations(runtime.osv_index.as_ref(), input_lockfile);
     }
 
     let config = runtime.config_for(&request);
@@ -321,7 +352,7 @@ pub(crate) async fn handle_verify_lockfile(runtime: &Resolver, body: Bytes) -> R
         // The dist stats the verifier observed feed `/v1/resolve`'s sized
         // `package` frames; this endpoint's client prefetches from its own
         // lockfile before the verdict arrives, so only the verdict is sent.
-        Ok(_) => ndjson_single_frame(&verify_done_frame()),
+        Ok(_) => verify_done_or_osv_violations(runtime.osv_index.as_ref(), input_lockfile),
         Err(VerifyFailure::Internal(response)) => response,
         Err(VerifyFailure::Violations(violations)) => {
             ndjson_single_frame(&violations_frame(&violations))
@@ -421,6 +452,7 @@ const NDJSON_CONTENT_TYPE: &str = "application/x-ndjson";
 /// frame silently — the resolve still runs to completion server-side.
 struct StreamObserver {
     tx: tokio::sync::mpsc::UnboundedSender<Vec<u8>>,
+    package_version_guard: Option<Arc<dyn PackageVersionGuard>>,
 }
 
 impl pacquet_package_manager::ResolutionObserver for StreamObserver {
@@ -428,6 +460,10 @@ impl pacquet_package_manager::ResolutionObserver for StreamObserver {
         if let Ok(line) = ndjson_line(&package_frame(&hint)) {
             let _ = self.tx.send(line);
         }
+    }
+
+    fn package_version_guard(&self) -> Option<Arc<dyn PackageVersionGuard>> {
+        self.package_version_guard.clone()
     }
 }
 
@@ -549,6 +585,74 @@ fn verify_done_frame() -> Vec<u8> {
         .unwrap_or_else(|_| br#"{"type":"error","message":"verification failed"}"#.to_vec())
 }
 
+const OSV_VULNERABILITY_CODE: &str = "ERR_PNPM_OSV_VULNERABILITY";
+
+fn verify_done_or_osv_violations(
+    osv_index: Option<&Arc<OsvIndex>>,
+    lockfile: &Lockfile,
+) -> Response {
+    let Some(osv_index) = osv_index else {
+        return ndjson_single_frame(&verify_done_frame());
+    };
+    let violations = osv_violations_for_lockfile(osv_index, lockfile);
+    if violations.is_empty() {
+        ndjson_single_frame(&verify_done_frame())
+    } else {
+        ndjson_single_frame(&violations_frame(&violations))
+    }
+}
+
+fn osv_violations_for_lockfile(index: &OsvIndex, lockfile: &Lockfile) -> Vec<serde_json::Value> {
+    let Some(packages) = lockfile.packages.as_ref() else {
+        return Vec::new();
+    };
+
+    let mut seen = std::collections::BTreeSet::new();
+    let mut violations = Vec::new();
+    for (package_key, snapshot) in packages {
+        if !is_osv_checkable_resolution(&snapshot.resolution) {
+            continue;
+        }
+        let name = package_key.name.to_string();
+        let version = package_key.suffix.version().to_string();
+        if !seen.insert((name.clone(), version.clone())) {
+            continue;
+        }
+        let ids = index.vulnerability_ids(&name, &version);
+        if !ids.is_empty() {
+            violations.push(serde_json::json!({
+                "name": name,
+                "version": version,
+                "code": OSV_VULNERABILITY_CODE,
+                "reason": format!(
+                    "is listed in the local OSV database as vulnerable ({})",
+                    ids.join(", "),
+                ),
+            }));
+        }
+    }
+    violations
+}
+
+fn is_osv_checkable_resolution(resolution: &LockfileResolution) -> bool {
+    match resolution {
+        LockfileResolution::Registry(_) => true,
+        LockfileResolution::Tarball(tarball) => {
+            if tarball.git_hosted == Some(true) {
+                return false;
+            }
+            reqwest::Url::parse(&tarball.tarball).is_ok_and(|url| {
+                let scheme = url.scheme();
+                scheme == "http" || scheme == "https"
+            })
+        }
+        LockfileResolution::Directory(_)
+        | LockfileResolution::Git(_)
+        | LockfileResolution::Binary(_)
+        | LockfileResolution::Variations(_) => false,
+    }
+}
+
 /// Serialize one frame to a newline-terminated NDJSON line.
 fn ndjson_line(value: &serde_json::Value) -> Result<Vec<u8>, serde_json::Error> {
     let mut bytes = serde_json::to_vec(value)?;
@@ -638,20 +742,25 @@ async fn verify_input_lockfile(
     if let Some(cache) = runtime.verdict_cache.as_ref()
         && cache.is_verified(&hash, |policy| {
             verifiers.iter().all(|verifier| verifier.can_trust_past_check(policy))
+                && runtime.osv_index.as_ref().is_none_or(|index| index.can_trust_policy(policy))
         })
     {
         return Ok(None);
     }
 
     let violations = collect_resolution_policy_violations(lockfile, &verifiers, None).await;
-    if violations.is_empty() {
+    let osv_violations = runtime
+        .osv_index
+        .as_ref()
+        .map_or_else(Vec::new, |index| osv_violations_for_lockfile(index, lockfile));
+    if violations.is_empty() && osv_violations.is_empty() {
         if let Some(cache) = runtime.verdict_cache.as_ref() {
-            cache.record(&hash, &merge_policies(&verifiers));
+            cache.record(&hash, &merge_policies(&verifiers, runtime.osv_index.as_ref()));
         }
         return Ok(Some(dist_stats));
     }
 
-    let rendered: Vec<serde_json::Value> = violations
+    let mut rendered: Vec<serde_json::Value> = violations
         .iter()
         .map(|violation| {
             serde_json::json!({
@@ -662,6 +771,7 @@ async fn verify_input_lockfile(
             })
         })
         .collect();
+    rendered.extend(osv_violations);
     Err(VerifyFailure::Violations(rendered))
 }
 
@@ -672,12 +782,16 @@ async fn verify_input_lockfile(
 /// client's own cache would write.
 fn merge_policies(
     verifiers: &[Arc<dyn ResolutionVerifier>],
+    osv_index: Option<&Arc<OsvIndex>>,
 ) -> serde_json::Map<String, serde_json::Value> {
     let mut merged = serde_json::Map::new();
     for verifier in verifiers {
         for (key, value) in verifier.policy() {
             merged.insert(key.clone(), value.clone());
         }
+    }
+    if let Some(osv_index) = osv_index {
+        merged.extend(osv_index.policy());
     }
     merged
 }

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -280,12 +280,14 @@ pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response 
         && let Some(lockfile) =
             cached_resolution(&runtime.resolution_cache, runtime.resolution_cache_ttl, key)
     {
-        if let Some(osv_index) = runtime.osv_index.as_ref() {
-            let violations = osv_violations_for_lockfile(osv_index, &lockfile);
-            if violations.is_empty() {
-                return ndjson_single_frame(&done_frame(&lockfile));
-            }
-        } else {
+        // A cached lockfile is only stored after passing the OSV check, so a
+        // hit is clean unless the OSV database changed since; re-check and fall
+        // through to a fresh resolve when it now flags a vulnerability.
+        let osv_clean = runtime
+            .osv_index
+            .as_ref()
+            .is_none_or(|index| osv_violations_for_lockfile(index, &lockfile).is_empty());
+        if osv_clean {
             return ndjson_single_frame(&done_frame(&lockfile));
         }
     }

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -344,15 +344,13 @@ fn load_from_directory(path: &Path) -> Result<OsvIndex, RegistryError> {
         {
             continue;
         }
-        // Bound the read itself with `take` rather than trusting a
-        // pre-read `metadata().len()`, which a concurrent swap could
-        // invalidate (TOCTOU) — matching the zip loader's guarantee.
-        let file = File::open(&entry_path).map_err(|err| {
+        // Open non-blocking so a concurrent swap of the path to a
+        // FIFO/socket after the `is_file` check can't make `open` itself
+        // block startup; then re-check the opened handle is a regular file
+        // before reading (the path check is racy on its own).
+        let file = open_osv_record(&entry_path).map_err(|err| {
             invalid_config(format!("failed to read OSV record {}: {err}", entry_path.display()))
         })?;
-        // Re-check the *opened handle* before reading: the earlier
-        // `is_file` check is on the path, so a concurrent swap to a
-        // FIFO/socket could otherwise make `read_to_end` block startup.
         let is_regular_file = file.metadata().is_ok_and(|metadata| metadata.is_file());
         if !is_regular_file {
             return Err(invalid_config(format!(
@@ -380,6 +378,21 @@ fn load_from_directory(path: &Path) -> Result<OsvIndex, RegistryError> {
 /// Per-record content digest over a length-prefixed `(name, bytes)` so
 /// the encoding is unambiguous — plain concatenation would let two
 /// different record sets hash to the same input.
+/// Open an OSV record file without blocking on it. On unix `O_NONBLOCK`
+/// keeps `open` from hanging if the path was raced into a FIFO with no
+/// writer; the caller still verifies the handle is a regular file before
+/// reading. A regular file ignores the flag for reads.
+#[cfg(unix)]
+fn open_osv_record(path: &Path) -> std::io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new().read(true).custom_flags(libc::O_NONBLOCK).open(path)
+}
+
+#[cfg(not(unix))]
+fn open_osv_record(path: &Path) -> std::io::Result<File> {
+    File::open(path)
+}
+
 fn record_digest(name: &str, bytes: &[u8]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update((name.len() as u64).to_le_bytes());

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -242,9 +242,19 @@ fn default_osv_path(config: &Config) -> PathBuf {
 }
 
 fn load_from_zip(path: &Path) -> Result<OsvIndex, RegistryError> {
-    let fingerprint = file_fingerprint(path)?;
-    let file = File::open(path).map_err(|err| {
+    // Fingerprint and parse the *same* open handle. Hashing one open and
+    // parsing a second would let an atomic replace of the path slip in
+    // between, so the recorded fingerprint could describe different bytes
+    // than the advisories actually loaded — and the verdict cache trusts
+    // that fingerprint to decide whether a cached pass still holds.
+    let mut file = File::open(path).map_err(|err| {
         invalid_config(format!("failed to open OSV database {}: {err}", path.display()))
+    })?;
+    let fingerprint = fingerprint_reader(&mut file).map_err(|err| {
+        invalid_config(format!("failed to hash OSV database {}: {err}", path.display()))
+    })?;
+    file.rewind().map_err(|err| {
+        invalid_config(format!("failed to rewind OSV database {}: {err}", path.display()))
     })?;
     let mut archive = zip::ZipArchive::new(file).map_err(|err| {
         invalid_config(format!("failed to read OSV zip {}: {err}", path.display()))
@@ -318,24 +328,16 @@ fn load_from_directory(path: &Path) -> Result<OsvIndex, RegistryError> {
     Ok(OsvIndex { packages, fingerprint: format!("sha256:{:x}", hasher.finalize()) })
 }
 
-fn file_fingerprint(path: &Path) -> Result<String, RegistryError> {
-    let mut file = File::open(path).map_err(|err| {
-        invalid_config(format!("failed to open OSV database {}: {err}", path.display()))
-    })?;
+fn fingerprint_reader(reader: &mut impl Read) -> std::io::Result<String> {
     let mut hasher = Sha256::new();
     let mut buf = vec![0_u8; 1024 * 64];
     loop {
-        let read = file.read(&mut buf).map_err(|err| {
-            invalid_config(format!("failed to hash OSV database {}: {err}", path.display()))
-        })?;
+        let read = reader.read(&mut buf)?;
         if read == 0 {
             break;
         }
         hasher.update(&buf[..read]);
     }
-    file.rewind().map_err(|err| {
-        invalid_config(format!("failed to rewind OSV database {}: {err}", path.display()))
-    })?;
     Ok(format!("sha256:{:x}", hasher.finalize()))
 }
 

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -57,7 +57,17 @@ impl OsvIndex {
         if path.is_dir() {
             return load_from_directory(path);
         }
-        load_from_zip(path)
+        // Only treat a regular file as a zip. Opening and streaming a
+        // FIFO/socket/device for fingerprinting could block startup
+        // indefinitely (the OSV DB loads before the listen socket binds),
+        // so reject anything that isn't a directory or regular file.
+        if path.is_file() {
+            return load_from_zip(path);
+        }
+        Err(invalid_config(format!(
+            "OSV database {} is neither a directory nor a regular file; point osv.path at the npm OSV dump (a .zip file or an extracted directory)",
+            path.display(),
+        )))
     }
 
     pub(crate) fn policy(&self) -> serde_json::Map<String, serde_json::Value> {

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -113,7 +113,7 @@ impl OsvIndex {
         PackageVersionGuardDecision::Reject {
             reason: format!(
                 "is listed in the local OSV database as vulnerable ({})",
-                ids.join(", "),
+                format_advisory_ids(&ids),
             ),
         }
     }
@@ -461,6 +461,17 @@ fn parse_osv_version(raw: &str) -> Option<Version> {
         );
     }
     parsed
+}
+
+/// Join advisory ids for a human-facing reason, capped so a package that
+/// matches a huge number of advisories can't inflate response or log
+/// payloads (which feed NDJSON frames and error messages).
+pub(crate) fn format_advisory_ids(ids: &[String]) -> String {
+    const MAX: usize = 20;
+    if ids.len() <= MAX {
+        return ids.join(", ");
+    }
+    format!("{}, and {} more", ids[..MAX].join(", "), ids.len() - MAX)
 }
 
 fn invalid_config(reason: String) -> RegistryError {

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -33,6 +33,15 @@ const MAX_OSV_NAME_BYTES: usize = 4096;
 /// in-memory state or the reason strings it feeds.
 const MAX_ADVISORY_ID_BYTES: usize = 256;
 
+/// Upper bounds on the item counts inside one `affected` entry. The
+/// per-record byte cap bounds parse-time memory, but a crafted record
+/// could still persist a huge `versions`/`ranges` set into the index;
+/// these caps are far above any real advisory so they only reject
+/// deliberately bloated records.
+const MAX_VERSIONS_PER_AFFECTED: usize = 100_000;
+const MAX_RANGES_PER_AFFECTED: usize = 10_000;
+const MAX_EVENTS_PER_RANGE: usize = 10_000;
+
 #[derive(Debug)]
 pub(crate) struct OsvIndex {
     packages: HashMap<String, Vec<Advisory>>,
@@ -432,6 +441,17 @@ fn ingest_record_bytes(
         let Some(package) = affected.package.as_ref() else { continue };
         if package.ecosystem != "npm" {
             continue;
+        }
+        // Reject deliberately bloated entries so a crafted record can't
+        // expand into a huge persistent set in the index.
+        if affected.versions.len() > MAX_VERSIONS_PER_AFFECTED
+            || affected.ranges.len() > MAX_RANGES_PER_AFFECTED
+            || affected.ranges.iter().any(|range| range.events.len() > MAX_EVENTS_PER_RANGE)
+        {
+            return Err(invalid_config(format!(
+                "OSV record {} has an affected entry exceeding the version/range/event limits",
+                truncate_advisory_id(&record.id),
+            )));
         }
         let name = normalized_name(&package.name).into_owned();
         let advisory = advisory_from_affected(&record.id, affected);

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -288,12 +288,19 @@ fn load_from_zip(path: &Path) -> Result<OsvIndex, RegistryError> {
                 entry.size(),
             )));
         }
-        // `take` caps the read in case the declared size lies.
+        // Read one past the cap so an underreported `entry.size()` can't
+        // silently truncate a record into still-valid JSON; reject if it
+        // actually exceeds the limit (matching the directory loader).
         let mut bytes = Vec::with_capacity(entry.size() as usize);
         (&mut entry)
-            .take(MAX_OSV_RECORD_BYTES)
+            .take(MAX_OSV_RECORD_BYTES + 1)
             .read_to_end(&mut bytes)
             .map_err(|err| invalid_config(format!("failed to read OSV zip entry {name}: {err}")))?;
+        if bytes.len() as u64 > MAX_OSV_RECORD_BYTES {
+            return Err(invalid_config(format!(
+                "OSV zip entry {name} is over the {MAX_OSV_RECORD_BYTES}-byte per-record limit",
+            )));
+        }
         digests.push(record_digest(&name, &bytes));
         ingest_record_bytes(&mut packages, &bytes)?;
     }

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -294,7 +294,7 @@ fn load_from_zip(path: &Path) -> Result<OsvIndex, RegistryError> {
             .take(MAX_OSV_RECORD_BYTES)
             .read_to_end(&mut bytes)
             .map_err(|err| invalid_config(format!("failed to read OSV zip entry {name}: {err}")))?;
-        digests.push((name.clone(), record_digest(&name, &bytes)));
+        digests.push(record_digest(&name, &bytes));
         ingest_record_bytes(&mut packages, &bytes)?;
     }
     Ok(OsvIndex { packages, fingerprint: combine_fingerprint(digests) })
@@ -336,7 +336,7 @@ fn load_from_directory(path: &Path) -> Result<OsvIndex, RegistryError> {
             )));
         }
         let name = entry_path.file_name().and_then(|name| name.to_str()).unwrap_or_default();
-        digests.push((name.to_string(), record_digest(name, &bytes)));
+        digests.push(record_digest(name, &bytes));
         ingest_record_bytes(&mut packages, &bytes)?;
     }
     Ok(OsvIndex { packages, fingerprint: combine_fingerprint(digests) })
@@ -354,14 +354,15 @@ fn record_digest(name: &str, bytes: &[u8]) -> [u8; 32] {
     hasher.finalize().into()
 }
 
-/// Combine per-record digests into the database fingerprint. Sorting by
-/// record name makes the fingerprint independent of the order entries
-/// happen to appear in the archive or directory listing, so reordering
-/// alone doesn't invalidate cached verdicts.
-fn combine_fingerprint(mut digests: Vec<(String, [u8; 32])>) -> String {
-    digests.sort_by(|a, b| a.0.cmp(&b.0));
+/// Combine per-record digests into the database fingerprint. Each digest
+/// already encodes its record's name and bytes, so sorting the digests
+/// makes the fingerprint independent of the order entries happen to
+/// appear in the archive or directory listing (even when two records
+/// share a name) — reordering alone doesn't invalidate cached verdicts.
+fn combine_fingerprint(mut digests: Vec<[u8; 32]>) -> String {
+    digests.sort_unstable();
     let mut hasher = Sha256::new();
-    for (_, digest) in &digests {
+    for digest in &digests {
         hasher.update(digest);
     }
     format!("sha256:{:x}", hasher.finalize())

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -17,6 +17,11 @@ use crate::{Config, error::RegistryError};
 
 const OSV_POLICY_KEY: &str = "osvNpmDatabase";
 
+/// Upper bound on the bytes read for a single OSV record (one zip entry
+/// or one directory file). OSV advisories are a few KB; this cap only
+/// exists so a crafted database can't exhaust memory at startup.
+const MAX_OSV_RECORD_BYTES: u64 = 16 * 1024 * 1024;
+
 #[derive(Debug)]
 pub(crate) struct OsvIndex {
     packages: HashMap<String, Vec<Advisory>>,
@@ -35,7 +40,16 @@ impl OsvIndex {
                 path.display(),
             )));
         }
-        Self::load_from_path(&path).map(Arc::new).map(Some)
+        let index = Self::load_from_path(&path)?;
+        // An enabled-but-empty index would make the guard a no-op and
+        // silently disable enforcement, so treat it as misconfiguration.
+        if index.packages.is_empty() {
+            return Err(invalid_config(format!(
+                "OSV is enabled but database {} yielded no npm advisories; check that the path points at the npm OSV dump",
+                path.display(),
+            )));
+        }
+        Ok(Some(Arc::new(index)))
     }
 
     pub(crate) fn load_from_path(path: &Path) -> Result<Self, RegistryError> {
@@ -219,16 +233,25 @@ fn load_from_zip(path: &Path) -> Result<OsvIndex, RegistryError> {
     })?;
     let mut packages = HashMap::new();
     for index in 0..archive.len() {
-        let mut entry = archive.by_index(index).map_err(|err| {
+        let entry = archive.by_index(index).map_err(|err| {
             invalid_config(format!("failed to read OSV zip entry in {}: {err}", path.display()))
         })?;
         if !entry.is_file() || !entry.name().ends_with(".json") {
             continue;
         }
-        let mut bytes = Vec::with_capacity(entry.size().min(1024 * 1024) as usize);
-        entry.read_to_end(&mut bytes).map_err(|err| {
-            invalid_config(format!("failed to read OSV zip entry {}: {err}", entry.name()))
-        })?;
+        let name = entry.name().to_string();
+        if entry.size() > MAX_OSV_RECORD_BYTES {
+            return Err(invalid_config(format!(
+                "OSV zip entry {name} is {} bytes, over the {MAX_OSV_RECORD_BYTES}-byte per-record limit",
+                entry.size(),
+            )));
+        }
+        // `take` also caps the read if the entry's declared size lies.
+        let mut bytes = Vec::with_capacity(entry.size() as usize);
+        entry
+            .take(MAX_OSV_RECORD_BYTES)
+            .read_to_end(&mut bytes)
+            .map_err(|err| invalid_config(format!("failed to read OSV zip entry {name}: {err}")))?;
         ingest_record_bytes(&mut packages, &bytes)?;
     }
     Ok(OsvIndex { packages, fingerprint })
@@ -253,6 +276,13 @@ fn load_from_directory(path: &Path) -> Result<OsvIndex, RegistryError> {
             || entry_path.extension().is_none_or(|extension| extension != "json")
         {
             continue;
+        }
+        let len = entry.metadata().map(|metadata| metadata.len()).unwrap_or_default();
+        if len > MAX_OSV_RECORD_BYTES {
+            return Err(invalid_config(format!(
+                "OSV record {} is {len} bytes, over the {MAX_OSV_RECORD_BYTES}-byte per-record limit",
+                entry_path.display(),
+            )));
         }
         hasher.update(entry_path.file_name().and_then(|name| name.to_str()).unwrap_or_default());
         let bytes = std::fs::read(&entry_path).map_err(|err| {

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -458,9 +458,14 @@ fn parse_osv_version(raw: &str) -> Option<Version> {
     if parsed.is_none() {
         // Surface rather than silently drop: an unparsable bound means
         // this range won't be enforced, so a corrupt dump can't degrade
-        // coverage without leaving a trace in the logs.
+        // coverage without leaving a trace in the logs. Bound the logged
+        // value — an OSV field can be up to the per-record cap, so log a
+        // short prefix plus the full length instead of the raw string.
+        const MAX_LOGGED_CHARS: usize = 64;
+        let prefix: String = raw.chars().take(MAX_LOGGED_CHARS).collect();
         tracing::warn!(
-            version = raw,
+            version_prefix = %prefix,
+            version_len = raw.len(),
             "ignoring OSV range event with an unparsable version; that range will not be enforced",
         );
     }

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
     fs::File,
-    io::{Read, Seek},
+    io::Read,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -262,26 +262,20 @@ fn default_osv_path(config: &Config) -> PathBuf {
 }
 
 fn load_from_zip(path: &Path) -> Result<OsvIndex, RegistryError> {
-    // Fingerprint and parse the *same* open handle. Hashing one open and
-    // parsing a second would let an atomic replace of the path slip in
-    // between, so the recorded fingerprint could describe different bytes
-    // than the advisories actually loaded — and the verdict cache trusts
-    // that fingerprint to decide whether a cached pass still holds.
-    let mut file = File::open(path).map_err(|err| {
+    let file = File::open(path).map_err(|err| {
         invalid_config(format!("failed to open OSV database {}: {err}", path.display()))
-    })?;
-    let fingerprint = fingerprint_reader(&mut file).map_err(|err| {
-        invalid_config(format!("failed to hash OSV database {}: {err}", path.display()))
-    })?;
-    file.rewind().map_err(|err| {
-        invalid_config(format!("failed to rewind OSV database {}: {err}", path.display()))
     })?;
     let mut archive = zip::ZipArchive::new(file).map_err(|err| {
         invalid_config(format!("failed to read OSV zip {}: {err}", path.display()))
     })?;
     let mut packages = HashMap::new();
+    // Fingerprint the decompressed record contents while parsing (one
+    // pass over the same handle), not the raw archive bytes: that avoids
+    // a second full read and keeps the fingerprint stable across
+    // recompression/repackaging of identical advisory data.
+    let mut digests = Vec::new();
     for index in 0..archive.len() {
-        let entry = archive.by_index(index).map_err(|err| {
+        let mut entry = archive.by_index(index).map_err(|err| {
             invalid_config(format!("failed to read OSV zip entry in {}: {err}", path.display()))
         })?;
         if !entry.is_file() || !entry.name().ends_with(".json") {
@@ -294,19 +288,20 @@ fn load_from_zip(path: &Path) -> Result<OsvIndex, RegistryError> {
                 entry.size(),
             )));
         }
-        // `take` also caps the read if the entry's declared size lies.
+        // `take` caps the read in case the declared size lies.
         let mut bytes = Vec::with_capacity(entry.size() as usize);
-        entry
+        (&mut entry)
             .take(MAX_OSV_RECORD_BYTES)
             .read_to_end(&mut bytes)
             .map_err(|err| invalid_config(format!("failed to read OSV zip entry {name}: {err}")))?;
+        digests.push((name.clone(), record_digest(&name, &bytes)));
         ingest_record_bytes(&mut packages, &bytes)?;
     }
-    Ok(OsvIndex { packages, fingerprint })
+    Ok(OsvIndex { packages, fingerprint: combine_fingerprint(digests) })
 }
 
 fn load_from_directory(path: &Path) -> Result<OsvIndex, RegistryError> {
-    let mut entries = std::fs::read_dir(path)
+    let entries = std::fs::read_dir(path)
         .map_err(|err| {
             invalid_config(format!("failed to read OSV directory {}: {err}", path.display()))
         })?
@@ -314,10 +309,9 @@ fn load_from_directory(path: &Path) -> Result<OsvIndex, RegistryError> {
         .map_err(|err| {
             invalid_config(format!("failed to read OSV directory {}: {err}", path.display()))
         })?;
-    entries.sort_by_key(std::fs::DirEntry::path);
 
     let mut packages = HashMap::new();
-    let mut hasher = Sha256::new();
+    let mut digests = Vec::new();
     for entry in entries {
         let entry_path = entry.path();
         if !entry_path.is_file()
@@ -341,32 +335,36 @@ fn load_from_directory(path: &Path) -> Result<OsvIndex, RegistryError> {
                 entry_path.display(),
             )));
         }
-        // Length-prefix each component so the hash input is unambiguous:
-        // plain concatenation of (name, bytes) lets two different
-        // directory states hash to the same stream, which would let an
-        // attacker with write access edit advisories while keeping the
-        // fingerprint (and thus a trusted verdict-cache pass) unchanged.
         let name = entry_path.file_name().and_then(|name| name.to_str()).unwrap_or_default();
-        hasher.update((name.len() as u64).to_le_bytes());
-        hasher.update(name.as_bytes());
-        hasher.update((bytes.len() as u64).to_le_bytes());
-        hasher.update(&bytes);
+        digests.push((name.to_string(), record_digest(name, &bytes)));
         ingest_record_bytes(&mut packages, &bytes)?;
     }
-    Ok(OsvIndex { packages, fingerprint: format!("sha256:{:x}", hasher.finalize()) })
+    Ok(OsvIndex { packages, fingerprint: combine_fingerprint(digests) })
 }
 
-fn fingerprint_reader(reader: &mut impl Read) -> std::io::Result<String> {
+/// Per-record content digest over a length-prefixed `(name, bytes)` so
+/// the encoding is unambiguous — plain concatenation would let two
+/// different record sets hash to the same input.
+fn record_digest(name: &str, bytes: &[u8]) -> [u8; 32] {
     let mut hasher = Sha256::new();
-    let mut buf = vec![0_u8; 1024 * 64];
-    loop {
-        let read = reader.read(&mut buf)?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buf[..read]);
+    hasher.update((name.len() as u64).to_le_bytes());
+    hasher.update(name.as_bytes());
+    hasher.update((bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
+    hasher.finalize().into()
+}
+
+/// Combine per-record digests into the database fingerprint. Sorting by
+/// record name makes the fingerprint independent of the order entries
+/// happen to appear in the archive or directory listing, so reordering
+/// alone doesn't invalidate cached verdicts.
+fn combine_fingerprint(mut digests: Vec<(String, [u8; 32])>) -> String {
+    digests.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut hasher = Sha256::new();
+    for (_, digest) in &digests {
+        hasher.update(digest);
     }
-    Ok(format!("sha256:{:x}", hasher.finalize()))
+    format!("sha256:{:x}", hasher.finalize())
 }
 
 fn ingest_record_bytes(

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -347,7 +347,10 @@ fn ingest_record_bytes(
 ) -> Result<(), RegistryError> {
     let record: OsvRecord = serde_json::from_slice(bytes)
         .map_err(|err| invalid_config(format!("failed to parse OSV record: {err}")))?;
-    if record.withdrawn.is_some() {
+    // OSV sets `withdrawn` to a timestamp string only for withdrawn
+    // records; a literal `null` is not a withdrawal, so don't drop the
+    // advisory on it.
+    if record.withdrawn.as_ref().is_some_and(|withdrawn| !withdrawn.is_null()) {
         return Ok(());
     }
     for affected in record.affected {
@@ -411,7 +414,17 @@ fn parse_osv_version(raw: &str) -> Option<Version> {
     if raw == "0" {
         return Version::parse("0.0.0").ok();
     }
-    Version::parse(raw).ok()
+    let parsed = Version::parse(raw).ok();
+    if parsed.is_none() {
+        // Surface rather than silently drop: an unparseable bound means
+        // this range won't be enforced, so a corrupt dump can't degrade
+        // coverage without leaving a trace in the logs.
+        tracing::warn!(
+            version = raw,
+            "ignoring OSV range event with an unparseable version; that range will not be enforced",
+        );
+    }
+    parsed
 }
 
 fn invalid_config(reason: String) -> RegistryError {

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     collections::{HashMap, HashSet},
     fs::File,
     io::{Read, Seek},
@@ -77,12 +78,15 @@ impl OsvIndex {
     }
 
     pub(crate) fn vulnerability_ids(&self, name: &str, version: &str) -> Vec<String> {
-        let Some(advisories) = self.packages.get(name) else {
+        let Some(advisories) = self.packages.get(normalized_name(name).as_ref()) else {
             return Vec::new();
         };
+        // Parse the candidate once and share it across every advisory's
+        // range check; exact-version advisories never need the parse.
+        let parsed = Version::parse(version).ok();
         advisories
             .iter()
-            .filter(|advisory| advisory.affects(version))
+            .filter(|advisory| advisory.affects(version, parsed.as_ref()))
             .map(|advisory| advisory.id.clone())
             .collect()
     }
@@ -115,14 +119,14 @@ struct Advisory {
 }
 
 impl Advisory {
-    fn affects(&self, version: &str) -> bool {
+    fn affects(&self, version: &str, parsed: Option<&Version>) -> bool {
         if self.versions.contains(version) {
             return true;
         }
-        let Ok(parsed) = Version::parse(version) else {
+        let Some(parsed) = parsed else {
             return false;
         };
-        self.ranges.iter().any(|range| range.affects(&parsed))
+        self.ranges.iter().any(|range| range.affects(parsed))
     }
 }
 
@@ -329,7 +333,7 @@ fn ingest_record_bytes(
         if package.ecosystem != "npm" {
             continue;
         }
-        let name = package.name.clone();
+        let name = normalized_name(&package.name).into_owned();
         let advisory = advisory_from_affected(&record.id, affected);
         if advisory.versions.is_empty() && advisory.ranges.is_empty() {
             continue;
@@ -337,6 +341,19 @@ fn ingest_record_bytes(
         packages.entry(name).or_default().push(advisory);
     }
     Ok(())
+}
+
+/// Fold an npm package name to its case-insensitive key. npm forbids
+/// names that differ only in case, so lowercasing can't collide two
+/// distinct packages, and it keeps OSV lookups from missing an advisory
+/// when a lockfile name and the OSV dump disagree on casing. Borrows
+/// when the name is already lowercase (the common case).
+fn normalized_name(name: &str) -> Cow<'_, str> {
+    if name.bytes().any(|byte| byte.is_ascii_uppercase()) {
+        Cow::Owned(name.to_ascii_lowercase())
+    } else {
+        Cow::Borrowed(name)
+    }
 }
 
 fn advisory_from_affected(id: &str, affected: OsvAffected) -> Advisory {

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -448,7 +448,11 @@ fn semver_event_from_osv(event: OsvEvent) -> Option<SemverEvent> {
 
 fn parse_osv_version(raw: &str) -> Option<Version> {
     if raw == "0" {
-        return Version::parse("0.0.0").ok();
+        // OSV's `introduced: "0"` means "from the beginning". Map it to the
+        // lowest possible semver (`0.0.0-0`) rather than `0.0.0`, so the
+        // `version >= introduced` check still covers prereleases that sort
+        // below `0.0.0` (e.g. `0.0.0-alpha.1`).
+        return Version::parse("0.0.0-0").ok();
     }
     let parsed = Version::parse(raw).ok();
     if parsed.is_none() {

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -84,9 +84,13 @@ impl OsvIndex {
         // Parse the candidate once and share it across every advisory's
         // range check; exact-version advisories never need the parse.
         let parsed = Version::parse(version).ok();
+        let mut seen = HashSet::new();
         advisories
             .iter()
             .filter(|advisory| advisory.affects(version, parsed.as_ref()))
+            // A single OSV record can list the same package in several
+            // `affected` blocks; dedup so one advisory id isn't repeated.
+            .filter(|advisory| seen.insert(advisory.id.as_str()))
             .map(|advisory| advisory.id.clone())
             .collect()
     }
@@ -281,17 +285,23 @@ fn load_from_directory(path: &Path) -> Result<OsvIndex, RegistryError> {
         {
             continue;
         }
-        let len = entry.metadata().map(|metadata| metadata.len()).unwrap_or_default();
-        if len > MAX_OSV_RECORD_BYTES {
+        hasher.update(entry_path.file_name().and_then(|name| name.to_str()).unwrap_or_default());
+        // Bound the read itself with `take` rather than trusting a
+        // pre-read `metadata().len()`, which a concurrent swap could
+        // invalidate (TOCTOU) — matching the zip loader's guarantee.
+        let file = File::open(&entry_path).map_err(|err| {
+            invalid_config(format!("failed to read OSV record {}: {err}", entry_path.display()))
+        })?;
+        let mut bytes = Vec::new();
+        file.take(MAX_OSV_RECORD_BYTES + 1).read_to_end(&mut bytes).map_err(|err| {
+            invalid_config(format!("failed to read OSV record {}: {err}", entry_path.display()))
+        })?;
+        if bytes.len() as u64 > MAX_OSV_RECORD_BYTES {
             return Err(invalid_config(format!(
-                "OSV record {} is {len} bytes, over the {MAX_OSV_RECORD_BYTES}-byte per-record limit",
+                "OSV record {} is over the {MAX_OSV_RECORD_BYTES}-byte per-record limit",
                 entry_path.display(),
             )));
         }
-        hasher.update(entry_path.file_name().and_then(|name| name.to_str()).unwrap_or_default());
-        let bytes = std::fs::read(&entry_path).map_err(|err| {
-            invalid_config(format!("failed to read OSV record {}: {err}", entry_path.display()))
-        })?;
         hasher.update(&bytes);
         ingest_record_bytes(&mut packages, &bytes)?;
     }

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -332,6 +332,16 @@ fn load_from_directory(path: &Path) -> Result<OsvIndex, RegistryError> {
         let file = File::open(&entry_path).map_err(|err| {
             invalid_config(format!("failed to read OSV record {}: {err}", entry_path.display()))
         })?;
+        // Re-check the *opened handle* before reading: the earlier
+        // `is_file` check is on the path, so a concurrent swap to a
+        // FIFO/socket could otherwise make `read_to_end` block startup.
+        let is_regular_file = file.metadata().is_ok_and(|metadata| metadata.is_file());
+        if !is_regular_file {
+            return Err(invalid_config(format!(
+                "OSV record {} is not a regular file",
+                entry_path.display(),
+            )));
+        }
         let mut bytes = Vec::new();
         file.take(MAX_OSV_RECORD_BYTES + 1).read_to_end(&mut bytes).map_err(|err| {
             invalid_config(format!("failed to read OSV record {}: {err}", entry_path.display()))

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -23,6 +23,16 @@ const OSV_POLICY_KEY: &str = "osvNpmDatabase";
 /// exists so a crafted database can't exhaust memory at startup.
 const MAX_OSV_RECORD_BYTES: u64 = 16 * 1024 * 1024;
 
+/// Upper bound on a zip entry's name length. OSV filenames are short
+/// (`GHSA-….json`); this only rejects crafted names that would otherwise
+/// force large allocations at startup.
+const MAX_OSV_NAME_BYTES: usize = 4096;
+
+/// Upper bound on a stored advisory id. Real ids are short (`GHSA-…`,
+/// `CVE-…`); cap so an oversized id from a crafted record can't bloat
+/// in-memory state or the reason strings it feeds.
+const MAX_ADVISORY_ID_BYTES: usize = 256;
+
 #[derive(Debug)]
 pub(crate) struct OsvIndex {
     packages: HashMap<String, Vec<Advisory>>,
@@ -281,6 +291,14 @@ fn load_from_zip(path: &Path) -> Result<OsvIndex, RegistryError> {
         if !entry.is_file() || !entry.name().ends_with(".json") {
             continue;
         }
+        // Bound the name before cloning it into errors/fingerprint — a
+        // crafted zip can carry arbitrarily long entry names.
+        if entry.name().len() > MAX_OSV_NAME_BYTES {
+            return Err(invalid_config(format!(
+                "OSV zip entry name is {} bytes, over the {MAX_OSV_NAME_BYTES}-byte limit",
+                entry.name().len(),
+            )));
+        }
         let name = entry.name().to_string();
         if entry.size() > MAX_OSV_RECORD_BYTES {
             return Err(invalid_config(format!(
@@ -427,7 +445,21 @@ fn normalized_name(name: &str) -> Cow<'_, str> {
 
 fn advisory_from_affected(id: &str, affected: OsvAffected) -> Advisory {
     let ranges = affected.ranges.into_iter().filter_map(semver_range_from_osv).collect();
-    Advisory { id: id.to_string(), versions: affected.versions.into_iter().collect(), ranges }
+    Advisory {
+        id: truncate_advisory_id(id),
+        versions: affected.versions.into_iter().collect(),
+        ranges,
+    }
+}
+
+/// Cap a stored advisory id at a char boundary so a crafted record can't
+/// carry a multi-megabyte id into memory and reason strings.
+fn truncate_advisory_id(id: &str) -> String {
+    if id.len() <= MAX_ADVISORY_ID_BYTES {
+        return id.to_string();
+    }
+    let end = (0..=MAX_ADVISORY_ID_BYTES).rev().find(|&i| id.is_char_boundary(i)).unwrap_or(0);
+    format!("{}…", &id[..end])
 }
 
 fn semver_range_from_osv(range: OsvRange) -> Option<SemverRange> {

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -1,0 +1,353 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fs::File,
+    io::{Read, Seek},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use node_semver::Version;
+use pacquet_resolving_resolver_base::{
+    PackageVersionGuard, PackageVersionGuardDecision, PackageVersionGuardFuture,
+};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+use crate::{Config, error::RegistryError};
+
+const OSV_POLICY_KEY: &str = "osvNpmDatabase";
+
+#[derive(Debug)]
+pub(crate) struct OsvIndex {
+    packages: HashMap<String, Vec<Advisory>>,
+    fingerprint: String,
+}
+
+impl OsvIndex {
+    pub(crate) fn load_from_config(config: &Config) -> Result<Option<Arc<Self>>, RegistryError> {
+        if !config.osv.enabled {
+            return Ok(None);
+        }
+        let path = config.osv.path.clone().unwrap_or_else(|| default_osv_path(config));
+        if !path.exists() {
+            return Err(invalid_config(format!(
+                "OSV is enabled but database {} does not exist; download the npm OSV dump to this path or set osv.path",
+                path.display(),
+            )));
+        }
+        Self::load_from_path(&path).map(Arc::new).map(Some)
+    }
+
+    pub(crate) fn load_from_path(path: &Path) -> Result<Self, RegistryError> {
+        if path.is_dir() {
+            return load_from_directory(path);
+        }
+        load_from_zip(path)
+    }
+
+    pub(crate) fn policy(&self) -> serde_json::Map<String, serde_json::Value> {
+        let mut policy = serde_json::Map::new();
+        policy.insert(
+            OSV_POLICY_KEY.to_string(),
+            serde_json::Value::String(self.fingerprint.clone()),
+        );
+        policy
+    }
+
+    pub(crate) fn can_trust_policy(
+        &self,
+        policy: &serde_json::Map<String, serde_json::Value>,
+    ) -> bool {
+        policy.get(OSV_POLICY_KEY).and_then(serde_json::Value::as_str)
+            == Some(self.fingerprint.as_str())
+    }
+
+    pub(crate) fn vulnerability_ids(&self, name: &str, version: &str) -> Vec<String> {
+        let Some(advisories) = self.packages.get(name) else {
+            return Vec::new();
+        };
+        advisories
+            .iter()
+            .filter(|advisory| advisory.affects(version))
+            .map(|advisory| advisory.id.clone())
+            .collect()
+    }
+
+    fn decision(&self, name: &str, version: &str) -> PackageVersionGuardDecision {
+        let ids = self.vulnerability_ids(name, version);
+        if ids.is_empty() {
+            return PackageVersionGuardDecision::Allow;
+        }
+        PackageVersionGuardDecision::Reject {
+            reason: format!(
+                "is listed in the local OSV database as vulnerable ({})",
+                ids.join(", "),
+            ),
+        }
+    }
+}
+
+impl PackageVersionGuard for OsvIndex {
+    fn check<'a>(&'a self, name: &'a str, version: &'a str) -> PackageVersionGuardFuture<'a> {
+        Box::pin(async move { Ok(self.decision(name, version)) })
+    }
+}
+
+#[derive(Debug)]
+struct Advisory {
+    id: String,
+    versions: HashSet<String>,
+    ranges: Vec<SemverRange>,
+}
+
+impl Advisory {
+    fn affects(&self, version: &str) -> bool {
+        if self.versions.contains(version) {
+            return true;
+        }
+        let Ok(parsed) = Version::parse(version) else {
+            return false;
+        };
+        self.ranges.iter().any(|range| range.affects(&parsed))
+    }
+}
+
+#[derive(Debug)]
+struct SemverRange {
+    events: Vec<SemverEvent>,
+}
+
+impl SemverRange {
+    fn affects(&self, version: &Version) -> bool {
+        let mut affected = false;
+        for event in &self.events {
+            match event {
+                SemverEvent::Introduced(introduced) => {
+                    if version >= introduced {
+                        affected = true;
+                    }
+                }
+                SemverEvent::Fixed(fixed) => {
+                    if version >= fixed {
+                        affected = false;
+                    }
+                }
+                SemverEvent::LastAffected(last_affected) => {
+                    if version > last_affected {
+                        affected = false;
+                    }
+                }
+                SemverEvent::Limit(limit) => {
+                    if version >= limit {
+                        affected = false;
+                    }
+                }
+            }
+        }
+        affected
+    }
+}
+
+#[derive(Debug)]
+enum SemverEvent {
+    Introduced(Version),
+    Fixed(Version),
+    LastAffected(Version),
+    Limit(Version),
+}
+
+#[derive(Deserialize)]
+struct OsvRecord {
+    id: String,
+    #[serde(default)]
+    withdrawn: Option<serde_json::Value>,
+    #[serde(default)]
+    affected: Vec<OsvAffected>,
+}
+
+#[derive(Deserialize)]
+struct OsvAffected {
+    #[serde(default)]
+    package: Option<OsvPackage>,
+    #[serde(default)]
+    ranges: Vec<OsvRange>,
+    #[serde(default)]
+    versions: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct OsvPackage {
+    ecosystem: String,
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct OsvRange {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    events: Vec<OsvEvent>,
+}
+
+#[derive(Deserialize)]
+struct OsvEvent {
+    #[serde(default)]
+    introduced: Option<String>,
+    #[serde(default)]
+    fixed: Option<String>,
+    #[serde(default, rename = "last_affected")]
+    last_affected: Option<String>,
+    #[serde(default)]
+    limit: Option<String>,
+}
+
+pub(crate) fn load_osv_index(config: &Config) -> Result<Option<Arc<OsvIndex>>, RegistryError> {
+    OsvIndex::load_from_config(config)
+}
+
+fn default_osv_path(config: &Config) -> PathBuf {
+    config.cache_storage.join("osv").join("npm").join("all.zip")
+}
+
+fn load_from_zip(path: &Path) -> Result<OsvIndex, RegistryError> {
+    let fingerprint = file_fingerprint(path)?;
+    let file = File::open(path).map_err(|err| {
+        invalid_config(format!("failed to open OSV database {}: {err}", path.display()))
+    })?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|err| {
+        invalid_config(format!("failed to read OSV zip {}: {err}", path.display()))
+    })?;
+    let mut packages = HashMap::new();
+    for index in 0..archive.len() {
+        let mut entry = archive.by_index(index).map_err(|err| {
+            invalid_config(format!("failed to read OSV zip entry in {}: {err}", path.display()))
+        })?;
+        if !entry.is_file() || !entry.name().ends_with(".json") {
+            continue;
+        }
+        let mut bytes = Vec::with_capacity(entry.size().min(1024 * 1024) as usize);
+        entry.read_to_end(&mut bytes).map_err(|err| {
+            invalid_config(format!("failed to read OSV zip entry {}: {err}", entry.name()))
+        })?;
+        ingest_record_bytes(&mut packages, &bytes)?;
+    }
+    Ok(OsvIndex { packages, fingerprint })
+}
+
+fn load_from_directory(path: &Path) -> Result<OsvIndex, RegistryError> {
+    let mut entries = std::fs::read_dir(path)
+        .map_err(|err| {
+            invalid_config(format!("failed to read OSV directory {}: {err}", path.display()))
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|err| {
+            invalid_config(format!("failed to read OSV directory {}: {err}", path.display()))
+        })?;
+    entries.sort_by_key(std::fs::DirEntry::path);
+
+    let mut packages = HashMap::new();
+    let mut hasher = Sha256::new();
+    for entry in entries {
+        let entry_path = entry.path();
+        if !entry_path.is_file()
+            || entry_path.extension().is_none_or(|extension| extension != "json")
+        {
+            continue;
+        }
+        hasher.update(entry_path.file_name().and_then(|name| name.to_str()).unwrap_or_default());
+        let bytes = std::fs::read(&entry_path).map_err(|err| {
+            invalid_config(format!("failed to read OSV record {}: {err}", entry_path.display()))
+        })?;
+        hasher.update(&bytes);
+        ingest_record_bytes(&mut packages, &bytes)?;
+    }
+    Ok(OsvIndex { packages, fingerprint: format!("sha256:{:x}", hasher.finalize()) })
+}
+
+fn file_fingerprint(path: &Path) -> Result<String, RegistryError> {
+    let mut file = File::open(path).map_err(|err| {
+        invalid_config(format!("failed to open OSV database {}: {err}", path.display()))
+    })?;
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0_u8; 1024 * 64];
+    loop {
+        let read = file.read(&mut buf).map_err(|err| {
+            invalid_config(format!("failed to hash OSV database {}: {err}", path.display()))
+        })?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buf[..read]);
+    }
+    file.rewind().map_err(|err| {
+        invalid_config(format!("failed to rewind OSV database {}: {err}", path.display()))
+    })?;
+    Ok(format!("sha256:{:x}", hasher.finalize()))
+}
+
+fn ingest_record_bytes(
+    packages: &mut HashMap<String, Vec<Advisory>>,
+    bytes: &[u8],
+) -> Result<(), RegistryError> {
+    let record: OsvRecord = serde_json::from_slice(bytes)
+        .map_err(|err| invalid_config(format!("failed to parse OSV record: {err}")))?;
+    if record.withdrawn.is_some() {
+        return Ok(());
+    }
+    for affected in record.affected {
+        let Some(package) = affected.package.as_ref() else { continue };
+        if package.ecosystem != "npm" {
+            continue;
+        }
+        let name = package.name.clone();
+        let advisory = advisory_from_affected(&record.id, affected);
+        if advisory.versions.is_empty() && advisory.ranges.is_empty() {
+            continue;
+        }
+        packages.entry(name).or_default().push(advisory);
+    }
+    Ok(())
+}
+
+fn advisory_from_affected(id: &str, affected: OsvAffected) -> Advisory {
+    let ranges = affected.ranges.into_iter().filter_map(semver_range_from_osv).collect();
+    Advisory { id: id.to_string(), versions: affected.versions.into_iter().collect(), ranges }
+}
+
+fn semver_range_from_osv(range: OsvRange) -> Option<SemverRange> {
+    if range.kind != "SEMVER" && range.kind != "ECOSYSTEM" {
+        return None;
+    }
+    let events = range.events.into_iter().filter_map(semver_event_from_osv).collect::<Vec<_>>();
+    (!events.is_empty()).then_some(SemverRange { events })
+}
+
+fn semver_event_from_osv(event: OsvEvent) -> Option<SemverEvent> {
+    if let Some(introduced) = event.introduced {
+        return parse_osv_version(&introduced).map(SemverEvent::Introduced);
+    }
+    if let Some(fixed) = event.fixed {
+        return parse_osv_version(&fixed).map(SemverEvent::Fixed);
+    }
+    if let Some(last_affected) = event.last_affected {
+        return parse_osv_version(&last_affected).map(SemverEvent::LastAffected);
+    }
+    if let Some(limit) = event.limit {
+        return parse_osv_version(&limit).map(SemverEvent::Limit);
+    }
+    None
+}
+
+fn parse_osv_version(raw: &str) -> Option<Version> {
+    if raw == "0" {
+        return Version::parse("0.0.0").ok();
+    }
+    Version::parse(raw).ok()
+}
+
+fn invalid_config(reason: String) -> RegistryError {
+    RegistryError::InvalidConfig { reason }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -305,7 +305,6 @@ fn load_from_directory(path: &Path) -> Result<OsvIndex, RegistryError> {
         {
             continue;
         }
-        hasher.update(entry_path.file_name().and_then(|name| name.to_str()).unwrap_or_default());
         // Bound the read itself with `take` rather than trusting a
         // pre-read `metadata().len()`, which a concurrent swap could
         // invalidate (TOCTOU) — matching the zip loader's guarantee.
@@ -322,6 +321,15 @@ fn load_from_directory(path: &Path) -> Result<OsvIndex, RegistryError> {
                 entry_path.display(),
             )));
         }
+        // Length-prefix each component so the hash input is unambiguous:
+        // plain concatenation of (name, bytes) lets two different
+        // directory states hash to the same stream, which would let an
+        // attacker with write access edit advisories while keeping the
+        // fingerprint (and thus a trusted verdict-cache pass) unchanged.
+        let name = entry_path.file_name().and_then(|name| name.to_str()).unwrap_or_default();
+        hasher.update((name.len() as u64).to_le_bytes());
+        hasher.update(name.as_bytes());
+        hasher.update((bytes.len() as u64).to_le_bytes());
         hasher.update(&bytes);
         ingest_record_bytes(&mut packages, &bytes)?;
     }
@@ -416,12 +424,12 @@ fn parse_osv_version(raw: &str) -> Option<Version> {
     }
     let parsed = Version::parse(raw).ok();
     if parsed.is_none() {
-        // Surface rather than silently drop: an unparseable bound means
+        // Surface rather than silently drop: an unparsable bound means
         // this range won't be enforced, so a corrupt dump can't degrade
         // coverage without leaving a trace in the logs.
         tracing::warn!(
             version = raw,
-            "ignoring OSV range event with an unparseable version; that range will not be enforced",
+            "ignoring OSV range event with an unparsable version; that range will not be enforced",
         );
     }
     parsed

--- a/pnpr/crates/pnpr/src/resolver/osv.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv.rs
@@ -188,6 +188,26 @@ enum SemverEvent {
     Limit(Version),
 }
 
+impl SemverEvent {
+    fn bound(&self) -> &Version {
+        match self {
+            SemverEvent::Introduced(version)
+            | SemverEvent::Fixed(version)
+            | SemverEvent::LastAffected(version)
+            | SemverEvent::Limit(version) => version,
+        }
+    }
+
+    /// At an equal version bound an `introduced` opens the range before a
+    /// closing event shuts it, so it must sort first.
+    fn sort_rank(&self) -> u8 {
+        match self {
+            SemverEvent::Introduced(_) => 0,
+            SemverEvent::Fixed(_) | SemverEvent::LastAffected(_) | SemverEvent::Limit(_) => 1,
+        }
+    }
+}
+
 #[derive(Deserialize)]
 struct OsvRecord {
     id: String,
@@ -398,7 +418,16 @@ fn semver_range_from_osv(range: OsvRange) -> Option<SemverRange> {
     if range.kind != "SEMVER" && range.kind != "ECOSYSTEM" {
         return None;
     }
-    let events = range.events.into_iter().filter_map(semver_event_from_osv).collect::<Vec<_>>();
+    let mut events = range.events.into_iter().filter_map(semver_event_from_osv).collect::<Vec<_>>();
+    // `SemverRange::affects` toggles state as it walks events, so it is
+    // order-sensitive. OSV expects events sorted by version bound; sort
+    // here so a malformed or reordered events array can't flip a verdict.
+    events.sort_by(|a, b| {
+        a.bound()
+            .partial_cmp(b.bound())
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.sort_rank().cmp(&b.sort_rank()))
+    });
     (!events.is_empty()).then_some(SemverRange { events })
 }
 

--- a/pnpr/crates/pnpr/src/resolver/osv/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv/tests.rs
@@ -1,0 +1,79 @@
+use std::{fs, sync::Arc};
+
+use pacquet_resolving_resolver_base::{PackageVersionGuard, PackageVersionGuardDecision};
+
+use super::OsvIndex;
+
+#[test]
+fn loads_directory_and_matches_semver_ranges() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        dir.path().join("GHSA-test.json"),
+        r#"{
+          "id": "GHSA-test",
+          "affected": [{
+            "package": { "ecosystem": "npm", "name": "acme" },
+            "ranges": [{
+              "type": "SEMVER",
+              "events": [
+                { "introduced": "1.0.0" },
+                { "fixed": "1.2.0" }
+              ]
+            }]
+          }]
+        }"#,
+    )
+    .expect("write record");
+
+    let index = OsvIndex::load_from_path(dir.path()).expect("load index");
+
+    assert_eq!(index.vulnerability_ids("acme", "0.9.0"), Vec::<String>::new());
+    assert_eq!(index.vulnerability_ids("acme", "1.1.0"), vec!["GHSA-test"]);
+    assert_eq!(index.vulnerability_ids("acme", "1.2.0"), Vec::<String>::new());
+}
+
+#[test]
+fn explicit_versions_match_even_without_semver() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        dir.path().join("GHSA-exact.json"),
+        r#"{
+          "id": "GHSA-exact",
+          "affected": [{
+            "package": { "ecosystem": "npm", "name": "odd" },
+            "versions": ["2026.06.18-custom"]
+          }]
+        }"#,
+    )
+    .expect("write record");
+
+    let index = OsvIndex::load_from_path(dir.path()).expect("load index");
+
+    assert_eq!(index.vulnerability_ids("odd", "2026.06.18-custom"), vec!["GHSA-exact"]);
+}
+
+#[tokio::test]
+async fn package_version_guard_rejects_vulnerable_versions() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        dir.path().join("GHSA-guard.json"),
+        r#"{
+          "id": "GHSA-guard",
+          "affected": [{
+            "package": { "ecosystem": "npm", "name": "guarded" },
+            "versions": ["1.0.0"]
+          }]
+        }"#,
+    )
+    .expect("write record");
+
+    let index = Arc::new(OsvIndex::load_from_path(dir.path()).expect("load index"));
+
+    assert_eq!(index.check("guarded", "1.1.0").await.unwrap(), PackageVersionGuardDecision::Allow);
+    match index.check("guarded", "1.0.0").await.unwrap() {
+        PackageVersionGuardDecision::Reject { reason } => {
+            assert!(reason.contains("GHSA-guard"));
+        }
+        PackageVersionGuardDecision::Allow => panic!("expected rejection, got allow"),
+    }
+}

--- a/pnpr/crates/pnpr/src/resolver/osv/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv/tests.rs
@@ -95,6 +95,27 @@ fn duplicate_affected_blocks_yield_one_id() {
     assert_eq!(index.vulnerability_ids("dup", "1.0.0"), vec!["GHSA-dup"]);
 }
 
+#[test]
+fn loads_zip_archive_and_fingerprints_it() {
+    use std::io::Write;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let zip_path = dir.path().join("all.zip");
+    let mut writer = zip::ZipWriter::new(fs::File::create(&zip_path).expect("create zip"));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    writer.start_file("GHSA-zip.json", options).expect("start file");
+    writer
+        .write_all(
+            br#"{"id":"GHSA-zip","affected":[{"package":{"ecosystem":"npm","name":"zipped"},"versions":["1.0.0"]}]}"#,
+        )
+        .expect("write entry");
+    writer.finish().expect("finish zip");
+
+    let index = OsvIndex::load_from_path(&zip_path).expect("load zip index");
+    assert_eq!(index.vulnerability_ids("zipped", "1.0.0"), vec!["GHSA-zip"]);
+}
+
 #[cfg(unix)]
 #[test]
 fn non_regular_file_path_is_rejected() {

--- a/pnpr/crates/pnpr/src/resolver/osv/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv/tests.rs
@@ -52,6 +52,27 @@ fn explicit_versions_match_even_without_semver() {
     assert_eq!(index.vulnerability_ids("odd", "2026.06.18-custom"), vec!["GHSA-exact"]);
 }
 
+#[test]
+fn package_name_lookup_is_case_insensitive() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        dir.path().join("GHSA-case.json"),
+        r#"{
+          "id": "GHSA-case",
+          "affected": [{
+            "package": { "ecosystem": "npm", "name": "JSONStream" },
+            "versions": ["1.0.0"]
+          }]
+        }"#,
+    )
+    .expect("write record");
+
+    let index = OsvIndex::load_from_path(dir.path()).expect("load index");
+
+    assert_eq!(index.vulnerability_ids("jsonstream", "1.0.0"), vec!["GHSA-case"]);
+    assert_eq!(index.vulnerability_ids("JSONStream", "1.0.0"), vec!["GHSA-case"]);
+}
+
 #[tokio::test]
 async fn package_version_guard_rejects_vulnerable_versions() {
     let dir = tempfile::tempdir().expect("tempdir");

--- a/pnpr/crates/pnpr/src/resolver/osv/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv/tests.rs
@@ -96,6 +96,29 @@ fn duplicate_affected_blocks_yield_one_id() {
 }
 
 #[test]
+fn withdrawn_handling_respects_null_vs_timestamp() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // `withdrawn: null` is not a withdrawal — the advisory stays active.
+    fs::write(
+        dir.path().join("GHSA-active.json"),
+        r#"{ "id": "GHSA-active", "withdrawn": null,
+            "affected": [{ "package": { "ecosystem": "npm", "name": "pkg" }, "versions": ["1.0.0"] }] }"#,
+    )
+    .expect("write active record");
+    // A real withdrawal timestamp drops the advisory.
+    fs::write(
+        dir.path().join("GHSA-gone.json"),
+        r#"{ "id": "GHSA-gone", "withdrawn": "2024-01-01T00:00:00Z",
+            "affected": [{ "package": { "ecosystem": "npm", "name": "pkg" }, "versions": ["1.0.0"] }] }"#,
+    )
+    .expect("write withdrawn record");
+
+    let index = OsvIndex::load_from_path(dir.path()).expect("load index");
+
+    assert_eq!(index.vulnerability_ids("pkg", "1.0.0"), vec!["GHSA-active"]);
+}
+
+#[test]
 fn loads_zip_archive_and_fingerprints_it() {
     use std::io::Write;
 

--- a/pnpr/crates/pnpr/src/resolver/osv/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv/tests.rs
@@ -73,6 +73,28 @@ fn package_name_lookup_is_case_insensitive() {
     assert_eq!(index.vulnerability_ids("JSONStream", "1.0.0"), vec!["GHSA-case"]);
 }
 
+#[test]
+fn duplicate_affected_blocks_yield_one_id() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // One record listing the same package twice — the id must appear once.
+    fs::write(
+        dir.path().join("GHSA-dup.json"),
+        r#"{
+          "id": "GHSA-dup",
+          "affected": [
+            { "package": { "ecosystem": "npm", "name": "dup" }, "versions": ["1.0.0"] },
+            { "package": { "ecosystem": "npm", "name": "dup" },
+              "ranges": [{ "type": "SEMVER", "events": [{ "introduced": "1.0.0" }] }] }
+          ]
+        }"#,
+    )
+    .expect("write record");
+
+    let index = OsvIndex::load_from_path(dir.path()).expect("load index");
+
+    assert_eq!(index.vulnerability_ids("dup", "1.0.0"), vec!["GHSA-dup"]);
+}
+
 #[tokio::test]
 async fn package_version_guard_rejects_vulnerable_versions() {
     let dir = tempfile::tempdir().expect("tempdir");

--- a/pnpr/crates/pnpr/src/resolver/osv/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv/tests.rs
@@ -96,6 +96,30 @@ fn duplicate_affected_blocks_yield_one_id() {
 }
 
 #[test]
+fn introduced_zero_covers_prerelease_versions() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // `introduced: "0"` means "all versions"; a prerelease below 0.0.0 must
+    // still be covered.
+    fs::write(
+        dir.path().join("GHSA-zero.json"),
+        r#"{
+          "id": "GHSA-zero",
+          "affected": [{
+            "package": { "ecosystem": "npm", "name": "zero" },
+            "ranges": [{ "type": "SEMVER", "events": [{ "introduced": "0" }, { "fixed": "2.0.0" }] }]
+          }]
+        }"#,
+    )
+    .expect("write record");
+
+    let index = OsvIndex::load_from_path(dir.path()).expect("load index");
+
+    assert_eq!(index.vulnerability_ids("zero", "0.0.0-alpha.1"), vec!["GHSA-zero"]);
+    assert_eq!(index.vulnerability_ids("zero", "1.0.0"), vec!["GHSA-zero"]);
+    assert_eq!(index.vulnerability_ids("zero", "2.0.0"), Vec::<String>::new());
+}
+
+#[test]
 fn out_of_order_range_events_are_normalized() {
     let dir = tempfile::tempdir().expect("tempdir");
     // Events are deliberately reversed (fixed before introduced). Without

--- a/pnpr/crates/pnpr/src/resolver/osv/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv/tests.rs
@@ -265,3 +265,23 @@ fn advisory_ids_are_capped_in_messages() {
     assert!(formatted.ends_with("and 5 more"), "{formatted}");
     assert_eq!(formatted.matches("GHSA-").count(), 20);
 }
+
+#[test]
+fn oversized_advisory_id_is_truncated() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let big_id = format!("GHSA-{}", "x".repeat(5000));
+    fs::write(
+        dir.path().join("GHSA-big.json"),
+        format!(
+            r#"{{"id":"{big_id}","affected":[{{"package":{{"ecosystem":"npm","name":"big"}},"versions":["1.0.0"]}}]}}"#,
+        ),
+    )
+    .expect("write record");
+
+    let index = OsvIndex::load_from_path(dir.path()).expect("load index");
+
+    let ids = index.vulnerability_ids("big", "1.0.0");
+    assert_eq!(ids.len(), 1);
+    assert!(ids[0].len() < 300, "id not truncated: {} bytes", ids[0].len());
+    assert!(ids[0].ends_with('…'), "truncated id should end with ellipsis");
+}

--- a/pnpr/crates/pnpr/src/resolver/osv/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv/tests.rs
@@ -77,3 +77,28 @@ async fn package_version_guard_rejects_vulnerable_versions() {
         PackageVersionGuardDecision::Allow => panic!("expected rejection, got allow"),
     }
 }
+
+#[test]
+fn enabled_database_without_npm_advisories_is_rejected() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Only a non-npm advisory, so the npm index ends up empty.
+    fs::write(
+        dir.path().join("GHSA-pypi.json"),
+        r#"{
+          "id": "GHSA-pypi",
+          "affected": [{
+            "package": { "ecosystem": "PyPI", "name": "x" },
+            "versions": ["1.0.0"]
+          }]
+        }"#,
+    )
+    .expect("write record");
+
+    let listen = "127.0.0.1:4873".parse().expect("listen addr");
+    let mut config = crate::Config::proxy(listen, dir.path().to_path_buf());
+    config.osv.enabled = true;
+    config.osv.path = Some(dir.path().to_path_buf());
+
+    let err = super::load_osv_index(&config).expect_err("an empty npm index must be rejected");
+    assert!(format!("{err}").contains("no npm advisories"));
+}

--- a/pnpr/crates/pnpr/src/resolver/osv/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv/tests.rs
@@ -230,3 +230,14 @@ fn enabled_database_without_npm_advisories_is_rejected() {
     let err = super::load_osv_index(&config).expect_err("an empty npm index must be rejected");
     assert!(format!("{err}").contains("no npm advisories"));
 }
+
+#[test]
+fn advisory_ids_are_capped_in_messages() {
+    let few: Vec<String> = (0..3).map(|i| format!("GHSA-{i}")).collect();
+    assert_eq!(super::format_advisory_ids(&few), "GHSA-0, GHSA-1, GHSA-2");
+
+    let many: Vec<String> = (0..25).map(|i| format!("GHSA-{i}")).collect();
+    let formatted = super::format_advisory_ids(&many);
+    assert!(formatted.ends_with("and 5 more"), "{formatted}");
+    assert_eq!(formatted.matches("GHSA-").count(), 20);
+}

--- a/pnpr/crates/pnpr/src/resolver/osv/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv/tests.rs
@@ -95,6 +95,19 @@ fn duplicate_affected_blocks_yield_one_id() {
     assert_eq!(index.vulnerability_ids("dup", "1.0.0"), vec!["GHSA-dup"]);
 }
 
+#[cfg(unix)]
+#[test]
+fn non_regular_file_path_is_rejected() {
+    // A socket is neither a directory nor a regular file; loading it as a
+    // zip would risk blocking on the read, so it must fail fast instead.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket_path = dir.path().join("osv.sock");
+    let _listener = std::os::unix::net::UnixListener::bind(&socket_path).expect("bind socket");
+
+    let err = OsvIndex::load_from_path(&socket_path).expect_err("a socket path must be rejected");
+    assert!(format!("{err}").contains("neither a directory nor a regular file"), "{err}");
+}
+
 #[tokio::test]
 async fn package_version_guard_rejects_vulnerable_versions() {
     let dir = tempfile::tempdir().expect("tempdir");

--- a/pnpr/crates/pnpr/src/resolver/osv/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/osv/tests.rs
@@ -96,6 +96,34 @@ fn duplicate_affected_blocks_yield_one_id() {
 }
 
 #[test]
+fn out_of_order_range_events_are_normalized() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Events are deliberately reversed (fixed before introduced). Without
+    // sorting, a version above the fix would be walked as still-affected.
+    fs::write(
+        dir.path().join("GHSA-order.json"),
+        r#"{
+          "id": "GHSA-order",
+          "affected": [{
+            "package": { "ecosystem": "npm", "name": "ord" },
+            "ranges": [{
+              "type": "SEMVER",
+              "events": [ { "fixed": "1.2.0" }, { "introduced": "1.0.0" } ]
+            }]
+          }]
+        }"#,
+    )
+    .expect("write record");
+
+    let index = OsvIndex::load_from_path(dir.path()).expect("load index");
+
+    assert_eq!(index.vulnerability_ids("ord", "0.9.0"), Vec::<String>::new());
+    assert_eq!(index.vulnerability_ids("ord", "1.1.0"), vec!["GHSA-order"]);
+    // Above the fix: must be safe — this is the case that fails without sorting.
+    assert_eq!(index.vulnerability_ids("ord", "1.3.0"), Vec::<String>::new());
+}
+
+#[test]
 fn withdrawn_handling_respects_null_vs_timestamp() {
     let dir = tempfile::tempdir().expect("tempdir");
     // `withdrawn: null` is not a withdrawal — the advisory stays active.

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -178,3 +178,21 @@ fn osv_checkable_tarball_does_not_trust_git_hosted_flag_or_strict_url_parsing() 
     // Non-http schemes are skipped.
     assert!(!super::is_osv_checkable_resolution(&tarball("file:../foo.tgz", None)));
 }
+
+#[test]
+fn tarball_url_version_extracts_conventional_names_only() {
+    use super::tarball_url_version;
+
+    assert_eq!(tarball_url_version("https://r/foo/-/foo-1.2.3.tgz", "foo"), Some("1.2.3"));
+    // Scoped packages name the tarball file with the unscoped name.
+    assert_eq!(tarball_url_version("https://r/@s/foo/-/foo-1.2.3.tgz", "@s/foo"), Some("1.2.3"));
+    // Query/fragment are stripped; prerelease/build keep working.
+    assert_eq!(tarball_url_version("https://r/foo/-/foo-1.2.3.tgz?x=1", "foo"), Some("1.2.3"));
+    assert_eq!(
+        tarball_url_version("https://r/foo/-/foo-1.2.3-beta.1.tgz", "foo"),
+        Some("1.2.3-beta.1"),
+    );
+    // Non-conventional naming yields None (fall back, don't misjudge).
+    assert_eq!(tarball_url_version("https://r/weird.tgz", "foo"), None);
+    assert_eq!(tarball_url_version("https://r/foo/-/foo.tgz", "foo"), None);
+}

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -146,3 +146,35 @@ fn frozen_package_frames_announce_lockfile_tarballs_with_sizes() {
     assert_eq!(frame["unpackedSize"], serde_json::json!(123_456));
     assert_eq!(frame["fileCount"], serde_json::json!(42));
 }
+
+#[test]
+fn osv_checkable_tarball_does_not_trust_git_hosted_flag_or_strict_url_parsing() {
+    use pacquet_lockfile::{LockfileResolution, TarballResolution};
+
+    let tarball = |url: &str, git_hosted: Option<bool>| {
+        LockfileResolution::Tarball(TarballResolution {
+            tarball: url.to_string(),
+            integrity: None,
+            git_hosted,
+            path: None,
+        })
+    };
+
+    // `gitHosted: true` must not let a normal https registry tarball opt out.
+    assert!(super::is_osv_checkable_resolution(&tarball(
+        "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
+        Some(true),
+    )));
+    // A URL that strict parsing would reject is still scanned when it is http(s).
+    assert!(super::is_osv_checkable_resolution(&tarball(
+        "https://registry.npmjs.org/foo/-/foo 1.0.0.tgz",
+        None,
+    )));
+    // Genuinely git-hosted-by-URL tarballs are skipped regardless of the flag.
+    assert!(!super::is_osv_checkable_resolution(&tarball(
+        "https://codeload.github.com/foo/bar/tar.gz/abc123",
+        Some(false),
+    )));
+    // Non-http schemes are skipped.
+    assert!(!super::is_osv_checkable_resolution(&tarball("file:../foo.tgz", None)));
+}

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -1,6 +1,8 @@
-use std::collections::BTreeMap;
-
 use pacquet_config::Config as PacquetConfig;
+use pacquet_resolving_resolver_base::{
+    PackageVersionGuard, PackageVersionGuardDecision, PackageVersionGuardFuture,
+};
+use std::{collections::BTreeMap, sync::Arc};
 
 use super::{
     protocol::{ResolveRequest, ResolveRequestProject},
@@ -15,6 +17,15 @@ fn config() -> PacquetConfig {
 
 fn deps(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
     entries.iter().map(|(name, spec)| ((*name).to_string(), (*spec).to_string())).collect()
+}
+
+#[derive(Debug)]
+struct AllowAllVersions;
+
+impl PackageVersionGuard for AllowAllVersions {
+    fn check<'a>(&'a self, _name: &'a str, _version: &'a str) -> PackageVersionGuardFuture<'a> {
+        Box::pin(async { Ok(PackageVersionGuardDecision::Allow) })
+    }
 }
 
 #[test]
@@ -66,7 +77,8 @@ fn a_package_frame_carries_unpacked_size_and_omits_it_when_unknown() {
     use pacquet_package_manager::{ResolutionObserver, ResolvedPackageHint};
 
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    let observer = super::StreamObserver { tx };
+    let observer =
+        super::StreamObserver { tx, package_version_guard: Some(Arc::new(AllowAllVersions)) };
 
     let hint = |unpacked_size, file_count| ResolvedPackageHint {
         id: "acme@1.0.0",

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -192,6 +192,10 @@ fn tarball_url_version_extracts_conventional_names_only() {
         tarball_url_version("https://r/foo/-/foo-1.2.3-beta.1.tgz", "foo"),
         Some("1.2.3-beta.1"),
     );
+    // Suffix matching is case-insensitive and covers `.tar.gz`, so a
+    // tampered lockfile can't dodge the cross-check with a variant.
+    assert_eq!(tarball_url_version("https://r/foo/-/foo-1.2.3.TGZ", "foo"), Some("1.2.3"));
+    assert_eq!(tarball_url_version("https://r/foo/-/foo-1.2.3.tar.gz", "foo"), Some("1.2.3"));
     // Non-conventional naming yields None (fall back, don't misjudge).
     assert_eq!(tarball_url_version("https://r/weird.tgz", "foo"), None);
     assert_eq!(tarball_url_version("https://r/foo/-/foo.tgz", "foo"), None);

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -72,6 +72,9 @@ struct AppInner {
     /// Lazily-built engine backing the `/v1/resolve` endpoint. Built on
     /// first such request so servers that never receive one pay nothing.
     resolver: std::sync::OnceLock<crate::resolver::Resolver>,
+    /// Local OSV index, loaded before the server accepts requests when
+    /// `osv.enabled` is set.
+    osv_index: Option<Arc<crate::resolver::OsvIndex>>,
 }
 
 /// Per-package serialization for the read-modify-write packument flows
@@ -155,6 +158,16 @@ pub fn router(config: Config) -> Router {
 /// by [`serve`] to wire the persistent file-backed stores, and by
 /// tests that want to override the bcrypt cost or pre-seed users.
 pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
+    let osv_index = crate::resolver::load_osv_index(&config)
+        .expect("enabled OSV database must load before building pnpr router");
+    router_with_auth_and_osv(config, auth, osv_index)
+}
+
+fn router_with_auth_and_osv(
+    config: Config,
+    auth: AuthState,
+    osv_index: Option<Arc<crate::resolver::OsvIndex>>,
+) -> Router {
     let storage =
         Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone());
     let upstreams: IndexMap<String, Upstream> = config
@@ -170,6 +183,7 @@ pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
             auth,
             package_locks: PackageLocks::new(),
             resolver: std::sync::OnceLock::new(),
+            osv_index,
         }),
     };
     Router::new()
@@ -259,9 +273,10 @@ pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
 /// connections.
 pub async fn serve(config: Config) -> crate::error::Result<()> {
     crate::journal::recover_publish_journal(&config).await?;
+    let osv_index = crate::resolver::load_osv_index(&config)?;
     let auth = AuthState::load(&config.auth, &config.backend).await?;
     let listen = config.listen;
-    let app = router_with_auth(config, auth);
+    let app = router_with_auth_and_osv(config, auth, osv_index);
     let listener = NodelayTcpListener(tokio::net::TcpListener::bind(listen).await?);
     tracing::info!(%listen, "pnpr listening");
     axum::serve(listener, app).with_graceful_shutdown(shutdown_signal()).await?;
@@ -279,11 +294,12 @@ pub async fn serve_listener(
 ) -> crate::error::Result<()> {
     let listen = listener.local_addr()?;
     crate::journal::recover_publish_journal(&config).await?;
+    let osv_index = crate::resolver::load_osv_index(&config)?;
     // Load the configured auth backends here too — going through
     // `router` would silently fall back to in-memory auth and ignore a
     // persisted htpasswd / SQLite store or a configured `backend:`.
     let auth = AuthState::load(&config.auth, &config.backend).await?;
-    let app = router_with_auth(config, auth);
+    let app = router_with_auth_and_osv(config, auth, osv_index);
     tracing::info!(%listen, "pnpr listening");
     axum::serve(NodelayTcpListener(listener), app)
         .with_graceful_shutdown(shutdown_signal())
@@ -1998,13 +2014,19 @@ async fn serve_resolve(State(state): State<AppState>, body: axum::body::Bytes) -
     // read gate here: the client fetches every tarball directly from the
     // registry with its own credentials, and resolution uses the client's
     // forwarded credentials for private packages.
-    let runtime =
-        crate::resolver::Resolver::get_or_init(&state.inner.resolver, &state.inner.config);
+    let runtime = crate::resolver::Resolver::get_or_init(
+        &state.inner.resolver,
+        &state.inner.config,
+        state.inner.osv_index.clone(),
+    );
     crate::resolver::handle_resolve(runtime, body).await
 }
 
 async fn serve_verify_lockfile(State(state): State<AppState>, body: axum::body::Bytes) -> Response {
-    let runtime =
-        crate::resolver::Resolver::get_or_init(&state.inner.resolver, &state.inner.config);
+    let runtime = crate::resolver::Resolver::get_or_init(
+        &state.inner.resolver,
+        &state.inner.config,
+        state.inner.osv_index.clone(),
+    );
     crate::resolver::handle_verify_lockfile(runtime, body).await
 }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -154,13 +154,28 @@ pub fn router(config: Config) -> Router {
     router_with_auth(config, AuthState::in_memory())
 }
 
+/// Fallible counterpart to [`router`]: surfaces a missing/invalid OSV
+/// database (when `osv.enabled`) as an error instead of panicking, for
+/// embedders that build the router directly rather than via [`serve`].
+pub fn try_router(config: Config) -> crate::error::Result<Router> {
+    try_router_with_auth(config, AuthState::in_memory())
+}
+
 /// Like [`router`] but with a caller-supplied [`AuthState`]. Used
 /// by [`serve`] to wire the persistent file-backed stores, and by
 /// tests that want to override the bcrypt cost or pre-seed users.
+///
+/// Panics if `osv.enabled` is set but the database can't load; call
+/// [`try_router_with_auth`] to handle that as a recoverable error.
 pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
-    let osv_index = crate::resolver::load_osv_index(&config)
-        .expect("enabled OSV database must load before building pnpr router");
-    router_with_auth_and_osv(config, auth, osv_index)
+    try_router_with_auth(config, auth)
+        .expect("enabled OSV database must load before building pnpr router")
+}
+
+/// Fallible counterpart to [`router_with_auth`].
+pub fn try_router_with_auth(config: Config, auth: AuthState) -> crate::error::Result<Router> {
+    let osv_index = crate::resolver::load_osv_index(&config)?;
+    Ok(router_with_auth_and_osv(config, auth, osv_index))
 }
 
 fn router_with_auth_and_osv(


### PR DESCRIPTION
## Summary

Adds optional pnpr OSV protection backed by a local npm OSV dump instead of live API calls in the resolver hot path.

- adds `osv.enabled` / `osv.path` config and `--osv` / `--osv-db` CLI flags
- loads the local OSV npm `all.zip` or extracted JSON directory at startup and fails closed when enabled but the database is missing, not a regular file, or contains no npm advisories
- rejects vulnerable npm versions during resolution via a resolver-time guard, letting the normal picker choose another compatible version — or failing with a distinct error when every matching version is blocked
- checks frozen, cached, verified, and freshly resolved lockfiles against the local index, gating tarball entries on the tarball URL rather than the tamper-prone `gitHosted` flag
- records a content-based OSV DB fingerprint in pnpr's lockfile-verdict cache so refreshed vulnerability data invalidates prior cached passes
- adds fallible `try_router` / `try_router_with_auth` constructors so embedders can surface an invalid OSV database as a recoverable error instead of a panic

No TypeScript CLI port is included: pnpr has no pnpm-CLI counterpart, and the pacquet-side resolver guard is the infrastructure pnpr uses, so both sides live here.

## Squash Commit Body

```text
Add local OSV npm database support to pnpr. When enabled, pnpr loads an OSV npm dump (an `all.zip` or an extracted JSON directory) from disk at startup and fails before serving requests if the configured database is missing, not a regular file, empty of npm advisories, or otherwise invalid. Resolution then uses the in-memory index rather than querying OSV during package selection. Package names are matched case-insensitively, OSV range events are sorted before evaluation, and per-record reads are size-bounded.

Add a resolver-time package version guard to pacquet's npm resolver. The guard can reject a concrete package version, after which the picker filters that version out of the packument and tries the normal selection flow again. pnpr uses this hook to avoid vulnerable versions while preserving existing semver selection semantics. When every matching version is rejected, the resolver returns a distinct AllVersionsBlockedError rather than reporting the spec as unsupported.

Check frozen, cached, verified, and freshly produced lockfiles against the local OSV index, gating tarball entries on the tarball URL rather than the tamper-prone gitHosted flag. The pnpr lockfile-verdict cache records a content-based OSV database fingerprint in its policy snapshot, so a changed vulnerability database invalidates previous cached verification passes and forces rechecking under the new data.

Add fallible try_router / try_router_with_auth constructors so callers that build the router directly can handle an invalid OSV database recoverably instead of panicking.

Add tests for OSV range matching (including out-of-order events), exact-version and case-insensitive matching, withdrawn handling, zip and directory loading, empty/non-regular-file rejection, pnpr config parsing, guarded re-pick and all-versions-blocked behavior, and tarball OSV-checkability.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5); description updated by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local OSV npm vulnerability checks with CLI options: `--osv` to enable scanning and `--osv-db` to specify the OSV database path.
  * Vulnerability-aware version selection is now enforced during both dependency resolution and lockfile verification.
* **Refactor**
  * Introduced an optional “package version guard” mechanism to constrain which versions can be selected, including cache usage.
* **Bug Fixes**
  * Resolution can now fail explicitly when all candidate versions are rejected by the guard.
* **Tests**
  * Expanded OSV config and end-to-end resolve/verify coverage, plus new scenarios for guarded version rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
