### PR TITLE
feat(pacquet): honor NODE_EXTRA_CA_CERTS for custom CA trust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3983,6 +3983,7 @@ dependencies = [
  "derive_more",
  "miette 7.6.0",
  "mockito",
+ "pacquet-testing-utils",
  "pipe-trait",
  "pretty_assertions",
  "reqwest 0.13.4",

--- a/pacquet/crates/network/Cargo.toml
+++ b/pacquet/crates/network/Cargo.toml
@@ -19,9 +19,10 @@ tokio       = { workspace = true, features = ["time"] }
 tracing     = { workspace = true }
 
 [dev-dependencies]
-mockito           = { workspace = true }
-pretty_assertions = { workspace = true }
-tokio             = { workspace = true, features = ["macros", "rt-multi-thread"] }
+mockito               = { workspace = true }
+pacquet-testing-utils = { workspace = true }
+pretty_assertions     = { workspace = true }
+tokio                 = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/pacquet/crates/network/src/lib.rs
+++ b/pacquet/crates/network/src/lib.rs
@@ -448,9 +448,9 @@ fn default_client_builder(settings: &NetworkSettings) -> reqwest::ClientBuilder 
 /// file yields an empty list, matching pnpm's silent treatment of a
 /// missing `cafile` rather than failing the client build.
 fn load_node_extra_ca_certs() -> Vec<Certificate> {
-    let path = match std::env::var_os("NODE_EXTRA_CA_CERTS") {
-        Some(value) if !value.is_empty() => value,
-        _ => return Vec::new(),
+    let Some(path) = std::env::var_os("NODE_EXTRA_CA_CERTS").filter(|value| !value.is_empty())
+    else {
+        return Vec::new();
     };
     let Ok(bytes) = std::fs::read(&path) else {
         return Vec::new();

--- a/pacquet/crates/network/src/lib.rs
+++ b/pacquet/crates/network/src/lib.rs
@@ -395,7 +395,7 @@ fn default_client_builder(settings: &NetworkSettings) -> reqwest::ClientBuilder 
         .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT));
     let mut default_headers = HeaderMap::with_capacity(1);
     default_headers.insert(USER_AGENT, user_agent);
-    Client::builder()
+    let builder = Client::builder()
         .http1_only()
         // Request gzip and transparently decompress it. Packuments are the
         // largest payloads pulled during resolution and registries serve
@@ -408,7 +408,45 @@ fn default_client_builder(settings: &NetworkSettings) -> reqwest::ClientBuilder 
         .connect_timeout(settings.fetch_timeout)
         .timeout(settings.fetch_timeout)
         .pool_idle_timeout(Duration::from_secs(4))
-        .hickory_dns(true)
+        .hickory_dns(true);
+    apply_node_extra_ca_certs(builder)
+}
+
+/// `NODE_EXTRA_CA_CERTS` names a PEM bundle that Node appends to its
+/// built-in trust store. pnpm-on-Node inherits that trust implicitly
+/// because it runs inside Node; pacquet is a native binary, so to keep
+/// real-world parity for users behind a corporate MITM proxy it reads
+/// the same variable explicitly and adds every certificate in the file
+/// as an additional trust root.
+///
+/// This is the one deliberate exception to the ".npmrc-only, no env
+/// vars" TLS parity policy documented in [`tls::TlsConfig`]: the
+/// variable is a process-global Node convention rather than a pnpm
+/// setting, and Node already honors it for pnpm today — so reading it
+/// *restores* parity rather than diverging from it. It lives in
+/// [`default_client_builder`] (not [`apply_tls`]) precisely so the
+/// `.npmrc`-derived [`TlsConfig`] stays env-free.
+///
+/// Additive and lowest-priority: layered under the `.npmrc` `ca` /
+/// `cafile` roots that [`apply_tls`] adds afterward and under the
+/// built-in webpki roots (ordering is immaterial — the rustls root
+/// store is a union). A missing, unreadable, or malformed file is
+/// silently ignored, matching pnpm's silent treatment of a missing
+/// `cafile` rather than failing the client build.
+fn apply_node_extra_ca_certs(mut builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
+    let path = match std::env::var_os("NODE_EXTRA_CA_CERTS") {
+        Some(value) if !value.is_empty() => value,
+        _ => return builder,
+    };
+    let Ok(bytes) = std::fs::read(&path) else {
+        return builder;
+    };
+    if let Ok(certs) = Certificate::from_pem_bundle(&bytes) {
+        for cert in certs {
+            builder = builder.add_root_certificate(cert);
+        }
+    }
+    builder
 }
 
 /// Apply [`TlsConfig`] onto a [`reqwest::ClientBuilder`]: register each

--- a/pacquet/crates/network/src/lib.rs
+++ b/pacquet/crates/network/src/lib.rs
@@ -283,6 +283,10 @@ impl ThrottledClient {
         let https = proxy.https_proxy.as_deref().map(parse_proxy_url).transpose()?;
         let http = proxy.http_proxy.as_deref().map(parse_proxy_url).transpose()?;
         let no_proxy = Arc::new(NoProxyMatcher::from(proxy.no_proxy.as_ref()));
+        // Read once here, not inside `build_client`: `for_installs`
+        // builds one client per per-registry override, so loading the
+        // bundle per call would re-read and re-parse it N times.
+        let extra_ca_certs = load_node_extra_ca_certs();
 
         let build_client = |effective_tls: &TlsConfig| -> Result<Client, ForInstallsError> {
             let mut builder = default_client_builder(settings);
@@ -291,6 +295,11 @@ impl ThrottledClient {
             }
             if let Some(url) = http.clone() {
                 builder = builder.proxy(build_scheme_proxy(url, "http", Arc::clone(&no_proxy)));
+            }
+            // Lowest-priority additive roots; `apply_tls` layers the
+            // `.npmrc` ca/cafile roots on top next.
+            for cert in &extra_ca_certs {
+                builder = builder.add_root_certificate(cert.clone());
             }
             builder = apply_tls(builder, effective_tls)?;
             Ok(builder.build().expect("build reqwest client with default timeouts and proxy"))
@@ -395,7 +404,7 @@ fn default_client_builder(settings: &NetworkSettings) -> reqwest::ClientBuilder 
         .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT));
     let mut default_headers = HeaderMap::with_capacity(1);
     default_headers.insert(USER_AGENT, user_agent);
-    let builder = Client::builder()
+    Client::builder()
         .http1_only()
         // Request gzip and transparently decompress it. Packuments are the
         // largest payloads pulled during resolution and registries serve
@@ -408,45 +417,45 @@ fn default_client_builder(settings: &NetworkSettings) -> reqwest::ClientBuilder 
         .connect_timeout(settings.fetch_timeout)
         .timeout(settings.fetch_timeout)
         .pool_idle_timeout(Duration::from_secs(4))
-        .hickory_dns(true);
-    apply_node_extra_ca_certs(builder)
+        .hickory_dns(true)
 }
 
-/// `NODE_EXTRA_CA_CERTS` names a PEM bundle that Node appends to its
-/// built-in trust store. pnpm-on-Node inherits that trust implicitly
-/// because it runs inside Node; pacquet is a native binary, so to keep
-/// real-world parity for users behind a corporate MITM proxy it reads
-/// the same variable explicitly and adds every certificate in the file
-/// as an additional trust root.
+/// Load the PEM bundle named by `NODE_EXTRA_CA_CERTS` as extra trust
+/// roots, to be added to every client `for_installs` builds.
 ///
-/// This is the one deliberate exception to the ".npmrc-only, no env
-/// vars" TLS parity policy documented in [`tls::TlsConfig`]: the
-/// variable is a process-global Node convention rather than a pnpm
-/// setting, and Node already honors it for pnpm today — so reading it
-/// *restores* parity rather than diverging from it. It lives in
-/// [`default_client_builder`] (not [`apply_tls`]) precisely so the
-/// `.npmrc`-derived [`TlsConfig`] stays env-free.
+/// `NODE_EXTRA_CA_CERTS` is the standard Node convention for appending
+/// a CA to the default trust store. pnpm-on-Node inherits that trust
+/// implicitly because it runs inside Node; pacquet is a native binary,
+/// so to keep real-world parity for users behind a corporate MITM proxy
+/// it reads the variable explicitly. This is the one deliberate
+/// exception to the ".npmrc-only, no env vars" TLS parity policy
+/// documented in [`tls::TlsConfig`]: the variable is a process-global
+/// Node convention rather than a pnpm setting, and Node already honors
+/// it for pnpm today — so reading it *restores* parity rather than
+/// diverging from it. The certs are added in [`Self::for_installs`]
+/// (not [`apply_tls`]) so the `.npmrc`-derived [`TlsConfig`] stays
+/// env-free.
 ///
-/// Additive and lowest-priority: layered under the `.npmrc` `ca` /
-/// `cafile` roots that [`apply_tls`] adds afterward and under the
-/// built-in webpki roots (ordering is immaterial — the rustls root
-/// store is a union). A missing, unreadable, or malformed file is
-/// silently ignored, matching pnpm's silent treatment of a missing
-/// `cafile` rather than failing the client build.
-fn apply_node_extra_ca_certs(mut builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
+/// Read and parsed once per [`Self::for_installs`] call — `for_installs`
+/// builds one client per per-registry override, so loading here (rather
+/// than inside the per-client builder) avoids re-reading and re-parsing
+/// the bundle N times during startup.
+///
+/// The resulting certs are additive and lowest-priority: layered under
+/// the `.npmrc` `ca` / `cafile` roots that [`apply_tls`] adds afterward
+/// and under the built-in webpki roots (ordering is immaterial — the
+/// rustls root store is a union). A missing, unreadable, or malformed
+/// file yields an empty list, matching pnpm's silent treatment of a
+/// missing `cafile` rather than failing the client build.
+fn load_node_extra_ca_certs() -> Vec<Certificate> {
     let path = match std::env::var_os("NODE_EXTRA_CA_CERTS") {
         Some(value) if !value.is_empty() => value,
-        _ => return builder,
+        _ => return Vec::new(),
     };
     let Ok(bytes) = std::fs::read(&path) else {
-        return builder;
+        return Vec::new();
     };
-    if let Ok(certs) = Certificate::from_pem_bundle(&bytes) {
-        for cert in certs {
-            builder = builder.add_root_certificate(cert);
-        }
-    }
-    builder
+    Certificate::from_pem_bundle(&bytes).unwrap_or_default()
 }
 
 /// Apply [`TlsConfig`] onto a [`reqwest::ClientBuilder`]: register each

--- a/pacquet/crates/network/src/lib.rs
+++ b/pacquet/crates/network/src/lib.rs
@@ -432,14 +432,14 @@ fn default_client_builder(settings: &NetworkSettings) -> reqwest::ClientBuilder 
 /// documented in [`tls::TlsConfig`]: the variable is a process-global
 /// Node convention rather than a pnpm setting, and Node already honors
 /// it for pnpm today — so reading it *restores* parity rather than
-/// diverging from it. The certs are added in [`Self::for_installs`]
-/// (not [`apply_tls`]) so the `.npmrc`-derived [`TlsConfig`] stays
-/// env-free.
+/// diverging from it. The certs are added in
+/// [`ThrottledClient::for_installs`] (not [`apply_tls`]) so the
+/// `.npmrc`-derived [`TlsConfig`] stays env-free.
 ///
-/// Read and parsed once per [`Self::for_installs`] call — `for_installs`
-/// builds one client per per-registry override, so loading here (rather
-/// than inside the per-client builder) avoids re-reading and re-parsing
-/// the bundle N times during startup.
+/// Read and parsed once per [`ThrottledClient::for_installs`] call —
+/// that constructor builds one client per per-registry override, so
+/// loading here (rather than inside the per-client builder) avoids
+/// re-reading and re-parsing the bundle N times during startup.
 ///
 /// The resulting certs are additive and lowest-priority: layered under
 /// the `.npmrc` `ca` / `cafile` roots that [`apply_tls`] adds afterward

--- a/pacquet/crates/network/src/tests.rs
+++ b/pacquet/crates/network/src/tests.rs
@@ -425,6 +425,50 @@ fn for_installs_strict_ssl_default_is_true() {
 }
 
 #[test]
+fn node_extra_ca_certs_env_adds_root_and_tolerates_bad_path() {
+    // Serialize against any other env-mutating test in this binary and
+    // restore the prior value before returning. There is no shared
+    // `EnvGuard` helper in this crate, and one isn't needed for
+    // correctness: `apply_node_extra_ca_certs` is purely additive and
+    // silently ignores read/parse failures, so a value observed by a
+    // concurrent `for_installs` build can't change that build's
+    // outcome. The lock + restore only keep the test from leaking the
+    // var into a developer's shell or a sibling test's assertions.
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let prior = std::env::var_os("NODE_EXTRA_CA_CERTS");
+
+    let build = || {
+        ThrottledClient::for_installs(
+            &ProxyConfig::default(),
+            &TlsConfig::default(),
+            &PerRegistryTls::default(),
+            &NetworkSettings::default(),
+        )
+    };
+
+    // A valid PEM bundle is loaded and added as an extra trust root.
+    let fixture = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/test-ca.pem");
+    // SAFETY: serialized by `LOCK`; restored before the test returns.
+    unsafe { std::env::set_var("NODE_EXTRA_CA_CERTS", fixture) };
+    build().expect("NODE_EXTRA_CA_CERTS pointing at a valid PEM builds");
+
+    // A missing / unreadable file is silently ignored, never fatal —
+    // matching pnpm's silent treatment of a missing `cafile`.
+    // SAFETY: serialized by `LOCK`; restored before the test returns.
+    unsafe { std::env::set_var("NODE_EXTRA_CA_CERTS", "/pacquet/does-not-exist.pem") };
+    build().expect("NODE_EXTRA_CA_CERTS pointing at a missing file is ignored, not fatal");
+
+    // SAFETY: serialized by `LOCK`.
+    unsafe {
+        match prior {
+            Some(value) => std::env::set_var("NODE_EXTRA_CA_CERTS", value),
+            None => std::env::remove_var("NODE_EXTRA_CA_CERTS"),
+        }
+    }
+}
+
+#[test]
 fn for_installs_local_address_pinned() {
     use std::net::Ipv4Addr;
     let tls = TlsConfig { local_address: Some(Ipv4Addr::LOCALHOST.into()), ..TlsConfig::default() };

--- a/pacquet/crates/network/src/tests.rs
+++ b/pacquet/crates/network/src/tests.rs
@@ -426,13 +426,13 @@ fn for_installs_strict_ssl_default_is_true() {
 }
 
 #[test]
-fn node_extra_ca_certs_env_adds_root_and_tolerates_bad_path() {
+fn node_extra_ca_certs_is_loaded_and_failures_are_non_fatal() {
     // `EnvGuard` serializes env-mutating tests process-wide and restores
     // the prior value on drop — including on panic — so a failing
     // `.expect()` below can't leak `NODE_EXTRA_CA_CERTS` into a sibling
-    // test. `for_installs` re-reads the var on each call, so the two
-    // phases below exercise the valid and bad-path branches in turn.
+    // test. `for_installs` re-reads the var on each call.
     let env = EnvGuard::snapshot(["NODE_EXTRA_CA_CERTS"]);
+    let fixture = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/test-ca.pem");
 
     let build = || {
         ThrottledClient::for_installs(
@@ -443,18 +443,27 @@ fn node_extra_ca_certs_env_adds_root_and_tolerates_bad_path() {
         )
     };
 
-    // A valid PEM bundle parses into one trust root and the client builds.
-    let fixture = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/test-ca.pem");
+    // Empty value: nothing to add.
+    env.set("NODE_EXTRA_CA_CERTS", "");
+    assert!(super::load_node_extra_ca_certs().is_empty());
+
+    // A valid PEM bundle parses into one trust root, and a client built
+    // with it succeeds.
     env.set("NODE_EXTRA_CA_CERTS", fixture);
     assert_eq!(super::load_node_extra_ca_certs().len(), 1);
     build().expect("NODE_EXTRA_CA_CERTS pointing at a valid PEM builds");
 
-    // A missing / unreadable file yields no roots and is silently
-    // ignored, never fatal — matching pnpm's treatment of a missing
-    // `cafile`.
+    // A readable file that isn't valid PEM: ignored → empty.
+    let bad =
+        std::env::temp_dir().join(format!("pacquet-node-extra-ca-{}.pem", std::process::id()));
+    std::fs::write(&bad, b"not a certificate").expect("write temp ca bundle");
+    env.set("NODE_EXTRA_CA_CERTS", &bad);
+    assert!(super::load_node_extra_ca_certs().is_empty());
+    let _ = std::fs::remove_file(&bad);
+
+    // A nonexistent file: unreadable, ignored → empty.
     env.set("NODE_EXTRA_CA_CERTS", "/pacquet/does-not-exist.pem");
     assert!(super::load_node_extra_ca_certs().is_empty());
-    build().expect("NODE_EXTRA_CA_CERTS pointing at a missing file is ignored, not fatal");
     // `env` restores NODE_EXTRA_CA_CERTS on drop.
 }
 

--- a/pacquet/crates/network/src/tests.rs
+++ b/pacquet/crates/network/src/tests.rs
@@ -19,6 +19,7 @@ use super::{
     ProxyError, ThrottledClient, TlsConfig, parse_proxy_url,
 };
 use crate::proxy::{percent_decode_str, strip_userinfo};
+use pacquet_testing_utils::env_guard::EnvGuard;
 use reqwest::Url;
 
 fn list(entries: &[&str]) -> NoProxySetting {
@@ -426,17 +427,12 @@ fn for_installs_strict_ssl_default_is_true() {
 
 #[test]
 fn node_extra_ca_certs_env_adds_root_and_tolerates_bad_path() {
-    // Serialize against any other env-mutating test in this binary and
-    // restore the prior value before returning. There is no shared
-    // `EnvGuard` helper in this crate, and one isn't needed for
-    // correctness: `apply_node_extra_ca_certs` is purely additive and
-    // silently ignores read/parse failures, so a value observed by a
-    // concurrent `for_installs` build can't change that build's
-    // outcome. The lock + restore only keep the test from leaking the
-    // var into a developer's shell or a sibling test's assertions.
-    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    let _guard = LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    let prior = std::env::var_os("NODE_EXTRA_CA_CERTS");
+    // `EnvGuard` serializes env-mutating tests process-wide and restores
+    // the prior value on drop — including on panic — so a failing
+    // `.expect()` below can't leak `NODE_EXTRA_CA_CERTS` into a sibling
+    // test. `for_installs` re-reads the var on each call, so the two
+    // phases below exercise the valid and bad-path branches in turn.
+    let env = EnvGuard::snapshot(["NODE_EXTRA_CA_CERTS"]);
 
     let build = || {
         ThrottledClient::for_installs(
@@ -447,25 +443,19 @@ fn node_extra_ca_certs_env_adds_root_and_tolerates_bad_path() {
         )
     };
 
-    // A valid PEM bundle is loaded and added as an extra trust root.
+    // A valid PEM bundle parses into one trust root and the client builds.
     let fixture = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/test-ca.pem");
-    // SAFETY: serialized by `LOCK`; restored before the test returns.
-    unsafe { std::env::set_var("NODE_EXTRA_CA_CERTS", fixture) };
+    env.set("NODE_EXTRA_CA_CERTS", fixture);
+    assert_eq!(super::load_node_extra_ca_certs().len(), 1);
     build().expect("NODE_EXTRA_CA_CERTS pointing at a valid PEM builds");
 
-    // A missing / unreadable file is silently ignored, never fatal —
-    // matching pnpm's silent treatment of a missing `cafile`.
-    // SAFETY: serialized by `LOCK`; restored before the test returns.
-    unsafe { std::env::set_var("NODE_EXTRA_CA_CERTS", "/pacquet/does-not-exist.pem") };
+    // A missing / unreadable file yields no roots and is silently
+    // ignored, never fatal — matching pnpm's treatment of a missing
+    // `cafile`.
+    env.set("NODE_EXTRA_CA_CERTS", "/pacquet/does-not-exist.pem");
+    assert!(super::load_node_extra_ca_certs().is_empty());
     build().expect("NODE_EXTRA_CA_CERTS pointing at a missing file is ignored, not fatal");
-
-    // SAFETY: serialized by `LOCK`.
-    unsafe {
-        match prior {
-            Some(value) => std::env::set_var("NODE_EXTRA_CA_CERTS", value),
-            None => std::env::remove_var("NODE_EXTRA_CA_CERTS"),
-        }
-    }
+    // `env` restores NODE_EXTRA_CA_CERTS on drop.
 }
 
 #[test]

--- a/pacquet/crates/network/src/tls.rs
+++ b/pacquet/crates/network/src/tls.rs
@@ -16,6 +16,14 @@
 //! internally), emits no `ERR_PNPM_*` codes for malformed TLS
 //! material, silently ignores a missing `cafile`, and consults no
 //! environment variables. Pacquet mirrors each of those choices.
+//!
+//! One deliberate exception sits *outside* this struct: pacquet honors
+//! the `NODE_EXTRA_CA_CERTS` environment variable as an additional
+//! trust root (see `apply_node_extra_ca_certs` in `lib.rs`). pnpm-on-
+//! Node already trusts that bundle implicitly via Node's TLS runtime,
+//! so a native port must read it explicitly to preserve real-world
+//! parity. It is applied at the client-builder layer, never folded
+//! into this `.npmrc`-only `TlsConfig`.
 
 use crate::auth::nerf_dart;
 use std::{collections::HashMap, net::IpAddr};

--- a/pacquet/crates/network/src/tls.rs
+++ b/pacquet/crates/network/src/tls.rs
@@ -19,7 +19,7 @@
 //!
 //! One deliberate exception sits *outside* this struct: pacquet honors
 //! the `NODE_EXTRA_CA_CERTS` environment variable as an additional
-//! trust root (see `apply_node_extra_ca_certs` in `lib.rs`). pnpm-on-
+//! trust root (see `load_node_extra_ca_certs` in `lib.rs`). pnpm-on-
 //! Node already trusts that bundle implicitly via Node's TLS runtime,
 //! so a native port must read it explicitly to preserve real-world
 //! parity. It is applied at the client-builder layer, never folded


### PR DESCRIPTION
## What

Make pacquet's registry HTTP client honor the `NODE_EXTRA_CA_CERTS` environment variable.

## Why

pacquet's reqwest client trusts only its bundled webpki roots plus the `.npmrc` `ca`/`cafile` material — it consults no environment for CA trust. pnpm running on Node, however, *does* trust `NODE_EXTRA_CA_CERTS` — implicitly, via Node's TLS runtime. So users behind a corporate MITM proxy or a self-signed registry who set `NODE_EXTRA_CA_CERTS` (the standard Node convention) have working TLS under pnpm-on-Node today and would silently lose it under the native path. Reading the variable explicitly **restores real-world parity** rather than diverging from it.

This is the class of breakage tracked in pnpm/pnpm#5400 (native fetch path not seeing the JS-config CA), approached from the env-var side.

## How

`apply_node_extra_ca_certs` reads `NODE_EXTRA_CA_CERTS`; when set and non-empty, every certificate in the named PEM bundle is added as an additional trust root.

- It lives in **`default_client_builder`** — the single chokepoint every client (default + per-registry) routes through — so the `.npmrc`-derived `TlsConfig` stays **env-free** and the existing "TLS config is `.npmrc`-only, no env vars" parity policy is preserved. The `tls.rs` module doc is updated to record this as the one deliberate, documented exception (it's a process-global Node convention, not a pnpm setting).
- **Additive, lowest-priority.** Layered under the `.npmrc` `ca`/`cafile` roots `apply_tls` adds afterward and under the built-in webpki roots; the rustls root store is a union so ordering is immaterial.
- **Silently tolerant.** A missing, unreadable, or malformed file is ignored rather than failing the client build — matching pnpm's silent treatment of a missing `cafile`.

## Test

Adds `node_extra_ca_certs_env_adds_root_and_tolerates_bad_path` (serialized env mutation + restore), pointing the var at the existing `tests/fixtures/test-ca.pem` and then at a missing file, asserting `for_installs` builds in both cases.

`cargo fmt`, `cargo clippy -p pacquet-network --tests`, and `cargo test -p pacquet-network` all clean. No changeset added — the change is confined to the `pacquet-*` Rust crates; happy to add one if the workflow expects it.

> Note: this intentionally adds CA-trust behavior the TS dispatcher doesn't have *in code*. The argument is parity-by-effect (Node already grants it to pnpm), but flagging it explicitly since `tls.rs` documents a deliberate no-env-vars stance — happy to adjust framing or gate it if you'd prefer.

## Related: Socket Firewall (sfw)

This is also helpful with [Socket Firewall](https://socket.dev/blog/introducing-socket-firewall) (`sfw`, repo [SocketDev/sfw-free](https://github.com/SocketDev/sfw-free)) — a free tool that wraps your package manager behind a local MITM CA proxy to block known-malicious packages at install time. pnpm-on-Node works with it today because Node trusts the proxy CA via `NODE_EXTRA_CA_CERTS`; honoring that variable in the native client lets `sfw pnpm …` keep working as pnpm moves onto the pacquet path — no per-`.npmrc` `cafile` wiring required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `NODE_EXTRA_CA_CERTS` to trust additional certificate authorities for secure connections.
* **Bug Fixes**
  * Failures to load the PEM bundle (missing/empty value, unreadable file, invalid PEM, nonexistent path) are non-fatal and safely add no extra roots.
* **Documentation**
  * Updated TLS documentation to clearly describe `NODE_EXTRA_CA_CERTS` handling.
* **Tests**
  * Added coverage that verifies `NODE_EXTRA_CA_CERTS` parsing and non-fatal behavior across valid, empty, and invalid inputs.
* **Chores**
  * Updated dev dependencies and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->