### PR TITLE
feat(pacquet): cover the gap in `nodeLinker: 'hoisted'`

### DIFF
--- a/pacquet/crates/cli/tests/hoisted_node_linker.rs
+++ b/pacquet/crates/cli/tests/hoisted_node_linker.rs
@@ -168,10 +168,8 @@ fn installing_with_hoisted_node_linker_and_no_lockfile() {
 /// Upstream: [`installing/deps-restorer/test/index.ts:859` "installing with node-linker=hoisted"](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/test/index.ts#L859).
 ///
 /// The headless (frozen-lockfile) path materializes the hoisted
-/// layout from a pre-existing lockfile. Pacquet seeds the lockfile
-/// with a first `pacquet install`, tears down `node_modules`, then
-/// replays via `--frozen-lockfile` and asserts the same real-dir +
-/// version-conflict-nesting shape the fresh path produces.
+/// layout from a pre-existing lockfile, reproducing the same
+/// real-dir + version-conflict-nesting shape as a fresh install.
 #[test]
 fn installing_with_hoisted_node_linker_frozen() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -212,13 +210,13 @@ fn installing_with_hoisted_node_linker_frozen() {
 
 /// Upstream: [`installing/deps-restorer/test/index.ts:873` "installing in a workspace with node-linker=hoisted"](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/test/index.ts#L873).
 ///
-/// Workspace-wide hoisting under the frozen path: the root importer
-/// and a workspace project pin conflicting versions of `ms`. The
-/// root's version wins the top-level `node_modules` slot (root deps
-/// rank first in the hoister's preference order) and the project's
-/// conflicting version nests under the project's own `node_modules`.
-/// Mirrors the upstream layout where the root's `webpack@5.65.0`
-/// lands at the root and `foo`'s `webpack@2.7.0` nests under `foo`.
+/// Workspace-wide hoisting under the frozen path. When the root
+/// importer and a workspace project pin conflicting versions of one
+/// name, the root's version wins the top-level slot — root deps rank
+/// first in the hoister's preference order — and the project's
+/// version nests under its own `node_modules`. Mirrors the upstream
+/// layout where the root's `webpack@5.65.0` lands at the root and
+/// `foo`'s `webpack@2.7.0` nests under `foo`.
 #[test]
 fn installing_in_a_workspace_with_hoisted_node_linker_frozen() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pacquet/crates/cli/tests/hoisted_node_linker.rs
+++ b/pacquet/crates/cli/tests/hoisted_node_linker.rs
@@ -60,6 +60,36 @@ fn is_real_dir(workspace: &Path, relative: &str) -> bool {
     path.is_dir() && !is_symlink_or_junction(&path).unwrap()
 }
 
+/// Build a fresh `pacquet` `Command` rooted at `workspace`. Needed to
+/// drive a second invocation in the same workspace because
+/// [`assert_cmd::Command::assert`] consumes the wrapped command. The
+/// mock registry is configured through the workspace's `.npmrc` /
+/// `pnpm-workspace.yaml`, so a command that merely runs in `workspace`
+/// inherits it without extra env.
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+}
+
+/// `rm -rf` that tolerates an already-absent path.
+fn fs_remove_dir_all(path: &Path) {
+    match fs::remove_dir_all(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => panic!("remove {path:?}: {error}"),
+    }
+}
+
+/// Read the `version` field of the `package.json` at
+/// `workspace/relative`. Used by the workspace tests to tell which
+/// version of a conflicting dependency landed at each location.
+fn read_pkg_version(workspace: &Path, relative: &str) -> String {
+    let manifest = fs::read_to_string(workspace.join(relative).join("package.json"))
+        .unwrap_or_else(|error| panic!("read {relative}/package.json: {error}"));
+    let parsed: serde_json::Value =
+        serde_json::from_str(&manifest).expect("parse package.json as JSON");
+    parsed["version"].as_str().expect("package.json has a string version").to_string()
+}
+
 /// Upstream: [`install.ts:16` "installing with hoisted node-linker"](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/test/hoistedNodeLinker/install.ts#L16).
 ///
 /// Direct deps land as real directories at the project root and a
@@ -130,6 +160,118 @@ fn installing_with_hoisted_node_linker_and_no_lockfile() {
     assert!(
         !workspace.join("pnpm-lock.yaml").exists(),
         "no lockfile should be written when lockfile: false",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// Upstream: [`installing/deps-restorer/test/index.ts:859` "installing with node-linker=hoisted"](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/test/index.ts#L859).
+///
+/// The headless (frozen-lockfile) path materializes the hoisted
+/// layout from a pre-existing lockfile. Pacquet seeds the lockfile
+/// with a first `pacquet install`, tears down `node_modules`, then
+/// replays via `--frozen-lockfile` and asserts the same real-dir +
+/// version-conflict-nesting shape the fresh path produces.
+#[test]
+fn installing_with_hoisted_node_linker_frozen() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(
+        &workspace,
+        serde_json::json!({ "send": "0.17.2", "has-flag": "1.0.0", "ms": "1.0.0" }),
+    );
+    write_workspace_yaml(&workspace, "nodeLinker: hoisted\n");
+
+    // Seed the lockfile and node_modules.
+    pacquet.with_args(["install"]).assert().success();
+    assert!(workspace.join("pnpm-lock.yaml").exists(), "first install writes the lockfile");
+
+    // Tear down node_modules so the frozen install is a pure replay.
+    fs_remove_dir_all(&workspace.join("node_modules"));
+
+    pacquet_at(&workspace).with_arg("install").with_arg("--frozen-lockfile").assert().success();
+
+    assert!(is_real_dir(&workspace, "node_modules/send"), "send is a real dir after frozen replay");
+    assert!(is_real_dir(&workspace, "node_modules/ms"), "ms is a real dir after frozen replay");
+    assert!(
+        workspace.join("node_modules/send/node_modules/ms").exists(),
+        "send's conflicting ms nests under send after frozen replay",
+    );
+
+    let modules_yaml = fs::read_to_string(workspace.join("node_modules/.modules.yaml"))
+        .expect("read .modules.yaml");
+    assert!(
+        modules_yaml.contains(r#""nodeLinker": "hoisted""#),
+        ".modules.yaml records the hoisted linker; got:\n{modules_yaml}",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// Upstream: [`installing/deps-restorer/test/index.ts:873` "installing in a workspace with node-linker=hoisted"](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/test/index.ts#L873).
+///
+/// Workspace-wide hoisting under the frozen path: the root importer
+/// and a workspace project pin conflicting versions of `ms`. The
+/// root's version wins the top-level `node_modules` slot (root deps
+/// rank first in the hoister's preference order) and the project's
+/// conflicting version nests under the project's own `node_modules`.
+/// Mirrors the upstream layout where the root's `webpack@5.65.0`
+/// lands at the root and `foo`'s `webpack@2.7.0` nests under `foo`.
+#[test]
+fn installing_in_a_workspace_with_hoisted_node_linker_frozen() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "ws-root",
+            "version": "0.0.0",
+            "private": true,
+            "dependencies": { "ms": "2.1.3" },
+        })
+        .to_string(),
+    )
+    .expect("write root package.json");
+
+    write_workspace_yaml(&workspace, "nodeLinker: hoisted\npackages:\n  - 'packages/*'\n");
+
+    fs::create_dir_all(workspace.join("packages/foo")).expect("mkdir packages/foo");
+    fs::write(
+        workspace.join("packages/foo/package.json"),
+        serde_json::json!({
+            "name": "foo",
+            "version": "1.0.0",
+            "dependencies": { "ms": "2.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write packages/foo/package.json");
+
+    // Seed the lockfile, then replay frozen.
+    pacquet.with_args(["install"]).assert().success();
+    fs_remove_dir_all(&workspace.join("node_modules"));
+    fs_remove_dir_all(&workspace.join("packages/foo/node_modules"));
+
+    pacquet_at(&workspace).with_arg("install").with_arg("--frozen-lockfile").assert().success();
+
+    assert!(is_real_dir(&workspace, "node_modules/ms"), "root ms is a real dir");
+    assert_eq!(
+        read_pkg_version(&workspace, "node_modules/ms"),
+        "2.1.3",
+        "the root importer's ms@2.1.3 wins the top-level slot",
+    );
+    assert!(
+        is_real_dir(&workspace, "packages/foo/node_modules/ms"),
+        "foo's conflicting ms is a real dir nested under foo",
+    );
+    assert_eq!(
+        read_pkg_version(&workspace, "packages/foo/node_modules/ms"),
+        "2.0.0",
+        "foo's conflicting ms@2.0.0 nests under the project",
     );
 
     drop((root, mock_instance));

--- a/pacquet/crates/package-manager/src/hoisted_dep_graph/tests.rs
+++ b/pacquet/crates/package-manager/src/hoisted_dep_graph/tests.rs
@@ -942,6 +942,62 @@ fn walker_multi_importer_version_conflict_nests_loser() {
     assert_ne!(root_a, foo_a, "conflict resolves to two distinct dirs");
 }
 
+/// The #873 workspace invariant: when the root importer and a
+/// workspace project pin conflicting versions of the same name, the
+/// root's version wins the top-level `node_modules` slot and the
+/// project's version nests under the project. Locks in the popularity
+/// preference (root deps rank first) together with the per-importer
+/// walk. Mirrors upstream's `installing/deps-restorer/test/index.ts`
+/// workspace-hoisted case where the root's `webpack@5.65.0` lands at
+/// the root and `foo`'s `webpack@2.7.0` nests under `foo`.
+#[test]
+fn walker_workspace_root_version_wins_root_slot() {
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("webby"), resolved_dep("5.0.0"));
+
+    let mut app_deps = ResolvedDependencyMap::new();
+    app_deps.insert(pkg_name("webby"), resolved_dep("2.0.0"));
+
+    let mut packages = HashMap::new();
+    packages.insert(dep_key("webby", "5.0.0"), metadata_stub());
+    packages.insert(dep_key("webby", "2.0.0"), metadata_stub());
+
+    let mut snapshots = HashMap::new();
+    snapshots.insert(dep_key("webby", "5.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("webby", "2.0.0"), SnapshotEntry::default());
+
+    let lockfile = workspace_lockfile(
+        vec![(Lockfile::ROOT_IMPORTER_KEY, root_deps), ("packages/app", app_deps)],
+        packages,
+        snapshots,
+    );
+    let lockfile_dir = PathBuf::from("/repo");
+    let opts = LockfileToHoistedDepGraphOptions {
+        lockfile_dir: lockfile_dir.clone(),
+        ..LockfileToHoistedDepGraphOptions::default()
+    };
+    let result = lockfile_to_hoisted_dep_graph(&lockfile, None, &opts).expect("walker succeeds");
+
+    let root_webby = lockfile_dir.join("node_modules").join("webby");
+    let nested_webby = lockfile_dir.join("packages/app").join("node_modules").join("webby");
+
+    assert_eq!(
+        result.graph[&root_webby].dep_path,
+        DepPath::from("webby@5.0.0".to_string()),
+        "the root importer's version wins the top-level slot",
+    );
+    assert_eq!(
+        result.graph[&nested_webby].dep_path,
+        DepPath::from("webby@2.0.0".to_string()),
+        "the workspace project's conflicting version nests under the project",
+    );
+    assert_eq!(
+        result.direct_dependencies_by_importer_id[Lockfile::ROOT_IMPORTER_KEY]["webby"],
+        root_webby,
+    );
+    assert_eq!(result.direct_dependencies_by_importer_id["packages/app"]["webby"], nested_webby,);
+}
+
 #[test]
 fn walker_forwards_external_dependencies_to_hoister() {
     let mut root_deps = ResolvedDependencyMap::new();

--- a/pacquet/crates/package-manager/src/hoisted_dep_graph/tests.rs
+++ b/pacquet/crates/package-manager/src/hoisted_dep_graph/tests.rs
@@ -942,8 +942,8 @@ fn walker_multi_importer_version_conflict_nests_loser() {
     assert_ne!(root_a, foo_a, "conflict resolves to two distinct dirs");
 }
 
-/// The #873 workspace invariant: when the root importer and a
-/// workspace project pin conflicting versions of the same name, the
+/// The cross-importer workspace invariant: when the root importer and
+/// a workspace project pin conflicting versions of the same name, the
 /// root's version wins the top-level `node_modules` slot and the
 /// project's version nests under the project. Locks in the popularity
 /// preference (root deps rank first) together with the per-importer
@@ -995,7 +995,7 @@ fn walker_workspace_root_version_wins_root_slot() {
         result.direct_dependencies_by_importer_id[Lockfile::ROOT_IMPORTER_KEY]["webby"],
         root_webby,
     );
-    assert_eq!(result.direct_dependencies_by_importer_id["packages/app"]["webby"], nested_webby,);
+    assert_eq!(result.direct_dependencies_by_importer_id["packages/app"]["webby"], nested_webby);
 }
 
 #[test]

--- a/pacquet/crates/real-hoist/src/lib.rs
+++ b/pacquet/crates/real-hoist/src/lib.rs
@@ -951,9 +951,6 @@ fn hoist_subtree(
             AbsorbDecision::Border
         } else {
             match root_index.get(&child.0.name) {
-                // Free slot, but only the currently-preferred ident
-                // may take it; a non-preferred version waits for the
-                // ident shift in `hoist_into_root`.
                 None if is_preferred_ident(&child.0, hoist_ident_map) => AbsorbDecision::Free,
                 None => AbsorbDecision::Defer,
                 Some(existing) if Rc::ptr_eq(&existing.0, &child.0) => AbsorbDecision::SameNode,
@@ -1007,16 +1004,11 @@ fn hoist_subtree(
                 | AbsorbDecision::PeerShadow
                 | AbsorbDecision::Border
                 | AbsorbDecision::Defer => {
-                    // Stays at the current parent. The version
-                    // already at root wins the slot, hoisting would
-                    // shadow a peer dependency, the candidate sits
-                    // beneath a `hoisting_limits` border, or its ident
-                    // is not the preferred one yet. Child's ancestor
-                    // path is the path through `node`; a later round
-                    // may revisit this candidate with a different peer
-                    // / conflict / preference context (the border
-                    // boundary is fixed so the Border verdict won't
-                    // change).
+                    // Stays at the current parent, so the child's
+                    // ancestor path is the path through `node`. A later
+                    // round may revisit it with a different peer /
+                    // conflict / preference context; only `Border` is
+                    // terminal, since the limit boundary never moves.
                     path_for_children.clone()
                 }
             }

--- a/pacquet/crates/real-hoist/src/lib.rs
+++ b/pacquet/crates/real-hoist/src/lib.rs
@@ -11,7 +11,7 @@
 //! [yarn-hoist]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts
 
 use derive_more::{Display, Error};
-use indexmap::IndexSet;
+use indexmap::{IndexMap, IndexSet};
 use miette::Diagnostic;
 use pacquet_lockfile::{Lockfile, PkgName, PkgNameVerPeer, ProjectSnapshot, SnapshotEntry};
 use std::{
@@ -85,11 +85,10 @@ pub struct HoisterTree {
     pub dependency_kind: HoisterDependencyKind,
     /// Tiebreaker used upstream when ranking competing hoist
     /// candidates. Carried through the type for parity with
-    /// `@yarnpkg/nm`'s `HoisterTree.hoistPriority` but currently
-    /// unread by pacquet's algorithm — pacquet builds every node
-    /// with `0` and the popularity-based preference pass that
-    /// would consume it isn't ported yet (see the "popularity-
-    /// based ident preference" gap on `nm_hoist`).
+    /// `@yarnpkg/nm`'s `HoisterTree.hoistPriority`, but pacquet
+    /// builds every node with `0`, so the preference pass ranks
+    /// purely by usage count — the `hoistPriority` tier stays inert
+    /// until a producer sets it.
     pub hoist_priority: u32,
     /// Children of this node. Order matches insertion order — the
     /// hoister depends on it.
@@ -569,13 +568,13 @@ pub fn percent_encode_path(text: &str) -> String {
 /// dependency that doesn't collide with an already-hoisted name
 /// surfaces at the root, just like a flat `node_modules`.
 ///
+/// Among competing versions of one name, the most-used version
+/// wins the root slot — ported from upstream's `buildPreferenceMap`
+/// / `getHoistIdentMap` (see [`build_hoist_ident_map`]) and the
+/// per-pass ident shift in [`hoist_into_root`].
+///
 /// What this does *not* model yet:
 ///
-/// * Popularity-based ident preference (upstream's
-///   `buildPreferenceMap`). When two distinct deps share an
-///   alias, pacquet picks the first-visited; upstream picks the
-///   one with more incoming references. Outcome differs for the
-///   handful of upstream test cases that exercise the tie-break.
 /// * Per-importer roots and the multi-level output shape upstream
 ///   produces for workspaces. [`hoist`] does attach every non-root
 ///   importer as a `Workspace`-kind child of the virtual `.` root
@@ -617,6 +616,17 @@ enum AbsorbDecision {
     /// Root's name slot is free; the child should be moved up to
     /// the root.
     Free,
+    /// Root's name slot is free, but this candidate's ident is not
+    /// the one currently preferred for its name (see
+    /// [`build_hoist_ident_map`]). The candidate stays under its
+    /// parent this pass; a later pass — after the preferred ident
+    /// either claims the slot or is shifted out in
+    /// [`hoist_into_root`] — may reconsider it. Mirrors upstream's
+    /// `hoistedIdent === node.ident` gate in `getNodeHoistInfo` at
+    /// [hoist.ts:387][prefer-gate].
+    ///
+    /// [prefer-gate]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L387
+    Defer,
     /// Root already holds *this exact `Rc`* (the same node was
     /// reachable through another parent path and got hoisted
     /// earlier). The duplicate reference in the current parent
@@ -682,9 +692,29 @@ enum AbsorbDecision {
 /// DAG sharing and accepts a more conservative ruling in the
 /// rare cross-path mismatch cases. The cost is layouts that are
 /// sometimes more nested than pnpm's, never less.
+/// Immutable context shared across every [`hoist_subtree`] call in
+/// one [`hoist_into_root`] pass: the hoisting root, the active
+/// border-name set, and the per-name preferred-ident map. Bundled
+/// into one struct so the recursive walker stays under the argument
+/// limit; only `root_index`, `visited`, and the per-node position
+/// (`node`, `ancestor_path`, `under_border`) vary per call.
+struct HoistCtx<'a> {
+    root: &'a Rc<HoisterResult>,
+    border_names: &'a BTreeSet<String>,
+    hoist_ident_map: &'a HashMap<String, Vec<String>>,
+}
+
 fn hoist_into_root(root: &Rc<HoisterResult>, root_locator: &str, opts: &HoistOpts) {
     let mut root_index: HashMap<String, RcByPtr<HoisterResult>> =
         root.dependencies.borrow().iter().map(|dep| (dep.0.name.clone(), dep.clone())).collect();
+
+    // Per-name candidate idents ordered most-preferred first. Only
+    // the front ident of each name may claim the root slot; the
+    // shift below promotes the next candidate when the preferred one
+    // can't be placed. Built from the pre-hoist subtree, matching
+    // yarn's `buildPreferenceMap(rootNode)` call at the top of
+    // `hoistTo`.
+    let mut hoist_ident_map = build_hoist_ident_map(root);
 
     // Look up the border names for *this* root locator: a node whose
     // name is in this set is a hoisting border, so its descendants
@@ -699,12 +729,164 @@ fn hoist_into_root(root: &Rc<HoisterResult>, root_locator: &str, opts: &HoistOpt
 
     loop {
         let mut visited: HashSet<*const HoisterResult> = HashSet::new();
-        let changed =
-            hoist_subtree(root, &[], root, &mut root_index, &mut visited, border_names, false);
-        if !changed {
+        let ctx = HoistCtx { root, border_names, hoist_ident_map: &hoist_ident_map };
+        let changed = hoist_subtree(root, &[], &ctx, &mut root_index, &mut visited, false);
+
+        // Per-pass ident shift: a name with more than one candidate
+        // ident whose preferred ident still hasn't reached the root
+        // drops that ident and promotes the next one, so a later pass
+        // can place a less-preferred version when the most-preferred
+        // is unreachable (nested under a conflict / border / peer).
+        // Mirrors the `idents.shift()` loop in yarn's `hoistTo` at
+        // <https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts>.
+        let mut shifted = false;
+        for (name, idents) in &mut hoist_ident_map {
+            if idents.len() > 1 && !root_index.contains_key(name) {
+                idents.remove(0);
+                shifted = true;
+            }
+        }
+
+        if !changed && !shifted {
             break;
         }
     }
+}
+
+/// The single canonical reference of a (pre-hoist) result node,
+/// used as its "ident" in the preference map and the per-name
+/// candidate lists. Pre-hoist nodes carry exactly one reference
+/// (see [`convert`]).
+fn node_ident(node: &HoisterResult) -> String {
+    node.references.borrow().iter().next().cloned().unwrap_or_default()
+}
+
+/// One entry of the preference map: the set of dependent idents
+/// (and peer-dependent idents) that pull in a given `(name,
+/// ident)` package. Usage count is the sum of the two, matching
+/// yarn's `entry.dependents.size + entry.peerDependents.size`.
+#[derive(Default)]
+struct PreferenceEntry {
+    dependents: HashSet<String>,
+    peer_dependents: HashSet<String>,
+}
+
+impl PreferenceEntry {
+    fn usages(&self) -> usize {
+        self.dependents.len() + self.peer_dependents.len()
+    }
+}
+
+/// Port of yarn's `buildPreferenceMap` + `getHoistIdentMap`. For
+/// each dependency name reachable from `root`, returns its
+/// candidate idents (references) ordered most-preferred first:
+///
+/// 1. The root's own direct deps are seeded first, so a version the
+///    root depends on always wins its name slot.
+/// 2. Every other ident follows, ordered by usage (the count of
+///    distinct dependents + peer-dependents) descending, stable on
+///    ties (preserving depth-first discovery order).
+///
+/// [`hoist_into_root`] consults the front of each list as the
+/// currently-preferred ident and shifts it as passes progress.
+/// Ports
+/// <https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts>.
+fn build_hoist_ident_map(root: &Rc<HoisterResult>) -> HashMap<String, Vec<String>> {
+    let mut preference: IndexMap<(String, String), PreferenceEntry> = IndexMap::new();
+    let mut seen: HashSet<*const HoisterResult> = HashSet::new();
+    seen.insert(Rc::as_ptr(root));
+
+    let root_ident = node_ident(root);
+    let root_children: Vec<Rc<HoisterResult>> =
+        root.dependencies.borrow().iter().map(|dep| Rc::clone(&dep.0)).collect();
+    for dep in &root_children {
+        if !root.peer_names.contains(&dep.name) {
+            add_dependent(&root_ident, dep, &mut preference, &mut seen);
+        }
+    }
+
+    // Seed the result with the root and its direct deps so their
+    // idents always rank first. Mirrors `getHoistIdentMap`'s initial
+    // `identMap` construction before the sorted append loop.
+    let mut ident_map: IndexMap<String, Vec<String>> = IndexMap::new();
+    ident_map.insert(root.name.clone(), vec![root_ident]);
+    for dep in &root_children {
+        if !root.peer_names.contains(&dep.name) {
+            ident_map.insert(dep.name.clone(), vec![node_ident(dep)]);
+        }
+    }
+
+    let mut keys: Vec<(String, String)> = preference.keys().cloned().collect();
+    // `hoist_priority` is always 0 in pacquet, so the sort reduces to
+    // usage (descending). `sort_by` is stable, so equal-usage keys
+    // keep preference-map insertion order (depth-first discovery) —
+    // matching yarn's `keyList.sort`, which is likewise stable on
+    // equal usage.
+    keys.sort_by(|left, right| preference[right].usages().cmp(&preference[left].usages()));
+    for (name, ident) in keys {
+        if root.peer_names.contains(&name) {
+            continue;
+        }
+        let idents = ident_map.entry(name).or_default();
+        if !idents.contains(&ident) {
+            idents.push(ident);
+        }
+    }
+
+    ident_map.into_iter().collect()
+}
+
+/// Recursive half of [`build_hoist_ident_map`]'s preference pass.
+/// Records `dependent_ident` as a dependent of `node`, then (the
+/// first time `node` is seen) recurses into its non-peer children
+/// and records peer children as peer-dependents. Mirrors yarn's
+/// `addDependent`.
+fn add_dependent(
+    dependent_ident: &str,
+    node: &Rc<HoisterResult>,
+    preference: &mut IndexMap<(String, String), PreferenceEntry>,
+    seen: &mut HashSet<*const HoisterResult>,
+) {
+    let parent_ident = node_ident(node);
+    preference
+        .entry((node.name.clone(), parent_ident.clone()))
+        .or_default()
+        .dependents
+        .insert(dependent_ident.to_string());
+
+    if seen.insert(Rc::as_ptr(node)) {
+        let children: Vec<Rc<HoisterResult>> =
+            node.dependencies.borrow().iter().map(|dep| Rc::clone(&dep.0)).collect();
+        for child in children {
+            if node.peer_names.contains(&child.name) {
+                preference
+                    .entry((child.name.clone(), node_ident(&child)))
+                    .or_default()
+                    .peer_dependents
+                    .insert(parent_ident.clone());
+            } else {
+                add_dependent(&parent_ident, &child, preference, seen);
+            }
+        }
+    }
+}
+
+/// Whether `child` carries the ident currently preferred for its
+/// name. Names absent from `hoist_ident_map` (none reachable, or a
+/// root peer) carry no preference and hoist freely. Ports yarn's
+/// `hoistedIdent === node.ident` gate in `getNodeHoistInfo` at
+/// [hoist.ts:387](https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L387).
+fn is_preferred_ident(
+    child: &HoisterResult,
+    hoist_ident_map: &HashMap<String, Vec<String>>,
+) -> bool {
+    let Some(idents) = hoist_ident_map.get(&child.name) else {
+        return true;
+    };
+    let Some(preferred) = idents.first() else {
+        return true;
+    };
+    child.references.borrow().iter().next().is_some_and(|reference| reference == preferred)
 }
 
 /// Depth-first hoist driver. `ancestor_path` is the path from
@@ -716,12 +898,12 @@ fn hoist_into_root(root: &Rc<HoisterResult>, root_locator: &str, opts: &HoistOpt
 fn hoist_subtree(
     node: &Rc<HoisterResult>,
     ancestor_path: &[Rc<HoisterResult>],
-    root: &Rc<HoisterResult>,
+    ctx: &HoistCtx<'_>,
     root_index: &mut HashMap<String, RcByPtr<HoisterResult>>,
     visited: &mut HashSet<*const HoisterResult>,
-    border_names: &BTreeSet<String>,
     under_border: bool,
 ) -> bool {
+    let &HoistCtx { root, border_names, hoist_ident_map } = ctx;
     let root_ptr = Rc::as_ptr(root);
     if !visited.insert(Rc::as_ptr(node)) {
         return false;
@@ -769,7 +951,11 @@ fn hoist_subtree(
             AbsorbDecision::Border
         } else {
             match root_index.get(&child.0.name) {
-                None => AbsorbDecision::Free,
+                // Free slot, but only the currently-preferred ident
+                // may take it; a non-preferred version waits for the
+                // ident shift in `hoist_into_root`.
+                None if is_preferred_ident(&child.0, hoist_ident_map) => AbsorbDecision::Free,
+                None => AbsorbDecision::Defer,
                 Some(existing) if Rc::ptr_eq(&existing.0, &child.0) => AbsorbDecision::SameNode,
                 Some(_) => AbsorbDecision::Conflict,
             }
@@ -817,14 +1003,18 @@ fn hoist_subtree(
                     changed_in_subtree = true;
                     vec![Rc::clone(root)]
                 }
-                AbsorbDecision::Conflict | AbsorbDecision::PeerShadow | AbsorbDecision::Border => {
+                AbsorbDecision::Conflict
+                | AbsorbDecision::PeerShadow
+                | AbsorbDecision::Border
+                | AbsorbDecision::Defer => {
                     // Stays at the current parent. The version
                     // already at root wins the slot, hoisting would
-                    // shadow a peer dependency, or the candidate sits
-                    // beneath a `hoisting_limits` border. Child's
-                    // ancestor path is the path through `node`; a
-                    // later round may revisit this candidate with a
-                    // different peer / conflict context (the border
+                    // shadow a peer dependency, the candidate sits
+                    // beneath a `hoisting_limits` border, or its ident
+                    // is not the preferred one yet. Child's ancestor
+                    // path is the path through `node`; a later round
+                    // may revisit this candidate with a different peer
+                    // / conflict / preference context (the border
                     // boundary is fixed so the Border verdict won't
                     // change).
                     path_for_children.clone()
@@ -835,10 +1025,9 @@ fn hoist_subtree(
         let child_changed = hoist_subtree(
             &child.0,
             &child_recursion_path,
-            root,
+            ctx,
             root_index,
             visited,
-            border_names,
             children_blocked,
         );
         changed_in_subtree |= child_changed;

--- a/pacquet/crates/real-hoist/src/lib.rs
+++ b/pacquet/crates/real-hoist/src/lib.rs
@@ -16,7 +16,7 @@ use miette::Diagnostic;
 use pacquet_lockfile::{Lockfile, PkgName, PkgNameVerPeer, ProjectSnapshot, SnapshotEntry};
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     fmt::Write as _,
     rc::Rc,
 };
@@ -659,6 +659,18 @@ enum AbsorbDecision {
     Border,
 }
 
+/// Immutable context shared across every [`hoist_subtree`] call in
+/// one [`hoist_into_root`] pass: the hoisting root, the active
+/// border-name set, and the per-name preferred-ident map. Bundled
+/// into one struct so the recursive walker stays under the argument
+/// limit; only `root_index`, `visited`, and the per-node position
+/// (`node`, `ancestor_path`, `under_border`) vary per call.
+struct HoistCtx<'a> {
+    root: &'a Rc<HoisterResult>,
+    border_names: &'a BTreeSet<String>,
+    hoist_ident_map: &'a HashMap<String, VecDeque<String>>,
+}
+
 /// Walk the result tree and hoist every eligible descendant of
 /// `root` onto `root` itself, iterating until the graph reaches a
 /// fixed point.
@@ -692,18 +704,6 @@ enum AbsorbDecision {
 /// DAG sharing and accepts a more conservative ruling in the
 /// rare cross-path mismatch cases. The cost is layouts that are
 /// sometimes more nested than pnpm's, never less.
-/// Immutable context shared across every [`hoist_subtree`] call in
-/// one [`hoist_into_root`] pass: the hoisting root, the active
-/// border-name set, and the per-name preferred-ident map. Bundled
-/// into one struct so the recursive walker stays under the argument
-/// limit; only `root_index`, `visited`, and the per-node position
-/// (`node`, `ancestor_path`, `under_border`) vary per call.
-struct HoistCtx<'a> {
-    root: &'a Rc<HoisterResult>,
-    border_names: &'a BTreeSet<String>,
-    hoist_ident_map: &'a HashMap<String, Vec<String>>,
-}
-
 fn hoist_into_root(root: &Rc<HoisterResult>, root_locator: &str, opts: &HoistOpts) {
     let mut root_index: HashMap<String, RcByPtr<HoisterResult>> =
         root.dependencies.borrow().iter().map(|dep| (dep.0.name.clone(), dep.clone())).collect();
@@ -742,7 +742,7 @@ fn hoist_into_root(root: &Rc<HoisterResult>, root_locator: &str, opts: &HoistOpt
         let mut shifted = false;
         for (name, idents) in &mut hoist_ident_map {
             if idents.len() > 1 && !root_index.contains_key(name) {
-                idents.remove(0);
+                idents.pop_front();
                 shifted = true;
             }
         }
@@ -791,7 +791,7 @@ impl PreferenceEntry {
 /// currently-preferred ident and shifts it as passes progress.
 /// Ports
 /// <https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts>.
-fn build_hoist_ident_map(root: &Rc<HoisterResult>) -> HashMap<String, Vec<String>> {
+fn build_hoist_ident_map(root: &Rc<HoisterResult>) -> HashMap<String, VecDeque<String>> {
     let mut preference: IndexMap<(String, String), PreferenceEntry> = IndexMap::new();
     let mut seen: HashSet<*const HoisterResult> = HashSet::new();
     seen.insert(Rc::as_ptr(root));
@@ -808,11 +808,11 @@ fn build_hoist_ident_map(root: &Rc<HoisterResult>) -> HashMap<String, Vec<String
     // Seed the result with the root and its direct deps so their
     // idents always rank first. Mirrors `getHoistIdentMap`'s initial
     // `identMap` construction before the sorted append loop.
-    let mut ident_map: IndexMap<String, Vec<String>> = IndexMap::new();
-    ident_map.insert(root.name.clone(), vec![root_ident]);
+    let mut ident_map: IndexMap<String, VecDeque<String>> = IndexMap::new();
+    ident_map.insert(root.name.clone(), VecDeque::from([root_ident]));
     for dep in &root_children {
         if !root.peer_names.contains(&dep.name) {
-            ident_map.insert(dep.name.clone(), vec![node_ident(dep)]);
+            ident_map.insert(dep.name.clone(), VecDeque::from([node_ident(dep)]));
         }
     }
 
@@ -829,7 +829,7 @@ fn build_hoist_ident_map(root: &Rc<HoisterResult>) -> HashMap<String, Vec<String
         }
         let idents = ident_map.entry(name).or_default();
         if !idents.contains(&ident) {
-            idents.push(ident);
+            idents.push_back(ident);
         }
     }
 
@@ -878,12 +878,12 @@ fn add_dependent(
 /// [hoist.ts:387](https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L387).
 fn is_preferred_ident(
     child: &HoisterResult,
-    hoist_ident_map: &HashMap<String, Vec<String>>,
+    hoist_ident_map: &HashMap<String, VecDeque<String>>,
 ) -> bool {
     let Some(idents) = hoist_ident_map.get(&child.name) else {
         return true;
     };
-    let Some(preferred) = idents.first() else {
+    let Some(preferred) = idents.front() else {
         return true;
     };
     child.references.borrow().iter().next().is_some_and(|reference| reference == preferred)

--- a/pacquet/crates/real-hoist/src/tests.rs
+++ b/pacquet/crates/real-hoist/src/tests.rs
@@ -1,4 +1,6 @@
-use super::{HoistError, HoistOpts, HoisterResult, RcByPtr, build_hoist_ident_map, hoist};
+use super::{
+    HoistError, HoistOpts, HoisterResult, RcByPtr, build_hoist_ident_map, hoist, is_preferred_ident,
+};
 use indexmap::IndexSet;
 use pacquet_lockfile::{
     ComVer, Lockfile, LockfileSettings, LockfileVersion, PkgName, PkgNameVerPeer, PkgVerPeer,
@@ -7,7 +9,7 @@ use pacquet_lockfile::{
 use pretty_assertions::assert_eq;
 use std::{
     cell::RefCell,
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap, VecDeque},
     rc::Rc,
 };
 
@@ -1098,5 +1100,62 @@ fn build_hoist_ident_map_skips_root_peer_names() {
     assert!(
         !ident_map.contains_key("react"),
         "a name the root declares as a peer is skipped even when reachable transitively",
+    );
+}
+
+/// When a *non-root* node declares one of its own children as a peer,
+/// `add_dependent` records that child as a peer-dependent but does not
+/// recurse into it (yarn's `entry.peerDependents.add` branch). The
+/// child's own exclusive subtree is therefore never discovered.
+///
+/// Reachable from `hoist` only with an exotic lockfile where a package
+/// lists the same name in both `dependencies` and `peerDependencies`;
+/// driving [`build_hoist_ident_map`] directly is simpler and lets the
+/// "subtree not walked" effect be asserted unambiguously.
+#[test]
+fn build_hoist_ident_map_records_node_peers_without_walking_their_subtree() {
+    // `app` declares `react` as its own peer, so the peer branch records
+    // `react` but skips its exclusive child `scheduler`.
+    let scheduler = result_node("scheduler", "scheduler@1.0.0", &[], vec![]);
+    let react = result_node("react", "react@18.0.0", &[], vec![scheduler]);
+    let app = result_node("app", "app@1.0.0", &["react"], vec![react]);
+    let root = result_node(".", "", &[], vec![app]);
+
+    let ident_map = build_hoist_ident_map(&root);
+    dbg!(&ident_map);
+    assert!(ident_map.contains_key("app"), "the regular dep is recorded");
+    assert!(ident_map.contains_key("react"), "the node's peer is still a candidate ident");
+    assert!(
+        !ident_map.contains_key("scheduler"),
+        "a peer's exclusive subtree is not walked, so its child never enters the map",
+    );
+}
+
+/// `is_preferred_ident` returns `true` for a name with no entry in the
+/// ident map. Unreachable from `hoist` (the map covers every name the
+/// walk encounters except root peers, and `hoist` builds the `.` root
+/// with no peers), so it is exercised by calling the guard directly.
+#[test]
+fn is_preferred_ident_allows_names_absent_from_the_map() {
+    let child = result_node("ghost", "ghost@1.0.0", &[], vec![]);
+    let ident_map: HashMap<String, VecDeque<String>> = HashMap::new();
+    assert!(
+        is_preferred_ident(&child, &ident_map),
+        "a name with no preference entry carries no constraint and hoists freely",
+    );
+}
+
+/// `is_preferred_ident` returns `true` when a name maps to an empty
+/// candidate list. [`build_hoist_ident_map`] never emits an empty
+/// `VecDeque` (every entry gets at least one ident), so this defensive
+/// guard is only reachable by constructing the empty list directly.
+#[test]
+fn is_preferred_ident_allows_empty_candidate_lists() {
+    let child = result_node("ghost", "ghost@1.0.0", &[], vec![]);
+    let ident_map: HashMap<String, VecDeque<String>> =
+        HashMap::from([("ghost".to_string(), VecDeque::new())]);
+    assert!(
+        is_preferred_ident(&child, &ident_map),
+        "an empty candidate list carries no constraint and hoists freely",
     );
 }

--- a/pacquet/crates/real-hoist/src/tests.rs
+++ b/pacquet/crates/real-hoist/src/tests.rs
@@ -327,7 +327,7 @@ fn most_used_version_wins_root_slot() {
     let x_under_aa = aa_kids[0].0.references.borrow();
     assert!(
         x_under_aa.contains("x@1.0.0"),
-        "the less-used x stays nested under aa: {x_under_aa:?}"
+        "the less-used x stays nested under aa: {x_under_aa:?}",
     );
 }
 

--- a/pacquet/crates/real-hoist/src/tests.rs
+++ b/pacquet/crates/real-hoist/src/tests.rs
@@ -260,11 +260,8 @@ fn version_conflict_keeps_loser_at_parent() {
 
 /// The most-depended-on version of a shared name wins the root
 /// slot, even when a less-used version is discovered first in the
-/// depth-first walk. `aa` (visited first, alphabetically) pulls
-/// `x@1.0.0`; `cc` and `dd` both pull `x@2.0.0`. A first-visitor
-/// rule would hoist `x@1.0.0`; the popularity preference hoists the
-/// more-used `x@2.0.0` and leaves `x@1.0.0` nested under `aa`.
-/// Ports the "most used version wins" guarantee of yarn's
+/// depth-first walk — a first-visitor rule would hoist the wrong
+/// one. Ports the "most used version wins" guarantee of yarn's
 /// `getHoistIdentMap`.
 #[test]
 fn most_used_version_wins_root_slot() {
@@ -1087,9 +1084,6 @@ fn result_node(
 /// the shape a per-importer hoisting root would take once those land.
 #[test]
 fn build_hoist_ident_map_skips_root_peer_names() {
-    // `.` declares `react` as a peer; its non-peer child `app` pulls
-    // `react` in transitively, so `react` enters the preference map and
-    // then hits the peer-name guard.
     let react = result_node("react", "react@18.0.0", &[], vec![]);
     let app = result_node("app", "app@1.0.0", &[], vec![react]);
     let root = result_node(".", "", &["react"], vec![app]);
@@ -1114,8 +1108,6 @@ fn build_hoist_ident_map_skips_root_peer_names() {
 /// "subtree not walked" effect be asserted unambiguously.
 #[test]
 fn build_hoist_ident_map_records_node_peers_without_walking_their_subtree() {
-    // `app` declares `react` as its own peer, so the peer branch records
-    // `react` but skips its exclusive child `scheduler`.
     let scheduler = result_node("scheduler", "scheduler@1.0.0", &[], vec![]);
     let react = result_node("react", "react@18.0.0", &[], vec![scheduler]);
     let app = result_node("app", "app@1.0.0", &["react"], vec![react]);

--- a/pacquet/crates/real-hoist/src/tests.rs
+++ b/pacquet/crates/real-hoist/src/tests.rs
@@ -1,10 +1,12 @@
-use super::{HoistError, HoistOpts, HoisterResult, hoist};
+use super::{HoistError, HoistOpts, HoisterResult, RcByPtr, build_hoist_ident_map, hoist};
+use indexmap::IndexSet;
 use pacquet_lockfile::{
     ComVer, Lockfile, LockfileSettings, LockfileVersion, PkgName, PkgNameVerPeer, PkgVerPeer,
     ProjectSnapshot, ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry,
 };
 use pretty_assertions::assert_eq;
 use std::{
+    cell::RefCell,
     collections::{BTreeSet, HashMap},
     rc::Rc,
 };
@@ -1051,5 +1053,50 @@ fn hoist_workspace_packages_false_omits_workspace_children() {
         result.dependencies.borrow().is_empty(),
         "non-root importers omitted: {:?}",
         result.dependencies.borrow().iter().map(|child| child.0.name.clone()).collect::<Vec<_>>(),
+    );
+}
+
+/// Construct a [`HoisterResult`] node directly, for unit-testing the
+/// preference machinery without going through [`hoist`] (which only ever
+/// builds the `.` root with empty `peer_names`).
+fn result_node(
+    name: &str,
+    reference: &str,
+    peer_names: &[&str],
+    dependencies: Vec<Rc<HoisterResult>>,
+) -> Rc<HoisterResult> {
+    Rc::new(HoisterResult {
+        name: name.to_string(),
+        ident_name: name.to_string(),
+        references: RefCell::new(BTreeSet::from([reference.to_string()])),
+        peer_names: peer_names.iter().map(|&peer| peer.to_string()).collect(),
+        dependencies: RefCell::new(dependencies.into_iter().map(RcByPtr).collect::<IndexSet<_>>()),
+    })
+}
+
+/// A candidate whose name the root declares as its own peer dependency is
+/// kept out of the ident map, even when reachable through the root's
+/// non-peer descendants. Ports yarn's `!rootNode.peerNames.has(name)`
+/// guard in `getHoistIdentMap`.
+///
+/// [`hoist`] always builds the `.` root with empty `peer_names`, so the
+/// guard is unreachable from the public entry point. This drives
+/// [`build_hoist_ident_map`] directly with a root that declares a peer —
+/// the shape a per-importer hoisting root would take once those land.
+#[test]
+fn build_hoist_ident_map_skips_root_peer_names() {
+    // `.` declares `react` as a peer; its non-peer child `app` pulls
+    // `react` in transitively, so `react` enters the preference map and
+    // then hits the peer-name guard.
+    let react = result_node("react", "react@18.0.0", &[], vec![]);
+    let app = result_node("app", "app@1.0.0", &[], vec![react]);
+    let root = result_node(".", "", &["react"], vec![app]);
+
+    let ident_map = build_hoist_ident_map(&root);
+    dbg!(&ident_map);
+    assert!(ident_map.contains_key("app"), "the non-peer child is recorded");
+    assert!(
+        !ident_map.contains_key("react"),
+        "a name the root declares as a peer is skipped even when reachable transitively",
     );
 }

--- a/pacquet/crates/real-hoist/src/tests.rs
+++ b/pacquet/crates/real-hoist/src/tests.rs
@@ -254,6 +254,83 @@ fn version_conflict_keeps_loser_at_parent() {
     assert_eq!(b_under_c_refs.len(), 1);
 }
 
+/// The most-depended-on version of a shared name wins the root
+/// slot, even when a less-used version is discovered first in the
+/// depth-first walk. `aa` (visited first, alphabetically) pulls
+/// `x@1.0.0`; `cc` and `dd` both pull `x@2.0.0`. A first-visitor
+/// rule would hoist `x@1.0.0`; the popularity preference hoists the
+/// more-used `x@2.0.0` and leaves `x@1.0.0` nested under `aa`.
+/// Ports the "most used version wins" guarantee of yarn's
+/// `getHoistIdentMap`.
+#[test]
+fn most_used_version_wins_root_slot() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("aa"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("cc"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("dd"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    let mut snapshots = HashMap::new();
+    let mut aa_deps = HashMap::new();
+    aa_deps.insert(pkg_name("x"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    let mut cc_deps = HashMap::new();
+    cc_deps.insert(pkg_name("x"), SnapshotDepRef::Plain(ver_peer("2.0.0")));
+    let mut dd_deps = HashMap::new();
+    dd_deps.insert(pkg_name("x"), SnapshotDepRef::Plain(ver_peer("2.0.0")));
+    snapshots.insert(
+        dep_key("aa", "1.0.0"),
+        SnapshotEntry { dependencies: Some(aa_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(
+        dep_key("cc", "1.0.0"),
+        SnapshotEntry { dependencies: Some(cc_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(
+        dep_key("dd", "1.0.0"),
+        SnapshotEntry { dependencies: Some(dd_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("x", "1.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("x", "2.0.0"), SnapshotEntry::default());
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers,
+        packages: None,
+        snapshots: Some(snapshots),
+    };
+
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("hoist should succeed");
+    let root_children = result.dependencies.borrow();
+    let mut names: Vec<&str> = root_children.iter().map(|dep| dep.0.name.as_str()).collect();
+    names.sort_unstable();
+    assert_eq!(names, ["aa", "cc", "dd", "x"], "one x at root: {result:#?}");
+    let x_at_root = Rc::clone(&root_children.iter().find(|dep| dep.0.name == "x").unwrap().0);
+    let x_refs = x_at_root.references.borrow();
+    assert!(
+        x_refs.contains("x@2.0.0"),
+        "the more-used x@2.0.0 wins root over the first-visited x@1.0.0: {x_refs:?}",
+    );
+    let dep_aa = Rc::clone(&root_children.iter().find(|dep| dep.0.name == "aa").unwrap().0);
+    let aa_kids = dep_aa.dependencies.borrow();
+    assert_eq!(aa_kids.len(), 1, "aa keeps its conflicting x@1.0.0");
+    let x_under_aa = aa_kids[0].0.references.borrow();
+    assert!(
+        x_under_aa.contains("x@1.0.0"),
+        "the less-used x stays nested under aa: {x_under_aa:?}"
+    );
+}
+
 #[test]
 fn deep_chain_flattens_in_one_pass() {
     let mut importers = HashMap::new();

--- a/pacquet/plans/TEST_PORTING.md
+++ b/pacquet/plans/TEST_PORTING.md
@@ -336,8 +336,8 @@ Frozen/headless cross-coverage:
 - [ ] `TypeScript repo: installing/deps-installer/test/install/patch.ts:386` `patch package when the package is not in allowBuilds list` includes frozen hoisted reinstall.
 - [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:579` `run pre/postinstall scripts in a workspace that uses node-linker=hoisted`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:686` `run pre/postinstall scripts in a project that uses node-linker=hoisted. Should not fail on repeat install`
-- [ ] `TypeScript repo: installing/deps-restorer/test/index.ts:859` `installing with node-linker=hoisted`
-- [ ] `TypeScript repo: installing/deps-restorer/test/index.ts:873` `installing in a workspace with node-linker=hoisted`
+- [x] `TypeScript repo: installing/deps-restorer/test/index.ts:859` `installing with node-linker=hoisted`. Ported as `installing_with_hoisted_node_linker_frozen` in `crates/cli/tests/hoisted_node_linker.rs` — seeds the lockfile with a fresh install, tears down `node_modules`, then replays via `--frozen-lockfile` and asserts the real-dir + version-conflict-nesting layout.
+- [x] `TypeScript repo: installing/deps-restorer/test/index.ts:873` `installing in a workspace with node-linker=hoisted`. Ported as `installing_in_a_workspace_with_hoisted_node_linker_frozen` — a frozen workspace replay where the root importer's `ms@2.1.3` wins the top-level slot and a project's conflicting `ms@2.0.0` nests under the project (the root-deps-rank-first preference landed in `real-hoist`).
 
 Rust port notes:
 


### PR DESCRIPTION
## Summary

Closes a parity gap in pacquet's `nodeLinker: 'hoisted'` implementation.

When several versions of the same dependency name compete for the top-level
`node_modules` slot, pnpm (via yarn berry's hoister) gives the slot to the
**most-used** version, with the root's own direct dependencies always ranking
first. pacquet previously hoisted whichever version it visited first in its
depth-first walk, so a less-used version could win the root slot and produce a
layout that is more deeply nested than pnpm's.

This PR ports yarn's `buildPreferenceMap` / `getHoistIdentMap` into
`real-hoist`:

- a per-name preferred-ident map orders candidate versions most-preferred-first
  (root deps first, then by usage count);
- a new `AbsorbDecision::Defer` plus an `is_preferred_ident` gate keeps a
  non-preferred version nested until a per-pass `VecDeque::pop_front` ident
  shift promotes the next candidate when the preferred one cannot reach the
  root;
- `HoistCtx` bundles the root, the border-name set, and the ident map so the
  recursive walker stays within the argument limit.

It also ports two upstream frozen-lockfile (headless) tests
(`installing/deps-restorer/test/index.ts:859` and `:873`), adds unit and
dep-graph coverage for the preference machinery, and marks both items as
ported in `pacquet/plans/TEST_PORTING.md`.

This is a pacquet-only port: the behavior already exists in the TypeScript pnpm
CLI (the source of truth), so no TypeScript-side change is required.

## Squash Commit Body

```text
Port yarn berry's popularity-based ident preference (buildPreferenceMap /
getHoistIdentMap) into the real-hoist crate so that, when multiple versions of
one name compete for the root node_modules slot, the most-used version wins —
with the root's direct dependencies always preferred first. This matches pnpm's
hoisted node-linker layout, which pacquet previously diverged from by hoisting
the first-visited version.

Mechanism:
- build_hoist_ident_map / add_dependent / PreferenceEntry build a per-name list
  of candidate idents ordered most-preferred-first (root deps, then by the
  count of distinct dependents + peer-dependents, stable on ties).
- A new AbsorbDecision::Defer plus is_preferred_ident gates free-slot
  absorption: only the currently-preferred ident may take a free root slot; a
  non-preferred version stays nested.
- hoist_into_root performs a per-pass ident shift (VecDeque::pop_front) that
  promotes the next candidate when the preferred ident still hasn't reached the
  root, so a less-preferred version can land once the preferred one is proven
  unreachable.
- HoistCtx bundles root, border_names, and the ident map to keep hoist_subtree
  within the argument limit.

Tests: unit tests for the preference machinery and most-used-wins precedence, a
dep-graph workspace test, and two frozen-lockfile CLI e2e tests
(single-project and workspace) ported from
installing/deps-restorer/test/index.ts. TEST_PORTING.md is updated accordingly.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port. This is a pacquet-only port of behavior that already exists
  in the TypeScript pnpm CLI (the reference being ported from), bringing the two
  back into parity.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end frozen-lockfile coverage for `nodeLinker: hoisted`, verifying real directory materialization and correct nesting for conflicting dependency versions.
  * Added workspace hoisting tests confirming the root importer’s higher version wins the top-level slot, with conflicting versions nested under the consuming workspace package.
  * Added unit tests for hoisting preference logic (e.g., “most-used version wins” and related ident-map behavior).
* **Documentation**
  * Updated the test porting checklist for hoisted frozen scenarios.
* **Chores**
  * Refactored internal hoisting decision flow to support preferred-ident handling per pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->