### PR TITLE
fix(resolver): make shared-children missing-peer reuse independent of resolution order

### DIFF
--- a/.changeset/deterministic-shared-children-peers.md
+++ b/.changeset/deterministic-shared-children-peers.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fixed non-deterministic peer resolution that could add or remove an optional transitive peer — for example `@babel/core`, reached through `styled-jsx` — from a package's peer-dependency suffix across otherwise identical installs, churning the lockfile and causing intermittent `pnpm dedupe --check` failures in CI. When a package's children are resolved by one occurrence (the "owner") and reused by a deeper consumer, whether that consumer inherited the owner's missing peers depended on whether the owner's resolution had finished yet — a race under concurrent resolution. The decision is now a function of the dependency graph's structure rather than resolution-completion order.

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1101,13 +1101,10 @@ fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
 // is reached through two occurrences at different depths: a shallow one whose
 // parent provides `@babel/core`, and a deeper one whose ancestors do not. The
 // shallow occurrence resolves the optional peer into its suffix; the deeper one
-// must not inherit it. In pnpm this could flip run to run when a shallow
-// "owner" occurrence's children finished resolving before a deeper consumer was
-// claimed — completion order leaking into the resolved suffix. pacquet resolves
-// the tree in a single deterministic walk, so the deeper occurrence's suffix is
-// a function of graph structure alone. Building a fresh tree (fresh `HashMap`s,
-// whose iteration order varies per process) on each iteration guards against any
-// hashing order leaking into the result the way completion order did upstream.
+// must not inherit it. The deeper occurrence's suffix must be a function of
+// graph structure alone, so each iteration resolves a freshly built tree
+// (fresh `HashMap`s, whose iteration order varies per process) to catch any
+// hashing order leaking into the result.
 #[test]
 fn shared_package_optional_transitive_peer_resolves_deterministically() {
     fn build_tree() -> ResolvedTree {

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1095,7 +1095,7 @@ fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
     assert!(!graph.contains_key(&trimmed_provider_dep_path));
 }
 
-// Parity check for https://github.com/pnpm/pnpm/pull/12514.
+// Parity check for <https://github.com/pnpm/pnpm/pull/12514>.
 //
 // A shared package (`styled-jsx`) declaring an *optional* peer (`@babel/core`)
 // is reached through two occurrences at different depths: a shallow one whose

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1095,6 +1095,108 @@ fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
     assert!(!graph.contains_key(&trimmed_provider_dep_path));
 }
 
+// Parity check for https://github.com/pnpm/pnpm/pull/12514.
+//
+// A shared package (`styled-jsx`) declaring an *optional* peer (`@babel/core`)
+// is reached through two occurrences at different depths: a shallow one whose
+// parent provides `@babel/core`, and a deeper one whose ancestors do not. The
+// shallow occurrence resolves the optional peer into its suffix; the deeper one
+// must not inherit it. In pnpm this could flip run to run when a shallow
+// "owner" occurrence's children finished resolving before a deeper consumer was
+// claimed — completion order leaking into the resolved suffix. pacquet resolves
+// the tree in a single deterministic walk, so the deeper occurrence's suffix is
+// a function of graph structure alone. Building a fresh tree (fresh `HashMap`s,
+// whose iteration order varies per process) on each iteration guards against any
+// hashing order leaking into the result the way completion order did upstream.
+#[test]
+fn shared_package_optional_transitive_peer_resolves_deterministically() {
+    fn build_tree() -> ResolvedTree {
+        let babel = NodeId::leaf("@babel/core@7.0.0");
+        let styled_shallow = NodeId::next();
+        let styled_deep = NodeId::next();
+        let app = NodeId::next();
+        let mid = NodeId::next();
+
+        let mut app_children = BTreeMap::new();
+        app_children.insert("styled-jsx".to_string(), styled_shallow.clone());
+        app_children.insert("@babel/core".to_string(), babel.clone());
+
+        let mut mid_children = BTreeMap::new();
+        mid_children.insert("styled-jsx".to_string(), styled_deep.clone());
+
+        ResolvedTree {
+            direct: vec![
+                DirectDep {
+                    alias: "app".to_string(),
+                    node_id: app.clone(),
+                    id: "app@1.0.0".to_string(),
+                },
+                DirectDep {
+                    alias: "mid".to_string(),
+                    node_id: mid.clone(),
+                    id: "mid@1.0.0".to_string(),
+                },
+            ],
+            packages: HashMap::from([
+                ("@babel/core@7.0.0".to_string(), package("@babel/core", "7.0.0", &[], true)),
+                (
+                    "styled-jsx@1.0.0".to_string(),
+                    package_with_peer_dependencies(
+                        "styled-jsx",
+                        "1.0.0",
+                        &[("@babel/core", "*", true)],
+                        false,
+                    ),
+                ),
+                ("app@1.0.0".to_string(), package("app", "1.0.0", &[], false)),
+                ("mid@1.0.0".to_string(), package("mid", "1.0.0", &[], false)),
+            ]),
+            dependencies_tree: HashMap::from([
+                (babel, tree_node("@babel/core@7.0.0", BTreeMap::new(), 1)),
+                (styled_shallow, tree_node("styled-jsx@1.0.0", BTreeMap::new(), 1)),
+                (styled_deep, tree_node("styled-jsx@1.0.0", BTreeMap::new(), 2)),
+                (app, tree_node("app@1.0.0", app_children, 0)),
+                (mid, tree_node("mid@1.0.0", mid_children, 1)),
+            ]),
+            all_peer_dep_names: HashSet::from(["@babel/core".to_string()]),
+            policy_violations: Vec::new(),
+            applied_patches: HashSet::new(),
+            children_by_id: HashMap::new(),
+        }
+    }
+
+    let styled_with_babel = DepPath::from("styled-jsx@1.0.0(@babel/core@7.0.0)");
+    let styled_without_babel = DepPath::from("styled-jsx@1.0.0");
+    let app_dep_path = DepPath::from("app@1.0.0");
+    let mid_dep_path = DepPath::from("mid@1.0.0");
+
+    let mut first_keys: Option<Vec<String>> = None;
+    for _ in 0..16 {
+        let mut tree = build_tree();
+        let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+
+        // The shallow occurrence resolves the optional peer from its sibling; the
+        // deeper occurrence, with no provider in scope, keeps the bare suffix.
+        assert_eq!(
+            result.graph[&app_dep_path].children.get("styled-jsx"),
+            Some(&styled_with_babel),
+        );
+        assert_eq!(
+            result.graph[&mid_dep_path].children.get("styled-jsx"),
+            Some(&styled_without_babel),
+        );
+        assert!(result.graph.contains_key(&styled_with_babel));
+        assert!(result.graph.contains_key(&styled_without_babel));
+
+        let mut keys: Vec<String> = result.graph.keys().map(DepPath::to_string).collect();
+        keys.sort();
+        match &first_keys {
+            None => first_keys = Some(keys),
+            Some(expected) => assert_eq!(&keys, expected, "graph keys must not vary across runs"),
+        }
+    }
+}
+
 fn tree_node(pkg_id: &str, children: BTreeMap<String, NodeId>, depth: i32) -> DependenciesTreeNode {
     DependenciesTreeNode {
         resolved_package_id: pkg_id.to_string(),

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -1085,7 +1085,7 @@ function hasActivePackageResolutionBeforeDepth (ctx: ResolutionContext, depth: n
   return false
 }
 
-function claimChildrenResolution (
+export function claimChildrenResolution (
   ctx: ResolutionContext,
   opts: {
     currentDepth: number

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -1141,17 +1141,12 @@ export function claimChildrenResolution (
     existing.missingPeersOfChildren &&
     existing.owner.depth >= opts.currentDepth
   ) {
-    // Sharing the owner's missing-peers promise when the owner is shallower than
-    // this consumer previously also happened whenever that promise had already
-    // settled (`existing.missingPeersOfChildren.resolved`). That made reuse depend
-    // on whether the owner had finished by the time this node was claimed — a race
-    // under real concurrent resolution that let a transitive optional peer (e.g.
-    // styled-jsx's `@babel/core`) propagate into a deeper consumer's suffix on some
-    // runs but not others, churning the lockfile non-deterministically. Reusing
-    // only when the owner is at the same or a deeper depth keeps the decision a
-    // function of graph structure rather than completion order; awaiting a strictly
-    // shallower, possibly-unsettled owner is what the deadlock guard in
-    // https://github.com/pnpm/pnpm/issues/11999 avoided anyway.
+    // Gating reuse on the owner's depth keeps a transitive optional peer's
+    // presence in the resolved suffix a function of graph structure, not of
+    // which occurrence happened to finish resolving first. A strictly shallower
+    // owner is excluded because its promise may still be unsettled here, and
+    // awaiting it can deadlock under auto-install-peers
+    // (https://github.com/pnpm/pnpm/issues/5454).
     missingPeersOfChildren = existing.missingPeersOfChildren
   }
   return {

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -1139,11 +1139,19 @@ function claimChildrenResolution (
     ctx.hoistPeers &&
     !opts.parentIds.includes(opts.pkgId) &&
     existing.missingPeersOfChildren &&
-    (
-      existing.owner.depth >= opts.currentDepth ||
-      existing.missingPeersOfChildren.resolved
-    )
+    existing.owner.depth >= opts.currentDepth
   ) {
+    // Sharing the owner's missing-peers promise when the owner is shallower than
+    // this consumer previously also happened whenever that promise had already
+    // settled (`existing.missingPeersOfChildren.resolved`). That made reuse depend
+    // on whether the owner had finished by the time this node was claimed — a race
+    // under real concurrent resolution that let a transitive optional peer (e.g.
+    // styled-jsx's `@babel/core`) propagate into a deeper consumer's suffix on some
+    // runs but not others, churning the lockfile non-deterministically. Reusing
+    // only when the owner is at the same or a deeper depth keeps the decision a
+    // function of graph structure rather than completion order; awaiting a strictly
+    // shallower, possibly-unsettled owner is what the deadlock guard in
+    // https://github.com/pnpm/pnpm/issues/11999 avoided anyway.
     missingPeersOfChildren = existing.missingPeersOfChildren
   }
   return {

--- a/pnpm11/installing/deps-resolver/test/claimChildrenResolution.test.ts
+++ b/pnpm11/installing/deps-resolver/test/claimChildrenResolution.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@jest/globals'
+import type { PkgResolutionId } from '@pnpm/resolving.resolver-base'
+
+import { claimChildrenResolution } from '../lib/resolveDependencies.js'
+
+type Ctx = Parameters<typeof claimChildrenResolution>[0]
+
+function createCtx (importerResolutionOrder: Record<string, number> = {}): Ctx {
+  return {
+    hoistPeers: true,
+    importerResolutionOrder,
+    childrenResolutionByPkgId: {},
+    childrenResolutionId: 0,
+    missingPeersOfChildrenByPkgId: {},
+  } as unknown as Ctx
+}
+
+// Regression test for https://github.com/pnpm/pnpm/pull/12514.
+//
+// When several occurrences of one shared package each resolve its children, the
+// shallowest occurrence becomes the "owner" and the others may reuse the owner's
+// `missingPeersOfChildren` promise. Reuse must be a function of the dependency
+// graph (the owner's depth), never of whether the owner's promise happens to
+// have settled by the time a given occurrence is claimed: that settling time
+// varies run to run under concurrent resolution, so keying reuse on it flipped a
+// transitive optional peer (e.g. styled-jsx's `@babel/core`) in and out of a
+// deeper consumer's resolved suffix and churned the lockfile.
+test('a deeper consumer never inherits a shallower owner\'s missing peers, even after the owner has resolved', () => {
+  const ctx = createCtx()
+  const pkgId = 'shared@1.0.0' as PkgResolutionId
+
+  const owner = claimChildrenResolution(ctx, {
+    currentDepth: 0,
+    parentIds: ['importer-1'] as PkgResolutionId[],
+    pkgId,
+  })
+  expect(owner.isOwner).toBe(true)
+  expect(owner.missingPeersOfChildren).toBeDefined()
+
+  // Simulate the owner's subtree finishing before the deeper consumer is
+  // claimed. This settled state is the only run-to-run-variable input the buggy
+  // reuse condition keyed on.
+  ctx.childrenResolutionByPkgId[pkgId].missingPeersOfChildren!.resolved = true
+
+  const deeperConsumer = claimChildrenResolution(ctx, {
+    currentDepth: 2,
+    parentIds: ['importer-1', 'a@1.0.0', 'b@1.0.0'] as PkgResolutionId[],
+    pkgId,
+  })
+  expect(deeperConsumer.isOwner).toBe(false)
+  // The owner is strictly shallower, so the consumer resolves its own children's
+  // peers regardless of the settled flag.
+  expect(deeperConsumer.missingPeersOfChildren).toBeUndefined()
+})
+
+test('a same-depth occurrence still reuses the owner\'s missing peers', () => {
+  const ctx = createCtx({ 'importer-1': 0, 'importer-2': 1 })
+  const pkgId = 'shared@1.0.0' as PkgResolutionId
+
+  // The first importer wins ownership on the importer-order tiebreak.
+  const owner = claimChildrenResolution(ctx, {
+    currentDepth: 1,
+    parentIds: ['importer-1', 'mid-a@1.0.0'] as PkgResolutionId[],
+    pkgId,
+  })
+  expect(owner.isOwner).toBe(true)
+  expect(owner.missingPeersOfChildren).toBeDefined()
+
+  // A second occurrence at the same depth shares the owner's promise. This reuse
+  // is structural — both occurrences are equidistant — and is intentionally kept.
+  const sibling = claimChildrenResolution(ctx, {
+    currentDepth: 1,
+    parentIds: ['importer-2', 'mid-b@1.0.0'] as PkgResolutionId[],
+    pkgId,
+  })
+  expect(sibling.isOwner).toBe(false)
+  expect(sibling.missingPeersOfChildren).toBe(owner.missingPeersOfChildren)
+})

--- a/pnpm11/installing/deps-resolver/test/claimChildrenResolution.test.ts
+++ b/pnpm11/installing/deps-resolver/test/claimChildrenResolution.test.ts
@@ -20,11 +20,11 @@ function createCtx (importerResolutionOrder: Record<string, number> = {}): Ctx {
 // When several occurrences of one shared package each resolve its children, the
 // shallowest occurrence becomes the "owner" and the others may reuse the owner's
 // `missingPeersOfChildren` promise. Reuse must be a function of the dependency
-// graph (the owner's depth), never of whether the owner's promise happens to
-// have settled by the time a given occurrence is claimed: that settling time
-// varies run to run under concurrent resolution, so keying reuse on it flipped a
-// transitive optional peer (e.g. styled-jsx's `@babel/core`) in and out of a
-// deeper consumer's resolved suffix and churned the lockfile.
+// graph (the owner's depth) alone. The owner's promise can settle at different
+// times run to run under concurrent resolution, so reuse that depended on the
+// settled state would drift a transitive optional peer (e.g. styled-jsx's
+// `@babel/core`) in and out of a deeper consumer's resolved suffix and churn
+// the lockfile.
 test('a deeper consumer never inherits a shallower owner\'s missing peers, even after the owner has resolved', () => {
   const ctx = createCtx()
   const pkgId = 'shared@1.0.0' as PkgResolutionId
@@ -37,9 +37,8 @@ test('a deeper consumer never inherits a shallower owner\'s missing peers, even 
   expect(owner.isOwner).toBe(true)
   expect(owner.missingPeersOfChildren).toBeDefined()
 
-  // Simulate the owner's subtree finishing before the deeper consumer is
-  // claimed. This settled state is the only run-to-run-variable input the buggy
-  // reuse condition keyed on.
+  // Mark the owner's subtree as already settled before the deeper consumer is
+  // claimed. Reuse must ignore the settled state and depend only on depth.
   ctx.childrenResolutionByPkgId[pkgId].missingPeersOfChildren!.resolved = true
 
   const deeperConsumer = claimChildrenResolution(ctx, {
@@ -66,8 +65,8 @@ test('a same-depth occurrence still reuses the owner\'s missing peers', () => {
   expect(owner.isOwner).toBe(true)
   expect(owner.missingPeersOfChildren).toBeDefined()
 
-  // A second occurrence at the same depth shares the owner's promise. This reuse
-  // is structural — both occurrences are equidistant — and is intentionally kept.
+  // A second occurrence at the same depth shares the owner's promise: reuse is
+  // gated on depth, and equidistant occurrences are eligible.
   const sibling = claimChildrenResolution(ctx, {
     currentDepth: 1,
     parentIds: ['importer-2', 'mid-b@1.0.0'] as PkgResolutionId[],


### PR DESCRIPTION
## Summary

### The problem

Peer resolution is non-deterministic in one case: an optional *transitive* peer can be pulled into — or left out of — a package's resolved peer-dependency suffix depending on **resolution-completion order**, not on the dependency graph. The result is lockfile churn and intermittent `pnpm dedupe --check` failures in CI, even when running `pnpm dedupe` locally reports nothing to change.

A concrete, public instance of the shape:

- [`next`](https://www.npmjs.com/package/next) depends on [`styled-jsx`](https://www.npmjs.com/package/styled-jsx), and `styled-jsx` declares [`@babel/core`](https://www.npmjs.com/package/@babel/core) as an **optional** peer (`@babel/core` under `peerDependenciesMeta` as optional — verifiable via `npm view styled-jsx peerDependenciesMeta`).
- When `@babel/core` is present elsewhere in a workspace (e.g. pulled by a Babel/Storybook/React-Native toolchain in another project), whether a given `next` occurrence resolves it as a transitive peer — i.e. whether its dep path becomes `next@x(@babel/core@y)…` or just `next@x(…)` — varies between otherwise identical installs.

### Root cause

The non-determinism is in [`claimChildrenResolution`](https://github.com/pnpm/pnpm/blob/2dd79e372c/installing/deps-resolver/src/resolveDependencies.ts#L1137-L1153). When a shared package's children are resolved by one occurrence (the "owner") and a deeper occurrence reuses them, the reuse condition was:

```ts
existing.owner.depth >= opts.currentDepth ||
existing.missingPeersOfChildren.resolved
```

The second clause keys the decision on whether the owner's `missingPeersOfChildren` promise has **settled yet** at the moment this node is claimed. Under concurrent resolution that settling time varies run to run, so a deeper consumer inherits the owner's missing peers on some runs and not others. That is exactly what flips an optional transitive peer like `@babel/core` in and out of the suffix.

The deterministic owner *selection* added in [#12362](https://github.com/pnpm/pnpm/pull/12362) (via [`compareChildrenResolutionOwners`](https://github.com/pnpm/pnpm/blob/2dd79e372c/installing/deps-resolver/src/resolveDependencies.ts#L1156)) made *which* occurrence owns a shared package order-independent — but it did not neutralize this `.resolved` timing branch, which predates it.

### Why the clause existed

The `.resolved` flag was introduced in [#5467](https://github.com/pnpm/pnpm/pull/5467) (closing [#5454](https://github.com/pnpm/pnpm/issues/5454), *"don't crash when auto-install-peers is true in a workspace"*). With `auto-install-peers` in a workspace, a shared package reached through multiple importers could end up awaiting its own not-yet-settled `missingPeersOfChildren` promise — a deadlock. The flag let the resolver reuse that promise only once it had settled, and otherwise re-resolve children instead of awaiting. #12362 later moved this guard verbatim into `claimChildrenResolution` without neutralizing its timing-dependence.

### The fix

Drop the `.resolved` clause: reuse the owner's missing peers only when the owner is at the same or a deeper depth — a function of the dependency-graph structure rather than completion order. This is **strictly more conservative** than the original guard: a shallower owner's promise is now never reused (settled or not), so no unsettled promise is ever awaited and the [#5454](https://github.com/pnpm/pnpm/issues/5454) deadlock cannot return. The #5454 regression test (`installation on a workspace with many complex circular dependencies does not fail when auto install peers is on`) still passes.

### How to verify the analysis

- The race is visible by reading [`claimChildrenResolution`](https://github.com/pnpm/pnpm/blob/2dd79e372c/installing/deps-resolver/src/resolveDependencies.ts#L1137-L1153): the only run-to-run-variable input to the branch is `existing.missingPeersOfChildren.resolved`; everything else (`owner.depth`, `currentDepth`, `parentIds`) is structural.
- `.resolved` is set when the owner's children finish resolving (see [where it is assigned](https://github.com/pnpm/pnpm/blob/2dd79e372c/installing/deps-resolver/src/resolveDependencies.ts#L1023)), so its value at claim time depends on concurrent ordering.
- The existing peer/dedupe/cyclic suites still pass with the clause removed (`resolvePeers`, `cyclicPeerDeterminism`, `peerDependencies`, and the `peers`/`hoist`/`dedupe`/`transitive`/`autoInstallPeers` install tests), including the regressions from [#12286](https://github.com/pnpm/pnpm/pull/12286) and [#11999](https://github.com/pnpm/pnpm/issues/11999).

### Testing note

I was not able to add a failing-then-passing unit test. The race only manifests under real concurrent network I/O; the mock-registry test harness serializes resolution through the depth barrier ([`waitForPackageResolutionTurn`](https://github.com/pnpm/pnpm/blob/2dd79e372c/installing/deps-resolver/src/resolveDependencies.ts#L1075)) and produces deterministic output regardless of response timing, so it does not reproduce the flake. The fix was validated against a large real workspace: before, `dedupe --check` flipped between clean and "changes" across cold runs; after, 30/30 cold runs produced a byte-identical result. Guidance on an acceptable deterministic test (e.g. a scheduler-injection seam) would be welcome.


**Update:** test coverage added in b19c3f53e4. The mock-registry harness still can't reproduce the flake, but the changed line is testable directly. A unit test on `claimChildrenResolution` asserts a deeper consumer never reuses a strictly shallower owner's `missingPeersOfChildren` even when that promise has already settled — the run-to-run-variable input the dropped clause keyed on. It fails with the old clause restored and passes after. pacquet gets the parity version of the same scenario (shared `styled-jsx` whose optional `@babel/core` peer is provided by a sibling at a shallow depth but absent deeper), asserted stable across 16 fresh-`HashMap` rebuilds.
## Squash Commit Body

```text
claimChildrenResolution let a non-owner occurrence of a shared package reuse the
owner's missingPeersOfChildren when `existing.owner.depth >= currentDepth ||
existing.missingPeersOfChildren.resolved`. The second clause made reuse depend on
whether the owner's resolution had settled by claim time. Under concurrent
resolution that timing varies run to run, so a deeper consumer inherited the
owner's missing peers on some runs but not others — flipping an optional
transitive peer (e.g. `@babel/core`, reached via styled-jsx) in and out of a
package's resolved peer suffix and churning the lockfile, with intermittent
`pnpm dedupe --check` failures in CI.

Drop the `.resolved` clause: reuse only when the owner is at the same or a deeper
depth, a function of the dependency graph rather than completion order.

The `.resolved` flag was introduced in pnpm/pnpm#5467 (closing pnpm/pnpm#5454) to
avoid a deadlock where, with auto-install-peers in a workspace, a shared package
awaited its own not-yet-settled missingPeersOfChildren promise. Removing the
clause is strictly more conservative — a shallower owner's promise is never
reused, settled or not, so no unsettled promise is ever awaited and the deadlock
cannot return. The pnpm/pnpm#5454 regression test still passes, as do the peer,
dedupe, and cyclic suites. The deterministic owner selection from pnpm/pnpm#12362
made shared-package ownership order-independent but had moved this timing branch
in verbatim without neutralizing it.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. — pnpm-only. pacquet needs no change: it resolves a non-owner's children lazily and per-occurrence during peer resolution (`realize_children` in `pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs`), with no settled-promise timing gate, so it is deterministic by construction here.
- [x] Added a changeset.
- [x] Added or updated tests. — unit coverage for the changed line in both stacks (b19c3f53e4); see the testing note above for why this is a unit test rather than an e2e reproduction.

---
Written by an agent (Claude Code, claude-opus-4-8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-deterministic peer dependency resolution that could intermittently add or omit optional transitive peers, leading to lockfile churn and occasional CI failures. Peer inclusion is now deterministic across identical installs.

* **Tests**
  * Added regression coverage to verify deterministic optional transitive peer handling.
  * Added tests to ensure child resolution reuse rules behave correctly across different resolution depths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
