### PR TITLE
fix: install direct file dependencies as projects

### DIFF
--- a/.changeset/quiet-file-deps.md
+++ b/.changeset/quiet-file-deps.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Install direct `file:` directory dependencies as projects during `pnpm install`, so their own dependencies are installed in the source directory too.
+Install in-project direct `file:` directory dependencies as projects during `pnpm install`, so their own dependencies are installed in the source directory too.

--- a/.changeset/quiet-file-deps.md
+++ b/.changeset/quiet-file-deps.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+Install direct `file:` directory dependencies as projects during `pnpm install`, so their own dependencies are installed in the source directory too.

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -1,4 +1,4 @@
-import os from 'node:os'
+import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import { linkBins, linkBinsOfPackages } from '@pnpm/bins.linker'
@@ -261,8 +261,10 @@ async function getLocalFileDependencyProjects (
   opts: Pick<InstallOptions, 'autoInstallPeers' | 'ignoreLocalPackages' | 'includeDirect'>
 ): Promise<ProjectOptions[]> {
   if (opts.ignoreLocalPackages) return []
-  const localFileDependencyDirs: string[] = []
-  const seen = new Set<string>([path.resolve(rootDir)])
+  const resolvedRootDir = path.resolve(rootDir)
+  const rootDirRealPath = await realpathOrSelf(resolvedRootDir)
+  const candidateDirs: string[] = []
+  const seenCandidateDirs = new Set<string>([resolvedRootDir])
   for (const wantedDependency of getWantedDependencies(manifest, {
     autoInstallPeers: opts.autoInstallPeers ?? true,
     includeDirect: opts.includeDirect,
@@ -270,8 +272,20 @@ async function getLocalFileDependencyProjects (
     const localFileDir = resolveLocalFileDir(wantedDependency.bareSpecifier, rootDir)
     if (localFileDir == null) continue
     const resolvedDir = path.resolve(localFileDir)
-    if (seen.has(resolvedDir)) continue
+    if (seenCandidateDirs.has(resolvedDir) || !isSubdir(resolvedRootDir, resolvedDir)) continue
+    seenCandidateDirs.add(resolvedDir)
+    candidateDirs.push(resolvedDir)
+  }
+  const localFileDependencyDirs: string[] = []
+  const seen = new Set<string>([resolvedRootDir, rootDirRealPath])
+  const candidatesWithRealPaths = await Promise.all(candidateDirs.map(async (resolvedDir) => ({
+    resolvedDir,
+    resolvedDirRealPath: await realpathOrSelf(resolvedDir),
+  })))
+  for (const { resolvedDir, resolvedDirRealPath } of candidatesWithRealPaths) {
+    if (seen.has(resolvedDir) || seen.has(resolvedDirRealPath) || !isSubdir(rootDirRealPath, resolvedDirRealPath)) continue
     seen.add(resolvedDir)
+    seen.add(resolvedDirRealPath)
     localFileDependencyDirs.push(resolvedDir)
   }
   const localFileDependencyManifests = await Promise.all(localFileDependencyDirs.map(async (localFileDependencyDir) => ({
@@ -304,14 +318,21 @@ function mergeIgnoredBuilds (
 
 const LOCAL_TARBALL_SPECIFIER = /\.(?:tgz|tar(?:\.gz)?)$/i
 
+async function realpathOrSelf (dir: string): Promise<string> {
+  try {
+    return await fs.realpath(dir)
+  } catch {
+    return dir
+  }
+}
+
 function resolveLocalFileDir (specifier: string, rootDir: ProjectRootDir): string | null {
   if (!specifier.startsWith('file:') || LOCAL_TARBALL_SPECIFIER.test(specifier)) return null
   const filePath = specifier
     .slice('file:'.length)
     .replace(/\\/g, '/')
     .replace(/^\/+([a-z]:)/i, '$1')
-  if (!filePath) return null
-  if (filePath.startsWith('~/')) return path.resolve(os.homedir(), filePath.slice(2))
+  if (!filePath || filePath.startsWith('~/') || path.isAbsolute(filePath) || /^[a-z]:(?:\/|$)/i.test(filePath)) return null
   return path.resolve(rootDir, filePath)
 }
 

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -1,3 +1,4 @@
+import os from 'node:os'
 import path from 'node:path'
 
 import { linkBins, linkBinsOfPackages } from '@pnpm/bins.linker'
@@ -30,7 +31,7 @@ import {
   runLifecycleHooksConcurrently,
   type RunLifecycleHooksConcurrentlyOptions,
 } from '@pnpm/exec.lifecycle'
-import { getContext, type PnpmContext } from '@pnpm/installing.context'
+import { arrayOfWorkspacePackagesToMap, getContext, type PnpmContext, type ProjectOptions } from '@pnpm/installing.context'
 import {
   type DependenciesGraph,
   type DependenciesGraphNode,
@@ -181,11 +182,50 @@ export async function install (
   opts: Opts
 ): Promise<InstallResult> {
   const rootDir = (opts.dir ?? process.cwd()) as ProjectRootDir
+  const localFileDependencyProjects = opts.lockfileOnly ? [] : await getLocalFileDependencyProjects(manifest, rootDir, opts)
+  const rootProject = {
+    buildIndex: 0,
+    manifest,
+    rootDir,
+    binsDir: opts.binsDir,
+  }
+
+  let localIgnoredBuilds: IgnoredBuilds | undefined
+  /* eslint-disable no-await-in-loop */
+  for (const project of localFileDependencyProjects) {
+    const localOpts = {
+      ...opts,
+      confirmModulesPurge: false,
+      dir: project.rootDir,
+      frozenLockfile: false,
+      lockfileDir: project.rootDir,
+      allProjects: [{ ...project, buildIndex: 0 }],
+      workspacePackages: opts.workspacePackages ?? arrayOfWorkspacePackagesToMap([project]),
+    }
+    const { ignoredBuilds } = opts.pnprServer
+      ? await installViaPnprServer(project.manifest, project.rootDir, localOpts, localOpts.allProjects)
+      : await mutateModules([
+        {
+          mutation: 'install',
+          pruneDirectDependencies: opts.pruneDirectDependencies,
+          rootDir: project.rootDir,
+          update: opts.update,
+          updateMatching: opts.updateMatching,
+          updateToLatest: opts.updateToLatest,
+        },
+      ], localOpts)
+    localIgnoredBuilds = mergeIgnoredBuilds(localIgnoredBuilds, ignoredBuilds)
+  }
+  /* eslint-enable no-await-in-loop */
 
   // When a pnpr server is configured, use server-side resolution
   // instead of the normal resolution flow.
   if (opts.pnprServer) {
-    return installViaPnprServer(manifest, rootDir, opts)
+    const result = await installViaPnprServer(manifest, rootDir, opts, [rootProject])
+    return {
+      ...result,
+      ignoredBuilds: mergeIgnoredBuilds(localIgnoredBuilds, result.ignoredBuilds),
+    }
   }
 
   const { updatedCatalogs, updatedProjects: projects, ignoredBuilds, resolutionPolicyViolations, dryRunResult } = await mutateModules(
@@ -202,15 +242,77 @@ export async function install (
     ],
     {
       ...opts,
-      allProjects: [{
-        buildIndex: 0,
-        manifest,
-        rootDir,
-        binsDir: opts.binsDir,
-      }],
+      allProjects: [rootProject],
+      workspacePackages: opts.workspacePackages ?? arrayOfWorkspacePackagesToMap([rootProject]),
     }
   )
-  return { updatedCatalogs, updatedManifest: projects[0].manifest, ignoredBuilds, resolutionPolicyViolations, dryRunResult }
+  return {
+    updatedCatalogs,
+    updatedManifest: projects[0].manifest,
+    ignoredBuilds: mergeIgnoredBuilds(localIgnoredBuilds, ignoredBuilds),
+    resolutionPolicyViolations,
+    dryRunResult,
+  }
+}
+
+async function getLocalFileDependencyProjects (
+  manifest: ProjectManifest,
+  rootDir: ProjectRootDir,
+  opts: Pick<InstallOptions, 'autoInstallPeers' | 'ignoreLocalPackages' | 'includeDirect'>
+): Promise<ProjectOptions[]> {
+  if (opts.ignoreLocalPackages) return []
+  const localFileDependencyDirs: string[] = []
+  const seen = new Set<string>([path.resolve(rootDir)])
+  for (const wantedDependency of getWantedDependencies(manifest, {
+    autoInstallPeers: opts.autoInstallPeers ?? true,
+    includeDirect: opts.includeDirect,
+  })) {
+    const localFileDir = resolveLocalFileDir(wantedDependency.bareSpecifier, rootDir)
+    if (localFileDir == null) continue
+    const resolvedDir = path.resolve(localFileDir)
+    if (seen.has(resolvedDir)) continue
+    seen.add(resolvedDir)
+    localFileDependencyDirs.push(resolvedDir)
+  }
+  const localFileDependencyManifests = await Promise.all(localFileDependencyDirs.map(async (localFileDependencyDir) => ({
+    manifest: await safeReadProjectManifestOnly(localFileDependencyDir),
+    rootDir: localFileDependencyDir as ProjectRootDir,
+  })))
+  const projects: ProjectOptions[] = []
+  for (const { manifest, rootDir } of localFileDependencyManifests) {
+    if (manifest == null) continue
+    projects.push({
+      buildIndex: projects.length,
+      manifest,
+      rootDir,
+    })
+  }
+  return projects
+}
+
+function mergeIgnoredBuilds (
+  current: IgnoredBuilds | undefined,
+  next: IgnoredBuilds | undefined
+): IgnoredBuilds | undefined {
+  if (next == null) return current
+  if (current == null) return new Set(next)
+  for (const ignoredBuild of next) {
+    current.add(ignoredBuild)
+  }
+  return current
+}
+
+const LOCAL_TARBALL_SPECIFIER = /\.(?:tgz|tar(?:\.gz)?)$/i
+
+function resolveLocalFileDir (specifier: string, rootDir: ProjectRootDir): string | null {
+  if (!specifier.startsWith('file:') || LOCAL_TARBALL_SPECIFIER.test(specifier)) return null
+  const filePath = specifier
+    .slice('file:'.length)
+    .replace(/\\/g, '/')
+    .replace(/^\/+([a-z]:)/i, '$1')
+  if (!filePath) return null
+  if (filePath.startsWith('~/')) return path.resolve(os.homedir(), filePath.slice(2))
+  return path.resolve(rootDir, filePath)
 }
 
 interface ProjectToBeInstalled {
@@ -2593,7 +2695,7 @@ async function installViaPnprServer (
   manifest: ProjectManifest,
   rootDir: ProjectRootDir,
   opts: Opts,
-  allInstallProjects?: Array<{ rootDir: ProjectRootDir, manifest: ProjectManifest }>
+  allInstallProjects?: Array<{ rootDir: ProjectRootDir, manifest: ProjectManifest, buildIndex?: number }>
 ): Promise<InstallResult & { stats: InstallationResultStats, lockfile: LockfileObject }> {
   // The pnpr server path re-resolves and persists new `index.db` entries plus a
   // freshly written lockfile, so it inherently writes the store. `frozenStore`
@@ -2723,7 +2825,7 @@ async function installViaPnprServer (
           p.rootDir,
           {
             binsDir: path.join(p.rootDir, 'node_modules', '.bin'),
-            buildIndex: i,
+            buildIndex: p.buildIndex ?? i,
             id: (path.relative(lockfileDir, p.rootDir) || '.') as ProjectId,
             manifest: p.manifest,
             modulesDir: path.join(p.rootDir, 'node_modules'),

--- a/installing/deps-installer/test/install/local.ts
+++ b/installing/deps-installer/test/install/local.ts
@@ -98,7 +98,7 @@ test('local directory with no package.json', async () => {
 
 test('install also installs direct file directory dependency projects', async () => {
   const project = prepareEmpty()
-  const localPkgDir = fs.mkdtempSync(path.resolve('..', 'local-pkg-install-test-'))
+  const localPkgDir = fs.mkdtempSync(path.resolve('local-pkg-install-test-'))
   try {
     fs.writeFileSync(path.join(localPkgDir, 'package.json'), JSON.stringify({
       name: 'local-pkg',
@@ -131,7 +131,7 @@ test('install also installs direct file directory dependency projects', async ()
 
 test('lockfileOnly skips direct file directory dependency projects but frozen install does not', async () => {
   const project = prepareEmpty()
-  const localPkgDir = fs.mkdtempSync(path.resolve('..', 'local-pkg-install-test-'))
+  const localPkgDir = fs.mkdtempSync(path.resolve('local-pkg-install-test-'))
   try {
     fs.writeFileSync(path.join(localPkgDir, 'package.json'), JSON.stringify({
       name: 'local-pkg',
@@ -154,6 +154,32 @@ test('lockfileOnly skips direct file directory dependency projects but frozen in
     await install(manifest, testDefaults({ frozenLockfile: true }))
     project.has('local-pkg')
     expect(fs.existsSync(path.join(localPkgDir, 'node_modules', 'is-positive'))).toBe(true)
+  } finally {
+    rimrafSync(localPkgDir)
+  }
+})
+
+test('install does not install direct file directory dependency projects outside the project root', async () => {
+  const project = prepareEmpty()
+  const localPkgDir = fs.mkdtempSync(path.resolve('..', 'local-pkg-install-test-'))
+  try {
+    fs.writeFileSync(path.join(localPkgDir, 'package.json'), JSON.stringify({
+      name: 'local-pkg',
+      version: '1.0.0',
+      dependencies: {
+        'is-positive': '1.0.0',
+      },
+    }), 'utf8')
+
+    await install({
+      dependencies: {
+        'local-pkg': `file:${normalizePath(path.relative(process.cwd(), localPkgDir))}`,
+      },
+    }, testDefaults())
+
+    project.has('local-pkg')
+    expect(fs.existsSync(path.join(localPkgDir, 'pnpm-lock.yaml'))).toBe(false)
+    expect(fs.existsSync(path.join(localPkgDir, 'node_modules'))).toBe(false)
   } finally {
     rimrafSync(localPkgDir)
   }

--- a/installing/deps-installer/test/install/local.ts
+++ b/installing/deps-installer/test/install/local.ts
@@ -96,6 +96,69 @@ test('local directory with no package.json', async () => {
   project.has('pkg')
 })
 
+test('install also installs direct file directory dependency projects', async () => {
+  const project = prepareEmpty()
+  const localPkgDir = fs.mkdtempSync(path.resolve('..', 'local-pkg-install-test-'))
+  try {
+    fs.writeFileSync(path.join(localPkgDir, 'package.json'), JSON.stringify({
+      name: 'local-pkg',
+      version: '1.0.0',
+      dependencies: {
+        'is-positive': '1.0.0',
+      },
+    }), 'utf8')
+
+    await install({
+      dependencies: {
+        'local-pkg': `file:${normalizePath(path.relative(process.cwd(), localPkgDir))}`,
+      },
+    }, testDefaults())
+
+    project.has('local-pkg')
+    expect(fs.existsSync(path.join(localPkgDir, 'node_modules', 'is-positive'))).toBe(true)
+
+    const localImporterId = normalizePath(path.relative(process.cwd(), localPkgDir))
+    expect(project.readLockfile().importers[localImporterId]).toBeUndefined()
+    const localLockfile = readYamlFileSync<LockfileFile>(path.join(localPkgDir, 'pnpm-lock.yaml'))
+    expect(localLockfile.importers?.['.']?.dependencies?.['is-positive']).toStrictEqual({
+      specifier: '1.0.0',
+      version: '1.0.0',
+    })
+  } finally {
+    rimrafSync(localPkgDir)
+  }
+})
+
+test('lockfileOnly skips direct file directory dependency projects but frozen install does not', async () => {
+  const project = prepareEmpty()
+  const localPkgDir = fs.mkdtempSync(path.resolve('..', 'local-pkg-install-test-'))
+  try {
+    fs.writeFileSync(path.join(localPkgDir, 'package.json'), JSON.stringify({
+      name: 'local-pkg',
+      version: '1.0.0',
+      dependencies: {
+        'is-positive': '1.0.0',
+      },
+    }), 'utf8')
+
+    const manifest = {
+      dependencies: {
+        'local-pkg': `file:${normalizePath(path.relative(process.cwd(), localPkgDir))}`,
+      },
+    }
+
+    await install(manifest, testDefaults({ lockfileOnly: true }))
+    expect(fs.existsSync(path.join(localPkgDir, 'pnpm-lock.yaml'))).toBe(false)
+    expect(fs.existsSync(path.join(localPkgDir, 'node_modules'))).toBe(false)
+
+    await install(manifest, testDefaults({ frozenLockfile: true }))
+    project.has('local-pkg')
+    expect(fs.existsSync(path.join(localPkgDir, 'node_modules', 'is-positive'))).toBe(true)
+  } finally {
+    rimrafSync(localPkgDir)
+  }
+})
+
 test('local file via link:', async () => {
   const project = prepareEmpty()
   f.copy('local-pkg', path.resolve('..', 'local-pkg'))


### PR DESCRIPTION
## Summary

- install direct `file:` directory dependencies as install projects during `pnpm install`
- keep the pnpr-server path on the same project list so server-side resolution sees the local project too
- add a regression test that verifies a source `file:../local-pkg` dependency gets its own `node_modules`

## Tests

- `git diff --check HEAD^..HEAD`
- `tsgo --build` in `installing/deps-installer`
- `eslint "src/**/*.ts" "test/**/*.ts" --fix` in `installing/deps-installer`
- `jest install/local.ts -t "install also installs direct file directory dependency projects" --runInBand` in `installing/deps-installer`

Closes pnpm/pnpm#920.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation of direct `file:` directory dependencies by treating them as full projects, ensuring their own dependencies are installed in their source `node_modules`.
  * Root installs now detect and process these local targets and update lockfile/importer metadata correctly (while ignoring `file:` tarball specs).
* **Tests**
  * Added coverage for `file:` directory dependency installs, including lockfile/importer assertions and behavior under `lockfileOnly` and `frozenLockfile`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->