### PR TITLE
fix(version-policy): treat multiple exact-version excludes as equivalent to a single disjunction

### DIFF
--- a/.changeset/minimum-release-age-exclude-multi-entry.md
+++ b/.changeset/minimum-release-age-exclude-multi-entry.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.version-policy": patch
+"pnpm": patch
+---
+
+Fixed `minimumReleaseAgeExclude` and `trustPolicyExclude` so multiple exact-version entries for the same package behave the same as a single `||` disjunction entry. Previously only the first matching rule's versions were honored, so a config like `[form-data@4.0.6, form-data@2.5.6]` could still flag `form-data@2.5.6` as violating `minimumReleaseAge`, while `[form-data@4.0.6 || 2.5.6]` worked as expected [#12463](https://github.com/pnpm/pnpm/issues/12463).

--- a/config/version-policy/src/index.ts
+++ b/config/version-policy/src/index.ts
@@ -72,16 +72,25 @@ export function expandPackageVersionSpecs (specs: string[]): Set<string> {
 }
 
 function evaluateVersionPolicy (rules: VersionPolicyRule[], pkgName: string): boolean | string[] {
+  let matchedVersions: string[] | undefined
   for (const { nameMatcher, exactVersions } of rules) {
     if (!nameMatcher(pkgName)) {
       continue
     }
     if (exactVersions.length === 0) {
-      return true
+      return matchedVersions ?? true
     }
-    return exactVersions
+    if (matchedVersions == null) {
+      matchedVersions = [...exactVersions]
+    } else {
+      for (const version of exactVersions) {
+        if (!matchedVersions.includes(version)) {
+          matchedVersions.push(version)
+        }
+      }
+    }
   }
-  return false
+  return matchedVersions ?? false
 }
 
 interface VersionPolicyRule {

--- a/config/version-policy/src/index.ts
+++ b/config/version-policy/src/index.ts
@@ -73,6 +73,7 @@ export function expandPackageVersionSpecs (specs: string[]): Set<string> {
 
 function evaluateVersionPolicy (rules: VersionPolicyRule[], pkgName: string): boolean | string[] {
   let matchedVersions: string[] | undefined
+  let seen: Set<string> | undefined
   for (const { nameMatcher, exactVersions } of rules) {
     if (!nameMatcher(pkgName)) {
       continue
@@ -81,12 +82,13 @@ function evaluateVersionPolicy (rules: VersionPolicyRule[], pkgName: string): bo
       return matchedVersions ?? true
     }
     if (matchedVersions == null) {
-      matchedVersions = [...exactVersions]
-    } else {
-      for (const version of exactVersions) {
-        if (!matchedVersions.includes(version)) {
-          matchedVersions.push(version)
-        }
+      matchedVersions = []
+      seen = new Set()
+    }
+    for (const version of exactVersions) {
+      if (!seen!.has(version)) {
+        seen!.add(version)
+        matchedVersions.push(version)
       }
     }
   }

--- a/config/version-policy/test/index.ts
+++ b/config/version-policy/test/index.ts
@@ -65,22 +65,14 @@ test('createPackageVersionPolicy()', () => {
     expect(match('form-data')).toStrictEqual(['4.0.6'])
   }
   {
-    // Once an exact-version rule has matched for the package, a later
-    // bare-name rule with the same name doesn't widen the policy to
-    // every version — the accumulated exact list wins.
     const match = createPackageVersionPolicy(['axios@1.12.2', 'axios'])
     expect(match('axios')).toStrictEqual(['1.12.2'])
   }
   {
-    // First-match precedence for bare-vs-exact: a bare-name rule
-    // listed first keeps its `true` (every version) semantics; later
-    // exact entries for the same name don't narrow it.
     const match = createPackageVersionPolicy(['axios', 'axios@1.12.2'])
     expect(match('axios')).toBe(true)
   }
   {
-    // Wildcard listed after an exact rule must not silently widen the
-    // exact-version exclusion to every version of the package.
     const match = createPackageVersionPolicy(['axios@1.12.2', 'ax*'])
     expect(match('axios')).toStrictEqual(['1.12.2'])
   }

--- a/config/version-policy/test/index.ts
+++ b/config/version-policy/test/index.ts
@@ -52,6 +52,42 @@ test('createPackageVersionPolicy()', () => {
     const match = createPackageVersionPolicy(['pkg@1.0.0||1.0.1  ||  1.0.2'])
     expect(match('pkg')).toStrictEqual(['1.0.0', '1.0.1', '1.0.2'])
   }
+  {
+    const match = createPackageVersionPolicy(['form-data@4.0.6', 'form-data@2.5.6'])
+    expect(match('form-data')).toStrictEqual(['4.0.6', '2.5.6'])
+  }
+  {
+    const match = createPackageVersionPolicy(['form-data@4.0.6', 'form-data@2.5.6 || 2.5.7'])
+    expect(match('form-data')).toStrictEqual(['4.0.6', '2.5.6', '2.5.7'])
+  }
+  {
+    const match = createPackageVersionPolicy(['form-data@4.0.6', 'form-data@4.0.6'])
+    expect(match('form-data')).toStrictEqual(['4.0.6'])
+  }
+  {
+    // Once an exact-version rule has matched for the package, a later
+    // bare-name rule with the same name doesn't widen the policy to
+    // every version — the accumulated exact list wins.
+    const match = createPackageVersionPolicy(['axios@1.12.2', 'axios'])
+    expect(match('axios')).toStrictEqual(['1.12.2'])
+  }
+  {
+    // First-match precedence for bare-vs-exact: a bare-name rule
+    // listed first keeps its `true` (every version) semantics; later
+    // exact entries for the same name don't narrow it.
+    const match = createPackageVersionPolicy(['axios', 'axios@1.12.2'])
+    expect(match('axios')).toBe(true)
+  }
+  {
+    // Wildcard listed after an exact rule must not silently widen the
+    // exact-version exclusion to every version of the package.
+    const match = createPackageVersionPolicy(['axios@1.12.2', 'ax*'])
+    expect(match('axios')).toStrictEqual(['1.12.2'])
+  }
+  {
+    const match = createPackageVersionPolicy(['ax*', 'axios@1.12.2'])
+    expect(match('axios')).toBe(true)
+  }
 })
 
 test('createPackageVersionPolicyOrThrow() rewraps parser errors with INVALID_<KEY>', () => {

--- a/pacquet/crates/config/src/version_policy.rs
+++ b/pacquet/crates/config/src/version_policy.rs
@@ -158,26 +158,26 @@ impl PackageVersionPolicy {
     /// when no rule matched.
     #[must_use]
     pub fn matches(&self, pkg_name: &str) -> PolicyMatch {
-        let mut merged: Option<Vec<String>> = None;
+        let mut merged: Option<(Vec<String>, HashSet<String>)> = None;
         for rule in &self.rules {
             if !rule.name_matcher.matches(pkg_name) {
                 continue;
             }
             if rule.exact_versions.is_empty() {
                 return match merged {
-                    Some(versions) => PolicyMatch::ExactVersions(versions),
+                    Some((versions, _)) => PolicyMatch::ExactVersions(versions),
                     None => PolicyMatch::AnyVersion,
                 };
             }
-            let acc = merged.get_or_insert_with(Vec::new);
+            let (acc, seen) = merged.get_or_insert_with(|| (Vec::new(), HashSet::new()));
             for version in &rule.exact_versions {
-                if !acc.iter().any(|v| v == version) {
+                if seen.insert(version.clone()) {
                     acc.push(version.clone());
                 }
             }
         }
         match merged {
-            Some(versions) => PolicyMatch::ExactVersions(versions),
+            Some((versions, _)) => PolicyMatch::ExactVersions(versions),
             None => PolicyMatch::No,
         }
     }

--- a/pacquet/crates/config/src/version_policy.rs
+++ b/pacquet/crates/config/src/version_policy.rs
@@ -112,8 +112,12 @@ pub enum PolicyMatch {
 
 /// Matcher-based version policy built from a list of
 /// `<name-pattern>[@<version>||<version>...]` rules. Rules are walked
-/// in order; the first whose name matcher accepts the input package
-/// name wins. Mirrors upstream's [`createPackageVersionPolicy`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/version-policy/src/index.ts#L6-L13).
+/// in source order: consecutive matching `name@version[...]` rules
+/// have their version lists merged in source order with duplicates
+/// removed, and a bare-name (or wildcard) match terminates the walk —
+/// returning `AnyVersion` if no exact versions were accumulated, or
+/// the accumulated `ExactVersions` otherwise. Mirrors upstream's
+/// [`createPackageVersionPolicy`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/version-policy/src/index.ts#L6-L13).
 ///
 /// Used by `minimumReleaseAgeExclude` and `trustPolicyExclude`, both
 /// of which need wildcard name patterns (`is-*`, `@scope/*`) AND
@@ -143,23 +147,39 @@ struct VersionPolicyRule {
 }
 
 impl PackageVersionPolicy {
-    /// Evaluate the policy against a package name. Returns the
-    /// matching rule's payload (`AnyVersion` for a bare-name rule,
-    /// `ExactVersions` for `name@versions...`), or `PolicyMatch::No`
+    /// Evaluate the policy against a package name. Walks rules in
+    /// source order, merging consecutive `name@version[...]` matches
+    /// (deduplicated). A bare-name (or wildcard) match short-circuits
+    /// the walk and returns the accumulated `ExactVersions` if any
+    /// were collected, or `AnyVersion` otherwise — first-match
+    /// precedence between exact and broader rules so a wildcard
+    /// listed after an exact-version rule never silently widens an
+    /// exclusion to every version of the package. `PolicyMatch::No`
     /// when no rule matched.
     #[must_use]
     pub fn matches(&self, pkg_name: &str) -> PolicyMatch {
+        let mut merged: Option<Vec<String>> = None;
         for rule in &self.rules {
             if !rule.name_matcher.matches(pkg_name) {
                 continue;
             }
-            return if rule.exact_versions.is_empty() {
-                PolicyMatch::AnyVersion
-            } else {
-                PolicyMatch::ExactVersions(rule.exact_versions.clone())
-            };
+            if rule.exact_versions.is_empty() {
+                return match merged {
+                    Some(versions) => PolicyMatch::ExactVersions(versions),
+                    None => PolicyMatch::AnyVersion,
+                };
+            }
+            let acc = merged.get_or_insert_with(Vec::new);
+            for version in &rule.exact_versions {
+                if !acc.iter().any(|v| v == version) {
+                    acc.push(version.clone());
+                }
+            }
         }
-        PolicyMatch::No
+        match merged {
+            Some(versions) => PolicyMatch::ExactVersions(versions),
+            None => PolicyMatch::No,
+        }
     }
 }
 

--- a/pacquet/crates/config/src/version_policy.rs
+++ b/pacquet/crates/config/src/version_policy.rs
@@ -111,12 +111,9 @@ pub enum PolicyMatch {
 }
 
 /// Matcher-based version policy built from a list of
-/// `<name-pattern>[@<version>||<version>...]` rules. Rules are walked
-/// in source order: consecutive matching `name@version[...]` rules
-/// have their version lists merged in source order with duplicates
-/// removed, and a bare-name (or wildcard) match terminates the walk —
-/// returning `AnyVersion` if no exact versions were accumulated, or
-/// the accumulated `ExactVersions` otherwise. Mirrors upstream's
+/// `<name-pattern>[@<version>||<version>...]` rules. See
+/// [`PackageVersionPolicy::matches`] for the evaluation semantics.
+/// Mirrors upstream's
 /// [`createPackageVersionPolicy`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/version-policy/src/index.ts#L6-L13).
 ///
 /// Used by `minimumReleaseAgeExclude` and `trustPolicyExclude`, both

--- a/pacquet/crates/config/src/version_policy.rs
+++ b/pacquet/crates/config/src/version_policy.rs
@@ -144,15 +144,13 @@ struct VersionPolicyRule {
 }
 
 impl PackageVersionPolicy {
-    /// Evaluate the policy against a package name. Walks rules in
-    /// source order, merging consecutive `name@version[...]` matches
-    /// (deduplicated). A bare-name (or wildcard) match short-circuits
-    /// the walk and returns the accumulated `ExactVersions` if any
-    /// were collected, or `AnyVersion` otherwise — first-match
-    /// precedence between exact and broader rules so a wildcard
-    /// listed after an exact-version rule never silently widens an
-    /// exclusion to every version of the package. `PolicyMatch::No`
-    /// when no rule matched.
+    /// Evaluate the policy against a package name, merging the exact
+    /// versions of all matching `name@version[...]` rules.
+    ///
+    /// A bare-name or wildcard rule matches every version, but never
+    /// widens exact versions already accumulated from earlier rules: a
+    /// wildcard listed after an exact-version rule does not silently
+    /// turn the exclusion into every version of the package.
     #[must_use]
     pub fn matches(&self, pkg_name: &str) -> PolicyMatch {
         let mut merged: Option<(Vec<String>, HashSet<String>)> = None;

--- a/pacquet/crates/config/src/version_policy/tests.rs
+++ b/pacquet/crates/config/src/version_policy/tests.rs
@@ -116,11 +116,75 @@ fn create_policy_scoped_bare_name_returns_any_version() {
 }
 
 #[test]
-fn create_policy_first_matching_rule_wins() {
+fn create_policy_distinct_name_rules() {
     let policy = create_package_version_policy(["axios@1.12.2", "lodash@4.17.21", "is-*"]).unwrap();
     assert_eq!(policy.matches("axios"), PolicyMatch::ExactVersions(vec!["1.12.2".to_string()]));
     assert_eq!(policy.matches("lodash"), PolicyMatch::ExactVersions(vec!["4.17.21".to_string()]));
     assert_eq!(policy.matches("is-odd"), PolicyMatch::AnyVersion);
+}
+
+#[test]
+fn create_policy_multiple_exact_version_rules_for_same_name_merge() {
+    // Regression test for pnpm/pnpm#12463: two separate exact-version
+    // entries for the same package must behave the same as a single
+    // disjunction entry containing the same versions.
+    let policy = create_package_version_policy(["form-data@4.0.6", "form-data@2.5.6"]).unwrap();
+    assert_eq!(
+        policy.matches("form-data"),
+        PolicyMatch::ExactVersions(vec!["4.0.6".to_string(), "2.5.6".to_string()]),
+    );
+}
+
+#[test]
+fn create_policy_merges_exact_versions_and_unions_for_same_name() {
+    let policy =
+        create_package_version_policy(["form-data@4.0.6", "form-data@2.5.6 || 2.5.7"]).unwrap();
+    assert_eq!(
+        policy.matches("form-data"),
+        PolicyMatch::ExactVersions(vec![
+            "4.0.6".to_string(),
+            "2.5.6".to_string(),
+            "2.5.7".to_string(),
+        ]),
+    );
+}
+
+#[test]
+fn create_policy_deduplicates_repeated_versions_across_rules() {
+    let policy = create_package_version_policy(["form-data@4.0.6", "form-data@4.0.6"]).unwrap();
+    assert_eq!(policy.matches("form-data"), PolicyMatch::ExactVersions(vec!["4.0.6".to_string()]),);
+}
+
+#[test]
+fn create_policy_bare_rule_after_exact_keeps_exact_versions() {
+    // Once an exact-version rule has matched, a later bare-name rule
+    // with the same name must not widen the policy to every version —
+    // a wildcard listed after an exact rule would otherwise silently
+    // bypass the version restriction.
+    let policy = create_package_version_policy(["axios@1.12.2", "axios"]).unwrap();
+    assert_eq!(policy.matches("axios"), PolicyMatch::ExactVersions(vec!["1.12.2".to_string()]));
+}
+
+#[test]
+fn create_policy_bare_rule_listed_first_wins_over_later_exact() {
+    // First-match precedence between bare-name and exact-version
+    // rules: an `AnyVersion` rule listed first keeps its `true`
+    // semantics; a later exact entry for the same name does not
+    // narrow it.
+    let policy = create_package_version_policy(["axios", "axios@1.12.2"]).unwrap();
+    assert_eq!(policy.matches("axios"), PolicyMatch::AnyVersion);
+}
+
+#[test]
+fn create_policy_wildcard_after_exact_keeps_exact_versions() {
+    let policy = create_package_version_policy(["axios@1.12.2", "ax*"]).unwrap();
+    assert_eq!(policy.matches("axios"), PolicyMatch::ExactVersions(vec!["1.12.2".to_string()]));
+}
+
+#[test]
+fn create_policy_wildcard_listed_first_wins_over_later_exact() {
+    let policy = create_package_version_policy(["ax*", "axios@1.12.2"]).unwrap();
+    assert_eq!(policy.matches("axios"), PolicyMatch::AnyVersion);
 }
 
 #[test]

--- a/pacquet/crates/config/src/version_policy/tests.rs
+++ b/pacquet/crates/config/src/version_policy/tests.rs
@@ -152,7 +152,7 @@ fn create_policy_merges_exact_versions_and_unions_for_same_name() {
 #[test]
 fn create_policy_deduplicates_repeated_versions_across_rules() {
     let policy = create_package_version_policy(["form-data@4.0.6", "form-data@4.0.6"]).unwrap();
-    assert_eq!(policy.matches("form-data"), PolicyMatch::ExactVersions(vec!["4.0.6".to_string()]),);
+    assert_eq!(policy.matches("form-data"), PolicyMatch::ExactVersions(vec!["4.0.6".to_string()]));
 }
 
 #[test]

--- a/pacquet/crates/config/src/version_policy/tests.rs
+++ b/pacquet/crates/config/src/version_policy/tests.rs
@@ -125,9 +125,6 @@ fn create_policy_distinct_name_rules() {
 
 #[test]
 fn create_policy_multiple_exact_version_rules_for_same_name_merge() {
-    // Regression test for pnpm/pnpm#12463: two separate exact-version
-    // entries for the same package must behave the same as a single
-    // disjunction entry containing the same versions.
     let policy = create_package_version_policy(["form-data@4.0.6", "form-data@2.5.6"]).unwrap();
     assert_eq!(
         policy.matches("form-data"),
@@ -157,20 +154,12 @@ fn create_policy_deduplicates_repeated_versions_across_rules() {
 
 #[test]
 fn create_policy_bare_rule_after_exact_keeps_exact_versions() {
-    // Once an exact-version rule has matched, a later bare-name rule
-    // with the same name must not widen the policy to every version —
-    // a wildcard listed after an exact rule would otherwise silently
-    // bypass the version restriction.
     let policy = create_package_version_policy(["axios@1.12.2", "axios"]).unwrap();
     assert_eq!(policy.matches("axios"), PolicyMatch::ExactVersions(vec!["1.12.2".to_string()]));
 }
 
 #[test]
 fn create_policy_bare_rule_listed_first_wins_over_later_exact() {
-    // First-match precedence between bare-name and exact-version
-    // rules: an `AnyVersion` rule listed first keeps its `true`
-    // semantics; a later exact entry for the same name does not
-    // narrow it.
     let policy = create_package_version_policy(["axios", "axios@1.12.2"]).unwrap();
     assert_eq!(policy.matches("axios"), PolicyMatch::AnyVersion);
 }


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#12463.

`minimumReleaseAgeExclude` (and `trustPolicyExclude`) silently ignored every rule after the first match for a given package, so two separate exact-version entries like `[form-data@4.0.6, form-data@2.5.6]` could still trip the policy for the second version while `[form-data@4.0.6 || 2.5.6]` (a single disjunction entry) worked. That made list semantics depend on whether the user happened to merge versions into one `||` selector, which is surprising and unsafe for supply-chain exclusion lists.

Now consecutive `name@version[...]` rules matching the same package have their version lists merged in source order with duplicates removed. A bare-name or wildcard match still terminates the walk, and first-match precedence is preserved between bare and exact rules:

- A wildcard listed **after** an exact-version rule no longer silently widens the exclusion to every version of the package — the accumulated `ExactVersions` win.
- A bare-name rule listed **first** keeps its existing `AnyVersion` (every version) semantics; later exact entries for the same name do not narrow it.

The same change lands in the pacquet (Rust) port so both stacks stay in sync.

## Squash Commit Body

```text
fix(version-policy): treat multiple exact-version excludes as equivalent to a single disjunction

`minimumReleaseAgeExclude` (and `trustPolicyExclude`) ignored every
rule after the first match for a given package, so two separate
exact-version entries like `[form-data@4.0.6, form-data@2.5.6]` could
still trip the policy for the second version while
`[form-data@4.0.6 || 2.5.6]` (a single disjunction entry) worked.
That made list semantics depend on whether the user happened to merge
versions into one `||` selector, which is surprising and unsafe for
supply-chain exclusion lists.

Walk every matching rule and merge consecutive `name@version[...]`
matches in source order with duplicates removed. A bare-name or
wildcard match still terminates the walk, with first-match precedence
between bare and exact rules: a wildcard listed after an
exact-version rule no longer silently widens the exclusion to every
version of the package, while a bare-name rule listed first keeps
its existing `AnyVersion` semantics. Apply the same change to the
pacquet port so both stacks stay in sync.

Closes pnpm/pnpm#12463
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-4-7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version-policy exclusions so multiple exact-version entries for the same package are merged and deduplicated correctly, with consistent precedence between exact, bare-name, and wildcard rules.
* **Tests**
  * Expanded version-policy coverage for multi-rule exact matching, `||` union combinations, deduplication of repeated versions, and precedence scenarios.
* **Documentation**
  * Updated version-policy documentation to match the new match-merging and rule-precedence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->