### PR TITLE
fix(network.fetch): reject non-retryable errors instead of throwing in the retry callback

### DIFF
--- a/.changeset/fetch-no-retry-reject.md
+++ b/.changeset/fetch-no-retry-reject.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/network.fetch": patch
+"pnpm": patch
+---
+
+Fixed `pnpm` hanging (and crashing with an unhandled promise rejection) when a non-retryable network error such as `SELF_SIGNED_CERT_IN_CHAIN` occurs while fetching from a registry. The error is now rejected through the returned promise instead of being thrown inside the detached retry callback.

--- a/network/fetch/src/fetch.ts
+++ b/network/fetch/src/fetch.ts
@@ -64,10 +64,6 @@ export async function fetch (url: RequestInfo, opts: RequestInit = {}): Promise<
             typeof errorCode === 'string' &&
             NO_RETRY_ERROR_CODES.has(errorCode)
           ) {
-            // Reject the governing promise instead of throwing. `op.attempt`'s
-            // callback runs detached, so a throw here never reaches the outer
-            // promise: it leaves it forever unsettled and surfaces as an
-            // unhandled rejection. This mirrors the retries-exhausted path below.
             reject(error)
             return
           }

--- a/network/fetch/src/fetch.ts
+++ b/network/fetch/src/fetch.ts
@@ -64,7 +64,12 @@ export async function fetch (url: RequestInfo, opts: RequestInit = {}): Promise<
             typeof errorCode === 'string' &&
             NO_RETRY_ERROR_CODES.has(errorCode)
           ) {
-            throw error
+            // Reject the governing promise instead of throwing. `op.attempt`'s
+            // callback runs detached, so a throw here never reaches the outer
+            // promise: it leaves it forever unsettled and surfaces as an
+            // unhandled rejection. This mirrors the retries-exhausted path below.
+            reject(error)
+            return
           }
           const retryTimeout = op.retry(err)
           if (retryTimeout === false) {

--- a/network/fetch/test/fetch.test.ts
+++ b/network/fetch/test/fetch.test.ts
@@ -1,0 +1,45 @@
+/// <reference path="../../../__typings__/index.d.ts"/>
+import { expect, test } from '@jest/globals'
+import { fetch } from '@pnpm/network.fetch'
+import { type Dispatcher, getGlobalDispatcher, MockAgent, setGlobalDispatcher } from 'undici'
+
+// Regression test: a non-retryable error code (e.g. a self-signed certificate)
+// must reject the returned promise, not leave it permanently unsettled. The
+// previous implementation threw inside the detached retry callback, so the
+// promise never settled (the caller hung) and an unhandled rejection crashed
+// the process.
+test('fetch rejects, and does not hang, on a non-retryable error code', async () => {
+  const originalDispatcher: Dispatcher = getGlobalDispatcher()
+  const mockAgent = new MockAgent()
+  mockAgent.disableNetConnect()
+  setGlobalDispatcher(mockAgent)
+  try {
+    const tlsError = Object.assign(
+      new Error('self signed certificate in certificate chain'),
+      { code: 'SELF_SIGNED_CERT_IN_CHAIN' }
+    )
+    mockAgent
+      .get('http://registry.pnpm.io')
+      .intercept({ path: '/is-positive', method: 'GET' })
+      .replyWithError(tlsError)
+
+    const TIMEOUT = Symbol('timeout')
+    let timer: NodeJS.Timeout | undefined
+    const outcome = await Promise.race([
+      fetch('http://registry.pnpm.io/is-positive', { retry: { retries: 0 } })
+        .then(() => 'resolved', (err: unknown) => err),
+      new Promise<typeof TIMEOUT>((resolve) => {
+        timer = setTimeout(() => resolve(TIMEOUT), 2000)
+      }),
+    ])
+    if (timer) clearTimeout(timer)
+
+    expect(outcome).not.toBe(TIMEOUT) // would hang (TIMEOUT) before the fix
+    expect(outcome).not.toBe('resolved')
+    const err = outcome as Error & { code?: string, cause?: { code?: string } }
+    expect(err.code ?? err.cause?.code).toBe('SELF_SIGNED_CERT_IN_CHAIN')
+  } finally {
+    await mockAgent.close()
+    setGlobalDispatcher(originalDispatcher)
+  }
+})

--- a/network/fetch/test/fetch.test.ts
+++ b/network/fetch/test/fetch.test.ts
@@ -3,11 +3,6 @@ import { expect, test } from '@jest/globals'
 import { fetch } from '@pnpm/network.fetch'
 import { type Dispatcher, getGlobalDispatcher, MockAgent, setGlobalDispatcher } from 'undici'
 
-// Regression test: a non-retryable error code (e.g. a self-signed certificate)
-// must reject the returned promise, not leave it permanently unsettled. The
-// previous implementation threw inside the detached retry callback, so the
-// promise never settled (the caller hung) and an unhandled rejection crashed
-// the process.
 test('fetch rejects, and does not hang, on a non-retryable error code', async () => {
   const originalDispatcher: Dispatcher = getGlobalDispatcher()
   const mockAgent = new MockAgent()
@@ -34,7 +29,7 @@ test('fetch rejects, and does not hang, on a non-retryable error code', async ()
     ])
     if (timer) clearTimeout(timer)
 
-    expect(outcome).not.toBe(TIMEOUT) // would hang (TIMEOUT) before the fix
+    expect(outcome).not.toBe(TIMEOUT)
     expect(outcome).not.toBe('resolved')
     const err = outcome as Error & { code?: string, cause?: { code?: string } }
     expect(err.code ?? err.cause?.code).toBe('SELF_SIGNED_CERT_IN_CHAIN')


### PR DESCRIPTION
## Summary

When a non-retryable network error occurs (one of the codes in `NO_RETRY_ERROR_CODES`: `SELF_SIGNED_CERT_IN_CHAIN`, `ERR_OSSL_PEM_NO_START_LINE`), `fetch()` in `@pnpm/network.fetch` used to re-`throw` the error from inside the `op.attempt(async …)` callback.

That callback runs detached from the governing `new Promise`, so the throw never reaches `reject`: the promise is left permanently unsettled (the caller hangs) and the rejected async callback surfaces as an unhandled promise rejection, crashing the process on modern Node.

This is hit by users behind a corporate proxy/registry that has a self-signed certificate in the chain, where pnpm should instead fail fast with a clear error.

The fix rejects the governing promise (`reject(error); return`) instead of throwing, mirroring the retries-exhausted path right below it. Callers now receive the error normally.

## Squash Commit Body

```text
fetch() in @pnpm/network.fetch re-threw non-retryable errors (e.g.
SELF_SIGNED_CERT_IN_CHAIN) from inside the op.attempt() retry callback.
That callback is detached from the governing `new Promise`, so the throw
never reached `reject`: the promise was left forever unsettled (caller
hangs) and the rejected async callback surfaced as an unhandled promise
rejection, crashing the process on modern Node.

Reject the governing promise instead of throwing, mirroring the
retries-exhausted path right below it, so callers receive the error
normally and fail fast.

Adds a regression test that simulates a SELF_SIGNED_CERT_IN_CHAIN failure
via undici's MockAgent and asserts fetch() rejects with that code (and
does not hang); without the fix the promise never settles and the test
times out.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  <!-- TS-only: fetch internals are not part of pacquet's command surface. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-8).
