### PR TITLE
fix(patching.commands): keep the dependency alias when patching a single git-hosted version

### DIFF
--- a/.changeset/patch-git-hosted-alias.md
+++ b/.changeset/patch-git-hosted-alias.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/patching.commands": patch
+"pnpm": patch
+---
+
+Fixed `pnpm patch` dropping the package name (and leaking internal option fields) when the patched dependency resolves to a single git-hosted version.

--- a/pnpm11/patching/commands/src/getPatchedDependency.ts
+++ b/pnpm11/patching/commands/src/getPatchedDependency.ts
@@ -60,7 +60,7 @@ export async function getPatchedDependency (rawDependency: string, opts: GetPatc
     const preferred = preferredVersions[0]
     if (preferred.gitTarballUrl) {
       return {
-        ...opts,
+        ...dep,
         applyToAll: false,
         bareSpecifier: preferred.gitTarballUrl,
       }

--- a/pnpm11/patching/commands/test/getPatchedDependency.test.ts
+++ b/pnpm11/patching/commands/test/getPatchedDependency.test.ts
@@ -1,0 +1,49 @@
+/// <reference path="../../../__typings__/index.d.ts"/>
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import { writeCurrentLockfile } from '@pnpm/lockfile.fs'
+import { temporaryDirectory } from 'tempy'
+
+import { getPatchedDependency } from '../src/getPatchedDependency.js'
+
+// Regression test: when the only installed version of the patched package is
+// git-hosted, getPatchedDependency must return the parsed dependency (which
+// carries `alias`), not the options object. It previously spread `opts`, which
+// dropped the package name and leaked unrelated option fields into the result.
+test('getPatchedDependency preserves the alias for a single git-hosted version', async () => {
+  const lockfileDir = fs.realpathSync(temporaryDirectory())
+  const gitTarballUrl =
+    'https://codeload.github.com/example/is-positive/tar.gz/0000000000000000000000000000000000000000'
+  // Assigned to a variable first so the object literal is not subject to excess
+  // property checks against LockfileObject's branded key types (matches the
+  // pattern in lockfile/fs/test/read.test.ts).
+  const lockfile = {
+    importers: {
+      '.': {
+        dependencies: { 'is-positive': gitTarballUrl },
+        specifiers: { 'is-positive': gitTarballUrl },
+      },
+    },
+    lockfileVersion: '9.0',
+    packages: {
+      'is-positive@1.0.0': {
+        version: '1.0.0',
+        resolution: { tarball: gitTarballUrl },
+      },
+    },
+    registry: 'https://registry.npmjs.org',
+  }
+  await writeCurrentLockfile(path.join(lockfileDir, 'node_modules', '.pnpm'), lockfile)
+
+  const result = await getPatchedDependency('is-positive', {
+    lockfileDir,
+    modulesDir: 'node_modules',
+    virtualStoreDir: path.join(lockfileDir, 'node_modules', '.pnpm'),
+  })
+
+  expect(result.alias).toBe('is-positive')
+  expect(result.bareSpecifier).toBe(gitTarballUrl)
+  expect(result.applyToAll).toBe(false)
+})


### PR DESCRIPTION
## What

In `getPatchedDependency`, the branch handling a single installed version that is git-hosted returns `{ ...opts, … }` instead of `{ ...dep, … }`. `opts` is `GetPatchedDependencyOptions` (`lockfileDir`, `virtualStoreDir`, `modulesDir`), so the result loses the parsed dependency's `alias` (the package name) and leaks unrelated option fields. The other two return branches in the same function correctly spread `dep`.

As a result, `pnpm patch <pkg>` for a package whose only matching version is git-hosted produces a result without the package name.

## Fix

Spread `dep` (the parsed wanted dependency) instead of `opts`, matching the sibling branches.

## Test

Added `patching/commands/test/getPatchedDependency.test.ts`: builds a current lockfile with a single git-hosted version and asserts the result preserves `alias`. Without the fix `alias` is `undefined`.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm patch` command for git-hosted dependencies to properly preserve package names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->