### PR TITLE
feat(pacquet): purge node_modules on layout changes matching validateModules

### DIFF
--- a/.changeset/pacquet-layout-mismatch-purge.md
+++ b/.changeset/pacquet-layout-mismatch-purge.md
@@ -1,6 +1,0 @@
----
-"pacquet-package-manager": patch
-"pnpm": patch
----
-
-Pacquet will now selectively purge stale `node_modules` content rather than deleting the entire directory when a layout mismatch is detected, matching pnpm's behavior. Additionally, it now enforces that the module directory being deleted is safely contained within the workspace root.

--- a/.changeset/pacquet-layout-mismatch-purge.md
+++ b/.changeset/pacquet-layout-mismatch-purge.md
@@ -1,0 +1,6 @@
+---
+"pacquet-package-manager": patch
+"pnpm": patch
+---
+
+Pacquet will now selectively purge stale `node_modules` content rather than deleting the entire directory when a layout mismatch is detected, matching pnpm's behavior. Additionally, it now enforces that the module directory being deleted is safely contained within the workspace root.

--- a/pacquet/crates/modules-yaml/src/lib.rs
+++ b/pacquet/crates/modules-yaml/src/lib.rs
@@ -256,6 +256,11 @@ pub struct ModulesLayout {
     pub registries: Option<BTreeMap<String, String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub public_hoist_pattern: Option<Vec<String>>,
+    /// Legacy: the v5-era flag used to mean "hoist everything publicly."
+    /// Needed by [`read_modules_layout`] to apply the same normalization as
+    /// [`read_modules_manifest`] and avoid false-positive layout mismatches.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shamefully_hoist: Option<bool>,
     #[serde(default)]
     pub skipped: Vec<String>,
     #[serde(default)]
@@ -456,6 +461,17 @@ where
             ReadModulesError::ParseYaml { path: manifest_path.clone(), source: Box::new(source) }
         })?;
     let Some(mut manifest) = parsed else { return Ok(None) };
+
+    // Mirror apply_legacy_shamefully_hoist: when the on-disk manifest still
+    // uses the old `shamefullyHoist` flag without a `publicHoistPattern`,
+    // synthesize the equivalent pattern so the consistency check matches what
+    // `read_modules_manifest` would produce on a full read.
+    if let Some(shamefully_hoist) = manifest.shamefully_hoist {
+        if manifest.public_hoist_pattern.is_none() {
+            manifest.public_hoist_pattern =
+                Some(if shamefully_hoist { vec!["*".to_string()] } else { Vec::new() });
+        }
+    }
 
     let stored_path = Path::new(&manifest.virtual_store_dir);
     let resolved = match (manifest.virtual_store_dir.is_empty(), stored_path.is_absolute()) {

--- a/pacquet/crates/modules-yaml/src/lib.rs
+++ b/pacquet/crates/modules-yaml/src/lib.rs
@@ -466,11 +466,11 @@ where
     // uses the old `shamefullyHoist` flag without a `publicHoistPattern`,
     // synthesize the equivalent pattern so the consistency check matches what
     // `read_modules_manifest` would produce on a full read.
-    if let Some(shamefully_hoist) = manifest.shamefully_hoist {
-        if manifest.public_hoist_pattern.is_none() {
-            manifest.public_hoist_pattern =
-                Some(if shamefully_hoist { vec!["*".to_string()] } else { Vec::new() });
-        }
+    if let Some(shamefully_hoist) = manifest.shamefully_hoist
+        && manifest.public_hoist_pattern.is_none()
+    {
+        manifest.public_hoist_pattern =
+            Some(if shamefully_hoist { vec!["*".to_string()] } else { Vec::new() });
     }
 
     let stored_path = Path::new(&manifest.virtual_store_dir);

--- a/pacquet/crates/modules-yaml/src/lib.rs
+++ b/pacquet/crates/modules-yaml/src/lib.rs
@@ -229,6 +229,45 @@ pub struct Modules {
     pub allow_builds: Option<BTreeMap<String, AllowBuildValue>>,
 }
 
+/// A lightweight version of [`Modules`] that skips deserializing the potentially
+/// large `hoisted_dependencies` and `hoisted_locations` maps. Used during
+/// the install fast path to check layout consistency without allocating massive
+/// amounts of memory.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModulesLayout {
+    #[serde(default)]
+    pub hoist_pattern: Option<Vec<String>>,
+    #[serde(default)]
+    pub included: IncludedDependencies,
+    #[serde(default)]
+    pub layout_version: Option<LayoutVersion>,
+    #[serde(default)]
+    pub node_linker: Option<NodeLinker>,
+    #[serde(default)]
+    pub package_manager: String,
+    #[serde(default)]
+    pub pending_builds: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ignored_builds: Option<IndexSet<DepPath>>,
+    #[serde(default)]
+    pub pruned_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub registries: Option<BTreeMap<String, String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_hoist_pattern: Option<Vec<String>>,
+    #[serde(default)]
+    pub skipped: Vec<String>,
+    #[serde(default)]
+    pub store_dir: String,
+    #[serde(default)]
+    pub virtual_store_dir: String,
+    #[serde(default)]
+    pub virtual_store_dir_max_length: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_builds: Option<BTreeMap<String, AllowBuildValue>>,
+}
+
 /// Which dependency groups the install pipeline included. Mirrors
 /// upstream's `IncludedDependencies` at
 /// <https://github.com/pnpm/pnpm/blob/1819226b51/installing/modules-yaml/src/index.ts#L19-L21>.
@@ -387,6 +426,45 @@ where
     let Some(mut manifest) = parsed else { return Ok(None) };
     apply_legacy_shamefully_hoist(&mut manifest);
     resolve_virtual_store_dir(&mut manifest, modules_dir);
+    if manifest.pruned_at.is_empty() {
+        manifest.pruned_at = httpdate::fmt_http_date(Sys::now());
+    }
+    if manifest.virtual_store_dir_max_length == 0 {
+        manifest.virtual_store_dir_max_length = DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH;
+    }
+    Ok(Some(manifest))
+}
+
+/// Reads the manifest into the lightweight [`ModulesLayout`] struct, skipping
+/// large maps like `hoisted_dependencies` and `hoisted_locations`.
+pub fn read_modules_layout<Sys>(
+    modules_dir: &Path,
+) -> Result<Option<ModulesLayout>, ReadModulesError>
+where
+    Sys: FsReadToString + Clock,
+{
+    let manifest_path = modules_dir.join(MODULES_FILENAME);
+    let content = match Sys::read_to_string(&manifest_path) {
+        Ok(content) => content,
+        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(ReadModulesError::ReadFile { path: manifest_path, source });
+        }
+    };
+    let parsed: Option<ModulesLayout> =
+        content.pipe_as_ref(serde_saphyr::from_str).map_err(|source| {
+            ReadModulesError::ParseYaml { path: manifest_path.clone(), source: Box::new(source) }
+        })?;
+    let Some(mut manifest) = parsed else { return Ok(None) };
+
+    let stored_path = Path::new(&manifest.virtual_store_dir);
+    let resolved = match (manifest.virtual_store_dir.is_empty(), stored_path.is_absolute()) {
+        (true, _) => modules_dir.join(".pnpm"),
+        (false, true) => stored_path.to_path_buf(),
+        (false, false) => lexical_normalize(&modules_dir.join(stored_path)),
+    };
+    manifest.virtual_store_dir = resolved.display().to_string();
+
     if manifest.pruned_at.is_empty() {
         manifest.pruned_at = httpdate::fmt_http_date(Sys::now());
     }

--- a/pacquet/crates/modules-yaml/src/lib.rs
+++ b/pacquet/crates/modules-yaml/src/lib.rs
@@ -462,10 +462,7 @@ where
         })?;
     let Some(mut manifest) = parsed else { return Ok(None) };
 
-    // Mirror apply_legacy_shamefully_hoist: when the on-disk manifest still
-    // uses the old `shamefullyHoist` flag without a `publicHoistPattern`,
-    // synthesize the equivalent pattern so the consistency check matches what
-    // `read_modules_manifest` would produce on a full read.
+    // Normalize legacy shamefully_hoist to public_hoist_pattern.
     if let Some(shamefully_hoist) = manifest.shamefully_hoist
         && manifest.public_hoist_pattern.is_none()
     {

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1048,40 +1048,66 @@ where
         if !resolve_only && is_inconsistent {
             // Settings mismatch forces a rewrite of node_modules, matching
             // upstream pnpm's `validateModules` prune side effects.
-            let is_safe = config.modules_dir.file_name().is_some_and(|n| n == "node_modules");
+            let (is_safe, target_dir) = if config.modules_dir.exists() {
+                match (
+                    std::fs::canonicalize(&config.modules_dir),
+                    std::fs::canonicalize(&workspace_root),
+                ) {
+                    (Ok(modules_canon), Ok(root_canon)) => {
+                        (modules_canon.starts_with(&root_canon), Some(modules_canon))
+                    }
+                    _ => (false, None),
+                }
+            } else {
+                (true, None)
+            };
             if is_safe {
-                match std::fs::read_dir(&config.modules_dir) {
-                    Ok(entries) => {
-                        for entry_res in entries {
-                            let entry = entry_res.map_err(InstallError::RemoveModulesDir)?;
-                            let file_name = entry.file_name();
-                            let file_name_str = file_name.to_string_lossy();
+                if let Some(target) = target_dir {
+                    match std::fs::read_dir(&target) {
+                        Ok(entries) => {
+                            for entry_res in entries {
+                                let entry = entry_res.map_err(InstallError::RemoveModulesDir)?;
+                                let file_name = entry.file_name();
+                                let file_name_str = file_name.to_string_lossy();
 
-                            let is_hidden = file_name_str.starts_with('.');
-                            let is_pnpm_hidden = file_name_str == ".bin"
-                                || file_name_str == ".modules.yaml"
-                                || entry.path() == config.virtual_store_dir;
+                                let is_hidden = file_name_str.starts_with('.');
+                                let is_pnpm_hidden = file_name_str == ".bin"
+                                    || file_name_str == ".modules.yaml"
+                                    || config
+                                        .virtual_store_dir
+                                        .file_name()
+                                        .is_some_and(|n| n == file_name_str.as_ref())
+                                    || modules_manifest.as_ref().is_some_and(|manifest| {
+                                        let old_vs =
+                                            config.modules_dir.join(&manifest.virtual_store_dir);
+                                        // Ensure we only delete it if it's a descendant of modules_dir
+                                        old_vs.starts_with(&config.modules_dir)
+                                            && old_vs
+                                                .file_name()
+                                                .is_some_and(|n| n == file_name_str.as_ref())
+                                    });
 
-                            if is_hidden && !is_pnpm_hidden {
-                                continue;
-                            }
+                                if is_hidden && !is_pnpm_hidden {
+                                    continue;
+                                }
 
-                            if entry.file_type().is_ok_and(|t| t.is_dir()) {
-                                std::fs::remove_dir_all(entry.path())
-                                    .map_err(InstallError::RemoveModulesDir)?;
-                            } else {
-                                std::fs::remove_file(entry.path())
-                                    .map_err(InstallError::RemoveModulesDir)?;
+                                if entry.file_type().is_ok_and(|t| t.is_dir()) {
+                                    std::fs::remove_dir_all(entry.path())
+                                        .map_err(InstallError::RemoveModulesDir)?;
+                                } else {
+                                    std::fs::remove_file(entry.path())
+                                        .map_err(InstallError::RemoveModulesDir)?;
+                                }
                             }
                         }
+                        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                        Err(err) => return Err(InstallError::RemoveModulesDir(err)),
                     }
-                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(err) => return Err(InstallError::RemoveModulesDir(err)),
                 }
             } else {
                 tracing::warn!(
                     ?config.modules_dir,
-                    "refusing to remove inconsistent modules directory outside the project root"
+                    "refusing to remove inconsistent modules directory outside the project root",
                 );
             }
         }

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1031,12 +1031,17 @@ where
         // `allProjectsAreUpToDate` fast path at
         // <https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-installer/src/install/index.ts#L913-L985>.
         // Parse `.modules.yaml` once and share it across the consistency,
-        // newly-allowed, and unapproved-ignored checks below. Only the
-        // frozen path reads it, so the fresh-lockfile/`add` path skips the
-        // file read + YAML parse entirely.
-        let modules_manifest = take_frozen_path
-            .then(|| read_modules_manifest::<Host>(&config.modules_dir).ok().flatten())
-            .flatten();
+        // newly-allowed, and unapproved-ignored checks below.
+        let modules_manifest = read_modules_manifest::<Host>(&config.modules_dir).ok().flatten();
+
+        if let Some(modules) = modules_manifest.as_ref()
+            && !modules_consistent_with(modules, config, node_linker, included)
+        {
+            // Settings mismatch forces a rewrite of node_modules, matching
+            // upstream pnpm's `validateModules` prune side effects.
+            let _ = std::fs::remove_dir_all(&config.modules_dir);
+        }
+
         if take_frozen_path
             && let Some(wanted_lockfile) = lockfile
             && let Some(current) = current_lockfile.as_ref()
@@ -1838,10 +1843,7 @@ fn map_node_linker(linker: NodeLinker) -> ModulesNodeLinker {
 /// unapproved-ignored checks.
 ///
 /// Mirrors the settings checks in upstream's
-/// [`validateModules`](https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-installer/src/install/validateModules.ts)
-/// minus the prune side effects: a settings mismatch in pnpm forces a
-/// rewrite of `node_modules`, but pacquet's caller falls through to the
-/// regular install path, which rebuilds the layout from scratch anyway.
+/// [`validateModules`](https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-installer/src/install/validateModules.ts).
 fn modules_consistent_with(
     modules: &Modules,
     config: &Config,

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1039,7 +1039,19 @@ where
         {
             // Settings mismatch forces a rewrite of node_modules, matching
             // upstream pnpm's `validateModules` prune side effects.
-            let _ = std::fs::remove_dir_all(&config.modules_dir);
+            let is_safe = config.modules_dir.file_name().is_some_and(|n| n == "node_modules");
+            if is_safe {
+                if let Err(err) = std::fs::remove_dir_all(&config.modules_dir)
+                    && err.kind() != std::io::ErrorKind::NotFound
+                {
+                    tracing::warn!(?err, "failed to remove inconsistent modules directory");
+                }
+            } else {
+                tracing::warn!(
+                    ?config.modules_dir,
+                    "refusing to remove inconsistent modules directory outside the project root"
+                );
+            }
         }
 
         if take_frozen_path

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1055,9 +1055,7 @@ where
         let is_inconsistent = read_failed
             || match &modules_manifest {
                 Some(modules) => !modules_consistent_with(modules, config, node_linker, included),
-                // No manifest on disk means first install — not inconsistent.
-                // If the existence check itself fails (e.g. permissions), treat
-                // it conservatively as inconsistent so the purge is not skipped.
+                // Treat existence-check errors conservatively as inconsistent.
                 None => config
                     .modules_dir
                     .join(pacquet_modules_yaml::MODULES_FILENAME)
@@ -1104,9 +1102,11 @@ where
                                         .file_name()
                                         .is_some_and(|n| n == file_name_str.as_ref())
                                     || modules_manifest.as_ref().is_some_and(|manifest| {
-                                        let old_vs =
-                                            config.modules_dir.join(&manifest.virtual_store_dir);
-                                        // Ensure we only delete it if it's a descendant of modules_dir
+                                        let mut old_vs =
+                                            std::path::PathBuf::from(&manifest.virtual_store_dir);
+                                        if old_vs.is_relative() {
+                                            old_vs = config.modules_dir.join(old_vs);
+                                        }
                                         old_vs.starts_with(&config.modules_dir)
                                             && old_vs
                                                 .file_name()

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1041,6 +1041,7 @@ where
         } else {
             Ok(None)
         };
+        let read_failed = modules_manifest_res.is_err();
         if let Err(err) = &modules_manifest_res {
             tracing::warn!(
                 target: "pacquet::install",
@@ -1051,10 +1052,18 @@ where
         let old_modules = modules_manifest_res.ok().flatten();
         let modules_manifest = old_modules.as_ref();
 
-        let is_inconsistent = match &modules_manifest {
-            Some(modules) => !modules_consistent_with(modules, config, node_linker, included),
-            None => config.modules_dir.join(pacquet_modules_yaml::MODULES_FILENAME).exists(),
-        };
+        let is_inconsistent = read_failed
+            || match &modules_manifest {
+                Some(modules) => !modules_consistent_with(modules, config, node_linker, included),
+                // No manifest on disk means first install — not inconsistent.
+                // If the existence check itself fails (e.g. permissions), treat
+                // it conservatively as inconsistent so the purge is not skipped.
+                None => config
+                    .modules_dir
+                    .join(pacquet_modules_yaml::MODULES_FILENAME)
+                    .try_exists()
+                    .unwrap_or(true),
+            };
 
         if !resolve_only && is_inconsistent {
             // Settings mismatch forces a rewrite of node_modules, matching

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -336,6 +336,10 @@ pub enum InstallError {
     #[diagnostic(transparent)]
     SaveWantedLockfile(#[error(source)] SaveLockfileError),
 
+    #[diagnostic(code(pacquet_package_manager::remove_modules_dir))]
+    #[display("Failed to remove modules directory contents: {_0}")]
+    RemoveModulesDir(#[error(source)] std::io::Error),
+
     /// `pnpm-lock.yaml` doesn't match the on-disk `package.json` for
     /// the project being installed. Mirrors upstream's
     /// `ERR_PNPM_OUTDATED_LOCKFILE` thrown from
@@ -1041,10 +1045,32 @@ where
             // upstream pnpm's `validateModules` prune side effects.
             let is_safe = config.modules_dir.file_name().is_some_and(|n| n == "node_modules");
             if is_safe {
-                if let Err(err) = std::fs::remove_dir_all(&config.modules_dir)
-                    && err.kind() != std::io::ErrorKind::NotFound
-                {
-                    tracing::warn!(?err, "failed to remove inconsistent modules directory");
+                match std::fs::read_dir(&config.modules_dir) {
+                    Ok(entries) => {
+                        for entry in entries.flatten() {
+                            let file_name = entry.file_name();
+                            let file_name_str = file_name.to_string_lossy();
+
+                            let is_hidden = file_name_str.starts_with('.');
+                            let is_pnpm_hidden = file_name_str == ".bin"
+                                || file_name_str == ".modules.yaml"
+                                || entry.path() == config.virtual_store_dir;
+
+                            if is_hidden && !is_pnpm_hidden {
+                                continue;
+                            }
+
+                            if entry.file_type().is_ok_and(|t| t.is_dir()) {
+                                std::fs::remove_dir_all(entry.path())
+                                    .map_err(InstallError::RemoveModulesDir)?;
+                            } else {
+                                std::fs::remove_file(entry.path())
+                                    .map_err(InstallError::RemoveModulesDir)?;
+                            }
+                        }
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(err) => return Err(InstallError::RemoveModulesDir(err)),
                 }
             } else {
                 tracing::warn!(

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -26,7 +26,7 @@ use pacquet_lockfile_verification::{
 };
 use pacquet_modules_yaml::{
     Host, IncludedDependencies, LayoutVersion, Modules, NodeLinker as ModulesNodeLinker,
-    WriteModulesError, read_modules_manifest, write_modules_manifest,
+    WriteModulesError, write_modules_manifest,
 };
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
@@ -644,7 +644,7 @@ where
             // to the full install rather than short-circuiting on a
             // swallowed read error.
             let fast_path_safe = if config.strict_dep_builds {
-                match read_modules_manifest::<Host>(&config.modules_dir) {
+                match pacquet_modules_yaml::read_modules_layout::<Host>(&config.modules_dir) {
                     Ok(Some(modules)) => match unapproved_recorded_ignored_builds(&modules, config)
                     {
                         Ok(Some(package_names)) => {
@@ -1036,7 +1036,11 @@ where
         // <https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-installer/src/install/index.ts#L913-L985>.
         // Parse `.modules.yaml` once and share it across the consistency,
         // newly-allowed, and unapproved-ignored checks below.
-        let modules_manifest_res = read_modules_manifest::<Host>(&config.modules_dir);
+        let modules_manifest_res = if !resolve_only || take_frozen_path {
+            pacquet_modules_yaml::read_modules_layout::<Host>(&config.modules_dir)
+        } else {
+            Ok(None)
+        };
         if let Err(err) = &modules_manifest_res {
             tracing::warn!(
                 target: "pacquet::install",
@@ -1073,7 +1077,13 @@ where
                     match std::fs::read_dir(&target) {
                         Ok(entries) => {
                             for entry_res in entries {
-                                let entry = entry_res.map_err(InstallError::RemoveModulesDir)?;
+                                let entry = match entry_res {
+                                    Ok(e) => e,
+                                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                                        continue;
+                                    }
+                                    Err(err) => return Err(InstallError::RemoveModulesDir(err)),
+                                };
                                 let file_name = entry.file_name();
                                 let file_name_str = file_name.to_string_lossy();
 
@@ -1105,13 +1115,16 @@ where
                                     #[cfg(not(windows))]
                                     let is_removed = false;
 
-                                    if !is_removed {
-                                        std::fs::remove_dir_all(entry.path())
-                                            .map_err(InstallError::RemoveModulesDir)?;
+                                    if !is_removed
+                                        && let Err(err) = std::fs::remove_dir_all(entry.path())
+                                        && err.kind() != std::io::ErrorKind::NotFound
+                                    {
+                                        return Err(InstallError::RemoveModulesDir(err));
                                     }
-                                } else {
-                                    std::fs::remove_file(entry.path())
-                                        .map_err(InstallError::RemoveModulesDir)?;
+                                } else if let Err(err) = std::fs::remove_file(entry.path())
+                                    && err.kind() != std::io::ErrorKind::NotFound
+                                {
+                                    return Err(InstallError::RemoveModulesDir(err));
                                 }
                             }
                         }
@@ -1239,7 +1252,7 @@ where
                 skip_runtimes,
                 node_linker,
                 tarball_mem_cache: Some(&tarball_mem_cache),
-                old_modules: modules_manifest,
+                seed_skipped: modules_manifest.map(|m| m.skipped.clone()),
             }
             .run::<Reporter>()
             .await
@@ -1925,7 +1938,7 @@ fn map_node_linker(linker: NodeLinker) -> ModulesNodeLinker {
 /// Mirrors the settings checks in upstream's
 /// [`validateModules`](https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-installer/src/install/validateModules.ts).
 fn modules_consistent_with(
-    modules: &Modules,
+    modules: &pacquet_modules_yaml::ModulesLayout,
     config: &Config,
     node_linker: NodeLinker,
     included: IncludedDependencies,
@@ -1952,7 +1965,10 @@ fn modules_consistent_with(
 /// result by letting the full frozen install run, whose `BuildModules`
 /// re-evaluates the policy and rebuilds the now-allowed package (already
 /// built deps are skipped by the side-effects-cache `is_built` gate).
-fn has_newly_allowed_ignored_builds(modules: &Modules, config: &Config) -> bool {
+fn has_newly_allowed_ignored_builds(
+    modules: &pacquet_modules_yaml::ModulesLayout,
+    config: &Config,
+) -> bool {
     let Some(ignored) = modules.ignored_builds.as_ref().filter(|set| !set.is_empty()) else {
         return false;
     };
@@ -1983,7 +1999,7 @@ fn has_newly_allowed_ignored_builds(modules: &Modules, config: &Config) -> bool 
 /// fast-path callers fall through to the full install on `Err`, which
 /// re-evaluates the policy and reports the real error.
 fn unapproved_recorded_ignored_builds(
-    modules: &Modules,
+    modules: &pacquet_modules_yaml::ModulesLayout,
     config: &Config,
 ) -> Result<Option<Vec<String>>, pacquet_config::version_policy::VersionPolicyError> {
     let Some(ignored) = modules.ignored_builds.as_ref().filter(|set| !set.is_empty()) else {
@@ -2256,7 +2272,7 @@ pub fn install_already_up_to_date(check: &UpToDateFastPathCheck<'_>) -> Option<P
     // is treated conservatively the same way (its `Err` can't prove the
     // absence of recorded ignored builds).
     if config.strict_dep_builds {
-        match read_modules_manifest::<Host>(&config.modules_dir) {
+        match pacquet_modules_yaml::read_modules_layout::<Host>(&config.modules_dir) {
             Ok(Some(modules)) => match unapproved_recorded_ignored_builds(&modules, config) {
                 Ok(Some(_)) => return None,
                 Ok(None) => {}

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1111,7 +1111,7 @@ where
                                 if entry.file_type().is_ok_and(|t| t.is_dir()) {
                                     #[cfg(windows)]
                                     let is_removed =
-                                        pacquet_fs::remove_symlink_dir(entry.path()).is_ok();
+                                        pacquet_fs::remove_symlink_dir(&entry.path()).is_ok();
                                     #[cfg(not(windows))]
                                     let is_removed = false;
 

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1036,18 +1036,24 @@ where
         // <https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-installer/src/install/index.ts#L913-L985>.
         // Parse `.modules.yaml` once and share it across the consistency,
         // newly-allowed, and unapproved-ignored checks below.
-        let modules_manifest = read_modules_manifest::<Host>(&config.modules_dir).ok().flatten();
+        let modules_manifest_res = read_modules_manifest::<Host>(&config.modules_dir);
+        let modules_manifest = modules_manifest_res.as_ref().ok().and_then(|opt| opt.as_ref());
 
-        if let Some(modules) = modules_manifest.as_ref()
-            && !modules_consistent_with(modules, config, node_linker, included)
-        {
+        let is_inconsistent = match &modules_manifest_res {
+            Ok(Some(modules)) => !modules_consistent_with(modules, config, node_linker, included),
+            Ok(None) => false,
+            Err(_) => true,
+        };
+
+        if !resolve_only && is_inconsistent {
             // Settings mismatch forces a rewrite of node_modules, matching
             // upstream pnpm's `validateModules` prune side effects.
             let is_safe = config.modules_dir.file_name().is_some_and(|n| n == "node_modules");
             if is_safe {
                 match std::fs::read_dir(&config.modules_dir) {
                     Ok(entries) => {
-                        for entry in entries.flatten() {
+                        for entry_res in entries {
+                            let entry = entry_res.map_err(InstallError::RemoveModulesDir)?;
                             let file_name = entry.file_name();
                             let file_name_str = file_name.to_string_lossy();
 

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1252,7 +1252,7 @@ where
                 skip_runtimes,
                 node_linker,
                 tarball_mem_cache: Some(&tarball_mem_cache),
-                seed_skipped: modules_manifest.map(|m| m.skipped.clone()),
+                seed_skipped: modules_manifest.map(|manifest| manifest.skipped.clone()),
             }
             .run::<Reporter>()
             .await

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1037,14 +1037,20 @@ where
         // Parse `.modules.yaml` once and share it across the consistency,
         // newly-allowed, and unapproved-ignored checks below.
         let modules_manifest_res = read_modules_manifest::<Host>(&config.modules_dir);
-        let modules_manifest = modules_manifest_res.as_ref().ok().and_then(|opt| opt.as_ref());
+        if let Err(err) = &modules_manifest_res {
+            tracing::warn!(
+                target: "pacquet::install",
+                ?err,
+                "failed to read .modules.yaml; treating as an inconsistent node_modules directory",
+            );
+        }
+        let old_modules = modules_manifest_res.ok().flatten();
+        let modules_manifest = old_modules.as_ref();
 
-        let is_inconsistent = match &modules_manifest_res {
-            Ok(Some(modules)) => !modules_consistent_with(modules, config, node_linker, included),
-            Ok(None) => config.modules_dir.join(pacquet_modules_yaml::MODULES_FILENAME).exists(),
-            Err(_) => true,
+        let is_inconsistent = match &modules_manifest {
+            Some(modules) => !modules_consistent_with(modules, config, node_linker, included),
+            None => config.modules_dir.join(pacquet_modules_yaml::MODULES_FILENAME).exists(),
         };
-        let old_modules = modules_manifest.cloned();
 
         if !resolve_only && is_inconsistent {
             // Settings mismatch forces a rewrite of node_modules, matching
@@ -1233,7 +1239,7 @@ where
                 skip_runtimes,
                 node_linker,
                 tarball_mem_cache: Some(&tarball_mem_cache),
-                old_modules: old_modules.clone(),
+                old_modules: modules_manifest,
             }
             .run::<Reporter>()
             .await
@@ -1445,7 +1451,7 @@ where
         // A genuine read/parse failure (not `NotFound`) is treated as
         // "no prior manifest" — the safe direction (prune + fresh
         // `prunedAt`) — but logged rather than silently swallowed.
-        let prior_modules = old_modules.clone();
+        let prior_modules = modules_manifest;
         let now = SystemTime::now();
         let effective_virtual_store_dir = config.effective_virtual_store_dir();
         // Decide "this is the global store" from the resolved paths, not

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1041,9 +1041,10 @@ where
 
         let is_inconsistent = match &modules_manifest_res {
             Ok(Some(modules)) => !modules_consistent_with(modules, config, node_linker, included),
-            Ok(None) => false,
+            Ok(None) => config.modules_dir.join(pacquet_modules_yaml::MODULES_FILENAME).exists(),
             Err(_) => true,
         };
+        let old_modules = modules_manifest.cloned();
 
         if !resolve_only && is_inconsistent {
             // Settings mismatch forces a rewrite of node_modules, matching
@@ -1092,8 +1093,16 @@ where
                                 }
 
                                 if entry.file_type().is_ok_and(|t| t.is_dir()) {
-                                    std::fs::remove_dir_all(entry.path())
-                                        .map_err(InstallError::RemoveModulesDir)?;
+                                    #[cfg(windows)]
+                                    let is_removed =
+                                        pacquet_fs::remove_symlink_dir(entry.path()).is_ok();
+                                    #[cfg(not(windows))]
+                                    let is_removed = false;
+
+                                    if !is_removed {
+                                        std::fs::remove_dir_all(entry.path())
+                                            .map_err(InstallError::RemoveModulesDir)?;
+                                    }
                                 } else {
                                     std::fs::remove_file(entry.path())
                                         .map_err(InstallError::RemoveModulesDir)?;
@@ -1224,6 +1233,7 @@ where
                 skip_runtimes,
                 node_linker,
                 tarball_mem_cache: Some(&tarball_mem_cache),
+                old_modules: old_modules.clone(),
             }
             .run::<Reporter>()
             .await
@@ -1435,13 +1445,7 @@ where
         // A genuine read/parse failure (not `NotFound`) is treated as
         // "no prior manifest" — the safe direction (prune + fresh
         // `prunedAt`) — but logged rather than silently swallowed.
-        let prior_modules = match read_modules_manifest::<Host>(&config.modules_dir) {
-            Ok(modules) => modules,
-            Err(error) => {
-                tracing::warn!(?error, "failed to read .modules.yaml; treating as a fresh install");
-                None
-            }
-        };
+        let prior_modules = old_modules.clone();
         let now = SystemTime::now();
         let effective_virtual_store_dir = config.effective_virtual_store_dir();
         // Decide "this is the global store" from the resolved paths, not

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -42,9 +42,9 @@ fn is_modules_yaml_consistent(
     node_linker: pacquet_config::NodeLinker,
     included: pacquet_modules_yaml::IncludedDependencies,
 ) -> bool {
-    read_modules_manifest::<Host>(modules_dir).ok().flatten().is_some_and(|modules| {
-        super::modules_consistent_with(&modules, config, node_linker, included)
-    })
+    pacquet_modules_yaml::read_modules_layout::<Host>(modules_dir).ok().flatten().is_some_and(
+        |modules| super::modules_consistent_with(&modules, config, node_linker, included),
+    )
 }
 
 const SCOPED_TEST_INTEGRITY: &str = "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==";
@@ -5585,7 +5585,7 @@ async fn stale_lockfile_under_no_flag_falls_through_to_fresh_resolve() {
 /// — rather than short-circuiting to success and hiding it.
 #[test]
 fn unapproved_recorded_ignored_builds_surfaces_invalid_allow_builds() {
-    let modules = Modules {
+    let modules = pacquet_modules_yaml::ModulesLayout {
         ignored_builds: Some([pacquet_modules_yaml::DepPath::from("pkg@1.0.0".to_string())].into()),
         ..Default::default()
     };

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -8065,3 +8065,112 @@ async fn test_install_purges_node_modules_on_layout_mismatch() {
 
     assert!(!canary_path.exists(), "node_modules should be purged due to mismatch");
 }
+
+#[tokio::test]
+async fn test_install_resolve_only_ignores_layout_mismatch() {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = project_root.join("package.json");
+    std::fs::create_dir_all(&project_root).unwrap();
+    let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+
+    let mut config_isolated = Config::new();
+    config_isolated.lockfile = false;
+    config_isolated.store_dir = store_dir.clone().into();
+    config_isolated.modules_dir = modules_dir.clone();
+    config_isolated.virtual_store_dir = virtual_store_dir.clone();
+
+    let mut config_hoisted = Config::new();
+    config_hoisted.lockfile = false;
+    config_hoisted.store_dir = store_dir.clone().into();
+    config_hoisted.modules_dir = modules_dir.clone();
+    config_hoisted.virtual_store_dir = virtual_store_dir.clone();
+    config_hoisted.hoist_pattern = Some(vec![]);
+
+    let config_isolated = config_isolated.leak();
+    let config_hoisted = config_hoisted.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies: {}"
+        "packages: {}"
+        "snapshots: {}"
+    })
+    .unwrap();
+
+    // 1st install: Isolated node linker (default)
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config: config_isolated,
+        manifest: &manifest,
+        lockfile: MaybeLazyLockfile::Loaded(Some(&lockfile)),
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
+        frozen_lockfile: true,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        is_full_install: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::Isolated,
+        lockfile_only: false,
+        dry_run: false,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+        auth_override: None,
+        resolution_observer: None,
+        catalogs_override: None,
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("1st install success");
+
+    let canary_path = modules_dir.join("canary.txt");
+    std::fs::create_dir_all(&modules_dir).unwrap();
+    std::fs::write(&canary_path, "canary").unwrap();
+    assert!(canary_path.exists());
+
+    // 2nd install: Hoisted node linker, but dry_run is true
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config: config_hoisted,
+        manifest: &manifest,
+        lockfile: MaybeLazyLockfile::Loaded(Some(&lockfile)),
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
+        frozen_lockfile: true,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        is_full_install: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::Hoisted,
+        lockfile_only: false,
+        dry_run: true,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+        auth_override: None,
+        resolution_observer: None,
+        catalogs_override: None,
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("2nd install success");
+
+    // Canary should still exist because dry_run doesn't mutate node_modules
+    assert!(canary_path.exists(), "canary was deleted despite dry_run: true");
+}

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -7957,3 +7957,111 @@ async fn async_after_all_resolved_hook_log_is_forwarded_to_pnpm_hook_channel() {
 
     drop((dir, registry));
 }
+
+#[tokio::test]
+async fn test_install_purges_node_modules_on_layout_mismatch() {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = project_root.join("package.json");
+    std::fs::create_dir_all(&project_root).unwrap();
+    let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+
+    let mut config_isolated = Config::new();
+    config_isolated.lockfile = false;
+    config_isolated.store_dir = store_dir.clone().into();
+    config_isolated.modules_dir = modules_dir.clone();
+    config_isolated.virtual_store_dir = virtual_store_dir.clone();
+
+    let mut config_hoisted = Config::new();
+    config_hoisted.lockfile = false;
+    config_hoisted.store_dir = store_dir.clone().into();
+    config_hoisted.modules_dir = modules_dir.clone();
+    config_hoisted.virtual_store_dir = virtual_store_dir.clone();
+    config_hoisted.hoist_pattern = Some(vec![]);
+
+    let config_isolated = config_isolated.leak();
+    let config_hoisted = config_hoisted.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies: {}"
+        "packages: {}"
+        "snapshots: {}"
+    })
+    .unwrap();
+
+    // 1st install: Isolated node linker (default)
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config: config_isolated,
+        manifest: &manifest,
+        lockfile: MaybeLazyLockfile::Loaded(Some(&lockfile)),
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
+        frozen_lockfile: true,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        is_full_install: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::Isolated,
+        lockfile_only: false,
+        dry_run: false,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+        auth_override: None,
+        resolution_observer: None,
+        catalogs_override: None,
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("1st install success");
+
+    let canary_path = modules_dir.join("canary.txt");
+    std::fs::create_dir_all(&modules_dir).unwrap();
+    std::fs::write(&canary_path, "canary").unwrap();
+    assert!(canary_path.exists());
+
+    // 2nd install: Hoisted node linker
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config: config_hoisted,
+        manifest: &manifest,
+        lockfile: MaybeLazyLockfile::Loaded(Some(&lockfile)),
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
+        frozen_lockfile: true,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        is_full_install: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::Hoisted,
+        lockfile_only: false,
+        dry_run: false,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+        auth_override: None,
+        resolution_observer: None,
+        catalogs_override: None,
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("2nd install success");
+
+    assert!(!canary_path.exists(), "node_modules should be purged due to mismatch");
+}

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -175,6 +175,7 @@ where
     /// re-fetching every tarball; `None` for installs without a shared
     /// prefetch in flight.
     pub tarball_mem_cache: Option<&'a Arc<MemCache>>,
+    pub old_modules: Option<pacquet_modules_yaml::Modules>,
 }
 
 /// Error type of [`InstallFrozenLockfile`].
@@ -269,6 +270,9 @@ pub enum InstallFrozenLockfileError {
     #[display("failed to write package map: {_0}")]
     #[diagnostic(code(pacquet_package_manager::write_package_map))]
     WritePackageMap(#[error(source)] crate::WritePackageMapError),
+
+    #[diagnostic(transparent)]
+    InstallError(#[error(source)] Box<crate::InstallError>),
 }
 
 /// Error type of `run_build_phase` and `resolve_snapshot_patches`.
@@ -575,7 +579,9 @@ where
             skip_runtimes,
             node_linker,
             tarball_mem_cache,
+            old_modules,
         } = self;
+
         let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
         // Cloned so the iterator can be reused below for hoist's
         // direct-deps map. `Vec<DependencyGroup>` is tiny (≤4 enum
@@ -644,16 +650,20 @@ where
         // A read error (corrupt yaml, permissions) is degraded to
         // an empty seed — `.modules.yaml` is a cache artifact, not
         // an authoritative source. Missing file → empty seed.
-        let seed = match read_modules_manifest::<Host>(&config.modules_dir) {
-            Ok(Some(manifest)) => SkippedSnapshots::from_strings(&manifest.skipped),
-            Ok(None) => SkippedSnapshots::new(),
-            Err(error) => {
-                tracing::warn!(
-                    target: "pacquet::install",
-                    ?error,
-                    "failed to read .modules.yaml for skipped seed; starting from empty",
-                );
-                SkippedSnapshots::new()
+        let seed = if let Some(manifest) = old_modules {
+            SkippedSnapshots::from_strings(&manifest.skipped)
+        } else {
+            match read_modules_manifest::<Host>(&config.modules_dir) {
+                Ok(Some(manifest)) => SkippedSnapshots::from_strings(&manifest.skipped),
+                Ok(None) => SkippedSnapshots::new(),
+                Err(error) => {
+                    tracing::warn!(
+                        target: "pacquet::install",
+                        ?error,
+                        "failed to read .modules.yaml for skipped seed; starting from empty",
+                    );
+                    SkippedSnapshots::new()
+                }
             }
         };
 

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -175,7 +175,7 @@ where
     /// re-fetching every tarball; `None` for installs without a shared
     /// prefetch in flight.
     pub tarball_mem_cache: Option<&'a Arc<MemCache>>,
-    pub old_modules: Option<pacquet_modules_yaml::Modules>,
+    pub old_modules: Option<&'a pacquet_modules_yaml::Modules>,
 }
 
 /// Error type of [`InstallFrozenLockfile`].

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -175,7 +175,7 @@ where
     /// re-fetching every tarball; `None` for installs without a shared
     /// prefetch in flight.
     pub tarball_mem_cache: Option<&'a Arc<MemCache>>,
-    pub old_modules: Option<&'a pacquet_modules_yaml::Modules>,
+    pub seed_skipped: Option<Vec<String>>,
 }
 
 /// Error type of [`InstallFrozenLockfile`].
@@ -579,7 +579,7 @@ where
             skip_runtimes,
             node_linker,
             tarball_mem_cache,
-            old_modules,
+            seed_skipped,
         } = self;
 
         let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
@@ -650,8 +650,8 @@ where
         // A read error (corrupt yaml, permissions) is degraded to
         // an empty seed — `.modules.yaml` is a cache artifact, not
         // an authoritative source. Missing file → empty seed.
-        let seed = if let Some(manifest) = old_modules {
-            SkippedSnapshots::from_strings(&manifest.skipped)
+        let seed = if let Some(skipped) = seed_skipped {
+            SkippedSnapshots::from_strings(&skipped)
         } else {
             match read_modules_manifest::<Host>(&config.modules_dir) {
                 Ok(Some(manifest)) => SkippedSnapshots::from_strings(&manifest.skipped),


### PR DESCRIPTION
## Summary

This PR implements `.modules.yaml` validation triggering re-install on layout change for pacquet. It mirrors upstream's `validateModules` behavior which forces a full re-import when layout-affecting settings (like `nodeLinker`, `hoistPattern`, `publicHoistPattern`, etc.) differ between runs. 

Previously, `pacquet` would write `.modules.yaml` but fail to check it on the read side during the non-fast path, causing layout-affecting setting changes to be silently ignored and resulting in stale files in `node_modules`. Now it reads `.modules.yaml` unconditionally and purges `node_modules` if the layout is inconsistent, forcing a clean reinstall.

Fixes part of pnpm/pnpm#11633 (Specifically the missing Stage 1 checklist item).

## Squash Commit Body

```text
feat(pacquet): purge node_modules on layout changes matching validateModules

Reads `.modules.yaml` unconditionally before dispatching the install path. If the layout settings (nodeLinker, hoist patterns, etc.) differ from the currently active config, it purges `node_modules` completely. This mirrors upstream's `validateModules` prune side-effects and prevents leaving behind stale dependencies or symlinks when layout settings change.


```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Antigravity, Gemini 3.1 Pro (Low)).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module layout consistency handling during installs: the installer now reads and reuses the existing module manifest for non-`resolve_only` runs, ensuring “up-to-date” checks stay consistent.
  * When the manifest conflicts with current install settings, the installer performs a best-effort cleanup to remove stale module directory contents (safely constrained), or logs a warning and skips deletion if it can’t do so safely.
* **Tests**
  * Added integration tests for frozen installs to verify node linker/layout mismatches purge stale `node_modules`, and that `resolve_only`/dry-run does not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
