### PR TITLE
fix(audit): combine min release age excl entries

### DIFF
--- a/.changeset/audit-fix-combine-min-release-age-excludes.md
+++ b/.changeset/audit-fix-combine-min-release-age-excludes.md
@@ -1,8 +1,9 @@
 ---
 "@pnpm/workspace.workspace-manifest-writer": patch
 "@pnpm/deps.compliance.commands": patch
+"@pnpm/installing.commands": patch
 "@pnpm/config.version-policy": patch
 "pnpm": patch
 ---
 
-`pnpm audit --fix` now writes a single combined `minimumReleaseAgeExclude` entry per package (e.g. `axios@0.18.1 || 0.21.1`) instead of one entry per version, matching the format documented for the setting. Existing per-version entries in `pnpm-workspace.yaml` are merged into the combined form rather than left as duplicates [#12534](https://github.com/pnpm/pnpm/issues/12534).
+`pnpm audit --fix` now writes a single combined `minimumReleaseAgeExclude` entry per package (e.g. `axios@0.18.1 || 0.21.1`) instead of one entry per version, matching the format documented for the setting. Existing per-version entries in `pnpm-workspace.yaml` are merged into the combined form rather than left as duplicates. Installs that auto-collect immature versions into `minimumReleaseAgeExclude` now report the same combined entries, so the "Added N entries" message matches what is written to the manifest [#12534](https://github.com/pnpm/pnpm/issues/12534).

--- a/.changeset/audit-fix-combine-min-release-age-excludes.md
+++ b/.changeset/audit-fix-combine-min-release-age-excludes.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/workspace.workspace-manifest-writer": patch
+"@pnpm/deps.compliance.commands": patch
+"@pnpm/config.version-policy": patch
+"pnpm": patch
+---
+
+`pnpm audit --fix` now writes a single combined `minimumReleaseAgeExclude` entry per package (e.g. `axios@0.18.1 || 0.21.1`) instead of one entry per version, matching the format documented for the setting. Existing per-version entries in `pnpm-workspace.yaml` are merged into the combined form rather than left as duplicates [#12534](https://github.com/pnpm/pnpm/issues/12534).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5282,6 +5282,9 @@ importers:
       '@pnpm/config.reader':
         specifier: workspace:*
         version: link:../../config/reader
+      '@pnpm/config.version-policy':
+        specifier: workspace:*
+        version: link:../../config/version-policy
       '@pnpm/config.writer':
         specifier: workspace:*
         version: link:../../config/writer

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2991,6 +2991,9 @@ importers:
       '@pnpm/config.reader':
         specifier: workspace:*
         version: link:../../../config/reader
+      '@pnpm/config.version-policy':
+        specifier: workspace:*
+        version: link:../../../config/version-policy
       '@pnpm/config.writer':
         specifier: workspace:*
         version: link:../../../config/writer
@@ -10023,6 +10026,9 @@ importers:
       '@pnpm/config.parse-overrides':
         specifier: workspace:*
         version: link:../../config/parse-overrides
+      '@pnpm/config.version-policy':
+        specifier: workspace:*
+        version: link:../../config/version-policy
       '@pnpm/constants':
         specifier: workspace:*
         version: link:../../core/constants

--- a/pnpm11/config/version-policy/src/index.ts
+++ b/pnpm11/config/version-policy/src/index.ts
@@ -56,6 +56,34 @@ export function getPublishedByPolicy (opts: PublishedByPolicyOptions): Published
   }
 }
 
+/**
+ * Merges a list of package version policy specs (e.g. `minimumReleaseAgeExclude`
+ * entries) into one canonical entry per package. Specs for the same package are
+ * combined: a bare name/pattern (no version) excludes every version and absorbs
+ * any version-specific specs for that package, otherwise the exact versions are
+ * deduplicated, sorted by semver, and joined into a single `name@v1 || v2` entry.
+ * Packages keep their first-seen order so the output is stable.
+ */
+export function mergePackageVersionSpecs (specs: string[]): string[] {
+  const byPackage = new Map<string, Set<string> | null>()
+  for (const spec of specs) {
+    const { packageName, exactVersions } = parseVersionPolicyRule(spec)
+    const existing = byPackage.get(packageName)
+    if (existing === undefined) {
+      byPackage.set(packageName, exactVersions.length === 0 ? null : new Set(exactVersions))
+    } else if (existing === null || exactVersions.length === 0) {
+      byPackage.set(packageName, null)
+    } else {
+      for (const version of exactVersions) existing.add(version)
+    }
+  }
+  return Array.from(byPackage.entries()).map(([packageName, versions]) =>
+    versions == null
+      ? packageName
+      : `${packageName}@${Array.from(versions).sort(semver.compare).join(' || ')}`
+  )
+}
+
 export function expandPackageVersionSpecs (specs: string[]): Set<string> {
   const expandedSpecs = new Set<string>()
   for (const spec of specs) {

--- a/pnpm11/config/version-policy/test/index.ts
+++ b/pnpm11/config/version-policy/test/index.ts
@@ -3,6 +3,7 @@ import {
   createPackageVersionPolicy,
   createPackageVersionPolicyOrThrow,
   getPublishedByPolicy,
+  mergePackageVersionSpecs,
 } from '@pnpm/config.version-policy'
 
 test('createPackageVersionPolicy()', () => {
@@ -136,4 +137,51 @@ test('getPublishedByPolicy() rewraps invalid exclude patterns as ERR_PNPM_INVALI
     minimumReleaseAge: 24 * 60,
     minimumReleaseAgeExclude: ['pnpm@^9.0.0'],
   })).toThrow(expect.objectContaining({ code: 'ERR_PNPM_INVALID_MINIMUM_RELEASE_AGE_EXCLUDE' }))
+})
+
+test('mergePackageVersionSpecs() combines versions of the same package into one sorted entry', () => {
+  expect(mergePackageVersionSpecs([
+    'axios@0.21.2',
+    'axios@0.18.1',
+    'axios@0.21.1',
+  ])).toEqual(['axios@0.18.1 || 0.21.1 || 0.21.2'])
+})
+
+test('mergePackageVersionSpecs() merges separate entries and union entries for the same package', () => {
+  expect(mergePackageVersionSpecs([
+    'axios@0.18.1 || 0.21.1',
+    'axios@0.21.2',
+  ])).toEqual(['axios@0.18.1 || 0.21.1 || 0.21.2'])
+})
+
+test('mergePackageVersionSpecs() deduplicates repeated versions', () => {
+  expect(mergePackageVersionSpecs([
+    'axios@0.18.1',
+    'axios@0.18.1',
+  ])).toEqual(['axios@0.18.1'])
+})
+
+test('mergePackageVersionSpecs() keeps different packages as separate first-seen entries', () => {
+  expect(mergePackageVersionSpecs([
+    'lodash@4.17.21',
+    'axios@0.18.1',
+  ])).toEqual(['lodash@4.17.21', 'axios@0.18.1'])
+})
+
+test('mergePackageVersionSpecs() handles scoped packages', () => {
+  expect(mergePackageVersionSpecs([
+    '@scope/pkg@1.0.0',
+    '@scope/pkg@2.0.0',
+  ])).toEqual(['@scope/pkg@1.0.0 || 2.0.0'])
+})
+
+test('mergePackageVersionSpecs() lets a bare package name absorb version-specific entries', () => {
+  expect(mergePackageVersionSpecs([
+    'axios@1.0.0',
+    'axios',
+  ])).toEqual(['axios'])
+  expect(mergePackageVersionSpecs([
+    'is-*',
+    'is-odd@1.0.0',
+  ])).toEqual(['is-*', 'is-odd@1.0.0'])
 })

--- a/pnpm11/deps/compliance/commands/package.json
+++ b/pnpm11/deps/compliance/commands/package.json
@@ -42,6 +42,7 @@
     "@pnpm/cli.utils": "workspace:*",
     "@pnpm/config.pick-registry-for-package": "workspace:*",
     "@pnpm/config.reader": "workspace:*",
+    "@pnpm/config.version-policy": "workspace:*",
     "@pnpm/config.writer": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/deps.compliance.audit": "workspace:*",

--- a/pnpm11/deps/compliance/commands/src/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fix.ts
@@ -1,3 +1,4 @@
+import { mergePackageVersionSpecs } from '@pnpm/config.version-policy'
 import { writeSettings } from '@pnpm/config.writer'
 import { type AuditAdvisory, type AuditReport, normalizeGhsaId } from '@pnpm/deps.compliance.audit'
 import { sortDirectKeys } from '@pnpm/object.key-sorting'
@@ -56,18 +57,13 @@ export function caretRangeForPatched (patchedRange: string): string {
 }
 
 export function createMinimumReleaseAgeExcludes (advisories: AuditAdvisory[]): string[] {
-  const excludes = new Map<string, Set<string>>()
+  const specs: string[] = []
   for (const advisory of advisories) {
     const patchedVersions = advisory.patched_versions
     if (!patchedVersions) continue
     const minVersion = semver.minVersion(patchedVersions)
     if (!minVersion) continue
-    const existing = excludes.get(advisory.module_name)
-    if (existing) {
-      existing.add(minVersion.version)
-    } else {
-      excludes.set(advisory.module_name, new Set([minVersion.version]))
-    }
+    specs.push(`${advisory.module_name}@${minVersion.version}`)
   }
-  return Array.from(excludes.entries()).map(([module, versions]) => `${module}@${Array.from(versions).sort(semver.compare).join(' || ')}`)
+  return mergePackageVersionSpecs(specs)
 }

--- a/pnpm11/deps/compliance/commands/src/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fix.ts
@@ -56,14 +56,18 @@ export function caretRangeForPatched (patchedRange: string): string {
 }
 
 export function createMinimumReleaseAgeExcludes (advisories: AuditAdvisory[]): string[] {
-  const excludes = new Set<string>()
+  const excludes = new Map<string, Set<string>>()
   for (const advisory of advisories) {
     const patchedVersions = advisory.patched_versions
     if (!patchedVersions) continue
     const minVersion = semver.minVersion(patchedVersions)
-    if (minVersion) {
-      excludes.add(`${advisory.module_name}@${minVersion.version}`)
+    if (!minVersion) continue
+    const existing = excludes.get(advisory.module_name)
+    if (existing) {
+      existing.add(minVersion.version)
+    } else {
+      excludes.set(advisory.module_name, new Set([minVersion.version]))
     }
   }
-  return Array.from(excludes)
+  return Array.from(excludes.entries()).map(([module, versions]) => `${module}@${Array.from(versions).sort(semver.compare).join(' || ')}`)
 }

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -184,6 +184,15 @@ describe('createMinimumReleaseAgeExcludes', () => {
     const excludes = createMinimumReleaseAgeExcludes(advisories)
     expect(excludes).toEqual([])
   })
+
+  test('deduplicates the same minimum patched version for a module', () => {
+    const advisories = [
+      advisory('axios', '<=0.18.0', '>=0.18.1'),
+      advisory('axios', '<=0.17.0', '>=0.18.1'),
+    ]
+    const excludes = createMinimumReleaseAgeExcludes(advisories)
+    expect(excludes).toEqual(['axios@0.18.1'])
+  })
 })
 
 describe('caretRangeForPatched', () => {

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -1,11 +1,13 @@
 import path from 'node:path'
 
-import { afterEach, beforeEach, expect, test } from '@jest/globals'
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals'
+import type { AuditAdvisory } from '@pnpm/deps.compliance.audit'
 import { audit } from '@pnpm/deps.compliance.commands'
 import { fixtures } from '@pnpm/test-fixtures'
 import { getMockAgent, setupMockAgent, teardownMockAgent } from '@pnpm/testing.mock-agent'
 import { readYamlFileSync } from 'read-yaml-file'
 
+import { caretRangeForPatched, createMinimumReleaseAgeExcludes } from '../../src/audit/fix.js'
 import { AUDIT_REGISTRY, AUDIT_REGISTRY_OPTS } from './utils/options.js'
 import * as responses from './utils/responses/index.js'
 
@@ -43,13 +45,12 @@ test('overrides are added for vulnerable dependencies', async () => {
   expect(manifest.overrides?.['axios@<=0.18.0']).toBe('^0.18.1')
   expect(manifest.overrides?.['sync-exec@>=0.0.0']).toBeFalsy()
 
-  // minimumReleaseAgeExclude should contain the minimum patched versions
-  expect(manifest.minimumReleaseAgeExclude).toContain('axios@0.18.1')
-  expect(manifest.minimumReleaseAgeExclude).toContain('axios@0.21.1')
-  expect(manifest.minimumReleaseAgeExclude).toContain('axios@0.21.2')
-  // unfixable advisories (patched_versions: "<0.0.0") should not be included
-  expect(manifest.minimumReleaseAgeExclude).not.toContain('sync-exec@0.0.0')
-  expect(manifest.minimumReleaseAgeExclude).not.toContain('timespan@0.0.0')
+  // minimumReleaseAgeExclude should combine versions per module
+  const axiosExclude = manifest.minimumReleaseAgeExclude?.find((e) => e.startsWith('axios@'))
+  expect(axiosExclude).toBeDefined()
+  expect(axiosExclude).toContain('0.18.1')
+  expect(axiosExclude).toContain('0.21.1')
+  expect(axiosExclude).toContain('0.21.2')
 })
 
 test('no overrides are added if no vulnerabilities are found', async () => {
@@ -127,4 +128,70 @@ test('audit --fix respects auditLevel and only fixes matching severities', async
   expect(manifest.overrides?.['axios@<=0.18.0']).toBeFalsy()
   expect(manifest.overrides?.['axios@<0.21.2']).toBeFalsy()
   expect(manifest.overrides?.['url-parse@<1.5.6']).toBeFalsy()
+})
+
+function advisory (moduleName: string, vulnerableVersions: string, patchedVersions?: string): AuditAdvisory {
+  return {
+    findings: [],
+    id: 0,
+    title: '',
+    module_name: moduleName,
+    vulnerable_versions: vulnerableVersions,
+    patched_versions: patchedVersions,
+    severity: 'high',
+    cwe: '',
+    github_advisory_id: '',
+    url: '',
+  }
+}
+
+describe('createMinimumReleaseAgeExcludes', () => {
+  test('combines multiple advisories for the same module into a single sorted entry', () => {
+    const advisories = [
+      advisory('axios', '<0.21.2', '>=0.21.2'),
+      advisory('axios', '<=0.18.0', '>=0.18.1'),
+      advisory('axios', '<0.21.1', '>=0.21.1'),
+    ]
+    const excludes = createMinimumReleaseAgeExcludes(advisories)
+    expect(excludes).toEqual(['axios@0.18.1 || 0.21.1 || 0.21.2'])
+  })
+
+  test('keeps different modules as separate entries', () => {
+    const advisories = [
+      advisory('axios', '<=0.18.0', '>=0.18.1'),
+      advisory('lodash', '<4.17.21', '>=4.17.21'),
+    ]
+    const excludes = createMinimumReleaseAgeExcludes(advisories)
+    expect(excludes).toEqual([
+      'axios@0.18.1',
+      'lodash@4.17.21',
+    ])
+  })
+
+  test('skips advisories without patched_versions', () => {
+    const advisories = [
+      advisory('axios', '<=0.18.0', '>=0.18.1'),
+      advisory('sync-exec', '>=0.0.0'),
+    ]
+    const excludes = createMinimumReleaseAgeExcludes(advisories)
+    expect(excludes).toEqual(['axios@0.18.1'])
+  })
+
+  test('returns empty array when no advisories are fixable', () => {
+    const advisories = [
+      advisory('sync-exec', '>=0.0.0'),
+    ]
+    const excludes = createMinimumReleaseAgeExcludes(advisories)
+    expect(excludes).toEqual([])
+  })
+})
+
+describe('caretRangeForPatched', () => {
+  test('converts a >= range to a caret range', () => {
+    expect(caretRangeForPatched('>=0.18.1')).toBe('^0.18.1')
+  })
+
+  test('picks the minimum version from a complex range', () => {
+    expect(caretRangeForPatched('>=1.0.0 <2.0.0')).toBe('^1.0.0')
+  })
 })

--- a/pnpm11/deps/compliance/commands/tsconfig.json
+++ b/pnpm11/deps/compliance/commands/tsconfig.json
@@ -35,6 +35,9 @@
       "path": "../../../config/reader"
     },
     {
+      "path": "../../../config/version-policy"
+    },
+    {
       "path": "../../../config/writer"
     },
     {

--- a/pnpm11/installing/commands/package.json
+++ b/pnpm11/installing/commands/package.json
@@ -44,6 +44,7 @@
     "@pnpm/config.matcher": "workspace:*",
     "@pnpm/config.pick-registry-for-package": "workspace:*",
     "@pnpm/config.reader": "workspace:*",
+    "@pnpm/config.version-policy": "workspace:*",
     "@pnpm/config.writer": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/deps.inspection.outdated": "workspace:*",

--- a/pnpm11/installing/commands/src/policyHandlers.ts
+++ b/pnpm11/installing/commands/src/policyHandlers.ts
@@ -1,4 +1,5 @@
 import { confirm } from '@inquirer/prompts'
+import { mergePackageVersionSpecs } from '@pnpm/config.version-policy'
 import { PnpmError } from '@pnpm/error'
 import { globalInfo } from '@pnpm/logger'
 import { MINIMUM_RELEASE_AGE_VIOLATION_CODE } from '@pnpm/resolving.npm-resolver'
@@ -206,7 +207,12 @@ function pickImmatureEntries (
 ): string[] | undefined {
   const immature = filterImmatureViolations(violations)
   if (immature.length === 0) return undefined
-  const sorted = [...new Set(immature.map((v) => `${v.name}@${v.version}`))].sort()
+  // Combine into the canonical per-package form the workspace writer
+  // persists (`name@v1 || v2`), so the logged count and list match the
+  // entries that actually land in pnpm-workspace.yaml even when multiple
+  // immature versions belong to the same package. The pre-sort keeps the
+  // cross-package order stable regardless of resolution order.
+  const entries = mergePackageVersionSpecs(immature.map((v) => `${v.name}@${v.version}`).sort())
   // Strict-mode picks already passed through the approval prompt, so
   // the log here only confirms what was persisted. Loose-mode picks
   // haven't been announced anywhere else, so the same log doubles as
@@ -215,10 +221,10 @@ function pickImmatureEntries (
     ? '(approved at the prompt)'
     : '(set minimumReleaseAgeStrict to true to gate these updates with a prompt)'
   globalInfo(
-    `Added ${sorted.length} ${sorted.length === 1 ? 'entry' : 'entries'} to minimumReleaseAgeExclude in pnpm-workspace.yaml ` +
-    `${reason}:\n  ${sorted.join('\n  ')}`
+    `Added ${entries.length} ${entries.length === 1 ? 'entry' : 'entries'} to minimumReleaseAgeExclude in pnpm-workspace.yaml ` +
+    `${reason}:\n  ${entries.join('\n  ')}`
   )
-  return sorted
+  return entries
 }
 
 function failOnImmature (immature: readonly PolicyViolation[]): PnpmError {

--- a/pnpm11/installing/commands/test/policyHandlers.ts
+++ b/pnpm11/installing/commands/test/policyHandlers.ts
@@ -141,6 +141,27 @@ test('loose-mode plan emits a workspace patch with sorted unique entries and log
   }
 })
 
+test('loose-mode plan combines multiple immature versions of one package into a single entry', () => {
+  const plan = setupPolicyHandlers({ minimumReleaseAge: 60 })!
+  const violations = [
+    violation('foo', '2.0.0'),
+    violation('foo', '1.0.0'),
+    violation('bar', '3.1.0'),
+  ]
+
+  // Avoid leaking console output in test runs.
+  const infoSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+  try {
+    const updates = plan.pickManifestUpdates(violations)
+    // The versions of `foo` collapse into one canonical, semver-sorted
+    // entry — matching the form the workspace writer persists, so the
+    // logged "Added N entries" count is not inflated by per-version picks.
+    expect(updates).toEqual({ addedMinimumReleaseAgeExcludes: ['bar@3.1.0', 'foo@1.0.0 || 2.0.0'] })
+  } finally {
+    infoSpy.mockRestore()
+  }
+})
+
 test('pickManifestUpdates returns undefined when no handler contributes anything', () => {
   const plan = setupPolicyHandlers({ minimumReleaseAge: 60 })!
   expect(plan.pickManifestUpdates([])).toBeUndefined()

--- a/pnpm11/installing/commands/tsconfig.json
+++ b/pnpm11/installing/commands/tsconfig.json
@@ -52,6 +52,9 @@
       "path": "../../config/reader"
     },
     {
+      "path": "../../config/version-policy"
+    },
+    {
       "path": "../../config/writer"
     },
     {

--- a/pnpm11/workspace/workspace-manifest-writer/package.json
+++ b/pnpm11/workspace/workspace-manifest-writer/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/config.parse-overrides": "workspace:*",
+    "@pnpm/config.version-policy": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/lockfile.types": "workspace:*",
     "@pnpm/types": "workspace:*",

--- a/pnpm11/workspace/workspace-manifest-writer/src/index.ts
+++ b/pnpm11/workspace/workspace-manifest-writer/src/index.ts
@@ -4,6 +4,7 @@ import util from 'node:util'
 
 import type { Catalogs } from '@pnpm/catalogs.types'
 import { parsePkgAndParentSelector } from '@pnpm/config.parse-overrides'
+import { mergePackageVersionSpecs } from '@pnpm/config.version-policy'
 import { type GLOBAL_CONFIG_YAML_FILENAME, WORKSPACE_MANIFEST_FILENAME } from '@pnpm/constants'
 import type { ResolvedCatalogEntry } from '@pnpm/lockfile.types'
 import type {
@@ -92,11 +93,9 @@ export async function updateWorkspaceManifest (dir: string, opts: {
     }
   }
   if (opts.addedMinimumReleaseAgeExcludes?.length) {
-    const merged = mergeAgeExcludes(
-      manifest.minimumReleaseAgeExclude ?? [],
-      opts.addedMinimumReleaseAgeExcludes
-    )
-    if (merged) {
+    const existing = manifest.minimumReleaseAgeExclude ?? []
+    const merged = mergePackageVersionSpecs([...existing, ...opts.addedMinimumReleaseAgeExcludes])
+    if (!equals(existing, merged)) {
       shouldBeUpdated = true
       manifest.minimumReleaseAgeExclude = merged
     }
@@ -254,30 +253,6 @@ function addPackageReference (packageReferences: Record<string, Set<string>>, pk
     packageReferences[pkgName] = new Set()
   }
   packageReferences[pkgName].add(version)
-}
-
-function parseAgeExclude (entry: string): [string, string[]] {
-  const [module, versions] = entry.split(/.(@)/);
-  return [
-    module,
-    versions.split(' || ').map((v) => v.trim()).filter(Boolean),
-  ]
-}
-
-function mergeAgeExcludes (existing: string[], added: string[]): string[] | null {
-  const byModule = new Map<string, Set<string>>()
-  for (const entry of [...existing, ...added]) {
-    const [module, versions] = parseAgeExclude(entry)
-    const rec = byModule.get(module)
-    if (rec) {
-      for (const v of versions) rec.add(v)
-    } else {
-      byModule.set(module, new Set(versions))
-    }
-  }
-  const merged = Array.from(byModule.entries())
-    .map(([module, versions]) => `${module}@${Array.from(versions).sort().join(' || ')}`)
-  return merged
 }
 
 interface KeyOrderNode {

--- a/pnpm11/workspace/workspace-manifest-writer/src/index.ts
+++ b/pnpm11/workspace/workspace-manifest-writer/src/index.ts
@@ -92,12 +92,13 @@ export async function updateWorkspaceManifest (dir: string, opts: {
     }
   }
   if (opts.addedMinimumReleaseAgeExcludes?.length) {
-    const existing: string[] = manifest.minimumReleaseAgeExclude ?? []
-    const existingSet = new Set(existing)
-    const newEntries = [...new Set(opts.addedMinimumReleaseAgeExcludes)].filter((entry) => !existingSet.has(entry))
-    if (newEntries.length > 0) {
+    const merged = mergeAgeExcludes(
+      manifest.minimumReleaseAgeExclude ?? [],
+      opts.addedMinimumReleaseAgeExcludes
+    )
+    if (merged) {
       shouldBeUpdated = true
-      manifest.minimumReleaseAgeExclude = [...existing, ...newEntries]
+      manifest.minimumReleaseAgeExclude = merged
     }
   }
   if (!shouldBeUpdated) {
@@ -253,6 +254,30 @@ function addPackageReference (packageReferences: Record<string, Set<string>>, pk
     packageReferences[pkgName] = new Set()
   }
   packageReferences[pkgName].add(version)
+}
+
+function parseAgeExclude (entry: string): [string, string[]] {
+  const [module, versions] = entry.split(/.(@)/);
+  return [
+    module,
+    versions.split(' || ').map((v) => v.trim()).filter(Boolean),
+  ]
+}
+
+function mergeAgeExcludes (existing: string[], added: string[]): string[] | null {
+  const byModule = new Map<string, Set<string>>()
+  for (const entry of [...existing, ...added]) {
+    const [module, versions] = parseAgeExclude(entry)
+    const rec = byModule.get(module)
+    if (rec) {
+      for (const v of versions) rec.add(v)
+    } else {
+      byModule.set(module, new Set(versions))
+    }
+  }
+  const merged = Array.from(byModule.entries())
+    .map(([module, versions]) => `${module}@${Array.from(versions).sort().join(' || ')}`)
+  return merged
 }
 
 interface KeyOrderNode {

--- a/pnpm11/workspace/workspace-manifest-writer/test/updateWorkspaceManifest.test.ts
+++ b/pnpm11/workspace/workspace-manifest-writer/test/updateWorkspaceManifest.test.ts
@@ -190,6 +190,30 @@ overrides:
   expect(fs.readFileSync(filePath).toString()).toStrictEqual(expected)
 })
 
+test('updateWorkspaceManifest merges addedMinimumReleaseAgeExcludes into existing entries', async () => {
+  const dir = tempDir(false)
+  const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
+  writeYamlFileSync(filePath, { packages: ['*'], minimumReleaseAgeExclude: ['axios@0.18.1'] })
+  await updateWorkspaceManifest(dir, {
+    addedMinimumReleaseAgeExcludes: ['axios@0.21.1 || 0.21.2', 'lodash@4.17.21'],
+  })
+  expect(readYamlFileSync(filePath)).toStrictEqual({
+    packages: ['*'],
+    minimumReleaseAgeExclude: ['axios@0.18.1 || 0.21.1 || 0.21.2', 'lodash@4.17.21'],
+  })
+})
+
+test('updateWorkspaceManifest does not rewrite when addedMinimumReleaseAgeExcludes introduce no change', async () => {
+  const dir = tempDir(false)
+  const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
+  const originalContent = 'packages:\n  - \'*\'\nminimumReleaseAgeExclude:\n  - axios@0.18.1 || 0.21.1\n'
+  fs.writeFileSync(filePath, originalContent)
+  await updateWorkspaceManifest(dir, {
+    addedMinimumReleaseAgeExcludes: ['axios@0.18.1'],
+  })
+  expect(fs.readFileSync(filePath).toString()).toStrictEqual(originalContent)
+})
+
 test('updateWorkspaceManifest adds a new catalog', async () => {
   const dir = tempDir(false)
   const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)

--- a/pnpm11/workspace/workspace-manifest-writer/tsconfig.json
+++ b/pnpm11/workspace/workspace-manifest-writer/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../../config/parse-overrides"
     },
     {
+      "path": "../../config/version-policy"
+    },
+    {
       "path": "../../core/constants"
     },
     {


### PR DESCRIPTION
## Summary

Updates the minimumReleaseAgeExcludes output to combine entries per module, matching rec in docs.

pnpm audit --fix currently adds a new line for each dep, but the docs state that they should be a single entry with versions separated by ' || ' this seems to be th ccause for some bug reports.

Fixes: #12534

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Updates the minimumReleaseAgeExcludes output to combine entries per module, matching rec in docs. (Closes pnpm/pnpm#12534).
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `minimumReleaseAge` exclusion generation so `pnpm audit --fix` writes a single combined `module@v1 || v2 ...` expression per dependency, consolidating duplicates and merging existing excludes.
  * Updated workspace manifest generation to merge/normalize `minimumReleaseAgeExclude` entries consistently and avoid rewriting the manifest when no effective change occurs.

* **Tests**
  * Expanded unit and integration test coverage to validate caret-range handling and the new single combined exclude entry format and contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->