### PR TITLE
chore(coderabbit): scope the pnpm CLI product label to the pnpm11 directory

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -42,8 +42,8 @@ reviews:
   auto_apply_labels: true
   # Custom labels assigned based on which product the diff touches. More than one may apply to a single PR.
   labeling_instructions:
-    - label: "product: pnpm"
-      instructions: "Apply when changes affect the TypeScript pnpm CLI (any code outside pacquet/ and pnpr/)."
+    - label: "product: pnpm@11"
+      instructions: "Apply only when changes are in the pnpm11/ directory (the TypeScript pnpm CLI, frozen at v11)."
     - label: "product: pacquet"
       instructions: "Apply when changes affect pacquet, the Rust port of the pnpm CLI (the pacquet/ directory)."
     - label: "product: pnpr"


### PR DESCRIPTION
## Summary

After the TypeScript pnpm CLI moved under `pnpm11/` (pnpm/pnpm#12537), CodeRabbit's `product: pnpm` auto-label was still defined as *"any code outside pacquet/ and pnpr/"* — which now also matches shared root files (workspace config, CI, docs) that aren't the TypeScript product.

This renames the label to **`product: pnpm@11`** and scopes it to apply **only when changes are in the `pnpm11/` directory**, so the label cleanly tracks the (frozen-at-v11) TypeScript CLI. The `product: pacquet` and `product: pnpr` instructions are unchanged.

> [!NOTE]
> **Companion admin step (not in this diff):** the repo currently has a GitHub label named `product: pnpm`, and no `product: pnpm@11`. For CodeRabbit's applied label to resolve, the GitHub label should be renamed `product: pnpm` → `product: pnpm@11` (`gh label edit "product: pnpm" --name "product: pnpm@11"`), which also preserves the label on existing PRs/issues. Happy to run it once this is approved.

## Squash Commit Body

```text
Rename the `product: pnpm` label to `product: pnpm@11` and apply it only
when changes touch the pnpm11/ directory. After the TypeScript CLI moved
under pnpm11/, the old "any code outside pacquet/ and pnpr/" instruction
over-matched shared root files (workspace config, CI, docs), so the label
no longer cleanly tracked the TypeScript product.
```

## Checklist

- [x] No `pacquet/` port needed — this changes CodeRabbit review tooling config only; no CLI behavior changes.
- [x] No changeset — `.coderabbit.yaml` is repo tooling, not a published package.
- [x] No tests — configuration-only change.
- [x] No docs change needed.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated labeling configuration for development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->