### PR TITLE
fix(pacquet): read moved pnpm sources from their pnpm11/ locations

### DIFF
--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -644,7 +644,7 @@ fn current_source_pnpm_version() -> Option<String> {
 }
 
 fn pnpm_version_from(root_dir: &Path) -> Option<String> {
-    let path = root_dir.join("pnpm").join("package.json");
+    let path = root_dir.join("pnpm11").join("pnpm").join("package.json");
     let value = read_manifest_json(&path).ok()??;
     value.get("version").and_then(Value::as_str).map(ToString::to_string)
 }

--- a/pacquet/crates/config/src/pnpm_default_parity.rs
+++ b/pacquet/crates/config/src/pnpm_default_parity.rs
@@ -229,7 +229,7 @@ fn scripts_prepend_node_path_scalar(value: ScriptsPrependNodePath) -> Scalar {
 /// config-reader source. Read live so the test tracks pnpm rather than
 /// a checked-in copy that could silently drift.
 fn read_pnpm_default_options() -> String {
-    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../../config/reader/src/index.ts");
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../../pnpm11/config/reader/src/index.ts");
     let src = std::fs::read_to_string(path).unwrap_or_else(|err| {
         panic!(
             "read pnpm config-reader source at {path}: {err}. \


### PR DESCRIPTION
## Summary

pnpm/pnpm#12537 moved the TypeScript pnpm CLI into a `pnpm11/` directory, but two pacquet code paths still read the old top-level locations, so they fail on `main`:

- `pacquet-cli`'s `pnpm_version_from` read `pnpm/package.json` (now `pnpm11/pnpm/package.json`), so `current_source_pnpm_version()` returned `None` and `package_manager_to_sync_preserves_dev_engine_specifier` failed.
- `pacquet-config`'s `pnpm_default_parity` contract tests read `config/reader/src/index.ts` (now `pnpm11/config/reader/src/index.ts`), so both parity tests failed with a missing-file panic.

Point both at their new `pnpm11/` locations.

## Squash Commit Body

```text
pnpm/pnpm#12537 moved the TypeScript pnpm CLI under `pnpm11/`. Two pacquet
paths into the TS tree weren't updated:

- pacquet-cli's `pnpm_version_from` read `pnpm/package.json`, so
  `current_source_pnpm_version` returned `None` and
  `package_manager_to_sync` (and its test) failed.
- pacquet-config's `pnpm_default_parity` contract tests read
  `config/reader/src/index.ts`, panicking on the missing file.

Read both from `pnpm11/...` instead.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated pnpm version detection to reference the correct package location within the workspace, ensuring the extracted version matches the expected pnpm installation.
* **Tests**
  * Refreshed the contract test setup so it reads pnpm’s default options from the correct TypeScript source path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->