### PR TITLE
feat(pacquet): add create command (port from pnpm create)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Fast, disk space efficient package manager:
 * **Works as a Node.js version manager.** See [pnpm runtime](https://pnpm.io/11.x/cli/runtime).
 * **Works everywhere.** Supports Windows, Linux, and macOS.
 * **Battle-tested.** Used in production by teams of [all sizes](https://pnpm.io/workspaces#usage-examples) since 2016.
+* **Experimental Rust port.** Includes [pacquet](./pacquet), an experimental port of the CLI written in Rust.
 * [See the full feature comparison with npm and Yarn](https://pnpm.io/feature-comparison).
 
 To quote the [Rush](https://rushjs.io/) team:

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -1,4 +1,5 @@
 pub mod add;
+pub mod create;
 pub mod dlx;
 pub mod exec;
 pub mod install;
@@ -15,6 +16,7 @@ pub mod why;
 use crate::{State, config_deps, config_overrides::ConfigOverrides};
 use add::AddArgs;
 use clap::{Parser, Subcommand, ValueEnum};
+use create::CreateArgs;
 use dlx::DlxArgs;
 use exec::ExecArgs;
 use install::InstallArgs;
@@ -141,6 +143,8 @@ pub enum CliCommand {
     Exec(ExecArgs),
     /// Run a package in a temporary environment.
     Dlx(DlxArgs),
+    /// Creates a project from a `create-*` starter kit.
+    Create(CreateArgs),
     /// Runs an arbitrary command specified in the package's start property of its scripts object.
     Start,
     /// Managing the package store.
@@ -225,7 +229,8 @@ impl CliArgs {
                 | CliCommand::Update(_)
                 | CliCommand::Remove(_)
                 | CliCommand::Install(_)
-                | CliCommand::Dlx(_),
+                | CliCommand::Dlx(_)
+                | CliCommand::Create(_),
         );
         let manifest_path = || dir.join("package.json");
         // Resolve `.npmrc` / `pnpm-workspace.yaml` from the canonicalized
@@ -408,6 +413,17 @@ impl CliArgs {
                 }
             }
             CliCommand::Dlx(args) => match reporter {
+                ReporterType::Default | ReporterType::AppendOnly => {
+                    Box::pin(args.run::<DefaultReporter>(&dir, config()?)).await?;
+                }
+                ReporterType::Ndjson => {
+                    Box::pin(args.run::<NdjsonReporter>(&dir, config()?)).await?;
+                }
+                ReporterType::Silent => {
+                    Box::pin(args.run::<SilentReporter>(&dir, config()?)).await?;
+                }
+            },
+            CliCommand::Create(args) => match reporter {
                 ReporterType::Default | ReporterType::AppendOnly => {
                     Box::pin(args.run::<DefaultReporter>(&dir, config()?)).await?;
                 }

--- a/pacquet/crates/cli/src/cli_args/create.rs
+++ b/pacquet/crates/cli/src/cli_args/create.rs
@@ -110,6 +110,7 @@ impl CreateArgs {
             os,
             libc,
         };
+        config.strict_dep_builds = false;
         dlx_args.run::<Reporter>(dir, config).await
     }
 }

--- a/pacquet/crates/cli/src/cli_args/create.rs
+++ b/pacquet/crates/cli/src/cli_args/create.rs
@@ -1,0 +1,187 @@
+use crate::cli_args::dlx::DlxArgs;
+use clap::Args;
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pacquet_config::Config;
+use pacquet_reporter::Reporter;
+use std::path::Path;
+
+/// Creates a project from a `create-*` starter kit.
+///
+/// Ports pnpm's `create` command from
+/// <https://github.com/pnpm/pnpm/blob/3687b0e180/exec/commands/src/create.ts>.
+/// The handler converts the user-provided name to a `create-*` package name
+/// and delegates to the existing `dlx` infrastructure.
+#[derive(Debug, Args)]
+pub struct CreateArgs {
+    /// The template name (e.g., `vite`, `create-vite`, `@scope/foo`).
+    pub name: Option<String>,
+
+    /// Arguments forwarded to the created package.
+    #[clap(trailing_var_arg = true, allow_hyphen_values = true)]
+    pub args: Vec<String>,
+
+    /// Package names allowed to run lifecycle (build) scripts during
+    /// the install. May be repeated.
+    #[clap(long = "allow-build")]
+    pub allow_build: Vec<String>,
+
+    /// Run the command inside of a shell. Uses `/bin/sh` on UNIX and
+    /// `cmd.exe` on Windows.
+    #[clap(long, short = 'c')]
+    pub shell_mode: bool,
+
+    /// CPU architectures whose platform-tagged optional dependencies the
+    /// install should keep. Repeat or comma-separate for multiple.
+    #[clap(long, value_delimiter = ',')]
+    pub cpu: Vec<String>,
+
+    /// Operating systems whose platform-tagged optional dependencies the
+    /// install should keep.
+    #[clap(long, value_delimiter = ',')]
+    pub os: Vec<String>,
+
+    /// libc families (`glibc`, `musl`) whose platform-tagged optional
+    /// dependencies the install should keep.
+    #[clap(long, value_delimiter = ',')]
+    pub libc: Vec<String>,
+}
+
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum CreateError {
+    #[display(
+        "Missing the template package name.\nThe correct usage is `pacquet create <name>` with <name> substituted for a package name."
+    )]
+    #[diagnostic(code(ERR_PNPM_MISSING_ARGS))]
+    MissingArgs,
+}
+
+const CREATE_PREFIX: &str = "create-";
+
+/// Resolves the npm package name for `create-*` packages.
+///
+/// Mirrors the naming algorithm in pnpm's `convertToCreateName`
+/// (<https://github.com/pnpm/pnpm/blob/3687b0e180/exec/commands/src/create.ts#L80-L98>).
+pub fn convert_to_create_name(package_name: &str) -> String {
+    if let Some(rest) = package_name.strip_prefix('@') {
+        let preferred_version_position = rest.find('@');
+        let (without_version, preferred_version) = match preferred_version_position {
+            Some(pos) => (&rest[..pos], &rest[pos..]),
+            None => (rest, ""),
+        };
+        let (scope, scoped_package) = match without_version.split_once('/') {
+            Some((scope, pkg)) => (scope, Some(pkg)),
+            None => (without_version, None),
+        };
+
+        match scoped_package {
+            Some("") | None => format!("@{scope}/create{preferred_version}"),
+            Some(pkg) => format!("@{scope}/{}{preferred_version}", ensure_create_prefixed(pkg)),
+        }
+    } else {
+        ensure_create_prefixed(package_name)
+    }
+}
+
+fn ensure_create_prefixed(package_name: &str) -> String {
+    if package_name.starts_with(CREATE_PREFIX) {
+        package_name.to_string()
+    } else {
+        format!("{CREATE_PREFIX}{package_name}")
+    }
+}
+
+impl CreateArgs {
+    pub async fn run<Reporter: self::Reporter + 'static>(
+        self,
+        dir: &Path,
+        config: &'static mut Config,
+    ) -> miette::Result<()> {
+        let CreateArgs { name, args, allow_build, shell_mode, cpu, os, libc } = self;
+        let name = name.ok_or(CreateError::MissingArgs)?;
+        let create_name = convert_to_create_name(&name);
+        let dlx_args = DlxArgs {
+            command: std::iter::once(create_name).chain(args).collect(),
+            package: vec![],
+            allow_build,
+            shell_mode,
+            cpu,
+            os,
+            libc,
+        };
+        dlx_args.run::<Reporter>(dir, config).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::convert_to_create_name;
+
+    #[test]
+    fn unscoped_unprefixed_gets_create_prefix() {
+        assert_eq!(convert_to_create_name("foo"), "create-foo");
+    }
+
+    #[test]
+    fn unscoped_already_prefixed_is_unchanged() {
+        assert_eq!(convert_to_create_name("create-foo"), "create-foo");
+    }
+
+    #[test]
+    fn unscoped_empty_prefix_is_unchanged() {
+        assert_eq!(convert_to_create_name("create-"), "create-");
+    }
+
+    #[test]
+    fn unscoped_underscore_prefix_gets_double_prefix() {
+        assert_eq!(convert_to_create_name("create_no_dash"), "create-create_no_dash");
+    }
+
+    #[test]
+    fn scoped_unprefixed_gets_create_prefix() {
+        assert_eq!(convert_to_create_name("@scope/foo"), "@scope/create-foo");
+    }
+
+    #[test]
+    fn scoped_already_prefixed_is_unchanged() {
+        assert_eq!(convert_to_create_name("@scope/create-foo"), "@scope/create-foo");
+    }
+
+    #[test]
+    fn scoped_empty_prefix_is_unchanged() {
+        assert_eq!(convert_to_create_name("@scope/create-"), "@scope/create-");
+    }
+
+    #[test]
+    fn scoped_underscore_prefix_gets_double_prefix() {
+        assert_eq!(convert_to_create_name("@scope/create_no_dash"), "@scope/create-create_no_dash");
+    }
+
+    #[test]
+    fn plain_scope_gets_create() {
+        assert_eq!(convert_to_create_name("@scope"), "@scope/create");
+    }
+
+    #[test]
+    fn unscoped_with_version() {
+        assert_eq!(convert_to_create_name("foo@2.0.0"), "create-foo@2.0.0");
+        assert_eq!(convert_to_create_name("foo@latest"), "create-foo@latest");
+    }
+
+    #[test]
+    fn scoped_with_version() {
+        assert_eq!(convert_to_create_name("@scope/foo@2.0.0"), "@scope/create-foo@2.0.0");
+    }
+
+    #[test]
+    fn scoped_already_prefixed_with_version() {
+        assert_eq!(convert_to_create_name("@scope/create-a@2.0.0"), "@scope/create-a@2.0.0");
+    }
+
+    #[test]
+    fn plain_scope_with_version() {
+        assert_eq!(convert_to_create_name("@scope@2.0.0"), "@scope/create@2.0.0");
+        assert_eq!(convert_to_create_name("@scope@next"), "@scope/create@next");
+    }
+}

--- a/pacquet/crates/cli/src/cli_args/create.rs
+++ b/pacquet/crates/cli/src/cli_args/create.rs
@@ -14,12 +14,10 @@ use std::path::Path;
 /// and delegates to the existing `dlx` infrastructure.
 #[derive(Debug, Args)]
 pub struct CreateArgs {
-    /// The template name (e.g., `vite`, `create-vite`, `@scope/foo`).
-    pub name: Option<String>,
-
-    /// Arguments forwarded to the created package.
+    /// The template name (e.g., `vite`, `create-vite`, `@scope/foo`),
+    /// followed by any arguments forwarded to the created package.
     #[clap(trailing_var_arg = true, allow_hyphen_values = true)]
-    pub args: Vec<String>,
+    pub command: Vec<String>,
 
     /// Package names allowed to run lifecycle (build) scripts during
     /// the install. May be repeated.
@@ -98,8 +96,10 @@ impl CreateArgs {
         dir: &Path,
         config: &'static mut Config,
     ) -> miette::Result<()> {
-        let CreateArgs { name, args, allow_build, shell_mode, cpu, os, libc } = self;
-        let name = name.ok_or(CreateError::MissingArgs)?;
+        let CreateArgs { command, allow_build, shell_mode, cpu, os, libc } = self;
+        let mut command_iter = command.into_iter();
+        let name = command_iter.next().ok_or(CreateError::MissingArgs)?;
+        let args: Vec<String> = command_iter.collect();
         let create_name = convert_to_create_name(&name);
         let dlx_args = DlxArgs {
             command: std::iter::once(create_name).chain(args).collect(),
@@ -115,73 +115,4 @@ impl CreateArgs {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::convert_to_create_name;
-
-    #[test]
-    fn unscoped_unprefixed_gets_create_prefix() {
-        assert_eq!(convert_to_create_name("foo"), "create-foo");
-    }
-
-    #[test]
-    fn unscoped_already_prefixed_is_unchanged() {
-        assert_eq!(convert_to_create_name("create-foo"), "create-foo");
-    }
-
-    #[test]
-    fn unscoped_empty_prefix_is_unchanged() {
-        assert_eq!(convert_to_create_name("create-"), "create-");
-    }
-
-    #[test]
-    fn unscoped_underscore_prefix_gets_double_prefix() {
-        assert_eq!(convert_to_create_name("create_no_dash"), "create-create_no_dash");
-    }
-
-    #[test]
-    fn scoped_unprefixed_gets_create_prefix() {
-        assert_eq!(convert_to_create_name("@scope/foo"), "@scope/create-foo");
-    }
-
-    #[test]
-    fn scoped_already_prefixed_is_unchanged() {
-        assert_eq!(convert_to_create_name("@scope/create-foo"), "@scope/create-foo");
-    }
-
-    #[test]
-    fn scoped_empty_prefix_is_unchanged() {
-        assert_eq!(convert_to_create_name("@scope/create-"), "@scope/create-");
-    }
-
-    #[test]
-    fn scoped_underscore_prefix_gets_double_prefix() {
-        assert_eq!(convert_to_create_name("@scope/create_no_dash"), "@scope/create-create_no_dash");
-    }
-
-    #[test]
-    fn plain_scope_gets_create() {
-        assert_eq!(convert_to_create_name("@scope"), "@scope/create");
-    }
-
-    #[test]
-    fn unscoped_with_version() {
-        assert_eq!(convert_to_create_name("foo@2.0.0"), "create-foo@2.0.0");
-        assert_eq!(convert_to_create_name("foo@latest"), "create-foo@latest");
-    }
-
-    #[test]
-    fn scoped_with_version() {
-        assert_eq!(convert_to_create_name("@scope/foo@2.0.0"), "@scope/create-foo@2.0.0");
-    }
-
-    #[test]
-    fn scoped_already_prefixed_with_version() {
-        assert_eq!(convert_to_create_name("@scope/create-a@2.0.0"), "@scope/create-a@2.0.0");
-    }
-
-    #[test]
-    fn plain_scope_with_version() {
-        assert_eq!(convert_to_create_name("@scope@2.0.0"), "@scope/create@2.0.0");
-        assert_eq!(convert_to_create_name("@scope@next"), "@scope/create@next");
-    }
-}
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/create/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/create/tests.rs
@@ -1,0 +1,68 @@
+use super::convert_to_create_name;
+
+#[test]
+fn unscoped_unprefixed_gets_create_prefix() {
+    assert_eq!(convert_to_create_name("foo"), "create-foo");
+}
+
+#[test]
+fn unscoped_already_prefixed_is_unchanged() {
+    assert_eq!(convert_to_create_name("create-foo"), "create-foo");
+}
+
+#[test]
+fn unscoped_empty_prefix_is_unchanged() {
+    assert_eq!(convert_to_create_name("create-"), "create-");
+}
+
+#[test]
+fn unscoped_underscore_prefix_gets_double_prefix() {
+    assert_eq!(convert_to_create_name("create_no_dash"), "create-create_no_dash");
+}
+
+#[test]
+fn scoped_unprefixed_gets_create_prefix() {
+    assert_eq!(convert_to_create_name("@scope/foo"), "@scope/create-foo");
+}
+
+#[test]
+fn scoped_already_prefixed_is_unchanged() {
+    assert_eq!(convert_to_create_name("@scope/create-foo"), "@scope/create-foo");
+}
+
+#[test]
+fn scoped_empty_prefix_is_unchanged() {
+    assert_eq!(convert_to_create_name("@scope/create-"), "@scope/create-");
+}
+
+#[test]
+fn scoped_underscore_prefix_gets_double_prefix() {
+    assert_eq!(convert_to_create_name("@scope/create_no_dash"), "@scope/create-create_no_dash");
+}
+
+#[test]
+fn plain_scope_gets_create() {
+    assert_eq!(convert_to_create_name("@scope"), "@scope/create");
+}
+
+#[test]
+fn unscoped_with_version() {
+    assert_eq!(convert_to_create_name("foo@2.0.0"), "create-foo@2.0.0");
+    assert_eq!(convert_to_create_name("foo@latest"), "create-foo@latest");
+}
+
+#[test]
+fn scoped_with_version() {
+    assert_eq!(convert_to_create_name("@scope/foo@2.0.0"), "@scope/create-foo@2.0.0");
+}
+
+#[test]
+fn scoped_already_prefixed_with_version() {
+    assert_eq!(convert_to_create_name("@scope/create-a@2.0.0"), "@scope/create-a@2.0.0");
+}
+
+#[test]
+fn plain_scope_with_version() {
+    assert_eq!(convert_to_create_name("@scope@2.0.0"), "@scope/create@2.0.0");
+    assert_eq!(convert_to_create_name("@scope@next"), "@scope/create@next");
+}

--- a/pacquet/crates/cli/src/cli_args/dlx.rs
+++ b/pacquet/crates/cli/src/cli_args/dlx.rs
@@ -292,8 +292,6 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
     for name in allow_build {
         config.allow_builds.insert(name.clone(), true);
     }
-    config.strict_dep_builds = false;
-
     let config: &Config = config;
 
     for pkg in pkgs {

--- a/pacquet/crates/cli/src/cli_args/dlx.rs
+++ b/pacquet/crates/cli/src/cli_args/dlx.rs
@@ -292,6 +292,8 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
     for name in allow_build {
         config.allow_builds.insert(name.clone(), true);
     }
+    config.strict_dep_builds = false;
+
     let config: &Config = config;
 
     for pkg in pkgs {

--- a/pacquet/crates/cli/tests/create.rs
+++ b/pacquet/crates/cli/tests/create.rs
@@ -35,10 +35,13 @@ fn create_converts_name_and_runs_via_dlx() {
 
     pacquet.with_arg("create").with_arg("touch-file-one-bin").assert().success();
 
+    let touch_txt = workspace.join("touch.txt");
     assert!(
-        workspace.join("touch.txt").exists(),
+        touch_txt.exists(),
         "the package's bin should run in the process cwd and write `touch.txt`",
     );
+    let content = std::fs::read_to_string(&touch_txt).unwrap();
+    assert_eq!(content, "[]", "no extra arguments should be forwarded");
 
     drop(root);
 }
@@ -47,7 +50,8 @@ fn create_converts_name_and_runs_via_dlx() {
 #[cfg(unix)]
 #[test]
 fn create_forwards_args_to_package() {
-    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init().add_mocked_registry();
+    let CommandTempCwd { pacquet, root, workspace, .. } =
+        CommandTempCwd::init().add_mocked_registry();
 
     pacquet
         .with_arg("create")
@@ -55,6 +59,11 @@ fn create_forwards_args_to_package() {
         .with_arg("--extra-arg")
         .assert()
         .success();
+
+    let touch_txt = workspace.join("touch.txt");
+    assert!(touch_txt.exists(), "touch.txt must exist");
+    let content = std::fs::read_to_string(&touch_txt).unwrap();
+    assert_eq!(content, "[\"--extra-arg\"]", "extra argument should be forwarded to the package");
 
     drop(root);
 }
@@ -76,9 +85,12 @@ fn create_allow_build_before_name_is_parsed() {
         .assert()
         .success();
 
-    assert!(
-        workspace.join("touch.txt").exists(),
-        "the package should install and run with --allow-build",
+    let touch_txt = workspace.join("touch.txt");
+    assert!(touch_txt.exists(), "the package should install and run with --allow-build",);
+    let content = std::fs::read_to_string(&touch_txt).unwrap();
+    assert_eq!(
+        content, "[]",
+        "--allow-build should be parsed/consumed by the CLI and not forwarded"
     );
 
     drop(root);
@@ -90,7 +102,8 @@ fn create_allow_build_before_name_is_parsed() {
 #[cfg(unix)]
 #[test]
 fn create_options_after_name_are_forwarded() {
-    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init().add_mocked_registry();
+    let CommandTempCwd { pacquet, root, workspace, .. } =
+        CommandTempCwd::init().add_mocked_registry();
 
     pacquet
         .with_arg("create")
@@ -98,6 +111,14 @@ fn create_options_after_name_are_forwarded() {
         .with_arg("--allow-build=touch-file-one-bin")
         .assert()
         .success();
+
+    let touch_txt = workspace.join("touch.txt");
+    assert!(touch_txt.exists(), "touch.txt must exist");
+    let content = std::fs::read_to_string(&touch_txt).unwrap();
+    assert_eq!(
+        content, "[\"--allow-build=touch-file-one-bin\"]",
+        "options after name should be forwarded to the package"
+    );
 
     drop(root);
 }
@@ -111,9 +132,12 @@ fn create_accepts_shell_mode_flag() {
 
     pacquet.with_arg("create").with_arg("-c").with_arg("touch-file-one-bin").assert().success();
 
-    assert!(
-        workspace.join("touch.txt").exists(),
-        "the package should install and run with shell mode",
+    let touch_txt = workspace.join("touch.txt");
+    assert!(touch_txt.exists(), "the package should install and run with shell mode",);
+    let content = std::fs::read_to_string(&touch_txt).unwrap();
+    assert_eq!(
+        content, "[]",
+        "shell mode flag should be parsed/consumed by the CLI and not forwarded"
     );
 
     drop(root);

--- a/pacquet/crates/cli/tests/create.rs
+++ b/pacquet/crates/cli/tests/create.rs
@@ -1,0 +1,120 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+
+/// `pacquet create` with no template name is an error, mirroring pnpm's
+/// `create`, which throws `ERR_PNPM_MISSING_ARGS` when given no arguments.
+#[test]
+fn create_errors_when_no_name_given() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+
+    let output = pacquet.with_arg("create").output().expect("spawn pacquet create");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    eprintln!("STDERR:\n{stderr}\n");
+    assert!(!output.status.success(), "create with no name must fail");
+    assert!(
+        stderr.contains("ERR_PNPM_MISSING_ARGS"),
+        "stderr must contain the pnpm-compatible error code",
+    );
+    assert!(
+        stderr.contains("Missing the template package name"),
+        "stderr must contain the human-readable message",
+    );
+
+    drop(root);
+}
+
+/// `pacquet create <name>` converts the name to `create-<name>` and
+/// delegates to dlx. Uses the mocked registry with a test package
+/// whose bin writes a file on execution.
+#[cfg(unix)]
+#[test]
+fn create_converts_name_and_runs_via_dlx() {
+    let CommandTempCwd { pacquet, root, workspace, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    pacquet.with_arg("create").with_arg("touch-file-one-bin").assert().success();
+
+    assert!(
+        workspace.join("touch.txt").exists(),
+        "the package's bin should run in the process cwd and write `touch.txt`",
+    );
+
+    drop(root);
+}
+
+/// `pacquet create` passes remaining arguments through to the package.
+#[cfg(unix)]
+#[test]
+fn create_forwards_args_to_package() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init().add_mocked_registry();
+
+    pacquet
+        .with_arg("create")
+        .with_arg("touch-file-one-bin")
+        .with_arg("--extra-arg")
+        .assert()
+        .success();
+
+    drop(root);
+}
+
+/// `pacquet create --allow-build <name>` passes the flag to dlx.
+/// Options must precede the `<name>` positional to be parsed by create;
+/// anything after `<name>` is forwarded opaquely (matching pnpm's
+/// `escapeArgs` semantics).
+#[cfg(unix)]
+#[test]
+fn create_allow_build_before_name_is_parsed() {
+    let CommandTempCwd { pacquet, root, workspace, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    pacquet
+        .with_arg("create")
+        .with_arg("--allow-build=touch-file-one-bin")
+        .with_arg("touch-file-one-bin")
+        .assert()
+        .success();
+
+    assert!(
+        workspace.join("touch.txt").exists(),
+        "the package should install and run with --allow-build",
+    );
+
+    drop(root);
+}
+
+/// Options placed after `<name>` are forwarded to the package, not parsed
+/// by create — matching pnpm's `escapeArgs` behavior where everything
+/// after the first positional is opaque.
+#[cfg(unix)]
+#[test]
+fn create_options_after_name_are_forwarded() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init().add_mocked_registry();
+
+    pacquet
+        .with_arg("create")
+        .with_arg("touch-file-one-bin")
+        .with_arg("--allow-build=touch-file-one-bin")
+        .assert()
+        .success();
+
+    drop(root);
+}
+
+/// `pacquet create` with `-c` (shell mode) flag works.
+#[cfg(unix)]
+#[test]
+fn create_accepts_shell_mode_flag() {
+    let CommandTempCwd { pacquet, root, workspace, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    pacquet.with_arg("create").with_arg("-c").with_arg("touch-file-one-bin").assert().success();
+
+    assert!(
+        workspace.join("touch.txt").exists(),
+        "the package should install and run with shell mode",
+    );
+
+    drop(root);
+}

--- a/pacquet/crates/cli/tests/create.rs
+++ b/pacquet/crates/cli/tests/create.rs
@@ -63,7 +63,7 @@ fn create_forwards_args_to_package() {
     let touch_txt = workspace.join("touch.txt");
     assert!(touch_txt.exists(), "touch.txt must exist");
     let content = std::fs::read_to_string(&touch_txt).unwrap();
-    assert_eq!(content, "[\"--extra-arg\"]", "extra argument should be forwarded to the package");
+    assert_eq!(content, r#"["--extra-arg"]"#, "extra argument should be forwarded to the package");
 
     drop(root);
 }
@@ -86,7 +86,7 @@ fn create_allow_build_before_name_is_parsed() {
         .success();
 
     let touch_txt = workspace.join("touch.txt");
-    assert!(touch_txt.exists(), "the package should install and run with --allow-build",);
+    assert!(touch_txt.exists(), "the package should install and run with --allow-build");
     let content = std::fs::read_to_string(&touch_txt).unwrap();
     assert_eq!(
         content, "[]",
@@ -116,7 +116,7 @@ fn create_options_after_name_are_forwarded() {
     assert!(touch_txt.exists(), "touch.txt must exist");
     let content = std::fs::read_to_string(&touch_txt).unwrap();
     assert_eq!(
-        content, "[\"--allow-build=touch-file-one-bin\"]",
+        content, r#"["--allow-build=touch-file-one-bin"]"#,
         "options after name should be forwarded to the package",
     );
 
@@ -133,7 +133,7 @@ fn create_accepts_shell_mode_flag() {
     pacquet.with_arg("create").with_arg("-c").with_arg("touch-file-one-bin").assert().success();
 
     let touch_txt = workspace.join("touch.txt");
-    assert!(touch_txt.exists(), "the package should install and run with shell mode",);
+    assert!(touch_txt.exists(), "the package should install and run with shell mode");
     let content = std::fs::read_to_string(&touch_txt).unwrap();
     assert_eq!(
         content, "[]",

--- a/pacquet/crates/cli/tests/create.rs
+++ b/pacquet/crates/cli/tests/create.rs
@@ -90,7 +90,7 @@ fn create_allow_build_before_name_is_parsed() {
     let content = std::fs::read_to_string(&touch_txt).unwrap();
     assert_eq!(
         content, "[]",
-        "--allow-build should be parsed/consumed by the CLI and not forwarded"
+        "--allow-build should be parsed/consumed by the CLI and not forwarded",
     );
 
     drop(root);
@@ -117,7 +117,7 @@ fn create_options_after_name_are_forwarded() {
     let content = std::fs::read_to_string(&touch_txt).unwrap();
     assert_eq!(
         content, "[\"--allow-build=touch-file-one-bin\"]",
-        "options after name should be forwarded to the package"
+        "options after name should be forwarded to the package",
     );
 
     drop(root);
@@ -137,7 +137,7 @@ fn create_accepts_shell_mode_flag() {
     let content = std::fs::read_to_string(&touch_txt).unwrap();
     assert_eq!(
         content, "[]",
-        "shell mode flag should be parsed/consumed by the CLI and not forwarded"
+        "shell mode flag should be parsed/consumed by the CLI and not forwarded",
     );
 
     drop(root);

--- a/pnpr/.fixtures/packages/create-touch-file-one-bin/1.0.0/cli.js
+++ b/pnpr/.fixtures/packages/create-touch-file-one-bin/1.0.0/cli.js
@@ -1,0 +1,4 @@
+'use strict'
+const fs = require('fs')
+
+fs.writeFileSync('touch.txt', 'hello world', 'utf8')

--- a/pnpr/.fixtures/packages/create-touch-file-one-bin/1.0.0/cli.js
+++ b/pnpr/.fixtures/packages/create-touch-file-one-bin/1.0.0/cli.js
@@ -1,4 +1,4 @@
 'use strict'
 const fs = require('fs')
 
-fs.writeFileSync('touch.txt', 'hello world', 'utf8')
+fs.writeFileSync('touch.txt', JSON.stringify(process.argv.slice(2)), 'utf8')

--- a/pnpr/.fixtures/packages/create-touch-file-one-bin/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/create-touch-file-one-bin/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "create-touch-file-one-bin",
+  "version": "1.0.0",
+  "bin": "cli.js"
+}

--- a/pnpr/.fixtures/packages/create-touch-file-one-bin/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/create-touch-file-one-bin/1.0.0/package.json
@@ -1,5 +1,8 @@
 {
   "name": "create-touch-file-one-bin",
   "version": "1.0.0",
-  "bin": "cli.js"
+  "bin": "cli.js",
+  "dependencies": {
+    "@pnpm.e2e/independent-and-requires-build": "1.0.0"
+  }
 }


### PR DESCRIPTION
## Summary

- Ports the `create` command from pnpm's `@pnpm/exec.commands/create` to Rust in pacquet
- Converts user-provided names to `create-*` packages via `convertToCreateName` and delegates to the existing `dlx` infrastructure — matching pnpm's exact design
- Implements the **Stage 3 "Script & process"** item from the [pacquet roadmap](https://github.com/pnpm/pnpm/issues/11633)
- 13 unit tests for name conversion covering all npm naming conventions
- 5 integration tests (error handling, happy path, args forwarding, `--allow-build`, `-c`)
- Adds `create-touch-file-one-bin` fixture to the pnpr mock registry

## Squash Commit Body

```text
Ports the create command from pnpm's TypeScript implementation
(@pnpm/exec.commands/create) to Rust. The handler converts the
user-provided name to a create-* package name via
convertToCreateName and delegates to the existing dlx
infrastructure — matching pnpm's exact design where create.ts
calls dlx.handler().

Implements the Stage 3 'Script & process' item from
pnpm/pnpm#11633 (pacquet roadmap).

Changes:
- Add pacquet/crates/cli/src/cli_args/create.rs: command handler,
  name-conversion algorithm (13 unit tests covering all npm naming
  conventions), and error for missing args.
- Wire Create(CreateArgs) into CliCommand dispatch.
- Add 5 integration tests (error handling, happy path, args
  forwarding, --allow-build, -c/--shell-mode).
- Add create-touch-file-one-bin fixture to pnpr mock registry.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (MiMoCode, mimo-auto).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `pacquet create` CLI subcommand to scaffold projects from `create-*` starter kits.
  * Converts input template names into pnpm-compatible `create-*` package names (supports scoped and versioned forms).
  * Supports forwarding trailing command arguments plus `--allow-build`, shell mode (`-c`), and platform selectors (CPU/OS/libc).
  * Added fixture packages to validate the delegated creation behavior.

* **Bug Fixes**
  * Improved the “missing template name” error output and exit behavior.

* **Tests**
  * Added CLI integration tests for argument/option forwarding and `create-*` name normalization edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->