### PR TITLE
fix(ci): point pnpm CLI bencher extraction at pnpm11/pnpm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,7 +185,7 @@ jobs:
         node .github/scripts/bencher-result-from-pnpm-summary.mjs \
           --name tests.cli \
           --output .bench/tests.cli.json \
-          --package-dir pnpm
+          --package-dir pnpm11/pnpm
     - name: Stage Bencher test durations
       if: steps.test-scope.outputs.full_tests == 'true'
       env:


### PR DESCRIPTION
## Summary

The full **TS CI** test job on `main` has been failing since pnpm/pnpm#12537 (which relocated the TypeScript pnpm CLI from `pnpm/` to `pnpm11/pnpm/`). The *Extract pnpm CLI e2e test duration* step still passed `--package-dir pnpm` to `bencher-result-from-pnpm-summary.mjs`. That path no longer exists, so the exec-summary lookup found no entry for it and the script exited 1, failing the job.

Example failure: https://github.com/pnpm/pnpm/actions/runs/27872725265/job/82487383311

This points `--package-dir` at the package's new location, `pnpm11/pnpm`.

## Squash Commit Body

```text
The TypeScript pnpm CLI was relocated from `pnpm/` to `pnpm11/pnpm/` in
pnpm/pnpm#12537, but the "Extract pnpm CLI e2e test duration" step still
passed `--package-dir pnpm`. That path no longer exists, so the
exec-summary lookup found no entry and the step exited 1, failing the
full TS CI test job on main.

Point `--package-dir` at the package's new location, `pnpm11/pnpm`.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. _(CI-only change; no pacquet port needed.)_
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. _(CI workflow only; no published package affected.)_
- [x] Added or updated tests. _(Not applicable — workflow path fix.)_
- [x] Updated the documentation if needed. _(Not applicable.)_

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal test workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->