### PR TITLE
fix(release): write release artifacts to the repo-root dist

### DIFF
--- a/pnpm11/__utils__/scripts/src/copy-artifacts.ts
+++ b/pnpm11/__utils__/scripts/src/copy-artifacts.ts
@@ -7,10 +7,10 @@ import { makeEmptyDir } from 'make-empty-dir'
 import * as tar from 'tar'
 import { glob } from 'tinyglobby'
 
-const repoRoot = path.join(import.meta.dirname, '../../..')
+const repoRoot = path.join(import.meta.dirname, '../../../..')
 const dest = path.join(repoRoot, 'dist')
-const artifactsDir = path.join(repoRoot, 'pnpm/artifacts')
-const pnpmDistDir = path.join(repoRoot, 'pnpm/dist')
+const artifactsDir = path.join(repoRoot, 'pnpm11/pnpm/artifacts')
+const pnpmDistDir = path.join(repoRoot, 'pnpm11/pnpm/dist')
 
 ;(async () => {
   await makeEmptyDir(dest)


### PR DESCRIPTION
## Summary

While checking the release pipeline after the `pnpm11/` relocation (pnpm/pnpm#12537), I found that `pn copy-artifacts` no longer writes to the directory the Release workflow reads from.

`copy-artifacts.ts` moved to `pnpm11/__utils__/scripts/src/`, so its `import.meta.dirname` + `'../../..'` now resolves to the `pnpm11/` directory instead of the repository root. As a result:

- `dest` became `pnpm11/dist` instead of the repo-root `dist`.

`release.yml` attests (`subject-path: 'dist/*'`) and uploads (`files: dist/*'`) from the repo-root `dist`. So a tagged release would publish to npm fine (those steps filter by package name) but produce a **GitHub Release with no binary assets** and a **failing build-provenance attestation**.

This restores `repoRoot` to the actual repository root and points the artifact source dirs at their new `pnpm11/pnpm/` locations. The resolved `artifactsDir`/`pnpmDistDir` are unchanged; only `dest` is corrected back to the repo root.

The other pnpm release-related workflows (`release.yml`, `create-release-pr.yml`, `update-latest.yml`, `docker.yml`) were also reviewed and reference packages by name or already-updated `pnpm11/...` paths, so they remain correct.

## Squash Commit Body

```text
The TypeScript stack was relocated under pnpm11/ in pnpm/pnpm#12537, which
moved copy-artifacts.ts to pnpm11/__utils__/scripts/src/. Its
import.meta.dirname + '../../..' now resolved to the pnpm11/ directory
instead of the repository root, so `pn copy-artifacts` wrote the release
tarballs to pnpm11/dist.

The Release workflow attests (subject-path: 'dist/*') and uploads
(files: dist/*) from the repo-root dist, so a tagged release would have
produced a GitHub Release with no binary assets and a failing provenance
attestation, even though the npm publishes (filtered by package name)
still succeeded.

Resolve repoRoot to the actual repository root again and point the
artifact source directories at their new pnpm11/pnpm/ locations.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. _(Release tooling only; no pacquet port needed.)_
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. _(Internal release script in a private package; nothing published changes.)_
- [x] Added or updated tests. _(Not applicable — path fix in a release script.)_
- [x] Updated the documentation if needed. _(Not applicable.)_

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal repository path references to reflect directory structure adjustments, ensuring proper artifact and distribution file handling in the build system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->