### PR TITLE
chore: reduce Qodo inline-comment noise on iterated PRs

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -49,8 +49,14 @@ auto_approve_for_no_suggestions = true
 auto_approve_for_low_review_effort = 2
 
 [review_agent]
+# `both` keeps every finding in the review summary; the threshold only
+# controls which ones are *also* posted as standalone inline threads.
+# Keep that bar high so per-push re-reviews don't repost low-severity
+# (perf/style) nits as new inline threads on every commit — the
+# higher-severity findings still surface inline, and everything remains
+# in the summary.
 comments_location_policy = "both"
-inline_comments_severity_threshold = 2
+inline_comments_severity_threshold = 3
 issues_user_guidelines = """
 Apply the review framework in REVIEW_GUIDE.md. The repo's priority order — security first, performance second — applies to every reviewer. You are one of two bots: to avoid duplicate comments, you provide the primary depth on security and performance while CodeRabbit provides the primary depth on correctness and convention adherence; always still report any clear correctness bug or documented-convention violation you find. Lead on: (1) security vulnerabilities per REVIEW_GUIDE.md's "Security review rules"; (2) performance regressions in pnpm, pacquet, and pnpr per REVIEW_GUIDE.md's "Performance review rules". Surface only issues tied to changed code, and explain the exploit path, impact, or hot path affected.
 """


### PR DESCRIPTION
## Summary

On long-running PRs, Qodo re-runs its full review on every push (`push_commands` with `handle_push_trigger = true`) and reposts low-severity perf/style findings as fresh inline threads each commit — which is noisy to manage.

This keeps the per-push review (it does catch real issues introduced in *later* commits, so dropping it would lose coverage) and instead raises `inline_comments_severity_threshold` from `2` to `3`. Effect:

- Higher-severity findings still get standalone inline threads on each push.
- Lower-severity (perf/style) findings are no longer re-threaded inline every push.
- `comments_location_policy = "both"` is unchanged, so **every** finding still appears in the review summary — nothing is dropped, it's just not re-posted as a new inline thread on each commit.

Per-push coverage and CodeRabbit are unaffected.

## Squash Commit Body

```text
Qodo re-runs its full review on every push (`push_commands`), reposting
low-severity perf/style nits as fresh inline threads on each commit of a
long-running PR. Keep the per-push review (it catches issues introduced in
later commits) but raise `inline_comments_severity_threshold` from 2 to 3 so
only higher-severity findings get standalone inline threads.
`comments_location_policy = "both"` is unchanged, so every finding still
appears in the review summary.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.

_Tooling/config only — no code, tests, changeset, or docs affected._

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted automated review settings to raise the threshold for when inline comments are generated.
  * Updated the related configuration documentation to match the new review workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->