### PR TITLE
feat(package-manager): port updateProjectManifest manifest writer

### DIFF
--- a/pacquet/crates/package-manager/src/lib.rs
+++ b/pacquet/crates/package-manager/src/lib.rs
@@ -44,6 +44,8 @@ mod symlink_direct_dependencies;
 mod symlink_package;
 mod tarball_prefetch;
 mod update;
+mod update_project_manifest;
+mod update_project_manifest_object;
 mod version_policy;
 mod virtual_store_layout;
 
@@ -86,5 +88,7 @@ pub use symlink_direct_dependencies::*;
 pub use symlink_package::*;
 pub use tarball_prefetch::*;
 pub use update::*;
+pub use update_project_manifest::*;
+pub use update_project_manifest_object::*;
 pub use version_policy::*;
 pub use virtual_store_layout::*;

--- a/pacquet/crates/package-manager/src/update.rs
+++ b/pacquet/crates/package-manager/src/update.rs
@@ -710,7 +710,7 @@ async fn fetch_latest(
 /// (the override that derives it from `linkWorkspacePackages` only runs under
 /// `--workspace`, and `--workspace` cannot be combined with `--latest`).
 /// Mirrors [`isWorkspaceLocalPathSpecifier`](https://github.com/pnpm/pnpm/blob/fddb8a4032/installing/deps-resolver/src/updateProjectManifest.ts#L72-L76).
-fn is_workspace_local_path_specifier(bare_specifier: &str) -> bool {
+pub(crate) fn is_workspace_local_path_specifier(bare_specifier: &str) -> bool {
     let Some(pref) = bare_specifier.strip_prefix("workspace:") else {
         return false;
     };

--- a/pacquet/crates/package-manager/src/update_project_manifest.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest.rs
@@ -25,10 +25,8 @@ pub struct ResolvedDirectDependency {
     /// registry range, `github:owner/repo#sha` for a git shorthand).
     pub normalized_bare_specifier: Option<String>,
     pub catalog_lookup: Option<CatalogLookup>,
-    /// The wanted dependency this was resolved from, carried so the spec is
-    /// saved against the exact request instead of a pairing reconstructed by
-    /// alias, specifier shape, or array position. Set by the resolver, which
-    /// already has it in hand when it produces the resolution.
+    /// The wanted dependency this was resolved from, populated by the resolver.
+    /// See [`update_project_manifest`] for why the linkage is carried.
     pub wanted_dependency: Option<WantedDependencyUpdate>,
 }
 

--- a/pacquet/crates/package-manager/src/update_project_manifest.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest.rs
@@ -1,7 +1,6 @@
 use crate::{PackageSpecObject, is_workspace_local_path_specifier, update_project_manifest_object};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry::PinnedVersion;
-use std::collections::HashMap;
 
 /// Catalog metadata for a direct dependency requested through the `catalog:`
 /// protocol. Port of pnpm's `CatalogLookupMetadata`.
@@ -26,11 +25,18 @@ pub struct ResolvedDirectDependency {
     /// registry range, `github:owner/repo#sha` for a git shorthand).
     pub normalized_bare_specifier: Option<String>,
     pub catalog_lookup: Option<CatalogLookup>,
+    /// The wanted dependency this was resolved from, carried so the spec is
+    /// saved against the exact request instead of a pairing reconstructed by
+    /// alias, specifier shape, or array position. Set by the resolver, which
+    /// already has it in hand when it produces the resolution.
+    pub wanted_dependency: Option<WantedDependencyUpdate>,
 }
 
-/// A wanted dependency the manifest writer matches resolved deps against. Only
-/// entries flagged [`update_spec`](Self::update_spec) participate, mirroring
-/// pnpm's `wantedDependencies` filter.
+/// A wanted dependency carried alongside its resolution and matched against the
+/// failed-to-resolve set. Only entries flagged
+/// [`update_spec`](Self::update_spec) are written, mirroring pnpm's
+/// `wantedDependencies` filter.
+#[derive(Clone)]
 pub struct WantedDependencyUpdate {
     /// Install alias, when the request carried one. `None` for a no-alias
     /// shorthand such as a bare `owner/repo#sha` GitHub request.
@@ -56,47 +62,27 @@ pub struct UpdateProjectManifestOptions<'a> {
 
 /// Rewrite `manifest`'s dependency specs from a completed resolution, mirroring
 /// pnpm's `updateProjectManifest`
-/// (`installing/deps-resolver/src/updateProjectManifest.ts`), including the
-/// matching fixes from [pnpm#11373](https://github.com/pnpm/pnpm/pull/11373).
+/// (`installing/deps-resolver/src/updateProjectManifest.ts`), with the
+/// explicit-linkage matching from [pnpm#11373](https://github.com/pnpm/pnpm/pull/11373).
 ///
-/// Each resolved direct dependency is paired with the wanted dependency it came
-/// from. A wanted dependency that carries an alias is matched **by alias** (not
-/// by position), so a dependency that failed to resolve — an optional dep
-/// dropped from `direct_dependencies` — cannot shift the pairing onto an
-/// unrelated dependency ([#11267](https://github.com/pnpm/pnpm/issues/11267)).
-/// Aliasless wanted dependencies (`pacquet add ./local`, `jsr:@x/y`, a bare
-/// `owner/repo#sha`, a GitHub URL) resolve to an alias no wanted dependency
-/// declared, so they are paired with the remaining resolved dependencies in
-/// order. A wanted dep flagged `update_spec` that matched nothing is still
-/// upserted with no specifier, which preserves its existing range rather than
-/// dropping it.
+/// Each resolved direct dependency carries the wanted dependency it was resolved
+/// from ([`ResolvedDirectDependency::wanted_dependency`]), so the spec is saved
+/// against the exact request rather than a pairing reconstructed by alias,
+/// specifier shape, or array position. This keeps a failed optional update from
+/// rewriting an unrelated dependency ([#11267](https://github.com/pnpm/pnpm/issues/11267))
+/// and lets aliasless selectors (`pacquet add ./local`, `jsr:@x/y`, a bare
+/// `owner/repo#sha`, a GitHub URL) be saved even when they resolve to an alias
+/// already present in the manifest. A wanted dep flagged `update_spec` that
+/// resolved to nothing is re-saved with no specifier, so it keeps its existing
+/// version under the importer's target field — a no-op when none is set (a
+/// plain install/update).
 pub fn update_project_manifest(
     manifest: &mut PackageManifest,
     opts: &UpdateProjectManifestOptions<'_>,
 ) {
-    let mut wanted_by_alias: HashMap<&str, &WantedDependencyUpdate> = HashMap::new();
-    let mut aliasless_wanted: Vec<&WantedDependencyUpdate> = Vec::new();
-    for wanted in opts.wanted_dependencies {
-        match wanted.alias.as_deref().filter(|alias| !alias.is_empty()) {
-            Some(alias) => {
-                wanted_by_alias.insert(alias, wanted);
-            }
-            None if wanted.update_spec => aliasless_wanted.push(wanted),
-            None => {}
-        }
-    }
-
-    let mut next_aliasless = 0;
     let mut specs: Vec<PackageSpecObject> = Vec::new();
     for resolved in opts.direct_dependencies {
-        let wanted = if let Some(wanted) = wanted_by_alias.get(resolved.alias.as_str()) {
-            Some(*wanted)
-        } else {
-            let wanted = aliasless_wanted.get(next_aliasless).copied();
-            next_aliasless += 1;
-            wanted
-        };
-        let Some(wanted) = wanted else { continue };
+        let Some(wanted) = resolved.wanted_dependency.as_ref() else { continue };
         if !wanted.update_spec {
             continue;
         }

--- a/pacquet/crates/package-manager/src/update_project_manifest.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest.rs
@@ -1,5 +1,5 @@
 use crate::{PackageSpecObject, is_workspace_local_path_specifier, update_project_manifest_object};
-use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_package_manifest::{DependencyGroup, PackageManifest, PackageManifestError};
 use pacquet_registry::PinnedVersion;
 
 /// Catalog metadata for a direct dependency requested through the `catalog:`
@@ -49,8 +49,9 @@ pub struct WantedDependencyUpdate {
 pub struct UpdateProjectManifestOptions<'a> {
     pub wanted_dependencies: &'a [WantedDependencyUpdate],
     pub direct_dependencies: &'a [ResolvedDirectDependency],
-    /// Also record the saved deps in `peerDependencies` (pnpm's
-    /// `importer.peer`).
+    /// Also record a saved dep in `peerDependencies` (pnpm's `importer.peer`).
+    /// Only takes effect alongside a `target_dependencies_field` write, mirroring
+    /// pnpm, where the peer entry is added inside the `saveType` branch.
     pub peer: bool,
     pub pinned_version: Option<PinnedVersion>,
     /// The dependency field the saved deps belong in (pnpm's
@@ -79,7 +80,7 @@ pub struct UpdateProjectManifestOptions<'a> {
 pub fn update_project_manifest(
     manifest: &mut PackageManifest,
     opts: &UpdateProjectManifestOptions<'_>,
-) {
+) -> Result<(), PackageManifestError> {
     let mut specs: Vec<PackageSpecObject> = Vec::new();
     for resolved in opts.direct_dependencies {
         let Some(wanted) = resolved.wanted_dependency.as_ref() else { continue };
@@ -116,7 +117,7 @@ pub fn update_project_manifest(
         }
     }
 
-    update_project_manifest_object(manifest, &specs);
+    update_project_manifest_object(manifest, &specs)
 }
 
 /// The specifier string to write for a matched dependency: a `catalog:`

--- a/pacquet/crates/package-manager/src/update_project_manifest.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest.rs
@@ -1,0 +1,153 @@
+use crate::{PackageSpecObject, is_workspace_local_path_specifier, update_project_manifest_object};
+use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_registry::PinnedVersion;
+
+/// Catalog metadata for a direct dependency requested through the `catalog:`
+/// protocol. Port of pnpm's `CatalogLookupMetadata`.
+pub struct CatalogLookup {
+    pub catalog_name: String,
+    pub specifier: String,
+    /// The `catalog:` text the user wrote (`catalog:` or `catalog:<name>`).
+    /// Written back to the manifest verbatim so a catalog reference survives
+    /// `add` / `update` instead of being replaced by the resolved version.
+    pub user_specified_bare_specifier: String,
+}
+
+/// A direct dependency as it came back from resolution. Port of the subset of
+/// pnpm's `ResolvedDirectDependency` that `updateProjectManifest` consumes.
+pub struct ResolvedDirectDependency {
+    /// Install name in `node_modules` (the manifest key to rewrite).
+    pub alias: String,
+    /// Resolved concrete version, when the resolver knows one. `None` for
+    /// git / tarball deps with no semver version.
+    pub version: Option<String>,
+    /// Resolver's canonical echo of the bare specifier (e.g. `^4` for a
+    /// registry range, `github:owner/repo#sha` for a git shorthand).
+    pub normalized_bare_specifier: Option<String>,
+    pub catalog_lookup: Option<CatalogLookup>,
+}
+
+/// A wanted dependency the manifest writer matches resolved deps against. Only
+/// entries flagged [`update_spec`](Self::update_spec) participate, mirroring
+/// pnpm's `wantedDependencies` filter.
+pub struct WantedDependencyUpdate {
+    /// Install alias, when the request carried one. `None` for a no-alias
+    /// shorthand such as a bare `owner/repo#sha` GitHub request.
+    pub alias: Option<String>,
+    pub bare_specifier: String,
+    pub update_spec: bool,
+}
+
+/// Inputs to [`update_project_manifest`] beyond the manifest itself.
+pub struct UpdateProjectManifestOptions<'a> {
+    pub wanted_dependencies: &'a [WantedDependencyUpdate],
+    pub direct_dependencies: &'a [ResolvedDirectDependency],
+    /// Also record the saved deps in `peerDependencies` (pnpm's
+    /// `importer.peer`).
+    pub peer: bool,
+    pub pinned_version: Option<PinnedVersion>,
+    /// The dependency field the saved deps belong in (pnpm's
+    /// `targetDependenciesField`). `None` leaves each dep in whichever field
+    /// already declares it.
+    pub target_dependencies_field: Option<DependencyGroup>,
+    pub preserve_workspace_protocol: bool,
+}
+
+/// Rewrite `manifest`'s dependency specs from a completed resolution, mirroring
+/// pnpm's `updateProjectManifest`
+/// (`installing/deps-resolver/src/updateProjectManifest.ts`), including the
+/// alias-matching fix from [pnpm#11373](https://github.com/pnpm/pnpm/pull/11373).
+///
+/// Each resolved direct dependency is matched to a wanted dependency **by
+/// alias** (not by position), so a dependency that failed to resolve — an
+/// optional dep dropped from `direct_dependencies` — cannot shift the match and
+/// rewrite an unrelated dependency ([#11267](https://github.com/pnpm/pnpm/issues/11267)).
+/// A wanted dep flagged `update_spec` that matched nothing is still upserted
+/// with no specifier, which preserves its existing range rather than dropping
+/// it.
+pub fn update_project_manifest(
+    manifest: &mut PackageManifest,
+    opts: &UpdateProjectManifestOptions<'_>,
+) {
+    let mut specs: Vec<PackageSpecObject> = opts
+        .direct_dependencies
+        .iter()
+        .filter_map(|resolved| {
+            let wanted = opts
+                .wanted_dependencies
+                .iter()
+                .find(|wanted| wanted_dep_matches_resolved_dep(wanted, resolved))?;
+            Some(PackageSpecObject {
+                alias: resolved.alias.clone(),
+                peer: opts.peer,
+                bare_specifier: Some(get_bare_specifier_to_save(
+                    wanted,
+                    resolved,
+                    opts.preserve_workspace_protocol,
+                )),
+                resolved_version: resolved.version.clone(),
+                pinned_version: opts.pinned_version,
+                save_type: opts.target_dependencies_field,
+            })
+        })
+        .collect();
+
+    for wanted in opts.wanted_dependencies {
+        let Some(alias) = wanted.alias.as_deref().filter(|alias| !alias.is_empty()) else {
+            continue;
+        };
+        if wanted.update_spec && !specs.iter().any(|spec| spec.alias == alias) {
+            specs.push(PackageSpecObject {
+                alias: alias.to_string(),
+                peer: opts.peer,
+                bare_specifier: None,
+                resolved_version: None,
+                pinned_version: None,
+                save_type: opts.target_dependencies_field,
+            });
+        }
+    }
+
+    update_project_manifest_object(manifest, &specs);
+}
+
+/// Whether `resolved` is the resolution of `wanted`. Matches by alias when the
+/// request carried one; otherwise by the resolved normalized specifier, with a
+/// `github:` shorthand fallback so a no-alias `owner/repo#sha` request matches
+/// its `github:owner/repo#sha` resolution.
+fn wanted_dep_matches_resolved_dep(
+    wanted: &WantedDependencyUpdate,
+    resolved: &ResolvedDirectDependency,
+) -> bool {
+    if !wanted.update_spec {
+        return false;
+    }
+    if let Some(alias) = wanted.alias.as_deref().filter(|alias| !alias.is_empty()) {
+        return alias == resolved.alias;
+    }
+    let Some(normalized) = resolved.normalized_bare_specifier.as_deref() else {
+        return false;
+    };
+    wanted.bare_specifier == normalized || format!("github:{}", wanted.bare_specifier) == normalized
+}
+
+/// The specifier string to write for a matched dependency: a `catalog:`
+/// reference is preserved verbatim; a workspace-local path spec is kept when
+/// `preserve_workspace_protocol` is set; otherwise the resolver's normalized
+/// specifier wins, falling back to the originally-wanted spec.
+fn get_bare_specifier_to_save(
+    wanted: &WantedDependencyUpdate,
+    resolved: &ResolvedDirectDependency,
+    preserve_workspace_protocol: bool,
+) -> String {
+    if let Some(catalog_lookup) = &resolved.catalog_lookup {
+        return catalog_lookup.user_specified_bare_specifier.clone();
+    }
+    if preserve_workspace_protocol && is_workspace_local_path_specifier(&wanted.bare_specifier) {
+        return wanted.bare_specifier.clone();
+    }
+    resolved.normalized_bare_specifier.clone().unwrap_or_else(|| wanted.bare_specifier.clone())
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/package-manager/src/update_project_manifest.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest.rs
@@ -1,6 +1,7 @@
 use crate::{PackageSpecObject, is_workspace_local_path_specifier, update_project_manifest_object};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry::PinnedVersion;
+use std::collections::HashMap;
 
 /// Catalog metadata for a direct dependency requested through the `catalog:`
 /// protocol. Port of pnpm's `CatalogLookupMetadata`.
@@ -56,41 +57,62 @@ pub struct UpdateProjectManifestOptions<'a> {
 /// Rewrite `manifest`'s dependency specs from a completed resolution, mirroring
 /// pnpm's `updateProjectManifest`
 /// (`installing/deps-resolver/src/updateProjectManifest.ts`), including the
-/// alias-matching fix from [pnpm#11373](https://github.com/pnpm/pnpm/pull/11373).
+/// matching fixes from [pnpm#11373](https://github.com/pnpm/pnpm/pull/11373).
 ///
-/// Each resolved direct dependency is matched to a wanted dependency **by
-/// alias** (not by position), so a dependency that failed to resolve — an
-/// optional dep dropped from `direct_dependencies` — cannot shift the match and
-/// rewrite an unrelated dependency ([#11267](https://github.com/pnpm/pnpm/issues/11267)).
-/// A wanted dep flagged `update_spec` that matched nothing is still upserted
-/// with no specifier, which preserves its existing range rather than dropping
-/// it.
+/// Each resolved direct dependency is paired with the wanted dependency it came
+/// from. A wanted dependency that carries an alias is matched **by alias** (not
+/// by position), so a dependency that failed to resolve — an optional dep
+/// dropped from `direct_dependencies` — cannot shift the pairing onto an
+/// unrelated dependency ([#11267](https://github.com/pnpm/pnpm/issues/11267)).
+/// Aliasless wanted dependencies (`pacquet add ./local`, `jsr:@x/y`, a bare
+/// `owner/repo#sha`, a GitHub URL) resolve to an alias no wanted dependency
+/// declared, so they are paired with the remaining resolved dependencies in
+/// order. A wanted dep flagged `update_spec` that matched nothing is still
+/// upserted with no specifier, which preserves its existing range rather than
+/// dropping it.
 pub fn update_project_manifest(
     manifest: &mut PackageManifest,
     opts: &UpdateProjectManifestOptions<'_>,
 ) {
-    let mut specs: Vec<PackageSpecObject> = opts
-        .direct_dependencies
-        .iter()
-        .filter_map(|resolved| {
-            let wanted = opts
-                .wanted_dependencies
-                .iter()
-                .find(|wanted| wanted_dep_matches_resolved_dep(wanted, resolved))?;
-            Some(PackageSpecObject {
-                alias: resolved.alias.clone(),
-                peer: opts.peer,
-                bare_specifier: Some(get_bare_specifier_to_save(
-                    wanted,
-                    resolved,
-                    opts.preserve_workspace_protocol,
-                )),
-                resolved_version: resolved.version.clone(),
-                pinned_version: opts.pinned_version,
-                save_type: opts.target_dependencies_field,
-            })
-        })
-        .collect();
+    let mut wanted_by_alias: HashMap<&str, &WantedDependencyUpdate> = HashMap::new();
+    let mut aliasless_wanted: Vec<&WantedDependencyUpdate> = Vec::new();
+    for wanted in opts.wanted_dependencies {
+        match wanted.alias.as_deref().filter(|alias| !alias.is_empty()) {
+            Some(alias) => {
+                wanted_by_alias.insert(alias, wanted);
+            }
+            None if wanted.update_spec => aliasless_wanted.push(wanted),
+            None => {}
+        }
+    }
+
+    let mut next_aliasless = 0;
+    let mut specs: Vec<PackageSpecObject> = Vec::new();
+    for resolved in opts.direct_dependencies {
+        let wanted = if let Some(wanted) = wanted_by_alias.get(resolved.alias.as_str()) {
+            Some(*wanted)
+        } else {
+            let wanted = aliasless_wanted.get(next_aliasless).copied();
+            next_aliasless += 1;
+            wanted
+        };
+        let Some(wanted) = wanted else { continue };
+        if !wanted.update_spec {
+            continue;
+        }
+        specs.push(PackageSpecObject {
+            alias: resolved.alias.clone(),
+            peer: opts.peer,
+            bare_specifier: Some(get_bare_specifier_to_save(
+                wanted,
+                resolved,
+                opts.preserve_workspace_protocol,
+            )),
+            resolved_version: resolved.version.clone(),
+            pinned_version: opts.pinned_version,
+            save_type: opts.target_dependencies_field,
+        });
+    }
 
     for wanted in opts.wanted_dependencies {
         let Some(alias) = wanted.alias.as_deref().filter(|alias| !alias.is_empty()) else {
@@ -109,26 +131,6 @@ pub fn update_project_manifest(
     }
 
     update_project_manifest_object(manifest, &specs);
-}
-
-/// Whether `resolved` is the resolution of `wanted`. Matches by alias when the
-/// request carried one; otherwise by the resolved normalized specifier, with a
-/// `github:` shorthand fallback so a no-alias `owner/repo#sha` request matches
-/// its `github:owner/repo#sha` resolution.
-fn wanted_dep_matches_resolved_dep(
-    wanted: &WantedDependencyUpdate,
-    resolved: &ResolvedDirectDependency,
-) -> bool {
-    if !wanted.update_spec {
-        return false;
-    }
-    if let Some(alias) = wanted.alias.as_deref().filter(|alias| !alias.is_empty()) {
-        return alias == resolved.alias;
-    }
-    let Some(normalized) = resolved.normalized_bare_specifier.as_deref() else {
-        return false;
-    };
-    wanted.bare_specifier == normalized || format!("github:{}", wanted.bare_specifier) == normalized
 }
 
 /// The specifier string to write for a matched dependency: a `catalog:`

--- a/pacquet/crates/package-manager/src/update_project_manifest/tests.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest/tests.rs
@@ -1,0 +1,190 @@
+use super::{
+    CatalogLookup, ResolvedDirectDependency, UpdateProjectManifestOptions, WantedDependencyUpdate,
+    update_project_manifest,
+};
+use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+fn manifest_from_json(value: &Value) -> (TempDir, PackageManifest) {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let path = dir.path().join("package.json");
+    std::fs::write(&path, serde_json::to_string(value).expect("serialize fixture"))
+        .expect("write package.json");
+    let manifest = PackageManifest::from_path(path).expect("read package.json");
+    (dir, manifest)
+}
+
+fn wanted(alias: Option<&str>, bare_specifier: &str, update_spec: bool) -> WantedDependencyUpdate {
+    WantedDependencyUpdate {
+        alias: alias.map(ToString::to_string),
+        bare_specifier: bare_specifier.to_string(),
+        update_spec,
+    }
+}
+
+fn resolved(
+    alias: &str,
+    version: Option<&str>,
+    normalized_bare_specifier: Option<&str>,
+) -> ResolvedDirectDependency {
+    ResolvedDirectDependency {
+        alias: alias.to_string(),
+        version: version.map(ToString::to_string),
+        normalized_bare_specifier: normalized_bare_specifier.map(ToString::to_string),
+        catalog_lookup: None,
+    }
+}
+
+#[test]
+fn preserves_workspace_protocol_when_requested() {
+    let (_dir, mut manifest) =
+        manifest_from_json(&json!({ "dependencies": { "foo": "workspace:../packages/foo/dist" } }));
+    update_project_manifest(
+        &mut manifest,
+        &UpdateProjectManifestOptions {
+            wanted_dependencies: &[wanted(Some("foo"), "workspace:../packages/foo/dist", true)],
+            direct_dependencies: &[resolved(
+                "foo",
+                Some("1.0.0"),
+                Some("link:../packages/foo/dist"),
+            )],
+            peer: false,
+            pinned_version: None,
+            target_dependencies_field: Some(DependencyGroup::Prod),
+            preserve_workspace_protocol: true,
+        },
+    );
+    assert_eq!(manifest.value()["dependencies"]["foo"], json!("workspace:../packages/foo/dist"));
+}
+
+#[test]
+fn saves_normalized_local_spec_when_workspace_protocol_not_preserved() {
+    let (_dir, mut manifest) =
+        manifest_from_json(&json!({ "dependencies": { "foo": "workspace:../packages/foo/dist" } }));
+    update_project_manifest(
+        &mut manifest,
+        &UpdateProjectManifestOptions {
+            wanted_dependencies: &[wanted(Some("foo"), "workspace:../packages/foo/dist", true)],
+            direct_dependencies: &[resolved(
+                "foo",
+                Some("1.0.0"),
+                Some("link:../packages/foo/dist"),
+            )],
+            peer: false,
+            pinned_version: None,
+            target_dependencies_field: Some(DependencyGroup::Prod),
+            preserve_workspace_protocol: false,
+        },
+    );
+    assert_eq!(manifest.value()["dependencies"]["foo"], json!("link:../packages/foo/dist"));
+}
+
+#[test]
+fn saves_normalized_workspace_range_spec() {
+    let (_dir, mut manifest) =
+        manifest_from_json(&json!({ "dependencies": { "foo": "workspace:*" } }));
+    update_project_manifest(
+        &mut manifest,
+        &UpdateProjectManifestOptions {
+            wanted_dependencies: &[wanted(Some("foo"), "workspace:*", true)],
+            direct_dependencies: &[resolved("foo", Some("1.0.0"), Some("workspace:^1.0.0"))],
+            peer: false,
+            pinned_version: None,
+            target_dependencies_field: Some(DependencyGroup::Prod),
+            preserve_workspace_protocol: true,
+        },
+    );
+    assert_eq!(manifest.value()["dependencies"]["foo"], json!("workspace:^1.0.0"));
+}
+
+#[test]
+fn preserves_catalog_specifier_precedence() {
+    let (_dir, mut manifest) =
+        manifest_from_json(&json!({ "dependencies": { "foo": "workspace:../packages/foo/dist" } }));
+    let direct = ResolvedDirectDependency {
+        alias: "foo".to_string(),
+        version: Some("1.0.0".to_string()),
+        normalized_bare_specifier: Some("^1.0.0".to_string()),
+        catalog_lookup: Some(CatalogLookup {
+            catalog_name: "default".to_string(),
+            specifier: "^1.0.0".to_string(),
+            user_specified_bare_specifier: "catalog:".to_string(),
+        }),
+    };
+    update_project_manifest(
+        &mut manifest,
+        &UpdateProjectManifestOptions {
+            wanted_dependencies: &[wanted(Some("foo"), "workspace:../packages/foo/dist", true)],
+            direct_dependencies: &[direct],
+            peer: false,
+            pinned_version: None,
+            target_dependencies_field: Some(DependencyGroup::Prod),
+            preserve_workspace_protocol: true,
+        },
+    );
+    assert_eq!(manifest.value()["dependencies"]["foo"], json!("catalog:"));
+}
+
+#[test]
+fn does_not_update_unrelated_dependency_when_optional_update_fails_to_resolve() {
+    let (_dir, mut manifest) = manifest_from_json(&json!({
+        "devDependencies": { "react": "19.0.0" },
+        "optionalDependencies": { "react-dom": "19.0.0" },
+    }));
+    update_project_manifest(
+        &mut manifest,
+        &UpdateProjectManifestOptions {
+            wanted_dependencies: &[
+                wanted(Some("react-dom"), "foo", true),
+                wanted(Some("react"), "19.0.0", false),
+            ],
+            // `react-dom` failed to resolve, so only `react` is in the
+            // resolved set.
+            direct_dependencies: &[resolved("react", Some("19.0.0"), None)],
+            peer: false,
+            pinned_version: None,
+            target_dependencies_field: None,
+            preserve_workspace_protocol: false,
+        },
+    );
+    assert_eq!(
+        *manifest.value(),
+        json!({
+            "devDependencies": { "react": "19.0.0" },
+            "optionalDependencies": { "react-dom": "19.0.0" },
+        }),
+    );
+}
+
+#[test]
+fn updates_manifest_for_github_shorthand_without_alias() {
+    let (_dir, mut manifest) = manifest_from_json(&json!({}));
+    update_project_manifest(
+        &mut manifest,
+        &UpdateProjectManifestOptions {
+            wanted_dependencies: &[wanted(
+                None,
+                "pnpm/test-git-fetch#8b333f12d5357f4f25a654c305c826294cb073bf",
+                true,
+            )],
+            direct_dependencies: &[resolved(
+                "test-git-fetch",
+                None,
+                Some("github:pnpm/test-git-fetch#8b333f12d5357f4f25a654c305c826294cb073bf"),
+            )],
+            peer: false,
+            pinned_version: None,
+            target_dependencies_field: None,
+            preserve_workspace_protocol: false,
+        },
+    );
+    assert_eq!(
+        *manifest.value(),
+        json!({
+            "dependencies": {
+                "test-git-fetch": "github:pnpm/test-git-fetch#8b333f12d5357f4f25a654c305c826294cb073bf",
+            },
+        }),
+    );
+}

--- a/pacquet/crates/package-manager/src/update_project_manifest/tests.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest/tests.rs
@@ -23,16 +23,19 @@ fn wanted(alias: Option<&str>, bare_specifier: &str, update_spec: bool) -> Wante
     }
 }
 
+/// A resolved direct dependency carrying the wanted dependency it came from.
 fn resolved(
     alias: &str,
     version: Option<&str>,
     normalized_bare_specifier: Option<&str>,
+    wanted_dependency: WantedDependencyUpdate,
 ) -> ResolvedDirectDependency {
     ResolvedDirectDependency {
         alias: alias.to_string(),
         version: version.map(ToString::to_string),
         normalized_bare_specifier: normalized_bare_specifier.map(ToString::to_string),
         catalog_lookup: None,
+        wanted_dependency: Some(wanted_dependency),
     }
 }
 
@@ -40,14 +43,16 @@ fn resolved(
 fn preserves_workspace_protocol_when_requested() {
     let (_dir, mut manifest) =
         manifest_from_json(&json!({ "dependencies": { "foo": "workspace:../packages/foo/dist" } }));
+    let foo = wanted(Some("foo"), "workspace:../packages/foo/dist", true);
     update_project_manifest(
         &mut manifest,
         &UpdateProjectManifestOptions {
-            wanted_dependencies: &[wanted(Some("foo"), "workspace:../packages/foo/dist", true)],
+            wanted_dependencies: std::slice::from_ref(&foo),
             direct_dependencies: &[resolved(
                 "foo",
                 Some("1.0.0"),
                 Some("link:../packages/foo/dist"),
+                foo.clone(),
             )],
             peer: false,
             pinned_version: None,
@@ -62,14 +67,16 @@ fn preserves_workspace_protocol_when_requested() {
 fn saves_normalized_local_spec_when_workspace_protocol_not_preserved() {
     let (_dir, mut manifest) =
         manifest_from_json(&json!({ "dependencies": { "foo": "workspace:../packages/foo/dist" } }));
+    let foo = wanted(Some("foo"), "workspace:../packages/foo/dist", true);
     update_project_manifest(
         &mut manifest,
         &UpdateProjectManifestOptions {
-            wanted_dependencies: &[wanted(Some("foo"), "workspace:../packages/foo/dist", true)],
+            wanted_dependencies: std::slice::from_ref(&foo),
             direct_dependencies: &[resolved(
                 "foo",
                 Some("1.0.0"),
                 Some("link:../packages/foo/dist"),
+                foo.clone(),
             )],
             peer: false,
             pinned_version: None,
@@ -84,11 +91,17 @@ fn saves_normalized_local_spec_when_workspace_protocol_not_preserved() {
 fn saves_normalized_workspace_range_spec() {
     let (_dir, mut manifest) =
         manifest_from_json(&json!({ "dependencies": { "foo": "workspace:*" } }));
+    let foo = wanted(Some("foo"), "workspace:*", true);
     update_project_manifest(
         &mut manifest,
         &UpdateProjectManifestOptions {
-            wanted_dependencies: &[wanted(Some("foo"), "workspace:*", true)],
-            direct_dependencies: &[resolved("foo", Some("1.0.0"), Some("workspace:^1.0.0"))],
+            wanted_dependencies: std::slice::from_ref(&foo),
+            direct_dependencies: &[resolved(
+                "foo",
+                Some("1.0.0"),
+                Some("workspace:^1.0.0"),
+                foo.clone(),
+            )],
             peer: false,
             pinned_version: None,
             target_dependencies_field: Some(DependencyGroup::Prod),
@@ -102,6 +115,7 @@ fn saves_normalized_workspace_range_spec() {
 fn preserves_catalog_specifier_precedence() {
     let (_dir, mut manifest) =
         manifest_from_json(&json!({ "dependencies": { "foo": "workspace:../packages/foo/dist" } }));
+    let foo = wanted(Some("foo"), "workspace:../packages/foo/dist", true);
     let direct = ResolvedDirectDependency {
         alias: "foo".to_string(),
         version: Some("1.0.0".to_string()),
@@ -111,11 +125,12 @@ fn preserves_catalog_specifier_precedence() {
             specifier: "^1.0.0".to_string(),
             user_specified_bare_specifier: "catalog:".to_string(),
         }),
+        wanted_dependency: Some(foo.clone()),
     };
     update_project_manifest(
         &mut manifest,
         &UpdateProjectManifestOptions {
-            wanted_dependencies: &[wanted(Some("foo"), "workspace:../packages/foo/dist", true)],
+            wanted_dependencies: &[foo],
             direct_dependencies: &[direct],
             peer: false,
             pinned_version: None,
@@ -132,16 +147,15 @@ fn does_not_update_unrelated_dependency_when_optional_update_fails_to_resolve() 
         "devDependencies": { "react": "19.0.0" },
         "optionalDependencies": { "react-dom": "19.0.0" },
     }));
+    // `react-dom` is the optional dependency being updated; it fails to resolve
+    // and is absent from `direct_dependencies`. `react` is present but is not
+    // flagged `update_spec`, so it must stay untouched.
+    let react = wanted(Some("react"), "19.0.0", false);
     update_project_manifest(
         &mut manifest,
         &UpdateProjectManifestOptions {
-            wanted_dependencies: &[
-                wanted(Some("react-dom"), "foo", true),
-                wanted(Some("react"), "19.0.0", false),
-            ],
-            // `react-dom` failed to resolve, so only `react` is in the
-            // resolved set.
-            direct_dependencies: &[resolved("react", Some("19.0.0"), None)],
+            wanted_dependencies: &[wanted(Some("react-dom"), "foo", true), react.clone()],
+            direct_dependencies: &[resolved("react", Some("19.0.0"), None, react)],
             peer: false,
             pinned_version: None,
             target_dependencies_field: None,
@@ -160,18 +174,17 @@ fn does_not_update_unrelated_dependency_when_optional_update_fails_to_resolve() 
 #[test]
 fn updates_manifest_for_github_shorthand_without_alias() {
     let (_dir, mut manifest) = manifest_from_json(&json!({}));
+    let selector =
+        wanted(None, "pnpm/test-git-fetch#8b333f12d5357f4f25a654c305c826294cb073bf", true);
     update_project_manifest(
         &mut manifest,
         &UpdateProjectManifestOptions {
-            wanted_dependencies: &[wanted(
-                None,
-                "pnpm/test-git-fetch#8b333f12d5357f4f25a654c305c826294cb073bf",
-                true,
-            )],
+            wanted_dependencies: std::slice::from_ref(&selector),
             direct_dependencies: &[resolved(
                 "test-git-fetch",
                 None,
                 Some("github:pnpm/test-git-fetch#8b333f12d5357f4f25a654c305c826294cb073bf"),
+                selector.clone(),
             )],
             peer: false,
             pinned_version: None,
@@ -192,11 +205,17 @@ fn updates_manifest_for_github_shorthand_without_alias() {
 #[test]
 fn updates_manifest_for_aliasless_dep_whose_specifier_does_not_resemble_resolution() {
     let (_dir, mut manifest) = manifest_from_json(&json!({}));
+    let selector = wanted(None, "jsr:@foo/bar", true);
     update_project_manifest(
         &mut manifest,
         &UpdateProjectManifestOptions {
-            wanted_dependencies: &[wanted(None, "jsr:@foo/bar", true)],
-            direct_dependencies: &[resolved("@foo/bar", Some("0.1.0"), Some("jsr:^0.1.0"))],
+            wanted_dependencies: std::slice::from_ref(&selector),
+            direct_dependencies: &[resolved(
+                "@foo/bar",
+                Some("0.1.0"),
+                Some("jsr:^0.1.0"),
+                selector.clone(),
+            )],
             peer: false,
             pinned_version: None,
             target_dependencies_field: None,
@@ -207,24 +226,36 @@ fn updates_manifest_for_aliasless_dep_whose_specifier_does_not_resemble_resoluti
 }
 
 #[test]
-fn pairs_multiple_aliasless_deps_with_resolutions_in_order() {
-    let (_dir, mut manifest) = manifest_from_json(&json!({}));
+fn updates_aliasless_selector_that_resolves_to_an_existing_alias() {
+    // Re-adding `test-git-fetch` at a new commit: the requested selector is
+    // aliasless and the existing manifest entry shares the resolved alias but
+    // is not flagged for update. Because the resolution carries its own wanted
+    // dependency, the new spec is saved instead of the stale aliased entry's.
+    let (_dir, mut manifest) = manifest_from_json(&json!({
+        "dependencies": {
+            "test-git-fetch": "github:pnpm/test-git-fetch#0000000000000000000000000000000000000000",
+        },
+    }));
+    let new_selector =
+        wanted(None, "pnpm/test-git-fetch#8b333f12d5357f4f25a654c305c826294cb073bf", true);
+    let existing_entry = wanted(
+        Some("test-git-fetch"),
+        "github:pnpm/test-git-fetch#0000000000000000000000000000000000000000",
+        false,
+    );
     update_project_manifest(
         &mut manifest,
         &UpdateProjectManifestOptions {
-            wanted_dependencies: &[
-                wanted(Some("foo"), "^1.0.0", true),
-                wanted(None, "jsr:@rus/greet@0.0.3", true),
-                wanted(None, "github:kevva/is-positive#97edff6", true),
-            ],
-            direct_dependencies: &[
-                resolved("foo", Some("1.0.0"), Some("^1.0.0")),
-                resolved("@rus/greet", Some("0.0.3"), Some("jsr:^0.0.3")),
-                resolved("is-positive", None, Some("github:kevva/is-positive#97edff6")),
-            ],
+            wanted_dependencies: &[existing_entry, new_selector.clone()],
+            direct_dependencies: &[resolved(
+                "test-git-fetch",
+                None,
+                Some("github:pnpm/test-git-fetch#8b333f12d5357f4f25a654c305c826294cb073bf"),
+                new_selector,
+            )],
             peer: false,
             pinned_version: None,
-            target_dependencies_field: Some(DependencyGroup::Prod),
+            target_dependencies_field: None,
             preserve_workspace_protocol: false,
         },
     );
@@ -232,10 +263,37 @@ fn pairs_multiple_aliasless_deps_with_resolutions_in_order() {
         *manifest.value(),
         json!({
             "dependencies": {
-                "foo": "^1.0.0",
-                "@rus/greet": "jsr:^0.0.3",
-                "is-positive": "github:kevva/is-positive#97edff6",
+                "test-git-fetch": "github:pnpm/test-git-fetch#8b333f12d5357f4f25a654c305c826294cb073bf",
             },
+        }),
+    );
+}
+
+#[test]
+fn does_not_misattribute_a_spec_when_an_aliasless_optional_dep_fails_to_resolve() {
+    // Two aliasless selectors; the optional one fails and drops out of
+    // `direct_dependencies`. Because each resolution carries its own wanted
+    // dependency, the survivor is saved with its own spec (the fallback path:
+    // no `normalized_bare_specifier`) rather than the failed one's.
+    let (_dir, mut manifest) = manifest_from_json(&json!({}));
+    let failed_optional =
+        wanted(None, "github:owner/missing#1111111111111111111111111111111111111111", true);
+    let survivor = wanted(None, "github:owner/good#2222222222222222222222222222222222222222", true);
+    update_project_manifest(
+        &mut manifest,
+        &UpdateProjectManifestOptions {
+            wanted_dependencies: &[failed_optional, survivor.clone()],
+            direct_dependencies: &[resolved("good", None, None, survivor)],
+            peer: false,
+            pinned_version: None,
+            target_dependencies_field: None,
+            preserve_workspace_protocol: false,
+        },
+    );
+    assert_eq!(
+        *manifest.value(),
+        json!({
+            "dependencies": { "good": "github:owner/good#2222222222222222222222222222222222222222" },
         }),
     );
 }

--- a/pacquet/crates/package-manager/src/update_project_manifest/tests.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest/tests.rs
@@ -151,9 +151,8 @@ fn does_not_update_unrelated_dependency_when_optional_update_fails_to_resolve() 
         "devDependencies": { "react": "19.0.0" },
         "optionalDependencies": { "react-dom": "19.0.0" },
     }));
-    // `react-dom` is the optional dependency being updated; it fails to resolve
-    // and is absent from `direct_dependencies`. `react` is present but is not
-    // flagged `update_spec`, so it must stay untouched.
+    // `react-dom` is the failed optional update, so it is absent from
+    // `direct_dependencies`.
     let react = wanted(Some("react"), "19.0.0", false);
     apply(
         &mut manifest,
@@ -231,10 +230,8 @@ fn updates_manifest_for_aliasless_dep_whose_specifier_does_not_resemble_resoluti
 
 #[test]
 fn updates_aliasless_selector_that_resolves_to_an_existing_alias() {
-    // Re-adding `test-git-fetch` at a new commit: the requested selector is
-    // aliasless and the existing manifest entry shares the resolved alias but
-    // is not flagged for update. Because the resolution carries its own wanted
-    // dependency, the new spec is saved instead of the stale aliased entry's.
+    // The resolved alias collides with the existing (non-updating) manifest
+    // entry; the resolution carries the new selector, so its spec wins.
     let (_dir, mut manifest) = manifest_from_json(&json!({
         "dependencies": {
             "test-git-fetch": "github:pnpm/test-git-fetch#0000000000000000000000000000000000000000",
@@ -275,10 +272,8 @@ fn updates_aliasless_selector_that_resolves_to_an_existing_alias() {
 
 #[test]
 fn does_not_misattribute_a_spec_when_an_aliasless_optional_dep_fails_to_resolve() {
-    // Two aliasless selectors; the optional one fails and drops out of
-    // `direct_dependencies`. Because each resolution carries its own wanted
-    // dependency, the survivor is saved with its own spec (the fallback path:
-    // no `normalized_bare_specifier`) rather than the failed one's.
+    // The survivor omits `normalized_bare_specifier` so its spec falls back to
+    // the wanted dependency's — the path where a wrong pairing would surface.
     let (_dir, mut manifest) = manifest_from_json(&json!({}));
     let failed_optional =
         wanted(None, "github:owner/missing#1111111111111111111111111111111111111111", true);

--- a/pacquet/crates/package-manager/src/update_project_manifest/tests.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest/tests.rs
@@ -188,3 +188,54 @@ fn updates_manifest_for_github_shorthand_without_alias() {
         }),
     );
 }
+
+#[test]
+fn updates_manifest_for_aliasless_dep_whose_specifier_does_not_resemble_resolution() {
+    let (_dir, mut manifest) = manifest_from_json(&json!({}));
+    update_project_manifest(
+        &mut manifest,
+        &UpdateProjectManifestOptions {
+            wanted_dependencies: &[wanted(None, "jsr:@foo/bar", true)],
+            direct_dependencies: &[resolved("@foo/bar", Some("0.1.0"), Some("jsr:^0.1.0"))],
+            peer: false,
+            pinned_version: None,
+            target_dependencies_field: None,
+            preserve_workspace_protocol: false,
+        },
+    );
+    assert_eq!(*manifest.value(), json!({ "dependencies": { "@foo/bar": "jsr:^0.1.0" } }));
+}
+
+#[test]
+fn pairs_multiple_aliasless_deps_with_resolutions_in_order() {
+    let (_dir, mut manifest) = manifest_from_json(&json!({}));
+    update_project_manifest(
+        &mut manifest,
+        &UpdateProjectManifestOptions {
+            wanted_dependencies: &[
+                wanted(Some("foo"), "^1.0.0", true),
+                wanted(None, "jsr:@rus/greet@0.0.3", true),
+                wanted(None, "github:kevva/is-positive#97edff6", true),
+            ],
+            direct_dependencies: &[
+                resolved("foo", Some("1.0.0"), Some("^1.0.0")),
+                resolved("@rus/greet", Some("0.0.3"), Some("jsr:^0.0.3")),
+                resolved("is-positive", None, Some("github:kevva/is-positive#97edff6")),
+            ],
+            peer: false,
+            pinned_version: None,
+            target_dependencies_field: Some(DependencyGroup::Prod),
+            preserve_workspace_protocol: false,
+        },
+    );
+    assert_eq!(
+        *manifest.value(),
+        json!({
+            "dependencies": {
+                "foo": "^1.0.0",
+                "@rus/greet": "jsr:^0.0.3",
+                "is-positive": "github:kevva/is-positive#97edff6",
+            },
+        }),
+    );
+}

--- a/pacquet/crates/package-manager/src/update_project_manifest/tests.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest/tests.rs
@@ -15,6 +15,10 @@ fn manifest_from_json(value: &Value) -> (TempDir, PackageManifest) {
     (dir, manifest)
 }
 
+fn apply(manifest: &mut PackageManifest, opts: &UpdateProjectManifestOptions<'_>) {
+    update_project_manifest(manifest, opts).expect("update manifest");
+}
+
 fn wanted(alias: Option<&str>, bare_specifier: &str, update_spec: bool) -> WantedDependencyUpdate {
     WantedDependencyUpdate {
         alias: alias.map(ToString::to_string),
@@ -44,7 +48,7 @@ fn preserves_workspace_protocol_when_requested() {
     let (_dir, mut manifest) =
         manifest_from_json(&json!({ "dependencies": { "foo": "workspace:../packages/foo/dist" } }));
     let foo = wanted(Some("foo"), "workspace:../packages/foo/dist", true);
-    update_project_manifest(
+    apply(
         &mut manifest,
         &UpdateProjectManifestOptions {
             wanted_dependencies: std::slice::from_ref(&foo),
@@ -68,7 +72,7 @@ fn saves_normalized_local_spec_when_workspace_protocol_not_preserved() {
     let (_dir, mut manifest) =
         manifest_from_json(&json!({ "dependencies": { "foo": "workspace:../packages/foo/dist" } }));
     let foo = wanted(Some("foo"), "workspace:../packages/foo/dist", true);
-    update_project_manifest(
+    apply(
         &mut manifest,
         &UpdateProjectManifestOptions {
             wanted_dependencies: std::slice::from_ref(&foo),
@@ -92,7 +96,7 @@ fn saves_normalized_workspace_range_spec() {
     let (_dir, mut manifest) =
         manifest_from_json(&json!({ "dependencies": { "foo": "workspace:*" } }));
     let foo = wanted(Some("foo"), "workspace:*", true);
-    update_project_manifest(
+    apply(
         &mut manifest,
         &UpdateProjectManifestOptions {
             wanted_dependencies: std::slice::from_ref(&foo),
@@ -127,7 +131,7 @@ fn preserves_catalog_specifier_precedence() {
         }),
         wanted_dependency: Some(foo.clone()),
     };
-    update_project_manifest(
+    apply(
         &mut manifest,
         &UpdateProjectManifestOptions {
             wanted_dependencies: &[foo],
@@ -151,7 +155,7 @@ fn does_not_update_unrelated_dependency_when_optional_update_fails_to_resolve() 
     // and is absent from `direct_dependencies`. `react` is present but is not
     // flagged `update_spec`, so it must stay untouched.
     let react = wanted(Some("react"), "19.0.0", false);
-    update_project_manifest(
+    apply(
         &mut manifest,
         &UpdateProjectManifestOptions {
             wanted_dependencies: &[wanted(Some("react-dom"), "foo", true), react.clone()],
@@ -176,7 +180,7 @@ fn updates_manifest_for_github_shorthand_without_alias() {
     let (_dir, mut manifest) = manifest_from_json(&json!({}));
     let selector =
         wanted(None, "pnpm/test-git-fetch#8b333f12d5357f4f25a654c305c826294cb073bf", true);
-    update_project_manifest(
+    apply(
         &mut manifest,
         &UpdateProjectManifestOptions {
             wanted_dependencies: std::slice::from_ref(&selector),
@@ -206,7 +210,7 @@ fn updates_manifest_for_github_shorthand_without_alias() {
 fn updates_manifest_for_aliasless_dep_whose_specifier_does_not_resemble_resolution() {
     let (_dir, mut manifest) = manifest_from_json(&json!({}));
     let selector = wanted(None, "jsr:@foo/bar", true);
-    update_project_manifest(
+    apply(
         &mut manifest,
         &UpdateProjectManifestOptions {
             wanted_dependencies: std::slice::from_ref(&selector),
@@ -243,7 +247,7 @@ fn updates_aliasless_selector_that_resolves_to_an_existing_alias() {
         "github:pnpm/test-git-fetch#0000000000000000000000000000000000000000",
         false,
     );
-    update_project_manifest(
+    apply(
         &mut manifest,
         &UpdateProjectManifestOptions {
             wanted_dependencies: &[existing_entry, new_selector.clone()],
@@ -279,7 +283,7 @@ fn does_not_misattribute_a_spec_when_an_aliasless_optional_dep_fails_to_resolve(
     let failed_optional =
         wanted(None, "github:owner/missing#1111111111111111111111111111111111111111", true);
     let survivor = wanted(None, "github:owner/good#2222222222222222222222222222222222222222", true);
-    update_project_manifest(
+    apply(
         &mut manifest,
         &UpdateProjectManifestOptions {
             wanted_dependencies: &[failed_optional, survivor.clone()],

--- a/pacquet/crates/package-manager/src/update_project_manifest_object.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest_object.rs
@@ -1,0 +1,154 @@
+use node_semver::{Range, Version};
+use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_registry::PinnedVersion;
+use serde_json::{Map, Value};
+
+/// pnpm's `DEPENDENCIES_FIELDS`, in its canonical order. A direct dependency
+/// is written to exactly one of these and removed from the other two.
+const DEPENDENCIES_FIELDS: [&str; 3] = ["optionalDependencies", "dependencies", "devDependencies"];
+
+/// pnpm's `DEPENDENCIES_OR_PEER_FIELDS`: the three dependency fields plus
+/// `peerDependencies`. `guess_dependency_type` scans them in this order and
+/// returns the first that already declares the alias.
+const DEPENDENCIES_OR_PEER_FIELDS: [&str; 4] =
+    ["optionalDependencies", "dependencies", "devDependencies", "peerDependencies"];
+
+/// One manifest mutation request. Port of pnpm's `PackageSpecObject`.
+///
+/// `save_type` and `bare_specifier` together select the behaviour:
+/// * `save_type` set → upsert into that field, deleting the alias from the
+///   other dependency fields; `bare_specifier` is the spec to write, falling
+///   back to the alias's existing spec when `None` (the path that preserves a
+///   failed optional update). When neither a `bare_specifier` nor an existing
+///   spec is found, the request is a no-op.
+/// * `save_type` `None` but `bare_specifier` set → write into whichever field
+///   already declares the alias (defaulting to `dependencies`), without
+///   moving it between fields.
+pub struct PackageSpecObject {
+    pub alias: String,
+    pub peer: bool,
+    pub bare_specifier: Option<String>,
+    pub resolved_version: Option<String>,
+    pub pinned_version: Option<PinnedVersion>,
+    pub save_type: Option<DependencyGroup>,
+}
+
+/// Apply `specs` to `manifest` in memory, mirroring pnpm's
+/// [`updateProjectManifestObject`](https://github.com/pnpm/pnpm/blob/fc2f33912e/pkg-manifest/utils/src/updateProjectManifestObject.ts).
+///
+/// Each entry either upserts a dependency into its `save_type` field (removing
+/// the alias from the other dependency fields and, when `peer` is set, also
+/// recording a peer range), or — with no `save_type` — rewrites the spec in
+/// whichever field already declares the alias. Empty specifiers are treated as
+/// absent, matching pnpm's truthiness guard.
+pub fn update_project_manifest_object(manifest: &mut PackageManifest, specs: &[PackageSpecObject]) {
+    let root = manifest.value_mut();
+    for spec in specs {
+        if let Some(save_type) = spec.save_type {
+            let field: &str = save_type.into();
+            let resolved_spec = spec
+                .bare_specifier
+                .clone()
+                .or_else(|| find_spec(&spec.alias, root))
+                .filter(|spec| !spec.is_empty());
+            let Some(spec_str) = resolved_spec else { continue };
+            define_dep_entry(root, field, &spec.alias, &spec_str);
+            for dep_field in DEPENDENCIES_FIELDS {
+                if dep_field != field {
+                    delete_dep_entry(root, dep_field, &spec.alias);
+                }
+            }
+            if spec.peer {
+                let peer_spec = get_peer_specifier(
+                    &spec_str,
+                    spec.resolved_version.as_deref(),
+                    spec.pinned_version,
+                );
+                define_dep_entry(root, "peerDependencies", &spec.alias, &peer_spec);
+            }
+        } else if let Some(bare_specifier) = spec.bare_specifier.as_deref()
+            && !bare_specifier.is_empty()
+        {
+            let used = guess_dependency_type(&spec.alias, root).unwrap_or("dependencies");
+            if used != "peerDependencies" {
+                define_dep_entry(root, used, &spec.alias, bare_specifier);
+            }
+        }
+    }
+}
+
+/// The peer range to record alongside a saved dependency: keep the saved spec
+/// when it is itself a valid peer range, otherwise derive a range from the
+/// resolved version, falling back to `*` when no version is available (git /
+/// tarball deps).
+fn get_peer_specifier(
+    spec: &str,
+    resolved_version: Option<&str>,
+    pinned_version: Option<PinnedVersion>,
+) -> String {
+    if is_valid_peer_range(spec) {
+        return spec.to_string();
+    }
+    resolved_version
+        .and_then(|version| create_version_spec_from_resolved_version(version, pinned_version))
+        .unwrap_or_else(|| "*".to_string())
+}
+
+/// Build a manifest range from a concrete resolved version and a pin operator,
+/// mirroring pnpm's `createVersionSpecFromResolvedVersion`: a prerelease is
+/// pinned exactly, otherwise the [`PinnedVersion`] operator is prepended.
+/// Returns `None` when `resolved_version` is not valid semver.
+fn create_version_spec_from_resolved_version(
+    resolved_version: &str,
+    pinned_version: Option<PinnedVersion>,
+) -> Option<String> {
+    let parsed = Version::parse(resolved_version).ok()?;
+    if !parsed.pre_release.is_empty() {
+        return Some(resolved_version.to_string());
+    }
+    let prefix = pinned_version.unwrap_or(PinnedVersion::Major).range_prefix();
+    Some(format!("{prefix}{resolved_version}"))
+}
+
+/// Whether `version` is acceptable as a `peerDependencies` range: a valid
+/// semver range, or a `workspace:` / `catalog:` reference. Mirrors pnpm's
+/// `isValidPeerRange`, which uses `includes` so the protocol can appear inside
+/// a wider range expression.
+fn is_valid_peer_range(version: &str) -> bool {
+    Range::parse(version).is_ok() || version.contains("workspace:") || version.contains("catalog:")
+}
+
+/// The alias's currently-declared spec, looked up in the first field that
+/// declares it. `None` when no field declares the alias.
+fn find_spec(alias: &str, root: &Value) -> Option<String> {
+    let field = guess_dependency_type(alias, root)?;
+    root.get(field)?.get(alias)?.as_str().map(ToString::to_string)
+}
+
+/// The first of pnpm's dependency-or-peer fields that already declares `alias`
+/// with a string spec. Mirrors pnpm's `guessDependencyType`.
+fn guess_dependency_type(alias: &str, root: &Value) -> Option<&'static str> {
+    DEPENDENCIES_OR_PEER_FIELDS.into_iter().find(|field| {
+        root.get(*field)
+            .and_then(Value::as_object)
+            .and_then(|deps| deps.get(alias))
+            .is_some_and(Value::is_string)
+    })
+}
+
+fn define_dep_entry(root: &mut Value, field: &str, alias: &str, value: &str) {
+    let Some(obj) = root.as_object_mut() else { return };
+    let deps = obj.entry(field).or_insert_with(|| Value::Object(Map::new()));
+    if let Some(deps) = deps.as_object_mut() {
+        deps.insert(alias.to_string(), Value::String(value.to_string()));
+    }
+}
+
+fn delete_dep_entry(root: &mut Value, field: &str, alias: &str) {
+    if let Some(deps) = root.get_mut(field).and_then(Value::as_object_mut) {
+        deps.remove(alias);
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/package-manager/src/update_project_manifest_object.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest_object.rs
@@ -51,6 +51,10 @@ pub fn update_project_manifest_object(
     manifest: &mut PackageManifest,
     specs: &[PackageSpecObject],
 ) -> Result<(), PackageManifestError> {
+    // Nothing to write: skip the clone + write-back the atomic path would do.
+    if specs.is_empty() {
+        return Ok(());
+    }
     let mut root = manifest.value().clone();
     for spec in specs {
         if let Some(save_type) = spec.save_type {

--- a/pacquet/crates/package-manager/src/update_project_manifest_object.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest_object.rs
@@ -1,5 +1,5 @@
 use node_semver::{Range, Version};
-use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_package_manifest::{DependencyGroup, PackageManifest, PackageManifestError};
 use pacquet_registry::PinnedVersion;
 use serde_json::{Map, Value};
 
@@ -41,21 +41,30 @@ pub struct PackageSpecObject {
 /// recording a peer range), or — with no `save_type` — rewrites the spec in
 /// whichever field already declares the alias. Empty specifiers are treated as
 /// absent, matching pnpm's truthiness guard.
-pub fn update_project_manifest_object(manifest: &mut PackageManifest, specs: &[PackageSpecObject]) {
-    let root = manifest.value_mut();
+///
+/// Errors when a dependency field that must be written is present but is not a
+/// JSON object (e.g. `"dependencies": "oops"`), mirroring pnpm throwing on the
+/// same input and [`PackageManifest::add_dependency`]. The mutation is applied
+/// atomically — a copy is mutated and committed only on success — so an error
+/// mid-way leaves the manifest untouched rather than partially updated.
+pub fn update_project_manifest_object(
+    manifest: &mut PackageManifest,
+    specs: &[PackageSpecObject],
+) -> Result<(), PackageManifestError> {
+    let mut root = manifest.value().clone();
     for spec in specs {
         if let Some(save_type) = spec.save_type {
             let field: &str = save_type.into();
             let resolved_spec = spec
                 .bare_specifier
                 .clone()
-                .or_else(|| find_spec(&spec.alias, root))
+                .or_else(|| find_spec(&spec.alias, &root))
                 .filter(|spec| !spec.is_empty());
             let Some(spec_str) = resolved_spec else { continue };
-            define_dep_entry(root, field, &spec.alias, &spec_str);
+            define_dep_entry(&mut root, field, &spec.alias, &spec_str)?;
             for dep_field in DEPENDENCIES_FIELDS {
                 if dep_field != field {
-                    delete_dep_entry(root, dep_field, &spec.alias);
+                    delete_dep_entry(&mut root, dep_field, &spec.alias);
                 }
             }
             if spec.peer {
@@ -64,17 +73,19 @@ pub fn update_project_manifest_object(manifest: &mut PackageManifest, specs: &[P
                     spec.resolved_version.as_deref(),
                     spec.pinned_version,
                 );
-                define_dep_entry(root, "peerDependencies", &spec.alias, &peer_spec);
+                define_dep_entry(&mut root, "peerDependencies", &spec.alias, &peer_spec)?;
             }
         } else if let Some(bare_specifier) = spec.bare_specifier.as_deref()
             && !bare_specifier.is_empty()
         {
-            let used = guess_dependency_type(&spec.alias, root).unwrap_or("dependencies");
+            let used = guess_dependency_type(&spec.alias, &root).unwrap_or("dependencies");
             if used != "peerDependencies" {
-                define_dep_entry(root, used, &spec.alias, bare_specifier);
+                define_dep_entry(&mut root, used, &spec.alias, bare_specifier)?;
             }
         }
     }
+    *manifest.value_mut() = root;
+    Ok(())
 }
 
 /// The peer range to record alongside a saved dependency: keep the saved spec
@@ -136,12 +147,31 @@ fn guess_dependency_type(alias: &str, root: &Value) -> Option<&'static str> {
     })
 }
 
-fn define_dep_entry(root: &mut Value, field: &str, alias: &str, value: &str) {
-    let Some(obj) = root.as_object_mut() else { return };
+fn define_dep_entry(
+    root: &mut Value,
+    field: &str,
+    alias: &str,
+    value: &str,
+) -> Result<(), PackageManifestError> {
+    let Some(obj) = root.as_object_mut() else {
+        return Err(PackageManifestError::InvalidAttribute(
+            "the manifest root must be an object".to_string(),
+        ));
+    };
+    // Mirror pnpm's `manifest[field] = manifest[field] ?? {}`: a missing or
+    // `null` field becomes a fresh object before the entry is written. A field
+    // present as a non-object is invalid (pnpm throws on it).
     let deps = obj.entry(field).or_insert_with(|| Value::Object(Map::new()));
-    if let Some(deps) = deps.as_object_mut() {
-        deps.insert(alias.to_string(), Value::String(value.to_string()));
+    if deps.is_null() {
+        *deps = Value::Object(Map::new());
     }
+    let Some(deps) = deps.as_object_mut() else {
+        return Err(PackageManifestError::InvalidAttribute(format!(
+            "the {field} field must be an object",
+        )));
+    };
+    deps.insert(alias.to_string(), Value::String(value.to_string()));
+    Ok(())
 }
 
 fn delete_dep_entry(root: &mut Value, field: &str, alias: &str) {

--- a/pacquet/crates/package-manager/src/update_project_manifest_object.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest_object.rs
@@ -159,8 +159,7 @@ fn define_dep_entry(
         ));
     };
     // Mirror pnpm's `manifest[field] = manifest[field] ?? {}`: a missing or
-    // `null` field becomes a fresh object before the entry is written. A field
-    // present as a non-object is invalid (pnpm throws on it).
+    // `null` field becomes a fresh object before the entry is written.
     let deps = obj.entry(field).or_insert_with(|| Value::Object(Map::new()));
     if deps.is_null() {
         *deps = Value::Object(Map::new());

--- a/pacquet/crates/package-manager/src/update_project_manifest_object/tests.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest_object/tests.rs
@@ -15,6 +15,10 @@ fn manifest_from_json(value: &Value) -> (TempDir, PackageManifest) {
     (dir, manifest)
 }
 
+fn apply(manifest: &mut PackageManifest, specs: &[PackageSpecObject]) {
+    update_project_manifest_object(manifest, specs).expect("update manifest object");
+}
+
 fn peer_spec(
     bare_specifier: &str,
     resolved_version: Option<&str>,
@@ -27,6 +31,17 @@ fn peer_spec(
         resolved_version: resolved_version.map(ToString::to_string),
         pinned_version,
         save_type: Some(DependencyGroup::Dev),
+    }
+}
+
+fn prod_spec(alias: &str, bare_specifier: &str) -> PackageSpecObject {
+    PackageSpecObject {
+        alias: alias.to_string(),
+        peer: false,
+        bare_specifier: Some(bare_specifier.to_string()),
+        resolved_version: None,
+        pinned_version: None,
+        save_type: Some(DependencyGroup::Prod),
     }
 }
 
@@ -52,7 +67,7 @@ fn peer_dependency_falls_back_to_star_without_resolved_version() {
         "https://github.com/hegemonic/taffydb/tarball/master",
     ] {
         let (_dir, mut manifest) = manifest_from_json(&json!({}));
-        update_project_manifest_object(&mut manifest, &[peer_spec(bare_specifier, None, None)]);
+        apply(&mut manifest, &[peer_spec(bare_specifier, None, None)]);
         assert_eq!(manifest.value()["devDependencies"], json!({ "foo": bare_specifier }));
         assert_eq!(manifest.value()["peerDependencies"], json!({ "foo": "*" }));
     }
@@ -61,10 +76,7 @@ fn peer_dependency_falls_back_to_star_without_resolved_version() {
 #[test]
 fn peer_dependency_derives_range_from_resolved_version() {
     let (_dir, mut manifest) = manifest_from_json(&json!({}));
-    update_project_manifest_object(
-        &mut manifest,
-        &[peer_spec("https://github.com/kevva/is-negative", Some("2.1.0"), None)],
-    );
+    apply(&mut manifest, &[peer_spec("https://github.com/kevva/is-negative", Some("2.1.0"), None)]);
     assert_eq!(
         manifest.value()["devDependencies"],
         json!({ "foo": "https://github.com/kevva/is-negative" }),
@@ -75,7 +87,7 @@ fn peer_dependency_derives_range_from_resolved_version() {
 #[test]
 fn peer_dependency_honors_pinned_version() {
     let (_dir, mut manifest) = manifest_from_json(&json!({}));
-    update_project_manifest_object(
+    apply(
         &mut manifest,
         &[peer_spec(
             "https://github.com/hegemonic/taffydb/tarball/master",
@@ -89,7 +101,7 @@ fn peer_dependency_honors_pinned_version() {
 #[test]
 fn peer_dependency_derives_range_for_jsr_protocol() {
     let (_dir, mut manifest) = manifest_from_json(&json!({}));
-    update_project_manifest_object(&mut manifest, &[peer_spec("jsr:^0.1.0", Some("0.1.0"), None)]);
+    apply(&mut manifest, &[peer_spec("jsr:^0.1.0", Some("0.1.0"), None)]);
     assert_eq!(manifest.value()["devDependencies"], json!({ "foo": "jsr:^0.1.0" }));
     assert_eq!(manifest.value()["peerDependencies"], json!({ "foo": "^0.1.0" }));
 }
@@ -97,7 +109,7 @@ fn peer_dependency_derives_range_for_jsr_protocol() {
 #[test]
 fn peer_dependency_keeps_prerelease_resolved_version_without_prefix() {
     let (_dir, mut manifest) = manifest_from_json(&json!({}));
-    update_project_manifest_object(
+    apply(
         &mut manifest,
         &[peer_spec(
             "https://github.com/kevva/is-negative",
@@ -114,7 +126,7 @@ fn peer_dependency_respects_patch_and_none_pins() {
         [(PinnedVersion::Patch, "3.2.1"), (PinnedVersion::None, "^3.2.1")]
     {
         let (_dir, mut manifest) = manifest_from_json(&json!({}));
-        update_project_manifest_object(
+        apply(
             &mut manifest,
             &[peer_spec(
                 "https://github.com/kevva/is-negative",
@@ -140,16 +152,9 @@ fn writes_prototype_conflicting_aliases_as_plain_entries() {
         ("real-pkg", "2.0.0"),
     ]
     .into_iter()
-    .map(|(alias, spec)| PackageSpecObject {
-        alias: alias.to_string(),
-        peer: false,
-        bare_specifier: Some(spec.to_string()),
-        resolved_version: None,
-        pinned_version: None,
-        save_type: Some(DependencyGroup::Prod),
-    })
+    .map(|(alias, spec)| prod_spec(alias, spec))
     .collect();
-    update_project_manifest_object(&mut manifest, &specs);
+    apply(&mut manifest, &specs);
     assert_eq!(
         manifest.value()["dependencies"],
         json!({
@@ -159,4 +164,47 @@ fn writes_prototype_conflicting_aliases_as_plain_entries() {
             "real-pkg": "2.0.0",
         }),
     );
+}
+
+/// A `null` dependency field is replaced with a fresh object before the write,
+/// mirroring pnpm's `manifest[field] = manifest[field] ?? {}`.
+#[test]
+fn replaces_a_null_dependency_field() {
+    let (_dir, mut manifest) = manifest_from_json(&json!({ "dependencies": Value::Null }));
+    apply(&mut manifest, &[prod_spec("foo", "1.0.0")]);
+    assert_eq!(manifest.value()["dependencies"], json!({ "foo": "1.0.0" }));
+}
+
+/// A dependency field that is present but not an object is rejected (pnpm
+/// throws on the same input), rather than silently skipping the write.
+#[test]
+fn errors_on_a_non_object_dependency_field() {
+    let (_dir, mut manifest) = manifest_from_json(&json!({ "dependencies": "oops" }));
+    let result = update_project_manifest_object(&mut manifest, &[prod_spec("foo", "1.0.0")]);
+    assert!(result.is_err());
+}
+
+/// The write is atomic: when a later spec errors, the earlier specs' mutations
+/// are rolled back, so the manifest is left exactly as it was.
+#[test]
+fn leaves_the_manifest_untouched_when_a_later_spec_errors() {
+    let (_dir, mut manifest) = manifest_from_json(&json!({
+        "devDependencies": { "keep": "1.0.0" },
+        "optionalDependencies": "oops",
+    }));
+    let before = manifest.value().clone();
+    let optional_bar = PackageSpecObject {
+        alias: "bar".to_string(),
+        peer: false,
+        bare_specifier: Some("2.0.0".to_string()),
+        resolved_version: None,
+        pinned_version: None,
+        save_type: Some(DependencyGroup::Optional),
+    };
+    // `foo` would be written first; `bar` then fails on the non-object
+    // `optionalDependencies`.
+    let result =
+        update_project_manifest_object(&mut manifest, &[prod_spec("foo", "1.0.0"), optional_bar]);
+    assert!(result.is_err());
+    assert_eq!(*manifest.value(), before);
 }

--- a/pacquet/crates/package-manager/src/update_project_manifest_object/tests.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest_object/tests.rs
@@ -208,3 +208,11 @@ fn leaves_the_manifest_untouched_when_a_later_spec_errors() {
     assert!(result.is_err());
     assert_eq!(*manifest.value(), before);
 }
+
+#[test]
+fn empty_specs_leave_the_manifest_unchanged() {
+    let (_dir, mut manifest) = manifest_from_json(&json!({ "dependencies": { "foo": "1.0.0" } }));
+    let before = manifest.value().clone();
+    apply(&mut manifest, &[]);
+    assert_eq!(*manifest.value(), before);
+}

--- a/pacquet/crates/package-manager/src/update_project_manifest_object/tests.rs
+++ b/pacquet/crates/package-manager/src/update_project_manifest_object/tests.rs
@@ -1,0 +1,162 @@
+use super::{PackageSpecObject, guess_dependency_type, update_project_manifest_object};
+use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_registry::PinnedVersion;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+/// Build an on-disk `PackageManifest` from a JSON literal. The `TempDir` is
+/// returned so the caller keeps the backing file alive for the test's body.
+fn manifest_from_json(value: &Value) -> (TempDir, PackageManifest) {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let path = dir.path().join("package.json");
+    std::fs::write(&path, serde_json::to_string(value).expect("serialize fixture"))
+        .expect("write package.json");
+    let manifest = PackageManifest::from_path(path).expect("read package.json");
+    (dir, manifest)
+}
+
+fn peer_spec(
+    bare_specifier: &str,
+    resolved_version: Option<&str>,
+    pinned_version: Option<PinnedVersion>,
+) -> PackageSpecObject {
+    PackageSpecObject {
+        alias: "foo".to_string(),
+        peer: true,
+        bare_specifier: Some(bare_specifier.to_string()),
+        resolved_version: resolved_version.map(ToString::to_string),
+        pinned_version,
+        save_type: Some(DependencyGroup::Dev),
+    }
+}
+
+#[test]
+fn guess_dependency_type_finds_the_field_declaring_the_alias() {
+    let (_dir, with_empty_dev) = manifest_from_json(&json!({
+        "dependencies": { "bar": "1.0.0" },
+        "devDependencies": { "foo": "" },
+    }));
+    assert_eq!(guess_dependency_type("foo", with_empty_dev.value()), Some("devDependencies"));
+
+    let (_dir, both_versioned) = manifest_from_json(&json!({
+        "dependencies": { "bar": "1.0.0" },
+        "devDependencies": { "foo": "1.0.0" },
+    }));
+    assert_eq!(guess_dependency_type("bar", both_versioned.value()), Some("dependencies"));
+}
+
+#[test]
+fn peer_dependency_falls_back_to_star_without_resolved_version() {
+    for bare_specifier in [
+        "https://github.com/kevva/is-negative",
+        "https://github.com/hegemonic/taffydb/tarball/master",
+    ] {
+        let (_dir, mut manifest) = manifest_from_json(&json!({}));
+        update_project_manifest_object(&mut manifest, &[peer_spec(bare_specifier, None, None)]);
+        assert_eq!(manifest.value()["devDependencies"], json!({ "foo": bare_specifier }));
+        assert_eq!(manifest.value()["peerDependencies"], json!({ "foo": "*" }));
+    }
+}
+
+#[test]
+fn peer_dependency_derives_range_from_resolved_version() {
+    let (_dir, mut manifest) = manifest_from_json(&json!({}));
+    update_project_manifest_object(
+        &mut manifest,
+        &[peer_spec("https://github.com/kevva/is-negative", Some("2.1.0"), None)],
+    );
+    assert_eq!(
+        manifest.value()["devDependencies"],
+        json!({ "foo": "https://github.com/kevva/is-negative" }),
+    );
+    assert_eq!(manifest.value()["peerDependencies"], json!({ "foo": "^2.1.0" }));
+}
+
+#[test]
+fn peer_dependency_honors_pinned_version() {
+    let (_dir, mut manifest) = manifest_from_json(&json!({}));
+    update_project_manifest_object(
+        &mut manifest,
+        &[peer_spec(
+            "https://github.com/hegemonic/taffydb/tarball/master",
+            Some("1.4.0"),
+            Some(PinnedVersion::Minor),
+        )],
+    );
+    assert_eq!(manifest.value()["peerDependencies"], json!({ "foo": "~1.4.0" }));
+}
+
+#[test]
+fn peer_dependency_derives_range_for_jsr_protocol() {
+    let (_dir, mut manifest) = manifest_from_json(&json!({}));
+    update_project_manifest_object(&mut manifest, &[peer_spec("jsr:^0.1.0", Some("0.1.0"), None)]);
+    assert_eq!(manifest.value()["devDependencies"], json!({ "foo": "jsr:^0.1.0" }));
+    assert_eq!(manifest.value()["peerDependencies"], json!({ "foo": "^0.1.0" }));
+}
+
+#[test]
+fn peer_dependency_keeps_prerelease_resolved_version_without_prefix() {
+    let (_dir, mut manifest) = manifest_from_json(&json!({}));
+    update_project_manifest_object(
+        &mut manifest,
+        &[peer_spec(
+            "https://github.com/kevva/is-negative",
+            Some("2.1.0-rc.1"),
+            Some(PinnedVersion::Minor),
+        )],
+    );
+    assert_eq!(manifest.value()["peerDependencies"], json!({ "foo": "2.1.0-rc.1" }));
+}
+
+#[test]
+fn peer_dependency_respects_patch_and_none_pins() {
+    for (pinned_version, expected) in
+        [(PinnedVersion::Patch, "3.2.1"), (PinnedVersion::None, "^3.2.1")]
+    {
+        let (_dir, mut manifest) = manifest_from_json(&json!({}));
+        update_project_manifest_object(
+            &mut manifest,
+            &[peer_spec(
+                "https://github.com/kevva/is-negative",
+                Some("3.2.1"),
+                Some(pinned_version),
+            )],
+        );
+        assert_eq!(manifest.value()["peerDependencies"], json!({ "foo": expected }));
+    }
+}
+
+/// pnpm guards its `package.json` writes against prototype pollution because
+/// JS object assignment can hit `__proto__`'s setter. Rust has no such hazard,
+/// but the behavioral contract — every alias is written as a plain entry — is
+/// the same, so the ported scenario still pins it.
+#[test]
+fn writes_prototype_conflicting_aliases_as_plain_entries() {
+    let (_dir, mut manifest) = manifest_from_json(&json!({}));
+    let specs: Vec<PackageSpecObject> = [
+        ("__proto__", "1.0.0"),
+        ("constructor", "1.0.1"),
+        ("prototype", "1.0.2"),
+        ("real-pkg", "2.0.0"),
+    ]
+    .into_iter()
+    .map(|(alias, spec)| PackageSpecObject {
+        alias: alias.to_string(),
+        peer: false,
+        bare_specifier: Some(spec.to_string()),
+        resolved_version: None,
+        pinned_version: None,
+        save_type: Some(DependencyGroup::Prod),
+    })
+    .collect();
+    update_project_manifest_object(&mut manifest, &specs);
+    assert_eq!(
+        manifest.value()["dependencies"],
+        json!({
+            "__proto__": "1.0.0",
+            "constructor": "1.0.1",
+            "prototype": "1.0.2",
+            "real-pkg": "2.0.0",
+        }),
+    );
+}


### PR DESCRIPTION
## Summary

Ports the core logic of pnpm's post-resolution manifest writer to the pacquet (Rust) `package-manager` crate, mirroring pnpm's crate boundaries. This is the Rust side of #11373 (which fixed the TypeScript `updateProjectManifest`); it brings the same matching algorithm — and the same #11267 bug fix — to pacquet.

Two new modules:

- **`update_project_manifest_object.rs`** — port of `@pnpm/pkg-manifest.utils`'s `updateProjectManifestObject`: upsert a dependency into its target field while deleting the alias from the other dependency fields, derive peer ranges (`createVersionSpecFromResolvedVersion` / `isValidPeerRange`), `guessDependencyType`, and the empty-spec no-op that preserves a failed optional update.
- **`update_project_manifest.rs`** — port of `updateProjectManifest`: match resolved direct dependencies to wanted dependencies **by alias** (with a `github:` shorthand fallback for no-alias requests) rather than by position, plus the failed-optional second loop. This is the alias-matching fix from #11373.

Both modules ship with the relevant pnpm unit tests ported as Rust tests (14 total, all passing), including the two regression scenarios from #11373 (a failed optional update leaving an unrelated dependency untouched, and a no-alias GitHub shorthand normalizing to `github:…`).

These modules are **not yet wired into `add` / `update`**. That integration — surfacing resolved direct dependencies out of `Install` and threading the catalog `userSpecifiedBareSpecifier` through resolution — is tracked in #12548.

Related to #11267, #11373. Part of #12548.

## Squash Commit Body

```text
Port pnpm's post-resolution manifest writer into the pacquet
package-manager crate as two modules mirroring pnpm's crate boundaries:

- update_project_manifest_object: port of @pnpm/pkg-manifest.utils'
  updateProjectManifestObject (field upsert with cross-field delete,
  peer-range derivation, guessDependencyType, empty-spec preservation).
- update_project_manifest: port of updateProjectManifest, matching
  resolved direct deps to wanted deps by alias (with a github: shorthand
  fallback) instead of by position, including the fix from #11373.

Both modules ship with the ported pnpm unit tests (14 total). They are
not yet wired into add/update; that integration (surfacing resolved
direct deps from Install and threading the catalog
userSpecifiedBareSpecifier) is tracked in #12548.

Related to #11267, #11373. Part of #12548.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  (TS landed in #11373; this is the Rust port of the writer logic. Wiring
  into the CLI is tracked in #12548.)
- [x] Added or updated tests. (14 ported pnpm unit tests.)

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public support for rewriting dependency specs in a package manifest, including selecting the right dependency field, handling alias updates, and optionally generating/updating `peerDependencies`.
* **Bug Fixes / Improvements**
  * Improved normalization and preservation logic for `workspace:` / `workspace:*`, `catalog:` precedence, GitHub shorthand expansion, and more reliable behavior when optional resolutions succeed or fail.
* **Tests**
  * Expanded unit coverage with fixtures and scenario-based assertions for spec rewriting, peer/range generation (including pinning and JSR cases), and correct field selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->