### PR TITLE
feat(pacquet): implement cat-file command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3470,6 +3470,7 @@ name = "pacquet-cli"
 version = "0.0.1"
 dependencies = [
  "assert_cmd",
+ "base64 0.22.1",
  "clap",
  "command-extra",
  "derive_more",

--- a/pacquet/crates/cli/Cargo.toml
+++ b/pacquet/crates/cli/Cargo.toml
@@ -60,6 +60,7 @@ serde_json   = { workspace = true }
 tabled       = { workspace = true }
 tokio        = { workspace = true }
 which        = { workspace = true }
+base64       = { workspace = true }
 
 # Windows has no process groups, so a Job Object ties the lifetime of spawned
 # children (lifecycle scripts and their descendants) to pacquet's. See

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -1,4 +1,5 @@
 pub mod add;
+pub mod cat_file;
 pub mod create;
 pub mod dlx;
 pub mod exec;
@@ -17,6 +18,7 @@ pub mod why;
 
 use crate::{State, config_deps, config_overrides::ConfigOverrides};
 use add::AddArgs;
+use cat_file::CatFileArgs;
 use clap::{Parser, Subcommand, ValueEnum};
 use create::CreateArgs;
 use dlx::DlxArgs;
@@ -159,6 +161,8 @@ pub enum CliCommand {
     /// Managing the package store.
     #[clap(subcommand)]
     Store(StoreCommand),
+    /// Prints the contents of a file based on the hash value stored in the index file.
+    CatFile(CatFileArgs),
 }
 
 impl CliArgs {
@@ -456,6 +460,9 @@ impl CliArgs {
                 args.run(&dir, config()?, matches!(reporter, ReporterType::Silent))?;
             }
             CliCommand::Store(command) => command.run(|| config().map(|m| &*m))?,
+            CliCommand::CatFile(args) => {
+                args.run(|| config().map(|m| &*m))?;
+            }
         }
 
         // The `Done in ...` footer covers the whole command, mirroring pnpm's

--- a/pacquet/crates/cli/src/cli_args/cat_file.rs
+++ b/pacquet/crates/cli/src/cli_args/cat_file.rs
@@ -3,8 +3,7 @@ use clap::Args;
 use miette::{Context, IntoDiagnostic};
 use pacquet_config::Config;
 use pacquet_store_dir::StoreDir;
-use std::fs::File;
-use std::io::Write;
+use std::{fs::File, io::Write};
 
 #[derive(Debug, Args)]
 pub struct CatFileArgs {

--- a/pacquet/crates/cli/src/cli_args/cat_file.rs
+++ b/pacquet/crates/cli/src/cli_args/cat_file.rs
@@ -3,7 +3,8 @@ use clap::Args;
 use miette::{Context, IntoDiagnostic};
 use pacquet_config::Config;
 use pacquet_store_dir::StoreDir;
-use std::fs;
+use std::fs::File;
+use std::io::Write;
 
 #[derive(Debug, Args)]
 pub struct CatFileArgs {
@@ -42,11 +43,15 @@ impl CatFileArgs {
         // Path should be <store>/files/<first 2 chars>/<rest of hex chars>
         let file_path = store_dir.root().join("files").join(&hex[..2]).join(&hex[2..]);
 
-        let content = fs::read_to_string(&file_path).into_diagnostic().wrap_err_with(|| {
-            format!("Corresponding hash file not found: {}", file_path.display())
-        })?;
+        let mut file = File::open(&file_path)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("File not found in store: {}", file_path.display()))?;
 
-        print!("{content}");
+        let mut stdout = std::io::stdout();
+        std::io::copy(&mut file, &mut stdout)
+            .into_diagnostic()
+            .wrap_err("Failed to write to stdout")?;
+        stdout.flush().into_diagnostic()?;
 
         Ok(())
     }

--- a/pacquet/crates/cli/src/cli_args/cat_file.rs
+++ b/pacquet/crates/cli/src/cli_args/cat_file.rs
@@ -3,8 +3,7 @@ use clap::Args;
 use miette::{Context, IntoDiagnostic};
 use pacquet_config::Config;
 use pacquet_store_dir::StoreDir;
-use std::fs::File;
-use std::io::Write as _;
+use std::{fs::File, io::Write as _};
 
 #[derive(Debug, Args)]
 pub struct CatFileArgs {

--- a/pacquet/crates/cli/src/cli_args/cat_file.rs
+++ b/pacquet/crates/cli/src/cli_args/cat_file.rs
@@ -3,7 +3,8 @@ use clap::Args;
 use miette::{Context, IntoDiagnostic};
 use pacquet_config::Config;
 use pacquet_store_dir::StoreDir;
-use std::{fs::File, io::Write};
+use std::fs::File;
+use std::io::Write as _;
 
 #[derive(Debug, Args)]
 pub struct CatFileArgs {
@@ -30,7 +31,7 @@ impl CatFileArgs {
             .into_diagnostic()
             .wrap_err("Failed to decode base64 hash")?;
 
-        use std::fmt::Write;
+        use std::fmt::Write as _;
         let mut hex = String::with_capacity(decoded.len() * 2);
         for b in decoded {
             // The hex conversion produces only characters 0-9a-f, which mathematically cannot

--- a/pacquet/crates/cli/src/cli_args/cat_file.rs
+++ b/pacquet/crates/cli/src/cli_args/cat_file.rs
@@ -1,0 +1,53 @@
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use clap::Args;
+use miette::{Context, IntoDiagnostic};
+use pacquet_config::Config;
+use pacquet_store_dir::StoreDir;
+use std::fs;
+
+#[derive(Debug, Args)]
+pub struct CatFileArgs {
+    /// The hash of the file to read (e.g. sha512-...)
+    pub hash: String,
+}
+
+impl CatFileArgs {
+    pub fn run<'a>(
+        self,
+        config: impl FnOnce() -> miette::Result<&'a Config>,
+    ) -> miette::Result<()> {
+        let hash = self.hash;
+
+        let Some((_, integrity_hash)) = hash.split_once('-') else {
+            return Err(miette::miette!(
+                "Invalid hash format. Expected something like sha512-..., got {}",
+                hash
+            ));
+        };
+
+        let decoded = BASE64
+            .decode(integrity_hash)
+            .into_diagnostic()
+            .wrap_err("Failed to decode base64 hash")?;
+
+        use std::fmt::Write;
+        let mut hex = String::with_capacity(decoded.len() * 2);
+        for b in decoded {
+            write!(&mut hex, "{b:02x}").into_diagnostic()?;
+        }
+
+        let config = config()?;
+        let store_dir: &StoreDir = &config.store_dir;
+
+        // Path should be <store>/files/<first 2 chars>/<rest of hex chars>
+        let file_path = store_dir.root().join("files").join(&hex[..2]).join(&hex[2..]);
+
+        let content = fs::read_to_string(&file_path).into_diagnostic().wrap_err_with(|| {
+            format!("Corresponding hash file not found: {}", file_path.display())
+        })?;
+
+        print!("{content}");
+
+        Ok(())
+    }
+}

--- a/pacquet/crates/cli/src/cli_args/cat_file.rs
+++ b/pacquet/crates/cli/src/cli_args/cat_file.rs
@@ -34,6 +34,8 @@ impl CatFileArgs {
         use std::fmt::Write;
         let mut hex = String::with_capacity(decoded.len() * 2);
         for b in decoded {
+            // The hex conversion produces only characters 0-9a-f, which mathematically cannot
+            // form path-traversal sequences (like '.', '/', or '\'), ensuring path safety by design.
             write!(&mut hex, "{b:02x}").into_diagnostic()?;
         }
 

--- a/pacquet/crates/cli/tests/cat_file.rs
+++ b/pacquet/crates/cli/tests/cat_file.rs
@@ -1,0 +1,30 @@
+use assert_cmd::prelude::*;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use std::fs;
+
+#[test]
+fn cat_file_works() {
+    let CommandTempCwd { mut pacquet, root: _root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    // Create a mock store directory
+    let store_dir = npmrc_info.store_dir;
+    let files_dir = store_dir.join("v11").join("files");
+
+    // Using some valid hash bytes.
+    // "hello world" -> sha512: 309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f
+    // which in base64 is: MJ7MSJwS1utMxA9QyQLytNDtd+5RGnx6m808qG1M2G+YndNbxf9JlnDaNCVbRbDP2DDoH2Bdz33FVC6TrpzXbw==
+    let content = "hello world";
+    let hex = "309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f";
+    let base64_hash =
+        "MJ7MSJwS1utMxA9QyQLytNDtd+5RGnx6m808qG1M2G+YndNbxf9JlnDaNCVbRbDP2DDoH2Bdz33FVC6TrpzXbw==";
+
+    let cafs_dir = files_dir.join(&hex[..2]);
+    fs::create_dir_all(&cafs_dir).unwrap();
+    let file_path = cafs_dir.join(&hex[2..]);
+    fs::write(&file_path, content).unwrap();
+
+    let output = pacquet.arg("cat-file").arg(format!("sha512-{base64_hash}")).assert().success();
+
+    assert_eq!(String::from_utf8(output.get_output().stdout.clone()).unwrap(), "hello world");
+}

--- a/pacquet/crates/cli/tests/cat_file.rs
+++ b/pacquet/crates/cli/tests/cat_file.rs
@@ -7,13 +7,9 @@ fn cat_file_works() {
     let CommandTempCwd { mut pacquet, root: _root, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
 
-    // Create a mock store directory
     let store_dir = npmrc_info.store_dir;
     let files_dir = store_dir.join("v11").join("files");
 
-    // Using some valid hash bytes.
-    // "hello world" -> sha512: 309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f
-    // which in base64 is: MJ7MSJwS1utMxA9QyQLytNDtd+5RGnx6m808qG1M2G+YndNbxf9JlnDaNCVbRbDP2DDoH2Bdz33FVC6TrpzXbw==
     let content = "hello world";
     let hex = "309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f";
     let base64_hash =
@@ -27,4 +23,55 @@ fn cat_file_works() {
     let output = pacquet.arg("cat-file").arg(format!("sha512-{base64_hash}")).assert().success();
 
     assert_eq!(String::from_utf8(output.get_output().stdout.clone()).unwrap(), "hello world");
+}
+
+#[test]
+fn cat_file_works_with_binary() {
+    let CommandTempCwd { mut pacquet, root: _root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    let store_dir = npmrc_info.store_dir;
+    let files_dir = store_dir.join("v11").join("files");
+
+    let binary_content = b"\x89PNG\r\n\x1a\n\x00\x01\x02\x03\xff\xfe";
+    let hex = "002fd6b03246626a0eb5d9a17b15b7d9d30fec368a04a8a809946750d66f22190ccf37a449207df3f98ac9bcf4554316e7beffa21dff3c80efc4b516f0c361be";
+    let base64_hash =
+        "AC/WsDJGYmoOtdmhexW32dMP7DaKBKioCZRnUNZvIhkMzzekSSB98/mKybz0VUMW577/oh3/PIDvxLUW8MNhvg==";
+
+    let cafs_dir = files_dir.join(&hex[..2]);
+    fs::create_dir_all(&cafs_dir).unwrap();
+    let file_path = cafs_dir.join(&hex[2..]);
+    fs::write(&file_path, binary_content).unwrap();
+
+    let output = pacquet.arg("cat-file").arg(format!("sha512-{base64_hash}")).assert().success();
+
+    assert_eq!(output.get_output().stdout, binary_content);
+}
+
+#[test]
+fn should_fail_on_missing_hash() {
+    let CommandTempCwd { mut pacquet, root: _root, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let output = pacquet.arg("cat-file").arg("sha512-MJ7MSJwS1utMxA9QyQLytNDtd+5RGnx6m808qG1M2G+YndNbxf9JlnDaNCVbRbDP2DDoH2Bdz33FVC6TrpzXbw==").assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(stderr.contains("File not found in store"));
+}
+
+#[test]
+fn should_fail_on_invalid_hash_format() {
+    let CommandTempCwd { mut pacquet, root: _root, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let output = pacquet.arg("cat-file").arg("invalidhashformatwithoutdash").assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    println!("STDERR format: {stderr}");
+    assert!(stderr.contains("Invalid hash format"));
+}
+
+#[test]
+fn should_fail_on_invalid_base64() {
+    let CommandTempCwd { mut pacquet, root: _root, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let output = pacquet.arg("cat-file").arg("sha512-InvalidBase64!!!").assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(stderr.contains("Failed to decode base64 hash"));
 }

--- a/pacquet/crates/cli/tests/cat_file.rs
+++ b/pacquet/crates/cli/tests/cat_file.rs
@@ -75,3 +75,15 @@ fn should_fail_on_invalid_base64() {
     let stderr = String::from_utf8_lossy(&output.get_output().stderr);
     assert!(stderr.contains("Failed to decode base64 hash"));
 }
+
+#[test]
+fn should_prevent_path_traversal() {
+    let CommandTempCwd { mut pacquet, root: _root, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    // A crafted base64 payload that decodes to bytes resembling a path traversal like "../../etc/passwd".
+    // "Li4vLi4vZXRjL3Bhc3N3ZA==" is base64 for "../../etc/passwd"
+    let output = pacquet.arg("cat-file").arg("sha512-Li4vLi4vZXRjL3Bhc3N3ZA==").assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    // It should fail to find the file (or decode as invalid depending on length), but it must NOT escape the store.
+    assert!(stderr.contains("File not found in store"));
+}

--- a/pacquet/crates/cli/tests/cat_file.rs
+++ b/pacquet/crates/cli/tests/cat_file.rs
@@ -63,7 +63,7 @@ fn should_fail_on_invalid_hash_format() {
         CommandTempCwd::init().add_mocked_registry();
     let output = pacquet.arg("cat-file").arg("invalidhashformatwithoutdash").assert().failure();
     let stderr = String::from_utf8_lossy(&output.get_output().stderr);
-    println!("STDERR format: {stderr}");
+
     assert!(stderr.contains("Invalid hash format"));
 }
 


### PR DESCRIPTION
## Summary

This PR implements the `cat-file` command in the `pacquet` Rust port.
This directly mirrors the TypeScript CLI's `cat-file` functionality.

Related https://github.com/pnpm/pnpm/issues/11633

## Squash Commit Body

```text
feat(pacquet): implement cat-file command

Adds `pnpm cat-file` functionality to the `pacquet` CLI. This extracts the
base64-encoded file hash from an integrity string (e.g. `sha512-...`),
decodes it, and reads the corresponding file from the CAFS store directory
at `files/XX/YYYY...`.

Includes a new e2e test verifying correct lookup and read operations.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `cat-file` CLI subcommand that retrieves an object by `sha512-<base64>` integrity hash and streams its raw contents directly to stdout.
* **Tests**
  * Added integration coverage for both UTF-8 text and binary output.
  * Added assertions for error handling when the object is missing, the hash format is invalid, or base64 decoding fails.
  * Included a regression test to ensure crafted inputs can’t escape store lookup boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->