### PR TITLE
feat(pacquet): implement cat-index command

### DIFF
--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -1,5 +1,6 @@
 pub mod add;
 pub mod cat_file;
+pub mod cat_index;
 pub mod create;
 pub mod dlx;
 pub mod exec;
@@ -19,6 +20,7 @@ pub mod why;
 use crate::{State, config_deps, config_overrides::ConfigOverrides};
 use add::AddArgs;
 use cat_file::CatFileArgs;
+use cat_index::CatIndexArgs;
 use clap::{Parser, Subcommand, ValueEnum};
 use create::CreateArgs;
 use dlx::DlxArgs;
@@ -163,6 +165,8 @@ pub enum CliCommand {
     Store(StoreCommand),
     /// Prints the contents of a file based on the hash value stored in the index file.
     CatFile(CatFileArgs),
+    /// Prints the index file of a specific package from the store.
+    CatIndex(CatIndexArgs),
 }
 
 impl CliArgs {
@@ -462,6 +466,9 @@ impl CliArgs {
             CliCommand::Store(command) => command.run(|| config().map(|m| &*m))?,
             CliCommand::CatFile(args) => {
                 args.run(|| config().map(|m| &*m))?;
+            }
+            CliCommand::CatIndex(args) => {
+                args.run(state(false)?).await?;
             }
         }
 

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -468,7 +468,7 @@ impl CliArgs {
                 args.run(|| config().map(|m| &*m))?;
             }
             CliCommand::CatIndex(args) => {
-                args.run(state(false)?).await?;
+                args.run(|| config().map(|m| &*m)).await?;
             }
         }
 

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -468,7 +468,7 @@ impl CliArgs {
                 args.run(|| config().map(|m| &*m))?;
             }
             CliCommand::CatIndex(args) => {
-                args.run(|| config().map(|m| &*m)).await?;
+                args.run(&dir, || config().map(|m| &*m)).await?;
             }
         }
 

--- a/pacquet/crates/cli/src/cli_args/cat_index.rs
+++ b/pacquet/crates/cli/src/cli_args/cat_index.rs
@@ -121,10 +121,10 @@ fn sort_deep_keys(value: &mut Value) {
         let mut keys: Vec<_> = map.keys().cloned().collect();
         keys.sort(); // Simple string comparison
 
-        for k in keys {
-            let mut v = map.remove(&k).unwrap();
-            sort_deep_keys(&mut v);
-            sorted.insert(k, v);
+        for key in keys {
+            let mut val = map.remove(&key).unwrap();
+            sort_deep_keys(&mut val);
+            sorted.insert(key, val);
         }
         *map = sorted;
     } else if let Value::Array(arr) = value {

--- a/pacquet/crates/cli/src/cli_args/cat_index.rs
+++ b/pacquet/crates/cli/src/cli_args/cat_index.rs
@@ -1,6 +1,7 @@
-use crate::State;
 use clap::Args;
 use miette::{Context, IntoDiagnostic, Result};
+use pacquet_config::Config;
+use pacquet_network::{NetworkSettings, RetryOpts, ThrottledClient};
 use pacquet_resolving_npm_resolver::{
     InMemoryPackageMetaCache, PickPackageContext, PickPackageOptions, parse_bare_specifier,
     pick_package, pick_registry_for_package, shared_packument_fetch_locker,
@@ -8,6 +9,7 @@ use pacquet_resolving_npm_resolver::{
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
 use pacquet_store_dir::{StoreIndex, store_index_key};
 use serde_json::Value;
+use std::{collections::HashMap, io::Write as _, time::Duration};
 
 #[derive(Debug, Args)]
 pub struct CatIndexArgs {
@@ -16,7 +18,7 @@ pub struct CatIndexArgs {
 }
 
 impl CatIndexArgs {
-    pub async fn run(self, state: State) -> Result<()> {
+    pub async fn run<'a>(self, config: impl FnOnce() -> Result<&'a Config>) -> Result<()> {
         let parsed = parse_wanted_dependency(&self.wanted_dependency);
         let Some(alias) = parsed.alias else {
             return Err(miette::miette!(
@@ -27,8 +29,8 @@ impl CatIndexArgs {
 
         let bare_specifier = parsed.bare_specifier.unwrap_or_else(|| "latest".to_string());
 
-        let config = state.config;
-        let registries: std::collections::HashMap<String, String> =
+        let config = config()?;
+        let registries: HashMap<String, String> =
             config.resolved_registries().into_iter().collect();
         let registry = pick_registry_for_package(&registries, &alias, None);
 
@@ -38,11 +40,24 @@ impl CatIndexArgs {
             return Err(miette::miette!("Invalid specifier for registry resolution"));
         };
 
+        let http_client = ThrottledClient::for_installs(
+            &config.proxy,
+            &config.tls,
+            &config.tls_by_uri,
+            &NetworkSettings {
+                network_concurrency: config.network_concurrency,
+                fetch_timeout: Duration::from_millis(config.fetch_timeout),
+                user_agent: config.user_agent.clone(),
+            },
+        )
+        .into_diagnostic()
+        .wrap_err("create the network client")?;
+
         let meta_cache = InMemoryPackageMetaCache::default();
         let fetch_locker = shared_packument_fetch_locker();
 
         let ctx = PickPackageContext {
-            http_client: &state.http_client,
+            http_client: &http_client,
             auth_headers: &config.auth_headers,
             meta_cache: &meta_cache,
             fetch_locker: &fetch_locker,
@@ -52,7 +67,12 @@ impl CatIndexArgs {
             ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
             full_metadata: false,
             filter_metadata: false,
-            retry_opts: pacquet_network::RetryOpts::default(),
+            retry_opts: RetryOpts {
+                retries: config.fetch_retries,
+                factor: config.fetch_retry_factor,
+                min_timeout: Duration::from_millis(config.fetch_retry_mintimeout),
+                max_timeout: Duration::from_millis(config.fetch_retry_maxtimeout),
+            },
         };
 
         let opts = PickPackageOptions {
@@ -62,7 +82,9 @@ impl CatIndexArgs {
             published_by_exclude: None,
             pick_lowest_version: false,
             include_latest_tag: false,
-            dry_run: false,
+            // A read-only inspection command: skip the cache write-back that
+            // `pick_package` performs on a fresh 200 response.
+            dry_run: true,
             optional: false,
             update_checksums: false,
             blocked_versions: None,
@@ -77,11 +99,9 @@ impl CatIndexArgs {
             return Err(miette::miette!("No version found matching the specifier"));
         };
 
-        let integrity = picked
-            .dist
-            .integrity
-            .clone()
-            .unwrap_or_else(|| panic!("Package resolved without integrity"));
+        let integrity = picked.dist.integrity.clone().ok_or_else(|| {
+            miette::miette!("Package {alias} has no integrity hash in registry metadata")
+        })?;
 
         let files_index_file =
             store_index_key(&integrity.to_string(), &format!("{}@{}", alias, picked.version));
@@ -96,40 +116,43 @@ impl CatIndexArgs {
 
         let store_index = StoreIndex::open_readonly(store_dir).into_diagnostic()?;
 
-        let pkg_files_index = store_index.get(&files_index_file).into_diagnostic()?;
-
-        let Some(pkg_files_index) = pkg_files_index else {
+        let Some(pkg_files_index) = store_index.get(&files_index_file).into_diagnostic()? else {
             return Err(miette::miette!(
                 "No corresponding index file found. You can use pnpm list to see if the package is installed."
             ));
         };
 
-        // pnpm's sortDeepKeys equivalent
+        // Mirror pnpm's `sortDeepKeys`: order every nested object's keys
+        // lexicographically so the rendered index is stable and diffable.
         let mut value = serde_json::to_value(&pkg_files_index).into_diagnostic()?;
         sort_deep_keys(&mut value);
 
         let json = serde_json::to_string_pretty(&value).into_diagnostic()?;
-        println!("{json}");
+        // Ignore write errors (e.g. a closed pipe from `| head`) so the command
+        // exits cleanly instead of panicking on EPIPE.
+        let mut stdout = std::io::stdout();
+        let _ = writeln!(stdout, "{json}");
+        let _ = stdout.flush();
 
         Ok(())
     }
 }
 
 fn sort_deep_keys(value: &mut Value) {
-    if let Value::Object(map) = value {
-        let mut sorted = serde_json::Map::new();
-        let mut keys: Vec<_> = map.keys().cloned().collect();
-        keys.sort(); // Simple string comparison
-
-        for key in keys {
-            let mut val = map.remove(&key).unwrap();
-            sort_deep_keys(&mut val);
-            sorted.insert(key, val);
+    match value {
+        Value::Object(map) => {
+            let mut entries: Vec<(String, Value)> = std::mem::take(map).into_iter().collect();
+            entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+            for (_, val) in &mut entries {
+                sort_deep_keys(val);
+            }
+            *map = entries.into_iter().collect();
         }
-        *map = sorted;
-    } else if let Value::Array(arr) = value {
-        for item in arr {
-            sort_deep_keys(item);
+        Value::Array(arr) => {
+            for item in arr {
+                sort_deep_keys(item);
+            }
         }
+        _ => {}
     }
 }

--- a/pacquet/crates/cli/src/cli_args/cat_index.rs
+++ b/pacquet/crates/cli/src/cli_args/cat_index.rs
@@ -1,15 +1,21 @@
 use clap::Args;
 use miette::{Context, IntoDiagnostic, Result};
 use pacquet_config::Config;
-use pacquet_network::{NetworkSettings, RetryOpts, ThrottledClient};
-use pacquet_resolving_npm_resolver::{
-    InMemoryPackageMetaCache, PickPackageContext, PickPackageOptions, parse_bare_specifier,
-    pick_package, pick_registry_for_package, shared_packument_fetch_locker,
+use pacquet_lockfile::{
+    Lockfile, LockfileResolution, PackageMetadata, PkgName, ProjectSnapshot, ResolvedDependencySpec,
 };
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
-use pacquet_store_dir::{StoreIndex, store_index_key};
+use pacquet_store_dir::{
+    PackageFilesIndex, StoreIndex, StoreIndexError, git_hosted_store_index_key, store_index_key,
+};
 use serde_json::Value;
-use std::{collections::HashMap, io::Write as _, time::Duration};
+use std::{
+    collections::HashSet,
+    io::Write as _,
+    path::{Path, PathBuf},
+};
+
+const MAX_JSON_SORT_DEPTH: usize = 128;
 
 #[derive(Debug, Args)]
 pub struct CatIndexArgs {
@@ -27,109 +33,37 @@ impl CatIndexArgs {
             ));
         };
 
-        let bare_specifier = parsed.bare_specifier.unwrap_or_else(|| "latest".to_string());
-
         let config = config()?;
-        let registries: HashMap<String, String> =
-            config.resolved_registries().into_iter().collect();
-        let registry = pick_registry_for_package(&registries, &alias, None);
+        let lockfile_dir = lockfile_dir(config)?;
+        let requested_bare = parsed.bare_specifier.as_deref();
+        let keys = lockfile_store_index_keys(&lockfile_dir, &alias, requested_bare)
+            .wrap_err("load package key from lockfile")?;
+        let fallback_pkg_ids = fallback_pkg_ids(&alias, requested_bare);
+        let store_dir = config.store_dir.root().to_path_buf();
+        let frozen_store = config.frozen_store;
 
-        let Some(spec_parsed) =
-            parse_bare_specifier(&bare_specifier, Some(&alias), "latest", &registry)
-        else {
-            return Err(miette::miette!("Invalid specifier for registry resolution"));
-        };
-
-        let http_client = ThrottledClient::for_installs(
-            &config.proxy,
-            &config.tls,
-            &config.tls_by_uri,
-            &NetworkSettings {
-                network_concurrency: config.network_concurrency,
-                fetch_timeout: Duration::from_millis(config.fetch_timeout),
-                user_agent: config.user_agent.clone(),
-            },
-        )
+        let pkg_files_index = tokio::task::spawn_blocking(move || {
+            read_package_index(&store_dir, frozen_store, keys, fallback_pkg_ids)
+        })
+        .await
         .into_diagnostic()
-        .wrap_err("create the network client")?;
+        .wrap_err("read package index")?
+        .into_diagnostic()?;
 
-        let meta_cache = InMemoryPackageMetaCache::default();
-        let fetch_locker = shared_packument_fetch_locker();
-
-        let ctx = PickPackageContext {
-            http_client: &http_client,
-            auth_headers: &config.auth_headers,
-            meta_cache: &meta_cache,
-            fetch_locker: &fetch_locker,
-            cache_dir: Some(&config.cache_dir),
-            offline: config.offline,
-            prefer_offline: config.prefer_offline,
-            ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
-            full_metadata: false,
-            filter_metadata: false,
-            retry_opts: RetryOpts {
-                retries: config.fetch_retries,
-                factor: config.fetch_retry_factor,
-                min_timeout: Duration::from_millis(config.fetch_retry_mintimeout),
-                max_timeout: Duration::from_millis(config.fetch_retry_maxtimeout),
-            },
+        let Some(pkg_files_index) = pkg_files_index else {
+            return Err(miette::miette!(
+                "No corresponding index file found. You can use pnpm list to see if the package is installed."
+            ));
         };
 
-        let opts = PickPackageOptions {
-            registry: &registry,
-            preferred_version_selectors: None,
-            published_by: None,
-            published_by_exclude: None,
-            pick_lowest_version: false,
-            include_latest_tag: false,
-            // A read-only inspection command: skip the cache write-back that
-            // `pick_package` performs on a fresh 200 response.
-            dry_run: true,
-            optional: false,
-            update_checksums: false,
-            blocked_versions: None,
-        };
-
-        let pick = pick_package(&ctx, &spec_parsed, &opts)
-            .await
+        let mut value = serde_json::to_value(&pkg_files_index)
             .into_diagnostic()
-            .wrap_err("Failed to resolve package")?;
+            .wrap_err("serialize package index")?;
+        sort_deep_keys(&mut value, 0)?;
 
-        let Some(picked) = pick.picked_package else {
-            return Err(miette::miette!("No version found matching the specifier"));
-        };
-
-        let integrity = picked.dist.integrity.clone().ok_or_else(|| {
-            miette::miette!("Package {alias} has no integrity hash in registry metadata")
-        })?;
-
-        let files_index_file =
-            store_index_key(&integrity.to_string(), &format!("{}@{}", alias, picked.version));
-
-        let store_dir = config.store_dir.root();
-
-        if !store_dir.join("index.db").exists() {
-            return Err(miette::miette!(
-                "No corresponding index file found. You can use pnpm list to see if the package is installed."
-            ));
-        }
-
-        let store_index = StoreIndex::open_readonly(store_dir).into_diagnostic()?;
-
-        let Some(pkg_files_index) = store_index.get(&files_index_file).into_diagnostic()? else {
-            return Err(miette::miette!(
-                "No corresponding index file found. You can use pnpm list to see if the package is installed."
-            ));
-        };
-
-        // Mirror pnpm's `sortDeepKeys`: order every nested object's keys
-        // lexicographically so the rendered index is stable and diffable.
-        let mut value = serde_json::to_value(&pkg_files_index).into_diagnostic()?;
-        sort_deep_keys(&mut value);
-
-        let json = serde_json::to_string_pretty(&value).into_diagnostic()?;
-        // Ignore write errors (e.g. a closed pipe from `| head`) so the command
-        // exits cleanly instead of panicking on EPIPE.
+        let json = serde_json::to_string_pretty(&value)
+            .into_diagnostic()
+            .wrap_err("render package index JSON")?;
         let mut stdout = std::io::stdout();
         let _ = writeln!(stdout, "{json}");
         let _ = stdout.flush();
@@ -138,21 +72,184 @@ impl CatIndexArgs {
     }
 }
 
-fn sort_deep_keys(value: &mut Value) {
+fn lockfile_dir(config: &Config) -> Result<PathBuf> {
+    match &config.workspace_dir {
+        Some(workspace_dir) => Ok(workspace_dir.clone()),
+        None => std::env::current_dir().into_diagnostic().wrap_err("get current directory"),
+    }
+}
+
+fn lockfile_store_index_keys(
+    lockfile_dir: &Path,
+    alias: &str,
+    requested_bare: Option<&str>,
+) -> Result<Vec<String>> {
+    let Some(lockfile) = Lockfile::load_wanted_from_dir(lockfile_dir)
+        .into_diagnostic()
+        .wrap_err("load pnpm-lock.yaml")?
+    else {
+        return Ok(Vec::new());
+    };
+    let Ok(alias_name) = alias.parse::<PkgName>() else {
+        return Ok(Vec::new());
+    };
+    let current_dir =
+        std::env::current_dir().into_diagnostic().wrap_err("get current directory")?;
+    let mut keys = Vec::new();
+    let mut seen = HashSet::new();
+    for importer_id in importer_ids(lockfile_dir, &current_dir) {
+        let Some(importer) = lockfile.importers.get(&importer_id) else { continue };
+        let Some(dependency) = find_dependency(importer, &alias_name) else { continue };
+        let Some(snapshot_key) = dependency.version.resolved_key(&alias_name) else { continue };
+        let metadata_key = snapshot_key.without_peer();
+        let pkg_id = metadata_key.to_string();
+        if !request_matches_dependency(alias, requested_bare, dependency, &pkg_id) {
+            continue;
+        }
+        let Some(metadata) =
+            lockfile.packages.as_ref().and_then(|packages| packages.get(&metadata_key))
+        else {
+            continue;
+        };
+        for key in metadata_store_index_keys(&pkg_id, metadata) {
+            if seen.insert(key.clone()) {
+                keys.push(key);
+            }
+        }
+    }
+    Ok(keys)
+}
+
+fn importer_ids(lockfile_dir: &Path, current_dir: &Path) -> Vec<String> {
+    let mut ids = Vec::with_capacity(2);
+    if let Ok(relative) = current_dir.strip_prefix(lockfile_dir) {
+        let id = if relative.as_os_str().is_empty() {
+            ".".to_string()
+        } else {
+            relative.to_string_lossy().replace(std::path::MAIN_SEPARATOR, "/")
+        };
+        ids.push(id);
+    }
+    if !ids.iter().any(|id| id == ".") {
+        ids.push(".".to_string());
+    }
+    ids
+}
+
+fn find_dependency<'a>(
+    importer: &'a ProjectSnapshot,
+    alias: &PkgName,
+) -> Option<&'a ResolvedDependencySpec> {
+    [&importer.dependencies, &importer.dev_dependencies, &importer.optional_dependencies]
+        .into_iter()
+        .find_map(|dependencies| {
+            dependencies.as_ref().and_then(|dependencies| dependencies.get(alias))
+        })
+}
+
+fn request_matches_dependency(
+    alias: &str,
+    requested_bare: Option<&str>,
+    dependency: &ResolvedDependencySpec,
+    pkg_id: &str,
+) -> bool {
+    let Some(requested_bare) = requested_bare else { return true };
+    dependency.specifier == requested_bare || pkg_id == format!("{alias}@{requested_bare}")
+}
+
+fn metadata_store_index_keys(pkg_id: &str, metadata: &PackageMetadata) -> Vec<String> {
+    match &metadata.resolution {
+        LockfileResolution::Tarball(resolution) if resolution.git_hosted == Some(true) => {
+            git_store_index_keys(pkg_id)
+        }
+        LockfileResolution::Tarball(resolution) => resolution
+            .integrity
+            .as_ref()
+            .map(|integrity| vec![store_index_key(&integrity.to_string(), pkg_id)])
+            .unwrap_or_default(),
+        LockfileResolution::Registry(resolution) => {
+            vec![store_index_key(&resolution.integrity.to_string(), pkg_id)]
+        }
+        LockfileResolution::Git(_) => git_store_index_keys(pkg_id),
+        LockfileResolution::Binary(resolution) => {
+            vec![store_index_key(&resolution.integrity.to_string(), pkg_id)]
+        }
+        LockfileResolution::Directory(_) | LockfileResolution::Variations(_) => Vec::new(),
+    }
+}
+
+fn git_store_index_keys(pkg_id: &str) -> Vec<String> {
+    vec![git_hosted_store_index_key(pkg_id, true), git_hosted_store_index_key(pkg_id, false)]
+}
+
+fn fallback_pkg_ids(alias: &str, requested_bare: Option<&str>) -> Vec<String> {
+    let Some(requested_bare) = requested_bare else { return Vec::new() };
+    let pkg_id = requested_bare
+        .strip_prefix("npm:")
+        .and_then(npm_alias_pkg_id)
+        .unwrap_or_else(|| format!("{alias}@{requested_bare}"));
+    vec![pkg_id]
+}
+
+fn npm_alias_pkg_id(target: &str) -> Option<String> {
+    let at_index = target.bytes().enumerate().rev().find_map(|(idx, byte)| {
+        (byte == b'@' && idx > usize::from(target.starts_with('@'))).then_some(idx)
+    })?;
+    let mut pkg_id = target[..at_index].to_string();
+    pkg_id.push('@');
+    pkg_id.push_str(&target[at_index + 1..]);
+    Some(pkg_id)
+}
+
+fn read_package_index(
+    store_dir: &Path,
+    frozen_store: bool,
+    keys: Vec<String>,
+    fallback_pkg_ids: Vec<String>,
+) -> std::result::Result<Option<PackageFilesIndex>, StoreIndexError> {
+    if !store_dir.join("index.db").exists() {
+        return Ok(None);
+    }
+    let store_index = if frozen_store {
+        StoreIndex::open_immutable(store_dir)?
+    } else {
+        StoreIndex::open_readonly(store_dir)?
+    };
+    for key in keys {
+        if let Some(pkg_files_index) = store_index.get(&key)? {
+            return Ok(Some(pkg_files_index));
+        }
+    }
+    for pkg_id in fallback_pkg_ids {
+        if let Some(pkg_files_index) = store_index.get_by_pkg_id(&pkg_id)? {
+            return Ok(Some(pkg_files_index));
+        }
+    }
+    Ok(None)
+}
+
+fn sort_deep_keys(value: &mut Value, depth: usize) -> Result<()> {
+    if depth > MAX_JSON_SORT_DEPTH {
+        return Err(miette::miette!("Package index JSON is nested too deeply to print safely"));
+    }
     match value {
         Value::Object(map) => {
             let mut entries: Vec<(String, Value)> = std::mem::take(map).into_iter().collect();
             entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
             for (_, val) in &mut entries {
-                sort_deep_keys(val);
+                sort_deep_keys(val, depth + 1)?;
             }
             *map = entries.into_iter().collect();
         }
         Value::Array(arr) => {
             for item in arr {
-                sort_deep_keys(item);
+                sort_deep_keys(item, depth + 1)?;
             }
         }
         _ => {}
     }
+    Ok(())
 }
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/cat_index.rs
+++ b/pacquet/crates/cli/src/cli_args/cat_index.rs
@@ -1,0 +1,135 @@
+use crate::State;
+use clap::Args;
+use miette::{Context, IntoDiagnostic, Result};
+use pacquet_resolving_npm_resolver::{
+    InMemoryPackageMetaCache, PickPackageContext, PickPackageOptions, parse_bare_specifier,
+    pick_package, pick_registry_for_package, shared_packument_fetch_locker,
+};
+use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
+use pacquet_store_dir::{StoreIndex, store_index_key};
+use serde_json::Value;
+
+#[derive(Debug, Args)]
+pub struct CatIndexArgs {
+    /// The package specifier (e.g., `pkg@version`)
+    pub wanted_dependency: String,
+}
+
+impl CatIndexArgs {
+    pub async fn run(self, state: State) -> Result<()> {
+        let parsed = parse_wanted_dependency(&self.wanted_dependency);
+        let Some(alias) = parsed.alias else {
+            return Err(miette::miette!(
+                "Cannot parse the \"{}\" selector",
+                self.wanted_dependency
+            ));
+        };
+
+        let bare_specifier = parsed.bare_specifier.unwrap_or_else(|| "latest".to_string());
+
+        let config = state.config;
+        let registries: std::collections::HashMap<String, String> =
+            config.resolved_registries().into_iter().collect();
+        let registry = pick_registry_for_package(&registries, &alias, None);
+
+        let Some(spec_parsed) =
+            parse_bare_specifier(&bare_specifier, Some(&alias), "latest", &registry)
+        else {
+            return Err(miette::miette!("Invalid specifier for registry resolution"));
+        };
+
+        let meta_cache = InMemoryPackageMetaCache::default();
+        let fetch_locker = shared_packument_fetch_locker();
+
+        let ctx = PickPackageContext {
+            http_client: &state.http_client,
+            auth_headers: &config.auth_headers,
+            meta_cache: &meta_cache,
+            fetch_locker: &fetch_locker,
+            cache_dir: Some(&config.cache_dir),
+            offline: config.offline,
+            prefer_offline: config.prefer_offline,
+            ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
+            full_metadata: false,
+            filter_metadata: false,
+            retry_opts: pacquet_network::RetryOpts::default(),
+        };
+
+        let opts = PickPackageOptions {
+            registry: &registry,
+            preferred_version_selectors: None,
+            published_by: None,
+            published_by_exclude: None,
+            pick_lowest_version: false,
+            include_latest_tag: false,
+            dry_run: false,
+            optional: false,
+            update_checksums: false,
+            blocked_versions: None,
+        };
+
+        let pick = pick_package(&ctx, &spec_parsed, &opts)
+            .await
+            .into_diagnostic()
+            .wrap_err("Failed to resolve package")?;
+
+        let Some(picked) = pick.picked_package else {
+            return Err(miette::miette!("No version found matching the specifier"));
+        };
+
+        let integrity = picked
+            .dist
+            .integrity
+            .clone()
+            .unwrap_or_else(|| panic!("Package resolved without integrity"));
+
+        let files_index_file =
+            store_index_key(&integrity.to_string(), &format!("{}@{}", alias, picked.version));
+
+        let store_dir = config.store_dir.root();
+
+        if !store_dir.join("index.db").exists() {
+            return Err(miette::miette!(
+                "No corresponding index file found. You can use pnpm list to see if the package is installed."
+            ));
+        }
+
+        let store_index = StoreIndex::open_readonly(store_dir).into_diagnostic()?;
+
+        let pkg_files_index = store_index.get(&files_index_file).into_diagnostic()?;
+
+        let Some(pkg_files_index) = pkg_files_index else {
+            return Err(miette::miette!(
+                "No corresponding index file found. You can use pnpm list to see if the package is installed."
+            ));
+        };
+
+        // pnpm's sortDeepKeys equivalent
+        let mut value = serde_json::to_value(&pkg_files_index).into_diagnostic()?;
+        sort_deep_keys(&mut value);
+
+        let json = serde_json::to_string_pretty(&value).into_diagnostic()?;
+        println!("{json}");
+
+        Ok(())
+    }
+}
+
+fn sort_deep_keys(value: &mut Value) {
+    if let Value::Object(map) = value {
+        let mut sorted = serde_json::Map::new();
+        let mut keys: Vec<_> = map.keys().cloned().collect();
+        keys.sort(); // Simple string comparison
+
+        for k in keys {
+            let mut v = map.remove(&k).unwrap();
+            sort_deep_keys(&mut v);
+            sorted.insert(k, v);
+        }
+        *map = sorted;
+    } else if let Value::Array(arr) = value {
+        for item in arr {
+            sort_deep_keys(item);
+        }
+    }
+}

--- a/pacquet/crates/cli/src/cli_args/cat_index.rs
+++ b/pacquet/crates/cli/src/cli_args/cat_index.rs
@@ -24,7 +24,11 @@ pub struct CatIndexArgs {
 }
 
 impl CatIndexArgs {
-    pub async fn run<'a>(self, config: impl FnOnce() -> Result<&'a Config>) -> Result<()> {
+    pub async fn run<'a>(
+        self,
+        dir: &Path,
+        config: impl FnOnce() -> Result<&'a Config>,
+    ) -> Result<()> {
         let parsed = parse_wanted_dependency(&self.wanted_dependency);
         let Some(alias) = parsed.alias else {
             return Err(miette::miette!(
@@ -34,9 +38,9 @@ impl CatIndexArgs {
         };
 
         let config = config()?;
-        let lockfile_dir = lockfile_dir(config)?;
+        let lockfile_dir = lockfile_dir(config, dir);
         let requested_bare = parsed.bare_specifier.as_deref();
-        let keys = lockfile_store_index_keys(&lockfile_dir, &alias, requested_bare)
+        let keys = lockfile_store_index_keys(&lockfile_dir, dir, &alias, requested_bare)
             .wrap_err("load package key from lockfile")?;
         let fallback_pkg_ids = fallback_pkg_ids(&alias, requested_bare);
         let store_dir = config.store_dir.root().to_path_buf();
@@ -72,15 +76,16 @@ impl CatIndexArgs {
     }
 }
 
-fn lockfile_dir(config: &Config) -> Result<PathBuf> {
+fn lockfile_dir(config: &Config, dir: &Path) -> PathBuf {
     match &config.workspace_dir {
-        Some(workspace_dir) => Ok(workspace_dir.clone()),
-        None => std::env::current_dir().into_diagnostic().wrap_err("get current directory"),
+        Some(workspace_dir) => workspace_dir.clone(),
+        None => dir.to_path_buf(),
     }
 }
 
 fn lockfile_store_index_keys(
     lockfile_dir: &Path,
+    dir: &Path,
     alias: &str,
     requested_bare: Option<&str>,
 ) -> Result<Vec<String>> {
@@ -93,11 +98,9 @@ fn lockfile_store_index_keys(
     let Ok(alias_name) = alias.parse::<PkgName>() else {
         return Ok(Vec::new());
     };
-    let current_dir =
-        std::env::current_dir().into_diagnostic().wrap_err("get current directory")?;
     let mut keys = Vec::new();
     let mut seen = HashSet::new();
-    for importer_id in importer_ids(lockfile_dir, &current_dir) {
+    for importer_id in importer_ids(lockfile_dir, dir) {
         let Some(importer) = lockfile.importers.get(&importer_id) else { continue };
         let Some(dependency) = find_dependency(importer, &alias_name) else { continue };
         let Some(snapshot_key) = dependency.version.resolved_key(&alias_name) else { continue };

--- a/pacquet/crates/cli/src/cli_args/cat_index/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/cat_index/tests.rs
@@ -25,3 +25,45 @@ fn sort_deep_keys_rejects_too_deep_json() {
     let error = sort_deep_keys(&mut value, 0).expect_err("deep JSON is rejected");
     assert!(error.to_string().contains("nested too deeply"));
 }
+
+#[test]
+fn sort_deep_keys_sorts_nested_objects_deterministically() {
+    let mut value = json!({
+        "z": 1,
+        "a": {
+            "d": 4,
+            "b": 2,
+            "c": [{ "y": 2, "x": 1 }],
+        },
+        "m": [{ "beta": 2, "alpha": 1 }],
+    });
+
+    sort_deep_keys(&mut value, 0).expect("sort JSON keys");
+
+    assert_eq!(object_keys(&value), vec!["a", "m", "z"]);
+
+    let nested = value.get("a").expect("has nested object");
+    assert_eq!(object_keys(nested), vec!["b", "c", "d"]);
+
+    let array_object = nested
+        .get("c")
+        .expect("has nested array")
+        .as_array()
+        .expect("nested value is an array")
+        .first()
+        .expect("nested array has an object");
+    assert_eq!(object_keys(array_object), vec!["x", "y"]);
+
+    let root_array_object = value
+        .get("m")
+        .expect("has root array")
+        .as_array()
+        .expect("root value is an array")
+        .first()
+        .expect("root array has an object");
+    assert_eq!(object_keys(root_array_object), vec!["alpha", "beta"]);
+}
+
+fn object_keys(value: &serde_json::Value) -> Vec<&str> {
+    value.as_object().expect("value is an object").keys().map(String::as_str).collect()
+}

--- a/pacquet/crates/cli/src/cli_args/cat_index/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/cat_index/tests.rs
@@ -1,0 +1,27 @@
+use pacquet_lockfile::ResolvedDependencySpec;
+use serde_json::json;
+
+use super::{MAX_JSON_SORT_DEPTH, request_matches_dependency, sort_deep_keys};
+
+#[test]
+fn request_does_not_reuse_lockfile_entry_for_different_exact_version() {
+    let dependency = ResolvedDependencySpec {
+        specifier: "^3.1.0".to_string(),
+        version: "3.1.2".parse().expect("parse importer dep version"),
+    };
+
+    assert!(request_matches_dependency("bytes", Some("^3.1.0"), &dependency, "bytes@3.1.2"));
+    assert!(request_matches_dependency("bytes", Some("3.1.2"), &dependency, "bytes@3.1.2"));
+    assert!(!request_matches_dependency("bytes", Some("3.1.1"), &dependency, "bytes@3.1.2"));
+}
+
+#[test]
+fn sort_deep_keys_rejects_too_deep_json() {
+    let mut value = json!(null);
+    for _ in 0..=MAX_JSON_SORT_DEPTH {
+        value = json!({ "child": value });
+    }
+
+    let error = sort_deep_keys(&mut value, 0).expect_err("deep JSON is rejected");
+    assert!(error.to_string().contains("nested too deeply"));
+}

--- a/pacquet/crates/cli/tests/cat_index.rs
+++ b/pacquet/crates/cli/tests/cat_index.rs
@@ -22,7 +22,8 @@ fn should_cat_index_of_installed_package() {
     let stdout = String::from_utf8(output.stdout).expect("valid utf8");
     let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
 
-    let files = json.get("files").expect("has 'files' object").as_object().expect("'files' is an object");
+    let files =
+        json.get("files").expect("has 'files' object").as_object().expect("'files' is an object");
     assert!(files.contains_key("package.json"), "package.json must be in the index");
 
     drop(root);

--- a/pacquet/crates/cli/tests/cat_index.rs
+++ b/pacquet/crates/cli/tests/cat_index.rs
@@ -1,0 +1,43 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+
+#[test]
+fn should_cat_index_of_installed_package() {
+    let CommandTempCwd { pacquet, workspace, root, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    let pacquet = pacquet;
+    pacquet.with_args(["add", "@pnpm.e2e/hello-world-js-bin-parent"]).assert().success();
+
+    let mut pacquet2 = std::process::Command::cargo_bin("pacquet").unwrap();
+    pacquet2.current_dir(&workspace);
+    let output = pacquet2
+        .with_args(["cat-index", "@pnpm.e2e/hello-world-js-bin-parent"])
+        .output()
+        .expect("run pacquet cat-index");
+
+    assert!(output.status.success(), "Failed to cat-index");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"files\": {"));
+
+    drop(root);
+}
+
+#[test]
+fn should_fail_on_missing_package() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init().add_mocked_registry();
+
+    let output = pacquet
+        .with_args(["cat-index", "@pnpm.e2e/hello-world-js-bin-parent"])
+        .output()
+        .expect("run pacquet cat-index");
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    println!("STDERR: {stderr}");
+    assert!(stderr.contains("No corresponding index file found"));
+
+    drop(root);
+}

--- a/pacquet/crates/cli/tests/cat_index.rs
+++ b/pacquet/crates/cli/tests/cat_index.rs
@@ -19,8 +19,11 @@ fn should_cat_index_of_installed_package() {
 
     assert!(output.status.success(), "Failed to cat-index");
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("\"files\": {"));
+    let stdout = String::from_utf8(output.stdout).expect("valid utf8");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+
+    let files = json.get("files").expect("has 'files' object").as_object().expect("'files' is an object");
+    assert!(files.contains_key("package.json"), "package.json must be in the index");
 
     drop(root);
 }
@@ -36,7 +39,6 @@ fn should_fail_on_missing_package() {
     assert!(!output.status.success());
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    println!("STDERR: {stderr}");
     assert!(stderr.contains("No corresponding index file found"));
 
     drop(root);

--- a/pacquet/crates/cli/tests/cat_index.rs
+++ b/pacquet/crates/cli/tests/cat_index.rs
@@ -1,6 +1,7 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::CommandTempCwd;
+use std::{fs, process::Command};
 
 #[test]
 fn should_cat_index_of_installed_package() {
@@ -42,6 +43,61 @@ fn should_cat_index_of_npm_alias() {
         pacquet2.with_args(["cat-index", alias_spec]).output().expect("run pacquet cat-index");
 
     assert!(output.status.success(), "Failed to cat-index npm alias");
+
+    let stdout = String::from_utf8(output.stdout).expect("valid utf8");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let files = files_from_cat_index(&json);
+    assert_package_json_file_entry(files);
+
+    drop(root);
+}
+
+#[test]
+fn should_cat_index_with_dir_pointing_to_workspace_project() {
+    let CommandTempCwd { pacquet, workspace, root, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let dependency = "@pnpm.e2e/hello-world-js-bin-parent";
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "root", "private": true }).to_string(),
+    )
+    .expect("write root package.json");
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "storeDir: ../pacquet-store\ncacheDir: ../pacquet-cache\nenableGlobalVirtualStore: false\npackages:\n  - 'packages/*'\n",
+    )
+    .expect("write pnpm-workspace.yaml");
+
+    let project_dir = workspace.join("packages/foo");
+    fs::create_dir_all(&project_dir).expect("mkdir workspace project");
+    fs::write(
+        project_dir.join("package.json"),
+        serde_json::json!({
+            "name": "@local/foo",
+            "version": "1.0.0",
+            "private": true,
+            "dependencies": { dependency: "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write workspace project package.json");
+
+    pacquet.with_args(["install"]).assert().success();
+
+    let project_dir_arg = project_dir.to_string_lossy().into_owned();
+    let mut pacquet2 = Command::cargo_bin("pacquet").unwrap();
+    pacquet2.current_dir(&workspace);
+    let output = pacquet2
+        .with_args(["--dir", project_dir_arg.as_str(), "cat-index", dependency])
+        .output()
+        .expect("run pacquet cat-index with --dir");
+
+    assert!(
+        output.status.success(),
+        "Failed to cat-index with --dir: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
 
     let stdout = String::from_utf8(output.stdout).expect("valid utf8");
     let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");

--- a/pacquet/crates/cli/tests/cat_index.rs
+++ b/pacquet/crates/cli/tests/cat_index.rs
@@ -22,19 +22,8 @@ fn should_cat_index_of_installed_package() {
     let stdout = String::from_utf8(output.stdout).expect("valid utf8");
     let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
 
-    let files =
-        json.get("files").expect("has 'files' object").as_object().expect("'files' is an object");
-    let package_json = files
-        .get("package.json")
-        .expect("package.json must be in the index")
-        .as_object()
-        .expect("the package.json entry is an object");
-    for key in ["digest", "mode", "size"] {
-        assert!(
-            package_json.contains_key(key),
-            "the package.json file entry records {key:?}, got: {package_json:?}",
-        );
-    }
+    let files = files_from_cat_index(&json);
+    assert_package_json_file_entry(files);
 
     drop(root);
 }
@@ -56,9 +45,8 @@ fn should_cat_index_of_npm_alias() {
 
     let stdout = String::from_utf8(output.stdout).expect("valid utf8");
     let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
-    let files =
-        json.get("files").expect("has 'files' object").as_object().expect("'files' is an object");
-    assert!(files.contains_key("package.json"));
+    let files = files_from_cat_index(&json);
+    assert_package_json_file_entry(files);
 
     drop(root);
 }
@@ -77,4 +65,22 @@ fn should_fail_on_missing_package() {
     assert!(stderr.contains("No corresponding index file found"));
 
     drop(root);
+}
+
+fn files_from_cat_index(json: &serde_json::Value) -> &serde_json::Map<String, serde_json::Value> {
+    json.get("files").expect("has 'files' object").as_object().expect("'files' is an object")
+}
+
+fn assert_package_json_file_entry(files: &serde_json::Map<String, serde_json::Value>) {
+    let package_json = files
+        .get("package.json")
+        .expect("package.json must be in the index")
+        .as_object()
+        .expect("the package.json entry is an object");
+    for key in ["digest", "mode", "size"] {
+        assert!(
+            package_json.contains_key(key),
+            "the package.json file entry records {key:?}, got: {package_json:?}",
+        );
+    }
 }

--- a/pacquet/crates/cli/tests/cat_index.rs
+++ b/pacquet/crates/cli/tests/cat_index.rs
@@ -40,6 +40,30 @@ fn should_cat_index_of_installed_package() {
 }
 
 #[test]
+fn should_cat_index_of_npm_alias() {
+    let CommandTempCwd { pacquet, workspace, root, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    let alias_spec = "my-alias@npm:@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0";
+    pacquet.with_args(["add", alias_spec]).assert().success();
+
+    let mut pacquet2 = std::process::Command::cargo_bin("pacquet").unwrap();
+    pacquet2.current_dir(&workspace);
+    let output =
+        pacquet2.with_args(["cat-index", alias_spec]).output().expect("run pacquet cat-index");
+
+    assert!(output.status.success(), "Failed to cat-index npm alias");
+
+    let stdout = String::from_utf8(output.stdout).expect("valid utf8");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let files =
+        json.get("files").expect("has 'files' object").as_object().expect("'files' is an object");
+    assert!(files.contains_key("package.json"));
+
+    drop(root);
+}
+
+#[test]
 fn should_fail_on_missing_package() {
     let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init().add_mocked_registry();
 

--- a/pacquet/crates/cli/tests/cat_index.rs
+++ b/pacquet/crates/cli/tests/cat_index.rs
@@ -24,7 +24,17 @@ fn should_cat_index_of_installed_package() {
 
     let files =
         json.get("files").expect("has 'files' object").as_object().expect("'files' is an object");
-    assert!(files.contains_key("package.json"), "package.json must be in the index");
+    let package_json = files
+        .get("package.json")
+        .expect("package.json must be in the index")
+        .as_object()
+        .expect("the package.json entry is an object");
+    for key in ["digest", "mode", "size"] {
+        assert!(
+            package_json.contains_key(key),
+            "the package.json file entry records {key:?}, got: {package_json:?}",
+        );
+    }
 
     drop(root);
 }

--- a/pacquet/crates/store-dir/src/store_index.rs
+++ b/pacquet/crates/store-dir/src/store_index.rs
@@ -566,6 +566,33 @@ impl StoreIndex {
         decode_index_value(&bytes).map(Some)
     }
 
+    /// Look up the first package-files index whose key ends with `\t{pkg_id}`.
+    ///
+    /// This is for read-only inspection commands that only know the local
+    /// package id and must not resolve against a registry to recover the
+    /// integrity half of the key.
+    pub fn get_by_pkg_id(
+        &self,
+        pkg_id: &str,
+    ) -> Result<Option<PackageFilesIndex>, StoreIndexError> {
+        let pattern = format!("%\t{}", escape_like_pattern(pkg_id));
+        let row: Option<Vec<u8>> = self
+            .conn
+            .query_row(
+                r"SELECT data FROM package_index WHERE key LIKE ?1 ESCAPE '\' ORDER BY key LIMIT 1",
+                [pattern],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .map(Some)
+            .or_else(|err| match err {
+                rusqlite::Error::QueryReturnedNoRows => Ok(None),
+                other => Err(StoreIndexError::Read { source: other }),
+            })?;
+
+        let Some(bytes) = row else { return Ok(None) };
+        decode_index_value(&bytes).map(Some)
+    }
+
     /// Look up many keys in one trip across the `SQLite` mutex.
     ///
     /// Returns a `key → PackageFilesIndex` map for every row that exists
@@ -808,6 +835,17 @@ fn decode_index_value(bytes: &[u8]) -> Result<PackageFilesIndex, StoreIndexError
     let plain = crate::msgpackr_records::transcode_to_plain_msgpack(bytes)
         .map_err(|source| StoreIndexError::Transcode { source })?;
     rmp_serde::from_slice(&plain).map_err(|source| StoreIndexError::Decode { source })
+}
+
+fn escape_like_pattern(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        if matches!(character, '\\' | '%' | '_') {
+            escaped.push('\\');
+        }
+        escaped.push(character);
+    }
+    escaped
 }
 
 /// Build the `SQLite` key pnpm uses: `"{integrity}\t{pkg_id}"`. Integrity strings

--- a/pacquet/crates/store-dir/src/store_index/tests.rs
+++ b/pacquet/crates/store-dir/src/store_index/tests.rs
@@ -118,6 +118,26 @@ fn get_returns_none_for_missing_key() {
 }
 
 #[test]
+fn get_by_pkg_id_escapes_like_metacharacters() {
+    let dir = tempdir().unwrap();
+    let idx = StoreIndex::open(dir.path()).unwrap();
+    let exact_pkg_id = r"pkg%_\name@1.0.0";
+    let wildcard_neighbor_pkg_id = "pkgXYZname@1.0.0";
+
+    let neighbor_payload = sample_index();
+    idx.set(&store_index_key("sha512-neighbor", wildcard_neighbor_pkg_id), &neighbor_payload)
+        .unwrap();
+
+    assert!(idx.get_by_pkg_id(exact_pkg_id).unwrap().is_none());
+
+    let mut exact_payload = sample_index();
+    exact_payload.algo = "sha512-special".to_string();
+    idx.set(&store_index_key("sha512-exact", exact_pkg_id), &exact_payload).unwrap();
+
+    assert_eq!(idx.get_by_pkg_id(exact_pkg_id).unwrap(), Some(exact_payload));
+}
+
+#[test]
 fn set_is_upsert() {
     let dir = tempdir().unwrap();
     let idx = StoreIndex::open(dir.path()).unwrap();


### PR DESCRIPTION
Implements the `cat-index` command for the Rust pacquet CLI. It mirrors the exact behavior of pnpm's `cat-index`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `cat-index` CLI subcommand to resolve an npm-like selector (including `npm:` aliases) to an installed package and print its local package index metadata as pretty-printed JSON with deterministically sorted keys.
* **Bug Fixes**
  * Clear failure message when no corresponding local index entry is found.
  * Graceful handling of broken-pipe stdout and protection against excessively deep JSON sorting.
* **Tests**
  * Expanded CLI and unit test coverage for successful JSON output (including `package.json` fields) and expected failure when the package isn’t installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->