### PR TITLE
fix(package-manager): save hosted-git adds in normalized shortcut form

### DIFF
--- a/pacquet/crates/package-manager/src/add.rs
+++ b/pacquet/crates/package-manager/src/add.rs
@@ -15,6 +15,7 @@ use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest, PackageManifestError};
 use pacquet_registry::{PackageTag, PackageVersion, PinnedVersion};
 use pacquet_reporter::{LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, Reporter};
+use pacquet_resolving_git_resolver::{HostedGit, HostedOpts};
 use pacquet_resolving_npm_resolver::{
     InMemoryPackageMetaCache, PickPackageContext, PickPackageError, PickPackageOptions,
     parse_bare_specifier, pick_package, pick_registry_for_package, shared_packument_fetch_locker,
@@ -192,7 +193,7 @@ where
                 manifest,
             )
             .await?
-            .unwrap_or_else(|| spec.to_string()),
+            .unwrap_or_else(|| normalized_save_specifier(spec)),
             (None, Some(prev)) => prev.to_string(),
             (None, None) => {
                 let registries: std::collections::HashMap<String, String> =
@@ -462,6 +463,17 @@ fn split_name_spec(input: &str) -> (&str, Option<&str>) {
         Some(idx) => (&input[..idx], Some(&input[idx + 1..])),
         None => (input, None),
     }
+}
+
+/// The specifier `pacquet add <name>@<spec>` saves when `<spec>` isn't a plain
+/// registry range. A hosted-git request — a bare `owner/repo#committish`
+/// shorthand or a GitHub / GitLab / Bitbucket URL — is rewritten to its
+/// `github:` / `gitlab:` / `bitbucket:` shortcut form, the same
+/// `normalizedBareSpecifier` pnpm saves. Everything else (`file:`, `link:`,
+/// `workspace:`, `npm:` aliases, tarball URLs) is kept verbatim.
+fn normalized_save_specifier(spec: &str) -> String {
+    HostedGit::from_url(spec)
+        .map_or_else(|| spec.to_string(), |hosted| hosted.shortcut(HostedOpts::default()))
 }
 
 #[cfg(test)]

--- a/pacquet/crates/package-manager/src/add.rs
+++ b/pacquet/crates/package-manager/src/add.rs
@@ -471,9 +471,18 @@ fn split_name_spec(input: &str) -> (&str, Option<&str>) {
 /// `github:` / `gitlab:` / `bitbucket:` shortcut form, the same
 /// `normalizedBareSpecifier` pnpm saves. Everything else (`file:`, `link:`,
 /// `workspace:`, `npm:` aliases, tarball URLs) is kept verbatim.
+///
+/// An auth-bearing HTTPS URL (`git+https://<token>@github.com/...`) is also
+/// kept verbatim: the shortcut form cannot carry userinfo, so shortcutting
+/// would silently drop the credentials the follow-up install needs to reach a
+/// private repo. This mirrors the git resolver, which keeps such URLs in a
+/// `git+https` form rather than shortcutting them
+/// (see `parse_bare_specifier`'s `hosted.auth.is_some()` branch).
 fn normalized_save_specifier(spec: &str) -> String {
-    HostedGit::from_url(spec)
-        .map_or_else(|| spec.to_string(), |hosted| hosted.shortcut(HostedOpts::default()))
+    match HostedGit::from_url(spec) {
+        Some(hosted) if hosted.auth.is_none() => hosted.shortcut(HostedOpts::default()),
+        _ => spec.to_string(),
+    }
 }
 
 #[cfg(test)]

--- a/pacquet/crates/package-manager/src/add/tests.rs
+++ b/pacquet/crates/package-manager/src/add/tests.rs
@@ -1,4 +1,4 @@
-use super::Add;
+use super::{Add, normalized_save_specifier};
 use crate::ResolvedPackages;
 use pacquet_config::Config;
 use pacquet_network::ThrottledClient;
@@ -120,4 +120,28 @@ fn scoped_package_body(registry_url: &str) -> String {
   }}
 }}"#,
     )
+}
+
+#[test]
+fn normalizes_hosted_git_specifiers_to_shortcut_form() {
+    // A bare `owner/repo#committish` shorthand becomes a `github:` shortcut.
+    assert_eq!(
+        normalized_save_specifier("pnpm/test-git-fetch#8b333f12d5357f4f25a654c305c826294cb073bf"),
+        "github:pnpm/test-git-fetch#8b333f12d5357f4f25a654c305c826294cb073bf",
+    );
+    // A full GitHub URL collapses to the same shortcut.
+    assert_eq!(
+        normalized_save_specifier("https://github.com/pnpm/test-git-fetch"),
+        "github:pnpm/test-git-fetch",
+    );
+    // An explicit `github:` shorthand is idempotent.
+    assert_eq!(
+        normalized_save_specifier("github:pnpm/test-git-fetch#abc"),
+        "github:pnpm/test-git-fetch#abc",
+    );
+    // Non-git specifiers are kept verbatim.
+    assert_eq!(normalized_save_specifier("^1.2.3"), "^1.2.3");
+    assert_eq!(normalized_save_specifier("npm:bar@^1"), "npm:bar@^1");
+    assert_eq!(normalized_save_specifier("file:../bar"), "file:../bar");
+    assert_eq!(normalized_save_specifier("workspace:*"), "workspace:*");
 }

--- a/pacquet/crates/package-manager/src/add/tests.rs
+++ b/pacquet/crates/package-manager/src/add/tests.rs
@@ -139,6 +139,20 @@ fn normalizes_hosted_git_specifiers_to_shortcut_form() {
         normalized_save_specifier("github:pnpm/test-git-fetch#abc"),
         "github:pnpm/test-git-fetch#abc",
     );
+    // GitLab and Bitbucket shorthands and URLs collapse to their own prefixes.
+    assert_eq!(normalized_save_specifier("gitlab:owner/repo#abc"), "gitlab:owner/repo#abc");
+    assert_eq!(normalized_save_specifier("https://gitlab.com/owner/repo"), "gitlab:owner/repo");
+    assert_eq!(normalized_save_specifier("bitbucket:owner/repo#abc"), "bitbucket:owner/repo#abc");
+    assert_eq!(
+        normalized_save_specifier("https://bitbucket.org/owner/repo"),
+        "bitbucket:owner/repo",
+    );
+    // An auth-bearing HTTPS URL is kept verbatim — the shortcut form cannot
+    // carry the embedded credentials, so shortcutting would drop them.
+    assert_eq!(
+        normalized_save_specifier("git+https://x-access-token:tkn@github.com/foo/bar.git#abc"),
+        "git+https://x-access-token:tkn@github.com/foo/bar.git#abc",
+    );
     // Non-git specifiers are kept verbatim.
     assert_eq!(normalized_save_specifier("^1.2.3"), "^1.2.3");
     assert_eq!(normalized_save_specifier("npm:bar@^1"), "npm:bar@^1");


### PR DESCRIPTION
## Summary

`pacquet add <name>@owner/repo#sha` (and GitHub / GitLab / Bitbucket URL forms) previously saved the request to `package.json` **verbatim**. pnpm saves the resolver's normalized shortcut form. This change does the same: the hosted-git request is rewritten to its `github:` / `gitlab:` / `bitbucket:` shortcut (e.g. `owner/repo#sha` → `github:owner/repo#sha`) via the git resolver's own `HostedGit::from_url(...).shortcut(...)` — the same logic that produces `ResolveResult::normalized_bare_specifier` — matching pnpm's saved `normalizedBareSpecifier`.

The normalization runs only in `add`'s non-registry fallback: a git shorthand isn't claimed by the npm resolver (`parse_bare_specifier` returns `None` for it, since `/`/`#` fail the dist-tag check), so no registry fetch happens and registry ranges, `npm:` aliases, `file:`, `link:`, `workspace:`, and tarball URLs are left untouched.

Scope note: this covers the aliased `add <name>@<git>` form. The aliasless `add owner/repo#sha` form (where pnpm derives the alias from the resolved repo's manifest) is a separate, larger feature and is out of scope here.

This is the focused, in-scope piece of #12548 — wiring the full post-resolution `updateProjectManifest` into pacquet add/update turned out to be a parity-only refactor with no functional gain and real regression risk (pacquet's resolver doesn't compute saved specs for registry deps, and pacquet's name-keyed writes are already immune to #11267), so only the genuine behavioral gap — git-shorthand normalization — is implemented.

## Squash Commit Body

```text
fix(package-manager): save hosted-git adds in normalized shortcut form

`pacquet add <name>@owner/repo#sha` (and GitHub / GitLab / Bitbucket URL
forms) previously saved the request verbatim. Save the resolver's shortcut
form instead — `github:owner/repo#sha` — matching pnpm's saved
normalizedBareSpecifier. The normalization runs only in the non-registry
fallback (a git shorthand isn't claimed by the npm resolver, so no registry
fetch happens), leaving registry ranges, npm: aliases, file:, link:,
workspace:, and tarball URLs untouched.

Related to #12548.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting. (Matches
  pnpm's existing `normalizedBareSpecifier` behavior; pacquet-only fix.)
- [x] Added or updated tests. (Unit test for the normalization across shorthand,
  URL, idempotent `github:`, and non-git specifiers.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of hosted Git repository specifications when saving manifests, normalizing GitHub/GitLab/Bitbucket inputs into standardized shortcut forms while preserving auth-bearing specs and leaving non-Git specifiers unchanged.

* **Tests**
  * Added unit tests to verify normalization behavior for hosted Git shorthands and full URLs, idempotency for existing shortcuts, preservation of auth-bearing inputs, and no changes for non-Git specifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->