### PR TITLE
feat(config): support an `_auth` setting for registry authentication

### DIFF
--- a/.changeset/json-env-auth.md
+++ b/.changeset/json-env-auth.md
@@ -22,10 +22,10 @@ _auth:
       authToken: org-token
 ```
 
-Within each registry URL, `@` means registry-wide/default credentials and package scopes like `@org` bind credentials to that scope on the same host. The only supported credential field is `authToken` (maps to `_authToken` / bearer auth); the deprecated `basicAuth` / `username` + `password` forms are intentionally not accepted here and are dropped with a warning.
+Within each registry URL, `@` means registry-wide/default credentials and package scopes like `@org` bind credentials to that scope on the same host. The only supported credential field is `authToken` (maps to `_authToken` / bearer auth); the deprecated `basicAuth` / `username` + `password` forms are intentionally not accepted here.
 
 Each entry also infers a trusted registry route: `@` routes the default registry (and `pnpm add <pkg>` resolves there), and `@org` routes that scope. Because the credential and destination host arrive in one trusted value, repo-controlled `pnpm-workspace.yaml` or project `.npmrc` cannot redirect the token to a different host. `_auth` is honored **only** from the env var and the global config — it is ignored in a project `pnpm-workspace.yaml` / `.npmrc`, so repo-controlled config can never supply registry auth. Precedence: CLI flags (`--registry`, `--@scope:registry`) > `pnpm_config__auth` > global `config.yaml` `_auth` > `pnpm-workspace.yaml`.
 
-Both `pnpm_config__auth` (lowercase, documented form) and `PNPM_CONFIG__AUTH` (all-caps, the shell convention some CI runners apply) are honored. If both are set, lowercase wins unless it is empty, in which case uppercase is used. The env var wins over the global `config.yaml` `_auth` on a conflicting key. `tokenHelper` is not supported in `_auth`. Malformed values warn and the install continues.
+Both `pnpm_config__auth` (lowercase, documented form) and `PNPM_CONFIG__AUTH` (all-caps, the shell convention some CI runners apply) are honored. If both are set, lowercase wins unless it is empty, in which case uppercase is used. The env var wins over the global `config.yaml` `_auth` on a conflicting key. `tokenHelper` is not supported in `_auth`. Parsing is strict: a malformed value (bad JSON, wrong shape, invalid registry URL or scope, an unsupported credential field) fails fast with an error rather than being silently dropped.
 
 **Pacquet parity note:** the pacquet (Rust) port supports the same single credential field as the TS CLI: `authToken`.

--- a/.changeset/json-env-auth.md
+++ b/.changeset/json-env-auth.md
@@ -1,0 +1,31 @@
+---
+"@pnpm/config.reader": minor
+"pnpm": minor
+---
+
+Added an `_auth` setting for configuring registry authentication as a single structured (URL-keyed) value. It can be set in the **global** pnpm config (`config.yaml`) or, for CI, via the `pnpm_config__auth` environment variable. The env form sidesteps the GitHub Actions / bash / zsh limitation that broke the existing `pnpm_config_//host/:_authToken=…` form (env var names containing `/`, `:`, or `.` are silently dropped). Closes pnpm/pnpm#12314.
+
+The value is keyed by registry URL so each secret is explicitly bound to the host that may receive it. Registry URL keys must use `http` or `https` and must not include credentials, query strings, or fragments:
+
+```sh
+export pnpm_config__auth='{"https://registry.npmjs.org":{"@":{"authToken":"npm-token"},"@org":{"authToken":"org-token"}}}'
+```
+
+The equivalent in the global `config.yaml`:
+
+```yaml
+_auth:
+  https://registry.npmjs.org:
+    '@':
+      authToken: npm-token
+    '@org':
+      authToken: org-token
+```
+
+Within each registry URL, `@` means registry-wide/default credentials and package scopes like `@org` bind credentials to that scope on the same host. The only supported credential field is `authToken` (maps to `_authToken` / bearer auth); the deprecated `basicAuth` / `username` + `password` forms are intentionally not accepted here and are dropped with a warning.
+
+Each entry also infers a trusted registry route: `@` routes the default registry (and `pnpm add <pkg>` resolves there), and `@org` routes that scope. Because the credential and destination host arrive in one trusted value, repo-controlled `pnpm-workspace.yaml` or project `.npmrc` cannot redirect the token to a different host. `_auth` is honored **only** from the env var and the global config — it is ignored in a project `pnpm-workspace.yaml` / `.npmrc`, so repo-controlled config can never supply registry auth. Precedence: CLI flags (`--registry`, `--@scope:registry`) > `pnpm_config__auth` > global `config.yaml` `_auth` > `pnpm-workspace.yaml`.
+
+Both `pnpm_config__auth` (lowercase, documented form) and `PNPM_CONFIG__AUTH` (all-caps, the shell convention some CI runners apply) are honored. If both are set, lowercase wins unless it is empty, in which case uppercase is used. The env var wins over the global `config.yaml` `_auth` on a conflicting key. `tokenHelper` is not supported in `_auth`. Malformed values warn and the install continues.
+
+**Pacquet parity note:** the pacquet (Rust) port supports the same single credential field as the TS CLI: `authToken`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3675,6 +3675,7 @@ dependencies = [
  "smart-default",
  "tempfile",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3676,6 +3676,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/pacquet/crates/cli/src/config_overrides.rs
+++ b/pacquet/crates/cli/src/config_overrides.rs
@@ -60,9 +60,16 @@ impl ConfigOverrides {
     pub fn apply(&self, config: &mut Config) {
         if let Some(registry) = &self.registry {
             config.registry.clone_from(registry);
+            config.registries.insert("default".to_string(), registry.clone());
+            config.package_manager_bootstrap.registry.clone_from(registry);
+            config
+                .package_manager_bootstrap
+                .registries
+                .insert("default".to_string(), registry.clone());
         }
         for (scope, registry) in &self.registries {
             config.registries.insert(scope.clone(), registry.clone());
+            config.package_manager_bootstrap.registries.insert(scope.clone(), registry.clone());
         }
     }
 }

--- a/pacquet/crates/cli/src/config_overrides/tests.rs
+++ b/pacquet/crates/cli/src/config_overrides/tests.rs
@@ -19,6 +19,12 @@ fn extract_separates_config_tokens_from_argv() {
     let mut config = Config::default();
     overrides.apply(&mut config);
     assert_eq!(config.registry, "https://example.test/");
+    assert_eq!(config.package_manager_bootstrap.registry, "https://example.test/");
+    assert_eq!(config.registries.get("default").map(String::as_str), Some("https://example.test/"));
+    assert_eq!(
+        config.package_manager_bootstrap.registries.get("default").map(String::as_str),
+        Some("https://example.test/"),
+    );
 }
 
 #[test]
@@ -35,6 +41,10 @@ fn extract_applies_scoped_registry_overrides() {
         config.registries.get("@private").map(String::as_str),
         Some("https://private.example/npm/"),
     );
+    assert_eq!(
+        config.package_manager_bootstrap.registries.get("@private").map(String::as_str),
+        Some("https://private.example/npm/"),
+    );
 }
 
 #[test]
@@ -43,9 +53,17 @@ fn scoped_registry_override_wins_over_existing_config() {
         ConfigOverrides::extract(argv(["--config.@private:registry=https://cli.example/npm/"]));
     let mut config = Config::default();
     config.registries.insert("@private".to_string(), "https://workspace.example/npm/".to_string());
+    config
+        .package_manager_bootstrap
+        .registries
+        .insert("@private".to_string(), "https://json-env.example/npm/".to_string());
     overrides.apply(&mut config);
     assert_eq!(
         config.registries.get("@private").map(String::as_str),
+        Some("https://cli.example/npm/"),
+    );
+    assert_eq!(
+        config.package_manager_bootstrap.registries.get("@private").map(String::as_str),
         Some("https://cli.example/npm/"),
     );
 }
@@ -77,6 +95,7 @@ fn last_value_wins_for_repeated_keys() {
     let mut config = Config::default();
     overrides.apply(&mut config);
     assert_eq!(config.registry, "https://second.test/");
+    assert_eq!(config.package_manager_bootstrap.registry, "https://second.test/");
 }
 
 #[test]

--- a/pacquet/crates/config/Cargo.toml
+++ b/pacquet/crates/config/Cargo.toml
@@ -39,8 +39,9 @@ libc = { workspace = true }
 [dev-dependencies]
 pacquet-testing-utils = { workspace = true }
 
-pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
+pretty_assertions  = { workspace = true }
+tempfile           = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true

--- a/pacquet/crates/config/Cargo.toml
+++ b/pacquet/crates/config/Cargo.toml
@@ -32,6 +32,7 @@ serde-saphyr  = { workspace = true }
 serde_json    = { workspace = true }
 smart-default = { workspace = true }
 tracing       = { workspace = true }
+url           = { workspace = true }
 
 [target.'cfg(all(unix, not(target_os = "cygwin")))'.dependencies]
 libc = { workspace = true }

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -9,6 +9,7 @@ mod workspace_yaml;
 
 pub use crate::api::{EnvVar, EnvVarOs, GetCurrentDir, GetHomeDir, Host, LinkProbe};
 
+use crate::npmrc_auth::NpmrcAuth;
 use indexmap::IndexMap;
 use pacquet_patching::{
     CalcPatchHashError, PatchGroupRecord, ResolvePatchedDependenciesError, calc_patch_hashes,
@@ -1836,15 +1837,14 @@ impl Config {
         // project `.npmrc` > `auth.ini` > user-level `.npmrc`. Each is
         // parsed and rescoped independently before being folded together.
         let parse_trusted_source = |text: String, dir: PathBuf, label: &str| {
-            let mut auth = crate::npmrc_auth::NpmrcAuth::from_ini::<Sys>(&text, &dir);
+            let mut auth = NpmrcAuth::from_ini::<Sys>(&text, &dir);
             auth.rescope_unscoped(label);
             auth
         };
         let project_npmrc_dir =
             workspace_yaml.as_ref().map_or(start_dir, |(base_dir, _)| base_dir.as_path());
         let project_source = read_npmrc(project_npmrc_dir).map(|text| {
-            let mut auth =
-                crate::npmrc_auth::NpmrcAuth::from_project_ini::<Sys>(&text, project_npmrc_dir);
+            let mut auth = NpmrcAuth::from_project_ini::<Sys>(&text, project_npmrc_dir);
             auth.rescope_unscoped("<project>/.npmrc");
             auth
         });
@@ -1873,20 +1873,21 @@ impl Config {
         // `.npmrc` — mirroring the env-over-workspace ordering in pnpm's
         // [`loadNpmrcFiles.ts`](https://github.com/pnpm/pnpm/blob/main/config/reader/src/loadNpmrcFiles.ts).
         let env_scoped_source = {
-            let auth = crate::npmrc_auth::NpmrcAuth::from_url_scoped_env::<Sys>();
+            let auth = NpmrcAuth::from_url_scoped_env::<Sys>();
             (!auth.creds_by_scope_by_uri.is_empty()).then_some(auth)
         };
 
         // Structured `_auth` registry auth from its two trusted sources:
         // the `pnpm_config__auth` env var and the global `config.yaml`'s
         // `_auth` key (env wins on conflict). See `from_json_sources`.
-        let json_auth = crate::npmrc_auth::NpmrcAuth::from_json_sources::<Sys>(
-            global_settings.as_ref().and_then(|settings| settings.auth.as_ref()),
-        );
-        let env_json_source = (!json_auth.creds_by_scope_by_uri.is_empty()
-            || !json_auth.json_env_registries.is_empty()
-            || !json_auth.warnings.is_empty())
-        .then_some(json_auth);
+        let json_auth = global_settings
+            .as_ref()
+            .and_then(|settings| settings.auth.as_ref())
+            .pipe(NpmrcAuth::from_json_sources::<Sys>)
+            .map_err(|source| LoadWorkspaceYamlError::InvalidJsonAuth { source })?;
+        let json_auth_has_content = !json_auth.creds_by_scope_by_uri.is_empty()
+            || !json_auth.json_env_registries.is_empty();
+        let env_json_source = json_auth_has_content.then_some(json_auth);
 
         // Capture the trusted sources (everything but `project_source`) for
         // [`PackageManagerBootstrap`] before the fold below consumes them.
@@ -2132,7 +2133,7 @@ impl Config {
 /// full config uses so the bootstrap cascade matches the project cascade
 /// minus the repository-controlled sources.
 fn build_package_manager_bootstrap<Sys: EnvVar>(
-    mut trusted_auth: crate::npmrc_auth::NpmrcAuth,
+    mut trusted_auth: NpmrcAuth,
 ) -> PackageManagerBootstrap {
     // The full-config fold already surfaced these sources' `${VAR}` warnings;
     // drop the duplicates this second pass would log.

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1877,16 +1877,37 @@ impl Config {
             (!auth.creds_by_scope_by_uri.is_empty()).then_some(auth)
         };
 
+        // Structured `_auth` registry auth from its two trusted sources:
+        // the `pnpm_config__auth` env var and the global `config.yaml`'s
+        // `_auth` key (env wins on conflict). See `from_json_sources`.
+        let json_auth = crate::npmrc_auth::NpmrcAuth::from_json_sources::<Sys>(
+            global_settings.as_ref().and_then(|settings| settings.auth.as_ref()),
+        );
+        let env_json_source = (!json_auth.creds_by_scope_by_uri.is_empty()
+            || !json_auth.json_env_registries.is_empty()
+            || !json_auth.warnings.is_empty())
+        .then_some(json_auth);
+
         // Capture the trusted sources (everything but `project_source`) for
         // [`PackageManagerBootstrap`] before the fold below consumes them.
-        let trusted_sources =
-            [env_scoped_source.clone(), auth_ini_source.clone(), user_source.clone()];
+        let trusted_sources = [
+            env_json_source.clone(),
+            env_scoped_source.clone(),
+            auth_ini_source.clone(),
+            user_source.clone(),
+        ];
 
         // Fold high-priority-first: the first present source is the
         // base, each lower source fills the gaps it left
-        // ([`NpmrcAuth::merge_under`]).
+        // ([`NpmrcAuth::merge_under`]). `env_json_source` is listed before
+        // `env_scoped_source` so the JSON env var wins on the rare occasion
+        // both define the same `//host/:_authToken` key — matches pnpm's
+        // TS merge, where JSON auth is spread after `envScopedConfig` so
+        // later wins.
         let mut sources =
-            [env_scoped_source, project_source, auth_ini_source, user_source].into_iter().flatten();
+            [env_json_source, env_scoped_source, project_source, auth_ini_source, user_source]
+                .into_iter()
+                .flatten();
         let mut npmrc_auth = sources.next().unwrap_or_default();
         for lower in sources {
             npmrc_auth.merge_under(lower);
@@ -2008,6 +2029,12 @@ impl Config {
             }
         }
 
+        // Apply `_auth` routes after workspace yaml (so they win over
+        // repo-controlled registries) but before `PNPM_CONFIG_*` (so an
+        // explicit `pnpm_config_registry` / `--registry` still wins) —
+        // pnpm's "CLI > _auth > yaml" precedence.
+        npmrc_auth.apply_json_env_registries(&mut self);
+
         // Apply `PNPM_CONFIG_*` env vars *after* `pnpm-workspace.yaml`,
         // mirroring pnpm v11's loop at
         // [`config/reader/src/index.ts:471-488`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/index.ts#L471-L488):
@@ -2035,8 +2062,11 @@ impl Config {
         env_settings.apply_to(&mut self, start_dir);
         self.workspace_dir = saved_workspace_dir;
         if let Some(registry) = env_registry_override {
-            self.package_manager_bootstrap.registry =
+            let normalized =
                 if registry.ends_with('/') { registry } else { format!("{registry}/") };
+            self.registries.insert("default".to_string(), normalized.clone());
+            self.package_manager_bootstrap.registry.clone_from(&normalized);
+            self.package_manager_bootstrap.registries.insert("default".to_string(), normalized);
         }
 
         // Build the per-URI auth-header lookup. Credentials were already
@@ -2109,6 +2139,7 @@ fn build_package_manager_bootstrap<Sys: EnvVar>(
     trusted_auth.warnings.clear();
     let mut config = Config::default();
     trusted_auth.apply_registry_and_warn(&mut config);
+    trusted_auth.apply_json_env_registries(&mut config);
     trusted_auth.apply_proxy_cascade::<Sys>(&mut config);
     trusted_auth.apply_tls_and_local_address(&mut config);
     trusted_auth.build_auth_headers(&mut config);

--- a/pacquet/crates/config/src/npmrc_auth.rs
+++ b/pacquet/crates/config/src/npmrc_auth.rs
@@ -1,4 +1,5 @@
 use crate::{Config, api::EnvVar};
+use indexmap::IndexMap;
 use pacquet_env_replace::env_replace_lossy;
 use pacquet_network::{
     AuthHeaders, DEFAULT_REGISTRY_SCOPE, NoProxySetting, PerRegistryTls, RegistryTls,
@@ -1031,14 +1032,19 @@ fn apply_creds_field(creds: &mut RawCreds, field: &str, value: String) {
 /// Deserialization is strict — any malformed entry (bad JSON, wrong shape,
 /// invalid URL/scope, unsupported credential field) is an error, never a
 /// silent skip. See [`NpmrcAuth::from_json_sources`].
+///
+/// [`IndexMap`] preserves source order so a later entry wins for a
+/// duplicate inferred route (`"@"` / `@scope` across different hosts),
+/// matching pnpm's `Object.entries` iteration — a `BTreeMap` would re-sort
+/// and could pick a different host.
 #[derive(Debug, serde::Deserialize)]
-struct JsonAuth(BTreeMap<JsonAuthRegistry, BTreeMap<JsonAuthScope, JsonAuthCreds>>);
+struct JsonAuth(IndexMap<JsonAuthRegistry, IndexMap<JsonAuthScope, JsonAuthCreds>>);
 
 /// A registry URL `_auth` key. Validated to be an http(s) URL with no
 /// userinfo, query, or fragment (those can carry secrets), then stored
 /// normalized (trailing slash) and nerf-darted for the credential key.
 /// Parsed with the `url` crate, matching the TS side's `new URL()`.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Deserialize)]
 #[serde(try_from = "String")]
 struct JsonAuthRegistry {
     normalized: String,
@@ -1085,7 +1091,7 @@ impl TryFrom<String> for JsonAuthRegistry {
 
 /// A scope key within a registry: `@` for registry-wide/default credentials,
 /// or a package scope like `@org`.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Deserialize)]
 #[serde(try_from = "String")]
 enum JsonAuthScope {
     Default,

--- a/pacquet/crates/config/src/npmrc_auth.rs
+++ b/pacquet/crates/config/src/npmrc_auth.rs
@@ -1,7 +1,8 @@
 use crate::{Config, api::EnvVar};
 use pacquet_env_replace::env_replace_lossy;
 use pacquet_network::{
-    AuthHeaders, DEFAULT_REGISTRY_SCOPE, NoProxySetting, PerRegistryTls, RegistryTls, base64_encode,
+    AuthHeaders, DEFAULT_REGISTRY_SCOPE, NoProxySetting, PerRegistryTls, RegistryTls,
+    base64_encode, nerf_dart,
 };
 use std::{
     collections::{BTreeMap, HashMap},
@@ -108,6 +109,12 @@ pub(crate) struct NpmrcAuth {
     /// pnpm's
     /// [`configByUri[<uri>].tls`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/getNetworkConfigs.ts#L34-L40).
     pub tls_by_uri: HashMap<String, RegistryTls>,
+    /// Scope→URL registry routes inferred from `_auth` (`"@"` → `"default"`,
+    /// `"@org"` → that scope). Safe because the credential and its
+    /// destination host come from the same trusted value, so repo config
+    /// can't redirect the token elsewhere. Applied after workspace yaml by
+    /// [`Self::apply_json_env_registries`].
+    pub json_env_registries: BTreeMap<String, String>,
 }
 
 /// Raw (unparsed) credential fields for a given registry URI, mirroring
@@ -205,6 +212,108 @@ impl NpmrcAuth {
             }
         }
         auth
+    }
+
+    /// Parse the structured `_auth` setting from its two trusted, non-repo
+    /// sources — the global pnpm `config.yaml` (`global_value`) and the
+    /// `pnpm_config__auth` env var — global-first then env, so the env var
+    /// wins on conflict. Mirrors pnpm's `readJsonAuthEnv` +
+    /// `readGlobalConfigAuth`.
+    ///
+    /// The env var exists because GitHub Actions / bash / zsh drop env var
+    /// names containing `/`, `:`, or `.`, breaking the
+    /// `pnpm_config_//host/:_authToken=…` form on CI (pnpm/pnpm#12314).
+    /// Values are used as-is — no `${VAR}` re-expansion, which would let
+    /// repo-controlled env vars leak into them.
+    pub fn from_json_sources<Sys: EnvVar>(global_value: Option<&serde_json::Value>) -> Self {
+        let mut auth = NpmrcAuth::default();
+        if let Some(global_value) = global_value {
+            auth.apply_json_object(global_value.clone(), "_auth");
+        }
+        // Lowercase is the documented form; UPPER covers the all-caps shell
+        // convention some CI runners apply.
+        let env_value = Sys::var("pnpm_config__auth")
+            .filter(|value| !value.is_empty())
+            .or_else(|| Sys::var("PNPM_CONFIG__AUTH").filter(|value| !value.is_empty()));
+        if let Some(value) = env_value {
+            match serde_json::from_str::<serde_json::Value>(&value) {
+                Ok(parsed) => auth.apply_json_object(parsed, "pnpm_config__auth"),
+                Err(err) => auth
+                    .warnings
+                    .push(format!("Failed to parse pnpm_config__auth as JSON: {err}. Ignored.")),
+            }
+        }
+        auth
+    }
+
+    /// Parse one URL-keyed `_auth` object into creds plus inferred registry
+    /// routes, appending to `self` (last-write-wins). `source` labels warnings.
+    fn apply_json_object(&mut self, parsed: serde_json::Value, source: &str) {
+        let serde_json::Value::Object(root) = parsed else {
+            self.warnings.push(format!(
+                "{source} must be a JSON object; got {}. Ignored.",
+                json_type_label(&parsed),
+            ));
+            return;
+        };
+
+        for (entry_index, (url, scopes)) in root.into_iter().enumerate() {
+            let label = json_auth_entry_label(&url, entry_index + 1);
+            let serde_json::Value::Object(scopes) = scopes else {
+                self.warnings.push(format!(
+                    "{source}[{label}] ignored: value must be an object keyed by scope.",
+                ));
+                continue;
+            };
+            if !is_valid_json_auth_registry_url(&url) {
+                self.warnings.push(format!(
+                    "{source}[{label}] ignored: key must be an http(s) registry URL.",
+                ));
+                continue;
+            }
+            if json_auth_url_has_credentials_or_extras(&url) {
+                self.warnings.push(format!(
+                    "{source}[{label}] ignored: registry URL must not include credentials, query, or fragment.",
+                ));
+                continue;
+            }
+            let normalized = normalize_registry_url(&url);
+            let nerfed = nerf_dart(&normalized);
+            if nerfed.is_empty() {
+                self.warnings.push(format!(
+                    "{source}[{label}] ignored: key must be an http(s) registry URL.",
+                ));
+                continue;
+            }
+            for (scope, creds) in scopes {
+                if !is_json_auth_scope(&scope) {
+                    self.warnings.push(format!(
+                        "{source}[{label}][{scope:?}] ignored: scope must be \"@\" or a package scope like \"@org\".",
+                    ));
+                    continue;
+                }
+                let serde_json::Value::Object(creds) = creds else {
+                    self.warnings.push(format!(
+                        "{source}[{label}][{scope:?}] ignored: value must be an auth object.",
+                    ));
+                    continue;
+                };
+                let accepted_creds =
+                    apply_json_auth_creds(self, &nerfed, &label, &scope, creds, source);
+                if !accepted_creds {
+                    continue;
+                }
+                // Infer a registry route from the same entry (see
+                // `json_env_registries`). Last write wins on a duplicate
+                // scope, matching yaml/CLI.
+                let route_key = if scope == DEFAULT_REGISTRY_SCOPE {
+                    "default".to_string()
+                } else {
+                    scope.clone()
+                };
+                self.json_env_registries.insert(route_key, normalized.clone());
+            }
+        }
     }
 
     /// Parse an `.npmrc` file's contents and pick out the auth/network keys.
@@ -499,6 +608,19 @@ impl NpmrcAuth {
         }
     }
 
+    /// Apply the [`Self::json_env_registries`] routes. Unlike
+    /// [`Self::apply_registry_and_warn`] (which runs *before* workspace
+    /// yaml), this is called *after* yaml so the inferred routes win over
+    /// repo-controlled registries.
+    pub fn apply_json_env_registries(&mut self, config: &mut Config) {
+        for (scope, url) in std::mem::take(&mut self.json_env_registries) {
+            if scope == "default" {
+                config.registry.clone_from(&url);
+            }
+            config.registries.insert(scope, url);
+        }
+    }
+
     /// Phase 2: compute and store the final [`AuthHeaders`] map,
     /// keying default-registry creds at `config.registry`'s nerf-darted
     /// URI. Mirrors pnpm's
@@ -633,6 +755,9 @@ impl NpmrcAuth {
         self.registry = self.registry.take().or(lower.registry);
         for (scope, registry) in lower.scoped_registries {
             self.scoped_registries.entry(scope).or_insert(registry);
+        }
+        for (scope, registry) in lower.json_env_registries {
+            self.json_env_registries.entry(scope).or_insert(registry);
         }
         self.https_proxy = self.https_proxy.take().or(lower.https_proxy);
         self.http_proxy = self.http_proxy.take().or(lower.http_proxy);
@@ -941,6 +1066,119 @@ fn apply_creds_field(creds: &mut RawCreds, field: &str, value: String) {
         "username" => creds.username = Some(value),
         "_password" => creds.password = Some(value),
         _ => {}
+    }
+}
+
+fn is_json_auth_scope(scope: &str) -> bool {
+    scope == DEFAULT_REGISTRY_SCOPE || is_package_scope(scope)
+}
+
+fn is_valid_json_auth_registry_url(url: &str) -> bool {
+    let Some((scheme, rest)) = url.split_once("://") else {
+        return false;
+    };
+    // Schemes are case-insensitive (`new URL()` on the TS side accepts
+    // `HTTPS://...`), so compare without regard to case.
+    if !scheme.eq_ignore_ascii_case("https") && !scheme.eq_ignore_ascii_case("http") {
+        return false;
+    }
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+    let host_port = authority.rsplit_once('@').map_or(authority, |(_, host_port)| host_port);
+    let host = match host_port.rsplit_once(':') {
+        Some((host, _)) if !host.contains('[') => host,
+        _ => host_port,
+    };
+    !host.is_empty()
+}
+
+/// Detect secret-bearing parts (`user:pw@`, `?token=`, `#frag`) in a
+/// registry URL key, which get a distinct rejection warning. The host is
+/// validated separately by [`is_valid_json_auth_registry_url`].
+fn json_auth_url_has_credentials_or_extras(url: &str) -> bool {
+    let Some((_, rest)) = url.split_once("://") else {
+        return false;
+    };
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+    if let Some((userinfo, _)) = authority.rsplit_once('@')
+        && !userinfo.is_empty()
+    {
+        return true;
+    }
+    rest.contains('?') || rest.contains('#')
+}
+
+/// A warning-safe label for an `_auth` entry: `scheme://host[:port]` for
+/// valid http(s) URLs (never userinfo/query/fragment, which may hold
+/// secrets), else `entry N` (1-based source order).
+fn json_auth_entry_label(url: &str, entry_number: usize) -> String {
+    let entry_label = format!("entry {entry_number}");
+    let Some((scheme, rest)) = url.split_once("://") else {
+        return entry_label;
+    };
+    if !scheme.eq_ignore_ascii_case("https") && !scheme.eq_ignore_ascii_case("http") {
+        return entry_label;
+    }
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+    let host_port = authority.rsplit_once('@').map_or(authority, |(_, host_port)| host_port);
+    let host = match host_port.rsplit_once(':') {
+        Some((host, _)) if !host.contains('[') => host,
+        _ => host_port,
+    };
+    if host.is_empty() {
+        return entry_label;
+    }
+    format!("{entry_label} ({scheme}://{host_port})")
+}
+
+fn apply_json_auth_creds(
+    auth: &mut NpmrcAuth,
+    nerfed: &str,
+    label: &str,
+    scope: &str,
+    creds: serde_json::Map<String, serde_json::Value>,
+    source: &str,
+) -> bool {
+    let key_prefix = if scope == DEFAULT_REGISTRY_SCOPE {
+        format!("{nerfed}:")
+    } else {
+        format!("{nerfed}:{scope}:")
+    };
+    let mut accepted = false;
+    for (field, value) in creds {
+        // Only `authToken` is supported. The other npm credential forms
+        // (`_auth`, username + `_password`) are deprecated, so this new
+        // setting deliberately does not introduce them.
+        if field != "authToken" {
+            auth.warnings.push(format!(
+                "{source}[{label}][{scope:?}][{field:?}] ignored: unsupported auth field (only \"authToken\" is supported).",
+            ));
+            continue;
+        }
+        let serde_json::Value::String(value) = value else {
+            auth.warnings.push(format!(
+                "{source}[{label}][{scope:?}][{field:?}] ignored: value must be a string.",
+            ));
+            continue;
+        };
+        let key = format!("{key_prefix}_authToken");
+        if let Some((uri, suffix)) = split_creds_key(&key) {
+            let entry = auth.creds_entry_mut(uri);
+            apply_creds_field(entry, suffix, value);
+            accepted = true;
+        }
+    }
+    accepted
+}
+
+/// A short type name for a JSON value, used in "must be an object" warnings.
+fn json_type_label(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
     }
 }
 

--- a/pacquet/crates/config/src/npmrc_auth.rs
+++ b/pacquet/crates/config/src/npmrc_auth.rs
@@ -220,15 +220,22 @@ impl NpmrcAuth {
     /// wins on conflict. Mirrors pnpm's `readJsonAuthEnv` +
     /// `readGlobalConfigAuth`.
     ///
+    /// Parsing is strict: a malformed value (bad JSON, wrong shape, invalid
+    /// registry URL or scope, an unsupported credential field) is a hard
+    /// error, not a warning — both sources are user-controlled, so a typo
+    /// should surface immediately rather than silently drop auth.
+    ///
     /// The env var exists because GitHub Actions / bash / zsh drop env var
     /// names containing `/`, `:`, or `.`, breaking the
     /// `pnpm_config_//host/:_authToken=…` form on CI (pnpm/pnpm#12314).
     /// Values are used as-is — no `${VAR}` re-expansion, which would let
     /// repo-controlled env vars leak into them.
-    pub fn from_json_sources<Sys: EnvVar>(global_value: Option<&serde_json::Value>) -> Self {
+    pub fn from_json_sources<Sys: EnvVar>(
+        global_value: Option<&serde_json::Value>,
+    ) -> Result<Self, serde_json::Error> {
         let mut auth = NpmrcAuth::default();
         if let Some(global_value) = global_value {
-            auth.apply_json_object(global_value.clone(), "_auth");
+            auth.apply_json_auth(serde_json::from_value(global_value.clone())?);
         }
         // Lowercase is the documented form; UPPER covers the all-caps shell
         // convention some CI runners apply.
@@ -236,82 +243,33 @@ impl NpmrcAuth {
             .filter(|value| !value.is_empty())
             .or_else(|| Sys::var("PNPM_CONFIG__AUTH").filter(|value| !value.is_empty()));
         if let Some(value) = env_value {
-            match serde_json::from_str::<serde_json::Value>(&value) {
-                Ok(parsed) => auth.apply_json_object(parsed, "pnpm_config__auth"),
-                Err(err) => auth
-                    .warnings
-                    .push(format!("Failed to parse pnpm_config__auth as JSON: {err}. Ignored.")),
-            }
+            auth.apply_json_auth(serde_json::from_str(&value)?);
         }
-        auth
+        Ok(auth)
     }
 
-    /// Parse one URL-keyed `_auth` object into creds plus inferred registry
-    /// routes, appending to `self` (last-write-wins). `source` labels warnings.
-    fn apply_json_object(&mut self, parsed: serde_json::Value, source: &str) {
-        let serde_json::Value::Object(root) = parsed else {
-            self.warnings.push(format!(
-                "{source} must be a JSON object; got {}. Ignored.",
-                json_type_label(&parsed),
-            ));
-            return;
-        };
-
-        for (entry_index, (url, scopes)) in root.into_iter().enumerate() {
-            let label = json_auth_entry_label(&url, entry_index + 1);
-            let serde_json::Value::Object(scopes) = scopes else {
-                self.warnings.push(format!(
-                    "{source}[{label}] ignored: value must be an object keyed by scope.",
-                ));
-                continue;
-            };
-            if !is_valid_json_auth_registry_url(&url) {
-                self.warnings.push(format!(
-                    "{source}[{label}] ignored: key must be an http(s) registry URL.",
-                ));
-                continue;
-            }
-            if json_auth_url_has_credentials_or_extras(&url) {
-                self.warnings.push(format!(
-                    "{source}[{label}] ignored: registry URL must not include credentials, query, or fragment.",
-                ));
-                continue;
-            }
-            let normalized = normalize_registry_url(&url);
-            let nerfed = nerf_dart(&normalized);
-            if nerfed.is_empty() {
-                self.warnings.push(format!(
-                    "{source}[{label}] ignored: key must be an http(s) registry URL.",
-                ));
-                continue;
-            }
+    /// Fold a parsed [`JsonAuth`] into `self` (last-write-wins, so the env
+    /// object applied after the global one overrides on conflict): each
+    /// entry becomes a `//host/:_authToken` credential and an inferred
+    /// registry route (see [`Self::json_env_registries`]).
+    fn apply_json_auth(&mut self, parsed: JsonAuth) {
+        for (registry, scopes) in parsed.0 {
             for (scope, creds) in scopes {
-                if !is_json_auth_scope(&scope) {
-                    self.warnings.push(format!(
-                        "{source}[{label}][{scope:?}] ignored: scope must be \"@\" or a package scope like \"@org\".",
-                    ));
-                    continue;
-                }
-                let serde_json::Value::Object(creds) = creds else {
-                    self.warnings.push(format!(
-                        "{source}[{label}][{scope:?}] ignored: value must be an auth object.",
-                    ));
-                    continue;
+                let key = match &scope {
+                    JsonAuthScope::Default => format!("{}:_authToken", registry.nerfed),
+                    JsonAuthScope::Package(scope) => {
+                        format!("{}:{scope}:_authToken", registry.nerfed)
+                    }
                 };
-                let accepted_creds =
-                    apply_json_auth_creds(self, &nerfed, &label, &scope, creds, source);
-                if !accepted_creds {
-                    continue;
+                if let Some((uri, suffix)) = split_creds_key(&key) {
+                    let entry = self.creds_entry_mut(uri);
+                    apply_creds_field(entry, suffix, creds.auth_token);
                 }
-                // Infer a registry route from the same entry (see
-                // `json_env_registries`). Last write wins on a duplicate
-                // scope, matching yaml/CLI.
-                let route_key = if scope == DEFAULT_REGISTRY_SCOPE {
-                    "default".to_string()
-                } else {
-                    scope.clone()
+                let route_key = match scope {
+                    JsonAuthScope::Default => "default".to_string(),
+                    JsonAuthScope::Package(scope) => scope,
                 };
-                self.json_env_registries.insert(route_key, normalized.clone());
+                self.json_env_registries.insert(route_key, registry.normalized.clone());
             }
         }
     }
@@ -1069,117 +1027,93 @@ fn apply_creds_field(creds: &mut RawCreds, field: &str, value: String) {
     }
 }
 
-fn is_json_auth_scope(scope: &str) -> bool {
-    scope == DEFAULT_REGISTRY_SCOPE || is_package_scope(scope)
+/// The parsed `_auth` setting: registry URL → scope → credentials.
+/// Deserialization is strict — any malformed entry (bad JSON, wrong shape,
+/// invalid URL/scope, unsupported credential field) is an error, never a
+/// silent skip. See [`NpmrcAuth::from_json_sources`].
+#[derive(Debug, serde::Deserialize)]
+struct JsonAuth(BTreeMap<JsonAuthRegistry, BTreeMap<JsonAuthScope, JsonAuthCreds>>);
+
+/// A registry URL `_auth` key. Validated to be an http(s) URL with no
+/// userinfo, query, or fragment (those can carry secrets), then stored
+/// normalized (trailing slash) and nerf-darted for the credential key.
+/// Parsed with the `url` crate, matching the TS side's `new URL()`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize)]
+#[serde(try_from = "String")]
+struct JsonAuthRegistry {
+    normalized: String,
+    nerfed: String,
 }
 
-fn is_valid_json_auth_registry_url(url: &str) -> bool {
-    let Some((scheme, rest)) = url.split_once("://") else {
-        return false;
-    };
-    // Schemes are case-insensitive (`new URL()` on the TS side accepts
-    // `HTTPS://...`), so compare without regard to case.
-    if !scheme.eq_ignore_ascii_case("https") && !scheme.eq_ignore_ascii_case("http") {
-        return false;
-    }
-    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
-    let host_port = authority.rsplit_once('@').map_or(authority, |(_, host_port)| host_port);
-    let host = match host_port.rsplit_once(':') {
-        Some((host, _)) if !host.contains('[') => host,
-        _ => host_port,
-    };
-    !host.is_empty()
-}
+impl TryFrom<String> for JsonAuthRegistry {
+    type Error = String;
 
-/// Detect secret-bearing parts (`user:pw@`, `?token=`, `#frag`) in a
-/// registry URL key, which get a distinct rejection warning. The host is
-/// validated separately by [`is_valid_json_auth_registry_url`].
-fn json_auth_url_has_credentials_or_extras(url: &str) -> bool {
-    let Some((_, rest)) = url.split_once("://") else {
-        return false;
-    };
-    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
-    if let Some((userinfo, _)) = authority.rsplit_once('@')
-        && !userinfo.is_empty()
-    {
-        return true;
-    }
-    rest.contains('?') || rest.contains('#')
-}
-
-/// A warning-safe label for an `_auth` entry: `scheme://host[:port]` for
-/// valid http(s) URLs (never userinfo/query/fragment, which may hold
-/// secrets), else `entry N` (1-based source order).
-fn json_auth_entry_label(url: &str, entry_number: usize) -> String {
-    let entry_label = format!("entry {entry_number}");
-    let Some((scheme, rest)) = url.split_once("://") else {
-        return entry_label;
-    };
-    if !scheme.eq_ignore_ascii_case("https") && !scheme.eq_ignore_ascii_case("http") {
-        return entry_label;
-    }
-    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
-    let host_port = authority.rsplit_once('@').map_or(authority, |(_, host_port)| host_port);
-    let host = match host_port.rsplit_once(':') {
-        Some((host, _)) if !host.contains('[') => host,
-        _ => host_port,
-    };
-    if host.is_empty() {
-        return entry_label;
-    }
-    format!("{entry_label} ({scheme}://{host_port})")
-}
-
-fn apply_json_auth_creds(
-    auth: &mut NpmrcAuth,
-    nerfed: &str,
-    label: &str,
-    scope: &str,
-    creds: serde_json::Map<String, serde_json::Value>,
-    source: &str,
-) -> bool {
-    let key_prefix = if scope == DEFAULT_REGISTRY_SCOPE {
-        format!("{nerfed}:")
-    } else {
-        format!("{nerfed}:{scope}:")
-    };
-    let mut accepted = false;
-    for (field, value) in creds {
-        // Only `authToken` is supported. The other npm credential forms
-        // (`_auth`, username + `_password`) are deprecated, so this new
-        // setting deliberately does not introduce them.
-        if field != "authToken" {
-            auth.warnings.push(format!(
-                "{source}[{label}][{scope:?}][{field:?}] ignored: unsupported auth field (only \"authToken\" is supported).",
-            ));
-            continue;
-        }
-        let serde_json::Value::String(value) = value else {
-            auth.warnings.push(format!(
-                "{source}[{label}][{scope:?}][{field:?}] ignored: value must be a string.",
-            ));
-            continue;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        // Error messages never echo the raw key: it can embed secrets in
+        // userinfo or a query string, and these messages reach logs.
+        let Ok(url) = url::Url::parse(&value) else {
+            return Err("an `_auth` key is not a valid http(s) registry URL".to_string());
         };
-        let key = format!("{key_prefix}_authToken");
-        if let Some((uri, suffix)) = split_creds_key(&key) {
-            let entry = auth.creds_entry_mut(uri);
-            apply_creds_field(entry, suffix, value);
-            accepted = true;
+        if url.scheme() != "http" && url.scheme() != "https" {
+            return Err("an `_auth` registry URL must use http or https".to_string());
         }
+        let Some(host) = url.host_str() else {
+            return Err("an `_auth` registry URL must have a host".to_string());
+        };
+        // A credential-free label for the remaining messages.
+        let label = match url.port() {
+            Some(port) => format!("{}://{host}:{port}", url.scheme()),
+            None => format!("{}://{host}", url.scheme()),
+        };
+        if !url.username().is_empty()
+            || url.password().is_some()
+            || url.query().is_some()
+            || url.fragment().is_some()
+        {
+            return Err(format!(
+                "registry URL {label} must not include credentials, a query, or a fragment",
+            ));
+        }
+        let normalized = normalize_registry_url(url.as_str());
+        let nerfed = nerf_dart(&normalized);
+        if nerfed.is_empty() {
+            return Err(format!("registry URL {label} is not a valid registry URL"));
+        }
+        Ok(JsonAuthRegistry { normalized, nerfed })
     }
-    accepted
 }
 
-/// A short type name for a JSON value, used in "must be an object" warnings.
-fn json_type_label(value: &serde_json::Value) -> &'static str {
-    match value {
-        serde_json::Value::Null => "null",
-        serde_json::Value::Bool(_) => "boolean",
-        serde_json::Value::Number(_) => "number",
-        serde_json::Value::String(_) => "string",
-        serde_json::Value::Array(_) => "array",
-        serde_json::Value::Object(_) => "object",
+/// A scope key within a registry: `@` for registry-wide/default credentials,
+/// or a package scope like `@org`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize)]
+#[serde(try_from = "String")]
+enum JsonAuthScope {
+    Default,
+    Package(String),
+}
+
+impl TryFrom<String> for JsonAuthScope {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if value == DEFAULT_REGISTRY_SCOPE {
+            return Ok(JsonAuthScope::Default);
+        }
+        if is_package_scope(&value) {
+            return Ok(JsonAuthScope::Package(value));
+        }
+        Err(format!("scope \"{value}\" must be \"@\" or a package scope like \"@org\""))
     }
+}
+
+/// Credentials for one registry scope. Only `authToken` is accepted; the
+/// deprecated `basicAuth` / `username` + `password` forms are rejected via
+/// `deny_unknown_fields`.
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct JsonAuthCreds {
+    #[serde(rename = "authToken")]
+    auth_token: String,
 }
 
 /// Per-registry TLS suffixes. The `*file` variants instruct the

--- a/pacquet/crates/config/src/npmrc_auth/tests.rs
+++ b/pacquet/crates/config/src/npmrc_auth/tests.rs
@@ -1181,6 +1181,25 @@ fn json_env_rejects_deprecated_basic_auth_field() {
 }
 
 #[test]
+fn json_env_duplicate_route_keeps_last_in_source_order() {
+    // Two hosts both route the default registry; the source-LAST entry wins,
+    // matching pnpm's `Object.entries` iteration. Listed reverse-alphabetically
+    // so a sorted map would pick the wrong host.
+    static_env!(
+        Env,
+        &[(
+            "pnpm_config__auth",
+            r#"{"https://zzz.example":{"@":{"authToken":"z"}},"https://aaa.example":{"@":{"authToken":"a"}}}"#
+        )]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None).expect("valid _auth");
+    assert_eq!(
+        auth.json_env_registries.get("default").map(String::as_str),
+        Some("https://aaa.example/"),
+    );
+}
+
+#[test]
 fn json_env_default_scope_infers_default_registry_route() {
     static_env!(
         Env,

--- a/pacquet/crates/config/src/npmrc_auth/tests.rs
+++ b/pacquet/crates/config/src/npmrc_auth/tests.rs
@@ -1122,3 +1122,508 @@ fn url_scoped_env_ignores_non_ascii_names_without_panicking() {
     let auth = NpmrcAuth::from_url_scoped_env::<Env>();
     assert!(auth.creds_by_scope_by_uri.is_empty());
 }
+
+#[test]
+fn json_env_reads_host_keyed_default_auth_token() {
+    static_env!(
+        Env,
+        &[(
+            "pnpm_config__auth",
+            r#"{"https://registry.npmjs.org":{"@":{"authToken":"json-token"}}}"#
+        )]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert_eq!(default_auth_token(&auth, "//registry.npmjs.org/"), Some(Some("json-token")));
+}
+
+#[test]
+fn json_env_accepts_uppercase_scheme() {
+    // URL schemes are case-insensitive; the TS side parses keys with
+    // `new URL()`, which accepts `HTTPS://...`. pacquet must too.
+    static_env!(
+        Env,
+        &[(
+            "pnpm_config__auth",
+            r#"{"HTTPS://registry.npmjs.org":{"@":{"authToken":"upper-scheme-token"}}}"#
+        )]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert_eq!(
+        default_auth_token(&auth, "//registry.npmjs.org/"),
+        Some(Some("upper-scheme-token")),
+    );
+}
+
+#[test]
+fn json_env_reads_scoped_auth_tokens_on_shared_host() {
+    static_env!(
+        Env,
+        &[(
+            "pnpm_config__auth",
+            r#"{"https://npm.pkg.github.com":{"@org-a":{"authToken":"a-tok"},"@org-b":{"authToken":"b-tok"}}}"#
+        )]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert_eq!(scoped_auth_token(&auth, "//npm.pkg.github.com/", "@org-a"), Some(Some("a-tok")));
+    assert_eq!(scoped_auth_token(&auth, "//npm.pkg.github.com/", "@org-b"), Some(Some("b-tok")));
+}
+
+#[test]
+fn json_env_rejects_deprecated_basic_auth_and_username_password_fields() {
+    // Only `authToken` is supported; the deprecated `basicAuth` /
+    // `username` + `password` forms are dropped with a warning and never
+    // produce an auth header.
+    struct EnvDeprecated;
+    impl EnvVar for EnvDeprecated {
+        fn var(name: &str) -> Option<String> {
+            (name == "pnpm_config__auth").then(|| {
+                let pair = base64_encode("alice:secret");
+                let password_b64 = base64_encode("p@ss");
+                format!(
+                    r#"{{"https://reg.example":{{"@":{{"basicAuth":"{pair}","username":"alice","password":"{password_b64}"}}}}}}"#,
+                )
+            })
+        }
+    }
+    let auth = NpmrcAuth::from_json_sources::<EnvDeprecated>(None);
+    for field in ["basicAuth", "username", "password"] {
+        assert!(
+            auth.warnings.iter().any(|warning| warning.contains(field)
+                && warning.contains(r#"only "authToken" is supported"#)),
+            "expected an unsupported-field warning for {field:?}, got: {:?}",
+            auth.warnings,
+        );
+    }
+    let mut config = Config::new();
+    auth.apply_to::<EnvDeprecated>(&mut config);
+    assert!(config.auth_headers.for_url("https://reg.example/").is_none());
+}
+
+#[test]
+fn json_env_default_scope_infers_default_registry_route() {
+    static_env!(
+        Env,
+        &[("pnpm_config__auth", r#"{"https://my-npm-proxy.example":{"@":{"authToken":"tok"}}}"#)]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert_eq!(
+        auth.json_env_registries.get("default").map(String::as_str),
+        Some("https://my-npm-proxy.example/"),
+    );
+}
+
+#[test]
+fn json_env_package_scope_infers_scoped_registry_route() {
+    static_env!(
+        Env,
+        &[("pnpm_config__auth", r#"{"https://npm.pkg.github.com":{"@org":{"authToken":"tok"}}}"#)]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert_eq!(
+        auth.json_env_registries.get("@org").map(String::as_str),
+        Some("https://npm.pkg.github.com/"),
+    );
+    assert!(!auth.json_env_registries.contains_key("default"));
+}
+
+#[test]
+fn json_env_honors_upper_case_form() {
+    // Both `pnpm_config__auth` (documented) and `PNPM_CONFIG__AUTH` (the
+    // all-caps shell convention) are accepted — mirrors `read_pnpm_env`'s
+    // two-form lookup shape.
+    static_env!(
+        Env,
+        &[(
+            "PNPM_CONFIG__AUTH",
+            r#"{"https://registry.npmjs.org":{"@":{"authToken":"upper-token"}}}"#
+        )]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert_eq!(default_auth_token(&auth, "//registry.npmjs.org/"), Some(Some("upper-token")));
+}
+
+#[test]
+fn json_env_lower_case_wins_over_upper_case_when_both_are_set() {
+    // Both forms are accepted; when both are set, the documented
+    // (lowercase) form wins. Mirrors `read_pnpm_env`'s two-form lookup.
+    static_env!(
+        Env,
+        &[
+            (
+                "pnpm_config__auth",
+                r#"{"https://registry.npmjs.org":{"@":{"authToken":"lower-token"}}}"#
+            ),
+            (
+                "PNPM_CONFIG__AUTH",
+                r#"{"https://registry.npmjs.org":{"@":{"authToken":"upper-token"}}}"#
+            ),
+        ]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert_eq!(default_auth_token(&auth, "//registry.npmjs.org/"), Some(Some("lower-token")));
+}
+
+#[test]
+fn json_env_empty_lowercase_falls_back_to_uppercase() {
+    static_env!(
+        Env,
+        &[
+            ("pnpm_config__auth", ""),
+            (
+                "PNPM_CONFIG__AUTH",
+                r#"{"https://registry.npmjs.org":{"@":{"authToken":"upper-token"}}}"#
+            ),
+        ]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert_eq!(default_auth_token(&auth, "//registry.npmjs.org/"), Some(Some("upper-token")));
+}
+
+#[test]
+fn json_env_warns_when_auth_field_value_is_not_a_string() {
+    static_env!(
+        Env,
+        &[("pnpm_config__auth", r#"{"https://registry.example":{"@":{"authToken":123}}}"#)]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert!(auth.creds_by_scope_by_uri.is_empty());
+    assert!(
+        auth.warnings
+            .iter()
+            .any(|warning| warning.contains("authToken")
+                && warning.contains("value must be a string")),
+        "expected a per-key type warning, got: {:?}",
+        auth.warnings,
+    );
+}
+
+#[test]
+fn json_env_warns_when_host_value_is_not_scope_object() {
+    static_env!(Env, &[("pnpm_config__auth", r#"{"https://registry.example":123}"#)]);
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert!(auth.creds_by_scope_by_uri.is_empty());
+    assert!(
+        auth.warnings.iter().any(|warning| warning.contains("entry 1")
+            && warning.contains("object keyed by scope")),
+        "expected a per-key type warning, got: {:?}",
+        auth.warnings,
+    );
+}
+
+#[test]
+fn json_env_warns_when_host_key_is_not_a_registry_url() {
+    static_env!(Env, &[("pnpm_config__auth", r#"{"not a url":{"@":{"authToken":"tok"}}}"#)]);
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert!(auth.creds_by_scope_by_uri.is_empty());
+    assert!(
+        auth.warnings
+            .iter()
+            .any(|warning| warning.contains("entry 1") && warning.contains("registry URL")),
+        "expected a registry-URL warning, got: {:?}",
+        auth.warnings,
+    );
+    assert!(
+        !auth.warnings.iter().any(|warning| warning.contains("not a url")),
+        "raw key must not leak into warnings: {:?}",
+        auth.warnings,
+    );
+}
+
+#[test]
+fn json_env_warns_when_host_key_has_empty_host() {
+    static_env!(
+        Env,
+        &[(
+            "pnpm_config__auth",
+            r#"{"https://":{"@":{"authToken":"tok"}},"https://:8080":{"@":{"authToken":"tok"}}}"#
+        )]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert!(auth.creds_by_scope_by_uri.is_empty());
+    let entry1_count = auth
+        .warnings
+        .iter()
+        .filter(|warning| warning.contains("entry 1") && warning.contains("registry URL"))
+        .count();
+    let entry2_count = auth
+        .warnings
+        .iter()
+        .filter(|warning| warning.contains("entry 2") && warning.contains("registry URL"))
+        .count();
+    assert_eq!(entry1_count, 1, "expected one entry-1 warning, got: {:?}", auth.warnings);
+    assert_eq!(entry2_count, 1, "expected one entry-2 warning, got: {:?}", auth.warnings);
+    assert!(
+        !auth.warnings.iter().any(|warning| warning.contains("https://")),
+        "raw URL must not leak into warnings: {:?}",
+        auth.warnings,
+    );
+}
+
+#[test]
+fn json_env_warns_when_host_key_has_non_http_scheme() {
+    // A key with a `://` separator parses a scheme, so it skips the
+    // missing-separator branch — but a non-http(s) scheme like `ftp://`
+    // must still be rejected on the scheme check, not accepted as a host.
+    static_env!(
+        Env,
+        &[("pnpm_config__auth", r#"{"ftp://registry.example":{"@":{"authToken":"tok"}}}"#)]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert!(auth.creds_by_scope_by_uri.is_empty());
+    assert!(
+        auth.warnings
+            .iter()
+            .any(|warning| warning.contains("entry 1") && warning.contains("registry URL")),
+        "expected a registry-URL warning, got: {:?}",
+        auth.warnings,
+    );
+    assert!(
+        !auth.warnings.iter().any(|warning| warning.contains("ftp://")),
+        "raw key must not leak into warnings: {:?}",
+        auth.warnings,
+    );
+}
+
+#[test]
+fn json_env_warns_when_scope_name_is_invalid() {
+    static_env!(
+        Env,
+        &[("pnpm_config__auth", r#"{"https://registry.example":{"org":{"authToken":"tok"}}}"#)]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert!(auth.creds_by_scope_by_uri.is_empty());
+    assert!(
+        auth.warnings
+            .iter()
+            .any(|warning| warning.contains("org") && warning.contains("scope must be")),
+        "expected a per-key type warning, got: {:?}",
+        auth.warnings,
+    );
+}
+
+#[test]
+fn json_env_warns_when_scope_value_is_not_auth_object() {
+    static_env!(Env, &[("pnpm_config__auth", r#"{"https://registry.example":{"@":"tok"}}"#)]);
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert!(auth.creds_by_scope_by_uri.is_empty());
+    assert!(
+        auth.warnings.iter().any(|warning| warning.contains("entry 1")
+            && warning.contains("value must be an auth object")),
+        "expected an auth-object warning, got: {:?}",
+        auth.warnings,
+    );
+}
+
+#[test]
+fn json_env_warns_when_auth_field_is_unsupported() {
+    static_env!(
+        Env,
+        &[(
+            "pnpm_config__auth",
+            r#"{"https://registry.example":{"@":{"tokenHelper":"/bin/echo"}}}"#
+        )]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert!(auth.creds_by_scope_by_uri.is_empty());
+    assert!(
+        auth.warnings
+            .iter()
+            .any(|warning| warning.contains("tokenHelper") && warning.contains("unsupported")),
+        "expected an unsupported-field warning, got: {:?}",
+        auth.warnings,
+    );
+    assert!(auth.json_env_registries.is_empty());
+}
+
+#[test]
+fn json_env_warnings_do_not_leak_url_credentials() {
+    // The URL key carries userinfo and a query-string token — both are
+    // common places to embed secrets in registry URLs. No warning should
+    // surface any fragment of the raw key.
+    static_env!(
+        Env,
+        &[(
+            "pnpm_config__auth",
+            r#"{"https://user:pw@registry.example?token=secret":{"@":{"authToken":"tok"}}}"#
+        )]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert!(
+        auth.warnings.iter().any(|warning| warning.contains("entry 1 (https://registry.example)")
+            && warning.contains("credentials, query, or fragment")),
+        "expected a credentials-rejection warning with sanitized label, got: {:?}",
+        auth.warnings,
+    );
+    for leak in &["user:pw", "pw@", "token=secret", "?token"] {
+        assert!(
+            !auth.warnings.iter().any(|warning| warning.contains(leak)),
+            "secret fragment {leak:?} leaked into a warning: {:?}",
+            auth.warnings,
+        );
+    }
+}
+
+#[test]
+fn json_env_rejects_urls_with_credentials_query_or_fragment() {
+    // Mirrors TS `parseJsonAuthRegistry`: URLs with userinfo, query, or
+    // fragment are rejected — no token is applied, no route is inferred.
+    static_env!(
+        Env,
+        &[(
+            "pnpm_config__auth",
+            r#"{"https://user:pw@reg.example":{"@":{"authToken":"tok"}},"https://reg.example?token=secret":{"@":{"authToken":"tok"}},"https://reg.example#frag":{"@":{"authToken":"tok"}}}"#
+        )]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert!(
+        auth.creds_by_scope_by_uri.is_empty(),
+        "no creds should be applied: {:?}",
+        auth.creds_by_scope_by_uri,
+    );
+    assert!(auth.json_env_registries.is_empty(), "no routes should be inferred");
+    let rejection_count = auth
+        .warnings
+        .iter()
+        .filter(|warning| warning.contains("credentials, query, or fragment"))
+        .count();
+    assert_eq!(rejection_count, 3, "expected 3 rejection warnings, got: {:?}", auth.warnings);
+    for leak in &["user:pw", "pw@", "token=secret", "?token", "#frag"] {
+        assert!(
+            !auth.warnings.iter().any(|warning| warning.contains(leak)),
+            "secret fragment {leak:?} leaked: {:?}",
+            auth.warnings,
+        );
+    }
+}
+
+#[test]
+fn json_env_does_not_infer_registry_route_when_no_auth_field_is_accepted() {
+    static_env!(
+        Env,
+        &[(
+            "pnpm_config__auth",
+            r#"{"https://private.example":{"@":{"tokenAuth":"tok"},"@org":{"authToken":123}}}"#
+        )]
+    );
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert!(auth.creds_by_scope_by_uri.is_empty());
+    assert!(auth.json_env_registries.is_empty());
+}
+
+#[test]
+fn json_env_malformed_json_pushes_warning_and_returns_empty() {
+    static_env!(Env, &[("pnpm_config__auth", "{ not valid json")]);
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert!(auth.creds_by_scope_by_uri.is_empty());
+    assert!(
+        auth.warnings.iter().any(|warning| warning.contains("Failed to parse pnpm_config__auth")),
+        "expected a parse-failure warning, got: {:?}",
+        auth.warnings,
+    );
+}
+
+#[test]
+fn json_env_rejects_non_object_top_level_with_warning() {
+    // Arrays expose their indices as keys, so reject them outright.
+    static_env!(Env, &[("pnpm_config__auth", r#"["//registry.example/:_authToken","sneaky"]"#)]);
+    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    assert!(auth.creds_by_scope_by_uri.is_empty());
+    assert!(
+        auth.warnings.iter().any(|warning| warning.contains("must be a JSON object")),
+        "expected a top-level type warning, got: {:?}",
+        auth.warnings,
+    );
+}
+
+#[test]
+fn json_env_empty_or_unset_returns_default() {
+    // Unset: `Sys::var` returns `None` for both forms.
+    struct UnsetEnv;
+    impl EnvVar for UnsetEnv {
+        fn var(_: &str) -> Option<String> {
+            None
+        }
+    }
+    let auth = NpmrcAuth::from_json_sources::<UnsetEnv>(None);
+    assert!(auth.creds_by_scope_by_uri.is_empty());
+    assert!(auth.warnings.is_empty());
+
+    // Set but empty: filtered out by the `.filter(|v| !v.is_empty())` step.
+    static_env!(EnvWithEmptyAuth, &[("pnpm_config__auth", "")]);
+    let auth = NpmrcAuth::from_json_sources::<EnvWithEmptyAuth>(None);
+    assert!(auth.creds_by_scope_by_uri.is_empty());
+    assert!(auth.warnings.is_empty());
+}
+
+#[test]
+fn json_global_value_configures_auth_and_env_wins_on_conflict() {
+    // `_auth` from the global `config.yaml` (the `global_value` argument)
+    // is parsed like the env var; the env var wins on a conflicting host.
+    struct EnvJson;
+    impl EnvVar for EnvJson {
+        fn var(name: &str) -> Option<String> {
+            (name == "pnpm_config__auth").then(|| {
+                r#"{"https://registry.npmjs.org":{"@":{"authToken":"env-token"}}}"#.to_string()
+            })
+        }
+    }
+    let global = serde_json::json!({
+        "https://registry.npmjs.org": { "@": { "authToken": "yaml-token" } },
+        "https://other.example": { "@": { "authToken": "yaml-other" } },
+    });
+    let auth = NpmrcAuth::from_json_sources::<EnvJson>(Some(&global));
+    // Env wins on the conflicting host.
+    assert_eq!(default_auth_token(&auth, "//registry.npmjs.org/"), Some(Some("env-token")));
+    // The global-only host is preserved.
+    assert_eq!(default_auth_token(&auth, "//other.example/"), Some(Some("yaml-other")));
+}
+
+#[test]
+fn json_type_label_names_every_variant() {
+    // Direct exercise of the helper across every serde_json variant —
+    // from_json_sources only reaches it on the non-Object error path, so a
+    // handful of variants (Null/Bool/Number/Object) never get hit through
+    // the integration tests.
+    use super::json_type_label;
+    assert_eq!(json_type_label(&serde_json::Value::Null), "null");
+    assert_eq!(json_type_label(&serde_json::Value::Bool(true)), "boolean");
+    assert_eq!(json_type_label(&serde_json::Value::from(42)), "number");
+    assert_eq!(json_type_label(&serde_json::Value::from("hi")), "string");
+    assert_eq!(json_type_label(&serde_json::Value::Array(vec![serde_json::Value::Null])), "array");
+    assert_eq!(json_type_label(&serde_json::Value::Object(serde_json::Map::new())), "object");
+}
+
+#[test]
+fn json_auth_entry_label_formats() {
+    use super::json_auth_entry_label;
+    // No scheme separator → bare entry label
+    assert_eq!(json_auth_entry_label("not a url", 1), "entry 1");
+    // Non-http scheme → bare entry label
+    assert_eq!(json_auth_entry_label("ftp://host", 2), "entry 2");
+    // http/https with empty host → bare entry label
+    assert_eq!(json_auth_entry_label("https://", 3), "entry 3");
+    assert_eq!(json_auth_entry_label("https://:8080", 4), "entry 4");
+    // Valid URL → entry N (scheme://host)
+    assert_eq!(json_auth_entry_label("https://reg.example", 5), "entry 5 (https://reg.example)");
+    // Port preserved in label
+    assert_eq!(
+        json_auth_entry_label("https://reg.example:8080", 6),
+        "entry 6 (https://reg.example:8080)",
+    );
+    // Userinfo stripped from label
+    assert_eq!(
+        json_auth_entry_label("https://user:pw@reg.example", 7),
+        "entry 7 (https://reg.example)",
+    );
+}
+
+#[test]
+fn json_auth_url_has_credentials_or_extras_truth_table() {
+    use super::json_auth_url_has_credentials_or_extras;
+    assert!(json_auth_url_has_credentials_or_extras("https://user:pw@host"));
+    assert!(json_auth_url_has_credentials_or_extras("https://host?token=x"));
+    assert!(json_auth_url_has_credentials_or_extras("https://host#frag"));
+    assert!(!json_auth_url_has_credentials_or_extras("https://host"));
+    assert!(!json_auth_url_has_credentials_or_extras("https://@host"));
+    assert!(!json_auth_url_has_credentials_or_extras("not a url"));
+}

--- a/pacquet/crates/config/src/npmrc_auth/tests.rs
+++ b/pacquet/crates/config/src/npmrc_auth/tests.rs
@@ -1132,7 +1132,7 @@ fn json_env_reads_host_keyed_default_auth_token() {
             r#"{"https://registry.npmjs.org":{"@":{"authToken":"json-token"}}}"#
         )]
     );
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    let auth = NpmrcAuth::from_json_sources::<Env>(None).expect("valid _auth");
     assert_eq!(default_auth_token(&auth, "//registry.npmjs.org/"), Some(Some("json-token")));
 }
 
@@ -1147,7 +1147,7 @@ fn json_env_accepts_uppercase_scheme() {
             r#"{"HTTPS://registry.npmjs.org":{"@":{"authToken":"upper-scheme-token"}}}"#
         )]
     );
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    let auth = NpmrcAuth::from_json_sources::<Env>(None).expect("valid _auth");
     assert_eq!(
         default_auth_token(&auth, "//registry.npmjs.org/"),
         Some(Some("upper-scheme-token")),
@@ -1163,40 +1163,21 @@ fn json_env_reads_scoped_auth_tokens_on_shared_host() {
             r#"{"https://npm.pkg.github.com":{"@org-a":{"authToken":"a-tok"},"@org-b":{"authToken":"b-tok"}}}"#
         )]
     );
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    let auth = NpmrcAuth::from_json_sources::<Env>(None).expect("valid _auth");
     assert_eq!(scoped_auth_token(&auth, "//npm.pkg.github.com/", "@org-a"), Some(Some("a-tok")));
     assert_eq!(scoped_auth_token(&auth, "//npm.pkg.github.com/", "@org-b"), Some(Some("b-tok")));
 }
 
 #[test]
-fn json_env_rejects_deprecated_basic_auth_and_username_password_fields() {
+fn json_env_rejects_deprecated_basic_auth_field() {
     // Only `authToken` is supported; the deprecated `basicAuth` /
-    // `username` + `password` forms are dropped with a warning and never
-    // produce an auth header.
-    struct EnvDeprecated;
-    impl EnvVar for EnvDeprecated {
-        fn var(name: &str) -> Option<String> {
-            (name == "pnpm_config__auth").then(|| {
-                let pair = base64_encode("alice:secret");
-                let password_b64 = base64_encode("p@ss");
-                format!(
-                    r#"{{"https://reg.example":{{"@":{{"basicAuth":"{pair}","username":"alice","password":"{password_b64}"}}}}}}"#,
-                )
-            })
-        }
-    }
-    let auth = NpmrcAuth::from_json_sources::<EnvDeprecated>(None);
-    for field in ["basicAuth", "username", "password"] {
-        assert!(
-            auth.warnings.iter().any(|warning| warning.contains(field)
-                && warning.contains(r#"only "authToken" is supported"#)),
-            "expected an unsupported-field warning for {field:?}, got: {:?}",
-            auth.warnings,
-        );
-    }
-    let mut config = Config::new();
-    auth.apply_to::<EnvDeprecated>(&mut config);
-    assert!(config.auth_headers.for_url("https://reg.example/").is_none());
+    // `username` + `password` forms are rejected (`deny_unknown_fields`),
+    // which is a hard error.
+    static_env!(
+        Env,
+        &[("pnpm_config__auth", r#"{"https://reg.example":{"@":{"basicAuth":"any-value"}}}"#)]
+    );
+    assert!(NpmrcAuth::from_json_sources::<Env>(None).is_err());
 }
 
 #[test]
@@ -1205,7 +1186,7 @@ fn json_env_default_scope_infers_default_registry_route() {
         Env,
         &[("pnpm_config__auth", r#"{"https://my-npm-proxy.example":{"@":{"authToken":"tok"}}}"#)]
     );
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    let auth = NpmrcAuth::from_json_sources::<Env>(None).expect("valid _auth");
     assert_eq!(
         auth.json_env_registries.get("default").map(String::as_str),
         Some("https://my-npm-proxy.example/"),
@@ -1218,7 +1199,7 @@ fn json_env_package_scope_infers_scoped_registry_route() {
         Env,
         &[("pnpm_config__auth", r#"{"https://npm.pkg.github.com":{"@org":{"authToken":"tok"}}}"#)]
     );
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    let auth = NpmrcAuth::from_json_sources::<Env>(None).expect("valid _auth");
     assert_eq!(
         auth.json_env_registries.get("@org").map(String::as_str),
         Some("https://npm.pkg.github.com/"),
@@ -1238,7 +1219,7 @@ fn json_env_honors_upper_case_form() {
             r#"{"https://registry.npmjs.org":{"@":{"authToken":"upper-token"}}}"#
         )]
     );
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    let auth = NpmrcAuth::from_json_sources::<Env>(None).expect("valid _auth");
     assert_eq!(default_auth_token(&auth, "//registry.npmjs.org/"), Some(Some("upper-token")));
 }
 
@@ -1259,7 +1240,7 @@ fn json_env_lower_case_wins_over_upper_case_when_both_are_set() {
             ),
         ]
     );
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    let auth = NpmrcAuth::from_json_sources::<Env>(None).expect("valid _auth");
     assert_eq!(default_auth_token(&auth, "//registry.npmjs.org/"), Some(Some("lower-token")));
 }
 
@@ -1275,147 +1256,64 @@ fn json_env_empty_lowercase_falls_back_to_uppercase() {
             ),
         ]
     );
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
+    let auth = NpmrcAuth::from_json_sources::<Env>(None).expect("valid _auth");
     assert_eq!(default_auth_token(&auth, "//registry.npmjs.org/"), Some(Some("upper-token")));
 }
 
 #[test]
-fn json_env_warns_when_auth_field_value_is_not_a_string() {
+fn json_env_rejects_non_string_auth_token() {
     static_env!(
         Env,
         &[("pnpm_config__auth", r#"{"https://registry.example":{"@":{"authToken":123}}}"#)]
     );
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
-    assert!(auth.creds_by_scope_by_uri.is_empty());
-    assert!(
-        auth.warnings
-            .iter()
-            .any(|warning| warning.contains("authToken")
-                && warning.contains("value must be a string")),
-        "expected a per-key type warning, got: {:?}",
-        auth.warnings,
-    );
+    assert!(NpmrcAuth::from_json_sources::<Env>(None).is_err());
 }
 
 #[test]
-fn json_env_warns_when_host_value_is_not_scope_object() {
+fn json_env_rejects_missing_auth_token() {
+    static_env!(Env, &[("pnpm_config__auth", r#"{"https://registry.example":{"@":{}}}"#)]);
+    assert!(NpmrcAuth::from_json_sources::<Env>(None).is_err());
+}
+
+#[test]
+fn json_env_rejects_host_value_that_is_not_a_scope_object() {
     static_env!(Env, &[("pnpm_config__auth", r#"{"https://registry.example":123}"#)]);
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
-    assert!(auth.creds_by_scope_by_uri.is_empty());
-    assert!(
-        auth.warnings.iter().any(|warning| warning.contains("entry 1")
-            && warning.contains("object keyed by scope")),
-        "expected a per-key type warning, got: {:?}",
-        auth.warnings,
-    );
+    assert!(NpmrcAuth::from_json_sources::<Env>(None).is_err());
 }
 
 #[test]
-fn json_env_warns_when_host_key_is_not_a_registry_url() {
+fn json_env_rejects_host_key_that_is_not_a_registry_url() {
     static_env!(Env, &[("pnpm_config__auth", r#"{"not a url":{"@":{"authToken":"tok"}}}"#)]);
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
-    assert!(auth.creds_by_scope_by_uri.is_empty());
-    assert!(
-        auth.warnings
-            .iter()
-            .any(|warning| warning.contains("entry 1") && warning.contains("registry URL")),
-        "expected a registry-URL warning, got: {:?}",
-        auth.warnings,
-    );
-    assert!(
-        !auth.warnings.iter().any(|warning| warning.contains("not a url")),
-        "raw key must not leak into warnings: {:?}",
-        auth.warnings,
-    );
+    let error = NpmrcAuth::from_json_sources::<Env>(None).unwrap_err().to_string();
+    assert!(!error.contains("not a url"), "raw key must not leak into the error: {error}");
 }
 
 #[test]
-fn json_env_warns_when_host_key_has_empty_host() {
-    static_env!(
-        Env,
-        &[(
-            "pnpm_config__auth",
-            r#"{"https://":{"@":{"authToken":"tok"}},"https://:8080":{"@":{"authToken":"tok"}}}"#
-        )]
-    );
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
-    assert!(auth.creds_by_scope_by_uri.is_empty());
-    let entry1_count = auth
-        .warnings
-        .iter()
-        .filter(|warning| warning.contains("entry 1") && warning.contains("registry URL"))
-        .count();
-    let entry2_count = auth
-        .warnings
-        .iter()
-        .filter(|warning| warning.contains("entry 2") && warning.contains("registry URL"))
-        .count();
-    assert_eq!(entry1_count, 1, "expected one entry-1 warning, got: {:?}", auth.warnings);
-    assert_eq!(entry2_count, 1, "expected one entry-2 warning, got: {:?}", auth.warnings);
-    assert!(
-        !auth.warnings.iter().any(|warning| warning.contains("https://")),
-        "raw URL must not leak into warnings: {:?}",
-        auth.warnings,
-    );
-}
-
-#[test]
-fn json_env_warns_when_host_key_has_non_http_scheme() {
-    // A key with a `://` separator parses a scheme, so it skips the
-    // missing-separator branch — but a non-http(s) scheme like `ftp://`
-    // must still be rejected on the scheme check, not accepted as a host.
+fn json_env_rejects_non_http_scheme() {
     static_env!(
         Env,
         &[("pnpm_config__auth", r#"{"ftp://registry.example":{"@":{"authToken":"tok"}}}"#)]
     );
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
-    assert!(auth.creds_by_scope_by_uri.is_empty());
-    assert!(
-        auth.warnings
-            .iter()
-            .any(|warning| warning.contains("entry 1") && warning.contains("registry URL")),
-        "expected a registry-URL warning, got: {:?}",
-        auth.warnings,
-    );
-    assert!(
-        !auth.warnings.iter().any(|warning| warning.contains("ftp://")),
-        "raw key must not leak into warnings: {:?}",
-        auth.warnings,
-    );
+    assert!(NpmrcAuth::from_json_sources::<Env>(None).is_err());
 }
 
 #[test]
-fn json_env_warns_when_scope_name_is_invalid() {
+fn json_env_rejects_invalid_scope_name() {
     static_env!(
         Env,
         &[("pnpm_config__auth", r#"{"https://registry.example":{"org":{"authToken":"tok"}}}"#)]
     );
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
-    assert!(auth.creds_by_scope_by_uri.is_empty());
-    assert!(
-        auth.warnings
-            .iter()
-            .any(|warning| warning.contains("org") && warning.contains("scope must be")),
-        "expected a per-key type warning, got: {:?}",
-        auth.warnings,
-    );
+    assert!(NpmrcAuth::from_json_sources::<Env>(None).is_err());
 }
 
 #[test]
-fn json_env_warns_when_scope_value_is_not_auth_object() {
+fn json_env_rejects_scope_value_that_is_not_an_auth_object() {
     static_env!(Env, &[("pnpm_config__auth", r#"{"https://registry.example":{"@":"tok"}}"#)]);
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
-    assert!(auth.creds_by_scope_by_uri.is_empty());
-    assert!(
-        auth.warnings.iter().any(|warning| warning.contains("entry 1")
-            && warning.contains("value must be an auth object")),
-        "expected an auth-object warning, got: {:?}",
-        auth.warnings,
-    );
+    assert!(NpmrcAuth::from_json_sources::<Env>(None).is_err());
 }
 
 #[test]
-fn json_env_warns_when_auth_field_is_unsupported() {
+fn json_env_rejects_unsupported_auth_field() {
     static_env!(
         Env,
         &[(
@@ -1423,23 +1321,13 @@ fn json_env_warns_when_auth_field_is_unsupported() {
             r#"{"https://registry.example":{"@":{"tokenHelper":"/bin/echo"}}}"#
         )]
     );
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
-    assert!(auth.creds_by_scope_by_uri.is_empty());
-    assert!(
-        auth.warnings
-            .iter()
-            .any(|warning| warning.contains("tokenHelper") && warning.contains("unsupported")),
-        "expected an unsupported-field warning, got: {:?}",
-        auth.warnings,
-    );
-    assert!(auth.json_env_registries.is_empty());
+    assert!(NpmrcAuth::from_json_sources::<Env>(None).is_err());
 }
 
 #[test]
-fn json_env_warnings_do_not_leak_url_credentials() {
-    // The URL key carries userinfo and a query-string token — both are
-    // common places to embed secrets in registry URLs. No warning should
-    // surface any fragment of the raw key.
+fn json_env_error_does_not_leak_url_credentials() {
+    // The URL key carries userinfo and a query-string token — both common
+    // places to embed secrets. The rejection error must not surface them.
     static_env!(
         Env,
         &[(
@@ -1447,92 +1335,23 @@ fn json_env_warnings_do_not_leak_url_credentials() {
             r#"{"https://user:pw@registry.example?token=secret":{"@":{"authToken":"tok"}}}"#
         )]
     );
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
-    assert!(
-        auth.warnings.iter().any(|warning| warning.contains("entry 1 (https://registry.example)")
-            && warning.contains("credentials, query, or fragment")),
-        "expected a credentials-rejection warning with sanitized label, got: {:?}",
-        auth.warnings,
-    );
-    for leak in &["user:pw", "pw@", "token=secret", "?token"] {
-        assert!(
-            !auth.warnings.iter().any(|warning| warning.contains(leak)),
-            "secret fragment {leak:?} leaked into a warning: {:?}",
-            auth.warnings,
-        );
+    let error = NpmrcAuth::from_json_sources::<Env>(None).unwrap_err().to_string();
+    for leak in ["user:pw", "pw@", "token=secret", "?token"] {
+        assert!(!error.contains(leak), "secret fragment {leak:?} leaked into the error: {error}");
     }
 }
 
 #[test]
-fn json_env_rejects_urls_with_credentials_query_or_fragment() {
-    // Mirrors TS `parseJsonAuthRegistry`: URLs with userinfo, query, or
-    // fragment are rejected — no token is applied, no route is inferred.
-    static_env!(
-        Env,
-        &[(
-            "pnpm_config__auth",
-            r#"{"https://user:pw@reg.example":{"@":{"authToken":"tok"}},"https://reg.example?token=secret":{"@":{"authToken":"tok"}},"https://reg.example#frag":{"@":{"authToken":"tok"}}}"#
-        )]
-    );
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
-    assert!(
-        auth.creds_by_scope_by_uri.is_empty(),
-        "no creds should be applied: {:?}",
-        auth.creds_by_scope_by_uri,
-    );
-    assert!(auth.json_env_registries.is_empty(), "no routes should be inferred");
-    let rejection_count = auth
-        .warnings
-        .iter()
-        .filter(|warning| warning.contains("credentials, query, or fragment"))
-        .count();
-    assert_eq!(rejection_count, 3, "expected 3 rejection warnings, got: {:?}", auth.warnings);
-    for leak in &["user:pw", "pw@", "token=secret", "?token", "#frag"] {
-        assert!(
-            !auth.warnings.iter().any(|warning| warning.contains(leak)),
-            "secret fragment {leak:?} leaked: {:?}",
-            auth.warnings,
-        );
-    }
-}
-
-#[test]
-fn json_env_does_not_infer_registry_route_when_no_auth_field_is_accepted() {
-    static_env!(
-        Env,
-        &[(
-            "pnpm_config__auth",
-            r#"{"https://private.example":{"@":{"tokenAuth":"tok"},"@org":{"authToken":123}}}"#
-        )]
-    );
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
-    assert!(auth.creds_by_scope_by_uri.is_empty());
-    assert!(auth.json_env_registries.is_empty());
-}
-
-#[test]
-fn json_env_malformed_json_pushes_warning_and_returns_empty() {
+fn json_env_rejects_malformed_json() {
     static_env!(Env, &[("pnpm_config__auth", "{ not valid json")]);
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
-    assert!(auth.creds_by_scope_by_uri.is_empty());
-    assert!(
-        auth.warnings.iter().any(|warning| warning.contains("Failed to parse pnpm_config__auth")),
-        "expected a parse-failure warning, got: {:?}",
-        auth.warnings,
-    );
+    assert!(NpmrcAuth::from_json_sources::<Env>(None).is_err());
 }
 
 #[test]
-fn json_env_rejects_non_object_top_level_with_warning() {
+fn json_env_rejects_non_object_top_level() {
     // Arrays expose their indices as keys, so reject them outright.
     static_env!(Env, &[("pnpm_config__auth", r#"["//registry.example/:_authToken","sneaky"]"#)]);
-    let auth = NpmrcAuth::from_json_sources::<Env>(None);
-    assert!(auth.creds_by_scope_by_uri.is_empty());
-    assert!(
-        auth.warnings.iter().any(|warning| warning.contains("must be a JSON object")),
-        "expected a top-level type warning, got: {:?}",
-        auth.warnings,
-    );
+    assert!(NpmrcAuth::from_json_sources::<Env>(None).is_err());
 }
 
 #[test]
@@ -1544,15 +1363,13 @@ fn json_env_empty_or_unset_returns_default() {
             None
         }
     }
-    let auth = NpmrcAuth::from_json_sources::<UnsetEnv>(None);
+    let auth = NpmrcAuth::from_json_sources::<UnsetEnv>(None).expect("valid _auth");
     assert!(auth.creds_by_scope_by_uri.is_empty());
-    assert!(auth.warnings.is_empty());
 
     // Set but empty: filtered out by the `.filter(|v| !v.is_empty())` step.
     static_env!(EnvWithEmptyAuth, &[("pnpm_config__auth", "")]);
-    let auth = NpmrcAuth::from_json_sources::<EnvWithEmptyAuth>(None);
+    let auth = NpmrcAuth::from_json_sources::<EnvWithEmptyAuth>(None).expect("valid _auth");
     assert!(auth.creds_by_scope_by_uri.is_empty());
-    assert!(auth.warnings.is_empty());
 }
 
 #[test]
@@ -1571,7 +1388,7 @@ fn json_global_value_configures_auth_and_env_wins_on_conflict() {
         "https://registry.npmjs.org": { "@": { "authToken": "yaml-token" } },
         "https://other.example": { "@": { "authToken": "yaml-other" } },
     });
-    let auth = NpmrcAuth::from_json_sources::<EnvJson>(Some(&global));
+    let auth = NpmrcAuth::from_json_sources::<EnvJson>(Some(&global)).expect("valid _auth");
     // Env wins on the conflicting host.
     assert_eq!(default_auth_token(&auth, "//registry.npmjs.org/"), Some(Some("env-token")));
     // The global-only host is preserved.
@@ -1579,51 +1396,17 @@ fn json_global_value_configures_auth_and_env_wins_on_conflict() {
 }
 
 #[test]
-fn json_type_label_names_every_variant() {
-    // Direct exercise of the helper across every serde_json variant —
-    // from_json_sources only reaches it on the non-Object error path, so a
-    // handful of variants (Null/Bool/Number/Object) never get hit through
-    // the integration tests.
-    use super::json_type_label;
-    assert_eq!(json_type_label(&serde_json::Value::Null), "null");
-    assert_eq!(json_type_label(&serde_json::Value::Bool(true)), "boolean");
-    assert_eq!(json_type_label(&serde_json::Value::from(42)), "number");
-    assert_eq!(json_type_label(&serde_json::Value::from("hi")), "string");
-    assert_eq!(json_type_label(&serde_json::Value::Array(vec![serde_json::Value::Null])), "array");
-    assert_eq!(json_type_label(&serde_json::Value::Object(serde_json::Map::new())), "object");
-}
-
-#[test]
-fn json_auth_entry_label_formats() {
-    use super::json_auth_entry_label;
-    // No scheme separator → bare entry label
-    assert_eq!(json_auth_entry_label("not a url", 1), "entry 1");
-    // Non-http scheme → bare entry label
-    assert_eq!(json_auth_entry_label("ftp://host", 2), "entry 2");
-    // http/https with empty host → bare entry label
-    assert_eq!(json_auth_entry_label("https://", 3), "entry 3");
-    assert_eq!(json_auth_entry_label("https://:8080", 4), "entry 4");
-    // Valid URL → entry N (scheme://host)
-    assert_eq!(json_auth_entry_label("https://reg.example", 5), "entry 5 (https://reg.example)");
-    // Port preserved in label
-    assert_eq!(
-        json_auth_entry_label("https://reg.example:8080", 6),
-        "entry 6 (https://reg.example:8080)",
+fn json_env_normalizes_registry_url_key() {
+    // The `url` crate lowercases scheme + host and drops the default port,
+    // matching the TS side's `new URL()`.
+    static_env!(
+        Env,
+        &[("pnpm_config__auth", r#"{"HTTPS://Reg.Example:443":{"@":{"authToken":"tok"}}}"#)]
     );
-    // Userinfo stripped from label
+    let auth = NpmrcAuth::from_json_sources::<Env>(None).expect("valid _auth");
+    assert_eq!(default_auth_token(&auth, "//reg.example/"), Some(Some("tok")));
     assert_eq!(
-        json_auth_entry_label("https://user:pw@reg.example", 7),
-        "entry 7 (https://reg.example)",
+        auth.json_env_registries.get("default").map(String::as_str),
+        Some("https://reg.example/"),
     );
-}
-
-#[test]
-fn json_auth_url_has_credentials_or_extras_truth_table() {
-    use super::json_auth_url_has_credentials_or_extras;
-    assert!(json_auth_url_has_credentials_or_extras("https://user:pw@host"));
-    assert!(json_auth_url_has_credentials_or_extras("https://host?token=x"));
-    assert!(json_auth_url_has_credentials_or_extras("https://host#frag"));
-    assert!(!json_auth_url_has_credentials_or_extras("https://host"));
-    assert!(!json_auth_url_has_credentials_or_extras("https://@host"));
-    assert!(!json_auth_url_has_credentials_or_extras("not a url"));
 }

--- a/pacquet/crates/config/src/tests.rs
+++ b/pacquet/crates/config/src/tests.rs
@@ -11,8 +11,60 @@ use std::{
     ffi::OsString,
     io,
     path::{Path, PathBuf},
+    sync::{Arc, Mutex},
 };
 use tempfile::tempdir;
+
+/// Capture everything pnpm emits through `tracing::warn!` / `info!` /
+/// `debug!` while `body` runs, returning the formatted text so assertions
+/// can grep for expected substrings.
+///
+/// `tracing` events are dropped silently when no subscriber is installed —
+/// the default in tests. The closure runs under a thread-local
+/// [`tracing::dispatcher::with_default`] scope so other tests running in
+/// parallel are unaffected. ANSI escapes and timestamps are disabled to
+/// keep the captured string easy to match.
+fn capture_tracing_output<Ret>(body: impl FnOnce() -> Ret) -> (Ret, String) {
+    let buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(BufferWriter(Arc::clone(&buffer)))
+        .without_time()
+        .with_ansi(false)
+        .with_target(false)
+        .finish();
+    let dispatch = tracing::dispatcher::Dispatch::new(subscriber);
+    let result = tracing::dispatcher::with_default(&dispatch, body);
+    let captured = String::from_utf8(buffer.lock().unwrap().clone())
+        .expect("captured tracing output is valid UTF-8");
+    (result, captured)
+}
+
+/// [`tracing_subscriber::fmt::MakeWriter`] impl that funnels formatted
+/// events into an [`Arc<Mutex<Vec<u8>>>`] so the test can read them back
+/// after the fact. Arc-clones the buffer per writer to side-step the
+/// `&'a self` lifetime in `MakeWriter::make_writer` — a tiny allocation
+/// cost per event that doesn't matter for tests.
+#[derive(Clone)]
+struct BufferWriter(Arc<Mutex<Vec<u8>>>);
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BufferWriter {
+    type Writer = BufferSink;
+    fn make_writer(&'a self) -> Self::Writer {
+        BufferSink(Arc::clone(&self.0))
+    }
+}
+
+struct BufferSink(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for BufferSink {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
 
 /// `Config::current` requires `Sys: LinkProbe` so the late-stage
 /// `store_dir` resolver (port of pnpm's `storePathRelativeToHome`)
@@ -443,6 +495,419 @@ pub fn url_scoped_env_auth_prefix_is_case_insensitive_end_to_end() {
     assert_eq!(
         config.auth_headers.for_url("https://env2e.example.com/pkg").as_deref(),
         Some("Bearer upper-token"),
+    );
+}
+
+#[test]
+pub fn json_env_host_keyed_token_is_used_and_outranks_project_npmrc() {
+    let project = tempdir().expect("project tempdir");
+    write_file(&project.path().join(".npmrc"), "//json2e.example.com/:_authToken=project-token\n");
+    set_fake_env(&[(
+        "pnpm_config__auth",
+        r#"{"https://json2e.example.com":{"@":{"authToken":"env-token"}}}"#,
+    )]);
+
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(
+        config.auth_headers.for_url("https://json2e.example.com/pkg").as_deref(),
+        Some("Bearer env-token"),
+    );
+}
+
+#[test]
+pub fn json_env_repo_registry_cannot_redirect_token() {
+    let project = tempdir().expect("project tempdir");
+    write_file(
+        &project.path().join("pnpm-workspace.yaml"),
+        "registries:\n  '@org-a': https://attacker.example/\n",
+    );
+    set_fake_env(&[(
+        "pnpm_config__auth",
+        r#"{"https://npm.pkg.github.com":{"@org-a":{"authToken":"org-a-token"}}}"#,
+    )]);
+
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(
+        config
+            .auth_headers
+            .for_url_with_package("https://npm.pkg.github.com/org-a/foo", Some("@org-a/foo"))
+            .as_deref(),
+        Some("Bearer org-a-token"),
+    );
+    // Use the scoped lookup the token is keyed under — `for_url` alone
+    // only checks the default/unscoped path and would pass even if the
+    // `@org-a` token had been rebound to the attacker host.
+    assert!(
+        config
+            .auth_headers
+            .for_url_with_package("https://attacker.example/org-a/foo", Some("@org-a/foo"))
+            .is_none(),
+        "repo-controlled registry URL must not receive the env token",
+    );
+}
+
+#[test]
+pub fn json_env_per_scope_token_on_shared_host() {
+    let project = tempdir().expect("project tempdir");
+    set_fake_env(&[(
+        "pnpm_config__auth",
+        r#"{"https://npm.pkg.github.com":{"@org-a":{"authToken":"a-tok"},"@org-b":{"authToken":"b-tok"}}}"#,
+    )]);
+
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(
+        config
+            .auth_headers
+            .for_url_with_package("https://npm.pkg.github.com/org-a/foo", Some("@org-a/foo"))
+            .as_deref(),
+        Some("Bearer a-tok"),
+    );
+    assert_eq!(
+        config
+            .auth_headers
+            .for_url_with_package("https://npm.pkg.github.com/org-b/foo", Some("@org-b/foo"))
+            .as_deref(),
+        Some("Bearer b-tok"),
+    );
+}
+
+/// End-to-end: malformed `pnpm_config__auth` JSON does not abort the load.
+/// Warning emission is verified at unit level in
+/// `npmrc_auth::tests::json_env_malformed_json_pushes_warning_and_returns_empty`.
+#[test]
+pub fn json_env_malformed_json_does_not_crash_the_load() {
+    let project = tempdir().expect("project tempdir");
+    write_file(&project.path().join(".npmrc"), "//json2e.example.com/:_authToken=project-token\n");
+    set_fake_env(&[("pnpm_config__auth", "{ not valid json")]);
+
+    let config = load_with_fake_env(project.path());
+
+    // The project .npmrc token still applies — env JSON was ignored.
+    assert_eq!(
+        config.auth_headers.for_url("https://json2e.example.com/pkg").as_deref(),
+        Some("Bearer project-token"),
+    );
+}
+
+/// End-to-end: `pnpm_config__auth` with parse-time warnings (malformed
+/// JSON, non-object top level) still emits those warnings via
+/// `tracing::warn!`. Regression for the "creds OR warnings" gate in
+/// `Config::current` — if `env_json_source` is dropped when only warnings
+/// are present, the warning never reaches the `apply_registry_and_warn`
+/// flush that turns the in-memory `NpmrcAuth.warnings` entry into an
+/// actual `tracing` event.
+#[test]
+pub fn json_env_warnings_survive_when_no_creds_present() {
+    let project = tempdir().expect("project tempdir");
+    set_fake_env(&[("pnpm_config__auth", r#"["array","is","not","an","object"]"#)]);
+
+    let (config, captured) = capture_tracing_output(|| load_with_fake_env(project.path()));
+
+    // Load completes; the malformed source contributes no creds.
+    assert!(config.auth_headers.for_url("https://json2e.example.com/pkg").is_none());
+    // The top-level type rejection produced a warning that reached
+    // `tracing::warn!` end-to-end (i.e. the env_json_source was not
+    // dropped by the gate before reaching the flush loop).
+    assert!(
+        captured.contains("must be a JSON object"),
+        "expected a tracing warn emission for the non-object top level, got: {captured:?}",
+    );
+}
+
+/// End-to-end: the "@" (default) scope in `pnpm_config__auth` routes the
+/// default registry to its host — `pnpm add <pkg>` resolves against the
+/// env-declared host, not the npmjs default. Confirmed semantics in
+/// pnpm/pnpm#12559.
+#[test]
+pub fn json_env_default_scope_routes_default_registry() {
+    let project = tempdir().expect("project tempdir");
+    set_fake_env(&[(
+        "pnpm_config__auth",
+        r#"{"https://my-npm-proxy.example":{"@":{"authToken":"proxy-token"}}}"#,
+    )]);
+
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(config.registry, "https://my-npm-proxy.example/");
+    assert_eq!(
+        config.registries.get("default").map(String::as_str),
+        Some("https://my-npm-proxy.example/"),
+    );
+    assert_eq!(
+        config.auth_headers.for_url("https://my-npm-proxy.example/pkg").as_deref(),
+        Some("Bearer proxy-token"),
+    );
+}
+
+/// End-to-end: a package scope in `pnpm_config__auth` routes that scope
+/// to its host.
+#[test]
+pub fn json_env_scoped_entry_routes_that_scope() {
+    let project = tempdir().expect("project tempdir");
+    set_fake_env(&[(
+        "pnpm_config__auth",
+        r#"{"https://npm.pkg.github.com":{"@org":{"authToken":"org-token"}}}"#,
+    )]);
+
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(
+        config.registries.get("@org").map(String::as_str),
+        Some("https://npm.pkg.github.com/"),
+    );
+}
+
+/// End-to-end: the env-inferred default registry wins over a
+/// repo-controlled `pnpm-workspace.yaml` default. The credential and
+/// its destination host come from the same trusted env value, so yaml
+/// cannot redirect the env token to a different registry.
+#[test]
+pub fn json_env_env_default_wins_over_workspace_yaml_default() {
+    let project = tempdir().expect("project tempdir");
+    write_file(
+        &project.path().join("pnpm-workspace.yaml"),
+        "registries:\n  default: https://registry.npmjs.org/\n",
+    );
+    set_fake_env(&[(
+        "pnpm_config__auth",
+        r#"{"https://my-npm-proxy.example":{"@":{"authToken":"proxy-token"}}}"#,
+    )]);
+
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(config.registry, "https://my-npm-proxy.example/");
+    assert_eq!(
+        config.registries.get("default").map(String::as_str),
+        Some("https://my-npm-proxy.example/"),
+    );
+}
+
+/// End-to-end: the `_auth` key of the global pnpm `config.yaml`
+/// configures registry auth and the inferred routes, just like the
+/// `pnpm_config__auth` env var.
+#[test]
+pub fn global_config_yaml_auth_configures_registry_auth() {
+    let xdg = tempdir().expect("xdg tempdir");
+    let config_dir = xdg.path().join("pnpm");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.yaml"),
+        "_auth:\n  \"https://global-auth.example.com\":\n    \"@\":\n      authToken: yaml-token\n    \"@org\":\n      authToken: org-yaml-token\n",
+    )
+    .expect("write global config.yaml");
+
+    let project = tempdir().expect("project tempdir");
+    set_fake_env(&[("XDG_CONFIG_HOME", xdg.path().to_str().unwrap())]);
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(
+        config.auth_headers.for_url("https://global-auth.example.com/pkg").as_deref(),
+        Some("Bearer yaml-token"),
+    );
+    assert_eq!(config.registry, "https://global-auth.example.com/");
+    assert_eq!(
+        config.registries.get("@org").map(String::as_str),
+        Some("https://global-auth.example.com/"),
+    );
+}
+
+/// End-to-end: the `pnpm_config__auth` env var wins over the global
+/// `config.yaml` `_auth` on a conflicting key.
+#[test]
+pub fn json_env_auth_wins_over_global_config_yaml_auth() {
+    let xdg = tempdir().expect("xdg tempdir");
+    let config_dir = xdg.path().join("pnpm");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.yaml"),
+        "_auth:\n  \"https://shared.example.com\":\n    \"@\":\n      authToken: yaml-token\n",
+    )
+    .expect("write global config.yaml");
+
+    let project = tempdir().expect("project tempdir");
+    set_fake_env(&[
+        ("XDG_CONFIG_HOME", xdg.path().to_str().unwrap()),
+        ("pnpm_config__auth", r#"{"https://shared.example.com":{"@":{"authToken":"env-token"}}}"#),
+    ]);
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(
+        config.auth_headers.for_url("https://shared.example.com/pkg").as_deref(),
+        Some("Bearer env-token"),
+    );
+}
+
+/// End-to-end: `_auth` in a project `pnpm-workspace.yaml` is ignored —
+/// repo-controlled config must never supply registry credentials.
+#[test]
+pub fn project_workspace_yaml_auth_is_ignored() {
+    let project = tempdir().expect("project tempdir");
+    write_file(
+        &project.path().join("pnpm-workspace.yaml"),
+        "_auth:\n  \"https://attacker.example\":\n    \"@\":\n      authToken: attacker-token\n",
+    );
+    set_fake_env(&[]);
+
+    let config = load_with_fake_env(project.path());
+
+    assert!(
+        config.auth_headers.for_url("https://attacker.example/pkg").is_none(),
+        "project pnpm-workspace.yaml _auth must not configure registry auth",
+    );
+    assert_ne!(config.registry, "https://attacker.example/");
+}
+
+/// End-to-end: a `PNPM_CONFIG_REGISTRY` env var (CLI-equivalent) still
+/// wins over the env JSON default — matching pnpm's "CLI > env JSON >
+/// yaml" precedence.
+#[test]
+pub fn json_env_env_registry_flag_wins_over_json_env_default() {
+    let project = tempdir().expect("project tempdir");
+    set_fake_env(&[
+        (
+            "pnpm_config__auth",
+            r#"{"https://my-npm-proxy.example":{"@":{"authToken":"proxy-token"}}}"#,
+        ),
+        ("PNPM_CONFIG_REGISTRY", "https://cli-registry.example/"),
+    ]);
+
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(config.registry, "https://cli-registry.example/");
+    assert_eq!(
+        config.registries.get("default").map(String::as_str),
+        Some("https://cli-registry.example/"),
+    );
+    assert_eq!(
+        config.package_manager_bootstrap.registries.get("default").map(String::as_str),
+        Some("https://cli-registry.example/"),
+    );
+    // Token is still pinned to the env-declared host.
+    assert_eq!(
+        config.auth_headers.for_url("https://my-npm-proxy.example/pkg").as_deref(),
+        Some("Bearer proxy-token"),
+    );
+}
+
+/// End-to-end: env-inferred registry routes flow through to the
+/// package-manager bootstrap path (self-download / version switching).
+#[test]
+pub fn json_env_inferred_registries_flow_to_bootstrap() {
+    let project = tempdir().expect("project tempdir");
+    set_fake_env(&[(
+        "pnpm_config__auth",
+        r#"{"https://my-npm-proxy.example":{"@":{"authToken":"proxy-token"},"@org":{"authToken":"org-token"}}}"#,
+    )]);
+
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(config.package_manager_bootstrap.registry, "https://my-npm-proxy.example/");
+    assert_eq!(
+        config.package_manager_bootstrap.registries.get("@org").map(String::as_str),
+        Some("https://my-npm-proxy.example/"),
+    );
+    assert_eq!(
+        config
+            .package_manager_bootstrap
+            .auth_headers
+            .for_url("https://my-npm-proxy.example/pkg")
+            .as_deref(),
+        Some("Bearer proxy-token"),
+    );
+    assert_eq!(
+        config
+            .package_manager_bootstrap
+            .auth_headers
+            .for_url_with_package("https://my-npm-proxy.example/org/foo", Some("@org/foo"))
+            .as_deref(),
+        Some("Bearer org-token"),
+    );
+}
+
+/// End-to-end: a scoped env JSON entry overrides a repo-controlled
+/// `pnpm-workspace.yaml` scoped registry in the main cascade, and the
+/// token is pinned to the env-declared host. Asserts
+/// `config.registries["@scope"]` — not just auth headers — so a regression
+/// that breaks routing while leaving auth-header pinning intact is caught.
+#[test]
+pub fn json_env_env_scoped_wins_over_workspace_yaml_scoped() {
+    let project = tempdir().expect("project tempdir");
+    write_file(
+        &project.path().join("pnpm-workspace.yaml"),
+        "registries:\n  '@victim-scope': https://attacker.example/\n",
+    );
+    set_fake_env(&[(
+        "pnpm_config__auth",
+        r#"{"https://registry.npmjs.org":{"@victim-scope":{"authToken":"secret-token"}}}"#,
+    )]);
+
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(
+        config.registries.get("@victim-scope").map(String::as_str),
+        Some("https://registry.npmjs.org/"),
+    );
+    assert_eq!(
+        config
+            .auth_headers
+            .for_url_with_package(
+                "https://registry.npmjs.org/@victim-scope/foo",
+                Some("@victim-scope/foo")
+            )
+            .as_deref(),
+        Some("Bearer secret-token"),
+    );
+    assert!(
+        config.auth_headers.for_url("https://attacker.example/@victim-scope/foo").is_none(),
+        "repo-controlled registry URL must not receive the env token",
+    );
+}
+
+#[test]
+pub fn json_env_invalid_auth_does_not_route_registry() {
+    let project = tempdir().expect("project tempdir");
+    set_fake_env(&[(
+        "pnpm_config__auth",
+        r#"{"https://private.example":{"@":{"tokenAuth":"tok"},"@org":{"authToken":123}}}"#,
+    )]);
+
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(config.registry, NPM_DEFAULT_REGISTRY);
+    assert_eq!(config.registries.get("@org"), None);
+    assert_eq!(config.package_manager_bootstrap.registries.get("@org"), None);
+}
+
+/// Env JSON routes override user-level (`~/.npmrc` / `auth.ini`) scoped
+/// registries in the package-manager bootstrap, matching pnpm's TS
+/// `packageManagerRegistries` precedence (env JSON > trusted .npmrc).
+/// CLI scoped overrides still win — applied later by `ConfigOverrides`.
+#[test]
+pub fn json_env_overrides_user_bootstrap_scoped_registry() {
+    let project = tempdir().expect("project tempdir");
+    let auth = tempdir().expect("auth tempdir");
+    let auth_file = auth.path().join("user-npmrc");
+    write_file(&auth_file, "@org:registry=https://user-registry.example/\n");
+    set_fake_env(&[
+        ("PNPM_CONFIG_NPMRC_AUTH_FILE", auth_file.to_str().unwrap()),
+        (
+            "pnpm_config__auth",
+            r#"{"https://my-npm-proxy.example":{"@org":{"authToken":"org-token"}}}"#,
+        ),
+    ]);
+
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(
+        config.package_manager_bootstrap.registries.get("@org").map(String::as_str),
+        Some("https://my-npm-proxy.example/"),
+    );
+    assert_eq!(
+        config.registries.get("@org").map(String::as_str),
+        Some("https://my-npm-proxy.example/"),
     );
 }
 
@@ -1703,5 +2168,29 @@ pub fn package_manager_bootstrap_honors_env_registry() {
     assert_eq!(
         config.package_manager_bootstrap.registry, "https://env.example.com/",
         "env registry overrides the package-manager bootstrap default",
+    );
+}
+
+/// When `PNPM_CONFIG_REGISTRY` is set without a trailing slash, the env
+/// override normalizes it before storing — matching pnpm, which treats
+/// `https://r` and `https://r/` as the same registry. The slash must be
+/// appended consistently to `config.registry`, `config.registries`, and
+/// the bootstrap map so downstream lookups (auth-header pinning,
+/// `package_manager_bootstrap`) all key against the normalized form.
+#[test]
+pub fn env_registry_override_appends_missing_trailing_slash() {
+    let project = tempdir().expect("project tempdir");
+    set_fake_env(&[("PNPM_CONFIG_REGISTRY", "https://env.example.com")]);
+
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(config.registry, "https://env.example.com/");
+    assert_eq!(
+        config.registries.get("default").map(String::as_str),
+        Some("https://env.example.com/"),
+    );
+    assert_eq!(
+        config.package_manager_bootstrap.registries.get("default").map(String::as_str),
+        Some("https://env.example.com/"),
     );
 }

--- a/pacquet/crates/config/src/tests.rs
+++ b/pacquet/crates/config/src/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    Config, EnvVar, EnvVarOs, GetCurrentDir, GetHomeDir, Host, LinkProbe, NodeLinker,
-    NodePackageMapType, PackageImportMethod, fs,
+    Config, EnvVar, EnvVarOs, GetCurrentDir, GetHomeDir, Host, LinkProbe, LoadWorkspaceYamlError,
+    NodeLinker, NodePackageMapType, PackageImportMethod, fs,
 };
 use crate::defaults::default_store_dir;
 use pacquet_store_dir::StoreDir;
@@ -11,60 +11,8 @@ use std::{
     ffi::OsString,
     io,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
 };
 use tempfile::tempdir;
-
-/// Capture everything pnpm emits through `tracing::warn!` / `info!` /
-/// `debug!` while `body` runs, returning the formatted text so assertions
-/// can grep for expected substrings.
-///
-/// `tracing` events are dropped silently when no subscriber is installed —
-/// the default in tests. The closure runs under a thread-local
-/// [`tracing::dispatcher::with_default`] scope so other tests running in
-/// parallel are unaffected. ANSI escapes and timestamps are disabled to
-/// keep the captured string easy to match.
-fn capture_tracing_output<Ret>(body: impl FnOnce() -> Ret) -> (Ret, String) {
-    let buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
-    let subscriber = tracing_subscriber::fmt()
-        .with_writer(BufferWriter(Arc::clone(&buffer)))
-        .without_time()
-        .with_ansi(false)
-        .with_target(false)
-        .finish();
-    let dispatch = tracing::dispatcher::Dispatch::new(subscriber);
-    let result = tracing::dispatcher::with_default(&dispatch, body);
-    let captured = String::from_utf8(buffer.lock().unwrap().clone())
-        .expect("captured tracing output is valid UTF-8");
-    (result, captured)
-}
-
-/// [`tracing_subscriber::fmt::MakeWriter`] impl that funnels formatted
-/// events into an [`Arc<Mutex<Vec<u8>>>`] so the test can read them back
-/// after the fact. Arc-clones the buffer per writer to side-step the
-/// `&'a self` lifetime in `MakeWriter::make_writer` — a tiny allocation
-/// cost per event that doesn't matter for tests.
-#[derive(Clone)]
-struct BufferWriter(Arc<Mutex<Vec<u8>>>);
-
-impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BufferWriter {
-    type Writer = BufferSink;
-    fn make_writer(&'a self) -> Self::Writer {
-        BufferSink(Arc::clone(&self.0))
-    }
-}
-
-struct BufferSink(Arc<Mutex<Vec<u8>>>);
-
-impl io::Write for BufferSink {
-    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
-        self.0.lock().unwrap().extend_from_slice(bytes);
-        Ok(bytes.len())
-    }
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
 
 /// `Config::current` requires `Sys: LinkProbe` so the late-stage
 /// `store_dir` resolver (port of pnpm's `storePathRelativeToHome`)
@@ -574,47 +522,25 @@ pub fn json_env_per_scope_token_on_shared_host() {
     );
 }
 
-/// End-to-end: malformed `pnpm_config__auth` JSON does not abort the load.
-/// Warning emission is verified at unit level in
-/// `npmrc_auth::tests::json_env_malformed_json_pushes_warning_and_returns_empty`.
+/// End-to-end: malformed `pnpm_config__auth` JSON aborts the load with an
+/// error rather than silently dropping the auth.
 #[test]
-pub fn json_env_malformed_json_does_not_crash_the_load() {
+pub fn json_env_malformed_json_aborts_the_load() {
     let project = tempdir().expect("project tempdir");
-    write_file(&project.path().join(".npmrc"), "//json2e.example.com/:_authToken=project-token\n");
     set_fake_env(&[("pnpm_config__auth", "{ not valid json")]);
 
-    let config = load_with_fake_env(project.path());
-
-    // The project .npmrc token still applies — env JSON was ignored.
-    assert_eq!(
-        config.auth_headers.for_url("https://json2e.example.com/pkg").as_deref(),
-        Some("Bearer project-token"),
-    );
+    let result = Config::default().current::<FakeEnv>(project.path());
+    assert!(matches!(result, Err(LoadWorkspaceYamlError::InvalidJsonAuth { .. })));
 }
 
-/// End-to-end: `pnpm_config__auth` with parse-time warnings (malformed
-/// JSON, non-object top level) still emits those warnings via
-/// `tracing::warn!`. Regression for the "creds OR warnings" gate in
-/// `Config::current` — if `env_json_source` is dropped when only warnings
-/// are present, the warning never reaches the `apply_registry_and_warn`
-/// flush that turns the in-memory `NpmrcAuth.warnings` entry into an
-/// actual `tracing` event.
+/// End-to-end: a non-object top-level `pnpm_config__auth` aborts the load.
 #[test]
-pub fn json_env_warnings_survive_when_no_creds_present() {
+pub fn json_env_non_object_top_level_aborts_the_load() {
     let project = tempdir().expect("project tempdir");
     set_fake_env(&[("pnpm_config__auth", r#"["array","is","not","an","object"]"#)]);
 
-    let (config, captured) = capture_tracing_output(|| load_with_fake_env(project.path()));
-
-    // Load completes; the malformed source contributes no creds.
-    assert!(config.auth_headers.for_url("https://json2e.example.com/pkg").is_none());
-    // The top-level type rejection produced a warning that reached
-    // `tracing::warn!` end-to-end (i.e. the env_json_source was not
-    // dropped by the gate before reaching the flush loop).
-    assert!(
-        captured.contains("must be a JSON object"),
-        "expected a tracing warn emission for the non-object top level, got: {captured:?}",
-    );
+    let result = Config::default().current::<FakeEnv>(project.path());
+    assert!(matches!(result, Err(LoadWorkspaceYamlError::InvalidJsonAuth { .. })));
 }
 
 /// End-to-end: the "@" (default) scope in `pnpm_config__auth` routes the
@@ -867,18 +793,17 @@ pub fn json_env_env_scoped_wins_over_workspace_yaml_scoped() {
 }
 
 #[test]
-pub fn json_env_invalid_auth_does_not_route_registry() {
+pub fn json_env_invalid_auth_aborts_the_load() {
+    // An unsupported field and a non-string token are both hard errors, so
+    // no partially-applied routing leaks through.
     let project = tempdir().expect("project tempdir");
     set_fake_env(&[(
         "pnpm_config__auth",
         r#"{"https://private.example":{"@":{"tokenAuth":"tok"},"@org":{"authToken":123}}}"#,
     )]);
 
-    let config = load_with_fake_env(project.path());
-
-    assert_eq!(config.registry, NPM_DEFAULT_REGISTRY);
-    assert_eq!(config.registries.get("@org"), None);
-    assert_eq!(config.package_manager_bootstrap.registries.get("@org"), None);
+    let result = Config::default().current::<FakeEnv>(project.path());
+    assert!(matches!(result, Err(LoadWorkspaceYamlError::InvalidJsonAuth { .. })));
 }
 
 /// Env JSON routes override user-level (`~/.npmrc` / `auth.ini`) scoped

--- a/pacquet/crates/config/src/workspace_yaml.rs
+++ b/pacquet/crates/config/src/workspace_yaml.rs
@@ -114,6 +114,14 @@ pub struct WorkspaceSettings {
     /// setting.
     pub named_registries: Option<BTreeMap<String, String>>,
 
+    /// Structured registry auth (`_auth`). Honored **only** from the global
+    /// pnpm `config.yaml` (read via `NpmrcAuth::from_json_sources`, not
+    /// applied in [`Self::apply_to`]) — never a project file, so repo config
+    /// can't supply credentials. A raw [`serde_json::Value`] so the auth
+    /// parser is the single validator of its shape.
+    #[serde(rename = "_auth")]
+    pub auth: Option<serde_json::Value>,
+
     pub auto_install_peers: Option<bool>,
     pub auto_install_peers_from_highest_match: Option<bool>,
     pub exclude_links_from_lockfile: Option<bool>,

--- a/pacquet/crates/config/src/workspace_yaml.rs
+++ b/pacquet/crates/config/src/workspace_yaml.rs
@@ -530,6 +530,11 @@ pub enum LoadWorkspaceYamlError {
         #[error(source)]
         source: Box<serde_saphyr::Error>,
     },
+    #[display("Invalid `_auth` setting: {source}")]
+    InvalidJsonAuth {
+        #[error(source)]
+        source: serde_json::Error,
+    },
 }
 
 impl WorkspaceSettings {

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -249,6 +249,9 @@ export async function getConfig (opts: {
     configDir: configDir as string,
     moduleDirname: import.meta.dirname,
     env: opts.env,
+    // Only the global config yaml may supply `_auth` (deleted from
+    // `globalYamlConfig` below so it isn't flagged as an unknown setting).
+    globalConfigAuth: (globalYamlConfigForNpmrcAuthFile as unknown as Record<string, unknown> | undefined)?._auth,
   })
   const warnings = npmrcResult.warnings
 
@@ -303,6 +306,8 @@ export async function getConfig (opts: {
   // Reuse the global config.yaml already read for npmrcAuthFile
   const globalYamlConfig = globalYamlConfigForNpmrcAuthFile
   if (globalYamlConfig) {
+    // Consumed by loadNpmrcConfig above; drop so it isn't flagged as unknown.
+    delete (globalYamlConfig as unknown as Record<string, unknown>)._auth
     const ignoredKeys: string[] = []
     for (const key in globalYamlConfig) {
       if (!isConfigFileKey(kebabCase(key))) {
@@ -329,6 +334,12 @@ export async function getConfig (opts: {
   }
   const trustedAuthConfig = pickIniConfig(npmrcResult.trustedConfig)
   const trustedNetworkConfigs = getNetworkConfigs(trustedAuthConfig)
+  const cliScopedRegistries: Record<string, string> = {}
+  for (const [key, value] of Object.entries(cliOptions)) {
+    if (key.startsWith('@') && key.endsWith(':registry') && typeof value === 'string') {
+      cliScopedRegistries[key.slice(0, -':registry'.length)] = normalizeRegistryUrl(value)
+    }
+  }
   pnpmConfig.registries = { ...registriesFromNpmrc }
   if (explicitlySetKeys.has('registry') && typeof pnpmConfig.registry === 'string') {
     pnpmConfig.registries.default = normalizeRegistryUrl(pnpmConfig.registry)
@@ -336,6 +347,13 @@ export async function getConfig (opts: {
   pnpmConfig.packageManagerRegistries = {
     default: normalizeRegistryUrl(trustedAuthConfig.registry as string),
     ...trustedNetworkConfigs.registries,
+    // `_auth` routes apply here too so bootstrap (self-download / version
+    // switching) resolves the same way as regular installs.
+    ...npmrcResult.jsonAuth.registries,
+    ...cliScopedRegistries,
+  }
+  if (explicitlySetKeys.has('registry') && typeof pnpmConfig.registry === 'string') {
+    pnpmConfig.packageManagerRegistries.default = normalizeRegistryUrl(pnpmConfig.registry)
   }
   pnpmConfig.packageManagerNetworkConfig = createPackageManagerNetworkConfig(
     npmrcResult.trustedConfig,
@@ -463,13 +481,26 @@ export async function getConfig (opts: {
     }
   }
 
-  // Merge registries from pnpm-workspace.yaml onto the .npmrc-based registries.
-  // The workspace manifest may have set pnpmConfig.registries via addSettingsFromWorkspaceManifestToConfig,
-  // but we need to ensure 'default' is always set and all URLs are normalized.
+  // Precedence: builtin < .npmrc < yaml < `_auth` < CLI. CLI
+  // `--@scope:registry` / `--registry` already entered `registriesFromNpmrc`
+  // via `authConfig`, so they're re-applied last here to avoid being buried
+  // by yaml. `cliScopedRegistries` iterates raw `cliOptions` because
+  // `explicitlySetKeys` is camelCased, which mangles `@org-a:registry`.
   const workspaceRegistries = pnpmConfig.registries as Record<string, string> | undefined
   pnpmConfig.registries = {
     ...registriesFromNpmrc,
     ...workspaceRegistries,
+    // `_auth` routes win over repo-controlled yaml on conflicting scopes.
+    ...npmrcResult.jsonAuth.registries,
+    // CLI per-scope registries last, so `--@scope:registry=...` wins over
+    // both yaml and `_auth` ("CLI > _auth > yaml").
+    ...cliScopedRegistries,
+  }
+  // Re-apply an unscoped `--registry` CLI flag last for the same reason
+  // as `cliScopedRegistries` — it entered `registriesFromNpmrc` via
+  // `authConfig.registry` and would otherwise be buried by env JSON.
+  if (explicitlySetKeys.has('registry') && typeof pnpmConfig.registry === 'string') {
+    pnpmConfig.registries.default = normalizeRegistryUrl(pnpmConfig.registry)
   }
   if (!pnpmConfig.registries.default) {
     pnpmConfig.registries.default = registriesFromNpmrc.default

--- a/pnpm11/config/reader/src/loadNpmrcFiles.ts
+++ b/pnpm11/config/reader/src/loadNpmrcFiles.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 
 import { envReplaceLossy } from '@pnpm/config.env-replace'
 import { nerfDart } from '@pnpm/config.nerf-dart'
+import { PnpmError } from '@pnpm/error'
 import normalizeRegistryUrl from 'normalize-registry-url'
 import { readIniFileSync } from 'read-ini-file'
 
@@ -122,8 +123,8 @@ export function loadNpmrcConfig (opts: LoadNpmrcConfigOpts): NpmrcConfigResult {
   // runners that silently drop env vars whose names contain `/`, `:`, or
   // `.` — GitHub Actions, bash, zsh; see pnpm/pnpm#12314) and the `_auth`
   // key of the global pnpm config yaml. The env var wins on conflict.
-  const envJsonAuth = readJsonAuthEnv(env, warnings)
-  const globalConfigJsonAuth = readGlobalConfigAuth(opts.globalConfigAuth, warnings)
+  const envJsonAuth = readJsonAuthEnv(env)
+  const globalConfigJsonAuth = readGlobalConfigAuth(opts.globalConfigAuth)
   const jsonAuth: JsonAuthResult = {
     auth: { ...globalConfigJsonAuth.auth, ...envJsonAuth.auth },
     registries: { ...globalConfigJsonAuth.registries, ...envJsonAuth.registries },
@@ -231,7 +232,7 @@ function readUrlScopedEnvConfig (env: Record<string, string | undefined>): Recor
   return { ...npmScoped, ...pnpmScoped }
 }
 
-function readJsonAuthEnv (env: Record<string, string | undefined>, warnings: string[]): JsonAuthResult {
+function readJsonAuthEnv (env: Record<string, string | undefined>): JsonAuthResult {
   const value = readJsonAuthEnvValue(env)
   if (value == null) return { auth: {}, registries: {} }
 
@@ -239,43 +240,41 @@ function readJsonAuthEnv (env: Record<string, string | undefined>, warnings: str
   try {
     parsed = JSON.parse(value)
   } catch (err: unknown) {
-    warnings.push(`Failed to parse pnpm_config__auth as JSON: ${err instanceof Error ? err.message : String(err)}. Ignored.`)
-    return { auth: {}, registries: {} }
+    throw new PnpmError('INVALID_AUTH_SETTING', `Failed to parse pnpm_config__auth as JSON: ${err instanceof Error ? err.message : String(err)}`)
   }
-  return parseJsonAuth(parsed, warnings, 'pnpm_config__auth')
+  return parseJsonAuth(parsed, 'pnpm_config__auth')
 }
 
 /**
  * Parse a URL-keyed `_auth` object into `.npmrc`-shaped flat auth keys plus
  * the registry routes inferred from each host. Shared by the env var and the
- * global config yaml; `source` labels warnings.
+ * global config yaml.
+ *
+ * Strict: any malformed entry throws. Both sources are user-controlled, so a
+ * typo should fail fast rather than silently drop auth. `source` names the
+ * origin in errors; raw URL keys are never echoed — they can embed secrets.
  */
-function parseJsonAuth (parsed: unknown, warnings: string[], source: string): JsonAuthResult {
+function parseJsonAuth (parsed: unknown, source: string): JsonAuthResult {
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    warnings.push(`${source} must be a JSON object; got ${Array.isArray(parsed) ? 'array' : parsed === null ? 'null' : typeof parsed}. Ignored.`)
-    return { auth: {}, registries: {} }
+    throw new PnpmError('INVALID_AUTH_SETTING', `${source} must be a JSON object`)
   }
 
   const auth: Record<string, string> = {}
   const registries: Record<string, string> = {}
   for (const [index, [url, scopes]] of Object.entries(parsed as Record<string, unknown>).entries()) {
-    const registry = parseJsonAuthRegistry(url, index + 1, warnings, source)
-    if (registry == null) continue
+    const registry = parseJsonAuthRegistry(url, index + 1, source)
     if (scopes === null || typeof scopes !== 'object' || Array.isArray(scopes)) {
-      warnings.push(`${source}[${registry.label}] ignored: value must be an object keyed by scope.`)
-      continue
+      throw new PnpmError('INVALID_AUTH_SETTING', `${source}[${registry.label}] must be an object keyed by scope`)
     }
     for (const [scope, rawCreds] of Object.entries(scopes as Record<string, unknown>)) {
       if (!isJsonAuthScope(scope)) {
-        warnings.push(`${source}[${registry.label}][${JSON.stringify(scope)}] ignored: scope must be "@" or a package scope like "@org".`)
-        continue
+        throw new PnpmError('INVALID_AUTH_SETTING', `${source}[${registry.label}][${JSON.stringify(scope)}]: scope must be "@" or a package scope like "@org"`)
       }
       if (rawCreds === null || typeof rawCreds !== 'object' || Array.isArray(rawCreds)) {
-        warnings.push(`${source}[${registry.label}][${JSON.stringify(scope)}] ignored: value must be an auth object.`)
-        continue
+        throw new PnpmError('INVALID_AUTH_SETTING', `${source}[${registry.label}][${JSON.stringify(scope)}] must be an auth object`)
       }
-      const acceptedCreds = appendJsonAuthCreds(auth, warnings, registry, scope, rawCreds as Record<string, unknown>, source)
-      if (!acceptedCreds) continue
+      const token = jsonAuthToken(rawCreds as Record<string, unknown>, registry, scope, source)
+      auth[`${registry.nerfed}:${scope === '@' ? '' : `${scope}:`}_authToken`] = token
       // Infer a registry route from the same entry (see JsonAuthResult.registries).
       // Last write wins on a duplicate scope, matching yaml/CLI.
       registries[scope === '@' ? 'default' : scope] = registry.normalized
@@ -285,9 +284,9 @@ function parseJsonAuth (parsed: unknown, warnings: string[], source: string): Js
 }
 
 /** Parse `_auth` from the global pnpm config yaml (already a parsed object). */
-function readGlobalConfigAuth (globalConfigAuth: unknown, warnings: string[]): JsonAuthResult {
+function readGlobalConfigAuth (globalConfigAuth: unknown): JsonAuthResult {
   if (globalConfigAuth == null) return { auth: {}, registries: {} }
-  return parseJsonAuth(globalConfigAuth, warnings, '_auth')
+  return parseJsonAuth(globalConfigAuth, '_auth')
 }
 
 interface JsonAuthRegistry {
@@ -296,29 +295,25 @@ interface JsonAuthRegistry {
   normalized: string
 }
 
-function parseJsonAuthRegistry (url: string, entryNumber: number, warnings: string[], source: string): JsonAuthRegistry | undefined {
+function parseJsonAuthRegistry (url: string, entryNumber: number, source: string): JsonAuthRegistry {
   const label = jsonAuthRegistryLabel(url, entryNumber)
   let parsed: URL
   try {
     parsed = new URL(url)
   } catch {
-    warnings.push(`${source}[${label}] ignored: key must be an http(s) registry URL.`)
-    return undefined
+    throw new PnpmError('INVALID_AUTH_SETTING', `${source}[${label}]: key must be an http(s) registry URL`)
   }
   if ((parsed.protocol !== 'https:' && parsed.protocol !== 'http:') || parsed.hostname === '') {
-    warnings.push(`${source}[${label}] ignored: key must be an http(s) registry URL.`)
-    return undefined
+    throw new PnpmError('INVALID_AUTH_SETTING', `${source}[${label}]: key must be an http(s) registry URL`)
   }
   if (parsed.username !== '' || parsed.password !== '' || parsed.search !== '' || parsed.hash !== '') {
-    warnings.push(`${source}[${label}] ignored: registry URL must not include credentials, query, or fragment.`)
-    return undefined
+    throw new PnpmError('INVALID_AUTH_SETTING', `${source}[${label}]: registry URL must not include credentials, query, or fragment`)
   }
 
   const normalized = normalizeRegistryUrl(parsed.href)
   const nerfed = nerfDart(normalized)
   if (nerfed === '') {
-    warnings.push(`${source}[${label}] ignored: key must be an http(s) registry URL.`)
-    return undefined
+    throw new PnpmError('INVALID_AUTH_SETTING', `${source}[${label}]: key must be an http(s) registry URL`)
   }
   return { label, nerfed, normalized }
 }
@@ -346,32 +341,26 @@ function isJsonAuthScope (scope: string): boolean {
   return scope === '@' || (scope.startsWith('@') && scope.length > 1 && !scope.includes('/') && !scope.includes(':'))
 }
 
-function appendJsonAuthCreds (
-  result: Record<string, string>,
-  warnings: string[],
+// Validate one scope's credentials and return its `authToken`. Only
+// `authToken` is supported — the deprecated `basicAuth` / `username` +
+// `password` forms (any other field) are rejected, as is a missing or
+// non-string token.
+function jsonAuthToken (
+  creds: Record<string, unknown>,
   registry: JsonAuthRegistry,
   scope: string,
-  creds: Record<string, unknown>,
   source: string
-): boolean {
-  const keyPrefix = `${registry.nerfed}:${scope === '@' ? '' : `${scope}:`}`
-  let accepted = false
-  for (const [field, value] of Object.entries(creds)) {
-    // Only `authToken` is supported. The other npm credential forms
-    // (`_auth`, username + `_password`) are deprecated, so this new
-    // setting deliberately does not introduce them.
+): string {
+  for (const field of Object.keys(creds)) {
     if (field !== 'authToken') {
-      warnings.push(`${source}[${registry.label}][${JSON.stringify(scope)}][${JSON.stringify(field)}] ignored: unsupported auth field (only "authToken" is supported).`)
-      continue
+      throw new PnpmError('INVALID_AUTH_SETTING', `${source}[${registry.label}][${JSON.stringify(scope)}][${JSON.stringify(field)}]: unsupported auth field (only "authToken" is supported)`)
     }
-    if (typeof value !== 'string') {
-      warnings.push(`${source}[${registry.label}][${JSON.stringify(scope)}][${JSON.stringify(field)}] ignored: value must be a string.`)
-      continue
-    }
-    result[`${keyPrefix}_authToken`] = value
-    accepted = true
   }
-  return accepted
+  const token = creds.authToken
+  if (typeof token !== 'string') {
+    throw new PnpmError('INVALID_AUTH_SETTING', `${source}[${registry.label}][${JSON.stringify(scope)}]: "authToken" must be a string`)
+  }
+  return token
 }
 
 // Per-registry rc keys that, when written without a `//host/` prefix, fall

--- a/pnpm11/config/reader/src/loadNpmrcFiles.ts
+++ b/pnpm11/config/reader/src/loadNpmrcFiles.ts
@@ -13,7 +13,7 @@ import { npmDefaults } from './npmDefaults.js'
 export interface NpmrcConfigResult {
   /**
    * Merged auth/registry config from all sources.
-   * Priority (lowest to highest): builtin < defaults < user < auth.ini < workspace < env (//-scoped) < CLI
+   * Priority (lowest to highest): builtin < defaults < user < auth.ini < workspace < env (//-scoped + JSON auth) < CLI
    */
   mergedConfig: Record<string, unknown>
   /** Raw config suitable for pnpmConfig.authConfig (filtered through pickIniConfig by consumer) */
@@ -28,6 +28,25 @@ export interface NpmrcConfigResult {
   localPrefix: string
   /** Warnings generated during loading */
   warnings: string[]
+  /** Parsed `_auth` (env var + global config yaml). See {@link JsonAuthResult}. */
+  jsonAuth: JsonAuthResult
+}
+
+/**
+ * Result of parsing the structured `_auth` value.
+ *
+ * - `auth` — `.npmrc`-shaped URL-scoped keys (`//host/:_authToken`, …)
+ *   ready to merge into the existing auth-config pipeline.
+ * - `registries` — trusted scope→URL routes inferred from the same
+ *   value. `"default"` is set by the `"@"` scope; `"@org"` by a package
+ *   scope. Because both the credential and its destination host arrive
+ *   in one trusted value, repo-controlled `pnpm-workspace.yaml` /
+ *   project `.npmrc` cannot redirect these tokens to a different host.
+ *   Merged above workspace yaml but below CLI flags.
+ */
+export interface JsonAuthResult {
+  auth: Record<string, string>
+  registries: Record<string, string>
 }
 
 export interface LoadNpmrcConfigOpts {
@@ -44,6 +63,12 @@ export interface LoadNpmrcConfigOpts {
   /** Module directory for pnpm builtin rc */
   moduleDirname: string
   env?: Record<string, string | undefined>
+  /**
+   * The `_auth` value read from the **global** pnpm config yaml (the only
+   * file source honored for `_auth`). Project `.npmrc` / `pnpm-workspace.yaml`
+   * must not reach this — repo-controlled config may never supply auth.
+   */
+  globalConfigAuth?: unknown
 }
 
 interface ReadAndFilterNpmrcOptions {
@@ -92,6 +117,18 @@ export function loadNpmrcConfig (opts: LoadNpmrcConfigOpts): NpmrcConfigResult {
   // making them a safe, file-free way to configure registry authentication.
   const envScopedConfig = readUrlScopedEnvConfig(env)
 
+  // Structured `_auth` registry auth from two trusted, non-repo sources:
+  // the `pnpm_config__auth` env var (one JSON object, so it survives CI
+  // runners that silently drop env vars whose names contain `/`, `:`, or
+  // `.` — GitHub Actions, bash, zsh; see pnpm/pnpm#12314) and the `_auth`
+  // key of the global pnpm config yaml. The env var wins on conflict.
+  const envJsonAuth = readJsonAuthEnv(env, warnings)
+  const globalConfigJsonAuth = readGlobalConfigAuth(opts.globalConfigAuth, warnings)
+  const jsonAuth: JsonAuthResult = {
+    auth: { ...globalConfigJsonAuth.auth, ...envJsonAuth.auth },
+    registries: { ...globalConfigJsonAuth.registries, ...envJsonAuth.registries },
+  }
+
   // Read pnpm builtin rc + inline defaults
   const pnpmBuiltinConfig: Record<string, unknown> = {
     ...readAndFilterNpmrc(
@@ -114,9 +151,9 @@ export function loadNpmrcConfig (opts: LoadNpmrcConfigOpts): NpmrcConfigResult {
   ])
 
   // Merge all sources (lowest to highest priority):
-  // builtin < defaults < user < auth.ini < workspace < env (//-scoped) < CLI
+  // builtin < defaults < user < auth.ini < workspace < env (//-scoped + JSON auth) < CLI
   const mergedConfig: Record<string, unknown> = {}
-  for (const source of [pnpmBuiltinConfig, opts.defaultOptions, userConfig, pnpmAuthConfig, workspaceNpmrc, envScopedConfig, cliOptions]) {
+  for (const source of [pnpmBuiltinConfig, opts.defaultOptions, userConfig, pnpmAuthConfig, workspaceNpmrc, envScopedConfig, jsonAuth.auth, cliOptions]) {
     for (const [key, value] of Object.entries(source)) {
       if (isNpmrcReadableKey(key)) {
         mergedConfig[key] = value
@@ -127,7 +164,7 @@ export function loadNpmrcConfig (opts: LoadNpmrcConfigOpts): NpmrcConfigResult {
   // The env-scoped config is trusted (it comes from the environment, not the
   // repository), so it is included here while the workspace .npmrc is not.
   const trustedConfig: Record<string, unknown> = {}
-  for (const source of [pnpmBuiltinConfig, opts.defaultOptions, userConfig, pnpmAuthConfig, envScopedConfig, cliOptions]) {
+  for (const source of [pnpmBuiltinConfig, opts.defaultOptions, userConfig, pnpmAuthConfig, envScopedConfig, jsonAuth.auth, cliOptions]) {
     for (const [key, value] of Object.entries(source)) {
       if (isNpmrcReadableKey(key)) {
         trustedConfig[key] = value
@@ -143,6 +180,7 @@ export function loadNpmrcConfig (opts: LoadNpmrcConfigOpts): NpmrcConfigResult {
     ...pnpmAuthConfig,
     ...workspaceNpmrc,
     ...envScopedConfig,
+    ...jsonAuth.auth,
     ...cliOptions,
   }
 
@@ -154,6 +192,7 @@ export function loadNpmrcConfig (opts: LoadNpmrcConfigOpts): NpmrcConfigResult {
     userConfig,
     localPrefix,
     warnings,
+    jsonAuth,
   }
 }
 
@@ -190,6 +229,149 @@ function readUrlScopedEnvConfig (env: Record<string, string | undefined>): Recor
     target[key] = value
   }
   return { ...npmScoped, ...pnpmScoped }
+}
+
+function readJsonAuthEnv (env: Record<string, string | undefined>, warnings: string[]): JsonAuthResult {
+  const value = readJsonAuthEnvValue(env)
+  if (value == null) return { auth: {}, registries: {} }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch (err: unknown) {
+    warnings.push(`Failed to parse pnpm_config__auth as JSON: ${err instanceof Error ? err.message : String(err)}. Ignored.`)
+    return { auth: {}, registries: {} }
+  }
+  return parseJsonAuth(parsed, warnings, 'pnpm_config__auth')
+}
+
+/**
+ * Parse a URL-keyed `_auth` object into `.npmrc`-shaped flat auth keys plus
+ * the registry routes inferred from each host. Shared by the env var and the
+ * global config yaml; `source` labels warnings.
+ */
+function parseJsonAuth (parsed: unknown, warnings: string[], source: string): JsonAuthResult {
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    warnings.push(`${source} must be a JSON object; got ${Array.isArray(parsed) ? 'array' : parsed === null ? 'null' : typeof parsed}. Ignored.`)
+    return { auth: {}, registries: {} }
+  }
+
+  const auth: Record<string, string> = {}
+  const registries: Record<string, string> = {}
+  for (const [index, [url, scopes]] of Object.entries(parsed as Record<string, unknown>).entries()) {
+    const registry = parseJsonAuthRegistry(url, index + 1, warnings, source)
+    if (registry == null) continue
+    if (scopes === null || typeof scopes !== 'object' || Array.isArray(scopes)) {
+      warnings.push(`${source}[${registry.label}] ignored: value must be an object keyed by scope.`)
+      continue
+    }
+    for (const [scope, rawCreds] of Object.entries(scopes as Record<string, unknown>)) {
+      if (!isJsonAuthScope(scope)) {
+        warnings.push(`${source}[${registry.label}][${JSON.stringify(scope)}] ignored: scope must be "@" or a package scope like "@org".`)
+        continue
+      }
+      if (rawCreds === null || typeof rawCreds !== 'object' || Array.isArray(rawCreds)) {
+        warnings.push(`${source}[${registry.label}][${JSON.stringify(scope)}] ignored: value must be an auth object.`)
+        continue
+      }
+      const acceptedCreds = appendJsonAuthCreds(auth, warnings, registry, scope, rawCreds as Record<string, unknown>, source)
+      if (!acceptedCreds) continue
+      // Infer a registry route from the same entry (see JsonAuthResult.registries).
+      // Last write wins on a duplicate scope, matching yaml/CLI.
+      registries[scope === '@' ? 'default' : scope] = registry.normalized
+    }
+  }
+  return { auth, registries }
+}
+
+/** Parse `_auth` from the global pnpm config yaml (already a parsed object). */
+function readGlobalConfigAuth (globalConfigAuth: unknown, warnings: string[]): JsonAuthResult {
+  if (globalConfigAuth == null) return { auth: {}, registries: {} }
+  return parseJsonAuth(globalConfigAuth, warnings, '_auth')
+}
+
+interface JsonAuthRegistry {
+  label: string
+  nerfed: string
+  normalized: string
+}
+
+function parseJsonAuthRegistry (url: string, entryNumber: number, warnings: string[], source: string): JsonAuthRegistry | undefined {
+  const label = jsonAuthRegistryLabel(url, entryNumber)
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    warnings.push(`${source}[${label}] ignored: key must be an http(s) registry URL.`)
+    return undefined
+  }
+  if ((parsed.protocol !== 'https:' && parsed.protocol !== 'http:') || parsed.hostname === '') {
+    warnings.push(`${source}[${label}] ignored: key must be an http(s) registry URL.`)
+    return undefined
+  }
+  if (parsed.username !== '' || parsed.password !== '' || parsed.search !== '' || parsed.hash !== '') {
+    warnings.push(`${source}[${label}] ignored: registry URL must not include credentials, query, or fragment.`)
+    return undefined
+  }
+
+  const normalized = normalizeRegistryUrl(parsed.href)
+  const nerfed = nerfDart(normalized)
+  if (nerfed === '') {
+    warnings.push(`${source}[${label}] ignored: key must be an http(s) registry URL.`)
+    return undefined
+  }
+  return { label, nerfed, normalized }
+}
+
+function jsonAuthRegistryLabel (url: string, entryNumber: number): string {
+  const entryLabel = `entry ${entryNumber}`
+  try {
+    const parsed = new URL(url)
+    if ((parsed.protocol === 'https:' || parsed.protocol === 'http:') && parsed.hostname !== '') {
+      return `${entryLabel} (${parsed.protocol}//${parsed.host})`
+    }
+  } catch {}
+  return entryLabel
+}
+
+function readJsonAuthEnvValue (env: Record<string, string | undefined>): string | undefined {
+  return env.pnpm_config__auth !== '' && env.pnpm_config__auth != null
+    ? env.pnpm_config__auth
+    : env.PNPM_CONFIG__AUTH !== '' && env.PNPM_CONFIG__AUTH != null
+      ? env.PNPM_CONFIG__AUTH
+      : undefined
+}
+
+function isJsonAuthScope (scope: string): boolean {
+  return scope === '@' || (scope.startsWith('@') && scope.length > 1 && !scope.includes('/') && !scope.includes(':'))
+}
+
+function appendJsonAuthCreds (
+  result: Record<string, string>,
+  warnings: string[],
+  registry: JsonAuthRegistry,
+  scope: string,
+  creds: Record<string, unknown>,
+  source: string
+): boolean {
+  const keyPrefix = `${registry.nerfed}:${scope === '@' ? '' : `${scope}:`}`
+  let accepted = false
+  for (const [field, value] of Object.entries(creds)) {
+    // Only `authToken` is supported. The other npm credential forms
+    // (`_auth`, username + `_password`) are deprecated, so this new
+    // setting deliberately does not introduce them.
+    if (field !== 'authToken') {
+      warnings.push(`${source}[${registry.label}][${JSON.stringify(scope)}][${JSON.stringify(field)}] ignored: unsupported auth field (only "authToken" is supported).`)
+      continue
+    }
+    if (typeof value !== 'string') {
+      warnings.push(`${source}[${registry.label}][${JSON.stringify(scope)}][${JSON.stringify(field)}] ignored: value must be a string.`)
+      continue
+    }
+    result[`${keyPrefix}_authToken`] = value
+    accepted = true
+  }
+  return accepted
 }
 
 // Per-registry rc keys that, when written without a `//host/` prefix, fall

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -1580,6 +1580,27 @@ test('pnpm_config__auth "@" scope routes the default registry to its host', asyn
   expect(config.authConfig['//my-npm-proxy.example/:_authToken']).toBe('proxy-token')
 })
 
+test('pnpm_config__auth keeps the last duplicate route in source order', async () => {
+  prepareEmpty()
+
+  // Two hosts both route the default registry; the source-last entry wins
+  // (object iteration order), listed reverse-alphabetically so an
+  // order-insensitive implementation would pick the wrong host.
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://zzz.example': { '@': { authToken: 'z' } },
+        'https://aaa.example': { '@': { authToken: 'a' } },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.registries.default).toBe('https://aaa.example/')
+})
+
 test('pnpm_config__auth scoped entry routes that scope to its host', async () => {
   prepareEmpty()
 

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -1281,33 +1281,20 @@ test('host-keyed pnpm_config__auth supports scoped tokens on a shared host', asy
 
 test('host-keyed pnpm_config__auth rejects deprecated basic-auth fields', async () => {
   prepareEmpty()
-  const basicAuth = Buffer.from('user:pass').toString('base64')
-  const password = Buffer.from('pass').toString('base64')
 
-  const { config, warnings } = await getConfig({
+  // Only `authToken` is supported; a deprecated field is a hard error.
+  await expect(getConfig({
     cliOptions: {},
     env: {
       ...env,
       pnpm_config__auth: JSON.stringify({
         'https://json-test.example': {
-          '@': {
-            basicAuth,
-            username: 'user',
-            password,
-          },
+          '@': { basicAuth: 'any-value' },
         },
       }),
     },
     packageManager: { name: 'pnpm', version: '1.0.0' },
-  })
-
-  // Only `authToken` is supported; the deprecated forms are dropped with a warning.
-  expect(config.authConfig['//json-test.example/:_auth']).toBeUndefined()
-  expect(config.authConfig['//json-test.example/:username']).toBeUndefined()
-  expect(config.authConfig['//json-test.example/:_password']).toBeUndefined()
-  for (const field of ['basicAuth', 'username', 'password']) {
-    expect(warnings.some(w => w.includes(field) && w.includes('only "authToken" is supported'))).toBe(true)
-  }
+  })).rejects.toThrow('only "authToken" is supported')
 })
 
 test('pnpm_config__auth token overrides a project .npmrc token for the same host', async () => {
@@ -1380,198 +1367,87 @@ test('repo registry config cannot redirect pnpm_config__auth tokens', async () =
   expect(config.authConfig['//registry.npmjs.org/:@victim-scope:_authToken']).toBe('secret-token')
 })
 
-test('host entry that is not a scope object is rejected with a warning', async () => {
+async function expectAuthError (auth: unknown): Promise<Error> {
+  let error: Error | undefined
+  try {
+    await getConfig({
+      cliOptions: {},
+      env: { ...env, pnpm_config__auth: typeof auth === 'string' ? auth : JSON.stringify(auth) },
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+    })
+  } catch (err: unknown) {
+    error = err as Error
+  }
+  expect(error).toBeDefined()
+  return error!
+}
+
+test('host entry that is not a scope object aborts the load', async () => {
   prepareEmpty()
-
-  const { warnings } = await getConfig({
-    cliOptions: {},
-    env: {
-      ...env,
-      pnpm_config__auth: JSON.stringify({
-        'https://json-test.example': 123,
-      }),
-    },
-    packageManager: { name: 'pnpm', version: '1.0.0' },
-  })
-
-  expect(warnings.some(w => w.includes('entry 1 (https://json-test.example)') && w.includes('object keyed by scope'))).toBe(true)
+  const error = await expectAuthError({ 'https://json-test.example': 123 })
+  expect(error.message).toContain('object keyed by scope')
 })
 
-test('pnpm_config__auth invalid registry URL key is rejected with a warning', async () => {
+test('pnpm_config__auth invalid registry URL key aborts the load without leaking the key', async () => {
   prepareEmpty()
-
-  const { config, warnings } = await getConfig({
-    cliOptions: {},
-    env: {
-      ...env,
-      pnpm_config__auth: JSON.stringify({
-        'not a url': {
-          '@': { authToken: 'token' },
-        },
-      }),
-    },
-    packageManager: { name: 'pnpm', version: '1.0.0' },
-  })
-
-  expect(Object.values(config.authConfig).filter(v => v === 'token')).toHaveLength(0)
-  expect(warnings.some(w => w.includes('entry 1') && w.includes('registry URL'))).toBe(true)
-  expect(warnings.some(w => w.includes('not a url'))).toBe(false)
+  const error = await expectAuthError({ 'not a url': { '@': { authToken: 'token' } } })
+  expect(error.message).toContain('registry URL')
+  expect(error.message).not.toContain('not a url')
 })
 
-test('pnpm_config__auth registry URL with credentials or query is rejected without leaking secrets', async () => {
+test('pnpm_config__auth registry URL with credentials or query aborts the load without leaking secrets', async () => {
   prepareEmpty()
-
-  const { config, warnings } = await getConfig({
-    cliOptions: {},
-    env: {
-      ...env,
-      pnpm_config__auth: JSON.stringify({
-        'https://user:secret-password@json-test.example?token=leaky-token#fragment': {
-          '@': { authToken: 'token' },
-        },
-      }),
+  const error = await expectAuthError({
+    'https://user:secret-password@json-test.example?token=leaky-token#fragment': {
+      '@': { authToken: 'token' },
     },
-    packageManager: { name: 'pnpm', version: '1.0.0' },
   })
-
-  expect(config.authConfig['//json-test.example/:_authToken']).toBeUndefined()
-  expect(config.registries.default).toBe('https://registry.npmjs.org/')
-  const warning = warnings.find(w => w.includes('credentials, query, or fragment'))
-  expect(warning).toContain('entry 1 (https://json-test.example)')
-  expect(warning).not.toContain('secret-password')
-  expect(warning).not.toContain('leaky-token')
+  expect(error.message).toContain('must not include credentials, query, or fragment')
+  expect(error.message).not.toContain('secret-password')
+  expect(error.message).not.toContain('leaky-token')
 })
 
-test('pnpm_config__auth invalid scope name is rejected with a warning', async () => {
+test('pnpm_config__auth invalid scope name aborts the load', async () => {
   prepareEmpty()
-
-  const { warnings } = await getConfig({
-    cliOptions: {},
-    env: {
-      ...env,
-      pnpm_config__auth: JSON.stringify({
-        'https://json-test.example': {
-          org: { authToken: 'token' },
-        },
-      }),
-    },
-    packageManager: { name: 'pnpm', version: '1.0.0' },
-  })
-
-  expect(warnings.some(w => w.includes('org') && w.includes('scope must be'))).toBe(true)
+  const error = await expectAuthError({ 'https://json-test.example': { org: { authToken: 'token' } } })
+  expect(error.message).toContain('scope must be')
 })
 
-test('pnpm_config__auth scope value that is not an auth object is rejected with a warning', async () => {
+test('pnpm_config__auth scope value that is not an auth object aborts the load', async () => {
   prepareEmpty()
-
-  const { config, warnings } = await getConfig({
-    cliOptions: {},
-    env: {
-      ...env,
-      pnpm_config__auth: JSON.stringify({
-        'https://json-test.example': {
-          '@': 'token',
-        },
-      }),
-    },
-    packageManager: { name: 'pnpm', version: '1.0.0' },
-  })
-
-  expect(config.authConfig['//json-test.example/:_authToken']).toBeUndefined()
-  expect(warnings.some(w => w.includes('entry 1 (https://json-test.example)') && w.includes('value must be an auth object'))).toBe(true)
+  const error = await expectAuthError({ 'https://json-test.example': { '@': 'token' } })
+  expect(error.message).toContain('must be an auth object')
 })
 
-test('pnpm_config__auth non-string auth field value warns and is dropped', async () => {
+test('pnpm_config__auth non-string auth token aborts the load', async () => {
   prepareEmpty()
-
-  const { config, warnings } = await getConfig({
-    cliOptions: {},
-    env: {
-      ...env,
-      pnpm_config__auth: JSON.stringify({
-        'https://json-test.example': {
-          '@': { authToken: 123 },
-        },
-      }),
-    },
-    packageManager: { name: 'pnpm', version: '1.0.0' },
-  })
-
-  expect(config.authConfig['//json-test.example/:_authToken']).toBeUndefined()
-  expect(warnings.some(w => w.includes('authToken') && w.includes('must be a string'))).toBe(true)
+  const error = await expectAuthError({ 'https://json-test.example': { '@': { authToken: 123 } } })
+  expect(error.message).toContain('"authToken" must be a string')
 })
 
-test('pnpm_config__auth unsupported auth field warns and is dropped', async () => {
+test('pnpm_config__auth unsupported auth field aborts the load', async () => {
   prepareEmpty()
-
-  const { config, warnings } = await getConfig({
-    cliOptions: {},
-    env: {
-      ...env,
-      pnpm_config__auth: JSON.stringify({
-        'https://json-test.example': {
-          '@': { tokenHelper: '/bin/echo' },
-        },
-      }),
-    },
-    packageManager: { name: 'pnpm', version: '1.0.0' },
-  })
-
-  expect(config.authConfig['//json-test.example/:tokenHelper']).toBeUndefined()
-  expect(warnings.some(w => w.includes('tokenHelper') && w.includes('unsupported'))).toBe(true)
+  const error = await expectAuthError({ 'https://json-test.example': { '@': { tokenHelper: '/bin/echo' } } })
+  expect(error.message).toContain('only "authToken" is supported')
 })
 
-test('pnpm_config__auth inherited property names like toString are rejected', async () => {
+test('pnpm_config__auth own property names like toString are rejected', async () => {
   prepareEmpty()
-
-  const { config, warnings } = await getConfig({
-    cliOptions: {},
-    env: {
-      ...env,
-      pnpm_config__auth: JSON.stringify({
-        'https://json-test.example': {
-          '@': { toString: 'sneaky-token' },
-        },
-      }),
-    },
-    packageManager: { name: 'pnpm', version: '1.0.0' },
-  })
-
-  expect(config.authConfig['//json-test.example/:_authToken']).toBeUndefined()
-  expect(warnings.some(w => w.includes('toString') && w.includes('unsupported'))).toBe(true)
+  const error = await expectAuthError({ 'https://json-test.example': { '@': { toString: 'sneaky-token' } } })
+  expect(error.message).toContain('only "authToken" is supported')
 })
 
-test('malformed pnpm_config__auth JSON produces a warning and does not crash', async () => {
+test('malformed pnpm_config__auth JSON aborts the load', async () => {
   prepareEmpty()
-
-  const { config, warnings } = await getConfig({
-    cliOptions: {},
-    env: {
-      ...env,
-      pnpm_config__auth: '{ not valid json',
-    },
-    packageManager: { name: 'pnpm', version: '1.0.0' },
-  })
-
-  expect(warnings.some((w: string) => w.includes('Failed to parse pnpm_config__auth'))).toBe(true)
-  expect(config.authConfig['//json-test.example/:_authToken']).toBeUndefined()
+  const error = await expectAuthError('{ not valid json')
+  expect(error.message).toContain('Failed to parse pnpm_config__auth')
 })
 
-test('a non-object pnpm_config__auth value is rejected with a warning', async () => {
+test('a non-object pnpm_config__auth value aborts the load', async () => {
   prepareEmpty()
-
-  // Arrays and primitives are rejected — arrays would expose their indices
-  // as keys, and primitives have no entries at all.
-  const { warnings } = await getConfig({
-    cliOptions: {},
-    env: {
-      ...env,
-      pnpm_config__auth: JSON.stringify(['//json-test.example/:_authToken', 'sneaky-token']),
-    },
-    packageManager: { name: 'pnpm', version: '1.0.0' },
-  })
-
-  expect(warnings.some((w: string) => w.includes('must be a JSON object'))).toBe(true)
+  // Arrays would expose their indices as keys; primitives have no entries.
+  const error = await expectAuthError(['//json-test.example/:_authToken', 'sneaky-token'])
+  expect(error.message).toContain('must be a JSON object')
 })
 
 test('PNPM_CONFIG__AUTH (all-caps) form is also honored', async () => {
@@ -1880,28 +1756,16 @@ test('CLI scoped registry overrides pnpm_config__auth in packageManagerRegistrie
   expect(config.authConfig['//cli-registry.example/:@org:_authToken']).toBeUndefined()
 })
 
-test('pnpm_config__auth does not infer registry routes from invalid auth objects', async () => {
+test('pnpm_config__auth invalid auth object aborts the load (no partial routing)', async () => {
   prepareEmpty()
 
-  const { config, warnings } = await getConfig({
-    cliOptions: {},
-    env: {
-      ...env,
-      pnpm_config__auth: JSON.stringify({
-        'https://private.example': {
-          '@': { tokenAuth: 'typo-token' },
-          '@org': { authToken: 123 },
-        },
-      }),
+  const error = await expectAuthError({
+    'https://private.example': {
+      '@': { tokenAuth: 'typo-token' },
+      '@org': { authToken: 123 },
     },
-    packageManager: { name: 'pnpm', version: '1.0.0' },
   })
-
-  expect(config.registries.default).toBe('https://registry.npmjs.org/')
-  expect(config.registries['@org']).toBeUndefined()
-  expect(config.packageManagerRegistries?.['@org']).toBeUndefined()
-  expect(warnings.some(w => w.includes('tokenAuth') && w.includes('unsupported'))).toBe(true)
-  expect(warnings.some(w => w.includes('authToken') && w.includes('must be a string'))).toBe(true)
+  expect(error.message).toContain('only "authToken" is supported')
 })
 
 test('workspace .npmrc overrides pnpm auth file', async () => {
@@ -1986,17 +1850,14 @@ test('pnpm_config__auth env wins over global yaml _auth on the same key', async 
   expect(config.authConfig['//json-test.example/:_authToken']).toBe('env-token')
 })
 
-test('a malformed global yaml _auth value warns and is ignored', async () => {
+test('a malformed global yaml _auth value aborts the load', async () => {
   prepareEmpty()
 
-  const { config, warnings } = await getConfigWithGlobalYaml({
+  await expect(getConfigWithGlobalYaml({
     _auth: {
       'https://json-test.example': 123,
     },
-  })
-
-  expect(config.authConfig['//json-test.example/:_authToken']).toBeUndefined()
-  expect(warnings.some(w => w.includes('_auth[entry 1 (https://json-test.example)') && w.includes('object keyed by scope'))).toBe(true)
+  })).rejects.toThrow('object keyed by scope')
 })
 
 test('_auth in a project pnpm-workspace.yaml is ignored (not honored as registry auth)', async () => {

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -1219,6 +1219,691 @@ test('URL-scoped env vars honor non-token credential fields and ignore non-URL k
   expect(config.authConfig['always-auth']).toBeUndefined()
 })
 
+test('reads a host-keyed default auth token from pnpm_config__auth', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://json-test.example': {
+          '@': { authToken: 'json-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.authConfig['//json-test.example/:_authToken']).toBe('json-token')
+})
+
+test('pnpm_config__auth normalizes registry URL keys before keying auth', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'HTTPS://JSON-Test.Example:443': {
+          '@': { authToken: 'json-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.authConfig['//json-test.example/:_authToken']).toBe('json-token')
+  expect(config.registries.default).toBe('https://json-test.example/')
+})
+
+test('host-keyed pnpm_config__auth supports scoped tokens on a shared host', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://npm.pkg.github.com': {
+          '@org-a': { authToken: 'org-a-token' },
+          '@org-b': { authToken: 'org-b-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.authConfig['//npm.pkg.github.com/:@org-a:_authToken']).toBe('org-a-token')
+  expect(config.authConfig['//npm.pkg.github.com/:@org-b:_authToken']).toBe('org-b-token')
+})
+
+test('host-keyed pnpm_config__auth rejects deprecated basic-auth fields', async () => {
+  prepareEmpty()
+  const basicAuth = Buffer.from('user:pass').toString('base64')
+  const password = Buffer.from('pass').toString('base64')
+
+  const { config, warnings } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://json-test.example': {
+          '@': {
+            basicAuth,
+            username: 'user',
+            password,
+          },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  // Only `authToken` is supported; the deprecated forms are dropped with a warning.
+  expect(config.authConfig['//json-test.example/:_auth']).toBeUndefined()
+  expect(config.authConfig['//json-test.example/:username']).toBeUndefined()
+  expect(config.authConfig['//json-test.example/:_password']).toBeUndefined()
+  for (const field of ['basicAuth', 'username', 'password']) {
+    expect(warnings.some(w => w.includes(field) && w.includes('only "authToken" is supported'))).toBe(true)
+  }
+})
+
+test('pnpm_config__auth token overrides a project .npmrc token for the same host', async () => {
+  prepareEmpty()
+
+  fs.writeFileSync('.npmrc', '//json-test.example/:_authToken=workspace-token', 'utf8')
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://json-test.example': {
+          '@': { authToken: 'env-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.authConfig['//json-test.example/:_authToken']).toBe('env-token')
+})
+
+test('a CLI-provided token overrides the same key from pnpm_config__auth', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfig({
+    cliOptions: {
+      '//json-test.example/:_authToken': 'cli-token',
+    },
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://json-test.example': {
+          '@': { authToken: 'env-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.authConfig['//json-test.example/:_authToken']).toBe('cli-token')
+})
+
+test('repo registry config cannot redirect pnpm_config__auth tokens', async () => {
+  prepareEmpty()
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    registries: {
+      '@victim-scope': 'https://attacker.example/',
+    },
+  })
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://registry.npmjs.org': {
+          '@victim-scope': { authToken: 'secret-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+    workspaceDir: process.cwd(),
+  })
+
+  expect(config.authConfig['//attacker.example/:_authToken']).toBeUndefined()
+  expect(config.authConfig['//attacker.example/:@victim-scope:_authToken']).toBeUndefined()
+  expect(config.authConfig['//registry.npmjs.org/:@victim-scope:_authToken']).toBe('secret-token')
+})
+
+test('host entry that is not a scope object is rejected with a warning', async () => {
+  prepareEmpty()
+
+  const { warnings } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://json-test.example': 123,
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(warnings.some(w => w.includes('entry 1 (https://json-test.example)') && w.includes('object keyed by scope'))).toBe(true)
+})
+
+test('pnpm_config__auth invalid registry URL key is rejected with a warning', async () => {
+  prepareEmpty()
+
+  const { config, warnings } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'not a url': {
+          '@': { authToken: 'token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(Object.values(config.authConfig).filter(v => v === 'token')).toHaveLength(0)
+  expect(warnings.some(w => w.includes('entry 1') && w.includes('registry URL'))).toBe(true)
+  expect(warnings.some(w => w.includes('not a url'))).toBe(false)
+})
+
+test('pnpm_config__auth registry URL with credentials or query is rejected without leaking secrets', async () => {
+  prepareEmpty()
+
+  const { config, warnings } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://user:secret-password@json-test.example?token=leaky-token#fragment': {
+          '@': { authToken: 'token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.authConfig['//json-test.example/:_authToken']).toBeUndefined()
+  expect(config.registries.default).toBe('https://registry.npmjs.org/')
+  const warning = warnings.find(w => w.includes('credentials, query, or fragment'))
+  expect(warning).toContain('entry 1 (https://json-test.example)')
+  expect(warning).not.toContain('secret-password')
+  expect(warning).not.toContain('leaky-token')
+})
+
+test('pnpm_config__auth invalid scope name is rejected with a warning', async () => {
+  prepareEmpty()
+
+  const { warnings } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://json-test.example': {
+          org: { authToken: 'token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(warnings.some(w => w.includes('org') && w.includes('scope must be'))).toBe(true)
+})
+
+test('pnpm_config__auth scope value that is not an auth object is rejected with a warning', async () => {
+  prepareEmpty()
+
+  const { config, warnings } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://json-test.example': {
+          '@': 'token',
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.authConfig['//json-test.example/:_authToken']).toBeUndefined()
+  expect(warnings.some(w => w.includes('entry 1 (https://json-test.example)') && w.includes('value must be an auth object'))).toBe(true)
+})
+
+test('pnpm_config__auth non-string auth field value warns and is dropped', async () => {
+  prepareEmpty()
+
+  const { config, warnings } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://json-test.example': {
+          '@': { authToken: 123 },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.authConfig['//json-test.example/:_authToken']).toBeUndefined()
+  expect(warnings.some(w => w.includes('authToken') && w.includes('must be a string'))).toBe(true)
+})
+
+test('pnpm_config__auth unsupported auth field warns and is dropped', async () => {
+  prepareEmpty()
+
+  const { config, warnings } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://json-test.example': {
+          '@': { tokenHelper: '/bin/echo' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.authConfig['//json-test.example/:tokenHelper']).toBeUndefined()
+  expect(warnings.some(w => w.includes('tokenHelper') && w.includes('unsupported'))).toBe(true)
+})
+
+test('pnpm_config__auth inherited property names like toString are rejected', async () => {
+  prepareEmpty()
+
+  const { config, warnings } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://json-test.example': {
+          '@': { toString: 'sneaky-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.authConfig['//json-test.example/:_authToken']).toBeUndefined()
+  expect(warnings.some(w => w.includes('toString') && w.includes('unsupported'))).toBe(true)
+})
+
+test('malformed pnpm_config__auth JSON produces a warning and does not crash', async () => {
+  prepareEmpty()
+
+  const { config, warnings } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: '{ not valid json',
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(warnings.some((w: string) => w.includes('Failed to parse pnpm_config__auth'))).toBe(true)
+  expect(config.authConfig['//json-test.example/:_authToken']).toBeUndefined()
+})
+
+test('a non-object pnpm_config__auth value is rejected with a warning', async () => {
+  prepareEmpty()
+
+  // Arrays and primitives are rejected — arrays would expose their indices
+  // as keys, and primitives have no entries at all.
+  const { warnings } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify(['//json-test.example/:_authToken', 'sneaky-token']),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(warnings.some((w: string) => w.includes('must be a JSON object'))).toBe(true)
+})
+
+test('PNPM_CONFIG__AUTH (all-caps) form is also honored', async () => {
+  prepareEmpty()
+
+  // Both forms are accepted — `pnpm_config__auth` (documented) and
+  // `PNPM_CONFIG__AUTH` (the all-caps shell convention some CI runners
+  // apply). Mirrors `readEnvVar`'s two-form lookup shape.
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      PNPM_CONFIG__AUTH: JSON.stringify({
+        'https://json-test.example': {
+          '@': { authToken: 'upper-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.authConfig['//json-test.example/:_authToken']).toBe('upper-token')
+})
+
+test('pnpm_config__auth wins over PNPM_CONFIG__AUTH when both are set', async () => {
+  prepareEmpty()
+
+  // The documented lowercase form wins when both are set, mirroring
+  // `readEnvVar`'s lookup order.
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://json-test.example': {
+          '@': { authToken: 'lower-token' },
+        },
+      }),
+      PNPM_CONFIG__AUTH: JSON.stringify({
+        'https://json-test.example': {
+          '@': { authToken: 'upper-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.authConfig['//json-test.example/:_authToken']).toBe('lower-token')
+})
+
+test('empty or unset pnpm_config__auth is a no-op', async () => {
+  prepareEmpty()
+
+  // Unset.
+  const { config: configUnset, warnings: warningsUnset } = await getConfig({
+    cliOptions: {},
+    env: { ...env },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+  expect(warningsUnset.some(w => w.includes('pnpm_config__auth'))).toBe(false)
+  expect(Object.keys(configUnset.authConfig).filter(k => k.startsWith('//json-test'))).toHaveLength(0)
+
+  // Set but empty string.
+  const { config: configEmpty, warnings: warningsEmpty } = await getConfig({
+    cliOptions: {},
+    env: { ...env, pnpm_config__auth: '' },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+  expect(warningsEmpty.some(w => w.includes('pnpm_config__auth'))).toBe(false)
+  expect(Object.keys(configEmpty.authConfig).filter(k => k.startsWith('//json-test'))).toHaveLength(0)
+})
+
+test('empty lowercase pnpm_config__auth falls back to PNPM_CONFIG__AUTH', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: '',
+      PNPM_CONFIG__AUTH: JSON.stringify({
+        'https://json-test.example': {
+          '@': { authToken: 'upper-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.authConfig['//json-test.example/:_authToken']).toBe('upper-token')
+})
+
+test('host-keyed pnpm_config__auth flows through to configByUri', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://npm.pkg.github.com': {
+          '@org-a': { authToken: 'org-a-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.configByUri?.['//npm.pkg.github.com/']?.['@org-a']?.authToken).toBe('org-a-token')
+})
+
+test('pnpm_config__auth "@" scope routes the default registry to its host', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://my-npm-proxy.example': {
+          '@': { authToken: 'proxy-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.registries.default).toBe('https://my-npm-proxy.example/')
+  expect(config.registry).toBe('https://my-npm-proxy.example/')
+  expect(config.authConfig['//my-npm-proxy.example/:_authToken']).toBe('proxy-token')
+})
+
+test('pnpm_config__auth scoped entry routes that scope to its host', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://npm.pkg.github.com': {
+          '@org': { authToken: 'org-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.registries['@org']).toBe('https://npm.pkg.github.com/')
+})
+
+test('pnpm_config__auth env default registry wins over pnpm-workspace.yaml default', async () => {
+  prepareEmpty()
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    registries: {
+      default: 'https://workspace-registry.example/',
+    },
+  })
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://my-npm-proxy.example': {
+          '@': { authToken: 'proxy-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+    workspaceDir: process.cwd(),
+  })
+
+  expect(config.registries.default).toBe('https://my-npm-proxy.example/')
+  expect(config.registry).toBe('https://my-npm-proxy.example/')
+})
+
+test('pnpm_config__auth env scoped registry wins over pnpm-workspace.yaml scoped registry', async () => {
+  prepareEmpty()
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    registries: {
+      '@victim-scope': 'https://attacker.example/',
+    },
+  })
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://registry.npmjs.org': {
+          '@victim-scope': { authToken: 'secret-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+    workspaceDir: process.cwd(),
+  })
+
+  expect(config.registries['@victim-scope']).toBe('https://registry.npmjs.org/')
+  expect(config.authConfig['//attacker.example/:_authToken']).toBeUndefined()
+  expect(config.authConfig['//attacker.example/:@victim-scope:_authToken']).toBeUndefined()
+  expect(config.authConfig['//registry.npmjs.org/:@victim-scope:_authToken']).toBe('secret-token')
+})
+
+test('pnpm_config__auth scoped registry wins over user .npmrc scoped registry', async () => {
+  prepareEmpty()
+
+  const userHome = path.resolve('user-home')
+  fs.mkdirSync(userHome, { recursive: true })
+  fs.writeFileSync(path.resolve(userHome, '.npmrc'), '@org:registry=https://user.example/', 'utf8')
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      PNPM_CONFIG_USERCONFIG: path.resolve(userHome, '.npmrc'),
+      pnpm_config__auth: JSON.stringify({
+        'https://env.example': {
+          '@org': { authToken: 'env-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.registries['@org']).toBe('https://env.example/')
+  expect(config.packageManagerRegistries?.['@org']).toBe('https://env.example/')
+})
+
+test('CLI --registry overrides pnpm_config__auth default registry routing', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfig({
+    cliOptions: {
+      registry: 'https://cli-registry.example/',
+    },
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://my-npm-proxy.example': {
+          '@': { authToken: 'proxy-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.registries.default).toBe('https://cli-registry.example/')
+  expect(config.registry).toBe('https://cli-registry.example/')
+  expect(config.packageManagerRegistries?.default).toBe('https://cli-registry.example/')
+  // The token is still pinned to the env-declared host.
+  expect(config.authConfig['//my-npm-proxy.example/:_authToken']).toBe('proxy-token')
+  expect(config.authConfig['//cli-registry.example/:_authToken']).toBeUndefined()
+})
+
+test('pnpm_config__auth inferred registries flow through to packageManagerRegistries', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://my-npm-proxy.example': {
+          '@': { authToken: 'proxy-token' },
+          '@org': { authToken: 'org-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.packageManagerRegistries?.default).toBe('https://my-npm-proxy.example/')
+  expect(config.packageManagerRegistries?.['@org']).toBe('https://my-npm-proxy.example/')
+  expect(config.packageManagerNetworkConfig?.configByUri['//my-npm-proxy.example/']).toMatchObject({
+    '@': { authToken: 'proxy-token' },
+    '@org': { authToken: 'org-token' },
+  })
+})
+
+test('CLI scoped registry overrides pnpm_config__auth in packageManagerRegistries', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfig({
+    cliOptions: {
+      '@org:registry': 'https://cli-registry.example',
+    },
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://my-npm-proxy.example': {
+          '@org': { authToken: 'org-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.registries['@org']).toBe('https://cli-registry.example/')
+  expect(config.packageManagerRegistries?.['@org']).toBe('https://cli-registry.example/')
+  // The token stays pinned to the env-declared host, not the CLI override host.
+  expect(config.authConfig['//my-npm-proxy.example/:@org:_authToken']).toBe('org-token')
+  expect(config.authConfig['//cli-registry.example/:@org:_authToken']).toBeUndefined()
+})
+
+test('pnpm_config__auth does not infer registry routes from invalid auth objects', async () => {
+  prepareEmpty()
+
+  const { config, warnings } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://private.example': {
+          '@': { tokenAuth: 'typo-token' },
+          '@org': { authToken: 123 },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.registries.default).toBe('https://registry.npmjs.org/')
+  expect(config.registries['@org']).toBeUndefined()
+  expect(config.packageManagerRegistries?.['@org']).toBeUndefined()
+  expect(warnings.some(w => w.includes('tokenAuth') && w.includes('unsupported'))).toBe(true)
+  expect(warnings.some(w => w.includes('authToken') && w.includes('must be a string'))).toBe(true)
+})
+
 test('workspace .npmrc overrides pnpm auth file', async () => {
   prepareEmpty()
 
@@ -1257,6 +1942,110 @@ test('workspace .npmrc overrides pnpm auth file', async () => {
     }
   }
 })
+
+test('_auth from the global config yaml configures registry auth and routing', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfigWithGlobalYaml({
+    _auth: {
+      'https://json-test.example': {
+        '@': { authToken: 'yaml-token' },
+        '@org': { authToken: 'org-yaml-token' },
+      },
+    },
+  })
+
+  expect(config.authConfig['//json-test.example/:_authToken']).toBe('yaml-token')
+  expect(config.authConfig['//json-test.example/:@org:_authToken']).toBe('org-yaml-token')
+  expect(config.registries.default).toBe('https://json-test.example/')
+  expect(config.registries['@org']).toBe('https://json-test.example/')
+})
+
+test('pnpm_config__auth env wins over global yaml _auth on the same key', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfigWithGlobalYaml(
+    {
+      _auth: {
+        'https://json-test.example': {
+          '@': { authToken: 'yaml-token' },
+        },
+      },
+    },
+    {
+      env: {
+        pnpm_config__auth: JSON.stringify({
+          'https://json-test.example': {
+            '@': { authToken: 'env-token' },
+          },
+        }),
+      },
+    }
+  )
+
+  expect(config.authConfig['//json-test.example/:_authToken']).toBe('env-token')
+})
+
+test('a malformed global yaml _auth value warns and is ignored', async () => {
+  prepareEmpty()
+
+  const { config, warnings } = await getConfigWithGlobalYaml({
+    _auth: {
+      'https://json-test.example': 123,
+    },
+  })
+
+  expect(config.authConfig['//json-test.example/:_authToken']).toBeUndefined()
+  expect(warnings.some(w => w.includes('_auth[entry 1 (https://json-test.example)') && w.includes('object keyed by scope'))).toBe(true)
+})
+
+test('_auth in a project pnpm-workspace.yaml is ignored (not honored as registry auth)', async () => {
+  prepareEmpty()
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    _auth: {
+      'https://attacker.example': {
+        '@': { authToken: 'attacker-token' },
+      },
+    },
+  })
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env,
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+    workspaceDir: process.cwd(),
+  })
+
+  expect(config.authConfig['//attacker.example/:_authToken']).toBeUndefined()
+  expect(config.registries.default).not.toBe('https://attacker.example/')
+})
+
+async function getConfigWithGlobalYaml (
+  globalConfigYaml: Record<string, unknown>,
+  opts: { cliOptions?: Record<string, unknown>, env?: Record<string, string | undefined>, workspaceDir?: string } = {}
+) {
+  const configHome = path.resolve('xdg-config')
+  fs.mkdirSync(path.join(configHome, 'pnpm'), { recursive: true })
+  writeYamlFileSync(path.join(configHome, 'pnpm', 'config.yaml'), globalConfigYaml)
+  const originalXdg = process.env.XDG_CONFIG_HOME
+  process.env.XDG_CONFIG_HOME = configHome
+  try {
+    const { config, warnings } = await getConfig({
+      cliOptions: opts.cliOptions ?? {},
+      env: { ...env, ...opts.env, XDG_CONFIG_HOME: configHome },
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: opts.workspaceDir,
+    })
+    return { config, warnings }
+  } finally {
+    if (originalXdg != null) {
+      process.env.XDG_CONFIG_HOME = originalXdg
+    } else {
+      delete process.env.XDG_CONFIG_HOME
+    }
+  }
+}
 
 describe('unresolved ${VAR} placeholders in .npmrc auth values', () => {
   // Regression suite for https://github.com/pnpm/pnpm/issues/11513: actions/setup-node


### PR DESCRIPTION
## Summary

Adds an `_auth` setting that configures registry authentication as a single structured (URL-keyed) value, instead of many `//host/:_authToken=…` keys. It can be set in two trusted places:

- the **global** pnpm config (`config.yaml`), as a native YAML map, and
- the `pnpm_config__auth` environment variable, as a JSON string — the CI-friendly form, since GitHub Actions / bash / zsh silently drop env vars whose names contain `/`, `:`, or `.` (which broke the old `pnpm_config_//host/:_authToken=…` form on CI).

`_auth` is **never** read from a project `.npmrc` / `pnpm-workspace.yaml`, so repository-controlled config can never supply registry credentials. (npm's deprecated `.npmrc` `_auth` scalar keeps its legacy meaning there — no collision, because pnpm only reads the structured `_auth` from its own yaml and the env projection.)

Example env form:

```sh
export pnpm_config__auth='{"https://registry.npmjs.org":{"@":{"authToken":"npm-token"},"@org":{"authToken":"org-token"}}}'
```

Equivalent in the global `config.yaml`:

```yaml
_auth:
  https://registry.npmjs.org:
    '@':
      authToken: npm-token
    '@org':
      authToken: org-token
```

- The value is keyed by registry URL, so each secret is explicitly bound to the host that may receive it. URL keys must use `http` or `https` and must not include credentials, query strings, or fragments.
- Within each registry URL, `@` means registry-wide/default credentials and package scopes like `@org` bind credentials to that scope on the same host.
- The only supported credential field is `authToken` (maps to `//host/:_authToken` / bearer auth). The deprecated `basicAuth` / `username` + `password` forms are intentionally not accepted in this new setting and are dropped with a warning; `tokenHelper` is likewise unsupported (executable paths must not come from this setting).
- Each accepted entry also infers a trusted registry route: `@` routes the default registry and `@org` routes that scope. Because the credential and its destination host arrive in one trusted value, repo-controlled config cannot redirect the token to a different host.
- Precedence: CLI flags (`--registry`, `--@scope:registry`) > `pnpm_config__auth` > global `config.yaml` `_auth` > `pnpm-workspace.yaml`. The env var wins over the global `config.yaml` on a conflicting key.
- Both `pnpm_config__auth` (lowercase, documented) and `PNPM_CONFIG__AUTH` (all-caps shell convention) are honored; lowercase wins unless empty.
- Reusing the `_auth` name means the value is already covered by the existing protected-settings redaction, so it prints as `(protected)` in `pnpm config list`.
- Lands on both stacks (TS CLI + pacquet) per the cardinal rule.

Closes pnpm/pnpm#12314. Related to pnpm/pnpm.io#827 (docs PR will follow in the `pnpm.io` repo).

## Squash Commit Body

```text
Add an `_auth` setting that carries registry authentication as one
structured, URL-keyed value instead of many `//host/:_authToken=…` keys.

GitHub Actions silently drops env vars whose names contain `/`, `:`, or `.`
(and bash/zsh reject them outright), which broke the
`pnpm_config_//host/:_authToken=…` form on CI (pnpm/pnpm#12314). The
`pnpm_config__auth` env var — the env projection of the `_auth` setting —
sidesteps the runner-level filter while preserving host scoping. The same
value can be set in the global pnpm config.yaml as a native YAML map.

Design:
- `_auth` is honored only from the env var and the global config.yaml —
  never a project pnpm-workspace.yaml / .npmrc — so repo-controlled config
  can never supply registry auth. The env var wins over the global config
  on a conflicting key.
- The value is host-keyed: `{ "https://registry.example": { "@": {...},
  "@org": {...} } }`. The host and credential arrive in one trusted value,
  so the same entry is a safe source of registry routing — repo config
  cannot redirect an env token to a different host. Routes inferred from
  `_auth` are applied after workspace yaml (env/global wins over repo
  config) and before PNPM_CONFIG_* so an explicit registry override still
  wins — matching pnpm's "CLI > _auth > yaml" precedence.
- Reuses npm's deprecated `_auth` key name on purpose: pnpm reads the
  structured form only from its own yaml (and the env projection), so it
  never collides with npm's legacy `.npmrc` `_auth` scalar, and it is
  already covered by the existing protected-settings redaction (prints as
  `(protected)`).
- Only `authToken` is accepted (maps byte-for-byte to the existing
  `//host/:_authToken` .npmrc key), so the parser is a thin adapter onto
  the existing auth pipeline. The deprecated `basicAuth` / `username` +
  `password` forms and `tokenHelper` are excluded — dropped with a warning.
- Malformed values, non-object shapes, non-URL keys, non-http(s) schemes,
  URLs carrying credentials/query/fragment, invalid scopes, and unsupported
  auth fields each push a distinct warning and are skipped without aborting
  the load. Warnings never leak raw URL credentials.

Parity: implemented on both sides (TS CLI + pacquet). Both support the
single credential field `authToken`.

Closes pnpm/pnpm#12314.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port. *(Both sides implemented.)*
- [x] Added a changeset (`.changeset/json-env-auth.md` — minor bump for `pnpm`
  and `@pnpm/config.reader`).
- [x] Added or updated tests. *(TS: env-rename + new global-yaml-sourcing,
  env-over-yaml precedence, and project-yaml-ignored tests in
  `pnpm11/config/reader/test/index.ts`. Pacquet: unit + end-to-end tests in
  `npmrc_auth/tests.rs` and `tests.rs` for the env rename, global `config.yaml`
  `_auth`, env-wins precedence, and the project-yaml trust boundary.)*
- [ ] Updated the documentation if needed. *(pnpm.io docs live in a separate
  repo — a follow-up PR there will document the `_auth` setting (pnpm/pnpm.io#827).)*

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for structured registry authentication from environment settings and global config, including host-based and scope-based routing.
  * Registry and package-manager bootstrap settings now stay in sync across command-line, environment, and config sources.

* **Bug Fixes**
  * Strengthened precedence so trusted auth settings win over workspace/project settings when they conflict.
  * Invalid auth values now fail fast instead of being silently ignored.
  * Improved registry URL normalization, including consistent trailing-slash handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->