### PR TITLE
feat(pnpr): add registry/resolver feature toggles

### DIFF
--- a/pnpr/crates/pnpr/config.yaml
+++ b/pnpr/crates/pnpr/config.yaml
@@ -40,6 +40,13 @@ storage: ./storage
 #  mysql:
 #    url: ${PNPR_MYSQL_URL}
 #    maxConnections: 16
+# Feature toggles for pnpr's two surfaces. Both are enabled by default;
+# disable one to carve down what this server exposes. At least one must
+# stay enabled. (`/-/ping` is always served.)
+#registry:          # npm registry: packument/tarball reads, publish,
+#  enabled: true    # unpublish, dist-tag, search, user/login endpoints
+#resolver:          # install accelerator: /-/pnpr, /v1/resolve,
+#  enabled: true    # and /v1/verify-lockfile
 secret: pnpm-registry-mock-secret-key-32
 
 auth:

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -903,7 +903,12 @@ struct OsvFile {
 /// field and the whole-block defaults are both `enabled: true`, so
 /// omitting the block — or writing `registry:` with no body — keeps the
 /// surface on.
+/// `deny_unknown_fields` so a typo like `registry: { enable: false }`
+/// (note: `enable`, not `enabled`) is a loud config error rather than
+/// silently leaving the surface enabled — these toggles scope which
+/// endpoints are exposed, so a silent default-on is a security footgun.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct FeatureFile {
     #[serde(default = "default_true")]
     enabled: bool,

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1109,14 +1109,23 @@ impl Config {
         let osv = build_osv_config(&file.osv, base_dir);
         let registry = RegistryFeature { enabled: file.registry.unwrap_or_default().enabled };
         let resolver = ResolverFeature { enabled: file.resolver.unwrap_or_default().enabled };
-        let uplinks = file
-            .uplinks
-            .into_iter()
-            .map(|(name, uplink)| {
-                let resolved = resolve_uplink::<SystemEnv>(&name, uplink)?;
-                Ok((name, resolved))
-            })
-            .collect::<Result<IndexMap<_, _>, RegistryError>>()?;
+        // Only the registry surface consults uplinks, and `resolve_uplink`
+        // is strict — a `uplink.auth` block with an unresolvable token is a
+        // config error. A resolver-only server mounts no registry routes,
+        // so skip resolution entirely; otherwise a registry-shaped config
+        // would force the resolver tier to carry upstream secrets it never
+        // uses.
+        let uplinks = if registry.enabled {
+            file.uplinks
+                .into_iter()
+                .map(|(name, uplink)| {
+                    let resolved = resolve_uplink::<SystemEnv>(&name, uplink)?;
+                    Ok((name, resolved))
+                })
+                .collect::<Result<IndexMap<_, _>, RegistryError>>()?
+        } else {
+            IndexMap::new()
+        };
         let config = Self {
             listen,
             public_url,

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -159,6 +159,19 @@ impl Default for ResolverFeature {
     }
 }
 
+/// CLI-level overrides for the feature toggles, applied *during* config
+/// parse so the effective surface enablement is known before any
+/// registry-only work runs. This matters because uplink resolution is
+/// strict (a `uplink.auth` block with an unresolvable token is a config
+/// error): applying `--disable-registry` only after parsing would still
+/// force a resolver-only tier to carry upstream secrets. A `true` field
+/// forces the corresponding surface off regardless of the config file.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FeatureOverrides {
+    pub disable_registry: bool,
+    pub disable_resolver: bool,
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct OsvConfig {
     pub enabled: bool,
@@ -1001,16 +1014,27 @@ impl Config {
         listen: SocketAddr,
         public_url: Option<String>,
     ) -> std::io::Result<Self> {
+        Self::from_yaml_with_overrides(path, listen, public_url, FeatureOverrides::default())
+    }
+
+    fn from_yaml_with_overrides(
+        path: &Path,
+        listen: SocketAddr,
+        public_url: Option<String>,
+        overrides: FeatureOverrides,
+    ) -> std::io::Result<Self> {
         let raw = std::fs::read_to_string(path).map_err(|err| {
             std::io::Error::new(err.kind(), format!("read {}: {err}", path.display()))
         })?;
         let base = path.parent().unwrap_or_else(|| Path::new("."));
-        Self::from_yaml_str(&raw, base, listen, public_url).map_err(|err| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("parse {}: {err}", path.display()),
-            )
-        })
+        Self::from_yaml_str_with_overrides(&raw, base, listen, public_url, overrides).map_err(
+            |err| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("parse {}: {err}", path.display()),
+                )
+            },
+        )
     }
 
     /// Parse [`DEFAULT_CONFIG_YAML`] (the verdaccio-shaped YAML
@@ -1028,8 +1052,28 @@ impl Config {
         listen: SocketAddr,
         public_url: Option<String>,
     ) -> Self {
-        Self::from_yaml_str(DEFAULT_CONFIG_YAML, base_dir, listen, public_url)
-            .expect("bundled DEFAULT_CONFIG_YAML must always parse")
+        Self::from_default_yaml_with_overrides(
+            base_dir,
+            listen,
+            public_url,
+            FeatureOverrides::default(),
+        )
+    }
+
+    fn from_default_yaml_with_overrides(
+        base_dir: &Path,
+        listen: SocketAddr,
+        public_url: Option<String>,
+        overrides: FeatureOverrides,
+    ) -> Self {
+        Self::from_yaml_str_with_overrides(
+            DEFAULT_CONFIG_YAML,
+            base_dir,
+            listen,
+            public_url,
+            overrides,
+        )
+        .expect("bundled DEFAULT_CONFIG_YAML must always parse")
     }
 
     /// Resolve the auto-discovery path for the global `config.yaml`,
@@ -1067,22 +1111,66 @@ impl Config {
         listen: SocketAddr,
         public_url: Option<String>,
     ) -> std::io::Result<(Self, ConfigSource)> {
+        Self::resolve_with_overrides(
+            explicit,
+            default_path,
+            listen,
+            public_url,
+            FeatureOverrides::default(),
+        )
+    }
+
+    /// Like [`Self::resolve`] but applies CLI [`FeatureOverrides`] during
+    /// parse, so a surface disabled on the command line skips its parse-time
+    /// work (e.g. strict uplink token resolution) — not just its routes. The
+    /// binary uses this; tests and embedders that don't override features
+    /// call [`Self::resolve`].
+    pub fn resolve_with_overrides(
+        explicit: Option<&Path>,
+        default_path: Option<&Path>,
+        listen: SocketAddr,
+        public_url: Option<String>,
+        overrides: FeatureOverrides,
+    ) -> std::io::Result<(Self, ConfigSource)> {
         if let Some(path) = explicit {
-            let config = Self::from_yaml(path, listen, public_url)?;
+            let config = Self::from_yaml_with_overrides(path, listen, public_url, overrides)?;
             return Ok((config, ConfigSource::Cli(path.to_path_buf())));
         }
         if let Some(path) = default_path {
-            let config = Self::from_yaml(path, listen, public_url)?;
+            let config = Self::from_yaml_with_overrides(path, listen, public_url, overrides)?;
             return Ok((config, ConfigSource::DefaultPath(path.to_path_buf())));
         }
-        Ok((Self::from_default_yaml(Path::new("."), listen, public_url), ConfigSource::Bundled))
+        Ok((
+            Self::from_default_yaml_with_overrides(Path::new("."), listen, public_url, overrides),
+            ConfigSource::Bundled,
+        ))
     }
 
+    /// Override-free convenience wrapper used by the test suite's many
+    /// parse cases; the binary path always goes through
+    /// [`Self::from_yaml_str_with_overrides`].
+    #[cfg(test)]
     fn from_yaml_str(
         raw: &str,
         base_dir: &Path,
         listen: SocketAddr,
         public_url: Option<String>,
+    ) -> Result<Self, RegistryError> {
+        Self::from_yaml_str_with_overrides(
+            raw,
+            base_dir,
+            listen,
+            public_url,
+            FeatureOverrides::default(),
+        )
+    }
+
+    fn from_yaml_str_with_overrides(
+        raw: &str,
+        base_dir: &Path,
+        listen: SocketAddr,
+        public_url: Option<String>,
+        overrides: FeatureOverrides,
     ) -> Result<Self, RegistryError> {
         let (substituted, unresolved) = env_replace_lossy::<SystemEnv>(raw);
         if !unresolved.is_empty() {
@@ -1107,8 +1195,16 @@ impl Config {
         let logs = build_log_config(file.log.as_ref());
         let policies = build_policies(&file.packages)?;
         let osv = build_osv_config(&file.osv, base_dir);
-        let registry = RegistryFeature { enabled: file.registry.unwrap_or_default().enabled };
-        let resolver = ResolverFeature { enabled: file.resolver.unwrap_or_default().enabled };
+        // Effective enablement folds the CLI overrides in here, so the
+        // registry-only work below (uplink resolution) is skipped whether
+        // the surface was disabled in the config file or on the command
+        // line.
+        let registry = RegistryFeature {
+            enabled: file.registry.unwrap_or_default().enabled && !overrides.disable_registry,
+        };
+        let resolver = ResolverFeature {
+            enabled: file.resolver.unwrap_or_default().enabled && !overrides.disable_resolver,
+        };
         // Only the registry surface consults uplinks, and `resolve_uplink`
         // is strict — a `uplink.auth` block with an unresolvable token is a
         // config error. A resolver-only server mounts no registry routes,

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1052,12 +1052,18 @@ impl Config {
         listen: SocketAddr,
         public_url: Option<String>,
     ) -> Self {
+        // With default (no) overrides the bundled config keeps both
+        // surfaces enabled, so the only way this errors is a malformed
+        // compiled-in YAML — a build-time bug, hence the `expect`. The
+        // override-taking variant returns `Result` because overrides can
+        // disable every surface (a runtime input error).
         Self::from_default_yaml_with_overrides(
             base_dir,
             listen,
             public_url,
             FeatureOverrides::default(),
         )
+        .expect("bundled DEFAULT_CONFIG_YAML must always parse")
     }
 
     fn from_default_yaml_with_overrides(
@@ -1065,7 +1071,7 @@ impl Config {
         listen: SocketAddr,
         public_url: Option<String>,
         overrides: FeatureOverrides,
-    ) -> Self {
+    ) -> Result<Self, RegistryError> {
         Self::from_yaml_str_with_overrides(
             DEFAULT_CONFIG_YAML,
             base_dir,
@@ -1073,7 +1079,6 @@ impl Config {
             public_url,
             overrides,
         )
-        .expect("bundled DEFAULT_CONFIG_YAML must always parse")
     }
 
     /// Resolve the auto-discovery path for the global `config.yaml`,
@@ -1140,10 +1145,15 @@ impl Config {
             let config = Self::from_yaml_with_overrides(path, listen, public_url, overrides)?;
             return Ok((config, ConfigSource::DefaultPath(path.to_path_buf())));
         }
-        Ok((
-            Self::from_default_yaml_with_overrides(Path::new("."), listen, public_url, overrides),
-            ConfigSource::Bundled,
-        ))
+        let config =
+            Self::from_default_yaml_with_overrides(Path::new("."), listen, public_url, overrides)
+                .map_err(|err| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("parse bundled config: {err}"),
+                )
+            })?;
+        Ok((config, ConfigSource::Bundled))
     }
 
     /// Override-free convenience wrapper used by the test suite's many

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -113,6 +113,50 @@ pub struct Config {
     /// Optional local OSV database used by the resolver to reject known
     /// vulnerable npm package versions without live API calls.
     pub osv: OsvConfig,
+    /// The npm-registry surface: packument and tarball reads, publish,
+    /// unpublish, dist-tag, search, and the user/login endpoints. Enabled
+    /// by default; disable it to run a stateless resolver tier in front
+    /// of an existing registry. See [`RegistryFeature`].
+    pub registry: RegistryFeature,
+    /// The install-accelerator surface: the `/-/pnpr` handshake and the
+    /// `/v1/resolve` / `/v1/verify-lockfile` endpoints. Enabled by
+    /// default; disable it to run a plain registry with no server-side
+    /// resolution. See [`ResolverFeature`].
+    pub resolver: ResolverFeature,
+}
+
+/// Toggle for the npm-registry surface. A dedicated type — rather than a
+/// bare `bool` on [`Config`] — so finer-grained registry sub-features
+/// (e.g. disabling `publish` for a read-only mirror) can be added here
+/// without changing the config shape.
+#[derive(Debug, Clone)]
+pub struct RegistryFeature {
+    /// Master switch for the whole npm-registry surface. When `false`,
+    /// none of the registry routes are mounted.
+    pub enabled: bool,
+}
+
+impl Default for RegistryFeature {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+/// Toggle for the install-accelerator (resolver) surface. Separate from
+/// [`RegistryFeature`] so each surface grows its own sub-features
+/// independently.
+#[derive(Debug, Clone)]
+pub struct ResolverFeature {
+    /// Master switch for the resolver surface (`/-/pnpr`, `/v1/resolve`,
+    /// `/v1/verify-lockfile`). When `false`, none of those routes are
+    /// mounted.
+    pub enabled: bool,
+}
+
+impl Default for ResolverFeature {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
 }
 
 #[derive(Debug, Default, Clone)]
@@ -760,6 +804,13 @@ struct ConfigFile {
     /// pnpr-only local OSV database settings.
     #[serde(default)]
     osv: OsvFile,
+    /// pnpr-only feature toggles for the two server surfaces. Each is on
+    /// unless explicitly disabled; absent on a stock verdaccio config, so
+    /// both stay enabled there.
+    #[serde(default)]
+    registry: FeatureFile,
+    #[serde(default)]
+    resolver: FeatureFile,
     #[serde(default)]
     uplinks: IndexMap<String, UplinkFile>,
     #[serde(default)]
@@ -845,6 +896,27 @@ struct OsvFile {
     path: Option<String>,
 }
 
+/// Disk shape of a `registry:` / `resolver:` feature block. A bare
+/// `enabled` today; per-surface sub-feature keys can be added later. The
+/// field and the whole-block defaults are both `enabled: true`, so
+/// omitting the block — or writing `registry:` with no body — keeps the
+/// surface on.
+#[derive(Debug, Deserialize)]
+struct FeatureFile {
+    #[serde(default = "default_true")]
+    enabled: bool,
+}
+
+impl Default for FeatureFile {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
 impl Config {
     /// Default `listen` when one isn't supplied by the caller.
     pub const DEFAULT_LISTEN: &'static str = "127.0.0.1:4873";
@@ -881,6 +953,8 @@ impl Config {
             hosted_store: HostedStoreConfig::Fs,
             backend: BackendConfig::Local,
             osv: OsvConfig::default(),
+            registry: RegistryFeature::default(),
+            resolver: ResolverFeature::default(),
         }
     }
 
@@ -902,6 +976,8 @@ impl Config {
             hosted_store: HostedStoreConfig::Fs,
             backend: BackendConfig::Local,
             osv: OsvConfig::default(),
+            registry: RegistryFeature::default(),
+            resolver: ResolverFeature::default(),
         }
     }
 
@@ -1024,6 +1100,8 @@ impl Config {
         let logs = build_log_config(file.log.as_ref());
         let policies = build_policies(&file.packages)?;
         let osv = build_osv_config(&file.osv, base_dir);
+        let registry = RegistryFeature { enabled: file.registry.enabled };
+        let resolver = ResolverFeature { enabled: file.resolver.enabled };
         let uplinks = file
             .uplinks
             .into_iter()
@@ -1032,7 +1110,7 @@ impl Config {
                 Ok((name, resolved))
             })
             .collect::<Result<IndexMap<_, _>, RegistryError>>()?;
-        Ok(Self {
+        let config = Self {
             listen,
             public_url,
             storage,
@@ -1046,7 +1124,24 @@ impl Config {
             hosted_store,
             backend,
             osv,
-        })
+            registry,
+            resolver,
+        };
+        config.ensure_a_feature_is_enabled()?;
+        Ok(config)
+    }
+
+    /// At least one top-level surface must be served; a server with both
+    /// `registry` and `resolver` disabled would answer only `/-/ping`.
+    /// Checked at config load and again after CLI overrides.
+    pub fn ensure_a_feature_is_enabled(&self) -> Result<(), RegistryError> {
+        if self.registry.enabled || self.resolver.enabled {
+            Ok(())
+        } else {
+            Err(RegistryError::InvalidConfig {
+                reason: "at least one of `registry` or `resolver` must be enabled".to_string(),
+            })
+        }
     }
 
     /// Find the uplink for `package_name` by walking [`Self::packages`]

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -806,11 +806,13 @@ struct ConfigFile {
     osv: OsvFile,
     /// pnpr-only feature toggles for the two server surfaces. Each is on
     /// unless explicitly disabled; absent on a stock verdaccio config, so
-    /// both stay enabled there.
+    /// both stay enabled there. `Option` so a bare `registry:` (which
+    /// YAML parses as null) is accepted as "default" rather than failing
+    /// to deserialize into the struct.
     #[serde(default)]
-    registry: FeatureFile,
+    registry: Option<FeatureFile>,
     #[serde(default)]
-    resolver: FeatureFile,
+    resolver: Option<FeatureFile>,
     #[serde(default)]
     uplinks: IndexMap<String, UplinkFile>,
     #[serde(default)]
@@ -1100,8 +1102,8 @@ impl Config {
         let logs = build_log_config(file.log.as_ref());
         let policies = build_policies(&file.packages)?;
         let osv = build_osv_config(&file.osv, base_dir);
-        let registry = RegistryFeature { enabled: file.registry.enabled };
-        let resolver = ResolverFeature { enabled: file.resolver.enabled };
+        let registry = RegistryFeature { enabled: file.registry.unwrap_or_default().enabled };
+        let resolver = ResolverFeature { enabled: file.resolver.unwrap_or_default().enabled };
         let uplinks = file
             .uplinks
             .into_iter()

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -244,6 +244,16 @@ fn feature_blocks_present_but_empty_default_to_enabled() {
 }
 
 #[test]
+fn unknown_key_in_feature_block_is_a_config_error() {
+    // A typo'd `enable` (vs `enabled`) must fail loudly rather than
+    // silently leaving the surface enabled.
+    let yaml = "registry:\n  enable: false\n";
+    let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
+        .expect_err("an unknown key in a feature block must error");
+    assert!(matches!(err, RegistryError::InvalidConfig { .. }));
+}
+
+#[test]
 fn from_yaml_str_parses_feature_toggles() {
     let yaml = r"
 registry:

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -267,6 +267,16 @@ packages:
 }
 
 #[test]
+fn cli_disabling_both_surfaces_with_bundled_config_errors_without_panicking() {
+    // No config file → the bundled branch. Disabling both surfaces via
+    // CLI must surface a clean error, not panic on the bundled `expect`.
+    let overrides = FeatureOverrides { disable_registry: true, disable_resolver: true };
+    let err = Config::resolve_with_overrides(None, None, listen(), None, overrides)
+        .expect_err("both surfaces disabled must error rather than panic");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+}
+
+#[test]
 fn cli_disable_registry_skips_uplink_resolution() {
     // The config file enables the registry, but `--disable-registry`
     // (a CLI override) turns it off. Uplink resolution must be skipped

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML, HostedStoreConfig, Interval,
-    LogFormat, LogLevel, TokenEnv, UplinkAuthFile, UplinkAuthType, UplinkConfig, UplinkFile,
-    config_file_in, parse_interval, pattern_matches, resolve_relative, resolve_uplink,
+    BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML, FeatureOverrides, HostedStoreConfig,
+    Interval, LogFormat, LogLevel, TokenEnv, UplinkAuthFile, UplinkAuthType, UplinkConfig,
+    UplinkFile, config_file_in, parse_interval, pattern_matches, resolve_relative, resolve_uplink,
 };
 use crate::{error::RegistryError, policy::Identity};
 use indexmap::IndexMap;
@@ -262,6 +262,31 @@ packages:
     proxy: npmjs
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+    assert!(!config.registry.enabled);
+    assert!(config.uplinks.is_empty());
+}
+
+#[test]
+fn cli_disable_registry_skips_uplink_resolution() {
+    // The config file enables the registry, but `--disable-registry`
+    // (a CLI override) turns it off. Uplink resolution must be skipped
+    // based on the *effective* enablement, so an unresolvable auth token
+    // doesn't fail startup of a resolver-only tier driven by the flag.
+    let yaml = r"
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    auth:
+      type: bearer
+      token_env: PNPR_DEFINITELY_UNSET_TOKEN_VAR
+packages:
+  '**':
+    proxy: npmjs
+";
+    let overrides = FeatureOverrides { disable_registry: true, disable_resolver: false };
+    let config =
+        Config::from_yaml_str_with_overrides(yaml, Path::new("/x"), listen(), None, overrides)
+            .expect("a CLI-disabled registry must skip strict uplink resolution");
     assert!(!config.registry.enabled);
     assert!(config.uplinks.is_empty());
 }

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -244,6 +244,29 @@ fn feature_blocks_present_but_empty_default_to_enabled() {
 }
 
 #[test]
+fn resolver_only_skips_uplink_resolution() {
+    // With the registry disabled, an uplink whose auth token can't be
+    // resolved must not fail config load — no registry route uses uplinks,
+    // so a resolver-only tier shouldn't need upstream secrets.
+    let yaml = r"
+registry:
+  enabled: false
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    auth:
+      type: bearer
+      token_env: PNPR_DEFINITELY_UNSET_TOKEN_VAR
+packages:
+  '**':
+    proxy: npmjs
+";
+    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+    assert!(!config.registry.enabled);
+    assert!(config.uplinks.is_empty());
+}
+
+#[test]
 fn unknown_key_in_feature_block_is_a_config_error() {
     // A typo'd `enable` (vs `enabled`) must fail loudly rather than
     // silently leaving the surface enabled.

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -227,6 +227,39 @@ packages:
 }
 
 #[test]
+fn features_default_to_enabled_when_absent() {
+    let config = Config::from_yaml_str("{}", Path::new("/x"), listen(), None).unwrap();
+    assert!(config.registry.enabled);
+    assert!(config.resolver.enabled);
+}
+
+#[test]
+fn from_yaml_str_parses_feature_toggles() {
+    let yaml = r"
+registry:
+  enabled: false
+resolver:
+  enabled: true
+";
+    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+    assert!(!config.registry.enabled);
+    assert!(config.resolver.enabled);
+}
+
+#[test]
+fn disabling_both_features_is_a_config_error() {
+    let yaml = r"
+registry:
+  enabled: false
+resolver:
+  enabled: false
+";
+    let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
+        .expect_err("a server with neither surface enabled must error");
+    assert!(matches!(err, RegistryError::InvalidConfig { .. }));
+}
+
+#[test]
 fn from_yaml_str_accepts_string_and_bare_number_intervals() {
     use std::time::Duration;
     // `maxage` is a string, `timeout` a bare number (verdaccio accepts

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -234,6 +234,16 @@ fn features_default_to_enabled_when_absent() {
 }
 
 #[test]
+fn feature_blocks_present_but_empty_default_to_enabled() {
+    // A bare `registry:` parses as YAML null and `resolver: {}` as an
+    // empty map; both must mean "enabled", not fail to deserialize.
+    let yaml = "registry:\nresolver: {}\n";
+    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+    assert!(config.registry.enabled);
+    assert!(config.resolver.enabled);
+}
+
+#[test]
 fn from_yaml_str_parses_feature_toggles() {
     let yaml = r"
 registry:

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -27,9 +27,9 @@ pub use auth::{
     identify,
 };
 pub use config::{
-    AuthConfig, BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML, HostedStoreConfig,
-    HtpasswdConfig, LibsqlSettings, LogConfig, LogFormat, LogLevel, MaxUsers, OsvConfig,
-    PackageAccess, RegistryFeature, ResolverFeature, SqlBackendSettings, TokensConfig,
+    AuthConfig, BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML, FeatureOverrides,
+    HostedStoreConfig, HtpasswdConfig, LibsqlSettings, LogConfig, LogFormat, LogLevel, MaxUsers,
+    OsvConfig, PackageAccess, RegistryFeature, ResolverFeature, SqlBackendSettings, TokensConfig,
     UplinkConfig, default_cache_dir,
 };
 pub use error::{RegistryError, Result};

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -29,7 +29,8 @@ pub use auth::{
 pub use config::{
     AuthConfig, BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML, HostedStoreConfig,
     HtpasswdConfig, LibsqlSettings, LogConfig, LogFormat, LogLevel, MaxUsers, OsvConfig,
-    PackageAccess, SqlBackendSettings, TokensConfig, UplinkConfig, default_cache_dir,
+    PackageAccess, RegistryFeature, ResolverFeature, SqlBackendSettings, TokensConfig,
+    UplinkConfig, default_cache_dir,
 };
 pub use error::{RegistryError, Result};
 pub use journal::recover_publish_journal;

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -51,6 +51,18 @@ struct Args {
     /// Path to the local OSV npm database zip or extracted JSON directory.
     #[arg(long)]
     osv_db: Option<PathBuf>,
+
+    /// Disable the npm-registry surface (packument/tarball reads, publish,
+    /// unpublish, dist-tag, search, and the user/login endpoints).
+    /// Overrides `registry.enabled` from the loaded config.
+    #[arg(long)]
+    disable_registry: bool,
+
+    /// Disable the install-accelerator surface (`/-/pnpr`, `/v1/resolve`,
+    /// `/v1/verify-lockfile`). Overrides `resolver.enabled` from the
+    /// loaded config.
+    #[arg(long)]
+    disable_resolver: bool,
 }
 
 #[tokio::main]
@@ -95,6 +107,15 @@ async fn main() -> miette::Result<()> {
     if let Some(osv_db) = args.osv_db {
         config.osv.path = Some(osv_db);
     }
+    // Only flip a surface off when its flag is present, so the config's
+    // `enabled` value still wins when the flag is absent.
+    if args.disable_registry {
+        config.registry.enabled = false;
+    }
+    if args.disable_resolver {
+        config.resolver.enabled = false;
+    }
+    config.ensure_a_feature_is_enabled().map_err(|err| miette::miette!("{err}"))?;
     init_logging(&config.logs);
     log_config_source(&source);
     serve(config).await.map_err(|err| redacted_report(&err))

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -69,11 +69,19 @@ struct Args {
 async fn main() -> miette::Result<()> {
     let args = Args::parse();
     let auto_path = Config::auto_config_path();
-    let (mut config, source) = Config::resolve(
+    // Pass the surface-disable flags into parsing so a CLI-disabled surface
+    // skips its parse-time work too (e.g. strict uplink token resolution),
+    // not just its routes — applying them after `resolve` would be too late.
+    let overrides = pnpr::FeatureOverrides {
+        disable_registry: args.disable_registry,
+        disable_resolver: args.disable_resolver,
+    };
+    let (mut config, source) = Config::resolve_with_overrides(
         args.config.as_deref(),
         auto_path.as_deref(),
         args.listen,
         args.public_url.clone(),
+        overrides,
     )
     .map_err(|err| miette::miette!("{err}"))?;
     if let Some(storage) = args.storage {
@@ -107,15 +115,8 @@ async fn main() -> miette::Result<()> {
     if let Some(osv_db) = args.osv_db {
         config.osv.path = Some(osv_db);
     }
-    // Only flip a surface off when its flag is present, so the config's
-    // `enabled` value still wins when the flag is absent.
-    if args.disable_registry {
-        config.registry.enabled = false;
-    }
-    if args.disable_resolver {
-        config.resolver.enabled = false;
-    }
-    config.ensure_a_feature_is_enabled().map_err(|err| miette::miette!("{err}"))?;
+    // Surface overrides were folded in during parse; the parse already
+    // enforced that at least one surface stays enabled.
     init_logging(&config.logs);
     log_config_source(&source);
     serve(config).await.map_err(|err| redacted_report(&err))

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -355,6 +355,11 @@ fn router_with_auth_and_osv(
 /// client connections; a resolver-only server skips journal recovery and
 /// on-disk auth entirely and stays stateless.
 pub async fn serve(config: Config) -> crate::error::Result<()> {
+    // Enforce the "at least one surface" invariant here too, not only at
+    // YAML load / CLI: embedders build `Config` programmatically and call
+    // straight into `serve`, so a both-disabled config must fail loudly
+    // rather than start a server that only answers `/-/ping`.
+    config.ensure_a_feature_is_enabled()?;
     let osv_index = load_active_osv_index(&config)?;
     let auth = load_startup_auth(&config).await?;
     let listen = config.listen;
@@ -375,6 +380,7 @@ pub async fn serve_listener(
     listener: tokio::net::TcpListener,
 ) -> crate::error::Result<()> {
     let listen = listener.local_addr()?;
+    config.ensure_a_feature_is_enabled()?;
     let osv_index = load_active_osv_index(&config)?;
     // Load the configured auth backends here too (when the registry is
     // enabled) — going through `router` would silently fall back to

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -190,6 +190,8 @@ fn router_with_auth_and_osv(
         .iter()
         .map(|(name, uplink)| (name.clone(), Upstream::new(name, uplink)))
         .collect();
+    let registry_enabled = config.registry.enabled;
+    let resolver_enabled = config.resolver.enabled;
     let state = AppState {
         inner: Arc::new(AppInner {
             storage,
@@ -201,32 +203,61 @@ fn router_with_auth_and_osv(
             osv_index,
         }),
     };
-    Router::new()
-        .route("/-/ping", get(serve_ping))
-        // pnpr resolver: opt-in, versioned endpoints layered on the
-        // registry core. Non-pnpm clients never touch these. `/-/pnpr`
-        // is the capability handshake (404 on a plain registry).
-        .route("/-/pnpr", get(serve_pnpr_handshake))
-        .route("/v1/resolve", post(serve_resolve))
-        .route("/v1/verify-lockfile", post(serve_verify_lockfile))
-        // Batch publish: one request carrying many packages' publish
-        // documents. Not part of the standard npm registry API —
-        // `pnpm publish --batch` opts into it explicitly.
-        .route("/-/pnpm/v1/publish", put(serve_batch_publish))
-        .route("/{name}", get(get_packument_unscoped).put(put_one_segment))
-        .route("/{first}/{second}", get(get_two_segments).put(put_two_segments))
-        .route(
-            "/{first}/{second}/{third}",
-            get(get_three_segments).put(put_three_segments).delete(delete_three_segments),
-        )
-        .route("/{scope}/{name}/-/{filename}", get(get_tarball_scoped))
-        .route("/{a}/{b}/{c}/{d}", get(get_four_segments).delete(delete_four_segments))
-        .route(
-            "/{a}/{b}/{c}/{d}/{e}",
-            get(get_five_segments).put(put_five_segments).delete(delete_five_segments),
-        )
-        // Scoped tarball delete: `DELETE /@scope/name/-/<basename-version>.tgz/-rev/<rev>`
-        .route("/{a}/{b}/{c}/{d}/{e}/{f}", delete(delete_six_segments))
+    // `/-/ping` is a health check and is always served. The two
+    // configurable surfaces — the resolver (install accelerator) and the
+    // npm registry — are each mounted only when their feature is enabled,
+    // so an operator can run resolver-only, registry-only, or both. The
+    // config guarantees at least one is enabled.
+    let mut router = Router::new().route("/-/ping", get(serve_ping));
+    // The install-accelerator (resolver) surface. `/-/pnpr` is the
+    // capability handshake (404 on a plain registry); `/v1/resolve` and
+    // `/v1/verify-lockfile` are the resolver endpoints. These resolve
+    // against the registries the *client* sends, so the accelerator works
+    // whether or not this process also fronts a registry.
+    //
+    // When the resolver is disabled these exact paths are still
+    // registered, but to a 404 stub. They overlap the registry's
+    // catch-all param routes (`/-/pnpr` matches `/{first}/{second}`), so
+    // without the stub a capability probe would fall through to the
+    // registry and be proxied upstream — surfacing a confusing 502 where
+    // a client expects the "no resolver here" 404.
+    if resolver_enabled {
+        router = router
+            .route("/-/pnpr", get(serve_pnpr_handshake))
+            .route("/v1/resolve", post(serve_resolve))
+            .route("/v1/verify-lockfile", post(serve_verify_lockfile));
+    } else {
+        router = router
+            .route("/-/pnpr", get(resolver_disabled))
+            .route("/v1/resolve", post(resolver_disabled))
+            .route("/v1/verify-lockfile", post(resolver_disabled));
+    }
+    // The npm-registry surface: every packument/tarball read, publish,
+    // unpublish, dist-tag, search, and the user/login endpoint. When the
+    // feature is disabled, none of these routes are mounted — not merely
+    // hidden — so a resolver-only tier exposes no registry surface at all.
+    if registry_enabled {
+        router = router
+            // Batch publish: one request carrying many packages' publish
+            // documents. Not part of the standard npm registry API —
+            // `pnpm publish --batch` opts into it explicitly.
+            .route("/-/pnpm/v1/publish", put(serve_batch_publish))
+            .route("/{name}", get(get_packument_unscoped).put(put_one_segment))
+            .route("/{first}/{second}", get(get_two_segments).put(put_two_segments))
+            .route(
+                "/{first}/{second}/{third}",
+                get(get_three_segments).put(put_three_segments).delete(delete_three_segments),
+            )
+            .route("/{scope}/{name}/-/{filename}", get(get_tarball_scoped))
+            .route("/{a}/{b}/{c}/{d}", get(get_four_segments).delete(delete_four_segments))
+            .route(
+                "/{a}/{b}/{c}/{d}/{e}",
+                get(get_five_segments).put(put_five_segments).delete(delete_five_segments),
+            )
+            // Scoped tarball delete: `DELETE /@scope/name/-/<basename-version>.tgz/-rev/<rev>`
+            .route("/{a}/{b}/{c}/{d}/{e}/{f}", delete(delete_six_segments));
+    }
+    router
         .layer(DefaultBodyLimit::max(MAX_PUBLISH_BODY_BYTES))
         // gzip metadata responses for clients that send `Accept-Encoding:
         // gzip`, matching how a real (CDN-fronted) registry serves
@@ -2044,6 +2075,15 @@ async fn serve_ping(State(_state): State<AppState>) -> Response {
 /// lists the `/vN/resolve` protocol versions this server speaks.
 async fn serve_pnpr_handshake() -> Response {
     (StatusCode::OK, axum::Json(serde_json::json!({ "pnpr": { "versions": [1] } }))).into_response()
+}
+
+/// 404 stub mounted on the resolver paths when the resolver feature is
+/// disabled. Registered so these specific paths return a clean
+/// not-found — in particular `/-/pnpr`, whose 404 is how a client
+/// detects "no resolver here" — rather than being shadowed by the
+/// registry's catch-all param routes and proxied upstream.
+async fn resolver_disabled() -> Response {
+    StatusCode::NOT_FOUND.into_response()
 }
 
 async fn serve_resolve(State(state): State<AppState>, body: axum::body::Bytes) -> Response {

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -252,25 +252,23 @@ fn router_with_auth_and_osv(
     // against the registries the *client* sends, so the accelerator works
     // whether or not this process also fronts a registry.
     //
-    // When the resolver is disabled these exact paths are still
-    // registered, but to an `any`-method 404 stub. They overlap the
-    // registry's catch-all param routes (`/-/pnpr` and `/v1/resolve` both
-    // match `/{first}/{second}`), so without the stub a probe would fall
-    // through to the registry and be proxied upstream — surfacing a
-    // confusing 502 where a client expects the "no resolver here" 404.
-    // The stub matches every method, not just the endpoint's real verb,
-    // so e.g. a `GET /v1/resolve` can't slip into the registry's GET
-    // catch-all.
+    // When the resolver is disabled, only `/-/pnpr` gets a 404 stub: it is
+    // the capability-probe path and overlaps the registry catch-all
+    // (`/-/pnpr` matches `/{first}/{second}`), so without the stub a probe
+    // would be proxied upstream, giving a confusing 502 where a client
+    // expects the "no resolver here" 404. `/v1/resolve` and
+    // `/v1/verify-lockfile` carry no capability probe and are POST-only, so
+    // they are left unmounted rather than stubbed: that keeps the registry
+    // npm-compatible for the (unusual but legitimate) version-manifest
+    // paths `GET /v1/resolve` / `GET /v1/verify-lockfile` (package `v1`,
+    // tag `resolve` / `verify-lockfile`), with their POST falling to a 405.
     if resolver_enabled {
         router = router
             .route("/-/pnpr", get(serve_pnpr_handshake))
             .route("/v1/resolve", post(serve_resolve))
             .route("/v1/verify-lockfile", post(serve_verify_lockfile));
     } else {
-        router = router
-            .route("/-/pnpr", any(resolver_disabled))
-            .route("/v1/resolve", any(resolver_disabled))
-            .route("/v1/verify-lockfile", any(resolver_disabled));
+        router = router.route("/-/pnpr", any(resolver_disabled));
     }
     // The npm-registry surface: every packument/tarball read, publish,
     // unpublish, dist-tag, search, and the user/login endpoint. When the

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -364,6 +364,7 @@ pub async fn serve(config: Config) -> crate::error::Result<()> {
     // straight into `serve`, so a both-disabled config must fail loudly
     // rather than start a server that only answers `/-/ping`.
     config.ensure_a_feature_is_enabled()?;
+    log_enabled_surfaces(&config);
     let osv_index = load_active_osv_index(&config)?;
     let auth = load_startup_auth(&config).await?;
     let listen = config.listen;
@@ -372,6 +373,19 @@ pub async fn serve(config: Config) -> crate::error::Result<()> {
     tracing::info!(%listen, "pnpr listening");
     axum::serve(listener, app).with_graceful_shutdown(shutdown_signal()).await?;
     Ok(())
+}
+
+/// Log which surfaces are mounted at startup. A misconfiguration — most
+/// importantly a typo'd `registry:` / `resolver:` block name, which the
+/// intentionally verdaccio-lenient config parser silently ignores and so
+/// leaves the surface at its default-enabled state — is then immediately
+/// visible to the operator rather than only discoverable by probing.
+fn log_enabled_surfaces(config: &Config) {
+    tracing::info!(
+        registry = config.registry.enabled,
+        resolver = config.resolver.enabled,
+        "pnpr surfaces",
+    );
 }
 
 /// Serve on an already-bound listener.
@@ -385,6 +399,7 @@ pub async fn serve_listener(
 ) -> crate::error::Result<()> {
     let listen = listener.local_addr()?;
     config.ensure_a_feature_is_enabled()?;
+    log_enabled_surfaces(&config);
     let osv_index = load_active_osv_index(&config)?;
     // Load the configured auth backends here too (when the registry is
     // enabled) — going through `router` would silently fall back to

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -174,8 +174,34 @@ pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
 
 /// Fallible counterpart to [`router_with_auth`].
 pub fn try_router_with_auth(config: Config, auth: AuthState) -> crate::error::Result<Router> {
-    let osv_index = crate::resolver::load_osv_index(&config)?;
+    let osv_index = load_active_osv_index(&config)?;
     Ok(router_with_auth_and_osv(config, auth, osv_index))
+}
+
+/// Load the OSV index only for surfaces that actually consult it. Today
+/// that is the resolver, so a registry-only server (`resolver.enabled =
+/// false`) skips the load — avoiding the startup cost and the
+/// missing/invalid-database error for a feature no mounted route uses.
+/// The gate widens to the registry once registry-side OSV screening
+/// lands (pnpm/pnpm#12561).
+fn load_active_osv_index(
+    config: &Config,
+) -> crate::error::Result<Option<Arc<crate::resolver::OsvIndex>>> {
+    if config.resolver.enabled { crate::resolver::load_osv_index(config) } else { Ok(None) }
+}
+
+/// Run the registry surface's startup side effects and load its auth
+/// backends — but only when the registry is enabled. A resolver-only
+/// deployment skips publish-journal recovery and on-disk auth entirely,
+/// so it stays stateless: it creates no credential files and reads
+/// nothing from the store, and so can run on a read-only or ephemeral
+/// host. The resolver routes never consult auth.
+async fn load_startup_auth(config: &Config) -> crate::error::Result<AuthState> {
+    if !config.registry.enabled {
+        return Ok(AuthState::in_memory());
+    }
+    crate::journal::recover_publish_journal(config).await?;
+    AuthState::load(&config.auth, &config.backend).await
 }
 
 fn router_with_auth_and_osv(
@@ -313,14 +339,14 @@ fn router_with_auth_and_osv(
         .with_state(state)
 }
 
-/// Bind to `config.listen` and serve forever. Loads the configured
-/// htpasswd users and token database before binding the socket so
-/// a startup-time auth error surfaces before we accept any client
-/// connections.
+/// Bind to `config.listen` and serve forever. When the registry surface
+/// is enabled, loads its htpasswd users and token database before binding
+/// the socket so a startup-time auth error surfaces before we accept any
+/// client connections; a resolver-only server skips journal recovery and
+/// on-disk auth entirely and stays stateless.
 pub async fn serve(config: Config) -> crate::error::Result<()> {
-    crate::journal::recover_publish_journal(&config).await?;
-    let osv_index = crate::resolver::load_osv_index(&config)?;
-    let auth = AuthState::load(&config.auth, &config.backend).await?;
+    let osv_index = load_active_osv_index(&config)?;
+    let auth = load_startup_auth(&config).await?;
     let listen = config.listen;
     let app = router_with_auth_and_osv(config, auth, osv_index);
     let listener = NodelayTcpListener(tokio::net::TcpListener::bind(listen).await?);
@@ -339,12 +365,13 @@ pub async fn serve_listener(
     listener: tokio::net::TcpListener,
 ) -> crate::error::Result<()> {
     let listen = listener.local_addr()?;
-    crate::journal::recover_publish_journal(&config).await?;
-    let osv_index = crate::resolver::load_osv_index(&config)?;
-    // Load the configured auth backends here too — going through
-    // `router` would silently fall back to in-memory auth and ignore a
-    // persisted htpasswd / SQLite store or a configured `backend:`.
-    let auth = AuthState::load(&config.auth, &config.backend).await?;
+    let osv_index = load_active_osv_index(&config)?;
+    // Load the configured auth backends here too (when the registry is
+    // enabled) — going through `router` would silently fall back to
+    // in-memory auth and ignore a persisted htpasswd / SQLite store or a
+    // configured `backend:`. A resolver-only server intentionally uses
+    // in-memory auth (see [`load_startup_auth`]).
+    let auth = load_startup_auth(&config).await?;
     let app = router_with_auth_and_osv(config, auth, osv_index);
     tracing::info!(%listen, "pnpr listening");
     axum::serve(NodelayTcpListener(listener), app)

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -22,7 +22,7 @@ use axum::{
     extract::{DefaultBodyLimit, OriginalUri, Path, Request, State},
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
-    routing::{delete, get, post, put},
+    routing::{any, delete, get, post, put},
 };
 use chrono::Utc;
 use indexmap::IndexMap;
@@ -211,13 +211,20 @@ fn router_with_auth_and_osv(
 ) -> Router {
     let storage =
         Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone());
-    let upstreams: IndexMap<String, Upstream> = config
-        .uplinks
-        .iter()
-        .map(|(name, uplink)| (name.clone(), Upstream::new(name, uplink)))
-        .collect();
     let registry_enabled = config.registry.enabled;
     let resolver_enabled = config.resolver.enabled;
+    // Only the registry routes consult the uplinks, so a resolver-only
+    // server builds none — skipping a `ThrottledClient` allocation per
+    // configured uplink.
+    let upstreams: IndexMap<String, Upstream> = if registry_enabled {
+        config
+            .uplinks
+            .iter()
+            .map(|(name, uplink)| (name.clone(), Upstream::new(name, uplink)))
+            .collect()
+    } else {
+        IndexMap::new()
+    };
     let state = AppState {
         inner: Arc::new(AppInner {
             storage,
@@ -242,11 +249,14 @@ fn router_with_auth_and_osv(
     // whether or not this process also fronts a registry.
     //
     // When the resolver is disabled these exact paths are still
-    // registered, but to a 404 stub. They overlap the registry's
-    // catch-all param routes (`/-/pnpr` matches `/{first}/{second}`), so
-    // without the stub a capability probe would fall through to the
-    // registry and be proxied upstream — surfacing a confusing 502 where
-    // a client expects the "no resolver here" 404.
+    // registered, but to an `any`-method 404 stub. They overlap the
+    // registry's catch-all param routes (`/-/pnpr` and `/v1/resolve` both
+    // match `/{first}/{second}`), so without the stub a probe would fall
+    // through to the registry and be proxied upstream — surfacing a
+    // confusing 502 where a client expects the "no resolver here" 404.
+    // The stub matches every method, not just the endpoint's real verb,
+    // so e.g. a `GET /v1/resolve` can't slip into the registry's GET
+    // catch-all.
     if resolver_enabled {
         router = router
             .route("/-/pnpr", get(serve_pnpr_handshake))
@@ -254,9 +264,9 @@ fn router_with_auth_and_osv(
             .route("/v1/verify-lockfile", post(serve_verify_lockfile));
     } else {
         router = router
-            .route("/-/pnpr", get(resolver_disabled))
-            .route("/v1/resolve", post(resolver_disabled))
-            .route("/v1/verify-lockfile", post(resolver_disabled));
+            .route("/-/pnpr", any(resolver_disabled))
+            .route("/v1/resolve", any(resolver_disabled))
+            .route("/v1/verify-lockfile", any(resolver_disabled));
     }
     // The npm-registry surface: every packument/tarball read, publish,
     // unpublish, dist-tag, search, and the user/login endpoint. When the

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -169,11 +169,15 @@ pub fn try_router(config: Config) -> crate::error::Result<Router> {
 /// [`try_router_with_auth`] to handle that as a recoverable error.
 pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
     try_router_with_auth(config, auth)
-        .expect("enabled OSV database must load before building pnpr router")
+        .expect("pnpr config must be valid and any enabled OSV database must load before building the router")
 }
 
 /// Fallible counterpart to [`router_with_auth`].
 pub fn try_router_with_auth(config: Config, auth: AuthState) -> crate::error::Result<Router> {
+    // Enforce the "at least one surface enabled" invariant for embedders
+    // that build and serve the router themselves rather than going through
+    // `serve`/`serve_listener`.
+    config.ensure_a_feature_is_enabled()?;
     let osv_index = load_active_osv_index(&config)?;
     Ok(router_with_auth_and_osv(config, auth, osv_index))
 }

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -984,32 +984,30 @@ async fn registry_only_serves_registry_and_refuses_resolver_endpoints() {
         app.clone().oneshot(Request::get("/-/pnpr").body(Body::empty()).unwrap()).await.unwrap();
     assert_eq!(handshake.status(), StatusCode::NOT_FOUND);
 
+    // `/-/pnpr` is the only stubbed resolver path, for every method, so
+    // capability detection cleanly concludes "no resolver here".
+    let handshake_post =
+        app.clone().oneshot(Request::post("/-/pnpr").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(handshake_post.status(), StatusCode::NOT_FOUND);
+
+    // `/v1/resolve` and `/v1/verify-lockfile` are NOT stubbed: they belong
+    // to the registry's version-manifest route (`GET|PUT /{first}/{second}`,
+    // i.e. package `v1`, tag `resolve` / `verify-lockfile`), so a POST
+    // returns 405 — proving the resolver stubs no longer shadow these
+    // legitimate registry paths.
     let resolve = app
         .clone()
         .oneshot(Request::post("/v1/resolve").body(Body::from("{}")).unwrap())
         .await
         .unwrap();
-    assert_eq!(resolve.status(), StatusCode::NOT_FOUND);
+    assert_eq!(resolve.status(), StatusCode::METHOD_NOT_ALLOWED);
 
     let verify = app
         .clone()
         .oneshot(Request::post("/v1/verify-lockfile").body(Body::from("{}")).unwrap())
         .await
         .unwrap();
-    assert_eq!(verify.status(), StatusCode::NOT_FOUND);
-
-    // A non-POST probe of a resolver path must also 404, not slip into the
-    // registry's catch-all GET routes and get proxied upstream.
-    let resolve_get = app
-        .clone()
-        .oneshot(Request::get("/v1/resolve").body(Body::empty()).unwrap())
-        .await
-        .unwrap();
-    assert_eq!(resolve_get.status(), StatusCode::NOT_FOUND);
-
-    let handshake_post =
-        app.clone().oneshot(Request::post("/-/pnpr").body(Body::empty()).unwrap()).await.unwrap();
-    assert_eq!(handshake_post.status(), StatusCode::NOT_FOUND);
+    assert_eq!(verify.status(), StatusCode::METHOD_NOT_ALLOWED);
 
     mock.assert_async().await;
 }

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -998,5 +998,18 @@ async fn registry_only_serves_registry_and_refuses_resolver_endpoints() {
         .unwrap();
     assert_eq!(verify.status(), StatusCode::NOT_FOUND);
 
+    // A non-POST probe of a resolver path must also 404, not slip into the
+    // registry's catch-all GET routes and get proxied upstream.
+    let resolve_get = app
+        .clone()
+        .oneshot(Request::get("/v1/resolve").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resolve_get.status(), StatusCode::NOT_FOUND);
+
+    let handshake_post =
+        app.clone().oneshot(Request::post("/-/pnpr").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(handshake_post.status(), StatusCode::NOT_FOUND);
+
     mock.assert_async().await;
 }

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -904,3 +904,99 @@ async fn cache_false_uplink_streams_tarball_without_mirroring() {
 
     mock.assert_async().await;
 }
+
+#[tokio::test]
+async fn resolver_only_serves_resolver_endpoints_and_refuses_registry_routes() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for("http://upstream.invalid", tmp.path().to_path_buf());
+    config.registry.enabled = false;
+    let app = router(config);
+
+    // The resolver surface stays reachable. `/-/ping` and the capability
+    // handshake answer 200; `/v1/verify-lockfile` is mounted, so an empty
+    // body is a 400 (bad request) rather than a 404 (route absent) — that
+    // distinction is the point of the assertion.
+    let ping =
+        app.clone().oneshot(Request::get("/-/ping").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(ping.status(), StatusCode::OK);
+
+    let handshake =
+        app.clone().oneshot(Request::get("/-/pnpr").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(handshake.status(), StatusCode::OK);
+
+    let verify = app
+        .clone()
+        .oneshot(Request::post("/v1/verify-lockfile").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_ne!(
+        verify.status(),
+        StatusCode::NOT_FOUND,
+        "the verify-lockfile route must stay mounted when the registry is disabled",
+    );
+
+    // Every npm-registry route is gone, not merely hidden: a packument
+    // read, a publish, and a batch publish all 404 without any upstream
+    // call (the route itself is absent).
+    let packument =
+        app.clone().oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(packument.status(), StatusCode::NOT_FOUND);
+
+    let publish =
+        app.clone().oneshot(Request::put("/foo").body(Body::from("{}")).unwrap()).await.unwrap();
+    assert_eq!(publish.status(), StatusCode::NOT_FOUND);
+
+    let batch_publish = app
+        .clone()
+        .oneshot(Request::put("/-/pnpm/v1/publish").body(Body::from("{}")).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(batch_publish.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn registry_only_serves_registry_and_refuses_resolver_endpoints() {
+    let mut upstream = mockito::Server::new_async().await;
+    let mock = upstream
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_body(json!({ "name": "foo", "versions": {} }).to_string())
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for(&upstream.url(), tmp.path().to_path_buf());
+    config.resolver.enabled = false;
+    let app = router(config);
+
+    // The registry surface still works: ping and a proxied packument read.
+    let ping =
+        app.clone().oneshot(Request::get("/-/ping").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(ping.status(), StatusCode::OK);
+
+    let packument =
+        app.clone().oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(packument.status(), StatusCode::OK);
+
+    // The resolver surface is gone: the handshake and both resolver
+    // endpoints 404.
+    let handshake =
+        app.clone().oneshot(Request::get("/-/pnpr").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(handshake.status(), StatusCode::NOT_FOUND);
+
+    let resolve = app
+        .clone()
+        .oneshot(Request::post("/v1/resolve").body(Body::from("{}")).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resolve.status(), StatusCode::NOT_FOUND);
+
+    let verify = app
+        .clone()
+        .oneshot(Request::post("/v1/verify-lockfile").body(Body::from("{}")).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(verify.status(), StatusCode::NOT_FOUND);
+
+    mock.assert_async().await;
+}


### PR DESCRIPTION
## Summary

Adds two independently toggleable surfaces to the pnpr server, configured via per-surface blocks (both enabled by default):

```yaml
registry:
  enabled: true   # packuments, tarballs, publish, search, users
resolver:
  enabled: true   # /-/pnpr, /v1/resolve, /v1/verify-lockfile
```

- Disable the registry to run a stateless **resolver-only** tier in front of an existing registry (the install-accelerator use case).
- Disable the resolver to run a **registry-only** server with no server-side resolution.
- `/-/ping` is always served. At least one surface must stay enabled (validated at config load and again after CLI overrides). CLI flags `--disable-registry` / `--disable-resolver` override the config.

OSV stays a **top-level** setting rather than nesting under either surface, because it is a cross-cutting policy. The registry serving path does not yet apply OSV screening; that gap is tracked in pnpm/pnpm#12561.

## Squash Commit Body

```text
pnpr now exposes its registry and resolver surfaces as independent,
config-toggleable features (per-surface `registry:` / `resolver:` blocks,
both enabled by default; CLI `--disable-registry` / `--disable-resolver`).
This supports running a stateless resolver-only tier in front of an
existing registry, or a registry with no server-side resolution. At least
one surface must stay enabled, validated at config load and after CLI
overrides.

The resolver paths overlap the registry's catch-all param routes, so when
the resolver is disabled they are registered to an explicit 404 stub —
otherwise a capability probe (GET /-/pnpr) would fall through to the
registry and be proxied upstream, surfacing a 502 where clients expect the
"no resolver" 404.

OSV stays a top-level (cross-cutting) setting rather than nesting under a
surface. Registry-side OSV screening is not yet implemented; tracked in
pnpm/pnpm#12561.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. — N/A: this is a change to the standalone `pnpr` server (its own subproject), which has no TypeScript-CLI or pacquet counterpart.
- [x] Added a changeset if this PR changes any published package. — N/A: `pnpr` is the Rust server binary; no published JS package is affected, so the JS changeset flow does not apply.
- [x] Added or updated tests. — `resolver_only` / `registry_only` server tests, plus config unit tests for feature parsing and the both-disabled validation error.
- [x] Updated the documentation if needed. — documented the `registry:` / `resolver:` blocks in the bundled `config.yaml`.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added YAML/runtime feature toggles to independently enable/disable the registry and resolver surfaces; `/-/ping` is always served.
  * Added CLI flags `--disable_registry` and `--disable_resolver` to override toggles at startup.
  * Added validation to prevent configurations where both surfaces are disabled.
* **Tests**
  * Added unit tests for toggle parsing (including YAML omission/`null` behavior and unknown/typo keys) and for “strict” registry-side handling when registry is disabled.
  * Added integration tests to verify correct route mounting and 404 behavior when each surface is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->