### PR TITLE
refactor(pnpr): move resolver endpoints under the /-/pnpr namespace

### DIFF
--- a/.changeset/pnpr-resolver-routes-under-pnpr-namespace.md
+++ b/.changeset/pnpr-resolver-routes-under-pnpr-namespace.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/pnpr.client": patch
+"pnpm": patch
+---
+
+The pnpr resolver endpoints moved under the reserved `/-/pnpr` namespace: `POST /v1/resolve` is now `POST /-/pnpr/v0/resolve` and `POST /v1/verify-lockfile` is now `POST /-/pnpr/v0/verify-lockfile`. The capability handshake at `GET /-/pnpr` advertises protocol version `0` to match. This keeps every pnpr-proprietary route in npm's reserved namespace, so it can never collide with a package path.

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -514,18 +514,18 @@ struct PnprLink<'a> {
     node_linker: NodeLinker,
     skip_runtimes: bool,
     /// Governs the *server's* resolution behavior (frozen vs
-    /// reuse-and-update); forwarded to `/v1/resolve`. The local
+    /// reuse-and-update); forwarded to `/-/pnpr/v0/resolve`. The local
     /// materialization always runs frozen against the server-produced
     /// lockfile.
     frozen_lockfile: bool,
     /// The *effective* `preferFrozenLockfile` (the CLI tri-state already
     /// resolved against `config.prefer_frozen_lockfile`, exactly as the
-    /// local `Install` resolves it); forwarded to `/v1/resolve`. `false`
+    /// local `Install` resolves it); forwarded to `/-/pnpr/v0/resolve`. `false`
     /// forces the server to re-resolve. Resolving here — rather than
     /// sending the raw CLI override — keeps a yaml `preferFrozenLockfile:
     /// false` honored on the pnpr path without `--no-prefer-frozen-lockfile`.
     prefer_frozen_lockfile: bool,
-    /// `--lockfile-only`. Forwarded to `/v1/resolve` so the server
+    /// `--lockfile-only`. Forwarded to `/-/pnpr/v0/resolve` so the server
     /// resolves only — returning the lockfile without fetching files —
     /// after which `install_via_pnpr` writes the lockfile and skips
     /// materialization, mirroring pnpm's resolve + write, fetch nothing,

--- a/pacquet/crates/cli/tests/pnpr_install.rs
+++ b/pacquet/crates/cli/tests/pnpr_install.rs
@@ -114,7 +114,7 @@ fn frozen_install_via_pnpr_verifies_the_local_lockfile_without_resolving_or_redo
 
     let mut verifier = mockito::Server::new();
     let verify_mock = verifier
-        .mock("POST", "/v1/verify-lockfile")
+        .mock("POST", "/-/pnpr/v0/verify-lockfile")
         .with_status(200)
         .with_header("content-type", "application/x-ndjson")
         .with_body("{\"type\":\"done\"}\n")

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -81,7 +81,7 @@ where
     pub resolution_verifiers: &'a [Arc<dyn ResolutionVerifier>],
     /// When set, replaces the local `resolution_verifiers` fan-out as the
     /// trust verdict — used by the pnpr client to delegate verification to
-    /// the server's `/v1/verify-lockfile` while the fetch runs locally. The
+    /// the server's `/-/pnpr/v0/verify-lockfile` while the fetch runs locally. The
     /// same concurrent sequencing and build gate apply.
     pub lockfile_verification_override: Option<LockfileVerificationOverride<'a>>,
     /// Absolute path of the lockfile being verified, for the on-disk

--- a/pacquet/crates/package-manager/src/tarball_prefetch.rs
+++ b/pacquet/crates/package-manager/src/tarball_prefetch.rs
@@ -1,7 +1,7 @@
 //! Background tarball downloads for the pnpr client path.
 //!
 //! [`TarballPrefetcher`] fires a download as each `package` frame streams
-//! in from `/v1/resolve` so the fetch overlaps the *server's* resolution
+//! in from `/-/pnpr/v0/resolve` so the fetch overlaps the *server's* resolution
 //! ([pnpm/pnpm#12234](https://github.com/pnpm/pnpm/issues/12234)). It is
 //! the streaming-client analogue of [`crate::PrefetchingResolver`] (the
 //! local fresh-install prefetcher), but independent: the resolver path
@@ -143,7 +143,7 @@ pub(crate) fn spawn_tarball_download(download: TarballDownload) {
 }
 
 /// Fires background tarball downloads on the pnpr client as resolved
-/// packages stream in from `/v1/resolve`, so each tarball fetch overlaps
+/// packages stream in from `/-/pnpr/v0/resolve`, so each tarball fetch overlaps
 /// the server's still-running resolution rather than waiting for the
 /// finished lockfile.
 ///

--- a/pacquet/crates/pnpr-client/src/lib.rs
+++ b/pacquet/crates/pnpr-client/src/lib.rs
@@ -1,6 +1,6 @@
 //! Client for pnpr's server-side resolver.
 //!
-//! Given a set of dependencies, it `POST`s them to `/v1/resolve`, where
+//! Given a set of dependencies, it `POST`s them to `/-/pnpr/v0/resolve`, where
 //! the server resolves against the client's registries, verifies the
 //! input lockfile under the client's policy, and streams the result back
 //! as NDJSON: one `package` frame per resolved tarball as the server's
@@ -83,7 +83,7 @@ pub struct ResolveOptions {
     pub trust_policy_ignore_after: Option<u64>,
 }
 
-/// Inputs for `/v1/verify-lockfile`, the resolution-free trust verdict
+/// Inputs for `/-/pnpr/v0/verify-lockfile`, the resolution-free trust verdict
 /// used by frozen restores that already know the local lockfile is fresh.
 #[derive(Clone)]
 pub struct VerifyLockfileOptions {
@@ -189,8 +189,8 @@ pub enum PnprClientError {
 }
 
 /// Protocol version this client speaks. The server advertises the
-/// versions it supports at `GET /-/pnpr`; today only v1 exists.
-const PROTOCOL_VERSION: u32 = 1;
+/// versions it supports at `GET /-/pnpr`; today only v0 exists.
+const PROTOCOL_VERSION: u32 = 0;
 
 #[derive(Default, Deserialize)]
 struct HandshakeResponse {
@@ -267,7 +267,7 @@ impl PnprClient {
         });
 
         let mut post =
-            self.http.post(format!("{}v1/verify-lockfile", self.base_url)).json(&request);
+            self.http.post(format!("{}-/pnpr/v0/verify-lockfile", self.base_url)).json(&request);
         if let Some(authorization) = opts.authorization.as_deref() {
             post = post.header("authorization", authorization);
         }
@@ -276,7 +276,7 @@ impl PnprClient {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
             return Err(PnprClientError::Server(format!(
-                "/v1/verify-lockfile returned {status}: {body}",
+                "/-/pnpr/v0/verify-lockfile returned {status}: {body}",
             )));
         }
 
@@ -303,7 +303,7 @@ impl PnprClient {
         }
 
         Err(PnprClientError::Protocol(
-            "/v1/verify-lockfile stream ended without a terminal frame".to_string(),
+            "/-/pnpr/v0/verify-lockfile stream ended without a terminal frame".to_string(),
         ))
     }
 
@@ -341,7 +341,7 @@ impl PnprClient {
             "trustPolicyIgnoreAfter": opts.trust_policy_ignore_after,
         });
 
-        let mut post = self.http.post(format!("{}v1/resolve", self.base_url)).json(&request);
+        let mut post = self.http.post(format!("{}-/pnpr/v0/resolve", self.base_url)).json(&request);
         if let Some(authorization) = opts.authorization.as_deref() {
             post = post.header("authorization", authorization);
         }
@@ -349,7 +349,9 @@ impl PnprClient {
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            return Err(PnprClientError::Server(format!("/v1/resolve returned {status}: {body}")));
+            return Err(PnprClientError::Server(format!(
+                "/-/pnpr/v0/resolve returned {status}: {body}",
+            )));
         }
 
         // Consume the NDJSON stream line by line. `package` frames feed
@@ -398,7 +400,7 @@ impl PnprClient {
             }
         }
         Err(PnprClientError::Protocol(
-            "/v1/resolve stream ended without a terminal frame".to_string(),
+            "/-/pnpr/v0/resolve stream ended without a terminal frame".to_string(),
         ))
     }
 }
@@ -411,7 +413,7 @@ fn parse_verify_frame(line: &[u8]) -> Result<VerifyFrame, PnprClientError> {
     serde_json::from_slice(line).map_err(|err| PnprClientError::Protocol(err.to_string()))
 }
 
-/// One NDJSON frame from `/v1/resolve`. `package` frames stream as the
+/// One NDJSON frame from `/-/pnpr/v0/resolve`. `package` frames stream as the
 /// server resolves; exactly one terminal frame (`done` / `error` /
 /// `violations`) closes the response.
 #[derive(Deserialize)]

--- a/pacquet/crates/pnpr-client/tests/integration.rs
+++ b/pacquet/crates/pnpr-client/tests/integration.rs
@@ -2,7 +2,7 @@
 //!
 //! Topology: a shared [`TestRegistry`] serves the package fixtures; a
 //! per-test in-process `pnpr` hosts the `/-/pnpr` handshake +
-//! `/v1/resolve` endpoints. The client sends the registry it wants
+//! `/-/pnpr/v0/resolve` endpoints. The client sends the registry it wants
 //! resolved from, so the pnpr server's *own* uplink is left at the
 //! default — proving resolution uses the client-supplied registry. pnpr
 //! serves no file content; the client receives only the resolved
@@ -119,7 +119,7 @@ fn options(registry: &str, dependencies: BTreeMap<String, String>) -> ResolveOpt
 async fn forwards_credentials_and_the_identity_header() {
     let mut server = mockito::Server::new_async().await;
     let mock = server
-        .mock("POST", "/v1/resolve")
+        .mock("POST", "/-/pnpr/v0/resolve")
         .match_header("authorization", "Bearer pnpr-token")
         .match_body(mockito::Matcher::PartialJsonString(
             r#"{"authHeaders":{"//npm.acme.test/":{"@":"Bearer upstream-token"}}}"#.to_string(),
@@ -366,7 +366,7 @@ async fn verify_lockfile_endpoint_rejects_policy_violation() {
 }
 
 /// The verification fan-out fetches each entry's packument, so a gated
-/// package verifies only when `/v1/verify-lockfile` forwards the
+/// package verifies only when `/-/pnpr/v0/verify-lockfile` forwards the
 /// client's credential map — and fails closed when it doesn't. Each
 /// verify call targets a fresh pnpr so neither the whole-lockfile
 /// verdict cache nor the metadata mirror warmed by an earlier call can

--- a/pnpm11/pnpm/test/install/pnpmRegistry.ts
+++ b/pnpm11/pnpm/test/install/pnpmRegistry.ts
@@ -11,7 +11,7 @@ import { writeYamlFileSync } from 'write-yaml-file'
 import { execPnpm } from '../utils/index.js'
 
 // The pnpr server started by the test harness (see the with-registry jest
-// preset) serves the resolver endpoint (/v1/resolve) on the
+// preset) serves the resolver endpoint (/-/pnpr/v0/resolve) on the
 // registry-mock port, so it doubles as the pnpr server under test.
 const PNPR = `http://localhost:${REGISTRY_MOCK_PORT}`
 
@@ -20,7 +20,7 @@ let serverPort: number
 let requestCount: number
 
 beforeAll(async () => {
-  // Counting proxy — forwards to the pnpr server and counts /v1/resolve
+  // Counting proxy — forwards to the pnpr server and counts /-/pnpr/v0/resolve
   // requests so we can assert that the pnpr server path was actually taken.
   requestCount = 0
   server = http.createServer((req, res) => {
@@ -28,7 +28,7 @@ beforeAll(async () => {
       res.writeHead(400).end()
       return
     }
-    if (req.url === '/v1/resolve') {
+    if (req.url === '/-/pnpr/v0/resolve') {
       requestCount++
     }
     const proxyReq = http.request(`${PNPR}${req.url}`, {

--- a/pnpr/client/src/resolveViaPnprServer.ts
+++ b/pnpr/client/src/resolveViaPnprServer.ts
@@ -70,7 +70,7 @@ export interface ResolveViaPnprServerResult {
 interface Violation { name: string, version: string, code: string, reason: string }
 
 /**
- * One NDJSON frame from `POST /v1/resolve`. `package` frames stream as
+ * One NDJSON frame from `POST /-/pnpr/v0/resolve`. `package` frames stream as
  * the server resolves; exactly one terminal frame (`done` / `error` /
  * `violations`) closes the response.
  */
@@ -84,7 +84,7 @@ type ResolveFrame =
  * Resolve a project against a pnpr server and return the resolved
  * lockfile.
  *
- * `POST /v1/resolve` answers with an `application/x-ndjson` stream: one
+ * `POST /-/pnpr/v0/resolve` answers with an `application/x-ndjson` stream: one
  * `package` frame per resolved tarball as the server's tree walk yields
  * it, then exactly one terminal frame — `done` (full lockfile + stats),
  * `error`, or `violations`. pnpr serves no file content — the caller
@@ -142,7 +142,7 @@ export async function resolveViaPnprServer (
 type TerminalFrame = Extract<ResolveFrame, { type: 'done' | 'error' | 'violations' }>
 
 /**
- * Parse the NDJSON `/v1/resolve` body and return its single terminal
+ * Parse the NDJSON `/-/pnpr/v0/resolve` body and return its single terminal
  * frame. `package` frames are skipped — this client fetches tarballs the
  * normal way after resolution rather than overlapping fetch with the
  * stream. Throws on an unknown frame type (so a protocol mismatch fails
@@ -157,15 +157,15 @@ function parseTerminalFrame (body: string): TerminalFrame {
     if (frame.type === 'done' || frame.type === 'error' || frame.type === 'violations') {
       return frame
     }
-    throw new Error(`pnpr server /v1/resolve stream emitted an unknown frame type: ${String((frame as { type: unknown }).type)}`)
+    throw new Error(`pnpr server /-/pnpr/v0/resolve stream emitted an unknown frame type: ${String((frame as { type: unknown }).type)}`)
   }
-  throw new Error('pnpr server /v1/resolve stream ended without a terminal frame')
+  throw new Error('pnpr server /-/pnpr/v0/resolve stream ended without a terminal frame')
 }
 
 const REQUEST_TIMEOUT = 600_000 // 10 minutes — server-side resolution can be slow on first run
 
 /**
- * `POST /v1/resolve` and return the full response body, decompressed.
+ * `POST /-/pnpr/v0/resolve` and return the full response body, decompressed.
  *
  * `urlPath` resolution normalizes the base to end with "/" so a path
  * prefix configured on the pnpr server URL (e.g. https://host/pnpr/) is
@@ -173,7 +173,7 @@ const REQUEST_TIMEOUT = 600_000 // 10 minutes — server-side resolution can be 
  */
 async function postResolve (registryUrl: string, body: string, authorization?: string): Promise<Buffer> {
   const base = registryUrl.endsWith('/') ? registryUrl : `${registryUrl}/`
-  const url = new URL('v1/resolve', base)
+  const url = new URL('-/pnpr/v0/resolve', base)
   const requestFn = url.protocol === 'https:' ? https.request : http.request
 
   const headers: http.OutgoingHttpHeaders = {

--- a/pnpr/crates/pnpr/config.yaml
+++ b/pnpr/crates/pnpr/config.yaml
@@ -45,8 +45,8 @@ storage: ./storage
 # stay enabled. (`/-/ping` is always served.)
 #registry:          # npm registry: packument/tarball reads, publish,
 #  enabled: true    # unpublish, dist-tag, search, user/login endpoints
-#resolver:          # install accelerator: /-/pnpr, /v1/resolve,
-#  enabled: true    # and /v1/verify-lockfile
+#resolver:          # install accelerator: /-/pnpr, /-/pnpr/v0/resolve,
+#  enabled: true    # and /-/pnpr/v0/verify-lockfile
 secret: pnpm-registry-mock-secret-key-32
 
 auth:

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -119,7 +119,7 @@ pub struct Config {
     /// of an existing registry. See [`RegistryFeature`].
     pub registry: RegistryFeature,
     /// The install-accelerator surface: the `/-/pnpr` handshake and the
-    /// `/v1/resolve` / `/v1/verify-lockfile` endpoints. Enabled by
+    /// `/-/pnpr/v0/resolve` / `/-/pnpr/v0/verify-lockfile` endpoints. Enabled by
     /// default; disable it to run a plain registry with no server-side
     /// resolution. See [`ResolverFeature`].
     pub resolver: ResolverFeature,
@@ -147,8 +147,8 @@ impl Default for RegistryFeature {
 /// independently.
 #[derive(Debug, Clone)]
 pub struct ResolverFeature {
-    /// Master switch for the resolver surface (`/-/pnpr`, `/v1/resolve`,
-    /// `/v1/verify-lockfile`). When `false`, none of those routes are
+    /// Master switch for the resolver surface (`/-/pnpr`, `/-/pnpr/v0/resolve`,
+    /// `/-/pnpr/v0/verify-lockfile`). When `false`, none of those routes are
     /// mounted.
     pub enabled: bool,
 }

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -58,8 +58,8 @@ struct Args {
     #[arg(long)]
     disable_registry: bool,
 
-    /// Disable the install-accelerator surface (`/-/pnpr`, `/v1/resolve`,
-    /// `/v1/verify-lockfile`). Overrides `resolver.enabled` from the
+    /// Disable the install-accelerator surface (`/-/pnpr`, `/-/pnpr/v0/resolve`,
+    /// `/-/pnpr/v0/verify-lockfile`). Overrides `resolver.enabled` from the
     /// loaded config.
     #[arg(long)]
     disable_resolver: bool,

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -6,7 +6,7 @@
 //!
 //! * `GET /-/pnpr` — capability handshake; advertises the supported
 //!   protocol versions so a client can negotiate or fail fast.
-//! * `POST /v1/resolve` — resolve a project **against the registries
+//! * `POST /-/pnpr/v0/resolve` — resolve a project **against the registries
 //!   the client sends** (so the server uses the same source of truth as
 //!   the client), verify the client's input lockfile under the client's
 //!   policy, and **stream** the result back as NDJSON: one `package`
@@ -17,7 +17,7 @@
 //!   ([pnpm/pnpm#12234](https://github.com/pnpm/pnpm/issues/12234)),
 //!   then fetches the rest in parallel like a normal install
 //!   ([pnpm/pnpm#12230](https://github.com/pnpm/pnpm/issues/12230)).
-//! * `POST /v1/verify-lockfile` — verify an already-fresh client
+//! * `POST /-/pnpr/v0/verify-lockfile` — verify an already-fresh client
 //!   lockfile under the same policy without resolving. A frozen restore
 //!   can start local fetch/materialization immediately and only use this
 //!   endpoint as the trust verdict.
@@ -199,7 +199,7 @@ impl Resolver {
     }
 }
 
-/// Handle `POST /v1/resolve`: verify the client's input lockfile under
+/// Handle `POST /-/pnpr/v0/resolve`: verify the client's input lockfile under
 /// the client's policy, resolve against the client's registries, and
 /// stream the result back as NDJSON.
 ///
@@ -322,7 +322,7 @@ pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response 
     ndjson_stream_response(rx)
 }
 
-/// Handle `POST /v1/verify-lockfile`: verify the client's input
+/// Handle `POST /-/pnpr/v0/verify-lockfile`: verify the client's input
 /// lockfile under the client's policy, returning only a terminal NDJSON
 /// verdict frame. The client already knows the lockfile is fresh for
 /// the current manifests, so this endpoint deliberately does not
@@ -345,7 +345,7 @@ pub(crate) async fn handle_verify_lockfile(runtime: &Resolver, body: Bytes) -> R
     let request_auth = Arc::new(AuthHeaders::from_by_scope(request.auth_headers.clone()));
 
     match verify_input_lockfile(runtime, config, &request_auth, input_lockfile).await {
-        // The dist stats the verifier observed feed `/v1/resolve`'s sized
+        // The dist stats the verifier observed feed `/-/pnpr/v0/resolve`'s sized
         // `package` frames; this endpoint's client prefetches from its own
         // lockfile before the verdict arrives, so only the verdict is sent.
         Ok(_) => verify_done_or_osv_violations(runtime.osv_index.as_ref(), input_lockfile),
@@ -435,7 +435,7 @@ fn resolution_cache_key(config: &PacquetConfig, request: &ResolveRequest) -> Opt
     Some(format!("{:x}", hasher.finalize()))
 }
 
-/// NDJSON content type for the `/v1/resolve` response. One JSON object
+/// NDJSON content type for the `/-/pnpr/v0/resolve` response. One JSON object
 /// per line; the client parses frames as they arrive. Excluded from the
 /// server's gzip [`CompressionLayer`](crate::server) so frames flush to
 /// the client incrementally rather than being buffered by the encoder.

--- a/pnpr/crates/pnpr/src/resolver/protocol.rs
+++ b/pnpr/crates/pnpr/src/resolver/protocol.rs
@@ -27,7 +27,7 @@ fn root_dir() -> String {
     ".".to_string()
 }
 
-/// Body of `POST /v1/resolve`. The registry fields carry the *client's*
+/// Body of `POST /-/pnpr/v0/resolve`. The registry fields carry the *client's*
 /// resolution configuration so the server resolves against the same
 /// registries the client would, and the policy fields carry the
 /// client's verification policy so the server verifies the input

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -188,7 +188,7 @@ pub async fn resolve(
         // per-user auth into the interned `&'static Config`.
         auth_override: Some(Arc::clone(auth_headers)),
         // Stream each resolved tarball to the client as the walk yields
-        // it (`/v1/resolve` NDJSON `package` frames) so tarball fetch
+        // it (`/-/pnpr/v0/resolve` NDJSON `package` frames) so tarball fetch
         // overlaps this server-side resolution. `None` falls back to a
         // single terminal `done` frame carrying the whole lockfile.
         resolution_observer: observer,

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -69,7 +69,7 @@ struct AppInner {
     /// two concurrent writers to the same package on this instance can't
     /// lose each other's changes. See [`PackageLocks`].
     package_locks: PackageLocks,
-    /// Lazily-built engine backing the `/v1/resolve` endpoint. Built on
+    /// Lazily-built engine backing the `/-/pnpr/v0/resolve` endpoint. Built on
     /// first such request so servers that never receive one pay nothing.
     resolver: std::sync::OnceLock<crate::resolver::Resolver>,
     /// Local OSV index, loaded before the server accepts requests when
@@ -246,27 +246,26 @@ fn router_with_auth_and_osv(
     // so an operator can run resolver-only, registry-only, or both. The
     // config guarantees at least one is enabled.
     let mut router = Router::new().route("/-/ping", get(serve_ping));
-    // The install-accelerator (resolver) surface. `/-/pnpr` is the
-    // capability handshake (404 on a plain registry); `/v1/resolve` and
-    // `/v1/verify-lockfile` are the resolver endpoints. These resolve
-    // against the registries the *client* sends, so the accelerator works
-    // whether or not this process also fronts a registry.
+    // The install-accelerator (resolver) surface, all under the reserved
+    // `/-/pnpr` namespace. `/-/pnpr` is the capability handshake (404 on a
+    // plain registry); `/-/pnpr/v0/resolve` and `/-/pnpr/v0/verify-lockfile`
+    // are the resolver endpoints. These resolve against the registries the
+    // *client* sends, so the accelerator works whether or not this process
+    // also fronts a registry.
     //
     // When the resolver is disabled, only `/-/pnpr` gets a 404 stub: it is
     // the capability-probe path and overlaps the registry catch-all
     // (`/-/pnpr` matches `/{first}/{second}`), so without the stub a probe
     // would be proxied upstream, giving a confusing 502 where a client
-    // expects the "no resolver here" 404. `/v1/resolve` and
-    // `/v1/verify-lockfile` carry no capability probe and are POST-only, so
-    // they are left unmounted rather than stubbed: that keeps the registry
-    // npm-compatible for the (unusual but legitimate) version-manifest
-    // paths `GET /v1/resolve` / `GET /v1/verify-lockfile` (package `v1`,
-    // tag `resolve` / `verify-lockfile`), with their POST falling to a 405.
+    // expects the "no resolver here" 404. The `/-/pnpr/v0/*` endpoints carry
+    // no capability probe, so they are left unmounted rather than stubbed: a
+    // client learns the resolver is absent from the handshake 404 and never
+    // calls them.
     if resolver_enabled {
         router = router
             .route("/-/pnpr", get(serve_pnpr_handshake))
-            .route("/v1/resolve", post(serve_resolve))
-            .route("/v1/verify-lockfile", post(serve_verify_lockfile));
+            .route("/-/pnpr/v0/resolve", post(serve_resolve))
+            .route("/-/pnpr/v0/verify-lockfile", post(serve_verify_lockfile));
     } else {
         router = router.route("/-/pnpr", any(resolver_disabled));
     }
@@ -2132,9 +2131,9 @@ async fn serve_ping(State(_state): State<AppState>) -> Response {
 /// `GET /-/pnpr` — capability handshake for the pnpr resolver
 /// protocol. A plain npm registry has no such route and 404s, so a
 /// client can fail fast against a misconfigured server. `versions`
-/// lists the `/vN/resolve` protocol versions this server speaks.
+/// lists the `/-/pnpr/vN/resolve` protocol versions this server speaks.
 async fn serve_pnpr_handshake() -> Response {
-    (StatusCode::OK, axum::Json(serde_json::json!({ "pnpr": { "versions": [1] } }))).into_response()
+    (StatusCode::OK, axum::Json(serde_json::json!({ "pnpr": { "versions": [0] } }))).into_response()
 }
 
 /// 404 stub mounted on the resolver paths when the resolver feature is

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -913,7 +913,7 @@ async fn resolver_only_serves_resolver_endpoints_and_refuses_registry_routes() {
     let app = router(config);
 
     // The resolver surface stays reachable. `/-/ping` and the capability
-    // handshake answer 200; `/v1/verify-lockfile` is mounted, so an empty
+    // handshake answer 200; `/-/pnpr/v0/verify-lockfile` is mounted, so an empty
     // body is a 400 (bad request) rather than a 404 (route absent) — that
     // distinction is the point of the assertion.
     let ping =
@@ -926,7 +926,7 @@ async fn resolver_only_serves_resolver_endpoints_and_refuses_registry_routes() {
 
     let verify = app
         .clone()
-        .oneshot(Request::post("/v1/verify-lockfile").body(Body::empty()).unwrap())
+        .oneshot(Request::post("/-/pnpr/v0/verify-lockfile").body(Body::empty()).unwrap())
         .await
         .unwrap();
     assert_ne!(
@@ -990,21 +990,21 @@ async fn registry_only_serves_registry_and_refuses_resolver_endpoints() {
         app.clone().oneshot(Request::post("/-/pnpr").body(Body::empty()).unwrap()).await.unwrap();
     assert_eq!(handshake_post.status(), StatusCode::NOT_FOUND);
 
-    // `/v1/resolve` and `/v1/verify-lockfile` are NOT stubbed: they belong
-    // to the registry's version-manifest route (`GET|PUT /{first}/{second}`,
-    // i.e. package `v1`, tag `resolve` / `verify-lockfile`), so a POST
-    // returns 405 — proving the resolver stubs no longer shadow these
-    // legitimate registry paths.
+    // `/-/pnpr/v0/resolve` and `/-/pnpr/v0/verify-lockfile` are NOT stubbed:
+    // with the resolver disabled they fall through to the registry's
+    // four-segment catch-all (`GET|DELETE /{a}/{b}/{c}/{d}`), which has no
+    // POST handler, so a POST returns 405. Only `/-/pnpr` needs a stub for
+    // clean capability detection.
     let resolve = app
         .clone()
-        .oneshot(Request::post("/v1/resolve").body(Body::from("{}")).unwrap())
+        .oneshot(Request::post("/-/pnpr/v0/resolve").body(Body::from("{}")).unwrap())
         .await
         .unwrap();
     assert_eq!(resolve.status(), StatusCode::METHOD_NOT_ALLOWED);
 
     let verify = app
         .clone()
-        .oneshot(Request::post("/v1/verify-lockfile").body(Body::from("{}")).unwrap())
+        .oneshot(Request::post("/-/pnpr/v0/verify-lockfile").body(Body::from("{}")).unwrap())
         .await
         .unwrap();
     assert_eq!(verify.status(), StatusCode::METHOD_NOT_ALLOWED);


### PR DESCRIPTION
## Summary

In pnpr, every proprietary route except the resolver's two POST endpoints already lived under npm's reserved `/-/` namespace (`/-/ping`, `/-/pnpr` handshake, `/-/pnpm/v1/publish`). The resolver endpoints sat at `/v1/resolve` and `/v1/verify-lockfile`, which overlaps the package path space — a package literally named `v1` — forcing the server to keep those `GET` paths npm-compatible.

This PR moves the two endpoints into the reserved namespace, grouping them with the handshake they're discovered through:

- `POST /v1/resolve` → `POST /-/pnpr/v0/resolve`
- `POST /v1/verify-lockfile` → `POST /-/pnpr/v0/verify-lockfile`
- `GET /-/pnpr` handshake now advertises `{"pnpr":{"versions":[0]}}`; the Rust client's `PROTOCOL_VERSION` drops to `0`.

Putting all pnpr routes in the reserved namespace removes the package-collision concern entirely and lets the disabled-resolver branch stop special-casing the old npm-compatible `GET` paths. No backward compatibility is kept — the resolver protocol is not yet released — so the server and both clients (Rust `pacquet-pnpr-client` and the TypeScript `@pnpm/pnpr.client`) change together.

## Squash Commit Body

```text
refactor(pnpr): move resolver endpoints under the /-/pnpr namespace

The pnpr resolver's two POST endpoints were the only proprietary routes
served outside npm's reserved /-/ namespace, where they overlapped the
package path space (a package literally named `v1`). Move them under the
/-/pnpr namespace alongside the existing capability handshake:

  POST /v1/resolve         -> POST /-/pnpr/v0/resolve
  POST /v1/verify-lockfile -> POST /-/pnpr/v0/verify-lockfile

The GET /-/pnpr handshake now advertises protocol version 0 to match, and
the Rust client's PROTOCOL_VERSION drops to 0. Keeping every pnpr route in
the reserved namespace removes the package-collision concern and lets the
disabled-resolver branch stop special-casing the old npm-compatible GET
paths.

No backward compatibility is kept: the resolver protocol is not yet
released. Server and both clients (Rust pacquet-pnpr-client and the
TypeScript @pnpm/pnpr.client) change together.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port (server: `pnpr` crate; clients: `pacquet-pnpr-client` and `@pnpm/pnpr.client`).
- [x] Added a changeset.
- [x] Added or updated tests (route-mounting tests, pnpr-client integration tests, CLI `pnpr_install` test, and the TS counting-proxy test).
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Migrated pnpr resolver endpoints to the reserved `/-/pnpr` namespace: `POST /v1/resolve` → `POST /-/pnpr/v0/resolve` and `POST /v1/verify-lockfile` → `POST /-/pnpr/v0/verify-lockfile`.
  * Updated protocol version from `1` to `0` in handshake responses.

* **Chores**
  * Updated documentation and test expectations across client and server implementations to reflect new endpoint paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->