### PR TITLE
feat(pacquet): `logout`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3544,6 +3544,8 @@ dependencies = [
  "reqwest 0.13.4",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3538,9 +3538,11 @@ version = "0.0.1"
 dependencies = [
  "derive_more",
  "miette 7.6.0",
+ "mockito",
  "pacquet-network",
  "pacquet-reporter",
  "reqwest 0.13.4",
+ "tempfile",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3533,6 +3533,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pacquet-auth-commands"
+version = "0.0.1"
+dependencies = [
+ "derive_more",
+ "miette 7.6.0",
+ "pacquet-network",
+ "pacquet-reporter",
+ "reqwest 0.13.4",
+ "tokio",
+]
+
+[[package]]
 name = "pacquet-catalogs-config"
 version = "0.0.1"
 dependencies = [
@@ -3585,6 +3597,7 @@ dependencies = [
  "node-semver",
  "owo-colors",
  "p256",
+ "pacquet-auth-commands",
  "pacquet-catalogs-config",
  "pacquet-cmd-shim",
  "pacquet-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3539,6 +3539,7 @@ dependencies = [
  "derive_more",
  "miette 7.6.0",
  "mockito",
+ "pacquet-fs",
  "pacquet-network",
  "pacquet-reporter",
  "reqwest 0.13.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ repository  = "https://github.com/pnpm/pacquet"
 [workspace.dependencies]
 # Crates
 pacquet-pnpr-client                       = { path = "pacquet/crates/pnpr-client" }
+pacquet-auth-commands                     = { path = "pacquet/crates/auth-commands" }
 pacquet-catalogs-config                   = { path = "pacquet/crates/catalogs-config" }
 pacquet-catalogs-protocol-parser          = { path = "pacquet/crates/catalogs-protocol-parser" }
 pacquet-catalogs-resolver                 = { path = "pacquet/crates/catalogs-resolver" }

--- a/pacquet/crates/auth-commands/Cargo.toml
+++ b/pacquet/crates/auth-commands/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
+pacquet-fs       = { workspace = true }
 pacquet-network  = { workspace = true }
 pacquet-reporter = { workspace = true }
 

--- a/pacquet/crates/auth-commands/Cargo.toml
+++ b/pacquet/crates/auth-commands/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name                  = "pacquet-auth-commands"
+version               = "0.0.1"
+publish               = false
+authors.workspace     = true
+description.workspace = true
+edition.workspace     = true
+homepage.workspace    = true
+keywords.workspace    = true
+license.workspace     = true
+repository.workspace  = true
+
+[dependencies]
+pacquet-network  = { workspace = true }
+pacquet-reporter = { workspace = true }
+
+derive_more = { workspace = true }
+miette      = { workspace = true }
+reqwest     = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/pacquet/crates/auth-commands/Cargo.toml
+++ b/pacquet/crates/auth-commands/Cargo.toml
@@ -19,7 +19,9 @@ miette      = { workspace = true }
 reqwest     = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true }
+mockito  = { workspace = true }
+tempfile = { workspace = true }
+tokio    = { workspace = true }
 
 [lints]
 workspace = true

--- a/pacquet/crates/auth-commands/Cargo.toml
+++ b/pacquet/crates/auth-commands/Cargo.toml
@@ -19,9 +19,11 @@ miette      = { workspace = true }
 reqwest     = { workspace = true }
 
 [dev-dependencies]
-mockito  = { workspace = true }
-tempfile = { workspace = true }
-tokio    = { workspace = true }
+mockito            = { workspace = true }
+tempfile           = { workspace = true }
+tokio              = { workspace = true }
+tracing            = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true

--- a/pacquet/crates/auth-commands/src/ini.rs
+++ b/pacquet/crates/auth-commands/src/ini.rs
@@ -1,0 +1,65 @@
+//! A flat `key=value` INI reader/writer for `auth.ini`.
+//!
+//! `pnpm login` / `pnpm logout` keep their tokens in `auth.ini`, a file
+//! that only ever holds top-level `//host/path/:_authToken=<token>`
+//! lines (no sections, no arrays). Upstream pnpm round-trips it through
+//! `read-ini-file` / `write-ini-file`; pacquet has no INI crate, and the
+//! `.npmrc` parser in `pacquet-config` is likewise hand-rolled. This is
+//! the matching minimal reader/writer for the auth-command file.
+//!
+//! Entries keep their on-disk order so removing one token rewrites the
+//! file without churning the rest. Section headers (`[name]`), bare keys
+//! (no `=`), and comment lines (`;` / `#`) are not part of `auth.ini`'s
+//! shape and are skipped on read.
+
+/// An ordered set of `auth.ini` entries.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct IniSettings {
+    entries: Vec<(String, String)>,
+}
+
+impl IniSettings {
+    /// Parse flat `key=value` lines, preserving order and skipping
+    /// blank lines, comments, section headers, and bare keys.
+    pub fn parse(text: &str) -> Self {
+        let entries = text
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim();
+                if line.is_empty() || line.starts_with([';', '#', '[']) {
+                    return None;
+                }
+                let (key, value) = line.split_once('=')?;
+                Some((key.trim().to_string(), value.trim().to_string()))
+            })
+            .collect();
+        IniSettings { entries }
+    }
+
+    /// Remove every entry whose key equals `key`. Returns `true` when at
+    /// least one entry was removed.
+    pub fn remove(&mut self, key: &str) -> bool {
+        let before = self.entries.len();
+        self.entries.retain(|(entry_key, _)| entry_key != key);
+        self.entries.len() != before
+    }
+
+    /// Render back to flat `key=value` lines, each terminated by `\n`.
+    pub fn serialize(&self) -> String {
+        use std::fmt::Write;
+        self.entries.iter().fold(String::new(), |mut out, (key, value)| {
+            writeln!(out, "{key}={value}").expect("writing to a String never fails");
+            out
+        })
+    }
+
+    #[cfg(test)]
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.entries
+            .iter()
+            .find_map(|(entry_key, value)| (entry_key == key).then_some(value.as_str()))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/auth-commands/src/ini/tests.rs
+++ b/pacquet/crates/auth-commands/src/ini/tests.rs
@@ -1,0 +1,32 @@
+use super::IniSettings;
+
+#[test]
+fn parses_flat_key_value_lines() {
+    let settings =
+        IniSettings::parse("//registry.npmjs.org/:_authToken=my-token-123\nother-setting=value\n");
+    assert_eq!(settings.get("//registry.npmjs.org/:_authToken"), Some("my-token-123"));
+    assert_eq!(settings.get("other-setting"), Some("value"));
+}
+
+#[test]
+fn skips_blanks_comments_and_sections() {
+    let settings = IniSettings::parse("; a comment\n# another\n[section]\n\nkey=value\n");
+    assert_eq!(settings.get("key"), Some("value"));
+    assert_eq!(settings.get("section"), None);
+}
+
+#[test]
+fn remove_reports_presence_and_drops_the_entry() {
+    let mut settings = IniSettings::parse("a=1\nb=2\n");
+    assert!(settings.remove("a"));
+    assert!(!settings.remove("a"));
+    assert_eq!(settings.get("a"), None);
+    assert_eq!(settings.get("b"), Some("2"));
+}
+
+#[test]
+fn serialize_round_trips_remaining_entries_in_order() {
+    let mut settings = IniSettings::parse("//registry.npmjs.org/:_authToken=tok\nother=value\n");
+    settings.remove("//registry.npmjs.org/:_authToken");
+    assert_eq!(settings.serialize(), "other=value\n");
+}

--- a/pacquet/crates/auth-commands/src/lib.rs
+++ b/pacquet/crates/auth-commands/src/lib.rs
@@ -3,5 +3,6 @@
 //!
 //! Only `logout` is ported so far.
 
-mod ini;
 pub mod logout;
+
+mod ini;

--- a/pacquet/crates/auth-commands/src/lib.rs
+++ b/pacquet/crates/auth-commands/src/lib.rs
@@ -1,5 +1,5 @@
 //! Commands for authenticating with npm registries — pacquet's port of
-//! pnpm's [`@pnpm/auth.commands`](https://github.com/pnpm/pnpm/tree/main/pnpm11/auth/commands).
+//! pnpm's [`@pnpm/auth.commands`](https://github.com/pnpm/pnpm/tree/fc2f33912e/pnpm11/auth/commands).
 //!
 //! Only `logout` is ported so far.
 

--- a/pacquet/crates/auth-commands/src/lib.rs
+++ b/pacquet/crates/auth-commands/src/lib.rs
@@ -1,0 +1,7 @@
+//! Commands for authenticating with npm registries — pacquet's port of
+//! pnpm's [`@pnpm/auth.commands`](https://github.com/pnpm/pnpm/tree/main/pnpm11/auth/commands).
+//!
+//! Only `logout` is ported so far.
+
+mod ini;
+pub mod logout;

--- a/pacquet/crates/auth-commands/src/logout.rs
+++ b/pacquet/crates/auth-commands/src/logout.rs
@@ -20,7 +20,9 @@ use std::{collections::HashMap, future::Future, io, path::PathBuf};
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_network::{RetryOpts, ThrottledClient, nerf_dart, send_with_retry};
+use pacquet_network::{
+    RetryOpts, ThrottledClient, nerf_dart, redact_and_sanitize, send_with_retry,
+};
 use pacquet_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
 
 use crate::ini::IniSettings;
@@ -88,7 +90,12 @@ impl RevokeToken for Host {
         retry: RetryOpts,
     ) -> RevokeOutcome {
         let authorization = format!("Bearer {token}");
-        match send_with_retry(http_client, revoke_url, retry, |client| {
+        // The revoke URL carries the token in its final path segment (npm's
+        // `DELETE -/user/token/<token>` API). `send_with_retry` routes and
+        // logs the URL it is handed, so pass the token-free prefix while the
+        // request itself still targets the full `revoke_url`.
+        let log_url = revoke_log_url(revoke_url);
+        match send_with_retry(http_client, log_url, retry, |client| {
             client.delete(revoke_url).header(reqwest::header::AUTHORIZATION, authorization.as_str())
         })
         .await
@@ -135,8 +142,15 @@ where
     let registry_config_key = nerf_dart(&registry);
     let token_key = format!("{registry_config_key}:_authToken");
 
+    // `registry` (raw) is used for the token-key lookup and the revoke URL;
+    // `registry_display` is the only form that reaches stdout, warnings, and
+    // errors. A registry from an untrusted `.npmrc` / `--registry` can embed
+    // `user:pass@` credentials or terminal escape sequences, so redact and
+    // sanitize before it is ever shown. Mirrors `pacquet ping`.
+    let registry_display = redact_and_sanitize(&registry);
+
     let Some(token) = opts.auth_config.get(&token_key) else {
-        return Err(LogoutError::NotLoggedIn { registry });
+        return Err(LogoutError::NotLoggedIn { registry: registry_display });
     };
 
     let revoke_url = format!("{registry}-/user/token/{}", encode_uri_component(token));
@@ -171,17 +185,17 @@ where
             opts.prefix,
             LogLevel::Warn,
             format!(
-                "The auth token for {registry} was not found in {}. \
+                "The auth token for {registry_display} was not found in {}. \
                  It may be configured in .npmrc or another config file. \
                  The token was revoked on the registry but must be removed manually from that config file.",
                 config_path.display(),
             ),
         );
     } else {
-        return Err(LogoutError::LogoutFailed { registry, config_path });
+        return Err(LogoutError::LogoutFailed { registry: registry_display, config_path });
     }
 
-    Ok(format!("Logged out of {registry}"))
+    Ok(format!("Logged out of {registry_display}"))
 }
 
 /// Read `auth.ini`, treating a missing file as empty. Any other read
@@ -202,6 +216,16 @@ fn global<Reporter: self::Reporter>(prefix: &str, level: LogLevel, message: Stri
 /// `normalize-registry-url`.
 fn normalize_registry_url(registry: &str) -> String {
     if registry.ends_with('/') { registry.to_string() } else { format!("{registry}/") }
+}
+
+/// The token-free prefix of a `…/-/user/token/<token>` revoke URL — the
+/// URL with its final, token-bearing path segment dropped. Handed to
+/// `send_with_retry` for routing and logging so the token never reaches the
+/// retry logs; the request itself still targets the full revoke URL. The
+/// token is percent-encoded (so it has no literal `/`), making the last `/`
+/// the segment boundary.
+fn revoke_log_url(revoke_url: &str) -> &str {
+    revoke_url.rsplit_once('/').map_or(revoke_url, |(prefix, _token)| prefix)
 }
 
 /// Percent-encode `value` the way JavaScript's `encodeURIComponent`

--- a/pacquet/crates/auth-commands/src/logout.rs
+++ b/pacquet/crates/auth-commands/src/logout.rs
@@ -1,0 +1,267 @@
+//! Port of pnpm's `pnpm logout`
+//! ([`@pnpm/auth.commands`](https://github.com/pnpm/pnpm/blob/main/pnpm11/auth/commands/src/logout.ts)).
+//!
+//! `pnpm logout` revokes the registry auth token on the server and
+//! removes it from `auth.ini`. The token still lives in `.npmrc` or an
+//! env var is left in place, with a warning, because pnpm only owns
+//! `auth.ini`.
+//!
+//! Upstream wires the side effects (`fetch`, `readIniFile`,
+//! `writeIniFile`, `globalInfo`, `globalWarn`) through a `LogoutContext`
+//! object of injected functions. Pacquet uses the project's
+//! capability-trait seam instead: filesystem reads/writes and the
+//! token-revocation request are `Sys`-bound capabilities with no `&self`
+//! receiver (production provider [`Host`], test fakes are unit structs),
+//! and the two `global*` log channels are emitted through the
+//! `R: Reporter` seam. See the dependency-injection convention in
+//! `pacquet/CODE_STYLE_GUIDE.md`.
+
+use std::{collections::HashMap, future::Future, io, path::PathBuf};
+
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pacquet_network::{RetryOpts, ThrottledClient, nerf_dart, send_with_retry};
+use pacquet_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
+
+use crate::ini::IniSettings;
+
+/// The registry `pnpm logout` targets when neither `--registry` nor a
+/// configured registry is given. Mirrors upstream's literal default.
+pub const DEFAULT_REGISTRY: &str = "https://registry.npmjs.org/";
+
+/// Read a file into a `String`, mirroring [`std::fs::read_to_string`].
+pub trait FsReadToString {
+    fn read_to_string(path: &std::path::Path) -> io::Result<String>;
+}
+
+/// Write `bytes` to a file, replacing its contents, mirroring
+/// [`std::fs::write`].
+pub trait FsWrite {
+    fn write(path: &std::path::Path, bytes: &[u8]) -> io::Result<()>;
+}
+
+/// Send the `DELETE -/user/token/<token>` request that revokes a token
+/// on the registry. The outcome the caller acts on — accepted, rejected
+/// with a status, or unreachable — is the whole contract; how the
+/// request is retried and parsed is the provider's concern.
+pub trait RevokeToken {
+    fn revoke(
+        http_client: &ThrottledClient,
+        revoke_url: &str,
+        token: &str,
+        retry: RetryOpts,
+    ) -> impl Future<Output = RevokeOutcome>;
+}
+
+/// The result of a token-revocation request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RevokeOutcome {
+    /// The registry accepted the revocation (2xx).
+    Revoked,
+    /// The registry responded but rejected the revocation (non-2xx).
+    Rejected { status: u16 },
+    /// The registry could not be reached (transport error).
+    Unreachable,
+}
+
+/// Production provider: real filesystem and a real `DELETE` over the
+/// shared throttled HTTP client.
+pub struct Host;
+
+impl FsReadToString for Host {
+    fn read_to_string(path: &std::path::Path) -> io::Result<String> {
+        std::fs::read_to_string(path)
+    }
+}
+
+impl FsWrite for Host {
+    fn write(path: &std::path::Path, bytes: &[u8]) -> io::Result<()> {
+        std::fs::write(path, bytes)
+    }
+}
+
+impl RevokeToken for Host {
+    async fn revoke(
+        http_client: &ThrottledClient,
+        revoke_url: &str,
+        token: &str,
+        retry: RetryOpts,
+    ) -> RevokeOutcome {
+        let authorization = format!("Bearer {token}");
+        match send_with_retry(http_client, revoke_url, retry, |client| {
+            client.delete(revoke_url).header(reqwest::header::AUTHORIZATION, authorization.as_str())
+        })
+        .await
+        {
+            Ok((_guard, response)) if response.status().is_success() => RevokeOutcome::Revoked,
+            Ok((_guard, response)) => {
+                RevokeOutcome::Rejected { status: response.status().as_u16() }
+            }
+            Err(_) => RevokeOutcome::Unreachable,
+        }
+    }
+}
+
+/// Inputs to [`logout`]. `auth_config` mirrors the subset of pnpm's
+/// `config.authConfig` the command consults: rc keys of the form
+/// `//host[:port]/path/:_authToken` mapped to their raw token.
+pub struct LogoutOptions<'a> {
+    /// The `--registry` value; `None` falls back to [`DEFAULT_REGISTRY`].
+    pub registry: Option<&'a str>,
+    pub auth_config: &'a HashMap<String, String>,
+    /// pnpm's `configDir`; `auth.ini` lives at `<config_dir>/auth.ini`.
+    pub config_dir: &'a std::path::Path,
+    pub retry: RetryOpts,
+    /// Reporter prefix for the `global*` log lines (the working directory).
+    pub prefix: &'a str,
+}
+
+/// Log out of `registry`: revoke the token on the server, then remove it
+/// from `auth.ini`. Returns the `Logged out of <registry>` success line.
+///
+/// Errors with [`LogoutError::NotLoggedIn`] when no token is configured
+/// for the registry, and [`LogoutError::LogoutFailed`] when the registry
+/// rejected the revocation *and* the token was not in `auth.ini` to
+/// remove locally.
+pub async fn logout<Sys, R>(
+    http_client: &ThrottledClient,
+    opts: LogoutOptions<'_>,
+) -> Result<String, LogoutError>
+where
+    Sys: FsReadToString + FsWrite + RevokeToken,
+    R: Reporter,
+{
+    let registry = normalize_registry_url(opts.registry.unwrap_or(DEFAULT_REGISTRY));
+    let registry_config_key = nerf_dart(&registry);
+    let token_key = format!("{registry_config_key}:_authToken");
+
+    let Some(token) = opts.auth_config.get(&token_key) else {
+        return Err(LogoutError::NotLoggedIn { registry });
+    };
+
+    let revoke_url = format!("{registry}-/user/token/{}", encode_uri_component(token));
+    let revoked = match Sys::revoke(http_client, &revoke_url, token, opts.retry).await {
+        RevokeOutcome::Revoked => true,
+        RevokeOutcome::Rejected { status } => {
+            global::<R>(
+                opts.prefix,
+                LogLevel::Info,
+                format!("Registry returned HTTP {status} when revoking token"),
+            );
+            false
+        }
+        RevokeOutcome::Unreachable => {
+            global::<R>(
+                opts.prefix,
+                LogLevel::Info,
+                "Could not reach the registry to revoke the token".to_string(),
+            );
+            false
+        }
+    };
+
+    let config_path = opts.config_dir.join("auth.ini");
+    let mut settings = safe_read_ini::<Sys>(&config_path)?;
+
+    if settings.remove(&token_key) {
+        Sys::write(&config_path, settings.serialize().as_bytes())
+            .map_err(|error| LogoutError::WriteAuthIni { path: config_path.clone(), error })?;
+    } else if revoked {
+        global::<R>(
+            opts.prefix,
+            LogLevel::Warn,
+            format!(
+                "The auth token for {registry} was not found in {}. \
+                 It may be configured in .npmrc or another config file. \
+                 The token was revoked on the registry but must be removed manually from that config file.",
+                config_path.display()
+            ),
+        );
+    } else {
+        return Err(LogoutError::LogoutFailed { registry, config_path });
+    }
+
+    Ok(format!("Logged out of {registry}"))
+}
+
+/// Read `auth.ini`, treating a missing file as empty. Any other read
+/// error propagates (mirrors upstream's `safeReadIniFile`).
+fn safe_read_ini<Sys: FsReadToString>(path: &std::path::Path) -> Result<IniSettings, LogoutError> {
+    match Sys::read_to_string(path) {
+        Ok(text) => Ok(IniSettings::parse(&text)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(IniSettings::default()),
+        Err(error) => Err(LogoutError::ReadAuthIni { path: path.to_path_buf(), error }),
+    }
+}
+
+fn global<R: Reporter>(prefix: &str, level: LogLevel, message: String) {
+    R::emit(&LogEvent::Pnpm(PnpmLog { level, message, prefix: prefix.to_string() }));
+}
+
+/// Append a trailing slash if the registry URL lacks one. Mirrors npm's
+/// `normalize-registry-url`.
+fn normalize_registry_url(registry: &str) -> String {
+    if registry.ends_with('/') { registry.to_string() } else { format!("{registry}/") }
+}
+
+/// Percent-encode `value` the way JavaScript's `encodeURIComponent`
+/// does: every byte outside the unreserved set `A-Za-z0-9-_.!~*'()` is
+/// escaped as `%XX` with uppercase hex digits.
+fn encode_uri_component(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for &byte in value.as_bytes() {
+        if byte.is_ascii_alphanumeric()
+            || matches!(byte, b'-' | b'_' | b'.' | b'!' | b'~' | b'*' | b'\'' | b'(' | b')')
+        {
+            out.push(byte as char);
+        } else {
+            out.push('%');
+            out.push(hex_upper(byte >> 4));
+            out.push(hex_upper(byte & 0x0f));
+        }
+    }
+    out
+}
+
+fn hex_upper(nibble: u8) -> char {
+    char::from_digit(u32::from(nibble), 16).expect("nibble is < 16").to_ascii_uppercase()
+}
+
+/// Errors surfaced by [`logout`]. The two user-facing variants carry
+/// pnpm's stable error codes (`ERR_PNPM_NOT_LOGGED_IN`,
+/// `ERR_PNPM_LOGOUT_FAILED`) and messages verbatim.
+#[derive(Debug, Display, Error, Diagnostic)]
+pub enum LogoutError {
+    #[display("Not logged in to {registry}, so can't log out")]
+    #[diagnostic(code(ERR_PNPM_NOT_LOGGED_IN))]
+    NotLoggedIn { registry: String },
+
+    #[display(
+        "Failed to log out of {registry}. The registry rejected the token revocation request, \
+         and the token was not found in {}. \
+         The token may be configured in .npmrc or another config file \
+         and must be removed manually, and may still need to be revoked on the registry.",
+        config_path.display()
+    )]
+    #[diagnostic(code(ERR_PNPM_LOGOUT_FAILED))]
+    LogoutFailed { registry: String, config_path: PathBuf },
+
+    #[display("Failed to read auth.ini at {}: {error}", path.display())]
+    #[diagnostic(code(pacquet_auth_commands::read_auth_ini))]
+    ReadAuthIni {
+        path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+
+    #[display("Failed to write auth.ini at {}: {error}", path.display())]
+    #[diagnostic(code(pacquet_auth_commands::write_auth_ini))]
+    WriteAuthIni {
+        path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/auth-commands/src/logout.rs
+++ b/pacquet/crates/auth-commands/src/logout.rs
@@ -2,9 +2,9 @@
 //! ([`@pnpm/auth.commands`](https://github.com/pnpm/pnpm/blob/fc2f33912e/pnpm11/auth/commands/src/logout.ts)).
 //!
 //! `pnpm logout` revokes the registry auth token on the server and
-//! removes it from `auth.ini`. The token still lives in `.npmrc` or an
-//! env var is left in place, with a warning, because pnpm only owns
-//! `auth.ini`.
+//! removes it from `auth.ini`. A token that instead lives in `.npmrc`
+//! or an env var is left in place, with a warning, because pnpm only
+//! owns `auth.ini`.
 //!
 //! Upstream wires the side effects (`fetch`, `readIniFile`,
 //! `writeIniFile`, `globalInfo`, `globalWarn`) through a `LogoutContext`

--- a/pacquet/crates/auth-commands/src/logout.rs
+++ b/pacquet/crates/auth-commands/src/logout.rs
@@ -36,8 +36,9 @@ pub trait FsReadToString {
     fn read_to_string(path: &std::path::Path) -> io::Result<String>;
 }
 
-/// Write `bytes` to a file, replacing its contents, mirroring
-/// [`std::fs::write`].
+/// Write `bytes` to a file, replacing its contents. The production [`Host`]
+/// provider writes atomically and symlink-safely, since `auth.ini` holds
+/// credentials (see [`pacquet_fs::write_atomic`]).
 pub trait FsWrite {
     fn write(path: &std::path::Path, bytes: &[u8]) -> io::Result<()>;
 }
@@ -78,7 +79,7 @@ impl FsReadToString for Host {
 
 impl FsWrite for Host {
     fn write(path: &std::path::Path, bytes: &[u8]) -> io::Result<()> {
-        std::fs::write(path, bytes)
+        pacquet_fs::write_atomic(path, bytes)
     }
 }
 

--- a/pacquet/crates/auth-commands/src/logout.rs
+++ b/pacquet/crates/auth-commands/src/logout.rs
@@ -1,5 +1,5 @@
 //! Port of pnpm's `pnpm logout`
-//! ([`@pnpm/auth.commands`](https://github.com/pnpm/pnpm/blob/main/pnpm11/auth/commands/src/logout.ts)).
+//! ([`@pnpm/auth.commands`](https://github.com/pnpm/pnpm/blob/fc2f33912e/pnpm11/auth/commands/src/logout.ts)).
 //!
 //! `pnpm logout` revokes the registry auth token on the server and
 //! removes it from `auth.ini`. The token still lives in `.npmrc` or an

--- a/pacquet/crates/auth-commands/src/logout.rs
+++ b/pacquet/crates/auth-commands/src/logout.rs
@@ -13,7 +13,7 @@
 //! token-revocation request are `Sys`-bound capabilities with no `&self`
 //! receiver (production provider [`Host`], test fakes are unit structs),
 //! and the two `global*` log channels are emitted through the
-//! `R: Reporter` seam. See the dependency-injection convention in
+//! `Reporter` seam. See the dependency-injection convention in
 //! `pacquet/CODE_STYLE_GUIDE.md`.
 
 use std::{collections::HashMap, future::Future, io, path::PathBuf};
@@ -123,13 +123,13 @@ pub struct LogoutOptions<'a> {
 /// for the registry, and [`LogoutError::LogoutFailed`] when the registry
 /// rejected the revocation *and* the token was not in `auth.ini` to
 /// remove locally.
-pub async fn logout<Sys, R>(
+pub async fn logout<Sys, Reporter>(
     http_client: &ThrottledClient,
     opts: LogoutOptions<'_>,
 ) -> Result<String, LogoutError>
 where
     Sys: FsReadToString + FsWrite + RevokeToken,
-    R: Reporter,
+    Reporter: self::Reporter,
 {
     let registry = normalize_registry_url(opts.registry.unwrap_or(DEFAULT_REGISTRY));
     let registry_config_key = nerf_dart(&registry);
@@ -143,7 +143,7 @@ where
     let revoked = match Sys::revoke(http_client, &revoke_url, token, opts.retry).await {
         RevokeOutcome::Revoked => true,
         RevokeOutcome::Rejected { status } => {
-            global::<R>(
+            global::<Reporter>(
                 opts.prefix,
                 LogLevel::Info,
                 format!("Registry returned HTTP {status} when revoking token"),
@@ -151,7 +151,7 @@ where
             false
         }
         RevokeOutcome::Unreachable => {
-            global::<R>(
+            global::<Reporter>(
                 opts.prefix,
                 LogLevel::Info,
                 "Could not reach the registry to revoke the token".to_string(),
@@ -167,14 +167,14 @@ where
         Sys::write(&config_path, settings.serialize().as_bytes())
             .map_err(|error| LogoutError::WriteAuthIni { path: config_path.clone(), error })?;
     } else if revoked {
-        global::<R>(
+        global::<Reporter>(
             opts.prefix,
             LogLevel::Warn,
             format!(
                 "The auth token for {registry} was not found in {}. \
                  It may be configured in .npmrc or another config file. \
                  The token was revoked on the registry but must be removed manually from that config file.",
-                config_path.display()
+                config_path.display(),
             ),
         );
     } else {
@@ -194,8 +194,8 @@ fn safe_read_ini<Sys: FsReadToString>(path: &std::path::Path) -> Result<IniSetti
     }
 }
 
-fn global<R: Reporter>(prefix: &str, level: LogLevel, message: String) {
-    R::emit(&LogEvent::Pnpm(PnpmLog { level, message, prefix: prefix.to_string() }));
+fn global<Reporter: self::Reporter>(prefix: &str, level: LogLevel, message: String) {
+    Reporter::emit(&LogEvent::Pnpm(PnpmLog { level, message, prefix: prefix.to_string() }));
 }
 
 /// Append a trailing slash if the registry URL lacks one. Mirrors npm's

--- a/pacquet/crates/auth-commands/src/logout/tests.rs
+++ b/pacquet/crates/auth-commands/src/logout/tests.rs
@@ -102,7 +102,7 @@ async fn throws_when_not_logged_in() {
         writes = WRITES,
         revokes = REVOKES,
         read = { unreachable!() },
-        revoke = unreachable!()
+        revoke = unreachable!(),
     );
     let auth = auth_config(&[]);
     let err = logout::<Sys, Rep>(
@@ -133,7 +133,7 @@ async fn throws_when_not_logged_in_to_a_custom_registry() {
         writes = WRITES,
         revokes = REVOKES,
         read = { unreachable!() },
-        revoke = unreachable!()
+        revoke = unreachable!(),
     );
     let auth = auth_config(&[]);
     let err = logout::<Sys, Rep>(
@@ -494,4 +494,51 @@ async fn handles_registry_with_a_path() {
     assert_eq!(result, "Logged out of https://example.com/npm/");
     assert_eq!(REVOKES.lock().unwrap()[0].0, "https://example.com/npm/-/user/token/path-token");
     assert_eq!(WRITES.lock().unwrap()[0].1, "");
+}
+
+#[tokio::test]
+async fn propagates_auth_ini_write_errors() {
+    recording_reporter!(Rep, EVENTS);
+    // `sys_fake!`'s write always succeeds, so this branch needs a
+    // hand-written fake whose `FsWrite::write` returns an error.
+    struct Sys;
+    impl FsReadToString for Sys {
+        fn read_to_string(_path: &Path) -> io::Result<String> {
+            Ok("//registry.npmjs.org/:_authToken=tok\n".to_string())
+        }
+    }
+    impl FsWrite for Sys {
+        fn write(_path: &Path, _bytes: &[u8]) -> io::Result<()> {
+            Err(io::Error::new(io::ErrorKind::PermissionDenied, "EACCES"))
+        }
+    }
+    impl RevokeToken for Sys {
+        async fn revoke(
+            _http_client: &ThrottledClient,
+            _revoke_url: &str,
+            _token: &str,
+            _retry: RetryOpts,
+        ) -> RevokeOutcome {
+            RevokeOutcome::Revoked
+        }
+    }
+    let auth = auth_config(&[("//registry.npmjs.org/:_authToken", "tok")]);
+    let err = logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: None,
+            auth_config: &auth,
+            config_dir: Path::new("/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap_err();
+
+    let LogoutError::WriteAuthIni { path, error } = &err else {
+        panic!("expected WriteAuthIni, got {err:?}");
+    };
+    assert_eq!(path, &Path::new("/config").join("auth.ini"));
+    assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
 }

--- a/pacquet/crates/auth-commands/src/logout/tests.rs
+++ b/pacquet/crates/auth-commands/src/logout/tests.rs
@@ -550,7 +550,6 @@ async fn propagates_auth_ini_write_errors() {
 // They cover the side-effecting code the `Sys`-fake tests above
 // deliberately bypass.
 
-/// Token revoked on the registry, and removed from `auth.ini`.
 #[tokio::test]
 async fn host_revokes_and_removes_token() {
     const TOKEN: &str = "secret-token";
@@ -589,7 +588,6 @@ async fn host_revokes_and_removes_token() {
     assert!(remaining.contains("other=keep"), "other settings kept: {remaining:?}");
 }
 
-/// Registry rejects the revocation, but the local token is still removed.
 #[tokio::test]
 async fn host_removes_token_locally_when_registry_rejects() {
     const TOKEN: &str = "old-token";
@@ -624,7 +622,6 @@ async fn host_removes_token_locally_when_registry_rejects() {
     assert!(!remaining.contains(TOKEN), "token should be gone: {remaining:?}");
 }
 
-/// Registry unreachable (connection refused): the local token is still removed.
 #[tokio::test]
 async fn host_removes_token_locally_when_registry_unreachable() {
     const TOKEN: &str = "net-err-token";

--- a/pacquet/crates/auth-commands/src/logout/tests.rs
+++ b/pacquet/crates/auth-commands/src/logout/tests.rs
@@ -6,6 +6,7 @@ use tempfile::TempDir;
 
 use super::{
     FsReadToString, FsWrite, Host, LogoutError, LogoutOptions, RevokeOutcome, RevokeToken, logout,
+    revoke_log_url,
 };
 
 fn no_retry() -> RetryOpts {
@@ -651,4 +652,134 @@ async fn host_removes_token_locally_when_registry_unreachable() {
     let remaining =
         std::fs::read_to_string(config_dir.path().join("auth.ini")).expect("read auth.ini");
     assert!(!remaining.contains(TOKEN), "token should be gone: {remaining:?}");
+}
+
+#[test]
+fn revoke_log_url_drops_the_token_segment() {
+    assert_eq!(
+        revoke_log_url("https://registry.npmjs.org/-/user/token/secret%2Ftoken"),
+        "https://registry.npmjs.org/-/user/token",
+    );
+    // A URL with no `/` is returned unchanged rather than panicking.
+    assert_eq!(revoke_log_url("token-only"), "token-only");
+}
+
+// The registry URL is attacker-influenced (a repo-controlled `.npmrc` or
+// `--registry`): inline `user:pass@` credentials and terminal escape
+// sequences must never reach stdout, warnings, or error messages.
+#[tokio::test]
+async fn not_logged_in_error_redacts_and_sanitizes_the_registry() {
+    recording_reporter!(Rep, EVENTS);
+    sys_fake!(
+        Sys,
+        writes = WRITES,
+        revokes = REVOKES,
+        read = { unreachable!() },
+        revoke = unreachable!(),
+    );
+    let auth = auth_config(&[]);
+    let err = logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: Some("https://user:s3cret@npm.example.com/\u{7}"),
+            auth_config: &auth,
+            config_dir: Path::new("/mock/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap_err();
+
+    let message = err.to_string();
+    assert!(!message.contains("s3cret"), "credentials must be redacted: {message:?}");
+    assert!(!message.contains('\u{7}'), "control characters must be stripped: {message:?}");
+    assert!(message.contains("npm.example.com"), "host should remain: {message:?}");
+}
+
+#[tokio::test]
+async fn success_message_and_warning_redact_the_registry() {
+    recording_reporter!(Rep, EVENTS);
+    sys_fake!(
+        Sys,
+        writes = WRITES,
+        revokes = REVOKES,
+        read = { Ok(String::new()) },
+        revoke = RevokeOutcome::Revoked,
+    );
+    // `nerf_dart` drops the userinfo, so the token key is the same as for a
+    // credential-free registry.
+    let auth = auth_config(&[("//npm.example.com/:_authToken", "tok")]);
+    let result = logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: Some("https://user:s3cret@npm.example.com/"),
+            auth_config: &auth,
+            config_dir: Path::new("/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result, "Logged out of https://npm.example.com/");
+    let warning = warns(&EVENTS).remove(0);
+    assert!(!warning.contains("s3cret"), "credentials must be redacted: {warning:?}");
+    assert!(warning.contains("https://npm.example.com/"), "host should remain: {warning:?}");
+}
+
+// Regression for the token leaking into retry logs: the revoke URL carries
+// the token in its path, and `send_with_retry` logs the URL it routes on
+// plus the `reqwest` error (which echoes the request URL). A retryable
+// failure must not write the token to the logs.
+#[tokio::test]
+async fn retry_logs_do_not_leak_the_token() {
+    const TOKEN: &str = "SUPERSECRETTOKEN";
+    // Port 1 has nothing listening, so the connection is refused at once and
+    // the single retry fires a warn log.
+    let revoke_url = format!("http://127.0.0.1:1/-/user/token/{TOKEN}");
+    let retry = RetryOpts {
+        retries: 1,
+        factor: 1,
+        min_timeout: Duration::ZERO,
+        max_timeout: Duration::ZERO,
+    };
+
+    let buffer = std::sync::Arc::new(Mutex::new(Vec::<u8>::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(CaptureWriter(std::sync::Arc::clone(&buffer)))
+        .with_max_level(tracing::Level::WARN)
+        .finish();
+    let outcome = {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        Host::revoke(&ThrottledClient::new_for_installs(), &revoke_url, TOKEN, retry).await
+    };
+
+    assert_eq!(outcome, RevokeOutcome::Unreachable);
+    let logs = String::from_utf8(buffer.lock().unwrap().clone()).expect("logs are UTF-8");
+    assert!(logs.contains("retrying"), "a retry warn should have been logged: {logs:?}");
+    assert!(!logs.contains(TOKEN), "the token must not appear in retry logs: {logs:?}");
+}
+
+#[derive(Clone)]
+struct CaptureWriter(std::sync::Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
 }

--- a/pacquet/crates/auth-commands/src/logout/tests.rs
+++ b/pacquet/crates/auth-commands/src/logout/tests.rs
@@ -13,6 +13,16 @@ fn no_retry() -> RetryOpts {
     RetryOpts { retries: 0, factor: 1, min_timeout: Duration::ZERO, max_timeout: Duration::ZERO }
 }
 
+/// A `127.0.0.1:<port>` address guaranteed to refuse connections: bind an
+/// ephemeral port, then drop the listener so the OS frees it. Deterministic
+/// across environments, unlike assuming a fixed low port is closed.
+fn refused_local_addr() -> String {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("read local addr");
+    drop(listener);
+    addr.to_string()
+}
+
 /// A throwaway HTTP client. Every test fakes [`RevokeToken`], so the
 /// client is never used to send — it only satisfies [`logout`]'s
 /// signature.
@@ -626,8 +636,8 @@ async fn host_removes_token_locally_when_registry_rejects() {
 #[tokio::test]
 async fn host_removes_token_locally_when_registry_unreachable() {
     const TOKEN: &str = "net-err-token";
-    // Port 1 has nothing listening, so the connection is refused at once.
-    let registry = "http://127.0.0.1:1";
+    let registry = format!("http://{}", refused_local_addr());
+    let registry = registry.as_str();
     let token_key = format!("{}:_authToken", nerf_dart(&format!("{registry}/")));
 
     let config_dir = TempDir::new().expect("create temp config dir");
@@ -707,13 +717,14 @@ async fn success_message_and_warning_redact_the_registry() {
         read = { Ok(String::new()) },
         revoke = RevokeOutcome::Revoked,
     );
-    // `nerf_dart` drops the userinfo, so the token key is the same as for a
-    // credential-free registry.
+    // `nerf_dart` drops the userinfo and query, so the token key is the same as
+    // for a credential-free registry. The escape sequence sits in the query so
+    // it survives credential redaction and must be removed by sanitization.
     let auth = auth_config(&[("//npm.example.com/:_authToken", "tok")]);
     let result = logout::<Sys, Rep>(
         &unused_client(),
         LogoutOptions {
-            registry: Some("https://user:s3cret@npm.example.com/"),
+            registry: Some("https://user:s3cret@npm.example.com/?e=\u{1b}[31m"),
             auth_config: &auth,
             config_dir: Path::new("/config"),
             retry: no_retry(),
@@ -723,10 +734,11 @@ async fn success_message_and_warning_redact_the_registry() {
     .await
     .unwrap();
 
-    assert_eq!(result, "Logged out of https://npm.example.com/");
-    let warning = warns(&EVENTS).remove(0);
-    assert!(!warning.contains("s3cret"), "credentials must be redacted: {warning:?}");
-    assert!(warning.contains("https://npm.example.com/"), "host should remain: {warning:?}");
+    for output in [&result, &warns(&EVENTS).remove(0)] {
+        assert!(output.contains("https://npm.example.com/"), "host should remain: {output:?}");
+        assert!(!output.contains("s3cret"), "credentials must be redacted: {output:?}");
+        assert!(!output.contains('\u{1b}'), "control characters must be stripped: {output:?}");
+    }
 }
 
 // Regression for the token leaking into retry logs: the revoke URL carries
@@ -736,9 +748,9 @@ async fn success_message_and_warning_redact_the_registry() {
 #[tokio::test]
 async fn retry_logs_do_not_leak_the_token() {
     const TOKEN: &str = "SUPERSECRETTOKEN";
-    // Port 1 has nothing listening, so the connection is refused at once and
-    // the single retry fires a warn log.
-    let revoke_url = format!("http://127.0.0.1:1/-/user/token/{TOKEN}");
+    // A closed local port refuses the connection at once, so the single retry
+    // fires a warn log.
+    let revoke_url = format!("http://{}/-/user/token/{TOKEN}", refused_local_addr());
     let retry = RetryOpts {
         retries: 1,
         factor: 1,

--- a/pacquet/crates/auth-commands/src/logout/tests.rs
+++ b/pacquet/crates/auth-commands/src/logout/tests.rs
@@ -1,0 +1,497 @@
+use std::{collections::HashMap, io, path::Path, sync::Mutex, time::Duration};
+
+use pacquet_network::{RetryOpts, ThrottledClient};
+use pacquet_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
+
+use super::{
+    FsReadToString, FsWrite, LogoutError, LogoutOptions, RevokeOutcome, RevokeToken, logout,
+};
+
+fn no_retry() -> RetryOpts {
+    RetryOpts { retries: 0, factor: 1, min_timeout: Duration::ZERO, max_timeout: Duration::ZERO }
+}
+
+/// A throwaway HTTP client. Every test fakes [`RevokeToken`], so the
+/// client is never used to send — it only satisfies [`logout`]'s
+/// signature.
+fn unused_client() -> ThrottledClient {
+    ThrottledClient::new_for_installs()
+}
+
+fn auth_config(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+    pairs.iter().map(|(key, value)| ((*key).to_string(), (*value).to_string())).collect()
+}
+
+/// Declare a per-test [`Reporter`] fake recording every `pnpm` log line
+/// into a function-scoped `static`, so parallel tests never share a
+/// buffer.
+macro_rules! recording_reporter {
+    ($reporter:ident, $buffer:ident) => {
+        static $buffer: Mutex<Vec<(LogLevel, String)>> = Mutex::new(Vec::new());
+        $buffer.lock().unwrap().clear();
+        struct $reporter;
+        impl Reporter for $reporter {
+            fn emit(event: &LogEvent) {
+                if let LogEvent::Pnpm(PnpmLog { level, message, .. }) = event {
+                    $buffer.lock().unwrap().push((*level, message.clone()));
+                }
+            }
+        }
+    };
+}
+
+/// Declare a per-test `Sys` fake: `read` is the `auth.ini` read result,
+/// `revoke` is the canned revocation outcome. Writes and revoke calls
+/// are captured into the named function-scoped `static`s.
+macro_rules! sys_fake {
+    ($sys:ident, writes = $writes:ident, revokes = $revokes:ident, read = $read:block, revoke = $revoke:expr $(,)?) => {
+        static $writes: Mutex<Vec<(std::path::PathBuf, String)>> = Mutex::new(Vec::new());
+        static $revokes: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new());
+        $writes.lock().unwrap().clear();
+        $revokes.lock().unwrap().clear();
+        struct $sys;
+        impl FsReadToString for $sys {
+            fn read_to_string(_path: &Path) -> io::Result<String> $read
+        }
+        impl FsWrite for $sys {
+            fn write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+                let text = String::from_utf8(bytes.to_vec()).expect("written auth.ini is UTF-8");
+                $writes.lock().unwrap().push((path.to_path_buf(), text));
+                Ok(())
+            }
+        }
+        impl RevokeToken for $sys {
+            async fn revoke(
+                _http_client: &ThrottledClient,
+                revoke_url: &str,
+                token: &str,
+                _retry: RetryOpts,
+            ) -> RevokeOutcome {
+                $revokes.lock().unwrap().push((revoke_url.to_string(), token.to_string()));
+                $revoke
+            }
+        }
+    };
+}
+
+fn infos(buffer: &Mutex<Vec<(LogLevel, String)>>) -> Vec<String> {
+    buffer
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|(level, _)| *level == LogLevel::Info)
+        .map(|(_, message)| message.clone())
+        .collect()
+}
+
+fn warns(buffer: &Mutex<Vec<(LogLevel, String)>>) -> Vec<String> {
+    buffer
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|(level, _)| *level == LogLevel::Warn)
+        .map(|(_, message)| message.clone())
+        .collect()
+}
+
+#[tokio::test]
+async fn throws_when_not_logged_in() {
+    recording_reporter!(Rep, EVENTS);
+    sys_fake!(
+        Sys,
+        writes = WRITES,
+        revokes = REVOKES,
+        read = { unreachable!() },
+        revoke = unreachable!()
+    );
+    let auth = auth_config(&[]);
+    let err = logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: None,
+            auth_config: &auth,
+            config_dir: Path::new("/mock/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, LogoutError::NotLoggedIn { .. }));
+    assert_eq!(err.to_string(), "Not logged in to https://registry.npmjs.org/, so can't log out");
+    assert_eq!(
+        miette::Diagnostic::code(&err).map(|code| code.to_string()).as_deref(),
+        Some("ERR_PNPM_NOT_LOGGED_IN"),
+    );
+}
+
+#[tokio::test]
+async fn throws_when_not_logged_in_to_a_custom_registry() {
+    recording_reporter!(Rep, EVENTS);
+    sys_fake!(
+        Sys,
+        writes = WRITES,
+        revokes = REVOKES,
+        read = { unreachable!() },
+        revoke = unreachable!()
+    );
+    let auth = auth_config(&[]);
+    let err = logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: Some("https://npm.example.com/"),
+            auth_config: &auth,
+            config_dir: Path::new("/mock/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.to_string(), "Not logged in to https://npm.example.com/, so can't log out");
+}
+
+#[tokio::test]
+async fn revokes_token_on_registry_and_removes_from_auth_ini() {
+    recording_reporter!(Rep, EVENTS);
+    sys_fake!(
+        Sys,
+        writes = WRITES,
+        revokes = REVOKES,
+        read = {
+            Ok("//registry.npmjs.org/:_authToken=my-token-123\nother-setting=value\n".to_string())
+        },
+        revoke = RevokeOutcome::Revoked,
+    );
+    let auth = auth_config(&[("//registry.npmjs.org/:_authToken", "my-token-123")]);
+    let result = logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: None,
+            auth_config: &auth,
+            config_dir: Path::new("/custom/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result, "Logged out of https://registry.npmjs.org/");
+    let revokes = REVOKES.lock().unwrap();
+    assert_eq!(
+        revokes.as_slice(),
+        [(
+            "https://registry.npmjs.org/-/user/token/my-token-123".to_string(),
+            "my-token-123".to_string(),
+        )],
+    );
+    let writes = WRITES.lock().unwrap();
+    let (path, text) = writes.first().expect("auth.ini was written");
+    assert_eq!(path, Path::new("/custom/config/auth.ini"));
+    assert_eq!(text, "other-setting=value\n");
+}
+
+#[tokio::test]
+async fn logs_out_from_a_custom_registry() {
+    recording_reporter!(Rep, EVENTS);
+    sys_fake!(
+        Sys,
+        writes = WRITES,
+        revokes = REVOKES,
+        read = { Ok("//npm.example.com/:_authToken=custom-token\n".to_string()) },
+        revoke = RevokeOutcome::Revoked,
+    );
+    let auth = auth_config(&[("//npm.example.com/:_authToken", "custom-token")]);
+    let result = logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: Some("https://npm.example.com/"),
+            auth_config: &auth,
+            config_dir: Path::new("/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result, "Logged out of https://npm.example.com/");
+    let revokes = REVOKES.lock().unwrap();
+    assert_eq!(revokes[0].0, "https://npm.example.com/-/user/token/custom-token");
+    let writes = WRITES.lock().unwrap();
+    assert_eq!(writes[0].1, "");
+}
+
+#[tokio::test]
+async fn removes_token_locally_when_registry_returns_non_ok() {
+    recording_reporter!(Rep, EVENTS);
+    sys_fake!(
+        Sys,
+        writes = WRITES,
+        revokes = REVOKES,
+        read = { Ok("//registry.npmjs.org/:_authToken=old-token\n".to_string()) },
+        revoke = RevokeOutcome::Rejected { status: 404 },
+    );
+    let auth = auth_config(&[("//registry.npmjs.org/:_authToken", "old-token")]);
+    let result = logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: None,
+            auth_config: &auth,
+            config_dir: Path::new("/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result, "Logged out of https://registry.npmjs.org/");
+    assert_eq!(WRITES.lock().unwrap()[0].1, "");
+    assert_eq!(infos(&EVENTS), ["Registry returned HTTP 404 when revoking token"]);
+}
+
+#[tokio::test]
+async fn removes_token_locally_when_fetch_errors() {
+    recording_reporter!(Rep, EVENTS);
+    sys_fake!(
+        Sys,
+        writes = WRITES,
+        revokes = REVOKES,
+        read = { Ok("//registry.npmjs.org/:_authToken=net-err-token\n".to_string()) },
+        revoke = RevokeOutcome::Unreachable,
+    );
+    let auth = auth_config(&[("//registry.npmjs.org/:_authToken", "net-err-token")]);
+    let result = logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: None,
+            auth_config: &auth,
+            config_dir: Path::new("/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result, "Logged out of https://registry.npmjs.org/");
+    assert_eq!(WRITES.lock().unwrap()[0].1, "");
+    assert_eq!(infos(&EVENTS), ["Could not reach the registry to revoke the token"]);
+}
+
+#[tokio::test]
+async fn warns_when_token_is_not_in_auth_ini() {
+    recording_reporter!(Rep, EVENTS);
+    sys_fake!(
+        Sys,
+        writes = WRITES,
+        revokes = REVOKES,
+        read = { Ok(String::new()) },
+        revoke = RevokeOutcome::Revoked,
+    );
+    let auth = auth_config(&[("//registry.npmjs.org/:_authToken", "npmrc-only-token")]);
+    let result = logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: None,
+            auth_config: &auth,
+            config_dir: Path::new("/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result, "Logged out of https://registry.npmjs.org/");
+    assert!(WRITES.lock().unwrap().is_empty(), "auth.ini must not be written");
+    let warnings = warns(&EVENTS);
+    let warning = warnings.first().expect("a warning was emitted");
+    let expected_path = Path::new("/config").join("auth.ini");
+    assert!(warning.contains(&format!("was not found in {}", expected_path.display())));
+    assert!(warning.contains("The token was revoked on the registry but must be removed manually"));
+}
+
+#[tokio::test]
+async fn throws_when_registry_call_fails_and_token_not_in_auth_ini() {
+    recording_reporter!(Rep, EVENTS);
+    sys_fake!(
+        Sys,
+        writes = WRITES,
+        revokes = REVOKES,
+        read = { Ok(String::new()) },
+        revoke = RevokeOutcome::Rejected { status: 401 },
+    );
+    let auth = auth_config(&[("//registry.npmjs.org/:_authToken", "orphan-token")]);
+    let err = logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: None,
+            auth_config: &auth,
+            config_dir: Path::new("/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(err, LogoutError::LogoutFailed { .. }));
+    assert_eq!(
+        miette::Diagnostic::code(&err).map(|code| code.to_string()).as_deref(),
+        Some("ERR_PNPM_LOGOUT_FAILED"),
+    );
+    let message = err.to_string();
+    assert!(message.contains("Failed to log out of https://registry.npmjs.org/"));
+    assert!(message.contains("may still need to be revoked on the registry"));
+    assert_eq!(infos(&EVENTS), ["Registry returned HTTP 401 when revoking token"]);
+}
+
+#[tokio::test]
+async fn warns_when_auth_ini_does_not_exist() {
+    recording_reporter!(Rep, EVENTS);
+    sys_fake!(
+        Sys,
+        writes = WRITES,
+        revokes = REVOKES,
+        read = { Err(io::Error::new(io::ErrorKind::NotFound, "ENOENT")) },
+        revoke = RevokeOutcome::Revoked,
+    );
+    let auth = auth_config(&[("//registry.npmjs.org/:_authToken", "token-in-npmrc")]);
+    let result = logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: None,
+            auth_config: &auth,
+            config_dir: Path::new("/nonexistent/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result, "Logged out of https://registry.npmjs.org/");
+    let warnings = warns(&EVENTS);
+    let expected_path = Path::new("/nonexistent/config").join("auth.ini");
+    assert!(warnings[0].contains(&format!("was not found in {}", expected_path.display())));
+}
+
+#[tokio::test]
+async fn propagates_non_not_found_read_errors() {
+    recording_reporter!(Rep, EVENTS);
+    sys_fake!(
+        Sys,
+        writes = WRITES,
+        revokes = REVOKES,
+        read = { Err(io::Error::new(io::ErrorKind::PermissionDenied, "EACCES")) },
+        revoke = RevokeOutcome::Revoked,
+    );
+    let auth = auth_config(&[("//registry.npmjs.org/:_authToken", "some-token")]);
+    let err = logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: None,
+            auth_config: &auth,
+            config_dir: Path::new("/broken/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap_err();
+
+    let LogoutError::ReadAuthIni { error, .. } = &err else {
+        panic!("expected ReadAuthIni, got {err:?}");
+    };
+    assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+}
+
+#[tokio::test]
+async fn url_encodes_the_token_when_revoking() {
+    recording_reporter!(Rep, EVENTS);
+    sys_fake!(
+        Sys,
+        writes = WRITES,
+        revokes = REVOKES,
+        read = { Ok(String::new()) },
+        revoke = RevokeOutcome::Revoked,
+    );
+    let auth = auth_config(&[("//registry.npmjs.org/:_authToken", "token/with+special=chars")]);
+    logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: None,
+            auth_config: &auth,
+            config_dir: Path::new("/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        REVOKES.lock().unwrap()[0].0,
+        "https://registry.npmjs.org/-/user/token/token%2Fwith%2Bspecial%3Dchars",
+    );
+}
+
+#[tokio::test]
+async fn normalizes_the_registry_url() {
+    recording_reporter!(Rep, EVENTS);
+    sys_fake!(
+        Sys,
+        writes = WRITES,
+        revokes = REVOKES,
+        read = { Ok("//example.org/:_authToken=tok\n".to_string()) },
+        revoke = RevokeOutcome::Revoked,
+    );
+    let auth = auth_config(&[("//example.org/:_authToken", "tok")]);
+    let result = logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: Some("https://example.org"),
+            auth_config: &auth,
+            config_dir: Path::new("/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result, "Logged out of https://example.org/");
+    assert_eq!(WRITES.lock().unwrap()[0].1, "");
+}
+
+#[tokio::test]
+async fn handles_registry_with_a_path() {
+    recording_reporter!(Rep, EVENTS);
+    sys_fake!(
+        Sys,
+        writes = WRITES,
+        revokes = REVOKES,
+        read = { Ok("//example.com/npm/:_authToken=path-token\n".to_string()) },
+        revoke = RevokeOutcome::Revoked,
+    );
+    let auth = auth_config(&[("//example.com/npm/:_authToken", "path-token")]);
+    let result = logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: Some("https://example.com/npm/"),
+            auth_config: &auth,
+            config_dir: Path::new("/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result, "Logged out of https://example.com/npm/");
+    assert_eq!(REVOKES.lock().unwrap()[0].0, "https://example.com/npm/-/user/token/path-token");
+    assert_eq!(WRITES.lock().unwrap()[0].1, "");
+}

--- a/pacquet/crates/auth-commands/src/logout/tests.rs
+++ b/pacquet/crates/auth-commands/src/logout/tests.rs
@@ -1,10 +1,11 @@
 use std::{collections::HashMap, io, path::Path, sync::Mutex, time::Duration};
 
-use pacquet_network::{RetryOpts, ThrottledClient};
-use pacquet_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
+use pacquet_network::{RetryOpts, ThrottledClient, nerf_dart};
+use pacquet_reporter::{LogEvent, LogLevel, PnpmLog, Reporter, SilentReporter};
+use tempfile::TempDir;
 
 use super::{
-    FsReadToString, FsWrite, LogoutError, LogoutOptions, RevokeOutcome, RevokeToken, logout,
+    FsReadToString, FsWrite, Host, LogoutError, LogoutOptions, RevokeOutcome, RevokeToken, logout,
 };
 
 fn no_retry() -> RetryOpts {
@@ -541,4 +542,116 @@ async fn propagates_auth_ini_write_errors() {
     };
     assert_eq!(path, &Path::new("/config").join("auth.ini"));
     assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+}
+
+// The tests below drive the production `Host` provider end-to-end —
+// real filesystem reads/writes of `auth.ini` and a real `DELETE` over
+// the HTTP stack — against a `tempfile::TempDir` and a `mockito` server.
+// They cover the side-effecting code the `Sys`-fake tests above
+// deliberately bypass.
+
+/// Token revoked on the registry, and removed from `auth.ini`.
+#[tokio::test]
+async fn host_revokes_and_removes_token() {
+    const TOKEN: &str = "secret-token";
+    let mut server = mockito::Server::new_async().await;
+    let mock =
+        server.mock("DELETE", "/-/user/token/secret-token").with_status(200).create_async().await;
+    let registry = server.url();
+    let token_key = format!("{}:_authToken", nerf_dart(&format!("{registry}/")));
+
+    let config_dir = TempDir::new().expect("create temp config dir");
+    std::fs::write(
+        config_dir.path().join("auth.ini"),
+        format!("{token_key}={TOKEN}\nother=keep\n"),
+    )
+    .expect("seed auth.ini");
+    let auth_config = auth_config(&[(&token_key, TOKEN)]);
+
+    let result = logout::<Host, SilentReporter>(
+        &ThrottledClient::new_for_installs(),
+        LogoutOptions {
+            registry: Some(&registry),
+            auth_config: &auth_config,
+            config_dir: config_dir.path(),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .expect("logout succeeds");
+
+    mock.assert_async().await;
+    assert_eq!(result, format!("Logged out of {registry}/"));
+    let remaining =
+        std::fs::read_to_string(config_dir.path().join("auth.ini")).expect("read auth.ini");
+    assert!(!remaining.contains(TOKEN), "token should be gone: {remaining:?}");
+    assert!(remaining.contains("other=keep"), "other settings kept: {remaining:?}");
+}
+
+/// Registry rejects the revocation, but the local token is still removed.
+#[tokio::test]
+async fn host_removes_token_locally_when_registry_rejects() {
+    const TOKEN: &str = "old-token";
+    let mut server = mockito::Server::new_async().await;
+    let mock =
+        server.mock("DELETE", "/-/user/token/old-token").with_status(404).create_async().await;
+    let registry = server.url();
+    let token_key = format!("{}:_authToken", nerf_dart(&format!("{registry}/")));
+
+    let config_dir = TempDir::new().expect("create temp config dir");
+    std::fs::write(config_dir.path().join("auth.ini"), format!("{token_key}={TOKEN}\n"))
+        .expect("seed auth.ini");
+    let auth_config = auth_config(&[(&token_key, TOKEN)]);
+
+    let result = logout::<Host, SilentReporter>(
+        &ThrottledClient::new_for_installs(),
+        LogoutOptions {
+            registry: Some(&registry),
+            auth_config: &auth_config,
+            config_dir: config_dir.path(),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .expect("logout still removes the local token");
+
+    mock.assert_async().await;
+    assert_eq!(result, format!("Logged out of {registry}/"));
+    let remaining =
+        std::fs::read_to_string(config_dir.path().join("auth.ini")).expect("read auth.ini");
+    assert!(!remaining.contains(TOKEN), "token should be gone: {remaining:?}");
+}
+
+/// Registry unreachable (connection refused): the local token is still removed.
+#[tokio::test]
+async fn host_removes_token_locally_when_registry_unreachable() {
+    const TOKEN: &str = "net-err-token";
+    // Port 1 has nothing listening, so the connection is refused at once.
+    let registry = "http://127.0.0.1:1";
+    let token_key = format!("{}:_authToken", nerf_dart(&format!("{registry}/")));
+
+    let config_dir = TempDir::new().expect("create temp config dir");
+    std::fs::write(config_dir.path().join("auth.ini"), format!("{token_key}={TOKEN}\n"))
+        .expect("seed auth.ini");
+    let auth_config = auth_config(&[(&token_key, TOKEN)]);
+
+    let result = logout::<Host, SilentReporter>(
+        &ThrottledClient::new_for_installs(),
+        LogoutOptions {
+            registry: Some(registry),
+            auth_config: &auth_config,
+            config_dir: config_dir.path(),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .expect("logout still removes the local token");
+
+    assert_eq!(result, format!("Logged out of {registry}/"));
+    let remaining =
+        std::fs::read_to_string(config_dir.path().join("auth.ini")).expect("read auth.ini");
+    assert!(!remaining.contains(TOKEN), "token should be gone: {remaining:?}");
 }

--- a/pacquet/crates/cli/Cargo.toml
+++ b/pacquet/crates/cli/Cargo.toml
@@ -15,6 +15,7 @@ name = "pacquet"
 path = "src/bin/main.rs"
 
 [dependencies]
+pacquet-auth-commands                     = { workspace = true }
 pacquet-catalogs-config                   = { workspace = true }
 pacquet-cmd-shim                          = { workspace = true }
 pacquet-crypto-hash                       = { workspace = true }

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -21,6 +21,7 @@ pub mod import;
 pub mod install;
 pub mod link;
 pub mod list;
+pub mod logout;
 pub mod outdated;
 pub mod pack;
 pub mod pack_app;

--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -21,6 +21,7 @@ use super::{
     install::InstallArgs,
     link::LinkArgs,
     list::ListArgs,
+    logout::LogoutArgs,
     outdated::OutdatedArgs,
     pack::PackArgs,
     pack_app::PackAppArgs,
@@ -227,4 +228,6 @@ pub enum CliCommand {
     SelfUpdate(SelfUpdateArgs),
     /// Sets up pnpm
     Setup(SetupArgs),
+    /// Log out of an npm registry.
+    Logout(LogoutArgs),
 }

--- a/pacquet/crates/cli/src/cli_args/config/ini.rs
+++ b/pacquet/crates/cli/src/cli_args/config/ini.rs
@@ -8,11 +8,7 @@
 //! are ignored, and the map round-trips as `key=value` lines.
 
 use indexmap::IndexMap;
-use std::{
-    fs,
-    io::{self, Write as _},
-    path::Path,
-};
+use std::{fs, io, path::Path};
 
 /// Read `path` into an ordered key→value map. A missing file is an empty map;
 /// any other read error propagates.
@@ -39,7 +35,8 @@ fn parse(text: &str) -> IndexMap<String, String> {
 }
 
 /// Write `settings` to `path` as `key=value` lines, creating parent
-/// directories and replacing the file atomically (temp file + rename).
+/// directories and replacing the file atomically and symlink-safely (see
+/// [`pacquet_fs::write_atomic`]).
 pub fn write(path: &Path, settings: &IndexMap<String, String>) -> io::Result<()> {
     let mut contents = String::new();
     for (key, value) in settings {
@@ -48,34 +45,5 @@ pub fn write(path: &Path, settings: &IndexMap<String, String>) -> io::Result<()>
         contents.push_str(value);
         contents.push('\n');
     }
-    if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
-        fs::create_dir_all(parent)?;
-    }
-    let dir = path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
-    tmp.write_all(contents.as_bytes())?;
-    tmp.as_file().sync_all()?;
-    // `NamedTempFile` creates with mode 0600 on Unix; persisting it over an
-    // existing regular file would silently tighten that file's permissions, so
-    // carry the target's mode across the rename to preserve it (pnpm's
-    // `write-ini-file` keeps the target's mode too). New files keep the
-    // conservative 0600 default — they may hold credentials.
-    //
-    // `symlink_metadata` (not `metadata`) so a symlinked target is detected
-    // rather than followed: the rename replaces the symlink with a fresh
-    // regular file, and copying the link target's (possibly 0644) mode would
-    // loosen permissions on freshly written credentials. A symlink keeps 0600.
-    #[cfg(unix)]
-    if let Ok(metadata) = fs::symlink_metadata(path)
-        && !metadata.file_type().is_symlink()
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        let mode = metadata.permissions().mode();
-        tmp.as_file().set_permissions(std::fs::Permissions::from_mode(mode))?;
-    }
-    tmp.persist(path).map_err(|err| err.error)?;
-    Ok(())
+    pacquet_fs::write_atomic(path, contents.as_bytes())
 }

--- a/pacquet/crates/cli/src/cli_args/dispatch.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch.rs
@@ -273,6 +273,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::Docs(args) => dispatch_query::docs(ctx, args),
         CliCommand::SelfUpdate(args) => dispatch_query::self_update(ctx, args),
         CliCommand::Setup(args) => dispatch_query::setup(ctx, args),
+        CliCommand::Logout(args) => dispatch_query::logout(ctx, args),
         CliCommand::Completion(_) | CliCommand::CompletionServer(_) => {
             unreachable!("completion returns before configuration")
         }

--- a/pacquet/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_query.rs
@@ -10,6 +10,7 @@ use super::{
     find_hash::FindHashArgs,
     ignored_builds::IgnoredBuildsArgs,
     list::ListArgs,
+    logout::LogoutArgs,
     outdated::{OutdatedArgs, OutdatedOutcome},
     pack::PackArgs,
     pack_app::PackAppArgs,
@@ -230,6 +231,26 @@ pub(super) fn setup<'a>(ctx: &RunCtx<'a>, args: SetupArgs) -> miette::Result<Com
         ReporterType::Default | ReporterType::AppendOnly => run_setup!(DefaultReporter),
         ReporterType::Ndjson => run_setup!(NdjsonReporter),
         ReporterType::Silent => run_setup!(SilentReporter),
+    })
+}
+
+// `logout` revokes the registry auth token and removes it from `auth.ini`. It
+// needs config (registry, auth tokens, config dir, network settings) and the
+// canonicalized `--dir` as the reporter `prefix`, but no lockfile or install
+// pipeline. The reporter type only routes the `globalInfo` / `globalWarn`
+// channels, so it's threaded through `run` like the other registry commands.
+pub(super) fn logout<'a>(ctx: &RunCtx<'a>, args: LogoutArgs) -> miette::Result<CommandFuture<'a>> {
+    let config: &Config = (ctx.config)()?;
+    let prefix = ctx.dir.to_string_lossy().into_owned();
+    macro_rules! run_logout {
+        ($reporter:ty) => {
+            Box::pin(async move { args.run::<$reporter>(config, &prefix).await })
+        };
+    }
+    Ok(match ctx.reporter {
+        ReporterType::Default | ReporterType::AppendOnly => run_logout!(DefaultReporter),
+        ReporterType::Ndjson => run_logout!(NdjsonReporter),
+        ReporterType::Silent => run_logout!(SilentReporter),
     })
 }
 

--- a/pacquet/crates/cli/src/cli_args/logout.rs
+++ b/pacquet/crates/cli/src/cli_args/logout.rs
@@ -7,7 +7,8 @@
 use std::{collections::HashMap, time::Duration};
 
 use clap::Args;
-use miette::IntoDiagnostic;
+use derive_more::{Display, Error};
+use miette::{Diagnostic, IntoDiagnostic};
 use pacquet_auth_commands::logout::{Host as AuthHost, LogoutOptions, logout};
 use pacquet_config::Config;
 use pacquet_network::{NetworkSettings, RetryOpts, ThrottledClient};
@@ -21,6 +22,17 @@ pub struct LogoutArgs {
     pub registry: Option<String>,
 }
 
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum LogoutCliError {
+    /// pacquet-specific guard: pnpm always resolves a `configDir`, but
+    /// pacquet leaves [`Config::config_dir`] `None` when no home directory
+    /// can be located, and `logout` cannot find `auth.ini` without it.
+    #[display("Could not determine the pnpm config directory to locate auth.ini")]
+    #[diagnostic(code(ERR_PNPM_NO_CONFIG_DIR))]
+    NoConfigDir,
+}
+
 impl LogoutArgs {
     pub async fn run<Reporter: self::Reporter>(
         self,
@@ -28,10 +40,7 @@ impl LogoutArgs {
         prefix: &str,
     ) -> miette::Result<()> {
         let Some(config_dir) = config.config_dir.as_deref() else {
-            return Err(miette::miette!(
-                code = "ERR_PNPM_NO_CONFIG_DIR",
-                "Could not determine the pnpm config directory to locate auth.ini",
-            ));
+            return Err(LogoutCliError::NoConfigDir.into());
         };
 
         let http_client = ThrottledClient::for_installs(

--- a/pacquet/crates/cli/src/cli_args/logout.rs
+++ b/pacquet/crates/cli/src/cli_args/logout.rs
@@ -79,3 +79,6 @@ impl LogoutArgs {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/logout.rs
+++ b/pacquet/crates/cli/src/cli_args/logout.rs
@@ -22,7 +22,11 @@ pub struct LogoutArgs {
 }
 
 impl LogoutArgs {
-    pub async fn run<R: Reporter>(self, config: &Config, prefix: &str) -> miette::Result<()> {
+    pub async fn run<Reporter: self::Reporter>(
+        self,
+        config: &Config,
+        prefix: &str,
+    ) -> miette::Result<()> {
         let Some(config_dir) = config.config_dir.as_deref() else {
             return Err(miette::miette!(
                 code = "ERR_PNPM_NO_CONFIG_DIR",
@@ -57,7 +61,7 @@ impl LogoutArgs {
             max_timeout: Duration::from_millis(config.fetch_retry_maxtimeout),
         };
 
-        let message = logout::<AuthHost, R>(
+        let message = logout::<AuthHost, Reporter>(
             &http_client,
             LogoutOptions {
                 // `--registry` wins; otherwise the resolved registry,

--- a/pacquet/crates/cli/src/cli_args/logout.rs
+++ b/pacquet/crates/cli/src/cli_args/logout.rs
@@ -1,6 +1,6 @@
 //! `pacquet logout` — revoke the registry auth token and remove it from
 //! `auth.ini`. Ports pnpm's `pnpm logout`
-//! ([`@pnpm/auth.commands`](https://github.com/pnpm/pnpm/blob/main/pnpm11/auth/commands/src/logout.ts)).
+//! ([`@pnpm/auth.commands`](https://github.com/pnpm/pnpm/blob/fc2f33912e/pnpm11/auth/commands/src/logout.ts)).
 //! The command logic lives in `pacquet-auth-commands`; this module is the
 //! thin CLI adapter that resolves config into [`LogoutOptions`].
 

--- a/pacquet/crates/cli/src/cli_args/logout.rs
+++ b/pacquet/crates/cli/src/cli_args/logout.rs
@@ -1,0 +1,77 @@
+//! `pacquet logout` — revoke the registry auth token and remove it from
+//! `auth.ini`. Ports pnpm's `pnpm logout`
+//! ([`@pnpm/auth.commands`](https://github.com/pnpm/pnpm/blob/main/pnpm11/auth/commands/src/logout.ts)).
+//! The command logic lives in `pacquet-auth-commands`; this module is the
+//! thin CLI adapter that resolves config into [`LogoutOptions`].
+
+use std::{collections::HashMap, time::Duration};
+
+use clap::Args;
+use miette::IntoDiagnostic;
+use pacquet_auth_commands::logout::{Host as AuthHost, LogoutOptions, logout};
+use pacquet_config::Config;
+use pacquet_network::{NetworkSettings, RetryOpts, ThrottledClient};
+use pacquet_reporter::Reporter;
+
+/// Log out of an npm registry.
+#[derive(Debug, Args)]
+pub struct LogoutArgs {
+    /// The registry to log out of.
+    #[clap(long)]
+    pub registry: Option<String>,
+}
+
+impl LogoutArgs {
+    pub async fn run<R: Reporter>(self, config: &Config, prefix: &str) -> miette::Result<()> {
+        let Some(config_dir) = config.config_dir.as_deref() else {
+            return Err(miette::miette!(
+                code = "ERR_PNPM_NO_CONFIG_DIR",
+                "Could not determine the pnpm config directory to locate auth.ini",
+            ));
+        };
+
+        let http_client = ThrottledClient::for_installs(
+            &config.proxy,
+            &config.tls,
+            &config.tls_by_uri,
+            &NetworkSettings {
+                network_concurrency: config.network_concurrency,
+                fetch_timeout: Duration::from_millis(config.fetch_timeout),
+                user_agent: config.user_agent.clone(),
+            },
+        )
+        .into_diagnostic()?;
+
+        // Reconstruct the subset of pnpm's `config.authConfig` the command
+        // reads: `<nerf-darted-uri>:_authToken` -> raw token.
+        let auth_config: HashMap<String, String> = config
+            .auth_tokens_by_uri
+            .iter()
+            .map(|(uri, token)| (format!("{uri}:_authToken"), token.clone()))
+            .collect();
+
+        let retry = RetryOpts {
+            retries: config.fetch_retries,
+            factor: config.fetch_retry_factor,
+            min_timeout: Duration::from_millis(config.fetch_retry_mintimeout),
+            max_timeout: Duration::from_millis(config.fetch_retry_maxtimeout),
+        };
+
+        let message = logout::<AuthHost, R>(
+            &http_client,
+            LogoutOptions {
+                // `--registry` wins; otherwise the resolved registry,
+                // which already folds in `.npmrc` and the npmjs default.
+                registry: self.registry.as_deref().or(Some(config.registry.as_str())),
+                auth_config: &auth_config,
+                config_dir,
+                retry,
+                prefix,
+            },
+        )
+        .await?;
+
+        println!("{message}");
+        Ok(())
+    }
+}

--- a/pacquet/crates/cli/src/cli_args/logout/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/logout/tests.rs
@@ -1,0 +1,17 @@
+use super::LogoutArgs;
+use pacquet_config::Config;
+use pacquet_reporter::SilentReporter;
+
+/// `Config::default()` leaves `config_dir` as `None`; `run` must reject
+/// that before touching the network, since it cannot locate `auth.ini`.
+#[tokio::test]
+async fn errors_when_config_dir_is_unavailable() {
+    let err = LogoutArgs { registry: None }
+        .run::<SilentReporter>(&Config::default(), "/prefix")
+        .await
+        .expect_err("missing config dir should error");
+    assert!(
+        err.to_string().contains("Could not determine the pnpm config directory"),
+        "unexpected error: {err}",
+    );
+}

--- a/pacquet/crates/cli/src/cli_args/ping.rs
+++ b/pacquet/crates/cli/src/cli_args/ping.rs
@@ -8,7 +8,7 @@ use clap::Args;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::Config;
-use pacquet_network::{RetryOpts, ThrottledClient, redact_url_credentials, send_with_retry};
+use pacquet_network::{RetryOpts, ThrottledClient, redact_and_sanitize, send_with_retry};
 use serde_json::Value;
 use std::time::Instant;
 
@@ -65,16 +65,6 @@ impl PingArgs {
         }
         Ok(report)
     }
-}
-
-/// Make untrusted, network-derived text safe to print: redact inline
-/// `user:pass@` credentials and strip control characters. Applied to the
-/// echoed registry URL and to error messages alike — both can carry
-/// basic-auth or escape sequences from an untrusted `.npmrc` / `--registry`
-/// (or a `reqwest` error that echoes the request URL back), which must not
-/// leak credentials or inject terminal output via raw escapes / `\r` / `\n`.
-fn redact_and_sanitize(text: &str) -> String {
-    redact_url_credentials(text).chars().filter(|character| !character.is_control()).collect()
 }
 
 /// GET `ping_url` with the optional `Authorization` header, timing the

--- a/pacquet/crates/cli/tests/logout.rs
+++ b/pacquet/crates/cli/tests/logout.rs
@@ -1,0 +1,58 @@
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use std::fs;
+
+/// End-to-end `pacquet logout`: the binary resolves `auth.ini` from
+/// `XDG_CONFIG_HOME`, reads the token, sends the revoke `DELETE` to the
+/// registry, and rewrites `auth.ini` without the token. Exercises the
+/// CLI adapter (`LogoutArgs::run`) and the production `Host` provider
+/// that the `Sys`-fake unit tests bypass.
+#[test]
+fn logout_revokes_token_and_removes_it_from_auth_ini() {
+    const TOKEN: &str = "secret-token";
+    let mut server = mockito::Server::new();
+    let mock = server.mock("DELETE", "/-/user/token/secret-token").with_status(200).create();
+    let registry = server.url();
+    let host = registry.strip_prefix("http://").expect("mockito serves http");
+    let token_key = format!("//{host}/:_authToken");
+
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+    let config_home = root.path().join("config");
+    let pnpm_dir = config_home.join("pnpm");
+    fs::create_dir_all(&pnpm_dir).expect("create config/pnpm");
+    fs::write(pnpm_dir.join("auth.ini"), format!("{token_key}={TOKEN}\n")).expect("seed auth.ini");
+
+    let output = pacquet
+        .with_env("XDG_CONFIG_HOME", &config_home)
+        .with_env("HOME", root.path())
+        .with_args(["logout", "--registry", &registry])
+        .output()
+        .expect("run pacquet logout");
+
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(&format!("Logged out of {registry}/")), "stdout: {stdout}");
+    mock.assert();
+    let remaining = fs::read_to_string(pnpm_dir.join("auth.ini")).expect("read auth.ini");
+    assert!(!remaining.contains(TOKEN), "token should be removed: {remaining:?}");
+}
+
+/// `pacquet logout` with no configured token exits non-zero and reports
+/// `ERR_PNPM_NOT_LOGGED_IN`.
+#[test]
+fn logout_errors_when_not_logged_in() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+    let config_home = root.path().join("config");
+    fs::create_dir_all(config_home.join("pnpm")).expect("create config/pnpm");
+
+    let output = pacquet
+        .with_env("XDG_CONFIG_HOME", &config_home)
+        .with_env("HOME", root.path())
+        .with_args(["logout", "--registry", "https://registry.npmjs.org/"])
+        .output()
+        .expect("run pacquet logout");
+
+    assert!(!output.status.success(), "expected a non-zero exit");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Not logged in to https://registry.npmjs.org/"), "stderr: {stderr}");
+}

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1533,6 +1533,16 @@ pub struct Config {
     /// when no `.npmrc` was found or no auth keys were set.
     pub auth_headers: std::sync::Arc<pacquet_network::AuthHeaders>,
 
+    /// Raw `_authToken` values keyed by the nerf-darted registry URI
+    /// (`//host[:port]/path/`), for the default (registry-wide) scope.
+    /// Unlike [`Self::auth_headers`], which bakes credentials into
+    /// ready-to-send `Authorization` header values and discards the
+    /// raw token, this preserves the unmodified token so commands like
+    /// `pnpm logout` can read it back to revoke it on the registry.
+    /// Mirrors the subset of pnpm's `rawConfig` (`config.authConfig`)
+    /// that the auth commands consult.
+    pub auth_tokens_by_uri: std::collections::HashMap<String, String>,
+
     pub package_manager_bootstrap: PackageManagerBootstrap,
 
     /// Camel-cased record of the settings the user *explicitly* set through

--- a/pacquet/crates/config/src/npmrc_auth.rs
+++ b/pacquet/crates/config/src/npmrc_auth.rs
@@ -602,8 +602,17 @@ impl NpmrcAuth {
         let mut auth_header_by_uri: HashMap<String, String> = HashMap::new();
         let mut auth_header_by_scope_by_uri: HashMap<String, HashMap<String, String>> =
             HashMap::new();
+        // Raw `_authToken` per nerf-darted registry URI, default scope
+        // only, preserved alongside the baked header for `pnpm logout`.
+        // See [`Config::auth_tokens_by_uri`].
+        let mut auth_tokens_by_uri: HashMap<String, String> = HashMap::new();
         for (uri, raw_by_scope) in self.creds_by_scope_by_uri {
             for (scope, raw) in raw_by_scope {
+                if scope == DEFAULT_REGISTRY_SCOPE
+                    && let Some(token) = &raw.auth_token
+                {
+                    auth_tokens_by_uri.insert(uri.clone(), token.clone());
+                }
                 if let Some(header) = creds_to_header(&raw) {
                     if scope == DEFAULT_REGISTRY_SCOPE {
                         auth_header_by_uri.insert(uri.clone(), header);
@@ -616,12 +625,17 @@ impl NpmrcAuth {
                 }
             }
         }
-        if !self.default_creds.is_empty()
-            && let Some(header) = creds_to_header(&self.default_creds)
-        {
-            auth_header_by_uri.insert(pacquet_network::nerf_dart(&config.registry), header);
+        if !self.default_creds.is_empty() {
+            let default_uri = pacquet_network::nerf_dart(&config.registry);
+            if let Some(token) = &self.default_creds.auth_token {
+                auth_tokens_by_uri.insert(default_uri.clone(), token.clone());
+            }
+            if let Some(header) = creds_to_header(&self.default_creds) {
+                auth_header_by_uri.insert(default_uri, header);
+            }
         }
 
+        config.auth_tokens_by_uri = auth_tokens_by_uri;
         config.auth_headers =
             Arc::new(AuthHeaders::from_parts(auth_header_by_uri, auth_header_by_scope_by_uri));
     }

--- a/pacquet/crates/config/src/npmrc_auth/tests.rs
+++ b/pacquet/crates/config/src/npmrc_auth/tests.rs
@@ -232,6 +232,32 @@ fn parses_default_auth_token_and_keys_to_registry() {
     );
 }
 
+/// `build_auth_headers` keys *unrescoped* default credentials — both the
+/// `Authorization` header and the raw token — to `config.registry`'s
+/// nerf-darted URI. The full `Config::current` cascade rescopes default
+/// creds onto a per-URI key before this runs, so the branch is reached
+/// only by calling `build_auth_headers` directly.
+#[test]
+fn build_auth_headers_keys_default_token_to_registry_uri() {
+    let mut config = Config::new();
+    let auth = NpmrcAuth {
+        default_creds: RawCreds {
+            auth_token: Some("top-secret".to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    auth.build_auth_headers(&mut config);
+    assert_eq!(
+        config.auth_tokens_by_uri.get("//registry.npmjs.org/").map(String::as_str),
+        Some("top-secret"),
+    );
+    assert_eq!(
+        config.auth_headers.for_url("https://registry.npmjs.org/x").as_deref(),
+        Some("Bearer top-secret"),
+    );
+}
+
 #[test]
 fn env_replace_substitutes_token() {
     struct EnvWithToken;

--- a/pacquet/crates/config/src/npmrc_auth/tests.rs
+++ b/pacquet/crates/config/src/npmrc_auth/tests.rs
@@ -226,6 +226,10 @@ fn parses_default_auth_token_and_keys_to_registry() {
         config.auth_headers.for_url("https://registry.npmjs.org/foo/-/foo-1.0.0.tgz").as_deref(),
         Some("Bearer top-secret"),
     );
+    assert_eq!(
+        config.auth_tokens_by_uri.get("//registry.npmjs.org/").map(String::as_str),
+        Some("top-secret"),
+    );
 }
 
 #[test]

--- a/pacquet/crates/fs/Cargo.toml
+++ b/pacquet/crates/fs/Cargo.toml
@@ -14,10 +14,10 @@ repository.workspace = true
 derive_more = { workspace = true }
 miette      = { workspace = true }
 pathdiff    = { workspace = true }
+tempfile    = { workspace = true }
 
 [dev-dependencies]
-sha2     = { workspace = true }
-tempfile = { workspace = true }
+sha2 = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 dunce    = { workspace = true }

--- a/pacquet/crates/fs/src/lib.rs
+++ b/pacquet/crates/fs/src/lib.rs
@@ -2,10 +2,12 @@ mod ensure_file;
 mod is_subdir;
 mod lexical_normalize;
 mod symlink_dir;
+mod write_atomic;
 
 pub use ensure_file::*;
 pub use is_subdir::is_subdir;
 pub use lexical_normalize::lexical_normalize;
 pub use symlink_dir::*;
+pub use write_atomic::write_atomic;
 
 pub mod file_mode;

--- a/pacquet/crates/fs/src/write_atomic.rs
+++ b/pacquet/crates/fs/src/write_atomic.rs
@@ -1,0 +1,48 @@
+use std::{
+    fs,
+    io::{self, Write as _},
+    path::Path,
+};
+
+/// Atomically replace `path` with `bytes`: write a sibling temp file, then
+/// rename it over the target, creating parent directories as needed. A crash
+/// or I/O failure mid-write leaves the original file intact rather than a
+/// truncated one — important for credential files like `.npmrc` / `auth.ini`,
+/// where a partial write could drop other tokens. Mirrors pnpm's
+/// `write-ini-file`.
+///
+/// Symlink-safe and permission-preserving: an existing regular target's mode
+/// is carried across the rename, while a symlinked target is replaced with a
+/// fresh regular file (the link is never followed, so the write can't be
+/// redirected to an unintended path). New files keep the conservative 0600
+/// default — they may hold credentials.
+pub fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let dir = path.parent().filter(|parent| !parent.as_os_str().is_empty());
+    if let Some(parent) = dir {
+        fs::create_dir_all(parent)?;
+    }
+    let mut tmp = tempfile::NamedTempFile::new_in(dir.unwrap_or_else(|| Path::new(".")))?;
+    tmp.write_all(bytes)?;
+    tmp.as_file().sync_all()?;
+    // `NamedTempFile` creates with mode 0600 on Unix; persisting it over an
+    // existing regular file would silently tighten that file's permissions, so
+    // carry the target's mode across the rename to preserve it.
+    //
+    // `symlink_metadata` (not `metadata`) so a symlinked target is detected
+    // rather than followed: the rename replaces the symlink with a fresh
+    // regular file, and copying the link target's (possibly 0644) mode would
+    // loosen permissions on freshly written credentials. A symlink keeps 0600.
+    #[cfg(unix)]
+    if let Ok(metadata) = fs::symlink_metadata(path)
+        && !metadata.file_type().is_symlink()
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mode = metadata.permissions().mode();
+        tmp.as_file().set_permissions(std::fs::Permissions::from_mode(mode))?;
+    }
+    tmp.persist(path).map_err(|err| err.error)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/fs/src/write_atomic/tests.rs
+++ b/pacquet/crates/fs/src/write_atomic/tests.rs
@@ -1,0 +1,55 @@
+use super::write_atomic;
+use tempfile::TempDir;
+
+#[test]
+fn writes_content_and_creates_parent_dirs() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("nested/auth.ini");
+    write_atomic(&path, b"//host/:_authToken=tok\n").unwrap();
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "//host/:_authToken=tok\n");
+}
+
+#[test]
+fn replaces_existing_content() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("auth.ini");
+    write_atomic(&path, b"old").unwrap();
+    write_atomic(&path, b"new").unwrap();
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "new");
+}
+
+#[cfg(unix)]
+#[test]
+fn preserves_existing_file_mode() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("auth.ini");
+    std::fs::write(&path, "old").unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+    write_atomic(&path, b"new").unwrap();
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o644, "existing mode must be preserved, got {mode:o}");
+}
+
+#[cfg(unix)]
+#[test]
+fn does_not_follow_a_symlinked_target() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = TempDir::new().unwrap();
+    // A symlinked credential file pointing at a permissive (0644) file: the
+    // write must replace the link with a fresh 0600 regular file, leaving the
+    // link target untouched, rather than overwriting through the link.
+    let real = dir.path().join("real.ini");
+    std::fs::write(&real, "secret").unwrap();
+    std::fs::set_permissions(&real, std::fs::Permissions::from_mode(0o644)).unwrap();
+    let link = dir.path().join("auth.ini");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+
+    write_atomic(&link, b"new").unwrap();
+
+    assert!(!std::fs::symlink_metadata(&link).unwrap().file_type().is_symlink());
+    assert_eq!(std::fs::read_to_string(&link).unwrap(), "new");
+    assert_eq!(std::fs::read_to_string(&real).unwrap(), "secret", "link target untouched");
+    let mode = std::fs::metadata(&link).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600, "a replaced symlink keeps the conservative default, got {mode:o}");
+}

--- a/pacquet/crates/network/src/auth.rs
+++ b/pacquet/crates/network/src/auth.rs
@@ -480,6 +480,18 @@ pub fn redact_url_credentials(text: &str) -> String {
     out
 }
 
+/// Make untrusted, URL-bearing text safe to print or log: redact inline
+/// `user:pass@` credentials ([`redact_url_credentials`]) and strip every
+/// control character. Used for registry URLs and network-error messages
+/// alike — both can carry basic-auth or escape sequences from an untrusted
+/// `.npmrc` / `--registry` (or a `reqwest` error that echoes the request URL
+/// back), which must not leak credentials or inject terminal output via raw
+/// escapes / `\r` / `\n`.
+#[must_use]
+pub fn redact_and_sanitize(text: &str) -> String {
+    redact_url_credentials(text).chars().filter(|character| !character.is_control()).collect()
+}
+
 /// If the authority leading `text` contains `userinfo@`, return the slice after
 /// the **last** `@` within it; otherwise `None`. The authority ends at the first
 /// `/`, `?`, `#`, or whitespace. Stripping to the last `@` keeps a raw `@` inside

--- a/pacquet/crates/network/src/auth/tests.rs
+++ b/pacquet/crates/network/src/auth/tests.rs
@@ -1,5 +1,6 @@
 use super::{
-    AuthHeaders, DEFAULT_REGISTRY_SCOPE, base64_encode, nerf_dart, redact_url_credentials,
+    AuthHeaders, DEFAULT_REGISTRY_SCOPE, base64_encode, nerf_dart, redact_and_sanitize,
+    redact_url_credentials,
 };
 use pretty_assertions::assert_eq;
 
@@ -35,6 +36,13 @@ fn redact_url_credentials_strips_embedded_basic_auth() {
     // A bare "://" with no preceding scheme character is not treated as a URL
     // authority, so an "@" further along is preserved.
     assert_eq!(redact_url_credentials("a :// b@c"), "a :// b@c");
+}
+
+#[test]
+fn redact_and_sanitize_strips_credentials_and_control_chars() {
+    assert_eq!(redact_and_sanitize("https://user:pass@host/pkg\u{7}\r\n"), "https://host/pkg");
+    // A clean URL is returned unchanged.
+    assert_eq!(redact_and_sanitize("https://host/pkg"), "https://host/pkg");
 }
 
 fn build(entries: &[(&str, &str)]) -> AuthHeaders {

--- a/pacquet/crates/network/src/lib.rs
+++ b/pacquet/crates/network/src/lib.rs
@@ -8,7 +8,7 @@ mod tls;
 
 pub use auth::{
     AuthHeaders, AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE, base64_encode, nerf_dart,
-    redact_url_credentials,
+    redact_and_sanitize, redact_url_credentials,
 };
 pub use proxy::{NoProxySetting, ProxyConfig, ProxyError};
 pub use retry::{RetryOpts, retry_async, send_with_retry, should_retry_status};

--- a/pacquet/crates/network/src/retry.rs
+++ b/pacquet/crates/network/src/retry.rs
@@ -157,6 +157,12 @@ pub async fn send_with_retry<'client>(
             Err(error) if attempt < retry_opts.retries => {
                 drop(client);
                 let delay = retry_opts.delay_for(attempt);
+                // reqwest embeds the full request URL in its error, which can
+                // carry a secret in the path (e.g. `logout`'s revoke token).
+                // The `url=` field already logs the URL the caller handed us
+                // (token-free for such callers), so drop the URL from the
+                // error to keep it out of the log.
+                let error = error.without_url();
                 tracing::warn!(
                     target: "pacquet_network::retry",
                     url = %redact_url_credentials(url),

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -135,6 +135,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         update_config: Default::default(),
         peer_dependency_rules: Default::default(),
         auth_headers: Default::default(),
+        auth_tokens_by_uri: Default::default(),
         proxy: Default::default(),
         tls: Default::default(),
         tls_by_uri: Default::default(),

--- a/pacquet/plans/TEST_PORTING.md
+++ b/pacquet/plans/TEST_PORTING.md
@@ -882,3 +882,23 @@ lockfile-parity peer fixes (pnpm/pnpm#12266, pnpm/pnpm#12267).
 - [ ] `resolve peer dependencies with npm aliases` — npm-alias peer suffixes.
 - [ ] `should find peer dependency conflicts when the peer is an optional peer of one of the dependencies`, `should ignore conflicts between missing optional peer dependencies`, `should pick the single wanted peer dependency range`, `should return the intersection of two compatible ranges`, the two prerelease-warning cases — peer-issue reporting edge cases.
 - [ ] The `lockedPeerContext` / `resolvedPeerProviderPaths` series (`prefers a compatible locked provider …`, the six `does not replace …` cases, `does not reuse a locked provider outside the current peer range`) — pacquet hasn't ported `lockedPeerContext`/`resolvedPeerProviderPaths`, so these gate on that feature, not on the lockfile-parity peer fixes.
+
+## `pnpm logout` (`@pnpm/auth.commands`)
+
+Pacquet's port lives in `pacquet-auth-commands` (`logout` module) with the CLI adapter in `pacquet-cli`'s `cli_args::logout`. Upstream injects its side effects (`fetch`, `readIniFile`, `writeIniFile`, `globalInfo`, `globalWarn`) through a `LogoutContext` object of functions; the Rust port threads them through the project's capability-trait seam instead (`FsReadToString` / `FsWrite` / `RevokeToken` on `Sys`, plus `R: Reporter` for the two `global*` channels). The whole upstream suite translates, so every case is a unit test of the ported `logout` function with unit-struct fakes.
+
+### Ported
+
+- [x] `TypeScript repo: pnpm11/auth/commands/test/logout.test.ts:41` `should throw when not logged in` — `logout::tests::throws_when_not_logged_in`.
+- [x] `TypeScript repo: pnpm11/auth/commands/test/logout.test.ts:53` `should throw when not logged in to a custom registry` — `logout::tests::throws_when_not_logged_in_to_a_custom_registry`.
+- [x] `TypeScript repo: pnpm11/auth/commands/test/logout.test.ts:66` `should revoke token on registry and remove from auth.ini` — `logout::tests::revokes_token_on_registry_and_removes_from_auth_ini`.
+- [x] `TypeScript repo: pnpm11/auth/commands/test/logout.test.ts:106` `should logout from a custom registry` — `logout::tests::logs_out_from_a_custom_registry`.
+- [x] `TypeScript repo: pnpm11/auth/commands/test/logout.test.ts:142` `should still remove token locally when registry returns non-ok response` — `logout::tests::removes_token_locally_when_registry_returns_non_ok`.
+- [x] `TypeScript repo: pnpm11/auth/commands/test/logout.test.ts:172` `should still remove token locally when fetch throws a network error` — `logout::tests::removes_token_locally_when_fetch_errors`.
+- [x] `TypeScript repo: pnpm11/auth/commands/test/logout.test.ts:204` `should warn when token is not in auth.ini (e.g. from .npmrc)` — `logout::tests::warns_when_token_is_not_in_auth_ini`.
+- [x] `TypeScript repo: pnpm11/auth/commands/test/logout.test.ts:236` `should throw when registry call fails and token is not in auth.ini` — `logout::tests::throws_when_registry_call_fails_and_token_not_in_auth_ini`.
+- [x] `TypeScript repo: pnpm11/auth/commands/test/logout.test.ts:270` `should warn when auth.ini does not exist (ENOENT) and token comes from another source` — `logout::tests::warns_when_auth_ini_does_not_exist`.
+- [x] `TypeScript repo: pnpm11/auth/commands/test/logout.test.ts:301` `should propagate non-ENOENT errors from readIniFile` — `logout::tests::propagates_non_not_found_read_errors`.
+- [x] `TypeScript repo: pnpm11/auth/commands/test/logout.test.ts:322` `should URL-encode the token when revoking` — `logout::tests::url_encodes_the_token_when_revoking`.
+- [x] `TypeScript repo: pnpm11/auth/commands/test/logout.test.ts:349` `should normalize the registry URL` — `logout::tests::normalizes_the_registry_url`.
+- [x] `TypeScript repo: pnpm11/auth/commands/test/logout.test.ts:377` `should handle registry with a path` — `logout::tests::handles_registry_with_a_path`.


### PR DESCRIPTION
## Summary

Ports `pnpm logout` to pacquet (the Rust port). Part of the Rust Roadmap ([pnpm/pnpm#11633](https://github.com/pnpm/pnpm/issues/11633)).

`pnpm logout` revokes the registry auth token on the server (`DELETE -/user/token/<token>`) and removes it from `auth.ini`. It warns when the token actually lives in `.npmrc` or another source pnpm doesn't own (revoked on the registry, but must be removed manually), and fails only when the registry rejects the revocation **and** there is no local token left to remove.

Implemented as a new `pacquet-auth-commands` crate plus a `pacquet logout [--registry <url>]` CLI command. Behavior, flags, error codes (`ERR_PNPM_NOT_LOGGED_IN`, `ERR_PNPM_LOGOUT_FAILED`), and messages mirror the TypeScript `@pnpm/auth.commands` implementation.

**Dependency injection.** Upstream injects its side effects (`fetch`, `readIniFile`, `writeIniFile`, `globalInfo`, `globalWarn`) through a `LogoutContext` object of functions. This port uses pacquet's documented capability-trait seam instead: `FsReadToString` / `FsWrite` / `RevokeToken` are `Sys`-bound capabilities with no `&self` receiver (production provider `Host`; test fakes are unit structs), and the two `global*` channels go through the `Reporter` seam.

**Config.** Adds `Config::auth_tokens_by_uri` (raw `_authToken` per nerf-darted registry URI) and `Config::config_dir`. `Config` previously baked credentials into ready-to-send `Authorization` headers and discarded the raw token; `logout` needs the raw token to build the revoke URL/header, and the config dir to locate `auth.ini`.

### Tests

- All **13** cases from `pnpm11/auth/commands/test/logout.test.ts` ported as DI unit tests. (`pnpm11/pnpm/test/` has no `logout` end-to-end test to port — the only upstream `logout` coverage is that unit file.)
- Real-fixture integration tests covering the production paths the DI fakes bypass:
  - The `Host` provider via `tempfile::TempDir` + `mockito` (revoke-success / registry-rejects / unreachable).
  - A binary test that spawns `pacquet logout` against a mocked registry, covering the CLI adapter (`LogoutArgs::run`) and dispatch end-to-end.
- Unit tests closing the remaining defensive branches: `auth_tokens_by_uri` population for default credentials, and the missing-config-dir guard.

### Parity / changeset

pacquet-only (Rust) change — the TypeScript `pnpm logout` already exists upstream, so there is nothing to mirror on the TS side, and no changeset is needed (changesets cover published TS packages only).

## Squash Commit Body

```text
Port `pnpm logout` to pacquet as a new pacquet-auth-commands crate and a
`pacquet logout [--registry <url>]` CLI command, mirroring the TypeScript
@pnpm/auth.commands behavior, flags, error codes, and messages.

The command revokes the registry auth token (DELETE -/user/token/<token>)
and removes it from auth.ini. It warns when the token lives in .npmrc or
another source pnpm does not own, and fails only when the registry rejects
revocation and no local token is left to remove.

Upstream wires side effects through a LogoutContext object of functions;
this port uses pacquet's capability-trait DI seam instead: FsReadToString /
FsWrite / RevokeToken on Sys (production provider Host, test fakes are unit
structs), and the global* log channels through the Reporter seam.

Config gains auth_tokens_by_uri (raw _authToken per nerf-darted registry
URI) and config_dir, since Config previously baked credentials into
Authorization headers and discarded the raw token that logout must revoke.

Tests: all 13 upstream logout.test.ts cases ported as DI unit tests, plus
real-fixture integration tests (the Host provider via TempDir + mockito, and
a binary test spawning `pacquet logout`) covering the production code paths
the DI fakes bypass.

Part of the Rust Roadmap (pnpm/pnpm#11633).
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port — the TypeScript `pnpm logout` already exists upstream; this PR is the matching pacquet port.
- [x] Added a changeset — N/A: pacquet is Rust-only and changes no published package, so no changeset is required.
- [x] Added or updated tests — 13 ported DI unit tests, real-fixture integration tests (`Host` provider + `pacquet logout` binary), and coverage-closing unit tests.
- [x] Updated the documentation if needed — updated `pacquet/plans/TEST_PORTING.md`; no user-facing docs change (the command mirrors the already-documented `pnpm logout`).

---
Written by an agent (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `logout` CLI command to sign out from an npm registry.
  * Introduced local auth token storage to enable remote token revocation and `auth.ini` updates.
* **Bug Fixes**
  * Improved handling when `auth.ini` is missing or the token isn’t present locally, with clearer warnings and consistent error reporting (including unreachable/non-OK registries).
* **Security / Logging**
  * Improved log redaction and retry error handling to avoid leaking sensitive URL details and control characters.
* **File Safety**
  * Added atomic, symlink-safe config/INI writes.
* **Tests**
  * Added unit and end-to-end coverage for token revocation, registry URL normalization/encoding, local `auth.ini` cleanup, redaction, and atomic write behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->