### PR TITLE
fix(pnpr): verify proxied tarball integrity

### DIFF
--- a/pnpr/crates/pnpr/src/error.rs
+++ b/pnpr/crates/pnpr/src/error.rs
@@ -31,6 +31,15 @@ pub enum RegistryError {
         uplink: String,
     },
 
+    #[display("EINTEGRITY: tarball {filename:?} for package {package:?}: {reason}")]
+    #[from(skip)]
+    TarballIntegrity {
+        #[error(not(source))]
+        package: String,
+        filename: String,
+        reason: String,
+    },
+
     #[display("Package name {name:?} is not a valid npm package name")]
     InvalidPackageName {
         #[error(not(source))]
@@ -192,6 +201,7 @@ impl RegistryError {
             RegistryError::Upstream { .. } => "upstream",
             RegistryError::UpstreamStatus { .. } => "upstream_status",
             RegistryError::UpstreamUnavailable { .. } => "upstream_unavailable",
+            RegistryError::TarballIntegrity { .. } => "tarball_integrity",
             RegistryError::InvalidPackageName { .. } => "invalid_package_name",
             RegistryError::InvalidTarballName { .. } => "invalid_tarball_name",
             RegistryError::InvalidPolicyPattern { .. } => "invalid_policy_pattern",
@@ -260,7 +270,9 @@ impl RegistryError {
                     StatusCode::BAD_GATEWAY
                 }
             }
-            RegistryError::UpstreamStatus { .. } => StatusCode::BAD_GATEWAY,
+            RegistryError::UpstreamStatus { .. } | RegistryError::TarballIntegrity { .. } => {
+                StatusCode::BAD_GATEWAY
+            }
             RegistryError::UpstreamUnavailable { .. } => StatusCode::SERVICE_UNAVAILABLE,
             RegistryError::InvalidPackageName { .. }
             | RegistryError::InvalidTarballName { .. }

--- a/pnpr/crates/pnpr/src/package_name.rs
+++ b/pnpr/crates/pnpr/src/package_name.rs
@@ -37,6 +37,10 @@ impl PackageName {
         &self.raw
     }
 
+    pub fn tarball_name_for_version(&self, version: &str) -> String {
+        format!("{}-{version}.tgz", self.basename)
+    }
+
     /// Validate `filename` and return the canonical disk filename
     /// (`<basename>-<version>.tgz`). Used by the publish handler so
     /// libnpmpublish's `@scope/name-1.0.0.tgz` attachment lands on
@@ -66,7 +70,7 @@ impl PackageName {
         if !is_safe_segment(version) {
             return Err(invalid());
         }
-        Ok((format!("{}-{}.tgz", self.basename, version), version.to_string()))
+        Ok((self.tarball_name_for_version(version), version.to_string()))
     }
 }
 

--- a/pnpr/crates/pnpr/src/package_name/tests.rs
+++ b/pnpr/crates/pnpr/src/package_name/tests.rs
@@ -4,6 +4,7 @@ use super::PackageName;
 fn accepts_unscoped() {
     let name = PackageName::parse("lodash").unwrap();
     assert_eq!(name.as_str(), "lodash");
+    assert_eq!(name.tarball_name_for_version("4.17.21"), "lodash-4.17.21.tgz");
     name.parse_tarball_name("lodash-4.17.21.tgz").unwrap();
 }
 
@@ -11,6 +12,7 @@ fn accepts_unscoped() {
 fn accepts_scoped() {
     let name = PackageName::parse("@types/node").unwrap();
     assert_eq!(name.as_str(), "@types/node");
+    assert_eq!(name.tarball_name_for_version("20.0.0"), "node-20.0.0.tgz");
     name.parse_tarball_name("node-20.0.0.tgz").unwrap();
 }
 

--- a/pnpr/crates/pnpr/src/publish.rs
+++ b/pnpr/crates/pnpr/src/publish.rs
@@ -9,10 +9,13 @@
 //! it inside [`tokio::task::spawn_blocking`] without blocking the
 //! async runtime, and so these helpers stay easy to unit-test.
 
-use crate::error::RegistryError;
+use crate::{
+    error::RegistryError,
+    streaming::{integrity_checker, parse_integrity},
+};
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64, read::DecoderReader};
 use serde_json::{Map, Value};
-use ssri::{Algorithm, Integrity, IntegrityChecker, IntegrityOpts};
+use ssri::{Algorithm, IntegrityOpts};
 use std::{
     collections::BTreeMap,
     fmt::Write as FmtWrite,
@@ -112,12 +115,12 @@ pub fn stream_decode_verify_and_write(
         .get("integrity")
         .and_then(Value::as_str)
         .ok_or_else(|| invalid("EINTEGRITY: dist.integrity is required".to_string()))?;
-    let integrity: Integrity = declared_integrity
-        .parse()
+    let integrity = parse_integrity(declared_integrity)
         .map_err(|err| invalid(format!("EINTEGRITY: malformed dist.integrity: {err}")))?;
     let declared_shasum = dist.get("shasum").and_then(Value::as_str);
 
-    let mut checker = IntegrityChecker::new(integrity);
+    let mut checker = integrity_checker(&integrity)
+        .map_err(|err| invalid(format!("EINTEGRITY: malformed dist.integrity: {err}")))?;
     let mut shasum_hasher =
         declared_shasum.is_some().then(|| IntegrityOpts::new().algorithm(Algorithm::Sha1));
 

--- a/pnpr/crates/pnpr/src/publish/tests.rs
+++ b/pnpr/crates/pnpr/src/publish/tests.rs
@@ -100,6 +100,26 @@ fn stream_rejects_malformed_integrity_sri() {
 }
 
 #[test]
+fn stream_rejects_integrity_without_hashes() {
+    for declared in ["", " \t\n "] {
+        let dist = json!({ "integrity": declared });
+        let (result, dest, _tmp) = run_stream(b"bytes", Some(&dist), None);
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("EINTEGRITY") && msg.contains("hash"), "got: {msg}");
+        assert!(!dest.exists());
+    }
+}
+
+#[test]
+fn stream_rejects_unsupported_integrity_algorithm() {
+    let dist = json!({ "integrity": "md5-deadbeef" });
+    let (result, dest, _tmp) = run_stream(b"bytes", Some(&dist), None);
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("EINTEGRITY") && msg.contains("malformed"), "got: {msg}");
+    assert!(!dest.exists());
+}
+
+#[test]
 fn stream_rejects_invalid_base64() {
     let tmp = TempDir::new().unwrap();
     let dest = tmp.path().join("out.tgz");

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -9,7 +9,7 @@ use crate::{
         PendingAttachment, extract_attachments, iso_from_unix_millis, merge_manifest, now_iso,
         stream_decode_verify_and_write,
     },
-    storage::{CachedPackument, Storage},
+    storage::{CachedPackument, CachedTarballIntegrity, Storage},
     streaming,
     upstream::{
         CacheValidators, FetchOutcome, FetchedPackument, PackumentFetch, Upstream,
@@ -27,6 +27,7 @@ use axum::{
 use chrono::Utc;
 use indexmap::IndexMap;
 use serde_json::{Value, json};
+use ssri::Integrity;
 use std::{collections::HashSet, sync::Arc, time::Duration};
 use tower_http::{
     compression::{
@@ -45,12 +46,17 @@ use tracing::Span;
 /// long version histories.
 const ABBREVIATED_CONTENT_TYPE: &str = "application/vnd.npm.install-v1+json";
 
+/// Cap tarballs at 100 MiB while pnpr has to spool them to disk for SRI
+/// verification. This bounds per-request temporary disk usage for
+/// chunked or malicious upstream bodies.
+const MAX_TARBALL_BYTES: u64 = 100 * 1024 * 1024;
+
 /// Cap publish bodies at 100 MiB. The default axum body limit is
 /// 2 MiB, far too small for a real package — npm itself caps publish
 /// at 100 MiB and verdaccio inherits that limit. We apply it via
 /// [`DefaultBodyLimit::max`] on the router rather than on each
 /// route, so future write endpoints inherit the same ceiling.
-const MAX_PUBLISH_BODY_BYTES: usize = 100 * 1024 * 1024;
+const MAX_PUBLISH_BODY_BYTES: usize = MAX_TARBALL_BYTES as usize;
 
 #[derive(Clone)]
 struct AppState {
@@ -775,7 +781,7 @@ async fn serve_tarball(
         Ok(n) => n,
         Err(err) => return error_response(&err),
     };
-    let (canonical_filename, version) = match name.parse_tarball_name(filename) {
+    let (filename, version) = match name.parse_tarball_name(filename) {
         Ok(parsed) => parsed,
         Err(err) => return error_response(&err),
     };
@@ -786,43 +792,200 @@ async fn serve_tarball(
         return error_response(&err);
     }
 
-    match state.inner.storage.open_tarball(&name, &canonical_filename).await {
+    // The hosted store is authoritative. A genuine fault here (not a
+    // plain miss, which surfaces as `Ok(None)`) must fail closed rather
+    // than fall through to upstream and serve bytes of a different
+    // provenance for the same package name.
+    match state.inner.storage.open_hosted_tarball(&name, &filename).await {
         Ok(Some((body, len))) => return tarball_response(body, len),
         Ok(None) => {}
         Err(err) => {
-            tracing::warn!(?err, package = %name.as_str(), %filename, canonical = %canonical_filename, "tarball cache open failed");
+            tracing::warn!(?err, package = %name.as_str(), %filename, "hosted tarball open failed");
+            return error_response(&err);
         }
     }
 
-    let Some(upstream) = resolve_upstream(state, &name) else {
+    let packument = match load_packument_bytes(state, &name).await {
+        PackumentLoad::Ok(bytes) => bytes,
+        PackumentLoad::NotFound => return not_found(),
+        PackumentLoad::Err(err) => return error_response(&err),
+    };
+    let integrity = match expected_tarball_integrity(&packument, &name, &filename, &version) {
+        Ok(Some(integrity)) => integrity,
+        Ok(None) => return not_found(),
+        Err(err) => return error_response(&err),
+    };
+
+    let upstream = resolve_upstream(state, &name);
+    let should_read_cache = upstream.as_ref().is_none_or(|upstream| upstream.caches());
+    if should_read_cache {
+        match state.inner.storage.open_cached_tarball(&name, &filename).await {
+            Ok(Some((file, len))) => {
+                let expected = cached_tarball_integrity(&integrity, len);
+                if state
+                    .inner
+                    .storage
+                    .read_cached_tarball_integrity(&name, &filename)
+                    .await
+                    .is_some_and(|cached| cached == expected)
+                {
+                    return tarball_response(streaming::stream_file(file), Some(len));
+                }
+                match streaming::verify_file(file, &integrity).await {
+                    Ok(file) => {
+                        record_cached_tarball_integrity(state, &name, &filename, expected).await;
+                        return tarball_response(streaming::stream_file(file), Some(len));
+                    }
+                    Err(err) => {
+                        let err = tarball_stream_error(err, &name, &filename);
+                        tracing::warn!(?err, package = %name.as_str(), %filename, "cached tarball failed verification");
+                        discard_cached_tarball(state, &name, &filename).await;
+                    }
+                }
+            }
+            Ok(None) => {}
+            Err(err) => {
+                tracing::warn!(?err, package = %name.as_str(), %filename, "tarball cache open failed");
+            }
+        }
+    }
+
+    let Some(upstream) = upstream else {
         return not_found();
     };
 
-    let response = match upstream.fetch_tarball_response(&name, &canonical_filename).await {
+    let response = match upstream.fetch_tarball_response(&name, &filename).await {
         Ok(FetchOutcome::Ok(response)) => response,
         Ok(FetchOutcome::NotFound) => return not_found(),
         Err(err) => return error_response(&err),
     };
-    let upstream_len = response.content_length();
 
-    // `cache: false` uplinks (verdaccio) are mirror-less: stream the
-    // tarball straight to the client without writing it to disk.
-    if !upstream.caches() {
-        return tarball_response(Body::from_stream(response.bytes_stream()), upstream_len);
-    }
-
-    let write = match state.inner.storage.open_cached_tarball_tmp(&name, &canonical_filename).await
-    {
+    let write = match state.inner.storage.open_cached_tarball_tmp(&name, &filename).await {
         Ok(w) => w,
-        Err(err) => {
-            tracing::warn!(?err, package = %name.as_str(), %filename, canonical = %canonical_filename, "tarball cache tmp-open failed; streaming without cache");
-            let body = Body::from_stream(response.bytes_stream());
-            return tarball_response(body, upstream_len);
-        }
+        Err(err) => return error_response(&err),
     };
 
-    let body = streaming::tee_to_cache(response, write);
-    tarball_response(body, upstream_len)
+    if upstream.caches() {
+        let len = match streaming::download_verified_to_cache(
+            response,
+            write,
+            &integrity,
+            MAX_TARBALL_BYTES,
+        )
+        .await
+        {
+            Ok(len) => len,
+            Err(err) => return error_response(&tarball_stream_error(err, &name, &filename)),
+        };
+        record_cached_tarball_integrity(
+            state,
+            &name,
+            &filename,
+            cached_tarball_integrity(&integrity, len),
+        )
+        .await;
+
+        match state.inner.storage.open_cached_tarball(&name, &filename).await {
+            Ok(Some((file, len))) => tarball_response(streaming::stream_file(file), Some(len)),
+            Ok(None) => error_response(&tarball_integrity_error(
+                &name,
+                &filename,
+                "verified cache entry disappeared before it could be served".to_string(),
+            )),
+            Err(err) => error_response(&err),
+        }
+    } else {
+        match streaming::download_verified_to_temp(response, write, &integrity, MAX_TARBALL_BYTES)
+            .await
+        {
+            Ok((file, len, tmp_path)) => {
+                tarball_response(streaming::stream_file_and_remove(file, tmp_path), Some(len))
+            }
+            Err(err) => error_response(&tarball_stream_error(err, &name, &filename)),
+        }
+    }
+}
+
+fn expected_tarball_integrity(
+    packument: &[u8],
+    name: &PackageName,
+    filename: &str,
+    version: &str,
+) -> Result<Option<Integrity>, RegistryError> {
+    let packument: Value = serde_json::from_slice(packument)?;
+    let Some(manifest) = packument
+        .get("versions")
+        .and_then(Value::as_object)
+        .and_then(|versions| versions.get(version))
+    else {
+        return Ok(None);
+    };
+    let declared = manifest
+        .get("dist")
+        .and_then(|dist| dist.get("integrity"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            tarball_integrity_error(
+                name,
+                filename,
+                format!("packument has no dist.integrity for version {version:?}"),
+            )
+        })?;
+    streaming::parse_integrity(declared).map(Some).map_err(|err| {
+        tarball_integrity_error(name, filename, format!("malformed dist.integrity: {err}"))
+    })
+}
+
+fn tarball_stream_error(
+    err: streaming::TarballStreamError,
+    name: &PackageName,
+    filename: &str,
+) -> RegistryError {
+    match err {
+        streaming::TarballStreamError::Upstream { url, source } => {
+            RegistryError::Upstream { url, source }
+        }
+        streaming::TarballStreamError::Io(err) => RegistryError::Io(err),
+        streaming::TarballStreamError::Integrity(err) => {
+            tarball_integrity_error(name, filename, format!("integrity verification failed: {err}"))
+        }
+        streaming::TarballStreamError::TooLarge { limit, received } => tarball_integrity_error(
+            name,
+            filename,
+            format!("tarball body exceeds {limit} byte limit (received {received} bytes)"),
+        ),
+    }
+}
+
+fn tarball_integrity_error(name: &PackageName, filename: &str, reason: String) -> RegistryError {
+    RegistryError::TarballIntegrity {
+        package: name.as_str().to_string(),
+        filename: filename.to_string(),
+        reason,
+    }
+}
+
+async fn discard_cached_tarball(state: &AppState, name: &PackageName, filename: &str) {
+    if let Err(err) = state.inner.storage.remove_cached_tarball(name, filename).await {
+        tracing::warn!(?err, package = %name.as_str(), %filename, "invalid tarball cache removal failed");
+    }
+}
+
+fn cached_tarball_integrity(integrity: &Integrity, len: u64) -> CachedTarballIntegrity {
+    CachedTarballIntegrity { integrity: integrity.to_string(), len }
+}
+
+async fn record_cached_tarball_integrity(
+    state: &AppState,
+    name: &PackageName,
+    filename: &str,
+    integrity: CachedTarballIntegrity,
+) {
+    if let Err(err) =
+        state.inner.storage.write_cached_tarball_integrity(name, filename, &integrity).await
+    {
+        tracing::warn!(?err, package = %name.as_str(), %filename, "tarball cache integrity marker write failed");
+    }
 }
 
 /// Add a new user or log in an existing one. Mirrors verdaccio's

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -7,8 +7,9 @@ use crate::{
     upstream::CacheValidators,
 };
 use axum::body::Body;
+use serde::{Deserialize, Serialize};
 use std::{
-    io::ErrorKind,
+    io::{ErrorKind, SeekFrom},
     path::{Path, PathBuf},
     sync::{
         Arc,
@@ -16,7 +17,10 @@ use std::{
     },
     time::{Duration, SystemTime},
 };
-use tokio::{fs, io::AsyncWriteExt};
+use tokio::{
+    fs,
+    io::{AsyncSeekExt, AsyncWriteExt},
+};
 
 const PACKUMENT_FILE: &str = "package.json";
 
@@ -26,23 +30,23 @@ const PACKUMENT_FILE: &str = "package.json";
 /// revalidate against. The leading dot keeps it out of the
 /// package-listing walk and any static-serve view.
 const PACKUMENT_META_FILE: &str = ".package.json.meta";
+const TARBALL_INTEGRITY_SUFFIX: &str = ".integrity";
 
 /// Per-process counter feeding [`unique_tmp_path`] so two concurrent
 /// writes to the same path don't collide on the same temp filename.
-/// Combined with the pid the suffix is unique across every writer this
-/// process spawns; the rename is still atomic on POSIX as long as src
-/// and dest sit in the same directory (they do).
+/// Combined with the pid and random suffix, the rename is still atomic
+/// on POSIX as long as src and dest sit in the same directory (they do).
 static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+const MAX_TEMP_CREATE_ATTEMPTS: usize = 16;
 
 /// Handle returned from [`Storage::open_cached_tarball_tmp`]. The caller
-/// writes to `file` (and on success calls [`Self::finalize`] to
-/// atomically promote the temp file to the final cache path); dropping
-/// the handle without calling [`Self::finalize`] is treated as abandon
-/// — callers that hit an error mid-write should call [`Self::abandon`]
-/// to actively remove the leftover temp file.
+/// writes through [`Self::write_all`] (and on success calls [`Self::finalize`] to
+/// atomically promote the temp file to the final cache path). The temp
+/// path remains armed until promotion succeeds, so cancellation and
+/// every error path remove it through [`Drop`].
 pub struct TarballWrite {
-    pub file: fs::File,
-    tmp_path: PathBuf,
+    file: Option<fs::File>,
+    tmp_path: Option<PathBuf>,
     final_path: PathBuf,
 }
 
@@ -72,23 +76,73 @@ impl TarballSlot {
 }
 
 impl TarballWrite {
+    pub async fn write_all(&mut self, bytes: &[u8]) -> std::io::Result<()> {
+        match self.file.as_mut() {
+            Some(file) => file.write_all(bytes).await,
+            None => Err(std::io::Error::other("tarball cache writer is closed")),
+        }
+    }
+
     /// Sync the file to disk and rename it to its final cache path.
-    pub async fn finalize(self) -> Result<()> {
-        self.file.sync_all().await?;
-        drop(self.file);
+    pub async fn finalize(mut self) -> std::io::Result<()> {
+        match self.file.as_mut() {
+            Some(file) => file.sync_all().await?,
+            None => return Err(std::io::Error::other("tarball cache writer is closed")),
+        }
+        drop(self.file.take());
         if let Some(parent) = self.final_path.parent() {
             fs::create_dir_all(parent).await?;
         }
-        fs::rename(&self.tmp_path, &self.final_path).await?;
+        let tmp_path = self
+            .tmp_path
+            .as_ref()
+            .ok_or_else(|| std::io::Error::other("tarball cache temp path is missing"))?;
+        fs::rename(tmp_path, &self.final_path).await?;
+        self.tmp_path = None;
         Ok(())
     }
 
-    /// Remove the temp file. Errors are swallowed since the caller
-    /// is already handling a higher-level failure and a leftover
-    /// `*.tmp.*` file is harmless beyond a small amount of disk.
-    pub async fn abandon(self) {
-        drop(self.file);
-        let _ = fs::remove_file(&self.tmp_path).await;
+    /// Rewind the verified write handle so the caller streams the exact
+    /// bytes that were hashed. The handle is opened read+write up front
+    /// and reused here — never dropped and reopened by path — so there is
+    /// no window for an attacker-writable cache directory to swap the
+    /// temp file between verification and streaming.
+    pub async fn into_temp_file(mut self) -> std::io::Result<(fs::File, u64, PathBuf)> {
+        let Some(mut file) = self.file.take() else {
+            return Err(std::io::Error::other("tarball cache writer is closed"));
+        };
+        file.sync_all().await?;
+        let len = file.metadata().await?.len();
+        let tmp_path = self
+            .tmp_path
+            .take()
+            .ok_or_else(|| std::io::Error::other("tarball cache temp path is missing"))?;
+        file.seek(SeekFrom::Start(0)).await?;
+        Ok((file, len, tmp_path))
+    }
+
+    pub async fn abandon(mut self) {
+        drop(self.file.take());
+        let Some(tmp_path) = self.tmp_path.as_ref() else { return };
+        match fs::remove_file(tmp_path).await {
+            Ok(()) => self.tmp_path = None,
+            Err(err) if err.kind() == ErrorKind::NotFound => self.tmp_path = None,
+            Err(_) => {}
+        }
+    }
+}
+
+impl Drop for TarballWrite {
+    fn drop(&mut self) {
+        drop(self.file.take());
+        let Some(tmp_path) = self.tmp_path.take() else { return };
+        match std::fs::remove_file(&tmp_path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == ErrorKind::NotFound => {}
+            Err(err) => {
+                tracing::warn!(?err, path = %tmp_path.display(), "tarball cache temp cleanup failed");
+            }
+        }
     }
 }
 
@@ -105,6 +159,12 @@ impl TarballWrite {
 pub enum CachedPackument {
     Fresh(Vec<u8>),
     Stale(CacheValidators),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CachedTarballIntegrity {
+    pub integrity: String,
+    pub len: u64,
 }
 
 /// Verdaccio-shaped storage split into two stores with different
@@ -260,6 +320,17 @@ impl Storage {
         self.hosted.write_packument(name, bytes).await
     }
 
+    /// Open a tarball from the authoritative hosted store. Hosted
+    /// publish writes verify their SRI before finalization, and static
+    /// storage remains operator-controlled rather than an uplink cache.
+    pub async fn open_hosted_tarball(
+        &self,
+        name: &PackageName,
+        filename: &str,
+    ) -> Result<Option<(Body, Option<u64>)>> {
+        self.hosted.open_tarball(name, filename).await
+    }
+
     /// Reserve a staging slot for a tarball this server hosts. The
     /// publish flow streams the decode + hash + write through
     /// `std::fs` inside `spawn_blocking` and only needs the path;
@@ -276,8 +347,8 @@ impl Storage {
     /// Remove a single tarball file from both stores. The
     /// partial-unpublish flow calls this after PUT'ing the modified
     /// packument back; clearing the proxied mirror too stops
-    /// [`Self::open_tarball`]'s cache fallback from serving a stale copy
-    /// of the just-removed version.
+    /// the proxy cache from serving a stale copy of the just-removed
+    /// version.
     pub async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
         let hosted = self.hosted.remove_tarball(name, filename).await?;
         let cached = self.cached.remove_tarball(name, filename).await?;
@@ -340,25 +411,37 @@ impl Storage {
         self.cached.open_tarball_tmp(name, filename).await
     }
 
-    // --- Composed (hosted-first) ----------------------------------------
-
-    /// Open a tarball for streaming, preferring the hosted store over
-    /// the proxy mirror. Returns a response body plus its size (for
-    /// `Content-Length`). `Ok(None)` means neither store has it, so the
-    /// caller can fall through to the upstream fetch.
-    pub async fn open_tarball(
+    /// Open a raw proxy-cache tarball so the caller can verify it before
+    /// constructing a response body.
+    pub async fn open_cached_tarball(
         &self,
         name: &PackageName,
         filename: &str,
-    ) -> Result<Option<(Body, Option<u64>)>> {
-        if let Some(hit) = self.hosted.open_tarball(name, filename).await? {
-            return Ok(Some(hit));
-        }
-        Ok(self
-            .cached
-            .open_tarball(name, filename)
-            .await?
-            .map(|(file, len)| (streaming::stream_file(file), Some(len))))
+    ) -> Result<Option<(fs::File, u64)>> {
+        self.cached.open_tarball(name, filename).await
+    }
+
+    pub async fn read_cached_tarball_integrity(
+        &self,
+        name: &PackageName,
+        filename: &str,
+    ) -> Option<CachedTarballIntegrity> {
+        self.cached.read_tarball_integrity(name, filename).await
+    }
+
+    pub async fn write_cached_tarball_integrity(
+        &self,
+        name: &PackageName,
+        filename: &str,
+        integrity: &CachedTarballIntegrity,
+    ) -> Result<()> {
+        self.cached.write_tarball_integrity(name, filename, integrity).await
+    }
+
+    /// Remove a proxy-cache tarball that failed verification so a
+    /// subsequent request cannot repeatedly encounter the same bytes.
+    pub async fn remove_cached_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
+        self.cached.remove_tarball(name, filename).await
     }
 
     /// Promote a tmp tarball written by the publish flow to its final
@@ -478,14 +561,34 @@ impl Store {
         Ok(Some((file, len)))
     }
 
+    async fn read_tarball_integrity(
+        &self,
+        name: &PackageName,
+        filename: &str,
+    ) -> Option<CachedTarballIntegrity> {
+        match fs::read(self.tarball_integrity_path(name, filename)).await {
+            Ok(bytes) => serde_json::from_slice(&bytes).ok(),
+            Err(_) => None,
+        }
+    }
+
+    async fn write_tarball_integrity(
+        &self,
+        name: &PackageName,
+        filename: &str,
+        integrity: &CachedTarballIntegrity,
+    ) -> Result<()> {
+        write_atomic(&self.tarball_integrity_path(name, filename), &serde_json::to_vec(integrity)?)
+            .await
+    }
+
     async fn open_tarball_tmp(&self, name: &PackageName, filename: &str) -> Result<TarballWrite> {
         let final_path = self.tarball_path(name, filename);
         if let Some(parent) = final_path.parent() {
             fs::create_dir_all(parent).await?;
         }
-        let tmp_path = unique_tmp_path(&final_path);
-        let file = fs::File::create(&tmp_path).await?;
-        Ok(TarballWrite { file, tmp_path, final_path })
+        let (file, tmp_path) = create_tmp_file(&final_path).await?;
+        Ok(TarballWrite { file: Some(file), tmp_path: Some(tmp_path), final_path })
     }
 
     /// Reserve a tmp path in the destination package directory so the
@@ -531,6 +634,12 @@ impl Store {
     /// surface as a real error to the caller.
     async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
         let path = self.tarball_path(name, filename);
+        let integrity_path = self.tarball_integrity_path(name, filename);
+        match fs::remove_file(&integrity_path).await {
+            Ok(()) => {}
+            Err(err) if err.kind() == ErrorKind::NotFound => {}
+            Err(err) => return Err(err.into()),
+        }
         match fs::remove_file(&path).await {
             Ok(()) => Ok(true),
             Err(err) if err.kind() == ErrorKind::NotFound => Ok(false),
@@ -597,30 +706,74 @@ impl Store {
     fn tarball_path(&self, name: &PackageName, filename: &str) -> PathBuf {
         self.package_dir(name).join(filename)
     }
+
+    fn tarball_integrity_path(&self, name: &PackageName, filename: &str) -> PathBuf {
+        self.package_dir(name).join(format!("{filename}{TARBALL_INTEGRITY_SUFFIX}"))
+    }
 }
 
 async fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).await?;
     }
-    let tmp = unique_tmp_path(path);
-    let mut file = fs::File::create(&tmp).await?;
-    file.write_all(bytes).await?;
-    file.sync_all().await?;
+    let (mut file, tmp) = create_tmp_file(path).await?;
+    if let Err(err) = file.write_all(bytes).await {
+        drop(file);
+        let _ = fs::remove_file(&tmp).await;
+        return Err(err.into());
+    }
+    if let Err(err) = file.sync_all().await {
+        drop(file);
+        let _ = fs::remove_file(&tmp).await;
+        return Err(err.into());
+    }
     drop(file);
-    fs::rename(&tmp, path).await?;
+    if let Err(err) = fs::rename(&tmp, path).await {
+        let _ = fs::remove_file(&tmp).await;
+        return Err(err.into());
+    }
     Ok(())
 }
 
-/// A unique sibling of `base` (`<base>.tmp.<pid>.<counter>`). The pid +
-/// per-process counter make the suffix unique across every writer this
-/// process spawns; keeping it in `base`'s directory keeps the eventual
-/// rename atomic on POSIX. Shared with [`crate::s3`]'s staging path.
+async fn create_tmp_file(base: &Path) -> Result<(fs::File, PathBuf)> {
+    create_tmp_file_with(base, unique_tmp_path).await
+}
+
+async fn create_tmp_file_with(
+    base: &Path,
+    mut next_path: impl FnMut(&Path) -> PathBuf,
+) -> Result<(fs::File, PathBuf)> {
+    let mut last_already_exists = None;
+    for _ in 0..MAX_TEMP_CREATE_ATTEMPTS {
+        let tmp_path = next_path(base);
+        match fs::OpenOptions::new().read(true).write(true).create_new(true).open(&tmp_path).await {
+            Ok(file) => return Ok((file, tmp_path)),
+            Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+                last_already_exists = Some(err);
+            }
+            Err(err) => return Err(err.into()),
+        }
+    }
+    Err(last_already_exists
+        .unwrap_or_else(|| {
+            std::io::Error::new(ErrorKind::AlreadyExists, "temporary path creation collided")
+        })
+        .into())
+}
+
+/// A unique sibling of `base` (`<base>.tmp.<pid>.<counter>.<random>`).
+/// Keeping it in `base`'s directory keeps the eventual rename atomic on
+/// POSIX. Shared with [`crate::s3`]'s staging path.
 pub(crate) fn unique_tmp_path(base: &Path) -> PathBuf {
     let counter = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let pid = std::process::id();
+    let mut random = [0u8; 8];
+    let random = match getrandom::fill(&mut random) {
+        Ok(()) => u64::from_ne_bytes(random),
+        Err(_) => 0,
+    };
     let mut name = base.file_name().map(std::ffi::OsStr::to_os_string).unwrap_or_default();
-    name.push(format!(".tmp.{pid}.{counter}"));
+    name.push(format!(".tmp.{pid}.{counter}.{random:016x}"));
     match base.parent() {
         Some(parent) => parent.join(name),
         None => PathBuf::from(name),

--- a/pnpr/crates/pnpr/src/storage/tests.rs
+++ b/pnpr/crates/pnpr/src/storage/tests.rs
@@ -21,6 +21,10 @@ fn sidecar_path(tmp: &TempDir, name: &str) -> PathBuf {
     tmp.path().join("cache").join(name).join(PACKUMENT_META_FILE)
 }
 
+fn tarball_sidecar_path(tmp: &TempDir, name: &str, filename: &str) -> PathBuf {
+    tmp.path().join("cache").join(name).join(format!("{filename}{TARBALL_INTEGRITY_SUFFIX}"))
+}
+
 /// Read an entry back as `Stale` so its validators can be inspected. The
 /// write is aged past a 1ms TTL with a short sleep.
 async fn read_stale_validators(storage: &Storage, name: &PackageName) -> CacheValidators {
@@ -133,4 +137,113 @@ async fn read_cached_packument_returns_bytes_regardless_of_age() {
     tokio::time::sleep(Duration::from_millis(10)).await;
     let bytes = storage.read_cached_packument(&name).await.unwrap();
     assert_eq!(bytes.as_deref(), Some(&br#"{"v":1}"#[..]));
+}
+
+#[tokio::test]
+async fn cached_tarball_integrity_roundtrips_and_malformed_is_none() {
+    let tmp = TempDir::new().unwrap();
+    let storage = storage_in(&tmp);
+    let name = pkg("foo");
+    let integrity = CachedTarballIntegrity { integrity: "sha512-ZGVhZGJlZWY=".to_string(), len: 7 };
+
+    storage.write_cached_tarball_integrity(&name, "foo-1.0.0.tgz", &integrity).await.unwrap();
+    assert_eq!(
+        storage.read_cached_tarball_integrity(&name, "foo-1.0.0.tgz").await,
+        Some(integrity),
+    );
+
+    fs::write(tarball_sidecar_path(&tmp, "foo", "foo-1.0.0.tgz"), b"not json").await.unwrap();
+    assert!(storage.read_cached_tarball_integrity(&name, "foo-1.0.0.tgz").await.is_none());
+}
+
+#[tokio::test]
+async fn removing_cached_tarball_removes_integrity_sidecar() {
+    let tmp = TempDir::new().unwrap();
+    let storage = storage_in(&tmp);
+    let name = pkg("foo");
+    let mut write = storage.open_cached_tarball_tmp(&name, "foo-1.0.0.tgz").await.unwrap();
+    write.write_all(b"tarball").await.unwrap();
+    write.finalize().await.unwrap();
+    storage
+        .write_cached_tarball_integrity(
+            &name,
+            "foo-1.0.0.tgz",
+            &CachedTarballIntegrity { integrity: "sha512-ZGVhZGJlZWY=".to_string(), len: 7 },
+        )
+        .await
+        .unwrap();
+
+    assert!(tarball_sidecar_path(&tmp, "foo", "foo-1.0.0.tgz").exists());
+    assert!(storage.remove_cached_tarball(&name, "foo-1.0.0.tgz").await.unwrap());
+    assert!(!tarball_sidecar_path(&tmp, "foo", "foo-1.0.0.tgz").exists());
+}
+
+#[tokio::test]
+async fn temp_file_creation_retries_existing_candidate_without_overwriting() {
+    let tmp = TempDir::new().unwrap();
+    let final_path = tmp.path().join("foo-1.0.0.tgz");
+    let occupied = tmp.path().join("foo-1.0.0.tgz.tmp.occupied");
+    let retry = tmp.path().join("foo-1.0.0.tgz.tmp.retry");
+    fs::write(&occupied, b"occupied").await.unwrap();
+
+    let mut first = true;
+    let (mut file, path) = create_tmp_file_with(&final_path, |_| {
+        if std::mem::replace(&mut first, false) { occupied.clone() } else { retry.clone() }
+    })
+    .await
+    .unwrap();
+    assert_eq!(path, retry);
+
+    file.write_all(b"new").await.unwrap();
+    file.sync_all().await.unwrap();
+    drop(file);
+
+    assert_eq!(fs::read(&occupied).await.unwrap(), b"occupied");
+    assert_eq!(fs::read(&retry).await.unwrap(), b"new");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn temp_file_creation_does_not_follow_symlink_candidate() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = TempDir::new().unwrap();
+    let final_path = tmp.path().join("foo-1.0.0.tgz");
+    let victim = tmp.path().join("victim");
+    let symlink_path = tmp.path().join("foo-1.0.0.tgz.tmp.symlink");
+    let retry = tmp.path().join("foo-1.0.0.tgz.tmp.retry");
+    fs::write(&victim, b"victim").await.unwrap();
+    symlink(&victim, &symlink_path).unwrap();
+
+    let mut first = true;
+    let (mut file, path) = create_tmp_file_with(&final_path, |_| {
+        if std::mem::replace(&mut first, false) { symlink_path.clone() } else { retry.clone() }
+    })
+    .await
+    .unwrap();
+    assert_eq!(path, retry);
+
+    file.write_all(b"new").await.unwrap();
+    file.sync_all().await.unwrap();
+    drop(file);
+
+    assert_eq!(fs::read(&victim).await.unwrap(), b"victim");
+    assert_eq!(fs::read(&retry).await.unwrap(), b"new");
+    assert!(std::fs::symlink_metadata(&symlink_path).unwrap().file_type().is_symlink());
+}
+
+#[tokio::test]
+async fn failed_tarball_finalize_removes_tmp_file() {
+    let tmp = TempDir::new().unwrap();
+    let tmp_path = tmp.path().join("foo-1.0.0.tgz.tmp.test");
+    let final_path = tmp.path().join("foo-1.0.0.tgz");
+    fs::create_dir(&final_path).await.unwrap();
+    fs::write(final_path.join("block-rename"), b"occupied").await.unwrap();
+
+    let file = fs::File::create(&tmp_path).await.unwrap();
+    let mut write = TarballWrite { file: Some(file), tmp_path: Some(tmp_path.clone()), final_path };
+    write.write_all(b"tarball").await.unwrap();
+
+    assert!(write.finalize().await.is_err());
+    assert!(!tmp_path.exists(), "failed finalization must remove its temporary file");
 }

--- a/pnpr/crates/pnpr/src/streaming.rs
+++ b/pnpr/crates/pnpr/src/streaming.rs
@@ -1,41 +1,149 @@
 //! Streaming helpers for the tarball path.
 //!
-//! Two flows live here:
+//! Four flows live here:
 //!
-//! * [`stream_file`] — cache hit. Open the cached tarball and yield
-//!   chunks straight to the response body.
-//! * [`tee_to_cache`] — cache miss. Pull chunks from the upstream
-//!   response, forward each chunk to the client *and* a temp file via
-//!   an mpsc channel, then atomically promote the temp file to the
-//!   final cache path on stream completion. On upstream error or
-//!   client disconnect the temp file is removed.
+//! * [`verify_file`] hashes a cache hit before it can be served.
+//! * [`download_verified_to_cache`] hashes an upstream response into a
+//!   temp file and promotes it only after the declared SRI matches.
+//! * [`download_verified_to_temp`] hashes an upstream response into a
+//!   temp file for mirror-less pass-through.
+//! * [`stream_file`] yields an already verified file to the response.
 
 use crate::storage::TarballWrite;
 use axum::body::{Body, Bytes};
-use futures_util::{
-    Stream,
-    stream::{self, StreamExt},
+use futures_util::{StreamExt, stream};
+use ssri::{Integrity, IntegrityChecker};
+use std::{
+    io::{self, SeekFrom},
+    path::PathBuf,
 };
-use std::{io, pin::Pin};
 use tokio::{
     fs::File,
-    io::{AsyncReadExt, AsyncWriteExt},
-    sync::mpsc,
+    io::{AsyncReadExt, AsyncSeekExt},
 };
 
 /// Chunk size for reading from a cached file. 64 KiB keeps syscall
 /// overhead low without buffering a meaningful fraction of a
-/// multi-MB tarball; matches the channel-element shape used for the
-/// upstream tee path.
+/// multi-MB tarball.
 const READ_CHUNK: usize = 64 * 1024;
 
-/// Backpressure budget for the upstream-tee channel. Each in-flight
-/// item is one chunk from the upstream response (typically
-/// hyper-sized — a few kB), so 16 caps the writer's lead over the
-/// client at ~1 MB. Once the buffer fills, the tee task awaits
-/// on `send`, which naturally throttles the upstream read loop to
-/// the client's read rate.
-const TEE_CHANNEL: usize = 16;
+pub fn parse_integrity(value: &str) -> Result<Integrity, ssri::Error> {
+    let integrity: Integrity = value.parse()?;
+    ensure_supported_hash(&integrity)?;
+    Ok(integrity)
+}
+
+fn ensure_supported_hash(integrity: &Integrity) -> Result<(), ssri::Error> {
+    if integrity.hashes.is_empty() {
+        return Err(ssri::Error::ParseIntegrityError(
+            "integrity string contains no supported hashes".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub fn integrity_checker(integrity: &Integrity) -> Result<IntegrityChecker, ssri::Error> {
+    ensure_supported_hash(integrity)?;
+    Ok(IntegrityChecker::new(integrity.clone()))
+}
+
+#[derive(Debug)]
+pub enum TarballStreamError {
+    Upstream { url: String, source: reqwest::Error },
+    Io(io::Error),
+    Integrity(ssri::Error),
+    TooLarge { limit: u64, received: u64 },
+}
+
+/// Hash a cached file against `integrity`, then rewind the same open
+/// file so the caller can stream the exact bytes that were checked.
+pub async fn verify_file(
+    mut file: File,
+    integrity: &Integrity,
+) -> Result<File, TarballStreamError> {
+    let mut checker = integrity_checker(integrity).map_err(TarballStreamError::Integrity)?;
+    let mut buf = vec![0u8; READ_CHUNK];
+    loop {
+        let bytes_read = file.read(&mut buf).await.map_err(TarballStreamError::Io)?;
+        if bytes_read == 0 {
+            break;
+        }
+        checker.input(&buf[..bytes_read]);
+    }
+    checker.result().map_err(TarballStreamError::Integrity)?;
+    file.seek(SeekFrom::Start(0)).await.map_err(TarballStreamError::Io)?;
+    Ok(file)
+}
+
+/// Download an upstream response into `write`, verify the complete body,
+/// and atomically promote it to the cache. No bytes become cache-visible
+/// until the declared SRI matches.
+pub async fn download_verified_to_cache(
+    response: reqwest::Response,
+    mut write: TarballWrite,
+    integrity: &Integrity,
+    max_bytes: u64,
+) -> Result<u64, TarballStreamError> {
+    let len = match download_verified(response, &mut write, integrity, max_bytes).await {
+        Ok(len) => len,
+        Err(err) => {
+            write.abandon().await;
+            return Err(err);
+        }
+    };
+    write.finalize().await.map_err(TarballStreamError::Io)?;
+    Ok(len)
+}
+
+pub async fn download_verified_to_temp(
+    response: reqwest::Response,
+    mut write: TarballWrite,
+    integrity: &Integrity,
+    max_bytes: u64,
+) -> Result<(File, u64, PathBuf), TarballStreamError> {
+    if let Err(err) = download_verified(response, &mut write, integrity, max_bytes).await {
+        write.abandon().await;
+        return Err(err);
+    }
+    write.into_temp_file().await.map_err(TarballStreamError::Io)
+}
+
+async fn download_verified(
+    response: reqwest::Response,
+    write: &mut TarballWrite,
+    integrity: &Integrity,
+    max_bytes: u64,
+) -> Result<u64, TarballStreamError> {
+    let url = response.url().to_string();
+    if let Some(received) = response.content_length()
+        && received > max_bytes
+    {
+        return Err(TarballStreamError::TooLarge { limit: max_bytes, received });
+    }
+    let mut upstream = response.bytes_stream();
+    let mut checker = integrity_checker(integrity).map_err(TarballStreamError::Integrity)?;
+    let mut written = 0u64;
+    while let Some(chunk_result) = upstream.next().await {
+        let chunk = match chunk_result {
+            Ok(chunk) => chunk,
+            Err(source) => return Err(TarballStreamError::Upstream { url, source }),
+        };
+        let received = written.saturating_add(chunk.len() as u64);
+        if received > max_bytes {
+            return Err(TarballStreamError::TooLarge { limit: max_bytes, received });
+        }
+        if let Err(err) = write.write_all(&chunk).await {
+            return Err(TarballStreamError::Io(err));
+        }
+        checker.input(&chunk);
+        written = received;
+    }
+
+    if let Err(err) = checker.result() {
+        return Err(TarballStreamError::Integrity(err));
+    }
+    Ok(written)
+}
 
 /// Stream a cached file as a response body. Caller is responsible for
 /// setting `Content-Length` (from the file metadata it already read).
@@ -59,71 +167,47 @@ pub fn stream_file(file: File) -> Body {
     Body::from_stream(stream)
 }
 
-/// Stream an upstream [`reqwest::Response`] to the client while
-/// teeing the bytes into a temp file owned by `write`. On clean
-/// completion the temp file is `finalize`d (synced + renamed); on
-/// upstream error or client disconnect it's abandoned.
-pub fn tee_to_cache(response: reqwest::Response, write: TarballWrite) -> Body {
-    let url = response.url().to_string();
-    let upstream = response.bytes_stream();
-    let (tx, rx) = mpsc::channel::<Result<Bytes, io::Error>>(TEE_CHANNEL);
-
-    tokio::spawn(run_tee(Box::pin(upstream), write, tx, url));
-
-    let stream = stream::unfold(rx, |mut rx| async move { rx.recv().await.map(|item| (item, rx)) });
+pub fn stream_file_and_remove(file: File, path: PathBuf) -> Body {
+    let stream = stream::unfold(Some(RemoveOnDropFile::new(file, path)), |state| async move {
+        let mut state = state?;
+        let mut buf = vec![0u8; READ_CHUNK];
+        let file = state.file.as_mut().expect("file is present until stream finishes");
+        match file.read(&mut buf).await {
+            Ok(0) => None,
+            Ok(n) => {
+                buf.truncate(n);
+                Some((Ok::<_, io::Error>(Bytes::from(buf)), Some(state)))
+            }
+            Err(err) => Some((Err(err), None)),
+        }
+    });
     Body::from_stream(stream)
 }
 
-async fn run_tee(
-    mut upstream: Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>> + Send>>,
-    write: TarballWrite,
-    tx: mpsc::Sender<Result<Bytes, io::Error>>,
-    url: String,
-) {
-    // `cache_write` goes to `None` after a write failure: the temp
-    // file is abandoned and the client continues to receive bytes
-    // from upstream. The cache is best-effort — matching the
-    // fallback that `serve_tarball` already does when `open_tarball_tmp`
-    // fails (see `streaming without cache` log).
-    let mut cache_write = Some(write);
-    while let Some(chunk_result) = upstream.next().await {
-        let chunk = match chunk_result {
-            Ok(chunk) => chunk,
-            Err(err) => {
-                tracing::warn!(%url, %err, "upstream stream errored mid-body");
-                let _ = tx.send(Err(io::Error::other(err.to_string()))).await;
-                if let Some(write) = cache_write {
-                    write.abandon().await;
-                }
-                return;
-            }
-        };
-        if let Some(write) = cache_write.as_mut()
-            && let Err(err) = write.file.write_all(&chunk).await
-        {
-            tracing::warn!(%url, ?err, "cache temp-file write failed; continuing without cache");
-            if let Some(write) = cache_write.take() {
-                write.abandon().await;
-            }
-        }
-        if tx.send(Ok(chunk)).await.is_err() {
-            // Client hung up. Don't keep streaming bytes nobody's
-            // reading; abandon the partial cache file too — a future
-            // request will refetch and (if it completes) populate
-            // the cache cleanly. Salvaging the partial write is
-            // possible (keep going, finalize at end) but adds the
-            // failure mode where a client that aborted *also* poisoned
-            // a half-written upstream into our cache.
-            tracing::debug!(%url, "client disconnected mid-stream; abandoning cache write");
-            if let Some(write) = cache_write {
-                write.abandon().await;
-            }
-            return;
-        }
-    }
-    if let Some(write) = cache_write
-        && let Err(err) = write.finalize().await
-    {
-        tracing::warn!(%url, ?err, "cache finalize failed");
+struct RemoveOnDropFile {
+    file: Option<File>,
+    path: Option<PathBuf>,
+}
+
+impl RemoveOnDropFile {
+    fn new(file: File, path: PathBuf) -> Self {
+        Self { file: Some(file), path: Some(path) }
     }
 }
+
+impl Drop for RemoveOnDropFile {
+    fn drop(&mut self) {
+        drop(self.file.take());
+        let Some(path) = self.path.take() else { return };
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => {
+                tracing::warn!(?err, path = %path.display(), "temporary tarball cleanup failed");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpr/crates/pnpr/src/streaming/tests.rs
+++ b/pnpr/crates/pnpr/src/streaming/tests.rs
@@ -1,0 +1,168 @@
+use super::{TarballStreamError, download_verified_to_cache, integrity_checker, parse_integrity};
+use crate::{config::HostedStoreConfig, package_name::PackageName, storage::Storage};
+use ssri::{Algorithm, Integrity, IntegrityOpts};
+use std::{path::Path, sync::Arc, time::Duration};
+use tempfile::TempDir;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+    sync::Notify,
+};
+
+#[test]
+fn accepts_integrity_with_supported_hash() {
+    assert!(parse_integrity("sha512-ZGVhZGJlZWY=").is_ok());
+}
+
+#[test]
+fn rejects_integrity_without_hashes() {
+    for value in ["", " \t\n "] {
+        let err = parse_integrity(value).unwrap_err();
+        assert!(err.to_string().contains("no supported hashes"));
+    }
+
+    let zero_hash = Integrity { hashes: Vec::new() };
+    assert!(integrity_checker(&zero_hash).is_err());
+}
+
+#[test]
+fn rejects_malformed_or_unsupported_integrity() {
+    for value in ["not-a-valid-sri", "md5-deadbeef"] {
+        assert!(parse_integrity(value).is_err());
+    }
+}
+
+fn sha512_integrity(bytes: &[u8]) -> String {
+    let mut opts = IntegrityOpts::new().algorithm(Algorithm::Sha512);
+    opts.input(bytes);
+    opts.result().to_string()
+}
+
+async fn spawn_stalled_response() -> (String, Arc<Notify>, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let release = Arc::new(Notify::new());
+    let release_for_server = Arc::clone(&release);
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut request = [0u8; 4096];
+        let _ = socket.read(&mut request).await;
+        socket
+            .write_all(
+                b"HTTP/1.1 200 OK\r\n\
+                  Content-Length: 1048576\r\n\
+                  Content-Type: application/octet-stream\r\n\
+                  Connection: close\r\n\
+                  \r\n",
+            )
+            .await
+            .unwrap();
+        socket.write_all(&vec![0xAA; 64 * 1024]).await.unwrap();
+        socket.flush().await.unwrap();
+        release_for_server.notified().await;
+    });
+    (format!("http://{addr}/foo/-/foo-1.0.0.tgz"), release, server)
+}
+
+async fn spawn_response(bytes: &'static [u8]) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut request = [0u8; 4096];
+        let _ = socket.read(&mut request).await;
+        let headers = format!(
+            "HTTP/1.1 200 OK\r\n\
+             Content-Length: {}\r\n\
+             Content-Type: application/octet-stream\r\n\
+             Connection: close\r\n\
+             \r\n",
+            bytes.len(),
+        );
+        socket.write_all(headers.as_bytes()).await.unwrap();
+        socket.write_all(bytes).await.unwrap();
+        socket.flush().await.unwrap();
+    });
+    format!("http://{addr}/foo/-/foo-1.0.0.tgz")
+}
+
+fn tarball_tmp_entries(dir: &Path) -> Vec<String> {
+    let mut entries = dir
+        .read_dir()
+        .map(|entries| {
+            entries
+                .filter_map(Result::ok)
+                .filter_map(|entry| {
+                    let name = entry.file_name().to_string_lossy().into_owned();
+                    name.starts_with("foo-1.0.0.tgz.tmp.").then_some(name)
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    entries.sort();
+    entries
+}
+
+async fn await_nonempty_tarball_tmp(dir: &Path) -> Vec<String> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        let entries = tarball_tmp_entries(dir);
+        if entries
+            .iter()
+            .any(|name| std::fs::metadata(dir.join(name)).is_ok_and(|metadata| metadata.len() > 0))
+        {
+            return entries;
+        }
+        assert!(std::time::Instant::now() < deadline, "tarball body was not written to tmp");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[tokio::test]
+async fn cancelling_in_flight_response_body_removes_tmp_file() {
+    let expected_bytes = vec![0xAA; 1024 * 1024];
+    let integrity = parse_integrity(&sha512_integrity(&expected_bytes)).unwrap();
+    let (url, release, server) = spawn_stalled_response().await;
+    let response = reqwest::get(url).await.unwrap();
+
+    let tmp = TempDir::new().unwrap();
+    let cache = tmp.path().join("cache");
+    let storage = Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), cache.clone());
+    let name = PackageName::parse("foo").unwrap();
+    let write = storage.open_cached_tarball_tmp(&name, "foo-1.0.0.tgz").await.unwrap();
+
+    let download = tokio::spawn(async move {
+        download_verified_to_cache(response, write, &integrity, u64::MAX).await
+    });
+    let package_dir = cache.join("foo");
+    let in_flight = await_nonempty_tarball_tmp(&package_dir).await;
+    assert_eq!(in_flight.len(), 1, "expected one in-flight tarball writer");
+
+    download.abort();
+    assert!(download.await.unwrap_err().is_cancelled());
+    assert!(tarball_tmp_entries(&package_dir).is_empty());
+    assert!(!package_dir.join("foo-1.0.0.tgz").exists());
+
+    release.notify_one();
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn oversized_response_is_rejected_and_tmp_is_removed() {
+    let bytes = b"oversized";
+    let integrity = parse_integrity(&sha512_integrity(bytes)).unwrap();
+    let response = reqwest::get(spawn_response(bytes).await).await.unwrap();
+
+    let tmp = TempDir::new().unwrap();
+    let cache = tmp.path().join("cache");
+    let storage = Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), cache.clone());
+    let name = PackageName::parse("foo").unwrap();
+    let write = storage.open_cached_tarball_tmp(&name, "foo-1.0.0.tgz").await.unwrap();
+
+    let err = download_verified_to_cache(response, write, &integrity, 3).await.unwrap_err();
+    assert!(matches!(err, TarballStreamError::TooLarge { limit: 3, received } if received > 3));
+
+    let package_dir = cache.join("foo");
+    assert!(tarball_tmp_entries(&package_dir).is_empty());
+    assert!(!package_dir.join("foo-1.0.0.tgz").exists());
+}

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -358,35 +358,31 @@ impl Upstream {
 }
 
 /// Rewrite every `dist.tarball` in `value` to a URL served by *this*
-/// registry instead of whatever URL the source put there. The new
-/// URL is `{public_url}/{pkg}/-/{basename}`, where `basename` is the
-/// last `/`-separated segment of the original tarball URL. This
-/// handles both npm's canonical `/{pkg}/-/{basename}` shape and
-/// verdaccio's `/{scope}/{name}/-/{scope}/{filename}` shape uniformly
-/// — we only look at the basename, never at the path prefix.
+/// registry instead of whatever URL the source put there. Each new URL
+/// is derived from its `versions` map key, so an uplink cannot point one
+/// manifest at another version's route, integrity, or cache entry.
 ///
-/// Walks both packument shape (`{ "versions": { v: { dist: ... } } }`)
-/// and single-version manifest shape (`{ dist: ... }` at the top
-/// level) so a single helper covers both endpoints.
+/// The version-manifest endpoint calls [`extract_version_manifest`],
+/// which binds the rewrite to its resolved `versions` map key directly.
 pub fn rewrite_tarball_urls(value: &mut Value, pkg: &PackageName, public_url: &str) {
     let public_url = public_url.trim_end_matches('/');
     if let Some(versions) = value.get_mut("versions").and_then(Value::as_object_mut) {
-        for version in versions.values_mut() {
-            rewrite_dist_tarball(version, pkg, public_url);
+        for (version, manifest) in versions {
+            rewrite_dist_tarball(manifest, pkg, version, public_url);
         }
     }
-    rewrite_dist_tarball(value, pkg, public_url);
 }
 
-fn rewrite_dist_tarball(value: &mut Value, pkg: &PackageName, public_url: &str) {
+fn rewrite_dist_tarball(value: &mut Value, pkg: &PackageName, version: &str, public_url: &str) {
     let Some(dist) = value.get_mut("dist").and_then(Value::as_object_mut) else {
         return;
     };
     let Some(tarball_value) = dist.get_mut("tarball") else { return };
-    let Some(basename) = tarball_value.as_str().and_then(|url| url.rsplit('/').next()) else {
+    if !tarball_value.is_string() {
         return;
-    };
-    *tarball_value = Value::String(format!("{public_url}/{}/-/{basename}", pkg.as_str()));
+    }
+    let filename = pkg.tarball_name_for_version(version);
+    *tarball_value = Value::String(format!("{public_url}/{}/-/{filename}", pkg.as_str()));
 }
 
 /// Look up the version manifest for `version_or_tag` inside a parsed
@@ -406,7 +402,7 @@ pub fn extract_version_manifest(
         .and_then(Value::as_str)
         .unwrap_or(version_or_tag);
     let mut manifest = packument.get("versions")?.get(resolved)?.clone();
-    rewrite_tarball_urls(&mut manifest, pkg, public_url);
+    rewrite_dist_tarball(&mut manifest, pkg, resolved, public_url.trim_end_matches('/'));
     Some(manifest)
 }
 

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -204,14 +204,11 @@ fn rewrites_npm_form_tarball() {
 
 #[test]
 fn rewrites_verdaccio_form_tarball_for_scoped() {
-    // Verdaccio publishes scoped tarball URLs like
-    // `/@scope/name/-/@scope/name-1.0.0.tgz` — the scope is
-    // present twice. We only care about the basename.
     let mut doc = json!({
         "versions": {
             "1.0.0": {
                 "dist": {
-                    "tarball": "http://localhost:4873/@foo/no-deps/-/@foo/no-deps-1.0.0.tgz"
+                    "tarball": "http://localhost:4873/@foo/no-deps/-/@foo/no-deps-9.9.9.tgz"
                 }
             }
         }
@@ -242,7 +239,7 @@ fn extracts_version_by_dist_tag() {
                 "name": "@foo/no-deps",
                 "version": "1.0.0",
                 "dist": {
-                    "tarball": "http://localhost:4873/@foo/no-deps/-/@foo/no-deps-1.0.0.tgz",
+                    "tarball": "http://localhost:4873/@foo/no-deps/-/@foo/no-deps-2.0.0.tgz",
                     "shasum": "abc"
                 }
             }

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -5,6 +5,7 @@ use axum::{
 use flate2::read::GzDecoder;
 use pnpr::{Config, router};
 use serde_json::{Value, json};
+use ssri::{Algorithm, IntegrityOpts};
 use std::{
     fs,
     io::Read as _,
@@ -36,6 +37,12 @@ async fn body_json(body: Body) -> Value {
     serde_json::from_slice(&body_bytes(body).await).expect("body parses as JSON")
 }
 
+fn sha512_integrity(bytes: &[u8]) -> String {
+    let mut opts = IntegrityOpts::new().algorithm(Algorithm::Sha512);
+    opts.input(bytes);
+    opts.result().to_string()
+}
+
 fn osv_database(package: &str, versions: &[&str]) -> TempDir {
     let dir = TempDir::new().unwrap();
     let versions: Vec<Value> = versions.iter().map(|version| json!(version)).collect();
@@ -53,6 +60,41 @@ fn osv_database(package: &str, versions: &[&str]) -> TempDir {
 fn enable_osv(config: &mut Config, path: &Path) {
     config.osv.enabled = true;
     config.osv.path = Some(path.to_path_buf());
+}
+
+async fn mock_packument_for_tarball(
+    upstream: &mut mockito::ServerGuard,
+    package: &str,
+    version: &str,
+    expected_bytes: &[u8],
+) -> mockito::Mock {
+    let basename = package.rsplit('/').next().expect("package has a basename");
+    let mut versions = serde_json::Map::new();
+    versions.insert(
+        version.to_string(),
+        json!({
+            "name": package,
+            "version": version,
+            "dist": {
+                "tarball": format!("{}/{package}/-/{basename}-{version}.tgz", upstream.url()),
+                "integrity": sha512_integrity(expected_bytes),
+            },
+        }),
+    );
+    let packument = json!({
+        "name": package,
+        "dist-tags": { "latest": version },
+        "versions": versions,
+    });
+    let path = format!("/{package}");
+    upstream
+        .mock("GET", path.as_str())
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(packument.to_string())
+        .expect(1)
+        .create_async()
+        .await
 }
 
 #[tokio::test]
@@ -322,6 +364,7 @@ async fn scoped_packument_is_served() {
 async fn tarball_is_proxied_and_cached() {
     let mut upstream = mockito::Server::new_async().await;
     let bytes = b"fake-tarball-bytes";
+    let packument_mock = mock_packument_for_tarball(&mut upstream, "foo", "1.0.0", bytes).await;
     let mock = upstream
         .mock("GET", "/foo/-/foo-1.0.0.tgz")
         .with_status(200)
@@ -332,7 +375,8 @@ async fn tarball_is_proxied_and_cached() {
         .await;
 
     let tmp = TempDir::new().unwrap();
-    let app = router(config_for(&upstream.url(), tmp.path().to_path_buf()));
+    let storage = tmp.path().to_path_buf();
+    let app = router(config_for(&upstream.url(), storage.clone()));
 
     let first = app
         .clone()
@@ -342,14 +386,14 @@ async fn tarball_is_proxied_and_cached() {
     assert_eq!(first.status(), StatusCode::OK);
     assert_eq!(body_bytes(first.into_body()).await, bytes);
 
-    let second = app
-        .clone()
+    let second = router(config_for("http://127.0.0.1:1", storage))
         .oneshot(Request::get("/foo/-/foo-1.0.0.tgz").body(Body::empty()).unwrap())
         .await
         .unwrap();
     assert_eq!(second.status(), StatusCode::OK);
     assert_eq!(body_bytes(second.into_body()).await, bytes);
 
+    packument_mock.assert_async().await;
     mock.assert_async().await;
 }
 
@@ -417,6 +461,7 @@ async fn osv_tarball_screening_preserves_access_gate() {
 async fn osv_refuses_vulnerable_tarball_from_cache() {
     let mut upstream = mockito::Server::new_async().await;
     let bytes = b"cached vulnerable tarball";
+    let packument_mock = mock_packument_for_tarball(&mut upstream, "foo", "1.0.0", bytes).await;
     let mock = upstream
         .mock("GET", "/foo/-/foo-1.0.0.tgz")
         .with_status(200)
@@ -448,7 +493,243 @@ async fn osv_refuses_vulnerable_tarball_from_cache() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 
+    packument_mock.assert_async().await;
     mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn selected_version_controls_tarball_route_and_offline_cache_key() {
+    let mut upstream = mockito::Server::new_async().await;
+    let v1_bytes = b"selected-version-one";
+    let v2_bytes = b"other-version-two";
+    let packument = json!({
+        "name": "foo",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "foo",
+                "version": "1.0.0",
+                "dist": {
+                    "tarball": format!("{}/foo/-/foo-2.0.0.tgz", upstream.url()),
+                    "integrity": sha512_integrity(v1_bytes),
+                },
+            },
+            "2.0.0": {
+                "name": "foo",
+                "version": "2.0.0",
+                "dist": {
+                    "tarball": format!("{}/foo/-/foo-1.0.0.tgz", upstream.url()),
+                    "integrity": sha512_integrity(v2_bytes),
+                },
+            },
+        },
+    });
+    let packument_mock = upstream
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(packument.to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    let tarball_mock = upstream
+        .mock("GET", "/foo/-/foo-1.0.0.tgz")
+        .with_status(200)
+        .with_body(v1_bytes)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(config_for(&upstream.url(), storage.clone()));
+
+    let selected = app
+        .clone()
+        .oneshot(Request::get("/foo/latest").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(selected.status(), StatusCode::OK);
+    let selected: Value = serde_json::from_slice(&body_bytes(selected.into_body()).await).unwrap();
+    assert_eq!(selected["dist"]["tarball"], "http://example.test/foo/-/foo-1.0.0.tgz");
+
+    let full =
+        app.clone().oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
+    let full: Value = serde_json::from_slice(&body_bytes(full.into_body()).await).unwrap();
+    assert_eq!(
+        full["versions"]["1.0.0"]["dist"]["tarball"],
+        "http://example.test/foo/-/foo-1.0.0.tgz",
+    );
+    assert_eq!(
+        full["versions"]["2.0.0"]["dist"]["tarball"],
+        "http://example.test/foo/-/foo-2.0.0.tgz",
+    );
+
+    let route =
+        selected["dist"]["tarball"].as_str().unwrap().strip_prefix("http://example.test").unwrap();
+    let first = app.oneshot(Request::get(route).body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(first.status(), StatusCode::OK);
+    assert_eq!(body_bytes(first.into_body()).await, v1_bytes);
+
+    let package_dir = storage.join(".pnpr-cache").join("foo");
+    assert_eq!(tarball_cache_entries(&package_dir), vec!["foo-1.0.0.tgz".to_string()]);
+
+    let offline = router(config_for("http://127.0.0.1:1", storage));
+    let replay = offline.oneshot(Request::get(route).body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(replay.status(), StatusCode::OK);
+    assert_eq!(body_bytes(replay.into_body()).await, v1_bytes);
+
+    packument_mock.assert_async().await;
+    tarball_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn tampered_upstream_tarball_is_rejected_and_not_cached() {
+    let mut upstream = mockito::Server::new_async().await;
+    let good_bytes = b"good-tarball-bytes";
+    let poison_bytes = b"poisoned-cache-bytes";
+    let packument = json!({
+        "name": "poisoned",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "poisoned",
+                "version": "1.0.0",
+                "dist": {
+                    "tarball": format!(
+                        "{}/poisoned/-/poisoned-1.0.0.tgz",
+                        upstream.url()
+                    ),
+                    "integrity": sha512_integrity(good_bytes),
+                },
+            },
+        },
+    });
+    let packument_mock = upstream
+        .mock("GET", "/poisoned")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(packument.to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    let tarball_mock = upstream
+        .mock("GET", "/poisoned/-/poisoned-1.0.0.tgz")
+        .with_status(200)
+        .with_header("content-type", "application/octet-stream")
+        .with_body(poison_bytes)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let cache_dir = storage.join(".pnpr-cache").join("poisoned");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    let cache_path = cache_dir.join("poisoned-1.0.0.tgz");
+    std::fs::write(&cache_path, poison_bytes).unwrap();
+
+    let app = router(config_for(&upstream.url(), storage.clone()));
+    let packument_response =
+        app.clone().oneshot(Request::get("/poisoned").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(packument_response.status(), StatusCode::OK);
+
+    let tarball_response = app
+        .oneshot(Request::get("/poisoned/-/poisoned-1.0.0.tgz").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(tarball_response.status(), StatusCode::BAD_GATEWAY);
+    assert!(!cache_path.exists(), "unverified tarball must not remain cached");
+
+    let cached_response = router(config_for("http://127.0.0.1:1", storage))
+        .oneshot(Request::get("/poisoned/-/poisoned-1.0.0.tgz").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(cached_response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    packument_mock.assert_async().await;
+    tarball_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn tarball_without_integrity_is_rejected_before_fetch() {
+    let mut upstream = mockito::Server::new_async().await;
+    let packument = foo_packument(&upstream.url());
+    let packument_mock = upstream
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(packument.to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    let tarball_mock = upstream
+        .mock("GET", "/foo/-/foo-1.0.0.tgz")
+        .with_status(200)
+        .with_body("unverified")
+        .expect(0)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let response = router(config_for(&upstream.url(), tmp.path().to_path_buf()))
+        .oneshot(Request::get("/foo/-/foo-1.0.0.tgz").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    packument_mock.assert_async().await;
+    tarball_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn invalid_tarball_integrities_are_controlled_failures() {
+    for (case, integrity) in [
+        ("malformed", "not-a-valid-sri"),
+        ("whitespace", " \t\n "),
+        ("zero-hash", ""),
+        ("unsupported", "md5-deadbeef"),
+    ] {
+        let mut upstream = mockito::Server::new_async().await;
+        let packument = json!({
+            "name": "foo",
+            "versions": {
+                "1.0.0": {
+                    "name": "foo",
+                    "version": "1.0.0",
+                    "dist": {
+                        "tarball": format!("{}/foo/-/foo-1.0.0.tgz", upstream.url()),
+                        "integrity": integrity,
+                    },
+                },
+            },
+        });
+        let packument_mock = upstream
+            .mock("GET", "/foo")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(packument.to_string())
+            .expect(1)
+            .create_async()
+            .await;
+        let tarball_mock = upstream
+            .mock("GET", "/foo/-/foo-1.0.0.tgz")
+            .with_status(200)
+            .with_body("must-not-be-fetched")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let tmp = TempDir::new().unwrap();
+        let response = router(config_for(&upstream.url(), tmp.path().to_path_buf()))
+            .oneshot(Request::get("/foo/-/foo-1.0.0.tgz").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY, "case: {case}");
+        packument_mock.assert_async().await;
+        tarball_mock.assert_async().await;
+    }
 }
 
 #[tokio::test]
@@ -470,11 +751,12 @@ async fn upstream_404_is_propagated() {
 }
 
 #[tokio::test]
-async fn tarball_streaming_finalizes_cache_with_no_tmp_leftover() {
+async fn tarball_verification_finalizes_cache_with_no_tmp_leftover() {
     let mut upstream = mockito::Server::new_async().await;
     // Large-ish body so the streaming path is exercised across many
     // chunks rather than fitting in a single hyper buffer.
     let bytes = vec![0xAB_u8; 512 * 1024];
+    let _packument_mock = mock_packument_for_tarball(&mut upstream, "big", "1.0.0", &bytes).await;
     let _mock = upstream
         .mock("GET", "/big/-/big-1.0.0.tgz")
         .with_status(200)
@@ -496,16 +778,10 @@ async fn tarball_streaming_finalizes_cache_with_no_tmp_leftover() {
     assert_eq!(received.len(), bytes.len());
     assert_eq!(received, bytes);
 
-    // By the time the client's stream ends (rx sees None), the tee
-    // task has already called finalize, so the cache file is in
-    // place at the canonical path and no `.tmp.*` siblings remain.
-    // Proxied tarballs land in the disposable cache root.
+    // Verification and finalization complete before the response is
+    // built, leaving only the canonical cache path.
     let package_dir = cache_dir.join(".pnpr-cache").join("big");
-    let entries: Vec<String> = std::fs::read_dir(&package_dir)
-        .unwrap()
-        .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
-        .filter(|name| name.ends_with(".tgz"))
-        .collect();
+    let entries = tarball_cache_entries(&package_dir);
     assert_eq!(entries, vec!["big-1.0.0.tgz".to_string()]);
 
     let cached = std::fs::read(package_dir.join("big-1.0.0.tgz")).unwrap();
@@ -561,6 +837,8 @@ async fn tarball_filename_for_other_package_is_rejected() {
 async fn scoped_tarball_is_proxied() {
     let mut upstream = mockito::Server::new_async().await;
     let bytes = b"scoped-tarball-bytes";
+    let _packument_mock =
+        mock_packument_for_tarball(&mut upstream, "@types/node", "20.0.0", bytes).await;
     let mock = upstream
         .mock("GET", "/@types/node/-/node-20.0.0.tgz")
         .with_status(200)
@@ -585,6 +863,8 @@ async fn scoped_tarball_is_proxied() {
 async fn scoped_tarball_filename_is_canonicalized_before_fetch_and_cache() {
     let mut upstream = mockito::Server::new_async().await;
     let bytes = b"scoped-tarball-full-name";
+    let packument_mock =
+        mock_packument_for_tarball(&mut upstream, "@types/node", "20.0.0", bytes).await;
     let mock = upstream
         .mock("GET", "/@types/node/-/node-20.0.0.tgz")
         .with_status(200)
@@ -615,6 +895,7 @@ async fn scoped_tarball_filename_is_canonicalized_before_fetch_and_cache() {
     assert_eq!(body_bytes(canonical.into_body()).await, bytes);
     assert!(storage.join(".pnpr-cache/@types/node/node-20.0.0.tgz").exists());
     assert!(!storage.join(".pnpr-cache/@types/node/@types").exists());
+    packument_mock.assert_async().await;
     mock.assert_async().await;
 }
 
@@ -813,20 +1094,22 @@ async fn invalid_package_name_returns_bad_request() {
 async fn concurrent_tarball_fetches_settle_to_one_cache_file() {
     let mut upstream = mockito::Server::new_async().await;
     let bytes = vec![0xCD; 128 * 1024];
+    let _packument_mock = mock_packument_for_tarball(&mut upstream, "foo", "1.0.0", &bytes).await;
     let mock = upstream
         .mock("GET", "/foo/-/foo-1.0.0.tgz")
         .with_status(200)
         .with_body(&bytes)
-        // We deliberately don't single-flight, so the upstream is hit
-        // at least twice. Bound only the lower side; the exact count
-        // depends on scheduling.
-        .expect_at_least(2)
+        .expect_at_least(1)
         .create_async()
         .await;
 
     let tmp = TempDir::new().unwrap();
     let cache_dir = tmp.path().to_path_buf();
     let app = router(config_for(&upstream.url(), cache_dir.clone()));
+
+    let packument =
+        app.clone().oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(packument.status(), StatusCode::OK);
 
     let req1 =
         app.clone().oneshot(Request::get("/foo/-/foo-1.0.0.tgz").body(Body::empty()).unwrap());
@@ -839,26 +1122,20 @@ async fn concurrent_tarball_fetches_settle_to_one_cache_file() {
     assert_eq!(body_bytes(r1.into_body()).await, bytes);
     assert_eq!(body_bytes(r2.into_body()).await, bytes);
 
-    // After both responses drain, both tee tasks have called
-    // `finalize` (rename is last-writer-wins on POSIX, and both
-    // wrote identical content). Exactly one `.tgz` file in the
-    // package dir, no `.tmp.*` survivors thanks to the unique-tmp
-    // suffix. Proxied tarballs live in the disposable cache root.
+    // Any overlapping verified writes atomically target the same final
+    // path, so one tarball remains with no temporary siblings.
     let dir = cache_dir.join(".pnpr-cache").join("foo");
-    let entries: Vec<String> = std::fs::read_dir(&dir)
-        .unwrap()
-        .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
-        .filter(|name| name.ends_with(".tgz"))
-        .collect();
+    let entries = tarball_cache_entries(&dir);
     assert_eq!(entries, vec!["foo-1.0.0.tgz".to_string()]);
 
     mock.assert_async().await;
 }
 
 #[tokio::test]
-async fn cache_tmp_open_failure_falls_back_to_uncached_stream() {
+async fn cache_tmp_open_failure_fails_closed() {
     let mut upstream = mockito::Server::new_async().await;
     let bytes = b"served-without-cache";
+    let _packument_mock = mock_packument_for_tarball(&mut upstream, "foo", "1.0.0", bytes).await;
     let _mock = upstream
         .mock("GET", "/foo/-/foo-1.0.0.tgz")
         .with_status(200)
@@ -867,8 +1144,8 @@ async fn cache_tmp_open_failure_falls_back_to_uncached_stream() {
         .await;
 
     // Point `cache_dir` at a regular file so `create_dir_all` inside
-    // `open_cached_tarball_tmp` fails. The handler should still stream
-    // the body to the client and skip the cache write.
+    // `open_cached_tarball_tmp` fails. Without a place to verify the
+    // complete body, the handler must fail rather than stream it.
     let tmp = TempDir::new().unwrap();
     let blocked = tmp.path().join("not-a-dir");
     std::fs::write(&blocked, b"already a file").unwrap();
@@ -879,12 +1156,37 @@ async fn cache_tmp_open_failure_falls_back_to_uncached_stream() {
         .oneshot(Request::get("/foo/-/foo-1.0.0.tgz").body(Body::empty()).unwrap())
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(body_bytes(response.into_body()).await, bytes);
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
 
     // The cache path under the not-a-dir should not exist.
     let cache_path = blocked.join(".pnpr-cache").join("foo").join("foo-1.0.0.tgz");
     assert!(!cache_path.exists());
+}
+
+#[tokio::test]
+async fn hosted_tarball_open_failure_fails_closed() {
+    let mut upstream = mockito::Server::new_async().await;
+    // A hosted-store fault must fail closed before any upstream lookup,
+    // so neither the packument nor the tarball may be fetched.
+    let packument_mock = upstream.mock("GET", "/foo").expect(0).create_async().await;
+    let tarball_mock = upstream.mock("GET", "/foo/-/foo-1.0.0.tgz").expect(0).create_async().await;
+
+    // Place a regular file where the hosted package directory belongs so
+    // opening the hosted tarball fails with a real I/O error (not a plain
+    // miss). The authoritative hosted store must fail closed instead of
+    // falling through to the upstream proxy.
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    std::fs::create_dir_all(&storage).unwrap();
+    std::fs::write(storage.join("foo"), b"not a directory").unwrap();
+
+    let response = router(config_for(&upstream.url(), storage))
+        .oneshot(Request::get("/foo/-/foo-1.0.0.tgz").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    packument_mock.assert_async().await;
+    tarball_mock.assert_async().await;
 }
 
 #[tokio::test]
@@ -905,30 +1207,60 @@ async fn malformed_upstream_json_maps_to_bad_gateway() {
     assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
 }
 
-/// Spawn a TCP listener that speaks just enough HTTP/1.1 to answer a
-/// single GET with valid headers and a *truncated* body, then drops
-/// the connection. Mockito can't simulate mid-body disconnects, so a
-/// hand-rolled server is the cheapest way to exercise the `upstream
-/// stream errored mid-body` branch in `run_tee`.
-async fn spawn_truncated_upstream() -> SocketAddr {
+/// Spawn a TCP listener that serves a valid packument but truncates the
+/// matching tarball body. Mockito cannot simulate a mid-body disconnect.
+async fn spawn_truncated_upstream(expected_integrity: String) -> SocketAddr {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
+    let packument = json!({
+        "name": "foo",
+        "versions": {
+            "1.0.0": {
+                "name": "foo",
+                "version": "1.0.0",
+                "dist": {
+                    "tarball": format!("http://{addr}/foo/-/foo-1.0.0.tgz"),
+                    "integrity": expected_integrity,
+                },
+            },
+        },
+    })
+    .to_string();
     tokio::spawn(async move {
         while let Ok((mut socket, _)) = listener.accept().await {
+            let packument = packument.clone();
             tokio::spawn(async move {
                 let mut buf = vec![0u8; 4096];
-                let _ = socket.read(&mut buf).await;
-                let _ = socket
-                    .write_all(
-                        b"HTTP/1.1 200 OK\r\n\
+                let bytes_read = socket.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..bytes_read]);
+                if request.starts_with("GET /foo HTTP/") {
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\n\
+                         Content-Length: {}\r\n\
+                         Content-Type: application/json\r\n\
+                         Connection: close\r\n\
+                         \r\n\
+                         {packument}",
+                        packument.len(),
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    return;
+                }
+                if request.starts_with("GET /foo/-/foo-1.0.0.tgz HTTP/") {
+                    let _ = socket
+                        .write_all(
+                            b"HTTP/1.1 200 OK\r\n\
                           Content-Length: 1048576\r\n\
                           Content-Type: application/octet-stream\r\n\
                           Connection: close\r\n\
                           \r\n",
-                    )
-                    .await;
-                let _ = socket.write_all(&[0xAA; 100]).await;
-                // Drop socket without sending the remaining 1048476 bytes.
+                        )
+                        .await;
+                    let _ = socket.write_all(&[0xAA; 100]).await;
+                    return;
+                }
+                let _ =
+                    socket.write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n").await;
             });
         }
     });
@@ -937,7 +1269,8 @@ async fn spawn_truncated_upstream() -> SocketAddr {
 
 #[tokio::test]
 async fn upstream_stream_error_clears_cache() {
-    let addr = spawn_truncated_upstream().await;
+    let expected_bytes = vec![0xAA; 1024 * 1024];
+    let addr = spawn_truncated_upstream(sha512_integrity(&expected_bytes)).await;
     let upstream_url = format!("http://{addr}");
     let tmp = TempDir::new().unwrap();
     let cache_dir = tmp.path().to_path_buf();
@@ -947,28 +1280,18 @@ async fn upstream_stream_error_clears_cache() {
         .oneshot(Request::get("/foo/-/foo-1.0.0.tgz").body(Body::empty()).unwrap())
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
 
-    // Body read should fail — upstream advertised 1 MiB and closed
-    // the socket after 100 bytes.
-    let result = to_bytes(response.into_body(), usize::MAX).await;
-    assert!(result.is_err(), "expected body to error mid-stream");
-
-    // The tee task observes the upstream error and calls
-    // `write.abandon()`. We don't know when that finishes, but it
-    // should happen quickly — poll for it so the test fails fast on
-    // success and gives a 1s budget for the worst case (heavy CI
-    // load).
+    // The incomplete body is rejected before a response or cache entry
+    // can expose its bytes.
     assert!(await_no_tgz(&cache_dir.join(".pnpr-cache").join("foo"), Duration::from_secs(1)).await);
 }
 
 #[tokio::test]
-async fn client_disconnect_mid_stream_clears_cache() {
+async fn verified_tarball_is_cached_before_response_is_served() {
     let mut upstream = mockito::Server::new_async().await;
-    // 8 MiB is comfortably larger than the tee channel can buffer
-    // (16 chunks × ~64 KiB ≈ 1 MiB), so the tee task is guaranteed
-    // to be parked on `tx.send` when we drop the response below.
-    let bytes = vec![0xEE_u8; 8 * 1024 * 1024];
+    let bytes = vec![0xEE_u8; 512 * 1024];
+    let _packument_mock = mock_packument_for_tarball(&mut upstream, "big", "1.0.0", &bytes).await;
     let _mock = upstream
         .mock("GET", "/big/-/big-1.0.0.tgz")
         .with_status(200)
@@ -986,29 +1309,35 @@ async fn client_disconnect_mid_stream_clears_cache() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    // Drop the response without reading the body. The mpsc receiver
-    // goes away, the tee task's next `tx.send` returns Err, and
-    // `write.abandon()` runs. Poll for the abandon so the test
-    // doesn't depend on a fixed sleep budget under heavy CI load.
+    // The response is not constructed until the complete upstream body
+    // has passed verification and cache finalization.
     drop(response);
-    assert!(await_no_tgz(&cache_dir.join(".pnpr-cache").join("big"), Duration::from_secs(1)).await);
+    let cache_path = cache_dir.join(".pnpr-cache").join("big").join("big-1.0.0.tgz");
+    assert_eq!(std::fs::read(cache_path).unwrap(), bytes);
 }
 
-/// Poll `dir` until it contains no `.tgz` files *and* no `.tmp.*`
-/// orphans (or doesn't exist), up to `budget`. Returns `true` on
-/// success, `false` on timeout — gives the calling test a single
-/// deterministic signal that the tee task observed the abandon
-/// condition and `write.abandon()` actually unlinked the temp file.
+fn is_tarball_tmp(name: &str) -> bool {
+    name.split_once(".tgz.tmp.").is_some_and(|(_, suffix)| !suffix.is_empty())
+}
+
+fn tarball_cache_entries(dir: &std::path::Path) -> Vec<String> {
+    let mut entries = dir
+        .read_dir()
+        .map(|iter| {
+            iter.filter_map(Result::ok)
+                .map(|entry| entry.file_name().to_string_lossy().into_owned())
+                .filter(|name| name.ends_with(".tgz") || is_tarball_tmp(name))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    entries.sort();
+    entries
+}
+
 async fn await_no_tgz(dir: &std::path::Path, budget: Duration) -> bool {
     let deadline = std::time::Instant::now() + budget;
     loop {
-        let still_present = dir.read_dir().is_ok_and(|iter| {
-            iter.filter_map(Result::ok).any(|entry| {
-                let name = entry.file_name().to_string_lossy().into_owned();
-                name.ends_with(".tgz") || name.contains(".tmp.")
-            })
-        });
-        if !still_present {
+        if tarball_cache_entries(dir).is_empty() {
             return true;
         }
         if std::time::Instant::now() >= deadline {
@@ -1120,6 +1449,7 @@ async fn packument_is_not_gzipped_without_accept_encoding() {
 async fn tarball_is_not_gzipped_even_when_accepted() {
     let mut upstream = mockito::Server::new_async().await;
     let bytes = b"fake-tarball-bytes-long-enough-to-clear-the-compression-size-floor";
+    let _packument_mock = mock_packument_for_tarball(&mut upstream, "foo", "1.0.0", bytes).await;
     let mock = upstream
         .mock("GET", "/foo/-/foo-1.0.0.tgz")
         .with_status(200)
@@ -1195,6 +1525,7 @@ async fn per_uplink_maxage_overrides_global_packument_ttl() {
 async fn cache_false_uplink_streams_tarball_without_mirroring() {
     let mut upstream = mockito::Server::new_async().await;
     let bytes = b"uncached-tarball-bytes";
+    let packument_mock = mock_packument_for_tarball(&mut upstream, "foo", "1.0.0", bytes).await;
     let mock = upstream
         .mock("GET", "/foo/-/foo-1.0.0.tgz")
         .with_status(200)
@@ -1220,17 +1551,51 @@ async fn cache_false_uplink_streams_tarball_without_mirroring() {
     }
 
     // Nothing was mirrored: the package dir either doesn't exist or holds
-    // no `.tgz`. Both requests therefore went to the upstream.
+    // no tarball or temp tarball. Both requests therefore went to the upstream.
     let package_dir = cache_dir.join(".pnpr-cache").join("foo");
-    let cached_tarballs = std::fs::read_dir(&package_dir).map_or(0, |entries| {
-        entries
-            .filter_map(Result::ok)
-            .filter(|entry| entry.file_name().to_string_lossy().ends_with(".tgz"))
-            .count()
-    });
-    assert_eq!(cached_tarballs, 0, "a cache:false uplink must not write tarballs to the mirror");
+    assert!(
+        tarball_cache_entries(&package_dir).is_empty(),
+        "a cache:false uplink must not write tarballs to the mirror",
+    );
 
+    packument_mock.assert_async().await;
     mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn cache_false_uplink_rejects_tampered_tarball_without_mirroring() {
+    let mut upstream = mockito::Server::new_async().await;
+    let good_bytes = b"good-uncached-tarball";
+    let poison_bytes = b"poisoned-uncached-tarball";
+    let packument_mock =
+        mock_packument_for_tarball(&mut upstream, "foo", "1.0.0", good_bytes).await;
+    let tarball_mock = upstream
+        .mock("GET", "/foo/-/foo-1.0.0.tgz")
+        .with_status(200)
+        .with_body(poison_bytes)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let cache_dir = tmp.path().to_path_buf();
+    let mut config = config_for(&upstream.url(), cache_dir.clone());
+    config.uplinks.get_mut("npmjs").expect("default `npmjs` uplink").cache = false;
+    let app = router(config);
+
+    let response = app
+        .oneshot(Request::get("/foo/-/foo-1.0.0.tgz").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    let package_dir = cache_dir.join(".pnpr-cache").join("foo");
+    assert!(
+        tarball_cache_entries(&package_dir).is_empty(),
+        "a rejected cache:false tarball must leave no mirror entry",
+    );
+
+    packument_mock.assert_async().await;
+    tarball_mock.assert_async().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Verifies proxied pnpr tarballs against the selected version `dist.integrity` before serving or caching them.
- Stores a verified cache marker with canonical SRI and length so cache hits skip repeat hashing unless the marker is missing, malformed, or mismatched.
- Enforces a 100 MiB spool limit for verified tarball downloads, including `cache: false` uplinks.
- Creates tarball and cache-marker temp files with exclusive, retrying, randomized temp paths so pre-existing files or symlinks are not clobbered.
- Rejects missing, malformed, empty, or unsupported tarball integrity metadata before fetching bytes.
- No TypeScript CLI or `pacquet/` port is needed; this change is scoped to the pnpr registry server.

Addresses https://github.com/pnpm/pnpm/security/advisories/GHSA-5f9g-98vq-2jxw.

## Squash Commit Body

```text
Bind proxied tarball requests to the selected packument version.

Require supported dist.integrity before serving upstream or cached tarballs.

Verify cache hits without repeated hashing when their cache marker matches the expected SRI and byte length. Missing, malformed, or mismatched markers still force full verification and marker refresh.

Delete invalid cache entries and promote upstream bytes only after SRI verification.

For cache:false uplinks, verify into a temp file and remove it after streaming.

Bound verified tarball spooling to 100 MiB using both Content-Length and a running byte counter.

Create tarball and cache-marker temp files with exclusive, retrying, randomized paths so pre-existing files or symlinks are not clobbered.

Harden publish attachment SRI parsing for missing or unsupported integrity.

Addresses GHSA-5f9g-98vq-2jxw.
```

## Checklist

- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enforced strict SRI integrity verification for proxied tarballs using each version’s declared `dist.integrity`. Missing, malformed, or unsupported values now fail with gateway-style errors and prevent serving/caching corrupted content. Absent versions return `404`.
* **Improvements**
  * Hardened tarball cache behavior with integrity-aware replay, discard-on-mismatch, and cleanup of temporary/sidecar artifacts.
* **Tests**
  * Added coverage for integrity parsing, publish rejection cases, oversized/cancelled downloads, and cache/temp cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->