### PR TITLE
feat(cli): port approve-builds, ignored-builds, and rebuild to pacquet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,6 +3596,7 @@ dependencies = [
  "pacquet-graph-hasher",
  "pacquet-hooks",
  "pacquet-lockfile",
+ "pacquet-modules-yaml",
  "pacquet-network",
  "pacquet-package-is-installable",
  "pacquet-package-manager",

--- a/pacquet/crates/cli/Cargo.toml
+++ b/pacquet/crates/cli/Cargo.toml
@@ -25,6 +25,7 @@ pacquet-fs                                = { workspace = true }
 pacquet-graph-hasher                      = { workspace = true }
 pacquet-hooks                             = { workspace = true }
 pacquet-lockfile                          = { workspace = true }
+pacquet-modules-yaml                      = { workspace = true }
 pacquet-network                           = { workspace = true }
 pacquet-config                            = { workspace = true }
 pacquet-default-reporter                  = { workspace = true }

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -276,7 +276,11 @@ impl CliArgs {
                 | CliCommand::Install(_)
                 | CliCommand::Dlx(_)
                 | CliCommand::Create(_)
-                | CliCommand::Runtime(_),
+                | CliCommand::Runtime(_)
+                // `rebuild` drives the frozen-install pipeline and emits
+                // the same progress events, so it shares the `Done in ...`
+                // footer.
+                | CliCommand::Rebuild(_),
         );
         let manifest_path = || dir.join("package.json");
         // Resolve `.npmrc` / `pnpm-workspace.yaml` from the canonicalized

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -1,4 +1,5 @@
 pub mod add;
+pub mod approve_builds;
 pub mod cache;
 pub mod cat_file;
 pub mod cat_index;
@@ -6,8 +7,10 @@ pub mod create;
 pub mod dlx;
 pub mod exec;
 pub mod find_hash;
+pub mod ignored_builds;
 pub mod install;
 pub mod outdated;
+pub mod rebuild;
 pub mod recursive;
 pub mod remove;
 pub mod restart;
@@ -23,6 +26,7 @@ pub mod why;
 
 use crate::{State, config_deps, config_overrides::ConfigOverrides};
 use add::AddArgs;
+use approve_builds::ApproveBuildsArgs;
 use cache::CacheCommand;
 use cat_file::CatFileArgs;
 use cat_index::CatIndexArgs;
@@ -31,6 +35,7 @@ use create::CreateArgs;
 use dlx::DlxArgs;
 use exec::ExecArgs;
 use find_hash::FindHashArgs;
+use ignored_builds::IgnoredBuildsArgs;
 use install::InstallArgs;
 use miette::{Context, IntoDiagnostic};
 use outdated::{OutdatedArgs, OutdatedOutcome};
@@ -41,6 +46,7 @@ use pacquet_package_manifest::PackageManifest;
 use pacquet_reporter::{
     ExecutionTimeLog, LogEvent, LogLevel, NdjsonReporter, Reporter, SilentReporter,
 };
+use rebuild::RebuildArgs;
 use remove::RemoveArgs;
 use restart::RestartArgs;
 use run::RunArgs;
@@ -145,6 +151,9 @@ pub enum CliCommand {
     Outdated(OutdatedArgs),
     /// Shows the packages that depend on `pkg`
     Why(WhyArgs),
+    /// Rebuild a package.
+    #[clap(visible_alias = "rb")]
+    Rebuild(RebuildArgs),
     /// Removes packages from `node_modules` and from the project's `package.json`.
     // Unlike npm, pnpm does not treat "r" as an alias of "remove" to avoid
     // confusion with "run" and "recursive". Mirrors pnpm's `commandNames`.
@@ -182,6 +191,10 @@ pub enum CliCommand {
     CatFile(CatFileArgs),
     /// Prints the index file of a specific package from the store.
     CatIndex(CatIndexArgs),
+    /// Print the list of packages with blocked build scripts.
+    IgnoredBuilds(IgnoredBuildsArgs),
+    /// Approve dependencies for running scripts during installation.
+    ApproveBuilds(ApproveBuildsArgs),
 }
 
 impl CliArgs {
@@ -503,6 +516,50 @@ impl CliArgs {
             }
             CliCommand::CatIndex(args) => {
                 args.run(&dir, || config().map(|m| &*m)).await?;
+            }
+            CliCommand::IgnoredBuilds(_) => {
+                let output = ignored_builds::render_ignored_builds(config()?)?;
+                print!("{output}");
+            }
+            CliCommand::Rebuild(args) => match reporter {
+                ReporterType::Default | ReporterType::AppendOnly => {
+                    Box::pin(args.run::<DefaultReporter>(state(true)?)).await?;
+                }
+                ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(state(true)?)).await?,
+                ReporterType::Silent => Box::pin(args.run::<SilentReporter>(state(true)?)).await?,
+            },
+            CliCommand::ApproveBuilds(args) => {
+                // The settings/prompt work is synchronous; only the rebuild
+                // is async, so the non-`Send` `config` / `state` closures
+                // stay out of the awaited future.
+                if let Some((rebuild_state, build_packages)) =
+                    args.prepare(&dir, &config, &state)?
+                {
+                    let selected = Some(build_packages);
+                    match reporter {
+                        ReporterType::Default | ReporterType::AppendOnly => {
+                            Box::pin(rebuild::run_rebuild::<DefaultReporter>(
+                                &rebuild_state,
+                                selected,
+                            ))
+                            .await?;
+                        }
+                        ReporterType::Ndjson => {
+                            Box::pin(rebuild::run_rebuild::<NdjsonReporter>(
+                                &rebuild_state,
+                                selected,
+                            ))
+                            .await?;
+                        }
+                        ReporterType::Silent => {
+                            Box::pin(rebuild::run_rebuild::<SilentReporter>(
+                                &rebuild_state,
+                                selected,
+                            ))
+                            .await?;
+                        }
+                    }
+                }
             }
         }
 

--- a/pacquet/crates/cli/src/cli_args/approve_builds.rs
+++ b/pacquet/crates/cli/src/cli_args/approve_builds.rs
@@ -1,0 +1,272 @@
+use clap::Args;
+use derive_more::{Display, Error};
+use dialoguer::{Confirm, MultiSelect};
+use miette::{Diagnostic, IntoDiagnostic};
+use pacquet_config::Config;
+use pacquet_modules_yaml::{Host, write_modules_manifest};
+use pacquet_package_manager::allow_build_key_from_ignored_build;
+use pacquet_workspace_manifest_writer::set_allow_builds;
+use std::{
+    collections::{BTreeMap, HashSet},
+    path::Path,
+};
+
+use crate::State;
+use crate::cli_args::ignored_builds::get_automatically_ignored_builds;
+
+/// `pacquet approve-builds` — approve dependencies for running scripts
+/// during installation. Ports pnpm's
+/// [`approve-builds`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/commands/src/policy/approveBuilds.ts).
+#[derive(Debug, Args)]
+pub struct ApproveBuildsArgs {
+    /// Packages to approve (`<pkg>`) or deny (`!<pkg>`). With no packages,
+    /// the packages awaiting approval are chosen interactively.
+    pub packages: Vec<String>,
+
+    /// Approve all pending dependencies without interactive prompts.
+    #[clap(long)]
+    pub all: bool,
+
+    /// Reserved for parity with pnpm; `approve-builds` is not supported
+    /// with global packages.
+    #[clap(long)]
+    pub global: bool,
+}
+
+/// Errors specific to `approve-builds`. Codes match pnpm's
+/// `ERR_PNPM_APPROVE_BUILDS_*` set.
+#[derive(Debug, Display, Error, Diagnostic)]
+enum ApproveBuildsError {
+    #[display(r#""approve-builds" is not supported with global packages"#)]
+    #[diagnostic(
+        code(ERR_PNPM_APPROVE_BUILDS_NOT_SUPPORTED_WITH_GLOBAL),
+        help(
+            "Use --allow-build when installing globally, e.g. \"pnpm add -g --allow-build=<pkg> <pkg>\". pnpm will also prompt to allow builds interactively during global install."
+        )
+    )]
+    NotSupportedWithGlobal,
+
+    #[display("Cannot use --all with positional arguments")]
+    #[diagnostic(code(ERR_PNPM_APPROVE_BUILDS_ALL_WITH_ARGS))]
+    AllWithArgs,
+
+    #[display("The following packages are not awaiting approval: {}", _0.join(", "))]
+    #[diagnostic(code(ERR_PNPM_APPROVE_BUILDS_UNKNOWN_PACKAGES))]
+    UnknownPackages(#[error(not(source))] Vec<String>),
+
+    #[display("The following packages are both approved and denied: {}", _0.join(", "))]
+    #[diagnostic(code(ERR_PNPM_APPROVE_BUILDS_CONTRADICTING_ARGS))]
+    ContradictingArgs(#[error(not(source))] Vec<String>),
+}
+
+impl ApproveBuildsArgs {
+    /// Validate, prompt, write `allowBuilds`, and clear the decided ignored
+    /// builds. Returns the rebuild inputs (`Some`) when packages were
+    /// approved to build, or `None` when there is nothing to rebuild; the
+    /// caller then drives `run_rebuild` with a reporter.
+    ///
+    /// This stays synchronous so the non-`Send` `config` / `state` closure
+    /// references never cross the rebuild's `await`. `config` loads a fresh
+    /// `&Config`; it is called before writing settings (to read the current
+    /// state) and `state` after, so the rebuild's allow-build policy
+    /// reflects the just-written `allowBuilds`. `dir` is the canonicalized
+    /// `--dir`, the fallback settings target when no `pnpm-workspace.yaml`
+    /// is found.
+    pub fn prepare(
+        self,
+        dir: &Path,
+        config: &dyn Fn() -> miette::Result<&'static mut Config>,
+        state: &dyn Fn(bool) -> miette::Result<State>,
+    ) -> miette::Result<Option<(State, Vec<String>)>> {
+        let ApproveBuildsArgs { packages, all, global } = self;
+
+        if global {
+            return Err(ApproveBuildsError::NotSupportedWithGlobal.into());
+        }
+        if all && !packages.is_empty() {
+            return Err(ApproveBuildsError::AllWithArgs.into());
+        }
+
+        let initial_config: &Config = config()?;
+        let scan = get_automatically_ignored_builds(initial_config)?;
+        let Some(pending) = scan.names.filter(|names| !names.is_empty()) else {
+            println!("There are no packages awaiting approval");
+            return Ok(None);
+        };
+
+        let (approved, denied) = partition_params(&packages, &pending)?;
+
+        // The packages to build: explicit approvals, every pending package
+        // under `--all`, or the interactive selection otherwise.
+        let build_packages: Vec<String> = if !packages.is_empty() {
+            sort_unique(approved.clone())
+        } else if all {
+            sort_unique(pending.clone())
+        } else {
+            let Some(selected) = prompt_for_builds(&pending)? else {
+                // The prompt was interrupted (Esc / Ctrl-C); leave
+                // everything untouched, matching pnpm's `ExitPromptError`
+                // early exit.
+                return Ok(None);
+            };
+            selected
+        };
+
+        // The `allowBuilds` entries to write: each decided package mapped to
+        // `true` (build) or `false` (skip). In interactive / `--all` mode
+        // every pending package is decided, so unselected ones are recorded
+        // as `false`.
+        let mut decisions: BTreeMap<String, bool> = BTreeMap::new();
+        if packages.is_empty() {
+            for pkg in &pending {
+                decisions.insert(pkg.clone(), build_packages.contains(pkg));
+            }
+        } else {
+            for pkg in &approved {
+                decisions.insert(pkg.clone(), true);
+            }
+            for pkg in &denied {
+                decisions.insert(pkg.clone(), false);
+            }
+        }
+
+        if !all && packages.is_empty() {
+            if build_packages.is_empty() {
+                println!("All packages were added to allowBuilds with value false.");
+            } else if !confirm_builds(&build_packages)? {
+                return Ok(None);
+            }
+        }
+
+        let settings_dir =
+            initial_config.workspace_dir.clone().unwrap_or_else(|| dir.to_path_buf());
+        set_allow_builds(
+            &settings_dir,
+            decisions.iter().map(|(pkg, &value)| (pkg.as_str(), value)),
+        )
+        .into_diagnostic()?;
+
+        clear_decided_ignored_builds(
+            scan.modules_manifest,
+            &scan.modules_dir,
+            &packages,
+            &approved,
+            &denied,
+        )?;
+
+        if build_packages.is_empty() {
+            return Ok(None);
+        }
+        // Build state from a freshly loaded config so the rebuild's
+        // allow-build policy reflects the `allowBuilds` just written.
+        Ok(Some((state(true)?, build_packages)))
+    }
+}
+
+/// Split `params` into approved (`<pkg>`) and denied (`!<pkg>`) names,
+/// validating each is awaiting approval and that none is both.
+fn partition_params(
+    params: &[String],
+    automatically_ignored_builds: &[String],
+) -> Result<(Vec<String>, Vec<String>), ApproveBuildsError> {
+    let mut approved = Vec::new();
+    let mut denied = Vec::new();
+    let mut unknown = Vec::new();
+    for param in params {
+        let name = param.strip_prefix('!').unwrap_or(param);
+        if !automatically_ignored_builds.iter().any(|build| build == name) {
+            unknown.push(name.to_string());
+        } else if param.starts_with('!') {
+            denied.push(name.to_string());
+        } else {
+            approved.push(name.to_string());
+        }
+    }
+    if !unknown.is_empty() {
+        return Err(ApproveBuildsError::UnknownPackages(unknown));
+    }
+    let contradictions: Vec<String> =
+        approved.iter().filter(|pkg| denied.contains(pkg)).cloned().collect();
+    if !contradictions.is_empty() {
+        return Err(ApproveBuildsError::ContradictingArgs(contradictions));
+    }
+    Ok((approved, denied))
+}
+
+/// Show the checkbox prompt and return the chosen package names, or `None`
+/// when the prompt is interrupted.
+fn prompt_for_builds(
+    automatically_ignored_builds: &[String],
+) -> miette::Result<Option<Vec<String>>> {
+    let choices = sort_unique(automatically_ignored_builds.to_vec());
+    match MultiSelect::new()
+        .with_prompt("Choose which packages to build (<space> to select, <enter> to confirm)")
+        .items(&choices)
+        .interact_opt()
+        .into_diagnostic()?
+    {
+        Some(indices) => {
+            Ok(Some(indices.into_iter().map(|index| choices[index].clone()).collect()))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Ask the user to confirm building `build_packages`. Defaults to "no",
+/// matching pnpm's `confirm({ default: false })`.
+fn confirm_builds(build_packages: &[String]) -> miette::Result<bool> {
+    Confirm::new()
+        .with_prompt(format!(
+            "The next packages will now be built: {}.\nDo you approve?",
+            build_packages.join(", "),
+        ))
+        .default(false)
+        .interact()
+        .into_diagnostic()
+}
+
+/// Drop the now-decided entries from `.modules.yaml`'s `ignoredBuilds` so a
+/// later `ignored-builds` / install no longer reports them. With positional
+/// arguments only the decided (approved + denied) packages are removed,
+/// preserving the still-pending ones; otherwise every entry is cleared.
+/// Mirrors pnpm's `writeModulesManifest` block in `approveBuilds`.
+fn clear_decided_ignored_builds(
+    modules_manifest: Option<pacquet_modules_yaml::Modules>,
+    modules_dir: &Path,
+    params: &[String],
+    approved: &[String],
+    denied: &[String],
+) -> miette::Result<()> {
+    let Some(mut modules) = modules_manifest else {
+        return Ok(());
+    };
+    if modules.ignored_builds.is_none() {
+        return Ok(());
+    }
+    if params.is_empty() {
+        modules.ignored_builds = None;
+    } else {
+        let decided: HashSet<&str> =
+            approved.iter().chain(denied.iter()).map(String::as_str).collect();
+        if let Some(ignored) = modules.ignored_builds.as_mut() {
+            ignored.retain(|dep_path| {
+                !decided.contains(allow_build_key_from_ignored_build(dep_path.as_str()).as_str())
+            });
+        }
+        if let Some(ignored) = &modules.ignored_builds
+            && ignored.is_empty()
+        {
+            modules.ignored_builds = None;
+        }
+    }
+    write_modules_manifest::<Host>(modules_dir, modules).into_diagnostic()?;
+    Ok(())
+}
+
+/// Deduplicate and sort `names` by code unit, matching pnpm's
+/// `sortUniqueStrings` (a `Set` then `lexCompare`).
+fn sort_unique(names: Vec<String>) -> Vec<String> {
+    let mut unique: Vec<String> = names.into_iter().collect::<HashSet<_>>().into_iter().collect();
+    unique.sort();
+    unique
+}

--- a/pacquet/crates/cli/src/cli_args/approve_builds.rs
+++ b/pacquet/crates/cli/src/cli_args/approve_builds.rs
@@ -11,8 +11,7 @@ use std::{
     path::Path,
 };
 
-use crate::State;
-use crate::cli_args::ignored_builds::get_automatically_ignored_builds;
+use crate::{State, cli_args::ignored_builds::get_automatically_ignored_builds};
 
 /// `pacquet approve-builds` — approve dependencies for running scripts
 /// during installation. Ports pnpm's
@@ -41,7 +40,7 @@ enum ApproveBuildsError {
     #[diagnostic(
         code(ERR_PNPM_APPROVE_BUILDS_NOT_SUPPORTED_WITH_GLOBAL),
         help(
-            "Use --allow-build when installing globally, e.g. \"pnpm add -g --allow-build=<pkg> <pkg>\". pnpm will also prompt to allow builds interactively during global install."
+            r#"Use --allow-build when installing globally, e.g. "pnpm add -g --allow-build=<pkg> <pkg>". pnpm will also prompt to allow builds interactively during global install."#
         )
     )]
     NotSupportedWithGlobal,

--- a/pacquet/crates/cli/src/cli_args/approve_builds.rs
+++ b/pacquet/crates/cli/src/cli_args/approve_builds.rs
@@ -269,3 +269,6 @@ fn sort_unique(names: Vec<String>) -> Vec<String> {
     unique.sort();
     unique
 }
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/approve_builds/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/approve_builds/tests.rs
@@ -1,0 +1,52 @@
+use super::{ApproveBuildsError, partition_params, sort_unique};
+
+fn pending(names: &[&str]) -> Vec<String> {
+    names.iter().map(|name| (*name).to_string()).collect()
+}
+
+fn params(args: &[&str]) -> Vec<String> {
+    args.iter().map(|arg| (*arg).to_string()).collect()
+}
+
+#[test]
+fn splits_approved_and_denied() {
+    let (approved, denied) =
+        partition_params(&params(&["foo", "!bar"]), &pending(&["foo", "bar"])).unwrap();
+    assert_eq!(approved, vec!["foo".to_string()]);
+    assert_eq!(denied, vec!["bar".to_string()]);
+}
+
+// Ports pnpm's `positional arguments with unknown package throws error`.
+#[test]
+fn rejects_unknown_approved_package() {
+    let err = partition_params(&params(&["nope"]), &pending(&["foo"])).unwrap_err();
+    let ApproveBuildsError::UnknownPackages(names) = err else {
+        panic!("expected UnknownPackages, got {err:?}");
+    };
+    assert_eq!(names, vec!["nope".to_string()]);
+}
+
+// Ports pnpm's `!pkg with unknown package throws error`.
+#[test]
+fn rejects_unknown_denied_package() {
+    let err = partition_params(&params(&["!nope"]), &pending(&["foo"])).unwrap_err();
+    let ApproveBuildsError::UnknownPackages(names) = err else {
+        panic!("expected UnknownPackages, got {err:?}");
+    };
+    assert_eq!(names, vec!["nope".to_string()]);
+}
+
+// Ports pnpm's `contradictory arguments throw error`.
+#[test]
+fn rejects_contradictory_arguments() {
+    let err = partition_params(&params(&["foo", "!foo"]), &pending(&["foo"])).unwrap_err();
+    let ApproveBuildsError::ContradictingArgs(names) = err else {
+        panic!("expected ContradictingArgs, got {err:?}");
+    };
+    assert_eq!(names, vec!["foo".to_string()]);
+}
+
+#[test]
+fn sort_unique_dedupes_and_sorts() {
+    assert_eq!(sort_unique(params(&["b", "a", "b"])), vec!["a".to_string(), "b".to_string()]);
+}

--- a/pacquet/crates/cli/src/cli_args/ignored_builds.rs
+++ b/pacquet/crates/cli/src/cli_args/ignored_builds.rs
@@ -1,0 +1,89 @@
+use clap::Args;
+use indexmap::IndexSet;
+use miette::IntoDiagnostic;
+use pacquet_config::Config;
+use pacquet_modules_yaml::{Host, Modules, read_modules_manifest};
+use pacquet_package_manager::allow_build_key_from_ignored_build;
+use std::path::PathBuf;
+
+/// `pacquet ignored-builds` — print the list of packages with blocked
+/// build scripts. Ports pnpm's
+/// [`ignored-builds`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/commands/src/policy/ignoredBuilds.ts).
+#[derive(Debug, Args)]
+pub struct IgnoredBuildsArgs {}
+
+/// The automatically-ignored builds recorded in `.modules.yaml`, paired
+/// with the manifest they came from. Mirrors pnpm's
+/// `getAutomaticallyIgnoredBuilds` return at
+/// <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/commands/src/policy/getAutomaticallyIgnoredBuilds.ts#L8-L12>.
+pub(crate) struct IgnoredBuildsScan {
+    /// The `allowBuilds` keys of the packages whose build scripts were
+    /// ignored, deduplicated in first-seen order. `None` when there is no
+    /// `.modules.yaml` or it records no `ignoredBuilds` field at all —
+    /// upstream's "cannot identify as no `node_modules` found" signal.
+    pub names: Option<Vec<String>>,
+    pub modules_dir: PathBuf,
+    pub modules_manifest: Option<Modules>,
+}
+
+/// Read `.modules.yaml` and project its `ignoredBuilds` depPaths onto the
+/// `allowBuilds` keys a user would approve them under. Ports pnpm's
+/// [`getAutomaticallyIgnoredBuilds`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/commands/src/policy/getAutomaticallyIgnoredBuilds.ts#L14-L32).
+pub(crate) fn get_automatically_ignored_builds(
+    config: &Config,
+) -> miette::Result<IgnoredBuildsScan> {
+    let modules_dir = config.modules_dir.clone();
+    let modules_manifest = read_modules_manifest::<Host>(&modules_dir).into_diagnostic()?;
+    let names = modules_manifest
+        .as_ref()
+        .and_then(|manifest| manifest.ignored_builds.as_ref())
+        .map(|ignored| {
+            ignored
+                .iter()
+                .map(|dep_path| allow_build_key_from_ignored_build(dep_path.as_str()))
+                .collect::<IndexSet<String>>()
+                .into_iter()
+                .collect()
+        });
+    Ok(IgnoredBuildsScan { names, modules_dir, modules_manifest })
+}
+
+pub(crate) fn render_ignored_builds(config: &Config) -> miette::Result<String> {
+    // pnpm preserves `allowBuilds` insertion order; pacquet's
+    // `Config::allow_builds` is a `HashMap`, so the source order is already
+    // lost. Sort for a deterministic, reproducible listing.
+    let mut disallowed_builds: Vec<String> = config
+        .allow_builds
+        .iter()
+        .filter(|&(_, &allowed)| !allowed)
+        .map(|(pkg, _)| pkg.clone())
+        .collect();
+    disallowed_builds.sort();
+
+    let mut automatically_ignored_builds = get_automatically_ignored_builds(config)?.names;
+    if let Some(list) = automatically_ignored_builds.as_mut() {
+        list.retain(|build| !disallowed_builds.contains(build));
+    }
+
+    let mut output = String::from("Automatically ignored builds during installation:\n");
+    match &automatically_ignored_builds {
+        None => output.push_str("  Cannot identify as no node_modules found"),
+        Some(list) if list.is_empty() => output.push_str("  None"),
+        Some(list) => {
+            output.push_str("  ");
+            output.push_str(&list.join("\n  "));
+            output.push_str(
+                "\nhint: To allow the execution of build scripts for a package, add its name to \"allowBuilds\" and set to \"true\", then run \"pnpm rebuild\".\nhint: For example:\nhint: allowBuilds:\nhint:   esbuild: true\nhint: If you don't want to build a package, set it to \"false\" instead.",
+            );
+        }
+    }
+    output.push('\n');
+
+    if !disallowed_builds.is_empty() {
+        output.push_str("\nExplicitly ignored package builds (via allowBuilds):\n  ");
+        output.push_str(&disallowed_builds.join("\n  "));
+        output.push('\n');
+    }
+
+    Ok(output)
+}

--- a/pacquet/crates/cli/src/cli_args/ignored_builds.rs
+++ b/pacquet/crates/cli/src/cli_args/ignored_builds.rs
@@ -87,3 +87,6 @@ pub(crate) fn render_ignored_builds(config: &Config) -> miette::Result<String> {
 
     Ok(output)
 }
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/ignored_builds/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/ignored_builds/tests.rs
@@ -1,0 +1,85 @@
+use super::render_ignored_builds;
+use pacquet_config::Config;
+use std::{fs, path::Path};
+use tempfile::tempdir;
+
+const HINTS: &str = "\nhint: To allow the execution of build scripts for a package, add its name to \"allowBuilds\" and set to \"true\", then run \"pnpm rebuild\".\nhint: For example:\nhint: allowBuilds:\nhint:   esbuild: true\nhint: If you don't want to build a package, set it to \"false\" instead.";
+
+/// Build a `Config` whose `modules_dir` is a `node_modules` under `dir`
+/// and whose `allow_builds` records each `disallowed` name as `false`.
+/// When `ignored_builds` is `Some`, a `.modules.yaml` recording those
+/// depPaths is written; `None` leaves `node_modules` absent (the
+/// "cannot identify" case).
+fn config_with(dir: &Path, ignored_builds: Option<&[&str]>, disallowed: &[&str]) -> Config {
+    let modules_dir = dir.join("node_modules");
+    if let Some(ignored) = ignored_builds {
+        fs::create_dir_all(&modules_dir).expect("create node_modules");
+        let manifest = serde_json::json!({
+            "layoutVersion": 5,
+            "packageManager": "pacquet@test",
+            "ignoredBuilds": ignored,
+            "storeDir": "/store",
+            "virtualStoreDir": ".pnpm",
+        });
+        fs::write(modules_dir.join(".modules.yaml"), manifest.to_string())
+            .expect("write .modules.yaml");
+    }
+    let mut config = Config::new();
+    config.modules_dir = modules_dir;
+    for name in disallowed {
+        config.allow_builds.insert((*name).to_string(), false);
+    }
+    config
+}
+
+// Ports pnpm's `ignoredBuilds lists automatically ignored dependencies`.
+#[test]
+fn lists_automatically_ignored_dependencies() {
+    let dir = tempdir().unwrap();
+    let config = config_with(dir.path(), Some(&["foo@1.0.0"]), &[]);
+    let output = render_ignored_builds(&config).unwrap();
+    assert_eq!(
+        output,
+        format!("Automatically ignored builds during installation:\n  foo{HINTS}\n"),
+    );
+}
+
+// Ports pnpm's `ignoredBuilds lists explicitly ignored dependencies`.
+#[test]
+fn lists_explicitly_ignored_dependencies() {
+    let dir = tempdir().unwrap();
+    let config = config_with(dir.path(), Some(&[]), &["bar"]);
+    let output = render_ignored_builds(&config).unwrap();
+    assert_eq!(
+        output,
+        "Automatically ignored builds during installation:\n  None\n\nExplicitly ignored package builds (via allowBuilds):\n  bar\n",
+    );
+}
+
+// Ports pnpm's `ignoredBuilds lists both automatically and explicitly
+// ignored dependencies`.
+#[test]
+fn lists_both_automatically_and_explicitly_ignored() {
+    let dir = tempdir().unwrap();
+    let config = config_with(dir.path(), Some(&["foo@1.0.0", "bar@1.0.0"]), &["qar", "zoo"]);
+    let output = render_ignored_builds(&config).unwrap();
+    assert_eq!(
+        output,
+        format!(
+            "Automatically ignored builds during installation:\n  foo\n  bar{HINTS}\n\nExplicitly ignored package builds (via allowBuilds):\n  qar\n  zoo\n",
+        ),
+    );
+}
+
+// Ports pnpm's `ignoredBuilds prints an info message when there is no
+// node_modules`.
+#[test]
+fn reports_cannot_identify_when_no_node_modules() {
+    let dir = tempdir().unwrap();
+    let config = config_with(dir.path(), None, &["qar", "zoo"]);
+    let output = render_ignored_builds(&config).unwrap();
+    assert_eq!(
+        output,
+        "Automatically ignored builds during installation:\n  Cannot identify as no node_modules found\n\nExplicitly ignored package builds (via allowBuilds):\n  qar\n  zoo\n",
+    );
+}

--- a/pacquet/crates/cli/src/cli_args/rebuild.rs
+++ b/pacquet/crates/cli/src/cli_args/rebuild.rs
@@ -23,6 +23,13 @@ pub struct RebuildArgs {
 
     /// Rebuild packages that were not built during installation. Packages
     /// are not built when installing with the `--ignore-scripts` flag.
+    ///
+    /// Accepted for parity with pnpm, but currently a no-op: pacquet's
+    /// install pipeline does not yet record `pendingBuilds` in
+    /// `.modules.yaml`, so there is nothing for `--pending` to select.
+    /// Tracked with the rest of the not-yet-populated `.modules.yaml`
+    /// fields; until then, name the packages explicitly or use
+    /// `approve-builds`.
     #[clap(long)]
     pub pending: bool,
 }
@@ -48,6 +55,11 @@ fn resolve_selection(
     if !pending {
         return Ok(None);
     }
+    // `pacquet`'s install pipeline does not populate `.modules.yaml`'s
+    // `pendingBuilds` yet (see [`RebuildArgs::pending`]), so this is
+    // effectively empty today. Reading it is forward-compatible: once the
+    // install pipeline records pending builds, `--pending` starts working
+    // without a change here.
     let modules = read_modules_manifest::<Host>(&config.modules_dir).into_diagnostic()?;
     let pending_names = modules
         .map(|manifest| {

--- a/pacquet/crates/cli/src/cli_args/rebuild.rs
+++ b/pacquet/crates/cli/src/cli_args/rebuild.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use miette::{Context, IntoDiagnostic};
 use pacquet_config::Config;
 use pacquet_lockfile::{Lockfile, MaybeLazyLockfile};
-use pacquet_modules_yaml::{Host, read_modules_manifest};
+use pacquet_modules_yaml::{Host, read_modules_layout, read_modules_manifest};
 use pacquet_package_manager::{
     Install, RebuildOptions, UpdateSeedPolicy, allow_build_key_from_ignored_build,
 };
@@ -78,6 +78,8 @@ pub(crate) async fn run_rebuild<Reporter: self::Reporter + 'static>(
         selected_names: selected_names.map(|names| names.into_iter().collect::<HashSet<_>>()),
     };
 
+    let dependency_groups = rebuild_dependency_groups(config)?;
+
     Install {
         tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
         http_client,
@@ -86,9 +88,10 @@ pub(crate) async fn run_rebuild<Reporter: self::Reporter + 'static>(
         manifest,
         lockfile: MaybeLazyLockfile::Lazy(lockfile),
         lockfile_path: lockfile_path.as_deref(),
-        // Rebuild operates over the whole already-resolved graph; include
-        // every group so no build-needing dependency is filtered out.
-        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
+        // Reuse exactly the dependency groups the current `node_modules`
+        // was materialized with, so a rebuild never widens the installed
+        // set (see [`rebuild_dependency_groups`]).
+        dependency_groups,
         frozen_lockfile: true,
         prefer_frozen_lockfile: None,
         ignore_manifest_check: false,
@@ -114,3 +117,31 @@ pub(crate) async fn run_rebuild<Reporter: self::Reporter + 'static>(
 
     Ok(())
 }
+
+/// The dependency groups the current `node_modules` was materialized with,
+/// read from `.modules.yaml`'s `included`. A rebuild must keep the
+/// installed set unchanged, so it reuses exactly these groups rather than
+/// widening to all of them — otherwise a `--prod` / `--no-optional`
+/// install would have its excluded dev/optional dependencies fetched and
+/// their lifecycle scripts run. Falls back to every group only when there
+/// is no `.modules.yaml` (nothing recorded to preserve).
+fn rebuild_dependency_groups(config: &Config) -> miette::Result<Vec<DependencyGroup>> {
+    let Some(modules) = read_modules_layout::<Host>(&config.modules_dir).into_diagnostic()? else {
+        return Ok(vec![DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional]);
+    };
+    let included = modules.included;
+    let mut groups = Vec::with_capacity(3);
+    if included.dependencies {
+        groups.push(DependencyGroup::Prod);
+    }
+    if included.dev_dependencies {
+        groups.push(DependencyGroup::Dev);
+    }
+    if included.optional_dependencies {
+        groups.push(DependencyGroup::Optional);
+    }
+    Ok(groups)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/rebuild.rs
+++ b/pacquet/crates/cli/src/cli_args/rebuild.rs
@@ -123,11 +123,15 @@ pub(crate) async fn run_rebuild<Reporter: self::Reporter + 'static>(
 /// installed set unchanged, so it reuses exactly these groups rather than
 /// widening to all of them — otherwise a `--prod` / `--no-optional`
 /// install would have its excluded dev/optional dependencies fetched and
-/// their lifecycle scripts run. Falls back to every group only when there
-/// is no `.modules.yaml` (nothing recorded to preserve).
+/// their lifecycle scripts run. Falls back to every group when there is no
+/// `.modules.yaml`, or when it records no included groups (a legacy
+/// manifest written before `included` existed, or a corrupt one) — neither
+/// is a recorded "include nothing" intent to preserve.
 fn rebuild_dependency_groups(config: &Config) -> miette::Result<Vec<DependencyGroup>> {
+    const ALL: [DependencyGroup; 3] =
+        [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional];
     let Some(modules) = read_modules_layout::<Host>(&config.modules_dir).into_diagnostic()? else {
-        return Ok(vec![DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional]);
+        return Ok(ALL.to_vec());
     };
     let included = modules.included;
     let mut groups = Vec::with_capacity(3);
@@ -140,7 +144,10 @@ fn rebuild_dependency_groups(config: &Config) -> miette::Result<Vec<DependencyGr
     if included.optional_dependencies {
         groups.push(DependencyGroup::Optional);
     }
-    Ok(groups)
+    // An all-false `included` would otherwise narrow the rebuild to no
+    // groups and persist that empty state into `.modules.yaml` and the
+    // current lockfile, breaking later installs.
+    Ok(if groups.is_empty() { ALL.to_vec() } else { groups })
 }
 
 #[cfg(test)]

--- a/pacquet/crates/cli/src/cli_args/rebuild.rs
+++ b/pacquet/crates/cli/src/cli_args/rebuild.rs
@@ -1,0 +1,116 @@
+use clap::Args;
+use miette::{Context, IntoDiagnostic};
+use pacquet_config::Config;
+use pacquet_lockfile::{Lockfile, MaybeLazyLockfile};
+use pacquet_modules_yaml::{Host, read_modules_manifest};
+use pacquet_package_manager::{
+    Install, RebuildOptions, UpdateSeedPolicy, allow_build_key_from_ignored_build,
+};
+use pacquet_package_manifest::DependencyGroup;
+use pacquet_reporter::Reporter;
+use std::collections::HashSet;
+
+use crate::State;
+
+/// `pacquet rebuild` — re-run the lifecycle scripts of installed
+/// dependencies. Ports pnpm's
+/// [`rebuild`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/commands/src/build/rebuild.ts).
+#[derive(Debug, Args)]
+pub struct RebuildArgs {
+    /// Rebuild only the named packages. With no names, every dependency
+    /// that requires a build is rebuilt.
+    pub packages: Vec<String>,
+
+    /// Rebuild packages that were not built during installation. Packages
+    /// are not built when installing with the `--ignore-scripts` flag.
+    #[clap(long)]
+    pub pending: bool,
+}
+
+impl RebuildArgs {
+    pub async fn run<Reporter: self::Reporter + 'static>(self, state: State) -> miette::Result<()> {
+        let selected = resolve_selection(&self.packages, self.pending, state.config)?;
+        run_rebuild::<Reporter>(&state, selected).await
+    }
+}
+
+/// Resolve the rebuild's package selection. Explicit `packages` win;
+/// otherwise `--pending` selects the packages `.modules.yaml` recorded as
+/// not-yet-built; otherwise `None` rebuilds every build-needing package.
+fn resolve_selection(
+    packages: &[String],
+    pending: bool,
+    config: &Config,
+) -> miette::Result<Option<Vec<String>>> {
+    if !packages.is_empty() {
+        return Ok(Some(packages.to_vec()));
+    }
+    if !pending {
+        return Ok(None);
+    }
+    let modules = read_modules_manifest::<Host>(&config.modules_dir).into_diagnostic()?;
+    let pending_names = modules
+        .map(|manifest| {
+            manifest
+                .pending_builds
+                .iter()
+                .map(|dep_path| allow_build_key_from_ignored_build(dep_path))
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(Some(pending_names))
+}
+
+/// Drive a forced rebuild of the selected packages (or every build-needing
+/// package when `selected_names` is `None`) through the frozen-install
+/// pipeline. Shared by `pacquet rebuild` and the rebuild step of
+/// `pacquet approve-builds`.
+pub(crate) async fn run_rebuild<Reporter: self::Reporter + 'static>(
+    state: &State,
+    selected_names: Option<Vec<String>>,
+) -> miette::Result<()> {
+    let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
+        state;
+
+    let lockfile_path = manifest.path().parent().map(|parent| parent.join(Lockfile::FILE_NAME));
+
+    let rebuild = RebuildOptions {
+        selected_names: selected_names.map(|names| names.into_iter().collect::<HashSet<_>>()),
+    };
+
+    Install {
+        tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
+        http_client,
+        http_client_arc: std::sync::Arc::clone(http_client),
+        config,
+        manifest,
+        lockfile: MaybeLazyLockfile::Lazy(lockfile),
+        lockfile_path: lockfile_path.as_deref(),
+        // Rebuild operates over the whole already-resolved graph; include
+        // every group so no build-needing dependency is filtered out.
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
+        frozen_lockfile: true,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: config.skip_runtimes,
+        trust_lockfile: config.trust_lockfile,
+        update_checksums: false,
+        // `rebuild` re-runs dependency build scripts, not the root
+        // project's own lifecycle scripts — matching pnpm's `buildProjects`.
+        is_full_install: false,
+        resolved_packages,
+        supported_architectures: config.supported_architectures.clone(),
+        node_linker: config.node_linker,
+        lockfile_only: false,
+        dry_run: false,
+        update_seed_policy: UpdateSeedPolicy::KeepAll,
+        auth_override: None,
+        resolution_observer: None,
+        catalogs_override: None,
+    }
+    .run_rebuild::<Reporter>(rebuild)
+    .await
+    .wrap_err("rebuilding dependencies")?;
+
+    Ok(())
+}

--- a/pacquet/crates/cli/src/cli_args/rebuild/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/rebuild/tests.rs
@@ -1,0 +1,84 @@
+use super::rebuild_dependency_groups;
+use pacquet_config::Config;
+use pacquet_package_manifest::DependencyGroup;
+use std::{fs, path::Path};
+use tempfile::tempdir;
+
+/// A `Config` whose `modules_dir` is a `node_modules` under `dir`. When
+/// `included` is `Some`, a `.modules.yaml` recording it is written.
+fn config_with_included(dir: &Path, included: Option<serde_json::Value>) -> Config {
+    let modules_dir = dir.join("node_modules");
+    if let Some(included) = included {
+        fs::create_dir_all(&modules_dir).expect("create node_modules");
+        let manifest = serde_json::json!({
+            "layoutVersion": 5,
+            "packageManager": "pacquet@test",
+            "included": included,
+            "storeDir": "/store",
+            "virtualStoreDir": ".pnpm",
+        });
+        fs::write(modules_dir.join(".modules.yaml"), manifest.to_string())
+            .expect("write .modules.yaml");
+    }
+    let mut config = Config::new();
+    config.modules_dir = modules_dir;
+    config
+}
+
+#[test]
+fn reuses_prod_only_when_only_dependencies_were_installed() {
+    let dir = tempdir().unwrap();
+    let config = config_with_included(
+        dir.path(),
+        Some(serde_json::json!({
+            "dependencies": true,
+            "devDependencies": false,
+            "optionalDependencies": false,
+        })),
+    );
+    assert_eq!(rebuild_dependency_groups(&config).unwrap(), vec![DependencyGroup::Prod]);
+}
+
+#[test]
+fn omits_optional_when_installed_with_no_optional() {
+    let dir = tempdir().unwrap();
+    let config = config_with_included(
+        dir.path(),
+        Some(serde_json::json!({
+            "dependencies": true,
+            "devDependencies": true,
+            "optionalDependencies": false,
+        })),
+    );
+    assert_eq!(
+        rebuild_dependency_groups(&config).unwrap(),
+        vec![DependencyGroup::Prod, DependencyGroup::Dev],
+    );
+}
+
+#[test]
+fn reuses_all_groups_when_all_were_installed() {
+    let dir = tempdir().unwrap();
+    let config = config_with_included(
+        dir.path(),
+        Some(serde_json::json!({
+            "dependencies": true,
+            "devDependencies": true,
+            "optionalDependencies": true,
+        })),
+    );
+    assert_eq!(
+        rebuild_dependency_groups(&config).unwrap(),
+        vec![DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
+    );
+}
+
+#[test]
+fn defaults_to_all_groups_without_a_modules_manifest() {
+    let dir = tempdir().unwrap();
+    let config = config_with_included(dir.path(), None);
+    assert_eq!(
+        rebuild_dependency_groups(&config).unwrap(),
+        vec![DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
+    );
+}

--- a/pacquet/crates/cli/src/cli_args/rebuild/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/rebuild/tests.rs
@@ -82,3 +82,22 @@ fn defaults_to_all_groups_without_a_modules_manifest() {
         vec![DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
     );
 }
+
+#[test]
+fn falls_back_to_all_groups_when_included_is_empty() {
+    // A `.modules.yaml` that records no included groups (e.g. a legacy
+    // manifest) must not narrow the rebuild to the empty set.
+    let dir = tempdir().unwrap();
+    let config = config_with_included(
+        dir.path(),
+        Some(serde_json::json!({
+            "dependencies": false,
+            "devDependencies": false,
+            "optionalDependencies": false,
+        })),
+    );
+    assert_eq!(
+        rebuild_dependency_groups(&config).unwrap(),
+        vec![DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
+    );
+}

--- a/pacquet/crates/cli/src/lib.rs
+++ b/pacquet/crates/cli/src/lib.rs
@@ -34,15 +34,35 @@ pub fn main() -> miette::Result<()> {
     // returns; see `job_control`.
     let _job_guard = job_control::setup();
     configure_rayon_pool();
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .expect("build the tokio runtime")
-        // Boxed for `clippy::large_futures`: the command future exceeds
-        // the lint's stack-size threshold (the limit trips on Windows
-        // first).
-        .block_on(Box::pin(args.run(&config_overrides)))
+    // `block_on` polls the command future on the calling thread, and the
+    // install pipeline has a deep synchronous call chain whose stack frames
+    // overflow Windows' 1 MiB default main-thread stack (Linux and macOS
+    // default to 8 MiB, so the limit trips on Windows first). Run it on a
+    // thread with a generous, platform-uniform stack instead of the OS
+    // default main-thread stack.
+    std::thread::Builder::new()
+        .name("pacquet-main".to_string())
+        .stack_size(MAIN_STACK_SIZE)
+        .spawn(move || {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("build the tokio runtime")
+                // Boxed for `clippy::large_futures`: the command future
+                // exceeds the lint's stack-size threshold.
+                .block_on(Box::pin(args.run(&config_overrides)))
+        })
+        .expect("spawn the pacquet-main thread")
+        .join()
+        // Re-raise a panic from the worker on this thread so the process
+        // still aborts with the original message and backtrace.
+        .unwrap_or_else(|payload| std::panic::resume_unwind(payload))
 }
+
+/// Stack size for the thread the command runs on. Generous headroom over
+/// the 8 MiB Linux/macOS default so the deep install call chain has the
+/// same room on every platform, including Windows (1 MiB default).
+const MAIN_STACK_SIZE: usize = 32 * 1024 * 1024;
 
 /// Size rayon's global pool at `2 × available_parallelism`. The link
 /// phase is dominated by clonefile / hardlink syscalls that block the

--- a/pacquet/crates/cli/tests/approve_builds.rs
+++ b/pacquet/crates/cli/tests/approve_builds.rs
@@ -170,3 +170,167 @@ fn rebuild_reruns_an_approved_build() {
 
     drop(harness);
 }
+
+/// Package names of the two build-script fixtures used by the multi-dep tests.
+const PREPOST: &str = "@pnpm.e2e/pre-and-postinstall-scripts-example";
+const INSTALL: &str = "@pnpm.e2e/install-script-example";
+
+/// The postinstall marker the `@pnpm.e2e/pre-and-postinstall-scripts-example`
+/// package writes when its build runs.
+const PREPOST_MARKER: &str = "node_modules/.pnpm/@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+     /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-postinstall.js";
+
+/// Install both build-script fixtures with their builds ignored (neither in
+/// `allowBuilds`).
+fn install_two_with_ignored_builds() -> (CommandTempCwd<AddMockedRegistry>, std::path::PathBuf) {
+    let harness = CommandTempCwd::init().add_mocked_registry();
+    let workspace = harness.workspace.clone();
+
+    let package_json = serde_json::json!({
+        "dependencies": { PREPOST: "1.0.0", INSTALL: "1.0.0" },
+    });
+    fs::write(workspace.join("package.json"), package_json.to_string())
+        .expect("write package.json");
+    disable_strict_dep_builds(&workspace);
+
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    assert!(!workspace.join(PREPOST_MARKER).exists(), "prepost build must be ignored initially");
+    assert!(!workspace.join(INSTALL_MARKER).exists(), "install build must be ignored initially");
+    (harness, workspace)
+}
+
+/// The `allowBuilds` map recorded in the workspace manifest.
+fn allow_builds(workspace: &Path) -> std::collections::BTreeMap<String, bool> {
+    #[derive(serde::Deserialize)]
+    struct Manifest {
+        #[serde(rename = "allowBuilds", default)]
+        allow_builds: std::collections::BTreeMap<String, bool>,
+    }
+    let text = fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read yaml");
+    serde_saphyr::from_str::<Manifest>(&text).expect("parse yaml").allow_builds
+}
+
+/// Seed an existing `allowBuilds: { name: true }` entry in the manifest.
+fn seed_allow_build(workspace: &Path, name: &str) {
+    let path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&path).unwrap_or_default();
+    if !yaml.is_empty() && !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    writeln!(yaml, "allowBuilds:\n  '{name}': true").expect("format allowBuilds");
+    fs::write(&path, yaml).expect("write pnpm-workspace.yaml");
+}
+
+// Ports pnpm's `approve all builds with --all flag`.
+#[test]
+fn approve_builds_all_flag_builds_everything() {
+    let (harness, workspace) = install_two_with_ignored_builds();
+
+    pacquet(&workspace).with_args(["approve-builds", "--all"]).assert().success();
+
+    assert!(workspace.join(PREPOST_MARKER).exists(), "prepost built under --all");
+    assert!(workspace.join(INSTALL_MARKER).exists(), "install built under --all");
+    assert_eq!(
+        allow_builds(&workspace),
+        std::collections::BTreeMap::from([
+            (INSTALL.to_string(), true),
+            (PREPOST.to_string(), true),
+        ]),
+    );
+
+    drop(harness);
+}
+
+// Ports pnpm's `deny builds via !pkg positional arguments`.
+#[test]
+fn approve_builds_approves_and_denies_via_positional_args() {
+    let (harness, workspace) = install_two_with_ignored_builds();
+
+    let deny_install = format!("!{INSTALL}");
+    pacquet(&workspace)
+        .with_args(["approve-builds", PREPOST, deny_install.as_str()])
+        .assert()
+        .success();
+
+    assert!(workspace.join(PREPOST_MARKER).exists(), "approved package built");
+    assert!(!workspace.join(INSTALL_MARKER).exists(), "denied package not built");
+    assert_eq!(
+        allow_builds(&workspace),
+        std::collections::BTreeMap::from([
+            (INSTALL.to_string(), false),
+            (PREPOST.to_string(), true),
+        ]),
+    );
+
+    drop(harness);
+}
+
+// Ports pnpm's `deny-only via !pkg keeps other builds pending`.
+#[test]
+fn approve_builds_deny_only_keeps_other_pending() {
+    let (harness, workspace) = install_two_with_ignored_builds();
+
+    let deny_install = format!("!{INSTALL}");
+    pacquet(&workspace).with_args(["approve-builds", deny_install.as_str()]).assert().success();
+
+    // Only the denied package is decided; the other stays pending.
+    assert_eq!(
+        allow_builds(&workspace),
+        std::collections::BTreeMap::from([(INSTALL.to_string(), false)]),
+    );
+
+    let output = stdout_of(pacquet(&workspace).with_arg("ignored-builds").assert());
+    let (automatic, explicit) = output
+        .split_once("Explicitly ignored package builds (via allowBuilds):")
+        .expect("explicit section present");
+    assert!(automatic.contains(PREPOST), "the undecided package stays pending: {output}");
+    assert!(explicit.contains(INSTALL), "the denied package is explicitly ignored: {output}");
+
+    drop(harness);
+}
+
+// Ports pnpm's `positional args preserve existing allowBuilds entries`.
+#[test]
+fn approve_builds_preserves_existing_allow_builds_entries() {
+    let (harness, workspace) = install_two_with_ignored_builds();
+    seed_allow_build(&workspace, "@pnpm.e2e/existing-package");
+
+    pacquet(&workspace).with_args(["approve-builds", PREPOST]).assert().success();
+
+    let builds = allow_builds(&workspace);
+    assert_eq!(builds.get("@pnpm.e2e/existing-package"), Some(&true), "existing entry kept");
+    assert_eq!(builds.get(PREPOST), Some(&true), "approved package recorded");
+    assert!(!builds.contains_key(INSTALL), "unmentioned package not touched: {builds:?}");
+
+    drop(harness);
+}
+
+// Ports pnpm's `--all with positional arguments throws error`.
+#[test]
+fn approve_builds_all_with_args_is_rejected() {
+    let CommandTempCwd { workspace, root, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), "{}").expect("write package.json");
+
+    let assert =
+        pacquet(&workspace).with_args(["approve-builds", "--all", "foo"]).assert().failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
+    assert!(stderr.contains("ERR_PNPM_APPROVE_BUILDS_ALL_WITH_ARGS"), "stderr: {stderr}");
+
+    drop(root);
+}
+
+#[test]
+fn approve_builds_global_is_rejected() {
+    let CommandTempCwd { workspace, root, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), "{}").expect("write package.json");
+
+    let assert = pacquet(&workspace).with_args(["approve-builds", "--global"]).assert().failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
+    assert!(
+        stderr.contains("ERR_PNPM_APPROVE_BUILDS_NOT_SUPPORTED_WITH_GLOBAL"),
+        "stderr: {stderr}",
+    );
+
+    drop(root);
+}

--- a/pacquet/crates/cli/tests/approve_builds.rs
+++ b/pacquet/crates/cli/tests/approve_builds.rs
@@ -21,7 +21,11 @@ const INSTALL_MARKER: &str = "node_modules/.pnpm/@pnpm.e2e+install-script-exampl
 /// `ERR_PNPM_IGNORED_BUILDS`.
 fn disable_strict_dep_builds(workspace: &Path) {
     let yaml_path = workspace.join("pnpm-workspace.yaml");
-    let mut yaml = fs::read_to_string(&yaml_path).unwrap_or_default();
+    let mut yaml = match fs::read_to_string(&yaml_path) {
+        Ok(content) => content,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(err) => panic!("read pnpm-workspace.yaml: {err}"),
+    };
     if !yaml.is_empty() && !yaml.ends_with('\n') {
         yaml.push('\n');
     }

--- a/pacquet/crates/cli/tests/approve_builds.rs
+++ b/pacquet/crates/cli/tests/approve_builds.rs
@@ -1,0 +1,168 @@
+//! Integration tests for `pacquet ignored-builds`, `approve-builds`, and
+//! `rebuild`. Ports the observable behavior of pnpm's
+//! [`approveBuilds`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/commands/src/policy/approveBuilds.ts)
+//! and [`ignoredBuilds`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/commands/src/policy/ignoredBuilds.ts)
+//! tests: a dependency whose build was ignored is listed by
+//! `ignored-builds`, approved by `approve-builds` (which writes
+//! `allowBuilds` and re-runs the build), and re-run by `rebuild`.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::{fmt::Write as _, fs, path::Path, process::Command};
+
+/// The install marker the `@pnpm.e2e/install-script-example` package's
+/// `install` lifecycle script writes when it runs.
+const INSTALL_MARKER: &str = "node_modules/.pnpm/@pnpm.e2e+install-script-example@1.0.0\
+     /node_modules/@pnpm.e2e/install-script-example/generated-by-install.js";
+
+/// Append `strictDepBuilds: false` so an install that intentionally leaves
+/// a build ignored completes instead of failing with
+/// `ERR_PNPM_IGNORED_BUILDS`.
+fn disable_strict_dep_builds(workspace: &Path) {
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&yaml_path).unwrap_or_default();
+    if !yaml.is_empty() && !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    writeln!(yaml, "strictDepBuilds: false").expect("format strictDepBuilds");
+    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+}
+
+/// A fresh `pacquet` command rooted at `workspace` (each `assert_cmd`
+/// `Command` is single-use, so sequential steps build their own).
+fn pacquet(workspace: &Path) -> Command {
+    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+}
+
+/// Set up a workspace that depends on `@pnpm.e2e/install-script-example`
+/// and install it with its build ignored (not in `allowBuilds`).
+fn install_with_ignored_build() -> (CommandTempCwd<AddMockedRegistry>, std::path::PathBuf) {
+    let harness = CommandTempCwd::init().add_mocked_registry();
+    let workspace = harness.workspace.clone();
+
+    let package_json = serde_json::json!({
+        "dependencies": { "@pnpm.e2e/install-script-example": "1.0.0" },
+    });
+    fs::write(workspace.join("package.json"), package_json.to_string())
+        .expect("write package.json");
+    disable_strict_dep_builds(&workspace);
+
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    assert!(
+        !workspace.join(INSTALL_MARKER).exists(),
+        "the build must be ignored on the initial install",
+    );
+    (harness, workspace)
+}
+
+fn stdout_of(command: assert_cmd::assert::Assert) -> String {
+    String::from_utf8(command.success().get_output().stdout.clone()).expect("utf-8 stdout")
+}
+
+#[test]
+fn ignored_builds_lists_the_blocked_dependency() {
+    let (harness, workspace) = install_with_ignored_build();
+
+    let output = stdout_of(pacquet(&workspace).with_arg("ignored-builds").assert());
+    assert!(
+        output.contains("Automatically ignored builds during installation:"),
+        "output: {output}",
+    );
+    assert!(output.contains("@pnpm.e2e/install-script-example"), "output: {output}");
+
+    drop(harness);
+}
+
+#[test]
+fn approve_builds_with_args_runs_the_build() {
+    let (harness, workspace) = install_with_ignored_build();
+
+    pacquet(&workspace)
+        .with_args(["approve-builds", "@pnpm.e2e/install-script-example"])
+        .assert()
+        .success();
+
+    assert!(
+        workspace.join(INSTALL_MARKER).exists(),
+        "approving the build must run its install script",
+    );
+
+    let yaml = fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read yaml");
+    assert!(
+        yaml.contains("allowBuilds:") && yaml.contains("@pnpm.e2e/install-script-example"),
+        "allowBuilds entry written: {yaml}",
+    );
+
+    // With its only ignored build approved, `.modules.yaml` no longer
+    // records an `ignoredBuilds` field, so the package is no longer listed.
+    // (pnpm prints "Cannot identify as no node_modules found" when the
+    // field is absent — "None" is reserved for a present-but-empty list.)
+    let output = stdout_of(pacquet(&workspace).with_arg("ignored-builds").assert());
+    assert!(
+        !output.contains("@pnpm.e2e/install-script-example"),
+        "the approved build is no longer reported as ignored: {output}",
+    );
+
+    drop(harness);
+}
+
+#[test]
+fn approve_builds_deny_keeps_the_build_ignored() {
+    let (harness, workspace) = install_with_ignored_build();
+
+    pacquet(&workspace)
+        .with_args(["approve-builds", "!@pnpm.e2e/install-script-example"])
+        .assert()
+        .success();
+
+    assert!(
+        !workspace.join(INSTALL_MARKER).exists(),
+        "denying the build must not run its install script",
+    );
+
+    let output = stdout_of(pacquet(&workspace).with_arg("ignored-builds").assert());
+    assert!(
+        output.contains("Explicitly ignored package builds (via allowBuilds):"),
+        "denied build is reported as explicitly ignored: {output}",
+    );
+
+    drop(harness);
+}
+
+#[test]
+fn approve_builds_with_nothing_pending_reports_so() {
+    let harness = CommandTempCwd::init().add_mocked_registry();
+    let workspace = harness.workspace.clone();
+    fs::write(workspace.join("package.json"), "{}").expect("write package.json");
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let output = stdout_of(pacquet(&workspace).with_arg("approve-builds").assert());
+    assert!(output.contains("There are no packages awaiting approval"), "output: {output}");
+
+    drop(harness);
+}
+
+#[test]
+fn rebuild_reruns_an_approved_build() {
+    let (harness, workspace) = install_with_ignored_build();
+
+    // Approve via `allowBuilds` and run the build once.
+    pacquet(&workspace)
+        .with_args(["approve-builds", "@pnpm.e2e/install-script-example"])
+        .assert()
+        .success();
+    let marker = workspace.join(INSTALL_MARKER);
+    assert!(marker.exists(), "approve-builds must have run the build");
+
+    // Delete the marker and rebuild: the script must run again.
+    fs::remove_file(&marker).expect("remove install marker");
+    pacquet(&workspace)
+        .with_args(["rebuild", "@pnpm.e2e/install-script-example"])
+        .assert()
+        .success();
+    assert!(marker.exists(), "rebuild must re-run the install script");
+
+    drop(harness);
+}

--- a/pacquet/crates/package-manager/src/build_modules.rs
+++ b/pacquet/crates/package-manager/src/build_modules.rs
@@ -302,10 +302,14 @@ fn is_source_like_dep_path_version(version: &str) -> bool {
 /// ignored-builds record for the packages it did not touch.
 #[derive(Debug, Default, Clone)]
 pub struct RebuildOptions {
-    /// Package names to force past the side-effects `is_built` gate.
-    /// `None` forces every build-needing package (`pnpm rebuild` with no
-    /// arguments); `Some(names)` forces only the matching names
-    /// (`pnpm rebuild <pkg>...`).
+    /// Allow-build keys (the package name for registry deps, the full
+    /// pkgId for git/tarball artifacts — see
+    /// [`allow_build_key_from_ignored_build`]) to force past the
+    /// side-effects `is_built` gate. `None` forces every build-needing
+    /// package (`pnpm rebuild` with no arguments); `Some(keys)` forces
+    /// only the matching ones (`pnpm rebuild <pkg>...`). A package matches
+    /// when either its name or its allow-build key is in the set, so a
+    /// `pnpm rebuild <name>` and an `approve-builds` key both select it.
     pub selected_names: Option<HashSet<String>>,
 }
 
@@ -740,17 +744,24 @@ fn build_one_snapshot<Reporter: self::Reporter>(
         return Ok(());
     }
 
-    let (name, version) = parse_name_version_from_key(&metadata_key.to_string());
+    let dep_path = metadata_key.to_string();
+    let (name, version) = parse_name_version_from_key(&dep_path);
 
     // An explicit `pacquet rebuild` re-runs the build scripts of the
     // selected packages even when the side-effects cache reports them
     // already built; `force_rebuild` marks those so they bypass the
-    // `is_built` gate below. The allow-policy gate still applies — a
+    // `is_built` gate below. The selection holds allow-build keys (the
+    // package name for registry deps, the full pkgId for git/tarball
+    // artifacts), so match either form — a selected non-registry artifact
+    // is forced past the gate too. The allow-policy gate still applies — a
     // rebuild never builds a disallowed package — matching pnpm's
     // `buildModules` honoring `allowBuild` during rebuild. Non-selected
     // packages are still visited under their normal gating so a partial
     // rebuild keeps the `.modules.yaml` ignored-builds record intact.
-    let force_rebuild = rebuild.is_some_and(|rebuild| rebuild.is_selected(&name));
+    let force_rebuild = rebuild.is_some_and(|rebuild| {
+        rebuild.is_selected(&name)
+            || rebuild.is_selected(&allow_build_key_from_ignored_build(&dep_path))
+    });
 
     // Mirrors upstream's `if (node.requiresBuild) { allowBuild(...) }`
     // at lines 88-101: the allowBuilds gate only applies when the
@@ -763,7 +774,6 @@ fn build_one_snapshot<Reporter: self::Reporter>(
     // `ignoreScripts = true; break` pattern.
     let mut should_run_scripts = requires_build && !ignore_scripts;
     if should_run_scripts {
-        let dep_path = metadata_key.to_string();
         match allow_build_policy.check(&dep_path) {
             Some(false) => {
                 should_run_scripts = false;

--- a/pacquet/crates/package-manager/src/build_modules.rs
+++ b/pacquet/crates/package-manager/src/build_modules.rs
@@ -756,8 +756,9 @@ fn build_one_snapshot<Reporter: self::Reporter>(
     // is forced past the gate too. The allow-policy gate still applies — a
     // rebuild never builds a disallowed package — matching pnpm's
     // `buildModules` honoring `allowBuild` during rebuild. Non-selected
-    // packages are still visited under their normal gating so a partial
-    // rebuild keeps the `.modules.yaml` ignored-builds record intact.
+    // packages still run the allow-policy gate below (so their
+    // `.modules.yaml` ignored-builds record stays intact), but their
+    // scripts are suppressed by the rebuild-selection gate after it.
     let force_rebuild = rebuild.is_some_and(|rebuild| {
         rebuild.is_selected(&name)
             || rebuild.is_selected(&allow_build_key_from_ignored_build(&dep_path))
@@ -791,6 +792,17 @@ fn build_one_snapshot<Reporter: self::Reporter>(
             }
             Some(true) => {}
         }
+    }
+
+    // A `pacquet rebuild <pkg>` runs scripts only for the selected
+    // packages. Non-selected packages were still evaluated by the policy
+    // gate above (so their ignored-builds state is recorded), but their
+    // scripts are suppressed here. The side-effects `is_built` gate below
+    // is only an optimization and is disabled by default, so this gate —
+    // not that short-circuit — is what bounds script execution to the
+    // selection, matching pnpm's `buildSelectedPkgs`.
+    if rebuild.is_some() && !force_rebuild {
+        should_run_scripts = false;
     }
 
     // Compute the side-effects cache key once per snapshot, before

--- a/pacquet/crates/package-manager/src/build_modules.rs
+++ b/pacquet/crates/package-manager/src/build_modules.rs
@@ -300,7 +300,7 @@ fn is_source_like_dep_path_version(version: &str) -> bool {
 /// never builds a disallowed package — and non-selected packages keep
 /// their normal install gating so a partial rebuild does not drop the
 /// ignored-builds record for the packages it did not touch.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct RebuildOptions {
     /// Package names to force past the side-effects `is_built` gate.
     /// `None` forces every build-needing package (`pnpm rebuild` with no

--- a/pacquet/crates/package-manager/src/build_modules.rs
+++ b/pacquet/crates/package-manager/src/build_modules.rs
@@ -7,7 +7,7 @@ use crate::{
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::{Config, PackageImportMethod};
-use pacquet_deps_path::remove_suffix;
+use pacquet_deps_path::{get_pkg_id_with_patch_hash, index_of_dep_path_suffix, remove_suffix};
 use pacquet_executor::{
     LifecycleScriptError, RunPostinstallHooks, ScriptsPrependNodePath, run_postinstall_hooks,
 };
@@ -234,6 +234,43 @@ pub(crate) fn normalize_build_dep_path(dep_path: &str) -> String {
     remove_suffix(dep_path).to_string()
 }
 
+/// The `allowBuilds` key under which an ignored build should be approved:
+/// the package name for registry packages, the peer-suffix-free depPath for
+/// git/tarball artifacts (whose name alone must not approve builds). Ports
+/// pnpm's
+/// [`allowBuildKeyFromIgnoredBuild`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/policy/src/index.ts#L83-L88).
+#[must_use]
+pub fn allow_build_key_from_ignored_build(dep_path: &str) -> String {
+    let pkg_id_with_patch_hash = get_pkg_id_with_patch_hash(dep_path);
+    match parse_dep_path_name_version(pkg_id_with_patch_hash) {
+        Some((name, version)) if node_semver::Version::parse(version).is_ok() => name.to_string(),
+        _ => pkg_id_with_patch_hash.to_string(),
+    }
+}
+
+/// Split a peer-suffix-free depPath / pkgId into its `name` and `version`
+/// (with any `(patch_hash=…)` segment stripped), mirroring the half of
+/// pnpm's
+/// [`parse`](https://github.com/pnpm/pnpm/blob/097983fbca/deps/path/src/index.ts#L123-L170)
+/// that [`allow_build_key_from_ignored_build`] consumes. Returns `None`
+/// when there is no `@` version separator past position 0 or the version
+/// is empty — the cases pnpm's `parse` reports as a name-less `{}`.
+fn parse_dep_path_name_version(pkg_id: &str) -> Option<(&str, &str)> {
+    let sep = pkg_id.get(1..)?.find('@').map(|off| off + 1)?;
+    let name = &pkg_id[..sep];
+    let mut version = &pkg_id[sep + 1..];
+    if version.is_empty() {
+        return None;
+    }
+    let suffix = index_of_dep_path_suffix(version);
+    if let Some(idx) = suffix.patch_hash_index {
+        version = &version[..idx];
+    } else if let Some(idx) = suffix.peers_index {
+        version = &version[..idx];
+    }
+    Some((name, version))
+}
+
 fn is_dep_path_allow_build_key(spec: &str) -> bool {
     if normalize_build_dep_path(spec) != spec {
         return true;
@@ -250,6 +287,34 @@ fn is_dep_path_allow_build_key(spec: &str) -> bool {
 
 fn is_source_like_dep_path_version(version: &str) -> bool {
     version.contains(':') || version.contains('/') || version.contains('#')
+}
+
+/// Drives a forced rebuild of already-installed packages. Constructed by
+/// `pacquet rebuild` and `pacquet approve-builds`; absent (`None`) for a
+/// normal install. Mirrors the rebuild half of pnpm's
+/// [`buildSelectedPkgs`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/after-install/src/index.ts).
+///
+/// Effect on [`BuildModules`]: a selected package is built even when the
+/// side-effects cache reports it already built (an explicit rebuild always
+/// re-runs the scripts). The allow-policy gate is unchanged — a rebuild
+/// never builds a disallowed package — and non-selected packages keep
+/// their normal install gating so a partial rebuild does not drop the
+/// ignored-builds record for the packages it did not touch.
+#[derive(Debug, Clone, Default)]
+pub struct RebuildOptions {
+    /// Package names to force past the side-effects `is_built` gate.
+    /// `None` forces every build-needing package (`pnpm rebuild` with no
+    /// arguments); `Some(names)` forces only the matching names
+    /// (`pnpm rebuild <pkg>...`).
+    pub selected_names: Option<HashSet<String>>,
+}
+
+impl RebuildOptions {
+    /// Whether a package named `name` is in the rebuild selection. An
+    /// absent selection (`None`) matches every package.
+    fn is_selected(&self, name: &str) -> bool {
+        self.selected_names.as_ref().is_none_or(|names| names.contains(name))
+    }
 }
 
 /// Run lifecycle scripts for all packages that require a build.
@@ -411,6 +476,14 @@ pub struct BuildModules<'a> {
     /// re-materialization doesn't re-announce a method the link phase
     /// already reported.
     pub logged_methods: &'a std::sync::atomic::AtomicU8,
+
+    /// Forced-rebuild selection. `None` for a normal install — every
+    /// package follows the standard `requires_build` + allow-policy +
+    /// side-effects-cache gates. `Some` (a `pacquet rebuild` /
+    /// `approve-builds`) restricts the build to the selected names and
+    /// forces them past the side-effects `is_built` gate. See
+    /// [`RebuildOptions`].
+    pub rebuild: Option<&'a RebuildOptions>,
 }
 
 impl BuildModules<'_> {
@@ -448,6 +521,7 @@ impl BuildModules<'_> {
             ignore_scripts,
             import_method,
             logged_methods,
+            rebuild,
         } = self;
 
         let Some(snapshots) = snapshots else { return Ok(Vec::new()) };
@@ -593,6 +667,7 @@ impl BuildModules<'_> {
                         ignore_scripts,
                         import_method,
                         logged_methods,
+                        rebuild,
                     )
                 })
             })?;
@@ -646,6 +721,7 @@ fn build_one_snapshot<Reporter: self::Reporter>(
     ignore_scripts: bool,
     import_method: PackageImportMethod,
     logged_methods: &std::sync::atomic::AtomicU8,
+    rebuild: Option<&RebuildOptions>,
 ) -> Result<(), BuildModulesError> {
     let metadata_key = snapshot_key.without_peer();
     // Look up against the peer-stripped key because patches are
@@ -665,6 +741,16 @@ fn build_one_snapshot<Reporter: self::Reporter>(
     }
 
     let (name, version) = parse_name_version_from_key(&metadata_key.to_string());
+
+    // An explicit `pacquet rebuild` re-runs the build scripts of the
+    // selected packages even when the side-effects cache reports them
+    // already built; `force_rebuild` marks those so they bypass the
+    // `is_built` gate below. The allow-policy gate still applies — a
+    // rebuild never builds a disallowed package — matching pnpm's
+    // `buildModules` honoring `allowBuild` during rebuild. Non-selected
+    // packages are still visited under their normal gating so a partial
+    // rebuild keeps the `.modules.yaml` ignored-builds record intact.
+    let force_rebuild = rebuild.is_some_and(|rebuild| rebuild.is_selected(&name));
 
     // Mirrors upstream's `if (node.requiresBuild) { allowBuild(...) }`
     // at lines 88-101: the allowBuilds gate only applies when the
@@ -750,8 +836,10 @@ fn build_one_snapshot<Reporter: self::Reporter>(
     // otherwise run its scripts — but if the prefetch surfaced a
     // matching side-effects-cache entry, the build is already
     // represented on disk (pnpm seeded it on a previous install)
-    // and we can skip.
-    if side_effects_cache
+    // and we can skip. An explicit `pacquet rebuild` (`force_rebuild`)
+    // always re-runs the scripts, so it bypasses this gate.
+    if !force_rebuild
+        && side_effects_cache
         && let Some(maps_by_snapshot) = side_effects_maps_by_snapshot
         && let Some(maps) = maps_by_snapshot.get(snapshot_key)
         && let Some(key) = cache_key.as_deref()

--- a/pacquet/crates/package-manager/src/build_modules/tests.rs
+++ b/pacquet/crates/package-manager/src/build_modules/tests.rs
@@ -2515,9 +2515,9 @@ fn allow_build_key_strips_version_for_registry_packages() {
 
 #[test]
 fn allow_build_key_ignores_patch_hash_when_deriving_name() {
-    // A `(patch_hash=…)` segment is dropped before the version is checked,
+    // A `(patch_hash=...)` segment is dropped before the version is checked,
     // so a patched registry package still reduces to its name.
-    assert_eq!(allow_build_key_from_ignored_build("esbuild@0.17.0(patch_hash=abcdef)"), "esbuild",);
+    assert_eq!(allow_build_key_from_ignored_build("esbuild@0.17.0(patch_hash=abcdef)"), "esbuild");
 }
 
 #[test]

--- a/pacquet/crates/package-manager/src/build_modules/tests.rs
+++ b/pacquet/crates/package-manager/src/build_modules/tests.rs
@@ -2527,6 +2527,8 @@ fn allow_build_key_keeps_full_id_for_non_semver_artifacts() {
     let git = "foo@github.com/foo/bar#0123456789";
     assert_eq!(allow_build_key_from_ignored_build(git), git);
 
-    let tarball = "https://example.com/foo.tgz";
+    // Ignored-build entries are depPath-shaped (`name@<resolution>`); a
+    // tarball's non-semver resolution keeps the whole pkgId as the key.
+    let tarball = "foo@https://example.com/foo.tgz";
     assert_eq!(allow_build_key_from_ignored_build(tarball), tarball);
 }

--- a/pacquet/crates/package-manager/src/build_modules/tests.rs
+++ b/pacquet/crates/package-manager/src/build_modules/tests.rs
@@ -1,7 +1,10 @@
 use super::{
-    AllowBuildPolicy, BuildModules, RebuildOptions, allow_build_key_from_ignored_build,
-    parse_name_version_from_key,
+    AllowBuildPolicy, BuildModules, allow_build_key_from_ignored_build, parse_name_version_from_key,
 };
+// Only the `#[cfg(unix)]` rebuild-selection test uses this; importing it
+// unconditionally would be an unused import on Windows.
+#[cfg(unix)]
+use super::RebuildOptions;
 use crate::{RequiresBuildBySnapshot, SkippedSnapshots, VirtualStoreLayout};
 use pacquet_config::{Config, PackageImportMethod};
 use pacquet_executor::ScriptsPrependNodePath;

--- a/pacquet/crates/package-manager/src/build_modules/tests.rs
+++ b/pacquet/crates/package-manager/src/build_modules/tests.rs
@@ -1,5 +1,6 @@
 use super::{
-    AllowBuildPolicy, BuildModules, allow_build_key_from_ignored_build, parse_name_version_from_key,
+    AllowBuildPolicy, BuildModules, RebuildOptions, allow_build_key_from_ignored_build,
+    parse_name_version_from_key,
 };
 use crate::{RequiresBuildBySnapshot, SkippedSnapshots, VirtualStoreLayout};
 use pacquet_config::{Config, PackageImportMethod};
@@ -2531,4 +2532,89 @@ fn allow_build_key_keeps_full_id_for_non_semver_artifacts() {
     // tarball's non-semver resolution keeps the whole pkgId as the key.
     let tarball = "foo@https://example.com/foo.tgz";
     assert_eq!(allow_build_key_from_ignored_build(tarball), tarball);
+}
+
+/// Like [`create_buildable_pkg`], but the postinstall writes a `built-marker`
+/// file into the package directory so a test can observe whether the script
+/// actually ran.
+#[cfg(unix)]
+fn create_marker_pkg(virtual_store_dir: &Path, key: &PackageKey) -> PathBuf {
+    let key_str = key.without_peer().to_string();
+    let name_version = key_str.strip_prefix('/').unwrap_or(&key_str);
+    let at_idx = name_version.rfind('@').unwrap_or(name_version.len());
+    let pkg_name = &name_version[..at_idx];
+    let store_name = name_version.replace('/', "+");
+    let pkg_dir = virtual_store_dir.join(&store_name).join("node_modules").join(pkg_name);
+    fs::create_dir_all(&pkg_dir).expect("create pkg dir");
+    let manifest = serde_json::json!({
+        "scripts": { "postinstall": "echo ran > built-marker" },
+    });
+    fs::write(pkg_dir.join("package.json"), manifest.to_string()).expect("write manifest");
+    pkg_dir
+}
+
+/// A `pacquet rebuild <pkg>` with a selection runs scripts ONLY for the
+/// selected package, even with the side-effects cache disabled (so its
+/// `is_built` short-circuit cannot fire). Both packages are allowed to
+/// build, so without the rebuild-selection gate `zzz` would also run.
+#[cfg(unix)]
+#[test]
+fn rebuild_selection_runs_only_selected_scripts() {
+    let snapshots = HashMap::from([
+        (key("aaa", "1.0.0"), SnapshotEntry::default()),
+        (key("zzz", "1.0.0"), SnapshotEntry::default()),
+    ]);
+    let importers = root_importers(&[("aaa", "1.0.0"), ("zzz", "1.0.0")]);
+    let policy = policy_from_specs([("aaa", true), ("zzz", true)], false);
+
+    let virtual_store_dir = tempdir().expect("create temp dir");
+    let modules_dir = tempdir().expect("create temp dir");
+    let lockfile_dir = tempdir().expect("create temp dir");
+
+    let aaa_dir = create_marker_pkg(virtual_store_dir.path(), &key("aaa", "1.0.0"));
+    let zzz_dir = create_marker_pkg(virtual_store_dir.path(), &key("zzz", "1.0.0"));
+
+    let rebuild =
+        RebuildOptions { selected_names: Some(std::iter::once("aaa".to_string()).collect()) };
+
+    BuildModules {
+        layout: &VirtualStoreLayout::legacy(
+            virtual_store_dir.path(),
+            pacquet_config::default_virtual_store_dir_max_length() as usize,
+        ),
+        modules_dir: modules_dir.path(),
+        lockfile_dir: lockfile_dir.path(),
+        snapshots: Some(&snapshots),
+        importers: &importers,
+        packages: None,
+        allow_build_policy: &policy,
+        side_effects_maps_by_snapshot: None,
+        requires_build_by_snapshot: None,
+        engine_name: None,
+        side_effects_cache: false,
+        side_effects_cache_write: false,
+        store_dir: None,
+        store_index_writer: None,
+        patches: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        extra_env: &HashMap::new(),
+        unsafe_perm: true,
+        child_concurrency: 1,
+        skipped: &SkippedSnapshots::default(),
+        pkg_root_by_key: None,
+        gather_ancestor_bin_paths: false,
+        frozen_store: false,
+        ignore_scripts: false,
+        import_method: PackageImportMethod::Auto,
+        logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: Some(&rebuild),
+    }
+    .run::<SilentReporter>()
+    .expect("rebuild runs");
+
+    assert!(aaa_dir.join("built-marker").exists(), "the selected package's script ran");
+    assert!(
+        !zzz_dir.join("built-marker").exists(),
+        "the non-selected package's script must not run",
+    );
 }

--- a/pacquet/crates/package-manager/src/build_modules/tests.rs
+++ b/pacquet/crates/package-manager/src/build_modules/tests.rs
@@ -1,4 +1,6 @@
-use super::{AllowBuildPolicy, BuildModules, parse_name_version_from_key};
+use super::{
+    AllowBuildPolicy, BuildModules, allow_build_key_from_ignored_build, parse_name_version_from_key,
+};
 use crate::{RequiresBuildBySnapshot, SkippedSnapshots, VirtualStoreLayout};
 use pacquet_config::{Config, PackageImportMethod};
 use pacquet_executor::ScriptsPrependNodePath;
@@ -348,6 +350,7 @@ fn build_modules_collects_ignored_builds() {
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<SilentReporter>()
     .expect("run BuildModules");
@@ -413,6 +416,7 @@ fn ignore_scripts_skips_build_without_collecting_ignored() {
         ignore_scripts: true,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<SilentReporter>()
     .expect("run BuildModules");
@@ -466,6 +470,7 @@ fn cached_requires_build_false_skips_package_dir_probe() {
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<SilentReporter>()
     .expect("run BuildModules");
@@ -539,6 +544,7 @@ fn build_modules_collects_ignored_builds_under_concurrency() {
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<SilentReporter>()
     .expect("run BuildModules under concurrency");
@@ -605,6 +611,7 @@ fn build_modules_excludes_explicit_deny_from_ignored() {
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<SilentReporter>()
     .expect("run BuildModules");
@@ -694,6 +701,7 @@ fn do_not_fail_on_optional_dep_with_failing_postinstall() {
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<RecordingReporter>()
     .expect("optional build failure must NOT abort the install");
@@ -856,6 +864,7 @@ fn using_side_effects_cache_skips_rebuild() {
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<RecordingReporter>()
     .expect("install must succeed when the cache hit skips the rebuild");
@@ -981,6 +990,7 @@ fn corrupt_side_effects_cache_falls_back_to_rebuild() {
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<SilentReporter>()
     .expect("a corrupt cache overlay must degrade to a rebuild, not abort the install");
@@ -1097,6 +1107,7 @@ fn materialization_failure_on_incomplete_slot_is_fatal() {
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<SilentReporter>();
 
@@ -1164,6 +1175,7 @@ fn side_effects_cache_disabled_bypasses_the_gate() {
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<SilentReporter>()
     .expect_err("with cache disabled, the failing postinstall must run and the install must fail");
@@ -1230,6 +1242,7 @@ fn fail_when_failing_postinstall_is_required() {
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<SilentReporter>()
     .expect_err("required build failure must propagate");
@@ -1318,6 +1331,7 @@ fn frozen_backstop_run(
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<SilentReporter>()
 }
@@ -1642,6 +1656,7 @@ async fn write_path_populates_side_effects_row() {
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<SilentReporter>()
     .expect("build modules must complete cleanly");
@@ -1762,6 +1777,7 @@ async fn write_path_disabled_skips_upload() {
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<SilentReporter>()
     .expect("build modules must complete cleanly");
@@ -1890,6 +1906,7 @@ async fn upload_error_does_not_interrupt_install() {
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<SilentReporter>()
     .expect("upload failure must not propagate; install continues");
@@ -2126,6 +2143,7 @@ new file mode 100644
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<SilentReporter>()
     .expect("build modules must complete cleanly");
@@ -2241,6 +2259,7 @@ new file mode 100644
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<SilentReporter>()
     .expect("build modules must complete cleanly");
@@ -2327,6 +2346,7 @@ async fn missing_patch_file_path_errors_with_diagnostic() {
         ignore_scripts: false,
         import_method: PackageImportMethod::Auto,
         logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
     }
     .run::<SilentReporter>()
     .expect_err("missing patch_file_path must surface as PatchFilePathMissing");
@@ -2480,4 +2500,33 @@ fn pkg_root_for_key_hoisted_missing_returns_none() {
 
     let result = super::pkg_root_for_key(&layout, Some(&map), &key);
     assert!(result.is_none(), "absent key surfaces None, got {result:?}");
+}
+
+#[test]
+fn allow_build_key_strips_version_for_registry_packages() {
+    // Registry depPaths reduce to the bare package name — the
+    // `allowBuilds` key a user would approve them under.
+    assert_eq!(allow_build_key_from_ignored_build("esbuild@0.17.0"), "esbuild");
+    assert_eq!(
+        allow_build_key_from_ignored_build("@pnpm.e2e/install-script-example@1.0.0"),
+        "@pnpm.e2e/install-script-example",
+    );
+}
+
+#[test]
+fn allow_build_key_ignores_patch_hash_when_deriving_name() {
+    // A `(patch_hash=…)` segment is dropped before the version is checked,
+    // so a patched registry package still reduces to its name.
+    assert_eq!(allow_build_key_from_ignored_build("esbuild@0.17.0(patch_hash=abcdef)"), "esbuild",);
+}
+
+#[test]
+fn allow_build_key_keeps_full_id_for_non_semver_artifacts() {
+    // Git / tarball artifacts have a non-semver "version", so the whole
+    // pkgId is the key — the name alone must not approve their builds.
+    let git = "foo@github.com/foo/bar#0123456789";
+    assert_eq!(allow_build_key_from_ignored_build(git), git);
+
+    let tarball = "https://example.com/foo.tgz";
+    assert_eq!(allow_build_key_from_ignored_build(tarball), tarball);
 }

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1,8 +1,8 @@
 use crate::{
     BuildVerifiersError, HoistedDependencies, InstallFrozenLockfile, InstallFrozenLockfileError,
     InstallWithFreshLockfile, InstallWithFreshLockfileError, LockfileVerificationOverride,
-    OptimisticRepeatInstallCheck, ResolvedPackages, UpdateSeedPolicy, build_resolution_verifiers,
-    check_optimistic_repeat_install,
+    OptimisticRepeatInstallCheck, RebuildOptions, ResolvedPackages, UpdateSeedPolicy,
+    build_resolution_verifiers, check_optimistic_repeat_install,
     optimistic_repeat_install::Decision as OptimisticRepeatInstallDecision,
 };
 use derive_more::{Display, Error};
@@ -454,19 +454,34 @@ where
 {
     /// Execute the subroutine.
     pub async fn run<Reporter: self::Reporter + 'static>(self) -> Result<(), InstallError> {
-        self.run_inner::<Reporter>(None).await
+        self.run_inner::<Reporter>(None, None).await
     }
 
     pub async fn run_with_lockfile_verification<Reporter: self::Reporter + 'static>(
         self,
         lockfile_verification_override: LockfileVerificationOverride<'a>,
     ) -> Result<(), InstallError> {
-        self.run_inner::<Reporter>(Some(lockfile_verification_override)).await
+        self.run_inner::<Reporter>(Some(lockfile_verification_override), None).await
+    }
+
+    /// Execute as a forced rebuild: take the frozen path against the
+    /// already-resolved lockfile + materialized `node_modules`, bypass the
+    /// "up to date" short-circuit, and re-run the lifecycle scripts of the
+    /// selected packages (or every build-needing package when
+    /// `rebuild.selected_names` is `None`). The caller must set
+    /// `frozen_lockfile: true`. Drives `pacquet rebuild` and the rebuild
+    /// step of `pacquet approve-builds`.
+    pub async fn run_rebuild<Reporter: self::Reporter + 'static>(
+        self,
+        rebuild: RebuildOptions,
+    ) -> Result<(), InstallError> {
+        self.run_inner::<Reporter>(None, Some(rebuild)).await
     }
 
     async fn run_inner<Reporter: self::Reporter + 'static>(
         self,
         lockfile_verification_override: Option<LockfileVerificationOverride<'a>>,
+        rebuild: Option<RebuildOptions>,
     ) -> Result<(), InstallError> {
         let Install {
             tarball_mem_cache,
@@ -1159,6 +1174,9 @@ where
             // build must rebuild it, even though the lockfile and layout are
             // unchanged. Mirrors pnpm's `runUnignoredDependencyBuilds`.
             && !has_newly_allowed_ignored_builds(modules, config)
+            // An explicit `pacquet rebuild` always re-runs the build phase,
+            // so it never short-circuits here.
+            && rebuild.is_none()
         {
             // Nothing to materialize means no fetch to overlap; verify
             // eagerly before the up-to-date early return.
@@ -1262,6 +1280,7 @@ where
                 node_linker,
                 tarball_mem_cache: Some(&tarball_mem_cache),
                 seed_skipped: modules_manifest.map(|manifest| manifest.skipped.clone()),
+                rebuild: rebuild.as_ref(),
             }
             .run::<Reporter>()
             .await

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -468,13 +468,19 @@ where
     /// already-resolved lockfile + materialized `node_modules`, bypass the
     /// "up to date" short-circuit, and re-run the lifecycle scripts of the
     /// selected packages (or every build-needing package when
-    /// `rebuild.selected_names` is `None`). The caller must set
-    /// `frozen_lockfile: true`. Drives `pacquet rebuild` and the rebuild
-    /// step of `pacquet approve-builds`.
+    /// `rebuild.selected_names` is `None`). Drives `pacquet rebuild` and
+    /// the rebuild step of `pacquet approve-builds`.
+    ///
+    /// # Panics
+    ///
+    /// Panics unless `frozen_lockfile` is set: a rebuild must take the
+    /// frozen path, since the fresh-resolve path drops the rebuild
+    /// selection and would silently degrade to a plain install.
     pub async fn run_rebuild<Reporter: self::Reporter + 'static>(
         self,
         rebuild: RebuildOptions,
     ) -> Result<(), InstallError> {
+        assert!(self.frozen_lockfile, "run_rebuild requires frozen_lockfile = true");
         self.run_inner::<Reporter>(None, Some(rebuild)).await
     }
 

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -176,6 +176,11 @@ where
     /// prefetch in flight.
     pub tarball_mem_cache: Option<&'a Arc<MemCache>>,
     pub seed_skipped: Option<Vec<String>>,
+    /// Forced-rebuild selection threaded from `pacquet rebuild` /
+    /// `approve-builds`; `None` for a normal install. Forwarded to
+    /// `run_build_phase`'s `BuildPhaseInputs`. See
+    /// [`crate::RebuildOptions`].
+    pub rebuild: Option<&'a crate::RebuildOptions>,
 }
 
 /// Error type of [`InstallFrozenLockfile`].
@@ -401,6 +406,10 @@ pub(crate) struct BuildPhaseInputs<'a> {
     /// and when no public-hoist pattern is set.
     pub(crate) publicly_hoisted_for_post_build: &'a [String],
     pub(crate) logged_methods: &'a AtomicU8,
+    /// Forced-rebuild selection threaded from `pacquet rebuild` /
+    /// `approve-builds`; `None` for a normal install. See
+    /// [`crate::RebuildOptions`].
+    pub(crate) rebuild: Option<&'a crate::RebuildOptions>,
 }
 
 /// Run dependency lifecycle scripts, report ignored builds, and
@@ -438,6 +447,7 @@ pub(crate) fn run_build_phase<Reporter: self::Reporter>(
         is_hoisted,
         publicly_hoisted_for_post_build,
         logged_methods,
+        rebuild,
     } = inputs;
 
     let patches = resolve_snapshot_patches(config, patch_groups, snapshots)?;
@@ -483,6 +493,7 @@ pub(crate) fn run_build_phase<Reporter: self::Reporter>(
         ignore_scripts: config.ignore_scripts,
         import_method: config.package_import_method,
         logged_methods,
+        rebuild,
     }
     .run::<Reporter>()
     .map_err(BuildPhaseError::BuildModules)?;
@@ -580,6 +591,7 @@ where
             node_linker,
             tarball_mem_cache,
             seed_skipped,
+            rebuild,
         } = self;
 
         let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
@@ -1296,6 +1308,7 @@ where
             is_hoisted,
             publicly_hoisted_for_post_build: &publicly_hoisted_for_post_build,
             logged_methods,
+            rebuild,
         })
         .map_err(InstallFrozenLockfileError::BuildPhase)?;
 

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1876,6 +1876,9 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 is_hoisted,
                 publicly_hoisted_for_post_build: &publicly_hoisted_for_post_build,
                 logged_methods,
+                // The fresh-resolve path never serves an explicit
+                // `pacquet rebuild`; rebuilds always take the frozen path.
+                rebuild: None,
             },
         )
         .map_err(InstallWithFreshLockfileError::BuildPhase)?;

--- a/pacquet/crates/workspace-manifest-writer/Cargo.toml
+++ b/pacquet/crates/workspace-manifest-writer/Cargo.toml
@@ -18,13 +18,13 @@ indexmap     = { workspace = true }
 miette       = { workspace = true }
 serde        = { workspace = true }
 serde-saphyr = { workspace = true }
+tempfile     = { workspace = true }
 yaml_serde   = { workspace = true }
 yamlpatch    = { workspace = true }
 yamlpath     = { workspace = true }
 
 [dev-dependencies]
-insta    = { workspace = true }
-tempfile = { workspace = true }
+insta = { workspace = true }
 
 [lints]
 workspace = true

--- a/pacquet/crates/workspace-manifest-writer/src/edit.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/edit.rs
@@ -75,6 +75,51 @@ pub(crate) fn add_config_dependency(
     Ok(true)
 }
 
+/// Upsert one `name → bool` entry into the top-level `allowBuilds:` block,
+/// creating the block if absent. Returns whether anything changed. Mirrors
+/// the `allowBuilds` half of pnpm's
+/// [`writeSettings`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/writer/src/index.ts),
+/// which `pnpm approve-builds` calls with each approved package set to
+/// `true` and each denied/unselected package set to `false`.
+pub(crate) fn add_allow_build(
+    manifest: &mut Manifest,
+    name: &str,
+    value: bool,
+) -> Result<bool, Box<yamlpatch::Error>> {
+    const BLOCK: &str = "allowBuilds";
+    let text = manifest.text();
+    let changed = if let Some(mapping) = locate(text, &[BLOCK]) {
+        if mapping.entries.iter().any(|entry| entry.key == name) {
+            // Already present with the same value — a true no-op, so don't
+            // rewrite the file (which would bump its mtime).
+            if manifest.allow_builds.as_ref().and_then(|builds| builds.get(name)) == Some(&value) {
+                return Ok(false);
+            }
+            let new_text = replace_scalar_at(text, &[BLOCK], name, value.into())?;
+            manifest.set_text(new_text);
+        } else {
+            let new_text = insert_rendered_entry_at(text, &[BLOCK], name, render_bool(value));
+            manifest.set_text(new_text);
+        }
+        true
+    } else {
+        let block = format!("{BLOCK}:\n  {}: {}\n", render::render_value(name), render_bool(value));
+        let new_text = insert_top_level_block(manifest, BLOCK, &block);
+        manifest.set_text(new_text);
+        manifest.top_level_keys =
+            render::target_order(&manifest.top_level_keys, &[BLOCK.to_string()]);
+        true
+    };
+    // Keep the decoded view in sync so later upserts in the same write see
+    // this entry (for both no-op detection and block-presence checks).
+    manifest.allow_builds.get_or_insert_with(IndexMap::new).insert(name.to_string(), value);
+    Ok(changed)
+}
+
+fn render_bool(value: bool) -> &'static str {
+    if value { "true" } else { "false" }
+}
+
 /// Where a catalog's entries live (or should be created) in the manifest.
 enum Target {
     /// The top-level `catalog:` shorthand for the default catalog.
@@ -239,6 +284,18 @@ fn replace_value_at(
     dep: &str,
     specifier: &str,
 ) -> Result<String, Box<yamlpatch::Error>> {
+    replace_scalar_at(text, path, dep, yaml_serde::Value::from(specifier))
+}
+
+/// [`replace_value_at`] for an arbitrary scalar value, so non-string blocks
+/// (e.g. `allowBuilds`'s booleans) can reuse the same comment-preserving
+/// splice.
+fn replace_scalar_at(
+    text: &str,
+    path: &[&str],
+    dep: &str,
+    value: yaml_serde::Value,
+) -> Result<String, Box<yamlpatch::Error>> {
     let document =
         Document::new(text.to_string()).map_err(yamlpatch::Error::from).map_err(Box::new)?;
     let components: Vec<Component> = path
@@ -247,10 +304,7 @@ fn replace_value_at(
         .chain(std::iter::once(dep))
         .map(|key| Component::Key(key.into()))
         .collect();
-    let patch = Patch {
-        route: Route::from(components),
-        operation: Op::Replace(yaml_serde::Value::from(specifier)),
-    };
+    let patch = Patch { route: Route::from(components), operation: Op::Replace(value) };
     let patched = yamlpatch::apply_yaml_patches(&document, &[patch]).map_err(Box::new)?;
     Ok(patched.source().to_string())
 }
@@ -265,6 +319,13 @@ fn insert_entry(text: &str, target: &Target, dep: &str, specifier: &str) -> Stri
 /// [`insert_entry`] addressed by an explicit mapping path, so non-catalog
 /// blocks (e.g. `configDependencies`) can reuse the reorder-aware splice.
 fn insert_entry_at(text: &str, path: &[&str], dep: &str, specifier: &str) -> String {
+    insert_rendered_entry_at(text, path, dep, &render::render_value(specifier))
+}
+
+/// [`insert_entry_at`] for an already-rendered value text, so non-string
+/// blocks (e.g. `allowBuilds`'s `true` / `false`) can reuse the
+/// reorder-aware splice without going through [`render::render_value`].
+fn insert_rendered_entry_at(text: &str, path: &[&str], dep: &str, value_text: &str) -> String {
     let mapping = locate(text, path).expect("mapping exists");
     let existing: Vec<String> = mapping.entries.iter().map(|entry| entry.key.clone()).collect();
     let order = render::target_order(&existing, &[dep.to_string()]);
@@ -274,7 +335,7 @@ fn insert_entry_at(text: &str, path: &[&str], dep: &str, specifier: &str) -> Str
         "{}{}: {}\n",
         " ".repeat(mapping.entry_indent),
         render::render_value(dep),
-        render::render_value(specifier),
+        value_text,
     );
     let offset = if position == 0 {
         mapping.body_start

--- a/pacquet/crates/workspace-manifest-writer/src/edit.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/edit.rs
@@ -81,11 +81,7 @@ pub(crate) fn add_config_dependency(
 /// [`writeSettings`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/writer/src/index.ts),
 /// which `pnpm approve-builds` calls with each approved package set to
 /// `true` and each denied/unselected package set to `false`.
-pub(crate) fn add_allow_build(
-    manifest: &mut Manifest,
-    name: &str,
-    value: bool,
-) -> Result<bool, Box<yamlpatch::Error>> {
+pub(crate) fn add_allow_build(manifest: &mut Manifest, name: &str, value: bool) -> bool {
     const BLOCK: &str = "allowBuilds";
     let text = manifest.text();
     let changed = if let Some(mapping) = locate(text, &[BLOCK]) {
@@ -93,9 +89,9 @@ pub(crate) fn add_allow_build(
             // Already present with the same value — a true no-op, so don't
             // rewrite the file (which would bump its mtime).
             if manifest.allow_builds.as_ref().and_then(|builds| builds.get(name)) == Some(&value) {
-                return Ok(false);
+                return false;
             }
-            let new_text = replace_scalar_at(text, &[BLOCK], name, value.into())?;
+            let new_text = replace_bool_value_at(text, &[BLOCK], name, value);
             manifest.set_text(new_text);
         } else {
             let new_text = insert_rendered_entry_at(text, &[BLOCK], name, render_bool(value));
@@ -113,7 +109,7 @@ pub(crate) fn add_allow_build(
     // Keep the decoded view in sync so later upserts in the same write see
     // this entry (for both no-op detection and block-presence checks).
     manifest.allow_builds.get_or_insert_with(IndexMap::new).insert(name.to_string(), value);
-    Ok(changed)
+    changed
 }
 
 fn render_bool(value: bool) -> &'static str {
@@ -444,6 +440,8 @@ struct Mapping {
 /// One direct child entry of a mapping.
 struct EntryPos {
     key: String,
+    /// Byte offset where this entry's line begins.
+    line_start: usize,
     /// Byte offset just past this entry's line (after its newline).
     line_end: usize,
     /// Byte offset where this entry's whole sub-block ends (for nested maps).
@@ -486,13 +484,54 @@ fn structural_indent(content: &str) -> Option<usize> {
 }
 
 /// The mapping-key a structural line declares (`key:` or `key: value`), if any.
+///
+/// The key/value delimiter is the first `:` that ends the line or is followed
+/// by whitespace — a `:` inside the value, or inside a key (quoted or not,
+/// e.g. an `allowBuilds` artifact key like `foo@https://example.com/foo.tgz`),
+/// is not the delimiter. Splitting on the first `:` would truncate such keys.
 fn line_key(content: &str) -> Option<String> {
     let trimmed = content.trim_start();
-    let key = trimmed.split_once(':')?.0.trim_end();
+    let delimiter = structural_colon_index(trimmed)?;
+    let key = trimmed[..delimiter].trim_end();
     if key.is_empty() {
         return None;
     }
     Some(strip_quotes(key))
+}
+
+/// Byte offset of the YAML key/value delimiter in `line`: the first `:` that
+/// ends the line or is followed by whitespace. A `:` inside a value or key
+/// (e.g. `foo@https://...`) is not the delimiter.
+fn structural_colon_index(line: &str) -> Option<usize> {
+    let bytes = line.as_bytes();
+    (0..bytes.len())
+        .find(|&idx| bytes[idx] == b':' && bytes.get(idx + 1).is_none_or(u8::is_ascii_whitespace))
+}
+
+/// Rewrite the scalar value of `key`'s existing entry under `path` in place,
+/// preserving the key's text/quoting and any trailing comment. Used for
+/// `allowBuilds` instead of the `yamlpatch` route, which rejects a key
+/// containing `:` (an artifact pkgId such as `foo@https://example.com/foo.tgz`).
+fn replace_bool_value_at(text: &str, path: &[&str], key: &str, value: bool) -> String {
+    let mapping = locate(text, path).expect("mapping exists");
+    let entry = mapping.entries.iter().find(|entry| entry.key == key).expect("entry exists");
+    let line = &text[entry.line_start..entry.line_end];
+    let content = line.strip_suffix('\n').unwrap_or(line);
+    let indent_len = content.len() - content.trim_start().len();
+    let colon = indent_len
+        + structural_colon_index(&content[indent_len..]).expect("entry line has a delimiter");
+    let key_text = content[..colon].trim_end();
+    // Preserve any trailing comment after the value token.
+    let after = content[colon + 1..].trim_start();
+    let value_end = after.find(char::is_whitespace).unwrap_or(after.len());
+    let trailing = &after[value_end..];
+    let new_line = format!("{key_text}: {}{trailing}\n", render_bool(value));
+
+    let mut out = String::with_capacity(text.len());
+    out.push_str(&text[..entry.line_start]);
+    out.push_str(&new_line);
+    out.push_str(&text[entry.line_end..]);
+    out
 }
 
 fn strip_quotes(key: &str) -> String {
@@ -563,7 +602,12 @@ fn collect_entries(all: &[Line<'_>], from: usize, to: usize, entry_indent: usize
                 })
                 .unwrap_or(to);
             let block_end = all.get(block_end_idx).map_or(all[to - 1].end, |line| line.start);
-            entries.push(EntryPos { key, line_end: all[idx].end, block_end });
+            entries.push(EntryPos {
+                key,
+                line_start: all[idx].start,
+                line_end: all[idx].end,
+                block_end,
+            });
             idx = block_end_idx;
         } else {
             idx += 1;

--- a/pacquet/crates/workspace-manifest-writer/src/lib.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/lib.rs
@@ -18,7 +18,11 @@
 //! [`reorderRecursive`]: https://github.com/pnpm/pnpm/blob/e7e99f04e4/workspace/workspace-manifest-writer/src/index.ts#L290-L313
 //! [`propagateBlankLinesToNewPairs`]: https://github.com/pnpm/pnpm/blob/e7e99f04e4/workspace/workspace-manifest-writer/src/index.ts#L347-L385
 
-use std::{fs, io, path::Path};
+use std::{
+    fs,
+    io::{self, Write as _},
+    path::Path,
+};
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;
@@ -97,7 +101,7 @@ pub fn update_workspace_manifest(
         return Ok(());
     }
 
-    fs::write(&path, manifest.into_text())
+    write_atomic(&path, &manifest.into_text())
         .map_err(|source| UpdateWorkspaceManifestError::Write { path, source })
 }
 
@@ -128,7 +132,7 @@ pub fn set_config_dependency(
         return Ok(());
     }
 
-    fs::write(&path, manifest.into_text())
+    write_atomic(&path, &manifest.into_text())
         .map_err(|source| UpdateWorkspaceManifestError::Write { path, source })
 }
 
@@ -167,6 +171,25 @@ where
         return Ok(());
     }
 
-    fs::write(&path, manifest.into_text())
+    write_atomic(&path, &manifest.into_text())
         .map_err(|source| UpdateWorkspaceManifestError::Write { path, source })
+}
+
+/// Write `contents` to `path` atomically: a sibling temp file in the same
+/// directory is written, flushed to disk, and renamed over `path`. The
+/// rename replaces the destination's directory entry, so a
+/// `pnpm-workspace.yaml` that is a symlink is overwritten rather than
+/// followed, and a crash mid-write cannot leave a torn manifest. Mirrors
+/// pnpm's `writeFileAtomic` use in
+/// [`updateWorkspaceManifest`](https://github.com/pnpm/pnpm/blob/e7e99f04e4/workspace/workspace-manifest-writer/src/index.ts#L32).
+fn write_atomic(path: &Path, contents: &str) -> io::Result<()> {
+    let dir = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+    tmp.write_all(contents.as_bytes())?;
+    tmp.as_file().sync_all()?;
+    tmp.persist(path).map_err(|err| err.error)?;
+    Ok(())
 }

--- a/pacquet/crates/workspace-manifest-writer/src/lib.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/lib.rs
@@ -140,9 +140,12 @@ pub fn set_config_dependency(
 ///
 /// `entries` is iterated in its own order; pass an ordered map for a
 /// deterministic result.
-pub fn set_allow_builds<'a, I>(dir: &Path, entries: I) -> Result<(), UpdateWorkspaceManifestError>
+pub fn set_allow_builds<'a, Entries>(
+    dir: &Path,
+    entries: Entries,
+) -> Result<(), UpdateWorkspaceManifestError>
 where
-    I: IntoIterator<Item = (&'a str, bool)>,
+    Entries: IntoIterator<Item = (&'a str, bool)>,
 {
     let path = dir.join(WORKSPACE_MANIFEST_FILENAME);
 

--- a/pacquet/crates/workspace-manifest-writer/src/lib.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/lib.rs
@@ -131,3 +131,39 @@ pub fn set_config_dependency(
     fs::write(&path, manifest.into_text())
         .map_err(|source| UpdateWorkspaceManifestError::Write { path, source })
 }
+
+/// Upsert `name → bool` entries into `dir`'s `pnpm-workspace.yaml`
+/// `allowBuilds:` block (creating the file/block if absent), preserving the
+/// rest of the document's formatting, and write the file back only when
+/// something actually changed. Used by `pnpm approve-builds` to record
+/// which dependencies may (`true`) or may not (`false`) run build scripts.
+///
+/// `entries` is iterated in its own order; pass an ordered map for a
+/// deterministic result.
+pub fn set_allow_builds<'a, I>(dir: &Path, entries: I) -> Result<(), UpdateWorkspaceManifestError>
+where
+    I: IntoIterator<Item = (&'a str, bool)>,
+{
+    let path = dir.join(WORKSPACE_MANIFEST_FILENAME);
+
+    let original = match fs::read_to_string(&path) {
+        Ok(text) => Some(text),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => None,
+        Err(source) => return Err(UpdateWorkspaceManifestError::Read { path, source }),
+    };
+
+    let mut manifest = Manifest::parse(original.as_deref())
+        .map_err(|source| UpdateWorkspaceManifestError::Parse { path: path.clone(), source })?;
+
+    let mut changed = false;
+    for (name, value) in entries {
+        changed |= edit::add_allow_build(&mut manifest, name, value)
+            .map_err(|source| UpdateWorkspaceManifestError::Edit { path: path.clone(), source })?;
+    }
+    if !changed {
+        return Ok(());
+    }
+
+    fs::write(&path, manifest.into_text())
+        .map_err(|source| UpdateWorkspaceManifestError::Write { path, source })
+}

--- a/pacquet/crates/workspace-manifest-writer/src/lib.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/lib.rs
@@ -164,8 +164,7 @@ where
 
     let mut changed = false;
     for (name, value) in entries {
-        changed |= edit::add_allow_build(&mut manifest, name, value)
-            .map_err(|source| UpdateWorkspaceManifestError::Edit { path: path.clone(), source })?;
+        changed |= edit::add_allow_build(&mut manifest, name, value);
     }
     if !changed {
         return Ok(());

--- a/pacquet/crates/workspace-manifest-writer/src/model.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/model.rs
@@ -21,6 +21,10 @@ pub(crate) struct Manifest {
     /// here — they're only consulted to detect a no-op write of an
     /// already-present clean specifier.
     pub(crate) config_dependencies: Option<IndexMap<String, String>>,
+    /// `allowBuilds:` boolean entries. Consulted to detect a no-op write
+    /// of an already-present value (and kept in sync as entries are
+    /// upserted during a single `pnpm approve-builds` write).
+    pub(crate) allow_builds: Option<IndexMap<String, bool>>,
 }
 
 #[derive(Default, Deserialize)]
@@ -31,6 +35,19 @@ struct CatalogData {
     catalogs: Option<IndexMap<String, IndexMap<String, String>>>,
     #[serde(default, rename = "configDependencies")]
     config_dependencies: Option<IndexMap<String, ConfigDepValue>>,
+    #[serde(default, rename = "allowBuilds")]
+    allow_builds: Option<IndexMap<String, AllowBuildValue>>,
+}
+
+/// An `allowBuilds` value, tolerant of the string form pnpm also accepts
+/// (a version spec) so decoding a manifest that uses it doesn't fail. Only
+/// the boolean shape is retained — the only shape `pnpm approve-builds`
+/// writes.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum AllowBuildValue {
+    Bool(bool),
+    Other(serde::de::IgnoredAny),
 }
 
 /// A `configDependencies` value, tolerant of the legacy object form so
@@ -57,6 +74,7 @@ impl Manifest {
                 catalog: None,
                 catalogs: None,
                 config_dependencies: None,
+                allow_builds: None,
             });
         }
 
@@ -74,6 +92,15 @@ impl Manifest {
                 })
                 .collect()
         });
+        let allow_builds = data.allow_builds.map(|entries| {
+            entries
+                .into_iter()
+                .filter_map(|(name, value)| match value {
+                    AllowBuildValue::Bool(allowed) => Some((name, allowed)),
+                    AllowBuildValue::Other(_) => None,
+                })
+                .collect()
+        });
 
         Ok(Manifest {
             text,
@@ -81,6 +108,7 @@ impl Manifest {
             catalog: data.catalog,
             catalogs: data.catalogs,
             config_dependencies,
+            allow_builds,
         })
     }
 

--- a/pacquet/crates/workspace-manifest-writer/src/tests.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/tests.rs
@@ -328,3 +328,29 @@ fn set_allow_builds_replaces_a_symlinked_manifest_without_following_it() {
         "allowBuilds:\n  esbuild: true\n",
     );
 }
+
+#[test]
+fn allow_builds_upserts_a_key_containing_a_colon() {
+    // Artifact allow-build keys keep the full pkgId, which contains `:`
+    // (e.g. a tarball/git URL). The upsert must find and toggle the
+    // existing entry instead of appending a duplicate — which a
+    // first-colon line scan would do by truncating the key.
+    let key = "foo@https://example.com/foo.tgz";
+    let original = format!("allowBuilds:\n  '{key}': false\n");
+    let out = run_allow_builds(Some(&original), &[(key, true)]).expect("file written");
+    assert_eq!(out, format!("allowBuilds:\n  '{key}': true\n"));
+    assert_eq!(out.matches(key).count(), 1, "exactly one entry, no duplicate: {out}");
+}
+
+#[test]
+fn allow_builds_creates_and_round_trips_a_colon_key() {
+    let key = "foo@https://example.com/foo.tgz";
+    let created = run_allow_builds(None, &[(key, true)]).expect("file written");
+    assert!(created.contains(key), "key written verbatim: {created}");
+    // Re-upserting the same value is a no-op (the entry is found, not duplicated).
+    let same = run_allow_builds(Some(&created), &[(key, true)]);
+    assert_eq!(same.as_deref(), Some(created.as_str()), "idempotent: {created}");
+    // Toggling flips the existing entry rather than appending a duplicate.
+    let toggled = run_allow_builds(Some(&created), &[(key, false)]).expect("written");
+    assert_eq!(toggled.matches(key).count(), 1, "no duplicate after toggle: {toggled}");
+}

--- a/pacquet/crates/workspace-manifest-writer/src/tests.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/tests.rs
@@ -276,7 +276,7 @@ fn allow_builds_creates_block_when_absent() {
 #[test]
 fn allow_builds_writes_boolean_values_unquoted() {
     let out = run_allow_builds(None, &[("esbuild", true), ("@scope/pkg", false)]);
-    assert_eq!(out.as_deref(), Some("allowBuilds:\n  '@scope/pkg': false\n  esbuild: true\n"),);
+    assert_eq!(out.as_deref(), Some("allowBuilds:\n  '@scope/pkg': false\n  esbuild: true\n"));
 }
 
 #[test]

--- a/pacquet/crates/workspace-manifest-writer/src/tests.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/tests.rs
@@ -301,3 +301,30 @@ fn allow_builds_preserves_other_keys_and_comments() {
     assert!(out.contains("storeDir: ../store"), "existing key preserved");
     assert!(out.contains("allowBuilds:\n  esbuild: true"), "block appended");
 }
+
+#[cfg(unix)]
+#[test]
+fn set_allow_builds_replaces_a_symlinked_manifest_without_following_it() {
+    use std::os::unix::fs::symlink;
+
+    let dir = TempDir::new().expect("temp dir");
+    // A file outside the manifest that a malicious symlink would target.
+    let outside = dir.path().join("outside.txt");
+    fs::write(&outside, "").expect("seed outside file");
+    let manifest = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+    symlink(&outside, &manifest).expect("symlink the manifest to the outside file");
+
+    crate::set_allow_builds(dir.path(), [("esbuild", true)]).expect("update succeeds");
+
+    // The atomic rename replaces the symlink's directory entry, so the
+    // outside target is untouched and the manifest is now a regular file.
+    assert_eq!(fs::read_to_string(&outside).expect("read outside"), "");
+    assert!(
+        !fs::symlink_metadata(&manifest).expect("stat manifest").file_type().is_symlink(),
+        "the manifest should no longer be a symlink",
+    );
+    assert_eq!(
+        fs::read_to_string(&manifest).expect("read manifest"),
+        "allowBuilds:\n  esbuild: true\n",
+    );
+}

--- a/pacquet/crates/workspace-manifest-writer/src/tests.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/tests.rs
@@ -254,3 +254,50 @@ fn config_dependency_noop_when_unchanged_returns_false() {
         "changing the specifier should report a change",
     );
 }
+
+/// Run `set_allow_builds` against `original` (when `Some`) and return the
+/// resulting file contents (or `None` when no file exists afterward).
+fn run_allow_builds(original: Option<&str>, entries: &[(&str, bool)]) -> Option<String> {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+    if let Some(text) = original {
+        fs::write(&path, text).expect("seed manifest");
+    }
+    crate::set_allow_builds(dir.path(), entries.iter().copied()).expect("update succeeds");
+    fs::read_to_string(&path).ok()
+}
+
+#[test]
+fn allow_builds_creates_block_when_absent() {
+    let out = run_allow_builds(None, &[("esbuild", true)]);
+    assert_eq!(out.as_deref(), Some("allowBuilds:\n  esbuild: true\n"));
+}
+
+#[test]
+fn allow_builds_writes_boolean_values_unquoted() {
+    let out = run_allow_builds(None, &[("esbuild", true), ("@scope/pkg", false)]);
+    assert_eq!(out.as_deref(), Some("allowBuilds:\n  '@scope/pkg': false\n  esbuild: true\n"),);
+}
+
+#[test]
+fn allow_builds_upserts_existing_entry() {
+    let original = "allowBuilds:\n  esbuild: false\n";
+    let out = run_allow_builds(Some(original), &[("esbuild", true)]);
+    assert_eq!(out.as_deref(), Some("allowBuilds:\n  esbuild: true\n"));
+}
+
+#[test]
+fn allow_builds_no_op_when_unchanged_keeps_file() {
+    let original = "allowBuilds:\n  esbuild: true\n";
+    let out = run_allow_builds(Some(original), &[("esbuild", true)]);
+    assert_eq!(out.as_deref(), Some(original));
+}
+
+#[test]
+fn allow_builds_preserves_other_keys_and_comments() {
+    let original = "# top comment\nstoreDir: ../store\n";
+    let out = run_allow_builds(Some(original), &[("esbuild", true)]).expect("file written");
+    assert!(out.contains("# top comment"), "comment preserved");
+    assert!(out.contains("storeDir: ../store"), "existing key preserved");
+    assert!(out.contains("allowBuilds:\n  esbuild: true"), "block appended");
+}

--- a/pacquet/crates/workspace-manifest-writer/src/tests.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/tests.rs
@@ -354,3 +354,27 @@ fn allow_builds_creates_and_round_trips_a_colon_key() {
     let toggled = run_allow_builds(Some(&created), &[(key, false)]).expect("written");
     assert_eq!(toggled.matches(key).count(), 1, "no duplicate after toggle: {toggled}");
 }
+
+#[test]
+fn allow_builds_rejects_a_manifest_with_duplicate_keys() {
+    // A repo-controlled manifest with duplicate `allowBuilds` keys is
+    // rejected at parse time (`DuplicateMappingKey`), so `set_allow_builds`
+    // errors and writes nothing rather than rewriting only the first
+    // occurrence and leaving the effective (last) value untouched. The
+    // policy change fails loudly instead of being silently bypassed.
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+    let original = "allowBuilds:\n  esbuild: false\n  esbuild: true\n";
+    fs::write(&path, original).expect("seed manifest");
+
+    let result = crate::set_allow_builds(dir.path(), [("esbuild", false)]);
+    assert!(
+        matches!(result, Err(crate::UpdateWorkspaceManifestError::Parse { .. })),
+        "duplicate keys must be rejected, got {result:?}",
+    );
+    assert_eq!(
+        fs::read_to_string(&path).expect("read manifest"),
+        original,
+        "the manifest is left unchanged when the update fails",
+    );
+}


### PR DESCRIPTION
## Summary

Ports pnpm's build-policy commands to the Rust `pacquet/` port:

- **`pacquet ignored-builds`** — prints the packages whose build scripts were blocked, byte-for-byte matching pnpm's output.
- **`pacquet approve-builds [<pkg>…] [!<pkg>…] [--all] [--global]`** — approves or denies pending dependency builds (interactive checkbox + confirm via `dialoguer`, or positional args), writes `allowBuilds` to `pnpm-workspace.yaml`, clears the decided entries from `.modules.yaml`, then rebuilds the approved packages.
- **`pacquet rebuild [<pkg>…] [--pending]`** (alias `rb`) — re-runs dependency build scripts, forcing the selected packages past the side-effects "already built" cache while still honoring the `allowBuilds` policy.

These were pnpm-only (TypeScript) commands; this PR is the pacquet-side port, so no changeset is needed.

## Squash Commit Body

```text
Port pnpm's build-policy commands to the Rust CLI: `ignored-builds`,
`approve-builds`, and the `rebuild` flow they build on.

The rebuild flow reuses the frozen-install pipeline: a `RebuildOptions`
selection threads from `Install::run_rebuild` through `InstallFrozenLockfile`
and `run_build_phase` into `BuildModules`, where selected packages bypass the
`is_built` side-effects gate and the "up to date" short-circuit is skipped.
The allow-build policy is still honored, matching `pnpm rebuild`.

`approve-builds` re-loads config after writing settings so the rebuild's
policy reflects the new `allowBuilds`; the frozen path then rewrites
`.modules.yaml` to pnpm's exact end state (decided entries removed, undecided
kept). Adds a boolean-aware `set_allow_builds` writer to
`workspace-manifest-writer` and an `allow_build_key_from_ignored_build`
helper (port of `@pnpm/building.policy` key derivation).

Tested with unit tests for the helper and writer plus mocked-registry
integration tests covering listing, approve, deny, and rebuild.

Pacquet-side port of existing TypeScript commands; no changeset needed.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. _(Port of existing TS commands into pacquet; TS side already has them.)_
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `rebuild` CLI command to rerun ignored builds by explicit packages or pending selection.
  * Added `ignored-builds` CLI command to report blocked builds (auto + explicitly ignored).
  * Added `approve-builds` CLI command to approve/deny pending builds, including interactive selection and `--all`.
  * Added `allowBuilds` read/write support in `pnpm-workspace.yaml` with safe boolean upserts (including keys containing `:`).
* **Bug Fixes**
  * Forced rebuilds no longer skip due to lockfile “up to date” short-circuit.
* **Tests**
  * Expanded integration and unit coverage for `rebuild`, `ignored-builds`, `approve-builds`, and allow-build key derivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->