### PR TITLE
fix(dlx): make failed-install cache cleanup best-effort on Windows

### DIFF
--- a/.changeset/dlx-resilient-cache-cleanup.md
+++ b/.changeset/dlx-resilient-cache-cleanup.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/exec.commands": patch
+"pnpm": patch
+---
+
+Fixed a Windows flakiness in `pnpm dlx` where a failed install could surface a spurious `EBUSY: resource busy or locked` error. The cleanup of a partially-populated dlx cache is now best-effort with retries and no longer masks the original error.

--- a/pnpm11/exec/commands/src/dlx.ts
+++ b/pnpm11/exec/commands/src/dlx.ts
@@ -212,8 +212,13 @@ export async function handler (
         cachedDir = completedDir
       } else {
         // Drop the partially-populated cache so a subsequent dlx run starts
-        // clean instead of reusing a broken install.
-        await fs.promises.rm(cachedDir, { recursive: true, force: true })
+        // clean instead of reusing a broken install. This is best-effort: on
+        // Windows the just-run install scripts (or antivirus) can briefly hold
+        // handles on freshly written files, so retry with backoff and never let
+        // a cleanup failure mask the original error. A leftover prepare dir is
+        // harmless — it has a unique name and findCache only trusts the `pkg`
+        // symlink.
+        await fs.promises.rm(cachedDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 }).catch(() => {})
         throw err
       }
     }

--- a/pnpm11/exec/commands/src/dlx.ts
+++ b/pnpm11/exec/commands/src/dlx.ts
@@ -17,6 +17,7 @@ import { createHexHash } from '@pnpm/crypto.hash'
 import { PnpmError } from '@pnpm/error'
 import { createResolver, makeResolutionStrict } from '@pnpm/installing.client'
 import { add } from '@pnpm/installing.commands'
+import { logger } from '@pnpm/logger'
 import { readPackageJsonFromDir } from '@pnpm/pkg-manifest.reader'
 import { parseWantedDependency } from '@pnpm/resolving.parse-wanted-dependency'
 import type { PackageManifest, PnpmSettings, SupportedArchitectures } from '@pnpm/types'
@@ -214,11 +215,20 @@ export async function handler (
         // Drop the partially-populated cache so a subsequent dlx run starts
         // clean instead of reusing a broken install. This is best-effort: on
         // Windows the just-run install scripts (or antivirus) can briefly hold
-        // handles on freshly written files, so retry with backoff and never let
-        // a cleanup failure mask the original error. A leftover prepare dir is
-        // harmless — it has a unique name and findCache only trusts the `pkg`
+        // handles on freshly written files, so retry with backoff. A cleanup
+        // failure must never mask the original install error, which is the one
+        // worth surfacing — log it and rethrow err. A leftover prepare dir is
+        // harmless: it has a unique name and findCache only trusts the `pkg`
         // symlink.
-        await fs.promises.rm(cachedDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 }).catch(() => {})
+        try {
+          await fs.promises.rm(cachedDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+        } catch (cleanupErr) {
+          logger.warn({
+            error: cleanupErr as Error,
+            message: `Failed to clean up the dlx cache directory at "${cachedDir}"`,
+            prefix: cachedDir,
+          })
+        }
         throw err
       }
     }


### PR DESCRIPTION
## Summary

On Windows, `pnpm dlx` intermittently fails with a spurious `EBUSY: resource busy or locked, rmdir ...` error (seen frequently in CI for `dlx prompts to approve ignored builds when invoked with a commands map`).

The path in the error is always inside the dlx **prepare dir** (`cachedDir`), which is removed in exactly one place — the install-failure catch block in `exec/commands/src/dlx.ts`:

```ts
await fs.promises.rm(cachedDir, { recursive: true, force: true })
throw err
```

Two problems:

1. **The cleanup masks the real error.** When something in the `try` (install → `approve-builds` rebuild → `symlinkDir`) throws — typically a transient Windows file lock from the just-run install script's child process or antivirus scanning freshly written files — the catch runs this `rm`. With no retries it dies on the *same* lingering handle and throws `EBUSY`, replacing the original error before line `throw err` is reached.
2. **The cleanup has no retries**, so it fails far more often than it needs to.

The fix makes the cleanup best-effort: `.catch(() => {})` so the original error always surfaces, plus `maxRetries`/`retryDelay` so the removal itself succeeds once the transient lock clears. A leftover prepare dir is harmless — it has a unique name and `findCache` only trusts the `pkg` symlink.

## Squash Commit Body

```text
On Windows, `pnpm dlx` could fail with a spurious "EBUSY: resource busy
or locked, rmdir" error. When an install into the dlx cache failed, the
catch block removed the partially-populated prepare dir with
fs.promises.rm(cachedDir, { recursive: true, force: true }). That call
has no retries, so it died on the same lingering Windows handle (a
just-run install script's child process, or antivirus scanning freshly
written files) and threw EBUSY — which then replaced and masked the
original install error.

Make the cleanup best-effort: swallow its failure so the original error
always surfaces, and add maxRetries/retryDelay so the removal itself
succeeds once the transient lock clears. A leftover prepare dir is
harmless — it has a unique name and findCache only trusts the `pkg`
symlink.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  <!-- pacquet's dlx already removes the prepare dir best-effort (`let _ = fs::remove_dir_all(...)`) and returns the original error, so the user-visible behavior already matches. The only delta is the retry, which has no observable effect there since cleanup failures are already swallowed; not mirrored. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests.
  <!-- The defect is a Windows-only filesystem-lock race in a cleanup path; there is no portable, deterministic way to assert it in a unit test without a filesystem-error injection seam this package doesn't have. -->
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows flakiness in `pnpm dlx` by preventing spurious “resource busy” errors during failed/partial installs
  * Improved dlx cache cleanup after failed installs to be best-effort with retries/backoff, while preserving the original install failure error

<!-- end of auto-generated comment: release notes by coderabbit.ai -->