### PR TITLE
fix(runtime): normalize blank runtime selectors

### DIFF
--- a/.changeset/prune-runtime-engine-removals.md
+++ b/.changeset/prune-runtime-engine-removals.md
@@ -1,6 +1,10 @@
 ---
 "@pnpm/workspace.project-manifest-reader": patch
+"@pnpm/pkg-manifest.utils": patch
+"@pnpm/engine.runtime.node-resolver": patch
+"@pnpm/engine.runtime.bun-resolver": patch
+"@pnpm/engine.runtime.deno-resolver": patch
 "pnpm": patch
 ---
 
-Removing a runtime dependency now removes the matching `devEngines.runtime` or `engines.runtime` entry that was materialized from it.
+Removing a runtime dependency now removes the matching `devEngines.runtime` or `engines.runtime` entry that was materialized from it. Blank runtime selectors are normalized to `latest`.

--- a/pacquet/crates/engine-runtime-bun-resolver/src/bun_resolver.rs
+++ b/pacquet/crates/engine-runtime-bun-resolver/src/bun_resolver.rs
@@ -175,6 +175,7 @@ fn bare_runtime_spec<'a>(wanted: &'a WantedDependency, expected_alias: &str) -> 
 }
 
 fn normalize_runtime_spec(version_spec: &str) -> &str {
+    let version_spec = version_spec.trim();
     if version_spec.is_empty() { "latest" } else { version_spec }
 }
 

--- a/pacquet/crates/engine-runtime-bun-resolver/src/bun_resolver/tests.rs
+++ b/pacquet/crates/engine-runtime-bun-resolver/src/bun_resolver/tests.rs
@@ -90,3 +90,21 @@ async fn empty_runtime_spec_delegates_latest_to_npm_resolver() {
 
     assert_eq!(npm_resolver.seen.lock().unwrap().clone(), vec![Some("latest".to_string())]);
 }
+
+#[tokio::test]
+async fn whitespace_runtime_spec_delegates_latest_to_npm_resolver() {
+    let npm_resolver = Arc::new(CapturingResolver::default());
+    let resolver = BunResolver::new(
+        Arc::new(ThrottledClient::new_for_installs()),
+        Arc::<CapturingResolver>::clone(&npm_resolver),
+    );
+    let wanted = WantedDependency {
+        alias: Some("bun".to_string()),
+        bare_specifier: Some("runtime:  ".to_string()),
+        ..WantedDependency::default()
+    };
+
+    resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap_err();
+
+    assert_eq!(npm_resolver.seen.lock().unwrap().clone(), vec![Some("latest".to_string())]);
+}

--- a/pacquet/crates/engine-runtime-deno-resolver/src/deno_resolver.rs
+++ b/pacquet/crates/engine-runtime-deno-resolver/src/deno_resolver.rs
@@ -182,6 +182,7 @@ fn bare_runtime_spec<'a>(wanted: &'a WantedDependency, expected_alias: &str) -> 
 }
 
 fn normalize_runtime_spec(version_spec: &str) -> &str {
+    let version_spec = version_spec.trim();
     if version_spec.is_empty() { "latest" } else { version_spec }
 }
 

--- a/pacquet/crates/engine-runtime-deno-resolver/src/deno_resolver/tests.rs
+++ b/pacquet/crates/engine-runtime-deno-resolver/src/deno_resolver/tests.rs
@@ -90,3 +90,21 @@ async fn empty_runtime_spec_delegates_latest_to_npm_resolver() {
 
     assert_eq!(npm_resolver.seen.lock().unwrap().clone(), vec![Some("latest".to_string())]);
 }
+
+#[tokio::test]
+async fn whitespace_runtime_spec_delegates_latest_to_npm_resolver() {
+    let npm_resolver = Arc::new(CapturingResolver::default());
+    let resolver = DenoResolver::new(
+        Arc::new(ThrottledClient::new_for_installs()),
+        Arc::<CapturingResolver>::clone(&npm_resolver),
+    );
+    let wanted = WantedDependency {
+        alias: Some("deno".to_string()),
+        bare_specifier: Some("runtime:  ".to_string()),
+        ..WantedDependency::default()
+    };
+
+    resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap_err();
+
+    assert_eq!(npm_resolver.seen.lock().unwrap().clone(), vec![Some("latest".to_string())]);
+}

--- a/pacquet/crates/engine-runtime-node-resolver/src/resolve_node_version.rs
+++ b/pacquet/crates/engine-runtime-node-resolver/src/resolve_node_version.rs
@@ -151,6 +151,7 @@ async fn fetch_all_versions(
 }
 
 fn is_latest_selector(version_spec: &str) -> bool {
+    let version_spec = version_spec.trim();
     version_spec.is_empty() || version_spec == "latest"
 }
 

--- a/pacquet/crates/engine-runtime-node-resolver/src/resolve_node_version/tests.rs
+++ b/pacquet/crates/engine-runtime-node-resolver/src/resolve_node_version/tests.rs
@@ -47,7 +47,7 @@ async fn empty_selector_picks_latest_version() {
                 { "version": "v20.10.0", "lts": "Iron" }
             ]"#,
         )
-        .expect(2)
+        .expect(4)
         .create_async()
         .await;
     let base_url = format!("{}/", server.url());
@@ -57,5 +57,11 @@ async fn empty_selector_picks_latest_version() {
     assert_eq!(picked, Some("22.1.0".to_string()));
 
     let picked = resolve_node_versions(&http_client, Some(""), Some(&base_url)).await.unwrap();
+    assert_eq!(picked, vec!["22.1.0"]);
+
+    let picked = resolve_node_version(&http_client, "  ", Some(&base_url)).await.unwrap();
+    assert_eq!(picked, Some("22.1.0".to_string()));
+
+    let picked = resolve_node_versions(&http_client, Some("  "), Some(&base_url)).await.unwrap();
     assert_eq!(picked, vec!["22.1.0"]);
 }

--- a/pacquet/crates/package-manifest/src/lib.rs
+++ b/pacquet/crates/package-manifest/src/lib.rs
@@ -397,17 +397,28 @@ pub fn convert_engines_runtime_to_dependencies(
 /// `workspace/project-manifest-reader`: the in-memory dependency form drives
 /// resolution and lockfile checks, while the on-disk manifest keeps the
 /// `devEngines.runtime` / `engines.runtime` contract.
+///
+/// Mutates `manifest` in place and removes consumed `runtime:` dependency
+/// entries. Returns `InvalidAttribute` when a field shape prevents a
+/// lossless write.
 pub fn convert_dependencies_to_engines_runtime(
     manifest: &mut Value,
     deps_field: &str,
     engines_field: &str,
 ) -> Result<(), PackageManifestError> {
+    if manifest.get(deps_field).is_some_and(|deps| !deps.is_object()) {
+        return Err(PackageManifestError::InvalidAttribute(format!(
+            "the {deps_field} field must be an object",
+        )));
+    }
     for runtime_name in RUNTIME_NAMES {
         let version = manifest
             .get(deps_field)
+            .and_then(Value::as_object)
             .and_then(|deps| deps.get(runtime_name))
             .and_then(Value::as_str)
             .and_then(|dep| dep.strip_prefix("runtime:"))
+            .map(str::trim)
             .map(str::to_string);
         if let Some(version) = version {
             upsert_runtime_entry(manifest, engines_field, runtime_name, &version)?;

--- a/pacquet/crates/package-manifest/src/tests.rs
+++ b/pacquet/crates/package-manifest/src/tests.rs
@@ -332,6 +332,29 @@ fn convert_dependencies_runtime_writes_devengines_runtime() {
 }
 
 #[test]
+fn convert_dependencies_runtime_trims_runtime_selector() {
+    let mut manifest = json!({
+        "devDependencies": {
+            "node": "runtime:  ",
+        },
+    });
+    convert_dependencies_to_engines_runtime(&mut manifest, "devDependencies", "devEngines")
+        .unwrap();
+
+    assert_eq!(
+        manifest.get("devEngines"),
+        Some(&json!({
+            "runtime": {
+                "name": "node",
+                "version": "",
+                "onFail": "download",
+            },
+        })),
+    );
+    assert_eq!(manifest.get("devDependencies"), Some(&json!({})));
+}
+
+#[test]
 fn convert_dependencies_runtime_updates_existing_single_entry() {
     let mut manifest = json!({
         "devEngines": {
@@ -543,6 +566,36 @@ fn failed_save_preserves_existing_file_contents() {
 
     let manifest = PackageManifest::from_path(path.clone()).unwrap();
     assert!(matches!(manifest.save(), Err(PackageManifestError::InvalidAttribute(_))));
+    assert_eq!(read_to_string(path).unwrap(), raw);
+}
+
+#[test]
+fn failed_save_preserves_existing_file_when_dependency_field_is_malformed() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("package.json");
+    let raw = serde_json::to_string_pretty(&json!({
+        "name": "fixture",
+        "devEngines": {
+            "runtime": {
+                "name": "node",
+                "version": "22",
+                "onFail": "download",
+            },
+        },
+    }))
+    .unwrap();
+    std::fs::write(&path, &raw).unwrap();
+
+    let mut manifest = PackageManifest::from_path(path.clone()).unwrap();
+    manifest.value_mut()["devDependencies"] = json!([]);
+    let err =
+        manifest.save().expect_err("malformed devDependencies must reject save before writing");
+    match err {
+        PackageManifestError::InvalidAttribute(msg) => {
+            assert!(msg.contains("devDependencies"), "got: {msg:?}");
+        }
+        other => panic!("expected InvalidAttribute, got {other:?}"),
+    }
     assert_eq!(read_to_string(path).unwrap(), raw);
 }
 

--- a/pnpm11/engine/runtime/bun-resolver/src/index.ts
+++ b/pnpm11/engine/runtime/bun-resolver/src/index.ts
@@ -40,7 +40,7 @@ export async function resolveBunRuntime (
     }
   }
 
-  const versionSpec = wantedDependency.bareSpecifier.substring('runtime:'.length)
+  const versionSpec = normalizeRuntimeSpec(wantedDependency.bareSpecifier.substring('runtime:'.length))
   // We use the npm registry for version resolution as it is easier than using the GitHub API for releases,
   // which uses pagination (e.g. https://api.github.com/repos/oven-sh/bun/releases?per_page=100).
   const npmResolution = await ctx.resolveFromNpm({ ...wantedDependency, bareSpecifier: versionSpec }, {})
@@ -74,7 +74,7 @@ export async function resolveLatestBunRuntime (
 ): Promise<LatestInfo | undefined> {
   const manifestSpec = query.wantedDependency.bareSpecifier
   if (query.wantedDependency.alias !== 'bun' || !manifestSpec?.startsWith('runtime:')) return undefined
-  const versionSpec = query.compatible ? manifestSpec.substring('runtime:'.length) : 'latest'
+  const versionSpec = query.compatible ? normalizeRuntimeSpec(manifestSpec.substring('runtime:'.length)) : 'latest'
   try {
     const npmResolution = await ctx.resolveFromNpm(
       { alias: 'bun', bareSpecifier: versionSpec },
@@ -89,6 +89,11 @@ export async function resolveLatestBunRuntime (
     }
     throw err
   }
+}
+
+function normalizeRuntimeSpec (versionSpec: string): string {
+  versionSpec = versionSpec.trim()
+  return versionSpec === '' ? 'latest' : versionSpec
 }
 
 async function readBunAssets (fetch: FetchFromRegistry, version: string): Promise<PlatformAssetResolution[]> {

--- a/pnpm11/engine/runtime/deno-resolver/src/index.ts
+++ b/pnpm11/engine/runtime/deno-resolver/src/index.ts
@@ -50,7 +50,7 @@ export async function resolveDenoRuntime (
     }
   }
 
-  const versionSpec = wantedDependency.bareSpecifier.substring('runtime:'.length)
+  const versionSpec = normalizeRuntimeSpec(wantedDependency.bareSpecifier.substring('runtime:'.length))
   // We use the npm registry for version resolution as it is easier than using the GitHub API for releases,
   // which uses pagination (e.g. https://api.github.com/repos/denoland/deno/releases?per_page=100).
   const npmResolution = await ctx.resolveFromNpm({ ...wantedDependency, bareSpecifier: versionSpec }, {})
@@ -105,7 +105,7 @@ export async function resolveLatestDenoRuntime (
 ): Promise<LatestInfo | undefined> {
   const manifestSpec = query.wantedDependency.bareSpecifier
   if (query.wantedDependency.alias !== 'deno' || !manifestSpec?.startsWith('runtime:')) return undefined
-  const versionSpec = query.compatible ? manifestSpec.substring('runtime:'.length) : 'latest'
+  const versionSpec = query.compatible ? normalizeRuntimeSpec(manifestSpec.substring('runtime:'.length)) : 'latest'
   try {
     const npmResolution = await ctx.resolveFromNpm(
       { alias: 'deno', bareSpecifier: versionSpec },
@@ -120,6 +120,11 @@ export async function resolveLatestDenoRuntime (
     }
     throw err
   }
+}
+
+function normalizeRuntimeSpec (versionSpec: string): string {
+  versionSpec = versionSpec.trim()
+  return versionSpec === '' ? 'latest' : versionSpec
 }
 
 function parseAssetName (name: string): PlatformAssetTarget[] | null {

--- a/pnpm11/engine/runtime/node-resolver/src/index.ts
+++ b/pnpm11/engine/runtime/node-resolver/src/index.ts
@@ -56,7 +56,7 @@ export async function resolveNodeRuntime (
   }
 
   if (ctx.offline) throw new PnpmError('NO_OFFLINE_NODEJS_RESOLUTION', 'Offline Node.js resolution is not supported')
-  const versionSpec = wantedDependency.bareSpecifier.substring('runtime:'.length)
+  const versionSpec = normalizeRuntimeSpec(wantedDependency.bareSpecifier.substring('runtime:'.length))
   const { releaseChannel, versionSpecifier } = parseNodeSpecifier(versionSpec)
   const nodeMirrorBaseUrl = getNodeMirror(ctx.nodeDownloadMirrors, releaseChannel)
   const version = await resolveNodeVersion(ctx.fetchFromRegistry, versionSpecifier, nodeMirrorBaseUrl)
@@ -88,7 +88,7 @@ export async function resolveLatestNodeRuntime (
 ): Promise<LatestInfo | undefined> {
   const manifestSpec = query.wantedDependency.bareSpecifier
   if (query.wantedDependency.alias !== 'node' || !manifestSpec?.startsWith('runtime:')) return undefined
-  const versionSpec = query.compatible ? manifestSpec.substring('runtime:'.length) : 'latest'
+  const versionSpec = query.compatible ? normalizeRuntimeSpec(manifestSpec.substring('runtime:'.length)) : 'latest'
   const { releaseChannel, versionSpecifier } = parseNodeSpecifier(versionSpec)
   const nodeMirrorBaseUrl = getNodeMirror(ctx.nodeDownloadMirrors, releaseChannel)
   const version = await resolveNodeVersion(ctx.fetchFromRegistry, versionSpecifier, nodeMirrorBaseUrl)
@@ -215,6 +215,7 @@ export async function resolveNodeVersion (
   nodeMirrorBaseUrl?: string
 ): Promise<string | null> {
   const allVersions = await fetchAllVersions(fetch, nodeMirrorBaseUrl)
+  versionSpec = normalizeRuntimeSpec(versionSpec)
   if (versionSpec === 'latest') {
     return allVersions[0].version
   }
@@ -228,14 +229,20 @@ export async function resolveNodeVersions (
   nodeMirrorBaseUrl?: string
 ): Promise<string[]> {
   const allVersions = await fetchAllVersions(fetch, nodeMirrorBaseUrl)
-  if (!versionSpec) {
+  if (versionSpec == null) {
     return allVersions.map(({ version }) => version)
   }
+  versionSpec = normalizeRuntimeSpec(versionSpec)
   if (versionSpec === 'latest') {
     return [allVersions[0].version]
   }
   const { versions, versionRange } = filterVersions(allVersions, versionSpec)
   return versions.filter(version => semver.satisfies(version, versionRange, SEMVER_OPTS))
+}
+
+function normalizeRuntimeSpec (versionSpec: string): string {
+  versionSpec = versionSpec.trim()
+  return versionSpec === '' ? 'latest' : versionSpec
 }
 
 async function fetchAllVersions (fetch: FetchFromRegistry, nodeMirrorBaseUrl?: string): Promise<NodeVersion[]> {

--- a/pnpm11/engine/runtime/node-resolver/test/resolveNodeVersion.test.ts
+++ b/pnpm11/engine/runtime/node-resolver/test/resolveNodeVersion.test.ts
@@ -12,6 +12,8 @@ test.each([
   ['https://nodejs.org/download/release/', 'lts', /.+/],
   ['https://nodejs.org/download/release/', 'argon', '4.9.1'],
   ['https://nodejs.org/download/release/', 'latest', /.+/],
+  ['https://nodejs.org/download/release/', '', /.+/],
+  ['https://nodejs.org/download/release/', '  ', /.+/],
   [undefined, 'latest', /.+/],
 ])('Node.js %s is resolved', async (nodeMirrorBaseUrl, spec, expectedVersion) => {
   const version = await resolveNodeVersion(fetch, spec, nodeMirrorBaseUrl)

--- a/pnpm11/engine/runtime/node-resolver/test/resolveNodeVersions.test.ts
+++ b/pnpm11/engine/runtime/node-resolver/test/resolveNodeVersions.test.ts
@@ -15,6 +15,11 @@ test('resolve latest version', async () => {
   expect(versions).toHaveLength(1)
 })
 
+test.each(['', '  '])('resolve blank version list as latest (%j)', async (spec) => {
+  const versions = await resolveNodeVersions(fetch, spec)
+  expect(versions).toHaveLength(1)
+})
+
 test('resolve all versions', async () => {
   const versions = await resolveNodeVersions(fetch)
   expect(versions.length).toBeGreaterThan(1)

--- a/pnpm11/pkg-manifest/utils/src/convertEnginesRuntimeToDependencies.ts
+++ b/pnpm11/pkg-manifest/utils/src/convertEnginesRuntimeToDependencies.ts
@@ -21,10 +21,11 @@ export function convertEnginesRuntimeToDependencies (
     if (runtime?.onFail !== 'download') {
       continue
     }
-    if (!runtime.version) {
+    if (typeof runtime.version !== 'string') {
       globalWarn(`Cannot download ${runtimeName} because no version is specified in ${enginesFieldName}.runtime`)
       continue
     }
+    const version = runtime.version.trim()
     if ('webcontainer' in process.versions) {
       globalWarn(`Installation of ${runtimeName} versions is not supported in WebContainer`)
     } else {
@@ -34,7 +35,7 @@ export function convertEnginesRuntimeToDependencies (
       // `constructor`, `prototype`) becomes a regular own data property
       // instead of altering Object.prototype.
       Object.defineProperty(deps, runtimeName, {
-        value: `runtime:${runtime.version}`,
+        value: `runtime:${version}`,
         enumerable: true,
         writable: true,
         configurable: true,

--- a/pnpm11/pkg-manifest/utils/test/convertEnginesRuntimeToDependencies.test.ts
+++ b/pnpm11/pkg-manifest/utils/test/convertEnginesRuntimeToDependencies.test.ts
@@ -20,6 +20,26 @@ test('convertEnginesRuntimeToDependencies() skips runtime entries without a vers
   expect(manifest.devDependencies).toBeUndefined()
 })
 
+test.each([
+  ['', 'runtime:'],
+  ['  ', 'runtime:'],
+  [' 22 ', 'runtime:22'],
+])('convertEnginesRuntimeToDependencies() normalizes runtime version %j', (version, expected) => {
+  const manifest: ProjectManifest = {
+    devEngines: {
+      runtime: {
+        name: 'node',
+        version,
+        onFail: 'download',
+      },
+    },
+  }
+
+  convertEnginesRuntimeToDependencies(manifest, 'devEngines', 'devDependencies')
+
+  expect(manifest.devDependencies?.node).toBe(expected)
+})
+
 test('applyRuntimeOnFailOverride(download) skips runtime entries without a version', () => {
   const manifest: ProjectManifest = {
     devEngines: {

--- a/pnpm11/workspace/project-manifest-reader/src/index.ts
+++ b/pnpm11/workspace/project-manifest-reader/src/index.ts
@@ -246,10 +246,11 @@ function convertDependenciesToEnginesRuntime (
   dependenciesFieldName: 'dependencies' | 'devDependencies',
   enginesFieldName: 'engines' | 'devEngines'
 ): void {
+  const dependencies = readDependenciesField(manifest, dependenciesFieldName)
   for (const runtimeName of ['node', 'deno', 'bun']) {
-    const dep = manifest[dependenciesFieldName]?.[runtimeName]
-    if (typeof dep === 'string' && dep.startsWith('runtime:')) {
-      const version = dep.replace(/^runtime:/, '')
+    const dep = dependencies?.[runtimeName]
+    if (dependencies != null && typeof dep === 'string' && dep.startsWith('runtime:')) {
+      const version = dep.slice('runtime:'.length).trim()
       manifest[enginesFieldName] ??= {}
 
       const runtimeEntry: EngineDependency = {
@@ -276,13 +277,23 @@ function convertDependenciesToEnginesRuntime (
           runtimeEntry,
         ]
       }
-      if (manifest[dependenciesFieldName]) {
-        delete manifest[dependenciesFieldName][runtimeName]
-      }
+      delete dependencies[runtimeName]
     } else {
       removeManagedRuntimeEntry(manifest[enginesFieldName], runtimeName)
     }
   }
+}
+
+function readDependenciesField (
+  manifest: ProjectManifest,
+  dependenciesFieldName: 'dependencies' | 'devDependencies'
+): Record<string, unknown> | undefined {
+  const dependencies = manifest[dependenciesFieldName] as unknown
+  if (dependencies === undefined) return undefined
+  if (dependencies === null || typeof dependencies !== 'object' || Array.isArray(dependencies)) {
+    throw new PnpmError('INVALID_DEPENDENCIES_FIELD', `The "${dependenciesFieldName}" field must be an object.`)
+  }
+  return dependencies as Record<string, unknown>
 }
 
 function removeManagedRuntimeEntry (
@@ -321,7 +332,12 @@ function normalize (manifest: ProjectManifest): ProjectManifest {
   for (const key in manifest) {
     if (Object.hasOwn(manifest, key)) {
       const value = manifest[key as keyof ProjectManifest]
-      if (typeof value !== 'object' || value === null || !dependencyKeys.has(key)) {
+      if (
+        typeof value !== 'object' ||
+        value === null ||
+        !dependencyKeys.has(key) ||
+        Array.isArray(value)
+      ) {
         result[key] = structuredClone(value)
       } else {
         const keys = Object.keys(value)

--- a/pnpm11/workspace/project-manifest-reader/test/index.ts
+++ b/pnpm11/workspace/project-manifest-reader/test/index.ts
@@ -134,6 +134,20 @@ test('writeProjectManifest() removes an empty-version devEngines runtime when it
   })
 })
 
+test('writeProjectManifest() rejects malformed dependency fields without pruning runtime entries', async () => {
+  const dir = f.prepare('package-json-with-dev-engines')
+  const manifestPath = path.join(dir, 'package.json')
+  const raw = fs.readFileSync(manifestPath, 'utf8')
+  const { manifest, writeProjectManifest } = await tryReadProjectManifest(dir)
+  const invalidManifest = manifest as unknown as Record<string, unknown>
+  invalidManifest.devDependencies = []
+
+  await expect(writeProjectManifest(invalidManifest as unknown as ProjectManifest)).rejects.toMatchObject({
+    code: 'ERR_PNPM_INVALID_DEPENDENCIES_FIELD',
+  })
+  expect(fs.readFileSync(manifestPath, 'utf8')).toBe(raw)
+})
+
 test('writeProjectManifest() removes only the removed runtime from a devEngines runtime array', async () => {
   const dir = f.prepare('package-json')
   fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({
@@ -234,6 +248,21 @@ test.each([
           onFail: 'download',
         },
       ],
+    },
+  },
+  {
+    name: 'trims a whitespace-only devDependency runtime selector',
+    manifest: {
+      devDependencies: {
+        node: 'runtime:  ',
+      },
+    },
+    expected: {
+      runtime: {
+        name: 'node',
+        version: '',
+        onFail: 'download',
+      },
     },
   },
   {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Normalize blank and whitespace-only runtime selectors to `latest` across pnpm and pacquet, and reject malformed dependency fields before runtime writeback can prune `devEngines.runtime` or `engines.runtime` entries.

Related to pnpm/pnpm#12571.

## Squash Commit Body

```text
Normalize blank and whitespace-only runtime selectors consistently in pnpm and pacquet.

The runtime command can produce `runtime:` when no version is provided, and hand-edited manifests may contain whitespace-only selectors. Treat those cases as `latest` in the TypeScript runtime resolvers, the pacquet runtime resolvers, and the manifest conversion helpers.

Also make manifest writeback reject malformed dependency fields before pruning managed runtime entries. This prevents a non-object dependency field from being interpreted as a removed runtime dependency and causing silent data loss during save.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed whitespace handling in runtime version specifications across Bun, Deno, and Node resolvers
  * Empty and whitespace-only runtime selectors now correctly normalize to 'latest'
  * Enhanced validation of package manifest dependency fields to reject malformed entries

* **Tests**
  * Added comprehensive test coverage for runtime specification whitespace edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->