### PR TITLE
fix(pnpr): reject unsafe htpasswd usernames

### DIFF
--- a/pnpr/crates/pnpr/src/auth.rs
+++ b/pnpr/crates/pnpr/src/auth.rs
@@ -88,6 +88,11 @@ pub(crate) fn validate_username(username: &str) -> Result<()> {
             reason: "username must not start or end with whitespace".to_string(),
         });
     }
+    if username.starts_with('#') {
+        return Err(RegistryError::BadRequest {
+            reason: "username must not start with '#'".to_string(),
+        });
+    }
     if contains_colon {
         return Err(RegistryError::BadRequest {
             reason: "username must not contain ':'".to_string(),
@@ -351,6 +356,8 @@ impl UserBackend for UserStore {
         username: &str,
         password: &str,
     ) -> Result<(UpsertOutcome, String)> {
+        validate_username(username)?;
+
         let existing_hash = {
             let users = self.users.lock().expect("UserStore mutex poisoned");
             users.get(username).cloned()
@@ -358,8 +365,6 @@ impl UserBackend for UserStore {
         if let Some(stored) = existing_hash {
             return verify_returning_user(username, password, stored).await;
         }
-
-        validate_username(username)?;
 
         // Brand-new user — check the registration cap before doing
         // the (expensive) bcrypt hash.
@@ -409,6 +414,10 @@ impl UserBackend for UserStore {
     }
 
     async fn verify(&self, username: &str, password: &str) -> Result<Option<String>> {
+        if validate_username(username).is_err() {
+            return Ok(None);
+        }
+
         let stored = {
             let users = self.users.lock().expect("UserStore mutex poisoned");
             users.get(username).cloned()
@@ -672,6 +681,13 @@ fn parse_htpasswd(raw: &str) -> std::result::Result<HashMap<String, String>, Str
         let hash = hash.trim();
         if user.is_empty() {
             return Err(format!("line {}: empty username", line_no + 1));
+        }
+        if let Err(err) = validate_username(user) {
+            let reason = match err {
+                RegistryError::BadRequest { reason } => reason,
+                err => err.to_string(),
+            };
+            return Err(format!("line {}: invalid username {user:?}: {reason}", line_no + 1));
         }
         if !is_supported_hash(hash) {
             return Err(format!(

--- a/pnpr/crates/pnpr/src/auth/libsql_backend.rs
+++ b/pnpr/crates/pnpr/src/auth/libsql_backend.rs
@@ -130,11 +130,11 @@ impl UserBackend for LibsqlAuth {
         username: &str,
         password: &str,
     ) -> Result<(UpsertOutcome, String)> {
+        validate_username(username)?;
+
         if let Some(stored) = self.stored_hash(username).await? {
             return verify_returning_user(username, password, stored).await;
         }
-
-        validate_username(username)?;
 
         // Brand-new user. The cheap pre-check avoids the (expensive) hash
         // when the cap is already full; the insert below re-checks the
@@ -222,6 +222,10 @@ impl UserBackend for LibsqlAuth {
     }
 
     async fn verify(&self, username: &str, password: &str) -> Result<Option<String>> {
+        if validate_username(username).is_err() {
+            return Ok(None);
+        }
+
         let Some(stored) = self.stored_hash(username).await? else {
             return Ok(None);
         };

--- a/pnpr/crates/pnpr/src/auth/libsql_backend/tests.rs
+++ b/pnpr/crates/pnpr/src/auth/libsql_backend/tests.rs
@@ -43,7 +43,7 @@ async fn add_or_login_rejects_invalid_username_before_insert() {
 }
 
 #[tokio::test]
-async fn add_or_login_allows_existing_legacy_username() {
+async fn add_or_login_rejects_existing_invalid_username() {
     let backend = local_backend(MaxUsers::Unlimited).await;
     let hash = bcrypt::hash("secret", 4).unwrap();
     backend
@@ -55,10 +55,10 @@ async fn add_or_login_allows_existing_legacy_username() {
         .await
         .unwrap();
 
-    let outcome = backend.add_or_login("alice ", "secret").await.unwrap();
+    let err = backend.add_or_login("alice ", "secret").await.unwrap_err();
 
-    assert!(matches!(outcome, (UpsertOutcome::LoggedIn, _)));
-    assert_eq!(outcome.1, "alice ");
+    assert_eq!(err.status_code(), axum::http::StatusCode::BAD_REQUEST);
+    assert!(backend.verify("alice ", "secret").await.unwrap().is_none());
 }
 
 #[tokio::test]

--- a/pnpr/crates/pnpr/src/auth/sqlx_backend.rs
+++ b/pnpr/crates/pnpr/src/auth/sqlx_backend.rs
@@ -2,9 +2,9 @@
 //! feature-gated `sqlx` drivers.
 
 use super::{
-    DEFAULT_BCRYPT_COST, MAX_USERNAME_CHARS, TokenBackend, TokenRecord, UpsertOutcome, UserBackend,
-    fresh_secret, hash_bcrypt, mint_token, sha256_hex, unix_seconds, validate_username,
-    verify_bcrypt, verify_returning_user,
+    DEFAULT_BCRYPT_COST, TokenBackend, TokenRecord, UpsertOutcome, UserBackend, fresh_secret,
+    hash_bcrypt, mint_token, sha256_hex, unix_seconds, validate_username, verify_bcrypt,
+    verify_returning_user,
 };
 use crate::{
     config::MaxUsers,
@@ -118,14 +118,12 @@ where
         username: &str,
         password: &str,
     ) -> Result<(UpsertOutcome, String)> {
-        validate_username_bounds(username)?;
+        validate_username(username)?;
 
         if let Some(stored) = with_auth_timeout(self.timeout, self.db.stored_user(username)).await?
         {
             return verify_returning_user(&stored.username, password, stored.bcrypt_hash).await;
         }
-
-        validate_username(username)?;
 
         match self.max_users {
             MaxUsers::Disabled => return Err(RegistryError::RegistrationDisabled),
@@ -158,7 +156,7 @@ where
     }
 
     async fn verify(&self, username: &str, password: &str) -> Result<Option<String>> {
-        if username_has_invalid_bounds(username) {
+        if validate_username(username).is_err() {
             return Ok(None);
         }
 
@@ -169,26 +167,6 @@ where
         let valid = verify_bcrypt(password.to_string(), stored.bcrypt_hash).await?;
         Ok(valid.then_some(stored.username))
     }
-}
-
-fn validate_username_bounds(username: &str) -> Result<()> {
-    if username.is_empty() {
-        return Err(RegistryError::BadRequest { reason: "username must not be empty".to_string() });
-    }
-    if username_too_long(username) {
-        return Err(RegistryError::BadRequest {
-            reason: format!("username must be at most {MAX_USERNAME_CHARS} characters"),
-        });
-    }
-    Ok(())
-}
-
-fn username_has_invalid_bounds(username: &str) -> bool {
-    username.is_empty() || username_too_long(username)
-}
-
-fn username_too_long(username: &str) -> bool {
-    username.chars().nth(MAX_USERNAME_CHARS).is_some()
 }
 
 #[async_trait]
@@ -945,6 +923,7 @@ fn timeout_seconds(timeout: Duration) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use super::super::MAX_USERNAME_CHARS;
     use super::*;
     use std::sync::Arc;
 
@@ -1229,7 +1208,9 @@ mod tests {
         );
         let overlong = "a".repeat(MAX_USERNAME_CHARS + 1);
 
-        assert_eq!(auth.verify("", "secret").await.unwrap(), None);
+        for username in ["", " alice", "alice ", "#alice", "alice:admin", "alice\nadmin"] {
+            assert_eq!(auth.verify(username, "secret").await.unwrap(), None);
+        }
         assert_eq!(auth.verify(&overlong, "secret").await.unwrap(), None);
         assert_eq!(stored_user_calls.load(Ordering::SeqCst), 0);
     }
@@ -1243,14 +1224,14 @@ mod tests {
             Duration::from_secs(30),
         );
 
-        let outcome = auth.add_or_login(" alice", "secret").await.unwrap();
+        let outcome = auth.add_or_login("alice", "secret").await.unwrap();
 
         assert!(matches!(outcome, (UpsertOutcome::LoggedIn, _)));
         assert_eq!(outcome.1, "Alice");
     }
 
     #[tokio::test]
-    async fn add_or_login_rejects_unbounded_usernames_without_db_lookup() {
+    async fn add_or_login_rejects_invalid_usernames_without_db_lookup() {
         let stored_user_calls = Arc::new(AtomicU64::new(0));
         let auth = SqlAuth::new(
             CountingLookupBackend { stored_user_calls: Arc::clone(&stored_user_calls) },
@@ -1259,14 +1240,16 @@ mod tests {
         );
         let overlong = "a".repeat(MAX_USERNAME_CHARS + 1);
 
-        let empty_err = auth.add_or_login("", "secret").await.unwrap_err();
-        assert!(
-            matches!(empty_err, RegistryError::BadRequest { reason } if reason == "username must not be empty")
-        );
-        let overlong_err = auth.add_or_login(&overlong, "secret").await.unwrap_err();
-        assert!(
-            matches!(overlong_err, RegistryError::BadRequest { reason } if reason == format!("username must be at most {MAX_USERNAME_CHARS} characters"))
-        );
+        for username in ["", " alice", "alice ", "#alice", "alice:admin", "alice\nadmin"] {
+            let err = auth.add_or_login(username, "secret").await.unwrap_err();
+            assert_eq!(
+                err.status_code(),
+                axum::http::StatusCode::BAD_REQUEST,
+                "expected {username:?} to be rejected",
+            );
+        }
+        let err = auth.add_or_login(&overlong, "secret").await.unwrap_err();
+        assert_eq!(err.status_code(), axum::http::StatusCode::BAD_REQUEST);
         assert_eq!(stored_user_calls.load(Ordering::SeqCst), 0);
     }
 

--- a/pnpr/crates/pnpr/src/auth/tests.rs
+++ b/pnpr/crates/pnpr/src/auth/tests.rs
@@ -11,6 +11,18 @@ use tokio::sync::Barrier;
 /// Production paths use [`DEFAULT_BCRYPT_COST`].
 const TEST_COST: u32 = 4;
 
+const INVALID_USERNAMES: &[&str] = &[
+    "",
+    " alice",
+    "alice ",
+    "#alice",
+    "alice:bob",
+    "alice\nbob",
+    "alice\rbob",
+    "alice\0bob",
+    "alice\u{7f}bob",
+];
+
 fn test_user_store() -> UserStore {
     UserStore {
         users: std::sync::Mutex::new(std::collections::HashMap::new()),
@@ -44,7 +56,7 @@ fn token_timestamp_to_sql_saturates_overflow() {
 
 #[test]
 fn username_validation_rejects_htpasswd_structural_characters() {
-    for username in ["", "alice:bob", "alice\nbob", "alice\rbob", "alice\0bob", "alice\u{7f}bob"] {
+    for username in INVALID_USERNAMES {
         let err = validate_username(username).unwrap_err();
         assert_eq!(
             err.status_code(),
@@ -69,8 +81,14 @@ fn username_validation_rejects_names_that_trim_differently() {
 #[tokio::test]
 async fn user_store_rejects_invalid_username_before_persisting() {
     let store = test_user_store();
-    let err = store.add_or_login("alice:bob", "secret").await.unwrap_err();
-    assert_eq!(err.status_code(), axum::http::StatusCode::BAD_REQUEST);
+    for username in INVALID_USERNAMES {
+        let err = store.add_or_login(username, "secret").await.unwrap_err();
+        assert_eq!(
+            err.status_code(),
+            axum::http::StatusCode::BAD_REQUEST,
+            "expected {username:?} to be rejected",
+        );
+    }
     assert!(
         store.users.lock().expect("UserStore mutex poisoned").is_empty(),
         "invalid username should be rejected before any persistence",
@@ -78,16 +96,28 @@ async fn user_store_rejects_invalid_username_before_persisting() {
 }
 
 #[tokio::test]
-async fn user_store_allows_existing_legacy_username_to_login() {
+async fn user_store_rejects_invalid_username_before_lookup() {
     let store = test_user_store();
-    let legacy = format!("{}:", "a".repeat(MAX_USERNAME_CHARS));
     let hash = bcrypt::hash("secret", TEST_COST).unwrap();
-    store.users.lock().expect("UserStore mutex poisoned").insert(legacy.clone(), hash);
+    {
+        let mut users = store.users.lock().expect("UserStore mutex poisoned");
+        for username in INVALID_USERNAMES {
+            users.insert((*username).to_string(), hash.clone());
+        }
+    }
 
-    let outcome = store.add_or_login(&legacy, "secret").await.unwrap();
-
-    assert!(matches!(outcome, (UpsertOutcome::LoggedIn, _)));
-    assert_eq!(outcome.1, legacy);
+    for username in INVALID_USERNAMES {
+        let err = store.add_or_login(username, "secret").await.unwrap_err();
+        assert_eq!(
+            err.status_code(),
+            axum::http::StatusCode::BAD_REQUEST,
+            "expected adduser for {username:?} to be rejected",
+        );
+        assert!(
+            store.verify(username, "secret").await.unwrap().is_none(),
+            "expected Basic auth for {username:?} to be rejected",
+        );
+    }
 }
 
 #[tokio::test]
@@ -236,6 +266,19 @@ fn parse_htpasswd_accepts_blank_and_comment_lines() {
     let map = parse_htpasswd(raw).unwrap();
     assert_eq!(map.len(), 1);
     assert!(map.contains_key("alice"));
+}
+
+#[test]
+fn parse_htpasswd_preserves_legacy_whitespace_normalization() {
+    let map = parse_htpasswd(" alice :$2y$10$abcdef\n").unwrap();
+    assert_eq!(map.get("alice").map(String::as_str), Some("$2y$10$abcdef"));
+}
+
+#[test]
+fn parse_htpasswd_rejects_invalid_usernames() {
+    for raw in [" #alice:$2y$10$abcdef\n", "alice\u{1}admin:$2y$10$abcdef\n"] {
+        assert!(parse_htpasswd(raw).is_err(), "expected {raw:?} to be rejected");
+    }
 }
 
 #[tokio::test]

--- a/pnpr/crates/pnpr/tests/auth_persistence.rs
+++ b/pnpr/crates/pnpr/tests/auth_persistence.rs
@@ -133,6 +133,51 @@ async fn user_and_token_survive_restart() {
     );
 }
 
+#[tokio::test]
+async fn invalid_usernames_do_not_change_htpasswd_across_restart() {
+    let auth_dir = TempDir::new().unwrap();
+    let storage = TempDir::new().unwrap();
+    let htpasswd = auth_dir.path().join("htpasswd");
+    let tokens_db = auth_dir.path().join("tokens.db");
+
+    let config =
+        persistent_config(storage.path().to_path_buf(), htpasswd.clone(), tokens_db.clone());
+    let auth = AuthState::load(&config.auth, &config.backend).await.expect("first boot");
+    let app = router_with_auth(config.clone(), auth);
+
+    let response = app
+        .clone()
+        .oneshot(put_json("/-/user/org.couchdb.user:alice", adduser_body("alice", "secret")))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let original_htpasswd = std::fs::read_to_string(&htpasswd).unwrap();
+
+    for (case, encoded_username, username) in [
+        ("newline", "alice%0Aadmin", "alice\nadmin"),
+        ("carriage return", "alice%0Dadmin", "alice\radmin"),
+        ("colon", "alice%3Aadmin", "alice:admin"),
+        ("comment marker", "%23alice", "#alice"),
+        ("leading whitespace", "%20alice", " alice"),
+        ("trailing whitespace", "alice%20", "alice "),
+    ] {
+        let path = format!("/-/user/org.couchdb.user:{encoded_username}");
+        let response =
+            app.clone().oneshot(put_json(&path, adduser_body(username, "secret"))).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{case} username");
+        assert_eq!(
+            std::fs::read_to_string(&htpasswd).unwrap(),
+            original_htpasswd,
+            "{case} username must not alter htpasswd",
+        );
+    }
+
+    drop(app);
+    let auth = AuthState::load(&config.auth, &config.backend).await.expect("reload after restart");
+    assert_eq!(auth.users.verify("alice", "secret").await.unwrap().as_deref(), Some("alice"));
+    assert_eq!(std::fs::read_to_string(&htpasswd).unwrap(), original_htpasswd);
+}
+
 /// Corrupt the htpasswd file → server returns a parse diagnostic on
 /// startup, not a silent empty user list. The acceptance criterion
 /// is that the operator sees an error rather than the server happily


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Reject unsafe pnpr usernames before they can be persisted to, or looked up from, htpasswd-style credential storage.

Usernames containing htpasswd delimiters, line breaks, control characters, comment markers, or edge whitespace are now rejected through the shared pnpr username validation path. The same validation now runs before existing-user lookup in the local htpasswd backend, the libsql backend, and the SQL backend, so pre-seeded unsafe records cannot be authenticated through Basic auth.

Related to GHSA-j5gw-4gg5-7hvp.

## Squash Commit Body

```text
Reject unsafe pnpr usernames before auth storage lookup or persistence.

The htpasswd backend serializes users as line-oriented username:hash records, so usernames containing structural characters must never reach the persistence boundary. Move shared username validation ahead of existing-user lookup, apply the same Basic-auth guard, and reject invalid usernames while parsing persisted htpasswd files.

Apply the same contract to the libsql and SQL auth backends so configured auth storage cannot authenticate username shapes that the local htpasswd backend rejects.

Add unit and persistence regression coverage for delimiter, line break, comment-marker, control-character, and edge-whitespace usernames.
```

## Checklist

- [x] No TypeScript CLI or `pacquet/` port is needed; this is pnpr-only registry auth behavior.
- [x] No changeset is needed; this is a Rust pnpr change and does not touch a published TypeScript package.
- [x] Added or updated tests.
- [x] Documentation update is not needed.

## Validation

```text
cargo test --locked -p pnpr auth
cargo test --locked -p pnpr --features backend-postgres sqlx_backend
cargo test --locked -p pnpr invalid_usernames_do_not_change_htpasswd_across_restart
cargo fmt --all -- --check
git diff --check
cargo clippy --locked -p pnpr --features backend-postgres --all-targets -- -D warnings
git push pre-push hook: passed TypeScript compile/lint, Rust fmt, workspace clippy, rustdoc, dylint, and taplo checks
```

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented consistent username validation across all authentication paths (registration, login, verification, and htpasswd parsing).
  * Invalid usernames—including those with leading/trailing whitespace, special characters, and problematic Unicode—are now immediately rejected with appropriate error messages.
  * Validation timing improved: username checks now occur before database operations, enhancing both security and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->