### PR TITLE
fix(pnpr): fail closed on invalid hosted tarball paths

### DIFF
--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -554,7 +554,24 @@ impl Store {
         let path = self.tarball_path(name, filename);
         let file = match fs::File::open(&path).await {
             Ok(f) => f,
-            Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                let package_dir = self.package_dir(name);
+                match fs::metadata(&package_dir).await {
+                    Ok(meta) if meta.is_dir() => return Ok(None),
+                    Ok(_) => {
+                        return Err(std::io::Error::new(
+                            ErrorKind::NotADirectory,
+                            format!(
+                                "package storage path is not a directory: {}",
+                                package_dir.display(),
+                            ),
+                        )
+                        .into());
+                    }
+                    Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
+                    Err(err) => return Err(err.into()),
+                }
+            }
             Err(err) => return Err(err.into()),
         };
         let len = file.metadata().await?.len();

--- a/pnpr/crates/pnpr/src/storage/tests.rs
+++ b/pnpr/crates/pnpr/src/storage/tests.rs
@@ -179,6 +179,24 @@ async fn removing_cached_tarball_removes_integrity_sidecar() {
 }
 
 #[tokio::test]
+async fn hosted_tarball_under_non_directory_package_path_is_an_error() {
+    let tmp = TempDir::new().unwrap();
+    let storage = storage_in(&tmp);
+    let name = pkg("foo");
+    let storage_root = tmp.path().join("storage");
+    fs::create_dir_all(&storage_root).await.unwrap();
+    fs::write(storage_root.join("foo"), b"not a directory").await.unwrap();
+
+    let Err(err) = storage.open_hosted_tarball(&name, "foo-1.0.0.tgz").await else {
+        panic!("expected hosted tarball open to fail");
+    };
+    match err {
+        RegistryError::Io(err) => assert_eq!(err.kind(), ErrorKind::NotADirectory),
+        other => panic!("expected I/O error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn temp_file_creation_retries_existing_candidate_without_overwriting() {
     let tmp = TempDir::new().unwrap();
     let final_path = tmp.path().join("foo-1.0.0.tgz");


### PR DESCRIPTION
## Summary

Fixes the Windows Rust CI failure in `Rust CI / Test / windows`: https://github.com/pnpm/pnpm/actions/runs/27947896199/job/82704486449

When opening a hosted tarball returns `NotFound`, pnpr now verifies the package path before treating the tarball as a miss. If the package path exists but is not a directory, pnpr returns a storage error and fails closed instead of falling through to the upstream proxy. This is pnpr server-only behavior; no TypeScript CLI or pacquet port is needed.

## Squash Commit Body

```text
Windows can surface opening <storage>/foo/foo-1.0.0.tgz when <storage>/foo is a regular file as NotFound rather than NotADirectory. The tarball handler treated NotFound as a hosted-store miss, so it fetched from the configured upstream even though the hosted store was in a faulted state.

Re-check the package path before classifying NotFound as a miss. Missing package directories and real directories still behave as cache misses; a non-directory package path returns a storage error, so the tarball handler fails closed before proxying. Add a storage regression covering this classification and keep the existing integration test as the endpoint guard.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error diagnostics for package storage. The system now validates package directory structure when accessing tarballs and provides clearer error messages when a directory path exists but is misconfigured, helping users quickly identify and resolve filesystem issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->