### PR TITLE
feat(pacquet-cli): add prune command

### DIFF
--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -16,6 +16,7 @@ pub mod patch;
 pub mod patch_commit;
 pub mod patch_remove;
 pub(crate) mod patch_state;
+pub mod prune;
 pub mod rebuild;
 pub mod recursive;
 pub mod remove;
@@ -57,6 +58,7 @@ use pacquet_reporter::{
 use patch::PatchArgs;
 use patch_commit::PatchCommitArgs;
 use patch_remove::PatchRemoveArgs;
+use prune::PruneArgs;
 use rebuild::RebuildArgs;
 use remove::RemoveArgs;
 use restart::RestartArgs;
@@ -222,6 +224,8 @@ pub enum CliCommand {
     Import(ImportArgs),
     /// Deduplicate packages in the lockfile
     Dedupe(DedupeArgs),
+    /// Remove extraneous packages
+    Prune(PruneArgs),
 }
 
 impl CliArgs {
@@ -308,6 +312,7 @@ impl CliArgs {
                 | CliCommand::Dlx(_)
                 | CliCommand::Import(_)
                 | CliCommand::Dedupe(_)
+                | CliCommand::Prune(_)
                 | CliCommand::Create(_)
                 | CliCommand::Runtime(_)
                 // `rebuild` drives the frozen-install pipeline and emits
@@ -691,6 +696,59 @@ impl CliArgs {
                     ReporterType::Silent => Box::pin(args.run::<SilentReporter>(command_state)),
                 }
             }
+            CliCommand::Prune(args) => Box::pin(async move {
+                let cfg = config()?;
+                cfg.modules_cache_max_age = 0;
+                cfg.ignore_scripts = cfg.ignore_scripts || args.ignore_scripts;
+                let workspace_root =
+                    cfg.workspace_dir.clone().unwrap_or_else(|| dir_ref.clone());
+                let workspace_root = std::fs::canonicalize(&workspace_root)
+                    .into_diagnostic()
+                    .wrap_err("canonicalize workspace root for prune safety check")?;
+                let modules_dir = std::fs::canonicalize(&cfg.modules_dir)
+                    .into_diagnostic()
+                    .wrap_err("canonicalize modules_dir for prune safety check")?;
+                if !modules_dir.starts_with(&workspace_root) {
+                    return Err(miette::miette!(
+                        "refusing prune: modules_dir ({}) is outside workspace root ({})",
+                        cfg.modules_dir.display(),
+                        workspace_root.display(),
+                    ));
+                }
+                let virtual_store_dir =
+                    std::fs::canonicalize(cfg.effective_virtual_store_dir())
+                        .into_diagnostic()
+                        .wrap_err("canonicalize virtual_store_dir for prune safety check")?;
+                if !virtual_store_dir.starts_with(&modules_dir) {
+                    return Err(miette::miette!(
+                        "refusing prune: virtual_store_dir ({}) is outside modules_dir ({})",
+                        cfg.effective_virtual_store_dir().display(),
+                        cfg.modules_dir.display(),
+                    ));
+                }
+                let (config_root, package_manager_to_sync) =
+                    derive_config_root_and_package_manager_to_sync(cfg, dir_ref)
+                        .wrap_err("derive workspace root and package manager policy")?;
+                let pipeline = PrunePipeline {
+                    args,
+                    cfg,
+                    config_root,
+                    package_manager_to_sync,
+                    manifest_path: manifest_path_ref.clone(),
+                };
+                match reporter {
+                    ReporterType::Default | ReporterType::AppendOnly => {
+                        Box::pin(pipeline.run::<DefaultReporter>()).await?;
+                    }
+                    ReporterType::Ndjson => {
+                        Box::pin(pipeline.run::<NdjsonReporter>()).await?;
+                    }
+                    ReporterType::Silent => {
+                        Box::pin(pipeline.run::<SilentReporter>()).await?;
+                    }
+                }
+                Ok(())
+            })
             CliCommand::CatIndex(args) => Box::pin(async move {
                 args.run(dir_ref, || config().map(|m| &*m)).await?;
                 Ok(())
@@ -793,8 +851,8 @@ impl InstallPipeline {
     }
 }
 
-/// Shared workspace-root and package-manager policy derivation used by both
-/// the install and dedupe dispatch paths.
+/// Shared workspace-root and package-manager policy derivation used by the
+/// install, dedupe, and prune dispatch paths.
 fn derive_config_root_and_package_manager_to_sync(
     cfg: &Config,
     dir_ref: &Path,
@@ -848,6 +906,43 @@ impl DedupePipeline {
         let cfg: &'static Config = cfg;
         let state = State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
         args.run::<Reporter>(state, existing, guard, &lockfile_path).await
+    }
+}
+
+/// The reporter-generic body of `pacquet prune`: runs config-deps, then
+/// state init, then the prune install pipeline. Mirrors what
+/// [`InstallPipeline`] does for the install command, since pnpm's prune
+/// delegates to its install handler which goes through the same
+/// config-finalization steps.
+struct PrunePipeline {
+    args: PruneArgs,
+    cfg: &'static mut Config,
+    config_root: PathBuf,
+    package_manager_to_sync: Option<PackageManagerToSync>,
+    manifest_path: PathBuf,
+}
+
+impl PrunePipeline {
+    async fn run<Reporter: self::Reporter + 'static>(self) -> miette::Result<()> {
+        let PrunePipeline { args, cfg, config_root, package_manager_to_sync, manifest_path } =
+            self;
+
+        if let Some(pm) = package_manager_to_sync.as_ref() {
+            config_deps::sync_package_manager_dependencies(
+                cfg,
+                &config_root,
+                &pm.specifier,
+                &pm.version,
+                false,
+            )
+            .await?;
+        }
+        config_deps::install_config_deps::<Reporter>(cfg, &config_root, false).await?;
+        config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
+        let cfg: &'static Config = cfg;
+        let state =
+            State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
+        args.run::<Reporter>(state).await
     }
 }
 

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -922,10 +922,10 @@ impl PrunePipeline {
         // path outside the workspace) before any destructive work begins.
         let workspace_root = cfg.workspace_dir.clone().unwrap_or_else(|| PathBuf::from("/"));
         if !cfg.modules_dir.starts_with(&workspace_root) {
+            let modules_dir = cfg.modules_dir.display();
+            let wr = workspace_root.display();
             return Err(miette::miette!(
-                "refusing prune: modules_dir ({}) is outside workspace root ({})",
-                cfg.modules_dir.display(),
-                workspace_root.display(),
+                "refusing prune: modules_dir ({modules_dir}) is outside workspace root ({wr})",
             ));
         }
         // Apply prune-specific overrides after hooks so that:

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -698,22 +698,12 @@ impl CliArgs {
             }
             CliCommand::Prune(args) => Box::pin(async move {
                 let cfg = config()?;
-                cfg.modules_cache_max_age = 0;
-                cfg.ignore_scripts = cfg.ignore_scripts || args.ignore_scripts;
                 let workspace_root = cfg.workspace_dir.clone().unwrap_or_else(|| dir_ref.clone());
                 if !cfg.modules_dir.starts_with(&workspace_root) {
                     return Err(miette::miette!(
                         "refusing prune: modules_dir ({}) is outside workspace root ({})",
                         cfg.modules_dir.display(),
                         workspace_root.display(),
-                    ));
-                }
-                let vsd = cfg.effective_virtual_store_dir();
-                if !vsd.starts_with(&cfg.modules_dir) {
-                    return Err(miette::miette!(
-                        "refusing prune: virtual_store_dir ({}) is outside modules_dir ({})",
-                        vsd.display(),
-                        cfg.modules_dir.display(),
                     ));
                 }
                 let (config_root, package_manager_to_sync) =
@@ -899,11 +889,14 @@ impl DedupePipeline {
     }
 }
 
-/// The reporter-generic body of `pacquet prune`: runs config-deps, then
-/// state init, then the prune install pipeline. Mirrors what
-/// [`InstallPipeline`] does for the install command, since pnpm's prune
-/// delegates to its install handler which goes through the same
-/// config-finalization steps.
+/// The reporter-generic body of `pacquet prune`: runs config-deps and
+/// `updateConfig` hooks first, then applies prune-specific config
+/// overrides (`modules_cache_max_age`, `ignore_scripts`) on the
+/// post-hook config, and finally dispatches to the install pipeline.
+/// The overrides must come after hooks because `updateConfig` can
+/// mutate `Config` fields (including `modules_dir` /
+/// `virtual_store_dir`), and the CLI `--ignore-scripts` flag must win
+/// over any hook-set value.
 struct PrunePipeline {
     args: PruneArgs,
     cfg: &'static mut Config,
@@ -928,6 +921,13 @@ impl PrunePipeline {
         }
         config_deps::install_config_deps::<Reporter>(cfg, &config_root, false).await?;
         config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
+        // Apply prune-specific overrides after hooks so that:
+        // - `modules_cache_max_age = 0` forces the virtual-store sweep
+        //   on the final (post-hook) config paths.
+        // - `--ignore-scripts` from the CLI wins over any value the
+        //   hooks set via `WorkspaceSettings::apply_to`.
+        cfg.modules_cache_max_age = 0;
+        cfg.ignore_scripts = cfg.ignore_scripts || args.ignore_scripts;
         let cfg: &'static Config = cfg;
         let state = State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
         args.run::<Reporter>(state).await

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -920,12 +920,15 @@ impl PrunePipeline {
         // VSD containment, but only at sweep time; this earlier check
         // catches a misconfigured modules_dir itself (e.g. an absolute
         // path outside the workspace) before any destructive work begins.
-        let workspace_root = cfg.workspace_dir.clone().unwrap_or_else(|| PathBuf::from("/"));
-        if !cfg.modules_dir.starts_with(&workspace_root) {
+        //
+        // `config_root` is `cfg.workspace_dir` when present, or the
+        // canonicalized `--dir` otherwise — a meaningful containment
+        // boundary in both cases.
+        if !cfg.modules_dir.starts_with(&config_root) {
             let modules_dir = cfg.modules_dir.display();
-            let wr = workspace_root.display();
+            let cr = config_root.display();
             return Err(miette::miette!(
-                "refusing prune: modules_dir ({modules_dir}) is outside workspace root ({wr})",
+                "refusing prune: modules_dir ({modules_dir}) is outside workspace root ({cr})",
             ));
         }
         // Apply prune-specific overrides after hooks so that:

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -700,29 +700,19 @@ impl CliArgs {
                 let cfg = config()?;
                 cfg.modules_cache_max_age = 0;
                 cfg.ignore_scripts = cfg.ignore_scripts || args.ignore_scripts;
-                let workspace_root =
-                    cfg.workspace_dir.clone().unwrap_or_else(|| dir_ref.clone());
-                let workspace_root = std::fs::canonicalize(&workspace_root)
-                    .into_diagnostic()
-                    .wrap_err("canonicalize workspace root for prune safety check")?;
-                let modules_dir = std::fs::canonicalize(&cfg.modules_dir)
-                    .into_diagnostic()
-                    .wrap_err("canonicalize modules_dir for prune safety check")?;
-                if !modules_dir.starts_with(&workspace_root) {
+                let workspace_root = cfg.workspace_dir.clone().unwrap_or_else(|| dir_ref.clone());
+                if !cfg.modules_dir.starts_with(&workspace_root) {
                     return Err(miette::miette!(
                         "refusing prune: modules_dir ({}) is outside workspace root ({})",
                         cfg.modules_dir.display(),
                         workspace_root.display(),
                     ));
                 }
-                let virtual_store_dir =
-                    std::fs::canonicalize(cfg.effective_virtual_store_dir())
-                        .into_diagnostic()
-                        .wrap_err("canonicalize virtual_store_dir for prune safety check")?;
-                if !virtual_store_dir.starts_with(&modules_dir) {
+                let vsd = cfg.effective_virtual_store_dir();
+                if !vsd.starts_with(&cfg.modules_dir) {
                     return Err(miette::miette!(
                         "refusing prune: virtual_store_dir ({}) is outside modules_dir ({})",
-                        cfg.effective_virtual_store_dir().display(),
+                        vsd.display(),
                         cfg.modules_dir.display(),
                     ));
                 }
@@ -748,7 +738,7 @@ impl CliArgs {
                     }
                 }
                 Ok(())
-            })
+            }),
             CliCommand::CatIndex(args) => Box::pin(async move {
                 args.run(dir_ref, || config().map(|m| &*m)).await?;
                 Ok(())
@@ -924,8 +914,7 @@ struct PrunePipeline {
 
 impl PrunePipeline {
     async fn run<Reporter: self::Reporter + 'static>(self) -> miette::Result<()> {
-        let PrunePipeline { args, cfg, config_root, package_manager_to_sync, manifest_path } =
-            self;
+        let PrunePipeline { args, cfg, config_root, package_manager_to_sync, manifest_path } = self;
 
         if let Some(pm) = package_manager_to_sync.as_ref() {
             config_deps::sync_package_manager_dependencies(
@@ -940,8 +929,7 @@ impl PrunePipeline {
         config_deps::install_config_deps::<Reporter>(cfg, &config_root, false).await?;
         config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
         let cfg: &'static Config = cfg;
-        let state =
-            State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
+        let state = State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
         args.run::<Reporter>(state).await
     }
 }

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -698,14 +698,6 @@ impl CliArgs {
             }
             CliCommand::Prune(args) => Box::pin(async move {
                 let cfg = config()?;
-                let workspace_root = cfg.workspace_dir.clone().unwrap_or_else(|| dir_ref.clone());
-                if !cfg.modules_dir.starts_with(&workspace_root) {
-                    return Err(miette::miette!(
-                        "refusing prune: modules_dir ({}) is outside workspace root ({})",
-                        cfg.modules_dir.display(),
-                        workspace_root.display(),
-                    ));
-                }
                 let (config_root, package_manager_to_sync) =
                     derive_config_root_and_package_manager_to_sync(cfg, dir_ref)
                         .wrap_err("derive workspace root and package manager policy")?;
@@ -921,6 +913,21 @@ impl PrunePipeline {
         }
         config_deps::install_config_deps::<Reporter>(cfg, &config_root, false).await?;
         config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
+        // Validate path containment AFTER hooks: updateConfig can mutate
+        // modules_dir / virtual_store_dir via WorkspaceSettings::apply_to,
+        // so the check must use the final (post-hook) config values.
+        // The install pipeline's prune_target_within_modules also validates
+        // VSD containment, but only at sweep time; this earlier check
+        // catches a misconfigured modules_dir itself (e.g. an absolute
+        // path outside the workspace) before any destructive work begins.
+        let workspace_root = cfg.workspace_dir.clone().unwrap_or_else(|| PathBuf::from("/"));
+        if !cfg.modules_dir.starts_with(&workspace_root) {
+            return Err(miette::miette!(
+                "refusing prune: modules_dir ({}) is outside workspace root ({})",
+                cfg.modules_dir.display(),
+                workspace_root.display(),
+            ));
+        }
         // Apply prune-specific overrides after hooks so that:
         // - `modules_cache_max_age = 0` forces the virtual-store sweep
         //   on the final (post-hook) config paths.

--- a/pacquet/crates/cli/src/cli_args/dedupe.rs
+++ b/pacquet/crates/cli/src/cli_args/dedupe.rs
@@ -62,6 +62,7 @@ impl DedupeArgs {
             auth_override: None,
             resolution_observer: None,
             catalogs_override: None,
+            disable_optimistic_repeat_install: false,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/cli/src/cli_args/import.rs
+++ b/pacquet/crates/cli/src/cli_args/import.rs
@@ -84,6 +84,7 @@ impl ImportArgs {
                 auth_override: None,
                 resolution_observer: None,
                 catalogs_override: None,
+                disable_optimistic_repeat_install: false,
             }
             .run::<Reporter>()
             .await

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -510,6 +510,7 @@ impl InstallArgs {
             auth_override: None,
             resolution_observer: None,
             catalogs_override: None,
+            disable_optimistic_repeat_install: false,
         }
         .run::<Reporter>()
         .await
@@ -767,6 +768,7 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
             auth_override: None,
             resolution_observer: None,
             catalogs_override: None,
+            disable_optimistic_repeat_install: false,
         };
 
         let result = match lockfile_verification_override {
@@ -895,6 +897,7 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<Reporter>()
     .await

--- a/pacquet/crates/cli/src/cli_args/prune.rs
+++ b/pacquet/crates/cli/src/cli_args/prune.rs
@@ -1,0 +1,74 @@
+use crate::State;
+use clap::Args;
+use miette::Context;
+use pacquet_package_manager::Install;
+use pacquet_package_manifest::DependencyGroup;
+use pacquet_reporter::Reporter;
+
+#[derive(Debug, Args)]
+pub struct PruneArgs {
+    #[clap(short = 'P', long)]
+    prod: bool,
+    #[clap(short = 'D', long)]
+    dev: bool,
+    #[clap(long)]
+    no_optional: bool,
+    #[clap(long = "ignore-scripts")]
+    pub ignore_scripts: bool,
+}
+
+impl PruneArgs {
+    fn dependency_groups(&self) -> impl Iterator<Item = DependencyGroup> {
+        let &PruneArgs { prod, dev, no_optional, ignore_scripts: _ } = self;
+        let has_both = prod == dev;
+        let has_prod = has_both || prod;
+        let has_dev = has_both || dev;
+        let has_optional = !no_optional;
+        std::iter::empty()
+            .chain(has_prod.then_some(DependencyGroup::Prod))
+            .chain(has_dev.then_some(DependencyGroup::Dev))
+            .chain(has_optional.then_some(DependencyGroup::Optional))
+    }
+
+    pub async fn run<Reporter: self::Reporter + 'static>(self, state: State) -> miette::Result<()> {
+        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
+            &state;
+
+        let lockfile_path = manifest
+            .path()
+            .parent()
+            .map(|parent| parent.join(pacquet_lockfile::Lockfile::FILE_NAME));
+
+        let dependency_groups: Vec<DependencyGroup> = self.dependency_groups().collect();
+
+        Install {
+            tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
+            http_client,
+            http_client_arc: std::sync::Arc::clone(http_client),
+            config,
+            manifest,
+            lockfile: pacquet_lockfile::MaybeLazyLockfile::Lazy(lockfile),
+            lockfile_path: lockfile_path.as_deref(),
+            dependency_groups,
+            frozen_lockfile: false,
+            prefer_frozen_lockfile: None,
+            ignore_manifest_check: false,
+            skip_runtimes: false,
+            trust_lockfile: false,
+            update_checksums: false,
+            is_full_install: true,
+            resolved_packages,
+            supported_architectures: config.supported_architectures.clone(),
+            node_linker: config.node_linker,
+            lockfile_only: false,
+            dry_run: false,
+            update_seed_policy: pacquet_package_manager::UpdateSeedPolicy::KeepAll,
+            auth_override: None,
+            resolution_observer: None,
+            catalogs_override: None,
+        }
+        .run::<Reporter>()
+        .await
+        .wrap_err("pruning dependencies")
+    }
+}

--- a/pacquet/crates/cli/src/cli_args/prune.rs
+++ b/pacquet/crates/cli/src/cli_args/prune.rs
@@ -66,6 +66,7 @@ impl PruneArgs {
             auth_override: None,
             resolution_observer: None,
             catalogs_override: None,
+            disable_optimistic_repeat_install: true,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/cli/src/cli_args/rebuild.rs
+++ b/pacquet/crates/cli/src/cli_args/rebuild.rs
@@ -122,6 +122,7 @@ pub(crate) async fn run_rebuild<Reporter: self::Reporter + 'static>(
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run_rebuild::<Reporter>(rebuild)
     .await

--- a/pacquet/crates/cli/tests/prune.rs
+++ b/pacquet/crates/cli/tests/prune.rs
@@ -47,6 +47,9 @@ fn prune_with_prod_only_omits_dev_deps() {
             "dependencies": {
                 "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
             },
+            "devDependencies": {
+                "@pnpm.e2e/hello-world-js-bin": "1.0.0",
+            }
         })
         .to_string(),
     )
@@ -60,6 +63,10 @@ fn prune_with_prod_only_omits_dev_deps() {
     assert!(
         lockfile.contains("@pnpm.e2e/pkg-with-1-dep"),
         "prune --prod must include prod dependencies:\n{lockfile}",
+    );
+    assert!(
+        !lockfile.contains("@pnpm.e2e/hello-world-js-bin"),
+        "prune --prod must NOT include dev dependencies:\n{lockfile}",
     );
 
     drop((root, mock_instance));

--- a/pacquet/crates/cli/tests/prune.rs
+++ b/pacquet/crates/cli/tests/prune.rs
@@ -71,3 +71,79 @@ fn prune_with_prod_only_omits_dev_deps() {
 
     drop((root, mock_instance));
 }
+
+#[test]
+fn prune_with_dev_only_includes_dev_deps() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+            },
+            "devDependencies": {
+                "@pnpm.e2e/hello-world-js-bin": "1.0.0",
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    pacquet.with_args(["prune", "--dev"]).assert().success();
+
+    assert!(lockfile_path.exists(), "prune --dev must create pnpm-lock.yaml");
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert!(
+        !lockfile.contains("@pnpm.e2e/pkg-with-1-dep"),
+        "prune --dev must NOT include prod dependencies:\n{lockfile}",
+    );
+    assert!(
+        lockfile.contains("@pnpm.e2e/hello-world-js-bin"),
+        "prune --dev must include dev dependencies:\n{lockfile}",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn prune_with_no_optional_excludes_optional_deps() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+            },
+            "optionalDependencies": {
+                "@pnpm.e2e/hello-world-js-bin": "1.0.0",
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    pacquet.with_args(["prune", "--no-optional"]).assert().success();
+
+    assert!(lockfile_path.exists(), "prune --no-optional must create pnpm-lock.yaml");
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("@pnpm.e2e/pkg-with-1-dep"),
+        "prune --no-optional must include prod dependencies:\n{lockfile}",
+    );
+    assert!(
+        !lockfile.contains("@pnpm.e2e/hello-world-js-bin"),
+        "prune --no-optional must exclude optional dependencies:\n{lockfile}",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pacquet/crates/cli/tests/prune.rs
+++ b/pacquet/crates/cli/tests/prune.rs
@@ -1,0 +1,66 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::fs;
+
+#[test]
+fn prune_writes_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    pacquet.with_arg("prune").assert().success();
+
+    assert!(lockfile_path.exists(), "prune must create pnpm-lock.yaml");
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("@pnpm.e2e/pkg-with-1-dep"),
+        "lockfile must record the dependency:\n{lockfile}",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn prune_with_prod_only_omits_dev_deps() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    pacquet.with_args(["prune", "--prod"]).assert().success();
+
+    assert!(lockfile_path.exists(), "prune --prod must create pnpm-lock.yaml");
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("@pnpm.e2e/pkg-with-1-dep"),
+        "prune --prod must include prod dependencies:\n{lockfile}",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pacquet/crates/package-manager/src/add.rs
+++ b/pacquet/crates/package-manager/src/add.rs
@@ -297,6 +297,7 @@ where
             auth_override: None,
             resolution_observer: None,
             catalogs_override: None,
+            disable_optimistic_repeat_install: false,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -244,6 +244,12 @@ where
     /// catalog bump drives resolution even under `--no-save`, where the
     /// bumped entry is intentionally not persisted to disk.
     pub catalogs_override: Option<Catalogs>,
+    /// When `true`, the optimistic repeat-install fast path is
+    /// disabled so the full install pipeline always runs. `pacquet
+    /// prune` sets this because the fast path short-circuits before
+    /// the virtual-store sweep, meaning extraneous packages can
+    /// survive a prune when the lockfile hasn't changed.
+    pub disable_optimistic_repeat_install: bool,
 }
 
 /// Error type of [`Install`].
@@ -514,6 +520,7 @@ where
             auth_override,
             resolution_observer,
             catalogs_override,
+            disable_optimistic_repeat_install,
         } = self;
 
         // `--dry-run` resolves but never materializes, so it borrows the
@@ -641,6 +648,7 @@ where
         let optimistic_decision = is_full_install
             && matches!(update_seed_policy, UpdateSeedPolicy::KeepAll)
             && !frozen_lockfile
+            && !disable_optimistic_repeat_install
             && check_optimistic_repeat_install(&OptimisticRepeatInstallCheck {
                 workspace_root: &workspace_root,
                 config,

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -164,6 +164,7 @@ async fn should_install_dependencies() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -255,6 +256,7 @@ async fn install_prunes_surplus_virtual_store_dir() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -331,6 +333,7 @@ async fn install_skips_prune_when_virtual_store_escapes_node_modules() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -409,6 +412,7 @@ async fn lockfile_only_routes_scoped_packages_to_configured_scoped_registry() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -463,6 +467,7 @@ async fn should_error_when_frozen_lockfile_is_requested_but_none_exists() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -514,6 +519,7 @@ async fn should_error_when_frozen_lockfile_and_update_checksums_are_both_set() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -594,6 +600,7 @@ async fn frozen_lockfile_flag_overrides_config_lockfile_false() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -667,6 +674,7 @@ async fn npm_alias_dependency_installs_under_alias_key() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -757,6 +765,7 @@ async fn unversioned_npm_alias_defaults_to_latest() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -831,6 +840,7 @@ async fn frozen_lockfile_flag_with_no_lockfile_errors() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -929,6 +939,7 @@ async fn install_emits_pnpm_event_sequence() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<RecordingReporter>()
     .await
@@ -1084,6 +1095,7 @@ async fn install_writes_modules_yaml() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -1199,6 +1211,7 @@ async fn install_writes_workspace_state() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -1442,6 +1455,7 @@ async fn install_optional_failing_postinstall_dep_via_registry_mock_succeeds() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -1522,6 +1536,7 @@ async fn auto_install_peers_does_not_cascade_optional_peers() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -1625,6 +1640,7 @@ async fn auto_install_peers_skips_meta_only_optional_peers() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -1764,6 +1780,7 @@ async fn warm_reinstall_skips_snapshot_when_current_lockfile_matches() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -1869,6 +1886,7 @@ async fn warm_reinstall_emits_broken_modules_when_dir_is_missing() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<RecordingReporter>()
     .await;
@@ -1982,6 +2000,7 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<RecordingReporter>()
     .await
@@ -2039,6 +2058,7 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<RecordingReporter>()
     .await
@@ -2138,6 +2158,7 @@ async fn warm_reinstall_reports_added_zero_and_emits_no_imported_events() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<RecordingReporter>()
     .await
@@ -2247,6 +2268,7 @@ async fn frozen_lockfile_errors_when_manifest_drifts_from_lockfile() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -2318,6 +2340,7 @@ async fn ignore_manifest_check_bypasses_manifest_freshness_gate() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -2390,6 +2413,7 @@ async fn frozen_lockfile_errors_when_overrides_drift_from_lockfile() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -2488,6 +2512,7 @@ async fn frozen_lockfile_applies_overrides_to_manifest_before_freshness_check() 
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -2602,6 +2627,7 @@ async fn frozen_lockfile_resolves_catalog_protocol_in_overrides_before_freshness
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -2670,6 +2696,7 @@ async fn frozen_lockfile_errors_when_lockfile_has_no_root_importer() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -2765,6 +2792,7 @@ async fn frozen_lockfile_under_gvs_registers_project_and_runs_clean() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -2879,6 +2907,7 @@ async fn gvs_persists_global_virtual_store_dir_in_modules_yaml_and_context_log()
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<RecordingReporter>()
     .await
@@ -3000,6 +3029,7 @@ async fn frozen_lockfile_with_gvs_off_skips_project_registry() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -3087,6 +3117,7 @@ async fn frozen_lockfile_under_gvs_registers_workspace_root_only() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -3298,6 +3329,7 @@ async fn frozen_install_preserves_seeded_skipped_across_reinstall() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -3429,6 +3461,7 @@ async fn frozen_install_silently_swallows_unreachable_optional_tarball() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -3536,6 +3569,7 @@ async fn frozen_install_propagates_non_optional_fetch_failure() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -3649,6 +3683,7 @@ async fn frozen_install_no_optional_drops_optional_only_snapshots() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -3746,6 +3781,7 @@ async fn frozen_install_optional_included_surfaces_missing_metadata() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -3847,6 +3883,7 @@ async fn frozen_install_no_optional_keeps_shared_non_optional_snapshot() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -3947,6 +3984,7 @@ async fn hoisted_node_linker_empty_lockfile_writes_modules_yaml() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -4042,6 +4080,7 @@ async fn hoisted_node_linker_does_not_create_virtual_store_root() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -4145,6 +4184,7 @@ async fn frozen_lockfile_install_errors_when_no_variant_matches_host() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -4245,6 +4285,7 @@ async fn frozen_lockfile_install_skips_runtime_when_skip_runtimes_set() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+            disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -4350,6 +4391,7 @@ async fn install_rejects_invalid_minimum_release_age_exclude_pattern() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -4455,6 +4497,7 @@ async fn frozen_lockfile_gate_rejects_under_huge_minimum_release_age() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -4548,6 +4591,7 @@ async fn fresh_install_writes_pnpm_lock_yaml_with_expected_shape() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -4630,6 +4674,7 @@ async fn fresh_install_uses_final_peer_suffix_for_transitive_pending_peer() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -4710,6 +4755,7 @@ async fn fresh_install_splits_dev_and_prod_dependency_sections() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -4787,6 +4833,7 @@ async fn fresh_install_records_user_written_specifier() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -4860,6 +4907,7 @@ async fn fresh_install_lockfile_round_trips_through_load_save_load() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -4932,6 +4980,7 @@ async fn fresh_install_with_lockfile_disabled_does_not_write_a_lockfile() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -5007,6 +5056,7 @@ async fn fresh_install_also_writes_current_lockfile_under_virtual_store() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -5098,6 +5148,7 @@ async fn fresh_install_with_lockfile_disabled_skips_current_lockfile_too() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -5167,6 +5218,7 @@ async fn fresh_install_marks_optional_snapshots_in_pnpm_lock_yaml() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -5260,6 +5312,7 @@ async fn fresh_install_hoisted_node_linker_records_modules_yaml() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -5334,6 +5387,7 @@ async fn fresh_install_refuses_skip_runtimes_before_writing_state() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -5412,6 +5466,7 @@ async fn prefer_frozen_lockfile_takes_frozen_path_when_lockfile_is_fresh() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -5491,6 +5546,7 @@ async fn no_prefer_frozen_lockfile_flag_forces_fresh_resolve() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -5564,6 +5620,7 @@ async fn stale_lockfile_under_no_flag_falls_through_to_fresh_resolve() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -5841,6 +5898,7 @@ async fn frozen_install_short_circuits_when_modules_and_lockfile_are_consistent(
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<RecordingReporter>()
     .await
@@ -6029,6 +6087,7 @@ async fn optimistic_repeat_install_skips_entire_pipeline_when_state_is_fresh() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<RecordingReporter>()
     .await
@@ -6267,6 +6326,7 @@ async fn frozen_lockfile_disables_optimistic_short_circuit() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<RecordingReporter>()
     .await
@@ -6413,6 +6473,7 @@ async fn partial_install_disables_optimistic_short_circuit() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<RecordingReporter>()
     .await
@@ -6555,6 +6616,7 @@ async fn optimistic_repeat_install_does_not_short_circuit_when_lockfile_missing(
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<RecordingReporter>()
     .await;
@@ -6640,6 +6702,7 @@ async fn optimistic_repeat_install_round_trips_on_single_project_install() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -6698,6 +6761,7 @@ async fn optimistic_repeat_install_round_trips_on_single_project_install() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<RecordingReporter>()
     .await
@@ -6788,6 +6852,7 @@ async fn fresh_install_records_lockfile_verification_for_mtime_bypassed_noop() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -6854,6 +6919,7 @@ async fn fresh_install_records_lockfile_verification_for_mtime_bypassed_noop() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<RecordingReporter>()
     .await
@@ -6943,6 +7009,7 @@ async fn install_then_go_offline() -> (tempfile::TempDir, &'static Config, Packa
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -7033,6 +7100,7 @@ async fn optimistic_repeat_install_short_circuits_offline_when_touched_manifest_
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<RecordingReporter>()
     .await
@@ -7115,6 +7183,7 @@ async fn optimistic_repeat_install_restores_missing_lockfile_offline() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<RecordingReporter>()
     .await
@@ -7261,6 +7330,7 @@ async fn fresh_lockfile_only_with_overrides(
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -7367,6 +7437,7 @@ async fn fresh_lockfile_only_with_compatibility_db(
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -7459,6 +7530,7 @@ async fn fresh_install_applies_package_extensions_to_dependency_manifest() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -7561,6 +7633,7 @@ async fn frozen_lockfile_errors_when_package_extensions_drift_from_lockfile() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -7645,6 +7718,7 @@ async fn install_with_pnpmfile_reporter<Reporter: self::Reporter + 'static>(
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<Reporter>()
     .await
@@ -8022,6 +8096,7 @@ async fn test_install_purges_node_modules_on_layout_mismatch() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -8058,6 +8133,7 @@ async fn test_install_purges_node_modules_on_layout_mismatch() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -8130,6 +8206,7 @@ async fn test_install_resolve_only_ignores_layout_mismatch() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await
@@ -8166,6 +8243,7 @@ async fn test_install_resolve_only_ignores_layout_mismatch() {
         auth_override: None,
         resolution_observer: None,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await

--- a/pacquet/crates/package-manager/src/remove.rs
+++ b/pacquet/crates/package-manager/src/remove.rs
@@ -134,6 +134,7 @@ impl Remove<'_> {
             auth_override: None,
             resolution_observer: None,
             catalogs_override: None,
+            disable_optimistic_repeat_install: false,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/package-manager/src/update.rs
+++ b/pacquet/crates/package-manager/src/update.rs
@@ -562,6 +562,7 @@ impl Update<'_> {
             auth_override: None,
             resolution_observer: None,
             catalogs_override,
+            disable_optimistic_repeat_install: false,
         }
         .run::<Reporter>()
         .await

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -193,6 +193,7 @@ pub async fn resolve(
         // single terminal `done` frame carrying the whole lockfile.
         resolution_observer: observer,
         catalogs_override: None,
+        disable_optimistic_repeat_install: false,
     }
     .run::<SilentReporter>()
     .await


### PR DESCRIPTION
## Summary

Ports the pnpm prune command to the pacquet Rust CLI. The command removes extraneous packages by restricting the dependency groups installed. It translates the --prod, --dev, and --no-optional flags into the corresponding DependencyGroup filter, sets modules_cache_max_age to zero so the store is not reused, and coalesces --ignore-scripts at the dispatch level before state initialization.

Related to pnpm/pnpm#11633

## Squash Commit Body

```
Ports the prune command from pnpm to pacquet. The dispatch arm modifies the leaked Config before State::init, setting modules_cache_max_age = 0 and accumulating ignore_scripts from both the config and the CLI flag. PruneArgs::dependency_groups translates the prod/dev/no-optional flags into a DependencyGroup iterator that is collected into a Vec and passed to Install.
```


## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust pacquet/ port, or the description notes what still needs porting. Implemented in pacquet only; the TypeScript CLI already has this command at pnpm11/installing/commands/src/prune.ts.
- [ ] No changeset needed pacquet-internal changes do not affect published packages.
- [x] Tests added for prune command execution.
- [ ] No documentation changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new `prune` CLI subcommand to reduce dependencies with `--prod`, `--dev`, and control over optional dependencies.
  * `prune` now generates/updates `pnpm-lock.yaml` based on the selected dependency set.
  * Added an `--ignore-scripts` flag to the `prune` command.

* **Tests**
  * Added CLI integration tests covering default pruning and `--prod` pruning, verifying the lockfile contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->