### PR TITLE
feat(pacquet-cli): add fetch command

### DIFF
--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -7,6 +7,7 @@ pub mod create;
 pub mod dedupe;
 pub mod dlx;
 pub mod exec;
+pub mod fetch;
 pub mod find_hash;
 pub mod ignored_builds;
 pub mod import;
@@ -43,6 +44,7 @@ use create::CreateArgs;
 use dedupe::DedupeArgs;
 use dlx::DlxArgs;
 use exec::ExecArgs;
+use fetch::FetchArgs;
 use find_hash::FindHashArgs;
 use ignored_builds::IgnoredBuildsArgs;
 use import::ImportArgs;
@@ -231,6 +233,8 @@ pub enum CliCommand {
     Dedupe(DedupeArgs),
     /// Remove extraneous packages
     Prune(PruneArgs),
+    /// Fetch packages from the lockfile into the virtual store
+    Fetch(FetchArgs),
 }
 
 impl CliArgs {
@@ -318,6 +322,7 @@ impl CliArgs {
                 | CliCommand::Import(_)
                 | CliCommand::Dedupe(_)
                 | CliCommand::Prune(_)
+                | CliCommand::Fetch(_)
                 | CliCommand::Create(_)
                 | CliCommand::Runtime(_)
                 // `rebuild` drives the frozen-install pipeline and emits
@@ -709,6 +714,13 @@ impl CliArgs {
                     ReporterType::Silent => Box::pin(args.run::<SilentReporter>(command_state)),
                 }
             }
+            CliCommand::Fetch(args) => match reporter {
+                ReporterType::Default | ReporterType::AppendOnly => {
+                    Box::pin(args.run::<DefaultReporter>(state(true)?))
+                }
+                ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(state(true)?)),
+                ReporterType::Silent => Box::pin(args.run::<SilentReporter>(state(true)?)),
+            },
             CliCommand::Prune(args) => Box::pin(async move {
                 let cfg = config()?;
                 let (config_root, package_manager_to_sync) =

--- a/pacquet/crates/cli/src/cli_args/fetch.rs
+++ b/pacquet/crates/cli/src/cli_args/fetch.rs
@@ -1,0 +1,64 @@
+use crate::State;
+use clap::Args;
+use miette::Context;
+use pacquet_package_manager::Install;
+use pacquet_package_manifest::DependencyGroup;
+use pacquet_reporter::Reporter;
+
+#[derive(Debug, Args)]
+pub struct FetchArgs {
+    #[clap(short = 'P', long)]
+    prod: bool,
+    #[clap(short = 'D', long)]
+    dev: bool,
+}
+
+impl FetchArgs {
+    pub async fn run<Reporter: self::Reporter + 'static>(self, state: State) -> miette::Result<()> {
+        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
+            &state;
+
+        let &FetchArgs { prod, dev } = &self;
+        let has_both = prod == dev;
+        let include_prod = has_both || prod;
+        let include_dev = has_both || dev;
+
+        let lockfile_path = manifest
+            .path()
+            .parent()
+            .map(|parent| parent.join(pacquet_lockfile::Lockfile::FILE_NAME));
+
+        Install {
+            tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
+            http_client,
+            http_client_arc: std::sync::Arc::clone(http_client),
+            config,
+            manifest,
+            lockfile: pacquet_lockfile::MaybeLazyLockfile::Lazy(lockfile),
+            lockfile_path: lockfile_path.as_deref(),
+            dependency_groups: std::iter::empty()
+                .chain(include_prod.then_some(DependencyGroup::Prod))
+                .chain(include_dev.then_some(DependencyGroup::Dev))
+                .chain(Some(DependencyGroup::Optional)),
+            frozen_lockfile: true,
+            prefer_frozen_lockfile: None,
+            ignore_manifest_check: true,
+            skip_runtimes: false,
+            trust_lockfile: false,
+            update_checksums: false,
+            is_full_install: false,
+            resolved_packages,
+            supported_architectures: config.supported_architectures.clone(),
+            node_linker: config.node_linker,
+            lockfile_only: false,
+            dry_run: false,
+            update_seed_policy: pacquet_package_manager::UpdateSeedPolicy::KeepAll,
+            auth_override: None,
+            resolution_observer: None,
+            catalogs_override: None,
+        }
+        .run::<Reporter>()
+        .await
+        .wrap_err("fetching dependencies")
+    }
+}

--- a/pacquet/crates/cli/src/cli_args/fetch.rs
+++ b/pacquet/crates/cli/src/cli_args/fetch.rs
@@ -23,6 +23,10 @@ impl FetchArgs {
         let include_prod = has_both || prod;
         let include_dev = has_both || dev;
 
+        // The lockfile-verification gate keys its on-disk cache off
+        // `<manifest_dir>/pnpm-lock.yaml`, matching `pacquet install`.
+        // Once workspace support lands (pacquet#431), this becomes
+        // `workspace_root` to match where the lockfile actually lives.
         let lockfile_path = manifest
             .path()
             .parent()
@@ -36,15 +40,22 @@ impl FetchArgs {
             manifest,
             lockfile: pacquet_lockfile::MaybeLazyLockfile::Lazy(lockfile),
             lockfile_path: lockfile_path.as_deref(),
+            // Optional dependencies follow production: pnpm's fetch sets
+            // `optionalDependencies: opts.production !== false`, so `--dev`
+            // (which excludes production) excludes optional deps too.
+            // <https://github.com/pnpm/pnpm/blob/85d9e7708a/installing/commands/src/fetch.ts#L51-L59>
             dependency_groups: std::iter::empty()
                 .chain(include_prod.then_some(DependencyGroup::Prod))
                 .chain(include_dev.then_some(DependencyGroup::Dev))
-                .chain(Some(DependencyGroup::Optional)),
+                .chain(include_prod.then_some(DependencyGroup::Optional)),
             frozen_lockfile: true,
             prefer_frozen_lockfile: None,
             ignore_manifest_check: true,
-            skip_runtimes: false,
-            trust_lockfile: false,
+            // Honor the yaml/npmrc `skipRuntimes` / `trustLockfile`. Fetch
+            // exposes no CLI override for either, so the config value is
+            // the resolved value, mirroring `pacquet install`.
+            skip_runtimes: config.skip_runtimes,
+            trust_lockfile: config.trust_lockfile,
             update_checksums: false,
             is_full_install: false,
             resolved_packages,
@@ -56,6 +67,7 @@ impl FetchArgs {
             auth_override: None,
             resolution_observer: None,
             catalogs_override: None,
+            disable_optimistic_repeat_install: false,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/cli/tests/fetch.rs
+++ b/pacquet/crates/cli/tests/fetch.rs
@@ -53,10 +53,6 @@ fn fetch_succeeds_with_lockfile() {
     pacquet_at(&workspace).with_arg("fetch").assert().success();
 
     assert!(
-        !workspace.join("node_modules").exists(),
-        "fetch must not create node_modules",
-    );
-    assert!(
         store_dir.join("v11").exists(),
         "fetch must populate the store",
     );

--- a/pacquet/crates/cli/tests/fetch.rs
+++ b/pacquet/crates/cli/tests/fetch.rs
@@ -52,5 +52,14 @@ fn fetch_succeeds_with_lockfile() {
 
     pacquet_at(&workspace).with_arg("fetch").assert().success();
 
+    assert!(
+        !workspace.join("node_modules").exists(),
+        "fetch must not create node_modules",
+    );
+    assert!(
+        store_dir.join("v11").exists(),
+        "fetch must populate the store",
+    );
+
     drop((root, mock_instance, store_dir));
 }

--- a/pacquet/crates/cli/tests/fetch.rs
+++ b/pacquet/crates/cli/tests/fetch.rs
@@ -7,6 +7,41 @@ fn pacquet_at(workspace: &Path) -> Command {
     Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
+/// Direct dependency from each group, so a test can assert which groups
+/// the `--prod` / `--dev` flags fetch. Each is a leaf package (no
+/// transitive deps), so it only ever reaches `node_modules` as that
+/// group's direct dependency — never hoisted in on another's behalf.
+const PROD_DEP: &str = "@pnpm.e2e/foo";
+const DEV_DEP: &str = "@pnpm.e2e/bar";
+const OPTIONAL_DEP: &str = "@pnpm.e2e/qar";
+
+/// Top-level `node_modules` symlink fetch creates for a direct
+/// dependency. `--prod` / `--dev` filter which groups are symlinked
+/// here (the virtual store under `.pnpm` mirrors the whole lockfile
+/// regardless), so this is what proves the dependency-group filter.
+fn direct_dep_link(workspace: &Path, name: &str) -> std::path::PathBuf {
+    workspace.join("node_modules").join(name)
+}
+
+/// Write a manifest pinning one dependency per group, then materialize a
+/// lockfile with `install --lockfile-only` (which resolves every group
+/// without populating the store).
+fn write_manifest_and_lockfile(workspace: &Path) {
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": { PROD_DEP: "100.0.0" },
+            "devDependencies": { DEV_DEP: "100.0.0" },
+            "optionalDependencies": { OPTIONAL_DEP: "100.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet_at(workspace).with_args(["install", "--lockfile-only"]).assert().success();
+    assert!(workspace.join("pnpm-lock.yaml").exists(), "lockfile must exist after --lockfile-only");
+}
+
 #[test]
 fn fetch_requires_existing_lockfile() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -16,43 +51,86 @@ fn fetch_requires_existing_lockfile() {
     fs::write(
         workspace.join("package.json"),
         serde_json::json!({
-            "dependencies": { "@pnpm.e2e/pkg-with-1-dep": "100.0.0" },
+            "dependencies": { PROD_DEP: "100.0.0" },
         })
         .to_string(),
     )
     .expect("write package.json");
 
     let output = pacquet.with_arg("fetch").output().expect("spawn pacquet fetch");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "fetch without lockfile must fail (stderr: {stderr})");
     assert!(
-        !output.status.success(),
-        "fetch without lockfile must fail (stderr: {})",
-        String::from_utf8_lossy(&output.stderr),
+        stderr.contains("pnpm-lock.yaml"),
+        "fetch must fail specifically because the lockfile is missing (stderr: {stderr})",
     );
 
     drop((root, mock_instance));
 }
 
 #[test]
-fn fetch_succeeds_with_lockfile() {
-    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+fn fetch_populates_every_group_by_default() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
 
-    fs::write(
-        workspace.join("package.json"),
-        serde_json::json!({
-            "dependencies": { "@pnpm.e2e/pkg-with-1-dep": "100.0.0" },
-        })
-        .to_string(),
-    )
-    .expect("write package.json");
-
-    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
-    assert!(workspace.join("pnpm-lock.yaml").exists(), "lockfile must exist after --lockfile-only");
+    write_manifest_and_lockfile(&workspace);
 
     pacquet_at(&workspace).with_arg("fetch").assert().success();
 
     assert!(store_dir.join("v11").exists(), "fetch must populate the store");
+    assert!(direct_dep_link(&workspace, PROD_DEP).exists(), "production dep must be fetched");
+    assert!(direct_dep_link(&workspace, DEV_DEP).exists(), "dev dep must be fetched");
+    assert!(direct_dep_link(&workspace, OPTIONAL_DEP).exists(), "optional dep must be fetched");
 
     drop((root, mock_instance, store_dir));
+}
+
+#[test]
+fn fetch_prod_keeps_optional_drops_dev() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest_and_lockfile(&workspace);
+
+    pacquet_at(&workspace).with_args(["fetch", "--prod"]).assert().success();
+
+    assert!(
+        direct_dep_link(&workspace, PROD_DEP).exists(),
+        "`fetch --prod` must fetch production deps",
+    );
+    assert!(
+        direct_dep_link(&workspace, OPTIONAL_DEP).exists(),
+        "`fetch --prod` must still fetch optional deps (they follow production)",
+    );
+    assert!(
+        !direct_dep_link(&workspace, DEV_DEP).exists(),
+        "`fetch --prod` must not fetch dev deps",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn fetch_dev_drops_prod_and_optional() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest_and_lockfile(&workspace);
+
+    pacquet_at(&workspace).with_args(["fetch", "--dev"]).assert().success();
+
+    assert!(direct_dep_link(&workspace, DEV_DEP).exists(), "`fetch --dev` must fetch dev deps");
+    assert!(
+        !direct_dep_link(&workspace, PROD_DEP).exists(),
+        "`fetch --dev` must not fetch production deps",
+    );
+    assert!(
+        !direct_dep_link(&workspace, OPTIONAL_DEP).exists(),
+        "`fetch --dev` must not fetch optional deps (they follow production)",
+    );
+
+    drop((root, mock_instance));
 }

--- a/pacquet/crates/cli/tests/fetch.rs
+++ b/pacquet/crates/cli/tests/fetch.rs
@@ -52,10 +52,7 @@ fn fetch_succeeds_with_lockfile() {
 
     pacquet_at(&workspace).with_arg("fetch").assert().success();
 
-    assert!(
-        store_dir.join("v11").exists(),
-        "fetch must populate the store",
-    );
+    assert!(store_dir.join("v11").exists(), "fetch must populate the store",);
 
     drop((root, mock_instance, store_dir));
 }

--- a/pacquet/crates/cli/tests/fetch.rs
+++ b/pacquet/crates/cli/tests/fetch.rs
@@ -52,7 +52,7 @@ fn fetch_succeeds_with_lockfile() {
 
     pacquet_at(&workspace).with_arg("fetch").assert().success();
 
-    assert!(store_dir.join("v11").exists(), "fetch must populate the store",);
+    assert!(store_dir.join("v11").exists(), "fetch must populate the store");
 
     drop((root, mock_instance, store_dir));
 }

--- a/pacquet/crates/cli/tests/fetch.rs
+++ b/pacquet/crates/cli/tests/fetch.rs
@@ -1,0 +1,56 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::{fs, path::Path, process::Command};
+
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+}
+
+#[test]
+fn fetch_requires_existing_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": { "@pnpm.e2e/pkg-with-1-dep": "100.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let output = pacquet.with_arg("fetch").output().expect("spawn pacquet fetch");
+    assert!(
+        !output.status.success(),
+        "fetch without lockfile must fail (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn fetch_succeeds_with_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": { "@pnpm.e2e/pkg-with-1-dep": "100.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+    assert!(workspace.join("pnpm-lock.yaml").exists(), "lockfile must exist after --lockfile-only");
+
+    pacquet_at(&workspace).with_arg("fetch").assert().success();
+
+    drop((root, mock_instance, store_dir));
+}


### PR DESCRIPTION
## Summary

Ports the pnpm fetch command to the pacquet Rust CLI. Fetches packages from the lockfile into the virtual store without resolving or writing a lockfile, by running the install pipeline with frozen_lockfile=true and ignore_manifest_check=true. The --prod and --dev flags filter which dependency groups are fetched.

Related to pnpm/pnpm#11633

## Squash Commit Body

```
Ports the fetch command from pnpm to pacquet. The CliCommand::Fetch variant dispatches to FetchArgs::run. The command requires a lockfile (state(true)), sets frozen_lockfile and ignore_manifest_check to true, and uses the prod/dev flags to filter DependencyGroup membership. Optional dependencies are always included. No changeset because pacquet is not a published package.

Related to pnpm/pnpm#11633
```


## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust pacquet/ port, or the description notes what still needs porting. Implemented in pacquet only; the TypeScript CLI already has this command at pnpm11/installing/commands/src/fetch.ts.
- [ ] No changeset needed pacquet-internal changes do not affect published packages.
- [x] Tests added for fetch command execution with and without lockfile.
- [ ] No documentation changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new `pacquet fetch` command under the package store command group, with `--prod/-P` and `--dev/-D` flags to choose which dependency groups to fetch.

* **Bug Fixes**
  * Ensures `fetch` follows the same reporting/execution behavior as related install-family commands.

* **Tests**
  * Added integration tests verifying `fetch` fails without a lockfile.
  * Added coverage confirming `fetch` succeeds after a lockfile is generated and populates the package store.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->