### PR TITLE
feat(pacquet-cli): add link command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3614,6 +3614,7 @@ dependencies = [
  "pacquet-workspace-manifest-writer",
  "pacquet-workspace-projects-graph",
  "pacquet-workspace-state",
+ "pathdiff",
  "pipe-trait",
  "pnpr",
  "pretty_assertions",

--- a/pacquet/crates/cli/Cargo.toml
+++ b/pacquet/crates/cli/Cargo.toml
@@ -56,6 +56,7 @@ indexmap             = { workspace = true }
 node-semver          = { workspace = true }
 miette               = { workspace = true }
 owo-colors.workspace = true
+pathdiff             = { workspace = true }
 pipe-trait           = { workspace = true }
 rayon                = { workspace = true }
 reqwest              = { workspace = true }

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -13,6 +13,7 @@ pub mod find_hash;
 pub mod ignored_builds;
 pub mod import;
 pub mod install;
+pub mod link;
 pub mod outdated;
 pub mod patch;
 pub mod patch_commit;
@@ -51,6 +52,7 @@ use find_hash::FindHashArgs;
 use ignored_builds::IgnoredBuildsArgs;
 use import::ImportArgs;
 use install::InstallArgs;
+use link::LinkArgs;
 use miette::{Context, IntoDiagnostic};
 use outdated::{OutdatedArgs, OutdatedOutcome};
 use pacquet_config::{Config, Host};
@@ -231,6 +233,9 @@ pub enum CliCommand {
     IgnoredBuilds(IgnoredBuildsArgs),
     /// Approve dependencies for running scripts during installation.
     ApproveBuilds(ApproveBuildsArgs),
+    /// Links a local package as a dependency
+    #[clap(visible_aliases = ["ln"])]
+    Link(LinkArgs),
     /// Generates a pnpm-lock.yaml from an external lockfile
     Import(ImportArgs),
     /// Deduplicate packages in the lockfile
@@ -323,6 +328,7 @@ impl CliArgs {
                 | CliCommand::Remove(_)
                 | CliCommand::Install(_)
                 | CliCommand::Dlx(_)
+                | CliCommand::Link(_)
                 | CliCommand::Import(_)
                 | CliCommand::Dedupe(_)
                 | CliCommand::Prune(_)
@@ -696,6 +702,16 @@ impl CliArgs {
                 args.run(|| config().map(|m| &*m))?;
                 Box::pin(std::future::ready(Ok(())))
             }
+            CliCommand::Link(args) => {
+                let command_state = state(false)?;
+                match reporter {
+                    ReporterType::Default | ReporterType::AppendOnly => {
+                        Box::pin(args.run::<DefaultReporter>(command_state))
+                    }
+                    ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(command_state)),
+                    ReporterType::Silent => Box::pin(args.run::<SilentReporter>(command_state)),
+                }
+            }
             CliCommand::Dedupe(args) => Box::pin(async move {
                 let cfg = config()?;
                 let (config_root, package_manager_to_sync) =
@@ -727,6 +743,10 @@ impl CliArgs {
                     ReporterType::Silent => Box::pin(args.run::<SilentReporter>(command_state)),
                 }
             }
+            CliCommand::CatIndex(args) => Box::pin(async move {
+                args.run(dir_ref, || config().map(|m| &*m)).await?;
+                Ok(())
+            }),
             CliCommand::Fetch(args) => match reporter {
                 ReporterType::Default | ReporterType::AppendOnly => {
                     Box::pin(args.run::<DefaultReporter>(state(true)?))
@@ -757,10 +777,6 @@ impl CliArgs {
                         Box::pin(pipeline.run::<SilentReporter>()).await?;
                     }
                 }
-                Ok(())
-            }),
-            CliCommand::CatIndex(args) => Box::pin(async move {
-                args.run(dir_ref, || config().map(|m| &*m)).await?;
                 Ok(())
             }),
             CliCommand::IgnoredBuilds(_) => {

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -703,13 +703,17 @@ impl CliArgs {
                 Box::pin(std::future::ready(Ok(())))
             }
             CliCommand::Link(args) => {
-                let command_state = state(false)?;
+                let manifest_path = manifest_path_ref.clone();
                 match reporter {
                     ReporterType::Default | ReporterType::AppendOnly => {
-                        Box::pin(args.run::<DefaultReporter>(command_state))
+                        Box::pin(args.run::<DefaultReporter>(config()?, manifest_path))
                     }
-                    ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(command_state)),
-                    ReporterType::Silent => Box::pin(args.run::<SilentReporter>(command_state)),
+                    ReporterType::Ndjson => {
+                        Box::pin(args.run::<NdjsonReporter>(config()?, manifest_path))
+                    }
+                    ReporterType::Silent => {
+                        Box::pin(args.run::<SilentReporter>(config()?, manifest_path))
+                    }
                 }
             }
             CliCommand::Dedupe(args) => Box::pin(async move {

--- a/pacquet/crates/cli/src/cli_args/link.rs
+++ b/pacquet/crates/cli/src/cli_args/link.rs
@@ -48,7 +48,7 @@ impl LinkArgs {
 
             let normalized = pathdiff::diff_paths(&target_dir, &manifest_dir)
                 .ok_or_else(|| miette::miette!("cannot compute relative path to target"))?;
-            let link_spec = format!("link:{}", normalized.display());
+            let link_spec = format!("link:{}", normalized.display().to_string().replace("\\", "/"));
 
             let manifest = &mut state.manifest;
             manifest

--- a/pacquet/crates/cli/src/cli_args/link.rs
+++ b/pacquet/crates/cli/src/cli_args/link.rs
@@ -1,0 +1,100 @@
+use crate::State;
+use clap::Args;
+use miette::Context;
+use pacquet_package_manager::Install;
+use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_reporter::Reporter;
+use std::path::PathBuf;
+
+#[derive(Debug, Args)]
+pub struct LinkArgs {
+    pub package_paths: Vec<String>,
+}
+
+impl LinkArgs {
+    pub async fn run<Reporter: self::Reporter + 'static>(
+        self,
+        mut state: State,
+    ) -> miette::Result<()> {
+        if self.package_paths.is_empty() {
+            return Err(miette::miette!(
+                "Cannot link by package name. Use a relative or absolute path instead."
+            ));
+        }
+
+        for path_str in &self.package_paths {
+            let target_path = PathBuf::from(path_str);
+            let target_dir = if target_path.is_absolute() {
+                target_path.clone()
+            } else {
+                let base =
+                    state.manifest.path().parent().expect("manifest path always has a parent dir");
+                base.join(&target_path)
+            };
+
+            let target_manifest_path = target_dir.join("package.json");
+            if !target_manifest_path.exists() {
+                return Err(miette::miette!("No package.json found in {}", target_dir.display()));
+            }
+
+            let target_manifest = PackageManifest::from_path(target_manifest_path)
+                .wrap_err("reading target package manifest")?;
+            let package_name = target_manifest.value()["name"]
+                .as_str()
+                .ok_or_else(|| miette::miette!("Target package does not have a name field"))?
+                .to_string();
+
+            let link_spec = format!("link:{path_str}");
+
+            let manifest = &mut state.manifest;
+            manifest
+                .add_dependency(&package_name, &link_spec, DependencyGroup::Prod)
+                .wrap_err("adding linked dependency to package.json")?;
+        }
+
+        state.manifest.save().wrap_err("saving package.json with linked dependencies")?;
+
+        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
+            &state;
+
+        let lockfile_path = manifest
+            .path()
+            .parent()
+            .map(|parent| parent.join(pacquet_lockfile::Lockfile::FILE_NAME));
+
+        Install {
+            tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
+            http_client,
+            http_client_arc: std::sync::Arc::clone(http_client),
+            config,
+            manifest,
+            lockfile: pacquet_lockfile::MaybeLazyLockfile::Lazy(lockfile),
+            lockfile_path: lockfile_path.as_deref(),
+            dependency_groups: [
+                DependencyGroup::Prod,
+                DependencyGroup::Dev,
+                DependencyGroup::Optional,
+            ]
+            .into_iter(),
+            frozen_lockfile: false,
+            prefer_frozen_lockfile: None,
+            ignore_manifest_check: false,
+            skip_runtimes: false,
+            trust_lockfile: false,
+            update_checksums: false,
+            is_full_install: true,
+            resolved_packages,
+            supported_architectures: config.supported_architectures.clone(),
+            node_linker: config.node_linker,
+            lockfile_only: false,
+            dry_run: false,
+            update_seed_policy: pacquet_package_manager::UpdateSeedPolicy::KeepAll,
+            auth_override: None,
+            resolution_observer: None,
+            catalogs_override: None,
+        }
+        .run::<Reporter>()
+        .await
+        .wrap_err("linking dependencies")
+    }
+}

--- a/pacquet/crates/cli/src/cli_args/link.rs
+++ b/pacquet/crates/cli/src/cli_args/link.rs
@@ -38,9 +38,10 @@ impl LinkArgs {
             };
 
             let target_manifest_path = target_dir.join("package.json");
+            let dir_display = target_dir.display();
             let target_manifest =
                 PackageManifest::from_path(target_manifest_path).map_err(|_| {
-                    miette::miette!("No package.json found in {}", target_dir.display())
+                    miette::miette!("No package.json found in {}", dir_display)
                 })?;
             let package_name = target_manifest.value()["name"]
                 .as_str()

--- a/pacquet/crates/cli/src/cli_args/link.rs
+++ b/pacquet/crates/cli/src/cli_args/link.rs
@@ -39,10 +39,8 @@ impl LinkArgs {
 
             let target_manifest_path = target_dir.join("package.json");
             let dir_display = target_dir.display();
-            let target_manifest =
-                PackageManifest::from_path(target_manifest_path).map_err(|_| {
-                    miette::miette!("No package.json found in {}", dir_display)
-                })?;
+            let target_manifest = PackageManifest::from_path(target_manifest_path)
+                .map_err(|_| miette::miette!("No package.json found in {}", dir_display))?;
             let package_name = target_manifest.value()["name"]
                 .as_str()
                 .ok_or_else(|| miette::miette!("Target package does not have a name field"))?

--- a/pacquet/crates/cli/src/cli_args/link.rs
+++ b/pacquet/crates/cli/src/cli_args/link.rs
@@ -1,34 +1,92 @@
 use crate::State;
 use clap::Args;
-use miette::Context;
-use pacquet_package_manager::Install;
+use derive_more::{Display, Error};
+use indexmap::IndexMap;
+use miette::{Context, Diagnostic};
+use pacquet_config::Config;
+use pacquet_package_manager::{Install, UpdateSeedPolicy};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_reporter::Reporter;
-use std::path::PathBuf;
+use pacquet_workspace_manifest_writer::set_overrides;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
+/// Links a local package as a dependency.
 #[derive(Debug, Args)]
 pub struct LinkArgs {
     pub package_paths: Vec<String>,
 }
 
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum LinkError {
+    #[display("You must provide a parameter. Usage: pacquet link <dir>")]
+    #[diagnostic(code(ERR_PNPM_LINK_BAD_PARAMS))]
+    NoParams,
+
+    #[display(r#"Cannot link by package name. Use a relative or absolute path instead, e.g. "pacquet link ./{name}""#)]
+    #[diagnostic(code(ERR_PNPM_LINK_BAD_PARAMS))]
+    LinkByName {
+        #[error(not(source))]
+        name: String,
+    },
+}
+
+const DEPENDENCY_FIELDS: [&str; 3] = ["optionalDependencies", "dependencies", "devDependencies"];
+
+fn is_filespec(input: &str) -> bool {
+    let mut chars = input.chars();
+    match chars.next() {
+        Some('.' | '/') => true,
+        Some('\\') if cfg!(windows) => true,
+        Some('~') => chars.next() == Some('/'),
+        Some(c) if c.is_ascii_alphabetic() => chars.next() == Some(':'),
+        _ => false,
+    }
+}
+
+fn link_spec(base: &Path, target: &Path) -> String {
+    let rel = pathdiff::diff_paths(target, base).unwrap_or_else(|| target.to_path_buf());
+    format!("link:{}", rel.display().to_string().replace('\\', "/"))
+}
+
+fn already_declared(manifest: &PackageManifest, name: &str) -> bool {
+    DEPENDENCY_FIELDS.iter().any(|field| {
+        manifest
+            .value()
+            .get(field)
+            .and_then(serde_json::Value::as_object)
+            .is_some_and(|deps| deps.contains_key(name))
+    })
+}
+
 impl LinkArgs {
     pub async fn run<Reporter: self::Reporter + 'static>(
         self,
-        mut state: State,
+        config: &'static mut Config,
+        manifest_path: PathBuf,
     ) -> miette::Result<()> {
         if self.package_paths.is_empty() {
-            return Err(miette::miette!(
-                "Cannot link by package name. Use a relative or absolute path instead."
-            ));
+            return Err(LinkError::NoParams.into());
         }
 
-        let manifest_dir = state
-            .manifest
-            .path()
+        if let Some(name) = self.package_paths.iter().find(|path| !is_filespec(path)) {
+            return Err(LinkError::LinkByName { name: name.clone() }.into());
+        }
+
+        let manifest_dir = manifest_path
             .parent()
             .ok_or_else(|| miette::miette!("manifest path has no parent directory"))?
             .to_path_buf();
 
+        let mut manifest = PackageManifest::create_if_needed(manifest_path.clone())
+            .wrap_err("reading the project package.json")?;
+
+        let root_dir = config.workspace_dir.clone().unwrap_or_else(|| manifest_dir.clone());
+
+        let mut new_overrides = IndexMap::<String, String>::new();
         for path_str in &self.package_paths {
             let target_path = PathBuf::from(path_str);
             let target_dir = if target_path.is_absolute() {
@@ -46,17 +104,29 @@ impl LinkArgs {
                 .ok_or_else(|| miette::miette!("Target package does not have a name field"))?
                 .to_string();
 
-            let normalized = pathdiff::diff_paths(&target_dir, &manifest_dir)
-                .ok_or_else(|| miette::miette!("cannot compute relative path to target"))?;
-            let link_spec = format!("link:{}", normalized.display().to_string().replace('\\', "/"));
-
-            let manifest = &mut state.manifest;
-            manifest
-                .add_dependency(&package_name, &link_spec, DependencyGroup::Prod)
-                .wrap_err("adding linked dependency to package.json")?;
+            if !already_declared(&manifest, &package_name) {
+                manifest
+                    .add_dependency(
+                        &package_name,
+                        &link_spec(&manifest_dir, &target_dir),
+                        DependencyGroup::Prod,
+                    )
+                    .wrap_err("adding linked dependency to package.json")?;
+            }
+            new_overrides.insert(package_name, link_spec(&root_dir, &target_dir));
         }
 
-        state.manifest.save().wrap_err("saving package.json with linked dependencies")?;
+        manifest.save().wrap_err("saving package.json with linked dependencies")?;
+
+        set_overrides(&root_dir, new_overrides.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+            .wrap_err("recording linked dependencies in pnpm-workspace.yaml")?;
+
+        let overrides = config.overrides.get_or_insert_with(IndexMap::new);
+        for (selector, specifier) in &new_overrides {
+            overrides.insert(selector.clone(), specifier.clone());
+        }
+
+        let state = State::init(manifest_path, config, false).wrap_err("initialize the state")?;
 
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &state;
@@ -67,9 +137,9 @@ impl LinkArgs {
             .map(|parent| parent.join(pacquet_lockfile::Lockfile::FILE_NAME));
 
         Install {
-            tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
+            tarball_mem_cache: Arc::clone(tarball_mem_cache),
             http_client,
-            http_client_arc: std::sync::Arc::clone(http_client),
+            http_client_arc: Arc::clone(http_client),
             config,
             manifest,
             lockfile: pacquet_lockfile::MaybeLazyLockfile::Lazy(lockfile),
@@ -81,19 +151,19 @@ impl LinkArgs {
             ]
             .into_iter(),
             frozen_lockfile: false,
-            prefer_frozen_lockfile: None,
+            prefer_frozen_lockfile: Some(false),
             ignore_manifest_check: false,
-            skip_runtimes: false,
-            trust_lockfile: false,
+            skip_runtimes: config.skip_runtimes,
+            trust_lockfile: config.trust_lockfile,
             update_checksums: false,
-            is_full_install: true,
+            is_full_install: false,
             resolved_packages,
             supported_architectures: config.supported_architectures.clone(),
             node_linker: config.node_linker,
             lockfile_only: false,
             dry_run: false,
             disable_optimistic_repeat_install: false,
-            update_seed_policy: pacquet_package_manager::UpdateSeedPolicy::KeepAll,
+            update_seed_policy: UpdateSeedPolicy::KeepAll,
             auth_override: None,
             resolution_observer: None,
             catalogs_override: None,

--- a/pacquet/crates/cli/src/cli_args/link.rs
+++ b/pacquet/crates/cli/src/cli_args/link.rs
@@ -22,29 +22,34 @@ impl LinkArgs {
             ));
         }
 
+        let manifest_dir = state
+            .manifest
+            .path()
+            .parent()
+            .ok_or_else(|| miette::miette!("manifest path has no parent directory"))?
+            .to_path_buf();
+
         for path_str in &self.package_paths {
             let target_path = PathBuf::from(path_str);
             let target_dir = if target_path.is_absolute() {
                 target_path.clone()
             } else {
-                let base =
-                    state.manifest.path().parent().expect("manifest path always has a parent dir");
-                base.join(&target_path)
+                manifest_dir.join(&target_path)
             };
 
             let target_manifest_path = target_dir.join("package.json");
-            if !target_manifest_path.exists() {
-                return Err(miette::miette!("No package.json found in {}", target_dir.display()));
-            }
-
-            let target_manifest = PackageManifest::from_path(target_manifest_path)
-                .wrap_err("reading target package manifest")?;
+            let target_manifest =
+                PackageManifest::from_path(target_manifest_path).map_err(|_| {
+                    miette::miette!("No package.json found in {}", target_dir.display())
+                })?;
             let package_name = target_manifest.value()["name"]
                 .as_str()
                 .ok_or_else(|| miette::miette!("Target package does not have a name field"))?
                 .to_string();
 
-            let link_spec = format!("link:{path_str}");
+            let normalized = pathdiff::diff_paths(&target_dir, &manifest_dir)
+                .ok_or_else(|| miette::miette!("cannot compute relative path to target"))?;
+            let link_spec = format!("link:{}", normalized.display());
 
             let manifest = &mut state.manifest;
             manifest

--- a/pacquet/crates/cli/src/cli_args/link.rs
+++ b/pacquet/crates/cli/src/cli_args/link.rs
@@ -92,6 +92,7 @@ impl LinkArgs {
             node_linker: config.node_linker,
             lockfile_only: false,
             dry_run: false,
+            disable_optimistic_repeat_install: false,
             update_seed_policy: pacquet_package_manager::UpdateSeedPolicy::KeepAll,
             auth_override: None,
             resolution_observer: None,

--- a/pacquet/crates/cli/src/cli_args/link.rs
+++ b/pacquet/crates/cli/src/cli_args/link.rs
@@ -48,7 +48,7 @@ impl LinkArgs {
 
             let normalized = pathdiff::diff_paths(&target_dir, &manifest_dir)
                 .ok_or_else(|| miette::miette!("cannot compute relative path to target"))?;
-            let link_spec = format!("link:{}", normalized.display().to_string().replace("\\", "/"));
+            let link_spec = format!("link:{}", normalized.display().to_string().replace('\\', "/"));
 
             let manifest = &mut state.manifest;
             manifest

--- a/pacquet/crates/cli/src/cli_args/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/tests.rs
@@ -85,6 +85,35 @@ fn runtime_global_flag_parses_after_version() {
 }
 
 #[test]
+fn link_command_parses_with_name_and_alias() {
+    let parsed =
+        CliArgs::try_parse_from(["pacquet", "link", "../foo"]).expect("parses pacquet link");
+    let CliCommand::Link(args) = &parsed.command else {
+        panic!("expected Link command, got {:?}", parsed.command);
+    };
+    assert_eq!(args.package_paths, ["../foo"]);
+}
+
+#[test]
+fn link_command_parses_ln_alias() {
+    let parsed = CliArgs::try_parse_from(["pacquet", "ln", "../bar"]).expect("parses pacquet ln");
+    let CliCommand::Link(args) = &parsed.command else {
+        panic!("expected Link command for ln alias, got {:?}", parsed.command);
+    };
+    assert_eq!(args.package_paths, ["../bar"]);
+}
+
+#[test]
+fn link_command_parses_multiple_paths() {
+    let parsed = CliArgs::try_parse_from(["pacquet", "link", "../a", "../b", "../c"])
+        .expect("parses pacquet link with multiple paths");
+    let CliCommand::Link(args) = &parsed.command else {
+        panic!("expected Link command, got {:?}", parsed.command);
+    };
+    assert_eq!(args.package_paths, ["../a", "../b", "../c"]);
+}
+
+#[test]
 fn package_manager_to_sync_preserves_dev_engine_specifier() {
     let root = TempDir::new().expect("tmp dir");
     let manifest_path = root.path().join("package.json");

--- a/pacquet/crates/cli/tests/link.rs
+++ b/pacquet/crates/cli/tests/link.rs
@@ -63,7 +63,7 @@ fn link_succeeds_with_valid_target() {
     )
     .expect("write target package.json");
 
-    pacquet.with_arg("link").with_arg(target_dir.to_str().unwrap()).assert().success();
+    pacquet.with_arg("link").with_arg("../target-project").assert().success();
 
     let manifest =
         pacquet_package_manifest::PackageManifest::from_path(workspace.join("package.json"))
@@ -95,7 +95,7 @@ fn link_fails_target_no_name() {
     )
     .expect("write target package.json");
 
-    pacquet.with_arg("link").with_arg(target_dir.to_str().unwrap()).assert().failure();
+    pacquet.with_arg("link").with_arg("../target-project-no-name").assert().failure();
 
     drop((root, mock_instance));
 }

--- a/pacquet/crates/cli/tests/link.rs
+++ b/pacquet/crates/cli/tests/link.rs
@@ -237,3 +237,99 @@ fn ln_alias_succeeds_with_valid_target() {
 
     drop((root, mock_instance));
 }
+
+/// `link` records the `link:` specifier in `pnpm-workspace.yaml`'s
+/// `overrides:` block (mirroring pnpm), not just in `dependencies`.
+#[test]
+fn link_persists_override_to_workspace_yaml() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "test-project", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write package.json");
+
+    let target_dir = root.path().join("override-target");
+    fs::create_dir_all(&target_dir).expect("create target dir");
+    fs::write(
+        target_dir.join("package.json"),
+        serde_json::json!({ "name": "override-target", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write target package.json");
+
+    pacquet.with_arg("link").with_arg("../override-target").assert().success();
+
+    let workspace_yaml =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace yaml");
+    assert!(workspace_yaml.contains("overrides:"), "overrides block must exist: {workspace_yaml}");
+    assert!(
+        workspace_yaml.contains("override-target: link:../override-target"),
+        "override must record the link spec: {workspace_yaml}",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// When the package is already declared in another dependency field, `link`
+/// records the override but does not add a duplicate `dependencies` entry,
+/// matching pnpm's `DEPENDENCIES_FIELDS.every(...)` guard. The override is
+/// what makes the `link:` spec win, so the install links the local target
+/// even though the existing spec is a registry range.
+#[test]
+fn link_existing_dependency_writes_override_only() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "test-project",
+            "version": "1.0.0",
+            "devDependencies": { "target-project": "^1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let target_dir = root.path().join("target-project");
+    fs::create_dir_all(&target_dir).expect("create target dir");
+    fs::write(
+        target_dir.join("package.json"),
+        serde_json::json!({ "name": "target-project", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write target package.json");
+
+    pacquet.with_arg("link").with_arg("../target-project").assert().success();
+
+    let manifest =
+        pacquet_package_manifest::PackageManifest::from_path(workspace.join("package.json"))
+            .expect("read manifest");
+    assert!(
+        manifest.value().get("dependencies").is_none(),
+        "no dependencies entry should be added when already declared elsewhere",
+    );
+    let dev_deps = manifest.value()["devDependencies"].as_object().expect("devDependencies exist");
+    assert_eq!(dev_deps["target-project"], "^1.0.0", "the existing entry stays untouched");
+
+    let workspace_yaml =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace yaml");
+    assert!(
+        workspace_yaml.contains("target-project: link:../target-project"),
+        "override must record the link spec: {workspace_yaml}",
+    );
+
+    // The install succeeded despite the registry-spec devDependency, which is
+    // only possible because the in-memory override rewrote it to the local
+    // `link:` — confirm the symlink was created rather than a registry fetch.
+    let linked = workspace.join("node_modules").join("target-project");
+    assert!(
+        fs::symlink_metadata(&linked).is_ok_and(|meta| meta.file_type().is_symlink()),
+        "node_modules/target-project must be a symlink created from the link override",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pacquet/crates/cli/tests/link.rs
+++ b/pacquet/crates/cli/tests/link.rs
@@ -1,0 +1,43 @@
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::fs;
+
+#[test]
+fn link_fails_without_paths() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "test-project", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write package.json");
+
+    let output = pacquet.with_arg("link").output().expect("spawn pacquet link");
+    assert!(!output.status.success(), "link without paths must fail");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn link_fails_with_nonexistent_target() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "test-project", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write package.json");
+
+    let output = pacquet
+        .with_arg("link")
+        .with_arg("/nonexistent/path")
+        .output()
+        .expect("spawn pacquet link");
+    assert!(!output.status.success(), "link to nonexistent path must fail");
+
+    drop((root, mock_instance));
+}

--- a/pacquet/crates/cli/tests/link.rs
+++ b/pacquet/crates/cli/tests/link.rs
@@ -65,7 +65,9 @@ fn link_succeeds_with_valid_target() {
 
     pacquet.with_arg("link").with_arg(target_dir.to_str().unwrap()).assert().success();
 
-    let manifest = pacquet_package_manifest::PackageManifest::from_path(workspace.join("package.json")).expect("read manifest");
+    let manifest =
+        pacquet_package_manifest::PackageManifest::from_path(workspace.join("package.json"))
+            .expect("read manifest");
     let deps = manifest.value()["dependencies"].as_object().expect("dependencies exist");
     assert!(deps.contains_key("target-project"), "dependency must exist");
     assert_eq!(deps["target-project"], "link:../target-project");

--- a/pacquet/crates/cli/tests/link.rs
+++ b/pacquet/crates/cli/tests/link.rs
@@ -17,6 +17,29 @@ fn link_fails_without_paths() {
 
     let output = pacquet.with_arg("link").output().expect("spawn pacquet link");
     assert!(!output.status.success(), "link without paths must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Cannot link by package name"),
+        "stderr should contain error message: {stderr}"
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn ln_alias_fails_without_paths() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "test-project", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write package.json");
+
+    let output = pacquet.with_arg("ln").output().expect("spawn pacquet ln");
+    assert!(!output.status.success(), "ln alias without paths must fail");
 
     drop((root, mock_instance));
 }
@@ -39,6 +62,11 @@ fn link_fails_with_nonexistent_target() {
         .output()
         .expect("spawn pacquet link");
     assert!(!output.status.success(), "link to nonexistent path must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("No package.json found"),
+        "stderr should contain error message: {stderr}"
+    );
 
     drop((root, mock_instance));
 }
@@ -76,6 +104,77 @@ fn link_succeeds_with_valid_target() {
 }
 
 #[test]
+fn link_succeeds_with_absolute_path() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "test-project", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write package.json");
+
+    let target_dir = root.path().join("abs-target");
+    fs::create_dir_all(&target_dir).expect("create target dir");
+    fs::write(
+        target_dir.join("package.json"),
+        serde_json::json!({ "name": "abs-target", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write target package.json");
+
+    pacquet.with_arg("link").with_arg(target_dir.to_string_lossy().as_ref()).assert().success();
+
+    let manifest =
+        pacquet_package_manifest::PackageManifest::from_path(workspace.join("package.json"))
+            .expect("read manifest");
+    let deps = manifest.value()["dependencies"].as_object().expect("dependencies exist");
+    assert!(deps.contains_key("abs-target"), "dependency must exist");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn link_succeeds_with_multiple_targets() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "test-project", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write package.json");
+
+    let target_a = root.path().join("multi-a");
+    fs::create_dir_all(&target_a).expect("create target dir");
+    fs::write(
+        target_a.join("package.json"),
+        serde_json::json!({ "name": "multi-a", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write target package.json");
+
+    let target_b = root.path().join("multi-b");
+    fs::create_dir_all(&target_b).expect("create target dir");
+    fs::write(
+        target_b.join("package.json"),
+        serde_json::json!({ "name": "multi-b", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write target package.json");
+
+    pacquet.with_arg("link").with_arg("../multi-a").with_arg("../multi-b").assert().success();
+
+    let manifest =
+        pacquet_package_manifest::PackageManifest::from_path(workspace.join("package.json"))
+            .expect("read manifest");
+    let deps = manifest.value()["dependencies"].as_object().expect("dependencies exist");
+    assert!(deps.contains_key("multi-a"), "dependency multi-a must exist");
+    assert!(deps.contains_key("multi-b"), "dependency multi-b must exist");
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn link_fails_target_no_name() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
@@ -95,7 +194,46 @@ fn link_fails_target_no_name() {
     )
     .expect("write target package.json");
 
-    pacquet.with_arg("link").with_arg("../target-project-no-name").assert().failure();
+    let output =
+        pacquet.with_arg("link").with_arg("../target-project-no-name").output().expect("spawn");
+    assert!(!output.status.success(), "link to target without name must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("does not have a name"),
+        "stderr should contain error message: {stderr}"
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn ln_alias_succeeds_with_valid_target() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "test-project", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write package.json");
+
+    let target_dir = root.path().join("ln-target");
+    fs::create_dir_all(&target_dir).expect("create target dir");
+    fs::write(
+        target_dir.join("package.json"),
+        serde_json::json!({ "name": "ln-target", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write target package.json");
+
+    pacquet.with_arg("ln").with_arg("../ln-target").assert().success();
+
+    let manifest =
+        pacquet_package_manifest::PackageManifest::from_path(workspace.join("package.json"))
+            .expect("read manifest");
+    let deps = manifest.value()["dependencies"].as_object().expect("dependencies exist");
+    assert!(deps.contains_key("ln-target"), "dependency must exist");
+    assert_eq!(deps["ln-target"], "link:../ln-target");
 
     drop((root, mock_instance));
 }

--- a/pacquet/crates/cli/tests/link.rs
+++ b/pacquet/crates/cli/tests/link.rs
@@ -35,7 +35,7 @@ fn link_fails_with_nonexistent_target() {
 
     let output = pacquet
         .with_arg("link")
-        .with_arg("/nonexistent/path")
+        .with_arg(workspace.join("definitely-missing-target").to_string_lossy().as_ref())
         .output()
         .expect("spawn pacquet link");
     assert!(!output.status.success(), "link to nonexistent path must fail");

--- a/pacquet/crates/cli/tests/link.rs
+++ b/pacquet/crates/cli/tests/link.rs
@@ -41,3 +41,59 @@ fn link_fails_with_nonexistent_target() {
 
     drop((root, mock_instance));
 }
+
+#[test]
+fn link_succeeds_with_valid_target() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "test-project", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write package.json");
+
+    let target_dir = root.join("target-project");
+    fs::create_dir_all(&target_dir).expect("create target dir");
+    fs::write(
+        target_dir.join("package.json"),
+        serde_json::json!({ "name": "target-project", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write target package.json");
+
+    pacquet.with_arg("link").with_arg(target_dir.to_str().unwrap()).assert().success();
+
+    let manifest =
+        pacquet_package_manifest::PackageManifest::from_path(workspace.join("package.json"))
+            .expect("read manifest");
+    let overrides = manifest.value()["pnpm"]["overrides"].as_object().expect("overrides exist");
+    assert!(overrides.contains_key("target-project"), "override must exist");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn link_fails_target_no_name() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "test-project", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write package.json");
+
+    let target_dir = root.join("target-project-no-name");
+    fs::create_dir_all(&target_dir).expect("create target dir");
+    fs::write(
+        target_dir.join("package.json"),
+        serde_json::json!({ "version": "1.0.0" }).to_string(),
+    )
+    .expect("write target package.json");
+
+    pacquet.with_arg("link").with_arg(target_dir.to_str().unwrap()).assert().failure();
+
+    drop((root, mock_instance));
+}

--- a/pacquet/crates/cli/tests/link.rs
+++ b/pacquet/crates/cli/tests/link.rs
@@ -1,3 +1,4 @@
+use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::fs;
@@ -54,7 +55,7 @@ fn link_succeeds_with_valid_target() {
     )
     .expect("write package.json");
 
-    let target_dir = root.join("target-project");
+    let target_dir = root.path().join("target-project");
     fs::create_dir_all(&target_dir).expect("create target dir");
     fs::write(
         target_dir.join("package.json"),
@@ -64,11 +65,10 @@ fn link_succeeds_with_valid_target() {
 
     pacquet.with_arg("link").with_arg(target_dir.to_str().unwrap()).assert().success();
 
-    let manifest =
-        pacquet_package_manifest::PackageManifest::from_path(workspace.join("package.json"))
-            .expect("read manifest");
-    let overrides = manifest.value()["pnpm"]["overrides"].as_object().expect("overrides exist");
-    assert!(overrides.contains_key("target-project"), "override must exist");
+    let manifest = pacquet_package_manifest::PackageManifest::from_path(workspace.join("package.json")).expect("read manifest");
+    let deps = manifest.value()["dependencies"].as_object().expect("dependencies exist");
+    assert!(deps.contains_key("target-project"), "dependency must exist");
+    assert_eq!(deps["target-project"], "link:../target-project");
 
     drop((root, mock_instance));
 }
@@ -85,7 +85,7 @@ fn link_fails_target_no_name() {
     )
     .expect("write package.json");
 
-    let target_dir = root.join("target-project-no-name");
+    let target_dir = root.path().join("target-project-no-name");
     fs::create_dir_all(&target_dir).expect("create target dir");
     fs::write(
         target_dir.join("package.json"),

--- a/pacquet/crates/cli/tests/link.rs
+++ b/pacquet/crates/cli/tests/link.rs
@@ -19,8 +19,8 @@ fn link_fails_without_paths() {
     assert!(!output.status.success(), "link without paths must fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("Cannot link by package name"),
-        "stderr should contain error message: {stderr}"
+        stderr.contains("You must provide a parameter"),
+        "stderr should contain error message: {stderr}",
     );
 
     drop((root, mock_instance));
@@ -65,7 +65,7 @@ fn link_fails_with_nonexistent_target() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("No package.json found"),
-        "stderr should contain error message: {stderr}"
+        "stderr should contain error message: {stderr}",
     );
 
     drop((root, mock_instance));
@@ -200,7 +200,7 @@ fn link_fails_target_no_name() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("does not have a name"),
-        "stderr should contain error message: {stderr}"
+        "stderr should contain error message: {stderr}",
     );
 
     drop((root, mock_instance));

--- a/pacquet/crates/workspace-manifest-writer/src/edit.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/edit.rs
@@ -116,6 +116,27 @@ pub(crate) fn add_patched_dependencies(
     Ok(changed)
 }
 
+/// Upsert one `selector → specifier` entry into the top-level `overrides:`
+/// block, creating the block if absent. Returns whether anything changed.
+pub(crate) fn add_overrides(
+    manifest: &mut Manifest,
+    selector: &str,
+    specifier: &str,
+) -> Result<bool, Box<yamlpatch::Error>> {
+    const BLOCK: &str = "overrides";
+    let current_matches =
+        manifest.overrides.as_ref().and_then(|deps| deps.get(selector)).map(String::as_str)
+            == Some(specifier);
+    let changed = upsert_top_level_entry(manifest, BLOCK, selector, specifier, current_matches)?;
+    if changed {
+        manifest
+            .overrides
+            .get_or_insert_with(IndexMap::new)
+            .insert(selector.to_string(), specifier.to_string());
+    }
+    Ok(changed)
+}
+
 fn upsert_top_level_entry(
     manifest: &mut Manifest,
     block_name: &str,

--- a/pacquet/crates/workspace-manifest-writer/src/lib.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/lib.rs
@@ -207,6 +207,43 @@ pub fn set_patched_dependencies(
     write_or_remove_manifest(&path, manifest)
 }
 
+/// Upsert `selector → specifier` entries into `dir`'s `pnpm-workspace.yaml`
+/// `overrides:` block (creating the file/block if absent), preserving the
+/// rest of the document's formatting, and write the file back only when
+/// something actually changed. Used by `pacquet link` to record link: overrides.
+///
+/// `entries` is iterated in its own order; pass an ordered map for a
+/// deterministic result.
+pub fn set_overrides<'a, Entries>(
+    dir: &Path,
+    entries: Entries,
+) -> Result<(), UpdateWorkspaceManifestError>
+where
+    Entries: IntoIterator<Item = (&'a str, &'a str)>,
+{
+    let path = dir.join(WORKSPACE_MANIFEST_FILENAME);
+
+    let original = match fs::read_to_string(&path) {
+        Ok(text) => Some(text),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => None,
+        Err(source) => return Err(UpdateWorkspaceManifestError::Read { path, source }),
+    };
+
+    let mut manifest = Manifest::parse(original.as_deref())
+        .map_err(|source| UpdateWorkspaceManifestError::Parse { path: path.clone(), source })?;
+
+    let mut changed = false;
+    for (selector, specifier) in entries {
+        changed |= edit::add_overrides(&mut manifest, selector, specifier)
+            .map_err(|source| UpdateWorkspaceManifestError::Edit { path: path.clone(), source })?;
+    }
+    if !changed {
+        return Ok(());
+    }
+
+    write_or_remove_manifest(&path, manifest)
+}
+
 fn write_or_remove_manifest(
     path: &Path,
     manifest: Manifest,

--- a/pacquet/crates/workspace-manifest-writer/src/model.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/model.rs
@@ -27,6 +27,8 @@ pub(crate) struct Manifest {
     pub(crate) allow_builds: Option<IndexMap<String, bool>>,
     /// `patchedDependencies:` entries, keyed by `name[@version]`.
     pub(crate) patched_dependencies: Option<IndexMap<String, String>>,
+    /// `overrides:` entries, keyed by package selector.
+    pub(crate) overrides: Option<IndexMap<String, String>>,
 }
 
 #[derive(Default, Deserialize)]
@@ -41,6 +43,8 @@ struct CatalogData {
     allow_builds: Option<IndexMap<String, AllowBuildValue>>,
     #[serde(default, rename = "patchedDependencies")]
     patched_dependencies: Option<IndexMap<String, String>>,
+    #[serde(default)]
+    overrides: Option<IndexMap<String, OverrideValue>>,
 }
 
 /// An `allowBuilds` value, tolerant of the string form pnpm also accepts
@@ -64,6 +68,16 @@ enum ConfigDepValue {
     Other(serde::de::IgnoredAny),
 }
 
+/// An overrides value, tolerant of non-string forms (nested objects) so
+/// decoding a manifest that uses them doesn't fail. Only the string shape
+/// is retained — the only shape `pacquet link` writes.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum OverrideValue {
+    String(String),
+    Other(serde::de::IgnoredAny),
+}
+
 impl Manifest {
     /// Parse `original` (the file's contents, or `None` when the file is
     /// absent). An empty or whitespace/comment-only document decodes to an
@@ -80,6 +94,7 @@ impl Manifest {
                 config_dependencies: None,
                 allow_builds: None,
                 patched_dependencies: None,
+                overrides: None,
             });
         }
 
@@ -106,6 +121,15 @@ impl Manifest {
                 })
                 .collect()
         });
+        let overrides = data.overrides.map(|entries| {
+            entries
+                .into_iter()
+                .filter_map(|(name, value)| match value {
+                    OverrideValue::String(spec) => Some((name, spec)),
+                    OverrideValue::Other(_) => None,
+                })
+                .collect()
+        });
 
         Ok(Manifest {
             text,
@@ -115,6 +139,7 @@ impl Manifest {
             config_dependencies,
             allow_builds,
             patched_dependencies: data.patched_dependencies,
+            overrides,
         })
     }
 


### PR DESCRIPTION
## Summary

Ports the pnpm link command to the pacquet Rust CLI. Resolves each provided path to its package.json, reads the package name, adds a link: specifier to the manifest under production dependencies, saves the manifest, and runs the install pipeline to wire the symlink into node_modules.

Related to pnpm/pnpm#11633

## Squash Commit Body

Ports the link command from pnpm to pacquet. LinkArgs::run errors when no paths are given (matching pnps cannot link by package name message), then for each path resolves the target directory relative to the manifest parent. It reads the target package.json, extracts the name, and calls PackageManifest::add_dependency with a link: protocol specifier. After saving the manifest, it delegates to Install which resolves the link: protocol through the existing LocalSchemeResolver. No changeset because pacquet is not a published package.

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust pacquet/ port, or the description notes what still needs porting. Implemented in pacquet only; the TypeScript CLI already has this command at pnpm11/installing/commands/src/link.ts.
- [ ] No changeset needed pacquet-internal changes do not affect published packages.
- [ ] No tests added the existing pacquet test infrastructure covers the Install and link resolution paths.
- [ ] No documentation changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new `link` subcommand (with `ln` alias) to link local packages into your project. Provide one or more package paths to validate them, update your manifest with production dependencies, save changes, and then run installation.
* **Bug Fixes**
  * Updated command execution footer behavior so `link` is treated like an install-family command.
* **Tests**
  * Added CLI tests for the `link` command, including failure when no paths are provided and when a target path is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->