### PR TITLE
feat(pacquet-cli): add unlink command

### DIFF
--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -33,6 +33,7 @@ pub mod set_script;
 pub mod stop;
 pub mod store;
 pub mod supported_architectures;
+pub mod unlink;
 pub mod update;
 pub mod update_interactive;
 pub mod why;
@@ -85,6 +86,7 @@ use std::{
 };
 use stop::StopArgs;
 use store::StoreCommand;
+use unlink::UnlinkArgs;
 use update::UpdateArgs;
 use why::WhyArgs;
 
@@ -250,6 +252,9 @@ pub enum CliCommand {
     Prune(PruneArgs),
     /// Fetch packages from the lockfile into the virtual store
     Fetch(FetchArgs),
+    /// Removes links to a local package and reinstalls it
+    #[clap(visible_aliases = ["dislink"])]
+    Unlink(UnlinkArgs),
 }
 
 impl CliArgs {
@@ -339,6 +344,7 @@ impl CliArgs {
                 | CliCommand::Dedupe(_)
                 | CliCommand::Prune(_)
                 | CliCommand::Fetch(_)
+                | CliCommand::Unlink(_)
                 | CliCommand::Create(_)
                 | CliCommand::Runtime(_)
                 // `rebuild` drives the frozen-install pipeline and emits
@@ -809,6 +815,17 @@ impl CliArgs {
                 args.run(dir_ref, || config().map(|m| &*m)).await?;
                 Ok(())
             }),
+            CliCommand::Unlink(args) => match reporter {
+                ReporterType::Default | ReporterType::AppendOnly => {
+                    Box::pin(args.run::<DefaultReporter>(state(false)?)).await?;
+                }
+                ReporterType::Ndjson => {
+                    Box::pin(args.run::<NdjsonReporter>(state(false)?)).await?;
+                }
+                ReporterType::Silent => {
+                    Box::pin(args.run::<SilentReporter>(state(false)?)).await?;
+                }
+            },
             CliCommand::Fetch(args) => match reporter {
                 ReporterType::Default | ReporterType::AppendOnly => {
                     Box::pin(args.run::<DefaultReporter>(state(true)?))

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -815,13 +815,20 @@ impl CliArgs {
                 args.run(dir_ref, || config().map(|m| &*m)).await?;
                 Ok(())
             }),
-            CliCommand::Unlink(args) => match reporter {
-                ReporterType::Default | ReporterType::AppendOnly => {
-                    Box::pin(args.run::<DefaultReporter>(state(false)?))
+            CliCommand::Unlink(args) => {
+                let manifest_path = manifest_path_ref.clone();
+                match reporter {
+                    ReporterType::Default | ReporterType::AppendOnly => {
+                        Box::pin(args.run::<DefaultReporter>(config()?, manifest_path))
+                    }
+                    ReporterType::Ndjson => {
+                        Box::pin(args.run::<NdjsonReporter>(config()?, manifest_path))
+                    }
+                    ReporterType::Silent => {
+                        Box::pin(args.run::<SilentReporter>(config()?, manifest_path))
+                    }
                 }
-                ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(state(false)?)),
-                ReporterType::Silent => Box::pin(args.run::<SilentReporter>(state(false)?)),
-            },
+            }
             CliCommand::Fetch(args) => match reporter {
                 ReporterType::Default | ReporterType::AppendOnly => {
                     Box::pin(args.run::<DefaultReporter>(state(true)?))

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -817,14 +817,10 @@ impl CliArgs {
             }),
             CliCommand::Unlink(args) => match reporter {
                 ReporterType::Default | ReporterType::AppendOnly => {
-                    Box::pin(args.run::<DefaultReporter>(state(false)?)).await?;
+                    Box::pin(args.run::<DefaultReporter>(state(false)?))
                 }
-                ReporterType::Ndjson => {
-                    Box::pin(args.run::<NdjsonReporter>(state(false)?)).await?;
-                }
-                ReporterType::Silent => {
-                    Box::pin(args.run::<SilentReporter>(state(false)?)).await?;
-                }
+                ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(state(false)?)),
+                ReporterType::Silent => Box::pin(args.run::<SilentReporter>(state(false)?)),
             },
             CliCommand::Fetch(args) => match reporter {
                 ReporterType::Default | ReporterType::AppendOnly => {

--- a/pacquet/crates/cli/src/cli_args/unlink.rs
+++ b/pacquet/crates/cli/src/cli_args/unlink.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use miette::Context;
 use pacquet_package_manager::Install;
 use pacquet_package_manifest::DependencyGroup;
-use pacquet_reporter::Reporter;
+use pacquet_reporter::{LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, Reporter};
 
 #[derive(Debug, Args)]
 pub struct UnlinkArgs {
@@ -57,8 +57,6 @@ impl UnlinkArgs {
             }
         }
 
-        state.manifest.save().wrap_err("saving package.json after unlinking")?;
-
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &state;
 
@@ -84,10 +82,10 @@ impl UnlinkArgs {
             frozen_lockfile: false,
             prefer_frozen_lockfile: None,
             ignore_manifest_check: false,
-            skip_runtimes: false,
-            trust_lockfile: false,
+            skip_runtimes: config.skip_runtimes,
+            trust_lockfile: config.trust_lockfile,
             update_checksums: false,
-            is_full_install: true,
+            is_full_install: false,
             resolved_packages,
             supported_architectures: config.supported_architectures.clone(),
             node_linker: config.node_linker,
@@ -97,9 +95,29 @@ impl UnlinkArgs {
             auth_override: None,
             resolution_observer: None,
             catalogs_override: None,
+            disable_optimistic_repeat_install: false,
         }
         .run::<Reporter>()
         .await
-        .wrap_err("unlinking dependencies")
+        .wrap_err("unlinking dependencies")?;
+
+        let updated = state
+            .manifest
+            .save_and_get_written_value()
+            .wrap_err("saving package.json after unlinking")?;
+
+        let prefix = state
+            .manifest
+            .path()
+            .parent()
+            .unwrap_or_else(|| state.manifest.path())
+            .to_string_lossy()
+            .into_owned();
+        Reporter::emit(&LogEvent::PackageManifest(PackageManifestLog {
+            level: LogLevel::Debug,
+            message: PackageManifestMessage::Updated { prefix, updated },
+        }));
+
+        Ok(())
     }
 }

--- a/pacquet/crates/cli/src/cli_args/unlink.rs
+++ b/pacquet/crates/cli/src/cli_args/unlink.rs
@@ -15,26 +15,48 @@ impl UnlinkArgs {
         self,
         mut state: State,
     ) -> miette::Result<()> {
-        let packages_to_remove: Vec<String> = if self.package_names.is_empty() {
-            state
-                .manifest
-                .dependencies([
-                    DependencyGroup::Prod,
-                    DependencyGroup::Dev,
-                    DependencyGroup::Optional,
-                ])
-                .filter(|(_, version)| version.starts_with("link:"))
-                .map(|(name, _)| name.to_string())
-                .collect()
-        } else {
-            self.package_names.clone()
+        let overrides = state
+            .manifest
+            .value()
+            .get("pnpm")
+            .and_then(|v| v.get("overrides"))
+            .and_then(|v| v.as_object());
+
+        let packages_to_remove: Vec<String> = match overrides {
+            None => return Ok(()),
+            Some(obj) if self.package_names.is_empty() => obj
+                .iter()
+                .filter(|(_, v)| v.as_str().is_some_and(|s| s.starts_with("link:")))
+                .map(|(k, _)| k.clone())
+                .collect(),
+            Some(obj) => self
+                .package_names
+                .iter()
+                .filter(|name| {
+                    obj.get(name.as_str())
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|s| s.starts_with("link:"))
+                })
+                .cloned()
+                .collect(),
         };
 
         if packages_to_remove.is_empty() {
             return Ok(());
         }
 
-        state.manifest.remove_dependencies(&packages_to_remove, None);
+        if let Some(obj) = state
+            .manifest
+            .value_mut()
+            .get_mut("pnpm")
+            .and_then(|v| v.get_mut("overrides"))
+            .and_then(|v| v.as_object_mut())
+        {
+            for name in &packages_to_remove {
+                obj.remove(name.as_str());
+            }
+        }
+
         state.manifest.save().wrap_err("saving package.json after unlinking")?;
 
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =

--- a/pacquet/crates/cli/src/cli_args/unlink.rs
+++ b/pacquet/crates/cli/src/cli_args/unlink.rs
@@ -1,0 +1,83 @@
+use crate::State;
+use clap::Args;
+use miette::Context;
+use pacquet_package_manager::Install;
+use pacquet_package_manifest::DependencyGroup;
+use pacquet_reporter::Reporter;
+
+#[derive(Debug, Args)]
+pub struct UnlinkArgs {
+    pub package_names: Vec<String>,
+}
+
+impl UnlinkArgs {
+    pub async fn run<Reporter: self::Reporter + 'static>(
+        self,
+        mut state: State,
+    ) -> miette::Result<()> {
+        let packages_to_remove: Vec<String> = if self.package_names.is_empty() {
+            state
+                .manifest
+                .dependencies([
+                    DependencyGroup::Prod,
+                    DependencyGroup::Dev,
+                    DependencyGroup::Optional,
+                ])
+                .filter(|(_, version)| version.starts_with("link:"))
+                .map(|(name, _)| name.to_string())
+                .collect()
+        } else {
+            self.package_names.clone()
+        };
+
+        if packages_to_remove.is_empty() {
+            return Ok(());
+        }
+
+        state.manifest.remove_dependencies(&packages_to_remove, None);
+        state.manifest.save().wrap_err("saving package.json after unlinking")?;
+
+        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
+            &state;
+
+        let lockfile_path = manifest
+            .path()
+            .parent()
+            .map(|parent| parent.join(pacquet_lockfile::Lockfile::FILE_NAME));
+
+        Install {
+            tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
+            http_client,
+            http_client_arc: std::sync::Arc::clone(http_client),
+            config,
+            manifest,
+            lockfile: pacquet_lockfile::MaybeLazyLockfile::Lazy(lockfile),
+            lockfile_path: lockfile_path.as_deref(),
+            dependency_groups: [
+                DependencyGroup::Prod,
+                DependencyGroup::Dev,
+                DependencyGroup::Optional,
+            ]
+            .into_iter(),
+            frozen_lockfile: false,
+            prefer_frozen_lockfile: None,
+            ignore_manifest_check: false,
+            skip_runtimes: false,
+            trust_lockfile: false,
+            update_checksums: false,
+            is_full_install: true,
+            resolved_packages,
+            supported_architectures: config.supported_architectures.clone(),
+            node_linker: config.node_linker,
+            lockfile_only: false,
+            dry_run: false,
+            update_seed_policy: pacquet_package_manager::UpdateSeedPolicy::KeepAll,
+            auth_override: None,
+            resolution_observer: None,
+            catalogs_override: None,
+        }
+        .run::<Reporter>()
+        .await
+        .wrap_err("unlinking dependencies")
+    }
+}

--- a/pacquet/crates/cli/src/cli_args/unlink.rs
+++ b/pacquet/crates/cli/src/cli_args/unlink.rs
@@ -29,8 +29,11 @@ impl UnlinkArgs {
         config: &'static mut Config,
         manifest_path: PathBuf,
     ) -> miette::Result<()> {
-        // pnpm bails with "Nothing to unlink" when no overrides are configured.
+        // pnpm prints "Nothing to unlink" and stops when no overrides are
+        // configured; otherwise it strips the matching link: overrides and
+        // reinstalls — running the install even when nothing matched.
         let Some(overrides) = config.overrides.as_mut() else {
+            println!("Nothing to unlink");
             return Ok(());
         };
 
@@ -44,22 +47,20 @@ impl UnlinkArgs {
             .map(|(selector, _)| selector.clone())
             .collect();
 
-        if removed.is_empty() {
-            return Ok(());
-        }
-
         for selector in &removed {
             overrides.shift_remove(selector);
         }
 
-        let root_dir = config
-            .workspace_dir
-            .clone()
-            .or_else(|| manifest_path.parent().map(Path::to_path_buf))
-            .ok_or_else(|| miette::miette!("manifest path has no parent directory"))?;
+        if !removed.is_empty() {
+            let root_dir = config
+                .workspace_dir
+                .clone()
+                .or_else(|| manifest_path.parent().map(Path::to_path_buf))
+                .ok_or_else(|| miette::miette!("manifest path has no parent directory"))?;
 
-        remove_overrides(&root_dir, &removed)
-            .wrap_err("removing link: overrides from pnpm-workspace.yaml")?;
+            remove_overrides(&root_dir, &removed)
+                .wrap_err("removing link: overrides from pnpm-workspace.yaml")?;
+        }
 
         let state = State::init(manifest_path, config, false).wrap_err("initialize the state")?;
 

--- a/pacquet/crates/cli/src/cli_args/unlink.rs
+++ b/pacquet/crates/cli/src/cli_args/unlink.rs
@@ -1,10 +1,23 @@
 use crate::State;
 use clap::Args;
 use miette::Context;
-use pacquet_package_manager::Install;
+use pacquet_config::Config;
+use pacquet_package_manager::{Install, UpdateSeedPolicy};
 use pacquet_package_manifest::DependencyGroup;
-use pacquet_reporter::{LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, Reporter};
+use pacquet_reporter::Reporter;
+use pacquet_workspace_manifest_writer::remove_overrides;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
+/// Removes the link created by `pacquet link` and reinstalls the package if
+/// it is saved in `package.json`.
+///
+/// Mirrors pnpm's `unlink`: it strips `link:` entries from the `overrides`
+/// block in `pnpm-workspace.yaml` (the same source the installer reads), then
+/// runs install so the previous resolution is restored. With package names it
+/// only drops the matching `link:` overrides; with none it drops them all.
 #[derive(Debug, Args)]
 pub struct UnlinkArgs {
     pub package_names: Vec<String>,
@@ -13,49 +26,42 @@ pub struct UnlinkArgs {
 impl UnlinkArgs {
     pub async fn run<Reporter: self::Reporter + 'static>(
         self,
-        mut state: State,
+        config: &'static mut Config,
+        manifest_path: PathBuf,
     ) -> miette::Result<()> {
-        let overrides = state
-            .manifest
-            .value()
-            .get("pnpm")
-            .and_then(|v| v.get("overrides"))
-            .and_then(|v| v.as_object());
-
-        let packages_to_remove: Vec<String> = match overrides {
-            None => return Ok(()),
-            Some(obj) if self.package_names.is_empty() => obj
-                .iter()
-                .filter(|(_, v)| v.as_str().is_some_and(|s| s.starts_with("link:")))
-                .map(|(k, _)| k.clone())
-                .collect(),
-            Some(obj) => self
-                .package_names
-                .iter()
-                .filter(|name| {
-                    obj.get(name.as_str())
-                        .and_then(|v| v.as_str())
-                        .is_some_and(|s| s.starts_with("link:"))
-                })
-                .cloned()
-                .collect(),
+        // pnpm bails with "Nothing to unlink" when no overrides are configured.
+        let Some(overrides) = config.overrides.as_mut() else {
+            return Ok(());
         };
 
-        if packages_to_remove.is_empty() {
+        let removed: Vec<String> = overrides
+            .iter()
+            .filter(|(selector, specifier)| {
+                specifier.starts_with("link:")
+                    && (self.package_names.is_empty()
+                        || self.package_names.iter().any(|name| name == *selector))
+            })
+            .map(|(selector, _)| selector.clone())
+            .collect();
+
+        if removed.is_empty() {
             return Ok(());
         }
 
-        if let Some(obj) = state
-            .manifest
-            .value_mut()
-            .get_mut("pnpm")
-            .and_then(|v| v.get_mut("overrides"))
-            .and_then(|v| v.as_object_mut())
-        {
-            for name in &packages_to_remove {
-                obj.remove(name.as_str());
-            }
+        for selector in &removed {
+            overrides.shift_remove(selector);
         }
+
+        let root_dir = config
+            .workspace_dir
+            .clone()
+            .or_else(|| manifest_path.parent().map(Path::to_path_buf))
+            .ok_or_else(|| miette::miette!("manifest path has no parent directory"))?;
+
+        remove_overrides(&root_dir, &removed)
+            .wrap_err("removing link: overrides from pnpm-workspace.yaml")?;
+
+        let state = State::init(manifest_path, config, false).wrap_err("initialize the state")?;
 
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &state;
@@ -66,9 +72,9 @@ impl UnlinkArgs {
             .map(|parent| parent.join(pacquet_lockfile::Lockfile::FILE_NAME));
 
         Install {
-            tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
+            tarball_mem_cache: Arc::clone(tarball_mem_cache),
             http_client,
-            http_client_arc: std::sync::Arc::clone(http_client),
+            http_client_arc: Arc::clone(http_client),
             config,
             manifest,
             lockfile: pacquet_lockfile::MaybeLazyLockfile::Lazy(lockfile),
@@ -80,7 +86,7 @@ impl UnlinkArgs {
             ]
             .into_iter(),
             frozen_lockfile: false,
-            prefer_frozen_lockfile: None,
+            prefer_frozen_lockfile: Some(false),
             ignore_manifest_check: false,
             skip_runtimes: config.skip_runtimes,
             trust_lockfile: config.trust_lockfile,
@@ -91,33 +97,14 @@ impl UnlinkArgs {
             node_linker: config.node_linker,
             lockfile_only: false,
             dry_run: false,
-            update_seed_policy: pacquet_package_manager::UpdateSeedPolicy::KeepAll,
+            disable_optimistic_repeat_install: false,
+            update_seed_policy: UpdateSeedPolicy::KeepAll,
             auth_override: None,
             resolution_observer: None,
             catalogs_override: None,
-            disable_optimistic_repeat_install: false,
         }
         .run::<Reporter>()
         .await
-        .wrap_err("unlinking dependencies")?;
-
-        let updated = state
-            .manifest
-            .save_and_get_written_value()
-            .wrap_err("saving package.json after unlinking")?;
-
-        let prefix = state
-            .manifest
-            .path()
-            .parent()
-            .unwrap_or_else(|| state.manifest.path())
-            .to_string_lossy()
-            .into_owned();
-        Reporter::emit(&LogEvent::PackageManifest(PackageManifestLog {
-            level: LogLevel::Debug,
-            message: PackageManifestMessage::Updated { prefix, updated },
-        }));
-
-        Ok(())
+        .wrap_err("unlinking dependencies")
     }
 }

--- a/pacquet/crates/cli/tests/unlink.rs
+++ b/pacquet/crates/cli/tests/unlink.rs
@@ -133,3 +133,101 @@ fn unlink_ignores_non_linked_packages() {
 
     drop((root, mock_instance));
 }
+
+#[test]
+fn unlink_filters_non_link_packages_from_args() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "name": "test-project",
+            "version": "1.0.0",
+            "pnpm": {
+                "overrides": {
+                    "foo": "link:../foo",
+                    "bar": "link:../bar",
+                    "baz": "1.0.0",
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_args(["unlink", "foo", "baz"]).assert().success();
+
+    let manifest = PackageManifest::from_path(manifest_path).expect("read manifest");
+    let overrides = manifest.value()["pnpm"]["overrides"].as_object().unwrap();
+    assert!(!overrides.contains_key("foo"), "foo (link:) must be removed");
+    assert!(overrides.contains_key("baz"), "baz (non-link) must remain");
+    assert!(overrides.contains_key("bar"), "bar must remain");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn dislink_alias_works() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "name": "test-project",
+            "version": "1.0.0",
+            "pnpm": {
+                "overrides": {
+                    "foo": "link:../foo",
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_args(["dislink", "foo"]).assert().success();
+
+    let manifest = PackageManifest::from_path(manifest_path).expect("read manifest");
+    let overrides = manifest.value()["pnpm"]["overrides"].as_object().unwrap();
+    assert!(!overrides.contains_key("foo"), "foo must be removed via dislink alias");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn unlink_multiple_link_overrides() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "name": "test-project",
+            "version": "1.0.0",
+            "pnpm": {
+                "overrides": {
+                    "foo": "link:../foo",
+                    "bar": "link:../bar",
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_args(["unlink", "foo", "bar"]).assert().success();
+
+    let manifest = PackageManifest::from_path(manifest_path).expect("read manifest");
+    let overrides = manifest.value()["pnpm"]["overrides"].as_object().unwrap();
+    assert!(overrides.is_empty(), "all link overrides must be removed");
+
+    drop((root, mock_instance));
+}

--- a/pacquet/crates/cli/tests/unlink.rs
+++ b/pacquet/crates/cli/tests/unlink.rs
@@ -1,0 +1,79 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_package_manifest::PackageManifest;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::fs;
+
+#[test]
+fn unlink_removes_single_link_override() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "name": "test-project",
+            "version": "1.0.0",
+            "pnpm": {
+                "overrides": {
+                    "foo": "link:../foo",
+                    "bar": "link:../bar",
+                    "baz": "1.0.0",
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_args(["unlink", "foo"]).assert().success();
+
+    let manifest = PackageManifest::from_path(manifest_path).expect("read manifest");
+    let overrides = manifest.value()["pnpm"]["overrides"].as_object();
+    assert!(overrides.is_some(), "overrides must still exist");
+    let overrides = overrides.unwrap();
+    assert!(!overrides.contains_key("foo"), "foo must be removed from overrides");
+    assert!(overrides.contains_key("bar"), "bar must remain in overrides");
+    assert!(overrides.contains_key("baz"), "non-link override must remain");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn unlink_without_args_removes_all_link_overrides() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "name": "test-project",
+            "version": "1.0.0",
+            "pnpm": {
+                "overrides": {
+                    "foo": "link:../foo",
+                    "bar": "link:../bar",
+                    "baz": "1.0.0",
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_arg("unlink").assert().success();
+
+    let manifest = PackageManifest::from_path(manifest_path).expect("read manifest");
+    let overrides = manifest.value()["pnpm"]["overrides"].as_object();
+    assert!(overrides.is_some(), "overrides must still exist");
+    let overrides = overrides.unwrap();
+    assert!(!overrides.contains_key("foo"), "foo must be removed from overrides");
+    assert!(!overrides.contains_key("bar"), "bar must be removed from overrides");
+    assert!(overrides.contains_key("baz"), "non-link override must remain");
+
+    drop((root, mock_instance));
+}

--- a/pacquet/crates/cli/tests/unlink.rs
+++ b/pacquet/crates/cli/tests/unlink.rs
@@ -77,3 +77,59 @@ fn unlink_without_args_removes_all_link_overrides() {
 
     drop((root, mock_instance));
 }
+
+#[test]
+fn unlink_does_nothing_if_no_overrides() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "name": "test-project",
+            "version": "1.0.0",
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_arg("unlink").assert().success();
+
+    let manifest = PackageManifest::from_path(manifest_path).expect("read manifest");
+    assert!(manifest.value().get("pnpm").is_none(), "no overrides should be created");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn unlink_ignores_non_linked_packages() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "name": "test-project",
+            "version": "1.0.0",
+            "pnpm": {
+                "overrides": {
+                    "baz": "1.0.0",
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_args(["unlink", "baz"]).assert().success();
+
+    let manifest = PackageManifest::from_path(manifest_path).expect("read manifest");
+    let overrides = manifest.value()["pnpm"]["overrides"].as_object().unwrap();
+    assert!(overrides.contains_key("baz"), "non-link override must remain");
+
+    drop((root, mock_instance));
+}

--- a/pacquet/crates/cli/tests/unlink.rs
+++ b/pacquet/crates/cli/tests/unlink.rs
@@ -1,42 +1,52 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use pacquet_package_manifest::PackageManifest;
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
-use std::fs;
+use std::{fs, path::Path};
+
+fn write_manifest(workspace: &Path, manifest: &serde_json::Value) {
+    fs::write(workspace.join("package.json"), manifest.to_string()).expect("write package.json");
+}
+
+/// Append an `overrides` block to the `pnpm-workspace.yaml` the mocked
+/// registry already wrote (it carries `storeDir`/`cacheDir`, so the tests must
+/// extend it rather than overwrite it). Pacquet (like pnpm) reads `overrides`
+/// from `pnpm-workspace.yaml`, not from `package.json#pnpm.overrides`, so this
+/// is where the link must be set up.
+fn add_overrides(workspace: &Path, block: &str) {
+    let path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&path).unwrap_or_default();
+    if !yaml.is_empty() && !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    yaml.push_str(block);
+    fs::write(&path, yaml).expect("update pnpm-workspace.yaml");
+}
+
+fn read_workspace_yaml(workspace: &Path) -> String {
+    fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace yaml")
+}
 
 #[test]
-fn unlink_removes_single_link_override() {
+fn unlink_removes_single_named_link_override() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
 
-    let manifest_path = workspace.join("package.json");
-    fs::write(
-        &manifest_path,
-        serde_json::json!({
-            "name": "test-project",
-            "version": "1.0.0",
-            "pnpm": {
-                "overrides": {
-                    "foo": "link:../foo",
-                    "bar": "link:../bar",
-                    "baz": "1.0.0",
-                }
-            }
-        })
-        .to_string(),
-    )
-    .expect("write package.json");
+    write_manifest(&workspace, &serde_json::json!({ "name": "test-project", "version": "1.0.0" }));
+    add_overrides(&workspace, "overrides:\n  foo: link:../foo\n  bar: link:../bar\n  baz: 1.0.0\n");
 
     pacquet.with_args(["unlink", "foo"]).assert().success();
 
-    let manifest = PackageManifest::from_path(manifest_path).expect("read manifest");
-    let overrides = manifest.value()["pnpm"]["overrides"].as_object();
-    assert!(overrides.is_some(), "overrides must still exist");
-    let overrides = overrides.unwrap();
-    assert!(!overrides.contains_key("foo"), "foo must be removed from overrides");
-    assert!(overrides.contains_key("bar"), "bar must remain in overrides");
-    assert!(overrides.contains_key("baz"), "non-link override must remain");
+    let workspace_yaml = read_workspace_yaml(&workspace);
+    assert!(!workspace_yaml.contains("foo"), "foo override must be removed: {workspace_yaml}");
+    assert!(
+        workspace_yaml.contains("bar: link:../bar"),
+        "bar override must remain: {workspace_yaml}",
+    );
+    assert!(
+        workspace_yaml.contains("baz: 1.0.0"),
+        "non-link override must remain: {workspace_yaml}",
+    );
 
     drop((root, mock_instance));
 }
@@ -47,124 +57,81 @@ fn unlink_without_args_removes_all_link_overrides() {
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
 
-    let manifest_path = workspace.join("package.json");
-    fs::write(
-        &manifest_path,
-        serde_json::json!({
-            "name": "test-project",
-            "version": "1.0.0",
-            "pnpm": {
-                "overrides": {
-                    "foo": "link:../foo",
-                    "bar": "link:../bar",
-                    "baz": "1.0.0",
-                }
-            }
-        })
-        .to_string(),
-    )
-    .expect("write package.json");
+    write_manifest(&workspace, &serde_json::json!({ "name": "test-project", "version": "1.0.0" }));
+    add_overrides(&workspace, "overrides:\n  foo: link:../foo\n  bar: link:../bar\n  baz: 1.0.0\n");
 
     pacquet.with_arg("unlink").assert().success();
 
-    let manifest = PackageManifest::from_path(manifest_path).expect("read manifest");
-    let overrides = manifest.value()["pnpm"]["overrides"].as_object();
-    assert!(overrides.is_some(), "overrides must still exist");
-    let overrides = overrides.unwrap();
-    assert!(!overrides.contains_key("foo"), "foo must be removed from overrides");
-    assert!(!overrides.contains_key("bar"), "bar must be removed from overrides");
-    assert!(overrides.contains_key("baz"), "non-link override must remain");
+    let workspace_yaml = read_workspace_yaml(&workspace);
+    assert!(!workspace_yaml.contains("foo"), "foo override must be removed: {workspace_yaml}");
+    assert!(!workspace_yaml.contains("bar"), "bar override must be removed: {workspace_yaml}");
+    assert!(
+        workspace_yaml.contains("baz: 1.0.0"),
+        "non-link override must remain: {workspace_yaml}",
+    );
 
     drop((root, mock_instance));
 }
 
 #[test]
-fn unlink_does_nothing_if_no_overrides() {
+fn unlink_keeps_non_link_overrides() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
 
-    let manifest_path = workspace.join("package.json");
-    fs::write(
-        &manifest_path,
-        serde_json::json!({
-            "name": "test-project",
-            "version": "1.0.0",
-        })
-        .to_string(),
-    )
-    .expect("write package.json");
-
-    pacquet.with_arg("unlink").assert().success();
-
-    let manifest = PackageManifest::from_path(manifest_path).expect("read manifest");
-    assert!(manifest.value().get("pnpm").is_none(), "no overrides should be created");
-
-    drop((root, mock_instance));
-}
-
-#[test]
-fn unlink_ignores_non_linked_packages() {
-    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
-        CommandTempCwd::init().add_mocked_registry();
-    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
-
-    let manifest_path = workspace.join("package.json");
-    fs::write(
-        &manifest_path,
-        serde_json::json!({
-            "name": "test-project",
-            "version": "1.0.0",
-            "pnpm": {
-                "overrides": {
-                    "baz": "1.0.0",
-                }
-            }
-        })
-        .to_string(),
-    )
-    .expect("write package.json");
+    write_manifest(&workspace, &serde_json::json!({ "name": "test-project", "version": "1.0.0" }));
+    add_overrides(&workspace, "overrides:\n  baz: 1.0.0\n");
 
     pacquet.with_args(["unlink", "baz"]).assert().success();
 
-    let manifest = PackageManifest::from_path(manifest_path).expect("read manifest");
-    let overrides = manifest.value()["pnpm"]["overrides"].as_object().unwrap();
-    assert!(overrides.contains_key("baz"), "non-link override must remain");
+    let workspace_yaml = read_workspace_yaml(&workspace);
+    assert!(
+        workspace_yaml.contains("baz: 1.0.0"),
+        "non-link override must remain untouched: {workspace_yaml}",
+    );
 
     drop((root, mock_instance));
 }
 
 #[test]
-fn unlink_filters_non_link_packages_from_args() {
+fn unlink_is_noop_without_overrides() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
 
-    let manifest_path = workspace.join("package.json");
-    fs::write(
-        &manifest_path,
-        serde_json::json!({
-            "name": "test-project",
-            "version": "1.0.0",
-            "pnpm": {
-                "overrides": {
-                    "foo": "link:../foo",
-                    "bar": "link:../bar",
-                    "baz": "1.0.0",
-                }
-            }
-        })
-        .to_string(),
-    )
-    .expect("write package.json");
+    write_manifest(&workspace, &serde_json::json!({ "name": "test-project", "version": "1.0.0" }));
 
-    pacquet.with_args(["unlink", "foo", "baz"]).assert().success();
+    pacquet.with_arg("unlink").assert().success();
 
-    let manifest = PackageManifest::from_path(manifest_path).expect("read manifest");
-    let overrides = manifest.value()["pnpm"]["overrides"].as_object().unwrap();
-    assert!(!overrides.contains_key("foo"), "foo (link:) must be removed");
-    assert!(overrides.contains_key("baz"), "baz (non-link) must remain");
-    assert!(overrides.contains_key("bar"), "bar must remain");
+    let workspace_yaml = read_workspace_yaml(&workspace);
+    assert!(
+        !workspace_yaml.contains("overrides"),
+        "no overrides block should be created when there is nothing to unlink: {workspace_yaml}",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn unlink_drops_overrides_block_when_it_empties() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, &serde_json::json!({ "name": "test-project", "version": "1.0.0" }));
+    add_overrides(&workspace, "overrides:\n  foo: link:../foo\n  bar: link:../bar\n");
+
+    pacquet.with_args(["unlink", "foo", "bar"]).assert().success();
+
+    let workspace_yaml = read_workspace_yaml(&workspace);
+    assert!(
+        !workspace_yaml.contains("overrides:"),
+        "the overrides block must be dropped once empty: {workspace_yaml}",
+    );
+    assert!(
+        workspace_yaml.contains("storeDir"),
+        "unrelated settings must be preserved: {workspace_yaml}",
+    );
 
     drop((root, mock_instance));
 }
@@ -175,59 +142,85 @@ fn dislink_alias_works() {
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
 
-    let manifest_path = workspace.join("package.json");
-    fs::write(
-        &manifest_path,
-        serde_json::json!({
-            "name": "test-project",
-            "version": "1.0.0",
-            "pnpm": {
-                "overrides": {
-                    "foo": "link:../foo",
-                }
-            }
-        })
-        .to_string(),
-    )
-    .expect("write package.json");
+    write_manifest(&workspace, &serde_json::json!({ "name": "test-project", "version": "1.0.0" }));
+    add_overrides(&workspace, "overrides:\n  foo: link:../foo\n  baz: 1.0.0\n");
 
     pacquet.with_args(["dislink", "foo"]).assert().success();
 
-    let manifest = PackageManifest::from_path(manifest_path).expect("read manifest");
-    let overrides = manifest.value()["pnpm"]["overrides"].as_object().unwrap();
-    assert!(!overrides.contains_key("foo"), "foo must be removed via dislink alias");
+    let workspace_yaml = read_workspace_yaml(&workspace);
+    assert!(
+        !workspace_yaml.contains("foo"),
+        "foo must be removed via the dislink alias: {workspace_yaml}",
+    );
+    assert!(
+        workspace_yaml.contains("baz: 1.0.0"),
+        "non-link override must remain: {workspace_yaml}",
+    );
 
     drop((root, mock_instance));
 }
 
+/// End-to-end: a `link:` override redirects a registry dependency to a local
+/// directory, so installing produces a symlink in `node_modules` and a
+/// `link:` resolution in the lockfile. After `unlink`, the override is gone
+/// and the reinstall re-resolves the dependency from the registry — the
+/// lockfile records the registry version instead of the link.
 #[test]
-fn unlink_multiple_link_overrides() {
+fn unlink_restores_registry_package_in_lockfile() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
 
-    let manifest_path = workspace.join("package.json");
+    const PKG: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
+
+    let local_target = workspace.join("local-dep");
+    fs::create_dir_all(&local_target).expect("create local target dir");
     fs::write(
-        &manifest_path,
-        serde_json::json!({
+        local_target.join("package.json"),
+        serde_json::json!({ "name": PKG, "version": "1.0.0" }).to_string(),
+    )
+    .expect("write local target package.json");
+
+    write_manifest(
+        &workspace,
+        &serde_json::json!({
             "name": "test-project",
             "version": "1.0.0",
-            "pnpm": {
-                "overrides": {
-                    "foo": "link:../foo",
-                    "bar": "link:../bar",
-                }
-            }
-        })
-        .to_string(),
-    )
-    .expect("write package.json");
+            "dependencies": { PKG: "100.0.0" },
+        }),
+    );
+    add_overrides(&workspace, &format!("overrides:\n  '{PKG}': link:./local-dep\n"));
 
-    pacquet.with_args(["unlink", "foo", "bar"]).assert().success();
+    // Materialize the link first: the override makes node_modules a symlink
+    // and pins a link: resolution in the lockfile.
+    pacquet.with_arg("install").assert().success();
+    let installed = workspace.join("node_modules").join(PKG);
+    assert!(
+        fs::symlink_metadata(&installed).is_ok_and(|meta| meta.file_type().is_symlink()),
+        "the link override should make node_modules/{PKG} a symlink before unlink",
+    );
 
-    let manifest = PackageManifest::from_path(manifest_path).expect("read manifest");
-    let overrides = manifest.value()["pnpm"]["overrides"].as_object().unwrap();
-    assert!(overrides.is_empty(), "all link overrides must be removed");
+    let mut unlink = std::process::Command::cargo_bin("pacquet").expect("locate pacquet binary");
+    unlink.current_dir(&workspace);
+    unlink.with_args(["unlink", PKG]).assert().success();
+
+    let workspace_yaml = read_workspace_yaml(&workspace);
+    assert!(
+        !workspace_yaml.contains("link:"),
+        "the link override must be removed from pnpm-workspace.yaml: {workspace_yaml}",
+    );
+
+    // The reinstall must re-resolve the dependency from the registry rather
+    // than the local link, so the lockfile records the registry version.
+    let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read lockfile");
+    assert!(
+        lockfile.contains("dep-of-pkg-with-1-dep@100.0.0"),
+        "lockfile must resolve the dependency from the registry after unlink: {lockfile}",
+    );
+    assert!(
+        !lockfile.contains("link:"),
+        "lockfile must not keep the link: resolution after unlink: {lockfile}",
+    );
 
     drop((root, mock_instance));
 }

--- a/pacquet/crates/cli/tests/unlink.rs
+++ b/pacquet/crates/cli/tests/unlink.rs
@@ -101,7 +101,12 @@ fn unlink_is_noop_without_overrides() {
 
     write_manifest(&workspace, &serde_json::json!({ "name": "test-project", "version": "1.0.0" }));
 
-    pacquet.with_arg("unlink").assert().success();
+    let output = pacquet.with_arg("unlink").output().expect("run pacquet unlink");
+    assert!(output.status.success(), "unlink without overrides must succeed");
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("Nothing to unlink"),
+        "unlink must report when there is nothing to unlink, matching pnpm",
+    );
 
     let workspace_yaml = read_workspace_yaml(&workspace);
     assert!(

--- a/pacquet/crates/workspace-manifest-writer/src/edit.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/edit.rs
@@ -138,6 +138,38 @@ pub(crate) fn add_overrides(
     Ok(changed)
 }
 
+/// Delete the given `selectors` from the top-level `overrides:` block,
+/// dropping the whole block when nothing remains. Selectors absent from the
+/// block are ignored. Returns whether anything changed. The inverse of
+/// [`add_overrides`]; used by `pacquet unlink`.
+pub(crate) fn remove_overrides(manifest: &mut Manifest, selectors: &[String]) -> bool {
+    const BLOCK: &str = "overrides";
+    let present: Vec<String> = match manifest.overrides.as_ref() {
+        Some(overrides) => {
+            selectors.iter().filter(|selector| overrides.contains_key(*selector)).cloned().collect()
+        }
+        None => return false,
+    };
+    if present.is_empty() {
+        return false;
+    }
+
+    let overrides = manifest.overrides.as_mut().expect("overrides decoded above");
+    for selector in &present {
+        overrides.shift_remove(selector);
+    }
+    let now_empty = overrides.is_empty();
+
+    if now_empty {
+        manifest.set_text(remove_top_level_block(manifest.text(), BLOCK));
+        manifest.overrides = None;
+        manifest.top_level_keys.retain(|key| key != BLOCK);
+    } else {
+        manifest.set_text(remove_mapping_entries(manifest.text(), &[BLOCK], &present));
+    }
+    true
+}
+
 /// Set `auditConfig.ignoreGhsas:` to `ghsas` (the complete desired list),
 /// creating the `auditConfig:` block or the nested `ignoreGhsas:` key when
 /// absent. An empty `ghsas` removes the `auditConfig:` block. Mirrors the

--- a/pacquet/crates/workspace-manifest-writer/src/edit.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/edit.rs
@@ -9,6 +9,8 @@
 //! are expressed as targeted text splices for inserts and a [`yamlpatch`]
 //! `Op::Replace` for value updates.
 
+use std::fmt::Write as _;
+
 use indexmap::IndexMap;
 use pacquet_catalogs_types::{Catalogs, DEFAULT_CATALOG_NAME};
 use yamlpatch::{Op, Patch};
@@ -158,14 +160,27 @@ pub(crate) fn remove_overrides(manifest: &mut Manifest, selectors: &[String]) ->
     for selector in &present {
         overrides.shift_remove(selector);
     }
-    let now_empty = overrides.is_empty();
 
-    if now_empty {
+    if manifest.overrides.as_ref().is_none_or(IndexMap::is_empty) {
         manifest.set_text(remove_top_level_block(manifest.text(), BLOCK));
         manifest.overrides = None;
         manifest.top_level_keys.retain(|key| key != BLOCK);
-    } else {
+        return true;
+    }
+
+    // A block-style mapping stores each entry on its own line, so the entries
+    // can be excised surgically while preserving the surrounding formatting. A
+    // flow-style mapping (`overrides: { ... }`) exposes no line entries, so
+    // `remove_mapping_entries` would be a silent no-op — fall back to dropping
+    // the block and re-rendering it block-style from the decoded map.
+    let line_based = locate(manifest.text(), &[BLOCK]).is_some_and(|mapping| {
+        present.iter().all(|key| mapping.entries.iter().any(|entry| &entry.key == key))
+    });
+
+    if line_based {
         manifest.set_text(remove_mapping_entries(manifest.text(), &[BLOCK], &present));
+    } else {
+        rerender_overrides_block(manifest, BLOCK);
     }
     true
 }
@@ -335,6 +350,32 @@ fn upsert_sequence_entry(text: &str, block_name: &str, key: &str, items: &[Strin
             .block_end
     };
     splice(text, offset, &rendered)
+}
+
+/// Replace the on-disk `overrides:` block with a block-style rendering of the
+/// decoded (already-edited) map. Used when the original block is flow-style and
+/// cannot be edited entry by entry.
+fn rerender_overrides_block(manifest: &mut Manifest, block_name: &str) {
+    let block = {
+        let overrides = manifest.overrides.as_ref().expect("non-empty overrides above");
+        let mut block = format!("{block_name}:\n");
+        for (selector, specifier) in overrides {
+            writeln!(
+                block,
+                "  {}: {}",
+                render::render_value(selector),
+                render::render_value(specifier),
+            )
+            .expect("writing to a String never fails");
+        }
+        block
+    };
+    manifest.set_text(remove_top_level_block(manifest.text(), block_name));
+    manifest.top_level_keys.retain(|key| key != block_name);
+    let new_text = insert_top_level_block(manifest, block_name, &block);
+    manifest.set_text(new_text);
+    manifest.top_level_keys =
+        render::target_order(&manifest.top_level_keys, &[block_name.to_string()]);
 }
 
 fn upsert_top_level_entry(

--- a/pacquet/crates/workspace-manifest-writer/src/edit.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/edit.rs
@@ -156,33 +156,62 @@ pub(crate) fn remove_overrides(manifest: &mut Manifest, selectors: &[String]) ->
         return false;
     }
 
-    let overrides = manifest.overrides.as_mut().expect("overrides decoded above");
-    for selector in &present {
-        overrides.shift_remove(selector);
+    // Emptiness is judged from the keys actually in the YAML, not the decoded
+    // map: `Manifest::parse` drops non-string override values, so the decoded
+    // map can be empty while the block still holds other entries. Deleting the
+    // whole block off the decoded map would silently drop that configuration.
+    let all_keys = override_keys_in_text(manifest.text());
+    let remaining_keys: Vec<&String> =
+        all_keys.iter().filter(|key| !present.contains(key)).collect();
+
+    if let Some(overrides) = manifest.overrides.as_mut() {
+        for selector in &present {
+            overrides.shift_remove(selector);
+        }
     }
 
-    if manifest.overrides.as_ref().is_none_or(IndexMap::is_empty) {
+    if remaining_keys.is_empty() {
         manifest.set_text(remove_top_level_block(manifest.text(), BLOCK));
         manifest.overrides = None;
         manifest.top_level_keys.retain(|key| key != BLOCK);
         return true;
     }
 
-    // A block-style mapping stores each entry on its own line, so the entries
-    // can be excised surgically while preserving the surrounding formatting. A
-    // flow-style mapping (`overrides: { ... }`) exposes no line entries, so
-    // `remove_mapping_entries` would be a silent no-op — fall back to dropping
-    // the block and re-rendering it block-style from the decoded map.
-    let line_based = locate(manifest.text(), &[BLOCK]).is_some_and(|mapping| {
-        present.iter().all(|key| mapping.entries.iter().any(|entry| &entry.key == key))
-    });
+    // A block-style mapping stores each entry on its own line, so the requested
+    // entries can be excised surgically while every other entry (string or not)
+    // is preserved. A flow-style mapping (`overrides: { ... }`) exposes no line
+    // entries, so it can only be rewritten wholesale — which the decoded map can
+    // do faithfully only when it accounts for every remaining key (i.e. the
+    // block has no non-string entries). When it does not, leave the file
+    // untouched rather than drop the entries we cannot reserialize.
+    let line_based =
+        locate(manifest.text(), &[BLOCK]).is_some_and(|mapping| !mapping.entries.is_empty());
 
     if line_based {
         manifest.set_text(remove_mapping_entries(manifest.text(), &[BLOCK], &present));
-    } else {
+        true
+    } else if manifest.overrides.as_ref().map_or(0, IndexMap::len) == remaining_keys.len() {
         rerender_overrides_block(manifest, BLOCK);
+        true
+    } else {
+        false
     }
-    true
+}
+
+/// Every key under the top-level `overrides:` block as written in `text`,
+/// including non-string values that the decoded [`Manifest`] drops. Returns an
+/// empty list when the block is absent or the text does not parse.
+fn override_keys_in_text(text: &str) -> Vec<String> {
+    #[derive(serde::Deserialize)]
+    struct OnlyOverrides {
+        #[serde(default)]
+        overrides: Option<IndexMap<String, serde::de::IgnoredAny>>,
+    }
+    serde_saphyr::from_str::<OnlyOverrides>(text)
+        .ok()
+        .and_then(|parsed| parsed.overrides)
+        .map(|map| map.into_keys().collect())
+        .unwrap_or_default()
 }
 
 /// Set `auditConfig.ignoreGhsas:` to `ghsas` (the complete desired list),

--- a/pacquet/crates/workspace-manifest-writer/src/lib.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/lib.rs
@@ -379,6 +379,33 @@ pub fn set_minimum_release_age_excludes(
     write_or_remove_manifest(&path, manifest)
 }
 
+/// Delete `selectors` from `dir`'s `pnpm-workspace.yaml` `overrides:` block,
+/// dropping the block (and the file, once it has no other top-level keys)
+/// when nothing remains, and writing back only when something actually
+/// changed. A missing file is a no-op. The inverse of [`set_overrides`];
+/// used by `pacquet unlink` to drop link: overrides.
+pub fn remove_overrides(
+    dir: &Path,
+    selectors: &[String],
+) -> Result<(), UpdateWorkspaceManifestError> {
+    let path = dir.join(WORKSPACE_MANIFEST_FILENAME);
+
+    let original = match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(source) => return Err(UpdateWorkspaceManifestError::Read { path, source }),
+    };
+
+    let mut manifest = Manifest::parse(Some(&original))
+        .map_err(|source| UpdateWorkspaceManifestError::Parse { path: path.clone(), source })?;
+
+    if !edit::remove_overrides(&mut manifest, selectors) {
+        return Ok(());
+    }
+
+    write_or_remove_manifest(&path, manifest)
+}
+
 fn write_or_remove_manifest(
     path: &Path,
     manifest: Manifest,

--- a/pacquet/crates/workspace-manifest-writer/src/tests.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/tests.rs
@@ -642,6 +642,19 @@ fn run_ignore_ghsas(original: Option<&str>, ghsas: &[&str]) -> Option<String> {
     fs::read_to_string(&path).ok()
 }
 
+/// Run `remove_overrides` against `original` and return the resulting file
+/// contents, or `None` when no file exists afterward.
+fn run_remove_overrides(original: Option<&str>, selectors: &[&str]) -> Option<String> {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+    if let Some(text) = original {
+        fs::write(&path, text).expect("seed manifest");
+    }
+    let selectors: Vec<String> = selectors.iter().copied().map(ToString::to_string).collect();
+    crate::remove_overrides(dir.path(), &selectors).expect("remove succeeds");
+    fs::read_to_string(&path).ok()
+}
+
 #[test]
 fn overrides_block_is_created() {
     let out = run_overrides(None, &overrides(&[("foo@<1.0.1", "^1.0.1")])).expect("written");
@@ -868,4 +881,36 @@ fn set_overrides_rejects_control_characters() {
         .expect_err("must reject a control character");
 
     assert!(matches!(err, crate::UpdateWorkspaceManifestError::InvalidControlCharacter { .. }));
+}
+
+#[test]
+fn remove_overrides_drops_only_the_named_entry() {
+    let original = "overrides:\n  foo: link:../foo\n  bar: link:../bar\n  baz: 1.0.0\n";
+    let out = run_remove_overrides(Some(original), &["foo"]).expect("file kept");
+    assert_eq!(out, "overrides:\n  bar: link:../bar\n  baz: 1.0.0\n");
+}
+
+#[test]
+fn remove_overrides_drops_the_block_when_emptied_but_keeps_siblings() {
+    let original = "packages:\n  - '*'\noverrides:\n  foo: link:../foo\n";
+    let out = run_remove_overrides(Some(original), &["foo"]).expect("file kept");
+    assert_eq!(out, "packages:\n  - '*'\n");
+}
+
+#[test]
+fn remove_overrides_deletes_the_file_when_nothing_remains() {
+    let original = "overrides:\n  foo: link:../foo\n  bar: link:../bar\n";
+    assert_eq!(run_remove_overrides(Some(original), &["foo", "bar"]), None);
+}
+
+#[test]
+fn remove_overrides_is_a_noop_for_absent_selectors() {
+    let original = "overrides:\n  foo: link:../foo\n";
+    let out = run_remove_overrides(Some(original), &["missing"]).expect("file kept");
+    assert_eq!(out, original);
+}
+
+#[test]
+fn remove_overrides_is_a_noop_when_the_manifest_is_missing() {
+    assert_eq!(run_remove_overrides(None, &["foo"]), None);
 }

--- a/pacquet/crates/workspace-manifest-writer/src/tests.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/tests.rs
@@ -928,3 +928,29 @@ fn remove_overrides_drops_a_flow_style_block_when_emptied() {
     let out = run_remove_overrides(Some(original), &["foo"]).expect("file kept");
     assert_eq!(out, "packages:\n  - '*'\n");
 }
+
+#[test]
+fn remove_overrides_preserves_non_string_entries_in_block_style() {
+    let original = "overrides:\n  foo: link:../foo\n  bar:\n    nested: value\n";
+    let out = run_remove_overrides(Some(original), &["foo"]).expect("file kept");
+    assert_eq!(out, "overrides:\n  bar:\n    nested: value\n");
+}
+
+#[test]
+fn remove_overrides_keeps_block_when_only_non_string_entry_remains() {
+    // Removing the last string entry must not delete the block while a
+    // non-string entry (which the decoded map drops) is still present.
+    let original = "overrides:\n  foo: link:../foo\n  bar:\n    nested: value\n";
+    let out = run_remove_overrides(Some(original), &["foo"]).expect("file kept");
+    assert!(out.contains("bar:"), "non-string override must survive: {out}");
+}
+
+#[test]
+fn remove_overrides_leaves_flow_style_block_with_non_string_entries_untouched() {
+    // A flow-style block can only be rewritten wholesale, and the decoded map
+    // cannot reserialize the non-string `bar`, so the file is left as-is rather
+    // than dropping data.
+    let original = "overrides: { foo: link:../foo, bar: { nested: value } }\n";
+    let out = run_remove_overrides(Some(original), &["foo"]).expect("file kept");
+    assert_eq!(out, original);
+}

--- a/pacquet/crates/workspace-manifest-writer/src/tests.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/tests.rs
@@ -914,3 +914,17 @@ fn remove_overrides_is_a_noop_for_absent_selectors() {
 fn remove_overrides_is_a_noop_when_the_manifest_is_missing() {
     assert_eq!(run_remove_overrides(None, &["foo"]), None);
 }
+
+#[test]
+fn remove_overrides_handles_flow_style_mappings() {
+    let original = "overrides: { foo: link:../foo, bar: 1.0.0 }\n";
+    let out = run_remove_overrides(Some(original), &["foo"]).expect("file kept");
+    assert_eq!(out, "overrides:\n  bar: 1.0.0\n");
+}
+
+#[test]
+fn remove_overrides_drops_a_flow_style_block_when_emptied() {
+    let original = "packages:\n  - '*'\noverrides: { foo: link:../foo }\n";
+    let out = run_remove_overrides(Some(original), &["foo"]).expect("file kept");
+    assert_eq!(out, "packages:\n  - '*'\n");
+}


### PR DESCRIPTION
## Summary

Ports the pnpm unlink command to the pacquet Rust CLI. When package names are provided, removes them from the manifest. When no names are given, discovers and removes all dependencies whose version specifier starts with link:. After removing the dependencies, saves the manifest and runs the install pipeline.

Related to pnpm/pnpm#11633

## Squash Commit Body

```text
Ports the unlink command from pnpm to pacquet. UnlinkArgs::run builds a
list of packages to remove: the explicitly provided names or all
link:-versioned dependencies across all groups (prod, dev, optional). If
the list is empty the command is a no-op. It calls
PackageManifest::remove_dependencies, saves the manifest, and delegates
to Install which cleans up the stale symlink. No changeset because
pacquet is not a published package. Related to pnpm/pnpm#11633
```


## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust pacquet/ port, or the description notes what still needs porting. Implemented in pacquet only; the TypeScript CLI already has this command at pnpm11/installing/commands/src/unlink.ts.
- [ ] No changeset needed pacquet-internal changes do not affect published packages.
- [ ] No tests added the existing pacquet test infrastructure covers the Install and manifest editing paths.
- [ ] No documentation changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new `unlink` CLI subcommand (alias: `dislink`) to remove `link:`-based dependency overrides from `pnpm.overrides` in your `package.json`.
  * You can target specific package names; with no names provided, it removes all `link:` overrides while leaving non-`link:` entries intact.
  * After updating the manifest, it refreshes dependencies by running an install for the relevant dependency groups.
* **Bug Fixes**
  * Kept execution-time reporting consistent with install-family commands.
* **Tests**
  * Added tests covering unlinking a single override and unlinking all matching overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->