### PR TITLE
perf(pnpr): serve cached tarballs without re-parsing the packument; stream on cache miss

### DIFF
--- a/pnpr/crates/pnpr/src/error.rs
+++ b/pnpr/crates/pnpr/src/error.rs
@@ -307,7 +307,7 @@ impl RegistryError {
     }
 }
 
-fn redact_url_credentials(message: &str) -> String {
+pub(crate) fn redact_url_credentials(message: &str) -> String {
     let mut redacted = String::with_capacity(message.len());
     let mut cursor = 0;
     while let Some(relative_scheme_end) = message[cursor..].find("://") {

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -859,41 +859,51 @@ async fn serve_tarball(
         }
     }
 
-    let packument = match load_packument_bytes(state, &name).await {
-        PackumentLoad::Ok(bytes) => bytes,
-        PackumentLoad::NotFound => return not_found(),
-        PackumentLoad::Err(err) => return error_response(&err),
-    };
-    let integrity = match expected_tarball_integrity(&packument, &name, &filename, &version) {
-        Ok(Some(integrity)) => integrity,
-        Ok(None) => return not_found(),
-        Err(err) => return error_response(&err),
-    };
-
     let upstream = resolve_upstream(state, &name);
     let should_read_cache = upstream.as_ref().is_none_or(|upstream| upstream.caches());
     if should_read_cache {
         match state.inner.storage.open_cached_tarball(&name, &filename).await {
             Ok(Some((file, len))) => {
-                let expected = cached_tarball_integrity(&integrity, len);
-                if state
-                    .inner
-                    .storage
-                    .read_cached_tarball_integrity(&name, &filename)
-                    .await
-                    .is_some_and(|cached| cached == expected)
-                {
-                    return tarball_response(streaming::stream_file(file), Some(len));
-                }
-                match streaming::verify_file(file, &integrity).await {
-                    Ok(file) => {
-                        record_cached_tarball_integrity(state, &name, &filename, expected).await;
+                // Fast path: a sidecar means these bytes were already verified
+                // against the packument integrity when they were cached (see the
+                // cache-miss tee below, which only promotes on an SRI match). Trust
+                // it — matched by length — rather than re-loading and re-parsing the
+                // packument and re-hashing the file on every read. The client
+                // verifies the bytes it installs against its own resolved integrity
+                // regardless, so the proxy guards what it *writes*, not every read.
+                match state.inner.storage.read_cached_tarball_integrity(&name, &filename).await {
+                    Some(sidecar) if sidecar.len == len => {
                         return tarball_response(streaming::stream_file(file), Some(len));
                     }
-                    Err(err) => {
-                        let err = tarball_stream_error(err, &name, &filename);
-                        tracing::warn!(?err, package = %name.as_str(), %filename, "cached tarball failed verification");
-                        discard_cached_tarball(state, &name, &filename).await;
+                    // No trustworthy sidecar (e.g. a cache entry from before sidecars
+                    // existed, or a size-mismatched one): verify once against the
+                    // packument integrity, then record the sidecar so later reads hit
+                    // the fast path above.
+                    _ => {
+                        let integrity =
+                            match expected_integrity_or_response(state, &name, &filename, &version)
+                                .await
+                            {
+                                Ok(integrity) => integrity,
+                                Err(response) => return response,
+                            };
+                        match streaming::verify_file(file, &integrity).await {
+                            Ok(file) => {
+                                record_cached_tarball_integrity(
+                                    state,
+                                    &name,
+                                    &filename,
+                                    cached_tarball_integrity(&integrity, len),
+                                )
+                                .await;
+                                return tarball_response(streaming::stream_file(file), Some(len));
+                            }
+                            Err(err) => {
+                                let err = tarball_stream_error(err, &name, &filename);
+                                tracing::warn!(?err, package = %name.as_str(), %filename, "cached tarball failed verification");
+                                discard_cached_tarball(state, &name, &filename).await;
+                            }
+                        }
                     }
                 }
             }
@@ -906,6 +916,12 @@ async fn serve_tarball(
 
     let Some(upstream) = upstream else {
         return not_found();
+    };
+
+    // Cache miss: the verified-streaming fetch below needs the expected integrity.
+    let integrity = match expected_integrity_or_response(state, &name, &filename, &version).await {
+        Ok(integrity) => integrity,
+        Err(response) => return response,
     };
 
     let response = match upstream.fetch_tarball_response(&name, &filename).await {
@@ -965,6 +981,27 @@ async fn serve_tarball(
             }
             Err(err) => error_response(&tarball_stream_error(err, &name, &filename)),
         }
+    }
+}
+
+/// Resolve the packument-declared tarball integrity for `version`, or the
+/// response (`not_found` / error) to return instead. Loaded lazily so the warm
+/// cache-hit path in `serve_tarball` never pays the packument load + parse.
+async fn expected_integrity_or_response(
+    state: &AppState,
+    name: &PackageName,
+    filename: &str,
+    version: &str,
+) -> Result<Integrity, Response> {
+    let packument = match load_packument_bytes(state, name).await {
+        PackumentLoad::Ok(bytes) => bytes,
+        PackumentLoad::NotFound => return Err(not_found()),
+        PackumentLoad::Err(err) => return Err(error_response(&err)),
+    };
+    match expected_tarball_integrity(&packument, name, filename, version) {
+        Ok(Some(integrity)) => Ok(integrity),
+        Ok(None) => Err(not_found()),
+        Err(err) => Err(error_response(&err)),
     }
 }
 

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -920,34 +920,31 @@ async fn serve_tarball(
     };
 
     if upstream.caches() {
-        let len = match streaming::download_verified_to_cache(
-            response,
-            write,
-            &integrity,
-            MAX_TARBALL_BYTES,
+        // Stream the tarball to the client immediately; the cache copy is
+        // hashed in the background and promoted only on an SRI match, so the
+        // proxy cache never stores unverified bytes. The client verifies the
+        // bytes it installs against the same integrity itself.
+        let upstream_len = response.content_length();
+        let inner = Arc::clone(&state.inner);
+        let commit_name = name.clone();
+        let commit_filename = filename.clone();
+        let commit_integrity = integrity.clone();
+        let commit: streaming::CacheCommit = Box::new(move |len| {
+            Box::pin(async move {
+                let marker = cached_tarball_integrity(&commit_integrity, len);
+                if let Err(err) = inner
+                    .storage
+                    .write_cached_tarball_integrity(&commit_name, &commit_filename, &marker)
+                    .await
+                {
+                    tracing::warn!(?err, package = %commit_name.as_str(), filename = %commit_filename, "tarball cache integrity marker write failed");
+                }
+            })
+        });
+        tarball_response(
+            streaming::tee_verified_to_cache(response, write, integrity, MAX_TARBALL_BYTES, commit),
+            upstream_len,
         )
-        .await
-        {
-            Ok(len) => len,
-            Err(err) => return error_response(&tarball_stream_error(err, &name, &filename)),
-        };
-        record_cached_tarball_integrity(
-            state,
-            &name,
-            &filename,
-            cached_tarball_integrity(&integrity, len),
-        )
-        .await;
-
-        match state.inner.storage.open_cached_tarball(&name, &filename).await {
-            Ok(Some((file, len))) => tarball_response(streaming::stream_file(file), Some(len)),
-            Ok(None) => error_response(&tarball_integrity_error(
-                &name,
-                &filename,
-                "verified cache entry disappeared before it could be served".to_string(),
-            )),
-            Err(err) => error_response(&err),
-        }
     } else {
         match streaming::download_verified_to_temp(response, write, &integrity, MAX_TARBALL_BYTES)
             .await

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -920,11 +920,19 @@ async fn serve_tarball(
     };
 
     if upstream.caches() {
+        // Reject an honestly-oversized body before streaming; the tee enforces
+        // the same cap for chunked/unknown-length bodies as it relays them.
+        if response.content_length().is_some_and(|len| len > MAX_TARBALL_BYTES) {
+            return error_response(&tarball_integrity_error(
+                &name,
+                &filename,
+                format!("upstream tarball exceeds the {MAX_TARBALL_BYTES} byte limit"),
+            ));
+        }
         // Stream the tarball to the client immediately; the cache copy is
         // hashed in the background and promoted only on an SRI match, so the
         // proxy cache never stores unverified bytes. The client verifies the
         // bytes it installs against the same integrity itself.
-        let upstream_len = response.content_length();
         let inner = Arc::clone(&state.inner);
         let commit_name = name.clone();
         let commit_filename = filename.clone();
@@ -941,9 +949,12 @@ async fn serve_tarball(
                 }
             })
         });
+        // The verified length is only known after the body has streamed, and the
+        // upstream's advertised Content-Length is attacker-controlled, so respond
+        // without asserting a length rather than promise one we can't guarantee.
         tarball_response(
             streaming::tee_verified_to_cache(response, write, integrity, MAX_TARBALL_BYTES, commit),
-            upstream_len,
+            None,
         )
     } else {
         match streaming::download_verified_to_temp(response, write, &integrity, MAX_TARBALL_BYTES)

--- a/pnpr/crates/pnpr/src/streaming.rs
+++ b/pnpr/crates/pnpr/src/streaming.rs
@@ -10,7 +10,7 @@
 //!   temp file for mirror-less pass-through.
 //! * [`stream_file`] yields an already verified file to the response.
 
-use crate::storage::TarballWrite;
+use crate::{error::redact_url_credentials, storage::TarballWrite};
 use axum::body::{Body, Bytes};
 use futures_util::{Stream, StreamExt, stream};
 use ssri::{Integrity, IntegrityChecker};
@@ -95,8 +95,10 @@ pub type CacheCommit = Box<dyn FnOnce(u64) -> Pin<Box<dyn Future<Output = ()> + 
 /// receives bytes as they arrive — the proxy does not buffer the whole body
 /// first — and the cache copy is promoted (and `commit` run) only if the
 /// complete body matches `integrity`, so the proxy cache never stores
-/// unverified bytes. A hash mismatch, oversized body, write error, upstream
-/// error, or client disconnect abandons the temp file without promoting it.
+/// unverified bytes. A hash mismatch, write error, upstream error, or client
+/// disconnect abandons the temp file without promoting it; a body that exceeds
+/// `max_bytes` additionally aborts the client stream, so the proxy never relays
+/// unbounded attacker-controlled data.
 ///
 /// Authoritative verification of the bytes a client *installs* is the
 /// client's own SRI check against the packument it resolved; this proxy
@@ -109,7 +111,9 @@ pub fn tee_verified_to_cache(
     max_bytes: u64,
     commit: CacheCommit,
 ) -> Body {
-    let url = response.url().to_string();
+    // The upstream URL is logged on several paths below; strip any embedded
+    // credentials/secrets first, since the uplink URL is operator-provided.
+    let url = redact_url_credentials(response.url().as_ref());
     let upstream = response.bytes_stream();
     let (tx, rx) = mpsc::channel::<Result<Bytes, io::Error>>(TEE_CHANNEL);
     tokio::spawn(run_tee_verified(
@@ -152,7 +156,7 @@ async fn run_tee_verified(
             None
         }
     };
-    let mut written = 0u64;
+    let mut streamed = 0u64;
     while let Some(chunk_result) = upstream.next().await {
         let chunk = match chunk_result {
             Ok(chunk) => chunk,
@@ -165,20 +169,24 @@ async fn run_tee_verified(
                 return;
             }
         };
+        // Cap the bytes relayed, not just the bytes cached: an oversized body is
+        // aborted so pnpr never forwards unbounded attacker-controlled data.
+        streamed = streamed.saturating_add(chunk.len() as u64);
+        if streamed > max_bytes {
+            tracing::warn!(%url, limit = max_bytes, received = streamed, "upstream body exceeds size cap; aborting");
+            let _ = tx.send(Err(io::Error::other("tarball body exceeds size limit"))).await;
+            if let Some(write) = cache_write {
+                write.abandon().await;
+            }
+            return;
+        }
         let mut abandon = false;
         if let Some(write) = cache_write.as_mut() {
-            let projected = written.saturating_add(chunk.len() as u64);
-            if projected > max_bytes {
-                tracing::warn!(%url, limit = max_bytes, received = projected, "upstream body exceeds cache size cap; serving without caching");
-                abandon = true;
-            } else if let Err(err) = write.write_all(&chunk).await {
+            if let Err(err) = write.write_all(&chunk).await {
                 tracing::warn!(%url, ?err, "cache temp-file write failed; continuing without cache");
                 abandon = true;
-            } else {
-                if let Some(checker) = checker.as_mut() {
-                    checker.input(&chunk);
-                }
-                written = projected;
+            } else if let Some(checker) = checker.as_mut() {
+                checker.input(&chunk);
             }
         }
         if abandon && let Some(write) = cache_write.take() {
@@ -206,7 +214,7 @@ async fn run_tee_verified(
         tracing::warn!(%url, ?err, "cache finalize failed");
         return;
     }
-    commit(written).await;
+    commit(streamed).await;
 }
 
 pub async fn download_verified_to_temp(

--- a/pnpr/crates/pnpr/src/streaming.rs
+++ b/pnpr/crates/pnpr/src/streaming.rs
@@ -1,31 +1,41 @@
 //! Streaming helpers for the tarball path.
 //!
-//! Four flows live here:
+//! Flows that live here:
 //!
 //! * [`verify_file`] hashes a cache hit before it can be served.
-//! * [`download_verified_to_cache`] hashes an upstream response into a
-//!   temp file and promotes it only after the declared SRI matches.
+//! * [`tee_verified_to_cache`] streams an upstream response to the client
+//!   immediately while hashing it in the background, promoting it into the
+//!   cache only after the declared SRI matches.
 //! * [`download_verified_to_temp`] hashes an upstream response into a
 //!   temp file for mirror-less pass-through.
 //! * [`stream_file`] yields an already verified file to the response.
 
 use crate::storage::TarballWrite;
 use axum::body::{Body, Bytes};
-use futures_util::{StreamExt, stream};
+use futures_util::{Stream, StreamExt, stream};
 use ssri::{Integrity, IntegrityChecker};
 use std::{
+    future::Future,
     io::{self, SeekFrom},
     path::PathBuf,
+    pin::Pin,
 };
 use tokio::{
     fs::File,
     io::{AsyncReadExt, AsyncSeekExt},
+    sync::mpsc,
 };
 
 /// Chunk size for reading from a cached file. 64 KiB keeps syscall
 /// overhead low without buffering a meaningful fraction of a
 /// multi-MB tarball.
 const READ_CHUNK: usize = 64 * 1024;
+
+/// Backpressure budget for the upstream-tee channel. Each in-flight item
+/// is one upstream chunk (a few kB), so 16 caps the writer's lead over the
+/// client at ~1 MB. Once the buffer fills, the tee task awaits on `send`,
+/// throttling the upstream read loop to the client's read rate.
+const TEE_CHANNEL: usize = 16;
 
 pub fn parse_integrity(value: &str) -> Result<Integrity, ssri::Error> {
     let integrity: Integrity = value.parse()?;
@@ -75,24 +85,128 @@ pub async fn verify_file(
     Ok(file)
 }
 
-/// Download an upstream response into `write`, verify the complete body,
-/// and atomically promote it to the cache. No bytes become cache-visible
-/// until the declared SRI matches.
-pub async fn download_verified_to_cache(
+/// Run once a teed body has been fully hashed and atomically promoted into
+/// the proxy cache, with the verified byte length, to persist the cache
+/// entry's integrity sidecar.
+pub type CacheCommit = Box<dyn FnOnce(u64) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send>;
+
+/// Stream an upstream response to the client immediately while teeing the
+/// bytes into a temp file and hashing them in the background. The client
+/// receives bytes as they arrive — the proxy does not buffer the whole body
+/// first — and the cache copy is promoted (and `commit` run) only if the
+/// complete body matches `integrity`, so the proxy cache never stores
+/// unverified bytes. A hash mismatch, oversized body, write error, upstream
+/// error, or client disconnect abandons the temp file without promoting it.
+///
+/// Authoritative verification of the bytes a client *installs* is the
+/// client's own SRI check against the packument it resolved; this proxy
+/// guards only what it persists, trading emit-time verification for the
+/// concurrency the streaming download regains.
+pub fn tee_verified_to_cache(
     response: reqwest::Response,
-    mut write: TarballWrite,
-    integrity: &Integrity,
+    write: TarballWrite,
+    integrity: Integrity,
     max_bytes: u64,
-) -> Result<u64, TarballStreamError> {
-    let len = match download_verified(response, &mut write, integrity, max_bytes).await {
-        Ok(len) => len,
+    commit: CacheCommit,
+) -> Body {
+    let url = response.url().to_string();
+    let upstream = response.bytes_stream();
+    let (tx, rx) = mpsc::channel::<Result<Bytes, io::Error>>(TEE_CHANNEL);
+    tokio::spawn(run_tee_verified(
+        Box::pin(upstream),
+        write,
+        tx,
+        url,
+        integrity,
+        max_bytes,
+        commit,
+    ));
+    let stream = stream::unfold(rx, |mut rx| async move { rx.recv().await.map(|item| (item, rx)) });
+    Body::from_stream(stream)
+}
+
+async fn run_tee_verified(
+    mut upstream: Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>> + Send>>,
+    write: TarballWrite,
+    tx: mpsc::Sender<Result<Bytes, io::Error>>,
+    url: String,
+    integrity: Integrity,
+    max_bytes: u64,
+    commit: CacheCommit,
+) {
+    // `cache_write` drops to `None` the moment caching is abandoned (write
+    // failure, oversized body, or a body that can't be hashed). The client
+    // keeps receiving upstream bytes regardless — a failed cache write must
+    // never truncate the response.
+    let mut cache_write = Some(write);
+    // `integrity` was already validated by `parse_integrity` upstream, so
+    // this only fails defensively; abandon caching rather than promote an
+    // unhashed body.
+    let mut checker = match integrity_checker(&integrity) {
+        Ok(checker) => Some(checker),
         Err(err) => {
-            write.abandon().await;
-            return Err(err);
+            tracing::warn!(%url, %err, "integrity checker init failed; serving without cache");
+            if let Some(write) = cache_write.take() {
+                write.abandon().await;
+            }
+            None
         }
     };
-    write.finalize().await.map_err(TarballStreamError::Io)?;
-    Ok(len)
+    let mut written = 0u64;
+    while let Some(chunk_result) = upstream.next().await {
+        let chunk = match chunk_result {
+            Ok(chunk) => chunk,
+            Err(err) => {
+                tracing::warn!(%url, %err, "upstream stream errored mid-body");
+                let _ = tx.send(Err(io::Error::other(err.to_string()))).await;
+                if let Some(write) = cache_write {
+                    write.abandon().await;
+                }
+                return;
+            }
+        };
+        let mut abandon = false;
+        if let Some(write) = cache_write.as_mut() {
+            let projected = written.saturating_add(chunk.len() as u64);
+            if projected > max_bytes {
+                tracing::warn!(%url, limit = max_bytes, received = projected, "upstream body exceeds cache size cap; serving without caching");
+                abandon = true;
+            } else if let Err(err) = write.write_all(&chunk).await {
+                tracing::warn!(%url, ?err, "cache temp-file write failed; continuing without cache");
+                abandon = true;
+            } else {
+                if let Some(checker) = checker.as_mut() {
+                    checker.input(&chunk);
+                }
+                written = projected;
+            }
+        }
+        if abandon && let Some(write) = cache_write.take() {
+            write.abandon().await;
+        }
+        if tx.send(Ok(chunk)).await.is_err() {
+            // Client hung up. Stop the cache write too — a future request
+            // will refetch and populate the cache cleanly.
+            tracing::debug!(%url, "client disconnected mid-stream; abandoning cache write");
+            if let Some(write) = cache_write {
+                write.abandon().await;
+            }
+            return;
+        }
+    }
+    let (Some(write), Some(checker)) = (cache_write, checker) else {
+        return;
+    };
+    if let Err(err) = checker.result() {
+        tracing::warn!(%url, %err, "upstream body failed integrity check; not caching");
+        write.abandon().await;
+        return;
+    }
+    if let Err(err) = write.finalize().await {
+        tracing::warn!(%url, ?err, "cache finalize failed");
+        return;
+    }
+    commit(written).await;
 }
 
 pub async fn download_verified_to_temp(

--- a/pnpr/crates/pnpr/src/streaming/tests.rs
+++ b/pnpr/crates/pnpr/src/streaming/tests.rs
@@ -1,7 +1,12 @@
-use super::{TarballStreamError, download_verified_to_cache, integrity_checker, parse_integrity};
+use super::{CacheCommit, integrity_checker, parse_integrity, tee_verified_to_cache};
 use crate::{config::HostedStoreConfig, package_name::PackageName, storage::Storage};
+use axum::body::to_bytes;
 use ssri::{Algorithm, Integrity, IntegrityOpts};
-use std::{path::Path, sync::Arc, time::Duration};
+use std::{
+    path::Path,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 use tempfile::TempDir;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -118,8 +123,92 @@ async fn await_nonempty_tarball_tmp(dir: &Path) -> Vec<String> {
     }
 }
 
+fn recording_commit() -> (CacheCommit, Arc<Mutex<Option<u64>>>) {
+    let recorded = Arc::new(Mutex::new(None));
+    let recorded_for_cb = Arc::clone(&recorded);
+    let commit: CacheCommit = Box::new(move |len| {
+        Box::pin(async move {
+            *recorded_for_cb.lock().unwrap() = Some(len);
+        })
+    });
+    (commit, recorded)
+}
+
 #[tokio::test]
-async fn cancelling_in_flight_response_body_removes_tmp_file() {
+async fn teed_matching_body_is_cached_and_committed() {
+    let bytes: &'static [u8] = b"a verified tarball body";
+    let integrity = parse_integrity(&sha512_integrity(bytes)).unwrap();
+    let response = reqwest::get(spawn_response(bytes).await).await.unwrap();
+
+    let tmp = TempDir::new().unwrap();
+    let cache = tmp.path().join("cache");
+    let storage = Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), cache.clone());
+    let name = PackageName::parse("foo").unwrap();
+    let write = storage.open_cached_tarball_tmp(&name, "foo-1.0.0.tgz").await.unwrap();
+
+    let (commit, committed) = recording_commit();
+    let body = tee_verified_to_cache(response, write, integrity, u64::MAX, commit);
+    // The stream closes only after the background task finalizes and commits,
+    // so a fully drained body means promotion has already completed.
+    let served = to_bytes(body, usize::MAX).await.unwrap();
+    assert_eq!(served.as_ref(), bytes);
+
+    let package_dir = cache.join("foo");
+    let cached_path = package_dir.join("foo-1.0.0.tgz");
+    assert_eq!(std::fs::read(&cached_path).unwrap(), bytes);
+    assert_eq!(*committed.lock().unwrap(), Some(bytes.len() as u64));
+    assert!(tarball_tmp_entries(&package_dir).is_empty());
+}
+
+#[tokio::test]
+async fn teed_mismatched_body_is_streamed_but_not_cached() {
+    let actual: &'static [u8] = b"actual upstream bytes";
+    let declared = parse_integrity(&sha512_integrity(b"a different body entirely")).unwrap();
+    let response = reqwest::get(spawn_response(actual).await).await.unwrap();
+
+    let tmp = TempDir::new().unwrap();
+    let cache = tmp.path().join("cache");
+    let storage = Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), cache.clone());
+    let name = PackageName::parse("foo").unwrap();
+    let write = storage.open_cached_tarball_tmp(&name, "foo-1.0.0.tgz").await.unwrap();
+
+    let (commit, committed) = recording_commit();
+    let body = tee_verified_to_cache(response, write, declared, u64::MAX, commit);
+    let served = to_bytes(body, usize::MAX).await.unwrap();
+    // The client still receives the bytes; its own SRI check is what rejects them.
+    assert_eq!(served.as_ref(), actual);
+
+    let package_dir = cache.join("foo");
+    assert!(!package_dir.join("foo-1.0.0.tgz").exists());
+    assert!(committed.lock().unwrap().is_none());
+    assert!(tarball_tmp_entries(&package_dir).is_empty());
+}
+
+#[tokio::test]
+async fn teed_oversized_body_is_streamed_but_not_cached() {
+    let bytes: &'static [u8] = b"oversized";
+    let integrity = parse_integrity(&sha512_integrity(bytes)).unwrap();
+    let response = reqwest::get(spawn_response(bytes).await).await.unwrap();
+
+    let tmp = TempDir::new().unwrap();
+    let cache = tmp.path().join("cache");
+    let storage = Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), cache.clone());
+    let name = PackageName::parse("foo").unwrap();
+    let write = storage.open_cached_tarball_tmp(&name, "foo-1.0.0.tgz").await.unwrap();
+
+    let (commit, committed) = recording_commit();
+    let body = tee_verified_to_cache(response, write, integrity, 3, commit);
+    let served = to_bytes(body, usize::MAX).await.unwrap();
+    assert_eq!(served.as_ref(), bytes);
+
+    let package_dir = cache.join("foo");
+    assert!(!package_dir.join("foo-1.0.0.tgz").exists());
+    assert!(committed.lock().unwrap().is_none());
+    assert!(tarball_tmp_entries(&package_dir).is_empty());
+}
+
+#[tokio::test]
+async fn client_disconnect_mid_stream_removes_tmp_file() {
     let expected_bytes = vec![0xAA; 1024 * 1024];
     let integrity = parse_integrity(&sha512_integrity(&expected_bytes)).unwrap();
     let (url, release, server) = spawn_stalled_response().await;
@@ -131,38 +220,28 @@ async fn cancelling_in_flight_response_body_removes_tmp_file() {
     let name = PackageName::parse("foo").unwrap();
     let write = storage.open_cached_tarball_tmp(&name, "foo-1.0.0.tgz").await.unwrap();
 
-    let download = tokio::spawn(async move {
-        download_verified_to_cache(response, write, &integrity, u64::MAX).await
-    });
+    let (commit, _committed) = recording_commit();
+    let body = tee_verified_to_cache(response, write, integrity, u64::MAX, commit);
     let package_dir = cache.join("foo");
     let in_flight = await_nonempty_tarball_tmp(&package_dir).await;
     assert_eq!(in_flight.len(), 1, "expected one in-flight tarball writer");
 
-    download.abort();
-    assert!(download.await.unwrap_err().is_cancelled());
-    assert!(tarball_tmp_entries(&package_dir).is_empty());
-    assert!(!package_dir.join("foo-1.0.0.tgz").exists());
-
+    // Client goes away mid-body; releasing the stalled upstream then lets the
+    // tee task observe the truncated body / gone receiver and abandon the tmp.
+    drop(body);
     release.notify_one();
     server.await.unwrap();
-}
 
-#[tokio::test]
-async fn oversized_response_is_rejected_and_tmp_is_removed() {
-    let bytes = b"oversized";
-    let integrity = parse_integrity(&sha512_integrity(bytes)).unwrap();
-    let response = reqwest::get(spawn_response(bytes).await).await.unwrap();
-
-    let tmp = TempDir::new().unwrap();
-    let cache = tmp.path().join("cache");
-    let storage = Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), cache.clone());
-    let name = PackageName::parse("foo").unwrap();
-    let write = storage.open_cached_tarball_tmp(&name, "foo-1.0.0.tgz").await.unwrap();
-
-    let err = download_verified_to_cache(response, write, &integrity, 3).await.unwrap_err();
-    assert!(matches!(err, TarballStreamError::TooLarge { limit: 3, received } if received > 3));
-
-    let package_dir = cache.join("foo");
-    assert!(tarball_tmp_entries(&package_dir).is_empty());
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        if tarball_tmp_entries(&package_dir).is_empty() {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "tmp file was not cleaned up after client disconnect",
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
     assert!(!package_dir.join("foo-1.0.0.tgz").exists());
 }

--- a/pnpr/crates/pnpr/src/streaming/tests.rs
+++ b/pnpr/crates/pnpr/src/streaming/tests.rs
@@ -185,7 +185,7 @@ async fn teed_mismatched_body_is_streamed_but_not_cached() {
 }
 
 #[tokio::test]
-async fn teed_oversized_body_is_streamed_but_not_cached() {
+async fn teed_oversized_body_is_aborted_and_not_cached() {
     let bytes: &'static [u8] = b"oversized";
     let integrity = parse_integrity(&sha512_integrity(bytes)).unwrap();
     let response = reqwest::get(spawn_response(bytes).await).await.unwrap();
@@ -198,8 +198,9 @@ async fn teed_oversized_body_is_streamed_but_not_cached() {
 
     let (commit, committed) = recording_commit();
     let body = tee_verified_to_cache(response, write, integrity, 3, commit);
-    let served = to_bytes(body, usize::MAX).await.unwrap();
-    assert_eq!(served.as_ref(), bytes);
+    // The body exceeds the cap, so the relayed stream is aborted (errors) rather
+    // than forwarding unbounded data, and nothing is cached.
+    assert!(to_bytes(body, usize::MAX).await.is_err());
 
     let package_dir = cache.join("foo");
     assert!(!package_dir.join("foo-1.0.0.tgz").exists());

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -898,6 +898,35 @@ async fn tampered_upstream_tarball_is_streamed_but_not_cached() {
     tarball_mock.assert_async().await;
 }
 
+// A cache entry with a matching integrity sidecar was already verified against
+// the packument when it was stored, so serving it must not re-load and re-parse
+// the packument (the hot-path cost) or re-hash the bytes on every read.
+#[tokio::test]
+async fn cached_tarball_with_valid_sidecar_is_served_without_packument() {
+    let bytes = b"already-verified-cached-bytes";
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let cache_dir = storage.join(".pnpr-cache").join("foo");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    std::fs::write(cache_dir.join("foo-1.0.0.tgz"), bytes).unwrap();
+    std::fs::write(
+        cache_dir.join("foo-1.0.0.tgz.integrity"),
+        json!({ "integrity": sha512_integrity(bytes), "len": bytes.len() }).to_string(),
+    )
+    .unwrap();
+
+    // Point the uplink at an unreachable address: there is no local packument, so
+    // any attempt to resolve the expected integrity would have to reach upstream
+    // and fail. The sidecar fast path must serve straight from the cache instead.
+    let app = router(config_for("http://127.0.0.1:1", storage));
+    let response = app
+        .oneshot(Request::get("/foo/-/foo-1.0.0.tgz").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_bytes(response.into_body()).await, bytes);
+}
+
 #[tokio::test]
 async fn tarball_without_integrity_is_rejected_before_fetch() {
     let mut upstream = mockito::Server::new_async().await;

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -827,7 +827,7 @@ async fn selected_version_controls_tarball_route_and_offline_cache_key() {
 }
 
 #[tokio::test]
-async fn tampered_upstream_tarball_is_rejected_and_not_cached() {
+async fn tampered_upstream_tarball_is_streamed_but_not_cached() {
     let mut upstream = mockito::Server::new_async().await;
     let good_bytes = b"good-tarball-bytes";
     let poison_bytes = b"poisoned-cache-bytes";
@@ -881,7 +881,11 @@ async fn tampered_upstream_tarball_is_rejected_and_not_cached() {
         .oneshot(Request::get("/poisoned/-/poisoned-1.0.0.tgz").body(Body::empty()).unwrap())
         .await
         .unwrap();
-    assert_eq!(tarball_response.status(), StatusCode::BAD_GATEWAY);
+    // The proxy streams the bytes through — the client's own SRI check against
+    // the packument integrity is what rejects them — but a body that fails
+    // verification must never be promoted into the cache.
+    assert_eq!(tarball_response.status(), StatusCode::OK);
+    assert_eq!(body_bytes(tarball_response.into_body()).await, poison_bytes);
     assert!(!cache_path.exists(), "unverified tarball must not remain cached");
 
     let cached_response = router(config_for("http://127.0.0.1:1", storage))
@@ -1523,15 +1527,18 @@ async fn upstream_stream_error_clears_cache() {
         .oneshot(Request::get("/foo/-/foo-1.0.0.tgz").body(Body::empty()).unwrap())
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    // The body is streamed, so the 200 status is already committed; the
+    // truncated upstream surfaces as a broken body the client rejects.
+    assert_eq!(response.status(), StatusCode::OK);
+    // Drive the stream to its error so the tee task reaches its abandon path.
+    let _ = to_bytes(response.into_body(), usize::MAX).await;
 
-    // The incomplete body is rejected before a response or cache entry
-    // can expose its bytes.
+    // An incomplete body must never leave a cached (or half-written) entry.
     assert!(await_no_tgz(&cache_dir.join(".pnpr-cache").join("foo"), Duration::from_secs(1)).await);
 }
 
 #[tokio::test]
-async fn verified_tarball_is_cached_before_response_is_served() {
+async fn verified_tarball_is_streamed_then_cached() {
     let mut upstream = mockito::Server::new_async().await;
     let bytes = vec![0xEE_u8; 512 * 1024];
     let _packument_mock = mock_packument_for_tarball(&mut upstream, "big", "1.0.0", &bytes).await;
@@ -1552,9 +1559,10 @@ async fn verified_tarball_is_cached_before_response_is_served() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    // The response is not constructed until the complete upstream body
-    // has passed verification and cache finalization.
-    drop(response);
+    // The body streams to the client; the verified copy is promoted into the
+    // cache once the whole body has drained, so it exists by the time the
+    // response body is fully read.
+    assert_eq!(body_bytes(response.into_body()).await, bytes);
     let cache_path = cache_dir.join(".pnpr-cache").join("big").join("big-1.0.0.tgz");
     assert_eq!(std::fs::read(cache_path).unwrap(), bytes);
 }


### PR DESCRIPTION
## Summary

Recovers the tarball-serving performance regression that landed with pnpm/pnpm#12570 (the GHSA-5f9g-98vq-2jxw hardening) and restores concurrent streaming on cache misses.

**Root cause (the actual regression).** #12570 added, to the tarball *serve* path, a packument load + full JSON parse (to derive the expected `dist.integrity`) plus a sidecar read and a conditional re-hash — on **every request**, before the cache lookup. Pre-#12570, a cached/proxied tarball was streamed straight from disk with none of that. On a warm proxy cache (the integrated-benchmark shape) this per-serve work is the cold-store regression. Bencher's main history shows a clean, sustained step exactly at #12570; my first attempt (the streaming tee below) moved nothing in the head-to-head because that benchmark serves from a warm cache and never hits the cache-miss path.

**Fix 1 — cache-hit fast path (the regression recovery).** Do the cache lookup first and trust the integrity sidecar: when a cached tarball has a sidecar whose recorded length matches the file, the bytes were already verified against the packument integrity when they were stored, so serve them directly — no packument load/parse, no re-hash. The packument is resolved lazily, only for a cache entry lacking a trustworthy sidecar (verified once, then the sidecar is recorded) and for cache misses (the verified fetch needs it).

**Fix 2 — stream on cache miss instead of buffering.** #12570 also made a cache-miss download buffer the whole tarball, hash it, fsync+rename, then reopen and reread before responding. Replace that with a verified tee: stream each upstream chunk to the client as it arrives while hashing into a temp file, and promote into the cache only on an SRI match. The proxy cache still never stores unverified bytes; the proxy just no longer waits for the whole body before the first byte reaches the client. (This helps real proxy-with-cold-cache usage over a high-latency link, which the benchmark doesn't model.)

Throughout, the client's own SRI check against the packument it resolved remains the authoritative gate on installed bytes — the proxy guards what it *writes* to its cache, not every read. The structural guarantees from #12570 are kept: hosted-store fail-closed, request-to-version binding, OSV screening, and verify-before-cache.

Review hardening folded in: the size cap is enforced on the bytes *relayed* (an oversized body aborts the stream, not just caching), the proxied response no longer asserts an attacker-controlled upstream `Content-Length`, and the upstream URL is redacted before logging.

## Squash Commit Body

```text
#12570 added a per-request packument load + full JSON parse (to derive the
expected integrity), a sidecar read, and a conditional re-hash to the tarball
serve path, before the cache lookup. Pre-#12570 a cached tarball was streamed
straight from disk. On a warm proxy cache that per-serve work is the cold-store
regression.

- Cache-hit fast path: take the cache lookup first and trust the integrity
  sidecar (matched by length) — serve directly without re-loading/parsing the
  packument or re-hashing. Resolve the packument lazily, only for sidecar-less
  entries (verified once, then recorded) and cache misses.
- Cache miss: stream the upstream body to the client via a verified tee instead
  of buffering it fully and reopening it; promote into the cache only on an SRI
  match, so the cache never stores unverified bytes.
- Enforce the size cap on relayed bytes (abort oversized streams), stop
  asserting the upstream Content-Length on the streamed response, and redact the
  upstream URL before logging.

The client verifies the bytes it installs against its own resolved integrity, so
the proxy guards what it writes to its cache, not every read. Hosted-store
fail-closed, request-to-version binding, OSV screening, and verify-before-cache
from #12570 are unchanged.
```

## Checklist

- [x] Added or updated tests.
- This is a `pnpr/` (registry proxy) change, outside the TypeScript CLI ↔ Rust `pacquet/` parity surface, so no port is needed.
- No changeset: `pnpr` is not a published TypeScript package.
- No documentation change needed.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved tarball caching and delivery using a streaming “verify-while-forwarding” flow, reducing unnecessary buffering and extra cache re-open steps.
  * Enhanced cache integrity handling: cached tarballs are served only when their integrity marker matches, and verification failures prevent cache promotion.

* **Tests**
  * Updated and expanded streaming/caching tests, including client disconnect cleanup of temporary cache entries and integrity mismatch/oversize scenarios.
  * Adjusted server tarball tests to reflect that responses may return success while the client-side rejects tampered/truncated content, and confirmed no invalid cache artifacts remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->