### PR TITLE
fix(cli): gate unix-only tests so Windows builds without warnings

### DIFF
--- a/pacquet/crates/cli/src/cli_args/restart/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/restart/tests.rs
@@ -1,3 +1,8 @@
+// Every test here drives `/bin/sh`-style lifecycle scripts, so the whole
+// module is Unix-only; gating it keeps Windows builds free of unused-import
+// and dead-code warnings.
+#![cfg(unix)]
+
 use super::RestartArgs;
 use serde_json::json;
 use tempfile::TempDir;

--- a/pacquet/crates/cli/src/cli_args/stop/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/stop/tests.rs
@@ -1,3 +1,8 @@
+// Every test here drives `/bin/sh`-style lifecycle scripts, so the whole
+// module is Unix-only; gating it keeps Windows builds free of unused-import
+// and dead-code warnings.
+#![cfg(unix)]
+
 use super::StopArgs;
 use serde_json::json;
 use tempfile::TempDir;

--- a/pacquet/crates/cli/tests/create.rs
+++ b/pacquet/crates/cli/tests/create.rs
@@ -1,3 +1,4 @@
+#[cfg(unix)]
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::CommandTempCwd;

--- a/pacquet/crates/package-manager/src/link_file/tests.rs
+++ b/pacquet/crates/package-manager/src/link_file/tests.rs
@@ -1,9 +1,9 @@
-#[cfg(unix)]
-use super::LINK_STATE_COPY;
 use super::{
     LINK_STATE_CLONE, LINK_STATE_HARDLINK, LinkFileError, auto_link, clone_or_copy_link,
-    import_into_fresh_target, is_call_error, is_cross_device, link_file,
+    is_call_error, is_cross_device, link_file,
 };
+#[cfg(unix)]
+use super::{LINK_STATE_COPY, import_into_fresh_target};
 use pacquet_config::PackageImportMethod;
 use pacquet_reporter::SilentReporter;
 use pretty_assertions::assert_eq;


### PR DESCRIPTION
## Summary

On Windows, `cargo` reports `unused_imports` / `dead_code` warnings in several pacquet test modules whose tests run only on Unix (they shell out to `/bin/sh`-style lifecycle scripts or assert POSIX file modes). The test bodies are `#[cfg(unix)]`, but their imports/helpers were not gated, so on Windows the imports and a helper are left unused.

This gates the Unix-only test code so Windows builds cleanly. No behavior change; Unix test coverage is unchanged.

- `cli_args/restart` and `cli_args/stop`: every test is Unix-only — added an inner `#![cfg(unix)]` to each `tests.rs`, dropping the unused `RestartArgs`/`StopArgs`/`TempDir` imports and the dead `setup_project` helper on Windows. `#[cfg(test)] mod tests;` is left intact so the `perfectionist` dylint still recognizes it as the external test module.
- `cli/tests/create.rs`: only the `#[cfg(unix)]` tests use `.assert()`, so the `assert_cmd::prelude` import is gated with `#[cfg(unix)]`. The Windows-active test uses `output.status.success()`.
- `package-manager/src/link_file/tests.rs`: `import_into_fresh_target` is used only by `#[cfg(unix)]` tests, so it moves under the existing `#[cfg(unix)]` import alongside `LINK_STATE_COPY`.

## Squash Commit Body

\`\`\`text
fix(cli): gate unix-only tests so Windows builds without warnings

Several test modules and helpers run only on Unix (they shell out to
`/bin/sh`-style lifecycle scripts or assert POSIX file modes) but their
imports and helpers were not gated, so `cargo` on Windows reported
unused-import and dead-code warnings.

- cli_args/restart and cli_args/stop: every test is Unix-only, so add an
  inner `#![cfg(unix)]` to each tests.rs. This drops the unused
  RestartArgs/StopArgs/TempDir imports and the dead setup_project helper on
  Windows while leaving `#[cfg(test)] mod tests;` intact (the perfectionist
  dylint recognizes that as the external test module).
- cli/tests/create.rs: only the #[cfg(unix)] tests use `.assert()`, so gate
  the assert_cmd::prelude import with #[cfg(unix)]. The Windows-active test
  uses output.status.success().
- package-manager/src/link_file/tests.rs: import_into_fresh_target is used
  only by #[cfg(unix)] tests, so move it under the existing #[cfg(unix)]
  import alongside LINK_STATE_COPY.

No behavior change; Unix test coverage is unchanged.
\`\`\`

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. — N/A: pacquet-only test-gating, no user-visible behavior.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. — N/A: pacquet is not a published npm package; no runtime change.
- [x] Added or updated tests. — N/A: gating only; coverage unchanged.
- [x] Updated the documentation if needed. — N/A.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Unix-specific compilation guards to test modules to prevent unnecessary warnings on non-Unix platforms.
  * New tests for the stop command validate script execution, conditional behavior with the `--if-present` flag, and error handling when scripts are missing.

* **Chores**
  * Refactored import statements to properly align with platform-specific module availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->