### PR TITLE
perf(pnpr): require bearer tokens and drop request-time Basic auth

### DIFF
--- a/pacquet/crates/pnpr-client/tests/integration.rs
+++ b/pacquet/crates/pnpr-client/tests/integration.rs
@@ -20,12 +20,11 @@ use pacquet_testing_utils::registry::TestRegistry;
 use tempfile::TempDir;
 use tokio::net::TcpListener;
 
-/// Basic auth for `pnpr-client:password123`, registered by [`start_pnpr`].
-const PNPR_AUTHORIZATION: &str = "Basic cG5wci1jbGllbnQ6cGFzc3dvcmQxMjM=";
-
 /// Start an in-process pnpr with the fast-path endpoints. Returns the
-/// base URL and the storage guard.
-async fn start_pnpr() -> (String, TempDir) {
+/// base URL, the bearer `Authorization` for the registered `pnpr-client`
+/// caller (pnpr only honors `_authToken` on requests — the resolver
+/// endpoints reject Basic credentials), and the storage guard.
+async fn start_pnpr() -> (String, String, TempDir) {
     let storage = TempDir::new().expect("pnpr storage tempdir");
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.expect("bind pnpr");
     let addr = listener.local_addr().expect("pnpr addr");
@@ -40,8 +39,8 @@ async fn start_pnpr() -> (String, TempDir) {
 
     wait_until_ready(addr).await;
     let base_url = format!("http://{addr}/");
-    let _ = register_token(&base_url, "pnpr-client").await;
-    (base_url, storage)
+    let token = register_token(&base_url, "pnpr-client").await;
+    (base_url, format!("Bearer {token}"), storage)
 }
 
 async fn wait_until_ready(addr: SocketAddr) {
@@ -77,8 +76,8 @@ fn nerf_key(url: &str) -> String {
 }
 
 /// Register a user with an npm-compatible registry and return its bearer
-/// token. The pnpr fixture reuses the account through Basic auth; registry
-/// tests forward the token as an upstream credential.
+/// token. The pnpr fixture authenticates its own caller with this token;
+/// registry tests forward it as an upstream credential.
 async fn register_token(registry_url: &str, username: &str) -> String {
     let body = serde_json::json!({ "name": username, "password": "password123" });
     let response = reqwest::Client::new()
@@ -92,7 +91,11 @@ async fn register_token(registry_url: &str, username: &str) -> String {
     json["token"].as_str().expect("token in adduser response").to_string()
 }
 
-fn options(registry: &str, dependencies: BTreeMap<String, String>) -> ResolveOptions {
+fn options(
+    registry: &str,
+    authorization: &str,
+    dependencies: BTreeMap<String, String>,
+) -> ResolveOptions {
     ResolveOptions {
         dependencies,
         dev_dependencies: BTreeMap::new(),
@@ -100,7 +103,7 @@ fn options(registry: &str, dependencies: BTreeMap<String, String>) -> ResolveOpt
         registry: registry.to_string(),
         named_registries: BTreeMap::new(),
         auth_headers: BTreeMap::new(),
-        authorization: Some(PNPR_AUTHORIZATION.to_string()),
+        authorization: Some(authorization.to_string()),
         overrides: None,
         lockfile: None,
         frozen_lockfile: false,
@@ -138,10 +141,10 @@ async fn forwards_credentials_and_the_identity_header() {
 
     let client = PnprClient::new(format!("{}/", server.url()));
 
-    let mut opts = options("https://npm.acme.test/", deps([("@acme/foo", "1.0.0")]));
+    let mut opts =
+        options("https://npm.acme.test/", "Bearer pnpr-token", deps([("@acme/foo", "1.0.0")]));
     opts.auth_headers =
         auth_headers([("//npm.acme.test/", DEFAULT_REGISTRY_SCOPE, "Bearer upstream-token")]);
-    opts.authorization = Some("Bearer pnpr-token".to_string());
 
     let result = client.resolve(opts).await;
     assert!(result.is_err(), "the canned 500 should surface as an error");
@@ -156,11 +159,11 @@ async fn forwards_credentials_and_the_identity_header() {
 async fn a_forwarded_credential_resolves_a_private_package() {
     let registry = TestRegistry::start();
     let token = register_token(&registry.url(), "needs-auth-forwarder").await;
-    let (pnpr_url, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
 
     let client = PnprClient::new(pnpr_url);
 
-    let mut opts = options(&registry.url(), deps([("@pnpm.e2e/needs-auth", "1.0.0")]));
+    let mut opts = options(&registry.url(), &pnpr_auth, deps([("@pnpm.e2e/needs-auth", "1.0.0")]));
     let registry_key = nerf_key(&registry.url());
     let bearer = format!("Bearer {token}");
     opts.auth_headers =
@@ -181,11 +184,11 @@ async fn a_forwarded_credential_resolves_a_private_package() {
 #[tokio::test]
 async fn a_private_package_fails_without_a_forwarded_credential() {
     let registry = TestRegistry::start();
-    let (pnpr_url, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
 
     let client = PnprClient::new(pnpr_url);
 
-    let opts = options(&registry.url(), deps([("@pnpm.e2e/needs-auth", "1.0.0")]));
+    let opts = options(&registry.url(), &pnpr_auth, deps([("@pnpm.e2e/needs-auth", "1.0.0")]));
     let Err(PnprClientError::Server(message)) = client.resolve(opts).await else {
         panic!("expected the gated install to fail with a server error");
     };
@@ -198,12 +201,12 @@ async fn a_private_package_fails_without_a_forwarded_credential() {
 #[tokio::test]
 async fn resolves_a_package() {
     let registry = TestRegistry::start();
-    let (pnpr_url, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
 
     let client = PnprClient::new(pnpr_url);
 
     let outcome = client
-        .resolve(options(&registry.url(), deps([("@foo/no-deps", "1.0.0")])))
+        .resolve(options(&registry.url(), &pnpr_auth, deps([("@foo/no-deps", "1.0.0")])))
         .await
         .expect("install should succeed");
 
@@ -225,18 +228,21 @@ async fn resolves_a_package() {
 #[tokio::test]
 async fn streams_resolved_packages_before_the_lockfile() {
     let registry = TestRegistry::start();
-    let (pnpr_url, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
 
     let client = PnprClient::new(pnpr_url);
 
     let mut streamed: Vec<String> = Vec::new();
     let outcome = client
-        .resolve_streaming(options(&registry.url(), deps([("@foo/no-deps", "1.0.0")])), |pkg| {
-            assert!(!pkg.integrity.is_empty(), "a package frame carries an integrity");
-            assert!(pkg.tarball.starts_with("http"), "a package frame carries a tarball URL");
-            assert_eq!(pkg.id, format!("{}@{}", pkg.name, pkg.version), "id is name@version");
-            streamed.push(pkg.id);
-        })
+        .resolve_streaming(
+            options(&registry.url(), &pnpr_auth, deps([("@foo/no-deps", "1.0.0")])),
+            |pkg| {
+                assert!(!pkg.integrity.is_empty(), "a package frame carries an integrity");
+                assert!(pkg.tarball.starts_with("http"), "a package frame carries a tarball URL");
+                assert_eq!(pkg.id, format!("{}@{}", pkg.name, pkg.version), "id is name@version");
+                streamed.push(pkg.id);
+            },
+        )
         .await
         .expect("streaming resolve should succeed");
 
@@ -256,11 +262,11 @@ async fn streams_resolved_packages_before_the_lockfile() {
 #[tokio::test]
 async fn forwards_optional_dependencies() {
     let registry = TestRegistry::start();
-    let (pnpr_url, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
 
     let client = PnprClient::new(pnpr_url);
 
-    let mut opts = options(&registry.url(), BTreeMap::new());
+    let mut opts = options(&registry.url(), &pnpr_auth, BTreeMap::new());
     opts.optional_dependencies = deps([("@foo/no-deps", "1.0.0")]);
 
     let outcome = client.resolve(opts).await.expect("install should succeed");
@@ -275,20 +281,20 @@ async fn forwards_optional_dependencies() {
 #[tokio::test]
 async fn verifies_and_accepts_a_clean_input_lockfile() {
     let registry = TestRegistry::start();
-    let (pnpr_url, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
 
     let client = PnprClient::new(pnpr_url);
 
     // A first install with no lockfile produces a valid resolved one.
     let first = client
-        .resolve(options(&registry.url(), deps([("@foo/no-deps", "1.0.0")])))
+        .resolve(options(&registry.url(), &pnpr_auth, deps([("@foo/no-deps", "1.0.0")])))
         .await
         .expect("first install");
 
     // Sending it back as the input lockfile makes the server verify it
     // under the (default, policy-free) client policy before resolving;
     // a clean lockfile passes and the install succeeds.
-    let mut opts = options(&registry.url(), deps([("@foo/no-deps", "1.0.0")]));
+    let mut opts = options(&registry.url(), &pnpr_auth, deps([("@foo/no-deps", "1.0.0")]));
     opts.lockfile = Some(first.lockfile.clone());
     let second = client.resolve(opts).await.expect("verified-input install should succeed");
     assert!(second.lockfile.packages.is_some(), "resolution still produced a lockfile");
@@ -297,19 +303,19 @@ async fn verifies_and_accepts_a_clean_input_lockfile() {
 #[tokio::test]
 async fn rejects_an_input_lockfile_that_violates_the_clients_policy() {
     let registry = TestRegistry::start();
-    let (pnpr_url, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
 
     let client = PnprClient::new(pnpr_url);
 
     let first = client
-        .resolve(options(&registry.url(), deps([("@foo/no-deps", "1.0.0")])))
+        .resolve(options(&registry.url(), &pnpr_auth, deps([("@foo/no-deps", "1.0.0")])))
         .await
         .expect("first install");
 
     // Re-send the same lockfile under a ~100-year minimumReleaseAge: no
     // real publish time can satisfy it, so the server rejects the input
     // lockfile and the client rebuilds the identical `VerifyError`.
-    let mut opts = options(&registry.url(), deps([("@foo/no-deps", "1.0.0")]));
+    let mut opts = options(&registry.url(), &pnpr_auth, deps([("@foo/no-deps", "1.0.0")]));
     opts.lockfile = Some(first.lockfile.clone());
     opts.minimum_release_age = Some(60 * 24 * 365 * 100);
     opts.minimum_release_age_ignore_missing_time = false;
@@ -326,16 +332,16 @@ async fn rejects_an_input_lockfile_that_violates_the_clients_policy() {
 #[tokio::test]
 async fn verify_lockfile_endpoint_accepts_a_clean_input_lockfile() {
     let registry = TestRegistry::start();
-    let (pnpr_url, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
 
     let client = PnprClient::new(pnpr_url);
 
     let first = client
-        .resolve(options(&registry.url(), deps([("@foo/no-deps", "1.0.0")])))
+        .resolve(options(&registry.url(), &pnpr_auth, deps([("@foo/no-deps", "1.0.0")])))
         .await
         .expect("first install");
 
-    let mut opts = options(&registry.url(), deps([("@foo/no-deps", "1.0.0")]));
+    let mut opts = options(&registry.url(), &pnpr_auth, deps([("@foo/no-deps", "1.0.0")]));
     opts.lockfile = Some(first.lockfile);
     let verify_opts =
         VerifyLockfileOptions::from_resolve_options(&opts).expect("lockfile is present");
@@ -346,16 +352,16 @@ async fn verify_lockfile_endpoint_accepts_a_clean_input_lockfile() {
 #[tokio::test]
 async fn verify_lockfile_endpoint_rejects_policy_violation() {
     let registry = TestRegistry::start();
-    let (pnpr_url, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
 
     let client = PnprClient::new(pnpr_url);
 
     let first = client
-        .resolve(options(&registry.url(), deps([("@foo/no-deps", "1.0.0")])))
+        .resolve(options(&registry.url(), &pnpr_auth, deps([("@foo/no-deps", "1.0.0")])))
         .await
         .expect("first install");
 
-    let mut opts = options(&registry.url(), deps([("@foo/no-deps", "1.0.0")]));
+    let mut opts = options(&registry.url(), &pnpr_auth, deps([("@foo/no-deps", "1.0.0")]));
     opts.lockfile = Some(first.lockfile);
     opts.minimum_release_age = Some(60 * 24 * 365 * 100);
     opts.minimum_release_age_ignore_missing_time = false;
@@ -382,9 +388,10 @@ async fn verify_lockfile_endpoint_rejects_policy_violation() {
 async fn verify_lockfile_endpoint_forwards_credentials() {
     let registry = TestRegistry::start();
     let token = register_token(&registry.url(), "needs-auth-verifier").await;
-    let (resolve_pnpr_url, _resolve_storage) = start_pnpr().await;
+    let (resolve_pnpr_url, resolve_auth, _resolve_storage) = start_pnpr().await;
 
-    let mut resolve_opts = options(&registry.url(), deps([("@pnpm.e2e/needs-auth", "1.0.0")]));
+    let mut resolve_opts =
+        options(&registry.url(), &resolve_auth, deps([("@pnpm.e2e/needs-auth", "1.0.0")]));
     let registry_key = nerf_key(&registry.url());
     let bearer = format!("Bearer {token}");
     resolve_opts.auth_headers =
@@ -398,20 +405,25 @@ async fn verify_lockfile_endpoint_forwards_credentials() {
     resolve_opts.lockfile = Some(first.lockfile);
     resolve_opts.minimum_release_age = Some(1);
     resolve_opts.minimum_release_age_ignore_missing_time = false;
-    let verify_opts =
-        VerifyLockfileOptions::from_resolve_options(&resolve_opts).expect("lockfile is present");
 
-    let (authed_pnpr_url, _authed_storage) = start_pnpr().await;
+    // Each verify targets a fresh pnpr, so the caller re-authenticates with
+    // that server's own bearer token.
+    let (authed_pnpr_url, authed_auth, _authed_storage) = start_pnpr().await;
+    let mut authed_opts = resolve_opts.clone();
+    authed_opts.authorization = Some(authed_auth);
+    let verify_opts =
+        VerifyLockfileOptions::from_resolve_options(&authed_opts).expect("lockfile is present");
     PnprClient::new(authed_pnpr_url)
         .verify_lockfile(verify_opts)
         .await
         .expect("forwarded credential should let the gated entry verify");
 
+    let (anonymous_pnpr_url, anonymous_auth, _anonymous_storage) = start_pnpr().await;
     let mut anonymous_opts = resolve_opts.clone();
+    anonymous_opts.authorization = Some(anonymous_auth);
     anonymous_opts.auth_headers = BTreeMap::new();
     let anonymous_verify_opts =
         VerifyLockfileOptions::from_resolve_options(&anonymous_opts).expect("lockfile is present");
-    let (anonymous_pnpr_url, _anonymous_storage) = start_pnpr().await;
     assert!(
         PnprClient::new(anonymous_pnpr_url).verify_lockfile(anonymous_verify_opts).await.is_err(),
         "without the credential the gated entry's metadata fetch must fail closed",
@@ -421,12 +433,12 @@ async fn verify_lockfile_endpoint_forwards_credentials() {
 #[tokio::test]
 async fn trust_lockfile_makes_the_server_skip_verification() {
     let registry = TestRegistry::start();
-    let (pnpr_url, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
 
     let client = PnprClient::new(pnpr_url);
 
     let first = client
-        .resolve(options(&registry.url(), deps([("@foo/no-deps", "1.0.0")])))
+        .resolve(options(&registry.url(), &pnpr_auth, deps([("@foo/no-deps", "1.0.0")])))
         .await
         .expect("first install");
 
@@ -434,7 +446,7 @@ async fn trust_lockfile_makes_the_server_skip_verification() {
     // trips on, but with the client's `trustLockfile` opt-out set: the
     // server must skip the verify gate and resolve normally, matching the
     // local `--trust-lockfile` path.
-    let mut opts = options(&registry.url(), deps([("@foo/no-deps", "1.0.0")]));
+    let mut opts = options(&registry.url(), &pnpr_auth, deps([("@foo/no-deps", "1.0.0")]));
     opts.lockfile = Some(first.lockfile.clone());
     opts.minimum_release_age = Some(60 * 24 * 365 * 100);
     opts.minimum_release_age_ignore_missing_time = false;

--- a/pnpr/crates/pnpr/src/auth.rs
+++ b/pnpr/crates/pnpr/src/auth.rs
@@ -31,7 +31,6 @@ use crate::{
     error::{RegistryError, Result},
 };
 use async_trait::async_trait;
-use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 #[cfg(feature = "backend-libsql")]
 use libsql_backend::LibsqlAuth;
 use rusqlite::Connection;
@@ -226,27 +225,20 @@ fn backend_not_enabled(name: &str, feature: &str) -> RegistryError {
     }
 }
 
-/// Username + password record store. The hot read is
-/// [`Self::verify`] (the Basic-auth path of [`identify`]); the write
-/// is [`Self::add_or_login`] (npm `adduser` / `login`).
+/// Username + password record store. The only operation is
+/// [`Self::add_or_login`] (npm `adduser` / `login`), which verifies a
+/// password and mints a bearer token. pnpr no longer verifies Basic
+/// credentials on requests, so there is no per-request password check.
 #[async_trait]
 pub trait UserBackend: Send + Sync {
     /// Add a new user or verify a returning one. On success, returns
     /// the outcome plus the canonical stored username to bind follow-up
-    /// token issuance to the same identity that Basic auth would
-    /// resolve. A wrong password for an existing user is
-    /// [`RegistryError::Unauthenticated`], and a new user past the
-    /// registration cap is [`RegistryError::RegistrationDisabled`] /
+    /// token issuance to the same identity. A wrong password for an
+    /// existing user is [`RegistryError::Unauthenticated`], and a new user
+    /// past the registration cap is [`RegistryError::RegistrationDisabled`] /
     /// `TooManyUsers`.
     async fn add_or_login(&self, username: &str, password: &str)
     -> Result<(UpsertOutcome, String)>;
-
-    /// Verify a username+password pair. `Ok(Some(username))` on a match,
-    /// `Ok(None)` when the user is unknown or the password is wrong, and
-    /// `Err` only when the backing store itself fails — so a store
-    /// outage surfaces as a 5xx rather than masquerading as a bad
-    /// password.
-    async fn verify(&self, username: &str, password: &str) -> Result<Option<String>>;
 }
 
 /// Bearer-token record store. The hot read is [`Self::lookup`]
@@ -433,26 +425,6 @@ impl UserBackend for UserStore {
             }
         }
     }
-
-    async fn verify(&self, username: &str, password: &str) -> Result<Option<String>> {
-        if validate_username(username).is_err() {
-            return Ok(None);
-        }
-
-        let stored = {
-            let users = self.users.lock().expect("UserStore mutex poisoned");
-            users.get(username).cloned()
-        };
-        let Some(stored) = stored else {
-            return Ok(None);
-        };
-        // The in-memory read can't fail; a bcrypt error is treated as a
-        // non-match (not a store outage), so it stays `Ok(None)`.
-        Ok(verify_bcrypt(password.to_string(), stored)
-            .await
-            .unwrap_or(false)
-            .then(|| username.to_string()))
-    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -633,22 +605,24 @@ impl Default for UserStore {
 }
 
 /// Identify the caller behind an HTTP request. Inspects the
-/// `Authorization` header and resolves it to a username via the
-/// token store (for `Bearer`) or the user store (for `Basic`).
-/// Returns `None` for missing/unsupported credentials so the caller
-/// can decide whether anonymous is allowed.
+/// `Authorization` header and resolves it to a username via the token
+/// store. Only `Bearer` tokens are honored: pnpr does not accept Basic
+/// credentials on requests. Clients authenticate with `_authToken`, and a
+/// password login mints a token through [`UserBackend::add_or_login`] — so
+/// request handling never pays a per-request bcrypt. Returns `None` for
+/// missing/unsupported credentials so the caller can decide whether
+/// anonymous is allowed.
 ///
 /// The scheme is matched case-insensitively (RFC 7235 §2.1: "the
 /// scheme is case-insensitive"), so `BEARER`, `bearer`, and `Bearer`
 /// all parse the same.
 /// `Ok(None)` covers every "no usable credentials" case — a missing or
-/// malformed header, an unsupported scheme, or credentials that simply
-/// don't match. `Err` is reserved for a failure of the backing store
-/// (e.g. the networked auth DB is unreachable) so the caller can return
-/// a 5xx instead of a misleading 401.
+/// malformed header, a non-`Bearer` scheme (including legacy `Basic`), or a
+/// token that simply doesn't match. `Err` is reserved for a failure of the
+/// backing store (e.g. the networked auth DB is unreachable) so the caller
+/// can return a 5xx instead of a misleading 401.
 pub async fn identify(
     header_value: Option<&str>,
-    users: &dyn UserBackend,
     tokens: &dyn TokenBackend,
 ) -> Result<Option<String>> {
     let Some(value) = header_value.map(str::trim) else {
@@ -663,18 +637,6 @@ pub async fn identify(
     };
     if scheme.eq_ignore_ascii_case("Bearer") {
         return tokens.lookup(credentials).await;
-    }
-    if scheme.eq_ignore_ascii_case("Basic") {
-        let Ok(decoded) = BASE64.decode(credentials) else {
-            return Ok(None);
-        };
-        let Ok(pair) = std::str::from_utf8(&decoded) else {
-            return Ok(None);
-        };
-        let Some((user, password)) = pair.split_once(':') else {
-            return Ok(None);
-        };
-        return users.verify(user, password).await;
     }
     Ok(None)
 }

--- a/pnpr/crates/pnpr/src/auth/libsql_backend.rs
+++ b/pnpr/crates/pnpr/src/auth/libsql_backend.rs
@@ -21,7 +21,7 @@
 use super::{
     DEFAULT_BCRYPT_COST, TokenBackend, TokenRecord, UpsertOutcome, UserBackend, fresh_secret,
     hash_bcrypt, mint_token, sha256_hex, token_timestamp_from_sql, unix_seconds, validate_username,
-    verify_bcrypt, verify_returning_user,
+    verify_returning_user,
 };
 use crate::{
     config::{LibsqlSettings, MaxUsers},
@@ -219,18 +219,6 @@ impl UserBackend for LibsqlAuth {
                 Err(err) => return Err(err.into()),
             }
         }
-    }
-
-    async fn verify(&self, username: &str, password: &str) -> Result<Option<String>> {
-        if validate_username(username).is_err() {
-            return Ok(None);
-        }
-
-        let Some(stored) = self.stored_hash(username).await? else {
-            return Ok(None);
-        };
-        let valid = verify_bcrypt(password.to_string(), stored).await?;
-        Ok(valid.then(|| username.to_string()))
     }
 }
 

--- a/pnpr/crates/pnpr/src/auth/libsql_backend/tests.rs
+++ b/pnpr/crates/pnpr/src/auth/libsql_backend/tests.rs
@@ -18,9 +18,6 @@ async fn add_or_login_creates_then_logs_in() {
         backend.add_or_login("alice", "secret").await.unwrap(),
         (UpsertOutcome::LoggedIn, _),
     ));
-    assert_eq!(backend.verify("alice", "secret").await.unwrap().as_deref(), Some("alice"));
-    assert!(backend.verify("alice", "wrong").await.unwrap().is_none());
-    assert!(backend.verify("bob", "secret").await.unwrap().is_none());
 }
 
 #[tokio::test]
@@ -65,11 +62,10 @@ async fn add_or_login_rejects_existing_invalid_username() {
     let err = backend.add_or_login("alice ", "secret").await.unwrap_err();
 
     assert_eq!(err.status_code(), axum::http::StatusCode::BAD_REQUEST);
-    assert!(backend.verify("alice ", "secret").await.unwrap().is_none());
 }
 
 #[tokio::test]
-async fn verify_propagates_corrupt_hash_errors() {
+async fn add_or_login_propagates_corrupt_hash_errors() {
     let backend = local_backend(MaxUsers::Unlimited).await;
     backend
         .conn
@@ -80,7 +76,7 @@ async fn verify_propagates_corrupt_hash_errors() {
         .await
         .unwrap();
 
-    let err = backend.verify("alice", "secret").await.unwrap_err();
+    let err = backend.add_or_login("alice", "secret").await.unwrap_err();
 
     assert!(matches!(err, RegistryError::Bcrypt(_)), "got {err:?}");
 }

--- a/pnpr/crates/pnpr/src/auth/sqlx_backend.rs
+++ b/pnpr/crates/pnpr/src/auth/sqlx_backend.rs
@@ -1173,25 +1173,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn add_or_login_skips_unbounded_usernames_without_db_lookup() {
-        let stored_user_calls = Arc::new(AtomicU64::new(0));
-        let auth = SqlAuth::new(
-            CountingLookupBackend { stored_user_calls: Arc::clone(&stored_user_calls) },
-            MaxUsers::Unlimited,
-            Duration::from_secs(30),
-        );
-        let overlong = "a".repeat(MAX_USERNAME_CHARS + 1);
-
-        for username in ["", " alice", "alice ", "#alice", "alice:admin", "alice\nadmin"] {
-            let err = auth.add_or_login(username, "secret").await.unwrap_err();
-            assert_eq!(err.status_code(), axum::http::StatusCode::BAD_REQUEST);
-        }
-        let err = auth.add_or_login(&overlong, "secret").await.unwrap_err();
-        assert_eq!(err.status_code(), axum::http::StatusCode::BAD_REQUEST);
-        assert_eq!(stored_user_calls.load(Ordering::SeqCst), 0);
-    }
-
-    #[tokio::test]
     async fn add_or_login_returns_the_stored_username_for_existing_users() {
         let bcrypt_hash = bcrypt::hash("secret", 4).unwrap();
         let auth = SqlAuth::new(

--- a/pnpr/crates/pnpr/src/auth/sqlx_backend.rs
+++ b/pnpr/crates/pnpr/src/auth/sqlx_backend.rs
@@ -3,8 +3,7 @@
 
 use super::{
     DEFAULT_BCRYPT_COST, TokenBackend, TokenRecord, UpsertOutcome, UserBackend, fresh_secret,
-    hash_bcrypt, mint_token, sha256_hex, unix_seconds, validate_username, verify_bcrypt,
-    verify_returning_user,
+    hash_bcrypt, mint_token, sha256_hex, unix_seconds, validate_username, verify_returning_user,
 };
 use crate::{
     config::MaxUsers,
@@ -153,19 +152,6 @@ where
                 }
             },
         }
-    }
-
-    async fn verify(&self, username: &str, password: &str) -> Result<Option<String>> {
-        if validate_username(username).is_err() {
-            return Ok(None);
-        }
-
-        let Some(stored) = with_auth_timeout(self.timeout, self.db.stored_user(username)).await?
-        else {
-            return Ok(None);
-        };
-        let valid = verify_bcrypt(password.to_string(), stored.bcrypt_hash).await?;
-        Ok(valid.then_some(stored.username))
     }
 }
 
@@ -1169,19 +1155,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn verify_returns_the_stored_username() {
-        let bcrypt_hash = bcrypt::hash("secret", 4).unwrap();
-        let auth = SqlAuth::new(
-            CanonicalBackend { user: StoredUser { username: "Alice".to_string(), bcrypt_hash } },
-            MaxUsers::Unlimited,
-            Duration::from_secs(30),
-        );
-
-        assert_eq!(auth.verify("alice", "secret").await.unwrap().as_deref(), Some("Alice"));
-    }
-
-    #[tokio::test]
-    async fn verify_propagates_corrupt_hash_errors() {
+    async fn add_or_login_propagates_corrupt_hash_errors() {
         let auth = SqlAuth::new(
             CanonicalBackend {
                 user: StoredUser {
@@ -1193,13 +1167,13 @@ mod tests {
             Duration::from_secs(30),
         );
 
-        let err = auth.verify("alice", "secret").await.unwrap_err();
+        let err = auth.add_or_login("alice", "secret").await.unwrap_err();
 
         assert!(matches!(err, RegistryError::Bcrypt(_)), "got {err:?}");
     }
 
     #[tokio::test]
-    async fn verify_skips_unbounded_usernames_without_db_lookup() {
+    async fn add_or_login_skips_unbounded_usernames_without_db_lookup() {
         let stored_user_calls = Arc::new(AtomicU64::new(0));
         let auth = SqlAuth::new(
             CountingLookupBackend { stored_user_calls: Arc::clone(&stored_user_calls) },
@@ -1209,9 +1183,11 @@ mod tests {
         let overlong = "a".repeat(MAX_USERNAME_CHARS + 1);
 
         for username in ["", " alice", "alice ", "#alice", "alice:admin", "alice\nadmin"] {
-            assert_eq!(auth.verify(username, "secret").await.unwrap(), None);
+            let err = auth.add_or_login(username, "secret").await.unwrap_err();
+            assert_eq!(err.status_code(), axum::http::StatusCode::BAD_REQUEST);
         }
-        assert_eq!(auth.verify(&overlong, "secret").await.unwrap(), None);
+        let err = auth.add_or_login(&overlong, "secret").await.unwrap_err();
+        assert_eq!(err.status_code(), axum::http::StatusCode::BAD_REQUEST);
         assert_eq!(stored_user_calls.load(Ordering::SeqCst), 0);
     }
 

--- a/pnpr/crates/pnpr/src/auth/tests.rs
+++ b/pnpr/crates/pnpr/src/auth/tests.rs
@@ -114,10 +114,6 @@ async fn user_store_rejects_invalid_username_before_lookup() {
             axum::http::StatusCode::BAD_REQUEST,
             "expected adduser for {username:?} to be rejected",
         );
-        assert!(
-            store.verify(username, "secret").await.unwrap().is_none(),
-            "expected Basic auth for {username:?} to be rejected",
-        );
     }
 }
 
@@ -132,9 +128,9 @@ async fn adduser_creates_then_validates() {
     assert!(matches!(outcome, (UpsertOutcome::LoggedIn, _)));
     assert_eq!(outcome.1, "alice");
 
-    assert!(store.verify("alice", "secret").await.unwrap().is_some());
-    assert!(store.verify("alice", "wrong").await.unwrap().is_none());
-    assert!(store.verify("bob", "secret").await.unwrap().is_none());
+    // A wrong password for an existing user is rejected.
+    let err = store.add_or_login("alice", "wrong").await.unwrap_err();
+    assert_eq!(err.status_code(), axum::http::StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]
@@ -189,10 +185,11 @@ async fn adduser_rejects_same_username_concurrent_registration_with_different_pa
 
     assert_eq!(created, 1, "exactly one concurrent adduser should create the account");
     assert_eq!(unauthorized, 1, "the losing registration must be rejected");
-    assert_ne!(
-        store.verify("alice", "pw-a").await.unwrap().is_some(),
-        store.verify("alice", "pw-b").await.unwrap().is_some(),
-    );
+    // Exactly one of the two passwords is the one that was stored: logging in
+    // with it succeeds, the other is unauthorized.
+    let pw_a_logs_in = store.add_or_login("alice", "pw-a").await.is_ok();
+    let pw_b_logs_in = store.add_or_login("alice", "pw-b").await.is_ok();
+    assert_ne!(pw_a_logs_in, pw_b_logs_in, "exactly one password must be the stored one");
 }
 
 #[tokio::test]
@@ -204,11 +201,10 @@ async fn adduser_persists_across_reopen() {
     store.add_or_login("alice", "secret").await.unwrap();
     drop(store);
 
-    // Cold-load from disk; the hashed entry should still verify.
+    // Cold-load from disk; the hashed entry should still log in.
     let reopened = UserStore::open_with_cost(path.clone(), MaxUsers::Unlimited, TEST_COST).unwrap();
     let outcome = reopened.add_or_login("alice", "secret").await.unwrap();
     assert!(matches!(outcome, (UpsertOutcome::LoggedIn, _)));
-    assert!(reopened.verify("alice", "secret").await.unwrap().is_some());
 }
 
 #[tokio::test]
@@ -408,53 +404,44 @@ async fn token_issue_rolls_back_memory_when_sqlite_persistence_fails() {
 }
 
 #[tokio::test]
-async fn identify_recognizes_bearer_and_basic() {
-    let users = test_user_store();
-    users.add_or_login("alice", "secret").await.unwrap();
+async fn identify_recognizes_bearer_and_ignores_basic() {
     let tokens = TokenStore::in_memory();
     let token = tokens.issue("alice").await.unwrap();
 
     let header = format!("Bearer {token}");
-    assert_eq!(identify(Some(&header), &users, &tokens).await.unwrap().as_deref(), Some("alice"));
+    assert_eq!(identify(Some(&header), &tokens).await.unwrap().as_deref(), Some("alice"));
 
-    // Basic: base64(alice:secret) = YWxpY2U6c2VjcmV0
+    // Basic credentials are no longer accepted on requests — the header is
+    // ignored (treated as anonymous), so request handling never pays a bcrypt.
     let basic = "Basic YWxpY2U6c2VjcmV0";
-    assert_eq!(identify(Some(basic), &users, &tokens).await.unwrap().as_deref(), Some("alice"));
+    assert!(identify(Some(basic), &tokens).await.unwrap().is_none());
 
-    let wrong = format!(
-        "Basic {}",
-        base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"alice:wrong"),
-    );
-    assert!(identify(Some(&wrong), &users, &tokens).await.unwrap().is_none());
-
-    assert!(identify(None, &users, &tokens).await.unwrap().is_none());
-    assert!(identify(Some("Bearer total-nonsense"), &users, &tokens).await.unwrap().is_none());
+    assert!(identify(None, &tokens).await.unwrap().is_none());
+    assert!(identify(Some("Bearer total-nonsense"), &tokens).await.unwrap().is_none());
 }
 
 /// RFC 7235 §2.1: "the scheme is case-insensitive". All of
 /// `Bearer`, `BEARER`, and `bearer` (and the mixed-case forms
-/// some clients emit) must resolve the same way.
+/// some clients emit) must resolve the same way; `Basic` is ignored in any
+/// case.
 #[tokio::test]
 async fn identify_parses_auth_scheme_case_insensitively() {
-    let users = test_user_store();
-    users.add_or_login("alice", "secret").await.unwrap();
     let tokens = TokenStore::in_memory();
     let token = tokens.issue("alice").await.unwrap();
 
     for scheme in ["Bearer", "bearer", "BEARER", "BeArEr"] {
         let header = format!("{scheme} {token}");
         assert_eq!(
-            identify(Some(&header), &users, &tokens).await.unwrap().as_deref(),
+            identify(Some(&header), &tokens).await.unwrap().as_deref(),
             Some("alice"),
             "Bearer scheme {scheme:?} should be recognized",
         );
     }
     for scheme in ["Basic", "basic", "BASIC", "bAsIc"] {
         let header = format!("{scheme} YWxpY2U6c2VjcmV0");
-        assert_eq!(
-            identify(Some(&header), &users, &tokens).await.unwrap().as_deref(),
-            Some("alice"),
-            "Basic scheme {scheme:?} should be recognized",
+        assert!(
+            identify(Some(&header), &tokens).await.unwrap().is_none(),
+            "Basic scheme {scheme:?} must be ignored",
         );
     }
 }

--- a/pnpr/crates/pnpr/src/auth/tests.rs
+++ b/pnpr/crates/pnpr/src/auth/tests.rs
@@ -186,10 +186,25 @@ async fn adduser_rejects_same_username_concurrent_registration_with_different_pa
     assert_eq!(created, 1, "exactly one concurrent adduser should create the account");
     assert_eq!(unauthorized, 1, "the losing registration must be rejected");
     // Exactly one of the two passwords is the one that was stored: logging in
-    // with it succeeds, the other is unauthorized.
-    let pw_a_logs_in = store.add_or_login("alice", "pw-a").await.is_ok();
-    let pw_b_logs_in = store.add_or_login("alice", "pw-b").await.is_ok();
-    assert_ne!(pw_a_logs_in, pw_b_logs_in, "exactly one password must be the stored one");
+    // with it succeeds, the other is rejected as unauthorized.
+    let login_a = store.add_or_login("alice", "pw-a").await;
+    let login_b = store.add_or_login("alice", "pw-b").await;
+    let logged_in = [login_a.as_ref(), login_b.as_ref()]
+        .into_iter()
+        .filter(|result| matches!(result, Ok((UpsertOutcome::LoggedIn, _))))
+        .count();
+    let unauthorized_logins = [&login_a, &login_b]
+        .into_iter()
+        .filter(|result| {
+            result
+                .as_ref()
+                .err()
+                .is_some_and(|err| err.status_code() == axum::http::StatusCode::UNAUTHORIZED)
+        })
+        .count();
+
+    assert_eq!(logged_in, 1, "exactly one password must be the stored one");
+    assert_eq!(unauthorized_logins, 1, "the other password must be unauthorized");
 }
 
 #[tokio::test]

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -2173,10 +2173,10 @@ async fn authenticate(State(state): State<AppState>, mut request: Request, next:
 /// Resolve the `Authorization` header to an [`Identity`], hitting the auth
 /// backend exactly once. A bearer token is looked up as a full record so
 /// its read-only / CIDR restrictions can be enforced here (a violation is
-/// a `Forbidden` error); an unknown bearer token, a wrong Basic password,
-/// and a missing header all resolve to [`Identity::Anonymous`]. `Err` is a
-/// backing-store failure, surfaced as a 5xx so an outage isn't mistaken
-/// for "not authenticated".
+/// a `Forbidden` error); an unknown bearer token, a non-`Bearer` scheme
+/// (e.g. legacy `Basic`), and a missing header all resolve to
+/// [`Identity::Anonymous`]. `Err` is a backing-store failure, surfaced as a
+/// 5xx so an outage isn't mistaken for "not authenticated".
 async fn resolve_caller(
     state: &AppState,
     header: Option<&str>,
@@ -2190,11 +2190,11 @@ async fn resolve_caller(
         check_token_restrictions(&record, method, peer)?;
         return Ok(Identity::User { username: record.username });
     }
-    // Not a bearer token: Basic (or no credentials), which carries no
-    // token-level restriction. `identify` does the decode + password
-    // verification.
-    let username = identify(header, state.inner.auth.tokens.as_ref()).await?;
-    Ok(username.map_or(Identity::Anonymous, |username| Identity::User { username }))
+    // Anything that is not a bearer token — Basic, another scheme, or no
+    // credentials — carries no request identity. Going through `identify`
+    // here would re-run the bearer lookup and bypass the restriction checks
+    // above, so resolve straight to anonymous.
+    Ok(Identity::Anonymous)
 }
 
 /// Enforce a bearer token's own restrictions. A read-only token may not

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1292,7 +1292,7 @@ async fn caller_username(
     headers: &HeaderMap,
 ) -> Result<Option<String>, RegistryError> {
     let authorization = single_authorization_header(headers)?;
-    identify(authorization, state.inner.auth.users.as_ref(), state.inner.auth.tokens.as_ref()).await
+    identify(authorization, state.inner.auth.tokens.as_ref()).await
 }
 
 async fn require_resolver_caller(
@@ -2193,8 +2193,7 @@ async fn resolve_caller(
     // Not a bearer token: Basic (or no credentials), which carries no
     // token-level restriction. `identify` does the decode + password
     // verification.
-    let username =
-        identify(header, state.inner.auth.users.as_ref(), state.inner.auth.tokens.as_ref()).await?;
+    let username = identify(header, state.inner.auth.tokens.as_ref()).await?;
     Ok(username.map_or(Identity::Anonymous, |username| Identity::User { username }))
 }
 

--- a/pnpr/crates/pnpr/tests/auth_persistence.rs
+++ b/pnpr/crates/pnpr/tests/auth_persistence.rs
@@ -174,7 +174,9 @@ async fn invalid_usernames_do_not_change_htpasswd_across_restart() {
 
     drop(app);
     let auth = AuthState::load(&config.auth, &config.backend).await.expect("reload after restart");
-    assert_eq!(auth.users.verify("alice", "secret").await.unwrap().as_deref(), Some("alice"));
+    // The reloaded htpasswd still logs the user in with the original password.
+    let (_, username) = auth.users.add_or_login("alice", "secret").await.unwrap();
+    assert_eq!(username, "alice");
     assert_eq!(std::fs::read_to_string(&htpasswd).unwrap(), original_htpasswd);
 }
 

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -152,11 +152,14 @@ async fn bearer_token_grants_access_to_protected_package() {
 }
 
 #[tokio::test]
-async fn basic_auth_grants_access_to_protected_package() {
+async fn basic_auth_is_rejected_for_protected_package() {
     let storage = common::build_storage();
     let app = router(static_config(storage.path().to_path_buf()));
     let (app, _) = add_user_and_get_token(app, "alice", "secret").await;
 
+    // pnpr no longer accepts Basic credentials on requests: the header is
+    // ignored (treated as anonymous), so a protected package is rejected.
+    // Clients must authenticate with a bearer token.
     let basic = BASE64.encode(b"alice:secret");
     let response = app
         .oneshot(
@@ -167,7 +170,7 @@ async fn basic_auth_grants_access_to_protected_package() {
         )
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]

--- a/pnpr/crates/pnpr/tests/auth_user_endpoints.rs
+++ b/pnpr/crates/pnpr/tests/auth_user_endpoints.rs
@@ -113,10 +113,6 @@ impl UserBackend for CanonicalUserBackend {
         assert_eq!(username, "alice");
         Ok((UpsertOutcome::LoggedIn, "Alice".to_string()))
     }
-
-    async fn verify(&self, _username: &str, _password: &str) -> pnpr::Result<Option<String>> {
-        Ok(None)
-    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes the pnpr install-latency regression at its root by removing per-request bcrypt.

**Root cause.** pnpm/pnpm#12577 required auth on the resolver endpoint and made clients send credentials on every request. When those credentials are HTTP **Basic** (`_auth`), pnpr's `authenticate` middleware verified them with **bcrypt** — deliberately slow (~50–100ms) — on *every* request. On the pnpr testbed this doubled the `fresh-install.*.hot-store` scenarios (~670ms → ~1500ms at #12577), and it hits any authenticated client in production, not just the benchmark.

**Fix.** Stop accepting Basic credentials on requests. `identify` now honors only `Bearer` tokens, resolved with a fast `SHA-256` hashmap lookup — request handling never runs bcrypt. Password login is unchanged: clients still log in with a password (one bcrypt) to mint a token via `add_or_login`, then authenticate with `_authToken`. This matches npm, which has rejected unscoped `_auth` since npm 9.

This supersedes the earlier "cache Basic verifications" approach in this PR — the integrated benchmark showed the cache only marginally helped (concurrent first-burst requests all bcrypt before it populates). Removing Basic eliminates the cost entirely. It pairs with pnpm/pnpm#12597, which switches the benchmark client to `_authToken` (now required).

Also removes the now-unused `UserBackend::verify` (trait + htpasswd/sqlx/libsql impls) and its tests, and switches the tests that authenticated via Basic to bearer tokens. The one Basic-auth integration test now asserts Basic is rejected. 442 pnpr tests pass across default/libsql/postgres feature sets; clippy, dylint, and `cargo doc --all-features` are clean.

> [!WARNING]
> **Breaking:** pnpr no longer accepts HTTP Basic credentials (`_auth`) on requests. Clients must authenticate with a bearer token (`_authToken`), which a password login mints. This is acceptable while pnpr is pre-production.

## Squash Commit Body

```text
#12577 required auth on the resolver endpoint and made clients send credentials
on every request. When those credentials are Basic (_auth), pnpr's authenticate
middleware verified them with bcrypt (deliberately slow) on every request,
doubling the integrated-benchmark hot-store scenarios on the pnpr testbed
(~670ms to ~1500ms) and adding the same cost to any authenticated client.

Stop accepting Basic credentials on requests: identify now honors only Bearer
tokens, resolved with a fast SHA-256 hashmap lookup, so request handling never
runs bcrypt. Password login is unchanged — clients still log in with a password
(one bcrypt) to mint a token via add_or_login, then authenticate with
_authToken. This matches npm, which rejects unscoped _auth since npm 9.

Remove the now-unused UserBackend::verify and its impls/tests, and switch the
tests that authenticated via Basic to bearer tokens.

BREAKING CHANGE: pnpr no longer accepts HTTP Basic credentials (_auth) on
requests; clients must authenticate with a bearer token (_authToken), which a
password login mints. Acceptable while pnpr is pre-production.
```

## Checklist

- [x] Added or updated tests.
- `pnpr/` (registry proxy) change, outside the TypeScript CLI ↔ Rust `pacquet/` parity surface, so no port is needed.
- No changeset: `pnpr` is not a published TypeScript package.
- No documentation change needed.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * HTTP Basic (username/password) authentication is no longer supported; Basic credentials are ignored and now treated as unauthorized where applicable.
  * Request authentication and identity resolution now use Bearer tokens only.

* **Authentication Updates**
  * Per-request password verification against the user store has been removed.
  * Existing login/token issuance continues via the add-or-login flow, including updated handling for invalid or corrupted credentials.

* **Tests**
  * Updated unit and integration tests to reflect Bearer-only behavior and revised assertions around login and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->