### PR TITLE
chore(integrated-benchmark): authenticate pnpr with a bearer token

### DIFF
--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -33,7 +33,8 @@ const BENCHMARK_DIAGNOSTICS_MD: &str = "BENCHMARK_DIAGNOSTICS.md";
 const PNPR_DIRECT_RATIO_MAX: f64 = 1.05;
 const PNPR_SERVER_REGISTRY_ENV: &str = "PACQUET_BENCHMARK_PNPR_SERVER_REGISTRY";
 const PNPR_TARBALL_REWRITE_FROM_ENV: &str = "PACQUET_BENCHMARK_PNPR_TARBALL_REWRITE_FROM";
-const PNPR_BENCHMARK_AUTH_PAIR_BASE64: &str = "cG5wci1iZW5jaG1hcms6cGFzc3dvcmQxMjM=";
+const PNPR_BENCHMARK_USERNAME: &str = "pnpr-benchmark";
+const PNPR_BENCHMARK_PASSWORD: &str = "password123";
 const PNPR_BENCHMARK_HTPASSWD: &str =
     "pnpr-benchmark:$2y$04$MpoezfOJSlhn9S4iiOJihue1IMZTZfYclKbajdz.Dt2pvAoBLNAay\n";
 
@@ -537,6 +538,13 @@ impl WorkEnv {
         let mut server = PnprServer { process, latency_proxy: None };
 
         wait_for_pnpr_ready(port);
+        // Log in as the seeded benchmark user to mint a bearer token. Real
+        // clients authenticate to a pnpr accelerator with `_authToken`, which
+        // the server resolves with a fast token lookup rather than a bcrypt on
+        // every request (as Basic `_auth` would). Done against the direct port
+        // before the latency proxy is interposed, and once per server, so the
+        // single login bcrypt stays out of the measured install loop.
+        let pnpr_token = mint_pnpr_token(port);
 
         // With `--pnpr-latency-ms`, the client reaches the server through
         // a latency-injecting proxy instead of directly, so the benchmark
@@ -576,7 +584,7 @@ impl WorkEnv {
         // raw upstream tarball URLs even when the server resolves through a
         // latency proxy; the pacquet client rewrites this prefix to its
         // configured registry, which is `client_registry` from `.npmrc`.
-        append_pnpr_auth_to_npmrc(&bench_dir, &client_url);
+        append_pnpr_auth_to_npmrc(&bench_dir, &client_url, &pnpr_token);
         fs::write(
             bench_dir.join(".pnpr-env"),
             format!(
@@ -1374,17 +1382,49 @@ fn seed_pnpr_auth(pnpr_storage: &Path) {
         .expect("seed pnpr benchmark htpasswd");
 }
 
-fn append_pnpr_auth_to_npmrc(dir: &Path, pnpr_server: &str) {
+fn append_pnpr_auth_to_npmrc(dir: &Path, pnpr_server: &str, token: &str) {
     let path = dir.join(".npmrc");
     let mut file =
         OpenOptions::new().append(true).open(&path).expect("open benchmark .npmrc for pnpr auth");
-    writeln!(
-        file,
-        "{}:_auth={}",
-        pnpr_auth_config_key(pnpr_server),
-        PNPR_BENCHMARK_AUTH_PAIR_BASE64,
-    )
-    .expect("append pnpr auth to benchmark .npmrc");
+    writeln!(file, "{}:_authToken={token}", pnpr_auth_config_key(pnpr_server))
+        .expect("append pnpr auth to benchmark .npmrc");
+}
+
+/// Log in as the seeded benchmark user and return a bearer token. The login
+/// runs on a dedicated thread with its own runtime so it doesn't reach into the
+/// harness's ambient `#[tokio::main]` runtime (which would make a blocking
+/// client panic).
+fn mint_pnpr_token(port: u16) -> String {
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Runtime::new().expect("runtime for pnpr token mint");
+        runtime.block_on(async move {
+            let url = format!(
+                "http://127.0.0.1:{port}/-/user/org.couchdb.user:{PNPR_BENCHMARK_USERNAME}",
+            );
+            let body = serde_json::json!({
+                "_id": format!("org.couchdb.user:{PNPR_BENCHMARK_USERNAME}"),
+                "name": PNPR_BENCHMARK_USERNAME,
+                "password": PNPR_BENCHMARK_PASSWORD,
+                "type": "user",
+                "roles": [],
+            });
+            let response = reqwest::Client::new()
+                .put(&url)
+                .json(&body)
+                .send()
+                .await
+                .expect("log in to pnpr to mint a benchmark token");
+            assert!(
+                response.status().is_success(),
+                "pnpr login returned {} when minting a benchmark token",
+                response.status(),
+            );
+            let payload: Value = response.json().await.expect("parse pnpr login response");
+            payload["token"].as_str().expect("token field in pnpr login response").to_string()
+        })
+    })
+    .join()
+    .expect("pnpr token mint thread panicked")
 }
 
 fn pnpr_auth_config_key(pnpr_server: &str) -> String {


### PR DESCRIPTION
## Summary

Makes the integrated benchmark authenticate to the pnpr server the way real clients do — with a bearer token (`_authToken`) — instead of Basic auth (`_auth`).

**Why.** pnpm/pnpm#12577 required auth on the pnpr resolver endpoint and changed the benchmark to seed an htpasswd user and send it as `_auth` on every request. pnpr verifies Basic credentials with **bcrypt**, which is deliberately slow (~50–100ms) and uncached, so every request paid a fresh bcrypt. On the pnpr testbed this **doubled** the `fresh-install.*.hot-store` scenarios (~670ms → ~1500ms at #12577) and inflated the cold-store ones — an artifact of the benchmark using a legacy, slow auth scheme. `_auth`/Basic is legacy (npm rejects unscoped `_auth` since npm 9); real clients authenticate with `_authToken`.

**Change.** At pnpr-server startup, log in once as the seeded user to mint a bearer token, then write it as `_authToken` in the client's `.npmrc`. pnpr resolves Bearer tokens with a `SHA-256` hashmap lookup instead of bcrypt, so the per-request auth cost disappears and the benchmark reflects a realistic, token-authenticated client. The single login bcrypt runs against the direct port before the latency proxy is interposed — once per server, outside the measured install loop.

This recovers the benchmark metric (the main-branch pnpr-testbed numbers should return to ~670ms once merged). It complements pnpm/pnpm#12596, which caches Basic/bcrypt verifications server-side for deployments that still use htpasswd auth.

Validated against a local pnpr server: the login returns a token (HTTP 201), the bearer token authenticates to `/-/pnpr/v0/resolve` (HTTP 200), and anonymous is rejected (HTTP 401).

## Squash Commit Body

```text
#12577 required auth on the pnpr resolver and made the benchmark send a seeded
htpasswd user as Basic `_auth` on every request. pnpr verifies Basic credentials
with bcrypt (deliberately slow, uncached), so every request paid a fresh bcrypt
— doubling the hot-store scenarios on the pnpr testbed and making the benchmark
unrepresentative of how clients authenticate to a pnpr accelerator (`_authToken`
is the norm; `_auth`/Basic is legacy).

Log in as the seeded user once at server startup to mint a bearer token and
write it as `_authToken` in the client's .npmrc. pnpr resolves Bearer tokens
with a SHA-256 hashmap lookup instead of bcrypt, so the per-request auth cost
disappears and the benchmark reflects a realistic, token-authenticated client.
The single login bcrypt runs against the direct port before the latency proxy,
outside the measured install loop.
```

## Checklist

- [x] Added or updated tests. *(benchmark-harness change; the token-mint flow was validated against a running pnpr server — no unit-testable seam, so covered by the integrated benchmark CI run)*
- Benchmark-tooling change under `pacquet/tasks/`; not part of the TypeScript CLI ↔ Rust `pacquet/` parity surface, so no port is needed.
- No changeset: this changes only the integrated-benchmark harness, not a published package.
- No documentation change needed.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated integrated benchmarking server authentication to use dynamic bearer token generation instead of static credentials, enhancing security during benchmark operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->