### PR TITLE
fix(dlx): shorten dlx cache path to avoid Windows MAX_PATH failures

### DIFF
--- a/.changeset/dlx-shorten-cache-path-windows.md
+++ b/.changeset/dlx-shorten-cache-path-windows.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/exec.commands": patch
+"pnpm": patch
+---
+
+Shortened the `pnpm dlx` cache path so deep dependency trees no longer overflow Windows' `MAX_PATH`, which could make a dependency's lifecycle script fail with `spawn cmd.exe ENOENT`.

--- a/pacquet/crates/cli/src/cli_args/dlx.rs
+++ b/pacquet/crates/cli/src/cli_args/dlx.rs
@@ -451,7 +451,28 @@ fn get_valid_cache_dir(
 /// (<https://github.com/pnpm/pnpm/blob/d4a2b0364c/exec/commands/src/dlx.ts#L433-L436>).
 fn get_prepare_dir(cache_path: &Path, now: SystemTime, pid: u32) -> PathBuf {
     let millis = now.duration_since(UNIX_EPOCH).map_or(0, |elapsed| elapsed.as_millis());
-    cache_path.join(format!("{millis:x}-{pid:x}"))
+    // base36 (vs hex) keeps this segment short: it sits between the cache key
+    // and pnpm's deep virtual-store layout, and long dlx paths overflow
+    // Windows' MAX_PATH (260), which makes lifecycle scripts fail with a
+    // `spawn cmd.exe ENOENT` (the cwd no longer resolves). time+pid stays
+    // unique across concurrent dlx processes and a process's own retries.
+    cache_path.join(format!("{}-{}", to_base36(millis), to_base36(u128::from(pid))))
+}
+
+/// Lowercase base36 (`0-9a-z`), matching JavaScript's
+/// `Number.prototype.toString(36)` used by `getPrepareDir`.
+fn to_base36(mut n: u128) -> String {
+    const DIGITS: &[u8; 36] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+    if n == 0 {
+        return "0".to_string();
+    }
+    let mut buf = Vec::new();
+    while n > 0 {
+        buf.push(DIGITS[(n % 36) as usize]);
+        n /= 36;
+    }
+    buf.reverse();
+    String::from_utf8(buf).expect("base36 digits are ASCII")
 }
 
 /// Determine the bin to run from the first installed dependency. Ports

--- a/pacquet/crates/cli/src/cli_args/dlx/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/dlx/tests.rs
@@ -124,11 +124,12 @@ fn create_cache_key_changes_with_supported_architectures() {
 }
 
 #[test]
-fn get_prepare_dir_encodes_time_and_pid_in_hex() {
+fn get_prepare_dir_encodes_time_and_pid_in_base36() {
     let base = std::path::Path::new("/cache/dlx/key");
-    let now = SystemTime::UNIX_EPOCH + Duration::from_millis(0x1a2b);
-    let dir = get_prepare_dir(base, now, 0xff);
-    assert_eq!(dir, base.join("1a2b-ff"));
+    // 6699 = 5*36^2 + 6*36 + 3 -> "563"; 255 = 7*36 + 3 -> "73".
+    let now = SystemTime::UNIX_EPOCH + Duration::from_millis(6699);
+    let dir = get_prepare_dir(base, now, 255);
+    assert_eq!(dir, base.join("563-73"));
 }
 
 #[test]

--- a/pnpm11/exec/commands/src/dlx.ts
+++ b/pnpm11/exec/commands/src/dlx.ts
@@ -13,7 +13,7 @@ import { OUTPUT_OPTIONS } from '@pnpm/cli.common-cli-options-help'
 import { docsUrl, readProjectManifestOnly } from '@pnpm/cli.utils'
 import { type Config, types } from '@pnpm/config.reader'
 import { getPublishedByPolicy } from '@pnpm/config.version-policy'
-import { createHexHash } from '@pnpm/crypto.hash'
+import { createShortHash } from '@pnpm/crypto.hash'
 import { PnpmError } from '@pnpm/error'
 import { createResolver, makeResolutionStrict } from '@pnpm/installing.client'
 import { add } from '@pnpm/installing.commands'
@@ -421,7 +421,12 @@ export function createCacheKey (opts: {
     }
   }
   const hashStr = JSON.stringify(args)
-  return createHexHash(hashStr)
+  // A short (truncated) hash keeps the dlx cache path short. The full
+  // virtual-store path below it (`<key>/<prepare>/node_modules/.pnpm/<pkgId>/
+  // node_modules/<pkg>`) can otherwise blow past Windows' MAX_PATH (260) and
+  // make lifecycle scripts fail with a `spawn cmd.exe ENOENT` (the cwd no
+  // longer resolves). 128 bits is ample collision resistance for a cache key.
+  return createShortHash(hashStr)
 }
 
 function getValidCacheDir (cacheLink: string, dlxCacheMaxAge: number): string | undefined {
@@ -446,7 +451,10 @@ function getValidCacheDir (cacheLink: string, dlxCacheMaxAge: number): string | 
 }
 
 function getPrepareDir (cachePath: string): string {
-  const name = `${new Date().getTime().toString(16)}-${process.pid.toString(16)}`
+  // base36 (vs hex) keeps this segment short — see createCacheKey for why dlx
+  // path length matters on Windows. time+pid stays unique across concurrent
+  // dlx processes and across a process's own retries of a failed install.
+  const name = `${Date.now().toString(36)}-${process.pid.toString(36)}`
   return path.join(cachePath, name)
 }
 

--- a/pnpm11/exec/commands/test/dlx.createCacheKey.test.ts
+++ b/pnpm11/exec/commands/test/dlx.createCacheKey.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { createHexHash } from '@pnpm/crypto.hash'
+import { createShortHash } from '@pnpm/crypto.hash'
 
 import { createCacheKey } from '../src/dlx.js'
 
@@ -11,7 +11,7 @@ test('creates a hash', () => {
       '@foo': 'https://example.com/npm-registry/foo/',
     },
   })
-  const expected = createHexHash(JSON.stringify([['@foo/bar', 'shx'], [
+  const expected = createShortHash(JSON.stringify([['@foo/bar', 'shx'], [
     ['@foo', 'https://example.com/npm-registry/foo/'],
     ['default', 'https://registry.npmjs.com/'],
   ]]))

--- a/pnpm11/exec/commands/test/dlx.e2e.ts
+++ b/pnpm11/exec/commands/test/dlx.e2e.ts
@@ -43,8 +43,9 @@ function sanitizeDlxCacheComponent (cacheName: string): string {
     throw new Error(`Unexpected name: ${cacheName}`)
   }
   const [date, pid] = segments
-  if (!/[0-9a-f]+/.test(date) && !/[0-9a-f]+/.test(pid)) {
-    throw new Error(`Name ${cacheName} doesn't end with 2 hex numbers`)
+  // getPrepareDir encodes time and pid in base36 (0-9a-z).
+  if (!/^[0-9a-z]+$/.test(date) || !/^[0-9a-z]+$/.test(pid)) {
+    throw new Error(`Name ${cacheName} is not a base36 "<time>-<pid>" prepare dir`)
   }
   return '***********-*****'
 }


### PR DESCRIPTION
## Summary

Follow-up to the dlx cleanup fix (pnpm/pnpm#12575). With the error-masking gone, the Windows CI flake on `dlx prompts to approve ignored builds when invoked with a commands map` now shows its true cause:

```
@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0 preinstall: `hello-world-js-bin && node create generated-by-preinstall`
spawn C:\Windows\system32\cmd.exe ENOENT
```

`spawn <full-path-to-cmd.exe> ENOENT` — where `cmd.exe` clearly exists — is the classic Windows signature of the child's **cwd not resolving**. The lifecycle script runs with `cwd = <pkgRoot>`, and for that transitive dep the directory is **259 chars**, right at Windows' `MAX_PATH` (260):

```
…\cache\dlx\<64-hex key>\<time-pid prepare>\node_modules\.pnpm\@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\node_modules\@pnpm.e2e\pre-and-postinstall-scripts-example
```

`CreateProcess` can't resolve an over-length `lpCurrentDirectory`, and Node surfaces it as the misleading `spawn cmd.exe ENOENT`. It's flaky rather than constant because the `<prepare>` segment (`<time>-<pid>` in hex) and the temp-dir segment vary in length run to run, straddling 260. It only hits this test because most deps have their builds skipped (no script spawned in the deep dir); this is the one that triggers the approve-builds rebuild.

The two dlx-specific path segments are pure overhead on top of pnpm's already-deep virtual store, so this shortens both:

- **cache key** — `createHexHash` (64 hex chars) → `createShortHash` (32 chars / 128 bits, ample for a cache key). pacquet already truncated to 32 via `create_short_hash`, so this also restores parity between the two stacks.
- **prepare dir** — encode `time`/`pid` in base36 instead of hex.

This takes the measured directory from 259 → ~225 chars, comfortably under `MAX_PATH` for realistic package names — not just the test.

## Squash Commit Body

```text
The dlx cache path is <cacheDir>/dlx/<key>/<prepare>/node_modules/.pnpm/
<pkgId>/node_modules/<pkg>. The <key> (64-char sha256 hex) and <prepare>
(<time>-<pid> in hex) segments are dlx overhead on top of pnpm's already-
deep virtual-store layout. For a transitive dep with a long name this tips
the package directory over Windows' MAX_PATH (260) — measured at 259 chars
for @pnpm.e2e/pre-and-postinstall-scripts-example in the dlx e2e test. A
lifecycle script then runs with that directory as its cwd, and CreateProcess
fails to resolve an over-length cwd, which Node surfaces as the confusing
"spawn C:\Windows\system32\cmd.exe ENOENT". Flaky rather than constant
because the <prepare> and temp-dir segments vary in length, straddling 260.

Shorten both dlx-specific segments:
- cache key: createShortHash (32 hex, 128 bits) instead of createHexHash
  (64). pacquet already truncated to 32, so this also restores parity.
- prepare dir: encode time and pid in base36 instead of hex.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  <!-- pacquet: cache key already 32 chars (no change); prepare dir switched to base36 (get_prepare_dir + to_base36 helper + test). -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
  <!-- Updated dlx.createCacheKey.test.ts (pnpm) and get_prepare_dir test (pacquet). -->
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed `pnpm dlx` on Windows failing due to overly long cache/lifecycle working paths hitting `MAX_PATH`, causing errors like failed `cmd.exe` spawns.
* Updated `dlx` cache key and temporary prepare-directory naming to use a shorter base36 encoding, reducing path length while keeping uniqueness to avoid collisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->