### PR TITLE
feat(pacquet): add patch workflow commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3601,6 +3601,7 @@ dependencies = [
  "pacquet-package-is-installable",
  "pacquet-package-manager",
  "pacquet-package-manifest",
+ "pacquet-patching",
  "pacquet-pnpr-client",
  "pacquet-registry",
  "pacquet-reporter",

--- a/pacquet/crates/cli/Cargo.toml
+++ b/pacquet/crates/cli/Cargo.toml
@@ -31,6 +31,7 @@ pacquet-config                            = { workspace = true }
 pacquet-default-reporter                  = { workspace = true }
 pacquet-package-manifest                  = { workspace = true }
 pacquet-package-manager                   = { workspace = true }
+pacquet-patching                          = { workspace = true }
 pacquet-package-is-installable            = { workspace = true }
 pacquet-registry                          = { workspace = true }
 pacquet-reporter                          = { workspace = true }

--- a/pacquet/crates/cli/Cargo.toml
+++ b/pacquet/crates/cli/Cargo.toml
@@ -62,6 +62,7 @@ rmp-serde            = { workspace = true }
 serde                = { workspace = true }
 serde_json           = { workspace = true }
 tabled               = { workspace = true }
+tempfile             = { workspace = true }
 tokio                = { workspace = true }
 which                = { workspace = true }
 base64               = { workspace = true }
@@ -85,7 +86,6 @@ mockito           = { workspace = true }
 pretty_assertions = { workspace = true }
 serde-saphyr      = { workspace = true }
 tar               = { workspace = true }
-tempfile          = { workspace = true }
 walkdir           = { workspace = true }
 
 [lints]

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -10,6 +10,10 @@ pub mod find_hash;
 pub mod ignored_builds;
 pub mod install;
 pub mod outdated;
+pub mod patch;
+pub mod patch_commit;
+pub mod patch_remove;
+pub(crate) mod patch_state;
 pub mod rebuild;
 pub mod recursive;
 pub mod remove;
@@ -46,6 +50,9 @@ use pacquet_package_manifest::PackageManifest;
 use pacquet_reporter::{
     ExecutionTimeLog, LogEvent, LogLevel, NdjsonReporter, Reporter, SilentReporter,
 };
+use patch::PatchArgs;
+use patch_commit::PatchCommitArgs;
+use patch_remove::PatchRemoveArgs;
 use rebuild::RebuildArgs;
 use remove::RemoveArgs;
 use restart::RestartArgs;
@@ -54,8 +61,10 @@ use runtime::RuntimeArgs;
 use serde_json::Value;
 use std::{
     fs,
+    future::Future,
     io::ErrorKind,
     path::{Path, PathBuf},
+    pin::Pin,
 };
 use stop::StopArgs;
 use store::StoreCommand;
@@ -136,6 +145,8 @@ pub enum ReporterType {
     Silent,
 }
 
+type CommandFuture<'a> = Pin<Box<dyn Future<Output = miette::Result<()>> + Send + 'a>>;
+
 #[derive(Debug, Subcommand)]
 pub enum CliCommand {
     /// Initialize a package.json
@@ -159,6 +170,14 @@ pub enum CliCommand {
     // confusion with "run" and "recursive". Mirrors pnpm's `commandNames`.
     #[clap(visible_aliases = ["uninstall", "rm", "un", "uni"])]
     Remove(RemoveArgs),
+    /// Prepare a package for patching.
+    Patch(PatchArgs),
+    /// Generate a patch out of a directory.
+    #[clap(name = "patch-commit")]
+    PatchCommit(PatchCommitArgs),
+    /// Remove existing patch files.
+    #[clap(name = "patch-remove")]
+    PatchRemove(PatchRemoveArgs),
     /// Runs a package's "test" script, if one was provided.
     Test,
     /// Runs a defined package script.
@@ -280,9 +299,11 @@ impl CliArgs {
                 // `rebuild` drives the frozen-install pipeline and emits
                 // the same progress events, so it shares the `Done in ...`
                 // footer.
-                | CliCommand::Rebuild(_),
+                | CliCommand::Rebuild(_)
+                | CliCommand::PatchCommit(_)
+                | CliCommand::PatchRemove(_),
         );
-        let manifest_path = || dir.join("package.json");
+        let manifest_path = dir.join("package.json");
         // Resolve `.npmrc` / `pnpm-workspace.yaml` from the canonicalized
         // `--dir` rather than the process cwd, matching pnpm 11 (which
         // builds its `localPrefix` from `cliOptions.dir`, not `cwd`) —
@@ -324,49 +345,142 @@ impl CliArgs {
         // must not be silently dropped because `lockfile=false` was set
         // (or defaulted) in config.
         let state = |require_lockfile: bool| -> miette::Result<State> {
-            State::init(manifest_path(), config()?, require_lockfile)
+            State::init(manifest_path.clone(), config()?, require_lockfile)
                 .wrap_err("initialize the state")
         };
 
-        match command {
+        let dir_ref = &dir;
+        let manifest_path_ref = &manifest_path;
+        let command_future: CommandFuture<'_> = match command {
             CliCommand::Init => {
-                PackageManifest::init(&manifest_path()).wrap_err("initialize package.json")?;
+                let result =
+                    PackageManifest::init(manifest_path_ref).wrap_err("initialize package.json");
+                Box::pin(std::future::ready(result))
             }
-            CliCommand::Add(args) => match reporter {
-                ReporterType::Default | ReporterType::AppendOnly => {
-                    Box::pin(args.run::<DefaultReporter>(state(false)?)).await?;
+            CliCommand::Add(args) => {
+                let command_state = state(false)?;
+                match reporter {
+                    ReporterType::Default | ReporterType::AppendOnly => {
+                        Box::pin(args.run::<DefaultReporter>(command_state))
+                    }
+                    ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(command_state)),
+                    ReporterType::Silent => Box::pin(args.run::<SilentReporter>(command_state)),
                 }
-                ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(state(false)?)).await?,
-                ReporterType::Silent => Box::pin(args.run::<SilentReporter>(state(false)?)).await?,
-            },
-            CliCommand::Update(args) => match reporter {
-                ReporterType::Default | ReporterType::AppendOnly => {
-                    Box::pin(args.run::<DefaultReporter>(state(false)?)).await?;
+            }
+            CliCommand::Update(args) => {
+                let command_state = state(false)?;
+                match reporter {
+                    ReporterType::Default | ReporterType::AppendOnly => {
+                        Box::pin(args.run::<DefaultReporter>(command_state))
+                    }
+                    ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(command_state)),
+                    ReporterType::Silent => Box::pin(args.run::<SilentReporter>(command_state)),
                 }
-                ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(state(false)?)).await?,
-                ReporterType::Silent => Box::pin(args.run::<SilentReporter>(state(false)?)).await?,
-            },
+            }
             // `outdated` is a read-only query: it prints a report to
             // stdout and never installs, so it has no reporter-typed
             // install pipeline to dispatch on. It reports back whether any
             // dependency was outdated; process termination stays here, at
             // the top-level harness, rather than inside the command.
             CliCommand::Outdated(args) => {
-                if args.run(state(false)?).await? == OutdatedOutcome::Outdated {
-                    std::process::exit(1);
+                let command_state = state(false)?;
+                Box::pin(async move {
+                    if args.run(command_state).await? == OutdatedOutcome::Outdated {
+                        std::process::exit(1);
+                    }
+                    Ok(())
+                })
+            }
+            CliCommand::Why(args) => Box::pin(args.run(state(true)?)),
+            CliCommand::Remove(args) => {
+                let command_state = state(false)?;
+                match reporter {
+                    ReporterType::Default | ReporterType::AppendOnly => {
+                        Box::pin(args.run::<DefaultReporter>(command_state))
+                    }
+                    ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(command_state)),
+                    ReporterType::Silent => Box::pin(args.run::<SilentReporter>(command_state)),
                 }
             }
-            CliCommand::Why(args) => {
-                args.run(state(true)?).await?;
-            }
-            CliCommand::Remove(args) => match reporter {
-                ReporterType::Default | ReporterType::AppendOnly => {
-                    Box::pin(args.run::<DefaultReporter>(state(false)?)).await?;
+            CliCommand::Patch(args) => {
+                let command_state = state(false)?;
+                match reporter {
+                    ReporterType::Default | ReporterType::AppendOnly => Box::pin(async move {
+                        args.run::<DefaultReporter>(dir_ref, command_state).await?;
+                        Ok(())
+                    }),
+                    ReporterType::Ndjson => Box::pin(async move {
+                        args.run::<NdjsonReporter>(dir_ref, command_state).await?;
+                        Ok(())
+                    }),
+                    ReporterType::Silent => Box::pin(async move {
+                        args.run::<SilentReporter>(dir_ref, command_state).await?;
+                        Ok(())
+                    }),
                 }
-                ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(state(false)?)).await?,
-                ReporterType::Silent => Box::pin(args.run::<SilentReporter>(state(false)?)).await?,
+            }
+            CliCommand::PatchCommit(args) => match reporter {
+                ReporterType::Default | ReporterType::AppendOnly => Box::pin(async move {
+                    if Box::pin(args.run::<DefaultReporter>(dir_ref, state(false)?)).await? {
+                        Box::pin(
+                            InstallArgs::for_patch_manifest_change()
+                                .run::<DefaultReporter>(state(false)?),
+                        )
+                        .await?;
+                    }
+                    Ok(())
+                }),
+                ReporterType::Ndjson => Box::pin(async move {
+                    if Box::pin(args.run::<NdjsonReporter>(dir_ref, state(false)?)).await? {
+                        Box::pin(
+                            InstallArgs::for_patch_manifest_change()
+                                .run::<NdjsonReporter>(state(false)?),
+                        )
+                        .await?;
+                    }
+                    Ok(())
+                }),
+                ReporterType::Silent => Box::pin(async move {
+                    if Box::pin(args.run::<SilentReporter>(dir_ref, state(false)?)).await? {
+                        Box::pin(
+                            InstallArgs::for_patch_manifest_change()
+                                .run::<SilentReporter>(state(false)?),
+                        )
+                        .await?;
+                    }
+                    Ok(())
+                }),
             },
-            CliCommand::Install(args) => {
+            CliCommand::PatchRemove(args) => match reporter {
+                ReporterType::Default | ReporterType::AppendOnly => Box::pin(async move {
+                    Box::pin(args.run(dir_ref, state(false)?)).await?;
+                    Box::pin(
+                        InstallArgs::for_patch_manifest_change()
+                            .run::<DefaultReporter>(state(false)?),
+                    )
+                    .await?;
+                    Ok(())
+                }),
+                ReporterType::Ndjson => Box::pin(async move {
+                    Box::pin(args.run(dir_ref, state(false)?)).await?;
+                    Box::pin(
+                        InstallArgs::for_patch_manifest_change()
+                            .run::<NdjsonReporter>(state(false)?),
+                    )
+                    .await?;
+                    Ok(())
+                }),
+                ReporterType::Silent => Box::pin(async move {
+                    Box::pin(args.run(dir_ref, state(false)?)).await?;
+                    Box::pin(
+                        InstallArgs::for_patch_manifest_change()
+                            .run::<SilentReporter>(state(false)?),
+                    )
+                    .await?;
+                    Ok(())
+                }),
+            },
+            CliCommand::Install(args) => Box::pin(async move {
                 // CLI overrides for `offline` / `prefer_offline` live
                 // alongside `--frozen-lockfile`: they upgrade an
                 // unset / `false` yaml value to `true`, but cannot
@@ -410,7 +524,7 @@ impl CliArgs {
                 // `pnpm-workspace.yaml` is found), falling back to `--dir`
                 // for a single-package repo. Owned so it doesn't hold a
                 // borrow of `cfg` across the `&mut` `updateConfig` pass.
-                let config_root = cfg.workspace_dir.clone().unwrap_or_else(|| dir.clone());
+                let config_root = cfg.workspace_dir.clone().unwrap_or_else(|| dir_ref.clone());
                 let package_manager_to_sync =
                     package_manager_to_sync(&config_root.join("package.json"), &config_root)
                         .wrap_err("read package manager policy")?;
@@ -426,7 +540,7 @@ impl CliArgs {
                     cfg,
                     config_root,
                     package_manager_to_sync,
-                    manifest_path: manifest_path(),
+                    manifest_path: manifest_path_ref.clone(),
                     require_lockfile,
                     frozen_lockfile,
                 };
@@ -440,132 +554,130 @@ impl CliArgs {
                     ReporterType::Ndjson => Box::pin(pipeline.run::<NdjsonReporter>()).await?,
                     ReporterType::Silent => Box::pin(pipeline.run::<SilentReporter>()).await?,
                 }
-            }
+                Ok(())
+            }),
             CliCommand::Test => {
-                let manifest = PackageManifest::from_path(manifest_path())
+                let manifest = PackageManifest::from_path(manifest_path_ref.clone())
                     .wrap_err("getting the package.json in current directory")?;
                 if let Some(script) = manifest.script("test", false)? {
                     execute_shell(script).wrap_err(format!("executing command: \"{script}\""))?;
                 }
+                Box::pin(std::future::ready(Ok(())))
             }
             CliCommand::Run(args) => {
                 if recursive {
-                    args.run_recursive(config()?, &dir)?;
+                    args.run_recursive(config()?, dir_ref)?;
                 } else {
-                    args.run(&dir, config()?, matches!(reporter, ReporterType::Silent))?;
+                    args.run(dir_ref, config()?, matches!(reporter, ReporterType::Silent))?;
                 }
+                Box::pin(std::future::ready(Ok(())))
             }
             CliCommand::Exec(args) => {
                 if recursive {
-                    args.run_recursive(config()?, &dir)?;
+                    args.run_recursive(config()?, dir_ref)?;
                 } else {
-                    args.run(&dir, config()?)?;
+                    args.run(dir_ref, config()?)?;
                 }
+                Box::pin(std::future::ready(Ok(())))
             }
             CliCommand::Dlx(args) => match reporter {
                 ReporterType::Default | ReporterType::AppendOnly => {
-                    Box::pin(args.run::<DefaultReporter>(&dir, config()?)).await?;
+                    Box::pin(args.run::<DefaultReporter>(dir_ref, config()?))
                 }
-                ReporterType::Ndjson => {
-                    Box::pin(args.run::<NdjsonReporter>(&dir, config()?)).await?;
-                }
-                ReporterType::Silent => {
-                    Box::pin(args.run::<SilentReporter>(&dir, config()?)).await?;
-                }
+                ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(dir_ref, config()?)),
+                ReporterType::Silent => Box::pin(args.run::<SilentReporter>(dir_ref, config()?)),
             },
             CliCommand::Create(args) => match reporter {
                 ReporterType::Default | ReporterType::AppendOnly => {
-                    Box::pin(args.run::<DefaultReporter>(&dir, config()?)).await?;
+                    Box::pin(args.run::<DefaultReporter>(dir_ref, config()?))
                 }
-                ReporterType::Ndjson => {
-                    Box::pin(args.run::<NdjsonReporter>(&dir, config()?)).await?;
-                }
-                ReporterType::Silent => {
-                    Box::pin(args.run::<SilentReporter>(&dir, config()?)).await?;
-                }
+                ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(dir_ref, config()?)),
+                ReporterType::Silent => Box::pin(args.run::<SilentReporter>(dir_ref, config()?)),
             },
             CliCommand::Start => {
-                let manifest = PackageManifest::from_path(manifest_path())
+                let manifest = PackageManifest::from_path(manifest_path_ref.clone())
                     .wrap_err("getting the package.json in current directory")?;
                 let command = manifest.script("start", true)?.unwrap_or("node server.js");
                 execute_shell(command).wrap_err(format!("executing command: \"{command}\""))?;
+                Box::pin(std::future::ready(Ok(())))
             }
             CliCommand::Stop(args) => {
-                args.run(&dir, config()?, matches!(reporter, ReporterType::Silent))?;
+                args.run(dir_ref, config()?, matches!(reporter, ReporterType::Silent))?;
+                Box::pin(std::future::ready(Ok(())))
             }
             CliCommand::Restart(args) => {
-                args.run(&dir, config()?, matches!(reporter, ReporterType::Silent))?;
+                args.run(dir_ref, config()?, matches!(reporter, ReporterType::Silent))?;
+                Box::pin(std::future::ready(Ok(())))
             }
             CliCommand::FindHash(args) => {
                 args.run(|| config().map(|m| &*m))?;
+                Box::pin(std::future::ready(Ok(())))
             }
             CliCommand::Runtime(args) => {
                 args.reject_unsupported_global()?;
+                let command_state = state(false)?;
                 match reporter {
                     ReporterType::Default | ReporterType::AppendOnly => {
-                        Box::pin(args.run::<DefaultReporter>(state(false)?)).await?;
+                        Box::pin(args.run::<DefaultReporter>(command_state))
                     }
-                    ReporterType::Ndjson => {
-                        Box::pin(args.run::<NdjsonReporter>(state(false)?)).await?;
-                    }
-                    ReporterType::Silent => {
-                        Box::pin(args.run::<SilentReporter>(state(false)?)).await?;
-                    }
+                    ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(command_state)),
+                    ReporterType::Silent => Box::pin(args.run::<SilentReporter>(command_state)),
                 }
             }
-            CliCommand::Store(command) => command.run(|| config().map(|m| &*m))?,
-            CliCommand::Cache(command) => command.run(config()?)?,
+            CliCommand::Store(command) => {
+                command.run(|| config().map(|m| &*m))?;
+                Box::pin(std::future::ready(Ok(())))
+            }
+            CliCommand::Cache(command) => {
+                command.run(config()?)?;
+                Box::pin(std::future::ready(Ok(())))
+            }
             CliCommand::CatFile(args) => {
                 args.run(|| config().map(|m| &*m))?;
+                Box::pin(std::future::ready(Ok(())))
             }
-            CliCommand::CatIndex(args) => {
-                args.run(&dir, || config().map(|m| &*m)).await?;
-            }
+            CliCommand::CatIndex(args) => Box::pin(async move {
+                args.run(dir_ref, || config().map(|m| &*m)).await?;
+                Ok(())
+            }),
             CliCommand::IgnoredBuilds(_) => {
                 let output = ignored_builds::render_ignored_builds(config()?)?;
                 print!("{output}");
+                Box::pin(std::future::ready(Ok(())))
             }
             CliCommand::Rebuild(args) => match reporter {
                 ReporterType::Default | ReporterType::AppendOnly => {
-                    Box::pin(args.run::<DefaultReporter>(state(true)?)).await?;
+                    Box::pin(args.run::<DefaultReporter>(state(true)?))
                 }
-                ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(state(true)?)).await?,
-                ReporterType::Silent => Box::pin(args.run::<SilentReporter>(state(true)?)).await?,
+                ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(state(true)?)),
+                ReporterType::Silent => Box::pin(args.run::<SilentReporter>(state(true)?)),
             },
             CliCommand::ApproveBuilds(args) => {
                 // The settings/prompt work is synchronous; only the rebuild
                 // is async, so the non-`Send` `config` / `state` closures
                 // stay out of the awaited future.
                 if let Some((rebuild_state, build_packages)) =
-                    args.prepare(&dir, &config, &state)?
+                    args.prepare(dir_ref, &config, &state)?
                 {
                     let selected = Some(build_packages);
                     match reporter {
-                        ReporterType::Default | ReporterType::AppendOnly => {
-                            Box::pin(rebuild::run_rebuild::<DefaultReporter>(
-                                &rebuild_state,
-                                selected,
-                            ))
-                            .await?;
-                        }
-                        ReporterType::Ndjson => {
-                            Box::pin(rebuild::run_rebuild::<NdjsonReporter>(
-                                &rebuild_state,
-                                selected,
-                            ))
-                            .await?;
-                        }
-                        ReporterType::Silent => {
-                            Box::pin(rebuild::run_rebuild::<SilentReporter>(
-                                &rebuild_state,
-                                selected,
-                            ))
-                            .await?;
-                        }
+                        ReporterType::Default | ReporterType::AppendOnly => Box::pin(async move {
+                            rebuild::run_rebuild::<DefaultReporter>(&rebuild_state, selected).await
+                        }),
+                        ReporterType::Ndjson => Box::pin(async move {
+                            rebuild::run_rebuild::<NdjsonReporter>(&rebuild_state, selected).await
+                        }),
+                        ReporterType::Silent => Box::pin(async move {
+                            rebuild::run_rebuild::<SilentReporter>(&rebuild_state, selected).await
+                        }),
                     }
+                } else {
+                    Box::pin(std::future::ready(Ok(())))
                 }
             }
-        }
+        };
+
+        command_future.await?;
 
         // The `Done in ...` footer covers the whole command, mirroring pnpm's
         // `pnpm:execution-time` emit in `main.ts`. Only the install-family

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -274,6 +274,36 @@ pub struct InstallArgs {
 }
 
 impl InstallArgs {
+    pub(crate) fn for_patch_manifest_change() -> Self {
+        Self {
+            dependency_options: InstallDependencyOptions {
+                prod: false,
+                dev: false,
+                no_optional: false,
+            },
+            supported_architectures: SupportedArchitecturesArgs::default(),
+            frozen_lockfile: false,
+            lockfile_only: false,
+            dry_run: false,
+            prefer_frozen_lockfile: false,
+            no_prefer_frozen_lockfile: true,
+            ignore_manifest_check: false,
+            no_runtime: false,
+            ignore_scripts: false,
+            node_linker: None,
+            offline: false,
+            frozen_store: false,
+            prefer_offline: false,
+            trust_lockfile: false,
+            update_checksums: false,
+            workspace_concurrency: None,
+            network_concurrency: None,
+            fetch_timeout: None,
+            user_agent: None,
+            pnpr_server: None,
+        }
+    }
+
     /// Run the repeat-install fast path before any of the async install
     /// machinery exists: when every gate below holds and
     /// [`install_already_up_to_date`] confirms nothing changed since the

--- a/pacquet/crates/cli/src/cli_args/patch.rs
+++ b/pacquet/crates/cli/src/cli_args/patch.rs
@@ -176,7 +176,11 @@ impl PatchArgs {
         write_edit_dir_state(
             &state.config.modules_dir,
             &edit_dir,
-            &EditDirState { patched_pkg: package_name.clone(), apply_to_all: target.apply_to_all },
+            &EditDirState {
+                patched_pkg: package_name.clone(),
+                apply_to_all: target.apply_to_all,
+                package_key: Some(target.package_key.clone()),
+            },
         )
         .map_err(PatchError::StateFile)?;
 

--- a/pacquet/crates/cli/src/cli_args/patch.rs
+++ b/pacquet/crates/cli/src/cli_args/patch.rs
@@ -7,6 +7,7 @@ use derive_more::{Display, Error};
 use dialoguer::{Confirm, Select};
 use miette::{Diagnostic, IntoDiagnostic, miette};
 use owo_colors::OwoColorize;
+use pacquet_fs::{is_subdir, lexical_normalize};
 use pacquet_lockfile::{LoadLockfileError, Lockfile};
 use pacquet_package_manager::{
     PatchCandidate, PatchCandidateSet, PatchTarget, PatchTargetError, WritePackageForPatch,
@@ -17,7 +18,7 @@ use pacquet_reporter::Reporter;
 use std::{
     fs,
     io::{self, IsTerminal},
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 
 #[derive(Debug, Args)]
@@ -81,6 +82,26 @@ pub enum PatchError {
     #[display("Unable to find patch file {}", patch_file_path.display())]
     #[diagnostic(code(ERR_PNPM_PATCH_FILE_NOT_FOUND))]
     PatchFileNotFound { patch_file_path: PathBuf },
+
+    #[display("The configured patches directory is outside the project: {patches_dir}")]
+    #[diagnostic(code(ERR_PNPM_PATCHES_DIR_OUTSIDE_PROJECT))]
+    PatchesDirOutsideProject { patches_dir: String },
+
+    #[display("Patch file \"{patch_file}\" is outside the configured patches directory")]
+    #[diagnostic(code(ERR_PNPM_PATCH_FILE_OUTSIDE_PATCHES_DIR))]
+    PatchFileOutsidePatchesDir { patch_file: String },
+
+    #[display("Patch file \"{patch_file}\" is a directory")]
+    #[diagnostic(code(ERR_PNPM_PATCH_FILE_IS_DIRECTORY))]
+    PatchFileIsDirectory { patch_file: String },
+
+    #[display("Failed to read patch file metadata for {}: {source}", path.display())]
+    #[diagnostic(code(pacquet::patch_read_patch_file_metadata))]
+    ReadPatchFileMetadata {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
 }
 
 impl PatchArgs {
@@ -90,10 +111,10 @@ impl PatchArgs {
         state: State,
     ) -> Result<(), PatchError> {
         let PatchArgs { package_name, edit_dir, ignore_existing } = self;
+        let package_name = package_name.ok_or(PatchError::MissingPackageName)?;
         if let Some(edit_dir) = edit_dir.as_ref().map(|path| resolve_path(dir, path)) {
             reject_non_empty_custom_edit_dir(&edit_dir)?;
         }
-        let package_name = package_name.ok_or(PatchError::MissingPackageName)?;
         let current_lockfile =
             Lockfile::load_current_from_virtual_store_dir(&state.config.virtual_store_dir)
                 .map_err(PatchError::LoadLockfile)?
@@ -284,12 +305,107 @@ fn apply_existing_patch_file(
         .workspace_dir
         .as_deref()
         .unwrap_or_else(|| config.modules_dir.parent().unwrap_or_else(|| Path::new(".")));
-    let patch_file_path = resolve_path(base_dir, Path::new(patch_file));
+    let patch_file_path = checked_existing_patch_file_path(
+        base_dir,
+        config.patches_dir.as_deref().unwrap_or("patches"),
+        patch_file,
+    )?;
     if !patch_file_path.exists() {
         return Err(PatchError::PatchFileNotFound { patch_file_path });
     }
     pacquet_patching::apply_patch_to_dir(edit_dir, &patch_file_path)
         .map_err(PatchError::ApplyExistingPatch)
+}
+
+struct ExistingPatchFileContext {
+    project_root: PathBuf,
+    patches_dir: PathBuf,
+    real_patches_dir: Option<PathBuf>,
+}
+
+impl ExistingPatchFileContext {
+    fn new(lockfile_dir: &Path, patches_dir_setting: &str) -> Result<Self, PatchError> {
+        let project_root = lexical_normalize(lockfile_dir);
+        let real_project_root =
+            dunce::canonicalize(&project_root).unwrap_or_else(|_| project_root.clone());
+        let patches_dir = join_setting_path(&project_root, patches_dir_setting);
+        if !is_subdir(&project_root, &patches_dir) {
+            return Err(PatchError::PatchesDirOutsideProject {
+                patches_dir: patches_dir_setting.to_string(),
+            });
+        }
+        let real_patches_dir = realpath_if_exists(&patches_dir);
+        if real_patches_dir.as_ref().is_some_and(|real| !is_subdir(&real_project_root, real)) {
+            return Err(PatchError::PatchesDirOutsideProject {
+                patches_dir: patches_dir_setting.to_string(),
+            });
+        }
+        Ok(Self { project_root, patches_dir, real_patches_dir })
+    }
+}
+
+fn checked_existing_patch_file_path(
+    lockfile_dir: &Path,
+    patches_dir_setting: &str,
+    patch_file: &str,
+) -> Result<PathBuf, PatchError> {
+    let ctx = ExistingPatchFileContext::new(lockfile_dir, patches_dir_setting)?;
+    let target_path = resolve_patch_path(&ctx.project_root, Path::new(patch_file));
+    if target_path == ctx.patches_dir || !is_subdir(&ctx.patches_dir, &target_path) {
+        return Err(PatchError::PatchFileOutsidePatchesDir { patch_file: patch_file.to_string() });
+    }
+
+    let parent_dir = target_path.parent().map_or_else(PathBuf::new, Path::to_path_buf);
+    let target_stats = lstat_patch_if_exists(&target_path)?;
+    let real_parent_dir = realpath_if_exists(&parent_dir);
+    let real_patches_dir = ctx.real_patches_dir.or_else(|| realpath_if_exists(&ctx.patches_dir));
+    if let (Some(real_parent_dir), Some(real_patches_dir)) = (&real_parent_dir, &real_patches_dir)
+        && !is_subdir(real_patches_dir, real_parent_dir)
+    {
+        return Err(PatchError::PatchFileOutsidePatchesDir { patch_file: patch_file.to_string() });
+    }
+    if target_stats.as_ref().is_some_and(fs::Metadata::is_dir) {
+        return Err(PatchError::PatchFileIsDirectory { patch_file: patch_file.to_string() });
+    }
+    if target_stats.as_ref().is_some_and(|stats| stats.file_type().is_symlink())
+        && real_patches_dir.as_ref().is_some_and(|real_patches_dir| {
+            dunce::canonicalize(&target_path)
+                .ok()
+                .is_none_or(|real_target| !is_subdir(real_patches_dir, &real_target))
+        })
+    {
+        return Err(PatchError::PatchFileOutsidePatchesDir { patch_file: patch_file.to_string() });
+    }
+    Ok(target_path)
+}
+
+fn join_setting_path(base: &Path, setting: &str) -> PathBuf {
+    let mut joined = base.to_path_buf();
+    for component in Path::new(setting).components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => {}
+            Component::CurDir => {}
+            Component::ParentDir => joined.push(".."),
+            Component::Normal(part) => joined.push(part),
+        }
+    }
+    lexical_normalize(&joined)
+}
+
+fn resolve_patch_path(base: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() { lexical_normalize(path) } else { lexical_normalize(&base.join(path)) }
+}
+
+fn lstat_patch_if_exists(path: &Path) -> Result<Option<fs::Metadata>, PatchError> {
+    match fs::symlink_metadata(path) {
+        Ok(meta) => Ok(Some(meta)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(PatchError::ReadPatchFileMetadata { path: path.to_path_buf(), source }),
+    }
+}
+
+fn realpath_if_exists(path: &Path) -> Option<PathBuf> {
+    dunce::canonicalize(path).ok()
 }
 
 fn print_success(edit_dir: &Path) {

--- a/pacquet/crates/cli/src/cli_args/patch.rs
+++ b/pacquet/crates/cli/src/cli_args/patch.rs
@@ -1,0 +1,315 @@
+use crate::{
+    State,
+    cli_args::patch_state::{EditDirState, StateFileError, write_edit_dir_state},
+};
+use clap::Args;
+use derive_more::{Display, Error};
+use dialoguer::{Confirm, Select};
+use miette::{Diagnostic, IntoDiagnostic, miette};
+use owo_colors::OwoColorize;
+use pacquet_lockfile::{LoadLockfileError, Lockfile};
+use pacquet_package_manager::{
+    PatchCandidate, PatchCandidateSet, PatchTarget, PatchTargetError, WritePackageForPatch,
+    WritePackageForPatchError, default_patch_target, patch_candidates_from_lockfile,
+};
+use pacquet_patching::PatchApplyError;
+use pacquet_reporter::Reporter;
+use std::{
+    fs,
+    io::{self, IsTerminal},
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Args)]
+pub struct PatchArgs {
+    /// Name of the package to patch.
+    pub package_name: Option<String>,
+    /// The package that needs to be modified will be extracted to this directory.
+    #[clap(short = 'd', long = "edit-dir", value_name = "dir")]
+    pub edit_dir: Option<PathBuf>,
+    /// Ignore existing patch files when patching.
+    #[clap(long = "ignore-existing")]
+    pub ignore_existing: bool,
+}
+
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum PatchError {
+    #[display("`pacquet patch` requires the package name")]
+    #[diagnostic(code(ERR_PNPM_MISSING_PACKAGE_NAME))]
+    MissingPackageName,
+
+    #[display("The modules directory is not ready for patching")]
+    #[diagnostic(code(ERR_PNPM_PATCH_NO_LOCKFILE), help("Run pacquet install first"))]
+    PatchNoLockfile,
+
+    #[display("The target directory already exists: '{}'", edit_dir.display())]
+    #[diagnostic(code(ERR_PNPM_PATCH_EDIT_DIR_EXISTS))]
+    PatchEditDirExists { edit_dir: PathBuf },
+
+    #[display("The directory {} is not empty", edit_dir.display())]
+    #[diagnostic(code(ERR_PNPM_EDIT_DIR_NOT_EMPTY))]
+    EditDirNotEmpty { edit_dir: PathBuf },
+
+    #[display("Unable to read the target directory '{}': {source}", edit_dir.display())]
+    #[diagnostic(code(pacquet::patch_edit_dir_read))]
+    ReadEditDir {
+        edit_dir: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display("Canceled")]
+    #[diagnostic(code(ERR_PNPM_PATCH_CANCELED))]
+    Canceled,
+
+    #[diagnostic(transparent)]
+    LoadLockfile(#[error(source)] LoadLockfileError),
+
+    #[diagnostic(transparent)]
+    PatchTarget(#[error(source)] PatchTargetError),
+
+    #[diagnostic(transparent)]
+    WritePackage(#[error(source)] WritePackageForPatchError),
+
+    #[diagnostic(transparent)]
+    StateFile(#[error(source)] StateFileError),
+
+    #[diagnostic(transparent)]
+    ApplyExistingPatch(#[error(source)] PatchApplyError),
+
+    #[display("Unable to find patch file {}", patch_file_path.display())]
+    #[diagnostic(code(ERR_PNPM_PATCH_FILE_NOT_FOUND))]
+    PatchFileNotFound { patch_file_path: PathBuf },
+}
+
+impl PatchArgs {
+    pub async fn run<Reporter: self::Reporter + 'static>(
+        self,
+        dir: &Path,
+        state: State,
+    ) -> Result<(), PatchError> {
+        let PatchArgs { package_name, edit_dir, ignore_existing } = self;
+        if let Some(edit_dir) = edit_dir.as_ref().map(|path| resolve_path(dir, path)) {
+            reject_non_empty_custom_edit_dir(&edit_dir)?;
+        }
+        let package_name = package_name.ok_or(PatchError::MissingPackageName)?;
+        let current_lockfile =
+            Lockfile::load_current_from_virtual_store_dir(&state.config.virtual_store_dir)
+                .map_err(PatchError::LoadLockfile)?
+                .ok_or(PatchError::PatchNoLockfile)?;
+
+        let candidate_set = patch_candidates_from_lockfile(&package_name, &current_lockfile)
+            .map_err(PatchError::PatchTarget)?;
+        let target = select_patch_target(&candidate_set)?;
+        let edit_dir = edit_dir.as_ref().map_or_else(
+            || default_edit_dir(&state.config.modules_dir, &package_name, &target),
+            |path| resolve_path(dir, path),
+        );
+        reject_non_empty_edit_dir(&edit_dir)?;
+
+        WritePackageForPatch {
+            tarball_mem_cache: &state.tarball_mem_cache,
+            http_client: &state.http_client,
+            config: state.config,
+            current_lockfile: &current_lockfile,
+            target: &target,
+            dest: &edit_dir,
+        }
+        .run::<Reporter>()
+        .await
+        .map_err(PatchError::WritePackage)?;
+
+        write_edit_dir_state(
+            &state.config.modules_dir,
+            &edit_dir,
+            &EditDirState { patched_pkg: package_name.clone(), apply_to_all: target.apply_to_all },
+        )
+        .map_err(PatchError::StateFile)?;
+
+        if !ignore_existing {
+            apply_existing_patch_file(state.config, &target, &edit_dir)?;
+        }
+
+        print_success(&edit_dir);
+        Ok(())
+    }
+}
+
+fn select_patch_target(set: &PatchCandidateSet) -> Result<PatchTarget, PatchError> {
+    if let Some(target) = default_patch_target(set) {
+        return Ok(target);
+    }
+
+    select_patch_target_with_prompt(set, &DialoguerPatchPrompt)
+}
+
+trait PatchPrompt {
+    fn select_version(&self, candidates: &[PatchCandidate]) -> Result<usize, PatchError>;
+    fn confirm_apply_to_all(&self) -> Result<bool, PatchError>;
+}
+
+struct DialoguerPatchPrompt;
+
+impl PatchPrompt for DialoguerPatchPrompt {
+    fn select_version(&self, candidates: &[PatchCandidate]) -> Result<usize, PatchError> {
+        let labels: Vec<String> = candidates
+            .iter()
+            .map(|candidate| match &candidate.git_tarball_url {
+                Some(url) => format!("{} (Git Hosted: {url})", candidate.version),
+                None => candidate.version.clone(),
+            })
+            .collect();
+        Select::new()
+            .with_prompt("Choose which version to patch")
+            .items(&labels)
+            .default(0)
+            .interact()
+            .into_diagnostic()
+            .map_err(|err| miette!("patch version selection failed: {err}"))
+            .map_err(|_| PatchError::Canceled)
+    }
+
+    fn confirm_apply_to_all(&self) -> Result<bool, PatchError> {
+        Confirm::new()
+            .with_prompt("Apply this patch to all versions?")
+            .interact()
+            .into_diagnostic()
+            .map_err(|err| miette!("patch apply-to-all confirmation failed: {err}"))
+            .map_err(|_| PatchError::Canceled)
+    }
+}
+
+fn select_patch_target_with_prompt(
+    set: &PatchCandidateSet,
+    prompt: &impl PatchPrompt,
+) -> Result<PatchTarget, PatchError> {
+    let selected = prompt.select_version(&set.preferred_versions)?;
+    let apply_to_all = prompt.confirm_apply_to_all()?;
+    Ok(target_from_candidate(set, &set.preferred_versions[selected], apply_to_all))
+}
+
+fn target_from_candidate(
+    set: &PatchCandidateSet,
+    candidate: &PatchCandidate,
+    apply_to_all: bool,
+) -> PatchTarget {
+    let bare_specifier =
+        candidate.git_tarball_url.clone().unwrap_or_else(|| candidate.version.clone());
+    PatchTarget {
+        alias: set.alias.clone(),
+        version: candidate.version.clone(),
+        bare_specifier,
+        apply_to_all,
+        git_tarball_url: candidate.git_tarball_url.clone(),
+        package_key: candidate.package_key.clone(),
+    }
+}
+
+fn resolve_path(dir: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() { path.to_path_buf() } else { dir.join(path) }
+}
+
+fn reject_non_empty_custom_edit_dir(edit_dir: &Path) -> Result<(), PatchError> {
+    if !edit_dir.exists() {
+        return Ok(());
+    }
+    if is_empty_dir(edit_dir)
+        .map_err(|source| PatchError::ReadEditDir { edit_dir: edit_dir.to_path_buf(), source })?
+    {
+        return Ok(());
+    }
+    Err(PatchError::PatchEditDirExists { edit_dir: edit_dir.to_path_buf() })
+}
+
+fn reject_non_empty_edit_dir(edit_dir: &Path) -> Result<(), PatchError> {
+    if !edit_dir.exists() {
+        return Ok(());
+    }
+    if is_empty_dir(edit_dir)
+        .map_err(|source| PatchError::ReadEditDir { edit_dir: edit_dir.to_path_buf(), source })?
+    {
+        return Ok(());
+    }
+    Err(PatchError::EditDirNotEmpty { edit_dir: edit_dir.to_path_buf() })
+}
+
+fn is_empty_dir(path: &Path) -> io::Result<bool> {
+    Ok(fs::read_dir(path)?.next().is_none())
+}
+
+fn default_edit_dir(modules_dir: &Path, package_name: &str, target: &PatchTarget) -> PathBuf {
+    modules_dir.join(".pnpm_patches").join(default_edit_dir_name(package_name, target))
+}
+
+fn default_edit_dir_name(package_name: &str, target: &PatchTarget) -> String {
+    if !target.alias.is_empty() && !target.bare_specifier.is_empty() {
+        return format!("{}@{}", target.alias, sanitize_bare_specifier(&target.bare_specifier));
+    }
+    if !target.alias.is_empty() {
+        return target.alias.clone();
+    }
+    package_name.to_string()
+}
+
+fn sanitize_bare_specifier(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut replacing = false;
+    for ch in input.chars() {
+        if matches!(ch, '\\' | '/' | ':' | '*' | '?' | '"' | '<' | '>' | '|') {
+            if !replacing {
+                result.push('+');
+                replacing = true;
+            }
+        } else {
+            result.push(ch);
+            replacing = false;
+        }
+    }
+    result
+}
+
+fn apply_existing_patch_file(
+    config: &pacquet_config::Config,
+    target: &PatchTarget,
+    edit_dir: &Path,
+) -> Result<(), PatchError> {
+    let Some(patched_dependencies) = &config.patched_dependencies else { return Ok(()) };
+    let exact_key = format!("{}@{}", target.alias, target.bare_specifier);
+    let patch_file = patched_dependencies
+        .get(&exact_key)
+        .or_else(|| target.apply_to_all.then(|| patched_dependencies.get(&target.alias)).flatten());
+    let Some(patch_file) = patch_file else { return Ok(()) };
+    let base_dir = config
+        .workspace_dir
+        .as_deref()
+        .unwrap_or_else(|| config.modules_dir.parent().unwrap_or_else(|| Path::new(".")));
+    let patch_file_path = resolve_path(base_dir, Path::new(patch_file));
+    if !patch_file_path.exists() {
+        return Err(PatchError::PatchFileNotFound { patch_file_path });
+    }
+    pacquet_patching::apply_patch_to_dir(edit_dir, &patch_file_path)
+        .map_err(PatchError::ApplyExistingPatch)
+}
+
+fn print_success(edit_dir: &Path) {
+    print!("{}", render_success(edit_dir, io::stdout().is_terminal()));
+}
+
+fn render_success(edit_dir: &Path, colors_enabled: bool) -> String {
+    let quote = if cfg!(windows) { r#"""# } else { "'" };
+    let edit_dir = edit_dir.display().to_string();
+    let command = format!("pacquet patch-commit {quote}{edit_dir}{quote}");
+    let edit_dir = if colors_enabled { edit_dir.blue().to_string() } else { edit_dir };
+    let command = if colors_enabled { command.green().to_string() } else { command };
+    render_success_parts(&edit_dir, &command)
+}
+
+fn render_success_parts(edit_dir: &str, command: &str) -> String {
+    format!(
+        "Patch: You can now edit the package at:\n\n  {edit_dir}\n\nTo commit your changes, run:\n\n  {command}\n\n",
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/patch.rs
+++ b/pacquet/crates/cli/src/cli_args/patch.rs
@@ -119,6 +119,10 @@ pub enum PatchError {
     #[diagnostic(code(ERR_PNPM_PATCH_FILE_IS_DIRECTORY))]
     PatchFileIsDirectory { patch_file: String },
 
+    #[display("Patch file \"{patch_file}\" is not a regular file")]
+    #[diagnostic(code(ERR_PNPM_PATCH_FILE_NOT_REGULAR))]
+    PatchFileNotRegular { patch_file: String },
+
     #[display("Failed to read patch file metadata for {}: {source}", path.display())]
     #[diagnostic(code(pacquet::patch_read_patch_file_metadata))]
     ReadPatchFileMetadata {
@@ -137,6 +141,7 @@ impl PatchArgs {
         let PatchArgs { package_name, edit_dir, ignore_existing } = self;
         let package_name = package_name.ok_or(PatchError::MissingPackageName)?;
         if let Some(edit_dir) = edit_dir.as_ref().map(|path| resolve_path(dir, path)) {
+            reject_edit_dir_symlink_components_under(dir, &edit_dir)?;
             reject_non_empty_custom_edit_dir(&edit_dir)?;
         }
         let current_lockfile =
@@ -259,6 +264,7 @@ fn resolve_path(dir: &Path, path: &Path) -> PathBuf {
 }
 
 fn reject_non_empty_custom_edit_dir(edit_dir: &Path) -> Result<(), PatchError> {
+    reject_edit_dir_symlink_if_exists(edit_dir)?;
     if !edit_dir.exists() {
         return Ok(());
     }
@@ -271,6 +277,7 @@ fn reject_non_empty_custom_edit_dir(edit_dir: &Path) -> Result<(), PatchError> {
 }
 
 fn reject_non_empty_edit_dir(edit_dir: &Path) -> Result<(), PatchError> {
+    reject_edit_dir_symlink_if_exists(edit_dir)?;
     if !edit_dir.exists() {
         return Ok(());
     }
@@ -355,6 +362,18 @@ fn reject_edit_dir_symlink_if_exists(path: &Path) -> Result<(), PatchError> {
         Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(source) => Err(PatchError::ReadEditDir { edit_dir: path.to_path_buf(), source }),
     }
+}
+
+fn reject_edit_dir_symlink_components_under(
+    root: &Path,
+    edit_dir: &Path,
+) -> Result<(), PatchError> {
+    let root = lexical_normalize(root);
+    let edit_dir = lexical_normalize(edit_dir);
+    if !is_subdir(&root, &edit_dir) {
+        return Ok(());
+    }
+    reject_default_edit_dir_symlink_components(&root, &edit_dir)
 }
 
 fn default_edit_dir_name(package_name: &str, target: &PatchTarget) -> String {
@@ -461,14 +480,21 @@ fn checked_existing_patch_file_path(
     if target_stats.as_ref().is_some_and(fs::Metadata::is_dir) {
         return Err(PatchError::PatchFileIsDirectory { patch_file: patch_file.to_string() });
     }
-    if target_stats.as_ref().is_some_and(|stats| stats.file_type().is_symlink())
-        && real_patches_dir.as_ref().is_some_and(|real_patches_dir| {
-            dunce::canonicalize(&target_path)
-                .ok()
-                .is_none_or(|real_target| !is_subdir(real_patches_dir, &real_target))
-        })
-    {
-        return Err(PatchError::PatchFileOutsidePatchesDir { patch_file: patch_file.to_string() });
+    if target_stats.as_ref().is_some_and(|stats| stats.file_type().is_symlink()) {
+        let real_target = dunce::canonicalize(&target_path).ok();
+        if real_patches_dir.as_ref().is_some_and(|real_patches_dir| {
+            real_target.as_ref().is_none_or(|real_target| !is_subdir(real_patches_dir, real_target))
+        }) {
+            return Err(PatchError::PatchFileOutsidePatchesDir {
+                patch_file: patch_file.to_string(),
+            });
+        }
+        let is_regular_file = fs::metadata(&target_path).is_ok_and(|stats| stats.is_file());
+        if !is_regular_file {
+            return Err(PatchError::PatchFileNotRegular { patch_file: patch_file.to_string() });
+        }
+    } else if target_stats.as_ref().is_some_and(|stats| !stats.is_file()) {
+        return Err(PatchError::PatchFileNotRegular { patch_file: patch_file.to_string() });
     }
     Ok(target_path)
 }
@@ -507,12 +533,19 @@ fn print_success(edit_dir: &Path) {
 }
 
 fn render_success(edit_dir: &Path, colors_enabled: bool) -> String {
-    let quote = if cfg!(windows) { r#"""# } else { "'" };
     let edit_dir = edit_dir.display().to_string();
-    let command = format!("pacquet patch-commit {quote}{edit_dir}{quote}");
+    let command = format!("pacquet patch-commit {}", shell_quote(&edit_dir));
     let edit_dir = if colors_enabled { edit_dir.blue().to_string() } else { edit_dir };
     let command = if colors_enabled { command.green().to_string() } else { command };
     render_success_parts(&edit_dir, &command)
+}
+
+fn shell_quote(value: &str) -> String {
+    if cfg!(windows) {
+        format!("\"{}\"", value.replace('"', r#"\""#))
+    } else {
+        format!("'{}'", value.replace('\'', r"'\''"))
+    }
 }
 
 fn render_success_parts(edit_dir: &str, command: &str) -> String {

--- a/pacquet/crates/cli/src/cli_args/patch.rs
+++ b/pacquet/crates/cli/src/cli_args/patch.rs
@@ -60,6 +60,30 @@ pub enum PatchError {
         source: io::Error,
     },
 
+    #[display("Unable to create the default patch edit directory '{}': {source}", edit_dir.display())]
+    #[diagnostic(code(pacquet::patch_edit_dir_create))]
+    CreateEditDir {
+        edit_dir: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display("Unable to resolve the default patch edit directory '{}': {source}", edit_dir.display())]
+    #[diagnostic(code(pacquet::patch_edit_dir_resolve))]
+    ResolveEditDir {
+        edit_dir: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display("The default patch edit directory is outside node_modules: '{}'", edit_dir.display())]
+    #[diagnostic(code(pacquet::patch_edit_dir_outside_modules_dir))]
+    EditDirOutsideModulesDir { edit_dir: PathBuf },
+
+    #[display("The default patch edit directory must not use a symbolic link: '{}'", edit_dir.display())]
+    #[diagnostic(code(pacquet::patch_edit_dir_symlink))]
+    EditDirSymlink { edit_dir: PathBuf },
+
     #[display("Canceled")]
     #[diagnostic(code(ERR_PNPM_PATCH_CANCELED))]
     Canceled,
@@ -123,10 +147,13 @@ impl PatchArgs {
         let candidate_set = patch_candidates_from_lockfile(&package_name, &current_lockfile)
             .map_err(PatchError::PatchTarget)?;
         let target = select_patch_target(&candidate_set)?;
-        let edit_dir = edit_dir.as_ref().map_or_else(
-            || default_edit_dir(&state.config.modules_dir, &package_name, &target),
-            |path| resolve_path(dir, path),
-        );
+        let edit_dir = if let Some(path) = edit_dir.as_ref() {
+            resolve_path(dir, path)
+        } else {
+            let edit_dir = default_edit_dir(&state.config.modules_dir, &package_name, &target);
+            prepare_default_edit_dir(&state.config.modules_dir, &edit_dir)?;
+            edit_dir
+        };
         reject_non_empty_edit_dir(&edit_dir)?;
 
         WritePackageForPatch {
@@ -261,6 +288,73 @@ fn is_empty_dir(path: &Path) -> io::Result<bool> {
 
 fn default_edit_dir(modules_dir: &Path, package_name: &str, target: &PatchTarget) -> PathBuf {
     modules_dir.join(".pnpm_patches").join(default_edit_dir_name(package_name, target))
+}
+
+fn prepare_default_edit_dir(modules_dir: &Path, edit_dir: &Path) -> Result<(), PatchError> {
+    let edit_root = modules_dir.join(".pnpm_patches");
+    if edit_dir == edit_root || !is_subdir(&edit_root, edit_dir) {
+        return Err(PatchError::EditDirOutsideModulesDir { edit_dir: edit_dir.to_path_buf() });
+    }
+    reject_edit_dir_symlink_if_exists(&edit_root)?;
+    fs::create_dir_all(&edit_root)
+        .map_err(|source| PatchError::CreateEditDir { edit_dir: edit_root.clone(), source })?;
+    reject_default_edit_dir_symlink_components(&edit_root, edit_dir)?;
+
+    let real_modules_dir = dunce::canonicalize(modules_dir).map_err(|source| {
+        PatchError::ResolveEditDir { edit_dir: modules_dir.to_path_buf(), source }
+    })?;
+    let real_edit_root = dunce::canonicalize(&edit_root)
+        .map_err(|source| PatchError::ResolveEditDir { edit_dir: edit_root.clone(), source })?;
+    if !is_subdir(&real_modules_dir, &real_edit_root) {
+        return Err(PatchError::EditDirOutsideModulesDir { edit_dir: edit_root });
+    }
+    Ok(())
+}
+
+fn reject_default_edit_dir_symlink_components(
+    edit_root: &Path,
+    edit_dir: &Path,
+) -> Result<(), PatchError> {
+    reject_edit_dir_symlink_if_exists(edit_root)?;
+    let relative = edit_dir
+        .strip_prefix(edit_root)
+        .map_err(|_| PatchError::EditDirOutsideModulesDir { edit_dir: edit_dir.to_path_buf() })?;
+    let mut current = edit_root.to_path_buf();
+    for component in relative.components() {
+        match component {
+            Component::Normal(part) => {
+                current.push(part);
+                match fs::symlink_metadata(&current) {
+                    Ok(meta) if meta.file_type().is_symlink() => {
+                        return Err(PatchError::EditDirSymlink { edit_dir: current });
+                    }
+                    Ok(_) => {}
+                    Err(source) if source.kind() == io::ErrorKind::NotFound => break,
+                    Err(source) => {
+                        return Err(PatchError::ReadEditDir { edit_dir: current, source });
+                    }
+                }
+            }
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(PatchError::EditDirOutsideModulesDir {
+                    edit_dir: edit_dir.to_path_buf(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn reject_edit_dir_symlink_if_exists(path: &Path) -> Result<(), PatchError> {
+    match fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_symlink() => {
+            Err(PatchError::EditDirSymlink { edit_dir: path.to_path_buf() })
+        }
+        Ok(_) => Ok(()),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(PatchError::ReadEditDir { edit_dir: path.to_path_buf(), source }),
+    }
 }
 
 fn default_edit_dir_name(package_name: &str, target: &PatchTarget) -> String {

--- a/pacquet/crates/cli/src/cli_args/patch/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch/tests.rs
@@ -1,0 +1,213 @@
+use super::*;
+use std::io::IsTerminal;
+use tempfile::tempdir;
+
+#[test]
+fn select_patch_target_uses_default_when_only_one_candidate_matches() {
+    let candidate = prompt_candidate("chalk@5.3.0");
+    let set = PatchCandidateSet {
+        alias: "chalk".to_string(),
+        requested: "chalk@5.3.0".to_string(),
+        bare_specifier: Some("5.3.0".to_string()),
+        versions: vec![candidate.clone()],
+        preferred_versions: vec![candidate],
+    };
+
+    let target = select_patch_target(&set).expect("select target");
+
+    assert_eq!(target.alias, "chalk");
+    assert_eq!(target.version, "5.3.0");
+    assert_eq!(target.bare_specifier, "5.3.0");
+    assert!(!target.apply_to_all);
+}
+
+#[test]
+fn prompt_selection_without_apply_to_all_selects_exact_target() {
+    let set = prompt_candidate_set();
+    let target =
+        select_patch_target_with_prompt(&set, &FakePrompt { selected: 1, apply_to_all: false })
+            .expect("select target");
+
+    assert_eq!(target.version, "5.3.0");
+    assert_eq!(target.bare_specifier, "5.3.0");
+    assert!(!target.apply_to_all);
+}
+
+#[test]
+fn prompt_selection_with_apply_to_all_selects_name_target() {
+    let set = prompt_candidate_set();
+    let target =
+        select_patch_target_with_prompt(&set, &FakePrompt { selected: 1, apply_to_all: true })
+            .expect("select target");
+
+    assert_eq!(target.version, "5.3.0");
+    assert_eq!(target.bare_specifier, "5.3.0");
+    assert!(target.apply_to_all);
+}
+
+#[test]
+fn prompt_selection_uses_git_tarball_url_as_bare_specifier() {
+    let tarball = "https://codeload.github.com/example/hi/tar.gz/deadbeef";
+    let mut set = prompt_candidate_set();
+    set.preferred_versions[1].git_tarball_url = Some(tarball.to_string());
+    let target =
+        select_patch_target_with_prompt(&set, &FakePrompt { selected: 1, apply_to_all: false })
+            .expect("select target");
+
+    assert_eq!(target.version, "5.3.0");
+    assert_eq!(target.bare_specifier, tarball);
+    assert_eq!(target.git_tarball_url.as_deref(), Some(tarball));
+    assert!(!target.apply_to_all);
+}
+
+#[test]
+fn select_patch_target_uses_dialoguer_when_no_default_target() {
+    if std::io::stdin().is_terminal() {
+        return;
+    }
+
+    assert!(matches!(select_patch_target(&prompt_candidate_set()), Err(PatchError::Canceled)));
+}
+
+#[test]
+fn dialoguer_prompt_reports_cancellation_when_stdin_is_not_interactive() {
+    if std::io::stdin().is_terminal() {
+        return;
+    }
+
+    let prompt = DialoguerPatchPrompt;
+    let mut git_candidate = prompt_candidate("chalk@5.3.0");
+    git_candidate.git_tarball_url =
+        Some("https://codeload.github.com/example/chalk/tar.gz/deadbeef".to_string());
+
+    assert!(matches!(
+        prompt.select_version(&[git_candidate, prompt_candidate("chalk@4.1.2")]),
+        Err(PatchError::Canceled),
+    ));
+    assert!(matches!(prompt.confirm_apply_to_all(), Err(PatchError::Canceled)));
+}
+
+#[test]
+fn success_message_colors_edit_dir_and_commit_command_when_enabled() {
+    let edit_dir = Path::new("/tmp/edit-dir");
+    let rendered = render_success(edit_dir, true);
+    let quote = if cfg!(windows) { r#"""# } else { "'" };
+
+    assert!(rendered.contains("\u{1b}[34m/tmp/edit-dir\u{1b}[39m"), "{rendered:?}");
+    assert!(
+        rendered.contains(&format!(
+            "\u{1b}[32mpacquet patch-commit {quote}/tmp/edit-dir{quote}\u{1b}[39m",
+        )),
+        "{rendered:?}",
+    );
+}
+
+#[test]
+fn success_message_is_plain_when_colors_are_disabled() {
+    let edit_dir = Path::new("/tmp/edit-dir");
+    let rendered = render_success(edit_dir, false);
+    let quote = if cfg!(windows) { r#"""# } else { "'" };
+
+    assert_eq!(
+        rendered,
+        format!(
+            "Patch: You can now edit the package at:\n\n  /tmp/edit-dir\n\nTo commit your changes, run:\n\n  pacquet patch-commit {quote}/tmp/edit-dir{quote}\n\n",
+        ),
+    );
+}
+
+#[test]
+fn edit_dir_rejectors_accept_missing_and_empty_dirs() {
+    let tmp = tempdir().expect("temp dir");
+    let missing = tmp.path().join("missing");
+    let empty = tmp.path().join("empty");
+    std::fs::create_dir(&empty).expect("create empty dir");
+
+    reject_non_empty_custom_edit_dir(&missing).expect("missing custom edit dir");
+    reject_non_empty_custom_edit_dir(&empty).expect("empty custom edit dir");
+    reject_non_empty_edit_dir(&missing).expect("missing edit dir");
+    reject_non_empty_edit_dir(&empty).expect("empty edit dir");
+}
+
+#[test]
+fn edit_dir_rejectors_reject_non_empty_dirs_with_command_specific_errors() {
+    let tmp = tempdir().expect("temp dir");
+    let edit_dir = tmp.path().join("edit");
+    std::fs::create_dir(&edit_dir).expect("create edit dir");
+    std::fs::write(edit_dir.join("index.js"), "module.exports = true\n").expect("write file");
+
+    assert!(matches!(
+        reject_non_empty_custom_edit_dir(&edit_dir),
+        Err(PatchError::PatchEditDirExists { .. }),
+    ));
+    assert!(matches!(
+        reject_non_empty_edit_dir(&edit_dir),
+        Err(PatchError::EditDirNotEmpty { .. })
+    ));
+}
+
+#[test]
+fn default_edit_dir_name_sanitizes_bare_specifier_path_chars() {
+    let target = PatchTarget {
+        alias: "@scope/pkg".to_string(),
+        version: "1.0.0".to_string(),
+        bare_specifier: "npm:@scope/pkg@^1.0.0".to_string(),
+        apply_to_all: false,
+        git_tarball_url: None,
+        package_key: "@scope/pkg@1.0.0".parse().expect("package key"),
+    };
+
+    assert_eq!(
+        default_edit_dir_name("@scope/pkg@npm:@scope/pkg@^1.0.0", &target),
+        "@scope/pkg@npm+@scope+pkg@^1.0.0",
+    );
+}
+
+#[test]
+fn default_edit_dir_name_falls_back_to_alias_then_requested_package() {
+    let mut target = PatchTarget {
+        alias: "chalk".to_string(),
+        version: "5.3.0".to_string(),
+        bare_specifier: String::new(),
+        apply_to_all: false,
+        git_tarball_url: None,
+        package_key: "chalk@5.3.0".parse().expect("package key"),
+    };
+
+    assert_eq!(default_edit_dir_name("chalk", &target), "chalk");
+
+    target.alias.clear();
+    assert_eq!(default_edit_dir_name("chalk@npm:chalk@5.3.0", &target), "chalk@npm:chalk@5.3.0");
+}
+
+struct FakePrompt {
+    selected: usize,
+    apply_to_all: bool,
+}
+
+impl PatchPrompt for FakePrompt {
+    fn select_version(&self, _candidates: &[PatchCandidate]) -> Result<usize, PatchError> {
+        Ok(self.selected)
+    }
+
+    fn confirm_apply_to_all(&self) -> Result<bool, PatchError> {
+        Ok(self.apply_to_all)
+    }
+}
+
+fn prompt_candidate_set() -> PatchCandidateSet {
+    let candidates = vec![prompt_candidate("chalk@4.1.2"), prompt_candidate("chalk@5.3.0")];
+    PatchCandidateSet {
+        alias: "chalk".to_string(),
+        requested: "chalk".to_string(),
+        bare_specifier: None,
+        versions: candidates.clone(),
+        preferred_versions: candidates,
+    }
+}
+
+fn prompt_candidate(key: &str) -> PatchCandidate {
+    let package_key = key.parse().expect("package key");
+    let version = key.rsplit('@').next().expect("version").to_string();
+    PatchCandidate { name: "chalk".to_string(), version, git_tarball_url: None, package_key }
+}

--- a/pacquet/crates/cli/src/cli_args/patch/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch/tests.rs
@@ -1,5 +1,9 @@
-use super::*;
-use std::io::IsTerminal;
+use super::{
+    DialoguerPatchPrompt, PatchCandidate, PatchCandidateSet, PatchError, PatchPrompt, PatchTarget,
+    default_edit_dir_name, reject_non_empty_custom_edit_dir, reject_non_empty_edit_dir,
+    render_success, select_patch_target, select_patch_target_with_prompt,
+};
+use std::{io::IsTerminal, path::Path};
 use tempfile::tempdir;
 
 #[test]
@@ -62,18 +66,14 @@ fn prompt_selection_uses_git_tarball_url_as_bare_specifier() {
 
 #[test]
 fn select_patch_target_uses_dialoguer_when_no_default_target() {
-    if std::io::stdin().is_terminal() {
-        return;
-    }
+    assert!(!std::io::stdin().is_terminal(), "test requires non-interactive stdin");
 
     assert!(matches!(select_patch_target(&prompt_candidate_set()), Err(PatchError::Canceled)));
 }
 
 #[test]
 fn dialoguer_prompt_reports_cancellation_when_stdin_is_not_interactive() {
-    if std::io::stdin().is_terminal() {
-        return;
-    }
+    assert!(!std::io::stdin().is_terminal(), "test requires non-interactive stdin");
 
     let prompt = DialoguerPatchPrompt;
     let mut git_candidate = prompt_candidate("chalk@5.3.0");

--- a/pacquet/crates/cli/src/cli_args/patch/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch/tests.rs
@@ -1,7 +1,8 @@
 use super::{
     DialoguerPatchPrompt, PatchCandidate, PatchCandidateSet, PatchError, PatchPrompt, PatchTarget,
-    default_edit_dir_name, reject_non_empty_custom_edit_dir, reject_non_empty_edit_dir,
-    render_success, select_patch_target, select_patch_target_with_prompt,
+    checked_existing_patch_file_path, default_edit_dir_name, reject_non_empty_custom_edit_dir,
+    reject_non_empty_edit_dir, render_success, select_patch_target,
+    select_patch_target_with_prompt,
 };
 use std::{io::IsTerminal, path::Path};
 use tempfile::tempdir;
@@ -116,6 +117,31 @@ fn success_message_is_plain_when_colors_are_disabled() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn success_message_shell_quotes_single_quotes_in_edit_dir() {
+    let edit_dir = Path::new("/tmp/patch user's dir");
+    let rendered = render_success(edit_dir, false);
+
+    assert!(rendered.contains(r"pacquet patch-commit '/tmp/patch user'\''s dir'"), "{rendered}");
+}
+
+#[cfg(unix)]
+#[test]
+fn existing_patch_file_path_rejects_non_regular_files() {
+    let tmp = tempdir().expect("temp dir");
+    let patches_dir = tmp.path().join("patches");
+    std::fs::create_dir(&patches_dir).expect("create patches dir");
+    let socket_path = patches_dir.join("pkg.patch");
+    let _listener =
+        std::os::unix::net::UnixListener::bind(&socket_path).expect("create patch socket");
+
+    let err = checked_existing_patch_file_path(tmp.path(), "patches", "patches/pkg.patch")
+        .expect_err("socket patch path should be rejected");
+
+    assert!(matches!(err, PatchError::PatchFileNotRegular { .. }));
+}
+
 #[test]
 fn edit_dir_rejectors_accept_missing_and_empty_dirs() {
     let tmp = tempdir().expect("temp dir");
@@ -144,6 +170,21 @@ fn edit_dir_rejectors_reject_non_empty_dirs_with_command_specific_errors() {
         reject_non_empty_edit_dir(&edit_dir),
         Err(PatchError::EditDirNotEmpty { .. })
     ));
+}
+
+#[cfg(unix)]
+#[test]
+fn custom_edit_dir_rejector_rejects_symlinked_edit_dir() {
+    let tmp = tempdir().expect("temp dir");
+    let outside = tmp.path().join("outside");
+    let edit_dir = tmp.path().join("edit");
+    std::fs::create_dir(&outside).expect("create outside dir");
+    std::os::unix::fs::symlink(&outside, &edit_dir).expect("symlink edit dir");
+
+    let err = reject_non_empty_custom_edit_dir(&edit_dir)
+        .expect_err("custom edit dir symlink should be rejected");
+
+    assert!(matches!(err, PatchError::EditDirSymlink { .. }));
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/patch_commit.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_commit.rs
@@ -1,16 +1,16 @@
 use crate::{
     State,
-    cli_args::patch_state::{StateFileError, read_edit_dir_state},
+    cli_args::patch_state::{EditDirState, StateFileError, read_edit_dir_state},
 };
 use clap::Args;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_crypto_hash::create_short_hash;
 use pacquet_fs::{is_subdir, lexical_normalize};
-use pacquet_lockfile::{LoadLockfileError, Lockfile};
+use pacquet_lockfile::{LoadLockfileError, Lockfile, PackageKey};
 use pacquet_package_manager::{
-    PatchTarget, PatchTargetError, PkgFilesForDiff, WritePackageForPatch,
-    WritePackageForPatchError, diff_folders, patch_candidates_from_lockfile,
+    PatchCandidate, PatchCandidateSet, PatchTarget, PatchTargetError, PkgFilesForDiff,
+    WritePackageForPatch, WritePackageForPatchError, diff_folders, patch_candidates_from_lockfile,
     prepare_pkg_files_for_diff,
 };
 use pacquet_package_manifest::{PackageManifest, PackageManifestError};
@@ -139,13 +139,7 @@ impl PatchCommitArgs {
             Lockfile::load_current_from_virtual_store_dir(&state.config.virtual_store_dir)
                 .map_err(PatchCommitError::LoadLockfile)?
                 .ok_or(PatchCommitError::PatchNoLockfile)?;
-        let target = patch_target_from_state(
-            &state_value.patched_pkg,
-            &name,
-            &version,
-            state_value.apply_to_all,
-            &current_lockfile,
-        )?;
+        let target = patch_target_from_state(&state_value, &name, &version, &current_lockfile)?;
 
         let clean_dir = clean_source_dir(&state, &patch_dir);
         remove_dir_if_exists(&clean_dir).map_err(|source| PatchCommitError::CleanupTempDir {
@@ -246,21 +240,16 @@ fn manifest_string(
 }
 
 fn patch_target_from_state(
-    raw_dependency: &str,
+    state_value: &EditDirState,
     name: &str,
     version: &str,
-    apply_to_all: bool,
     current_lockfile: &Lockfile,
 ) -> Result<PatchTarget, PatchCommitError> {
     let fallback = format!("{name}@{version}");
-    let set = patch_candidates_from_lockfile(raw_dependency, current_lockfile)
+    let set = patch_candidates_from_lockfile(&state_value.patched_pkg, current_lockfile)
         .or_else(|_| patch_candidates_from_lockfile(&fallback, current_lockfile))
         .map_err(PatchCommitError::PatchTarget)?;
-    let candidate = set
-        .preferred_versions
-        .iter()
-        .chain(set.versions.iter())
-        .find(|candidate| candidate.version == version)
+    let candidate = matching_candidate(&set, version, state_value.package_key.as_ref())
         .ok_or_else(|| {
             PatchCommitError::PatchTarget(PatchTargetError::VersionNotFound {
                 requested: fallback.clone(),
@@ -271,10 +260,25 @@ fn patch_target_from_state(
         alias: name.to_string(),
         version: version.to_string(),
         bare_specifier: candidate.git_tarball_url.clone().unwrap_or_else(|| version.to_string()),
-        apply_to_all,
+        apply_to_all: state_value.apply_to_all,
         git_tarball_url: candidate.git_tarball_url.clone(),
-        package_key: candidate.package_key.clone(),
+        package_key: candidate.package_key,
     })
+}
+
+fn matching_candidate(
+    set: &PatchCandidateSet,
+    version: &str,
+    package_key: Option<&PackageKey>,
+) -> Option<PatchCandidate> {
+    set.preferred_versions
+        .iter()
+        .chain(set.versions.iter())
+        .find(|candidate| {
+            candidate.version == version
+                && package_key.is_none_or(|package_key| candidate.package_key == *package_key)
+        })
+        .cloned()
 }
 
 fn resolve_path(dir: &Path, path: &Path) -> PathBuf {

--- a/pacquet/crates/cli/src/cli_args/patch_commit.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_commit.rs
@@ -18,10 +18,9 @@ use pacquet_reporter::Reporter;
 use pacquet_workspace_manifest_writer::UpdateWorkspaceManifestError;
 use serde_json::Value;
 use std::{
-    fs::{self, OpenOptions},
+    fs,
     io::{self, Write},
     path::{Component, Path, PathBuf},
-    sync::atomic::{AtomicU64, Ordering},
 };
 
 #[derive(Debug, Args)]
@@ -370,46 +369,12 @@ fn lstat_if_exists(path: &Path) -> Result<Option<fs::Metadata>, PatchCommitError
 }
 
 fn write_patch_file_atomically(target: &Path, content: &[u8]) -> io::Result<()> {
-    const MAX_TEMP_ATTEMPTS: usize = 16;
-
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let pid = std::process::id();
     let parent = target.parent().unwrap_or_else(|| Path::new("."));
-    let file_name = target
-        .file_name()
-        .map_or_else(|| String::from("patch"), |name| name.to_string_lossy().into_owned());
-
-    let mut last_already_exists = None;
-    for _ in 0..MAX_TEMP_ATTEMPTS {
-        let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let tmp = parent.join(format!(".{file_name}.{pid}.{counter}.pacquet-tmp"));
-        let mut file = match OpenOptions::new().write(true).create_new(true).open(&tmp) {
-            Ok(file) => file,
-            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-                last_already_exists = Some(error);
-                continue;
-            }
-            Err(error) => return Err(error),
-        };
-
-        if let Err(error) = file.write_all(content) {
-            drop(file);
-            let _ = fs::remove_file(&tmp);
-            return Err(error);
-        }
-        drop(file);
-
-        return fs::rename(&tmp, target).inspect_err(|_| {
-            let _ = fs::remove_file(&tmp);
-        });
-    }
-
-    Err(last_already_exists.unwrap_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::AlreadyExists,
-            "exhausted temp-path attempts for atomic patch write",
-        )
-    }))
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+    tmp.write_all(content)?;
+    tmp.as_file().sync_all()?;
+    tmp.persist(target).map_err(|error| error.error)?;
+    Ok(())
 }
 
 fn clean_source_dir(state: &State, patch_dir: &Path) -> PathBuf {

--- a/pacquet/crates/cli/src/cli_args/patch_commit.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_commit.rs
@@ -1,0 +1,278 @@
+use crate::{
+    State,
+    cli_args::patch_state::{StateFileError, read_edit_dir_state},
+};
+use clap::Args;
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pacquet_crypto_hash::create_short_hash;
+use pacquet_lockfile::{LoadLockfileError, Lockfile};
+use pacquet_package_manager::{
+    PatchTarget, PatchTargetError, PkgFilesForDiff, WritePackageForPatch,
+    WritePackageForPatchError, diff_folders, patch_candidates_from_lockfile,
+    prepare_pkg_files_for_diff,
+};
+use pacquet_package_manifest::{PackageManifest, PackageManifestError};
+use pacquet_reporter::Reporter;
+use pacquet_workspace_manifest_writer::UpdateWorkspaceManifestError;
+use serde_json::Value;
+use std::{
+    fs, io,
+    path::{Component, Path, PathBuf},
+};
+
+#[derive(Debug, Args)]
+pub struct PatchCommitArgs {
+    /// Directory created by `pacquet patch`.
+    pub patch_dir: PathBuf,
+    /// The generated patch file will be saved to this directory.
+    #[clap(long = "patches-dir", value_name = "dir")]
+    pub patches_dir: Option<String>,
+}
+
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum PatchCommitError {
+    #[display("{} is not a valid patch directory", patch_dir.display())]
+    #[diagnostic(
+        code(ERR_PNPM_INVALID_PATCH_DIR),
+        help("A valid patch directory should be created by `pacquet patch`")
+    )]
+    InvalidPatchDir { patch_dir: PathBuf },
+
+    #[display("Missing package manifest field `{field}` in {}", path.display())]
+    #[diagnostic(code(pacquet::patch_commit_missing_manifest_field))]
+    MissingManifestField { path: PathBuf, field: &'static str },
+
+    #[display("Failed to read package manifest from {}: {source}", path.display())]
+    #[diagnostic(code(pacquet::patch_commit_read_manifest))]
+    ReadManifest {
+        path: PathBuf,
+        #[error(source)]
+        source: PackageManifestError,
+    },
+
+    #[display("The modules directory is not ready for patching")]
+    #[diagnostic(code(ERR_PNPM_PATCH_NO_LOCKFILE), help("Run pacquet install first"))]
+    PatchNoLockfile,
+
+    #[display("Failed to create patches directory {}: {source}", path.display())]
+    #[diagnostic(code(pacquet::patch_commit_create_patches_dir))]
+    CreatePatchesDir {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display("Failed to write patch file {}: {source}", path.display())]
+    #[diagnostic(code(pacquet::patch_commit_write_patch))]
+    WritePatch {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[diagnostic(transparent)]
+    StateFile(#[error(source)] StateFileError),
+
+    #[diagnostic(transparent)]
+    LoadLockfile(#[error(source)] LoadLockfileError),
+
+    #[diagnostic(transparent)]
+    PatchTarget(#[error(source)] PatchTargetError),
+
+    #[diagnostic(transparent)]
+    WritePackage(#[error(source)] WritePackageForPatchError),
+
+    #[diagnostic(transparent)]
+    PatchCommit(#[error(source)] pacquet_package_manager::PatchCommitError),
+
+    #[diagnostic(transparent)]
+    UpdateWorkspaceManifest(#[error(source)] UpdateWorkspaceManifestError),
+}
+
+impl PatchCommitArgs {
+    pub async fn run<Reporter: self::Reporter + 'static>(
+        self,
+        dir: &Path,
+        state: State,
+    ) -> Result<bool, PatchCommitError> {
+        let patch_dir = resolve_path(dir, &self.patch_dir);
+        let manifest_path = patch_dir.join("package.json");
+        let patched_manifest =
+            PackageManifest::from_path(manifest_path.clone()).map_err(|source| {
+                PatchCommitError::ReadManifest { path: manifest_path.clone(), source }
+            })?;
+        let name = manifest_string(patched_manifest.value(), "name", &manifest_path)?;
+        let version = manifest_string(patched_manifest.value(), "version", &manifest_path)?;
+        let state_value = read_edit_dir_state(&state.config.modules_dir, &patch_dir)
+            .map_err(PatchCommitError::StateFile)?
+            .ok_or_else(|| PatchCommitError::InvalidPatchDir { patch_dir: patch_dir.clone() })?;
+
+        let current_lockfile =
+            Lockfile::load_current_from_virtual_store_dir(&state.config.virtual_store_dir)
+                .map_err(PatchCommitError::LoadLockfile)?
+                .ok_or(PatchCommitError::PatchNoLockfile)?;
+        let target = patch_target_from_state(
+            &state_value.patched_pkg,
+            &name,
+            &version,
+            state_value.apply_to_all,
+            &current_lockfile,
+        )?;
+
+        let clean_dir = clean_source_dir(&state, &patch_dir);
+        remove_dir_if_exists(&clean_dir);
+        WritePackageForPatch {
+            tarball_mem_cache: &state.tarball_mem_cache,
+            http_client: &state.http_client,
+            config: state.config,
+            current_lockfile: &current_lockfile,
+            target: &target,
+            dest: &clean_dir,
+        }
+        .run::<Reporter>()
+        .await
+        .map_err(PatchCommitError::WritePackage)?;
+
+        let filtered =
+            prepare_pkg_files_for_diff(&patch_dir).map_err(PatchCommitError::PatchCommit)?;
+        let filtered_path = match &filtered {
+            PkgFilesForDiff::Original(path) | PkgFilesForDiff::Temporary(path) => path,
+        };
+        let patch_content =
+            diff_folders(&clean_dir, filtered_path).map_err(PatchCommitError::PatchCommit)?;
+        cleanup_after_diff(&clean_dir, &filtered);
+
+        if patch_content.is_empty() {
+            println!("No changes were found to the following directory: {}", patch_dir.display());
+            return Ok(false);
+        }
+
+        let workspace_dir = state.config.workspace_dir.clone().unwrap_or_else(|| dir.to_path_buf());
+        let patches_dir_name = normalize_patches_dir_name(
+            self.patches_dir
+                .as_deref()
+                .or(state.config.patches_dir.as_deref())
+                .unwrap_or("patches"),
+        );
+        let patches_dir = workspace_dir.join(path_from_forward_slash(&patches_dir_name));
+        fs::create_dir_all(&patches_dir).map_err(|source| PatchCommitError::CreatePatchesDir {
+            path: patches_dir.clone(),
+            source,
+        })?;
+
+        let patch_key =
+            if state_value.apply_to_all { name.clone() } else { format!("{name}@{version}") };
+        let patch_file_name = format!("{}.patch", patch_key.replace('/', "__"));
+        let patch_file_path = patches_dir.join(&patch_file_name);
+        fs::write(&patch_file_path, patch_content).map_err(|source| {
+            PatchCommitError::WritePatch { path: patch_file_path.clone(), source }
+        })?;
+
+        let mut patched_dependencies =
+            state.config.patched_dependencies.clone().unwrap_or_default();
+        patched_dependencies.insert(patch_key, format!("{patches_dir_name}/{patch_file_name}"));
+        pacquet_workspace_manifest_writer::set_patched_dependencies(
+            &workspace_dir,
+            &patched_dependencies,
+        )
+        .map_err(PatchCommitError::UpdateWorkspaceManifest)?;
+
+        Ok(true)
+    }
+}
+
+fn manifest_string(
+    manifest: &Value,
+    field: &'static str,
+    path: &Path,
+) -> Result<String, PatchCommitError> {
+    manifest
+        .get(field)
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .ok_or_else(|| PatchCommitError::MissingManifestField { path: path.to_path_buf(), field })
+}
+
+fn patch_target_from_state(
+    raw_dependency: &str,
+    name: &str,
+    version: &str,
+    apply_to_all: bool,
+    current_lockfile: &Lockfile,
+) -> Result<PatchTarget, PatchCommitError> {
+    let fallback = format!("{name}@{version}");
+    let set = patch_candidates_from_lockfile(raw_dependency, current_lockfile)
+        .or_else(|_| patch_candidates_from_lockfile(&fallback, current_lockfile))
+        .map_err(PatchCommitError::PatchTarget)?;
+    let candidate = set
+        .preferred_versions
+        .iter()
+        .chain(set.versions.iter())
+        .find(|candidate| candidate.version == version)
+        .ok_or_else(|| {
+            PatchCommitError::PatchTarget(PatchTargetError::VersionNotFound {
+                requested: fallback.clone(),
+                hint: format!("did you forget to install {fallback}?"),
+            })
+        })?;
+    Ok(PatchTarget {
+        alias: name.to_string(),
+        version: version.to_string(),
+        bare_specifier: candidate.git_tarball_url.clone().unwrap_or_else(|| version.to_string()),
+        apply_to_all,
+        git_tarball_url: candidate.git_tarball_url.clone(),
+        package_key: candidate.package_key.clone(),
+    })
+}
+
+fn resolve_path(dir: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() { path.to_path_buf() } else { dir.join(path) }
+}
+
+fn clean_source_dir(state: &State, patch_dir: &Path) -> PathBuf {
+    let hash = create_short_hash(&patch_dir.to_string_lossy());
+    state.config.store_dir.tmp().join("patch-commit").join(hash)
+}
+
+fn cleanup_after_diff(clean_dir: &Path, filtered: &PkgFilesForDiff) {
+    remove_dir_if_exists(clean_dir);
+    if let PkgFilesForDiff::Temporary(path) = filtered {
+        remove_dir_if_exists(path);
+    }
+}
+
+fn remove_dir_if_exists(path: &Path) {
+    match fs::remove_dir_all(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            eprintln!("Failed to clean up temporary directory at {}: {error}", path.display());
+        }
+    }
+}
+
+fn normalize_patches_dir_name(input: &str) -> String {
+    let mut parts = Vec::new();
+    for component in Path::new(input).components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !parts.is_empty() {
+                    parts.pop();
+                }
+            }
+            Component::Normal(part) => parts.push(part.to_string_lossy().into_owned()),
+            Component::RootDir | Component::Prefix(_) => {}
+        }
+    }
+    if parts.is_empty() { ".".to_string() } else { parts.join("/") }
+}
+
+fn path_from_forward_slash(path: &str) -> PathBuf {
+    path.split('/').collect()
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/patch_commit.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_commit.rs
@@ -6,6 +6,7 @@ use clap::Args;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_crypto_hash::create_short_hash;
+use pacquet_fs::{is_subdir, lexical_normalize};
 use pacquet_lockfile::{LoadLockfileError, Lockfile};
 use pacquet_package_manager::{
     PatchTarget, PatchTargetError, PkgFilesForDiff, WritePackageForPatch,
@@ -17,8 +18,10 @@ use pacquet_reporter::Reporter;
 use pacquet_workspace_manifest_writer::UpdateWorkspaceManifestError;
 use serde_json::Value;
 use std::{
-    fs, io,
+    fs::{self, OpenOptions},
+    io::{self, Write},
     path::{Component, Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 #[derive(Debug, Args)]
@@ -59,6 +62,22 @@ pub enum PatchCommitError {
     #[display("Failed to create patches directory {}: {source}", path.display())]
     #[diagnostic(code(pacquet::patch_commit_create_patches_dir))]
     CreatePatchesDir {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display("The configured patches directory is outside the project: {patches_dir}")]
+    #[diagnostic(code(ERR_PNPM_PATCHES_DIR_OUTSIDE_PROJECT))]
+    PatchesDirOutsideProject { patches_dir: String },
+
+    #[display("Patch file \"{patch_file}\" is outside the configured patches directory")]
+    #[diagnostic(code(ERR_PNPM_PATCH_FILE_OUTSIDE_PATCHES_DIR))]
+    PatchFileOutsidePatchesDir { patch_file: String },
+
+    #[display("Failed to read patch file metadata for {}: {source}", path.display())]
+    #[diagnostic(code(pacquet::patch_commit_read_patch_file_metadata))]
+    ReadPatchFileMetadata {
         path: PathBuf,
         #[error(source)]
         source: io::Error,
@@ -133,15 +152,28 @@ impl PatchCommitArgs {
         }
         .run::<Reporter>()
         .await
-        .map_err(PatchCommitError::WritePackage)?;
+        .map_err(|source| {
+            remove_dir_if_exists(&clean_dir);
+            PatchCommitError::WritePackage(source)
+        })?;
 
-        let filtered =
-            prepare_pkg_files_for_diff(&patch_dir).map_err(PatchCommitError::PatchCommit)?;
+        let filtered = match prepare_pkg_files_for_diff(&patch_dir) {
+            Ok(filtered) => filtered,
+            Err(source) => {
+                remove_dir_if_exists(&clean_dir);
+                return Err(PatchCommitError::PatchCommit(source));
+            }
+        };
         let filtered_path = match &filtered {
             PkgFilesForDiff::Original(path) | PkgFilesForDiff::Temporary(path) => path,
         };
-        let patch_content =
-            diff_folders(&clean_dir, filtered_path).map_err(PatchCommitError::PatchCommit)?;
+        let patch_content = match diff_folders(&clean_dir, filtered_path) {
+            Ok(patch_content) => patch_content,
+            Err(source) => {
+                cleanup_after_diff(&clean_dir, &filtered);
+                return Err(PatchCommitError::PatchCommit(source));
+            }
+        };
         cleanup_after_diff(&clean_dir, &filtered);
 
         if patch_content.is_empty() {
@@ -161,14 +193,15 @@ impl PatchCommitArgs {
             path: patches_dir.clone(),
             source,
         })?;
+        let patch_file_context = PatchFileWriteContext::new(&workspace_dir, &patches_dir_name)?;
 
         let patch_key =
             if state_value.apply_to_all { name.clone() } else { format!("{name}@{version}") };
         let patch_file_name = format!("{}.patch", patch_key.replace('/', "__"));
-        let patch_file_path = patches_dir.join(&patch_file_name);
-        fs::write(&patch_file_path, patch_content).map_err(|source| {
-            PatchCommitError::WritePatch { path: patch_file_path.clone(), source }
-        })?;
+        let patch_file_path = patch_file_context.patch_file_path(&patch_file_name)?;
+        write_patch_file_atomically(&patch_file_path, patch_content.as_bytes()).map_err(
+            |source| PatchCommitError::WritePatch { path: patch_file_path.clone(), source },
+        )?;
 
         let mut patched_dependencies =
             state.config.patched_dependencies.clone().unwrap_or_default();
@@ -231,6 +264,136 @@ fn resolve_path(dir: &Path, path: &Path) -> PathBuf {
     if path.is_absolute() { path.to_path_buf() } else { dir.join(path) }
 }
 
+struct PatchFileWriteContext {
+    patches_dir: PathBuf,
+    real_patches_dir: PathBuf,
+}
+
+impl PatchFileWriteContext {
+    fn new(lockfile_dir: &Path, patches_dir_setting: &str) -> Result<Self, PatchCommitError> {
+        let project_root = lexical_normalize(lockfile_dir);
+        let real_project_root =
+            dunce::canonicalize(&project_root).unwrap_or_else(|_| project_root.clone());
+        let patches_dir = join_setting_path(&project_root, patches_dir_setting);
+        if !is_subdir(&project_root, &patches_dir) {
+            return Err(PatchCommitError::PatchesDirOutsideProject {
+                patches_dir: patches_dir_setting.to_string(),
+            });
+        }
+        let real_patches_dir = dunce::canonicalize(&patches_dir).map_err(|source| {
+            PatchCommitError::ReadPatchFileMetadata { path: patches_dir.clone(), source }
+        })?;
+        if !is_subdir(&real_project_root, &real_patches_dir) {
+            return Err(PatchCommitError::PatchesDirOutsideProject {
+                patches_dir: patches_dir_setting.to_string(),
+            });
+        }
+        Ok(Self { patches_dir, real_patches_dir })
+    }
+
+    fn patch_file_path(&self, patch_file: &str) -> Result<PathBuf, PatchCommitError> {
+        let target_path = resolve_patch_path(&self.patches_dir, Path::new(patch_file));
+        if target_path == self.patches_dir || !is_subdir(&self.patches_dir, &target_path) {
+            return Err(PatchCommitError::PatchFileOutsidePatchesDir {
+                patch_file: patch_file.to_string(),
+            });
+        }
+
+        let parent_dir = target_path.parent().map_or_else(PathBuf::new, Path::to_path_buf);
+        let real_parent_dir = dunce::canonicalize(&parent_dir).map_err(|source| {
+            PatchCommitError::ReadPatchFileMetadata { path: parent_dir.clone(), source }
+        })?;
+        if !is_subdir(&self.real_patches_dir, &real_parent_dir) {
+            return Err(PatchCommitError::PatchFileOutsidePatchesDir {
+                patch_file: patch_file.to_string(),
+            });
+        }
+
+        if lstat_if_exists(&target_path)?.as_ref().is_some_and(|stats| {
+            stats.file_type().is_symlink()
+                && dunce::canonicalize(&target_path)
+                    .ok()
+                    .is_none_or(|real_target| !is_subdir(&self.real_patches_dir, &real_target))
+        }) {
+            return Err(PatchCommitError::PatchFileOutsidePatchesDir {
+                patch_file: patch_file.to_string(),
+            });
+        }
+
+        Ok(target_path)
+    }
+}
+
+fn join_setting_path(base: &Path, setting: &str) -> PathBuf {
+    let mut joined = base.to_path_buf();
+    for component in Path::new(setting).components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => {}
+            Component::CurDir => {}
+            Component::ParentDir => joined.push(".."),
+            Component::Normal(part) => joined.push(part),
+        }
+    }
+    lexical_normalize(&joined)
+}
+
+fn resolve_patch_path(base: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() { lexical_normalize(path) } else { lexical_normalize(&base.join(path)) }
+}
+
+fn lstat_if_exists(path: &Path) -> Result<Option<fs::Metadata>, PatchCommitError> {
+    match fs::symlink_metadata(path) {
+        Ok(meta) => Ok(Some(meta)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(source) => {
+            Err(PatchCommitError::ReadPatchFileMetadata { path: path.to_path_buf(), source })
+        }
+    }
+}
+
+fn write_patch_file_atomically(target: &Path, content: &[u8]) -> io::Result<()> {
+    const MAX_TEMP_ATTEMPTS: usize = 16;
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let pid = std::process::id();
+    let parent = target.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = target
+        .file_name()
+        .map_or_else(|| String::from("patch"), |name| name.to_string_lossy().into_owned());
+
+    let mut last_already_exists = None;
+    for _ in 0..MAX_TEMP_ATTEMPTS {
+        let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let tmp = parent.join(format!(".{file_name}.{pid}.{counter}.pacquet-tmp"));
+        let mut file = match OpenOptions::new().write(true).create_new(true).open(&tmp) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                last_already_exists = Some(error);
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
+
+        if let Err(error) = file.write_all(content) {
+            drop(file);
+            let _ = fs::remove_file(&tmp);
+            return Err(error);
+        }
+        drop(file);
+
+        return fs::rename(&tmp, target).inspect_err(|_| {
+            let _ = fs::remove_file(&tmp);
+        });
+    }
+
+    Err(last_already_exists.unwrap_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "exhausted temp-path attempts for atomic patch write",
+        )
+    }))
+}
+
 fn clean_source_dir(state: &State, patch_dir: &Path) -> PathBuf {
     let hash = create_short_hash(&patch_dir.to_string_lossy());
     state.config.store_dir.tmp().join("patch-commit").join(hash)
@@ -247,9 +410,7 @@ fn remove_dir_if_exists(path: &Path) {
     match fs::remove_dir_all(path) {
         Ok(()) => {}
         Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-        Err(error) => {
-            eprintln!("Failed to clean up temporary directory at {}: {error}", path.display());
-        }
+        Err(_) => {}
     }
 }
 

--- a/pacquet/crates/cli/src/cli_args/patch_commit.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_commit.rs
@@ -91,6 +91,14 @@ pub enum PatchCommitError {
         source: io::Error,
     },
 
+    #[display("Failed to clean up temporary patch directory {}: {source}", path.display())]
+    #[diagnostic(code(pacquet::patch_commit_cleanup_temp_dir))]
+    CleanupTempDir {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
     #[diagnostic(transparent)]
     StateFile(#[error(source)] StateFileError),
 
@@ -141,7 +149,10 @@ impl PatchCommitArgs {
         )?;
 
         let clean_dir = clean_source_dir(&state, &patch_dir);
-        remove_dir_if_exists(&clean_dir);
+        remove_dir_if_exists(&clean_dir).map_err(|source| PatchCommitError::CleanupTempDir {
+            path: clean_dir.clone(),
+            source,
+        })?;
         WritePackageForPatch {
             tarball_mem_cache: &state.tarball_mem_cache,
             http_client: &state.http_client,
@@ -152,15 +163,22 @@ impl PatchCommitArgs {
         }
         .run::<Reporter>()
         .await
-        .map_err(|source| {
-            remove_dir_if_exists(&clean_dir);
-            PatchCommitError::WritePackage(source)
+        .map_err(|source| match remove_dir_if_exists(&clean_dir) {
+            Ok(()) => PatchCommitError::WritePackage(source),
+            Err(cleanup_source) => {
+                PatchCommitError::CleanupTempDir { path: clean_dir.clone(), source: cleanup_source }
+            }
         })?;
 
         let filtered = match prepare_pkg_files_for_diff(&patch_dir) {
             Ok(filtered) => filtered,
             Err(source) => {
-                remove_dir_if_exists(&clean_dir);
+                remove_dir_if_exists(&clean_dir).map_err(|cleanup_source| {
+                    PatchCommitError::CleanupTempDir {
+                        path: clean_dir.clone(),
+                        source: cleanup_source,
+                    }
+                })?;
                 return Err(PatchCommitError::PatchCommit(source));
             }
         };
@@ -170,11 +188,11 @@ impl PatchCommitArgs {
         let patch_content = match diff_folders(&clean_dir, filtered_path) {
             Ok(patch_content) => patch_content,
             Err(source) => {
-                cleanup_after_diff(&clean_dir, &filtered);
+                cleanup_after_diff(&clean_dir, &filtered)?;
                 return Err(PatchCommitError::PatchCommit(source));
             }
         };
-        cleanup_after_diff(&clean_dir, &filtered);
+        cleanup_after_diff(&clean_dir, &filtered)?;
 
         if patch_content.is_empty() {
             println!("No changes were found to the following directory: {}", patch_dir.display());
@@ -399,18 +417,37 @@ fn clean_source_dir(state: &State, patch_dir: &Path) -> PathBuf {
     state.config.store_dir.tmp().join("patch-commit").join(hash)
 }
 
-fn cleanup_after_diff(clean_dir: &Path, filtered: &PkgFilesForDiff) {
-    remove_dir_if_exists(clean_dir);
+fn cleanup_after_diff(
+    clean_dir: &Path,
+    filtered: &PkgFilesForDiff,
+) -> Result<(), PatchCommitError> {
+    remove_dir_if_exists(clean_dir).map_err(|source| PatchCommitError::CleanupTempDir {
+        path: clean_dir.to_path_buf(),
+        source,
+    })?;
     if let PkgFilesForDiff::Temporary(path) = filtered {
-        remove_dir_if_exists(path);
+        remove_dir_if_exists(path)
+            .map_err(|source| PatchCommitError::CleanupTempDir { path: path.clone(), source })?;
     }
+    Ok(())
 }
 
-fn remove_dir_if_exists(path: &Path) {
+fn remove_dir_if_exists(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_symlink() => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "temporary directory must not be a symbolic link",
+            ));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    }
     match fs::remove_dir_all(path) {
-        Ok(()) => {}
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-        Err(_) => {}
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
     }
 }
 

--- a/pacquet/crates/cli/src/cli_args/patch_commit/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_commit/tests.rs
@@ -1,8 +1,12 @@
-use super::*;
+use super::{
+    cleanup_after_diff, normalize_patches_dir_name, patch_target_from_state,
+    path_from_forward_slash, remove_dir_if_exists,
+};
 use pacquet_lockfile::{ComVer, Lockfile, LockfileVersion, PackageKey, PackageMetadata};
+use pacquet_package_manager::PkgFilesForDiff;
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 use tempfile::tempdir;
 
 fn empty_lockfile() -> Lockfile {
@@ -102,7 +106,7 @@ fn remove_dir_if_exists_keeps_going_after_non_directory_cleanup_error() {
 
     remove_dir_if_exists(&path);
 
-    assert!(path.is_file(), "cleanup errors are reported but not fatal");
+    assert!(path.is_file(), "cleanup errors are ignored but not fatal");
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/patch_commit/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_commit/tests.rs
@@ -93,20 +93,21 @@ fn remove_dir_if_exists_removes_existing_dir() {
     let dir = tmp.path().join("patch-commit-temp");
     std::fs::create_dir(&dir).expect("create temp dir");
 
-    remove_dir_if_exists(&dir);
+    remove_dir_if_exists(&dir).expect("remove temp dir");
 
     assert!(!dir.exists(), "temp dir should be removed");
 }
 
 #[test]
-fn remove_dir_if_exists_keeps_going_after_non_directory_cleanup_error() {
+fn remove_dir_if_exists_reports_non_directory_cleanup_error() {
     let tmp = tempdir().expect("temp dir");
     let path = tmp.path().join("patch-commit-temp");
     std::fs::write(&path, "").expect("create file");
 
-    remove_dir_if_exists(&path);
+    let err = remove_dir_if_exists(&path).expect_err("file cleanup should fail");
 
     assert!(path.is_file(), "cleanup errors are ignored but not fatal");
+    assert_eq!(err.kind(), std::io::ErrorKind::NotADirectory);
 }
 
 #[test]
@@ -117,7 +118,8 @@ fn cleanup_after_diff_removes_temporary_filtered_dir() {
     std::fs::create_dir(&clean_dir).expect("create clean dir");
     std::fs::create_dir(&filtered_dir).expect("create filtered dir");
 
-    cleanup_after_diff(&clean_dir, &PkgFilesForDiff::Temporary(filtered_dir.clone()));
+    cleanup_after_diff(&clean_dir, &PkgFilesForDiff::Temporary(filtered_dir.clone()))
+        .expect("cleanup temp dirs");
 
     assert!(!clean_dir.exists(), "clean dir should be removed");
     assert!(!filtered_dir.exists(), "filtered dir should be removed");
@@ -131,7 +133,8 @@ fn cleanup_after_diff_keeps_original_patch_dir() {
     std::fs::create_dir(&clean_dir).expect("create clean dir");
     std::fs::create_dir(&patch_dir).expect("create patch dir");
 
-    cleanup_after_diff(&clean_dir, &PkgFilesForDiff::Original(patch_dir.clone()));
+    cleanup_after_diff(&clean_dir, &PkgFilesForDiff::Original(patch_dir.clone()))
+        .expect("cleanup clean dir");
 
     assert!(!clean_dir.exists(), "clean dir should be removed");
     assert!(patch_dir.exists(), "original patch dir should remain");

--- a/pacquet/crates/cli/src/cli_args/patch_commit/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_commit/tests.rs
@@ -2,6 +2,7 @@ use super::{
     cleanup_after_diff, normalize_patches_dir_name, patch_target_from_state,
     path_from_forward_slash, remove_dir_if_exists, write_patch_file_atomically,
 };
+use crate::cli_args::patch_state::EditDirState;
 use pacquet_lockfile::{ComVer, Lockfile, LockfileVersion, PackageKey, PackageMetadata};
 use pacquet_package_manager::PkgFilesForDiff;
 use pretty_assertions::assert_eq;
@@ -31,6 +32,10 @@ fn lockfile_with_packages(keys: &[&str]) -> Lockfile {
     Lockfile { packages: Some(packages), ..empty_lockfile() }
 }
 
+fn lockfile_with_package_entries(entries: Vec<(PackageKey, PackageMetadata)>) -> Lockfile {
+    Lockfile { packages: Some(entries.into_iter().collect()), ..empty_lockfile() }
+}
+
 fn registry_metadata() -> PackageMetadata {
     serde_json::from_value(json!({
         "resolution": {
@@ -40,12 +45,28 @@ fn registry_metadata() -> PackageMetadata {
     .unwrap()
 }
 
+fn git_tarball_metadata(version: &str, tarball: &str) -> PackageMetadata {
+    serde_json::from_value(json!({
+        "resolution": {
+            "tarball": tarball,
+            "gitHosted": true,
+        },
+        "version": version,
+    }))
+    .unwrap()
+}
+
 #[test]
 fn patch_target_from_state_falls_back_to_manifest_name_and_version() {
     let lockfile = lockfile_with_packages(&["foo@1.0.0"]);
+    let state = EditDirState {
+        patched_pkg: "old-name@9.9.9".to_string(),
+        apply_to_all: true,
+        package_key: None,
+    };
 
-    let target = patch_target_from_state("old-name@9.9.9", "foo", "1.0.0", true, &lockfile)
-        .expect("target from fallback");
+    let target =
+        patch_target_from_state(&state, "foo", "1.0.0", &lockfile).expect("target from fallback");
 
     assert_eq!(target.alias, "foo");
     assert_eq!(target.version, "1.0.0");
@@ -56,8 +77,13 @@ fn patch_target_from_state_falls_back_to_manifest_name_and_version() {
 #[test]
 fn patch_target_from_state_reports_missing_manifest_version() {
     let lockfile = lockfile_with_packages(&["foo@1.0.0"]);
+    let state = EditDirState {
+        patched_pkg: "old-name@9.9.9".to_string(),
+        apply_to_all: false,
+        package_key: None,
+    };
 
-    let err = patch_target_from_state("old-name@9.9.9", "foo", "2.0.0", false, &lockfile)
+    let err = patch_target_from_state(&state, "foo", "2.0.0", &lockfile)
         .expect_err("missing fallback version");
 
     assert!(err.to_string().contains("foo@2.0.0"), "error names fallback target: {err}");
@@ -66,11 +92,34 @@ fn patch_target_from_state_reports_missing_manifest_version() {
 #[test]
 fn patch_target_from_state_reports_installed_name_version_mismatch() {
     let lockfile = lockfile_with_packages(&["foo@1.0.0"]);
+    let state =
+        EditDirState { patched_pkg: "foo".to_string(), apply_to_all: false, package_key: None };
 
-    let err = patch_target_from_state("foo", "foo", "2.0.0", false, &lockfile)
+    let err = patch_target_from_state(&state, "foo", "2.0.0", &lockfile)
         .expect_err("missing selected version");
 
     assert!(err.to_string().contains("did you forget to install foo@2.0.0"), "{err}");
+}
+
+#[test]
+fn patch_target_from_state_uses_persisted_package_key_for_same_version_candidates() {
+    let git_tarball_url = "https://codeload.github.com/foo/foo/tar.gz/0123456789abcdef";
+    let git_package_key = format!("foo@{git_tarball_url}").parse::<PackageKey>().unwrap();
+    let lockfile = lockfile_with_package_entries(vec![
+        ("foo@1.0.0".parse::<PackageKey>().unwrap(), registry_metadata()),
+        (git_package_key.clone(), git_tarball_metadata("1.0.0", git_tarball_url)),
+    ]);
+    let state = EditDirState {
+        patched_pkg: "foo".to_string(),
+        apply_to_all: false,
+        package_key: Some(git_package_key.clone()),
+    };
+
+    let target =
+        patch_target_from_state(&state, "foo", "1.0.0", &lockfile).expect("target from state");
+
+    assert_eq!(target.package_key, git_package_key);
+    assert_eq!(target.git_tarball_url, Some(git_tarball_url.to_string()));
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/patch_commit/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_commit/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     cleanup_after_diff, normalize_patches_dir_name, patch_target_from_state,
-    path_from_forward_slash, remove_dir_if_exists,
+    path_from_forward_slash, remove_dir_if_exists, write_patch_file_atomically,
 };
 use pacquet_lockfile::{ComVer, Lockfile, LockfileVersion, PackageKey, PackageMetadata};
 use pacquet_package_manager::PkgFilesForDiff;
@@ -108,6 +108,17 @@ fn remove_dir_if_exists_reports_non_directory_cleanup_error() {
 
     assert!(path.is_file(), "cleanup errors are ignored but not fatal");
     assert_eq!(err.kind(), std::io::ErrorKind::NotADirectory);
+}
+
+#[test]
+fn patch_commit_atomic_writer_replaces_existing_patch_file() {
+    let tmp = tempdir().expect("temp dir");
+    let patch_file = tmp.path().join("pkg.patch");
+    std::fs::write(&patch_file, "old").expect("write old patch");
+
+    write_patch_file_atomically(&patch_file, b"new").expect("replace patch");
+
+    assert_eq!(std::fs::read_to_string(patch_file).expect("read patch"), "new");
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/patch_commit/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_commit/tests.rs
@@ -1,0 +1,142 @@
+use super::*;
+use pacquet_lockfile::{ComVer, Lockfile, LockfileVersion, PackageKey, PackageMetadata};
+use pretty_assertions::assert_eq;
+use serde_json::json;
+use std::collections::HashMap;
+use tempfile::tempdir;
+
+fn empty_lockfile() -> Lockfile {
+    Lockfile {
+        lockfile_version: LockfileVersion::<9>::try_from(ComVer { major: 9, minor: 0 }).unwrap(),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers: HashMap::new(),
+        packages: None,
+        snapshots: None,
+    }
+}
+
+fn lockfile_with_packages(keys: &[&str]) -> Lockfile {
+    let packages =
+        keys.iter().map(|key| (key.parse::<PackageKey>().unwrap(), registry_metadata())).collect();
+    Lockfile { packages: Some(packages), ..empty_lockfile() }
+}
+
+fn registry_metadata() -> PackageMetadata {
+    serde_json::from_value(json!({
+        "resolution": {
+            "integrity": "sha512-aGVsbG8=",
+        },
+    }))
+    .unwrap()
+}
+
+#[test]
+fn patch_target_from_state_falls_back_to_manifest_name_and_version() {
+    let lockfile = lockfile_with_packages(&["foo@1.0.0"]);
+
+    let target = patch_target_from_state("old-name@9.9.9", "foo", "1.0.0", true, &lockfile)
+        .expect("target from fallback");
+
+    assert_eq!(target.alias, "foo");
+    assert_eq!(target.version, "1.0.0");
+    assert_eq!(target.bare_specifier, "1.0.0");
+    assert!(target.apply_to_all);
+}
+
+#[test]
+fn patch_target_from_state_reports_missing_manifest_version() {
+    let lockfile = lockfile_with_packages(&["foo@1.0.0"]);
+
+    let err = patch_target_from_state("old-name@9.9.9", "foo", "2.0.0", false, &lockfile)
+        .expect_err("missing fallback version");
+
+    assert!(err.to_string().contains("foo@2.0.0"), "error names fallback target: {err}");
+}
+
+#[test]
+fn patch_target_from_state_reports_installed_name_version_mismatch() {
+    let lockfile = lockfile_with_packages(&["foo@1.0.0"]);
+
+    let err = patch_target_from_state("foo", "foo", "2.0.0", false, &lockfile)
+        .expect_err("missing selected version");
+
+    assert!(err.to_string().contains("did you forget to install foo@2.0.0"), "{err}");
+}
+
+#[test]
+fn normalize_patches_dir_name_removes_dot_and_parent_components() {
+    assert_eq!(normalize_patches_dir_name("./patches"), "patches");
+    assert_eq!(normalize_patches_dir_name("patches/nested/../final"), "patches/final");
+    assert_eq!(normalize_patches_dir_name("../outside"), "outside");
+    assert_eq!(normalize_patches_dir_name("."), ".");
+}
+
+#[cfg(unix)]
+#[test]
+fn normalize_patches_dir_name_ignores_root_component() {
+    assert_eq!(normalize_patches_dir_name("/tmp/patches"), "tmp/patches");
+}
+
+#[test]
+fn remove_dir_if_exists_removes_existing_dir() {
+    let tmp = tempdir().expect("temp dir");
+    let dir = tmp.path().join("patch-commit-temp");
+    std::fs::create_dir(&dir).expect("create temp dir");
+
+    remove_dir_if_exists(&dir);
+
+    assert!(!dir.exists(), "temp dir should be removed");
+}
+
+#[test]
+fn remove_dir_if_exists_keeps_going_after_non_directory_cleanup_error() {
+    let tmp = tempdir().expect("temp dir");
+    let path = tmp.path().join("patch-commit-temp");
+    std::fs::write(&path, "").expect("create file");
+
+    remove_dir_if_exists(&path);
+
+    assert!(path.is_file(), "cleanup errors are reported but not fatal");
+}
+
+#[test]
+fn cleanup_after_diff_removes_temporary_filtered_dir() {
+    let tmp = tempdir().expect("temp dir");
+    let clean_dir = tmp.path().join("clean");
+    let filtered_dir = tmp.path().join("filtered");
+    std::fs::create_dir(&clean_dir).expect("create clean dir");
+    std::fs::create_dir(&filtered_dir).expect("create filtered dir");
+
+    cleanup_after_diff(&clean_dir, &PkgFilesForDiff::Temporary(filtered_dir.clone()));
+
+    assert!(!clean_dir.exists(), "clean dir should be removed");
+    assert!(!filtered_dir.exists(), "filtered dir should be removed");
+}
+
+#[test]
+fn cleanup_after_diff_keeps_original_patch_dir() {
+    let tmp = tempdir().expect("temp dir");
+    let clean_dir = tmp.path().join("clean");
+    let patch_dir = tmp.path().join("patch");
+    std::fs::create_dir(&clean_dir).expect("create clean dir");
+    std::fs::create_dir(&patch_dir).expect("create patch dir");
+
+    cleanup_after_diff(&clean_dir, &PkgFilesForDiff::Original(patch_dir.clone()));
+
+    assert!(!clean_dir.exists(), "clean dir should be removed");
+    assert!(patch_dir.exists(), "original patch dir should remain");
+}
+
+#[test]
+fn path_from_forward_slash_builds_platform_path() {
+    assert_eq!(
+        path_from_forward_slash("patches/@scope__pkg.patch"),
+        PathBuf::from("patches").join("@scope__pkg.patch"),
+    );
+}

--- a/pacquet/crates/cli/src/cli_args/patch_remove.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_remove.rs
@@ -1,0 +1,338 @@
+use crate::State;
+use clap::Args;
+use derive_more::{Display, Error};
+use dialoguer::MultiSelect;
+use indexmap::IndexMap;
+use miette::Diagnostic;
+use pacquet_fs::{is_subdir, lexical_normalize};
+use pacquet_workspace_manifest_writer::UpdateWorkspaceManifestError;
+use std::{
+    fs, io,
+    path::{Component, Path, PathBuf},
+};
+
+#[derive(Debug, Args)]
+pub struct PatchRemoveArgs {
+    /// Patches to remove from patchedDependencies.
+    #[clap(value_name = "pkg")]
+    pub patches: Vec<String>,
+}
+
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum PatchRemoveError {
+    #[display("There are no patches that need to be removed")]
+    #[diagnostic(code(ERR_PNPM_NO_PATCHES_TO_REMOVE))]
+    NoPatchesToRemove,
+
+    #[display("Canceled")]
+    #[diagnostic(code(ERR_PNPM_PATCH_REMOVE_CANCELED))]
+    Canceled,
+
+    #[display("Patch \"{patch}\" not found in patched dependencies")]
+    #[diagnostic(code(ERR_PNPM_PATCH_NOT_FOUND))]
+    PatchNotFound { patch: String },
+
+    #[display("The configured patches directory is outside the project: {patches_dir}")]
+    #[diagnostic(code(ERR_PNPM_PATCHES_DIR_OUTSIDE_PROJECT))]
+    PatchesDirOutsideProject { patches_dir: String },
+
+    #[display("Patch file \"{patch_file}\" is outside the configured patches directory")]
+    #[diagnostic(code(ERR_PNPM_PATCH_FILE_OUTSIDE_PATCHES_DIR))]
+    PatchFileOutsidePatchesDir { patch_file: String },
+
+    #[display("Patch file \"{patch_file}\" is a directory")]
+    #[diagnostic(code(ERR_PNPM_PATCH_FILE_IS_DIRECTORY))]
+    PatchFileIsDirectory { patch_file: String },
+
+    #[display("Failed to remove patch file {}: {source}", path.display())]
+    #[diagnostic(code(pacquet::patch_remove_unlink_patch_file))]
+    RemovePatchFile {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display("Failed to read patch directory {}: {source}", path.display())]
+    #[diagnostic(code(pacquet::patch_remove_read_patch_dir))]
+    ReadPatchDir {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display("Failed to remove empty patch directory {}: {source}", path.display())]
+    #[diagnostic(code(pacquet::patch_remove_remove_patch_dir))]
+    RemovePatchDir {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[diagnostic(transparent)]
+    UpdateWorkspaceManifest(#[error(source)] UpdateWorkspaceManifestError),
+}
+
+impl PatchRemoveArgs {
+    pub async fn run(self, dir: &Path, state: State) -> Result<bool, PatchRemoveError> {
+        let mut patched_dependencies =
+            state.config.patched_dependencies.clone().unwrap_or_default();
+        let patches_to_remove =
+            patches_to_remove(self.patches, &patched_dependencies, &DialoguerPatchRemovePrompt)?;
+        for patch in &patches_to_remove {
+            if !patched_dependencies.contains_key(patch) {
+                return Err(PatchRemoveError::PatchNotFound { patch: patch.clone() });
+            }
+        }
+
+        let lockfile_dir = state.config.workspace_dir.clone().unwrap_or_else(|| dir.to_path_buf());
+        let ctx = PatchRemovalContext::new(
+            &lockfile_dir,
+            state.config.patches_dir.as_deref().unwrap_or("patches"),
+        )?;
+        let targets = patches_to_remove
+            .iter()
+            .map(|patch| {
+                let patch_file = patched_dependencies
+                    .get(patch)
+                    .ok_or_else(|| PatchRemoveError::PatchNotFound { patch: patch.clone() })?;
+                PatchRemovalTarget::new(patch, patch_file, &ctx)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        for target in &targets {
+            unlink_patch_if_exists(target)?;
+        }
+        for target in &targets {
+            patched_dependencies.shift_remove(&target.patch);
+        }
+        remove_empty_patch_dirs(&targets)?;
+
+        pacquet_workspace_manifest_writer::set_patched_dependencies(
+            &lockfile_dir,
+            &patched_dependencies,
+        )
+        .map_err(PatchRemoveError::UpdateWorkspaceManifest)?;
+
+        Ok(true)
+    }
+}
+
+fn patches_to_remove(
+    patches: Vec<String>,
+    patched_dependencies: &IndexMap<String, String>,
+    prompt: &impl PatchRemovePrompt,
+) -> Result<Vec<String>, PatchRemoveError> {
+    if !patches.is_empty() {
+        return Ok(patches);
+    }
+    if patched_dependencies.is_empty() {
+        return Err(PatchRemoveError::NoPatchesToRemove);
+    }
+    let all_patches: Vec<String> = patched_dependencies.keys().cloned().collect();
+    prompt.select_patches(&all_patches).and_then(|selected| {
+        if selected.is_empty() { Err(PatchRemoveError::NoPatchesToRemove) } else { Ok(selected) }
+    })
+}
+
+trait PatchRemovePrompt {
+    fn select_patches(&self, patches: &[String]) -> Result<Vec<String>, PatchRemoveError>;
+}
+
+struct DialoguerPatchRemovePrompt;
+
+impl PatchRemovePrompt for DialoguerPatchRemovePrompt {
+    fn select_patches(&self, patches: &[String]) -> Result<Vec<String>, PatchRemoveError> {
+        select_patches_from_indices(patches, dialoguer_select_patch_indices)
+    }
+}
+
+fn dialoguer_select_patch_indices(patches: &[String]) -> Result<Vec<usize>, PatchRemoveError> {
+    MultiSelect::new()
+        .with_prompt("Select the patch to be removed")
+        .items(patches)
+        .interact()
+        .map_err(|_| PatchRemoveError::Canceled)
+}
+
+fn select_patches_from_indices(
+    patches: &[String],
+    select_indices: impl FnOnce(&[String]) -> Result<Vec<usize>, PatchRemoveError>,
+) -> Result<Vec<String>, PatchRemoveError> {
+    select_indices(patches)
+        .map(|selected_indices| patches_from_selected_indices(patches, selected_indices))
+}
+
+fn patches_from_selected_indices(patches: &[String], selected_indices: Vec<usize>) -> Vec<String> {
+    selected_indices.into_iter().map(|index| patches[index].clone()).collect()
+}
+
+struct PatchRemovalContext {
+    project_root: PathBuf,
+    patches_dir: PathBuf,
+    real_patches_dir: Option<PathBuf>,
+}
+
+impl PatchRemovalContext {
+    fn new(lockfile_dir: &Path, patches_dir_setting: &str) -> Result<Self, PatchRemoveError> {
+        let project_root = lexical_normalize(lockfile_dir);
+        let real_project_root =
+            dunce::canonicalize(&project_root).unwrap_or_else(|_| project_root.clone());
+        let patches_dir = join_setting_path(&project_root, patches_dir_setting);
+        if !is_subdir(&project_root, &patches_dir) {
+            return Err(PatchRemoveError::PatchesDirOutsideProject {
+                patches_dir: patches_dir_setting.to_string(),
+            });
+        }
+        let real_patches_dir = realpath_if_exists(&patches_dir);
+        if real_patches_dir.as_ref().is_some_and(|real| !is_subdir(&real_project_root, real)) {
+            return Err(PatchRemoveError::PatchesDirOutsideProject {
+                patches_dir: patches_dir_setting.to_string(),
+            });
+        }
+        Ok(Self { project_root, patches_dir, real_patches_dir })
+    }
+}
+
+struct PatchRemovalTarget {
+    patch: String,
+    parent_dir: PathBuf,
+    target_path: PathBuf,
+    target_exists: bool,
+}
+
+impl PatchRemovalTarget {
+    fn new(
+        patch: &str,
+        patch_file: &str,
+        ctx: &PatchRemovalContext,
+    ) -> Result<Self, PatchRemoveError> {
+        let target_path = resolve_path(&ctx.project_root, Path::new(patch_file));
+        if target_path == ctx.patches_dir || !is_subdir(&ctx.patches_dir, &target_path) {
+            return Err(PatchRemoveError::PatchFileOutsidePatchesDir {
+                patch_file: patch_file.to_string(),
+            });
+        }
+
+        let parent_dir = target_path.parent().map_or_else(PathBuf::new, Path::to_path_buf);
+        let target_stats = lstat_if_exists(&target_path)?;
+        let real_parent_dir = realpath_if_exists(&parent_dir);
+        let real_patches_dir =
+            ctx.real_patches_dir.clone().or_else(|| realpath_if_exists(&ctx.patches_dir));
+        if let (Some(real_parent_dir), Some(real_patches_dir)) = (real_parent_dir, real_patches_dir)
+            && !is_subdir(&real_patches_dir, &real_parent_dir)
+        {
+            return Err(PatchRemoveError::PatchFileOutsidePatchesDir {
+                patch_file: patch_file.to_string(),
+            });
+        }
+        if target_stats.as_ref().is_some_and(fs::Metadata::is_dir) {
+            return Err(PatchRemoveError::PatchFileIsDirectory {
+                patch_file: patch_file.to_string(),
+            });
+        }
+
+        Ok(Self {
+            patch: patch.to_string(),
+            parent_dir,
+            target_path,
+            target_exists: target_stats.is_some(),
+        })
+    }
+}
+
+fn join_setting_path(base: &Path, setting: &str) -> PathBuf {
+    let mut joined = base.to_path_buf();
+    for component in Path::new(setting).components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => {}
+            Component::CurDir => {}
+            Component::ParentDir => joined.push(".."),
+            Component::Normal(part) => joined.push(part),
+        }
+    }
+    lexical_normalize(&joined)
+}
+
+fn resolve_path(base: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() { lexical_normalize(path) } else { lexical_normalize(&base.join(path)) }
+}
+
+fn lstat_if_exists(path: &Path) -> Result<Option<fs::Metadata>, PatchRemoveError> {
+    match fs::symlink_metadata(path) {
+        Ok(meta) => Ok(Some(meta)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(PatchRemoveError::ReadPatchDir {
+            path: path.parent().map_or_else(PathBuf::new, Path::to_path_buf),
+            source,
+        }),
+    }
+}
+
+fn realpath_if_exists(path: &Path) -> Option<PathBuf> {
+    dunce::canonicalize(path).ok()
+}
+
+fn unlink_patch_if_exists(target: &PatchRemovalTarget) -> Result<(), PatchRemoveError> {
+    if !target.target_exists {
+        return Ok(());
+    }
+    match fs::remove_file(&target.target_path) {
+        Ok(()) => Ok(()),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(source) => {
+            Err(PatchRemoveError::RemovePatchFile { path: target.target_path.clone(), source })
+        }
+    }
+}
+
+fn remove_empty_patch_dirs(targets: &[PatchRemovalTarget]) -> Result<(), PatchRemoveError> {
+    remove_empty_patch_dirs_with_fs(targets, &RealPatchRemoveFs)
+}
+
+fn remove_empty_patch_dirs_with_fs(
+    targets: &[PatchRemovalTarget],
+    fs_ops: &impl PatchRemoveFs,
+) -> Result<(), PatchRemoveError> {
+    for target in targets {
+        match fs_ops.is_dir_empty(&target.parent_dir) {
+            Ok(true) => {
+                if let Err(source) = fs_ops.remove_dir(&target.parent_dir) {
+                    return Err(PatchRemoveError::RemovePatchDir {
+                        path: target.parent_dir.clone(),
+                        source,
+                    });
+                }
+            }
+            Ok(false) => {}
+            Err(source) if source.kind() == io::ErrorKind::NotFound => {}
+            Err(source) => {
+                return Err(PatchRemoveError::ReadPatchDir {
+                    path: target.parent_dir.clone(),
+                    source,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+trait PatchRemoveFs {
+    fn is_dir_empty(&self, path: &Path) -> io::Result<bool>;
+    fn remove_dir(&self, path: &Path) -> io::Result<()>;
+}
+
+struct RealPatchRemoveFs;
+
+impl PatchRemoveFs for RealPatchRemoveFs {
+    fn is_dir_empty(&self, path: &Path) -> io::Result<bool> {
+        fs::read_dir(path).map(|mut entries| entries.next().is_none())
+    }
+
+    fn remove_dir(&self, path: &Path) -> io::Result<()> {
+        fs::remove_dir(path)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/patch_remove.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_remove.rs
@@ -7,6 +7,7 @@ use miette::Diagnostic;
 use pacquet_fs::{is_subdir, lexical_normalize};
 use pacquet_workspace_manifest_writer::UpdateWorkspaceManifestError;
 use std::{
+    collections::HashSet,
     fs, io,
     path::{Component, Path, PathBuf},
 };
@@ -99,9 +100,19 @@ impl PatchRemoveArgs {
                 PatchRemovalTarget::new(patch, patch_file, &ctx)
             })
             .collect::<Result<Vec<_>, _>>()?;
+        let removed_patches: HashSet<&String> = patches_to_remove.iter().collect();
+        let remaining_patch_files = patched_dependencies
+            .iter()
+            .filter(|(patch, _)| !removed_patches.contains(patch))
+            .map(|(patch, patch_file)| {
+                PatchRemovalTarget::new(patch, patch_file, &ctx).map(|target| target.target_path)
+            })
+            .collect::<Result<HashSet<_>, _>>()?;
 
         for target in &targets {
-            unlink_patch_if_exists(target)?;
+            if !remaining_patch_files.contains(&target.target_path) {
+                unlink_patch_if_exists(target)?;
+            }
         }
         for target in &targets {
             patched_dependencies.shift_remove(&target.patch);

--- a/pacquet/crates/cli/src/cli_args/patch_remove/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_remove/tests.rs
@@ -1,4 +1,11 @@
-use super::*;
+use super::{
+    DialoguerPatchRemovePrompt, PatchRemovalContext, PatchRemovalTarget, PatchRemoveArgs,
+    PatchRemoveError, PatchRemoveFs, PatchRemovePrompt, join_setting_path,
+    patches_from_selected_indices, patches_to_remove, remove_empty_patch_dirs,
+    remove_empty_patch_dirs_with_fs, select_patches_from_indices, unlink_patch_if_exists,
+};
+use crate::State;
+use indexmap::IndexMap;
 use std::{io::IsTerminal, path::Path};
 
 #[test]
@@ -76,9 +83,7 @@ fn select_patches_from_indices_maps_selected_indices() {
 
 #[test]
 fn dialoguer_prompt_reports_cancellation_when_stdin_is_not_interactive() {
-    if std::io::stdin().is_terminal() {
-        return;
-    }
+    assert!(!std::io::stdin().is_terminal(), "test requires non-interactive stdin");
 
     let prompt = DialoguerPatchRemovePrompt;
     let err = prompt.select_patches(&["pkg".to_string()]).expect_err("prompt should cancel");

--- a/pacquet/crates/cli/src/cli_args/patch_remove/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_remove/tests.rs
@@ -1,0 +1,345 @@
+use super::*;
+use std::{io::IsTerminal, path::Path};
+
+#[test]
+fn explicit_patch_args_skip_prompt() {
+    let selected = patches_to_remove(
+        vec!["pkg".to_string()],
+        &IndexMap::new(),
+        &FakePrompt { selected: vec![], called: std::cell::Cell::new(false) },
+    )
+    .expect("selected patches");
+
+    assert_eq!(selected, vec!["pkg"]);
+}
+
+#[test]
+fn empty_patch_args_prompt_for_available_patches() {
+    let patched_dependencies =
+        IndexMap::from([("pkg".to_string(), "patches/pkg.patch".to_string())]);
+    let prompt =
+        FakePrompt { selected: vec!["pkg".to_string()], called: std::cell::Cell::new(false) };
+
+    let selected =
+        patches_to_remove(Vec::new(), &patched_dependencies, &prompt).expect("selected patch");
+
+    assert_eq!(selected, vec!["pkg"]);
+    assert!(prompt.called.get());
+}
+
+#[test]
+fn empty_patch_args_without_patches_errors() {
+    let err = patches_to_remove(
+        Vec::new(),
+        &IndexMap::new(),
+        &FakePrompt { selected: vec![], called: std::cell::Cell::new(false) },
+    )
+    .expect_err("no patches should error");
+
+    assert!(matches!(err, PatchRemoveError::NoPatchesToRemove));
+}
+
+#[test]
+fn empty_prompt_selection_is_treated_as_no_patches_to_remove() {
+    let patched_dependencies =
+        IndexMap::from([("pkg".to_string(), "patches/pkg.patch".to_string())]);
+
+    let err = patches_to_remove(
+        Vec::new(),
+        &patched_dependencies,
+        &FakePrompt { selected: vec![], called: std::cell::Cell::new(false) },
+    )
+    .expect_err("empty prompt selection should error");
+
+    assert!(matches!(err, PatchRemoveError::NoPatchesToRemove));
+}
+
+#[test]
+fn selected_prompt_indices_are_mapped_to_patch_names() {
+    let patches = vec!["first".to_string(), "second".to_string(), "third".to_string()];
+
+    assert_eq!(
+        patches_from_selected_indices(&patches, vec![2, 0]),
+        vec!["third".to_string(), "first".to_string()],
+    );
+}
+
+#[test]
+fn select_patches_from_indices_maps_selected_indices() {
+    let patches = vec!["first".to_string(), "second".to_string(), "third".to_string()];
+
+    let selected = select_patches_from_indices(&patches, |_| Ok(vec![1, 2]))
+        .expect("selected patches from indices");
+
+    assert_eq!(selected, vec!["second".to_string(), "third".to_string()]);
+}
+
+#[test]
+fn dialoguer_prompt_reports_cancellation_when_stdin_is_not_interactive() {
+    if std::io::stdin().is_terminal() {
+        return;
+    }
+
+    let prompt = DialoguerPatchRemovePrompt;
+    let err = prompt.select_patches(&["pkg".to_string()]).expect_err("prompt should cancel");
+
+    assert!(matches!(err, PatchRemoveError::Canceled));
+}
+
+#[test]
+fn patch_removal_context_rejects_patches_dir_outside_project() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+
+    let Err(err) = PatchRemovalContext::new(tmp.path(), "../patches") else {
+        panic!("outside patches dir should error");
+    };
+
+    assert!(matches!(err, PatchRemoveError::PatchesDirOutsideProject { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn patch_removal_context_rejects_real_patches_dir_symlink_outside_project() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let project = tmp.path().join("project");
+    let outside = tmp.path().join("outside");
+    std::fs::create_dir_all(&project).expect("create project");
+    std::fs::create_dir_all(&outside).expect("create outside");
+    std::os::unix::fs::symlink(&outside, project.join("patches")).expect("symlink patches dir");
+
+    let Err(err) = PatchRemovalContext::new(&project, "patches") else {
+        panic!("symlinked outside patches dir should error");
+    };
+
+    assert!(matches!(err, PatchRemoveError::PatchesDirOutsideProject { .. }));
+}
+
+#[tokio::test]
+async fn run_rejects_configured_patches_dir_outside_project() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    std::fs::write(tmp.path().join("package.json"), "{}").expect("write package.json");
+
+    let mut config = pacquet_config::Config::new();
+    config.workspace_dir = Some(tmp.path().to_path_buf());
+    config.patches_dir = Some("../patches".to_string());
+    config.patched_dependencies =
+        Some(IndexMap::from([("pkg@1.0.0".to_string(), "patches/pkg.patch".to_string())]));
+    let config: &'static pacquet_config::Config = Box::leak(Box::new(config));
+    let state = State {
+        tarball_mem_cache: std::sync::Arc::new(pacquet_tarball::MemCache::default()),
+        http_client: std::sync::Arc::new(pacquet_network::ThrottledClient::default()),
+        config,
+        manifest: pacquet_package_manifest::PackageManifest::from_path(
+            tmp.path().join("package.json"),
+        )
+        .expect("package manifest"),
+        lockfile: pacquet_lockfile::LazyLockfile::disabled(),
+        resolved_packages: pacquet_package_manager::ResolvedPackages::new(),
+    };
+
+    let err = PatchRemoveArgs { patches: vec!["pkg@1.0.0".to_string()] }
+        .run(tmp.path(), state)
+        .await
+        .expect_err("outside patches dir should error");
+
+    assert!(matches!(err, PatchRemoveError::PatchesDirOutsideProject { .. }));
+}
+
+#[test]
+fn patch_removal_target_rejects_patch_file_outside_patches_dir() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let ctx = PatchRemovalContext::new(tmp.path(), "patches").expect("context");
+
+    let Err(err) = PatchRemovalTarget::new("pkg", "other/pkg.patch", &ctx) else {
+        panic!("patch file outside patches dir should error");
+    };
+
+    assert!(matches!(err, PatchRemoveError::PatchFileOutsidePatchesDir { .. }));
+}
+
+#[test]
+fn patch_removal_target_rejects_directory_entries() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let patches = tmp.path().join("patches");
+    std::fs::create_dir_all(patches.join("pkg.patch")).expect("create directory patch target");
+    let ctx = PatchRemovalContext::new(tmp.path(), "patches").expect("context");
+
+    let Err(err) = PatchRemovalTarget::new("pkg", "patches/pkg.patch", &ctx) else {
+        panic!("directory patch target should error");
+    };
+
+    assert!(matches!(err, PatchRemoveError::PatchFileIsDirectory { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn patch_removal_target_reports_lstat_errors() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let patches = tmp.path().join("patches");
+    std::fs::create_dir_all(&patches).expect("create patches dir");
+    std::fs::write(patches.join("not-a-dir"), "file").expect("write file parent");
+    let ctx = PatchRemovalContext::new(tmp.path(), "patches").expect("context");
+
+    let Err(err) = PatchRemovalTarget::new("pkg", "patches/not-a-dir/pkg.patch", &ctx) else {
+        panic!("non-directory parent should error");
+    };
+
+    assert!(matches!(err, PatchRemoveError::ReadPatchDir { .. }));
+}
+
+#[test]
+fn join_setting_path_ignores_root_and_current_dir_components() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+
+    assert_eq!(
+        join_setting_path(tmp.path(), "./patches/./nested"),
+        tmp.path().join("patches").join("nested"),
+    );
+
+    #[cfg(unix)]
+    assert_eq!(join_setting_path(tmp.path(), "/patches"), tmp.path().join("patches"));
+}
+
+#[test]
+fn unlink_patch_if_exists_ignores_missing_existing_target() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let target = PatchRemovalTarget {
+        patch: "pkg".to_string(),
+        parent_dir: tmp.path().join("patches"),
+        target_path: tmp.path().join("patches/pkg.patch"),
+        target_exists: true,
+    };
+
+    unlink_patch_if_exists(&target).expect("missing target is ignored");
+}
+
+#[test]
+fn unlink_patch_if_exists_reports_remove_errors() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let target_path = tmp.path().join("patches/pkg.patch");
+    std::fs::create_dir_all(&target_path).expect("create directory at target path");
+    let target = PatchRemovalTarget {
+        patch: "pkg".to_string(),
+        parent_dir: tmp.path().join("patches"),
+        target_path,
+        target_exists: true,
+    };
+
+    let err = unlink_patch_if_exists(&target).expect_err("directory target should fail to unlink");
+
+    assert!(matches!(err, PatchRemoveError::RemovePatchFile { .. }));
+}
+
+#[test]
+fn remove_empty_patch_dirs_removes_empty_dirs_and_ignores_missing_dirs() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let empty = tmp.path().join("patches").join("nested");
+    std::fs::create_dir_all(&empty).expect("create empty patch dir");
+    let missing = tmp.path().join("patches").join("missing");
+
+    remove_empty_patch_dirs(&[
+        PatchRemovalTarget {
+            patch: "empty".to_string(),
+            parent_dir: empty.clone(),
+            target_path: empty.join("pkg.patch"),
+            target_exists: false,
+        },
+        PatchRemovalTarget {
+            patch: "missing".to_string(),
+            parent_dir: missing,
+            target_path: tmp.path().join("patches/missing/pkg.patch"),
+            target_exists: false,
+        },
+    ])
+    .expect("remove empty dirs");
+
+    assert!(!empty.exists(), "empty patch dir should be removed");
+}
+
+#[test]
+fn remove_empty_patch_dirs_reports_read_errors() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let parent = tmp.path().join("patches");
+    std::fs::write(&parent, "not a directory").expect("write file parent");
+
+    let err = remove_empty_patch_dirs(&[PatchRemovalTarget {
+        patch: "pkg".to_string(),
+        parent_dir: parent,
+        target_path: tmp.path().join("patches/pkg.patch"),
+        target_exists: false,
+    }])
+    .expect_err("file parent should error");
+
+    assert!(matches!(err, PatchRemoveError::ReadPatchDir { .. }));
+}
+
+#[test]
+fn remove_empty_patch_dirs_reports_remove_errors() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let empty = tmp.path().join("patches").join("nested");
+
+    let result = remove_empty_patch_dirs_with_fs(
+        &[PatchRemovalTarget {
+            patch: "pkg".to_string(),
+            parent_dir: empty.clone(),
+            target_path: empty.join("pkg.patch"),
+            target_exists: false,
+        }],
+        &RemoveDirErrorFs,
+    );
+
+    assert!(matches!(result, Err(PatchRemoveError::RemovePatchDir { .. })));
+}
+
+#[test]
+fn remove_empty_patch_dirs_keeps_non_empty_dirs() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let parent = tmp.path().join("patches").join("nested");
+
+    remove_empty_patch_dirs_with_fs(
+        &[PatchRemovalTarget {
+            patch: "pkg".to_string(),
+            parent_dir: parent.clone(),
+            target_path: parent.join("pkg.patch"),
+            target_exists: false,
+        }],
+        &NonEmptyDirFs,
+    )
+    .expect("keep non-empty dir");
+}
+
+struct FakePrompt {
+    selected: Vec<String>,
+    called: std::cell::Cell<bool>,
+}
+
+impl PatchRemovePrompt for FakePrompt {
+    fn select_patches(&self, _patches: &[String]) -> Result<Vec<String>, PatchRemoveError> {
+        self.called.set(true);
+        Ok(self.selected.clone())
+    }
+}
+
+struct RemoveDirErrorFs;
+
+impl PatchRemoveFs for RemoveDirErrorFs {
+    fn is_dir_empty(&self, _path: &Path) -> std::io::Result<bool> {
+        Ok(true)
+    }
+
+    fn remove_dir(&self, _path: &Path) -> std::io::Result<()> {
+        Err(std::io::Error::new(std::io::ErrorKind::PermissionDenied, "blocked remove_dir"))
+    }
+}
+
+struct NonEmptyDirFs;
+
+impl PatchRemoveFs for NonEmptyDirFs {
+    fn is_dir_empty(&self, _path: &Path) -> std::io::Result<bool> {
+        Ok(false)
+    }
+
+    fn remove_dir(&self, _path: &Path) -> std::io::Result<()> {
+        panic!("non-empty dirs should not be removed")
+    }
+}

--- a/pacquet/crates/cli/src/cli_args/patch_remove/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_remove/tests.rs
@@ -150,6 +150,42 @@ async fn run_rejects_configured_patches_dir_outside_project() {
     assert!(matches!(err, PatchRemoveError::PatchesDirOutsideProject { .. }));
 }
 
+#[tokio::test]
+async fn run_keeps_patch_file_still_used_by_remaining_entries() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    std::fs::write(tmp.path().join("package.json"), "{}").expect("write package.json");
+    let patch_file = tmp.path().join("patches/shared.patch");
+    std::fs::create_dir_all(patch_file.parent().expect("patch parent"))
+        .expect("create patches dir");
+    std::fs::write(&patch_file, "shared patch").expect("write shared patch");
+
+    let mut config = pacquet_config::Config::new();
+    config.workspace_dir = Some(tmp.path().to_path_buf());
+    config.patched_dependencies = Some(IndexMap::from([
+        ("first@1.0.0".to_string(), "patches/shared.patch".to_string()),
+        ("second@1.0.0".to_string(), "patches/shared.patch".to_string()),
+    ]));
+    let config: &'static pacquet_config::Config = Box::leak(Box::new(config));
+    let state = State {
+        tarball_mem_cache: std::sync::Arc::new(pacquet_tarball::MemCache::default()),
+        http_client: std::sync::Arc::new(pacquet_network::ThrottledClient::default()),
+        config,
+        manifest: pacquet_package_manifest::PackageManifest::from_path(
+            tmp.path().join("package.json"),
+        )
+        .expect("package manifest"),
+        lockfile: pacquet_lockfile::LazyLockfile::disabled(),
+        resolved_packages: pacquet_package_manager::ResolvedPackages::new(),
+    };
+
+    PatchRemoveArgs { patches: vec!["first@1.0.0".to_string()] }
+        .run(tmp.path(), state)
+        .await
+        .expect("remove first patch entry");
+
+    assert_eq!(std::fs::read_to_string(&patch_file).expect("shared patch file"), "shared patch");
+}
+
 #[test]
 fn patch_removal_target_rejects_patch_file_outside_patches_dir() {
     let tmp = tempfile::tempdir().expect("temp dir");

--- a/pacquet/crates/cli/src/cli_args/patch_state.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_state.rs
@@ -13,6 +13,7 @@ use std::{
 
 const STATE_DIR: &str = ".pnpm_patches";
 const STATE_FILE: &str = "state.json";
+pub(crate) const MAX_STATE_FILE_BYTES: usize = 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct EditDirState {
@@ -61,6 +62,10 @@ pub(crate) enum StateFileError {
     #[diagnostic(code(pacquet::patch_state_unsafe_path))]
     UnsafePath { path: PathBuf, reason: &'static str },
 
+    #[display("Patch state file {path:?} is larger than {limit} bytes")]
+    #[diagnostic(code(pacquet::patch_state_file_too_large))]
+    StateFileTooLarge { path: PathBuf, limit: usize },
+
     #[display("Failed to resolve patch edit directory {path:?}: {source}")]
     #[diagnostic(code(pacquet::patch_state_resolve_edit_dir))]
     ResolveEditDir {
@@ -75,11 +80,7 @@ pub(crate) fn read_edit_dir_state(
     edit_dir: &Path,
 ) -> Result<Option<EditDirState>, StateFileError> {
     let path = checked_state_file_path_for_read(modules_dir)?;
-    let text = match fs::read_to_string(&path) {
-        Ok(text) => text,
-        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(None),
-        Err(source) => return Err(StateFileError::Read { path, source }),
-    };
+    let Some(text) = read_state_file_text(&path)? else { return Ok(None) };
     let state: BTreeMap<String, EditDirState> = serde_json::from_str(&text)
         .map_err(|source| StateFileError::Parse { path: path.clone(), source })?;
     let key = edit_dir_key(edit_dir)?;
@@ -104,13 +105,32 @@ pub(crate) fn write_edit_dir_state(
 fn read_state_file_for_write(
     path: &Path,
 ) -> Result<BTreeMap<String, EditDirState>, StateFileError> {
-    let text = match fs::read_to_string(path) {
-        Ok(text) => text,
-        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
-        Err(source) => return Err(StateFileError::Read { path: path.to_path_buf(), source }),
-    };
+    let Some(text) = read_state_file_text(path)? else { return Ok(BTreeMap::new()) };
     serde_json::from_str(&text)
         .map_err(|source| StateFileError::Parse { path: path.to_path_buf(), source })
+}
+
+fn read_state_file_text(path: &Path) -> Result<Option<String>, StateFileError> {
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(StateFileError::Read { path: path.to_path_buf(), source }),
+    };
+    if !metadata.is_file() {
+        return Err(StateFileError::Read {
+            path: path.to_path_buf(),
+            source: io::Error::new(io::ErrorKind::InvalidData, "state path is not a file"),
+        });
+    }
+    if metadata.len() > MAX_STATE_FILE_BYTES as u64 {
+        return Err(StateFileError::StateFileTooLarge {
+            path: path.to_path_buf(),
+            limit: MAX_STATE_FILE_BYTES,
+        });
+    }
+    fs::read_to_string(path)
+        .map(Some)
+        .map_err(|source| StateFileError::Read { path: path.to_path_buf(), source })
 }
 
 fn state_file_path(modules_dir: &Path) -> PathBuf {

--- a/pacquet/crates/cli/src/cli_args/patch_state.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_state.rs
@@ -4,11 +4,9 @@ use pacquet_fs::{is_subdir, lexical_normalize};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
-    env,
-    fs::{self, OpenOptions},
+    env, fs,
     io::{self, Write},
     path::{Path, PathBuf},
-    sync::atomic::{AtomicU64, Ordering},
 };
 
 const STATE_DIR: &str = ".pnpm_patches";
@@ -182,44 +180,12 @@ fn reject_state_symlink_if_exists(path: &Path) -> Result<(), StateFileError> {
 }
 
 fn write_state_file_atomically(target: &Path, content: &[u8]) -> io::Result<()> {
-    const MAX_TEMP_ATTEMPTS: usize = 16;
-
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let pid = std::process::id();
     let parent = target.parent().unwrap_or_else(|| Path::new("."));
-    let file_name = target
-        .file_name()
-        .map_or_else(|| String::from("state.json"), |name| name.to_string_lossy().into_owned());
-
-    let mut last_already_exists = None;
-    for _ in 0..MAX_TEMP_ATTEMPTS {
-        let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let tmp = parent.join(format!(".{file_name}.{pid}.{counter}.pacquet-tmp"));
-        let mut file = match OpenOptions::new().write(true).create_new(true).open(&tmp) {
-            Ok(file) => file,
-            Err(source) if source.kind() == io::ErrorKind::AlreadyExists => {
-                last_already_exists = Some(source);
-                continue;
-            }
-            Err(source) => return Err(source),
-        };
-        if let Err(source) = file.write_all(content) {
-            drop(file);
-            let _ = fs::remove_file(&tmp);
-            return Err(source);
-        }
-        drop(file);
-        return fs::rename(&tmp, target).inspect_err(|_| {
-            let _ = fs::remove_file(&tmp);
-        });
-    }
-
-    Err(last_already_exists.unwrap_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::AlreadyExists,
-            "exhausted temp-path attempts for atomic patch state write",
-        )
-    }))
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+    tmp.write_all(content)?;
+    tmp.as_file().sync_all()?;
+    tmp.persist(target).map_err(|error| error.error)?;
+    Ok(())
 }
 
 fn edit_dir_key(edit_dir: &Path) -> Result<String, StateFileError> {

--- a/pacquet/crates/cli/src/cli_args/patch_state.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_state.rs
@@ -1,6 +1,7 @@
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_fs::{is_subdir, lexical_normalize};
+use pacquet_lockfile::PackageKey;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
@@ -19,6 +20,8 @@ pub(crate) struct EditDirState {
     pub(crate) patched_pkg: String,
     #[serde(rename = "applyToAll")]
     pub(crate) apply_to_all: bool,
+    #[serde(rename = "packageKey", default, skip_serializing_if = "Option::is_none")]
+    pub(crate) package_key: Option<PackageKey>,
 }
 
 #[derive(Debug, Display, Error, Diagnostic)]

--- a/pacquet/crates/cli/src/cli_args/patch_state.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_state.rs
@@ -1,0 +1,139 @@
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pacquet_fs::lexical_normalize;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeMap,
+    env, fs, io,
+    path::{Path, PathBuf},
+};
+
+const STATE_DIR: &str = ".pnpm_patches";
+const STATE_FILE: &str = "state.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct EditDirState {
+    #[serde(rename = "patchedPkg")]
+    pub(crate) patched_pkg: String,
+    #[serde(rename = "applyToAll")]
+    pub(crate) apply_to_all: bool,
+}
+
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub(crate) enum StateFileError {
+    #[display("Failed to read patch state file {path:?}: {source}")]
+    #[diagnostic(code(pacquet::patch_state_read))]
+    Read {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display("Failed to parse patch state file {path:?}: {source}")]
+    #[diagnostic(code(pacquet::patch_state_parse))]
+    Parse {
+        path: PathBuf,
+        #[error(source)]
+        source: serde_json::Error,
+    },
+
+    #[display("Failed to serialize patch state file {path:?}: {source}")]
+    #[diagnostic(code(pacquet::patch_state_serialize))]
+    Serialize {
+        path: PathBuf,
+        #[error(source)]
+        source: serde_json::Error,
+    },
+
+    #[display("Failed to write patch state file {path:?}: {source}")]
+    #[diagnostic(code(pacquet::patch_state_write))]
+    Write {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display("Failed to resolve patch edit directory {path:?}: {source}")]
+    #[diagnostic(code(pacquet::patch_state_resolve_edit_dir))]
+    ResolveEditDir {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+}
+
+pub(crate) fn read_edit_dir_state(
+    modules_dir: &Path,
+    edit_dir: &Path,
+) -> Result<Option<EditDirState>, StateFileError> {
+    let path = state_file_path(modules_dir);
+    let text = match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(StateFileError::Read { path, source }),
+    };
+    let state: BTreeMap<String, EditDirState> = serde_json::from_str(&text)
+        .map_err(|source| StateFileError::Parse { path: path.clone(), source })?;
+    let key = edit_dir_key(edit_dir)?;
+    Ok(state.get(&key).cloned())
+}
+
+pub(crate) fn write_edit_dir_state(
+    modules_dir: &Path,
+    edit_dir: &Path,
+    edit_dir_state: &EditDirState,
+) -> Result<(), StateFileError> {
+    let path = state_file_path(modules_dir);
+    let mut state = read_state_file_for_write(&path)?;
+    state.insert(edit_dir_key(edit_dir)?, edit_dir_state.clone());
+
+    let text = serde_json::to_string_pretty(&state)
+        .map_err(|source| StateFileError::Serialize { path: path.clone(), source })?;
+    let state_dir = path.parent().expect("state file has parent");
+    fs::create_dir_all(state_dir)
+        .map_err(|source| StateFileError::Write { path: state_dir.to_path_buf(), source })?;
+    fs::write(&path, text).map_err(|source| StateFileError::Write { path, source })
+}
+
+fn read_state_file_for_write(
+    path: &Path,
+) -> Result<BTreeMap<String, EditDirState>, StateFileError> {
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
+        Err(source) => return Err(StateFileError::Read { path: path.to_path_buf(), source }),
+    };
+    serde_json::from_str(&text)
+        .map_err(|source| StateFileError::Parse { path: path.to_path_buf(), source })
+}
+
+fn state_file_path(modules_dir: &Path) -> PathBuf {
+    modules_dir.join(STATE_DIR).join(STATE_FILE)
+}
+
+fn edit_dir_key(edit_dir: &Path) -> Result<String, StateFileError> {
+    let absolute = if edit_dir.is_absolute() {
+        edit_dir.to_path_buf()
+    } else {
+        env::current_dir()
+            .map_err(|source| StateFileError::ResolveEditDir {
+                path: edit_dir.to_path_buf(),
+                source,
+            })?
+            .join(edit_dir)
+    };
+    let normalized = lexical_normalize(&absolute);
+    Ok(match dunce::canonicalize(&normalized) {
+        Ok(path) => path,
+        Err(source) if source.kind() == io::ErrorKind::NotFound => normalized,
+        Err(source) => {
+            return Err(StateFileError::ResolveEditDir { path: edit_dir.to_path_buf(), source });
+        }
+    }
+    .display()
+    .to_string())
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/patch_state.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_state.rs
@@ -1,11 +1,14 @@
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_fs::lexical_normalize;
+use pacquet_fs::{is_subdir, lexical_normalize};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
-    env, fs, io,
+    env,
+    fs::{self, OpenOptions},
+    io::{self, Write},
     path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 const STATE_DIR: &str = ".pnpm_patches";
@@ -54,6 +57,10 @@ pub(crate) enum StateFileError {
         source: io::Error,
     },
 
+    #[display("Unsafe patch state path {path:?}: {reason}")]
+    #[diagnostic(code(pacquet::patch_state_unsafe_path))]
+    UnsafePath { path: PathBuf, reason: &'static str },
+
     #[display("Failed to resolve patch edit directory {path:?}: {source}")]
     #[diagnostic(code(pacquet::patch_state_resolve_edit_dir))]
     ResolveEditDir {
@@ -67,7 +74,7 @@ pub(crate) fn read_edit_dir_state(
     modules_dir: &Path,
     edit_dir: &Path,
 ) -> Result<Option<EditDirState>, StateFileError> {
-    let path = state_file_path(modules_dir);
+    let path = checked_state_file_path_for_read(modules_dir)?;
     let text = match fs::read_to_string(&path) {
         Ok(text) => text,
         Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(None),
@@ -84,16 +91,14 @@ pub(crate) fn write_edit_dir_state(
     edit_dir: &Path,
     edit_dir_state: &EditDirState,
 ) -> Result<(), StateFileError> {
-    let path = state_file_path(modules_dir);
+    let path = checked_state_file_path_for_write(modules_dir)?;
     let mut state = read_state_file_for_write(&path)?;
     state.insert(edit_dir_key(edit_dir)?, edit_dir_state.clone());
 
     let text = serde_json::to_string_pretty(&state)
         .map_err(|source| StateFileError::Serialize { path: path.clone(), source })?;
-    let state_dir = path.parent().expect("state file has parent");
-    fs::create_dir_all(state_dir)
-        .map_err(|source| StateFileError::Write { path: state_dir.to_path_buf(), source })?;
-    fs::write(&path, text).map_err(|source| StateFileError::Write { path, source })
+    write_state_file_atomically(&path, text.as_bytes())
+        .map_err(|source| StateFileError::Write { path, source })
 }
 
 fn read_state_file_for_write(
@@ -110,6 +115,91 @@ fn read_state_file_for_write(
 
 fn state_file_path(modules_dir: &Path) -> PathBuf {
     modules_dir.join(STATE_DIR).join(STATE_FILE)
+}
+
+fn checked_state_file_path_for_read(modules_dir: &Path) -> Result<PathBuf, StateFileError> {
+    let path = state_file_path(modules_dir);
+    validate_existing_state_path(modules_dir, &path)?;
+    Ok(path)
+}
+
+fn checked_state_file_path_for_write(modules_dir: &Path) -> Result<PathBuf, StateFileError> {
+    let path = state_file_path(modules_dir);
+    let state_dir = path.parent().expect("state file has parent");
+    reject_state_symlink_if_exists(state_dir)?;
+    fs::create_dir_all(state_dir)
+        .map_err(|source| StateFileError::Write { path: state_dir.to_path_buf(), source })?;
+    validate_existing_state_path(modules_dir, &path)?;
+    Ok(path)
+}
+
+fn validate_existing_state_path(modules_dir: &Path, path: &Path) -> Result<(), StateFileError> {
+    let state_dir = path.parent().expect("state file has parent");
+    reject_state_symlink_if_exists(state_dir)?;
+    reject_state_symlink_if_exists(path)?;
+    if let (Ok(real_modules_dir), Ok(real_state_dir)) =
+        (dunce::canonicalize(modules_dir), dunce::canonicalize(state_dir))
+        && !is_subdir(&real_modules_dir, &real_state_dir)
+    {
+        return Err(StateFileError::UnsafePath {
+            path: state_dir.to_path_buf(),
+            reason: "must stay under the modules directory",
+        });
+    }
+    Ok(())
+}
+
+fn reject_state_symlink_if_exists(path: &Path) -> Result<(), StateFileError> {
+    match fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_symlink() => Err(StateFileError::UnsafePath {
+            path: path.to_path_buf(),
+            reason: "must not be a symbolic link",
+        }),
+        Ok(_) => Ok(()),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(StateFileError::Read { path: path.to_path_buf(), source }),
+    }
+}
+
+fn write_state_file_atomically(target: &Path, content: &[u8]) -> io::Result<()> {
+    const MAX_TEMP_ATTEMPTS: usize = 16;
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let pid = std::process::id();
+    let parent = target.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = target
+        .file_name()
+        .map_or_else(|| String::from("state.json"), |name| name.to_string_lossy().into_owned());
+
+    let mut last_already_exists = None;
+    for _ in 0..MAX_TEMP_ATTEMPTS {
+        let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let tmp = parent.join(format!(".{file_name}.{pid}.{counter}.pacquet-tmp"));
+        let mut file = match OpenOptions::new().write(true).create_new(true).open(&tmp) {
+            Ok(file) => file,
+            Err(source) if source.kind() == io::ErrorKind::AlreadyExists => {
+                last_already_exists = Some(source);
+                continue;
+            }
+            Err(source) => return Err(source),
+        };
+        if let Err(source) = file.write_all(content) {
+            drop(file);
+            let _ = fs::remove_file(&tmp);
+            return Err(source);
+        }
+        drop(file);
+        return fs::rename(&tmp, target).inspect_err(|_| {
+            let _ = fs::remove_file(&tmp);
+        });
+    }
+
+    Err(last_already_exists.unwrap_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "exhausted temp-path attempts for atomic patch state write",
+        )
+    }))
 }
 
 fn edit_dir_key(edit_dir: &Path) -> Result<String, StateFileError> {

--- a/pacquet/crates/cli/src/cli_args/patch_state/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_state/tests.rs
@@ -10,7 +10,11 @@ use tempfile::tempdir;
 static CWD_LOCK: Mutex<()> = Mutex::new(());
 
 fn sample_state() -> EditDirState {
-    EditDirState { patched_pkg: "is-positive@1.0.0".to_string(), apply_to_all: false }
+    EditDirState {
+        patched_pkg: "is-positive@1.0.0".to_string(),
+        apply_to_all: false,
+        package_key: None,
+    }
 }
 
 #[test]
@@ -58,7 +62,11 @@ fn patch_state_write_updates_existing_state_file() {
     write_edit_dir_state(
         &modules_dir,
         &second_edit_dir,
-        &EditDirState { patched_pkg: "is-negative@1.0.0".to_string(), apply_to_all: true },
+        &EditDirState {
+            patched_pkg: "is-negative@1.0.0".to_string(),
+            apply_to_all: true,
+            package_key: None,
+        },
     )
     .unwrap();
 

--- a/pacquet/crates/cli/src/cli_args/patch_state/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_state/tests.rs
@@ -1,4 +1,6 @@
-use super::*;
+use super::{
+    EditDirState, StateFileError, edit_dir_key, read_edit_dir_state, write_edit_dir_state,
+};
 use pretty_assertions::assert_eq;
 use serde_json::json;
 use std::{env, fs, path::Path, sync::Mutex};

--- a/pacquet/crates/cli/src/cli_args/patch_state/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_state/tests.rs
@@ -45,6 +45,48 @@ fn patch_state_write_creates_pnpm_state_file() {
 }
 
 #[test]
+fn patch_state_write_updates_existing_state_file() {
+    let tmp = tempdir().expect("temp dir");
+    let modules_dir = tmp.path().join("node_modules");
+    let first_edit_dir = tmp.path().join("first-edit");
+    let second_edit_dir = tmp.path().join("second-edit");
+    fs::create_dir_all(&first_edit_dir).expect("create first edit dir");
+    fs::create_dir_all(&second_edit_dir).expect("create second edit dir");
+
+    write_edit_dir_state(&modules_dir, &first_edit_dir, &sample_state()).unwrap();
+    write_edit_dir_state(
+        &modules_dir,
+        &second_edit_dir,
+        &EditDirState { patched_pkg: "is-negative@1.0.0".to_string(), apply_to_all: true },
+    )
+    .unwrap();
+
+    let first_key = dunce::canonicalize(&first_edit_dir)
+        .expect("canonical first edit dir")
+        .display()
+        .to_string();
+    let second_key = dunce::canonicalize(&second_edit_dir)
+        .expect("canonical second edit dir")
+        .display()
+        .to_string();
+    let state_path = modules_dir.join(".pnpm_patches").join("state.json");
+    let text = fs::read_to_string(state_path).expect("state file");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&text).expect("valid JSON"),
+        json!({
+            first_key: {
+                "patchedPkg": "is-positive@1.0.0",
+                "applyToAll": false,
+            },
+            second_key: {
+                "patchedPkg": "is-negative@1.0.0",
+                "applyToAll": true,
+            },
+        }),
+    );
+}
+
+#[test]
 fn patch_state_read_uses_resolved_edit_dir_key() {
     let tmp = tempdir().expect("temp dir");
     let modules_dir = tmp.path().join("node_modules");
@@ -95,6 +137,43 @@ fn patch_state_write_errors_when_existing_state_path_is_not_a_file() {
         write_edit_dir_state(&modules_dir, &tmp.path().join("edit"), &sample_state()).unwrap_err();
 
     assert!(matches!(err, StateFileError::Read { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn patch_state_write_rejects_symlinked_state_dir() {
+    let tmp = tempdir().expect("temp dir");
+    let modules_dir = tmp.path().join("node_modules");
+    let state_dir = modules_dir.join(".pnpm_patches");
+    let outside_dir = tmp.path().join("outside");
+    fs::create_dir_all(&modules_dir).expect("create modules dir");
+    fs::create_dir(&outside_dir).expect("create outside dir");
+    std::os::unix::fs::symlink(&outside_dir, &state_dir).expect("symlink state dir");
+
+    let err =
+        write_edit_dir_state(&modules_dir, &tmp.path().join("edit"), &sample_state()).unwrap_err();
+
+    assert!(matches!(err, StateFileError::UnsafePath { .. }));
+    assert!(!outside_dir.join("state.json").exists(), "outside state file must not be written");
+}
+
+#[cfg(unix)]
+#[test]
+fn patch_state_write_rejects_symlinked_state_file() {
+    let tmp = tempdir().expect("temp dir");
+    let modules_dir = tmp.path().join("node_modules");
+    let state_dir = modules_dir.join(".pnpm_patches");
+    let state_path = state_dir.join("state.json");
+    let outside_target = tmp.path().join("outside-state.json");
+    fs::create_dir_all(&state_dir).expect("create state dir");
+    fs::write(&outside_target, "{}").expect("write outside state");
+    std::os::unix::fs::symlink(&outside_target, &state_path).expect("symlink state file");
+
+    let err =
+        write_edit_dir_state(&modules_dir, &tmp.path().join("edit"), &sample_state()).unwrap_err();
+
+    assert!(matches!(err, StateFileError::UnsafePath { .. }));
+    assert_eq!(fs::read_to_string(&outside_target).expect("read outside state"), "{}");
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/patch_state/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_state/tests.rs
@@ -1,0 +1,180 @@
+use super::*;
+use pretty_assertions::assert_eq;
+use serde_json::json;
+use std::{env, fs, path::Path, sync::Mutex};
+use tempfile::tempdir;
+
+static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+fn sample_state() -> EditDirState {
+    EditDirState { patched_pkg: "is-positive@1.0.0".to_string(), apply_to_all: false }
+}
+
+#[test]
+fn patch_state_read_missing_state_file_returns_none() {
+    let tmp = tempdir().expect("temp dir");
+    let modules_dir = tmp.path().join("node_modules");
+    let edit_dir = tmp.path().join("edit");
+
+    assert_eq!(read_edit_dir_state(&modules_dir, &edit_dir).unwrap(), None);
+}
+
+#[test]
+fn patch_state_write_creates_pnpm_state_file() {
+    let tmp = tempdir().expect("temp dir");
+    let modules_dir = tmp.path().join("node_modules");
+    let edit_dir = tmp.path().join("edit");
+    fs::create_dir_all(&edit_dir).expect("create edit dir");
+
+    write_edit_dir_state(&modules_dir, &edit_dir, &sample_state()).unwrap();
+
+    let state_path = modules_dir.join(".pnpm_patches").join("state.json");
+    let text = fs::read_to_string(state_path).expect("state file");
+    let key = dunce::canonicalize(&edit_dir).expect("canonical edit dir").display().to_string();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&text).expect("valid JSON"),
+        json!({
+            key: {
+                "patchedPkg": "is-positive@1.0.0",
+                "applyToAll": false,
+            },
+        }),
+    );
+}
+
+#[test]
+fn patch_state_read_uses_resolved_edit_dir_key() {
+    let tmp = tempdir().expect("temp dir");
+    let modules_dir = tmp.path().join("node_modules");
+    let edit_dir = tmp.path().join("edit");
+    fs::create_dir_all(&edit_dir).expect("create edit dir");
+
+    write_edit_dir_state(&modules_dir, &edit_dir, &sample_state()).unwrap();
+
+    let edit_dir_with_dot = tmp.path().join(".").join("edit");
+    assert_eq!(
+        read_edit_dir_state(&modules_dir, &edit_dir_with_dot).unwrap(),
+        Some(sample_state()),
+    );
+}
+
+#[test]
+fn patch_state_malformed_json_is_an_error() {
+    let tmp = tempdir().expect("temp dir");
+    let modules_dir = tmp.path().join("node_modules");
+    let state_dir = modules_dir.join(".pnpm_patches");
+    fs::create_dir_all(&state_dir).expect("create state dir");
+    fs::write(state_dir.join("state.json"), "{").expect("write malformed state");
+
+    let err = read_edit_dir_state(&modules_dir, &tmp.path().join("edit")).unwrap_err();
+    assert!(err.to_string().contains("state.json"), "error includes state path: {err}");
+}
+
+#[test]
+fn patch_state_read_errors_when_state_path_is_not_a_file() {
+    let tmp = tempdir().expect("temp dir");
+    let modules_dir = tmp.path().join("node_modules");
+    let state_path = modules_dir.join(".pnpm_patches").join("state.json");
+    fs::create_dir_all(&state_path).expect("create state dir at file path");
+
+    let err = read_edit_dir_state(&modules_dir, &tmp.path().join("edit")).unwrap_err();
+
+    assert!(matches!(err, StateFileError::Read { .. }));
+}
+
+#[test]
+fn patch_state_write_errors_when_existing_state_path_is_not_a_file() {
+    let tmp = tempdir().expect("temp dir");
+    let modules_dir = tmp.path().join("node_modules");
+    let state_path = modules_dir.join(".pnpm_patches").join("state.json");
+    fs::create_dir_all(&state_path).expect("create state dir at file path");
+
+    let err =
+        write_edit_dir_state(&modules_dir, &tmp.path().join("edit"), &sample_state()).unwrap_err();
+
+    assert!(matches!(err, StateFileError::Read { .. }));
+}
+
+#[test]
+fn patch_state_write_uses_current_dir_for_relative_edit_dirs() {
+    let _guard = CWD_LOCK.lock().expect("cwd lock");
+    let tmp = tempdir().expect("temp dir");
+    let original_cwd = env::current_dir().expect("current dir");
+    env::set_current_dir(tmp.path()).expect("enter temp dir");
+    let _restore = CurrentDirGuard(original_cwd);
+
+    let modules_dir = tmp.path().join("node_modules");
+    fs::create_dir("edit").expect("create relative edit dir");
+
+    write_edit_dir_state(&modules_dir, Path::new("edit"), &sample_state()).unwrap();
+
+    let state_path = modules_dir.join(".pnpm_patches").join("state.json");
+    let text = fs::read_to_string(state_path).expect("state file");
+    let key = dunce::canonicalize(tmp.path().join("edit"))
+        .expect("canonical edit dir")
+        .display()
+        .to_string();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&text).expect("valid JSON"),
+        json!({
+            key: {
+                "patchedPkg": "is-positive@1.0.0",
+                "applyToAll": false,
+            },
+        }),
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn patch_state_reports_current_dir_resolution_errors_for_relative_edit_dirs() {
+    let _guard = CWD_LOCK.lock().expect("cwd lock");
+    let tmp = tempdir().expect("temp dir");
+    let doomed = tmp.path().join("doomed");
+    fs::create_dir(&doomed).expect("create cwd");
+    let original_cwd = env::current_dir().expect("current dir");
+    env::set_current_dir(&doomed).expect("enter doomed cwd");
+    let _restore = CurrentDirGuard(original_cwd);
+    fs::remove_dir(&doomed).expect("remove cwd");
+
+    let err = edit_dir_key(Path::new("edit")).expect_err("deleted cwd should fail");
+
+    assert!(matches!(err, StateFileError::ResolveEditDir { .. }));
+}
+
+#[test]
+fn patch_state_write_uses_normalized_missing_edit_dir_key() {
+    let tmp = tempdir().expect("temp dir");
+    let modules_dir = tmp.path().join("node_modules");
+    let missing_edit_dir = tmp.path().join("missing-edit");
+
+    write_edit_dir_state(&modules_dir, &missing_edit_dir, &sample_state()).unwrap();
+
+    let state_path = modules_dir.join(".pnpm_patches").join("state.json");
+    let text = fs::read_to_string(state_path).expect("state file");
+    assert!(
+        serde_json::from_str::<serde_json::Value>(&text).expect("valid JSON")
+            [&missing_edit_dir.display().to_string()]
+            .is_object(),
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn patch_state_errors_when_edit_dir_parent_is_not_a_directory() {
+    let tmp = tempdir().expect("temp dir");
+    let file_parent = tmp.path().join("file-parent");
+    fs::write(&file_parent, "").expect("write file parent");
+
+    let err = edit_dir_key(&file_parent.join("edit")).expect_err("file parent should fail");
+
+    assert!(matches!(err, StateFileError::ResolveEditDir { .. }));
+}
+
+struct CurrentDirGuard(std::path::PathBuf);
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        env::set_current_dir(&self.0).expect("restore current dir");
+    }
+}

--- a/pacquet/crates/cli/src/cli_args/patch_state/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_state/tests.rs
@@ -1,5 +1,6 @@
 use super::{
     EditDirState, StateFileError, edit_dir_key, read_edit_dir_state, write_edit_dir_state,
+    write_state_file_atomically,
 };
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -84,6 +85,17 @@ fn patch_state_write_updates_existing_state_file() {
             },
         }),
     );
+}
+
+#[test]
+fn patch_state_atomic_writer_replaces_existing_file() {
+    let tmp = tempdir().expect("temp dir");
+    let state_file = tmp.path().join("state.json");
+    fs::write(&state_file, "old").expect("write old state");
+
+    write_state_file_atomically(&state_file, b"new").expect("replace state");
+
+    assert_eq!(fs::read_to_string(state_file).expect("read state"), "new");
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/patch_state/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/patch_state/tests.rs
@@ -127,6 +127,20 @@ fn patch_state_read_errors_when_state_path_is_not_a_file() {
 }
 
 #[test]
+fn patch_state_read_rejects_oversized_state_file() {
+    let tmp = tempdir().expect("temp dir");
+    let modules_dir = tmp.path().join("node_modules");
+    let state_path = modules_dir.join(".pnpm_patches").join("state.json");
+    fs::create_dir_all(state_path.parent().expect("state parent")).expect("create state dir");
+    fs::write(&state_path, " ".repeat(super::MAX_STATE_FILE_BYTES + 1))
+        .expect("write oversized state");
+
+    let err = read_edit_dir_state(&modules_dir, &tmp.path().join("edit")).unwrap_err();
+
+    assert!(matches!(err, StateFileError::StateFileTooLarge { .. }));
+}
+
+#[test]
 fn patch_state_write_errors_when_existing_state_path_is_not_a_file() {
     let tmp = tempdir().expect("temp dir");
     let modules_dir = tmp.path().join("node_modules");

--- a/pacquet/crates/cli/tests/add.rs
+++ b/pacquet/crates/cli/tests/add.rs
@@ -111,6 +111,25 @@ fn should_add_to_package_json() {
     drop((root, anchor)); // cleanup
 }
 
+#[test]
+fn add_runs_with_ndjson_and_silent_reporters() {
+    for reporter in ["--reporter=ndjson", "--reporter=silent"] {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+
+        pacquet.with_args([reporter, "add", "@pnpm.e2e/hello-world-js-bin"]).assert().success();
+
+        let file = PackageManifest::from_path(workspace.join("package.json")).unwrap();
+        assert!(
+            file.dependencies([DependencyGroup::Prod])
+                .any(|(key, _)| key == "@pnpm.e2e/hello-world-js-bin"),
+            "dependency should be saved when running add with {reporter}",
+        );
+
+        drop((root, npmrc_info)); // cleanup
+    }
+}
+
 fn prod_spec(dir: &std::path::Path, name: &str) -> String {
     let manifest = dir.join("package.json").pipe(PackageManifest::from_path).unwrap();
     let (_, spec) = manifest

--- a/pacquet/crates/cli/tests/approve_builds.rs
+++ b/pacquet/crates/cli/tests/approve_builds.rs
@@ -113,6 +113,25 @@ fn approve_builds_with_args_runs_the_build() {
 }
 
 #[test]
+fn approve_builds_runs_the_build_with_ndjson_and_silent_reporters() {
+    for reporter in ["--reporter=ndjson", "--reporter=silent"] {
+        let (harness, workspace) = install_with_ignored_build();
+
+        pacquet(&workspace)
+            .with_args([reporter, "approve-builds", "@pnpm.e2e/install-script-example"])
+            .assert()
+            .success();
+
+        assert!(
+            workspace.join(INSTALL_MARKER).exists(),
+            "approving the build under {reporter} must run its install script",
+        );
+
+        drop(harness);
+    }
+}
+
+#[test]
 fn approve_builds_deny_keeps_the_build_ignored() {
     let (harness, workspace) = install_with_ignored_build();
 
@@ -169,6 +188,20 @@ fn rebuild_reruns_an_approved_build() {
     assert!(marker.exists(), "rebuild must re-run the install script");
 
     drop(harness);
+}
+
+#[test]
+fn rebuild_runs_with_ndjson_and_silent_reporters() {
+    for reporter in ["--reporter=ndjson", "--reporter=silent"] {
+        let harness = CommandTempCwd::init().add_mocked_registry();
+        let workspace = harness.workspace.clone();
+        fs::write(workspace.join("package.json"), "{}").expect("write package.json");
+        pacquet(&workspace).with_arg("install").assert().success();
+
+        pacquet(&workspace).with_args([reporter, "rebuild"]).assert().success();
+
+        drop(harness);
+    }
 }
 
 /// Package names of the two build-script fixtures used by the multi-dep tests.

--- a/pacquet/crates/cli/tests/create.rs
+++ b/pacquet/crates/cli/tests/create.rs
@@ -6,22 +6,29 @@ use pacquet_testing_utils::bin::CommandTempCwd;
 /// `create`, which throws `ERR_PNPM_MISSING_ARGS` when given no arguments.
 #[test]
 fn create_errors_when_no_name_given() {
-    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+    for reporter in [None, Some("--reporter=ndjson"), Some("--reporter=silent")] {
+        let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
 
-    let output = pacquet.with_arg("create").output().expect("spawn pacquet create");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    eprintln!("STDERR:\n{stderr}\n");
-    assert!(!output.status.success(), "create with no name must fail");
-    assert!(
-        stderr.contains("ERR_PNPM_MISSING_ARGS"),
-        "stderr must contain the pnpm-compatible error code",
-    );
-    assert!(
-        stderr.contains("Missing the template package name"),
-        "stderr must contain the human-readable message",
-    );
+        let mut command = pacquet;
+        if let Some(reporter) = reporter {
+            command.arg(reporter);
+        }
+        command.arg("create");
+        let output = command.output().expect("spawn pacquet create");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eprintln!("STDERR:\n{stderr}\n");
+        assert!(!output.status.success(), "create with no name must fail");
+        assert!(
+            stderr.contains("ERR_PNPM_MISSING_ARGS"),
+            "stderr must contain the pnpm-compatible error code",
+        );
+        assert!(
+            stderr.contains("Missing the template package name"),
+            "stderr must contain the human-readable message",
+        );
 
-    drop(root);
+        drop(root);
+    }
 }
 
 /// `pacquet create <name>` converts the name to `create-<name>` and

--- a/pacquet/crates/cli/tests/dlx.rs
+++ b/pacquet/crates/cli/tests/dlx.rs
@@ -14,18 +14,25 @@ use pacquet_testing_utils::bin::CommandTempCwd;
 /// the mocked registry and is exercised in CI rather than here.
 #[test]
 fn dlx_errors_when_no_command_given() {
-    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+    for reporter in [None, Some("--reporter=ndjson"), Some("--reporter=silent")] {
+        let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
 
-    let output = pacquet.with_arg("dlx").output().expect("spawn pacquet dlx");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    eprintln!("STDERR:\n{stderr}\n");
-    assert!(!output.status.success(), "dlx with no command must fail");
-    assert!(
-        stderr.contains("requires a command to run"),
-        "the failure must be the missing-command diagnostic",
-    );
+        let mut command = pacquet;
+        if let Some(reporter) = reporter {
+            command.arg(reporter);
+        }
+        command.arg("dlx");
+        let output = command.output().expect("spawn pacquet dlx");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eprintln!("STDERR:\n{stderr}\n");
+        assert!(!output.status.success(), "dlx with no command must fail");
+        assert!(
+            stderr.contains("requires a command to run"),
+            "the failure must be the missing-command diagnostic",
+        );
 
-    drop(root);
+        drop(root);
+    }
 }
 
 /// `pacquet dlx <package>` resolves the package against the mocked

--- a/pacquet/crates/cli/tests/patch.rs
+++ b/pacquet/crates/cli/tests/patch.rs
@@ -1,0 +1,920 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use serde_json::Value;
+use std::{ffi::OsStr, fmt::Write as _, fs, path::Path, process::Command};
+use tempfile::TempDir;
+
+const IS_POSITIVE_PATCH: &str = include_str!(
+    "../../../../pnpm11/installing/deps-installer/test/fixtures/patch-pkg/is-positive@1.0.0.patch"
+);
+
+fn setup_installed() -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "is-positive": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    pacquet(&workspace, ["install"]).assert().success();
+    (root, workspace, npmrc_info)
+}
+
+fn setup_installed_workspace_project()
+-> (TempDir, std::path::PathBuf, std::path::PathBuf, AddMockedRegistry) {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "root",
+            "version": "0.0.0",
+            "private": true,
+        })
+        .to_string(),
+    )
+    .expect("write root package.json");
+    let app_dir = workspace.join("packages/app");
+    fs::create_dir_all(&app_dir).expect("create workspace app");
+    fs::write(
+        app_dir.join("package.json"),
+        serde_json::json!({
+            "name": "app",
+            "version": "0.0.0",
+            "dependencies": {
+                "is-positive": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write app package.json");
+    pacquet(&workspace, ["install"]).assert().success();
+    (root, workspace, app_dir, npmrc_info)
+}
+
+fn setup_configured_patch(
+    patch_key: &str,
+    patch_file_name: &str,
+) -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "is-positive": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    fs::create_dir_all(workspace.join("patches")).expect("create patches dir");
+    fs::write(workspace.join("patches").join(patch_file_name), IS_POSITIVE_PATCH)
+        .expect("write patch file");
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    writeln!(&mut workspace_yaml, "patchedDependencies:\n  {patch_key}: patches/{patch_file_name}")
+        .expect("append patchedDependencies");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+    (root, workspace, npmrc_info)
+}
+
+fn setup_patch_remove_project(
+    entries: &[(&str, &str)],
+) -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "is-positive": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("patchedDependencies:\n");
+    for (key, patch_file) in entries {
+        writeln!(&mut workspace_yaml, "  {key}: {patch_file}")
+            .expect("append patchedDependencies entry");
+    }
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+    (root, workspace, npmrc_info)
+}
+
+fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
+    Command::cargo_bin("pacquet")
+        .expect("find the pacquet binary")
+        .with_current_dir(workspace)
+        .with_args(args)
+}
+
+fn patch_state(workspace: &Path) -> Value {
+    let state_path = workspace.join("node_modules/.pnpm_patches/state.json");
+    serde_json::from_str(&fs::read_to_string(state_path).expect("read patch state"))
+        .expect("parse patch state")
+}
+
+fn write_patch_edit(edit_dir: &Path, marker: &str) {
+    fs::write(
+        edit_dir.join("index.js"),
+        format!("module.exports = function () {{ return {marker:?} }}\n"),
+    )
+    .expect("edit package file");
+}
+
+fn remove_dir_if_exists(path: &Path) {
+    match fs::remove_dir_all(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => panic!("remove {}: {error}", path.display()),
+    }
+}
+
+#[test]
+fn patch_errors_when_package_is_missing() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let output = pacquet(&workspace, ["patch", "--reporter=silent"]).output().expect("run patch");
+
+    assert!(!output.status.success(), "patch without package should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("requires the package name"), "stderr: {stderr}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_errors_when_requested_version_is_not_installed() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let output = pacquet(&workspace, ["patch", "is-positive@2.0.0", "--reporter=silent"])
+        .output()
+        .expect("run patch");
+
+    assert!(!output.status.success(), "missing installed version should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERR_PNPM_PATCH_VERSION_NOT_FOUND"), "stderr: {stderr}");
+    assert!(stderr.contains("1.0.0"), "stderr: {stderr}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn install_level_exact_version_patch_applies_with_frozen_reinstall() {
+    let (root, workspace, npmrc_info) =
+        setup_configured_patch("is-positive@1.0.0", "is-positive@1.0.0.patch");
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["install", "--reporter=silent"]).assert().success();
+
+    let installed =
+        fs::read_to_string(workspace.join("node_modules/is-positive/index.js")).unwrap();
+    assert!(installed.contains("// patched"), "installed: {installed}");
+    let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("lockfile");
+    assert!(lockfile.contains("patchedDependencies:"), "lockfile: {lockfile}");
+    assert!(lockfile.contains("is-positive@1.0.0:"), "lockfile: {lockfile}");
+
+    remove_dir_if_exists(&workspace.join("node_modules"));
+    pacquet(&workspace, ["install", "--frozen-lockfile", "--reporter=silent"]).assert().success();
+    let replayed = fs::read_to_string(workspace.join("node_modules/is-positive/index.js")).unwrap();
+    assert!(replayed.contains("// patched"), "replayed: {replayed}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn install_level_range_patch_applies_with_frozen_reinstall() {
+    let (root, workspace, npmrc_info) =
+        setup_configured_patch("is-positive@1", "is-positive@1.patch");
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["install", "--reporter=silent"]).assert().success();
+
+    let installed =
+        fs::read_to_string(workspace.join("node_modules/is-positive/index.js")).unwrap();
+    assert!(installed.contains("// patched"), "installed: {installed}");
+    let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("lockfile");
+    assert!(lockfile.contains("patchedDependencies:"), "lockfile: {lockfile}");
+    assert!(lockfile.contains("is-positive@1:"), "lockfile: {lockfile}");
+
+    remove_dir_if_exists(&workspace.join("node_modules"));
+    pacquet(&workspace, ["install", "--frozen-lockfile", "--reporter=silent"]).assert().success();
+    let replayed = fs::read_to_string(workspace.join("node_modules/is-positive/index.js")).unwrap();
+    assert!(replayed.contains("// patched"), "replayed: {replayed}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_commit_exact_version_writes_patch_and_reinstalls() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"]).assert().success();
+    let edit_dir = workspace.join("node_modules/.pnpm_patches/is-positive@1.0.0");
+    write_patch_edit(&edit_dir, "patched exact");
+
+    pacquet(
+        &workspace,
+        ["patch-commit", edit_dir.to_str().expect("utf8 edit dir"), "--reporter=silent"],
+    )
+    .assert()
+    .success();
+
+    let workspace_yaml =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("workspace yaml");
+    assert!(workspace_yaml.contains("is-positive@1.0.0: patches/is-positive@1.0.0.patch"));
+
+    let patch_file = workspace.join("patches/is-positive@1.0.0.patch");
+    let patch = fs::read_to_string(patch_file).expect("patch file");
+    assert!(patch.contains("diff --git a/index.js b/index.js"), "patch: {patch}");
+    assert!(patch.contains("patched exact"), "patch: {patch}");
+
+    let installed =
+        fs::read_to_string(workspace.join("node_modules/is-positive/index.js")).unwrap();
+    assert!(installed.contains("patched exact"), "installed: {installed}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_commit_bare_name_writes_apply_to_all_key() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["patch", "is-positive", "--reporter=silent"]).assert().success();
+    let edit_dir = workspace.join("node_modules/.pnpm_patches/is-positive@1.0.0");
+    write_patch_edit(&edit_dir, "patched all");
+
+    pacquet(
+        &workspace,
+        ["patch-commit", edit_dir.to_str().expect("utf8 edit dir"), "--reporter=silent"],
+    )
+    .assert()
+    .success();
+
+    let workspace_yaml =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("workspace yaml");
+    assert!(workspace_yaml.contains("is-positive: patches/is-positive.patch"));
+    assert!(workspace.join("patches/is-positive.patch").is_file());
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_commit_workspace_project_shared_lockfile_updates_root_manifest_and_reinstalls() {
+    let (root, workspace, app_dir, npmrc_info) = setup_installed_workspace_project();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"]).assert().success();
+    let edit_dir = workspace.join("node_modules/.pnpm_patches/is-positive@1.0.0");
+    write_patch_edit(&edit_dir, "patched workspace");
+
+    pacquet(
+        &workspace,
+        ["patch-commit", edit_dir.to_str().expect("utf8 edit dir"), "--reporter=silent"],
+    )
+    .assert()
+    .success();
+
+    let workspace_yaml =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("workspace yaml");
+    assert!(workspace_yaml.contains("packages:"), "workspace yaml: {workspace_yaml}");
+    assert!(
+        workspace_yaml.contains("is-positive@1.0.0: patches/is-positive@1.0.0.patch"),
+        "workspace yaml: {workspace_yaml}",
+    );
+
+    let installed = fs::read_to_string(app_dir.join("node_modules/is-positive/index.js")).unwrap();
+    assert!(installed.contains("patched workspace"), "installed: {installed}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_commit_accepts_relative_patch_dir() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"]).assert().success();
+    let edit_dir = workspace.join("node_modules/.pnpm_patches/is-positive@1.0.0");
+    write_patch_edit(&edit_dir, "patched relative");
+
+    pacquet(
+        &workspace,
+        ["patch-commit", "node_modules/.pnpm_patches/is-positive@1.0.0", "--reporter=silent"],
+    )
+    .assert()
+    .success();
+
+    let patch =
+        fs::read_to_string(workspace.join("patches/is-positive@1.0.0.patch")).expect("patch");
+    assert!(patch.contains("patched relative"), "patch: {patch}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_commit_custom_patches_dir_normalizes_path() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"]).assert().success();
+    let edit_dir = workspace.join("node_modules/.pnpm_patches/is-positive@1.0.0");
+    write_patch_edit(&edit_dir, "patched custom dir");
+
+    pacquet(
+        &workspace,
+        [
+            "patch-commit",
+            "--patches-dir",
+            "ts/src/../custom-patches",
+            edit_dir.to_str().expect("utf8 edit dir"),
+            "--reporter=silent",
+        ],
+    )
+    .assert()
+    .success();
+
+    let workspace_yaml =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("workspace yaml");
+    assert!(
+        workspace_yaml.contains("is-positive@1.0.0: ts/custom-patches/is-positive@1.0.0.patch"),
+        "workspace yaml: {workspace_yaml}",
+    );
+    assert!(workspace.join("ts/custom-patches/is-positive@1.0.0.patch").is_file());
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_commit_no_changes_does_not_create_patches_dir() {
+    for reporter in [None, Some("--reporter=ndjson"), Some("--reporter=silent")] {
+        let (root, workspace, npmrc_info) = setup_installed();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"]).assert().success();
+        let edit_dir = workspace.join("node_modules/.pnpm_patches/is-positive@1.0.0");
+
+        let mut patch_commit =
+            pacquet(&workspace, ["patch-commit", edit_dir.to_str().expect("utf8 edit dir")]);
+        if let Some(reporter) = reporter {
+            patch_commit.arg(reporter);
+        }
+        let output = patch_commit.output().expect("run patch-commit");
+
+        assert!(output.status.success(), "patch-commit with no changes should succeed");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("No changes were found"), "stdout: {stdout}");
+        assert!(!workspace.join("patches").exists(), "patches dir should not be created");
+
+        drop((root, mock_instance));
+    }
+}
+
+#[test]
+fn patch_commit_errors_when_patch_dir_manifest_is_missing() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let output = pacquet(&workspace, ["patch-commit", "missing-edit-dir", "--reporter=silent"])
+        .output()
+        .expect("run patch-commit");
+
+    assert!(!output.status.success(), "missing patch dir should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Failed to read package manifest"), "stderr: {stderr}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_commit_errors_when_manifest_version_no_longer_matches_installed_patch_target() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"]).assert().success();
+    let edit_dir = workspace.join("node_modules/.pnpm_patches/is-positive@1.0.0");
+    fs::write(
+        edit_dir.join("package.json"),
+        serde_json::json!({
+            "name": "is-positive",
+            "version": "2.0.0",
+        })
+        .to_string(),
+    )
+    .expect("rewrite patch manifest");
+
+    let output = pacquet(
+        &workspace,
+        ["patch-commit", edit_dir.to_str().expect("utf8 edit dir"), "--reporter=silent"],
+    )
+    .output()
+    .expect("run patch-commit");
+
+    assert!(!output.status.success(), "mismatched manifest version should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERR_PNPM_PATCH_VERSION_NOT_FOUND"), "stderr: {stderr}");
+    assert!(stderr.contains("current lockfile"), "stderr: {stderr}");
+    assert!(stderr.contains("is-positive@2.0.0"), "stderr: {stderr}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_commit_reports_patches_dir_create_errors() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"]).assert().success();
+    let edit_dir = workspace.join("node_modules/.pnpm_patches/is-positive@1.0.0");
+    write_patch_edit(&edit_dir, "create patches dir error");
+    fs::write(workspace.join("not-a-dir"), "").expect("create patches-dir file");
+
+    let output = pacquet(
+        &workspace,
+        [
+            "patch-commit",
+            "--patches-dir",
+            "not-a-dir",
+            edit_dir.to_str().expect("utf8 edit dir"),
+            "--reporter=silent",
+        ],
+    )
+    .output()
+    .expect("run patch-commit");
+
+    assert!(!output.status.success(), "file patches dir should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Failed to create patches directory"), "stderr: {stderr}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_commit_reports_patch_file_write_errors() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"]).assert().success();
+    let edit_dir = workspace.join("node_modules/.pnpm_patches/is-positive@1.0.0");
+    write_patch_edit(&edit_dir, "write patch error");
+    fs::create_dir_all(workspace.join("patches/is-positive@1.0.0.patch"))
+        .expect("create directory at patch file path");
+
+    let output = pacquet(
+        &workspace,
+        ["patch-commit", edit_dir.to_str().expect("utf8 edit dir"), "--reporter=silent"],
+    )
+    .output()
+    .expect("run patch-commit");
+
+    assert!(!output.status.success(), "directory patch path should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Failed to write patch file"), "stderr: {stderr}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_workflow_runs_with_default_ndjson_and_silent_reporters() {
+    for reporter in [None, Some("--reporter=ndjson"), Some("--reporter=silent")] {
+        let (root, workspace, npmrc_info) = setup_installed();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+        let marker = match reporter {
+            None => "patched default reporter",
+            Some("--reporter=ndjson") => "patched ndjson reporter",
+            Some("--reporter=silent") => "patched silent reporter",
+            Some(other) => panic!("unexpected reporter {other}"),
+        };
+
+        let mut patch_cmd = pacquet(&workspace, ["patch", "is-positive@1.0.0"]);
+        if let Some(reporter) = reporter {
+            patch_cmd.arg(reporter);
+        }
+        patch_cmd.assert().success();
+
+        let edit_dir = workspace.join("node_modules/.pnpm_patches/is-positive@1.0.0");
+        write_patch_edit(&edit_dir, marker);
+
+        let mut patch_commit_cmd =
+            pacquet(&workspace, ["patch-commit", edit_dir.to_str().expect("utf8 edit dir")]);
+        if let Some(reporter) = reporter {
+            patch_commit_cmd.arg(reporter);
+        }
+        patch_commit_cmd.assert().success();
+
+        let installed =
+            fs::read_to_string(workspace.join("node_modules/is-positive/index.js")).unwrap();
+        assert!(installed.contains(marker), "installed: {installed}");
+        assert!(workspace.join("patches/is-positive@1.0.0.patch").is_file());
+
+        let mut patch_remove_cmd = pacquet(&workspace, ["patch-remove", "is-positive@1.0.0"]);
+        if let Some(reporter) = reporter {
+            patch_remove_cmd.arg(reporter);
+        }
+        patch_remove_cmd.assert().success();
+
+        let workspace_yaml =
+            fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("workspace yaml");
+        assert!(
+            !workspace_yaml.contains("patchedDependencies:"),
+            "workspace yaml: {workspace_yaml}",
+        );
+        assert!(!workspace.join("patches/is-positive@1.0.0.patch").exists());
+
+        drop((root, mock_instance));
+    }
+}
+
+#[test]
+fn patch_reuses_existing_exact_patch_file_by_default() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"]).assert().success();
+    let edit_dir = workspace.join("node_modules/.pnpm_patches/is-positive@1.0.0");
+    write_patch_edit(&edit_dir, "reused patch");
+    pacquet(
+        &workspace,
+        ["patch-commit", edit_dir.to_str().expect("utf8 edit dir"), "--reporter=silent"],
+    )
+    .assert()
+    .success();
+    fs::remove_dir_all(&edit_dir).expect("remove edit dir");
+
+    pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"]).assert().success();
+
+    let edited = fs::read_to_string(edit_dir.join("index.js")).expect("edit dir index");
+    assert!(edited.contains("reused patch"), "edited: {edited}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_ignore_existing_skips_existing_patch_file() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"]).assert().success();
+    let edit_dir = workspace.join("node_modules/.pnpm_patches/is-positive@1.0.0");
+    write_patch_edit(&edit_dir, "ignored patch");
+    pacquet(
+        &workspace,
+        ["patch-commit", edit_dir.to_str().expect("utf8 edit dir"), "--reporter=silent"],
+    )
+    .assert()
+    .success();
+    fs::remove_dir_all(&edit_dir).expect("remove edit dir");
+
+    pacquet(&workspace, ["patch", "--ignore-existing", "is-positive@1.0.0", "--reporter=silent"])
+        .assert()
+        .success();
+
+    let edited = fs::read_to_string(edit_dir.join("index.js")).expect("edit dir index");
+    assert!(!edited.contains("ignored patch"), "edited: {edited}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_errors_when_existing_patch_file_is_missing() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("patchedDependencies:\n  is-positive@1.0.0: patches/not-found.patch\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    let output = pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"])
+        .output()
+        .expect("run patch");
+
+    assert!(!output.status.success(), "missing patch file should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERR_PNPM_PATCH_FILE_NOT_FOUND"), "stderr: {stderr}");
+    assert!(stderr.contains("Unable to find patch file"), "stderr: {stderr}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_exact_version_creates_edit_dir_and_state() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"]).assert().success();
+
+    let edit_dir = workspace.join("node_modules/.pnpm_patches/is-positive@1.0.0");
+    assert!(edit_dir.join("package.json").is_file(), "edit dir package.json exists");
+    assert!(edit_dir.join("index.js").is_file(), "edit dir package files exist");
+
+    let key = dunce::canonicalize(&edit_dir).expect("canonical edit dir").display().to_string();
+    let state = patch_state(&workspace);
+    assert_eq!(state[&key]["patchedPkg"], "is-positive@1.0.0");
+    assert_eq!(state[&key]["applyToAll"], false);
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_bare_name_single_version_sets_apply_to_all() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["patch", "is-positive", "--reporter=silent"]).assert().success();
+
+    let edit_dir = workspace.join("node_modules/.pnpm_patches/is-positive@1.0.0");
+    let key = dunce::canonicalize(&edit_dir).expect("canonical edit dir").display().to_string();
+    let state = patch_state(&workspace);
+    assert_eq!(state[&key]["patchedPkg"], "is-positive");
+    assert_eq!(state[&key]["applyToAll"], true);
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_rejects_non_empty_edit_dir() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let edit_dir = workspace.join("custom-edit");
+    fs::create_dir_all(&edit_dir).expect("create edit dir");
+    fs::write(edit_dir.join("file.txt"), "already here").expect("seed edit dir");
+
+    let output = pacquet(
+        &workspace,
+        [
+            "patch",
+            "--edit-dir",
+            edit_dir.to_str().expect("utf8 path"),
+            "is-positive@1.0.0",
+            "--reporter=silent",
+        ],
+    )
+    .output()
+    .expect("run patch");
+
+    assert!(!output.status.success(), "non-empty edit dir should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("target directory already exists"), "stderr: {stderr}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_accepts_empty_custom_edit_dir() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let edit_dir = workspace.join("custom-edit");
+    fs::create_dir_all(&edit_dir).expect("create edit dir");
+
+    pacquet(
+        &workspace,
+        [
+            "patch",
+            "--edit-dir",
+            edit_dir.to_str().expect("utf8 path"),
+            "is-positive@1.0.0",
+            "--reporter=silent",
+        ],
+    )
+    .assert()
+    .success();
+
+    assert!(edit_dir.join("package.json").is_file(), "custom edit dir package.json exists");
+    assert!(edit_dir.join("index.js").is_file(), "custom edit dir package file exists");
+
+    let key = dunce::canonicalize(&edit_dir).expect("canonical edit dir").display().to_string();
+    let state = patch_state(&workspace);
+    assert_eq!(state[&key]["patchedPkg"], "is-positive@1.0.0");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_remove_removes_patch_file_manifest_entry_and_reinstalls() {
+    let (root, workspace, npmrc_info) =
+        setup_configured_patch("is-positive@1.0.0", "is-positive@1.0.0.patch");
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["install", "--reporter=silent"]).assert().success();
+    let patched = fs::read_to_string(workspace.join("node_modules/is-positive/index.js")).unwrap();
+    assert!(patched.contains("// patched"), "patched install: {patched}");
+
+    pacquet(&workspace, ["patch-remove", "is-positive@1.0.0", "--reporter=silent"])
+        .assert()
+        .success();
+
+    let workspace_yaml =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("workspace yaml");
+    assert!(!workspace_yaml.contains("patchedDependencies:"), "workspace yaml: {workspace_yaml}");
+    assert!(
+        !workspace.join("patches/is-positive@1.0.0.patch").exists(),
+        "patch file should be removed",
+    );
+    let installed =
+        fs::read_to_string(workspace.join("node_modules/is-positive/index.js")).unwrap();
+    assert!(!installed.contains("// patched"), "installed: {installed}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_remove_keeps_missing_patch_files_as_noop_targets() {
+    let (root, workspace, npmrc_info) =
+        setup_configured_patch("is-positive@1.0.0", "is-positive@1.0.0.patch");
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::remove_file(workspace.join("patches/is-positive@1.0.0.patch")).expect("remove patch file");
+
+    pacquet(&workspace, ["patch-remove", "is-positive@1.0.0", "--reporter=silent"])
+        .assert()
+        .success();
+
+    let workspace_yaml =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("workspace yaml");
+    assert!(!workspace_yaml.contains("patchedDependencies:"), "workspace yaml: {workspace_yaml}");
+    let installed =
+        fs::read_to_string(workspace.join("node_modules/is-positive/index.js")).unwrap();
+    assert!(!installed.contains("// patched"), "installed: {installed}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_remove_errors_when_requested_patch_is_missing_from_manifest() {
+    let (root, workspace, npmrc_info) =
+        setup_configured_patch("is-positive@1.0.0", "is-positive@1.0.0.patch");
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let output = pacquet(&workspace, ["patch-remove", "is-negative", "--reporter=silent"])
+        .output()
+        .expect("run patch-remove");
+
+    assert!(!output.status.success(), "unknown patch should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERR_PNPM_PATCH_NOT_FOUND"), "stderr: {stderr}");
+    assert!(
+        workspace.join("patches/is-positive@1.0.0.patch").exists(),
+        "existing patch should not be removed",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_remove_errors_when_no_patches_are_configured() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "is-positive": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let output = pacquet(&workspace, ["patch-remove", "--reporter=silent"])
+        .output()
+        .expect("run patch-remove");
+
+    assert!(!output.status.success(), "patch-remove with no configured patches should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERR_PNPM_NO_PATCHES_TO_REMOVE"), "stderr: {stderr}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_remove_rejects_traversal_before_deleting_any_patch() {
+    let (root, workspace, npmrc_info) =
+        setup_patch_remove_project(&[("good", "patches/good.patch"), ("bad", "../outside.patch")]);
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::create_dir_all(workspace.join("patches")).expect("create patches dir");
+    fs::write(workspace.join("patches/good.patch"), "good patch").expect("write good patch");
+    fs::write(root.path().join("outside.patch"), "outside patch").expect("write outside patch");
+
+    let output = pacquet(&workspace, ["patch-remove", "good", "bad", "--reporter=silent"])
+        .output()
+        .expect("run patch-remove");
+
+    assert!(!output.status.success(), "outside patch should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERR_PNPM_PATCH_FILE_OUTSIDE_PATCHES_DIR"), "stderr: {stderr}");
+    assert!(workspace.join("patches/good.patch").exists(), "good patch must remain");
+    assert!(root.path().join("outside.patch").exists(), "outside patch must remain");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn patch_remove_rejects_directory_entries_before_deleting_any_patch() {
+    let (root, workspace, npmrc_info) = setup_patch_remove_project(&[
+        ("good", "patches/good.patch"),
+        ("bad", "patches/not-a-file.patch"),
+    ]);
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::create_dir_all(workspace.join("patches/not-a-file.patch")).expect("create patch directory");
+    fs::write(workspace.join("patches/good.patch"), "good patch").expect("write good patch");
+
+    let output = pacquet(&workspace, ["patch-remove", "good", "bad", "--reporter=silent"])
+        .output()
+        .expect("run patch-remove");
+
+    assert!(!output.status.success(), "directory patch target should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERR_PNPM_PATCH_FILE_IS_DIRECTORY"), "stderr: {stderr}");
+    assert!(workspace.join("patches/good.patch").exists(), "good patch must remain");
+
+    drop((root, mock_instance));
+}
+
+#[cfg(unix)]
+#[test]
+fn patch_remove_rejects_parent_symlink_outside_patches_dir_before_unlinking_target() {
+    let (root, workspace, npmrc_info) =
+        setup_patch_remove_project(&[("bad", "patches/linked-dir/dangling.patch")]);
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let patches_dir = workspace.join("patches");
+    let outside_dir = root.path().join("outside");
+    let outside_link = outside_dir.join("dangling.patch");
+    fs::create_dir_all(&patches_dir).expect("create patches dir");
+    fs::create_dir_all(&outside_dir).expect("create outside dir");
+    std::os::unix::fs::symlink(&outside_dir, patches_dir.join("linked-dir"))
+        .expect("symlink parent dir");
+    std::os::unix::fs::symlink(root.path().join("missing-target.patch"), &outside_link)
+        .expect("symlink dangling target");
+
+    let output = pacquet(&workspace, ["patch-remove", "bad", "--reporter=silent"])
+        .output()
+        .expect("run patch-remove");
+
+    assert!(!output.status.success(), "parent symlink outside patches dir should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERR_PNPM_PATCH_FILE_OUTSIDE_PATCHES_DIR"), "stderr: {stderr}");
+    assert!(
+        fs::symlink_metadata(&outside_link).expect("outside link").file_type().is_symlink(),
+        "outside symlink target must remain",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[cfg(unix)]
+#[test]
+fn patch_remove_unlinks_final_symlink_without_touching_target() {
+    let (root, workspace, npmrc_info) =
+        setup_patch_remove_project(&[("is-positive@1.0.0", "patches/linked.patch")]);
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let patches_dir = workspace.join("patches");
+    let outside_target = root.path().join("outside-target.patch");
+    let patch_link = patches_dir.join("linked.patch");
+    fs::create_dir_all(&patches_dir).expect("create patches dir");
+    fs::write(&outside_target, "outside target").expect("write outside target");
+    std::os::unix::fs::symlink(&outside_target, &patch_link).expect("symlink patch file");
+
+    pacquet(&workspace, ["patch-remove", "is-positive@1.0.0", "--reporter=silent"])
+        .assert()
+        .success();
+
+    assert!(!patch_link.exists(), "patch symlink should be removed");
+    assert_eq!(fs::read_to_string(&outside_target).expect("read outside target"), "outside target");
+
+    drop((root, mock_instance));
+}

--- a/pacquet/crates/cli/tests/patch.rs
+++ b/pacquet/crates/cli/tests/patch.rs
@@ -172,6 +172,30 @@ fn patch_errors_when_package_is_missing() {
 }
 
 #[test]
+fn patch_missing_package_name_takes_precedence_over_edit_dir_checks() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let edit_dir = workspace.join("custom-edit");
+    fs::create_dir_all(&edit_dir).expect("create edit dir");
+    fs::write(edit_dir.join("index.js"), "already here").expect("seed edit dir");
+
+    let output = pacquet(
+        &workspace,
+        ["patch", "--edit-dir", edit_dir.to_str().expect("utf8 edit dir"), "--reporter=silent"],
+    )
+    .output()
+    .expect("run patch");
+
+    assert!(!output.status.success(), "patch without package should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("requires the package name"), "stderr: {stderr}");
+    assert!(!stderr.contains("already exists"), "stderr: {stderr}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn patch_errors_when_requested_version_is_not_installed() {
     let (root, workspace, npmrc_info) = setup_installed();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
@@ -632,6 +656,32 @@ fn patch_errors_when_existing_patch_file_is_missing() {
 }
 
 #[test]
+fn patch_rejects_existing_patch_file_outside_patches_dir() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let outside_patch = workspace.parent().expect("workspace parent").join("outside.patch");
+    fs::write(&outside_patch, IS_POSITIVE_PATCH).expect("write outside patch");
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("patchedDependencies:\n  is-positive@1.0.0: ../outside.patch\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    let output = pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"])
+        .output()
+        .expect("run patch");
+
+    assert!(!output.status.success(), "outside patch file should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERR_PNPM_PATCH_FILE_OUTSIDE_PATCHES_DIR"), "stderr: {stderr}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn patch_exact_version_creates_edit_dir_and_state() {
     let (root, workspace, npmrc_info) = setup_installed();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
@@ -646,6 +696,40 @@ fn patch_exact_version_creates_edit_dir_and_state() {
     let state = patch_state(&workspace);
     assert_eq!(state[&key]["patchedPkg"], "is-positive@1.0.0");
     assert_eq!(state[&key]["applyToAll"], false);
+
+    drop((root, mock_instance));
+}
+
+#[cfg(unix)]
+#[test]
+fn patch_commit_rejects_symlinked_patch_file_outside_patches_dir() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"]).assert().success();
+    let edit_dir = workspace.join("node_modules/.pnpm_patches/is-positive@1.0.0");
+    write_patch_edit(&edit_dir, "symlink write attempt");
+    let patches_dir = workspace.join("patches");
+    fs::create_dir_all(&patches_dir).expect("create patches dir");
+    let outside_target = workspace.parent().expect("workspace parent").join("outside.patch");
+    fs::write(&outside_target, "outside original\n").expect("write outside target");
+    std::os::unix::fs::symlink(&outside_target, patches_dir.join("is-positive@1.0.0.patch"))
+        .expect("create patch symlink");
+
+    let output = pacquet(
+        &workspace,
+        ["patch-commit", edit_dir.to_str().expect("utf8 edit dir"), "--reporter=silent"],
+    )
+    .output()
+    .expect("run patch-commit");
+
+    assert!(!output.status.success(), "symlinked patch file should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERR_PNPM_PATCH_FILE_OUTSIDE_PATCHES_DIR"), "stderr: {stderr}");
+    assert_eq!(
+        fs::read_to_string(&outside_target).expect("read outside target"),
+        "outside original\n",
+    );
 
     drop((root, mock_instance));
 }

--- a/pacquet/crates/cli/tests/patch.rs
+++ b/pacquet/crates/cli/tests/patch.rs
@@ -696,6 +696,7 @@ fn patch_exact_version_creates_edit_dir_and_state() {
     let state = patch_state(&workspace);
     assert_eq!(state[&key]["patchedPkg"], "is-positive@1.0.0");
     assert_eq!(state[&key]["applyToAll"], false);
+    assert_eq!(state[&key]["packageKey"], "is-positive@1.0.0");
 
     drop((root, mock_instance));
 }
@@ -769,6 +770,7 @@ fn patch_bare_name_single_version_sets_apply_to_all() {
     let state = patch_state(&workspace);
     assert_eq!(state[&key]["patchedPkg"], "is-positive");
     assert_eq!(state[&key]["applyToAll"], true);
+    assert_eq!(state[&key]["packageKey"], "is-positive@1.0.0");
 
     drop((root, mock_instance));
 }
@@ -827,6 +829,7 @@ fn patch_accepts_empty_custom_edit_dir() {
     let key = dunce::canonicalize(&edit_dir).expect("canonical edit dir").display().to_string();
     let state = patch_state(&workspace);
     assert_eq!(state[&key]["patchedPkg"], "is-positive@1.0.0");
+    assert_eq!(state[&key]["packageKey"], "is-positive@1.0.0");
 
     drop((root, mock_instance));
 }

--- a/pacquet/crates/cli/tests/patch.rs
+++ b/pacquet/crates/cli/tests/patch.rs
@@ -702,6 +702,29 @@ fn patch_exact_version_creates_edit_dir_and_state() {
 
 #[cfg(unix)]
 #[test]
+fn patch_rejects_symlinked_default_edit_root() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let outside_dir = root.path().join("outside-patch-edits");
+    fs::create_dir(&outside_dir).expect("create outside edit dir");
+    std::os::unix::fs::symlink(&outside_dir, workspace.join("node_modules/.pnpm_patches"))
+        .expect("symlink default patch edit root");
+
+    let output = pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"])
+        .output()
+        .expect("run patch");
+
+    assert!(!output.status.success(), "symlinked default edit root should fail");
+    assert!(
+        !outside_dir.join("is-positive@1.0.0").exists(),
+        "package files must not be extracted outside node_modules",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[cfg(unix)]
+#[test]
 fn patch_commit_rejects_symlinked_patch_file_outside_patches_dir() {
     let (root, workspace, npmrc_info) = setup_installed();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;

--- a/pacquet/crates/cli/tests/remove.rs
+++ b/pacquet/crates/cli/tests/remove.rs
@@ -33,6 +33,26 @@ fn should_remove_from_package_json() {
 }
 
 #[test]
+fn remove_runs_with_ndjson_and_silent_reporters() {
+    for reporter in ["--reporter=ndjson", "--reporter=silent"] {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        pacquet.with_args(["add", "@pnpm.e2e/hello-world-js-bin"]).assert().success();
+        assert!(manifest_has(&workspace, DependencyGroup::Prod, "@pnpm.e2e/hello-world-js-bin"));
+
+        pacquet_at(&workspace)
+            .with_args([reporter, "remove", "@pnpm.e2e/hello-world-js-bin"])
+            .assert()
+            .success();
+        assert!(!manifest_has(&workspace, DependencyGroup::Prod, "@pnpm.e2e/hello-world-js-bin"));
+
+        drop((root, mock_instance));
+    }
+}
+
+#[test]
 fn should_remove_only_from_targeted_field() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pacquet/crates/cli/tests/runtime.rs
+++ b/pacquet/crates/cli/tests/runtime.rs
@@ -1,0 +1,23 @@
+use pacquet_testing_utils::bin::CommandTempCwd;
+use std::fs;
+
+#[test]
+fn runtime_unknown_subcommand_runs_with_default_ndjson_and_silent_reporters() {
+    for reporter in [None, Some("--reporter=ndjson"), Some("--reporter=silent")] {
+        let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+        fs::write(workspace.join("package.json"), "{}").expect("write package.json");
+
+        let mut command = pacquet;
+        if let Some(reporter) = reporter {
+            command.arg(reporter);
+        }
+        command.arg("runtime").arg("unknown");
+        let output = command.output().expect("spawn pacquet runtime");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(!output.status.success(), "unknown runtime subcommand must fail");
+        assert!(stderr.contains("ERR_PNPM_RUNTIME_UNKNOWN_SUBCOMMAND"), "stderr: {stderr}");
+
+        drop(root);
+    }
+}

--- a/pacquet/crates/cli/tests/test_command.rs
+++ b/pacquet/crates/cli/tests/test_command.rs
@@ -1,0 +1,26 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use serde_json::json;
+use std::fs;
+
+#[cfg_attr(target_os = "windows", ignore = "uses a POSIX shell command")]
+#[test]
+fn test_runs_declared_test_script() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let marker = workspace.join("tested.txt");
+    let manifest = json!({
+        "name": "test-command",
+        "version": "0.0.0",
+        "scripts": {
+            "test": format!(r#"printf tested > "{}""#, marker.display()),
+        },
+    });
+    fs::write(workspace.join("package.json"), manifest.to_string()).expect("write package.json");
+
+    pacquet.with_arg("test").assert().success();
+
+    assert_eq!(fs::read_to_string(marker).expect("read marker"), "tested");
+
+    drop(root);
+}

--- a/pacquet/crates/cli/tests/update.rs
+++ b/pacquet/crates/cli/tests/update.rs
@@ -116,6 +116,26 @@ fn update_bumps_within_range() {
     drop((root, anchor));
 }
 
+#[test]
+fn update_runs_with_ndjson_and_silent_reporters() {
+    for reporter in ["--reporter=ndjson", "--reporter=silent"] {
+        let (root, workspace, anchor) = setup();
+
+        write_manifest(&workspace, &format!(r#"{{ "{DEP}": "100.0.0" }}"#));
+        pacquet(&workspace, ["install"]).assert().success();
+        write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+
+        pacquet(&workspace, [reporter, "update"]).assert().success();
+
+        assert!(
+            virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"),
+            "update should bump the dependency when running with {reporter}",
+        );
+
+        drop((root, anchor));
+    }
+}
+
 /// Mixing a transitive selector with a direct dependency selector must
 /// still update the matching transitive package. Ports pnpm's regression
 /// test for <https://github.com/pnpm/pnpm/issues/12103>, where a direct

--- a/pacquet/crates/config/src/env_overlay.rs
+++ b/pacquet/crates/config/src/env_overlay.rs
@@ -178,6 +178,7 @@ impl WorkspaceSettings {
         json_field!(fetch_timeout, "FETCH_TIMEOUT");
         string_field!(user_agent, "USER_AGENT");
         json_field!(patched_dependencies, "PATCHED_DEPENDENCIES");
+        string_field!(patches_dir, "PATCHES_DIR");
         json_field!(allow_builds, "ALLOW_BUILDS");
         json_field!(dangerously_allow_all_builds, "DANGEROUSLY_ALLOW_ALL_BUILDS");
         json_field!(strict_dep_builds, "STRICT_DEP_BUILDS");

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1007,6 +1007,11 @@ pub struct Config {
     /// [`addSettingsFromWorkspaceManifestToConfig`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/index.ts#L803-L831).
     pub patched_dependencies: Option<IndexMap<String, String>>,
 
+    /// Raw `patchesDir` setting used by `patch-commit` when writing
+    /// generated patch files. `None` means the command default
+    /// (`patches`) applies, matching pnpm's `opts.patchesDir ?? 'patches'`.
+    pub patches_dir: Option<String>,
+
     /// Raw `configDependencies` from `pnpm-workspace.yaml`: package
     /// name → version-with-integrity spec. Recorded verbatim in the
     /// workspace-state file so pnpm's `checkDepsStatus` sees the same

--- a/pacquet/crates/config/src/tests.rs
+++ b/pacquet/crates/config/src/tests.rs
@@ -1359,6 +1359,34 @@ pub fn pnpm_config_env_var_overrides_workspace_yaml() {
     );
 }
 
+#[test]
+pub fn patches_dir_reads_from_env_overlay() {
+    struct HostWithPatchesDirEnv;
+    impl EnvVar for HostWithPatchesDirEnv {
+        fn var(name: &str) -> Option<String> {
+            if name == "PNPM_CONFIG_PATCHES_DIR" {
+                return Some("custom-patches".to_owned());
+            }
+            safe_host_var(name)
+        }
+    }
+    impl EnvVarOs for HostWithPatchesDirEnv {
+        fn var_os(_: &str) -> Option<OsString> {
+            None
+        }
+    }
+    impl GetHomeDir for HostWithPatchesDirEnv {
+        fn home_dir() -> Option<PathBuf> {
+            None
+        }
+    }
+    inert_link_probe!(HostWithPatchesDirEnv);
+
+    let tmp = tempdir().unwrap();
+    let config = Config::new().current::<HostWithPatchesDirEnv>(tmp.path()).expect("loads");
+    assert_eq!(config.patches_dir.as_deref(), Some("custom-patches"));
+}
+
 /// `PNPM_CONFIG_HOIST=false` runs the same post-processing as
 /// yaml-set `hoist: false` — it short-circuits `hoist_pattern`
 /// to `None`, mirroring upstream's

--- a/pacquet/crates/config/src/workspace_yaml.rs
+++ b/pacquet/crates/config/src/workspace_yaml.rs
@@ -194,6 +194,8 @@ pub struct WorkspaceSettings {
     /// [`BTreeMap`]: std::collections::BTreeMap
     pub patched_dependencies: Option<IndexMap<String, String>>,
 
+    pub patches_dir: Option<String>,
+
     /// `configDependencies` from `pnpm-workspace.yaml`: package name →
     /// version-with-integrity spec. pnpm records this verbatim in the
     /// workspace-state file so that `checkDepsStatus` can detect when a
@@ -685,6 +687,7 @@ impl WorkspaceSettings {
         substitute_optional_string::<Sys>(&mut self.global_virtual_store_dir);
         substitute_optional_string::<Sys>(&mut self.user_agent);
         substitute_optional_string::<Sys>(&mut self.npmrc_auth_file);
+        substitute_optional_string::<Sys>(&mut self.patches_dir);
         substitute_optional_string::<Sys>(&mut self.cache_dir);
         substitute_optional_inner_string::<Sys>(&mut self.script_shell);
         substitute_optional_inner_string::<Sys>(&mut self.node_options);
@@ -788,6 +791,9 @@ impl WorkspaceSettings {
         config.workspace_dir = Some(base_dir.to_path_buf());
         if let Some(v) = self.patched_dependencies {
             config.patched_dependencies = Some(v);
+        }
+        if let Some(v) = self.patches_dir {
+            config.patches_dir = Some(v);
         }
         if let Some(v) = self.config_dependencies {
             config.config_dependencies = Some(v);

--- a/pacquet/crates/config/src/workspace_yaml/tests.rs
+++ b/pacquet/crates/config/src/workspace_yaml/tests.rs
@@ -470,6 +470,17 @@ patchedDependencies:
     assert_eq!(map.get("lodash@4.17.21").map(String::as_str), Some("patches/lodash@4.17.21.patch"));
 }
 
+#[test]
+fn patches_dir_reads_from_workspace_yaml() {
+    let settings: WorkspaceSettings =
+        serde_saphyr::from_str("patchesDir: custom-patches\n").unwrap();
+    assert_eq!(settings.patches_dir.as_deref(), Some("custom-patches"));
+
+    let mut config = Config::new();
+    settings.apply_to(&mut config, Path::new("/workspace/root"));
+    assert_eq!(config.patches_dir.as_deref(), Some("custom-patches"));
+}
+
 /// `configDependencies` is a map of package name → version-with-integrity
 /// spec. pacquet records it into the workspace-state file so pnpm's
 /// `checkDepsStatus` doesn't treat the install as stale on the next

--- a/pacquet/crates/engine-runtime-node-resolver/src/node_resolver.rs
+++ b/pacquet/crates/engine-runtime-node-resolver/src/node_resolver.rs
@@ -373,14 +373,11 @@ struct NodeFileName {
 fn parse_node_file_name(file_name: &str, version: &str) -> Option<NodeFileName> {
     let prefix = format!("node-v{version}-");
     let rest = file_name.strip_prefix(&prefix)?;
-    let (head, suffix) = if let Some(head) = rest.strip_suffix(".tar.gz") {
-        (head, ".tar.gz")
-    } else if let Some(head) = rest.strip_suffix(".zip") {
-        (head, ".zip")
+    let head = if let Some(head) = rest.strip_suffix(".tar.gz") {
+        head
     } else {
-        return None;
+        rest.strip_suffix(".zip")?
     };
-    let _ = suffix;
     let (platform, after_platform) = head.split_once('-')?;
     if platform.is_empty() || platform.contains('.') {
         return None;

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -781,7 +781,7 @@ fn walk_subgraph<'g>(
 /// depNode.peerDependencies[child.alias]?.optional === true` in
 /// [`updateLockfile`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/updateLockfile.ts#L28-L31).
 fn optional_children_of(node: &DependenciesGraphNode) -> HashSet<String> {
-    let mut out: HashSet<String> = HashSet::new();
+    let mut out: HashSet<String> = node.optional_children.clone();
     if let Some(manifest) = node.resolve_result.manifest.as_ref()
         && let Some(map) = manifest.get("optionalDependencies").and_then(Value::as_object)
     {

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -6,13 +6,17 @@ use pacquet_lockfile::{
     RegistryResolution, SnapshotDepRef, VariationsResolution,
 };
 use pacquet_package_manifest::PackageManifest;
-use pacquet_resolving_deps_resolver::{DependenciesGraph, DependenciesGraphNode, PeerDep};
+use pacquet_resolving_deps_resolver::{
+    ChildEdge, DependenciesGraph, DependenciesGraphNode, DependenciesTreeNode, DirectDep, NodeId,
+    PeerDep, ResolvePeersOptions, ResolvedPackage, ResolvedTree, TreeChildren, resolve_peers,
+};
 use pacquet_resolving_resolver_base::{PkgResolutionId, ResolveResult};
 use serde_json::json;
 use ssri::Integrity;
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     str::FromStr,
+    sync::Arc,
 };
 use tempfile::TempDir;
 
@@ -113,6 +117,7 @@ fn make_node_with_optional(
         resolved_package_id: format!("{name}@{version}"),
         resolve_result: std::sync::Arc::new(make_resolve_result(name, version, manifest)),
         children,
+        optional_children: HashSet::new(),
         peer_dependencies,
         transitive_peer_dependencies,
         resolved_peer_names: HashSet::new(),
@@ -489,6 +494,7 @@ fn runtime_dependency_strips_importer_prefix_and_records_package_version() {
         resolved_package_id: "node@runtime:26.3.0".to_string(),
         resolve_result: std::sync::Arc::new(resolve_result),
         children: BTreeMap::new(),
+        optional_children: HashSet::new(),
         peer_dependencies: BTreeMap::new(),
         transitive_peer_dependencies: HashSet::new(),
         resolved_peer_names: HashSet::new(),
@@ -567,6 +573,7 @@ fn peer_suffixed_dep_path_splits_into_distinct_snapshot_and_package_keys() {
             }),
         )),
         children: react_dom_children,
+        optional_children: HashSet::new(),
         peer_dependencies: react_dom_peers,
         transitive_peer_dependencies: HashSet::new(),
         resolved_peer_names: std::iter::once("react".to_string()).collect(),
@@ -660,6 +667,98 @@ fn snapshot_partitions_optional_children_by_manifest_optional_dependencies() {
         SnapshotDepRef::Plain(ver) => assert_eq!(ver.to_string(), "1.0.0"),
         other => panic!("expected Plain, got {other:?}"),
     }
+}
+
+#[test]
+fn snapshot_preserves_optional_child_edges_from_resolved_tree() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "fixture",
+        "version": "1.0.0",
+        "dependencies": { "outer": "^1.0.0" },
+    }));
+
+    let outer_id = "outer@1.0.0".to_string();
+    let inner_id = "inner@1.0.0".to_string();
+    let outer_node_id = NodeId::next();
+
+    let mut tree = ResolvedTree {
+        direct: vec![DirectDep {
+            alias: "outer".to_string(),
+            node_id: outer_node_id.clone(),
+            id: outer_id.clone(),
+        }],
+        packages: HashMap::from([
+            (
+                outer_id.clone(),
+                ResolvedPackage {
+                    id: outer_id.clone(),
+                    result: Arc::new(make_resolve_result(
+                        "outer",
+                        "1.0.0",
+                        json!({ "name": "outer", "version": "1.0.0" }),
+                    )),
+                    peer_dependencies: BTreeMap::new(),
+                    optional: false,
+                    is_leaf: false,
+                },
+            ),
+            (
+                inner_id.clone(),
+                ResolvedPackage {
+                    id: inner_id.clone(),
+                    result: Arc::new(make_resolve_result(
+                        "inner",
+                        "1.0.0",
+                        json!({ "name": "inner", "version": "1.0.0" }),
+                    )),
+                    peer_dependencies: BTreeMap::new(),
+                    optional: true,
+                    is_leaf: true,
+                },
+            ),
+        ]),
+        dependencies_tree: HashMap::from([(
+            outer_node_id,
+            DependenciesTreeNode {
+                resolved_package_id: outer_id.clone(),
+                children: TreeChildren::Lazy { parent_ids: Arc::new(Vec::new()) },
+                depth: 0,
+                installable: true,
+            },
+        )]),
+        all_peer_dep_names: HashSet::new(),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::from([(
+            outer_id,
+            Arc::new(vec![ChildEdge {
+                alias: "inner".to_string(),
+                pkg_id: inner_id,
+                optional: true,
+            }]),
+        )]),
+    };
+
+    let resolved = resolve_peers(&mut tree, ResolvePeersOptions::default());
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest,
+        &resolved.graph,
+        resolved.direct_dependencies_by_alias,
+        false,
+        false,
+        None,
+        None,
+    ));
+
+    let snapshots = lockfile.snapshots.as_ref().unwrap();
+    let outer_key: PackageKey = "outer@1.0.0".parse().unwrap();
+    let outer_snap = &snapshots[&outer_key];
+    assert!(outer_snap.dependencies.is_none(), "optional child must not be written as regular");
+    let opt = outer_snap.optional_dependencies.as_ref().expect("opt deps map");
+    assert!(opt.contains_key(&PkgName::parse("inner").unwrap()));
+
+    let inner_key: PackageKey = "inner@1.0.0".parse().unwrap();
+    assert!(snapshots[&inner_key].optional, "optional child edge keeps the child optional");
 }
 
 #[test]
@@ -924,6 +1023,7 @@ fn make_link_node(target: &str, manifest: serde_json::Value) -> DependenciesGrap
         resolved_package_id: id_text,
         resolve_result: std::sync::Arc::new(resolve_result),
         children: BTreeMap::new(),
+        optional_children: HashSet::new(),
         peer_dependencies: BTreeMap::new(),
         transitive_peer_dependencies: HashSet::new(),
         resolved_peer_names: HashSet::new(),

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -85,6 +85,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         npmrc_auth_file: None,
         workspace_dir: None,
         patched_dependencies: None,
+        patches_dir: None,
         config_dependencies: None,
         allow_builds: Default::default(),
         dangerously_allow_all_builds: false,

--- a/pacquet/crates/package-manager/src/lib.rs
+++ b/pacquet/crates/package-manager/src/lib.rs
@@ -31,6 +31,8 @@ mod optimistic_repeat_install;
 mod overrides;
 mod package_extender;
 mod package_map;
+mod patch;
+mod patch_commit;
 mod prefetching_resolver;
 mod prune_virtual_store;
 mod remove;
@@ -81,6 +83,8 @@ pub use package_extender::*;
 pub use package_map::{
     WritePackageMapError, make_node_package_map_option, package_map_path_for_execution,
 };
+pub use patch::*;
+pub use patch_commit::*;
 pub use prefetching_resolver::*;
 pub use remove::*;
 pub use resolution_observer::*;

--- a/pacquet/crates/package-manager/src/overrides.rs
+++ b/pacquet/crates/package-manager/src/overrides.rs
@@ -391,10 +391,8 @@ fn semver_satisfies(version: &str, range: &str) -> bool {
 fn parse_local_target(new_bare_specifier: &str, root_dir: &Path) -> Option<LocalTarget> {
     let (protocol, pkg_path) = if let Some(rest) = new_bare_specifier.strip_prefix("file:") {
         (LocalProtocol::File, rest)
-    } else if let Some(rest) = new_bare_specifier.strip_prefix("link:") {
-        (LocalProtocol::Link, rest)
     } else {
-        return None;
+        (LocalProtocol::Link, new_bare_specifier.strip_prefix("link:")?)
     };
 
     let candidate = Path::new(pkg_path);

--- a/pacquet/crates/package-manager/src/patch.rs
+++ b/pacquet/crates/package-manager/src/patch.rs
@@ -214,7 +214,7 @@ impl WritePackageForPatch<'_> {
         .map_err(WritePackageForPatchError::DownloadTarball)?;
         let raw_cas_paths = (*cas_paths).clone();
         let cas_paths = if let LockfileResolution::Tarball(t) = &metadata.resolution
-            && t.git_hosted == Some(true)
+            && git_tarball_url(&metadata.resolution).is_some()
         {
             let allow_build_closure = |_dep_path: &str| false;
             let files_index_file = git_hosted_store_index_key(&package_id, !config.ignore_scripts);

--- a/pacquet/crates/package-manager/src/patch.rs
+++ b/pacquet/crates/package-manager/src/patch.rs
@@ -1,0 +1,319 @@
+use crate::{
+    ImportIndexedDirError, ImportIndexedDirOpts, InstallPackageBySnapshotError, import_indexed_dir,
+    retry_config::retry_opts_from_config, tarball_url_and_integrity,
+};
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use node_semver::{Range, Version};
+use pacquet_config::{Config, PackageImportMethod, ScriptsPrependNodePath};
+use pacquet_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
+use pacquet_git_fetcher::{GitFetchOutput, GitFetcherError, GitHostedTarballFetcher};
+use pacquet_lockfile::{Lockfile, LockfileResolution, PackageKey, is_git_hosted_tarball_url};
+use pacquet_network::ThrottledClient;
+use pacquet_reporter::Reporter;
+use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
+use pacquet_store_dir::{SharedVerifiedFilesCache, git_hosted_store_index_key};
+use pacquet_tarball::{DownloadTarballToStore, MemCache, TarballError};
+use std::{cmp::Ordering, collections::BTreeSet, path::Path, sync::atomic::AtomicU8};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PatchCandidate {
+    pub name: String,
+    pub version: String,
+    pub git_tarball_url: Option<String>,
+    pub package_key: PackageKey,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PatchCandidateSet {
+    pub alias: String,
+    pub requested: String,
+    pub bare_specifier: Option<String>,
+    pub versions: Vec<PatchCandidate>,
+    pub preferred_versions: Vec<PatchCandidate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PatchTarget {
+    pub alias: String,
+    pub version: String,
+    pub bare_specifier: String,
+    pub apply_to_all: bool,
+    pub git_tarball_url: Option<String>,
+    pub package_key: PackageKey,
+}
+
+#[must_use]
+pub struct WritePackageForPatch<'a> {
+    pub tarball_mem_cache: &'a MemCache,
+    pub http_client: &'a ThrottledClient,
+    pub config: &'static Config,
+    pub current_lockfile: &'a Lockfile,
+    pub target: &'a PatchTarget,
+    pub dest: &'a Path,
+}
+
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum PatchTargetError {
+    #[display("Can not find {requested} in the current lockfile, {hint}")]
+    #[diagnostic(code(ERR_PNPM_PATCH_VERSION_NOT_FOUND))]
+    VersionNotFound { requested: String, hint: String },
+}
+
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum WritePackageForPatchError {
+    #[display("Package `{package_key}` is missing from the current lockfile packages map.")]
+    #[diagnostic(code(pacquet_package_manager::patch_package_missing_metadata))]
+    MissingPackageMetadata { package_key: String },
+
+    #[display(
+        "Package `{package}` uses a `{resolution_kind}` resolution, which pacquet patch does not yet support."
+    )]
+    #[diagnostic(code(pacquet_package_manager::patch_unsupported_resolution))]
+    UnsupportedResolution { package: String, resolution_kind: &'static str },
+
+    #[diagnostic(transparent)]
+    TarballResolution(#[error(source)] InstallPackageBySnapshotError),
+
+    #[diagnostic(transparent)]
+    DownloadTarball(#[error(source)] TarballError),
+
+    #[diagnostic(transparent)]
+    GitFetch(#[error(source)] GitFetcherError),
+
+    #[diagnostic(transparent)]
+    ImportIndexedDir(#[error(source)] ImportIndexedDirError),
+}
+
+pub fn patch_candidates_from_lockfile(
+    raw_dependency: &str,
+    current_lockfile: &Lockfile,
+) -> Result<PatchCandidateSet, PatchTargetError> {
+    let parsed = parse_wanted_dependency(raw_dependency);
+    let package_name =
+        parsed.alias.as_deref().or(parsed.bare_specifier.as_deref()).unwrap_or(raw_dependency);
+    let alias = parsed.alias.clone().unwrap_or_else(|| raw_dependency.to_string());
+    let bare_specifier = parsed.bare_specifier.clone();
+
+    let mut versions = Vec::new();
+    let mut seen = BTreeSet::new();
+    for (key, metadata) in current_lockfile.packages.as_ref().into_iter().flatten() {
+        let package_key = key.without_peer();
+        let name = package_key.name.to_string();
+        if name != package_name {
+            continue;
+        }
+        let version =
+            metadata.version.clone().unwrap_or_else(|| package_key.suffix.version().to_string());
+        let git_tarball_url = git_tarball_url(&metadata.resolution);
+        if seen.insert((name.clone(), version.clone(), git_tarball_url.clone())) {
+            versions.push(PatchCandidate { name, version, git_tarball_url, package_key });
+        }
+    }
+    versions.sort_by(compare_candidates);
+
+    let preferred_versions = match bare_specifier.as_deref() {
+        Some(specifier) => versions
+            .iter()
+            .filter(|candidate| version_satisfies(&candidate.version, specifier))
+            .cloned()
+            .collect(),
+        None => versions.clone(),
+    };
+
+    if preferred_versions.is_empty() {
+        return Err(PatchTargetError::VersionNotFound {
+            requested: raw_dependency.to_string(),
+            hint: version_not_found_hint(&versions, raw_dependency),
+        });
+    }
+
+    Ok(PatchCandidateSet {
+        alias,
+        requested: raw_dependency.to_string(),
+        bare_specifier,
+        versions,
+        preferred_versions,
+    })
+}
+
+#[must_use]
+pub fn default_patch_target(set: &PatchCandidateSet) -> Option<PatchTarget> {
+    if set.preferred_versions.len() != 1 {
+        return None;
+    }
+    let preferred = set.preferred_versions.first().expect("len checked");
+    let bare_specifier =
+        preferred.git_tarball_url.clone().unwrap_or_else(|| preferred.version.clone());
+    Some(PatchTarget {
+        alias: set.alias.clone(),
+        version: preferred.version.clone(),
+        bare_specifier,
+        apply_to_all: set.bare_specifier.is_none() && preferred.git_tarball_url.is_none(),
+        git_tarball_url: preferred.git_tarball_url.clone(),
+        package_key: preferred.package_key.clone(),
+    })
+}
+
+impl WritePackageForPatch<'_> {
+    pub async fn run<Reporter: self::Reporter>(self) -> Result<(), WritePackageForPatchError> {
+        let WritePackageForPatch {
+            tarball_mem_cache,
+            http_client,
+            config,
+            current_lockfile,
+            target,
+            dest,
+        } = self;
+        let metadata = current_lockfile
+            .packages
+            .as_ref()
+            .and_then(|packages| packages.get(&target.package_key))
+            .ok_or_else(|| WritePackageForPatchError::MissingPackageMetadata {
+                package_key: target.package_key.to_string(),
+            })?;
+
+        if !matches!(
+            metadata.resolution,
+            LockfileResolution::Registry(_) | LockfileResolution::Tarball(_),
+        ) {
+            return Err(WritePackageForPatchError::UnsupportedResolution {
+                package: format!("{}@{}", target.alias, target.version),
+                resolution_kind: resolution_kind(&metadata.resolution),
+            });
+        }
+
+        let (tarball_url, integrity) =
+            tarball_url_and_integrity(&metadata.resolution, &target.package_key, config)
+                .map_err(WritePackageForPatchError::TarballResolution)?;
+        let package_id = format!("{}@{}", target.alias, target.version);
+        let cas_paths = DownloadTarballToStore {
+            http_client,
+            store_dir: &config.store_dir,
+            store_index: None,
+            store_index_writer: None,
+            verify_store_integrity: config.verify_store_integrity,
+            verified_files_cache: SharedVerifiedFilesCache::default(),
+            package_integrity: integrity,
+            package_unpacked_size: None,
+            package_file_count: None,
+            package_url: &tarball_url,
+            package_id: &package_id,
+            auth_headers: &config.auth_headers,
+            requester: "",
+            prefetched_cas_paths: None,
+            retry_opts: retry_opts_from_config(config),
+            ignore_file_pattern: None,
+            offline: config.offline,
+            progress_reported: None,
+        }
+        .run_with_mem_cache::<Reporter>(tarball_mem_cache)
+        .await
+        .map_err(WritePackageForPatchError::DownloadTarball)?;
+        let raw_cas_paths = (*cas_paths).clone();
+        let cas_paths = if let LockfileResolution::Tarball(t) = &metadata.resolution
+            && t.git_hosted == Some(true)
+        {
+            let allow_build_closure = |_dep_path: &str| false;
+            let files_index_file = git_hosted_store_index_key(&package_id, !config.ignore_scripts);
+            let GitFetchOutput { cas_paths, built: _built } = GitHostedTarballFetcher {
+                cas_paths: raw_cas_paths,
+                path: t.path.as_deref(),
+                allow_build: &allow_build_closure,
+                ignore_scripts: config.ignore_scripts,
+                unsafe_perm: config.unsafe_perm,
+                user_agent: None,
+                scripts_prepend_node_path: executor_scripts_prepend_node_path(
+                    config.scripts_prepend_node_path,
+                ),
+                script_shell: None,
+                node_execpath: None,
+                npm_execpath: None,
+                store_dir: &config.store_dir,
+                package_id: &package_id,
+                requester: "",
+                store_index_writer: None,
+                files_index_file: &files_index_file,
+            }
+            .run::<Reporter>()
+            .await
+            .map_err(WritePackageForPatchError::GitFetch)?;
+            cas_paths
+        } else {
+            raw_cas_paths
+        };
+
+        import_indexed_dir::<Reporter>(
+            &AtomicU8::new(0),
+            PackageImportMethod::CloneOrCopy,
+            dest,
+            &cas_paths,
+            ImportIndexedDirOpts { force: true, keep_modules_dir: false },
+        )
+        .map_err(WritePackageForPatchError::ImportIndexedDir)
+    }
+}
+
+fn git_tarball_url(resolution: &LockfileResolution) -> Option<String> {
+    let LockfileResolution::Tarball(tarball) = resolution else { return None };
+    (tarball.git_hosted == Some(true)
+        || is_git_hosted_tarball_url(&tarball.tarball)
+        || tarball.tarball.starts_with("https://pkg.pr.new/"))
+    .then(|| tarball.tarball.clone())
+}
+
+fn executor_scripts_prepend_node_path(
+    scripts_prepend_node_path: ScriptsPrependNodePath,
+) -> ExecScriptsPrependNodePath {
+    match scripts_prepend_node_path {
+        ScriptsPrependNodePath::Always => ExecScriptsPrependNodePath::Always,
+        ScriptsPrependNodePath::Never => ExecScriptsPrependNodePath::Never,
+        ScriptsPrependNodePath::WarnOnly => ExecScriptsPrependNodePath::WarnOnly,
+    }
+}
+
+fn version_satisfies(version: &str, range: &str) -> bool {
+    let Ok(version) = Version::parse(version) else { return false };
+    let Ok(range) = Range::parse(range) else { return false };
+    version.satisfies(&range)
+}
+
+fn compare_candidates(left: &PatchCandidate, right: &PatchCandidate) -> Ordering {
+    match (Version::parse(&left.version), Version::parse(&right.version)) {
+        (Ok(left), Ok(right)) => left.cmp(&right),
+        (Ok(_), Err(_)) => Ordering::Less,
+        (Err(_), Ok(_)) => Ordering::Greater,
+        (Err(_), Err(_)) => Ordering::Equal,
+    }
+}
+
+fn version_not_found_hint(versions: &[PatchCandidate], raw_dependency: &str) -> String {
+    if versions.is_empty() {
+        format!("did you forget to install {raw_dependency}?")
+    } else {
+        format!(
+            "you can specify currently installed version: {}.",
+            versions
+                .iter()
+                .map(|candidate| candidate.version.as_str())
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
+    }
+}
+
+fn resolution_kind(resolution: &LockfileResolution) -> &'static str {
+    match resolution {
+        LockfileResolution::Tarball(_) => "tarball",
+        LockfileResolution::Registry(_) => "registry",
+        LockfileResolution::Directory(_) => "directory",
+        LockfileResolution::Git(_) => "git",
+        LockfileResolution::Binary(_) => "binary",
+        LockfileResolution::Variations(_) => "variations",
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/package-manager/src/patch.rs
+++ b/pacquet/crates/package-manager/src/patch.rs
@@ -12,9 +12,18 @@ use pacquet_lockfile::{Lockfile, LockfileResolution, PackageKey, is_git_hosted_t
 use pacquet_network::ThrottledClient;
 use pacquet_reporter::Reporter;
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
-use pacquet_store_dir::{SharedVerifiedFilesCache, git_hosted_store_index_key};
+use pacquet_store_dir::{
+    SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreIndex, StoreIndexError,
+    StoreIndexWriter, git_hosted_store_index_key,
+};
 use pacquet_tarball::{DownloadTarballToStore, MemCache, TarballError};
-use std::{cmp::Ordering, collections::BTreeSet, path::Path, sync::atomic::AtomicU8};
+use std::{
+    cmp::Ordering,
+    collections::BTreeSet,
+    io,
+    path::{Path, PathBuf},
+    sync::{Arc, atomic::AtomicU8},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PatchCandidate {
@@ -76,6 +85,18 @@ pub enum WritePackageForPatchError {
 
     #[diagnostic(transparent)]
     TarballResolution(#[error(source)] InstallPackageBySnapshotError),
+
+    #[display("Failed to inspect patch edit directory {dest:?}: {source}")]
+    #[diagnostic(code(pacquet_package_manager::patch_dest_stat))]
+    PatchDestinationStat {
+        dest: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display("Refusing to write package files to unsafe patch edit directory {dest:?}: {reason}")]
+    #[diagnostic(code(pacquet_package_manager::unsafe_patch_dest))]
+    UnsafePatchDestination { dest: PathBuf, reason: &'static str },
 
     #[diagnostic(transparent)]
     DownloadTarball(#[error(source)] TarballError),
@@ -189,70 +210,145 @@ impl WritePackageForPatch<'_> {
             tarball_url_and_integrity(&metadata.resolution, &target.package_key, config)
                 .map_err(WritePackageForPatchError::TarballResolution)?;
         let package_id = format!("{}@{}", target.alias, target.version);
-        let cas_paths = DownloadTarballToStore {
-            http_client,
-            store_dir: &config.store_dir,
-            store_index: None,
-            store_index_writer: None,
-            verify_store_integrity: config.verify_store_integrity,
-            verified_files_cache: SharedVerifiedFilesCache::default(),
-            package_integrity: integrity,
-            package_unpacked_size: None,
-            package_file_count: None,
-            package_url: &tarball_url,
-            package_id: &package_id,
-            auth_headers: &config.auth_headers,
-            requester: "",
-            prefetched_cas_paths: None,
-            retry_opts: retry_opts_from_config(config),
-            ignore_file_pattern: None,
-            offline: config.offline,
-            progress_reported: None,
-        }
-        .run_with_mem_cache::<Reporter>(tarball_mem_cache)
-        .await
-        .map_err(WritePackageForPatchError::DownloadTarball)?;
-        let raw_cas_paths = (*cas_paths).clone();
-        let cas_paths = if let LockfileResolution::Tarball(t) = &metadata.resolution
-            && git_tarball_url(&metadata.resolution).is_some()
-        {
-            let allow_build_closure = |_dep_path: &str| false;
-            let files_index_file = git_hosted_store_index_key(&package_id, !config.ignore_scripts);
-            let GitFetchOutput { cas_paths, built: _built } = GitHostedTarballFetcher {
-                cas_paths: raw_cas_paths,
-                path: t.path.as_deref(),
-                allow_build: &allow_build_closure,
-                ignore_scripts: config.ignore_scripts,
-                unsafe_perm: config.unsafe_perm,
-                user_agent: None,
-                scripts_prepend_node_path: executor_scripts_prepend_node_path(
-                    config.scripts_prepend_node_path,
-                ),
-                script_shell: None,
-                node_execpath: None,
-                npm_execpath: None,
-                store_dir: &config.store_dir,
-                package_id: &package_id,
-                requester: "",
-                store_index_writer: None,
-                files_index_file: &files_index_file,
-            }
-            .run::<Reporter>()
-            .await
-            .map_err(WritePackageForPatchError::GitFetch)?;
-            cas_paths
-        } else {
-            raw_cas_paths
-        };
 
-        import_indexed_dir::<Reporter>(
-            &AtomicU8::new(0),
-            PackageImportMethod::CloneOrCopy,
-            dest,
-            &cas_paths,
-            ImportIndexedDirOpts { force: true, keep_modules_dir: false },
-        )
-        .map_err(WritePackageForPatchError::ImportIndexedDir)
+        validate_patch_destination(dest)?;
+
+        let store_index = open_store_index_for_patch(config).await;
+        let (store_index_writer, writer_task) = if config.frozen_store {
+            StoreIndexWriter::spawn_disabled()
+        } else {
+            StoreIndexWriter::spawn(&config.store_dir)
+        };
+        let verified_files_cache = SharedVerifiedFilesCache::default();
+
+        let result = async {
+            let cas_paths = DownloadTarballToStore {
+                http_client,
+                store_dir: &config.store_dir,
+                store_index: store_index.clone(),
+                store_index_writer: Some(Arc::clone(&store_index_writer)),
+                verify_store_integrity: config.verify_store_integrity,
+                verified_files_cache: SharedVerifiedFilesCache::clone(&verified_files_cache),
+                package_integrity: integrity,
+                package_unpacked_size: None,
+                package_file_count: None,
+                package_url: &tarball_url,
+                package_id: &package_id,
+                auth_headers: &config.auth_headers,
+                requester: "",
+                prefetched_cas_paths: None,
+                retry_opts: retry_opts_from_config(config),
+                ignore_file_pattern: None,
+                offline: config.offline,
+                progress_reported: None,
+            }
+            .run_with_mem_cache::<Reporter>(tarball_mem_cache)
+            .await
+            .map_err(WritePackageForPatchError::DownloadTarball)?;
+            let raw_cas_paths = (*cas_paths).clone();
+            let cas_paths = if let LockfileResolution::Tarball(t) = &metadata.resolution
+                && git_tarball_url(&metadata.resolution).is_some()
+            {
+                let allow_build_closure = |_dep_path: &str| false;
+                let files_index_file =
+                    git_hosted_store_index_key(&package_id, !config.ignore_scripts);
+                let GitFetchOutput { cas_paths, built: _built } = GitHostedTarballFetcher {
+                    cas_paths: raw_cas_paths,
+                    path: t.path.as_deref(),
+                    allow_build: &allow_build_closure,
+                    ignore_scripts: config.ignore_scripts,
+                    unsafe_perm: config.unsafe_perm,
+                    user_agent: None,
+                    scripts_prepend_node_path: executor_scripts_prepend_node_path(
+                        config.scripts_prepend_node_path,
+                    ),
+                    script_shell: None,
+                    node_execpath: None,
+                    npm_execpath: None,
+                    store_dir: &config.store_dir,
+                    package_id: &package_id,
+                    requester: "",
+                    store_index_writer: Some(&store_index_writer),
+                    files_index_file: &files_index_file,
+                }
+                .run::<Reporter>()
+                .await
+                .map_err(WritePackageForPatchError::GitFetch)?;
+                cas_paths
+            } else {
+                raw_cas_paths
+            };
+
+            import_indexed_dir::<Reporter>(
+                &AtomicU8::new(0),
+                PackageImportMethod::CloneOrCopy,
+                dest,
+                &cas_paths,
+                ImportIndexedDirOpts { force: true, keep_modules_dir: false },
+            )
+            .map_err(WritePackageForPatchError::ImportIndexedDir)
+        }
+        .await;
+
+        shutdown_store_index_writer_for_patch(store_index_writer, writer_task).await;
+        result
+    }
+}
+
+fn validate_patch_destination(dest: &Path) -> Result<(), WritePackageForPatchError> {
+    match std::fs::symlink_metadata(dest) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            Err(WritePackageForPatchError::UnsafePatchDestination {
+                dest: dest.to_path_buf(),
+                reason: "destination is a symlink",
+            })
+        }
+        Ok(_) => Ok(()),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(WritePackageForPatchError::PatchDestinationStat {
+            dest: dest.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+async fn open_store_index_for_patch(config: &'static Config) -> Option<SharedReadonlyStoreIndex> {
+    let open_store_index = if config.frozen_store {
+        StoreIndex::shared_immutable_in
+    } else {
+        StoreIndex::shared_readonly_in
+    };
+    let store_dir: &'static _ = &config.store_dir;
+    match tokio::task::spawn_blocking(move || open_store_index(store_dir)).await {
+        Ok(store_index) => store_index,
+        Err(error) => {
+            tracing::warn!(
+                target: "pacquet::patch",
+                ?error,
+                "store-index open task failed; continuing without a shared cache index",
+            );
+            None
+        }
+    }
+}
+
+async fn shutdown_store_index_writer_for_patch(
+    store_index_writer: Arc<StoreIndexWriter>,
+    writer_task: tokio::task::JoinHandle<Result<(), StoreIndexError>>,
+) {
+    drop(store_index_writer);
+    match writer_task.await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => tracing::warn!(
+            target: "pacquet::patch",
+            ?error,
+            "store-index writer task returned an error; some rows may not be persisted",
+        ),
+        Err(error) => tracing::warn!(
+            target: "pacquet::patch",
+            ?error,
+            "store-index writer task panicked; some rows may not be persisted",
+        ),
     }
 }
 

--- a/pacquet/crates/package-manager/src/patch/tests.rs
+++ b/pacquet/crates/package-manager/src/patch/tests.rs
@@ -1,4 +1,8 @@
-use super::*;
+use super::{
+    PatchCandidate, PatchTarget, WritePackageForPatch, WritePackageForPatchError,
+    compare_candidates, default_patch_target, executor_scripts_prepend_node_path,
+    patch_candidates_from_lockfile, resolution_kind,
+};
 use pacquet_config::ScriptsPrependNodePath;
 use pacquet_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
 use pacquet_lockfile::{
@@ -9,6 +13,8 @@ use pacquet_lockfile::{
 use pretty_assertions::assert_eq;
 use serde_json::json;
 use std::collections::HashMap;
+
+const GIT_HOSTED_COMMIT: &str = "0123456789abcdef0123456789abcdef01234567";
 
 fn empty_lockfile() -> Lockfile {
     Lockfile {
@@ -241,6 +247,31 @@ async fn patch_extract_git_hosted_tarball_runs_packlist() {
     assert!(!dest.join("ignore.txt").exists(), "packlist should filter ignored files");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn patch_extract_url_inferred_git_hosted_tarball_runs_packlist() {
+    let fixture = PatchExtractFixture::new_git_hosted_without_flag("foo", "1.0.0");
+    let dest = fixture.tmp.path().join("edit");
+
+    WritePackageForPatch {
+        tarball_mem_cache: &fixture.mem_cache,
+        http_client: &fixture.http_client,
+        config: fixture.config,
+        current_lockfile: &fixture.lockfile,
+        target: &fixture.target,
+        dest: &dest,
+    }
+    .run::<pacquet_reporter::SilentReporter>()
+    .await
+    .expect("extract URL-inferred git-hosted package for patching");
+
+    assert_eq!(
+        std::fs::read_to_string(dest.join("package.json")).expect("package.json"),
+        r#"{"name":"foo","version":"1.0.0","files":["index.js"]}"#,
+    );
+    assert_eq!(std::fs::read_to_string(dest.join("index.js")).expect("index.js"), "ok\n");
+    assert!(!dest.join("ignore.txt").exists(), "packlist should filter ignored files");
+}
+
 #[tokio::test]
 async fn patch_extract_rejects_unsupported_resolution_shape() {
     let tmp = tempfile::tempdir().expect("temp dir");
@@ -396,14 +427,23 @@ struct PatchExtractFixture {
 
 impl PatchExtractFixture {
     fn new(name: &str, version: &str) -> Self {
-        Self::new_with_options(name, version, false)
+        Self::new_with_options(name, version, false, false)
     }
 
     fn new_git_hosted(name: &str, version: &str) -> Self {
-        Self::new_with_options(name, version, true)
+        Self::new_with_options(name, version, true, true)
     }
 
-    fn new_with_options(name: &str, version: &str, git_hosted: bool) -> Self {
+    fn new_git_hosted_without_flag(name: &str, version: &str) -> Self {
+        Self::new_with_options(name, version, true, false)
+    }
+
+    fn new_with_options(
+        name: &str,
+        version: &str,
+        use_git_hosted_url: bool,
+        git_hosted_flag: bool,
+    ) -> Self {
         use pacquet_tarball::CacheValue;
         use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
@@ -412,7 +452,7 @@ impl PatchExtractFixture {
         std::fs::create_dir_all(&store_dir).expect("create store dir");
         let pkg_json = store_dir.join("pkg-json");
         let index = store_dir.join("index");
-        let manifest = if git_hosted {
+        let manifest = if use_git_hosted_url {
             format!(r#"{{"name":"{name}","version":"{version}","files":["index.js"]}}"#)
         } else {
             format!(r#"{{"name":"{name}","version":"{version}"}}"#)
@@ -431,11 +471,15 @@ impl PatchExtractFixture {
         let key = format!("{name}@{version}");
         let lockfile = lockfile_with_package_metadata(
             &key,
-            if git_hosted { git_hosted_metadata() } else { registry_metadata() },
+            if use_git_hosted_url {
+                git_hosted_metadata(git_hosted_flag)
+            } else {
+                registry_metadata()
+            },
         );
         let target = patch_target(&key, &lockfile);
-        let tarball_url = if git_hosted {
-            format!("https://codeload.github.com/example/{name}/tar.gz/deadbeef")
+        let tarball_url = if use_git_hosted_url {
+            git_hosted_tarball(name)
         } else {
             format!("https://registry.test/{name}/-/{name}-{version}.tgz")
         };
@@ -461,14 +505,27 @@ impl PatchExtractFixture {
     }
 }
 
-fn git_hosted_metadata() -> PackageMetadata {
-    serde_json::from_value(json!({
-        "resolution": {
-            "tarball": "https://codeload.github.com/example/foo/tar.gz/deadbeef",
+fn git_hosted_metadata(git_hosted_flag: bool) -> PackageMetadata {
+    let tarball = git_hosted_tarball("foo");
+    let resolution = if git_hosted_flag {
+        json!({
+            "tarball": tarball,
             "integrity": "sha512-aGVsbG8=",
             "gitHosted": true,
-        },
+        })
+    } else {
+        json!({
+            "tarball": tarball,
+            "integrity": "sha512-aGVsbG8=",
+        })
+    };
+    serde_json::from_value(json!({
+        "resolution": resolution,
         "version": "1.0.0",
     }))
     .unwrap()
+}
+
+fn git_hosted_tarball(name: &str) -> String {
+    format!("https://codeload.github.com/example/{name}/tar.gz/{GIT_HOSTED_COMMIT}")
 }

--- a/pacquet/crates/package-manager/src/patch/tests.rs
+++ b/pacquet/crates/package-manager/src/patch/tests.rs
@@ -1,0 +1,474 @@
+use super::*;
+use pacquet_config::ScriptsPrependNodePath;
+use pacquet_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
+use pacquet_lockfile::{
+    BinaryArchive, BinaryResolution, BinarySpec, ComVer, GitResolution, Lockfile,
+    LockfileResolution, LockfileVersion, PackageKey, PackageMetadata, RegistryResolution,
+    TarballResolution, VariationsResolution,
+};
+use pretty_assertions::assert_eq;
+use serde_json::json;
+use std::collections::HashMap;
+
+fn empty_lockfile() -> Lockfile {
+    Lockfile {
+        lockfile_version: LockfileVersion::<9>::try_from(ComVer { major: 9, minor: 0 }).unwrap(),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers: HashMap::new(),
+        packages: None,
+        snapshots: None,
+    }
+}
+
+fn lockfile_with_packages(keys: &[&str]) -> Lockfile {
+    let packages =
+        keys.iter().map(|key| (key.parse::<PackageKey>().unwrap(), registry_metadata())).collect();
+    Lockfile { packages: Some(packages), ..empty_lockfile() }
+}
+
+fn registry_metadata() -> PackageMetadata {
+    serde_json::from_value(json!({
+        "resolution": {
+            "integrity": "sha512-aGVsbG8=",
+        },
+    }))
+    .unwrap()
+}
+
+fn lockfile_with_package_metadata(key: &str, metadata: PackageMetadata) -> Lockfile {
+    Lockfile {
+        packages: Some(HashMap::from([(key.parse::<PackageKey>().unwrap(), metadata)])),
+        ..empty_lockfile()
+    }
+}
+
+fn patch_target(raw: &str, lockfile: &Lockfile) -> PatchTarget {
+    let set = patch_candidates_from_lockfile(raw, lockfile).unwrap();
+    default_patch_target(&set).expect("single target")
+}
+
+fn versions(candidates: &[PatchCandidate]) -> Vec<&str> {
+    candidates.iter().map(|candidate| candidate.version.as_str()).collect()
+}
+
+#[test]
+fn patch_candidate_exact_version_selects_matching_installed_version() {
+    let lockfile = lockfile_with_packages(&["is-positive@1.0.0"]);
+
+    let set = patch_candidates_from_lockfile("is-positive@1.0.0", &lockfile).unwrap();
+    let target = default_patch_target(&set).expect("single target");
+
+    assert_eq!(versions(&set.versions), vec!["1.0.0"]);
+    assert_eq!(versions(&set.preferred_versions), vec!["1.0.0"]);
+    assert_eq!(target.alias, "is-positive");
+    assert_eq!(target.version, "1.0.0");
+    assert_eq!(target.bare_specifier, "1.0.0");
+    assert!(!target.apply_to_all);
+}
+
+#[test]
+fn patch_candidate_bare_name_single_version_applies_to_all() {
+    let lockfile = lockfile_with_packages(&["is-positive@1.0.0"]);
+
+    let set = patch_candidates_from_lockfile("is-positive", &lockfile).unwrap();
+    let target = default_patch_target(&set).expect("single target");
+
+    assert_eq!(versions(&set.preferred_versions), vec!["1.0.0"]);
+    assert_eq!(target.bare_specifier, "1.0.0");
+    assert!(target.apply_to_all);
+}
+
+#[test]
+fn patch_candidate_range_selects_satisfying_installed_versions() {
+    let lockfile = lockfile_with_packages(&["is-positive@1.0.0", "is-positive@2.0.0"]);
+
+    let set = patch_candidates_from_lockfile("is-positive@1", &lockfile).unwrap();
+
+    assert_eq!(versions(&set.versions), vec!["1.0.0", "2.0.0"]);
+    assert_eq!(versions(&set.preferred_versions), vec!["1.0.0"]);
+}
+
+#[test]
+fn patch_candidate_missing_package_reports_installed_versions_when_name_exists() {
+    let lockfile = lockfile_with_packages(&["is-positive@1.0.0"]);
+
+    let err = patch_candidates_from_lockfile("is-positive@2.0.0", &lockfile).unwrap_err();
+
+    assert!(err.to_string().contains("1.0.0"), "error should mention installed versions: {err}");
+}
+
+#[test]
+fn patch_candidate_missing_package_without_installed_versions_reports_install_hint() {
+    let err = patch_candidates_from_lockfile("is-positive", &empty_lockfile()).unwrap_err();
+
+    assert!(
+        err.to_string().contains("did you forget to install is-positive?"),
+        "error should mention install hint: {err}",
+    );
+}
+
+#[test]
+fn default_patch_target_returns_none_when_multiple_versions_match() {
+    let lockfile = lockfile_with_packages(&["is-positive@1.0.0", "is-positive@2.0.0"]);
+    let set = patch_candidates_from_lockfile("is-positive", &lockfile).unwrap();
+
+    assert!(default_patch_target(&set).is_none());
+}
+
+#[test]
+fn patch_candidate_reports_missing_for_non_package_specs() {
+    let err = patch_candidates_from_lockfile("^1.0.0", &empty_lockfile()).unwrap_err();
+    assert!(err.to_string().contains("^1.0.0"), "error should mention raw spec: {err}");
+
+    let err = patch_candidates_from_lockfile("", &empty_lockfile()).unwrap_err();
+    assert!(err.to_string().contains("install"), "error should include install hint: {err}");
+}
+
+#[test]
+fn patch_candidate_detects_git_hosted_tarball_url_without_flag() {
+    let tarball =
+        "https://codeload.github.com/example/foo/tar.gz/0123456789abcdef0123456789abcdef01234567";
+    let metadata: PackageMetadata = serde_json::from_value(json!({
+        "resolution": {
+            "tarball": tarball,
+            "integrity": "sha512-aGVsbG8="
+        },
+        "version": "1.0.0",
+    }))
+    .unwrap();
+    let lockfile = lockfile_with_package_metadata("foo@1.0.0", metadata);
+
+    let target = patch_target("foo@1.0.0", &lockfile);
+
+    assert_eq!(target.bare_specifier, tarball);
+    assert_eq!(target.git_tarball_url.as_deref(), Some(tarball));
+    assert!(!target.apply_to_all);
+}
+
+#[test]
+fn patch_candidate_detects_pr_new_tarball_url_as_git_hosted() {
+    let tarball = "https://pkg.pr.new/example/foo@deadbeef";
+    let metadata: PackageMetadata = serde_json::from_value(json!({
+        "resolution": {
+            "tarball": tarball,
+            "integrity": "sha512-aGVsbG8="
+        },
+        "version": "1.0.0",
+    }))
+    .unwrap();
+    let lockfile = lockfile_with_package_metadata("foo@1.0.0", metadata);
+
+    let target = patch_target("foo@1.0.0", &lockfile);
+
+    assert_eq!(target.bare_specifier, tarball);
+    assert_eq!(target.git_tarball_url.as_deref(), Some(tarball));
+}
+
+#[tokio::test]
+async fn patch_extract_imports_package_files_into_empty_destination() {
+    let fixture = PatchExtractFixture::new("foo", "1.0.0");
+    let dest = fixture.tmp.path().join("edit");
+
+    WritePackageForPatch {
+        tarball_mem_cache: &fixture.mem_cache,
+        http_client: &fixture.http_client,
+        config: fixture.config,
+        current_lockfile: &fixture.lockfile,
+        target: &fixture.target,
+        dest: &dest,
+    }
+    .run::<pacquet_reporter::SilentReporter>()
+    .await
+    .expect("extract package for patching");
+
+    assert_eq!(
+        std::fs::read_to_string(dest.join("package.json")).expect("package.json"),
+        r#"{"name":"foo","version":"1.0.0"}"#,
+    );
+    assert_eq!(std::fs::read_to_string(dest.join("index.js")).expect("index.js"), "ok\n");
+    assert!(!dest.join("node_modules").exists(), "edit dir should not contain wrapper deps");
+}
+
+#[tokio::test]
+async fn patch_extract_replaces_existing_empty_destination() {
+    let fixture = PatchExtractFixture::new("foo", "1.0.0");
+    let dest = fixture.tmp.path().join("edit");
+    std::fs::create_dir_all(&dest).expect("create empty edit dir");
+
+    WritePackageForPatch {
+        tarball_mem_cache: &fixture.mem_cache,
+        http_client: &fixture.http_client,
+        config: fixture.config,
+        current_lockfile: &fixture.lockfile,
+        target: &fixture.target,
+        dest: &dest,
+    }
+    .run::<pacquet_reporter::SilentReporter>()
+    .await
+    .expect("extract into empty dir");
+
+    assert!(dest.join("package.json").is_file());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn patch_extract_git_hosted_tarball_runs_packlist() {
+    let fixture = PatchExtractFixture::new_git_hosted("foo", "1.0.0");
+    let dest = fixture.tmp.path().join("edit");
+
+    WritePackageForPatch {
+        tarball_mem_cache: &fixture.mem_cache,
+        http_client: &fixture.http_client,
+        config: fixture.config,
+        current_lockfile: &fixture.lockfile,
+        target: &fixture.target,
+        dest: &dest,
+    }
+    .run::<pacquet_reporter::SilentReporter>()
+    .await
+    .expect("extract git-hosted package for patching");
+
+    assert_eq!(
+        std::fs::read_to_string(dest.join("package.json")).expect("package.json"),
+        r#"{"name":"foo","version":"1.0.0","files":["index.js"]}"#,
+    );
+    assert_eq!(std::fs::read_to_string(dest.join("index.js")).expect("index.js"), "ok\n");
+    assert!(!dest.join("ignore.txt").exists(), "packlist should filter ignored files");
+}
+
+#[tokio::test]
+async fn patch_extract_rejects_unsupported_resolution_shape() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let mut config = pacquet_config::Config::new();
+    config.store_dir = tmp.path().join("store").into();
+    let config: &'static pacquet_config::Config = Box::leak(Box::new(config));
+    let metadata: PackageMetadata = serde_json::from_value(json!({
+        "resolution": {
+            "type": "directory",
+            "directory": "../foo",
+        },
+        "version": "1.0.0",
+    }))
+    .unwrap();
+    let lockfile = lockfile_with_package_metadata("foo@1.0.0", metadata);
+    let target = patch_target("foo@1.0.0", &lockfile);
+    let mem_cache = pacquet_tarball::MemCache::default();
+    let http_client = pacquet_network::ThrottledClient::default();
+    let dest = tmp.path().join("edit");
+
+    let err = WritePackageForPatch {
+        tarball_mem_cache: &mem_cache,
+        http_client: &http_client,
+        config,
+        current_lockfile: &lockfile,
+        target: &target,
+        dest: &dest,
+    }
+    .run::<pacquet_reporter::SilentReporter>()
+    .await
+    .unwrap_err();
+
+    assert!(err.to_string().contains("directory"), "error should name unsupported shape: {err}");
+}
+
+#[tokio::test]
+async fn patch_extract_rejects_missing_package_metadata() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let mut config = pacquet_config::Config::new();
+    config.store_dir = tmp.path().join("store").into();
+    let config: &'static pacquet_config::Config = Box::leak(Box::new(config));
+    let mem_cache = pacquet_tarball::MemCache::default();
+    let http_client = pacquet_network::ThrottledClient::default();
+    let target = PatchTarget {
+        alias: "missing".to_string(),
+        version: "1.0.0".to_string(),
+        bare_specifier: "1.0.0".to_string(),
+        apply_to_all: false,
+        git_tarball_url: None,
+        package_key: "missing@1.0.0".parse().expect("package key"),
+    };
+
+    let err = WritePackageForPatch {
+        tarball_mem_cache: &mem_cache,
+        http_client: &http_client,
+        config,
+        current_lockfile: &empty_lockfile(),
+        target: &target,
+        dest: &tmp.path().join("edit"),
+    }
+    .run::<pacquet_reporter::SilentReporter>()
+    .await
+    .unwrap_err();
+
+    assert!(
+        matches!(err, WritePackageForPatchError::MissingPackageMetadata { .. }),
+        "missing metadata should be reported, got {err:?}",
+    );
+}
+
+#[test]
+fn executor_scripts_prepend_node_path_maps_all_variants() {
+    assert_eq!(
+        executor_scripts_prepend_node_path(ScriptsPrependNodePath::Always),
+        ExecScriptsPrependNodePath::Always,
+    );
+    assert_eq!(
+        executor_scripts_prepend_node_path(ScriptsPrependNodePath::Never),
+        ExecScriptsPrependNodePath::Never,
+    );
+    assert_eq!(
+        executor_scripts_prepend_node_path(ScriptsPrependNodePath::WarnOnly),
+        ExecScriptsPrependNodePath::WarnOnly,
+    );
+}
+
+#[test]
+fn compare_candidates_orders_semver_before_non_semver() {
+    let candidate = |version: &str| PatchCandidate {
+        name: "foo".to_string(),
+        version: version.to_string(),
+        git_tarball_url: None,
+        package_key: "foo@1.0.0".parse().expect("package key"),
+    };
+
+    assert_eq!(
+        compare_candidates(&candidate("1.0.0"), &candidate("workspace:*")),
+        std::cmp::Ordering::Less,
+    );
+    assert_eq!(
+        compare_candidates(&candidate("workspace:*"), &candidate("1.0.0")),
+        std::cmp::Ordering::Greater,
+    );
+    assert_eq!(
+        compare_candidates(&candidate("workspace:*"), &candidate("npm:foo@1.0.0")),
+        std::cmp::Ordering::Equal,
+    );
+}
+
+#[test]
+fn resolution_kind_names_non_patchable_resolution_shapes() {
+    let tarball = LockfileResolution::Tarball(TarballResolution {
+        tarball: "https://registry.test/foo/-/foo-1.0.0.tgz".to_string(),
+        integrity: Some("sha512-aGVsbG8=".parse().expect("integrity")),
+        git_hosted: None,
+        path: None,
+    });
+    assert_eq!(resolution_kind(&tarball), "tarball");
+
+    let registry = LockfileResolution::Registry(RegistryResolution {
+        integrity: "sha512-aGVsbG8=".parse().expect("integrity"),
+    });
+    assert_eq!(resolution_kind(&registry), "registry");
+
+    let git = LockfileResolution::Git(GitResolution {
+        repo: "https://github.com/example/foo.git".to_string(),
+        commit: "deadbeef".to_string(),
+        path: None,
+    });
+    assert_eq!(resolution_kind(&git), "git");
+
+    let binary = LockfileResolution::Binary(BinaryResolution {
+        url: "https://nodejs.org/dist/v1.0.0/node.tar.gz".to_string(),
+        integrity: "sha512-aGVsbG8=".parse().expect("integrity"),
+        bin: BinarySpec::Single("bin/node".to_string()),
+        archive: BinaryArchive::Tarball,
+        prefix: None,
+    });
+    assert_eq!(resolution_kind(&binary), "binary");
+
+    let variations = LockfileResolution::Variations(VariationsResolution { variants: Vec::new() });
+    assert_eq!(resolution_kind(&variations), "variations");
+}
+
+struct PatchExtractFixture {
+    tmp: tempfile::TempDir,
+    mem_cache: pacquet_tarball::MemCache,
+    http_client: pacquet_network::ThrottledClient,
+    config: &'static pacquet_config::Config,
+    lockfile: Lockfile,
+    target: PatchTarget,
+}
+
+impl PatchExtractFixture {
+    fn new(name: &str, version: &str) -> Self {
+        Self::new_with_options(name, version, false)
+    }
+
+    fn new_git_hosted(name: &str, version: &str) -> Self {
+        Self::new_with_options(name, version, true)
+    }
+
+    fn new_with_options(name: &str, version: &str, git_hosted: bool) -> Self {
+        use pacquet_tarball::CacheValue;
+        use std::{collections::HashMap, path::PathBuf, sync::Arc};
+
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let store_dir = tmp.path().join("store");
+        std::fs::create_dir_all(&store_dir).expect("create store dir");
+        let pkg_json = store_dir.join("pkg-json");
+        let index = store_dir.join("index");
+        let manifest = if git_hosted {
+            format!(r#"{{"name":"{name}","version":"{version}","files":["index.js"]}}"#)
+        } else {
+            format!(r#"{{"name":"{name}","version":"{version}"}}"#)
+        };
+        std::fs::write(&pkg_json, manifest).expect("write package json");
+        std::fs::write(&index, "ok\n").expect("write index");
+        let ignored = store_dir.join("ignore");
+        std::fs::write(&ignored, "do not publish\n").expect("write ignored file");
+
+        let mut config = pacquet_config::Config::new();
+        config.registry = "https://registry.test/".to_string();
+        config.store_dir = store_dir.into();
+        config.offline = true;
+        let config: &'static pacquet_config::Config = Box::leak(Box::new(config));
+
+        let key = format!("{name}@{version}");
+        let lockfile = lockfile_with_package_metadata(
+            &key,
+            if git_hosted { git_hosted_metadata() } else { registry_metadata() },
+        );
+        let target = patch_target(&key, &lockfile);
+        let tarball_url = if git_hosted {
+            format!("https://codeload.github.com/example/{name}/tar.gz/deadbeef")
+        } else {
+            format!("https://registry.test/{name}/-/{name}-{version}.tgz")
+        };
+        let seeded: HashMap<String, PathBuf> = HashMap::from([
+            ("package.json".to_string(), pkg_json),
+            ("index.js".to_string(), index),
+            ("ignore.txt".to_string(), ignored),
+        ]);
+        let mem_cache = pacquet_tarball::MemCache::default();
+        mem_cache.insert(
+            tarball_url,
+            Arc::new(tokio::sync::RwLock::new(CacheValue::Available(Arc::new(seeded)))),
+        );
+
+        Self {
+            tmp,
+            mem_cache,
+            http_client: pacquet_network::ThrottledClient::default(),
+            config,
+            lockfile,
+            target,
+        }
+    }
+}
+
+fn git_hosted_metadata() -> PackageMetadata {
+    serde_json::from_value(json!({
+        "resolution": {
+            "tarball": "https://codeload.github.com/example/foo/tar.gz/deadbeef",
+            "integrity": "sha512-aGVsbG8=",
+            "gitHosted": true,
+        },
+        "version": "1.0.0",
+    }))
+    .unwrap()
+}

--- a/pacquet/crates/package-manager/src/patch/tests.rs
+++ b/pacquet/crates/package-manager/src/patch/tests.rs
@@ -10,9 +10,17 @@ use pacquet_lockfile::{
     LockfileResolution, LockfileVersion, PackageKey, PackageMetadata, RegistryResolution,
     TarballResolution, VariationsResolution,
 };
+use pacquet_network::{RetryOpts, ThrottledClient};
+use pacquet_resolving_npm_resolver::{
+    InMemoryPackageMetaCache, NpmResolver, shared_packument_fetch_locker,
+    shared_picked_manifest_cache,
+};
+use pacquet_resolving_resolver_base::{ResolveOptions, Resolver, WantedDependency};
+use pacquet_store_dir::{StoreDir, StoreIndex, store_index_key};
+use pacquet_testing_utils::registry::TestRegistry;
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 const GIT_HOSTED_COMMIT: &str = "0123456789abcdef0123456789abcdef01234567";
 
@@ -199,6 +207,98 @@ async fn patch_extract_imports_package_files_into_empty_destination() {
     );
     assert_eq!(std::fs::read_to_string(dest.join("index.js")).expect("index.js"), "ok\n");
     assert!(!dest.join("node_modules").exists(), "edit dir should not contain wrapper deps");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn patch_extract_rejects_symlinked_destination() {
+    let fixture = PatchExtractFixture::new("foo", "1.0.0");
+    let outside = fixture.tmp.path().join("outside");
+    let dest = fixture.tmp.path().join("edit");
+    std::fs::create_dir_all(&outside).expect("create symlink target");
+    std::os::unix::fs::symlink(&outside, &dest).expect("create edit symlink");
+
+    let err = WritePackageForPatch {
+        tarball_mem_cache: &fixture.mem_cache,
+        http_client: &fixture.http_client,
+        config: fixture.config,
+        current_lockfile: &fixture.lockfile,
+        target: &fixture.target,
+        dest: &dest,
+    }
+    .run::<pacquet_reporter::SilentReporter>()
+    .await
+    .expect_err("symlink destination must be rejected");
+
+    assert!(err.to_string().contains("symlink"), "error should mention symlink: {err}");
+    assert!(
+        !outside.join("package.json").exists(),
+        "patch extraction must not write through the destination symlink",
+    );
+}
+
+#[tokio::test]
+async fn patch_extract_records_download_in_store_index() {
+    let registry = TestRegistry::start();
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let store_dir = tmp.path().join("store");
+    std::fs::create_dir_all(&store_dir).expect("create store dir");
+
+    let mut config = pacquet_config::Config::new();
+    config.registry = registry.url();
+    config.store_dir = StoreDir::new(&store_dir);
+    let config: &'static pacquet_config::Config = Box::leak(Box::new(config));
+
+    let http_client = Arc::new(ThrottledClient::new_for_installs());
+    let resolved = resolve_registry_fixture(
+        &config.registry,
+        tmp.path(),
+        Arc::clone(&http_client),
+        "@pnpm.e2e/hello-world-js-bin",
+        "1.0.0",
+    )
+    .await;
+    let name_ver = resolved.name_ver.as_ref().expect("npm resolver fills name/version");
+    let package_id = name_ver.to_string();
+    let integrity = resolved.resolution.integrity().expect("registry fixture has integrity");
+    let store_index_key = store_index_key(&integrity.to_string(), &package_id);
+    let lockfile = lockfile_with_package_metadata(
+        &package_id,
+        PackageMetadata {
+            resolution: resolved.resolution,
+            version: None,
+            engines: None,
+            cpu: None,
+            os: None,
+            libc: None,
+            deprecated: None,
+            has_bin: None,
+            prepare: None,
+            bundled_dependencies: None,
+            peer_dependencies: None,
+            peer_dependencies_meta: None,
+        },
+    );
+    let target = patch_target(&package_id, &lockfile);
+    let dest = tmp.path().join("edit");
+
+    WritePackageForPatch {
+        tarball_mem_cache: &pacquet_tarball::MemCache::default(),
+        http_client: http_client.as_ref(),
+        config,
+        current_lockfile: &lockfile,
+        target: &target,
+        dest: &dest,
+    }
+    .run::<pacquet_reporter::SilentReporter>()
+    .await
+    .expect("extract registry package");
+
+    let store_index = StoreIndex::shared_readonly_in(&config.store_dir)
+        .expect("patch extraction should create a store index");
+    let indexed_package =
+        store_index.lock().expect("store index lock").get(&store_index_key).expect("read row");
+    assert!(indexed_package.is_some(), "store index row should exist for {store_index_key}");
 }
 
 #[tokio::test]
@@ -503,6 +603,43 @@ impl PatchExtractFixture {
             target,
         }
     }
+}
+
+async fn resolve_registry_fixture(
+    registry: &str,
+    cache_dir: &std::path::Path,
+    http_client: Arc<ThrottledClient>,
+    alias: &str,
+    range: &str,
+) -> pacquet_resolving_resolver_base::ResolveResult {
+    let mut registries = HashMap::new();
+    registries.insert("default".to_string(), registry.to_string());
+    let resolver = NpmResolver {
+        registries,
+        named_registries: HashMap::new(),
+        http_client,
+        auth_headers: Arc::default(),
+        meta_cache: Arc::new(InMemoryPackageMetaCache::default()),
+        fetch_locker: shared_packument_fetch_locker(),
+        picked_manifest_cache: shared_picked_manifest_cache(),
+        cache_dir: Some(cache_dir.to_path_buf()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: true,
+        full_metadata: false,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+    let wanted = WantedDependency {
+        alias: Some(alias.to_string()),
+        bare_specifier: Some(range.to_string()),
+        ..WantedDependency::default()
+    };
+    resolver
+        .resolve(&wanted, &ResolveOptions::default())
+        .await
+        .expect("resolve succeeds against fixture registry")
+        .expect("npm resolver claims fixture")
 }
 
 fn git_hosted_metadata(git_hosted_flag: bool) -> PackageMetadata {

--- a/pacquet/crates/package-manager/src/patch_commit.rs
+++ b/pacquet/crates/package-manager/src/patch_commit.rs
@@ -4,11 +4,14 @@ use pacquet_git_fetcher::PacklistError;
 use pacquet_package_manifest::PackageManifestError;
 use serde_json::{Map, Value};
 use std::{
-    collections::BTreeSet,
-    fs, io,
+    fs::{self, File, OpenOptions},
+    io::{self, Read},
     path::{Path, PathBuf},
     process::Command,
+    sync::atomic::{AtomicU64, Ordering},
 };
+
+const MAX_DIFF_OUTPUT_BYTES: u64 = 128 * 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PkgFilesForDiff {
@@ -59,6 +62,10 @@ pub enum PatchCommitError {
         source: io::Error,
     },
 
+    #[display("Unsafe temporary patch directory {}: {reason}", dir.display())]
+    #[diagnostic(code(pacquet_package_manager::patch_commit_unsafe_temp_dir))]
+    UnsafeTempDir { dir: PathBuf, reason: &'static str },
+
     #[display(
         "Failed to link package file from {} to {}: {source}",
         source_path.display(),
@@ -88,6 +95,10 @@ pub enum PatchCommitError {
         #[error(source)]
         source: io::Error,
     },
+
+    #[display("git diff {stream} output exceeded {limit} bytes")]
+    #[diagnostic(code(pacquet_package_manager::patch_commit_diff_output_too_large))]
+    DiffOutputTooLarge { stream: &'static str, limit: u64 },
 }
 
 pub fn prepare_pkg_files_for_diff(src: &Path) -> Result<PkgFilesForDiff, PatchCommitError> {
@@ -103,9 +114,6 @@ fn prepare_pkg_files_for_diff_with_fs(
         .unwrap_or_else(|| Value::Object(Map::default()));
     let files = pacquet_git_fetcher::packlist(src, &manifest)
         .map_err(|source| PatchCommitError::Packlist { dir: src.to_path_buf(), source })?;
-    if all_files(src)? == files.iter().cloned().collect::<BTreeSet<_>>() {
-        return Ok(PkgFilesForDiff::Original(src.to_path_buf()));
-    }
 
     let temp_dir = temporary_filtered_dir(src);
     remove_existing_temp_dir_with_fs(&temp_dir, fs_ops)?;
@@ -134,7 +142,9 @@ fn prepare_pkg_files_for_diff_with_fs(
 pub fn diff_folders(folder_a: &Path, folder_b: &Path) -> Result<String, PatchCommitError> {
     let folder_a_slash = slash_path(folder_a);
     let folder_b_slash = slash_path(folder_b);
-    let output = Command::new("git")
+    let stdout = DiffTempFile::new("stdout")?;
+    let stderr = DiffTempFile::new("stderr")?;
+    let status = Command::new("git")
         .arg("-c")
         .arg("core.safecrlf=false")
         .arg("diff")
@@ -147,18 +157,21 @@ pub fn diff_folders(folder_a: &Path, folder_b: &Path) -> Result<String, PatchCom
         .arg("--text")
         .arg("--no-ext-diff")
         .arg("--no-color")
+        .arg("--")
         .arg(&folder_a_slash)
         .arg(&folder_b_slash)
         .env("GIT_CONFIG_NOSYSTEM", "1")
         .env("GIT_CONFIG_GLOBAL", "/dev/null")
-        .output()
+        .stdout(stdout.writer.try_clone().map_err(|source| PatchCommitError::DiffSpawn { source })?)
+        .stderr(stderr.writer.try_clone().map_err(|source| PatchCommitError::DiffSpawn { source })?)
+        .status()
         .map_err(|source| PatchCommitError::DiffSpawn { source })?;
 
-    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-    if !stderr.is_empty() || !matches!(output.status.code(), Some(0 | 1)) {
+    let stderr = stderr.read_to_string("stderr")?;
+    if !stderr.is_empty() || !matches!(status.code(), Some(0 | 1)) {
         return Err(PatchCommitError::DiffFailed { stderr });
     }
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stdout = stdout.read_to_string("stdout")?;
     Ok(normalize_diff_output(&stdout, &folder_a_slash, &folder_b_slash))
 }
 
@@ -166,6 +179,19 @@ fn remove_existing_temp_dir_with_fs(
     temp_dir: &Path,
     fs_ops: &impl PatchCommitFs,
 ) -> Result<(), PatchCommitError> {
+    let metadata = match fs_ops.symlink_metadata(temp_dir) {
+        Ok(metadata) => metadata,
+        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(source) => {
+            return Err(PatchCommitError::RemoveTempDir { dir: temp_dir.to_path_buf(), source });
+        }
+    };
+    if metadata.file_type().is_symlink() {
+        return Err(PatchCommitError::UnsafeTempDir {
+            dir: temp_dir.to_path_buf(),
+            reason: "must not be a symbolic link",
+        });
+    }
     match fs_ops.remove_dir_all(temp_dir) {
         Ok(()) => Ok(()),
         Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(()),
@@ -173,7 +199,78 @@ fn remove_existing_temp_dir_with_fs(
     }
 }
 
+struct DiffTempFile {
+    path: PathBuf,
+    writer: File,
+}
+
+impl DiffTempFile {
+    fn new(stream: &'static str) -> Result<Self, PatchCommitError> {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let pid = std::process::id();
+        let temp_dir = std::env::temp_dir();
+        for _ in 0..16 {
+            let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = temp_dir.join(format!("pacquet-git-diff-{stream}-{pid}-{counter}.tmp"));
+            match OpenOptions::new().write(true).create_new(true).open(&path) {
+                Ok(writer) => return Ok(Self { path, writer }),
+                Err(source) if source.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(source) => return Err(PatchCommitError::DiffSpawn { source }),
+            }
+        }
+        Err(PatchCommitError::DiffSpawn {
+            source: io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "exhausted temp-path attempts for git diff output",
+            ),
+        })
+    }
+
+    fn read_to_string(&self, stream: &'static str) -> Result<String, PatchCommitError> {
+        let len = fs::metadata(&self.path)
+            .map_err(|source| PatchCommitError::DiffSpawn { source })?
+            .len();
+        if len > MAX_DIFF_OUTPUT_BYTES {
+            return Err(PatchCommitError::DiffOutputTooLarge {
+                stream,
+                limit: MAX_DIFF_OUTPUT_BYTES,
+            });
+        }
+        let mut file =
+            File::open(&self.path).map_err(|source| PatchCommitError::DiffSpawn { source })?;
+        let mut bytes = Vec::with_capacity(len as usize);
+        let mut buffer = [0; 8192];
+        loop {
+            let read =
+                file.read(&mut buffer).map_err(|source| PatchCommitError::DiffSpawn { source })?;
+            if read == 0 {
+                break;
+            }
+            let next_len =
+                bytes.len().checked_add(read).ok_or(PatchCommitError::DiffOutputTooLarge {
+                    stream,
+                    limit: MAX_DIFF_OUTPUT_BYTES,
+                })?;
+            if next_len as u64 > MAX_DIFF_OUTPUT_BYTES {
+                return Err(PatchCommitError::DiffOutputTooLarge {
+                    stream,
+                    limit: MAX_DIFF_OUTPUT_BYTES,
+                });
+            }
+            bytes.extend_from_slice(&buffer[..read]);
+        }
+        Ok(String::from_utf8_lossy(&bytes).into_owned())
+    }
+}
+
+impl Drop for DiffTempFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
 trait PatchCommitFs {
+    fn symlink_metadata(&self, path: &Path) -> io::Result<fs::Metadata>;
     fn create_dir_all(&self, path: &Path) -> io::Result<()>;
     fn hard_link(&self, source: &Path, target: &Path) -> io::Result<()>;
     fn remove_dir_all(&self, path: &Path) -> io::Result<()>;
@@ -182,6 +279,10 @@ trait PatchCommitFs {
 struct RealPatchCommitFs;
 
 impl PatchCommitFs for RealPatchCommitFs {
+    fn symlink_metadata(&self, path: &Path) -> io::Result<fs::Metadata> {
+        fs::symlink_metadata(path)
+    }
+
     fn create_dir_all(&self, path: &Path) -> io::Result<()> {
         fs::create_dir_all(path)
     }
@@ -202,39 +303,6 @@ fn temporary_filtered_dir(src: &Path) -> PathBuf {
     src.parent()
         .unwrap_or_else(|| Path::new("."))
         .join(format!("{name}_tmp_{}", std::process::id()))
-}
-
-fn all_files(base: &Path) -> Result<BTreeSet<String>, PatchCommitError> {
-    let mut files = BTreeSet::new();
-    collect_files(base, base, &mut files)?;
-    Ok(files)
-}
-
-fn collect_files(
-    base: &Path,
-    dir: &Path,
-    files: &mut BTreeSet<String>,
-) -> Result<(), PatchCommitError> {
-    for entry in fs::read_dir(dir)
-        .map_err(|source| PatchCommitError::ReadDir { dir: dir.to_path_buf(), source })?
-    {
-        let entry =
-            entry.map_err(|source| PatchCommitError::ReadDir { dir: dir.to_path_buf(), source })?;
-        let path = entry.path();
-        let file_type = entry
-            .file_type()
-            .map_err(|source| PatchCommitError::ReadDir { dir: path.clone(), source })?;
-        if file_type.is_dir() {
-            collect_files(base, &path, files)?;
-        } else if file_type.is_file() {
-            files.insert(relative_slash_path(base, &path));
-        }
-    }
-    Ok(())
-}
-
-fn relative_slash_path(base: &Path, path: &Path) -> String {
-    slash_path(path.strip_prefix(base).unwrap_or(path))
 }
 
 fn slash_path(path: &Path) -> String {
@@ -322,10 +390,17 @@ fn push_non_ds_store_block(output: &mut String, block: &str) {
         return;
     }
     let header = block.lines().next().unwrap_or_default();
-    if header.contains(".DS_Store") {
+    if is_ds_store_diff_header(header) {
         return;
     }
     output.push_str(block);
+}
+
+fn is_ds_store_diff_header(header: &str) -> bool {
+    let mut parts = header.split_whitespace();
+    matches!(parts.next(), Some("diff"))
+        && matches!(parts.next(), Some("--git"))
+        && parts.take(2).all(|path| path.rsplit('/').next() == Some(".DS_Store"))
 }
 
 #[cfg(test)]

--- a/pacquet/crates/package-manager/src/patch_commit.rs
+++ b/pacquet/crates/package-manager/src/patch_commit.rs
@@ -1,0 +1,283 @@
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pacquet_git_fetcher::PacklistError;
+use pacquet_package_manifest::PackageManifestError;
+use serde_json::{Map, Value};
+use std::{
+    collections::BTreeSet,
+    fs, io,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PkgFilesForDiff {
+    Original(PathBuf),
+    Temporary(PathBuf),
+}
+
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum PatchCommitError {
+    #[display("Failed to read package manifest in {}: {source}", dir.display())]
+    #[diagnostic(code(pacquet_package_manager::patch_commit_read_manifest))]
+    ReadManifest {
+        dir: PathBuf,
+        #[error(source)]
+        source: PackageManifestError,
+    },
+
+    #[display("Failed to compute package files for {}: {source}", dir.display())]
+    #[diagnostic(code(pacquet_package_manager::patch_commit_packlist))]
+    Packlist {
+        dir: PathBuf,
+        #[error(source)]
+        source: PacklistError,
+    },
+
+    #[display("Failed to read directory {}: {source}", dir.display())]
+    #[diagnostic(code(pacquet_package_manager::patch_commit_read_dir))]
+    ReadDir {
+        dir: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display("Failed to create temporary patch directory {}: {source}", dir.display())]
+    #[diagnostic(code(pacquet_package_manager::patch_commit_create_temp_dir))]
+    CreateTempDir {
+        dir: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display("Failed to remove temporary patch directory {}: {source}", dir.display())]
+    #[diagnostic(code(pacquet_package_manager::patch_commit_remove_temp_dir))]
+    RemoveTempDir {
+        dir: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display(
+        "Failed to link package file from {} to {}: {source}",
+        source_path.display(),
+        target.display()
+    )]
+    #[diagnostic(code(pacquet_package_manager::patch_commit_link_file))]
+    LinkFile {
+        source_path: PathBuf,
+        target: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display(
+        "Unable to diff directories. Make sure you have a recent version of 'git' available in PATH.\nThe following error was reported by 'git':\n{stderr}"
+    )]
+    #[diagnostic(code(pacquet_package_manager::patch_commit_diff_failed))]
+    DiffFailed { stderr: String },
+
+    #[display("Failed to run git diff: {source}")]
+    #[diagnostic(code(pacquet_package_manager::patch_commit_diff_spawn))]
+    DiffSpawn {
+        #[error(source)]
+        source: io::Error,
+    },
+}
+
+pub fn prepare_pkg_files_for_diff(src: &Path) -> Result<PkgFilesForDiff, PatchCommitError> {
+    prepare_pkg_files_for_diff_with_fs(src, &RealPatchCommitFs)
+}
+
+fn prepare_pkg_files_for_diff_with_fs(
+    src: &Path,
+    fs_ops: &impl PatchCommitFs,
+) -> Result<PkgFilesForDiff, PatchCommitError> {
+    let manifest = pacquet_package_manifest::safe_read_package_json_from_dir(src)
+        .map_err(|source| PatchCommitError::ReadManifest { dir: src.to_path_buf(), source })?
+        .unwrap_or_else(|| Value::Object(Map::default()));
+    let files = pacquet_git_fetcher::packlist(src, &manifest)
+        .map_err(|source| PatchCommitError::Packlist { dir: src.to_path_buf(), source })?;
+    if all_files(src)? == files.iter().cloned().collect::<BTreeSet<_>>() {
+        return Ok(PkgFilesForDiff::Original(src.to_path_buf()));
+    }
+
+    let temp_dir = temporary_filtered_dir(src);
+    remove_existing_temp_dir_with_fs(&temp_dir, fs_ops)?;
+    fs_ops
+        .create_dir_all(&temp_dir)
+        .map_err(|source| PatchCommitError::CreateTempDir { dir: temp_dir.clone(), source })?;
+    for file in files {
+        let source_path = src.join(path_from_forward_slash(&file));
+        let target = temp_dir.join(path_from_forward_slash(&file));
+        let parent =
+            target.parent().expect("filtered package file target should have a parent directory");
+        fs_ops.create_dir_all(parent).map_err(|source| PatchCommitError::CreateTempDir {
+            dir: parent.to_path_buf(),
+            source,
+        })?;
+        fs_ops.hard_link(&source_path, &target).map_err(|source| PatchCommitError::LinkFile {
+            source_path,
+            target,
+            source,
+        })?;
+    }
+    Ok(PkgFilesForDiff::Temporary(temp_dir))
+}
+
+pub fn diff_folders(folder_a: &Path, folder_b: &Path) -> Result<String, PatchCommitError> {
+    let folder_a_slash = slash_path(folder_a);
+    let folder_b_slash = slash_path(folder_b);
+    let output = Command::new("git")
+        .arg("-c")
+        .arg("core.safecrlf=false")
+        .arg("diff")
+        .arg("--src-prefix=a/")
+        .arg("--dst-prefix=b/")
+        .arg("--ignore-cr-at-eol")
+        .arg("--irreversible-delete")
+        .arg("--full-index")
+        .arg("--no-index")
+        .arg("--text")
+        .arg("--no-ext-diff")
+        .arg("--no-color")
+        .arg(&folder_a_slash)
+        .arg(&folder_b_slash)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .output()
+        .map_err(|source| PatchCommitError::DiffSpawn { source })?;
+
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    if !stderr.is_empty() || !matches!(output.status.code(), Some(0 | 1)) {
+        return Err(PatchCommitError::DiffFailed { stderr });
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    Ok(normalize_diff_output(&stdout, &folder_a_slash, &folder_b_slash))
+}
+
+fn remove_existing_temp_dir_with_fs(
+    temp_dir: &Path,
+    fs_ops: &impl PatchCommitFs,
+) -> Result<(), PatchCommitError> {
+    match fs_ops.remove_dir_all(temp_dir) {
+        Ok(()) => Ok(()),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(PatchCommitError::RemoveTempDir { dir: temp_dir.to_path_buf(), source }),
+    }
+}
+
+trait PatchCommitFs {
+    fn create_dir_all(&self, path: &Path) -> io::Result<()>;
+    fn hard_link(&self, source: &Path, target: &Path) -> io::Result<()>;
+    fn remove_dir_all(&self, path: &Path) -> io::Result<()>;
+}
+
+struct RealPatchCommitFs;
+
+impl PatchCommitFs for RealPatchCommitFs {
+    fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+        fs::create_dir_all(path)
+    }
+
+    fn hard_link(&self, source: &Path, target: &Path) -> io::Result<()> {
+        fs::hard_link(source, target)
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+        fs::remove_dir_all(path)
+    }
+}
+
+fn temporary_filtered_dir(src: &Path) -> PathBuf {
+    let name = src
+        .file_name()
+        .map_or_else(|| String::from("patch"), |name| name.to_string_lossy().into_owned());
+    src.parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(format!("{name}_tmp_{}", std::process::id()))
+}
+
+fn all_files(base: &Path) -> Result<BTreeSet<String>, PatchCommitError> {
+    let mut files = BTreeSet::new();
+    collect_files(base, base, &mut files)?;
+    Ok(files)
+}
+
+fn collect_files(
+    base: &Path,
+    dir: &Path,
+    files: &mut BTreeSet<String>,
+) -> Result<(), PatchCommitError> {
+    for entry in fs::read_dir(dir)
+        .map_err(|source| PatchCommitError::ReadDir { dir: dir.to_path_buf(), source })?
+    {
+        let entry =
+            entry.map_err(|source| PatchCommitError::ReadDir { dir: dir.to_path_buf(), source })?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .map_err(|source| PatchCommitError::ReadDir { dir: path.clone(), source })?;
+        if file_type.is_dir() {
+            collect_files(base, &path, files)?;
+        } else if file_type.is_file() {
+            files.insert(relative_slash_path(base, &path));
+        }
+    }
+    Ok(())
+}
+
+fn relative_slash_path(base: &Path, path: &Path) -> String {
+    slash_path(path.strip_prefix(base).unwrap_or(path))
+}
+
+fn slash_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn path_from_forward_slash(path: &str) -> PathBuf {
+    path.split('/').collect()
+}
+
+fn normalize_diff_output(diff: &str, folder_a: &str, folder_b: &str) -> String {
+    let mut out = diff.to_string();
+    for (prefix, folder) in [('a', folder_a), ('b', folder_b)] {
+        let trimmed = folder.trim_matches('/');
+        out = out.replace(&format!("{prefix}/{trimmed}/"), &format!("{prefix}/"));
+        out = out.replace(&format!("{prefix}{folder}/"), &format!("{prefix}/"));
+        out = out.replace(&format!("{folder}/"), "");
+    }
+    if let Some(without_marker) = out.strip_suffix("\n\\ No newline at end of file\n") {
+        out = format!("{without_marker}\n");
+    }
+    remove_ds_store_diff_blocks(&out)
+}
+
+fn remove_ds_store_diff_blocks(diff: &str) -> String {
+    let mut kept = String::new();
+    let mut current = String::new();
+    for line in diff.split_inclusive('\n') {
+        if line.starts_with("diff --git ") {
+            push_non_ds_store_block(&mut kept, &current);
+            current.clear();
+        }
+        current.push_str(line);
+    }
+    push_non_ds_store_block(&mut kept, &current);
+    kept
+}
+
+fn push_non_ds_store_block(output: &mut String, block: &str) {
+    if block.is_empty() {
+        return;
+    }
+    let header = block.lines().next().unwrap_or_default();
+    if header.contains(".DS_Store") {
+        return;
+    }
+    output.push_str(block);
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/package-manager/src/patch_commit.rs
+++ b/pacquet/crates/package-manager/src/patch_commit.rs
@@ -3,6 +3,8 @@ use miette::Diagnostic;
 use pacquet_git_fetcher::PacklistError;
 use pacquet_package_manifest::PackageManifestError;
 use serde_json::{Map, Value};
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::{
     fs::{self, File, OpenOptions},
     io::{self, Read},
@@ -212,7 +214,7 @@ impl DiffTempFile {
         for _ in 0..16 {
             let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
             let path = temp_dir.join(format!("pacquet-git-diff-{stream}-{pid}-{counter}.tmp"));
-            match OpenOptions::new().write(true).create_new(true).open(&path) {
+            match diff_temp_file_options().open(&path) {
                 Ok(writer) => return Ok(Self { path, writer }),
                 Err(source) if source.kind() == io::ErrorKind::AlreadyExists => {}
                 Err(source) => return Err(PatchCommitError::DiffSpawn { source }),
@@ -261,6 +263,14 @@ impl DiffTempFile {
         }
         Ok(String::from_utf8_lossy(&bytes).into_owned())
     }
+}
+
+fn diff_temp_file_options() -> OpenOptions {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    options
 }
 
 impl Drop for DiffTempFile {

--- a/pacquet/crates/package-manager/src/patch_commit.rs
+++ b/pacquet/crates/package-manager/src/patch_commit.rs
@@ -72,6 +72,10 @@ pub enum PatchCommitError {
         source: io::Error,
     },
 
+    #[display("Package file path escapes package directory: {path}")]
+    #[diagnostic(code(pacquet_package_manager::patch_commit_invalid_package_file_path))]
+    InvalidPackageFilePath { path: String },
+
     #[display(
         "Unable to diff directories. Make sure you have a recent version of 'git' available in PATH.\nThe following error was reported by 'git':\n{stderr}"
     )]
@@ -109,8 +113,9 @@ fn prepare_pkg_files_for_diff_with_fs(
         .create_dir_all(&temp_dir)
         .map_err(|source| PatchCommitError::CreateTempDir { dir: temp_dir.clone(), source })?;
     for file in files {
-        let source_path = src.join(path_from_forward_slash(&file));
-        let target = temp_dir.join(path_from_forward_slash(&file));
+        let relative_path = safe_package_file_path(&file)?;
+        let source_path = src.join(&relative_path);
+        let target = temp_dir.join(&relative_path);
         let parent =
             target.parent().expect("filtered package file target should have a parent directory");
         fs_ops.create_dir_all(parent).map_err(|source| PatchCommitError::CreateTempDir {
@@ -236,22 +241,66 @@ fn slash_path(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
 
+fn safe_package_file_path(path: &str) -> Result<PathBuf, PatchCommitError> {
+    let path = path_from_forward_slash(path);
+    if path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::ParentDir
+                    | std::path::Component::RootDir
+                    | std::path::Component::Prefix(_)
+            )
+        })
+    {
+        return Err(PatchCommitError::InvalidPackageFilePath {
+            path: path.to_string_lossy().into_owned(),
+        });
+    }
+    Ok(path)
+}
+
 fn path_from_forward_slash(path: &str) -> PathBuf {
     path.split('/').collect()
 }
 
 fn normalize_diff_output(diff: &str, folder_a: &str, folder_b: &str) -> String {
-    let mut out = diff.to_string();
+    let mut out = String::with_capacity(diff.len());
+    let mut in_hunk = false;
+    for line in diff.split_inclusive('\n') {
+        let (content, newline) = line.strip_suffix('\n').map_or((line, ""), |line| (line, "\n"));
+        if content.starts_with("diff --git ") {
+            in_hunk = false;
+            out.push_str(&normalize_diff_path_line(content, folder_a, folder_b));
+        } else if !in_hunk && is_diff_path_line(content) {
+            out.push_str(&normalize_diff_path_line(content, folder_a, folder_b));
+        } else {
+            out.push_str(content);
+        }
+        if content.starts_with("@@ ") || content.starts_with("@@@ ") {
+            in_hunk = true;
+        }
+        out.push_str(newline);
+    }
+    if let Some(without_marker) = out.strip_suffix("\n\\ No newline at end of file\n") {
+        out = format!("{without_marker}\n");
+    }
+    remove_ds_store_diff_blocks(&out)
+}
+
+fn is_diff_path_line(line: &str) -> bool {
+    line.starts_with("diff --git ") || line.starts_with("--- ") || line.starts_with("+++ ")
+}
+
+fn normalize_diff_path_line(line: &str, folder_a: &str, folder_b: &str) -> String {
+    let mut out = line.to_string();
     for (prefix, folder) in [('a', folder_a), ('b', folder_b)] {
         let trimmed = folder.trim_matches('/');
         out = out.replace(&format!("{prefix}/{trimmed}/"), &format!("{prefix}/"));
         out = out.replace(&format!("{prefix}{folder}/"), &format!("{prefix}/"));
         out = out.replace(&format!("{folder}/"), "");
     }
-    if let Some(without_marker) = out.strip_suffix("\n\\ No newline at end of file\n") {
-        out = format!("{without_marker}\n");
-    }
-    remove_ds_store_diff_blocks(&out)
+    out
 }
 
 fn remove_ds_store_diff_blocks(diff: &str) -> String {

--- a/pacquet/crates/package-manager/src/patch_commit.rs
+++ b/pacquet/crates/package-manager/src/patch_commit.rs
@@ -249,7 +249,7 @@ fn safe_package_file_path(path: &str) -> Result<PathBuf, PatchCommitError> {
                 component,
                 std::path::Component::ParentDir
                     | std::path::Component::RootDir
-                    | std::path::Component::Prefix(_)
+                    | std::path::Component::Prefix(_),
             )
         })
     {

--- a/pacquet/crates/package-manager/src/patch_commit/tests.rs
+++ b/pacquet/crates/package-manager/src/patch_commit/tests.rs
@@ -181,8 +181,8 @@ index 123..456 100644
     assert!(normalized.contains("diff --git a/index.js b/index.js"), "{normalized}");
     assert!(normalized.contains("--- a/index.js"), "{normalized}");
     assert!(normalized.contains("+++ b/index.js"), "{normalized}");
-    assert!(normalized.contains("-console.log(\"/tmp/before/ must stay in content\")"));
-    assert!(normalized.contains("+console.log(\"/tmp/after/ must stay in content\")"));
+    assert!(normalized.contains(r#"-console.log("/tmp/before/ must stay in content")"#));
+    assert!(normalized.contains(r#"+console.log("/tmp/after/ must stay in content")"#));
     assert!(normalized.contains("--- /tmp/before/ also stays"));
     assert!(normalized.contains("+++ /tmp/after/ also stays"));
 }

--- a/pacquet/crates/package-manager/src/patch_commit/tests.rs
+++ b/pacquet/crates/package-manager/src/patch_commit/tests.rs
@@ -1,0 +1,240 @@
+use super::{
+    PatchCommitError, PatchCommitFs, PkgFilesForDiff, RealPatchCommitFs, diff_folders,
+    prepare_pkg_files_for_diff, prepare_pkg_files_for_diff_with_fs,
+    remove_existing_temp_dir_with_fs,
+};
+use pretty_assertions::assert_eq;
+use std::{cell::Cell, fs, io, path::Path};
+use tempfile::tempdir;
+
+#[test]
+fn patch_commit_diff_dirs_strips_absolute_temp_paths() {
+    let before = tempdir().expect("before dir");
+    let after = tempdir().expect("after dir");
+    fs::write(before.path().join("index.js"), "module.exports = false\n").unwrap();
+    fs::write(after.path().join("index.js"), "module.exports = true\n").unwrap();
+
+    let diff = diff_folders(before.path(), after.path()).expect("diff dirs");
+
+    assert!(diff.contains("diff --git a/index.js b/index.js"), "diff: {diff}");
+    assert!(!diff.contains(&before.path().display().to_string()), "diff: {diff}");
+    assert!(!diff.contains(&after.path().display().to_string()), "diff: {diff}");
+}
+
+#[test]
+fn patch_commit_diff_dirs_filters_ds_store_diffs() {
+    let before = tempdir().expect("before dir");
+    let after = tempdir().expect("after dir");
+    fs::create_dir_all(before.path().join("sub")).unwrap();
+    fs::create_dir_all(after.path().join("sub")).unwrap();
+    fs::write(before.path().join(".DS_Store"), "before").unwrap();
+    fs::write(after.path().join(".DS_Store"), "after").unwrap();
+    fs::write(before.path().join("sub/.DS_Store"), "before").unwrap();
+    fs::write(after.path().join("sub/.DS_Store"), "after").unwrap();
+
+    let diff = diff_folders(before.path(), after.path()).expect("diff dirs");
+
+    assert!(!diff.contains(".DS_Store"), "diff: {diff}");
+}
+
+#[test]
+fn patch_commit_prepare_pkg_files_for_diff_honors_files_field() {
+    let edit_dir = tempdir().expect("edit dir");
+    fs::write(
+        edit_dir.path().join("package.json"),
+        r#"{"name":"pkg","version":"1.0.0","files":["index.js"]}"#,
+    )
+    .unwrap();
+    fs::write(edit_dir.path().join("index.js"), "included\n").unwrap();
+    fs::write(edit_dir.path().join("ignore.txt"), "excluded\n").unwrap();
+
+    let filtered = prepare_pkg_files_for_diff(edit_dir.path()).expect("prepare files");
+    let PkgFilesForDiff::Temporary(path) = filtered else {
+        panic!("files field should require a temporary filtered dir");
+    };
+
+    assert!(path.join("index.js").is_file());
+    assert!(path.join("package.json").is_file());
+    assert!(!path.join("ignore.txt").exists());
+
+    fs::remove_dir_all(path).unwrap();
+}
+
+#[test]
+fn patch_commit_prepare_pkg_files_for_diff_creates_nested_parent_dirs() {
+    let edit_dir = tempdir().expect("edit dir");
+    fs::write(
+        edit_dir.path().join("package.json"),
+        r#"{"name":"pkg","version":"1.0.0","files":["lib/index.js"]}"#,
+    )
+    .unwrap();
+    fs::create_dir(edit_dir.path().join("lib")).unwrap();
+    fs::write(edit_dir.path().join("lib/index.js"), "included\n").unwrap();
+    fs::write(edit_dir.path().join("ignore.txt"), "excluded\n").unwrap();
+
+    let filtered = prepare_pkg_files_for_diff(edit_dir.path()).expect("prepare files");
+    let PkgFilesForDiff::Temporary(path) = filtered else {
+        panic!("files field should require a temporary filtered dir");
+    };
+
+    assert_eq!(fs::read_to_string(path.join("lib/index.js")).unwrap(), "included\n");
+    assert!(!path.join("ignore.txt").exists());
+
+    fs::remove_dir_all(path).unwrap();
+}
+
+#[test]
+fn patch_commit_prepare_pkg_files_for_diff_reports_nested_parent_create_errors() {
+    let edit_dir = tempdir().expect("edit dir");
+    fs::write(
+        edit_dir.path().join("package.json"),
+        r#"{"name":"pkg","version":"1.0.0","files":["lib/index.js"]}"#,
+    )
+    .unwrap();
+    fs::create_dir(edit_dir.path().join("lib")).unwrap();
+    fs::write(edit_dir.path().join("lib/index.js"), "included\n").unwrap();
+    fs::write(edit_dir.path().join("ignore.txt"), "excluded\n").unwrap();
+
+    let err = prepare_pkg_files_for_diff_with_fs(
+        edit_dir.path(),
+        &CreateDirErrorFs { fail_on: "lib", created_dirs: Cell::new(0) },
+    )
+    .expect_err("nested parent creation should fail");
+
+    assert!(matches!(err, PatchCommitError::CreateTempDir { .. }));
+}
+
+#[test]
+fn patch_commit_prepare_pkg_files_for_diff_reports_hard_link_errors() {
+    let edit_dir = tempdir().expect("edit dir");
+    fs::write(
+        edit_dir.path().join("package.json"),
+        r#"{"name":"pkg","version":"1.0.0","files":["index.js"]}"#,
+    )
+    .unwrap();
+    fs::write(edit_dir.path().join("index.js"), "included\n").unwrap();
+    fs::write(edit_dir.path().join("ignore.txt"), "excluded\n").unwrap();
+
+    let err = prepare_pkg_files_for_diff_with_fs(edit_dir.path(), &HardLinkErrorFs)
+        .expect_err("hard link creation should fail");
+
+    assert!(matches!(err, PatchCommitError::LinkFile { .. }));
+}
+
+#[test]
+fn patch_commit_prepare_pkg_files_for_diff_returns_original_when_all_files_match() {
+    let edit_dir = tempdir().expect("edit dir");
+    fs::write(edit_dir.path().join("package.json"), r#"{"name":"pkg","version":"1.0.0"}"#).unwrap();
+    fs::write(edit_dir.path().join("index.js"), "included\n").unwrap();
+
+    let filtered = prepare_pkg_files_for_diff(edit_dir.path()).expect("prepare files");
+
+    assert_eq!(filtered, PkgFilesForDiff::Original(edit_dir.path().to_path_buf()));
+}
+
+#[test]
+fn patch_commit_diff_dirs_returns_empty_for_equal_dirs() {
+    let before = tempdir().expect("before dir");
+    let after = tempdir().expect("after dir");
+    fs::write(before.path().join("index.js"), "module.exports = true\n").unwrap();
+    fs::write(after.path().join("index.js"), "module.exports = true\n").unwrap();
+
+    let diff = diff_folders(before.path(), after.path()).expect("diff dirs");
+
+    assert_eq!(diff, "");
+}
+
+#[test]
+fn patch_commit_diff_dirs_reports_git_errors() {
+    let tmp = tempdir().expect("temp dir");
+
+    let err = diff_folders(&tmp.path().join("missing-a"), &tmp.path().join("missing-b"))
+        .expect_err("missing dirs should fail");
+
+    assert!(matches!(err, PatchCommitError::DiffFailed { .. }));
+}
+
+#[test]
+fn patch_commit_remove_existing_temp_dir_removes_existing_dir() {
+    let tmp = tempdir().expect("temp dir");
+    let temp_dir = tmp.path().join("filtered");
+    fs::create_dir(&temp_dir).expect("create temp dir");
+
+    remove_existing_temp_dir_with_fs(&temp_dir, &RealPatchCommitFs).expect("remove temp dir");
+
+    assert!(!temp_dir.exists(), "temp dir should be removed");
+}
+
+#[test]
+fn patch_commit_remove_existing_temp_dir_reports_remove_errors() {
+    let tmp = tempdir().expect("temp dir");
+    let temp_dir = tmp.path().join("filtered");
+
+    let err = remove_existing_temp_dir_with_fs(&temp_dir, &RemoveDirErrorFs)
+        .expect_err("remove error should be reported");
+
+    assert!(matches!(err, PatchCommitError::RemoveTempDir { .. }));
+}
+
+struct CreateDirErrorFs {
+    fail_on: &'static str,
+    created_dirs: Cell<usize>,
+}
+
+impl PatchCommitFs for CreateDirErrorFs {
+    fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+        if path.ends_with(self.fail_on) {
+            return Err(io::Error::new(io::ErrorKind::PermissionDenied, "blocked create_dir_all"));
+        }
+        self.created_dirs.set(self.created_dirs.get() + 1);
+        fs::create_dir_all(path)
+    }
+
+    fn hard_link(&self, source: &Path, target: &Path) -> io::Result<()> {
+        fs::hard_link(source, target)
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+        match fs::remove_dir_all(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+struct HardLinkErrorFs;
+
+impl PatchCommitFs for HardLinkErrorFs {
+    fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+        fs::create_dir_all(path)
+    }
+
+    fn hard_link(&self, _source: &Path, _target: &Path) -> io::Result<()> {
+        Err(io::Error::new(io::ErrorKind::PermissionDenied, "blocked hard_link"))
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+        match fs::remove_dir_all(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+struct RemoveDirErrorFs;
+
+impl PatchCommitFs for RemoveDirErrorFs {
+    fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+        fs::create_dir_all(path)
+    }
+
+    fn hard_link(&self, source: &Path, target: &Path) -> io::Result<()> {
+        fs::hard_link(source, target)
+    }
+
+    fn remove_dir_all(&self, _path: &Path) -> io::Result<()> {
+        Err(io::Error::new(io::ErrorKind::PermissionDenied, "blocked remove_dir_all"))
+    }
+}

--- a/pacquet/crates/package-manager/src/patch_commit/tests.rs
+++ b/pacquet/crates/package-manager/src/patch_commit/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     PatchCommitError, PatchCommitFs, PkgFilesForDiff, RealPatchCommitFs, diff_folders,
     normalize_diff_output, prepare_pkg_files_for_diff, prepare_pkg_files_for_diff_with_fs,
-    remove_existing_temp_dir_with_fs,
+    remove_existing_temp_dir_with_fs, temporary_filtered_dir,
 };
 use pretty_assertions::assert_eq;
 use std::{cell::Cell, fs, io, path::Path};
@@ -35,6 +35,33 @@ fn patch_commit_diff_dirs_filters_ds_store_diffs() {
     let diff = diff_folders(before.path(), after.path()).expect("diff dirs");
 
     assert!(!diff.contains(".DS_Store"), "diff: {diff}");
+}
+
+#[test]
+fn patch_commit_diff_dirs_keeps_files_whose_names_contain_ds_store() {
+    let before = tempdir().expect("before dir");
+    let after = tempdir().expect("after dir");
+    fs::write(before.path().join("foo.DS_Store.js"), "before\n").unwrap();
+    fs::write(after.path().join("foo.DS_Store.js"), "after\n").unwrap();
+
+    let diff = diff_folders(before.path(), after.path()).expect("diff dirs");
+
+    assert!(diff.contains("foo.DS_Store.js"), "diff: {diff}");
+}
+
+#[test]
+fn patch_commit_diff_dirs_accepts_paths_that_start_with_dash() {
+    let tmp = tempdir().expect("temp dir");
+    let before = tmp.path().join("-before");
+    let after = tmp.path().join("-after");
+    fs::create_dir(&before).unwrap();
+    fs::create_dir(&after).unwrap();
+    fs::write(before.join("index.js"), "before\n").unwrap();
+    fs::write(after.join("index.js"), "after\n").unwrap();
+
+    let diff = diff_folders(&before, &after).expect("diff dirs");
+
+    assert!(diff.contains("diff --git a/index.js b/index.js"), "diff: {diff}");
 }
 
 #[test]
@@ -140,14 +167,19 @@ fn patch_commit_prepare_pkg_files_for_diff_rejects_packlist_paths_that_escape_so
 }
 
 #[test]
-fn patch_commit_prepare_pkg_files_for_diff_returns_original_when_all_files_match() {
+fn patch_commit_prepare_pkg_files_for_diff_uses_filtered_view_when_packlist_matches_all_files() {
     let edit_dir = tempdir().expect("edit dir");
     fs::write(edit_dir.path().join("package.json"), r#"{"name":"pkg","version":"1.0.0"}"#).unwrap();
     fs::write(edit_dir.path().join("index.js"), "included\n").unwrap();
 
     let filtered = prepare_pkg_files_for_diff(edit_dir.path()).expect("prepare files");
+    let PkgFilesForDiff::Temporary(path) = filtered else {
+        panic!("package files should be prepared in a temporary filtered dir");
+    };
 
-    assert_eq!(filtered, PkgFilesForDiff::Original(edit_dir.path().to_path_buf()));
+    assert_eq!(path, temporary_filtered_dir(edit_dir.path()));
+    assert_eq!(fs::read_to_string(path.join("index.js")).unwrap(), "included\n");
+    fs::remove_dir_all(path).unwrap();
 }
 
 #[test]
@@ -212,11 +244,29 @@ fn patch_commit_remove_existing_temp_dir_removes_existing_dir() {
 fn patch_commit_remove_existing_temp_dir_reports_remove_errors() {
     let tmp = tempdir().expect("temp dir");
     let temp_dir = tmp.path().join("filtered");
+    fs::create_dir(&temp_dir).expect("create temp dir");
 
     let err = remove_existing_temp_dir_with_fs(&temp_dir, &RemoveDirErrorFs)
         .expect_err("remove error should be reported");
 
     assert!(matches!(err, PatchCommitError::RemoveTempDir { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn patch_commit_remove_existing_temp_dir_rejects_symlinked_temp_dir() {
+    let tmp = tempdir().expect("temp dir");
+    let outside = tmp.path().join("outside");
+    let temp_dir = tmp.path().join("filtered");
+    fs::create_dir(&outside).expect("create outside dir");
+    fs::write(outside.join("sentinel"), "keep").expect("write outside sentinel");
+    std::os::unix::fs::symlink(&outside, &temp_dir).expect("symlink temp dir");
+
+    let err = remove_existing_temp_dir_with_fs(&temp_dir, &RealPatchCommitFs)
+        .expect_err("symlinked temp dir should be rejected");
+
+    assert!(matches!(err, PatchCommitError::UnsafeTempDir { .. }));
+    assert_eq!(fs::read_to_string(outside.join("sentinel")).unwrap(), "keep");
 }
 
 struct CreateDirErrorFs {
@@ -225,6 +275,10 @@ struct CreateDirErrorFs {
 }
 
 impl PatchCommitFs for CreateDirErrorFs {
+    fn symlink_metadata(&self, path: &Path) -> io::Result<fs::Metadata> {
+        fs::symlink_metadata(path)
+    }
+
     fn create_dir_all(&self, path: &Path) -> io::Result<()> {
         if path.ends_with(self.fail_on) {
             return Err(io::Error::new(io::ErrorKind::PermissionDenied, "blocked create_dir_all"));
@@ -249,6 +303,10 @@ impl PatchCommitFs for CreateDirErrorFs {
 struct HardLinkErrorFs;
 
 impl PatchCommitFs for HardLinkErrorFs {
+    fn symlink_metadata(&self, path: &Path) -> io::Result<fs::Metadata> {
+        fs::symlink_metadata(path)
+    }
+
     fn create_dir_all(&self, path: &Path) -> io::Result<()> {
         fs::create_dir_all(path)
     }
@@ -269,6 +327,10 @@ impl PatchCommitFs for HardLinkErrorFs {
 struct RemoveDirErrorFs;
 
 impl PatchCommitFs for RemoveDirErrorFs {
+    fn symlink_metadata(&self, path: &Path) -> io::Result<fs::Metadata> {
+        fs::symlink_metadata(path)
+    }
+
     fn create_dir_all(&self, path: &Path) -> io::Result<()> {
         fs::create_dir_all(path)
     }

--- a/pacquet/crates/package-manager/src/patch_commit/tests.rs
+++ b/pacquet/crates/package-manager/src/patch_commit/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     PatchCommitError, PatchCommitFs, PkgFilesForDiff, RealPatchCommitFs, diff_folders,
-    prepare_pkg_files_for_diff, prepare_pkg_files_for_diff_with_fs,
+    normalize_diff_output, prepare_pkg_files_for_diff, prepare_pkg_files_for_diff_with_fs,
     remove_existing_temp_dir_with_fs,
 };
 use pretty_assertions::assert_eq;
@@ -122,6 +122,24 @@ fn patch_commit_prepare_pkg_files_for_diff_reports_hard_link_errors() {
 }
 
 #[test]
+fn patch_commit_prepare_pkg_files_for_diff_rejects_packlist_paths_that_escape_source() {
+    let root = tempdir().expect("root dir");
+    let edit_dir = root.path().join("edit");
+    fs::create_dir(&edit_dir).expect("create edit dir");
+    fs::write(
+        edit_dir.join("package.json"),
+        r#"{"name":"pkg","version":"1.0.0","main":"../secret.js","files":["index.js"]}"#,
+    )
+    .unwrap();
+    fs::write(edit_dir.join("index.js"), "included\n").unwrap();
+    fs::write(root.path().join("secret.js"), "outside\n").unwrap();
+
+    let err = prepare_pkg_files_for_diff(&edit_dir).expect_err("escaping packlist path");
+
+    assert!(matches!(err, PatchCommitError::InvalidPackageFilePath { .. }));
+}
+
+#[test]
 fn patch_commit_prepare_pkg_files_for_diff_returns_original_when_all_files_match() {
     let edit_dir = tempdir().expect("edit dir");
     fs::write(edit_dir.path().join("package.json"), r#"{"name":"pkg","version":"1.0.0"}"#).unwrap();
@@ -142,6 +160,31 @@ fn patch_commit_diff_dirs_returns_empty_for_equal_dirs() {
     let diff = diff_folders(before.path(), after.path()).expect("diff dirs");
 
     assert_eq!(diff, "");
+}
+
+#[test]
+fn patch_commit_diff_normalization_leaves_hunk_content_untouched() {
+    let diff = "\
+diff --git a/tmp/before/index.js b/tmp/after/index.js
+index 123..456 100644
+--- a/tmp/before/index.js
++++ b/tmp/after/index.js
+@@ -1 +1 @@
+-console.log(\"/tmp/before/ must stay in content\")
++console.log(\"/tmp/after/ must stay in content\")
+--- /tmp/before/ also stays when content resembles a file header
++++ /tmp/after/ also stays when content resembles a file header
+";
+
+    let normalized = normalize_diff_output(diff, "/tmp/before", "/tmp/after");
+
+    assert!(normalized.contains("diff --git a/index.js b/index.js"), "{normalized}");
+    assert!(normalized.contains("--- a/index.js"), "{normalized}");
+    assert!(normalized.contains("+++ b/index.js"), "{normalized}");
+    assert!(normalized.contains("-console.log(\"/tmp/before/ must stay in content\")"));
+    assert!(normalized.contains("+console.log(\"/tmp/after/ must stay in content\")"));
+    assert!(normalized.contains("--- /tmp/before/ also stays"));
+    assert!(normalized.contains("+++ /tmp/after/ also stays"));
 }
 
 #[test]

--- a/pacquet/crates/package-manager/src/patch_commit/tests.rs
+++ b/pacquet/crates/package-manager/src/patch_commit/tests.rs
@@ -1,9 +1,11 @@
 use super::{
-    PatchCommitError, PatchCommitFs, PkgFilesForDiff, RealPatchCommitFs, diff_folders,
-    normalize_diff_output, prepare_pkg_files_for_diff, prepare_pkg_files_for_diff_with_fs,
-    remove_existing_temp_dir_with_fs, temporary_filtered_dir,
+    DiffTempFile, PatchCommitError, PatchCommitFs, PkgFilesForDiff, RealPatchCommitFs,
+    diff_folders, normalize_diff_output, prepare_pkg_files_for_diff,
+    prepare_pkg_files_for_diff_with_fs, remove_existing_temp_dir_with_fs, temporary_filtered_dir,
 };
 use pretty_assertions::assert_eq;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::{cell::Cell, fs, io, path::Path};
 use tempfile::tempdir;
 
@@ -62,6 +64,16 @@ fn patch_commit_diff_dirs_accepts_paths_that_start_with_dash() {
     let diff = diff_folders(&before, &after).expect("diff dirs");
 
     assert!(diff.contains("diff --git a/index.js b/index.js"), "diff: {diff}");
+}
+
+#[cfg(unix)]
+#[test]
+fn patch_commit_diff_temp_files_are_owner_only() {
+    let temp_file = DiffTempFile::new("stdout").expect("diff temp file");
+
+    let mode = fs::metadata(&temp_file.path).expect("diff temp metadata").permissions().mode();
+
+    assert_eq!(mode & 0o777, 0o600);
 }
 
 #[test]

--- a/pacquet/crates/resolving-deps-resolver/src/dedupe_injected_deps/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/dedupe_injected_deps/tests.rs
@@ -27,6 +27,7 @@ fn make_node(id: &str, children: BTreeMap<String, DepPath>) -> DependenciesGraph
             policy_violation: None,
         }),
         children,
+        optional_children: HashSet::new(),
         peer_dependencies: BTreeMap::new(),
         transitive_peer_dependencies: HashSet::new(),
         resolved_peer_names: HashSet::new(),

--- a/pacquet/crates/resolving-deps-resolver/src/dedupe_peer_dependents/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/dedupe_peer_dependents/tests.rs
@@ -36,6 +36,7 @@ fn make_node(
             policy_violation: None,
         }),
         children: children.iter().map(|(alias, child)| (alias.to_string(), dp(child))).collect(),
+        optional_children: HashSet::new(),
         peer_dependencies: BTreeMap::new(),
         transitive_peer_dependencies: HashSet::new(),
         resolved_peer_names: resolved_peers.iter().map(std::string::ToString::to_string).collect(),

--- a/pacquet/crates/resolving-deps-resolver/src/dependencies_graph.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/dependencies_graph.rs
@@ -33,6 +33,12 @@ pub struct DependenciesGraphNode {
     /// inherited from the per-occurrence tree node, peers added during
     /// peer resolution.
     pub children: BTreeMap<String, DepPath>,
+    /// Child aliases that originated from `optionalDependencies`.
+    /// This is kept separately from [`Self::children`] because lockfile
+    /// reuse may realize child edges from an existing `pnpm-lock.yaml`
+    /// snapshot whose synthetic manifest no longer carries an
+    /// `optionalDependencies` block.
+    pub optional_children: HashSet<String>,
     pub peer_dependencies: BTreeMap<String, PeerDep>,
     /// Names of peers resolved from outside this node's own peer-deps —
     /// i.e. peers it inherited from its parents' context.

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -597,6 +597,7 @@ struct NodeRecord {
     /// its final depPath.
     edges: BTreeMap<String, NodeId>,
     peer_edges: HashSet<String>,
+    optional_child_aliases: HashSet<String>,
     transitive_peer_dependencies: HashSet<String>,
     depth: i32,
     installable: bool,
@@ -1138,6 +1139,7 @@ impl Walker<'_> {
         for (peer_alias, peer_node_id) in &own_resolved_peers {
             record_edges.insert(peer_alias.clone(), peer_node_id.clone());
         }
+        let optional_child_aliases = self.optional_child_aliases(&pkg.id, &record_edges);
         let peer_edges = own_resolved_peers.keys().cloned().collect();
         let record_order = self.next_record_order;
         self.next_record_order += 1;
@@ -1146,6 +1148,7 @@ impl Walker<'_> {
             NodeRecord {
                 edges: record_edges,
                 peer_edges,
+                optional_child_aliases: optional_child_aliases.clone(),
                 transitive_peer_dependencies: transitive_peer_dependencies.clone(),
                 depth: tree_node.depth,
                 installable: tree_node.installable,
@@ -1202,6 +1205,7 @@ impl Walker<'_> {
                 resolved_package_id: pkg.id.clone(),
                 resolve_result: Arc::clone(&pkg.result),
                 children: graph_children,
+                optional_children: optional_child_aliases,
                 peer_dependencies: pkg.peer_dependencies.clone(),
                 transitive_peer_dependencies,
                 resolved_peer_names: all_resolved_peers.keys().cloned().collect(),
@@ -1763,6 +1767,7 @@ impl Walker<'_> {
                 resolved_package_id: pkg_id.clone(),
                 resolve_result: Arc::clone(&pkg.result),
                 children,
+                optional_children: record.optional_child_aliases.clone(),
                 peer_dependencies: pkg.peer_dependencies.clone(),
                 transitive_peer_dependencies: record.transitive_peer_dependencies.clone(),
                 resolved_peer_names,
@@ -1786,6 +1791,9 @@ impl Walker<'_> {
                         candidate
                             .transitive_peer_dependencies
                             .extend(existing.transitive_peer_dependencies.iter().cloned());
+                        candidate
+                            .optional_children
+                            .extend(existing.optional_children.iter().cloned());
                         merge_preferred_child_edges(
                             &mut candidate,
                             existing.children.clone(),
@@ -1798,6 +1806,7 @@ impl Walker<'_> {
                         existing
                             .transitive_peer_dependencies
                             .extend(candidate.transitive_peer_dependencies);
+                        existing.optional_children.extend(candidate.optional_children);
                         merge_preferred_child_edges(
                             existing,
                             candidate.children,
@@ -1902,6 +1911,12 @@ impl Walker<'_> {
             }
             children.insert(alias.clone(), self.final_dep_path_of(edge_node_id, final_dep_paths));
         }
+        let optional_children = record
+            .optional_child_aliases
+            .iter()
+            .filter(|alias| children.contains_key(*alias))
+            .cloned()
+            .collect();
         let resolved_peer_names: HashSet<String> = record_resolved_peer_names
             .get(provider_node_id)
             .into_iter()
@@ -1914,6 +1929,7 @@ impl Walker<'_> {
             resolved_package_id: tree_node.resolved_package_id.clone(),
             resolve_result: Arc::clone(&pkg.result),
             children,
+            optional_children,
             peer_dependencies: pkg.peer_dependencies.clone(),
             transitive_peer_dependencies: record.transitive_peer_dependencies.clone(),
             resolved_peer_names,
@@ -1922,6 +1938,21 @@ impl Walker<'_> {
             is_pure: false,
             optional: pkg.optional,
         })
+    }
+
+    fn optional_child_aliases(
+        &self,
+        pkg_id: &str,
+        edges: &BTreeMap<String, NodeId>,
+    ) -> HashSet<String> {
+        self.tree
+            .children_by_id
+            .get(pkg_id)
+            .into_iter()
+            .flat_map(|children| children.iter())
+            .filter(|edge| edge.optional && edges.contains_key(&edge.alias))
+            .map(|edge| edge.alias.clone())
+            .collect()
     }
 
     /// Realize the `(alias → NodeId)` children of `node_id` if it's

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -749,6 +749,7 @@ fn final_graph_keeps_first_equal_depth_payload_and_unions_transitive_peers() {
         NodeRecord {
             edges: BTreeMap::from([("peer".to_string(), second_child)]),
             peer_edges: HashSet::new(),
+            optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::from(["debug".to_string()]),
             depth: 1,
             installable: true,
@@ -761,6 +762,7 @@ fn final_graph_keeps_first_equal_depth_payload_and_unions_transitive_peers() {
         NodeRecord {
             edges: BTreeMap::from([("peer".to_string(), first_child)]),
             peer_edges: HashSet::new(),
+            optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::new(),
             depth: 1,
             installable: true,
@@ -816,6 +818,7 @@ fn final_graph_duplicate_parent_prefers_child_variant_matching_parent_peers() {
         NodeRecord {
             edges: BTreeMap::from([("webpack-cli".to_string(), first_child.clone())]),
             peer_edges: HashSet::new(),
+            optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::new(),
             depth: 1,
             installable: true,
@@ -828,6 +831,7 @@ fn final_graph_duplicate_parent_prefers_child_variant_matching_parent_peers() {
         NodeRecord {
             edges: BTreeMap::from([("webpack-cli".to_string(), second_child.clone())]),
             peer_edges: HashSet::new(),
+            optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::new(),
             depth: 1,
             installable: true,
@@ -909,6 +913,7 @@ fn final_graph_peer_edge_uses_provider_variant_without_unavailable_extra_peers()
         NodeRecord {
             edges: BTreeMap::new(),
             peer_edges: HashSet::new(),
+            optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::new(),
             depth: 0,
             installable: true,
@@ -921,6 +926,7 @@ fn final_graph_peer_edge_uses_provider_variant_without_unavailable_extra_peers()
         NodeRecord {
             edges: BTreeMap::new(),
             peer_edges: HashSet::new(),
+            optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::new(),
             depth: 0,
             installable: true,
@@ -933,6 +939,7 @@ fn final_graph_peer_edge_uses_provider_variant_without_unavailable_extra_peers()
         NodeRecord {
             edges: BTreeMap::from([("webpack-cli".to_string(), provider_analyzer.clone())]),
             peer_edges: HashSet::from(["webpack-dev-server".to_string(), "webpack".to_string()]),
+            optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::new(),
             depth: 1,
             installable: true,
@@ -1037,6 +1044,7 @@ fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
         NodeRecord {
             edges: BTreeMap::new(),
             peer_edges: HashSet::new(),
+            optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::from([
                 "bufferutil".to_string(),
                 "tslib".to_string(),
@@ -1057,6 +1065,7 @@ fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
                 "webpack-bundle-analyzer".to_string(),
                 "webpack-dev-server".to_string(),
             ]),
+            optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::new(),
             depth: 0,
             installable: true,

--- a/pacquet/crates/workspace-manifest-writer/src/edit.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/edit.rs
@@ -45,32 +45,104 @@ pub(crate) fn add_config_dependency(
     specifier: &str,
 ) -> Result<bool, Box<yamlpatch::Error>> {
     const BLOCK: &str = "configDependencies";
+    let current_matches =
+        manifest.config_dependencies.as_ref().and_then(|deps| deps.get(name)).map(String::as_str)
+            == Some(specifier);
+    let changed = upsert_top_level_entry(manifest, BLOCK, name, specifier, current_matches)?;
+    if changed {
+        manifest
+            .config_dependencies
+            .get_or_insert_with(IndexMap::new)
+            .insert(name.to_string(), specifier.to_string());
+    }
+    Ok(changed)
+}
+
+/// Upsert `patchedDependencies:` entries into the workspace manifest,
+/// creating the block when needed.
+pub(crate) fn add_patched_dependencies(
+    manifest: &mut Manifest,
+    patched_dependencies: &IndexMap<String, String>,
+) -> Result<bool, Box<yamlpatch::Error>> {
+    const BLOCK: &str = "patchedDependencies";
+    let mut changed = false;
+
+    if patched_dependencies.is_empty() {
+        if manifest.patched_dependencies.is_none() {
+            return Ok(false);
+        }
+        manifest.set_text(remove_top_level_block(manifest.text(), BLOCK));
+        manifest.patched_dependencies = None;
+        manifest.top_level_keys.retain(|key| key != BLOCK);
+        return Ok(true);
+    }
+
+    if let Some(existing) = manifest.patched_dependencies.as_ref() {
+        let omitted: Vec<String> = existing
+            .keys()
+            .filter(|key| !patched_dependencies.contains_key(*key))
+            .cloned()
+            .collect();
+        if !omitted.is_empty() {
+            manifest.set_text(remove_mapping_entries(manifest.text(), &[BLOCK], &omitted));
+            let current = manifest
+                .patched_dependencies
+                .as_mut()
+                .expect("existing patched dependencies should remain decoded");
+            for key in &omitted {
+                current.shift_remove(key);
+            }
+            changed = true;
+        }
+    }
+
+    for (key, path) in patched_dependencies {
+        let current_matches = manifest
+            .patched_dependencies
+            .as_ref()
+            .and_then(|deps| deps.get(key))
+            .map(String::as_str)
+            == Some(path);
+        let entry_changed = upsert_top_level_entry(manifest, BLOCK, key, path, current_matches)?;
+        if entry_changed {
+            manifest
+                .patched_dependencies
+                .get_or_insert_with(IndexMap::new)
+                .insert(key.clone(), path.clone());
+            changed = true;
+        }
+    }
+    Ok(changed)
+}
+
+fn upsert_top_level_entry(
+    manifest: &mut Manifest,
+    block_name: &str,
+    key: &str,
+    value: &str,
+    current_matches: bool,
+) -> Result<bool, Box<yamlpatch::Error>> {
     let text = manifest.text();
-    if let Some(mapping) = locate(text, &[BLOCK]) {
-        let new_text = if mapping.entries.iter().any(|entry| entry.key == name) {
-            // Already present with the same clean specifier — a true
-            // no-op, so don't rewrite the file (which would bump its
-            // mtime and look like a change to freshness checks).
-            if manifest.config_dependencies.as_ref().and_then(|deps| deps.get(name))
-                == Some(&specifier.to_string())
-            {
+    if let Some(mapping) = locate(text, &[block_name]) {
+        let new_text = if mapping.entries.iter().any(|entry| entry.key == key) {
+            if current_matches {
                 return Ok(false);
             }
-            replace_value_at(text, &[BLOCK], name, specifier)?
+            replace_value_at(text, &[block_name], key, value)?
         } else {
-            insert_entry_at(text, &[BLOCK], name, specifier)
+            insert_entry_at(text, &[block_name], key, value)
         };
         manifest.set_text(new_text);
     } else {
         let block = format!(
-            "{BLOCK}:\n  {}: {}\n",
-            render::render_value(name),
-            render::render_value(specifier),
+            "{block_name}:\n  {}: {}\n",
+            render::render_value(key),
+            render::render_value(value),
         );
-        let new_text = insert_top_level_block(manifest, BLOCK, &block);
+        let new_text = insert_top_level_block(manifest, block_name, &block);
         manifest.set_text(new_text);
         manifest.top_level_keys =
-            render::target_order(&manifest.top_level_keys, &[BLOCK.to_string()]);
+            render::target_order(&manifest.top_level_keys, &[block_name.to_string()]);
     }
     Ok(true)
 }
@@ -347,6 +419,26 @@ fn insert_rendered_entry_at(text: &str, path: &[&str], dep: &str, value_text: &s
     splice(text, offset, &line)
 }
 
+fn remove_mapping_entries(text: &str, path: &[&str], keys: &[String]) -> String {
+    let Some(mapping) = locate(text, path) else {
+        return text.to_string();
+    };
+    let mut out = text.to_string();
+    for entry in mapping.entries.iter().rev().filter(|entry| keys.contains(&entry.key)) {
+        out.replace_range(entry.line_start..entry.block_end, "");
+    }
+    out
+}
+
+fn remove_top_level_block(text: &str, key: &str) -> String {
+    let Some(span) = top_level_span(text, key) else {
+        return text.to_string();
+    };
+    let mut out = text.to_string();
+    out.replace_range(span.key_line_start..span.block_end, "");
+    out
+}
+
 /// Insert a new named catalog (`<name>:` + its first entry) into an existing
 /// top-level `catalogs:` block, at the position the reorder pass would choose.
 fn insert_named_subblock(manifest: &Manifest, name: &str, dep: &str, value: &str) -> String {
@@ -451,6 +543,7 @@ struct EntryPos {
 /// Span of a top-level block keyed by `key`.
 struct TopLevelSpan {
     key_line_start: usize,
+    block_end: usize,
 }
 
 struct Line<'a> {
@@ -619,12 +712,21 @@ fn collect_entries(all: &[Line<'_>], from: usize, to: usize, entry_indent: usize
 /// The starting offset of a top-level key's line.
 fn top_level_span(text: &str, key: &str) -> Option<TopLevelSpan> {
     let all = lines(text);
-    all.iter()
-        .find(|line| {
+    let key_idx = all.iter().position(|line| {
+        structural_indent(line.content) == Some(0) && line_key(line.content).as_deref() == Some(key)
+    })?;
+    let block_end_idx = ((key_idx + 1)..all.len())
+        .find(|&idx| structural_indent(all[idx].content) == Some(0))
+        .unwrap_or(all.len());
+    let block_end = all
+        .get(block_end_idx)
+        .map_or_else(|| all.last().map_or(0, |line| line.end), |line| line.start);
+    all.get(key_idx)
+        .filter(|line| {
             structural_indent(line.content) == Some(0)
                 && line_key(line.content).as_deref() == Some(key)
         })
-        .map(|line| TopLevelSpan { key_line_start: line.start })
+        .map(|line| TopLevelSpan { key_line_start: line.start, block_end })
 }
 
 /// Whether every original non-first top-level key has a blank line before it

--- a/pacquet/crates/workspace-manifest-writer/src/edit.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/edit.rs
@@ -68,7 +68,8 @@ pub(crate) fn add_patched_dependencies(
     let mut changed = false;
 
     if patched_dependencies.is_empty() {
-        if manifest.patched_dependencies.is_none() {
+        let has_block = manifest.top_level_keys.iter().any(|key| key == BLOCK);
+        if manifest.patched_dependencies.is_none() && !has_block {
             return Ok(false);
         }
         manifest.set_text(remove_top_level_block(manifest.text(), BLOCK));
@@ -715,9 +716,10 @@ fn top_level_span(text: &str, key: &str) -> Option<TopLevelSpan> {
     let key_idx = all.iter().position(|line| {
         structural_indent(line.content) == Some(0) && line_key(line.content).as_deref() == Some(key)
     })?;
-    let block_end_idx = ((key_idx + 1)..all.len())
+    let next_key_idx = ((key_idx + 1)..all.len())
         .find(|&idx| structural_indent(all[idx].content) == Some(0))
         .unwrap_or(all.len());
+    let block_end_idx = leading_comment_start(&all, key_idx + 1, next_key_idx);
     let block_end = all
         .get(block_end_idx)
         .map_or_else(|| all.last().map_or(0, |line| line.end), |line| line.start);
@@ -727,6 +729,22 @@ fn top_level_span(text: &str, key: &str) -> Option<TopLevelSpan> {
                 && line_key(line.content).as_deref() == Some(key)
         })
         .map(|line| TopLevelSpan { key_line_start: line.start, block_end })
+}
+
+fn leading_comment_start(all: &[Line<'_>], block_start: usize, next_key_idx: usize) -> usize {
+    if next_key_idx == all.len() {
+        return next_key_idx;
+    }
+    let mut idx = next_key_idx;
+    while idx > block_start && is_comment_line(all[idx - 1].content) {
+        idx -= 1;
+    }
+    idx
+}
+
+fn is_comment_line(content: &str) -> bool {
+    let trimmed = content.trim_start();
+    !trimmed.is_empty() && trimmed.starts_with('#')
 }
 
 /// Whether every original non-first top-level key has a blank line before it

--- a/pacquet/crates/workspace-manifest-writer/src/lib.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/lib.rs
@@ -25,6 +25,7 @@ use std::{
 };
 
 use derive_more::{Display, Error};
+use indexmap::IndexMap;
 use miette::Diagnostic;
 use pacquet_catalogs_types::Catalogs;
 
@@ -76,6 +77,14 @@ pub enum UpdateWorkspaceManifestError {
         #[error(source)]
         source: io::Error,
     },
+
+    #[display("Failed to remove {path:?}: {source}")]
+    #[diagnostic(code(pacquet_workspace_manifest_writer::remove))]
+    Remove {
+        path: std::path::PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
 }
 
 /// Merge `updated_catalogs` into `dir`'s `pnpm-workspace.yaml`, writing the
@@ -101,8 +110,7 @@ pub fn update_workspace_manifest(
         return Ok(());
     }
 
-    write_atomic(&path, &manifest.into_text())
-        .map_err(|source| UpdateWorkspaceManifestError::Write { path, source })
+    write_or_remove_manifest(&path, manifest)
 }
 
 /// Write a `name → specifier` entry into `dir`'s `pnpm-workspace.yaml`
@@ -132,8 +140,7 @@ pub fn set_config_dependency(
         return Ok(());
     }
 
-    write_atomic(&path, &manifest.into_text())
-        .map_err(|source| UpdateWorkspaceManifestError::Write { path, source })
+    write_or_remove_manifest(&path, manifest)
 }
 
 /// Upsert `name → bool` entries into `dir`'s `pnpm-workspace.yaml`
@@ -170,8 +177,53 @@ where
         return Ok(());
     }
 
-    write_atomic(&path, &manifest.into_text())
-        .map_err(|source| UpdateWorkspaceManifestError::Write { path, source })
+    write_or_remove_manifest(&path, manifest)
+}
+
+/// Merge `patched_dependencies` into `dir`'s `pnpm-workspace.yaml`
+/// `patchedDependencies:` block, preserving the rest of the document's
+/// formatting.
+pub fn set_patched_dependencies(
+    dir: &Path,
+    patched_dependencies: &IndexMap<String, String>,
+) -> Result<(), UpdateWorkspaceManifestError> {
+    let path = dir.join(WORKSPACE_MANIFEST_FILENAME);
+
+    let original = match fs::read_to_string(&path) {
+        Ok(text) => Some(text),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => None,
+        Err(source) => return Err(UpdateWorkspaceManifestError::Read { path, source }),
+    };
+
+    let mut manifest = Manifest::parse(original.as_deref())
+        .map_err(|source| UpdateWorkspaceManifestError::Parse { path: path.clone(), source })?;
+
+    let changed = edit::add_patched_dependencies(&mut manifest, patched_dependencies)
+        .map_err(|source| UpdateWorkspaceManifestError::Edit { path: path.clone(), source })?;
+    if !changed {
+        return Ok(());
+    }
+
+    write_or_remove_manifest(&path, manifest)
+}
+
+fn write_or_remove_manifest(
+    path: &Path,
+    manifest: Manifest,
+) -> Result<(), UpdateWorkspaceManifestError> {
+    if manifest.top_level_keys.is_empty() {
+        match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(source) => {
+                Err(UpdateWorkspaceManifestError::Remove { path: path.to_path_buf(), source })
+            }
+        }
+    } else {
+        write_atomic(path, &manifest.into_text()).map_err(|source| {
+            UpdateWorkspaceManifestError::Write { path: path.to_path_buf(), source }
+        })
+    }
 }
 
 /// Write `contents` to `path` atomically: a sibling temp file in the same

--- a/pacquet/crates/workspace-manifest-writer/src/model.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/model.rs
@@ -25,6 +25,8 @@ pub(crate) struct Manifest {
     /// of an already-present value (and kept in sync as entries are
     /// upserted during a single `pnpm approve-builds` write).
     pub(crate) allow_builds: Option<IndexMap<String, bool>>,
+    /// `patchedDependencies:` entries, keyed by `name[@version]`.
+    pub(crate) patched_dependencies: Option<IndexMap<String, String>>,
 }
 
 #[derive(Default, Deserialize)]
@@ -37,6 +39,8 @@ struct CatalogData {
     config_dependencies: Option<IndexMap<String, ConfigDepValue>>,
     #[serde(default, rename = "allowBuilds")]
     allow_builds: Option<IndexMap<String, AllowBuildValue>>,
+    #[serde(default, rename = "patchedDependencies")]
+    patched_dependencies: Option<IndexMap<String, String>>,
 }
 
 /// An `allowBuilds` value, tolerant of the string form pnpm also accepts
@@ -75,6 +79,7 @@ impl Manifest {
                 catalogs: None,
                 config_dependencies: None,
                 allow_builds: None,
+                patched_dependencies: None,
             });
         }
 
@@ -109,6 +114,7 @@ impl Manifest {
             catalogs: data.catalogs,
             config_dependencies,
             allow_builds,
+            patched_dependencies: data.patched_dependencies,
         })
     }
 

--- a/pacquet/crates/workspace-manifest-writer/src/tests.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/tests.rs
@@ -489,7 +489,7 @@ fn patched_dependency_remove_preserves_successor_comments() {
     let original = "packages:\n  - '*'\n\npatchedDependencies:\n  is-positive: patches/is-positive.patch\n\n# catalog pins\ncatalog:\n  react: 18.2.0\n";
     let out = run_patched_deps(Some(original), &[]);
 
-    assert_eq!(out, "packages:\n  - '*'\n\n# catalog pins\ncatalog:\n  react: 18.2.0\n",);
+    assert_eq!(out, "packages:\n  - '*'\n\n# catalog pins\ncatalog:\n  react: 18.2.0\n");
 }
 
 #[test]

--- a/pacquet/crates/workspace-manifest-writer/src/tests.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/tests.rs
@@ -4,8 +4,9 @@
 //! Structural cases assert the parsed shape; the format-sensitive cases
 //! assert byte-for-byte, matching pnpm's own expectations.
 
-use std::fs;
+use std::{fs, path::PathBuf};
 
+use indexmap::IndexMap;
 use pacquet_catalogs_types::Catalogs;
 use tempfile::TempDir;
 
@@ -377,4 +378,214 @@ fn allow_builds_rejects_a_manifest_with_duplicate_keys() {
         original,
         "the manifest is left unchanged when the update fails",
     );
+}
+
+fn patched_deps(entries: &[(&str, &str)]) -> IndexMap<String, String> {
+    entries.iter().map(|(key, value)| ((*key).to_string(), (*value).to_string())).collect()
+}
+
+/// Run `set_patched_dependencies` against `original` (when `Some`) and return
+/// the resulting file contents.
+fn run_patched_deps(original: Option<&str>, entries: &[(&str, &str)]) -> String {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+    if let Some(text) = original {
+        fs::write(&path, text).expect("seed manifest");
+    }
+    crate::set_patched_dependencies(dir.path(), &patched_deps(entries)).expect("update succeeds");
+    fs::read_to_string(&path).expect("file written")
+}
+
+fn run_patched_deps_path(original: Option<&str>, entries: &[(&str, &str)]) -> (TempDir, PathBuf) {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+    if let Some(text) = original {
+        fs::write(&path, text).expect("seed manifest");
+    }
+    crate::set_patched_dependencies(dir.path(), &patched_deps(entries)).expect("update succeeds");
+    (dir, path)
+}
+
+#[test]
+fn patched_dependency_creates_block_when_absent() {
+    let out = run_patched_deps(None, &[("is-positive@1.0.0", "patches/is-positive@1.0.0.patch")]);
+    assert_eq!(out, "patchedDependencies:\n  is-positive@1.0.0: patches/is-positive@1.0.0.patch\n");
+}
+
+#[test]
+fn patched_dependency_quotes_scoped_keys_and_slash_paths() {
+    let out = run_patched_deps(
+        None,
+        &[("@pnpm.e2e/console-log", "patches/@pnpm.e2e__console-log.patch")],
+    );
+    assert_eq!(
+        out,
+        "patchedDependencies:\n  '@pnpm.e2e/console-log': patches/@pnpm.e2e__console-log.patch\n",
+    );
+}
+
+#[test]
+fn patched_dependency_preserves_existing_manifest_content() {
+    let original = "packages:\n  - '*'\n\nallowBuilds:\n  foo: true\n\ncatalog:\n  react: 18.2.0\n";
+    let out = run_patched_deps(
+        Some(original),
+        &[("is-positive@1.0.0", "patches/is-positive@1.0.0.patch")],
+    );
+    assert_eq!(
+        out,
+        "packages:\n  - '*'\n\nallowBuilds:\n  foo: true\n\ncatalog:\n  react: 18.2.0\n\npatchedDependencies:\n  is-positive@1.0.0: patches/is-positive@1.0.0.patch\n",
+    );
+}
+
+#[test]
+fn patched_dependency_noops_when_unchanged() {
+    use crate::{edit, model::Manifest};
+
+    let original = "patchedDependencies:\n  is-positive@1.0.0: patches/is-positive@1.0.0.patch\n";
+    let deps = patched_deps(&[("is-positive@1.0.0", "patches/is-positive@1.0.0.patch")]);
+    let mut manifest = Manifest::parse(Some(original)).unwrap();
+    assert!(
+        !edit::add_patched_dependencies(&mut manifest, &deps).unwrap(),
+        "re-adding the same patch entry should report no change",
+    );
+    assert_eq!(manifest.into_text(), original);
+}
+
+#[test]
+fn patched_dependency_removes_omitted_entries() {
+    let original = "packages:\n  - '*'\n\npatchedDependencies:\n  is-negative@1.0.0: patches/is-negative@1.0.0.patch\n  is-positive@1.0.0: patches/is-positive@1.0.0.patch\n\ncatalog:\n  react: 18.2.0\n";
+    let out = run_patched_deps(
+        Some(original),
+        &[("is-positive@1.0.0", "patches/is-positive@1.0.0.patch")],
+    );
+
+    assert_eq!(
+        out,
+        "packages:\n  - '*'\n\npatchedDependencies:\n  is-positive@1.0.0: patches/is-positive@1.0.0.patch\n\ncatalog:\n  react: 18.2.0\n",
+    );
+}
+
+#[test]
+fn patched_dependency_removes_empty_block() {
+    let original = "packages:\n  - '*'\n\npatchedDependencies:\n  is-positive@1.0.0: patches/is-positive@1.0.0.patch\n\ncatalog:\n  react: 18.2.0\n";
+    let out = run_patched_deps(Some(original), &[]);
+
+    assert_eq!(out, "packages:\n  - '*'\n\ncatalog:\n  react: 18.2.0\n");
+}
+
+#[test]
+fn patched_dependency_removes_empty_last_block() {
+    let original = "packages:\n  - '*'\n\npatchedDependencies:\n  is-positive@1.0.0: patches/is-positive@1.0.0.patch\n";
+    let out = run_patched_deps(Some(original), &[]);
+
+    assert_eq!(out, "packages:\n  - '*'\n\n");
+}
+
+#[test]
+fn patched_dependency_removes_manifest_when_last_setting_is_removed() {
+    let original = "patchedDependencies:\n  is-positive@1.0.0: patches/is-positive@1.0.0.patch\n";
+    let (_dir, path) = run_patched_deps_path(Some(original), &[]);
+
+    assert!(!path.exists(), "empty pnpm-workspace.yaml should be removed");
+}
+
+#[test]
+fn patched_dependency_empty_map_does_not_create_manifest() {
+    let (_dir, path) = run_patched_deps_path(None, &[]);
+
+    assert!(!path.exists(), "empty patchedDependencies should not create pnpm-workspace.yaml");
+}
+
+#[test]
+fn patched_dependency_empty_map_preserves_manifest_without_patch_block() {
+    let original = "packages:\n  - '*'\n";
+    let out = run_patched_deps(Some(original), &[]);
+
+    assert_eq!(out, original);
+}
+
+#[test]
+fn patched_dependency_missing_decoded_block_returns_original_text_when_removing_block() {
+    use crate::{edit, model::Manifest};
+
+    let original = "packages:\n  - '*'\n";
+    let mut manifest = Manifest::parse(Some(original)).unwrap();
+    manifest.patched_dependencies = Some(IndexMap::from([(
+        "is-positive".to_string(),
+        "patches/is-positive.patch".to_string(),
+    )]));
+
+    assert!(edit::add_patched_dependencies(&mut manifest, &IndexMap::new()).unwrap());
+    assert_eq!(manifest.into_text(), original);
+}
+
+#[test]
+fn patched_dependency_missing_decoded_mapping_keeps_text_before_inserting_new_block() {
+    use crate::{edit, model::Manifest};
+
+    let original = "packages:\n  - '*'\n";
+    let mut manifest = Manifest::parse(Some(original)).unwrap();
+    manifest.patched_dependencies = Some(IndexMap::from([(
+        "is-negative".to_string(),
+        "patches/is-negative.patch".to_string(),
+    )]));
+    let deps = patched_deps(&[("is-positive", "patches/is-positive.patch")]);
+
+    assert!(edit::add_patched_dependencies(&mut manifest, &deps).unwrap());
+
+    let text = manifest.into_text();
+    assert!(text.contains("packages:\n  - '*'\n"), "text: {text}");
+    assert!(text.contains("is-positive: patches/is-positive.patch"), "text: {text}");
+    assert!(!text.contains("is-negative"), "text: {text}");
+}
+
+#[test]
+fn write_or_remove_manifest_ignores_missing_empty_manifest() {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+    let manifest = crate::model::Manifest::parse(Some("")).expect("empty manifest");
+
+    crate::write_or_remove_manifest(&path, manifest).expect("remove missing empty manifest");
+
+    assert!(!path.exists());
+}
+
+#[test]
+fn set_patched_dependencies_reports_read_errors() {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+    fs::create_dir(&path).expect("create manifest dir");
+
+    let err = crate::set_patched_dependencies(
+        dir.path(),
+        &patched_deps(&[("is-positive", "patches/is-positive.patch")]),
+    )
+    .expect_err("manifest directory should fail to read");
+
+    assert!(matches!(err, crate::UpdateWorkspaceManifestError::Read { .. }));
+}
+
+#[test]
+fn write_or_remove_manifest_reports_remove_errors() {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+    fs::create_dir(&path).expect("create manifest dir");
+    let manifest = crate::model::Manifest::parse(Some("")).expect("empty manifest");
+
+    let err =
+        crate::write_or_remove_manifest(&path, manifest).expect_err("directory remove should fail");
+
+    assert!(matches!(err, crate::UpdateWorkspaceManifestError::Remove { .. }));
+}
+
+#[test]
+fn write_or_remove_manifest_reports_write_errors() {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join("missing").join(WORKSPACE_MANIFEST_FILENAME);
+    let manifest = crate::model::Manifest::parse(Some("packages:\n  - '*'\n")).expect("manifest");
+
+    let err =
+        crate::write_or_remove_manifest(&path, manifest).expect_err("missing parent should fail");
+
+    assert!(matches!(err, crate::UpdateWorkspaceManifestError::Write { .. }));
 }

--- a/pacquet/crates/workspace-manifest-writer/src/tests.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/tests.rs
@@ -474,6 +474,25 @@ fn patched_dependency_removes_empty_block() {
 }
 
 #[test]
+fn patched_dependency_removes_empty_or_null_block() {
+    let empty = "packages:\n  - '*'\n\npatchedDependencies:\n\ncatalog:\n  react: 18.2.0\n";
+    let out = run_patched_deps(Some(empty), &[]);
+    assert_eq!(out, "packages:\n  - '*'\n\ncatalog:\n  react: 18.2.0\n");
+
+    let null = "packages:\n  - '*'\n\npatchedDependencies: null\n\ncatalog:\n  react: 18.2.0\n";
+    let out = run_patched_deps(Some(null), &[]);
+    assert_eq!(out, "packages:\n  - '*'\n\ncatalog:\n  react: 18.2.0\n");
+}
+
+#[test]
+fn patched_dependency_remove_preserves_successor_comments() {
+    let original = "packages:\n  - '*'\n\npatchedDependencies:\n  is-positive: patches/is-positive.patch\n\n# catalog pins\ncatalog:\n  react: 18.2.0\n";
+    let out = run_patched_deps(Some(original), &[]);
+
+    assert_eq!(out, "packages:\n  - '*'\n\n# catalog pins\ncatalog:\n  react: 18.2.0\n",);
+}
+
+#[test]
 fn patched_dependency_removes_empty_last_block() {
     let original = "packages:\n  - '*'\n\npatchedDependencies:\n  is-positive@1.0.0: patches/is-positive@1.0.0.patch\n";
     let out = run_patched_deps(Some(original), &[]);

--- a/pacquet/tasks/registry-mock/src/registry_anchor.rs
+++ b/pacquet/tasks/registry-mock/src/registry_anchor.rs
@@ -29,7 +29,7 @@ impl Drop for RegistryAnchor {
         // load an up-to-date anchor, it is leaked to prevent dropping (again).
         let anchor = RegistryAnchor::load().pipe(Box::new).pipe(Box::leak);
         if self.info != anchor.info {
-            eprintln!("info: {:?} is outdated. Skip.", &self.info);
+            eprintln!("info: {:?} is outdated. Skip.", self.info);
             return;
         }
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

- Port the patch workflow commands to pacquet: `patch`, `patch-commit`, and `patch-remove`.
- Add pacquet support for `patchesDir`, patch state handling, patched dependency manifest edits, and lockfile patch metadata.
- Align patch workflow behavior with pnpm for cleanup, optional dependency edges, and colored success output.

Related to https://github.com/pnpm/pnpm/issues/11633.

## Squash Commit Body

```text
Port pnpm's package patch workflow to pacquet.

This adds pacquet implementations for patch, patch-commit, and patch-remove,
including edit-dir state, patch file creation and removal, patchedDependencies
manifest updates, reinstall integration, and lockfile patch metadata.

The implementation also adds patchesDir support to pacquet configuration and
extends the workspace manifest writer so patchedDependencies can be updated
without disturbing unrelated workspace fields. Patch removal now avoids leaving
empty pnpm-workspace.yaml files behind and preserves optional lockfile child
edges when removing patches.

Tests cover package selection, edit-dir state, patch file reuse, custom patch
directories, patch removal validation, workspace-project behavior, symlink and
traversal rejection, and the patch reinstall paths.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added patch workflow commands: `pacquet patch`, `pacquet patch-commit`, and `pacquet patch-remove`.
  * Added `patchesDir` / `PNPM_CONFIG_PATCHES_DIR` support to control where generated patch files are written.
  * Workspace manifest `patchedDependencies` is now created/updated/removed as part of the patch lifecycle.
* **Bug Fixes**
  * Hardened patch file/directory handling to prevent traversal and symlink escape; improved patch-state persistence safety.
* **Tests**
  * Added/expanded unit and integration coverage for the full patch lifecycle and reporter modes (`ndjson`, `silent`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->