### PR TITLE
ci: shard Windows TS tests

### DIFF
--- a/.github/scripts/bencher-result-from-pnpm-summary.mjs
+++ b/.github/scripts/bencher-result-from-pnpm-summary.mjs
@@ -3,7 +3,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { resolveBenchOutputPath } from './bench-output-path.mjs'
 
-const { name, output, packageDir, summary } = parseArgs(process.argv.slice(2))
+const { allowMissing, name, output, packageDir, summary } = parseArgs(process.argv.slice(2))
 const summaryPath = resolve(summary)
 const outputPath = resolveBenchOutputPath(output)
 const packagePath = resolve(packageDir)
@@ -11,6 +11,9 @@ const { executionStatus } = JSON.parse(await readFile(summaryPath, 'utf8'))
 
 const entry = executionStatus?.[packagePath]
 if (entry == null) {
+  if (allowMissing) {
+    process.exit(0)
+  }
   console.error(`No execution summary entry found for ${packagePath}`)
   process.exit(1)
 }
@@ -48,6 +51,7 @@ function parseArgs (args) {
   let output
   let packageDir
   let summary = 'pnpm-exec-summary.json'
+  let allowMissing = false
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]
@@ -59,6 +63,8 @@ function parseArgs (args) {
       packageDir = args[++i]
     } else if (arg === '--summary') {
       summary = args[++i]
+    } else if (arg === '--allow-missing') {
+      allowMissing = true
     } else {
       usage(`unknown argument: ${arg}`)
     }
@@ -68,11 +74,11 @@ function parseArgs (args) {
   if (!output) usage('missing --output')
   if (!packageDir) usage('missing --package-dir')
 
-  return { name, output, packageDir, summary }
+  return { allowMissing, name, output, packageDir, summary }
 }
 
 function usage (message) {
   console.error(message)
-  console.error('Usage: bencher-result-from-pnpm-summary.mjs --name <benchmark> --output <file> --package-dir <dir> [--summary <file>]')
+  console.error('Usage: bencher-result-from-pnpm-summary.mjs --name <benchmark> --output <file> --package-dir <dir> [--summary <file>] [--allow-missing]')
   process.exit(1)
 }

--- a/.github/scripts/run-ts-tests-chunk.mjs
+++ b/.github/scripts/run-ts-tests-chunk.mjs
@@ -86,6 +86,14 @@ function usesJest (scripts) {
   ))
 }
 
+function readRegistryMockPort (scripts) {
+  for (const script of Object.values(scripts ?? {})) {
+    const match = /PNPM_REGISTRY_MOCK_PORT=(\d+)/.exec(script)
+    if (match != null) return match[1]
+  }
+  return undefined
+}
+
 function selectChunk (tasks, opts) {
   const groups = Array.from({ length: opts.chunks }, () => ({ tasks: [], weight: 0 }))
   for (const task of [...tasks].sort(compareTasksByWeight)) {
@@ -128,8 +136,12 @@ async function runJestPackage (pkg, selectedPackage) {
     path.join(pkg.path, 'node_modules', '.bin'),
     path.join(rootDir, 'node_modules', '.bin'),
   ])
-  if (pkg.manifest.name === '@pnpm/installing.deps-installer') {
-    env.PNPM_REGISTRY_MOCK_PORT = '7769'
+  // Some packages pin PNPM_REGISTRY_MOCK_PORT in their `.test` script (e.g. a
+  // fixture whose dependency is a tarball URL baked to that port). Running jest
+  // directly bypasses the script, so carry the pin over from the manifest.
+  const registryMockPort = readRegistryMockPort(pkg.manifest.scripts)
+  if (registryMockPort != null) {
+    env.PNPM_REGISTRY_MOCK_PORT = registryMockPort
   }
 
   let status = 'passed'

--- a/.github/scripts/run-ts-tests-chunk.mjs
+++ b/.github/scripts/run-ts-tests-chunk.mjs
@@ -1,0 +1,333 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { mkdir, readdir, stat, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { performance } from 'node:perf_hooks'
+
+const rootDir = process.cwd()
+const { chunk, chunks, dryRun, script, summary } = parseArgs(process.argv.slice(2))
+
+if (!dryRun) {
+  await runPnpm(['run', 'prepare-fixtures'])
+  await runPnpm(['run', 'remove-temp-dir'])
+}
+
+const packages = await listSelectedPackages(script)
+const tasks = await listTestTasks(packages)
+const selectedTasks = selectChunk(tasks, { chunk, chunks })
+const selectedPackages = groupJestTasksByPackage(selectedTasks)
+const executionStatus = {}
+
+console.log(`Selected ${selectedTasks.length} of ${tasks.length} test tasks for chunk ${chunk}/${chunks}`)
+
+if (!dryRun) {
+  for (const pkg of packages) {
+    const selectedPackage = selectedPackages.get(pkg.path)
+    if (selectedPackage != null) {
+      await runJestPackage(pkg, selectedPackage)
+    } else if (selectedTasks.some((task) => task.kind === 'script' && task.packagePath === pkg.path)) {
+      await runScriptTask(pkg)
+    }
+  }
+  await writeSummary(summary, executionStatus)
+}
+
+const failures = Object.values(executionStatus).filter((status) => status.status === 'failure')
+if (failures.length > 0) {
+  process.exitCode = 1
+}
+
+async function listSelectedPackages (scriptName) {
+  const filterArgs = scriptName === 'ci:test-branch' ? ['--filter=...[origin/main]'] : []
+  const stdout = await capturePnpm([...filterArgs, '-r', 'list', '--depth', '-1', '--json'])
+  return JSON.parse(stdout)
+    .map((pkg) => ({
+      path: pkg.path,
+      manifest: readManifest(pkg.path),
+    }))
+    .filter((pkg) => pkg.manifest.scripts?.['.test'] != null)
+}
+
+async function listTestTasks (packages) {
+  const tasks = []
+  for (const pkg of packages) {
+    if (!usesJest(pkg.manifest.scripts)) {
+      tasks.push({
+        id: normalizePath(path.relative(rootDir, pkg.path)),
+        kind: 'script',
+        packagePath: pkg.path,
+        weight: 1,
+      })
+      continue
+    }
+
+    for (const file of await findJestTestFiles(pkg.path)) {
+      const fileStat = await stat(file)
+      tasks.push({
+        file,
+        id: normalizePath(path.relative(rootDir, file)),
+        kind: 'jest',
+        packagePath: pkg.path,
+        weight: Math.max(1, fileStat.size),
+      })
+    }
+  }
+  return tasks
+}
+
+function usesJest (scripts) {
+  return Object.entries(scripts).some(([name, script]) => (
+    (name === '.test' || name.startsWith('.test:')) && script.includes('jest')
+  ))
+}
+
+function selectChunk (tasks, opts) {
+  const groups = Array.from({ length: opts.chunks }, () => ({ tasks: [], weight: 0 }))
+  for (const task of [...tasks].sort(compareTasksByWeight)) {
+    const group = groups.reduce((best, candidate) => (
+      candidate.weight < best.weight ? candidate : best
+    ))
+    group.tasks.push(task)
+    group.weight += task.weight
+  }
+  return groups[opts.chunk - 1].tasks.sort((a, b) => a.id.localeCompare(b.id))
+}
+
+function groupJestTasksByPackage (tasks) {
+  const selectedPackages = new Map()
+  for (const task of tasks) {
+    if (task.kind !== 'jest') continue
+    const selectedPackage = selectedPackages.get(task.packagePath) ?? { files: [] }
+    selectedPackage.files.push(task.file)
+    selectedPackages.set(task.packagePath, selectedPackage)
+  }
+  for (const selectedPackage of selectedPackages.values()) {
+    selectedPackage.files.sort()
+  }
+  return selectedPackages
+}
+
+async function runJestPackage (pkg, selectedPackage) {
+  const startedAt = performance.now()
+  const relDir = normalizePath(path.relative(rootDir, pkg.path))
+  const relFiles = selectedPackage.files.map((file) => normalizePath(path.relative(pkg.path, file)))
+  console.log(`Running ${relFiles.length} Jest file(s) in ${relDir}`)
+
+  const env = {
+    ...process.env,
+    NODE_OPTIONS: withJestNodeOptions(process.env.NODE_OPTIONS),
+    PNPM_SCRIPT_SRC_DIR: pkg.path,
+  }
+  if (pkg.manifest.name === '@pnpm/installing.deps-installer') {
+    env.PNPM_REGISTRY_MOCK_PORT = '7769'
+  }
+
+  let status = 'passed'
+  let exitCode = 0
+  try {
+    if (pkg.manifest.scripts.pretest != null) {
+      await runPnpm(['--dir', pkg.path, 'run', 'pretest'], { env })
+    }
+    await runPnpm(['--dir', pkg.path, 'exec', 'jest', '--runTestsByPath', ...relFiles], { env })
+  } catch (err) {
+    status = 'failure'
+    exitCode = err.exitCode ?? 1
+  }
+
+  executionStatus[pkg.path] = {
+    status,
+    duration: performance.now() - startedAt,
+    exitCode,
+  }
+}
+
+async function runScriptTask (pkg) {
+  const startedAt = performance.now()
+  const relDir = normalizePath(path.relative(rootDir, pkg.path))
+  console.log(`Running non-Jest test script in ${relDir}`)
+
+  let status = 'passed'
+  let exitCode = 0
+  try {
+    if (pkg.manifest.name === 'pd') {
+      await runCommand('node', ['pd.js', '--version'], { cwd: pkg.path })
+    } else {
+      throw new Error(`Unsupported non-Jest .test script in ${relDir}: ${pkg.manifest.scripts['.test']}`)
+    }
+  } catch (err) {
+    status = 'failure'
+    exitCode = err.exitCode ?? 1
+  }
+
+  executionStatus[pkg.path] = {
+    status,
+    duration: performance.now() - startedAt,
+    exitCode,
+  }
+}
+
+async function findJestTestFiles (packageDir) {
+  const files = []
+  await collectTestFiles(path.join(packageDir, 'test'), files, isTestDirFile)
+  await collectTestFiles(path.join(packageDir, 'src'), files, isSrcTestFile)
+  return files.sort()
+}
+
+async function collectTestFiles (dir, files, matches) {
+  let entries
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  } catch (err) {
+    if (err.code === 'ENOENT') return
+    throw err
+  }
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === 'fixtures' || entry.name === '__fixtures__') continue
+      if (isTestUtilsDir(entryPath)) continue
+      await collectTestFiles(entryPath, files, matches)
+    } else if (entry.isFile() && matches(entryPath)) {
+      files.push(entryPath)
+    }
+  }
+}
+
+function isTestDirFile (file) {
+  return /\.[jt]sx?$/.test(file) && !file.endsWith('.d.ts')
+}
+
+function isSrcTestFile (file) {
+  return file.endsWith('.test.ts')
+}
+
+function isTestUtilsDir (dir) {
+  const segments = normalizePath(path.relative(rootDir, dir)).split('/')
+  const testIndex = segments.indexOf('test')
+  return testIndex !== -1 && segments.slice(testIndex + 1).includes('utils')
+}
+
+async function writeSummary (summaryPath, status) {
+  await mkdir(path.dirname(summaryPath), { recursive: true })
+  await writeFile(summaryPath, JSON.stringify({ executionStatus: status }, null, 2) + '\n')
+}
+
+function readManifest (packageDir) {
+  return JSON.parse(readFileSyncUtf8(path.join(packageDir, 'package.json')))
+}
+
+function readFileSyncUtf8 (file) {
+  return readFileSync(file, 'utf8')
+}
+
+function compareTasksByWeight (a, b) {
+  return b.weight - a.weight || a.id.localeCompare(b.id)
+}
+
+function withJestNodeOptions (current = '') {
+  const options = new Set(current.split(/\s+/).filter(Boolean))
+  options.add('--experimental-vm-modules')
+  options.add('--disable-warning=ExperimentalWarning')
+  options.add('--disable-warning=DEP0169')
+  return Array.from(options).join(' ')
+}
+
+function runPnpm (args, opts = {}) {
+  return runCommand('pn', args, opts)
+}
+
+function capturePnpm (args) {
+  return captureCommand('pn', args)
+}
+
+function runCommand (command, args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: opts.cwd ?? rootDir,
+      env: opts.env ?? process.env,
+      shell: process.platform === 'win32',
+      stdio: 'inherit',
+    })
+    child.on('error', reject)
+    child.on('close', (code, signal) => {
+      if (signal) {
+        reject(Object.assign(new Error(`${command} terminated by signal ${signal}`), { exitCode: 1 }))
+      } else if (code === 0) {
+        resolve()
+      } else {
+        reject(Object.assign(new Error(`${command} exited with code ${code}`), { exitCode: code ?? 1 }))
+      }
+    })
+  })
+}
+
+function captureCommand (command, args) {
+  return new Promise((resolve, reject) => {
+    let stdout = ''
+    const child = spawn(command, args, {
+      cwd: rootDir,
+      shell: process.platform === 'win32',
+      stdio: ['ignore', 'pipe', 'inherit'],
+    })
+    child.stdout.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.on('error', reject)
+    child.on('close', (code, signal) => {
+      if (signal) {
+        reject(Object.assign(new Error(`${command} terminated by signal ${signal}`), { exitCode: 1 }))
+      } else if (code === 0) {
+        resolve(stdout)
+      } else {
+        reject(Object.assign(new Error(`${command} exited with code ${code}`), { exitCode: code ?? 1 }))
+      }
+    })
+  })
+}
+
+function normalizePath (file) {
+  return file.split(path.sep).join('/')
+}
+
+function parseArgs (args) {
+  let chunk
+  let chunks
+  let script
+  let summary = 'pnpm-exec-summary.json'
+  let dryRun = false
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg === '--chunk') {
+      chunk = Number(args[++i])
+    } else if (arg === '--chunks') {
+      chunks = Number(args[++i])
+    } else if (arg === '--dry-run') {
+      dryRun = true
+    } else if (arg === '--script') {
+      script = args[++i]
+    } else if (arg === '--summary') {
+      summary = args[++i]
+    } else {
+      usage(`unknown argument: ${arg}`)
+    }
+  }
+
+  if (script !== 'ci:test-all' && script !== 'ci:test-branch') {
+    usage('missing or unsupported --script')
+  }
+  if (!Number.isInteger(chunk) || chunk < 1) usage('missing or invalid --chunk')
+  if (!Number.isInteger(chunks) || chunks < 1) usage('missing or invalid --chunks')
+  if (chunk > chunks) usage('--chunk cannot be greater than --chunks')
+
+  return { chunk, chunks, dryRun, script, summary }
+}
+
+function usage (message) {
+  console.error(message)
+  console.error('Usage: run-ts-tests-chunk.mjs --script <ci:test-all|ci:test-branch> --chunk <n> --chunks <n> [--summary <file>] [--dry-run]')
+  process.exit(1)
+}

--- a/.github/scripts/run-ts-tests-chunk.mjs
+++ b/.github/scripts/run-ts-tests-chunk.mjs
@@ -6,6 +6,7 @@ import path from 'node:path'
 import { performance } from 'node:perf_hooks'
 
 const rootDir = process.cwd()
+const JEST_FILES_PER_SPLIT_SCRIPT_BATCH = 10
 const { chunk, chunks, dryRun, script, summary } = parseArgs(process.argv.slice(2))
 
 if (!dryRun) {
@@ -112,6 +113,7 @@ async function runJestPackage (pkg, selectedPackage) {
   const startedAt = performance.now()
   const relDir = normalizePath(path.relative(rootDir, pkg.path))
   const relFiles = selectedPackage.files.map((file) => normalizePath(path.relative(pkg.path, file)))
+  const batches = getJestFileBatches(pkg, relFiles)
   console.log(`Running ${relFiles.length} Jest file(s) in ${relDir}`)
 
   const env = {
@@ -133,7 +135,12 @@ async function runJestPackage (pkg, selectedPackage) {
     if (pkg.manifest.scripts.pretest != null) {
       await runPnpm(['--dir', pkg.path, 'run', 'pretest'], { env })
     }
-    await runPnpm(['--dir', pkg.path, 'exec', 'jest', '--runTestsByPath', ...relFiles], { env })
+    for (const [index, files] of batches.entries()) {
+      if (batches.length > 1) {
+        console.log(`Running batch ${index + 1}/${batches.length} (${files.length} Jest file(s)) in ${relDir}`)
+      }
+      await runPnpm(['--dir', pkg.path, 'exec', 'jest', '--runTestsByPath', ...files], { env })
+    }
   } catch (err) {
     status = 'failure'
     exitCode = err.exitCode ?? 1
@@ -236,6 +243,42 @@ function withJestNodeOptions (current = '') {
   options.add('--disable-warning=ExperimentalWarning')
   options.add('--disable-warning=DEP0169')
   return Array.from(options).join(' ')
+}
+
+function getJestFileBatches (pkg, relFiles) {
+  const isolatedFiles = Array.from(getExplicitJestFiles(pkg.manifest.scripts))
+    .filter((file) => relFiles.includes(file))
+  if (isolatedFiles.length === 0 && !hasSplitJestScripts(pkg.manifest.scripts)) return [relFiles]
+
+  const isolatedFileSet = new Set(isolatedFiles)
+  const remainingFiles = relFiles.filter((file) => !isolatedFileSet.has(file))
+  return [
+    ...isolatedFiles.map((file) => [file]),
+    ...chunkArray(remainingFiles, JEST_FILES_PER_SPLIT_SCRIPT_BATCH),
+  ].filter((files) => files.length > 0)
+}
+
+function hasSplitJestScripts (scripts) {
+  return Object.entries(scripts).some(([name, script]) => name.startsWith('.test:') && script.includes('jest'))
+}
+
+function getExplicitJestFiles (scripts) {
+  const files = new Set()
+  for (const [name, script] of Object.entries(scripts)) {
+    if (!name.startsWith('.test:') || !script.includes('jest')) continue
+    for (const match of script.matchAll(/(?:^|\s)(test\/[^\s"'`]+?\.[jt]sx?)(?=\s|$)/g)) {
+      files.add(match[1])
+    }
+  }
+  return files
+}
+
+function chunkArray (items, size) {
+  const chunks = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
 }
 
 function prependPath (env, dirs) {

--- a/.github/scripts/run-ts-tests-chunk.mjs
+++ b/.github/scripts/run-ts-tests-chunk.mjs
@@ -119,6 +119,10 @@ async function runJestPackage (pkg, selectedPackage) {
     NODE_OPTIONS: withJestNodeOptions(process.env.NODE_OPTIONS),
     PNPM_SCRIPT_SRC_DIR: pkg.path,
   }
+  prependPath(env, [
+    path.join(pkg.path, 'node_modules', '.bin'),
+    path.join(rootDir, 'node_modules', '.bin'),
+  ])
   if (pkg.manifest.name === '@pnpm/installing.deps-installer') {
     env.PNPM_REGISTRY_MOCK_PORT = '7769'
   }
@@ -232,6 +236,18 @@ function withJestNodeOptions (current = '') {
   options.add('--disable-warning=ExperimentalWarning')
   options.add('--disable-warning=DEP0169')
   return Array.from(options).join(' ')
+}
+
+function prependPath (env, dirs) {
+  const pathKey = getPathKey(env)
+  env[pathKey] = [
+    ...dirs,
+    env[pathKey],
+  ].filter(Boolean).join(path.delimiter)
+}
+
+function getPathKey (env) {
+  return Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'PATH'
 }
 
 function runPnpm (args, opts = {}) {

--- a/.github/scripts/run-ts-tests-chunk.mjs
+++ b/.github/scripts/run-ts-tests-chunk.mjs
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { mkdir, readdir, stat, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { performance } from 'node:perf_hooks'
 
 const rootDir = process.cwd()
-const JEST_FILES_PER_SPLIT_SCRIPT_BATCH = 10
+const pnpmCommand = resolveCommand('pn')
+const WINDOWS_SHELL_COMMAND_LENGTH_LIMIT = 7000
+const DEFAULT_COMMAND_LENGTH_LIMIT = 100000
 const { chunk, chunks, dryRun, script, summary } = parseArgs(process.argv.slice(2))
 
 if (!dryRun) {
@@ -63,16 +65,17 @@ async function listTestTasks (packages) {
       continue
     }
 
-    for (const file of await findJestTestFiles(pkg.path)) {
+    const testFiles = await findJestTestFiles(pkg.path)
+    tasks.push(...await Promise.all(testFiles.map(async (file) => {
       const fileStat = await stat(file)
-      tasks.push({
+      return {
         file,
         id: normalizePath(path.relative(rootDir, file)),
         kind: 'jest',
         packagePath: pkg.path,
         weight: Math.max(1, fileStat.size),
-      })
-    }
+      }
+    })))
   }
   return tasks
 }
@@ -238,11 +241,20 @@ function compareTasksByWeight (a, b) {
 }
 
 function withJestNodeOptions (current = '') {
-  const options = new Set(current.split(/\s+/).filter(Boolean))
-  options.add('--experimental-vm-modules')
-  options.add('--disable-warning=ExperimentalWarning')
-  options.add('--disable-warning=DEP0169')
-  return Array.from(options).join(' ')
+  const options = current.split(/\s+/).filter(Boolean)
+  addNodeOption(options, '--experimental-vm-modules')
+  addNodeOption(options, '--disable-warning=ExperimentalWarning')
+  addNodeOption(options, '--disable-warning=DEP0169')
+  if (!options.some((option) => option.startsWith('--max-old-space-size='))) {
+    options.push('--max-old-space-size=6144')
+  }
+  return options.join(' ')
+}
+
+function addNodeOption (options, option) {
+  if (!options.includes(option)) {
+    options.push(option)
+  }
 }
 
 function getJestFileBatches (pkg, relFiles) {
@@ -254,7 +266,7 @@ function getJestFileBatches (pkg, relFiles) {
   const remainingFiles = relFiles.filter((file) => !isolatedFileSet.has(file))
   return [
     ...isolatedFiles.map((file) => [file]),
-    ...chunkArray(remainingFiles, JEST_FILES_PER_SPLIT_SCRIPT_BATCH),
+    ...splitJestFilesByCommandLength(pkg, remainingFiles),
   ].filter((files) => files.length > 0)
 }
 
@@ -273,12 +285,32 @@ function getExplicitJestFiles (scripts) {
   return files
 }
 
-function chunkArray (items, size) {
+function splitJestFilesByCommandLength (pkg, files) {
+  const limit = process.platform === 'win32' ? WINDOWS_SHELL_COMMAND_LENGTH_LIMIT : DEFAULT_COMMAND_LENGTH_LIMIT
+  const baseArgs = [pnpmCommand, '--dir', pkg.path, 'exec', 'jest', '--runTestsByPath']
   const chunks = []
-  for (let index = 0; index < items.length; index += size) {
-    chunks.push(items.slice(index, index + size))
+  let currentChunk = []
+  let currentLength = estimateCommandLength(baseArgs)
+
+  for (const file of files) {
+    const fileLength = estimateCommandLength([file])
+    if (currentChunk.length > 0 && currentLength + fileLength > limit) {
+      chunks.push(currentChunk)
+      currentChunk = []
+      currentLength = estimateCommandLength(baseArgs)
+    }
+    currentChunk.push(file)
+    currentLength += fileLength
+  }
+
+  if (currentChunk.length > 0) {
+    chunks.push(currentChunk)
   }
   return chunks
+}
+
+function estimateCommandLength (args) {
+  return args.reduce((total, arg) => total + arg.length + 3, 0)
 }
 
 function prependPath (env, dirs) {
@@ -294,19 +326,23 @@ function getPathKey (env) {
 }
 
 function runPnpm (args, opts = {}) {
-  return runCommand('pn', args, opts)
+  return runCommand(pnpmCommand, args, opts)
 }
 
 function capturePnpm (args) {
-  return captureCommand('pn', args)
+  return captureCommand(pnpmCommand, args)
 }
 
 function runCommand (command, args, opts = {}) {
   return new Promise((resolve, reject) => {
+    const shell = process.platform === 'win32'
+    if (shell) {
+      validateWindowsShellArgs([command, ...args])
+    }
     const child = spawn(command, args, {
       cwd: opts.cwd ?? rootDir,
       env: opts.env ?? process.env,
-      shell: process.platform === 'win32',
+      shell,
       stdio: 'inherit',
     })
     child.on('error', reject)
@@ -325,9 +361,13 @@ function runCommand (command, args, opts = {}) {
 function captureCommand (command, args) {
   return new Promise((resolve, reject) => {
     let stdout = ''
+    const shell = process.platform === 'win32'
+    if (shell) {
+      validateWindowsShellArgs([command, ...args])
+    }
     const child = spawn(command, args, {
       cwd: rootDir,
-      shell: process.platform === 'win32',
+      shell,
       stdio: ['ignore', 'pipe', 'inherit'],
     })
     child.stdout.setEncoding('utf8')
@@ -345,6 +385,27 @@ function captureCommand (command, args) {
       }
     })
   })
+}
+
+function resolveCommand (command) {
+  const result = process.platform === 'win32'
+    ? spawnSync('where', [command], { encoding: 'utf8' })
+    : spawnSync('sh', ['-c', `command -v ${command}`], { encoding: 'utf8' })
+  if (result.error != null) {
+    throw result.error
+  }
+  if (result.status !== 0) {
+    throw new Error(`Cannot resolve command: ${command}`)
+  }
+  return result.stdout.split(/\r?\n/).find(Boolean) ?? command
+}
+
+function validateWindowsShellArgs (args) {
+  for (const arg of args) {
+    if (/[&|<>^%\r\n]/.test(arg)) {
+      throw new Error(`Cannot run command with Windows shell metacharacters: ${arg}`)
+    }
+  }
 }
 
 function normalizePath (file) {

--- a/.github/scripts/run-ts-tests-chunk.mjs
+++ b/.github/scripts/run-ts-tests-chunk.mjs
@@ -335,14 +335,11 @@ function capturePnpm (args) {
 
 function runCommand (command, args, opts = {}) {
   return new Promise((resolve, reject) => {
-    const shell = process.platform === 'win32'
-    if (shell) {
-      validateWindowsShellArgs([command, ...args])
-    }
-    const child = spawn(command, args, {
+    const spawnTarget = resolveSpawnTarget(command, args)
+    const child = spawn(spawnTarget.command, spawnTarget.args, {
       cwd: opts.cwd ?? rootDir,
       env: opts.env ?? process.env,
-      shell,
+      shell: spawnTarget.shell,
       stdio: 'inherit',
     })
     child.on('error', reject)
@@ -361,13 +358,10 @@ function runCommand (command, args, opts = {}) {
 function captureCommand (command, args) {
   return new Promise((resolve, reject) => {
     let stdout = ''
-    const shell = process.platform === 'win32'
-    if (shell) {
-      validateWindowsShellArgs([command, ...args])
-    }
-    const child = spawn(command, args, {
+    const spawnTarget = resolveSpawnTarget(command, args)
+    const child = spawn(spawnTarget.command, spawnTarget.args, {
       cwd: rootDir,
-      shell,
+      shell: spawnTarget.shell,
       stdio: ['ignore', 'pipe', 'inherit'],
     })
     child.stdout.setEncoding('utf8')
@@ -400,9 +394,33 @@ function resolveCommand (command) {
   return result.stdout.split(/\r?\n/).find(Boolean) ?? command
 }
 
+// On Windows the command (e.g. `pn`) resolves to a `.cmd` shim, which Node
+// refuses to spawn without a shell (CVE-2024-27980). But `spawn(cmd, args,
+// { shell: true })` joins the args into one string without quoting, so an arg
+// containing a space would be split into separate tokens. Build the quoted
+// command line ourselves and hand it to cmd.exe as a single string — the same
+// thing Node does internally for the non-shell Windows path.
+function resolveSpawnTarget (command, args) {
+  if (process.platform !== 'win32') {
+    return { command, args, shell: false }
+  }
+  validateWindowsShellArgs([command, ...args])
+  return {
+    command: [command, ...args].map(quoteWindowsArg).join(' '),
+    args: undefined,
+    shell: true,
+  }
+}
+
+function quoteWindowsArg (arg) {
+  return arg === '' || /\s/.test(arg) ? `"${arg}"` : arg
+}
+
 function validateWindowsShellArgs (args) {
   for (const arg of args) {
-    if (/[&|<>^%\r\n]/.test(arg)) {
+    // `"` is rejected alongside the shell metacharacters so quoteWindowsArg can
+    // wrap spaced args in double quotes without needing to escape inner quotes.
+    if (/[&|<>^%"\r\n]/.test(arg)) {
       throw new Error(`Cannot run command with Windows shell metacharacters: ${arg}`)
     }
   }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,8 @@ jobs:
       with:
         name: pnpr-bins-${{ runner.os }}
         path: .pnpr-bin
+        # `.pnpr-bin` is a dotfile dir, which upload-artifact skips by default.
+        include-hidden-files: true
         if-no-files-found: error
         retention-days: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,24 @@ jobs:
             platform_label: ubuntu
             test_chunk: '1'
             test_chunk_total: '1'
+    uses: ./.github/workflows/test.yml
+    with:
+      node: ${{ matrix.node }}
+      node_major: ${{ matrix.node_major }}
+      platform: ${{ matrix.platform }}
+      test_chunk: ${{ matrix.test_chunk }}
+      test_chunk_total: ${{ matrix.test_chunk_total }}
+
+  # Windows is the slowest platform. Gate it only on compile-and-lint so its
+  # shards run in parallel with the ubuntu smoke job, instead of waiting for
+  # the smoke job like the other Node.js versions do.
+  test-windows:
+    name: TS CI / Test / ${{ matrix.platform_label }}
+    needs: compile-and-lint
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - node: '22.13.0'
             node_major: '22'
             platform: windows-latest
@@ -147,6 +165,7 @@ jobs:
       - compile-and-lint
       - test-smoke
       - test
+      - test-windows
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any dependency failed or was cancelled

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
               - 'cspell.json'
               - '.github/workflows/ci.yml'
               - '.github/workflows/test.yml'
+              - '.github/scripts/**'
 
   compile-and-lint:
     needs: changes
@@ -91,33 +92,44 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['22.13.0', '24.0.0', '26.3.1']
-        platform: [ubuntu-latest, windows-latest]
         include:
           - node: '22.13.0'
             node_major: '22'
-          - node: '24.0.0'
-            node_major: '24'
+            platform: ubuntu-latest
+            platform_label: ubuntu
+            test_chunk: '1'
+            test_chunk_total: '1'
           - node: '26.3.1'
             node_major: '26'
-          - platform: ubuntu-latest
-            platform_label: ubuntu
-          - platform: windows-latest
-            platform_label: windows
-        exclude:
-          - node: '24.0.0'
             platform: ubuntu-latest
-          # On branches, only run Windows with the lowest supported Node.js.
-          # Exception: main and release branches (release/x, release/x.x) run the full matrix.
-          - node: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 'none' || '24.0.0' }}
+            platform_label: ubuntu
+            test_chunk: '1'
+            test_chunk_total: '1'
+          - node: '22.13.0'
+            node_major: '22'
             platform: windows-latest
-          - node: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 'none' || '26.3.1' }}
+            platform_label: windows 1/3
+            test_chunk: '1'
+            test_chunk_total: '3'
+          - node: '22.13.0'
+            node_major: '22'
             platform: windows-latest
+            platform_label: windows 2/3
+            test_chunk: '2'
+            test_chunk_total: '3'
+          - node: '22.13.0'
+            node_major: '22'
+            platform: windows-latest
+            platform_label: windows 3/3
+            test_chunk: '3'
+            test_chunk_total: '3'
     uses: ./.github/workflows/test.yml
     with:
       node: ${{ matrix.node }}
       node_major: ${{ matrix.node_major }}
       platform: ${{ matrix.platform }}
+      test_chunk: ${{ matrix.test_chunk }}
+      test_chunk_total: ${{ matrix.test_chunk_total }}
 
   # Single aggregate gate — the only TS CI context branch protection needs
   # to require. Listing the individual jobs as required checks does not

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,75 @@ jobs:
         path: compiled.tar.gz
         retention-days: 1
 
+  # Build the pnpr server and registry fixture preparer once per OS, then
+  # share the binaries with every test job/shard as an artifact. Building
+  # inside each test job instead rebuilt pnpr once per shard, because the
+  # parallel shards all miss the build cache at job start.
+  build-pnpr:
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.ts == 'true' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository || github.head_ref == 'chore/update-lockfile') }}
+    name: TS CI / Build pnpr / ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Free up runner disk space
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        df -h /
+    - name: Checkout Commit
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+    # The binaries are cached and keyed on the Rust sources that produce them,
+    # so a run that only touches TypeScript restores them in seconds instead of
+    # recompiling. They are copied out of `target/` into a stable dir so
+    # `Swatinem/rust-cache`'s `target/` cleanup can't strip them before the
+    # cache saves.
+    - name: Restore prebuilt pnpr binaries
+      id: pnpr-bins
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: .pnpr-bin
+        key: pnpr-bins-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml', '**/Cargo.lock', '**/Cargo.toml', 'pnpr/**/*.rs', 'pacquet/**/*.rs') }}
+    - name: Install Rust
+      if: steps.pnpr-bins.outputs.cache-hit != 'true'
+      uses: ./.github/actions/rustup
+      with:
+        save-cache: ${{ github.ref_name == 'main' }}
+        shared-key: registry-prepare
+    - name: Build the pnpr server and registry fixture preparer
+      if: steps.pnpr-bins.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cargo build --locked --release -p pnpr --bin pnpr -p pnpr-fixtures --bin pnpr-prepare
+        mkdir -p .pnpr-bin
+        ext=""
+        [ -f target/release/pnpr.exe ] && ext=".exe"
+        cp "target/release/pnpr$ext" "target/release/pnpr-prepare$ext" .pnpr-bin/
+    # Save the binaries to the cache right after they build, not in a post-job
+    # step: a later step failing would otherwise skip the save and force a full
+    # Rust rebuild on the next run.
+    - name: Save prebuilt pnpr binaries
+      if: steps.pnpr-bins.outputs.cache-hit != 'true'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: .pnpr-bin
+        key: ${{ steps.pnpr-bins.outputs.cache-primary-key }}
+    - name: Upload pnpr binaries
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: pnpr-bins-${{ runner.os }}
+        path: .pnpr-bin
+        if-no-files-found: error
+        retention-days: 1
+
   test-smoke:
     name: TS CI / Test / ubuntu
-    needs: compile-and-lint
+    needs: [compile-and-lint, build-pnpr]
     uses: ./.github/workflows/test.yml
     with:
       node: '24.0.0'
@@ -118,7 +184,7 @@ jobs:
   # the smoke job like the other Node.js versions do.
   test-windows:
     name: TS CI / Test / ${{ matrix.platform_label }}
-    needs: compile-and-lint
+    needs: [compile-and-lint, build-pnpr]
     strategy:
       fail-fast: false
       matrix:
@@ -163,6 +229,7 @@ jobs:
     needs:
       - changes
       - compile-and-lint
+      - build-pnpr
       - test-smoke
       - test
       - test-windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,14 @@ on:
         required: false
         type: boolean
         default: false
+      test_chunk:
+        required: false
+        type: string
+        default: '1'
+      test_chunk_total:
+        required: false
+        type: string
+        default: '1'
     secrets:
       GARNET_API_TOKEN:
         required: false
@@ -25,9 +33,9 @@ permissions:
 
 jobs:
   test:
-    name: Node ${{ inputs.node_major }}
+    name: Node ${{ inputs.node_major }} / chunk ${{ inputs.test_chunk }}/${{ inputs.test_chunk_total }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.platform }}-${{ inputs.node }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.platform }}-${{ inputs.node }}-${{ inputs.test_chunk }}-${{ inputs.test_chunk_total }}
       cancel-in-progress: true
 
     runs-on: ${{ inputs.platform }}
@@ -173,26 +181,55 @@ jobs:
         BENCHMARK: ${{ steps.test-scope.outputs.benchmark }}
         PNPM_WORKERS: 3
         TEST_SCRIPT: ${{ steps.test-scope.outputs.script }}
+        TEST_CHUNK: ${{ inputs.test_chunk }}
+        TEST_CHUNK_TOTAL: ${{ inputs.test_chunk_total }}
       run: |
+        benchmark="$BENCHMARK"
+        command=(pn run "$TEST_SCRIPT")
+        if [ "$TEST_CHUNK_TOTAL" != "1" ]; then
+          benchmark="${BENCHMARK}.chunk${TEST_CHUNK}"
+          command=(
+            node .github/scripts/run-ts-tests-chunk.mjs
+            --script "$TEST_SCRIPT"
+            --chunk "$TEST_CHUNK"
+            --chunks "$TEST_CHUNK_TOTAL"
+          )
+        fi
         node .github/scripts/measure-command.mjs \
-          --name "$BENCHMARK" \
-          --output ".bench/${BENCHMARK}.json" \
-          -- pn run "$TEST_SCRIPT"
+          --name "$benchmark" \
+          --output ".bench/${benchmark}.json" \
+          -- "${command[@]}"
     - name: Extract pnpm CLI e2e test duration
       if: steps.test-scope.outputs.full_tests == 'true'
       shell: bash
+      env:
+        TEST_CHUNK: ${{ inputs.test_chunk }}
+        TEST_CHUNK_TOTAL: ${{ inputs.test_chunk_total }}
       run: |
+        benchmark=tests.cli
+        if [ "$TEST_CHUNK_TOTAL" != "1" ]; then
+          benchmark="${benchmark}.chunk${TEST_CHUNK}"
+        fi
         node .github/scripts/bencher-result-from-pnpm-summary.mjs \
-          --name tests.cli \
-          --output .bench/tests.cli.json \
+          --name "$benchmark" \
+          --output ".bench/${benchmark}.json" \
           --package-dir pnpm11/pnpm
     - name: Stage Bencher test durations
       if: steps.test-scope.outputs.full_tests == 'true'
       env:
+        BENCHMARK: ${{ steps.test-scope.outputs.benchmark }}
         NODE_VERSION: ${{ inputs.node }}
         PLATFORM: ${{ inputs.platform }}
+        TEST_CHUNK: ${{ inputs.test_chunk }}
+        TEST_CHUNK_TOTAL: ${{ inputs.test_chunk_total }}
       shell: bash
       run: |
+        benchmark="$BENCHMARK"
+        cli_benchmark=tests.cli
+        if [ "$TEST_CHUNK_TOTAL" != "1" ]; then
+          benchmark="${BENCHMARK}.chunk${TEST_CHUNK}"
+          cli_benchmark="${cli_benchmark}.chunk${TEST_CHUNK}"
+        fi
         platform_slug=${PLATFORM%-latest}
         node_major=${NODE_VERSION%%.*}
         case "$platform_slug" in
@@ -211,22 +248,30 @@ jobs:
         esac
         artifact_dir=.bench/artifact/pnpm
         mkdir -p "$artifact_dir"
+        files=(".bench/${benchmark}.json")
+        if [ -f ".bench/${cli_benchmark}.json" ]; then
+          files+=(".bench/${cli_benchmark}.json")
+        fi
 
         node .github/scripts/merge-bencher-results.mjs \
           --output "$artifact_dir/results.json" \
-          -- .bench/tests.all.json .bench/tests.cli.json
+          -- "${files[@]}"
 
         cat > "$artifact_dir/metadata.json" <<EOF
         {
           "kind": "pnpm",
-          "testbed": "pnpm.${platform_slug}.node${node_major}"
+          "testbed": "pnpm.${platform_slug}.node${node_major}",
+          "chunk": {
+            "index": ${TEST_CHUNK},
+            "total": ${TEST_CHUNK_TOTAL}
+          }
         }
         EOF
     - name: Upload Bencher test duration artifact
       if: steps.test-scope.outputs.full_tests == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: ci-performance-pnpm-${{ inputs.platform }}-node-${{ inputs.node }}
+        name: ci-performance-pnpm-${{ inputs.platform }}-node-${{ inputs.node }}-chunk-${{ inputs.test_chunk }}-of-${{ inputs.test_chunk_total }}
         path: .bench/artifact/pnpm/
         if-no-files-found: error
         retention-days: 14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,6 +174,28 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
         fi
+    - name: Validate test chunk inputs
+      shell: bash
+      env:
+        TEST_CHUNK: ${{ inputs.test_chunk }}
+        TEST_CHUNK_TOTAL: ${{ inputs.test_chunk_total }}
+      run: |
+        case "$TEST_CHUNK" in
+          ''|*[!0-9]*)
+            echo "::error::test_chunk must be a positive integer"
+            exit 1
+            ;;
+        esac
+        case "$TEST_CHUNK_TOTAL" in
+          ''|*[!0-9]*)
+            echo "::error::test_chunk_total must be a positive integer"
+            exit 1
+            ;;
+        esac
+        if (( TEST_CHUNK < 1 || TEST_CHUNK_TOTAL < 1 || TEST_CHUNK > TEST_CHUNK_TOTAL )); then
+          echo "::error::test_chunk must be between 1 and test_chunk_total"
+          exit 1
+        fi
     - name: Run tests (${{ steps.test-scope.outputs.scope }})
       timeout-minutes: 70
       shell: bash
@@ -207,13 +229,21 @@ jobs:
         TEST_CHUNK_TOTAL: ${{ inputs.test_chunk_total }}
       run: |
         benchmark=tests.cli
+        args=(
+          --name "$benchmark"
+          --output ".bench/${benchmark}.json"
+          --package-dir pnpm11/pnpm
+        )
         if [ "$TEST_CHUNK_TOTAL" != "1" ]; then
           benchmark="${benchmark}.chunk${TEST_CHUNK}"
+          args=(
+            --name "$benchmark"
+            --output ".bench/${benchmark}.json"
+            --package-dir pnpm11/pnpm
+            --allow-missing
+          )
         fi
-        node .github/scripts/bencher-result-from-pnpm-summary.mjs \
-          --name "$benchmark" \
-          --output ".bench/${benchmark}.json" \
-          --package-dir pnpm11/pnpm
+        node .github/scripts/bencher-result-from-pnpm-summary.mjs "${args[@]}"
     - name: Stage Bencher test durations
       if: steps.test-scope.outputs.full_tests == 'true'
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,10 @@ jobs:
     runs-on: ${{ inputs.platform }}
 
     steps:
-    # A near-full "affected packages" sweep plus the pnpr Rust build
-    # can exhaust the hosted runner's free disk mid-test (the runner
-    # worker itself dies with "No space left on device"). Drop the
-    # preinstalled toolchains this job never uses (~25 GB) first.
+    # A near-full "affected packages" sweep can exhaust the hosted runner's
+    # free disk mid-test (the runner worker itself dies with "No space left
+    # on device"). Drop the preinstalled toolchains this job never uses
+    # (~25 GB) first.
     - name: Free up runner disk space
       if: ${{ runner.os == 'Linux' }}
       run: |
@@ -94,53 +94,25 @@ jobs:
         name: compiled-packages
     - name: Extract compiled artifacts
       run: tar -xzf compiled.tar.gz
-    # The test harness serves package fixtures through the in-repo
-    # `pnpr` server; `pnpr-prepare` turns the raw fixtures under
-    # `pnpr/.fixtures/packages` into the storage the server reads. Both
-    # are built from source so the tests exercise the current server
-    # (e.g. the install-accelerator endpoints) rather than a published
-    # `@pnpm/pnpr` binary that may predate it.
-    #
-    # The built binaries are cached and keyed on the Rust sources that
-    # produce them, so a run that only touches TypeScript restores them
-    # in seconds instead of recompiling. They are copied out of `target/`
-    # into a stable dir so `Swatinem/rust-cache`'s `target/` cleanup
-    # can't strip them before this cache saves.
-    - name: Restore prebuilt pnpr binaries
-      id: pnpr-bins
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    # The test harness serves package fixtures through the in-repo `pnpr`
+    # server; `pnpr-prepare` turns the raw fixtures under
+    # `pnpr/.fixtures/packages` into the storage the server reads. Both are
+    # built from source (so the tests exercise the current server, not a
+    # published `@pnpm/pnpr` that may predate it) once per OS by the
+    # `build-pnpr` job, then shared with every test job/shard here as an
+    # artifact instead of rebuilt per job.
+    - name: Download prebuilt pnpr binaries
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
+        name: pnpr-bins-${{ runner.os }}
         path: .pnpr-bin
-        key: pnpr-bins-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml', '**/Cargo.lock', '**/Cargo.toml', 'pnpr/**/*.rs', 'pacquet/**/*.rs') }}
-    - name: Install Rust
-      if: steps.pnpr-bins.outputs.cache-hit != 'true'
-      uses: ./.github/actions/rustup
-      with:
-        save-cache: ${{ github.ref_name == 'main' }}
-        shared-key: registry-prepare
-    - name: Build the pnpr server and registry fixture preparer
-      if: steps.pnpr-bins.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        cargo build --locked --release -p pnpr --bin pnpr -p pnpr-fixtures --bin pnpr-prepare
-        mkdir -p .pnpr-bin
-        ext=""
-        [ -f target/release/pnpr.exe ] && ext=".exe"
-        cp "target/release/pnpr$ext" "target/release/pnpr-prepare$ext" .pnpr-bin/
-    # Save the binaries to the cache right after they build, not in a post-job
-    # step: a later step failing (e.g. a crashing test) would otherwise skip
-    # the save and force a full Rust rebuild on the next run.
-    - name: Save prebuilt pnpr binaries
-      if: steps.pnpr-bins.outputs.cache-hit != 'true'
-      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: .pnpr-bin
-        key: ${{ steps.pnpr-bins.outputs.cache-primary-key }}
     - name: Export pnpr binary paths
       shell: bash
       run: |
         ext=""
         [ -f "$PWD/.pnpr-bin/pnpr.exe" ] && ext=".exe"
+        # Artifacts don't preserve the executable bit; restore it on POSIX.
+        [ -z "$ext" ] && chmod +x "$PWD/.pnpr-bin/pnpr" "$PWD/.pnpr-bin/pnpr-prepare"
         echo "PNPR_BIN=$PWD/.pnpr-bin/pnpr$ext" >> "$GITHUB_ENV"
         echo "PNPR_PREPARE_BIN=$PWD/.pnpr-bin/pnpr-prepare$ext" >> "$GITHUB_ENV"
     - name: Determine test scope

--- a/pnpm11/installing/deps-installer/test/fixtures/dep-of-pkg-with-1-dep.json
+++ b/pnpm11/installing/deps-installer/test/fixtures/dep-of-pkg-with-1-dep.json
@@ -11,7 +11,7 @@
       "dist": {
         "integrity": "sha512-KUmwlEiE3pzpmPCfrLkoOO7fmL4Tft+dcm6YQlUfOUJvHO73xlcKVoA/xOHP/ayUO8GiPlIqWRbKHrsxvXGE8g==",
         "shasum": "a95f834b4a4d9661623a0cf2bd76acbc213192fc",
-        "tarball": "http://localhost:7769/@pnpm.e2e/dep-of-pkg-with-1-dep/-/@pnpm.e2e/dep-of-pkg-with-1-dep-100.0.0.tgz"
+        "tarball": "http://localhost/@pnpm.e2e/dep-of-pkg-with-1-dep/-/@pnpm.e2e/dep-of-pkg-with-1-dep-100.0.0.tgz"
       },
       "contributors": []
     },
@@ -25,7 +25,7 @@
       "dist": {
         "integrity": "sha512-CAF68U5SjOQOT2dubJxAxauvQwm0G2IWS+Si7xP6Za79ZAt2VmCG5LMoSfv7GkbKk0RvSm/EMpT4BQVGy1yCpg==",
         "shasum": "7647e89d79edff3ea46b0b04e390e2c820995be6",
-        "tarball": "http://localhost:7769/@pnpm.e2e/dep-of-pkg-with-1-dep/-/@pnpm.e2e/dep-of-pkg-with-1-dep-100.1.0.tgz"
+        "tarball": "http://localhost/@pnpm.e2e/dep-of-pkg-with-1-dep/-/@pnpm.e2e/dep-of-pkg-with-1-dep-100.1.0.tgz"
       },
       "contributors": []
     },
@@ -39,7 +39,7 @@
       "dist": {
         "integrity": "sha512-v/FQPTv+Y6j/J5a7ymlifFIhJa28wROyiTfg1vcAVKdJ9S94E32CHVUbzgvdcu9pAkLqe7INiwJ2ynqmgiTiiw==",
         "shasum": "0cd58112bc509221dc3dfd97736a1feae3872b69",
-        "tarball": "http://localhost:7769/@pnpm.e2e/dep-of-pkg-with-1-dep/-/@pnpm.e2e/dep-of-pkg-with-1-dep-101.0.0.tgz"
+        "tarball": "http://localhost/@pnpm.e2e/dep-of-pkg-with-1-dep/-/@pnpm.e2e/dep-of-pkg-with-1-dep-101.0.0.tgz"
       },
       "contributors": []
     }

--- a/pnpm11/installing/deps-installer/test/fixtures/pkg-with-1-dep.json
+++ b/pnpm11/installing/deps-installer/test/fixtures/pkg-with-1-dep.json
@@ -14,7 +14,7 @@
       "dist": {
         "integrity": "sha512-IGrkh3wu1jOzTFzi/S+XOkuhEwhV03qRaH7tcwPoPJ+AQo2cAuhgOBwczq2y8DPfob+BlzSmZXjEvEqoXKio7A==",
         "shasum": "b78a05932d20b071b84d42b6964621a197118870",
-        "tarball": "http://localhost:7769/@pnpm.e2e/pkg-with-1-dep/-/@pnpm.e2e/pkg-with-1-dep-100.0.0.tgz"
+        "tarball": "http://localhost/@pnpm.e2e/pkg-with-1-dep/-/@pnpm.e2e/pkg-with-1-dep-100.0.0.tgz"
       },
       "contributors": []
     },
@@ -31,7 +31,7 @@
       "dist": {
         "integrity": "sha512-fdlqYHFD2EY3e1Lf2x2V3gVJdNkybtPiQ8DLUZCJjxyMl0oxymB0EQSHqSjvBYoDss7Jj9eGLx9+utpOuXRX7A==",
         "shasum": "2d2293b5595718890bd322da51359ec25334b85e",
-        "tarball": "http://localhost:7769/@pnpm.e2e/pkg-with-1-dep/-/@pnpm.e2e/pkg-with-1-dep-100.1.0.tgz"
+        "tarball": "http://localhost/@pnpm.e2e/pkg-with-1-dep/-/@pnpm.e2e/pkg-with-1-dep-100.1.0.tgz"
       },
       "contributors": []
     }

--- a/pnpm11/installing/deps-installer/test/install/errors.ts
+++ b/pnpm11/installing/deps-installer/test/install/errors.ts
@@ -14,6 +14,23 @@ import { testDefaults } from '../utils/index.js'
 
 const f = fixtures(import.meta.dirname)
 
+interface PackumentFixture {
+  versions: Record<string, { dist: { tarball: string } }>
+}
+
+// The committed packument fixtures carry tarball URLs whose origin is just a
+// placeholder. Rebuild each one against the live registry mock port so the
+// mock agent (which intercepts `http://localhost:${REGISTRY_MOCK_PORT}`) sees
+// the tarball request — this is what lets the test run on any port instead of
+// pinning PNPM_REGISTRY_MOCK_PORT to match a baked-in value.
+function loadPackument (fixtureName: string): PackumentFixture {
+  const packument = loadJsonFileSync<PackumentFixture>(f.find(fixtureName))
+  for (const version of Object.values(packument.versions)) {
+    version.dist.tarball = `http://localhost:${REGISTRY_MOCK_PORT}${new URL(version.dist.tarball).pathname}`
+  }
+  return packument
+}
+
 test('fail if none of the available resolvers support a version spec', async () => {
   prepareEmpty()
 
@@ -49,12 +66,10 @@ test('fail if a package cannot be fetched', async () => {
   prepareEmpty()
   await setupMockAgent()
   const mockPool = getMockAgent().get(`http://localhost:${REGISTRY_MOCK_PORT}`)
-  /* eslint-disable @typescript-eslint/no-explicit-any */
   mockPool.intercept({ path: '/@pnpm.e2e%2Fpkg-with-1-dep', method: 'GET' }) // cspell:disable-line
-    .reply(200, loadJsonFileSync<any>(f.find('pkg-with-1-dep.json')))
+    .reply(200, loadPackument('pkg-with-1-dep.json'))
   mockPool.intercept({ path: '/@pnpm.e2e%2Fdep-of-pkg-with-1-dep', method: 'GET' }) // cspell:disable-line
-    .reply(200, loadJsonFileSync<any>(f.find('dep-of-pkg-with-1-dep.json')))
-  /* eslint-enable @typescript-eslint/no-explicit-any */
+    .reply(200, loadPackument('dep-of-pkg-with-1-dep.json'))
   const tarballContent = fs.readFileSync(f.find('pkg-with-1-dep-100.0.0.tgz'))
   mockPool.intercept({ path: '/@pnpm.e2e/pkg-with-1-dep/-/@pnpm.e2e/pkg-with-1-dep-100.0.0.tgz', method: 'GET' })
     .reply(200, tarballContent, { headers: { 'content-length': String(tarballContent.length) } })


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

- Run Windows TS CI only on Node.js 22 and split it into three parallel test chunks.
- Add a CI helper that shards Jest test files while preserving package setup and pnpm execution summaries.
- Keep Bencher performance data for each Windows chunk with chunk-specific benchmark names under the existing `pnpm.windows.node22` testbed.
- CI-only change; no pnpm CLI behavior or pacquet porting is needed.

## Squash Commit Body

```text
Run Windows TypeScript test jobs only on Node.js 22 and split them into three parallel chunks.

Windows TS tests are significantly slower than Linux, and running the full suite on three Node versions spends the extra capacity on duplicate runtime coverage instead of reducing wall clock time. The reusable test workflow now accepts chunk inputs, includes chunk identity in concurrency and artifact names, and keeps Bencher uploads with chunk-specific benchmark names.

Add a CI helper that discovers the selected workspace packages for the same full or affected test scope, shards Jest test files into balanced chunks, runs selected package files with the same Jest Node options and package pretest setup, and writes pnpm-style execution summaries so the pnpm CLI e2e duration extraction still works.
```

## Checklist

- [x] CI-only change; no TypeScript CLI behavior or Rust pacquet porting is needed.
- [x] Updated the TS CI test workflow and validated chunk selection.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic, chunked TypeScript test execution in CI, including chunk-aware Jest scheduling and chunk-specific benchmark outputs/metadata.
* **Chores**
  * Updated CI change detection to treat modifications under the CI scripts area as TypeScript-relevant.
  * Extended the reusable test workflow to accept `test_chunk`/`test_chunk_total`, run the appropriate chunk commands, and merge chunk results.
* **Bug Fixes**
  * Improved benchmark result parsing to optionally tolerate missing entries when extracting chunked CLI e2e durations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->