### PR TITLE
ci: fix release workflow body generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,22 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           pn config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}"
-          pn publish --filter=!pnpm --filter=!@pnpm/exe --access=public --provenance
+          publish_filters=(
+            "--filter=!pnpm"
+            "--filter=!@pnpm/exe"
+          )
+          if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
+            publish_filters+=(
+              "--filter=!@pnpm/macos-arm64"
+              "--filter=!@pnpm/linux-arm64"
+              "--filter=!@pnpm/linux-x64"
+              "--filter=!@pnpm/linuxstatic-arm64"
+              "--filter=!@pnpm/linuxstatic-x64"
+              "--filter=!@pnpm/win-arm64"
+              "--filter=!@pnpm/win-x64"
+            )
+          fi
+          pn publish "${publish_filters[@]}" --access=public --provenance
           pn config delete "//registry.npmjs.org/:_authToken"
       - name: Publish pnpm CLI (trusted publishing)
         # No NPM_TOKEN — same rationale as the @pnpm/exe step above. This must come after

--- a/pnpm11/__utils__/get-release-text/src/main.ts
+++ b/pnpm11/__utils__/get-release-text/src/main.ts
@@ -16,11 +16,12 @@ export const BumpLevels = {
 } as const
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
-const pnpmDir = path.join(dirname, '../../../pnpm')
+const repoRoot = path.resolve(dirname, '../../../..')
+const pnpmDir = path.join(repoRoot, 'pnpm11/pnpm')
 const changelog = fs.readFileSync(path.join(pnpmDir, 'CHANGELOG.md'), 'utf8')
 const pnpm = JSON.parse(fs.readFileSync(path.join(pnpmDir, 'package.json'), 'utf8'))
 const release = getChangelogEntry(changelog, pnpm.version)
-fs.writeFileSync(path.join(dirname, '../../../RELEASE.md'), release.content)
+fs.writeFileSync(path.join(repoRoot, 'RELEASE.md'), release.content)
 
 interface ChangelogEntry {
   content: string


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Fix the release workflow paths and filters that broke the pnpm v11.9.0 release draft:

- `@pnpm/get-release-text` now writes `RELEASE.md` at the repository root, matching `softprops/action-gh-release`'s `body_path: RELEASE.md`.
- Branch-dispatched release runs now exclude the platform artifact packages, because their binaries are only built on tag refs. Tag runs still publish those artifact packages.

Related failures:

- `workflow_dispatch` from `main` failed while publishing `@pnpm/macos-arm64`, because the artifact build step was skipped.
- `workflow_dispatch` from `v11.9.0` generated the release draft, but `softprops/action-gh-release` could not read root `RELEASE.md` and created the draft with an empty body.

## Squash Commit Body

```text
The release description generator was writing RELEASE.md under pnpm11/, but release.yml passed body_path: RELEASE.md to softprops/action-gh-release, which resolves relative to the repository root. That made the action fall back to an empty body and create a draft release without release notes.

The release workflow also used the same static-token publish filter on branch dispatches and tag refs. Branch-dispatched lib-only releases skip the artifact build step, so they must not select the platform artifact packages whose prepublish gates require the generated binaries.
```

## Checklist

- [x] TypeScript CLI and pacquet parity are not applicable; this is release workflow/private tooling only.
- [x] Changeset is not needed; this does not change published package behavior.
- [x] Verified with `pn --filter=@pnpm/get-release-text run lint`, `pn make-release-description`, `git diff --check`, branch/tag shell checks for the publish filters, and the repository pre-push hook.
- [x] Documentation is not needed.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to dynamically filter packages based on release type.
  * Updated build scripts for improved file path handling during release generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->