### PR TITLE
fix: show available workspace versions on version mismatch

### DIFF
--- a/.changeset/workspace-version-mismatch-hint.md
+++ b/.changeset/workspace-version-mismatch-hint.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"pnpm": patch
+---
+
+When a dependency cannot be found in the registry (404) or the registry has no matching version, and a workspace project with the same name exists only at non-matching versions, the error now reports the available workspace versions (`ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE`) instead of the raw registry failure [pnpm/pnpm#1379](https://github.com/pnpm/pnpm/issues/1379). Other registry failures (authorization, network, server errors) still propagate unchanged. The pacquet (Rust) resolver applies the same behavior.

--- a/pacquet/crates/resolving-npm-resolver/src/errors.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/errors.rs
@@ -180,44 +180,5 @@ pub struct GuardRepickLimitError {
     pub reason: String,
 }
 
-/// Raised when a dependency resolution fails and a workspace package
-/// with the same name exists but no version satisfies the requested
-/// range. The `message` includes the list of available workspace
-/// versions. Mirrors pnpm's
-/// [`NO_MATCHING_VERSION_INSIDE_WORKSPACE`](https://github.com/pnpm/pnpm/blob/ef87f3ccff/resolving/npm-resolver/src/index.ts#L877-L885)
-/// error with an enhanced message for the non-`workspace:`-prefixed
-/// case (pnpm/pnpm#1379).
-#[derive(Debug, Display, Error, Diagnostic)]
-#[display("{message}")]
-#[diagnostic(code(pacquet_resolving_npm_resolver::no_matching_version_inside_workspace))]
-pub struct WorkspaceVersionMismatchError {
-    #[error(not(source))]
-    pub message: String,
-}
-
-/// Build a human-readable message listing available workspace versions
-/// for a package, or `None` if the package is not in the workspace.
-pub fn build_workspace_version_hint(
-    pkg_name: &str,
-    workspace_packages: &pacquet_resolving_resolver_base::WorkspacePackages,
-) -> Option<String> {
-    let by_version = workspace_packages.get(pkg_name)?;
-    let mut versions: Vec<String> = by_version.keys().cloned().collect();
-    // Sort in descending semver order so the highest version comes first.
-    versions.sort_by(|a, b| {
-        match (node_semver::Version::parse(a), node_semver::Version::parse(b)) {
-            (Ok(a), Ok(b)) => b.cmp(&a),
-            _ => b.cmp(a),
-        }
-    });
-    if versions.is_empty() {
-        return None;
-    }
-    Some(format!(
-        "Package \"{pkg_name}\" is not available in the registry but is present in the workspace with available version(s): {}",
-        versions.join(", "),
-    ))
-}
-
 #[cfg(test)]
 mod tests;

--- a/pacquet/crates/resolving-npm-resolver/src/errors.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/errors.rs
@@ -180,5 +180,44 @@ pub struct GuardRepickLimitError {
     pub reason: String,
 }
 
+/// Raised when a dependency resolution fails and a workspace package
+/// with the same name exists but no version satisfies the requested
+/// range. The `message` includes the list of available workspace
+/// versions. Mirrors pnpm's
+/// [`NO_MATCHING_VERSION_INSIDE_WORKSPACE`](https://github.com/pnpm/pnpm/blob/ef87f3ccff/resolving/npm-resolver/src/index.ts#L877-L885)
+/// error with an enhanced message for the non-`workspace:`-prefixed
+/// case (pnpm/pnpm#1379).
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display("{message}")]
+#[diagnostic(code(pacquet_resolving_npm_resolver::no_matching_version_inside_workspace))]
+pub struct WorkspaceVersionMismatchError {
+    #[error(not(source))]
+    pub message: String,
+}
+
+/// Build a human-readable message listing available workspace versions
+/// for a package, or `None` if the package is not in the workspace.
+pub fn build_workspace_version_hint(
+    pkg_name: &str,
+    workspace_packages: &pacquet_resolving_resolver_base::WorkspacePackages,
+) -> Option<String> {
+    let by_version = workspace_packages.get(pkg_name)?;
+    let mut versions: Vec<String> = by_version.keys().cloned().collect();
+    // Sort in descending semver order so the highest version comes first.
+    versions.sort_by(|a, b| {
+        match (node_semver::Version::parse(a), node_semver::Version::parse(b)) {
+            (Ok(a), Ok(b)) => b.cmp(&a),
+            _ => b.cmp(a),
+        }
+    });
+    if versions.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "Package \"{pkg_name}\" is not available in the registry but is present in the workspace with available version(s): {}",
+        versions.join(", "),
+    ))
+}
+
 #[cfg(test)]
 mod tests;

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -38,18 +38,15 @@ use pacquet_resolving_resolver_base::{
 };
 
 use crate::{
-    errors::{
-        AllVersionsBlockedError, GuardRepickLimitError, WorkspaceVersionMismatchError,
-        build_workspace_version_hint,
-    },
+    errors::{AllVersionsBlockedError, GuardRepickLimitError},
     named_registry::pick_registry_for_package,
     parse_bare_specifier::{parse_bare_specifier, parse_jsr_specifier_to_registry_package_spec},
     pick_package::{PackageMetaCache, PickPackageContext, PickPackageOptions, pick_package},
     pick_package_from_meta::{RegistryPackageSpec, RegistryPackageSpecType},
     resolve_from_workspace::{
-        ResolveFromWorkspaceOptions, pick_matching_local_version_or_null,
-        resolve_from_local_package, try_resolve_from_workspace,
-        try_resolve_from_workspace_packages,
+        ResolveFromWorkspaceError, ResolveFromWorkspaceOptions,
+        pick_matching_local_version_or_null, resolve_from_local_package,
+        try_resolve_from_workspace, try_resolve_from_workspace_packages,
     },
     trust_checks::{TrustCheckOptions, fail_if_trust_downgraded},
     violation_codes::MINIMUM_RELEASE_AGE_VIOLATION_CODE,
@@ -218,41 +215,38 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
         let picked = match pick_result {
             Ok(Some(picked)) => picked,
             Ok(None) => {
-                if let Some(workspace_packages) = workspace_packages_active
-                    && let Some(result) =
-                        try_workspace_fallback(workspace_packages, &spec, wanted_dependency, opts)
-                {
-                    return Ok(Some(result));
-                }
-                // The registry had no matching version and the workspace
-                // fallback also failed. If a workspace package with the
-                // same name exists, surface the available versions so the
-                // user knows which versions they can pick (pnpm/pnpm#1379).
-                if let Some(hint) = workspace_packages_active
-                    .and_then(|wp| build_workspace_version_hint(&spec.name, wp))
-                {
-                    return Err(Box::new(WorkspaceVersionMismatchError { message: hint }));
-                }
-                return Ok(None);
+                return match workspace_packages_active.map(|workspace_packages| {
+                    try_workspace_fallback(workspace_packages, &spec, wanted_dependency, opts)
+                }) {
+                    Some(Ok(result)) => Ok(Some(result)),
+                    // Neither the registry nor the workspace has a
+                    // matching version; the workspace mismatch error
+                    // carries the available local versions, which is the
+                    // actionable detail here (pnpm/pnpm#1379).
+                    Some(Err(
+                        ws_err @ ResolveFromWorkspaceError::NoMatchingVersionInsideWorkspace {
+                            ..
+                        },
+                    )) => Err(Box::new(ws_err)),
+                    _ => Ok(None),
+                };
             }
             Err(err) => {
-                if let Some(workspace_packages) = workspace_packages_active
-                    && let Some(result) =
-                        try_workspace_fallback(workspace_packages, &spec, wanted_dependency, opts)
-                {
-                    return Ok(Some(result));
-                }
-                // The registry fetch failed and the workspace fallback
-                // also failed. Only surface workspace version hints for
-                // 404 (not-found) errors — auth, network, or server
-                // errors should propagate as-is (pnpm/pnpm#1379).
-                if is_not_found_error(err.as_ref())
-                    && let Some(hint) = workspace_packages_active
-                        .and_then(|wp| build_workspace_version_hint(&spec.name, wp))
-                {
-                    return Err(Box::new(WorkspaceVersionMismatchError { message: hint }));
-                }
-                return Err(err);
+                return match workspace_packages_active.map(|workspace_packages| {
+                    try_workspace_fallback(workspace_packages, &spec, wanted_dependency, opts)
+                }) {
+                    Some(Ok(result)) => Ok(Some(result)),
+                    // Surface the workspace mismatch (with its available
+                    // versions) only when the registry said "not found";
+                    // auth, network, and server errors propagate as-is
+                    // (pnpm/pnpm#1379).
+                    Some(Err(
+                        ws_err @ ResolveFromWorkspaceError::NoMatchingVersionInsideWorkspace {
+                            ..
+                        },
+                    )) if is_not_found_error(err.as_ref()) => Err(Box::new(ws_err)),
+                    _ => Err(err),
+                };
             }
         };
 
@@ -419,17 +413,17 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
 
 /// Registry pick was unavailable (no matching version or fetch
 /// error); try the workspace as a fallback via
-/// [`try_resolve_from_workspace_packages`]. Workspace errors (missing
-/// name, no matching version) are swallowed — the caller re-raises the
-/// original registry error.
+/// [`try_resolve_from_workspace_packages`]. The caller decides which
+/// workspace errors to surface and which to swallow in favour of the
+/// original registry outcome.
 fn try_workspace_fallback(
     workspace_packages: &WorkspacePackages,
     spec: &RegistryPackageSpec,
     wanted_dependency: &WantedDependency,
     opts: &ResolveOptions,
-) -> Option<ResolveResult> {
+) -> Result<ResolveResult, ResolveFromWorkspaceError> {
     let ws_opts = workspace_fallback_options(opts);
-    try_resolve_from_workspace_packages(workspace_packages, spec, wanted_dependency, &ws_opts).ok()
+    try_resolve_from_workspace_packages(workspace_packages, spec, wanted_dependency, &ws_opts)
 }
 
 /// Registry pick succeeded; check whether a workspace package
@@ -794,17 +788,16 @@ fn detect_min_release_age_violation(
     })
 }
 
-/// Walk the error chain looking for a reqwest 404 status code.
+/// Whether any error in the source chain is a reqwest `404 Not Found`.
 fn is_not_found_error(err: &(dyn std::error::Error + 'static)) -> bool {
-    // Check the current error
-    if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>()
-        && reqwest_err.status() == Some(reqwest::StatusCode::NOT_FOUND)
-    {
-        return true;
-    }
-    // Walk the source chain
-    if let Some(source) = err.source() {
-        return is_not_found_error(source);
+    let mut current = Some(err);
+    while let Some(err) = current {
+        if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>()
+            && reqwest_err.status() == Some(reqwest::StatusCode::NOT_FOUND)
+        {
+            return true;
+        }
+        current = err.source();
     }
     false
 }

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -38,7 +38,10 @@ use pacquet_resolving_resolver_base::{
 };
 
 use crate::{
-    errors::{AllVersionsBlockedError, GuardRepickLimitError},
+    errors::{
+        AllVersionsBlockedError, GuardRepickLimitError, WorkspaceVersionMismatchError,
+        build_workspace_version_hint,
+    },
     named_registry::pick_registry_for_package,
     parse_bare_specifier::{parse_bare_specifier, parse_jsr_specifier_to_registry_package_spec},
     pick_package::{PackageMetaCache, PickPackageContext, PickPackageOptions, pick_package},
@@ -221,6 +224,15 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
                 {
                     return Ok(Some(result));
                 }
+                // The registry had no matching version and the workspace
+                // fallback also failed. If a workspace package with the
+                // same name exists, surface the available versions so the
+                // user knows which versions they can pick (pnpm/pnpm#1379).
+                if let Some(hint) = workspace_packages_active
+                    .and_then(|wp| build_workspace_version_hint(&spec.name, wp))
+                {
+                    return Err(Box::new(WorkspaceVersionMismatchError { message: hint }));
+                }
                 return Ok(None);
             }
             Err(err) => {
@@ -229,6 +241,16 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
                         try_workspace_fallback(workspace_packages, &spec, wanted_dependency, opts)
                 {
                     return Ok(Some(result));
+                }
+                // The registry fetch failed and the workspace fallback
+                // also failed. Only surface workspace version hints for
+                // 404 (not-found) errors — auth, network, or server
+                // errors should propagate as-is (pnpm/pnpm#1379).
+                if is_not_found_error(err.as_ref())
+                    && let Some(hint) = workspace_packages_active
+                        .and_then(|wp| build_workspace_version_hint(&spec.name, wp))
+                {
+                    return Err(Box::new(WorkspaceVersionMismatchError { message: hint }));
                 }
                 return Err(err);
             }
@@ -770,6 +792,21 @@ fn detect_min_release_age_violation(
             cutoff = cutoff.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
         ),
     })
+}
+
+/// Walk the error chain looking for a reqwest 404 status code.
+fn is_not_found_error(err: &(dyn std::error::Error + 'static)) -> bool {
+    // Check the current error
+    if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>()
+        && reqwest_err.status() == Some(reqwest::StatusCode::NOT_FOUND)
+    {
+        return true;
+    }
+    // Walk the source chain
+    if let Some(source) = err.source() {
+        return is_not_found_error(source);
+    }
+    false
 }
 
 #[cfg(test)]

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -1163,7 +1163,7 @@ async fn workspace_fallback_kicks_in_when_registry_lacks_requested_version() {
 }
 
 #[tokio::test]
-async fn registry_error_propagates_when_workspace_has_no_matching_version() {
+async fn workspace_version_hint_shown_when_registry_and_workspace_both_fail() {
     let mut server = mockito::Server::new_async().await;
     let _mock = server.mock("GET", "/acme").with_status(404).create_async().await;
     let registry = format!("{}/", server.url());
@@ -1180,8 +1180,16 @@ async fn registry_error_propagates_when_workspace_has_no_matching_version() {
     let err = resolver
         .resolve(&wanted, &opts)
         .await
-        .expect_err("workspace can't satisfy 2.0.0; original 404 error must surface");
-    assert!(err.to_string().contains("404"), "expected the 404 to propagate, got: {err}");
+        .expect_err("workspace can't satisfy 2.0.0; workspace version hint must surface");
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("1.0.0"),
+        "expected error to mention available workspace version 1.0.0, got: {err_msg}",
+    );
+    assert!(
+        err_msg.contains("available"),
+        "expected error to mention available versions, got: {err_msg}",
+    );
 }
 
 #[tokio::test]
@@ -1210,4 +1218,131 @@ async fn registry_pick_wins_when_workspace_version_does_not_match() {
     let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("registry pick");
     assert_eq!(result.resolved_via, "npm-registry");
     assert_eq!(result.id.as_str(), "acme@3.1.0");
+}
+
+/// When registry returns 404 and the workspace has a package with the
+/// same name at a different version, the error includes a helpful hint.
+#[tokio::test]
+async fn workspace_version_hint_shown_when_registry_404_and_workspace_version_mismatch() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server.mock("GET", "/acme").with_status(404).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    // Workspace has "acme" at 1.0.0, but we request 2.0.0 (404 on registry).
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let opts = workspace_resolve_options(packages);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^2.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let err = resolver
+        .resolve(&wanted, &opts)
+        .await
+        .expect_err("should fail since registry returns 404 and workspace version doesn't match");
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("1.0.0"),
+        "expected error to mention available workspace version 1.0.0, got: {err_msg}",
+    );
+    assert!(
+        err_msg.contains("available"),
+        "expected error to mention available versions, got: {err_msg}",
+    );
+}
+
+/// When registry returns 404 and the workspace does NOT have a
+/// package with the same name, the registry error propagates as-is
+/// without any workspace hint.
+#[tokio::test]
+async fn no_workspace_hint_when_package_not_in_workspace() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server.mock("GET", "/acme").with_status(404).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    // Workspace has "other-pkg" but not "acme".
+    let packages = build_workspace_packages("other-pkg", &["1.0.0"]);
+    let opts = workspace_resolve_options(packages);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let err = resolver
+        .resolve(&wanted, &opts)
+        .await
+        .expect_err("should fail since package not in workspace and registry 404s");
+    let err_msg = err.to_string();
+    assert!(
+        !err_msg.contains("available"),
+        "should NOT include workspace hint when package is not in workspace, got: {err_msg}",
+    );
+}
+
+/// Workspace fallback still works when the version matches.
+#[tokio::test]
+async fn workspace_fallback_succeeds_when_version_matches() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server.mock("GET", "/acme").with_status(404).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    // Workspace has "acme" at 1.0.0, and we request ^1.0.0 — matches.
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let opts = workspace_resolve_options(packages);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace fallback");
+    assert_eq!(result.resolved_via, "workspace");
+}
+
+/// Non-404 registry errors (500, auth) must NOT be masked by workspace
+/// version hints. Regression test for the `CodeRabbit` review on this pull request.
+#[tokio::test]
+async fn non_404_registry_error_not_masked_by_workspace_hint() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server.mock("GET", "/acme").with_status(500).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    // Workspace has "acme" at 1.0.0, but we request ^2.0.0 — no match
+    // AND the registry returns 500 (not 404).
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let opts = workspace_resolve_options(packages);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^2.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await;
+    // The resolve should either:
+    // - Return an Err (500 propagated), or
+    // - Return Ok(None) (no matching version found)
+    // But it must NOT return an Err containing the workspace hint text.
+    // Before the fix, a 500 + workspace package existing would incorrectly
+    // surface "available version(s)" hint even for non-404 errors.
+    match result {
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                !msg.contains("available version(s)"),
+                "Workspace hint should not appear for 500 errors, got: {msg}",
+            );
+        }
+        Ok(None) => {
+            // This is acceptable — the 500 produced no versions, not a workspace hint
+        }
+        Ok(Some(_)) => {
+            panic!("Should not resolve successfully from a 500 registry response");
+        }
+    }
 }

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -22,6 +22,7 @@ use crate::{
     pick_package::{
         InMemoryPackageMetaCache, shared_packument_fetch_locker, shared_picked_manifest_cache,
     },
+    resolve_from_workspace::ResolveFromWorkspaceError,
     violation_codes::MINIMUM_RELEASE_AGE_VIOLATION_CODE,
 };
 
@@ -1163,7 +1164,7 @@ async fn workspace_fallback_kicks_in_when_registry_lacks_requested_version() {
 }
 
 #[tokio::test]
-async fn workspace_version_hint_shown_when_registry_and_workspace_both_fail() {
+async fn workspace_version_mismatch_surfaces_for_exact_request_on_registry_404() {
     let mut server = mockito::Server::new_async().await;
     let _mock = server.mock("GET", "/acme").with_status(404).create_async().await;
     let registry = format!("{}/", server.url());
@@ -1180,15 +1181,22 @@ async fn workspace_version_hint_shown_when_registry_and_workspace_both_fail() {
     let err = resolver
         .resolve(&wanted, &opts)
         .await
-        .expect_err("workspace can't satisfy 2.0.0; workspace version hint must surface");
+        .expect_err("workspace can't satisfy 2.0.0; workspace version mismatch must surface");
+    assert!(
+        err.downcast_ref::<ResolveFromWorkspaceError>().is_some_and(|ws_err| matches!(
+            ws_err,
+            ResolveFromWorkspaceError::NoMatchingVersionInsideWorkspace { .. }
+        )),
+        "expected NoMatchingVersionInsideWorkspace, got: {err}",
+    );
     let err_msg = err.to_string();
     assert!(
-        err_msg.contains("1.0.0"),
-        "expected error to mention available workspace version 1.0.0, got: {err_msg}",
+        err_msg.contains("No matching version found for acme@2.0.0 inside the workspace"),
+        "expected the workspace mismatch message, got: {err_msg}",
     );
     assert!(
-        err_msg.contains("available"),
-        "expected error to mention available versions, got: {err_msg}",
+        err_msg.contains("Available versions: 1.0.0"),
+        "expected error to list available workspace versions, got: {err_msg}",
     );
 }
 
@@ -1220,16 +1228,13 @@ async fn registry_pick_wins_when_workspace_version_does_not_match() {
     assert_eq!(result.id.as_str(), "acme@3.1.0");
 }
 
-/// When registry returns 404 and the workspace has a package with the
-/// same name at a different version, the error includes a helpful hint.
 #[tokio::test]
-async fn workspace_version_hint_shown_when_registry_404_and_workspace_version_mismatch() {
+async fn workspace_version_mismatch_surfaces_for_range_request_on_registry_404() {
     let mut server = mockito::Server::new_async().await;
     let _mock = server.mock("GET", "/acme").with_status(404).create_async().await;
     let registry = format!("{}/", server.url());
     let (resolver, _tempdir) = build_resolver(&registry);
 
-    // Workspace has "acme" at 1.0.0, but we request 2.0.0 (404 on registry).
     let packages = build_workspace_packages("acme", &["1.0.0"]);
     let opts = workspace_resolve_options(packages);
 
@@ -1241,29 +1246,63 @@ async fn workspace_version_hint_shown_when_registry_404_and_workspace_version_mi
     let err = resolver
         .resolve(&wanted, &opts)
         .await
-        .expect_err("should fail since registry returns 404 and workspace version doesn't match");
+        .expect_err("registry 404 and no matching workspace version must fail");
     let err_msg = err.to_string();
     assert!(
-        err_msg.contains("1.0.0"),
-        "expected error to mention available workspace version 1.0.0, got: {err_msg}",
+        err_msg.contains("No matching version found for acme@^2.0.0 inside the workspace"),
+        "expected the workspace mismatch message, got: {err_msg}",
     );
     assert!(
-        err_msg.contains("available"),
-        "expected error to mention available versions, got: {err_msg}",
+        err_msg.contains("Available versions: 1.0.0"),
+        "expected error to list available workspace versions, got: {err_msg}",
     );
 }
 
-/// When registry returns 404 and the workspace does NOT have a
-/// package with the same name, the registry error propagates as-is
-/// without any workspace hint.
 #[tokio::test]
-async fn no_workspace_hint_when_package_not_in_workspace() {
+async fn workspace_version_mismatch_surfaces_when_registry_lacks_matching_version() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(single_version_body(
+            "2.0.0",
+            "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+        ))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let opts = workspace_resolve_options(packages);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^3.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let err = resolver
+        .resolve(&wanted, &opts)
+        .await
+        .expect_err("neither registry nor workspace satisfies ^3.0.0");
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("No matching version found for acme@^3.0.0 inside the workspace"),
+        "expected the workspace mismatch message, got: {err_msg}",
+    );
+    assert!(
+        err_msg.contains("Available versions: 1.0.0"),
+        "expected error to list available workspace versions, got: {err_msg}",
+    );
+}
+
+#[tokio::test]
+async fn registry_404_propagates_when_package_not_in_workspace() {
     let mut server = mockito::Server::new_async().await;
     let _mock = server.mock("GET", "/acme").with_status(404).create_async().await;
     let registry = format!("{}/", server.url());
     let (resolver, _tempdir) = build_resolver(&registry);
 
-    // Workspace has "other-pkg" but not "acme".
     let packages = build_workspace_packages("other-pkg", &["1.0.0"]);
     let opts = workspace_resolve_options(packages);
 
@@ -1275,23 +1314,22 @@ async fn no_workspace_hint_when_package_not_in_workspace() {
     let err = resolver
         .resolve(&wanted, &opts)
         .await
-        .expect_err("should fail since package not in workspace and registry 404s");
+        .expect_err("package absent from both registry and workspace must fail");
     let err_msg = err.to_string();
+    assert!(err_msg.contains("404"), "expected the 404 to propagate, got: {err_msg}");
     assert!(
-        !err_msg.contains("available"),
-        "should NOT include workspace hint when package is not in workspace, got: {err_msg}",
+        !err_msg.contains("inside the workspace"),
+        "workspace mismatch must not surface when the package is not in the workspace, got: {err_msg}",
     );
 }
 
-/// Workspace fallback still works when the version matches.
 #[tokio::test]
-async fn workspace_fallback_succeeds_when_version_matches() {
+async fn workspace_fallback_succeeds_for_range_request_on_registry_404() {
     let mut server = mockito::Server::new_async().await;
     let _mock = server.mock("GET", "/acme").with_status(404).create_async().await;
     let registry = format!("{}/", server.url());
     let (resolver, _tempdir) = build_resolver(&registry);
 
-    // Workspace has "acme" at 1.0.0, and we request ^1.0.0 — matches.
     let packages = build_workspace_packages("acme", &["1.0.0"]);
     let opts = workspace_resolve_options(packages);
 
@@ -1304,17 +1342,16 @@ async fn workspace_fallback_succeeds_when_version_matches() {
     assert_eq!(result.resolved_via, "workspace");
 }
 
-/// Non-404 registry errors (500, auth) must NOT be masked by workspace
-/// version hints. Regression test for the `CodeRabbit` review on this pull request.
 #[tokio::test]
-async fn non_404_registry_error_not_masked_by_workspace_hint() {
+async fn non_404_registry_error_not_masked_by_workspace_version_mismatch() {
     let mut server = mockito::Server::new_async().await;
     let _mock = server.mock("GET", "/acme").with_status(500).create_async().await;
     let registry = format!("{}/", server.url());
-    let (resolver, _tempdir) = build_resolver(&registry);
+    let (mut resolver, _tempdir) = build_resolver(&registry);
+    // A 5xx is retried with backoff; skip the retries so the test
+    // doesn't spend over a minute sleeping.
+    resolver.retry_opts = RetryOpts { retries: 0, ..RetryOpts::default() };
 
-    // Workspace has "acme" at 1.0.0, but we request ^2.0.0 — no match
-    // AND the registry returns 500 (not 404).
     let packages = build_workspace_packages("acme", &["1.0.0"]);
     let opts = workspace_resolve_options(packages);
 
@@ -1323,26 +1360,14 @@ async fn non_404_registry_error_not_masked_by_workspace_hint() {
         bare_specifier: Some("^2.0.0".to_string()),
         ..WantedDependency::default()
     };
-    let result = resolver.resolve(&wanted, &opts).await;
-    // The resolve should either:
-    // - Return an Err (500 propagated), or
-    // - Return Ok(None) (no matching version found)
-    // But it must NOT return an Err containing the workspace hint text.
-    // Before the fix, a 500 + workspace package existing would incorrectly
-    // surface "available version(s)" hint even for non-404 errors.
-    match result {
-        Err(e) => {
-            let msg = e.to_string();
-            assert!(
-                !msg.contains("available version(s)"),
-                "Workspace hint should not appear for 500 errors, got: {msg}",
-            );
-        }
-        Ok(None) => {
-            // This is acceptable — the 500 produced no versions, not a workspace hint
-        }
-        Ok(Some(_)) => {
-            panic!("Should not resolve successfully from a 500 registry response");
-        }
-    }
+    let err = resolver
+        .resolve(&wanted, &opts)
+        .await
+        .expect_err("a 500 registry response must propagate as an error");
+    let err_msg = err.to_string();
+    assert!(err_msg.contains("500"), "expected the 500 to propagate, got: {err_msg}");
+    assert!(
+        !err_msg.contains("inside the workspace"),
+        "workspace mismatch must not mask a non-404 registry error, got: {err_msg}",
+    );
 }

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -520,8 +520,13 @@ async function resolveNpm (
           calcSpecifier: opts.calcSpecifier,
           pinnedVersion: opts.pinnedVersion,
         })
-      } catch {
-        // ignore
+      } catch (workspaceErr: any) { // eslint-disable-line
+        // When the registry doesn't have the package and the workspace has it
+        // only at non-matching versions, the mismatch error (which lists the
+        // available workspace versions) is more actionable than the raw 404.
+        if (err.code === 'ERR_PNPM_FETCH_404' && workspaceErr.code === 'ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE') {
+          throw workspaceErr
+        }
       }
     }
     throw err
@@ -541,8 +546,13 @@ async function resolveNpm (
           calcSpecifier: opts.calcSpecifier,
           pinnedVersion: opts.pinnedVersion,
         })
-      } catch {
-        // ignore
+      } catch (workspaceErr: any) { // eslint-disable-line
+        // Neither the registry nor the workspace has a matching version; the
+        // workspace mismatch error carries the available local versions,
+        // which is the actionable detail here.
+        if (workspaceErr.code === 'ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE') {
+          throw workspaceErr
+        }
       }
     }
 

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -520,11 +520,11 @@ async function resolveNpm (
           calcSpecifier: opts.calcSpecifier,
           pinnedVersion: opts.pinnedVersion,
         })
-      } catch (workspaceErr: any) { // eslint-disable-line
+      } catch (workspaceErr) {
         // When the registry doesn't have the package and the workspace has it
         // only at non-matching versions, the mismatch error (which lists the
         // available workspace versions) is more actionable than the raw 404.
-        if (err.code === 'ERR_PNPM_FETCH_404' && workspaceErr.code === 'ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE') {
+        if (err.code === 'ERR_PNPM_FETCH_404' && (workspaceErr as { code?: string }).code === 'ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE') {
           throw workspaceErr
         }
       }
@@ -546,11 +546,11 @@ async function resolveNpm (
           calcSpecifier: opts.calcSpecifier,
           pinnedVersion: opts.pinnedVersion,
         })
-      } catch (workspaceErr: any) { // eslint-disable-line
+      } catch (workspaceErr) {
         // Neither the registry nor the workspace has a matching version; the
         // workspace mismatch error carries the available local versions,
         // which is the actionable detail here.
-        if (workspaceErr.code === 'ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE') {
+        if ((workspaceErr as { code?: string }).code === 'ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE') {
           throw workspaceErr
         }
       }

--- a/pnpm11/resolving/npm-resolver/test/index.ts
+++ b/pnpm11/resolving/npm-resolver/test/index.ts
@@ -2114,7 +2114,7 @@ test('pick lowest version by * when there are only prerelease versions', async (
   expect(resolveResult!.manifest!.version).toBe('1.0.0-alpha.1')
 })
 
-test('throws when workspace package version does not match and package is not found in the registry', async () => {
+test('throws an error with the available workspace versions when workspace package version does not match and package is not found in the registry', async () => {
   getMockAgent().get(registries.default.replace(/\/$/, ''))
     .intercept({ path: '/is-positive', method: 'GET' })
     .reply(404, {})
@@ -2126,9 +2126,11 @@ test('throws when workspace package version does not match and package is not fo
     registries,
   })
 
-  await expect(
-    resolveFromNpm({ alias: 'is-positive', bareSpecifier: '2.0.0' }, {
-      projectDir: '/home/istvan/src',
+  const projectDir = '/home/istvan/src'
+  let err!: Error & { code: string }
+  try {
+    await resolveFromNpm({ alias: 'is-positive', bareSpecifier: '2.0.0' }, {
+      projectDir,
       update: 'compatible',
       workspacePackages: new Map([
         ['is-positive', new Map([
@@ -2142,10 +2144,16 @@ test('throws when workspace package version does not match and package is not fo
         ])],
       ]),
     })
-  ).rejects.toThrow()
+  } catch (_err: any) { // eslint-disable-line
+    err = _err
+  }
+
+  expect(err).toBeTruthy()
+  expect(err.code).toBe('ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE')
+  expect(err.message).toBe(`In ${path.relative(process.cwd(), projectDir)}: No matching version found for is-positive@2.0.0 inside the workspace. Available versions: 1.0.0`)
 })
 
-test('throws NoMatchingVersionError when workspace package version does not match and registry has no matching version', async () => {
+test('throws an error with the available workspace versions when workspace package version does not match and registry has no matching version', async () => {
   getMockAgent().get(registries.default.replace(/\/$/, ''))
     .intercept({ path: '/is-positive', method: 'GET' })
     .reply(200, isPositiveMeta)
@@ -2157,8 +2165,49 @@ test('throws NoMatchingVersionError when workspace package version does not matc
     registries,
   })
 
-  await expect(
-    resolveFromNpm({ alias: 'is-positive', bareSpecifier: '99.0.0' }, {
+  const projectDir = '/home/istvan/src'
+  let err!: Error & { code: string }
+  try {
+    await resolveFromNpm({ alias: 'is-positive', bareSpecifier: '99.0.0' }, {
+      projectDir,
+      update: 'compatible',
+      workspacePackages: new Map([
+        ['is-positive', new Map([
+          ['1.0.0', {
+            rootDir: '/home/istvan/src/is-positive' as ProjectRootDir,
+            manifest: {
+              name: 'is-positive',
+              version: '1.0.0',
+            },
+          }],
+        ])],
+      ]),
+    })
+  } catch (_err: any) { // eslint-disable-line
+    err = _err
+  }
+
+  expect(err).toBeTruthy()
+  expect(err.code).toBe('ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE')
+  expect(err.message).toBe(`In ${path.relative(process.cwd(), projectDir)}: No matching version found for is-positive@99.0.0 inside the workspace. Available versions: 1.0.0`)
+})
+
+test('non-404 registry errors are not masked when the workspace package version does not match', async () => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(500, {})
+
+  const cacheDir = temporaryDirectory()
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir,
+    registries,
+    retry: { retries: 0 },
+  })
+
+  let err!: Error & { code: string }
+  try {
+    await resolveFromNpm({ alias: 'is-positive', bareSpecifier: '2.0.0' }, {
       projectDir: '/home/istvan/src',
       update: 'compatible',
       workspacePackages: new Map([
@@ -2173,7 +2222,12 @@ test('throws NoMatchingVersionError when workspace package version does not matc
         ])],
       ]),
     })
-  ).rejects.toThrow(NoMatchingVersionError)
+  } catch (_err: any) { // eslint-disable-line
+    err = _err
+  }
+
+  expect(err).toBeTruthy()
+  expect(err.code).toBe('ERR_PNPM_FETCH_500')
 })
 
 test('resolve from registry when workspace package version does not match the requested version', async () => {


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#1379

When a dependency's requested version matches no local workspace project and the registry can't provide it either, the error previously surfaced only the raw registry failure (a 404, or a generic "no matching version"), giving no clue that the package exists in the workspace at other versions.

Now, when registry resolution fails with a 404 (or succeeds but has no matching version) and a workspace project with the same name exists only at non-matching versions, both resolvers throw the existing `ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE` error, which names the requested range and lists the available workspace versions:

```
In <project>: No matching version found for acme@^2.0.0 inside the workspace. Available versions: 1.0.0
```

Other registry failures (authorization, network, server errors) propagate unchanged, and a 404 for a package that is not in the workspace at all still surfaces as the registry error.

The fix lands in **both stacks**:

- **pacquet** (`pacquet/crates/resolving-npm-resolver`): `try_workspace_fallback` now returns the workspace error instead of swallowing it, and `resolve_impl` surfaces the `NoMatchingVersionInsideWorkspace` variant (gated on a 404 on the fetch-error path). The earlier revision's new `WorkspaceVersionMismatchError` + `build_workspace_version_hint` were dropped in favour of the existing error, which already carries pnpm's message, code, and version sorting.
- **TypeScript** (`pnpm11/resolving/npm-resolver`): the workspace fallback's `catch { /* ignore */ }` blocks now rethrow the mismatch error (gated on `ERR_PNPM_FETCH_404` on the fetch-error path), so the TypeScript CLI — where pnpm/pnpm#1379 was originally reported — gets the same behavior.

## Squash Commit Body

```text
When registry resolution fails (404 or no matching version) and a
workspace project with the same name exists only at non-matching
versions, surface ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE with
the available workspace versions instead of the raw registry failure.

- pacquet: reuse ResolveFromWorkspaceError::NoMatchingVersionInsideWorkspace
  rather than introducing a parallel error type; try_workspace_fallback
  returns the workspace error and the caller decides which failures to
  surface. Non-404 fetch errors propagate unchanged.
- TypeScript (pnpm11): the npm resolver's workspace fallback no longer
  swallows the mismatch error; on the fetch-error path it is gated on
  ERR_PNPM_FETCH_404 so auth, network, and server errors propagate
  unchanged.
- Tests cover: 404 + exact/range mismatch, registry-200 without a
  matching version, package absent from the workspace (404 propagates),
  non-404 errors not masked, and the still-working fallback match.

Closes pnpm/pnpm#1379
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. (No docs change needed — existing error code, improved routing only.)

---
PR description updated by an agent (Claude Code, claude-fable-5) after pushing review fixes.
