### PR TITLE
feat(pnpr): change default port to 7677

### DIFF
--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -943,7 +943,7 @@ fn default_true() -> bool {
 
 impl Config {
     /// Default `listen` when one isn't supplied by the caller.
-    pub const DEFAULT_LISTEN: &'static str = "127.0.0.1:4873";
+    pub const DEFAULT_LISTEN: &'static str = "127.0.0.1:7677";
     /// Default packument TTL — five minutes, matching the historical
     /// proxy-mode default.
     pub const DEFAULT_PACKUMENT_TTL: Duration = Duration::from_mins(5);

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -14,7 +14,7 @@ struct Args {
     config: Option<PathBuf>,
 
     /// Address to bind to.
-    #[arg(long, default_value = "127.0.0.1:4873")]
+    #[arg(long, default_value = "127.0.0.1:7677")]
     listen: SocketAddr,
 
     /// Override the storage path from the loaded config (bundled or

--- a/pnpr/npm/pnpr/README.md
+++ b/pnpr/npm/pnpr/README.md
@@ -28,11 +28,11 @@ Start the server with the bundled default config:
 pnpr
 ```
 
-It listens on `127.0.0.1:4873` and proxies `https://registry.npmjs.org/`
+It listens on `127.0.0.1:7677` and proxies `https://registry.npmjs.org/`
 by default. Point a client at it with:
 
 ```sh
-pnpm config set registry http://127.0.0.1:4873/
+pnpm config set registry http://127.0.0.1:7677/
 ```
 
 ## CLI flags
@@ -40,7 +40,7 @@ pnpm config set registry http://127.0.0.1:4873/
 | Flag | Description |
 | --- | --- |
 | `-c, --config <path>` | Path to a verdaccio-shaped YAML config. When omitted, the bundled default is used. |
-| `--listen <addr>` | Address to bind to. Defaults to `127.0.0.1:4873`. |
+| `--listen <addr>` | Address to bind to. Defaults to `127.0.0.1:7677`. |
 | `--storage <path>` | Override the storage directory from the loaded config. |
 | `--cache <path>` | Override the disposable proxy-cache directory (the mirror of upstream registries plus the resolver cache). Defaults to a `.pnpr-cache` subdirectory of `--storage`. |
 | `--public-url <url>` | URL clients should use to reach the server, used when rewriting `dist.tarball` in served packuments. Defaults to `http://<listen>`. |
@@ -165,7 +165,7 @@ packages:
 ```sh
 export AWS_ACCESS_KEY_ID="<r2-access-key-id>"
 export AWS_SECRET_ACCESS_KEY="<r2-secret-access-key>"
-pnpr -c ./pnpr.yaml --listen 0.0.0.0:4873 --public-url https://registry.example.com
+pnpr -c ./pnpr.yaml --listen 0.0.0.0:7677 --public-url https://registry.example.com
 ```
 
 (`--public-url` is what rewrites the `dist.tarball` URLs in served


### PR DESCRIPTION
## Summary

Changes the default port of the `pnpr` registry server from `4873` to `7677`. `7677` spells **PNPR** on a standard telephone keypad (P=7, N=6, P=7, R=7), giving pnpr its own mnemonic default instead of sharing verdaccio's historical `4873`.

This is a pnpr-only change (the Rust registry server). It does not touch the `@pnpm/testing.registry-mock` mock, which keeps `4873`.

## Squash Commit Body

```text
Change pnpr's default listen port from 4873 to 7677, which spells PNPR on a
standard telephone keypad (P=7, N=6, P=7, R=7). The old 4873 collides with
verdaccio's default, so a distinct, mnemonic default avoids clashes when both
run side by side.

Updated the DEFAULT_LISTEN constant, the --listen clap default, and the README.
Tests pin the listen address explicitly, so they are unaffected.
```

## Checklist

- [x] Updated the documentation if needed.

<!-- The pnpr server is designed, not ported from the TypeScript CLI, so the
TS/pacquet parity item does not apply. pnpr has no changeset setup. Tests pin
the listen address explicitly, so no test changes were needed. -->

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default listening address from 127.0.0.1:4873 to 127.0.0.1:7677
  * Updated documentation to reflect the new default port

<!-- end of auto-generated comment: release notes by coderabbit.ai -->