### PR TITLE
perf(package-requester): defer fetcher selection for skipped fetches

### DIFF
--- a/.changeset/lazy-pick-fetcher.md
+++ b/.changeset/lazy-pick-fetcher.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.package-requester": patch
+"pnpm": patch
+---
+
+Avoid selecting package fetchers for skip-fetch installs when a registry tarball already has integrity metadata.

--- a/pnpm11/installing/package-requester/src/packageRequester.ts
+++ b/pnpm11/installing/package-requester/src/packageRequester.ts
@@ -266,16 +266,18 @@ async function resolveAndFetch (
         })
     )
   )
-  const fetcherForResolution = resolution.type === 'variations'
-    ? undefined
-    : await pickFetcher(ctx.fetchers, resolution as AtomicResolution, {
+  let fetcherForResolution: PickedFetcher | undefined
+  let resolutionNeedsFetch = false
+  if (shouldPickFetcherBeforeSkipFetch(resolution, ctx.customFetchers)) {
+    fetcherForResolution = await pickFetcher(ctx.fetchers, resolution as AtomicResolution, {
       customFetchers: ctx.customFetchers,
       packageId: id,
     })
-  const resolutionNeedsFetchHook = fetcherForResolution?.resolutionNeedsFetch
-  const resolutionNeedsFetch = typeof resolutionNeedsFetchHook === 'function'
-    ? resolutionNeedsFetchHook(resolution)
-    : false
+    const resolutionNeedsFetchHook = fetcherForResolution.resolutionNeedsFetch
+    resolutionNeedsFetch = typeof resolutionNeedsFetchHook === 'function'
+      ? resolutionNeedsFetchHook(resolution)
+      : false
+  }
   // Fetching can be skipped only when the manifest is available, the package content
   // did not change, and the resolution does not need fetch-derived data.
   if ((options.skipFetch === true || isInstallable === false) && !resolutionNeedsFetch && !integrityChanged && (manifest != null)) {
@@ -432,6 +434,15 @@ function findResolution (resolutionVariants: PlatformAssetResolution[], supporte
     throw new PnpmError('NO_RESOLUTION_MATCHED', `Cannot find a resolution variant for the current platform in these resolutions: ${JSON.stringify(resolutionTargets)}`)
   }
   return variant.resolution
+}
+
+function shouldPickFetcherBeforeSkipFetch (
+  resolution: Resolution,
+  customFetchers: CustomFetcher[] | undefined
+): boolean {
+  if (resolution.type === 'variations') return false
+  if (customFetchers != null && customFetchers.length > 0) return true
+  return resolution.type == null && getExpectedIntegrity(resolution) == null
 }
 
 function fetchToStore (

--- a/pnpm11/installing/package-requester/test/index.ts
+++ b/pnpm11/installing/package-requester/test/index.ts
@@ -175,6 +175,40 @@ test('request package but skip fetching', async () => {
   expect(pkgResponse.fetching).toBeFalsy()
 })
 
+test('skipFetch does not pick a fetcher for registry tarballs with integrity', async () => {
+  const storeDir = temporaryDirectory()
+  const cafs = createCafsStore(storeDir)
+  let remoteTarballReads = 0
+  const trackedFetchers = { ...fetchers }
+  Object.defineProperty(trackedFetchers, 'remoteTarball', {
+    get () {
+      remoteTarballReads++
+      return fetchers.remoteTarball
+    },
+  })
+  const requestPackage = createPackageRequester({
+    resolve,
+    fetchers: trackedFetchers,
+    cafs,
+    networkConcurrency: 1,
+    storeDir,
+    verifyStoreIntegrity: true,
+    virtualStoreDirMaxLength: 120,
+  })
+
+  const projectDir = temporaryDirectory()
+  const pkgResponse = await requestPackage({ alias: 'is-positive', bareSpecifier: '1.0.0' }, {
+    downloadPriority: 0,
+    lockfileDir: projectDir,
+    preferredVersions: {},
+    projectDir,
+    skipFetch: true,
+  })
+
+  expect(pkgResponse.fetching).toBeFalsy()
+  expect(remoteTarballReads).toBe(0)
+})
+
 test('request package but skip fetching, when resolution is already available', async () => {
   const storeDir = temporaryDirectory()
   const cafs = createCafsStore(storeDir)


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Closes pnpm/pnpm#12583.

This PR avoids selecting a fetcher before the skip-fetch fast path when a registry tarball resolution already includes integrity metadata. It preserves eager fetcher selection for custom fetchers and integrity-less tarballs, where `resolutionNeedsFetch` may still need to force fetch-derived metadata.

No pacquet port is needed because this is an internal TypeScript package-requester scheduling change and does not change CLI behavior, flags, file formats, lockfile shape, or other user-visible contracts.

## Squash Commit Body

```text
Avoid selecting fetchers before skip-fetch short-circuits when registry tarballs
already carry integrity.

Custom fetchers and integrity-less tarballs still pick eagerly so
resolutionNeedsFetch can force fetch-derived metadata when needed.

Closes pnpm/pnpm#12583.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users; it becomes a release note.
- [x] Added or updated tests.
- [x] No documentation update needed; this is an internal performance fix.

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Skip-fetch installs now avoid unnecessary package fetcher selection when registry tarballs already include integrity metadata. This optimization reduces redundant operations and improves installation performance in these scenarios.

* **Tests**
  * Added test coverage to verify skip-fetch installations correctly bypass fetcher selection when integrity metadata is already present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->