### PR TITLE
ci: run required checks on merge_group so the merge queue works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: TS CI
 
-on: [push, pull_request]
+on: [push, pull_request, merge_group]
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -13,12 +13,23 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      ts: ${{ steps.filter.outputs.ts }}
+      ts: ${{ steps.force.outputs.ts || steps.filter.outputs.ts }}
     steps:
+      # In the merge queue the full suite must run: `TS CI / Compile & Lint`
+      # is itself a required check, and a skipped job never reports its
+      # context, which would leave the queue waiting forever. Forcing
+      # detection true also tests the merged result, which is the point of
+      # the queue.
+      - name: Force TS CI for merge queue
+        if: github.event_name == 'merge_group'
+        id: force
+        run: echo "ts=true" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        if: github.event_name != 'merge_group'
         with:
           persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        if: github.event_name != 'merge_group'
         id: filter
         with:
           # The TypeScript pnpm stack lives under pnpm11/, plus the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     # pull_request events from PRs in the same repo to prevent duplicate
     # build jobs (the push event already covers them).
     # Exception: chore/update-lockfile PRs (created by automation with GITHUB_TOKEN, which doesn't trigger push events)
-    if: ${{ !cancelled() && needs.changes.outputs.ts == 'true' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository || github.head_ref == 'chore/update-lockfile') }}
+    if: ${{ !cancelled() && needs.changes.outputs.ts == 'true' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository || github.head_ref == 'chore/update-lockfile') }}
 
     name: TS CI / Compile & Lint
     runs-on: ubuntu-latest
@@ -91,7 +91,7 @@ jobs:
   # parallel shards all miss the build cache at job start.
   build-pnpr:
     needs: changes
-    if: ${{ !cancelled() && needs.changes.outputs.ts == 'true' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository || github.head_ref == 'chore/update-lockfile') }}
+    if: ${{ !cancelled() && needs.changes.outputs.ts == 'true' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository || github.head_ref == 'chore/update-lockfile') }}
     name: TS CI / Build pnpr / ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -13,6 +13,7 @@ permissions:
 
 on:
   workflow_dispatch:
+  merge_group:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
@@ -30,18 +31,22 @@ jobs:
     outputs:
       rust: ${{ steps.manual.outputs.rust || steps.filter.outputs.rust }}
     steps:
-      - name: Run Rust CI for manual dispatch
-        if: github.event_name == 'workflow_dispatch'
+      # Force the full Rust suite on manual runs and in the merge queue.
+      # The merge queue tests the merged commit, so path filtering it away
+      # would defeat the point; running unconditionally also guarantees the
+      # `success` gate has a real (non-skipped) result to report.
+      - name: Force Rust CI
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group'
         id: manual
         run: echo "rust=true" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'workflow_dispatch' && github.event_name != 'merge_group'
         with:
           persist-credentials: false
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'workflow_dispatch' && github.event_name != 'merge_group'
         id: filter
         with:
           filters: |
@@ -267,6 +272,7 @@ jobs:
           persist-credentials: false
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        if: github.event_name != 'merge_group'
         id: filter
         with:
           filters: |
@@ -275,12 +281,12 @@ jobs:
               - 'deny.toml'
 
       - name: Install cargo-deny
-        if: steps.filter.outputs.src == 'true'
+        if: github.event_name == 'merge_group' || steps.filter.outputs.src == 'true'
         uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
         with:
           tool: cargo-deny
 
-      - if: steps.filter.outputs.src == 'true'
+      - if: github.event_name == 'merge_group' || steps.filter.outputs.src == 'true'
         run: cargo deny check
 
   format:


### PR DESCRIPTION
## Summary

The merge queue currently hangs: a queued PR sits forever on its required checks (e.g. `Rust CI / Success` never starts). The cause is that the merge queue runs against a temporary `gh-readonly-queue/main/...` ref via a **`merge_group`** event, but neither `TS CI` (`ci.yml`) nor `Rust CI` (`pacquet-ci.yml`) listened for that event. Their required status checks (`Rust CI / Success`, `TS CI / Compile & Lint`, `TS CI / Success`) therefore never run in the queue, so the contexts never report and the entry waits indefinitely.

This adds `merge_group` to both workflows' triggers and forces their change-detection step to `true` for that event:

- `TS CI / Compile & Lint` is itself a required context (a real job, not the always-running aggregate gate). A *skipped* job never reports its context, which would keep the queue waiting — so on `merge_group` it must actually run. Forcing detection true guarantees that.
- Forcing the full suite also makes the queue test the fully merged result, which is the entire purpose of a merge queue.
- The Rust `deny` job's nested path filter has no push/PR base to diff against in the queue, so on `merge_group` its `cargo deny check` runs unconditionally instead of behind the filter.

On `merge_group`, `github.event.pull_request` is null, so the existing `compile-and-lint` guard (`github.event.pull_request.head.repo.full_name != github.repository`) evaluates true and the job runs.

> [!NOTE]
> The fix only takes effect once it is on `main`. Because the queue is currently broken, this PR likely needs to be merged by bypassing the queue (admin merge) — after which the queue will work for subsequent PRs.

## Squash Commit Body

```text
The merge queue dispatches a merge_group event against a temporary
gh-readonly-queue/main ref, but neither TS CI (ci.yml) nor Rust CI
(pacquet-ci.yml) listened for it. Their required status checks therefore
never ran in the queue, so every queued PR waited forever on the missing
contexts (e.g. Rust CI / Success never starting).

Add merge_group to both workflows' triggers and force the change
detection true for that event. Forcing matters because TS CI / Compile &
Lint is itself a required context: a skipped job never reports its
context, which would keep the queue waiting, so it has to actually run.
It also makes the queue test the fully merged result, which is the point
of a merge queue. The Rust deny job's nested path filter, which has no
push/PR base to diff against in the queue, runs unconditionally on
merge_group instead.
```

## Checklist

- [x] Updated the documentation if needed.

<!-- CI-only change: no published package is affected, so no changeset.
The pnpr/pacquet parity rule does not apply to CI workflow config. -->

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now supports merge-queue runs, enabling validation before changes are merged.

* **Bug Fixes**
  * Improved TypeScript CI gating so compile/lint and build steps run reliably for merge-queue commits.
  * Improved Rust CI behavior for merge-queue events, ensuring the correct Rust test/deny checks execute and are not blocked by path filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->