### PR TITLE
test(pnpm): isolate the metadata cache per test

### DIFF
--- a/pnpm11/pnpm/test/utils/execPnpm.ts
+++ b/pnpm11/pnpm/test/utils/execPnpm.ts
@@ -202,6 +202,12 @@ function createEnv (opts?: { storeDir?: string, omitEnvDefaults?: PnpmEnvDefault
   }
 
   const env: Record<string, string> = {
+    // Isolate the metadata cache per test, alongside the store. The mock
+    // registry serves fixture packuments without cache-control headers, so a
+    // shared cache lets one test's packument (e.g. a default `latest` dist-tag)
+    // leak into another test that changed that tag via `addDistTag`, resolving
+    // a stale version. Keeping it next to the project dir makes it per-test.
+    pnpm_config_cache_dir: fallback('cacheDir', '../cache'),
     pnpm_config_fetch_retries: fallback('fetchRetries', '4'),
     pnpm_config_hoist: fallback('hoist', 'true'),
     pnpm_config_minimum_release_age: '0',


### PR DESCRIPTION
## Summary

The pnpm CLI e2e test harness gave each test its own **store** dir but left the **package-metadata cache** at pnpm's shared default location. The mock registry (`pnpr`) serves fixture packuments without `cache-control` headers, so once one test caused a packument to be cached, a later test in the same run that changed that package's dist-tag via `addDistTag` could resolve a **stale** version from the shared cache.

This surfaced as a reliable failure in `test/install/preferLockedPeerContexts.ts`: it pins `@pnpm.e2e/peer-c`'s `latest` tag to `1.0.0`, but when co-scheduled with a sibling that resolves `peer-c` (e.g. `test/list.ts` installing `@pnpm.e2e/abc`), the cached packument still reported the default `latest` (`2.0.0`, out of `^1.0.0` range), so pnpm fell back to the highest in-range version `1.0.1` instead of the pinned `1.0.0`.

Setting `pnpm_config_cache_dir` next to the per-test project dir isolates the metadata cache the same way the store already is, so a dist-tag change is always reflected.

Reproduced locally (`jest --runTestsByPath test/list.ts test/install/preferLockedPeerContexts.ts` fails before, passes after) and confirmed `test/install/minimumReleaseAge.ts` (which asserts a cache-file location via a `pnpm-workspace.yaml` `cacheDir`) still passes — the new env default flows through the existing `fallback()` so manifest-set / `--config.cache-dir` values continue to win.

## Squash Commit Body

```text
The pnpm CLI e2e test harness gave each test its own store dir but left the
package-metadata cache at pnpm's shared default location. The mock registry
serves fixture packuments without cache-control headers, so once one test
cached a packument, a later test that changed that package's dist-tag via
addDistTag could resolve a stale version from the shared cache. This made
test/install/preferLockedPeerContexts.ts fail reliably whenever it was
grouped with a sibling that resolves @pnpm.e2e/peer-c.

Set pnpm_config_cache_dir next to the per-test project dir (via the same
fallback() that store_dir uses, so manifest-set and --config.cache-dir
values still win) to isolate the metadata cache too.
```

## Checklist

- [x] Test-only change to the TypeScript CLI's e2e harness; no user-visible behavior, so no `pacquet/` port needed.
- [x] No published package changes, so no changeset.
- [x] Added or updated tests. (Fixes a test-isolation bug in the harness; validated by local reproduction.)
- [x] No documentation changes needed.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by directing the package manager to use a per-test cache directory, reducing the chance of stale registry cache data affecting results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->