### PR TITLE
refactor(pnpr): source --listen default from Config::DEFAULT_LISTEN

### DIFF
--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -14,7 +14,7 @@ struct Args {
     config: Option<PathBuf>,
 
     /// Address to bind to.
-    #[arg(long, default_value = "127.0.0.1:7677")]
+    #[arg(long, default_value = Config::DEFAULT_LISTEN)]
     listen: SocketAddr,
 
     /// Override the storage path from the loaded config (bundled or


### PR DESCRIPTION
## Summary

Follow-up to the merged pnpm/pnpm#12622 (change pnpr's default port to `7677`), addressing a CodeRabbit review comment on that PR.

The default listen address was duplicated: a string literal in the `--listen` CLI argument (`pnpr/crates/pnpr/src/main.rs`) and the `Config::DEFAULT_LISTEN` constant (`pnpr/crates/pnpr/src/config.rs`). This points the CLI default at the constant, so the two cannot drift apart — a single source of truth, which is stronger than a regression test guarding the parity.

Verified the resolved default is unchanged:

```
$ pnpr --help
      --listen <LISTEN>
          Address to bind to [default: 127.0.0.1:7677]
```

## Squash Commit Body

```text
Address a CodeRabbit review on pnpm/pnpm#12622: instead of duplicating the
default listen address as a string literal in the CLI arg, reference the
existing Config::DEFAULT_LISTEN constant so the CLI default and the config
default cannot drift apart.
```

## Checklist

- [x] Updated the documentation if needed.

<!-- pnpr is designed, not ported from the TS CLI, so the parity item does not
apply. pnpr has no changeset setup. No behavior change (the resolved default is
identical), so no test is added. -->

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default server bind address used by the CLI to match the app’s configured default, keeping startup behavior consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->