### PR TITLE
ci: build pnpr per-OS so Linux tests don't wait on the Windows build

### DIFF
--- a/.github/workflows/build-pnpr.yml
+++ b/.github/workflows/build-pnpr.yml
@@ -1,0 +1,80 @@
+name: Build pnpr (reusable)
+
+# Build the pnpr server and registry fixture preparer once for the given OS,
+# then share the binaries with every test job/shard as an artifact. Building
+# inside each test job instead rebuilt pnpr once per shard, because the
+# parallel shards all miss the build cache at job start.
+#
+# This is a per-OS reusable workflow rather than a single matrix job so each
+# platform's test jobs can gate on their own build. `needs` can only target a
+# whole job, never an individual matrix leg, so a matrix build would force the
+# ubuntu tests to wait for the (slower) windows build and vice versa.
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build-pnpr:
+    name: ${{ inputs.os }}
+    runs-on: ${{ inputs.os }}
+    steps:
+    - name: Free up runner disk space
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        df -h /
+    - name: Checkout Commit
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+    # The binaries are cached and keyed on the Rust sources that produce them,
+    # so a run that only touches TypeScript restores them in seconds instead of
+    # recompiling. They are copied out of `target/` into a stable dir so
+    # `Swatinem/rust-cache`'s `target/` cleanup can't strip them before the
+    # cache saves.
+    - name: Restore prebuilt pnpr binaries
+      id: pnpr-bins
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: .pnpr-bin
+        key: pnpr-bins-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml', '**/Cargo.lock', '**/Cargo.toml', 'pnpr/**/*.rs', 'pacquet/**/*.rs') }}
+    - name: Install Rust
+      if: steps.pnpr-bins.outputs.cache-hit != 'true'
+      uses: ./.github/actions/rustup
+      with:
+        save-cache: ${{ github.ref_name == 'main' }}
+        shared-key: registry-prepare
+    - name: Build the pnpr server and registry fixture preparer
+      if: steps.pnpr-bins.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cargo build --locked --release -p pnpr --bin pnpr -p pnpr-fixtures --bin pnpr-prepare
+        mkdir -p .pnpr-bin
+        ext=""
+        [ -f target/release/pnpr.exe ] && ext=".exe"
+        cp "target/release/pnpr$ext" "target/release/pnpr-prepare$ext" .pnpr-bin/
+    # Save the binaries to the cache right after they build, not in a post-job
+    # step: a later step failing would otherwise skip the save and force a full
+    # Rust rebuild on the next run.
+    - name: Save prebuilt pnpr binaries
+      if: steps.pnpr-bins.outputs.cache-hit != 'true'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: .pnpr-bin
+        key: ${{ steps.pnpr-bins.outputs.cache-primary-key }}
+    - name: Upload pnpr binaries
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: pnpr-bins-${{ runner.os }}
+        path: .pnpr-bin
+        # `.pnpr-bin` is a dotfile dir, which upload-artifact skips by default.
+        include-hidden-files: true
+        if-no-files-found: error
+        retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,77 +85,30 @@ jobs:
         path: compiled.tar.gz
         retention-days: 1
 
-  # Build the pnpr server and registry fixture preparer once per OS, then
-  # share the binaries with every test job/shard as an artifact. Building
-  # inside each test job instead rebuilt pnpr once per shard, because the
-  # parallel shards all miss the build cache at job start.
-  build-pnpr:
+  # Build the pnpr binaries once per OS via a per-OS reusable workflow (not a
+  # single matrix job) so each platform's test jobs gate only on their own
+  # build. `needs` can only target a whole job, never an individual matrix
+  # leg, so a matrix build would make the ubuntu tests wait for the slower
+  # windows build and vice versa.
+  build-pnpr-linux:
     needs: changes
     if: ${{ !cancelled() && needs.changes.outputs.ts == 'true' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository || github.head_ref == 'chore/update-lockfile') }}
-    name: TS CI / Build pnpr / ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-    - name: Free up runner disk space
-      if: ${{ runner.os == 'Linux' }}
-      run: |
-        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-        df -h /
-    - name: Checkout Commit
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        persist-credentials: false
-    # The binaries are cached and keyed on the Rust sources that produce them,
-    # so a run that only touches TypeScript restores them in seconds instead of
-    # recompiling. They are copied out of `target/` into a stable dir so
-    # `Swatinem/rust-cache`'s `target/` cleanup can't strip them before the
-    # cache saves.
-    - name: Restore prebuilt pnpr binaries
-      id: pnpr-bins
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: .pnpr-bin
-        key: pnpr-bins-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml', '**/Cargo.lock', '**/Cargo.toml', 'pnpr/**/*.rs', 'pacquet/**/*.rs') }}
-    - name: Install Rust
-      if: steps.pnpr-bins.outputs.cache-hit != 'true'
-      uses: ./.github/actions/rustup
-      with:
-        save-cache: ${{ github.ref_name == 'main' }}
-        shared-key: registry-prepare
-    - name: Build the pnpr server and registry fixture preparer
-      if: steps.pnpr-bins.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        cargo build --locked --release -p pnpr --bin pnpr -p pnpr-fixtures --bin pnpr-prepare
-        mkdir -p .pnpr-bin
-        ext=""
-        [ -f target/release/pnpr.exe ] && ext=".exe"
-        cp "target/release/pnpr$ext" "target/release/pnpr-prepare$ext" .pnpr-bin/
-    # Save the binaries to the cache right after they build, not in a post-job
-    # step: a later step failing would otherwise skip the save and force a full
-    # Rust rebuild on the next run.
-    - name: Save prebuilt pnpr binaries
-      if: steps.pnpr-bins.outputs.cache-hit != 'true'
-      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: .pnpr-bin
-        key: ${{ steps.pnpr-bins.outputs.cache-primary-key }}
-    - name: Upload pnpr binaries
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: pnpr-bins-${{ runner.os }}
-        path: .pnpr-bin
-        # `.pnpr-bin` is a dotfile dir, which upload-artifact skips by default.
-        include-hidden-files: true
-        if-no-files-found: error
-        retention-days: 1
+    name: TS CI / Build pnpr
+    uses: ./.github/workflows/build-pnpr.yml
+    with:
+      os: ubuntu-latest
+
+  build-pnpr-windows:
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.ts == 'true' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository || github.head_ref == 'chore/update-lockfile') }}
+    name: TS CI / Build pnpr
+    uses: ./.github/workflows/build-pnpr.yml
+    with:
+      os: windows-latest
 
   test-smoke:
     name: TS CI / Test / ubuntu
-    needs: [compile-and-lint, build-pnpr]
+    needs: [compile-and-lint, build-pnpr-linux]
     uses: ./.github/workflows/test.yml
     with:
       node: '24.0.0'
@@ -197,7 +150,7 @@ jobs:
   # the smoke job like the other Node.js versions do.
   test-windows:
     name: TS CI / Test / ${{ matrix.platform_label }}
-    needs: [compile-and-lint, build-pnpr]
+    needs: [compile-and-lint, build-pnpr-windows]
     strategy:
       fail-fast: false
       matrix:
@@ -242,7 +195,8 @@ jobs:
     needs:
       - changes
       - compile-and-lint
-      - build-pnpr
+      - build-pnpr-linux
+      - build-pnpr-windows
       - test-smoke
       - test
       - test-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
               - 'cspell.json'
               - '.github/workflows/ci.yml'
               - '.github/workflows/test.yml'
+              - '.github/workflows/build-pnpr.yml'
               - '.github/scripts/**'
 
   compile-and-lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,8 +99,8 @@ jobs:
     # `pnpr/.fixtures/packages` into the storage the server reads. Both are
     # built from source (so the tests exercise the current server, not a
     # published `@pnpm/pnpr` that may predate it) once per OS by the
-    # `build-pnpr` job, then shared with every test job/shard here as an
-    # artifact instead of rebuilt per job.
+    # `build-pnpr` reusable workflow, then shared with every test job/shard
+    # here as an artifact instead of rebuilt per job.
     - name: Download prebuilt pnpr binaries
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:


### PR DESCRIPTION
## Summary

The pnpr binaries are built by a single `build-pnpr` **matrix** job spanning `[ubuntu-latest, windows-latest]`. In GitHub Actions a `needs` edge can only target a whole job, never an individual matrix leg, so every consumer of `build-pnpr` blocks until **both** legs finish. The result: the Linux test jobs (`test-smoke`, `test`) wait for the slower **Windows** pnpr build even though they only consume the Linux binary artifact. (This was the symptom in the [referenced run](https://github.com/pnpm/pnpm/actions/runs/28090482757/job/83166994222).)

This PR extracts the build into a per-OS **reusable workflow** (`.github/workflows/build-pnpr.yml`) and calls it twice from `ci.yml`:

- `build-pnpr-linux` (ubuntu) → required by `test-smoke` / `test`
- `build-pnpr-windows` → required by `test-windows`

Each platform's test jobs now gate only on their own build, so neither platform waits on the other's pnpr build. The build steps are unchanged (they were already `runner.os`-guarded); only the job topology changed.

## Squash Commit Body

```text
The pnpr binaries were built by a single `build-pnpr` matrix job spanning
[ubuntu-latest, windows-latest]. A `needs` edge can only target a whole job,
never an individual matrix leg, so every consumer of `build-pnpr` (the ubuntu
smoke/test jobs and the windows test shards) blocked until both legs finished.
The Linux tests therefore waited for the slower Windows pnpr build even though
they only consume the Linux binary artifact.

Extract the build into a per-OS reusable workflow (build-pnpr.yml) and call it
twice from ci.yml as build-pnpr-linux and build-pnpr-windows. The ubuntu test
jobs now gate only on build-pnpr-linux and the windows shards only on
build-pnpr-windows, so neither platform waits on the other's build.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. — CI-only change; no port needed.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note. — No published package is affected.
- [x] Added or updated tests. — N/A for a CI topology change.
- [x] Updated the documentation if needed. — N/A.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable build workflow that compiles pnpr binaries per operating system and shares them with downstream jobs/tests.
  * Updated CI to run separate Linux and Windows pnpr build jobs using the reusable workflow for improved reuse.
* **Bug Fixes**
  * Improved CI change detection so updates to the reusable build workflow are included in CI runs.
* **Documentation**
  * Clarified CI notes that compiled artifacts are produced once per OS and then shared across test shards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->