### PR TITLE
ci(benchmark): show commit hash in Integrated-Benchmark Report

### DIFF
--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -325,9 +325,17 @@ jobs:
 
       - name: Generate summary
         shell: bash
+        env:
+          # The PR head SHA for pull_request events, otherwise (push,
+          # workflow_dispatch) the ref's own SHA. Display-only — no
+          # control flow consumes it; the comment workflow resolves the
+          # PR number from the trusted workflow_run payload regardless.
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           (
             echo '## Integrated-Benchmark Report (${{ runner.os }})'
+            echo
+            echo "**Commit:** [\`${SHA:0:12}\`](${{ github.server_url }}/${{ github.repository }}/commit/$SHA)"
             echo
             echo 'Each scenario reports direct installs and pnpr installs. Bencher consumes pacquet@HEAD and pnpr@HEAD.'
             echo


### PR DESCRIPTION
## Summary

Adds a clickable short-SHA line directly under the `## Integrated-Benchmark Report (Linux)` header so the PR comment is self-describing. Without it, the comment is detached from the exact revision it benchmarked once the originating workflow run scrolls out of view.

The SHA comes from the build workflow's event payload (`github.event.pull_request.head.sha` for PRs, `github.sha` otherwise). It is display-only; the comment workflow continues to resolve the PR number from the trusted `workflow_run` payload, so a fork-controlled SHA in the artifact cannot redirect where the comment lands.

## Squash Commit Body

```text
The Integrated-Benchmark Report PR comment previously carried no commit identifier, leaving readers unable to map a posted report back to the exact revision once the originating workflow_run scrolled out of view. Add a clickable short-SHA line directly under the report header in the `Generate summary` step of `pacquet-integrated-benchmark.yml`.

Source the SHA from `github.event.pull_request.head.sha` on pull_request events (stable commit that survives merge) and fall back to `github.sha` for push and workflow_dispatch. Display-only — the comment workflow resolves the PR number from the trusted workflow_run payload, so the SHA in the fork-controlled artifact cannot redirect where the comment lands.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting.
  — N/A: CI workflow YAML only; no CLI surface, on-disk contract, or user-visible behavior affected (parity rule in `AGENTS.md` scopes to user-visible changes).
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
  — N/A: no published package touched.
- [ ] Added or updated tests.
  — N/A: workflow YAML; the existing `body-includes: 'Integrated-Benchmark Report (Linux)'` matcher in `pacquet-integrated-benchmark-comment.yml` still matches the new header, so no comment-dedup regression.
- [ ] Updated the documentation if needed.
  — N/A.

---

Written by an agent (opencode, glm-5.2).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated benchmark report output to show a clickable commit reference in the header.
  * The displayed commit ID is now shortened for easier reading while still linking to the full commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->