### PR TITLE
ci: don't run push CI on merge-queue branches

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,12 @@
 name: Audit
 
-on: [push, pull_request]
+on:
+  push:
+    # Skip the redundant run on the merge queue's temporary
+    # `gh-readonly-queue/**` branches; the pull_request run already covered it.
+    branches-ignore:
+      - 'gh-readonly-queue/**'
+  pull_request:
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,18 @@
 name: TS CI
 
-on: [push, pull_request, merge_group]
+on:
+  push:
+    # The merge queue runs each entry on a temporary `gh-readonly-queue/**`
+    # branch, whose creation also fires a `push` event. That duplicate run
+    # shares `github.ref` (hence the test.yml concurrency group) with the
+    # `merge_group` run for the same commit, so with `cancel-in-progress`
+    # the two cancel each other's test jobs — failing `TS CI / Success` and
+    # ejecting the PR. Only the `merge_group` run reports to the queue, so
+    # skip `push` for those branches.
+    branches-ignore:
+      - 'gh-readonly-queue/**'
+  pull_request:
+  merge_group:
 
 permissions:
   contents: read # to fetch code (actions/checkout)


### PR DESCRIPTION
## Summary

Fixes the merge queue ejecting PRs for "failed status checks" (e.g. [this run](https://github.com/pnpm/pnpm/actions/runs/28100166658/job/83200854709)).

GitHub's merge queue runs each entry on a temporary `gh-readonly-queue/**` branch, whose creation **also fires a `push` event**. Because `ci.yml` listens on `[push, pull_request, merge_group]`, this produced **two TS CI runs for the identical commit** — one `push`, one `merge_group`:

```
28100166958  push         success     gh-readonly-queue/main/pr-12630-ebd38f8...
28100166658  merge_group  cancelled   gh-readonly-queue/main/pr-12630-ebd38f8...  ← same SHA
```

Both runs reach the reusable `test.yml`, whose concurrency group keys on `github.ref` with `cancel-in-progress: true`. Since the two runs share `github.ref`, each per-`(platform, node, chunk)` test job lands in the **same** group, so the later one cancels the earlier:

> Canceling since a higher priority waiting request for `TS CI-refs/heads/gh-readonly-queue/main/pr-12630-…-windows-latest-22.13.0-2-3` exists

The Windows shards are gated only on `compile-and-lint` + `build-pnpr`, so both runs' Windows jobs start near-simultaneously and reliably collide (the ubuntu jobs wait on `test-smoke`, which staggers them apart). The `merge_group` run — the only one the queue's required `TS CI / Success` check reads — lost the race, so its cancelled test jobs failed `Success` and the PR was ejected.

`TS CI / Success` is **not** the culprit: it `needs:` every test job, so it waits for them and only reports the cancellation afterward.

## Fix

Restrict the `push` trigger in `ci.yml` to ignore `gh-readonly-queue/**`, so only the `merge_group` run executes for queued commits (that run already forces the full suite and is the only run the queue reads, so dropping the push duplicate is pure upside). `pacquet-ci.yml` already scopes push to `branches: [main]` and was unaffected. The same `branches-ignore` is applied to `audit.yml` to drop its redundant (non-breaking, just wasteful) push run on those branches.

## Squash Commit Body

```text
GitHub's merge queue runs each entry on a temporary gh-readonly-queue/**
branch, whose creation also fires a push event. For ci.yml
(on: [push, pull_request, merge_group]) that produced two TS CI runs for
the identical commit: one push, one merge_group. Both reach the reusable
test.yml, whose concurrency group keys on github.ref with
cancel-in-progress: true, so their per-(platform, node, chunk) test jobs
land in the same group and cancel each other. The merge_group run — the
only one the queue's required TS CI / Success check reads — lost the
race, failing Success and ejecting the PR.

Restrict the push trigger to ignore gh-readonly-queue/** so only the
merge_group run executes for queued commits. pacquet-ci.yml already
scopes push to main and was unaffected. Apply the same branches-ignore
to audit.yml to drop its redundant push run on those branches.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. _(CI-only; not user-visible CLI surface — no pacquet port needed.)_
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. _(No published package changes — CI workflow only.)_
- [x] Added or updated tests. _(Not applicable to workflow trigger config.)_
- [x] Updated the documentation if needed. _(Not applicable.)_

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automation workflow triggers to use explicit event definitions instead of shorthand configuration.
  * Reduced duplicate runs by excluding temporary merge-queue branches from push-triggered workflows.
  * Kept pull request and merge-queue checks active, with no changes to the actual audit or CI job steps/logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->