### PR TITLE
ci: carry TS CI / Success only from pull_request and merge_group runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,18 @@
 name: TS CI
 
 on:
+  # Run push CI only on the default branch. A branch that lives in this repo
+  # fires both a `push` and a `pull_request` event for the same commit, and
+  # both runs report the `TS CI / Success` context to that commit. Branch
+  # protection then sees two results for the required check, so a cancellation
+  # or flake on the push side (e.g. two pushes racing on the test.yml
+  # concurrency group) blocks the PR even when the pull_request run passed.
+  # Restricting push to `main` means PRs carry `TS CI / Success` only via
+  # their `pull_request` run (and the merge queue via `merge_group`); `main`
+  # is validated pre-merge by `merge_group` and re-checked post-merge here.
   push:
-    # The merge queue runs each entry on a temporary `gh-readonly-queue/**`
-    # branch, whose creation also fires a `push` event. That duplicate run
-    # shares `github.ref` (hence the test.yml concurrency group) with the
-    # `merge_group` run for the same commit, so with `cancel-in-progress`
-    # the two cancel each other's test jobs — failing `TS CI / Success` and
-    # ejecting the PR. Only the `merge_group` run reports to the queue, so
-    # skip `push` for those branches.
-    branches-ignore:
-      - 'gh-readonly-queue/**'
+    branches:
+      - main
   pull_request:
   merge_group:
 
@@ -65,11 +67,10 @@ jobs:
 
   compile-and-lint:
     needs: changes
-    # Run only when TypeScript-relevant files changed. Also skip
-    # pull_request events from PRs in the same repo to prevent duplicate
-    # build jobs (the push event already covers them).
-    # Exception: chore/update-lockfile PRs (created by automation with GITHUB_TOKEN, which doesn't trigger push events)
-    if: ${{ !cancelled() && needs.changes.outputs.ts == 'true' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository || github.head_ref == 'chore/update-lockfile') }}
+    # Run only when TypeScript-relevant files changed. Every PR (same-repo or
+    # fork) is covered by its pull_request run, and push only fires on main, so
+    # there are no duplicate build jobs to guard against here.
+    if: ${{ !cancelled() && needs.changes.outputs.ts == 'true' }}
 
     name: TS CI / Compile & Lint
     runs-on: ubuntu-latest
@@ -105,7 +106,7 @@ jobs:
   # windows build and vice versa.
   build-pnpr-linux:
     needs: changes
-    if: ${{ !cancelled() && needs.changes.outputs.ts == 'true' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository || github.head_ref == 'chore/update-lockfile') }}
+    if: ${{ !cancelled() && needs.changes.outputs.ts == 'true' }}
     name: TS CI / Build pnpr
     uses: ./.github/workflows/build-pnpr.yml
     with:
@@ -113,7 +114,7 @@ jobs:
 
   build-pnpr-windows:
     needs: changes
-    if: ${{ !cancelled() && needs.changes.outputs.ts == 'true' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository || github.head_ref == 'chore/update-lockfile') }}
+    if: ${{ !cancelled() && needs.changes.outputs.ts == 'true' }}
     name: TS CI / Build pnpr
     uses: ./.github/workflows/build-pnpr.yml
     with:


### PR DESCRIPTION
## Summary

A branch that lives in this repo fires **both** a `push` and a `pull_request`
TS CI run for the same commit, and **both** report the `TS CI / Success`
required check to that commit. Branch protection then sees two results for the
one required context, so a cancellation or flake on the push side — for
example two pushes racing on the `test.yml` concurrency group — blocks the PR
even when the `pull_request` run passed.

This makes a PR's `TS CI / Success` come solely from its `pull_request` run
(and from `merge_group` in the merge queue):

- **`push` now triggers only on `main`.** PR/feature/Dependabot branches no
  longer start a second push run alongside their `pull_request` run, so there
  is only ever one `TS CI / Success` context per PR commit. `main` is still
  validated pre-merge by `merge_group` and re-checked post-merge by the
  `push`-on-`main` run. This also subsumes the old `gh-readonly-queue/**`
  ignore.
- **The build/test jobs now run on every `pull_request`** (same-repo and
  fork), so the `pull_request` run does the real testing. Previously same-repo
  PRs were tested on the `push` event and the `pull_request` run skipped the
  heavy jobs; pointing the required check at `pull_request` without this would
  have produced a false green.

No double-running (each PR is one run; each `main` push is one run), no
branch-protection config change (the required context name `TS CI / Success`
is unchanged), and the `chore/update-lockfile` special case is handled
naturally now that `pull_request` always runs the heavy jobs.

## Squash Commit Body

```text
A branch that lives in this repo fires both a push and a pull_request TS CI
run for the same commit, and both report the TS CI / Success required check.
Branch protection then sees two results for that context, so a cancellation or
flake on the push side (e.g. two pushes racing on the test.yml concurrency
group) blocks the PR even when the pull_request run passed.

Restrict push CI to main so PR branches carry TS CI / Success only via their
pull_request run (and the merge queue via merge_group). Since pull_request now
covers every PR, run the build/test jobs on every pull_request (same-repo and
fork) instead of relying on the push run, and drop the same-repo/fork/
chore-lockfile gating that existed only to avoid duplicate push+pull_request
builds. main stays covered pre-merge by merge_group and post-merge by the push
run.
```

## Checklist

- [x] Added or updated tests. <!-- N/A: CI workflow-only change; validated with actionlint. -->

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI job conditions for TypeScript-related checks, making automated runs more consistent.
  * Updated workflow triggering so checks now run on the main branch and only when relevant TypeScript files change.
  * Removed several special-case branch and event rules to reduce unnecessary CI complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->