### PR TITLE
test: authenticate to the pnpr registry mock with bearer tokens

### DIFF
--- a/pnpm11/installing/deps-installer/test/install/auth.ts
+++ b/pnpm11/installing/deps-installer/test/install/auth.ts
@@ -1,15 +1,77 @@
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
 import path from 'node:path'
 
 import { test } from '@jest/globals'
 import { addDependenciesToPackage, install } from '@pnpm/installing.deps-installer'
 import { prepareEmpty } from '@pnpm/prepare'
-import { addUser, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
+import { addUser, getRegistryMockToken, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import type { RegistryConfig } from '@pnpm/types'
 import { rimrafSync } from '@zkochan/rimraf'
 
 import { testDefaults } from '../utils/index.js'
 
 const skipOnNode17 = ['v14', 'v16'].includes(process.version.split('.')[0]) ? test : test.skip
+
+const BASIC_AUTH_CREDENTIALS = { username: 'foo', password: 'bar' }
+const EXPECTED_BASIC_AUTH = `Basic ${Buffer.from(
+  `${BASIC_AUTH_CREDENTIALS.username}:${BASIC_AUTH_CREDENTIALS.password}`
+).toString('base64')}`
+
+// pnpr only accepts bearer tokens, so it can't exercise pnpm's HTTP Basic
+// (`_auth`) client support directly. This stands up a registry that does:
+// it rejects requests lacking the expected Basic credentials with 401, and
+// otherwise forwards to pnpr with a bearer token. Packument tarball URLs
+// (rewritten by pnpr to its `public_url`) are pointed back at this proxy so
+// tarball fetches go through the same Basic-auth boundary.
+async function withBasicAuthRegistry (run: (registryUrl: string) => Promise<void>): Promise<void> {
+  const upstreamBase = `http://localhost:${REGISTRY_MOCK_PORT}`
+  const bearer = `Bearer ${getRegistryMockToken()}`
+  let proxyBase = ''
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      if (req.headers.authorization !== EXPECTED_BASIC_AUTH) {
+        res.writeHead(401, { 'www-authenticate': 'Basic realm="pnpr"' })
+        res.end('Unauthorized')
+        return
+      }
+      const upstream = await fetch(`${upstreamBase}${req.url}`, {
+        method: req.method,
+        headers: { accept: req.headers.accept ?? '*/*', authorization: bearer },
+      })
+      const contentType = upstream.headers.get('content-type') ?? ''
+      if (contentType.includes('json')) {
+        const body = (await upstream.text()).split(upstreamBase).join(proxyBase)
+        res.writeHead(upstream.status, { 'content-type': 'application/json' })
+        res.end(body)
+      } else {
+        res.writeHead(upstream.status, { 'content-type': contentType })
+        res.end(Buffer.from(await upstream.arrayBuffer()))
+      }
+    })().catch((err: unknown) => {
+      res.writeHead(500)
+      res.end(String(err))
+    })
+  })
+  await new Promise<void>((resolve) => {
+    server.listen(0, resolve)
+  })
+  proxyBase = `http://localhost:${(server.address() as AddressInfo).port}`
+  try {
+    await run(`${proxyBase}/`)
+  } finally {
+    server.closeAllConnections()
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err == null) {
+          resolve()
+        } else {
+          reject(err)
+        }
+      })
+    })
+  }
+}
 
 test('a package that need authentication', async () => {
   const project = prepareEmpty()
@@ -52,22 +114,21 @@ test('a package that need authentication', async () => {
 test('installing a package that need authentication, using password', async () => {
   const project = prepareEmpty()
 
-  await addUser({
-    email: 'foo@bar.com',
-    password: 'bar',
-    username: 'foo',
+  await withBasicAuthRegistry(async (registry) => {
+    const configByUri: Record<string, RegistryConfig> = {
+      [registry.replace(/^https?:/, '')]: { '@': { basicAuth: BASIC_AUTH_CREDENTIALS } },
+    }
+    await addDependenciesToPackage({}, ['@pnpm.e2e/needs-auth'], testDefaults({
+      registries: { default: registry },
+    }, {
+      configByUri,
+      registry,
+    }, {
+      configByUri,
+    }))
+
+    project.has('@pnpm.e2e/needs-auth')
   })
-
-  const configByUri: Record<string, RegistryConfig> = {
-    [`//localhost:${REGISTRY_MOCK_PORT}/`]: { '@': { basicAuth: { username: 'foo', password: 'bar' } } },
-  }
-  await addDependenciesToPackage({}, ['@pnpm.e2e/needs-auth'], testDefaults({}, {
-    configByUri,
-  }, {
-    configByUri,
-  }))
-
-  project.has('@pnpm.e2e/needs-auth')
 })
 
 test('a scoped package that need authentication specific to scope', async () => {
@@ -121,49 +182,45 @@ test('a scoped package that need authentication specific to scope', async () => 
 test('a scoped package that need legacy authentication specific to scope', async () => {
   const project = prepareEmpty()
 
-  await addUser({
-    email: 'foo@bar.com',
-    password: 'bar',
-    username: 'foo',
+  await withBasicAuthRegistry(async (registry) => {
+    const configByUri: Record<string, RegistryConfig> = {
+      [registry.replace(/^https?:/, '')]: { '@': { basicAuth: BASIC_AUTH_CREDENTIALS } },
+    }
+    let opts = testDefaults({
+      registries: {
+        default: 'https://registry.npmjs.org/',
+        '@private': registry,
+      },
+    }, {
+      configByUri,
+      registry: 'https://registry.npmjs.org/',
+    }, {
+      configByUri,
+    })
+    const { updatedManifest: manifest } = await addDependenciesToPackage({}, ['@private/foo'], opts)
+
+    project.has('@private/foo')
+
+    // should work when a lockfile is available
+    rimrafSync('node_modules')
+    rimrafSync(path.join('..', '.store'))
+
+    // Recreating options to have a new storeController with clean cache
+    opts = testDefaults({
+      registries: {
+        default: 'https://registry.npmjs.org/',
+        '@private': registry,
+      },
+    }, {
+      configByUri,
+      registry: 'https://registry.npmjs.org/',
+    }, {
+      configByUri,
+    })
+    await addDependenciesToPackage(manifest, ['@private/foo'], opts)
+
+    project.has('@private/foo')
   })
-
-  const configByUri: Record<string, RegistryConfig> = {
-    [`//localhost:${REGISTRY_MOCK_PORT}/`]: { '@': { basicAuth: { username: 'foo', password: 'bar' } } },
-  }
-  let opts = testDefaults({
-    registries: {
-      default: 'https://registry.npmjs.org/',
-      '@private': `http://localhost:${REGISTRY_MOCK_PORT}/`,
-    },
-  }, {
-    configByUri,
-    registry: 'https://registry.npmjs.org/',
-  }, {
-    configByUri,
-  })
-  const { updatedManifest: manifest } = await addDependenciesToPackage({}, ['@private/foo'], opts)
-
-  project.has('@private/foo')
-
-  // should work when a lockfile is available
-  rimrafSync('node_modules')
-  rimrafSync(path.join('..', '.store'))
-
-  // Recreating options to have a new storeController with clean cache
-  opts = testDefaults({
-    registries: {
-      default: 'https://registry.npmjs.org/',
-      '@private': `http://localhost:${REGISTRY_MOCK_PORT}/`,
-    },
-  }, {
-    configByUri,
-    registry: 'https://registry.npmjs.org/',
-  }, {
-    configByUri,
-  })
-  await addDependenciesToPackage(manifest, ['@private/foo'], opts)
-
-  project.has('@private/foo')
 })
 
 skipOnNode17('a package that need authentication reuses authorization tokens for tarball fetching', async () => {

--- a/pnpm11/registry-access/commands/test/deprecate.ts
+++ b/pnpm11/registry-access/commands/test/deprecate.ts
@@ -3,7 +3,7 @@ import { prepare } from '@pnpm/prepare'
 import { deprecate, undeprecate } from '@pnpm/registry-access.commands'
 import { publish } from '@pnpm/releasing.commands'
 import { DEFAULT_OPTS as BASE_OPTS } from '@pnpm/testing.command-defaults'
-import { REGISTRY_MOCK_CREDENTIALS, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
+import { getRegistryMockToken, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import { safeExeca as execa } from 'execa'
 
 const DEFAULT_OPTS = {
@@ -15,7 +15,7 @@ const REGISTRY = `http://localhost:${REGISTRY_MOCK_PORT}`
 
 const CONFIG_BY_URI = {
   [`//localhost:${REGISTRY_MOCK_PORT}/`]: {
-    '@': { basicAuth: REGISTRY_MOCK_CREDENTIALS },
+    '@': { authToken: getRegistryMockToken() },
   },
 }
 

--- a/pnpm11/registry-access/commands/test/dist-tag.ts
+++ b/pnpm11/registry-access/commands/test/dist-tag.ts
@@ -4,7 +4,7 @@ import { distTag } from '@pnpm/registry-access.commands'
 import { publish } from '@pnpm/releasing.commands'
 import { DEFAULT_OPTS as BASE_OPTS } from '@pnpm/testing.command-defaults'
 import { getMockAgent, setupMockAgent, teardownMockAgent } from '@pnpm/testing.mock-agent'
-import { REGISTRY_MOCK_CREDENTIALS, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
+import { getRegistryMockToken, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 
 const DEFAULT_OPTS = {
   ...BASE_OPTS,
@@ -13,7 +13,7 @@ const DEFAULT_OPTS = {
 
 const CONFIG_BY_URI = {
   [`//localhost:${REGISTRY_MOCK_PORT}/`]: {
-    '@': { basicAuth: REGISTRY_MOCK_CREDENTIALS },
+    '@': { authToken: getRegistryMockToken() },
   },
 }
 

--- a/pnpm11/registry-access/commands/test/unpublish.ts
+++ b/pnpm11/registry-access/commands/test/unpublish.ts
@@ -3,7 +3,7 @@ import { prepare } from '@pnpm/prepare'
 import { unpublish } from '@pnpm/registry-access.commands'
 import { publish } from '@pnpm/releasing.commands'
 import { DEFAULT_OPTS as BASE_OPTS } from '@pnpm/testing.command-defaults'
-import { REGISTRY_MOCK_CREDENTIALS, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
+import { getRegistryMockToken, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import { safeExeca as execa } from 'execa'
 
 const DEFAULT_OPTS = {
@@ -15,7 +15,7 @@ const REGISTRY = `http://localhost:${REGISTRY_MOCK_PORT}`
 
 const CONFIG_BY_URI = {
   [`//localhost:${REGISTRY_MOCK_PORT}/`]: {
-    '@': { basicAuth: REGISTRY_MOCK_CREDENTIALS },
+    '@': { authToken: getRegistryMockToken() },
   },
 }
 

--- a/pnpm11/releasing/commands/test/publish/batchPublish.test.ts
+++ b/pnpm11/releasing/commands/test/publish/batchPublish.test.ts
@@ -5,7 +5,7 @@ import type { AddressInfo } from 'node:net'
 import { afterEach, beforeEach, expect, test } from '@jest/globals'
 import { preparePackages } from '@pnpm/prepare'
 import { publish } from '@pnpm/releasing.commands'
-import { REGISTRY_MOCK_CREDENTIALS, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
+import { getRegistryMockToken, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import { filterProjectsBySelectorObjectsFromDir } from '@pnpm/workspace.projects-filter'
 
 import { checkPkgExists, DEFAULT_OPTS } from './utils/index.js'
@@ -208,7 +208,7 @@ test('batch publish against a real pnpr registry publishes every package', async
     batch: true,
     configByUri: {
       [`//localhost:${REGISTRY_MOCK_PORT}/`]: {
-        '@': { basicAuth: REGISTRY_MOCK_CREDENTIALS },
+        '@': { authToken: getRegistryMockToken() },
       },
     },
     dir: process.cwd(),

--- a/pnpm11/releasing/commands/test/publish/publish.ts
+++ b/pnpm11/releasing/commands/test/publish/publish.ts
@@ -6,7 +6,7 @@ import { getCatalogsFromWorkspaceManifest } from '@pnpm/catalogs.config'
 import { prepare, preparePackages } from '@pnpm/prepare'
 import { pack, publish } from '@pnpm/releasing.commands'
 import { createTestIpcServer } from '@pnpm/test-ipc-server'
-import { REGISTRY_MOCK_CREDENTIALS, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
+import { getRegistryMockToken, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import { isCI } from 'ci-info'
 import crossSpawn from 'cross-spawn'
 import { safeExeca as execa } from 'execa'
@@ -20,7 +20,7 @@ const skipOnWindowsCI = isCI && isWindows() ? test.skip : test
 
 const CONFIG_BY_URI = {
   [`//localhost:${REGISTRY_MOCK_PORT}/`]: {
-    '@': { basicAuth: REGISTRY_MOCK_CREDENTIALS },
+    '@': { authToken: getRegistryMockToken() },
   },
 }
 const pnpmBin = path.join(import.meta.dirname, '../../../../pnpm/bin/pnpm.mjs')

--- a/pnpm11/releasing/commands/test/publish/recursivePublish.ts
+++ b/pnpm11/releasing/commands/test/publish/recursivePublish.ts
@@ -5,7 +5,7 @@ import { expect, jest, test } from '@jest/globals'
 import { streamParser } from '@pnpm/logger'
 import { preparePackages } from '@pnpm/prepare'
 import { publish } from '@pnpm/releasing.commands'
-import { REGISTRY_MOCK_CREDENTIALS, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
+import { getRegistryMockToken, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import type { ProjectManifest } from '@pnpm/types'
 import { filterProjectsBySelectorObjectsFromDir } from '@pnpm/workspace.projects-filter'
 import crossSpawn from 'cross-spawn'
@@ -16,7 +16,7 @@ import { checkPkgExists, DEFAULT_OPTS } from './utils/index.js'
 
 const CONFIG_BY_URI = {
   [`//localhost:${REGISTRY_MOCK_PORT}/`]: {
-    '@': { basicAuth: REGISTRY_MOCK_CREDENTIALS },
+    '@': { authToken: getRegistryMockToken() },
   },
 }
 

--- a/pnpm11/testing/registry-mock/src/index.ts
+++ b/pnpm11/testing/registry-mock/src/index.ts
@@ -12,9 +12,26 @@ export const REGISTRY_MOCK_CREDENTIALS = {
 
 const REGISTRY_URL = `http://localhost:${REGISTRY_MOCK_PORT}/`
 
-const AUTH_HEADER = `Basic ${Buffer.from(
-  `${REGISTRY_MOCK_CREDENTIALS.username}:${REGISTRY_MOCK_CREDENTIALS.password}`
-).toString('base64')}`
+/**
+ * The bearer token the with-registry jest globalSetup minted for the test user
+ * and published as `REGISTRY_MOCK_TOKEN`.
+ *
+ * pnpr only honors `Authorization: Bearer` credentials on requests — it rejects
+ * HTTP Basic (`_auth`) since the bearer-only auth change. So any test that
+ * authenticates to the mock registry (publishing, setting a dist-tag, etc. on a
+ * `publish: $authenticated` package) must send this token rather than Basic
+ * credentials. Throws if the with-registry preset hasn't run.
+ */
+export function getRegistryMockToken (): string {
+  const token = process.env.REGISTRY_MOCK_TOKEN
+  if (!token) {
+    throw new Error(
+      'REGISTRY_MOCK_TOKEN is not set — the registry mock auth token is unknown. ' +
+      'Tests that authenticate to the registry mock must run under the with-registry jest preset.'
+    )
+  }
+  return token
+}
 
 export interface AddDistTagOptions {
   package: string
@@ -35,7 +52,7 @@ export async function addDistTag (opts: AddDistTagOptions): Promise<void> {
     version: opts.version,
     distTag: opts.distTag,
     registryUrl: REGISTRY_URL,
-    authHeader: AUTH_HEADER,
+    authHeader: `Bearer ${getRegistryMockToken()}`,
     fetchFromRegistry: createFetchFromRegistry({}),
   })
 }

--- a/pnpm11/testing/registry-mock/src/index.ts
+++ b/pnpm11/testing/registry-mock/src/index.ts
@@ -13,14 +13,13 @@ export const REGISTRY_MOCK_CREDENTIALS = {
 const REGISTRY_URL = `http://localhost:${REGISTRY_MOCK_PORT}/`
 
 /**
- * The bearer token the with-registry jest globalSetup minted for the test user
- * and published as `REGISTRY_MOCK_TOKEN`.
+ * The bearer token the with-registry jest globalSetup mints for the test user
+ * and publishes as `REGISTRY_MOCK_TOKEN`.
  *
- * pnpr only honors `Authorization: Bearer` credentials on requests — it rejects
- * HTTP Basic (`_auth`) since the bearer-only auth change. So any test that
- * authenticates to the mock registry (publishing, setting a dist-tag, etc. on a
- * `publish: $authenticated` package) must send this token rather than Basic
- * credentials. Throws if the with-registry preset hasn't run.
+ * pnpr honors only `Authorization: Bearer` credentials on requests; HTTP Basic
+ * (`_auth`) resolves to anonymous. So any test that authenticates to the mock
+ * registry (publishing, setting a dist-tag, etc. on a `publish: $authenticated`
+ * package) must send this token. Throws if the with-registry preset hasn't run.
  */
 export function getRegistryMockToken (): string {
   const token = process.env.REGISTRY_MOCK_TOKEN


### PR DESCRIPTION
## Summary

CI on Windows test chunks was failing with ~46 tests red, all tracing to a single cause:

```
You must be logged in to set dist-tag "latest" on packages.
Authentication required for package "@pnpm.e2e/..."   → HTTP 401
```

The mock registry is now **pnpr**, and `perf(pnpr): require bearer tokens and drop request-time Basic auth` made pnpr reject HTTP Basic (`_auth`) on requests — any non-`Bearer` credential resolves to *anonymous*. But several TypeScript test helpers still authenticated with Basic, so every test that publishes, sets a dist-tag, deprecates, or unpublishes against pnpr got 401. Because many of those calls run at `beforeAll`/module scope, the setup failure cascaded into whole files failing.

It looked intermittent only because `main` reuses a pre-built pnpr binary that predates the bearer-only change; any PR that rebuilds pnpr (this one's lineage does) gets the bearer-only server and the Basic helpers break. The `with-registry` jest globalSetup already mints a bearer token and exposes it as `REGISTRY_MOCK_TOKEN` — the helpers just weren't using it.

This makes the test auth deterministic against bearer-only pnpr:

- `@pnpm/testing.registry-mock`: add `getRegistryMockToken()` and switch `addDistTag()` from a hardcoded Basic header to `Bearer <token>`.
- Convert the live-registry `configByUri` in the **publish / recursivePublish / batchPublish / deprecate / dist-tag / unpublish** suites from `basicAuth: REGISTRY_MOCK_CREDENTIALS` to `authToken: getRegistryMockToken()`, matching the token-based tests already green in those same files.
- The two `install/auth.ts` tests that specifically cover pnpm's own Basic `_auth` **client** support can no longer use pnpr directly (it won't accept Basic). They now run against a small local registry proxy that enforces Basic auth and forwards to pnpr with a bearer token — keeping that coverage intact.

Verified locally against a freshly built bearer-only pnpr: `dist-tag.ts` passes fully (covers publish + dist-tag with a token), `resolutionMode.ts` passes (covers `addDistTag`), and `install/auth.ts` passes (Basic proxy). Related to the CI failure on pnpm/pnpm#12559.

## Squash Commit Body

```text
test: authenticate to the pnpr registry mock with bearer tokens

pnpr no longer accepts HTTP Basic (`_auth`) on requests, so test helpers
that authenticated with Basic credentials started returning 401 once CI
ran against a bearer-only pnpr build.

Switch the registry-mock `addDistTag` helper and the
publish/deprecate/dist-tag/unpublish suites to the bearer token that the
with-registry globalSetup already mints (`REGISTRY_MOCK_TOKEN`), exposed
through a new `getRegistryMockToken()` helper.

The two install/auth.ts tests that cover pnpm's own Basic `_auth` client
support now run against a small local registry proxy that enforces Basic
auth and forwards to pnpr with a bearer token, so that coverage is kept.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. *(Test-only change to TypeScript test helpers; no pacquet port needed.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. *(Test-only; no published-package behavior changes, so no changeset.)*
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry authentication handling in test scenarios, including correct proxying and authorization failures (401) when credentials are missing or incorrect.
  * Enhanced install/install-metadata handling to ensure registry URLs are rewritten correctly for JSON payloads while binary responses stream through properly.

* **New Features**
  * Added token-based authentication helper support for registry-mock interactions.

* **Tests**
  * Updated publish, deprecate, unpublish, and dist-tag coverage to use token-based registry access instead of basic-auth credentials.
  * Extended install authentication coverage to run through a basic-auth enforced proxy setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->