### PR TITLE
feat(pacquet): port audit command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3618,6 +3618,7 @@ dependencies = [
  "pnpr",
  "pretty_assertions",
  "rayon",
+ "reqwest 0.13.4",
  "rmp-serde",
  "serde",
  "serde-saphyr",

--- a/pacquet/crates/cli/Cargo.toml
+++ b/pacquet/crates/cli/Cargo.toml
@@ -58,6 +58,7 @@ miette               = { workspace = true }
 owo-colors.workspace = true
 pipe-trait           = { workspace = true }
 rayon                = { workspace = true }
+reqwest              = { workspace = true }
 rmp-serde            = { workspace = true }
 serde                = { workspace = true }
 serde_json           = { workspace = true }

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -1,5 +1,6 @@
 pub mod add;
 pub mod approve_builds;
+pub mod audit;
 pub mod cache;
 pub mod cat_file;
 pub mod cat_index;
@@ -34,6 +35,7 @@ pub mod why;
 use crate::{State, config_deps, config_overrides::ConfigOverrides};
 use add::AddArgs;
 use approve_builds::ApproveBuildsArgs;
+use audit::{AuditArgs, AuditOutcome};
 use cache::CacheCommand;
 use cat_file::CatFileArgs;
 use cat_index::CatIndexArgs;
@@ -166,6 +168,8 @@ pub enum CliCommand {
     Update(UpdateArgs),
     /// Check for outdated packages
     Outdated(OutdatedArgs),
+    /// Checks for known security issues with the installed packages.
+    Audit(AuditArgs),
     /// Shows the packages that depend on `pkg`
     Why(WhyArgs),
     /// Rebuild a package.
@@ -405,6 +409,15 @@ impl CliArgs {
                 let command_state = state(false)?;
                 Box::pin(async move {
                     if args.run(command_state).await? == OutdatedOutcome::Outdated {
+                        std::process::exit(1);
+                    }
+                    Ok(())
+                })
+            }
+            CliCommand::Audit(args) => {
+                let command_state = state(true)?;
+                Box::pin(async move {
+                    if args.run(command_state).await? == AuditOutcome::Vulnerable {
                         std::process::exit(1);
                     }
                     Ok(())

--- a/pacquet/crates/cli/src/cli_args/audit.rs
+++ b/pacquet/crates/cli/src/cli_args/audit.rs
@@ -336,8 +336,9 @@ async fn audit(
         .expect("audit request is a map of package names to version strings");
     let authorization = config.auth_headers.for_url(&registry);
     let retry_opts = retry_opts_from_config(config);
-    let request_url = audit_url.clone();
-    let (_, response) = send_with_retry(http_client, &audit_url, retry_opts, |client| {
+    let request_url = redact_url_userinfo(&audit_url);
+    let display_audit_url = request_url.clone();
+    let (_, response) = send_with_retry(http_client, &display_audit_url, retry_opts, |client| {
         let mut request =
             client.post(&request_url).header("content-type", "application/json").body(body.clone());
         if let Some(value) = &authorization {
@@ -346,30 +347,30 @@ async fn audit(
         request
     })
     .await
-    .map_err(|source| AuditError::Network { url: audit_url.clone(), source })?;
+    .map_err(|source| AuditError::Network { url: display_audit_url.clone(), source })?;
 
     let status = response.status().as_u16();
     let raw_body = response
         .text()
         .await
-        .map_err(|source| AuditError::Network { url: audit_url.clone(), source })?;
+        .map_err(|source| AuditError::Network { url: display_audit_url.clone(), source })?;
     match status {
         200 => {
             let parsed: serde_json::Value =
                 serde_json::from_str(&raw_body).map_err(|source| AuditError::InvalidJson {
-                    url: audit_url.clone(),
+                    url: display_audit_url.clone(),
                     reason: source.to_string(),
                     body: truncate_chars(&raw_body, 500),
                 })?;
             let bulk: BTreeMap<String, Vec<RawBulkAdvisory>> =
                 serde_json::from_value(parsed.clone()).map_err(|_| AuditError::UnexpectedBody {
-                    url: audit_url.clone(),
+                    url: display_audit_url.clone(),
                     body: truncate_chars(&parsed.to_string(), 500),
                 })?;
             Ok(bulk_response_to_audit_report(bulk, &audit_request, lockfile, env_lockfile, include))
         }
-        404 => Err(AuditError::EndpointNotExists { url: audit_url }),
-        _ => Err(AuditError::BadStatus { url: audit_url, status, body: raw_body }),
+        404 => Err(AuditError::EndpointNotExists { url: display_audit_url }),
+        _ => Err(AuditError::BadStatus { url: display_audit_url, status, body: raw_body }),
     }
 }
 
@@ -1203,6 +1204,18 @@ fn normalize_ghsa_id(ghsa_id: &str) -> String {
 
 fn normalize_registry(registry: &str) -> String {
     if registry.ends_with('/') { registry.to_string() } else { format!("{registry}/") }
+}
+
+fn redact_url_userinfo(url: &str) -> String {
+    let Ok(mut parsed) = reqwest::Url::parse(url) else {
+        return url.to_string();
+    };
+    if parsed.username().is_empty() && parsed.password().is_none() {
+        return url.to_string();
+    }
+    let _ = parsed.set_username("");
+    let _ = parsed.set_password(None);
+    parsed.to_string()
 }
 
 fn truncate_chars(value: &str, max_chars: usize) -> String {

--- a/pacquet/crates/cli/src/cli_args/audit.rs
+++ b/pacquet/crates/cli/src/cli_args/audit.rs
@@ -1088,14 +1088,18 @@ fn filter_ignored_advisories(
         .audit_config
         .ignore_ghsas
         .iter()
-        .map(|ghsa| normalize_ghsa_id(ghsa))
+        .filter_map(|ghsa| {
+            let ghsa_id = normalize_ghsa_id(ghsa);
+            (!ghsa_id.is_empty()).then_some(ghsa_id)
+        })
         .collect::<HashSet<_>>();
     if ignore_set.is_empty() {
         return AuditVulnerabilityCounts::default();
     }
     let mut ignored = AuditVulnerabilityCounts::default();
     report.advisories.retain(|_, advisory| {
-        if !ignore_set.contains(&normalize_ghsa_id(&advisory.github_advisory_id)) {
+        let ghsa_id = normalize_ghsa_id(&advisory.github_advisory_id);
+        if ghsa_id.is_empty() || !ignore_set.contains(&ghsa_id) {
             return true;
         }
         ignored.increment(advisory.severity);

--- a/pacquet/crates/cli/src/cli_args/audit.rs
+++ b/pacquet/crates/cli/src/cli_args/audit.rs
@@ -1,0 +1,1238 @@
+use crate::State;
+use clap::{Args, ValueEnum};
+use derive_more::{Display, Error};
+use miette::{Diagnostic, IntoDiagnostic};
+use node_semver::{Range, Version};
+use owo_colors::{OwoColorize, Stream};
+use pacquet_config::{AuditLevel as ConfigAuditLevel, Config};
+use pacquet_lockfile::{
+    EnvLockfile, ImporterDepVersion, Lockfile, PackageKey, PkgName, ResolvedDependencyMap,
+    SnapshotDepRef, SnapshotEntry, SpecifierAndResolution,
+};
+use pacquet_network::{RetryOpts, send_with_retry};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    io::Write,
+    rc::Rc,
+    time::Duration,
+};
+
+const MAX_PATHS_COUNT: usize = 3;
+const MAX_PATHS_PER_FINDING: usize = 100;
+
+#[derive(Debug, Args)]
+pub struct AuditArgs {
+    /// Output audit report in JSON format.
+    #[clap(long)]
+    pub json: bool,
+
+    /// Only print advisories with severity greater than or equal to this level.
+    #[clap(long = "audit-level", value_enum)]
+    pub audit_level: Option<AuditLevelArg>,
+
+    /// --prod, --dev, and --no-optional.
+    #[clap(flatten)]
+    pub dependency_options: AuditDependencyOptions,
+
+    /// Use exit code 0 if the registry responds with an error.
+    #[clap(long = "ignore-registry-errors")]
+    pub ignore_registry_errors: bool,
+
+    /// Audit subcommand. `audit signatures` has not been ported yet.
+    pub params: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "lowercase")]
+pub enum AuditLevelArg {
+    Info,
+    Low,
+    Moderate,
+    High,
+    Critical,
+}
+
+impl From<AuditLevelArg> for ConfigAuditLevel {
+    fn from(value: AuditLevelArg) -> Self {
+        match value {
+            AuditLevelArg::Info => ConfigAuditLevel::Info,
+            AuditLevelArg::Low => ConfigAuditLevel::Low,
+            AuditLevelArg::Moderate => ConfigAuditLevel::Moderate,
+            AuditLevelArg::High => ConfigAuditLevel::High,
+            AuditLevelArg::Critical => ConfigAuditLevel::Critical,
+        }
+    }
+}
+
+#[derive(Debug, Args)]
+pub struct AuditDependencyOptions {
+    /// Only audit "dependencies" and "optionalDependencies".
+    #[clap(short = 'P', long, visible_alias = "production")]
+    prod: bool,
+    /// Only audit "devDependencies".
+    #[clap(short = 'D', long)]
+    dev: bool,
+    /// Don't audit "optionalDependencies".
+    #[clap(long)]
+    no_optional: bool,
+}
+
+impl AuditDependencyOptions {
+    fn include(&self) -> Include {
+        let mut dependencies = true;
+        let mut dev_dependencies = true;
+        let mut optional_dependencies = !self.no_optional;
+        if self.prod {
+            dev_dependencies = false;
+        } else if self.dev {
+            dependencies = false;
+            optional_dependencies = false;
+        }
+        Include { dependencies, dev_dependencies, optional_dependencies }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuditOutcome {
+    Clean,
+    Vulnerable,
+}
+
+impl AuditArgs {
+    pub async fn run(self, state: State) -> miette::Result<AuditOutcome> {
+        if let Some(subcommand) = self.params.first() {
+            return if subcommand == "signatures" {
+                Err(miette::miette!(
+                    "`pacquet audit signatures` is not supported yet; registry signature verification has not been ported to pacquet."
+                ))
+            } else {
+                Err(AuditError::UnknownSubcommand {
+                    subcommand: self.params.iter().take(2).cloned().collect::<Vec<_>>().join(" "),
+                }
+                .into())
+            };
+        }
+
+        let lockfile = state
+            .lockfile
+            .get()
+            .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
+        let Some(lockfile) = lockfile else {
+            return Err(AuditError::NoLockfile.into());
+        };
+        let lockfile_dir = state.manifest.path().parent().unwrap_or_else(|| state.manifest.path());
+        let env_lockfile_dir = state.config.workspace_dir.as_deref().unwrap_or(lockfile_dir);
+        let env_lockfile = EnvLockfile::read(env_lockfile_dir)
+            .map_err(|err| miette::Report::new(err).wrap_err("load the env lockfile"))?;
+
+        let include = self.dependency_options.include();
+        let audit_level = self
+            .audit_level
+            .map(ConfigAuditLevel::from)
+            .or(state.config.audit_level)
+            .unwrap_or(ConfigAuditLevel::Low);
+        let mut report = match audit(
+            lockfile,
+            env_lockfile.as_ref(),
+            include,
+            state.config,
+            state.http_client.as_ref(),
+        )
+        .await
+        {
+            Ok(report) => report,
+            Err(err) if self.ignore_registry_errors => {
+                print!("{err}");
+                let _ = std::io::stdout().flush();
+                return Ok(AuditOutcome::Clean);
+            }
+            Err(err) => return Err(err.into()),
+        };
+
+        let total_vulnerability_count = report.metadata.vulnerabilities.total();
+        let ignored = filter_ignored_advisories(&mut report, state.config);
+
+        let output = if self.json {
+            render_json_report(&report, audit_level)?
+        } else {
+            render_text_report(&report, audit_level, total_vulnerability_count, &ignored)
+        };
+        print!("{output}");
+        let _ = std::io::stdout().flush();
+
+        Ok(
+            if report
+                .advisories
+                .values()
+                .any(|advisory| severity_number(advisory.severity) >= severity_number(audit_level))
+            {
+                AuditOutcome::Vulnerable
+            } else {
+                AuditOutcome::Clean
+            },
+        )
+    }
+}
+
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+enum AuditError {
+    #[display("No pnpm-lock.yaml found: Cannot audit a project without a lockfile")]
+    #[diagnostic(code(ERR_PNPM_AUDIT_NO_LOCKFILE))]
+    NoLockfile,
+
+    #[display("Unknown audit subcommand: {subcommand}")]
+    #[diagnostic(code(ERR_PNPM_AUDIT_UNKNOWN_SUBCOMMAND))]
+    UnknownSubcommand { subcommand: String },
+
+    #[display("Failed to request the audit endpoint (at {url}): {source}")]
+    #[diagnostic(code(ERR_PNPM_AUDIT_BAD_RESPONSE))]
+    Network {
+        url: String,
+        #[error(source)]
+        source: reqwest::Error,
+    },
+
+    #[display(
+        "The audit endpoint (at {url}) returned invalid JSON: {reason}. Response body: {body}"
+    )]
+    #[diagnostic(code(ERR_PNPM_AUDIT_BAD_RESPONSE))]
+    InvalidJson { url: String, reason: String, body: String },
+
+    #[display(
+        "The audit endpoint (at {url}) returned an unexpected body. Expected an object keyed by package name; got: {body}"
+    )]
+    #[diagnostic(code(ERR_PNPM_AUDIT_BAD_RESPONSE))]
+    UnexpectedBody { url: String, body: String },
+
+    #[display("The audit endpoint (at {url}) doesn't exist.")]
+    #[diagnostic(
+        code(ERR_PNPM_AUDIT_ENDPOINT_NOT_EXISTS),
+        help(
+            "This issue is probably because you are using a private npm registry and that endpoint doesn't have an implementation of audit."
+        )
+    )]
+    EndpointNotExists { url: String },
+
+    #[display("The audit endpoint (at {url}) responded with {status}: {body}")]
+    #[diagnostic(code(ERR_PNPM_AUDIT_BAD_RESPONSE))]
+    BadStatus { url: String, status: u16, body: String },
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AuditReport {
+    advisories: BTreeMap<String, AuditAdvisory>,
+    metadata: AuditMetadata,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AuditMetadata {
+    vulnerabilities: AuditVulnerabilityCounts,
+    dependencies: usize,
+    #[serde(rename = "devDependencies")]
+    dev_dependencies: usize,
+    #[serde(rename = "optionalDependencies")]
+    optional_dependencies: usize,
+    #[serde(rename = "totalDependencies")]
+    total_dependencies: usize,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+struct AuditVulnerabilityCounts {
+    info: usize,
+    low: usize,
+    moderate: usize,
+    high: usize,
+    critical: usize,
+}
+
+impl AuditVulnerabilityCounts {
+    fn increment(&mut self, severity: ConfigAuditLevel) {
+        match severity {
+            ConfigAuditLevel::Info => self.info += 1,
+            ConfigAuditLevel::Low => self.low += 1,
+            ConfigAuditLevel::Moderate => self.moderate += 1,
+            ConfigAuditLevel::High => self.high += 1,
+            ConfigAuditLevel::Critical => self.critical += 1,
+        }
+    }
+
+    fn total(&self) -> usize {
+        self.info + self.low + self.moderate + self.high + self.critical
+    }
+
+    fn entries(&self) -> [(ConfigAuditLevel, usize); 5] {
+        [
+            (ConfigAuditLevel::Info, self.info),
+            (ConfigAuditLevel::Low, self.low),
+            (ConfigAuditLevel::Moderate, self.moderate),
+            (ConfigAuditLevel::High, self.high),
+            (ConfigAuditLevel::Critical, self.critical),
+        ]
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AuditAdvisory {
+    findings: Vec<AuditFinding>,
+    id: u64,
+    title: String,
+    module_name: String,
+    vulnerable_versions: String,
+    patched_versions: Option<String>,
+    severity: ConfigAuditLevel,
+    cwe: String,
+    github_advisory_id: String,
+    url: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AuditFinding {
+    version: String,
+    paths: Vec<String>,
+    dev: bool,
+    optional: bool,
+    bundled: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawBulkAdvisory {
+    id: Option<serde_json::Value>,
+    url: Option<String>,
+    title: Option<String>,
+    severity: Option<String>,
+    vulnerable_versions: String,
+    cwe: Option<Cwe>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum Cwe {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl Cwe {
+    fn into_string(self) -> String {
+        match self {
+            Cwe::One(value) => value,
+            Cwe::Many(values) => values.join(", "),
+        }
+    }
+}
+
+async fn audit(
+    lockfile: &Lockfile,
+    env_lockfile: Option<&EnvLockfile>,
+    include: Include,
+    config: &Config,
+    http_client: &pacquet_network::ThrottledClient,
+) -> Result<AuditReport, AuditError> {
+    let audit_request = lockfile_to_audit_request(lockfile, env_lockfile, include);
+    let registry = normalize_registry(&config.registry);
+    let audit_url = format!("{registry}-/npm/v1/security/advisories/bulk");
+    let body = serde_json::to_vec(&audit_request.request)
+        .expect("audit request is a map of package names to version strings");
+    let authorization = config.auth_headers.for_url(&registry);
+    let retry_opts = retry_opts_from_config(config);
+    let request_url = audit_url.clone();
+    let (_, response) = send_with_retry(http_client, &audit_url, retry_opts, |client| {
+        let mut request =
+            client.post(&request_url).header("content-type", "application/json").body(body.clone());
+        if let Some(value) = &authorization {
+            request = request.header("authorization", value);
+        }
+        request
+    })
+    .await
+    .map_err(|source| AuditError::Network { url: audit_url.clone(), source })?;
+
+    let status = response.status().as_u16();
+    let raw_body = response
+        .text()
+        .await
+        .map_err(|source| AuditError::Network { url: audit_url.clone(), source })?;
+    match status {
+        200 => {
+            let parsed: serde_json::Value =
+                serde_json::from_str(&raw_body).map_err(|source| AuditError::InvalidJson {
+                    url: audit_url.clone(),
+                    reason: source.to_string(),
+                    body: truncate_chars(&raw_body, 500),
+                })?;
+            let bulk: BTreeMap<String, Vec<RawBulkAdvisory>> =
+                serde_json::from_value(parsed.clone()).map_err(|_| AuditError::UnexpectedBody {
+                    url: audit_url.clone(),
+                    body: truncate_chars(&parsed.to_string(), 500),
+                })?;
+            Ok(bulk_response_to_audit_report(bulk, &audit_request, lockfile, env_lockfile, include))
+        }
+        404 => Err(AuditError::EndpointNotExists { url: audit_url }),
+        _ => Err(AuditError::BadStatus { url: audit_url, status, body: raw_body }),
+    }
+}
+
+fn retry_opts_from_config(config: &Config) -> RetryOpts {
+    RetryOpts {
+        retries: config.fetch_retries,
+        factor: config.fetch_retry_factor,
+        min_timeout: Duration::from_millis(config.fetch_retry_mintimeout),
+        max_timeout: Duration::from_millis(config.fetch_retry_maxtimeout),
+    }
+}
+
+fn bulk_response_to_audit_report(
+    bulk: BTreeMap<String, Vec<RawBulkAdvisory>>,
+    audit_request: &AuditIndexRequest,
+    lockfile: &Lockfile,
+    env_lockfile: Option<&EnvLockfile>,
+    include: Include,
+) -> AuditReport {
+    let vulnerable_names: HashSet<String> = bulk.keys().cloned().collect();
+    let audit_path_index = if vulnerable_names.is_empty() {
+        AuditPathIndex::default()
+    } else {
+        build_audit_path_index(lockfile, env_lockfile, &vulnerable_names, include)
+    };
+    let mut advisories = BTreeMap::new();
+    let mut vulnerabilities = AuditVulnerabilityCounts::default();
+
+    for (module_name, package_advisories) in bulk {
+        let by_version = audit_path_index.get(&module_name);
+        for raw in package_advisories {
+            let Some(id) = raw.id.as_ref().and_then(serde_json::Value::as_u64) else {
+                continue;
+            };
+            let Some(severity) = raw.severity.as_deref().and_then(parse_audit_level) else {
+                continue;
+            };
+            let findings = build_findings(&raw.vulnerable_versions, by_version);
+            if findings.is_empty() {
+                continue;
+            }
+            let advisory = normalize_advisory(raw, id, module_name.clone(), severity, findings);
+            vulnerabilities.increment(severity);
+            advisories.insert(id.to_string(), advisory);
+        }
+    }
+
+    AuditReport {
+        advisories,
+        metadata: AuditMetadata {
+            vulnerabilities,
+            dependencies: audit_request.dependencies,
+            dev_dependencies: audit_request.dev_dependencies,
+            optional_dependencies: audit_request.optional_dependencies,
+            total_dependencies: audit_request.total_dependencies,
+        },
+    }
+}
+
+fn build_findings(
+    vulnerable_versions: &str,
+    by_version: Option<&BTreeMap<String, PathInfo>>,
+) -> Vec<AuditFinding> {
+    let Some(by_version) = by_version else { return Vec::new() };
+    by_version
+        .iter()
+        .filter(|(version, _)| satisfies_safe(version, vulnerable_versions))
+        .map(|(version, info)| AuditFinding {
+            version: version.clone(),
+            paths: info.paths.clone(),
+            dev: info.dev,
+            optional: info.optional,
+            bundled: false,
+        })
+        .collect()
+}
+
+fn normalize_advisory(
+    raw: RawBulkAdvisory,
+    id: u64,
+    module_name: String,
+    severity: ConfigAuditLevel,
+    findings: Vec<AuditFinding>,
+) -> AuditAdvisory {
+    let url = raw.url.unwrap_or_default();
+    AuditAdvisory {
+        findings,
+        id,
+        title: raw.title.unwrap_or_default(),
+        module_name,
+        vulnerable_versions: raw.vulnerable_versions.clone(),
+        patched_versions: infer_patched_versions(&raw.vulnerable_versions),
+        severity,
+        cwe: raw.cwe.map_or_else(String::new, Cwe::into_string),
+        github_advisory_id: derive_github_advisory_id(&url),
+        url,
+    }
+}
+
+#[derive(Debug, Default)]
+struct AuditIndexRequest {
+    request: BTreeMap<String, Vec<String>>,
+    total_dependencies: usize,
+    dependencies: usize,
+    dev_dependencies: usize,
+    optional_dependencies: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Include {
+    dependencies: bool,
+    dev_dependencies: bool,
+    optional_dependencies: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DepKind {
+    Prod,
+    Dev,
+    Optional,
+}
+
+#[derive(Debug, Clone)]
+struct Edge {
+    key: PackageKey,
+}
+
+#[derive(Debug)]
+struct GraphImporter {
+    path_segment: String,
+    roots: Vec<(DepKind, Edge)>,
+}
+
+#[derive(Debug)]
+struct AuditGraph<'a> {
+    importers: Vec<GraphImporter>,
+    snapshots: &'a HashMap<PackageKey, SnapshotEntry>,
+}
+
+impl<'a> AuditGraph<'a> {
+    fn main(lockfile: &'a Lockfile) -> Self {
+        let empty = empty_snapshots();
+        let snapshots = lockfile.snapshots.as_ref().unwrap_or(empty);
+        let importers = lockfile
+            .importers
+            .iter()
+            .map(|(id, importer)| GraphImporter {
+                path_segment: id.replace('/', "__"),
+                roots: importer_roots(importer),
+            })
+            .collect();
+        Self { importers, snapshots }
+    }
+
+    fn env(env_lockfile: &'a EnvLockfile) -> Self {
+        let importer = env_lockfile.importers.get(EnvLockfile::ROOT_IMPORTER_KEY);
+        let mut importers = Vec::new();
+        if let Some(importer) = importer {
+            let config_roots = env_roots(&importer.config_dependencies);
+            if !config_roots.is_empty() {
+                importers.push(GraphImporter {
+                    path_segment: "configDependencies".to_string(),
+                    roots: config_roots.into_iter().map(|edge| (DepKind::Prod, edge)).collect(),
+                });
+            }
+            if let Some(package_manager_dependencies) = &importer.package_manager_dependencies {
+                let package_manager_roots = env_roots(package_manager_dependencies);
+                if !package_manager_roots.is_empty() {
+                    importers.push(GraphImporter {
+                        path_segment: "packageManagerDependencies".to_string(),
+                        roots: package_manager_roots
+                            .into_iter()
+                            .map(|edge| (DepKind::Prod, edge))
+                            .collect(),
+                    });
+                }
+            }
+        }
+        Self { importers, snapshots: &env_lockfile.snapshots }
+    }
+
+    fn children(&self, key: &PackageKey, include_optional_edges: bool) -> Vec<Edge> {
+        let Some(snapshot) = self.snapshots.get(key) else { return Vec::new() };
+        let mut children = Vec::new();
+        append_snapshot_edges(&mut children, snapshot.dependencies.as_ref());
+        if include_optional_edges {
+            append_snapshot_edges(&mut children, snapshot.optional_dependencies.as_ref());
+        }
+        children
+    }
+}
+
+fn empty_snapshots() -> &'static HashMap<PackageKey, SnapshotEntry> {
+    use std::sync::OnceLock;
+
+    static EMPTY: OnceLock<HashMap<PackageKey, SnapshotEntry>> = OnceLock::new();
+    EMPTY.get_or_init(HashMap::new)
+}
+
+fn importer_roots(importer: &pacquet_lockfile::ProjectSnapshot) -> Vec<(DepKind, Edge)> {
+    let mut roots = Vec::new();
+    append_importer_edges(&mut roots, DepKind::Prod, importer.dependencies.as_ref());
+    append_importer_edges(&mut roots, DepKind::Dev, importer.dev_dependencies.as_ref());
+    append_importer_edges(&mut roots, DepKind::Optional, importer.optional_dependencies.as_ref());
+    roots
+}
+
+fn append_importer_edges(
+    roots: &mut Vec<(DepKind, Edge)>,
+    kind: DepKind,
+    deps: Option<&ResolvedDependencyMap>,
+) {
+    let Some(deps) = deps else { return };
+    for (name, spec) in deps {
+        if let Some(key) = spec.version.resolved_key(name) {
+            roots.push((kind, Edge { key }));
+        }
+    }
+}
+
+fn env_roots(deps: &BTreeMap<String, SpecifierAndResolution>) -> Vec<Edge> {
+    deps.iter()
+        .filter_map(|(name, spec)| {
+            let name = name.parse::<PkgName>().ok()?;
+            let version = spec.version.parse::<ImporterDepVersion>().ok()?;
+            version.resolved_key(&name).map(|key| Edge { key })
+        })
+        .collect()
+}
+
+fn append_snapshot_edges(
+    children: &mut Vec<Edge>,
+    deps: Option<&HashMap<PkgName, SnapshotDepRef>>,
+) {
+    let Some(deps) = deps else { return };
+    for (name, dep_ref) in deps {
+        if let Some(key) = dep_ref.resolve(name) {
+            children.push(Edge { key });
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DepClass {
+    dev_only: bool,
+    optional_only: bool,
+}
+
+fn classify_graph(graph: &AuditGraph<'_>, include: Include) -> HashMap<PackageKey, DepClass> {
+    let dev_include = Include {
+        dependencies: false,
+        dev_dependencies: include.dev_dependencies,
+        optional_dependencies: false,
+    };
+    let non_dev_include = Include {
+        dependencies: include.dependencies,
+        dev_dependencies: false,
+        optional_dependencies: include.optional_dependencies,
+    };
+    let dev_reachable = walk_reachable(graph, dev_include, include.optional_dependencies);
+    let non_dev_reachable = walk_reachable(graph, non_dev_include, include.optional_dependencies);
+    let optional_only = collect_optional_only_keys(graph, include);
+    dev_reachable
+        .union(&non_dev_reachable)
+        .cloned()
+        .map(|key| {
+            let class = DepClass {
+                dev_only: dev_reachable.contains(&key) && !non_dev_reachable.contains(&key),
+                optional_only: optional_only.contains(&key),
+            };
+            (key, class)
+        })
+        .collect()
+}
+
+fn collect_optional_only_keys(graph: &AuditGraph<'_>, include: Include) -> HashSet<PackageKey> {
+    if !include.optional_dependencies {
+        return HashSet::new();
+    }
+    let with_optional = walk_reachable(graph, include, true);
+    let without_optional =
+        walk_reachable(graph, Include { optional_dependencies: false, ..include }, false);
+    with_optional.difference(&without_optional).cloned().collect()
+}
+
+fn walk_reachable(
+    graph: &AuditGraph<'_>,
+    include: Include,
+    include_optional_edges: bool,
+) -> HashSet<PackageKey> {
+    let mut seen = HashSet::new();
+    let mut stack =
+        selected_root_edges(graph, include).map(|edge| edge.key.clone()).collect::<Vec<_>>();
+    while let Some(key) = stack.pop() {
+        if !seen.insert(key.clone()) {
+            continue;
+        }
+        stack.extend(graph.children(&key, include_optional_edges).into_iter().map(|edge| edge.key));
+    }
+    seen
+}
+
+fn selected_root_edges<'a>(
+    graph: &'a AuditGraph<'a>,
+    include: Include,
+) -> impl Iterator<Item = &'a Edge> {
+    graph.importers.iter().flat_map(move |importer| {
+        importer
+            .roots
+            .iter()
+            .filter(move |(kind, _)| root_included(*kind, include))
+            .map(|(_, edge)| edge)
+    })
+}
+
+fn root_included(kind: DepKind, include: Include) -> bool {
+    match kind {
+        DepKind::Prod => include.dependencies,
+        DepKind::Dev => include.dev_dependencies,
+        DepKind::Optional => include.optional_dependencies,
+    }
+}
+
+fn lockfile_to_audit_request(
+    lockfile: &Lockfile,
+    env_lockfile: Option<&EnvLockfile>,
+    include: Include,
+) -> AuditIndexRequest {
+    let mut request = AuditRequestBuilder::default();
+    let main = AuditGraph::main(lockfile);
+    request.register_graph(&main, include);
+    if let Some(env_lockfile) = env_lockfile {
+        let env = AuditGraph::env(env_lockfile);
+        request.register_graph(&env, include);
+    }
+    request.finish()
+}
+
+#[derive(Default)]
+struct AuditRequestBuilder {
+    request: BTreeMap<String, Vec<String>>,
+    states_by_name: BTreeMap<String, BTreeMap<String, VersionState>>,
+    total_dependencies: usize,
+    dependencies: usize,
+    dev_dependencies: usize,
+    optional_dependencies: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct VersionState {
+    dev_only: bool,
+    optional_only: bool,
+}
+
+impl AuditRequestBuilder {
+    fn register_graph(&mut self, graph: &AuditGraph<'_>, include: Include) {
+        let classes = classify_graph(graph, include);
+        let mut seen = HashSet::new();
+        let mut stack =
+            selected_root_edges(graph, include).map(|edge| edge.key.clone()).collect::<Vec<_>>();
+        while let Some(key) = stack.pop() {
+            if !seen.insert(key.clone()) {
+                continue;
+            }
+            let class = classes
+                .get(&key)
+                .copied()
+                .unwrap_or(DepClass { dev_only: false, optional_only: false });
+            self.register_occurrence(&key, class);
+            stack.extend(
+                graph
+                    .children(&key, include.optional_dependencies)
+                    .into_iter()
+                    .map(|edge| edge.key),
+            );
+        }
+    }
+
+    fn register_occurrence(&mut self, key: &PackageKey, class: DepClass) {
+        let Some(version) = package_version(key) else { return };
+        let name = key.name.to_string();
+        let version_states = self.states_by_name.entry(name.clone()).or_default();
+        let Some(state) = version_states.get_mut(&version) else {
+            version_states.insert(
+                version.clone(),
+                VersionState { dev_only: class.dev_only, optional_only: class.optional_only },
+            );
+            self.request.entry(name).or_default().push(version);
+            self.total_dependencies += 1;
+            if class.dev_only {
+                self.dev_dependencies += 1;
+            }
+            if class.optional_only {
+                self.optional_dependencies += 1;
+            }
+            if !class.dev_only && !class.optional_only {
+                self.dependencies += 1;
+            }
+            return;
+        };
+        let was_production = !state.dev_only && !state.optional_only;
+        if state.dev_only && !class.dev_only {
+            state.dev_only = false;
+            self.dev_dependencies -= 1;
+        }
+        if state.optional_only && !class.optional_only {
+            state.optional_only = false;
+            self.optional_dependencies -= 1;
+        }
+        if !was_production && !state.dev_only && !state.optional_only {
+            self.dependencies += 1;
+        }
+    }
+
+    fn finish(self) -> AuditIndexRequest {
+        AuditIndexRequest {
+            request: self.request,
+            total_dependencies: self.total_dependencies,
+            dependencies: self.dependencies,
+            dev_dependencies: self.dev_dependencies,
+            optional_dependencies: self.optional_dependencies,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct PathInfo {
+    paths: Vec<String>,
+    dev: bool,
+    optional: bool,
+}
+
+type AuditPathIndex = BTreeMap<String, BTreeMap<String, PathInfo>>;
+
+fn build_audit_path_index(
+    lockfile: &Lockfile,
+    env_lockfile: Option<&EnvLockfile>,
+    vulnerable_names: &HashSet<String>,
+    include: Include,
+) -> AuditPathIndex {
+    let mut paths = AuditPathIndex::default();
+    let main = AuditGraph::main(lockfile);
+    walk_for_paths(&main, vulnerable_names, include, &mut paths);
+    if let Some(env_lockfile) = env_lockfile {
+        let env = AuditGraph::env(env_lockfile);
+        walk_for_paths(&env, vulnerable_names, include, &mut paths);
+    }
+    paths
+}
+
+#[derive(Debug)]
+struct TrailNode {
+    name: String,
+    parent: Option<Rc<TrailNode>>,
+}
+
+#[derive(Debug)]
+struct PathFrame {
+    key: PackageKey,
+    trail: Rc<TrailNode>,
+    children: Vec<Edge>,
+    next: usize,
+}
+
+fn walk_for_paths(
+    graph: &AuditGraph<'_>,
+    vulnerable_names: &HashSet<String>,
+    include: Include,
+    paths: &mut AuditPathIndex,
+) {
+    let classes = classify_graph(graph, include);
+    for importer in &graph.importers {
+        let importer_trail =
+            Rc::new(TrailNode { name: importer.path_segment.clone(), parent: None });
+        let mut in_trail = HashSet::new();
+        let mut stack: Vec<PathFrame> = Vec::new();
+        for (_, root) in importer.roots.iter().filter(|(kind, _)| root_included(*kind, include)) {
+            open_path_node(
+                graph,
+                root.key.clone(),
+                Rc::clone(&importer_trail),
+                vulnerable_names,
+                include,
+                &classes,
+                paths,
+                &mut in_trail,
+                &mut stack,
+            );
+            while let Some(frame) = stack.last_mut() {
+                if frame.next < frame.children.len() {
+                    let child = frame.children[frame.next].key.clone();
+                    let parent = Rc::clone(&frame.trail);
+                    frame.next += 1;
+                    open_path_node(
+                        graph,
+                        child,
+                        parent,
+                        vulnerable_names,
+                        include,
+                        &classes,
+                        paths,
+                        &mut in_trail,
+                        &mut stack,
+                    );
+                } else {
+                    let frame = stack.pop().expect("stack is non-empty");
+                    in_trail.remove(&frame.key);
+                }
+            }
+        }
+    }
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Path traversal carries independent graph, filter, classification, and output state without a useful grouping abstraction"
+)]
+fn open_path_node(
+    graph: &AuditGraph<'_>,
+    key: PackageKey,
+    parent_trail: Rc<TrailNode>,
+    vulnerable_names: &HashSet<String>,
+    include: Include,
+    classes: &HashMap<PackageKey, DepClass>,
+    paths: &mut AuditPathIndex,
+    in_trail: &mut HashSet<PackageKey>,
+    stack: &mut Vec<PathFrame>,
+) {
+    if in_trail.contains(&key) {
+        return;
+    }
+    let name = key.name.to_string();
+    let trail = Rc::new(TrailNode { name: name.clone(), parent: Some(parent_trail) });
+    if vulnerable_names.contains(&name)
+        && let Some(version) = package_version(&key)
+    {
+        let class = classes
+            .get(&key)
+            .copied()
+            .unwrap_or(DepClass { dev_only: false, optional_only: false });
+        record_path(
+            paths,
+            &name,
+            &version,
+            join_trail(&trail),
+            class.dev_only,
+            class.optional_only,
+        );
+    }
+    let children = graph.children(&key, include.optional_dependencies);
+    if children.is_empty() {
+        return;
+    }
+    in_trail.insert(key.clone());
+    stack.push(PathFrame { key, trail, children, next: 0 });
+}
+
+fn record_path(
+    paths: &mut AuditPathIndex,
+    name: &str,
+    version: &str,
+    joined: String,
+    is_dev: bool,
+    is_optional: bool,
+) {
+    let by_version = paths.entry(name.to_string()).or_default();
+    let info = by_version.entry(version.to_string()).or_insert_with(|| PathInfo {
+        paths: Vec::new(),
+        dev: is_dev,
+        optional: is_optional,
+    });
+    if !is_dev {
+        info.dev = false;
+    }
+    if !is_optional {
+        info.optional = false;
+    }
+    if info.paths.len() >= MAX_PATHS_PER_FINDING || info.paths.contains(&joined) {
+        return;
+    }
+    info.paths.push(joined);
+}
+
+fn join_trail(node: &Rc<TrailNode>) -> String {
+    let mut parts = Vec::new();
+    let mut current = Some(Rc::clone(node));
+    while let Some(node) = current.take() {
+        parts.push(node.name.clone());
+        current.clone_from(&node.parent);
+    }
+    parts.reverse();
+    parts.join(">")
+}
+
+fn package_version(key: &PackageKey) -> Option<String> {
+    key.suffix.version_semver().map(ToString::to_string)
+}
+
+fn render_json_report(
+    report: &AuditReport,
+    audit_level: ConfigAuditLevel,
+) -> miette::Result<String> {
+    let advisories = report
+        .advisories
+        .iter()
+        .filter(|(_, advisory)| severity_number(advisory.severity) >= severity_number(audit_level))
+        .map(|(id, advisory)| (id.clone(), advisory.clone()))
+        .collect();
+    serde_json::to_string_pretty(&AuditReport { advisories, metadata: report.metadata.clone() })
+        .into_diagnostic()
+}
+
+fn render_text_report(
+    report: &AuditReport,
+    audit_level: ConfigAuditLevel,
+    total_vulnerability_count: usize,
+    ignored: &AuditVulnerabilityCounts,
+) -> String {
+    let mut advisories = report
+        .advisories
+        .values()
+        .filter(|advisory| severity_number(advisory.severity) >= severity_number(audit_level))
+        .collect::<Vec<_>>();
+    advisories.sort_by(|left, right| {
+        severity_number(right.severity).cmp(&severity_number(left.severity))
+    });
+    let mut output = String::new();
+    for advisory in advisories {
+        output.push_str(&render_advisory(advisory));
+    }
+    output.push_str(&report_summary(
+        &report.metadata.vulnerabilities,
+        total_vulnerability_count,
+        ignored,
+    ));
+    output
+}
+
+fn render_advisory(advisory: &AuditAdvisory) -> String {
+    use tabled::{builder::Builder, settings::Style};
+
+    let paths = advisory
+        .findings
+        .iter()
+        .flat_map(|finding| finding.paths.iter().cloned())
+        .collect::<Vec<_>>();
+    let rendered_paths = if paths.len() > MAX_PATHS_COUNT {
+        paths[..MAX_PATHS_COUNT]
+            .iter()
+            .cloned()
+            .chain(std::iter::once(format!(
+                "... Found {} paths, run `pnpm why {}` for more information",
+                paths.len(),
+                advisory.module_name,
+            )))
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    } else {
+        paths.join("\n\n")
+    };
+
+    let mut builder = Builder::default();
+    builder.push_record(vec![
+        color_severity(advisory.severity, severity_name(advisory.severity)),
+        bold(&advisory.title),
+    ]);
+    builder.push_record(vec!["Package".to_string(), advisory.module_name.clone()]);
+    builder
+        .push_record(vec!["Vulnerable versions".to_string(), advisory.vulnerable_versions.clone()]);
+    builder.push_record(vec![
+        "Patched versions".to_string(),
+        advisory.patched_versions.clone().unwrap_or_else(|| "(unknown)".to_string()),
+    ]);
+    builder.push_record(vec!["Paths".to_string(), rendered_paths]);
+    builder.push_record(vec!["More info".to_string(), advisory.url.clone()]);
+    let mut table = builder.build();
+    table.with(Style::modern());
+    format!("{table}\n")
+}
+
+fn report_summary(
+    vulnerabilities: &AuditVulnerabilityCounts,
+    total_vulnerability_count: usize,
+    ignored: &AuditVulnerabilityCounts,
+) -> String {
+    if total_vulnerability_count == 0 {
+        return "No known vulnerabilities found\n".to_string();
+    }
+    let severities = vulnerabilities
+        .entries()
+        .into_iter()
+        .filter(|(_, count)| *count > 0)
+        .map(|(level, count)| {
+            let ignored_count = count_for_level(ignored, level);
+            let label = if ignored_count > 0 {
+                format!("{count} {} ({ignored_count} ignored)", severity_name(level))
+            } else {
+                format!("{count} {}", severity_name(level))
+            };
+            color_severity(level, &label)
+        })
+        .collect::<Vec<_>>()
+        .join(" | ");
+    format!(
+        "{} vulnerabilities found\nSeverity: {severities}",
+        red(&total_vulnerability_count.to_string()),
+    )
+}
+
+fn filter_ignored_advisories(
+    report: &mut AuditReport,
+    config: &Config,
+) -> AuditVulnerabilityCounts {
+    let ignore_set = config
+        .audit_config
+        .ignore_ghsas
+        .iter()
+        .map(|ghsa| normalize_ghsa_id(ghsa))
+        .collect::<HashSet<_>>();
+    if ignore_set.is_empty() {
+        return AuditVulnerabilityCounts::default();
+    }
+    let mut ignored = AuditVulnerabilityCounts::default();
+    report.advisories.retain(|_, advisory| {
+        if !ignore_set.contains(&normalize_ghsa_id(&advisory.github_advisory_id)) {
+            return true;
+        }
+        ignored.increment(advisory.severity);
+        false
+    });
+    ignored
+}
+
+fn count_for_level(counts: &AuditVulnerabilityCounts, level: ConfigAuditLevel) -> usize {
+    match level {
+        ConfigAuditLevel::Info => counts.info,
+        ConfigAuditLevel::Low => counts.low,
+        ConfigAuditLevel::Moderate => counts.moderate,
+        ConfigAuditLevel::High => counts.high,
+        ConfigAuditLevel::Critical => counts.critical,
+    }
+}
+
+fn parse_audit_level(value: &str) -> Option<ConfigAuditLevel> {
+    match value {
+        "info" => Some(ConfigAuditLevel::Info),
+        "low" => Some(ConfigAuditLevel::Low),
+        "moderate" => Some(ConfigAuditLevel::Moderate),
+        "high" => Some(ConfigAuditLevel::High),
+        "critical" => Some(ConfigAuditLevel::Critical),
+        _ => None,
+    }
+}
+
+fn severity_number(level: ConfigAuditLevel) -> u8 {
+    match level {
+        ConfigAuditLevel::Info => 0,
+        ConfigAuditLevel::Low => 1,
+        ConfigAuditLevel::Moderate => 2,
+        ConfigAuditLevel::High => 3,
+        ConfigAuditLevel::Critical => 4,
+    }
+}
+
+fn severity_name(level: ConfigAuditLevel) -> &'static str {
+    match level {
+        ConfigAuditLevel::Info => "info",
+        ConfigAuditLevel::Low => "low",
+        ConfigAuditLevel::Moderate => "moderate",
+        ConfigAuditLevel::High => "high",
+        ConfigAuditLevel::Critical => "critical",
+    }
+}
+
+fn satisfies_safe(version: &str, range: &str) -> bool {
+    let Ok(version) = version.parse::<Version>() else { return false };
+    let Ok(range) = range.parse::<Range>() else { return false };
+    version.satisfies(&range)
+}
+
+fn infer_patched_versions(vulnerable_range: &str) -> Option<String> {
+    let (operator, version) = last_upper_bound(vulnerable_range.trim())?;
+    let version = version.parse::<Version>().ok()?;
+    match operator {
+        "<" => Some(format!(">={version}")),
+        "<=" => {
+            let next = Version {
+                major: version.major,
+                minor: version.minor,
+                patch: version.patch + 1,
+                pre_release: Vec::new(),
+                build: Vec::new(),
+            };
+            Some(format!(">={next}"))
+        }
+        _ => None,
+    }
+}
+
+fn last_upper_bound(input: &str) -> Option<(&str, &str)> {
+    let mut parts = input.split_whitespace().collect::<Vec<_>>();
+    let last = parts.pop()?;
+    if let Some(version) = last.strip_prefix("<=") {
+        return Some(("<=", version.trim()));
+    }
+    if let Some(version) = last.strip_prefix('<') {
+        return Some(("<", version.trim()));
+    }
+    let operator = parts.pop()?;
+    matches!(operator, "<" | "<=").then_some((operator, last))
+}
+
+fn derive_github_advisory_id(url: &str) -> String {
+    let Some(idx) = url.to_ascii_uppercase().find("GHSA-") else {
+        return String::new();
+    };
+    let id = url[idx..]
+        .split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '-'))
+        .next()
+        .unwrap_or_default();
+    normalize_ghsa_id(id)
+}
+
+fn normalize_ghsa_id(ghsa_id: &str) -> String {
+    let trimmed = ghsa_id.trim();
+    let Some(dash) = trimmed.find('-') else {
+        return trimmed.to_ascii_uppercase();
+    };
+    format!("{}{}", trimmed[..dash].to_ascii_uppercase(), trimmed[dash..].to_ascii_lowercase())
+}
+
+fn normalize_registry(registry: &str) -> String {
+    if registry.ends_with('/') { registry.to_string() } else { format!("{registry}/") }
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
+fn bold(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, |t| t.bold()).to_string()
+}
+
+fn red(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, |t| t.red()).to_string()
+}
+
+fn color_severity(level: ConfigAuditLevel, text: &str) -> String {
+    match level {
+        ConfigAuditLevel::Info => {
+            text.if_supports_color(Stream::Stdout, |t| t.dimmed()).to_string()
+        }
+        ConfigAuditLevel::Low => text.if_supports_color(Stream::Stdout, |t| t.bold()).to_string(),
+        ConfigAuditLevel::Moderate => {
+            let style = owo_colors::Style::new().yellow().bold();
+            text.if_supports_color(Stream::Stdout, |t| t.style(style)).to_string()
+        }
+        ConfigAuditLevel::High | ConfigAuditLevel::Critical => {
+            let style = owo_colors::Style::new().red().bold();
+            text.if_supports_color(Stream::Stdout, |t| t.style(style)).to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/audit.rs
+++ b/pacquet/crates/cli/src/cli_args/audit.rs
@@ -143,8 +143,13 @@ impl AuditArgs {
         {
             Ok(report) => report,
             Err(err) if self.ignore_registry_errors => {
-                print!("{err}");
-                let _ = std::io::stdout().flush();
+                eprintln!("{err}");
+                let _ = std::io::stderr().flush();
+                if self.json {
+                    let report = empty_audit_report(lockfile, env_lockfile.as_ref(), include);
+                    print!("{}", render_json_report(&report, audit_level)?);
+                    let _ = std::io::stdout().flush();
+                }
                 return Ok(AuditOutcome::Clean);
             }
             Err(err) => return Err(err.into()),
@@ -360,17 +365,21 @@ async fn audit(
                 serde_json::from_str(&raw_body).map_err(|source| AuditError::InvalidJson {
                     url: display_audit_url.clone(),
                     reason: source.to_string(),
-                    body: truncate_chars(&raw_body, 500),
+                    body: sanitize_response_body(&raw_body),
                 })?;
             let bulk: BTreeMap<String, Vec<RawBulkAdvisory>> =
                 serde_json::from_value(parsed.clone()).map_err(|_| AuditError::UnexpectedBody {
                     url: display_audit_url.clone(),
-                    body: truncate_chars(&parsed.to_string(), 500),
+                    body: sanitize_response_body(&parsed.to_string()),
                 })?;
             Ok(bulk_response_to_audit_report(bulk, &audit_request, lockfile, env_lockfile, include))
         }
         404 => Err(AuditError::EndpointNotExists { url: display_audit_url }),
-        _ => Err(AuditError::BadStatus { url: display_audit_url, status, body: raw_body }),
+        _ => Err(AuditError::BadStatus {
+            url: display_audit_url,
+            status,
+            body: sanitize_response_body(&raw_body),
+        }),
     }
 }
 
@@ -418,15 +427,31 @@ fn bulk_response_to_audit_report(
         }
     }
 
+    AuditReport { advisories, metadata: audit_metadata(audit_request, vulnerabilities) }
+}
+
+fn empty_audit_report(
+    lockfile: &Lockfile,
+    env_lockfile: Option<&EnvLockfile>,
+    include: Include,
+) -> AuditReport {
+    let audit_request = lockfile_to_audit_request(lockfile, env_lockfile, include);
     AuditReport {
-        advisories,
-        metadata: AuditMetadata {
-            vulnerabilities,
-            dependencies: audit_request.dependencies,
-            dev_dependencies: audit_request.dev_dependencies,
-            optional_dependencies: audit_request.optional_dependencies,
-            total_dependencies: audit_request.total_dependencies,
-        },
+        advisories: BTreeMap::new(),
+        metadata: audit_metadata(&audit_request, AuditVulnerabilityCounts::default()),
+    }
+}
+
+fn audit_metadata(
+    audit_request: &AuditIndexRequest,
+    vulnerabilities: AuditVulnerabilityCounts,
+) -> AuditMetadata {
+    AuditMetadata {
+        vulnerabilities,
+        dependencies: audit_request.dependencies,
+        dev_dependencies: audit_request.dev_dependencies,
+        optional_dependencies: audit_request.optional_dependencies,
+        total_dependencies: audit_request.total_dependencies,
     }
 }
 
@@ -1257,6 +1282,22 @@ fn redact_url_userinfo(url: &str) -> String {
 
 fn truncate_chars(value: &str, max_chars: usize) -> String {
     value.chars().take(max_chars).collect()
+}
+
+fn sanitize_response_body(value: &str) -> String {
+    sanitize_control_chars(&truncate_chars(value, 500))
+}
+
+fn sanitize_control_chars(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if ch.is_control() {
+            output.extend(ch.escape_unicode());
+        } else {
+            output.push(ch);
+        }
+    }
+    output
 }
 
 fn bold(text: &str) -> String {

--- a/pacquet/crates/cli/src/cli_args/audit.rs
+++ b/pacquet/crates/cli/src/cli_args/audit.rs
@@ -1152,7 +1152,40 @@ fn severity_name(level: ConfigAuditLevel) -> &'static str {
 fn satisfies_safe(version: &str, range: &str) -> bool {
     let Ok(version) = version.parse::<Version>() else { return false };
     let Ok(range) = range.parse::<Range>() else { return false };
-    version.satisfies(&range)
+    satisfies_including_prerelease(&version, &range)
+}
+
+fn satisfies_including_prerelease(version: &Version, range: &Range) -> bool {
+    if version.satisfies(range) {
+        return true;
+    }
+    range.to_string().split("||").any(|comparators| {
+        comparators.split_whitespace().all(|comparator| comparator_matches(version, comparator))
+    })
+}
+
+fn comparator_matches(version: &Version, comparator: &str) -> bool {
+    if comparator == "*" {
+        return true;
+    }
+    let (operator, wanted) = comparator_operator_and_version(comparator);
+    let Ok(wanted) = wanted.parse::<Version>() else { return false };
+    match operator {
+        ">" => version > &wanted,
+        ">=" => version >= &wanted,
+        "<" => version < &wanted,
+        "<=" => version <= &wanted,
+        _ => version == &wanted,
+    }
+}
+
+fn comparator_operator_and_version(comparator: &str) -> (&str, &str) {
+    for operator in [">=", "<=", ">", "<"] {
+        if let Some(version) = comparator.strip_prefix(operator) {
+            return (operator, version);
+        }
+    }
+    ("", comparator)
 }
 
 fn infer_patched_versions(vulnerable_range: &str) -> Option<String> {

--- a/pacquet/crates/cli/src/cli_args/audit/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/audit/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use pacquet_lockfile::{EnvLockfile, Lockfile, SnapshotEntry, SpecifierAndResolution};
+use std::{collections::HashSet, fmt::Write as _};
 
 fn parse_lockfile(yaml: &str) -> Lockfile {
     serde_saphyr::from_str(yaml).expect("parse lockfile fixture")
@@ -63,6 +64,47 @@ fn prod_without_optional() -> Include {
     Include { dependencies: true, dev_dependencies: false, optional_dependencies: false }
 }
 
+fn empty_lockfile() -> Lockfile {
+    parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .: {}
+",
+    )
+}
+
+fn vulnerable_names(names: &[&str]) -> HashSet<String> {
+    names.iter().map(|name| (*name).to_string()).collect()
+}
+
+fn path_info<'a>(index: &'a AuditPathIndex, name: &str, version: &str) -> &'a PathInfo {
+    index.get(name).and_then(|by_version| by_version.get(version)).expect("path info")
+}
+
+fn snapshot(deps: &[(&str, &str)], optional_deps: &[(&str, &str)]) -> SnapshotEntry {
+    SnapshotEntry {
+        dependencies: (!deps.is_empty()).then(|| {
+            deps.iter()
+                .map(|(name, version)| {
+                    ((*name).parse().unwrap(), (*version).parse::<SnapshotDepRef>().unwrap())
+                })
+                .collect()
+        }),
+        optional_dependencies: (!optional_deps.is_empty()).then(|| {
+            optional_deps
+                .iter()
+                .map(|(name, version)| {
+                    ((*name).parse().unwrap(), (*version).parse::<SnapshotDepRef>().unwrap())
+                })
+                .collect()
+        }),
+        ..SnapshotEntry::default()
+    }
+}
+
 #[test]
 fn lockfile_to_audit_request_includes_project_and_env_dependencies() {
     let lockfile = fixture_lockfile();
@@ -98,6 +140,577 @@ fn lockfile_to_audit_request_respects_prod_and_no_optional() {
     assert_eq!(request.dependencies, 3);
     assert_eq!(request.dev_dependencies, 0);
     assert_eq!(request.optional_dependencies, 0);
+}
+
+#[test]
+fn lockfile_to_audit_request_accepts_absent_env_lockfile() {
+    let lockfile = parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      foo:
+        specifier: '1.0.0'
+        version: '1.0.0'
+
+snapshots:
+
+  foo@1.0.0: {}
+",
+    );
+
+    let request = lockfile_to_audit_request(&lockfile, None, all_dependencies());
+
+    assert_eq!(request.request["foo"], vec!["1.0.0"]);
+    assert_eq!(request.total_dependencies, 1);
+}
+
+#[test]
+fn lockfile_to_audit_request_includes_env_package_manager_dependencies() {
+    let lockfile = parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      foo:
+        specifier: '1.0.0'
+        version: '1.0.0'
+
+snapshots:
+
+  foo@1.0.0: {}
+",
+    );
+    let mut env = EnvLockfile::create();
+    {
+        let importer = env.root_importer_mut();
+        importer.config_dependencies.insert(
+            "my-config".to_string(),
+            SpecifierAndResolution { specifier: "2.0.0".to_string(), version: "2.0.0".to_string() },
+        );
+        importer.package_manager_dependencies = Some(BTreeMap::from([(
+            "pnpm".to_string(),
+            SpecifierAndResolution { specifier: "9.0.0".to_string(), version: "9.0.0".to_string() },
+        )]));
+    }
+    env.snapshots
+        .insert("my-config@2.0.0".parse().unwrap(), snapshot(&[("config-util", "1.0.0")], &[]));
+    env.snapshots.insert("config-util@1.0.0".parse().unwrap(), SnapshotEntry::default());
+    env.snapshots.insert("pnpm@9.0.0".parse().unwrap(), SnapshotEntry::default());
+
+    let request = lockfile_to_audit_request(&lockfile, Some(&env), all_dependencies());
+
+    assert_eq!(request.request["foo"], vec!["1.0.0"]);
+    assert_eq!(request.request["my-config"], vec!["2.0.0"]);
+    assert_eq!(request.request["config-util"], vec!["1.0.0"]);
+    assert_eq!(request.request["pnpm"], vec!["9.0.0"]);
+}
+
+#[test]
+fn lockfile_to_audit_request_includes_optional_dependencies_from_env_snapshots() {
+    let lockfile = empty_lockfile();
+    let mut env = EnvLockfile::create();
+    env.root_importer_mut().config_dependencies.insert(
+        "my-tool".to_string(),
+        SpecifierAndResolution { specifier: "1.0.0".to_string(), version: "1.0.0".to_string() },
+    );
+    env.snapshots.insert(
+        "my-tool@1.0.0".parse().unwrap(),
+        snapshot(&[("required-dep", "1.0.0")], &[("optional-dep", "2.0.0")]),
+    );
+    env.snapshots.insert("required-dep@1.0.0".parse().unwrap(), SnapshotEntry::default());
+    env.snapshots.insert("optional-dep@2.0.0".parse().unwrap(), SnapshotEntry::default());
+
+    let request = lockfile_to_audit_request(&lockfile, Some(&env), all_dependencies());
+
+    assert_eq!(request.request["required-dep"], vec!["1.0.0"]);
+    assert_eq!(request.request["optional-dep"], vec!["2.0.0"]);
+
+    let without_optional =
+        lockfile_to_audit_request(&lockfile, Some(&env), prod_without_optional());
+    assert_eq!(without_optional.request["required-dep"], vec!["1.0.0"]);
+    assert!(!without_optional.request.contains_key("optional-dep"));
+}
+
+#[test]
+fn lockfile_to_audit_request_ignores_unreachable_env_packages() {
+    let lockfile = empty_lockfile();
+    let mut env = EnvLockfile::create();
+    env.root_importer_mut().config_dependencies.insert(
+        "my-config".to_string(),
+        SpecifierAndResolution { specifier: "1.0.0".to_string(), version: "1.0.0".to_string() },
+    );
+    env.snapshots.insert("my-config@1.0.0".parse().unwrap(), SnapshotEntry::default());
+    env.snapshots.insert("orphan-pkg@3.0.0".parse().unwrap(), SnapshotEntry::default());
+
+    let request = lockfile_to_audit_request(&lockfile, Some(&env), all_dependencies());
+
+    assert!(request.request.contains_key("my-config"));
+    assert!(!request.request.contains_key("orphan-pkg"));
+}
+
+#[test]
+fn build_audit_path_index_records_install_paths_for_vulnerable_packages() {
+    let lockfile = parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      foo:
+        specifier: '1.0.0'
+        version: '1.0.0'
+
+snapshots:
+
+  foo@1.0.0:
+    dependencies:
+      bar: '1.0.0'
+
+  bar@1.0.0: {}
+",
+    );
+    let index =
+        build_audit_path_index(&lockfile, None, &vulnerable_names(&["bar"]), all_dependencies());
+
+    let info = path_info(&index, "bar", "1.0.0");
+    assert_eq!(info.paths, vec![".>foo>bar"]);
+    assert!(!info.dev);
+    assert!(!info.optional);
+    assert!(!index.contains_key("foo"));
+}
+
+#[test]
+fn build_audit_path_index_records_every_distinct_install_path_for_shared_dependencies() {
+    let lockfile = parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      a:
+        specifier: '1.0.0'
+        version: '1.0.0'
+      b:
+        specifier: '1.0.0'
+        version: '1.0.0'
+
+snapshots:
+
+  a@1.0.0:
+    dependencies:
+      lodash: '4.0.0'
+
+  b@1.0.0:
+    dependencies:
+      lodash: '4.0.0'
+
+  lodash@4.0.0: {}
+",
+    );
+    let index =
+        build_audit_path_index(&lockfile, None, &vulnerable_names(&["lodash"]), all_dependencies());
+
+    let mut paths = path_info(&index, "lodash", "4.0.0").paths.clone();
+    paths.sort();
+    assert_eq!(paths, vec![".>a>lodash", ".>b>lodash"]);
+}
+
+#[test]
+fn build_audit_path_index_keeps_all_vulnerable_paths_while_ignoring_non_vulnerable_nodes() {
+    let mut importers = String::new();
+    let mut snapshots = String::from(
+        "
+  vuln@1.0.0: {}
+
+  cold@1.0.0:
+    dependencies:
+      cold-leaf: '1.0.0'
+
+  cold-leaf@1.0.0: {}
+",
+    );
+    for i in 0..50 {
+        write!(
+            importers,
+            "
+  .{i}:
+    dependencies:
+      parent-{i}:
+        specifier: '1.0.0'
+        version: '1.0.0'
+",
+        )
+        .unwrap();
+        write!(
+            snapshots,
+            "
+  parent-{i}@1.0.0:
+    dependencies:
+      cold: '1.0.0'
+      vuln: '1.0.0'
+",
+        )
+        .unwrap();
+    }
+    let lockfile = parse_lockfile(&format!(
+        "
+lockfileVersion: '9.0'
+
+importers:
+{importers}
+snapshots:
+{snapshots}
+",
+    ));
+
+    let index =
+        build_audit_path_index(&lockfile, None, &vulnerable_names(&["vuln"]), all_dependencies());
+
+    assert_eq!(path_info(&index, "vuln", "1.0.0").paths.len(), 50);
+    assert!(!index.contains_key("cold"));
+    assert!(!index.contains_key("cold-leaf"));
+}
+
+#[test]
+fn build_audit_path_index_limits_paths_per_finding() {
+    let mut importers = String::new();
+    for i in 0..150 {
+        write!(
+            importers,
+            "
+  .{i}:
+    dependencies:
+      vuln:
+        specifier: '1.0.0'
+        version: '1.0.0'
+",
+        )
+        .unwrap();
+    }
+    let lockfile = parse_lockfile(&format!(
+        "
+lockfileVersion: '9.0'
+
+importers:
+{importers}
+snapshots:
+
+  vuln@1.0.0: {{}}
+",
+    ));
+
+    let index =
+        build_audit_path_index(&lockfile, None, &vulnerable_names(&["vuln"]), all_dependencies());
+
+    assert_eq!(path_info(&index, "vuln", "1.0.0").paths.len(), MAX_PATHS_PER_FINDING);
+}
+
+#[test]
+fn build_audit_path_index_classifies_optional_when_only_included_path_is_optional() {
+    let lockfile = parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    devDependencies:
+      dev-root:
+        specifier: '1.0.0'
+        version: '1.0.0'
+    optionalDependencies:
+      opt-root:
+        specifier: '1.0.0'
+        version: '1.0.0'
+
+snapshots:
+
+  dev-root@1.0.0:
+    dependencies:
+      shared-pkg: '1.0.0'
+
+  opt-root@1.0.0:
+    dependencies:
+      shared-pkg: '1.0.0'
+
+  shared-pkg@1.0.0: {}
+",
+    );
+
+    let with_dev = build_audit_path_index(
+        &lockfile,
+        None,
+        &vulnerable_names(&["shared-pkg"]),
+        all_dependencies(),
+    );
+    assert!(!path_info(&with_dev, "shared-pkg", "1.0.0").optional);
+
+    let prod_only = build_audit_path_index(
+        &lockfile,
+        None,
+        &vulnerable_names(&["shared-pkg"]),
+        Include { dependencies: true, dev_dependencies: false, optional_dependencies: true },
+    );
+    assert!(path_info(&prod_only, "shared-pkg", "1.0.0").optional);
+}
+
+#[test]
+fn build_audit_path_index_flags_findings_reached_only_through_optional_edges() {
+    let lockfile = parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    optionalDependencies:
+      native:
+        specifier: '1.0.0'
+        version: '1.0.0'
+
+snapshots:
+
+  native@1.0.0: {}
+",
+    );
+    let index =
+        build_audit_path_index(&lockfile, None, &vulnerable_names(&["native"]), all_dependencies());
+
+    let info = path_info(&index, "native", "1.0.0");
+    assert_eq!(info.paths, vec![".>native"]);
+    assert!(info.optional);
+    assert!(!info.dev);
+}
+
+#[test]
+fn build_audit_path_index_preserves_reachability_across_cycles() {
+    let lockfile = parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      a:
+        specifier: '1.0.0'
+        version: '1.0.0'
+
+snapshots:
+
+  a@1.0.0:
+    dependencies:
+      b: '1.0.0'
+
+  b@1.0.0:
+    dependencies:
+      a: '1.0.0'
+",
+    );
+    let index =
+        build_audit_path_index(&lockfile, None, &vulnerable_names(&["a", "b"]), all_dependencies());
+
+    assert_eq!(path_info(&index, "a", "1.0.0").paths, vec![".>a"]);
+    assert_eq!(path_info(&index, "b", "1.0.0").paths, vec![".>a>b"]);
+}
+
+#[test]
+fn build_audit_path_index_preserves_reachability_when_cycle_root_is_queried_later() {
+    let lockfile = parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      root:
+        specifier: '1.0.0'
+        version: '1.0.0'
+
+snapshots:
+
+  root@1.0.0:
+    dependencies:
+      b: '1.0.0'
+
+  a@1.0.0:
+    dependencies:
+      b: '1.0.0'
+
+  b@1.0.0:
+    dependencies:
+      a: '1.0.0'
+",
+    );
+    let index =
+        build_audit_path_index(&lockfile, None, &vulnerable_names(&["a"]), all_dependencies());
+
+    assert_eq!(path_info(&index, "a", "1.0.0").paths, vec![".>root>b>a"]);
+}
+
+#[test]
+fn build_audit_path_index_keeps_paths_reached_through_non_entry_cycle_member() {
+    let lockfile = parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      c:
+        specifier: '1.0.0'
+        version: '1.0.0'
+      b:
+        specifier: '1.0.0'
+        version: '1.0.0'
+
+snapshots:
+
+  b@1.0.0:
+    dependencies:
+      c: '1.0.0'
+
+  c@1.0.0:
+    dependencies:
+      b: '1.0.0'
+      x: '1.0.0'
+
+  x@1.0.0: {}
+",
+    );
+    let index =
+        build_audit_path_index(&lockfile, None, &vulnerable_names(&["x"]), all_dependencies());
+
+    let mut paths = path_info(&index, "x", "1.0.0").paths.clone();
+    paths.sort();
+    assert_eq!(paths, vec![".>b>c>x", ".>c>x"]);
+}
+
+#[test]
+fn build_audit_path_index_handles_large_cycle_with_vulnerable_leaf() {
+    let size = 400;
+    let mut snapshots = String::new();
+    for i in 0..size {
+        let next = if i + 1 < size { format!("n{}", i + 1) } else { "n0".to_string() };
+        write!(
+            snapshots,
+            "
+  n{i}@1.0.0:
+    dependencies:
+      {next}: '1.0.0'
+      leaf{i}: '1.0.0'
+
+  leaf{i}@1.0.0: {{}}
+",
+        )
+        .unwrap();
+    }
+    let lockfile = parse_lockfile(&format!(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      n0:
+        specifier: '1.0.0'
+        version: '1.0.0'
+
+snapshots:
+{snapshots}
+",
+    ));
+    let index =
+        build_audit_path_index(&lockfile, None, &vulnerable_names(&["leaf0"]), all_dependencies());
+
+    let info = path_info(&index, "leaf0", "1.0.0");
+    assert_eq!(info.paths, vec![".>n0>leaf0"]);
+}
+
+#[test]
+fn build_audit_path_index_handles_very_deep_dependency_chain() {
+    let size = 12_000;
+    let mut snapshots = String::new();
+    for i in 0..size {
+        let child = if i + 1 < size { format!("n{}", i + 1) } else { "vuln".to_string() };
+        write!(
+            snapshots,
+            "
+  n{i}@1.0.0:
+    dependencies:
+      {child}: '1.0.0'
+",
+        )
+        .unwrap();
+    }
+    snapshots.push_str(
+        "
+  vuln@1.0.0: {}
+",
+    );
+    let lockfile = parse_lockfile(&format!(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      n0:
+        specifier: '1.0.0'
+        version: '1.0.0'
+
+snapshots:
+{snapshots}
+",
+    ));
+
+    let index =
+        build_audit_path_index(&lockfile, None, &vulnerable_names(&["vuln"]), all_dependencies());
+
+    let info = path_info(&index, "vuln", "1.0.0");
+    assert_eq!(info.paths.len(), 1);
+    assert!(info.paths[0].starts_with(".>n0>n1>"));
+    assert!(info.paths[0].ends_with(">vuln"));
+}
+
+#[test]
+fn build_audit_path_index_replaces_slashes_in_workspace_importer_ids() {
+    let lockfile = parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  packages/foo:
+    dependencies:
+      foo:
+        specifier: '1.0.0'
+        version: '1.0.0'
+
+snapshots:
+
+  foo@1.0.0: {}
+",
+    );
+    let index =
+        build_audit_path_index(&lockfile, None, &vulnerable_names(&["foo"]), all_dependencies());
+
+    assert_eq!(path_info(&index, "foo", "1.0.0").paths, vec!["packages__foo>foo"]);
 }
 
 #[test]
@@ -149,6 +762,94 @@ fn bulk_response_to_audit_report_keeps_only_installed_vulnerable_versions() {
     assert!(!advisory.findings[0].optional);
     assert_eq!(report.metadata.vulnerabilities.high, 1);
     assert_eq!(report.metadata.vulnerabilities.critical, 0);
+}
+
+#[test]
+fn bulk_response_to_audit_report_computes_findings_and_counts_from_bare_bulk_response() {
+    let lockfile = parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      foo:
+        specifier: '1.0.0'
+        version: '1.0.0'
+
+snapshots:
+
+  foo@1.0.0:
+    dependencies:
+      bar: '1.0.0'
+
+  bar@1.0.0: {}
+",
+    );
+    let audit_request = lockfile_to_audit_request(&lockfile, None, all_dependencies());
+    let bulk = BTreeMap::from([(
+        "bar".to_string(),
+        vec![RawBulkAdvisory {
+            id: Some(serde_json::json!(42)),
+            url: Some("https://github.com/advisories/GHSA-xxxx-yyyy-zzzz".to_string()),
+            title: Some("bar is bad".to_string()),
+            severity: Some("high".to_string()),
+            vulnerable_versions: "<2.0.0".to_string(),
+            cwe: None,
+        }],
+    )]);
+
+    let report =
+        bulk_response_to_audit_report(bulk, &audit_request, &lockfile, None, all_dependencies());
+
+    let advisory = &report.advisories["42"];
+    assert_eq!(advisory.module_name, "bar");
+    assert_eq!(advisory.github_advisory_id, "GHSA-xxxx-yyyy-zzzz");
+    assert_eq!(advisory.patched_versions.as_deref(), Some(">=2.0.0"));
+    assert_eq!(advisory.findings[0].version, "1.0.0");
+    assert_eq!(advisory.findings[0].paths, vec![".>foo>bar"]);
+    assert_eq!(report.metadata.vulnerabilities.high, 1);
+    assert_eq!(report.metadata.total_dependencies, 2);
+}
+
+#[test]
+fn bulk_response_to_audit_report_handles_info_severity() {
+    let lockfile = parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      info-pkg:
+        specifier: '1.0.0'
+        version: '1.0.0'
+
+snapshots:
+
+  info-pkg@1.0.0: {}
+",
+    );
+    let audit_request = lockfile_to_audit_request(&lockfile, None, all_dependencies());
+    let bulk = BTreeMap::from([(
+        "info-pkg".to_string(),
+        vec![RawBulkAdvisory {
+            id: Some(serde_json::json!(100)),
+            url: Some("https://github.com/advisories/GHSA-info-info-info".to_string()),
+            title: Some("just some info".to_string()),
+            severity: Some("info".to_string()),
+            vulnerable_versions: "*".to_string(),
+            cwe: None,
+        }],
+    )]);
+
+    let report =
+        bulk_response_to_audit_report(bulk, &audit_request, &lockfile, None, all_dependencies());
+
+    assert_eq!(report.metadata.vulnerabilities.info, 1);
+    assert_eq!(report.advisories["100"].severity, ConfigAuditLevel::Info);
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/audit/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/audit/tests.rs
@@ -194,6 +194,41 @@ fn render_json_filters_by_audit_level_after_ignores() {
 }
 
 #[test]
+fn filter_ignored_advisories_does_not_match_blank_ghsa_ids() {
+    let mut report = AuditReport {
+        advisories: BTreeMap::from([
+            ("1".to_string(), advisory(1, "missing ghsa", ConfigAuditLevel::High, "")),
+            (
+                "2".to_string(),
+                advisory(2, "ignored ghsa", ConfigAuditLevel::High, "GHSA-high-3333-4444"),
+            ),
+        ]),
+        metadata: AuditMetadata {
+            vulnerabilities: AuditVulnerabilityCounts {
+                info: 0,
+                low: 0,
+                moderate: 0,
+                high: 2,
+                critical: 0,
+            },
+            dependencies: 2,
+            dev_dependencies: 0,
+            optional_dependencies: 0,
+            total_dependencies: 2,
+        },
+    };
+    let mut config = Config::default();
+    config.audit_config.ignore_ghsas =
+        vec![String::new(), "  ".to_string(), "ghsa-HIGH-3333-4444".to_string()];
+
+    let ignored = filter_ignored_advisories(&mut report, &config);
+
+    assert_eq!(ignored.high, 1);
+    assert!(report.advisories.contains_key("1"));
+    assert!(!report.advisories.contains_key("2"));
+}
+
+#[test]
 fn text_report_separates_advisory_table_from_summary() {
     let report = AuditReport {
         advisories: BTreeMap::from([(

--- a/pacquet/crates/cli/src/cli_args/audit/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/audit/tests.rs
@@ -229,6 +229,14 @@ fn filter_ignored_advisories_does_not_match_blank_ghsa_ids() {
 }
 
 #[test]
+fn satisfies_safe_includes_prerelease_versions_for_audit_ranges() {
+    assert!(satisfies_safe("1.2.3-rc.0", "<2.0.0"));
+    assert!(satisfies_safe("2.0.0-rc.1", "<2.0.0"));
+    assert!(satisfies_safe("1.2.3-beta.0", "^1.2.0"));
+    assert!(!satisfies_safe("1.2.0-beta.0", "^1.2.0"));
+}
+
+#[test]
 fn text_report_separates_advisory_table_from_summary() {
     let report = AuditReport {
         advisories: BTreeMap::from([(

--- a/pacquet/crates/cli/src/cli_args/audit/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/audit/tests.rs
@@ -1,0 +1,243 @@
+use super::*;
+use pacquet_lockfile::{EnvLockfile, Lockfile, SnapshotEntry, SpecifierAndResolution};
+
+fn parse_lockfile(yaml: &str) -> Lockfile {
+    serde_saphyr::from_str(yaml).expect("parse lockfile fixture")
+}
+
+fn fixture_lockfile() -> Lockfile {
+    parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      prod:
+        specifier: '1.0.0'
+        version: '1.0.0'
+    devDependencies:
+      dev-only:
+        specifier: '1.0.0'
+        version: '1.0.0'
+    optionalDependencies:
+      optional-only:
+        specifier: '1.0.0'
+        version: '1.0.0'
+
+snapshots:
+
+  prod@1.0.0:
+    dependencies:
+      transitive: '2.0.0'
+    optionalDependencies:
+      transitive-optional: '3.0.0'
+
+  dev-only@1.0.0: {}
+
+  optional-only@1.0.0: {}
+
+  transitive@2.0.0: {}
+
+  transitive-optional@3.0.0: {}
+",
+    )
+}
+
+fn fixture_env_lockfile() -> EnvLockfile {
+    let mut env = EnvLockfile::create();
+    env.root_importer_mut().config_dependencies.insert(
+        "config-dep".to_string(),
+        SpecifierAndResolution { specifier: "1.0.0".to_string(), version: "1.0.0".to_string() },
+    );
+    env.snapshots.insert("config-dep@1.0.0".parse().unwrap(), SnapshotEntry::default());
+    env
+}
+
+fn all_dependencies() -> Include {
+    Include { dependencies: true, dev_dependencies: true, optional_dependencies: true }
+}
+
+fn prod_without_optional() -> Include {
+    Include { dependencies: true, dev_dependencies: false, optional_dependencies: false }
+}
+
+#[test]
+fn lockfile_to_audit_request_includes_project_and_env_dependencies() {
+    let lockfile = fixture_lockfile();
+    let env_lockfile = fixture_env_lockfile();
+    let request = lockfile_to_audit_request(&lockfile, Some(&env_lockfile), all_dependencies());
+
+    assert_eq!(request.request["prod"], vec!["1.0.0"]);
+    assert_eq!(request.request["transitive"], vec!["2.0.0"]);
+    assert_eq!(request.request["transitive-optional"], vec!["3.0.0"]);
+    assert_eq!(request.request["dev-only"], vec!["1.0.0"]);
+    assert_eq!(request.request["optional-only"], vec!["1.0.0"]);
+    assert_eq!(request.request["config-dep"], vec!["1.0.0"]);
+    assert_eq!(request.total_dependencies, 6);
+    assert_eq!(request.dependencies, 3);
+    assert_eq!(request.dev_dependencies, 1);
+    assert_eq!(request.optional_dependencies, 2);
+}
+
+#[test]
+fn lockfile_to_audit_request_respects_prod_and_no_optional() {
+    let lockfile = fixture_lockfile();
+    let env_lockfile = fixture_env_lockfile();
+    let request =
+        lockfile_to_audit_request(&lockfile, Some(&env_lockfile), prod_without_optional());
+
+    assert_eq!(request.request["prod"], vec!["1.0.0"]);
+    assert_eq!(request.request["transitive"], vec!["2.0.0"]);
+    assert_eq!(request.request["config-dep"], vec!["1.0.0"]);
+    assert!(!request.request.contains_key("dev-only"));
+    assert!(!request.request.contains_key("optional-only"));
+    assert!(!request.request.contains_key("transitive-optional"));
+    assert_eq!(request.total_dependencies, 3);
+    assert_eq!(request.dependencies, 3);
+    assert_eq!(request.dev_dependencies, 0);
+    assert_eq!(request.optional_dependencies, 0);
+}
+
+#[test]
+fn bulk_response_to_audit_report_keeps_only_installed_vulnerable_versions() {
+    let lockfile = fixture_lockfile();
+    let env_lockfile = fixture_env_lockfile();
+    let audit_request =
+        lockfile_to_audit_request(&lockfile, Some(&env_lockfile), all_dependencies());
+    let mut bulk = BTreeMap::new();
+    bulk.insert(
+        "transitive".to_string(),
+        vec![
+            RawBulkAdvisory {
+                id: Some(serde_json::json!(101)),
+                url: Some("https://github.com/advisories/GHSA-AbCd-1111-2222".to_string()),
+                title: Some("transitive issue".to_string()),
+                severity: Some("high".to_string()),
+                vulnerable_versions: "<3.0.0".to_string(),
+                cwe: Some(Cwe::Many(vec!["CWE-1".to_string(), "CWE-2".to_string()])),
+            },
+            RawBulkAdvisory {
+                id: Some(serde_json::json!(102)),
+                url: None,
+                title: Some("not installed".to_string()),
+                severity: Some("critical".to_string()),
+                vulnerable_versions: "<2.0.0".to_string(),
+                cwe: None,
+            },
+        ],
+    );
+
+    let report = bulk_response_to_audit_report(
+        bulk,
+        &audit_request,
+        &lockfile,
+        Some(&env_lockfile),
+        all_dependencies(),
+    );
+
+    assert_eq!(report.advisories.len(), 1);
+    let advisory = &report.advisories["101"];
+    assert_eq!(advisory.github_advisory_id, "GHSA-abcd-1111-2222");
+    assert_eq!(advisory.patched_versions.as_deref(), Some(">=3.0.0"));
+    assert_eq!(advisory.cwe, "CWE-1, CWE-2");
+    assert_eq!(advisory.findings.len(), 1);
+    assert_eq!(advisory.findings[0].version, "2.0.0");
+    assert_eq!(advisory.findings[0].paths, vec![".>prod>transitive"]);
+    assert!(!advisory.findings[0].dev);
+    assert!(!advisory.findings[0].optional);
+    assert_eq!(report.metadata.vulnerabilities.high, 1);
+    assert_eq!(report.metadata.vulnerabilities.critical, 0);
+}
+
+#[test]
+fn render_json_filters_by_audit_level_after_ignores() {
+    let mut report = AuditReport {
+        advisories: BTreeMap::from([
+            (
+                "1".to_string(),
+                advisory(1, "low issue", ConfigAuditLevel::Low, "GHSA-low1-1111-2222"),
+            ),
+            (
+                "2".to_string(),
+                advisory(2, "high issue", ConfigAuditLevel::High, "GHSA-high-3333-4444"),
+            ),
+        ]),
+        metadata: AuditMetadata {
+            vulnerabilities: AuditVulnerabilityCounts {
+                info: 0,
+                low: 1,
+                moderate: 0,
+                high: 1,
+                critical: 0,
+            },
+            dependencies: 2,
+            dev_dependencies: 0,
+            optional_dependencies: 0,
+            total_dependencies: 2,
+        },
+    };
+    let mut config = Config::default();
+    config.audit_config.ignore_ghsas = vec!["ghsa-HIGH-3333-4444".to_string()];
+
+    let ignored = filter_ignored_advisories(&mut report, &config);
+    assert_eq!(ignored.high, 1);
+    assert!(report.advisories.contains_key("1"));
+    assert!(!report.advisories.contains_key("2"));
+
+    let rendered = render_json_report(&report, ConfigAuditLevel::Moderate).unwrap();
+    let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+    assert_eq!(value["advisories"].as_object().unwrap().len(), 0);
+    assert_eq!(value["metadata"]["vulnerabilities"]["low"], 1);
+    assert_eq!(value["metadata"]["vulnerabilities"]["high"], 1);
+}
+
+#[test]
+fn text_report_separates_advisory_table_from_summary() {
+    let report = AuditReport {
+        advisories: BTreeMap::from([(
+            "1".to_string(),
+            advisory(1, "high issue", ConfigAuditLevel::High, "GHSA-high-3333-4444"),
+        )]),
+        metadata: AuditMetadata {
+            vulnerabilities: AuditVulnerabilityCounts {
+                info: 0,
+                low: 0,
+                moderate: 0,
+                high: 1,
+                critical: 0,
+            },
+            dependencies: 1,
+            dev_dependencies: 0,
+            optional_dependencies: 0,
+            total_dependencies: 1,
+        },
+    };
+
+    let output =
+        render_text_report(&report, ConfigAuditLevel::Low, 1, &AuditVulnerabilityCounts::default());
+    let summary_start = output.find("1 vulnerabilities found").unwrap();
+    assert_eq!(output.as_bytes()[summary_start - 1], b'\n');
+}
+
+fn advisory(id: u64, title: &str, severity: ConfigAuditLevel, ghsa: &str) -> AuditAdvisory {
+    AuditAdvisory {
+        findings: vec![AuditFinding {
+            version: "1.0.0".to_string(),
+            paths: vec![".>pkg".to_string()],
+            dev: false,
+            optional: false,
+            bundled: false,
+        }],
+        id,
+        title: title.to_string(),
+        module_name: "pkg".to_string(),
+        vulnerable_versions: "<2.0.0".to_string(),
+        patched_versions: Some(">=2.0.0".to_string()),
+        severity,
+        cwe: String::new(),
+        github_advisory_id: normalize_ghsa_id(ghsa),
+        url: format!("https://github.com/advisories/{ghsa}"),
+    }
+}

--- a/pacquet/crates/cli/src/cli_args/audit/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/audit/tests.rs
@@ -221,6 +221,21 @@ fn text_report_separates_advisory_table_from_summary() {
     assert_eq!(output.as_bytes()[summary_start - 1], b'\n');
 }
 
+#[test]
+fn redact_url_userinfo_removes_credentials_from_audit_endpoint() {
+    assert_eq!(
+        redact_url_userinfo(
+            "https://user:secret@registry.example.com/npm/-/npm/v1/security/advisories/bulk"
+        ),
+        "https://registry.example.com/npm/-/npm/v1/security/advisories/bulk",
+    );
+    assert_eq!(
+        redact_url_userinfo("https://user@registry.example.com/-/npm/v1/security/advisories/bulk"),
+        "https://registry.example.com/-/npm/v1/security/advisories/bulk",
+    );
+    assert_eq!(redact_url_userinfo("not a url"), "not a url");
+}
+
 fn advisory(id: u64, title: &str, severity: ConfigAuditLevel, ghsa: &str) -> AuditAdvisory {
     AuditAdvisory {
         findings: vec![AuditFinding {

--- a/pacquet/crates/cli/src/cli_args/audit/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/audit/tests.rs
@@ -980,6 +980,11 @@ fn redact_url_userinfo_removes_credentials_from_audit_endpoint() {
     assert_eq!(redact_url_userinfo("not a url"), "not a url");
 }
 
+#[test]
+fn sanitize_control_chars_escapes_registry_control_characters() {
+    assert_eq!(sanitize_control_chars("ok\u{1b}[31m\n\u{7f}"), r"ok\u{1b}[31m\u{a}\u{7f}");
+}
+
 fn advisory(id: u64, title: &str, severity: ConfigAuditLevel, ghsa: &str) -> AuditAdvisory {
     AuditAdvisory {
         findings: vec![AuditFinding {

--- a/pacquet/crates/cli/tests/audit.rs
+++ b/pacquet/crates/cli/tests/audit.rs
@@ -1,5 +1,6 @@
+use mockito::Matcher;
 use pacquet_testing_utils::bin::CommandTempCwd;
-use std::fs;
+use std::{fs, path::Path, process::Output};
 
 #[test]
 fn audit_json_posts_bulk_request_and_exits_on_vulnerability() {
@@ -26,11 +27,486 @@ fn audit_json_posts_bulk_request_and_exits_on_vulnerability() {
         )
         .create();
 
-    fs::write(workspace.join(".npmrc"), format!("registry={}/\n", registry.url()))
-        .expect("write .npmrc");
+    write_audit_workspace(&workspace, &registry.url(), "");
+
+    let output = pacquet.arg("audit").arg("--json").output().expect("run pacquet audit");
+
+    assert_eq!(output.status.code(), Some(1), "vulnerability should produce exit code 1");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let report: serde_json::Value = serde_json::from_str(&stdout).expect("audit JSON output");
+    assert_eq!(report["advisories"]["123"]["title"], "test vulnerability");
+    assert_eq!(report["advisories"]["123"]["module_name"], "vulnerable");
+    assert_eq!(report["advisories"]["123"]["findings"][0]["paths"][0], ".>vulnerable");
+    assert_eq!(report["metadata"]["vulnerabilities"]["high"], 1);
+    mock.assert();
+}
+
+#[test]
+fn audit_no_vulnerabilities_exits_successfully() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(&mut registry, "{}").create();
+    write_audit_workspace(&workspace, &registry.url(), "");
+
+    let output = pacquet.arg("audit").output().expect("run pacquet audit");
+
+    assert_success(&output);
+    assert_eq!(stdout(&output), "No known vulnerabilities found\n");
+    mock.assert();
+}
+
+#[test]
+fn audit_dev_reports_only_dev_dependencies() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = registry
+        .mock("POST", "/-/npm/v1/security/advisories/bulk")
+        .match_body(Matcher::PartialJsonString(r#"{"dev-vulnerable":["1.0.0"]}"#.to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(advisory_response(
+            "dev-vulnerable",
+            124,
+            "high",
+            "<2.0.0",
+            "dev vulnerability",
+            "GHSA-devv-1111-2222",
+        ))
+        .create();
+    write_audit_workspace(&workspace, &registry.url(), "");
+
+    let output =
+        pacquet.arg("audit").arg("--dev").arg("--json").output().expect("run pacquet audit");
+
+    assert_eq!(output.status.code(), Some(1));
+    let report: serde_json::Value = serde_json::from_str(&stdout(&output)).unwrap();
+    assert_eq!(report["advisories"]["124"]["module_name"], "dev-vulnerable");
+    assert_eq!(report["advisories"]["124"]["findings"][0]["dev"], true);
+    assert_eq!(report["advisories"]["124"]["findings"][0]["paths"][0], ".>dev-vulnerable");
+    mock.assert();
+}
+
+#[test]
+fn audit_exits_zero_when_every_vulnerability_is_below_audit_level() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(
+        &mut registry,
+        &advisory_response(
+            "vulnerable",
+            125,
+            "moderate",
+            "<2.0.0",
+            "moderate vulnerability",
+            "GHSA-modr-1111-2222",
+        ),
+    )
+    .create();
+    write_audit_workspace(&workspace, &registry.url(), "");
+
+    let output =
+        pacquet.arg("audit").arg("--audit-level").arg("high").output().expect("run pacquet audit");
+
+    assert_success(&output);
+    assert_eq!(stdout(&output), "1 vulnerabilities found\nSeverity: 1 moderate");
+    mock.assert();
+}
+
+#[test]
+fn audit_json_filters_advisories_by_audit_level() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(
+        &mut registry,
+        r#"{
+  "vulnerable": [
+    {
+      "id": 201,
+      "url": "https://github.com/advisories/GHSA-loww-1111-2222",
+      "title": "low vulnerability",
+      "severity": "low",
+      "vulnerable_versions": "<2.0.0"
+    },
+    {
+      "id": 202,
+      "url": "https://github.com/advisories/GHSA-high-1111-2222",
+      "title": "high vulnerability",
+      "severity": "high",
+      "vulnerable_versions": "<2.0.0"
+    },
+    {
+      "id": 203,
+      "url": "https://github.com/advisories/GHSA-crit-1111-2222",
+      "title": "critical vulnerability",
+      "severity": "critical",
+      "vulnerable_versions": "<2.0.0"
+    }
+  ]
+}"#,
+    )
+    .create();
+    write_audit_workspace(&workspace, &registry.url(), "");
+
+    let output = pacquet
+        .arg("audit")
+        .arg("--json")
+        .arg("--audit-level")
+        .arg("high")
+        .output()
+        .expect("run pacquet audit");
+
+    assert_eq!(output.status.code(), Some(1));
+    let report: serde_json::Value = serde_json::from_str(&stdout(&output)).unwrap();
+    let advisories = report["advisories"].as_object().unwrap();
+    assert!(!advisories.contains_key("201"));
+    assert_eq!(advisories["202"]["severity"], "high");
+    assert_eq!(advisories["203"]["severity"], "critical");
+    mock.assert();
+}
+
+#[test]
+fn audit_ignore_registry_errors_keeps_exit_code_zero() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = registry
+        .mock("POST", "/-/npm/v1/security/advisories/bulk")
+        .with_status(500)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"message":"Something bad happened"}"#)
+        .create();
+    write_audit_workspace(&workspace, &registry.url(), "");
+
+    let output =
+        pacquet.arg("audit").arg("--ignore-registry-errors").output().expect("run pacquet audit");
+
+    assert_success(&output);
+    assert!(stdout(&output).contains("responded with 500"));
+    assert!(stdout(&output).contains(r#"{"message":"Something bad happened"}"#));
+    mock.assert();
+}
+
+#[test]
+fn audit_sends_auth_token() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = registry
+        .mock("POST", "/-/npm/v1/security/advisories/bulk")
+        .match_header("authorization", "Bearer 123")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("{}")
+        .create();
+    write_audit_workspace_with_npmrc(
+        &workspace,
+        &format!("registry={}/\n{}/:_authToken=123\n", registry.url(), nerf(&registry.url())),
+        "",
+    );
+
+    let output = pacquet.arg("audit").output().expect("run pacquet audit");
+
+    assert_success(&output);
+    assert_eq!(stdout(&output), "No known vulnerabilities found\n");
+    mock.assert();
+}
+
+#[test]
+fn audit_omits_authorization_header_without_credentials() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = registry
+        .mock("POST", "/-/npm/v1/security/advisories/bulk")
+        .match_header("authorization", Matcher::Missing)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("{}")
+        .create();
+    write_audit_workspace(&workspace, &registry.url(), "");
+
+    let output = pacquet.arg("audit").output().expect("run pacquet audit");
+
+    assert_success(&output);
+    mock.assert();
+}
+
+#[test]
+fn audit_endpoint_not_exists_reports_dedicated_error() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = registry
+        .mock("POST", "/-/npm/v1/security/advisories/bulk")
+        .with_status(404)
+        .with_header("content-type", "application/json")
+        .with_body("{}")
+        .create();
+    write_audit_workspace(&workspace, &registry.url(), "");
+
+    let output = pacquet.arg("audit").output().expect("run pacquet audit");
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains("ERR_PNPM_AUDIT_ENDPOINT_NOT_EXISTS"));
+    assert!(stderr(&output).contains("doesn't exist"));
+    mock.assert();
+}
+
+#[test]
+fn audit_invalid_json_reports_bad_response() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(&mut registry, "not json <html>").create();
+    write_audit_workspace(&workspace, &registry.url(), "");
+
+    let output = pacquet.arg("audit").output().expect("run pacquet audit");
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains("ERR_PNPM_AUDIT_BAD_RESPONSE"));
+    assert!(stderr(&output).contains("invalid JSON"));
+    assert!(stderr(&output).contains("not json <html>"));
+    mock.assert();
+}
+
+#[test]
+fn audit_unexpected_json_body_reports_bad_response() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(&mut registry, "[]").create();
+    write_audit_workspace(&workspace, &registry.url(), "");
+
+    let output = pacquet.arg("audit").output().expect("run pacquet audit");
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains("ERR_PNPM_AUDIT_BAD_RESPONSE"));
+    assert!(stderr(&output).contains("unexpected body"));
+    mock.assert();
+}
+
+#[test]
+fn audit_ignores_configured_ghsas_in_text_report() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(
+        &mut registry,
+        &advisory_response(
+            "vulnerable",
+            301,
+            "high",
+            "<2.0.0",
+            "ignored vulnerability",
+            "GHSA-ignr-1111-2222",
+        ),
+    )
+    .create();
+    write_audit_workspace(
+        &workspace,
+        &registry.url(),
+        "auditConfig:\n  ignoreGhsas:\n    - GHSA-ignr-1111-2222\n",
+    );
+
+    let output =
+        pacquet.arg("audit").arg("--audit-level").arg("moderate").output().expect("run pacquet");
+
+    assert_success(&output);
+    let stdout = stdout(&output);
+    assert!(!stdout.contains("ignored vulnerability"));
+    assert!(stdout.contains("1 high (1 ignored)"));
+    mock.assert();
+}
+
+#[test]
+fn audit_ignores_configured_ghsas_in_json_report() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(
+        &mut registry,
+        r#"{
+  "vulnerable": [
+    {
+      "id": 401,
+      "url": "https://github.com/advisories/GHSA-ignr-1111-2222",
+      "title": "ignored vulnerability",
+      "severity": "high",
+      "vulnerable_versions": "<2.0.0"
+    },
+    {
+      "id": 402,
+      "url": "https://github.com/advisories/GHSA-visi-1111-2222",
+      "title": "visible vulnerability",
+      "severity": "critical",
+      "vulnerable_versions": "<2.0.0"
+    }
+  ]
+}"#,
+    )
+    .create();
+    write_audit_workspace(
+        &workspace,
+        &registry.url(),
+        "auditConfig:\n  ignoreGhsas:\n    - GHSA-ignr-1111-2222\n",
+    );
+
+    let output = pacquet.arg("audit").arg("--json").output().expect("run pacquet audit");
+
+    assert_eq!(output.status.code(), Some(1));
+    let report: serde_json::Value = serde_json::from_str(&stdout(&output)).unwrap();
+    let advisories = report["advisories"].as_object().unwrap();
+    assert!(!advisories.contains_key("401"));
+    assert_eq!(advisories["402"]["title"], "visible vulnerability");
+    assert_eq!(report["metadata"]["vulnerabilities"]["high"], 1);
+    mock.assert();
+}
+
+#[test]
+fn audit_level_info_includes_info_advisories() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(
+        &mut registry,
+        &advisory_response("info-pkg", 501, "info", "*", "just some info", "GHSA-info-info-info"),
+    )
+    .create();
+    write_audit_workspace(&workspace, &registry.url(), "");
+
+    let output =
+        pacquet.arg("audit").arg("--audit-level").arg("info").output().expect("run pacquet audit");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = stdout(&output);
+    assert!(stdout.contains("just some info"));
+    assert!(stdout.contains("info"));
+    mock.assert();
+}
+
+#[test]
+fn audit_defaults_to_low_and_ignores_info_for_exit_code() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(
+        &mut registry,
+        &advisory_response("info-pkg", 502, "info", "*", "just some info", "GHSA-info-info-info"),
+    )
+    .create();
+    write_audit_workspace(&workspace, &registry.url(), "");
+
+    let output = pacquet.arg("audit").output().expect("run pacquet audit");
+
+    assert_success(&output);
+    assert_eq!(stdout(&output), "1 vulnerabilities found\nSeverity: 1 info");
+    mock.assert();
+}
+
+#[test]
+fn audit_signatures_is_reported_as_unsupported() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    write_minimal_manifest(&workspace);
+
+    let output = pacquet.arg("audit").arg("signatures").output().expect("run pacquet audit");
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains("not supported yet"));
+}
+
+#[test]
+fn audit_rejects_unknown_subcommands() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    write_minimal_manifest(&workspace);
+
+    let output = pacquet.arg("audit").arg("unknown").output().expect("run pacquet audit");
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains("ERR_PNPM_AUDIT_UNKNOWN_SUBCOMMAND"));
+    assert!(stderr(&output).contains("Unknown audit subcommand: unknown"));
+}
+
+#[test]
+fn audit_fix_options_are_reported_as_unsupported() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    write_minimal_manifest(&workspace);
+
+    let output = pacquet.arg("audit").arg("--fix").output().expect("run pacquet audit");
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains("unexpected argument '--fix'"));
+}
+
+#[test]
+fn audit_ignore_options_are_reported_as_unsupported() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    write_minimal_manifest(&workspace);
+
+    let output = pacquet.arg("audit").arg("--ignore").arg("GHSA-test-1111-2222").output().unwrap();
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains("unexpected argument '--ignore'"));
+}
+
+#[test]
+fn audit_ignore_unfixable_options_are_reported_as_unsupported() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    write_minimal_manifest(&workspace);
+
+    let output = pacquet.arg("audit").arg("--ignore-unfixable").output().unwrap();
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains("unexpected argument '--ignore-unfixable'"));
+}
+
+#[test]
+fn audit_interactive_fix_options_are_reported_as_unsupported() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    write_minimal_manifest(&workspace);
+
+    let output = pacquet.arg("audit").arg("--fix").arg("--interactive").output().unwrap();
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains("unexpected argument '--fix'"));
+}
+
+fn audit_mock(registry: &mut mockito::Server, body: &str) -> mockito::Mock {
+    registry
+        .mock("POST", "/-/npm/v1/security/advisories/bulk")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(body)
+}
+
+fn advisory_response(
+    package: &str,
+    id: u64,
+    severity: &str,
+    vulnerable_versions: &str,
+    title: &str,
+    ghsa: &str,
+) -> String {
+    format!(
+        r#"{{
+  "{package}": [
+    {{
+      "id": {id},
+      "url": "https://github.com/advisories/{ghsa}",
+      "title": "{title}",
+      "severity": "{severity}",
+      "vulnerable_versions": "{vulnerable_versions}",
+      "cwe": []
+    }}
+  ]
+}}"#,
+    )
+}
+
+fn write_audit_workspace(workspace: &Path, registry_url: &str, workspace_yaml: &str) {
+    write_audit_workspace_with_npmrc(
+        workspace,
+        &format!("registry={registry_url}/\n"),
+        workspace_yaml,
+    );
+}
+
+fn write_audit_workspace_with_npmrc(workspace: &Path, npmrc: &str, workspace_yaml: &str) {
+    fs::write(workspace.join(".npmrc"), npmrc).expect("write .npmrc");
+    fs::write(workspace.join("pnpm-workspace.yaml"), format!("fetchRetries: 0\n{workspace_yaml}"))
+        .expect("write workspace manifest");
     fs::write(
         workspace.join("package.json"),
-        r#"{"name":"audit-test","version":"1.0.0","dependencies":{"vulnerable":"1.0.0"}}"#,
+        r#"{"name":"audit-test","version":"1.0.0","dependencies":{"vulnerable":"1.0.0","moderate-pkg":"1.0.0","info-pkg":"1.0.0"},"devDependencies":{"dev-vulnerable":"1.0.0"},"optionalDependencies":{"optional-vulnerable":"1.0.0"}}"#,
     )
     .expect("write package.json");
     fs::write(
@@ -45,22 +521,58 @@ importers:
       vulnerable:
         specifier: '1.0.0'
         version: '1.0.0'
+      moderate-pkg:
+        specifier: '1.0.0'
+        version: '1.0.0'
+      info-pkg:
+        specifier: '1.0.0'
+        version: '1.0.0'
+    devDependencies:
+      dev-vulnerable:
+        specifier: '1.0.0'
+        version: '1.0.0'
+    optionalDependencies:
+      optional-vulnerable:
+        specifier: '1.0.0'
+        version: '1.0.0'
 
 snapshots:
 
   vulnerable@1.0.0: {}
+
+  moderate-pkg@1.0.0: {}
+
+  info-pkg@1.0.0: {}
+
+  dev-vulnerable@1.0.0: {}
+
+  optional-vulnerable@1.0.0: {}
 ",
     )
     .expect("write lockfile");
+}
 
-    let output = pacquet.arg("audit").arg("--json").output().expect("run pacquet audit");
+fn write_minimal_manifest(workspace: &Path) {
+    fs::write(workspace.join("package.json"), r#"{"name":"audit-test","version":"1.0.0"}"#)
+        .expect("write package.json");
+}
 
-    assert_eq!(output.status.code(), Some(1), "vulnerability should produce exit code 1");
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let report: serde_json::Value = serde_json::from_str(&stdout).expect("audit JSON output");
-    assert_eq!(report["advisories"]["123"]["title"], "test vulnerability");
-    assert_eq!(report["advisories"]["123"]["module_name"], "vulnerable");
-    assert_eq!(report["advisories"]["123"]["findings"][0]["paths"][0], ".>vulnerable");
-    assert_eq!(report["metadata"]["vulnerabilities"]["high"], 1);
-    mock.assert();
+fn nerf(registry_url: &str) -> &str {
+    registry_url.strip_prefix("http:").expect("mockito registry uses http")
+}
+
+fn assert_success(output: &Output) {
+    assert!(output.status.success(), "stderr:\n{}", stderr(output));
+}
+
+fn assert_failure(output: &Output) {
+    assert!(!output.status.success(), "stdout:\n{}", stdout(output));
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
 }

--- a/pacquet/crates/cli/tests/audit.rs
+++ b/pacquet/crates/cli/tests/audit.rs
@@ -172,7 +172,7 @@ fn audit_ignore_registry_errors_keeps_exit_code_zero() {
         .mock("POST", "/-/npm/v1/security/advisories/bulk")
         .with_status(500)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"message":"Something bad happened"}"#)
+        .with_body("Something bad happened \u{1b}[31m\n")
         .create();
     write_audit_workspace(&workspace, &registry.url(), "");
 
@@ -180,8 +180,46 @@ fn audit_ignore_registry_errors_keeps_exit_code_zero() {
         pacquet.arg("audit").arg("--ignore-registry-errors").output().expect("run pacquet audit");
 
     assert_success(&output);
-    assert!(stdout(&output).contains("responded with 500"));
-    assert!(stdout(&output).contains(r#"{"message":"Something bad happened"}"#));
+    assert_eq!(stdout(&output), "");
+    let stderr = stderr(&output);
+    eprintln!("STDERR:\n{stderr}\n");
+    assert!(stderr.contains("responded with 500"));
+    assert!(stderr.contains(r"Something bad happened \u{1b}[31m\u{a}"));
+    assert!(!stderr.contains('\u{1b}'));
+    mock.assert();
+}
+
+#[test]
+fn audit_json_ignore_registry_errors_keeps_stdout_parseable() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = registry
+        .mock("POST", "/-/npm/v1/security/advisories/bulk")
+        .with_status(500)
+        .with_header("content-type", "application/json")
+        .with_body("bad \u{1b}[31m")
+        .create();
+    write_audit_workspace(&workspace, &registry.url(), "");
+
+    let output = pacquet
+        .arg("audit")
+        .arg("--json")
+        .arg("--ignore-registry-errors")
+        .output()
+        .expect("run pacquet audit");
+
+    assert_success(&output);
+    let report: serde_json::Value = serde_json::from_str(&stdout(&output)).unwrap();
+    assert_eq!(report["advisories"].as_object().unwrap().len(), 0);
+    assert_eq!(report["metadata"]["vulnerabilities"]["high"], 0);
+    assert_eq!(report["metadata"]["dependencies"], 3);
+    assert_eq!(report["metadata"]["devDependencies"], 1);
+    assert_eq!(report["metadata"]["optionalDependencies"], 1);
+    assert_eq!(report["metadata"]["totalDependencies"], 5);
+    let stderr = stderr(&output);
+    eprintln!("STDERR:\n{stderr}\n");
+    assert!(stderr.contains(r"bad \u{1b}[31m"));
+    assert!(!stderr.contains('\u{1b}'));
     mock.assert();
 }
 

--- a/pacquet/crates/cli/tests/audit.rs
+++ b/pacquet/crates/cli/tests/audit.rs
@@ -1,0 +1,66 @@
+use pacquet_testing_utils::bin::CommandTempCwd;
+use std::fs;
+
+#[test]
+fn audit_json_posts_bulk_request_and_exits_on_vulnerability() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = registry
+        .mock("POST", "/-/npm/v1/security/advisories/bulk")
+        .match_body(mockito::Matcher::PartialJsonString(r#"{"vulnerable":["1.0.0"]}"#.to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{
+  "vulnerable": [
+    {
+      "id": 123,
+      "url": "https://github.com/advisories/GHSA-test-1111-2222",
+      "title": "test vulnerability",
+      "severity": "high",
+      "vulnerable_versions": "<2.0.0",
+      "cwe": "CWE-79"
+    }
+  ]
+}"#,
+        )
+        .create();
+
+    fs::write(workspace.join(".npmrc"), format!("registry={}/\n", registry.url()))
+        .expect("write .npmrc");
+    fs::write(
+        workspace.join("package.json"),
+        r#"{"name":"audit-test","version":"1.0.0","dependencies":{"vulnerable":"1.0.0"}}"#,
+    )
+    .expect("write package.json");
+    fs::write(
+        workspace.join("pnpm-lock.yaml"),
+        r"
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      vulnerable:
+        specifier: '1.0.0'
+        version: '1.0.0'
+
+snapshots:
+
+  vulnerable@1.0.0: {}
+",
+    )
+    .expect("write lockfile");
+
+    let output = pacquet.arg("audit").arg("--json").output().expect("run pacquet audit");
+
+    assert_eq!(output.status.code(), Some(1), "vulnerability should produce exit code 1");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let report: serde_json::Value = serde_json::from_str(&stdout).expect("audit JSON output");
+    assert_eq!(report["advisories"]["123"]["title"], "test vulnerability");
+    assert_eq!(report["advisories"]["123"]["module_name"], "vulnerable");
+    assert_eq!(report["advisories"]["123"]["findings"][0]["paths"][0], ".>vulnerable");
+    assert_eq!(report["metadata"]["vulnerabilities"]["high"], 1);
+    mock.assert();
+}

--- a/pacquet/crates/config/src/env_overlay.rs
+++ b/pacquet/crates/config/src/env_overlay.rs
@@ -17,7 +17,7 @@
 //! [`config/reader/src/index.ts:719-722`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/index.ts#L719-L722).
 
 use crate::{
-    CatalogMode, HoistingLimits, NodeLinker, NodePackageMapType, PackageImportMethod,
+    AuditLevel, CatalogMode, HoistingLimits, NodeLinker, NodePackageMapType, PackageImportMethod,
     ResolutionMode, ScriptsPrependNodePath, TrustPolicy, WorkspaceSettings, api::EnvVar,
 };
 use serde::de::DeserializeOwned;
@@ -206,6 +206,8 @@ impl WorkspaceSettings {
         json_field!(minimum_release_age_strict, "MINIMUM_RELEASE_AGE_STRICT");
         json_field!(trust_lockfile, "TRUST_LOCKFILE");
         enum_field!(trust_policy, "TRUST_POLICY", TrustPolicy);
+        enum_field!(audit_level, "AUDIT_LEVEL", AuditLevel);
+        json_field!(audit_config, "AUDIT_CONFIG");
         json_field!(trust_policy_exclude, "TRUST_POLICY_EXCLUDE");
         json_field!(trust_policy_ignore_after, "TRUST_POLICY_IGNORE_AFTER");
         enum_field!(resolution_mode, "RESOLUTION_MODE", ResolutionMode);

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -114,6 +114,30 @@ pub enum TrustPolicy {
     NoDowngrade,
 }
 
+/// Minimum advisory severity shown by `pnpm audit`.
+///
+/// Mirrors `Config.auditLevel` in pnpm's config reader. The command-level
+/// default is `low`, so [`Config::audit_level`] stays optional and the audit
+/// command applies the fallback when the setting is unset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AuditLevel {
+    Info,
+    Low,
+    Moderate,
+    High,
+    Critical,
+}
+
+/// `auditConfig` from `pnpm-workspace.yaml`.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct AuditConfig {
+    /// GHSA identifiers that `pnpm audit` should suppress in the rendered
+    /// report.
+    pub ignore_ghsas: Vec<String>,
+}
+
 /// Tri-state mirror of `pacquet_executor::ScriptsPrependNodePath`
 /// with serde wiring. The executor crate keeps its own enum free of
 /// serde so config concerns don't leak into the spawn-path. Converted
@@ -1344,6 +1368,12 @@ pub struct Config {
     /// Trust-evidence policy applied to lockfile entries; see
     /// [`TrustPolicy`].
     pub trust_policy: TrustPolicy,
+
+    /// `audit-level` / `auditLevel` config for `pnpm audit`.
+    pub audit_level: Option<AuditLevel>,
+
+    /// `auditConfig` config for `pnpm audit`.
+    pub audit_config: AuditConfig,
 
     /// Glob-style `name[@version]` patterns that opt specific packages
     /// out of the [`trust_policy`] check. Mirrors pnpm's

--- a/pacquet/crates/config/src/workspace_yaml.rs
+++ b/pacquet/crates/config/src/workspace_yaml.rs
@@ -1,7 +1,7 @@
 use crate::{
-    CatalogMode, Config, HoistingLimits, LinkWorkspacePackages, NodeLinker, NodePackageMapType,
-    PackageImportMethod, ResolutionMode, ScriptsPrependNodePath, TrustPolicy, api::EnvVar,
-    resolve_child_concurrency,
+    AuditConfig, AuditLevel, CatalogMode, Config, HoistingLimits, LinkWorkspacePackages,
+    NodeLinker, NodePackageMapType, PackageImportMethod, ResolutionMode, ScriptsPrependNodePath,
+    TrustPolicy, api::EnvVar, resolve_child_concurrency,
 };
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
@@ -373,6 +373,12 @@ pub struct WorkspaceSettings {
 
     /// `trustPolicy` from `pnpm-workspace.yaml`. See [`TrustPolicy`].
     pub trust_policy: Option<TrustPolicy>,
+
+    /// `auditLevel` from `pnpm-workspace.yaml`.
+    pub audit_level: Option<AuditLevel>,
+
+    /// `auditConfig` from `pnpm-workspace.yaml`.
+    pub audit_config: Option<AuditConfig>,
 
     /// `trustPolicyExclude` from `pnpm-workspace.yaml`.
     pub trust_policy_exclude: Option<Vec<String>>,
@@ -866,6 +872,12 @@ impl WorkspaceSettings {
         }
         if let Some(v) = self.trust_policy {
             config.trust_policy = v;
+        }
+        if let Some(v) = self.audit_level {
+            config.audit_level = Some(v);
+        }
+        if let Some(v) = self.audit_config {
+            config.audit_config = v;
         }
         if let Some(v) = self.trust_policy_exclude {
             config.trust_policy_exclude = Some(v);

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -115,6 +115,8 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         minimum_release_age_strict: None,
         trust_lockfile: false,
         trust_policy: Default::default(),
+        audit_level: None,
+        audit_config: Default::default(),
         trust_policy_exclude: None,
         trust_policy_ignore_after: None,
         resolution_mode: Default::default(),


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Ports the main `pnpm audit` report path to the Rust pacquet CLI. The command now reads wanted and env lockfiles, sends npm bulk audit requests with auth/retry behavior, renders JSON/text reports, honors dependency filters, `auditLevel`, `auditConfig.ignoreGhsas`, and `--ignore-registry-errors`, and exits non-zero for visible vulnerabilities.

This PR does not port `audit --fix`, `audit --ignore`, or `audit signatures` yet; unsupported paths are rejected instead of silently doing partial work. The TypeScript CLI already owns those surfaces.

## Squash Commit Body

```text
Port the main audit report path to pacquet.

The new command builds npm bulk audit requests from the wanted lockfile and env lockfile, posts them to the configured registry with auth and retry settings, reconstructs advisory findings from installed dependency paths, and renders pnpm-style JSON and text reports.

The implementation wires auditLevel and auditConfig.ignoreGhsas into pacquet config loading so severity filtering and GHSA ignores match the existing TypeScript audit report behavior. It also preserves the audit exit-code contract by returning a failing process status when visible advisories meet the selected severity threshold.

`audit fix`, `audit ignore`, and `audit signatures` are intentionally left unsupported in this PR because they require additional mutation and signature-verification surfaces.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `pacquet audit` command to scan installed packages for known security issues, with JSON/text reports that include vulnerability counts and dependency paths.
  * Added configurable audit severity and ignore rules via workspace YAML and `PNPM_CONFIG_AUDIT_*` environment variables (`auditLevel`, `auditConfig.ignoreGhsa`).

* **Bug Fixes**
  * Improved report filtering (audit level + ignored advisories), dependency path reporting, and credential redaction in audit endpoint URLs.
  * The CLI now returns failure when vulnerabilities meet/exceed the selected audit level, while supporting “ignore registry errors”.

* **Tests**
  * Expanded CLI unit and integration test coverage for request/response handling, scoping, and reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->