### PR TITLE
ci: gate the docker.yml workflow_dispatch build behind the release environment

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

`docker.yml` can be triggered via `workflow_dispatch`, and its `build` job pushes mutable image
tags (`:latest` and `:<major>`) to `ghcr.io/pnpm/pnpm`. Unlike `release.yml` and
`update-latest.yml`, the `build` job had no `environment: release` gate, so any collaborator with
write access could overwrite the public mutable tags via a manual dispatch without reviewer
approval.

This adds `environment: release` to the `build` job so `workflow_dispatch` runs require approval
from the release environment's reviewers, matching the protection already used by the other
publishing workflows. The `release` (published) event path is unaffected.

## Squash Commit Body

```text
The Docker workflow can be triggered via workflow_dispatch, and its build job pushes mutable
tags (:latest and :<major>) to ghcr.io/pnpm/pnpm. Unlike release.yml and update-latest.yml,
the build job had no environment gate, so any collaborator with write access could publish an
image to the public mutable tags without reviewer approval.

Add an environment: release gate to the build job so workflow_dispatch runs require approval
from the release environment reviewers, matching the protection already used by the other
publishing workflows. The release (published) event path is unaffected.
```

## Checklist

- [x] Added or updated tests — n/a; this is a CI workflow permission gate with no unit-testable surface.
- [x] Updated the documentation if needed — n/a.

(No changeset: no published package changes. No pacquet port needed: CI-only change.)

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release build workflow to run in the `release` environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->