### PR TITLE
ci: gate the pnpr release publish and docker jobs behind the release environment

### DIFF
--- a/.github/workflows/pnpr-release-to-npm.yml
+++ b/.github/workflows/pnpr-release-to-npm.yml
@@ -150,6 +150,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       # Required for npm provenance attestations via OIDC.
       id-token: write
@@ -222,6 +223,7 @@ jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
+    environment: release
     needs:
       - build
       - publish


### PR DESCRIPTION
## Summary

`pnpr-release-to-npm.yml` can be triggered via `workflow_dispatch`. Its `publish` job uses npm
OIDC trusted publishing to publish the `@pnpm/pnpr` package, and its `docker` job pushes the
mutable `ghcr.io/pnpm/pnpr:latest` tag. Neither job had an `environment: release` gate, so any
collaborator with write access could publish to npm and overwrite the mutable Docker tag via a
manual dispatch without reviewer approval — unlike `release.yml`, which gates its publishing job.

This adds `environment: release` to the `publish` and `docker` jobs. The `build` job produces no
externally visible artifacts and is intentionally left ungated so the matrix legs are not blocked
on approval.

## Squash Commit Body

```text
pnpr-release-to-npm.yml can be triggered via workflow_dispatch. Its publish job uses npm OIDC
trusted publishing to publish the `@pnpm/pnpr` package, and its docker job pushes the mutable
ghcr.io/pnpm/pnpr:latest tag. Neither had an environment gate, so any collaborator with write
access could publish to npm and overwrite the mutable Docker tag without reviewer approval.

Add an environment: release gate to the publish and docker jobs (the build job produces no
externally visible artifacts and is intentionally left ungated), matching the protection used
by release.yml.
```

## Checklist

- [x] Added or updated tests — n/a; CI workflow permission gate with no unit-testable surface.
- [x] Updated the documentation if needed — n/a.

(No changeset: no published package changes. CI-only change.)

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow’s environment handling for publishing and Docker-related release steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->