### PR TITLE
ci: gate the pacquet release publish job behind the release environment

### DIFF
--- a/.github/workflows/pacquet-release-to-npm.yml
+++ b/.github/workflows/pacquet-release-to-npm.yml
@@ -140,6 +140,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       # Required for npm provenance attestations via OIDC.
       id-token: write


### PR DESCRIPTION
## Summary

`pacquet-release-to-npm.yml` can be triggered via `workflow_dispatch`. Its `publish` job uses npm
OIDC trusted publishing to publish the `pacquet`, `@pnpm/pacquet`, and `pnpm-pacquet` packages
(plus the per-target sub-packages). The job had no `environment: release` gate, so any
collaborator with write access could publish these packages to npm via a manual dispatch without
reviewer approval — unlike `release.yml`, which gates its publishing job.

This adds `environment: release` to the `publish` job. The `build` job produces no externally
visible artifacts and is intentionally left ungated so the matrix legs are not blocked on approval.

## Squash Commit Body

```text
pacquet-release-to-npm.yml can be triggered via workflow_dispatch. Its publish job uses npm OIDC
trusted publishing to publish the pacquet, `@pnpm/pacquet`, and pnpm-pacquet packages. It had no
environment gate, so any collaborator with write access could publish to npm via a manual
dispatch without reviewer approval.

Add an environment: release gate to the publish job (the build job produces no externally
visible artifacts and is intentionally left ungated), matching the protection used by release.yml.
```

## Checklist

- [x] Added or updated tests — n/a; CI workflow permission gate with no unit-testable surface.
- [x] Updated the documentation if needed — n/a.

(No changeset: no published package changes. CI-only change.)

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release publishing workflow to use a dedicated release environment for npm publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->