### PR TITLE
fix(package-manifest): write package.json atomically via a temp file

### DIFF
--- a/pacquet/crates/package-manifest/Cargo.toml
+++ b/pacquet/crates/package-manifest/Cargo.toml
@@ -16,6 +16,7 @@ miette      = { workspace = true }
 serde       = { workspace = true }
 serde_json  = { workspace = true }
 strum       = { workspace = true }
+tempfile    = { workspace = true }
 
 [dev-dependencies]
 pipe-trait        = { workspace = true }

--- a/pacquet/crates/package-manifest/src/lib.rs
+++ b/pacquet/crates/package-manifest/src/lib.rs
@@ -9,6 +9,7 @@ use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use strum::IntoStaticStr;
+use tempfile::NamedTempFile;
 
 #[derive(Debug, Display, Error, Diagnostic, From)]
 #[non_exhaustive]
@@ -96,6 +97,22 @@ impl PackageManifest {
         Ok((manifest, contents))
     }
 
+    /// Write `contents` to `path` atomically: a sibling temp file is written
+    /// and fsynced, then renamed over `path`. A crash or write error therefore
+    /// never leaves a truncated or partial `package.json` behind, matching the
+    /// `write-file-atomic` guarantee the TypeScript pnpm CLI relies on.
+    fn write_atomic(path: &Path, contents: &str) -> io::Result<()> {
+        let dir = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let mut tmp = NamedTempFile::new_in(dir)?;
+        tmp.write_all(contents.as_bytes())?;
+        tmp.as_file().sync_all()?;
+        tmp.persist(path).map_err(|err| err.error)?;
+        Ok(())
+    }
+
     fn read_from_file(path: &Path) -> Result<Value, PackageManifestError> {
         let contents = fs::read_to_string(path)?;
         let mut value: Value = serde_json::from_str(&contents)?;
@@ -158,8 +175,7 @@ impl PackageManifest {
         convert_dependencies_to_engines_runtime(&mut value, "devDependencies", "devEngines")?;
         convert_dependencies_to_engines_runtime(&mut value, "dependencies", "engines")?;
         let contents = serde_json::to_string_pretty(&value)?;
-        let mut file = fs::File::create(&self.path)?;
-        file.write_all(contents.as_bytes())?;
+        Self::write_atomic(&self.path, &contents)?;
         Ok(value)
     }
 

--- a/pacquet/crates/package-manifest/src/lib.rs
+++ b/pacquet/crates/package-manifest/src/lib.rs
@@ -109,6 +109,12 @@ impl PackageManifest {
         let mut tmp = NamedTempFile::new_in(dir)?;
         tmp.write_all(contents.as_bytes())?;
         tmp.as_file().sync_all()?;
+        // A NamedTempFile is created 0o600; preserve the original file's mode
+        // when overwriting an existing package.json (write-file-atomic does the
+        // same) so the rename doesn't silently tighten its permissions.
+        if let Ok(metadata) = fs::metadata(path) {
+            tmp.as_file().set_permissions(metadata.permissions())?;
+        }
         tmp.persist(path).map_err(|err| err.error)?;
         Ok(())
     }

--- a/pacquet/crates/package-manifest/src/tests.rs
+++ b/pacquet/crates/package-manifest/src/tests.rs
@@ -15,6 +15,31 @@ use crate::DependencyGroup;
 use serde_json::json;
 use std::io::Write;
 
+#[cfg(unix)]
+#[test]
+fn save_leaves_the_original_intact_when_the_write_cannot_complete() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("package.json");
+    let original = r#"{"name":"intact","version":"1.0.0"}"#;
+    std::fs::write(&path, original).unwrap();
+
+    let manifest = PackageManifest::from_path(path.clone()).unwrap();
+
+    // Make the directory read-only so a sibling temp file cannot be created.
+    // An atomic temp-file-then-rename write fails up front and leaves the
+    // original untouched; a non-atomic in-place write would instead truncate
+    // the existing package.json before failing.
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
+    let result = manifest.save();
+    // Restore permissions before the assertions so tempdir cleanup succeeds.
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    assert!(result.is_err());
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+}
+
 #[test]
 fn test_init_package_json_content() {
     let manifest = PackageManifest::create_init_package_json("test");

--- a/pacquet/crates/package-manifest/src/tests.rs
+++ b/pacquet/crates/package-manifest/src/tests.rs
@@ -40,6 +40,25 @@ fn save_leaves_the_original_intact_when_the_write_cannot_complete() {
     assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
 }
 
+#[cfg(unix)]
+#[test]
+fn save_preserves_the_existing_package_json_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("package.json");
+    std::fs::write(&path, r#"{"name":"perm","version":"1.0.0"}"#).unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
+
+    let manifest = PackageManifest::from_path(path.clone()).unwrap();
+    manifest.save().unwrap();
+
+    // The atomic temp-file-then-rename must keep the original mode, not leave
+    // the NamedTempFile's default 0o600 behind.
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o640);
+}
+
 #[test]
 fn test_init_package_json_content() {
     let manifest = PackageManifest::create_init_package_json("test");


### PR DESCRIPTION
## Summary

`PackageManifest::save` rewrote `package.json` in place with `fs::File::create` (which truncates)
followed by `write_all`. If the process is killed (OOM, CI timeout, Ctrl-C) or the disk fills
between the truncate and the completed write, the file is left empty or partial and the user's
dependency declarations are lost with no recovery path. Every `pacquet add`, `remove`, `update`,
and `set-script` goes through this path.

This writes the serialized manifest to a sibling temp file, fsyncs it, then renames it over the
target, so a crash or write error never leaves a truncated `package.json` behind. This matches
the `write-file-atomic` guarantee the TypeScript pnpm CLI relies on for manifest writes, and the
same temp-file-then-rename pattern already used by this repo's `workspace-manifest-writer`,
`lockfile`, and `fs` crates.

`tempfile` was already a dev-dependency and a workspace dependency; it is promoted to a normal
dependency of `pacquet-package-manifest`.

## Squash Commit Body

```text
PackageManifest::save truncated package.json in place with File::create + write_all. A crash,
OOM, or ENOSPC between the truncate and the completed write left the file empty or partial,
destroying the user's dependency declarations with no recovery path. add/remove/update and
set-script all go through this path.

Write the serialized manifest to a sibling temp file, fsync it, then rename it over the target,
matching the write-file-atomic guarantee the TypeScript pnpm CLI relies on. The crate's sibling
workspace-manifest-writer already uses this pattern.
```

## Checklist

- [x] Added or updated tests — `save_leaves_the_original_intact_when_the_write_cannot_complete`
  (Unix) asserts a failed write leaves the original `package.json` byte-for-byte intact.
- [x] Updated the documentation if needed — n/a.

(No changeset: `pacquet-*` crates are `publish = false`. No pnpm-side port: this aligns pacquet
with the existing pnpm `write-file-atomic` behavior.)

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved saving of package metadata to be crash-safe, avoiding partially written or truncated `package.json`.
  * Ensures the existing `package.json` remains unchanged if the save can’t complete.
  * Preserves existing `package.json` file permissions after a successful save.

* **Tests**
  * Added Unix-gated tests to verify failed saves don’t corrupt on-disk contents and that file permissions are retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->