### PR TITLE
fix: restore pacquet current lockfile on repeat install

### DIFF
--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1598,7 +1598,7 @@ where
         )
         .map_err(InstallError::WriteModules)?;
 
-        let filtered_current_lockfile = if frozen_lockfile {
+        let filtered_current_lockfile = if take_frozen_path {
             lockfile.map(|lockfile| {
                 crate::filter_lockfile_for_current(lockfile, included, &frozen_skipped)
             })
@@ -1623,7 +1623,7 @@ where
         // <https://github.com/pnpm/pacquet/issues/299>), this needs to narrow to the filtered lockfile
         // (selected importers × engine filter) so the saved current
         // lockfile reflects only what was actually materialized.
-        if frozen_lockfile && let Some(lockfile) = filtered_current_lockfile.as_ref() {
+        if take_frozen_path && let Some(lockfile) = filtered_current_lockfile.as_ref() {
             // Filter the wanted lockfile down to the snapshots that
             // were actually materialized: dep maps the user excluded
             // (`--no-optional`, `--no-dev`) plus snapshots the

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -5095,6 +5095,107 @@ async fn fresh_install_also_writes_current_lockfile_under_virtual_store() {
     drop((dir, mock_instance));
 }
 
+#[tokio::test]
+async fn prefer_frozen_install_writes_missing_current_lockfile() {
+    let mock_instance = TestRegistry::start();
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    fs::create_dir_all(&project_root).unwrap();
+    let manifest_path = project_root.join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    manifest
+        .add_dependency("@pnpm.e2e/hello-world-js-bin", "1.0.0", DependencyGroup::Prod)
+        .unwrap();
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir;
+    config.virtual_store_dir = virtual_store_dir.clone();
+    config.registry = mock_instance.url();
+    let config = config.leak();
+
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        lockfile: MaybeLazyLockfile::Loaded(None),
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        is_full_install: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
+        dry_run: false,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+        auth_override: None,
+        resolution_observer: None,
+        catalogs_override: None,
+        disable_optimistic_repeat_install: true,
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("first install should succeed");
+
+    let current_lockfile_path = virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
+    fs::remove_file(&current_lockfile_path).expect("remove current lockfile");
+    let wanted = Lockfile::load_wanted_from_dir(&project_root)
+        .expect("parse wanted lockfile")
+        .expect("wanted lockfile should exist");
+
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        lockfile: MaybeLazyLockfile::Loaded(Some(&wanted)),
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: Some(true),
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        is_full_install: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
+        dry_run: false,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+        auth_override: None,
+        resolution_observer: None,
+        catalogs_override: None,
+        disable_optimistic_repeat_install: true,
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("prefer-frozen reinstall should succeed");
+
+    assert!(
+        current_lockfile_path.is_file(),
+        "prefer-frozen reinstall must restore the current lockfile",
+    );
+
+    drop((dir, mock_instance));
+}
+
 /// `config.lockfile = false` opts out of *both* lockfile writes (the
 /// wanted `pnpm-lock.yaml` and the per-virtual-store `lock.yaml`),
 /// matching upstream pnpm's all-or-nothing `useLockfile` behavior.

--- a/pacquet/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pacquet/crates/package-manager/src/optimistic_repeat_install.rs
@@ -275,6 +275,12 @@ pub fn check_optimistic_repeat_install(check: &OptimisticRepeatInstallCheck<'_>)
     let lockfile_modified =
         wanted_lockfile_modified(workspace_root, state.last_validated_timestamp);
 
+    match current_lockfile_missing_with_non_empty_wanted(check) {
+        Ok(true) => return Decision::Skipped { reason: "current lockfile missing" },
+        Ok(false) => {}
+        Err(reason) => return Decision::Skipped { reason },
+    }
+
     if modified.is_empty() && !lockfile_modified {
         return match regenerate_wanted_lockfile_if_missing(check, None) {
             Ok(()) => Decision::UpToDate,
@@ -902,6 +908,23 @@ fn mtime_ms(path: &Path) -> Option<i64> {
 fn wanted_lockfile_modified(workspace_root: &Path, last_validated_timestamp: i64) -> bool {
     mtime_ms(&workspace_root.join(Lockfile::FILE_NAME))
         .is_some_and(|mtime| mtime > last_validated_timestamp)
+}
+
+fn current_lockfile_missing_with_non_empty_wanted(
+    check: &OptimisticRepeatInstallCheck<'_>,
+) -> Result<bool, &'static str> {
+    if check.is_workspace_install || !check.config.lockfile {
+        return Ok(false);
+    }
+    if check.config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME).exists() {
+        return Ok(false);
+    }
+    let Some(wanted) =
+        check.lockfile.get().map_err(|_| "the wanted lockfile cannot be read or parsed")?
+    else {
+        return Ok(false);
+    };
+    Ok(wanted.packages.as_ref().is_some_and(|packages| !packages.is_empty()))
 }
 
 /// Compare today's settings against what the previous install

--- a/pacquet/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pacquet/crates/package-manager/src/optimistic_repeat_install.rs
@@ -229,7 +229,7 @@ pub fn check_optimistic_repeat_install(check: &OptimisticRepeatInstallCheck<'_>)
     // probe is handled by `wanted_lockfile_modified` below.
     if !is_workspace_install
         && !workspace_root.join(Lockfile::FILE_NAME).exists()
-        && !config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME).exists()
+        && !current_lockfile_file_has_content(&config.virtual_store_dir)
     {
         return Decision::Skipped { reason: "wanted lockfile missing" };
     }
@@ -275,7 +275,7 @@ pub fn check_optimistic_repeat_install(check: &OptimisticRepeatInstallCheck<'_>)
     let lockfile_modified =
         wanted_lockfile_modified(workspace_root, state.last_validated_timestamp);
 
-    match current_lockfile_missing_with_non_empty_wanted(check) {
+    match current_lockfile_unusable_with_non_empty_wanted(check) {
         Ok(true) => return Decision::Skipped { reason: "current lockfile missing" },
         Ok(false) => {}
         Err(reason) => return Decision::Skipped { reason },
@@ -609,7 +609,7 @@ fn modified_manifests_match_lockfile(
             // "The manifest file is not newer than the lockfile.
             // Exiting check."
             &[]
-        } else if wanted.packages.as_ref().is_some_and(|packages| !packages.is_empty()) {
+        } else if !wanted.is_empty() {
             // RUN_CHECK_DEPS_NO_DEPS: the lockfile requires
             // dependencies but nothing was ever installed.
             return Err("the lockfile requires dependencies but none were installed");
@@ -910,13 +910,13 @@ fn wanted_lockfile_modified(workspace_root: &Path, last_validated_timestamp: i64
         .is_some_and(|mtime| mtime > last_validated_timestamp)
 }
 
-fn current_lockfile_missing_with_non_empty_wanted(
+fn current_lockfile_unusable_with_non_empty_wanted(
     check: &OptimisticRepeatInstallCheck<'_>,
 ) -> Result<bool, &'static str> {
     if check.is_workspace_install || !check.config.lockfile {
         return Ok(false);
     }
-    if check.config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME).exists() {
+    if current_lockfile_file_has_content(&check.config.virtual_store_dir) {
         return Ok(false);
     }
     let Some(wanted) =
@@ -924,7 +924,12 @@ fn current_lockfile_missing_with_non_empty_wanted(
     else {
         return Ok(false);
     };
-    Ok(wanted.packages.as_ref().is_some_and(|packages| !packages.is_empty()))
+    Ok(!wanted.is_empty())
+}
+
+fn current_lockfile_file_has_content(virtual_store_dir: &Path) -> bool {
+    fs::metadata(virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME))
+        .is_ok_and(|metadata| metadata.is_file() && metadata.len() > 0)
 }
 
 /// Compare today's settings against what the previous install

--- a/pacquet/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pacquet/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -1880,6 +1880,20 @@ fn content_check_decision(
     })
 }
 
+#[test]
+fn returns_skipped_when_current_lockfile_missing_for_non_empty_wanted_lockfile() {
+    let (dir, config) = setup_content_check_project();
+    fs::remove_file(config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME)).unwrap();
+    let manifest = PackageManifest::from_path(dir.path().join("package.json")).unwrap();
+
+    let decision =
+        content_check_decision(&dir, config, false, &[(dir.path().to_path_buf(), &manifest)]);
+    assert!(
+        matches!(decision, Decision::Skipped { reason } if reason.contains("current lockfile")),
+        "expected Skipped(current lockfile missing), got {decision:?}",
+    );
+}
+
 /// A manifest rewrite that leaves the dependency fields intact — the
 /// shape `touch package.json` / `npm pkg set/delete` produce — must
 /// still short-circuit. Ports the contract behind upstream's

--- a/pacquet/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pacquet/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -1828,6 +1828,17 @@ snapshots:
   foo@1.0.0: {}
 ";
 
+const FOO_LOCKFILE_WITHOUT_PACKAGES: &str = "lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.0.0
+";
+
 const FOO_MANIFEST: &str = r#"{"name":"root","version":"1.0.0","dependencies":{"foo":"^1.0.0"}}"#;
 
 /// Build a single project whose manifest, wanted lockfile, and current
@@ -1884,6 +1895,48 @@ fn content_check_decision(
 fn returns_skipped_when_current_lockfile_missing_for_non_empty_wanted_lockfile() {
     let (dir, config) = setup_content_check_project();
     fs::remove_file(config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME)).unwrap();
+    let manifest = PackageManifest::from_path(dir.path().join("package.json")).unwrap();
+
+    let decision =
+        content_check_decision(&dir, config, false, &[(dir.path().to_path_buf(), &manifest)]);
+    assert!(
+        matches!(decision, Decision::Skipped { reason } if reason.contains("current lockfile")),
+        "expected Skipped(current lockfile missing), got {decision:?}",
+    );
+}
+
+#[test]
+fn returns_skipped_when_current_lockfile_missing_for_wanted_lockfile_with_importer_deps() {
+    let (dir, config) = setup_content_check_project();
+    let workspace_root = dir.path();
+    fs::write(workspace_root.join(Lockfile::FILE_NAME), FOO_LOCKFILE_WITHOUT_PACKAGES).unwrap();
+
+    sleep(Duration::from_millis(20));
+    let settings =
+        current_settings(config, pacquet_config::NodeLinker::Isolated, isolated_included());
+    let mut projects = BTreeMap::new();
+    projects.insert(
+        workspace_root.to_string_lossy().into_owned(),
+        ProjectEntry { name: Some("root".into()), version: Some("1.0.0".into()) },
+    );
+    write_state(workspace_root, now_millis(), settings, projects);
+    sleep(Duration::from_millis(20));
+
+    fs::remove_file(config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME)).unwrap();
+    let manifest = PackageManifest::from_path(workspace_root.join("package.json")).unwrap();
+
+    let decision =
+        content_check_decision(&dir, config, false, &[(workspace_root.to_path_buf(), &manifest)]);
+    assert!(
+        matches!(decision, Decision::Skipped { reason } if reason.contains("current lockfile")),
+        "expected Skipped(current lockfile missing), got {decision:?}",
+    );
+}
+
+#[test]
+fn returns_skipped_when_current_lockfile_is_empty_for_non_empty_wanted_lockfile() {
+    let (dir, config) = setup_content_check_project();
+    fs::write(config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME), "").unwrap();
     let manifest = PackageManifest::from_path(dir.path().join("package.json")).unwrap();
 
     let decision =


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#12582.

- Prevents pacquet's optimistic repeat-install check from reporting `Already up to date` when the wanted lockfile records packages but the current lockfile under the virtual store is missing.
- Persists the current lockfile after the `preferFrozenLockfile` auto-frozen materialization path, not only after explicit `--frozen-lockfile`.
- Adds regression coverage for both the fast-path decision and the prefer-frozen reinstall path.

## Squash Commit Body

```text
Pacquet could leave node_modules/.pnpm/lock.yaml missing after a repeat install when the wanted lockfile was still present but the current lockfile had been deleted. The optimistic repeat-install check only considered workspace state, manifest mtimes, and wanted lockfile mtimes, so it could return "Already up to date" before the install path had a chance to rebuild the current lockfile.

Make the optimistic check fall through for single-project installs when the wanted lockfile has package entries but the current lockfile is absent. Also persist the filtered current lockfile whenever pacquet actually takes the frozen materialization path, including the implicit preferFrozenLockfile path, so the full reinstall repairs the missing file.

Fixes pnpm/pnpm#12582.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  TypeScript pnpm already repairs this scenario; this PR ports the matching behavior to pacquet.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.
  Not needed; this is a parity bug fix with no documented surface change.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved install behavior so missing current lockfile content is recreated for both explicit frozen and auto-frozen installs.
  * Refined optimistic repeat-install fast-path detection to treat an empty/missing virtual-store lockfile as unusable when dependency data is expected, avoiding incorrect skips.
* **Tests**
  * Added new async coverage ensuring frozen/auto-frozen installs restore a deleted current lockfile.
  * Added content-check tests for optimistic repeat installs when the current lockfile is missing or lacks dependency data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->