### PR TITLE
test(git-fetcher): cover `bundleDependencies` closure depth cap

### DIFF
--- a/pacquet/crates/git-fetcher/src/packlist/tests.rs
+++ b/pacquet/crates/git-fetcher/src/packlist/tests.rs
@@ -610,6 +610,62 @@ fn bundle_dependencies_self_cycle_is_caught() {
 }
 
 #[test]
+fn bundle_dependencies_closure_stops_past_max_depth() {
+    // On top of the visited-set, the closure walk carries a
+    // belt-and-braces `MAX_BUNDLE_DEPTH` cap: a pathological chain of
+    // `dependencies` that keeps resolving fresh, never-repeating
+    // canonical paths would slip past the cycle check and descend
+    // forever. Build a linear chain longer than the cap (each package
+    // depends on the next) and assert the packages beyond it are
+    // refused while everything within it still ships.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+
+    // The cap refuses any task whose depth exceeds 32. Tasks are
+    // depth-0 for the root's bundle seed and gain one level per
+    // `dependencies` hop, so `p33` is the first package created beyond
+    // the cap. Lay the chain out hoisted-flat under the root
+    // `node_modules/`: the walk-up resolves `p{n+1}` from there while
+    // the depth counter still climbs one per hop.
+    const FIRST_REFUSED: usize = 33;
+    const LAST: usize = FIRST_REFUSED + 1;
+    for n in 0..=LAST {
+        let deps = if n < LAST {
+            format!(r#","dependencies":{{"p{}":"1.0.0"}}"#, n + 1)
+        } else {
+            String::new()
+        };
+        write(
+            root,
+            &format!("node_modules/p{n}/package.json"),
+            &format!(r#"{{"name":"p{n}","version":"1.0.0"{deps}}}"#),
+        );
+        touch(root, &format!("node_modules/p{n}/index.js"));
+    }
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "bundleDependencies": ["p0"],
+    });
+    let out = packlist(root, &manifest).unwrap();
+
+    // The last package within the cap (depth 32) is processed and ships.
+    assert!(
+        out.contains(&format!("node_modules/p{}/index.js", FIRST_REFUSED - 1)),
+        "packages within MAX_BUNDLE_DEPTH must ship: {out:?}",
+    );
+    // `p33` is created at depth 33 (> 32); the cap refuses to descend,
+    // so it and everything past it are dropped even though they exist
+    // on disk.
+    assert!(
+        !out.iter().any(|p| p.starts_with(&format!("node_modules/p{FIRST_REFUSED}/"))),
+        "packages past MAX_BUNDLE_DEPTH must be refused: {out:?}",
+    );
+}
+
+#[test]
 fn main_field_pointing_at_always_excluded_basename_is_refused() {
     let dir = tempdir().unwrap();
     let root = dir.path();

--- a/pacquet/crates/git-fetcher/src/packlist/tests.rs
+++ b/pacquet/crates/git-fetcher/src/packlist/tests.rs
@@ -634,10 +634,11 @@ fn bundle_dependencies_closure_stops_past_max_depth() {
         // Every package except the last depends on the next one, forming the
         // linear chain.
         let manifest = if n < LAST {
+            let next = format!("p{}", n + 1);
             json!({
                 "name": format!("p{n}"),
                 "version": "1.0.0",
-                "dependencies": { (format!("p{}", n + 1)): "1.0.0" },
+                "dependencies": { (next): "1.0.0" },
             })
         } else {
             json!({

--- a/pacquet/crates/git-fetcher/src/packlist/tests.rs
+++ b/pacquet/crates/git-fetcher/src/packlist/tests.rs
@@ -631,16 +631,21 @@ fn bundle_dependencies_closure_stops_past_max_depth() {
     const FIRST_REFUSED: usize = 33;
     const LAST: usize = FIRST_REFUSED + 1;
     for n in 0..=LAST {
-        let deps = if n < LAST {
-            format!(r#","dependencies":{{"p{}":"1.0.0"}}"#, n + 1)
+        // Every package except the last depends on the next one, forming the
+        // linear chain.
+        let manifest = if n < LAST {
+            json!({
+                "name": format!("p{n}"),
+                "version": "1.0.0",
+                "dependencies": { (format!("p{}", n + 1)): "1.0.0" },
+            })
         } else {
-            String::new()
+            json!({
+                "name": format!("p{n}"),
+                "version": "1.0.0",
+            })
         };
-        write(
-            root,
-            &format!("node_modules/p{n}/package.json"),
-            &format!(r#"{{"name":"p{n}","version":"1.0.0"{deps}}}"#),
-        );
+        write(root, &format!("node_modules/p{n}/package.json"), &manifest.to_string());
         touch(root, &format!("node_modules/p{n}/index.js"));
     }
 


### PR DESCRIPTION
## Summary

Adds a regression test that closes a coverage hole left by pnpm/pnpm#12620 (the `bundleDependencies`-closure rewrite in the pacquet git-fetcher).

#12620 replaced the per-dependency recursion in `pacquet/crates/git-fetcher/src/packlist.rs` with `npm-bundled`'s reachability walk, and added a `MAX_BUNDLE_DEPTH` (32) belt-and-braces cap on top of the visited-set. CodeCov flagged the cap's `warn`-and-`continue` branch (`packlist.rs:143-150`) as uncovered: every existing closure test terminates through the visited-set (a cycle / diamond resolving back to an already-seen canonical path), so the depth counter was never the thing that stopped the walk.

This test builds a linear `dependencies` chain longer than the cap, with every package resolving to a fresh, never-repeating canonical path so the visited-set can't short-circuit it — the only way to make the depth counter, rather than the visited-set, terminate the walk. It asserts that packages within the cap (depth ≤ 32) still ship while the first package created past it (depth 33) and everything beyond is refused. A mutation check (raising the cap so the over-limit package ships) confirms the assertion actually exercises the branch.

Coverage on `packlist.rs` after this change: lines `143-150` move from uncovered to covered.

### Remaining uncovered lines in the #12620 diff (intentionally not chased)

For reviewers comparing against the CodeCov report, the other uncovered added lines are deliberate:

- `192` `(Some(_), None) => true` and `195` lexical fallback — fail-closed arms that fire only when `fs::canonicalize` returns `Err` on a path that exists. No portable fixture can produce that (a resolved dependency with a readable `package.json`, and the package root, always canonicalize), so reaching them would need a filesystem-error dependency-injection seam that `packlist.rs` does not currently thread. Left for a follow-up if we decide to add that seam.
- `168` / `201` — field-formatting closures inside `tracing::debug!` / `tracing::warn!`; their enclosing branches (resolve-miss skip, symlink escape refusal) are already covered, only the log-arg closures stay uncovered without an active subscriber. Cosmetic, no behavioral value.
- `244` — `parent == current → None` in `resolve_bundled_dependency`'s walk-up is dead code given the call contract (`current == root` always returns first); unreachable without violating the function's contract.

## Squash Commit Body

```text
test(git-fetcher): cover bundleDependencies closure depth cap

The MAX_BUNDLE_DEPTH belt-and-braces guard in collect_bundled_files
(added in pnpm/pnpm#12620) had no coverage: the existing closure tests
all terminate through the visited-set, never the depth counter, leaving
packlist.rs lines 143-150 uncovered in the CodeCov report.

Add a test that builds a linear `dependencies` chain longer than the cap,
with every package resolving to a fresh canonical path so the visited-set
can't short-circuit the walk. It asserts packages created past depth 32
are refused while everything within the cap still ships, exercising the
warn-and-continue branch.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. *(Test-only change to the Rust port; no behavior change, nothing to port.)*
- [x] Added or updated tests. *(This PR is the test.)*

<!-- Not applicable: -->
<!-- - Changeset: test-only, no published-package change. -->
<!-- - Documentation: no user-facing surface change. -->

---
Written by an agent (Claude Code, Claude Opus 4.8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for dependency bundling limits to ensure packages deeper than the supported depth are excluded from bundled output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->