### PR TITLE
fix(pnpr): bound libsql auth backend reads with a timeout

### DIFF
--- a/pnpr/crates/pnpr/src/auth.rs
+++ b/pnpr/crates/pnpr/src/auth.rs
@@ -55,6 +55,25 @@ mod libsql_backend;
 #[cfg(any(feature = "backend-postgres", feature = "backend-mysql"))]
 mod sqlx_backend;
 
+/// Bound a read-only request-path or startup database future with a
+/// deadline, surfacing [`RegistryError::AuthDatabaseTimeout`] on expiry.
+/// Use only around reads and startup setup: request-path writes must
+/// await the database result directly, so a caller never observes a
+/// timeout with an unknown commit state.
+#[cfg(any(feature = "backend-libsql", feature = "backend-postgres", feature = "backend-mysql"))]
+async fn with_auth_timeout<Loaded, DbError>(
+    deadline: std::time::Duration,
+    future: impl std::future::Future<Output = std::result::Result<Loaded, DbError>>,
+) -> Result<Loaded>
+where
+    RegistryError: From<DbError>,
+{
+    match tokio::time::timeout(deadline, future).await {
+        Ok(result) => result.map_err(RegistryError::from),
+        Err(_) => Err(RegistryError::AuthDatabaseTimeout),
+    }
+}
+
 pub(crate) const MAX_USERNAME_CHARS: usize = 255;
 
 pub(crate) fn validate_username(username: &str) -> Result<()> {

--- a/pnpr/crates/pnpr/src/auth/libsql_backend.rs
+++ b/pnpr/crates/pnpr/src/auth/libsql_backend.rs
@@ -21,7 +21,7 @@
 use super::{
     DEFAULT_BCRYPT_COST, TokenBackend, TokenRecord, UpsertOutcome, UserBackend, fresh_secret,
     hash_bcrypt, mint_token, sha256_hex, token_timestamp_from_sql, unix_seconds, validate_username,
-    verify_returning_user,
+    verify_returning_user, with_auth_timeout,
 };
 use crate::{
     config::{LibsqlSettings, MaxUsers},
@@ -30,49 +30,22 @@ use crate::{
 use async_trait::async_trait;
 use libsql::{Builder, Connection, Database, Error as LibsqlError, Row, params};
 use std::{
-    future::Future,
     sync::atomic::{AtomicU64, Ordering},
     time::Duration,
 };
-use tokio::time::timeout;
 
 /// The `tokens` columns selected (in order) by every token read, so
 /// [`row_to_keyed_record`] can decode any of them the same way.
 const TOKEN_COLUMNS: &str =
     "token_hash, username, created_at, last_used_at, readonly, cidr_whitelist";
 
-/// Deadline applied to every request-path auth database read. Mirrors the
-/// sqlx backend's `backend.<driver>.timeout` default so a stalled or hostile
-/// libsql/Turso endpoint cannot hold a Tokio task open indefinitely and
-/// exhaust the executor — a registry-wide `DoS`. (Not yet a separate YAML knob
-/// like the sqlx backend exposes; see the PR description.)
+/// Deadline for request-path auth reads, beyond which a stalled endpoint
+/// surfaces [`RegistryError::AuthDatabaseTimeout`] rather than hanging.
 const DEFAULT_AUTH_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Deadline for the one-time startup connect + schema setup. More generous
-/// than [`DEFAULT_AUTH_TIMEOUT`] (cold schema DDL against a remote primary can
-/// be slow) but still bounded so an unreachable database fails fast.
+/// Deadline for the one-time startup connect and schema setup; more
+/// generous than [`DEFAULT_AUTH_TIMEOUT`] for cold remote DDL.
 const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_mins(5);
-
-/// Bound a read-only request-path (or startup) database future with
-/// [`DEFAULT_AUTH_TIMEOUT`]-style deadline, surfacing
-/// [`RegistryError::AuthDatabaseTimeout`] (HTTP 504) on expiry instead of
-/// awaiting forever. Mirror of `with_auth_timeout` in the `sqlx_backend` module;
-/// the two backends are independently feature-gated, so the helper is not
-/// shared. Use only around reads and startup: request-path writes must await
-/// the database result so a caller never observes a timeout with an unknown
-/// commit state.
-async fn with_auth_timeout<Loaded, DbError>(
-    deadline: Duration,
-    future: impl Future<Output = std::result::Result<Loaded, DbError>>,
-) -> Result<Loaded>
-where
-    RegistryError: From<DbError>,
-{
-    match timeout(deadline, future).await {
-        Ok(result) => result.map_err(RegistryError::from),
-        Err(_) => Err(RegistryError::AuthDatabaseTimeout),
-    }
-}
 
 /// Networked-SQLite auth backend. One [`Connection`] serves both record
 /// stores; the [`Database`] handle is held only to keep the connection
@@ -86,7 +59,7 @@ pub struct LibsqlAuth {
     secret: [u8; 32],
     counter: AtomicU64,
     max_users: MaxUsers,
-    /// Deadline applied to every request-path auth database read.
+    /// Deadline for each request-path auth read.
     timeout: Duration,
 }
 
@@ -120,9 +93,15 @@ impl LibsqlAuth {
                 if interval > 0 {
                     builder = builder.sync_interval(Duration::from_secs(interval));
                 }
-                builder.build().await?
+                with_auth_timeout(DEFAULT_STARTUP_TIMEOUT, Box::pin(builder.build())).await?
             }
-            None => Builder::new_remote(settings.url.clone(), auth_token).build().await?,
+            None => {
+                with_auth_timeout(
+                    DEFAULT_STARTUP_TIMEOUT,
+                    Box::pin(Builder::new_remote(settings.url.clone(), auth_token).build()),
+                )
+                .await?
+            }
         };
         Self::from_database(db, max_users).await
     }

--- a/pnpr/crates/pnpr/src/auth/libsql_backend.rs
+++ b/pnpr/crates/pnpr/src/auth/libsql_backend.rs
@@ -56,17 +56,17 @@ const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_mins(5);
 /// Bound a read-only request-path (or startup) database future with
 /// [`DEFAULT_AUTH_TIMEOUT`]-style deadline, surfacing
 /// [`RegistryError::AuthDatabaseTimeout`] (HTTP 504) on expiry instead of
-/// awaiting forever. Mirror of `with_auth_timeout` in [`super::sqlx_backend`];
+/// awaiting forever. Mirror of `with_auth_timeout` in the `sqlx_backend` module;
 /// the two backends are independently feature-gated, so the helper is not
 /// shared. Use only around reads and startup: request-path writes must await
 /// the database result so a caller never observes a timeout with an unknown
 /// commit state.
-async fn with_auth_timeout<T, E>(
+async fn with_auth_timeout<Loaded, DbError>(
     deadline: Duration,
-    future: impl Future<Output = std::result::Result<T, E>>,
-) -> Result<T>
+    future: impl Future<Output = std::result::Result<Loaded, DbError>>,
+) -> Result<Loaded>
 where
-    RegistryError: From<E>,
+    RegistryError: From<DbError>,
 {
     match timeout(deadline, future).await {
         Ok(result) => result.map_err(RegistryError::from),

--- a/pnpr/crates/pnpr/src/auth/libsql_backend.rs
+++ b/pnpr/crates/pnpr/src/auth/libsql_backend.rs
@@ -30,14 +30,49 @@ use crate::{
 use async_trait::async_trait;
 use libsql::{Builder, Connection, Database, Error as LibsqlError, Row, params};
 use std::{
+    future::Future,
     sync::atomic::{AtomicU64, Ordering},
     time::Duration,
 };
+use tokio::time::timeout;
 
 /// The `tokens` columns selected (in order) by every token read, so
 /// [`row_to_keyed_record`] can decode any of them the same way.
 const TOKEN_COLUMNS: &str =
     "token_hash, username, created_at, last_used_at, readonly, cidr_whitelist";
+
+/// Deadline applied to every request-path auth database read. Mirrors the
+/// sqlx backend's `backend.<driver>.timeout` default so a stalled or hostile
+/// libsql/Turso endpoint cannot hold a Tokio task open indefinitely and
+/// exhaust the executor — a registry-wide `DoS`. (Not yet a separate YAML knob
+/// like the sqlx backend exposes; see the PR description.)
+const DEFAULT_AUTH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Deadline for the one-time startup connect + schema setup. More generous
+/// than [`DEFAULT_AUTH_TIMEOUT`] (cold schema DDL against a remote primary can
+/// be slow) but still bounded so an unreachable database fails fast.
+const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_mins(5);
+
+/// Bound a read-only request-path (or startup) database future with
+/// [`DEFAULT_AUTH_TIMEOUT`]-style deadline, surfacing
+/// [`RegistryError::AuthDatabaseTimeout`] (HTTP 504) on expiry instead of
+/// awaiting forever. Mirror of `with_auth_timeout` in [`super::sqlx_backend`];
+/// the two backends are independently feature-gated, so the helper is not
+/// shared. Use only around reads and startup: request-path writes must await
+/// the database result so a caller never observes a timeout with an unknown
+/// commit state.
+async fn with_auth_timeout<T, E>(
+    deadline: Duration,
+    future: impl Future<Output = std::result::Result<T, E>>,
+) -> Result<T>
+where
+    RegistryError: From<E>,
+{
+    match timeout(deadline, future).await {
+        Ok(result) => result.map_err(RegistryError::from),
+        Err(_) => Err(RegistryError::AuthDatabaseTimeout),
+    }
+}
 
 /// Networked-SQLite auth backend. One [`Connection`] serves both record
 /// stores; the [`Database`] handle is held only to keep the connection
@@ -51,6 +86,8 @@ pub struct LibsqlAuth {
     secret: [u8; 32],
     counter: AtomicU64,
     max_users: MaxUsers,
+    /// Deadline applied to every request-path auth database read.
+    timeout: Duration,
 }
 
 impl std::fmt::Debug for LibsqlAuth {
@@ -94,32 +131,45 @@ impl LibsqlAuth {
     /// [`Self::connect`] and the local-database test setup.
     async fn from_database(db: Database, max_users: MaxUsers) -> Result<Self> {
         let conn = db.connect()?;
-        init_schema(&conn).await?;
-        Ok(Self { _db: db, conn, secret: fresh_secret(), counter: AtomicU64::new(0), max_users })
+        with_auth_timeout(DEFAULT_STARTUP_TIMEOUT, init_schema(&conn)).await?;
+        Ok(Self {
+            _db: db,
+            conn,
+            secret: fresh_secret(),
+            counter: AtomicU64::new(0),
+            max_users,
+            timeout: DEFAULT_AUTH_TIMEOUT,
+        })
     }
 
     /// The bcrypt hash stored for `username`, or `None` when no such
     /// user exists.
     async fn stored_hash(&self, username: &str) -> Result<Option<String>> {
-        let mut rows = self
-            .conn
-            .query("SELECT bcrypt_hash FROM users WHERE username = ?1", params![username])
-            .await?;
-        match rows.next().await? {
-            Some(row) => Ok(Some(row.get::<String>(0)?)),
-            None => Ok(None),
-        }
+        with_auth_timeout::<_, RegistryError>(self.timeout, async {
+            let mut rows = self
+                .conn
+                .query("SELECT bcrypt_hash FROM users WHERE username = ?1", params![username])
+                .await?;
+            match rows.next().await? {
+                Some(row) => Ok(Some(row.get::<String>(0)?)),
+                None => Ok(None),
+            }
+        })
+        .await
     }
 
     /// Current number of registered users — read under the
     /// registration cap, never on the hot path.
     async fn user_count(&self) -> Result<u64> {
-        let mut rows = self.conn.query("SELECT COUNT(*) FROM users", ()).await?;
-        let Some(row) = rows.next().await? else {
-            return Err(missing_count_row());
-        };
-        let count: i64 = row.get(0)?;
-        Ok(count.max(0) as u64)
+        with_auth_timeout::<_, RegistryError>(self.timeout, async {
+            let mut rows = self.conn.query("SELECT COUNT(*) FROM users", ()).await?;
+            let Some(row) = rows.next().await? else {
+                return Err(missing_count_row());
+            };
+            let count: i64 = row.get(0)?;
+            Ok(count.max(0) as u64)
+        })
+        .await
     }
 }
 
@@ -242,33 +292,42 @@ impl TokenBackend for LibsqlAuth {
 
     async fn lookup(&self, raw: &str) -> Result<Option<String>> {
         let token_hash = sha256_hex(raw.as_bytes());
-        let mut rows = self
-            .conn
-            .query("SELECT username FROM tokens WHERE token_hash = ?1", params![token_hash])
-            .await?;
-        match rows.next().await? {
-            Some(row) => Ok(Some(row.get::<String>(0)?)),
-            None => Ok(None),
-        }
+        with_auth_timeout::<_, RegistryError>(self.timeout, async {
+            let mut rows = self
+                .conn
+                .query("SELECT username FROM tokens WHERE token_hash = ?1", params![token_hash])
+                .await?;
+            match rows.next().await? {
+                Some(row) => Ok(Some(row.get::<String>(0)?)),
+                None => Ok(None),
+            }
+        })
+        .await
     }
 
     async fn find_by_key(&self, key: &str) -> Result<Option<TokenRecord>> {
         let query = format!("SELECT {TOKEN_COLUMNS} FROM tokens WHERE token_hash = ?1");
-        let mut rows = self.conn.query(&query, params![key]).await?;
-        match rows.next().await? {
-            Some(row) => Ok(Some(row_to_keyed_record(&row)?.1)),
-            None => Ok(None),
-        }
+        with_auth_timeout::<_, RegistryError>(self.timeout, async {
+            let mut rows = self.conn.query(&query, params![key]).await?;
+            match rows.next().await? {
+                Some(row) => Ok(Some(row_to_keyed_record(&row)?.1)),
+                None => Ok(None),
+            }
+        })
+        .await
     }
 
     async fn list_for_user(&self, username: &str) -> Result<Vec<(String, TokenRecord)>> {
         let query = format!("SELECT {TOKEN_COLUMNS} FROM tokens WHERE username = ?1");
-        let mut rows = self.conn.query(&query, params![username]).await?;
-        let mut out = Vec::new();
-        while let Some(row) = rows.next().await? {
-            out.push(row_to_keyed_record(&row)?);
-        }
-        Ok(out)
+        with_auth_timeout::<_, RegistryError>(self.timeout, async {
+            let mut rows = self.conn.query(&query, params![username]).await?;
+            let mut out = Vec::new();
+            while let Some(row) = rows.next().await? {
+                out.push(row_to_keyed_record(&row)?);
+            }
+            Ok(out)
+        })
+        .await
     }
 
     async fn revoke_by_key(&self, key: &str) -> Result<Option<TokenRecord>> {

--- a/pnpr/crates/pnpr/src/auth/libsql_backend/tests.rs
+++ b/pnpr/crates/pnpr/src/auth/libsql_backend/tests.rs
@@ -8,6 +8,23 @@ async fn local_backend(max_users: MaxUsers) -> LibsqlAuth {
 }
 
 #[tokio::test]
+async fn with_auth_timeout_surfaces_auth_database_timeout_when_a_read_stalls() {
+    let result: Result<()> = with_auth_timeout(Duration::from_millis(5), async {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        Ok::<(), RegistryError>(())
+    })
+    .await;
+    assert!(matches!(result, Err(RegistryError::AuthDatabaseTimeout)));
+}
+
+#[tokio::test]
+async fn with_auth_timeout_passes_a_fast_read_through() {
+    let result: Result<u32> =
+        with_auth_timeout(Duration::from_secs(30), async { Ok::<_, RegistryError>(7) }).await;
+    assert_eq!(result.unwrap(), 7);
+}
+
+#[tokio::test]
 async fn add_or_login_creates_then_logs_in() {
     let backend = local_backend(MaxUsers::Unlimited).await;
     assert!(matches!(

--- a/pnpr/crates/pnpr/src/auth/sqlx_backend.rs
+++ b/pnpr/crates/pnpr/src/auth/sqlx_backend.rs
@@ -4,6 +4,7 @@
 use super::{
     DEFAULT_BCRYPT_COST, TokenBackend, TokenRecord, UpsertOutcome, UserBackend, fresh_secret,
     hash_bcrypt, mint_token, sha256_hex, unix_seconds, validate_username, verify_returning_user,
+    with_auth_timeout,
 };
 use crate::{
     config::MaxUsers,
@@ -11,7 +12,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use std::{
-    future::Future,
     sync::atomic::{AtomicU64, Ordering},
     time::Duration,
 };
@@ -58,22 +58,6 @@ impl<Db> SqlAuth<Db> {
             return Ok(false);
         }
         self.db.reconcile_user_counter_overcount().await
-    }
-}
-
-/// Only use this around read-only request-path work or startup setup. Request-path
-/// writes rely on the backend's statement timeout and must await the database
-/// result so callers do not observe a timeout with an unknown commit state.
-async fn with_auth_timeout<T, E>(
-    timeout: Duration,
-    future: impl Future<Output = std::result::Result<T, E>>,
-) -> Result<T>
-where
-    RegistryError: From<E>,
-{
-    match tokio::time::timeout(timeout, future).await {
-        Ok(result) => result.map_err(RegistryError::from),
-        Err(_) => Err(RegistryError::AuthDatabaseTimeout),
     }
 }
 

--- a/pnpr/crates/pnpr/src/error.rs
+++ b/pnpr/crates/pnpr/src/error.rs
@@ -188,7 +188,11 @@ pub enum RegistryError {
     Sqlx(sqlx::Error),
 
     /// SQL auth backend operation timed out.
-    #[cfg(any(feature = "backend-postgres", feature = "backend-mysql"))]
+    #[cfg(any(
+        feature = "backend-libsql",
+        feature = "backend-postgres",
+        feature = "backend-mysql"
+    ))]
     #[display("Auth database timeout")]
     AuthDatabaseTimeout,
 
@@ -237,7 +241,11 @@ impl RegistryError {
             RegistryError::Libsql(_) => "libsql",
             #[cfg(any(feature = "backend-postgres", feature = "backend-mysql"))]
             RegistryError::Sqlx(_) => "sqlx",
-            #[cfg(any(feature = "backend-postgres", feature = "backend-mysql"))]
+            #[cfg(any(
+                feature = "backend-libsql",
+                feature = "backend-postgres",
+                feature = "backend-mysql"
+            ))]
             RegistryError::AuthDatabaseTimeout => "auth_database_timeout",
             RegistryError::JoinError(_) => "join_error",
             RegistryError::Io(_) => "io",
@@ -312,7 +320,11 @@ impl RegistryError {
             RegistryError::Libsql(_) => StatusCode::INTERNAL_SERVER_ERROR,
             #[cfg(any(feature = "backend-postgres", feature = "backend-mysql"))]
             RegistryError::Sqlx(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            #[cfg(any(feature = "backend-postgres", feature = "backend-mysql"))]
+            #[cfg(any(
+                feature = "backend-libsql",
+                feature = "backend-postgres",
+                feature = "backend-mysql"
+            ))]
             RegistryError::AuthDatabaseTimeout => StatusCode::GATEWAY_TIMEOUT,
             RegistryError::Io(_) | RegistryError::ObjectStore(_) | RegistryError::Json(_) => {
                 StatusCode::BAD_GATEWAY


### PR DESCRIPTION
## Summary

Every request-path database call in the libsql/Turso auth backend (`stored_hash`, `user_count`,
`lookup`, `find_by_key`, `list_for_user`) was a bare `.await?` with no timeout. The sqlx backend,
by contrast, wraps each read in `with_auth_timeout` and surfaces `AuthDatabaseTimeout` (HTTP 504)
on expiry. A stalled or hostile libsql endpoint (network partition, overloaded primary,
slow-loris) could therefore hold a Tokio task open indefinitely on *every* authenticated request,
exhausting the executor and taking the whole registry down — a remote DoS, with no 504 ever
returned.

This wraps the request-path reads and the startup schema setup with a deadline. The
`AuthDatabaseTimeout` variant (and its `log_kind` / `status_code` arms) now compiles under
`backend-libsql`, not just the sqlx drivers. Writes are intentionally left unwrapped, for the same
reason the sqlx backend documents: a Tokio cancellation mid-write would leave an unknown commit
state, so writes rely on the database's own statement timeout.

The read deadline uses a 30s default to match the sqlx backend. Exposing it as a YAML knob
(`backend.libsql.timeout`, like the sqlx backends) is a follow-up; this PR fixes the unbounded
hang. `with_auth_timeout` mirrors the sqlx helper rather than sharing it, because the two backends
are independently feature-gated.

## Squash Commit Body

```text
Every request-path database call in the libsql/Turso auth backend was a bare await with no
timeout, while the sqlx backend wraps its reads in with_auth_timeout and returns
AuthDatabaseTimeout (HTTP 504). A stalled or hostile libsql endpoint could hold a Tokio task
open indefinitely on every authenticated request, exhausting the executor and taking the whole
registry down — a remote DoS with no 504 ever returned.

Wrap the request-path reads (stored_hash, user_count, lookup, find_by_key, list_for_user) and
the startup schema setup with a deadline, surfacing AuthDatabaseTimeout on expiry. The
AuthDatabaseTimeout variant and its log_kind / status_code arms now compile under backend-libsql,
not just the sqlx drivers. Writes stay unwrapped for the reason the sqlx backend documents: a
cancelled write would leave an unknown commit state.
```

## Checklist

- [x] Added or updated tests — deterministic unit tests for the timeout helper (elapse -> 504,
  fast result passes through). `LibsqlAuth` holds a concrete `libsql::Connection` rather than an
  injectable trait, so a connection-level stall isn't reproducible in a unit test the way the
  sqlx backend's `SlowLookupBackend` is; the helper test plus the wrapped call sites cover it.
- [x] Updated the documentation if needed — n/a.

(No changeset: pnpr is not a published npm package. No pnpm-side port: pnpr-only infrastructure.)

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication reliability by enforcing time limits on libsql auth database operations, including startup/schema setup and request-path user/token lookups.
  * Long-running or stalled auth reads now fail gracefully with an auth database timeout error instead of hanging.
* **Tests**
  * Added async coverage for both timeout (slow) and non-timeout (fast) auth read scenarios.
* **Chores**
  * Expanded compile-time feature gating so the auth timeout error handling applies consistently across supported SQL backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->