### PR TITLE
fix(pnpr): reject re-publishing an existing version with 409 Conflict

### DIFF
--- a/pnpr/crates/pnpr/src/error.rs
+++ b/pnpr/crates/pnpr/src/error.rs
@@ -110,6 +110,18 @@ pub enum RegistryError {
         reason: String,
     },
 
+    /// A publish targeted a `name@version` that is already hosted.
+    /// Published versions are immutable; npm and verdaccio both answer a
+    /// re-publish with 409 Conflict.
+    #[display("Cannot publish over the previously published version {package}@{version}")]
+    #[from(skip)]
+    VersionAlreadyPublished {
+        #[error(not(source))]
+        package: String,
+        #[error(not(source))]
+        version: String,
+    },
+
     #[display(
         "Package {package}@{version} is listed in the local OSV database as vulnerable ({advisories})"
     )]
@@ -213,6 +225,7 @@ impl RegistryError {
             RegistryError::Forbidden { .. } => "forbidden",
             RegistryError::InvalidAttachment { .. } => "invalid_attachment",
             RegistryError::BadRequest { .. } => "bad_request",
+            RegistryError::VersionAlreadyPublished { .. } => "version_already_published",
             RegistryError::OsvVulnerability { .. } => "osv_vulnerability",
             RegistryError::RegistrationDisabled => "registration_disabled",
             RegistryError::TooManyUsers { .. } => "too_many_users",
@@ -283,6 +296,7 @@ impl RegistryError {
             | RegistryError::InvalidConfig { .. }
             | RegistryError::InvalidAttachment { .. }
             | RegistryError::BadRequest { .. } => StatusCode::BAD_REQUEST,
+            RegistryError::VersionAlreadyPublished { .. } => StatusCode::CONFLICT,
             RegistryError::Unauthenticated { .. } => StatusCode::UNAUTHORIZED,
             RegistryError::Forbidden { .. } => StatusCode::FORBIDDEN,
             RegistryError::OsvVulnerability { .. } => StatusCode::FORBIDDEN,

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1505,14 +1505,12 @@ struct ValidatedPublish {
     prepared: Vec<PreparedAttachment>,
 }
 
-/// One publish attachment resolved to its canonical on-disk filename, the
-/// version it publishes, and its `versions[version].dist` block.
+/// One publish attachment resolved to its canonical on-disk filename and its
+/// `versions[version].dist` block.
 struct PreparedAttachment {
     attachment: PendingAttachment,
     /// Canonical on-disk filename.
     canonical: String,
-    /// The version this attachment publishes.
-    version: String,
     /// The matching `dist` block, or `Value::Null` when absent.
     dist: Value,
 }
@@ -1544,7 +1542,7 @@ async fn validate_publish_doc(
             .and_then(|manifest| manifest.get("dist"))
             .cloned()
             .unwrap_or(Value::Null);
-        prepared.push(PreparedAttachment { attachment, canonical, version, dist });
+        prepared.push(PreparedAttachment { attachment, canonical, dist });
     }
     Ok(ValidatedPublish { name, incoming, prepared })
 }
@@ -1574,17 +1572,20 @@ async fn stage_publish(
 
     // Reject a re-publish of an already-hosted version: published versions
     // are immutable, and npm/verdaccio answer a re-publish with 409. Check
-    // only the locally hosted packument, not the upstream-seeded merge
-    // below — a version that exists only upstream may still be published
-    // here for the first time.
+    // every version in the incoming body — not just the ones backed by an
+    // attachment, since merge_manifest below consumes the whole `versions`
+    // map — against the locally hosted packument only (a version that exists
+    // only upstream may still be published here for the first time).
     if let Some(bytes) = hosted_bytes.as_deref() {
         let hosted: Value = serde_json::from_slice(bytes).map_err(RegistryError::Json)?;
-        if let Some(versions) = hosted.get("versions").and_then(Value::as_object)
-            && let Some(clash) = prepared.iter().find(|entry| versions.contains_key(&entry.version))
+        if let Some(hosted_versions) = hosted.get("versions").and_then(Value::as_object)
+            && let Some(incoming_versions) = incoming.get("versions").and_then(Value::as_object)
+            && let Some(clash) =
+                incoming_versions.keys().find(|version| hosted_versions.contains_key(*version))
         {
             return Err(RegistryError::VersionAlreadyPublished {
                 package: name.as_str().to_string(),
-                version: clash.version.clone(),
+                version: clash.clone(),
             });
         }
     }
@@ -1621,7 +1622,7 @@ async fn stage_publish(
     // 400; any tmp files written before the failure get removed
     // along the way so a bad upload leaves no on-disk artifact.
     let mut written_slots = Vec::with_capacity(prepared.len());
-    for PreparedAttachment { attachment, canonical, dist, version: _ } in prepared {
+    for PreparedAttachment { attachment, canonical, dist } in prepared {
         let slot = match state.inner.storage.reserve_hosted_tarball(&name, &canonical).await {
             Ok(slot) => slot,
             Err(err) => {

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1501,9 +1501,20 @@ struct ValidatedPublish {
     name: PackageName,
     /// The publish body with `_attachments` stripped.
     incoming: Value,
-    /// One `(attachment, canonical disk filename, dist)` triple per
-    /// attachment.
-    prepared: Vec<(PendingAttachment, String, Value)>,
+    /// One entry per attachment.
+    prepared: Vec<PreparedAttachment>,
+}
+
+/// One publish attachment resolved to its canonical on-disk filename, the
+/// version it publishes, and its `versions[version].dist` block.
+struct PreparedAttachment {
+    attachment: PendingAttachment,
+    /// Canonical on-disk filename.
+    canonical: String,
+    /// The version this attachment publishes.
+    version: String,
+    /// The matching `dist` block, or `Value::Null` when absent.
+    dist: Value,
 }
 
 async fn validate_publish_doc(
@@ -1524,8 +1535,7 @@ async fn validate_publish_doc(
     // scoped libnpmpublish bodies the wire form is `@scope/name-version.tgz`
     // but on disk it lives at `<root>/@scope/name/name-version.tgz`,
     // matching what `serve_tarball` expects.
-    let mut prepared: Vec<(PendingAttachment, String, Value)> =
-        Vec::with_capacity(attachments.len());
+    let mut prepared: Vec<PreparedAttachment> = Vec::with_capacity(attachments.len());
     for attachment in attachments {
         let (canonical, version) = name.parse_tarball_name(&attachment.filename)?;
         let dist = incoming
@@ -1534,7 +1544,7 @@ async fn validate_publish_doc(
             .and_then(|manifest| manifest.get("dist"))
             .cloned()
             .unwrap_or(Value::Null);
-        prepared.push((attachment, canonical, dist));
+        prepared.push(PreparedAttachment { attachment, canonical, version, dist });
     }
     Ok(ValidatedPublish { name, incoming, prepared })
 }
@@ -1560,6 +1570,25 @@ async fn stage_publish(
 ) -> Result<StagedPublish, RegistryError> {
     let ValidatedPublish { name, incoming, prepared } = doc;
 
+    let hosted_bytes = state.inner.storage.read_hosted_packument(&name).await?;
+
+    // Reject a re-publish of an already-hosted version: published versions
+    // are immutable, and npm/verdaccio answer a re-publish with 409. Check
+    // only the locally hosted packument, not the upstream-seeded merge
+    // below — a version that exists only upstream may still be published
+    // here for the first time.
+    if let Some(bytes) = hosted_bytes.as_deref() {
+        let hosted: Value = serde_json::from_slice(bytes).map_err(RegistryError::Json)?;
+        if let Some(versions) = hosted.get("versions").and_then(Value::as_object)
+            && let Some(clash) = prepared.iter().find(|entry| versions.contains_key(&entry.version))
+        {
+            return Err(RegistryError::VersionAlreadyPublished {
+                package: name.as_str().to_string(),
+                version: clash.version.clone(),
+            });
+        }
+    }
+
     // Seed the merge from whatever the upstream knows about the
     // package, not just from a cold cache. Without this, a publish
     // of a brand-new version of an upstream-only package would
@@ -1567,7 +1596,7 @@ async fn stage_publish(
     // would mask every upstream version + dist-tag on subsequent
     // reads. `update_dist_tag` already does the same fallback —
     // we just mirror it here.
-    let existing_bytes = match state.inner.storage.read_hosted_packument(&name).await? {
+    let existing_bytes = match hosted_bytes {
         Some(bytes) => Some(bytes),
         None => match load_packument_bytes(state, &name).await {
             PackumentLoad::Ok(bytes) => Some(bytes),
@@ -1592,7 +1621,7 @@ async fn stage_publish(
     // 400; any tmp files written before the failure get removed
     // along the way so a bad upload leaves no on-disk artifact.
     let mut written_slots = Vec::with_capacity(prepared.len());
-    for (attachment, canonical, dist) in prepared {
+    for PreparedAttachment { attachment, canonical, dist, version: _ } in prepared {
         let slot = match state.inner.storage.reserve_hosted_tarball(&name, &canonical).await {
             Ok(slot) => slot,
             Err(err) => {

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -252,6 +252,40 @@ async fn republishing_an_existing_version_is_rejected_with_conflict() {
     assert_eq!(on_disk, b"original-bytes");
 }
 
+#[tokio::test]
+async fn republish_via_a_smuggled_version_entry_without_an_attachment_is_rejected() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    // Publish 1.0.0 normally.
+    let first = Request::put("/mypkg")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(
+            serde_json::to_vec(&sample_publish_body("mypkg", "1.0.0", b"original")).unwrap(),
+        ))
+        .unwrap();
+    assert_eq!(app.clone().oneshot(first).await.unwrap().status(), StatusCode::CREATED);
+
+    // Publish 1.0.1 (with its own attachment) but smuggle a modified 1.0.0
+    // entry into `versions` with no matching attachment. The conflict check
+    // must still reject it because 1.0.0 is already hosted.
+    let mut body = sample_publish_body("mypkg", "1.0.1", b"new-bytes");
+    body["versions"]["1.0.0"] = json!({
+        "name": "mypkg",
+        "version": "1.0.0",
+        "dist": { "tarball": "http://example.test/mypkg/-/mypkg-1.0.0.tgz", "integrity": "sha512-EVIL" },
+    });
+    let smuggle = Request::put("/mypkg")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    assert_eq!(app.oneshot(smuggle).await.unwrap().status(), StatusCode::CONFLICT);
+}
+
 /// Published packages are the source of truth: they live in the
 /// authoritative `storage` root, never in the disposable proxy cache,
 /// and survive a full wipe of that cache.

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -224,6 +224,34 @@ async fn authenticated_publish_writes_manifest_and_tarball() {
     );
 }
 
+#[tokio::test]
+async fn republishing_an_existing_version_is_rejected_with_conflict() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let publish = |bytes: &[u8]| {
+        let body = serde_json::to_vec(&sample_publish_body("mypkg", "1.0.0", bytes)).unwrap();
+        Request::put("/mypkg")
+            .header("content-type", "application/json")
+            .header("Authorization", format!("Bearer {token}"))
+            .body(Body::from(body))
+            .unwrap()
+    };
+
+    let first = app.clone().oneshot(publish(b"original-bytes")).await.unwrap();
+    assert_eq!(first.status(), StatusCode::CREATED);
+
+    // Re-publishing the same version with different bytes must be refused.
+    let second = app.clone().oneshot(publish(b"backdoored-bytes")).await.unwrap();
+    assert_eq!(second.status(), StatusCode::CONFLICT);
+
+    // The originally published tarball must be untouched on disk.
+    let on_disk = std::fs::read(storage.join("mypkg/mypkg-1.0.0.tgz")).unwrap();
+    assert_eq!(on_disk, b"original-bytes");
+}
+
 /// Published packages are the source of truth: they live in the
 /// authoritative `storage` root, never in the disposable proxy cache,
 /// and survive a full wipe of that cache.


### PR DESCRIPTION
## Summary

`merge_objects` unconditionally overwrote an existing `versions[v]` entry, and `stage_publish`
renamed the new tarball over the old one, so a user with Publish access could re-publish
`name@version` with backdoored bytes and a fresh `dist.integrity`. Clients that pinned the old
hash in their lockfile then hit `EINTEGRITY`; clients without a lockfile silently fetched the
replaced bytes. npm and verdaccio treat a published version as immutable and answer a re-publish
with `409 Conflict`.

`stage_publish` now reads the hosted packument once and rejects the publish with a new
`VersionAlreadyPublished` error (HTTP 409) when any incoming version is already hosted — before any
tarball is written. The check looks only at the locally hosted packument, not the upstream-seeded
merge, so a version that exists only upstream can still be published locally for the first time.
The attachment's version is threaded through `ValidatedPublish` via a named `PreparedAttachment`
struct (replacing the former positional tuple).

## Squash Commit Body

```text
merge_objects unconditionally overwrote an existing versions[v] entry, and stage_publish wrote
the new tarball over the old one, so a Publish-permissioned user could re-publish name@version
with backdoored bytes and a new dist.integrity. Clients with the old hash in their lockfile then
hit EINTEGRITY; clients without a lockfile silently fetched the replaced bytes. npm and verdaccio
treat published versions as immutable and answer a re-publish with 409.

stage_publish now reads the hosted packument once and rejects the publish with the new
VersionAlreadyPublished error (HTTP 409) when any incoming version is already hosted, before any
tarball is written. The check looks only at the locally hosted packument, not the upstream-seeded
merge, so a version that exists only upstream can still be published locally for the first time.
```

## Checklist

- [x] Added or updated tests — `republishing_an_existing_version_is_rejected_with_conflict`
  asserts the second publish gets 409 and the original tarball bytes are untouched on disk.
- [x] Updated the documentation if needed — n/a.

(No changeset: pnpr is not a published npm package. No pnpm-side port: pnpr-only endpoint;
pacquet has not ported publish.)

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publishing now rejects attempts to publish an already-hosted `name@version`, returning a clear `409 Conflict` response.
  * Re-publishing is blocked even when the incoming payload differs (including cases using manipulated version metadata without matching attachment data).

* **Bug Fixes**
  * Improved publish validation to detect existing hosted versions earlier in the workflow.
  * Added tests to ensure rejected re-publishes do not overwrite the originally published package tarball bytes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->