### PR TITLE
fix(pnpr): reject dist.integrity tampering in the partial-unpublish PUT

### DIFF
--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1895,7 +1895,7 @@ async fn update_packument(
     // packument writers (publish / dist-tag), so the client-supplied
     // rewrite can't interleave with a concurrent merge.
     let _packument_guard = state.inner.package_locks.lock(name.as_str()).await;
-    if let Some(err) = enforce_published_version_integrity(state, &name, &mut packument).await {
+    if let Some(err) = enforce_published_version_immutability(state, &name, &mut packument).await {
         return error_response(&err);
     }
     let bytes = match serde_json::to_vec_pretty(&packument) {
@@ -1914,21 +1914,27 @@ async fn update_packument(
         .expect("static-shape response always builds")
 }
 
-/// Enforce that an already-published version's `dist.integrity` is immutable
-/// across the partial-unpublish `PUT`. Changing it while the tarball on disk
-/// stays the same would break every client with `EINTEGRITY`, so:
+/// Enforce that an already-published version's security-critical `dist` fields —
+/// its `integrity` and its `tarball` basename — are immutable across the
+/// partial-unpublish `PUT`. Either one changing while the bytes on disk stay the
+/// same breaks installs of that version: a swapped `integrity` fails every
+/// client with `EINTEGRITY`, and a repointed `tarball` basename sends clients at
+/// a missing or foreign tarball that can't match the version's integrity. So for
+/// every version already in the hosted packument:
 ///
-/// - A *change* to a published version's integrity is rejected.
-/// - An *omission* is repaired in place by restoring the hosted value — the
+/// - A *change* to its `dist.integrity`, or to its `dist.tarball` basename, is
+///   rejected.
+/// - An *omission* of either is repaired in place from the hosted value — the
 ///   round-trip body legitimately re-PUTs the remaining versions, and a dropped
-///   integrity would otherwise leave that version's tarball unservable, since
-///   [`expected_tarball_dist`] requires a string integrity.
+///   field would otherwise leave that version unservable. [`expected_tarball_dist`]
+///   matches a tarball request to a version by basename and verifies the bytes
+///   against a string integrity, so both fields must survive.
 /// - A newly added version entry must carry a syntactically valid SRI.
 ///
 /// Returns the rejection error, or `None` when the body is acceptable (possibly
-/// after restoring stripped integrities). Must be called while holding the
-/// package lock so a concurrent publish can't race the read.
-async fn enforce_published_version_integrity(
+/// after restoring omitted fields). Must be called while holding the package
+/// lock so a concurrent publish can't race the read.
+async fn enforce_published_version_immutability(
     state: &AppState,
     name: &PackageName,
     incoming: &mut Value,
@@ -1936,7 +1942,7 @@ async fn enforce_published_version_integrity(
     let incoming_versions = incoming.get("versions").and_then(Value::as_object)?;
     let hosted: Option<Value> = match state.inner.storage.read_hosted_packument(name).await {
         // Fail closed: a corrupt hosted packument must not silently disable the
-        // immutability gate (which would let a tampered dist.integrity through).
+        // immutability gate (which would let tampered dist fields through).
         Ok(Some(bytes)) => match serde_json::from_slice(&bytes) {
             Ok(value) => Some(value),
             Err(err) => return Some(RegistryError::Json(err)),
@@ -1946,9 +1952,10 @@ async fn enforce_published_version_integrity(
     };
     let hosted_versions =
         hosted.as_ref().and_then(|value| value.get("versions")).and_then(Value::as_object);
-    // Published versions whose integrity the body omitted: their hosted value is
-    // re-inserted after the scan (a borrow of `incoming` is live until then).
-    let mut restore: Vec<(String, String)> = Vec::new();
+    // (version, dist key, hosted value) triples re-inserted after the scan, for
+    // published versions whose body omitted an immutable dist field (a borrow of
+    // `incoming` is live until then).
+    let mut restore: Vec<(String, &'static str, Value)> = Vec::new();
     for (version, manifest) in incoming_versions {
         // A present dist.integrity must be a string — a valid SRI is the only
         // acceptable shape. A present-but-non-string value (null, number,
@@ -1963,61 +1970,94 @@ async fn enforce_published_version_integrity(
                 });
             }
         };
-        match hosted_versions.and_then(|versions| versions.get(version)) {
-            Some(existing) => {
-                let existing_integrity = existing
-                    .get("dist")
-                    .and_then(|dist| dist.get("integrity"))
-                    .and_then(Value::as_str);
-                match (existing_integrity, incoming_integrity) {
-                    (Some(stored), Some(submitted)) if stored != submitted => {
-                        return Some(RegistryError::BadRequest {
-                            reason: format!(
-                                "dist.integrity for the published version {version:?} is immutable",
-                            ),
-                        });
-                    }
-                    // Integrity omitted: restore the stored value. Restoring
-                    // requires an object `dist` to write into, so a published
-                    // version sent with a non-object (or absent) `dist` is
-                    // rejected — otherwise the restore would silently no-op and
-                    // persist the version without its integrity, the very
-                    // stripping this guards against.
-                    (Some(stored), None) => {
-                        if !manifest.get("dist").is_some_and(Value::is_object) {
-                            return Some(RegistryError::BadRequest {
-                                reason: format!(
-                                    "dist for the published version {version:?} must be an object carrying its integrity",
-                                ),
-                            });
-                        }
-                        restore.push((version.clone(), stored.to_string()));
-                    }
-                    _ => {}
-                }
+        let Some(existing) = hosted_versions.and_then(|versions| versions.get(version)) else {
+            // Newly added version: not an immutability concern, but its SRI must
+            // be syntactically valid so it can't poison tarball serving later.
+            if let Some(sri) = incoming_integrity
+                && let Err(err) = crate::streaming::parse_integrity(sri)
+            {
+                return Some(RegistryError::BadRequest {
+                    reason: format!("malformed dist.integrity for version {version:?}: {err}"),
+                });
             }
-            None => {
-                if let Some(sri) = incoming_integrity
-                    && let Err(err) = crate::streaming::parse_integrity(sri)
-                {
+            continue;
+        };
+        let existing_dist = existing.get("dist");
+        // dist.integrity immutability.
+        let existing_integrity =
+            existing_dist.and_then(|dist| dist.get("integrity")).and_then(Value::as_str);
+        match (existing_integrity, incoming_integrity) {
+            (Some(stored), Some(submitted)) if stored != submitted => {
+                return Some(RegistryError::BadRequest {
+                    reason: format!(
+                        "dist.integrity for the published version {version:?} is immutable",
+                    ),
+                });
+            }
+            (Some(stored), None) => {
+                if let Some(err) = require_object_dist(manifest, version) {
+                    return Some(err);
+                }
+                restore.push((version.clone(), "integrity", Value::String(stored.to_string())));
+            }
+            _ => {}
+        }
+        // dist.tarball basename immutability. The hosted tarball is the
+        // originally published URL while the round-trip body carries the
+        // rewritten URL (see [`rewrite_tarball_urls`]), so only the basename —
+        // the trust key shared with serve time — is comparable.
+        let existing_tarball = existing_dist.and_then(|dist| dist.get("tarball"));
+        if let Some(stored_basename) =
+            existing_tarball.and_then(Value::as_str).and_then(tarball_basename)
+        {
+            let incoming_basename = manifest
+                .get("dist")
+                .and_then(|dist| dist.get("tarball"))
+                .and_then(Value::as_str)
+                .and_then(tarball_basename);
+            match incoming_basename {
+                Some(submitted) if submitted != stored_basename => {
                     return Some(RegistryError::BadRequest {
-                        reason: format!("malformed dist.integrity for version {version:?}: {err}"),
+                        reason: format!(
+                            "dist.tarball for the published version {version:?} is immutable",
+                        ),
                     });
+                }
+                Some(_) => {}
+                None => {
+                    if let Some(err) = require_object_dist(manifest, version) {
+                        return Some(err);
+                    }
+                    let stored = existing_tarball.cloned().unwrap_or(Value::Null);
+                    restore.push((version.clone(), "tarball", stored));
                 }
             }
         }
     }
-    for (version, integrity) in restore {
+    for (version, key, value) in restore {
         if let Some(dist) = incoming
             .get_mut("versions")
             .and_then(|versions| versions.get_mut(&version))
             .and_then(|manifest| manifest.get_mut("dist"))
             .and_then(Value::as_object_mut)
         {
-            dist.insert("integrity".to_string(), Value::String(integrity));
+            dist.insert(key.to_string(), value);
         }
     }
     None
+}
+
+/// Restoring an omitted immutable dist field needs an object `dist` to write
+/// into. A published version sent with a non-object (or absent) `dist` is
+/// rejected rather than silently left as-is — otherwise the restore would no-op
+/// and persist the version without the field, the stripping this guards against.
+fn require_object_dist(manifest: &Value, version: &str) -> Option<RegistryError> {
+    if manifest.get("dist").is_some_and(Value::is_object) {
+        return None;
+    }
+    Some(RegistryError::BadRequest {
+        reason: format!("dist for the published version {version:?} must be an object"),
+    })
 }
 
 /// `DELETE /:pkg/-rev/:rev` — remove the entire package directory,

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1977,7 +1977,22 @@ async fn enforce_published_version_integrity(
                             ),
                         });
                     }
-                    (Some(stored), None) => restore.push((version.clone(), stored.to_string())),
+                    // Integrity omitted: restore the stored value. Restoring
+                    // requires an object `dist` to write into, so a published
+                    // version sent with a non-object (or absent) `dist` is
+                    // rejected — otherwise the restore would silently no-op and
+                    // persist the version without its integrity, the very
+                    // stripping this guards against.
+                    (Some(stored), None) => {
+                        if !manifest.get("dist").is_some_and(Value::is_object) {
+                            return Some(RegistryError::BadRequest {
+                                reason: format!(
+                                    "dist for the published version {version:?} must be an object carrying its integrity",
+                                ),
+                            });
+                        }
+                        restore.push((version.clone(), stored.to_string()));
+                    }
                     _ => {}
                 }
             }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -2023,11 +2023,12 @@ async fn enforce_published_version_immutability(
         // dist.tarball basename immutability. The hosted tarball is the
         // originally published URL while the round-trip body carries the
         // rewritten URL (see [`rewrite_tarball_urls`]), so only the basename —
-        // the trust key shared with serve time — is comparable.
+        // the trust key shared with serve time — is comparable. The hosted side
+        // uses the *served* basename ([`served_tarball_basename`]), which mirrors
+        // the rewrite's version-derived fallback, so a stored URL without a
+        // basename is still protected rather than left open to a redirect.
         let existing_tarball = existing_dist.and_then(|dist| dist.get("tarball"));
-        if let Some(stored_basename) =
-            existing_tarball.and_then(Value::as_str).and_then(tarball_basename)
-        {
+        if let Some(stored_basename) = served_tarball_basename(existing, name) {
             let incoming_basename = manifest
                 .get("dist")
                 .and_then(|dist| dist.get("tarball"))
@@ -2042,6 +2043,10 @@ async fn enforce_published_version_immutability(
                     });
                 }
                 Some(_) => {}
+                // Omitted, non-string, or basename-less incoming tarball: restore
+                // the hosted value so the served basename can't shift (a
+                // basename-less URL would otherwise fall back to a *different*
+                // version-derived name when the stored one was non-canonical).
                 None => {
                     if let Some(err) = require_object_dist(manifest, version) {
                         return Some(err);
@@ -2063,6 +2068,19 @@ async fn enforce_published_version_immutability(
         }
     }
     None
+}
+
+/// The tarball basename a version is actually served under, mirroring
+/// [`rewrite_tarball_urls`]: the `dist.tarball` URL's own basename when it has
+/// one, otherwise the version-derived canonical name the rewrite falls back to.
+/// Returns `None` when the manifest carries no string `dist.tarball` to serve.
+fn served_tarball_basename(manifest: &Value, pkg: &PackageName) -> Option<String> {
+    let url = manifest.get("dist").and_then(|dist| dist.get("tarball")).and_then(Value::as_str)?;
+    if let Some(basename) = tarball_basename(url) {
+        return Some(basename.to_owned());
+    }
+    let version = manifest.get("version").and_then(Value::as_str)?;
+    Some(pkg.tarball_name_for_version(version))
 }
 
 /// Restoring an omitted immutable dist field needs an object `dist` to write

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1891,23 +1891,17 @@ async fn update_packument(
         obj.remove("_rev");
         obj.remove("_revisions");
     }
-    let bytes = match serde_json::to_vec_pretty(&packument) {
-        Ok(b) => b,
-        Err(err) => return error_response(&RegistryError::Json(err)),
-    };
     // Serialize the write against this instance's other same-package
     // packument writers (publish / dist-tag), so the client-supplied
     // rewrite can't interleave with a concurrent merge.
     let _packument_guard = state.inner.package_locks.lock(name.as_str()).await;
-    // A published version's dist.integrity is immutable. This endpoint is the
-    // partial-unpublish flow (removing versions), not a way to rewrite the
-    // integrity of versions still on disk — doing so would break every
-    // client's install with EINTEGRITY while the real tarball is untouched.
-    // The hosted packument is read under the lock so a concurrent publish
-    // can't race the check.
-    if let Some(err) = reject_packument_integrity_tampering(state, &name, &packument).await {
+    if let Some(err) = enforce_published_version_integrity(state, &name, &mut packument).await {
         return error_response(&err);
     }
+    let bytes = match serde_json::to_vec_pretty(&packument) {
+        Ok(b) => b,
+        Err(err) => return error_response(&RegistryError::Json(err)),
+    };
     if let Err(err) = state.inner.storage.write_hosted_packument(&name, &bytes).await {
         return error_response(&err);
     }
@@ -1920,15 +1914,24 @@ async fn update_packument(
         .expect("static-shape response always builds")
 }
 
-/// Guard the partial-unpublish `PUT` against `dist.integrity` tampering: a
-/// version already on disk must keep its integrity, and any newly added
-/// version entry must carry a syntactically valid SRI. Returns the rejection
-/// error, or `None` when the body is acceptable. Must be called while holding
-/// the package lock so a concurrent publish can't race the read.
-async fn reject_packument_integrity_tampering(
+/// Enforce that an already-published version's `dist.integrity` is immutable
+/// across the partial-unpublish `PUT`. Changing it while the tarball on disk
+/// stays the same would break every client with `EINTEGRITY`, so:
+///
+/// - A *change* to a published version's integrity is rejected.
+/// - An *omission* is repaired in place by restoring the hosted value — the
+///   round-trip body legitimately re-PUTs the remaining versions, and a dropped
+///   integrity would otherwise leave that version's tarball unservable, since
+///   [`expected_tarball_dist`] requires a string integrity.
+/// - A newly added version entry must carry a syntactically valid SRI.
+///
+/// Returns the rejection error, or `None` when the body is acceptable (possibly
+/// after restoring stripped integrities). Must be called while holding the
+/// package lock so a concurrent publish can't race the read.
+async fn enforce_published_version_integrity(
     state: &AppState,
     name: &PackageName,
-    incoming: &Value,
+    incoming: &mut Value,
 ) -> Option<RegistryError> {
     let incoming_versions = incoming.get("versions").and_then(Value::as_object)?;
     let hosted: Option<Value> = match state.inner.storage.read_hosted_packument(name).await {
@@ -1943,12 +1946,14 @@ async fn reject_packument_integrity_tampering(
     };
     let hosted_versions =
         hosted.as_ref().and_then(|value| value.get("versions")).and_then(Value::as_object);
+    // Published versions whose integrity the body omitted: their hosted value is
+    // re-inserted after the scan (a borrow of `incoming` is live until then).
+    let mut restore: Vec<(String, String)> = Vec::new();
     for (version, manifest) in incoming_versions {
         // A present dist.integrity must be a string — a valid SRI is the only
-        // acceptable shape. Absence is allowed (the partial-unpublish flow
-        // re-PUTs remaining versions without it), but a present-but-non-string
-        // value (null, number, object) would slip past the string-only checks
-        // below and still break tarball serving, so reject it outright.
+        // acceptable shape. A present-but-non-string value (null, number,
+        // object) would slip past the string-only checks below and still break
+        // tarball serving, so reject it outright.
         let incoming_integrity = match manifest.get("dist").and_then(|dist| dist.get("integrity")) {
             None => None,
             Some(Value::String(value)) => Some(value.as_str()),
@@ -1964,19 +1969,16 @@ async fn reject_packument_integrity_tampering(
                     .get("dist")
                     .and_then(|dist| dist.get("integrity"))
                     .and_then(Value::as_str);
-                // Reject only a *change* to an integrity that is already
-                // present. A partial-unpublish legitimately re-PUTs the
-                // remaining versions with dist.integrity omitted, so an absent
-                // incoming integrity is allowed — it doesn't substitute a bogus
-                // value, which is the tampering this guards against.
-                if let (Some(stored), Some(submitted)) = (existing_integrity, incoming_integrity)
-                    && stored != submitted
-                {
-                    return Some(RegistryError::BadRequest {
-                        reason: format!(
-                            "dist.integrity for the published version {version:?} is immutable",
-                        ),
-                    });
+                match (existing_integrity, incoming_integrity) {
+                    (Some(stored), Some(submitted)) if stored != submitted => {
+                        return Some(RegistryError::BadRequest {
+                            reason: format!(
+                                "dist.integrity for the published version {version:?} is immutable",
+                            ),
+                        });
+                    }
+                    (Some(stored), None) => restore.push((version.clone(), stored.to_string())),
+                    _ => {}
                 }
             }
             None => {
@@ -1988,6 +1990,16 @@ async fn reject_packument_integrity_tampering(
                     });
                 }
             }
+        }
+    }
+    for (version, integrity) in restore {
+        if let Some(dist) = incoming
+            .get_mut("versions")
+            .and_then(|versions| versions.get_mut(&version))
+            .and_then(|manifest| manifest.get_mut("dist"))
+            .and_then(Value::as_object_mut)
+        {
+            dist.insert("integrity".to_string(), Value::String(integrity));
         }
     }
     None

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1850,10 +1850,12 @@ async fn augment_search_with_upstream(state: &AppState, query: &str, body: &mut 
 /// `PUT /:pkg/-rev/:rev` — overwrite the on-disk packument with the
 /// client-supplied body. pnpm uses this in the partial-unpublish
 /// flow: it fetches the packument, removes the unpublished version
-/// from `versions` / `dist-tags`, then PUTs the result back. We
-/// trust the body verbatim — the same trust verdaccio extends — and
-/// strip any `_attachments` so we don't persist base64 payloads
-/// alongside the manifest.
+/// from `versions` / `dist-tags`, then PUTs the result back. We strip
+/// any `_attachments` so we don't persist base64 payloads alongside
+/// the manifest, and run [`enforce_published_version_immutability`] so
+/// the body can't tamper with a published version's `dist` or smuggle
+/// in a new one — everything else in the body is trusted verbatim, the
+/// same trust verdaccio extends.
 async fn update_packument(
     state: &AppState,
     identity: &Identity,
@@ -1929,7 +1931,12 @@ async fn update_packument(
 ///   field would otherwise leave that version unservable. [`expected_tarball_dist`]
 ///   matches a tarball request to a version by basename and verifies the bytes
 ///   against a string integrity, so both fields must survive.
-/// - A newly added version entry must carry a syntactically valid SRI.
+/// - A version *not* already published is rejected: this endpoint only removes
+///   versions, never adds them, and a new entry could declare a `dist.tarball`
+///   basename that collides with a published version — making
+///   [`expected_tarball_dist`] fail closed (502) for that filename. (When no
+///   hosted packument exists there is nothing to unpublish from, so a fresh body
+///   is accepted once its SRIs are validated.)
 ///
 /// Returns the rejection error, or `None` when the body is acceptable (possibly
 /// after restoring omitted fields). Must be called while holding the package
@@ -1971,8 +1978,19 @@ async fn enforce_published_version_immutability(
             }
         };
         let Some(existing) = hosted_versions.and_then(|versions| versions.get(version)) else {
-            // Newly added version: not an immutability concern, but its SRI must
-            // be syntactically valid so it can't poison tarball serving later.
+            // Partial-unpublish only removes versions from an existing package;
+            // it must not add one. A new entry could declare a dist.tarball
+            // basename colliding with a published version, which makes
+            // expected_tarball_dist fail closed (502) for that filename. Only
+            // when there is no hosted packument is there nothing to unpublish
+            // from, so a fresh body is accepted once its SRI is validated.
+            if hosted_versions.is_some() {
+                return Some(RegistryError::BadRequest {
+                    reason: format!(
+                        "version {version:?} is not in the published package; this endpoint removes versions, it does not add them",
+                    ),
+                });
+            }
             if let Some(sri) = incoming_integrity
                 && let Err(err) = crate::streaming::parse_integrity(sri)
             {

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1952,7 +1952,14 @@ async fn reject_packument_integrity_tampering(
                     .get("dist")
                     .and_then(|dist| dist.get("integrity"))
                     .and_then(Value::as_str);
-                if incoming_integrity != existing_integrity {
+                // Reject only a *change* to an integrity that is already
+                // present. A partial-unpublish legitimately re-PUTs the
+                // remaining versions with dist.integrity omitted, so an absent
+                // incoming integrity is allowed — it doesn't substitute a bogus
+                // value, which is the tampering this guards against.
+                if let (Some(stored), Some(submitted)) = (existing_integrity, incoming_integrity)
+                    && stored != submitted
+                {
                     return Some(RegistryError::BadRequest {
                         reason: format!(
                             "dist.integrity for the published version {version:?} is immutable",

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1944,8 +1944,20 @@ async fn reject_packument_integrity_tampering(
     let hosted_versions =
         hosted.as_ref().and_then(|value| value.get("versions")).and_then(Value::as_object);
     for (version, manifest) in incoming_versions {
-        let incoming_integrity =
-            manifest.get("dist").and_then(|dist| dist.get("integrity")).and_then(Value::as_str);
+        // A present dist.integrity must be a string — a valid SRI is the only
+        // acceptable shape. Absence is allowed (the partial-unpublish flow
+        // re-PUTs remaining versions without it), but a present-but-non-string
+        // value (null, number, object) would slip past the string-only checks
+        // below and still break tarball serving, so reject it outright.
+        let incoming_integrity = match manifest.get("dist").and_then(|dist| dist.get("integrity")) {
+            None => None,
+            Some(Value::String(value)) => Some(value.as_str()),
+            Some(_) => {
+                return Some(RegistryError::BadRequest {
+                    reason: format!("dist.integrity for version {version:?} must be a string"),
+                });
+            }
+        };
         match hosted_versions.and_then(|versions| versions.get(version)) {
             Some(existing) => {
                 let existing_integrity = existing

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1916,49 +1916,35 @@ async fn update_packument(
         .expect("static-shape response always builds")
 }
 
-/// Enforce that an already-published version's security-critical `dist` fields —
-/// its `integrity` and its `tarball` basename — are immutable across the
-/// partial-unpublish `PUT`. Either one changing while the bytes on disk stay the
-/// same breaks installs of that version: a swapped `integrity` fails every
-/// client with `EINTEGRITY`, and a repointed `tarball` basename sends clients at
-/// a missing or foreign tarball that can't match the version's integrity. So for
-/// every version already in the hosted packument:
+/// Hold a published version's security-critical `dist` fields immutable across
+/// the partial-unpublish `PUT`, which otherwise persists the body verbatim.
+/// [`expected_tarball_dist`] resolves a tarball request to a version by
+/// `dist.tarball` basename and verifies the bytes against that version's string
+/// `dist.integrity`, so letting either drift — while the bytes on disk stay put —
+/// breaks installs of that version (`EINTEGRITY`, or a 404/502 redirect).
 ///
-/// - A *change* to its `dist.integrity`, or to its `dist.tarball` basename, is
-///   rejected.
-/// - An *omission* of either is repaired in place from the hosted value — the
-///   round-trip body legitimately re-PUTs the remaining versions, and a dropped
-///   field would otherwise leave that version unservable. [`expected_tarball_dist`]
-///   matches a tarball request to a version by basename and verifies the bytes
-///   against a string integrity, so both fields must survive.
-/// - A version *not* already published is rejected: this endpoint only removes
-///   versions, never adds them, and a new entry could declare a `dist.tarball`
-///   basename that collides with a published version (making
-///   [`expected_tarball_dist`] fail closed / 502) or seed a tarball-less version.
-/// - A `PUT` to a package with no hosted packument is rejected outright: there is
-///   nothing to unpublish, and writing the body would seed authoritative versions
-///   that publish can never overwrite (a durable squat).
+/// For each version in the body, given a hosted packument: changing the
+/// `dist.integrity` or `dist.tarball` basename of an already-published version is
+/// rejected; omitting either is repaired from the hosted value (the round-trip
+/// drops them on retained versions); and a version not already published is
+/// rejected — this endpoint only removes versions, and an added entry could
+/// collide a basename or seed a tarball-less one. A `PUT` to a package with no
+/// hosted packument is rejected outright (nothing to unpublish, and the write
+/// would seed versions that publish can never overwrite).
 ///
-/// Returns the rejection error, or `None` when the body is acceptable (possibly
-/// after restoring omitted fields). Must be called while holding the package
-/// lock so a concurrent publish can't race the read.
+/// Returns the rejection, or `None` when the body is acceptable (after any
+/// restores). Must hold the package lock so a concurrent publish can't race it.
 async fn enforce_published_version_immutability(
     state: &AppState,
     name: &PackageName,
     incoming: &mut Value,
 ) -> Option<RegistryError> {
     let hosted: Value = match state.inner.storage.read_hosted_packument(name).await {
-        // Fail closed: a corrupt hosted packument must not silently disable the
-        // immutability gate (which would let tampered dist fields through).
+        // Fail closed: a corrupt packument must not silently disable the gate.
         Ok(Some(bytes)) => match serde_json::from_slice(&bytes) {
             Ok(value) => value,
             Err(err) => return Some(RegistryError::Json(err)),
         },
-        // Partial-unpublish operates on an already-published package; with no
-        // hosted packument there is nothing to unpublish. Writing the body would
-        // instead seed authoritative versions with no tarballs and — because
-        // publish refuses any version already in the packument — permanently
-        // block their later legitimate publish. Refuse it.
         Ok(None) => {
             return Some(RegistryError::BadRequest {
                 reason: format!(
@@ -1969,19 +1955,13 @@ async fn enforce_published_version_immutability(
         }
         Err(err) => return Some(err),
     };
-    // A body without a versions object has nothing to enforce (and nothing the
-    // caller could be unpublishing); accept it.
+    // None (no versions to enforce) means "accept", not "error" here.
     let incoming_versions = incoming.get("versions").and_then(Value::as_object)?;
     let hosted_versions = hosted.get("versions").and_then(Value::as_object);
-    // (version, dist key, hosted value) triples re-inserted after the scan, for
-    // published versions whose body omitted an immutable dist field (a borrow of
-    // `incoming` is live until then).
+    // Fields to re-insert after the scan; deferred because the scan borrows
+    // `incoming` and the restore mutates it.
     let mut restore: Vec<(String, &'static str, Value)> = Vec::new();
     for (version, manifest) in incoming_versions {
-        // Partial-unpublish only removes versions; it must not add one. A new
-        // entry could declare a dist.tarball basename colliding with a published
-        // version (making expected_tarball_dist fail closed / 502) or seed a
-        // version with no tarball, so reject anything not already published.
         let Some(existing) = hosted_versions.and_then(|versions| versions.get(version)) else {
             return Some(RegistryError::BadRequest {
                 reason: format!(
@@ -1989,10 +1969,8 @@ async fn enforce_published_version_immutability(
                 ),
             });
         };
-        // A present dist.integrity must be a string — a valid SRI is the only
-        // acceptable shape. A present-but-non-string value (null, number,
-        // object) would slip past the string-only checks below and still break
-        // tarball serving, so reject it outright.
+        // A present dist.integrity must be a string; a non-string would slip past
+        // the string-only checks below.
         let incoming_integrity = match manifest.get("dist").and_then(|dist| dist.get("integrity")) {
             None => None,
             Some(Value::String(value)) => Some(value.as_str()),
@@ -2003,7 +1981,6 @@ async fn enforce_published_version_immutability(
             }
         };
         let existing_dist = existing.get("dist");
-        // dist.integrity immutability.
         let existing_integrity =
             existing_dist.and_then(|dist| dist.get("integrity")).and_then(Value::as_str);
         match (existing_integrity, incoming_integrity) {
@@ -2022,13 +1999,10 @@ async fn enforce_published_version_immutability(
             }
             _ => {}
         }
-        // dist.tarball basename immutability. The hosted tarball is the
-        // originally published URL while the round-trip body carries the
-        // rewritten URL (see [`rewrite_tarball_urls`]), so only the basename —
-        // the trust key shared with serve time — is comparable. The hosted side
-        // uses the *served* basename ([`served_tarball_basename`]), which mirrors
-        // the rewrite's version-derived fallback, so a stored URL without a
-        // basename is still protected rather than left open to a redirect.
+        // Compare basenames, not URLs: the round-trip carries the rewritten URL
+        // (see [`rewrite_tarball_urls`]) while the hosted side keeps the original,
+        // and [`served_tarball_basename`] applies the same version-derived
+        // fallback so a basename-less stored URL is still pinned.
         let existing_tarball = existing_dist.and_then(|dist| dist.get("tarball"));
         if let Some(stored_basename) = served_tarball_basename(existing, name) {
             let incoming_basename = manifest
@@ -2045,10 +2019,6 @@ async fn enforce_published_version_immutability(
                     });
                 }
                 Some(_) => {}
-                // Omitted, non-string, or basename-less incoming tarball: restore
-                // the hosted value so the served basename can't shift (a
-                // basename-less URL would otherwise fall back to a *different*
-                // version-derived name when the stored one was non-canonical).
                 None => {
                     if let Some(err) = require_object_dist(manifest, version) {
                         return Some(err);
@@ -2085,10 +2055,9 @@ fn served_tarball_basename(manifest: &Value, pkg: &PackageName) -> Option<String
     Some(pkg.tarball_name_for_version(version))
 }
 
-/// Restoring an omitted immutable dist field needs an object `dist` to write
-/// into. A published version sent with a non-object (or absent) `dist` is
-/// rejected rather than silently left as-is — otherwise the restore would no-op
-/// and persist the version without the field, the stripping this guards against.
+/// Reject a published version whose `dist` isn't an object: a restore needs an
+/// object to write into, so otherwise it would no-op and persist the version
+/// without the field — the stripping this guards against.
 fn require_object_dist(manifest: &Value, version: &str) -> Option<RegistryError> {
     if manifest.get("dist").is_some_and(Value::is_object) {
         return None;

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1933,10 +1933,11 @@ async fn update_packument(
 ///   against a string integrity, so both fields must survive.
 /// - A version *not* already published is rejected: this endpoint only removes
 ///   versions, never adds them, and a new entry could declare a `dist.tarball`
-///   basename that collides with a published version — making
-///   [`expected_tarball_dist`] fail closed (502) for that filename. (When no
-///   hosted packument exists there is nothing to unpublish from, so a fresh body
-///   is accepted once its SRIs are validated.)
+///   basename that collides with a published version (making
+///   [`expected_tarball_dist`] fail closed / 502) or seed a tarball-less version.
+/// - A `PUT` to a package with no hosted packument is rejected outright: there is
+///   nothing to unpublish, and writing the body would seed authoritative versions
+///   that publish can never overwrite (a durable squat).
 ///
 /// Returns the rejection error, or `None` when the body is acceptable (possibly
 /// after restoring omitted fields). Must be called while holding the package
@@ -1946,24 +1947,48 @@ async fn enforce_published_version_immutability(
     name: &PackageName,
     incoming: &mut Value,
 ) -> Option<RegistryError> {
-    let incoming_versions = incoming.get("versions").and_then(Value::as_object)?;
-    let hosted: Option<Value> = match state.inner.storage.read_hosted_packument(name).await {
+    let hosted: Value = match state.inner.storage.read_hosted_packument(name).await {
         // Fail closed: a corrupt hosted packument must not silently disable the
         // immutability gate (which would let tampered dist fields through).
         Ok(Some(bytes)) => match serde_json::from_slice(&bytes) {
-            Ok(value) => Some(value),
+            Ok(value) => value,
             Err(err) => return Some(RegistryError::Json(err)),
         },
-        Ok(None) => None,
+        // Partial-unpublish operates on an already-published package; with no
+        // hosted packument there is nothing to unpublish. Writing the body would
+        // instead seed authoritative versions with no tarballs and — because
+        // publish refuses any version already in the packument — permanently
+        // block their later legitimate publish. Refuse it.
+        Ok(None) => {
+            return Some(RegistryError::BadRequest {
+                reason: format!(
+                    "cannot update {:?}: it has no published packument to unpublish from",
+                    name.as_str(),
+                ),
+            });
+        }
         Err(err) => return Some(err),
     };
-    let hosted_versions =
-        hosted.as_ref().and_then(|value| value.get("versions")).and_then(Value::as_object);
+    // A body without a versions object has nothing to enforce (and nothing the
+    // caller could be unpublishing); accept it.
+    let incoming_versions = incoming.get("versions").and_then(Value::as_object)?;
+    let hosted_versions = hosted.get("versions").and_then(Value::as_object);
     // (version, dist key, hosted value) triples re-inserted after the scan, for
     // published versions whose body omitted an immutable dist field (a borrow of
     // `incoming` is live until then).
     let mut restore: Vec<(String, &'static str, Value)> = Vec::new();
     for (version, manifest) in incoming_versions {
+        // Partial-unpublish only removes versions; it must not add one. A new
+        // entry could declare a dist.tarball basename colliding with a published
+        // version (making expected_tarball_dist fail closed / 502) or seed a
+        // version with no tarball, so reject anything not already published.
+        let Some(existing) = hosted_versions.and_then(|versions| versions.get(version)) else {
+            return Some(RegistryError::BadRequest {
+                reason: format!(
+                    "version {version:?} is not in the published package; this endpoint removes versions, it does not add them",
+                ),
+            });
+        };
         // A present dist.integrity must be a string — a valid SRI is the only
         // acceptable shape. A present-but-non-string value (null, number,
         // object) would slip past the string-only checks below and still break
@@ -1976,29 +2001,6 @@ async fn enforce_published_version_immutability(
                     reason: format!("dist.integrity for version {version:?} must be a string"),
                 });
             }
-        };
-        let Some(existing) = hosted_versions.and_then(|versions| versions.get(version)) else {
-            // Partial-unpublish only removes versions from an existing package;
-            // it must not add one. A new entry could declare a dist.tarball
-            // basename colliding with a published version, which makes
-            // expected_tarball_dist fail closed (502) for that filename. Only
-            // when there is no hosted packument is there nothing to unpublish
-            // from, so a fresh body is accepted once its SRI is validated.
-            if hosted_versions.is_some() {
-                return Some(RegistryError::BadRequest {
-                    reason: format!(
-                        "version {version:?} is not in the published package; this endpoint removes versions, it does not add them",
-                    ),
-                });
-            }
-            if let Some(sri) = incoming_integrity
-                && let Err(err) = crate::streaming::parse_integrity(sri)
-            {
-                return Some(RegistryError::BadRequest {
-                    reason: format!("malformed dist.integrity for version {version:?}: {err}"),
-                });
-            }
-            continue;
         };
         let existing_dist = existing.get("dist");
         // dist.integrity immutability.

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1873,6 +1873,19 @@ async fn update_packument(
         Ok(v) => v,
         Err(err) => return error_response(&RegistryError::Json(err)),
     };
+    // The write destination is the URL package name; a mismatched body name
+    // would otherwise land under the URL package and persist an inconsistent
+    // manifest.
+    if let Some(body_name) = packument.get("name").and_then(Value::as_str)
+        && body_name != name.as_str()
+    {
+        return error_response(&RegistryError::BadRequest {
+            reason: format!(
+                "packument name {body_name:?} does not match the URL package {:?}",
+                name.as_str()
+            ),
+        });
+    }
     if let Some(obj) = packument.as_object_mut() {
         obj.remove("_attachments");
         obj.remove("_rev");
@@ -1886,6 +1899,15 @@ async fn update_packument(
     // packument writers (publish / dist-tag), so the client-supplied
     // rewrite can't interleave with a concurrent merge.
     let _packument_guard = state.inner.package_locks.lock(name.as_str()).await;
+    // A published version's dist.integrity is immutable. This endpoint is the
+    // partial-unpublish flow (removing versions), not a way to rewrite the
+    // integrity of versions still on disk — doing so would break every
+    // client's install with EINTEGRITY while the real tarball is untouched.
+    // The hosted packument is read under the lock so a concurrent publish
+    // can't race the check.
+    if let Some(err) = reject_packument_integrity_tampering(state, &name, &packument).await {
+        return error_response(&err);
+    }
     if let Err(err) = state.inner.storage.write_hosted_packument(&name, &bytes).await {
         return error_response(&err);
     }
@@ -1896,6 +1918,55 @@ async fn update_packument(
         .header(header::CONTENT_TYPE, "application/json")
         .body(Body::from(bytes))
         .expect("static-shape response always builds")
+}
+
+/// Guard the partial-unpublish `PUT` against `dist.integrity` tampering: a
+/// version already on disk must keep its integrity, and any newly added
+/// version entry must carry a syntactically valid SRI. Returns the rejection
+/// error, or `None` when the body is acceptable. Must be called while holding
+/// the package lock so a concurrent publish can't race the read.
+async fn reject_packument_integrity_tampering(
+    state: &AppState,
+    name: &PackageName,
+    incoming: &Value,
+) -> Option<RegistryError> {
+    let incoming_versions = incoming.get("versions").and_then(Value::as_object)?;
+    let hosted: Option<Value> = match state.inner.storage.read_hosted_packument(name).await {
+        Ok(Some(bytes)) => serde_json::from_slice(&bytes).ok(),
+        Ok(None) => None,
+        Err(err) => return Some(err),
+    };
+    let hosted_versions =
+        hosted.as_ref().and_then(|value| value.get("versions")).and_then(Value::as_object);
+    for (version, manifest) in incoming_versions {
+        let incoming_integrity =
+            manifest.get("dist").and_then(|dist| dist.get("integrity")).and_then(Value::as_str);
+        match hosted_versions.and_then(|versions| versions.get(version)) {
+            Some(existing) => {
+                let existing_integrity = existing
+                    .get("dist")
+                    .and_then(|dist| dist.get("integrity"))
+                    .and_then(Value::as_str);
+                if incoming_integrity != existing_integrity {
+                    return Some(RegistryError::BadRequest {
+                        reason: format!(
+                            "dist.integrity for the published version {version:?} is immutable"
+                        ),
+                    });
+                }
+            }
+            None => {
+                if let Some(sri) = incoming_integrity
+                    && let Err(err) = crate::streaming::parse_integrity(sri)
+                {
+                    return Some(RegistryError::BadRequest {
+                        reason: format!("malformed dist.integrity for version {version:?}: {err}"),
+                    });
+                }
+            }
+        }
+    }
+    None
 }
 
 /// `DELETE /:pkg/-rev/:rev` — remove the entire package directory,

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1882,7 +1882,7 @@ async fn update_packument(
         return error_response(&RegistryError::BadRequest {
             reason: format!(
                 "packument name {body_name:?} does not match the URL package {:?}",
-                name.as_str()
+                name.as_str(),
             ),
         });
     }
@@ -1932,7 +1932,12 @@ async fn reject_packument_integrity_tampering(
 ) -> Option<RegistryError> {
     let incoming_versions = incoming.get("versions").and_then(Value::as_object)?;
     let hosted: Option<Value> = match state.inner.storage.read_hosted_packument(name).await {
-        Ok(Some(bytes)) => serde_json::from_slice(&bytes).ok(),
+        // Fail closed: a corrupt hosted packument must not silently disable the
+        // immutability gate (which would let a tampered dist.integrity through).
+        Ok(Some(bytes)) => match serde_json::from_slice(&bytes) {
+            Ok(value) => Some(value),
+            Err(err) => return Some(RegistryError::Json(err)),
+        },
         Ok(None) => None,
         Err(err) => return Some(err),
     };
@@ -1950,7 +1955,7 @@ async fn reject_packument_integrity_tampering(
                 if incoming_integrity != existing_integrity {
                     return Some(RegistryError::BadRequest {
                         reason: format!(
-                            "dist.integrity for the published version {version:?} is immutable"
+                            "dist.integrity for the published version {version:?} is immutable",
                         ),
                     });
                 }

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -479,6 +479,44 @@ async fn update_packument_rejects_adding_a_version_via_the_unpublish_put() {
     assert_eq!(after["versions"], original_versions);
 }
 
+#[tokio::test]
+async fn update_packument_protects_a_published_tarball_with_a_basenameless_url() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let publish = Request::put("/mypkg")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(
+            serde_json::to_vec(&sample_publish_body("mypkg", "1.0.0", b"real-bytes")).unwrap(),
+        ))
+        .unwrap();
+    assert_eq!(app.clone().oneshot(publish).await.unwrap().status(), StatusCode::CREATED);
+
+    // Force the *stored* dist.tarball to a URL with no basename (ends in `/`).
+    // rewrite_tarball_urls serves such a URL under the version-derived canonical
+    // name, so the served basename is still well-defined and must stay immutable.
+    let packument_path = storage.join("mypkg/package.json");
+    let mut stored: Value =
+        serde_json::from_slice(&std::fs::read(&packument_path).unwrap()).unwrap();
+    stored["versions"]["1.0.0"]["dist"]["tarball"] = json!("http://localhost:4873/mypkg/-/");
+    std::fs::write(&packument_path, serde_json::to_vec(&stored).unwrap()).unwrap();
+
+    // A PUT that repoints the version at a concrete, different basename must
+    // still be rejected, even though the stored URL itself has no basename.
+    let mut tampered = stored.clone();
+    tampered["versions"]["1.0.0"]["dist"]["tarball"] =
+        json!("http://example.test/mypkg/-/mypkg-9.9.9.tgz");
+    let request = Request::put("/mypkg/-rev/1-0")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_vec(&tampered).unwrap()))
+        .unwrap();
+    assert_eq!(app.oneshot(request).await.unwrap().status(), StatusCode::BAD_REQUEST);
+}
+
 /// Published packages are the source of truth: they live in the
 /// authoritative `storage` root, never in the disposable proxy cache,
 /// and survive a full wipe of that cache.

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -286,6 +286,46 @@ async fn republish_via_a_smuggled_version_entry_without_an_attachment_is_rejecte
     assert_eq!(app.oneshot(smuggle).await.unwrap().status(), StatusCode::CONFLICT);
 }
 
+#[tokio::test]
+async fn update_packument_rejects_tampering_with_a_published_version_integrity() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let publish = Request::put("/mypkg")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(
+            serde_json::to_vec(&sample_publish_body("mypkg", "1.0.0", b"real-bytes")).unwrap(),
+        ))
+        .unwrap();
+    assert_eq!(app.clone().oneshot(publish).await.unwrap().status(), StatusCode::CREATED);
+
+    let get =
+        app.clone().oneshot(Request::get("/mypkg").body(Body::empty()).unwrap()).await.unwrap();
+    let mut packument = body_json(get.into_body()).await;
+    let original_integrity = packument["versions"]["1.0.0"]["dist"]["integrity"].clone();
+    assert!(original_integrity.is_string(), "published version should carry an integrity");
+
+    // Point the already-published version at a bogus integrity and PUT it back
+    // through the partial-unpublish endpoint.
+    packument["versions"]["1.0.0"]["dist"]["integrity"] = json!(
+        "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+    );
+    let tamper = Request::put("/mypkg/-rev/1-0")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_vec(&packument).unwrap()))
+        .unwrap();
+    assert_eq!(app.clone().oneshot(tamper).await.unwrap().status(), StatusCode::BAD_REQUEST);
+
+    // The stored integrity must be untouched.
+    let after = app.oneshot(Request::get("/mypkg").body(Body::empty()).unwrap()).await.unwrap();
+    let after = body_json(after.into_body()).await;
+    assert_eq!(after["versions"]["1.0.0"]["dist"]["integrity"], original_integrity);
+}
+
 /// Published packages are the source of truth: they live in the
 /// authoritative `storage` root, never in the disposable proxy cache,
 /// and survive a full wipe of that cache.

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -326,6 +326,36 @@ async fn update_packument_rejects_tampering_with_a_published_version_integrity()
     assert_eq!(after["versions"]["1.0.0"]["dist"]["integrity"], original_integrity);
 }
 
+#[tokio::test]
+async fn update_packument_rejects_a_non_string_dist_integrity() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let publish = Request::put("/mypkg")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(
+            serde_json::to_vec(&sample_publish_body("mypkg", "1.0.0", b"real")).unwrap(),
+        ))
+        .unwrap();
+    assert_eq!(app.clone().oneshot(publish).await.unwrap().status(), StatusCode::CREATED);
+
+    let get =
+        app.clone().oneshot(Request::get("/mypkg").body(Body::empty()).unwrap()).await.unwrap();
+    let mut packument = body_json(get.into_body()).await;
+    // A present-but-non-string integrity must be rejected — otherwise it slips
+    // past the string-only immutability check and breaks tarball serving.
+    packument["versions"]["1.0.0"]["dist"]["integrity"] = json!(null);
+    let request = Request::put("/mypkg/-rev/1-0")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_vec(&packument).unwrap()))
+        .unwrap();
+    assert_eq!(app.oneshot(request).await.unwrap().status(), StatusCode::BAD_REQUEST);
+}
+
 /// Published packages are the source of truth: they live in the
 /// authoritative `storage` root, never in the disposable proxy cache,
 /// and survive a full wipe of that cache.

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -320,7 +320,6 @@ async fn update_packument_rejects_tampering_with_a_published_version_integrity()
         .unwrap();
     assert_eq!(app.clone().oneshot(tamper).await.unwrap().status(), StatusCode::BAD_REQUEST);
 
-    // The stored integrity must be untouched.
     let after = app.oneshot(Request::get("/mypkg").body(Body::empty()).unwrap()).await.unwrap();
     let after = body_json(after.into_body()).await;
     assert_eq!(after["versions"]["1.0.0"]["dist"]["integrity"], original_integrity);
@@ -376,9 +375,8 @@ async fn update_packument_rejects_a_non_object_dist_for_a_published_version() {
         app.clone().oneshot(Request::get("/mypkg").body(Body::empty()).unwrap()).await.unwrap();
     let mut packument = body_json(get.into_body()).await;
     let original_integrity = packument["versions"]["1.0.0"]["dist"]["integrity"].clone();
-    // Replacing dist with a non-object would skip the integrity-restore path and
-    // leave the published version without its hash; it must be rejected, not
-    // silently persisted.
+    // A non-object dist would skip the integrity-restore path and strip the hash,
+    // so it must be rejected rather than silently persisted.
     packument["versions"]["1.0.0"]["dist"] = json!(null);
     let request = Request::put("/mypkg/-rev/1-0")
         .header("content-type", "application/json")
@@ -387,7 +385,6 @@ async fn update_packument_rejects_a_non_object_dist_for_a_published_version() {
         .unwrap();
     assert_eq!(app.clone().oneshot(request).await.unwrap().status(), StatusCode::BAD_REQUEST);
 
-    // The stored integrity must be untouched.
     let after = app.oneshot(Request::get("/mypkg").body(Body::empty()).unwrap()).await.unwrap();
     let after = body_json(after.into_body()).await;
     assert_eq!(after["versions"]["1.0.0"]["dist"]["integrity"], original_integrity);
@@ -426,7 +423,6 @@ async fn update_packument_rejects_tampering_with_a_published_version_tarball() {
         .unwrap();
     assert_eq!(app.clone().oneshot(tamper).await.unwrap().status(), StatusCode::BAD_REQUEST);
 
-    // The stored tarball must be untouched.
     let after = app.oneshot(Request::get("/mypkg").body(Body::empty()).unwrap()).await.unwrap();
     let after = body_json(after.into_body()).await;
     assert_eq!(after["versions"]["1.0.0"]["dist"]["tarball"], original_tarball);
@@ -453,11 +449,9 @@ async fn update_packument_rejects_adding_a_version_via_the_unpublish_put() {
     let mut packument = body_json(get.into_body()).await;
     let original_versions = packument["versions"].clone();
 
-    // Smuggle in a brand-new version whose tarball basename collides with the
-    // published 1.0.0 tarball. expected_tarball_dist fails closed on a duplicate
-    // basename, so persisting this would 502 every fetch of mypkg-1.0.0.tgz. The
-    // endpoint only removes versions, so adding one must be rejected — even with
-    // an otherwise-valid integrity.
+    // Add a new version whose tarball basename collides with 1.0.0's. A duplicate
+    // basename makes expected_tarball_dist fail closed (502), so the addition must
+    // be rejected — even with an otherwise-valid integrity.
     packument["versions"]["9.9.9"] = json!({
         "name": "mypkg",
         "version": "9.9.9",
@@ -473,7 +467,6 @@ async fn update_packument_rejects_adding_a_version_via_the_unpublish_put() {
         .unwrap();
     assert_eq!(app.clone().oneshot(request).await.unwrap().status(), StatusCode::BAD_REQUEST);
 
-    // No new version may have been persisted.
     let after = app.oneshot(Request::get("/mypkg").body(Body::empty()).unwrap()).await.unwrap();
     let after = body_json(after.into_body()).await;
     assert_eq!(after["versions"], original_versions);
@@ -495,17 +488,15 @@ async fn update_packument_protects_a_published_tarball_with_a_basenameless_url()
         .unwrap();
     assert_eq!(app.clone().oneshot(publish).await.unwrap().status(), StatusCode::CREATED);
 
-    // Force the *stored* dist.tarball to a URL with no basename (ends in `/`).
-    // rewrite_tarball_urls serves such a URL under the version-derived canonical
-    // name, so the served basename is still well-defined and must stay immutable.
+    // Force the stored dist.tarball to a basename-less URL (ends in `/`), which
+    // rewrite_tarball_urls serves under the version-derived canonical name — so
+    // the served basename is still well-defined and must stay pinned.
     let packument_path = storage.join("mypkg/package.json");
     let mut stored: Value =
         serde_json::from_slice(&std::fs::read(&packument_path).unwrap()).unwrap();
     stored["versions"]["1.0.0"]["dist"]["tarball"] = json!("http://localhost:4873/mypkg/-/");
     std::fs::write(&packument_path, serde_json::to_vec(&stored).unwrap()).unwrap();
 
-    // A PUT that repoints the version at a concrete, different basename must
-    // still be rejected, even though the stored URL itself has no basename.
     let mut tampered = stored.clone();
     tampered["versions"]["1.0.0"]["dist"]["tarball"] =
         json!("http://example.test/mypkg/-/mypkg-9.9.9.tgz");
@@ -524,10 +515,8 @@ async fn update_packument_rejects_seeding_a_package_with_no_published_packument(
     let app = router(static_config(storage.clone()));
     let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
 
-    // No prior publish: PUT a packument straight to the unpublish route. This
-    // would otherwise seed an authoritative version with no tarball and — since
-    // publish refuses a version already in the packument — block its future
-    // legitimate publish, so it must be rejected.
+    // PUT to the unpublish route with no prior publish would seed an authoritative
+    // version that publish can never overwrite, so it must be rejected.
     let body = sample_publish_body("ghost", "1.0.0", b"bytes");
     let request = Request::put("/ghost/-rev/anything")
         .header("content-type", "application/json")
@@ -536,7 +525,6 @@ async fn update_packument_rejects_seeding_a_package_with_no_published_packument(
         .unwrap();
     assert_eq!(app.oneshot(request).await.unwrap().status(), StatusCode::BAD_REQUEST);
 
-    // Nothing may have been written to the hosted store.
     assert!(!storage.join("ghost/package.json").exists());
 }
 

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -393,6 +393,45 @@ async fn update_packument_rejects_a_non_object_dist_for_a_published_version() {
     assert_eq!(after["versions"]["1.0.0"]["dist"]["integrity"], original_integrity);
 }
 
+#[tokio::test]
+async fn update_packument_rejects_tampering_with_a_published_version_tarball() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let publish = Request::put("/mypkg")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(
+            serde_json::to_vec(&sample_publish_body("mypkg", "1.0.0", b"real-bytes")).unwrap(),
+        ))
+        .unwrap();
+    assert_eq!(app.clone().oneshot(publish).await.unwrap().status(), StatusCode::CREATED);
+
+    let get =
+        app.clone().oneshot(Request::get("/mypkg").body(Body::empty()).unwrap()).await.unwrap();
+    let mut packument = body_json(get.into_body()).await;
+    let original_tarball = packument["versions"]["1.0.0"]["dist"]["tarball"].clone();
+
+    // Repoint the published version at a different tarball basename. The version
+    // keeps its immutable integrity, so this would make clients fetch bytes that
+    // can't match it (or 404) — it must be rejected, not persisted.
+    packument["versions"]["1.0.0"]["dist"]["tarball"] =
+        json!("http://example.test/mypkg/-/mypkg-9.9.9.tgz");
+    let tamper = Request::put("/mypkg/-rev/1-0")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_vec(&packument).unwrap()))
+        .unwrap();
+    assert_eq!(app.clone().oneshot(tamper).await.unwrap().status(), StatusCode::BAD_REQUEST);
+
+    // The stored tarball must be untouched.
+    let after = app.oneshot(Request::get("/mypkg").body(Body::empty()).unwrap()).await.unwrap();
+    let after = body_json(after.into_body()).await;
+    assert_eq!(after["versions"]["1.0.0"]["dist"]["tarball"], original_tarball);
+}
+
 /// Published packages are the source of truth: they live in the
 /// authoritative `storage` root, never in the disposable proxy cache,
 /// and survive a full wipe of that cache.

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -432,6 +432,53 @@ async fn update_packument_rejects_tampering_with_a_published_version_tarball() {
     assert_eq!(after["versions"]["1.0.0"]["dist"]["tarball"], original_tarball);
 }
 
+#[tokio::test]
+async fn update_packument_rejects_adding_a_version_via_the_unpublish_put() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let publish = Request::put("/mypkg")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(
+            serde_json::to_vec(&sample_publish_body("mypkg", "1.0.0", b"real-bytes")).unwrap(),
+        ))
+        .unwrap();
+    assert_eq!(app.clone().oneshot(publish).await.unwrap().status(), StatusCode::CREATED);
+
+    let get =
+        app.clone().oneshot(Request::get("/mypkg").body(Body::empty()).unwrap()).await.unwrap();
+    let mut packument = body_json(get.into_body()).await;
+    let original_versions = packument["versions"].clone();
+
+    // Smuggle in a brand-new version whose tarball basename collides with the
+    // published 1.0.0 tarball. expected_tarball_dist fails closed on a duplicate
+    // basename, so persisting this would 502 every fetch of mypkg-1.0.0.tgz. The
+    // endpoint only removes versions, so adding one must be rejected — even with
+    // an otherwise-valid integrity.
+    packument["versions"]["9.9.9"] = json!({
+        "name": "mypkg",
+        "version": "9.9.9",
+        "dist": {
+            "tarball": "http://example.test/mypkg/-/mypkg-1.0.0.tgz",
+            "integrity": packument["versions"]["1.0.0"]["dist"]["integrity"].clone(),
+        },
+    });
+    let request = Request::put("/mypkg/-rev/1-0")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_vec(&packument).unwrap()))
+        .unwrap();
+    assert_eq!(app.clone().oneshot(request).await.unwrap().status(), StatusCode::BAD_REQUEST);
+
+    // No new version may have been persisted.
+    let after = app.oneshot(Request::get("/mypkg").body(Body::empty()).unwrap()).await.unwrap();
+    let after = body_json(after.into_body()).await;
+    assert_eq!(after["versions"], original_versions);
+}
+
 /// Published packages are the source of truth: they live in the
 /// authoritative `storage` root, never in the disposable proxy cache,
 /// and survive a full wipe of that cache.

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -1182,6 +1182,13 @@ async fn unpublish_partial_writes_modified_packument() {
         .unwrap();
     let served = body_json(response.into_body()).await;
     assert_eq!(served["versions"].as_object().unwrap().keys().collect::<Vec<_>>(), vec!["2.0.0"]);
+    // The PUT body dropped dist.integrity for the retained version; the server
+    // restores the published value so the round-trip can't strip a hash and
+    // leave 2.0.0's tarball unservable.
+    assert!(
+        served["versions"]["2.0.0"]["dist"]["integrity"].is_string(),
+        "stripped integrity must be restored from the hosted packument",
+    );
 
     // DELETE the 1.0.0 tarball next.
     let request = Request::delete("/unpub-partial/-/unpub-partial-1.0.0.tgz/-rev/anything")

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -517,6 +517,29 @@ async fn update_packument_protects_a_published_tarball_with_a_basenameless_url()
     assert_eq!(app.oneshot(request).await.unwrap().status(), StatusCode::BAD_REQUEST);
 }
 
+#[tokio::test]
+async fn update_packument_rejects_seeding_a_package_with_no_published_packument() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    // No prior publish: PUT a packument straight to the unpublish route. This
+    // would otherwise seed an authoritative version with no tarball and — since
+    // publish refuses a version already in the packument — block its future
+    // legitimate publish, so it must be rejected.
+    let body = sample_publish_body("ghost", "1.0.0", b"bytes");
+    let request = Request::put("/ghost/-rev/anything")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    assert_eq!(app.oneshot(request).await.unwrap().status(), StatusCode::BAD_REQUEST);
+
+    // Nothing may have been written to the hosted store.
+    assert!(!storage.join("ghost/package.json").exists());
+}
+
 /// Published packages are the source of truth: they live in the
 /// authoritative `storage` root, never in the disposable proxy cache,
 /// and survive a full wipe of that cache.

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -356,6 +356,43 @@ async fn update_packument_rejects_a_non_string_dist_integrity() {
     assert_eq!(app.oneshot(request).await.unwrap().status(), StatusCode::BAD_REQUEST);
 }
 
+#[tokio::test]
+async fn update_packument_rejects_a_non_object_dist_for_a_published_version() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let publish = Request::put("/mypkg")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(
+            serde_json::to_vec(&sample_publish_body("mypkg", "1.0.0", b"real")).unwrap(),
+        ))
+        .unwrap();
+    assert_eq!(app.clone().oneshot(publish).await.unwrap().status(), StatusCode::CREATED);
+
+    let get =
+        app.clone().oneshot(Request::get("/mypkg").body(Body::empty()).unwrap()).await.unwrap();
+    let mut packument = body_json(get.into_body()).await;
+    let original_integrity = packument["versions"]["1.0.0"]["dist"]["integrity"].clone();
+    // Replacing dist with a non-object would skip the integrity-restore path and
+    // leave the published version without its hash; it must be rejected, not
+    // silently persisted.
+    packument["versions"]["1.0.0"]["dist"] = json!(null);
+    let request = Request::put("/mypkg/-rev/1-0")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_vec(&packument).unwrap()))
+        .unwrap();
+    assert_eq!(app.clone().oneshot(request).await.unwrap().status(), StatusCode::BAD_REQUEST);
+
+    // The stored integrity must be untouched.
+    let after = app.oneshot(Request::get("/mypkg").body(Body::empty()).unwrap()).await.unwrap();
+    let after = body_json(after.into_body()).await;
+    assert_eq!(after["versions"]["1.0.0"]["dist"]["integrity"], original_integrity);
+}
+
 /// Published packages are the source of truth: they live in the
 /// authoritative `storage` root, never in the disposable proxy cache,
 /// and survive a full wipe of that cache.
@@ -1183,11 +1220,13 @@ async fn unpublish_partial_writes_modified_packument() {
     let served = body_json(response.into_body()).await;
     assert_eq!(served["versions"].as_object().unwrap().keys().collect::<Vec<_>>(), vec!["2.0.0"]);
     // The PUT body dropped dist.integrity for the retained version; the server
-    // restores the published value so the round-trip can't strip a hash and
-    // leave 2.0.0's tarball unservable.
-    assert!(
-        served["versions"]["2.0.0"]["dist"]["integrity"].is_string(),
-        "stripped integrity must be restored from the hosted packument",
+    // restores the *exact* published hash (2.0.0 was published with its version
+    // string as the tarball bytes), so the round-trip can neither strip nor
+    // corrupt a published version's integrity.
+    assert_eq!(
+        served["versions"]["2.0.0"]["dist"]["integrity"],
+        json!(sri_sha512(b"2.0.0")),
+        "the original published integrity must be restored, unchanged",
     );
 
     // DELETE the 1.0.0 tarball next.


### PR DESCRIPTION
## Summary

`update_packument` (`PUT /:pkg/-rev/:rev`, the partial-unpublish flow) stripped only
`_attachments` / `_rev` / `_revisions` and wrote the client body verbatim. A publisher with both
publish and unpublish rights could therefore set `versions[v].dist.integrity` to a bogus SRI while
the real tarball on disk stayed valid — a permanent client-side `EINTEGRITY` DoS for that version,
with no upload required. The body `name` was also never checked against the URL.

This adds three guards:

1. **Name match** — reject a body whose `name` doesn't match the URL package (400).
2. **Integrity immutability** — reject any change to an already-published version's
   `dist.integrity`. The hosted packument is read under the package lock so a concurrent publish
   can't race the check (400).
3. **SRI validity** — reject a malformed `dist.integrity` on a newly added version entry (400).

The legitimate partial-unpublish flow (remove a version, leave the rest byte-for-byte unchanged)
is unaffected.

## Squash Commit Body

```text
update_packument (PUT /:pkg/-rev/:rev) stripped only _attachments/_rev/_revisions and wrote the
body verbatim, so a publisher with publish+unpublish rights could set versions[v].dist.integrity
to a bogus SRI while the real tarball stayed valid — a permanent client-side EINTEGRITY DoS for
that version, with no upload. The body name was also unchecked.

Add three guards: reject a body whose name does not match the URL package; reject any change to
an already-published version's dist.integrity (read under the package lock so a concurrent publish
cannot race it); and reject a malformed SRI on a newly added version entry. All map to 400. The
partial-unpublish flow is unaffected.
```

## Checklist

- [x] Added or updated tests — `update_packument_rejects_tampering_with_a_published_version_integrity`
  publishes a version, PUTs back a packument with a poisoned `dist.integrity`, asserts 400, and
  confirms the stored integrity is unchanged.
- [x] Updated the documentation if needed — n/a.

(No changeset: pnpr is not a published npm package. No pnpm-side port: pnpr-only endpoint.)

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `PUT` partial-unpublish now returns **400 BadRequest** when the optional request-body package `name` doesn’t match the URL package name.
  * Prevents tampering with already-published `versions[*].dist.integrity` during partial-unpublish: differing integrity is rejected with **400 BadRequest**; if omitted, the hosted integrity is restored.
  * Rejects invalid `dist.integrity` values (including non-string or `null`) with **400 BadRequest**.
* **Tests**
  * Added integration tests covering rejection of integrity tampering and invalid `dist.integrity`, plus assertions that previously stored integrity remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->