### PR TITLE
feat(pacquet): port whoami command

### DIFF
--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -517,7 +517,7 @@ impl CliArgs {
                 let cfg: &Config = config()?;
                 Box::pin(async move {
                     let username = whoami::whoami(cfg).await?;
-                    println!("{username}");
+                    println!("{}", sanitize::sanitize(&username));
                     Ok(())
                 })
             }

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -36,6 +36,7 @@ pub mod supported_architectures;
 pub mod unlink;
 pub mod update;
 pub mod update_interactive;
+pub mod whoami;
 pub mod why;
 
 use crate::{State, config_deps, config_overrides::ConfigOverrides};
@@ -186,6 +187,8 @@ pub enum CliCommand {
     List(ListArgs),
     /// Shows the packages that depend on `pkg`
     Why(WhyArgs),
+    /// Displays your pnpm username.
+    Whoami,
     /// Rebuild a package.
     #[clap(visible_alias = "rb")]
     Rebuild(RebuildArgs),
@@ -503,6 +506,20 @@ impl CliArgs {
             CliCommand::Remove(args) if args.global => {
                 global::handle_global_remove(config()?, &args.package_names)?;
                 Box::pin(std::future::ready(Ok(())))
+            }
+            // `whoami` is a read-only registry query: it resolves the
+            // default registry's auth header from config and GETs
+            // `-/whoami`, with no lockfile or install pipeline. It needs
+            // an async future for the request but no reporter-typed
+            // fan-out, so it dispatches off `config()` like the other
+            // read-only commands.
+            CliCommand::Whoami => {
+                let cfg: &Config = config()?;
+                Box::pin(async move {
+                    let username = whoami::whoami(cfg).await?;
+                    println!("{username}");
+                    Ok(())
+                })
             }
             CliCommand::Remove(args) => {
                 let command_state = state(false)?;

--- a/pacquet/crates/cli/src/cli_args/whoami.rs
+++ b/pacquet/crates/cli/src/cli_args/whoami.rs
@@ -80,12 +80,15 @@ async fn fetch_whoami(
     retry_opts: RetryOpts,
 ) -> miette::Result<String> {
     let url = format!("{registry_url}-/whoami");
+    // Diagnostic context omits the URL: a registry configured as
+    // `https://user:password@host/` carries inline credentials (accepted by
+    // `AuthHeaders`), which must not reach stderr / CI logs.
     let (client, response) = send_with_retry(http_client, &url, retry_opts, |client| {
         client.get(&url).header("authorization", auth_header)
     })
     .await
     .into_diagnostic()
-    .wrap_err_with(|| format!("requesting {url}"))?;
+    .wrap_err("requesting the registry whoami endpoint")?;
     if !response.status().is_success() {
         let status = response.status();
         return Err(WhoamiError::Failed {
@@ -98,7 +101,7 @@ async fn fetch_whoami(
         .json::<WhoamiResponse>()
         .await
         .into_diagnostic()
-        .wrap_err_with(|| format!("parsing the whoami response from {url}"))?;
+        .wrap_err("parsing the whoami response")?;
     drop(client);
     Ok(body.username)
 }

--- a/pacquet/crates/cli/src/cli_args/whoami.rs
+++ b/pacquet/crates/cli/src/cli_args/whoami.rs
@@ -1,0 +1,104 @@
+use derive_more::{Display, Error};
+use miette::{Context, Diagnostic, IntoDiagnostic};
+use pacquet_config::Config;
+use pacquet_network::{NetworkSettings, RetryOpts, ThrottledClient, send_with_retry};
+use serde::Deserialize;
+use std::time::Duration;
+
+/// Errors from `pacquet whoami`.
+///
+/// Mirrors the error codes pnpm raises in `whoami.ts`
+/// (<https://github.com/pnpm/pnpm/blob/fc2f33912e/pnpm11/registry-access/commands/src/whoami.ts>).
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum WhoamiError {
+    #[display("You must be logged in to use whoami")]
+    #[diagnostic(code(ERR_PNPM_WHOAMI_UNAUTHORIZED))]
+    Unauthorized,
+
+    #[display("Failed to find the current user: {status} {status_text}")]
+    #[diagnostic(code(ERR_PNPM_WHOAMI_FAILED))]
+    Failed { status: u16, status_text: String },
+}
+
+/// The `GET /-/whoami` response body. The registry returns other fields
+/// too; only `username` is read.
+#[derive(Debug, Deserialize)]
+struct WhoamiResponse {
+    username: String,
+}
+
+/// `pacquet whoami` — return the username the configured registry
+/// associates with the current auth token.
+///
+/// Ports `whoami.ts`'s `handler`: resolve the default registry, look up
+/// its `Authorization` header, and fail with `ERR_PNPM_WHOAMI_UNAUTHORIZED`
+/// when no credentials are configured — before any request is made.
+pub async fn whoami(config: &Config) -> miette::Result<String> {
+    let auth_header =
+        config.auth_headers.for_url(&config.registry).ok_or(WhoamiError::Unauthorized)?;
+    let http_client = build_http_client(config)?;
+    let retry_opts = RetryOpts {
+        retries: config.fetch_retries,
+        factor: config.fetch_retry_factor,
+        min_timeout: Duration::from_millis(config.fetch_retry_mintimeout),
+        max_timeout: Duration::from_millis(config.fetch_retry_maxtimeout),
+    };
+    fetch_whoami(&config.registry, &http_client, &auth_header, retry_opts).await
+}
+
+/// The network client `whoami` makes its single request through, built
+/// from the same proxy / TLS / timeout config as the install client
+/// ([`crate::state::State::init`]).
+fn build_http_client(config: &Config) -> miette::Result<ThrottledClient> {
+    ThrottledClient::for_installs(
+        &config.proxy,
+        &config.tls,
+        &config.tls_by_uri,
+        &NetworkSettings {
+            network_concurrency: config.network_concurrency,
+            fetch_timeout: Duration::from_millis(config.fetch_timeout),
+            user_agent: config.user_agent.clone(),
+        },
+    )
+    .into_diagnostic()
+    .wrap_err("create the network client for whoami")
+}
+
+/// GET `<registry>-/whoami` with the resolved `Authorization` header and
+/// read `username` from the JSON body.
+///
+/// Ports `whoami.ts`'s `fetchWhoami`, erroring with
+/// `ERR_PNPM_WHOAMI_FAILED` on any non-success status. `registry_url` is
+/// the config registry, which always carries a trailing slash, so
+/// concatenating `-/whoami` reproduces pnpm's `new URL('./-/whoami', ...)`
+/// join (preserving any registry path prefix).
+async fn fetch_whoami(
+    registry_url: &str,
+    http_client: &ThrottledClient,
+    auth_header: &str,
+    retry_opts: RetryOpts,
+) -> miette::Result<String> {
+    let url = format!("{registry_url}-/whoami");
+    let (client, response) = send_with_retry(http_client, &url, retry_opts, |client| {
+        client.get(&url).header("authorization", auth_header)
+    })
+    .await
+    .into_diagnostic()
+    .wrap_err_with(|| format!("requesting {url}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        return Err(WhoamiError::Failed {
+            status: status.as_u16(),
+            status_text: status.canonical_reason().unwrap_or_default().to_string(),
+        }
+        .into());
+    }
+    let body = response
+        .json::<WhoamiResponse>()
+        .await
+        .into_diagnostic()
+        .wrap_err_with(|| format!("parsing the whoami response from {url}"))?;
+    drop(client);
+    Ok(body.username)
+}

--- a/pacquet/crates/cli/tests/whoami.rs
+++ b/pacquet/crates/cli/tests/whoami.rs
@@ -4,7 +4,8 @@
 //! Ports the upstream whoami tests
 //! (<https://github.com/pnpm/pnpm/blob/fc2f33912e/pnpm11/registry-access/commands/test/whoami.ts>):
 //! the success path, the unauthenticated path, a registry that rejects the
-//! request, and preservation of a registry path prefix.
+//! request, and preservation of a registry path prefix. Adds a pacquet-only
+//! guard that control characters in a registry-provided username are stripped.
 //!
 //! The registry is a `mockito` server the spawned `pacquet` connects to
 //! over loopback. Credentials are supplied through `--npmrc-auth-file`,
@@ -80,6 +81,35 @@ fn returns_the_current_username() {
         String::from_utf8_lossy(&output.stderr),
     );
     assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "alice");
+    drop((root, server));
+}
+
+#[test]
+fn strips_control_characters_from_the_username() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    // A malicious/compromised registry returns a username carrying an ESC
+    // (0x1b) and a BEL (0x07); pacquet must not emit them raw to the terminal.
+    let esc = char::from(0x1b);
+    let bel = char::from(0x07);
+    let username = format!("al{esc}[31mice{bel}");
+    let body = serde_json::json!({ "username": username }).to_string();
+    let mock = server.mock("GET", "/-/whoami").with_status(200).with_body(body).create();
+    let auth_file = configure(root.path(), &workspace, &registry, Some("test-token"));
+
+    let output = run_whoami(&workspace, &auth_file);
+
+    mock.assert();
+    assert!(
+        output.status.success(),
+        "whoami must succeed (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim(), "al[31mice", "control characters must be stripped");
+    assert!(!stdout.contains(esc), "ESC must be stripped: {stdout:?}");
+    assert!(!stdout.contains(bel), "BEL must be stripped: {stdout:?}");
     drop((root, server));
 }
 

--- a/pacquet/crates/cli/tests/whoami.rs
+++ b/pacquet/crates/cli/tests/whoami.rs
@@ -1,0 +1,155 @@
+//! `pacquet whoami` resolves the default registry's auth token from config
+//! and prints the username returned by `GET <registry>-/whoami`.
+//!
+//! Ports the upstream whoami tests
+//! (<https://github.com/pnpm/pnpm/blob/fc2f33912e/pnpm11/registry-access/commands/test/whoami.ts>):
+//! the success path, the unauthenticated path, a registry that rejects the
+//! request, and preservation of a registry path prefix.
+//!
+//! The registry is a `mockito` server the spawned `pacquet` connects to
+//! over loopback. Credentials are supplied through `--npmrc-auth-file`,
+//! which replaces the developer's real `~/.npmrc`, so the unauthenticated
+//! test can't be fooled by a token already on the machine.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+}
+
+/// The nerf-darted `.npmrc` auth-key prefix (`//host:port/path/`) for a
+/// registry URL — its scheme dropped and a single trailing slash kept.
+fn nerf(registry: &str) -> String {
+    let without_scheme = registry
+        .strip_prefix("http://")
+        .or_else(|| registry.strip_prefix("https://"))
+        .unwrap_or(registry);
+    format!("//{}/", without_scheme.trim_end_matches('/'))
+}
+
+/// Point `pacquet whoami` at `registry`: the project `.npmrc` carries the
+/// registry URL and a separate auth file (returned for `--npmrc-auth-file`)
+/// carries the token. Passing `None` leaves the user unauthenticated.
+fn configure(root: &Path, workspace: &Path, registry: &str, auth_token: Option<&str>) -> PathBuf {
+    fs::write(workspace.join(".npmrc"), format!("registry={registry}\n"))
+        .expect("write project .npmrc");
+    let auth_file = root.join("auth-npmrc");
+    let contents = match auth_token {
+        Some(token) => format!("{}:_authToken={token}\n", nerf(registry)),
+        None => String::new(),
+    };
+    fs::write(&auth_file, contents).expect("write auth .npmrc");
+    auth_file
+}
+
+fn run_whoami(workspace: &Path, auth_file: &Path) -> std::process::Output {
+    pacquet_at(workspace)
+        .with_arg("--npmrc-auth-file")
+        .with_arg(auth_file)
+        .with_arg("whoami")
+        .output()
+        .expect("spawn pacquet whoami")
+}
+
+#[test]
+fn returns_the_current_username() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let mock = server
+        .mock("GET", "/-/whoami")
+        .match_header("authorization", "Bearer test-token")
+        .with_status(200)
+        .with_body(r#"{"username":"alice"}"#)
+        .create();
+    let auth_file = configure(root.path(), &workspace, &registry, Some("test-token"));
+
+    let output = run_whoami(&workspace, &auth_file);
+
+    mock.assert();
+    assert!(
+        output.status.success(),
+        "whoami must succeed (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "alice");
+    drop((root, server));
+}
+
+#[test]
+fn fails_when_not_logged_in() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    // No request is made, so no server is needed; the registry just has to
+    // resolve to no credentials.
+    let auth_file = configure(root.path(), &workspace, "http://127.0.0.1:1/", None);
+
+    let output = run_whoami(&workspace, &auth_file);
+
+    assert!(
+        !output.status.success(),
+        "an unauthenticated whoami must fail (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        stderr.contains("ERR_PNPM_WHOAMI_UNAUTHORIZED") && stderr.contains("You must be logged in"),
+        "stderr must name the unauthorized diagnostic; got:\n{stderr}",
+    );
+    drop(root);
+}
+
+#[test]
+fn fails_when_the_registry_rejects_the_request() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let mock = server.mock("GET", "/-/whoami").with_status(401).with_body("{}").create();
+    let auth_file = configure(root.path(), &workspace, &registry, Some("test-token"));
+
+    let output = run_whoami(&workspace, &auth_file);
+
+    mock.assert();
+    assert!(
+        !output.status.success(),
+        "a rejected whoami must fail (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        stderr.contains("ERR_PNPM_WHOAMI_FAILED")
+            && stderr.contains("Failed to find the current user"),
+        "stderr must name the failed diagnostic; got:\n{stderr}",
+    );
+    drop((root, server));
+}
+
+#[test]
+fn preserves_a_registry_path_prefix() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/custom-prefix/", server.url());
+    let mock = server
+        .mock("GET", "/custom-prefix/-/whoami")
+        .with_status(200)
+        .with_body(r#"{"username":"alice"}"#)
+        .create();
+    let auth_file = configure(root.path(), &workspace, &registry, Some("test-token"));
+
+    let output = run_whoami(&workspace, &auth_file);
+
+    mock.assert();
+    assert!(
+        output.status.success(),
+        "whoami must succeed against a prefixed registry (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "alice");
+    drop((root, server));
+}


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

Ports pnpm's `whoami` command to pacquet. `pacquet whoami` prints the username
the configured registry associates with the current auth token.

It resolves the default registry and its `Authorization` header from config
(via the existing `AuthHeaders::for_url`, pacquet's port of
`createGetAuthHeaderByURI`), issues `GET <registry>-/whoami` through the shared
network client, and prints the response's `username`. Errors mirror pnpm
verbatim:

- `ERR_PNPM_WHOAMI_UNAUTHORIZED` ("You must be logged in to use whoami") when no
  credentials are configured — raised before any request is made.
- `ERR_PNPM_WHOAMI_FAILED` ("Failed to find the current user: {status} {reason}")
  on a non-success response.

Source of truth: pnpm's registry-access `whoami`
(`pnpm11/registry-access/commands/src/whoami.ts`). whoami already exists in the
TypeScript CLI; this PR brings the Rust port to parity.

Relates to pnpm/pnpm#11633.

### Behavioral parity with pnpm

**Matches:** registry resolution + normalization, auth-header lookup (incl.
inline `user:pass@`), URL construction (`-/whoami`, path prefix preserved),
GET + `authorization` header, 2xx success check, retry defaults (2 retries,
factor 10, 10s/60s), 60s timeout, `username` parsing (extra fields ignored),
and — verified — cross-host-redirect stripping of `Authorization` via reqwest's
default `remove_sensitive_headers`, matching pnpm's redirect auth-strip
workaround (pnpm/pnpm#1815).

**Known divergences** (all inert or deliberate; none user-visible in normal use):

1. **No `Accept` header.** pnpm's generic fetch wrapper adds a packument
   `Accept` (`application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*`)
   to every GET, including whoami; the `/-/whoami` endpoint ignores it. pacquet
   omits it, consistent with its other non-packument fetches (e.g. the
   attestation lookup). No functional effect.
2. **Retry status set.** pacquet routes through the shared `send_with_retry`
   (retries 408/429/5xx); pnpm's `fetch.ts` additionally retries 409/420. This
   is a pacquet-wide policy, not whoami-specific.
3. **`statusText`.** The `WHOAMI_FAILED` message uses
   `StatusCode::canonical_reason()` (reqwest exposes no wire reason phrase) —
   identical to pnpm for standard codes; an empty reason for non-standard codes.
4. **Non-conformant 200.** A 200 without a `username` field errors in pacquet
   (strict deserialization) where pnpm would print `undefined`.
5. **No `--registry` flag.** pnpm accepts `whoami --registry=<url>`; in pacquet
   the registry comes from config (`--config.registry=<url>`), consistent with
   every pacquet command.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Print the username the configured registry associates with the current
auth token, mirroring pnpm's whoami.

Resolve the default registry and its Authorization header from config,
GET <registry>-/whoami, and print the response's username. Reuse the
shared network client and send_with_retry so proxy/TLS/timeout/retry
config behaves as for every other registry request. Surface pnpm's
error codes verbatim: ERR_PNPM_WHOAMI_UNAUTHORIZED when no credentials
are configured (before any request), ERR_PNPM_WHOAMI_FAILED on a
non-success response.

Known parity gaps, all inert or deliberate: no packument Accept header
(the endpoint ignores it; consistent with pacquet's other non-packument
fetches); retries follow pacquet's shared policy (408/429/5xx) rather
than fetch.ts's extra 409/420; the failure message uses the canonical
status reason since reqwest exposes no wire reason phrase; a 200 without
a username field errors instead of yielding undefined; the registry is
taken from config (--config.registry) rather than a dedicated --registry
flag.

Ported from pnpm's registry-access whoami command (pnpm/pnpm#11633).
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Made with the help of Claude Code (claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `whoami` CLI command that displays your authenticated username for the configured registry.
  * Fetches the username from the registry’s `-/whoami` endpoint.
* **Bug Fixes**
  * Improved error messages for unauthorized access and unsuccessful registry responses.
  * Sanitizes registry-provided usernames to remove control characters.
  * Correctly supports registries that include URL path prefixes.
* **Tests**
  * Added integration tests covering success, sanitization, unauthorized/failure cases, and prefixed registry URL handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->