### PR TITLE
fix: pack node-gyp's gyp entrypoints as executable

### DIFF
--- a/.changeset/node-gyp-gyp-executable.md
+++ b/.changeset/node-gyp-gyp-executable.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/exe": patch
+"pnpm": patch
+---
+
+Restore the execute bit on the `node-gyp` gyp entrypoints packed inside `pnpm` and `@pnpm/exe` (`dist/node_modules/node-gyp/gyp/gyp_main.py` and `dist/node_modules/node-gyp/gyp/gyp`). These ship with shebangs and are exec'd directly by gyp's `make` generator when it regenerates the `Makefile` during a from-source native addon build. Without the execute bit they are packed at 0644, so the build fails with `Permission denied` / `make: *** [Makefile] Error 126`. This is a follow-up to [#11485](https://github.com/pnpm/pnpm/pull/11485), which restored the bit on the `node-gyp` bin shims but missed the two gyp entrypoints [#12455](https://github.com/pnpm/pnpm/issues/12455).

--- a/.changeset/node-gyp-gyp-executable.md
+++ b/.changeset/node-gyp-gyp-executable.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Restore the execute bit on the `node-gyp` gyp entrypoints packed inside `pnpm` and `@pnpm/exe` (`dist/node_modules/node-gyp/gyp/gyp_main.py` and `dist/node_modules/node-gyp/gyp/gyp`). These ship with shebangs and are exec'd directly by gyp's `make` generator when it regenerates the `Makefile` during a from-source native addon build. Without the execute bit they are packed at 0644, so the build fails with `Permission denied` / `make: *** [Makefile] Error 126`. This is a follow-up to [#11485](https://github.com/pnpm/pnpm/pull/11485), which restored the bit on the `node-gyp` bin shims but missed the two gyp entrypoints [#12455](https://github.com/pnpm/pnpm/issues/12455).
+node-gyp's `gyp_main.py` and `gyp` entrypoints are now packed with the executable bit in the `pnpm` and `@pnpm/exe` tarballs. Without it, building native addons from source could fail with a permission error.

--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -29,6 +29,8 @@ const PUBLISH_EXECUTABLE_FILES = [
   './dist/node-gyp-bin/node-gyp',
   './dist/node-gyp-bin/node-gyp.cmd',
   './dist/node_modules/node-gyp/bin/node-gyp.js',
+  './dist/node_modules/node-gyp/gyp/gyp_main.py',
+  './dist/node_modules/node-gyp/gyp/gyp',
 ]
 
 // Packages whose tests spawn the local pnpm CLI binary (pnpm/bin/pnpm.mjs)

--- a/pnpm11/pnpm/artifacts/exe/package.json
+++ b/pnpm11/pnpm/artifacts/exe/package.json
@@ -85,7 +85,9 @@
     "executableFiles": [
       "./dist/node-gyp-bin/node-gyp",
       "./dist/node-gyp-bin/node-gyp.cmd",
-      "./dist/node_modules/node-gyp/bin/node-gyp.js"
+      "./dist/node_modules/node-gyp/bin/node-gyp.js",
+      "./dist/node_modules/node-gyp/gyp/gyp_main.py",
+      "./dist/node_modules/node-gyp/gyp/gyp"
     ]
   }
 }

--- a/pnpm11/pnpm/package.json
+++ b/pnpm11/pnpm/package.json
@@ -196,7 +196,9 @@
     "executableFiles": [
       "./dist/node-gyp-bin/node-gyp",
       "./dist/node-gyp-bin/node-gyp.cmd",
-      "./dist/node_modules/node-gyp/bin/node-gyp.js"
+      "./dist/node_modules/node-gyp/bin/node-gyp.js",
+      "./dist/node_modules/node-gyp/gyp/gyp_main.py",
+      "./dist/node_modules/node-gyp/gyp/gyp"
     ]
   }
 }


### PR DESCRIPTION
## Summary

The bundled node-gyp ships two gyp entrypoints — `gyp/gyp_main.py` and `gyp/gyp` — as non-executable (0644) inside the `pnpm` and `@pnpm/exe` tarballs. Both start with a shebang and are exec'd directly by gyp's `make` generator when it regenerates the `Makefile` during a from-source native addon build, so the build fails with `Permission denied` / `make: *** [Makefile] Error 126`.

pnpm/pnpm#11485 restored the execute bit on the node-gyp bin shims for the same class of bug (pnpm/pnpm#11483) but missed these two gyp entrypoints. This adds them to `PUBLISH_EXECUTABLE_FILES` in the meta-updater, which writes `publishConfig.executableFiles` for both the `pnpm` and `@pnpm/exe` manifests.

Reproduced on the published 11.9.0 tarballs:

    $ npm pack pnpm@11.9.0
    $ tar -tvf pnpm-11.9.0.tgz | grep 'node-gyp/\(gyp\|bin\)'
    -rw-r--r--  node-gyp/gyp/gyp_main.py    # 0644, missing from the allowlist
    -rw-r--r--  node-gyp/gyp/gyp            # 0644, missing from the allowlist
    -rwxr-xr-x  node-gyp/bin/node-gyp.js    # 0755, already on the allowlist

`@pnpm/exe@11.9.0` packs them the same way. Files on `publishConfig.executableFiles` come out 0755 while the two gyp entrypoints, which carry the same shebangs, come out 0644.

Closes pnpm/pnpm#12455

## Squash Commit Body

```text
gyp's make generator execs gyp/gyp_main.py and gyp/gyp directly through
their shebangs when it regenerates the Makefile during a from-source
native build. They were missing from publishConfig.executableFiles, so
they got packed at 0644 and the build failed with "Permission denied"
(make error 126).

pnpm/pnpm#11485 fixed the node-gyp bin shims but not these two. Add them
to PUBLISH_EXECUTABLE_FILES so the pnpm and `@pnpm/exe` tarballs pack
them at 0755.

Closes pnpm/pnpm#12455
```

## Checklist

- [x] No `pacquet/` port needed — this only changes how the `pnpm`/`@pnpm/exe` tarballs are packed (`publishConfig.executableFiles`), which has no equivalent in the Rust port.
- [x] Added a changeset.
- [ ] No unit test added — the allowlist is regenerated and checked by `meta-updater --test` (`lint:meta`) in CI, same as pnpm/pnpm#11485.
- [ ] Docs not affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated packaged releases to include `node-gyp` entrypoint files with the correct executable permissions.
  * Fixed build failures for native addons that previously hit “Permission denied” and related execution errors.
  * Improved the reliability of building from source by ensuring all required `node-gyp` artifacts are bundled correctly in the produced tarballs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->