### PR TITLE
ci: make review label automation tolerate queued captures

### DIFF
--- a/.github/workflows/pr-review-automation-privileged.yml
+++ b/.github/workflows/pr-review-automation-privileged.yml
@@ -44,20 +44,38 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
           REVIEWER: ${{ github.event.workflow_run.actor.login }}
+        shell: bash
         run: |
-          if [ -z "$PR_NUMBER" ]; then
-            echo "::notice::No pull request attached to the review workflow run; nothing to do"
-            echo "has_approval=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if ! printf '%s' "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
-            echo "Invalid PR number: $PR_NUMBER" >&2
-            exit 1
-          fi
-          if ! printf '%s' "$HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+          set -euo pipefail
+
+          if ! [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Invalid head SHA: $HEAD_SHA" >&2
             exit 1
           fi
+
+          pr_number="${PR_NUMBER:-}"
+          if [ -z "$pr_number" ]; then
+            pr_matches="$(
+              gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100" --paginate --jq '.[]' |
+                jq -s --arg sha "$HEAD_SHA" '[.[] | select(.head.sha == $sha) | .number] | unique'
+            )"
+            pr_count="$(printf '%s' "$pr_matches" | jq 'length')"
+            if [ "$pr_count" = "0" ]; then
+              echo "::error::No open PR matches head_sha=$HEAD_SHA in $GITHUB_REPOSITORY"
+              exit 1
+            fi
+            if [ "$pr_count" != "1" ]; then
+              echo "::error::Ambiguous head_sha=$HEAD_SHA matches $pr_count PRs: $pr_matches"
+              exit 1
+            fi
+            pr_number="$(printf '%s' "$pr_matches" | jq -r '.[0]')"
+          fi
+
+          if ! [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Invalid PR number: $pr_number" >&2
+            exit 1
+          fi
+
           case "$REVIEWER" in
             'coderabbitai[bot]') label='reviewed: coderabbit'; announce=true ;;
             'qodo-free-for-open-source-projects[bot]') label='reviewed: qodo'; announce=false ;;
@@ -69,28 +87,37 @@ jobs:
               ;;
           esac
 
-          approved_review_id=
+          latest_review=
           for _ in 1 2 3 4 5; do
-            approved_review_id="$(
-              gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" |
+            latest_review="$(
+              gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number/reviews" --paginate --jq '.[]' |
                 jq -sr --arg reviewer "$REVIEWER" --arg head_sha "$HEAD_SHA" \
-                  '[.[][] | select(.user.login == $reviewer and .state == "APPROVED" and .commit_id == $head_sha) | .id][0] // empty'
+                  '[.[] | select(.user.login == $reviewer and .commit_id == $head_sha and .state != "COMMENTED")]
+                  | sort_by(.submitted_at // .created_at // "")
+                  | last // empty'
             )"
-            if [ -n "$approved_review_id" ]; then
+            if [ -n "$latest_review" ]; then
               break
             fi
             sleep 2
           done
 
-          if [ -z "$approved_review_id" ]; then
-            echo "::notice::No approved $REVIEWER review on $HEAD_SHA for PR #$PR_NUMBER; nothing to do"
+          if [ -z "$latest_review" ]; then
+            echo "::notice::No decision review by $REVIEWER on $HEAD_SHA for PR #$pr_number; nothing to do"
+            echo "has_approval=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          review_state="$(printf '%s' "$latest_review" | jq -r '.state')"
+          if [ "$review_state" != "APPROVED" ]; then
+            echo "::notice::Latest decision review by $REVIEWER on $HEAD_SHA is $review_state; nothing to do"
             echo "has_approval=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           {
             echo "has_approval=true"
-            echo "pr_number=$PR_NUMBER"
+            echo "pr_number=$pr_number"
             echo "label=$label"
             echo "announce=$announce"
           } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-review-automation-privileged.yml
+++ b/.github/workflows/pr-review-automation-privileged.yml
@@ -21,8 +21,13 @@ permissions: {}
 
 jobs:
   act:
-    if: github.event.workflow_run.event == 'pull_request_review'
+    if: >-
+      github.event.workflow_run.event == 'pull_request_review' &&
+      contains(fromJSON('["coderabbitai[bot]", "qodo-free-for-open-source-projects[bot]", "zkochan"]'), github.event.workflow_run.actor.login)
     runs-on: ubuntu-latest
+    concurrency:
+      group: pr-review-automation-${{ github.event.workflow_run.head_sha }}-${{ github.event.workflow_run.actor.login }}
+      cancel-in-progress: true
     permissions:
       # The POST /issues/{n}/labels endpoint is shared between issues and PRs,
       # but the governing permission depends on the target: labeling a pull

--- a/.github/workflows/pr-review-automation-privileged.yml
+++ b/.github/workflows/pr-review-automation-privileged.yml
@@ -4,29 +4,26 @@ name: PR review automation (privileged)
 # executes from the base repository's default branch with a write-scoped token
 # and access to secrets, even when the originating PR came from a fork (where the
 # pull_request_review run is denied both). This job performs only fixed,
-# repo-controlled actions — adding a known label and posting to Discord — on data
-# read from the artifact as inert files. It never checks out or executes PR content.
+# repo-controlled actions — adding a known label and posting to Discord — after
+# checking the review through GitHub's API. It never checks out or executes PR
+# content.
 on:
   # zizmor: ignore[dangerous-triggers]
-  # The capture workflow runs with no token permissions and produces only inert
-  # data files. This workflow runs from the default branch via workflow_run,
-  # validates that data, then performs fixed repo-controlled actions (label +
-  # Discord) without ever checking out or executing PR content.
+  # The capture workflow runs with no token permissions. This workflow runs from
+  # the default branch via workflow_run, validates the requested review against
+  # GitHub's API, then performs fixed repo-controlled actions (label + Discord)
+  # without ever checking out or executing PR content.
   workflow_run:
     workflows: ["PR review automation"]
-    types: [completed]
+    types: [requested]
 
 permissions: {}
 
 jobs:
   act:
-    if: >-
-      github.event.workflow_run.event == 'pull_request_review' &&
-      github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.event == 'pull_request_review'
     runs-on: ubuntu-latest
     permissions:
-      # Downloading an artifact from the triggering run requires actions: read.
-      actions: read
       # The POST /issues/{n}/labels endpoint is shared between issues and PRs,
       # but the governing permission depends on the target: labeling a pull
       # request needs pull-requests: write (issues: write only covers issues).
@@ -41,60 +38,65 @@ jobs:
       # the Discord step. (Step-level env is not visible to that step's own `if`.)
       HAS_DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK != '' }}
     steps:
-      - name: Download the event artifact
-        id: download
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        # The capture job is skipped for non-approval reviews, leaving no artifact;
-        # tolerate its absence instead of failing the run.
-        continue-on-error: true
-        with:
-          name: pr-review-event
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: pr-review-event
-
-      - name: Distinguish a missing artifact from a failed download
-        if: steps.download.outcome != 'success'
-        env:
-          RUN_ID: ${{ github.event.workflow_run.id }}
-        run: |
-          # No artifact is the expected, benign case: the capture job is skipped for
-          # non-approval reviews. But if the artifact does exist and we still failed
-          # to download it, the run would otherwise pass as a silent no-op — surface
-          # that as an error so a missed label/announcement is observable in CI.
-          artifacts="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/artifacts" --paginate --jq '.artifacts[].name')"
-          if printf '%s\n' "$artifacts" | grep -qx 'pr-review-event'; then
-            echo "::error::pr-review-event artifact exists but could not be downloaded"
-            exit 1
-          fi
-          echo "::notice::No pr-review-event artifact (non-approval review); nothing to do"
-
-      - name: Parse the event
+      - name: Resolve the review event
         id: event
-        if: steps.download.outcome == 'success'
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          REVIEWER: ${{ github.event.workflow_run.actor.login }}
         run: |
-          # The artifact is influenced by the fork PR; treat it as untrusted.
-          reviewer="$(cat pr-review-event/reviewer)"
-          pr_number="$(cat pr-review-event/pr_number)"
-          # Reject anything that is not a plain integer to keep it out of the API path.
-          if ! printf '%s' "$pr_number" | grep -qE '^[0-9]+$'; then
-            echo "Invalid PR number: $pr_number" >&2
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::notice::No pull request attached to the review workflow run; nothing to do"
+            echo "has_approval=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! printf '%s' "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+            echo "Invalid PR number: $PR_NUMBER" >&2
             exit 1
           fi
-          case "$reviewer" in
+          if ! printf '%s' "$HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "Invalid head SHA: $HEAD_SHA" >&2
+            exit 1
+          fi
+          case "$REVIEWER" in
             'coderabbitai[bot]') label='reviewed: coderabbit'; announce=true ;;
             'qodo-free-for-open-source-projects[bot]') label='reviewed: qodo'; announce=false ;;
             'zkochan') label='state: automerge'; announce=false ;;
-            *) echo "Unexpected reviewer: $reviewer" >&2; exit 1 ;;
+            *)
+              echo "::notice::Ignoring review by $REVIEWER"
+              echo "has_approval=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
           esac
+
+          approved_review_id=
+          for _ in 1 2 3 4 5; do
+            approved_review_id="$(
+              gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" |
+                jq -sr --arg reviewer "$REVIEWER" --arg head_sha "$HEAD_SHA" \
+                  '[.[][] | select(.user.login == $reviewer and .state == "APPROVED" and .commit_id == $head_sha) | .id][0] // empty'
+            )"
+            if [ -n "$approved_review_id" ]; then
+              break
+            fi
+            sleep 2
+          done
+
+          if [ -z "$approved_review_id" ]; then
+            echo "::notice::No approved $REVIEWER review on $HEAD_SHA for PR #$PR_NUMBER; nothing to do"
+            echo "has_approval=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           {
-            echo "pr_number=$pr_number"
+            echo "has_approval=true"
+            echo "pr_number=$PR_NUMBER"
             echo "label=$label"
             echo "announce=$announce"
           } >> "$GITHUB_OUTPUT"
 
       - name: Add the reviewed label
-        if: steps.event.outcome == 'success'
+        if: steps.event.outputs.has_approval == 'true'
         env:
           PR_NUMBER: ${{ steps.event.outputs.pr_number }}
           LABEL: ${{ steps.event.outputs.label }}
@@ -105,7 +107,7 @@ jobs:
 
       - name: Announce on Discord
         if: >-
-          steps.event.outcome == 'success' &&
+          steps.event.outputs.has_approval == 'true' &&
           steps.event.outputs.announce == 'true' &&
           env.HAS_DISCORD_WEBHOOK == 'true'
         env:
@@ -114,8 +116,9 @@ jobs:
         run: |
           # PR title and URL are read as data and passed via jq --arg, never as code.
           # allowed_mentions parse:[] stops a PR title like "@everyone" from pinging the Discord server.
-          title="$(cat pr-review-event/title)"
-          url="$(cat pr-review-event/url)"
+          pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          title="$(printf '%s' "$pr" | jq -r '.title')"
+          url="$(printf '%s' "$pr" | jq -r '.html_url')"
           payload="$(jq -n \
             --arg n "$PR_NUMBER" \
             --arg t "$title" \

--- a/.github/workflows/pr-review-automation.yml
+++ b/.github/workflows/pr-review-automation.yml
@@ -1,8 +1,9 @@
 name: PR review automation
 
 # Capture PR review approvals from the AI reviewers and the maintainer. This
-# workflow only records the event as an artifact; the privileged follow-up
-# (pr-review-automation-privileged.yml) adds the label and posts to Discord.
+# workflow is intentionally unprivileged; the privileged follow-up
+# (pr-review-automation-privileged.yml) verifies the review through GitHub's API
+# before it adds the label and posts to Discord.
 #
 # The split exists because pull_request_review runs triggered by a forked PR are
 # given a read-only token and no secrets, so the label/Discord steps cannot run
@@ -21,25 +22,6 @@ jobs:
       contains(fromJSON('["coderabbitai[bot]", "qodo-free-for-open-source-projects[bot]", "zkochan"]'), github.event.review.user.login)
     runs-on: ubuntu-latest
     permissions: {}
-    env:
-      # PR fields are written to inert files, never interpolated into a script,
-      # so an attacker-controlled PR title cannot inject shell commands.
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      PR_TITLE: ${{ github.event.pull_request.title }}
-      PR_URL: ${{ github.event.pull_request.html_url }}
-      REVIEWER: ${{ github.event.review.user.login }}
     steps:
-      - name: Record the review event
-        run: |
-          mkdir -p pr-review-event
-          printf '%s' "$PR_NUMBER" > pr-review-event/pr_number
-          printf '%s' "$REVIEWER" > pr-review-event/reviewer
-          printf '%s' "$PR_TITLE" > pr-review-event/title
-          printf '%s' "$PR_URL" > pr-review-event/url
-
-      - name: Upload the event artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: pr-review-event
-          path: pr-review-event/
-          retention-days: 1
+      - name: Record the review trigger
+        run: echo "Review trigger accepted"


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

- Uses the `workflow_run: requested` event for PR review automation so reviewed labels do not depend on the unprivileged capture job reaching a runner.
- Verifies the triggering reviewer, PR number, head SHA, and matching `APPROVED` review through GitHub's PR reviews API before adding labels or announcing.
- Related to https://github.com/pnpm/pnpm/pull/12638, where CodeRabbit approved but the capture run stayed queued.

## Squash Commit Body

```text
The review-label workflow previously waited for the unprivileged capture workflow to complete and upload an artifact. A CodeRabbit approval can leave that capture run queued, which prevents the privileged workflow_run follow-up from ever running and drops the reviewed label.

Act on the workflow_run requested event instead. The privileged job now reads trusted workflow_run metadata, verifies the matching APPROVED review against GitHub's PR reviews API for the same PR/head SHA/reviewer, then applies the existing label and Discord behavior without checking out PR code.
```

## Checklist

- [x] Workflow-only change; no TypeScript/pacquet parity work needed.
- [x] No changeset needed because this does not change a published package.
- [x] Validated with `actionlint`, `zizmor`, and the repository pre-push hook.

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved review automation now triggers directly from GitHub review request events for quicker, more consistent handling.
  * Discord announcements now pull the latest pull request title and URL at send time.

* **Bug Fixes**
  * Labels and announcements are applied only after confirming the latest matching `APPROVED` review for the pull request head.

* **Chores**
  * Updated workflow permissions to an intentionally unprivileged setup, with verification handled by a separate privileged workflow.
  * Removed the prior artifact-based review event capture flow in favor of direct event data resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->