### PR TITLE
fix(network): retry metadata fetches that fail while reading the body

### DIFF
--- a/pacquet/crates/network/src/auth.rs
+++ b/pacquet/crates/network/src/auth.rs
@@ -457,5 +457,45 @@ pub fn base64_encode(input: &str) -> String {
     out
 }
 
+/// Strip `user:pass@` (or `user@`) that appears right after a URL scheme in
+/// any message text, e.g. `… https://user:pass@host/pkg …` →
+/// `… https://host/pkg …`. A registry configured as `https://user:pass@host/`
+/// would otherwise leak its embedded basic-auth into a fetch error or a retry
+/// log line. Ports pnpm's
+/// [`redactUrlCredentials`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/core/error/src/index.ts#L78-L101).
+#[must_use]
+pub fn redact_url_credentials(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(pos) = rest.find("://") {
+        let (before, after) = rest.split_at(pos + "://".len());
+        out.push_str(before);
+        // Only treat "://" as a URL authority boundary when a scheme character
+        // (schemes end in an ASCII alphanumeric) precedes it, so an unrelated
+        // "://" in the message isn't mangled.
+        let has_scheme = pos > 0 && rest.as_bytes()[pos - 1].is_ascii_alphanumeric();
+        rest = strip_leading_userinfo(after).filter(|_| has_scheme).unwrap_or(after);
+    }
+    out.push_str(rest);
+    out
+}
+
+/// If the authority leading `text` contains `userinfo@`, return the slice after
+/// the **last** `@` within it; otherwise `None`. The authority ends at the first
+/// `/`, `?`, `#`, or whitespace. Stripping to the last `@` keeps a raw `@` inside
+/// the password (`user:p@ss@host`) from leaking its tail.
+fn strip_leading_userinfo(authority: &str) -> Option<&str> {
+    let mut last_at = None;
+    for (idx, ch) in authority.char_indices() {
+        match ch {
+            '@' => last_at = Some(idx + ch.len_utf8()),
+            '/' | '?' | '#' => break,
+            c if c.is_whitespace() => break,
+            _ => {}
+        }
+    }
+    last_at.map(|end| &authority[end..])
+}
+
 #[cfg(test)]
 mod tests;

--- a/pacquet/crates/network/src/auth/tests.rs
+++ b/pacquet/crates/network/src/auth/tests.rs
@@ -1,5 +1,41 @@
-use super::{AuthHeaders, DEFAULT_REGISTRY_SCOPE, base64_encode, nerf_dart};
+use super::{
+    AuthHeaders, DEFAULT_REGISTRY_SCOPE, base64_encode, nerf_dart, redact_url_credentials,
+};
 use pretty_assertions::assert_eq;
+
+#[test]
+fn redact_url_credentials_strips_embedded_basic_auth() {
+    assert_eq!(
+        redact_url_credentials(
+            "Failed to fetch metadata from https://user:pass@host/pkg: timed out"
+        ),
+        "Failed to fetch metadata from https://host/pkg: timed out",
+    );
+    // user-only userinfo (no password) is stripped too.
+    assert_eq!(
+        redact_url_credentials("got https://token@registry.example/foo"),
+        "got https://registry.example/foo",
+    );
+    // A raw "@" inside the password is stripped up to the last "@" in the
+    // authority, so the password tail can't leak.
+    assert_eq!(
+        redact_url_credentials("Failed to fetch metadata from https://user:p@ss@host/pkg: 403"),
+        "Failed to fetch metadata from https://host/pkg: 403",
+    );
+    // An "@" in the path/query (after the authority) is preserved.
+    assert_eq!(
+        redact_url_credentials("got https://host/path?to=a@b"),
+        "got https://host/path?to=a@b",
+    );
+    // A credential-free URL is left untouched.
+    assert_eq!(
+        redact_url_credentials("Failed to fetch metadata from https://host/pkg: timed out"),
+        "Failed to fetch metadata from https://host/pkg: timed out",
+    );
+    // A bare "://" with no preceding scheme character is not treated as a URL
+    // authority, so an "@" further along is preserved.
+    assert_eq!(redact_url_credentials("a :// b@c"), "a :// b@c");
+}
 
 fn build(entries: &[(&str, &str)]) -> AuthHeaders {
     AuthHeaders::from_creds_map(

--- a/pacquet/crates/network/src/lib.rs
+++ b/pacquet/crates/network/src/lib.rs
@@ -6,7 +6,10 @@ mod retry;
 mod tests;
 mod tls;
 
-pub use auth::{AuthHeaders, AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE, base64_encode, nerf_dart};
+pub use auth::{
+    AuthHeaders, AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE, base64_encode, nerf_dart,
+    redact_url_credentials,
+};
 pub use proxy::{NoProxySetting, ProxyConfig, ProxyError};
 pub use retry::{RetryOpts, retry_async, send_with_retry, should_retry_status};
 pub use tls::{PerRegistryTls, RegistryTls, TlsConfig, TlsError};

--- a/pacquet/crates/network/src/lib.rs
+++ b/pacquet/crates/network/src/lib.rs
@@ -8,7 +8,7 @@ mod tls;
 
 pub use auth::{AuthHeaders, AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE, base64_encode, nerf_dart};
 pub use proxy::{NoProxySetting, ProxyConfig, ProxyError};
-pub use retry::{RetryOpts, send_with_retry, should_retry_status};
+pub use retry::{RetryOpts, retry_async, send_with_retry, should_retry_status};
 pub use tls::{PerRegistryTls, RegistryTls, TlsConfig, TlsError};
 
 use priority_semaphore::{Permit, PrioritySemaphore};

--- a/pacquet/crates/network/src/retry.rs
+++ b/pacquet/crates/network/src/retry.rs
@@ -25,7 +25,7 @@ use std::{future::Future, time::Duration};
 
 use reqwest::{Client, RequestBuilder, Response, StatusCode};
 
-use crate::{ThrottledClient, ThrottledClientGuard};
+use crate::{ThrottledClient, ThrottledClientGuard, redact_url_credentials};
 
 /// Settings for the per-request retry loop. Mirrors pnpm's
 /// `fetch-retries` / `fetch-retry-factor` / `fetch-retry-mintimeout` /
@@ -143,7 +143,7 @@ pub async fn send_with_retry<'client>(
                 let delay = retry_opts.delay_for(attempt);
                 tracing::warn!(
                     target: "pacquet_network::retry",
-                    url,
+                    url = %redact_url_credentials(url),
                     ?status,
                     attempt = attempt + 1,
                     max_attempts = retry_opts.retries + 1,
@@ -159,7 +159,7 @@ pub async fn send_with_retry<'client>(
                 let delay = retry_opts.delay_for(attempt);
                 tracing::warn!(
                     target: "pacquet_network::retry",
-                    url,
+                    url = %redact_url_credentials(url),
                     ?error,
                     attempt = attempt + 1,
                     max_attempts = retry_opts.retries + 1,
@@ -211,7 +211,7 @@ where
                 let delay = retry_opts.delay_for(attempt);
                 tracing::warn!(
                     target: "pacquet_network::retry",
-                    url,
+                    url = %redact_url_credentials(url),
                     ?error,
                     attempt = attempt + 1,
                     max_attempts = retry_opts.retries + 1,

--- a/pacquet/crates/network/src/retry.rs
+++ b/pacquet/crates/network/src/retry.rs
@@ -27,8 +27,7 @@
 //!
 //! [`RetryTimeoutOptions`]: https://github.com/pnpm/pnpm/blob/1819226b51/network/fetch/src/fetch.ts
 
-use std::future::Future;
-use std::time::Duration;
+use std::{future::Future, time::Duration};
 
 use reqwest::{Client, RequestBuilder, Response, StatusCode};
 
@@ -200,15 +199,15 @@ pub async fn send_with_retry<'client>(
 /// [`send_with_retry`] inside the closure already owns that budget,
 /// exactly as pnpm rejects a fetch failure immediately while letting
 /// the network library retry it internally.
-pub async fn retry_async<T, E, Fut>(
+pub async fn retry_async<Value, Err, Fut>(
     url: &str,
     retry_opts: RetryOpts,
-    is_retryable: impl Fn(&E) -> bool,
+    is_retryable: impl Fn(&Err) -> bool,
     mut attempt_fn: impl FnMut() -> Fut,
-) -> Result<T, E>
+) -> Result<Value, Err>
 where
-    Fut: Future<Output = Result<T, E>>,
-    E: std::fmt::Debug,
+    Fut: Future<Output = Result<Value, Err>>,
+    Err: std::fmt::Debug,
 {
     let mut attempt = 0;
     loop {

--- a/pacquet/crates/network/src/retry.rs
+++ b/pacquet/crates/network/src/retry.rs
@@ -160,7 +160,7 @@ pub async fn send_with_retry<'client>(
                 tracing::warn!(
                     target: "pacquet_network::retry",
                     url = %redact_url_credentials(url),
-                    ?error,
+                    error = %redact_url_credentials(&format!("{error:?}")),
                     attempt = attempt + 1,
                     max_attempts = retry_opts.retries + 1,
                     ?delay,
@@ -212,7 +212,7 @@ where
                 tracing::warn!(
                     target: "pacquet_network::retry",
                     url = %redact_url_credentials(url),
-                    ?error,
+                    error = %redact_url_credentials(&format!("{error:?}")),
                     attempt = attempt + 1,
                     max_attempts = retry_opts.retries + 1,
                     ?delay,

--- a/pacquet/crates/network/src/retry.rs
+++ b/pacquet/crates/network/src/retry.rs
@@ -14,8 +14,20 @@
 //! retry boundary wraps the whole fetch + integrity + decode + extract
 //! pipeline, not just a single request — but reuses [`RetryOpts`].
 //!
+//! Reading a response body can fail *after* [`send_with_retry`] has
+//! handed back a `200`: a connection reset or truncated transfer
+//! mid-stream surfaces as reqwest's "error decoding response body".
+//! [`send_with_retry`] cannot retry that — the body is consumed by the
+//! caller, outside its loop. [`retry_async`] is the companion that
+//! re-issues the *whole* request when consuming or parsing the body
+//! fails, mirroring pnpm's metadata fetch, which nests a second
+//! `@zkochan/retry` operation around `response.text()` + `JSON.parse`
+//! on top of the network library's request retry
+//! ([`resolving/npm-resolver/src/fetch.ts`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/fetch.ts#L172-L210)).
+//!
 //! [`RetryTimeoutOptions`]: https://github.com/pnpm/pnpm/blob/1819226b51/network/fetch/src/fetch.ts
 
+use std::future::Future;
 use std::time::Duration;
 
 use reqwest::{Client, RequestBuilder, Response, StatusCode};
@@ -160,6 +172,58 @@ pub async fn send_with_retry<'client>(
                     max_attempts = retry_opts.retries + 1,
                     ?delay,
                     "Request errored; retrying after backoff",
+                );
+                tokio::time::sleep(delay).await;
+                attempt += 1;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+/// Run `attempt` — a full "issue the request, then read and parse its
+/// body" round trip — retrying under `retry_opts`'s exponential
+/// backoff whenever it fails with an error `is_retryable` accepts and
+/// retries remain.
+///
+/// This is the body-read/parse companion to [`send_with_retry`].
+/// pnpm's metadata fetch nests two retry layers: the shared network
+/// library retries the request ([`send_with_retry`] here), and the
+/// resolver re-runs the *whole* fetch when reading or parsing the
+/// response body fails — "error decoding response body" from a
+/// mid-stream reset, or broken JSON — via a second `@zkochan/retry`
+/// operation in
+/// [`resolving/npm-resolver/src/fetch.ts`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/fetch.ts#L172-L210).
+/// The `attempt` closure issues the request *and* consumes its body,
+/// so `is_retryable` should accept only body-read/parse failures:
+/// transport and status failures stay non-retryable here because
+/// [`send_with_retry`] inside the closure already owns that budget,
+/// exactly as pnpm rejects a fetch failure immediately while letting
+/// the network library retry it internally.
+pub async fn retry_async<T, E, Fut>(
+    url: &str,
+    retry_opts: RetryOpts,
+    is_retryable: impl Fn(&E) -> bool,
+    mut attempt_fn: impl FnMut() -> Fut,
+) -> Result<T, E>
+where
+    Fut: Future<Output = Result<T, E>>,
+    E: std::fmt::Debug,
+{
+    let mut attempt = 0;
+    loop {
+        match attempt_fn().await {
+            Ok(value) => return Ok(value),
+            Err(error) if is_retryable(&error) && attempt < retry_opts.retries => {
+                let delay = retry_opts.delay_for(attempt);
+                tracing::warn!(
+                    target: "pacquet_network::retry",
+                    url,
+                    ?error,
+                    attempt = attempt + 1,
+                    max_attempts = retry_opts.retries + 1,
+                    ?delay,
+                    "Reading response body failed; retrying after backoff",
                 );
                 tokio::time::sleep(delay).await;
                 attempt += 1;

--- a/pacquet/crates/network/src/retry.rs
+++ b/pacquet/crates/network/src/retry.rs
@@ -15,15 +15,9 @@
 //! pipeline, not just a single request — but reuses [`RetryOpts`].
 //!
 //! Reading a response body can fail *after* [`send_with_retry`] has
-//! handed back a `200`: a connection reset or truncated transfer
-//! mid-stream surfaces as reqwest's "error decoding response body".
-//! [`send_with_retry`] cannot retry that — the body is consumed by the
-//! caller, outside its loop. [`retry_async`] is the companion that
-//! re-issues the *whole* request when consuming or parsing the body
-//! fails, mirroring pnpm's metadata fetch, which nests a second
-//! `@zkochan/retry` operation around `response.text()` + `JSON.parse`
-//! on top of the network library's request retry
-//! ([`resolving/npm-resolver/src/fetch.ts`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/fetch.ts#L172-L210)).
+//! handed back a `200`, outside its loop; [`retry_async`] is the
+//! companion that re-issues the whole request when consuming or parsing
+//! the body fails. See its docs for why that second layer exists.
 //!
 //! [`RetryTimeoutOptions`]: https://github.com/pnpm/pnpm/blob/1819226b51/network/fetch/src/fetch.ts
 

--- a/pacquet/crates/network/src/retry/tests.rs
+++ b/pacquet/crates/network/src/retry/tests.rs
@@ -1,4 +1,7 @@
-use std::{cell::Cell, time::Duration};
+use std::{
+    sync::atomic::{AtomicU32, Ordering},
+    time::Duration,
+};
 
 use reqwest::StatusCode;
 
@@ -68,52 +71,52 @@ fn retryable_statuses_match_pnpm() {
 
 #[tokio::test]
 async fn retry_async_retries_a_retryable_error_until_success() {
-    let calls = Cell::new(0u32);
+    let calls = AtomicU32::new(0);
     let result: Result<&str, &str> = retry_async(
         "https://registry/pkg",
         instant_retry_opts(3),
         |_error| true,
         || {
-            let attempt = calls.get();
-            calls.set(attempt + 1);
+            let attempt = calls.fetch_add(1, Ordering::Relaxed);
             async move { if attempt < 2 { Err("error decoding response body") } else { Ok("ok") } }
         },
     )
     .await;
     assert_eq!(result, Ok("ok"));
-    assert_eq!(calls.get(), 3, "two failures then a success");
+    assert_eq!(calls.load(Ordering::Relaxed), 3, "two failures then a success");
 }
 
 #[tokio::test]
 async fn retry_async_does_not_retry_a_non_retryable_error() {
-    let calls = Cell::new(0u32);
+    let calls = AtomicU32::new(0);
     let result: Result<(), &str> = retry_async(
         "https://registry/pkg",
         instant_retry_opts(3),
         |_error| false,
         || {
-            calls.set(calls.get() + 1);
+            calls.fetch_add(1, Ordering::Relaxed);
             async { Err("fatal") }
         },
     )
     .await;
     assert_eq!(result, Err("fatal"));
-    assert_eq!(calls.get(), 1, "non-retryable errors return on the first attempt");
+    let total = calls.load(Ordering::Relaxed);
+    assert_eq!(total, 1, "non-retryable errors return on the first attempt");
 }
 
 #[tokio::test]
 async fn retry_async_gives_up_after_the_retry_budget() {
-    let calls = Cell::new(0u32);
+    let calls = AtomicU32::new(0);
     let result: Result<(), &str> = retry_async(
         "https://registry/pkg",
         instant_retry_opts(2),
         |_error| true,
         || {
-            calls.set(calls.get() + 1);
+            calls.fetch_add(1, Ordering::Relaxed);
             async { Err("error decoding response body") }
         },
     )
     .await;
     assert_eq!(result, Err("error decoding response body"));
-    assert_eq!(calls.get(), 3, "initial attempt plus `retries` retries");
+    assert_eq!(calls.load(Ordering::Relaxed), 3, "initial attempt plus `retries` retries");
 }

--- a/pacquet/crates/network/src/retry/tests.rs
+++ b/pacquet/crates/network/src/retry/tests.rs
@@ -1,5 +1,4 @@
-use std::cell::Cell;
-use std::time::Duration;
+use std::{cell::Cell, time::Duration};
 
 use reqwest::StatusCode;
 

--- a/pacquet/crates/network/src/retry/tests.rs
+++ b/pacquet/crates/network/src/retry/tests.rs
@@ -1,8 +1,20 @@
+use std::cell::Cell;
 use std::time::Duration;
 
 use reqwest::StatusCode;
 
-use super::{RetryOpts, should_retry_status};
+use super::{RetryOpts, retry_async, should_retry_status};
+
+/// `RetryOpts` whose backoff is effectively instant, so retry-loop
+/// tests don't sleep.
+fn instant_retry_opts(retries: u32) -> RetryOpts {
+    RetryOpts {
+        retries,
+        factor: 1,
+        min_timeout: Duration::from_millis(1),
+        max_timeout: Duration::from_millis(1),
+    }
+}
 
 #[test]
 fn default_matches_pnpm_fetch_retries() {
@@ -53,4 +65,56 @@ fn retryable_statuses_match_pnpm() {
     assert!(!should_retry_status(StatusCode::UNAUTHORIZED)); // 401
     assert!(!should_retry_status(StatusCode::FORBIDDEN)); // 403
     assert!(!should_retry_status(StatusCode::NOT_FOUND)); // 404
+}
+
+#[tokio::test]
+async fn retry_async_retries_a_retryable_error_until_success() {
+    let calls = Cell::new(0u32);
+    let result: Result<&str, &str> = retry_async(
+        "https://registry/pkg",
+        instant_retry_opts(3),
+        |_error| true,
+        || {
+            let attempt = calls.get();
+            calls.set(attempt + 1);
+            async move { if attempt < 2 { Err("error decoding response body") } else { Ok("ok") } }
+        },
+    )
+    .await;
+    assert_eq!(result, Ok("ok"));
+    assert_eq!(calls.get(), 3, "two failures then a success");
+}
+
+#[tokio::test]
+async fn retry_async_does_not_retry_a_non_retryable_error() {
+    let calls = Cell::new(0u32);
+    let result: Result<(), &str> = retry_async(
+        "https://registry/pkg",
+        instant_retry_opts(3),
+        |_error| false,
+        || {
+            calls.set(calls.get() + 1);
+            async { Err("fatal") }
+        },
+    )
+    .await;
+    assert_eq!(result, Err("fatal"));
+    assert_eq!(calls.get(), 1, "non-retryable errors return on the first attempt");
+}
+
+#[tokio::test]
+async fn retry_async_gives_up_after_the_retry_budget() {
+    let calls = Cell::new(0u32);
+    let result: Result<(), &str> = retry_async(
+        "https://registry/pkg",
+        instant_retry_opts(2),
+        |_error| true,
+        || {
+            calls.set(calls.get() + 1);
+            async { Err("error decoding response body") }
+        },
+    )
+    .await;
+    assert_eq!(result, Err("error decoding response body"));
+    assert_eq!(calls.get(), 3, "initial attempt plus `retries` retries");
 }

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -26,7 +26,7 @@ use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use pacquet_config::{TrustPolicy, version_policy::PackageVersionPolicy};
 use pacquet_lockfile::{LockfileResolution, PkgName};
-use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, redact_url_credentials};
 use pacquet_registry::{Approver, NpmUser, Package, PackageDistribution, PackageVersion};
 use pacquet_resolving_resolver_base::{
     ResolutionVerification, ResolutionVerifier, VerifyCtx, VerifyFuture, parse_packument_timestamp,
@@ -1088,44 +1088,6 @@ fn project_abbreviated_meta(meta: &Package) -> crate::lookup_context::Abbreviate
         version_tarballs: Some(version_tarballs),
         version_dist_stats: Some(version_dist_stats),
     }
-}
-
-/// Strip `user:pass@` (or `user@`) that appears right after a URL scheme in
-/// any message text, e.g. `… https://user:pass@host/pkg …` →
-/// `… https://host/pkg …`. A registry configured as `https://user:pass@host/`
-/// would otherwise leak its embedded basic-auth into the fetch error the
-/// verifier surfaces when it aborts on a transport failure.
-fn redact_url_credentials(text: &str) -> String {
-    let mut out = String::with_capacity(text.len());
-    let mut rest = text;
-    while let Some(pos) = rest.find("://") {
-        let (before, after) = rest.split_at(pos + "://".len());
-        out.push_str(before);
-        // Only treat "://" as a URL authority boundary when a scheme character
-        // (schemes end in an ASCII alphanumeric) precedes it, so an unrelated
-        // "://" in the message isn't mangled.
-        let has_scheme = pos > 0 && rest.as_bytes()[pos - 1].is_ascii_alphanumeric();
-        rest = strip_leading_userinfo(after).filter(|_| has_scheme).unwrap_or(after);
-    }
-    out.push_str(rest);
-    out
-}
-
-/// If the authority leading `text` contains `userinfo@`, return the slice after
-/// the **last** `@` within it; otherwise `None`. The authority ends at the first
-/// `/`, `?`, `#`, or whitespace. Stripping to the last `@` keeps a raw `@` inside
-/// the password (`user:p@ss@host`) from leaking its tail.
-fn strip_leading_userinfo(authority: &str) -> Option<&str> {
-    let mut last_at = None;
-    for (idx, ch) in authority.char_indices() {
-        match ch {
-            '@' => last_at = Some(idx + ch.len_utf8()),
-            '/' | '?' | '#' => break,
-            c if c.is_whitespace() => break,
-            _ => {}
-        }
-    }
-    last_at.map(|end| &authority[end..])
 }
 
 fn same_tarball_url(left: &str, right: &str) -> bool {

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -10,7 +10,6 @@ use ssri::Integrity;
 
 use super::{
     CreateNpmResolutionVerifierOptions, create_npm_resolution_verifier, observed_dist_stats_sink,
-    redact_url_credentials,
 };
 
 const FAKE_INTEGRITY: &str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
@@ -1155,38 +1154,4 @@ async fn version_absent_from_fetched_metadata_stays_tarball_url_mismatch() {
         panic!("expected Err, got {result:?}");
     };
     assert_eq!(code, "TARBALL_URL_MISMATCH");
-}
-
-#[test]
-fn redact_url_credentials_strips_embedded_basic_auth() {
-    assert_eq!(
-        redact_url_credentials(
-            "Failed to fetch metadata from https://user:pass@host/pkg: timed out"
-        ),
-        "Failed to fetch metadata from https://host/pkg: timed out",
-    );
-    // user-only userinfo (no password) is stripped too.
-    assert_eq!(
-        redact_url_credentials("got https://token@registry.example/foo"),
-        "got https://registry.example/foo",
-    );
-    // A raw "@" inside the password is stripped up to the last "@" in the
-    // authority, so the password tail can't leak.
-    assert_eq!(
-        redact_url_credentials("Failed to fetch metadata from https://user:p@ss@host/pkg: 403"),
-        "Failed to fetch metadata from https://host/pkg: 403",
-    );
-    // An "@" in the path/query (after the authority) is preserved.
-    assert_eq!(
-        redact_url_credentials("got https://host/path?to=a@b"),
-        "got https://host/path?to=a@b",
-    );
-    // A credential-free URL is left untouched.
-    assert_eq!(
-        redact_url_credentials("Failed to fetch metadata from https://host/pkg: timed out"),
-        "Failed to fetch metadata from https://host/pkg: timed out",
-    );
-    // A bare "://" with no preceding scheme character is not treated as a URL
-    // authority, so an "@" further along is preserved.
-    assert_eq!(redact_url_credentials("a :// b@c"), "a :// b@c");
 }

--- a/pacquet/crates/resolving-npm-resolver/src/errors.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/errors.rs
@@ -45,6 +45,21 @@ pub enum FetchMetadataError {
         error: serde_json::Error,
     },
 
+    /// Filtering a parsed packument down to the fields pnpm keeps
+    /// (`clear_meta`, the `filterMetadata` path) failed. Unlike a body
+    /// read or the top-level parse, this runs on an already-parsed,
+    /// complete `Package`, so it is deterministic — a fresh re-fetch
+    /// would feed `clear_meta` the same structure and fail identically.
+    /// Kept out of [`FetchMetadataError::is_body_retryable`] for that
+    /// reason.
+    #[display("Failed to filter metadata from {url}: {error}")]
+    #[diagnostic(code(pacquet_resolving_npm_resolver::filter_metadata_error))]
+    FilterMetadata {
+        url: String,
+        #[error(source)]
+        error: serde_json::Error,
+    },
+
     /// Mirrors upstream's `META_NOT_MODIFIED_WITHOUT_CACHE`. Surfaces
     /// only when a stale-but-removed mirror plus an `If-None-Match`
     /// header the caller-provided cache headers carried (impossible

--- a/pacquet/crates/resolving-npm-resolver/src/errors.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/errors.rs
@@ -149,3 +149,6 @@ pub struct GuardRepickLimitError {
     pub limit: usize,
     pub reason: String,
 }
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/resolving-npm-resolver/src/errors.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/errors.rs
@@ -21,6 +21,22 @@ pub enum FetchMetadataError {
         error: reqwest::Error,
     },
 
+    /// Reading the response body failed *after* the registry returned
+    /// a `2xx` — a connection reset or truncated transfer mid-stream,
+    /// reqwest's "error decoding response body". Kept distinct from
+    /// [`FetchMetadataError::Network`] (the request itself, already
+    /// retried by [`pacquet_network::send_with_retry`]) so the body
+    /// re-fetch loop in the fetchers retries only this and
+    /// [`FetchMetadataError::Decode`] — see
+    /// [`FetchMetadataError::is_body_retryable`].
+    #[display("Failed to read metadata response body from {url}: {error}")]
+    #[diagnostic(code(pacquet_resolving_npm_resolver::body_read_error))]
+    BodyRead {
+        url: String,
+        #[error(source)]
+        error: reqwest::Error,
+    },
+
     #[display("Failed to decode metadata from {url}: {error}")]
     #[diagnostic(code(pacquet_resolving_npm_resolver::decode_error))]
     Decode {
@@ -62,6 +78,29 @@ pub enum FetchMetadataError {
         #[error(source)]
         error: tokio::task::JoinError,
     },
+}
+
+impl FetchMetadataError {
+    /// Whether a fresh re-fetch of the whole request could plausibly
+    /// succeed where this attempt failed. Only the body-consumption
+    /// failures qualify — a mid-stream transport drop
+    /// ([`FetchMetadataError::BodyRead`]) or a body that parsed as
+    /// broken JSON ([`FetchMetadataError::Decode`]). This is the
+    /// predicate the fetchers hand to
+    /// [`pacquet_network::retry_async`], mirroring pnpm's metadata
+    /// fetch, which retries exactly `response.text()` and `JSON.parse`
+    /// failures while letting the network library own request retry
+    /// ([`resolving/npm-resolver/src/fetch.ts`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/fetch.ts#L172-L210)).
+    ///
+    /// [`FetchMetadataError::Network`] stays non-retryable here: the
+    /// request (transport error or a `4xx`/`5xx` status) was already
+    /// retried inside [`pacquet_network::send_with_retry`], exactly as
+    /// pnpm rejects a fetch failure immediately rather than re-running
+    /// its outer operation.
+    #[must_use]
+    pub fn is_body_retryable(&self) -> bool {
+        matches!(self, FetchMetadataError::BodyRead { .. } | FetchMetadataError::Decode { .. })
+    }
 }
 
 /// Raised when an external `PackageVersionGuard` rejects every

--- a/pacquet/crates/resolving-npm-resolver/src/errors.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/errors.rs
@@ -10,6 +10,13 @@ use miette::Diagnostic;
 /// [`crate::MINIMUM_RELEASE_AGE_VIOLATION_CODE`] or
 /// [`crate::TRUST_DOWNGRADE_VIOLATION_CODE`] depending on which
 /// policy triggered the lookup.
+///
+/// Every URL-bearing variant stores a credential-redacted `url` (the
+/// fetchers pass it through [`pacquet_network::redact_url_credentials`]
+/// at construction), so a registry configured with inline
+/// `user:pass@host` basic-auth can't leak into the `Display` /
+/// `Diagnostic` message — which reaches the terminal, CI logs, and
+/// reporters whenever the resolver surfaces the error.
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum FetchMetadataError {

--- a/pacquet/crates/resolving-npm-resolver/src/errors/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/errors/tests.rs
@@ -1,0 +1,20 @@
+use super::FetchMetadataError;
+use pacquet_network::redact_url_credentials;
+
+/// The retry path logs the failing error through
+/// `redact_url_credentials(&format!("{error:?}"))`. `FetchMetadataError`'s
+/// derived `Debug` embeds its raw `url` field, so this guards that an
+/// inline-credential registry URL (`https://user:pass@host/`) can't survive
+/// into a retry log line through the error value.
+#[test]
+fn debug_render_redacts_embedded_url_credentials() {
+    let json_error = serde_json::from_str::<u8>(r#""not a number""#).unwrap_err();
+    let error = FetchMetadataError::Decode {
+        url: "https://user:secret@registry.example/pkg".to_string(),
+        error: json_error,
+    };
+    let logged = redact_url_credentials(&format!("{error:?}"));
+    assert!(!logged.contains("secret"), "password must not survive: {logged}");
+    assert!(!logged.contains("user:"), "userinfo must not survive: {logged}");
+    assert!(logged.contains("registry.example/pkg"), "host/path retained: {logged}");
+}

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
@@ -20,7 +20,9 @@
 //! Ports the request half of upstream's
 //! [`fetchMetadataFromFromRegistry`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/fetch.ts#L118-L204).
 
-use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, retry_async, send_with_retry};
+use pacquet_network::{
+    AuthHeaders, RetryOpts, ThrottledClient, redact_url_credentials, retry_async, send_with_retry,
+};
 use pacquet_registry::Package;
 use reqwest::{StatusCode, header};
 
@@ -107,17 +109,20 @@ pub async fn fetch_full_metadata(
                 request
             })
             .await
-            .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
+            .map_err(|error| FetchMetadataError::Network {
+                url: redact_url_credentials(&url),
+                error,
+            })?;
         if response.status() == StatusCode::NOT_MODIFIED {
             return Ok(FetchFullMetadataOutcome::NotModified);
         }
-        let response = response
-            .error_for_status()
-            .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
-        let raw_body = response
-            .text()
-            .await
-            .map_err(|error| FetchMetadataError::BodyRead { url: url.clone(), error })?;
+        let response = response.error_for_status().map_err(|error| {
+            FetchMetadataError::Network { url: redact_url_credentials(&url), error }
+        })?;
+        let raw_body = response.text().await.map_err(|error| FetchMetadataError::BodyRead {
+            url: redact_url_credentials(&url),
+            error,
+        })?;
         // Body fully buffered — release the connection and its
         // network-concurrency permit, then parse off the reactor: a
         // multi-MB packument parse would otherwise pin a tokio worker
@@ -126,11 +131,16 @@ pub async fn fetch_full_metadata(
         drop(client);
         let task_url = url.clone();
         let meta = tokio::task::spawn_blocking(move || {
-            serde_json::from_str::<Package>(&raw_body)
-                .map_err(|error| FetchMetadataError::Decode { url: task_url.clone(), error })
+            serde_json::from_str::<Package>(&raw_body).map_err(|error| FetchMetadataError::Decode {
+                url: redact_url_credentials(&task_url),
+                error,
+            })
         })
         .await
-        .map_err(|error| FetchMetadataError::ParseTask { url: url.clone(), error })??;
+        .map_err(|error| FetchMetadataError::ParseTask {
+            url: redact_url_credentials(&url),
+            error,
+        })??;
         Ok(FetchFullMetadataOutcome::Modified(Box::new(meta)))
     })
     .await

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
@@ -20,7 +20,7 @@
 //! Ports the request half of upstream's
 //! [`fetchMetadataFromFromRegistry`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/fetch.ts#L118-L204).
 
-use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, send_with_retry};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, retry_async, send_with_retry};
 use pacquet_registry::Package;
 use reqwest::{StatusCode, header};
 
@@ -91,45 +91,53 @@ pub async fn fetch_full_metadata(
 ) -> Result<FetchFullMetadataOutcome, FetchMetadataError> {
     let url = to_registry_url(opts.registry, pkg_name);
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
-    let (client, response) = send_with_retry(opts.http_client, &url, opts.retry_opts, |client| {
-        let mut request = client.get(&url).header(header::ACCEPT, accept);
-        if let Some(value) = opts.auth_headers.for_url_with_package(&url, Some(pkg_name)) {
-            request = request.header(header::AUTHORIZATION, value);
+    // The request itself is retried inside `send_with_retry`; this
+    // outer loop re-issues the whole fetch when reading or parsing the
+    // body fails ("error decoding response body", broken JSON), the
+    // way pnpm nests a second retry around `response.text()`.
+    retry_async(&url, opts.retry_opts, FetchMetadataError::is_body_retryable, || async {
+        let (client, response) =
+            send_with_retry(opts.http_client, &url, opts.retry_opts, |client| {
+                let mut request = client.get(&url).header(header::ACCEPT, accept);
+                if let Some(value) = opts.auth_headers.for_url_with_package(&url, Some(pkg_name)) {
+                    request = request.header(header::AUTHORIZATION, value);
+                }
+                if let Some(etag) = opts.etag {
+                    request = request.header(header::IF_NONE_MATCH, etag);
+                }
+                if let Some(modified) = opts.modified {
+                    request = request.header(header::IF_MODIFIED_SINCE, modified);
+                }
+                request
+            })
+            .await
+            .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
+        if response.status() == StatusCode::NOT_MODIFIED {
+            return Ok(FetchFullMetadataOutcome::NotModified);
         }
-        if let Some(etag) = opts.etag {
-            request = request.header(header::IF_NONE_MATCH, etag);
-        }
-        if let Some(modified) = opts.modified {
-            request = request.header(header::IF_MODIFIED_SINCE, modified);
-        }
-        request
-    })
-    .await
-    .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
-    if response.status() == StatusCode::NOT_MODIFIED {
-        return Ok(FetchFullMetadataOutcome::NotModified);
-    }
-    let response = response
-        .error_for_status()
-        .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
-    let raw_body = response
-        .text()
+        let response = response
+            .error_for_status()
+            .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
+        let raw_body = response
+            .text()
+            .await
+            .map_err(|error| FetchMetadataError::BodyRead { url: url.clone(), error })?;
+        // Body fully buffered — release the connection and its
+        // network-concurrency permit, then parse off the reactor: a
+        // multi-MB packument parse would otherwise pin a tokio worker
+        // and stall every socket it pumps (see
+        // `fetch_full_metadata_cached` for the cold-install numbers).
+        drop(client);
+        let task_url = url.clone();
+        let meta = tokio::task::spawn_blocking(move || {
+            serde_json::from_str::<Package>(&raw_body)
+                .map_err(|error| FetchMetadataError::Decode { url: task_url.clone(), error })
+        })
         .await
-        .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
-    // Body fully buffered — release the connection and its
-    // network-concurrency permit, then parse off the reactor: a
-    // multi-MB packument parse would otherwise pin a tokio worker
-    // and stall every socket it pumps (see
-    // `fetch_full_metadata_cached` for the cold-install numbers).
-    drop(client);
-    let task_url = url.clone();
-    let meta = tokio::task::spawn_blocking(move || {
-        serde_json::from_str::<Package>(&raw_body)
-            .map_err(|error| FetchMetadataError::Decode { url: task_url, error })
+        .map_err(|error| FetchMetadataError::ParseTask { url: url.clone(), error })??;
+        Ok(FetchFullMetadataOutcome::Modified(Box::new(meta)))
     })
     .await
-    .map_err(|error| FetchMetadataError::ParseTask { url, error })??;
-    Ok(FetchFullMetadataOutcome::Modified(Box::new(meta)))
 }
 
 #[cfg(test)]

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
@@ -91,10 +91,6 @@ pub async fn fetch_full_metadata(
 ) -> Result<FetchFullMetadataOutcome, FetchMetadataError> {
     let url = to_registry_url(opts.registry, pkg_name);
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
-    // The request itself is retried inside `send_with_retry`; this
-    // outer loop re-issues the whole fetch when reading or parsing the
-    // body fails ("error decoding response body", broken JSON), the
-    // way pnpm nests a second retry around `response.text()`.
     retry_async(&url, opts.retry_opts, FetchMetadataError::is_body_retryable, || async {
         let (client, response) =
             send_with_retry(opts.http_client, &url, opts.retry_opts, |client| {

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
@@ -221,6 +221,96 @@ async fn fetch_full_metadata_retries_transient_status() {
     second.assert_async().await;
 }
 
+/// A `Content-Encoding: gzip` header over a body that isn't gzip makes
+/// reqwest fail while *decoding the response body* — the same class of
+/// failure as a connection reset mid-transfer, surfacing as reqwest's
+/// "error decoding response body". This is the error the CI benchmark
+/// hit against the live registry and that `send_with_retry` can't see,
+/// because it happens after the request returns `200`.
+async fn corrupt_gzip_body_mock(server: &mut mockito::ServerGuard) -> mockito::Mock {
+    server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_header("content-encoding", "gzip")
+        .with_body("this is not valid gzip")
+        .expect(1)
+        .create_async()
+        .await
+}
+
+#[tokio::test]
+async fn fetch_full_metadata_surfaces_body_read_failure_distinctly() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = corrupt_gzip_body_mock(&mut server).await;
+
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let opts = FetchFullMetadataOptions {
+        registry: &registry,
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        full_metadata: true,
+        etag: None,
+        modified: None,
+        retry_opts: no_retry_opts(),
+    };
+
+    let err = fetch_full_metadata("acme", &opts).await.expect_err("undecodable body must surface");
+    assert!(
+        matches!(err, super::FetchMetadataError::BodyRead { .. }),
+        "expected BodyRead variant, got: {err:?}",
+    );
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn fetch_full_metadata_retries_body_read_failure() {
+    let mut server = mockito::Server::new_async().await;
+    let first = corrupt_gzip_body_mock(&mut server).await;
+    let body = r#"{
+        "name": "acme",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "acme",
+                "version": "1.0.0",
+                "dist": {
+                    "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                    "shasum": "0000000000000000000000000000000000000000",
+                    "tarball": "https://registry/acme-1.0.0.tgz"
+                }
+            }
+        }
+    }"#;
+    let second = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(body)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let opts = FetchFullMetadataOptions {
+        registry: &registry,
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        full_metadata: true,
+        etag: None,
+        modified: None,
+        retry_opts: fast_retry_opts(),
+    };
+
+    let pkg = expect_modified(fetch_full_metadata("acme", &opts).await.expect("body read retries"));
+    assert_eq!(pkg.name, "acme");
+    first.assert_async().await;
+    second.assert_async().await;
+}
+
 #[tokio::test]
 async fn fetch_full_metadata_encodes_scoped_name() {
     let mut server = mockito::Server::new_async().await;

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
@@ -175,6 +175,35 @@ async fn fetch_full_metadata_surfaces_5xx_as_network_error() {
 }
 
 #[tokio::test]
+async fn fetch_full_metadata_redacts_credentials_in_surfaced_error() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server.mock("GET", "/acme").with_status(503).expect(1).create_async().await;
+
+    // Registry configured with inline basic-auth in the URL: the surfaced
+    // error (Display *and* Debug, which reach the terminal and CI logs) must
+    // not carry the password.
+    let registry = format!("{}/", server.url().replacen("http://", "http://user:secret@", 1));
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let opts = FetchFullMetadataOptions {
+        registry: &registry,
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        full_metadata: true,
+        etag: None,
+        modified: None,
+        retry_opts: no_retry_opts(),
+    };
+
+    let err = fetch_full_metadata("acme", &opts).await.expect_err("503 must surface");
+    for rendered in [err.to_string(), format!("{err:?}")] {
+        assert!(!rendered.contains("secret"), "password must not leak: {rendered}");
+        assert!(!rendered.contains("user:"), "userinfo must not leak: {rendered}");
+    }
+    mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn fetch_full_metadata_retries_transient_status() {
     let mut server = mockito::Server::new_async().await;
     let first = server.mock("GET", "/acme").with_status(503).expect(1).create_async().await;

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -18,7 +18,7 @@
 
 use std::path::Path;
 
-use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, send_with_retry};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, retry_async, send_with_retry};
 use pacquet_registry::Package;
 use pipe_trait::Pipe;
 use reqwest::{StatusCode, header};
@@ -101,107 +101,119 @@ pub async fn fetch_full_metadata_cached(
 
     let url = to_registry_url(opts.registry, pkg_name);
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
-    let (client, response) = send_with_retry(opts.http_client, &url, opts.retry_opts, |client| {
-        let mut request = client.get(&url).header(header::ACCEPT, accept);
-        if let Some(value) = opts.auth_headers.for_url_with_package(&url, Some(pkg_name)) {
-            request = request.header(header::AUTHORIZATION, value);
-        }
-        if let Some(headers) = cache_headers.as_ref() {
-            if let Some(etag) = headers.etag.as_deref() {
-                request = request.header(header::IF_NONE_MATCH, etag);
-            }
-            if let Some(modified) = headers.modified.as_deref() {
-                request = request.header(header::IF_MODIFIED_SINCE, modified);
-            }
-        }
-        request
-    })
-    .await
-    .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
-
-    if response.status() == StatusCode::NOT_MODIFIED {
-        // No body to stream — release the connection and its
-        // network-concurrency permit before the mirror disk read.
-        drop(client);
-        let Some(path) = mirror_path else {
-            // 304 without an existing cache to fall back on — the
-            // registry over-reached on `If-None-Match: <stale>`.
-            // Mirrors upstream's `META_NOT_MODIFIED_WITHOUT_CACHE`.
-            return Err(FetchMetadataError::NotModifiedWithoutCache {
-                pkg_name: pkg_name.to_string(),
-            });
-        };
-        let meta = load_meta_async(Some(&path)).await.ok_or_else(|| {
-            FetchMetadataError::CacheMissingAfter304 { pkg_name: pkg_name.to_string() }
-        })?;
-        renew_mirror_freshness(&path);
-        return Ok(meta);
-    }
-
-    let response = response
-        .error_for_status()
-        .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
-
-    let etag = response
-        .headers()
-        .get(header::ETAG)
-        .and_then(|value| value.to_str().ok())
-        .map(str::to_string);
-    let raw_body = response
-        .text()
-        .await
-        .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
-
-    // Body fully buffered — release the connection and its
-    // network-concurrency permit before the CPU-bound parse so the
-    // semaphore keeps bounding *sockets*, not parses. Same
-    // buffer-then-release shape as the tarball pipeline in
-    // `pacquet-tarball`.
-    drop(client);
-
-    // Deserialize and persist the mirror off the reactor. Packuments
-    // run to several megabytes for high-release-cadence packages
-    // (`@fluentui/*`, `@types/node`, ...); parsing one inline pins a
-    // tokio worker for hundreds of milliseconds and stalls every
-    // socket that worker pumps — on a cold babylon install the
-    // inline parses held the metadata phase to a third of pnpm's
-    // throughput.
-    let task_url = url.clone();
     let should_filter_metadata = opts.full_metadata && opts.filter_metadata;
-    let meta = tokio::task::spawn_blocking(move || -> Result<Package, FetchMetadataError> {
-        let mut meta: Package = serde_json::from_str(&raw_body)
-            .map_err(|error| FetchMetadataError::Decode { url: task_url.clone(), error })?;
-        if should_filter_metadata {
-            meta = clear_meta(&meta).map_err(|error| FetchMetadataError::Decode {
-                url: task_url.clone(),
-                error: error.into_inner(),
+
+    // The request itself is retried inside `send_with_retry`; this
+    // outer loop re-issues the whole fetch — conditional headers and
+    // all — when reading or parsing the body fails ("error decoding
+    // response body", broken JSON), the way pnpm nests a second retry
+    // around `response.text()`. A `304` is a success, not a retry: it
+    // returns the cached mirror body.
+    retry_async(&url, opts.retry_opts, FetchMetadataError::is_body_retryable, || async {
+        let (client, response) =
+            send_with_retry(opts.http_client, &url, opts.retry_opts, |client| {
+                let mut request = client.get(&url).header(header::ACCEPT, accept);
+                if let Some(value) = opts.auth_headers.for_url_with_package(&url, Some(pkg_name)) {
+                    request = request.header(header::AUTHORIZATION, value);
+                }
+                if let Some(headers) = cache_headers.as_ref() {
+                    if let Some(etag) = headers.etag.as_deref() {
+                        request = request.header(header::IF_NONE_MATCH, etag);
+                    }
+                    if let Some(modified) = headers.modified.as_deref() {
+                        request = request.header(header::IF_MODIFIED_SINCE, modified);
+                    }
+                }
+                request
+            })
+            .await
+            .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
+
+        if response.status() == StatusCode::NOT_MODIFIED {
+            // No body to stream — release the connection and its
+            // network-concurrency permit before the mirror disk read.
+            drop(client);
+            let Some(path) = mirror_path.as_deref() else {
+                // 304 without an existing cache to fall back on — the
+                // registry over-reached on `If-None-Match: <stale>`.
+                // Mirrors upstream's `META_NOT_MODIFIED_WITHOUT_CACHE`.
+                return Err(FetchMetadataError::NotModifiedWithoutCache {
+                    pkg_name: pkg_name.to_string(),
+                });
+            };
+            let meta = load_meta_async(Some(path)).await.ok_or_else(|| {
+                FetchMetadataError::CacheMissingAfter304 { pkg_name: pkg_name.to_string() }
             })?;
+            renew_mirror_freshness(path);
+            return Ok(meta);
         }
 
-        if let Some(path) = mirror_path.as_deref() {
-            // A filtered full response is written in pnpm's NDJSON
-            // shape. Other responses keep pacquet's indexed mirror
-            // layout for lazy version hydration.
-            let save_result = if should_filter_metadata {
-                save_meta_ndjson(path, &meta, etag.as_deref())
-            } else {
-                save_meta_indexed(path, &meta, etag.as_deref())
-            };
-            if let Err(error) = save_result {
-                tracing::debug!(
-                    target: "pacquet_resolving_npm_resolver::cache",
-                    ?error,
-                    path = %path.display(),
-                    "could not persist mirror; bypassing cache write",
-                );
+        let response = response
+            .error_for_status()
+            .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
+
+        let etag = response
+            .headers()
+            .get(header::ETAG)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string);
+        let raw_body = response
+            .text()
+            .await
+            .map_err(|error| FetchMetadataError::BodyRead { url: url.clone(), error })?;
+
+        // Body fully buffered — release the connection and its
+        // network-concurrency permit before the CPU-bound parse so the
+        // semaphore keeps bounding *sockets*, not parses. Same
+        // buffer-then-release shape as the tarball pipeline in
+        // `pacquet-tarball`.
+        drop(client);
+
+        // Deserialize and persist the mirror off the reactor. Packuments
+        // run to several megabytes for high-release-cadence packages
+        // (`@fluentui/*`, `@types/node`, ...); parsing one inline pins a
+        // tokio worker for hundreds of milliseconds and stalls every
+        // socket that worker pumps — on a cold babylon install the
+        // inline parses held the metadata phase to a third of pnpm's
+        // throughput.
+        let task_url = url.clone();
+        let task_mirror_path = mirror_path.clone();
+        let meta = tokio::task::spawn_blocking(move || -> Result<Package, FetchMetadataError> {
+            let mut meta: Package = serde_json::from_str(&raw_body)
+                .map_err(|error| FetchMetadataError::Decode { url: task_url.clone(), error })?;
+            if should_filter_metadata {
+                meta = clear_meta(&meta).map_err(|error| FetchMetadataError::Decode {
+                    url: task_url.clone(),
+                    error: error.into_inner(),
+                })?;
             }
-        }
-        Ok(meta)
+
+            if let Some(path) = task_mirror_path.as_deref() {
+                // A filtered full response is written in pnpm's NDJSON
+                // shape. Other responses keep pacquet's indexed mirror
+                // layout for lazy version hydration.
+                let save_result = if should_filter_metadata {
+                    save_meta_ndjson(path, &meta, etag.as_deref())
+                } else {
+                    save_meta_indexed(path, &meta, etag.as_deref())
+                };
+                if let Err(error) = save_result {
+                    tracing::debug!(
+                        target: "pacquet_resolving_npm_resolver::cache",
+                        ?error,
+                        path = %path.display(),
+                        "could not persist mirror; bypassing cache write",
+                    );
+                }
+            }
+            Ok(meta)
+        })
+        .await
+        .map_err(|error| FetchMetadataError::ParseTask { url: url.clone(), error })??;
+
+        meta.pipe(Ok)
     })
     .await
-    .map_err(|error| FetchMetadataError::ParseTask { url, error })??;
-
-    meta.pipe(Ok)
 }
 
 /// Bump the mirror file's mtime to "now" after a `304 Not Modified`.

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -179,7 +179,7 @@ pub async fn fetch_full_metadata_cached(
             let mut meta: Package = serde_json::from_str(&raw_body)
                 .map_err(|error| FetchMetadataError::Decode { url: task_url.clone(), error })?;
             if should_filter_metadata {
-                meta = clear_meta(&meta).map_err(|error| FetchMetadataError::Decode {
+                meta = clear_meta(&meta).map_err(|error| FetchMetadataError::FilterMetadata {
                     url: task_url.clone(),
                     error: error.into_inner(),
                 })?;

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -103,12 +103,9 @@ pub async fn fetch_full_metadata_cached(
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
     let should_filter_metadata = opts.full_metadata && opts.filter_metadata;
 
-    // The request itself is retried inside `send_with_retry`; this
-    // outer loop re-issues the whole fetch — conditional headers and
-    // all — when reading or parsing the body fails ("error decoding
-    // response body", broken JSON), the way pnpm nests a second retry
-    // around `response.text()`. A `304` is a success, not a retry: it
-    // returns the cached mirror body.
+    // A body-read retry re-issues the whole request, conditional
+    // headers and all, so a `304` stays a success that returns the
+    // cached mirror body rather than re-fetching it.
     retry_async(&url, opts.retry_opts, FetchMetadataError::is_body_retryable, || async {
         let (client, response) =
             send_with_retry(opts.http_client, &url, opts.retry_opts, |client| {

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -18,7 +18,9 @@
 
 use std::path::Path;
 
-use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, retry_async, send_with_retry};
+use pacquet_network::{
+    AuthHeaders, RetryOpts, ThrottledClient, redact_url_credentials, retry_async, send_with_retry,
+};
 use pacquet_registry::Package;
 use pipe_trait::Pipe;
 use reqwest::{StatusCode, header};
@@ -124,7 +126,10 @@ pub async fn fetch_full_metadata_cached(
                 request
             })
             .await
-            .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
+            .map_err(|error| FetchMetadataError::Network {
+                url: redact_url_credentials(&url),
+                error,
+            })?;
 
         if response.status() == StatusCode::NOT_MODIFIED {
             // No body to stream — release the connection and its
@@ -145,19 +150,19 @@ pub async fn fetch_full_metadata_cached(
             return Ok(meta);
         }
 
-        let response = response
-            .error_for_status()
-            .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
+        let response = response.error_for_status().map_err(|error| {
+            FetchMetadataError::Network { url: redact_url_credentials(&url), error }
+        })?;
 
         let etag = response
             .headers()
             .get(header::ETAG)
             .and_then(|value| value.to_str().ok())
             .map(str::to_string);
-        let raw_body = response
-            .text()
-            .await
-            .map_err(|error| FetchMetadataError::BodyRead { url: url.clone(), error })?;
+        let raw_body = response.text().await.map_err(|error| FetchMetadataError::BodyRead {
+            url: redact_url_credentials(&url),
+            error,
+        })?;
 
         // Body fully buffered — release the connection and its
         // network-concurrency permit before the CPU-bound parse so the
@@ -176,11 +181,12 @@ pub async fn fetch_full_metadata_cached(
         let task_url = url.clone();
         let task_mirror_path = mirror_path.clone();
         let meta = tokio::task::spawn_blocking(move || -> Result<Package, FetchMetadataError> {
-            let mut meta: Package = serde_json::from_str(&raw_body)
-                .map_err(|error| FetchMetadataError::Decode { url: task_url.clone(), error })?;
+            let mut meta: Package = serde_json::from_str(&raw_body).map_err(|error| {
+                FetchMetadataError::Decode { url: redact_url_credentials(&task_url), error }
+            })?;
             if should_filter_metadata {
                 meta = clear_meta(&meta).map_err(|error| FetchMetadataError::FilterMetadata {
-                    url: task_url.clone(),
+                    url: redact_url_credentials(&task_url),
                     error: error.into_inner(),
                 })?;
             }
@@ -206,7 +212,10 @@ pub async fn fetch_full_metadata_cached(
             Ok(meta)
         })
         .await
-        .map_err(|error| FetchMetadataError::ParseTask { url: url.clone(), error })??;
+        .map_err(|error| FetchMetadataError::ParseTask {
+            url: redact_url_credentials(&url),
+            error,
+        })??;
 
         meta.pipe(Ok)
     })

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
@@ -28,6 +28,30 @@ fn no_retry_opts() -> RetryOpts {
     RetryOpts { retries: 0, ..Default::default() }
 }
 
+fn fast_retry_opts() -> RetryOpts {
+    RetryOpts {
+        retries: 1,
+        min_timeout: std::time::Duration::from_millis(1),
+        max_timeout: std::time::Duration::from_millis(1),
+        ..Default::default()
+    }
+}
+
+/// A `Content-Encoding: gzip` header over a body that isn't gzip makes
+/// reqwest fail while decoding the response body — the same class of
+/// failure as a connection reset mid-transfer, which `send_with_retry`
+/// can't see because it happens after the request returns `200`.
+async fn corrupt_gzip_body_mock(server: &mut mockito::ServerGuard) -> mockito::Mock {
+    server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_header("content-encoding", "gzip")
+        .with_body("this is not valid gzip")
+        .expect(1)
+        .create_async()
+        .await
+}
+
 #[tokio::test]
 async fn cold_cache_writes_mirror_on_200() {
     let mut server = mockito::Server::new_async().await;
@@ -327,4 +351,43 @@ async fn read_only_cache_dir_does_not_fail_the_call() {
 
     // Restore so TempDir's drop can clean up.
     let _ = fs::set_permissions(cache.path(), fs::Permissions::from_mode(mode));
+}
+
+#[tokio::test]
+async fn body_read_failure_retries_and_writes_mirror() {
+    let mut server = mockito::Server::new_async().await;
+    let first = corrupt_gzip_body_mock(&mut server).await;
+    let second = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_header("etag", r#"W/"after-retry""#)
+        .with_body(PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let cache = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let opts = FetchFullMetadataCachedOptions {
+        registry: &registry,
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        cache_dir: Some(cache.path()),
+        full_metadata: true,
+        filter_metadata: false,
+        retry_opts: fast_retry_opts(),
+    };
+
+    let pkg = fetch_full_metadata_cached("acme", &opts).await.expect("body read retries");
+    assert_eq!(pkg.name, "acme");
+    first.assert_async().await;
+    second.assert_async().await;
+
+    // The retry's body is what gets persisted to the mirror.
+    let mirror_path =
+        get_pkg_mirror_path(cache.path(), FULL_META_DIR, &registry, "acme").expect("path");
+    let headers = load_meta_headers(&mirror_path).expect("headers readable");
+    assert_eq!(headers.etag.as_deref(), Some(r#"W/"after-retry""#));
 }

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
@@ -390,4 +390,12 @@ async fn body_read_failure_retries_and_writes_mirror() {
         get_pkg_mirror_path(cache.path(), FULL_META_DIR, &registry, "acme").expect("path");
     let headers = load_meta_headers(&mirror_path).expect("headers readable");
     assert_eq!(headers.etag.as_deref(), Some(r#"W/"after-retry""#));
+
+    // A follow-up conditional GET answered 304 proves the persisted body is
+    // a usable mirror, not just freshened headers over a missing/stale body.
+    let not_modified = server.mock("GET", "/acme").with_status(304).expect(1).create_async().await;
+    let cached_pkg =
+        fetch_full_metadata_cached("acme", &opts).await.expect("mirror body readable after retry");
+    assert_eq!(cached_pkg.name, "acme");
+    not_modified.assert_async().await;
 }


### PR DESCRIPTION
## Summary

A CI benchmark intermittently failed pacquet installs with:

```
ERR_PNPM_META_FETCH_FAIL
  Failed to fetch metadata from https://registry.npmjs.org/typescript:
  error decoding response body for url (https://registry.npmjs.org/typescript)
```

`error decoding response body` is a reqwest error raised while **reading the response body** — after the registry already returned `200 OK` — when the connection resets or the transfer is truncated mid-stream. pacquet's `send_with_retry` wraps only the request (`.send()`), so the body read (`response.text()`) and the JSON parse sat outside any retry, and a single mid-stream hiccup aborted the whole install.

The pnpm CLI never surfaces this because it retries in **two layers**: the network library retries the request, and `fetchMetadataFromFromRegistry` wraps `response.text()` + `JSON.parse` in a second `@zkochan/retry` operation (with the comment *"Here we only retry broken JSON responses. Other HTTP issues are retried by the `@pnpm/network.fetch` library"*). pacquet only had the first layer.

This PR adds the missing second layer, mirroring pnpm's structure.

## Squash Commit Body

```text
fix(network): retry metadata fetches that fail while reading the body

`send_with_retry` wraps only the request, so a body that fails mid-stream
after a 200 ("error decoding response body") aborted the install instead
of retrying. pnpm CLI retries this in a second `@zkochan/retry` layer in
`fetchMetadataFromFromRegistry`; pacquet only had the request-level layer.

- Add `retry_async` to `pacquet-network`, the body-read/parse companion to
  `send_with_retry`: it re-issues a full fetch closure under the same
  `RetryOpts` backoff when the closure returns a retryable error.
- Add a distinct `FetchMetadataError::BodyRead` variant plus an
  `is_body_retryable()` predicate. Only `BodyRead` (mid-stream body
  failure) and `Decode` (broken JSON) retry; `Network` (transport/status,
  already retried inside `send_with_retry`) does not, so transport errors
  are not double-retried — matching pnpm, which rejects a fetch failure
  immediately while letting the network library retry internally.
- Both metadata fetchers wrap their send -> body-read -> parse pipeline in
  `retry_async`, mapping `response.text()` failures to `BodyRead`. A 304
  stays a success (returns the cached mirror body), not a retry.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  *(pacquet-only parity fix — the TypeScript CLI already has this behavior;
  it is the source of truth being ported from.)*
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an additional async retry layer for failures that occur while reading/decoding/parsing response bodies.

* **Bug Fixes**
  * Metadata fetching (including cached conditional-GET) now retries body-related errors while still returning immediately on “not modified”.
  * Improved diagnostics by adding dedicated body-read error reporting and redacting embedded basic-auth credentials from URL-based messages.

* **Tests**
  * Added async retry coverage, including retry behavior for corrupted gzip responses, verification of retry call counts, and assertions that persisted mirrors remain usable after retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->