### PR TITLE
fix(lockfile): match pnpm's `__` separator for nested peer-group boundaries

### DIFF
--- a/pacquet/crates/deps-path/src/dep_path_to_filename/tests.rs
+++ b/pacquet/crates/deps-path/src/dep_path_to_filename/tests.rs
@@ -49,6 +49,20 @@ fn uppercase_in_file_scheme_is_preserved_untouched() {
 }
 
 #[test]
+fn nested_peer_group_uses_double_underscore_at_boundary() {
+    // eslint-plugin-testing-library@7.7.0(eslint@9.35.0(jiti@2.6.1))(typescript@6.0.3)
+    // The `))(` sequence should produce `__`: the inner `)` closes the nested
+    // group and the outer `)(` separates top-level peers.
+    assert_eq!(
+        dep_path_to_filename(
+            "eslint-plugin-testing-library@7.7.0(eslint@9.35.0(jiti@2.6.1))(typescript@6.0.3)",
+            120,
+        ),
+        "eslint-plugin-testing-library@7.7.0_eslint@9.35.0_jiti@2.6.1__typescript@6.0.3",
+    );
+}
+
+#[test]
 fn empty_input_does_not_panic() {
     assert_eq!(dep_path_to_filename("", 120), "");
 }

--- a/pacquet/crates/lockfile/src/pkg_name_ver_peer.rs
+++ b/pacquet/crates/lockfile/src/pkg_name_ver_peer.rs
@@ -27,12 +27,13 @@ impl PkgNameVerPeer {
         let escape_for_fs = |character: char| {
             matches!(character, '\\' | '/' | ':' | '*' | '?' | '"' | '<' | '>' | '|' | '#')
         };
-        let filename = self
-            .to_string()
-            .replace(escape_for_fs, "+")
-            .replace(")(", "_")
-            .replace('(', "_")
-            .replace(')', "");
+        let mut filename = self.to_string().replace(escape_for_fs, "+");
+        if filename.contains('(') {
+            if filename.ends_with(')') {
+                filename.pop();
+            }
+            filename = filename.replace(")(", "_").replace(['(', ')'], "_");
+        }
         shorten_virtual_store_name(filename, max_length)
     }
 

--- a/pacquet/crates/lockfile/src/pkg_name_ver_peer/tests.rs
+++ b/pacquet/crates/lockfile/src/pkg_name_ver_peer/tests.rs
@@ -185,6 +185,32 @@ fn without_peer_handles_workspace_link_with_peer_suffix() {
     assert!(!rendered.contains(")("), "peer suffix must be stripped; got {rendered:?}");
 }
 
+/// Nested peer groups must produce `__` at the group boundary, matching pnpm.
+/// See <https://github.com/pnpm/pnpm/issues/12452>
+#[test]
+fn to_virtual_store_name_nested_peer_uses_double_underscore() {
+    fn case(input: &'static str, expected: &'static str) {
+        eprintln!("CASE: {input:?}");
+        let name_ver_peer: PkgNameVerPeer = input.parse().unwrap();
+        let received = name_ver_peer.to_virtual_store_name(DEFAULT_MAX_LENGTH);
+        assert_eq!(received, expected);
+    }
+
+    case(
+        "eslint-plugin-testing-library@7.7.0(eslint@9.35.0(jiti@2.6.1))(typescript@6.0.3)",
+        "eslint-plugin-testing-library@7.7.0_eslint@9.35.0_jiti@2.6.1__typescript@6.0.3",
+    );
+    case("foo@1.0.0(bar@2.0.0(baz@3.0.0))", "foo@1.0.0_bar@2.0.0_baz@3.0.0_");
+    case(
+        "foo@1.0.0(a@1.0.0(b@2.0.0(c@3.0.0)))(d@4.0.0)",
+        "foo@1.0.0_a@1.0.0_b@2.0.0_c@3.0.0___d@4.0.0",
+    );
+    case(
+        "foo@1.0.0(patch_hash=abc)(bar@2.0.0(baz@3.0.0))",
+        "foo@1.0.0_patch_hash=abc_bar@2.0.0_baz@3.0.0_",
+    );
+}
+
 /// The user-reported macOS errno-63 case: a vitest snapshot key whose
 /// escaped filename blows past 120 bytes. The shortening must produce a
 /// name that fits inside `max_length` so `fs::create_dir_all` doesn't


### PR DESCRIPTION
`to_virtual_store_name` removed all `)` instead of only stripping the
trailing one and replacing inner `)` with `_`. For nested peers like
`(eslint@9.35.0(jiti@2.6.1))(typescript@6.0.3)`, the inner `)` closing
the nested group was deleted rather than becoming `_`, losing the `__`
that pnpm produces at the group boundary.

Fixes https://github.com/pnpm/pnpm/issues/12452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how nested peer-dependency package names are converted into virtual store filenames.
  * Nested peer group boundaries now use `__`, matching expected naming behavior in more complex dependency trees.
  * Added coverage for nested and deeply nested peer patterns, including cases with patch-related segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->