### PR TITLE
ci(pacquet): shrink test build debuginfo to avoid ENOSPC on the ubuntu runner

### DIFF
--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -72,6 +72,20 @@ jobs:
     name: Rust CI / Test / ${{ matrix.os_label }}
     needs: changes
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') }}
+    # Build the nextest artifacts with line-tables-only debug info. The full
+    # `cargo nextest` build holds a complete set of `--all-targets` debug
+    # binaries for the whole workspace (~60 crates plus heavy C deps like
+    # aws-lc-sys, ring, libsql-ffi, and tree-sitter) in target/, which had
+    # grown close to the hosted runner's free-disk ceiling even after the
+    # cleanup step below — a run can cross ENOSPC mid-link (the linker dies
+    # with "No space left on device"). Line tables keep panic backtraces
+    # file:line-accurate while dropping most of the debuginfo bytes. Set here
+    # in CI rather than in Cargo.toml so local `just test` keeps full debug
+    # info. CARGO_PROFILE_DEV_DEBUG covers dependencies (built dev), _TEST_
+    # covers the test targets.
+    env:
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Follow-up to the `pacquet audit signatures` PR, where the merge-queue `Rust CI / Test / ubuntu` job failed with:

```
rustc-LLVM ERROR: IO failure on output stream: No space left on device
error: linking with `cc` failed: exit status: 1
```

The failure is disk exhaustion, not a code error — macOS and Windows passed, and it died linking an unrelated crate's test binary. The `cargo nextest` build holds a full set of `--all-targets` debug binaries for the whole workspace (~60 crates plus heavy C deps like `aws-lc-sys`, `ring`, `libsql-ffi`, `tree-sitter`) in `target/`, which has grown close to the hosted ubuntu runner's free-disk ceiling. The existing `Free up runner disk space` step frees a fixed ~25 GB, but `target/` had crept up to where a run can still cross ENOSPC mid-link.

This builds the test artifacts with `line-tables-only` debug info (via job-level `CARGO_PROFILE_DEV_DEBUG` / `CARGO_PROFILE_TEST_DEBUG`), which drops most of the debuginfo bytes that fill `target/` while keeping panic backtraces file:line-accurate. It's set in the workflow rather than `Cargo.toml`, so local `just test` keeps full debug info.

Attacking the consumer (`target/` size) rather than freeing more host space addresses the growth directly; if headroom gets tight again later, freeing more host space is the next lever.

## Squash Commit Body

```text
The Rust CI test job's `cargo nextest` build holds a full set of
`--all-targets` debug binaries for the whole workspace (~60 crates plus
heavy C deps such as aws-lc-sys, ring, libsql-ffi, and tree-sitter) in
target/. That had grown close to the hosted ubuntu runner's free-disk
ceiling even after the fixed `Free up runner disk space` step, and a run
crossed it: the linker died with "No space left on device" while building
an unrelated crate's test binary (macOS and Windows were unaffected).

Build the test artifacts with line-tables-only debug info via job-level
CARGO_PROFILE_DEV_DEBUG / CARGO_PROFILE_TEST_DEBUG env. This drops most of
the debuginfo bytes that fill target/ while keeping panic backtraces
file:line-accurate. Setting it in the workflow rather than Cargo.toml
leaves local `just test` builds with full debug info.
```

## Checklist

- [x] Added or updated tests.
  <!-- N/A — CI configuration change; validated by the workflow run on this PR (the ubuntu test job building and passing). -->

<!-- Parity item removed: this is a CI-infrastructure change, not a user-visible CLI/format change, so there is nothing to mirror between the TypeScript CLI and pacquet. -->
<!-- No changeset: no published package is affected. -->
<!-- No docs change needed. -->

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI test settings to use smaller debug information for Rust builds, helping jobs fit within disk-space limits and run more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->