### PR TITLE
feat(pacquet): port the "ping" command

### DIFF
--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Triage with Oz agent
         uses: warpdotdev/oz-agent-action@501d24fbf4d1447e8db60eb0973eeadeb5ff54c2 # v1

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -24,9 +24,11 @@ pub mod patch;
 pub mod patch_commit;
 pub mod patch_remove;
 pub(crate) mod patch_state;
+pub mod ping;
 pub mod prune;
 pub mod rebuild;
 pub mod recursive;
+pub mod registry_client;
 pub mod remove;
 pub mod restart;
 pub mod root;
@@ -77,6 +79,7 @@ use pacquet_reporter::{
 use patch::PatchArgs;
 use patch_commit::PatchCommitArgs;
 use patch_remove::PatchRemoveArgs;
+use ping::PingArgs;
 use prune::PruneArgs;
 use rebuild::RebuildArgs;
 use remove::RemoveArgs;
@@ -203,6 +206,8 @@ pub enum CliCommand {
     /// Manage a package's distribution tags.
     #[clap(name = "dist-tag", visible_alias = "dist-tags")]
     DistTag(DistTagArgs),
+    /// Test connectivity to the configured registry.
+    Ping(PingArgs),
     /// Rebuild a package.
     #[clap(visible_alias = "rb")]
     Rebuild(RebuildArgs),
@@ -557,6 +562,19 @@ impl CliArgs {
                         }
                         println!("{output}");
                     }
+                    Ok(())
+                })
+            }
+            // `ping` is a read-only connectivity check: it resolves the
+            // registry (and any auth header) from config and GETs
+            // `-/ping`, with no lockfile or install pipeline, so it
+            // dispatches off `config()` like the other read-only registry
+            // commands.
+            CliCommand::Ping(args) => {
+                let cfg: &Config = config()?;
+                Box::pin(async move {
+                    let report = args.run(cfg).await?;
+                    println!("{report}");
                     Ok(())
                 })
             }

--- a/pacquet/crates/cli/src/cli_args/ping.rs
+++ b/pacquet/crates/cli/src/cli_args/ping.rs
@@ -1,0 +1,133 @@
+//! `pacquet ping` — test connectivity to the configured registry.
+//!
+//! Ports pnpm's
+//! [`ping` command](https://github.com/pnpm/pnpm/blob/fc2f33912e/pnpm11/registry-access/commands/src/ping.ts).
+
+use crate::cli_args::registry_client::build_registry_client;
+use clap::Args;
+use derive_more::{Display, Error};
+use miette::{Context, Diagnostic, IntoDiagnostic};
+use pacquet_config::Config;
+use pacquet_network::{RetryOpts, ThrottledClient, redact_url_credentials, send_with_retry};
+use serde_json::Value;
+use std::time::Instant;
+
+/// Errors from `pacquet ping`.
+///
+/// Both a transport failure and a non-success status map to the single
+/// `PING_ERROR` code pnpm raises in `ping.ts`.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum PingError {
+    #[display("Failed to reach registry: {message}")]
+    #[diagnostic(code(ERR_PNPM_PING_ERROR))]
+    Unreachable { message: String },
+}
+
+#[derive(Debug, Args)]
+pub struct PingArgs {
+    /// Test a specific registry URL.
+    #[clap(long)]
+    pub registry: Option<String>,
+}
+
+impl PingArgs {
+    /// Ports `ping.ts`'s `handler`: resolve the registry (the `--registry`
+    /// override or the configured default), GET `<registry>-/ping?write=true`
+    /// with any resolved auth header, and render pnpm's `PING`/`PONG` report.
+    pub async fn run(&self, config: &Config) -> miette::Result<String> {
+        let registry_url = self.registry.as_deref().unwrap_or(&config.registry);
+        // Add a trailing slash before joining so a registry with a path
+        // prefix keeps it, matching `new URL('./-/ping', normalizedRegistryUrl)`.
+        let normalized_registry_url = if registry_url.ends_with('/') {
+            registry_url.to_owned()
+        } else {
+            format!("{registry_url}/")
+        };
+        let ping_url = format!("{normalized_registry_url}-/ping?write=true");
+        let auth_header = config.auth_headers.for_url(&normalized_registry_url);
+        let http_client = build_registry_client(config)?;
+
+        // `ping` issues a single attempt with no retries, matching pnpm's
+        // `retry: { retries: 0 }`.
+        let (time, body) = fetch_ping(
+            &ping_url,
+            &http_client,
+            auth_header.as_deref(),
+            RetryOpts { retries: 0, ..RetryOpts::default() },
+        )
+        .await?;
+
+        let mut report = format!("PING {registry_url}\nPONG {time}ms");
+        if let Some(details) = format_details(&body) {
+            report.push_str("\nPONG ");
+            report.push_str(&details);
+        }
+        Ok(report)
+    }
+}
+
+/// GET `ping_url` with the optional `Authorization` header, timing the
+/// round trip (request plus body read) the way pnpm measures `Date.now()`.
+///
+/// Errors with `ERR_PNPM_PING_ERROR` on any transport failure or
+/// non-success status. The transport error message is credential-redacted
+/// before it reaches stderr / CI logs: a registry configured as
+/// `https://user:password@host/` carries inline credentials that the
+/// underlying error may echo back.
+async fn fetch_ping(
+    ping_url: &str,
+    http_client: &ThrottledClient,
+    auth_header: Option<&str>,
+    retry_opts: RetryOpts,
+) -> miette::Result<(u128, String)> {
+    let start = Instant::now();
+    let (client, response) = send_with_retry(http_client, ping_url, retry_opts, |client| {
+        let request = client.get(ping_url);
+        match auth_header {
+            Some(value) => request.header("authorization", value),
+            None => request,
+        }
+    })
+    .await
+    .map_err(|error| PingError::Unreachable {
+        message: redact_url_credentials(&error.to_string()),
+    })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        return Err(PingError::Unreachable {
+            message: format!(
+                "{} {}",
+                status.as_u16(),
+                status.canonical_reason().unwrap_or_default(),
+            )
+            .trim_end()
+            .to_owned(),
+        }
+        .into());
+    }
+
+    let body =
+        response.text().await.into_diagnostic().wrap_err("reading the registry ping response")?;
+    let time = start.elapsed().as_millis();
+    drop(client);
+    Ok((time, body))
+}
+
+/// Pretty-print the ping response body when it is a non-empty JSON object
+/// or array, mirroring `ping.ts`'s `JSON.stringify(parsed, null, 2)` branch
+/// (which fires for any `typeof === 'object'` value with at least one entry).
+/// Returns `None` for an empty body, non-JSON, or an empty/primitive value.
+fn format_details(body: &str) -> Option<String> {
+    if body.is_empty() {
+        return None;
+    }
+    let value = serde_json::from_str::<Value>(body).ok()?;
+    let non_empty = match &value {
+        Value::Object(map) => !map.is_empty(),
+        Value::Array(items) => !items.is_empty(),
+        _ => false,
+    };
+    if non_empty { serde_json::to_string_pretty(&value).ok() } else { None }
+}

--- a/pacquet/crates/cli/src/cli_args/ping.rs
+++ b/pacquet/crates/cli/src/cli_args/ping.rs
@@ -6,7 +6,7 @@
 use crate::cli_args::registry_client::build_registry_client;
 use clap::Args;
 use derive_more::{Display, Error};
-use miette::{Context, Diagnostic, IntoDiagnostic};
+use miette::Diagnostic;
 use pacquet_config::Config;
 use pacquet_network::{RetryOpts, ThrottledClient, redact_url_credentials, send_with_retry};
 use serde_json::Value;
@@ -58,7 +58,7 @@ impl PingArgs {
         )
         .await?;
 
-        let mut report = format!("PING {registry_url}\nPONG {time}ms");
+        let mut report = format!("PING {}\nPONG {time}ms", sanitized_registry(registry_url));
         if let Some(details) = format_details(&body) {
             report.push_str("\nPONG ");
             report.push_str(&details);
@@ -67,14 +67,25 @@ impl PingArgs {
     }
 }
 
+/// Render a registry URL for the echoed `PING` line: redact any inline
+/// `user:pass@` credentials and strip control characters. A registry from an
+/// untrusted `.npmrc` / `--registry` must not leak its basic-auth or emit raw
+/// escape sequences — or inject lines via `\r` / `\n` — to the terminal.
+fn sanitized_registry(registry_url: &str) -> String {
+    redact_url_credentials(registry_url)
+        .chars()
+        .filter(|character| !character.is_control())
+        .collect()
+}
+
 /// GET `ping_url` with the optional `Authorization` header, timing the
 /// round trip (request plus body read) the way pnpm measures `Date.now()`.
 ///
-/// Errors with `ERR_PNPM_PING_ERROR` on any transport failure or
-/// non-success status. The transport error message is credential-redacted
-/// before it reaches stderr / CI logs: a registry configured as
-/// `https://user:password@host/` carries inline credentials that the
-/// underlying error may echo back.
+/// Errors with `ERR_PNPM_PING_ERROR` on a transport failure, a non-success
+/// status, or a failed body read. Messages from network failures are
+/// credential-redacted before they reach stderr / CI logs: a registry
+/// configured as `https://user:password@host/` carries inline credentials
+/// that the underlying `reqwest` error would otherwise echo back.
 async fn fetch_ping(
     ping_url: &str,
     http_client: &ThrottledClient,
@@ -108,8 +119,9 @@ async fn fetch_ping(
         .into());
     }
 
-    let body =
-        response.text().await.into_diagnostic().wrap_err("reading the registry ping response")?;
+    let body = response.text().await.map_err(|error| PingError::Unreachable {
+        message: redact_url_credentials(&error.to_string()),
+    })?;
     let time = start.elapsed().as_millis();
     drop(client);
     Ok((time, body))

--- a/pacquet/crates/cli/src/cli_args/ping.rs
+++ b/pacquet/crates/cli/src/cli_args/ping.rs
@@ -58,7 +58,7 @@ impl PingArgs {
         )
         .await?;
 
-        let mut report = format!("PING {}\nPONG {time}ms", sanitized_registry(registry_url));
+        let mut report = format!("PING {}\nPONG {time}ms", redact_and_sanitize(registry_url));
         if let Some(details) = format_details(&body) {
             report.push_str("\nPONG ");
             report.push_str(&details);
@@ -67,15 +67,14 @@ impl PingArgs {
     }
 }
 
-/// Render a registry URL for the echoed `PING` line: redact any inline
-/// `user:pass@` credentials and strip control characters. A registry from an
-/// untrusted `.npmrc` / `--registry` must not leak its basic-auth or emit raw
-/// escape sequences — or inject lines via `\r` / `\n` — to the terminal.
-fn sanitized_registry(registry_url: &str) -> String {
-    redact_url_credentials(registry_url)
-        .chars()
-        .filter(|character| !character.is_control())
-        .collect()
+/// Make untrusted, network-derived text safe to print: redact inline
+/// `user:pass@` credentials and strip control characters. Applied to the
+/// echoed registry URL and to error messages alike — both can carry
+/// basic-auth or escape sequences from an untrusted `.npmrc` / `--registry`
+/// (or a `reqwest` error that echoes the request URL back), which must not
+/// leak credentials or inject terminal output via raw escapes / `\r` / `\n`.
+fn redact_and_sanitize(text: &str) -> String {
+    redact_url_credentials(text).chars().filter(|character| !character.is_control()).collect()
 }
 
 /// GET `ping_url` with the optional `Authorization` header, timing the
@@ -83,9 +82,11 @@ fn sanitized_registry(registry_url: &str) -> String {
 ///
 /// Errors with `ERR_PNPM_PING_ERROR` on a transport failure, a non-success
 /// status, or a failed body read. Messages from network failures are
-/// credential-redacted before they reach stderr / CI logs: a registry
-/// configured as `https://user:password@host/` carries inline credentials
-/// that the underlying `reqwest` error would otherwise echo back.
+/// credential-redacted and control-character-stripped before they reach
+/// stderr / CI logs: a registry configured as `https://user:password@host/`
+/// carries inline credentials, and an untrusted `.npmrc` / `--registry` can
+/// carry escape sequences, that the underlying `reqwest` error would
+/// otherwise echo back.
 async fn fetch_ping(
     ping_url: &str,
     http_client: &ThrottledClient,
@@ -101,9 +102,7 @@ async fn fetch_ping(
         }
     })
     .await
-    .map_err(|error| PingError::Unreachable {
-        message: redact_url_credentials(&error.to_string()),
-    })?;
+    .map_err(|error| PingError::Unreachable { message: redact_and_sanitize(&error.to_string()) })?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -120,7 +119,7 @@ async fn fetch_ping(
     }
 
     let body = response.text().await.map_err(|error| PingError::Unreachable {
-        message: redact_url_credentials(&error.to_string()),
+        message: redact_and_sanitize(&error.to_string()),
     })?;
     let time = start.elapsed().as_millis();
     drop(client);
@@ -142,4 +141,21 @@ fn format_details(body: &str) -> Option<String> {
         _ => false,
     };
     if non_empty { serde_json::to_string_pretty(&value).ok() } else { None }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_and_sanitize;
+
+    #[test]
+    fn redact_and_sanitize_strips_credentials_and_control_chars() {
+        // A `reqwest` error that echoes a registry URL with inline basic-auth
+        // and an attacker-injected escape sequence + newline.
+        let dirty = "error sending request for url (https://user:pass@host/-/ping): \u{1b}[31m\nPONG spoofed";
+        let clean = redact_and_sanitize(dirty);
+        assert!(!clean.contains("user:pass"), "credentials must be redacted: {clean:?}");
+        assert!(!clean.contains('\u{1b}'), "escape sequences must be stripped: {clean:?}");
+        assert!(!clean.contains('\n'), "newlines must be stripped: {clean:?}");
+        assert!(clean.contains("https://host/-/ping"), "non-sensitive text is kept: {clean:?}");
+    }
 }

--- a/pacquet/crates/cli/src/cli_args/ping.rs
+++ b/pacquet/crates/cli/src/cli_args/ping.rs
@@ -144,18 +144,4 @@ fn format_details(body: &str) -> Option<String> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::redact_and_sanitize;
-
-    #[test]
-    fn redact_and_sanitize_strips_credentials_and_control_chars() {
-        // A `reqwest` error that echoes a registry URL with inline basic-auth
-        // and an attacker-injected escape sequence + newline.
-        let dirty = "error sending request for url (https://user:pass@host/-/ping): \u{1b}[31m\nPONG spoofed";
-        let clean = redact_and_sanitize(dirty);
-        assert!(!clean.contains("user:pass"), "credentials must be redacted: {clean:?}");
-        assert!(!clean.contains('\u{1b}'), "escape sequences must be stripped: {clean:?}");
-        assert!(!clean.contains('\n'), "newlines must be stripped: {clean:?}");
-        assert!(clean.contains("https://host/-/ping"), "non-sensitive text is kept: {clean:?}");
-    }
-}
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/ping/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/ping/tests.rs
@@ -1,0 +1,14 @@
+use super::redact_and_sanitize;
+
+#[test]
+fn redact_and_sanitize_strips_credentials_and_control_chars() {
+    // A `reqwest` error that echoes a registry URL with inline basic-auth
+    // and an attacker-injected escape sequence + newline.
+    let dirty =
+        "error sending request for url (https://user:pass@host/-/ping): \u{1b}[31m\nPONG spoofed";
+    let clean = redact_and_sanitize(dirty);
+    assert!(!clean.contains("user:pass"), "credentials must be redacted: {clean:?}");
+    assert!(!clean.contains('\u{1b}'), "escape sequences must be stripped: {clean:?}");
+    assert!(!clean.contains('\n'), "newlines must be stripped: {clean:?}");
+    assert!(clean.contains("https://host/-/ping"), "non-sensitive text is kept: {clean:?}");
+}

--- a/pacquet/crates/cli/src/cli_args/registry_client.rs
+++ b/pacquet/crates/cli/src/cli_args/registry_client.rs
@@ -1,0 +1,22 @@
+use miette::{Context, IntoDiagnostic};
+use pacquet_config::Config;
+use pacquet_network::{NetworkSettings, ThrottledClient};
+use std::time::Duration;
+
+/// Build the network client a one-off registry query (`whoami`, `ping`, ...)
+/// makes its request through, from the same proxy / TLS / timeout config as
+/// the install client ([`crate::state::State::init`]).
+pub fn build_registry_client(config: &Config) -> miette::Result<ThrottledClient> {
+    ThrottledClient::for_installs(
+        &config.proxy,
+        &config.tls,
+        &config.tls_by_uri,
+        &NetworkSettings {
+            network_concurrency: config.network_concurrency,
+            fetch_timeout: Duration::from_millis(config.fetch_timeout),
+            user_agent: config.user_agent.clone(),
+        },
+    )
+    .into_diagnostic()
+    .wrap_err("create the network client for the registry request")
+}

--- a/pacquet/crates/cli/src/cli_args/whoami.rs
+++ b/pacquet/crates/cli/src/cli_args/whoami.rs
@@ -1,7 +1,8 @@
+use crate::cli_args::registry_client::build_registry_client;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pacquet_config::Config;
-use pacquet_network::{NetworkSettings, RetryOpts, ThrottledClient, send_with_retry};
+use pacquet_network::{RetryOpts, ThrottledClient, send_with_retry};
 use serde::Deserialize;
 use std::time::Duration;
 
@@ -37,7 +38,7 @@ struct WhoamiResponse {
 pub async fn whoami(config: &Config) -> miette::Result<String> {
     let auth_header =
         config.auth_headers.for_url(&config.registry).ok_or(WhoamiError::Unauthorized)?;
-    let http_client = build_http_client(config)?;
+    let http_client = build_registry_client(config)?;
     let retry_opts = RetryOpts {
         retries: config.fetch_retries,
         factor: config.fetch_retry_factor,
@@ -45,24 +46,6 @@ pub async fn whoami(config: &Config) -> miette::Result<String> {
         max_timeout: Duration::from_millis(config.fetch_retry_maxtimeout),
     };
     fetch_whoami(&config.registry, &http_client, &auth_header, retry_opts).await
-}
-
-/// The network client `whoami` makes its single request through, built
-/// from the same proxy / TLS / timeout config as the install client
-/// ([`crate::state::State::init`]).
-fn build_http_client(config: &Config) -> miette::Result<ThrottledClient> {
-    ThrottledClient::for_installs(
-        &config.proxy,
-        &config.tls,
-        &config.tls_by_uri,
-        &NetworkSettings {
-            network_concurrency: config.network_concurrency,
-            fetch_timeout: Duration::from_millis(config.fetch_timeout),
-            user_agent: config.user_agent.clone(),
-        },
-    )
-    .into_diagnostic()
-    .wrap_err("create the network client for whoami")
 }
 
 /// GET `<registry>-/whoami` with the resolved `Authorization` header and

--- a/pacquet/crates/cli/tests/ping.rs
+++ b/pacquet/crates/cli/tests/ping.rs
@@ -1,0 +1,199 @@
+//! `pacquet ping` resolves the registry (the `--registry` override or the
+//! configured default) and prints pnpm's `PING`/`PONG` report for
+//! `GET <registry>-/ping?write=true`.
+//!
+//! Ports the upstream ping tests
+//! (<https://github.com/pnpm/pnpm/blob/fc2f33912e/pnpm11/registry-access/commands/test/ping.ts>):
+//! the reachable-registry report, the JSON-details branch, the configured
+//! default registry, rejection on a non-success status, preservation of a
+//! registry path prefix, and a transport failure.
+//!
+//! The registry is a `mockito` server the spawned `pacquet` connects to
+//! over loopback. An empty `--npmrc-auth-file` replaces the developer's
+//! real `~/.npmrc` so a token or `registry=` already on the machine can't
+//! influence the test.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use mockito::Matcher;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+}
+
+/// An empty user-level `.npmrc`, returned for `--npmrc-auth-file`, so the
+/// developer's real `~/.npmrc` cannot leak a registry or token into the test.
+fn empty_auth_file(root: &Path) -> PathBuf {
+    let auth_file = root.join("auth-npmrc");
+    fs::write(&auth_file, "").expect("write empty auth .npmrc");
+    auth_file
+}
+
+fn run_ping(workspace: &Path, auth_file: &Path, registry: Option<&str>) -> std::process::Output {
+    let mut command =
+        pacquet_at(workspace).with_arg("--npmrc-auth-file").with_arg(auth_file).with_arg("ping");
+    if let Some(registry) = registry {
+        command = command.with_arg("--registry").with_arg(registry);
+    }
+    command.output().expect("spawn pacquet ping")
+}
+
+/// Match `GET /<path>-/ping?write=true`, the request pnpm's ping issues.
+fn ping_mock(server: &mut mockito::Server, path_prefix: &str) -> mockito::Mock {
+    server
+        .mock("GET", format!("{path_prefix}/-/ping").as_str())
+        .match_query(Matcher::UrlEncoded("write".into(), "true".into()))
+}
+
+#[test]
+fn reports_ping_and_pong_for_a_reachable_registry() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let mock = ping_mock(&mut server, "").with_status(200).with_body("{}").create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_ping(&workspace, &auth_file, Some(&registry));
+
+    mock.assert();
+    assert!(
+        output.status.success(),
+        "ping must succeed (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(lines.len(), 2, "an empty JSON body produces no details: {stdout:?}");
+    assert_eq!(lines[0], format!("PING {registry}"));
+    let pong = lines[1].strip_prefix("PONG ").expect("PONG line").strip_suffix("ms").expect("ms");
+    pong.parse::<u128>().expect("the elapsed time must be a number of milliseconds");
+    drop((root, server));
+}
+
+#[test]
+fn includes_details_when_the_body_is_non_empty_json() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let body = r#"{"host":"npm","user":"anonymous"}"#;
+    let mock = ping_mock(&mut server, "").with_status(200).with_body(body).create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_ping(&workspace, &auth_file, Some(&registry));
+
+    mock.assert();
+    assert!(
+        output.status.success(),
+        "ping must succeed (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(&format!("PING {registry}")), "missing PING line: {stdout:?}");
+    assert!(stdout.contains("PONG "), "missing PONG line: {stdout:?}");
+    assert!(stdout.contains(r#""host": "npm""#), "missing pretty-printed details: {stdout:?}");
+    drop((root, server));
+}
+
+#[test]
+fn uses_the_configured_registry_when_no_flag_is_given() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    fs::write(workspace.join(".npmrc"), format!("registry={}\n", server.url()))
+        .expect("write project .npmrc");
+    let mock = ping_mock(&mut server, "").with_status(200).with_body("{}").create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_ping(&workspace, &auth_file, None);
+
+    mock.assert();
+    assert!(
+        output.status.success(),
+        "ping must succeed against the configured registry (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // The configured registry is normalized to carry a trailing slash.
+    assert!(
+        stdout.contains(&format!("PING {}/", server.url())),
+        "PING must echo the configured registry: {stdout:?}",
+    );
+    drop((root, server));
+}
+
+#[test]
+fn fails_when_the_registry_responds_with_an_error_status() {
+    for status in [401_usize, 403, 404, 500] {
+        let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+        let mut server = mockito::Server::new();
+        let registry = format!("{}/", server.url());
+        let mock = ping_mock(&mut server, "")
+            .with_status(status)
+            .with_body(r#"{"error":"nope"}"#)
+            .create();
+        let auth_file = empty_auth_file(root.path());
+
+        let output = run_ping(&workspace, &auth_file, Some(&registry));
+
+        mock.assert();
+        assert!(
+            !output.status.success(),
+            "ping must fail on status {status} (stderr: {})",
+            String::from_utf8_lossy(&output.stderr),
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        assert!(
+            stderr.contains("ERR_PNPM_PING_ERROR") && stderr.contains("Failed to reach registry"),
+            "stderr must name the ping diagnostic for status {status}; got:\n{stderr}",
+        );
+        drop((root, server));
+    }
+}
+
+#[test]
+fn preserves_a_registry_path_prefix() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    // No trailing slash: ping must still target `<prefix>/-/ping`.
+    let registry = format!("{}/custom-prefix", server.url());
+    let mock = ping_mock(&mut server, "/custom-prefix").with_status(200).with_body("{}").create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_ping(&workspace, &auth_file, Some(&registry));
+
+    mock.assert();
+    assert!(
+        output.status.success(),
+        "ping must succeed against a prefixed registry (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(&format!("PING {registry}")), "PING must echo the raw URL: {stdout:?}");
+    drop((root, server));
+}
+
+#[test]
+fn fails_on_a_network_failure() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    // Port 1 is not listening, so the connection is refused immediately.
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_ping(&workspace, &auth_file, Some("http://127.0.0.1:1/"));
+
+    assert!(
+        !output.status.success(),
+        "ping must fail when the registry is unreachable (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        stderr.contains("ERR_PNPM_PING_ERROR") && stderr.contains("Failed to reach registry"),
+        "stderr must name the ping diagnostic; got:\n{stderr}",
+    );
+    drop(root);
+}

--- a/pacquet/crates/cli/tests/ping.rs
+++ b/pacquet/crates/cli/tests/ping.rs
@@ -6,7 +6,8 @@
 //! (<https://github.com/pnpm/pnpm/blob/fc2f33912e/pnpm11/registry-access/commands/test/ping.ts>):
 //! the reachable-registry report, the JSON-details branch, the configured
 //! default registry, rejection on a non-success status, preservation of a
-//! registry path prefix, and a transport failure.
+//! registry path prefix, and a transport failure. Adds a pacquet-only guard
+//! that inline registry credentials are redacted from the echoed `PING` line.
 //!
 //! The registry is a `mockito` server the spawned `pacquet` connects to
 //! over loopback. An empty `--npmrc-auth-file` replaces the developer's
@@ -19,6 +20,7 @@ use mockito::Matcher;
 use pacquet_testing_utils::bin::CommandTempCwd;
 use std::{
     fs,
+    net::TcpListener,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -49,6 +51,17 @@ fn ping_mock(server: &mut mockito::Server, path_prefix: &str) -> mockito::Mock {
     server
         .mock("GET", format!("{path_prefix}/-/ping").as_str())
         .match_query(Matcher::UrlEncoded("write".into(), "true".into()))
+}
+
+/// A loopback registry URL with nothing listening: bind an ephemeral port,
+/// then drop the listener so a connection is refused immediately. Avoids
+/// assuming a fixed port is free and keeps the network-failure test fast — a
+/// closed loopback port returns `ECONNREFUSED` rather than stalling on connect.
+fn unreachable_registry() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind a probe socket");
+    let port = listener.local_addr().expect("read the probe socket address").port();
+    drop(listener);
+    format!("http://127.0.0.1:{port}/")
 }
 
 #[test]
@@ -178,12 +191,43 @@ fn preserves_a_registry_path_prefix() {
 }
 
 #[test]
-fn fails_on_a_network_failure() {
+fn redacts_inline_credentials_in_the_ping_line() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
-    // Port 1 is not listening, so the connection is refused immediately.
+    let mut server = mockito::Server::new();
+    let mock = ping_mock(&mut server, "").with_status(200).with_body("{}").create();
+    // A registry URL carrying inline basic-auth credentials, which must not
+    // leak into the echoed `PING` line.
+    let host = server.url();
+    let with_credentials = format!("{}/", host.replacen("http://", "http://hunter2:s3cr3t@", 1));
     let auth_file = empty_auth_file(root.path());
 
-    let output = run_ping(&workspace, &auth_file, Some("http://127.0.0.1:1/"));
+    let output = run_ping(&workspace, &auth_file, Some(&with_credentials));
+
+    mock.assert();
+    assert!(
+        output.status.success(),
+        "ping must succeed (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("hunter2") && !stdout.contains("s3cr3t"),
+        "inline credentials must be redacted from the PING line: {stdout:?}",
+    );
+    assert!(
+        stdout.contains(&format!("PING {host}/")),
+        "PING must echo the credential-free registry URL: {stdout:?}",
+    );
+    drop((root, server));
+}
+
+#[test]
+fn fails_on_a_network_failure() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let auth_file = empty_auth_file(root.path());
+    let registry = unreachable_registry();
+
+    let output = run_ping(&workspace, &auth_file, Some(&registry));
 
     assert!(
         !output.status.success(),


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

Ports pnpm's `ping` command to pacquet. `pacquet ping` tests connectivity
to the configured registry: it GETs `<registry>-/ping?write=true` and
prints

```
PING <registry>
PONG <elapsed>ms
```

plus a pretty-printed `PONG <details>` line when the registry returns a
non-empty JSON body. Faithful to [`ping.ts`](https://github.com/pnpm/pnpm/blob/fc2f33912e/pnpm11/registry-access/commands/src/ping.ts):
`--registry` override with fallback to the configured default, trailing-slash
normalization that preserves a registry path prefix, an optional (not
required) `Authorization` header, no retries (`retry: { retries: 0 }`), and
a single `ERR_PNPM_PING_ERROR` code for both transport failures and
non-success statuses.

Also dedups the registry-client builder: whoami and ping now share
`cli_args::registry_client::build_registry_client` instead of each keeping
its own copy.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Add `pacquet ping`, ported from pnpm's ping command.

`ping` GETs `<registry>-/ping?write=true` and prints pnpm's PING/PONG
report, plus a pretty-printed `PONG <details>` line when the registry
returns a non-empty JSON body. It resolves the registry from `--registry`
or the configured default, adds a trailing slash before joining so a
registry path prefix is preserved (matching pnpm's
`new URL('./-/ping', ...)`), sends the optional `Authorization` header when
one is configured (unlike whoami it does not require auth), and issues a
single attempt with no retries (pnpm's `retry: { retries: 0 }`). Timing
wraps the request and body read, matching pnpm's `Date.now()` measurement.

Both a transport failure and a non-success status map to the single
`ERR_PNPM_PING_ERROR` code with pnpm's "Failed to reach registry" message;
the transport error message is credential-redacted before it reaches
stderr / CI logs, the same precaution as whoami. Unlike whoami's username
(printed raw, hence sanitized), ping's JSON details are re-serialized
through serde_json, which escapes control characters, so no raw registry
bytes reach the terminal.

Extract the registry-client builder duplicated from whoami into a shared
`cli_args::registry_client::build_registry_client` and switch whoami to it.

```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `pacquet ping` command to verify registry connectivity and report `PING`/`PONG` latency.
  * Supports an optional `--registry` override with URL normalization and appends pretty-printed JSON details when the registry returns non-empty JSON.
* **Bug Fixes**
  * Improved registry request consistency across commands, and enhanced error/reporting by redacting inline credentials while preserving the requested registry path.
* **Tests**
  * Added end-to-end coverage for `pacquet ping` (success, JSON details, HTTP error handling, URL construction, transport failures, and credential redaction).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->