### PR TITLE
feat(pacquet-cli): port the `config` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4613,6 +4613,7 @@ dependencies = [
  "pacquet-catalogs-types",
  "serde",
  "serde-saphyr",
+ "serde_json",
  "tempfile",
  "yaml_serde",
  "yamlpatch",

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -4,6 +4,7 @@ pub mod audit;
 pub mod cache;
 pub mod cat_file;
 pub mod cat_index;
+pub mod config;
 pub mod create;
 pub mod dedupe;
 pub mod dlx;
@@ -49,6 +50,7 @@ use cache::CacheCommand;
 use cat_file::CatFileArgs;
 use cat_index::CatIndexArgs;
 use clap::{Parser, Subcommand, ValueEnum};
+use config::ConfigArgs;
 use create::CreateArgs;
 use dedupe::DedupeArgs;
 use dlx::DlxArgs;
@@ -241,6 +243,9 @@ pub enum CliCommand {
     Runtime(RuntimeArgs),
     /// Print the effective `node_modules` directory.
     Root(RootArgs),
+    /// Manage the pnpm configuration files.
+    #[clap(visible_alias = "c")]
+    Config(ConfigArgs),
     /// Managing the package store.
     #[clap(subcommand)]
     Store(StoreCommand),
@@ -812,6 +817,10 @@ impl CliArgs {
             }
             CliCommand::Root(args) => {
                 args.run(dir_ref)?;
+                Box::pin(std::future::ready(Ok(())))
+            }
+            CliCommand::Config(args) => {
+                args.run(config()?, dir_ref)?;
                 Box::pin(std::future::ready(Ok(())))
             }
             CliCommand::Store(command) => {

--- a/pacquet/crates/cli/src/cli_args/config.rs
+++ b/pacquet/crates/cli/src/cli_args/config.rs
@@ -51,7 +51,7 @@ pub enum ConfigSubcommand {
 
 /// Shared `--global` / `--location` / `--json` flags. Marked `global` so they
 /// can appear before or after the positional arguments, matching pnpm.
-#[derive(Debug, Clone, Copy, Default, Args)]
+#[derive(Debug, Default, Clone, Copy, Args)]
 pub struct ConfigFlags {
     /// Operate on the global config file.
     #[clap(short = 'g', long, global = true)]

--- a/pacquet/crates/cli/src/cli_args/config.rs
+++ b/pacquet/crates/cli/src/cli_args/config.rs
@@ -1,0 +1,581 @@
+//! `pacquet config` — manage the pnpm configuration files.
+//!
+//! Port of pnpm's
+//! [`@pnpm/config.commands`](https://github.com/pnpm/pnpm/blob/8eb1be4988/config/commands/src):
+//! the `set` / `get` / `delete` / `list` subcommands, their file routing
+//! (`getConfigFileInfo`), key validation and value casting (`configSet`), and
+//! the read path (`configGet` / `configList` / `configToRecord`).
+//!
+//! pacquet's [`Config`] is the loaded, merged config rather than pnpm's
+//! injected `_config` / `_context`: `pnpm config list` / `get` read the
+//! explicitly-set settings from [`Config::explicit_settings`] and the raw auth
+//! keys from [`Config::raw_auth_config`] (pacquet's stand-ins for pnpm's
+//! `explicitlySetKeys` + `authConfig`).
+
+mod ini;
+
+#[cfg(test)]
+mod tests;
+
+use clap::{Args, Subcommand, ValueEnum};
+use derive_more::{Display, Error};
+use indexmap::IndexMap;
+use miette::Diagnostic;
+use pacquet_config::{
+    Config, GLOBAL_CONFIG_YAML_FILENAME, WORKSPACE_MANIFEST_FILENAME, config_types, naming_cases,
+    property_path::{self, Segment},
+    protected_settings,
+};
+use pacquet_workspace_manifest_writer::update_manifest_field;
+use serde_json::{Map, Value};
+use std::path::{Path, PathBuf};
+
+/// `pacquet config` and its subcommands.
+#[derive(Debug, Args)]
+pub struct ConfigArgs {
+    #[clap(subcommand)]
+    pub command: ConfigSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ConfigSubcommand {
+    /// Set the config key to the value provided.
+    Set(ConfigSetArgs),
+    /// Print the config value for the provided key.
+    Get(ConfigGetArgs),
+    /// Remove the config key from the config file.
+    Delete(ConfigDeleteArgs),
+    /// Show all the config settings.
+    List(ConfigListArgs),
+}
+
+/// Shared `--global` / `--location` / `--json` flags. Marked `global` so they
+/// can appear before or after the positional arguments, matching pnpm.
+#[derive(Debug, Clone, Copy, Default, Args)]
+pub struct ConfigFlags {
+    /// Operate on the global config file.
+    #[clap(short = 'g', long, global = true)]
+    pub global: bool,
+
+    /// When `project`, use `pnpm-workspace.yaml` / `.npmrc`; when `global`, use
+    /// the global `config.yaml` / `auth.ini`.
+    #[clap(long, value_enum, global = true)]
+    pub location: Option<ConfigLocation>,
+
+    /// Show all types of values in JSON format (not just objects and arrays).
+    #[clap(long, global = true)]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ConfigLocation {
+    Project,
+    Global,
+}
+
+#[derive(Debug, Args)]
+pub struct ConfigSetArgs {
+    pub key: Option<String>,
+    pub value: Option<String>,
+    #[clap(flatten)]
+    pub flags: ConfigFlags,
+}
+
+#[derive(Debug, Args)]
+pub struct ConfigGetArgs {
+    pub key: Option<String>,
+    #[clap(flatten)]
+    pub flags: ConfigFlags,
+}
+
+#[derive(Debug, Args)]
+pub struct ConfigDeleteArgs {
+    pub key: Option<String>,
+    #[clap(flatten)]
+    pub flags: ConfigFlags,
+}
+
+#[derive(Debug, Args)]
+pub struct ConfigListArgs {
+    #[clap(flatten)]
+    pub flags: ConfigFlags,
+}
+
+/// Errors raised by `pacquet config`, mirroring the `PnpmError` codes pnpm's
+/// config command raises (the `ERR_PNPM_` prefix is part of the public
+/// contract; see <https://pnpm.io/errors>).
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum ConfigError {
+    #[display("`pacquet config {subcommand}` requires the config key")]
+    #[diagnostic(code(ERR_PNPM_CONFIG_NO_PARAMS))]
+    NoParams { subcommand: String },
+
+    #[display("Cannot set {key} to a non-string value ({value})")]
+    #[diagnostic(code(ERR_PNPM_CONFIG_SET_AUTH_NON_STRING))]
+    SetAuthNonString { key: String, value: String },
+
+    #[display("Cannot set config with an empty key")]
+    #[diagnostic(code(ERR_PNPM_CONFIG_SET_EMPTY_KEY))]
+    SetEmptyKey,
+
+    #[display("Setting deep property path is not supported")]
+    #[diagnostic(code(ERR_PNPM_CONFIG_SET_DEEP_KEY))]
+    SetDeepKey,
+
+    #[display("Key {key:?} isn't supported by INI config files")]
+    #[diagnostic(
+        code(ERR_PNPM_CONFIG_SET_UNSUPPORTED_INI_CONFIG_KEY),
+        help("Add {camel:?} to the project workspace manifest instead")
+    )]
+    SetUnsupportedIniConfigKey { key: String, camel: String },
+
+    #[display("The key {key:?} isn't supported by the workspace manifest")]
+    #[diagnostic(code(ERR_PNPM_CONFIG_SET_UNSUPPORTED_WORKSPACE_KEY), help("Try {camel:?}"))]
+    SetUnsupportedWorkspaceKey { key: String, camel: String },
+
+    #[display("The key {key:?} isn't supported by the global config.yaml file")]
+    #[diagnostic(
+        code(ERR_PNPM_CONFIG_SET_UNSUPPORTED_YAML_CONFIG_KEY),
+        help("Try setting them instead to the local pnpm-workspace.yaml file")
+    )]
+    SetUnsupportedYamlConfigKey { key: String },
+
+    #[display("Invalid property path: {_0}")]
+    #[diagnostic(code(ERR_PNPM_CONFIG_INVALID_PROPERTY_PATH))]
+    InvalidPropertyPath(#[error(not(source))] property_path::ParsePropertyPathError),
+
+    #[display("Invalid JSON value: {_0}")]
+    #[diagnostic(code(ERR_PNPM_CONFIG_INVALID_JSON))]
+    InvalidJson(#[error(not(source))] serde_json::Error),
+
+    #[display("The global config directory could not be determined")]
+    #[diagnostic(code(ERR_PNPM_CONFIG_NO_GLOBAL_DIR))]
+    NoGlobalConfigDir,
+}
+
+impl ConfigArgs {
+    pub fn run(self, config: &Config, dir: &Path) -> miette::Result<()> {
+        match self.command {
+            ConfigSubcommand::Set(args) => {
+                let flags = args.flags;
+                let (key, value) = split_set_params(args.key, args.value, "set")?;
+                config_set(config, dir, flags, &key, Some(value))?;
+            }
+            ConfigSubcommand::Delete(args) => {
+                let key = args
+                    .key
+                    .filter(|key| !key.is_empty())
+                    .ok_or_else(|| ConfigError::NoParams { subcommand: "delete".to_string() })?;
+                config_set(config, dir, args.flags, &key, None)?;
+            }
+            ConfigSubcommand::Get(args) => {
+                let output = match args.key.as_deref().filter(|key| !key.is_empty()) {
+                    Some(key) => config_get(config, args.flags, key)?,
+                    None => config_list(config),
+                };
+                println!("{output}");
+            }
+            ConfigSubcommand::List(args) => {
+                let _ = args.flags;
+                println!("{}", config_list(config));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Resolve the effective `global` boolean from the `--location` / `--global`
+/// flags. Mirrors pnpm's handler: `--location` wins, otherwise config
+/// operations default to global.
+fn resolve_global(flags: ConfigFlags) -> bool {
+    match flags.location {
+        Some(ConfigLocation::Global) => true,
+        Some(ConfigLocation::Project) => false,
+        // No `--location`: pnpm defaults config operations to global when no
+        // explicit location was given (a bare `--global` lands here too).
+        None => true,
+    }
+}
+
+/// Split `pnpm config set <key> [value]` params, handling the `key=value` form
+/// when no separate value is given. Mirrors the `set` arm of pnpm's handler.
+fn split_set_params(
+    key: Option<String>,
+    value: Option<String>,
+    subcommand: &str,
+) -> Result<(String, String), ConfigError> {
+    let key = key
+        .filter(|key| !key.is_empty())
+        .ok_or_else(|| ConfigError::NoParams { subcommand: subcommand.to_string() })?;
+    match value {
+        Some(value) => Ok((key, value)),
+        None => {
+            // `key=value` form: the key is everything before the first `=`, the
+            // value everything after (so a value may itself contain `=`).
+            match key.split_once('=') {
+                Some((k, v)) => Ok((k.to_string(), v.to_string())),
+                None => Ok((key, String::new())),
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// config set / delete
+// ---------------------------------------------------------------------------
+
+/// `pnpm config set` (when `value` is `Some`) / `pnpm config delete` (when
+/// `value` is `None`). Port of `configSet`.
+fn config_set(
+    config: &Config,
+    dir: &Path,
+    flags: ConfigFlags,
+    key: &str,
+    value: Option<String>,
+) -> miette::Result<()> {
+    let global = resolve_global(flags);
+    let mut key = key.to_string();
+    let mut is_auth_setting = config_types::is_ini_config_key(&key);
+    if !is_auth_setting {
+        key = validate_simple_key(&key)?;
+        is_auth_setting = config_types::is_ini_config_key(&key);
+    }
+
+    // The cast/parsed value. `None` (delete) and JSON `null` both delete.
+    let value: Value = match value {
+        None => Value::Null,
+        Some(raw) if flags.json => serde_json::from_str(&raw).map_err(ConfigError::InvalidJson)?,
+        Some(raw) => Value::String(raw),
+    };
+
+    if is_auth_setting {
+        let config_path =
+            if global { global_config_dir(config)?.join("auth.ini") } else { dir.join(".npmrc") };
+        if !value.is_null() && !value.is_string() && is_string_only_ini_key(&key) {
+            return Err(ConfigError::SetAuthNonString { key, value: value.to_string() }.into());
+        }
+        return write_ini_setting(&config_path, &key, &value);
+    }
+
+    let (config_dir, config_file_name) = get_config_file_info(&key, global, config, dir)?;
+    let config_path = config_dir.join(config_file_name);
+
+    match config_file_name {
+        GLOBAL_CONFIG_YAML_FILENAME | WORKSPACE_MANIFEST_FILENAME => {
+            if config_file_name == GLOBAL_CONFIG_YAML_FILENAME {
+                key = validate_yaml_config_key(&key)?;
+            }
+            key = validate_workspace_key(&key)?;
+            let cast = cast_field(value, &naming_cases::to_kebab_case(&key));
+            update_manifest_field(&config_path, &key, &cast).map_err(miette::Report::new)?;
+        }
+        _ => {
+            // INI file reached via `getConfigFileInfo` (auth/scoped/registry key
+            // whose kebab-case form is an INI key). Validate against `types`.
+            key = validate_ini_config_key(&key)?;
+            write_ini_setting(&config_path, &key, &value)?;
+        }
+    }
+    Ok(())
+}
+
+/// Read the INI file, set or delete `key`, and write it back. A delete of an
+/// absent key is a no-op (no write). Mirrors the INI arms of `configSet`.
+fn write_ini_setting(config_path: &Path, key: &str, value: &Value) -> miette::Result<()> {
+    let mut settings = ini::read(config_path)
+        .map_err(miette::Report::msg)
+        .map_err(|err| err.wrap_err(format!("reading {}", config_path.display())))?;
+    if value.is_null() {
+        if settings.shift_remove(key).is_none() {
+            return Ok(());
+        }
+    } else {
+        settings.insert(key.to_string(), ini_value_string(value));
+    }
+    ini::write(config_path, &settings)
+        .map_err(miette::Report::msg)
+        .map_err(|err| err.wrap_err(format!("writing {}", config_path.display())))?;
+    Ok(())
+}
+
+/// Render a JSON value as its INI string form. Auth values are strings; the
+/// non-string forms (only reachable for keys that are not string-only) follow
+/// the `ini` package's scalar stringification.
+fn ini_value_string(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+/// `getConfigFileInfo`: route `key` to its config directory and file name.
+fn get_config_file_info<'a>(
+    key: &str,
+    global: bool,
+    config: &'a Config,
+    dir: &'a Path,
+) -> Result<(PathBuf, &'static str), ConfigError> {
+    let kebab = naming_cases::to_kebab_case(key);
+    let config_dir = if global { global_config_dir(config)? } else { dir.to_path_buf() };
+    let file_name = if config_types::is_ini_config_key(&kebab) {
+        if global { "auth.ini" } else { ".npmrc" }
+    } else if global {
+        GLOBAL_CONFIG_YAML_FILENAME
+    } else {
+        WORKSPACE_MANIFEST_FILENAME
+    };
+    Ok((config_dir, file_name))
+}
+
+fn global_config_dir(config: &Config) -> Result<PathBuf, ConfigError> {
+    config.config_dir.clone().ok_or(ConfigError::NoGlobalConfigDir)
+}
+
+/// `castField`: coerce a string value per its key's type. Booleans, `null`,
+/// and `undefined` literals are recognized; numeric-typed keys parse to a
+/// number; everything else is the trimmed string. Non-string values pass
+/// through unchanged. `undefined` maps to JSON `null` (a deletion downstream).
+fn cast_field(value: Value, kebab_key: &str) -> Value {
+    let Value::String(raw) = value else {
+        return value;
+    };
+    let trimmed = raw.trim();
+    match trimmed {
+        "true" => return Value::Bool(true),
+        "false" => return Value::Bool(false),
+        "null" | "undefined" => return Value::Null,
+        _ => {}
+    }
+    if config_types::type_includes_number(kebab_key)
+        && let Some(number) = parse_number(trimmed)
+    {
+        return Value::Number(number);
+    }
+    Value::String(trimmed.to_string())
+}
+
+/// Parse a trimmed numeric string into a JSON number (integer when whole),
+/// matching JS `Number(value)` for the integer/decimal config values pnpm
+/// accepts.
+fn parse_number(value: &str) -> Option<serde_json::Number> {
+    if let Ok(int) = value.parse::<i64>() {
+        return Some(int.into());
+    }
+    value.parse::<f64>().ok().and_then(serde_json::Number::from_f64)
+}
+
+/// `validateSimpleKey`: a strictly-kebab-case key passes through; otherwise the
+/// key must parse to a single property-path segment.
+fn validate_simple_key(key: &str) -> Result<String, ConfigError> {
+    if naming_cases::is_strictly_kebab_case(key) {
+        return Ok(key.to_string());
+    }
+    let segments =
+        property_path::parse_property_path(key).map_err(ConfigError::InvalidPropertyPath)?;
+    match segments.as_slice() {
+        [] => Err(ConfigError::SetEmptyKey),
+        [single] => Ok(segment_to_string(single)),
+        _ => Err(ConfigError::SetDeepKey),
+    }
+}
+
+fn segment_to_string(segment: &Segment) -> String {
+    match segment {
+        Segment::Key(key) => key.clone(),
+        Segment::Index(n) => format!("{}", *n as i64),
+    }
+}
+
+/// `validateWorkspaceKey`: a known `types` key becomes camelCase; otherwise it
+/// must already be camelCase.
+fn validate_workspace_key(key: &str) -> Result<String, ConfigError> {
+    if config_types::is_type_key(key) {
+        return Ok(naming_cases::to_camel_case(key));
+    }
+    if !naming_cases::is_camel_case(key) {
+        return Err(ConfigError::SetUnsupportedWorkspaceKey {
+            key: key.to_string(),
+            camel: naming_cases::to_camel_case(key),
+        });
+    }
+    Ok(key.to_string())
+}
+
+/// `validateIniConfigKey`: the kebab-case key must be a known `types` key.
+fn validate_ini_config_key(key: &str) -> Result<String, ConfigError> {
+    let kebab = naming_cases::to_kebab_case(key);
+    if config_types::is_type_key(&kebab) {
+        return Ok(kebab);
+    }
+    Err(ConfigError::SetUnsupportedIniConfigKey {
+        key: key.to_string(),
+        camel: naming_cases::to_camel_case(key),
+    })
+}
+
+/// `validateYamlConfigKey`: the kebab-case key must be valid in the global
+/// `config.yaml`.
+fn validate_yaml_config_key(key: &str) -> Result<String, ConfigError> {
+    let kebab = naming_cases::to_kebab_case(key);
+    if config_types::is_config_file_key(&kebab) {
+        return Ok(kebab);
+    }
+    Err(ConfigError::SetUnsupportedYamlConfigKey { key: key.to_string() })
+}
+
+const STRING_ONLY_INI_KEYS: &[&str] = &["_auth", "_authToken", "_password", "username", "registry"];
+
+fn is_string_only_ini_key(key: &str) -> bool {
+    STRING_ONLY_INI_KEYS.contains(&key) || key.starts_with('@') || key.starts_with("//")
+}
+
+// ---------------------------------------------------------------------------
+// config get / list
+// ---------------------------------------------------------------------------
+
+/// `configGet`: resolve and render the value at `key`. Port of `configGet`.
+fn config_get(config: &Config, flags: ConfigFlags, key: &str) -> Result<String, ConfigError> {
+    let is_scoped = key.starts_with('@');
+    let value = match lookup_config(config, key, is_scoped) {
+        Some(value) => value,
+        None if is_property_path(key) => lookup_by_property_path(config, key)?,
+        None => Value::Null,
+    };
+    Ok(display_config(&value, flags.json))
+}
+
+/// `configList`: the full config record as pretty JSON. Port of `configList`.
+fn config_list(config: &Config) -> String {
+    serde_json::to_string_pretty(&Value::Object(config_to_record(config)))
+        .expect("serializing the config record to JSON never fails")
+}
+
+/// `lookupConfig`: resolve `key` against scoped registries, `globalconfig`,
+/// the typed settings, the raw auth keys, or the config record. `None` means
+/// "not found, fall through to a property-path lookup".
+fn lookup_config(config: &Config, key: &str, is_scoped: bool) -> Option<Value> {
+    if is_scoped {
+        if let Some(scope) = key.strip_suffix(":registry") {
+            // Prefer the merged `registries` map so this reports the same URL
+            // resolvers/publish use (pnpm/pnpm#11492).
+            if let Some(merged) = config.registries.get(scope) {
+                return Some(Value::String(merged.clone()));
+            }
+        }
+        return Some(auth_value(config, key));
+    }
+    if key == "globalconfig" {
+        let path = config
+            .config_dir
+            .as_ref()
+            .map(|dir| dir.join(GLOBAL_CONFIG_YAML_FILENAME).to_string_lossy().into_owned())
+            .unwrap_or_default();
+        return Some(Value::String(path));
+    }
+    let kebab = if naming_cases::is_camel_case(key) {
+        naming_cases::to_kebab_case(key)
+    } else {
+        key.to_string()
+    };
+    if config_types::is_type_key(&kebab) {
+        let camel = naming_cases::to_camel_case(&kebab);
+        if let Some(value) = config.explicit_settings.get(&camel) {
+            return Some(value.clone());
+        }
+        if let Some(value) = config.raw_auth_config.get(&kebab) {
+            return Some(Value::String(value.clone()));
+        }
+        return Some(Value::Null);
+    }
+    if config_types::is_ini_config_key(key) {
+        return Some(auth_value(config, key));
+    }
+    // Not in `types` (e.g. packageExtensions): look it up in the record, which
+    // excludes internal/sensitive fields.
+    let camel = naming_cases::to_camel_case(key);
+    let record = config_to_record(config);
+    record.get(&camel).cloned()
+}
+
+fn auth_value(config: &Config, key: &str) -> Value {
+    config.raw_auth_config.get(key).map_or(Value::Null, |value| Value::String(value.clone()))
+}
+
+/// `lookupByPropertyPath`: resolve a (possibly nested) property path against the
+/// config record. An empty path returns the whole record.
+fn lookup_by_property_path(config: &Config, property_path: &str) -> Result<Value, ConfigError> {
+    let segments = parse_config_property_path(property_path)?;
+    let record = Value::Object(config_to_record(config));
+    if segments.is_empty() {
+        return Ok(record);
+    }
+    Ok(property_path::get_object_value_by_property_path(&record, &segments)
+        .cloned()
+        .unwrap_or(Value::Null))
+}
+
+/// `parseConfigPropertyPath`: like `parsePropertyPath` but with the first
+/// string segment camelCased to match the record's camelCase keys.
+fn parse_config_property_path(property_path: &str) -> Result<Vec<Segment>, ConfigError> {
+    let mut segments = property_path::parse_property_path(property_path)
+        .map_err(ConfigError::InvalidPropertyPath)?;
+    if let Some(Segment::Key(first)) = segments.first_mut() {
+        *first = naming_cases::to_camel_case(first);
+    }
+    Ok(segments)
+}
+
+fn is_property_path(key: &str) -> bool {
+    key.is_empty() || key.contains('.') || key.contains('[')
+}
+
+/// `displayConfig`: JSON for objects/arrays (and always under `--json`), the
+/// plain string form otherwise.
+fn display_config(value: &Value, json: bool) -> String {
+    if json || value.is_array() || value.is_object() {
+        serde_json::to_string_pretty(value).expect("serializing a config value to JSON never fails")
+    } else {
+        plain_string(value)
+    }
+}
+
+/// The `String(value)` rendering pnpm uses for a non-object scalar.
+fn plain_string(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        // pacquet represents both "undefined" and JSON null as `Null`; the
+        // command only ever produces it for an unset key, which pnpm renders
+        // as `String(undefined)`.
+        Value::Null => "undefined".to_string(),
+        Value::Array(_) | Value::Object(_) => value.to_string(),
+    }
+}
+
+/// `configToRecord`: build the camelCase record shown by `list` / `get` — the
+/// explicitly-set settings, then the raw auth keys (original casing), then
+/// `userAgent` — sorted by key and with protected settings censored.
+fn config_to_record(config: &Config) -> Map<String, Value> {
+    let mut result: Map<String, Value> = Map::new();
+    for (key, value) in &config.explicit_settings {
+        result.insert(key.clone(), value.clone());
+    }
+    for (key, value) in &config.raw_auth_config {
+        result.entry(key.clone()).or_insert_with(|| Value::String(value.clone()));
+    }
+    if !config.user_agent.is_empty() {
+        result.insert("userAgent".to_string(), Value::String(config.user_agent.clone()));
+    }
+
+    // sortDirectKeys: order the top-level keys lexicographically.
+    let mut sorted: IndexMap<String, Value> = result.into_iter().collect();
+    sorted.sort_keys();
+    let mut censored: Map<String, Value> = sorted.into_iter().collect();
+    protected_settings::censor_protected_settings(&mut censored);
+    censored
+}

--- a/pacquet/crates/cli/src/cli_args/config.rs
+++ b/pacquet/crates/cli/src/cli_args/config.rs
@@ -152,6 +152,12 @@ pub enum ConfigError {
     #[display("The global config directory could not be determined")]
     #[diagnostic(code(ERR_PNPM_CONFIG_NO_GLOBAL_DIR))]
     NoGlobalConfigDir,
+
+    #[display(
+        "Cannot write {value:?} to an INI config file: it contains a control character that would corrupt the file"
+    )]
+    #[diagnostic(code(pacquet_cli::config_set_invalid_control_character))]
+    SetIniControlCharacter { value: String },
 }
 
 impl ConfigArgs {
@@ -291,12 +297,26 @@ fn write_ini_setting(config_path: &Path, key: &str, value: &Value) -> miette::Re
             return Ok(());
         }
     } else {
-        settings.insert(key.to_string(), ini_value_string(value));
+        let value_string = ini_value_string(value);
+        // A control character (notably a newline) in the value would split into
+        // extra `key=value` lines when the INI file is re-parsed, injecting
+        // settings the user never set. Refuse rather than corrupt the file.
+        if has_control_char(key) || has_control_char(&value_string) {
+            return Err(ConfigError::SetIniControlCharacter { value: value_string }.into());
+        }
+        settings.insert(key.to_string(), value_string);
     }
     ini::write(config_path, &settings)
         .map_err(miette::Report::msg)
         .map_err(|err| err.wrap_err(format!("writing {}", config_path.display())))?;
     Ok(())
+}
+
+/// Whether `text` holds a control character. The INI writer splices `text`
+/// into a single `key=value` line, so a control character would corrupt the
+/// file; the values `config set` writes never legitimately contain one.
+fn has_control_char(text: &str) -> bool {
+    text.chars().any(char::is_control)
 }
 
 /// Render a JSON value as its INI string form. Auth values are strings; the

--- a/pacquet/crates/cli/src/cli_args/config.rs
+++ b/pacquet/crates/cli/src/cli_args/config.rs
@@ -153,11 +153,11 @@ pub enum ConfigError {
     #[diagnostic(code(ERR_PNPM_CONFIG_NO_GLOBAL_DIR))]
     NoGlobalConfigDir,
 
-    #[display(
-        "Cannot write {value:?} to an INI config file: it contains a control character that would corrupt the file"
-    )]
+    // The rejected value is deliberately not echoed — it may be a credential
+    // (e.g. a token with a stray newline pasted from an env var).
+    #[display("Cannot write a value containing a control character to an INI config file")]
     #[diagnostic(code(pacquet_cli::config_set_invalid_control_character))]
-    SetIniControlCharacter { value: String },
+    SetIniControlCharacter,
 }
 
 impl ConfigArgs {
@@ -302,7 +302,7 @@ fn write_ini_setting(config_path: &Path, key: &str, value: &Value) -> miette::Re
         // extra `key=value` lines when the INI file is re-parsed, injecting
         // settings the user never set. Refuse rather than corrupt the file.
         if has_control_char(key) || has_control_char(&value_string) {
-            return Err(ConfigError::SetIniControlCharacter { value: value_string }.into());
+            return Err(ConfigError::SetIniControlCharacter.into());
         }
         settings.insert(key.to_string(), value_string);
     }

--- a/pacquet/crates/cli/src/cli_args/config/ini.rs
+++ b/pacquet/crates/cli/src/cli_args/config/ini.rs
@@ -59,12 +59,19 @@ pub fn write(path: &Path, settings: &IndexMap<String, String>) -> io::Result<()>
     tmp.write_all(contents.as_bytes())?;
     tmp.as_file().sync_all()?;
     // `NamedTempFile` creates with mode 0600 on Unix; persisting it over an
-    // existing file would silently tighten that file's permissions. Carry the
-    // target's existing mode across the rename so rewriting a project `.npmrc`
-    // preserves it (pnpm's `write-ini-file` keeps the target's mode too). New
-    // files keep the conservative 0600 default — they may hold credentials.
+    // existing regular file would silently tighten that file's permissions, so
+    // carry the target's mode across the rename to preserve it (pnpm's
+    // `write-ini-file` keeps the target's mode too). New files keep the
+    // conservative 0600 default — they may hold credentials.
+    //
+    // `symlink_metadata` (not `metadata`) so a symlinked target is detected
+    // rather than followed: the rename replaces the symlink with a fresh
+    // regular file, and copying the link target's (possibly 0644) mode would
+    // loosen permissions on freshly written credentials. A symlink keeps 0600.
     #[cfg(unix)]
-    if let Ok(metadata) = fs::metadata(path) {
+    if let Ok(metadata) = fs::symlink_metadata(path)
+        && !metadata.file_type().is_symlink()
+    {
         use std::os::unix::fs::PermissionsExt as _;
         let mode = metadata.permissions().mode();
         tmp.as_file().set_permissions(std::fs::Permissions::from_mode(mode))?;

--- a/pacquet/crates/cli/src/cli_args/config/ini.rs
+++ b/pacquet/crates/cli/src/cli_args/config/ini.rs
@@ -1,0 +1,63 @@
+//! Minimal flat-key INI read/modify/write for `.npmrc` and `auth.ini`.
+//!
+//! `pnpm config` reads and writes these files through the `ini` npm package
+//! (`read-ini-file` / `write-ini-file`). The config keys it touches are flat
+//! `key=value` pairs (`registry`, `@scope:registry`, `//host/:_authToken`,
+//! `cafile`, ...) — no sections, no arrays — so this reproduces just that
+//! subset: a missing file reads as empty, comments (`;` / `#`) and blank lines
+//! are ignored, and the map round-trips as `key=value` lines.
+
+use indexmap::IndexMap;
+use std::{
+    fs,
+    io::{self, Write as _},
+    path::Path,
+};
+
+/// Read `path` into an ordered key→value map. A missing file is an empty map;
+/// any other read error propagates.
+pub fn read(path: &Path) -> io::Result<IndexMap<String, String>> {
+    match fs::read_to_string(path) {
+        Ok(text) => Ok(parse(&text)),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(IndexMap::new()),
+        Err(err) => Err(err),
+    }
+}
+
+fn parse(text: &str) -> IndexMap<String, String> {
+    let mut map = IndexMap::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with(';') || line.starts_with('#') {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once('=') {
+            map.insert(key.trim().to_string(), value.trim().to_string());
+        }
+    }
+    map
+}
+
+/// Write `settings` to `path` as `key=value` lines, creating parent
+/// directories and replacing the file atomically (temp file + rename).
+pub fn write(path: &Path, settings: &IndexMap<String, String>) -> io::Result<()> {
+    let mut contents = String::new();
+    for (key, value) in settings {
+        contents.push_str(key);
+        contents.push('=');
+        contents.push_str(value);
+        contents.push('\n');
+    }
+    if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+        fs::create_dir_all(parent)?;
+    }
+    let dir = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+    tmp.write_all(contents.as_bytes())?;
+    tmp.as_file().sync_all()?;
+    tmp.persist(path).map_err(|err| err.error)?;
+    Ok(())
+}

--- a/pacquet/crates/cli/src/cli_args/config/ini.rs
+++ b/pacquet/crates/cli/src/cli_args/config/ini.rs
@@ -58,6 +58,17 @@ pub fn write(path: &Path, settings: &IndexMap<String, String>) -> io::Result<()>
     let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
     tmp.write_all(contents.as_bytes())?;
     tmp.as_file().sync_all()?;
+    // `NamedTempFile` creates with mode 0600 on Unix; persisting it over an
+    // existing file would silently tighten that file's permissions. Carry the
+    // target's existing mode across the rename so rewriting a project `.npmrc`
+    // preserves it (pnpm's `write-ini-file` keeps the target's mode too). New
+    // files keep the conservative 0600 default — they may hold credentials.
+    #[cfg(unix)]
+    if let Ok(metadata) = fs::metadata(path) {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mode = metadata.permissions().mode();
+        tmp.as_file().set_permissions(std::fs::Permissions::from_mode(mode))?;
+    }
     tmp.persist(path).map_err(|err| err.error)?;
     Ok(())
 }

--- a/pacquet/crates/cli/src/cli_args/config/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/config/tests.rs
@@ -522,3 +522,51 @@ fn list_includes_settings_and_censors_protected() {
     let got_value: Value = serde_json::from_str(&got).unwrap();
     assert_eq!(got_value["storeDir"], json!("~/store"));
 }
+
+// --- security hardening for the INI write path -----------------------------
+
+#[test]
+fn set_ini_value_with_control_char_is_rejected() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_with_dir(&tmp.path().join("global-config"));
+
+    let err = config_set(
+        &config,
+        tmp.path(),
+        flags(false, Some(ConfigLocation::Project), false),
+        "//registry.example.com/:_authToken",
+        Some("token\ninjected=evil".to_string()),
+    )
+    .unwrap_err();
+
+    assert_eq!(
+        err.code().unwrap().to_string(),
+        "pacquet_cli::config_set_invalid_control_character",
+    );
+    // The file must not have been written.
+    assert!(!tmp.path().join(".npmrc").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn set_preserves_existing_npmrc_mode() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let tmp = TempDir::new().unwrap();
+    let npmrc = tmp.path().join(".npmrc");
+    std::fs::write(&npmrc, "@local:registry=https://localhost/\n").unwrap();
+    std::fs::set_permissions(&npmrc, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+    let config = config_with_dir(&tmp.path().join("global-config"));
+    config_set(
+        &config,
+        tmp.path(),
+        flags(false, Some(ConfigLocation::Project), false),
+        "registry",
+        Some("https://example.com/".to_string()),
+    )
+    .unwrap();
+
+    let mode = std::fs::metadata(&npmrc).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o644, "existing .npmrc mode must be preserved, got {mode:o}");
+}

--- a/pacquet/crates/cli/src/cli_args/config/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/config/tests.rs
@@ -1,0 +1,524 @@
+//! Ports of pnpm's `config` command tests
+//! ([source](https://github.com/pnpm/pnpm/blob/8eb1be4988/config/commands/test/)).
+//!
+//! pnpm's tests inject a `_config` / `_context`; pacquet builds a [`Config`]
+//! and sets the public fields the command reads ([`Config::config_dir`],
+//! [`Config::explicit_settings`], [`Config::raw_auth_config`]) — the same
+//! injection, expressed against pacquet's loaded-config shape.
+
+use super::{ConfigFlags, ConfigLocation, config_get, config_list, config_set, ini};
+use indexmap::IndexMap;
+use pacquet_config::Config;
+use serde_json::{Value, json};
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn config_with_dir(config_dir: &Path) -> Config {
+    Config { config_dir: Some(config_dir.to_path_buf()), ..Config::default() }
+}
+
+fn flags(global: bool, location: Option<ConfigLocation>, json: bool) -> ConfigFlags {
+    ConfigFlags { global, location, json }
+}
+
+fn read_yaml(path: &Path) -> Option<Value> {
+    let text = std::fs::read_to_string(path).ok()?;
+    Some(serde_saphyr::from_str(&text).expect("parse yaml"))
+}
+
+fn read_ini(path: &Path) -> IndexMap<String, String> {
+    ini::read(path).expect("read ini")
+}
+
+// --- config set: INI routing -----------------------------------------------
+
+#[test]
+fn set_registry_global_writes_auth_ini() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("global-config");
+    let config = config_with_dir(&config_dir);
+
+    config_set(
+        &config,
+        tmp.path(),
+        flags(true, None, false),
+        "registry",
+        Some("https://npm-registry.example.com/".to_string()),
+    )
+    .unwrap();
+
+    let ini = read_ini(&config_dir.join("auth.ini"));
+    assert_eq!(ini.get("registry").map(String::as_str), Some("https://npm-registry.example.com/"));
+}
+
+#[test]
+fn set_cafile_global_writes_auth_ini() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("global-config");
+    let config = config_with_dir(&config_dir);
+
+    config_set(&config, tmp.path(), flags(true, None, false), "cafile", Some("some-cafile".into()))
+        .unwrap();
+
+    assert_eq!(
+        read_ini(&config_dir.join("auth.ini")).get("cafile").map(String::as_str),
+        Some("some-cafile")
+    );
+}
+
+#[test]
+fn set_scoped_registry_project_creates_npmrc() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_with_dir(&tmp.path().join("global-config"));
+
+    config_set(
+        &config,
+        tmp.path(),
+        flags(false, Some(ConfigLocation::Project), false),
+        "@myorg:registry",
+        Some("https://test-registry.example.com/".to_string()),
+    )
+    .unwrap();
+
+    assert_eq!(
+        read_ini(&tmp.path().join(".npmrc")).get("@myorg:registry").map(String::as_str),
+        Some("https://test-registry.example.com/")
+    );
+    assert!(!tmp.path().join("pnpm-workspace.yaml").exists());
+}
+
+#[test]
+fn set_per_registry_auth_project_creates_npmrc() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_with_dir(&tmp.path().join("global-config"));
+
+    config_set(
+        &config,
+        tmp.path(),
+        flags(false, Some(ConfigLocation::Project), false),
+        "//registry.example.com/:_auth",
+        Some("test-auth-value".to_string()),
+    )
+    .unwrap();
+
+    assert_eq!(
+        read_ini(&tmp.path().join(".npmrc"))
+            .get("//registry.example.com/:_auth")
+            .map(String::as_str),
+        Some("test-auth-value")
+    );
+}
+
+// --- config set: YAML routing ----------------------------------------------
+
+#[test]
+fn set_pnpm_key_global_writes_config_yaml_as_number() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("global-config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let config = config_with_dir(&config_dir);
+
+    config_set(&config, tmp.path(), flags(true, None, false), "fetch-retries", Some("1".into()))
+        .unwrap();
+
+    assert_eq!(read_yaml(&config_dir.join("config.yaml")).unwrap(), json!({ "fetchRetries": 1 }));
+}
+
+#[test]
+fn set_camel_key_location_global() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("global-config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let config = config_with_dir(&config_dir);
+
+    config_set(
+        &config,
+        tmp.path(),
+        flags(false, Some(ConfigLocation::Global), false),
+        "fetchRetries",
+        Some("1".into()),
+    )
+    .unwrap();
+
+    assert_eq!(read_yaml(&config_dir.join("config.yaml")).unwrap(), json!({ "fetchRetries": 1 }));
+}
+
+#[test]
+fn set_pnpm_key_project_writes_workspace_yaml() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_with_dir(&tmp.path().join("global-config"));
+
+    config_set(
+        &config,
+        tmp.path(),
+        flags(false, Some(ConfigLocation::Project), false),
+        "virtual-store-dir",
+        Some(".pnpm".into()),
+    )
+    .unwrap();
+
+    assert_eq!(
+        read_yaml(&tmp.path().join("pnpm-workspace.yaml")).unwrap(),
+        json!({ "virtualStoreDir": ".pnpm" })
+    );
+}
+
+#[test]
+fn set_global_https_proxy_writes_config_yaml_not_auth_ini() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("global-config");
+    let config = config_with_dir(&config_dir);
+
+    config_set(
+        &config,
+        tmp.path(),
+        flags(true, None, false),
+        "https-proxy",
+        Some("http://proxy.example.com:8443".into()),
+    )
+    .unwrap();
+
+    assert_eq!(
+        read_yaml(&config_dir.join("config.yaml")).unwrap(),
+        json!({ "httpsProxy": "http://proxy.example.com:8443" })
+    );
+    assert!(!config_dir.join("auth.ini").exists());
+}
+
+#[test]
+fn set_key_equals_value_form() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_with_dir(&tmp.path().join("global-config"));
+
+    // value with an embedded `=` keeps everything after the first `=`.
+    super::split_set_params(Some("lockfile-dir=foo=bar".into()), None, "set")
+        .map(|(k, v)| {
+            config_set(
+                &config,
+                tmp.path(),
+                flags(false, Some(ConfigLocation::Project), false),
+                &k,
+                Some(v),
+            )
+        })
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        read_yaml(&tmp.path().join("pnpm-workspace.yaml")).unwrap(),
+        json!({ "lockfileDir": "foo=bar" })
+    );
+}
+
+#[test]
+fn set_dot_leading_and_subscripted_keys() {
+    for key in [".fetchRetries", "[\"fetch-retries\"]"] {
+        let tmp = TempDir::new().unwrap();
+        let config_dir = tmp.path().join("global-config");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let config = config_with_dir(&config_dir);
+
+        config_set(&config, tmp.path(), flags(true, None, false), key, Some("1".into())).unwrap();
+
+        assert_eq!(
+            read_yaml(&config_dir.join("config.yaml")).unwrap(),
+            json!({ "fetchRetries": 1 }),
+            "key {key}"
+        );
+    }
+}
+
+#[test]
+fn set_object_value_with_json_writes_workspace_yaml() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_with_dir(&tmp.path().join("global-config"));
+
+    let extensions = json!({
+        "@babel/parser": { "peerDependencies": { "@babel/types": "*" } },
+        "jest-circus": { "dependencies": { "slash": "3" } },
+    });
+    config_set(
+        &config,
+        tmp.path(),
+        flags(false, Some(ConfigLocation::Project), true),
+        "packageExtensions",
+        Some(extensions.to_string()),
+    )
+    .unwrap();
+
+    assert_eq!(
+        read_yaml(&tmp.path().join("pnpm-workspace.yaml")).unwrap(),
+        json!({ "packageExtensions": extensions })
+    );
+}
+
+// --- config set: validation errors -----------------------------------------
+
+#[test]
+fn set_rejects_deep_property_path() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_with_dir(&tmp.path().join("global-config"));
+    let err = config_set(
+        &config,
+        tmp.path(),
+        flags(true, None, false),
+        ".catalog.react",
+        Some("19".into()),
+    )
+    .unwrap_err();
+    assert_eq!(err.code().unwrap().to_string(), "ERR_PNPM_CONFIG_SET_DEEP_KEY");
+}
+
+#[test]
+fn set_refuses_workspace_key_in_global_config() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("global-config");
+    let config = config_with_dir(&config_dir);
+    let err = config_set(
+        &config,
+        tmp.path(),
+        flags(false, Some(ConfigLocation::Global), true),
+        "catalog",
+        Some(r#"{"react":"19"}"#.into()),
+    )
+    .unwrap_err();
+    assert_eq!(err.code().unwrap().to_string(), "ERR_PNPM_CONFIG_SET_UNSUPPORTED_YAML_CONFIG_KEY");
+}
+
+#[test]
+fn set_refuses_kebab_workspace_key() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_with_dir(&tmp.path().join("global-config"));
+    let err = config_set(
+        &config,
+        tmp.path(),
+        flags(false, Some(ConfigLocation::Project), true),
+        "package-extensions",
+        Some("{}".into()),
+    )
+    .unwrap_err();
+    assert_eq!(err.code().unwrap().to_string(), "ERR_PNPM_CONFIG_SET_UNSUPPORTED_WORKSPACE_KEY");
+}
+
+// --- config delete ---------------------------------------------------------
+
+#[test]
+fn delete_last_yaml_key_removes_file() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_with_dir(&tmp.path().join("global-config"));
+
+    config_set(
+        &config,
+        tmp.path(),
+        flags(false, Some(ConfigLocation::Project), false),
+        "virtual-store-dir",
+        Some(".pnpm".into()),
+    )
+    .unwrap();
+    assert!(tmp.path().join("pnpm-workspace.yaml").exists());
+
+    config_set(
+        &config,
+        tmp.path(),
+        flags(false, Some(ConfigLocation::Project), false),
+        "virtual-store-dir",
+        None,
+    )
+    .unwrap();
+    assert!(!tmp.path().join("pnpm-workspace.yaml").exists());
+}
+
+#[test]
+fn delete_auth_key_set_and_unset() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("global-config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let config = config_with_dir(&config_dir);
+
+    // set, not present → file untouched (no registry key)
+    std::fs::write(
+        config_dir.join("auth.ini"),
+        "@my-company:registry=https://registry.my-company.example.com/\n",
+    )
+    .unwrap();
+    config_set(&config, tmp.path(), flags(true, None, false), "registry", None).unwrap();
+    assert_eq!(
+        read_ini(&config_dir.join("auth.ini")).get("@my-company:registry").map(String::as_str),
+        Some("https://registry.my-company.example.com/")
+    );
+
+    // set present → removed
+    std::fs::write(
+        config_dir.join("auth.ini"),
+        "registry=https://registry.my-company.example.com/\n",
+    )
+    .unwrap();
+    config_set(&config, tmp.path(), flags(true, None, false), "registry", None).unwrap();
+    assert!(read_ini(&config_dir.join("auth.ini")).is_empty());
+}
+
+#[test]
+fn delete_missing_params_errors() {
+    // No key → NoParams. Exercised through the param-splitting shape the
+    // dispatch uses.
+    let (key, value) = (None::<String>, None::<String>);
+    let err = super::split_set_params(key, value, "set").unwrap_err();
+    assert_eq!(miette::Diagnostic::code(&err).unwrap().to_string(), "ERR_PNPM_CONFIG_NO_PARAMS");
+}
+
+// --- config get / list -----------------------------------------------------
+
+fn config_for_get(explicit: &[(&str, Value)], auth: &[(&str, &str)]) -> Config {
+    let mut config = Config { config_dir: Some(PathBuf::from("/config")), ..Config::default() };
+    for (key, value) in explicit {
+        config.explicit_settings.insert((*key).to_string(), value.clone());
+    }
+    for (key, value) in auth {
+        config.raw_auth_config.insert((*key).to_string(), (*value).to_string());
+    }
+    config
+}
+
+#[test]
+fn get_scalar_string_and_camel() {
+    let config = config_for_get(&[("storeDir", json!("~/store"))], &[]);
+    assert_eq!(config_get(&config, flags(true, None, false), "store-dir").unwrap(), "~/store");
+    assert_eq!(config_get(&config, flags(true, None, false), "storeDir").unwrap(), "~/store");
+}
+
+#[test]
+fn get_boolean_and_array_and_object() {
+    let config = config_for_get(
+        &[
+            ("updateNotifier", json!(true)),
+            ("publicHoistPattern", json!(["*eslint*", "*prettier*"])),
+            ("packageExtensions", json!({ "a": { "dependencies": { "b": "1" } } })),
+        ],
+        &[],
+    );
+    assert_eq!(config_get(&config, flags(true, None, false), "update-notifier").unwrap(), "true");
+    assert_eq!(
+        serde_json::from_str::<Value>(
+            &config_get(&config, flags(true, None, false), "public-hoist-pattern").unwrap()
+        )
+        .unwrap(),
+        json!(["*eslint*", "*prettier*"])
+    );
+    assert_eq!(
+        serde_json::from_str::<Value>(
+            &config_get(&config, flags(true, None, false), "package-extensions").unwrap()
+        )
+        .unwrap(),
+        json!({ "a": { "dependencies": { "b": "1" } } })
+    );
+}
+
+#[test]
+fn get_unknown_key_is_undefined() {
+    let config = config_for_get(&[], &[]);
+    assert_eq!(
+        config_get(&config, flags(true, None, false), "no-such-setting").unwrap(),
+        "undefined"
+    );
+    // prototype-chain names must not resolve
+    for key in ["constructor", "__proto__", "hasOwnProperty"] {
+        assert_eq!(
+            config_get(&config, flags(true, None, false), key).unwrap(),
+            "undefined",
+            "{key}"
+        );
+    }
+}
+
+#[test]
+fn get_scoped_registry_from_auth_and_merged() {
+    let from_auth =
+        config_for_get(&[], &[("@scope:registry", "https://custom-registry.example.com/")]);
+    assert_eq!(
+        config_get(&from_auth, flags(false, None, false), "@scope:registry").unwrap(),
+        "https://custom-registry.example.com/"
+    );
+
+    // merged `registries` block wins over the raw .npmrc value (pnpm/pnpm#11492)
+    let mut merged = config_for_get(&[], &[("@scope:registry", "https://from-npmrc.example.com/")]);
+    merged
+        .registries
+        .insert("@scope".to_string(), "https://from-workspace-yaml.example.com/".to_string());
+    assert_eq!(
+        config_get(&merged, flags(false, None, false), "@scope:registry").unwrap(),
+        "https://from-workspace-yaml.example.com/"
+    );
+
+    let absent = config_for_get(&[], &[]);
+    assert_eq!(
+        config_get(&absent, flags(false, None, false), "@scope:registry").unwrap(),
+        "undefined"
+    );
+}
+
+#[test]
+fn get_globalconfig_path() {
+    let config = config_for_get(&[], &[]);
+    assert_eq!(
+        config_get(&config, flags(true, None, false), "globalconfig").unwrap(),
+        Path::new("/config").join("config.yaml").to_string_lossy()
+    );
+}
+
+#[test]
+fn get_property_path_into_object() {
+    let config = config_for_get(
+        &[
+            ("trustPolicyExclude", json!(["foo", "bar"])),
+            (
+                "packageExtensions",
+                json!({ "@babel/parser": { "peerDependencies": { "@babel/types": "*" } } }),
+            ),
+        ],
+        &[],
+    );
+    assert_eq!(
+        config_get(&config, flags(false, None, false), "trustPolicyExclude[0]").unwrap(),
+        "foo"
+    );
+    assert_eq!(
+        config_get(
+            &config,
+            flags(false, None, false),
+            r#"packageExtensions["@babel/parser"].peerDependencies["@babel/types"]"#
+        )
+        .unwrap(),
+        "*"
+    );
+    assert_eq!(
+        serde_json::from_str::<Value>(
+            &config_get(&config, flags(false, None, false), "package-extensions").unwrap()
+        )
+        .unwrap(),
+        json!({ "@babel/parser": { "peerDependencies": { "@babel/types": "*" } } })
+    );
+}
+
+#[test]
+fn list_includes_settings_and_censors_protected() {
+    let config = config_for_get(
+        &[("storeDir", json!("~/store")), ("fetchRetries", json!(2))],
+        &[
+            ("username", "general-username"),
+            ("@my-org:registry", "https://my-org.example.com/registry"),
+            ("//my-org.example.com:username", "my-username-in-my-org"),
+        ],
+    );
+    let listed: Value = serde_json::from_str(&config_list(&config)).unwrap();
+    assert_eq!(listed["storeDir"], json!("~/store"));
+    assert_eq!(listed["fetchRetries"], json!(2));
+    assert_eq!(listed["@my-org:registry"], json!("https://my-org.example.com/registry"));
+    assert_eq!(listed["username"], json!("(protected)"));
+    assert_eq!(listed["//my-org.example.com:username"], json!("(protected)"));
+
+    // `get` with no key equals `list`.
+    let got = config_get(&config, flags(false, None, false), "").unwrap();
+    // empty key is a property path → whole record
+    let got_value: Value = serde_json::from_str(&got).unwrap();
+    assert_eq!(got_value["storeDir"], json!("~/store"));
+}

--- a/pacquet/crates/cli/src/cli_args/config/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/config/tests.rs
@@ -62,7 +62,7 @@ fn set_cafile_global_writes_auth_ini() {
 
     assert_eq!(
         read_ini(&config_dir.join("auth.ini")).get("cafile").map(String::as_str),
-        Some("some-cafile")
+        Some("some-cafile"),
     );
 }
 
@@ -82,7 +82,7 @@ fn set_scoped_registry_project_creates_npmrc() {
 
     assert_eq!(
         read_ini(&tmp.path().join(".npmrc")).get("@myorg:registry").map(String::as_str),
-        Some("https://test-registry.example.com/")
+        Some("https://test-registry.example.com/"),
     );
     assert!(!tmp.path().join("pnpm-workspace.yaml").exists());
 }
@@ -105,7 +105,7 @@ fn set_per_registry_auth_project_creates_npmrc() {
         read_ini(&tmp.path().join(".npmrc"))
             .get("//registry.example.com/:_auth")
             .map(String::as_str),
-        Some("test-auth-value")
+        Some("test-auth-value"),
     );
 }
 
@@ -159,7 +159,7 @@ fn set_pnpm_key_project_writes_workspace_yaml() {
 
     assert_eq!(
         read_yaml(&tmp.path().join("pnpm-workspace.yaml")).unwrap(),
-        json!({ "virtualStoreDir": ".pnpm" })
+        json!({ "virtualStoreDir": ".pnpm" }),
     );
 }
 
@@ -180,7 +180,7 @@ fn set_global_https_proxy_writes_config_yaml_not_auth_ini() {
 
     assert_eq!(
         read_yaml(&config_dir.join("config.yaml")).unwrap(),
-        json!({ "httpsProxy": "http://proxy.example.com:8443" })
+        json!({ "httpsProxy": "http://proxy.example.com:8443" }),
     );
     assert!(!config_dir.join("auth.ini").exists());
 }
@@ -206,13 +206,13 @@ fn set_key_equals_value_form() {
 
     assert_eq!(
         read_yaml(&tmp.path().join("pnpm-workspace.yaml")).unwrap(),
-        json!({ "lockfileDir": "foo=bar" })
+        json!({ "lockfileDir": "foo=bar" }),
     );
 }
 
 #[test]
 fn set_dot_leading_and_subscripted_keys() {
-    for key in [".fetchRetries", "[\"fetch-retries\"]"] {
+    for key in [".fetchRetries", r#"["fetch-retries"]"#] {
         let tmp = TempDir::new().unwrap();
         let config_dir = tmp.path().join("global-config");
         std::fs::create_dir_all(&config_dir).unwrap();
@@ -223,7 +223,7 @@ fn set_dot_leading_and_subscripted_keys() {
         assert_eq!(
             read_yaml(&config_dir.join("config.yaml")).unwrap(),
             json!({ "fetchRetries": 1 }),
-            "key {key}"
+            "key {key}",
         );
     }
 }
@@ -248,7 +248,7 @@ fn set_object_value_with_json_writes_workspace_yaml() {
 
     assert_eq!(
         read_yaml(&tmp.path().join("pnpm-workspace.yaml")).unwrap(),
-        json!({ "packageExtensions": extensions })
+        json!({ "packageExtensions": extensions }),
     );
 }
 
@@ -344,7 +344,7 @@ fn delete_auth_key_set_and_unset() {
     config_set(&config, tmp.path(), flags(true, None, false), "registry", None).unwrap();
     assert_eq!(
         read_ini(&config_dir.join("auth.ini")).get("@my-company:registry").map(String::as_str),
-        Some("https://registry.my-company.example.com/")
+        Some("https://registry.my-company.example.com/"),
     );
 
     // set present → removed
@@ -402,14 +402,14 @@ fn get_boolean_and_array_and_object() {
             &config_get(&config, flags(true, None, false), "public-hoist-pattern").unwrap()
         )
         .unwrap(),
-        json!(["*eslint*", "*prettier*"])
+        json!(["*eslint*", "*prettier*"]),
     );
     assert_eq!(
         serde_json::from_str::<Value>(
             &config_get(&config, flags(true, None, false), "package-extensions").unwrap()
         )
         .unwrap(),
-        json!({ "a": { "dependencies": { "b": "1" } } })
+        json!({ "a": { "dependencies": { "b": "1" } } }),
     );
 }
 
@@ -418,14 +418,14 @@ fn get_unknown_key_is_undefined() {
     let config = config_for_get(&[], &[]);
     assert_eq!(
         config_get(&config, flags(true, None, false), "no-such-setting").unwrap(),
-        "undefined"
+        "undefined",
     );
     // prototype-chain names must not resolve
     for key in ["constructor", "__proto__", "hasOwnProperty"] {
         assert_eq!(
             config_get(&config, flags(true, None, false), key).unwrap(),
             "undefined",
-            "{key}"
+            "{key}",
         );
     }
 }
@@ -436,7 +436,7 @@ fn get_scoped_registry_from_auth_and_merged() {
         config_for_get(&[], &[("@scope:registry", "https://custom-registry.example.com/")]);
     assert_eq!(
         config_get(&from_auth, flags(false, None, false), "@scope:registry").unwrap(),
-        "https://custom-registry.example.com/"
+        "https://custom-registry.example.com/",
     );
 
     // merged `registries` block wins over the raw .npmrc value (pnpm/pnpm#11492)
@@ -446,13 +446,13 @@ fn get_scoped_registry_from_auth_and_merged() {
         .insert("@scope".to_string(), "https://from-workspace-yaml.example.com/".to_string());
     assert_eq!(
         config_get(&merged, flags(false, None, false), "@scope:registry").unwrap(),
-        "https://from-workspace-yaml.example.com/"
+        "https://from-workspace-yaml.example.com/",
     );
 
     let absent = config_for_get(&[], &[]);
     assert_eq!(
         config_get(&absent, flags(false, None, false), "@scope:registry").unwrap(),
-        "undefined"
+        "undefined",
     );
 }
 
@@ -461,7 +461,7 @@ fn get_globalconfig_path() {
     let config = config_for_get(&[], &[]);
     assert_eq!(
         config_get(&config, flags(true, None, false), "globalconfig").unwrap(),
-        Path::new("/config").join("config.yaml").to_string_lossy()
+        Path::new("/config").join("config.yaml").to_string_lossy(),
     );
 }
 
@@ -479,7 +479,7 @@ fn get_property_path_into_object() {
     );
     assert_eq!(
         config_get(&config, flags(false, None, false), "trustPolicyExclude[0]").unwrap(),
-        "foo"
+        "foo",
     );
     assert_eq!(
         config_get(
@@ -488,14 +488,14 @@ fn get_property_path_into_object() {
             r#"packageExtensions["@babel/parser"].peerDependencies["@babel/types"]"#
         )
         .unwrap(),
-        "*"
+        "*",
     );
     assert_eq!(
         serde_json::from_str::<Value>(
             &config_get(&config, flags(false, None, false), "package-extensions").unwrap()
         )
         .unwrap(),
-        json!({ "@babel/parser": { "peerDependencies": { "@babel/types": "*" } } })
+        json!({ "@babel/parser": { "peerDependencies": { "@babel/types": "*" } } }),
     );
 }
 

--- a/pacquet/crates/cli/src/cli_args/config/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/config/tests.rs
@@ -570,3 +570,37 @@ fn set_preserves_existing_npmrc_mode() {
     let mode = std::fs::metadata(&npmrc).unwrap().permissions().mode() & 0o777;
     assert_eq!(mode, 0o644, "existing .npmrc mode must be preserved, got {mode:o}");
 }
+
+#[cfg(unix)]
+#[test]
+fn set_does_not_follow_symlinked_npmrc_mode() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let tmp = TempDir::new().unwrap();
+    // A repo-controlled symlinked `.npmrc` pointing at a permissive (0644) file.
+    let target = tmp.path().join("target-npmrc");
+    std::fs::write(&target, "@local:registry=https://localhost/\n").unwrap();
+    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
+    let npmrc = tmp.path().join(".npmrc");
+    std::os::unix::fs::symlink(&target, &npmrc).unwrap();
+
+    let config = config_with_dir(&tmp.path().join("global-config"));
+    config_set(
+        &config,
+        tmp.path(),
+        flags(false, Some(ConfigLocation::Project), false),
+        "//registry.example.com/:_authToken",
+        Some("secret-token".to_string()),
+    )
+    .unwrap();
+
+    // The rename replaced the symlink with a fresh regular file that must keep
+    // the conservative 0600 default, not the link target's 0644.
+    let meta = std::fs::symlink_metadata(&npmrc).unwrap();
+    assert!(!meta.file_type().is_symlink(), "symlink should be replaced by a regular file");
+    let mode = meta.permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o600,
+        "credentials written through a symlinked .npmrc must stay 0600, got {mode:o}",
+    );
+}

--- a/pacquet/crates/config/src/config_types.rs
+++ b/pacquet/crates/config/src/config_types.rs
@@ -1,0 +1,479 @@
+//! The pnpm config-key `types` registry and the file-routing predicates the
+//! `pnpm config` command builds on.
+//!
+//! Ports:
+//! - the merged `types` table (`pnpmTypes` ∪ `npmConfigTypes`) from pnpm's
+//!   [`types.ts`](https://github.com/pnpm/pnpm/blob/8eb1be4988/config/reader/src/types.ts)
+//!   and [`npmConfigTypes.ts`](https://github.com/pnpm/pnpm/blob/8eb1be4988/config/reader/src/npmConfigTypes.ts),
+//!   reduced to the only fact the config command reads off a type: whether the
+//!   type list includes `Number` (used by `castField` to coerce a value).
+//! - [`is_ini_config_key`] / [`is_config_file_key`] from
+//!   [`localConfig.ts`](https://github.com/pnpm/pnpm/blob/8eb1be4988/config/reader/src/localConfig.ts)
+//!   and [`configFileKey.ts`](https://github.com/pnpm/pnpm/blob/8eb1be4988/config/reader/src/configFileKey.ts).
+
+use std::{collections::HashSet, sync::OnceLock};
+
+/// `(kebab-key, type-includes-Number)` for pnpm's own settings (`pnpmTypes`).
+const PNPM_TYPES: &[(&str, bool)] = &[
+    ("auto-install-peers", false),
+    ("bail", false),
+    ("ci", false),
+    ("cache-dir", false),
+    ("catalog-mode", false),
+    ("child-concurrency", true),
+    ("merge-git-branch-lockfiles", false),
+    ("merge-git-branch-lockfiles-branch-pattern", false),
+    ("color", false),
+    ("config-dir", false),
+    ("dangerously-allow-all-builds", false),
+    ("deploy-all-files", false),
+    ("dedupe-peer-dependents", false),
+    ("dedupe-peers", false),
+    ("dedupe-direct-deps", false),
+    ("dedupe-injected-deps", false),
+    ("dev", false),
+    ("dir", false),
+    ("disallow-workspace-cycles", false),
+    ("enable-modules-dir", false),
+    ("enable-pre-post-scripts", false),
+    ("enable-global-virtual-store", false),
+    ("exclude-links-from-lockfile", false),
+    ("extend-node-path", false),
+    ("fetch-timeout", true),
+    ("fetch-warn-timeout-ms", true),
+    ("fetch-min-speed-ki-bps", true),
+    ("fetching-concurrency", true),
+    ("filter", false),
+    ("filter-prod", false),
+    ("force-legacy-deploy", false),
+    ("frozen-lockfile", false),
+    ("git-checks", false),
+    ("git-shallow-hosts", false),
+    ("global-bin-dir", false),
+    ("global-dir", false),
+    ("global-path", false),
+    ("global-pnpmfile", false),
+    ("git-branch-lockfile", false),
+    ("hoist", false),
+    ("http-proxy", false),
+    ("hoist-pattern", false),
+    ("hoist-workspace-packages", false),
+    ("hoisting-limits", false),
+    ("ignore-compatibility-db", false),
+    ("ignore-pnpmfile", false),
+    ("ignore-workspace", false),
+    ("ignore-workspace-cycles", false),
+    ("ignore-workspace-root-check", false),
+    ("optimistic-repeat-install", false),
+    ("include-workspace-root", false),
+    ("init-package-manager", false),
+    ("init-type", false),
+    ("inject-workspace-packages", false),
+    ("legacy-dir-filtering", false),
+    ("link-workspace-packages", false),
+    ("lockfile", false),
+    ("lockfile-dir", false),
+    ("lockfile-include-tarball-url", false),
+    ("lockfile-only", false),
+    ("loglevel", false),
+    ("maxsockets", true),
+    ("modules-cache-max-age", true),
+    ("dlx-cache-max-age", true),
+    ("minimum-release-age", true),
+    ("minimum-release-age-exclude", false),
+    ("minimum-release-age-ignore-missing-time", false),
+    ("minimum-release-age-strict", false),
+    ("modules-dir", false),
+    ("network-concurrency", true),
+    ("node-experimental-package-map", false),
+    ("node-package-map-type", false),
+    ("node-linker", false),
+    ("noproxy", false),
+    ("npm-path", false),
+    ("npmrc-auth-file", false),
+    ("offline", false),
+    ("pack-destination", false),
+    ("pack-gzip-level", true),
+    ("package-import-method", false),
+    ("patches-dir", false),
+    ("pnpmfile", false),
+    ("pm-on-fail", false),
+    ("prefer-frozen-lockfile", false),
+    ("prefer-offline", false),
+    ("prefer-symlinked-executables", false),
+    ("prefer-workspace-packages", false),
+    ("preserve-absolute-paths", false),
+    ("production", false),
+    ("public-hoist-pattern", false),
+    ("publish-branch", false),
+    ("recursive-install", false),
+    ("block-exotic-subdeps", false),
+    ("reporter", false),
+    ("resolution-mode", false),
+    ("resolve-peers-from-workspace-root", false),
+    ("runtime", false),
+    ("runtime-on-fail", false),
+    ("aggregate-output", false),
+    ("reporter-hide-prefix", false),
+    ("save-peer", false),
+    ("save-catalog-name", false),
+    ("save-workspace-protocol", false),
+    ("script-shell", false),
+    ("shamefully-hoist", false),
+    ("shared-workspace-lockfile", false),
+    ("shell-emulator", false),
+    ("side-effects-cache", false),
+    ("side-effects-cache-readonly", false),
+    ("symlink", false),
+    ("sort", false),
+    ("state-dir", false),
+    ("store-dir", false),
+    ("stream", false),
+    ("strict-dep-builds", false),
+    ("strict-store-pkg-content-check", false),
+    ("strict-peer-dependencies", false),
+    ("trust-lockfile", false),
+    ("trust-policy", false),
+    ("trust-policy-exclude", false),
+    ("trust-policy-ignore-after", true),
+    ("use-beta-cli", false),
+    ("use-stderr", false),
+    ("verify-deps-before-run", false),
+    ("verify-store-integrity", false),
+    ("frozen-store", false),
+    ("global-virtual-store-dir", false),
+    ("virtual-store-dir", false),
+    ("virtual-store-only", false),
+    ("virtual-store-dir-max-length", true),
+    ("peers-suffix-max-length", true),
+    ("workspace-concurrency", true),
+    ("workspace-packages", false),
+    ("workspace-root", false),
+    ("yes", false),
+    ("test-pattern", false),
+    ("changed-files-ignore-pattern", false),
+    ("embed-readme", false),
+    ("skip-manifest-obfuscation", false),
+    ("update-notifier", false),
+    ("pnpr-server", false),
+    ("registry-supports-time-field", false),
+    ("fail-if-no-match", false),
+    ("sync-injected-deps-after-scripts", false),
+    ("cpu", false),
+    ("libc", false),
+    ("os", false),
+    ("audit-level", false),
+];
+
+/// `(kebab-key, type-includes-Number)` for the npm-compatible settings
+/// (`npmConfigTypes`). Spread after [`PNPM_TYPES`] upstream, so on the few
+/// overlapping keys these definitions win — but none of the overlaps change
+/// number-ness, so the merged "includes Number" answer is the union.
+const NPM_CONFIG_TYPES: &[(&str, bool)] = &[
+    ("access", false),
+    ("allow-same-version", false),
+    ("bin-links", false),
+    ("ca", false),
+    ("cafile", false),
+    ("cert", false),
+    ("commit-hooks", false),
+    ("depth", true),
+    ("description", false),
+    ("dev", false),
+    ("dry-run", false),
+    ("engine-strict", false),
+    ("fetch-retries", true),
+    ("fetch-retry-factor", true),
+    ("fetch-retry-mintimeout", true),
+    ("fetch-retry-maxtimeout", true),
+    ("force", false),
+    ("git", false),
+    ("git-tag-version", false),
+    ("global", false),
+    ("https-proxy", false),
+    ("ignore-scripts", false),
+    ("init-author-name", false),
+    ("init-author-email", false),
+    ("init-author-url", false),
+    ("init-license", false),
+    ("init-version", false),
+    ("json", false),
+    ("key", false),
+    ("local-address", false),
+    ("long", false),
+    ("maxsockets", true),
+    ("message", false),
+    ("node-options", false),
+    ("node-version", false),
+    ("no-proxy", false),
+    ("offline", false),
+    ("only", false),
+    ("optional", false),
+    ("otp", false),
+    ("package-lock", false),
+    ("parseable", false),
+    ("prefer-offline", false),
+    ("prefix", false),
+    ("production", false),
+    ("progress", false),
+    ("provenance", false),
+    ("proxy", false),
+    ("registry", false),
+    ("save", false),
+    ("save-dev", false),
+    ("save-exact", false),
+    ("save-optional", false),
+    ("save-prefix", false),
+    ("save-prod", false),
+    ("scope", false),
+    ("script-shell", false),
+    ("scripts-prepend-node-path", false),
+    ("sign-git-tag", false),
+    ("strict-ssl", false),
+    ("tag", false),
+    ("tag-version-prefix", false),
+    ("unsafe-perm", false),
+    ("user-agent", false),
+    ("userconfig", false),
+    ("umask", true),
+    ("version", false),
+];
+
+/// Keys from `pnpmTypes` that are valid in a global config file
+/// (`pnpmConfigFileKeys` in `configFileKey.ts`).
+const PNPM_CONFIG_FILE_KEYS: &[&str] = &[
+    "bail",
+    "ci",
+    "color",
+    "cache-dir",
+    "child-concurrency",
+    "dangerously-allow-all-builds",
+    "enable-modules-dir",
+    "enable-global-virtual-store",
+    "exclude-links-from-lockfile",
+    "extend-node-path",
+    "fetch-timeout",
+    "fetch-warn-timeout-ms",
+    "fetch-min-speed-ki-bps",
+    "fetching-concurrency",
+    "frozen-store",
+    "git-checks",
+    "git-shallow-hosts",
+    "global-bin-dir",
+    "global-dir",
+    "global-path",
+    "global-pnpmfile",
+    "global-virtual-store-dir",
+    "http-proxy",
+    "init-package-manager",
+    "init-type",
+    "optimistic-repeat-install",
+    "loglevel",
+    "maxsockets",
+    "modules-cache-max-age",
+    "dlx-cache-max-age",
+    "minimum-release-age",
+    "minimum-release-age-exclude",
+    "minimum-release-age-ignore-missing-time",
+    "minimum-release-age-strict",
+    "network-concurrency",
+    "node-experimental-package-map",
+    "node-package-map-type",
+    "noproxy",
+    "npm-path",
+    "npmrc-auth-file",
+    "package-import-method",
+    "pnpr-server",
+    "prefer-frozen-lockfile",
+    "prefer-offline",
+    "prefer-symlinked-executables",
+    "block-exotic-subdeps",
+    "registry-supports-time-field",
+    "reporter",
+    "resolution-mode",
+    "script-shell",
+    "shell-emulator",
+    "side-effects-cache",
+    "side-effects-cache-readonly",
+    "state-dir",
+    "store-dir",
+    "strict-dep-builds",
+    "trust-lockfile",
+    "trust-policy",
+    "trust-policy-exclude",
+    "trust-policy-ignore-after",
+    "update-notifier",
+    "use-beta-cli",
+    "use-stderr",
+    "verify-deps-before-run",
+    "verify-store-integrity",
+    "virtual-store-dir",
+    "virtual-store-dir-max-length",
+];
+
+/// Keys present in `pnpmTypes` but excluded from the global config file
+/// (`excludedPnpmKeys` in `configFileKey.ts`) — CLI flags and workspace-only
+/// settings.
+const EXCLUDED_PNPM_KEYS: &[&str] = &[
+    "auto-install-peers",
+    "catalog-mode",
+    "config-dir",
+    "merge-git-branch-lockfiles",
+    "merge-git-branch-lockfiles-branch-pattern",
+    "deploy-all-files",
+    "dedupe-peer-dependents",
+    "dedupe-peers",
+    "dedupe-direct-deps",
+    "dedupe-injected-deps",
+    "dev",
+    "dir",
+    "disallow-workspace-cycles",
+    "enable-pre-post-scripts",
+    "filter",
+    "filter-prod",
+    "force-legacy-deploy",
+    "frozen-lockfile",
+    "git-branch-lockfile",
+    "hoist",
+    "hoist-pattern",
+    "hoist-workspace-packages",
+    "hoisting-limits",
+    "ignore-compatibility-db",
+    "ignore-pnpmfile",
+    "ignore-workspace",
+    "ignore-workspace-cycles",
+    "ignore-workspace-root-check",
+    "include-workspace-root",
+    "inject-workspace-packages",
+    "legacy-dir-filtering",
+    "link-workspace-packages",
+    "lockfile",
+    "lockfile-dir",
+    "lockfile-include-tarball-url",
+    "lockfile-only",
+    "modules-dir",
+    "node-linker",
+    "offline",
+    "pack-destination",
+    "pack-gzip-level",
+    "patches-dir",
+    "pnpmfile",
+    "pm-on-fail",
+    "prefer-workspace-packages",
+    "preserve-absolute-paths",
+    "production",
+    "public-hoist-pattern",
+    "publish-branch",
+    "recursive-install",
+    "resolve-peers-from-workspace-root",
+    "runtime",
+    "runtime-on-fail",
+    "aggregate-output",
+    "reporter-hide-prefix",
+    "save-catalog-name",
+    "save-peer",
+    "save-workspace-protocol",
+    "shamefully-hoist",
+    "shared-workspace-lockfile",
+    "symlink",
+    "sort",
+    "stream",
+    "strict-store-pkg-content-check",
+    "strict-peer-dependencies",
+    "virtual-store-only",
+    "peers-suffix-max-length",
+    "workspace-concurrency",
+    "workspace-packages",
+    "workspace-root",
+    "test-pattern",
+    "changed-files-ignore-pattern",
+    "embed-readme",
+    "skip-manifest-obfuscation",
+    "fail-if-no-match",
+    "sync-injected-deps-after-scripts",
+    "cpu",
+    "libc",
+    "os",
+    "audit-level",
+    "yes",
+];
+
+/// The npm auth settings recognized by [`is_ini_config_key`]
+/// (`NPM_AUTH_SETTINGS` in `localConfig.ts`).
+const NPM_AUTH_SETTINGS: &[&str] = &[
+    "ca",
+    "cafile",
+    "cert",
+    "key",
+    "registry",
+    "_auth",
+    "_authToken",
+    "_password",
+    "email",
+    "username",
+];
+
+fn numeric_type_keys() -> &'static HashSet<&'static str> {
+    static SET: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    SET.get_or_init(|| {
+        PNPM_TYPES
+            .iter()
+            .chain(NPM_CONFIG_TYPES)
+            .filter(|(_, is_number)| *is_number)
+            .map(|(key, _)| *key)
+            .collect()
+    })
+}
+
+fn all_type_keys() -> &'static HashSet<&'static str> {
+    static SET: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    SET.get_or_init(|| PNPM_TYPES.iter().chain(NPM_CONFIG_TYPES).map(|(key, _)| *key).collect())
+}
+
+fn npm_config_type_keys() -> &'static HashSet<&'static str> {
+    static SET: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    SET.get_or_init(|| NPM_CONFIG_TYPES.iter().map(|(key, _)| *key).collect())
+}
+
+fn pnpm_config_file_keys() -> &'static HashSet<&'static str> {
+    static SET: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    SET.get_or_init(|| PNPM_CONFIG_FILE_KEYS.iter().copied().collect())
+}
+
+fn excluded_pnpm_keys() -> &'static HashSet<&'static str> {
+    static SET: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    SET.get_or_init(|| EXCLUDED_PNPM_KEYS.iter().copied().collect())
+}
+
+/// Whether `kebab_key` is a known config key (an own key of pnpm's merged
+/// `types` table). Mirrors `Object.hasOwn(types, kebabKey)`.
+#[must_use]
+pub fn is_type_key(kebab_key: &str) -> bool {
+    all_type_keys().contains(kebab_key)
+}
+
+/// Whether the type of `kebab_key` includes `Number`, i.e. a string value
+/// should be coerced to a number. Mirrors `castField`'s `typeList.includes(Number)`.
+#[must_use]
+pub fn type_includes_number(kebab_key: &str) -> bool {
+    numeric_type_keys().contains(kebab_key)
+}
+
+/// Whether `key` would be read from an INI config file (auth / scoped /
+/// per-registry). Mirrors `isIniConfigKey`.
+#[must_use]
+pub fn is_ini_config_key(key: &str) -> bool {
+    key.starts_with('@') || key.starts_with("//") || NPM_AUTH_SETTINGS.contains(&key)
+}
+
+/// Whether `kebab_key` is valid in a global config file. Mirrors
+/// `isConfigFileKey`: a pnpm config-file key, or an npm-compatible key that
+/// is not in the excluded list.
+#[must_use]
+pub fn is_config_file_key(kebab_key: &str) -> bool {
+    pnpm_config_file_keys().contains(kebab_key)
+        || (npm_config_type_keys().contains(kebab_key) && !excluded_pnpm_keys().contains(kebab_key))
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/config/src/config_types/tests.rs
+++ b/pacquet/crates/config/src/config_types/tests.rs
@@ -1,0 +1,59 @@
+use super::{is_config_file_key, is_ini_config_key, is_type_key, type_includes_number};
+
+#[test]
+fn type_membership() {
+    assert!(is_type_key("fetch-retries"));
+    assert!(is_type_key("store-dir"));
+    assert!(is_type_key("registry"));
+    assert!(is_type_key("virtual-store-dir"));
+    assert!(!is_type_key("no-such-setting"));
+    // prototype-chain names must not be members
+    assert!(!is_type_key("constructor"));
+    assert!(!is_type_key("__proto__"));
+}
+
+#[test]
+fn numeric_types() {
+    assert!(type_includes_number("fetch-retries"));
+    assert!(type_includes_number("fetch-timeout"));
+    assert!(type_includes_number("modules-cache-max-age"));
+    assert!(type_includes_number("dlx-cache-max-age"));
+    assert!(type_includes_number("umask"));
+    assert!(!type_includes_number("store-dir"));
+    assert!(!type_includes_number("registry"));
+    assert!(!type_includes_number("minimum-release-age-strict"));
+}
+
+#[test]
+fn ini_keys() {
+    assert!(is_ini_config_key("registry"));
+    assert!(is_ini_config_key("cafile"));
+    assert!(is_ini_config_key("_authToken"));
+    assert!(is_ini_config_key("username"));
+    assert!(is_ini_config_key("@scope:registry"));
+    assert!(is_ini_config_key("//registry.example.com/:_auth"));
+    // not auth/scoped/registry keys
+    assert!(!is_ini_config_key("store-dir"));
+    assert!(!is_ini_config_key("fetch-retries"));
+    assert!(!is_ini_config_key("https-proxy"));
+    assert!(!is_ini_config_key("no-proxy"));
+}
+
+#[test]
+fn config_file_keys() {
+    // pnpm config-file keys
+    assert!(is_config_file_key("store-dir"));
+    assert!(is_config_file_key("fetch-timeout"));
+    assert!(is_config_file_key("cache-dir"));
+    // npm-compatible, not excluded
+    assert!(is_config_file_key("fetch-retries"));
+    assert!(is_config_file_key("registry"));
+    // excluded workspace-only / CLI keys
+    assert!(!is_config_file_key("catalog-mode"));
+    assert!(!is_config_file_key("node-linker"));
+    assert!(!is_config_file_key("hoist"));
+    assert!(!is_config_file_key("lockfile"));
+    // catalog / package-extensions are not even type keys → not config-file keys
+    assert!(!is_config_file_key("catalog"));
+    assert!(!is_config_file_key("package-extensions"));
+}

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1,9 +1,13 @@
 mod api;
+pub mod config_types;
 mod defaults;
 mod env_overlay;
 mod global_bin_check;
 pub mod matcher;
+pub mod naming_cases;
 mod npmrc_auth;
+pub mod property_path;
+pub mod protected_settings;
 mod store_path;
 pub mod version_policy;
 mod workspace_yaml;
@@ -1517,6 +1521,31 @@ pub struct Config {
     pub auth_headers: std::sync::Arc<pacquet_network::AuthHeaders>,
 
     pub package_manager_bootstrap: PackageManagerBootstrap,
+
+    /// Camel-cased record of the settings the user *explicitly* set through
+    /// `pnpm-workspace.yaml`, the global `config.yaml`, and `PNPM_CONFIG_*`
+    /// env vars (with `_auth` excluded and `null` values dropped). Populated
+    /// by [`Config::current`]; empty when a `Config` is built without it.
+    ///
+    /// This is pacquet's stand-in for pnpm's `explicitlySetKeys` + the merged
+    /// config record consumed by `pnpm config get` / `pnpm config list`:
+    /// because [`WorkspaceSettings`]'s fields are `Option`s, a serialized
+    /// settings struct names exactly the keys a source set, with the user's
+    /// raw value. See [`Config::config_to_record`].
+    pub explicit_settings: serde_json::Map<String, serde_json::Value>,
+
+    /// Raw `.npmrc` / `auth.ini` config keys (those for which
+    /// [`config_types::is_ini_config_key`] holds: `registry`, `@scope:registry`,
+    /// `//host/:_authToken`, `username`, `ca`, ...), post-`${VAR}` substitution
+    /// and merged across sources. pacquet's stand-in for pnpm's `authConfig`
+    /// map, consumed by `pnpm config get` / `pnpm config list`.
+    pub raw_auth_config: BTreeMap<String, String>,
+
+    /// The global pnpm config directory (`<configDir>`), where `config.yaml`
+    /// and `auth.ini` live. `None` when it cannot be determined. Mirrors pnpm's
+    /// `Config.configDir`; consumed by `pnpm config` and by `globalconfig`
+    /// lookups.
+    pub config_dir: Option<PathBuf>,
 }
 
 /// Registry + network configuration for resolving the package manager pnpm
@@ -1832,6 +1861,7 @@ impl Config {
         // participates in the user-level path resolution below, and its
         // directory is where `auth.ini` lives.
         let global_config_dir = default_config_dir::<Sys>();
+        self.config_dir.clone_from(&global_config_dir);
         let mut global_settings =
             global_config_dir.as_deref().map(WorkspaceSettings::load_global).transpose()?.flatten();
         if let Some(global_settings) = global_settings.as_mut() {
@@ -1971,6 +2001,10 @@ impl Config {
         for lower in sources {
             npmrc_auth.merge_under(lower);
         }
+        // Retain the merged raw `.npmrc` / `auth.ini` config keys for
+        // `pnpm config get` / `pnpm config list` before the structured fields
+        // are consumed below.
+        self.raw_auth_config = std::mem::take(&mut npmrc_auth.raw_ini_config);
 
         let mut trusted_sources = trusted_sources.into_iter().flatten();
         let mut trusted_auth = trusted_sources.next().unwrap_or_default();
@@ -2029,6 +2063,7 @@ impl Config {
             virtual_store_dir_explicit |= global_settings.virtual_store_dir.is_some();
             global_virtual_store_dir_explicit |= global_settings.global_virtual_store_dir.is_some();
             store_dir_explicit |= global_settings.store_dir.is_some();
+            collect_explicit_settings(&mut self.explicit_settings, &global_settings);
             let saved_workspace_dir = self.workspace_dir.take();
             global_settings.apply_to(&mut self, start_dir);
             self.workspace_dir = saved_workspace_dir;
@@ -2084,6 +2119,7 @@ impl Config {
                 global_virtual_store_dir_explicit |= settings.global_virtual_store_dir.is_some();
                 store_dir_explicit |= settings.store_dir.is_some();
                 settings.substitute_env_untrusted::<Sys>();
+                collect_explicit_settings(&mut self.explicit_settings, &settings);
                 settings.apply_to(&mut self, &base_dir);
             }
         }
@@ -2117,6 +2153,7 @@ impl Config {
         // `PNPM_CONFIG_REGISTRY` comes from the environment, not the
         // repository, so it overrides the bootstrap default registry too.
         let env_registry_override = env_settings.registry.clone();
+        collect_explicit_settings(&mut self.explicit_settings, &env_settings);
         let saved_workspace_dir = self.workspace_dir.clone();
         env_settings.apply_to(&mut self, start_dir);
         self.workspace_dir = saved_workspace_dir;
@@ -2205,6 +2242,29 @@ impl Config {
     /// Persist the config data until the program terminates.
     pub fn leak(self) -> &'static mut Self {
         self.pipe(Box::new).pipe(Box::leak)
+    }
+}
+
+/// Fold a source's explicitly-set settings into the running record.
+///
+/// Serializes `settings` to a camelCase JSON object (its `Option` fields make
+/// a serialized value name exactly the keys this source set) and copies every
+/// non-`null` entry into `target`, later sources overriding earlier ones. The
+/// `_auth` key is dropped — it carries credentials and never belongs in
+/// `pnpm config list` output (raw auth keys come from `raw_auth_config`,
+/// censored at render time).
+fn collect_explicit_settings(
+    target: &mut serde_json::Map<String, serde_json::Value>,
+    settings: &WorkspaceSettings,
+) {
+    let Ok(serde_json::Value::Object(map)) = serde_json::to_value(settings) else {
+        return;
+    };
+    for (key, value) in map {
+        if key == "_auth" || value.is_null() {
+            continue;
+        }
+        target.insert(key, value);
     }
 }
 

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1531,7 +1531,7 @@ pub struct Config {
     /// config record consumed by `pnpm config get` / `pnpm config list`:
     /// because [`WorkspaceSettings`]'s fields are `Option`s, a serialized
     /// settings struct names exactly the keys a source set, with the user's
-    /// raw value. See [`Config::config_to_record`].
+    /// raw value. The `config` command turns this into the record it prints.
     pub explicit_settings: serde_json::Map<String, serde_json::Value>,
 
     /// Raw `.npmrc` / `auth.ini` config keys (those for which

--- a/pacquet/crates/config/src/naming_cases.rs
+++ b/pacquet/crates/config/src/naming_cases.rs
@@ -1,0 +1,145 @@
+//! Naming-case predicates and conversions used by `pnpm config`.
+//!
+//! Ports the two predicates from pnpm's
+//! [`@pnpm/text.naming-cases`](https://github.com/pnpm/pnpm/blob/8eb1be4988/text/naming-cases/src/index.ts)
+//! plus the kebab/camel conversions the config command reaches for through
+//! `lodash.kebabcase` and the `camelcase` npm package. Only the behavior the
+//! config command depends on is reproduced: the inputs are config keys
+//! (kebab-case or camelCase ASCII identifiers) and the user-typed keys the
+//! command normalizes before validation.
+
+/// Whether `name` is *strictly* kebab-case: at least two `-`-separated
+/// segments, each `[a-z][a-z0-9]*`.
+///
+/// Mirrors pnpm's `isStrictlyKebabCase`.
+#[must_use]
+pub fn is_strictly_kebab_case(name: &str) -> bool {
+    let mut segments = name.split('-');
+    let first = segments.next();
+    let second = segments.next();
+    if first.is_none() || second.is_none() {
+        return false;
+    }
+    name.split('-').all(is_kebab_segment)
+}
+
+fn is_kebab_segment(segment: &str) -> bool {
+    let mut chars = segment.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_lowercase() {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+}
+
+/// Whether `name` is camelCase: `[a-z][a-zA-Z0-9]*`.
+///
+/// Mirrors pnpm's `isCamelCase`.
+#[must_use]
+pub fn is_camel_case(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_lowercase() {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric())
+}
+
+/// Convert `name` to kebab-case, matching `lodash.kebabcase` for the ASCII
+/// identifier inputs the config command uses: split into words on case
+/// transitions, digit boundaries, and non-alphanumeric separators, lowercase
+/// each word, and join with `-`.
+#[must_use]
+pub fn to_kebab_case(name: &str) -> String {
+    words(name).join("-").to_ascii_lowercase()
+}
+
+/// Convert `name` to camelCase, matching the `camelcase` npm package for the
+/// ASCII identifier inputs the config command uses: split into words the same
+/// way as [`to_kebab_case`], lowercase the first word, and capitalize the
+/// first letter of each subsequent word.
+#[must_use]
+pub fn to_camel_case(name: &str) -> String {
+    let mut result = String::with_capacity(name.len());
+    for (index, word) in words(name).into_iter().enumerate() {
+        let lower = word.to_ascii_lowercase();
+        if index == 0 {
+            result.push_str(&lower);
+        } else {
+            let mut chars = lower.chars();
+            if let Some(first) = chars.next() {
+                result.extend(first.to_uppercase());
+                result.push_str(chars.as_str());
+            }
+        }
+    }
+    result
+}
+
+/// Split an ASCII identifier into words, mirroring `lodash`'s `words` for the
+/// inputs the config command sees. Word boundaries: any run of
+/// non-alphanumeric characters separates words; within an alphanumeric run, a
+/// new word starts at a lower→upper transition, an upper→upper-then-lower
+/// transition (`XMLHttp` → `XML`, `Http`), and at letter↔digit transitions.
+fn words(name: &str) -> Vec<String> {
+    let chars: Vec<char> = name.chars().collect();
+    let mut result = Vec::new();
+    let mut current = String::new();
+    let mut prev: Option<char> = None;
+
+    for (i, &c) in chars.iter().enumerate() {
+        if !c.is_ascii_alphanumeric() {
+            if !current.is_empty() {
+                result.push(std::mem::take(&mut current));
+            }
+            prev = None;
+            continue;
+        }
+
+        if let Some(p) = prev {
+            let boundary = boundary_before(p, c, chars.get(i + 1).copied());
+            if boundary && !current.is_empty() {
+                result.push(std::mem::take(&mut current));
+            }
+        }
+
+        current.push(c);
+        prev = Some(c);
+    }
+
+    if !current.is_empty() {
+        result.push(current);
+    }
+    result
+}
+
+/// Whether a word boundary falls *before* `c` given the previous char `p`
+/// (both alphanumeric, same separator-free run) and the following char `next`.
+fn boundary_before(p: char, c: char, next: Option<char>) -> bool {
+    let p_lower = p.is_ascii_lowercase();
+    let p_upper = p.is_ascii_uppercase();
+    let p_digit = p.is_ascii_digit();
+    let c_upper = c.is_ascii_uppercase();
+    let c_digit = c.is_ascii_digit();
+
+    // letter → digit and digit → letter both start a new word
+    if (p.is_ascii_alphabetic() && c_digit) || (p_digit && c.is_ascii_alphabetic()) {
+        return true;
+    }
+    // lower → upper: camelCase hump (`fetchRetries` → `fetch`, `Retries`)
+    if p_lower && c_upper {
+        return true;
+    }
+    // upper → upper followed by lower: acronym end (`XMLHttp` → `XML`, `Http`)
+    if p_upper && c_upper && next.is_some_and(|n| n.is_ascii_lowercase()) {
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/config/src/naming_cases.rs
+++ b/pacquet/crates/config/src/naming_cases.rs
@@ -31,7 +31,7 @@ fn is_kebab_segment(segment: &str) -> bool {
     if !first.is_ascii_lowercase() {
         return false;
     }
-    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+    chars.all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit())
 }
 
 /// Whether `name` is camelCase: `[a-z][a-zA-Z0-9]*`.
@@ -46,7 +46,7 @@ pub fn is_camel_case(name: &str) -> bool {
     if !first.is_ascii_lowercase() {
         return false;
     }
-    chars.all(|c| c.is_ascii_alphanumeric())
+    chars.all(|ch| ch.is_ascii_alphanumeric())
 }
 
 /// Convert `name` to kebab-case, matching `lodash.kebabcase` for the ASCII
@@ -117,25 +117,26 @@ fn words(name: &str) -> Vec<String> {
     result
 }
 
-/// Whether a word boundary falls *before* `c` given the previous char `p`
-/// (both alphanumeric, same separator-free run) and the following char `next`.
-fn boundary_before(p: char, c: char, next: Option<char>) -> bool {
-    let p_lower = p.is_ascii_lowercase();
-    let p_upper = p.is_ascii_uppercase();
-    let p_digit = p.is_ascii_digit();
-    let c_upper = c.is_ascii_uppercase();
-    let c_digit = c.is_ascii_digit();
+/// Whether a word boundary falls *before* `curr` given the previous char
+/// `prev` (both alphanumeric, same separator-free run) and the following char
+/// `next`.
+fn boundary_before(prev: char, curr: char, next: Option<char>) -> bool {
+    let prev_lower = prev.is_ascii_lowercase();
+    let prev_upper = prev.is_ascii_uppercase();
+    let prev_digit = prev.is_ascii_digit();
+    let curr_upper = curr.is_ascii_uppercase();
+    let curr_digit = curr.is_ascii_digit();
 
     // letter → digit and digit → letter both start a new word
-    if (p.is_ascii_alphabetic() && c_digit) || (p_digit && c.is_ascii_alphabetic()) {
+    if (prev.is_ascii_alphabetic() && curr_digit) || (prev_digit && curr.is_ascii_alphabetic()) {
         return true;
     }
     // lower → upper: camelCase hump (`fetchRetries` → `fetch`, `Retries`)
-    if p_lower && c_upper {
+    if prev_lower && curr_upper {
         return true;
     }
     // upper → upper followed by lower: acronym end (`XMLHttp` → `XML`, `Http`)
-    if p_upper && c_upper && next.is_some_and(|n| n.is_ascii_lowercase()) {
+    if prev_upper && curr_upper && next.is_some_and(|following| following.is_ascii_lowercase()) {
         return true;
     }
     false

--- a/pacquet/crates/config/src/naming_cases/tests.rs
+++ b/pacquet/crates/config/src/naming_cases/tests.rs
@@ -1,0 +1,47 @@
+use super::{is_camel_case, is_strictly_kebab_case, to_camel_case, to_kebab_case};
+
+#[test]
+fn strictly_kebab_case() {
+    assert!(is_strictly_kebab_case("fetch-retries"));
+    assert!(is_strictly_kebab_case("fetch-retry-mintimeout"));
+    assert!(is_strictly_kebab_case("store-dir"));
+    // single segment is not strictly kebab-case
+    assert!(!is_strictly_kebab_case("storedir"));
+    assert!(!is_strictly_kebab_case("registry"));
+    // camelCase is not kebab-case
+    assert!(!is_strictly_kebab_case("fetchRetries"));
+    // leading digit segment is rejected
+    assert!(!is_strictly_kebab_case("1-foo"));
+    assert!(!is_strictly_kebab_case(""));
+}
+
+#[test]
+fn camel_case() {
+    assert!(is_camel_case("fetchRetries"));
+    assert!(is_camel_case("storeDir"));
+    assert!(is_camel_case("registry"));
+    assert!(!is_camel_case("fetch-retries"));
+    assert!(!is_camel_case("FetchRetries"));
+    assert!(!is_camel_case("@scope:registry"));
+    assert!(!is_camel_case(""));
+}
+
+#[test]
+fn kebab_conversion() {
+    assert_eq!(to_kebab_case("fetchRetries"), "fetch-retries");
+    assert_eq!(to_kebab_case("storeDir"), "store-dir");
+    assert_eq!(to_kebab_case("fetch-retries"), "fetch-retries");
+    assert_eq!(to_kebab_case("httpProxy"), "http-proxy");
+    assert_eq!(to_kebab_case("fetchMinSpeedKiBps"), "fetch-min-speed-ki-bps");
+    assert_eq!(to_kebab_case("registry"), "registry");
+}
+
+#[test]
+fn camel_conversion() {
+    assert_eq!(to_camel_case("fetch-retries"), "fetchRetries");
+    assert_eq!(to_camel_case("store-dir"), "storeDir");
+    assert_eq!(to_camel_case("package-extensions"), "packageExtensions");
+    assert_eq!(to_camel_case("fetchRetries"), "fetchRetries");
+    assert_eq!(to_camel_case("registry"), "registry");
+    assert_eq!(to_camel_case("fetch-min-speed-ki-bps"), "fetchMinSpeedKiBps");
+}

--- a/pacquet/crates/config/src/npmrc_auth.rs
+++ b/pacquet/crates/config/src/npmrc_auth.rs
@@ -116,6 +116,13 @@ pub(crate) struct NpmrcAuth {
     /// can't redirect the token elsewhere. Applied after workspace yaml by
     /// [`Self::apply_json_env_registries`].
     pub json_env_registries: BTreeMap<String, String>,
+    /// Raw INI config keys (those for which
+    /// [`crate::config_types::is_ini_config_key`] holds), post-`${VAR}`
+    /// substitution, captured verbatim for `pnpm config get` / `list`. This
+    /// is the source of [`crate::Config::raw_auth_config`] (pnpm's
+    /// `authConfig`); it does not feed auth-header resolution, which reads
+    /// the structured fields above.
+    pub raw_ini_config: BTreeMap<String, String>,
 }
 
 /// Raw (unparsed) credential fields for a given registry URI, mirroring
@@ -368,6 +375,13 @@ impl NpmrcAuth {
             let (value, value_unresolved) = env_replace_lossy::<Sys>(raw_value);
             for placeholder in key_unresolved.into_iter().chain(value_unresolved) {
                 auth.warnings.push(format!("Failed to replace env in config: {placeholder}"));
+            }
+
+            // Capture every auth/scoped/per-registry key verbatim for
+            // `pnpm config get` / `list`, independent of the structured
+            // parsing below (which only some of these keys feed).
+            if crate::config_types::is_ini_config_key(&key) {
+                auth.raw_ini_config.insert(key.clone(), value.clone());
             }
 
             if key == "registry" {
@@ -717,6 +731,9 @@ impl NpmrcAuth {
         }
         for (scope, registry) in lower.json_env_registries {
             self.json_env_registries.entry(scope).or_insert(registry);
+        }
+        for (key, value) in lower.raw_ini_config {
+            self.raw_ini_config.entry(key).or_insert(value);
         }
         self.https_proxy = self.https_proxy.take().or(lower.https_proxy);
         self.http_proxy = self.http_proxy.take().or(lower.http_proxy);

--- a/pacquet/crates/config/src/property_path.rs
+++ b/pacquet/crates/config/src/property_path.rs
@@ -2,7 +2,7 @@
 //!
 //! Port of the read half of pnpm's
 //! [`@pnpm/object.property-path`](https://github.com/pnpm/pnpm/blob/8eb1be4988/object/property-path/src):
-//! the tokenizer ([`tokenize`]), the parser ([`parse_property_path`]), and
+//! the tokenizer (`tokenize`), the parser ([`parse_property_path`]), and
 //! [`get_object_value_by_property_path`]. The mutating `set`/`delete` halves
 //! are not ported — the config command only reads through a property path and
 //! uses [`parse_property_path`] to classify a key as simple vs. deep.
@@ -324,17 +324,21 @@ pub fn get_object_value_by_property_path<'a>(
 
 /// Convert a numeric segment to a valid array index, or `None` when it is not
 /// a non-negative integer (`Object.hasOwn(array, name)` is false otherwise).
-fn array_index(n: f64) -> Option<usize> {
-    if n.fract() != 0.0 || n.is_sign_negative() || !n.is_finite() {
+fn array_index(value: f64) -> Option<usize> {
+    if value.fract() != 0.0 || value.is_sign_negative() || !value.is_finite() {
         return None;
     }
-    Some(n as usize)
+    Some(value as usize)
 }
 
 /// Render a JS number the way `String(number)` / object-key coercion would for
 /// the integer values these paths use.
-fn number_to_string(n: f64) -> String {
-    if n.fract() == 0.0 && n.is_finite() { format!("{}", n as i64) } else { n.to_string() }
+fn number_to_string(value: f64) -> String {
+    if value.fract() == 0.0 && value.is_finite() {
+        format!("{}", value as i64)
+    } else {
+        value.to_string()
+    }
 }
 
 #[cfg(test)]

--- a/pacquet/crates/config/src/property_path.rs
+++ b/pacquet/crates/config/src/property_path.rs
@@ -1,0 +1,341 @@
+//! Parser for the property-path mini-language used by `pnpm config get`.
+//!
+//! Port of the read half of pnpm's
+//! [`@pnpm/object.property-path`](https://github.com/pnpm/pnpm/blob/8eb1be4988/object/property-path/src):
+//! the tokenizer ([`tokenize`]), the parser ([`parse_property_path`]), and
+//! [`get_object_value_by_property_path`]. The mutating `set`/`delete` halves
+//! are not ported — the config command only reads through a property path and
+//! uses [`parse_property_path`] to classify a key as simple vs. deep.
+//!
+//! Grammar (mirroring upstream's examples):
+//! `foo.bar.baz`, `.foo.bar`, `foo.bar["baz"]`, `foo['bar'].baz`,
+//! `["foo"].bar`, `foo[123]`.
+
+use derive_more::{Display, Error};
+use serde_json::Value;
+
+/// One parsed property-path segment. A numeric literal keeps its numeric
+/// identity (it is the only form that may index into an array), mirroring
+/// upstream's `string | number` yield type.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Segment {
+    Key(String),
+    Index(f64),
+}
+
+/// Error raised while parsing a property path. Mirrors the `PnpmError`
+/// subclasses in pnpm's `parse.ts` / token parsers; the codes match so
+/// they remain part of the public contract.
+#[derive(Debug, Display, Error, PartialEq)]
+#[non_exhaustive]
+pub enum ParsePropertyPathError {
+    #[display("Unexpected token {token:?} in property path")]
+    UnexpectedToken { token: String },
+
+    #[display("Unexpected identifier {token} in property path")]
+    UnexpectedIdentifier { token: String },
+
+    #[display("Unexpected literal {token:?} in property path")]
+    UnexpectedLiteral { token: String },
+
+    #[display("The property path does not end properly")]
+    UnexpectedEndOfInput,
+
+    #[display("Numeric suffix {suffix:?} is not supported")]
+    UnsupportedNumericSuffix { suffix: String },
+
+    #[display("pnpm's string literal doesn't support {sequence:?}")]
+    UnsupportedEscapeSequence { sequence: String },
+
+    #[display("Input ends without closing quote ({quote})")]
+    IncompleteStringLiteral { quote: char },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    Dot,
+    OpenBracket,
+    CloseBracket,
+    Identifier(String),
+    NumericLiteral(f64),
+    StringLiteral(String),
+    Whitespace,
+    Unexpected(String),
+}
+
+/// Tokenize `source`, returning the token stream or the first parse error.
+fn tokenize(source: &str) -> Result<Vec<Token>, ParsePropertyPathError> {
+    let mut tokens = Vec::new();
+    let mut rest = source;
+    while !rest.is_empty() {
+        let (token, remaining) = parse_token(rest)?;
+        tokens.push(token);
+        rest = remaining;
+    }
+    Ok(tokens)
+}
+
+fn parse_token(source: &str) -> Result<(Token, &str), ParsePropertyPathError> {
+    if let Some(result) = parse_exact(source) {
+        return Ok(result);
+    }
+    if let Some(result) = parse_identifier(source) {
+        return Ok(result);
+    }
+    if let Some(result) = parse_numeric_literal(source)? {
+        return Ok(result);
+    }
+    if let Some(result) = parse_string_literal(source)? {
+        return Ok(result);
+    }
+    if let Some(result) = parse_whitespace(source) {
+        return Ok(result);
+    }
+    // Unexpected: a single (char-boundary-safe) unit, mirroring upstream's
+    // `source.slice(0, 1)`.
+    let mut indices = source.char_indices();
+    indices.next();
+    let split = indices.next().map_or(source.len(), |(i, _)| i);
+    let (head, tail) = source.split_at(split);
+    Ok((Token::Unexpected(head.to_string()), tail))
+}
+
+fn parse_exact(source: &str) -> Option<(Token, &str)> {
+    for (prefix, token) in
+        [('.', Token::Dot), ('[', Token::OpenBracket), (']', Token::CloseBracket)]
+    {
+        if let Some(rest) = source.strip_prefix(prefix) {
+            return Some((token, rest));
+        }
+    }
+    None
+}
+
+fn parse_identifier(source: &str) -> Option<(Token, &str)> {
+    let mut chars = source.char_indices();
+    let (_, first) = chars.next()?;
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return None;
+    }
+    let mut end = first.len_utf8();
+    for (i, c) in chars {
+        // `\w` in JS = [A-Za-z0-9_]
+        if c.is_ascii_alphanumeric() || c == '_' {
+            end = i + c.len_utf8();
+        } else {
+            break;
+        }
+    }
+    let (content, rest) = source.split_at(end);
+    Some((Token::Identifier(content.to_string()), rest))
+}
+
+fn parse_numeric_literal(source: &str) -> Result<Option<(Token, &str)>, ParsePropertyPathError> {
+    let mut chars = source.char_indices();
+    let Some((_, first)) = chars.next() else {
+        return Ok(None);
+    };
+    if !first.is_ascii_digit() {
+        return Ok(None);
+    }
+    let mut end = 1;
+    for (i, c) in chars {
+        if c.is_ascii_digit() || c == '.' {
+            end = i + c.len_utf8();
+        } else if c.is_ascii_alphabetic() {
+            // Forbid `0x1A`, `1e20`, `123n`, ... like upstream.
+            return Err(ParsePropertyPathError::UnsupportedNumericSuffix { suffix: c.to_string() });
+        } else {
+            break;
+        }
+    }
+    let (number_string, rest) = source.split_at(end);
+    let number: f64 = number_string.parse().unwrap_or(f64::NAN);
+    Ok(Some((Token::NumericLiteral(number), rest)))
+}
+
+fn parse_string_literal(source: &str) -> Result<Option<(Token, &str)>, ParsePropertyPathError> {
+    let quote = match source.chars().next() {
+        Some('"') => '"',
+        Some('\'') => '\'',
+        _ => return Ok(None),
+    };
+    let mut content = String::new();
+    let mut escaped = false;
+    let mut chars = source.char_indices();
+    chars.next(); // consume opening quote
+    for (i, c) in chars {
+        if escaped {
+            escaped = false;
+            let real = match c {
+                '\\' => '\\',
+                '\'' => '\'',
+                '"' => '"',
+                'b' => '\u{08}',
+                'n' => '\n',
+                'r' => '\r',
+                't' => '\t',
+                other => {
+                    return Err(ParsePropertyPathError::UnsupportedEscapeSequence {
+                        sequence: other.to_string(),
+                    });
+                }
+            };
+            content.push(real);
+            continue;
+        }
+        if c == quote {
+            let rest = &source[i + c.len_utf8()..];
+            return Ok(Some((Token::StringLiteral(content), rest)));
+        }
+        if c == '\\' {
+            escaped = true;
+            continue;
+        }
+        content.push(c);
+    }
+    Err(ParsePropertyPathError::IncompleteStringLiteral { quote })
+}
+
+fn parse_whitespace(source: &str) -> Option<(Token, &str)> {
+    let trimmed = source.trim_start();
+    if trimmed.len() == source.len() { None } else { Some((Token::Whitespace, trimmed)) }
+}
+
+/// Parse a property path string into its segments.
+///
+/// Mirrors pnpm's `parsePropertyPath` shift/reduce loop: a leading or
+/// inter-segment `.`, bracketed string/number literals, and bare identifiers.
+pub fn parse_property_path(property_path: &str) -> Result<Vec<Segment>, ParsePropertyPathError> {
+    enum Stack {
+        Dot,
+        OpenBracket,
+        Bracketed(Token),
+    }
+    let mut stack: Option<Stack> = None;
+    let mut segments = Vec::new();
+
+    for token in tokenize(property_path)? {
+        match token {
+            Token::Dot => match stack {
+                None => stack = Some(Stack::Dot),
+                _ => return Err(unexpected(&Token::Dot)),
+            },
+            Token::OpenBracket => match stack {
+                None => stack = Some(Stack::OpenBracket),
+                _ => return Err(unexpected(&Token::OpenBracket)),
+            },
+            Token::CloseBracket => {
+                let Some(Stack::Bracketed(literal)) = stack else {
+                    return Err(unexpected(&Token::CloseBracket));
+                };
+                segments.push(literal_to_segment(literal));
+                stack = None;
+            }
+            Token::Identifier(ref content) => match stack {
+                None | Some(Stack::Dot) => {
+                    stack = None;
+                    segments.push(Segment::Key(content.clone()));
+                }
+                _ => {
+                    return Err(ParsePropertyPathError::UnexpectedIdentifier {
+                        token: content.clone(),
+                    });
+                }
+            },
+            Token::NumericLiteral(_) | Token::StringLiteral(_) => match stack {
+                Some(Stack::OpenBracket) => stack = Some(Stack::Bracketed(token)),
+                _ => return Err(unexpected_literal(&token)),
+            },
+            Token::Whitespace => {}
+            Token::Unexpected(ref content) => {
+                return Err(ParsePropertyPathError::UnexpectedToken { token: content.clone() });
+            }
+        }
+    }
+
+    if stack.is_some() {
+        return Err(ParsePropertyPathError::UnexpectedEndOfInput);
+    }
+    Ok(segments)
+}
+
+fn literal_to_segment(token: Token) -> Segment {
+    match token {
+        Token::NumericLiteral(n) => Segment::Index(n),
+        Token::StringLiteral(s) => Segment::Key(s),
+        _ => unreachable!("only literal tokens are pushed onto the bracket stack"),
+    }
+}
+
+fn unexpected(token: &Token) -> ParsePropertyPathError {
+    ParsePropertyPathError::UnexpectedToken { token: token_content(token) }
+}
+
+fn unexpected_literal(token: &Token) -> ParsePropertyPathError {
+    ParsePropertyPathError::UnexpectedLiteral { token: token_content(token) }
+}
+
+fn token_content(token: &Token) -> String {
+    match token {
+        Token::Dot => ".".to_string(),
+        Token::OpenBracket => "[".to_string(),
+        Token::CloseBracket => "]".to_string(),
+        Token::Identifier(s) | Token::StringLiteral(s) | Token::Unexpected(s) => s.clone(),
+        Token::NumericLiteral(n) => number_to_string(*n),
+        Token::Whitespace => " ".to_string(),
+    }
+}
+
+/// Walk `value` along `property_path`, returning the value found there, or
+/// `None` if any step meets a non-object/array, a missing key, or a
+/// non-numeric segment indexing an array.
+///
+/// Mirrors pnpm's `getObjectValueByPropertyPath`.
+#[must_use]
+pub fn get_object_value_by_property_path<'a>(
+    value: &'a Value,
+    property_path: &[Segment],
+) -> Option<&'a Value> {
+    let mut current = value;
+    for segment in property_path {
+        match current {
+            Value::Object(map) => {
+                let key = match segment {
+                    Segment::Key(key) => key.clone(),
+                    Segment::Index(n) => number_to_string(*n),
+                };
+                current = map.get(&key)?;
+            }
+            Value::Array(items) => {
+                // On an array, a non-numeric segment yields `undefined`
+                // (`typeof name !== 'number'`).
+                let Segment::Index(n) = segment else {
+                    return None;
+                };
+                let index = array_index(*n)?;
+                current = items.get(index)?;
+            }
+            _ => return None,
+        }
+    }
+    Some(current)
+}
+
+/// Convert a numeric segment to a valid array index, or `None` when it is not
+/// a non-negative integer (`Object.hasOwn(array, name)` is false otherwise).
+fn array_index(n: f64) -> Option<usize> {
+    if n.fract() != 0.0 || n.is_sign_negative() || !n.is_finite() {
+        return None;
+    }
+    Some(n as usize)
+}
+
+/// Render a JS number the way `String(number)` / object-key coercion would for
+/// the integer values these paths use.
+fn number_to_string(n: f64) -> String {
+    if n.fract() == 0.0 && n.is_finite() { format!("{}", n as i64) } else { n.to_string() }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/config/src/property_path/tests.rs
+++ b/pacquet/crates/config/src/property_path/tests.rs
@@ -11,17 +11,17 @@ fn keys(path: &str) -> Vec<Segment> {
 fn parses_dotted_and_bracketed_forms() {
     assert_eq!(
         keys("foo.bar.baz"),
-        vec![Segment::Key("foo".into()), Segment::Key("bar".into()), Segment::Key("baz".into()),]
+        vec![Segment::Key("foo".into()), Segment::Key("bar".into()), Segment::Key("baz".into()),],
     );
     assert_eq!(keys(".foo.bar"), vec![Segment::Key("foo".into()), Segment::Key("bar".into())]);
     assert_eq!(
         keys(r#"foo["bar"].baz"#),
-        vec![Segment::Key("foo".into()), Segment::Key("bar".into()), Segment::Key("baz".into()),]
+        vec![Segment::Key("foo".into()), Segment::Key("bar".into()), Segment::Key("baz".into()),],
     );
     assert_eq!(keys("foo['bar']"), vec![Segment::Key("foo".into()), Segment::Key("bar".into())]);
     assert_eq!(
         keys(r#"["foo"].bar"#),
-        vec![Segment::Key("foo".into()), Segment::Key("bar".into())]
+        vec![Segment::Key("foo".into()), Segment::Key("bar".into())],
     );
     assert_eq!(keys("foo[123]"), vec![Segment::Key("foo".into()), Segment::Index(123.0)]);
     assert!(keys("").is_empty());
@@ -35,7 +35,7 @@ fn parses_scoped_package_keys() {
             Segment::Key("packageExtensions".into()),
             Segment::Key("@babel/parser".into()),
             Segment::Key("peerDependencies".into()),
-        ]
+        ],
     );
 }
 
@@ -43,7 +43,7 @@ fn parses_scoped_package_keys() {
 fn parse_errors() {
     assert_eq!(
         parse_property_path("foo..bar"),
-        Err(ParsePropertyPathError::UnexpectedToken { token: ".".into() })
+        Err(ParsePropertyPathError::UnexpectedToken { token: ".".into() }),
     );
     assert_eq!(parse_property_path("foo["), Err(ParsePropertyPathError::UnexpectedEndOfInput));
 }
@@ -59,18 +59,18 @@ fn gets_nested_values() {
 
     assert_eq!(
         get_object_value_by_property_path(&value, &keys("trustPolicyExclude[0]")),
-        Some(&json!("foo"))
+        Some(&json!("foo")),
     );
     assert_eq!(
         get_object_value_by_property_path(&value, &keys("trustPolicyExclude[1]")),
-        Some(&json!("bar"))
+        Some(&json!("bar")),
     );
     assert_eq!(
         get_object_value_by_property_path(
             &value,
             &keys(r#"packageExtensions["@babel/parser"].peerDependencies["@babel/types"]"#)
         ),
-        Some(&json!("*"))
+        Some(&json!("*")),
     );
     // out-of-range index, missing key, and non-numeric array index → None
     assert_eq!(get_object_value_by_property_path(&value, &keys("trustPolicyExclude[2]")), None);

--- a/pacquet/crates/config/src/property_path/tests.rs
+++ b/pacquet/crates/config/src/property_path/tests.rs
@@ -1,0 +1,79 @@
+use super::{
+    ParsePropertyPathError, Segment, get_object_value_by_property_path, parse_property_path,
+};
+use serde_json::json;
+
+fn keys(path: &str) -> Vec<Segment> {
+    parse_property_path(path).expect("parse")
+}
+
+#[test]
+fn parses_dotted_and_bracketed_forms() {
+    assert_eq!(
+        keys("foo.bar.baz"),
+        vec![Segment::Key("foo".into()), Segment::Key("bar".into()), Segment::Key("baz".into()),]
+    );
+    assert_eq!(keys(".foo.bar"), vec![Segment::Key("foo".into()), Segment::Key("bar".into())]);
+    assert_eq!(
+        keys(r#"foo["bar"].baz"#),
+        vec![Segment::Key("foo".into()), Segment::Key("bar".into()), Segment::Key("baz".into()),]
+    );
+    assert_eq!(keys("foo['bar']"), vec![Segment::Key("foo".into()), Segment::Key("bar".into())]);
+    assert_eq!(
+        keys(r#"["foo"].bar"#),
+        vec![Segment::Key("foo".into()), Segment::Key("bar".into())]
+    );
+    assert_eq!(keys("foo[123]"), vec![Segment::Key("foo".into()), Segment::Index(123.0)]);
+    assert!(keys("").is_empty());
+}
+
+#[test]
+fn parses_scoped_package_keys() {
+    assert_eq!(
+        keys(r#"packageExtensions["@babel/parser"].peerDependencies"#),
+        vec![
+            Segment::Key("packageExtensions".into()),
+            Segment::Key("@babel/parser".into()),
+            Segment::Key("peerDependencies".into()),
+        ]
+    );
+}
+
+#[test]
+fn parse_errors() {
+    assert_eq!(
+        parse_property_path("foo..bar"),
+        Err(ParsePropertyPathError::UnexpectedToken { token: ".".into() })
+    );
+    assert_eq!(parse_property_path("foo["), Err(ParsePropertyPathError::UnexpectedEndOfInput));
+}
+
+#[test]
+fn gets_nested_values() {
+    let value = json!({
+        "packageExtensions": {
+            "@babel/parser": { "peerDependencies": { "@babel/types": "*" } },
+        },
+        "trustPolicyExclude": ["foo", "bar"],
+    });
+
+    assert_eq!(
+        get_object_value_by_property_path(&value, &keys("trustPolicyExclude[0]")),
+        Some(&json!("foo"))
+    );
+    assert_eq!(
+        get_object_value_by_property_path(&value, &keys("trustPolicyExclude[1]")),
+        Some(&json!("bar"))
+    );
+    assert_eq!(
+        get_object_value_by_property_path(
+            &value,
+            &keys(r#"packageExtensions["@babel/parser"].peerDependencies["@babel/types"]"#)
+        ),
+        Some(&json!("*"))
+    );
+    // out-of-range index, missing key, and non-numeric array index → None
+    assert_eq!(get_object_value_by_property_path(&value, &keys("trustPolicyExclude[2]")), None);
+    assert_eq!(get_object_value_by_property_path(&value, &keys("nope")), None);
+    assert_eq!(get_object_value_by_property_path(&value, &keys("trustPolicyExclude.foo")), None);
+}

--- a/pacquet/crates/config/src/protected_settings.rs
+++ b/pacquet/crates/config/src/protected_settings.rs
@@ -1,0 +1,41 @@
+//! Protected-settings censoring for `pnpm config list` / `pnpm config get`.
+//!
+//! Port of pnpm's
+//! [`protectedSettings.ts`](https://github.com/pnpm/pnpm/blob/8eb1be4988/config/commands/src/protectedSettings.ts):
+//! credential-bearing keys are replaced with `(protected)` so the command
+//! never prints a token, password, or username.
+
+use serde_json::{Map, Value};
+
+const PROTECTED_SUFFIXES: &[&str] = &["_auth", "_authToken", "username", "_password"];
+
+/// The placeholder written in place of a protected value.
+pub const PROTECTED_PLACEHOLDER: &str = "(protected)";
+
+/// Whether `key` names a protected (credential-bearing) setting. A
+/// per-registry key (`//host/...`) is protected when it ends with one of the
+/// credential suffixes; otherwise the key itself must be one of them.
+///
+/// Mirrors pnpm's `isSettingProtected`.
+#[must_use]
+pub fn is_setting_protected(key: &str) -> bool {
+    if key.starts_with("//") {
+        PROTECTED_SUFFIXES.iter().any(|suffix| key.ends_with(&format!(":{suffix}")))
+    } else {
+        PROTECTED_SUFFIXES.contains(&key)
+    }
+}
+
+/// Replace every protected setting's value with [`PROTECTED_PLACEHOLDER`].
+///
+/// Mirrors pnpm's `censorProtectedSettings`.
+pub fn censor_protected_settings(config: &mut Map<String, Value>) {
+    for (key, value) in config.iter_mut() {
+        if is_setting_protected(key) {
+            *value = Value::String(PROTECTED_PLACEHOLDER.to_string());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/config/src/protected_settings/tests.rs
+++ b/pacquet/crates/config/src/protected_settings/tests.rs
@@ -1,0 +1,35 @@
+use super::{censor_protected_settings, is_setting_protected};
+use serde_json::json;
+
+#[test]
+fn protected_predicate() {
+    assert!(is_setting_protected("username"));
+    assert!(is_setting_protected("_auth"));
+    assert!(is_setting_protected("_authToken"));
+    assert!(is_setting_protected("_password"));
+    assert!(is_setting_protected("//my-org.example.com:username"));
+    assert!(is_setting_protected("//registry.example.com/:_authToken"));
+    assert!(!is_setting_protected("registry"));
+    assert!(!is_setting_protected("@my-org:registry"));
+    assert!(!is_setting_protected("store-dir"));
+}
+
+#[test]
+fn censors_in_place() {
+    let mut map = json!({
+        "storeDir": "~/store",
+        "username": "general-username",
+        "@my-org:registry": "https://my-org.example.com/registry",
+        "//my-org.example.com:username": "my-username-in-my-org",
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+
+    censor_protected_settings(&mut map);
+
+    assert_eq!(map["storeDir"], json!("~/store"));
+    assert_eq!(map["@my-org:registry"], json!("https://my-org.example.com/registry"));
+    assert_eq!(map["username"], json!("(protected)"));
+    assert_eq!(map["//my-org.example.com:username"], json!("(protected)"));
+}

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -136,6 +136,9 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         tls: Default::default(),
         tls_by_uri: Default::default(),
         package_manager_bootstrap: Default::default(),
+        explicit_settings: Default::default(),
+        raw_auth_config: Default::default(),
+        config_dir: None,
     }
 }
 

--- a/pacquet/crates/workspace-manifest-writer/Cargo.toml
+++ b/pacquet/crates/workspace-manifest-writer/Cargo.toml
@@ -18,6 +18,7 @@ indexmap     = { workspace = true }
 miette       = { workspace = true }
 serde        = { workspace = true }
 serde-saphyr = { workspace = true }
+serde_json   = { workspace = true }
 tempfile     = { workspace = true }
 yaml_serde   = { workspace = true }
 yamlpatch    = { workspace = true }

--- a/pacquet/crates/workspace-manifest-writer/src/edit.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/edit.rs
@@ -480,6 +480,80 @@ fn render_bool(value: bool) -> &'static str {
     if value { "true" } else { "false" }
 }
 
+/// Set the top-level `key` to `value` (a non-null JSON value), inserting the
+/// block when absent and replacing it when present. Returns whether anything
+/// changed — a deep-equal current value is a no-op. Used by `pnpm config set`
+/// for arbitrary `pnpm-workspace.yaml` / `config.yaml` keys.
+///
+/// The replace path removes the old block and re-inserts the new one at the
+/// reorder position (rather than an in-place value patch), so the same code
+/// handles scalar and nested-object values uniformly; sibling keys and their
+/// comments are preserved.
+pub(crate) fn set_top_level_field(
+    manifest: &mut Manifest,
+    key: &str,
+    value: &serde_json::Value,
+) -> bool {
+    if current_top_level_value(manifest.text(), key).as_ref() == Some(value) {
+        return false;
+    }
+    let block = render_top_level_field(key, value);
+    if manifest.top_level_keys.iter().any(|existing| existing == key) {
+        manifest.set_text(remove_top_level_block(manifest.text(), key));
+        manifest.top_level_keys.retain(|existing| existing != key);
+    }
+    let new_text = insert_top_level_block(manifest, key, &block);
+    manifest.set_text(new_text);
+    manifest.top_level_keys = render::target_order(&manifest.top_level_keys, &[key.to_string()]);
+    true
+}
+
+/// Remove the top-level `key`. Returns whether anything changed (false when the
+/// key is absent). Used by `pnpm config delete` and by `pnpm config set` when
+/// the cast value is null/undefined.
+pub(crate) fn remove_top_level_field(manifest: &mut Manifest, key: &str) -> bool {
+    if !manifest.top_level_keys.iter().any(|existing| existing == key) {
+        return false;
+    }
+    manifest.set_text(remove_top_level_block(manifest.text(), key));
+    manifest.top_level_keys.retain(|existing| existing != key);
+    true
+}
+
+/// Decode the current value of top-level `key` as JSON, or `None` when the key
+/// is absent or the document does not parse. Used for no-op detection.
+fn current_top_level_value(text: &str, key: &str) -> Option<serde_json::Value> {
+    let map: IndexMap<String, serde_json::Value> = serde_saphyr::from_str(text).ok()?;
+    map.get(key).cloned()
+}
+
+/// Render a brand-new top-level block for `key: value`. Scalars render inline;
+/// objects and arrays render as an indented block body via [`yaml_serde`].
+fn render_top_level_field(key: &str, value: &serde_json::Value) -> String {
+    let key_text = render::render_value(key);
+    match value {
+        serde_json::Value::String(s) => format!("{key_text}: {}\n", render::render_value(s)),
+        serde_json::Value::Number(n) => format!("{key_text}: {n}\n"),
+        serde_json::Value::Bool(b) => format!("{key_text}: {b}\n"),
+        serde_json::Value::Null => format!("{key_text}: null\n"),
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
+            let body =
+                yaml_serde::to_string(value).expect("serializing a JSON value to YAML never fails");
+            let mut out = format!("{key_text}:\n");
+            for line in body.trim_end_matches('\n').lines() {
+                if line.is_empty() {
+                    out.push('\n');
+                } else {
+                    out.push_str("  ");
+                    out.push_str(line);
+                    out.push('\n');
+                }
+            }
+            out
+        }
+    }
+}
+
 /// Where a catalog's entries live (or should be created) in the manifest.
 enum Target {
     /// The top-level `catalog:` shorthand for the default catalog.

--- a/pacquet/crates/workspace-manifest-writer/src/lib.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/lib.rs
@@ -406,6 +406,44 @@ pub fn remove_overrides(
     write_or_remove_manifest(&path, manifest)
 }
 
+/// Set or delete an arbitrary top-level field in the YAML manifest at `path`
+/// (a `pnpm-workspace.yaml` or a global `config.yaml`), preserving the rest of
+/// the document's formatting and writing back only when something changed.
+///
+/// A `null` `value` deletes the key (mirroring pnpm's
+/// [`updateWorkspaceManifest`](https://github.com/pnpm/pnpm/blob/e7e99f04e4/workspace/workspace-manifest-writer/src/index.ts#L75-L83),
+/// where `value == null` `delete`s the field); any other value sets it. When the
+/// edit empties the document, the file is removed. Used by `pnpm config set` /
+/// `pnpm config delete` for the keys routed to a YAML config file.
+pub fn update_manifest_field(
+    path: &Path,
+    key: &str,
+    value: &serde_json::Value,
+) -> Result<(), UpdateWorkspaceManifestError> {
+    let original = match fs::read_to_string(path) {
+        Ok(text) => Some(text),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => None,
+        Err(source) => {
+            return Err(UpdateWorkspaceManifestError::Read { path: path.to_path_buf(), source });
+        }
+    };
+
+    let mut manifest = Manifest::parse(original.as_deref()).map_err(|source| {
+        UpdateWorkspaceManifestError::Parse { path: path.to_path_buf(), source }
+    })?;
+
+    let changed = if value.is_null() {
+        edit::remove_top_level_field(&mut manifest, key)
+    } else {
+        edit::set_top_level_field(&mut manifest, key, value)
+    };
+    if !changed {
+        return Ok(());
+    }
+
+    write_or_remove_manifest(path, manifest)
+}
+
 fn write_or_remove_manifest(
     path: &Path,
     manifest: Manifest,
@@ -437,6 +475,10 @@ fn write_atomic(path: &Path, contents: &str) -> io::Result<()> {
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
+    // Mirror pnpm's `fs.mkdir(dir, { recursive: true })` before writing, so a
+    // global `config.yaml` whose `<configDir>` does not yet exist is created
+    // (`pnpm config set --global`).
+    fs::create_dir_all(dir)?;
     let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
     tmp.write_all(contents.as_bytes())?;
     tmp.as_file().sync_all()?;

--- a/pacquet/crates/workspace-manifest-writer/src/lib.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/lib.rs
@@ -441,6 +441,19 @@ pub fn update_manifest_field(
         return Ok(());
     }
 
+    // A `set` may target a config directory that does not exist yet
+    // (`pnpm config set --global`). Mirror pnpm's `fs.mkdir(dir, { recursive:
+    // true })` before the write; a `delete` never needs it (the file, hence its
+    // parent, already exists).
+    if !value.is_null()
+        && let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).map_err(|source| UpdateWorkspaceManifestError::Write {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    }
+
     write_or_remove_manifest(path, manifest)
 }
 
@@ -475,10 +488,6 @@ fn write_atomic(path: &Path, contents: &str) -> io::Result<()> {
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
-    // Mirror pnpm's `fs.mkdir(dir, { recursive: true })` before writing, so a
-    // global `config.yaml` whose `<configDir>` does not yet exist is created
-    // (`pnpm config set --global`).
-    fs::create_dir_all(dir)?;
     let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
     tmp.write_all(contents.as_bytes())?;
     tmp.as_file().sync_all()?;

--- a/pacquet/crates/workspace-manifest-writer/src/tests.rs
+++ b/pacquet/crates/workspace-manifest-writer/src/tests.rs
@@ -954,3 +954,61 @@ fn remove_overrides_leaves_flow_style_block_with_non_string_entries_untouched() 
     let out = run_remove_overrides(Some(original), &["foo"]).expect("file kept");
     assert_eq!(out, original);
 }
+
+// --- generic top-level field set/delete (pnpm config set / delete) ---
+
+fn run_update_field(
+    original: Option<&str>,
+    key: &str,
+    value: &serde_json::Value,
+) -> Option<String> {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+    if let Some(text) = original {
+        fs::write(&path, text).expect("seed manifest");
+    }
+    crate::update_manifest_field(&path, key, value).expect("update succeeds");
+    fs::read_to_string(&path).ok()
+}
+
+#[test]
+fn set_scalar_field_into_existing_file() {
+    let out =
+        run_update_field(Some("storeDir: ~/store\n"), "fetchTimeout", &serde_json::json!(1000))
+            .expect("file written");
+    let parsed: indexmap::IndexMap<String, serde_json::Value> =
+        serde_saphyr::from_str(&out).expect("parse");
+    assert_eq!(parsed["storeDir"], serde_json::json!("~/store"));
+    assert_eq!(parsed["fetchTimeout"], serde_json::json!(1000));
+}
+
+#[test]
+fn set_object_field_with_json() {
+    let value = serde_json::json!({
+        "@babel/parser": { "peerDependencies": { "@babel/types": "*" } },
+        "jest-circus": { "dependencies": { "slash": "3" } },
+    });
+    let out = run_update_field(None, "packageExtensions", &value).expect("file written");
+    let parsed: serde_json::Value = serde_saphyr::from_str(&out).expect("parse");
+    assert_eq!(parsed["packageExtensions"], value);
+}
+
+#[test]
+fn delete_last_field_removes_file() {
+    let out = run_update_field(
+        Some("virtualStoreDir: .pnpm\n"),
+        "virtualStoreDir",
+        &serde_json::Value::Null,
+    );
+    assert_eq!(out, None);
+}
+
+#[test]
+fn delete_unset_field_is_noop() {
+    let out = run_update_field(Some("cacheDir: ~/cache\n"), "storeDir", &serde_json::Value::Null)
+        .expect("file kept");
+    let parsed: indexmap::IndexMap<String, serde_json::Value> =
+        serde_saphyr::from_str(&out).expect("parse");
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed["cacheDir"], serde_json::json!("~/cache"));
+}


### PR DESCRIPTION
## Summary

Ports pnpm's `config` command to pacquet: `pacquet config set | get | delete | list` (with the `c` alias), mirroring `@pnpm/config.commands` — its file routing, key validation, value casting, and output formatting.

To support it, several pieces of config infrastructure that pacquet lacked were ported into `pacquet-config`:

- `config_types` — the merged `types` registry (`types.ts` ∪ `npmConfigTypes.ts`), plus the `is_ini_config_key` / `is_config_file_key` predicates.
- `naming_cases` (`is_camel_case` / `is_strictly_kebab_case` + kebab/camel conversions), `property_path` (tokenizer + parser + `getObjectValueByPropertyPath`), and `protected_settings` (`(protected)` censoring).
- `Config::explicit_settings`, `Config::raw_auth_config`, and `Config::config_dir` — pacquet's stand-ins for pnpm's `explicitlySetKeys` / `authConfig` / `configDir`, populated while loading the merged config. `explicit_settings` is captured by serializing each settings source (whose fields are `Option`s, so a serialized struct names exactly the keys that source set); `raw_auth_config` is collected from `.npmrc` parsing.

`pacquet-workspace-manifest-writer` gains a generic, format-preserving `update_manifest_field` (scalar/object set + delete, deletes on `null`, removes the emptied file), and a small INI read-modify-write helper backs `.npmrc` / `auth.ini` writes.

Verified with unit tests across the three crates and an end-to-end run of the built binary (`set` routes to `pnpm-workspace.yaml` / `.npmrc` / `config.yaml` / `auth.ini`; `get` resolves typed, auth, scoped-registry, and property-path keys; `list` shows explicit settings + auth keys sorted with protected values censored; `delete` removes an emptied file).

Known minor gaps vs. pnpm (noted for follow-up): the top-level `pnpm get` / `pnpm set` alias commands aren't added (only `pnpm config …` and `c`); without `--location`, config ops default to global (no `--no-global`); and `get` / `list` show the user's raw set values rather than fully-resolved merged values.

## Squash Commit Body

```text
Port pnpm's `config` command (set, get, delete, list; alias `c`) from
`@pnpm/config.commands`, matching its file routing, key validation, value
casting, and output.

Supporting infrastructure ported into `pacquet-config`:
- `config_types`: the merged `types` registry plus `is_ini_config_key` /
  `is_config_file_key` predicates.
- `naming_cases`, `property_path`, `protected_settings`.
- `Config::explicit_settings` / `raw_auth_config` / `config_dir` as the
  stand-ins for pnpm's `explicitlySetKeys` / `authConfig` / `configDir`,
  populated while loading the merged config.

`pacquet-workspace-manifest-writer` gains a generic, format-preserving
`update_manifest_field` (scalar/object set + delete), and a small INI
read-modify-write helper backs `.npmrc` / `auth.ini` writes.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  <!-- The TypeScript `config` command already exists; this is the pacquet port. -->
- [x] Added or updated tests.


---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `config` command with `set`, `get`, `delete`, and `list` actions (including a short alias), supporting project/global scopes and `--json` output.
  * Enabled safe editing of `config.yaml` / `pnpm-workspace.yaml` via top-level field updates.
* **Bug Fixes**
  * Hardened `.npmrc`/INI writes with atomic updates; preserves `.npmrc` permissions on Unix and avoids writing through symlinked `.npmrc`.
  * Rejects control characters in INI `_auth`-related values.
* **Improvements**
  * Better key/value coercion, naming-case conversion, property-path navigation, and protected credential redaction.
* **Tests**
  * Expanded coverage for INI hardening, property paths, and protected-value censoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->