### PR TITLE
fix(pnpr): cap distinct interned configs to bound resolver memory

### DIFF
--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -213,11 +213,18 @@ fn intern_config(
     let registry = if registry.ends_with('/') { registry } else { format!("{registry}/") };
     let overrides: Option<IndexMap<String, String>> =
         request.overrides.as_ref().and_then(|value| serde_json::from_value(value.clone()).ok());
+    // Key on a sorted view of `overrides`: serde_json preserves insertion order
+    // and `IndexMap` is insertion-ordered, so the same overrides sent with a
+    // different key order would otherwise hash to distinct cache keys and intern
+    // duplicate leaked configs — defeating dedup and burning the cap faster.
+    let overrides_key: Option<std::collections::BTreeMap<&str, &str>> = overrides
+        .as_ref()
+        .map(|overrides| overrides.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect());
 
     let key = serde_json::json!({
         "registry": registry,
         "namedRegistries": request.named_registries,
-        "overrides": overrides,
+        "overrides": overrides_key,
         "minimumReleaseAge": request.minimum_release_age,
         "minimumReleaseAgeExclude": request.minimum_release_age_exclude,
         "minimumReleaseAgeIgnoreMissingTime": request.minimum_release_age_ignore_missing_time,

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -46,7 +46,7 @@ mod verdict_cache;
 
 use std::{
     collections::HashMap,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{Arc, Mutex, OnceLock},
     time::{Duration, Instant},
 };
@@ -98,8 +98,9 @@ pub(crate) struct Resolver {
     resolution_cache: Arc<Mutex<HashMap<String, CachedResolution>>>,
     resolution_cache_ttl: Duration,
     /// One leaked `Config` per distinct client registry configuration,
-    /// keyed by its canonical JSON. Bounds the leak to the number of
-    /// distinct client setups the server sees (typically one).
+    /// keyed by its canonical JSON. Capped at [`MAX_INTERNED_CONFIGS`] so a
+    /// caller varying its registry/policy fields can't grow the leak
+    /// without bound; see [`intern_config`].
     configs: Mutex<HashMap<String, &'static PacquetConfig>>,
     /// SQLite-backed whole-lockfile verification verdict cache. `None`
     /// only if the database couldn't be opened — verification then runs
@@ -147,56 +148,99 @@ impl Resolver {
     /// registry configuration. Pacquet's install path resolves against
     /// `config.registry` / `named_registries` / `overrides`, so a request
     /// from a client with a different registry setup gets its own Config.
-    fn config_for(&self, request: &ResolveRequest) -> &'static PacquetConfig {
-        let registry =
-            request.registry.clone().unwrap_or_else(|| "https://registry.npmjs.org/".to_string());
-        let registry = if registry.ends_with('/') { registry } else { format!("{registry}/") };
-        let overrides: Option<IndexMap<String, String>> =
-            request.overrides.as_ref().and_then(|value| serde_json::from_value(value.clone()).ok());
-
-        let key = serde_json::json!({
-            "registry": registry,
-            "namedRegistries": request.named_registries,
-            "overrides": overrides,
-            "minimumReleaseAge": request.minimum_release_age,
-            "minimumReleaseAgeExclude": request.minimum_release_age_exclude,
-            "minimumReleaseAgeIgnoreMissingTime": request.minimum_release_age_ignore_missing_time,
-            "trustPolicy": request.trust_policy,
-            "trustPolicyExclude": request.trust_policy_exclude,
-            "trustPolicyIgnoreAfter": request.trust_policy_ignore_after,
-        })
-        .to_string();
-
-        let mut configs = self.configs.lock().expect("config cache poisoned");
-        if let Some(config) = configs.get(&key) {
-            return config;
-        }
-
-        let mut config = PacquetConfig::new();
-        config.store_dir = self.store_dir.clone();
-        config.cache_dir.clone_from(&self.cache_dir);
-        config.registry = registry;
-        config.named_registries = request.named_registries.clone();
-        config.overrides = overrides;
-        config.modules_dir = PathBuf::from("node_modules");
-        config.lockfile = true;
-        config.verify_store_integrity = true;
-        // The client's verification policy drives both the input-lockfile
-        // verifier and the resolver's pick-time `minimumReleaseAge` /
-        // `trustPolicy` checks, so newly-resolved entries are held to the
-        // same policy as the reused ones.
-        config.minimum_release_age = request.minimum_release_age;
-        config.minimum_release_age_exclude.clone_from(&request.minimum_release_age_exclude);
-        if let Some(ignore_missing_time) = request.minimum_release_age_ignore_missing_time {
-            config.minimum_release_age_ignore_missing_time = ignore_missing_time;
-        }
-        config.trust_policy = request.trust_policy;
-        config.trust_policy_exclude.clone_from(&request.trust_policy_exclude);
-        config.trust_policy_ignore_after = request.trust_policy_ignore_after;
-        let config: &'static PacquetConfig = config.leak();
-        configs.insert(key, config);
-        config
+    ///
+    /// `None` once [`MAX_INTERNED_CONFIGS`] distinct configurations have
+    /// been interned — see [`intern_config`].
+    fn config_for(&self, request: &ResolveRequest) -> Option<&'static PacquetConfig> {
+        intern_config(
+            &self.configs,
+            &self.store_dir,
+            &self.cache_dir,
+            request,
+            MAX_INTERNED_CONFIGS,
+        )
     }
+}
+
+/// Hard cap on how many distinct client configurations the server will
+/// intern. Each interned [`PacquetConfig`] is leaked (the install path
+/// requires a `&'static Config`), so without a cap an authenticated
+/// caller could exhaust memory by varying its registry/policy fields on
+/// every request. `1024` is far above the handful of distinct setups a
+/// real fleet produces (typically one), matching
+/// [`MAX_RESOLUTION_CACHE_ENTRIES`].
+const MAX_INTERNED_CONFIGS: usize = 1024;
+
+/// Returned (as a `503`) when [`MAX_INTERNED_CONFIGS`] is reached. The
+/// limit resets on restart and a real client reuses one configuration, so
+/// a legitimate caller never sees it.
+const TOO_MANY_CONFIGS_MESSAGE: &str = "too many distinct registry configurations";
+
+/// Build + leak a `&'static Config` for a request's registry
+/// configuration, interned by its canonical JSON so repeat requests reuse
+/// it. Returns `None` once `max_interned` distinct configurations have
+/// been interned: a leaked config can never be reclaimed, so refusing to
+/// leak more is the only real bound on the per-request leak — eviction
+/// would just let the same key be re-leaked. The cap is generous enough
+/// that legitimate clients (which reuse one configuration) never hit it.
+fn intern_config(
+    configs: &Mutex<HashMap<String, &'static PacquetConfig>>,
+    store_dir: &StoreDir,
+    cache_dir: &Path,
+    request: &ResolveRequest,
+    max_interned: usize,
+) -> Option<&'static PacquetConfig> {
+    let registry =
+        request.registry.clone().unwrap_or_else(|| "https://registry.npmjs.org/".to_string());
+    let registry = if registry.ends_with('/') { registry } else { format!("{registry}/") };
+    let overrides: Option<IndexMap<String, String>> =
+        request.overrides.as_ref().and_then(|value| serde_json::from_value(value.clone()).ok());
+
+    let key = serde_json::json!({
+        "registry": registry,
+        "namedRegistries": request.named_registries,
+        "overrides": overrides,
+        "minimumReleaseAge": request.minimum_release_age,
+        "minimumReleaseAgeExclude": request.minimum_release_age_exclude,
+        "minimumReleaseAgeIgnoreMissingTime": request.minimum_release_age_ignore_missing_time,
+        "trustPolicy": request.trust_policy,
+        "trustPolicyExclude": request.trust_policy_exclude,
+        "trustPolicyIgnoreAfter": request.trust_policy_ignore_after,
+    })
+    .to_string();
+
+    let mut configs = configs.lock().expect("config cache poisoned");
+    if let Some(config) = configs.get(&key) {
+        return Some(config);
+    }
+    if configs.len() >= max_interned {
+        return None;
+    }
+
+    let mut config = PacquetConfig::new();
+    config.store_dir = store_dir.clone();
+    config.cache_dir = cache_dir.to_path_buf();
+    config.registry = registry;
+    config.named_registries = request.named_registries.clone();
+    config.overrides = overrides;
+    config.modules_dir = PathBuf::from("node_modules");
+    config.lockfile = true;
+    config.verify_store_integrity = true;
+    // The client's verification policy drives both the input-lockfile
+    // verifier and the resolver's pick-time `minimumReleaseAge` /
+    // `trustPolicy` checks, so newly-resolved entries are held to the
+    // same policy as the reused ones.
+    config.minimum_release_age = request.minimum_release_age;
+    config.minimum_release_age_exclude.clone_from(&request.minimum_release_age_exclude);
+    if let Some(ignore_missing_time) = request.minimum_release_age_ignore_missing_time {
+        config.minimum_release_age_ignore_missing_time = ignore_missing_time;
+    }
+    config.trust_policy = request.trust_policy;
+    config.trust_policy_exclude.clone_from(&request.trust_policy_exclude);
+    config.trust_policy_ignore_after = request.trust_policy_ignore_after;
+    let config: &'static PacquetConfig = config.leak();
+    configs.insert(key, config);
+    Some(config)
 }
 
 /// Handle `POST /-/pnpr/v0/resolve`: verify the client's input lockfile under
@@ -220,7 +264,9 @@ pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response 
     };
 
     // Resolve against the client's registries, not the server's own.
-    let config = runtime.config_for(&request);
+    let Some(config) = runtime.config_for(&request) else {
+        return json_error(StatusCode::SERVICE_UNAVAILABLE, TOO_MANY_CONFIGS_MESSAGE);
+    };
     let package_version_guard =
         runtime.osv_index.as_ref().map(|index| Arc::clone(index) as Arc<dyn PackageVersionGuard>);
 
@@ -341,7 +387,9 @@ pub(crate) async fn handle_verify_lockfile(runtime: &Resolver, body: Bytes) -> R
         return verify_done_or_osv_violations(runtime.osv_index.as_ref(), input_lockfile);
     }
 
-    let config = runtime.config_for(&request);
+    let Some(config) = runtime.config_for(&request) else {
+        return json_error(StatusCode::SERVICE_UNAVAILABLE, TOO_MANY_CONFIGS_MESSAGE);
+    };
     let request_auth = Arc::new(AuthHeaders::from_by_scope(request.auth_headers.clone()));
 
     match verify_input_lockfile(runtime, config, &request_auth, input_lockfile).await {

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -158,6 +158,7 @@ impl Resolver {
             &self.cache_dir,
             request,
             MAX_INTERNED_CONFIGS,
+            MAX_CONFIG_KEY_BYTES,
         )
     }
 }
@@ -176,19 +177,36 @@ const MAX_INTERNED_CONFIGS: usize = 1024;
 /// a legitimate caller never sees it.
 const TOO_MANY_CONFIGS_MESSAGE: &str = "too many distinct registry configurations";
 
+/// Hard cap on the byte size of a single interned config's canonical key,
+/// which carries its attacker-controlled `registry` / `namedRegistries` /
+/// `overrides` content. [`MAX_INTERNED_CONFIGS`] bounds only the *count* of
+/// leaked configs; without this a caller could pad each distinct config with
+/// a giant overrides/named-registries map and still amplify the per-request
+/// leak (the whole request body is allowed up to the publish-sized limit).
+/// `128 KiB` is far above any real registry/overrides configuration.
+const MAX_CONFIG_KEY_BYTES: usize = 128 * 1024;
+
 /// Build + leak a `&'static Config` for a request's registry
 /// configuration, interned by its canonical JSON so repeat requests reuse
-/// it. Returns `None` once `max_interned` distinct configurations have
-/// been interned: a leaked config can never be reclaimed, so refusing to
-/// leak more is the only real bound on the per-request leak — eviction
-/// would just let the same key be re-leaked. The cap is generous enough
-/// that legitimate clients (which reuse one configuration) never hit it.
+/// it. Returns `None` when the config can't be safely interned:
+///
+/// * once `max_interned` distinct configurations have been interned — a
+///   leaked config can never be reclaimed, so refusing to leak more is the
+///   only real bound on the per-request leak (eviction would just let the
+///   same key be re-leaked); or
+/// * when a single config's canonical key exceeds `max_key_bytes`, which
+///   bounds the *size* of each leaked config so a caller can't amplify the
+///   leak with a giant `overrides` / `namedRegistries` map.
+///
+/// Both caps are generous enough that legitimate clients (which reuse one
+/// small configuration) never hit them.
 fn intern_config(
     configs: &Mutex<HashMap<String, &'static PacquetConfig>>,
     store_dir: &StoreDir,
     cache_dir: &Path,
     request: &ResolveRequest,
     max_interned: usize,
+    max_key_bytes: usize,
 ) -> Option<&'static PacquetConfig> {
     let registry =
         request.registry.clone().unwrap_or_else(|| "https://registry.npmjs.org/".to_string());
@@ -208,6 +226,9 @@ fn intern_config(
         "trustPolicyIgnoreAfter": request.trust_policy_ignore_after,
     })
     .to_string();
+    if key.len() > max_key_bytes {
+        return None;
+    }
 
     let mut configs = configs.lock().expect("config cache poisoned");
     if let Some(config) = configs.get(&key) {

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -264,3 +264,24 @@ fn intern_config_refuses_a_config_key_larger_than_the_byte_cap() {
     let oversized = format!("https://{}.test/", "x".repeat(2048));
     assert!(intern(&oversized).is_none());
 }
+
+#[test]
+fn intern_config_keys_overrides_canonically_regardless_of_order() {
+    use super::intern_config;
+    use pacquet_store_dir::StoreDir;
+    use std::{collections::HashMap, path::PathBuf, sync::Mutex};
+
+    let configs = Mutex::new(HashMap::new());
+    let store_dir = StoreDir::new(PathBuf::from("/tmp/pnpr-canon-test-store"));
+    let cache_dir = PathBuf::from("/tmp/pnpr-canon-test-cache");
+    let intern = |overrides: serde_json::Value| {
+        let request = ResolveRequest { overrides: Some(overrides), ..ResolveRequest::default() };
+        intern_config(&configs, &store_dir, &cache_dir, &request, 10, usize::MAX)
+    };
+
+    // The same overrides sent with a different JSON key order must dedup to a
+    // single interned config, not leak two.
+    assert!(intern(serde_json::json!({ "a": "1.0.0", "b": "2.0.0" })).is_some());
+    assert!(intern(serde_json::json!({ "b": "2.0.0", "a": "1.0.0" })).is_some());
+    assert_eq!(configs.lock().expect("config cache poisoned").len(), 1);
+}

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -280,8 +280,11 @@ fn intern_config_keys_overrides_canonically_regardless_of_order() {
     };
 
     // The same overrides sent with a different JSON key order must dedup to a
-    // single interned config, not leak two.
-    assert!(intern(serde_json::json!({ "a": "1.0.0", "b": "2.0.0" })).is_some());
-    assert!(intern(serde_json::json!({ "b": "2.0.0", "a": "1.0.0" })).is_some());
+    // single interned config — the second call returns the *same* leaked
+    // config, not a new one, and the map stays at one entry.
+    let first =
+        intern(serde_json::json!({ "a": "1.0.0", "b": "2.0.0" })).expect("first config interned");
+    let second = intern(serde_json::json!({ "b": "2.0.0", "a": "1.0.0" })).expect("config reused");
+    assert!(std::ptr::eq(first, second));
     assert_eq!(configs.lock().expect("config cache poisoned").len(), 1);
 }

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -205,3 +205,44 @@ fn tarball_url_version_extracts_conventional_names_only() {
     assert_eq!(tarball_url_version("https://r/weird.tgz", "foo"), None);
     assert_eq!(tarball_url_version("https://r/foo/-/foo.tgz", "foo"), None);
 }
+
+#[test]
+fn intern_config_caps_distinct_leaked_configs_but_keeps_serving_known_ones() {
+    use super::intern_config;
+    use pacquet_store_dir::StoreDir;
+    use std::{collections::HashMap, path::PathBuf, sync::Mutex};
+
+    let configs = Mutex::new(HashMap::new());
+    let store_dir = StoreDir::new(PathBuf::from("/tmp/pnpr-intern-test-store"));
+    let cache_dir = PathBuf::from("/tmp/pnpr-intern-test-cache");
+    let max = 2;
+
+    let registry_request = |registry: &str| ResolveRequest {
+        registry: Some(registry.to_string()),
+        ..ResolveRequest::default()
+    };
+
+    // Distinct registry configurations are interned up to the cap.
+    assert!(
+        intern_config(&configs, &store_dir, &cache_dir, &registry_request("https://a.test/"), max)
+            .is_some()
+    );
+    assert!(
+        intern_config(&configs, &store_dir, &cache_dir, &registry_request("https://b.test/"), max)
+            .is_some()
+    );
+
+    // A new distinct configuration past the cap is refused, not leaked — this
+    // is the bound on how much an authenticated caller can make the server
+    // leak by varying its registry/policy fields.
+    assert!(
+        intern_config(&configs, &store_dir, &cache_dir, &registry_request("https://c.test/"), max)
+            .is_none()
+    );
+
+    // An already-interned configuration is still served even at the cap.
+    assert!(
+        intern_config(&configs, &store_dir, &cache_dir, &registry_request("https://a.test/"), max)
+            .is_some()
+    );
+}

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -217,32 +217,50 @@ fn intern_config_caps_distinct_leaked_configs_but_keeps_serving_known_ones() {
     let cache_dir = PathBuf::from("/tmp/pnpr-intern-test-cache");
     let max = 2;
 
-    let registry_request = |registry: &str| ResolveRequest {
+    let request = |registry: &str| ResolveRequest {
         registry: Some(registry.to_string()),
         ..ResolveRequest::default()
     };
+    let intern = |registry: &str| {
+        intern_config(&configs, &store_dir, &cache_dir, &request(registry), max, usize::MAX)
+    };
 
     // Distinct registry configurations are interned up to the cap.
-    assert!(
-        intern_config(&configs, &store_dir, &cache_dir, &registry_request("https://a.test/"), max)
-            .is_some()
-    );
-    assert!(
-        intern_config(&configs, &store_dir, &cache_dir, &registry_request("https://b.test/"), max)
-            .is_some()
-    );
+    assert!(intern("https://a.test/").is_some());
+    assert!(intern("https://b.test/").is_some());
 
     // A new distinct configuration past the cap is refused, not leaked — this
     // is the bound on how much an authenticated caller can make the server
     // leak by varying its registry/policy fields.
-    assert!(
-        intern_config(&configs, &store_dir, &cache_dir, &registry_request("https://c.test/"), max)
-            .is_none()
-    );
+    assert!(intern("https://c.test/").is_none());
+    // ...and nothing was interned beyond the cap (the refusal didn't leak).
+    assert_eq!(configs.lock().expect("config cache poisoned").len(), max);
 
     // An already-interned configuration is still served even at the cap.
-    assert!(
-        intern_config(&configs, &store_dir, &cache_dir, &registry_request("https://a.test/"), max)
-            .is_some()
-    );
+    assert!(intern("https://a.test/").is_some());
+}
+
+#[test]
+fn intern_config_refuses_a_config_key_larger_than_the_byte_cap() {
+    use super::intern_config;
+    use pacquet_store_dir::StoreDir;
+    use std::{collections::HashMap, path::PathBuf, sync::Mutex};
+
+    let configs = Mutex::new(HashMap::new());
+    let store_dir = StoreDir::new(PathBuf::from("/tmp/pnpr-bytecap-test-store"));
+    let cache_dir = PathBuf::from("/tmp/pnpr-bytecap-test-cache");
+    let request = |registry: &str| ResolveRequest {
+        registry: Some(registry.to_string()),
+        ..ResolveRequest::default()
+    };
+    let intern = |registry: &str| {
+        intern_config(&configs, &store_dir, &cache_dir, &request(registry), 10, 1024)
+    };
+
+    // A normal configuration is interned.
+    assert!(intern("https://a.test/").is_some());
+    // A configuration whose canonical key exceeds the byte cap is refused, so a
+    // caller can't amplify the per-config leak with a giant overrides/registry.
+    let oversized = format!("https://{}.test/", "x".repeat(2048));
+    assert!(intern(&oversized).is_none());
 }


### PR DESCRIPTION
## Summary

The pnpr resolver interns one `&'static Config` per distinct client
configuration — keyed by the canonical JSON of the caller-supplied
`registry`, `namedRegistries`, `overrides`, and verification policy — and
this cache was unbounded. Each config is **leaked** (`config.leak()`)
because pacquet's install path requires a `&'static Config`.

An authenticated caller of `POST /-/pnpr/v0/resolve` (or
`/-/pnpr/v0/verify-lockfile`) can therefore exhaust the server's memory by
sending a fresh registry/policy combination on every request: each
distinct key leaks another `Config` that can never be reclaimed. The
field's "typically one distinct config" rationale only holds for honest
clients.

This caps the cache at `MAX_INTERNED_CONFIGS` (`1024`, matching the
existing `MAX_RESOLUTION_CACHE_ENTRIES`). Past the cap, both endpoints
return `503` instead of interning more. The interning logic is extracted
into a free `intern_config` function so the bound is unit-testable
without standing up a whole `Resolver`.

Why a hard cap and not LRU eviction: a leaked config can't be freed, and
removing its key from the map would just let the same key be re-leaked on
the next request — so refusing to leak past a fixed cap is the only real
bound. Reclaiming memory instead would mean threading `Arc<Config>`
through pacquet's install path in place of `&'static Config`, which is out
of scope here. The cap is far above the handful of distinct setups a real
fleet produces, and it resets on restart, so legitimate callers never hit
it.

## Squash Commit Body

```text
The resolve and verify-lockfile endpoints intern one `&'static Config`
per distinct client configuration, keyed by the canonical JSON of the
caller-supplied registry, namedRegistries, overrides, and verification
policy. Each config is leaked because pacquet's install path requires a
`&'static Config`, and the cache was unbounded.

An authenticated caller could exhaust the server's memory by sending a
request with a fresh registry/policy combination every time: each
distinct key leaks another config that can never be reclaimed.

Cap the cache at MAX_INTERNED_CONFIGS (1024, matching
MAX_RESOLUTION_CACHE_ENTRIES); past the cap, both endpoints return 503
instead of interning more. Eviction is not an option — a leaked config
can't be freed, and removing its key would just let it be re-leaked, so
a hard cap is the only real bound. Reclaiming memory instead would
require threading Arc<Config> through pacquet's install path in place of
`&'static Config`, which is out of scope.
```

## Checklist

- [x] Added or updated tests.
- [x] Updated the documentation if needed (doc comments on the cap and the
  `configs` field).

<!-- pnpr is a server with no pnpm-CLI counterpart to mirror (see
pnpr/AGENTS.md), so the TS/pacquet parity item does not apply. pnpr is not a
published npm package, so no changeset is needed. -->

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolver endpoints now return a clear **HTTP 503** with a JSON error (“too many configs”) when configuration interning limits are reached.
  * Once the limit is hit, the service continues using previously cached configurations instead of failing.
  * Added stricter protection to refuse requests that would exceed the configured canonical key size limit.
* **Tests**
  * Added unit tests covering distinct-config capping, byte-limit rejection, and override deduplication regardless of JSON key order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->