### PR TITLE
fix(pnpr): reject link-local registry hosts to block resolver SSRF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4132,6 +4132,7 @@ dependencies = [
  "reqwest 0.13.4",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/pacquet/crates/network/Cargo.toml
+++ b/pacquet/crates/network/Cargo.toml
@@ -17,6 +17,7 @@ pipe-trait  = { workspace = true }
 reqwest     = { workspace = true }
 tokio       = { workspace = true, features = ["time"] }
 tracing     = { workspace = true }
+url         = { workspace = true }
 
 [dev-dependencies]
 mockito               = { workspace = true }

--- a/pacquet/crates/network/src/lib.rs
+++ b/pacquet/crates/network/src/lib.rs
@@ -421,6 +421,54 @@ fn default_client_builder(settings: &NetworkSettings) -> reqwest::ClientBuilder 
         .timeout(settings.fetch_timeout)
         .pool_idle_timeout(Duration::from_secs(4))
         .hickory_dns(true)
+        // Reject redirects to link-local / instance-metadata hosts: a
+        // (client-supplied) registry that 302-redirects there must not be
+        // able to turn a server-side metadata fetch into SSRF. Legitimate
+        // redirects to other hosts still follow, up to the default depth.
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            if attempt.previous().len() >= 10 {
+                attempt.error("too many redirects")
+            } else if is_blocked_request_host(attempt.url()) {
+                attempt.error("redirect to a link-local or instance-metadata host is not allowed")
+            } else {
+                attempt.follow()
+            }
+        }))
+}
+
+/// Hostnames that resolve into the link-local instance-metadata range but
+/// don't look like a link-local address. Kept tiny and explicit — the IP
+/// checks in [`is_blocked_request_host`] cover the addresses themselves.
+const BLOCKED_REQUEST_HOSTS: &[&str] = &["metadata.google.internal"];
+
+/// Whether a URL targets a host the install / resolver clients must never
+/// connect to: the link-local range that fronts cloud instance metadata
+/// (`169.254.0.0/16`, `fe80::/10`, and IPv4-mapped link-local addresses)
+/// plus the well-known metadata hostnames that resolve into it.
+///
+/// Used both as a request-boundary check (on a URL a client supplies) and
+/// as the client redirect policy in `default_client_builder`, so a
+/// redirect can't reach a blocked host that a boundary check on the
+/// *original* URL would miss (e.g. an allowed host that `302`s to
+/// `http://169.254.169.254/`). A trailing dot on a domain
+/// (`metadata.google.internal.`) is normalized away before matching.
+/// Private and loopback addresses are deliberately allowed — resolving
+/// against an internal registry (or a loopback dev registry) is legitimate.
+#[must_use]
+pub fn is_blocked_request_host(url: &url::Url) -> bool {
+    match url.host() {
+        Some(url::Host::Ipv4(addr)) => addr.is_link_local(),
+        Some(url::Host::Ipv6(addr)) => {
+            // fe80::/10, plus any IPv4-mapped form of a link-local v4 address.
+            (addr.segments()[0] & 0xffc0) == 0xfe80
+                || addr.to_ipv4_mapped().is_some_and(|v4| v4.is_link_local())
+        }
+        Some(url::Host::Domain(host)) => {
+            let host = host.strip_suffix('.').unwrap_or(host);
+            BLOCKED_REQUEST_HOSTS.iter().any(|blocked| host.eq_ignore_ascii_case(blocked))
+        }
+        None => false,
+    }
 }
 
 /// Load the PEM bundle named by `NODE_EXTRA_CA_CERTS` as extra trust

--- a/pacquet/crates/network/src/tests.rs
+++ b/pacquet/crates/network/src/tests.rs
@@ -726,3 +726,30 @@ fn default_network_concurrency_stays_within_floor_and_cap() {
     let concurrency = super::default_network_concurrency();
     assert!((64..=96).contains(&concurrency), "got {concurrency}");
 }
+
+/// [`super::is_blocked_request_host`] blocks the link-local instance-metadata
+/// range and well-known metadata hostnames (including the trailing-dot FQDN
+/// form), while allowing public, private, and loopback registries. This is
+/// the predicate the install client's redirect policy and pnpr's
+/// request-boundary check share.
+#[test]
+fn is_blocked_request_host_blocks_link_local_and_metadata_only() {
+    let blocked = |u: &str| super::is_blocked_request_host(&url::Url::parse(u).unwrap());
+
+    // Link-local IPv4 (cloud instance metadata) and the range around it.
+    assert!(blocked("http://169.254.169.254/"));
+    assert!(blocked("http://169.254.0.1:8080/path/"));
+    // Link-local IPv6 (fe80::/10) and an IPv4-mapped link-local address.
+    assert!(blocked("http://[fe80::1]/"));
+    assert!(blocked("http://[::ffff:169.254.169.254]/"));
+    // Metadata hostname: case-insensitive and trailing-dot (root-zone) FQDN.
+    assert!(blocked("https://metadata.google.internal/"));
+    assert!(blocked("https://Metadata.Google.Internal/"));
+    assert!(blocked("https://metadata.google.internal./"));
+
+    // Public, private, and loopback hosts are allowed.
+    assert!(!blocked("https://registry.npmjs.org/"));
+    assert!(!blocked("http://10.0.0.5:4873/"));
+    assert!(!blocked("http://192.168.1.10/"));
+    assert!(!blocked("http://127.0.0.1:4873/"));
+}

--- a/pacquet/crates/network/src/tests.rs
+++ b/pacquet/crates/network/src/tests.rs
@@ -753,3 +753,34 @@ fn is_blocked_request_host_blocks_link_local_and_metadata_only() {
     assert!(!blocked("http://192.168.1.10/"));
     assert!(!blocked("http://127.0.0.1:4873/"));
 }
+
+/// End-to-end proof that the redirect policy in `default_client_builder`
+/// actually rejects a redirect to a blocked host — not merely that the
+/// predicate is correct. A loopback mock server (an allowed host)
+/// `302`-redirects to `http://169.254.169.254/`, and the client must fail
+/// the request during redirect handling rather than connect to the
+/// metadata host.
+#[tokio::test]
+async fn redirect_to_a_link_local_host_is_rejected_by_the_client() {
+    let mut server = mockito::Server::new_async().await;
+    let redirect = server
+        .mock("GET", "/pkg")
+        .with_status(302)
+        .with_header("location", "http://169.254.169.254/latest/meta-data/")
+        .create_async()
+        .await;
+
+    let client = super::ThrottledClient::new_for_installs();
+    let guard = client.acquire().await;
+    let err = guard
+        .get(format!("{}/pkg", server.url()))
+        .send()
+        .await
+        .expect_err("redirect to a link-local host must fail");
+
+    let debug = format!("{err:?}");
+    eprintln!("err={debug}");
+    assert!(debug.contains("link-local or instance-metadata host"), "err={debug}");
+    // The initial (allowed) request was made; the blocked redirect was not.
+    redirect.assert_async().await;
+}

--- a/pacquet/crates/network/src/tests.rs
+++ b/pacquet/crates/network/src/tests.rs
@@ -734,7 +734,8 @@ fn default_network_concurrency_stays_within_floor_and_cap() {
 /// request-boundary check share.
 #[test]
 fn is_blocked_request_host_blocks_link_local_and_metadata_only() {
-    let blocked = |u: &str| super::is_blocked_request_host(&url::Url::parse(u).unwrap());
+    let blocked =
+        |url_str: &str| super::is_blocked_request_host(&url::Url::parse(url_str).unwrap());
 
     // Link-local IPv4 (cloud instance metadata) and the range around it.
     assert!(blocked("http://169.254.169.254/"));

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -202,33 +202,16 @@ impl Resolver {
 /// Hostnames that resolve into the link-local instance-metadata range but
 /// don't look like a link-local address. Kept tiny and explicit — the IP
 /// check below covers the addresses themselves.
-const BLOCKED_METADATA_HOSTS: &[&str] = &["metadata.google.internal"];
-
-/// Whether a client-supplied registry URL points at a host the resolver
-/// must never fetch from: the link-local range that fronts cloud instance
-/// metadata (`169.254.0.0/16`, `fe80::/10`) plus the well-known metadata
-/// hostnames that resolve into it. Private and loopback addresses are
-/// deliberately *allowed* — resolving against an internal registry is
-/// pnpr's core use case. This is a request-boundary check on the URL the
-/// client sends; a hostname that only *resolves* to a link-local address
-/// at connect time (DNS rebinding) is out of scope here. A value that
-/// doesn't parse as a URL can't drive a fetch, so it isn't blocked.
+/// Whether a client-supplied registry URL string points at a host the
+/// resolver must never fetch from. Delegates to
+/// [`pacquet_network::is_blocked_request_host`] so this request-boundary
+/// check and the install client's redirect policy share one definition —
+/// an attacker can't slip past the boundary by pointing `registry` at an
+/// allowed host that redirects to a link-local / instance-metadata host.
+/// A value that doesn't parse as a URL can't drive a fetch, so it isn't
+/// blocked here.
 fn is_blocked_registry_host(registry: &str) -> bool {
-    let Ok(url) = url::Url::parse(registry) else {
-        return false;
-    };
-    match url.host() {
-        Some(url::Host::Ipv4(addr)) => addr.is_link_local(),
-        Some(url::Host::Ipv6(addr)) => {
-            // fe80::/10, plus any IPv4-mapped form of a link-local v4 address.
-            (addr.segments()[0] & 0xffc0) == 0xfe80
-                || addr.to_ipv4_mapped().is_some_and(|v4| v4.is_link_local())
-        }
-        Some(url::Host::Domain(host)) => {
-            BLOCKED_METADATA_HOSTS.iter().any(|blocked| host.eq_ignore_ascii_case(blocked))
-        }
-        None => false,
-    }
+    url::Url::parse(registry).is_ok_and(|url| pacquet_network::is_blocked_request_host(&url))
 }
 
 /// Reject (as `400`) a request that would point the resolver's

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -199,6 +199,57 @@ impl Resolver {
     }
 }
 
+/// Hostnames that resolve into the link-local instance-metadata range but
+/// don't look like a link-local address. Kept tiny and explicit — the IP
+/// check below covers the addresses themselves.
+const BLOCKED_METADATA_HOSTS: &[&str] = &["metadata.google.internal"];
+
+/// Whether a client-supplied registry URL points at a host the resolver
+/// must never fetch from: the link-local range that fronts cloud instance
+/// metadata (`169.254.0.0/16`, `fe80::/10`) plus the well-known metadata
+/// hostnames that resolve into it. Private and loopback addresses are
+/// deliberately *allowed* — resolving against an internal registry is
+/// pnpr's core use case. This is a request-boundary check on the URL the
+/// client sends; a hostname that only *resolves* to a link-local address
+/// at connect time (DNS rebinding) is out of scope here. A value that
+/// doesn't parse as a URL can't drive a fetch, so it isn't blocked.
+fn is_blocked_registry_host(registry: &str) -> bool {
+    let Ok(url) = url::Url::parse(registry) else {
+        return false;
+    };
+    match url.host() {
+        Some(url::Host::Ipv4(addr)) => addr.is_link_local(),
+        Some(url::Host::Ipv6(addr)) => {
+            // fe80::/10, plus any IPv4-mapped form of a link-local v4 address.
+            (addr.segments()[0] & 0xffc0) == 0xfe80
+                || addr.to_ipv4_mapped().is_some_and(|v4| v4.is_link_local())
+        }
+        Some(url::Host::Domain(host)) => {
+            BLOCKED_METADATA_HOSTS.iter().any(|blocked| host.eq_ignore_ascii_case(blocked))
+        }
+        None => false,
+    }
+}
+
+/// Reject (as `400`) a request that would point the resolver's
+/// server-side metadata fetches at a blocked host — see
+/// [`is_blocked_registry_host`]. Both the default registry and every
+/// named-registry alias are checked. The message stays generic so a
+/// registry URL carrying credentials isn't echoed back.
+fn reject_blocked_registries(request: &ResolveRequest) -> Option<Response> {
+    let registries =
+        request.registry.iter().chain(request.named_registries.values()).map(String::as_str);
+    for registry in registries {
+        if is_blocked_registry_host(registry) {
+            return Some(json_error(
+                StatusCode::BAD_REQUEST,
+                "registry host is not allowed (link-local and instance-metadata addresses are blocked)",
+            ));
+        }
+    }
+    None
+}
+
 /// Handle `POST /-/pnpr/v0/resolve`: verify the client's input lockfile under
 /// the client's policy, resolve against the client's registries, and
 /// stream the result back as NDJSON.
@@ -220,6 +271,9 @@ pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response 
     };
 
     // Resolve against the client's registries, not the server's own.
+    if let Some(blocked) = reject_blocked_registries(&request) {
+        return blocked;
+    }
     let config = runtime.config_for(&request);
     let package_version_guard =
         runtime.osv_index.as_ref().map(|index| Arc::clone(index) as Arc<dyn PackageVersionGuard>);
@@ -341,6 +395,9 @@ pub(crate) async fn handle_verify_lockfile(runtime: &Resolver, body: Bytes) -> R
         return verify_done_or_osv_violations(runtime.osv_index.as_ref(), input_lockfile);
     }
 
+    if let Some(blocked) = reject_blocked_registries(&request) {
+        return blocked;
+    }
     let config = runtime.config_for(&request);
     let request_auth = Arc::new(AuthHeaders::from_by_scope(request.auth_headers.clone()));
 

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -205,3 +205,54 @@ fn tarball_url_version_extracts_conventional_names_only() {
     assert_eq!(tarball_url_version("https://r/weird.tgz", "foo"), None);
     assert_eq!(tarball_url_version("https://r/foo/-/foo.tgz", "foo"), None);
 }
+
+#[test]
+fn link_local_and_metadata_registries_are_blocked_but_private_ones_are_not() {
+    use super::is_blocked_registry_host;
+
+    // Cloud instance-metadata via link-local IPv4 (and the range around it).
+    assert!(is_blocked_registry_host("http://169.254.169.254/"));
+    assert!(is_blocked_registry_host("http://169.254.0.1:8080/path/"));
+    // Link-local IPv6 (fe80::/10) and an IPv4-mapped link-local address.
+    assert!(is_blocked_registry_host("http://[fe80::1]/"));
+    assert!(is_blocked_registry_host("http://[::ffff:169.254.169.254]/"));
+    // Well-known metadata hostname, case-insensitively.
+    assert!(is_blocked_registry_host("https://Metadata.Google.Internal/"));
+
+    // Private and loopback registries are deliberately allowed — resolving
+    // against an internal registry is pnpr's core use case.
+    assert!(!is_blocked_registry_host("https://registry.npmjs.org/"));
+    assert!(!is_blocked_registry_host("http://10.0.0.5:4873/"));
+    assert!(!is_blocked_registry_host("http://192.168.1.10/"));
+    assert!(!is_blocked_registry_host("http://127.0.0.1:4873/"));
+    // A non-URL can't drive a fetch, so it isn't treated as blocked here.
+    assert!(!is_blocked_registry_host("not-a-url"));
+}
+
+#[test]
+fn reject_blocked_registries_checks_the_default_and_named_registries() {
+    use super::reject_blocked_registries;
+    use std::collections::BTreeMap;
+
+    let clean = ResolveRequest {
+        registry: Some("https://registry.npmjs.org/".to_string()),
+        ..ResolveRequest::default()
+    };
+    assert!(reject_blocked_registries(&clean).is_none());
+
+    let blocked_default = ResolveRequest {
+        registry: Some("http://169.254.169.254/".to_string()),
+        ..ResolveRequest::default()
+    };
+    assert!(reject_blocked_registries(&blocked_default).is_some());
+
+    let blocked_named = ResolveRequest {
+        registry: Some("https://registry.npmjs.org/".to_string()),
+        named_registries: BTreeMap::from([(
+            "@scope".to_string(),
+            "http://169.254.169.254/".to_string(),
+        )]),
+        ..ResolveRequest::default()
+    };
+    assert!(reject_blocked_registries(&blocked_named).is_some());
+}

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -218,6 +218,8 @@ fn link_local_and_metadata_registries_are_blocked_but_private_ones_are_not() {
     assert!(is_blocked_registry_host("http://[::ffff:169.254.169.254]/"));
     // Well-known metadata hostname, case-insensitively.
     assert!(is_blocked_registry_host("https://Metadata.Google.Internal/"));
+    // A trailing dot (root-zone FQDN) must not bypass the metadata-host match.
+    assert!(is_blocked_registry_host("https://metadata.google.internal./"));
 
     // Private and loopback registries are deliberately allowed — resolving
     // against an internal registry is pnpr's core use case.


### PR DESCRIPTION
## Summary

To shape a lockfile, `POST /-/pnpr/v0/resolve` and
`POST /-/pnpr/v0/verify-lockfile` fetch package **metadata** server-side
from the registry the client supplies — the `registry` default and every
`namedRegistries` alias. Those URLs were used verbatim, so an
authenticated caller could point them at the link-local range that fronts
cloud instance metadata (e.g. `http://169.254.169.254/`) and make the
server issue requests from its own network position — SSRF, including the
classic IMDS credential-theft target.

This rejects, at the request boundary, any registry whose host is:

- a link-local IPv4 address (`169.254.0.0/16`),
- a link-local IPv6 address (`fe80::/10`), or an IPv4-mapped form of a
  link-local v4 address, or
- a well-known metadata hostname (`metadata.google.internal`).

**Private and loopback addresses are deliberately still allowed** —
resolving against an internal registry (often on `10.x`/`192.168.x` or
behind `localhost` in dev) is pnpr's core use case, so blanket private-IP
blocking would break legitimate deployments.

### Scope / residual risk

This is a check on the URL string the client sends. A hostname that
*resolves* to a link-local address only at connect time (DNS rebinding)
is **not** covered here — closing that needs a connect-time guard in the
HTTP client's connector, which is a larger change left for a follow-up.
The check is applied before any server-side fetch on both endpoints.

## Squash Commit Body

```text
The resolve and verify-lockfile endpoints fetch package metadata
server-side from the registry the client sends (registry and the
namedRegistries aliases). Those URLs were used verbatim, so an
authenticated caller could point them at the link-local range that fronts
cloud instance metadata (e.g. http://169.254.169.254/) and make the
server issue requests from its own network position (SSRF).

Reject, at the request boundary, any registry whose host is a link-local
address (169.254.0.0/16, fe80::/10, or an IPv4-mapped link-local
address) or a well-known metadata hostname. Private and loopback
addresses stay allowed: resolving against an internal registry is pnpr's
core use case.

This is a boundary check on the URL the client sends; a hostname that
only resolves to a link-local address at connect time (DNS rebinding) is
not covered and would need a connect-time guard in the HTTP client.
```

## Checklist

- [x] Added or updated tests.
- [x] Updated the documentation if needed (doc comments on the new guard).

<!-- pnpr is a server with no pnpm-CLI counterpart to mirror (see
pnpr/AGENTS.md), so the TS/pacquet parity item does not apply. pnpr is not a
published npm package, so no changeset is needed. -->

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked client-supplied registry hosts that target link-local or instance-metadata address ranges, validating during both resolution and lockfile verification.
  * Prevented registry-controlled redirects to blocked link-local/instance-metadata destinations.
  * When blocked, the API now returns a generic bad-request error without echoing sensitive registry URL details.
* **Tests**
  * Added resolver and network coverage for blocked vs. allowed hosts, including case-insensitive and trailing-dot forms, plus redirect rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->