### PR TITLE
fix(package-manager): don't wipe node_modules on an included-deps change

### DIFF
--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -338,6 +338,12 @@ pub enum InstallError {
     #[display("Failed to remove modules directory contents: {_0}")]
     RemoveModulesDir(#[error(source)] std::io::Error),
 
+    /// Surfaces a failure while removing the direct-dep links an
+    /// `included` drift excluded — the non-destructive counterpart of
+    /// the purge. See [`crate::prune_direct_deps_excluded_by_groups`].
+    #[diagnostic(transparent)]
+    PruneDirectDeps(#[error(source)] crate::PruneDirectDepsError),
+
     /// `pnpm-lock.yaml` doesn't match the on-disk `package.json` for
     /// the project being installed. `ERR_PNPM_OUTDATED_LOCKFILE`:
     /// the user (or CI) edited the manifest without regenerating the
@@ -1117,6 +1123,27 @@ where
             }
         }
 
+        // An included-only drift (`--prod`<->full, `--no-optional`)
+        // skips the purge above, so the direct-dep links the previous
+        // install created for now-excluded groups would linger — and
+        // stay resolvable — after the relink. Remove exactly those
+        // (plus their bin shims), leaving everything else in place.
+        if !resolve_only
+            && !is_inconsistent
+            && let Some(modules) = modules_manifest
+            && modules.included != included
+            && let Some(current) = current_lockfile.as_ref()
+        {
+            crate::prune_direct_deps_excluded_by_groups(
+                current,
+                modules.included,
+                included,
+                &workspace_root,
+                config,
+            )
+            .map_err(InstallError::PruneDirectDeps)?;
+        }
+
         if take_frozen_path
             && let Some(wanted_lockfile) = lockfile
             && let Some(current) = current_lockfile.as_ref()
@@ -1881,11 +1908,12 @@ fn modules_consistent_with(
 
 /// The subset of [`modules_consistent_with`] that, when it drifts, requires
 /// **wiping and recreating** `node_modules`. It deliberately excludes
-/// `included`: a `--prod`<->full switch is satisfied by relinking
-/// (`filter_lockfile_for_current` + the removed-alias pruning in
-/// `create_virtual_store`), not by deleting the directory. pnpm never
-/// purges the root project's `node_modules` for an included mismatch — its
-/// `validateModules` only does so for non-root importers
+/// `included`: a `--prod`<->full switch is satisfied by relinking the
+/// newly-selected groups plus the targeted removal of the now-excluded
+/// ones ([`crate::prune_direct_deps_excluded_by_groups`]), not by
+/// deleting the directory. pnpm never purges the root project's
+/// `node_modules` for an included mismatch — its `validateModules` only
+/// does so for non-root importers
 /// ([`lockfileDir !== rootDir`](https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-installer/src/install/validateModules.ts#L105))
 /// — so purging here would destroy the user's own non-pnpm entries (a
 /// vendored directory, stray files) on a routine flag change. The

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1017,9 +1017,13 @@ where
         let old_modules = modules_manifest_res.ok().flatten();
         let modules_manifest = old_modules.as_ref();
 
+        // The purge keys off *layout* drift only, not `included`: an
+        // included (`--prod`<->full) change is handled by relinking, so it
+        // must not wipe the user's `node_modules` contents. See
+        // [`modules_layout_consistent_with`].
         let is_inconsistent = read_failed
             || match &modules_manifest {
-                Some(modules) => !modules_consistent_with(modules, config, node_linker, included),
+                Some(modules) => !modules_layout_consistent_with(modules, config, node_linker),
                 // Treat existence-check errors conservatively as inconsistent.
                 None => config
                     .modules_dir
@@ -1872,9 +1876,28 @@ fn modules_consistent_with(
     node_linker: NodeLinker,
     included: IncludedDependencies,
 ) -> bool {
+    modules.included == included && modules_layout_consistent_with(modules, config, node_linker)
+}
+
+/// The subset of [`modules_consistent_with`] that, when it drifts, requires
+/// **wiping and recreating** `node_modules`. It deliberately excludes
+/// `included`: a `--prod`<->full switch is satisfied by relinking
+/// (`filter_lockfile_for_current` + the removed-alias pruning in
+/// `create_virtual_store`), not by deleting the directory. pnpm never
+/// purges the root project's `node_modules` for an included mismatch — its
+/// `validateModules` only does so for non-root importers
+/// ([`lockfileDir !== rootDir`](https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-installer/src/install/validateModules.ts#L105))
+/// — so purging here would destroy the user's own non-pnpm entries (a
+/// vendored directory, stray files) on a routine flag change. The
+/// up-to-date fast path still compares `included` via
+/// [`modules_consistent_with`], so the relink it triggers stays correct.
+fn modules_layout_consistent_with(
+    modules: &pacquet_modules_yaml::ModulesLayout,
+    config: &Config,
+    node_linker: NodeLinker,
+) -> bool {
     modules.layout_version == Some(LayoutVersion)
         && modules.node_linker == Some(map_node_linker(node_linker))
-        && modules.included == included
         && modules.hoist_pattern == config.hoist_pattern
         && modules.public_hoist_pattern == config.public_hoist_pattern
         && modules.virtual_store_dir_max_length == config.virtual_store_dir_max_length

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -47,6 +47,20 @@ fn is_modules_yaml_consistent(
     )
 }
 
+/// Reading wrapper over [`super::modules_layout_consistent_with`] — the
+/// purge-gate consistency check, which (unlike [`is_modules_yaml_consistent`])
+/// ignores `included`.
+fn is_modules_yaml_layout_consistent(
+    modules_dir: &std::path::Path,
+    config: &Config,
+    node_linker: pacquet_config::NodeLinker,
+) -> bool {
+    pacquet_modules_yaml::read_modules_layout::<Host>(modules_dir)
+        .ok()
+        .flatten()
+        .is_some_and(|modules| super::modules_layout_consistent_with(&modules, config, node_linker))
+}
+
 const SCOPED_TEST_INTEGRITY: &str = "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==";
 
 fn scoped_package_body(registry_url: &str) -> String {
@@ -5838,6 +5852,98 @@ fn is_modules_yaml_consistent_returns_false_when_included_drifts() {
         config,
         pacquet_config::NodeLinker::Isolated,
         with_optional,
+    ));
+}
+
+/// A `--prod`<->full switch changes `.modules.yaml.included`, which the
+/// up-to-date fast path must still notice (so it relinks). But it must NOT
+/// make the *layout* look inconsistent: pnpm never purges the root
+/// project's `node_modules` for an included mismatch (validateModules's
+/// `lockfileDir !== rootDir` guard), and the purge wipes the user's
+/// non-pnpm entries (a vendored dir, custom files). So an included-only
+/// drift keeps the layout consistent — the purge does not run and the
+/// directory is left untouched; relinking adds/removes the right deps.
+#[test]
+fn included_drift_alone_does_not_make_the_layout_inconsistent() {
+    let dir = tempdir().unwrap();
+    let modules_dir = dir.path().join("node_modules");
+
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = modules_dir.join(".pacquet");
+    let config = config.leak();
+
+    let prod_only = pacquet_modules_yaml::IncludedDependencies {
+        dependencies: true,
+        dev_dependencies: false,
+        optional_dependencies: false,
+    };
+    let with_optional = pacquet_modules_yaml::IncludedDependencies {
+        dependencies: true,
+        dev_dependencies: false,
+        optional_dependencies: true,
+    };
+
+    let seed = Modules {
+        layout_version: Some(LayoutVersion),
+        node_linker: Some(NodeLinker::Isolated),
+        included: prod_only,
+        hoist_pattern: config.hoist_pattern.clone(),
+        public_hoist_pattern: config.public_hoist_pattern.clone(),
+        store_dir: config.store_dir.display().to_string(),
+        virtual_store_dir: config.effective_virtual_store_dir().to_string_lossy().into_owned(),
+        virtual_store_dir_max_length: config.virtual_store_dir_max_length,
+        ..Default::default()
+    };
+    write_modules_manifest::<Host>(&modules_dir, seed).expect("seed .modules.yaml");
+
+    // The fast path still sees the included change and forces a reinstall...
+    assert!(!is_modules_yaml_consistent(
+        &modules_dir,
+        config,
+        pacquet_config::NodeLinker::Isolated,
+        with_optional,
+    ));
+    // ...but the layout is still consistent, so the destructive purge does
+    // not run and the user's node_modules contents survive.
+    assert!(is_modules_yaml_layout_consistent(
+        &modules_dir,
+        config,
+        pacquet_config::NodeLinker::Isolated,
+    ));
+}
+
+/// A real layout setting (here `nodeLinker`) drifting still makes the
+/// layout inconsistent, so the purge that recreates `node_modules` runs —
+/// the included guard above must not suppress genuine layout rebuilds.
+#[test]
+fn layout_drift_still_makes_the_layout_inconsistent() {
+    let dir = tempdir().unwrap();
+    let modules_dir = dir.path().join("node_modules");
+
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = modules_dir.join(".pacquet");
+    let config = config.leak();
+
+    let seed = Modules {
+        layout_version: Some(LayoutVersion),
+        node_linker: Some(NodeLinker::Hoisted),
+        hoist_pattern: config.hoist_pattern.clone(),
+        public_hoist_pattern: config.public_hoist_pattern.clone(),
+        store_dir: config.store_dir.display().to_string(),
+        virtual_store_dir: config.effective_virtual_store_dir().to_string_lossy().into_owned(),
+        virtual_store_dir_max_length: config.virtual_store_dir_max_length,
+        ..Default::default()
+    };
+    write_modules_manifest::<Host>(&modules_dir, seed).expect("seed .modules.yaml");
+
+    assert!(!is_modules_yaml_layout_consistent(
+        &modules_dir,
+        config,
+        pacquet_config::NodeLinker::Isolated,
     ));
 }
 

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -5969,10 +5969,14 @@ async fn run_purge_regression_install(
     config.virtual_store_dir_max_length = virtual_store_dir_max_length;
     let config = config.leak();
     let is_full_install = dependency_groups.contains(&DependencyGroup::Dev);
+    // One client behind both fields, matching the CLI's single-source
+    // wiring documented on [`Install::http_client_arc`].
+    let http_client_arc: std::sync::Arc<pacquet_network::ThrottledClient> =
+        std::sync::Arc::default();
     Install {
         tarball_mem_cache: Default::default(),
-        http_client: &Default::default(),
-        http_client_arc: std::sync::Arc::new(Default::default()),
+        http_client: &http_client_arc,
+        http_client_arc: std::sync::Arc::clone(&http_client_arc),
         config,
         manifest,
         lockfile: MaybeLazyLockfile::Loaded(None),
@@ -6006,6 +6010,11 @@ async fn run_purge_regression_install(
 /// `node_modules`, while a real layout drift still recreates the directory
 /// from scratch. Without the `modules_layout_consistent_with` split, the
 /// included drift would purge the directory and delete the user's file.
+///
+/// The skipped purge must not leave the excluded dev dep behind either:
+/// the targeted prune ([`crate::prune_direct_deps_excluded_by_groups`])
+/// removes its `node_modules` link and its `.bin` shim while everything
+/// else stays.
 #[tokio::test]
 async fn included_drift_keeps_user_node_modules_entry_while_layout_drift_wipes_it() {
     let mock_instance = TestRegistry::start();
@@ -6015,12 +6024,11 @@ async fn included_drift_keeps_user_node_modules_entry_while_layout_drift_wipes_i
     let modules_dir = project_root.join("node_modules");
     let virtual_store_dir = modules_dir.join(".pacquet");
 
-    let manifest_path = dir.path().join("package.json");
+    fs::create_dir_all(&project_root).unwrap();
+    let manifest_path = project_root.join("package.json");
     let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
-    manifest
-        .add_dependency("@pnpm.e2e/hello-world-js-bin", "1.0.0", DependencyGroup::Prod)
-        .unwrap();
-    manifest.add_dependency("@pnpm/xyz", "1.0.0", DependencyGroup::Dev).unwrap();
+    manifest.add_dependency("@pnpm.e2e/console-log", "1.0.0", DependencyGroup::Prod).unwrap();
+    manifest.add_dependency("@pnpm.e2e/hello-world-js-bin", "1.0.0", DependencyGroup::Dev).unwrap();
     manifest.save().unwrap();
 
     let full = || vec![DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional];
@@ -6038,11 +6046,18 @@ async fn included_drift_keeps_user_node_modules_entry_while_layout_drift_wipes_i
     )
     .await;
 
+    let prod_link = modules_dir.join("@pnpm.e2e/console-log");
+    let dev_link = modules_dir.join("@pnpm.e2e/hello-world-js-bin");
+    let dev_shim = modules_dir.join(".bin/hello-world-js-bin");
+    assert!(dev_link.symlink_metadata().is_ok(), "full install links the dev dep");
+    assert!(dev_shim.exists(), "full install shims the dev dep's bin");
+
     // The user drops their own non-pnpm file directly into node_modules.
     let vendored = modules_dir.join("vendored-by-user.txt");
     fs::write(&vendored, b"keep me").unwrap();
 
-    // 2. Switching to --prod is an included drift only, so the file survives.
+    // 2. Switching to --prod is an included drift only, so the file survives —
+    // but the now-excluded dev dep's link and bin shim must be pruned.
     run_purge_regression_install(
         &store_dir,
         &modules_dir,
@@ -6054,6 +6069,15 @@ async fn included_drift_keeps_user_node_modules_entry_while_layout_drift_wipes_i
     )
     .await;
     assert!(vendored.exists(), "included drift must not purge the user's node_modules entry");
+    assert!(
+        dev_link.symlink_metadata().is_err(),
+        "the excluded dev dep's link must be pruned on an included drift",
+    );
+    assert!(
+        !dev_shim.exists(),
+        "the excluded dev dep's bin shim must be pruned on an included drift",
+    );
+    assert!(prod_link.symlink_metadata().is_ok(), "the prod dep stays linked");
 
     // 3. A real layout drift (virtual-store-dir-max-length) still wipes it.
     run_purge_regression_install(

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -5947,6 +5947,128 @@ fn layout_drift_still_makes_the_layout_inconsistent() {
     ));
 }
 
+/// Run one install against `modules_dir` for the purge regression below: a
+/// fresh leaked config per call (the install path needs `&'static Config`),
+/// `included` driven by `dependency_groups`, and `virtual_store_dir_max_length`
+/// surfaced so the test can force a layout drift. `disable_optimistic_repeat_install`
+/// keeps every call on the full path so the purge branch is actually evaluated.
+async fn run_purge_regression_install(
+    store_dir: &std::path::Path,
+    modules_dir: &std::path::Path,
+    virtual_store_dir: &std::path::Path,
+    registry: String,
+    manifest: &PackageManifest,
+    dependency_groups: Vec<DependencyGroup>,
+    virtual_store_dir_max_length: u64,
+) {
+    let mut config = Config::new();
+    config.store_dir = store_dir.to_path_buf().into();
+    config.modules_dir = modules_dir.to_path_buf();
+    config.virtual_store_dir = virtual_store_dir.to_path_buf();
+    config.registry = registry;
+    config.virtual_store_dir_max_length = virtual_store_dir_max_length;
+    let config = config.leak();
+    let is_full_install = dependency_groups.contains(&DependencyGroup::Dev);
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest,
+        lockfile: MaybeLazyLockfile::Loaded(None),
+        lockfile_path: None,
+        dependency_groups,
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        is_full_install,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
+        dry_run: false,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+        auth_override: None,
+        resolution_observer: None,
+        catalogs_override: None,
+        disable_optimistic_repeat_install: true,
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("install should succeed");
+}
+
+/// Install-level regression for the purge guard: switching `--prod` <-> full
+/// (an `included` drift) must keep a user's own non-pnpm entry in
+/// `node_modules`, while a real layout drift still recreates the directory
+/// from scratch. Without the `modules_layout_consistent_with` split, the
+/// included drift would purge the directory and delete the user's file.
+#[tokio::test]
+async fn included_drift_keeps_user_node_modules_entry_while_layout_drift_wipes_it() {
+    let mock_instance = TestRegistry::start();
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    manifest
+        .add_dependency("@pnpm.e2e/hello-world-js-bin", "1.0.0", DependencyGroup::Prod)
+        .unwrap();
+    manifest.add_dependency("@pnpm/xyz", "1.0.0", DependencyGroup::Dev).unwrap();
+    manifest.save().unwrap();
+
+    let full = || vec![DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional];
+    let prod_only = || vec![DependencyGroup::Prod];
+
+    // 1. A full install creates node_modules + .modules.yaml (included = full).
+    run_purge_regression_install(
+        &store_dir,
+        &modules_dir,
+        &virtual_store_dir,
+        mock_instance.url(),
+        &manifest,
+        full(),
+        DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
+    )
+    .await;
+
+    // The user drops their own non-pnpm file directly into node_modules.
+    let vendored = modules_dir.join("vendored-by-user.txt");
+    fs::write(&vendored, b"keep me").unwrap();
+
+    // 2. Switching to --prod is an included drift only, so the file survives.
+    run_purge_regression_install(
+        &store_dir,
+        &modules_dir,
+        &virtual_store_dir,
+        mock_instance.url(),
+        &manifest,
+        prod_only(),
+        DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
+    )
+    .await;
+    assert!(vendored.exists(), "included drift must not purge the user's node_modules entry");
+
+    // 3. A real layout drift (virtual-store-dir-max-length) still wipes it.
+    run_purge_regression_install(
+        &store_dir,
+        &modules_dir,
+        &virtual_store_dir,
+        mock_instance.url(),
+        &manifest,
+        prod_only(),
+        DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH - 1,
+    )
+    .await;
+    assert!(!vendored.exists(), "layout drift must still recreate node_modules from scratch");
+}
+
 /// End-to-end: when `.modules.yaml`, `<virtual_store_dir>/lock.yaml`,
 /// and the wanted lockfile all agree, [`Install::run`] must emit the
 /// `name: "pnpm"` "Lockfile is up to date" log and return without

--- a/pacquet/crates/package-manager/src/lib.rs
+++ b/pacquet/crates/package-manager/src/lib.rs
@@ -34,6 +34,7 @@ mod package_map;
 mod patch;
 mod patch_commit;
 mod prefetching_resolver;
+mod prune_direct_deps;
 mod prune_virtual_store;
 mod remove;
 mod remove_quarantine;
@@ -86,6 +87,7 @@ pub use package_map::{
 pub use patch::*;
 pub use patch_commit::*;
 pub use prefetching_resolver::*;
+pub use prune_direct_deps::*;
 pub use remove::*;
 pub use resolution_observer::*;
 pub use symlink_direct_dependencies::*;

--- a/pacquet/crates/package-manager/src/prune_direct_deps.rs
+++ b/pacquet/crates/package-manager/src/prune_direct_deps.rs
@@ -76,8 +76,14 @@ pub enum PruneDirectDepsError {
 /// drift skips the destructive purge, so the links the previous install
 /// created for now-excluded groups have to be removed individually —
 /// pnpm does the same through its prune's `removeDirectDependency`.
-/// Removal is conservative on two axes:
+/// Removal is conservative on three axes:
 ///
+/// - Each importer's modules dir must canonicalize to a path inside the
+///   workspace root (`confined_modules_dir`, the purge's containment
+///   check), and removals never reach through an intermediate
+///   `@scope/` or `.bin/` component that isn't a real directory — a
+///   symlinked or junctioned one could redirect the deletions outside
+///   the confined dir.
 /// - Only symlinks (junctions on Windows) are removed. The isolated
 ///   linker only ever writes links for direct deps, so a real file or
 ///   directory under the same name belongs to the user — or to the
@@ -116,11 +122,18 @@ pub fn prune_direct_deps_excluded_by_groups(
         if validate_importer_id(importer_id).is_err() {
             continue;
         }
+        // Same canonical containment check as the purge: delete only
+        // through a modules dir that resolves inside the workspace
+        // root, and operate on the canonicalized path so a symlink
+        // swap can't redirect the removals after the check.
+        let modules_dir = importer_root_dir(workspace_root, importer_id).join(modules_dir_name);
+        let Some(modules_dir) = confined_modules_dir(&modules_dir, workspace_root) else {
+            continue;
+        };
         let new_names: HashSet<String> =
             direct_dep_names_for_importer(snapshot, new_groups.iter().copied(), &skipped, false)
                 .into_iter()
                 .collect();
-        let modules_dir = importer_root_dir(workspace_root, importer_id).join(modules_dir_name);
         for name in
             direct_dep_names_for_importer(snapshot, old_groups.iter().copied(), &skipped, false)
         {
@@ -131,6 +144,36 @@ pub fn prune_direct_deps_excluded_by_groups(
         }
     }
     Ok(())
+}
+
+/// Canonicalize `modules_dir` and require it to stay within
+/// `workspace_root` — the same containment check the purge applies
+/// before its destructive sweep. Returns the canonical path the
+/// removals should operate on, or `None` when there is nothing to
+/// prune (the directory doesn't exist) or when the resolution escapes
+/// the workspace — never delete through an escape.
+fn confined_modules_dir(modules_dir: &Path, workspace_root: &Path) -> Option<PathBuf> {
+    let modules_canon = std::fs::canonicalize(modules_dir).ok()?;
+    let root_canon = std::fs::canonicalize(workspace_root).ok()?;
+    if modules_canon.starts_with(&root_canon) {
+        Some(modules_canon)
+    } else {
+        tracing::warn!(
+            ?modules_dir,
+            "refusing to prune direct dependencies outside the workspace root",
+        );
+        None
+    }
+}
+
+/// `true` when `path` is a real directory — not a symlink (nor a
+/// junction on Windows, which `FileType::is_dir` reports as a
+/// directory). Removals must not reach *through* a redirected
+/// intermediate component (`@scope/`, `.bin/`); the containment check
+/// above only vouches for the modules dir itself.
+fn is_real_dir(path: &Path) -> bool {
+    fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_dir())
+        && read_symlink_dir(path).is_err()
 }
 
 fn selected_groups(included: IncludedDependencies) -> Vec<DependencyGroup> {
@@ -150,6 +193,14 @@ fn selected_groups(included: IncludedDependencies) -> Vec<DependencyGroup> {
 fn remove_direct_dep_link(modules_dir: &Path, name: &str) -> Result<(), PruneDirectDepsError> {
     let link =
         safe_join_modules_dir(modules_dir, name).map_err(PruneDirectDepsError::InvalidAlias)?;
+    // For a scoped alias the join passes through `@scope/`; refuse to
+    // unlink through one that is not a real directory.
+    if let Some(parent) = link.parent()
+        && parent != modules_dir
+        && !is_real_dir(parent)
+    {
+        return Ok(());
+    }
     // Only a symlink (junction on Windows) can be a direct-dep entry the
     // isolated linker wrote; anything else stays untouched. The probe
     // also covers "not there at all" — nothing to remove.
@@ -180,7 +231,14 @@ fn remove_dep_bins(modules_dir: &Path, link: &Path) -> Result<(), PruneDirectDep
     let Ok(manifest) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
         return Ok(());
     };
+    // Shims are deleted with plain `remove_file`, so a `.bin` that is
+    // itself a symlink or junction would redirect the deletions
+    // outside the confined modules dir — skip shim removal unless
+    // `.bin` is a real directory. (Absent `.bin` means no shims.)
     let bins_dir = modules_dir.join(".bin");
+    if !is_real_dir(&bins_dir) {
+        return Ok(());
+    }
     for command in get_bins_from_package_manifest::<Host>(&manifest, link) {
         let shim_path = bins_dir.join(&command.name);
         remove_bin(&shim_path)

--- a/pacquet/crates/package-manager/src/prune_direct_deps.rs
+++ b/pacquet/crates/package-manager/src/prune_direct_deps.rs
@@ -1,0 +1,193 @@
+//! Targeted cleanup for an `included` (dependency-group selection)
+//! drift: remove the direct-dependency links a previous install created
+//! for groups the current install excludes, leaving everything else in
+//! the importer's `node_modules` — the user's own files above all — in
+//! place. The non-destructive counterpart of the purge in
+//! [`crate::Install`], mirroring pnpm's `removeDirectDependency` prune.
+
+use crate::{
+    SkippedSnapshots,
+    safe_join_modules_dir::{InvalidDependencyAliasError, safe_join_modules_dir},
+    symlink_direct_dependencies::{
+        direct_dep_names_for_importer, importer_root_dir, validate_importer_id,
+    },
+};
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pacquet_cmd_shim::{Host, get_bins_from_package_manifest, remove_bin};
+use pacquet_config::Config;
+use pacquet_fs::{read_symlink_dir, remove_symlink_dir};
+use pacquet_lockfile::Lockfile;
+use pacquet_modules_yaml::IncludedDependencies;
+use pacquet_package_manifest::DependencyGroup;
+use std::{
+    collections::HashSet,
+    ffi::OsStr,
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+/// Error type of [`prune_direct_deps_excluded_by_groups`].
+#[derive(Debug, Display, Error, Diagnostic)]
+pub enum PruneDirectDepsError {
+    /// A direct-dep alias recorded in the current lockfile is not a
+    /// valid npm package name. Joining it under `node_modules` could
+    /// escape the directory, so the removal is refused — same boundary
+    /// `safe_join_modules_dir` enforces on the hoisted restore path.
+    #[diagnostic(transparent)]
+    InvalidAlias(#[error(source)] InvalidDependencyAliasError),
+
+    #[display(
+        "Failed to read {path:?} while removing the bins of an excluded direct dependency: {error}"
+    )]
+    #[diagnostic(code(pacquet_package_manager::prune_direct_deps_read_manifest))]
+    ReadManifest {
+        path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+
+    #[display(
+        "Failed to remove the bin shim at {path:?} of an excluded direct dependency: {error}"
+    )]
+    #[diagnostic(code(pacquet_package_manager::prune_direct_deps_remove_bin))]
+    RemoveBin {
+        path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+
+    #[display("Failed to remove the excluded direct dependency at {path:?}: {error}")]
+    #[diagnostic(code(pacquet_package_manager::prune_direct_deps_remove_link))]
+    RemoveLink {
+        path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+}
+
+/// Remove the direct-dependency links that `old_included` selected but
+/// `new_included` does not, for every importer recorded in the current
+/// lockfile (`<virtual_store_dir>/lock.yaml` — what the previous install
+/// actually materialized).
+///
+/// Runs when `.modules.yaml` records a different `included` set than the
+/// current install wants while the layout itself is unchanged: that
+/// drift skips the destructive purge, so the links the previous install
+/// created for now-excluded groups have to be removed individually —
+/// pnpm does the same through its prune's `removeDirectDependency`.
+/// Removal is conservative on two axes:
+///
+/// - Only symlinks (junctions on Windows) are removed. The isolated
+///   linker only ever writes links for direct deps, so a real file or
+///   directory under the same name belongs to the user — or to the
+///   hoisted linker, whose own orphan diff handles removal.
+/// - A dep's bin shims are removed first, resolved from the same
+///   sanitized [`get_bins_from_package_manifest`] name set the shim
+///   writer uses, so removal touches exactly the files the writer could
+///   have created. The relink that follows this cleanup re-creates any
+///   shim a still-included dep owns.
+///
+/// Over-removal is self-healing: anything in the new `included` set is
+/// re-linked right after by [`crate::SymlinkDirectDependencies`], so the
+/// diff only has to be correct for entries the new install won't touch.
+pub fn prune_direct_deps_excluded_by_groups(
+    current_lockfile: &Lockfile,
+    old_included: IncludedDependencies,
+    new_included: IncludedDependencies,
+    workspace_root: &Path,
+    config: &Config,
+) -> Result<(), PruneDirectDepsError> {
+    let old_groups = selected_groups(old_included);
+    let new_groups = selected_groups(new_included);
+    // The skip filter only narrows what the linker materializes. For
+    // removal, a name that was skipped last install has no on-disk
+    // entry, so removing it is a no-op — no skip set needed.
+    let skipped = SkippedSnapshots::new();
+    // Same per-importer `modulesDir` suffix peeling as
+    // [`crate::SymlinkDirectDependencies`], so removal targets exactly
+    // where the linker writes.
+    let modules_dir_name: &OsStr =
+        config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
+
+    for (importer_id, snapshot) in &current_lockfile.importers {
+        // A malformed importer key is rejected with a typed error by
+        // the symlink pass; never *delete* based on one.
+        if validate_importer_id(importer_id).is_err() {
+            continue;
+        }
+        let new_names: HashSet<String> =
+            direct_dep_names_for_importer(snapshot, new_groups.iter().copied(), &skipped, false)
+                .into_iter()
+                .collect();
+        let modules_dir = importer_root_dir(workspace_root, importer_id).join(modules_dir_name);
+        for name in
+            direct_dep_names_for_importer(snapshot, old_groups.iter().copied(), &skipped, false)
+        {
+            if new_names.contains(&name) {
+                continue;
+            }
+            remove_direct_dep_link(&modules_dir, &name)?;
+        }
+    }
+    Ok(())
+}
+
+fn selected_groups(included: IncludedDependencies) -> Vec<DependencyGroup> {
+    let mut groups = Vec::with_capacity(3);
+    if included.dependencies {
+        groups.push(DependencyGroup::Prod);
+    }
+    if included.dev_dependencies {
+        groups.push(DependencyGroup::Dev);
+    }
+    if included.optional_dependencies {
+        groups.push(DependencyGroup::Optional);
+    }
+    groups
+}
+
+fn remove_direct_dep_link(modules_dir: &Path, name: &str) -> Result<(), PruneDirectDepsError> {
+    let link =
+        safe_join_modules_dir(modules_dir, name).map_err(PruneDirectDepsError::InvalidAlias)?;
+    // Only a symlink (junction on Windows) can be a direct-dep entry the
+    // isolated linker wrote; anything else stays untouched. The probe
+    // also covers "not there at all" — nothing to remove.
+    if read_symlink_dir(&link).is_err() {
+        return Ok(());
+    }
+    remove_dep_bins(modules_dir, &link)?;
+    match remove_symlink_dir(&link) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(PruneDirectDepsError::RemoveLink { path: link, error }),
+    }
+}
+
+/// Remove the shims the package behind `link` declares from
+/// `<modules_dir>/.bin`. A missing or unparsable `package.json` (a
+/// dangling link, a broken package) yields no bins to remove — the same
+/// best-effort read as pnpm's `removeBins`.
+fn remove_dep_bins(modules_dir: &Path, link: &Path) -> Result<(), PruneDirectDepsError> {
+    let manifest_path = link.join("package.json");
+    let bytes = match fs::read(&manifest_path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(PruneDirectDepsError::ReadManifest { path: manifest_path, error });
+        }
+    };
+    let Ok(manifest) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return Ok(());
+    };
+    let bins_dir = modules_dir.join(".bin");
+    for command in get_bins_from_package_manifest::<Host>(&manifest, link) {
+        let shim_path = bins_dir.join(&command.name);
+        remove_bin(&shim_path)
+            .map_err(|error| PruneDirectDepsError::RemoveBin { path: shim_path, error })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/package-manager/src/prune_direct_deps/tests.rs
+++ b/pacquet/crates/package-manager/src/prune_direct_deps/tests.rs
@@ -127,6 +127,126 @@ fn removes_only_excluded_direct_dep_links_and_their_bins() {
     assert!(modules_dir.join("user-owned-dir").is_dir());
 }
 
+/// A `node_modules` that is itself a symlink resolving outside the
+/// workspace root fails the containment check, so nothing behind it is
+/// touched — the same refusal the purge applies.
+#[test]
+fn refuses_to_prune_through_a_modules_dir_escaping_the_workspace() {
+    let dir = tempdir().unwrap();
+    let workspace_root = dir.path().join("workspace");
+    let outside = dir.path().join("outside-modules");
+    fs::create_dir_all(&workspace_root).unwrap();
+
+    // Seed the external dir with a linked dep + shim, then point the
+    // workspace's node_modules at it.
+    link_dep(&outside, "dev-dep", Some("devtool"));
+    let outside_bins = outside.join(".bin");
+    fs::create_dir_all(&outside_bins).unwrap();
+    fs::write(outside_bins.join("devtool"), b"#!/bin/sh\n").unwrap();
+    let modules_dir = workspace_root.join("node_modules");
+    pacquet_fs::symlink_dir(&outside, &modules_dir).unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = modules_dir.join(".pacquet");
+    let config = config.leak();
+
+    let current_lockfile = lockfile_with_root_importer(ProjectSnapshot {
+        dev_dependencies: Some(dep_map(&[("dev-dep", "1.0.0")])),
+        ..ProjectSnapshot::default()
+    });
+
+    prune_direct_deps_excluded_by_groups(
+        &current_lockfile,
+        FULL,
+        PROD_ONLY,
+        &workspace_root,
+        config,
+    )
+    .expect("prune should succeed");
+
+    assert!(is_symlink_or_junction(&outside.join("dev-dep")).unwrap());
+    assert!(outside_bins.join("devtool").exists());
+}
+
+/// A `.bin` that is itself a symlink must not have shims deleted
+/// through it, while the dep's own link is still pruned.
+#[test]
+fn skips_shim_removal_through_a_symlinked_bin_dir() {
+    let dir = tempdir().unwrap();
+    let workspace_root = dir.path();
+    let modules_dir = workspace_root.join("node_modules");
+    let outside_bins = workspace_root.join("outside-bins");
+
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = modules_dir.join(".pacquet");
+    let config = config.leak();
+
+    link_dep(&modules_dir, "dev-dep", Some("devtool"));
+    fs::create_dir_all(&outside_bins).unwrap();
+    fs::write(outside_bins.join("devtool"), b"#!/bin/sh\n").unwrap();
+    pacquet_fs::symlink_dir(&outside_bins, &modules_dir.join(".bin")).unwrap();
+
+    let current_lockfile = lockfile_with_root_importer(ProjectSnapshot {
+        dev_dependencies: Some(dep_map(&[("dev-dep", "1.0.0")])),
+        ..ProjectSnapshot::default()
+    });
+
+    prune_direct_deps_excluded_by_groups(
+        &current_lockfile,
+        FULL,
+        PROD_ONLY,
+        workspace_root,
+        config,
+    )
+    .expect("prune should succeed");
+
+    assert!(outside_bins.join("devtool").exists());
+    assert!(modules_dir.join("dev-dep").symlink_metadata().is_err());
+}
+
+/// A scoped alias whose `@scope/` component is a symlink must not be
+/// unlinked through it.
+#[test]
+fn refuses_to_unlink_through_a_symlinked_scope_dir() {
+    let dir = tempdir().unwrap();
+    let workspace_root = dir.path();
+    let modules_dir = workspace_root.join("node_modules");
+    let outside_scope = workspace_root.join("outside-scope");
+
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = modules_dir.join(".pacquet");
+    let config = config.leak();
+
+    fs::create_dir_all(&modules_dir).unwrap();
+    fs::create_dir_all(&outside_scope).unwrap();
+    let target = workspace_root.join("some-target");
+    fs::create_dir_all(&target).unwrap();
+    pacquet_fs::symlink_dir(&target, &outside_scope.join("dev-dep")).unwrap();
+    pacquet_fs::symlink_dir(&outside_scope, &modules_dir.join("@scope")).unwrap();
+
+    let current_lockfile = lockfile_with_root_importer(ProjectSnapshot {
+        dev_dependencies: Some(dep_map(&[("@scope/dev-dep", "1.0.0")])),
+        ..ProjectSnapshot::default()
+    });
+
+    prune_direct_deps_excluded_by_groups(
+        &current_lockfile,
+        FULL,
+        PROD_ONLY,
+        workspace_root,
+        config,
+    )
+    .expect("prune should succeed");
+
+    assert!(is_symlink_or_junction(&outside_scope.join("dev-dep")).unwrap());
+}
+
 /// The reverse switch (`--prod` → full) only widens the selection, so
 /// nothing is removed.
 #[test]

--- a/pacquet/crates/package-manager/src/prune_direct_deps/tests.rs
+++ b/pacquet/crates/package-manager/src/prune_direct_deps/tests.rs
@@ -1,0 +1,161 @@
+use super::prune_direct_deps_excluded_by_groups;
+use pacquet_config::Config;
+use pacquet_lockfile::{
+    ComVer, Lockfile, LockfileVersion, ProjectSnapshot, ResolvedDependencyMap,
+    ResolvedDependencySpec,
+};
+use pacquet_modules_yaml::IncludedDependencies;
+use pacquet_testing_utils::fs::is_symlink_or_junction;
+use std::{collections::HashMap, fs, path::Path};
+use tempfile::tempdir;
+
+fn lockfile_with_root_importer(snapshot: ProjectSnapshot) -> Lockfile {
+    let mut importers = HashMap::new();
+    importers.insert(Lockfile::ROOT_IMPORTER_KEY.to_string(), snapshot);
+    Lockfile {
+        lockfile_version: LockfileVersion::<9>::try_from(ComVer { major: 9, minor: 0 }).unwrap(),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers,
+        packages: None,
+        snapshots: None,
+    }
+}
+
+const FULL: IncludedDependencies = IncludedDependencies {
+    dependencies: true,
+    dev_dependencies: true,
+    optional_dependencies: true,
+};
+const PROD_ONLY: IncludedDependencies = IncludedDependencies {
+    dependencies: true,
+    dev_dependencies: false,
+    optional_dependencies: false,
+};
+
+fn dep_map(entries: &[(&str, &str)]) -> ResolvedDependencyMap {
+    let mut map = ResolvedDependencyMap::new();
+    for (name, version) in entries {
+        map.insert(
+            name.parse().expect("parse pkg name"),
+            ResolvedDependencySpec {
+                specifier: format!("^{version}"),
+                version: version.parse::<pacquet_lockfile::PkgVerPeer>().unwrap().into(),
+            },
+        );
+    }
+    map
+}
+
+/// Lay down a direct-dep symlink the way the isolated linker would:
+/// a real package dir in the virtual store (with a `package.json`
+/// declaring `bin` when given) and a `node_modules/<name>` symlink
+/// pointing at it. The target must exist for Windows junctions.
+fn link_dep(modules_dir: &Path, name: &str, bin: Option<&str>) {
+    let target =
+        modules_dir.join(".pacquet").join(name.replace('/', "+")).join("node_modules").join(name);
+    fs::create_dir_all(&target).expect("create symlink target");
+    let manifest = match bin {
+        Some(bin_name) => {
+            fs::write(target.join("cli.js"), b"#!/usr/bin/env node\n").expect("write bin script");
+            format!(r#"{{"name":{name:?},"version":"1.0.0","bin":{{{bin_name:?}:"./cli.js"}}}}"#)
+        }
+        None => format!(r#"{{"name":{name:?},"version":"1.0.0"}}"#),
+    };
+    fs::write(target.join("package.json"), manifest).expect("write package.json");
+    let link = modules_dir.join(name);
+    fs::create_dir_all(link.parent().unwrap()).expect("create link parent");
+    pacquet_fs::symlink_dir(&target, &link).expect("create direct-dep symlink");
+}
+
+/// A full → `--prod` switch must remove exactly the dev dep's symlink
+/// and its bin shim: the prod dep's link, the user's own real file and
+/// directory (even one shadowing a former dep name), and unrelated
+/// shims all survive.
+#[test]
+fn removes_only_excluded_direct_dep_links_and_their_bins() {
+    let dir = tempdir().unwrap();
+    let workspace_root = dir.path();
+    let modules_dir = workspace_root.join("node_modules");
+
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = modules_dir.join(".pacquet");
+    let config = config.leak();
+
+    link_dep(&modules_dir, "keep-me", None);
+    link_dep(&modules_dir, "@scope/dev-dep", Some("devtool"));
+    // Shims as the bin linker would have written them.
+    let bins_dir = modules_dir.join(".bin");
+    fs::create_dir_all(&bins_dir).unwrap();
+    fs::write(bins_dir.join("devtool"), b"#!/bin/sh\n").unwrap();
+    fs::write(bins_dir.join("unrelated-tool"), b"#!/bin/sh\n").unwrap();
+    // The user's own entries: a stray file, and a real directory whose
+    // name collides with a dev dep recorded in the lockfile.
+    fs::write(modules_dir.join("vendored.txt"), b"keep me").unwrap();
+    fs::create_dir_all(modules_dir.join("user-owned-dir")).unwrap();
+
+    let current_lockfile = lockfile_with_root_importer(ProjectSnapshot {
+        dependencies: Some(dep_map(&[("keep-me", "1.0.0")])),
+        dev_dependencies: Some(dep_map(&[
+            ("@scope/dev-dep", "1.0.0"),
+            ("user-owned-dir", "1.0.0"),
+        ])),
+        ..ProjectSnapshot::default()
+    });
+
+    prune_direct_deps_excluded_by_groups(
+        &current_lockfile,
+        FULL,
+        PROD_ONLY,
+        workspace_root,
+        config,
+    )
+    .expect("prune should succeed");
+
+    assert!(modules_dir.join("@scope/dev-dep").symlink_metadata().is_err());
+    assert!(!bins_dir.join("devtool").exists());
+    assert!(is_symlink_or_junction(&modules_dir.join("keep-me")).unwrap());
+    assert!(bins_dir.join("unrelated-tool").exists());
+    assert!(modules_dir.join("vendored.txt").exists());
+    assert!(modules_dir.join("user-owned-dir").is_dir());
+}
+
+/// The reverse switch (`--prod` → full) only widens the selection, so
+/// nothing is removed.
+#[test]
+fn widening_the_selection_removes_nothing() {
+    let dir = tempdir().unwrap();
+    let workspace_root = dir.path();
+    let modules_dir = workspace_root.join("node_modules");
+
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = modules_dir.join(".pacquet");
+    let config = config.leak();
+
+    link_dep(&modules_dir, "keep-me", None);
+
+    let current_lockfile = lockfile_with_root_importer(ProjectSnapshot {
+        dependencies: Some(dep_map(&[("keep-me", "1.0.0")])),
+        ..ProjectSnapshot::default()
+    });
+
+    prune_direct_deps_excluded_by_groups(
+        &current_lockfile,
+        PROD_ONLY,
+        FULL,
+        workspace_root,
+        config,
+    )
+    .expect("prune should succeed");
+
+    assert!(is_symlink_or_junction(&modules_dir.join("keep-me")).unwrap());
+}

--- a/pacquet/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/pacquet/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -252,7 +252,9 @@ where
 /// drive prefix, a `..` segment — is either malformed or hostile, so
 /// surface it as a typed error rather than silently letting
 /// `Path::join` produce an off-workspace path.
-fn validate_importer_id(importer_id: &str) -> Result<(), SymlinkDirectDependenciesError> {
+pub(crate) fn validate_importer_id(
+    importer_id: &str,
+) -> Result<(), SymlinkDirectDependenciesError> {
     let unsafe_path = || SymlinkDirectDependenciesError::UnsafeImporterPath {
         importer_id: importer_id.to_string(),
     };


### PR DESCRIPTION
## Summary

When `.modules.yaml` recorded a different `included` dependency set than
the current install wants — switching `pnpm install --prod` <-> a full
install, or toggling `--no-optional` — `modules_consistent_with` reported
`node_modules` inconsistent, which drives the purge that empties the
directory of everything except pnpm's own and dotfile entries. **A user's
non-pnpm contents (a vendored directory, stray files placed directly in
`node_modules`) were deleted silently on that routine flag change.**

pnpm never purges the **root** project's `node_modules` for an included
mismatch: its [`validateModules`](https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-installer/src/install/validateModules.ts#L105)
only treats included drift as purge-worthy for non-root importers (the
`lockfileDir !== rootDir` guard), and an included change is satisfied by
relinking plus a targeted prune of the removed deps — not by wiping the
directory.

This splits the consistency check and adds the targeted prune:

- The **purge gate** now uses `modules_layout_consistent_with`, which
  compares every layout-determining setting **except** `included`.
- The **up-to-date fast path** keeps using `modules_consistent_with`
  (which still compares `included`), so a `--prod`<->full switch still
  forces a reinstall.
- A new **`prune_direct_deps_excluded_by_groups`** pass runs exactly when
  the purge is skipped for an included drift: it diffs each importer's
  direct-dep names between the old and new group selections (via the
  current lockfile) and removes the now-excluded links **and their
  `.bin` shims** — mirroring pnpm's `removeDirectDependency` prune. So
  excluded dev deps do not stay resolvable after a `--prod` reinstall.
  Removal is conservative: importer keys are validated, aliases go
  through `safe_join_modules_dir`, only symlinks/junctions are removed
  (a user's real file or directory is never touched; hoisted-linker real
  directories are handled by its own orphan diff), and bin names come
  from the same sanitized set the shim writer uses.

The relink that follows re-creates everything the new selection wants,
so correctness of the switch is preserved while the directory — and the
user's own contents — are left intact.

### Parity

pnpm already behaves this way (`validateModules` + the modules-cleaner
prune), so this is the pacquet side catching up — no TypeScript-side
change is needed. pnpm's `pnpm:root removed` / `stats.removed` emissions
remain unported (pacquet currently emits a hardcoded `removed: 0`
placeholder); that slice is unchanged here.

## Squash Commit Body

```text
When .modules.yaml recorded a different `included` set than the current
install wants (pnpm install --prod <-> full, or --no-optional),
modules_consistent_with reported the directory inconsistent, driving the
purge that empties node_modules of everything except pnpm's own and
dotfile entries. A user's non-pnpm contents were deleted silently.

pnpm never purges the root project's node_modules for an included
mismatch (validateModules's lockfileDir !== rootDir guard); an included
change is satisfied by relinking plus a targeted prune of the removed
deps.

Split the check: the purge gate uses modules_layout_consistent_with
(every layout setting except included); the up-to-date fast path keeps
modules_consistent_with (still compares included), so a --prod<->full
switch still forces a reinstall. A new prune pass
(prune_direct_deps_excluded_by_groups) runs when the purge is skipped
for an included drift and removes the now-excluded direct-dep links and
their .bin shims — mirroring pnpm's removeDirectDependency — so excluded
deps don't stay resolvable. Only symlinks/junctions are removed, so the
user's own node_modules contents are never touched.
```

## Checklist

- [x] Added or updated tests.
- [x] Updated the documentation if needed (doc comments on the split check and the prune).

<!-- pnpm already guards this (validateModules), so no TS-side change is
needed. pacquet is Rust, so there is no changeset. -->

---
Written by an agent (Claude Code, claude-opus-4-8; revised by Claude Code, claude-fable-5).
