### PR TITLE
fix(resolving): reject malformed `jsr:` and named-registry package names (empty scope/name, path separators)

### DIFF
--- a/.changeset/jsr-specifier-empty-name.md
+++ b/.changeset/jsr-specifier-empty-name.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/resolving.jsr-specifier-parser": patch
+---
+
+fix: throw `INVALID_JSR_PACKAGE_NAME` for `jsr:@scope/` specifiers with an empty package name instead of silently returning a malformed `@jsr/scope__` npm package name

--- a/.changeset/jsr-specifier-empty-name.md
+++ b/.changeset/jsr-specifier-empty-name.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/resolving.jsr-specifier-parser": patch
+"pnpm": patch
 ---
 
-fix: throw `INVALID_JSR_PACKAGE_NAME` for `jsr:@scope/` specifiers with an empty package name instead of silently returning a malformed `@jsr/scope__` npm package name
+pnpm now rejects `jsr:` specifiers with a malformed package name — an empty scope or name (e.g. `jsr:@scope/`) or path separators inside the name — with `ERR_PNPM_INVALID_JSR_PACKAGE_NAME` instead of silently converting them into a malformed `@jsr/...` npm package name.

--- a/.changeset/jsr-specifier-empty-name.md
+++ b/.changeset/jsr-specifier-empty-name.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-pnpm now rejects `jsr:` specifiers with a malformed package name — an empty scope or name (e.g. `jsr:@scope/`) or path separators inside the name — with `ERR_PNPM_INVALID_JSR_PACKAGE_NAME` instead of silently converting them into a malformed `@jsr/...` npm package name.
+pnpm now rejects `jsr:` specifiers whose package name is not a valid npm package name — an empty scope or name (e.g. `jsr:@scope/`), path separators inside the name, or any other shape `validate-npm-package-name` rejects — with `ERR_PNPM_INVALID_JSR_PACKAGE_NAME` instead of silently converting them into a malformed `@jsr/...` npm package name.

--- a/.changeset/named-registry-invalid-name.md
+++ b/.changeset/named-registry-invalid-name.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-pnpm now rejects named-registry specifiers (e.g. `gh:`) with a malformed package name — an empty scope (e.g. `gh:@/bar`), path separators inside the name (e.g. `gh:@scope/../name`), or a dot-segment name (e.g. `gh:..`) — with `ERR_PNPM_INVALID_NAMED_REGISTRY_PACKAGE_NAME` instead of passing the name through to registry URLs and metadata cache file paths.
+pnpm now rejects named-registry specifiers (e.g. `gh:`) whose package name is not a valid npm package name — an empty scope (e.g. `gh:@/bar`), path separators inside the name (e.g. `gh:@scope/../name`), or any other shape `validate-npm-package-name` rejects — with `ERR_PNPM_INVALID_NAMED_REGISTRY_PACKAGE_NAME` instead of passing the name through to registry URLs and metadata cache file paths.

--- a/.changeset/named-registry-invalid-name.md
+++ b/.changeset/named-registry-invalid-name.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"pnpm": patch
+---
+
+pnpm now rejects named-registry specifiers (e.g. `gh:`) with a malformed package name — an empty scope (e.g. `gh:@/bar`) or path separators inside the name (e.g. `gh:@scope/../name`) — with `ERR_PNPM_INVALID_NAMED_REGISTRY_PACKAGE_NAME` instead of passing the name through to registry URLs and metadata cache file paths.

--- a/.changeset/named-registry-invalid-name.md
+++ b/.changeset/named-registry-invalid-name.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-pnpm now rejects named-registry specifiers (e.g. `gh:`) with a malformed package name — an empty scope (e.g. `gh:@/bar`) or path separators inside the name (e.g. `gh:@scope/../name`) — with `ERR_PNPM_INVALID_NAMED_REGISTRY_PACKAGE_NAME` instead of passing the name through to registry URLs and metadata cache file paths.
+pnpm now rejects named-registry specifiers (e.g. `gh:`) with a malformed package name — an empty scope (e.g. `gh:@/bar`), path separators inside the name (e.g. `gh:@scope/../name`), or a dot-segment name (e.g. `gh:..`) — with `ERR_PNPM_INVALID_NAMED_REGISTRY_PACKAGE_NAME` instead of passing the name through to registry URLs and metadata cache file paths.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4526,6 +4526,7 @@ version = "0.0.1"
 dependencies = [
  "derive_more",
  "miette 7.6.0",
+ "pacquet-resolving-parse-wanted-dependency",
 ]
 
 [[package]]
@@ -4568,6 +4569,7 @@ dependencies = [
  "pacquet-resolving-default-resolver",
  "pacquet-resolving-jsr-specifier-parser",
  "pacquet-resolving-local-resolver",
+ "pacquet-resolving-parse-wanted-dependency",
  "pacquet-resolving-resolver-base",
  "pacquet-workspace-range-resolver",
  "pacquet-workspace-spec",

--- a/deny.toml
+++ b/deny.toml
@@ -52,6 +52,15 @@ ignore = [
   # ships only in `hickory-proto` 0.26.1+. Revisit when reqwest moves to
   # hickory 0.26.
   { id = "RUSTSEC-2026-0119", reason = "Temporary risk acceptance: reqwest 0.13.x (latest 0.13.3) is locked to hickory-resolver 0.25 and no release consumes hickory-proto 0.26.1+ yet; revisit on reqwest upgrade." },
+  # quick-xml DoS advisories (quadratic duplicate-attribute check, unbounded
+  # namespace-declaration allocation). quick-xml is reached only through
+  # object_store's S3 XML response parsing in pnpr, so the XML comes from the
+  # operator-configured S3-compatible storage backend, not from untrusted
+  # clients. Both fixes ship only in quick-xml 0.41.0, which no object_store
+  # release can resolve yet: object_store 0.13 requires ^0.39 and 0.14
+  # requires ^0.40.1. Revisit when object_store consumes quick-xml 0.41+.
+  { id = "RUSTSEC-2026-0194", reason = "Temporary risk acceptance: XML parsed by quick-xml comes only from the operator-configured S3 backend via object_store; no object_store release consumes the patched quick-xml 0.41 yet." },
+  { id = "RUSTSEC-2026-0195", reason = "Temporary risk acceptance: XML parsed by quick-xml comes only from the operator-configured S3 backend via object_store; no object_store release consumes the patched quick-xml 0.41 yet." },
 ]
 
 # --- Licenses ------------------------------------------------------------

--- a/pacquet/crates/resolving-jsr-specifier-parser/Cargo.toml
+++ b/pacquet/crates/resolving-jsr-specifier-parser/Cargo.toml
@@ -11,6 +11,8 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
+pacquet-resolving-parse-wanted-dependency = { workspace = true }
+
 derive_more = { workspace = true }
 miette      = { workspace = true }
 

--- a/pacquet/crates/resolving-jsr-specifier-parser/src/lib.rs
+++ b/pacquet/crates/resolving-jsr-specifier-parser/src/lib.rs
@@ -43,8 +43,9 @@ pub enum ParseJsrSpecifierError {
     #[diagnostic(code(ERR_PNPM_MISSING_JSR_PACKAGE_SCOPE))]
     MissingScope,
 
-    /// Specifier carries a scope but no `/name` segment
-    /// (e.g. `jsr:@foo` or `jsr:@foo@^1`).
+    /// Specifier carries a malformed scoped name: no `/name` segment
+    /// (e.g. `jsr:@foo`), an empty scope or name (e.g. `jsr:@foo/`),
+    /// or path separators inside the name (e.g. `jsr:@foo/../bar`).
     #[display("The package name '{pkg_name}' is invalid")]
     #[diagnostic(code(ERR_PNPM_INVALID_JSR_PACKAGE_NAME))]
     InvalidPackageName {
@@ -129,11 +130,16 @@ fn jsr_to_npm_package_name(jsr_pkg_name: &str) -> Result<String, ParseJsrSpecifi
     let Some(after_at) = jsr_pkg_name.strip_prefix('@') else {
         return Err(ParseJsrSpecifierError::MissingScope);
     };
+    let invalid =
+        || ParseJsrSpecifierError::InvalidPackageName { pkg_name: jsr_pkg_name.to_string() };
     let Some((scope, name)) = after_at.split_once('/') else {
-        return Err(ParseJsrSpecifierError::InvalidPackageName {
-            pkg_name: jsr_pkg_name.to_string(),
-        });
+        return Err(invalid());
     };
+    // The returned name is used in registry URLs and metadata cache file
+    // paths, so path separator characters must never make it through.
+    if scope.is_empty() || name.is_empty() || name.contains('/') || jsr_pkg_name.contains('\\') {
+        return Err(invalid());
+    }
     Ok(format!("@jsr/{scope}__{name}"))
 }
 

--- a/pacquet/crates/resolving-jsr-specifier-parser/src/lib.rs
+++ b/pacquet/crates/resolving-jsr-specifier-parser/src/lib.rs
@@ -13,6 +13,7 @@
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;
+use pacquet_resolving_parse_wanted_dependency::is_valid_old_npm_package_name;
 
 /// Parsed `jsr:` specifier.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -43,9 +44,11 @@ pub enum ParseJsrSpecifierError {
     #[diagnostic(code(ERR_PNPM_MISSING_JSR_PACKAGE_SCOPE))]
     MissingScope,
 
-    /// Specifier carries a malformed scoped name: no `/name` segment
-    /// (e.g. `jsr:@foo`), an empty scope or name (e.g. `jsr:@foo/`),
-    /// or path separators inside the name (e.g. `jsr:@foo/../bar`).
+    /// Specifier carries a scoped name that is not a valid npm package
+    /// name: no `/name` segment (e.g. `jsr:@foo`), an empty scope or
+    /// name (e.g. `jsr:@foo/`), path separators inside the name
+    /// (e.g. `jsr:@foo/../bar`), or anything else
+    /// `validate-npm-package-name` rejects.
     #[display("The package name '{pkg_name}' is invalid")]
     #[diagnostic(code(ERR_PNPM_INVALID_JSR_PACKAGE_NAME))]
     InvalidPackageName {
@@ -132,14 +135,15 @@ fn jsr_to_npm_package_name(jsr_pkg_name: &str) -> Result<String, ParseJsrSpecifi
     };
     let invalid =
         || ParseJsrSpecifierError::InvalidPackageName { pkg_name: jsr_pkg_name.to_string() };
+    // The returned name is used in registry URLs and metadata cache file
+    // paths, so anything that is not a valid npm package name must never
+    // make it through.
+    if !is_valid_old_npm_package_name(jsr_pkg_name) {
+        return Err(invalid());
+    }
     let Some((scope, name)) = after_at.split_once('/') else {
         return Err(invalid());
     };
-    // The returned name is used in registry URLs and metadata cache file
-    // paths, so path separator characters must never make it through.
-    if scope.is_empty() || name.is_empty() || name.contains('/') || jsr_pkg_name.contains('\\') {
-        return Err(invalid());
-    }
     Ok(format!("@jsr/{scope}__{name}"))
 }
 

--- a/pacquet/crates/resolving-jsr-specifier-parser/src/tests.rs
+++ b/pacquet/crates/resolving-jsr-specifier-parser/src/tests.rs
@@ -85,6 +85,34 @@ fn scope_without_name_is_an_error() {
         parse_jsr_specifier("jsr:@foo", None),
         Err(ParseJsrSpecifierError::InvalidPackageName { pkg_name: "@foo".to_string() }),
     );
+    assert_eq!(
+        parse_jsr_specifier("jsr:@foo/", None),
+        Err(ParseJsrSpecifierError::InvalidPackageName { pkg_name: "@foo/".to_string() }),
+    );
+    assert_eq!(
+        parse_jsr_specifier("jsr:@foo/@^1.0.0", None),
+        Err(ParseJsrSpecifierError::InvalidPackageName { pkg_name: "@foo/".to_string() }),
+    );
+}
+
+#[test]
+fn empty_scope_is_an_error() {
+    assert_eq!(
+        parse_jsr_specifier("jsr:@/bar", None),
+        Err(ParseJsrSpecifierError::InvalidPackageName { pkg_name: "@/bar".to_string() }),
+    );
+}
+
+#[test]
+fn path_separators_in_name_are_an_error() {
+    for input in ["jsr:@foo/../bar", "jsr:@foo/bar/baz", r"jsr:@foo/bar\baz", r"jsr:@fo\o/bar"] {
+        let pkg_name = input.strip_prefix("jsr:").unwrap().to_string();
+        assert_eq!(
+            parse_jsr_specifier(input, None),
+            Err(ParseJsrSpecifierError::InvalidPackageName { pkg_name }),
+            "input: {input}",
+        );
+    }
 }
 
 #[test]

--- a/pacquet/crates/resolving-jsr-specifier-parser/src/tests.rs
+++ b/pacquet/crates/resolving-jsr-specifier-parser/src/tests.rs
@@ -105,7 +105,7 @@ fn empty_scope_is_an_error() {
 
 #[test]
 fn path_separators_in_name_are_an_error() {
-    for input in ["jsr:@foo/../bar", "jsr:@foo/bar/baz", r"jsr:@foo/bar\baz", r"jsr:@fo\o/bar"] {
+    for input in ["jsr:@foo/../bar", "jsr:@foo/bar/baz", r"jsr:@foo/bar\baz", r"jsr:@sco\pe/bar"] {
         let pkg_name = input.strip_prefix("jsr:").unwrap().to_string();
         assert_eq!(
             parse_jsr_specifier(input, None),

--- a/pacquet/crates/resolving-npm-resolver/Cargo.toml
+++ b/pacquet/crates/resolving-npm-resolver/Cargo.toml
@@ -11,14 +11,15 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
-pacquet-config                         = { workspace = true }
-pacquet-lockfile                       = { workspace = true }
-pacquet-network                        = { workspace = true }
-pacquet-registry                       = { workspace = true }
-pacquet-resolving-jsr-specifier-parser = { workspace = true }
-pacquet-resolving-resolver-base        = { workspace = true }
-pacquet-workspace-range-resolver       = { workspace = true }
-pacquet-workspace-spec                 = { workspace = true }
+pacquet-config                            = { workspace = true }
+pacquet-lockfile                          = { workspace = true }
+pacquet-network                           = { workspace = true }
+pacquet-registry                          = { workspace = true }
+pacquet-resolving-jsr-specifier-parser    = { workspace = true }
+pacquet-resolving-parse-wanted-dependency = { workspace = true }
+pacquet-resolving-resolver-base           = { workspace = true }
+pacquet-workspace-range-resolver          = { workspace = true }
+pacquet-workspace-spec                    = { workspace = true }
 
 chrono      = { workspace = true }
 dashmap     = { workspace = true }

--- a/pacquet/crates/resolving-npm-resolver/src/parse_bare_specifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/parse_bare_specifier.rs
@@ -17,6 +17,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use node_semver::{Range, Version};
 use pacquet_resolving_jsr_specifier_parser::{ParseJsrSpecifierError, parse_jsr_specifier};
+use pacquet_resolving_parse_wanted_dependency::is_valid_old_npm_package_name;
 use reqwest::Url;
 
 use crate::pick_package_from_meta::{RegistryPackageSpec, RegistryPackageSpecType};
@@ -157,11 +158,13 @@ pub struct NamedRegistryPackageSpec {
 #[derive(Debug, Display, Error, Diagnostic, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ParseNamedRegistrySpecifierError {
-    /// Malformed package name — a missing or empty scope/name segment,
-    /// or path separators inside the name. Always a configuration bug,
-    /// refused so the user gets an immediate, actionable error instead
-    /// of a confusing downstream 404 (or a name that escapes into
-    /// registry URL paths and metadata cache file paths).
+    /// Package name that is not a valid npm package name — a missing
+    /// or empty scope/name segment, path separators inside the name,
+    /// or anything else `validate-npm-package-name` rejects. Always a
+    /// configuration bug, refused so the user gets an immediate,
+    /// actionable error instead of a confusing downstream 404 (or a
+    /// name that escapes into registry URL paths and metadata cache
+    /// file paths).
     #[display("The package name '{pkg_name}' in named registry '{registry_name}:' is invalid")]
     #[diagnostic(code(ERR_PNPM_INVALID_NAMED_REGISTRY_PACKAGE_NAME))]
     InvalidPackageName {
@@ -241,8 +244,9 @@ pub fn parse_named_registry_specifier_to_registry_package_spec(
     }
 
     // The name is used in registry URLs and metadata cache file paths, so
-    // path separator characters must never make it through.
-    if !is_well_formed_package_name(&pkg_name) {
+    // anything that is not a valid npm package name must never make it
+    // through.
+    if !is_valid_old_npm_package_name(&pkg_name) {
         return Err(ParseNamedRegistrySpecifierError::InvalidPackageName {
             registry_name: registry_name.to_string(),
             pkg_name,
@@ -263,27 +267,6 @@ pub fn parse_named_registry_specifier_to_registry_package_spec(
         },
         registry_name: registry_name.to_string(),
     }))
-}
-
-fn is_well_formed_package_name(pkg_name: &str) -> bool {
-    if pkg_name.contains('\\') {
-        return false;
-    }
-    match pkg_name.strip_prefix('@') {
-        Some(scoped) => match scoped.split_once('/') {
-            Some((scope, name)) => {
-                !scope.is_empty() && !name.contains('/') && is_well_formed_name_segment(name)
-            }
-            None => false,
-        },
-        None => !pkg_name.contains('/') && is_well_formed_name_segment(pkg_name),
-    }
-}
-
-// `.` and `..` are never valid npm names, and as URL path segments they
-// get normalized away from the intended registry path.
-fn is_well_formed_name_segment(name: &str) -> bool {
-    !name.is_empty() && name != "." && name != ".."
 }
 
 /// Discriminate between an exact version, a semver range, and a

--- a/pacquet/crates/resolving-npm-resolver/src/parse_bare_specifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/parse_bare_specifier.rs
@@ -157,9 +157,11 @@ pub struct NamedRegistryPackageSpec {
 #[derive(Debug, Display, Error, Diagnostic, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ParseNamedRegistrySpecifierError {
-    /// Scope without a `/<name>` segment. Always a configuration bug,
+    /// Malformed package name — a missing or empty scope/name segment,
+    /// or path separators inside the name. Always a configuration bug,
     /// refused so the user gets an immediate, actionable error instead
-    /// of a confusing downstream 404.
+    /// of a confusing downstream 404 (or a name that escapes into
+    /// registry URL paths and metadata cache file paths).
     #[display("The package name '{pkg_name}' in named registry '{registry_name}:' is invalid")]
     #[diagnostic(code(ERR_PNPM_INVALID_NAMED_REGISTRY_PACKAGE_NAME))]
     InvalidPackageName {
@@ -174,9 +176,9 @@ pub enum ParseNamedRegistrySpecifierError {
 ///
 /// Returns `Ok(None)` for any specifier that does not use one of the
 /// configured aliases (no colon, alias unknown, body unparsable) so
-/// the caller can fall through to other resolvers. Errors only for
-/// recoverable-by-the-user input — a scoped name with no `/<name>`
-/// segment.
+/// the caller can fall through to other resolvers. Errors when the
+/// alias matches but the package name is malformed (see
+/// [`ParseNamedRegistrySpecifierError::InvalidPackageName`]).
 ///
 /// Supported shapes:
 /// - `<alias>:[@<owner>/]<name>[@<version_selector>]`
@@ -216,12 +218,6 @@ pub fn parse_named_registry_specifier_to_registry_package_spec(
         } else {
             (&body[..last_at], Some(body[last_at + 1..].to_string()))
         };
-        if !name_part.contains('/') || name_part.ends_with('/') {
-            return Err(ParseNamedRegistrySpecifierError::InvalidPackageName {
-                registry_name: registry_name.to_string(),
-                pkg_name: name_part.to_string(),
-            });
-        }
         pkg_name = name_part.to_string();
         version_selector = ver_part;
     } else if package_alias.is_some_and(|alias| alias.starts_with('@')) {
@@ -244,6 +240,15 @@ pub fn parse_named_registry_specifier_to_registry_package_spec(
         version_selector = ver_part;
     }
 
+    // The name is used in registry URLs and metadata cache file paths, so
+    // path separator characters must never make it through.
+    if !is_well_formed_package_name(&pkg_name) {
+        return Err(ParseNamedRegistrySpecifierError::InvalidPackageName {
+            registry_name: registry_name.to_string(),
+            pkg_name,
+        });
+    }
+
     let selector_input = version_selector.as_deref().unwrap_or(default_tag);
     let Some(selector) = get_version_selector_type(selector_input) else {
         return Ok(None);
@@ -258,6 +263,19 @@ pub fn parse_named_registry_specifier_to_registry_package_spec(
         },
         registry_name: registry_name.to_string(),
     }))
+}
+
+fn is_well_formed_package_name(pkg_name: &str) -> bool {
+    if pkg_name.contains('\\') {
+        return false;
+    }
+    match pkg_name.strip_prefix('@') {
+        Some(scoped) => match scoped.split_once('/') {
+            Some((scope, name)) => !scope.is_empty() && !name.is_empty() && !name.contains('/'),
+            None => false,
+        },
+        None => !pkg_name.contains('/'),
+    }
 }
 
 /// Discriminate between an exact version, a semver range, and a

--- a/pacquet/crates/resolving-npm-resolver/src/parse_bare_specifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/parse_bare_specifier.rs
@@ -271,11 +271,19 @@ fn is_well_formed_package_name(pkg_name: &str) -> bool {
     }
     match pkg_name.strip_prefix('@') {
         Some(scoped) => match scoped.split_once('/') {
-            Some((scope, name)) => !scope.is_empty() && !name.is_empty() && !name.contains('/'),
+            Some((scope, name)) => {
+                !scope.is_empty() && !name.contains('/') && is_well_formed_name_segment(name)
+            }
             None => false,
         },
-        None => !pkg_name.contains('/'),
+        None => !pkg_name.contains('/') && is_well_formed_name_segment(pkg_name),
     }
+}
+
+// `.` and `..` are never valid npm names, and as URL path segments they
+// get normalized away from the intended registry path.
+fn is_well_formed_name_segment(name: &str) -> bool {
+    !name.is_empty() && name != "." && name != ".."
 }
 
 /// Discriminate between an exact version, a semver range, and a

--- a/pacquet/crates/resolving-npm-resolver/src/parse_bare_specifier/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/parse_bare_specifier/tests.rs
@@ -391,6 +391,20 @@ fn named_registry_empty_scope_errors() {
 }
 
 #[test]
+fn named_registry_dot_segment_name_errors() {
+    let gh = gh_aliases();
+    for input in ["gh:.", "gh:..", "gh:@acme/.", "gh:@acme/.."] {
+        let err =
+            parse_named_registry_specifier_to_registry_package_spec(input, &gh, None, "latest")
+                .expect_err("dot-segment names must error");
+        assert!(
+            matches!(err, ParseNamedRegistrySpecifierError::InvalidPackageName { .. }),
+            "got {err:?} for {input:?}",
+        );
+    }
+}
+
+#[test]
 fn named_registry_path_separators_in_name_error() {
     let gh = gh_aliases();
     for input in [

--- a/pacquet/crates/resolving-npm-resolver/src/parse_bare_specifier/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/parse_bare_specifier/tests.rs
@@ -379,6 +379,39 @@ fn named_registry_scope_without_name_errors() {
 }
 
 #[test]
+fn named_registry_empty_scope_errors() {
+    let gh = gh_aliases();
+    let err =
+        parse_named_registry_specifier_to_registry_package_spec("gh:@/bar", &gh, None, "latest")
+            .expect_err("empty scope must error");
+    assert!(
+        matches!(err, ParseNamedRegistrySpecifierError::InvalidPackageName { .. }),
+        "got {err:?}",
+    );
+}
+
+#[test]
+fn named_registry_path_separators_in_name_error() {
+    let gh = gh_aliases();
+    for input in [
+        "gh:@acme/../foo",
+        "gh:@acme/foo/bar",
+        r"gh:@acme/foo\bar",
+        r"gh:@sco\pe/foo",
+        "gh:foo/../bar",
+        r"gh:foo\bar",
+    ] {
+        let err =
+            parse_named_registry_specifier_to_registry_package_spec(input, &gh, None, "latest")
+                .expect_err("path separators in the name must error");
+        assert!(
+            matches!(err, ParseNamedRegistrySpecifierError::InvalidPackageName { .. }),
+            "got {err:?} for {input:?}",
+        );
+    }
+}
+
+#[test]
 fn named_registry_version_only_no_alias_declines() {
     let gh = gh_aliases();
     let result =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8670,6 +8670,9 @@ importers:
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../core/error
+      validate-npm-package-name:
+        specifier: 'catalog:'
+        version: 7.0.2
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -8677,6 +8680,9 @@ importers:
       '@pnpm/resolving.jsr-specifier-parser':
         specifier: workspace:*
         version: 'link:'
+      '@types/validate-npm-package-name':
+        specifier: 'catalog:'
+        version: 4.0.2
 
   pnpm11/resolving/local-resolver:
     dependencies:
@@ -8807,6 +8813,9 @@ importers:
       ssri:
         specifier: 'catalog:'
         version: 13.0.1
+      validate-npm-package-name:
+        specifier: 'catalog:'
+        version: 7.0.2
       version-selector-type:
         specifier: 'catalog:'
         version: 3.0.0
@@ -8841,6 +8850,9 @@ importers:
       '@types/ssri':
         specifier: 'catalog:'
         version: 7.1.5
+      '@types/validate-npm-package-name':
+        specifier: 'catalog:'
+        version: 4.0.2
       load-json-file:
         specifier: 'catalog:'
         version: 7.0.1

--- a/pnpm11/resolving/jsr-specifier-parser/package.json
+++ b/pnpm11/resolving/jsr-specifier-parser/package.json
@@ -32,11 +32,13 @@
     ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
   },
   "dependencies": {
-    "@pnpm/error": "workspace:*"
+    "@pnpm/error": "workspace:*",
+    "validate-npm-package-name": "catalog:"
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
-    "@pnpm/resolving.jsr-specifier-parser": "workspace:*"
+    "@pnpm/resolving.jsr-specifier-parser": "workspace:*",
+    "@types/validate-npm-package-name": "catalog:"
   },
   "engines": {
     "node": ">=22.13"

--- a/pnpm11/resolving/jsr-specifier-parser/src/index.ts
+++ b/pnpm11/resolving/jsr-specifier-parser/src/index.ts
@@ -58,10 +58,12 @@ function jsrToNpmPackageName (jsrPkgName: string): string {
   if (sepIndex === -1) {
     throw new PnpmError('INVALID_JSR_PACKAGE_NAME', `The package name '${jsrPkgName}' is invalid`)
   }
-  const scope = jsrPkgName.substring(0, sepIndex)
+  const scope = jsrPkgName.substring('@'.length, sepIndex)
   const name = jsrPkgName.substring(sepIndex + '/'.length)
-  if (!name) {
+  // The returned name is used in registry URLs and metadata cache file paths,
+  // so path separator characters must never make it through.
+  if (!scope || !name || name.includes('/') || jsrPkgName.includes('\\')) {
     throw new PnpmError('INVALID_JSR_PACKAGE_NAME', `The package name '${jsrPkgName}' is invalid`)
   }
-  return `@jsr/${scope.substring(1)}__${name}`
+  return `@jsr/${scope}__${name}`
 }

--- a/pnpm11/resolving/jsr-specifier-parser/src/index.ts
+++ b/pnpm11/resolving/jsr-specifier-parser/src/index.ts
@@ -1,4 +1,5 @@
 import { PnpmError } from '@pnpm/error'
+import validateNpmPackageName from 'validate-npm-package-name'
 
 export interface JsrSpec {
   jsrPkgName: string
@@ -54,16 +55,13 @@ function jsrToNpmPackageName (jsrPkgName: string): string {
   if (jsrPkgName[0] !== '@') {
     throw new PnpmError('MISSING_JSR_PACKAGE_SCOPE', 'Package names from JSR must have a scope')
   }
-  const sepIndex = jsrPkgName.indexOf('/')
-  if (sepIndex === -1) {
+  // The returned name is used in registry URLs and metadata cache file paths,
+  // so anything that is not a valid npm package name must never make it through.
+  if (!validateNpmPackageName(jsrPkgName).validForOldPackages) {
     throw new PnpmError('INVALID_JSR_PACKAGE_NAME', `The package name '${jsrPkgName}' is invalid`)
   }
+  const sepIndex = jsrPkgName.indexOf('/')
   const scope = jsrPkgName.substring('@'.length, sepIndex)
   const name = jsrPkgName.substring(sepIndex + '/'.length)
-  // The returned name is used in registry URLs and metadata cache file paths,
-  // so path separator characters must never make it through.
-  if (!scope || !name || name.includes('/') || jsrPkgName.includes('\\')) {
-    throw new PnpmError('INVALID_JSR_PACKAGE_NAME', `The package name '${jsrPkgName}' is invalid`)
-  }
   return `@jsr/${scope}__${name}`
 }

--- a/pnpm11/resolving/jsr-specifier-parser/src/index.ts
+++ b/pnpm11/resolving/jsr-specifier-parser/src/index.ts
@@ -60,5 +60,8 @@ function jsrToNpmPackageName (jsrPkgName: string): string {
   }
   const scope = jsrPkgName.substring(0, sepIndex)
   const name = jsrPkgName.substring(sepIndex + '/'.length)
+  if (!name) {
+    throw new PnpmError('INVALID_JSR_PACKAGE_NAME', `The package name '${jsrPkgName}' is invalid`)
+  }
   return `@jsr/${scope.substring(1)}__${name}`
 }

--- a/pnpm11/resolving/jsr-specifier-parser/test/parse.test.ts
+++ b/pnpm11/resolving/jsr-specifier-parser/test/parse.test.ts
@@ -42,8 +42,31 @@ describe('parseJsrSpecifier', () => {
     expect(() => parseJsrSpecifier('jsr:@foo')).toThrow(expect.objectContaining({
       code: 'ERR_PNPM_INVALID_JSR_PACKAGE_NAME',
     }))
-    // scope with a trailing slash but empty package name: jsr:@scope/
     expect(() => parseJsrSpecifier('jsr:@foo/')).toThrow(expect.objectContaining({
+      code: 'ERR_PNPM_INVALID_JSR_PACKAGE_NAME',
+    }))
+    expect(() => parseJsrSpecifier('jsr:@foo/@^1.0.0')).toThrow(expect.objectContaining({
+      code: 'ERR_PNPM_INVALID_JSR_PACKAGE_NAME',
+    }))
+  })
+
+  test('errors on jsr specifiers that contain names with empty scopes', () => {
+    expect(() => parseJsrSpecifier('jsr:@/bar')).toThrow(expect.objectContaining({
+      code: 'ERR_PNPM_INVALID_JSR_PACKAGE_NAME',
+    }))
+  })
+
+  test('errors on jsr specifiers that contain path separators in the package name', () => {
+    expect(() => parseJsrSpecifier('jsr:@foo/../bar')).toThrow(expect.objectContaining({
+      code: 'ERR_PNPM_INVALID_JSR_PACKAGE_NAME',
+    }))
+    expect(() => parseJsrSpecifier('jsr:@foo/bar/baz')).toThrow(expect.objectContaining({
+      code: 'ERR_PNPM_INVALID_JSR_PACKAGE_NAME',
+    }))
+    expect(() => parseJsrSpecifier('jsr:@foo/bar\\baz')).toThrow(expect.objectContaining({
+      code: 'ERR_PNPM_INVALID_JSR_PACKAGE_NAME',
+    }))
+    expect(() => parseJsrSpecifier('jsr:@fo\\o/bar')).toThrow(expect.objectContaining({
       code: 'ERR_PNPM_INVALID_JSR_PACKAGE_NAME',
     }))
   })

--- a/pnpm11/resolving/jsr-specifier-parser/test/parse.test.ts
+++ b/pnpm11/resolving/jsr-specifier-parser/test/parse.test.ts
@@ -66,7 +66,7 @@ describe('parseJsrSpecifier', () => {
     expect(() => parseJsrSpecifier('jsr:@foo/bar\\baz')).toThrow(expect.objectContaining({
       code: 'ERR_PNPM_INVALID_JSR_PACKAGE_NAME',
     }))
-    expect(() => parseJsrSpecifier('jsr:@fo\\o/bar')).toThrow(expect.objectContaining({
+    expect(() => parseJsrSpecifier('jsr:@sco\\pe/bar')).toThrow(expect.objectContaining({
       code: 'ERR_PNPM_INVALID_JSR_PACKAGE_NAME',
     }))
   })

--- a/pnpm11/resolving/jsr-specifier-parser/test/parse.test.ts
+++ b/pnpm11/resolving/jsr-specifier-parser/test/parse.test.ts
@@ -42,5 +42,9 @@ describe('parseJsrSpecifier', () => {
     expect(() => parseJsrSpecifier('jsr:@foo')).toThrow(expect.objectContaining({
       code: 'ERR_PNPM_INVALID_JSR_PACKAGE_NAME',
     }))
+    // scope with a trailing slash but empty package name: jsr:@scope/
+    expect(() => parseJsrSpecifier('jsr:@foo/')).toThrow(expect.objectContaining({
+      code: 'ERR_PNPM_INVALID_JSR_PACKAGE_NAME',
+    }))
   })
 })

--- a/pnpm11/resolving/npm-resolver/package.json
+++ b/pnpm11/resolving/npm-resolver/package.json
@@ -63,6 +63,7 @@
     "semver": "catalog:",
     "semver-utils": "catalog:",
     "ssri": "catalog:",
+    "validate-npm-package-name": "catalog:",
     "version-selector-type": "catalog:"
   },
   "peerDependencies": {
@@ -80,6 +81,7 @@
     "@types/ramda": "catalog:",
     "@types/semver": "catalog:",
     "@types/ssri": "catalog:",
+    "@types/validate-npm-package-name": "catalog:",
     "load-json-file": "catalog:",
     "tempy": "catalog:"
   },

--- a/pnpm11/resolving/npm-resolver/src/parseBareSpecifier.ts
+++ b/pnpm11/resolving/npm-resolver/src/parseBareSpecifier.ts
@@ -2,6 +2,7 @@ import { PnpmError } from '@pnpm/error'
 import { parseJsrSpecifier } from '@pnpm/resolving.jsr-specifier-parser'
 import { parseNpmTarballUrl } from 'parse-npm-tarball-url'
 import semver from 'semver'
+import validateNpmPackageName from 'validate-npm-package-name'
 import getVersionSelectorType from 'version-selector-type'
 
 export interface RegistryPackageSpec {
@@ -150,8 +151,8 @@ export function parseNamedRegistrySpecifierToRegistryPackageSpec (
   }
 
   // The name is used in registry URLs and metadata cache file paths, so
-  // path separator characters must never make it through.
-  if (!isWellFormedPackageName(pkgName)) {
+  // anything that is not a valid npm package name must never make it through.
+  if (!validateNpmPackageName(pkgName).validForOldPackages) {
     throw new PnpmError(
       'INVALID_NAMED_REGISTRY_PACKAGE_NAME',
       `The package name '${pkgName}' in named registry '${registryName}:' is invalid`
@@ -167,22 +168,4 @@ export function parseNamedRegistrySpecifierToRegistryPackageSpec (
     type: selector.type,
     registryName,
   }
-}
-
-function isWellFormedPackageName (pkgName: string): boolean {
-  if (pkgName.includes('\\')) return false
-  if (pkgName.startsWith('@')) {
-    const sepIndex = pkgName.indexOf('/')
-    if (sepIndex === -1) return false
-    const scope = pkgName.substring('@'.length, sepIndex)
-    const name = pkgName.substring(sepIndex + '/'.length)
-    return scope.length > 0 && !name.includes('/') && isWellFormedNameSegment(name)
-  }
-  return !pkgName.includes('/') && isWellFormedNameSegment(pkgName)
-}
-
-// `.` and `..` are never valid npm names, and as URL path segments they get
-// normalized away from the intended registry path.
-function isWellFormedNameSegment (name: string): boolean {
-  return name.length > 0 && name !== '.' && name !== '..'
 }

--- a/pnpm11/resolving/npm-resolver/src/parseBareSpecifier.ts
+++ b/pnpm11/resolving/npm-resolver/src/parseBareSpecifier.ts
@@ -176,7 +176,13 @@ function isWellFormedPackageName (pkgName: string): boolean {
     if (sepIndex === -1) return false
     const scope = pkgName.substring('@'.length, sepIndex)
     const name = pkgName.substring(sepIndex + '/'.length)
-    return scope.length > 0 && name.length > 0 && !name.includes('/')
+    return scope.length > 0 && !name.includes('/') && isWellFormedNameSegment(name)
   }
-  return !pkgName.includes('/')
+  return !pkgName.includes('/') && isWellFormedNameSegment(pkgName)
+}
+
+// `.` and `..` are never valid npm names, and as URL path segments they get
+// normalized away from the intended registry path.
+function isWellFormedNameSegment (name: string): boolean {
+  return name.length > 0 && name !== '.' && name !== '..'
 }

--- a/pnpm11/resolving/npm-resolver/src/parseBareSpecifier.ts
+++ b/pnpm11/resolving/npm-resolver/src/parseBareSpecifier.ts
@@ -95,6 +95,9 @@ export interface NamedRegistryPackageSpec extends RegistryPackageSpec {
 // Parses a named-registry specifier of the shape `<alias>:<body>` into a
 // RegistryPackageSpec. Returns `null` when the specifier does not use one of
 // the configured aliases, so the caller can fall through to other resolvers.
+// Throws INVALID_NAMED_REGISTRY_PACKAGE_NAME when the alias matches but the
+// package name is malformed (missing or empty scope/name segments, path
+// separators inside the name).
 // Supported shapes:
 // - `<alias>:[@<owner>/]<name>[@<version_selector>]`
 // - `<alias>:<version_selector>` paired with a package alias
@@ -128,12 +131,6 @@ export function parseNamedRegistrySpecifierToRegistryPackageSpec (
       pkgName = body.substring(0, index)
       versionSelector = body.substring(index + '@'.length)
     }
-    if (pkgName.indexOf('/') === -1 || pkgName.endsWith('/')) {
-      throw new PnpmError(
-        'INVALID_NAMED_REGISTRY_PACKAGE_NAME',
-        `The package name '${pkgName}' in named registry '${registryName}:' is invalid`
-      )
-    }
   } else if (packageAlias?.startsWith('@')) {
     // `<alias>:<tag>` paired with a scoped alias — body is a version
     // selector (tag/dist-tag). Mirrors GitHub Packages, where the package
@@ -152,6 +149,15 @@ export function parseNamedRegistrySpecifierToRegistryPackageSpec (
     if (!pkgName) return null
   }
 
+  // The name is used in registry URLs and metadata cache file paths, so
+  // path separator characters must never make it through.
+  if (!isWellFormedPackageName(pkgName)) {
+    throw new PnpmError(
+      'INVALID_NAMED_REGISTRY_PACKAGE_NAME',
+      `The package name '${pkgName}' in named registry '${registryName}:' is invalid`
+    )
+  }
+
   const selector = getVersionSelectorType(versionSelector ?? defaultTag)
   if (selector == null) return null
 
@@ -161,4 +167,16 @@ export function parseNamedRegistrySpecifierToRegistryPackageSpec (
     type: selector.type,
     registryName,
   }
+}
+
+function isWellFormedPackageName (pkgName: string): boolean {
+  if (pkgName.includes('\\')) return false
+  if (pkgName.startsWith('@')) {
+    const sepIndex = pkgName.indexOf('/')
+    if (sepIndex === -1) return false
+    const scope = pkgName.substring('@'.length, sepIndex)
+    const name = pkgName.substring(sepIndex + '/'.length)
+    return scope.length > 0 && name.length > 0 && !name.includes('/')
+  }
+  return !pkgName.includes('/')
 }

--- a/pnpm11/resolving/npm-resolver/test/parseBareSpecifier.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/parseBareSpecifier.test.ts
@@ -115,6 +115,20 @@ describe('parseNamedRegistrySpecifierToRegistryPackageSpec', () => {
     }))
   })
 
+  test('throws when the scope is empty', () => {
+    expect(() => parseNamedRegistrySpecifierToRegistryPackageSpec('gh:@/bar', GH_ALIASES, undefined, DEFAULT_TAG)).toThrow(expect.objectContaining({
+      code: 'ERR_PNPM_INVALID_NAMED_REGISTRY_PACKAGE_NAME',
+    }))
+  })
+
+  test('throws when the package name contains path separators', () => {
+    for (const rawSpecifier of ['gh:@acme/../foo', 'gh:@acme/foo/bar', 'gh:@acme/foo\\bar', 'gh:@sco\\pe/foo', 'gh:foo/../bar', 'gh:foo\\bar']) {
+      expect(() => parseNamedRegistrySpecifierToRegistryPackageSpec(rawSpecifier, GH_ALIASES, undefined, DEFAULT_TAG)).toThrow(expect.objectContaining({
+        code: 'ERR_PNPM_INVALID_NAMED_REGISTRY_PACKAGE_NAME',
+      }))
+    }
+  })
+
   test('does not claim <alias>:<version_selector> when no package alias is provided', () => {
     // No alias means we cannot know the package name — we must not hijack such specifiers.
     expect(parseNamedRegistrySpecifierToRegistryPackageSpec('gh:^1.0.0', GH_ALIASES, undefined, DEFAULT_TAG)).toBeNull()

--- a/pnpm11/resolving/npm-resolver/test/parseBareSpecifier.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/parseBareSpecifier.test.ts
@@ -121,6 +121,14 @@ describe('parseNamedRegistrySpecifierToRegistryPackageSpec', () => {
     }))
   })
 
+  test('throws when the package name is a dot segment', () => {
+    for (const rawSpecifier of ['gh:.', 'gh:..', 'gh:@acme/.', 'gh:@acme/..']) {
+      expect(() => parseNamedRegistrySpecifierToRegistryPackageSpec(rawSpecifier, GH_ALIASES, undefined, DEFAULT_TAG)).toThrow(expect.objectContaining({
+        code: 'ERR_PNPM_INVALID_NAMED_REGISTRY_PACKAGE_NAME',
+      }))
+    }
+  })
+
   test('throws when the package name contains path separators', () => {
     for (const rawSpecifier of ['gh:@acme/../foo', 'gh:@acme/foo/bar', 'gh:@acme/foo\\bar', 'gh:@sco\\pe/foo', 'gh:foo/../bar', 'gh:foo\\bar']) {
       expect(() => parseNamedRegistrySpecifierToRegistryPackageSpec(rawSpecifier, GH_ALIASES, undefined, DEFAULT_TAG)).toThrow(expect.objectContaining({


### PR DESCRIPTION
## Summary

`jsrToNpmPackageName` checked for a missing `/` separator but not for other malformed shapes. Passing `jsr:@foo/` (a scope with a trailing slash but no name) silently returned the malformed npm package name `@jsr/foo__` instead of raising `INVALID_JSR_PACKAGE_NAME`. Review also surfaced that the name segment could carry extra path separators (e.g. `jsr:@foo/../bar`), which flowed into the generated `@jsr/...` npm name and from there into registry URLs and metadata cache file paths — a path-injection risk.

The named-registry specifier parser (e.g. `gh:`) had the same class of gap: its scoped branch only checked for a missing `/` and a trailing slash, and its unscoped branch checked nothing, so names like `gh:@foo/../bar`, `gh:@/bar`, `gh:foo/../bar`, dot segments (`gh:..`), and backslash variants parsed successfully. The downstream `validatePackageName` in pick-package only rejects a `/` in unscoped names, so scoped traversal reached `getPkgMirrorPath`, which joins the raw name into the metadata cache file path.

### Fix

Both parsers now validate the package name with the validator the repo already ships — `validate-npm-package-name` (`validForOldPackages`) in TypeScript and its existing pacquet port `is_valid_old_npm_package_name` — instead of hand-rolled shape checks. That rejects every shape above (empty scope/name, extra `/`, `\`, `.`/`..`) plus everything else npm forbids (leading dots/underscores/hyphens, non-URL-safe characters, `node_modules`, whitespace).

- `jsrToNpmPackageName` throws `INVALID_JSR_PACKAGE_NAME` for any invalid scoped name (missing-scope input still throws `MISSING_JSR_PACKAGE_SCOPE`).
- `parseNamedRegistrySpecifierToRegistryPackageSpec` validates all branches (scoped, unscoped, and alias-derived names) and throws `INVALID_NAMED_REGISTRY_PACKAGE_NAME` — the error code its scoped branch already used.

Both fixes land in the TypeScript CLI and pacquet, keeping the two stacks behaviorally identical.

### Testing

- `pnpm --filter @pnpm/resolving.jsr-specifier-parser test` — 8/8 pass (new cases for the rejected shapes).
- `pnpm --filter @pnpm/resolving.npm-resolver test` — 236/236 pass (new negative cases for named-registry names, incl. dot segments).
- `cargo nextest run -p pacquet-resolving-jsr-specifier-parser -p pacquet-resolving-npm-resolver` — 283/283 pass.
- `cargo clippy --all-targets -- --deny warnings`, `cargo fmt --check`, and `typos pacquet pnpr` clean.

## Squash Commit Body

```text
The jsr: specifier parser accepted scoped names with an empty scope or
name and with path separators inside the name; the malformed name was
folded into the @jsr/... npm name and flowed into registry URLs and
metadata cache file paths. It now throws INVALID_JSR_PACKAGE_NAME for
any name rejected by npm's package-name rules.

The named-registry specifier parser (e.g. gh:) had the same gap: the
scoped branch only rejected a missing '/' or trailing slash, and the
unscoped branch validated nothing, while the downstream pick-package
validator only rejects '/' in unscoped names. The parser now validates
the final package name in every branch (including alias-derived names)
and throws INVALID_NAMED_REGISTRY_PACKAGE_NAME for the same shapes.

Rather than hand-rolling the shape checks, both parsers delegate to the
validator the repo already ships: validate-npm-package-name
(validForOldPackages) in TypeScript and its existing pacquet port
is_valid_old_npm_package_name. Both fixes land in the TypeScript CLI
and pacquet, with matching tests.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

> AI-assisted fix (Anthropic Claude). Review-hardening commit 2d368acd26 and the named-registry/validator commits written by an agent (Claude Code, claude-fable-5).
