### PR TITLE
ci: pin oz-agent-action to the exact tag for zizmor's version check

### DIFF
--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Triage with Oz agent
-        uses: warpdotdev/oz-agent-action@501d24fbf4d1447e8db60eb0973eeadeb5ff54c2 # v1
+        uses: warpdotdev/oz-agent-action@501d24fbf4d1447e8db60eb0973eeadeb5ff54c2 # v1.0.19
         id: triage
         env:
           # Authenticates the `gh` CLI the agent uses to read/label/comment.


### PR DESCRIPTION
## Summary

The "Security Analysis with zizmor" check currently fails on **every** open
pull request, regardless of its contents, because of a single unsuppressed
finding in `.github/workflows/triage-issues.yml`:

```
warning[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
  --> .github/workflows/triage-issues.yml:40:85
40 |  uses: warpdotdev/oz-agent-action@501d24fbf4d1447e8db60eb0973eeadeb5ff54c2 # v1
   |  is pointed to by tag v1.0.19
```

The Oz triage agent's action is correctly pinned by SHA, but the version
comment said `# v1` while that SHA is the commit tag `v1.0.19` points to.
zizmor's `ref-version-mismatch` audit (an online audit) flags this as a
medium finding, and one unsuppressed medium fails the check.

This corrects the comment to `# v1.0.19`. The SHA pin — and therefore the
action's behavior — is unchanged; only the human-facing version annotation
is fixed, matching the precise-version convention the other pins in the
repo already use (e.g. `actions/checkout@... # v7.0.0`).

zizmor runs each PR against its merge with `main`, so this finding surfaces
on PRs opened before it landed too; merging this clears the check across
all of them.

## Squash Commit Body

```text
zizmor's ref-version-mismatch audit flags the Oz triage agent's action
pin: SHA 501d24fbf4d1447e8db60eb0973eeadeb5ff54c2 is the commit tag
v1.0.19 points to, but the comment said `# v1`. One unsuppressed medium
finding fails the "Security Analysis with zizmor" check on every PR.
Correct the comment to `# v1.0.19`; the SHA pin (and the action's
behavior) is unchanged. Verified with `zizmor .`: no findings.
```

## Checklist

- [x] Verified locally with `zizmor .` ("No findings to report").

<!-- CI-only change to a workflow file: no TS/pacquet code, no published package,
so the parity and changeset items do not apply; no unit tests apply. -->

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the issue-triage automation to use a newer pinned version of the agent action for improved consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->