### PR TITLE
fix: suppress auth warning when PNPM_CONFIG_NPMRC_AUTH_FILE points at project .npmrc

### DIFF
--- a/.changeset/rare-mice-peel.md
+++ b/.changeset/rare-mice-peel.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-fix: no longer warn about ignored auth settings when PNPM_CONFIG_NPMRC_AUTH_FILE points at the project .npmrc
+pnpm no longer warns about ignored project-level auth settings when `PNPM_CONFIG_NPMRC_AUTH_FILE` points at the project `.npmrc` — setting it to that file is an explicit opt-in to trusting it, so auth env variables in it are expanded [pnpm/pnpm#12480](https://github.com/pnpm/pnpm/issues/12480).

--- a/.changeset/rare-mice-peel.md
+++ b/.changeset/rare-mice-peel.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/config.reader": patch
+"pnpm": patch
 ---
 
 fix: no longer warn about ignored auth settings when PNPM_CONFIG_NPMRC_AUTH_FILE points at the project .npmrc

--- a/.changeset/rare-mice-peel.md
+++ b/.changeset/rare-mice-peel.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/config.reader": patch
+---
+
+fix: no longer warn about ignored auth settings when PNPM_CONFIG_NPMRC_AUTH_FILE points at the project .npmrc

--- a/pacquet/crates/config/src/api.rs
+++ b/pacquet/crates/config/src/api.rs
@@ -59,10 +59,13 @@ pub trait GetHomeDir {
 /// Mirrors [`std::env::current_dir`]. Only used by code that
 /// genuinely needs the cwd — the `SmartDefault` for
 /// [`crate::Config::store_dir`] consults it on Windows for the
-/// drive-letter derivation. Code that needs a "starting path" — like
-/// [`crate::Config::current`] — takes a direct path parameter
-/// instead, because production passes a caller-supplied path (the
-/// canonicalized `--dir`) rather than the host's cwd.
+/// drive-letter derivation, and [`crate::Config::current`] anchors a
+/// relative `npmrcAuthFile` value at the cwd (matching where the file
+/// is actually read from, and pnpm's `path.resolve`). Code that needs
+/// a "starting path" — like [`crate::Config::current`] — otherwise
+/// takes a direct path parameter, because production passes a
+/// caller-supplied path (the canonicalized `--dir`) rather than the
+/// host's cwd.
 pub trait GetCurrentDir {
     /// Return the process's current working directory, or an error
     /// if it can't be determined. Mirrors [`std::env::current_dir`].

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1719,7 +1719,7 @@ impl Config {
         start_dir: &std::path::Path,
     ) -> Result<Self, LoadWorkspaceYamlError>
     where
-        Sys: EnvVar + EnvVarOs + GetHomeDir + LinkProbe,
+        Sys: EnvVar + EnvVarOs + GetCurrentDir + GetHomeDir + LinkProbe,
     {
         // Re-anchor the path-valued defaults (`modules_dir`,
         // `virtual_store_dir`) onto the caller-supplied starting directory.
@@ -1822,11 +1822,16 @@ impl Config {
         let project_npmrc_path = project_npmrc_dir.join(".npmrc");
         // When npmrcAuthFile explicitly points at the project .npmrc, the user has
         // opted in to trusting it — allow auth env expansion and suppress the warning.
-        // Resolve to absolute so relative values like ".npmrc" still match.
-        let project_is_trusted_auth_file = user_npmrc_path
-            .as_deref()
-            .and_then(|user| std::path::absolute(user).ok())
-            .is_some_and(|user_abs| user_abs == project_npmrc_path);
+        // A relative value (e.g. `PNPM_CONFIG_NPMRC_AUTH_FILE=.npmrc`) is anchored
+        // at the cwd — where the user-level read below actually reads it from, and
+        // how pnpm's `path.resolve` anchors it.
+        let project_is_trusted_auth_file = user_npmrc_path.as_deref().is_some_and(|user| {
+            if user.is_absolute() {
+                user == project_npmrc_path
+            } else {
+                Sys::current_dir().is_ok_and(|cwd| cwd.join(user) == project_npmrc_path)
+            }
+        });
         let project_source = read_npmrc(project_npmrc_dir).map(|text| {
             let mut auth = if project_is_trusted_auth_file {
                 NpmrcAuth::from_ini::<Sys>(&text, project_npmrc_dir)

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1822,11 +1822,8 @@ impl Config {
         let project_npmrc_path = project_npmrc_dir.join(".npmrc");
         // When npmrcAuthFile explicitly points at the project .npmrc, the user has
         // opted in to trusting it — allow auth env expansion and suppress the warning.
-        let project_is_trusted_auth_file = user_npmrc_path
-            .as_deref()
-            .and_then(|p| p.canonicalize().ok())
-            .zip(project_npmrc_path.canonicalize().ok())
-            .is_some_and(|(user, project)| user == project);
+        let project_is_trusted_auth_file =
+            user_npmrc_path.as_deref().is_some_and(|user| user == project_npmrc_path);
         let project_source = read_npmrc(project_npmrc_dir).map(|text| {
             let mut auth = if project_is_trusted_auth_file {
                 NpmrcAuth::from_ini::<Sys>(&text, project_npmrc_dir)

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1819,8 +1819,20 @@ impl Config {
         };
         let project_npmrc_dir =
             workspace_yaml.as_ref().map_or(start_dir, |(base_dir, _)| base_dir.as_path());
+        let project_npmrc_path = project_npmrc_dir.join(".npmrc");
+        // When npmrcAuthFile explicitly points at the project .npmrc, the user has
+        // opted in to trusting it — allow auth env expansion and suppress the warning.
+        let project_is_trusted_auth_file = user_npmrc_path
+            .as_deref()
+            .and_then(|p| p.canonicalize().ok())
+            .zip(project_npmrc_path.canonicalize().ok())
+            .is_some_and(|(user, project)| user == project);
         let project_source = read_npmrc(project_npmrc_dir).map(|text| {
-            let mut auth = NpmrcAuth::from_project_ini::<Sys>(&text, project_npmrc_dir);
+            let mut auth = if project_is_trusted_auth_file {
+                NpmrcAuth::from_ini::<Sys>(&text, project_npmrc_dir)
+            } else {
+                NpmrcAuth::from_project_ini::<Sys>(&text, project_npmrc_dir)
+            };
             auth.rescope_unscoped("<project>/.npmrc");
             auth
         });

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1822,8 +1822,11 @@ impl Config {
         let project_npmrc_path = project_npmrc_dir.join(".npmrc");
         // When npmrcAuthFile explicitly points at the project .npmrc, the user has
         // opted in to trusting it — allow auth env expansion and suppress the warning.
-        let project_is_trusted_auth_file =
-            user_npmrc_path.as_deref().is_some_and(|user| user == project_npmrc_path);
+        // Resolve to absolute so relative values like ".npmrc" still match.
+        let project_is_trusted_auth_file = user_npmrc_path
+            .as_deref()
+            .and_then(|user| std::path::absolute(user).ok())
+            .is_some_and(|user_abs| user_abs == project_npmrc_path);
         let project_source = read_npmrc(project_npmrc_dir).map(|text| {
             let mut auth = if project_is_trusted_auth_file {
                 NpmrcAuth::from_ini::<Sys>(&text, project_npmrc_dir)

--- a/pacquet/crates/config/src/npmrc_auth/tests.rs
+++ b/pacquet/crates/config/src/npmrc_auth/tests.rs
@@ -1459,3 +1459,48 @@ fn json_env_normalizes_registry_url_key() {
         Some("https://reg.example/"),
     );
 }
+
+// Regression test for pnpm/pnpm#12480: from_project_ini warns and drops
+// auth env vars (correct default); from_ini trusts them (used when
+// PNPM_CONFIG_NPMRC_AUTH_FILE explicitly points at the project .npmrc).
+#[test]
+fn from_project_ini_warns_on_auth_env_placeholder() {
+    static_env!(Env, &[("MY_TOKEN", "secret")]);
+
+    let auth = NpmrcAuth::from_project_ini::<Env>(
+        "//registry.npmjs.org/:_authToken=${MY_TOKEN}\n",
+        Path::new(""),
+    );
+
+    assert!(
+        auth.warnings.iter().any(|w| w.contains("Ignored project-level auth setting")),
+        "expected auth warning but got: {:?}",
+        auth.warnings,
+    );
+    assert_eq!(
+        default_auth_token(&auth, "//registry.npmjs.org/"),
+        None,
+        "token must not be set when project .npmrc is untrusted",
+    );
+}
+
+#[test]
+fn from_ini_expands_auth_env_placeholder_without_warning() {
+    static_env!(Env, &[("MY_TOKEN", "secret")]);
+
+    let auth = NpmrcAuth::from_ini::<Env>(
+        "//registry.npmjs.org/:_authToken=${MY_TOKEN}\n",
+        Path::new(""),
+    );
+
+    assert!(
+        !auth.warnings.iter().any(|w| w.contains("Ignored project-level auth setting")),
+        "unexpected auth warning: {:?}",
+        auth.warnings,
+    );
+    assert_eq!(
+        default_auth_token(&auth, "//registry.npmjs.org/"),
+        Some(Some("secret")),
+        "token must be expanded when the file is trusted via PNPM_CONFIG_NPMRC_AUTH_FILE",
+    );
+}

--- a/pacquet/crates/config/src/npmrc_auth/tests.rs
+++ b/pacquet/crates/config/src/npmrc_auth/tests.rs
@@ -1488,10 +1488,8 @@ fn from_project_ini_warns_on_auth_env_placeholder() {
 fn from_ini_expands_auth_env_placeholder_without_warning() {
     static_env!(Env, &[("MY_TOKEN", "secret")]);
 
-    let auth = NpmrcAuth::from_ini::<Env>(
-        "//registry.npmjs.org/:_authToken=${MY_TOKEN}\n",
-        Path::new(""),
-    );
+    let auth =
+        NpmrcAuth::from_ini::<Env>("//registry.npmjs.org/:_authToken=${MY_TOKEN}\n", Path::new(""));
 
     assert!(
         !auth.warnings.iter().any(|w| w.contains("Ignored project-level auth setting")),

--- a/pacquet/crates/config/src/tests.rs
+++ b/pacquet/crates/config/src/tests.rs
@@ -15,24 +15,36 @@ use std::{
 };
 use tempfile::tempdir;
 use tracing::Level;
-use tracing_subscriber::{layer::SubscriberExt, Layer};
+use tracing_subscriber::{Layer, layer::SubscriberExt};
 
 /// Capture all tracing WARN messages emitted during a closure.
 fn capture_warnings<F: FnOnce()>(f: F) -> Vec<String> {
     let messages: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-    let messages_clone = messages.clone();
+    let messages_clone = Arc::clone(&messages);
 
     struct CaptureLayer(Arc<Mutex<Vec<String>>>);
     impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
-        fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
             if *event.metadata().level() == Level::WARN {
                 struct Visitor(String);
                 impl tracing::field::Visit for Visitor {
                     fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-                        if field.name() == "message" { self.0 = value.to_string(); }
+                        if field.name() == "message" {
+                            self.0 = value.to_string();
+                        }
                     }
-                    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-                        if field.name() == "message" { self.0 = format!("{value:?}"); }
+                    fn record_debug(
+                        &mut self,
+                        field: &tracing::field::Field,
+                        value: &dyn std::fmt::Debug,
+                    ) {
+                        if field.name() == "message" {
+                            self.0 = format!("{value:?}");
+                        }
                     }
                 }
                 let mut v = Visitor(String::new());
@@ -2161,12 +2173,12 @@ pub fn npmrc_auth_file_pointing_at_project_npmrc_suppresses_warning() {
         ("PNPM_CONFIG_NPMRC_AUTH_FILE", project_npmrc.to_str().unwrap()),
     ]);
 
-    let warnings = capture_warnings(|| { load_with_fake_env(project.path()); });
+    let warnings = capture_warnings(|| {
+        load_with_fake_env(project.path());
+    });
 
-    let auth_warnings: Vec<_> = warnings
-        .iter()
-        .filter(|w| w.contains("Ignored project-level auth setting"))
-        .collect();
+    let auth_warnings: Vec<_> =
+        warnings.iter().filter(|w| w.contains("Ignored project-level auth setting")).collect();
     assert!(
         auth_warnings.is_empty(),
         "expected no auth warning when PNPM_CONFIG_NPMRC_AUTH_FILE points at project .npmrc, got: {auth_warnings:?}",

--- a/pacquet/crates/config/src/tests.rs
+++ b/pacquet/crates/config/src/tests.rs
@@ -18,16 +18,16 @@ use tracing::Level;
 use tracing_subscriber::{Layer, layer::SubscriberExt};
 
 /// Capture all tracing WARN messages emitted during a closure.
-fn capture_warnings<F: FnOnce()>(f: F) -> Vec<String> {
+fn capture_warnings<Func: FnOnce()>(f: Func) -> Vec<String> {
     let messages: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
     let messages_clone = Arc::clone(&messages);
 
     struct CaptureLayer(Arc<Mutex<Vec<String>>>);
-    impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
+    impl<Sub: tracing::Subscriber> Layer<Sub> for CaptureLayer {
         fn on_event(
             &self,
             event: &tracing::Event<'_>,
-            _ctx: tracing_subscriber::layer::Context<'_, S>,
+            _ctx: tracing_subscriber::layer::Context<'_, Sub>,
         ) {
             if *event.metadata().level() == Level::WARN {
                 struct Visitor(String);
@@ -47,9 +47,9 @@ fn capture_warnings<F: FnOnce()>(f: F) -> Vec<String> {
                         }
                     }
                 }
-                let mut v = Visitor(String::new());
-                event.record(&mut v);
-                self.0.lock().unwrap().push(v.0);
+                let mut visitor = Visitor(String::new());
+                event.record(&mut visitor);
+                self.0.lock().unwrap().push(visitor.0);
             }
         }
     }

--- a/pacquet/crates/config/src/tests.rs
+++ b/pacquet/crates/config/src/tests.rs
@@ -228,7 +228,7 @@ thread_local! {
 
 /// Reset both [`FakeEnv`] thread-locals to the given env and no fake
 /// cwd, so a test's setup never leaks into a later test sharing the
-/// worker thread. Every `FakeEnv` test starts here; the ones that
+/// worker thread. Every [`FakeEnv`] test starts here; the ones that
 /// need a fake cwd call [`set_fake_cwd`] afterwards.
 fn set_fake_env(pairs: &[(&str, &str)]) {
     FAKE_ENV.with(|map| {

--- a/pacquet/crates/config/src/tests.rs
+++ b/pacquet/crates/config/src/tests.rs
@@ -226,6 +226,10 @@ thread_local! {
         std::cell::RefCell::new(std::collections::HashMap::new());
 }
 
+/// Reset both [`FakeEnv`] thread-locals to the given env and no fake
+/// cwd, so a test's setup never leaks into a later test sharing the
+/// worker thread. Every `FakeEnv` test starts here; the ones that
+/// need a fake cwd call [`set_fake_cwd`] afterwards.
 fn set_fake_env(pairs: &[(&str, &str)]) {
     FAKE_ENV.with(|map| {
         let mut map = map.borrow_mut();
@@ -234,11 +238,13 @@ fn set_fake_env(pairs: &[(&str, &str)]) {
             map.insert((*key).to_string(), (*value).to_string());
         }
     });
+    FAKE_CWD.with(|cwd| *cwd.borrow_mut() = None);
 }
 
 thread_local! {
-    /// Per-thread fake cwd for [`FakeEnv`], set via [`set_fake_cwd`].
-    /// `None` (the default) falls through to the real process cwd.
+    /// Per-thread fake cwd for [`FakeEnv`], set via [`set_fake_cwd`]
+    /// and reset by [`set_fake_env`]. `None` (the default) falls
+    /// through to the real process cwd.
     static FAKE_CWD: std::cell::RefCell<Option<PathBuf>> =
         const { std::cell::RefCell::new(None) };
 }

--- a/pacquet/crates/config/src/tests.rs
+++ b/pacquet/crates/config/src/tests.rs
@@ -11,8 +11,41 @@ use std::{
     ffi::OsString,
     io,
     path::{Path, PathBuf},
+    sync::{Arc, Mutex},
 };
 use tempfile::tempdir;
+use tracing::Level;
+use tracing_subscriber::{layer::SubscriberExt, Layer};
+
+/// Capture all tracing WARN messages emitted during a closure.
+fn capture_warnings<F: FnOnce()>(f: F) -> Vec<String> {
+    let messages: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let messages_clone = messages.clone();
+
+    struct CaptureLayer(Arc<Mutex<Vec<String>>>);
+    impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+            if *event.metadata().level() == Level::WARN {
+                struct Visitor(String);
+                impl tracing::field::Visit for Visitor {
+                    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                        if field.name() == "message" { self.0 = value.to_string(); }
+                    }
+                    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                        if field.name() == "message" { self.0 = format!("{value:?}"); }
+                    }
+                }
+                let mut v = Visitor(String::new());
+                event.record(&mut v);
+                self.0.lock().unwrap().push(v.0);
+            }
+        }
+    }
+
+    let subscriber = tracing_subscriber::registry().with(CaptureLayer(messages_clone));
+    tracing::subscriber::with_default(subscriber, f);
+    Arc::try_unwrap(messages).unwrap().into_inner().unwrap()
+}
 
 /// `Config::current` requires `Sys: LinkProbe` so the late-stage
 /// `store_dir` resolver can probe linkability between project and
@@ -2111,5 +2144,31 @@ pub fn env_registry_override_appends_missing_trailing_slash() {
     assert_eq!(
         config.package_manager_bootstrap.registries.get("default").map(String::as_str),
         Some("https://env.example.com/"),
+    );
+}
+
+// Regression test for pnpm/pnpm#12480: when PNPM_CONFIG_NPMRC_AUTH_FILE points
+// at the project .npmrc, no "Ignored project-level auth setting" warning should fire.
+#[test]
+pub fn npmrc_auth_file_pointing_at_project_npmrc_suppresses_warning() {
+    let project = tempdir().expect("project tempdir");
+    let project_npmrc = project.path().join(".npmrc");
+    fs::write(&project_npmrc, "//registry.npmjs.org/:_authToken=${MY_TOKEN}\n")
+        .expect("write project .npmrc");
+
+    set_fake_env(&[
+        ("MY_TOKEN", "secret-token"),
+        ("PNPM_CONFIG_NPMRC_AUTH_FILE", project_npmrc.to_str().unwrap()),
+    ]);
+
+    let warnings = capture_warnings(|| { load_with_fake_env(project.path()); });
+
+    let auth_warnings: Vec<_> = warnings
+        .iter()
+        .filter(|w| w.contains("Ignored project-level auth setting"))
+        .collect();
+    assert!(
+        auth_warnings.is_empty(),
+        "expected no auth warning when PNPM_CONFIG_NPMRC_AUTH_FILE points at project .npmrc, got: {auth_warnings:?}",
     );
 }

--- a/pacquet/crates/config/src/tests.rs
+++ b/pacquet/crates/config/src/tests.rs
@@ -80,6 +80,19 @@ macro_rules! inert_link_probe {
     )+};
 }
 
+/// `Config::current` consults [`GetCurrentDir`] only to anchor a
+/// relative `npmrcAuthFile` value. `host_current_dir!(Name)` wires
+/// the real-cwd impl onto fakes whose tests never set one.
+macro_rules! host_current_dir {
+    ($($t:ty),+ $(,)?) => {$(
+        impl GetCurrentDir for $t {
+            fn current_dir() -> io::Result<PathBuf> {
+                std::env::current_dir()
+            }
+        }
+    )+};
+}
+
 fn display_store_dir(store_dir: &StoreDir) -> String {
     store_dir.display().to_string().replace('\\', "/")
 }
@@ -136,6 +149,7 @@ impl GetHomeDir for HostNoHome {
     }
 }
 inert_link_probe!(HostNoHome);
+host_current_dir!(HostNoHome);
 
 #[test]
 pub fn have_default_values() {
@@ -222,6 +236,17 @@ fn set_fake_env(pairs: &[(&str, &str)]) {
     });
 }
 
+thread_local! {
+    /// Per-thread fake cwd for [`FakeEnv`], set via [`set_fake_cwd`].
+    /// `None` (the default) falls through to the real process cwd.
+    static FAKE_CWD: std::cell::RefCell<Option<PathBuf>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+fn set_fake_cwd(dir: &Path) {
+    FAKE_CWD.with(|cwd| *cwd.borrow_mut() = Some(dir.to_path_buf()));
+}
+
 /// `Sys` fake whose env reads come from the thread-local
 /// [`FAKE_ENV`] (and nothing else), with no home dir. Isolates the
 /// `npmrcAuthFile` env-resolution from the developer's real shell.
@@ -242,6 +267,11 @@ impl EnvVarOs for FakeEnv {
 impl GetHomeDir for FakeEnv {
     fn home_dir() -> Option<PathBuf> {
         None
+    }
+}
+impl GetCurrentDir for FakeEnv {
+    fn current_dir() -> io::Result<PathBuf> {
+        FAKE_CWD.with(|cwd| cwd.borrow().clone()).map_or_else(std::env::current_dir, Ok)
     }
 }
 inert_link_probe!(FakeEnv);
@@ -1153,6 +1183,7 @@ pub fn npmrc_in_home_folder_applies_registry() {
         }
     }
     inert_link_probe!(HostWithHome);
+    host_current_dir!(HostWithHome);
     let config = Config::new()
         .current::<HostWithHome>(current_dir.path())
         .expect("workspace yaml absent => no error");
@@ -1225,6 +1256,7 @@ pub fn test_current_folder_fallback_to_default() {
         }
     }
     inert_link_probe!(HostWithHome);
+    host_current_dir!(HostWithHome);
     let config = Config { symlink: false, ..Config::new() }
         .current::<HostWithHome>(current_dir.path())
         .expect("workspace yaml absent => no error");
@@ -1439,6 +1471,7 @@ pub fn npm_config_workspace_dir_re_anchors_modules() {
         }
     }
     inert_link_probe!(HostWithEnvWorkspaceDir);
+    host_current_dir!(HostWithEnvWorkspaceDir);
 
     let config =
         Config::new().current::<HostWithEnvWorkspaceDir>(cwd_dir.path()).expect("config loads");
@@ -1483,6 +1516,7 @@ pub fn empty_npm_config_workspace_dir_falls_through() {
         }
     }
     inert_link_probe!(HostWithEmptyEnvWorkspaceDir);
+    host_current_dir!(HostWithEmptyEnvWorkspaceDir);
     let tmp = tempdir().unwrap();
     let config =
         Config::new().current::<HostWithEmptyEnvWorkspaceDir>(tmp.path()).expect("config loads");
@@ -1533,6 +1567,7 @@ pub fn global_config_yaml_enables_gvs() {
         }
     }
     inert_link_probe!(HostWithXdgConfigHome);
+    host_current_dir!(HostWithXdgConfigHome);
 
     let tmp = tempdir().unwrap();
     let config = Config::new().current::<HostWithXdgConfigHome>(tmp.path()).expect("config loads");
@@ -1577,6 +1612,7 @@ pub fn pnpm_workspace_yaml_overrides_global_config_yaml() {
         }
     }
     inert_link_probe!(HostWithXdgConfigHome);
+    host_current_dir!(HostWithXdgConfigHome);
 
     let config =
         Config::new().current::<HostWithXdgConfigHome>(project.path()).expect("config loads");
@@ -1634,6 +1670,7 @@ pub fn global_virtual_store_dir_survives_workspace_yaml_anchor() {
         }
     }
     inert_link_probe!(HostWithXdgConfigHome);
+    host_current_dir!(HostWithXdgConfigHome);
 
     let config =
         Config::new().current::<HostWithXdgConfigHome>(project.path()).expect("config loads");
@@ -1684,6 +1721,7 @@ pub fn global_config_yaml_workspace_only_keys_are_ignored() {
         }
     }
     inert_link_probe!(HostWithXdgConfigHome);
+    host_current_dir!(HostWithXdgConfigHome);
 
     let tmp = tempdir().unwrap();
     let defaults = Config::new();
@@ -1716,6 +1754,7 @@ pub fn pnpm_config_env_var_enables_gvs() {
         }
     }
     inert_link_probe!(HostWithPnpmConfigEnv);
+    host_current_dir!(HostWithPnpmConfigEnv);
 
     let tmp = tempdir().unwrap();
     let config = Config::new().current::<HostWithPnpmConfigEnv>(tmp.path()).expect("loads");
@@ -1744,6 +1783,7 @@ pub fn pnpm_config_env_var_lowercase_works() {
         }
     }
     inert_link_probe!(HostWithLowercaseEnv);
+    host_current_dir!(HostWithLowercaseEnv);
 
     let tmp = tempdir().unwrap();
     let config = Config::new().current::<HostWithLowercaseEnv>(tmp.path()).expect("loads");
@@ -1781,6 +1821,7 @@ pub fn pnpm_config_env_var_overrides_workspace_yaml() {
         }
     }
     inert_link_probe!(HostWithPnpmConfigEnv);
+    host_current_dir!(HostWithPnpmConfigEnv);
 
     let config = Config::new().current::<HostWithPnpmConfigEnv>(tmp.path()).expect("loads");
     assert!(
@@ -1811,6 +1852,7 @@ pub fn patches_dir_reads_from_env_overlay() {
         }
     }
     inert_link_probe!(HostWithPatchesDirEnv);
+    host_current_dir!(HostWithPatchesDirEnv);
 
     let tmp = tempdir().unwrap();
     let config = Config::new().current::<HostWithPatchesDirEnv>(tmp.path()).expect("loads");
@@ -1846,6 +1888,7 @@ pub fn pnpm_config_hoist_false_clears_hoist_pattern() {
         }
     }
     inert_link_probe!(HostWithHoistEnv);
+    host_current_dir!(HostWithHoistEnv);
 
     let tmp = tempdir().unwrap();
     let config = Config::new().current::<HostWithHoistEnv>(tmp.path()).expect("loads");
@@ -1899,6 +1942,7 @@ pub fn virtual_store_dir_max_length_env_var_overrides_yaml() {
         }
     }
     inert_link_probe!(HostWithEnvOverride);
+    host_current_dir!(HostWithEnvOverride);
 
     let config = Config::new().current::<HostWithEnvOverride>(tmp.path()).expect("loads");
     assert_eq!(
@@ -1943,6 +1987,7 @@ pub fn package_map_settings_load_from_env() {
         }
     }
     inert_link_probe!(HostWithPackageMapEnv);
+    host_current_dir!(HostWithPackageMapEnv);
 
     let tmp = tempdir().unwrap();
     let config = Config::new().current::<HostWithPackageMapEnv>(tmp.path()).expect("loads");
@@ -1992,6 +2037,7 @@ pub fn peers_suffix_max_length_env_var_overrides_yaml() {
         }
     }
     inert_link_probe!(HostWithEnvOverride);
+    host_current_dir!(HostWithEnvOverride);
 
     let config = Config::new().current::<HostWithEnvOverride>(tmp.path()).expect("loads");
     assert_eq!(config.peers_suffix_max_length, 25, "env var must win over pnpm-workspace.yaml");
@@ -2182,5 +2228,56 @@ pub fn npmrc_auth_file_pointing_at_project_npmrc_suppresses_warning() {
     assert!(
         auth_warnings.is_empty(),
         "expected no auth warning when PNPM_CONFIG_NPMRC_AUTH_FILE points at project .npmrc, got: {auth_warnings:?}",
+    );
+}
+
+// The exact shape reported in pnpm/pnpm#12480: a relative
+// `PNPM_CONFIG_NPMRC_AUTH_FILE=.npmrc`, anchored at the cwd.
+#[test]
+pub fn npmrc_auth_file_relative_to_cwd_pointing_at_project_npmrc_suppresses_warning() {
+    let project = tempdir().expect("project tempdir");
+    fs::write(project.path().join(".npmrc"), "//registry.npmjs.org/:_authToken=${MY_TOKEN}\n")
+        .expect("write project .npmrc");
+
+    set_fake_env(&[("MY_TOKEN", "secret-token"), ("PNPM_CONFIG_NPMRC_AUTH_FILE", ".npmrc")]);
+    set_fake_cwd(project.path());
+
+    let mut config = None;
+    let warnings = capture_warnings(|| {
+        config = Some(load_with_fake_env(project.path()));
+    });
+
+    let auth_warnings: Vec<_> =
+        warnings.iter().filter(|w| w.contains("Ignored project-level auth setting")).collect();
+    assert!(
+        auth_warnings.is_empty(),
+        "expected no auth warning for a relative npmrcAuthFile that resolves to the project .npmrc, got: {auth_warnings:?}",
+    );
+    assert_eq!(
+        config.unwrap().auth_headers.for_url("https://registry.npmjs.org/pkg").as_deref(),
+        Some("Bearer secret-token"),
+        "the trusted project .npmrc must expand the auth env placeholder",
+    );
+}
+
+// A relative npmrcAuthFile that resolves somewhere other than the project
+// .npmrc must not trust it — the warning stays.
+#[test]
+pub fn npmrc_auth_file_relative_resolving_elsewhere_keeps_warning() {
+    let project = tempdir().expect("project tempdir");
+    let elsewhere = tempdir().expect("elsewhere tempdir");
+    fs::write(project.path().join(".npmrc"), "//registry.npmjs.org/:_authToken=${MY_TOKEN}\n")
+        .expect("write project .npmrc");
+
+    set_fake_env(&[("MY_TOKEN", "secret-token"), ("PNPM_CONFIG_NPMRC_AUTH_FILE", ".npmrc")]);
+    set_fake_cwd(elsewhere.path());
+
+    let warnings = capture_warnings(|| {
+        load_with_fake_env(project.path());
+    });
+
+    assert!(
+        warnings.iter().any(|w| w.contains("Ignored project-level auth setting")),
+        "expected the auth warning when the relative npmrcAuthFile does not resolve to the project .npmrc, got: {warnings:?}",
     );
 }

--- a/pnpm11/config/reader/src/loadNpmrcFiles.ts
+++ b/pnpm11/config/reader/src/loadNpmrcFiles.ts
@@ -89,11 +89,18 @@ export function loadNpmrcConfig (opts: LoadNpmrcConfigOpts): NpmrcConfigResult {
 
   // Read .npmrc from workspace root (or project root if no workspace)
   const workspaceNpmrcDir = opts.workspaceDir ?? localPrefix
+  const workspaceNpmrcPath = path.resolve(workspaceNpmrcDir, '.npmrc')
+  // When npmrcAuthFile explicitly points at the project .npmrc, the user has
+  // opted in to trusting it — allow auth env expansion and suppress the warning.
+  const workspaceIsTrustedAuthFile = userConfigPath === workspaceNpmrcPath
   const workspaceNpmrc = readAndFilterNpmrc(
-    path.resolve(workspaceNpmrcDir, '.npmrc'),
+    workspaceNpmrcPath,
     warnings,
     env,
-    { expandAuthValueEnv: false, expandRequestDestinationEnv: false }
+    {
+      expandAuthValueEnv: workspaceIsTrustedAuthFile,
+      expandRequestDestinationEnv: workspaceIsTrustedAuthFile,
+    }
   )
 
   // Read user .npmrc (from npmrcAuthFile setting or ~/.npmrc)

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -3845,17 +3845,29 @@ test('ci disables enableGlobalVirtualStore by default', async () => {
     ci: true,
   })
 
-  const { config } = await getConfig({
-    cliOptions: {},
-    env,
-    packageManager: {
-      name: 'pnpm',
-      version: '1.0.0',
-    },
-    workspaceDir: process.cwd(),
-  })
+  // Point the global config dir at an empty location so the developer's
+  // real config.yaml (which may set enableGlobalVirtualStore) can't leak in.
+  const originalXdg = process.env.XDG_CONFIG_HOME
+  process.env.XDG_CONFIG_HOME = path.resolve('xdg-config')
+  try {
+    const { config } = await getConfig({
+      cliOptions: {},
+      env,
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+      workspaceDir: process.cwd(),
+    })
 
-  expect(config.enableGlobalVirtualStore).toBe(false)
+    expect(config.enableGlobalVirtualStore).toBe(false)
+  } finally {
+    if (originalXdg != null) {
+      process.env.XDG_CONFIG_HOME = originalXdg
+    } else {
+      delete process.env.XDG_CONFIG_HOME
+    }
+  }
 })
 
 test('ci respects explicit enableGlobalVirtualStore from config', async () => {
@@ -4025,4 +4037,30 @@ test('no warning when PNPM_CONFIG_NPMRC_AUTH_FILE points at the project .npmrc',
   // the user explicitly opted in by setting PNPM_CONFIG_NPMRC_AUTH_FILE.
   const authWarnings = warnings.filter((w) => w.includes('Ignored project-level auth setting'))
   expect(authWarnings).toHaveLength(0)
+})
+
+test('no warning when PNPM_CONFIG_NPMRC_AUTH_FILE is the literal relative ".npmrc"', async () => {
+  prepare()
+
+  fs.writeFileSync('.npmrc', '//registry.npmjs.org/:_authToken=${MY_TOKEN}\n', 'utf8')
+
+  const { config, warnings } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      MY_TOKEN: 'secret',
+      // The exact shape reported in pnpm/pnpm#12480 — a relative path,
+      // resolved against the cwd, that lands on the project .npmrc.
+      PNPM_CONFIG_NPMRC_AUTH_FILE: '.npmrc',
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+
+  const authWarnings = warnings.filter((w) => w.includes('Ignored project-level auth setting'))
+  expect(authWarnings).toHaveLength(0)
+  // The trusted project .npmrc must expand the auth env placeholder.
+  expect(config.authConfig['//registry.npmjs.org/:_authToken']).toBe('secret')
 })

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -3997,3 +3997,32 @@ test('GVS: global config.yaml dangerouslyAllowAllBuilds is preserved when no wor
     }
   }
 })
+
+test('no warning when PNPM_CONFIG_NPMRC_AUTH_FILE points at the project .npmrc', async () => {
+  prepare()
+
+  // Write an auth token using an env var into the project .npmrc.
+  fs.writeFileSync('.npmrc', '//registry.npmjs.org/:_authToken=${MY_TOKEN}\n', 'utf8')
+
+  // Resolve the absolute path that pnpm will derive for the workspace .npmrc.
+  const projectNpmrc = path.resolve('.npmrc')
+
+  const { warnings } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      MY_TOKEN: 'secret',
+      // Trust this file explicitly — same path as the project .npmrc.
+      PNPM_CONFIG_NPMRC_AUTH_FILE: projectNpmrc,
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+
+  // No "Ignored project-level auth setting" warning should appear because
+  // the user explicitly opted in by setting PNPM_CONFIG_NPMRC_AUTH_FILE.
+  const authWarnings = warnings.filter((w) => w.includes('Ignored project-level auth setting'))
+  expect(authWarnings).toHaveLength(0)
+})

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -4064,3 +4064,41 @@ test('no warning when PNPM_CONFIG_NPMRC_AUTH_FILE is the literal relative ".npmr
   // The trusted project .npmrc must expand the auth env placeholder.
   expect(config.authConfig['//registry.npmjs.org/:_authToken']).toBe('secret')
 })
+
+test('warning stays when PNPM_CONFIG_NPMRC_AUTH_FILE is a relative path that does not resolve to the project .npmrc', async () => {
+  prepare()
+
+  fs.writeFileSync('.npmrc', '//registry.npmjs.org/:_authToken=${MY_TOKEN}\n', 'utf8')
+
+  // Point the global config dir at an empty location so the developer's
+  // real auth.ini can't leak a token into authConfig.
+  const originalXdg = process.env.XDG_CONFIG_HOME
+  process.env.XDG_CONFIG_HOME = path.resolve('xdg-config')
+  try {
+    const { config, warnings } = await getConfig({
+      cliOptions: {},
+      env: {
+        ...env,
+        MY_TOKEN: 'secret',
+        // Resolves to <cwd>/other/.npmrc — not the project .npmrc, so the
+        // project file stays untrusted.
+        PNPM_CONFIG_NPMRC_AUTH_FILE: 'other/.npmrc',
+      },
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+    })
+
+    expect(warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining('Ignored project-level auth setting "//registry.npmjs.org/:_authToken"'),
+    ]))
+    expect(config.authConfig['//registry.npmjs.org/:_authToken']).toBeUndefined()
+  } finally {
+    if (originalXdg != null) {
+      process.env.XDG_CONFIG_HOME = originalXdg
+    } else {
+      delete process.env.XDG_CONFIG_HOME
+    }
+  }
+})


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

When `PNPM_CONFIG_NPMRC_AUTH_FILE` is set to the project `.npmrc`, pnpm still fires the "Ignored project-level auth setting" warning even though the user explicitly opted in to trusting that file. The point of `PNPM_CONFIG_NPMRC_AUTH_FILE` is to declare trust — the warning is wrong in this case.

Closes pnpm/pnpm#12480

## Squash Commit Body

When npmrcAuthFile resolves to the same path as the project .npmrc, the user
has explicitly opted in to trusting that file for auth. Before this fix, the
warning was unconditionally fired for any auth env var in the project .npmrc,
even when PNPM_CONFIG_NPMRC_AUTH_FILE pointed at it.

Fix: compare the resolved npmrcAuthFile path against the workspace .npmrc path.
If they match, allow env var expansion and skip the warning.

Closes pnpm/pnpm#12480

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed the “ignored project-level auth setting” warning when the project’s `.npmrc` is explicitly used as the auth source (via `PNPM_CONFIG_NPMRC_AUTH_FILE`), including relative-path scenarios.
  * Improved `.npmrc` env placeholder handling for `_authToken`, expanding values only for trusted auth sources and avoiding incorrect “project-level” treatment.
  * Updated workspace `.npmrc` processing so env placeholder expansion behavior matches whether the project `.npmrc` was explicitly selected.
* **Tests**
  * Added regression tests covering warning suppression and `_authToken` placeholder expansion.
* **Documentation**
  * Refined configuration comments around cwd-based resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->