### PR TITLE
feat(pacquet): route preResolution hook info/warn logging to pnpm:hook channel

### DIFF
--- a/pacquet/crates/default-reporter/src/state.rs
+++ b/pacquet/crates/default-reporter/src/state.rs
@@ -7,7 +7,7 @@
 use std::{collections::HashMap, fmt::Write as _};
 
 use pacquet_reporter::{
-    AddedRoot, ContextLog, DependencyType, ExecutionTimeLog, FetchingProgressMessage,
+    AddedRoot, ContextLog, DependencyType, ExecutionTimeLog, FetchingProgressMessage, HookLog,
     IgnoredScriptsLog, InstallingConfigDepsLog, InstallingConfigDepsStatus, LifecycleMessage,
     LifecycleStdio, LockfileVerificationMessage, LogEvent, LogLevel, PackageImportMethod,
     PackageManifestMessage, ProgressMessage, RemovedRoot, RequestRetryLog, SkippedOptionalPackage,
@@ -318,8 +318,9 @@ impl ReporterState {
             // empty-prefix path in `on_pnpm`).
             LogEvent::Global(log) => self.on_pnpm(log.level, &log.message, ""),
             LogEvent::ExecutionTime(log) => self.on_execution_time(log),
+            LogEvent::Hook(log) => self.on_hook(log),
             // Debug-only / non-rendered channels in pnpm's default reporter.
-            LogEvent::Hook(_) | LogEvent::BrokenModules(_) => {}
+            LogEvent::BrokenModules(_) => {}
         }
         self.finish()
     }
@@ -964,6 +965,19 @@ impl ReporterState {
         let mut slot = std::mem::take(&mut self.exec_slot);
         self.frame.emit(&mut slot, msg, true);
         self.exec_slot = slot;
+    }
+
+    /// Renders a `pnpm:hook` event as `hook: message`, matching pnpm's
+    /// `reportHooks.ts` format. When the hook's `prefix` differs from
+    /// `self.cwd` the message is zoomed out with the prefix.
+    fn on_hook(&mut self, log: &HookLog) {
+        let msg = format!("{}: {}", self.colors.magenta_bright(&log.hook), log.message);
+        if log.prefix.is_empty() || log.prefix == self.cwd {
+            self.push_block(msg);
+        } else {
+            let zoomed = zoom_out(&self.cwd, &log.prefix, &msg);
+            self.push_block(zoomed);
+        }
     }
 
     /// A warning, honoring pnpm's "only show the first

--- a/pacquet/crates/default-reporter/tests/render.rs
+++ b/pacquet/crates/default-reporter/tests/render.rs
@@ -8,7 +8,7 @@ use pacquet_default_reporter::{
     state::{Output, ReporterState},
 };
 use pacquet_reporter::{
-    AddedRoot, ContextLog, DependencyType, ExecutionTimeLog, GlobalLog, LifecycleLog,
+    AddedRoot, ContextLog, DependencyType, ExecutionTimeLog, GlobalLog, HookLog, LifecycleLog,
     LifecycleMessage, LifecycleStdio, LogEvent, LogLevel, PackageImportMethod,
     PackageImportMethodLog, PnpmLog, ProgressLog, ProgressMessage, RootLog, RootMessage, Stage,
     StageLog, StatsLog, StatsMessage, SummaryLog,
@@ -329,4 +329,20 @@ fn lifecycle_script_output_is_grouped_and_indented() {
     ];
     let frame = render(&mut reporter, events);
     assert_eq!(frame, "deps/foo postinstall$ node build.js\n│ building\n└─ Running...");
+}
+
+#[test]
+fn hook_log_renders_with_magenta_hook_name() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![LogEvent::Hook(HookLog {
+            level: LogLevel::Info,
+            from: "pnpmfile".to_string(),
+            hook: "preResolution".to_string(),
+            message: "Starting resolution".to_string(),
+            prefix: CWD.to_string(),
+        })],
+    );
+    assert_eq!(frame, "preResolution: Starting resolution");
 }

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -182,7 +182,9 @@ async fn forward_hook_stdout(
 async fn read_tail(stream: impl AsyncRead + Unpin, cap: usize) -> Vec<u8> {
     let mut stream = stream;
     let mut tail = Vec::new();
-    let mut buf = [0u8; 8192];
+    // Heap-allocated so the read buffer doesn't bloat the future
+    // (`clippy::large_futures`).
+    let mut buf = vec![0u8; 8192];
     loop {
         match stream.read(&mut buf).await {
             Ok(0) | Err(_) => break,

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -90,6 +90,8 @@ await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
             .arg(&wrapper)
             .kill_on_drop(true)
             .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
             .spawn()
         else {
             (logger.warn)("pnpmfile hook failed to start".to_string());
@@ -107,6 +109,28 @@ await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
             (logger.warn)("pnpmfile hook timed out or failed to execute".to_string());
             return;
         };
+
+        // Forward each JSON line from the JS info/warn logger calls to the
+        // Rust-side closures, which emit them as `pnpm:hook` events. The JS
+        // wrapper writes `{"level":"info","message":"..."}` or
+        // `{"level":"warn","message":"..."}` to stdout; everything else is
+        // silently ignored (it may be debug output from Node.js internals).
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(line) {
+                let level = parsed.get("level").and_then(|v| v.as_str());
+                let message =
+                    parsed.get("message").and_then(|v| v.as_str()).unwrap_or_default().to_string();
+                match level {
+                    Some("info") => (logger.info)(message),
+                    Some("warn") => (logger.warn)(message),
+                    _ => {}
+                }
+            }
+        }
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 use std::{path::PathBuf, sync::Arc};
 use tokio::{
-    io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader},
+    io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader},
     process::Command,
     sync::OnceCell,
     time::{Duration, timeout},
@@ -143,38 +143,93 @@ await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
 /// exits non-zero.
 const STDERR_TAIL_LIMIT: usize = 64 * 1024;
 
+/// Longest hook stdout line kept; the remainder of an over-long line is
+/// discarded so hook-controlled output cannot grow memory without bound.
+const STDOUT_LINE_LIMIT: usize = 64 * 1024;
+
 /// Forwards each of the one-shot hook's stdout lines to the Rust-side logger
-/// closures as it arrives, which emit them as `pnpm:hook` events. The JS
-/// wrapper writes `{"level":"info","message":String(...)}` or
-/// `{"level":"warn","message":String(...)}` lines. Non-JSON lines (e.g. a
-/// hook's own `console.log`) are forwarded as info so they are not silently
-/// lost.
+/// closures as it arrives, which emit them as `pnpm:hook` events. Lines the
+/// JS wrapper's logger writes carry their level; everything else the hook
+/// prints (e.g. its own `console.log`) is forwarded as info so it is not
+/// silently lost.
 async fn forward_hook_stdout(
     stdout: tokio::process::ChildStdout,
     logger: &crate::PreResolutionHookLogger,
 ) {
-    let mut lines = BufReader::new(stdout).lines();
-    while let Ok(Some(line)) = lines.next_line().await {
+    let mut reader = BufReader::new(stdout);
+    while let Ok(Some(line)) = next_line_bounded(&mut reader, STDOUT_LINE_LIMIT).await {
         let line = line.trim();
         if line.is_empty() {
             continue;
         }
-        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(line) {
-            let level = parsed.get("level").and_then(|v| v.as_str());
-            let message = match parsed.get("message") {
-                Some(v) if v.is_string() => v.as_str().unwrap().to_string(),
-                Some(v) => v.to_string(),
-                None => continue,
-            };
-            match level {
-                Some("info") => (logger.info)(message),
-                Some("warn") => (logger.warn)(message),
-                _ => {}
-            }
-        } else {
-            (logger.info)(line.to_string());
+        match parse_logger_line(line) {
+            Some((LoggerLevel::Info, message)) => (logger.info)(message),
+            Some((LoggerLevel::Warn, message)) => (logger.warn)(message),
+            None => (logger.info)(line.to_string()),
         }
     }
+}
+
+enum LoggerLevel {
+    Info,
+    Warn,
+}
+
+/// Parses one line of the JS wrapper's logger protocol,
+/// `{"level":"info"|"warn","message":...}`. Anything else — non-JSON, or
+/// JSON the hook printed itself — returns `None` so the caller forwards it
+/// verbatim.
+fn parse_logger_line(line: &str) -> Option<(LoggerLevel, String)> {
+    if !line.starts_with('{') {
+        return None;
+    }
+    let parsed = serde_json::from_str::<serde_json::Value>(line).ok()?;
+    let level = match parsed.get("level").and_then(|v| v.as_str()) {
+        Some("info") => LoggerLevel::Info,
+        Some("warn") => LoggerLevel::Warn,
+        _ => return None,
+    };
+    let message = match parsed.get("message")? {
+        v if v.is_string() => v.as_str().unwrap().to_string(),
+        v => v.to_string(),
+    };
+    Some((level, message))
+}
+
+/// Reads one `\n`-terminated line, keeping at most `cap` bytes of it and
+/// discarding the rest, and decodes it lossily. Unlike
+/// [`AsyncBufReadExt::read_line`] this neither buffers an unbounded line nor
+/// stops on invalid UTF-8 — the pipe must keep draining either way, or the
+/// child blocks on a full pipe until the hook timeout. Returns `None` at EOF.
+async fn next_line_bounded(
+    reader: &mut (impl AsyncBufRead + Unpin),
+    cap: usize,
+) -> std::io::Result<Option<String>> {
+    let mut line = Vec::new();
+    loop {
+        let (consumed, line_complete) = {
+            let available = reader.fill_buf().await?;
+            if available.is_empty() {
+                return Ok(if line.is_empty() { None } else { Some(lossy_string(&line)) });
+            }
+            let newline = available.iter().position(|&byte| byte == b'\n');
+            let visible = newline.unwrap_or(available.len());
+            let keep = visible.min(cap.saturating_sub(line.len()));
+            line.extend_from_slice(&available[..keep]);
+            match newline {
+                Some(pos) => (pos + 1, true),
+                None => (available.len(), false),
+            }
+        };
+        reader.consume(consumed);
+        if line_complete {
+            return Ok(Some(lossy_string(&line)));
+        }
+    }
+}
+
+fn lossy_string(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
 }
 
 /// Reads `stream` to EOF keeping only the final `cap` bytes, so a
@@ -190,12 +245,15 @@ async fn read_tail(stream: impl AsyncRead + Unpin, cap: usize) -> Vec<u8> {
             Ok(0) | Err(_) => break,
             Ok(n) => {
                 tail.extend_from_slice(&buf[..n]);
-                if tail.len() > cap {
+                // Trim only past twice the cap so noisy output memmoves the
+                // tail once per `cap` bytes, not once per read.
+                if tail.len() > cap * 2 {
                     tail.drain(..tail.len() - cap);
                 }
             }
         }
     }
+    tail.drain(..tail.len().saturating_sub(cap));
     tail
 }
 
@@ -346,3 +404,6 @@ impl crate::CustomResolver for NodeJsCustomResolver {
         Ok(res.as_bool().unwrap_or(false))
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -117,13 +117,12 @@ await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
             }
             // Dropping stdin closes the pipe so `readFileSync(0)` sees EOF.
         };
+        let forward_stdout = forward_hook_stdout(stdout, logger);
+        let collect_stderr = read_tail(stderr, STDERR_TAIL_LIMIT);
+        let wait_child = child.wait();
         let hook_result = timeout(HOOK_TIMEOUT, async {
-            let ((), (), stderr_tail, status) = tokio::join!(
-                write_context,
-                forward_hook_stdout(stdout, logger),
-                read_tail(stderr, STDERR_TAIL_LIMIT),
-                child.wait(),
-            );
+            let ((), (), stderr_tail, status) =
+                tokio::join!(write_context, forward_stdout, collect_stderr, wait_child);
             (stderr_tail, status)
         })
         .await;

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 use std::{path::PathBuf, sync::Arc};
 use tokio::{
-    io::AsyncWriteExt,
+    io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader},
     process::Command,
     sync::OnceCell,
     time::{Duration, timeout},
@@ -98,51 +98,104 @@ await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
             return;
         };
 
-        if let Some(mut stdin) = child.stdin.take()
-            && stdin.write_all(ctx_payload.as_bytes()).await.is_err()
-        {
-            let _ = child.kill().await;
-            return;
-        }
+        let stdin = child.stdin.take();
+        let stdout = child.stdout.take().expect("stdout is piped");
+        let stderr = child.stderr.take().expect("stderr is piped");
 
-        let Ok(Ok(output)) = timeout(HOOK_TIMEOUT, child.wait_with_output()).await else {
+        // Stream all three pipes concurrently instead of buffering:
+        // stdout/stderr are hook-controlled, so buffering would let a noisy
+        // pnpmfile grow memory without bound, and log messages should surface
+        // while the hook is still running (pnpm runs the hook in-process, so
+        // its logger calls render immediately). The context write runs in the
+        // same join because a pnpmfile that logs heavily at import time could
+        // otherwise fill the stdout pipe and deadlock against the stdin
+        // write. A write error is left for `child.wait()` to surface as a
+        // non-zero exit.
+        let write_context = async {
+            if let Some(mut stdin) = stdin {
+                let _ = stdin.write_all(ctx_payload.as_bytes()).await;
+            }
+            // Dropping stdin closes the pipe so `readFileSync(0)` sees EOF.
+        };
+        let hook_result = timeout(HOOK_TIMEOUT, async {
+            let ((), (), stderr_tail, status) = tokio::join!(
+                write_context,
+                forward_hook_stdout(stdout, logger),
+                read_tail(stderr, STDERR_TAIL_LIMIT),
+                child.wait(),
+            );
+            (stderr_tail, status)
+        })
+        .await;
+
+        let Ok((stderr_tail, Ok(status))) = hook_result else {
             (logger.warn)("pnpmfile hook timed out or failed to execute".to_string());
             return;
         };
 
-        // Forward each JSON line from the JS info/warn logger calls to the Rust-
-        // side closures, which emit them as `pnpm:hook` events. The JS wrapper
-        // writes `{"level":"info","message":String(...)}` or
-        // `{"level":"warn","message":String(...)}` to stdout. Non-JSON lines
-        // (e.g. Node.js debug output) are forwarded as info so they are not
-        // silently lost.
-        for line in String::from_utf8_lossy(&output.stdout).lines() {
-            let line = line.trim();
-            if line.is_empty() {
-                continue;
-            }
-            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(line) {
-                let level = parsed.get("level").and_then(|v| v.as_str());
-                let message = match parsed.get("message") {
-                    Some(v) if v.is_string() => v.as_str().unwrap().to_string(),
-                    Some(v) => v.to_string(),
-                    None => continue,
-                };
-                match level {
-                    Some("info") => (logger.info)(message),
-                    Some("warn") => (logger.warn)(message),
-                    _ => {}
-                }
-            } else {
-                (logger.info)(line.to_string());
-            }
-        }
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
+        if !status.success() {
+            let stderr = String::from_utf8_lossy(&stderr_tail);
             (logger.warn)(format!("pnpmfile hook failed: {stderr}"));
         }
     }
+}
+
+/// How much trailing stderr to keep for the failure message when the hook
+/// exits non-zero.
+const STDERR_TAIL_LIMIT: usize = 64 * 1024;
+
+/// Forwards each of the one-shot hook's stdout lines to the Rust-side logger
+/// closures as it arrives, which emit them as `pnpm:hook` events. The JS
+/// wrapper writes `{"level":"info","message":String(...)}` or
+/// `{"level":"warn","message":String(...)}` lines. Non-JSON lines (e.g. a
+/// hook's own `console.log`) are forwarded as info so they are not silently
+/// lost.
+async fn forward_hook_stdout(
+    stdout: tokio::process::ChildStdout,
+    logger: &crate::PreResolutionHookLogger,
+) {
+    let mut lines = BufReader::new(stdout).lines();
+    while let Ok(Some(line)) = lines.next_line().await {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(line) {
+            let level = parsed.get("level").and_then(|v| v.as_str());
+            let message = match parsed.get("message") {
+                Some(v) if v.is_string() => v.as_str().unwrap().to_string(),
+                Some(v) => v.to_string(),
+                None => continue,
+            };
+            match level {
+                Some("info") => (logger.info)(message),
+                Some("warn") => (logger.warn)(message),
+                _ => {}
+            }
+        } else {
+            (logger.info)(line.to_string());
+        }
+    }
+}
+
+/// Reads `stream` to EOF keeping only the final `cap` bytes, so a
+/// hook-controlled pipe cannot grow the buffer without bound.
+async fn read_tail(stream: impl AsyncRead + Unpin, cap: usize) -> Vec<u8> {
+    let mut stream = stream;
+    let mut tail = Vec::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        match stream.read(&mut buf).await {
+            Ok(0) | Err(_) => break,
+            Ok(n) => {
+                tail.extend_from_slice(&buf[..n]);
+                if tail.len() > cap {
+                    tail.drain(..tail.len() - cap);
+                }
+            }
+        }
+    }
+    tail
 }
 
 #[async_trait]

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -58,8 +58,8 @@ impl NodeJsHooks {
 const hooks = await import({file_path_escaped});
 const ctx = JSON.parse(readFileSync(0, 'utf8'));
 const logger = {{
-  info: (m) => {{ console.log(JSON.stringify({{"level":"info","message":m}})); }},
-  warn: (m) => {{ console.log(JSON.stringify({{"level":"warn","message":m}})); }}
+  info: (m) => {{ console.log(JSON.stringify({{"level":"info","message":String(m)}})); }},
+  warn: (m) => {{ console.log(JSON.stringify({{"level":"warn","message":String(m)}})); }}
 }};
 await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
 "#,
@@ -73,8 +73,8 @@ await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
   const hooks = require({file_path_escaped});
   const ctx = JSON.parse(require('fs').readFileSync(0, 'utf8'));
   const logger = {{
-    info: (m) => {{ console.log(JSON.stringify({{"level":"info","message":m}})); }},
-    warn: (m) => {{ console.log(JSON.stringify({{"level":"warn","message":m}})); }}
+    info: (m) => {{ console.log(JSON.stringify({{"level":"info","message":String(m)}})); }},
+    warn: (m) => {{ console.log(JSON.stringify({{"level":"warn","message":String(m)}})); }}
   }};
   await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
 }})();
@@ -110,11 +110,12 @@ await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
             return;
         };
 
-        // Forward each JSON line from the JS info/warn logger calls to the
-        // Rust-side closures, which emit them as `pnpm:hook` events. The JS
-        // wrapper writes `{"level":"info","message":"..."}` or
-        // `{"level":"warn","message":"..."}` to stdout; everything else is
-        // silently ignored (it may be debug output from Node.js internals).
+        // Forward each JSON line from the JS info/warn logger calls to the Rust-
+        // side closures, which emit them as `pnpm:hook` events. The JS wrapper
+        // writes `{"level":"info","message":String(...)}` or
+        // `{"level":"warn","message":String(...)}` to stdout. Non-JSON lines
+        // (e.g. Node.js debug output) are forwarded as info so they are not
+        // silently lost.
         for line in String::from_utf8_lossy(&output.stdout).lines() {
             let line = line.trim();
             if line.is_empty() {
@@ -122,13 +123,18 @@ await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
             }
             if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(line) {
                 let level = parsed.get("level").and_then(|v| v.as_str());
-                let message =
-                    parsed.get("message").and_then(|v| v.as_str()).unwrap_or_default().to_string();
+                let message = match parsed.get("message") {
+                    Some(v) if v.is_string() => v.as_str().unwrap().to_string(),
+                    Some(v) => v.to_string(),
+                    None => continue,
+                };
                 match level {
                     Some("info") => (logger.info)(message),
                     Some("warn") => (logger.warn)(message),
                     _ => {}
                 }
+            } else {
+                (logger.info)(line.to_string());
             }
         }
 

--- a/pacquet/crates/hooks/src/node_runtime/tests.rs
+++ b/pacquet/crates/hooks/src/node_runtime/tests.rs
@@ -1,0 +1,43 @@
+use super::{LoggerLevel, next_line_bounded, parse_logger_line};
+use tokio::io::BufReader;
+
+#[tokio::test]
+async fn next_line_bounded_truncates_long_lines_and_keeps_draining() {
+    let long = "x".repeat(100);
+    let input = format!("{long}\nafter\n");
+    let mut reader = BufReader::new(input.as_bytes());
+    assert_eq!(next_line_bounded(&mut reader, 10).await.unwrap().unwrap(), "x".repeat(10));
+    assert_eq!(next_line_bounded(&mut reader, 10).await.unwrap().unwrap(), "after");
+    assert_eq!(next_line_bounded(&mut reader, 10).await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn next_line_bounded_survives_invalid_utf8() {
+    let mut reader = BufReader::new(&b"bad\xffbyte\nnext\n"[..]);
+    assert_eq!(next_line_bounded(&mut reader, 64).await.unwrap().unwrap(), "bad\u{fffd}byte");
+    assert_eq!(next_line_bounded(&mut reader, 64).await.unwrap().unwrap(), "next");
+}
+
+#[tokio::test]
+async fn next_line_bounded_returns_final_unterminated_line() {
+    let mut reader = BufReader::new(&b"no newline"[..]);
+    assert_eq!(next_line_bounded(&mut reader, 64).await.unwrap().unwrap(), "no newline");
+    assert_eq!(next_line_bounded(&mut reader, 64).await.unwrap(), None);
+}
+
+#[test]
+fn parse_logger_line_accepts_only_the_wrapper_protocol() {
+    let (level, message) = parse_logger_line(r#"{"level":"info","message":"hi"}"#).unwrap();
+    assert!(matches!(level, LoggerLevel::Info));
+    assert_eq!(message, "hi");
+
+    let (level, message) = parse_logger_line(r#"{"level":"warn","message":42}"#).unwrap();
+    assert!(matches!(level, LoggerLevel::Warn));
+    assert_eq!(message, "42");
+
+    // Hook-printed JSON and plain text fall through to raw forwarding.
+    assert!(parse_logger_line(r#"{"foo":"bar"}"#).is_none());
+    assert!(parse_logger_line(r#"{"level":"debug","message":"hi"}"#).is_none());
+    assert!(parse_logger_line(r#"{"level":"info"}"#).is_none());
+    assert!(parse_logger_line("plain text").is_none());
+}

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -8109,7 +8109,7 @@ async fn pre_resolution_hook_log_is_forwarded_to_pnpm_hook_channel() {
     assert_eq!(info_log.hook, "preResolution");
     assert_eq!(info_log.message, "Starting resolution");
     assert_eq!(info_log.from, "pnpmfile", "preResolution from is hardcoded to 'pnpmfile'");
-    assert!(!info_log.prefix.is_empty(), "prefix must be the project dir");
+    assert_eq!(info_log.prefix, *dir.path().to_string_lossy(), "prefix must be the lockfile dir");
 
     // Find the warn event
     let warn_log = captured
@@ -8124,7 +8124,7 @@ async fn pre_resolution_hook_log_is_forwarded_to_pnpm_hook_channel() {
     assert_eq!(warn_log.hook, "preResolution");
     assert_eq!(warn_log.message, "Some packages may need updates");
     assert_eq!(warn_log.from, "pnpmfile", "preResolution from is hardcoded to 'pnpmfile'");
-    assert!(!warn_log.prefix.is_empty(), "prefix must be the project dir");
+    assert_eq!(warn_log.prefix, *dir.path().to_string_lossy(), "prefix must be the lockfile dir");
 
     drop((dir, registry));
 }

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -8066,7 +8066,9 @@ async fn async_after_all_resolved_hook_log_is_forwarded_to_pnpm_hook_channel() {
 // hook's `logger.info(...)` and `logger.warn(...)` surface on the
 // `pnpm:hook` channel with `from: "pnpmfile"`, `hook: "preResolution"`,
 // and the matching log level. Mirrors the TypeScript
-// `createPreResolutionHookLogger` which emits at `info`/`warn`.
+// `createPreResolutionHookLogger` which emits at `info`/`warn`. A raw
+// `console.log(...)` line from the hook (not wrapped in the JSON logger
+// protocol) is forwarded at `info` rather than silently dropped.
 #[tokio::test]
 async fn pre_resolution_hook_log_is_forwarded_to_pnpm_hook_channel() {
     static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
@@ -8089,42 +8091,39 @@ async fn pre_resolution_hook_log_is_forwarded_to_pnpm_hook_channel() {
         r"module.exports = { hooks: { preResolution (ctx, logger) {
   logger.info('Starting resolution');
   logger.warn('Some packages may need updates');
+  console.log('raw hook output');
 } } }",
     )
     .await
     .expect("install should succeed");
 
     let captured = EVENTS.lock().unwrap();
+    let find_hook_event = |level: LogLevel, message: &str| {
+        captured
+            .iter()
+            .find_map(|event| match event {
+                LogEvent::Hook(log)
+                    if log.hook == "preResolution"
+                        && log.level == level
+                        && log.message == message =>
+                {
+                    Some(log)
+                }
+                _ => None,
+            })
+            .unwrap_or_else(|| {
+                panic!("a pnpm:hook {level:?} event with message {message:?} must be emitted")
+            })
+    };
 
-    // Find the info event
-    let info_log = captured
-        .iter()
-        .find_map(|event| match event {
-            LogEvent::Hook(log) if log.hook == "preResolution" && log.level == LogLevel::Info => {
-                Some(log)
-            }
-            _ => None,
-        })
-        .expect("a pnpm:hook info event must be emitted for preResolution");
-    assert_eq!(info_log.hook, "preResolution");
-    assert_eq!(info_log.message, "Starting resolution");
-    assert_eq!(info_log.from, "pnpmfile", "preResolution from is hardcoded to 'pnpmfile'");
-    assert_eq!(info_log.prefix, *dir.path().to_string_lossy(), "prefix must be the lockfile dir");
-
-    // Find the warn event
-    let warn_log = captured
-        .iter()
-        .find_map(|event| match event {
-            LogEvent::Hook(log) if log.hook == "preResolution" && log.level == LogLevel::Warn => {
-                Some(log)
-            }
-            _ => None,
-        })
-        .expect("a pnpm:hook warn event must be emitted for preResolution");
-    assert_eq!(warn_log.hook, "preResolution");
-    assert_eq!(warn_log.message, "Some packages may need updates");
-    assert_eq!(warn_log.from, "pnpmfile", "preResolution from is hardcoded to 'pnpmfile'");
-    assert_eq!(warn_log.prefix, *dir.path().to_string_lossy(), "prefix must be the lockfile dir");
+    for log in [
+        find_hook_event(LogLevel::Info, "Starting resolution"),
+        find_hook_event(LogLevel::Warn, "Some packages may need updates"),
+        find_hook_event(LogLevel::Info, "raw hook output"),
+    ] {
+        assert_eq!(log.from, "pnpmfile", "preResolution from is hardcoded to 'pnpmfile'");
+        assert_eq!(log.prefix, *dir.path().to_string_lossy(), "prefix must be the lockfile dir");
+    }
 
     drop((dir, registry));
 }

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -16,8 +16,8 @@ use pacquet_modules_yaml::{
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_reporter::{
     BrokenModulesLog, ContextLog, HookLog, IgnoredScriptsLog, LockfileVerificationMessage,
-    LogEvent, PackageManifestLog, PackageManifestMessage, ProgressLog, ProgressMessage, Reporter,
-    SilentReporter, Stage, StageLog, StatsLog, StatsMessage, SummaryLog,
+    LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, ProgressLog, ProgressMessage,
+    Reporter, SilentReporter, Stage, StageLog, StatsLog, StatsMessage, SummaryLog,
 };
 use pacquet_store_dir::STORE_VERSION;
 use pacquet_testing_utils::{
@@ -8058,6 +8058,73 @@ async fn async_after_all_resolved_hook_log_is_forwarded_to_pnpm_hook_channel() {
     let hook_log = first_hook_log(&captured);
     assert_eq!(hook_log.hook, "afterAllResolved");
     assert_eq!(hook_log.message, "All resolved");
+
+    drop((dir, registry));
+}
+
+// Ports pnpm's `pnpmfile: preResolution hook logger`: a `preResolution`
+// hook's `logger.info(...)` and `logger.warn(...)` surface on the
+// `pnpm:hook` channel with `from: "pnpmfile"`, `hook: "preResolution"`,
+// and the matching log level. Mirrors the TypeScript
+// `createPreResolutionHookLogger` which emits at `info`/`warn`.
+#[tokio::test]
+async fn pre_resolution_hook_log_is_forwarded_to_pnpm_hook_channel() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let registry = TestRegistry::start();
+    let dir = tempdir().unwrap();
+
+    install_with_pnpmfile_reporter::<RecordingReporter>(
+        registry.url(),
+        dir.path(),
+        &[("@pnpm.e2e/pkg-with-1-dep", "100.0.0")],
+        r"module.exports = { hooks: { preResolution (ctx, logger) {
+  logger.info('Starting resolution');
+  logger.warn('Some packages may need updates');
+} } }",
+    )
+    .await
+    .expect("install should succeed");
+
+    let captured = EVENTS.lock().unwrap();
+
+    // Find the info event
+    let info_log = captured
+        .iter()
+        .find_map(|event| match event {
+            LogEvent::Hook(log) if log.hook == "preResolution" && log.level == LogLevel::Info => {
+                Some(log)
+            }
+            _ => None,
+        })
+        .expect("a pnpm:hook info event must be emitted for preResolution");
+    assert_eq!(info_log.hook, "preResolution");
+    assert_eq!(info_log.message, "Starting resolution");
+    assert_eq!(info_log.from, "pnpmfile", "preResolution from is hardcoded to 'pnpmfile'");
+    assert!(!info_log.prefix.is_empty(), "prefix must be the project dir");
+
+    // Find the warn event
+    let warn_log = captured
+        .iter()
+        .find_map(|event| match event {
+            LogEvent::Hook(log) if log.hook == "preResolution" && log.level == LogLevel::Warn => {
+                Some(log)
+            }
+            _ => None,
+        })
+        .expect("a pnpm:hook warn event must be emitted for preResolution");
+    assert_eq!(warn_log.hook, "preResolution");
+    assert_eq!(warn_log.message, "Some packages may need updates");
+    assert_eq!(warn_log.from, "pnpmfile", "preResolution from is hardcoded to 'pnpmfile'");
+    assert!(!warn_log.prefix.is_empty(), "prefix must be the project dir");
 
     drop((dir, registry));
 }

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1035,11 +1035,34 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 store_dir: config.store_dir.display().to_string(),
                 registries,
             };
+            let log_prefix = lockfile_dir.to_string_lossy().into_owned();
             hook.pre_resolution(
                 ctx,
                 pacquet_hooks::PreResolutionHookLogger {
-                    info: Arc::new(|_| {}),
-                    warn: Arc::new(|_| {}),
+                    info: {
+                        let prefix = log_prefix.clone();
+                        Arc::new(move |message: String| {
+                            Reporter::emit(&LogEvent::Hook(HookLog {
+                                level: LogLevel::Info,
+                                from: "pnpmfile".to_string(),
+                                hook: "preResolution".to_string(),
+                                message,
+                                prefix: prefix.clone(),
+                            }));
+                        })
+                    },
+                    warn: {
+                        let prefix = log_prefix.clone();
+                        Arc::new(move |message: String| {
+                            Reporter::emit(&LogEvent::Hook(HookLog {
+                                level: LogLevel::Warn,
+                                from: "pnpmfile".to_string(),
+                                hook: "preResolution".to_string(),
+                                message,
+                                prefix: prefix.clone(),
+                            }));
+                        })
+                    },
                 },
             )
             .await;

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1035,34 +1035,11 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 store_dir: config.store_dir.display().to_string(),
                 registries,
             };
-            let log_prefix = lockfile_dir.to_string_lossy().into_owned();
             hook.pre_resolution(
                 ctx,
                 pacquet_hooks::PreResolutionHookLogger {
-                    info: {
-                        let prefix = log_prefix.clone();
-                        Arc::new(move |message: String| {
-                            Reporter::emit(&LogEvent::Hook(HookLog {
-                                level: LogLevel::Info,
-                                from: "pnpmfile".to_string(),
-                                hook: "preResolution".to_string(),
-                                message,
-                                prefix: prefix.clone(),
-                            }));
-                        })
-                    },
-                    warn: {
-                        let prefix = log_prefix.clone();
-                        Arc::new(move |message: String| {
-                            Reporter::emit(&LogEvent::Hook(HookLog {
-                                level: LogLevel::Warn,
-                                from: "pnpmfile".to_string(),
-                                hook: "preResolution".to_string(),
-                                message,
-                                prefix: prefix.clone(),
-                            }));
-                        })
-                    },
+                    info: pre_resolution_log_fn::<Reporter>(lockfile_dir, LogLevel::Info),
+                    warn: pre_resolution_log_fn::<Reporter>(lockfile_dir, LogLevel::Warn),
                 },
             )
             .await;
@@ -2004,6 +1981,27 @@ fn hook_log_fn<Reporter: self::Reporter>(
             level: LogLevel::Debug,
             from: from.clone(),
             hook: hook.to_string(),
+            message,
+            prefix: prefix.clone(),
+        }));
+    })
+}
+
+/// Build one side of the `preResolution` hook's `logger`: each
+/// `logger.info(...)` / `logger.warn(...)` call emits a `pnpm:hook` event at
+/// the given level. `from` is the literal `"pnpmfile"` — pnpm's
+/// `createPreResolutionHookLogger` hardcodes it rather than passing the
+/// pnpmfile path.
+fn pre_resolution_log_fn<Reporter: self::Reporter>(
+    prefix: &Path,
+    level: LogLevel,
+) -> pacquet_hooks::LogFn {
+    let prefix = prefix.to_string_lossy().into_owned();
+    Arc::new(move |message: String| {
+        Reporter::emit(&LogEvent::Hook(HookLog {
+            level,
+            from: "pnpmfile".to_string(),
+            hook: "preResolution".to_string(),
             message,
             prefix: prefix.clone(),
         }));


### PR DESCRIPTION
## Summary

Route `preResolution` hook `info`/`warn` logging to the `pnpm:hook` channel with the correct event payload, matching the TypeScript `createPreResolutionHookLogger` in `requireHooks.ts`. Previously the Rust port used no-op closures that silently discarded all preResolution log messages.

Changes:
- **`node_runtime.rs`**: Pipe stdout/stderr in the one-shot `node -e` process and parse JSON logger lines, forwarding `info`/`warn` messages to the Rust-side closures.
- **`install_with_fresh_lockfile.rs`**: Replace no-op `info`/`warn` closures with `Reporter::emit(&LogEvent::Hook(HookLog { ... }))` calls using `LogLevel::Info`/`LogLevel::Warn` and hardcoded `from: "pnpmfile"` (matching TypeScript's hardcoded `"pnpmfile"` for preResolution).
- **`install/tests.rs`**: Add `pre_resolution_hook_log_is_forwarded_to_pnpm_hook_channel` test verifying both info and warn events have correct `hook`, `message`, `from`, `prefix`, and `level`.

Related to pnpm/pnpm#11633

## Squash Commit Body

```
Route preResolution hook info/warn logging to the pnpm:hook channel

The preResolution hook's logger.info() and logger.warn() calls now emit
pnpm:hook events through the install reporter, matching the TypeScript
implementation in requireHooks.ts's createPreResolutionHookLogger.

- node_runtime.rs: pipe stdout/stderr in the one-shot node process and
  parse JSON logger lines from stdout, forwarding them to the Rust-side
  info/warn closures
- install_with_fresh_lockfile.rs: replace no-op info/warn closures with
  proper Reporter::emit(&LogEvent::Hook(HookLog { ... })) calls using
  LogLevel::Info/LogLevel::Warn and hardcoded from="pnpmfile"
- install/tests.rs: add pre_resolution_hook_log_is_forwarded_to_pnpm_hook_channel
  test verifying both info and warn events have the correct hook name,
  message, from field, and prefix

Related to pnpm/pnpm#11633
```

## Checklist

- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---

Written by an agent (big-pickle).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for `pnpm:hook` logs in the default reporter, displaying hook name and message.

* **Bug Fixes**
  * Hook log output from resolution hooks (e.g., `preResolution`) is now forwarded reliably, including both JSON and non-JSON lines.
  * Preserves `info`/`warn` severity and formats hook messages consistently across project paths.

* **Tests**
  * Added coverage to verify hook log forwarding for both `info` and `warn` scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->