### PR TITLE
feat(pacquet-cli): port the with command

### DIFF
--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -51,6 +51,7 @@ pub mod update;
 pub mod update_interactive;
 pub mod whoami;
 pub mod why;
+pub mod with;
 
 mod cli_command;
 mod dispatch;

--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -45,6 +45,7 @@ use super::{
     unlink::UnlinkArgs,
     update::UpdateArgs,
     why::WhyArgs,
+    with::WithArgs,
 };
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
@@ -230,4 +231,8 @@ pub enum CliCommand {
     Setup(SetupArgs),
     /// Log out of an npm registry.
     Logout(LogoutArgs),
+    /// Runs pnpm at a specific version (or the currently running one) for a
+    /// single invocation, ignoring the "packageManager" and
+    /// "devEngines.packageManager" fields of the project's manifest.
+    With(WithArgs),
 }

--- a/pacquet/crates/cli/src/cli_args/dispatch.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch.rs
@@ -274,6 +274,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::SelfUpdate(args) => dispatch_query::self_update(ctx, args),
         CliCommand::Setup(args) => dispatch_query::setup(ctx, args),
         CliCommand::Logout(args) => dispatch_query::logout(ctx, args),
+        CliCommand::With(args) => dispatch_query::with(ctx, args),
         CliCommand::Completion(_) | CliCommand::CompletionServer(_) => {
             unreachable!("completion returns before configuration")
         }

--- a/pacquet/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_query.rs
@@ -21,6 +21,7 @@ use super::{
     setup::SetupArgs,
     store::StoreCommand,
     why::WhyArgs,
+    with::WithArgs,
 };
 use pacquet_config::Config;
 use pacquet_default_reporter::DefaultReporter;
@@ -191,6 +192,20 @@ pub(super) fn pack_app<'a>(
 pub(super) fn docs<'a>(ctx: &RunCtx<'a>, args: DocsArgs) -> miette::Result<CommandFuture<'a>> {
     let cfg = (ctx.config)()?;
     Ok(Box::pin(async move { args.run(cfg).await }))
+}
+
+pub(super) fn with<'a>(ctx: &RunCtx<'a>, args: WithArgs) -> miette::Result<CommandFuture<'a>> {
+    let config = (ctx.config)()?;
+    macro_rules! run_with {
+        ($reporter:ty) => {
+            Box::pin(args.run::<$reporter>(config))
+        };
+    }
+    Ok(match ctx.reporter {
+        ReporterType::Default | ReporterType::AppendOnly => run_with!(DefaultReporter),
+        ReporterType::Ndjson => run_with!(NdjsonReporter),
+        ReporterType::Silent => run_with!(SilentReporter),
+    })
 }
 
 pub(super) fn self_update<'a>(

--- a/pacquet/crates/cli/src/cli_args/self_update.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update.rs
@@ -10,8 +10,10 @@
 //! directory, its native binary linked, its registry signature verified,
 //! and its bins linked into the global bin directory.
 
-mod install_pnpm;
-mod verify_engine;
+// `pub(crate)` so `pnpm with` can reuse the engine installer and the
+// engine-identity verifier; both commands install the same pnpm engine.
+pub(crate) mod install_pnpm;
+pub(crate) mod verify_engine;
 
 use clap::Args;
 use derive_more::{Display, Error};

--- a/pacquet/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -29,7 +29,14 @@ use super::SelfUpdateError;
 /// (equal content to `@pnpm/exe`), so a self-update always converges on
 /// installing `pnpm`. Mirrors pnpm's `pnpmPackageNameToInstall` for the
 /// v12+ branch.
-pub(super) const PNPM_PACKAGE_NAME: &str = "pnpm";
+pub(crate) const PNPM_PACKAGE_NAME: &str = "pnpm";
+
+/// The package-manager components pnpm marks buildable when installing
+/// the engine, so the `ENGINE_NAME` is folded into their global-virtual-
+/// store hash and each platform resolves to its own slot instead of
+/// colliding. Mirrors pnpm's `PNPM_ALLOW_BUILDS`
+/// (`{ '@pnpm/exe': true, 'pnpm': true }`).
+pub(crate) const PNPM_ALLOW_BUILDS: [&str; 2] = ["pnpm", "@pnpm/exe"];
 
 pub(super) struct InstallPnpmResult {
     pub install_dir: PathBuf,
@@ -67,6 +74,7 @@ pub(super) async fn install_pnpm<Reporter: self::Reporter + 'static>(
         &install_dir,
         version,
         supported_architectures,
+        false,
     ))
     .await
     .and_then(|()| link_exe_platform_binary(&install_dir, PNPM_PACKAGE_NAME));
@@ -89,11 +97,21 @@ fn installed_version(install_dir: &Path) -> Option<String> {
 /// Install `pnpm@<version>` into a fresh group directory, mirroring the
 /// global-add group install but with scripts disabled (the native binary
 /// is linked manually afterwards) and no build-approval prompt.
-async fn run_install<Reporter: self::Reporter + 'static>(
+///
+/// When `enable_global_virtual_store` is `true` the engine is installed
+/// into the shared global virtual store (`<store>/links/...`) — the layout
+/// `pnpm with` reuses across invocations — with the package-manager
+/// components ([`PNPM_ALLOW_BUILDS`]) marked buildable so the
+/// `ENGINE_NAME` is folded into their GVS hash. When `false` the engine is
+/// self-contained inside `install_dir` (the `self-update` global install).
+/// In both cases scripts are disabled and the native binary is linked
+/// manually by the caller via [`link_exe_platform_binary`].
+pub(crate) async fn run_install<Reporter: self::Reporter + 'static>(
     base_config: &'static Config,
     install_dir: &Path,
     version: &str,
     supported_architectures: Option<SupportedArchitectures>,
+    enable_global_virtual_store: bool,
 ) -> miette::Result<()> {
     let mut cfg = base_config.clone();
     // Resolve and fetch the engine bytes through the trusted
@@ -105,20 +123,31 @@ async fn run_install<Reporter: self::Reporter + 'static>(
     apply_package_manager_bootstrap(&mut cfg, &base_config.package_manager_bootstrap);
     cfg.modules_dir = install_dir.join("node_modules");
     cfg.virtual_store_dir = install_dir.join("node_modules").join(".pnpm");
-    // The engine install is self-contained, so its virtual store lives
-    // inside its own install dir, never the shared global one.
-    cfg.enable_global_virtual_store = false;
+    cfg.enable_global_virtual_store = enable_global_virtual_store;
     cfg.lockfile = true;
     cfg.workspace_dir = None;
     cfg.supported_architectures = supported_architectures;
     // pnpm installs the engine with `ignoreScripts: true` — the wrapper's
     // preinstall (which links the platform binary) is replicated by
     // `link_exe_platform_binary`, so running it here is both unnecessary
-    // and a code-execution surface during a privileged self-update.
+    // and a code-execution surface during a privileged install.
     cfg.ignore_scripts = true;
     cfg.dangerously_allow_all_builds = false;
-    cfg.allow_builds.clear();
     cfg.strict_dep_builds = false;
+    if enable_global_virtual_store {
+        // The engine lands in the shared GVS, so mark the package-manager
+        // components buildable — exactly as pnpm's `installPnpmToStore`
+        // passes `PNPM_ALLOW_BUILDS` to `findPnpmGvsPath` — so the
+        // `ENGINE_NAME` enters their GVS hash and each platform gets its
+        // own slot. Scripts still don't run (`ignore_scripts` above).
+        cfg.global_virtual_store_dir = base_config.store_dir.links();
+        cfg.allow_builds.clear();
+        for name in PNPM_ALLOW_BUILDS {
+            cfg.allow_builds.insert(name.to_string(), true);
+        }
+    } else {
+        cfg.allow_builds.clear();
+    }
     // Drop repo-controlled resolution-rewrite settings so a project's
     // `pnpm-workspace.yaml` can't change the engine's installed dependency
     // graph. The top-level engine components are signature-verified, but
@@ -203,7 +232,10 @@ fn apply_package_manager_bootstrap(cfg: &mut Config, bootstrap: &PackageManagerB
 /// when the hard link fails: with scripts disabled, this manual linking is
 /// the critical path, so a silent no-op would leave a "successful"
 /// self-update with a non-functional `pnpm`.
-fn link_exe_platform_binary(install_dir: &Path, wrapper_pkg_name: &str) -> miette::Result<()> {
+pub(crate) fn link_exe_platform_binary(
+    install_dir: &Path,
+    wrapper_pkg_name: &str,
+) -> miette::Result<()> {
     let mut wrapper_dir = install_dir.join("node_modules");
     for segment in wrapper_pkg_name.split('/') {
         wrapper_dir.push(segment);

--- a/pacquet/crates/cli/src/cli_args/self_update/verify_engine.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update/verify_engine.rs
@@ -74,7 +74,7 @@ struct EngineComponent {
 /// component carries no integrity metadata, or when the registry is
 /// unreachable — failing closed in every case, since the lockfile
 /// integrity is project-controlled and not a safe fallback.
-pub(super) async fn verify_pnpm_engine_identity(
+pub(crate) async fn verify_pnpm_engine_identity(
     env: &EnvLockfile,
     pnpm_version: &str,
     config: &Config,

--- a/pacquet/crates/cli/src/cli_args/with.rs
+++ b/pacquet/crates/cli/src/cli_args/with.rs
@@ -101,12 +101,15 @@ impl WithArgs {
 /// `crossSpawn.sync` at the end of pnpm's `with` handler.
 fn spawn_pnpm(bin_dir: &Path, args: &[String]) -> miette::Result<std::process::ExitStatus> {
     let path = prepend_to_path(bin_dir);
-    let cwd = std::env::current_dir().into_diagnostic().wrap_err("read the current directory")?;
-    // Resolve `pnpm` against the extended PATH so the platform-correct
-    // shim (e.g. `pnpm.cmd` on Windows) is found, matching cross-spawn.
-    let program = which::which_in("pnpm", Some(&path), &cwd)
+    // Resolve `pnpm` strictly within `bin_dir`, never the full PATH, so a
+    // missing or broken shim is an error rather than silently falling
+    // through to a different `pnpm` elsewhere on PATH (which would run the
+    // wrong engine). Mirrors pnpm's `with`, which spawns the explicit
+    // `path.join(binDir, 'pnpm')`; `which_in` is used only to pick the
+    // platform-correct shim name (e.g. `pnpm.cmd` on Windows).
+    let program = which::which_in("pnpm", Some(bin_dir), bin_dir)
         .into_diagnostic()
-        .wrap_err("locate the requested pnpm binary")?;
+        .wrap_err("locate the requested pnpm binary in the engine's bin directory")?;
 
     let mut cmd = Command::new(program);
     cmd.args(args);

--- a/pacquet/crates/cli/src/cli_args/with.rs
+++ b/pacquet/crates/cli/src/cli_args/with.rs
@@ -46,6 +46,12 @@ pub enum WithError {
         )
     )]
     NoGlobalDir,
+
+    #[display(
+        "Cannot add {dir} to PATH because it contains the path delimiter character ({delimiter})"
+    )]
+    #[diagnostic(code(ERR_PNPM_BAD_PATH_DIR))]
+    BadPathDir { dir: String, delimiter: char },
 }
 
 #[derive(Debug, Args)]
@@ -100,7 +106,7 @@ impl WithArgs {
 /// child's package-manager check disabled, inheriting stdio. Mirrors the
 /// `crossSpawn.sync` at the end of pnpm's `with` handler.
 fn spawn_pnpm(bin_dir: &Path, args: &[String]) -> miette::Result<std::process::ExitStatus> {
-    let path = prepend_to_path(bin_dir);
+    let path = prepend_to_path(bin_dir)?;
     // Resolve `pnpm` strictly within `bin_dir`, never the full PATH, so a
     // missing or broken shim is an error rather than silently falling
     // through to a different `pnpm` elsewhere on PATH (which would run the
@@ -131,15 +137,22 @@ fn spawn_pnpm(bin_dir: &Path, args: &[String]) -> miette::Result<std::process::E
     cmd.status().into_diagnostic().wrap_err("run the requested pnpm version")
 }
 
-/// Prepend `dir` to the current process `PATH`.
-fn prepend_to_path(dir: &Path) -> OsString {
-    let sep = if cfg!(windows) { ";" } else { ":" };
+/// Prepend `dir` to the current process `PATH`, rejecting a `dir` that
+/// contains the platform path delimiter (it cannot be expressed as a
+/// single `PATH` entry and would silently split into several). Mirrors the
+/// `BAD_PATH_DIR` guard `exec`'s `prepend_dirs_to_path` already applies;
+/// `dir` here is the engine's store-resident `bin` directory.
+fn prepend_to_path(dir: &Path) -> Result<OsString, WithError> {
+    let delimiter = if cfg!(windows) { ';' } else { ':' };
+    if dir.to_string_lossy().contains(delimiter) {
+        return Err(WithError::BadPathDir { dir: dir.to_string_lossy().into_owned(), delimiter });
+    }
     let mut out = OsString::from(dir);
     if let Some(current) = std::env::var_os("PATH").filter(|value| !value.is_empty()) {
-        out.push(sep);
+        out.push(if cfg!(windows) { ";" } else { ":" });
         out.push(current);
     }
-    out
+    Ok(out)
 }
 
 /// `true` when pnpm is running under corepack (which sets `COREPACK_ROOT`
@@ -148,3 +161,6 @@ fn prepend_to_path(dir: &Path) -> OsString {
 fn is_executed_by_corepack() -> bool {
     std::env::var_os("COREPACK_ROOT").is_some()
 }
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/with.rs
+++ b/pacquet/crates/cli/src/cli_args/with.rs
@@ -1,0 +1,147 @@
+//! `pacquet with <version|current> <args...>` — run pnpm at a specific
+//! version (or the currently running one) for a single invocation,
+//! ignoring the project's `packageManager` / `devEngines.packageManager`
+//! pin.
+//!
+//! Ports pnpm's
+//! [`with` command](https://github.com/pnpm/pnpm/blob/a33eeec9cd/pnpm11/engine/pm/commands/src/with/with.ts).
+//! `with current <cmd>` is rewritten before clap parses argv (see
+//! [`crate::with_current`]) into a direct dispatch of `<cmd>` with
+//! `pmOnFail` forced to `ignore`, so this handler only ever sees a
+//! version / range / dist-tag spec, which it resolves, installs into the
+//! global virtual store, and spawns.
+
+mod install_pnpm_to_store;
+
+use clap::Args;
+use derive_more::{Display, Error};
+use miette::{Context, Diagnostic, IntoDiagnostic};
+use pacquet_config::Config;
+use pacquet_reporter::Reporter;
+use std::{ffi::OsString, fs, path::Path, process::Command};
+
+use crate::config_deps;
+
+/// Errors specific to `pacquet with`. Codes mirror pnpm's `PnpmError`
+/// codes (pnpm prefixes them with `ERR_PNPM_`).
+#[derive(Debug, Display, Error, Diagnostic)]
+pub enum WithError {
+    #[display("Missing version argument. Usage: pnpm with <version|current> <args...>")]
+    #[diagnostic(code(ERR_PNPM_MISSING_WITH_SPEC))]
+    MissingSpec,
+
+    #[display(r#"The "pnpm with" command does not work under corepack"#)]
+    #[diagnostic(code(ERR_PNPM_CANT_USE_WITH_IN_COREPACK))]
+    CantUseWithInCorepack,
+
+    #[display(r#"Cannot resolve pnpm version for "{spec}""#)]
+    #[diagnostic(code(ERR_PNPM_CANNOT_RESOLVE_PNPM))]
+    CannotResolvePnpm { spec: String },
+
+    #[display("Unable to find the global packages directory")]
+    #[diagnostic(
+        code(ERR_PNPM_NO_GLOBAL_BIN_DIR),
+        help(
+            r#"Run "pnpm setup" to create it automatically, or set the global-bin-dir setting, or the PNPM_HOME env variable."#
+        )
+    )]
+    NoGlobalDir,
+}
+
+#[derive(Debug, Args)]
+pub struct WithArgs {
+    /// The pnpm version, range, or dist-tag to run, followed by the pnpm
+    /// command and its arguments. (`with current <args>` is handled before
+    /// argv parsing, so it never reaches this handler.)
+    #[clap(trailing_var_arg = true, allow_hyphen_values = true)]
+    pub params: Vec<String>,
+}
+
+impl WithArgs {
+    pub async fn run<Reporter: self::Reporter + 'static>(
+        self,
+        config: &'static Config,
+    ) -> miette::Result<()> {
+        let Some((spec, args)) = self.params.split_first() else {
+            return Err(WithError::MissingSpec.into());
+        };
+        if is_executed_by_corepack() {
+            return Err(WithError::CantUseWithInCorepack.into());
+        }
+
+        let resolved = config_deps::resolve_pnpm_version(config, spec)
+            .await?
+            .ok_or_else(|| WithError::CannotResolvePnpm { spec: spec.clone() })?;
+
+        let env_root = config.global_pkg_dir.clone().ok_or(WithError::NoGlobalDir)?;
+        fs::create_dir_all(&env_root)
+            .into_diagnostic()
+            .wrap_err("create the global packages directory")?;
+
+        let bin_dir = Box::pin(install_pnpm_to_store::install_pnpm_to_store::<Reporter>(
+            config,
+            &env_root,
+            spec,
+            &resolved.version,
+        ))
+        .await?;
+
+        let status = spawn_pnpm(&bin_dir, args)?;
+        if !status.success() {
+            // Propagate the child's exit code. A signal-terminated child
+            // has no code; fall back to 1, matching pnpm's `exitCode ?? 1`.
+            std::process::exit(status.code().unwrap_or(1));
+        }
+        Ok(())
+    }
+}
+
+/// Spawn the downloaded `pnpm` with `bin_dir` prepended to `PATH` and the
+/// child's package-manager check disabled, inheriting stdio. Mirrors the
+/// `crossSpawn.sync` at the end of pnpm's `with` handler.
+fn spawn_pnpm(bin_dir: &Path, args: &[String]) -> miette::Result<std::process::ExitStatus> {
+    let path = prepend_to_path(bin_dir);
+    let cwd = std::env::current_dir().into_diagnostic().wrap_err("read the current directory")?;
+    // Resolve `pnpm` against the extended PATH so the platform-correct
+    // shim (e.g. `pnpm.cmd` on Windows) is found, matching cross-spawn.
+    let program = which::which_in("pnpm", Some(&path), &cwd)
+        .into_diagnostic()
+        .wrap_err("locate the requested pnpm binary")?;
+
+    let mut cmd = Command::new(program);
+    cmd.args(args);
+    // Drop any inherited PATH-like key before re-inserting our own, so a
+    // Windows `Path`/`PATH` pair can't collapse to an unspecified winner.
+    cmd.env_remove("PATH");
+    cmd.env_remove("Path");
+    cmd.env("PATH", &path);
+    // The child pnpm must skip the packageManager / devEngines check so the
+    // requested version stays active. `COREPACK_ROOT` is honored by every
+    // pnpm release that supports corepack (older versions skip the check
+    // whenever it is set); `pnpm_config_pm_on_fail=ignore` is the
+    // principled override for releases that ship the `pmOnFail` setting.
+    if std::env::var_os("COREPACK_ROOT").is_none() {
+        cmd.env("COREPACK_ROOT", "pnpm-with");
+    }
+    cmd.env("pnpm_config_pm_on_fail", "ignore");
+
+    cmd.status().into_diagnostic().wrap_err("run the requested pnpm version")
+}
+
+/// Prepend `dir` to the current process `PATH`.
+fn prepend_to_path(dir: &Path) -> OsString {
+    let sep = if cfg!(windows) { ";" } else { ":" };
+    let mut out = OsString::from(dir);
+    if let Some(current) = std::env::var_os("PATH").filter(|value| !value.is_empty()) {
+        out.push(sep);
+        out.push(current);
+    }
+    out
+}
+
+/// `true` when pnpm is running under corepack (which sets `COREPACK_ROOT`
+/// and manages its own version switching). Mirrors pnpm's
+/// `isExecutedByCorepack`.
+fn is_executed_by_corepack() -> bool {
+    std::env::var_os("COREPACK_ROOT").is_some()
+}

--- a/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
+++ b/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
@@ -99,8 +99,11 @@ pub(super) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
     .await
     .and_then(|()| resolve_slot(&tmp_install_dir));
     // The temp directory held only symlinks into the GVS, so removing it
-    // does not touch the installed engine.
-    let _ = fs::remove_dir_all(&tmp_install_dir);
+    // does not touch the installed engine. Refuse to recurse through a
+    // symlink at the temp path as defense-in-depth — even though the store
+    // is within pnpm's trust domain — mirroring the guard `patch-commit`
+    // applies before its own `remove_dir_all`.
+    let _ = remove_dir_if_not_symlink(&tmp_install_dir);
     let slot = slot?;
 
     let pkg_dir = slot.join("node_modules").join(PNPM_PACKAGE_NAME);
@@ -168,6 +171,28 @@ fn link_bins(pkg_dir: &Path, bin_dir: &Path) -> miette::Result<()> {
     link_bins_of_packages::<CmdShimHost>(&[source], bin_dir)
         .map_err(miette::Report::new)
         .wrap_err("link the pnpm bins")
+}
+
+/// Remove `path` and its contents, refusing to recurse through a symlink
+/// at `path` itself. A missing path is success. Mirrors the symlink guard
+/// `patch-commit` applies before `remove_dir_all`.
+fn remove_dir_if_not_symlink(path: &Path) -> std::io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_symlink() => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "temporary directory must not be a symbolic link",
+            ));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    }
+    match fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
 }
 
 /// A best-effort unique component for the temporary install directory

--- a/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
+++ b/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
@@ -1,0 +1,180 @@
+//! Install a specific pnpm version into the shared global virtual store
+//! for `pnpm with`.
+//!
+//! Ports pnpm's
+//! [`installPnpmToStore`](https://github.com/pnpm/pnpm/blob/a33eeec9cd/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts#L93-L151):
+//! the engine lands in `<store>/links/...` (shared across `pnpm with`
+//! invocations and, unlike `self-update`, not registered in the global
+//! packages directory, so `pnpm ls -g` does not see it), its registry
+//! signature is verified on a genuine download, and its native platform
+//! binary + bins are linked into a `bin/` directory the caller prepends to
+//! `PATH`.
+
+use miette::{Context, IntoDiagnostic};
+use pacquet_cmd_shim::{Host as CmdShimHost, PackageBinSource, link_bins_of_packages};
+use pacquet_config::Config;
+use pacquet_graph_hasher::{detect_node_major, engine_name};
+use pacquet_lockfile::{EnvLockfile, PackageKey};
+use pacquet_package_manager::{AllowBuildPolicy, VirtualStoreLayout};
+use pacquet_reporter::Reporter;
+use serde_json::Value;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use crate::{
+    cli_args::self_update::{
+        install_pnpm::{
+            PNPM_ALLOW_BUILDS, PNPM_PACKAGE_NAME, link_exe_platform_binary, run_install,
+        },
+        verify_engine::verify_pnpm_engine_identity,
+    },
+    config_deps,
+};
+
+/// Install `pnpm@<version>` into the global virtual store and return the
+/// directory holding the linked `pnpm` binary.
+///
+/// `env_root` is where the package-manager env lockfile (the resolved
+/// `pnpm` + `@pnpm/exe` closure) is written, mirroring pnpm's
+/// `pnpmHomeDir`. `spec` is the user's bare specifier (a version, range,
+/// or dist-tag) and `version` the exact version it resolved to.
+pub(super) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
+    config: &'static Config,
+    env_root: &Path,
+    spec: &str,
+    version: &str,
+) -> miette::Result<PathBuf> {
+    // Resolve `pnpm` + `@pnpm/exe` + their closure into the env lockfile
+    // (a no-op when this spec+version is already recorded there).
+    config_deps::sync_package_manager_dependencies(config, env_root, spec, version, false).await?;
+    let env = EnvLockfile::read(env_root)
+        .map_err(miette::Report::new)
+        .wrap_err("read the package-manager env lockfile")?
+        .ok_or_else(|| {
+            miette::miette!("the package-manager env lockfile is missing after resolution")
+        })?;
+
+    // Cache hit: when the engine already sits in its GVS slot, skip both
+    // the signature check and the install — exactly as pnpm short-circuits
+    // on `fs.existsSync(pnpmPkgDir/package.json)`. The slot is computed
+    // with the same hashing the install pipeline uses, so a stale or wrong
+    // computation merely misses the cache (the idempotent install below
+    // then re-derives the slot from the install's own symlink).
+    if let Some(slot) = compute_pnpm_slot(config, &env, version) {
+        let pkg_dir = slot.join("node_modules").join(PNPM_PACKAGE_NAME);
+        let bin_dir = slot.join("bin");
+        if pkg_dir.join("package.json").exists() {
+            if !bin_dir.exists() {
+                link_bins(&pkg_dir, &bin_dir)?;
+            }
+            return Ok(bin_dir);
+        }
+    }
+
+    // Genuine download: verify the engine's registry signature before
+    // installing or executing it.
+    verify_pnpm_engine_identity(&env, version, config)
+        .await
+        .map_err(miette::Report::new)
+        .wrap_err("verify the pnpm engine identity")?;
+
+    // Install into a throwaway directory with the global virtual store
+    // enabled, so the engine itself materializes in `<store>/links/...`
+    // and the temp directory holds only symlinks into it.
+    let tmp_install_dir =
+        config.store_dir.tmp().join(format!("pnpm-with-{version}-{}", unique_suffix()));
+    fs::create_dir_all(&tmp_install_dir)
+        .into_diagnostic()
+        .wrap_err("create the temporary pnpm install directory")?;
+    let slot = Box::pin(run_install::<Reporter>(
+        config,
+        &tmp_install_dir,
+        version,
+        config.supported_architectures.clone(),
+        true,
+    ))
+    .await
+    .and_then(|()| resolve_slot(&tmp_install_dir));
+    // The temp directory held only symlinks into the GVS, so removing it
+    // does not touch the installed engine.
+    let _ = fs::remove_dir_all(&tmp_install_dir);
+    let slot = slot?;
+
+    let pkg_dir = slot.join("node_modules").join(PNPM_PACKAGE_NAME);
+    let bin_dir = slot.join("bin");
+    // Replicate the wrapper's preinstall (skipped because the engine is
+    // installed with scripts disabled): link the host's native binary.
+    link_exe_platform_binary(&slot, PNPM_PACKAGE_NAME)?;
+    link_bins(&pkg_dir, &bin_dir)?;
+    Ok(bin_dir)
+}
+
+/// The global-virtual-store slot `pnpm@<version>` resolves to, or `None`
+/// when it can't be derived (e.g. the engine snapshot is missing or the
+/// allow-build policy fails to compile). Drives only the cache-hit
+/// short-circuit, so `None` is a safe "treat as a miss".
+fn compute_pnpm_slot(config: &Config, env: &EnvLockfile, version: &str) -> Option<PathBuf> {
+    let wanted: PackageKey = format!("{PNPM_PACKAGE_NAME}@{version}").parse().ok()?;
+    let key = env.snapshots.keys().find(|key| key.without_peer() == wanted)?.clone();
+
+    let mut cfg = config.clone();
+    cfg.enable_global_virtual_store = true;
+    cfg.global_virtual_store_dir = config.store_dir.links();
+    cfg.allow_builds.clear();
+    for name in PNPM_ALLOW_BUILDS {
+        cfg.allow_builds.insert(name.to_string(), true);
+    }
+    let policy = AllowBuildPolicy::from_config(&cfg).ok()?;
+    let engine = detect_node_major().map(|major| engine_name(major, None, None));
+    let layout = VirtualStoreLayout::new(
+        &cfg,
+        engine.as_deref(),
+        Some(&env.snapshots),
+        Some(&env.packages),
+        Some(&policy),
+    );
+    Some(layout.slot_dir(&key))
+}
+
+/// Derive the engine's GVS slot from the install's own `pnpm` symlink
+/// (`<install_dir>/node_modules/pnpm` → `<slot>/node_modules/pnpm`). This
+/// is the ground truth after an install, independent of any hash
+/// recomputation.
+fn resolve_slot(install_dir: &Path) -> miette::Result<PathBuf> {
+    let link = install_dir.join("node_modules").join(PNPM_PACKAGE_NAME);
+    let real = fs::canonicalize(&link)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("resolve the installed pnpm at {}", link.display()))?;
+    real.parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .ok_or_else(|| miette::miette!("could not locate the pnpm global-virtual-store slot"))
+}
+
+/// Link `pnpm`'s declared bins into `bin_dir`. Mirrors pnpm's `linkBins`
+/// call after the engine install.
+fn link_bins(pkg_dir: &Path, bin_dir: &Path) -> miette::Result<()> {
+    let manifest_path = pkg_dir.join("package.json");
+    let text = fs::read_to_string(&manifest_path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("read {}", manifest_path.display()))?;
+    let manifest: Value = serde_json::from_str(&text)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("parse {}", manifest_path.display()))?;
+    let source = PackageBinSource::new(pkg_dir.to_path_buf(), Arc::new(manifest));
+    link_bins_of_packages::<CmdShimHost>(&[source], bin_dir)
+        .map_err(miette::Report::new)
+        .wrap_err("link the pnpm bins")
+}
+
+/// A best-effort unique component for the temporary install directory
+/// name, so concurrent `pnpm with` invocations don't collide.
+fn unique_suffix() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos =
+        SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |elapsed| elapsed.as_nanos());
+    format!("{}-{nanos}", std::process::id())
+}

--- a/pacquet/crates/cli/src/cli_args/with/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/with/tests.rs
@@ -1,0 +1,16 @@
+use super::{WithError, prepend_to_path};
+use std::path::Path;
+
+#[test]
+fn prepend_to_path_rejects_a_delimiter_in_the_bin_dir() {
+    let delimiter = if cfg!(windows) { "a;b" } else { "a:b" };
+    let error = prepend_to_path(Path::new(delimiter)).expect_err("must reject the delimiter");
+    assert!(matches!(error, WithError::BadPathDir { .. }));
+}
+
+#[test]
+fn prepend_to_path_accepts_a_normal_bin_dir() {
+    let dir = if cfg!(windows) { r"C:\store\bin" } else { "/store/bin" };
+    let path = prepend_to_path(Path::new(dir)).expect("a normal dir is accepted");
+    assert!(path.to_string_lossy().starts_with(dir));
+}

--- a/pacquet/crates/cli/src/lib.rs
+++ b/pacquet/crates/cli/src/lib.rs
@@ -3,6 +3,7 @@ mod config_deps;
 mod config_overrides;
 mod job_control;
 mod state;
+mod with_current;
 
 use clap::Parser;
 use cli_args::CliArgs;
@@ -21,6 +22,11 @@ pub fn main() -> miette::Result<()> {
     // would otherwise error out as "unexpected argument". Each extracted
     // token is layered onto `Config` after `.npmrc` / yaml run.
     let (config_overrides, argv) = ConfigOverrides::extract(argv_with_alias_subcommand());
+    // `pnpm with current <cmd>` is sugar for running `<cmd>` in-process with
+    // the packageManager / devEngines check disabled; rewrite argv before
+    // clap parses it. A version spec (`pnpm with 10 <cmd>`) is left for the
+    // `with` subcommand to handle.
+    let argv = with_current::rewrite(argv)?;
     // The default reporter's `Done in ... using pacquet v<version>` footer needs
     // the version before the first event (including the fast path's).
     pacquet_default_reporter::set_package_version(pacquet_config::PACQUET_VERSION);

--- a/pacquet/crates/cli/src/with_current.rs
+++ b/pacquet/crates/cli/src/with_current.rs
@@ -1,0 +1,105 @@
+//! Rewrite `pnpm with current <cmd> [args]` before clap parses argv.
+//!
+//! `pnpm [global-opts] with current <cmd> [args]` is sugar for
+//! `pnpm [global-opts] <cmd> [args]` run with the project's
+//! `packageManager` / `devEngines.packageManager` check disabled. Ports
+//! the `with current` branch of pnpm's
+//! [`parseCliArgs`](https://github.com/pnpm/pnpm/blob/a33eeec9cd/pnpm11/pnpm/src/parseCliArgs.ts#L45-L56):
+//! the `with current` tokens are removed in place (so any global flags
+//! before `with` are preserved) and the override is propagated via the
+//! `pnpm_config_pm_on_fail` env var rather than an argv flag, so it
+//! survives clap's `-v` / `--version` short-circuit and reaches both the
+//! in-process config load and any child process the command spawns.
+
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use std::ffi::OsString;
+
+/// Global long options that do **not** take a value, so a following
+/// `with` is the command rather than the option's argument. Every other
+/// long option (known value-takers like `--dir` / `--reporter`, and any
+/// unknown flag) is assumed to consume its successor — matching pnpm's
+/// `longOptionConsumesValue`, which treats a non-boolean (including
+/// unknown) option as value-consuming.
+const BOOLEAN_LONG_OPTIONS: &[&str] = &["recursive"];
+
+/// Raised when `with current` has no command after it.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display(r#"Missing command after "current". Usage: pnpm with current <command> [args...]"#)]
+#[diagnostic(code(ERR_PNPM_MISSING_WITH_CURRENT_CMD))]
+pub struct MissingWithCurrentCommand;
+
+/// Rewrite `argv` (program name at index 0) when it contains a
+/// `with current` command pair, returning the argv clap should parse. A
+/// no-op when there is no such pair. As a side effect, forces
+/// `pmOnFail=ignore` for the in-process run (and its children) via the
+/// `pnpm_config_pm_on_fail` env var.
+pub fn rewrite(argv: Vec<OsString>) -> miette::Result<Vec<OsString>> {
+    let (argv, force_pm_on_fail_ignore) = plan(argv)?;
+    if force_pm_on_fail_ignore {
+        // SAFETY: `rewrite` runs in `main` before the tokio runtime and
+        // rayon pool start, so the process is single-threaded and no other
+        // thread can be reading the environment concurrently.
+        unsafe {
+            std::env::set_var("pnpm_config_pm_on_fail", "ignore");
+        }
+    }
+    Ok(argv)
+}
+
+/// The pure core of [`rewrite`]: returns the rewritten argv and whether a
+/// `with current` pair was stripped (in which case the caller must force
+/// `pmOnFail=ignore`). Split out so the argv transformation is testable
+/// without mutating the process environment.
+fn plan(mut argv: Vec<OsString>) -> miette::Result<(Vec<OsString>, bool)> {
+    let Some(index) = find_with_current_index(&argv) else {
+        return Ok((argv, false));
+    };
+    // `with current` with nothing after it is a usage error.
+    if argv.len() <= index + 2 {
+        return Err(MissingWithCurrentCommand.into());
+    }
+    argv.drain(index..index + 2);
+    Ok((argv, true))
+}
+
+/// The index of the `with` token of the first `with current` command pair
+/// in `argv`, skipping a pair whose `with` is the argument of a preceding
+/// value-taking long option. Mirrors pnpm's `findWithCurrentIndex`.
+fn find_with_current_index(argv: &[OsString]) -> Option<usize> {
+    // Start at 1 to skip the program name; stop before the last element so
+    // `index + 1` is always in bounds.
+    for index in 1..argv.len().saturating_sub(1) {
+        if argv[index] != "with" || argv[index + 1] != "current" {
+            continue;
+        }
+        if let Some(prev) = argv.get(index - 1)
+            && long_option_consumes_value(prev)
+        {
+            continue;
+        }
+        return Some(index);
+    }
+    None
+}
+
+/// Whether `token` is a long option that consumes the next argv token as
+/// its value. Booleans and `--no-` negations don't; an inline `--opt=val`
+/// carries its own value. Unknown long options are assumed to consume a
+/// value, matching pnpm.
+fn long_option_consumes_value(token: &OsString) -> bool {
+    let Some(token) = token.to_str() else {
+        return false;
+    };
+    if !token.starts_with("--") || token.contains('=') {
+        return false;
+    }
+    let name = &token[2..];
+    if name.starts_with("no-") {
+        return false;
+    }
+    !BOOLEAN_LONG_OPTIONS.contains(&name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/with_current.rs
+++ b/pacquet/crates/cli/src/with_current.rs
@@ -15,13 +15,18 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use std::ffi::OsString;
 
-/// Global long options that do **not** take a value, so a following
-/// `with` is the command rather than the option's argument. Every other
-/// long option (known value-takers like `--dir` / `--reporter`, and any
-/// unknown flag) is assumed to consume its successor — matching pnpm's
+/// Global long options that do **not** take a value, so the next token is
+/// the subcommand rather than the option's argument. Every other long
+/// option (known value-takers like `--dir` / `--reporter`, and any unknown
+/// flag) is assumed to consume its successor — matching pnpm's
 /// `longOptionConsumesValue`, which treats a non-boolean (including
 /// unknown) option as value-consuming.
 const BOOLEAN_LONG_OPTIONS: &[&str] = &["recursive"];
+
+/// Global short options that take a value (`-C` = `--dir`, `-F` =
+/// `--filter`), so the next token is the value, not the subcommand. Other
+/// short flags (`-r`) are boolean and consume nothing.
+const VALUE_TAKING_SHORT_OPTIONS: &[&str] = &["-C", "-F"];
 
 /// Raised when `with current` has no command after it.
 #[derive(Debug, Display, Error, Diagnostic)]
@@ -63,35 +68,60 @@ fn plan(mut argv: Vec<OsString>) -> miette::Result<(Vec<OsString>, bool)> {
     Ok((argv, true))
 }
 
-/// The index of the `with` token of the first `with current` command pair
-/// in `argv`, skipping a pair whose `with` is the argument of a preceding
-/// value-taking long option. Mirrors pnpm's `findWithCurrentIndex`.
+/// The index of the `with` token when `with current` is the actual
+/// top-level subcommand, or `None` otherwise.
+///
+/// `with current` is only the sugar when `with` sits at the subcommand
+/// position — `pnpm [global-opts] with current ...`. A `with current`
+/// appearing later as data for another command (`pnpm exec with current
+/// ...`) must be left alone. Mirrors pnpm, which enters the rewrite only
+/// when the parsed command is `with` with first param `current`.
 fn find_with_current_index(argv: &[OsString]) -> Option<usize> {
-    // Start at 1 to skip the program name; stop before the last element so
-    // `index + 1` is always in bounds.
-    for index in 1..argv.len().saturating_sub(1) {
-        if argv[index] != "with" || argv[index + 1] != "current" {
-            continue;
+    let command = command_index(argv)?;
+    let is_with = argv.get(command).is_some_and(|token| token == "with");
+    let is_current = argv.get(command + 1).is_some_and(|token| token == "current");
+    (is_with && is_current).then_some(command)
+}
+
+/// Index of the top-level subcommand token: the first positional after the
+/// program name, skipping global options (and the values they consume) and
+/// honoring `--` as end-of-options. `None` when argv carries no subcommand.
+fn command_index(argv: &[OsString]) -> Option<usize> {
+    let mut index = 1;
+    while index < argv.len() {
+        let Some(token) = argv[index].to_str() else {
+            // A non-UTF-8 token can't be a known option or `with`; treat it
+            // as the subcommand position (it simply won't match `with`).
+            return Some(index);
+        };
+        if token == "--" {
+            let next = index + 1;
+            return (next < argv.len()).then_some(next);
         }
-        if let Some(prev) = argv.get(index - 1)
-            && long_option_consumes_value(prev)
-        {
-            continue;
+        if !token.starts_with('-') {
+            return Some(index);
         }
-        return Some(index);
+        index += if option_consumes_value(token) { 2 } else { 1 };
     }
     None
 }
 
-/// Whether `token` is a long option that consumes the next argv token as
-/// its value. Booleans and `--no-` negations don't; an inline `--opt=val`
-/// carries its own value. Unknown long options are assumed to consume a
-/// value, matching pnpm.
-fn long_option_consumes_value(token: &OsString) -> bool {
-    let Some(token) = token.to_str() else {
-        return false;
-    };
-    if !token.starts_with("--") || token.contains('=') {
+/// Whether the option token `token` consumes the next argv token as its
+/// value.
+fn option_consumes_value(token: &str) -> bool {
+    if token.starts_with("--") {
+        long_option_consumes_value(token)
+    } else {
+        VALUE_TAKING_SHORT_OPTIONS.contains(&token)
+    }
+}
+
+/// Whether a long option consumes the next argv token as its value.
+/// Booleans and `--no-` negations don't; an inline `--opt=val` carries its
+/// own value. Unknown long options are assumed to consume a value, matching
+/// pnpm.
+fn long_option_consumes_value(token: &str) -> bool {
+    if token.contains('=') {
         return false;
     }
     let name = &token[2..];

--- a/pacquet/crates/cli/src/with_current/tests.rs
+++ b/pacquet/crates/cli/src/with_current/tests.rs
@@ -1,0 +1,74 @@
+use super::{MissingWithCurrentCommand, long_option_consumes_value, plan};
+use std::ffi::OsString;
+
+/// Build an argv (with a leading program name) from string slices.
+fn argv(tokens: &[&str]) -> Vec<OsString> {
+    std::iter::once("pnpm").chain(tokens.iter().copied()).map(OsString::from).collect()
+}
+
+fn strings(argv: &[OsString]) -> Vec<String> {
+    argv.iter().map(|token| token.to_string_lossy().into_owned()).collect()
+}
+
+#[test]
+fn strips_the_with_current_tokens_and_flags_the_override() {
+    let (rewritten, force) = plan(argv(&["with", "current", "install"])).expect("plan");
+    assert!(force, "a stripped `with current` forces pmOnFail=ignore");
+    assert_eq!(strings(&rewritten), vec!["pnpm", "install"]);
+}
+
+#[test]
+fn forwards_the_command_arguments() {
+    let (rewritten, _) =
+        plan(argv(&["with", "current", "add", "foo", "--save-dev"])).expect("plan");
+    assert_eq!(strings(&rewritten), vec!["pnpm", "add", "foo", "--save-dev"]);
+}
+
+#[test]
+fn preserves_global_flags_before_with() {
+    // A boolean global flag (`-r` long form) before `with` is kept.
+    let (rewritten, force) =
+        plan(argv(&["--recursive", "with", "current", "install"])).expect("plan");
+    assert!(force);
+    assert_eq!(strings(&rewritten), vec!["pnpm", "--recursive", "install"]);
+}
+
+#[test]
+fn leaves_argv_untouched_without_with_current() {
+    let (rewritten, force) = plan(argv(&["with", "10", "install"])).expect("plan");
+    assert!(!force, "a version spec is not the `current` sugar");
+    assert_eq!(strings(&rewritten), vec!["pnpm", "with", "10", "install"]);
+
+    let (rewritten, force) = plan(argv(&["install"])).expect("plan");
+    assert!(!force);
+    assert_eq!(strings(&rewritten), vec!["pnpm", "install"]);
+}
+
+#[test]
+fn errors_when_no_command_follows_current() {
+    let error = plan(argv(&["with", "current"])).expect_err("missing command must error");
+    assert!(error.downcast_ref::<MissingWithCurrentCommand>().is_some());
+}
+
+#[test]
+fn skips_a_with_consumed_by_a_value_taking_option() {
+    // `--reporter with` makes `with` the reporter's value, so this
+    // `with current` pair is not the command and must not be rewritten.
+    let (rewritten, force) =
+        plan(argv(&["--reporter", "with", "current", "install"])).expect("plan");
+    assert!(!force);
+    assert_eq!(strings(&rewritten), vec!["pnpm", "--reporter", "with", "current", "install"]);
+}
+
+#[test]
+fn long_option_value_consumption_matches_pnpm() {
+    // Value-takers and unknown options consume their successor.
+    assert!(long_option_consumes_value(&OsString::from("--reporter")));
+    assert!(long_option_consumes_value(&OsString::from("--unknown-flag")));
+    // Booleans, `--no-` negations, and inline `=` values do not.
+    assert!(!long_option_consumes_value(&OsString::from("--recursive")));
+    assert!(!long_option_consumes_value(&OsString::from("--no-something")));
+    assert!(!long_option_consumes_value(&OsString::from("--reporter=ndjson")));
+    // Short options aren't long options.
+    assert!(!long_option_consumes_value(&OsString::from("-r")));
+}

--- a/pacquet/crates/cli/src/with_current/tests.rs
+++ b/pacquet/crates/cli/src/with_current/tests.rs
@@ -1,4 +1,4 @@
-use super::{MissingWithCurrentCommand, long_option_consumes_value, plan};
+use super::{MissingWithCurrentCommand, option_consumes_value, plan};
 use std::ffi::OsString;
 
 /// Build an argv (with a leading program name) from string slices.
@@ -61,14 +61,40 @@ fn skips_a_with_consumed_by_a_value_taking_option() {
 }
 
 #[test]
-fn long_option_value_consumption_matches_pnpm() {
-    // Value-takers and unknown options consume their successor.
-    assert!(long_option_consumes_value(&OsString::from("--reporter")));
-    assert!(long_option_consumes_value(&OsString::from("--unknown-flag")));
-    // Booleans, `--no-` negations, and inline `=` values do not.
-    assert!(!long_option_consumes_value(&OsString::from("--recursive")));
-    assert!(!long_option_consumes_value(&OsString::from("--no-something")));
-    assert!(!long_option_consumes_value(&OsString::from("--reporter=ndjson")));
-    // Short options aren't long options.
-    assert!(!long_option_consumes_value(&OsString::from("-r")));
+fn does_not_rewrite_with_current_inside_another_subcommand() {
+    // `with current` as data for another command must be left alone — only
+    // `with` at the subcommand position is the sugar.
+    for tokens in [
+        vec!["exec", "with", "current", "install"],
+        vec!["run", "with", "current"],
+        vec!["dlx", "with", "current", "foo"],
+    ] {
+        let original = argv(&tokens);
+        let (rewritten, force) = plan(original.clone()).expect("plan");
+        assert!(!force, "`with current` as an argument must not force pmOnFail: {tokens:?}");
+        assert_eq!(strings(&rewritten), strings(&original), "argv must be untouched: {tokens:?}");
+    }
+}
+
+#[test]
+fn rewrites_with_current_after_a_value_taking_global_flag() {
+    // `--reporter ndjson` consumes its value, so `with` is the subcommand.
+    let (rewritten, force) =
+        plan(argv(&["--reporter", "ndjson", "with", "current", "install"])).expect("plan");
+    assert!(force);
+    assert_eq!(strings(&rewritten), vec!["pnpm", "--reporter", "ndjson", "install"]);
+}
+
+#[test]
+fn option_value_consumption_matches_pnpm() {
+    // Value-takers and unknown long options consume their successor.
+    assert!(option_consumes_value("--reporter"));
+    assert!(option_consumes_value("--unknown-flag"));
+    assert!(option_consumes_value("-C"));
+    assert!(option_consumes_value("-F"));
+    // Booleans, `--no-` negations, inline `=` values, and boolean shorts do not.
+    assert!(!option_consumes_value("--recursive"));
+    assert!(!option_consumes_value("--no-something"));
+    assert!(!option_consumes_value("--reporter=ndjson"));
+    assert!(!option_consumes_value("-r"));
 }

--- a/pacquet/crates/cli/tests/with.rs
+++ b/pacquet/crates/cli/tests/with.rs
@@ -37,7 +37,7 @@ fn with_current_requires_a_command() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains(r#"Missing command after "current""#),
-        "stderr should explain the gap: {stderr}"
+        "stderr should explain the gap: {stderr}",
     );
 
     drop(root);
@@ -61,7 +61,7 @@ fn with_current_runs_the_inner_command() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("this-command-does-not-exist") || stderr.contains("unrecognized"),
-        "the inner command should reach the parser: {stderr}"
+        "the inner command should reach the parser: {stderr}",
     );
 
     drop(root);

--- a/pacquet/crates/cli/tests/with.rs
+++ b/pacquet/crates/cli/tests/with.rs
@@ -1,0 +1,68 @@
+//! `pacquet with <version|current> <args...>` runs pnpm at a specific
+//! version (or the currently running one) for a single invocation,
+//! ignoring the project's `packageManager` / `devEngines.packageManager`
+//! pin.
+//!
+//! These cover the network-free surface of the command: the usage errors
+//! and the `with current` argv rewrite. The end-to-end `with <version>`
+//! download path is not covered here because the mock registry does not
+//! serve the `pnpm` / `@pnpm/exe` engine packages (the same reason
+//! `self-update` has no end-to-end install test).
+
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+
+#[test]
+fn with_requires_a_version_spec() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+
+    let output = pacquet.with_args(["with"]).output().expect("run pacquet with");
+    dbg!(&output);
+    assert!(!output.status.success(), "pacquet with (no spec) should fail");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Missing version argument"), "stderr should explain the gap: {stderr}");
+
+    drop(root);
+}
+
+#[test]
+fn with_current_requires_a_command() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+
+    let output = pacquet.with_args(["with", "current"]).output().expect("run pacquet with current");
+    dbg!(&output);
+    assert!(!output.status.success(), "pacquet with current (no command) should fail");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(r#"Missing command after "current""#),
+        "stderr should explain the gap: {stderr}"
+    );
+
+    drop(root);
+}
+
+#[test]
+fn with_current_runs_the_inner_command() {
+    // `with current <cmd>` is rewritten to a direct `<cmd>` dispatch, so an
+    // unknown inner command surfaces clap's error for that command — proof
+    // the `with current` tokens were stripped and `<cmd>` reached the
+    // parser, rather than being swallowed by the `with` subcommand.
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+
+    let output = pacquet
+        .with_args(["with", "current", "this-command-does-not-exist"])
+        .output()
+        .expect("run pacquet with current <cmd>");
+    dbg!(&output);
+    assert!(!output.status.success(), "an unknown inner command should fail");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("this-command-does-not-exist") || stderr.contains("unrecognized"),
+        "the inner command should reach the parser: {stderr}"
+    );
+
+    drop(root);
+}

--- a/pacquet/crates/config/src/env_overlay.rs
+++ b/pacquet/crates/config/src/env_overlay.rs
@@ -18,7 +18,7 @@
 
 use crate::{
     AuditLevel, CatalogMode, HoistingLimits, NodeLinker, NodePackageMapType, PackageImportMethod,
-    ResolutionMode, ScriptsPrependNodePath, TrustPolicy, WorkspaceSettings, api::EnvVar,
+    PmOnFail, ResolutionMode, ScriptsPrependNodePath, TrustPolicy, WorkspaceSettings, api::EnvVar,
 };
 use serde::de::DeserializeOwned;
 
@@ -209,6 +209,7 @@ impl WorkspaceSettings {
         json_field!(minimum_release_age_strict, "MINIMUM_RELEASE_AGE_STRICT");
         json_field!(trust_lockfile, "TRUST_LOCKFILE");
         enum_field!(trust_policy, "TRUST_POLICY", TrustPolicy);
+        enum_field!(pm_on_fail, "PM_ON_FAIL", PmOnFail);
         enum_field!(audit_level, "AUDIT_LEVEL", AuditLevel);
         json_field!(audit_config, "AUDIT_CONFIG");
         json_field!(trust_policy_exclude, "TRUST_POLICY_EXCLUDE");

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -124,6 +124,28 @@ pub enum TrustPolicy {
     NoDowngrade,
 }
 
+/// What to do when the project's `packageManager` /
+/// `devEngines.packageManager` field doesn't match the running pnpm.
+///
+/// Mirrors pnpm's
+/// [`pmOnFail`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/Config.ts#L272)
+/// setting (`'download' | 'error' | 'warn' | 'ignore'`). `download`
+/// switches to the pinned version, `error` aborts, `warn` prints a
+/// warning, and `ignore` skips the check entirely. The documented
+/// default is `download`, so [`Config::pm_on_fail`] stays optional and the
+/// package-manager check applies the fallback when the setting is unset.
+///
+/// `pnpm with current <cmd>` runs `<cmd>` with `pmOnFail` forced to
+/// [`PmOnFail::Ignore`] via the `pnpm_config_pm_on_fail` env var.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PmOnFail {
+    Download,
+    Error,
+    Warn,
+    Ignore,
+}
+
 /// Minimum advisory severity shown by `pnpm audit`.
 ///
 /// Mirrors `Config.auditLevel` in pnpm's config reader. The command-level
@@ -1414,6 +1436,13 @@ pub struct Config {
     /// Trust-evidence policy applied to lockfile entries; see
     /// [`TrustPolicy`].
     pub trust_policy: TrustPolicy,
+
+    /// `pm-on-fail` / `pmOnFail` config: what to do when the project's
+    /// `packageManager` / `devEngines.packageManager` pin doesn't match the
+    /// running pnpm. See [`PmOnFail`]. Stays optional so the
+    /// package-manager check applies the documented `download` default
+    /// when unset.
+    pub pm_on_fail: Option<PmOnFail>,
 
     /// `audit-level` / `auditLevel` config for `pnpm audit`.
     pub audit_level: Option<AuditLevel>,

--- a/pacquet/crates/config/src/workspace_yaml.rs
+++ b/pacquet/crates/config/src/workspace_yaml.rs
@@ -1,7 +1,7 @@
 use crate::{
     AuditConfig, AuditLevel, CatalogMode, Config, HoistingLimits, LinkWorkspacePackages,
-    NodeLinker, NodePackageMapType, PackageImportMethod, ResolutionMode, ScriptsPrependNodePath,
-    TrustPolicy, api::EnvVar, resolve_child_concurrency,
+    NodeLinker, NodePackageMapType, PackageImportMethod, PmOnFail, ResolutionMode,
+    ScriptsPrependNodePath, TrustPolicy, api::EnvVar, resolve_child_concurrency,
 };
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
@@ -384,6 +384,9 @@ pub struct WorkspaceSettings {
 
     /// `trustPolicy` from `pnpm-workspace.yaml`. See [`TrustPolicy`].
     pub trust_policy: Option<TrustPolicy>,
+
+    /// `pmOnFail` from `pnpm-workspace.yaml`. See [`PmOnFail`].
+    pub pm_on_fail: Option<PmOnFail>,
 
     /// `auditLevel` from `pnpm-workspace.yaml`.
     pub audit_level: Option<AuditLevel>,
@@ -893,6 +896,9 @@ impl WorkspaceSettings {
         }
         if let Some(v) = self.trust_policy {
             config.trust_policy = v;
+        }
+        if let Some(v) = self.pm_on_fail {
+            config.pm_on_fail = Some(v);
         }
         if let Some(v) = self.audit_level {
             config.audit_level = Some(v);

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -122,6 +122,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         minimum_release_age_strict: None,
         trust_lockfile: false,
         trust_policy: Default::default(),
+        pm_on_fail: None,
         audit_level: None,
         audit_config: Default::default(),
         trust_policy_exclude: None,


### PR DESCRIPTION
## Summary

Ports pnpm's `with` command to the Rust `pacquet/` port (the TypeScript CLI already ships it, so this is the pacquet side catching up — no TypeScript change).

- **`pnpm with <version> <args...>`** — resolves the spec (version / range / dist-tag) through the trusted package-manager bootstrap registry, installs that pnpm engine into the **global virtual store** (`<store>/links/...`, matching pnpm's `installPnpmToStore`: shared across invocations and, unlike `self-update`, not registered in the global packages directory so `pnpm ls -g` doesn't see it), then spawns it with the remaining args and the child's `packageManager` / `devEngines.packageManager` check disabled.
- **`pnpm with current <args...>`** — rewritten before clap parses argv into a direct in-process dispatch of `<args>`, forcing `pmOnFail` to `ignore` via the `pnpm_config_pm_on_fail` env var.

Implementation notes:

- **GVS install fidelity.** The engine is installed with the global virtual store enabled and `pnpm` / `` `@pnpm/exe` `` marked buildable, so `ENGINE_NAME` is folded into the GVS hash exactly as pnpm's `findPnpmGvsPath` does. To avoid any hash-mismatch risk, the install is **located via its post-install symlink** (ground truth), while the pipeline's own `VirtualStoreLayout` drives the cache-hit short-circuit — so install and locate are guaranteed consistent, and a cache hit skips both the re-install and the network signature check, like pnpm.
- **Reuse.** The `self-update` engine installer was made global-virtual-store aware and its engine-identity verifier + native-binary linker promoted to `pub(crate)`, so `with` reuses the proven, signature-verifying install path instead of duplicating it.
- **`pmOnFail` setting** is wired into `Config` and the env overlay so the override is honored once the runtime `packageManager` check is ported (the check itself is not ported yet).

## Squash Commit Body

```text
Port pnpm's `with` command to pacquet.

`pnpm with <version> <args...>` resolves the spec through the trusted
package-manager bootstrap registry, installs that pnpm engine into the
global virtual store (matching pnpm's installPnpmToStore — shared across
invocations and, unlike self-update, not registered in the global
packages directory), and spawns it with the remaining args and the
child's packageManager check disabled.

`pnpm with current <args...>` is rewritten before clap parses argv into a
direct in-process dispatch of `<args>`, forcing pmOnFail to ignore via
the pnpm_config_pm_on_fail env var.

Wire the pmOnFail setting into Config and the env overlay so the override
is honored once the packageManager check is ported. Reuse the self-update
engine installer (now global-virtual-store aware) and the engine-identity
verifier rather than duplicating them.

The end-to-end `with <version>` download path has no automated test
because the mock registry does not serve the pnpm / `@pnpm/exe` engine
packages, the same limitation self-update has.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting. _(The
  TypeScript CLI already has `with`; this is the pacquet port.)_
- [x] Added or updated tests. _(`with_current` argv-rewrite unit tests +
  `with` integration tests for the usage errors and the `with current`
  rewrite. The end-to-end `with <version>` download path is not covered
  because the mock registry doesn't serve the pnpm / `` `@pnpm/exe` ``
  engine packages — the same limitation `self-update` has.)_

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `with` command to run pnpm for a specified version (or `current`) in a single invocation.
  * Added `with current` shorthand for inline commands.
  * Added `pmOnFail` / `PM_ON_FAIL` support across configuration, workspace YAML, and environment overrides.
* **Bug Fixes**
  * Improved `with`/`with current` validation and diagnostics for missing spec/command and safer argument handling.
  * Prevents running under corepack and forwards pnpm spawn failures correctly.
  * Adds a PATH delimiter safety check for the shared pnpm install. 
* **Tests**
  * Added/expanded unit and CLI test coverage for `with` and `with current`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->