### PR TITLE
feat(pacquet-cli): port the setup command

### DIFF
--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -41,6 +41,7 @@ pub mod runtime;
 pub mod sanitize;
 pub mod self_update;
 pub mod set_script;
+pub mod setup;
 pub mod stop;
 pub mod store;
 pub mod supported_architectures;

--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -38,6 +38,7 @@ use super::{
     runtime::RuntimeArgs,
     self_update::SelfUpdateArgs,
     set_script::SetScriptArgs,
+    setup::SetupArgs,
     stop::StopArgs,
     store::StoreCommand,
     unlink::UnlinkArgs,
@@ -224,4 +225,6 @@ pub enum CliCommand {
     Docs(DocsArgs),
     /// Updates pnpm to the latest version (or the one specified)
     SelfUpdate(SelfUpdateArgs),
+    /// Sets up pnpm
+    Setup(SetupArgs),
 }

--- a/pacquet/crates/cli/src/cli_args/dispatch.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch.rs
@@ -272,6 +272,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::Unlink(args) => dispatch_install::unlink(ctx, args),
         CliCommand::Docs(args) => dispatch_query::docs(ctx, args),
         CliCommand::SelfUpdate(args) => dispatch_query::self_update(ctx, args),
+        CliCommand::Setup(args) => dispatch_query::setup(ctx, args),
         CliCommand::Completion(_) | CliCommand::CompletionServer(_) => {
             unreachable!("completion returns before configuration")
         }

--- a/pacquet/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_query.rs
@@ -17,6 +17,7 @@ use super::{
     reporter::ReporterType,
     root::RootArgs,
     self_update::SelfUpdateArgs,
+    setup::SetupArgs,
     store::StoreCommand,
     why::WhyArgs,
 };
@@ -209,6 +210,26 @@ pub(super) fn self_update<'a>(
         ReporterType::Default | ReporterType::AppendOnly => run_self_update!(DefaultReporter),
         ReporterType::Ndjson => run_self_update!(NdjsonReporter),
         ReporterType::Silent => run_self_update!(SilentReporter),
+    })
+}
+
+// `setup` makes pnpm available globally: it installs the CLI into the
+// global packages dir, writes the alias scripts, and persists `PNPM_HOME` /
+// PATH into the user's shell rc file (POSIX) or registry (Windows). It needs
+// a reporter for the "Installing pnpm CLI globally" log but no project
+// config or lockfile, so it dispatches off `ctx.dir` like the other
+// reporter-typed commands.
+pub(super) fn setup<'a>(ctx: &RunCtx<'a>, args: SetupArgs) -> miette::Result<CommandFuture<'a>> {
+    let dir = ctx.dir;
+    macro_rules! run_setup {
+        ($reporter:ty) => {
+            Box::pin(args.run::<$reporter>(dir))
+        };
+    }
+    Ok(match ctx.reporter {
+        ReporterType::Default | ReporterType::AppendOnly => run_setup!(DefaultReporter),
+        ReporterType::Ndjson => run_setup!(NdjsonReporter),
+        ReporterType::Silent => run_setup!(SilentReporter),
     })
 }
 

--- a/pacquet/crates/cli/src/cli_args/setup.rs
+++ b/pacquet/crates/cli/src/cli_args/setup.rs
@@ -1,0 +1,212 @@
+//! `pacquet setup` — make pnpm available for global use.
+//!
+//! Ports pnpm's
+//! [`setup` command](https://github.com/pnpm/pnpm/blob/a33eeec9cd/pnpm11/engine/pm/commands/src/setup/setup.ts):
+//! the CLI is installed into the global packages directory, the `pn` /
+//! `pnpx` / `pnx` alias scripts are written into `$PNPM_HOME/bin`, and
+//! `PNPM_HOME` plus `$PNPM_HOME/bin` are added to the user's environment
+//! (the shell rc file on POSIX, the registry on Windows).
+
+mod path_extender;
+
+use clap::Args;
+use miette::{Context, IntoDiagnostic};
+use pacquet_config::{Host, PACQUET_VERSION, default_pnpm_home_dir};
+use pacquet_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
+use path_extender::{
+    AddDirToEnvPathOpts, AddingPosition, ConfigFileChangeType, ConfigReport, PathExtenderReport,
+};
+use std::{fs, path::Path, process::Command};
+
+#[derive(Debug, Args)]
+pub struct SetupArgs {
+    /// Override the `PNPM_HOME` env variable in case it already exists.
+    // `help` carries the verbatim pnpm wording (un-backticked) for `--help`,
+    // while the doc comment keeps backticks for rustdoc.
+    #[clap(
+        long,
+        short = 'f',
+        help = "Override the PNPM_HOME env variable in case it already exists"
+    )]
+    pub force: bool,
+}
+
+impl SetupArgs {
+    pub async fn run<Reporter: self::Reporter + 'static>(self, dir: &Path) -> miette::Result<()> {
+        let output = handler::<Reporter>(self.force, dir)?;
+        println!("{output}");
+        Ok(())
+    }
+}
+
+fn handler<Reporter: self::Reporter + 'static>(force: bool, dir: &Path) -> miette::Result<String> {
+    let pnpm_home_dir = default_pnpm_home_dir::<Host>().ok_or_else(|| {
+        miette::miette!(
+            "Could not determine the pnpm home directory. Set the PNPM_HOME environment variable."
+        )
+    })?;
+    let bin_dir = pnpm_home_dir.join("bin");
+
+    let exec_path = std::env::current_exe()
+        .into_diagnostic()
+        .wrap_err("determine the path to the pnpm executable")?;
+    // pacquet is always a native executable (never a `.js` entrypoint), so
+    // pnpm's single-executable branch always applies: install the CLI
+    // globally and write the alias scripts.
+    install_cli_globally::<Reporter>(&exec_path, &pnpm_home_dir, dir)?;
+    create_alias_scripts(&bin_dir).into_diagnostic().wrap_err("create the pnpm alias scripts")?;
+
+    let report = path_extender::add_dir_to_env_path(
+        &pnpm_home_dir,
+        &AddDirToEnvPathOpts {
+            config_section_name: "pnpm",
+            proxy_var_name: Some("PNPM_HOME"),
+            proxy_var_sub_dir: Some("bin"),
+            overwrite: force,
+            position: AddingPosition::Start,
+        },
+    )?;
+    Ok(render_setup_output(&report))
+}
+
+/// Install the CLI as a global package using `pnpm add -g file:<dir>`,
+/// placing it in the standard global directory alongside other globally
+/// installed packages. Mirrors pnpm's `installCliGlobally`.
+fn install_cli_globally<Reporter: self::Reporter + 'static>(
+    exec_path: &Path,
+    pnpm_home_dir: &Path,
+    prefix_dir: &Path,
+) -> miette::Result<()> {
+    let exec_dir = exec_path
+        .parent()
+        .ok_or_else(|| miette::miette!("the pnpm executable has no parent directory"))?;
+    let exec_name = exec_path
+        .file_name()
+        .ok_or_else(|| miette::miette!("the pnpm executable has no file name"))?
+        .to_string_lossy()
+        .into_owned();
+    let pkg_json_path = exec_dir.join("package.json");
+
+    // Write a package.json if one doesn't already exist. (Updated tarballs
+    // ship with package.json already.)
+    let created_pkg_json = !pkg_json_path.exists();
+    if created_pkg_json {
+        let pkg = serde_json::json!({
+            "name": "@pnpm/exe",
+            "version": PACQUET_VERSION,
+            "bin": { "pnpm": exec_name, "pn": exec_name },
+        });
+        fs::write(&pkg_json_path, pkg.to_string())
+            .into_diagnostic()
+            .wrap_err("write the temporary package.json next to the pnpm executable")?;
+    }
+
+    info::<Reporter>(
+        &prefix_dir.to_string_lossy(),
+        &format!("Installing pnpm CLI globally from {}", exec_dir.display()),
+    );
+
+    // `@pnpm/exe` ships a preinstall/prepare pair that hardlinks the
+    // platform-specific binary out of its optional platform packages. None
+    // of that applies here: this `file:` dependency is the standalone
+    // executable itself, the platform packages aren't installed alongside
+    // it, and the host may have no `node` to run the scripts. Skipping them
+    // also avoids a build-approval prompt for pnpm's own install. See
+    // <https://github.com/pnpm/pnpm/issues/12377>.
+    let bin_dir = pnpm_home_dir.join("bin");
+    let separator = if cfg!(windows) { ";" } else { ":" };
+    let path_value =
+        format!("{}{separator}{}", bin_dir.display(), std::env::var("PATH").unwrap_or_default());
+    let status = Command::new(exec_path)
+        .args(["add", "-g", "--ignore-scripts", &format!("file:{}", exec_dir.display())])
+        .env("PNPM_HOME", pnpm_home_dir)
+        .env("PATH", path_value)
+        .status();
+
+    if created_pkg_json {
+        let _ = fs::remove_file(&pkg_json_path);
+    }
+
+    let status = status.into_diagnostic().wrap_err("run the global pnpm install")?;
+    if !status.success() {
+        let code = status.code().map_or_else(|| "unknown".to_string(), |code| code.to_string());
+        return Err(miette::miette!("Failed to install pnpm globally (exit code {code})"));
+    }
+    Ok(())
+}
+
+/// Write the `pn` / `pnpx` / `pnx` wrapper scripts into `$PNPM_HOME/bin`.
+/// Mirrors pnpm's `createAliasScripts`.
+///
+/// Script files are used instead of shell aliases because aliases don't work
+/// across all shells (Windows `cmd`, POSIX `sh`) or environments
+/// (non-interactive, CI), can't be located with `which` / `where`, and
+/// editing rc files is more error-prone than writing files.
+fn create_alias_scripts(target_dir: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(target_dir)?;
+    create_shell_script(target_dir, "pn", "pnpm")?;
+    create_shell_script(target_dir, "pnpx", "pnpm dlx")?;
+    create_shell_script(target_dir, "pnx", "pnpm dlx")?;
+    Ok(())
+}
+
+fn create_shell_script(target_dir: &Path, name: &str, command: &str) -> std::io::Result<()> {
+    // Windows can also run shell scripts via mingw / cygwin, so write the
+    // POSIX script unconditionally.
+    let shell_script = format!("#!/bin/sh\nexec {command} \"$@\"\n");
+    let script_path = target_dir.join(name);
+    fs::write(&script_path, shell_script)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755))?;
+    }
+
+    if cfg!(windows) {
+        fs::write(target_dir.join(format!("{name}.cmd")), format!("@echo off\n{command} %*\n"))?;
+        fs::write(target_dir.join(format!("{name}.ps1")), format!("{command} @args\n"))?;
+    }
+    Ok(())
+}
+
+/// Render the user-facing summary of what changed. Mirrors pnpm's
+/// `renderSetupOutput`.
+fn render_setup_output(report: &PathExtenderReport) -> String {
+    if report.old_settings == report.new_settings {
+        return "No changes to the environment were made. Everything is already up to date."
+            .to_string();
+    }
+    let mut output = Vec::new();
+    if let Some(config_file) = &report.config_file {
+        output.push(report_config_change(config_file));
+    }
+    output.push(format!("Next configuration changes were made:\n{}", report.new_settings));
+    match &report.config_file {
+        None => output.push("Setup complete. Open a new terminal to start using pnpm.".to_string()),
+        Some(config_file) if config_file.change_type != ConfigFileChangeType::Skipped => output
+            .push(format!("To start using pnpm, run:\nsource {}\n", config_file.path.display())),
+        Some(_) => {}
+    }
+    output.join("\n\n")
+}
+
+fn report_config_change(config_report: &ConfigReport) -> String {
+    let path = config_report.path.display();
+    match config_report.change_type {
+        ConfigFileChangeType::Created => format!("Created {path}"),
+        ConfigFileChangeType::Appended => format!("Appended new lines to {path}"),
+        ConfigFileChangeType::Modified => format!("Replaced configuration in {path}"),
+        ConfigFileChangeType::Skipped => format!("Configuration already up to date in {path}"),
+    }
+}
+
+fn info<Reporter: self::Reporter>(prefix: &str, message: &str) {
+    Reporter::emit(&LogEvent::Pnpm(PnpmLog {
+        level: LogLevel::Info,
+        message: message.to_string(),
+        prefix: prefix.to_string(),
+    }));
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/setup.rs
+++ b/pacquet/crates/cli/src/cli_args/setup.rs
@@ -113,25 +113,32 @@ fn install_cli_globally<Reporter: self::Reporter + 'static>(
     // it, and the host may have no `node` to run the scripts. Skipping them
     // also avoids a build-approval prompt for pnpm's own install. See
     // <https://github.com/pnpm/pnpm/issues/12377>.
-    let bin_dir = pnpm_home_dir.join("bin");
     let separator = if cfg!(windows) { ";" } else { ":" };
-    let path_value =
-        format!("{}{separator}{}", bin_dir.display(), std::env::var("PATH").unwrap_or_default());
+    // Build `PATH` as an `OsString` so a non-UTF-8 ambient `PATH` is
+    // preserved verbatim rather than lost to a lossy string conversion.
+    let mut path_value = pnpm_home_dir.join("bin").into_os_string();
+    path_value.push(separator);
+    if let Some(existing) = std::env::var_os("PATH") {
+        path_value.push(existing);
+    }
     let status = Command::new(exec_path)
         .args(["add", "-g", "--ignore-scripts", &format!("file:{}", exec_dir.display())])
         .env("PNPM_HOME", pnpm_home_dir)
         .env("PATH", path_value)
         .status();
 
-    if created_pkg_json {
-        let _ = fs::remove_file(&pkg_json_path);
-    }
+    // Mirror pnpm's `try { spawn } finally { unlink }`: always attempt the
+    // cleanup, but let the install error take precedence over a cleanup error.
+    let cleanup = if created_pkg_json { fs::remove_file(&pkg_json_path) } else { Ok(()) };
 
     let status = status.into_diagnostic().wrap_err("run the global pnpm install")?;
     if !status.success() {
         let code = status.code().map_or_else(|| "unknown".to_string(), |code| code.to_string());
         return Err(miette::miette!("Failed to install pnpm globally (exit code {code})"));
     }
+    cleanup
+        .into_diagnostic()
+        .wrap_err("remove the temporary package.json next to the pnpm executable")?;
     Ok(())
 }
 

--- a/pacquet/crates/cli/src/cli_args/setup.rs
+++ b/pacquet/crates/cli/src/cli_args/setup.rs
@@ -45,6 +45,9 @@ fn handler<Reporter: self::Reporter + 'static>(force: bool, dir: &Path) -> miett
             "Could not determine the pnpm home directory. Set the PNPM_HOME environment variable."
         )
     })?;
+    // Validate before any side effect: an unsafe `PNPM_HOME` must not reach
+    // the self-install subprocess's `PATH` or the alias-script writes.
+    path_extender::validate_pnpm_home_dir(&pnpm_home_dir)?;
     let bin_dir = pnpm_home_dir.join("bin");
 
     let exec_path = std::env::current_exe()

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender.rs
@@ -1,0 +1,186 @@
+//! Add a directory (and an optional proxy variable such as `PNPM_HOME`) to
+//! the user's `PATH` persistently.
+//!
+//! Ports pnpm's
+//! [`@pnpm/os.env.path-extender`](https://github.com/pnpm/pnpm/blob/1819226b51/packages/path-extender/src/path-extender.ts):
+//! on Windows the user registry is edited; on every other platform the
+//! current shell's rc file is edited. The Windows changes are rendered into
+//! the same `old_settings` / `new_settings` shape the POSIX path reports.
+
+mod posix;
+mod windows;
+
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use std::path::PathBuf;
+
+/// Where the new directory is inserted into `PATH`. Mirrors pnpm's
+/// `AddingPosition` (defaulting to `start`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum AddingPosition {
+    Start,
+    // `setup` always inserts at the start, but `end` is part of the ported
+    // path-extender contract (and exercised by the renderer tests), so the
+    // renderers keep handling it to stay aligned with upstream pnpm.
+    #[allow(dead_code, reason = "ported path-extender API; setup only uses Start")]
+    End,
+}
+
+/// How the shell config file changed. Mirrors pnpm's `ConfigFileChangeType`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ConfigFileChangeType {
+    Skipped,
+    Appended,
+    Modified,
+    Created,
+}
+
+/// The config file that was touched and how. `None` on Windows, where the
+/// registry — not a file — is edited. Mirrors pnpm's `ConfigReport`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ConfigReport {
+    pub path: PathBuf,
+    pub change_type: ConfigFileChangeType,
+}
+
+/// The before/after of a path-extension run. Mirrors pnpm's
+/// `PathExtenderReport`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PathExtenderReport {
+    pub config_file: Option<ConfigReport>,
+    pub old_settings: String,
+    pub new_settings: String,
+}
+
+/// Options for [`add_dir_to_env_path`]. Mirrors pnpm's
+/// `AddDirToPosixEnvPathOpts` (the superset the public `addDirToEnvPath`
+/// accepts).
+pub(super) struct AddDirToEnvPathOpts<'a> {
+    pub config_section_name: &'a str,
+    pub proxy_var_name: Option<&'a str>,
+    pub proxy_var_sub_dir: Option<&'a str>,
+    pub overwrite: bool,
+    pub position: AddingPosition,
+}
+
+/// Errors raised while extending `PATH`. Codes mirror pnpm's `PnpmError`
+/// codes (pnpm prefixes them with `ERR_PNPM_`).
+#[derive(Debug, Display, Error, Diagnostic)]
+pub(crate) enum PathExtenderError {
+    #[display(
+        r#"The config file at "{}" already contains a {config_section_name} section but with other configuration"#,
+        config_file.display(),
+    )]
+    #[diagnostic(
+        code(ERR_PNPM_BAD_SHELL_SECTION),
+        help("If you want to override the existing configuration section, use the --force option")
+    )]
+    BadShellSection { config_file: PathBuf, config_section_name: String },
+
+    #[display("Could not infer shell type.")]
+    #[diagnostic(
+        code(ERR_PNPM_UNKNOWN_SHELL),
+        help(
+            "Set the SHELL environment variable to your active shell.\nSupported shell languages are bash, zsh, fish, ksh, dash, sh, and nushell."
+        )
+    )]
+    UnknownShell,
+
+    #[display(r#"Can't setup configuration for "{shell}" shell"#)]
+    #[diagnostic(
+        code(ERR_PNPM_UNSUPPORTED_SHELL),
+        help("Supported shell languages are bash, zsh, fish, ksh, dash, sh, and nushell.")
+    )]
+    UnsupportedShell { shell: String },
+
+    #[display("Cannot find a config file for {shell}. The ENV environment variable is not set.")]
+    #[diagnostic(code(ERR_PNPM_NO_SHELL_CONFIG))]
+    NoShellConfig { shell: String },
+
+    #[display("Could not determine the home directory")]
+    NoHomeDir,
+
+    #[display(r#"Invalid proxyVarSubDir: "{sub_dir}""#)]
+    #[diagnostic(code(ERR_PNPM_INVALID_SUBDIR))]
+    InvalidSubDir { sub_dir: String },
+
+    #[display("Currently '{env_name}' is set to '{wanted_value}'")]
+    #[diagnostic(
+        code(ERR_PNPM_BAD_ENV_FOUND),
+        help("If you want to override the existing env variable, use the --force option")
+    )]
+    BadEnvFound { env_name: String, wanted_value: String },
+
+    #[display("exec chcp failed: {message}")]
+    #[diagnostic(code(ERR_PNPM_CHCP))]
+    Chcp { message: String },
+
+    #[display("win32 registry environment values could not be retrieved")]
+    #[diagnostic(code(ERR_PNPM_REG_READ))]
+    RegRead,
+
+    #[display(r#""Path" environment variable is not found in the registry"#)]
+    #[diagnostic(code(ERR_PNPM_NO_PATH))]
+    NoPath,
+
+    #[display(r#"Failed to set "{env_name}" to "{value}": {stderr}"#)]
+    #[diagnostic(code(ERR_PNPM_FAILED_SET_ENV))]
+    FailedSetEnv { env_name: String, value: String, stderr: String },
+
+    #[display("{_0}")]
+    Io(std::io::Error),
+}
+
+impl From<std::io::Error> for PathExtenderError {
+    fn from(err: std::io::Error) -> Self {
+        PathExtenderError::Io(err)
+    }
+}
+
+/// Persistently add `dir` to the user's `PATH`. The proxy-variable
+/// indirection (`PNPM_HOME` → `$PNPM_HOME/bin`) keeps the `PATH` entry
+/// stable when the home directory moves. Mirrors pnpm's `addDirToEnvPath`.
+pub(super) fn add_dir_to_env_path(
+    dir: &std::path::Path,
+    opts: &AddDirToEnvPathOpts,
+) -> Result<PathExtenderReport, PathExtenderError> {
+    if let Some(sub_dir) = opts.proxy_var_sub_dir
+        && (sub_dir.starts_with('/')
+            || sub_dir.starts_with('\\')
+            || sub_dir.contains("..")
+            || sub_dir.contains([';', '%', '"', '\'', '`', '$', '<', '>', '&', '|', '\n', '\r']))
+    {
+        return Err(PathExtenderError::InvalidSubDir { sub_dir: sub_dir.to_string() });
+    }
+    // Per-target compilation: the Windows registry path and the POSIX
+    // rc-file path are both compiled everywhere, and `cfg!(windows)` selects
+    // the right one at runtime, mirroring pnpm's `process.platform` branch.
+    if cfg!(windows) {
+        let changes = windows::add_dir_to_windows_env_path(dir, opts)?;
+        Ok(render_windows_report(&changes))
+    } else {
+        posix::add_dir_to_posix_env_path(dir, opts)
+    }
+}
+
+/// Render the per-variable Windows registry changes into the file-oriented
+/// report shape. Mirrors pnpm's `renderWindowsReport`.
+fn render_windows_report(changes: &[windows::EnvVariableChange]) -> PathExtenderReport {
+    let mut old_settings = Vec::new();
+    let mut new_settings = Vec::new();
+    for change in changes {
+        if let Some(old_value) = &change.old_value
+            && !old_value.is_empty()
+        {
+            old_settings.push(format!("{}={}", change.variable, old_value));
+        }
+        if !change.new_value.is_empty() {
+            new_settings.push(format!("{}={}", change.variable, change.new_value));
+        }
+    }
+    PathExtenderReport {
+        config_file: None,
+        old_settings: old_settings.join("\n"),
+        new_settings: new_settings.join("\n"),
+    }
+}

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender.rs
@@ -104,15 +104,15 @@ pub(crate) enum PathExtenderError {
     #[diagnostic(code(ERR_PNPM_INVALID_SUBDIR))]
     InvalidSubDir { sub_dir: String },
 
-    // Hardening beyond pnpm's `@pnpm/os.env.path-extender`: a `;`, `%`, or
-    // newline in `PNPM_HOME` would split the persisted Windows `Path` into
-    // extra entries (or break `%PNPM_HOME%` expansion), so it is rejected
-    // rather than written to the registry.
+    // Hardening beyond pnpm's `@pnpm/os.env.path-extender`: a path-separator
+    // (`:` on POSIX, `;` on Windows), a `%` (Windows `%PNPM_HOME%`
+    // expansion), or a newline in `PNPM_HOME` would split the persisted
+    // `PATH` into extra entries, so it is rejected rather than written.
     #[display(
-        r#"The pnpm home directory "{dir}" contains a character ({character:?}) that is unsafe for the Windows PATH"#
+        r#"The pnpm home directory "{dir}" contains a character ({character:?}) that is unsafe for the PATH"#
     )]
     #[diagnostic(code(ERR_PNPM_INVALID_PNPM_HOME))]
-    UnsafePnpmHomeForWindows { dir: String, character: char },
+    UnsafePnpmHome { dir: String, character: char },
 
     #[display("Currently '{env_name}' is set to '{wanted_value}'")]
     #[diagnostic(
@@ -143,11 +143,20 @@ pub(crate) enum PathExtenderError {
 
     #[display("{_0}")]
     Io(std::io::Error),
+
+    #[display("{_0}")]
+    EnsureFile(pacquet_fs::EnsureFileError),
 }
 
 impl From<std::io::Error> for PathExtenderError {
     fn from(err: std::io::Error) -> Self {
         PathExtenderError::Io(err)
+    }
+}
+
+impl From<pacquet_fs::EnsureFileError> for PathExtenderError {
+    fn from(err: pacquet_fs::EnsureFileError) -> Self {
+        PathExtenderError::EnsureFile(err)
     }
 }
 

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender.rs
@@ -12,7 +12,7 @@ mod windows;
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Where the new directory is inserted into `PATH`. Mirrors pnpm's
 /// `AddingPosition` (defaulting to `start`).
@@ -160,11 +160,40 @@ impl From<pacquet_fs::EnsureFileError> for PathExtenderError {
     }
 }
 
+/// Reject a pnpm home directory whose characters would split or corrupt the
+/// persisted `PATH` on the current platform. Call this *before* any side
+/// effect (the global self-install, the alias scripts) so an unsafe
+/// `PNPM_HOME` can never influence the install subprocess's environment or
+/// leave partial state behind. The platform implementations re-check as
+/// defense in depth.
+pub(super) fn validate_pnpm_home_dir(dir: &Path) -> Result<(), PathExtenderError> {
+    if cfg!(windows) { validate_windows_pnpm_home(dir) } else { validate_posix_pnpm_home(dir) }
+}
+
+/// Reject `:` (the POSIX `PATH` separator), newlines, and NUL.
+pub(super) fn validate_posix_pnpm_home(dir: &Path) -> Result<(), PathExtenderError> {
+    reject_unsafe_chars(dir, &[':', '\n', '\r', '\0'])
+}
+
+/// Reject `;` (the Windows `Path` separator), `%` (`%PNPM_HOME%` expansion),
+/// and newlines. `:` is allowed because Windows paths contain drive letters.
+pub(super) fn validate_windows_pnpm_home(dir: &Path) -> Result<(), PathExtenderError> {
+    reject_unsafe_chars(dir, &[';', '%', '\n', '\r'])
+}
+
+fn reject_unsafe_chars(dir: &Path, unsafe_chars: &[char]) -> Result<(), PathExtenderError> {
+    let dir = dir.to_string_lossy();
+    if let Some(character) = dir.chars().find(|character| unsafe_chars.contains(character)) {
+        return Err(PathExtenderError::UnsafePnpmHome { dir: dir.into_owned(), character });
+    }
+    Ok(())
+}
+
 /// Persistently add `dir` to the user's `PATH`. The proxy-variable
 /// indirection (`PNPM_HOME` → `$PNPM_HOME/bin`) keeps the `PATH` entry
 /// stable when the home directory moves. Mirrors pnpm's `addDirToEnvPath`.
 pub(super) fn add_dir_to_env_path(
-    dir: &std::path::Path,
+    dir: &Path,
     opts: &AddDirToEnvPathOpts,
 ) -> Result<PathExtenderReport, PathExtenderError> {
     if let Some(sub_dir) = opts.proxy_var_sub_dir

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender.rs
@@ -104,6 +104,16 @@ pub(crate) enum PathExtenderError {
     #[diagnostic(code(ERR_PNPM_INVALID_SUBDIR))]
     InvalidSubDir { sub_dir: String },
 
+    // Hardening beyond pnpm's `@pnpm/os.env.path-extender`: a `;`, `%`, or
+    // newline in `PNPM_HOME` would split the persisted Windows `Path` into
+    // extra entries (or break `%PNPM_HOME%` expansion), so it is rejected
+    // rather than written to the registry.
+    #[display(
+        r#"The pnpm home directory "{dir}" contains a character ({character:?}) that is unsafe for the Windows PATH"#
+    )]
+    #[diagnostic(code(ERR_PNPM_INVALID_PNPM_HOME))]
+    UnsafePnpmHomeForWindows { dir: String, character: char },
+
     #[display("Currently '{env_name}' is set to '{wanted_value}'")]
     #[diagnostic(
         code(ERR_PNPM_BAD_ENV_FOUND),

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender.rs
@@ -125,6 +125,10 @@ pub(crate) enum PathExtenderError {
     #[diagnostic(code(ERR_PNPM_CHCP))]
     Chcp { message: String },
 
+    #[display("`{command}` failed: {stderr}")]
+    #[diagnostic(code(ERR_PNPM_SETUP_COMMAND_FAILED))]
+    CommandFailed { command: String, stderr: String },
+
     #[display("win32 registry environment values could not be retrieved")]
     #[diagnostic(code(ERR_PNPM_REG_READ))]
     RegRead,

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/posix.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/posix.rs
@@ -247,14 +247,14 @@ fn update_shell_config(
         if let Some(parent) = config_file.parent() {
             fs::create_dir_all(parent)?;
         }
-        fs::write(config_file, format!("{new_content}\n"))?;
+        write_atomic(config_file, &format!("{new_content}\n"))?;
         return Ok((ConfigFileChangeType::Created, String::new()));
     }
     let config_content = fs::read_to_string(config_file)?;
     let Some((matched_range, old_settings)) =
         find_section(&config_content, opts.config_section_name)
     else {
-        fs::write(config_file, format!("{config_content}\n{new_content}\n"))?;
+        write_atomic(config_file, &format!("{config_content}\n{new_content}\n"))?;
         return Ok((ConfigFileChangeType::Appended, String::new()));
     };
     if &config_content[matched_range] != new_content {
@@ -266,10 +266,34 @@ fn update_shell_config(
         }
         let new_config_content =
             replace_section(&config_content, new_content, opts.config_section_name);
-        fs::write(config_file, new_config_content)?;
+        write_atomic(config_file, &new_config_content)?;
         return Ok((ConfigFileChangeType::Modified, old_settings));
     }
     Ok((ConfigFileChangeType::Skipped, old_settings))
+}
+
+/// Overwrite `path` crash-safely: write to a sibling temp file, flush it to
+/// disk, then atomically rename it over the target. A crash or disk-full
+/// error mid-write leaves the original rc file intact rather than truncated.
+fn write_atomic(path: &Path, content: &str) -> std::io::Result<()> {
+    use std::io::Write;
+    let file_name = path.file_name().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "config path has no file name")
+    })?;
+    let mut temp_name = file_name.to_os_string();
+    temp_name.push(".pnpm-tmp");
+    let temp_path = path.with_file_name(temp_name);
+    let mut file = fs::File::create(&temp_path)?;
+    let write_result = file.write_all(content.as_bytes()).and_then(|()| file.sync_all());
+    if let Err(err) = write_result {
+        let _ = fs::remove_file(&temp_path);
+        return Err(err);
+    }
+    if let Err(err) = fs::rename(&temp_path, path) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(err);
+    }
+    Ok(())
 }
 
 /// Locate the `# <section>` ... `# <section> end` block, returning the byte

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/posix.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/posix.rs
@@ -1,0 +1,282 @@
+//! Extend the `PATH` (and a proxy variable like `PNPM_HOME`) by editing the
+//! current POSIX shell's rc file.
+//!
+//! Ports pnpm's
+//! [`@pnpm/os.env.path-extender-posix`](https://github.com/pnpm/pnpm/blob/1819226b51/packages/path-extender-posix/src/path-extender-posix.ts):
+//! the shell is inferred from the environment, the settings block for that
+//! shell is rendered, and a `# <section>` ... `# <section> end` block is
+//! created in / appended to / replaced in the rc file.
+
+use super::{
+    AddDirToEnvPathOpts, AddingPosition, ConfigFileChangeType, ConfigReport, PathExtenderError,
+    PathExtenderReport,
+};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+pub(super) fn add_dir_to_posix_env_path(
+    dir: &Path,
+    opts: &AddDirToEnvPathOpts,
+) -> Result<PathExtenderReport, PathExtenderError> {
+    let current_shell = detect_current_shell();
+    update_shell(current_shell.as_deref(), dir, opts)
+}
+
+/// Mirrors pnpm's `detectCurrentShell`: a shell-specific version variable
+/// wins, then the basename of `$SHELL`.
+fn detect_current_shell() -> Option<String> {
+    if std::env::var_os("ZSH_VERSION").is_some() {
+        return Some("zsh".to_string());
+    }
+    if std::env::var_os("BASH_VERSION").is_some() {
+        return Some("bash".to_string());
+    }
+    if std::env::var_os("FISH_VERSION").is_some() {
+        return Some("fish".to_string());
+    }
+    if std::env::var_os("NU_VERSION").is_some() {
+        return Some("nu".to_string());
+    }
+    let shell = std::env::var("SHELL").ok()?;
+    Path::new(&shell).file_name().map(|name| name.to_string_lossy().into_owned())
+}
+
+fn update_shell(
+    current_shell: Option<&str>,
+    pnpm_home_dir: &Path,
+    opts: &AddDirToEnvPathOpts,
+) -> Result<PathExtenderReport, PathExtenderError> {
+    match current_shell {
+        Some("bash" | "zsh" | "ksh" | "dash" | "sh") => {
+            // SAFETY of the unwrap: the match guarantees `current_shell` is `Some`.
+            setup_shell(current_shell.unwrap(), pnpm_home_dir, opts)
+        }
+        Some("fish") => setup_fish_shell(pnpm_home_dir, opts),
+        Some("nu") => setup_nu_shell(pnpm_home_dir, opts),
+        Some(other) => Err(PathExtenderError::UnsupportedShell { shell: other.to_string() }),
+        None => Err(PathExtenderError::UnknownShell),
+    }
+}
+
+fn setup_shell(
+    shell: &str,
+    dir: &Path,
+    opts: &AddDirToEnvPathOpts,
+) -> Result<PathExtenderReport, PathExtenderError> {
+    let config_file = get_config_file_path(shell)?;
+    let new_settings = render_posix_settings(&dir.to_string_lossy(), opts);
+    let content = wrap_settings(opts.config_section_name, &new_settings);
+    let (change_type, old_settings) = update_shell_config(&config_file, &content, opts)?;
+    Ok(PathExtenderReport {
+        config_file: Some(ConfigReport { path: config_file, change_type }),
+        old_settings,
+        new_settings,
+    })
+}
+
+/// The `# <section>` body for a POSIX `sh`-family shell. Pure so the
+/// rendering can be unit-tested without touching the filesystem.
+fn render_posix_settings(dir: &str, opts: &AddDirToEnvPathOpts) -> String {
+    if let Some(proxy) = opts.proxy_var_name {
+        let path_ref = match opts.proxy_var_sub_dir {
+            Some(sub_dir) => format!("${proxy}/{sub_dir}"),
+            None => format!("${proxy}"),
+        };
+        format!(
+            "export {proxy}=\"{dir}\"\ncase \":$PATH:\" in\n  *\":{path_ref}:\"*) ;;\n  *) export PATH=\"{path_value}\" ;;\nesac",
+            path_value = create_path_value(opts.position, &path_ref),
+        )
+    } else {
+        format!(
+            "case \":$PATH:\" in\n  *\":{dir}:\"*) ;;\n  *) export PATH=\"{path_value}\" ;;\nesac",
+            path_value = create_path_value(opts.position, dir),
+        )
+    }
+}
+
+fn create_path_value(position: AddingPosition, dir: &str) -> String {
+    match position {
+        AddingPosition::Start => format!("{dir}:$PATH"),
+        AddingPosition::End => format!("$PATH:{dir}"),
+    }
+}
+
+fn get_config_file_path(shell: &str) -> Result<PathBuf, PathExtenderError> {
+    match shell {
+        "zsh" => Ok(zdotdir_or_home()?.join(".zshrc")),
+        "dash" | "sh" => match std::env::var("ENV").ok().filter(|env| !env.is_empty()) {
+            Some(env) => Ok(PathBuf::from(env)),
+            None => Err(PathExtenderError::NoShellConfig { shell: shell.to_string() }),
+        },
+        _ => Ok(home_dir()?.join(format!(".{shell}rc"))),
+    }
+}
+
+fn setup_fish_shell(
+    dir: &Path,
+    opts: &AddDirToEnvPathOpts,
+) -> Result<PathExtenderReport, PathExtenderError> {
+    let config_file = home_dir()?.join(".config/fish/config.fish");
+    let new_settings = render_fish_settings(&dir.to_string_lossy(), opts);
+    let content = wrap_settings(opts.config_section_name, &new_settings);
+    let (change_type, old_settings) = update_shell_config(&config_file, &content, opts)?;
+    Ok(PathExtenderReport {
+        config_file: Some(ConfigReport { path: config_file, change_type }),
+        old_settings,
+        new_settings,
+    })
+}
+
+fn render_fish_settings(dir: &str, opts: &AddDirToEnvPathOpts) -> String {
+    if let Some(proxy) = opts.proxy_var_name {
+        let path_ref = match opts.proxy_var_sub_dir {
+            Some(sub_dir) => format!("${proxy}/{sub_dir}"),
+            None => format!("${proxy}"),
+        };
+        let match_pattern = match opts.proxy_var_sub_dir {
+            Some(_) => format!("\"{path_ref}\""),
+            None => path_ref.clone(),
+        };
+        format!(
+            "set -gx {proxy} \"{dir}\"\nif not string match -q -- {match_pattern} $PATH\n  set -gx PATH {path_value}\nend",
+            path_value = create_fish_path_value(opts.position, &path_ref),
+        )
+    } else {
+        format!(
+            "if not string match -q -- \"{dir}\" $PATH\n  set -gx PATH {path_value}\nend",
+            path_value = create_fish_path_value(opts.position, dir),
+        )
+    }
+}
+
+fn create_fish_path_value(position: AddingPosition, dir: &str) -> String {
+    match position {
+        AddingPosition::Start => format!("\"{dir}\" $PATH"),
+        AddingPosition::End => format!("$PATH \"{dir}\""),
+    }
+}
+
+fn setup_nu_shell(
+    dir: &Path,
+    opts: &AddDirToEnvPathOpts,
+) -> Result<PathExtenderReport, PathExtenderError> {
+    let config_file = home_dir()?.join(".config/nushell/env.nu");
+    let new_settings = render_nu_settings(&dir.to_string_lossy(), opts);
+    let content = wrap_settings(opts.config_section_name, &new_settings);
+    let (change_type, old_settings) = update_shell_config(&config_file, &content, opts)?;
+    Ok(PathExtenderReport {
+        config_file: Some(ConfigReport { path: config_file, change_type }),
+        old_settings,
+        new_settings,
+    })
+}
+
+fn render_nu_settings(dir: &str, opts: &AddDirToEnvPathOpts) -> String {
+    let adding_command = match opts.position {
+        AddingPosition::Start => "prepend",
+        AddingPosition::End => "append",
+    };
+    let (prefix, path_ref) = match opts.proxy_var_name {
+        Some(proxy) => {
+            let path_ref = match opts.proxy_var_sub_dir {
+                Some(sub_dir) => format!("($env.{proxy} | path join \"{sub_dir}\")"),
+                None => format!("$env.{proxy}"),
+            };
+            (format!("$env.{proxy} = \"{dir}\"\n"), path_ref)
+        }
+        None => (String::new(), dir.to_string()),
+    };
+    // Built piecewise rather than with one long `format!`: the PATH line
+    // exceeds the line-width limit, which would force a multi-line macro
+    // invocation that conflicts with the no-trailing-comma rule for
+    // argument-less `format!`s.
+    let mut settings = prefix;
+    settings.push_str("$env.PATH = ($env.PATH | split row (char esep) | ");
+    settings.push_str(adding_command);
+    settings.push(' ');
+    settings.push_str(&path_ref);
+    settings.push_str(" )");
+    settings
+}
+
+fn wrap_settings(section_name: &str, settings: &str) -> String {
+    format!("# {section_name}\n{settings}\n# {section_name} end")
+}
+
+fn update_shell_config(
+    config_file: &Path,
+    new_content: &str,
+    opts: &AddDirToEnvPathOpts,
+) -> Result<(ConfigFileChangeType, String), PathExtenderError> {
+    if !config_file.exists() {
+        if let Some(parent) = config_file.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(config_file, format!("{new_content}\n"))?;
+        return Ok((ConfigFileChangeType::Created, String::new()));
+    }
+    let config_content = fs::read_to_string(config_file)?;
+    let Some((matched_range, old_settings)) =
+        find_section(&config_content, opts.config_section_name)
+    else {
+        fs::write(config_file, format!("{config_content}\n{new_content}\n"))?;
+        return Ok((ConfigFileChangeType::Appended, String::new()));
+    };
+    if &config_content[matched_range] != new_content {
+        if !opts.overwrite {
+            return Err(PathExtenderError::BadShellSection {
+                config_file: config_file.to_path_buf(),
+                config_section_name: opts.config_section_name.to_string(),
+            });
+        }
+        let new_config_content =
+            replace_section(&config_content, new_content, opts.config_section_name);
+        fs::write(config_file, new_config_content)?;
+        return Ok((ConfigFileChangeType::Modified, old_settings));
+    }
+    Ok((ConfigFileChangeType::Skipped, old_settings))
+}
+
+/// Locate the `# <section>` ... `# <section> end` block, returning the byte
+/// range of the whole block and the inner settings between the markers.
+/// Mirrors pnpm's greedy `# <section>\n([\s\S]*)\n# <section> end` match:
+/// the block opens at the first `# <section>\n` and closes at the last
+/// `\n# <section> end`.
+fn find_section(content: &str, section: &str) -> Option<(std::ops::Range<usize>, String)> {
+    let start_pat = format!("# {section}\n");
+    let end_pat = format!("\n# {section} end");
+    let start = content.find(&start_pat)?;
+    let inner_start = start + start_pat.len();
+    let end = content.rfind(&end_pat)?;
+    if end < inner_start {
+        return None;
+    }
+    let inner = content[inner_start..end].to_string();
+    Some((start..end + end_pat.len(), inner))
+}
+
+/// Replace the `# <section>` ... `# <section> end` block with `new_section`.
+/// Mirrors pnpm's greedy `# <section>[\s\S]*# <section> end` replacement.
+fn replace_section(content: &str, new_section: &str, section: &str) -> String {
+    let begin_pat = format!("# {section}");
+    let end_pat = format!("# {section} end");
+    let begin = content.find(&begin_pat).unwrap_or(0);
+    let end = content.rfind(&end_pat).map_or(content.len(), |index| index + end_pat.len());
+    format!("{}{}{}", &content[..begin], new_section, &content[end..])
+}
+
+fn home_dir() -> Result<PathBuf, PathExtenderError> {
+    home::home_dir().ok_or(PathExtenderError::NoHomeDir)
+}
+
+fn zdotdir_or_home() -> Result<PathBuf, PathExtenderError> {
+    match std::env::var("ZDOTDIR").ok().filter(|dir| !dir.is_empty()) {
+        Some(dir) => Ok(PathBuf::from(dir)),
+        None => home_dir(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/posix.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/posix.rs
@@ -78,6 +78,11 @@ fn setup_shell(
 
 /// The `# <section>` body for a POSIX `sh`-family shell. Pure so the
 /// rendering can be unit-tested without touching the filesystem.
+///
+/// `dir` is single-quote escaped before it is interpolated into the shell
+/// code. This hardens beyond pnpm's `@pnpm/os.env.path-extender`, which
+/// interpolates the directory into double quotes — where a value containing
+/// `$(...)` / backticks would execute when the rc file is sourced.
 fn render_posix_settings(dir: &str, opts: &AddDirToEnvPathOpts) -> String {
     if let Some(proxy) = opts.proxy_var_name {
         let path_ref = match opts.proxy_var_sub_dir {
@@ -85,15 +90,23 @@ fn render_posix_settings(dir: &str, opts: &AddDirToEnvPathOpts) -> String {
             None => format!("${proxy}"),
         };
         format!(
-            "export {proxy}=\"{dir}\"\ncase \":$PATH:\" in\n  *\":{path_ref}:\"*) ;;\n  *) export PATH=\"{path_value}\" ;;\nesac",
+            "export {proxy}={value}\ncase \":$PATH:\" in\n  *\":{path_ref}:\"*) ;;\n  *) export PATH=\"{path_value}\" ;;\nesac",
+            value = sh_quote(dir),
             path_value = create_path_value(opts.position, &path_ref),
         )
     } else {
+        let quoted = sh_quote(dir);
         format!(
-            "case \":$PATH:\" in\n  *\":{dir}:\"*) ;;\n  *) export PATH=\"{path_value}\" ;;\nesac",
-            path_value = create_path_value(opts.position, dir),
+            "case \":$PATH:\" in\n  *\":\"{quoted}\":\"*) ;;\n  *) export PATH={path_value} ;;\nesac",
+            path_value = create_path_value(opts.position, &quoted),
         )
     }
+}
+
+/// Wrap `value` in single quotes, escaping any embedded single quote as
+/// `'\''`, so the POSIX shell treats it as a literal with no expansion.
+fn sh_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r"'\''"))
 }
 
 fn create_path_value(position: AddingPosition, dir: &str) -> String {
@@ -140,21 +153,33 @@ fn render_fish_settings(dir: &str, opts: &AddDirToEnvPathOpts) -> String {
             None => path_ref.clone(),
         };
         format!(
-            "set -gx {proxy} \"{dir}\"\nif not string match -q -- {match_pattern} $PATH\n  set -gx PATH {path_value}\nend",
-            path_value = create_fish_path_value(opts.position, &path_ref),
+            "set -gx {proxy} {value}\nif not string match -q -- {match_pattern} $PATH\n  set -gx PATH {path_value}\nend",
+            value = fish_quote(dir),
+            path_value = create_fish_path_value(opts.position, &format!("\"{path_ref}\"")),
         )
     } else {
+        let quoted = fish_quote(dir);
         format!(
-            "if not string match -q -- \"{dir}\" $PATH\n  set -gx PATH {path_value}\nend",
-            path_value = create_fish_path_value(opts.position, dir),
+            "if not string match -q -- {quoted} $PATH\n  set -gx PATH {path_value}\nend",
+            path_value = create_fish_path_value(opts.position, &quoted),
         )
     }
 }
 
-fn create_fish_path_value(position: AddingPosition, dir: &str) -> String {
+/// Wrap `value` in fish single quotes, escaping `\` and `'` (the only two
+/// characters fish recognizes inside single quotes), so fish treats it as a
+/// literal with no expansion.
+fn fish_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\\', r"\\").replace('\'', r"\'"))
+}
+
+/// Build the fish `PATH` list value from a pre-quoted `entry` (a
+/// double-quoted variable reference for the proxy case, or a single-quoted
+/// literal directory for the no-proxy case).
+fn create_fish_path_value(position: AddingPosition, entry: &str) -> String {
     match position {
-        AddingPosition::Start => format!("\"{dir}\" $PATH"),
-        AddingPosition::End => format!("$PATH \"{dir}\""),
+        AddingPosition::Start => format!("{entry} $PATH"),
+        AddingPosition::End => format!("$PATH {entry}"),
     }
 }
 
@@ -184,9 +209,9 @@ fn render_nu_settings(dir: &str, opts: &AddDirToEnvPathOpts) -> String {
                 Some(sub_dir) => format!("($env.{proxy} | path join \"{sub_dir}\")"),
                 None => format!("$env.{proxy}"),
             };
-            (format!("$env.{proxy} = \"{dir}\"\n"), path_ref)
+            (format!("$env.{proxy} = {value}\n", value = nu_quote(dir)), path_ref)
         }
-        None => (String::new(), dir.to_string()),
+        None => (String::new(), nu_quote(dir)),
     };
     // Built piecewise rather than with one long `format!`: the PATH line
     // exceeds the line-width limit, which would force a multi-line macro
@@ -199,6 +224,14 @@ fn render_nu_settings(dir: &str, opts: &AddDirToEnvPathOpts) -> String {
     settings.push_str(&path_ref);
     settings.push_str(" )");
     settings
+}
+
+/// Wrap `value` in nushell double quotes, escaping `\` and `"`. nushell does
+/// not perform command substitution or variable interpolation inside a plain
+/// double-quoted string (only `$"..."` interpolates), so the result is a
+/// literal with no expansion.
+fn nu_quote(value: &str) -> String {
+    format!(r#""{}""#, value.replace('\\', r"\\").replace('"', r#"\""#))
 }
 
 fn wrap_settings(section_name: &str, settings: &str) -> String {

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/posix.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/posix.rs
@@ -20,16 +20,11 @@ pub(super) fn add_dir_to_posix_env_path(
     dir: &Path,
     opts: &AddDirToEnvPathOpts,
 ) -> Result<PathExtenderReport, PathExtenderError> {
-    // Reject characters that would split the rendered colon-delimited `PATH`
-    // into extra entries (`:`) or corrupt the rc block (`\n` / `\r` / NUL).
-    // Single-quote escaping neutralizes shell expansion but cannot stop a
-    // `:` from acting as a PATH separator once `$PNPM_HOME/bin` expands.
-    let dir_str = dir.to_string_lossy();
-    if let Some(character) =
-        dir_str.chars().find(|character| matches!(character, ':' | '\n' | '\r' | '\0'))
-    {
-        return Err(PathExtenderError::UnsafePnpmHome { dir: dir_str.into_owned(), character });
-    }
+    // Defense in depth: `handler` validates before any side effect, but
+    // re-check here so the renderers never see a `:` that single-quote
+    // escaping cannot neutralize (it would still split the colon-delimited
+    // `PATH` once `$PNPM_HOME/bin` expands).
+    super::validate_posix_pnpm_home(dir)?;
     let current_shell = detect_current_shell();
     update_shell(current_shell.as_deref(), dir, opts)
 }

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/posix.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/posix.rs
@@ -20,6 +20,16 @@ pub(super) fn add_dir_to_posix_env_path(
     dir: &Path,
     opts: &AddDirToEnvPathOpts,
 ) -> Result<PathExtenderReport, PathExtenderError> {
+    // Reject characters that would split the rendered colon-delimited `PATH`
+    // into extra entries (`:`) or corrupt the rc block (`\n` / `\r` / NUL).
+    // Single-quote escaping neutralizes shell expansion but cannot stop a
+    // `:` from acting as a PATH separator once `$PNPM_HOME/bin` expands.
+    let dir_str = dir.to_string_lossy();
+    if let Some(character) =
+        dir_str.chars().find(|character| matches!(character, ':' | '\n' | '\r' | '\0'))
+    {
+        return Err(PathExtenderError::UnsafePnpmHome { dir: dir_str.into_owned(), character });
+    }
     let current_shell = detect_current_shell();
     update_shell(current_shell.as_deref(), dir, opts)
 }
@@ -247,14 +257,14 @@ fn update_shell_config(
         if let Some(parent) = config_file.parent() {
             fs::create_dir_all(parent)?;
         }
-        write_atomic(config_file, &format!("{new_content}\n"))?;
+        write_config(config_file, &format!("{new_content}\n"))?;
         return Ok((ConfigFileChangeType::Created, String::new()));
     }
     let config_content = fs::read_to_string(config_file)?;
     let Some((matched_range, old_settings)) =
         find_section(&config_content, opts.config_section_name)
     else {
-        write_atomic(config_file, &format!("{config_content}\n{new_content}\n"))?;
+        write_config(config_file, &format!("{config_content}\n{new_content}\n"))?;
         return Ok((ConfigFileChangeType::Appended, String::new()));
     };
     if &config_content[matched_range] != new_content {
@@ -266,33 +276,19 @@ fn update_shell_config(
         }
         let new_config_content =
             replace_section(&config_content, new_content, opts.config_section_name);
-        write_atomic(config_file, &new_config_content)?;
+        write_config(config_file, &new_config_content)?;
         return Ok((ConfigFileChangeType::Modified, old_settings));
     }
     Ok((ConfigFileChangeType::Skipped, old_settings))
 }
 
-/// Overwrite `path` crash-safely: write to a sibling temp file, flush it to
-/// disk, then atomically rename it over the target. A crash or disk-full
-/// error mid-write leaves the original rc file intact rather than truncated.
-fn write_atomic(path: &Path, content: &str) -> std::io::Result<()> {
-    use std::io::Write;
-    let file_name = path.file_name().ok_or_else(|| {
-        std::io::Error::new(std::io::ErrorKind::InvalidInput, "config path has no file name")
-    })?;
-    let mut temp_name = file_name.to_os_string();
-    temp_name.push(".pnpm-tmp");
-    let temp_path = path.with_file_name(temp_name);
-    let mut file = fs::File::create(&temp_path)?;
-    let write_result = file.write_all(content.as_bytes()).and_then(|()| file.sync_all());
-    if let Err(err) = write_result {
-        let _ = fs::remove_file(&temp_path);
-        return Err(err);
-    }
-    if let Err(err) = fs::rename(&temp_path, path) {
-        let _ = fs::remove_file(&temp_path);
-        return Err(err);
-    }
+/// Overwrite the rc file crash-safely via [`pacquet_fs::ensure_file`], the
+/// repo's hardened atomic writer: it writes through a unique sibling temp
+/// file opened with `O_CREAT|O_EXCL` (so it never follows a pre-seeded
+/// symlink or truncates an attacker-planted path) and renames it over the
+/// target.
+fn write_config(path: &Path, content: &str) -> Result<(), PathExtenderError> {
+    pacquet_fs::ensure_file(path, content.as_bytes(), None)?;
     Ok(())
 }
 

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/posix/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/posix/tests.rs
@@ -1,0 +1,232 @@
+//! Ports the rendering and config-file-editing cases of pnpm's
+//! [`path-extender-posix.spec.ts`](https://github.com/pnpm/pnpm/blob/1819226b51/packages/path-extender-posix/test/index.ts).
+//! The shell-detection / home-resolution wrapper reads process-global env
+//! state, so the tests exercise the pure renderers and the file editor
+//! directly (with a `tempfile` config file) instead of through
+//! `add_dir_to_posix_env_path`.
+
+use super::{
+    AddDirToEnvPathOpts, AddingPosition, ConfigFileChangeType, PathExtenderError, find_section,
+    render_fish_settings, render_nu_settings, render_posix_settings, replace_section,
+    update_shell_config, wrap_settings,
+};
+use pretty_assertions::assert_eq;
+use std::fs;
+
+const HOME: &str = "/home/user/.pnpm";
+
+fn opts(overwrite: bool) -> AddDirToEnvPathOpts<'static> {
+    AddDirToEnvPathOpts {
+        config_section_name: "pnpm",
+        proxy_var_name: Some("PNPM_HOME"),
+        proxy_var_sub_dir: None,
+        overwrite,
+        position: AddingPosition::Start,
+    }
+}
+
+#[test]
+fn bash_settings_with_proxy_variable() {
+    let settings = render_posix_settings(HOME, &opts(false));
+    assert_eq!(
+        settings,
+        r#"export PNPM_HOME="/home/user/.pnpm"
+case ":$PATH:" in
+  *":$PNPM_HOME:"*) ;;
+  *) export PATH="$PNPM_HOME:$PATH" ;;
+esac"#,
+    );
+}
+
+#[test]
+fn bash_settings_without_proxy_variable() {
+    let mut opts = opts(false);
+    opts.proxy_var_name = None;
+    let settings = render_posix_settings(HOME, &opts);
+    assert_eq!(
+        settings,
+        r#"case ":$PATH:" in
+  *":/home/user/.pnpm:"*) ;;
+  *) export PATH="/home/user/.pnpm:$PATH" ;;
+esac"#,
+    );
+}
+
+#[test]
+fn bash_settings_with_proxy_var_sub_dir() {
+    let mut opts = opts(false);
+    opts.proxy_var_sub_dir = Some("bin");
+    let settings = render_posix_settings(HOME, &opts);
+    assert_eq!(
+        settings,
+        r#"export PNPM_HOME="/home/user/.pnpm"
+case ":$PATH:" in
+  *":$PNPM_HOME/bin:"*) ;;
+  *) export PATH="$PNPM_HOME/bin:$PATH" ;;
+esac"#,
+    );
+}
+
+#[test]
+fn bash_settings_appending_to_the_end_of_path() {
+    let mut opts = opts(false);
+    opts.position = AddingPosition::End;
+    let settings = render_posix_settings(HOME, &opts);
+    assert_eq!(
+        settings,
+        r#"export PNPM_HOME="/home/user/.pnpm"
+case ":$PATH:" in
+  *":$PNPM_HOME:"*) ;;
+  *) export PATH="$PATH:$PNPM_HOME" ;;
+esac"#,
+    );
+}
+
+#[test]
+fn fish_settings_with_proxy_var_sub_dir() {
+    let mut opts = opts(false);
+    opts.proxy_var_sub_dir = Some("bin");
+    let settings = render_fish_settings(HOME, &opts);
+    assert_eq!(
+        settings,
+        r#"set -gx PNPM_HOME "/home/user/.pnpm"
+if not string match -q -- "$PNPM_HOME/bin" $PATH
+  set -gx PATH "$PNPM_HOME/bin" $PATH
+end"#,
+    );
+}
+
+#[test]
+fn fish_settings_without_proxy_variable() {
+    let mut opts = opts(false);
+    opts.proxy_var_name = None;
+    let settings = render_fish_settings(HOME, &opts);
+    assert_eq!(
+        settings,
+        r#"if not string match -q -- "/home/user/.pnpm" $PATH
+  set -gx PATH "/home/user/.pnpm" $PATH
+end"#,
+    );
+}
+
+#[test]
+fn nu_settings_with_proxy_var_sub_dir() {
+    let mut opts = opts(false);
+    opts.proxy_var_sub_dir = Some("bin");
+    let settings = render_nu_settings(HOME, &opts);
+    assert_eq!(
+        settings,
+        r#"$env.PNPM_HOME = "/home/user/.pnpm"
+$env.PATH = ($env.PATH | split row (char esep) | prepend ($env.PNPM_HOME | path join "bin") )"#,
+    );
+}
+
+#[test]
+fn nu_settings_appending_to_the_end_of_path() {
+    let mut opts = opts(false);
+    opts.proxy_var_name = None;
+    opts.position = AddingPosition::End;
+    let settings = render_nu_settings(HOME, &opts);
+    assert_eq!(
+        settings,
+        "$env.PATH = ($env.PATH | split row (char esep) | append /home/user/.pnpm )",
+    );
+}
+
+#[test]
+fn create_config_file_when_it_does_not_exist() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let config_file = dir.path().join("sub").join(".bashrc");
+    let content = wrap_settings("pnpm", "export FOO=1");
+
+    let (change_type, old_settings) =
+        update_shell_config(&config_file, &content, &opts(false)).expect("update shell config");
+
+    assert_eq!(change_type, ConfigFileChangeType::Created);
+    assert_eq!(old_settings, "");
+    let written = fs::read_to_string(&config_file).expect("read config file");
+    assert_eq!(written, "# pnpm\nexport FOO=1\n# pnpm end\n");
+}
+
+#[test]
+fn append_to_an_existing_config_file() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let config_file = dir.path().join(".bashrc");
+    fs::write(&config_file, "").expect("write empty config file");
+    let content = wrap_settings("pnpm", "export FOO=1");
+
+    let (change_type, old_settings) =
+        update_shell_config(&config_file, &content, &opts(false)).expect("update shell config");
+
+    assert_eq!(change_type, ConfigFileChangeType::Appended);
+    assert_eq!(old_settings, "");
+    let written = fs::read_to_string(&config_file).expect("read config file");
+    assert_eq!(written, "\n# pnpm\nexport FOO=1\n# pnpm end\n");
+}
+
+#[test]
+fn skip_when_the_config_is_already_present() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let config_file = dir.path().join(".bashrc");
+    let content = wrap_settings("pnpm", "export FOO=1");
+    fs::write(&config_file, format!("\n{content}\n")).expect("write config file");
+
+    let (change_type, old_settings) =
+        update_shell_config(&config_file, &content, &opts(false)).expect("update shell config");
+
+    assert_eq!(change_type, ConfigFileChangeType::Skipped);
+    assert_eq!(old_settings, "export FOO=1");
+}
+
+#[test]
+fn fail_when_the_section_differs_and_overwrite_is_off() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let config_file = dir.path().join(".bashrc");
+    let existing = wrap_settings("pnpm", "export FOO=old");
+    fs::write(&config_file, format!("\n{existing}\n")).expect("write config file");
+    let content = wrap_settings("pnpm", "export FOO=new");
+
+    let err = update_shell_config(&config_file, &content, &opts(false))
+        .expect_err("differing section without --force must error");
+    assert!(matches!(err, PathExtenderError::BadShellSection { .. }));
+    // The original content is left untouched.
+    let written = fs::read_to_string(&config_file).expect("read config file");
+    assert_eq!(written, format!("\n{existing}\n"));
+}
+
+#[test]
+fn replace_when_the_section_differs_and_overwrite_is_on() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let config_file = dir.path().join(".bashrc");
+    let existing = wrap_settings("pnpm", "export FOO=old");
+    fs::write(&config_file, format!("before\n{existing}\nafter\n")).expect("write config file");
+    let content = wrap_settings("pnpm", "export FOO=new");
+
+    let (change_type, old_settings) =
+        update_shell_config(&config_file, &content, &opts(true)).expect("update shell config");
+
+    assert_eq!(change_type, ConfigFileChangeType::Modified);
+    assert_eq!(old_settings, "export FOO=old");
+    let written = fs::read_to_string(&config_file).expect("read config file");
+    assert_eq!(written, format!("before\n{content}\nafter\n"));
+}
+
+#[test]
+fn find_section_extracts_the_inner_settings() {
+    let content = "head\n# pnpm\nbody line 1\nbody line 2\n# pnpm end\ntail";
+    let (range, inner) = find_section(content, "pnpm").expect("section is present");
+    assert_eq!(inner, "body line 1\nbody line 2");
+    assert_eq!(&content[range], "# pnpm\nbody line 1\nbody line 2\n# pnpm end");
+}
+
+#[test]
+fn find_section_absent_returns_none() {
+    assert!(find_section("no markers here", "pnpm").is_none());
+}
+
+#[test]
+fn replace_section_swaps_the_block() {
+    let content = "a\n# pnpm\nold\n# pnpm end\nb";
+    let replaced = replace_section(content, "# pnpm\nnew\n# pnpm end", "pnpm");
+    assert_eq!(replaced, "a\n# pnpm\nnew\n# pnpm end\nb");
+}

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/posix/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/posix/tests.rs
@@ -6,12 +6,12 @@
 //! `add_dir_to_posix_env_path`.
 
 use super::{
-    AddDirToEnvPathOpts, AddingPosition, ConfigFileChangeType, PathExtenderError, find_section,
-    render_fish_settings, render_nu_settings, render_posix_settings, replace_section,
-    update_shell_config, wrap_settings,
+    AddDirToEnvPathOpts, AddingPosition, ConfigFileChangeType, PathExtenderError,
+    add_dir_to_posix_env_path, find_section, render_fish_settings, render_nu_settings,
+    render_posix_settings, replace_section, update_shell_config, wrap_settings,
 };
 use pretty_assertions::assert_eq;
-use std::fs;
+use std::{fs, path::Path};
 
 const HOME: &str = "/home/user/.pnpm";
 
@@ -141,6 +141,15 @@ fn proxy_value_is_single_quote_escaped_against_injection() {
     let settings = render_posix_settings("/home/u/$(touch pwned)/it's", &opts(false));
     let first_line = settings.lines().next();
     assert_eq!(first_line, Some(r"export PNPM_HOME='/home/u/$(touch pwned)/it'\''s'"));
+}
+
+#[test]
+fn rejects_pnpm_home_with_a_path_separator() {
+    // A `:` in PNPM_HOME would split the rendered POSIX PATH into extra
+    // entries, so it is rejected before any rc file is touched.
+    let err = add_dir_to_posix_env_path(Path::new("/home/pnpm:/tmp/evil"), &opts(false))
+        .expect_err("a colon in PNPM_HOME must be rejected");
+    assert!(matches!(err, PathExtenderError::UnsafePnpmHome { character: ':', .. }));
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/posix/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/posix/tests.rs
@@ -30,7 +30,7 @@ fn bash_settings_with_proxy_variable() {
     let settings = render_posix_settings(HOME, &opts(false));
     assert_eq!(
         settings,
-        r#"export PNPM_HOME="/home/user/.pnpm"
+        r#"export PNPM_HOME='/home/user/.pnpm'
 case ":$PATH:" in
   *":$PNPM_HOME:"*) ;;
   *) export PATH="$PNPM_HOME:$PATH" ;;
@@ -46,8 +46,8 @@ fn bash_settings_without_proxy_variable() {
     assert_eq!(
         settings,
         r#"case ":$PATH:" in
-  *":/home/user/.pnpm:"*) ;;
-  *) export PATH="/home/user/.pnpm:$PATH" ;;
+  *":"'/home/user/.pnpm'":"*) ;;
+  *) export PATH='/home/user/.pnpm':$PATH ;;
 esac"#,
     );
 }
@@ -59,7 +59,7 @@ fn bash_settings_with_proxy_var_sub_dir() {
     let settings = render_posix_settings(HOME, &opts);
     assert_eq!(
         settings,
-        r#"export PNPM_HOME="/home/user/.pnpm"
+        r#"export PNPM_HOME='/home/user/.pnpm'
 case ":$PATH:" in
   *":$PNPM_HOME/bin:"*) ;;
   *) export PATH="$PNPM_HOME/bin:$PATH" ;;
@@ -74,7 +74,7 @@ fn bash_settings_appending_to_the_end_of_path() {
     let settings = render_posix_settings(HOME, &opts);
     assert_eq!(
         settings,
-        r#"export PNPM_HOME="/home/user/.pnpm"
+        r#"export PNPM_HOME='/home/user/.pnpm'
 case ":$PATH:" in
   *":$PNPM_HOME:"*) ;;
   *) export PATH="$PATH:$PNPM_HOME" ;;
@@ -89,7 +89,7 @@ fn fish_settings_with_proxy_var_sub_dir() {
     let settings = render_fish_settings(HOME, &opts);
     assert_eq!(
         settings,
-        r#"set -gx PNPM_HOME "/home/user/.pnpm"
+        r#"set -gx PNPM_HOME '/home/user/.pnpm'
 if not string match -q -- "$PNPM_HOME/bin" $PATH
   set -gx PATH "$PNPM_HOME/bin" $PATH
 end"#,
@@ -103,9 +103,9 @@ fn fish_settings_without_proxy_variable() {
     let settings = render_fish_settings(HOME, &opts);
     assert_eq!(
         settings,
-        r#"if not string match -q -- "/home/user/.pnpm" $PATH
-  set -gx PATH "/home/user/.pnpm" $PATH
-end"#,
+        r"if not string match -q -- '/home/user/.pnpm' $PATH
+  set -gx PATH '/home/user/.pnpm' $PATH
+end",
     );
 }
 
@@ -129,8 +129,18 @@ fn nu_settings_appending_to_the_end_of_path() {
     let settings = render_nu_settings(HOME, &opts);
     assert_eq!(
         settings,
-        "$env.PATH = ($env.PATH | split row (char esep) | append /home/user/.pnpm )",
+        r#"$env.PATH = ($env.PATH | split row (char esep) | append "/home/user/.pnpm" )"#,
     );
+}
+
+#[test]
+fn proxy_value_is_single_quote_escaped_against_injection() {
+    // A command-substitution payload and an embedded single quote must end
+    // up inside a single-quoted literal (the `'` escaped as `'\''`), so the
+    // shell never expands `$(...)` when the rc file is sourced.
+    let settings = render_posix_settings("/home/u/$(touch pwned)/it's", &opts(false));
+    let first_line = settings.lines().next();
+    assert_eq!(first_line, Some(r"export PNPM_HOME='/home/u/$(touch pwned)/it'\''s'"));
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/windows.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/windows.rs
@@ -28,7 +28,8 @@ pub(super) fn add_dir_to_windows_env_path(
 ) -> Result<Vec<EnvVariableChange>, PathExtenderError> {
     // `chcp` makes `reg` use UTF-8 for output. Otherwise non-ASCII
     // characters in environment variables become garbled.
-    let chcp_output = run_capture("chcp", &[])?;
+    let chcp_output = run_capture("chcp", &[])
+        .map_err(|err| PathExtenderError::Chcp { message: err.to_string() })?;
     let cp_bak = first_number(&chcp_output)
         .ok_or_else(|| PathExtenderError::Chcp { message: chcp_output.clone() })?;
     run_capture("chcp", &["65001"])?;
@@ -148,6 +149,20 @@ fn get_registry_output() -> Result<String, PathExtenderError> {
     run_capture("reg", &["query", REG_KEY]).map_err(|_| PathExtenderError::RegRead)
 }
 
+/// Run a command and capture stdout, returning an error if it cannot be
+/// spawned or exits non-zero. Mirrors pnpm's `safe-execa`, which rejects on
+/// a non-zero exit rather than silently continuing with empty output.
+fn run_capture(program: &str, args: &[&str]) -> Result<String, PathExtenderError> {
+    let output = Command::new(program).args(args).output()?;
+    if !output.status.success() {
+        return Err(PathExtenderError::CommandFailed {
+            command: program.to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
 /// Parse a `reg query` line of the form `    <name>    <type>    <data>`
 /// (four-space separators), matching `name` case-insensitively. Mirrors
 /// pnpm's `getEnvValueFromRegistry` regex.
@@ -201,14 +216,9 @@ fn set_env_var_in_registry(
 /// variable to trigger the broadcast. Mirrors pnpm's `refreshEnvVars`.
 fn refresh_env_vars() -> Result<(), PathExtenderError> {
     const TEMP_ENV_VAR: &str = "REFRESH_ENV_VARS";
-    Command::new("setx").args([TEMP_ENV_VAR, "1"]).output()?;
-    Command::new("reg").args(["delete", REG_KEY, "/v", TEMP_ENV_VAR, "/f"]).output()?;
+    run_capture("setx", &[TEMP_ENV_VAR, "1"])?;
+    run_capture("reg", &["delete", REG_KEY, "/v", TEMP_ENV_VAR, "/f"])?;
     Ok(())
-}
-
-fn run_capture(program: &str, args: &[&str]) -> Result<String, PathExtenderError> {
-    let output = Command::new(program).args(args).output()?;
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 fn first_number(text: &str) -> Option<u32> {

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/windows.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/windows.rs
@@ -56,7 +56,7 @@ fn add_dir_to_windows_env_path_inner(
     if let Some(character) =
         added_dir.chars().find(|character| matches!(character, ';' | '%' | '\n' | '\r'))
     {
-        return Err(PathExtenderError::UnsafePnpmHomeForWindows { dir: added_dir, character });
+        return Err(PathExtenderError::UnsafePnpmHome { dir: added_dir, character });
     }
     let registry_output = get_registry_output()?;
     let mut changes = Vec::new();

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/windows.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/windows.rs
@@ -1,0 +1,215 @@
+//! Extend the user `Path` (and a proxy variable like `PNPM_HOME`) in the
+//! Windows registry under `HKEY_CURRENT_USER\Environment`.
+//!
+//! Ports pnpm's
+//! [`@pnpm/os.env.path-extender-windows`](https://github.com/pnpm/pnpm/blob/1819226b51/packages/path-extender-windows/src/path-extender-windows.ts):
+//! the registry is read with `reg query`, the proxy variable and `Path` are
+//! written with `reg add`, and a dummy `setx` forces the new values to be
+//! picked up by future processes. `chcp 65001` makes `reg` emit UTF-8 so
+//! non-ASCII values survive the round-trip.
+
+use super::{AddDirToEnvPathOpts, AddingPosition, PathExtenderError};
+use std::{path::Path, process::Command};
+
+/// The change made to one environment variable, used to render the
+/// before/after report. Mirrors pnpm's `EnvVariableChange`.
+pub(super) struct EnvVariableChange {
+    pub variable: String,
+    pub old_value: Option<String>,
+    pub new_value: String,
+}
+
+const REG_KEY: &str = r"HKEY_CURRENT_USER\Environment";
+
+pub(super) fn add_dir_to_windows_env_path(
+    dir: &Path,
+    opts: &AddDirToEnvPathOpts,
+) -> Result<Vec<EnvVariableChange>, PathExtenderError> {
+    // `chcp` makes `reg` use UTF-8 for output. Otherwise non-ASCII
+    // characters in environment variables become garbled.
+    let chcp_output = run_capture("chcp", &[])?;
+    let cp_bak = first_number(&chcp_output)
+        .ok_or_else(|| PathExtenderError::Chcp { message: chcp_output.clone() })?;
+    run_capture("chcp", &["65001"])?;
+
+    let result = (|| {
+        let report = add_dir_to_windows_env_path_inner(dir, opts)?;
+        refresh_env_vars()?;
+        Ok(report)
+    })();
+
+    // Restore the original code page even when the body failed.
+    let _ = run_capture("chcp", &[&cp_bak.to_string()]);
+    result
+}
+
+fn add_dir_to_windows_env_path_inner(
+    dir: &Path,
+    opts: &AddDirToEnvPathOpts,
+) -> Result<Vec<EnvVariableChange>, PathExtenderError> {
+    let added_dir = dir.to_string_lossy().replace('/', r"\");
+    let registry_output = get_registry_output()?;
+    let mut changes = Vec::new();
+    if let Some(proxy) = opts.proxy_var_name {
+        changes.push(update_env_variable(
+            &registry_output,
+            proxy,
+            &added_dir,
+            false,
+            opts.overwrite,
+        )?);
+        let path_entry = match opts.proxy_var_sub_dir {
+            Some(sub_dir) => format!("%{proxy}%\\{sub_dir}"),
+            None => format!("%{proxy}%"),
+        };
+        changes.push(add_to_path(&registry_output, &path_entry, opts.position)?);
+    } else {
+        changes.push(add_to_path(&registry_output, &added_dir, opts.position)?);
+    }
+    Ok(changes)
+}
+
+fn update_env_variable(
+    registry_output: &str,
+    name: &str,
+    value: &str,
+    expandable_string: bool,
+    overwrite: bool,
+) -> Result<EnvVariableChange, PathExtenderError> {
+    let current_value = get_env_value_from_registry(registry_output, name);
+    match &current_value {
+        Some(current) if !overwrite => {
+            if current != value {
+                return Err(PathExtenderError::BadEnvFound {
+                    env_name: name.to_string(),
+                    wanted_value: value.to_string(),
+                });
+            }
+            Ok(EnvVariableChange {
+                variable: name.to_string(),
+                old_value: current_value,
+                new_value: value.to_string(),
+            })
+        }
+        _ => {
+            set_env_var_in_registry(name, value, expandable_string)?;
+            Ok(EnvVariableChange {
+                variable: name.to_string(),
+                old_value: current_value,
+                new_value: value.to_string(),
+            })
+        }
+    }
+}
+
+fn add_to_path(
+    registry_output: &str,
+    added_dir: &str,
+    position: AddingPosition,
+) -> Result<EnvVariableChange, PathExtenderError> {
+    let variable = "Path";
+    let path_data = get_env_value_from_registry(registry_output, variable);
+    let path_data = match path_data {
+        Some(data) if !data.trim().is_empty() => data,
+        _ => return Err(PathExtenderError::NoPath),
+    };
+    if path_data.split(';').any(|entry| entry == added_dir) {
+        return Ok(EnvVariableChange {
+            variable: variable.to_string(),
+            old_value: Some(path_data.clone()),
+            new_value: path_data,
+        });
+    }
+    let new_path_value = match position {
+        AddingPosition::Start => format!("{added_dir};{path_data}"),
+        AddingPosition::End => format!("{path_data};{added_dir}"),
+    };
+    set_env_var_in_registry("Path", &new_path_value, true)?;
+    Ok(EnvVariableChange {
+        variable: variable.to_string(),
+        old_value: Some(path_data),
+        new_value: new_path_value,
+    })
+}
+
+/// Read every value under `REG_KEY` and pick the one we need, rather than
+/// querying a single value (which fails when the value is absent and hides
+/// the real cause). Mirrors pnpm's `getRegistryOutput`.
+fn get_registry_output() -> Result<String, PathExtenderError> {
+    run_capture("reg", &["query", REG_KEY]).map_err(|_| PathExtenderError::RegRead)
+}
+
+/// Parse a `reg query` line of the form `    <name>    <type>    <data>`
+/// (four-space separators), matching `name` case-insensitively. Mirrors
+/// pnpm's `getEnvValueFromRegistry` regex.
+fn get_env_value_from_registry(registry_output: &str, env_var_name: &str) -> Option<String> {
+    for line in registry_output.lines() {
+        let Some(rest) = line.strip_prefix("    ") else {
+            continue;
+        };
+        if rest.len() < env_var_name.len()
+            || !rest[..env_var_name.len()].eq_ignore_ascii_case(env_var_name)
+        {
+            continue;
+        }
+        let Some(after_name) = rest[env_var_name.len()..].strip_prefix("    ") else {
+            continue;
+        };
+        let Some(type_end) = after_name.find("    ") else {
+            continue;
+        };
+        let value_type = &after_name[..type_end];
+        if value_type.is_empty() || !value_type.chars().all(|ch| ch.is_alphanumeric() || ch == '_')
+        {
+            continue;
+        }
+        return Some(after_name[type_end + 4..].to_string());
+    }
+    None
+}
+
+fn set_env_var_in_registry(
+    env_var_name: &str,
+    env_var_value: &str,
+    expandable_string: bool,
+) -> Result<(), PathExtenderError> {
+    let reg_type = if expandable_string { "REG_EXPAND_SZ" } else { "REG_SZ" };
+    let output = Command::new("reg")
+        .args(["add", REG_KEY, "/v", env_var_name, "/t", reg_type, "/d", env_var_value, "/f"])
+        .output()?;
+    if !output.status.success() {
+        return Err(PathExtenderError::FailedSetEnv {
+            env_name: env_var_name.to_string(),
+            value: env_var_value.to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        });
+    }
+    Ok(())
+}
+
+/// Registry writes are not seen by future processes until at least one
+/// variable is set with `setx`. Set and immediately delete a throwaway
+/// variable to trigger the broadcast. Mirrors pnpm's `refreshEnvVars`.
+fn refresh_env_vars() -> Result<(), PathExtenderError> {
+    const TEMP_ENV_VAR: &str = "REFRESH_ENV_VARS";
+    Command::new("setx").args([TEMP_ENV_VAR, "1"]).output()?;
+    Command::new("reg").args(["delete", REG_KEY, "/v", TEMP_ENV_VAR, "/f"]).output()?;
+    Ok(())
+}
+
+fn run_capture(program: &str, args: &[&str]) -> Result<String, PathExtenderError> {
+    let output = Command::new(program).args(args).output()?;
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn first_number(text: &str) -> Option<u32> {
+    let digits: String = text
+        .chars()
+        .skip_while(|ch| !ch.is_ascii_digit())
+        .take_while(char::is_ascii_digit)
+        .collect();
+    digits.parse().ok()
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/windows.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/windows.rs
@@ -13,6 +13,7 @@ use std::{path::Path, process::Command};
 
 /// The change made to one environment variable, used to render the
 /// before/after report. Mirrors pnpm's `EnvVariableChange`.
+#[derive(Debug)]
 pub(super) struct EnvVariableChange {
     pub variable: String,
     pub old_value: Option<String>,
@@ -48,6 +49,14 @@ fn add_dir_to_windows_env_path_inner(
     opts: &AddDirToEnvPathOpts,
 ) -> Result<Vec<EnvVariableChange>, PathExtenderError> {
     let added_dir = dir.to_string_lossy().replace('/', r"\");
+    // Reject characters that would split the persisted `Path` into extra
+    // entries (`;`), break the `%PNPM_HOME%` indirection (`%`), or corrupt
+    // the value (`\n` / `\r`). See `PathExtenderError::UnsafePnpmHomeForWindows`.
+    if let Some(character) =
+        added_dir.chars().find(|character| matches!(character, ';' | '%' | '\n' | '\r'))
+    {
+        return Err(PathExtenderError::UnsafePnpmHomeForWindows { dir: added_dir, character });
+    }
     let registry_output = get_registry_output()?;
     let mut changes = Vec::new();
     if let Some(proxy) = opts.proxy_var_name {

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/windows.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/windows.rs
@@ -49,15 +49,10 @@ fn add_dir_to_windows_env_path_inner(
     dir: &Path,
     opts: &AddDirToEnvPathOpts,
 ) -> Result<Vec<EnvVariableChange>, PathExtenderError> {
+    // Defense in depth: `handler` validates before any side effect; re-check
+    // before writing anything to the registry.
+    super::validate_windows_pnpm_home(dir)?;
     let added_dir = dir.to_string_lossy().replace('/', r"\");
-    // Reject characters that would split the persisted `Path` into extra
-    // entries (`;`), break the `%PNPM_HOME%` indirection (`%`), or corrupt
-    // the value (`\n` / `\r`). See `PathExtenderError::UnsafePnpmHomeForWindows`.
-    if let Some(character) =
-        added_dir.chars().find(|character| matches!(character, ';' | '%' | '\n' | '\r'))
-    {
-        return Err(PathExtenderError::UnsafePnpmHome { dir: added_dir, character });
-    }
     let registry_output = get_registry_output()?;
     let mut changes = Vec::new();
     if let Some(proxy) = opts.proxy_var_name {

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/windows/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/windows/tests.rs
@@ -1,0 +1,51 @@
+//! Unit tests for the pure pieces of the Windows registry path-extender:
+//! the `reg query` line parser, the code-page number extraction, and the
+//! before/after report rendering. The registry-mutating commands need a real
+//! Windows host and are exercised by `pacquet setup` end to end there.
+
+use super::{EnvVariableChange, first_number, get_env_value_from_registry};
+use pretty_assertions::assert_eq;
+
+const SAMPLE: &str = "\r\nHKEY_CURRENT_USER\\Environment\r\n    Path    REG_EXPAND_SZ    C:\\Users\\me\\bin\r\n    PNPM_HOME    REG_SZ    C:\\pnpm\r\n";
+
+#[test]
+fn reads_a_value_by_name() {
+    assert_eq!(get_env_value_from_registry(SAMPLE, "Path").as_deref(), Some(r"C:\Users\me\bin"));
+    assert_eq!(get_env_value_from_registry(SAMPLE, "PNPM_HOME").as_deref(), Some(r"C:\pnpm"));
+}
+
+#[test]
+fn matches_the_name_case_insensitively() {
+    assert_eq!(get_env_value_from_registry(SAMPLE, "path").as_deref(), Some(r"C:\Users\me\bin"));
+}
+
+#[test]
+fn missing_value_returns_none() {
+    assert!(get_env_value_from_registry(SAMPLE, "NOT_THERE").is_none());
+}
+
+#[test]
+fn first_number_extracts_the_code_page() {
+    assert_eq!(first_number("Active code page: 437"), Some(437));
+    assert_eq!(first_number("no digits"), None);
+}
+
+#[test]
+fn render_report_lists_changed_variables() {
+    let changes = vec![
+        EnvVariableChange {
+            variable: "PNPM_HOME".to_string(),
+            old_value: None,
+            new_value: r"C:\pnpm".to_string(),
+        },
+        EnvVariableChange {
+            variable: "Path".to_string(),
+            old_value: Some(r"C:\old".to_string()),
+            new_value: r"%PNPM_HOME%;C:\old".to_string(),
+        },
+    ];
+    let report = super::super::render_windows_report(&changes);
+    assert!(report.config_file.is_none());
+    assert_eq!(report.old_settings, r"Path=C:\old");
+    assert_eq!(report.new_settings, "PNPM_HOME=C:\\pnpm\nPath=%PNPM_HOME%;C:\\old");
+}

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/windows/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/windows/tests.rs
@@ -3,8 +3,12 @@
 //! before/after report rendering. The registry-mutating commands need a real
 //! Windows host and are exercised by `pacquet setup` end to end there.
 
-use super::{EnvVariableChange, first_number, get_env_value_from_registry};
+use super::{
+    AddDirToEnvPathOpts, AddingPosition, EnvVariableChange, PathExtenderError,
+    add_dir_to_windows_env_path_inner, first_number, get_env_value_from_registry,
+};
 use pretty_assertions::assert_eq;
+use std::path::Path;
 
 const SAMPLE: &str = "\r\nHKEY_CURRENT_USER\\Environment\r\n    Path    REG_EXPAND_SZ    C:\\Users\\me\\bin\r\n    PNPM_HOME    REG_SZ    C:\\pnpm\r\n";
 
@@ -28,6 +32,22 @@ fn missing_value_returns_none() {
 fn first_number_extracts_the_code_page() {
     assert_eq!(first_number("Active code page: 437"), Some(437));
     assert_eq!(first_number("no digits"), None);
+}
+
+#[test]
+fn rejects_pnpm_home_that_would_split_the_path() {
+    // Validation runs before any `reg` command, so this is exercisable off
+    // Windows. A `;` in PNPM_HOME would split the persisted Path.
+    let opts = AddDirToEnvPathOpts {
+        config_section_name: "pnpm",
+        proxy_var_name: Some("PNPM_HOME"),
+        proxy_var_sub_dir: Some("bin"),
+        overwrite: false,
+        position: AddingPosition::Start,
+    };
+    let err = add_dir_to_windows_env_path_inner(Path::new(r"C:\pnpm;C:\evil"), &opts)
+        .expect_err("a semicolon in PNPM_HOME must be rejected");
+    assert!(matches!(err, PathExtenderError::UnsafePnpmHomeForWindows { character: ';', .. }));
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/windows/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/windows/tests.rs
@@ -47,7 +47,7 @@ fn rejects_pnpm_home_that_would_split_the_path() {
     };
     let err = add_dir_to_windows_env_path_inner(Path::new(r"C:\pnpm;C:\evil"), &opts)
         .expect_err("a semicolon in PNPM_HOME must be rejected");
-    assert!(matches!(err, PathExtenderError::UnsafePnpmHomeForWindows { character: ';', .. }));
+    assert!(matches!(err, PathExtenderError::UnsafePnpmHome { character: ';', .. }));
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/setup/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/tests.rs
@@ -1,0 +1,74 @@
+//! Unit tests for the pure summary rendering and the alias-script writer.
+//! The full `setup` flow installs the CLI globally and edits the user's
+//! shell config, so it is exercised on a real host rather than here.
+
+use super::{
+    ConfigFileChangeType, ConfigReport, PathExtenderReport, create_alias_scripts,
+    render_setup_output,
+};
+use pretty_assertions::assert_eq;
+use std::path::PathBuf;
+
+fn report(change_type: ConfigFileChangeType, old: &str, new: &str) -> PathExtenderReport {
+    PathExtenderReport {
+        config_file: Some(ConfigReport { path: PathBuf::from("/home/user/.bashrc"), change_type }),
+        old_settings: old.to_string(),
+        new_settings: new.to_string(),
+    }
+}
+
+#[test]
+fn no_changes_when_settings_are_unchanged() {
+    let report = report(ConfigFileChangeType::Skipped, "same", "same");
+    assert_eq!(
+        render_setup_output(&report),
+        "No changes to the environment were made. Everything is already up to date.",
+    );
+}
+
+#[test]
+fn created_config_reports_the_source_hint() {
+    let report = report(ConfigFileChangeType::Created, "", "export PNPM_HOME=...");
+    assert_eq!(
+        render_setup_output(&report),
+        "Created /home/user/.bashrc\n\nNext configuration changes were made:\nexport PNPM_HOME=...\n\nTo start using pnpm, run:\nsource /home/user/.bashrc\n",
+    );
+}
+
+#[test]
+fn windows_report_omits_the_source_hint() {
+    let report = PathExtenderReport {
+        config_file: None,
+        old_settings: String::new(),
+        new_settings: r"PNPM_HOME=C:\pnpm".to_string(),
+    };
+    assert_eq!(
+        render_setup_output(&report),
+        "Next configuration changes were made:\nPNPM_HOME=C:\\pnpm\n\nSetup complete. Open a new terminal to start using pnpm.",
+    );
+}
+
+#[test]
+fn alias_scripts_are_written_and_executable() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let bin_dir = dir.path().join("bin");
+    create_alias_scripts(&bin_dir).expect("write alias scripts");
+
+    let pn = bin_dir.join("pn");
+    assert_eq!(std::fs::read_to_string(&pn).expect("read pn"), "#!/bin/sh\nexec pnpm \"$@\"\n");
+    assert_eq!(
+        std::fs::read_to_string(bin_dir.join("pnpx")).expect("read pnpx"),
+        "#!/bin/sh\nexec pnpm dlx \"$@\"\n",
+    );
+    assert_eq!(
+        std::fs::read_to_string(bin_dir.join("pnx")).expect("read pnx"),
+        "#!/bin/sh\nexec pnpm dlx \"$@\"\n",
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&pn).expect("stat pn").permissions().mode();
+        assert_eq!(mode & 0o777, 0o755);
+    }
+}


### PR DESCRIPTION
## Summary

Ports pnpm's `setup` command to the pacquet (Rust) CLI, making `pnpm`
available for global use. It mirrors `pnpm11/engine/pm/commands/src/setup/setup.ts`
and the `@pnpm/os.env.path-extender` package family that command depends on.

What `pacquet setup` does, matching pnpm:

- Installs the CLI into the global packages directory by spawning
  `<exe> add -g --ignore-scripts file:<execDir>` (writing a temporary
  `@pnpm/exe` package.json when none exists, then removing it).
- Writes the `pn` / `pnpx` / `pnx` alias scripts into `$PNPM_HOME/bin`
  (POSIX `sh` scripts everywhere, plus `.cmd` / `.ps1` on Windows).
- Persists `PNPM_HOME` and `$PNPM_HOME/bin` into the user's environment:
  the current shell's rc file on POSIX (bash/zsh/ksh/dash/sh/fish/nushell),
  or the registry (`reg` / `chcp` / `setx`) on Windows.

Implementation notes:

- The path-extender is inlined as a private module under the command. The
  shell rc-block create/append/skip/modify logic and the Windows `reg query`
  line parsing use plain string operations rather than adding a `regex`
  dependency.
- Error codes mirror pnpm's `PnpmError` codes (`ERR_PNPM_BAD_SHELL_SECTION`,
  `ERR_PNPM_BAD_ENV_FOUND`, `ERR_PNPM_UNKNOWN_SHELL`, …), including the
  `--force` hints.
- Unit tests port the upstream `path-extender-posix` spec cases and cover the
  Windows registry parser/renderer and the output rendering (26 tests).

No standalone end-to-end test for the full command: the flow always
self-installs via `add -g file:<execDir>`, which on a dev build points at the
build output directory — too heavy/side-effecting for a spawned-binary test.
This matches upstream, whose setup tests also skip the single-executable
branch. The Windows registry path is selected at runtime via `cfg!(windows)`
(so it compiles on all targets) but is only fully exercisable on Windows.

## Squash Commit Body

```text
Port pnpm's `setup` command to pacquet, making `pnpm` available for global
use. Mirrors pnpm11/engine/pm/commands/src/setup/setup.ts and the
`@pnpm/os.env.path-extender` package family it depends on.

The command installs the CLI into the global packages directory (spawning
`<exe> add -g --ignore-scripts file:<execDir>` with a temporary `@pnpm/exe`
package.json, as pnpm does), writes the `pn` / `pnpx` / `pnx` alias scripts
into `$PNPM_HOME/bin`, and persists `PNPM_HOME` plus `$PNPM_HOME/bin` into
the user's environment — the current shell's rc file on POSIX
(bash/zsh/ksh/dash/sh/fish/nushell) or the registry on Windows.

The path-extender is inlined as a private module under the command. The
shell rc-block editing and the Windows `reg query` parsing use plain string
operations rather than a regex dependency. Error codes mirror pnpm's
PnpmError codes, including the `--force` hints.

Unit tests port the upstream path-extender-posix spec cases and cover the
Windows registry parser/renderer and the output rendering.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  (TypeScript `setup` already exists; this is the pacquet-side port. pnpm is
  the source of truth.)
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `setup` command to configure the CLI for global use.
  * Installs pnpm globally and generates `pn`, `pnx`, and `pnpx` launcher scripts (with Windows equivalents).
  * Updates your shell `PATH` persistently, using shell rc/config blocks on Unix and the Windows user environment registry on Windows.
  * Includes clear install status output and a `--force/-f` option to overwrite existing configuration.

* **Bug Fixes**
  * Improves safety by validating `PNPM_HOME`, preventing duplicate `PATH` entries, and escaping proxy values to avoid unintended shell expansion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->