### PR TITLE
feat(pnpr): make resolver cache authorization-aware

### DIFF
--- a/.changeset/pnpr-no-forwarded-upstream-credentials.md
+++ b/.changeset/pnpr-no-forwarded-upstream-credentials.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": minor
+"@pnpm/pnpr.client": minor
+"pnpm": minor
+---
+
+When resolving through a pnpr install-accelerator server, pnpm no longer forwards its own upstream registry credentials in the resolve request. Only the `Authorization` header identifying the caller to pnpr is sent. The pnpr server now selects upstream credentials from its own route policy (operator-configured upstream credential aliases), so private dependencies resolve through a pnpr-managed alias the caller is authorized to use, rather than by sending the client's registry tokens to the server.

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -676,10 +676,9 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
         optional_dependencies,
         registry: resolve_registry,
         named_registries: state.config.named_registries.clone(),
-        // Forward the whole credential map: the registries a graph
-        // touches aren't known up front (scope-routed or tarball-URL
-        // sub-deps), so the server attaches the right token per URL.
-        auth_headers: state.config.auth_headers.to_by_scope(),
+        // Only the caller's identity to pnpr is sent. Upstream registry
+        // credentials are never forwarded: pnpr selects them from its own
+        // route policy, so they stay out of the request body.
         authorization: state.config.auth_headers.for_url(pnpr_server),
         overrides,
         lockfile: state

--- a/pacquet/crates/cli/tests/pnpr_install.rs
+++ b/pacquet/crates/cli/tests/pnpr_install.rs
@@ -2,10 +2,11 @@
 //!
 //! Runs the real `pacquet` binary against a mocked fixtures registry,
 //! with an in-process `pnpr` hosting the fast-path endpoints. The pnpr
-//! server's own uplink is left at the default — the client sends the
-//! registry it wants resolved from (the mock), so a passing test proves
-//! resolution used the client-supplied registry. The client then links
-//! `node_modules` from the server-produced lockfile.
+//! server's own uplink is left at the default; the client sends the
+//! registry it wants resolved from (the mock, which the server allowlists
+//! as a public route), so a passing test proves resolution used the
+//! client-supplied registry. The client then links `node_modules` from the
+//! server-produced lockfile.
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
@@ -24,8 +25,11 @@ use std::{
 };
 
 /// Start an in-process pnpr with the fast-path endpoints on a detached
-/// thread; returns its base URL and a pre-seeded bearer token.
-fn start_pnpr() -> (String, String) {
+/// thread, allowlisting `registry_url` as a public route so the client may
+/// resolve against it (off-allowlist registries are rejected at the request
+/// boundary); returns its base URL and a pre-seeded bearer token.
+fn start_pnpr(registry_url: &str) -> (String, String) {
+    let registry_url = registry_url.to_string();
     // Persisted (not cleaned) because the detached server thread outlives
     // this function.
     let storage = tempfile::tempdir().expect("pnpr storage").keep();
@@ -54,6 +58,10 @@ fn start_pnpr() -> (String, String) {
                 let mut config = pnpr::Config::proxy(addr, storage);
                 config.public_url = format!("http://{addr}");
                 config.auth.tokens.file = Some(tokens_path);
+                config
+                    .route_policy
+                    .public
+                    .push(pnpr::PublicRoute { registry: Some(registry_url), package: None });
                 let listener = tokio::net::TcpListener::from_std(listener).expect("tokio listener");
                 let _ = pnpr::serve_listener(config, listener).await;
             });
@@ -93,7 +101,7 @@ fn install_via_pnpr_links_node_modules() {
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { npmrc_path, store_dir, mock_instance, .. } = npmrc_info;
 
-    let (pnpr_url, token) = start_pnpr();
+    let (pnpr_url, token) = start_pnpr(&mock_instance.url());
     configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);
 
     let manifest_path = workspace.join("package.json");
@@ -128,7 +136,7 @@ fn frozen_install_via_pnpr_verifies_the_local_lockfile_without_resolving_or_redo
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { npmrc_path, mock_instance, .. } = npmrc_info;
 
-    let (pnpr_url, token) = start_pnpr();
+    let (pnpr_url, token) = start_pnpr(&mock_instance.url());
     configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);
 
     let manifest_path = workspace.join("package.json");
@@ -198,7 +206,7 @@ fn install_via_pnpr_lockfile_only_writes_lockfile_without_linking() {
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { npmrc_path, store_dir, mock_instance, .. } = npmrc_info;
 
-    let (pnpr_url, token) = start_pnpr();
+    let (pnpr_url, token) = start_pnpr(&mock_instance.url());
     configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);
 
     let manifest_path = workspace.join("package.json");
@@ -232,7 +240,7 @@ fn import_via_pnpr_server_writes_lockfile_without_linking() {
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { npmrc_path, store_dir, mock_instance, .. } = npmrc_info;
 
-    let (pnpr_url, token) = start_pnpr();
+    let (pnpr_url, token) = start_pnpr(&mock_instance.url());
     configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);
 
     let manifest_path = workspace.join("package.json");

--- a/pacquet/crates/network/src/auth.rs
+++ b/pacquet/crates/network/src/auth.rs
@@ -17,9 +17,11 @@
 //! key at that host or prefix in `.npmrc`; if it redirects across
 //! hosts, no header is attached, matching upstream.
 
-use std::collections::{BTreeMap, HashMap};
-use std::fmt;
-use std::sync::Arc;
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt,
+    sync::Arc,
+};
 
 pub const DEFAULT_REGISTRY_SCOPE: &str = "@";
 

--- a/pacquet/crates/network/src/auth.rs
+++ b/pacquet/crates/network/src/auth.rs
@@ -48,6 +48,44 @@ pub trait UpstreamRouteHook: Send + Sync {
     /// package `package` (`None` for non-package fetches), and record the
     /// route the decision selected. `None` means fetch anonymously.
     fn authorize(&self, url: &str, package: Option<&str>) -> Option<String>;
+
+    /// Classify the metadata cache scope for a fetch to `url` for package
+    /// `package` (`None` for non-package fetches). Unlike [`Self::authorize`]
+    /// this is a read-only query — it must **not** record into the resolve's
+    /// footprint — so the resolver can pick the on-disk mirror namespace and
+    /// in-memory/fetch-lock keys without double-counting a route.
+    ///
+    /// Defaults to [`MetadataCacheScope::Public`] for hooks that don't
+    /// partition metadata by route.
+    fn metadata_scope(&self, _url: &str, _package: Option<&str>) -> MetadataCacheScope {
+        MetadataCacheScope::Public
+    }
+}
+
+/// The cache namespace a metadata fetch for one `(registry, package)` route
+/// belongs to, decided once per fetch from the route policy. A server (pnpr)
+/// that resolves on behalf of many callers must keep one caller's private
+/// metadata out of the global mirror every other caller reads; this enum is
+/// how the route decision reaches the npm resolver's mirror path, in-memory
+/// cache key, and fetch-lock key.
+///
+/// The pnpm CLI has no route hook, so every fetch is [`Self::Public`] and the
+/// global mirror behaves exactly as before.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MetadataCacheScope {
+    /// Public route: the shared, global metadata mirror — current behavior,
+    /// shared by every caller.
+    Public,
+    /// Private route keyed by a private access descriptor. `descriptor_id`
+    /// is a filesystem-safe, server-secret-keyed digest that namespaces the
+    /// on-disk mirror, in-memory cache, and fetch lock, so one caller's
+    /// private metadata never satisfies a fetch for a caller who does not
+    /// reproduce the same descriptor.
+    Private { descriptor_id: String },
+    /// Unknown-private route with no shareable descriptor: never read or
+    /// write a shared mirror or in-memory entry. The fetch is performed
+    /// fresh and its result stays request-local.
+    Bypass,
 }
 
 /// Bag of `Authorization` header values keyed by the nerf-darted form
@@ -271,6 +309,18 @@ impl AuthHeaders {
     pub fn record_route(&self, url: &str, pkg_name: Option<&str>) {
         if let Some(hook) = &self.route_hook {
             hook.authorize(url, pkg_name);
+        }
+    }
+
+    /// The metadata cache scope a fetch to `url` for `pkg_name` belongs to.
+    /// A server route hook owns the decision; without one (the CLI case)
+    /// every fetch is [`MetadataCacheScope::Public`], leaving the global
+    /// mirror unchanged. Read-only — never records into a footprint.
+    #[must_use]
+    pub fn metadata_scope(&self, url: &str, pkg_name: Option<&str>) -> MetadataCacheScope {
+        match &self.route_hook {
+            Some(hook) => hook.metadata_scope(url, pkg_name),
+            None => MetadataCacheScope::Public,
         }
     }
 

--- a/pacquet/crates/network/src/auth.rs
+++ b/pacquet/crates/network/src/auth.rs
@@ -18,10 +18,35 @@
 //! hosts, no header is attached, matching upstream.
 
 use std::collections::{BTreeMap, HashMap};
+use std::fmt;
+use std::sync::Arc;
 
 pub const DEFAULT_REGISTRY_SCOPE: &str = "@";
 
 pub type AuthHeadersByScope = BTreeMap<String, BTreeMap<String, String>>;
+
+/// Server-side override for upstream auth selection.
+///
+/// A plain [`AuthHeaders`] answers "what `Authorization` header does the
+/// client's `.npmrc` attach to this URL?" — the right question for the
+/// pnpm CLI, which fetches as the user. A server (pnpr) that resolves on
+/// behalf of many callers must instead answer "what credential does *this
+/// deployment's route policy* attach to this fetch, for this caller?" and
+/// record which private route was touched so the result can be cached
+/// without leaking one caller's private resolution to another.
+///
+/// When a hook is attached via [`AuthHeaders::with_route_hook`], every
+/// [`AuthHeaders::for_url`] / [`AuthHeaders::for_url_with_package`] lookup
+/// is delegated to it: the client-forwarded credentials carried by the
+/// [`AuthHeaders`] are ignored, and the hook alone decides the header
+/// (returning `None` for an anonymous/public fetch) and records the
+/// route. A `None` hook (the CLI case) leaves lookup behavior unchanged.
+pub trait UpstreamRouteHook: Send + Sync {
+    /// Decide the `Authorization` header value for a fetch to `url` for
+    /// package `package` (`None` for non-package fetches), and record the
+    /// route the decision selected. `None` means fetch anonymously.
+    fn authorize(&self, url: &str, package: Option<&str>) -> Option<String>;
+}
 
 /// Bag of `Authorization` header values keyed by the nerf-darted form
 /// of each registry URL. Pacquet builds one of these from the parsed
@@ -30,7 +55,7 @@ pub type AuthHeadersByScope = BTreeMap<String, BTreeMap<String, String>>;
 /// Construct via [`AuthHeaders::from_parts`], [`AuthHeaders::from_creds_map`],
 /// [`AuthHeaders::from_map`], or [`AuthHeaders::default`] (empty). Look up via
 /// [`AuthHeaders::for_url`].
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
 pub struct AuthHeaders {
     /// Keys are the nerf-darted form (`//host[:port]/path/`). Values
     /// are ready-to-send header values like `Bearer abc123` or
@@ -47,6 +72,23 @@ pub struct AuthHeaders {
     /// The longest registry key per package scope, measured the same
     /// way as `max_parts`.
     max_scoped_parts_by_scope: HashMap<String, usize>,
+    /// Server-side route hook. When set, it owns every auth lookup and
+    /// the client-forwarded credentials above are ignored. See
+    /// [`UpstreamRouteHook`].
+    route_hook: Option<Arc<dyn UpstreamRouteHook>>,
+}
+
+impl fmt::Debug for AuthHeaders {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Header values carry credentials, so the maps' *contents* must
+        // never reach a log line; show only key counts plus whether a
+        // server route hook is overriding lookup.
+        f.debug_struct("AuthHeaders")
+            .field("by_uri", &self.by_uri.len())
+            .field("scoped_by_scope", &self.scoped_by_scope.len())
+            .field("route_hook", &self.route_hook.is_some())
+            .finish_non_exhaustive()
+    }
 }
 
 impl AuthHeaders {
@@ -132,7 +174,13 @@ impl AuthHeaders {
             }
         }
         let max_parts = by_uri.keys().map(|key| key.split('/').count()).max().unwrap_or(0);
-        AuthHeaders { by_uri, scoped_by_scope, max_parts, max_scoped_parts_by_scope }
+        AuthHeaders {
+            by_uri,
+            scoped_by_scope,
+            max_parts,
+            max_scoped_parts_by_scope,
+            route_hook: None,
+        }
     }
 
     /// Build an [`AuthHeaders`] from the structured pnpr wire shape:
@@ -194,10 +242,29 @@ impl AuthHeaders {
         self.for_url_with_package(url, None)
     }
 
+    /// Attach a server-side [`UpstreamRouteHook`] that takes over auth
+    /// selection. The returned [`AuthHeaders`] keeps its
+    /// client-forwarded credentials (so [`Self::to_by_scope`] still
+    /// reflects them) but no longer consults them on lookup — the hook
+    /// decides. Used by pnpr to resolve as the deployment's route policy
+    /// rather than as the calling client.
+    #[must_use]
+    pub fn with_route_hook(mut self, hook: Arc<dyn UpstreamRouteHook>) -> Self {
+        self.route_hook = Some(hook);
+        self
+    }
+
     /// Resolve an `Authorization` header for `url`, preferring
     /// package-scope credentials when `pkg_name` is scoped.
     #[must_use]
     pub fn for_url_with_package(&self, url: &str, pkg_name: Option<&str>) -> Option<String> {
+        // A server route hook owns the decision: ignore the
+        // client-forwarded credentials entirely (including any inline
+        // `user:pass@` in `url`) and let the deployment's policy pick the
+        // credential and record the route.
+        if let Some(hook) = &self.route_hook {
+            return hook.authorize(url, pkg_name);
+        }
         // Append a trailing `/` first, matching pnpm's lookup which
         // does the same before parsing. Without this, a URL like
         // `https://npm.pkg.github.com/pnpm` (registry without

--- a/pacquet/crates/network/src/auth.rs
+++ b/pacquet/crates/network/src/auth.rs
@@ -82,10 +82,6 @@ pub enum MetadataCacheScope {
     /// private metadata never satisfies a fetch for a caller who does not
     /// reproduce the same descriptor.
     Private { descriptor_id: String },
-    /// Unknown-private route with no shareable descriptor: never read or
-    /// write a shared mirror or in-memory entry. The fetch is performed
-    /// fresh and its result stays request-local.
-    Bypass,
 }
 
 /// Bag of `Authorization` header values keyed by the nerf-darted form

--- a/pacquet/crates/network/src/auth.rs
+++ b/pacquet/crates/network/src/auth.rs
@@ -256,6 +256,24 @@ impl AuthHeaders {
         self
     }
 
+    /// Record the route for a metadata/tarball fetch that is about to be
+    /// served from an in-memory or on-disk cache *without* an HTTP
+    /// request, so a server [`UpstreamRouteHook`]'s footprint still
+    /// reflects every private route the resolve depended on. The route is
+    /// classified exactly as the real fetch would have (same `url`, same
+    /// `pkg_name`); the credential the hook selects is discarded because
+    /// no request is sent.
+    ///
+    /// No-op when no route hook is installed (the CLI case): a fetch that
+    /// never happens needs no `Authorization` header, and the CLI keeps no
+    /// footprint. Idempotent for the hook — recording the same route more
+    /// than once collapses to one footprint entry.
+    pub fn record_route(&self, url: &str, pkg_name: Option<&str>) {
+        if let Some(hook) = &self.route_hook {
+            hook.authorize(url, pkg_name);
+        }
+    }
+
     /// Resolve an `Authorization` header for `url`, preferring
     /// package-scope credentials when `pkg_name` is scoped.
     #[must_use]

--- a/pacquet/crates/network/src/auth/tests.rs
+++ b/pacquet/crates/network/src/auth/tests.rs
@@ -32,7 +32,7 @@ fn route_hook_overrides_client_credentials() {
     // Without a hook the client-forwarded token is returned.
     assert_eq!(
         client_creds.for_url("https://reg.com/pkg"),
-        Some("Bearer client-token".to_string())
+        Some("Bearer client-token".to_string()),
     );
 
     let hook =

--- a/pacquet/crates/network/src/auth/tests.rs
+++ b/pacquet/crates/network/src/auth/tests.rs
@@ -44,6 +44,27 @@ fn route_hook_overrides_client_credentials() {
 }
 
 #[test]
+fn record_route_drives_the_hook_without_a_fetch() {
+    let hook =
+        Arc::new(RecordingHook { answer: Some("Bearer alias".to_string()), ..Default::default() });
+    let hooked =
+        AuthHeaders::default().with_route_hook(Arc::clone(&hook) as Arc<dyn UpstreamRouteHook>);
+    // A cache-served metadata pick records its route through the hook so a
+    // server footprint stays complete, discarding the selected credential
+    // because no request is sent.
+    hooked.record_route("https://reg.com/@scope/pkg", Some("@scope/pkg"));
+    assert_eq!(hook.calls.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn record_route_is_a_noop_without_a_hook() {
+    // The CLI never installs a hook: a fetch that doesn't happen needs no
+    // header and there is no footprint to record into. This must not panic
+    // or otherwise touch the client-forwarded credentials.
+    AuthHeaders::default().record_route("https://reg.com/pkg", None);
+}
+
+#[test]
 fn route_hook_suppresses_inline_url_basic_auth() {
     // A bare `AuthHeaders` would synthesize a `Basic` header from inline
     // `user:pass@`; with a hook attached the inline credential must not

--- a/pacquet/crates/network/src/auth/tests.rs
+++ b/pacquet/crates/network/src/auth/tests.rs
@@ -1,8 +1,57 @@
 use super::{
-    AuthHeaders, DEFAULT_REGISTRY_SCOPE, base64_encode, nerf_dart, redact_and_sanitize,
-    redact_url_credentials,
+    AuthHeaders, DEFAULT_REGISTRY_SCOPE, UpstreamRouteHook, base64_encode, nerf_dart,
+    redact_and_sanitize, redact_url_credentials,
 };
 use pretty_assertions::assert_eq;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+/// Records every `(url, package)` it is asked about and answers with a
+/// fixed header, so a test can assert the hook — not the client
+/// credentials — drove the lookup.
+#[derive(Default)]
+struct RecordingHook {
+    calls: AtomicUsize,
+    answer: Option<String>,
+}
+
+impl UpstreamRouteHook for RecordingHook {
+    fn authorize(&self, _url: &str, _package: Option<&str>) -> Option<String> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        self.answer.clone()
+    }
+}
+
+#[test]
+fn route_hook_overrides_client_credentials() {
+    let client_creds = AuthHeaders::from_map(
+        std::iter::once(("//reg.com/".to_string(), "Bearer client-token".to_string())).collect(),
+    );
+    // Without a hook the client-forwarded token is returned.
+    assert_eq!(
+        client_creds.for_url("https://reg.com/pkg"),
+        Some("Bearer client-token".to_string())
+    );
+
+    let hook =
+        Arc::new(RecordingHook { answer: Some("Bearer alias".to_string()), ..Default::default() });
+    let hooked = client_creds.with_route_hook(Arc::clone(&hook) as Arc<dyn UpstreamRouteHook>);
+    // With a hook the client token is ignored and the hook decides.
+    assert_eq!(hooked.for_url("https://reg.com/pkg"), Some("Bearer alias".to_string()));
+    assert_eq!(hook.calls.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn route_hook_suppresses_inline_url_basic_auth() {
+    // A bare `AuthHeaders` would synthesize a `Basic` header from inline
+    // `user:pass@`; with a hook attached the inline credential must not
+    // leak through — the hook (returning None here) owns the decision.
+    let hook = Arc::new(RecordingHook::default());
+    let hooked = AuthHeaders::default().with_route_hook(hook as Arc<dyn UpstreamRouteHook>);
+    assert_eq!(hooked.for_url("https://user:pass@reg.com/pkg"), None);
+}
 
 #[test]
 fn redact_url_credentials_strips_embedded_basic_auth() {

--- a/pacquet/crates/network/src/lib.rs
+++ b/pacquet/crates/network/src/lib.rs
@@ -280,6 +280,40 @@ impl ThrottledClient {
         per_registry: &PerRegistryTls,
         settings: &NetworkSettings,
     ) -> Result<Self, ForInstallsError> {
+        Self::for_installs_with_redirect(proxy, tls, per_registry, settings, None)
+    }
+
+    /// Like [`Self::new_for_installs`] but installs `redirect_guard` as the
+    /// client's redirect policy: every redirect hop is re-validated by the
+    /// guard, and a hop it rejects fails the request without fetching. pnpr
+    /// resolves on behalf of untrusted callers, so it passes a guard that
+    /// re-checks each redirect target against its fetch allowlist — otherwise
+    /// an allowlisted registry could `302` pnpr onto an internal host, slipping
+    /// a server-side request past the request-boundary allowlist (SSRF). The
+    /// CLI fetches on the user's own behalf and keeps the default follow
+    /// policy via [`Self::new_for_installs`].
+    #[must_use]
+    pub fn new_for_installs_with_redirect_guard(
+        is_allowed: impl Fn(&reqwest::Url) -> bool + Send + Sync + 'static,
+    ) -> Self {
+        let redirect_guard: RedirectGuard = Arc::new(is_allowed);
+        Self::for_installs_with_redirect(
+            &ProxyConfig::default(),
+            &TlsConfig::default(),
+            &PerRegistryTls::default(),
+            &NetworkSettings::default(),
+            Some(&redirect_guard),
+        )
+        .expect("default proxy + TLS configs carry no URLs/PEMs and cannot fail")
+    }
+
+    fn for_installs_with_redirect(
+        proxy: &ProxyConfig,
+        tls: &TlsConfig,
+        per_registry: &PerRegistryTls,
+        settings: &NetworkSettings,
+        redirect_guard: Option<&RedirectGuard>,
+    ) -> Result<Self, ForInstallsError> {
         if settings.network_concurrency == 0 {
             return Err(ForInstallsError::ZeroNetworkConcurrency);
         }
@@ -305,6 +339,9 @@ impl ThrottledClient {
                 builder = builder.add_root_certificate(cert.clone());
             }
             builder = apply_tls(builder, effective_tls)?;
+            if let Some(guard) = redirect_guard {
+                builder = builder.redirect(allowlist_redirect_policy(Arc::clone(guard)));
+            }
             Ok(builder.build().expect("build reqwest client with default timeouts and proxy"))
         };
 
@@ -402,6 +439,43 @@ impl ThrottledClient {
 /// total deadline and undici `connectTimeout = fetchTimeout + 1`).
 /// `settings.user_agent` is sent verbatim; a value that cannot be
 /// encoded as an HTTP header falls back to [`DEFAULT_USER_AGENT`].
+/// A redirect-hop validator: returns `true` to follow a redirect to `url`,
+/// `false` to block it. See
+/// [`ThrottledClient::new_for_installs_with_redirect_guard`].
+pub type RedirectGuard = Arc<dyn Fn(&reqwest::Url) -> bool + Send + Sync>;
+
+/// Cap on redirect hops, matching reqwest's default `Policy::default()` limit
+/// so the guarded client doesn't follow a redirect chain further than the
+/// unguarded one would.
+const MAX_REDIRECT_HOPS: usize = 10;
+
+/// A redirect target the [`RedirectGuard`] rejected. Surfaced as the request
+/// error so a blocked redirect fails loudly rather than silently fetching.
+#[derive(Debug)]
+struct BlockedRedirect(reqwest::Url);
+
+impl std::fmt::Display for BlockedRedirect {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "redirect to {} is not allowed by the fetch allowlist", self.0)
+    }
+}
+
+impl std::error::Error for BlockedRedirect {}
+
+/// A reqwest redirect policy that consults `guard` for every hop: an allowed
+/// target is followed (up to [`MAX_REDIRECT_HOPS`]), a rejected one fails the
+/// request with [`BlockedRedirect`] instead of being fetched.
+fn allowlist_redirect_policy(guard: RedirectGuard) -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(move |attempt| {
+        let target = attempt.url().clone();
+        if attempt.previous().len() >= MAX_REDIRECT_HOPS || !guard(&target) {
+            attempt.error(BlockedRedirect(target))
+        } else {
+            attempt.follow()
+        }
+    })
+}
+
 fn default_client_builder(settings: &NetworkSettings) -> reqwest::ClientBuilder {
     let user_agent = HeaderValue::from_str(&settings.user_agent)
         .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT));

--- a/pacquet/crates/network/src/lib.rs
+++ b/pacquet/crates/network/src/lib.rs
@@ -456,7 +456,20 @@ struct BlockedRedirect(reqwest::Url);
 
 impl std::fmt::Display for BlockedRedirect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "redirect to {} is not allowed by the fetch allowlist", self.0)
+        // Surface only `scheme://host[:port]` — never the path, query,
+        // fragment, or userinfo, where a presigned-URL signature/token could
+        // live. This error string can reach a client, so it must not leak the
+        // very credential the redirect was carrying.
+        write!(
+            f,
+            "redirect to {}://{}",
+            self.0.scheme(),
+            self.0.host_str().unwrap_or("<unknown>"),
+        )?;
+        if let Some(port) = self.0.port() {
+            write!(f, ":{port}")?;
+        }
+        write!(f, " is not allowed by the fetch allowlist")
     }
 }
 

--- a/pacquet/crates/network/src/lib.rs
+++ b/pacquet/crates/network/src/lib.rs
@@ -7,8 +7,8 @@ mod tests;
 mod tls;
 
 pub use auth::{
-    AuthHeaders, AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE, UpstreamRouteHook, base64_encode,
-    nerf_dart, redact_and_sanitize, redact_url_credentials,
+    AuthHeaders, AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE, MetadataCacheScope, UpstreamRouteHook,
+    base64_encode, nerf_dart, redact_and_sanitize, redact_url_credentials,
 };
 pub use proxy::{NoProxySetting, ProxyConfig, ProxyError};
 pub use retry::{RetryOpts, retry_async, send_with_retry, should_retry_status};

--- a/pacquet/crates/network/src/lib.rs
+++ b/pacquet/crates/network/src/lib.rs
@@ -7,8 +7,8 @@ mod tests;
 mod tls;
 
 pub use auth::{
-    AuthHeaders, AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE, base64_encode, nerf_dart,
-    redact_and_sanitize, redact_url_credentials,
+    AuthHeaders, AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE, UpstreamRouteHook, base64_encode,
+    nerf_dart, redact_and_sanitize, redact_url_credentials,
 };
 pub use proxy::{NoProxySetting, ProxyConfig, ProxyError};
 pub use retry::{RetryOpts, retry_async, send_with_retry, should_retry_status};

--- a/pacquet/crates/network/src/tests.rs
+++ b/pacquet/crates/network/src/tests.rs
@@ -726,3 +726,56 @@ fn default_network_concurrency_stays_within_floor_and_cap() {
     let concurrency = super::default_network_concurrency();
     assert!((64..=96).contains(&concurrency), "got {concurrency}");
 }
+
+/// A redirect to a host the guard rejects must fail the request before the
+/// off-allowlist target is ever contacted — the redirect SSRF boundary.
+#[tokio::test]
+async fn redirect_guard_blocks_off_allowlist_redirect_target() {
+    let mut server = mockito::Server::new_async().await;
+    let redirect = server
+        .mock("GET", "/pkg")
+        .with_status(302)
+        .with_header("location", "http://169.254.169.254/internal")
+        .create_async()
+        .await;
+
+    // Allow only the entry server's own origin, never the redirect target.
+    let allowed = format!("{}/", server.url());
+    let client = ThrottledClient::new_for_installs_with_redirect_guard(move |url| {
+        url.as_str().starts_with(&allowed)
+    });
+    let guard = client.acquire().await;
+    let result = guard.get(format!("{}/pkg", server.url())).send().await;
+
+    redirect.assert_async().await;
+    assert!(result.is_err(), "a redirect to an off-allowlist host must be blocked");
+}
+
+/// A redirect whose target the guard allows is followed normally, so an
+/// allowlisted registry that legitimately redirects keeps working.
+#[tokio::test]
+async fn redirect_guard_follows_allowlisted_redirect_target() {
+    let mut target = mockito::Server::new_async().await;
+    let body = target.mock("GET", "/final").with_status(200).with_body("ok").create_async().await;
+    let mut entry = mockito::Server::new_async().await;
+    let redirect = entry
+        .mock("GET", "/pkg")
+        .with_status(302)
+        .with_header("location", &format!("{}/final", target.url()))
+        .create_async()
+        .await;
+
+    let entry_origin = format!("{}/", entry.url());
+    let target_origin = format!("{}/", target.url());
+    let client = ThrottledClient::new_for_installs_with_redirect_guard(move |url| {
+        let url = url.as_str();
+        url.starts_with(&entry_origin) || url.starts_with(&target_origin)
+    });
+    let guard = client.acquire().await;
+    let resp = guard.get(format!("{}/pkg", entry.url())).send().await.expect("redirect followed");
+
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.expect("body"), "ok");
+    redirect.assert_async().await;
+    body.assert_async().await;
+}

--- a/pacquet/crates/network/src/tests.rs
+++ b/pacquet/crates/network/src/tests.rs
@@ -727,6 +727,20 @@ fn default_network_concurrency_stays_within_floor_and_cap() {
     assert!((64..=96).contains(&concurrency), "got {concurrency}");
 }
 
+/// The blocked-redirect error must name only the origin, never the path or
+/// query/fragment where a presigned-URL signature/token lives — the error can
+/// reach a client.
+#[test]
+fn blocked_redirect_error_redacts_token() {
+    let url = Url::parse("https://cdn.example:8443/asset.tgz?X-Amz-Signature=topsecret#frag")
+        .expect("valid url");
+    let message = super::BlockedRedirect(url).to_string();
+    assert!(message.contains("https://cdn.example:8443"), "got: {message}");
+    assert!(!message.contains("topsecret"), "token leaked: {message}");
+    assert!(!message.contains("asset.tgz"), "path leaked: {message}");
+    assert!(!message.contains("frag"), "fragment leaked: {message}");
+}
+
 /// A redirect to a host the guard rejects must fail the request before the
 /// off-allowlist target is ever contacted — the redirect SSRF boundary.
 #[tokio::test]

--- a/pacquet/crates/package-manager/src/resolution_observer.rs
+++ b/pacquet/crates/package-manager/src/resolution_observer.rs
@@ -43,6 +43,14 @@ pub struct ResolvedPackageHint<'a> {
     /// registry published one. The per-file term of the download
     /// priority's pipeline-work estimate.
     pub file_count: Option<usize>,
+    /// Whether the package resolved from a registry (npm / named / jsr), so
+    /// [`Self::tarball_url`] is the registry packument's `dist.tarball`. A
+    /// server router must classify such a package by its *registry* route, not
+    /// by the tarball host — which can differ for a split-domain registry —
+    /// to avoid emitting (and leaking) a private upstream tarball URL. `false`
+    /// for a direct tarball/git/local dependency, whose tarball URL *is* its
+    /// source.
+    pub from_registry: bool,
 }
 
 /// Sink notified once per resolved tarball package during a resolve.
@@ -110,8 +118,15 @@ impl ObservingResolver {
             tarball_url,
             unpacked_size: manifest_unpacked_size(result.manifest.as_deref()),
             file_count: manifest_file_count(result.manifest.as_deref()),
+            from_registry: is_registry_resolution(&result.resolved_via),
         });
     }
+}
+
+/// Whether `resolved_via` denotes a registry protocol whose `dist.tarball`
+/// comes from a packument (and so can point at a split-domain host).
+fn is_registry_resolution(resolved_via: &str) -> bool {
+    matches!(resolved_via, "npm-registry" | "named-registry" | "jsr-registry")
 }
 
 impl Resolver for ObservingResolver {

--- a/pacquet/crates/pnpr-client/src/lib.rs
+++ b/pacquet/crates/pnpr-client/src/lib.rs
@@ -11,8 +11,8 @@
 //! then fetches the rest in parallel like a normal install
 //! ([pnpm/pnpm#12230](https://github.com/pnpm/pnpm/issues/12230)).
 //!
-//! pnpr is a stateless resolver: it stores no tarballs and serves no file
-//! content.
+//! pnpr is a stateless resolver: it stores no tarballs. Resolved tarballs
+//! are fetched from upstream public URLs or pnpr's read-only gateway.
 
 use std::collections::BTreeMap;
 
@@ -230,10 +230,8 @@ impl PnprClient {
     }
 
     /// Resolve a single project against the server and return the
-    /// resolved lockfile, ignoring the streamed per-package frames. The
-    /// server serves no file content — the caller fetches every tarball
-    /// itself. Equivalent to [`Self::resolve_streaming`] with a no-op
-    /// callback.
+    /// resolved lockfile, ignoring the streamed per-package frames.
+    /// Equivalent to [`Self::resolve_streaming`] with a no-op callback.
     pub async fn resolve(&self, opts: ResolveOptions) -> Result<ResolveOutcome, PnprClientError> {
         self.resolve_streaming(opts, |_| {}).await
     }

--- a/pacquet/crates/pnpr-client/src/lib.rs
+++ b/pacquet/crates/pnpr-client/src/lib.rs
@@ -21,7 +21,6 @@ use futures_util::StreamExt as _;
 use pacquet_config::TrustPolicy;
 use pacquet_lockfile::Lockfile;
 use pacquet_lockfile_verification::{RenderedViolation, VerifyError};
-use pacquet_network::AuthHeadersByScope;
 use reqwest::Client;
 use serde::Deserialize;
 
@@ -46,13 +45,10 @@ pub struct ResolveOptions {
     pub registry: String,
     /// The client's named-registry aliases.
     pub named_registries: DepMap,
-    /// The caller's forwarded upstream credentials, keyed by nerf-darted
-    /// registry URI and package scope. The `@` scope stores registry-wide
-    /// auth. Distinct from [`Self::authorization`] (pnpr identity).
-    pub auth_headers: AuthHeadersByScope,
     /// `Authorization` for the pnpr server's own URL (`None` if it needs
-    /// none): identifies the caller to pnpr. Distinct from the upstream
-    /// creds in [`Self::auth_headers`].
+    /// none): identifies the caller to pnpr. The client never forwards its
+    /// own registry credentials — pnpr selects upstream credentials from
+    /// its route policy, so none are placed in the request body.
     pub authorization: Option<String>,
     /// The client's `overrides` (selector -> spec) as raw JSON, applied
     /// at resolve time server-side.
@@ -89,7 +85,6 @@ pub struct ResolveOptions {
 pub struct VerifyLockfileOptions {
     pub registry: String,
     pub named_registries: DepMap,
-    pub auth_headers: AuthHeadersByScope,
     pub authorization: Option<String>,
     pub overrides: Option<serde_json::Value>,
     pub lockfile: Lockfile,
@@ -108,7 +103,6 @@ impl VerifyLockfileOptions {
         Some(Self {
             registry: opts.registry.clone(),
             named_registries: opts.named_registries.clone(),
-            auth_headers: opts.auth_headers.clone(),
             authorization: opts.authorization.clone(),
             overrides: opts.overrides.clone(),
             lockfile: opts.lockfile.clone()?,
@@ -254,7 +248,6 @@ impl PnprClient {
         let request = serde_json::json!({
             "registry": opts.registry,
             "namedRegistries": opts.named_registries,
-            "authHeaders": opts.auth_headers,
             "overrides": opts.overrides,
             "lockfile": opts.lockfile,
             "trustLockfile": opts.trust_lockfile,
@@ -326,7 +319,6 @@ impl PnprClient {
             }],
             "registry": opts.registry,
             "namedRegistries": opts.named_registries,
-            "authHeaders": opts.auth_headers,
             "overrides": opts.overrides,
             "lockfile": opts.lockfile,
             "frozenLockfile": opts.frozen_lockfile,

--- a/pacquet/crates/pnpr-client/src/lib.rs
+++ b/pacquet/crates/pnpr-client/src/lib.rs
@@ -12,7 +12,8 @@
 //! ([pnpm/pnpm#12230](https://github.com/pnpm/pnpm/issues/12230)).
 //!
 //! pnpr is a stateless resolver: it stores no tarballs. Resolved tarballs
-//! are fetched from upstream public URLs or pnpr's read-only gateway.
+//! are fetched from upstream public URLs or an uplink's `/~<uplink>/`
+//! registry endpoint.
 
 use std::collections::BTreeMap;
 

--- a/pacquet/crates/pnpr-client/src/lib.rs
+++ b/pacquet/crates/pnpr-client/src/lib.rs
@@ -11,9 +11,11 @@
 //! then fetches the rest in parallel like a normal install
 //! ([pnpm/pnpm#12230](https://github.com/pnpm/pnpm/issues/12230)).
 //!
-//! pnpr is a stateless resolver: it stores no tarballs. Resolved tarballs
-//! are fetched from upstream public URLs or an uplink's `/~<uplink>/`
-//! registry endpoint.
+//! The resolver itself is stateless — it materializes no store and the
+//! `/resolve` endpoint persists no tarballs. Resolved tarballs are fetched
+//! from upstream public URLs or, for a private proxied route, an uplink's
+//! `/~<uplink>/` registry endpoint (which may cache them server-side under
+//! its own private namespace).
 
 use std::collections::BTreeMap;
 

--- a/pacquet/crates/pnpr-client/tests/integration.rs
+++ b/pacquet/crates/pnpr-client/tests/integration.rs
@@ -267,10 +267,7 @@ async fn a_private_package_fails_without_an_uplink() {
     let Err(PnprClientError::Server(message)) = client.resolve(opts).await else {
         panic!("expected the gated install to fail with a server error");
     };
-    assert!(
-        message.contains("401"),
-        "expected an auth denial without an uplink, got: {message}",
-    );
+    assert!(message.contains("401"), "expected an auth denial without an uplink, got: {message}");
 }
 
 #[tokio::test]
@@ -497,9 +494,11 @@ async fn verify_lockfile_endpoint_uses_uplinks() {
     let token = register_token(&registry.url(), "needs-auth-verifier").await;
     let shared_public_url = "http://pnpr.verify.test";
 
-    let (resolve_pnpr_url, resolve_auth, _resolve_storage) =
-        start_pnpr_with_uplinks_at(shared_public_url, vec![registry_uplink(&registry.url(), &token)])
-            .await;
+    let (resolve_pnpr_url, resolve_auth, _resolve_storage) = start_pnpr_with_uplinks_at(
+        shared_public_url,
+        vec![registry_uplink(&registry.url(), &token)],
+    )
+    .await;
     let mut resolve_opts =
         options(&registry.url(), &resolve_auth, deps([("@pnpm.e2e/needs-auth", "1.0.0")]));
     let first = PnprClient::new(resolve_pnpr_url)
@@ -513,9 +512,11 @@ async fn verify_lockfile_endpoint_uses_uplinks() {
     resolve_opts.minimum_release_age_ignore_missing_time = false;
 
     // A fresh pnpr that carries the uplink verifies the gated entry.
-    let (aliased_pnpr_url, aliased_auth, _aliased_storage) =
-        start_pnpr_with_uplinks_at(shared_public_url, vec![registry_uplink(&registry.url(), &token)])
-            .await;
+    let (aliased_pnpr_url, aliased_auth, _aliased_storage) = start_pnpr_with_uplinks_at(
+        shared_public_url,
+        vec![registry_uplink(&registry.url(), &token)],
+    )
+    .await;
     let mut aliased_opts = resolve_opts.clone();
     aliased_opts.authorization = Some(aliased_auth);
     let verify_opts =

--- a/pacquet/crates/pnpr-client/tests/integration.rs
+++ b/pacquet/crates/pnpr-client/tests/integration.rs
@@ -7,6 +7,11 @@
 //! default — proving resolution uses the client-supplied registry. pnpr
 //! serves no file content; the client receives only the resolved
 //! lockfile.
+//!
+//! The client authenticates to pnpr with a bearer token but never
+//! forwards its own upstream registry credentials. Private upstream
+//! content resolves only when the pnpr server is configured with an
+//! upstream credential alias the caller is authorized to use.
 
 use std::{
     collections::BTreeMap,
@@ -14,17 +19,28 @@ use std::{
     time::Duration,
 };
 
-use pacquet_network::{AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE};
 use pacquet_pnpr_client::{PnprClient, PnprClientError, ResolveOptions, VerifyLockfileOptions};
 use pacquet_testing_utils::registry::TestRegistry;
 use tempfile::TempDir;
-use tokio::net::TcpListener;
+use tokio::{
+    io::{AsyncReadExt as _, AsyncWriteExt as _},
+    net::TcpListener,
+};
 
 /// Start an in-process pnpr with the fast-path endpoints. Returns the
 /// base URL, the bearer `Authorization` for the registered `pnpr-client`
 /// caller (pnpr only honors `_authToken` on requests — the resolver
 /// endpoints reject Basic credentials), and the storage guard.
 async fn start_pnpr() -> (String, String, TempDir) {
+    start_pnpr_with_aliases(Vec::new()).await
+}
+
+/// Like [`start_pnpr`] but registers operator-managed upstream credential
+/// aliases, so the server can fetch private upstream content on behalf of
+/// an authorized caller without the client forwarding any credential.
+async fn start_pnpr_with_aliases(
+    aliases: Vec<(String, pnpr::UpstreamAlias)>,
+) -> (String, String, TempDir) {
     let storage = TempDir::new().expect("pnpr storage tempdir");
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.expect("bind pnpr");
     let addr = listener.local_addr().expect("pnpr addr");
@@ -32,6 +48,9 @@ async fn start_pnpr() -> (String, String, TempDir) {
     let mut config = pnpr::Config::proxy(addr, storage.path().to_path_buf());
     config.public_url = format!("http://{addr}");
     config.auth.htpasswd.max_users = pnpr::MaxUsers::Unlimited;
+    for (name, alias) in aliases {
+        config.upstream_aliases.insert(name, alias);
+    }
 
     tokio::spawn(async move {
         let _ = pnpr::serve_listener(config, listener).await;
@@ -41,6 +60,21 @@ async fn start_pnpr() -> (String, String, TempDir) {
     let base_url = format!("http://{addr}/");
     let token = register_token(&base_url, "pnpr-client").await;
     (base_url, format!("Bearer {token}"), storage)
+}
+
+/// An upstream credential alias that serves `registry_url` with `token`,
+/// usable by any authenticated pnpr caller.
+fn registry_alias(registry_url: &str, token: &str) -> (String, pnpr::UpstreamAlias) {
+    (
+        "test-registry".to_string(),
+        pnpr::UpstreamAlias {
+            registry: registry_url.to_string(),
+            package: None,
+            authorization: format!("Bearer {token}"),
+            access: pnpr::AccessList::parse("$authenticated"),
+            generation: 1,
+        },
+    )
 }
 
 async fn wait_until_ready(addr: SocketAddr) {
@@ -53,31 +87,50 @@ async fn wait_until_ready(addr: SocketAddr) {
     panic!("pnpr server never became ready at {addr}");
 }
 
+/// Accept one HTTP request, return its full raw bytes (headers + body),
+/// and answer `500` so the client stops after the capture.
+async fn capture_one_request(listener: TcpListener) -> String {
+    let (mut socket, _) = listener.accept().await.expect("accept request");
+    let mut buffer = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        let read = socket.read(&mut chunk).await.expect("read request");
+        if read == 0 {
+            break;
+        }
+        buffer.extend_from_slice(&chunk[..read]);
+        // Stop once the full body (per Content-Length) has arrived.
+        let text = String::from_utf8_lossy(&buffer);
+        if let Some(headers_end) = text.find("\r\n\r\n") {
+            let content_length = text[..headers_end]
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.trim()
+                        .eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+            if buffer.len() >= headers_end + 4 + content_length {
+                break;
+            }
+        }
+    }
+    let _ = socket
+        .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 4\r\nConnection: close\r\n\r\nstop")
+        .await;
+    let _ = socket.shutdown().await;
+    String::from_utf8_lossy(&buffer).into_owned()
+}
+
 fn deps<const COUNT: usize>(entries: [(&str, &str); COUNT]) -> BTreeMap<String, String> {
     entries.into_iter().map(|(name, range)| (name.to_string(), range.to_string())).collect()
 }
 
-fn auth_headers<const COUNT: usize>(entries: [(&str, &str, &str); COUNT]) -> AuthHeadersByScope {
-    let mut result = AuthHeadersByScope::new();
-    for (uri, scope, value) in entries {
-        result.entry(uri.to_string()).or_default().insert(scope.to_string(), value.to_string());
-    }
-    result
-}
-
-/// The nerf-darted key (`//host[:port]/path/`) a forwarded credential for
-/// `url` is keyed by, mirroring `AuthHeaders`' lookup on the server —
-/// keeping any registry path prefix so the key isn't wrong for one.
-fn nerf_key(url: &str) -> String {
-    let authority_and_path = url.split("://").nth(1).unwrap_or(url);
-    let (authority, path) = authority_and_path.split_once('/').unwrap_or((authority_and_path, ""));
-    let path = path.split(['?', '#']).next().unwrap_or("").trim_matches('/');
-    if path.is_empty() { format!("//{authority}/") } else { format!("//{authority}/{path}/") }
-}
-
 /// Register a user with an npm-compatible registry and return its bearer
 /// token. The pnpr fixture authenticates its own caller with this token;
-/// registry tests forward it as an upstream credential.
+/// an upstream alias uses one as its server-side upstream credential.
 async fn register_token(registry_url: &str, username: &str) -> String {
     let body = serde_json::json!({ "name": username, "password": "password123" });
     let response = reqwest::Client::new()
@@ -102,7 +155,6 @@ fn options(
         optional_dependencies: BTreeMap::new(),
         registry: registry.to_string(),
         named_registries: BTreeMap::new(),
-        auth_headers: BTreeMap::new(),
         authorization: Some(authorization.to_string()),
         overrides: None,
         lockfile: None,
@@ -119,57 +171,50 @@ fn options(
     }
 }
 
-/// The forwarded per-registry credentials and the pnpr-server identity
-/// header must travel on the wire: `authHeaders` in the body (so the
-/// server resolves private content as the caller) and `Authorization` on
-/// the request (so pnpr identifies the caller). A `mockito` server
-/// captures the request and asserts both are present; the canned 500 just
-/// short-circuits the client after the match.
+/// The request must identify the caller to pnpr (`Authorization`) but
+/// must never carry the client's own upstream registry credentials in the
+/// body — pnpr selects upstream auth from its route policy. A raw TCP
+/// listener captures the wire bytes and asserts both invariants; the
+/// canned 500 just short-circuits the client after the capture.
 #[tokio::test]
-async fn forwards_credentials_and_the_identity_header() {
-    let mut server = mockito::Server::new_async().await;
-    let mock = server
-        .mock("POST", "/-/pnpr/v0/resolve")
-        .match_header("authorization", "Bearer pnpr-token")
-        .match_body(mockito::Matcher::PartialJsonString(
-            r#"{"authHeaders":{"//npm.acme.test/":{"@":"Bearer upstream-token"}}}"#.to_string(),
-        ))
-        .with_status(500)
-        .with_body("stop")
-        .create_async()
-        .await;
+async fn sends_the_identity_header_but_no_upstream_credentials() {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.expect("bind capture");
+    let addr = listener.local_addr().expect("capture addr");
+    let capture = tokio::spawn(capture_one_request(listener));
 
-    let client = PnprClient::new(format!("{}/", server.url()));
-
-    let mut opts =
+    let client = PnprClient::new(format!("http://{addr}/"));
+    let opts =
         options("https://npm.acme.test/", "Bearer pnpr-token", deps([("@acme/foo", "1.0.0")]));
-    opts.auth_headers =
-        auth_headers([("//npm.acme.test/", DEFAULT_REGISTRY_SCOPE, "Bearer upstream-token")]);
-
     let result = client.resolve(opts).await;
     assert!(result.is_err(), "the canned 500 should surface as an error");
-    mock.assert_async().await;
+
+    let request = capture.await.expect("capture task");
+    assert!(
+        request.to_lowercase().contains("authorization: bearer pnpr-token"),
+        "the identity header must be sent, got:\n{request}",
+    );
+    assert!(
+        !request.contains("authHeaders"),
+        "the request body must not carry upstream credentials, got:\n{request}",
+    );
 }
 
 /// End-to-end: the test registry gates `@pnpm.e2e/needs-auth` behind
-/// `$authenticated`, so resolving it through the resolver only works
-/// when the caller's upstream token is forwarded and the server fetches
-/// the packument as the caller.
+/// `$authenticated`. The client never forwards its own credentials, so
+/// resolving it works only when the pnpr server is configured with an
+/// upstream credential alias for that registry that the caller is
+/// authorized to use.
 #[tokio::test]
-async fn a_forwarded_credential_resolves_a_private_package() {
+async fn an_upstream_alias_resolves_a_private_package() {
     let registry = TestRegistry::start();
     let token = register_token(&registry.url(), "needs-auth-forwarder").await;
-    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) =
+        start_pnpr_with_aliases(vec![registry_alias(&registry.url(), &token)]).await;
 
     let client = PnprClient::new(pnpr_url);
 
-    let mut opts = options(&registry.url(), &pnpr_auth, deps([("@pnpm.e2e/needs-auth", "1.0.0")]));
-    let registry_key = nerf_key(&registry.url());
-    let bearer = format!("Bearer {token}");
-    opts.auth_headers =
-        auth_headers([(registry_key.as_str(), DEFAULT_REGISTRY_SCOPE, bearer.as_str())]);
-
-    let outcome = client.resolve(opts).await.expect("forwarded credential should resolve it");
+    let opts = options(&registry.url(), &pnpr_auth, deps([("@pnpm.e2e/needs-auth", "1.0.0")]));
+    let outcome = client.resolve(opts).await.expect("the upstream alias should resolve it");
     let packages = outcome.lockfile.packages.as_ref().expect("lockfile has packages");
     assert!(
         packages.keys().any(|key| key.to_string().starts_with("@pnpm.e2e/needs-auth@1.0.0")),
@@ -178,11 +223,12 @@ async fn a_forwarded_credential_resolves_a_private_package() {
     );
 }
 
-/// The same install without a forwarded credential fails: the registry
-/// won't serve the gated packument anonymously, so resolution can't read
-/// it.
+/// The same install against a server with no matching upstream alias
+/// fails: the client forwards no credential and pnpr has none to select,
+/// so the gated packument can only be fetched anonymously — which the
+/// registry refuses.
 #[tokio::test]
-async fn a_private_package_fails_without_a_forwarded_credential() {
+async fn a_private_package_fails_without_an_upstream_alias() {
     let registry = TestRegistry::start();
     let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
 
@@ -194,7 +240,7 @@ async fn a_private_package_fails_without_a_forwarded_credential() {
     };
     assert!(
         message.contains("401"),
-        "expected an auth denial without a forwarded credential, got: {message}",
+        "expected an auth denial without an upstream alias, got: {message}",
     );
 }
 
@@ -379,54 +425,52 @@ async fn verify_lockfile_endpoint_rejects_policy_violation() {
 }
 
 /// The verification fan-out fetches each entry's packument, so a gated
-/// package verifies only when `/-/pnpr/v0/verify-lockfile` forwards the
-/// client's credential map — and fails closed when it doesn't. Each
-/// verify call targets a fresh pnpr so neither the whole-lockfile
-/// verdict cache nor the metadata mirror warmed by an earlier call can
-/// satisfy it without exercising the forwarded credential.
+/// package verifies only when the pnpr server has an upstream alias for
+/// the registry — and fails closed against a server without one. Each
+/// verify targets a fresh pnpr so neither the whole-lockfile verdict
+/// cache nor the metadata mirror warmed by an earlier call can satisfy it
+/// without exercising the alias.
 #[tokio::test]
-async fn verify_lockfile_endpoint_forwards_credentials() {
+async fn verify_lockfile_endpoint_uses_upstream_aliases() {
     let registry = TestRegistry::start();
     let token = register_token(&registry.url(), "needs-auth-verifier").await;
-    let (resolve_pnpr_url, resolve_auth, _resolve_storage) = start_pnpr().await;
 
+    let (resolve_pnpr_url, resolve_auth, _resolve_storage) =
+        start_pnpr_with_aliases(vec![registry_alias(&registry.url(), &token)]).await;
     let mut resolve_opts =
         options(&registry.url(), &resolve_auth, deps([("@pnpm.e2e/needs-auth", "1.0.0")]));
-    let registry_key = nerf_key(&registry.url());
-    let bearer = format!("Bearer {token}");
-    resolve_opts.auth_headers =
-        auth_headers([(registry_key.as_str(), DEFAULT_REGISTRY_SCOPE, bearer.as_str())]);
     let first = PnprClient::new(resolve_pnpr_url)
         .resolve(resolve_opts.clone())
         .await
-        .expect("authed install");
+        .expect("aliased install");
 
     // An active policy makes the verifier fetch the gated packument.
     resolve_opts.lockfile = Some(first.lockfile);
     resolve_opts.minimum_release_age = Some(1);
     resolve_opts.minimum_release_age_ignore_missing_time = false;
 
-    // Each verify targets a fresh pnpr, so the caller re-authenticates with
-    // that server's own bearer token.
-    let (authed_pnpr_url, authed_auth, _authed_storage) = start_pnpr().await;
-    let mut authed_opts = resolve_opts.clone();
-    authed_opts.authorization = Some(authed_auth);
+    // A fresh pnpr that carries the alias verifies the gated entry.
+    let (aliased_pnpr_url, aliased_auth, _aliased_storage) =
+        start_pnpr_with_aliases(vec![registry_alias(&registry.url(), &token)]).await;
+    let mut aliased_opts = resolve_opts.clone();
+    aliased_opts.authorization = Some(aliased_auth);
     let verify_opts =
-        VerifyLockfileOptions::from_resolve_options(&authed_opts).expect("lockfile is present");
-    PnprClient::new(authed_pnpr_url)
+        VerifyLockfileOptions::from_resolve_options(&aliased_opts).expect("lockfile is present");
+    PnprClient::new(aliased_pnpr_url)
         .verify_lockfile(verify_opts)
         .await
-        .expect("forwarded credential should let the gated entry verify");
+        .expect("the upstream alias should let the gated entry verify");
 
-    let (anonymous_pnpr_url, anonymous_auth, _anonymous_storage) = start_pnpr().await;
-    let mut anonymous_opts = resolve_opts.clone();
-    anonymous_opts.authorization = Some(anonymous_auth);
-    anonymous_opts.auth_headers = BTreeMap::new();
-    let anonymous_verify_opts =
-        VerifyLockfileOptions::from_resolve_options(&anonymous_opts).expect("lockfile is present");
+    // A pnpr without the alias has no credential to select, so the gated
+    // entry's metadata fetch must fail closed.
+    let (plain_pnpr_url, plain_auth, _plain_storage) = start_pnpr().await;
+    let mut plain_opts = resolve_opts.clone();
+    plain_opts.authorization = Some(plain_auth);
+    let plain_verify_opts =
+        VerifyLockfileOptions::from_resolve_options(&plain_opts).expect("lockfile is present");
     assert!(
-        PnprClient::new(anonymous_pnpr_url).verify_lockfile(anonymous_verify_opts).await.is_err(),
-        "without the credential the gated entry's metadata fetch must fail closed",
+        PnprClient::new(plain_pnpr_url).verify_lockfile(plain_verify_opts).await.is_err(),
+        "without an alias the gated entry's metadata fetch must fail closed",
     );
 }
 

--- a/pacquet/crates/pnpr-client/tests/integration.rs
+++ b/pacquet/crates/pnpr-client/tests/integration.rs
@@ -3,10 +3,10 @@
 //! Topology: a shared [`TestRegistry`] serves the package fixtures; a
 //! per-test in-process `pnpr` hosts the `/-/pnpr` handshake +
 //! `/-/pnpr/v0/resolve` endpoints. The client sends the registry it wants
-//! resolved from, so the pnpr server's *own* uplink is left at the
-//! default — proving resolution uses the client-supplied registry. Public
-//! and unknown routes keep their upstream tarball URLs; a private proxied
-//! route is returned as its uplink's `/~<uplink>/` registry-endpoint URL.
+//! resolved from (allowlisted on the server), proving resolution uses the
+//! client-supplied registry. Public routes keep their upstream tarball URLs;
+//! a private proxied route is returned as its uplink's `/~<uplink>/`
+//! registry-endpoint URL.
 //!
 //! The client authenticates to pnpr with a bearer token but never
 //! forwards its own upstream registry credentials. Private upstream
@@ -27,21 +27,24 @@ use tokio::{
     net::TcpListener,
 };
 
-/// Start an in-process pnpr with the fast-path endpoints. Returns the
-/// base URL, the bearer `Authorization` for the registered `pnpr-client`
+/// Start an in-process pnpr with the fast-path endpoints, allowlisting
+/// `registry_url` as a public route so the client may resolve against it
+/// (off-allowlist registries are rejected at the request boundary). Returns
+/// the base URL, the bearer `Authorization` for the registered `pnpr-client`
 /// caller (pnpr only honors `_authToken` on requests — the resolver
 /// endpoints reject Basic credentials), and the storage guard.
-async fn start_pnpr() -> (String, String, TempDir) {
-    start_pnpr_with_uplinks(Vec::new()).await
+async fn start_pnpr(registry_url: &str) -> (String, String, TempDir) {
+    start_pnpr_inner(None, Vec::new(), vec![registry_url.to_string()]).await
 }
 
 /// Like [`start_pnpr`] but registers operator-managed access-bearing
 /// uplinks, so the server can fetch private upstream content on behalf of
-/// an authorized caller without the client forwarding any credential.
+/// an authorized caller without the client forwarding any credential. A
+/// uplink's origin is itself allowlisted, so no public route is needed.
 async fn start_pnpr_with_uplinks(
     uplinks: Vec<(String, pnpr::UplinkConfig)>,
 ) -> (String, String, TempDir) {
-    start_pnpr_inner(None, uplinks).await
+    start_pnpr_inner(None, uplinks, Vec::new()).await
 }
 
 /// Like [`start_pnpr_with_uplinks`] but pins `public_url` so a lockfile
@@ -53,12 +56,13 @@ async fn start_pnpr_with_uplinks_at(
     public_url: &str,
     uplinks: Vec<(String, pnpr::UplinkConfig)>,
 ) -> (String, String, TempDir) {
-    start_pnpr_inner(Some(public_url.to_string()), uplinks).await
+    start_pnpr_inner(Some(public_url.to_string()), uplinks, Vec::new()).await
 }
 
 async fn start_pnpr_inner(
     public_url: Option<String>,
     uplinks: Vec<(String, pnpr::UplinkConfig)>,
+    public_registries: Vec<String>,
 ) -> (String, String, TempDir) {
     let storage = TempDir::new().expect("pnpr storage tempdir");
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.expect("bind pnpr");
@@ -69,6 +73,12 @@ async fn start_pnpr_inner(
     config.auth.htpasswd.max_users = pnpr::MaxUsers::Unlimited;
     for (name, uplink) in uplinks {
         config.uplinks.insert(name, uplink);
+    }
+    for registry in public_registries {
+        config
+            .route_policy
+            .public
+            .push(pnpr::PublicRoute { registry: Some(registry), package: None });
     }
 
     tokio::spawn(async move {
@@ -259,7 +269,7 @@ async fn an_uplink_resolves_a_private_package() {
 #[tokio::test]
 async fn a_private_package_fails_without_an_uplink() {
     let registry = TestRegistry::start();
-    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr(&registry.url()).await;
 
     let client = PnprClient::new(pnpr_url);
 
@@ -273,7 +283,7 @@ async fn a_private_package_fails_without_an_uplink() {
 #[tokio::test]
 async fn resolves_a_package() {
     let registry = TestRegistry::start();
-    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr(&registry.url()).await;
 
     let client = PnprClient::new(pnpr_url);
 
@@ -299,7 +309,7 @@ async fn resolves_a_package() {
 #[tokio::test]
 async fn unknown_route_keeps_its_upstream_tarball_url() {
     let registry = TestRegistry::start();
-    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr(&registry.url()).await;
 
     let outcome = PnprClient::new(pnpr_url)
         .resolve(options(&registry.url(), &pnpr_auth, deps([("@foo/no-deps", "1.0.0")])))
@@ -330,7 +340,7 @@ async fn unknown_route_keeps_its_upstream_tarball_url() {
 #[tokio::test]
 async fn streams_resolved_packages_before_the_lockfile() {
     let registry = TestRegistry::start();
-    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr(&registry.url()).await;
 
     let client = PnprClient::new(pnpr_url);
 
@@ -364,7 +374,7 @@ async fn streams_resolved_packages_before_the_lockfile() {
 #[tokio::test]
 async fn forwards_optional_dependencies() {
     let registry = TestRegistry::start();
-    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr(&registry.url()).await;
 
     let client = PnprClient::new(pnpr_url);
 
@@ -383,7 +393,7 @@ async fn forwards_optional_dependencies() {
 #[tokio::test]
 async fn verifies_and_accepts_a_clean_input_lockfile() {
     let registry = TestRegistry::start();
-    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr(&registry.url()).await;
 
     let client = PnprClient::new(pnpr_url);
 
@@ -405,7 +415,7 @@ async fn verifies_and_accepts_a_clean_input_lockfile() {
 #[tokio::test]
 async fn rejects_an_input_lockfile_that_violates_the_clients_policy() {
     let registry = TestRegistry::start();
-    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr(&registry.url()).await;
 
     let client = PnprClient::new(pnpr_url);
 
@@ -434,7 +444,7 @@ async fn rejects_an_input_lockfile_that_violates_the_clients_policy() {
 #[tokio::test]
 async fn verify_lockfile_endpoint_accepts_a_clean_input_lockfile() {
     let registry = TestRegistry::start();
-    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr(&registry.url()).await;
 
     let client = PnprClient::new(pnpr_url);
 
@@ -454,7 +464,7 @@ async fn verify_lockfile_endpoint_accepts_a_clean_input_lockfile() {
 #[tokio::test]
 async fn verify_lockfile_endpoint_rejects_policy_violation() {
     let registry = TestRegistry::start();
-    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr(&registry.url()).await;
 
     let client = PnprClient::new(pnpr_url);
 
@@ -528,7 +538,7 @@ async fn verify_lockfile_endpoint_uses_uplinks() {
 
     // A pnpr without the uplink has no credential to select, so the gated
     // entry's metadata fetch must fail closed.
-    let (plain_pnpr_url, plain_auth, _plain_storage) = start_pnpr().await;
+    let (plain_pnpr_url, plain_auth, _plain_storage) = start_pnpr(&registry.url()).await;
     let mut plain_opts = resolve_opts.clone();
     plain_opts.authorization = Some(plain_auth);
     let plain_verify_opts =
@@ -542,7 +552,7 @@ async fn verify_lockfile_endpoint_uses_uplinks() {
 #[tokio::test]
 async fn trust_lockfile_makes_the_server_skip_verification() {
     let registry = TestRegistry::start();
-    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr(&registry.url()).await;
 
     let client = PnprClient::new(pnpr_url);
 

--- a/pacquet/crates/pnpr-client/tests/integration.rs
+++ b/pacquet/crates/pnpr-client/tests/integration.rs
@@ -4,9 +4,9 @@
 //! per-test in-process `pnpr` hosts the `/-/pnpr` handshake +
 //! `/-/pnpr/v0/resolve` endpoints. The client sends the registry it wants
 //! resolved from, so the pnpr server's *own* uplink is left at the
-//! default — proving resolution uses the client-supplied registry. pnpr
-//! serves no file content; the client receives only the resolved
-//! lockfile.
+//! default — proving resolution uses the client-supplied registry. Public
+//! tarballs can stay upstream; private and unknown routes are returned as
+//! pnpr read-only gateway URLs.
 //!
 //! The client authenticates to pnpr with a bearer token but never
 //! forwards its own upstream registry credentials. Private upstream
@@ -264,6 +264,39 @@ async fn resolves_a_package() {
     );
 
     assert!(outcome.stats.total_packages >= 1);
+}
+
+#[tokio::test]
+async fn unknown_gateway_tarball_url_fetches_through_pnpr() {
+    let registry = TestRegistry::start();
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
+
+    let outcome = PnprClient::new(pnpr_url)
+        .resolve(options(&registry.url(), &pnpr_auth, deps([("@foo/no-deps", "1.0.0")])))
+        .await
+        .expect("install should succeed");
+    let lockfile = serde_json::to_value(&outcome.lockfile).expect("lockfile serializes");
+    let tarball = lockfile["packages"]["@foo/no-deps@1.0.0"]["resolution"]["tarball"]
+        .as_str()
+        .expect("routed tarball URL");
+
+    assert!(tarball.contains("/-/pnpr/v0/tarballs/unknown/"));
+    assert!(!tarball.contains(&registry.url()));
+
+    let response = reqwest::Client::new()
+        .get(tarball)
+        .header(reqwest::header::AUTHORIZATION, pnpr_auth)
+        .send()
+        .await
+        .expect("gateway tarball request");
+    assert!(response.status().is_success(), "gateway returned {}", response.status());
+    let body = response.bytes().await.expect("gateway tarball body");
+    let direct = reqwest::get(format!("{}@foo/no-deps/-/no-deps-1.0.0.tgz", registry.url()))
+        .await
+        .expect("direct tarball request");
+    assert!(direct.status().is_success(), "registry returned {}", direct.status());
+    let direct_body = direct.bytes().await.expect("direct tarball body");
+    assert_eq!(body, direct_body);
 }
 
 /// The streaming API surfaces each resolved tarball as a `package`

--- a/pacquet/crates/pnpr-client/tests/integration.rs
+++ b/pacquet/crates/pnpr-client/tests/integration.rs
@@ -5,13 +5,13 @@
 //! `/-/pnpr/v0/resolve` endpoints. The client sends the registry it wants
 //! resolved from, so the pnpr server's *own* uplink is left at the
 //! default — proving resolution uses the client-supplied registry. Public
-//! tarballs can stay upstream; private and unknown routes are returned as
-//! pnpr read-only gateway URLs.
+//! and unknown routes keep their upstream tarball URLs; a private proxied
+//! route is returned as its uplink's `/~<uplink>/` registry-endpoint URL.
 //!
 //! The client authenticates to pnpr with a bearer token but never
 //! forwards its own upstream registry credentials. Private upstream
 //! content resolves only when the pnpr server is configured with an
-//! upstream credential alias the caller is authorized to use.
+//! access-bearing uplink the caller is authorized to use.
 
 use std::{
     collections::BTreeMap,
@@ -32,24 +32,43 @@ use tokio::{
 /// caller (pnpr only honors `_authToken` on requests — the resolver
 /// endpoints reject Basic credentials), and the storage guard.
 async fn start_pnpr() -> (String, String, TempDir) {
-    start_pnpr_with_aliases(Vec::new()).await
+    start_pnpr_with_uplinks(Vec::new()).await
 }
 
-/// Like [`start_pnpr`] but registers operator-managed upstream credential
-/// aliases, so the server can fetch private upstream content on behalf of
+/// Like [`start_pnpr`] but registers operator-managed access-bearing
+/// uplinks, so the server can fetch private upstream content on behalf of
 /// an authorized caller without the client forwarding any credential.
-async fn start_pnpr_with_aliases(
-    aliases: Vec<(String, pnpr::UpstreamAlias)>,
+async fn start_pnpr_with_uplinks(
+    uplinks: Vec<(String, pnpr::UplinkConfig)>,
+) -> (String, String, TempDir) {
+    start_pnpr_inner(None, uplinks).await
+}
+
+/// Like [`start_pnpr_with_uplinks`] but pins `public_url` so a lockfile
+/// produced by one instance can be verified by another fresh instance: a
+/// `/~<uplink>/` endpoint URL is reversed to its upstream by matching the
+/// verifying server's own `public_url`, which a real single-pnpr deployment
+/// shares across resolve and verify.
+async fn start_pnpr_with_uplinks_at(
+    public_url: &str,
+    uplinks: Vec<(String, pnpr::UplinkConfig)>,
+) -> (String, String, TempDir) {
+    start_pnpr_inner(Some(public_url.to_string()), uplinks).await
+}
+
+async fn start_pnpr_inner(
+    public_url: Option<String>,
+    uplinks: Vec<(String, pnpr::UplinkConfig)>,
 ) -> (String, String, TempDir) {
     let storage = TempDir::new().expect("pnpr storage tempdir");
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.expect("bind pnpr");
     let addr = listener.local_addr().expect("pnpr addr");
 
     let mut config = pnpr::Config::proxy(addr, storage.path().to_path_buf());
-    config.public_url = format!("http://{addr}");
+    config.public_url = public_url.unwrap_or_else(|| format!("http://{addr}"));
     config.auth.htpasswd.max_users = pnpr::MaxUsers::Unlimited;
-    for (name, alias) in aliases {
-        config.upstream_aliases.insert(name, alias);
+    for (name, uplink) in uplinks {
+        config.uplinks.insert(name, uplink);
     }
 
     tokio::spawn(async move {
@@ -62,16 +81,26 @@ async fn start_pnpr_with_aliases(
     (base_url, format!("Bearer {token}"), storage)
 }
 
-/// An upstream credential alias that serves `registry_url` with `token`,
-/// usable by any authenticated pnpr caller.
-fn registry_alias(registry_url: &str, token: &str) -> (String, pnpr::UpstreamAlias) {
+/// An access-bearing uplink that serves `registry_url` with `token`, usable
+/// by any authenticated pnpr caller (exposed at `/~test-registry/`).
+fn registry_uplink(registry_url: &str, token: &str) -> (String, pnpr::UplinkConfig) {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::AUTHORIZATION,
+        reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
+            .expect("valid authorization header"),
+    );
     (
         "test-registry".to_string(),
-        pnpr::UpstreamAlias {
-            registry: registry_url.to_string(),
-            package: None,
-            authorization: format!("Bearer {token}"),
-            access: pnpr::AccessList::parse("$authenticated"),
+        pnpr::UplinkConfig {
+            url: registry_url.to_string(),
+            headers,
+            maxage: None,
+            timeout: pnpr::UplinkConfig::DEFAULT_TIMEOUT,
+            max_fails: pnpr::UplinkConfig::DEFAULT_MAX_FAILS,
+            fail_timeout: pnpr::UplinkConfig::DEFAULT_FAIL_TIMEOUT,
+            cache: true,
+            access: Some(pnpr::AccessList::parse("$authenticated")),
             generation: 1,
         },
     )
@@ -130,7 +159,7 @@ fn deps<const COUNT: usize>(entries: [(&str, &str); COUNT]) -> BTreeMap<String, 
 
 /// Register a user with an npm-compatible registry and return its bearer
 /// token. The pnpr fixture authenticates its own caller with this token;
-/// an upstream alias uses one as its server-side upstream credential.
+/// an access-bearing uplink uses one as its server-side credential.
 async fn register_token(registry_url: &str, username: &str) -> String {
     let body = serde_json::json!({ "name": username, "password": "password123" });
     let response = reqwest::Client::new()
@@ -202,19 +231,19 @@ async fn sends_the_identity_header_but_no_upstream_credentials() {
 /// End-to-end: the test registry gates `@pnpm.e2e/needs-auth` behind
 /// `$authenticated`. The client never forwards its own credentials, so
 /// resolving it works only when the pnpr server is configured with an
-/// upstream credential alias for that registry that the caller is
+/// uplink for that registry that the caller is
 /// authorized to use.
 #[tokio::test]
-async fn an_upstream_alias_resolves_a_private_package() {
+async fn an_uplink_resolves_a_private_package() {
     let registry = TestRegistry::start();
     let token = register_token(&registry.url(), "needs-auth-forwarder").await;
     let (pnpr_url, pnpr_auth, _storage) =
-        start_pnpr_with_aliases(vec![registry_alias(&registry.url(), &token)]).await;
+        start_pnpr_with_uplinks(vec![registry_uplink(&registry.url(), &token)]).await;
 
     let client = PnprClient::new(pnpr_url);
 
     let opts = options(&registry.url(), &pnpr_auth, deps([("@pnpm.e2e/needs-auth", "1.0.0")]));
-    let outcome = client.resolve(opts).await.expect("the upstream alias should resolve it");
+    let outcome = client.resolve(opts).await.expect("the uplink should resolve it");
     let packages = outcome.lockfile.packages.as_ref().expect("lockfile has packages");
     assert!(
         packages.keys().any(|key| key.to_string().starts_with("@pnpm.e2e/needs-auth@1.0.0")),
@@ -223,12 +252,12 @@ async fn an_upstream_alias_resolves_a_private_package() {
     );
 }
 
-/// The same install against a server with no matching upstream alias
+/// The same install against a server with no matching uplink
 /// fails: the client forwards no credential and pnpr has none to select,
 /// so the gated packument can only be fetched anonymously — which the
 /// registry refuses.
 #[tokio::test]
-async fn a_private_package_fails_without_an_upstream_alias() {
+async fn a_private_package_fails_without_an_uplink() {
     let registry = TestRegistry::start();
     let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
 
@@ -240,7 +269,7 @@ async fn a_private_package_fails_without_an_upstream_alias() {
     };
     assert!(
         message.contains("401"),
-        "expected an auth denial without an upstream alias, got: {message}",
+        "expected an auth denial without an uplink, got: {message}",
     );
 }
 
@@ -266,8 +295,12 @@ async fn resolves_a_package() {
     assert!(outcome.stats.total_packages >= 1);
 }
 
+/// An unknown route (no uplink, no public rule) has no managed credential,
+/// so it was resolved anonymously and pnpr mints no gateway URL: the
+/// resolution keeps its registry resolution, and the client fetches the
+/// tarball directly from the upstream the same way pnpr did.
 #[tokio::test]
-async fn unknown_gateway_tarball_url_fetches_through_pnpr() {
+async fn unknown_route_keeps_its_upstream_tarball_url() {
     let registry = TestRegistry::start();
     let (pnpr_url, pnpr_auth, _storage) = start_pnpr().await;
 
@@ -276,27 +309,20 @@ async fn unknown_gateway_tarball_url_fetches_through_pnpr() {
         .await
         .expect("install should succeed");
     let lockfile = serde_json::to_value(&outcome.lockfile).expect("lockfile serializes");
-    let tarball = lockfile["packages"]["@foo/no-deps@1.0.0"]["resolution"]["tarball"]
-        .as_str()
-        .expect("routed tarball URL");
+    let resolution = &lockfile["packages"]["@foo/no-deps@1.0.0"]["resolution"];
 
-    assert!(tarball.contains("/-/pnpr/v0/tarballs/unknown/"));
-    assert!(!tarball.contains(&registry.url()));
+    // No pnpr gateway URL is minted; the entry stays integrity-only (its URL
+    // is reconstructed from the client's configured registry).
+    assert!(
+        resolution.get("tarball").is_none(),
+        "unknown route should stay integrity-only, got: {resolution}",
+    );
 
-    let response = reqwest::Client::new()
-        .get(tarball)
-        .header(reqwest::header::AUTHORIZATION, pnpr_auth)
-        .send()
-        .await
-        .expect("gateway tarball request");
-    assert!(response.status().is_success(), "gateway returned {}", response.status());
-    let body = response.bytes().await.expect("gateway tarball body");
+    // The tarball is fetchable directly from the upstream registry.
     let direct = reqwest::get(format!("{}@foo/no-deps/-/no-deps-1.0.0.tgz", registry.url()))
         .await
         .expect("direct tarball request");
     assert!(direct.status().is_success(), "registry returned {}", direct.status());
-    let direct_body = direct.bytes().await.expect("direct tarball body");
-    assert_eq!(body, direct_body);
 }
 
 /// The streaming API surfaces each resolved tarball as a `package`
@@ -458,18 +484,22 @@ async fn verify_lockfile_endpoint_rejects_policy_violation() {
 }
 
 /// The verification fan-out fetches each entry's packument, so a gated
-/// package verifies only when the pnpr server has an upstream alias for
-/// the registry — and fails closed against a server without one. Each
-/// verify targets a fresh pnpr so neither the whole-lockfile verdict
-/// cache nor the metadata mirror warmed by an earlier call can satisfy it
-/// without exercising the alias.
+/// package verifies only when the pnpr server has an uplink for the
+/// registry — and fails closed against a server without one. Each verify
+/// targets a fresh pnpr so neither the whole-lockfile verdict cache nor the
+/// metadata mirror warmed by an earlier call can satisfy it without
+/// exercising the uplink. The resolve and aliased-verify instances share a
+/// `public_url` so the verifier can reverse the lockfile's `/~<uplink>/`
+/// tarball URLs back to upstream — what a real single-pnpr deployment does.
 #[tokio::test]
-async fn verify_lockfile_endpoint_uses_upstream_aliases() {
+async fn verify_lockfile_endpoint_uses_uplinks() {
     let registry = TestRegistry::start();
     let token = register_token(&registry.url(), "needs-auth-verifier").await;
+    let shared_public_url = "http://pnpr.verify.test";
 
     let (resolve_pnpr_url, resolve_auth, _resolve_storage) =
-        start_pnpr_with_aliases(vec![registry_alias(&registry.url(), &token)]).await;
+        start_pnpr_with_uplinks_at(shared_public_url, vec![registry_uplink(&registry.url(), &token)])
+            .await;
     let mut resolve_opts =
         options(&registry.url(), &resolve_auth, deps([("@pnpm.e2e/needs-auth", "1.0.0")]));
     let first = PnprClient::new(resolve_pnpr_url)
@@ -482,9 +512,10 @@ async fn verify_lockfile_endpoint_uses_upstream_aliases() {
     resolve_opts.minimum_release_age = Some(1);
     resolve_opts.minimum_release_age_ignore_missing_time = false;
 
-    // A fresh pnpr that carries the alias verifies the gated entry.
+    // A fresh pnpr that carries the uplink verifies the gated entry.
     let (aliased_pnpr_url, aliased_auth, _aliased_storage) =
-        start_pnpr_with_aliases(vec![registry_alias(&registry.url(), &token)]).await;
+        start_pnpr_with_uplinks_at(shared_public_url, vec![registry_uplink(&registry.url(), &token)])
+            .await;
     let mut aliased_opts = resolve_opts.clone();
     aliased_opts.authorization = Some(aliased_auth);
     let verify_opts =
@@ -492,9 +523,9 @@ async fn verify_lockfile_endpoint_uses_upstream_aliases() {
     PnprClient::new(aliased_pnpr_url)
         .verify_lockfile(verify_opts)
         .await
-        .expect("the upstream alias should let the gated entry verify");
+        .expect("the uplink should let the gated entry verify");
 
-    // A pnpr without the alias has no credential to select, so the gated
+    // A pnpr without the uplink has no credential to select, so the gated
     // entry's metadata fetch must fail closed.
     let (plain_pnpr_url, plain_auth, _plain_storage) = start_pnpr().await;
     let mut plain_opts = resolve_opts.clone();
@@ -503,7 +534,7 @@ async fn verify_lockfile_endpoint_uses_upstream_aliases() {
         VerifyLockfileOptions::from_resolve_options(&plain_opts).expect("lockfile is present");
     assert!(
         PnprClient::new(plain_pnpr_url).verify_lockfile(plain_verify_opts).await.is_err(),
-        "without an alias the gated entry's metadata fetch must fail closed",
+        "without an uplink the gated entry's metadata fetch must fail closed",
     );
 }
 

--- a/pacquet/crates/pnpr-client/tests/integration.rs
+++ b/pacquet/crates/pnpr-client/tests/integration.rs
@@ -111,7 +111,6 @@ fn registry_uplink(registry_url: &str, token: &str) -> (String, pnpr::UplinkConf
             fail_timeout: pnpr::UplinkConfig::DEFAULT_FAIL_TIMEOUT,
             cache: true,
             access: Some(pnpr::AccessList::parse("$authenticated")),
-            generation: 1,
         },
     )
 }

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -748,14 +748,20 @@ impl NpmResolutionVerifier {
             let mut cache = self.lookup_context.local_meta.lock().await;
             Arc::clone(cache.entry(key).or_insert_with(|| Arc::new(OnceCell::new())))
         };
+        // The verifier reads the *same* scoped mirror a resolve would
+        // populate. A private packument lives under its descriptor
+        // namespace, so a caller who can't reproduce the descriptor (a
+        // `Bypass` route → no mirror) can't read another caller's private
+        // `time` map through the trust-check path.
+        let name_string = name.to_string();
+        let url = crate::registry_url::to_registry_url(registry, &name_string);
+        let scope = self.auth_headers.metadata_scope(&url, Some(&name_string));
         cell.get_or_init(|| async {
-            let mirror_path = crate::mirror::get_pkg_mirror_path(
-                cache_dir,
-                crate::mirror::FULL_META_DIR,
-                registry,
-                &name.to_string(),
-            )
-            .ok();
+            let mirror_path = crate::mirror::scoped_meta_dir(&scope, crate::mirror::FULL_META_DIR)
+                .and_then(|meta_dir| {
+                    crate::mirror::get_pkg_mirror_path(cache_dir, &meta_dir, registry, &name_string)
+                        .ok()
+                });
             crate::mirror::load_meta_async(mirror_path.as_deref()).await.and_then(|pkg| {
                 pkg.time.as_ref().map(|raw| {
                     raw.iter()

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -750,18 +750,17 @@ impl NpmResolutionVerifier {
         };
         // The verifier reads the *same* scoped mirror a resolve would
         // populate. A private packument lives under its descriptor
-        // namespace, so a caller who can't reproduce the descriptor (a
-        // `Bypass` route → no mirror) can't read another caller's private
-        // `time` map through the trust-check path.
+        // namespace, so a caller who can't reproduce the descriptor can't
+        // read another caller's private `time` map through the trust-check
+        // path.
         let name_string = name.to_string();
         let url = crate::registry_url::to_registry_url(registry, &name_string);
         let scope = self.auth_headers.metadata_scope(&url, Some(&name_string));
         cell.get_or_init(|| async {
-            let mirror_path = crate::mirror::scoped_meta_dir(&scope, crate::mirror::FULL_META_DIR)
-                .and_then(|meta_dir| {
-                    crate::mirror::get_pkg_mirror_path(cache_dir, &meta_dir, registry, &name_string)
-                        .ok()
-                });
+            let meta_dir = crate::mirror::scoped_meta_dir(&scope, crate::mirror::FULL_META_DIR);
+            let mirror_path =
+                crate::mirror::get_pkg_mirror_path(cache_dir, &meta_dir, registry, &name_string)
+                    .ok();
             crate::mirror::load_meta_async(mirror_path.as_deref()).await.and_then(|pkg| {
                 pkg.time.as_ref().map(|raw| {
                     raw.iter()

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -3,13 +3,21 @@ use std::{collections::HashMap, sync::Arc};
 use chrono::{DateTime, Utc};
 use pacquet_config::{TrustPolicy, version_policy::create_package_version_policy};
 use pacquet_lockfile::{LockfileResolution, PkgName, RegistryResolution, TarballResolution};
-use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
+use pacquet_network::{
+    AuthHeaders, MetadataCacheScope, RetryOpts, ThrottledClient, UpstreamRouteHook,
+};
+use pacquet_registry::Package;
 use pacquet_resolving_resolver_base::{ResolutionVerification, ResolutionVerifier, VerifyCtx};
 use pretty_assertions::assert_eq;
 use ssri::Integrity;
+use tempfile::TempDir;
 
 use super::{
     CreateNpmResolutionVerifierOptions, create_npm_resolution_verifier, observed_dist_stats_sink,
+};
+use crate::{
+    mirror::{ABBREVIATED_META_DIR, get_pkg_mirror_path, load_meta},
+    persist_meta_to_mirror,
 };
 
 const FAKE_INTEGRITY: &str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
@@ -56,6 +64,20 @@ fn default_opts(registry_url: &str) -> CreateNpmResolutionVerifierOptions {
         retry_opts: RetryOpts { retries: 0, ..RetryOpts::default() },
         now: None,
         observed_dist_stats: None,
+    }
+}
+
+struct ScopeHook {
+    scope: MetadataCacheScope,
+}
+
+impl UpstreamRouteHook for ScopeHook {
+    fn authorize(&self, _url: &str, _package: Option<&str>) -> Option<String> {
+        None
+    }
+
+    fn metadata_scope(&self, _url: &str, _package: Option<&str>) -> MetadataCacheScope {
+        self.scope.clone()
     }
 }
 
@@ -205,6 +227,94 @@ async fn verifies_tarball_url_when_no_policy_active() {
         panic!("expected Err, got {result:?}");
     };
     assert_eq!(code, "TARBALL_URL_MISMATCH");
+}
+
+#[tokio::test]
+async fn private_scope_verifier_ignores_public_mirror_and_writes_private_mirror() {
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let server_url = server.url();
+    let public_tarball = format!("{server_url}/acme/-/acme-1.0.0.tgz");
+    let private_tarball = format!("{server_url}/acme/-/acme-private-1.0.0.tgz");
+    let public_packument = serde_json::json!({
+        "name": "acme",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "acme",
+                "version": "1.0.0",
+                "dist": {
+                    "integrity": FAKE_INTEGRITY,
+                    "shasum": "0000000000000000000000000000000000000000",
+                    "tarball": public_tarball,
+                }
+            }
+        }
+    });
+    let private_packument = serde_json::json!({
+        "name": "acme",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "acme",
+                "version": "1.0.0",
+                "dist": {
+                    "integrity": FAKE_INTEGRITY,
+                    "shasum": "0000000000000000000000000000000000000000",
+                    "tarball": private_tarball,
+                }
+            }
+        }
+    });
+    let _meta_mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(private_packument.to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    let cache = TempDir::new().expect("tempdir");
+    let public_meta: Package = serde_json::from_value(public_packument).expect("package parses");
+    persist_meta_to_mirror(cache.path(), ABBREVIATED_META_DIR, &registry, &public_meta)
+        .expect("warm public mirror");
+
+    let mut opts = default_opts(&registry);
+    opts.cache_dir = Some(cache.path().to_path_buf());
+    opts.auth_headers =
+        Arc::new(AuthHeaders::default().with_route_hook(Arc::new(ScopeHook {
+            scope: MetadataCacheScope::Private { descriptor_id: "private-scope".to_string() },
+        }) as Arc<dyn UpstreamRouteHook>));
+    let verifier = create_npm_resolution_verifier(opts);
+    let resolution = LockfileResolution::Tarball(TarballResolution {
+        tarball: public_tarball.clone(),
+        integrity: Some(fake_integrity()),
+        git_hosted: None,
+        path: None,
+    });
+    let name: PkgName = "acme".parse().expect("parse");
+    let result = verifier.verify(&resolution, ctx(&name, "1.0.0")).await;
+
+    let ResolutionVerification::Err { code, .. } = result else {
+        panic!("expected private metadata mismatch, got {result:?}");
+    };
+    assert_eq!(code, "TARBALL_URL_MISMATCH");
+
+    let private_path = get_pkg_mirror_path(
+        cache.path(),
+        "v11/metadata-private/private-scope/metadata",
+        &registry,
+        "acme",
+    )
+    .expect("private mirror path");
+    let private_meta = load_meta(&private_path).expect("private mirror written");
+    let private_version = private_meta.versions.get("1.0.0").expect("private version");
+    assert_eq!(private_version.dist.tarball, private_tarball);
+
+    let public_path =
+        get_pkg_mirror_path(cache.path(), ABBREVIATED_META_DIR, &registry, "acme").expect("path");
+    let public_meta = load_meta(&public_path).expect("public mirror remains readable");
+    let public_version = public_meta.versions.get("1.0.0").expect("public version");
+    assert_eq!(public_version.dist.tarball, public_tarball);
 }
 
 #[tokio::test]

--- a/pacquet/crates/resolving-npm-resolver/src/errors.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/errors.rs
@@ -123,6 +123,31 @@ impl FetchMetadataError {
     pub fn is_body_retryable(&self) -> bool {
         matches!(self, FetchMetadataError::BodyRead { .. } | FetchMetadataError::Decode { .. })
     }
+
+    /// Whether this failure is a hard access/existence denial — HTTP
+    /// `401`, `403`, or `404` — rather than a transport failure
+    /// (`5xx`/timeout/connection reset).
+    ///
+    /// A private-scope metadata fetch must **fail closed** on a denial:
+    /// never fall back to a cached mirror (stale-or-broader namespace),
+    /// because a revoked credential or a hidden private `404` would
+    /// otherwise keep serving the last private packument. A transport
+    /// failure may still fall back, but only within the same namespace.
+    /// Public-scope fetches keep their existing disk fallback regardless.
+    #[must_use]
+    pub fn is_access_denied(&self) -> bool {
+        match self {
+            FetchMetadataError::Network { error, .. } => matches!(
+                error.status(),
+                Some(
+                    reqwest::StatusCode::UNAUTHORIZED
+                        | reqwest::StatusCode::FORBIDDEN
+                        | reqwest::StatusCode::NOT_FOUND
+                )
+            ),
+            _ => false,
+        }
+    }
 }
 
 /// Raised when an external `PackageVersionGuard` rejects every

--- a/pacquet/crates/resolving-npm-resolver/src/errors.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/errors.rs
@@ -143,7 +143,7 @@ impl FetchMetadataError {
                     reqwest::StatusCode::UNAUTHORIZED
                         | reqwest::StatusCode::FORBIDDEN
                         | reqwest::StatusCode::NOT_FOUND
-                )
+                ),
             ),
             _ => false,
         }

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -80,16 +80,16 @@ pub async fn fetch_full_metadata_cached(
     };
     let url = to_registry_url(opts.registry, pkg_name);
     // Classify the route once so the mirror lands in the namespace the
-    // route policy permits: the global mirror for a public route, a
-    // descriptor-scoped private mirror for a proxied/hosted route, and no
-    // shared mirror at all for an unknown-private (`Bypass`) route.
+    // route policy permits: the global mirror for a public route and a
+    // descriptor-scoped private mirror for a proxied/hosted route.
     let scope = opts.auth_headers.metadata_scope(&url, Some(pkg_name));
     // Encoding the mirror path can fail only on a malformed registry
     // URL (no host, unparsable). Either case is a config bug; we
     // log and proceed without a cache so the user still gets metadata
     // on this install instead of a hard error.
-    let mirror_path = match (opts.cache_dir, scoped_meta_dir(&scope, base_meta_dir)) {
-        (Some(dir), Some(meta_dir)) => {
+    let mirror_path = match opts.cache_dir {
+        Some(dir) => {
+            let meta_dir = scoped_meta_dir(&scope, base_meta_dir);
             match get_pkg_mirror_path(dir, &meta_dir, opts.registry, pkg_name) {
                 Ok(path) => Some(path),
                 Err(error) => {
@@ -105,9 +105,8 @@ pub async fn fetch_full_metadata_cached(
                 }
             }
         }
-        // No cache dir, or a `Bypass` route that must not touch a shared
-        // mirror — fetch fresh without reading or writing one.
-        _ => None,
+        // No cache dir — fetch fresh without reading or writing a mirror.
+        None => None,
     };
     let cache_headers = load_meta_headers_async(mirror_path.as_deref()).await;
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -31,7 +31,7 @@ use crate::{
     mirror::{
         ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, clear_meta,
         get_pkg_mirror_path, load_meta_async, load_meta_headers_async, save_meta_indexed,
-        save_meta_ndjson,
+        save_meta_ndjson, scoped_meta_dir,
     },
     registry_url::to_registry_url,
 };
@@ -73,35 +73,43 @@ pub async fn fetch_full_metadata_cached(
     pkg_name: &str,
     opts: &FetchFullMetadataCachedOptions<'_>,
 ) -> Result<Package, FetchMetadataError> {
-    let meta_dir = if opts.full_metadata {
+    let base_meta_dir = if opts.full_metadata {
         if opts.filter_metadata { FULL_FILTERED_META_DIR } else { FULL_META_DIR }
     } else {
         ABBREVIATED_META_DIR
     };
+    let url = to_registry_url(opts.registry, pkg_name);
+    // Classify the route once so the mirror lands in the namespace the
+    // route policy permits: the global mirror for a public route, a
+    // descriptor-scoped private mirror for a proxied/hosted route, and no
+    // shared mirror at all for an unknown-private (`Bypass`) route.
+    let scope = opts.auth_headers.metadata_scope(&url, Some(pkg_name));
     // Encoding the mirror path can fail only on a malformed registry
     // URL (no host, unparsable). Either case is a config bug; we
     // log and proceed without a cache so the user still gets metadata
     // on this install instead of a hard error.
-    let mirror_path = match opts.cache_dir {
-        Some(dir) => match get_pkg_mirror_path(dir, meta_dir, opts.registry, pkg_name) {
-            Ok(path) => Some(path),
-            Err(error) => {
-                tracing::debug!(
-                    target: "pacquet_resolving_npm_resolver::cache",
-                    ?error,
-                    registry = opts.registry,
-                    pkg_name,
-                    full_metadata = opts.full_metadata,
-                    "could not encode mirror path; bypassing cache for this call",
-                );
-                None
+    let mirror_path = match (opts.cache_dir, scoped_meta_dir(&scope, base_meta_dir)) {
+        (Some(dir), Some(meta_dir)) => {
+            match get_pkg_mirror_path(dir, &meta_dir, opts.registry, pkg_name) {
+                Ok(path) => Some(path),
+                Err(error) => {
+                    tracing::debug!(
+                        target: "pacquet_resolving_npm_resolver::cache",
+                        ?error,
+                        registry = opts.registry,
+                        pkg_name,
+                        full_metadata = opts.full_metadata,
+                        "could not encode mirror path; bypassing cache for this call",
+                    );
+                    None
+                }
             }
-        },
-        None => None,
+        }
+        // No cache dir, or a `Bypass` route that must not touch a shared
+        // mirror — fetch fresh without reading or writing one.
+        _ => None,
     };
     let cache_headers = load_meta_headers_async(mirror_path.as_deref()).await;
-
-    let url = to_registry_url(opts.registry, pkg_name);
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
     let should_filter_metadata = opts.full_metadata && opts.filter_metadata;
 

--- a/pacquet/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/mirror.rs
@@ -142,17 +142,14 @@ const PRIVATE_META_ROOT: &str = "v11/metadata-private";
 ///   `v11/metadata-private/<descriptor-id>/` keyed by the descriptor id,
 ///   preserving the abbreviated/full/filtered split via the suffix after
 ///   `v11/`.
-/// * [`MetadataCacheScope::Bypass`] returns `None` — the route must not
-///   touch any shared on-disk mirror.
 #[must_use]
-pub fn scoped_meta_dir(scope: &MetadataCacheScope, base_meta_dir: &str) -> Option<String> {
+pub fn scoped_meta_dir(scope: &MetadataCacheScope, base_meta_dir: &str) -> String {
     match scope {
-        MetadataCacheScope::Public => Some(base_meta_dir.to_string()),
+        MetadataCacheScope::Public => base_meta_dir.to_string(),
         MetadataCacheScope::Private { descriptor_id } => {
             let suffix = base_meta_dir.strip_prefix("v11/").unwrap_or(base_meta_dir);
-            Some(format!("{PRIVATE_META_ROOT}/{descriptor_id}/{suffix}"))
+            format!("{PRIVATE_META_ROOT}/{descriptor_id}/{suffix}")
         }
-        MetadataCacheScope::Bypass => None,
     }
 }
 

--- a/pacquet/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/mirror.rs
@@ -59,6 +59,7 @@ use std::{
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;
+use pacquet_network::MetadataCacheScope;
 use pacquet_registry::{Package, PackageVersions};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -124,6 +125,35 @@ pub enum SaveMetaError {
         #[error(source)]
         error: io::Error,
     },
+}
+
+/// Mirror root for descriptor-scoped private metadata. A
+/// [`MetadataCacheScope::Private`] route stores its packuments under
+/// `<cache_dir>/v11/metadata-private/<descriptor-id>/<meta-suffix>/...`
+/// so one caller's private metadata never lands in the global mirror
+/// every other caller reads.
+const PRIVATE_META_ROOT: &str = "v11/metadata-private";
+
+/// The mirror directory `base_meta_dir` resolves to under `scope`.
+///
+/// * [`MetadataCacheScope::Public`] keeps the global directory unchanged
+///   (the CLI and public routes).
+/// * [`MetadataCacheScope::Private`] relocates it under
+///   `v11/metadata-private/<descriptor-id>/` keyed by the descriptor id,
+///   preserving the abbreviated/full/filtered split via the suffix after
+///   `v11/`.
+/// * [`MetadataCacheScope::Bypass`] returns `None` — the route must not
+///   touch any shared on-disk mirror.
+#[must_use]
+pub fn scoped_meta_dir(scope: &MetadataCacheScope, base_meta_dir: &str) -> Option<String> {
+    match scope {
+        MetadataCacheScope::Public => Some(base_meta_dir.to_string()),
+        MetadataCacheScope::Private { descriptor_id } => {
+            let suffix = base_meta_dir.strip_prefix("v11/").unwrap_or(base_meta_dir);
+            Some(format!("{PRIVATE_META_ROOT}/{descriptor_id}/{suffix}"))
+        }
+        MetadataCacheScope::Bypass => None,
+    }
 }
 
 /// On-disk path of the JSONL document where pacquet (and pnpm)

--- a/pacquet/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -41,7 +41,7 @@ fn scoped_meta_dir_private_namespaces_by_descriptor() {
     );
     // Distinct descriptors never share a directory.
     let other = MetadataCacheScope::Private { descriptor_id: "def456".to_string() };
-    assert_ne!(scoped_meta_dir(&scope, FULL_META_DIR), scoped_meta_dir(&other, FULL_META_DIR),);
+    assert_ne!(scoped_meta_dir(&scope, FULL_META_DIR), scoped_meta_dir(&other, FULL_META_DIR));
 }
 
 #[test]

--- a/pacquet/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -16,7 +16,7 @@ use super::{
 fn scoped_meta_dir_public_is_unchanged() {
     assert_eq!(
         scoped_meta_dir(&MetadataCacheScope::Public, ABBREVIATED_META_DIR),
-        ABBREVIATED_META_DIR
+        ABBREVIATED_META_DIR,
     );
     assert_eq!(scoped_meta_dir(&MetadataCacheScope::Public, FULL_META_DIR), FULL_META_DIR);
 }
@@ -28,7 +28,7 @@ fn scoped_meta_dir_private_namespaces_by_descriptor() {
         scoped_meta_dir(&scope, ABBREVIATED_META_DIR),
         "v11/metadata-private/abc123/metadata",
     );
-    assert_eq!(scoped_meta_dir(&scope, FULL_META_DIR), "v11/metadata-private/abc123/metadata-full",);
+    assert_eq!(scoped_meta_dir(&scope, FULL_META_DIR), "v11/metadata-private/abc123/metadata-full");
     assert_eq!(
         scoped_meta_dir(&scope, FULL_FILTERED_META_DIR),
         "v11/metadata-private/abc123/metadata-full-filtered",

--- a/pacquet/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -4,10 +4,51 @@ use pacquet_registry::Package;
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 
+use pacquet_network::MetadataCacheScope;
+
 use super::{
     ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, encode_pkg_name,
     get_pkg_mirror_path, get_registry_name, load_meta, load_meta_headers, save_meta_indexed,
+    scoped_meta_dir,
 };
+
+#[test]
+fn scoped_meta_dir_public_is_unchanged() {
+    assert_eq!(
+        scoped_meta_dir(&MetadataCacheScope::Public, ABBREVIATED_META_DIR).as_deref(),
+        Some(ABBREVIATED_META_DIR),
+    );
+    assert_eq!(
+        scoped_meta_dir(&MetadataCacheScope::Public, FULL_META_DIR).as_deref(),
+        Some(FULL_META_DIR),
+    );
+}
+
+#[test]
+fn scoped_meta_dir_private_namespaces_by_descriptor() {
+    let scope = MetadataCacheScope::Private { descriptor_id: "abc123".to_string() };
+    assert_eq!(
+        scoped_meta_dir(&scope, ABBREVIATED_META_DIR).as_deref(),
+        Some("v11/metadata-private/abc123/metadata"),
+    );
+    assert_eq!(
+        scoped_meta_dir(&scope, FULL_META_DIR).as_deref(),
+        Some("v11/metadata-private/abc123/metadata-full"),
+    );
+    assert_eq!(
+        scoped_meta_dir(&scope, FULL_FILTERED_META_DIR).as_deref(),
+        Some("v11/metadata-private/abc123/metadata-full-filtered"),
+    );
+    // Distinct descriptors never share a directory.
+    let other = MetadataCacheScope::Private { descriptor_id: "def456".to_string() };
+    assert_ne!(scoped_meta_dir(&scope, FULL_META_DIR), scoped_meta_dir(&other, FULL_META_DIR),);
+}
+
+#[test]
+fn scoped_meta_dir_bypass_has_no_shared_mirror() {
+    assert_eq!(scoped_meta_dir(&MetadataCacheScope::Bypass, ABBREVIATED_META_DIR), None);
+    assert_eq!(scoped_meta_dir(&MetadataCacheScope::Bypass, FULL_META_DIR), None);
+}
 
 #[test]
 fn encode_pkg_name_passes_lowercase_through() {

--- a/pacquet/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -15,39 +15,27 @@ use super::{
 #[test]
 fn scoped_meta_dir_public_is_unchanged() {
     assert_eq!(
-        scoped_meta_dir(&MetadataCacheScope::Public, ABBREVIATED_META_DIR).as_deref(),
-        Some(ABBREVIATED_META_DIR),
+        scoped_meta_dir(&MetadataCacheScope::Public, ABBREVIATED_META_DIR),
+        ABBREVIATED_META_DIR
     );
-    assert_eq!(
-        scoped_meta_dir(&MetadataCacheScope::Public, FULL_META_DIR).as_deref(),
-        Some(FULL_META_DIR),
-    );
+    assert_eq!(scoped_meta_dir(&MetadataCacheScope::Public, FULL_META_DIR), FULL_META_DIR);
 }
 
 #[test]
 fn scoped_meta_dir_private_namespaces_by_descriptor() {
     let scope = MetadataCacheScope::Private { descriptor_id: "abc123".to_string() };
     assert_eq!(
-        scoped_meta_dir(&scope, ABBREVIATED_META_DIR).as_deref(),
-        Some("v11/metadata-private/abc123/metadata"),
+        scoped_meta_dir(&scope, ABBREVIATED_META_DIR),
+        "v11/metadata-private/abc123/metadata",
     );
+    assert_eq!(scoped_meta_dir(&scope, FULL_META_DIR), "v11/metadata-private/abc123/metadata-full",);
     assert_eq!(
-        scoped_meta_dir(&scope, FULL_META_DIR).as_deref(),
-        Some("v11/metadata-private/abc123/metadata-full"),
-    );
-    assert_eq!(
-        scoped_meta_dir(&scope, FULL_FILTERED_META_DIR).as_deref(),
-        Some("v11/metadata-private/abc123/metadata-full-filtered"),
+        scoped_meta_dir(&scope, FULL_FILTERED_META_DIR),
+        "v11/metadata-private/abc123/metadata-full-filtered",
     );
     // Distinct descriptors never share a directory.
     let other = MetadataCacheScope::Private { descriptor_id: "def456".to_string() };
     assert_ne!(scoped_meta_dir(&scope, FULL_META_DIR), scoped_meta_dir(&other, FULL_META_DIR));
-}
-
-#[test]
-fn scoped_meta_dir_bypass_has_no_shared_mirror() {
-    assert_eq!(scoped_meta_dir(&MetadataCacheScope::Bypass, ABBREVIATED_META_DIR), None);
-    assert_eq!(scoped_meta_dir(&MetadataCacheScope::Bypass, FULL_META_DIR), None);
 }
 
 #[test]

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -61,7 +61,7 @@ use dashmap::DashMap;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::version_policy::{PackageVersionPolicy, PolicyMatch};
-use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
+use pacquet_network::{AuthHeaders, MetadataCacheScope, RetryOpts, ThrottledClient};
 use pacquet_registry::{Package, PackageVersion};
 use pacquet_resolving_resolver_base::{VersionSelectors, parse_packument_timestamp};
 use tokio::sync::Semaphore;
@@ -71,7 +71,7 @@ use crate::{
     FetchMetadataError, fetch_full_metadata, fetch_full_metadata_cached,
     mirror::{
         ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, clear_meta,
-        get_pkg_mirror_path, load_meta_async, save_meta_indexed, save_meta_ndjson,
+        get_pkg_mirror_path, load_meta_async, save_meta_indexed, save_meta_ndjson, scoped_meta_dir,
     },
     pick_package_from_meta::{
         PickPackageFromMetaError, PickPackageFromMetaOptions, RegistryPackageSpec,
@@ -407,7 +407,15 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     // would classify it, so the footprint is complete regardless of which
     // layer serves the metadata. A no-op for the CLI (no hook installed);
     // idempotent on the hook, so the network path re-recording it is fine.
-    ctx.auth_headers.record_route(&to_registry_url(opts.registry, &spec.name), Some(&spec.name));
+    let url = to_registry_url(opts.registry, &spec.name);
+    ctx.auth_headers.record_route(&url, Some(&spec.name));
+
+    // Classify the metadata cache scope once. Every layer below — the
+    // in-memory cache, the disk fast paths, and the network fetch — must
+    // agree on the mirror namespace and cache keys this route resolves to,
+    // or a private packument could leak into (or read from) the global
+    // mirror. `Public` for the CLI, leaving the global mirror unchanged.
+    let scope = ctx.auth_headers.metadata_scope(&url, Some(&spec.name));
 
     let picker_opts = PickerOpts {
         preferred_version_selectors: opts.preferred_version_selectors,
@@ -420,42 +428,37 @@ pub async fn pick_package<Cache: PackageMetaCache>(
 
     let full_metadata = opts.optional || ctx.full_metadata;
     let use_filtered_full_metadata = full_metadata && ctx.filter_metadata;
-    let meta_dir = if full_metadata {
+    let base_meta_dir = if full_metadata {
         if use_filtered_full_metadata { FULL_FILTERED_META_DIR } else { FULL_META_DIR }
     } else {
         ABBREVIATED_META_DIR
     };
 
-    let pkg_mirror = ctx
-        .cache_dir
-        .and_then(|dir| get_pkg_mirror_path(dir, meta_dir, opts.registry, &spec.name).ok());
-
-    // Scope the in-memory cache key by registry so the same package
-    // name in two different registries (private + public, scoped
-    // override, etc.) never short-circuits to the wrong packument.
-    // Upstream pnpm gets the same scoping by holding one
-    // `PackageMetaCache` per resolver instance per registry; pacquet
-    // shares one cache across all `pick_package` calls, so the key
-    // has to do the scoping itself.
-    //
-    // The full-mode suffix mirrors upstream's
-    // [cache-key shape](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L206):
-    // a later call with `opts.optional = true` must not satisfy
-    // itself with the abbreviated cache entry an earlier call
-    // populated (the abbreviated form drops `libc`/`cpu`/`os` from
-    // some shapes). Filtered full metadata gets its own suffix
-    // because pacquet stores it in a distinct on-disk mirror shape.
-    let cache_key = if full_metadata {
-        let suffix = if use_filtered_full_metadata { ":full:filtered" } else { ":full" };
-        format!("{}\x00{}{suffix}", opts.registry, spec.name)
-    } else {
-        format!("{}\x00{}", opts.registry, spec.name)
+    // A `Bypass` route resolves to no shared mirror (`scoped_meta_dir`
+    // returns `None`); a `Private` route relocates the mirror under its
+    // descriptor namespace so it can never be read by a caller who doesn't
+    // reproduce the same descriptor.
+    let pkg_mirror = match (ctx.cache_dir, scoped_meta_dir(&scope, base_meta_dir)) {
+        (Some(dir), Some(meta_dir)) => {
+            get_pkg_mirror_path(dir, &meta_dir, opts.registry, &spec.name).ok()
+        }
+        _ => None,
     };
+
+    let cache_key = metadata_cache_key(
+        &scope,
+        opts.registry,
+        &spec.name,
+        full_metadata,
+        use_filtered_full_metadata,
+    );
 
     // updateChecksums must reach the conditional registry request below, so it
     // can't be served from the in-memory cache — which may hold a disk-promoted
     // entry rather than a fresh network fetch (see the `update_checksums` doc).
-    let use_mem_cache = !opts.update_checksums;
+    // A `Bypass` route is request-local: it must not read or populate the
+    // shared in-memory cache either.
+    let use_mem_cache = !opts.update_checksums && !matches!(scope, MetadataCacheScope::Bypass);
 
     // 1. In-memory cache.
     if use_mem_cache && let Some(cached) = ctx.meta_cache.get(&cache_key) {
@@ -642,9 +645,24 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             // returned (when it returned Ok). If it returned Err,
             // try the disk fallback: an existing mirror is good
             // enough to pick from, even if the latest sync failed.
-            let disk_fallback = match meta_cached_in_store {
-                Some(meta) => Some(meta),
-                None => load_meta_async(pkg_mirror.as_deref()).await.map(Arc::new),
+            //
+            // A private/bypass route must fail closed on a `401`/`403`/
+            // private-`404`: a revoked credential or a hidden private
+            // package must not keep serving the last cached packument,
+            // even from its own (same-namespace) mirror. Only a transport
+            // failure (`5xx`/timeout/network) falls back, and only within
+            // the scoped mirror `pkg_mirror` already points at. A public
+            // route (the CLI / public registries) keeps the original
+            // fall-back-on-any-error behavior.
+            let allow_fallback =
+                matches!(scope, MetadataCacheScope::Public) || !error.is_access_denied();
+            let disk_fallback = if allow_fallback {
+                match meta_cached_in_store {
+                    Some(meta) => Some(meta),
+                    None => load_meta_async(pkg_mirror.as_deref()).await.map(Arc::new),
+                }
+            } else {
+                None
             };
             if let Some(disk) = disk_fallback {
                 tracing::debug!(
@@ -679,7 +697,11 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     // suppresses the in-memory cache write. A future
     // refactor that threads `dry_run` into the fetcher can restore
     // upstream's no-disk-side-effect dry-run.
-    if !opts.dry_run {
+    //
+    // A `Bypass` route stays request-local: its packument must not land
+    // in the shared in-memory cache (`update_checksums` still writes back,
+    // so this keeps that case but excludes bypass).
+    if !opts.dry_run && !matches!(scope, MetadataCacheScope::Bypass) {
         ctx.meta_cache.set(cache_key, Arc::clone(&meta));
     }
     let (meta, picked) = pick_from_meta(&picker_opts, spec, meta, opts.blocked_versions)?;
@@ -951,6 +973,44 @@ fn meta_opts<'a>(picker_opts: &'a PickerOpts<'_>) -> PickPackageFromMetaOptions<
         preferred_version_selectors: picker_opts.preferred_version_selectors,
         published_by: picker_opts.published_by,
         published_by_exclude: picker_opts.published_by_exclude,
+    }
+}
+
+/// The in-memory cache + fetch-lock key for a `(registry, package)` pick,
+/// namespaced by its [`MetadataCacheScope`].
+///
+/// A [`MetadataCacheScope::Public`] route keeps the exact upstream-shaped
+/// `{registry}\x00{name}` key (with the `:full` / `:full:filtered` suffix
+/// from upstream's
+/// [cache-key shape](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L206)),
+/// so the CLI and public routes are unchanged. A private or bypass route
+/// prepends its descriptor namespace so one caller's private packument
+/// can't satisfy another caller's pick for the same name.
+///
+/// The registry is part of the key because the same package name can live
+/// in two registries (a public `lodash` and a private one); upstream pnpm
+/// gets that scoping by holding one cache per resolver instance per
+/// registry, while pacquet shares one cache across every pick. The
+/// full-mode suffix keeps a later `optional` pick from reusing an
+/// abbreviated entry that dropped `libc`/`cpu`/`os`.
+fn metadata_cache_key(
+    scope: &MetadataCacheScope,
+    registry: &str,
+    name: &str,
+    full_metadata: bool,
+    use_filtered_full_metadata: bool,
+) -> String {
+    let suffix = if full_metadata {
+        if use_filtered_full_metadata { ":full:filtered" } else { ":full" }
+    } else {
+        ""
+    };
+    match scope {
+        MetadataCacheScope::Public => format!("{registry}\x00{name}{suffix}"),
+        MetadataCacheScope::Private { descriptor_id } => {
+            format!("private\x00{descriptor_id}\x00{registry}\x00{name}{suffix}")
+        }
+        MetadataCacheScope::Bypass => format!("bypass\x00{registry}\x00{name}{suffix}"),
     }
 }
 

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -434,16 +434,13 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         ABBREVIATED_META_DIR
     };
 
-    // A `Bypass` route resolves to no shared mirror (`scoped_meta_dir`
-    // returns `None`); a `Private` route relocates the mirror under its
-    // descriptor namespace so it can never be read by a caller who doesn't
-    // reproduce the same descriptor.
-    let pkg_mirror = match (ctx.cache_dir, scoped_meta_dir(&scope, base_meta_dir)) {
-        (Some(dir), Some(meta_dir)) => {
-            get_pkg_mirror_path(dir, &meta_dir, opts.registry, &spec.name).ok()
-        }
-        _ => None,
-    };
+    // A `Private` route relocates the mirror under its descriptor namespace
+    // so it can never be read by a caller who doesn't reproduce the same
+    // descriptor; a `Public` route keeps the global mirror.
+    let pkg_mirror = ctx.cache_dir.and_then(|dir| {
+        let meta_dir = scoped_meta_dir(&scope, base_meta_dir);
+        get_pkg_mirror_path(dir, &meta_dir, opts.registry, &spec.name).ok()
+    });
 
     let cache_key = metadata_cache_key(
         &scope,
@@ -456,9 +453,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     // updateChecksums must reach the conditional registry request below, so it
     // can't be served from the in-memory cache — which may hold a disk-promoted
     // entry rather than a fresh network fetch (see the `update_checksums` doc).
-    // A `Bypass` route is request-local: it must not read or populate the
-    // shared in-memory cache either.
-    let use_mem_cache = !opts.update_checksums && !matches!(scope, MetadataCacheScope::Bypass);
+    let use_mem_cache = !opts.update_checksums;
 
     // 1. In-memory cache.
     if use_mem_cache && let Some(cached) = ctx.meta_cache.get(&cache_key) {
@@ -646,7 +641,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             // try the disk fallback: an existing mirror is good
             // enough to pick from, even if the latest sync failed.
             //
-            // A private/bypass route must fail closed on a `401`/`403`/
+            // A private route must fail closed on a `401`/`403`/
             // private-`404`: a revoked credential or a hidden private
             // package must not keep serving the last cached packument,
             // even from its own (same-namespace) mirror. Only a transport
@@ -698,10 +693,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     // refactor that threads `dry_run` into the fetcher can restore
     // upstream's no-disk-side-effect dry-run.
     //
-    // A `Bypass` route stays request-local: its packument must not land
-    // in the shared in-memory cache (`update_checksums` still writes back,
-    // so this keeps that case but excludes bypass).
-    if !opts.dry_run && !matches!(scope, MetadataCacheScope::Bypass) {
+    if !opts.dry_run {
         ctx.meta_cache.set(cache_key, Arc::clone(&meta));
     }
     let (meta, picked) = pick_from_meta(&picker_opts, spec, meta, opts.blocked_versions)?;
@@ -983,9 +975,9 @@ fn meta_opts<'a>(picker_opts: &'a PickerOpts<'_>) -> PickPackageFromMetaOptions<
 /// `{registry}\x00{name}` key (with the `:full` / `:full:filtered` suffix
 /// from upstream's
 /// [cache-key shape](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L206)),
-/// so the CLI and public routes are unchanged. A private or bypass route
-/// prepends its descriptor namespace so one caller's private packument
-/// can't satisfy another caller's pick for the same name.
+/// so the CLI and public routes are unchanged. A private route prepends its
+/// descriptor namespace so one caller's private packument can't satisfy
+/// another caller's pick for the same name.
 ///
 /// The registry is part of the key because the same package name can live
 /// in two registries (a public `lodash` and a private one); upstream pnpm
@@ -1010,7 +1002,6 @@ fn metadata_cache_key(
         MetadataCacheScope::Private { descriptor_id } => {
             format!("private\x00{descriptor_id}\x00{registry}\x00{name}{suffix}")
         }
-        MetadataCacheScope::Bypass => format!("bypass\x00{registry}\x00{name}{suffix}"),
     }
 }
 

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -79,6 +79,7 @@ use crate::{
         pick_lowest_version_by_version_range, pick_package_from_meta,
         pick_version_by_version_range,
     },
+    registry_url::to_registry_url,
 };
 
 /// In-memory packument cache the orchestrator consults before any
@@ -395,6 +396,18 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     opts: &PickPackageOptions<'_>,
 ) -> Result<PickPackageResult, PickPackageError> {
     validate_package_name(&spec.name)?;
+
+    // Every layer below — the in-memory cache, the offline / version-spec
+    // / publishedBy disk fast paths, and the network fetch — answers this
+    // pick for the same `(registry, package)` route. The fast paths return
+    // straight from cache without ever reaching the auth-selection point,
+    // so a server route hook would never see this package and its private
+    // footprint would under-report the data the resolve depended on.
+    // Record the route up front, classified exactly as the network fetch
+    // would classify it, so the footprint is complete regardless of which
+    // layer serves the metadata. A no-op for the CLI (no hook installed);
+    // idempotent on the hook, so the network path re-recording it is fine.
+    ctx.auth_headers.record_route(&to_registry_url(opts.registry, &spec.name), Some(&spec.name));
 
     let picker_opts = PickerOpts {
         preferred_version_selectors: opts.preferred_version_selectors,

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -1301,7 +1301,7 @@ fn metadata_cache_key_public_matches_upstream_shape() {
 }
 
 #[test]
-fn metadata_cache_key_private_and_bypass_are_namespaced() {
+fn metadata_cache_key_private_is_namespaced() {
     let private = MetadataCacheScope::Private { descriptor_id: "id1".to_string() };
     assert_eq!(
         metadata_cache_key(&private, "https://reg/", "acme", false, false),
@@ -1313,18 +1313,15 @@ fn metadata_cache_key_private_and_bypass_are_namespaced() {
         metadata_cache_key(&private, "https://reg/", "acme", false, false),
         metadata_cache_key(&other, "https://reg/", "acme", false, false),
     );
-    // Neither private nor bypass can collide with the public key.
+    // A private key never collides with the public key.
     let public =
         metadata_cache_key(&MetadataCacheScope::Public, "https://reg/", "acme", false, false);
-    let bypass =
-        metadata_cache_key(&MetadataCacheScope::Bypass, "https://reg/", "acme", false, false);
-    assert_ne!(public, bypass);
     assert_ne!(public, metadata_cache_key(&private, "https://reg/", "acme", false, false));
 }
 
 /// A route hook that classifies every fetch into one fixed
-/// [`MetadataCacheScope`], so a test can drive the private/bypass mirror
-/// paths without standing up a full pnpr route policy.
+/// [`MetadataCacheScope`], so a test can drive the private mirror path
+/// without standing up a full pnpr route policy.
 struct ScopeHook {
     scope: MetadataCacheScope,
 }
@@ -1388,49 +1385,6 @@ async fn private_scope_writes_descriptor_namespaced_mirror() {
     let global = get_pkg_mirror_path(cache_dir.path(), ABBREVIATED_META_DIR, &registry, "acme")
         .expect("global path");
     assert!(!global.exists(), "private packument must not touch the global mirror");
-}
-
-/// A `Bypass` route (unknown-private) must not write any shared mirror.
-#[tokio::test]
-async fn bypass_scope_writes_no_shared_mirror() {
-    let mut server = mockito::Server::new_async().await;
-    let mock = server
-        .mock("GET", "/acme")
-        .with_status(200)
-        .with_body(PACKAGE_BODY)
-        .expect(1)
-        .create_async()
-        .await;
-    let registry = format!("{}/", server.url());
-    let cache_dir = TempDir::new().expect("tempdir");
-    let http_client = ThrottledClient::default();
-    let auth_headers =
-        AuthHeaders::default()
-            .with_route_hook(Arc::new(ScopeHook { scope: MetadataCacheScope::Bypass })
-                as Arc<dyn UpstreamRouteHook>);
-    let meta_cache = InMemoryPackageMetaCache::default();
-    let fetch_locker = shared_packument_fetch_locker();
-    let ctx = PickPackageContext {
-        http_client: &http_client,
-        auth_headers: &auth_headers,
-        meta_cache: &meta_cache,
-        fetch_locker: &fetch_locker,
-        cache_dir: Some(cache_dir.path()),
-        offline: false,
-        prefer_offline: false,
-        ignore_missing_time_field: false,
-        full_metadata: false,
-        filter_metadata: false,
-        retry_opts: RetryOpts::default(),
-    };
-    pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry)).await.expect("ok");
-    mock.assert_async().await;
-
-    let global = get_pkg_mirror_path(cache_dir.path(), ABBREVIATED_META_DIR, &registry, "acme")
-        .expect("global path");
-    assert!(!global.exists(), "bypass route writes no shared mirror");
-    // The bypass route is also kept out of the shared in-memory cache.
-    assert!(meta_cache.get(&format!("{registry}\x00acme")).is_none());
 }
 
 /// A `Private` route must fail closed on a `401`: a revoked credential

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -1288,7 +1288,7 @@ fn metadata_cache_key_public_matches_upstream_shape() {
     let scope = MetadataCacheScope::Public;
     assert_eq!(
         metadata_cache_key(&scope, "https://reg/", "acme", false, false),
-        "https://reg/\x00acme"
+        "https://reg/\x00acme",
     );
     assert_eq!(
         metadata_cache_key(&scope, "https://reg/", "acme", true, false),
@@ -1319,7 +1319,7 @@ fn metadata_cache_key_private_and_bypass_are_namespaced() {
     let bypass =
         metadata_cache_key(&MetadataCacheScope::Bypass, "https://reg/", "acme", false, false);
     assert_ne!(public, bypass);
-    assert_ne!(public, metadata_cache_key(&private, "https://reg/", "acme", false, false),);
+    assert_ne!(public, metadata_cache_key(&private, "https://reg/", "acme", false, false));
 }
 
 /// A route hook that classifies every fetch into one fixed

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, UpstreamRouteHook};
+use pacquet_network::{
+    AuthHeaders, MetadataCacheScope, RetryOpts, ThrottledClient, UpstreamRouteHook,
+};
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 
@@ -9,7 +11,8 @@ use pacquet_config::version_policy::create_package_version_policy;
 
 use super::{
     InMemoryPackageMetaCache, PackageMetaCache, PickPackageContext, PickPackageError,
-    PickPackageOptions, persist_meta_to_mirror, pick_package, shared_packument_fetch_locker,
+    PickPackageOptions, metadata_cache_key, persist_meta_to_mirror, pick_package,
+    shared_packument_fetch_locker,
 };
 use crate::{
     mirror::{
@@ -1275,5 +1278,239 @@ async fn cache_fast_paths_record_route_through_hook() {
         assert_eq!(routes.as_slice(), &[(expected_url.clone(), Some("acme".to_string()))]);
     }
 
+    mock.assert_async().await;
+}
+
+#[test]
+fn metadata_cache_key_public_matches_upstream_shape() {
+    // The CLI / public route must keep the exact `{registry}\x00{name}`
+    // key (plus the `:full` suffixes) so behavior is unchanged.
+    let scope = MetadataCacheScope::Public;
+    assert_eq!(
+        metadata_cache_key(&scope, "https://reg/", "acme", false, false),
+        "https://reg/\x00acme"
+    );
+    assert_eq!(
+        metadata_cache_key(&scope, "https://reg/", "acme", true, false),
+        "https://reg/\x00acme:full",
+    );
+    assert_eq!(
+        metadata_cache_key(&scope, "https://reg/", "acme", true, true),
+        "https://reg/\x00acme:full:filtered",
+    );
+}
+
+#[test]
+fn metadata_cache_key_private_and_bypass_are_namespaced() {
+    let private = MetadataCacheScope::Private { descriptor_id: "id1".to_string() };
+    assert_eq!(
+        metadata_cache_key(&private, "https://reg/", "acme", false, false),
+        "private\x00id1\x00https://reg/\x00acme",
+    );
+    // A different descriptor never collides with the first.
+    let other = MetadataCacheScope::Private { descriptor_id: "id2".to_string() };
+    assert_ne!(
+        metadata_cache_key(&private, "https://reg/", "acme", false, false),
+        metadata_cache_key(&other, "https://reg/", "acme", false, false),
+    );
+    // Neither private nor bypass can collide with the public key.
+    let public =
+        metadata_cache_key(&MetadataCacheScope::Public, "https://reg/", "acme", false, false);
+    let bypass =
+        metadata_cache_key(&MetadataCacheScope::Bypass, "https://reg/", "acme", false, false);
+    assert_ne!(public, bypass);
+    assert_ne!(public, metadata_cache_key(&private, "https://reg/", "acme", false, false),);
+}
+
+/// A route hook that classifies every fetch into one fixed
+/// [`MetadataCacheScope`], so a test can drive the private/bypass mirror
+/// paths without standing up a full pnpr route policy.
+struct ScopeHook {
+    scope: MetadataCacheScope,
+}
+
+impl UpstreamRouteHook for ScopeHook {
+    fn authorize(&self, _url: &str, _package: Option<&str>) -> Option<String> {
+        None
+    }
+
+    fn metadata_scope(&self, _url: &str, _package: Option<&str>) -> MetadataCacheScope {
+        self.scope.clone()
+    }
+}
+
+/// A `Private` route must persist its packument under the
+/// descriptor-namespaced mirror and never under the global one, so a
+/// caller who can't reproduce the descriptor can't read it.
+#[tokio::test]
+async fn private_scope_writes_descriptor_namespaced_mirror() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_header("etag", r#"W/"fresh""#)
+        .with_body(PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let cache_dir = TempDir::new().expect("tempdir");
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default().with_route_hook(Arc::new(ScopeHook {
+        scope: MetadataCacheScope::Private { descriptor_id: "deadbeef".to_string() },
+    }) as Arc<dyn UpstreamRouteHook>);
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+    pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry)).await.expect("ok");
+    mock.assert_async().await;
+
+    let scoped = get_pkg_mirror_path(
+        cache_dir.path(),
+        "v11/metadata-private/deadbeef/metadata",
+        &registry,
+        "acme",
+    )
+    .expect("scoped path");
+    assert!(scoped.exists(), "private packument lands in the descriptor-scoped mirror");
+    let global = get_pkg_mirror_path(cache_dir.path(), ABBREVIATED_META_DIR, &registry, "acme")
+        .expect("global path");
+    assert!(!global.exists(), "private packument must not touch the global mirror");
+}
+
+/// A `Bypass` route (unknown-private) must not write any shared mirror.
+#[tokio::test]
+async fn bypass_scope_writes_no_shared_mirror() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let cache_dir = TempDir::new().expect("tempdir");
+    let http_client = ThrottledClient::default();
+    let auth_headers =
+        AuthHeaders::default()
+            .with_route_hook(Arc::new(ScopeHook { scope: MetadataCacheScope::Bypass })
+                as Arc<dyn UpstreamRouteHook>);
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+    pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry)).await.expect("ok");
+    mock.assert_async().await;
+
+    let global = get_pkg_mirror_path(cache_dir.path(), ABBREVIATED_META_DIR, &registry, "acme")
+        .expect("global path");
+    assert!(!global.exists(), "bypass route writes no shared mirror");
+    // The bypass route is also kept out of the shared in-memory cache.
+    assert!(meta_cache.get(&format!("{registry}\x00acme")).is_none());
+}
+
+/// A `Private` route must fail closed on a `401`: a revoked credential
+/// must not keep serving the last cached packument, even from the route's
+/// own descriptor-scoped mirror.
+#[tokio::test]
+async fn private_scope_fails_closed_on_401_without_disk_fallback() {
+    let preloaded: pacquet_registry::Package =
+        serde_json::from_str(PACKAGE_BODY).expect("parse packument");
+    let mut server = mockito::Server::new_async().await;
+    let mock = server.mock("GET", "/acme").with_status(401).create_async().await;
+    let registry = format!("{}/", server.url());
+    let cache_dir = TempDir::new().expect("tempdir");
+    // Warm the descriptor-scoped mirror that the fail-closed path must NOT
+    // serve from.
+    persist_meta_to_mirror(
+        cache_dir.path(),
+        "v11/metadata-private/deadbeef/metadata",
+        &registry,
+        &preloaded,
+    )
+    .expect("warm scoped mirror");
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default().with_route_hook(Arc::new(ScopeHook {
+        scope: MetadataCacheScope::Private { descriptor_id: "deadbeef".to_string() },
+    }) as Arc<dyn UpstreamRouteHook>);
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+    let result = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry)).await;
+    assert!(result.is_err(), "private 401 fails closed instead of serving the stale mirror");
+    mock.assert_async().await;
+}
+
+/// A public route keeps its disk fallback on the same `401`, proving the
+/// fail-closed behavior is scoped to private routes only.
+#[tokio::test]
+async fn public_scope_falls_back_to_mirror_on_401() {
+    let preloaded: pacquet_registry::Package =
+        serde_json::from_str(PACKAGE_BODY).expect("parse packument");
+    let mut server = mockito::Server::new_async().await;
+    let mock = server.mock("GET", "/acme").with_status(401).create_async().await;
+    let registry = format!("{}/", server.url());
+    let cache_dir = TempDir::new().expect("tempdir");
+    persist_meta_to_mirror(cache_dir.path(), ABBREVIATED_META_DIR, &registry, &preloaded)
+        .expect("warm global mirror");
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+    let result = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
+        .await
+        .expect("ok");
+    assert_eq!(result.picked_package.expect("picked").version.to_string(), "1.1.0");
     mock.assert_async().await;
 }

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -1170,7 +1170,7 @@ impl UpstreamRouteHook for RouteRecorder {
 /// private-footprint stays complete regardless of cache state. Without
 /// the up-front [`AuthHeaders::record_route`] in [`pick_package`], a
 /// private package served from cache would never be recorded and its
-/// resolution would be mis-cached as public.
+/// resolution would be wrongly cached as public.
 #[tokio::test]
 async fn cache_fast_paths_record_route_through_hook() {
     let preloaded: pacquet_registry::Package =

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -1,4 +1,6 @@
-use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
+use std::sync::Arc;
+
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, UpstreamRouteHook};
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 
@@ -14,6 +16,7 @@ use crate::{
         ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, get_pkg_mirror_path, load_meta,
     },
     pick_package_from_meta::{RegistryPackageSpec, RegistryPackageSpecType},
+    registry_url::to_registry_url,
 };
 
 const PACKAGE_BODY: &str = r#"{
@@ -1141,5 +1144,136 @@ async fn update_checksums_bypasses_warm_in_memory_cache() {
     let second =
         pick_package(&ctx, &version_spec("acme", "1.0.0"), &update_opts).await.expect("ok");
     assert_eq!(second.picked_package.expect("picked").version.to_string(), "1.0.0");
+    mock.assert_async().await;
+}
+
+/// A route hook that records every `(url, package)` it is asked to
+/// classify, so a test can assert a cache-served pick still surfaces its
+/// route to a server footprint even though no HTTP request happened.
+#[derive(Default)]
+struct RouteRecorder {
+    routes: std::sync::Mutex<Vec<(String, Option<String>)>>,
+}
+
+impl UpstreamRouteHook for RouteRecorder {
+    fn authorize(&self, url: &str, package: Option<&str>) -> Option<String> {
+        self.routes
+            .lock()
+            .expect("route recorder poisoned")
+            .push((url.to_string(), package.map(str::to_string)));
+        None
+    }
+}
+
+/// Every fast path that answers a pick from a warm in-memory or on-disk
+/// cache must still record the route through the hook, so a server's
+/// private-footprint stays complete regardless of cache state. Without
+/// the up-front [`AuthHeaders::record_route`] in [`pick_package`], a
+/// private package served from cache would never be recorded and its
+/// resolution would be mis-cached as public.
+#[tokio::test]
+async fn cache_fast_paths_record_route_through_hook() {
+    let preloaded: pacquet_registry::Package =
+        serde_json::from_str(PACKAGE_BODY).expect("parse packument");
+
+    // The mock 500s and expects zero calls: every pick below is served
+    // from cache, so the only signal the route was seen is the recorder.
+    let mut server = mockito::Server::new_async().await;
+    let mock = server.mock("GET", "/acme").with_status(500).expect(0).create_async().await;
+    let registry = format!("{}/", server.url());
+    let expected_url = to_registry_url(&registry, "acme");
+
+    // In-memory cache hit.
+    {
+        let recorder = Arc::new(RouteRecorder::default());
+        let auth_headers = AuthHeaders::default()
+            .with_route_hook(Arc::clone(&recorder) as Arc<dyn UpstreamRouteHook>);
+        let cache_dir = TempDir::new().expect("tempdir");
+        let http_client = ThrottledClient::default();
+        let meta_cache = InMemoryPackageMetaCache::default();
+        meta_cache.set(format!("{registry}\x00acme"), Arc::new(preloaded.clone()));
+        let fetch_locker = shared_packument_fetch_locker();
+        let ctx = PickPackageContext {
+            http_client: &http_client,
+            auth_headers: &auth_headers,
+            meta_cache: &meta_cache,
+            fetch_locker: &fetch_locker,
+            cache_dir: Some(cache_dir.path()),
+            offline: false,
+            prefer_offline: false,
+            ignore_missing_time_field: false,
+            full_metadata: false,
+            filter_metadata: false,
+            retry_opts: RetryOpts::default(),
+        };
+        pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
+            .await
+            .expect("ok");
+        let routes = recorder.routes.lock().expect("routes");
+        assert_eq!(routes.as_slice(), &[(expected_url.clone(), Some("acme".to_string()))]);
+    }
+
+    // Offline disk fast path.
+    {
+        let recorder = Arc::new(RouteRecorder::default());
+        let auth_headers = AuthHeaders::default()
+            .with_route_hook(Arc::clone(&recorder) as Arc<dyn UpstreamRouteHook>);
+        let cache_dir = TempDir::new().expect("tempdir");
+        persist_meta_to_mirror(cache_dir.path(), ABBREVIATED_META_DIR, &registry, &preloaded)
+            .expect("warm mirror");
+        let http_client = ThrottledClient::default();
+        let meta_cache = InMemoryPackageMetaCache::default();
+        let fetch_locker = shared_packument_fetch_locker();
+        let ctx = PickPackageContext {
+            http_client: &http_client,
+            auth_headers: &auth_headers,
+            meta_cache: &meta_cache,
+            fetch_locker: &fetch_locker,
+            cache_dir: Some(cache_dir.path()),
+            offline: true,
+            prefer_offline: false,
+            ignore_missing_time_field: false,
+            full_metadata: false,
+            filter_metadata: false,
+            retry_opts: RetryOpts::default(),
+        };
+        pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
+            .await
+            .expect("ok");
+        let routes = recorder.routes.lock().expect("routes");
+        assert_eq!(routes.as_slice(), &[(expected_url.clone(), Some("acme".to_string()))]);
+    }
+
+    // Version-spec disk fast path (no network, pinned version on disk).
+    {
+        let recorder = Arc::new(RouteRecorder::default());
+        let auth_headers = AuthHeaders::default()
+            .with_route_hook(Arc::clone(&recorder) as Arc<dyn UpstreamRouteHook>);
+        let cache_dir = TempDir::new().expect("tempdir");
+        persist_meta_to_mirror(cache_dir.path(), ABBREVIATED_META_DIR, &registry, &preloaded)
+            .expect("warm mirror");
+        let http_client = ThrottledClient::default();
+        let meta_cache = InMemoryPackageMetaCache::default();
+        let fetch_locker = shared_packument_fetch_locker();
+        let ctx = PickPackageContext {
+            http_client: &http_client,
+            auth_headers: &auth_headers,
+            meta_cache: &meta_cache,
+            fetch_locker: &fetch_locker,
+            cache_dir: Some(cache_dir.path()),
+            offline: false,
+            prefer_offline: false,
+            ignore_missing_time_field: false,
+            full_metadata: false,
+            filter_metadata: false,
+            retry_opts: RetryOpts::default(),
+        };
+        pick_package(&ctx, &version_spec("acme", "1.0.0"), &default_opts(&registry))
+            .await
+            .expect("ok");
+        let routes = recorder.routes.lock().expect("routes");
+        assert_eq!(routes.as_slice(), &[(expected_url.clone(), Some("acme".to_string()))]);
+    }
+
     mock.assert_async().await;
 }

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -1413,7 +1413,6 @@ fn pnpr_benchmark_config_yaml(pnpr_storage: &Path, public_route_registries: &[&s
             },
         },
         routes: PnprBenchmarkRoutes {
-            npmjs_public: true,
             public: public_route_registries
                 .iter()
                 .map(|registry| PnprBenchmarkPublicRoute { registry: (*registry).to_string() })
@@ -1459,7 +1458,6 @@ struct PnprBenchmarkHtpasswd {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PnprBenchmarkRoutes {
-    npmjs_public: bool,
     public: Vec<PnprBenchmarkPublicRoute>,
 }
 

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -507,6 +507,13 @@ impl WorkEnv {
         );
         let pnpr_storage = bench_dir.join("pnpr-storage");
         seed_pnpr_auth(&pnpr_storage);
+        let public_route_registries = if matches!(self.registry_mode, RegistryMode::Npm) {
+            Vec::new()
+        } else {
+            distinct_public_route_registries([self.registry.as_str(), pnpr_server_registry])
+        };
+        let pnpr_config =
+            write_pnpr_benchmark_config(&bench_dir, &pnpr_storage, &public_route_registries);
         let port = pick_unused_port().expect("pick an unused port for the pnpr server");
 
         eprintln!("Starting pnpr server for {id} on 127.0.0.1:{port}...");
@@ -515,6 +522,8 @@ impl WorkEnv {
         let stderr = File::create(bench_dir.join("pnpr-server.stderr.log"))
             .expect("create pnpr server stderr log");
         let process = Command::new(&binary)
+            .arg("--config")
+            .arg(&pnpr_config)
             .arg("--listen")
             .arg(format!("127.0.0.1:{port}"))
             .arg("--storage")
@@ -1380,6 +1389,90 @@ fn seed_pnpr_auth(pnpr_storage: &Path) {
     fs::create_dir_all(pnpr_storage).expect("create pnpr storage before seeding auth");
     fs::write(pnpr_storage.join("htpasswd"), PNPR_BENCHMARK_HTPASSWD)
         .expect("seed pnpr benchmark htpasswd");
+}
+
+fn write_pnpr_benchmark_config(
+    bench_dir: &Path,
+    pnpr_storage: &Path,
+    public_route_registries: &[&str],
+) -> PathBuf {
+    let path = bench_dir.join("pnpr-config.yaml");
+    let yaml = pnpr_benchmark_config_yaml(pnpr_storage, public_route_registries);
+    fs::write(&path, yaml).expect("write pnpr benchmark config");
+    path
+}
+
+fn pnpr_benchmark_config_yaml(pnpr_storage: &Path, public_route_registries: &[&str]) -> String {
+    let config = PnprBenchmarkConfig {
+        storage: pnpr_storage.display().to_string(),
+        secret: "pnpr-integrated-benchmark-secret",
+        auth: PnprBenchmarkAuth {
+            htpasswd: PnprBenchmarkHtpasswd {
+                file: pnpr_storage.join("htpasswd").display().to_string(),
+                max_users: -1,
+            },
+        },
+        routes: PnprBenchmarkRoutes {
+            npmjs_unscoped_public: true,
+            public: public_route_registries
+                .iter()
+                .map(|registry| PnprBenchmarkPublicRoute { registry: (*registry).to_string() })
+                .collect(),
+        },
+        log: PnprBenchmarkLog { r#type: "stdout", format: "pretty", level: "error" },
+    };
+    serde_saphyr::to_string(&config).expect("serialize pnpr benchmark config")
+}
+
+fn distinct_public_route_registries<const REGISTRY_COUNT: usize>(
+    registries: [&str; REGISTRY_COUNT],
+) -> Vec<&str> {
+    let mut distinct = Vec::with_capacity(registries.len());
+    for registry in registries {
+        if !distinct.contains(&registry) {
+            distinct.push(registry);
+        }
+    }
+    distinct
+}
+
+#[derive(Serialize)]
+struct PnprBenchmarkConfig {
+    storage: String,
+    secret: &'static str,
+    auth: PnprBenchmarkAuth,
+    routes: PnprBenchmarkRoutes,
+    log: PnprBenchmarkLog,
+}
+
+#[derive(Serialize)]
+struct PnprBenchmarkAuth {
+    htpasswd: PnprBenchmarkHtpasswd,
+}
+
+#[derive(Serialize)]
+struct PnprBenchmarkHtpasswd {
+    file: String,
+    max_users: i64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PnprBenchmarkRoutes {
+    npmjs_unscoped_public: bool,
+    public: Vec<PnprBenchmarkPublicRoute>,
+}
+
+#[derive(Serialize)]
+struct PnprBenchmarkPublicRoute {
+    registry: String,
+}
+
+#[derive(Serialize)]
+struct PnprBenchmarkLog {
+    r#type: &'static str,
+    format: &'static str,
+    level: &'static str,
 }
 
 fn append_pnpr_auth_to_npmrc(dir: &Path, pnpr_server: &str, token: &str) {

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -1413,7 +1413,7 @@ fn pnpr_benchmark_config_yaml(pnpr_storage: &Path, public_route_registries: &[&s
             },
         },
         routes: PnprBenchmarkRoutes {
-            npmjs_unscoped_public: true,
+            npmjs_public: true,
             public: public_route_registries
                 .iter()
                 .map(|registry| PnprBenchmarkPublicRoute { registry: (*registry).to_string() })
@@ -1459,7 +1459,7 @@ struct PnprBenchmarkHtpasswd {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PnprBenchmarkRoutes {
-    npmjs_unscoped_public: bool,
+    npmjs_public: bool,
     public: Vec<PnprBenchmarkPublicRoute>,
 }
 

--- a/pacquet/tasks/integrated-benchmark/src/work_env/tests.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env/tests.rs
@@ -153,7 +153,7 @@ fn pnpr_benchmark_config_declares_local_registry_public() {
 
     assert!(yaml.contains("registry: http://localhost:4873/"));
     assert!(yaml.contains("registry: http://127.0.0.1:61824/"));
-    assert!(yaml.contains("npmjsUnscopedPublic: true"));
+    assert!(yaml.contains("npmjsPublic: true"));
     assert!(yaml.contains("max_users: -1"));
     assert!(yaml.contains("htpasswd"));
 }
@@ -164,7 +164,7 @@ fn pnpr_benchmark_config_keeps_npm_mode_on_builtin_public_rule() {
 
     let yaml = pnpr_benchmark_config_yaml(&storage, &[]);
 
-    assert!(yaml.contains("npmjsUnscopedPublic: true"));
+    assert!(yaml.contains("npmjsPublic: true"));
     assert!(yaml.contains("public: []"));
     assert!(!yaml.contains("registry: https://registry.npmjs.org/"));
 }

--- a/pacquet/tasks/integrated-benchmark/src/work_env/tests.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     BenchmarkScenario, HyperfineCommand, PhaseEvent, collect_pnpr_direct_ratios,
-    non_trivial_cold_batch, pnpr_auth_config_key, read_phase_events, render_diagnostics_markdown,
-    requires_fresh_pnpr_cold_batch_metrics, summarize_phase_events,
+    non_trivial_cold_batch, pnpr_auth_config_key, pnpr_benchmark_config_yaml, read_phase_events,
+    render_diagnostics_markdown, requires_fresh_pnpr_cold_batch_metrics, summarize_phase_events,
 };
 use std::{collections::HashMap, fs};
 
@@ -140,6 +140,33 @@ fn cold_batch_metrics_canary_targets_current_pnpr_revision() {
 fn pnpr_auth_config_key_uses_npmrc_nerf_shape() {
     assert_eq!(pnpr_auth_config_key("http://127.0.0.1:42509"), "//127.0.0.1:42509/");
     assert_eq!(pnpr_auth_config_key("http://localhost:4873/pnpr/"), "//localhost:4873/pnpr/");
+}
+
+#[test]
+fn pnpr_benchmark_config_declares_local_registry_public() {
+    let storage = std::env::temp_dir().join("pnpr-benchmark-config-test-storage");
+
+    let yaml = pnpr_benchmark_config_yaml(
+        &storage,
+        &["http://localhost:4873/", "http://127.0.0.1:61824/"],
+    );
+
+    assert!(yaml.contains("registry: http://localhost:4873/"));
+    assert!(yaml.contains("registry: http://127.0.0.1:61824/"));
+    assert!(yaml.contains("npmjsUnscopedPublic: true"));
+    assert!(yaml.contains("max_users: -1"));
+    assert!(yaml.contains("htpasswd"));
+}
+
+#[test]
+fn pnpr_benchmark_config_keeps_npm_mode_on_builtin_public_rule() {
+    let storage = std::env::temp_dir().join("pnpr-benchmark-config-test-storage");
+
+    let yaml = pnpr_benchmark_config_yaml(&storage, &[]);
+
+    assert!(yaml.contains("npmjsUnscopedPublic: true"));
+    assert!(yaml.contains("public: []"));
+    assert!(!yaml.contains("registry: https://registry.npmjs.org/"));
 }
 
 #[test]

--- a/pacquet/tasks/integrated-benchmark/src/work_env/tests.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env/tests.rs
@@ -153,18 +153,18 @@ fn pnpr_benchmark_config_declares_local_registry_public() {
 
     assert!(yaml.contains("registry: http://localhost:4873/"));
     assert!(yaml.contains("registry: http://127.0.0.1:61824/"));
-    assert!(yaml.contains("npmjsPublic: true"));
     assert!(yaml.contains("max_users: -1"));
     assert!(yaml.contains("htpasswd"));
 }
 
 #[test]
-fn pnpr_benchmark_config_keeps_npm_mode_on_builtin_public_rule() {
+fn pnpr_benchmark_config_relies_on_the_builtin_npm_route() {
     let storage = std::env::temp_dir().join("pnpr-benchmark-config-test-storage");
 
     let yaml = pnpr_benchmark_config_yaml(&storage, &[]);
 
-    assert!(yaml.contains("npmjsPublic: true"));
+    // No operator-declared public routes: npmjs resolution comes from the
+    // built-in route, so the config never spells out an npmjs registry rule.
     assert!(yaml.contains("public: []"));
     assert!(!yaml.contains("registry: https://registry.npmjs.org/"));
 }

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -2621,13 +2621,12 @@ async function installViaPnprServer (
     )
   }
   const { resolveViaPnprServer } = await import('@pnpm/pnpr.client')
-  const { createGetAuthHeaderByURI, getAuthHeadersByScope, getAuthHeadersFromCreds } = await import('@pnpm/network.auth-header')
+  const { createGetAuthHeaderByURI } = await import('@pnpm/network.auth-header')
 
-  // Forward the whole credential map (the registries a graph touches
-  // aren't known up front), so the server attaches the right token per
-  // URL. `authorization` also identifies the caller to pnpr's gate.
+  // Identify the caller to pnpr's gate. The client does not forward its
+  // upstream registry credentials: pnpr selects upstream credentials from
+  // its own route policy, so they never travel in the request body.
   const configByUri = opts.configByUri ?? {}
-  const forwardedAuthHeaders = getAuthHeadersFromCreds(configByUri)
   const pnprAuthorization = createGetAuthHeaderByURI(configByUri)(opts.pnprServer!)
 
   try {
@@ -2663,7 +2662,6 @@ async function installViaPnprServer (
       projects: projectsList,
       registry: opts.registries?.default,
       namedRegistries: opts.namedRegistries,
-      authHeaders: getAuthHeadersByScope(forwardedAuthHeaders),
       authorization: pnprAuthorization,
       overrides: opts.overrides,
       minimumReleaseAge: opts.minimumReleaseAge,

--- a/pnpr/client/src/resolveViaPnprServer.ts
+++ b/pnpr/client/src/resolveViaPnprServer.ts
@@ -8,8 +8,6 @@ import type { LockfileFile, LockfileObject } from '@pnpm/lockfile.types'
 
 import type { ResponseMetadata } from './protocol.js'
 
-export type AuthHeadersByScope = Record<string, Record<string, string>>
-
 export interface PnprProject {
   /** Relative dir within the workspace (e.g. "." or "packages/foo") */
   dir: string
@@ -37,15 +35,10 @@ export interface ResolveViaPnprServerOptions {
   /** The client's named-registry aliases (`namedRegistries`). */
   namedRegistries?: Record<string, string>
   /**
-   * The caller's forwarded upstream credentials, keyed by nerf-darted
-   * registry URI and package scope, so the server resolves private
-   * content as the caller. The `@` scope stores registry-wide auth.
-   * Distinct from `authorization` (pnpr identity).
-   */
-  authHeaders?: AuthHeadersByScope
-  /**
    * `Authorization` for the pnpr server's own URL (`undefined` if none):
-   * identifies the caller to pnpr's gate.
+   * identifies the caller to pnpr's gate. The client never forwards its
+   * own upstream registry credentials — pnpr selects upstream credentials
+   * from its route policy, so none are placed in the request body.
    */
   authorization?: string
   /** Overrides */
@@ -105,7 +98,6 @@ export async function resolveViaPnprServer (
     projects,
     registry: opts.registry,
     namedRegistries: opts.namedRegistries,
-    authHeaders: opts.authHeaders,
     overrides: opts.overrides,
     nodeVersion: opts.nodeVersion ?? process.version.slice(1),
     os: process.platform,

--- a/pnpr/crates/pnpr/config.yaml
+++ b/pnpr/crates/pnpr/config.yaml
@@ -56,6 +56,14 @@ auth:
     # (registration disabled); set a non-negative cap to allow registration.
     max_users: -1
 
+# Optional static group/team memberships. Package policies and upstream
+# aliases can use these group names anywhere they already accept usernames.
+#groups:
+#  platform: alice bob
+#  release:
+#    - alice
+#    - carol
+
 plugins: ../node_modules
 
 middlewares:
@@ -66,6 +74,20 @@ middlewares:
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
+
+# Optional pnpr-owned upstream credentials for private resolver routes.
+# pnpr selects an alias only when the caller satisfies `access`, sends the
+# alias credential upstream, and uses `generation` as part of the private
+# cache namespace during rotations.
+#upstreamAliases:
+#  corp:
+#    registry: https://npm.corp.example/
+#    package: '@acme/*'
+#    access: platform
+#    generation: 1
+#    auth:
+#      type: bearer
+#      tokenEnv: PNPR_CORP_NPM_TOKEN
 
 web:
   enable: false

--- a/pnpr/crates/pnpr/config.yaml
+++ b/pnpr/crates/pnpr/config.yaml
@@ -75,19 +75,19 @@ uplinks:
   npmjs:
     url: https://registry.npmjs.org/
 
-# Optional pnpr-owned upstream credentials for private resolver routes.
-# pnpr selects an alias only when the caller satisfies `access`, sends the
-# alias credential upstream, and uses `generation` as part of the private
-# cache namespace during rotations.
-#upstreamAliases:
-#  corp:
-#    registry: https://npm.corp.example/
-#    package: '@acme/*'
-#    access: platform
-#    generation: 1
-#    auth:
-#      type: bearer
-#      tokenEnv: PNPR_CORP_NPM_TOKEN
+  # An uplink that declares `access:` becomes a pnpr-managed private-route
+  # credential, exposed as a registry endpoint at `/~<name>/` (here,
+  # `/~corp/`). pnpr selects it only when the caller satisfies `access`, sends
+  # its credential upstream, and uses `generation` as part of the private
+  # cache namespace during rotations. Point a scope at the endpoint to use it,
+  # e.g. `@acme:registry=https://<pnpr>/~corp/`.
+  #corp:
+  #  url: https://npm.corp.example/
+  #  access: platform
+  #  generation: 1
+  #  auth:
+  #    type: bearer
+  #    tokenEnv: PNPR_CORP_NPM_TOKEN
 
 web:
   enable: false

--- a/pnpr/crates/pnpr/config.yaml
+++ b/pnpr/crates/pnpr/config.yaml
@@ -77,14 +77,14 @@ uplinks:
 
   # An uplink that declares `access:` becomes a pnpr-managed private-route
   # credential, exposed as a registry endpoint at `/~<name>/` (here,
-  # `/~corp/`). pnpr selects it only when the caller satisfies `access`, sends
-  # its credential upstream, and uses `generation` as part of the private
-  # cache namespace during rotations. Point a scope at the endpoint to use it,
-  # e.g. `@acme:registry=https://<pnpr>/~corp/`.
+  # `/~corp/`). pnpr selects it only when the caller satisfies `access` and
+  # sends its credential upstream. The private cache is namespaced by a hash of
+  # that credential, so rotating it (editing `auth`) automatically moves to a
+  # fresh namespace — no manual epoch to bump. Point a scope at the endpoint to
+  # use it, e.g. `@acme:registry=https://<pnpr>/~corp/`.
   #corp:
   #  url: https://npm.corp.example/
   #  access: platform
-  #  generation: 1
   #  auth:
   #    type: bearer
   #    tokenEnv: PNPR_CORP_NPM_TOKEN

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -141,12 +141,13 @@ pub struct Config {
 /// Which fetch routes the resolution cache treats as public.
 #[derive(Debug, Clone)]
 pub struct RoutePolicy {
-    /// Treat unscoped packages on the official `registry.npmjs.org` as
-    /// public (the built-in route). `true` by default; operators can
-    /// disable it for a conservative deployment or if npm's policy
-    /// changes. Scoped npmjs packages are *not* covered — npm allows
-    /// private scoped packages — so they stay private unless an operator
-    /// declares the scope public via [`Self::public`].
+    /// Treat the official `registry.npmjs.org` host as public (the built-in
+    /// route), so packages resolved from it — scoped or unscoped — are
+    /// fetched anonymously and globally shareable. A *private* scoped npm
+    /// package 404s on the anonymous fetch, so it is never resolved this way;
+    /// a private npm dependency must be fronted by an uplink. `true` by
+    /// default; operators can disable it for a conservative deployment that
+    /// allowlists every registry explicitly, or if npm's policy changes.
     pub npmjs_public: bool,
     /// Operator-declared public routes, matched by registry prefix
     /// and/or package pattern.

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -138,26 +138,15 @@ pub struct Config {
     pub resolution_cache_secret: Arc<[u8]>,
 }
 
-/// Which fetch routes the resolution cache treats as public.
-#[derive(Debug, Clone)]
+/// Which fetch routes the resolution cache treats as public. The official
+/// `registry.npmjs.org` host is always a built-in public route (added by the
+/// route layer when it builds its classification context); these are the
+/// *additional* operator-declared ones.
+#[derive(Debug, Default, Clone)]
 pub struct RoutePolicy {
-    /// Treat the official `registry.npmjs.org` host as public (the built-in
-    /// route), so packages resolved from it — scoped or unscoped — are
-    /// fetched anonymously and globally shareable. A *private* scoped npm
-    /// package 404s on the anonymous fetch, so it is never resolved this way;
-    /// a private npm dependency must be fronted by an uplink. `true` by
-    /// default; operators can disable it for a conservative deployment that
-    /// allowlists every registry explicitly, or if npm's policy changes.
-    pub npmjs_public: bool,
     /// Operator-declared public routes, matched by registry prefix
     /// and/or package pattern.
     pub public: Vec<PublicRoute>,
-}
-
-impl Default for RoutePolicy {
-    fn default() -> Self {
-        Self { npmjs_public: true, public: Vec::new() }
-    }
 }
 
 /// One operator-declared public route. A fetch matches when its registry
@@ -879,8 +868,6 @@ impl AccessSpec {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RoutesFile {
-    #[serde(default = "default_true")]
-    npmjs_public: bool,
     #[serde(default)]
     public: Vec<PublicRouteFile>,
 }
@@ -1477,7 +1464,6 @@ fn build_route_policy(file: Option<RoutesFile>) -> RoutePolicy {
     match file {
         None => RoutePolicy::default(),
         Some(file) => RoutePolicy {
-            npmjs_public: file.npmjs_public,
             public: file
                 .public
                 .into_iter()

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -130,11 +130,6 @@ pub struct Config {
     /// anonymously and shared globally) vs. private, driving the
     /// resolver's route classification.
     pub route_policy: RoutePolicy,
-    /// pnpr-managed upstream credential aliases, keyed by name. A resolve
-    /// uses one of these for a private proxied route the caller is
-    /// authorized for, instead of forwarding the client's own upstream
-    /// credentials. See [`UpstreamAlias`].
-    pub upstream_aliases: IndexMap<String, UpstreamAlias>,
     /// Secret keying the HMAC that namespaces private resolution-cache
     /// entries, so the private key is not correlatable offline. Sourced
     /// from the YAML `secret:` key when present; otherwise a fresh
@@ -171,39 +166,6 @@ impl Default for RoutePolicy {
 pub struct PublicRoute {
     pub registry: Option<String>,
     pub package: Option<String>,
-}
-
-/// A pnpr-managed upstream credential alias: the upstream route it serves,
-/// the resolved `Authorization` header it sends, which pnpr callers may
-/// select it, and a rotation generation. The raw credential never reaches
-/// a cache key or a client — only the `name + generation` descriptor does.
-#[derive(Clone)]
-pub struct UpstreamAlias {
-    /// Upstream registry URL this alias serves (its origin is matched
-    /// against fetch URLs).
-    pub registry: String,
-    /// Optional package pattern restricting the alias to a scope/package.
-    pub package: Option<String>,
-    /// Fully-formed `Authorization` header value sent upstream
-    /// (`Bearer …` / `Basic …`).
-    pub authorization: String,
-    /// Which pnpr callers may select this alias.
-    pub access: AccessList,
-    /// Rotation generation; bumping it moves future private hits to a new
-    /// cache namespace so a rotated credential's old entries age out.
-    pub generation: u64,
-}
-
-impl fmt::Debug for UpstreamAlias {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("UpstreamAlias")
-            .field("registry", &self.registry)
-            .field("package", &self.package)
-            .field("authorization", &"<redacted>")
-            .field("access", &self.access)
-            .field("generation", &self.generation)
-            .finish()
-    }
 }
 
 /// Toggle for the npm-registry surface. A dedicated type — rather than a
@@ -930,23 +892,6 @@ struct PublicRouteFile {
     package: Option<String>,
 }
 
-/// Disk shape of one `upstreamAliases:` entry. The `auth:` block reuses
-/// the uplink credential shape (`type` + `token`/`tokenEnv`); `access`
-/// reuses the verdaccio permission-list shape.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct UpstreamAliasFile {
-    registry: String,
-    #[serde(default)]
-    package: Option<String>,
-    #[serde(default)]
-    auth: Option<UplinkAuthFile>,
-    #[serde(default)]
-    access: Option<AccessSpec>,
-    #[serde(default = "default_generation")]
-    generation: u64,
-}
-
 fn default_generation() -> u64 {
     1
 }
@@ -1000,9 +945,6 @@ struct ConfigFile {
     /// apply).
     #[serde(default)]
     routes: Option<RoutesFile>,
-    /// pnpr-only: upstream credential aliases for private proxied routes.
-    #[serde(default, rename = "upstreamAliases")]
-    upstream_aliases: IndexMap<String, UpstreamAliasFile>,
     /// Verdaccio's `secret:` — reused here to key the private
     /// resolution-cache HMAC. A random per-process secret is used when
     /// absent.
@@ -1158,7 +1100,6 @@ impl Config {
             registry: RegistryFeature::default(),
             resolver: ResolverFeature::default(),
             route_policy: RoutePolicy::default(),
-            upstream_aliases: IndexMap::new(),
             resolution_cache_secret: random_secret(),
         }
     }
@@ -1185,7 +1126,6 @@ impl Config {
             registry: RegistryFeature::default(),
             resolver: ResolverFeature::default(),
             route_policy: RoutePolicy::default(),
-            upstream_aliases: IndexMap::new(),
             resolution_cache_secret: random_secret(),
         }
     }
@@ -1423,14 +1363,6 @@ impl Config {
             IndexMap::new()
         };
         let route_policy = build_route_policy(file.routes);
-        // Aliases carry upstream secrets and are consulted only by the
-        // resolver surface; skip their (strict) credential resolution when
-        // the resolver is disabled, mirroring the uplink gating above.
-        let upstream_aliases = if resolver.enabled {
-            build_upstream_aliases(file.upstream_aliases)?
-        } else {
-            IndexMap::new()
-        };
         let resolution_cache_secret = resolution_secret(file.secret.as_deref());
         let config = Self {
             listen,
@@ -1450,7 +1382,6 @@ impl Config {
             registry,
             resolver,
             route_policy,
-            upstream_aliases,
             resolution_cache_secret,
         };
         config.ensure_a_feature_is_enabled()?;
@@ -1563,61 +1494,6 @@ fn build_groups(file: &IndexMap<String, AccessSpec>) -> AccessGroups {
         }
     }
     groups
-}
-
-/// Compile each `upstreamAliases:` entry into a runtime [`UpstreamAlias`],
-/// resolving its credential the same way uplinks do. A missing or
-/// unresolvable `auth:` block is a config error rather than a silent
-/// unauthenticated alias.
-fn build_upstream_aliases(
-    files: IndexMap<String, UpstreamAliasFile>,
-) -> Result<IndexMap<String, UpstreamAlias>, RegistryError> {
-    files
-        .into_iter()
-        .map(|(name, file)| {
-            let authorization =
-                resolve_alias_authorization::<SystemEnv>(&name, file.auth.as_ref())?;
-            let access = file
-                .access
-                .as_ref()
-                .map_or_else(|| AccessList::parse("$authenticated"), AccessSpec::to_access_list);
-            let alias = UpstreamAlias {
-                registry: file.registry,
-                package: file.package,
-                authorization,
-                access,
-                generation: file.generation,
-            };
-            Ok((name, alias))
-        })
-        .collect()
-}
-
-/// Resolve an alias's `auth:` block into the `Authorization` header value
-/// it sends upstream. Reuses the uplink token resolution and
-/// bearer/basic encoding, and validates the result is a usable header
-/// value so a bad credential fails at config load, not mid-resolve.
-fn resolve_alias_authorization<Sys: EnvVar>(
-    name: &str,
-    auth: Option<&UplinkAuthFile>,
-) -> Result<String, RegistryError> {
-    let auth = auth.ok_or_else(|| RegistryError::InvalidConfig {
-        reason: format!("upstream alias {name:?} requires an auth block with a token"),
-    })?;
-    let token = resolve_uplink_token::<Sys>(auth).ok_or_else(|| RegistryError::InvalidConfig {
-        reason: format!(
-            "upstream alias {name:?} has an auth block but no token could be resolved \
-             (set auth.token or point auth.tokenEnv at a set env var)",
-        ),
-    })?;
-    let value = match auth.r#type {
-        UplinkAuthType::Bearer => format!("Bearer {token}"),
-        UplinkAuthType::Basic => format!("Basic {token}"),
-    };
-    HeaderValue::from_str(&value).map_err(|_| RegistryError::InvalidConfig {
-        reason: format!("upstream alias {name:?} auth token is not a valid header value"),
-    })?;
-    Ok(value)
 }
 
 /// The HMAC secret keying private resolution-cache entries: the YAML

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -147,7 +147,7 @@ pub struct RoutePolicy {
     /// changes. Scoped npmjs packages are *not* covered — npm allows
     /// private scoped packages — so they stay private unless an operator
     /// declares the scope public via [`Self::public`].
-    pub npmjs_unscoped_public: bool,
+    pub npmjs_public: bool,
     /// Operator-declared public routes, matched by registry prefix
     /// and/or package pattern.
     pub public: Vec<PublicRoute>,
@@ -155,7 +155,7 @@ pub struct RoutePolicy {
 
 impl Default for RoutePolicy {
     fn default() -> Self {
-        Self { npmjs_unscoped_public: true, public: Vec::new() }
+        Self { npmjs_public: true, public: Vec::new() }
     }
 }
 
@@ -879,7 +879,7 @@ impl AccessSpec {
 #[serde(rename_all = "camelCase")]
 struct RoutesFile {
     #[serde(default = "default_true")]
-    npmjs_unscoped_public: bool,
+    npmjs_public: bool,
     #[serde(default)]
     public: Vec<PublicRouteFile>,
 }
@@ -1476,7 +1476,7 @@ fn build_route_policy(file: Option<RoutesFile>) -> RoutePolicy {
     match file {
         None => RoutePolicy::default(),
         Some(file) => RoutePolicy {
-            npmjs_unscoped_public: file.npmjs_unscoped_public,
+            npmjs_public: file.npmjs_public,
             public: file
                 .public
                 .into_iter()

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -124,8 +124,8 @@ pub struct Config {
     /// resolution. See [`ResolverFeature`].
     pub resolver: ResolverFeature,
     /// Which fetch routes the resolution cache treats as public (fetched
-    /// anonymously and shared globally) vs. private. See
-    /// [`crate::route`].
+    /// anonymously and shared globally) vs. private, driving the
+    /// resolver's route classification.
     pub route_policy: RoutePolicy,
     /// pnpr-managed upstream credential aliases, keyed by name. A resolve
     /// uses one of these for a private proxied route the caller is

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -530,6 +530,16 @@ pub struct UplinkConfig {
     /// mirror (verdaccio's `cache`). `false` streams them through
     /// uncached. Defaults to `true`.
     pub cache: bool,
+    /// Which pnpr callers may select this uplink as a proxied private-route
+    /// credential, and reach it through its `/~<name>/` registry endpoint.
+    /// `None` means the uplink is registry-proxy only and is never offered as
+    /// a resolver private-route credential — only uplinks that declare
+    /// `access:` participate in route classification.
+    pub access: Option<AccessList>,
+    /// Rotation generation for the uplink credential; bumping it moves future
+    /// private cache hits to a new namespace. Server-side only — never
+    /// embedded in a client-visible URL.
+    pub generation: u64,
 }
 
 impl UplinkConfig {
@@ -552,6 +562,8 @@ impl UplinkConfig {
             max_fails: Self::DEFAULT_MAX_FAILS,
             fail_timeout: Self::DEFAULT_FAIL_TIMEOUT,
             cache: true,
+            access: None,
+            generation: default_generation(),
         }
     }
 }
@@ -566,6 +578,8 @@ impl fmt::Debug for UplinkConfig {
             .field("max_fails", &self.max_fails)
             .field("fail_timeout", &self.fail_timeout)
             .field("cache", &self.cache)
+            .field("access", &self.access)
+            .field("generation", &self.generation)
             .finish()
     }
 }
@@ -607,6 +621,13 @@ struct UplinkFile {
     fail_timeout: Option<Interval>,
     #[serde(default)]
     cache: Option<bool>,
+    /// Which pnpr callers may select this uplink as a proxied private-route
+    /// credential. Its presence is what promotes a plain proxy uplink into a
+    /// resolver private-route credential exposed at `/~<name>/`.
+    #[serde(default)]
+    access: Option<AccessSpec>,
+    #[serde(default = "default_generation")]
+    generation: u64,
 }
 
 /// A verdaccio interval scalar as written in YAML: either a string
@@ -765,6 +786,8 @@ fn resolve_uplink<Sys: EnvVar>(
         max_fails: file.max_fails.unwrap_or(UplinkConfig::DEFAULT_MAX_FAILS),
         fail_timeout,
         cache: file.cache.unwrap_or(true),
+        access: file.access.as_ref().map(AccessSpec::to_access_list),
+        generation: file.generation,
     })
 }
 

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1363,7 +1363,7 @@ impl Config {
             IndexMap::new()
         };
         let route_policy = build_route_policy(file.routes);
-        let resolution_cache_secret = resolution_secret(file.secret.as_deref());
+        let resolution_cache_secret = resolution_secret(file.secret.as_deref())?;
         let config = Self {
             listen,
             public_url,
@@ -1496,12 +1496,29 @@ fn build_groups(file: &IndexMap<String, AccessSpec>) -> AccessGroups {
     groups
 }
 
+/// Minimum length for an operator-configured `secret:`. A shorter value makes
+/// the private-cache descriptor HMAC guessable, defeating its "not
+/// correlatable offline" property; a generated secret is 32 bytes.
+const MIN_RESOLUTION_SECRET_LEN: usize = 16;
+
 /// The HMAC secret keying private resolution-cache entries: the YAML
-/// `secret:` when set, else a fresh per-process value.
-fn resolution_secret(secret: Option<&str>) -> Arc<[u8]> {
+/// `secret:` when set (rejected if too short to be a safe HMAC key), else a
+/// fresh per-process value.
+fn resolution_secret(secret: Option<&str>) -> Result<Arc<[u8]>, RegistryError> {
     match secret {
-        Some(secret) if !secret.is_empty() => Arc::from(secret.as_bytes().to_vec()),
-        _ => random_secret(),
+        Some(secret) if !secret.is_empty() => {
+            if secret.len() < MIN_RESOLUTION_SECRET_LEN {
+                return Err(RegistryError::InvalidConfig {
+                    reason: format!(
+                        "`secret:` must be at least {MIN_RESOLUTION_SECRET_LEN} bytes to key the \
+                         private resolution-cache HMAC (it is {})",
+                        secret.len(),
+                    ),
+                });
+            }
+            Ok(Arc::from(secret.as_bytes().to_vec()))
+        }
+        _ => Ok(random_secret()),
     }
 }
 

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -488,10 +488,6 @@ pub struct UplinkConfig {
     /// a resolver private-route credential — only uplinks that declare
     /// `access:` participate in route classification.
     pub access: Option<AccessList>,
-    /// Rotation generation for the uplink credential; bumping it moves future
-    /// private cache hits to a new namespace. Server-side only — never
-    /// embedded in a client-visible URL.
-    pub generation: u64,
 }
 
 impl UplinkConfig {
@@ -515,7 +511,6 @@ impl UplinkConfig {
             fail_timeout: Self::DEFAULT_FAIL_TIMEOUT,
             cache: true,
             access: None,
-            generation: default_generation(),
         }
     }
 }
@@ -531,7 +526,6 @@ impl fmt::Debug for UplinkConfig {
             .field("fail_timeout", &self.fail_timeout)
             .field("cache", &self.cache)
             .field("access", &self.access)
-            .field("generation", &self.generation)
             .finish()
     }
 }
@@ -578,8 +572,6 @@ struct UplinkFile {
     /// resolver private-route credential exposed at `/~<name>/`.
     #[serde(default)]
     access: Option<AccessSpec>,
-    #[serde(default = "default_generation")]
-    generation: u64,
 }
 
 /// A verdaccio interval scalar as written in YAML: either a string
@@ -739,7 +731,6 @@ fn resolve_uplink<Sys: EnvVar>(
         fail_timeout,
         cache: file.cache.unwrap_or(true),
         access: file.access.as_ref().map(AccessSpec::to_access_list),
-        generation: file.generation,
     })
 }
 
@@ -878,10 +869,6 @@ struct PublicRouteFile {
     registry: Option<String>,
     #[serde(default)]
     package: Option<String>,
-}
-
-fn default_generation() -> u64 {
-    1
 }
 
 /// Disk shape of the YAML file. Fields verdaccio supports but

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -123,6 +123,84 @@ pub struct Config {
     /// default; disable it to run a plain registry with no server-side
     /// resolution. See [`ResolverFeature`].
     pub resolver: ResolverFeature,
+    /// Which fetch routes the resolution cache treats as public (fetched
+    /// anonymously and shared globally) vs. private. See
+    /// [`crate::route`].
+    pub route_policy: RoutePolicy,
+    /// pnpr-managed upstream credential aliases, keyed by name. A resolve
+    /// uses one of these for a private proxied route the caller is
+    /// authorized for, instead of forwarding the client's own upstream
+    /// credentials. See [`UpstreamAlias`].
+    pub upstream_aliases: IndexMap<String, UpstreamAlias>,
+    /// Secret keying the HMAC that namespaces private resolution-cache
+    /// entries, so the private key is not correlatable offline. Sourced
+    /// from the YAML `secret:` key when present; otherwise a fresh
+    /// 32-byte value from the OS CSPRNG at startup (private entries then
+    /// live only for this process's lifetime).
+    pub resolution_cache_secret: Arc<[u8]>,
+}
+
+/// Which fetch routes the resolution cache treats as public.
+#[derive(Debug, Clone)]
+pub struct RoutePolicy {
+    /// Treat unscoped packages on the official `registry.npmjs.org` as
+    /// public (the built-in route). `true` by default; operators can
+    /// disable it for a conservative deployment or if npm's policy
+    /// changes. Scoped npmjs packages are *not* covered — npm allows
+    /// private scoped packages — so they stay private unless an operator
+    /// declares the scope public via [`Self::public`].
+    pub npmjs_unscoped_public: bool,
+    /// Operator-declared public routes, matched by registry prefix
+    /// and/or package pattern.
+    pub public: Vec<PublicRoute>,
+}
+
+impl Default for RoutePolicy {
+    fn default() -> Self {
+        Self { npmjs_unscoped_public: true, public: Vec::new() }
+    }
+}
+
+/// One operator-declared public route. A fetch matches when its registry
+/// URL is under `registry` (when set) and its package name matches
+/// `package` (when set); an all-`None` rule matches every fetch.
+#[derive(Debug, Clone)]
+pub struct PublicRoute {
+    pub registry: Option<String>,
+    pub package: Option<String>,
+}
+
+/// A pnpr-managed upstream credential alias: the upstream route it serves,
+/// the resolved `Authorization` header it sends, which pnpr callers may
+/// select it, and a rotation generation. The raw credential never reaches
+/// a cache key or a client — only the `name + generation` descriptor does.
+#[derive(Clone)]
+pub struct UpstreamAlias {
+    /// Upstream registry URL this alias serves (its origin is matched
+    /// against fetch URLs).
+    pub registry: String,
+    /// Optional package pattern restricting the alias to a scope/package.
+    pub package: Option<String>,
+    /// Fully-formed `Authorization` header value sent upstream
+    /// (`Bearer …` / `Basic …`).
+    pub authorization: String,
+    /// Which pnpr callers may select this alias.
+    pub access: AccessList,
+    /// Rotation generation; bumping it moves future private hits to a new
+    /// cache namespace so a rotated credential's old entries age out.
+    pub generation: u64,
+}
+
+impl fmt::Debug for UpstreamAlias {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UpstreamAlias")
+            .field("registry", &self.registry)
+            .field("package", &self.package)
+            .field("authorization", &"<redacted>")
+            .field("access", &self.access)
+            .field("generation", &self.generation)
+            .finish()
+    }
 }
 
 /// Toggle for the npm-registry surface. A dedicated type — rather than a
@@ -808,6 +886,45 @@ impl AccessSpec {
     }
 }
 
+/// Disk shape of the `routes:` block.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RoutesFile {
+    #[serde(default = "default_true")]
+    npmjs_unscoped_public: bool,
+    #[serde(default)]
+    public: Vec<PublicRouteFile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PublicRouteFile {
+    #[serde(default)]
+    registry: Option<String>,
+    #[serde(default)]
+    package: Option<String>,
+}
+
+/// Disk shape of one `upstreamAliases:` entry. The `auth:` block reuses
+/// the uplink credential shape (`type` + `token`/`tokenEnv`); `access`
+/// reuses the verdaccio permission-list shape.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UpstreamAliasFile {
+    registry: String,
+    #[serde(default)]
+    package: Option<String>,
+    #[serde(default)]
+    auth: Option<UplinkAuthFile>,
+    #[serde(default)]
+    access: Option<AccessSpec>,
+    #[serde(default = "default_generation")]
+    generation: u64,
+}
+
+fn default_generation() -> u64 {
+    1
+}
+
 /// Disk shape of the YAML file. Fields verdaccio supports but
 /// pnpr doesn't (`auth`, `web`, `plugins`, `middlewares`,
 /// `logs`, `secret`) are accepted and silently dropped via
@@ -848,6 +965,19 @@ struct ConfigFile {
     uplinks: IndexMap<String, UplinkFile>,
     #[serde(default)]
     packages: IndexMap<String, PackageAccess>,
+    /// pnpr-only: which fetch routes the resolution cache treats as
+    /// public. Absent on a stock verdaccio config (built-in defaults
+    /// apply).
+    #[serde(default)]
+    routes: Option<RoutesFile>,
+    /// pnpr-only: upstream credential aliases for private proxied routes.
+    #[serde(default, rename = "upstreamAliases")]
+    upstream_aliases: IndexMap<String, UpstreamAliasFile>,
+    /// Verdaccio's `secret:` — reused here to key the private
+    /// resolution-cache HMAC. A random per-process secret is used when
+    /// absent.
+    #[serde(default)]
+    secret: Option<String>,
     #[serde(default)]
     auth: AuthFile,
     /// Verdaccio 6+ shape: `log:` is a single object at the top
@@ -996,6 +1126,9 @@ impl Config {
             osv: OsvConfig::default(),
             registry: RegistryFeature::default(),
             resolver: ResolverFeature::default(),
+            route_policy: RoutePolicy::default(),
+            upstream_aliases: IndexMap::new(),
+            resolution_cache_secret: random_secret(),
         }
     }
 
@@ -1019,6 +1152,9 @@ impl Config {
             osv: OsvConfig::default(),
             registry: RegistryFeature::default(),
             resolver: ResolverFeature::default(),
+            route_policy: RoutePolicy::default(),
+            upstream_aliases: IndexMap::new(),
+            resolution_cache_secret: random_secret(),
         }
     }
 
@@ -1253,6 +1389,16 @@ impl Config {
         } else {
             IndexMap::new()
         };
+        let route_policy = build_route_policy(file.routes);
+        // Aliases carry upstream secrets and are consulted only by the
+        // resolver surface; skip their (strict) credential resolution when
+        // the resolver is disabled, mirroring the uplink gating above.
+        let upstream_aliases = if resolver.enabled {
+            build_upstream_aliases(file.upstream_aliases)?
+        } else {
+            IndexMap::new()
+        };
+        let resolution_cache_secret = resolution_secret(file.secret.as_deref());
         let config = Self {
             listen,
             public_url,
@@ -1269,6 +1415,9 @@ impl Config {
             osv,
             registry,
             resolver,
+            route_policy,
+            upstream_aliases,
+            resolution_cache_secret,
         };
         config.ensure_a_feature_is_enabled()?;
         Ok(config)
@@ -1349,6 +1498,92 @@ fn build_auth_config(file: &AuthFile, base_dir: &Path) -> AuthConfig {
         },
         tokens: TokensConfig { file: tokens_file },
     }
+}
+
+fn build_route_policy(file: Option<RoutesFile>) -> RoutePolicy {
+    match file {
+        None => RoutePolicy::default(),
+        Some(file) => RoutePolicy {
+            npmjs_unscoped_public: file.npmjs_unscoped_public,
+            public: file
+                .public
+                .into_iter()
+                .map(|route| PublicRoute { registry: route.registry, package: route.package })
+                .collect(),
+        },
+    }
+}
+
+/// Compile each `upstreamAliases:` entry into a runtime [`UpstreamAlias`],
+/// resolving its credential the same way uplinks do. A missing or
+/// unresolvable `auth:` block is a config error rather than a silent
+/// unauthenticated alias.
+fn build_upstream_aliases(
+    files: IndexMap<String, UpstreamAliasFile>,
+) -> Result<IndexMap<String, UpstreamAlias>, RegistryError> {
+    files
+        .into_iter()
+        .map(|(name, file)| {
+            let authorization =
+                resolve_alias_authorization::<SystemEnv>(&name, file.auth.as_ref())?;
+            let access = file
+                .access
+                .as_ref()
+                .map_or_else(|| AccessList::parse("$authenticated"), AccessSpec::to_access_list);
+            let alias = UpstreamAlias {
+                registry: file.registry,
+                package: file.package,
+                authorization,
+                access,
+                generation: file.generation,
+            };
+            Ok((name, alias))
+        })
+        .collect()
+}
+
+/// Resolve an alias's `auth:` block into the `Authorization` header value
+/// it sends upstream. Reuses the uplink token resolution and
+/// bearer/basic encoding, and validates the result is a usable header
+/// value so a bad credential fails at config load, not mid-resolve.
+fn resolve_alias_authorization<Sys: EnvVar>(
+    name: &str,
+    auth: Option<&UplinkAuthFile>,
+) -> Result<String, RegistryError> {
+    let auth = auth.ok_or_else(|| RegistryError::InvalidConfig {
+        reason: format!("upstream alias {name:?} requires an auth block with a token"),
+    })?;
+    let token = resolve_uplink_token::<Sys>(auth).ok_or_else(|| RegistryError::InvalidConfig {
+        reason: format!(
+            "upstream alias {name:?} has an auth block but no token could be resolved \
+             (set auth.token or point auth.tokenEnv at a set env var)",
+        ),
+    })?;
+    let value = match auth.r#type {
+        UplinkAuthType::Bearer => format!("Bearer {token}"),
+        UplinkAuthType::Basic => format!("Basic {token}"),
+    };
+    HeaderValue::from_str(&value).map_err(|_| RegistryError::InvalidConfig {
+        reason: format!("upstream alias {name:?} auth token is not a valid header value"),
+    })?;
+    Ok(value)
+}
+
+/// The HMAC secret keying private resolution-cache entries: the YAML
+/// `secret:` when set, else a fresh per-process value.
+fn resolution_secret(secret: Option<&str>) -> Arc<[u8]> {
+    match secret {
+        Some(secret) if !secret.is_empty() => Arc::from(secret.as_bytes().to_vec()),
+        _ => random_secret(),
+    }
+}
+
+/// 32 bytes from the OS CSPRNG, for a deployment that configures no
+/// `secret:`. Private cache entries then live only for this process.
+fn random_secret() -> Arc<[u8]> {
+    let mut bytes = [0u8; 32];
+    getrandom::fill(&mut bytes).expect("OS CSPRNG must be available");
+    Arc::from(bytes.to_vec())
 }
 
 fn build_osv_config(file: &OsvFile, base_dir: &Path) -> OsvConfig {

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::RegistryError,
-    policy::{AccessList, PackagePolicies, PackagePolicy},
+    policy::{AccessGroups, AccessList, Identity, PackagePolicies, PackagePolicy},
     s3::{S3Settings, build_s3_store},
 };
 use indexmap::IndexMap;
@@ -78,6 +78,9 @@ pub struct Config {
     /// uplink (via `proxy`). Patterns without a `proxy` make the
     /// package storage-only (effectively static for that pattern).
     pub packages: IndexMap<String, PackageAccess>,
+    /// Optional static group memberships used by named access tokens in
+    /// package policies and upstream aliases.
+    pub groups: AccessGroups,
     /// How long a cached packument is considered fresh before it is
     /// re-fetched from the resolved uplink. Ignored when no uplink
     /// matches.
@@ -965,6 +968,10 @@ struct ConfigFile {
     uplinks: IndexMap<String, UplinkFile>,
     #[serde(default)]
     packages: IndexMap<String, PackageAccess>,
+    /// pnpr-only static groups: each key is a group/team name and each
+    /// value is the list of pnpr usernames in that group.
+    #[serde(default)]
+    groups: IndexMap<String, AccessSpec>,
     /// pnpr-only: which fetch routes the resolution cache treats as
     /// public. Absent on a stock verdaccio config (built-in defaults
     /// apply).
@@ -1117,6 +1124,7 @@ impl Config {
             storage,
             uplinks,
             packages,
+            groups: AccessGroups::default(),
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
             policies: PackagePolicies::registry_mock_defaults(),
             auth: AuthConfig::default(),
@@ -1143,6 +1151,7 @@ impl Config {
             storage,
             uplinks: IndexMap::new(),
             packages: IndexMap::new(),
+            groups: AccessGroups::default(),
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
             policies: PackagePolicies::registry_mock_defaults(),
             auth: AuthConfig::default(),
@@ -1360,6 +1369,7 @@ impl Config {
         let public_url = public_url.unwrap_or_else(|| format!("http://{listen}"));
         let auth = build_auth_config(&file.auth, base_dir);
         let logs = build_log_config(file.log.as_ref());
+        let groups = build_groups(&file.groups);
         let policies = build_policies(&file.packages)?;
         let osv = build_osv_config(&file.osv, base_dir);
         // Effective enablement folds the CLI overrides in here, so the
@@ -1406,6 +1416,7 @@ impl Config {
             cache_storage,
             uplinks,
             packages: file.packages,
+            groups,
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
             policies,
             auth,
@@ -1474,6 +1485,13 @@ impl Config {
     pub fn resolve_uplink(&self, package_name: &str) -> Option<(&str, &UplinkConfig)> {
         self.resolve_uplinks(package_name).into_iter().next()
     }
+
+    /// Build the caller identity used by access policies after a bearer
+    /// token has authenticated `username`.
+    #[must_use]
+    pub fn identity_for_user(&self, username: impl Into<String>) -> Identity {
+        self.groups.identity_for(username.into())
+    }
 }
 
 /// Build the runtime [`AuthConfig`] from the YAML `auth:` block.
@@ -1512,6 +1530,16 @@ fn build_route_policy(file: Option<RoutesFile>) -> RoutePolicy {
                 .collect(),
         },
     }
+}
+
+fn build_groups(file: &IndexMap<String, AccessSpec>) -> AccessGroups {
+    let mut groups = AccessGroups::default();
+    for (group, members) in file {
+        for username in members.to_ordered_tokens() {
+            groups.add_user_to_group(username, group);
+        }
+    }
+    groups
 }
 
 /// Compile each `upstreamAliases:` entry into a runtime [`UpstreamAlias`],

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1787,7 +1787,7 @@ fn bundled_default_config_enforces_its_protections() {
 #[test]
 fn route_policy_defaults_when_absent() {
     let config = Config::from_yaml_str("{}", Path::new("/x"), listen(), None).unwrap();
-    assert!(config.route_policy.npmjs_unscoped_public);
+    assert!(config.route_policy.npmjs_public);
     assert!(config.route_policy.public.is_empty());
 }
 
@@ -1795,14 +1795,14 @@ fn route_policy_defaults_when_absent() {
 fn route_policy_parses_builtin_toggle_and_public_routes() {
     let yaml = r"
 routes:
-  npmjsUnscopedPublic: false
+  npmjsPublic: false
   public:
     - registry: https://registry.npmjs.org/
       package: '@babel/*'
     - package: '@types/*'
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    assert!(!config.route_policy.npmjs_unscoped_public);
+    assert!(!config.route_policy.npmjs_public);
     assert_eq!(config.route_policy.public.len(), 2);
     assert_eq!(
         config.route_policy.public[0].registry.as_deref(),

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -373,7 +373,7 @@ packages:
 }
 
 fn user(name: &str) -> Identity {
-    Identity::User { username: name.to_string() }
+    Identity::user(name)
 }
 
 fn listen() -> SocketAddr {
@@ -1636,6 +1636,41 @@ packages:
     assert!(!team.access.allows(&Identity::Anonymous));
     assert!(team.publish.allows(&user("alice")));
     assert!(!team.publish.allows(&user("bob")));
+}
+
+#[test]
+fn groups_grant_package_and_alias_access() {
+    let yaml = r"
+groups:
+  platform: alice bob
+  release:
+    - carol
+packages:
+  '@team/*':
+    access: platform
+upstreamAliases:
+  corp:
+    registry: https://npm.corp.example/
+    access: platform
+    auth:
+      type: bearer
+      token: corp-token
+";
+    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+    let alice = config.identity_for_user("alice");
+    let bob = config.identity_for_user("bob");
+    let carol = config.identity_for_user("carol");
+
+    let team = config.policies.for_package("@team/widget");
+    assert!(team.access.allows(&alice));
+    assert!(team.access.allows(&bob));
+    assert!(!team.access.allows(&carol));
+    assert!(!team.access.allows(&Identity::Anonymous));
+
+    let alias = &config.upstream_aliases["corp"];
+    assert!(alias.access.allows(&alice));
+    assert!(alias.access.allows(&bob));
+    assert!(!alias.access.allows(&carol));
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -814,7 +814,7 @@ auth:
 web:
   enable: false
 plugins: ../node_modules
-secret: hunter2
+secret: a-sufficiently-long-secret-value
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
@@ -1881,4 +1881,8 @@ fn resolution_secret_uses_yaml_secret_then_falls_back_to_random() {
     // No `secret:` yields a fresh 32-byte CSPRNG value.
     let without_secret = Config::from_yaml_str("{}", Path::new("/x"), listen(), None).unwrap();
     assert_eq!(without_secret.resolution_cache_secret.len(), 32);
+
+    // A too-short `secret:` is a config error rather than a weak HMAC key.
+    let short = Config::from_yaml_str("secret: short", Path::new("/x"), listen(), None);
+    assert!(matches!(short, Err(RegistryError::InvalidConfig { .. })));
 }

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1838,7 +1838,7 @@ fn resolution_secret_uses_yaml_secret_then_falls_back_to_random() {
         None,
     )
     .unwrap();
-    assert_eq!(with_secret.resolution_cache_secret.as_ref(), b"pnpm-registry-mock-secret-key-32",);
+    assert_eq!(with_secret.resolution_cache_secret.as_ref(), b"pnpm-registry-mock-secret-key-32");
 
     // No `secret:` yields a fresh 32-byte CSPRNG value.
     let without_secret = Config::from_yaml_str("{}", Path::new("/x"), listen(), None).unwrap();

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1746,3 +1746,101 @@ fn bundled_default_config_enforces_its_protections() {
     assert!(public.access.allows(&Identity::Anonymous));
     assert!(!public.publish.allows(&Identity::Anonymous));
 }
+
+#[test]
+fn route_policy_defaults_when_absent() {
+    let config = Config::from_yaml_str("{}", Path::new("/x"), listen(), None).unwrap();
+    assert!(config.route_policy.npmjs_unscoped_public);
+    assert!(config.route_policy.public.is_empty());
+}
+
+#[test]
+fn route_policy_parses_builtin_toggle_and_public_routes() {
+    let yaml = r"
+routes:
+  npmjsUnscopedPublic: false
+  public:
+    - registry: https://registry.npmjs.org/
+      package: '@babel/*'
+    - package: '@types/*'
+";
+    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+    assert!(!config.route_policy.npmjs_unscoped_public);
+    assert_eq!(config.route_policy.public.len(), 2);
+    assert_eq!(
+        config.route_policy.public[0].registry.as_deref(),
+        Some("https://registry.npmjs.org/"),
+    );
+    assert_eq!(config.route_policy.public[0].package.as_deref(), Some("@babel/*"));
+    assert_eq!(config.route_policy.public[1].registry, None);
+}
+
+#[test]
+fn upstream_alias_resolves_credential_access_and_generation() {
+    let yaml = r"
+upstreamAliases:
+  corp:
+    registry: https://npm.corp.example/
+    package: '@acme/*'
+    generation: 7
+    access: $authenticated alice
+    auth:
+      type: bearer
+      token: corp-token
+";
+    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+    let alias = &config.upstream_aliases["corp"];
+    assert_eq!(alias.registry, "https://npm.corp.example/");
+    assert_eq!(alias.package.as_deref(), Some("@acme/*"));
+    assert_eq!(alias.authorization, "Bearer corp-token");
+    assert_eq!(alias.generation, 7);
+    assert!(alias.access.allows(&user("alice")));
+    assert!(!alias.access.allows(&Identity::Anonymous));
+}
+
+#[test]
+fn upstream_alias_generation_defaults_to_one() {
+    let yaml = r"
+upstreamAliases:
+  corp:
+    registry: https://npm.corp.example/
+    auth:
+      type: basic
+      token: dXNlcjpwYXNz
+";
+    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+    let alias = &config.upstream_aliases["corp"];
+    assert_eq!(alias.generation, 1);
+    assert_eq!(alias.authorization, "Basic dXNlcjpwYXNz");
+    // An alias with no explicit access defaults to authenticated callers.
+    assert!(alias.access.allows(&user("bob")));
+    assert!(!alias.access.allows(&Identity::Anonymous));
+}
+
+#[test]
+fn upstream_alias_without_auth_is_a_config_error() {
+    let yaml = r"
+upstreamAliases:
+  corp:
+    registry: https://npm.corp.example/
+";
+    let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
+        .expect_err("an alias without an auth block must fail to load");
+    assert!(matches!(err, RegistryError::InvalidConfig { .. }));
+}
+
+#[test]
+fn resolution_secret_uses_yaml_secret_then_falls_back_to_random() {
+    let with_secret = Config::from_yaml_str(
+        "secret: pnpm-registry-mock-secret-key-32",
+        Path::new("/x"),
+        listen(),
+        None,
+    )
+    .unwrap();
+    assert_eq!(with_secret.resolution_cache_secret.as_ref(), b"pnpm-registry-mock-secret-key-32",);
+
+    // No `secret:` yields a fresh 32-byte CSPRNG value.
+    let without_secret = Config::from_yaml_str("{}", Path::new("/x"), listen(), None).unwrap();
+    assert_eq!(without_secret.resolution_cache_secret.len(), 32);
+}

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -40,7 +40,6 @@ fn uplink_file(auth: Option<UplinkAuthFile>, headers: IndexMap<String, String>) 
         fail_timeout: None,
         cache: None,
         access: None,
-        generation: super::default_generation(),
     }
 }
 
@@ -1810,12 +1809,11 @@ routes:
 }
 
 #[test]
-fn uplink_resolves_access_and_generation() {
+fn uplink_resolves_bearer_auth_and_access() {
     let yaml = r"
 uplinks:
   corp:
     url: https://npm.corp.example/
-    generation: 7
     access: $authenticated alice
     auth:
       type: bearer
@@ -1825,14 +1823,13 @@ uplinks:
     let uplink = &config.uplinks["corp"];
     assert_eq!(uplink.url, "https://npm.corp.example/");
     assert_eq!(auth_header(uplink), Some("Bearer corp-token"));
-    assert_eq!(uplink.generation, 7);
     let access = uplink.access.as_ref().expect("uplink declares access");
     assert!(access.allows(&user("alice")));
     assert!(!access.allows(&Identity::Anonymous));
 }
 
 #[test]
-fn uplink_generation_defaults_to_one() {
+fn uplink_resolves_basic_auth_and_access() {
     let yaml = r"
 uplinks:
   corp:
@@ -1844,7 +1841,6 @@ uplinks:
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
     let uplink = &config.uplinks["corp"];
-    assert_eq!(uplink.generation, 1);
     assert_eq!(auth_header(uplink), Some("Basic dXNlcjpwYXNz"));
     let access = uplink.access.as_ref().expect("uplink declares access");
     assert!(access.allows(&user("bob")));

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -39,6 +39,8 @@ fn uplink_file(auth: Option<UplinkAuthFile>, headers: IndexMap<String, String>) 
         max_fails: None,
         fail_timeout: None,
         cache: None,
+        access: None,
+        generation: super::default_generation(),
     }
 }
 

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1650,9 +1650,9 @@ groups:
 packages:
   '@team/*':
     access: platform
-upstreamAliases:
+uplinks:
   corp:
-    registry: https://npm.corp.example/
+    url: https://npm.corp.example/
     access: platform
     auth:
       type: bearer
@@ -1669,10 +1669,10 @@ upstreamAliases:
     assert!(!team.access.allows(&carol));
     assert!(!team.access.allows(&Identity::Anonymous));
 
-    let alias = &config.upstream_aliases["corp"];
-    assert!(alias.access.allows(&alice));
-    assert!(alias.access.allows(&bob));
-    assert!(!alias.access.allows(&carol));
+    let access = config.uplinks["corp"].access.as_ref().expect("uplink declares access");
+    assert!(access.allows(&alice));
+    assert!(access.allows(&bob));
+    assert!(!access.allows(&carol));
 }
 
 #[test]
@@ -1813,12 +1813,11 @@ routes:
 }
 
 #[test]
-fn upstream_alias_resolves_credential_access_and_generation() {
+fn uplink_resolves_access_and_generation() {
     let yaml = r"
-upstreamAliases:
+uplinks:
   corp:
-    registry: https://npm.corp.example/
-    package: '@acme/*'
+    url: https://npm.corp.example/
     generation: 7
     access: $authenticated alice
     auth:
@@ -1826,44 +1825,46 @@ upstreamAliases:
       token: corp-token
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    let alias = &config.upstream_aliases["corp"];
-    assert_eq!(alias.registry, "https://npm.corp.example/");
-    assert_eq!(alias.package.as_deref(), Some("@acme/*"));
-    assert_eq!(alias.authorization, "Bearer corp-token");
-    assert_eq!(alias.generation, 7);
-    assert!(alias.access.allows(&user("alice")));
-    assert!(!alias.access.allows(&Identity::Anonymous));
+    let uplink = &config.uplinks["corp"];
+    assert_eq!(uplink.url, "https://npm.corp.example/");
+    assert_eq!(auth_header(uplink), Some("Bearer corp-token"));
+    assert_eq!(uplink.generation, 7);
+    let access = uplink.access.as_ref().expect("uplink declares access");
+    assert!(access.allows(&user("alice")));
+    assert!(!access.allows(&Identity::Anonymous));
 }
 
 #[test]
-fn upstream_alias_generation_defaults_to_one() {
+fn uplink_generation_defaults_to_one() {
     let yaml = r"
-upstreamAliases:
+uplinks:
   corp:
-    registry: https://npm.corp.example/
+    url: https://npm.corp.example/
+    access: $authenticated
     auth:
       type: basic
       token: dXNlcjpwYXNz
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    let alias = &config.upstream_aliases["corp"];
-    assert_eq!(alias.generation, 1);
-    assert_eq!(alias.authorization, "Basic dXNlcjpwYXNz");
-    // An alias with no explicit access defaults to authenticated callers.
-    assert!(alias.access.allows(&user("bob")));
-    assert!(!alias.access.allows(&Identity::Anonymous));
+    let uplink = &config.uplinks["corp"];
+    assert_eq!(uplink.generation, 1);
+    assert_eq!(auth_header(uplink), Some("Basic dXNlcjpwYXNz"));
+    let access = uplink.access.as_ref().expect("uplink declares access");
+    assert!(access.allows(&user("bob")));
+    assert!(!access.allows(&Identity::Anonymous));
 }
 
 #[test]
-fn upstream_alias_without_auth_is_a_config_error() {
+fn uplink_without_access_is_not_a_private_route_credential() {
     let yaml = r"
-upstreamAliases:
+uplinks:
   corp:
-    registry: https://npm.corp.example/
+    url: https://npm.corp.example/
 ";
-    let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
-        .expect_err("an alias without an auth block must fail to load");
-    assert!(matches!(err, RegistryError::InvalidConfig { .. }));
+    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+    // A plain proxy uplink with no `access:` parses fine; it simply carries no
+    // access policy and is never offered as a private-route credential.
+    assert!(config.uplinks["corp"].access.is_none());
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1787,22 +1787,19 @@ fn bundled_default_config_enforces_its_protections() {
 #[test]
 fn route_policy_defaults_when_absent() {
     let config = Config::from_yaml_str("{}", Path::new("/x"), listen(), None).unwrap();
-    assert!(config.route_policy.npmjs_public);
     assert!(config.route_policy.public.is_empty());
 }
 
 #[test]
-fn route_policy_parses_builtin_toggle_and_public_routes() {
+fn route_policy_parses_public_routes() {
     let yaml = r"
 routes:
-  npmjsPublic: false
   public:
     - registry: https://registry.npmjs.org/
       package: '@babel/*'
     - package: '@types/*'
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    assert!(!config.route_policy.npmjs_public);
     assert_eq!(config.route_policy.public.len(), 2);
     assert_eq!(
         config.route_policy.public[0].registry.as_deref(),

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -30,8 +30,8 @@ pub use auth::{
 pub use config::{
     AccessSpec, AuthConfig, BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML,
     FeatureOverrides, HostedStoreConfig, HtpasswdConfig, LibsqlSettings, LogConfig, LogFormat,
-    LogLevel, MaxUsers, OsvConfig, PackageAccess, RegistryFeature, ResolverFeature,
-    SqlBackendSettings, TokensConfig, UplinkConfig, default_cache_dir,
+    LogLevel, MaxUsers, OsvConfig, PackageAccess, PublicRoute, RegistryFeature, ResolverFeature,
+    RoutePolicy, SqlBackendSettings, TokensConfig, UplinkConfig, UpstreamAlias, default_cache_dir,
 };
 pub use error::{RegistryError, Result};
 pub use journal::recover_publish_journal;

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -15,6 +15,7 @@ mod package_name;
 mod policy;
 mod publish;
 mod resolver;
+mod route;
 mod s3;
 mod search;
 mod server;

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -31,7 +31,7 @@ pub use config::{
     AccessSpec, AuthConfig, BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML,
     FeatureOverrides, HostedStoreConfig, HtpasswdConfig, LibsqlSettings, LogConfig, LogFormat,
     LogLevel, MaxUsers, OsvConfig, PackageAccess, PublicRoute, RegistryFeature, ResolverFeature,
-    RoutePolicy, SqlBackendSettings, TokensConfig, UplinkConfig, UpstreamAlias, default_cache_dir,
+    RoutePolicy, SqlBackendSettings, TokensConfig, UplinkConfig, default_cache_dir,
 };
 pub use error::{RegistryError, Result};
 pub use journal::recover_publish_journal;

--- a/pnpr/crates/pnpr/src/policy.rs
+++ b/pnpr/crates/pnpr/src/policy.rs
@@ -6,13 +6,13 @@
 //! groups); a request is allowed when the caller's identity satisfies
 //! any token in the list. Tokens are the built-in pseudo-groups
 //! (`$all`, `$authenticated`, `$anonymous`, plus their `@`/bare
-//! aliases) or a *name*. With htpasswd auth a caller's only group is
-//! their own username, so a name token matches an authenticated caller
-//! whose username equals it — group names supplied by other auth
-//! backends would match here too once such a backend lands. This is
-//! verdaccio's model, where the auth plugin owns group membership and
-//! the htpasswd plugin contributes only the username.
+//! aliases) or a *name*. A name token matches either the authenticated
+//! username or any group attached to that identity. pnpr's static
+//! `groups:` config adds group membership on top of htpasswd users,
+//! matching verdaccio's model where access lists do not distinguish
+//! usernames from group names.
 
+use std::collections::{BTreeMap, BTreeSet};
 use wax::{Glob, Program};
 
 use crate::error::RegistryError;
@@ -29,7 +29,7 @@ pub enum AccessToken {
     /// *without* valid credentials.
     Anonymous,
     /// A username or group name. Matches an authenticated caller whose
-    /// username (or, eventually, auth-provided group) equals it.
+    /// username or group membership equals it.
     Named(String),
 }
 
@@ -78,18 +78,54 @@ impl AccessList {
     }
 }
 
+/// Static group memberships layered onto authenticated pnpr users.
+/// Values are keyed by username so resolving a caller identity stays a
+/// single lookup after the bearer token has been validated.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct AccessGroups {
+    by_user: BTreeMap<String, BTreeSet<String>>,
+}
+
+impl AccessGroups {
+    pub(crate) fn add_user_to_group(&mut self, username: &str, group: &str) {
+        self.by_user.entry(username.to_string()).or_default().insert(group.to_string());
+    }
+
+    #[must_use]
+    pub fn identity_for(&self, username: String) -> Identity {
+        let groups = self.by_user.get(&username).cloned().unwrap_or_default();
+        Identity::User { username, groups }
+    }
+}
+
 /// The resolved caller identity an [`AccessList`] is evaluated against.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Identity {
     /// No valid credentials were presented.
     Anonymous,
-    /// Authenticated as `username`. (With htpasswd that's the caller's
-    /// only group beyond the built-ins; a group-providing auth backend
-    /// would widen this.)
-    User { username: String },
+    /// Authenticated as `username`, with any configured static groups.
+    User { username: String, groups: BTreeSet<String> },
 }
 
 impl Identity {
+    #[must_use]
+    pub fn user(username: impl Into<String>) -> Self {
+        Self::User { username: username.into(), groups: BTreeSet::new() }
+    }
+
+    #[must_use]
+    pub fn user_with_groups<User, Groups, Group>(username: User, groups: Groups) -> Self
+    where
+        User: Into<String>,
+        Groups: IntoIterator<Item = Group>,
+        Group: Into<String>,
+    {
+        Self::User {
+            username: username.into(),
+            groups: groups.into_iter().map(Into::into).collect(),
+        }
+    }
+
     #[must_use]
     pub fn is_authenticated(&self) -> bool {
         matches!(self, Identity::User { .. })
@@ -100,7 +136,9 @@ impl Identity {
             (AccessToken::All, _) => true,
             (AccessToken::Authenticated, Identity::User { .. }) => true,
             (AccessToken::Anonymous, Identity::Anonymous) => true,
-            (AccessToken::Named(name), Identity::User { username }) => name == username,
+            (AccessToken::Named(name), Identity::User { username, groups }) => {
+                name == username || groups.contains(name)
+            }
             _ => false,
         }
     }

--- a/pnpr/crates/pnpr/src/policy/tests.rs
+++ b/pnpr/crates/pnpr/src/policy/tests.rs
@@ -1,7 +1,7 @@
 use super::{AccessList, AccessToken, Identity, PackagePolicies};
 
 fn user(name: &str) -> Identity {
-    Identity::User { username: name.to_string() }
+    Identity::user(name)
 }
 
 #[test]
@@ -44,6 +44,15 @@ fn usernames_grant_per_user_access() {
     assert!(list.allows(&user("alice")));
     assert!(list.allows(&user("bob")));
     assert!(!list.allows(&user("carol")));
+    assert!(!list.allows(&Identity::Anonymous));
+}
+
+#[test]
+fn groups_grant_named_access() {
+    let list = AccessList::parse("platform");
+    assert!(list.allows(&Identity::user_with_groups("alice", ["platform"])));
+    assert!(list.allows(&user("platform")));
+    assert!(!list.allows(&Identity::user_with_groups("bob", ["release"])));
     assert!(!list.allows(&Identity::Anonymous));
 }
 

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -349,6 +349,10 @@ pub(crate) async fn handle_resolve(
         return response;
     }
 
+    if let Some(response) = reject_off_allowlist_registries(&request, &runtime.route_context) {
+        return response;
+    }
+
     // Resolve against the client's registries, not the server's own.
     let Some(config) = runtime.config_for(&request) else {
         return json_error(StatusCode::SERVICE_UNAVAILABLE, TOO_MANY_CONFIGS_MESSAGE);
@@ -505,6 +509,10 @@ pub(crate) async fn handle_verify_lockfile(
     };
 
     if let Some(response) = reject_inline_url_auth(&request) {
+        return response;
+    }
+
+    if let Some(response) = reject_off_allowlist_registries(&request, &runtime.route_context) {
         return response;
     }
 
@@ -1284,6 +1292,31 @@ fn merge_policies(
 /// values, and the tarball URLs of an input lockfile — every surface a
 /// tarball/registry URL can reach the resolver (or be echoed back) through.
 /// Returns a `400` response when one is found.
+/// Reject a request whose client-supplied `registry`/`namedRegistries` would
+/// have pnpr fetch from a host that is not on the route allowlist (see
+/// [`RouteContext::allows_registry`]). This is the resolver's SSRF boundary:
+/// pnpr fetches only from operator-configured registries, so a caller cannot
+/// point it at cloud instance metadata, an internal service, or any other
+/// off-allowlist host. Runs before any server-side fetch.
+fn reject_off_allowlist_registries(
+    request: &ResolveRequest,
+    context: &RouteContext,
+) -> Option<Response> {
+    let mut registries: Vec<&str> = Vec::new();
+    if let Some(registry) = request.registry.as_deref() {
+        registries.push(registry);
+    }
+    registries.extend(request.named_registries.values().map(String::as_str));
+    let off = registries.into_iter().find(|registry| !context.allows_registry(registry))?;
+    Some(json_error(
+        StatusCode::FORBIDDEN,
+        &format!(
+            "registry {off:?} is not allowed by this pnpr server; the operator must declare it \
+             as a public route or an uplink",
+        ),
+    ))
+}
+
 fn reject_inline_url_auth(request: &ResolveRequest) -> Option<Response> {
     let mut specs: Vec<&str> = Vec::new();
     if let Some(registry) = request.registry.as_deref() {

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -23,9 +23,9 @@
 //!   endpoint as the trust verdict.
 //!
 //! pnpr is a stateless resolver: it stores no tarballs. Public tarballs
-//! can still be fetched directly from their upstream registry, while
-//! private or unknown routes are rewritten to pnpr's read-only tarball
-//! gateway so upstream URLs and credentials stay server-side.
+//! can still be fetched directly from their upstream registry, while a
+//! private proxied route is rewritten to the uplink's `/~<uplink>/`
+//! registry endpoint so upstream URLs and credentials stay server-side.
 //!
 //! The client's `registry`, `namedRegistries`, `overrides`, and the
 //! verification policy (`minimumReleaseAge`, `trustPolicy`, ...) drive
@@ -39,7 +39,7 @@
 //! authenticates to pnpr (its request `Authorization` identifies the
 //! caller) but does not forward its own upstream registry credentials:
 //! pnpr selects upstream auth from its route policy (see [`crate::route`]),
-//! so private dependencies resolve via a pnpr-managed credential alias or
+//! so private dependencies resolve via a pnpr-managed uplink credential or
 //! fail closed.
 
 pub(crate) mod osv;
@@ -88,30 +88,6 @@ pub(crate) use self::osv::{OsvIndex, format_advisory_ids, load_osv_index};
 
 use self::{protocol::ResolveRequest, verdict_cache::VerdictCache};
 
-#[derive(Default, Clone)]
-pub(crate) struct TarballGatewayRoutes {
-    routes: Arc<Mutex<HashMap<String, String>>>,
-}
-
-impl TarballGatewayRoutes {
-    pub(crate) fn insert(&self, key: String, url: String) {
-        let mut routes = self.routes.lock().expect("tarball gateway routes poisoned");
-        if routes.len() >= MAX_TARBALL_GATEWAY_ROUTES
-            && !routes.contains_key(&key)
-            && let Some(evicted) = routes.keys().next().cloned()
-        {
-            routes.remove(&evicted);
-        }
-        routes.insert(key, url);
-    }
-
-    pub(crate) fn get(&self, key: &str) -> Option<String> {
-        self.routes.lock().expect("tarball gateway routes poisoned").get(key).cloned()
-    }
-}
-
-const MAX_TARBALL_GATEWAY_ROUTES: usize = 8192;
-
 /// Per-server engine backing the pnpr install endpoint: it holds the
 /// store, cache, and HTTP client used to resolve a client's project. The
 /// store and cache dirs are fixed for the server's lifetime; the
@@ -147,14 +123,13 @@ pub(crate) struct Resolver {
     /// from the server config and combined per request with the caller's
     /// identity to drive auth selection and footprint recording.
     route_context: RouteContext,
-    /// Public URL clients use for pnpr-hosted and resolver-gateway tarball
-    /// URLs.
+    /// Public URL clients use for pnpr-hosted and `/~<uplink>/` endpoint
+    /// tarball URLs.
     public_url: String,
     /// HMAC secret namespacing a private footprint's cache descriptor.
     /// Part 1 uses it only to label each resolve's cache class in the
     /// operator debug log; Part 2 keys private cache entries by it.
     resolution_cache_secret: Arc<[u8]>,
-    tarball_gateway_routes: TarballGatewayRoutes,
 }
 
 struct CachedResolution {
@@ -170,16 +145,11 @@ impl Resolver {
         cell: &'a OnceLock<Resolver>,
         config: &RegistryConfig,
         osv_index: Option<Arc<OsvIndex>>,
-        tarball_gateway_routes: TarballGatewayRoutes,
     ) -> &'a Resolver {
-        cell.get_or_init(|| Resolver::build(config, osv_index, tarball_gateway_routes))
+        cell.get_or_init(|| Resolver::build(config, osv_index))
     }
 
-    fn build(
-        config: &RegistryConfig,
-        osv_index: Option<Arc<OsvIndex>>,
-        tarball_gateway_routes: TarballGatewayRoutes,
-    ) -> Resolver {
+    fn build(config: &RegistryConfig, osv_index: Option<Arc<OsvIndex>>) -> Resolver {
         let store_dir = config.cache_storage.join("pnpr-store");
         let cache_dir = config.cache_storage.join("pnpr-cache");
         // Best-effort: a real failure here (e.g. a permission problem)
@@ -200,7 +170,6 @@ impl Resolver {
             route_context: RouteContext::from_config(config),
             public_url: config.public_url.clone(),
             resolution_cache_secret: Arc::clone(&config.resolution_cache_secret),
-            tarball_gateway_routes,
         }
     }
 
@@ -397,8 +366,6 @@ pub(crate) async fn handle_resolve(
         runtime.route_context.clone(),
         identity.clone(),
         runtime.public_url.clone(),
-        Arc::clone(&runtime.resolution_cache_secret),
-        runtime.tarball_gateway_routes.clone(),
     );
 
     // Verify the *input* lockfile under the client's policy before any
@@ -562,8 +529,6 @@ pub(crate) async fn handle_verify_lockfile(
         runtime.route_context.clone(),
         identity.clone(),
         runtime.public_url.clone(),
-        Arc::clone(&runtime.resolution_cache_secret),
-        runtime.tarball_gateway_routes.clone(),
     );
     let input_lockfile = tarball_router.verification_lockfile(input_lockfile);
 
@@ -767,19 +732,11 @@ struct TarballRouter {
     context: RouteContext,
     identity: Identity,
     public_url: String,
-    secret: Arc<[u8]>,
-    gateway_routes: TarballGatewayRoutes,
 }
 
 impl TarballRouter {
-    fn new(
-        context: RouteContext,
-        identity: Identity,
-        public_url: String,
-        secret: Arc<[u8]>,
-        gateway_routes: TarballGatewayRoutes,
-    ) -> Self {
-        Self { context, identity, public_url, secret, gateway_routes }
+    fn new(context: RouteContext, identity: Identity, public_url: String) -> Self {
+        Self { context, identity, public_url }
     }
 
     fn route_lockfile(&self, config: &PacquetConfig, lockfile: &Lockfile) -> Lockfile {
@@ -823,15 +780,11 @@ impl TarballRouter {
         let Some(packages) = upstream.packages.as_mut() else {
             return upstream;
         };
-        for (package_key, metadata) in packages {
+        for metadata in packages.values_mut() {
             let LockfileResolution::Tarball(resolution) = &mut metadata.resolution else {
                 continue;
             };
-            if let Some(tarball_url) = self.upstream_alias_tarball_url(&resolution.tarball) {
-                resolution.tarball = tarball_url;
-            } else if let Some(tarball_url) = self
-                .upstream_unknown_tarball_url(&package_key.name.to_string(), &resolution.tarball)
-            {
+            if let Some(tarball_url) = self.upstream_endpoint_tarball_url(&resolution.tarball) {
                 resolution.tarball = tarball_url;
             }
         }
@@ -839,73 +792,37 @@ impl TarballRouter {
     }
 
     fn route_url(&self, package: &str, version: &str, tarball_url: &str) -> String {
-        if self.is_alias_gateway_url(tarball_url) {
-            return tarball_url.to_string();
-        }
         match self.context.classify(&self.identity, tarball_url, Some(package)) {
-            RouteClass::Public => tarball_url.to_string(),
+            // A public or unknown route keeps its upstream URL. An unknown
+            // route that produced a resolution was fetched without a managed
+            // credential (anonymously), so its tarball is anonymously
+            // fetchable; pnpr never mints a per-tarball gateway URL.
+            RouteClass::Public | RouteClass::Unknown => tarball_url.to_string(),
             RouteClass::Hosted { .. } => pnpr_tarball_url(
                 &self.public_url,
                 package,
                 &tarball_filename(package, version, tarball_url),
             ),
-            RouteClass::Proxied { alias, generation } => alias_gateway_tarball_url(
+            RouteClass::Proxied { alias, .. } => uplink_endpoint_tarball_url(
                 &self.public_url,
                 &alias,
-                generation,
                 package,
                 &tarball_filename(package, version, tarball_url),
             ),
-            RouteClass::Unknown => {
-                let filename = tarball_filename(package, version, tarball_url);
-                let key = unknown_gateway_key(&self.secret, tarball_url);
-                self.gateway_routes.insert(key.clone(), tarball_url.to_string());
-                unknown_gateway_tarball_url(&self.public_url, &key, package, &filename)
-            }
         }
     }
 
-    fn is_alias_gateway_url(&self, tarball_url: &str) -> bool {
-        tarball_url.starts_with(&format!(
-            "{}/-/pnpr/v0/tarballs/alias/",
-            self.public_url.trim_end_matches('/'),
-        ))
-    }
-
-    fn upstream_alias_tarball_url(&self, tarball_url: &str) -> Option<String> {
-        let url = url::Url::parse(tarball_url).ok()?;
-        let route = url.path().strip_prefix("/-/pnpr/v0/tarballs/alias/")?;
-        let segments: Vec<_> = route.split('/').collect();
-        let [raw_alias, raw_generation, raw_package, "-", raw_filename] = segments.as_slice()
-        else {
-            return None;
-        };
-        let alias = percent_decode(raw_alias)?;
-        let generation = raw_generation.parse::<u64>().ok()?;
-        let package = percent_decode(raw_package)?;
-        let filename = percent_decode(raw_filename)?;
-        let alias_config =
-            self.context.gateway_alias(&self.identity, &alias, generation, &package)?;
-        Some(format!("{}/{}/-/{}", alias_config.registry.trim_end_matches('/'), package, filename))
-    }
-
-    fn upstream_unknown_tarball_url(
-        &self,
-        expected_package: &str,
-        tarball_url: &str,
-    ) -> Option<String> {
-        let url = url::Url::parse(tarball_url).ok()?;
-        let route = url.path().strip_prefix("/-/pnpr/v0/tarballs/unknown/")?;
-        let segments: Vec<_> = route.split('/').collect();
-        let [key, raw_package, "-", raw_filename] = segments.as_slice() else {
-            return None;
-        };
-        let package = percent_decode(raw_package)?;
-        if package != expected_package {
-            return None;
-        }
-        let _filename = percent_decode(raw_filename)?;
-        self.gateway_routes.get(key)
+    /// Reverse a `/~<uplink>/<pkg>/-/<file>` endpoint tarball URL back to its
+    /// upstream URL so an input lockfile carrying endpoint URLs can be verified
+    /// against the real registry. Returns `None` for any other URL, and for an
+    /// endpoint the caller is not authorized for (so verification cannot be
+    /// used as an oracle for an uplink the caller cannot reach).
+    fn upstream_endpoint_tarball_url(&self, tarball_url: &str) -> Option<String> {
+        let prefix = format!("{}/~", self.public_url.trim_end_matches('/'));
+        let route = tarball_url.strip_prefix(&prefix)?;
+        let (uplink, rest) = route.split_once('/')?;
+        let registry = self.context.uplink_registry(&self.identity, uplink)?;
+        Some(format!("{}/{rest}", registry.trim_end_matches('/')))
     }
 }
 
@@ -925,91 +842,17 @@ fn pnpr_tarball_url(public_url: &str, package: &str, filename: &str) -> String {
     format!("{}/{package}/-/{filename}", public_url.trim_end_matches('/'))
 }
 
-fn alias_gateway_tarball_url(
+/// The `/~<uplink>/<package>/-/<filename>` registry-endpoint URL a proxied
+/// route's tarball is served through. Canonical for a client whose scope is
+/// configured at `https://<pnpr>/~<uplink>/`, so the lockfile entry collapses
+/// to integrity-only; the upstream URL and credential stay server-side.
+fn uplink_endpoint_tarball_url(
     public_url: &str,
-    alias: &str,
-    generation: u64,
+    uplink: &str,
     package: &str,
     filename: &str,
 ) -> String {
-    let base = format!("{}/", public_url.trim_end_matches('/'));
-    let Ok(mut url) = url::Url::parse(&base) else {
-        return pnpr_tarball_url(public_url, package, filename);
-    };
-    let generation = generation.to_string();
-    {
-        let Ok(mut segments) = url.path_segments_mut() else {
-            return pnpr_tarball_url(public_url, package, filename);
-        };
-        segments.extend([
-            "-",
-            "pnpr",
-            "v0",
-            "tarballs",
-            "alias",
-            alias,
-            generation.as_str(),
-            package,
-            "-",
-            filename,
-        ]);
-    }
-    url.to_string()
-}
-
-fn unknown_gateway_key(secret: &[u8], tarball_url: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(b"pnpr unknown tarball gateway route\0");
-    hasher.update(secret);
-    hasher.update(b"\0");
-    hasher.update(tarball_url.as_bytes());
-    format!("{:x}", hasher.finalize())
-}
-
-fn unknown_gateway_tarball_url(
-    public_url: &str,
-    key: &str,
-    package: &str,
-    filename: &str,
-) -> String {
-    let base = format!("{}/", public_url.trim_end_matches('/'));
-    let Ok(mut url) = url::Url::parse(&base) else {
-        return pnpr_tarball_url(public_url, package, filename);
-    };
-    {
-        let Ok(mut segments) = url.path_segments_mut() else {
-            return pnpr_tarball_url(public_url, package, filename);
-        };
-        segments.extend(["-", "pnpr", "v0", "tarballs", "unknown", key, package, "-", filename]);
-    }
-    url.to_string()
-}
-
-fn percent_decode(input: &str) -> Option<String> {
-    let bytes = input.as_bytes();
-    let mut decoded = Vec::with_capacity(bytes.len());
-    let mut index = 0;
-    while index < bytes.len() {
-        if bytes[index] == b'%' {
-            let high = hex_value(*bytes.get(index + 1)?)?;
-            let low = hex_value(*bytes.get(index + 2)?)?;
-            decoded.push((high << 4) | low);
-            index += 3;
-        } else {
-            decoded.push(bytes[index]);
-            index += 1;
-        }
-    }
-    String::from_utf8(decoded).ok()
-}
-
-fn hex_value(byte: u8) -> Option<u8> {
-    match byte {
-        b'0'..=b'9' => Some(byte - b'0'),
-        b'a'..=b'f' => Some(byte - b'a' + 10),
-        b'A'..=b'F' => Some(byte - b'A' + 10),
-        _ => None,
-    }
+    format!("{}/~{uplink}/{package}/-/{filename}", public_url.trim_end_matches('/'))
 }
 
 /// NDJSON content type for the `/-/pnpr/v0/resolve` response. One JSON object

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -35,9 +35,12 @@
 //! non-frozen → reuse-and-update). A multi-project workspace is resolved
 //! by reconstructing the workspace on disk (root manifest +
 //! `pnpm-workspace.yaml` + member manifests) and letting pacquet's
-//! install path discover and resolve every importer. The client also
-//! forwards its per-registry credentials, so private dependencies resolve
-//! as the caller.
+//! install path discover and resolve every importer. The client
+//! authenticates to pnpr (its request `Authorization` identifies the
+//! caller) but does not forward its own upstream registry credentials:
+//! pnpr selects upstream auth from its route policy (see [`crate::route`]),
+//! so private dependencies resolve via a pnpr-managed credential alias or
+//! fail closed.
 
 pub(crate) mod osv;
 mod protocol;

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -1352,15 +1352,21 @@ fn reject_off_allowlist_fetches(
 }
 
 /// Whether `spec` would trigger a server-side fetch to an origin that is not on
-/// the allowlist. Covers `scheme://host` URLs (`http(s)`/`git`/`ssh`, with a
-/// `git+` transport prefix stripped) and scp-style git remotes
-/// (`[user@]host:path`), which pacquet routes to the ssh git resolver. Specs
-/// that never reach the network — semver ranges, `npm:`/`workspace:`/`file:`/
-/// `link:` aliases, scoped names — return `false`.
+/// the allowlist. Covers any `scheme://host` URL (an `http(s)` tarball and
+/// every git transport — `git`/`ssh`/`rsync`/`ftp`/`file`/... — with a `git+`
+/// prefix stripped) and scp-style git remotes (`[user@]host:path`), which
+/// pacquet routes to the ssh git resolver. Specs that never reach the network —
+/// semver ranges, `npm:`/`workspace:`/`file:`/`link:` aliases (no `://`),
+/// scoped names — return `false`.
 fn fetch_is_off_allowlist(spec: &str, context: &RouteContext) -> bool {
     let url = spec.strip_prefix("git+").unwrap_or(spec);
-    if let Some((scheme, _)) = url.split_once("://") {
-        return matches!(scheme, "http" | "https" | "git" | "ssh") && !context.allows_registry(url);
+    if url.contains("://") {
+        // Gate by origin regardless of scheme: any transport that reaches a
+        // host can be an SSRF vector (every git transport — git/ssh/rsync/ftp/
+        // file/...), and a scheme with no allowlistable host (e.g. `file://`,
+        // which would read a server-local path) nerf-darts to nothing and is
+        // rejected.
+        return !context.allows_registry(url);
     }
     // A scp-style git remote carries no scheme, so normalize its host to an
     // `ssh://host/` origin the allowlist can match (nerf-darting is
@@ -1373,9 +1379,9 @@ fn fetch_is_off_allowlist(spec: &str, context: &RouteContext) -> bool {
 
 /// The host of a scp-style git remote (`[user@]host:path`), or `None`. The
 /// distinguishing shape is a `user@host` authority before the first `:` with a
-/// path after it — generalizing the `git@…` form pacquet's git resolver treats
-/// as ssh. A protocol spec (`npm:…`, `file:…`) has no `@` in its authority, and
-/// a `scheme://…` URL is handled before this is reached.
+/// path after it — generalizing the `git@...` form pacquet's git resolver treats
+/// as ssh. A protocol spec (`npm:...`, `file:...`) has no `@` in its authority, and
+/// a `scheme://...` URL is handled before this is reached.
 fn scp_git_host(spec: &str) -> Option<&str> {
     let (authority, path) = spec.split_once(':')?;
     if path.is_empty() || authority.contains('/') {

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -1327,9 +1327,7 @@ fn reject_off_allowlist_fetches(
             }
         }
     }
-    if let Some(off) =
-        url_specs.into_iter().filter_map(fetch_url_of).find(|url| !context.allows_registry(url))
-    {
+    if let Some(off) = url_specs.into_iter().find(|spec| fetch_is_off_allowlist(spec, context)) {
         return Some(forbidden_off_allowlist(off));
     }
 
@@ -1345,15 +1343,38 @@ fn reject_off_allowlist_fetches(
     None
 }
 
-/// The fetchable URL inside a dependency/override spec, if its scheme triggers
-/// a server-side network fetch — an `http(s)` tarball or a `git`/`ssh` git
-/// remote. A `git+` transport prefix is stripped so the origin check sees the
-/// bare URL. `None` for specs that never reach the network (semver ranges,
-/// `npm:`/`workspace:`/`file:`/`link:` aliases, scoped names).
-fn fetch_url_of(spec: &str) -> Option<&str> {
+/// Whether `spec` would trigger a server-side fetch to an origin that is not on
+/// the allowlist. Covers `scheme://host` URLs (`http(s)`/`git`/`ssh`, with a
+/// `git+` transport prefix stripped) and scp-style git remotes
+/// (`[user@]host:path`), which pacquet routes to the ssh git resolver. Specs
+/// that never reach the network — semver ranges, `npm:`/`workspace:`/`file:`/
+/// `link:` aliases, scoped names — return `false`.
+fn fetch_is_off_allowlist(spec: &str, context: &RouteContext) -> bool {
     let url = spec.strip_prefix("git+").unwrap_or(spec);
-    let (scheme, _) = url.split_once("://")?;
-    matches!(scheme, "http" | "https" | "git" | "ssh").then_some(url)
+    if let Some((scheme, _)) = url.split_once("://") {
+        return matches!(scheme, "http" | "https" | "git" | "ssh") && !context.allows_registry(url);
+    }
+    // A scp-style git remote carries no scheme, so normalize its host to an
+    // `ssh://host/` origin the allowlist can match (nerf-darting is
+    // scheme-agnostic, so an operator allowlisting `https://host/` covers it).
+    match scp_git_host(url) {
+        Some(host) => !context.allows_registry(&format!("ssh://{host}/")),
+        None => false,
+    }
+}
+
+/// The host of a scp-style git remote (`[user@]host:path`), or `None`. The
+/// distinguishing shape is a `user@host` authority before the first `:` with a
+/// path after it — generalizing the `git@…` form pacquet's git resolver treats
+/// as ssh. A protocol spec (`npm:…`, `file:…`) has no `@` in its authority, and
+/// a `scheme://…` URL is handled before this is reached.
+fn scp_git_host(spec: &str) -> Option<&str> {
+    let (authority, path) = spec.split_once(':')?;
+    if path.is_empty() || authority.contains('/') {
+        return None;
+    }
+    let (_, host) = authority.rsplit_once('@')?;
+    (!host.is_empty()).then_some(host)
 }
 
 /// The first override URL leaf whose origin is off the fetch allowlist, if any.
@@ -1363,7 +1384,7 @@ fn first_off_allowlist_override(
 ) -> Option<String> {
     match value {
         serde_json::Value::String(spec) => {
-            fetch_url_of(spec).filter(|url| !context.allows_registry(url)).map(str::to_string)
+            fetch_is_off_allowlist(spec, context).then(|| spec.clone())
         }
         serde_json::Value::Array(items) => {
             items.iter().find_map(|item| first_off_allowlist_override(item, context))

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -118,8 +118,8 @@ pub(crate) struct Resolver {
     /// every time (uncached) rather than failing the server.
     verdict_cache: Option<VerdictCache>,
     osv_index: Option<Arc<OsvIndex>>,
-    /// Route-classification inputs (public/private rules, upstream
-    /// credential aliases, hosted origin, package policy), resolved once
+    /// Route-classification inputs (public/private rules, pnpr-managed
+    /// uplink credentials, hosted origin, package policy), resolved once
     /// from the server config and combined per request with the caller's
     /// identity to drive auth selection and footprint recording.
     route_context: RouteContext,
@@ -333,8 +333,8 @@ fn intern_config(
 /// lockfile + stats, `error` if resolution aborts mid-stream, or
 /// `violations` if the input lockfile failed the client's policy. The
 /// short-circuit paths (frozen reuse, cache hit) emit only the terminal
-/// `done` frame. Private or unknown tarballs are announced through
-/// pnpr's read-only gateway rather than their upstream URLs.
+/// `done` frame. A private proxied tarball is announced through its
+/// uplink's `/~<uplink>/` registry endpoint rather than its upstream URL.
 pub(crate) async fn handle_resolve(
     runtime: &Resolver,
     identity: Identity,

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -476,7 +476,6 @@ pub(crate) async fn handle_resolve(
                     );
                     if !footprint.is_public() {
                         tracing::debug!(
-                            shareable = footprint.is_shareable(),
                             cached,
                             descriptor = descriptor.as_deref().unwrap_or("none"),
                             "private resolution cache candidate evaluated",
@@ -589,7 +588,7 @@ fn store_resolution(
     secret: &[u8],
     lockfile: &Lockfile,
 ) -> bool {
-    if ttl.is_zero() || !footprint.is_shareable() {
+    if ttl.is_zero() {
         return false;
     }
     let now = Instant::now();
@@ -801,11 +800,10 @@ impl TarballRouter {
 
     fn route_url(&self, package: &str, version: &str, tarball_url: &str) -> String {
         match self.context.classify(&self.identity, tarball_url, Some(package)) {
-            // A public or unknown route keeps its upstream URL. An unknown
-            // route that produced a resolution was fetched without a managed
-            // credential (anonymously), so its tarball is anonymously
-            // fetchable; pnpr never mints a per-tarball gateway URL.
-            RouteClass::Public | RouteClass::Unknown => tarball_url.to_string(),
+            // A public route keeps its upstream URL: it was fetched
+            // anonymously, so its tarball is anonymously fetchable and pnpr
+            // never mints a per-tarball gateway URL.
+            RouteClass::Public => tarball_url.to_string(),
             RouteClass::Hosted { .. } => pnpr_tarball_url(
                 &self.public_url,
                 package,

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -349,7 +349,7 @@ pub(crate) async fn handle_resolve(
         return response;
     }
 
-    if let Some(response) = reject_off_allowlist_registries(&request, &runtime.route_context) {
+    if let Some(response) = reject_off_allowlist_fetches(&request, &runtime.route_context) {
         return response;
     }
 
@@ -511,7 +511,7 @@ pub(crate) async fn handle_verify_lockfile(
         return response;
     }
 
-    if let Some(response) = reject_off_allowlist_registries(&request, &runtime.route_context) {
+    if let Some(response) = reject_off_allowlist_fetches(&request, &runtime.route_context) {
         return response;
     }
 
@@ -1284,37 +1284,113 @@ fn merge_policies(
     merged
 }
 
+/// Reject a request that would have pnpr fetch from an origin that is not on
+/// the route allowlist (see [`RouteContext::allows_registry`]) — the
+/// resolver's SSRF boundary, run before any server-side fetch. pnpr fetches
+/// only from operator-configured registries, so a caller cannot point it at
+/// cloud instance metadata, an internal service, or any other off-allowlist
+/// host. Beyond the default/named registries this also covers every fetch a
+/// *direct-URL dependency* would trigger: an `http(s)`/`git` dependency spec,
+/// an override URL leaf, or an input lockfile's tarball URL. A semver range or
+/// `npm:`/`workspace:`/`file:` alias never hits the network, so it is ignored.
+fn reject_off_allowlist_fetches(
+    request: &ResolveRequest,
+    context: &RouteContext,
+) -> Option<Response> {
+    // Registries are fetch targets whatever their scheme.
+    let mut registries: Vec<&str> = Vec::new();
+    if let Some(registry) = request.registry.as_deref() {
+        registries.push(registry);
+    }
+    registries.extend(request.named_registries.values().map(String::as_str));
+    if let Some(off) = registries.into_iter().find(|registry| !context.allows_registry(registry)) {
+        return Some(forbidden_off_allowlist(off));
+    }
+
+    // Direct-URL dependency specs and input-lockfile tarball URLs reach the
+    // network only when they carry an http(s)/git URL.
+    let mut url_specs: Vec<&str> = Vec::new();
+    let projects = request.projects_normalized();
+    for project in &projects {
+        for map in
+            [&project.dependencies, &project.dev_dependencies, &project.optional_dependencies]
+        {
+            url_specs.extend(map.values().map(String::as_str));
+        }
+    }
+    if let Some(packages) =
+        request.lockfile.as_ref().and_then(|lockfile| lockfile.packages.as_ref())
+    {
+        for package in packages.values() {
+            if let LockfileResolution::Tarball(resolution) = &package.resolution {
+                url_specs.push(resolution.tarball.as_str());
+            }
+        }
+    }
+    if let Some(off) =
+        url_specs.into_iter().filter_map(fetch_url_of).find(|url| !context.allows_registry(url))
+    {
+        return Some(forbidden_off_allowlist(off));
+    }
+
+    // Override leaves can themselves be direct-URL specs.
+    if let Some(off) = request
+        .overrides
+        .as_ref()
+        .and_then(|overrides| first_off_allowlist_override(overrides, context))
+    {
+        return Some(forbidden_off_allowlist(&off));
+    }
+
+    None
+}
+
+/// The fetchable URL inside a dependency/override spec, if its scheme triggers
+/// a server-side network fetch — an `http(s)` tarball or a `git`/`ssh` git
+/// remote. A `git+` transport prefix is stripped so the origin check sees the
+/// bare URL. `None` for specs that never reach the network (semver ranges,
+/// `npm:`/`workspace:`/`file:`/`link:` aliases, scoped names).
+fn fetch_url_of(spec: &str) -> Option<&str> {
+    let url = spec.strip_prefix("git+").unwrap_or(spec);
+    let (scheme, _) = url.split_once("://")?;
+    matches!(scheme, "http" | "https" | "git" | "ssh").then_some(url)
+}
+
+/// The first override URL leaf whose origin is off the fetch allowlist, if any.
+fn first_off_allowlist_override(
+    value: &serde_json::Value,
+    context: &RouteContext,
+) -> Option<String> {
+    match value {
+        serde_json::Value::String(spec) => {
+            fetch_url_of(spec).filter(|url| !context.allows_registry(url)).map(str::to_string)
+        }
+        serde_json::Value::Array(items) => {
+            items.iter().find_map(|item| first_off_allowlist_override(item, context))
+        }
+        serde_json::Value::Object(map) => {
+            map.values().find_map(|item| first_off_allowlist_override(item, context))
+        }
+        _ => None,
+    }
+}
+
+fn forbidden_off_allowlist(target: &str) -> Response {
+    json_error(
+        StatusCode::FORBIDDEN,
+        &format!(
+            "{target:?} is not allowed by this pnpr server; the operator must declare its \
+             registry as a public route or an uplink",
+        ),
+    )
+}
+
 /// Reject a request whose client-supplied URLs carry inline
 /// `user:pass@host` credentials, before any fetch or cache write. Covers
 /// the default and named registries, every dependency spec, override
 /// values, and the tarball URLs of an input lockfile — every surface a
 /// tarball/registry URL can reach the resolver (or be echoed back) through.
 /// Returns a `400` response when one is found.
-/// Reject a request whose client-supplied `registry`/`namedRegistries` would
-/// have pnpr fetch from a host that is not on the route allowlist (see
-/// [`RouteContext::allows_registry`]). This is the resolver's SSRF boundary:
-/// pnpr fetches only from operator-configured registries, so a caller cannot
-/// point it at cloud instance metadata, an internal service, or any other
-/// off-allowlist host. Runs before any server-side fetch.
-fn reject_off_allowlist_registries(
-    request: &ResolveRequest,
-    context: &RouteContext,
-) -> Option<Response> {
-    let mut registries: Vec<&str> = Vec::new();
-    if let Some(registry) = request.registry.as_deref() {
-        registries.push(registry);
-    }
-    registries.extend(request.named_registries.values().map(String::as_str));
-    let off = registries.into_iter().find(|registry| !context.allows_registry(registry))?;
-    Some(json_error(
-        StatusCode::FORBIDDEN,
-        &format!(
-            "registry {off:?} is not allowed by this pnpr server; the operator must declare it \
-             as a public route or an uplink",
-        ),
-    ))
-}
-
 fn reject_inline_url_auth(request: &ResolveRequest) -> Option<Response> {
     let mut specs: Vec<&str> = Vec::new();
     if let Some(registry) = request.registry.as_deref() {

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -158,16 +158,24 @@ impl Resolver {
         let _ = std::fs::create_dir_all(&store_dir);
         let _ = std::fs::create_dir_all(&cache_dir);
         let verdict_cache = VerdictCache::open(&cache_dir.join("lockfile-verdicts.sqlite")).ok();
+        let route_context = Arc::new(RouteContext::from_config(config));
+        // Re-validate every redirect hop against the same fetch allowlist the
+        // request boundary uses, so an allowlisted registry that redirects to
+        // an off-allowlist host cannot slip a server-side fetch past it (SSRF).
+        let redirect_context = Arc::clone(&route_context);
+        let client = Arc::new(ThrottledClient::new_for_installs_with_redirect_guard(move |url| {
+            redirect_context.allows_registry(url.as_str())
+        }));
         Resolver {
             store_dir: StoreDir::new(store_dir),
             cache_dir,
-            client: Arc::new(ThrottledClient::new_for_installs()),
+            client,
             resolution_cache: Arc::new(Mutex::new(HashMap::new())),
             resolution_cache_ttl: config.packument_ttl,
             configs: Mutex::new(HashMap::new()),
             verdict_cache,
             osv_index,
-            route_context: Arc::new(RouteContext::from_config(config)),
+            route_context,
             public_url: config.public_url.clone(),
             resolution_cache_secret: Arc::clone(&config.resolution_cache_secret),
         }

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -58,7 +58,7 @@ use crate::{
     config::Config as RegistryConfig,
     package_name::PackageName,
     policy::Identity,
-    route::{Footprint, RouteClass, RouteContext, RouteHook},
+    route::{Footprint, RouteClass, RouteContext, RouteHook, strip_url_credentials},
     upstream::tarball_basename,
 };
 
@@ -776,7 +776,12 @@ impl TarballRouter {
     fn route_registry_url(&self, package: &str, version: &str, tarball_url: &str) -> String {
         let registry = pick_registry_for_package(&self.registries, package, None);
         match self.context.classify(&self.identity, &registry, Some(package)) {
-            RouteClass::Public => tarball_url.to_string(),
+            // Strip any inline userinfo before emitting: a malicious or
+            // compromised allowlisted registry could embed `user:pass@host`
+            // credentials in its `dist.tarball`, and pnpr must never stream or
+            // cache those. A genuinely public tarball is anonymously fetchable,
+            // so the credential-free URL still works.
+            RouteClass::Public => strip_url_credentials(tarball_url),
             RouteClass::Hosted { .. } => pnpr_tarball_url(
                 &self.public_url,
                 package,
@@ -847,8 +852,10 @@ impl TarballRouter {
         match self.context.classify(&self.identity, tarball_url, Some(package)) {
             // A public route keeps its upstream URL: it was fetched
             // anonymously, so its tarball is anonymously fetchable and pnpr
-            // never mints a per-tarball gateway URL.
-            RouteClass::Public => tarball_url.to_string(),
+            // never mints a per-tarball gateway URL. Any inline userinfo a
+            // malicious/compromised registry embedded in `dist.tarball` is
+            // stripped first, so pnpr never streams or caches it.
+            RouteClass::Public => strip_url_credentials(tarball_url),
             RouteClass::Hosted { .. } => pnpr_tarball_url(
                 &self.public_url,
                 package,

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -1280,9 +1280,10 @@ fn merge_policies(
 
 /// Reject a request whose client-supplied URLs carry inline
 /// `user:pass@host` credentials, before any fetch or cache write. Covers
-/// the default and named registries, every dependency spec, and override
-/// values — the surfaces a tarball/registry URL can reach the resolver
-/// through. Returns a `400` response when one is found.
+/// the default and named registries, every dependency spec, override
+/// values, and the tarball URLs of an input lockfile — every surface a
+/// tarball/registry URL can reach the resolver (or be echoed back) through.
+/// Returns a `400` response when one is found.
 fn reject_inline_url_auth(request: &ResolveRequest) -> Option<Response> {
     let mut specs: Vec<&str> = Vec::new();
     if let Some(registry) = request.registry.as_deref() {
@@ -1295,6 +1296,17 @@ fn reject_inline_url_auth(request: &ResolveRequest) -> Option<Response> {
             [&project.dependencies, &project.dev_dependencies, &project.optional_dependencies]
         {
             specs.extend(map.values().map(String::as_str));
+        }
+    }
+    // A supplied lockfile can carry `resolution.tarball` URLs that reach the
+    // verify/frozen paths and would otherwise be routed or echoed back.
+    if let Some(packages) =
+        request.lockfile.as_ref().and_then(|lockfile| lockfile.packages.as_ref())
+    {
+        for package in packages.values() {
+            if let LockfileResolution::Tarball(resolution) = &package.resolution {
+                specs.push(resolution.tarball.as_str());
+            }
         }
     }
     let inline = specs.iter().any(|spec| crate::route::url_has_inline_credentials(spec))

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -58,7 +58,10 @@ use crate::{
     config::Config as RegistryConfig,
     package_name::PackageName,
     policy::Identity,
-    route::{Footprint, RouteClass, RouteContext, RouteHook, strip_url_credentials},
+    route::{
+        Footprint, RouteClass, RouteContext, RouteHook, sanitize_registry_tarball_url,
+        strip_url_credentials,
+    },
     upstream::tarball_basename,
 };
 
@@ -776,12 +779,12 @@ impl TarballRouter {
     fn route_registry_url(&self, package: &str, version: &str, tarball_url: &str) -> String {
         let registry = pick_registry_for_package(&self.registries, package, None);
         match self.context.classify(&self.identity, &registry, Some(package)) {
-            // Strip any inline userinfo before emitting: a malicious or
-            // compromised allowlisted registry could embed `user:pass@host`
-            // credentials in its `dist.tarball`, and pnpr must never stream or
-            // cache those. A genuinely public tarball is anonymously fetchable,
-            // so the credential-free URL still works.
-            RouteClass::Public => strip_url_credentials(tarball_url),
+            // The `dist.tarball` is untrusted upstream metadata, so sanitize it
+            // before emitting/caching: drop inline `user:pass@host` userinfo and
+            // any query/fragment a registry could use to carry a signed-URL
+            // token. A genuinely public tarball is anonymously fetchable, so the
+            // sanitized URL still works.
+            RouteClass::Public => sanitize_registry_tarball_url(tarball_url),
             RouteClass::Hosted { .. } => pnpr_tarball_url(
                 &self.public_url,
                 package,

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -122,7 +122,7 @@ pub(crate) struct Resolver {
     /// uplink credentials, hosted origin, package policy), resolved once
     /// from the server config and combined per request with the caller's
     /// identity to drive auth selection and footprint recording.
-    route_context: RouteContext,
+    route_context: Arc<RouteContext>,
     /// Public URL clients use for pnpr-hosted and `/~<uplink>/` endpoint
     /// tarball URLs.
     public_url: String,
@@ -167,7 +167,7 @@ impl Resolver {
             configs: Mutex::new(HashMap::new()),
             verdict_cache,
             osv_index,
-            route_context: RouteContext::from_config(config),
+            route_context: Arc::new(RouteContext::from_config(config)),
             public_url: config.public_url.clone(),
             resolution_cache_secret: Arc::clone(&config.resolution_cache_secret),
         }
@@ -186,7 +186,7 @@ impl Resolver {
         footprint: &Arc<Mutex<Footprint>>,
     ) -> Arc<AuthHeaders> {
         let hook: Arc<dyn UpstreamRouteHook> = Arc::new(RouteHook::new(
-            self.route_context.clone(),
+            Arc::clone(&self.route_context),
             identity.clone(),
             Arc::clone(footprint),
             Arc::clone(&self.resolution_cache_secret),
@@ -363,7 +363,7 @@ pub(crate) async fn handle_resolve(
     let footprint = Arc::new(Mutex::new(Footprint::default()));
     let request_auth = runtime.hooked_auth(&request, &identity, &footprint);
     let tarball_router = TarballRouter::new(
-        runtime.route_context.clone(),
+        Arc::clone(&runtime.route_context),
         identity.clone(),
         runtime.public_url.clone(),
     );
@@ -526,7 +526,7 @@ pub(crate) async fn handle_verify_lockfile(
     let footprint = Arc::new(Mutex::new(Footprint::default()));
     let request_auth = runtime.hooked_auth(&request, &identity, &footprint);
     let tarball_router = TarballRouter::new(
-        runtime.route_context.clone(),
+        Arc::clone(&runtime.route_context),
         identity.clone(),
         runtime.public_url.clone(),
     );
@@ -729,13 +729,13 @@ fn resolution_cache_key(config: &PacquetConfig, request: &ResolveRequest) -> Opt
 
 #[derive(Clone)]
 struct TarballRouter {
-    context: RouteContext,
+    context: Arc<RouteContext>,
     identity: Identity,
     public_url: String,
 }
 
 impl TarballRouter {
-    fn new(context: RouteContext, identity: Identity, public_url: String) -> Self {
+    fn new(context: Arc<RouteContext>, identity: Identity, public_url: String) -> Self {
         Self { context, identity, public_url }
     }
 

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -102,7 +102,7 @@ pub(crate) struct Resolver {
     /// Held behind an [`Arc`] so the detached streaming-resolve task can
     /// own a clone and record its result after the response body has
     /// already started flowing to the client.
-    resolution_cache: Arc<Mutex<HashMap<String, CachedResolution>>>,
+    resolution_cache: Arc<Mutex<HashMap<String, Vec<CachedResolution>>>>,
     resolution_cache_ttl: Duration,
     /// One leaked `Config` per distinct client registry configuration,
     /// keyed by its canonical JSON. Capped at [`MAX_INTERNED_CONFIGS`] so a
@@ -128,6 +128,9 @@ pub(crate) struct Resolver {
 struct CachedResolution {
     lockfile: Lockfile,
     inserted: Instant,
+    last_used: Instant,
+    footprint: Footprint,
+    descriptor_digest: Option<String>,
 }
 
 impl Resolver {
@@ -393,17 +396,18 @@ pub(crate) async fn handle_resolve(
         frames.push(done_frame(&lockfile));
         return ndjson_frames(&frames);
     }
-    // A no-lockfile resolve is keyed by its inputs (auth excluded). The
-    // entry is written only if the resolution turns out fully public
-    // (empty private footprint), so an authenticated caller's public
-    // install now populates and reuses the shared cache — while a private
-    // resolution is never stored under this auth-excluded key. Keying
-    // private resolutions by their access descriptor is Part 2.
-    let resolution_cache_key =
-        if request.lockfile.is_none() { resolution_cache_key(config, &request) } else { None };
+    // The base key is auth-excluded and shared by every candidate for the
+    // same resolution inputs. Candidate footprints decide which callers
+    // may reuse a stored lockfile.
+    let resolution_cache_key = resolution_cache_key(config, &request);
     if let Some(key) = resolution_cache_key.as_ref()
-        && let Some(lockfile) =
-            cached_resolution(&runtime.resolution_cache, runtime.resolution_cache_ttl, key)
+        && let Some(lockfile) = cached_resolution(
+            &runtime.resolution_cache,
+            runtime.resolution_cache_ttl,
+            key,
+            &runtime.route_context,
+            &identity,
+        )
     {
         // The OSV index is immutable for this resolver instance and a lockfile
         // is only stored after passing the OSV check, so a cache hit is already
@@ -436,23 +440,23 @@ pub(crate) async fn handle_resolve(
                         return;
                     }
                 }
-                // Only a fully-public resolution is safe to share under the
-                // auth-excluded key. A private footprint means the lockfile
-                // carries private versions/URLs that must not be served to a
-                // different caller, so it is left uncached here (Part 2 keys
-                // such entries by their private access descriptor instead).
-                {
-                    let footprint = footprint_for_store.lock().expect("footprint poisoned");
-                    if footprint.is_public() {
-                        if let Some(key) = resolution_cache_key {
-                            store_resolution(&cache, cache_ttl, key, &lockfile);
-                        }
-                    } else {
+                if let Some(key) = resolution_cache_key {
+                    let footprint = footprint_for_store.lock().expect("footprint poisoned").clone();
+                    let descriptor = footprint.digest(&cache_secret);
+                    let cached = store_resolution(
+                        &cache,
+                        cache_ttl,
+                        key,
+                        footprint.clone(),
+                        &cache_secret,
+                        &lockfile,
+                    );
+                    if !footprint.is_public() {
                         tracing::debug!(
                             shareable = footprint.is_shareable(),
-                            descriptor =
-                                footprint.digest(&cache_secret).as_deref().unwrap_or("none"),
-                            "private resolution not shared under the public cache key",
+                            cached,
+                            descriptor = descriptor.as_deref().unwrap_or("none"),
+                            "private resolution cache candidate evaluated",
                         );
                     }
                 }
@@ -516,46 +520,150 @@ pub(crate) async fn handle_verify_lockfile(
 }
 
 const MAX_RESOLUTION_CACHE_ENTRIES: usize = 1024;
+const MAX_RESOLUTION_CACHE_CANDIDATES_PER_KEY: usize = 8;
 
 fn cached_resolution(
-    cache: &Mutex<HashMap<String, CachedResolution>>,
+    cache: &Mutex<HashMap<String, Vec<CachedResolution>>>,
     ttl: Duration,
     key: &str,
+    route_context: &RouteContext,
+    identity: &Identity,
 ) -> Option<Lockfile> {
     if ttl.is_zero() {
         return None;
     }
     let mut cache = cache.lock().expect("resolution cache poisoned");
-    match cache.get(key) {
-        Some(cached) if cached.inserted.elapsed() <= ttl => Some(cached.lockfile.clone()),
-        Some(_) => {
+    let candidates = cache.get_mut(key)?;
+    candidates.retain(|candidate| candidate.inserted.elapsed() <= ttl);
+    let Some((candidate_index, _)) = candidates.iter().enumerate().find(|(_, candidate)| {
+        candidate.footprint.is_public() || candidate.footprint.allows(route_context, identity)
+    }) else {
+        if candidates.is_empty() {
             cache.remove(key);
-            None
         }
-        None => None,
-    }
+        return None;
+    };
+    let candidate = &mut candidates[candidate_index];
+    candidate.last_used = Instant::now();
+    Some(candidate.lockfile.clone())
 }
 
 fn store_resolution(
-    cache: &Mutex<HashMap<String, CachedResolution>>,
+    cache: &Mutex<HashMap<String, Vec<CachedResolution>>>,
     ttl: Duration,
     key: String,
+    footprint: Footprint,
+    secret: &[u8],
     lockfile: &Lockfile,
+) -> bool {
+    if ttl.is_zero() || !footprint.is_shareable() {
+        return false;
+    }
+    let now = Instant::now();
+    let descriptor_digest = footprint.digest(secret);
+    let candidate = CachedResolution {
+        lockfile: lockfile.clone(),
+        inserted: now,
+        last_used: now,
+        footprint,
+        descriptor_digest,
+    };
+    let mut cache = cache.lock().expect("resolution cache poisoned");
+    prune_expired_resolution_cache(&mut cache, ttl);
+    let candidates = cache.entry(key).or_default();
+    if let Some(existing) =
+        candidates.iter_mut().find(|entry| entry.descriptor_digest == candidate.descriptor_digest)
+    {
+        *existing = candidate;
+        return true;
+    }
+    candidates.push(candidate);
+    enforce_candidate_limit(candidates);
+    while count_resolution_candidates(&cache) > MAX_RESOLUTION_CACHE_ENTRIES {
+        if !evict_lru_resolution_candidate(&mut cache, true) {
+            break;
+        }
+    }
+    true
+}
+
+fn prune_expired_resolution_cache(
+    cache: &mut HashMap<String, Vec<CachedResolution>>,
+    ttl: Duration,
 ) {
-    if ttl.is_zero() {
+    cache.retain(|_, candidates| {
+        candidates.retain(|candidate| candidate.inserted.elapsed() <= ttl);
+        !candidates.is_empty()
+    });
+}
+
+fn enforce_candidate_limit(candidates: &mut Vec<CachedResolution>) {
+    while candidates.len() > MAX_RESOLUTION_CACHE_CANDIDATES_PER_KEY {
+        evict_lru_candidate(candidates, true);
+    }
+}
+
+fn evict_lru_candidate(candidates: &mut Vec<CachedResolution>, private_first: bool) {
+    if private_first
+        && let Some(index) = candidates
+            .iter()
+            .enumerate()
+            .filter(|(_, candidate)| !candidate.footprint.is_public())
+            .min_by_key(|(_, candidate)| candidate.last_used)
+            .map(|(index, _)| index)
+    {
+        candidates.remove(index);
         return;
     }
-    let mut cache = cache.lock().expect("resolution cache poisoned");
-    if cache.len() >= MAX_RESOLUTION_CACHE_ENTRIES {
-        cache.retain(|_, cached| cached.inserted.elapsed() <= ttl);
-    }
-    if cache.len() >= MAX_RESOLUTION_CACHE_ENTRIES
-        && let Some(oldest) =
-            cache.iter().min_by_key(|(_, cached)| cached.inserted).map(|(key, _)| key.clone())
+    if let Some(index) = candidates
+        .iter()
+        .enumerate()
+        .min_by_key(|(_, candidate)| candidate.last_used)
+        .map(|(index, _)| index)
     {
-        cache.remove(&oldest);
+        candidates.remove(index);
     }
-    cache.insert(key, CachedResolution { lockfile: lockfile.clone(), inserted: Instant::now() });
+}
+
+fn count_resolution_candidates(cache: &HashMap<String, Vec<CachedResolution>>) -> usize {
+    cache.values().map(Vec::len).sum()
+}
+
+fn evict_lru_resolution_candidate(
+    cache: &mut HashMap<String, Vec<CachedResolution>>,
+    private_first: bool,
+) -> bool {
+    let target = lru_resolution_candidate(cache, private_first)
+        .or_else(|| if private_first { lru_resolution_candidate(cache, false) } else { None });
+    let Some((key, index, _)) = target else {
+        return false;
+    };
+    if let Some(candidates) = cache.get_mut(&key)
+        && index < candidates.len()
+    {
+        candidates.remove(index);
+    }
+    if cache.get(&key).is_some_and(Vec::is_empty) {
+        cache.remove(&key);
+    }
+    true
+}
+
+fn lru_resolution_candidate(
+    cache: &HashMap<String, Vec<CachedResolution>>,
+    private_only: bool,
+) -> Option<(String, usize, Instant)> {
+    cache
+        .iter()
+        .filter_map(|(key, candidates)| {
+            candidates
+                .iter()
+                .enumerate()
+                .filter(|(_, candidate)| !private_only || !candidate.footprint.is_public())
+                .min_by_key(|(_, candidate)| candidate.last_used)
+                .map(|(index, candidate)| (key.clone(), index, candidate.last_used))
+        })
+        .min_by_key(|(_, _, last_used)| *last_used)
 }
 
 fn resolution_cache_key(config: &PacquetConfig, request: &ResolveRequest) -> Option<String> {
@@ -576,7 +684,7 @@ fn resolution_cache_key(config: &PacquetConfig, request: &ResolveRequest) -> Opt
         "namedRegistries": &request.named_registries,
         "overrides": &request.overrides,
         "projects": projects,
-        "lockfile": &request.lockfile,
+        "inputLockfileHash": request.lockfile.as_ref().map(hash_lockfile),
         "frozenLockfile": request.frozen_lockfile,
         "preferFrozenLockfile": request.prefer_frozen_lockfile,
         "ignoreManifestCheck": request.ignore_manifest_check,

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -54,9 +54,11 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::config::Config as RegistryConfig;
-use crate::policy::Identity;
-use crate::route::{Footprint, RouteContext, RouteHook};
+use crate::{
+    config::Config as RegistryConfig,
+    policy::Identity,
+    route::{Footprint, RouteContext, RouteHook},
+};
 
 use axum::{
     body::{Body, Bytes},

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -220,6 +220,7 @@ impl Resolver {
             self.route_context.clone(),
             identity.clone(),
             Arc::clone(footprint),
+            Arc::clone(&self.resolution_cache_secret),
         ));
         Arc::new(AuthHeaders::from_by_scope(request.auth_headers.clone()).with_route_hook(hook))
     }

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -71,6 +71,7 @@ use indexmap::IndexMap;
 use pacquet_config::Config as PacquetConfig;
 use pacquet_lockfile::{
     Lockfile, LockfileResolution, TarballResolution, is_git_hosted_tarball_url,
+    pick_registry_for_package,
 };
 use pacquet_lockfile_verification::{collect_resolution_policy_violations, hash_lockfile};
 use pacquet_network::{AuthHeaders, ThrottledClient, UpstreamRouteHook};
@@ -378,6 +379,7 @@ pub(crate) async fn handle_resolve(
         Arc::clone(&runtime.route_context),
         identity.clone(),
         runtime.public_url.clone(),
+        config.resolved_registries().into_iter().collect(),
     );
 
     // Verify the *input* lockfile under the client's policy before any
@@ -544,6 +546,7 @@ pub(crate) async fn handle_verify_lockfile(
         Arc::clone(&runtime.route_context),
         identity.clone(),
         runtime.public_url.clone(),
+        config.resolved_registries().into_iter().collect(),
     );
     let input_lockfile = tarball_router.verification_lockfile(input_lockfile);
 
@@ -747,11 +750,45 @@ struct TarballRouter {
     context: Arc<RouteContext>,
     identity: Identity,
     public_url: String,
+    /// Per-scope registry map (`scope -> registry URL`, plus the default) used
+    /// to classify a registry-resolved package by its *registry* route rather
+    /// than its `dist.tarball` host. See [`Self::route_registry_url`].
+    registries: HashMap<String, String>,
 }
 
 impl TarballRouter {
-    fn new(context: Arc<RouteContext>, identity: Identity, public_url: String) -> Self {
-        Self { context, identity, public_url }
+    fn new(
+        context: Arc<RouteContext>,
+        identity: Identity,
+        public_url: String,
+        registries: HashMap<String, String>,
+    ) -> Self {
+        Self { context, identity, public_url, registries }
+    }
+
+    /// Route a registry-resolved package's tarball by the **registry** it came
+    /// from, not its `dist.tarball` URL. A split-domain registry serves the
+    /// tarball from a different host than the packument, so classifying by the
+    /// tarball URL would misread a private package as public and leak its raw
+    /// upstream URL. Classifying by the registry origin keeps a private
+    /// package on its `/~<uplink>/` endpoint; a public one still emits its real
+    /// (anonymously fetchable) tarball URL for a direct CDN download.
+    fn route_registry_url(&self, package: &str, version: &str, tarball_url: &str) -> String {
+        let registry = pick_registry_for_package(&self.registries, package, None);
+        match self.context.classify(&self.identity, &registry, Some(package)) {
+            RouteClass::Public => tarball_url.to_string(),
+            RouteClass::Hosted { .. } => pnpr_tarball_url(
+                &self.public_url,
+                package,
+                &tarball_filename(package, version, tarball_url),
+            ),
+            RouteClass::Proxied { alias, .. } => uplink_endpoint_tarball_url(
+                &self.public_url,
+                &alias,
+                package,
+                &tarball_filename(package, version, tarball_url),
+            ),
+        }
     }
 
     fn route_lockfile(&self, config: &PacquetConfig, lockfile: &Lockfile) -> Lockfile {
@@ -902,7 +939,15 @@ impl pacquet_package_manager::ResolutionObserver for StreamObserver {
 /// when the registry never published a `dist.unpackedSize`, so older
 /// clients parse the frame unchanged.
 fn package_frame(router: &TarballRouter, hint: &ResolvedPackageHint<'_>) -> serde_json::Value {
-    let tarball_url = router.route_url(hint.name, hint.version, hint.tarball_url);
+    // A registry-resolved package's `tarball_url` is the packument's
+    // `dist.tarball`, which a split-domain registry hosts on a different origin
+    // — route it by the registry, not the tarball host, so a private package
+    // never leaks its raw upstream URL. Direct tarball deps keep their own URL.
+    let tarball_url = if hint.from_registry {
+        router.route_registry_url(hint.name, hint.version, hint.tarball_url)
+    } else {
+        router.route_url(hint.name, hint.version, hint.tarball_url)
+    };
     let mut frame = serde_json::json!({
         "type": "package",
         "id": hint.id,
@@ -975,6 +1020,10 @@ fn frozen_package_frames(
                 tarball_url: &tarball_url,
                 unpacked_size: stats.and_then(|stats| stats.unpacked_size),
                 file_count: stats.and_then(|stats| stats.file_count),
+                // The URL is already routed (canonical → endpoint above), so
+                // re-routing by registry would be redundant; route_url is a
+                // no-op on an already-routed URL.
+                from_registry: false,
             },
         );
         if let Ok(line) = ndjson_line(&frame) {

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -22,10 +22,10 @@
 //!   can start local fetch/materialization immediately and only use this
 //!   endpoint as the trust verdict.
 //!
-//! pnpr is a stateless resolver: it stores no tarballs and serves no file
-//! content. The client fetches every tarball directly from the registry
-//! with its own credentials, so the registry enforces access on the
-//! bytes; pnpr only shapes the lockfile.
+//! pnpr is a stateless resolver: it stores no tarballs. Public tarballs
+//! can still be fetched directly from their upstream registry, while
+//! private or unknown routes are rewritten to pnpr's read-only tarball
+//! gateway so upstream URLs and credentials stay server-side.
 //!
 //! The client's `registry`, `namedRegistries`, `overrides`, and the
 //! verification policy (`minimumReleaseAge`, `trustPolicy`, ...) drive
@@ -56,8 +56,10 @@ use std::{
 
 use crate::{
     config::Config as RegistryConfig,
+    package_name::PackageName,
     policy::Identity,
-    route::{Footprint, RouteContext, RouteHook},
+    route::{Footprint, RouteClass, RouteContext, RouteHook},
+    upstream::tarball_basename,
 };
 
 use axum::{
@@ -67,7 +69,9 @@ use axum::{
 };
 use indexmap::IndexMap;
 use pacquet_config::Config as PacquetConfig;
-use pacquet_lockfile::{Lockfile, LockfileResolution, is_git_hosted_tarball_url};
+use pacquet_lockfile::{
+    Lockfile, LockfileResolution, TarballResolution, is_git_hosted_tarball_url,
+};
 use pacquet_lockfile_verification::{collect_resolution_policy_violations, hash_lockfile};
 use pacquet_network::{AuthHeaders, ThrottledClient, UpstreamRouteHook};
 use pacquet_package_manager::{
@@ -83,6 +87,30 @@ use sha2::{Digest, Sha256};
 pub(crate) use self::osv::{OsvIndex, format_advisory_ids, load_osv_index};
 
 use self::{protocol::ResolveRequest, verdict_cache::VerdictCache};
+
+#[derive(Default, Clone)]
+pub(crate) struct TarballGatewayRoutes {
+    routes: Arc<Mutex<HashMap<String, String>>>,
+}
+
+impl TarballGatewayRoutes {
+    pub(crate) fn insert(&self, key: String, url: String) {
+        let mut routes = self.routes.lock().expect("tarball gateway routes poisoned");
+        if routes.len() >= MAX_TARBALL_GATEWAY_ROUTES
+            && !routes.contains_key(&key)
+            && let Some(evicted) = routes.keys().next().cloned()
+        {
+            routes.remove(&evicted);
+        }
+        routes.insert(key, url);
+    }
+
+    pub(crate) fn get(&self, key: &str) -> Option<String> {
+        self.routes.lock().expect("tarball gateway routes poisoned").get(key).cloned()
+    }
+}
+
+const MAX_TARBALL_GATEWAY_ROUTES: usize = 8192;
 
 /// Per-server engine backing the pnpr install endpoint: it holds the
 /// store, cache, and HTTP client used to resolve a client's project. The
@@ -119,10 +147,14 @@ pub(crate) struct Resolver {
     /// from the server config and combined per request with the caller's
     /// identity to drive auth selection and footprint recording.
     route_context: RouteContext,
+    /// Public URL clients use for pnpr-hosted and resolver-gateway tarball
+    /// URLs.
+    public_url: String,
     /// HMAC secret namespacing a private footprint's cache descriptor.
     /// Part 1 uses it only to label each resolve's cache class in the
     /// operator debug log; Part 2 keys private cache entries by it.
     resolution_cache_secret: Arc<[u8]>,
+    tarball_gateway_routes: TarballGatewayRoutes,
 }
 
 struct CachedResolution {
@@ -138,11 +170,16 @@ impl Resolver {
         cell: &'a OnceLock<Resolver>,
         config: &RegistryConfig,
         osv_index: Option<Arc<OsvIndex>>,
+        tarball_gateway_routes: TarballGatewayRoutes,
     ) -> &'a Resolver {
-        cell.get_or_init(|| Resolver::build(config, osv_index))
+        cell.get_or_init(|| Resolver::build(config, osv_index, tarball_gateway_routes))
     }
 
-    fn build(config: &RegistryConfig, osv_index: Option<Arc<OsvIndex>>) -> Resolver {
+    fn build(
+        config: &RegistryConfig,
+        osv_index: Option<Arc<OsvIndex>>,
+        tarball_gateway_routes: TarballGatewayRoutes,
+    ) -> Resolver {
         let store_dir = config.cache_storage.join("pnpr-store");
         let cache_dir = config.cache_storage.join("pnpr-cache");
         // Best-effort: a real failure here (e.g. a permission problem)
@@ -161,7 +198,9 @@ impl Resolver {
             verdict_cache,
             osv_index,
             route_context: RouteContext::from_config(config),
+            public_url: config.public_url.clone(),
             resolution_cache_secret: Arc::clone(&config.resolution_cache_secret),
+            tarball_gateway_routes,
         }
     }
 
@@ -324,8 +363,8 @@ fn intern_config(
 /// lockfile + stats, `error` if resolution aborts mid-stream, or
 /// `violations` if the input lockfile failed the client's policy. The
 /// short-circuit paths (frozen reuse, cache hit) emit only the terminal
-/// `done` frame. No tarball leaves the server — the client fetches them
-/// itself.
+/// `done` frame. Private or unknown tarballs are announced through
+/// pnpr's read-only gateway rather than their upstream URLs.
 pub(crate) async fn handle_resolve(
     runtime: &Resolver,
     identity: Identity,
@@ -353,6 +392,13 @@ pub(crate) async fn handle_resolve(
     // then decides whether the resolution may populate the shared cache.
     let footprint = Arc::new(Mutex::new(Footprint::default()));
     let request_auth = runtime.hooked_auth(&request, &identity, &footprint);
+    let tarball_router = TarballRouter::new(
+        runtime.route_context.clone(),
+        identity.clone(),
+        runtime.public_url.clone(),
+        Arc::clone(&runtime.resolution_cache_secret),
+        runtime.tarball_gateway_routes.clone(),
+    );
 
     // Verify the *input* lockfile under the client's policy before any
     // package is streamed ([pnpm/pnpm#12139](https://github.com/pnpm/pnpm/issues/12139)).
@@ -367,7 +413,8 @@ pub(crate) async fn handle_resolve(
     if !request.trust_lockfile
         && let Some(input_lockfile) = request.lockfile.as_ref()
     {
-        match verify_input_lockfile(runtime, config, &request_auth, input_lockfile).await {
+        let input_lockfile = tarball_router.verification_lockfile(input_lockfile);
+        match verify_input_lockfile(runtime, config, &request_auth, &input_lockfile).await {
             Ok(stats) => verified_dist_stats = stats,
             Err(VerifyFailure::Internal(response)) => return response,
             Err(VerifyFailure::Violations(violations)) => {
@@ -384,6 +431,8 @@ pub(crate) async fn handle_resolve(
     // fetched, so there's nothing to add and the response is the bare
     // `done` frame.
     if let Some(lockfile) = resolve::fresh_frozen_input_lockfile(config, &request) {
+        let lockfile = tarball_router.verification_lockfile(&lockfile);
+        let lockfile = tarball_router.route_lockfile(config, &lockfile);
         if let Some(osv_index) = runtime.osv_index.as_ref() {
             let violations = osv_violations_for_lockfile(osv_index, &lockfile);
             if !violations.is_empty() {
@@ -391,7 +440,7 @@ pub(crate) async fn handle_resolve(
             }
         }
         let mut frames = verified_dist_stats
-            .map(|sizes| frozen_package_frames(config, &lockfile, &sizes))
+            .map(|sizes| frozen_package_frames(config, &tarball_router, &lockfile, &sizes))
             .unwrap_or_default();
         frames.push(done_frame(&lockfile));
         return ndjson_frames(&frames);
@@ -423,6 +472,7 @@ pub(crate) async fn handle_resolve(
     let observer: Arc<dyn pacquet_package_manager::ResolutionObserver> = Arc::new(StreamObserver {
         tx: tx.clone(),
         package_version_guard: package_version_guard.clone(),
+        tarball_router: tarball_router.clone(),
     });
     let client = Arc::clone(&runtime.client);
     let cache = Arc::clone(&runtime.resolution_cache);
@@ -433,6 +483,7 @@ pub(crate) async fn handle_resolve(
     tokio::spawn(async move {
         match resolve::resolve(config, &client, &request, &request_auth, Some(observer)).await {
             Ok(lockfile) => {
+                let lockfile = tarball_router.route_lockfile(config, &lockfile);
                 if let Some(osv_index) = final_osv_index.as_ref() {
                     let violations = osv_violations_for_lockfile(osv_index, &lockfile);
                     if !violations.is_empty() {
@@ -506,12 +557,20 @@ pub(crate) async fn handle_verify_lockfile(
     // populate a cache scope a resolve wouldn't.
     let footprint = Arc::new(Mutex::new(Footprint::default()));
     let request_auth = runtime.hooked_auth(&request, &identity, &footprint);
+    let tarball_router = TarballRouter::new(
+        runtime.route_context.clone(),
+        identity.clone(),
+        runtime.public_url.clone(),
+        Arc::clone(&runtime.resolution_cache_secret),
+        runtime.tarball_gateway_routes.clone(),
+    );
+    let input_lockfile = tarball_router.verification_lockfile(input_lockfile);
 
-    match verify_input_lockfile(runtime, config, &request_auth, input_lockfile).await {
+    match verify_input_lockfile(runtime, config, &request_auth, &input_lockfile).await {
         // The dist stats the verifier observed feed `/-/pnpr/v0/resolve`'s sized
         // `package` frames; this endpoint's client prefetches from its own
         // lockfile before the verdict arrives, so only the verdict is sent.
-        Ok(_) => verify_done_or_osv_violations(runtime.osv_index.as_ref(), input_lockfile),
+        Ok(_) => verify_done_or_osv_violations(runtime.osv_index.as_ref(), &input_lockfile),
         Err(VerifyFailure::Internal(response)) => response,
         Err(VerifyFailure::Violations(violations)) => {
             ndjson_single_frame(&violations_frame(&violations))
@@ -702,6 +761,256 @@ fn resolution_cache_key(config: &PacquetConfig, request: &ResolveRequest) -> Opt
     Some(format!("{:x}", hasher.finalize()))
 }
 
+#[derive(Clone)]
+struct TarballRouter {
+    context: RouteContext,
+    identity: Identity,
+    public_url: String,
+    secret: Arc<[u8]>,
+    gateway_routes: TarballGatewayRoutes,
+}
+
+impl TarballRouter {
+    fn new(
+        context: RouteContext,
+        identity: Identity,
+        public_url: String,
+        secret: Arc<[u8]>,
+        gateway_routes: TarballGatewayRoutes,
+    ) -> Self {
+        Self { context, identity, public_url, secret, gateway_routes }
+    }
+
+    fn route_lockfile(&self, config: &PacquetConfig, lockfile: &Lockfile) -> Lockfile {
+        let mut routed = lockfile.clone();
+        let Some(packages) = routed.packages.as_mut() else {
+            return routed;
+        };
+        for (package_key, metadata) in packages {
+            if !matches!(
+                metadata.resolution,
+                LockfileResolution::Registry(_) | LockfileResolution::Tarball(_),
+            ) {
+                continue;
+            }
+            let Ok((tarball_url, integrity)) =
+                tarball_url_and_integrity(&metadata.resolution, package_key, config)
+            else {
+                continue;
+            };
+            if !is_http_tarball_url(&tarball_url) || is_git_hosted_tarball_url(&tarball_url) {
+                continue;
+            }
+            let name = package_key.name.to_string();
+            let version = package_key.suffix.version().to_string();
+            let routed_url = self.route_url(&name, &version, &tarball_url);
+            if routed_url == tarball_url.as_ref() {
+                continue;
+            }
+            metadata.resolution = LockfileResolution::Tarball(TarballResolution {
+                tarball: routed_url,
+                integrity: Some(integrity.clone()),
+                git_hosted: None,
+                path: None,
+            });
+        }
+        routed
+    }
+
+    fn verification_lockfile(&self, lockfile: &Lockfile) -> Lockfile {
+        let mut upstream = lockfile.clone();
+        let Some(packages) = upstream.packages.as_mut() else {
+            return upstream;
+        };
+        for (package_key, metadata) in packages {
+            let LockfileResolution::Tarball(resolution) = &mut metadata.resolution else {
+                continue;
+            };
+            if let Some(tarball_url) = self.upstream_alias_tarball_url(&resolution.tarball) {
+                resolution.tarball = tarball_url;
+            } else if let Some(tarball_url) = self
+                .upstream_unknown_tarball_url(&package_key.name.to_string(), &resolution.tarball)
+            {
+                resolution.tarball = tarball_url;
+            }
+        }
+        upstream
+    }
+
+    fn route_url(&self, package: &str, version: &str, tarball_url: &str) -> String {
+        if self.is_alias_gateway_url(tarball_url) {
+            return tarball_url.to_string();
+        }
+        match self.context.classify(&self.identity, tarball_url, Some(package)) {
+            RouteClass::Public => tarball_url.to_string(),
+            RouteClass::Hosted { .. } => pnpr_tarball_url(
+                &self.public_url,
+                package,
+                &tarball_filename(package, version, tarball_url),
+            ),
+            RouteClass::Proxied { alias, generation } => alias_gateway_tarball_url(
+                &self.public_url,
+                &alias,
+                generation,
+                package,
+                &tarball_filename(package, version, tarball_url),
+            ),
+            RouteClass::Unknown => {
+                let filename = tarball_filename(package, version, tarball_url);
+                let key = unknown_gateway_key(&self.secret, tarball_url);
+                self.gateway_routes.insert(key.clone(), tarball_url.to_string());
+                unknown_gateway_tarball_url(&self.public_url, &key, package, &filename)
+            }
+        }
+    }
+
+    fn is_alias_gateway_url(&self, tarball_url: &str) -> bool {
+        tarball_url.starts_with(&format!(
+            "{}/-/pnpr/v0/tarballs/alias/",
+            self.public_url.trim_end_matches('/'),
+        ))
+    }
+
+    fn upstream_alias_tarball_url(&self, tarball_url: &str) -> Option<String> {
+        let url = url::Url::parse(tarball_url).ok()?;
+        let route = url.path().strip_prefix("/-/pnpr/v0/tarballs/alias/")?;
+        let segments: Vec<_> = route.split('/').collect();
+        let [raw_alias, raw_generation, raw_package, "-", raw_filename] = segments.as_slice()
+        else {
+            return None;
+        };
+        let alias = percent_decode(raw_alias)?;
+        let generation = raw_generation.parse::<u64>().ok()?;
+        let package = percent_decode(raw_package)?;
+        let filename = percent_decode(raw_filename)?;
+        let alias_config =
+            self.context.gateway_alias(&self.identity, &alias, generation, &package)?;
+        Some(format!("{}/{}/-/{}", alias_config.registry.trim_end_matches('/'), package, filename))
+    }
+
+    fn upstream_unknown_tarball_url(
+        &self,
+        expected_package: &str,
+        tarball_url: &str,
+    ) -> Option<String> {
+        let url = url::Url::parse(tarball_url).ok()?;
+        let route = url.path().strip_prefix("/-/pnpr/v0/tarballs/unknown/")?;
+        let segments: Vec<_> = route.split('/').collect();
+        let [key, raw_package, "-", raw_filename] = segments.as_slice() else {
+            return None;
+        };
+        let package = percent_decode(raw_package)?;
+        if package != expected_package {
+            return None;
+        }
+        let _filename = percent_decode(raw_filename)?;
+        self.gateway_routes.get(key)
+    }
+}
+
+fn tarball_filename(package: &str, version: &str, tarball_url: &str) -> String {
+    tarball_basename(tarball_url).map_or_else(
+        || {
+            PackageName::parse(package).map_or_else(
+                |_| format!("{package}-{version}.tgz"),
+                |name| name.tarball_name_for_version(version),
+            )
+        },
+        str::to_string,
+    )
+}
+
+fn pnpr_tarball_url(public_url: &str, package: &str, filename: &str) -> String {
+    format!("{}/{package}/-/{filename}", public_url.trim_end_matches('/'))
+}
+
+fn alias_gateway_tarball_url(
+    public_url: &str,
+    alias: &str,
+    generation: u64,
+    package: &str,
+    filename: &str,
+) -> String {
+    let base = format!("{}/", public_url.trim_end_matches('/'));
+    let Ok(mut url) = url::Url::parse(&base) else {
+        return pnpr_tarball_url(public_url, package, filename);
+    };
+    let generation = generation.to_string();
+    {
+        let Ok(mut segments) = url.path_segments_mut() else {
+            return pnpr_tarball_url(public_url, package, filename);
+        };
+        segments.extend([
+            "-",
+            "pnpr",
+            "v0",
+            "tarballs",
+            "alias",
+            alias,
+            generation.as_str(),
+            package,
+            "-",
+            filename,
+        ]);
+    }
+    url.to_string()
+}
+
+fn unknown_gateway_key(secret: &[u8], tarball_url: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"pnpr unknown tarball gateway route\0");
+    hasher.update(secret);
+    hasher.update(b"\0");
+    hasher.update(tarball_url.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn unknown_gateway_tarball_url(
+    public_url: &str,
+    key: &str,
+    package: &str,
+    filename: &str,
+) -> String {
+    let base = format!("{}/", public_url.trim_end_matches('/'));
+    let Ok(mut url) = url::Url::parse(&base) else {
+        return pnpr_tarball_url(public_url, package, filename);
+    };
+    {
+        let Ok(mut segments) = url.path_segments_mut() else {
+            return pnpr_tarball_url(public_url, package, filename);
+        };
+        segments.extend(["-", "pnpr", "v0", "tarballs", "unknown", key, package, "-", filename]);
+    }
+    url.to_string()
+}
+
+fn percent_decode(input: &str) -> Option<String> {
+    let bytes = input.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            let high = hex_value(*bytes.get(index + 1)?)?;
+            let low = hex_value(*bytes.get(index + 2)?)?;
+            decoded.push((high << 4) | low);
+            index += 3;
+        } else {
+            decoded.push(bytes[index]);
+            index += 1;
+        }
+    }
+    String::from_utf8(decoded).ok()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
 /// NDJSON content type for the `/-/pnpr/v0/resolve` response. One JSON object
 /// per line; the client parses frames as they arrive. Excluded from the
 /// server's gzip [`CompressionLayer`](crate::server) so frames flush to
@@ -716,11 +1025,12 @@ const NDJSON_CONTENT_TYPE: &str = "application/x-ndjson";
 struct StreamObserver {
     tx: tokio::sync::mpsc::UnboundedSender<Vec<u8>>,
     package_version_guard: Option<Arc<dyn PackageVersionGuard>>,
+    tarball_router: TarballRouter,
 }
 
 impl pacquet_package_manager::ResolutionObserver for StreamObserver {
     fn on_resolved(&self, hint: pacquet_package_manager::ResolvedPackageHint<'_>) {
-        if let Ok(line) = ndjson_line(&package_frame(&hint)) {
+        if let Ok(line) = ndjson_line(&package_frame(&self.tarball_router, &hint)) {
             let _ = self.tx.send(line);
         }
     }
@@ -733,14 +1043,15 @@ impl pacquet_package_manager::ResolutionObserver for StreamObserver {
 /// One `package` NDJSON frame. `unpackedSize` is omitted (not null)
 /// when the registry never published a `dist.unpackedSize`, so older
 /// clients parse the frame unchanged.
-fn package_frame(hint: &ResolvedPackageHint<'_>) -> serde_json::Value {
+fn package_frame(router: &TarballRouter, hint: &ResolvedPackageHint<'_>) -> serde_json::Value {
+    let tarball_url = router.route_url(hint.name, hint.version, hint.tarball_url);
     let mut frame = serde_json::json!({
         "type": "package",
         "id": hint.id,
         "name": hint.name,
         "version": hint.version,
         "integrity": hint.integrity,
-        "tarball": hint.tarball_url,
+        "tarball": tarball_url,
     });
     if let Some(size) = hint.unpacked_size {
         frame["unpackedSize"] = serde_json::Value::from(size);
@@ -766,6 +1077,7 @@ fn package_frame(hint: &ResolvedPackageHint<'_>) -> serde_json::Value {
 /// own protocol paths.
 fn frozen_package_frames(
     config: &PacquetConfig,
+    router: &TarballRouter,
     lockfile: &Lockfile,
     dist_stats: &ObservedDistStats,
 ) -> Vec<Vec<u8>> {
@@ -786,23 +1098,27 @@ fn frozen_package_frames(
         else {
             continue;
         };
-        if !seen_urls.insert(tarball_url.to_string()) {
-            continue;
-        }
         let name = package_key.name.to_string();
         let version = package_key.suffix.version().to_string();
+        let tarball_url = router.route_url(&name, &version, &tarball_url);
+        if !seen_urls.insert(tarball_url.clone()) {
+            continue;
+        }
         let id = format!("{name}@{version}");
         let integrity = integrity.to_string();
         let stats = dist_stats.get(&(name.clone(), version.clone())).map(|entry| *entry.value());
-        let frame = package_frame(&ResolvedPackageHint {
-            id: &id,
-            name: &name,
-            version: &version,
-            integrity: &integrity,
-            tarball_url: &tarball_url,
-            unpacked_size: stats.and_then(|stats| stats.unpacked_size),
-            file_count: stats.and_then(|stats| stats.file_count),
-        });
+        let frame = package_frame(
+            router,
+            &ResolvedPackageHint {
+                id: &id,
+                name: &name,
+                version: &version,
+                integrity: &integrity,
+                tarball_url: &tarball_url,
+                unpacked_size: stats.and_then(|stats| stats.unpacked_size),
+                file_count: stats.and_then(|stats| stats.file_count),
+            },
+        );
         if let Ok(line) = ndjson_line(&frame) {
             frames.push(line);
         }

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -52,6 +52,8 @@ use std::{
 };
 
 use crate::config::Config as RegistryConfig;
+use crate::policy::Identity;
+use crate::route::{Footprint, RouteContext, RouteHook};
 
 use axum::{
     body::{Body, Bytes},
@@ -62,7 +64,7 @@ use indexmap::IndexMap;
 use pacquet_config::Config as PacquetConfig;
 use pacquet_lockfile::{Lockfile, LockfileResolution, is_git_hosted_tarball_url};
 use pacquet_lockfile_verification::{collect_resolution_policy_violations, hash_lockfile};
-use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_network::{AuthHeaders, ThrottledClient, UpstreamRouteHook};
 use pacquet_package_manager::{
     ResolvedPackageHint, build_resolution_verifiers, tarball_url_and_integrity,
 };
@@ -107,6 +109,15 @@ pub(crate) struct Resolver {
     /// every time (uncached) rather than failing the server.
     verdict_cache: Option<VerdictCache>,
     osv_index: Option<Arc<OsvIndex>>,
+    /// Route-classification inputs (public/private rules, upstream
+    /// credential aliases, hosted origin, package policy), resolved once
+    /// from the server config and combined per request with the caller's
+    /// identity to drive auth selection and footprint recording.
+    route_context: RouteContext,
+    /// HMAC secret namespacing a private footprint's cache descriptor.
+    /// Part 1 uses it only to label each resolve's cache class in the
+    /// operator debug log; Part 2 keys private cache entries by it.
+    resolution_cache_secret: Arc<[u8]>,
 }
 
 struct CachedResolution {
@@ -141,7 +152,29 @@ impl Resolver {
             configs: Mutex::new(HashMap::new()),
             verdict_cache,
             osv_index,
+            route_context: RouteContext::from_config(config),
+            resolution_cache_secret: Arc::clone(&config.resolution_cache_secret),
         }
+    }
+
+    /// Build the request's [`AuthHeaders`] with the route hook installed:
+    /// every metadata/tarball fetch is classified against this server's
+    /// route policy for `identity`, the pnpr-managed credential (never the
+    /// client's) is selected, and the touched private routes accumulate in
+    /// `footprint`. The client's forwarded `auth_headers` are kept on the
+    /// value (so `to_by_scope` still reflects them) but no longer consulted.
+    fn hooked_auth(
+        &self,
+        request: &ResolveRequest,
+        identity: &Identity,
+        footprint: &Arc<Mutex<Footprint>>,
+    ) -> Arc<AuthHeaders> {
+        let hook: Arc<dyn UpstreamRouteHook> = Arc::new(RouteHook::new(
+            self.route_context.clone(),
+            identity.clone(),
+            Arc::clone(footprint),
+        ));
+        Arc::new(AuthHeaders::from_by_scope(request.auth_headers.clone()).with_route_hook(hook))
     }
 
     /// Resolve (or build + intern) the `&'static Config` for a request's
@@ -285,11 +318,19 @@ fn intern_config(
 /// short-circuit paths (frozen reuse, cache hit) emit only the terminal
 /// `done` frame. No tarball leaves the server — the client fetches them
 /// itself.
-pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response {
+pub(crate) async fn handle_resolve(
+    runtime: &Resolver,
+    identity: Identity,
+    body: Bytes,
+) -> Response {
     let request: ResolveRequest = match serde_json::from_slice(&body) {
         Ok(request) => request,
         Err(err) => return json_error(StatusCode::BAD_REQUEST, &err.to_string()),
     };
+
+    if let Some(response) = reject_inline_url_auth(&request) {
+        return response;
+    }
 
     // Resolve against the client's registries, not the server's own.
     let Some(config) = runtime.config_for(&request) else {
@@ -298,10 +339,12 @@ pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response 
     let package_version_guard =
         runtime.osv_index.as_ref().map(|index| Arc::clone(index) as Arc<dyn PackageVersionGuard>);
 
-    // The caller's forwarded upstream credentials, threaded through
-    // resolve/verify but kept out of the interned `config` so it never
-    // leaks a `&'static Config` per user.
-    let request_auth = Arc::new(AuthHeaders::from_by_scope(request.auth_headers.clone()));
+    // Auth is selected by this server's route policy for the caller, not
+    // forwarded from the client. Every metadata/tarball fetch the
+    // resolve+verify performs records its route into `footprint`, which
+    // then decides whether the resolution may populate the shared cache.
+    let footprint = Arc::new(Mutex::new(Footprint::default()));
+    let request_auth = runtime.hooked_auth(&request, &identity, &footprint);
 
     // Verify the *input* lockfile under the client's policy before any
     // package is streamed ([pnpm/pnpm#12139](https://github.com/pnpm/pnpm/issues/12139)).
@@ -345,11 +388,14 @@ pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response 
         frames.push(done_frame(&lockfile));
         return ndjson_frames(&frames);
     }
-    let resolution_cache_key = if request.auth_headers.is_empty() && request.lockfile.is_none() {
-        resolution_cache_key(config, &request)
-    } else {
-        None
-    };
+    // A no-lockfile resolve is keyed by its inputs (auth excluded). The
+    // entry is written only if the resolution turns out fully public
+    // (empty private footprint), so an authenticated caller's public
+    // install now populates and reuses the shared cache — while a private
+    // resolution is never stored under this auth-excluded key. Keying
+    // private resolutions by their access descriptor is Part 2.
+    let resolution_cache_key =
+        if request.lockfile.is_none() { resolution_cache_key(config, &request) } else { None };
     if let Some(key) = resolution_cache_key.as_ref()
         && let Some(lockfile) =
             cached_resolution(&runtime.resolution_cache, runtime.resolution_cache_ttl, key)
@@ -373,6 +419,8 @@ pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response 
     let cache = Arc::clone(&runtime.resolution_cache);
     let cache_ttl = runtime.resolution_cache_ttl;
     let final_osv_index = runtime.osv_index.clone();
+    let footprint_for_store = Arc::clone(&footprint);
+    let cache_secret = Arc::clone(&runtime.resolution_cache_secret);
     tokio::spawn(async move {
         match resolve::resolve(config, &client, &request, &request_auth, Some(observer)).await {
             Ok(lockfile) => {
@@ -383,8 +431,25 @@ pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response 
                         return;
                     }
                 }
-                if let Some(key) = resolution_cache_key {
-                    store_resolution(&cache, cache_ttl, key, &lockfile);
+                // Only a fully-public resolution is safe to share under the
+                // auth-excluded key. A private footprint means the lockfile
+                // carries private versions/URLs that must not be served to a
+                // different caller, so it is left uncached here (Part 2 keys
+                // such entries by their private access descriptor instead).
+                {
+                    let footprint = footprint_for_store.lock().expect("footprint poisoned");
+                    if footprint.is_public() {
+                        if let Some(key) = resolution_cache_key {
+                            store_resolution(&cache, cache_ttl, key, &lockfile);
+                        }
+                    } else {
+                        tracing::debug!(
+                            shareable = footprint.is_shareable(),
+                            descriptor =
+                                footprint.digest(&cache_secret).as_deref().unwrap_or("none"),
+                            "private resolution not shared under the public cache key",
+                        );
+                    }
                 }
                 let _ = tx.send(done_frame(&lockfile));
             }
@@ -401,11 +466,19 @@ pub(crate) async fn handle_resolve(runtime: &Resolver, body: Bytes) -> Response 
 /// verdict frame. The client already knows the lockfile is fresh for
 /// the current manifests, so this endpoint deliberately does not
 /// resolve or echo the lockfile back.
-pub(crate) async fn handle_verify_lockfile(runtime: &Resolver, body: Bytes) -> Response {
+pub(crate) async fn handle_verify_lockfile(
+    runtime: &Resolver,
+    identity: Identity,
+    body: Bytes,
+) -> Response {
     let request: ResolveRequest = match serde_json::from_slice(&body) {
         Ok(request) => request,
         Err(err) => return json_error(StatusCode::BAD_REQUEST, &err.to_string()),
     };
+
+    if let Some(response) = reject_inline_url_auth(&request) {
+        return response;
+    }
 
     let Some(input_lockfile) = request.lockfile.as_ref() else {
         return json_error(StatusCode::BAD_REQUEST, "`lockfile` is required");
@@ -418,7 +491,12 @@ pub(crate) async fn handle_verify_lockfile(runtime: &Resolver, body: Bytes) -> R
     let Some(config) = runtime.config_for(&request) else {
         return json_error(StatusCode::SERVICE_UNAVAILABLE, TOO_MANY_CONFIGS_MESSAGE);
     };
-    let request_auth = Arc::new(AuthHeaders::from_by_scope(request.auth_headers.clone()));
+    // Verifier packument fetches run under the same route hook, so they
+    // select the same pnpr-managed credentials and are recorded in the
+    // same footprint as a resolve would be — a verifier can't read or
+    // populate a cache scope a resolve wouldn't.
+    let footprint = Arc::new(Mutex::new(Footprint::default()));
+    let request_auth = runtime.hooked_auth(&request, &identity, &footprint);
 
     match verify_input_lockfile(runtime, config, &request_auth, input_lockfile).await {
         // The dist stats the verifier observed feed `/-/pnpr/v0/resolve`'s sized
@@ -925,6 +1003,47 @@ fn merge_policies(
         merged.extend(osv_index.policy());
     }
     merged
+}
+
+/// Reject a request whose client-supplied URLs carry inline
+/// `user:pass@host` credentials, before any fetch or cache write. Covers
+/// the default and named registries, every dependency spec, and override
+/// values — the surfaces a tarball/registry URL can reach the resolver
+/// through. Returns a `400` response when one is found.
+fn reject_inline_url_auth(request: &ResolveRequest) -> Option<Response> {
+    let mut specs: Vec<&str> = Vec::new();
+    if let Some(registry) = request.registry.as_deref() {
+        specs.push(registry);
+    }
+    specs.extend(request.named_registries.values().map(String::as_str));
+    let projects = request.projects_normalized();
+    for project in &projects {
+        for map in
+            [&project.dependencies, &project.dev_dependencies, &project.optional_dependencies]
+        {
+            specs.extend(map.values().map(String::as_str));
+        }
+    }
+    let inline = specs.iter().any(|spec| crate::route::url_has_inline_credentials(spec))
+        || request.overrides.as_ref().is_some_and(overrides_have_inline_url_auth);
+    inline.then(|| {
+        json_error(
+            StatusCode::BAD_REQUEST,
+            "inline URL credentials (user:pass@host) are not allowed; \
+             configure an upstream credential alias instead",
+        )
+    })
+}
+
+/// Recursively scan an `overrides` JSON value for any string leaf that is
+/// a URL carrying inline credentials.
+fn overrides_have_inline_url_auth(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::String(spec) => crate::route::url_has_inline_credentials(spec),
+        serde_json::Value::Array(items) => items.iter().any(overrides_have_inline_url_auth),
+        serde_json::Value::Object(map) => map.values().any(overrides_have_inline_url_auth),
+        _ => false,
+    }
 }
 
 fn json_error(status: StatusCode, message: &str) -> Response {

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -49,8 +49,8 @@ impl From<std::io::Error> for ResolveError {
 
 /// Resolve a request lockfile-only and return the produced lockfile.
 /// The store is intentionally left untouched (no tarball is fetched):
-/// tarball downloads happen later from upstream URLs or pnpr's read-only
-/// gateway.
+/// tarball downloads happen later from upstream URLs or an uplink's
+/// `/~<uplink>/` registry endpoint.
 ///
 /// A single-project request resolves one root (`.`) importer. A
 /// multi-project request is reconstructed as a real workspace in the

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -49,7 +49,8 @@ impl From<std::io::Error> for ResolveError {
 
 /// Resolve a request lockfile-only and return the produced lockfile.
 /// The store is intentionally left untouched (no tarball is fetched):
-/// pnpr serves no file content, so the client fetches every tarball.
+/// tarball downloads happen later from upstream URLs or pnpr's read-only
+/// gateway.
 ///
 /// A single-project request resolves one root (`.`) importer. A
 /// multi-project request is reconstructed as a real workspace in the

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -73,21 +73,30 @@ fn user(name: &str) -> Identity {
     Identity::user(name)
 }
 
-fn uplink_with_access(registry: &str, access: &str, generation: u64) -> UplinkConfig {
+/// The standard token test uplinks carry; the credential digest it produces is
+/// what [`private_alias_footprint`] records, so a footprint and an uplink built
+/// with it share a credential epoch.
+const ALIAS_TOKEN: &str = "Bearer alias-secret";
+
+fn uplink_with_access(registry: &str, access: &str) -> UplinkConfig {
+    uplink_with_token(registry, access, ALIAS_TOKEN)
+}
+
+fn uplink_with_token(registry: &str, access: &str, token: &'static str) -> UplinkConfig {
     let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert(
-        reqwest::header::AUTHORIZATION,
-        reqwest::header::HeaderValue::from_static("Bearer alias-secret"),
-    );
+    headers
+        .insert(reqwest::header::AUTHORIZATION, reqwest::header::HeaderValue::from_static(token));
     let mut uplink = UplinkConfig::with_defaults(registry.to_string(), headers);
     uplink.access = Some(AccessList::parse(access));
-    uplink.generation = generation;
     uplink
 }
 
-fn private_alias_footprint(alias: &str, generation: u64) -> Footprint {
+fn private_alias_footprint(alias: &str) -> Footprint {
     let mut footprint = Footprint::default();
-    footprint.add(PrivateAccessDescriptor::Alias { alias: alias.to_string(), generation });
+    footprint.add(PrivateAccessDescriptor::Alias {
+        alias: alias.to_string(),
+        credential_digest: crate::route::credential_digest(ALIAS_TOKEN),
+    });
     footprint
 }
 
@@ -279,7 +288,7 @@ fn private_cached_resolution_requires_current_alias_authorization() {
         &cache,
         Duration::from_mins(1),
         key.clone(),
-        private_alias_footprint("corp", 1),
+        private_alias_footprint("corp"),
         b"secret",
         &lockfile,
     ));
@@ -287,7 +296,7 @@ fn private_cached_resolution_requires_current_alias_authorization() {
     let mut config = registry_config();
     config
         .uplinks
-        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "alice", 1));
+        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "alice"));
     let context = RouteContext::from_config(&config);
     assert!(
         cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_some(),
@@ -296,9 +305,13 @@ fn private_cached_resolution_requires_current_alias_authorization() {
         cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("bob")).is_none(),
     );
 
-    config
-        .uplinks
-        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "alice", 2));
+    // Rotate the upstream credential (new token → new credential digest). The
+    // resolution cached under the old credential must no longer be reused, even
+    // for a still-authorized caller.
+    config.uplinks.insert(
+        "corp".to_string(),
+        uplink_with_token("https://npm.corp.example/", "alice", "Bearer rotated-secret"),
+    );
     let rotated = RouteContext::from_config(&config);
     assert!(
         cached_resolution(&cache, Duration::from_mins(1), &key, &rotated, &user("alice")).is_none(),
@@ -314,7 +327,7 @@ fn same_alias_authorized_users_share_private_resolution_cache() {
         &cache,
         Duration::from_mins(1),
         key.clone(),
-        private_alias_footprint("corp", 1),
+        private_alias_footprint("corp"),
         b"secret",
         &lockfile,
     ));
@@ -322,7 +335,7 @@ fn same_alias_authorized_users_share_private_resolution_cache() {
     let mut config = registry_config();
     config.uplinks.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated", 1),
+        uplink_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let context = RouteContext::from_config(&config);
 
@@ -347,7 +360,7 @@ fn revoked_alias_access_stops_matching_private_resolution_hits() {
         &cache,
         Duration::from_mins(1),
         key.clone(),
-        private_alias_footprint("corp", 1),
+        private_alias_footprint("corp"),
         b"secret",
         &lockfile,
     ));
@@ -355,7 +368,7 @@ fn revoked_alias_access_stops_matching_private_resolution_hits() {
     let mut config = registry_config();
     config
         .uplinks
-        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "alice", 1));
+        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "alice"));
     let context = RouteContext::from_config(&config);
     assert!(
         cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_some(),
@@ -363,7 +376,7 @@ fn revoked_alias_access_stops_matching_private_resolution_hits() {
 
     config
         .uplinks
-        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "bob", 1));
+        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "bob"));
     let context = RouteContext::from_config(&config);
     assert!(
         cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_none(),
@@ -428,7 +441,7 @@ fn private_alias_lockfile_routing_uses_gateway_url() {
     let mut registry = registry_config();
     registry.uplinks.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated", 7),
+        uplink_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let router = tarball_router(&registry, user("alice"));
 
@@ -451,7 +464,7 @@ fn private_alias_lockfile_routing_encodes_scoped_packages_as_one_gateway_segment
     let mut registry = registry_config();
     registry.uplinks.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated", 7),
+        uplink_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let router = tarball_router(&registry, user("alice"));
 
@@ -630,7 +643,7 @@ fn private_cached_resolution_keeps_routed_tarball_urls() {
     let mut registry = registry_config();
     registry
         .uplinks
-        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "alice", 7));
+        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "alice"));
     let router = tarball_router(&registry, user("alice"));
     let routed = router.route_lockfile(&pacquet_config, &lockfile("1.0.0"));
 
@@ -638,7 +651,7 @@ fn private_cached_resolution_keeps_routed_tarball_urls() {
         &cache,
         Duration::from_mins(1),
         key.clone(),
-        private_alias_footprint("corp", 7),
+        private_alias_footprint("corp"),
         b"secret",
         &routed,
     ));
@@ -674,7 +687,7 @@ fn candidate_lists_stay_bounded_and_keep_public_entries() {
             &cache,
             Duration::from_mins(1),
             key.clone(),
-            private_alias_footprint(&format!("corp-{index}"), 1),
+            private_alias_footprint(&format!("corp-{index}")),
             b"secret",
             &lockfile,
         ));
@@ -730,7 +743,7 @@ fn package_frames_route_private_alias_tarballs_to_gateway() {
     let mut registry = registry_config();
     registry.uplinks.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated", 7),
+        uplink_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let router = tarball_router(&registry, user("alice"));
     let frame = super::package_frame(
@@ -759,7 +772,7 @@ fn package_frame_routes_split_domain_registry_tarball_by_registry() {
     let mut registry = registry_config();
     registry.uplinks.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated", 7),
+        uplink_with_access("https://npm.corp.example/", "$authenticated"),
     );
     // The package resolves from the private corp registry, but its packument's
     // dist.tarball lives on a *different* host (a split-domain CDN).
@@ -872,7 +885,7 @@ fn frozen_package_frames_route_private_alias_tarballs_to_gateway() {
     let mut registry = registry_config();
     registry.uplinks.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated", 7),
+        uplink_with_access("https://npm.corp.example/", "$authenticated"),
     );
 
     let frames = super::frozen_package_frames(

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -18,7 +18,7 @@ use super::{
 };
 use crate::{
     config::{Config as RegistryConfig, PublicRoute, UpstreamAlias},
-    policy::{AccessList, Identity},
+    policy::{AccessList, Identity, PackagePolicies, PackagePolicy},
     route::{Footprint, PrivateAccessDescriptor, RouteContext},
 };
 
@@ -80,6 +80,24 @@ fn private_alias_footprint(alias: &str, generation: u64) -> Footprint {
     let mut footprint = Footprint::default();
     footprint.add(PrivateAccessDescriptor::Alias { alias: alias.to_string(), generation });
     footprint
+}
+
+fn private_hosted_footprint(policy_id: &str) -> Footprint {
+    let mut footprint = Footprint::default();
+    footprint.add(PrivateAccessDescriptor::Hosted { policy_id: policy_id.to_string() });
+    footprint
+}
+
+fn package_policies(pattern: &str, access: &str) -> PackagePolicies {
+    PackagePolicies::new(vec![
+        PackagePolicy::new(
+            pattern,
+            AccessList::parse(access),
+            AccessList::parse("$authenticated"),
+            AccessList::default(),
+        )
+        .expect("policy parses"),
+    ])
 }
 
 fn lockfile(version: &str) -> Lockfile {
@@ -275,6 +293,107 @@ fn private_cached_resolution_requires_current_alias_authorization() {
     let rotated = RouteContext::from_config(&config);
     assert!(
         cached_resolution(&cache, Duration::from_mins(1), &key, &rotated, &user("alice")).is_none(),
+    );
+}
+
+#[test]
+fn same_alias_authorized_users_share_private_resolution_cache() {
+    let cache = Mutex::new(HashMap::new());
+    let key = "base".to_string();
+    let lockfile = lockfile("1.0.0");
+    assert!(store_resolution(
+        &cache,
+        Duration::from_mins(1),
+        key.clone(),
+        private_alias_footprint("corp", 1),
+        b"secret",
+        &lockfile,
+    ));
+
+    let mut config = registry_config();
+    config
+        .upstream_aliases
+        .insert("corp".to_string(), alias("https://npm.corp.example/", "$authenticated", 1));
+    let context = RouteContext::from_config(&config);
+
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_some(),
+    );
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("bob")).is_some(),
+    );
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &context, &Identity::Anonymous,)
+            .is_none(),
+    );
+}
+
+#[test]
+fn revoked_alias_access_stops_matching_private_resolution_hits() {
+    let cache = Mutex::new(HashMap::new());
+    let key = "base".to_string();
+    let lockfile = lockfile("1.0.0");
+    assert!(store_resolution(
+        &cache,
+        Duration::from_mins(1),
+        key.clone(),
+        private_alias_footprint("corp", 1),
+        b"secret",
+        &lockfile,
+    ));
+
+    let mut config = registry_config();
+    config
+        .upstream_aliases
+        .insert("corp".to_string(), alias("https://npm.corp.example/", "alice", 1));
+    let context = RouteContext::from_config(&config);
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_some(),
+    );
+
+    config
+        .upstream_aliases
+        .insert("corp".to_string(), alias("https://npm.corp.example/", "bob", 1));
+    let context = RouteContext::from_config(&config);
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_none(),
+    );
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("bob")).is_some(),
+    );
+}
+
+#[test]
+fn revoked_hosted_package_access_stops_matching_private_resolution_hits() {
+    let cache = Mutex::new(HashMap::new());
+    let key = "base".to_string();
+    let lockfile = lockfile("1.0.0");
+    assert!(store_resolution(
+        &cache,
+        Duration::from_mins(1),
+        key.clone(),
+        private_hosted_footprint("@private/pkg"),
+        b"secret",
+        &lockfile,
+    ));
+
+    let mut config = registry_config();
+    config.policies = package_policies("@private/*", "alice");
+    let context = RouteContext::from_config(&config);
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_some(),
+    );
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("bob")).is_none(),
+    );
+
+    config.policies = package_policies("@private/*", "bob");
+    let context = RouteContext::from_config(&config);
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_none(),
+    );
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("bob")).is_some(),
     );
 }
 

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -53,10 +53,19 @@ fn public_registry_config(registry: &str) -> RegistryConfig {
 }
 
 fn tarball_router(config: &RegistryConfig, identity: Identity) -> super::TarballRouter {
+    tarball_router_with_registries(config, identity, HashMap::new())
+}
+
+fn tarball_router_with_registries(
+    config: &RegistryConfig,
+    identity: Identity,
+    registries: HashMap<String, String>,
+) -> super::TarballRouter {
     super::TarballRouter::new(
         Arc::new(RouteContext::from_config(config)),
         identity,
         config.public_url.clone(),
+        registries,
     )
 }
 
@@ -697,6 +706,7 @@ fn a_package_frame_carries_unpacked_size_and_omits_it_when_unknown() {
         tarball_url: "https://r.test/acme/-/acme-1.0.0.tgz",
         unpacked_size,
         file_count,
+        from_registry: false,
     };
     observer.on_resolved(hint(Some(123_456), Some(42)));
     observer.on_resolved(hint(None, None));
@@ -733,12 +743,48 @@ fn package_frames_route_private_alias_tarballs_to_gateway() {
             tarball_url: "https://npm.corp.example/acme/-/acme-1.0.0.tgz",
             unpacked_size: None,
             file_count: None,
+            from_registry: false,
         },
     );
     let tarball = frame["tarball"].as_str().expect("tarball URL");
 
     assert!(tarball.contains("/~corp/acme/-/acme-1.0.0.tgz"));
     assert!(!tarball.contains("npm.corp.example"));
+}
+
+#[test]
+fn package_frame_routes_split_domain_registry_tarball_by_registry() {
+    use pacquet_package_manager::ResolvedPackageHint;
+
+    let mut registry = registry_config();
+    registry.uplinks.insert(
+        "corp".to_string(),
+        uplink_with_access("https://npm.corp.example/", "$authenticated", 7),
+    );
+    // The package resolves from the private corp registry, but its packument's
+    // dist.tarball lives on a *different* host (a split-domain CDN).
+    let registries =
+        HashMap::from([("default".to_string(), "https://npm.corp.example/".to_string())]);
+    let router = tarball_router_with_registries(&registry, user("alice"), registries);
+    let frame = super::package_frame(
+        &router,
+        &ResolvedPackageHint {
+            id: "acme@1.0.0",
+            name: "acme",
+            version: "1.0.0",
+            integrity: "sha512-abc",
+            tarball_url: "https://cdn.split-domain.example/acme-1.0.0.tgz",
+            unpacked_size: None,
+            file_count: None,
+            from_registry: true,
+        },
+    );
+    let tarball = frame["tarball"].as_str().expect("tarball URL");
+
+    // Routed by the corp registry, not the CDN host — so the raw upstream CDN
+    // URL is never emitted to the client.
+    assert!(tarball.contains("/~corp/acme/-/acme-1.0.0.tgz"), "got {tarball}");
+    assert!(!tarball.contains("split-domain.example"), "raw CDN URL leaked: {tarball}");
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -498,6 +498,37 @@ fn lockfile_with_tarball(tarball: &str) -> Lockfile {
 }
 
 #[test]
+fn reject_off_allowlist_registries_blocks_unconfigured_hosts() {
+    use super::reject_off_allowlist_registries;
+    let context = RouteContext::from_config(&registry_config());
+
+    // The built-in npm registry is allowlisted.
+    let ok = ResolveRequest {
+        registry: Some("https://registry.npmjs.org/".to_string()),
+        ..ResolveRequest::default()
+    };
+    assert!(reject_off_allowlist_registries(&ok, &context).is_none());
+
+    // An IMDS / off-allowlist default registry is rejected before any fetch.
+    let ssrf = ResolveRequest {
+        registry: Some("http://169.254.169.254/".to_string()),
+        ..ResolveRequest::default()
+    };
+    assert!(reject_off_allowlist_registries(&ssrf, &context).is_some());
+
+    // A named registry off the allowlist is rejected too.
+    let named = ResolveRequest {
+        registry: Some("https://registry.npmjs.org/".to_string()),
+        named_registries: BTreeMap::from([(
+            "@acme".to_string(),
+            "http://169.254.169.254/".to_string(),
+        )]),
+        ..ResolveRequest::default()
+    };
+    assert!(reject_off_allowlist_registries(&named, &context).is_some());
+}
+
+#[test]
 fn reject_inline_url_auth_scans_input_lockfile_tarballs() {
     use super::reject_inline_url_auth;
 

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -17,15 +17,19 @@ use super::{
     resolution_cache_key, store_resolution,
 };
 use crate::{
-    config::{Config as RegistryConfig, UpstreamAlias},
+    config::{Config as RegistryConfig, PublicRoute, UpstreamAlias},
     policy::{AccessList, Identity},
     route::{Footprint, PrivateAccessDescriptor, RouteContext},
 };
 
-fn config() -> PacquetConfig {
+fn config_for_registry(registry: &str) -> PacquetConfig {
     let mut config = PacquetConfig::new();
-    config.registry = "https://registry.example.test/".to_string();
+    config.registry = registry.to_string();
     config
+}
+
+fn config() -> PacquetConfig {
+    config_for_registry("https://registry.example.test/")
 }
 
 fn deps(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
@@ -36,6 +40,25 @@ fn registry_config() -> RegistryConfig {
     RegistryConfig::proxy(
         "127.0.0.1:7677".parse::<SocketAddr>().unwrap(),
         PathBuf::from("/tmp/pnpr-resolver-cache-test"),
+    )
+}
+
+fn public_registry_config(registry: &str) -> RegistryConfig {
+    let mut config = registry_config();
+    config
+        .route_policy
+        .public
+        .push(PublicRoute { registry: Some(registry.to_string()), package: None });
+    config
+}
+
+fn tarball_router(config: &RegistryConfig, identity: Identity) -> super::TarballRouter {
+    super::TarballRouter::new(
+        RouteContext::from_config(config),
+        identity,
+        config.public_url.clone(),
+        Arc::from(b"test-secret".to_vec()),
+        super::TarballGatewayRoutes::default(),
     )
 }
 
@@ -60,21 +83,33 @@ fn private_alias_footprint(alias: &str, generation: u64) -> Footprint {
 }
 
 fn lockfile(version: &str) -> Lockfile {
+    package_lockfile("acme", version)
+}
+
+fn package_lockfile(name: &str, version: &str) -> Lockfile {
     let mut packages = serde_json::Map::new();
     packages.insert(
-        format!("acme@{version}"),
+        format!("{name}@{version}"),
         serde_json::json!({
             "resolution": { "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==" }
         }),
     );
+    let mut dependencies = serde_json::Map::new();
+    dependencies
+        .insert(name.to_string(), serde_json::json!({ "specifier": "^1.0.0", "version": version }));
     serde_json::from_value(serde_json::json!({
         "lockfileVersion": "9.0",
         "importers": {
-            ".": { "dependencies": { "acme": { "specifier": "^1.0.0", "version": version } } }
+            ".": { "dependencies": dependencies }
         },
         "packages": packages
     }))
     .expect("lockfile parses")
+}
+
+fn lockfile_tarball_url(lockfile: &Lockfile, key: &str) -> String {
+    let value = serde_json::to_value(lockfile).expect("lockfile serializes");
+    value["packages"][key]["resolution"]["tarball"].as_str().expect("tarball URL").to_string()
 }
 
 #[derive(Debug)]
@@ -244,6 +279,121 @@ fn private_cached_resolution_requires_current_alias_authorization() {
 }
 
 #[test]
+fn public_lockfile_routing_keeps_registry_resolutions_compact() {
+    let registry = public_registry_config("https://registry.example.test/");
+    let router = tarball_router(&registry, Identity::Anonymous);
+    let routed = router.route_lockfile(&config(), &lockfile("1.0.0"));
+    let value = serde_json::to_value(&routed).expect("lockfile serializes");
+
+    assert_eq!(
+        value["packages"]["acme@1.0.0"]["resolution"],
+        serde_json::json!({
+            "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        }),
+    );
+}
+
+#[test]
+fn private_alias_lockfile_routing_uses_gateway_url() {
+    let pacquet_config = config_for_registry("https://npm.corp.example/");
+    let mut registry = registry_config();
+    registry
+        .upstream_aliases
+        .insert("corp".to_string(), alias("https://npm.corp.example/", "$authenticated", 7));
+    let router = tarball_router(&registry, user("alice"));
+
+    let routed = router.route_lockfile(&pacquet_config, &lockfile("1.0.0"));
+    let tarball = lockfile_tarball_url(&routed, "acme@1.0.0");
+
+    assert!(tarball.starts_with(
+        "http://127.0.0.1:7677/-/pnpr/v0/tarballs/alias/corp/7/acme/-/acme-1.0.0.tgz"
+    ));
+    assert!(!tarball.contains("npm.corp.example"));
+
+    let upstream = router.verification_lockfile(&routed);
+    assert_eq!(
+        lockfile_tarball_url(&upstream, "acme@1.0.0"),
+        "https://npm.corp.example/acme/-/acme-1.0.0.tgz",
+    );
+}
+
+#[test]
+fn private_alias_lockfile_routing_encodes_scoped_packages_as_one_gateway_segment() {
+    let pacquet_config = config_for_registry("https://npm.corp.example/");
+    let mut registry = registry_config();
+    registry
+        .upstream_aliases
+        .insert("corp".to_string(), alias("https://npm.corp.example/", "$authenticated", 7));
+    let router = tarball_router(&registry, user("alice"));
+
+    let routed = router.route_lockfile(&pacquet_config, &package_lockfile("@acme/foo", "1.0.0"));
+    let tarball = lockfile_tarball_url(&routed, "@acme/foo@1.0.0");
+
+    assert!(tarball.contains("/alias/corp/7/@acme%2Ffoo/-/foo-1.0.0.tgz"));
+    assert!(!tarball.contains("npm.corp.example"));
+
+    let upstream = router.verification_lockfile(&routed);
+    assert_eq!(
+        lockfile_tarball_url(&upstream, "@acme/foo@1.0.0"),
+        "https://npm.corp.example/@acme/foo/-/foo-1.0.0.tgz",
+    );
+}
+
+#[test]
+fn unknown_lockfile_routing_uses_marked_gateway_url() {
+    let pacquet_config = config_for_registry("https://unknown.example/");
+    let registry = registry_config();
+    let router = tarball_router(&registry, user("alice"));
+
+    let routed = router.route_lockfile(&pacquet_config, &lockfile("1.0.0"));
+    let tarball = lockfile_tarball_url(&routed, "acme@1.0.0");
+
+    assert!(tarball.contains("/-/pnpr/v0/tarballs/unknown/"));
+    assert!(tarball.ends_with("/acme/-/acme-1.0.0.tgz"));
+    assert!(!tarball.contains("unknown.example"));
+
+    let upstream = router.verification_lockfile(&routed);
+    assert_eq!(
+        lockfile_tarball_url(&upstream, "acme@1.0.0"),
+        "https://unknown.example/acme/-/acme-1.0.0.tgz",
+    );
+}
+
+#[test]
+fn private_cached_resolution_keeps_routed_tarball_urls() {
+    let cache = Mutex::new(HashMap::new());
+    let key = "base".to_string();
+    let pacquet_config = config_for_registry("https://npm.corp.example/");
+    let mut registry = registry_config();
+    registry
+        .upstream_aliases
+        .insert("corp".to_string(), alias("https://npm.corp.example/", "alice", 7));
+    let router = tarball_router(&registry, user("alice"));
+    let routed = router.route_lockfile(&pacquet_config, &lockfile("1.0.0"));
+
+    assert!(store_resolution(
+        &cache,
+        Duration::from_mins(1),
+        key.clone(),
+        private_alias_footprint("corp", 7),
+        b"secret",
+        &routed,
+    ));
+    let cached = cached_resolution(
+        &cache,
+        Duration::from_mins(1),
+        &key,
+        &RouteContext::from_config(&registry),
+        &user("alice"),
+    )
+    .expect("authorized caller reuses private cached lockfile");
+    let tarball = lockfile_tarball_url(&cached, "acme@1.0.0");
+
+    assert!(tarball.contains("/-/pnpr/v0/tarballs/alias/corp/7/acme/-/acme-1.0.0.tgz"));
+    assert!(!tarball.contains("npm.corp.example"));
+}
+
+#[test]
 fn candidate_lists_stay_bounded_and_keep_public_entries() {
     let cache = Mutex::new(HashMap::new());
     let key = "base".to_string();
@@ -278,8 +428,12 @@ fn a_package_frame_carries_unpacked_size_and_omits_it_when_unknown() {
     use pacquet_package_manager::{ResolutionObserver, ResolvedPackageHint};
 
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    let observer =
-        super::StreamObserver { tx, package_version_guard: Some(Arc::new(AllowAllVersions)) };
+    let registry = public_registry_config("https://r.test/");
+    let observer = super::StreamObserver {
+        tx,
+        package_version_guard: Some(Arc::new(AllowAllVersions)),
+        tarball_router: tarball_router(&registry, Identity::Anonymous),
+    };
 
     let hint = |unpacked_size, file_count| ResolvedPackageHint {
         id: "acme@1.0.0",
@@ -300,10 +454,36 @@ fn a_package_frame_carries_unpacked_size_and_omits_it_when_unknown() {
 
     let unsized_frame: serde_json::Value =
         serde_json::from_slice(&rx.try_recv().expect("unsized frame sent")).unwrap();
-    dbg!(&unsized_frame);
     assert!(unsized_frame.get("unpackedSize").is_none());
     assert!(unsized_frame.get("fileCount").is_none());
     assert_eq!(unsized_frame["tarball"], serde_json::json!("https://r.test/acme/-/acme-1.0.0.tgz"));
+}
+
+#[test]
+fn package_frames_route_private_alias_tarballs_to_gateway() {
+    use pacquet_package_manager::ResolvedPackageHint;
+
+    let mut registry = registry_config();
+    registry
+        .upstream_aliases
+        .insert("corp".to_string(), alias("https://npm.corp.example/", "$authenticated", 7));
+    let router = tarball_router(&registry, user("alice"));
+    let frame = super::package_frame(
+        &router,
+        &ResolvedPackageHint {
+            id: "acme@1.0.0",
+            name: "acme",
+            version: "1.0.0",
+            integrity: "sha512-abc",
+            tarball_url: "https://npm.corp.example/acme/-/acme-1.0.0.tgz",
+            unpacked_size: None,
+            file_count: None,
+        },
+    );
+    let tarball = frame["tarball"].as_str().expect("tarball URL");
+
+    assert!(tarball.contains("/-/pnpr/v0/tarballs/alias/corp/7/acme/-/acme-1.0.0.tgz"));
+    assert!(!tarball.contains("npm.corp.example"));
 }
 
 #[test]
@@ -333,8 +513,13 @@ fn frozen_package_frames_announce_lockfile_tarballs_with_sizes() {
         DistStats { unpacked_size: Some(123_456), file_count: Some(42) },
     );
 
-    let frames = super::frozen_package_frames(&config(), &lockfile, &stats);
-    dbg!(frames.len());
+    let registry = public_registry_config("https://registry.example.test/");
+    let frames = super::frozen_package_frames(
+        &config(),
+        &tarball_router(&registry, Identity::Anonymous),
+        &lockfile,
+        &stats,
+    );
     assert_eq!(frames.len(), 1);
 
     let frame: serde_json::Value = serde_json::from_slice(&frames[0]).unwrap();
@@ -346,6 +531,31 @@ fn frozen_package_frames_announce_lockfile_tarballs_with_sizes() {
     );
     assert_eq!(frame["unpackedSize"], serde_json::json!(123_456));
     assert_eq!(frame["fileCount"], serde_json::json!(42));
+}
+
+#[test]
+fn frozen_package_frames_route_private_alias_tarballs_to_gateway() {
+    use pacquet_resolving_npm_resolver::observed_dist_stats_sink;
+
+    let pacquet_config = config_for_registry("https://npm.corp.example/");
+    let lockfile = lockfile("1.0.0");
+    let stats = observed_dist_stats_sink();
+    let mut registry = registry_config();
+    registry
+        .upstream_aliases
+        .insert("corp".to_string(), alias("https://npm.corp.example/", "$authenticated", 7));
+
+    let frames = super::frozen_package_frames(
+        &pacquet_config,
+        &tarball_router(&registry, user("alice")),
+        &lockfile,
+        &stats,
+    );
+
+    let frame: serde_json::Value = serde_json::from_slice(&frames[0]).unwrap();
+    let tarball = frame["tarball"].as_str().expect("tarball URL");
+    assert!(tarball.contains("/-/pnpr/v0/tarballs/alias/corp/7/acme/-/acme-1.0.0.tgz"));
+    assert!(!tarball.contains("npm.corp.example"));
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -498,8 +498,8 @@ fn lockfile_with_tarball(tarball: &str) -> Lockfile {
 }
 
 #[test]
-fn reject_off_allowlist_registries_blocks_unconfigured_hosts() {
-    use super::reject_off_allowlist_registries;
+fn reject_off_allowlist_fetches_blocks_unconfigured_hosts() {
+    use super::reject_off_allowlist_fetches;
     let context = RouteContext::from_config(&registry_config());
 
     // The built-in npm registry is allowlisted.
@@ -507,14 +507,14 @@ fn reject_off_allowlist_registries_blocks_unconfigured_hosts() {
         registry: Some("https://registry.npmjs.org/".to_string()),
         ..ResolveRequest::default()
     };
-    assert!(reject_off_allowlist_registries(&ok, &context).is_none());
+    assert!(reject_off_allowlist_fetches(&ok, &context).is_none());
 
     // An IMDS / off-allowlist default registry is rejected before any fetch.
     let ssrf = ResolveRequest {
         registry: Some("http://169.254.169.254/".to_string()),
         ..ResolveRequest::default()
     };
-    assert!(reject_off_allowlist_registries(&ssrf, &context).is_some());
+    assert!(reject_off_allowlist_fetches(&ssrf, &context).is_some());
 
     // A named registry off the allowlist is rejected too.
     let named = ResolveRequest {
@@ -525,7 +525,40 @@ fn reject_off_allowlist_registries_blocks_unconfigured_hosts() {
         )]),
         ..ResolveRequest::default()
     };
-    assert!(reject_off_allowlist_registries(&named, &context).is_some());
+    assert!(reject_off_allowlist_fetches(&named, &context).is_some());
+
+    // A semver-range dependency never hits the network, so it is ignored.
+    let ranges = ResolveRequest {
+        registry: Some("https://registry.npmjs.org/".to_string()),
+        dependencies: Some(deps(&[("foo", "^1.0.0")])),
+        ..ResolveRequest::default()
+    };
+    assert!(reject_off_allowlist_fetches(&ranges, &context).is_none());
+
+    // A direct http(s) tarball dependency pointing at an off-allowlist host is
+    // rejected before the tarball resolver issues a HEAD/GET.
+    let tarball_dep = ResolveRequest {
+        registry: Some("https://registry.npmjs.org/".to_string()),
+        dependencies: Some(deps(&[("foo", "https://169.254.169.254/foo.tgz")])),
+        ..ResolveRequest::default()
+    };
+    assert!(reject_off_allowlist_fetches(&tarball_dep, &context).is_some());
+
+    // A git dependency to an off-allowlist host is rejected the same way.
+    let git_dep = ResolveRequest {
+        registry: Some("https://registry.npmjs.org/".to_string()),
+        dependencies: Some(deps(&[("foo", "git+https://169.254.169.254/repo.git#main")])),
+        ..ResolveRequest::default()
+    };
+    assert!(reject_off_allowlist_fetches(&git_dep, &context).is_some());
+
+    // An override whose leaf is an off-allowlist URL is rejected.
+    let override_dep = ResolveRequest {
+        registry: Some("https://registry.npmjs.org/".to_string()),
+        overrides: Some(serde_json::json!({ "foo": "https://169.254.169.254/foo.tgz" })),
+        ..ResolveRequest::default()
+    };
+    assert!(reject_off_allowlist_fetches(&override_dep, &context).is_some());
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -54,7 +54,7 @@ fn public_registry_config(registry: &str) -> RegistryConfig {
 
 fn tarball_router(config: &RegistryConfig, identity: Identity) -> super::TarballRouter {
     super::TarballRouter::new(
-        RouteContext::from_config(config),
+        Arc::new(RouteContext::from_config(config)),
         identity,
         config.public_url.clone(),
     )

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -481,6 +481,47 @@ fn unknown_lockfile_routing_leaves_resolution_unrewritten() {
     assert_eq!(value, serde_json::to_value(&input).expect("lockfile serializes"));
 }
 
+fn lockfile_with_tarball(tarball: &str) -> Lockfile {
+    serde_json::from_value(serde_json::json!({
+        "lockfileVersion": "9.0",
+        "importers": { ".": { "dependencies": { "acme": { "specifier": "^1.0.0", "version": "1.0.0" } } } },
+        "packages": {
+            "acme@1.0.0": {
+                "resolution": {
+                    "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                    "tarball": tarball,
+                },
+            },
+        },
+    }))
+    .expect("lockfile parses")
+}
+
+#[test]
+fn reject_inline_url_auth_scans_input_lockfile_tarballs() {
+    use super::reject_inline_url_auth;
+
+    // A lockfile tarball carrying inline `user:pass@host` credentials is
+    // rejected before any fetch, so it can't reach the verify/frozen paths or
+    // be echoed back.
+    let dirty = ResolveRequest {
+        lockfile: Some(lockfile_with_tarball(
+            "https://user:pass@evil.example/acme/-/acme-1.0.0.tgz",
+        )),
+        ..ResolveRequest::default()
+    };
+    assert!(reject_inline_url_auth(&dirty).is_some());
+
+    // A clean lockfile tarball is accepted.
+    let clean = ResolveRequest {
+        lockfile: Some(lockfile_with_tarball(
+            "https://registry.example.test/acme/-/acme-1.0.0.tgz",
+        )),
+        ..ResolveRequest::default()
+    };
+    assert!(reject_inline_url_auth(&clean).is_none());
+}
+
 #[test]
 fn private_cached_resolution_keeps_routed_tarball_urls() {
     let cache = Mutex::new(HashMap::new());

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -17,7 +17,7 @@ use super::{
     resolution_cache_key, store_resolution,
 };
 use crate::{
-    config::{Config as RegistryConfig, PublicRoute, UpstreamAlias},
+    config::{Config as RegistryConfig, PublicRoute, UplinkConfig},
     policy::{AccessList, Identity, PackagePolicies, PackagePolicy},
     route::{Footprint, PrivateAccessDescriptor, RouteContext},
 };
@@ -57,8 +57,6 @@ fn tarball_router(config: &RegistryConfig, identity: Identity) -> super::Tarball
         RouteContext::from_config(config),
         identity,
         config.public_url.clone(),
-        Arc::from(b"test-secret".to_vec()),
-        super::TarballGatewayRoutes::default(),
     )
 }
 
@@ -66,14 +64,16 @@ fn user(name: &str) -> Identity {
     Identity::user(name)
 }
 
-fn alias(registry: &str, access: &str, generation: u64) -> UpstreamAlias {
-    UpstreamAlias {
-        registry: registry.to_string(),
-        package: None,
-        authorization: "Bearer alias-secret".to_string(),
-        access: AccessList::parse(access),
-        generation,
-    }
+fn uplink_with_access(registry: &str, access: &str, generation: u64) -> UplinkConfig {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::AUTHORIZATION,
+        reqwest::header::HeaderValue::from_static("Bearer alias-secret"),
+    );
+    let mut uplink = UplinkConfig::with_defaults(registry.to_string(), headers);
+    uplink.access = Some(AccessList::parse(access));
+    uplink.generation = generation;
+    uplink
 }
 
 fn private_alias_footprint(alias: &str, generation: u64) -> Footprint {
@@ -277,8 +277,8 @@ fn private_cached_resolution_requires_current_alias_authorization() {
 
     let mut config = registry_config();
     config
-        .upstream_aliases
-        .insert("corp".to_string(), alias("https://npm.corp.example/", "alice", 1));
+        .uplinks
+        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "alice", 1));
     let context = RouteContext::from_config(&config);
     assert!(
         cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_some(),
@@ -288,8 +288,8 @@ fn private_cached_resolution_requires_current_alias_authorization() {
     );
 
     config
-        .upstream_aliases
-        .insert("corp".to_string(), alias("https://npm.corp.example/", "alice", 2));
+        .uplinks
+        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "alice", 2));
     let rotated = RouteContext::from_config(&config);
     assert!(
         cached_resolution(&cache, Duration::from_mins(1), &key, &rotated, &user("alice")).is_none(),
@@ -311,9 +311,10 @@ fn same_alias_authorized_users_share_private_resolution_cache() {
     ));
 
     let mut config = registry_config();
-    config
-        .upstream_aliases
-        .insert("corp".to_string(), alias("https://npm.corp.example/", "$authenticated", 1));
+    config.uplinks.insert(
+        "corp".to_string(),
+        uplink_with_access("https://npm.corp.example/", "$authenticated", 1),
+    );
     let context = RouteContext::from_config(&config);
 
     assert!(
@@ -344,16 +345,16 @@ fn revoked_alias_access_stops_matching_private_resolution_hits() {
 
     let mut config = registry_config();
     config
-        .upstream_aliases
-        .insert("corp".to_string(), alias("https://npm.corp.example/", "alice", 1));
+        .uplinks
+        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "alice", 1));
     let context = RouteContext::from_config(&config);
     assert!(
         cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_some(),
     );
 
     config
-        .upstream_aliases
-        .insert("corp".to_string(), alias("https://npm.corp.example/", "bob", 1));
+        .uplinks
+        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "bob", 1));
     let context = RouteContext::from_config(&config);
     assert!(
         cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_none(),
@@ -416,17 +417,16 @@ fn public_lockfile_routing_keeps_registry_resolutions_compact() {
 fn private_alias_lockfile_routing_uses_gateway_url() {
     let pacquet_config = config_for_registry("https://npm.corp.example/");
     let mut registry = registry_config();
-    registry
-        .upstream_aliases
-        .insert("corp".to_string(), alias("https://npm.corp.example/", "$authenticated", 7));
+    registry.uplinks.insert(
+        "corp".to_string(),
+        uplink_with_access("https://npm.corp.example/", "$authenticated", 7),
+    );
     let router = tarball_router(&registry, user("alice"));
 
     let routed = router.route_lockfile(&pacquet_config, &lockfile("1.0.0"));
     let tarball = lockfile_tarball_url(&routed, "acme@1.0.0");
 
-    assert!(tarball.starts_with(
-        "http://127.0.0.1:7677/-/pnpr/v0/tarballs/alias/corp/7/acme/-/acme-1.0.0.tgz"
-    ));
+    assert!(tarball.starts_with("http://127.0.0.1:7677/~corp/acme/-/acme-1.0.0.tgz"));
     assert!(!tarball.contains("npm.corp.example"));
 
     let upstream = router.verification_lockfile(&routed);
@@ -440,15 +440,16 @@ fn private_alias_lockfile_routing_uses_gateway_url() {
 fn private_alias_lockfile_routing_encodes_scoped_packages_as_one_gateway_segment() {
     let pacquet_config = config_for_registry("https://npm.corp.example/");
     let mut registry = registry_config();
-    registry
-        .upstream_aliases
-        .insert("corp".to_string(), alias("https://npm.corp.example/", "$authenticated", 7));
+    registry.uplinks.insert(
+        "corp".to_string(),
+        uplink_with_access("https://npm.corp.example/", "$authenticated", 7),
+    );
     let router = tarball_router(&registry, user("alice"));
 
     let routed = router.route_lockfile(&pacquet_config, &package_lockfile("@acme/foo", "1.0.0"));
     let tarball = lockfile_tarball_url(&routed, "@acme/foo@1.0.0");
 
-    assert!(tarball.contains("/alias/corp/7/@acme%2Ffoo/-/foo-1.0.0.tgz"));
+    assert!(tarball.contains("/~corp/@acme/foo/-/foo-1.0.0.tgz"));
     assert!(!tarball.contains("npm.corp.example"));
 
     let upstream = router.verification_lockfile(&routed);
@@ -459,23 +460,25 @@ fn private_alias_lockfile_routing_encodes_scoped_packages_as_one_gateway_segment
 }
 
 #[test]
-fn unknown_lockfile_routing_uses_marked_gateway_url() {
+fn unknown_lockfile_routing_leaves_resolution_unrewritten() {
     let pacquet_config = config_for_registry("https://unknown.example/");
     let registry = registry_config();
     let router = tarball_router(&registry, user("alice"));
 
-    let routed = router.route_lockfile(&pacquet_config, &lockfile("1.0.0"));
-    let tarball = lockfile_tarball_url(&routed, "acme@1.0.0");
+    let input = lockfile("1.0.0");
+    let routed = router.route_lockfile(&pacquet_config, &input);
 
-    assert!(tarball.contains("/-/pnpr/v0/tarballs/unknown/"));
-    assert!(tarball.ends_with("/acme/-/acme-1.0.0.tgz"));
-    assert!(!tarball.contains("unknown.example"));
-
-    let upstream = router.verification_lockfile(&routed);
-    assert_eq!(
-        lockfile_tarball_url(&upstream, "acme@1.0.0"),
-        "https://unknown.example/acme/-/acme-1.0.0.tgz",
+    // An unknown route has no uplink and no managed credential, so pnpr mints
+    // no gateway URL: the integrity-only registry resolution is left untouched
+    // (the client fetches the upstream tarball directly, as it was resolved
+    // anonymously), never rewritten into an explicit tarball URL.
+    let value = serde_json::to_value(&routed).expect("lockfile serializes");
+    let resolution = &value["packages"]["acme@1.0.0"]["resolution"];
+    assert!(
+        resolution.get("tarball").is_none(),
+        "unknown route stays integrity-only: {resolution}"
     );
+    assert_eq!(value, serde_json::to_value(&input).expect("lockfile serializes"));
 }
 
 #[test]
@@ -485,8 +488,8 @@ fn private_cached_resolution_keeps_routed_tarball_urls() {
     let pacquet_config = config_for_registry("https://npm.corp.example/");
     let mut registry = registry_config();
     registry
-        .upstream_aliases
-        .insert("corp".to_string(), alias("https://npm.corp.example/", "alice", 7));
+        .uplinks
+        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "alice", 7));
     let router = tarball_router(&registry, user("alice"));
     let routed = router.route_lockfile(&pacquet_config, &lockfile("1.0.0"));
 
@@ -508,7 +511,7 @@ fn private_cached_resolution_keeps_routed_tarball_urls() {
     .expect("authorized caller reuses private cached lockfile");
     let tarball = lockfile_tarball_url(&cached, "acme@1.0.0");
 
-    assert!(tarball.contains("/-/pnpr/v0/tarballs/alias/corp/7/acme/-/acme-1.0.0.tgz"));
+    assert!(tarball.contains("/~corp/acme/-/acme-1.0.0.tgz"));
     assert!(!tarball.contains("npm.corp.example"));
 }
 
@@ -583,9 +586,10 @@ fn package_frames_route_private_alias_tarballs_to_gateway() {
     use pacquet_package_manager::ResolvedPackageHint;
 
     let mut registry = registry_config();
-    registry
-        .upstream_aliases
-        .insert("corp".to_string(), alias("https://npm.corp.example/", "$authenticated", 7));
+    registry.uplinks.insert(
+        "corp".to_string(),
+        uplink_with_access("https://npm.corp.example/", "$authenticated", 7),
+    );
     let router = tarball_router(&registry, user("alice"));
     let frame = super::package_frame(
         &router,
@@ -601,7 +605,7 @@ fn package_frames_route_private_alias_tarballs_to_gateway() {
     );
     let tarball = frame["tarball"].as_str().expect("tarball URL");
 
-    assert!(tarball.contains("/-/pnpr/v0/tarballs/alias/corp/7/acme/-/acme-1.0.0.tgz"));
+    assert!(tarball.contains("/~corp/acme/-/acme-1.0.0.tgz"));
     assert!(!tarball.contains("npm.corp.example"));
 }
 
@@ -660,9 +664,10 @@ fn frozen_package_frames_route_private_alias_tarballs_to_gateway() {
     let lockfile = lockfile("1.0.0");
     let stats = observed_dist_stats_sink();
     let mut registry = registry_config();
-    registry
-        .upstream_aliases
-        .insert("corp".to_string(), alias("https://npm.corp.example/", "$authenticated", 7));
+    registry.uplinks.insert(
+        "corp".to_string(),
+        uplink_with_access("https://npm.corp.example/", "$authenticated", 7),
+    );
 
     let frames = super::frozen_package_frames(
         &pacquet_config,
@@ -673,7 +678,7 @@ fn frozen_package_frames_route_private_alias_tarballs_to_gateway() {
 
     let frame: serde_json::Value = serde_json::from_slice(&frames[0]).unwrap();
     let tarball = frame["tarball"].as_str().expect("tarball URL");
-    assert!(tarball.contains("/-/pnpr/v0/tarballs/alias/corp/7/acme/-/acme-1.0.0.tgz"));
+    assert!(tarball.contains("/~corp/acme/-/acme-1.0.0.tgz"));
     assert!(!tarball.contains("npm.corp.example"));
 }
 

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -476,7 +476,7 @@ fn unknown_lockfile_routing_leaves_resolution_unrewritten() {
     let resolution = &value["packages"]["acme@1.0.0"]["resolution"];
     assert!(
         resolution.get("tarball").is_none(),
-        "unknown route stays integrity-only: {resolution}"
+        "unknown route stays integrity-only: {resolution}",
     );
     assert_eq!(value, serde_json::to_value(&input).expect("lockfile serializes"));
 }

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -40,7 +40,7 @@ fn registry_config() -> RegistryConfig {
 }
 
 fn user(name: &str) -> Identity {
-    Identity::User { username: name.to_string() }
+    Identity::user(name)
 }
 
 fn alias(registry: &str, access: &str, generation: u64) -> UpstreamAlias {

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -1,12 +1,25 @@
 use pacquet_config::Config as PacquetConfig;
+use pacquet_lockfile::Lockfile;
 use pacquet_resolving_resolver_base::{
     PackageVersionGuard, PackageVersionGuardDecision, PackageVersionGuardFuture,
 };
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    net::SocketAddr,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use super::{
+    MAX_RESOLUTION_CACHE_CANDIDATES_PER_KEY, cached_resolution,
     protocol::{ResolveRequest, ResolveRequestProject},
-    resolution_cache_key,
+    resolution_cache_key, store_resolution,
+};
+use crate::{
+    config::{Config as RegistryConfig, UpstreamAlias},
+    policy::{AccessList, Identity},
+    route::{Footprint, PrivateAccessDescriptor, RouteContext},
 };
 
 fn config() -> PacquetConfig {
@@ -17,6 +30,51 @@ fn config() -> PacquetConfig {
 
 fn deps(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
     entries.iter().map(|(name, spec)| ((*name).to_string(), (*spec).to_string())).collect()
+}
+
+fn registry_config() -> RegistryConfig {
+    RegistryConfig::proxy(
+        "127.0.0.1:7677".parse::<SocketAddr>().unwrap(),
+        PathBuf::from("/tmp/pnpr-resolver-cache-test"),
+    )
+}
+
+fn user(name: &str) -> Identity {
+    Identity::User { username: name.to_string() }
+}
+
+fn alias(registry: &str, access: &str, generation: u64) -> UpstreamAlias {
+    UpstreamAlias {
+        registry: registry.to_string(),
+        package: None,
+        authorization: "Bearer alias-secret".to_string(),
+        access: AccessList::parse(access),
+        generation,
+    }
+}
+
+fn private_alias_footprint(alias: &str, generation: u64) -> Footprint {
+    let mut footprint = Footprint::default();
+    footprint.add(PrivateAccessDescriptor::Alias { alias: alias.to_string(), generation });
+    footprint
+}
+
+fn lockfile(version: &str) -> Lockfile {
+    let mut packages = serde_json::Map::new();
+    packages.insert(
+        format!("acme@{version}"),
+        serde_json::json!({
+            "resolution": { "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==" }
+        }),
+    );
+    serde_json::from_value(serde_json::json!({
+        "lockfileVersion": "9.0",
+        "importers": {
+            ".": { "dependencies": { "acme": { "specifier": "^1.0.0", "version": version } } }
+        },
+        "packages": packages
+    }))
+    .expect("lockfile parses")
 }
 
 #[derive(Debug)]
@@ -70,6 +128,149 @@ fn resolution_cache_key_changes_with_dependencies_and_policy() {
 
     assert_ne!(base_key, resolution_cache_key(&config, &different_dep));
     assert_ne!(base_key, resolution_cache_key(&config, &different_policy));
+}
+
+#[test]
+fn resolution_cache_key_hashes_input_lockfile_stably() {
+    let first_lockfile: Lockfile = serde_saphyr::from_str(
+        "lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+      react:
+        specifier: ^17.0.2
+        version: 17.0.2
+",
+    )
+    .unwrap();
+    let reordered_lockfile: Lockfile = serde_saphyr::from_str(
+        "lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      react:
+        specifier: ^17.0.2
+        version: 17.0.2
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+",
+    )
+    .unwrap();
+    let drifted_lockfile: Lockfile = serde_saphyr::from_str(
+        "lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.22
+",
+    )
+    .unwrap();
+
+    let request =
+        |lockfile| ResolveRequest { lockfile: Some(lockfile), ..ResolveRequest::default() };
+    let config = config();
+    let first_key = resolution_cache_key(&config, &request(first_lockfile));
+    assert_eq!(first_key, resolution_cache_key(&config, &request(reordered_lockfile)));
+    assert_ne!(first_key, resolution_cache_key(&config, &request(drifted_lockfile)));
+}
+
+#[test]
+fn public_cached_resolution_matches_every_caller() {
+    let cache = Mutex::new(HashMap::new());
+    let key = "base".to_string();
+    let lockfile = lockfile("1.0.0");
+    let context = RouteContext::from_config(&registry_config());
+
+    assert!(store_resolution(
+        &cache,
+        Duration::from_mins(1),
+        key.clone(),
+        Footprint::default(),
+        b"secret",
+        &lockfile,
+    ));
+
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &context, &Identity::Anonymous,)
+            .is_some(),
+    );
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_some(),
+    );
+}
+
+#[test]
+fn private_cached_resolution_requires_current_alias_authorization() {
+    let cache = Mutex::new(HashMap::new());
+    let key = "base".to_string();
+    let lockfile = lockfile("1.0.0");
+    assert!(store_resolution(
+        &cache,
+        Duration::from_mins(1),
+        key.clone(),
+        private_alias_footprint("corp", 1),
+        b"secret",
+        &lockfile,
+    ));
+
+    let mut config = registry_config();
+    config
+        .upstream_aliases
+        .insert("corp".to_string(), alias("https://npm.corp.example/", "alice", 1));
+    let context = RouteContext::from_config(&config);
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_some(),
+    );
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("bob")).is_none(),
+    );
+
+    config
+        .upstream_aliases
+        .insert("corp".to_string(), alias("https://npm.corp.example/", "alice", 2));
+    let rotated = RouteContext::from_config(&config);
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &rotated, &user("alice")).is_none(),
+    );
+}
+
+#[test]
+fn candidate_lists_stay_bounded_and_keep_public_entries() {
+    let cache = Mutex::new(HashMap::new());
+    let key = "base".to_string();
+    let lockfile = lockfile("1.0.0");
+    assert!(store_resolution(
+        &cache,
+        Duration::from_mins(1),
+        key.clone(),
+        Footprint::default(),
+        b"secret",
+        &lockfile,
+    ));
+    for index in 0..(MAX_RESOLUTION_CACHE_CANDIDATES_PER_KEY + 2) {
+        assert!(store_resolution(
+            &cache,
+            Duration::from_mins(1),
+            key.clone(),
+            private_alias_footprint(&format!("corp-{index}"), 1),
+            b"secret",
+            &lockfile,
+        ));
+    }
+
+    let cache = cache.lock().expect("resolution cache poisoned");
+    let candidates = cache.get(&key).expect("base key remains cached");
+    assert_eq!(candidates.len(), MAX_RESOLUTION_CACHE_CANDIDATES_PER_KEY);
+    assert!(candidates.iter().any(|candidate| candidate.footprint.is_public()));
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -552,6 +552,15 @@ fn reject_off_allowlist_fetches_blocks_unconfigured_hosts() {
     };
     assert!(reject_off_allowlist_fetches(&git_dep, &context).is_some());
 
+    // An scp-style git remote (`[user@]host:path`) carries no `://` but still
+    // triggers an ssh git fetch, so it is rejected too.
+    let scp_dep = ResolveRequest {
+        registry: Some("https://registry.npmjs.org/".to_string()),
+        dependencies: Some(deps(&[("foo", "git@169.254.169.254:org/repo.git")])),
+        ..ResolveRequest::default()
+    };
+    assert!(reject_off_allowlist_fetches(&scp_dep, &context).is_some());
+
     // An override whose leaf is an off-allowlist URL is rejected.
     let override_dep = ResolveRequest {
         registry: Some("https://registry.npmjs.org/".to_string()),

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -788,6 +788,34 @@ fn package_frame_routes_split_domain_registry_tarball_by_registry() {
 }
 
 #[test]
+fn package_frame_strips_signed_token_from_public_registry_tarball() {
+    use pacquet_package_manager::ResolvedPackageHint;
+
+    let registry = registry_config();
+    let registries =
+        HashMap::from([("default".to_string(), "https://registry.npmjs.org/".to_string())]);
+    let router = tarball_router_with_registries(&registry, user("alice"), registries);
+    let frame = super::package_frame(
+        &router,
+        &ResolvedPackageHint {
+            id: "acme@1.0.0",
+            name: "acme",
+            version: "1.0.0",
+            integrity: "sha512-abc",
+            // A public registry that fronts a presigned CDN URL with a token.
+            tarball_url: "https://registry.npmjs.org/acme/-/acme-1.0.0.tgz?token=secret",
+            unpacked_size: None,
+            file_count: None,
+            from_registry: true,
+        },
+    );
+    let tarball = frame["tarball"].as_str().expect("tarball URL");
+
+    // The upstream token is never emitted to the client.
+    assert_eq!(tarball, "https://registry.npmjs.org/acme/-/acme-1.0.0.tgz", "got {tarball}");
+}
+
+#[test]
 fn frozen_package_frames_announce_lockfile_tarballs_with_sizes() {
     use pacquet_lockfile::Lockfile;
     use pacquet_resolving_npm_resolver::{DistStats, observed_dist_stats_sink};

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -561,6 +561,24 @@ fn reject_off_allowlist_fetches_blocks_unconfigured_hosts() {
     };
     assert!(reject_off_allowlist_fetches(&scp_dep, &context).is_some());
 
+    // Every git transport is gated by origin, not just http(s)/git/ssh — and
+    // `file://` (a server-local read) nerf-darts to no host and is rejected.
+    for spec in [
+        "git+rsync://169.254.169.254/repo",
+        "git+ftp://169.254.169.254/repo",
+        "git+file:///etc/passwd",
+    ] {
+        let dep = ResolveRequest {
+            registry: Some("https://registry.npmjs.org/".to_string()),
+            dependencies: Some(deps(&[("foo", spec)])),
+            ..ResolveRequest::default()
+        };
+        assert!(
+            reject_off_allowlist_fetches(&dep, &context).is_some(),
+            "spec {spec:?} not rejected",
+        );
+    }
+
     // An override whose leaf is an off-allowlist URL is rejected.
     let override_dep = ResolveRequest {
         registry: Some("https://registry.npmjs.org/".to_string()),

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -33,7 +33,7 @@ use sha2::{Digest, Sha256};
 use wax::{Glob, Program};
 
 use crate::{
-    config::{Config, UplinkConfig},
+    config::{Config, PublicRoute, UplinkConfig},
     policy::{AccessList, Identity, PackagePolicies},
 };
 
@@ -210,15 +210,8 @@ impl RouteContext {
     #[must_use]
     pub fn from_config(config: &Config) -> Self {
         let hosted_origin = nerf_prefix(&config.public_url);
-        let public_routes = config
-            .route_policy
-            .public
-            .iter()
-            .map(|route| RouteMatcher {
-                origin: route.registry.as_deref().and_then(nerf_prefix),
-                package: route.package.as_deref().and_then(compile_glob),
-            })
-            .collect();
+        let public_routes =
+            config.route_policy.public.iter().filter_map(RouteMatcher::from_public_route).collect();
         // Proxied-route credentials come from `uplinks:` entries that declare
         // an `access:` policy. They are matched by registry origin and exposed
         // to clients at `/~<name>/`.
@@ -397,6 +390,32 @@ impl RouteContext {
 }
 
 impl RouteMatcher {
+    /// Build a matcher from an operator-declared public route, failing
+    /// closed. An *omitted* `registry`/`package` field means "match any" —
+    /// the intended wildcard — but a field that is *present yet unparsable*
+    /// (a typo'd registry URL or glob) drops the whole rule (`None`) rather
+    /// than collapsing to a `None` field that [`Self::matches`] would read as
+    /// match-any. A typo must narrow matching, never widen a scoped public
+    /// route into a match-all that leaks private metadata onto the public
+    /// path.
+    fn from_public_route(route: &PublicRoute) -> Option<Self> {
+        let origin = match route.registry.as_deref() {
+            None => None,
+            Some(registry) => Some(nerf_prefix(registry).or_else(|| {
+                tracing::warn!(registry, "ignoring public route with an unparsable registry URL");
+                None
+            })?),
+        };
+        let package = match route.package.as_deref() {
+            None => None,
+            Some(pattern) => Some(compile_glob(pattern).or_else(|| {
+                tracing::warn!(pattern, "ignoring public route with an invalid package glob");
+                None
+            })?),
+        };
+        Some(Self { origin, package })
+    }
+
     fn matches(&self, fetch: &str, package: Option<&str>) -> bool {
         let origin_ok = self.origin.as_deref().is_none_or(|origin| fetch.starts_with(origin));
         let package_ok = self
@@ -531,10 +550,10 @@ pub fn url_has_inline_credentials(spec: &str) -> bool {
     }
 }
 
-/// Compile a package glob, dropping (rather than failing the whole
-/// resolve over) an invalid pattern. An operator typo therefore makes a
-/// route *more* restrictive (the rule never matches) rather than opening
-/// a private route up.
+/// Compile a package glob, returning `None` for an invalid pattern rather
+/// than failing the whole resolve. [`RouteMatcher::from_public_route`] turns
+/// that `None` into a dropped (never-matching) rule, so an operator typo
+/// narrows matching instead of opening a private route up.
 fn compile_glob(pattern: &str) -> Option<Glob<'static>> {
     Glob::new(pattern).ok().map(Glob::into_owned)
 }

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -189,6 +189,7 @@ struct RouteMatcher {
 struct ResolvedAlias {
     name: String,
     generation: u64,
+    registry: String,
     /// Nerf-darted upstream origin the alias serves.
     origin: String,
     package: Option<Glob<'static>>,
@@ -197,6 +198,12 @@ struct ResolvedAlias {
     authorization: String,
     /// Which pnpr callers may select this alias.
     access: AccessList,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct GatewayAlias {
+    pub(crate) registry: String,
+    pub(crate) authorization: String,
 }
 
 impl RouteContext {
@@ -321,6 +328,27 @@ impl RouteContext {
             }
         }
     }
+
+    pub(crate) fn gateway_alias(
+        &self,
+        identity: &Identity,
+        alias: &str,
+        generation: u64,
+        package: &str,
+    ) -> Option<GatewayAlias> {
+        self.aliases
+            .iter()
+            .find(|candidate| {
+                candidate.name == alias
+                    && candidate.generation == generation
+                    && candidate.access.allows(identity)
+                    && candidate.package.as_ref().is_none_or(|glob| glob.is_match(package))
+            })
+            .map(|candidate| GatewayAlias {
+                registry: candidate.registry.clone(),
+                authorization: candidate.authorization.clone(),
+            })
+    }
 }
 
 impl RouteMatcher {
@@ -339,6 +367,7 @@ impl ResolvedAlias {
         Some(Self {
             name: name.to_string(),
             generation: alias.generation,
+            registry: alias.registry.clone(),
             origin: nerf_origin(&alias.registry)?,
             package: alias.package.as_deref().and_then(compile_glob),
             authorization: alias.authorization.clone(),

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -593,6 +593,25 @@ pub fn url_has_inline_credentials(spec: &str) -> bool {
     }
 }
 
+/// Strip an inline `user:pass@`/`user@` userinfo from a `scheme://` URL,
+/// returning the credential-free form. A tarball URL taken from an untrusted
+/// upstream `dist.tarball` must never be emitted to a client or written to a
+/// shared cache with embedded credentials; a genuinely public tarball is
+/// anonymously fetchable, so the stripped URL still works. Returns the input
+/// unchanged when there is no `scheme://` authority or no userinfo.
+#[must_use]
+pub(crate) fn strip_url_credentials(url: &str) -> String {
+    let Some((scheme, after)) = url.split_once("://") else {
+        return url.to_string();
+    };
+    let authority_end = after.find(['/', '?', '#']).unwrap_or(after.len());
+    let (authority, rest) = after.split_at(authority_end);
+    match authority.rsplit_once('@') {
+        Some((_, host)) => format!("{scheme}://{host}{rest}"),
+        None => url.to_string(),
+    }
+}
+
 /// Compile a package glob, returning `None` for an invalid pattern rather
 /// than failing the whole resolve. [`RouteMatcher::from_public_route`] turns
 /// that `None` into a dropped (never-matching) rule, so an operator typo

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -1,0 +1,463 @@
+//! Authorization-aware route classification for the resolution cache.
+//!
+//! pnpr's resolution cache stores a whole resolved lockfile keyed by the
+//! resolution inputs, with auth deliberately excluded from the key. That
+//! is safe only for resolutions that touched no private data. This module
+//! decides, for every metadata/tarball fetch a resolve performs, whether
+//! its **route** is public or private — without a second request — so a
+//! public resolution can be shared globally while a private one is keyed
+//! by the *private access descriptor* that produced it.
+//!
+//! Privacy is a property of the fetch route (registry + package +
+//! configured rules), not of whether the request carried a credential:
+//!
+//! * scoped names can be public (`@babel/core` on npmjs), and
+//! * unscoped names can be private (a corporate default registry).
+//!
+//! [`classify`] maps one fetch to a [`RouteClass`]. The [`RouteHook`]
+//! installed on the resolve's [`AuthHeaders`](pacquet_network::AuthHeaders)
+//! runs that classification at the real auth-selection point, selects the
+//! pnpr-managed credential (never a client-forwarded one), and records the
+//! route into a [`Footprint`]. The footprint's [`Footprint::digest`] is
+//! the per-resolution private key the cache layer will gate on.
+
+use std::{
+    collections::BTreeSet,
+    sync::{Arc, Mutex},
+};
+
+use pacquet_network::{UpstreamRouteHook, nerf_dart};
+use sha2::{Digest, Sha256};
+use wax::{Glob, Program};
+
+use crate::{
+    config::{Config, UpstreamAlias},
+    policy::{AccessList, Identity, PackagePolicies},
+};
+
+/// The classification of a single fetch route.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RouteClass {
+    /// Public route — fetched anonymously and shareable globally. The
+    /// built-in unscoped-npmjs route, an operator-declared public route,
+    /// or a pnpr-hosted package whose access policy admits everyone.
+    Public,
+    /// A package hosted by pnpr itself whose access policy is private.
+    /// Gated by re-running that policy for the caller; `policy_id`
+    /// identifies the access-policy rule that produced the entry.
+    Hosted { policy_id: String },
+    /// A proxied upstream route served with a pnpr-managed credential
+    /// alias the caller is authorized to use.
+    Proxied { alias: String, generation: u64 },
+    /// A private/unknown route for which the caller has no usable
+    /// pnpr-managed credential or hosted authorization. Resolved
+    /// anonymously as a *non-shareable* miss; never written to the
+    /// global public cache.
+    Unknown,
+}
+
+/// The cache-namespace identity of a private route: a key input plus
+/// (for the cache layer) an authorization gate. The key input is what
+/// gets HMAC'd into the cache key; identical inputs from different
+/// callers who share the same access collapse to one shared entry.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum PrivateAccessDescriptor {
+    /// Proxied route via a pnpr-managed upstream alias. Rotating the
+    /// alias bumps `generation`, moving future hits to a new namespace.
+    Alias { alias: String, generation: u64 },
+    /// pnpr-hosted route, gated by re-running the named package access
+    /// policy for the caller.
+    Hosted { policy_id: String },
+}
+
+impl PrivateAccessDescriptor {
+    /// The stable, collision-resistant bytes that go into the cache-key
+    /// HMAC. `\0` separates fields so distinct shapes can't alias (an
+    /// alias literally named `hosted` can't collide with a hosted
+    /// policy of the same text).
+    fn key_input(&self) -> String {
+        match self {
+            PrivateAccessDescriptor::Alias { alias, generation } => {
+                format!("alias\0{alias}\0{generation}")
+            }
+            PrivateAccessDescriptor::Hosted { policy_id } => format!("hosted\0{policy_id}"),
+        }
+    }
+}
+
+/// The set of private routes a single resolve actually touched, paired
+/// with the descriptor selected for each. Accumulated during resolution
+/// through the [`RouteHook`]; consumed afterwards to decide how the
+/// resolution may be cached.
+///
+/// An empty footprint with no unknown-private touch means the resolution
+/// is fully public and shareable globally.
+#[derive(Debug, Default)]
+pub struct Footprint {
+    descriptors: BTreeSet<PrivateAccessDescriptor>,
+    /// A private/unknown route with no usable descriptor was fetched, so
+    /// the resolution carries private data that cannot be safely keyed —
+    /// it must not be shared at all.
+    touched_unknown_private: bool,
+}
+
+impl Footprint {
+    fn add(&mut self, descriptor: PrivateAccessDescriptor) {
+        self.descriptors.insert(descriptor);
+    }
+
+    fn mark_unknown_private(&mut self) {
+        self.touched_unknown_private = true;
+    }
+
+    /// Whether the resolution touched no private data and may be cached
+    /// under the global, auth-excluded key.
+    #[must_use]
+    pub fn is_public(&self) -> bool {
+        self.descriptors.is_empty() && !self.touched_unknown_private
+    }
+
+    /// Whether the resolution may be cached at all. A resolution that
+    /// touched an unknown-private route carries private data with no
+    /// descriptor to key it, so it can be served only to the caller that
+    /// produced it (i.e. not shared) — Part 2 treats this as
+    /// non-cacheable.
+    #[must_use]
+    pub fn is_shareable(&self) -> bool {
+        !self.touched_unknown_private
+    }
+
+    /// The private-key component for this footprint: an HMAC over the
+    /// sorted union of its descriptors, keyed with the server `secret`
+    /// so the key is not correlatable offline. `None` for a public
+    /// footprint (no private descriptors), in which case the cache uses
+    /// the global auth-excluded key.
+    #[must_use]
+    pub fn digest(&self, secret: &[u8]) -> Option<String> {
+        if self.descriptors.is_empty() {
+            return None;
+        }
+        let mut message = String::new();
+        for descriptor in &self.descriptors {
+            message.push_str(&descriptor.key_input());
+            message.push('\n');
+        }
+        Some(hex(&hmac_sha256(secret, message.as_bytes())))
+    }
+}
+
+/// Everything [`classify`] needs, resolved once from the server
+/// [`Config`] and reused across every fetch in a resolve.
+#[derive(Debug, Clone)]
+pub struct RouteContext {
+    /// Built-in route: unscoped packages on `registry.npmjs.org` are
+    /// public. Operators can disable this for a conservative deployment.
+    npmjs_unscoped_public: bool,
+    /// Nerf-darted origin of this pnpr service (from `public_url`). A
+    /// fetch whose URL falls under it is a pnpr-hosted route.
+    hosted_origin: Option<String>,
+    /// Operator-declared public routes, matched by nerf-darted registry
+    /// prefix and/or package glob.
+    public_routes: Vec<RouteMatcher>,
+    /// pnpr-managed upstream credential aliases, in declared order.
+    aliases: Vec<ResolvedAlias>,
+    /// Package access policy, used to decide whether a pnpr-hosted route
+    /// is public (admits everyone) or private, and to gate hosted hits.
+    policies: PackagePolicies,
+}
+
+#[derive(Debug, Clone)]
+struct RouteMatcher {
+    /// Nerf-darted registry prefix this rule applies to, or `None` for
+    /// any registry.
+    origin: Option<String>,
+    package: Option<Glob<'static>>,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedAlias {
+    name: String,
+    generation: u64,
+    /// Nerf-darted upstream origin the alias serves.
+    origin: String,
+    package: Option<Glob<'static>>,
+    /// The fully-formed `Authorization` header value the alias sends
+    /// upstream (`Bearer …` / `Basic …`).
+    authorization: String,
+    /// Which pnpr callers may select this alias.
+    access: AccessList,
+}
+
+impl RouteContext {
+    /// Resolve route-classification inputs from the server config.
+    #[must_use]
+    pub fn from_config(config: &Config) -> Self {
+        let hosted_origin = nerf_origin(&config.public_url);
+        let public_routes = config
+            .route_policy
+            .public
+            .iter()
+            .map(|route| RouteMatcher {
+                origin: route.registry.as_deref().and_then(nerf_origin),
+                package: route.package.as_deref().and_then(compile_glob),
+            })
+            .collect();
+        let aliases = config
+            .upstream_aliases
+            .iter()
+            .filter_map(|(name, alias)| ResolvedAlias::from_config(name, alias))
+            .collect();
+        Self {
+            npmjs_unscoped_public: config.route_policy.npmjs_unscoped_public,
+            hosted_origin,
+            public_routes,
+            aliases,
+            policies: config.policies.clone(),
+        }
+    }
+
+    /// Classify a single fetch to `url` for `package` (`None` for a
+    /// non-package fetch), for `identity`. Precedence follows the RFC:
+    /// public wins and suppresses auth; then pnpr-hosted; then an
+    /// authorized proxied alias; otherwise unknown/private.
+    #[must_use]
+    pub fn classify(&self, identity: &Identity, url: &str, package: Option<&str>) -> RouteClass {
+        let fetch = nerf_dart(url);
+        if fetch.is_empty() {
+            return RouteClass::Unknown;
+        }
+
+        if self.is_public_route(&fetch, package) {
+            return RouteClass::Public;
+        }
+
+        if let Some(hosted) = self.hosted_origin.as_deref()
+            && fetch.starts_with(hosted)
+        {
+            return self.classify_hosted(identity, package);
+        }
+
+        if let Some(alias) = self.select_alias(identity, &fetch, package) {
+            return RouteClass::Proxied { alias: alias.name.clone(), generation: alias.generation };
+        }
+
+        RouteClass::Unknown
+    }
+
+    fn is_public_route(&self, fetch: &str, package: Option<&str>) -> bool {
+        if self.npmjs_unscoped_public
+            && origin_of(fetch) == Some("registry.npmjs.org")
+            && package.is_none_or(|name| !name.starts_with('@'))
+        {
+            return true;
+        }
+        self.public_routes.iter().any(|route| route.matches(fetch, package))
+    }
+
+    /// A pnpr-hosted route is public when its package access policy
+    /// admits an anonymous caller; otherwise it is private and gated by
+    /// re-running that policy for the caller.
+    fn classify_hosted(&self, identity: &Identity, package: Option<&str>) -> RouteClass {
+        let Some(package) = package else {
+            // A non-package fetch against pnpr itself carries no private
+            // package data to key.
+            return RouteClass::Public;
+        };
+        let access = self.policies.for_package(package).access;
+        if access.allows(&Identity::Anonymous) {
+            return RouteClass::Public;
+        }
+        if access.allows(identity) {
+            RouteClass::Hosted { policy_id: package.to_string() }
+        } else {
+            // The caller can't read this hosted package, so it must not
+            // match any private hosted entry; fail closed.
+            RouteClass::Unknown
+        }
+    }
+
+    fn select_alias(
+        &self,
+        identity: &Identity,
+        fetch: &str,
+        package: Option<&str>,
+    ) -> Option<&ResolvedAlias> {
+        self.aliases.iter().find(|alias| {
+            fetch.starts_with(&alias.origin)
+                && alias
+                    .package
+                    .as_ref()
+                    .is_none_or(|glob| package.is_some_and(|name| glob.is_match(name)))
+                && alias.access.allows(identity)
+        })
+    }
+}
+
+impl RouteMatcher {
+    fn matches(&self, fetch: &str, package: Option<&str>) -> bool {
+        let origin_ok = self.origin.as_deref().is_none_or(|origin| fetch.starts_with(origin));
+        let package_ok = self
+            .package
+            .as_ref()
+            .is_none_or(|glob| package.is_some_and(|name| glob.is_match(name)));
+        origin_ok && package_ok
+    }
+}
+
+impl ResolvedAlias {
+    fn from_config(name: &str, alias: &UpstreamAlias) -> Option<Self> {
+        Some(Self {
+            name: name.to_string(),
+            generation: alias.generation,
+            origin: nerf_origin(&alias.registry)?,
+            package: alias.package.as_deref().and_then(compile_glob),
+            authorization: alias.authorization.clone(),
+            access: alias.access.clone(),
+        })
+    }
+}
+
+/// The [`UpstreamRouteHook`] pnpr installs on a resolve's
+/// [`AuthHeaders`](pacquet_network::AuthHeaders). Every metadata/tarball
+/// fetch routes through [`UpstreamRouteHook::authorize`], which classifies
+/// the route, records it into the shared [`Footprint`], and returns the
+/// pnpr-managed credential (never a client-forwarded one).
+#[derive(Debug)]
+pub struct RouteHook {
+    context: RouteContext,
+    identity: Identity,
+    footprint: Arc<Mutex<Footprint>>,
+}
+
+impl RouteHook {
+    #[must_use]
+    pub fn new(
+        context: RouteContext,
+        identity: Identity,
+        footprint: Arc<Mutex<Footprint>>,
+    ) -> Self {
+        Self { context, identity, footprint }
+    }
+}
+
+impl UpstreamRouteHook for RouteHook {
+    fn authorize(&self, url: &str, package: Option<&str>) -> Option<String> {
+        match self.context.classify(&self.identity, url, package) {
+            RouteClass::Public => None,
+            RouteClass::Hosted { policy_id } => {
+                self.record(PrivateAccessDescriptor::Hosted { policy_id });
+                // Hosted packages are served by pnpr itself; no upstream
+                // credential is involved.
+                None
+            }
+            RouteClass::Proxied { alias, generation } => {
+                let authorization = self
+                    .context
+                    .aliases
+                    .iter()
+                    .find(|candidate| candidate.name == alias)
+                    .map(|candidate| candidate.authorization.clone());
+                self.record(PrivateAccessDescriptor::Alias { alias, generation });
+                authorization
+            }
+            RouteClass::Unknown => {
+                self.footprint.lock().expect("footprint poisoned").mark_unknown_private();
+                None
+            }
+        }
+    }
+}
+
+impl RouteHook {
+    fn record(&self, descriptor: PrivateAccessDescriptor) {
+        self.footprint.lock().expect("footprint poisoned").add(descriptor);
+    }
+}
+
+/// Whether a registry/dependency/tarball spec carries inline
+/// `user:pass@host` (or `user@host`) credentials. Such URLs must be
+/// rejected before any fetch: pnpr must not turn a client-embedded
+/// credential into upstream Basic auth, treat it as a cache identity, or
+/// store it in a shared cache. Specs without a `scheme://` (a semver
+/// range, a scoped name, `npm:`/`workspace:` aliases) never match.
+#[must_use]
+pub fn url_has_inline_credentials(spec: &str) -> bool {
+    let Some((_, after_scheme)) = spec.split_once("://") else {
+        return false;
+    };
+    let authority = after_scheme.split(['/', '?', '#']).next().unwrap_or(after_scheme);
+    match authority.rsplit_once('@') {
+        Some((userinfo, _)) => !userinfo.is_empty(),
+        None => false,
+    }
+}
+
+/// Compile a package glob, dropping (rather than failing the whole
+/// resolve over) an invalid pattern. An operator typo therefore makes a
+/// route *more* restrictive (the rule never matches) rather than opening
+/// a private route up.
+fn compile_glob(pattern: &str) -> Option<Glob<'static>> {
+    Glob::new(pattern).ok().map(Glob::into_owned)
+}
+
+/// Nerf-dart a registry URL down to its host-only origin
+/// (`//host[:port]/`), the prefix every fetch under it shares. `None`
+/// for an unparseable URL.
+fn nerf_origin(url: &str) -> Option<String> {
+    let nerfed = nerf_dart(url);
+    if nerfed.is_empty() { None } else { Some(host_prefix(&nerfed)) }
+}
+
+/// The `//host[:port]/` prefix of a nerf-darted key, discarding any
+/// path so an origin comparison ignores path depth.
+fn host_prefix(nerfed: &str) -> String {
+    match origin_of(nerfed) {
+        Some(host) => format!("//{host}/"),
+        None => nerfed.to_string(),
+    }
+}
+
+/// The `host[:port]` of a nerf-darted key (`//host[:port]/path/`).
+fn origin_of(nerfed: &str) -> Option<&str> {
+    nerfed.strip_prefix("//")?.split('/').next().filter(|host| !host.is_empty())
+}
+
+/// HMAC-SHA256 (RFC 2104) over the workspace's audited `sha2`, so the
+/// descriptor digest needs no extra crypto dependency. Verified against
+/// the RFC 4231 test vectors in the unit tests.
+fn hmac_sha256(key: &[u8], message: &[u8]) -> [u8; 32] {
+    const BLOCK: usize = 64;
+    let mut block_key = [0u8; BLOCK];
+    if key.len() > BLOCK {
+        let digest = Sha256::digest(key);
+        block_key[..digest.len()].copy_from_slice(&digest);
+    } else {
+        block_key[..key.len()].copy_from_slice(key);
+    }
+    let mut inner = Sha256::new();
+    let mut outer = Sha256::new();
+    let mut inner_pad = [0u8; BLOCK];
+    let mut outer_pad = [0u8; BLOCK];
+    for index in 0..BLOCK {
+        inner_pad[index] = block_key[index] ^ 0x36;
+        outer_pad[index] = block_key[index] ^ 0x5c;
+    }
+    inner.update(inner_pad);
+    inner.update(message);
+    outer.update(outer_pad);
+    outer.update(inner.finalize());
+    outer.finalize().into()
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -201,9 +201,9 @@ struct ResolvedAlias {
     name: String,
     generation: u64,
     registry: String,
-    /// Nerf-darted upstream origin the alias serves.
+    /// Nerf-darted upstream origin the alias serves. Routing is by origin
+    /// alone — an uplink credential covers every package on its registry.
     origin: String,
-    package: Option<Glob<'static>>,
     /// The fully-formed `Authorization` header value the alias sends
     /// upstream (`Bearer …` / `Basic …`).
     authorization: String,
@@ -284,7 +284,7 @@ impl RouteContext {
             return self.classify_hosted(identity, package);
         }
 
-        if let Some(alias) = self.select_alias(identity, &fetch, package) {
+        if let Some(alias) = self.select_alias(identity, &fetch) {
             return RouteClass::Proxied { alias: alias.name.clone(), generation: alias.generation };
         }
 
@@ -323,20 +323,10 @@ impl RouteContext {
         }
     }
 
-    fn select_alias(
-        &self,
-        identity: &Identity,
-        fetch: &str,
-        package: Option<&str>,
-    ) -> Option<&ResolvedAlias> {
-        self.aliases.iter().find(|alias| {
-            fetch.starts_with(&alias.origin)
-                && alias
-                    .package
-                    .as_ref()
-                    .is_none_or(|glob| package.is_some_and(|name| glob.is_match(name)))
-                && alias.access.allows(identity)
-        })
+    fn select_alias(&self, identity: &Identity, fetch: &str) -> Option<&ResolvedAlias> {
+        self.aliases
+            .iter()
+            .find(|alias| fetch.starts_with(&alias.origin) && alias.access.allows(identity))
     }
 
     pub(crate) fn allows_descriptor(
@@ -395,7 +385,6 @@ impl ResolvedAlias {
             generation: uplink.generation,
             registry: uplink.url.clone(),
             origin: nerf_origin(&uplink.url)?,
-            package: None,
             authorization,
             access,
         })

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -183,8 +183,13 @@ struct ResolvedAlias {
     /// Nerf-darted upstream origin the alias serves. Routing is by origin
     /// alone — an uplink credential covers every package on its registry.
     origin: String,
+    /// The uplink registry's URL scheme (`https`/`http`). The credential is
+    /// attached only to a fetch of this same scheme: nerf-darting strips the
+    /// scheme from [`Self::origin`], so without this check an `http://host`
+    /// fetch would match an `https://host` uplink and send its token in clear.
+    scheme: String,
     /// The fully-formed `Authorization` header value the alias sends
-    /// upstream (`Bearer …` / `Basic …`).
+    /// upstream (`Bearer ...` / `Basic ...`).
     authorization: String,
     /// Which pnpr callers may select this alias.
     access: AccessList,
@@ -199,6 +204,7 @@ impl fmt::Debug for ResolvedAlias {
             .field("generation", &self.generation)
             .field("registry", &self.registry)
             .field("origin", &self.origin)
+            .field("scheme", &self.scheme)
             .field("authorization", &"<redacted>")
             .field("access", &self.access)
             .finish()
@@ -281,7 +287,14 @@ impl RouteContext {
             return self.classify_hosted(identity, package);
         }
 
-        if let Some(alias) = self.select_alias(identity, &fetch) {
+        if let Some(alias) = self.select_alias(identity, &fetch)
+            && scheme_of(url) == Some(alias.scheme.as_str())
+        {
+            // Scheme must match the uplink's: nerf-darting strips it, so an
+            // `http://host` fetch would otherwise be handed an `https://host`
+            // uplink's server-owned credential and leak it in cleartext. A
+            // scheme mismatch falls through to an anonymous public fetch (which
+            // fails closed upstream if the resource is actually private).
             return RouteClass::Proxied { alias: alias.name.clone(), generation: alias.generation };
         }
 
@@ -451,6 +464,7 @@ impl ResolvedAlias {
             generation: uplink.generation,
             registry: uplink.url.clone(),
             origin: nerf_prefix(&uplink.url)?,
+            scheme: scheme_of(&uplink.url)?.to_string(),
             authorization,
             access,
         })
@@ -586,6 +600,12 @@ fn nerf_prefix(url: &str) -> Option<String> {
 /// The `host[:port]` of a nerf-darted key (`//host[:port]/path/`).
 fn origin_of(nerfed: &str) -> Option<&str> {
     nerfed.strip_prefix("//")?.split('/').next().filter(|host| !host.is_empty())
+}
+
+/// The URL scheme (`https`, `http`, ...), i.e. the segment before `://`. `None`
+/// for a value with no scheme.
+fn scheme_of(url: &str) -> Option<&str> {
+    url.split_once("://").map(|(scheme, _)| scheme)
 }
 
 /// HMAC-SHA256 (RFC 2104) over the workspace's audited `sha2`, so the

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -14,7 +14,7 @@
 //! * scoped names can be public (`@babel/core` on npmjs), and
 //! * unscoped names can be private (a corporate default registry).
 //!
-//! [`classify`] maps one fetch to a [`RouteClass`]. The [`RouteHook`]
+//! [`RouteContext::classify`] maps one fetch to a [`RouteClass`]. The [`RouteHook`]
 //! installed on the resolve's [`AuthHeaders`](pacquet_network::AuthHeaders)
 //! runs that classification at the real auth-selection point, selects the
 //! pnpr-managed credential (never a client-forwarded one), and records the
@@ -157,7 +157,7 @@ impl Footprint {
     }
 }
 
-/// Everything [`classify`] needs, resolved once from the server
+/// Everything [`RouteContext::classify`] needs, resolved once from the server
 /// [`Config`] and reused across every fetch in a resolve.
 #[derive(Debug, Clone)]
 pub struct RouteContext {

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -23,6 +23,7 @@
 
 use std::{
     collections::BTreeSet,
+    fmt,
     sync::{Arc, Mutex},
 };
 
@@ -196,7 +197,7 @@ struct RouteMatcher {
     package: Option<Glob<'static>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct ResolvedAlias {
     name: String,
     generation: u64,
@@ -209,6 +210,21 @@ struct ResolvedAlias {
     authorization: String,
     /// Which pnpr callers may select this alias.
     access: AccessList,
+}
+
+impl fmt::Debug for ResolvedAlias {
+    /// Redacts [`Self::authorization`] — it carries the uplink's server-owned
+    /// upstream credential, which must never reach a log line or panic dump.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ResolvedAlias")
+            .field("name", &self.name)
+            .field("generation", &self.generation)
+            .field("registry", &self.registry)
+            .field("origin", &self.origin)
+            .field("authorization", &"<redacted>")
+            .field("access", &self.access)
+            .finish()
+    }
 }
 
 impl RouteContext {
@@ -396,7 +412,6 @@ impl ResolvedAlias {
 /// fetch routes through [`UpstreamRouteHook::authorize`], which classifies
 /// the route, records it into the shared [`Footprint`], and returns the
 /// pnpr-managed credential (never a client-forwarded one).
-#[derive(Debug)]
 pub struct RouteHook {
     context: RouteContext,
     identity: Identity,
@@ -405,6 +420,19 @@ pub struct RouteHook {
     /// ([`MetadataCacheScope::Private`]); the same server secret the
     /// resolution cache keys private footprints with.
     secret: Arc<[u8]>,
+}
+
+impl fmt::Debug for RouteHook {
+    /// Redacts [`Self::secret`] — the descriptor-HMAC key must never reach a
+    /// log line or panic dump, or the private namespace becomes correlatable.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RouteHook")
+            .field("context", &self.context)
+            .field("identity", &self.identity)
+            .field("footprint", &self.footprint)
+            .field("secret", &"<redacted>")
+            .finish()
+    }
 }
 
 impl RouteHook {

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -432,7 +432,7 @@ fn compile_glob(pattern: &str) -> Option<Glob<'static>> {
 
 /// Nerf-dart a registry URL down to its host-only origin
 /// (`//host[:port]/`), the prefix every fetch under it shares. `None`
-/// for an unparseable URL.
+/// for an unparsable URL.
 fn nerf_origin(url: &str) -> Option<String> {
     let nerfed = nerf_dart(url);
     if nerfed.is_empty() { None } else { Some(host_prefix(&nerfed)) }

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -49,8 +49,10 @@ pub enum RouteClass {
     /// identifies the access-policy rule that produced the entry.
     Hosted { policy_id: String },
     /// A proxied upstream route served with a pnpr-managed credential
-    /// alias the caller is authorized to use.
-    Proxied { alias: String, generation: u64 },
+    /// alias the caller is authorized to use. `credential_digest` is a hash
+    /// of the uplink's `Authorization`, so rotating the credential changes it
+    /// (see [`credential_digest`]).
+    Proxied { alias: String, credential_digest: String },
 }
 
 /// The cache-namespace identity of a private route: a key input plus
@@ -59,9 +61,10 @@ pub enum RouteClass {
 /// callers who share the same access collapse to one shared entry.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum PrivateAccessDescriptor {
-    /// Proxied route via a pnpr-managed upstream alias. Rotating the
-    /// alias bumps `generation`, moving future hits to a new namespace.
-    Alias { alias: String, generation: u64 },
+    /// Proxied route via a pnpr-managed upstream alias. `credential_digest`
+    /// hashes the uplink's `Authorization`, so rotating the credential moves
+    /// future hits to a new namespace — no manual epoch counter to bump.
+    Alias { alias: String, credential_digest: String },
     /// pnpr-hosted route, gated by re-running the named package access
     /// policy for the caller.
     Hosted { policy_id: String },
@@ -74,8 +77,8 @@ impl PrivateAccessDescriptor {
     /// policy of the same text).
     fn key_input(&self) -> String {
         match self {
-            PrivateAccessDescriptor::Alias { alias, generation } => {
-                format!("alias\0{alias}\0{generation}")
+            PrivateAccessDescriptor::Alias { alias, credential_digest } => {
+                format!("alias\0{alias}\0{credential_digest}")
             }
             PrivateAccessDescriptor::Hosted { policy_id } => format!("hosted\0{policy_id}"),
         }
@@ -94,13 +97,31 @@ impl PrivateAccessDescriptor {
 
 /// The HMAC digest namespacing an uplink's private cache (packuments and
 /// tarballs), identical to the metadata-mirror descriptor id for the same
-/// `(uplink, generation)`. Keyed by the server `secret` so the on-disk path
-/// reveals neither the uplink name nor its generation, and so a path-unsafe
+/// `(uplink, credential)`. Keyed by the server `secret` so the on-disk path
+/// reveals neither the uplink name nor its credential, and so a path-unsafe
 /// uplink name (`..`, `/`) can never escape the cache root — the digest is
-/// hex.
+/// hex. `credential_digest` is a [`credential_digest`] of the uplink's
+/// `Authorization`, so a credential rotation moves to a fresh namespace.
 #[must_use]
-pub(crate) fn uplink_cache_digest(uplink: &str, generation: u64, secret: &[u8]) -> String {
-    PrivateAccessDescriptor::Alias { alias: uplink.to_string(), generation }.digest_id(secret)
+pub(crate) fn uplink_cache_digest(
+    uplink: &str,
+    credential_digest: String,
+    secret: &[u8],
+) -> String {
+    PrivateAccessDescriptor::Alias { alias: uplink.to_string(), credential_digest }
+        .digest_id(secret)
+}
+
+/// A hash of an uplink's `Authorization` header value, used as the credential
+/// epoch in [`PrivateAccessDescriptor::Alias`]. Rotating the upstream
+/// credential changes this automatically, re-keying every private cache the
+/// uplink owns — so a rotation invalidates old-credential content with no
+/// manual step to forget. The raw token never appears: it's a one-way SHA-256
+/// (then HMAC-keyed with the server secret by [`PrivateAccessDescriptor::digest_id`]
+/// before it reaches disk).
+#[must_use]
+pub(crate) fn credential_digest(authorization: &str) -> String {
+    hex(&Sha256::digest(authorization.as_bytes()))
 }
 
 /// The set of private routes a single resolve actually touched, paired
@@ -187,7 +208,10 @@ struct RouteMatcher {
 #[derive(Clone)]
 struct ResolvedAlias {
     name: String,
-    generation: u64,
+    /// [`credential_digest`] of [`Self::authorization`]: the credential epoch
+    /// this alias's private cache entries are keyed by. Changes when the
+    /// upstream credential rotates.
+    credential_digest: String,
     registry: String,
     /// Nerf-darted upstream origin the alias serves. Routing is by origin
     /// alone — an uplink credential covers every package on its registry.
@@ -210,7 +234,7 @@ impl fmt::Debug for ResolvedAlias {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ResolvedAlias")
             .field("name", &self.name)
-            .field("generation", &self.generation)
+            .field("credential_digest", &self.credential_digest)
             .field("registry", &self.registry)
             .field("origin", &self.origin)
             .field("scheme", &self.scheme)
@@ -291,7 +315,7 @@ impl RouteContext {
                 {
                     Some(alias) => RouteClass::Proxied {
                         alias: alias.name.clone(),
-                        generation: alias.generation,
+                        credential_digest: alias.credential_digest.clone(),
                     },
                     None => RouteClass::Public,
                 };
@@ -307,7 +331,10 @@ impl RouteContext {
             // uplink's server-owned credential and leak it in cleartext. A
             // scheme mismatch falls through to an anonymous public fetch (which
             // fails closed upstream if the resource is actually private).
-            return RouteClass::Proxied { alias: alias.name.clone(), generation: alias.generation };
+            return RouteClass::Proxied {
+                alias: alias.name.clone(),
+                credential_digest: alias.credential_digest.clone(),
+            };
         }
 
         RouteClass::Public
@@ -386,20 +413,22 @@ impl RouteContext {
         descriptor: &PrivateAccessDescriptor,
     ) -> bool {
         match descriptor {
-            PrivateAccessDescriptor::Alias { alias, generation } => {
+            PrivateAccessDescriptor::Alias { alias, credential_digest } => {
                 // Reuse the cached resolution only if `identity` would *select*
-                // this exact alias+generation for its origin — the first
-                // authorized alias [`Self::select_alias`] returns there — not
-                // merely one the caller is authorized for. With overlapping
-                // uplink access (several aliases on one origin a caller can
-                // use), an authorization-only check could replay a lockfile
-                // routed through a different `/~<uplink>/` endpoint than this
-                // caller resolves through. A since-removed alias (`find` →
-                // `None`) or a rotated generation also fails closed here.
+                // this exact alias for its origin — the first authorized alias
+                // [`Self::select_alias`] returns there — and its credential
+                // still hashes to the same digest. Not merely an alias the
+                // caller is authorized for: with overlapping uplink access
+                // (several aliases on one origin a caller can use), an
+                // authorization-only check could replay a lockfile routed
+                // through a different `/~<uplink>/` endpoint than this caller
+                // resolves through. A since-removed alias (`find` → `None`) or
+                // a rotated credential also fails closed here.
                 self.aliases.iter().find(|candidate| candidate.name == alias.as_str()).is_some_and(
                     |candidate| {
                         self.select_alias(identity, &candidate.origin).is_some_and(|selected| {
-                            selected.name == alias.as_str() && selected.generation == *generation
+                            selected.name == alias.as_str()
+                                && selected.credential_digest == *credential_digest
                         })
                     },
                 )
@@ -484,7 +513,7 @@ impl ResolvedAlias {
             uplink.headers.get(AUTHORIZATION).and_then(|value| value.to_str().ok())?.to_string();
         Some(Self {
             name: name.to_string(),
-            generation: uplink.generation,
+            credential_digest: credential_digest(&authorization),
             registry: uplink.url.clone(),
             origin: nerf_prefix(&uplink.url)?,
             scheme: scheme_of(&uplink.url)?.to_string(),
@@ -544,14 +573,14 @@ impl UpstreamRouteHook for RouteHook {
                 // credential is involved.
                 None
             }
-            RouteClass::Proxied { alias, generation } => {
+            RouteClass::Proxied { alias, credential_digest } => {
                 let authorization = self
                     .context
                     .aliases
                     .iter()
                     .find(|candidate| candidate.name == alias)
                     .map(|candidate| candidate.authorization.clone());
-                self.record(PrivateAccessDescriptor::Alias { alias, generation });
+                self.record(PrivateAccessDescriptor::Alias { alias, credential_digest });
                 authorization
             }
         }
@@ -566,8 +595,8 @@ impl UpstreamRouteHook for RouteHook {
                 descriptor_id: PrivateAccessDescriptor::Hosted { policy_id }
                     .digest_id(&self.secret),
             },
-            RouteClass::Proxied { alias, generation } => MetadataCacheScope::Private {
-                descriptor_id: PrivateAccessDescriptor::Alias { alias, generation }
+            RouteClass::Proxied { alias, credential_digest } => MetadataCacheScope::Private {
+                descriptor_id: PrivateAccessDescriptor::Alias { alias, credential_digest }
                     .digest_id(&self.secret),
             },
         }

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -27,11 +27,12 @@ use std::{
 };
 
 use pacquet_network::{MetadataCacheScope, UpstreamRouteHook, nerf_dart};
+use reqwest::header::AUTHORIZATION;
 use sha2::{Digest, Sha256};
 use wax::{Glob, Program};
 
 use crate::{
-    config::{Config, UpstreamAlias},
+    config::{Config, UplinkConfig, UpstreamAlias},
     policy::{AccessList, Identity, PackagePolicies},
 };
 
@@ -230,10 +231,20 @@ impl RouteContext {
                 package: route.package.as_deref().and_then(compile_glob),
             })
             .collect();
+        // Proxied-route credentials come from two sources during the
+        // `upstreamAliases` → `uplinks` migration: the legacy alias block and
+        // `uplinks:` entries that declare an `access:` policy. Uplink-sourced
+        // entries are matched by origin and exposed at `/~<name>/`.
         let aliases = config
             .upstream_aliases
             .iter()
             .filter_map(|(name, alias)| ResolvedAlias::from_config(name, alias))
+            .chain(
+                config
+                    .uplinks
+                    .iter()
+                    .filter_map(|(name, uplink)| ResolvedAlias::from_uplink(name, uplink)),
+            )
             .collect();
         Self {
             npmjs_unscoped_public: config.route_policy.npmjs_unscoped_public,
@@ -382,6 +393,25 @@ impl ResolvedAlias {
             package: alias.package.as_deref().and_then(compile_glob),
             authorization: alias.authorization.clone(),
             access: alias.access.clone(),
+        })
+    }
+
+    /// Build a proxied-route alias from a `uplinks:` entry. An uplink
+    /// participates in route classification only when it declares both an
+    /// `access:` policy and a resolved `Authorization` credential; routing is
+    /// by registry origin, so no package glob is attached.
+    fn from_uplink(name: &str, uplink: &UplinkConfig) -> Option<Self> {
+        let access = uplink.access.clone()?;
+        let authorization =
+            uplink.headers.get(AUTHORIZATION).and_then(|value| value.to_str().ok())?.to_string();
+        Some(Self {
+            name: name.to_string(),
+            generation: uplink.generation,
+            registry: uplink.url.clone(),
+            origin: nerf_origin(&uplink.url)?,
+            package: None,
+            authorization,
+            access,
         })
     }
 }

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -273,6 +273,27 @@ impl RouteContext {
         if let Some(hosted) = self.hosted_origin.as_deref()
             && fetch.starts_with(hosted)
         {
+            // A fetch to pnpr's own `/~<uplink>/` endpoint addresses that
+            // uplink, not a hosted package (a package name can never begin
+            // with `~`). Authorized callers resolve through the uplink;
+            // everyone else — and an unknown uplink — fails closed rather
+            // than falling through to the hosted-package policy.
+            if let Some(rest) = fetch.strip_prefix(hosted)
+                && let Some(uplink) = rest.strip_prefix('~').and_then(|rest| rest.split('/').next())
+                && !uplink.is_empty()
+            {
+                return match self
+                    .aliases
+                    .iter()
+                    .find(|alias| alias.name == uplink && alias.access.allows(identity))
+                {
+                    Some(alias) => RouteClass::Proxied {
+                        alias: alias.name.clone(),
+                        generation: alias.generation,
+                    },
+                    None => RouteClass::Unknown,
+                };
+            }
             return self.classify_hosted(identity, package);
         }
 

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -61,7 +61,7 @@ pub enum RouteClass {
 /// gets HMAC'd into the cache key; identical inputs from different
 /// callers who share the same access collapse to one shared entry.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-enum PrivateAccessDescriptor {
+pub(crate) enum PrivateAccessDescriptor {
     /// Proxied route via a pnpr-managed upstream alias. Rotating the
     /// alias bumps `generation`, moving future hits to a new namespace.
     Alias { alias: String, generation: u64 },
@@ -92,7 +92,7 @@ impl PrivateAccessDescriptor {
 ///
 /// An empty footprint with no unknown-private touch means the resolution
 /// is fully public and shareable globally.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Footprint {
     descriptors: BTreeSet<PrivateAccessDescriptor>,
     /// A private/unknown route with no usable descriptor was fetched, so
@@ -102,7 +102,7 @@ pub struct Footprint {
 }
 
 impl Footprint {
-    fn add(&mut self, descriptor: PrivateAccessDescriptor) {
+    pub(crate) fn add(&mut self, descriptor: PrivateAccessDescriptor) {
         self.descriptors.insert(descriptor);
     }
 
@@ -143,6 +143,17 @@ impl Footprint {
             message.push('\n');
         }
         Some(hex(&hmac_sha256(secret, message.as_bytes())))
+    }
+
+    /// Whether every private descriptor in this footprint is still
+    /// authorized for `identity` under the current route context.
+    #[must_use]
+    pub(crate) fn allows(&self, context: &RouteContext, identity: &Identity) -> bool {
+        !self.touched_unknown_private
+            && self
+                .descriptors
+                .iter()
+                .all(|descriptor| context.allows_descriptor(identity, descriptor))
     }
 }
 
@@ -290,6 +301,25 @@ impl RouteContext {
                     .is_none_or(|glob| package.is_some_and(|name| glob.is_match(name)))
                 && alias.access.allows(identity)
         })
+    }
+
+    pub(crate) fn allows_descriptor(
+        &self,
+        identity: &Identity,
+        descriptor: &PrivateAccessDescriptor,
+    ) -> bool {
+        match descriptor {
+            PrivateAccessDescriptor::Alias { alias, generation } => {
+                self.aliases.iter().any(|candidate| {
+                    candidate.name == alias.as_str()
+                        && candidate.generation == *generation
+                        && candidate.access.allows(identity)
+                })
+            }
+            PrivateAccessDescriptor::Hosted { policy_id } => {
+                self.policies.for_package(policy_id).access.allows(identity)
+            }
+        }
     }
 }
 

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -175,7 +175,7 @@ impl Footprint {
 pub struct RouteContext {
     /// Built-in route: unscoped packages on `registry.npmjs.org` are
     /// public. Operators can disable this for a conservative deployment.
-    npmjs_unscoped_public: bool,
+    npmjs_public: bool,
     /// Nerf-darted origin of this pnpr service (from `public_url`). A
     /// fetch whose URL falls under it is a pnpr-hosted route.
     hosted_origin: Option<String>,
@@ -250,7 +250,7 @@ impl RouteContext {
             .filter_map(|(name, uplink)| ResolvedAlias::from_uplink(name, uplink))
             .collect();
         Self {
-            npmjs_unscoped_public: config.route_policy.npmjs_unscoped_public,
+            npmjs_public: config.route_policy.npmjs_public,
             hosted_origin,
             public_routes,
             aliases,
@@ -308,13 +308,43 @@ impl RouteContext {
     }
 
     fn is_public_route(&self, fetch: &str, package: Option<&str>) -> bool {
-        if self.npmjs_unscoped_public
-            && origin_of(fetch) == Some("registry.npmjs.org")
-            && package.is_none_or(|name| !name.starts_with('@'))
-        {
+        // The official npm registry is public at the host level: an anonymous
+        // fetch returns only public content (a private scoped package 404s),
+        // so a successfully-resolved npmjs route — scoped or not — is public
+        // and globally shareable.
+        if self.npmjs_public && origin_of(fetch) == Some("registry.npmjs.org") {
             return true;
         }
         self.public_routes.iter().any(|route| route.matches(fetch, package))
+    }
+
+    /// Whether pnpr is permitted to fetch from `url`'s registry at all. The
+    /// allowlist is the union of every configured route: the built-in npm
+    /// host, operator-declared public routes, configured uplink origins, and
+    /// pnpr's own origin (which serves its hosted packages and `/~<uplink>/`
+    /// endpoints). A client `registry`/`namedRegistries` matching none of
+    /// these is rejected before any server-side fetch — the resolver's SSRF
+    /// boundary — so there is no "unknown registry" to resolve anonymously.
+    #[must_use]
+    pub fn allows_registry(&self, url: &str) -> bool {
+        let fetch = nerf_dart(url);
+        if fetch.is_empty() {
+            return false;
+        }
+        if self.npmjs_public && origin_of(&fetch) == Some("registry.npmjs.org") {
+            return true;
+        }
+        if self.hosted_origin.as_deref().is_some_and(|hosted| fetch.starts_with(hosted)) {
+            return true;
+        }
+        if self
+            .public_routes
+            .iter()
+            .any(|route| route.origin.as_deref().is_some_and(|origin| fetch.starts_with(origin)))
+        {
+            return true;
+        }
+        self.aliases.iter().any(|alias| fetch.starts_with(&alias.origin))
     }
 
     /// A pnpr-hosted route is public when its package access policy

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -157,14 +157,12 @@ impl Footprint {
 /// [`Config`] and reused across every fetch in a resolve.
 #[derive(Debug, Clone)]
 pub struct RouteContext {
-    /// Built-in route: unscoped packages on `registry.npmjs.org` are
-    /// public. Operators can disable this for a conservative deployment.
-    npmjs_public: bool,
     /// Nerf-darted origin of this pnpr service (from `public_url`). A
     /// fetch whose URL falls under it is a pnpr-hosted route.
     hosted_origin: Option<String>,
-    /// Operator-declared public routes, matched by nerf-darted registry
-    /// prefix and/or package glob.
+    /// Public routes, matched by nerf-darted registry prefix and/or package
+    /// glob. Always begins with the built-in official-npm route
+    /// ([`RouteMatcher::npmjs`]), followed by the operator-declared ones.
     public_routes: Vec<RouteMatcher>,
     /// pnpr-managed upstream credential aliases, in declared order.
     aliases: Vec<ResolvedAlias>,
@@ -227,8 +225,12 @@ impl RouteContext {
     #[must_use]
     pub fn from_config(config: &Config) -> Self {
         let hosted_origin = nerf_prefix(&config.public_url);
-        let public_routes =
-            config.route_policy.public.iter().filter_map(RouteMatcher::from_public_route).collect();
+        // The official npm registry is a built-in public route, so it is both
+        // allowlisted and classified public without any operator config (and
+        // ahead of any uplink credential for the same origin — public wins).
+        let public_routes = std::iter::once(RouteMatcher::npmjs())
+            .chain(config.route_policy.public.iter().filter_map(RouteMatcher::from_public_route))
+            .collect();
         // Proxied-route credentials come from `uplinks:` entries that declare
         // an `access:` policy. They are matched by registry origin and exposed
         // to clients at `/~<name>/`.
@@ -240,7 +242,6 @@ impl RouteContext {
         let uplink_origins =
             config.uplinks.values().filter_map(|uplink| nerf_prefix(&uplink.url)).collect();
         Self {
-            npmjs_public: config.route_policy.npmjs_public,
             hosted_origin,
             public_routes,
             aliases,
@@ -313,13 +314,6 @@ impl RouteContext {
     }
 
     fn is_public_route(&self, fetch: &str, package: Option<&str>) -> bool {
-        // The official npm registry is public at the host level: an anonymous
-        // fetch returns only public content (a private scoped package 404s),
-        // so a successfully-resolved npmjs route — scoped or not — is public
-        // and globally shareable.
-        if self.npmjs_public && origin_of(fetch) == Some("registry.npmjs.org") {
-            return true;
-        }
         self.public_routes.iter().any(|route| route.matches(fetch, package))
     }
 
@@ -342,9 +336,6 @@ impl RouteContext {
         // so any dot-segment fails closed.
         if contains_dot_segment(&fetch) {
             return false;
-        }
-        if self.npmjs_public && origin_of(&fetch) == Some("registry.npmjs.org") {
-            return true;
         }
         if self.hosted_origin.as_deref().is_some_and(|hosted| fetch.starts_with(hosted)) {
             return true;
@@ -431,7 +422,21 @@ impl RouteContext {
     }
 }
 
+/// Nerf-darted origin of the official npm registry, the built-in public route.
+const NPMJS_ORIGIN: &str = "//registry.npmjs.org/";
+
 impl RouteMatcher {
+    /// The built-in public route: the official npm registry, host-level (no
+    /// package glob, so scoped and unscoped packages alike are public). An
+    /// anonymous fetch returns only public content — a private scoped package
+    /// `404`s — so a successfully-resolved npmjs route is public and globally
+    /// shareable. Prepended to the operator-declared routes in
+    /// [`RouteContext::from_config`], so it is allowlisted and public without
+    /// any config, and ahead of any uplink credential for the same origin.
+    fn npmjs() -> Self {
+        Self { origin: Some(NPMJS_ORIGIN.to_string()), package: None }
+    }
+
     /// Build a matcher from an operator-declared public route, failing
     /// closed. An *omitted* `registry`/`package` field means "match any" —
     /// the intended wildcard — but a field that is *present yet unparsable*
@@ -650,11 +655,6 @@ fn compile_glob(pattern: &str) -> Option<Glob<'static>> {
 fn nerf_prefix(url: &str) -> Option<String> {
     let nerfed = nerf_dart(url);
     if nerfed.is_empty() { None } else { Some(nerfed) }
-}
-
-/// The `host[:port]` of a nerf-darted key (`//host[:port]/path/`).
-fn origin_of(nerfed: &str) -> Option<&str> {
-    nerfed.strip_prefix("//")?.split('/').next().filter(|host| !host.is_empty())
 }
 
 /// The URL scheme (`https`, `http`, ...), i.e. the segment before `://`. `None`

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -92,6 +92,17 @@ impl PrivateAccessDescriptor {
     }
 }
 
+/// The HMAC digest namespacing an uplink's private cache (packuments and
+/// tarballs), identical to the metadata-mirror descriptor id for the same
+/// `(uplink, generation)`. Keyed by the server `secret` so the on-disk path
+/// reveals neither the uplink name nor its generation, and so a path-unsafe
+/// uplink name (`..`, `/`) can never escape the cache root — the digest is
+/// hex.
+#[must_use]
+pub(crate) fn uplink_cache_digest(uplink: &str, generation: u64, secret: &[u8]) -> String {
+    PrivateAccessDescriptor::Alias { alias: uplink.to_string(), generation }.digest_id(secret)
+}
+
 /// The set of private routes a single resolve actually touched, paired
 /// with the descriptor selected for each. Accumulated during resolution
 /// through the [`RouteHook`]; consumed afterwards to decide how the

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -413,7 +413,7 @@ impl ResolvedAlias {
 /// the route, records it into the shared [`Footprint`], and returns the
 /// pnpr-managed credential (never a client-forwarded one).
 pub struct RouteHook {
-    context: RouteContext,
+    context: Arc<RouteContext>,
     identity: Identity,
     footprint: Arc<Mutex<Footprint>>,
     /// HMAC secret keying the per-descriptor metadata namespace
@@ -438,7 +438,7 @@ impl fmt::Debug for RouteHook {
 impl RouteHook {
     #[must_use]
     pub fn new(
-        context: RouteContext,
+        context: Arc<RouteContext>,
         identity: Identity,
         footprint: Arc<Mutex<Footprint>>,
         secret: Arc<[u8]>,

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -51,11 +51,6 @@ pub enum RouteClass {
     /// A proxied upstream route served with a pnpr-managed credential
     /// alias the caller is authorized to use.
     Proxied { alias: String, generation: u64 },
-    /// A private/unknown route for which the caller has no usable
-    /// pnpr-managed credential or hosted authorization. Resolved
-    /// anonymously as a *non-shareable* miss; never written to the
-    /// global public cache.
-    Unknown,
 }
 
 /// The cache-namespace identity of a private route: a key input plus
@@ -102,15 +97,11 @@ impl PrivateAccessDescriptor {
 /// through the [`RouteHook`]; consumed afterwards to decide how the
 /// resolution may be cached.
 ///
-/// An empty footprint with no unknown-private touch means the resolution
-/// is fully public and shareable globally.
+/// An empty footprint means the resolution is fully public and shareable
+/// globally; a non-empty one is keyed by its private access descriptors.
 #[derive(Debug, Default, Clone)]
 pub struct Footprint {
     descriptors: BTreeSet<PrivateAccessDescriptor>,
-    /// A private/unknown route with no usable descriptor was fetched, so
-    /// the resolution carries private data that cannot be safely keyed —
-    /// it must not be shared at all.
-    touched_unknown_private: bool,
 }
 
 impl Footprint {
@@ -118,25 +109,11 @@ impl Footprint {
         self.descriptors.insert(descriptor);
     }
 
-    fn mark_unknown_private(&mut self) {
-        self.touched_unknown_private = true;
-    }
-
     /// Whether the resolution touched no private data and may be cached
     /// under the global, auth-excluded key.
     #[must_use]
     pub fn is_public(&self) -> bool {
-        self.descriptors.is_empty() && !self.touched_unknown_private
-    }
-
-    /// Whether the resolution may be cached at all. A resolution that
-    /// touched an unknown-private route carries private data with no
-    /// descriptor to key it, so it can be served only to the caller that
-    /// produced it (i.e. not shared) — Part 2 treats this as
-    /// non-cacheable.
-    #[must_use]
-    pub fn is_shareable(&self) -> bool {
-        !self.touched_unknown_private
+        self.descriptors.is_empty()
     }
 
     /// The private-key component for this footprint: an HMAC over the
@@ -161,11 +138,7 @@ impl Footprint {
     /// authorized for `identity` under the current route context.
     #[must_use]
     pub(crate) fn allows(&self, context: &RouteContext, identity: &Identity) -> bool {
-        !self.touched_unknown_private
-            && self
-                .descriptors
-                .iter()
-                .all(|descriptor| context.allows_descriptor(identity, descriptor))
+        self.descriptors.iter().all(|descriptor| context.allows_descriptor(identity, descriptor))
     }
 }
 
@@ -184,6 +157,11 @@ pub struct RouteContext {
     public_routes: Vec<RouteMatcher>,
     /// pnpr-managed upstream credential aliases, in declared order.
     aliases: Vec<ResolvedAlias>,
+    /// Nerf-darted origin of every configured uplink (access-bearing or a
+    /// plain mirror), forming the uplink half of the fetch allowlist. A
+    /// plain mirror needs no credential, so it has no [`ResolvedAlias`]; it
+    /// is still a configured registry pnpr may fetch from anonymously.
+    uplink_origins: Vec<String>,
     /// Package access policy, used to decide whether a pnpr-hosted route
     /// is public (admits everyone) or private, and to gate hosted hits.
     policies: PackagePolicies,
@@ -249,11 +227,14 @@ impl RouteContext {
             .iter()
             .filter_map(|(name, uplink)| ResolvedAlias::from_uplink(name, uplink))
             .collect();
+        let uplink_origins =
+            config.uplinks.values().filter_map(|uplink| nerf_prefix(&uplink.url)).collect();
         Self {
             npmjs_public: config.route_policy.npmjs_public,
             hosted_origin,
             public_routes,
             aliases,
+            uplink_origins,
             policies: config.policies.clone(),
         }
     }
@@ -261,12 +242,18 @@ impl RouteContext {
     /// Classify a single fetch to `url` for `package` (`None` for a
     /// non-package fetch), for `identity`. Precedence follows the RFC:
     /// public wins and suppresses auth; then pnpr-hosted; then an
-    /// authorized proxied alias; otherwise unknown/private.
+    /// authorized proxied alias; otherwise an anonymous public fetch (no
+    /// managed credential). The fetch allowlist ([`Self::allows_registry`])
+    /// runs first at the request boundary, so a route reaching here is a
+    /// configured registry: an anonymous fall-through either succeeds —
+    /// proving the content is public and globally shareable — or fails
+    /// closed upstream (`401`/`403`) when it actually needed a credential
+    /// the caller is not authorized for.
     #[must_use]
     pub fn classify(&self, identity: &Identity, url: &str, package: Option<&str>) -> RouteClass {
         let fetch = nerf_dart(url);
         if fetch.is_empty() {
-            return RouteClass::Unknown;
+            return RouteClass::Public;
         }
 
         if self.is_public_route(&fetch, package) {
@@ -279,8 +266,9 @@ impl RouteContext {
             // A fetch to pnpr's own `/~<uplink>/` endpoint addresses that
             // uplink, not a hosted package (a package name can never begin
             // with `~`). Authorized callers resolve through the uplink;
-            // everyone else — and an unknown uplink — fails closed rather
-            // than falling through to the hosted-package policy.
+            // everyone else — and an unknown uplink — gets an anonymous
+            // fetch the endpoint itself rejects, rather than falling through
+            // to the hosted-package policy.
             if let Some(rest) = fetch.strip_prefix(hosted)
                 && let Some(uplink) = rest.strip_prefix('~').and_then(|rest| rest.split('/').next())
                 && !uplink.is_empty()
@@ -294,7 +282,7 @@ impl RouteContext {
                         alias: alias.name.clone(),
                         generation: alias.generation,
                     },
-                    None => RouteClass::Unknown,
+                    None => RouteClass::Public,
                 };
             }
             return self.classify_hosted(identity, package);
@@ -304,7 +292,7 @@ impl RouteContext {
             return RouteClass::Proxied { alias: alias.name.clone(), generation: alias.generation };
         }
 
-        RouteClass::Unknown
+        RouteClass::Public
     }
 
     fn is_public_route(&self, fetch: &str, package: Option<&str>) -> bool {
@@ -344,7 +332,7 @@ impl RouteContext {
         {
             return true;
         }
-        self.aliases.iter().any(|alias| fetch.starts_with(&alias.origin))
+        self.uplink_origins.iter().any(|origin| fetch.starts_with(origin))
     }
 
     /// A pnpr-hosted route is public when its package access policy
@@ -363,9 +351,11 @@ impl RouteContext {
         if access.allows(identity) {
             RouteClass::Hosted { policy_id: package.to_string() }
         } else {
-            // The caller can't read this hosted package, so it must not
-            // match any private hosted entry; fail closed.
-            RouteClass::Unknown
+            // The caller can't read this hosted package: classify it as an
+            // anonymous public fetch with no managed credential, which the
+            // hosted-serving endpoint re-checks and rejects, so it never
+            // matches a private hosted entry.
+            RouteClass::Public
         }
     }
 
@@ -497,10 +487,6 @@ impl UpstreamRouteHook for RouteHook {
                 self.record(PrivateAccessDescriptor::Alias { alias, generation });
                 authorization
             }
-            RouteClass::Unknown => {
-                self.footprint.lock().expect("footprint poisoned").mark_unknown_private();
-                None
-            }
         }
     }
 
@@ -517,7 +503,6 @@ impl UpstreamRouteHook for RouteHook {
                 descriptor_id: PrivateAccessDescriptor::Alias { alias, generation }
                     .digest_id(&self.secret),
             },
-            RouteClass::Unknown => MetadataCacheScope::Bypass,
         }
     }
 }

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -26,7 +26,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use pacquet_network::{UpstreamRouteHook, nerf_dart};
+use pacquet_network::{MetadataCacheScope, UpstreamRouteHook, nerf_dart};
 use sha2::{Digest, Sha256};
 use wax::{Glob, Program};
 
@@ -82,6 +82,16 @@ impl PrivateAccessDescriptor {
             }
             PrivateAccessDescriptor::Hosted { policy_id } => format!("hosted\0{policy_id}"),
         }
+    }
+
+    /// The metadata-namespace id for this single descriptor: an HMAC over
+    /// its [`Self::key_input`] keyed with the server `secret`, so the
+    /// on-disk private-metadata mirror path is not correlatable offline.
+    /// Distinct from [`Footprint::digest`], which combines *all* of a
+    /// resolution's descriptors — metadata is fetched one route at a time,
+    /// so each fetch keys on its own descriptor.
+    fn digest_id(&self, secret: &[u8]) -> String {
+        hex(&hmac_sha256(secret, self.key_input().as_bytes()))
     }
 }
 
@@ -386,6 +396,10 @@ pub struct RouteHook {
     context: RouteContext,
     identity: Identity,
     footprint: Arc<Mutex<Footprint>>,
+    /// HMAC secret keying the per-descriptor metadata namespace
+    /// ([`MetadataCacheScope::Private`]); the same server secret the
+    /// resolution cache keys private footprints with.
+    secret: Arc<[u8]>,
 }
 
 impl RouteHook {
@@ -394,8 +408,9 @@ impl RouteHook {
         context: RouteContext,
         identity: Identity,
         footprint: Arc<Mutex<Footprint>>,
+        secret: Arc<[u8]>,
     ) -> Self {
-        Self { context, identity, footprint }
+        Self { context, identity, footprint, secret }
     }
 }
 
@@ -423,6 +438,23 @@ impl UpstreamRouteHook for RouteHook {
                 self.footprint.lock().expect("footprint poisoned").mark_unknown_private();
                 None
             }
+        }
+    }
+
+    fn metadata_scope(&self, url: &str, package: Option<&str>) -> MetadataCacheScope {
+        // Read-only classification — this must not record into the
+        // footprint (`authorize` already does, at the real fetch point).
+        match self.context.classify(&self.identity, url, package) {
+            RouteClass::Public => MetadataCacheScope::Public,
+            RouteClass::Hosted { policy_id } => MetadataCacheScope::Private {
+                descriptor_id: PrivateAccessDescriptor::Hosted { policy_id }
+                    .digest_id(&self.secret),
+            },
+            RouteClass::Proxied { alias, generation } => MetadataCacheScope::Private {
+                descriptor_id: PrivateAccessDescriptor::Alias { alias, generation }
+                    .digest_id(&self.secret),
+            },
+            RouteClass::Unknown => MetadataCacheScope::Bypass,
         }
     }
 }

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -231,13 +231,13 @@ impl RouteContext {
     /// Resolve route-classification inputs from the server config.
     #[must_use]
     pub fn from_config(config: &Config) -> Self {
-        let hosted_origin = nerf_origin(&config.public_url);
+        let hosted_origin = nerf_prefix(&config.public_url);
         let public_routes = config
             .route_policy
             .public
             .iter()
             .map(|route| RouteMatcher {
-                origin: route.registry.as_deref().and_then(nerf_origin),
+                origin: route.registry.as_deref().and_then(nerf_prefix),
                 package: route.package.as_deref().and_then(compile_glob),
             })
             .collect();
@@ -400,7 +400,7 @@ impl ResolvedAlias {
             name: name.to_string(),
             generation: uplink.generation,
             registry: uplink.url.clone(),
-            origin: nerf_origin(&uplink.url)?,
+            origin: nerf_prefix(&uplink.url)?,
             authorization,
             access,
         })
@@ -527,18 +527,15 @@ fn compile_glob(pattern: &str) -> Option<Glob<'static>> {
 /// Nerf-dart a registry URL down to its host-only origin
 /// (`//host[:port]/`), the prefix every fetch under it shares. `None`
 /// for an unparsable URL.
-fn nerf_origin(url: &str) -> Option<String> {
+/// The nerf-darted registry prefix used to match fetches to a hosted, public,
+/// or proxied-uplink route. Path-preserving (`//host/base/`), unlike a bare
+/// host: a pnpr served under a path prefix (`https://host/pnpr/`) still
+/// recognizes its own `/pnpr/~<uplink>/` endpoints, and a public/uplink route
+/// declared for `https://host/base/` does not also match a sibling
+/// `https://host/other/` path on the same host.
+fn nerf_prefix(url: &str) -> Option<String> {
     let nerfed = nerf_dart(url);
-    if nerfed.is_empty() { None } else { Some(host_prefix(&nerfed)) }
-}
-
-/// The `//host[:port]/` prefix of a nerf-darted key, discarding any
-/// path so an origin comparison ignores path depth.
-fn host_prefix(nerfed: &str) -> String {
-    match origin_of(nerfed) {
-        Some(host) => format!("//{host}/"),
-        None => nerfed.to_string(),
-    }
+    if nerfed.is_empty() { None } else { Some(nerfed) }
 }
 
 /// The `host[:port]` of a nerf-darted key (`//host[:port]/path/`).

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -612,6 +612,24 @@ pub(crate) fn strip_url_credentials(url: &str) -> String {
     }
 }
 
+/// Sanitize an upstream `dist.tarball` URL for public emission: drop inline
+/// userinfo (via [`strip_url_credentials`]) **and** any query string or
+/// fragment, where a registry could carry a signed-URL / tokenized credential
+/// (`?X-Amz-Signature=…`, `?token=…`). A genuinely public tarball is fetched by
+/// its bare path and verified by SRI regardless, so the sanitized URL still
+/// works; one that truly needed a token was never a public route and must be
+/// configured as an uplink (whose tarballs route through `/~<uplink>/`, keeping
+/// the token server-side). Unlike a client-supplied direct-tarball spec — whose
+/// query is the caller's own intent — this is untrusted upstream metadata.
+#[must_use]
+pub(crate) fn sanitize_registry_tarball_url(url: &str) -> String {
+    let no_creds = strip_url_credentials(url);
+    match no_creds.split_once(['?', '#']) {
+        Some((base, _)) => base.to_string(),
+        None => no_creds,
+    }
+}
+
 /// Compile a package glob, returning `None` for an invalid pattern rather
 /// than failing the whole resolve. [`RouteMatcher::from_public_route`] turns
 /// that `None` into a dropped (never-matching) rule, so an operator typo

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -365,11 +365,22 @@ impl RouteContext {
     ) -> bool {
         match descriptor {
             PrivateAccessDescriptor::Alias { alias, generation } => {
-                self.aliases.iter().any(|candidate| {
-                    candidate.name == alias.as_str()
-                        && candidate.generation == *generation
-                        && candidate.access.allows(identity)
-                })
+                // Reuse the cached resolution only if `identity` would *select*
+                // this exact alias+generation for its origin — the first
+                // authorized alias [`Self::select_alias`] returns there — not
+                // merely one the caller is authorized for. With overlapping
+                // uplink access (several aliases on one origin a caller can
+                // use), an authorization-only check could replay a lockfile
+                // routed through a different `/~<uplink>/` endpoint than this
+                // caller resolves through. A since-removed alias (`find` →
+                // `None`) or a rotated generation also fails closed here.
+                self.aliases.iter().find(|candidate| candidate.name == alias.as_str()).is_some_and(
+                    |candidate| {
+                        self.select_alias(identity, &candidate.origin).is_some_and(|selected| {
+                            selected.name == alias.as_str() && selected.generation == *generation
+                        })
+                    },
+                )
             }
             PrivateAccessDescriptor::Hosted { policy_id } => {
                 self.policies.for_package(policy_id).access.allows(identity)

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -32,7 +32,7 @@ use sha2::{Digest, Sha256};
 use wax::{Glob, Program};
 
 use crate::{
-    config::{Config, UplinkConfig, UpstreamAlias},
+    config::{Config, UplinkConfig},
     policy::{AccessList, Identity, PackagePolicies},
 };
 
@@ -211,12 +211,6 @@ struct ResolvedAlias {
     access: AccessList,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct GatewayAlias {
-    pub(crate) registry: String,
-    pub(crate) authorization: String,
-}
-
 impl RouteContext {
     /// Resolve route-classification inputs from the server config.
     #[must_use]
@@ -231,20 +225,13 @@ impl RouteContext {
                 package: route.package.as_deref().and_then(compile_glob),
             })
             .collect();
-        // Proxied-route credentials come from two sources during the
-        // `upstreamAliases` → `uplinks` migration: the legacy alias block and
-        // `uplinks:` entries that declare an `access:` policy. Uplink-sourced
-        // entries are matched by origin and exposed at `/~<name>/`.
+        // Proxied-route credentials come from `uplinks:` entries that declare
+        // an `access:` policy. They are matched by registry origin and exposed
+        // to clients at `/~<name>/`.
         let aliases = config
-            .upstream_aliases
+            .uplinks
             .iter()
-            .filter_map(|(name, alias)| ResolvedAlias::from_config(name, alias))
-            .chain(
-                config
-                    .uplinks
-                    .iter()
-                    .filter_map(|(name, uplink)| ResolvedAlias::from_uplink(name, uplink)),
-            )
+            .filter_map(|(name, uplink)| ResolvedAlias::from_uplink(name, uplink))
             .collect();
         Self {
             npmjs_unscoped_public: config.route_policy.npmjs_unscoped_public,
@@ -371,25 +358,15 @@ impl RouteContext {
         }
     }
 
-    pub(crate) fn gateway_alias(
-        &self,
-        identity: &Identity,
-        alias: &str,
-        generation: u64,
-        package: &str,
-    ) -> Option<GatewayAlias> {
+    /// The upstream registry an authorized caller reaches through the
+    /// `/~<uplink>/` endpoint, used to reverse an endpoint tarball URL back to
+    /// its upstream when verifying an input lockfile. Returns `None` when the
+    /// uplink is unknown or the caller is not authorized for it.
+    pub(crate) fn uplink_registry(&self, identity: &Identity, uplink: &str) -> Option<String> {
         self.aliases
             .iter()
-            .find(|candidate| {
-                candidate.name == alias
-                    && candidate.generation == generation
-                    && candidate.access.allows(identity)
-                    && candidate.package.as_ref().is_none_or(|glob| glob.is_match(package))
-            })
-            .map(|candidate| GatewayAlias {
-                registry: candidate.registry.clone(),
-                authorization: candidate.authorization.clone(),
-            })
+            .find(|candidate| candidate.name == uplink && candidate.access.allows(identity))
+            .map(|candidate| candidate.registry.clone())
     }
 }
 
@@ -405,18 +382,6 @@ impl RouteMatcher {
 }
 
 impl ResolvedAlias {
-    fn from_config(name: &str, alias: &UpstreamAlias) -> Option<Self> {
-        Some(Self {
-            name: name.to_string(),
-            generation: alias.generation,
-            registry: alias.registry.clone(),
-            origin: nerf_origin(&alias.registry)?,
-            package: alias.package.as_deref().and_then(compile_glob),
-            authorization: alias.authorization.clone(),
-            access: alias.access.clone(),
-        })
-    }
-
     /// Build a proxied-route alias from a `uplinks:` entry. An uplink
     /// participates in route classification only when it declares both an
     /// `access:` policy and a resolved `Authorization` credential; routing is

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -325,6 +325,13 @@ impl RouteContext {
         if fetch.is_empty() {
             return false;
         }
+        // A `.`/`..` path segment can slip past a path-scoped prefix match
+        // (`//host/base/../admin` starts_with `//host/base/` yet resolves to
+        // `//host/admin`), escaping the allowlist. Registries never use them,
+        // so any dot-segment fails closed.
+        if contains_dot_segment(&fetch) {
+            return false;
+        }
         if self.npmjs_public && origin_of(&fetch) == Some("registry.npmjs.org") {
             return true;
         }
@@ -606,6 +613,12 @@ fn origin_of(nerfed: &str) -> Option<&str> {
 /// for a value with no scheme.
 fn scheme_of(url: &str) -> Option<&str> {
     url.split_once("://").map(|(scheme, _)| scheme)
+}
+
+/// Whether a nerf-darted key (`//host/path/`) has a `.` or `..` path segment,
+/// which could escape a path-scoped prefix match in [`RouteContext::allows_registry`].
+fn contains_dot_segment(nerfed: &str) -> bool {
+    nerfed.split('/').any(|segment| segment == "." || segment == "..")
 }
 
 /// HMAC-SHA256 (RFC 2104) over the workspace's audited `sha2`, so the

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -174,6 +174,30 @@ fn uplink_with_access_is_a_proxied_route_matched_by_origin() {
 }
 
 #[test]
+fn self_uplink_endpoint_url_classifies_as_proxied_for_authorized_caller() {
+    let mut config = base_config();
+    config.uplinks.insert(
+        "corp".to_string(),
+        uplink_with_access("https://npm.corp.example/", "$authenticated", 5),
+    );
+    let context = RouteContext::from_config(&config);
+    // A request to pnpr's own `/~corp/` endpoint resolves through the corp
+    // uplink, using its current generation (the URL carries none).
+    let url = format!("{}/~corp/@acme%2fwidget", config.public_url);
+    assert_eq!(
+        context.classify(&user("alice"), &url, Some("@acme/widget")),
+        RouteClass::Proxied { alias: "corp".to_string(), generation: 5 },
+    );
+    // An unauthorized caller fails closed: a `/~<uplink>/` URL is an uplink
+    // endpoint, never a hosted package, so it does not fall through to the
+    // hosted-package policy.
+    assert_eq!(context.classify(&anon(), &url, Some("@acme/widget")), RouteClass::Unknown);
+    // An unknown uplink name also fails closed.
+    let ghost = format!("{}/~ghost/@acme%2fwidget", config.public_url);
+    assert_eq!(context.classify(&user("alice"), &ghost, Some("@acme/widget")), RouteClass::Unknown);
+}
+
+#[test]
 fn uplink_without_access_is_not_a_proxied_route() {
     let mut config = base_config();
     let mut headers = HeaderMap::new();

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -9,7 +9,7 @@ use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 
 use super::{Footprint, PrivateAccessDescriptor, RouteClass, RouteContext, RouteHook};
 use crate::{
-    config::{Config, PublicRoute, UplinkConfig, UpstreamAlias},
+    config::{Config, PublicRoute, UplinkConfig},
     policy::{AccessList, Identity, PackagePolicies},
 };
 
@@ -23,16 +23,6 @@ fn anon() -> Identity {
 
 fn user(name: &str) -> Identity {
     Identity::user(name)
-}
-
-fn alias(registry: &str, package: Option<&str>, access: &str, generation: u64) -> UpstreamAlias {
-    UpstreamAlias {
-        registry: registry.to_string(),
-        package: package.map(str::to_string),
-        authorization: "Bearer alias-secret".to_string(),
-        access: AccessList::parse(access),
-        generation,
-    }
 }
 
 #[test]
@@ -106,30 +96,6 @@ fn operator_declared_public_route_matches_scope() {
     assert_eq!(
         context.classify(&anon(), "https://registry.npmjs.org/@babel%2fcore", Some("@babel/core")),
         RouteClass::Public,
-    );
-}
-
-#[test]
-fn proxied_alias_requires_authorization() {
-    let mut config = base_config();
-    config.upstream_aliases.insert(
-        "corp".to_string(),
-        alias("https://npm.corp.example/", Some("@acme/*"), "$authenticated", 2),
-    );
-    let context = RouteContext::from_config(&config);
-    let url = "https://npm.corp.example/@acme%2fwidget";
-
-    assert_eq!(
-        context.classify(&user("alice"), url, Some("@acme/widget")),
-        RouteClass::Proxied { alias: "corp".to_string(), generation: 2 },
-    );
-    // An unauthorized caller cannot select the alias, so the route is a
-    // non-shareable unknown rather than the alias's private namespace.
-    assert_eq!(context.classify(&anon(), url, Some("@acme/widget")), RouteClass::Unknown);
-    // A package outside the alias's pattern doesn't match it.
-    assert_eq!(
-        context.classify(&user("alice"), "https://npm.corp.example/lodash", Some("lodash")),
-        RouteClass::Unknown,
     );
 }
 
@@ -219,10 +185,9 @@ fn uplink_without_access_is_not_a_proxied_route() {
 fn proxied_alias_accepts_configured_group_identity() {
     let mut config = base_config();
     config.groups.add_user_to_group("alice", "platform");
-    config.upstream_aliases.insert(
-        "corp".to_string(),
-        alias("https://npm.corp.example/", Some("@acme/*"), "platform", 2),
-    );
+    config
+        .uplinks
+        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "platform", 2));
     let context = RouteContext::from_config(&config);
     let url = "https://npm.corp.example/@acme%2fwidget";
 
@@ -306,9 +271,10 @@ fn footprint_unknown_private_is_not_shareable() {
 #[test]
 fn route_hook_records_routes_and_returns_alias_credential() {
     let mut config = base_config();
-    config
-        .upstream_aliases
-        .insert("corp".to_string(), alias("https://npm.corp.example/", None, "$authenticated", 1));
+    config.uplinks.insert(
+        "corp".to_string(),
+        uplink_with_access("https://npm.corp.example/", "$authenticated", 1),
+    );
     let footprint = std::sync::Arc::new(std::sync::Mutex::new(Footprint::default()));
     let hook = RouteHook::new(
         RouteContext::from_config(&config),
@@ -319,10 +285,10 @@ fn route_hook_records_routes_and_returns_alias_credential() {
 
     // Public fetch: no upstream credential, no private footprint entry.
     assert_eq!(hook.authorize("https://registry.npmjs.org/lodash", Some("lodash")), None);
-    // Private proxied fetch: the alias credential is returned and recorded.
+    // Private proxied fetch: the uplink credential is returned and recorded.
     assert_eq!(
         hook.authorize("https://npm.corp.example/@acme%2fwidget", Some("@acme/widget")),
-        Some("Bearer alias-secret".to_string()),
+        Some("Bearer uplink-secret".to_string()),
     );
 
     let footprint = footprint.lock().unwrap();
@@ -333,9 +299,10 @@ fn route_hook_records_routes_and_returns_alias_credential() {
 #[test]
 fn metadata_scope_maps_route_classes() {
     let mut config = base_config();
-    config
-        .upstream_aliases
-        .insert("corp".to_string(), alias("https://npm.corp.example/", None, "$authenticated", 3));
+    config.uplinks.insert(
+        "corp".to_string(),
+        uplink_with_access("https://npm.corp.example/", "$authenticated", 3),
+    );
     let footprint = std::sync::Arc::new(std::sync::Mutex::new(Footprint::default()));
     let hook = RouteHook::new(
         RouteContext::from_config(&config),
@@ -375,9 +342,10 @@ fn metadata_scope_maps_route_classes() {
 #[test]
 fn authorized_alias_users_share_metadata_scope() {
     let mut config = base_config();
-    config
-        .upstream_aliases
-        .insert("corp".to_string(), alias("https://npm.corp.example/", None, "$authenticated", 3));
+    config.uplinks.insert(
+        "corp".to_string(),
+        uplink_with_access("https://npm.corp.example/", "$authenticated", 3),
+    );
     let context = RouteContext::from_config(&config);
     let secret = Arc::from(b"server-secret".as_slice());
     let alice = RouteHook::new(

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -204,6 +204,29 @@ fn uplink_with_access_is_a_proxied_route_matched_by_origin() {
 }
 
 #[test]
+fn uplink_credential_is_not_attached_over_a_mismatched_scheme() {
+    let mut config = base_config();
+    config.uplinks.insert(
+        "corp".to_string(),
+        uplink_with_access("https://npm.corp.example/", "$authenticated", 1),
+    );
+    let context = RouteContext::from_config(&config);
+
+    // An https fetch matches the https uplink and gets the managed credential.
+    assert_eq!(
+        context.classify(&user("alice"), "https://npm.corp.example/lodash", Some("lodash")),
+        RouteClass::Proxied { alias: "corp".to_string(), generation: 1 },
+    );
+    // A plain-http fetch to the same origin must NOT receive the https uplink's
+    // server-owned token (nerf-darting strips the scheme); it falls through to
+    // an anonymous public fetch instead.
+    assert_eq!(
+        context.classify(&user("alice"), "http://npm.corp.example/lodash", Some("lodash")),
+        RouteClass::Public,
+    );
+}
+
+#[test]
 fn self_uplink_endpoint_url_classifies_as_proxied_for_authorized_caller() {
     let mut config = base_config();
     config.uplinks.insert(

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -1,6 +1,6 @@
 use std::{net::SocketAddr, path::PathBuf};
 
-use pacquet_network::UpstreamRouteHook;
+use pacquet_network::{MetadataCacheScope, UpstreamRouteHook};
 
 use super::{Footprint, PrivateAccessDescriptor, RouteClass, RouteContext, RouteHook};
 use crate::{
@@ -207,6 +207,7 @@ fn route_hook_records_routes_and_returns_alias_credential() {
         RouteContext::from_config(&config),
         user("alice"),
         std::sync::Arc::clone(&footprint),
+        std::sync::Arc::from(b"secret".as_slice()),
     );
 
     // Public fetch: no upstream credential, no private footprint entry.
@@ -220,4 +221,55 @@ fn route_hook_records_routes_and_returns_alias_credential() {
     let footprint = footprint.lock().unwrap();
     assert!(!footprint.is_public());
     assert!(footprint.digest(b"secret").is_some());
+}
+
+#[test]
+fn metadata_scope_maps_route_classes() {
+    let mut config = base_config();
+    config
+        .upstream_aliases
+        .insert("corp".to_string(), alias("https://npm.corp.example/", None, "$authenticated", 3));
+    let footprint = std::sync::Arc::new(std::sync::Mutex::new(Footprint::default()));
+    let hook = RouteHook::new(
+        RouteContext::from_config(&config),
+        user("alice"),
+        std::sync::Arc::clone(&footprint),
+        std::sync::Arc::from(b"server-secret".as_slice()),
+    );
+
+    // Public route → the shared global mirror.
+    assert_eq!(
+        hook.metadata_scope("https://registry.npmjs.org/lodash", Some("lodash")),
+        MetadataCacheScope::Public,
+    );
+    // Authorized proxied route → a descriptor-scoped private mirror.
+    let widget =
+        hook.metadata_scope("https://npm.corp.example/@acme%2fwidget", Some("@acme/widget"));
+    let MetadataCacheScope::Private { descriptor_id } = widget else {
+        panic!("proxied route should be private, got {widget:?}");
+    };
+    assert!(!descriptor_id.is_empty());
+    // The id is the HMAC of the alias descriptor; it must be stable.
+    assert_eq!(
+        descriptor_id,
+        PrivateAccessDescriptor::Alias { alias: "corp".to_string(), generation: 3 }
+            .digest_id(b"server-secret"),
+    );
+    // Unknown/private with no usable credential → bypass (request-local).
+    assert_eq!(
+        hook.metadata_scope("https://private.unknown.example/secret", Some("secret")),
+        MetadataCacheScope::Bypass,
+    );
+
+    // metadata_scope is read-only: classifying must not grow the footprint.
+    assert!(footprint.lock().unwrap().is_public());
+}
+
+#[test]
+fn descriptor_digest_id_depends_on_secret() {
+    let descriptor = PrivateAccessDescriptor::Alias { alias: "corp".to_string(), generation: 1 };
+    assert_ne!(descriptor.digest_id(b"secret-a"), descriptor.digest_id(b"secret-b"));
+    // Generation rotation moves the namespace.
+    let rotated = PrivateAccessDescriptor::Alias { alias: "corp".to_string(), generation: 2 };
+    assert_ne!(descriptor.digest_id(b"secret-a"), rotated.digest_id(b"secret-a"));
 }

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -17,7 +17,7 @@ fn anon() -> Identity {
 }
 
 fn user(name: &str) -> Identity {
-    Identity::User { username: name.to_string() }
+    Identity::user(name)
 }
 
 fn alias(registry: &str, package: Option<&str>, access: &str, generation: u64) -> UpstreamAlias {
@@ -104,6 +104,27 @@ fn proxied_alias_requires_authorization() {
     // A package outside the alias's pattern doesn't match it.
     assert_eq!(
         context.classify(&user("alice"), "https://npm.corp.example/lodash", Some("lodash")),
+        RouteClass::Unknown,
+    );
+}
+
+#[test]
+fn proxied_alias_accepts_configured_group_identity() {
+    let mut config = base_config();
+    config.groups.add_user_to_group("alice", "platform");
+    config.upstream_aliases.insert(
+        "corp".to_string(),
+        alias("https://npm.corp.example/", Some("@acme/*"), "platform", 2),
+    );
+    let context = RouteContext::from_config(&config);
+    let url = "https://npm.corp.example/@acme%2fwidget";
+
+    assert_eq!(
+        context.classify(&config.identity_for_user("alice"), url, Some("@acme/widget")),
+        RouteClass::Proxied { alias: "corp".to_string(), generation: 2 },
+    );
+    assert_eq!(
+        context.classify(&config.identity_for_user("bob"), url, Some("@acme/widget")),
         RouteClass::Unknown,
     );
 }

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -1,4 +1,8 @@
-use std::{net::SocketAddr, path::PathBuf};
+use std::{
+    net::SocketAddr,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
 
 use pacquet_network::{MetadataCacheScope, UpstreamRouteHook};
 
@@ -67,6 +71,26 @@ fn disabling_the_builtin_makes_unscoped_npmjs_private() {
     assert_eq!(
         context.classify(&user("alice"), "https://registry.npmjs.org/lodash", Some("lodash")),
         RouteClass::Unknown,
+    );
+}
+
+#[test]
+fn custom_registry_is_unknown_until_declared_public() {
+    let mut config = base_config();
+    let context = RouteContext::from_config(&config);
+    assert_eq!(
+        context.classify(&user("alice"), "https://custom.registry.example/lodash", Some("lodash"),),
+        RouteClass::Unknown,
+    );
+
+    config.route_policy.public.push(PublicRoute {
+        registry: Some("https://custom.registry.example/".to_string()),
+        package: None,
+    });
+    let context = RouteContext::from_config(&config);
+    assert_eq!(
+        context.classify(&user("alice"), "https://custom.registry.example/lodash", Some("lodash"),),
+        RouteClass::Public,
     );
 }
 
@@ -263,6 +287,42 @@ fn metadata_scope_maps_route_classes() {
 
     // metadata_scope is read-only: classifying must not grow the footprint.
     assert!(footprint.lock().unwrap().is_public());
+}
+
+#[test]
+fn authorized_alias_users_share_metadata_scope() {
+    let mut config = base_config();
+    config
+        .upstream_aliases
+        .insert("corp".to_string(), alias("https://npm.corp.example/", None, "$authenticated", 3));
+    let context = RouteContext::from_config(&config);
+    let secret = Arc::from(b"server-secret".as_slice());
+    let alice = RouteHook::new(
+        context.clone(),
+        user("alice"),
+        Arc::new(Mutex::new(Footprint::default())),
+        Arc::clone(&secret),
+    );
+    let bob = RouteHook::new(
+        context,
+        user("bob"),
+        Arc::new(Mutex::new(Footprint::default())),
+        Arc::clone(&secret),
+    );
+    let url = "https://npm.corp.example/@acme%2fwidget";
+
+    let alice_scope = alice.metadata_scope(url, Some("@acme/widget"));
+    let bob_scope = bob.metadata_scope(url, Some("@acme/widget"));
+    assert_eq!(alice_scope, bob_scope);
+
+    let MetadataCacheScope::Private { descriptor_id } = alice_scope else {
+        panic!("authorized alias route should be private");
+    };
+    assert_eq!(
+        descriptor_id,
+        PrivateAccessDescriptor::Alias { alias: "corp".to_string(), generation: 3 }
+            .digest_id(b"server-secret"),
+    );
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -156,13 +156,13 @@ fn footprint_digest_is_stable_and_namespaced() {
     assert_ne!(digest, footprint.digest(b"other-secret").unwrap());
 
     // The digest is order-independent (BTreeSet union).
-    let mut a = Footprint::default();
-    a.add(PrivateAccessDescriptor::Alias { alias: "x".to_string(), generation: 1 });
-    a.add(PrivateAccessDescriptor::Hosted { policy_id: "@p/*".to_string() });
-    let mut b = Footprint::default();
-    b.add(PrivateAccessDescriptor::Hosted { policy_id: "@p/*".to_string() });
-    b.add(PrivateAccessDescriptor::Alias { alias: "x".to_string(), generation: 1 });
-    assert_eq!(a.digest(b"k"), b.digest(b"k"));
+    let mut one_order = Footprint::default();
+    one_order.add(PrivateAccessDescriptor::Alias { alias: "x".to_string(), generation: 1 });
+    one_order.add(PrivateAccessDescriptor::Hosted { policy_id: "@p/*".to_string() });
+    let mut other_order = Footprint::default();
+    other_order.add(PrivateAccessDescriptor::Hosted { policy_id: "@p/*".to_string() });
+    other_order.add(PrivateAccessDescriptor::Alias { alias: "x".to_string(), generation: 1 });
+    assert_eq!(one_order.digest(b"k"), other_order.digest(b"k"));
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -299,7 +299,7 @@ fn route_hook_records_routes_and_returns_alias_credential() {
     );
     let footprint = std::sync::Arc::new(std::sync::Mutex::new(Footprint::default()));
     let hook = RouteHook::new(
-        RouteContext::from_config(&config),
+        Arc::new(RouteContext::from_config(&config)),
         user("alice"),
         std::sync::Arc::clone(&footprint),
         std::sync::Arc::from(b"secret".as_slice()),
@@ -327,7 +327,7 @@ fn metadata_scope_maps_route_classes() {
     );
     let footprint = std::sync::Arc::new(std::sync::Mutex::new(Footprint::default()));
     let hook = RouteHook::new(
-        RouteContext::from_config(&config),
+        Arc::new(RouteContext::from_config(&config)),
         user("alice"),
         std::sync::Arc::clone(&footprint),
         std::sync::Arc::from(b"server-secret".as_slice()),
@@ -368,10 +368,10 @@ fn authorized_alias_users_share_metadata_scope() {
         "corp".to_string(),
         uplink_with_access("https://npm.corp.example/", "$authenticated", 3),
     );
-    let context = RouteContext::from_config(&config);
+    let context = Arc::new(RouteContext::from_config(&config));
     let secret = Arc::from(b"server-secret".as_slice());
     let alice = RouteHook::new(
-        context.clone(),
+        Arc::clone(&context),
         user("alice"),
         Arc::new(Mutex::new(Footprint::default())),
         Arc::clone(&secret),

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -45,6 +45,27 @@ fn strip_url_credentials_removes_inline_userinfo() {
 }
 
 #[test]
+fn sanitize_registry_tarball_url_drops_userinfo_query_and_fragment() {
+    use super::sanitize_registry_tarball_url;
+    // A presigned/tokenized upstream URL loses its token.
+    assert_eq!(
+        sanitize_registry_tarball_url(
+            "https://cdn.example/acme-1.0.0.tgz?X-Amz-Signature=secret&token=abc",
+        ),
+        "https://cdn.example/acme-1.0.0.tgz",
+    );
+    assert_eq!(
+        sanitize_registry_tarball_url("https://user:pass@cdn.example/x.tgz#frag"),
+        "https://cdn.example/x.tgz",
+    );
+    // A clean canonical npm URL is unchanged.
+    assert_eq!(
+        sanitize_registry_tarball_url("https://registry.npmjs.org/acme/-/acme-1.0.0.tgz"),
+        "https://registry.npmjs.org/acme/-/acme-1.0.0.tgz",
+    );
+}
+
+#[test]
 fn hmac_sha256_matches_rfc4231_case1() {
     // RFC 4231 test case 1: 20-byte 0x0b key, "Hi There".
     let mac = super::hmac_sha256(&[0x0b; 20], b"Hi There");

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -82,30 +82,34 @@ fn allows_registry_is_a_default_deny_allowlist() {
 }
 
 #[test]
-fn disabling_the_builtin_makes_unscoped_npmjs_private() {
+fn disabling_the_builtin_drops_npmjs_from_the_allowlist() {
     let mut config = base_config();
+    // A conservative deployment that allowlists every registry explicitly:
+    // no blanket npmjs uplink, and the built-in route disabled. npmjs is then
+    // off the allowlist, so a resolve naming it is rejected at the boundary.
+    config.uplinks.clear();
     config.route_policy.npmjs_public = false;
     let context = RouteContext::from_config(&config);
-    assert_eq!(
-        context.classify(&user("alice"), "https://registry.npmjs.org/lodash", Some("lodash")),
-        RouteClass::Unknown,
-    );
+    assert!(!context.allows_registry("https://registry.npmjs.org/lodash"));
+
+    // Re-enabling the built-in allowlists npmjs again.
+    config.route_policy.npmjs_public = true;
+    let context = RouteContext::from_config(&config);
+    assert!(context.allows_registry("https://registry.npmjs.org/lodash"));
 }
 
 #[test]
-fn custom_registry_is_unknown_until_declared_public() {
+fn custom_registry_is_off_allowlist_until_declared_public() {
     let mut config = base_config();
     let context = RouteContext::from_config(&config);
-    assert_eq!(
-        context.classify(&user("alice"), "https://custom.registry.example/lodash", Some("lodash"),),
-        RouteClass::Unknown,
-    );
+    assert!(!context.allows_registry("https://custom.registry.example/lodash"));
 
     config.route_policy.public.push(PublicRoute {
         registry: Some("https://custom.registry.example/".to_string()),
         package: None,
     });
     let context = RouteContext::from_config(&config);
+    assert!(context.allows_registry("https://custom.registry.example/lodash"));
     assert_eq!(
         context.classify(&user("alice"), "https://custom.registry.example/lodash", Some("lodash"),),
         RouteClass::Public,
@@ -159,10 +163,12 @@ fn uplink_with_access_is_a_proxied_route_matched_by_origin() {
         context.classify(&user("alice"), "https://npm.corp.example/lodash", Some("lodash")),
         RouteClass::Proxied { alias: "corp".to_string(), generation: 3 },
     );
-    // An unauthorized caller cannot select it.
+    // An unauthorized caller cannot select it: it gets no managed credential
+    // (an anonymous public fetch), which the upstream rejects if the package
+    // is private.
     assert_eq!(
         context.classify(&anon(), "https://npm.corp.example/lodash", Some("lodash")),
-        RouteClass::Unknown,
+        RouteClass::Public,
     );
 }
 
@@ -181,13 +187,14 @@ fn self_uplink_endpoint_url_classifies_as_proxied_for_authorized_caller() {
         context.classify(&user("alice"), &url, Some("@acme/widget")),
         RouteClass::Proxied { alias: "corp".to_string(), generation: 5 },
     );
-    // An unauthorized caller fails closed: a `/~<uplink>/` URL is an uplink
-    // endpoint, never a hosted package, so it does not fall through to the
-    // hosted-package policy.
-    assert_eq!(context.classify(&anon(), &url, Some("@acme/widget")), RouteClass::Unknown);
-    // An unknown uplink name also fails closed.
+    // An unauthorized caller gets no managed credential: a `/~<uplink>/` URL
+    // is an uplink endpoint, never a hosted package, so it does not fall
+    // through to the hosted-package policy; the anonymous fetch the endpoint
+    // itself rejects is the fail-closed point.
+    assert_eq!(context.classify(&anon(), &url, Some("@acme/widget")), RouteClass::Public);
+    // An unknown uplink name is treated the same way.
     let ghost = format!("{}/~ghost/@acme%2fwidget", config.public_url);
-    assert_eq!(context.classify(&user("alice"), &ghost, Some("@acme/widget")), RouteClass::Unknown);
+    assert_eq!(context.classify(&user("alice"), &ghost, Some("@acme/widget")), RouteClass::Public);
 }
 
 #[test]
@@ -213,20 +220,22 @@ fn self_endpoint_recognized_when_pnpr_is_served_under_a_path_prefix() {
 }
 
 #[test]
-fn uplink_without_access_is_not_a_proxied_route() {
+fn uplink_without_access_is_an_anonymous_route() {
     let mut config = base_config();
     let mut headers = HeaderMap::new();
     headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer uplink-secret"));
     // A plain proxy uplink that does not declare `access:` is never offered
-    // as a resolver private-route credential.
+    // as a resolver private-route credential, but its origin is still
+    // allowlisted (a configured registry) and fetched anonymously.
     config.uplinks.insert(
         "mirror".to_string(),
         UplinkConfig::with_defaults("https://npm.corp.example/".to_string(), headers),
     );
     let context = RouteContext::from_config(&config);
+    assert!(context.allows_registry("https://npm.corp.example/lodash"));
     assert_eq!(
         context.classify(&user("alice"), "https://npm.corp.example/lodash", Some("lodash")),
-        RouteClass::Unknown,
+        RouteClass::Public,
     );
 }
 
@@ -244,9 +253,10 @@ fn proxied_alias_accepts_configured_group_identity() {
         context.classify(&config.identity_for_user("alice"), url, Some("@acme/widget")),
         RouteClass::Proxied { alias: "corp".to_string(), generation: 2 },
     );
+    // A caller outside the alias's group gets no managed credential.
     assert_eq!(
         context.classify(&config.identity_for_user("bob"), url, Some("@acme/widget")),
-        RouteClass::Unknown,
+        RouteClass::Public,
     );
 }
 
@@ -257,8 +267,10 @@ fn hosted_route_follows_package_access_policy() {
     config.policies = PackagePolicies::registry_mock_defaults();
     let context = RouteContext::from_config(&config);
 
-    // `@private/*` requires auth: private+gated for an authorized caller,
-    // fail-closed for anonymous.
+    // `@private/*` requires auth: private+gated for an authorized caller. An
+    // anonymous caller gets no managed credential (the hosted-serving
+    // endpoint re-checks the policy and rejects it), so it never matches the
+    // private hosted entry.
     assert_eq!(
         context.classify(
             &user("alice"),
@@ -269,7 +281,7 @@ fn hosted_route_follows_package_access_policy() {
     );
     assert_eq!(
         context.classify(&anon(), "https://pnpr.example/@private%2fpkg", Some("@private/pkg")),
-        RouteClass::Unknown,
+        RouteClass::Public,
     );
     // A package the hosted policy opens to everyone is public.
     assert_eq!(
@@ -282,7 +294,6 @@ fn hosted_route_follows_package_access_policy() {
 fn footprint_digest_is_stable_and_namespaced() {
     let mut footprint = Footprint::default();
     assert!(footprint.is_public());
-    assert!(footprint.is_shareable());
     assert_eq!(footprint.digest(b"secret"), None);
 
     footprint.add(PrivateAccessDescriptor::Alias { alias: "corp".to_string(), generation: 1 });
@@ -305,16 +316,6 @@ fn footprint_digest_is_stable_and_namespaced() {
     other_order.add(PrivateAccessDescriptor::Hosted { policy_id: "@p/*".to_string() });
     other_order.add(PrivateAccessDescriptor::Alias { alias: "x".to_string(), generation: 1 });
     assert_eq!(one_order.digest(b"k"), other_order.digest(b"k"));
-}
-
-#[test]
-fn footprint_unknown_private_is_not_shareable() {
-    let mut footprint = Footprint::default();
-    footprint.mark_unknown_private();
-    assert!(!footprint.is_public());
-    assert!(!footprint.is_shareable());
-    // No descriptor was recorded, so there is nothing to key on.
-    assert_eq!(footprint.digest(b"secret"), None);
 }
 
 #[test]
@@ -378,12 +379,6 @@ fn metadata_scope_maps_route_classes() {
         PrivateAccessDescriptor::Alias { alias: "corp".to_string(), generation: 3 }
             .digest_id(b"server-secret"),
     );
-    // Unknown/private with no usable credential → bypass (request-local).
-    assert_eq!(
-        hook.metadata_scope("https://private.unknown.example/secret", Some("secret")),
-        MetadataCacheScope::Bypass,
-    );
-
     // metadata_scope is read-only: classifying must not grow the footprint.
     assert!(footprint.lock().unwrap().is_public());
 }

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -5,10 +5,11 @@ use std::{
 };
 
 use pacquet_network::{MetadataCacheScope, UpstreamRouteHook};
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 
 use super::{Footprint, PrivateAccessDescriptor, RouteClass, RouteContext, RouteHook};
 use crate::{
-    config::{Config, PublicRoute, UpstreamAlias},
+    config::{Config, PublicRoute, UplinkConfig, UpstreamAlias},
     policy::{AccessList, Identity, PackagePolicies},
 };
 
@@ -126,6 +127,64 @@ fn proxied_alias_requires_authorization() {
     // non-shareable unknown rather than the alias's private namespace.
     assert_eq!(context.classify(&anon(), url, Some("@acme/widget")), RouteClass::Unknown);
     // A package outside the alias's pattern doesn't match it.
+    assert_eq!(
+        context.classify(&user("alice"), "https://npm.corp.example/lodash", Some("lodash")),
+        RouteClass::Unknown,
+    );
+}
+
+fn uplink_with_access(registry: &str, access: &str, generation: u64) -> UplinkConfig {
+    let mut headers = HeaderMap::new();
+    headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer uplink-secret"));
+    let mut uplink = UplinkConfig::with_defaults(registry.to_string(), headers);
+    uplink.access = Some(AccessList::parse(access));
+    uplink.generation = generation;
+    uplink
+}
+
+#[test]
+fn uplink_with_access_is_a_proxied_route_matched_by_origin() {
+    let mut config = base_config();
+    config.uplinks.insert(
+        "corp".to_string(),
+        uplink_with_access("https://npm.corp.example/", "$authenticated", 3),
+    );
+    let context = RouteContext::from_config(&config);
+
+    // An authorized caller selects the uplink as a proxied route.
+    assert_eq!(
+        context.classify(
+            &user("alice"),
+            "https://npm.corp.example/@acme%2fwidget",
+            Some("@acme/widget")
+        ),
+        RouteClass::Proxied { alias: "corp".to_string(), generation: 3 },
+    );
+    // Routing is by registry origin, not a package glob, so any package on
+    // that origin matches the same uplink.
+    assert_eq!(
+        context.classify(&user("alice"), "https://npm.corp.example/lodash", Some("lodash")),
+        RouteClass::Proxied { alias: "corp".to_string(), generation: 3 },
+    );
+    // An unauthorized caller cannot select it.
+    assert_eq!(
+        context.classify(&anon(), "https://npm.corp.example/lodash", Some("lodash")),
+        RouteClass::Unknown,
+    );
+}
+
+#[test]
+fn uplink_without_access_is_not_a_proxied_route() {
+    let mut config = base_config();
+    let mut headers = HeaderMap::new();
+    headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer uplink-secret"));
+    // A plain proxy uplink that does not declare `access:` is never offered
+    // as a resolver private-route credential.
+    config.uplinks.insert(
+        "mirror".to_string(),
+        UplinkConfig::with_defaults("https://npm.corp.example/".to_string(), headers),
+    );
+    let context = RouteContext::from_config(&config);
     assert_eq!(
         context.classify(&user("alice"), "https://npm.corp.example/lodash", Some("lodash")),
         RouteClass::Unknown,

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -1,0 +1,202 @@
+use std::{net::SocketAddr, path::PathBuf};
+
+use pacquet_network::UpstreamRouteHook;
+
+use super::{Footprint, PrivateAccessDescriptor, RouteClass, RouteContext, RouteHook};
+use crate::{
+    config::{Config, PublicRoute, UpstreamAlias},
+    policy::{AccessList, Identity, PackagePolicies},
+};
+
+fn base_config() -> Config {
+    Config::proxy("127.0.0.1:7677".parse::<SocketAddr>().unwrap(), PathBuf::from("/tmp/pnpr-route"))
+}
+
+fn anon() -> Identity {
+    Identity::Anonymous
+}
+
+fn user(name: &str) -> Identity {
+    Identity::User { username: name.to_string() }
+}
+
+fn alias(registry: &str, package: Option<&str>, access: &str, generation: u64) -> UpstreamAlias {
+    UpstreamAlias {
+        registry: registry.to_string(),
+        package: package.map(str::to_string),
+        authorization: "Bearer alias-secret".to_string(),
+        access: AccessList::parse(access),
+        generation,
+    }
+}
+
+#[test]
+fn hmac_sha256_matches_rfc4231_case1() {
+    // RFC 4231 test case 1: 20-byte 0x0b key, "Hi There".
+    let mac = super::hmac_sha256(&[0x0b; 20], b"Hi There");
+    assert_eq!(
+        super::hex(&mac),
+        "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7",
+    );
+}
+
+#[test]
+fn unscoped_npmjs_is_public_scoped_is_not() {
+    let context = RouteContext::from_config(&base_config());
+    assert_eq!(
+        context.classify(&user("alice"), "https://registry.npmjs.org/lodash", Some("lodash")),
+        RouteClass::Public,
+    );
+    // npm allows private scoped packages, so a scoped npmjs name is not
+    // public under the built-in route — it needs an explicit rule.
+    assert_eq!(
+        context.classify(
+            &user("alice"),
+            "https://registry.npmjs.org/@babel%2fcore",
+            Some("@babel/core"),
+        ),
+        RouteClass::Unknown,
+    );
+}
+
+#[test]
+fn disabling_the_builtin_makes_unscoped_npmjs_private() {
+    let mut config = base_config();
+    config.route_policy.npmjs_unscoped_public = false;
+    let context = RouteContext::from_config(&config);
+    assert_eq!(
+        context.classify(&user("alice"), "https://registry.npmjs.org/lodash", Some("lodash")),
+        RouteClass::Unknown,
+    );
+}
+
+#[test]
+fn operator_declared_public_route_matches_scope() {
+    let mut config = base_config();
+    config.route_policy.public.push(PublicRoute {
+        registry: Some("https://registry.npmjs.org/".to_string()),
+        package: Some("@babel/*".to_string()),
+    });
+    let context = RouteContext::from_config(&config);
+    assert_eq!(
+        context.classify(&anon(), "https://registry.npmjs.org/@babel%2fcore", Some("@babel/core")),
+        RouteClass::Public,
+    );
+}
+
+#[test]
+fn proxied_alias_requires_authorization() {
+    let mut config = base_config();
+    config.upstream_aliases.insert(
+        "corp".to_string(),
+        alias("https://npm.corp.example/", Some("@acme/*"), "$authenticated", 2),
+    );
+    let context = RouteContext::from_config(&config);
+    let url = "https://npm.corp.example/@acme%2fwidget";
+
+    assert_eq!(
+        context.classify(&user("alice"), url, Some("@acme/widget")),
+        RouteClass::Proxied { alias: "corp".to_string(), generation: 2 },
+    );
+    // An unauthorized caller cannot select the alias, so the route is a
+    // non-shareable unknown rather than the alias's private namespace.
+    assert_eq!(context.classify(&anon(), url, Some("@acme/widget")), RouteClass::Unknown);
+    // A package outside the alias's pattern doesn't match it.
+    assert_eq!(
+        context.classify(&user("alice"), "https://npm.corp.example/lodash", Some("lodash")),
+        RouteClass::Unknown,
+    );
+}
+
+#[test]
+fn hosted_route_follows_package_access_policy() {
+    let mut config = base_config();
+    config.public_url = "https://pnpr.example/".to_string();
+    config.policies = PackagePolicies::registry_mock_defaults();
+    let context = RouteContext::from_config(&config);
+
+    // `@private/*` requires auth: private+gated for an authorized caller,
+    // fail-closed for anonymous.
+    assert_eq!(
+        context.classify(
+            &user("alice"),
+            "https://pnpr.example/@private%2fpkg",
+            Some("@private/pkg")
+        ),
+        RouteClass::Hosted { policy_id: "@private/pkg".to_string() },
+    );
+    assert_eq!(
+        context.classify(&anon(), "https://pnpr.example/@private%2fpkg", Some("@private/pkg")),
+        RouteClass::Unknown,
+    );
+    // A package the hosted policy opens to everyone is public.
+    assert_eq!(
+        context.classify(&anon(), "https://pnpr.example/lodash", Some("lodash")),
+        RouteClass::Public,
+    );
+}
+
+#[test]
+fn footprint_digest_is_stable_and_namespaced() {
+    let mut footprint = Footprint::default();
+    assert!(footprint.is_public());
+    assert!(footprint.is_shareable());
+    assert_eq!(footprint.digest(b"secret"), None);
+
+    footprint.add(PrivateAccessDescriptor::Alias { alias: "corp".to_string(), generation: 1 });
+    assert!(!footprint.is_public());
+    let digest = footprint.digest(b"secret").expect("private footprint has a digest");
+
+    // Rotating the alias generation moves to a new namespace.
+    let mut rotated = Footprint::default();
+    rotated.add(PrivateAccessDescriptor::Alias { alias: "corp".to_string(), generation: 2 });
+    assert_ne!(digest, rotated.digest(b"secret").unwrap());
+
+    // A different server secret yields a different (non-correlatable) key.
+    assert_ne!(digest, footprint.digest(b"other-secret").unwrap());
+
+    // The digest is order-independent (BTreeSet union).
+    let mut a = Footprint::default();
+    a.add(PrivateAccessDescriptor::Alias { alias: "x".to_string(), generation: 1 });
+    a.add(PrivateAccessDescriptor::Hosted { policy_id: "@p/*".to_string() });
+    let mut b = Footprint::default();
+    b.add(PrivateAccessDescriptor::Hosted { policy_id: "@p/*".to_string() });
+    b.add(PrivateAccessDescriptor::Alias { alias: "x".to_string(), generation: 1 });
+    assert_eq!(a.digest(b"k"), b.digest(b"k"));
+}
+
+#[test]
+fn footprint_unknown_private_is_not_shareable() {
+    let mut footprint = Footprint::default();
+    footprint.mark_unknown_private();
+    assert!(!footprint.is_public());
+    assert!(!footprint.is_shareable());
+    // No descriptor was recorded, so there is nothing to key on.
+    assert_eq!(footprint.digest(b"secret"), None);
+}
+
+#[test]
+fn route_hook_records_routes_and_returns_alias_credential() {
+    let mut config = base_config();
+    config
+        .upstream_aliases
+        .insert("corp".to_string(), alias("https://npm.corp.example/", None, "$authenticated", 1));
+    let footprint = std::sync::Arc::new(std::sync::Mutex::new(Footprint::default()));
+    let hook = RouteHook::new(
+        RouteContext::from_config(&config),
+        user("alice"),
+        std::sync::Arc::clone(&footprint),
+    );
+
+    // Public fetch: no upstream credential, no private footprint entry.
+    assert_eq!(hook.authorize("https://registry.npmjs.org/lodash", Some("lodash")), None);
+    // Private proxied fetch: the alias credential is returned and recorded.
+    assert_eq!(
+        hook.authorize("https://npm.corp.example/@acme%2fwidget", Some("@acme/widget")),
+        Some("Bearer alias-secret".to_string()),
+    );
+
+    let footprint = footprint.lock().unwrap();
+    assert!(!footprint.is_public());
+    assert!(footprint.digest(b"secret").is_some());
+}

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -127,20 +127,27 @@ fn allows_registry_is_a_default_deny_allowlist() {
 }
 
 #[test]
-fn disabling_the_builtin_drops_npmjs_from_the_allowlist() {
+fn the_builtin_npmjs_route_is_always_allowlisted_and_public() {
+    // Even a deployment that declares no uplinks and no public routes still
+    // resolves from the official npm registry: it's a built-in public route.
     let mut config = base_config();
-    // A conservative deployment that allowlists every registry explicitly:
-    // no blanket npmjs uplink, and the built-in route disabled. npmjs is then
-    // off the allowlist, so a resolve naming it is rejected at the boundary.
     config.uplinks.clear();
-    config.route_policy.npmjs_public = false;
     let context = RouteContext::from_config(&config);
-    assert!(!context.allows_registry("https://registry.npmjs.org/lodash"));
 
-    // Re-enabling the built-in allowlists npmjs again.
-    config.route_policy.npmjs_public = true;
-    let context = RouteContext::from_config(&config);
     assert!(context.allows_registry("https://registry.npmjs.org/lodash"));
+    assert_eq!(
+        context.classify(&user("alice"), "https://registry.npmjs.org/lodash", Some("lodash")),
+        RouteClass::Public,
+    );
+    // Host-level: scoped npmjs names are public too.
+    assert_eq!(
+        context.classify(
+            &user("alice"),
+            "https://registry.npmjs.org/@babel%2fcore",
+            Some("@babel/core"),
+        ),
+        RouteClass::Public,
+    );
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -36,28 +36,55 @@ fn hmac_sha256_matches_rfc4231_case1() {
 }
 
 #[test]
-fn unscoped_npmjs_is_public_scoped_is_not() {
+fn npmjs_host_is_public_including_scoped() {
     let context = RouteContext::from_config(&base_config());
     assert_eq!(
         context.classify(&user("alice"), "https://registry.npmjs.org/lodash", Some("lodash")),
         RouteClass::Public,
     );
-    // npm allows private scoped packages, so a scoped npmjs name is not
-    // public under the built-in route — it needs an explicit rule.
+    // The npmjs host is public at the host level: an anonymous fetch returns
+    // only public content (a private scoped package 404s), so a scoped npmjs
+    // name resolves as public and globally shareable too.
     assert_eq!(
         context.classify(
             &user("alice"),
             "https://registry.npmjs.org/@babel%2fcore",
             Some("@babel/core"),
         ),
-        RouteClass::Unknown,
+        RouteClass::Public,
     );
+}
+
+#[test]
+fn allows_registry_is_a_default_deny_allowlist() {
+    let mut config = base_config();
+    config.uplinks.insert(
+        "corp".to_string(),
+        uplink_with_access("https://npm.corp.example/", "$authenticated", 1),
+    );
+    config.route_policy.public.push(PublicRoute {
+        registry: Some("https://public.mirror.example/".to_string()),
+        package: None,
+    });
+    let context = RouteContext::from_config(&config);
+
+    // Allowed: the built-in npm host, a declared public route, a uplink
+    // origin, and pnpr's own origin (its `/~<uplink>/` endpoints).
+    assert!(context.allows_registry("https://registry.npmjs.org/"));
+    assert!(context.allows_registry("https://public.mirror.example/@scope/pkg"));
+    assert!(context.allows_registry("https://npm.corp.example/@acme/widget"));
+    assert!(context.allows_registry(&format!("{}/~corp/@acme/widget", config.public_url)));
+
+    // Rejected: cloud instance metadata and any other off-allowlist host.
+    assert!(!context.allows_registry("http://169.254.169.254/"));
+    assert!(!context.allows_registry("https://evil.example/"));
+    assert!(!context.allows_registry("not a url"));
 }
 
 #[test]
 fn disabling_the_builtin_makes_unscoped_npmjs_private() {
     let mut config = base_config();
-    config.route_policy.npmjs_unscoped_public = false;
+    config.route_policy.npmjs_public = false;
     let context = RouteContext::from_config(&config);
     assert_eq!(
         context.classify(&user("alice"), "https://registry.npmjs.org/lodash", Some("lodash")),

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -79,6 +79,11 @@ fn allows_registry_is_a_default_deny_allowlist() {
     assert!(!context.allows_registry("http://169.254.169.254/"));
     assert!(!context.allows_registry("https://evil.example/"));
     assert!(!context.allows_registry("not a url"));
+
+    // Rejected: a `..` segment that could escape a path-scoped prefix match
+    // (here pnpr's own `/~corp/` endpoint prefix) onto a sibling path.
+    assert!(!context.allows_registry(&format!("{}/~corp/../admin", config.public_url)));
+    assert!(!context.allows_registry("https://npm.corp.example/../etc"));
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -100,7 +100,7 @@ fn allows_registry_is_a_default_deny_allowlist() {
     let mut config = base_config();
     config.uplinks.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated", 1),
+        uplink_with_access("https://npm.corp.example/", "$authenticated"),
     );
     config.route_policy.public.push(PublicRoute {
         registry: Some("https://public.mirror.example/".to_string()),
@@ -213,12 +213,26 @@ fn public_route_with_an_invalid_field_fails_closed_instead_of_matching_all() {
     assert!(!context.allows_registry("https://npm.corp.example/@secret/pkg"));
 }
 
-fn uplink_with_access(registry: &str, access: &str, generation: u64) -> UplinkConfig {
+/// The standard bearer token every test uplink uses, and the credential digest
+/// it produces — what a `RouteClass::Proxied` / `PrivateAccessDescriptor::Alias`
+/// for such an uplink carries.
+const UPLINK_TOKEN: &str = "Bearer uplink-secret";
+
+fn corp_credential() -> String {
+    super::credential_digest(UPLINK_TOKEN)
+}
+
+/// A *different* credential digest, standing in for the same uplink after its
+/// upstream credential has been rotated.
+fn rotated_credential() -> String {
+    super::credential_digest("Bearer rotated-secret")
+}
+
+fn uplink_with_access(registry: &str, access: &str) -> UplinkConfig {
     let mut headers = HeaderMap::new();
     headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer uplink-secret"));
     let mut uplink = UplinkConfig::with_defaults(registry.to_string(), headers);
     uplink.access = Some(AccessList::parse(access));
-    uplink.generation = generation;
     uplink
 }
 
@@ -227,7 +241,7 @@ fn uplink_with_access_is_a_proxied_route_matched_by_origin() {
     let mut config = base_config();
     config.uplinks.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated", 3),
+        uplink_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let context = RouteContext::from_config(&config);
 
@@ -238,13 +252,13 @@ fn uplink_with_access_is_a_proxied_route_matched_by_origin() {
             "https://npm.corp.example/@acme%2fwidget",
             Some("@acme/widget")
         ),
-        RouteClass::Proxied { alias: "corp".to_string(), generation: 3 },
+        RouteClass::Proxied { alias: "corp".to_string(), credential_digest: corp_credential() },
     );
     // Routing is by registry origin, not a package glob, so any package on
     // that origin matches the same uplink.
     assert_eq!(
         context.classify(&user("alice"), "https://npm.corp.example/lodash", Some("lodash")),
-        RouteClass::Proxied { alias: "corp".to_string(), generation: 3 },
+        RouteClass::Proxied { alias: "corp".to_string(), credential_digest: corp_credential() },
     );
     // An unauthorized caller cannot select it: it gets no managed credential
     // (an anonymous public fetch), which the upstream rejects if the package
@@ -260,14 +274,14 @@ fn uplink_credential_is_not_attached_over_a_mismatched_scheme() {
     let mut config = base_config();
     config.uplinks.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated", 1),
+        uplink_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let context = RouteContext::from_config(&config);
 
     // An https fetch matches the https uplink and gets the managed credential.
     assert_eq!(
         context.classify(&user("alice"), "https://npm.corp.example/lodash", Some("lodash")),
-        RouteClass::Proxied { alias: "corp".to_string(), generation: 1 },
+        RouteClass::Proxied { alias: "corp".to_string(), credential_digest: corp_credential() },
     );
     // A plain-http fetch to the same origin must NOT receive the https uplink's
     // server-owned token (nerf-darting strips the scheme); it falls through to
@@ -283,15 +297,15 @@ fn self_uplink_endpoint_url_classifies_as_proxied_for_authorized_caller() {
     let mut config = base_config();
     config.uplinks.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated", 5),
+        uplink_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let context = RouteContext::from_config(&config);
     // A request to pnpr's own `/~corp/` endpoint resolves through the corp
-    // uplink, using its current generation (the URL carries none).
+    // uplink, using its current credential (the URL carries none).
     let url = format!("{}/~corp/@acme%2fwidget", config.public_url);
     assert_eq!(
         context.classify(&user("alice"), &url, Some("@acme/widget")),
-        RouteClass::Proxied { alias: "corp".to_string(), generation: 5 },
+        RouteClass::Proxied { alias: "corp".to_string(), credential_digest: corp_credential() },
     );
     // An unauthorized caller gets no managed credential: a `/~<uplink>/` URL
     // is an uplink endpoint, never a hosted package, so it does not fall
@@ -310,7 +324,7 @@ fn self_endpoint_recognized_when_pnpr_is_served_under_a_path_prefix() {
     config.public_url = "https://host.example/pnpr/".to_string();
     config.uplinks.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated", 5),
+        uplink_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let context = RouteContext::from_config(&config);
     // The path-preserving hosted prefix still recognizes the `/pnpr/~corp/`
@@ -321,7 +335,7 @@ fn self_endpoint_recognized_when_pnpr_is_served_under_a_path_prefix() {
             "https://host.example/pnpr/~corp/@acme%2fwidget",
             Some("@acme/widget"),
         ),
-        RouteClass::Proxied { alias: "corp".to_string(), generation: 5 },
+        RouteClass::Proxied { alias: "corp".to_string(), credential_digest: corp_credential() },
     );
 }
 
@@ -351,13 +365,13 @@ fn proxied_alias_accepts_configured_group_identity() {
     config.groups.add_user_to_group("alice", "platform");
     config
         .uplinks
-        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "platform", 2));
+        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "platform"));
     let context = RouteContext::from_config(&config);
     let url = "https://npm.corp.example/@acme%2fwidget";
 
     assert_eq!(
         context.classify(&config.identity_for_user("alice"), url, Some("@acme/widget")),
-        RouteClass::Proxied { alias: "corp".to_string(), generation: 2 },
+        RouteClass::Proxied { alias: "corp".to_string(), credential_digest: corp_credential() },
     );
     // A caller outside the alias's group gets no managed credential.
     assert_eq!(
@@ -403,23 +417,28 @@ fn overlapping_uplink_access_reuses_only_the_selected_alias() {
     // `select_alias` picks it for a caller authorized for both.
     config.uplinks.insert(
         "primary".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated", 1),
+        uplink_with_access("https://npm.corp.example/", "$authenticated"),
     );
     config.uplinks.insert(
         "secondary".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated", 1),
+        uplink_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let context = RouteContext::from_config(&config);
 
     let mut via_primary = Footprint::default();
-    via_primary.add(PrivateAccessDescriptor::Alias { alias: "primary".to_string(), generation: 1 });
+    via_primary.add(PrivateAccessDescriptor::Alias {
+        alias: "primary".to_string(),
+        credential_digest: corp_credential(),
+    });
     assert!(via_primary.allows(&context, &user("alice")));
 
     // A lockfile routed through `secondary` must NOT be replayed for alice,
     // even though she is authorized for it — she resolves through `primary`.
     let mut via_secondary = Footprint::default();
-    via_secondary
-        .add(PrivateAccessDescriptor::Alias { alias: "secondary".to_string(), generation: 1 });
+    via_secondary.add(PrivateAccessDescriptor::Alias {
+        alias: "secondary".to_string(),
+        credential_digest: corp_credential(),
+    });
     assert!(!via_secondary.allows(&context, &user("alice")));
 }
 
@@ -429,13 +448,19 @@ fn footprint_digest_is_stable_and_namespaced() {
     assert!(footprint.is_public());
     assert_eq!(footprint.digest(b"secret"), None);
 
-    footprint.add(PrivateAccessDescriptor::Alias { alias: "corp".to_string(), generation: 1 });
+    footprint.add(PrivateAccessDescriptor::Alias {
+        alias: "corp".to_string(),
+        credential_digest: corp_credential(),
+    });
     assert!(!footprint.is_public());
     let digest = footprint.digest(b"secret").expect("private footprint has a digest");
 
-    // Rotating the alias generation moves to a new namespace.
+    // Rotating the alias's credential moves to a new namespace.
     let mut rotated = Footprint::default();
-    rotated.add(PrivateAccessDescriptor::Alias { alias: "corp".to_string(), generation: 2 });
+    rotated.add(PrivateAccessDescriptor::Alias {
+        alias: "corp".to_string(),
+        credential_digest: rotated_credential(),
+    });
     assert_ne!(digest, rotated.digest(b"secret").unwrap());
 
     // A different server secret yields a different (non-correlatable) key.
@@ -443,11 +468,17 @@ fn footprint_digest_is_stable_and_namespaced() {
 
     // The digest is order-independent (BTreeSet union).
     let mut one_order = Footprint::default();
-    one_order.add(PrivateAccessDescriptor::Alias { alias: "x".to_string(), generation: 1 });
+    one_order.add(PrivateAccessDescriptor::Alias {
+        alias: "x".to_string(),
+        credential_digest: corp_credential(),
+    });
     one_order.add(PrivateAccessDescriptor::Hosted { policy_id: "@p/*".to_string() });
     let mut other_order = Footprint::default();
     other_order.add(PrivateAccessDescriptor::Hosted { policy_id: "@p/*".to_string() });
-    other_order.add(PrivateAccessDescriptor::Alias { alias: "x".to_string(), generation: 1 });
+    other_order.add(PrivateAccessDescriptor::Alias {
+        alias: "x".to_string(),
+        credential_digest: corp_credential(),
+    });
     assert_eq!(one_order.digest(b"k"), other_order.digest(b"k"));
 }
 
@@ -456,7 +487,7 @@ fn route_hook_records_routes_and_returns_alias_credential() {
     let mut config = base_config();
     config.uplinks.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated", 1),
+        uplink_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let footprint = std::sync::Arc::new(std::sync::Mutex::new(Footprint::default()));
     let hook = RouteHook::new(
@@ -484,7 +515,7 @@ fn metadata_scope_maps_route_classes() {
     let mut config = base_config();
     config.uplinks.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated", 3),
+        uplink_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let footprint = std::sync::Arc::new(std::sync::Mutex::new(Footprint::default()));
     let hook = RouteHook::new(
@@ -509,8 +540,11 @@ fn metadata_scope_maps_route_classes() {
     // The id is the HMAC of the alias descriptor; it must be stable.
     assert_eq!(
         descriptor_id,
-        PrivateAccessDescriptor::Alias { alias: "corp".to_string(), generation: 3 }
-            .digest_id(b"server-secret"),
+        PrivateAccessDescriptor::Alias {
+            alias: "corp".to_string(),
+            credential_digest: corp_credential()
+        }
+        .digest_id(b"server-secret"),
     );
     // metadata_scope is read-only: classifying must not grow the footprint.
     assert!(footprint.lock().unwrap().is_public());
@@ -521,7 +555,7 @@ fn authorized_alias_users_share_metadata_scope() {
     let mut config = base_config();
     config.uplinks.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated", 3),
+        uplink_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let context = Arc::new(RouteContext::from_config(&config));
     let secret = Arc::from(b"server-secret".as_slice());
@@ -548,16 +582,25 @@ fn authorized_alias_users_share_metadata_scope() {
     };
     assert_eq!(
         descriptor_id,
-        PrivateAccessDescriptor::Alias { alias: "corp".to_string(), generation: 3 }
-            .digest_id(b"server-secret"),
+        PrivateAccessDescriptor::Alias {
+            alias: "corp".to_string(),
+            credential_digest: corp_credential()
+        }
+        .digest_id(b"server-secret"),
     );
 }
 
 #[test]
 fn descriptor_digest_id_depends_on_secret() {
-    let descriptor = PrivateAccessDescriptor::Alias { alias: "corp".to_string(), generation: 1 };
+    let descriptor = PrivateAccessDescriptor::Alias {
+        alias: "corp".to_string(),
+        credential_digest: corp_credential(),
+    };
     assert_ne!(descriptor.digest_id(b"secret-a"), descriptor.digest_id(b"secret-b"));
     // Generation rotation moves the namespace.
-    let rotated = PrivateAccessDescriptor::Alias { alias: "corp".to_string(), generation: 2 };
+    let rotated = PrivateAccessDescriptor::Alias {
+        alias: "corp".to_string(),
+        credential_digest: rotated_credential(),
+    };
     assert_ne!(descriptor.digest_id(b"secret-a"), rotated.digest_id(b"secret-a"));
 }

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -322,6 +322,33 @@ fn hosted_route_follows_package_access_policy() {
 }
 
 #[test]
+fn overlapping_uplink_access_reuses_only_the_selected_alias() {
+    let mut config = base_config();
+    // Two uplinks serving the same origin; `primary` is declared first, so
+    // `select_alias` picks it for a caller authorized for both.
+    config.uplinks.insert(
+        "primary".to_string(),
+        uplink_with_access("https://npm.corp.example/", "$authenticated", 1),
+    );
+    config.uplinks.insert(
+        "secondary".to_string(),
+        uplink_with_access("https://npm.corp.example/", "$authenticated", 1),
+    );
+    let context = RouteContext::from_config(&config);
+
+    let mut via_primary = Footprint::default();
+    via_primary.add(PrivateAccessDescriptor::Alias { alias: "primary".to_string(), generation: 1 });
+    assert!(via_primary.allows(&context, &user("alice")));
+
+    // A lockfile routed through `secondary` must NOT be replayed for alice,
+    // even though she is authorized for it — she resolves through `primary`.
+    let mut via_secondary = Footprint::default();
+    via_secondary
+        .add(PrivateAccessDescriptor::Alias { alias: "secondary".to_string(), generation: 1 });
+    assert!(!via_secondary.allows(&context, &user("alice")));
+}
+
+#[test]
 fn footprint_digest_is_stable_and_namespaced() {
     let mut footprint = Footprint::default();
     assert!(footprint.is_public());

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -26,6 +26,25 @@ fn user(name: &str) -> Identity {
 }
 
 #[test]
+fn strip_url_credentials_removes_inline_userinfo() {
+    use super::strip_url_credentials;
+    assert_eq!(
+        strip_url_credentials("https://user:pass@cdn.example/acme-1.0.0.tgz"),
+        "https://cdn.example/acme-1.0.0.tgz",
+    );
+    assert_eq!(
+        strip_url_credentials("https://token@cdn.example/x.tgz?a=1"),
+        "https://cdn.example/x.tgz?a=1",
+    );
+    // No userinfo / no scheme: returned unchanged.
+    assert_eq!(
+        strip_url_credentials("https://registry.npmjs.org/acme/-/acme-1.0.0.tgz"),
+        "https://registry.npmjs.org/acme/-/acme-1.0.0.tgz",
+    );
+    assert_eq!(strip_url_credentials("^1.0.0"), "^1.0.0");
+}
+
+#[test]
 fn hmac_sha256_matches_rfc4231_case1() {
     // RFC 4231 test case 1: 20-byte 0x0b key, "Hi There".
     let mac = super::hmac_sha256(&[0x0b; 20], b"Hi There");

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -130,6 +130,37 @@ fn operator_declared_public_route_matches_scope() {
     );
 }
 
+#[test]
+fn public_route_with_an_invalid_field_fails_closed_instead_of_matching_all() {
+    // A typo'd registry URL must not collapse to a match-any public rule
+    // that would classify a private registry's packages as Public.
+    let mut config = base_config();
+    config.uplinks.clear();
+    config.route_policy.public.push(PublicRoute {
+        registry: Some("not a url".to_string()),
+        package: Some("@public/*".to_string()),
+    });
+    let context = RouteContext::from_config(&config);
+    assert_eq!(
+        context.classify(&anon(), "https://npm.corp.example/@secret%2fpkg", Some("@secret/pkg")),
+        RouteClass::Public,
+        "the dropped rule leaves classification to the anonymous fall-through, not a match-all",
+    );
+    // The dropped rule contributes nothing to the allowlist either, so the
+    // private registry is rejected at the request boundary.
+    assert!(!context.allows_registry("https://npm.corp.example/@secret/pkg"));
+
+    // An invalid package glob drops the rule the same way.
+    let mut config = base_config();
+    config.uplinks.clear();
+    config.route_policy.public.push(PublicRoute {
+        registry: Some("https://npm.corp.example/".to_string()),
+        package: Some("[".to_string()),
+    });
+    let context = RouteContext::from_config(&config);
+    assert!(!context.allows_registry("https://npm.corp.example/@secret/pkg"));
+}
+
 fn uplink_with_access(registry: &str, access: &str, generation: u64) -> UplinkConfig {
     let mut headers = HeaderMap::new();
     headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer uplink-secret"));

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -164,6 +164,28 @@ fn self_uplink_endpoint_url_classifies_as_proxied_for_authorized_caller() {
 }
 
 #[test]
+fn self_endpoint_recognized_when_pnpr_is_served_under_a_path_prefix() {
+    let mut config = base_config();
+    // pnpr deployed behind a reverse proxy under a `/pnpr/` sub-path.
+    config.public_url = "https://host.example/pnpr/".to_string();
+    config.uplinks.insert(
+        "corp".to_string(),
+        uplink_with_access("https://npm.corp.example/", "$authenticated", 5),
+    );
+    let context = RouteContext::from_config(&config);
+    // The path-preserving hosted prefix still recognizes the `/pnpr/~corp/`
+    // endpoint instead of dropping the `/pnpr` path and misclassifying it.
+    assert_eq!(
+        context.classify(
+            &user("alice"),
+            "https://host.example/pnpr/~corp/@acme%2fwidget",
+            Some("@acme/widget"),
+        ),
+        RouteClass::Proxied { alias: "corp".to_string(), generation: 5 },
+    );
+}
+
+#[test]
 fn uplink_without_access_is_not_a_proxied_route() {
     let mut config = base_config();
     let mut headers = HeaderMap::new();

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -904,10 +904,17 @@ fn authorized_uplink<'a>(
 /// The disposable cache namespace for an uplink's `/~<uplink>/` route,
 /// keyed by the uplink and its rotation generation so its packuments and
 /// tarballs never collide with the public mirror or another uplink, and so a
-/// credential rotation moves to a fresh namespace.
+/// credential rotation moves to a fresh namespace. The `(uplink, generation)`
+/// is HMAC'd with the server secret, so the on-disk path leaks neither, and a
+/// path-unsafe uplink name can't escape the cache root (the digest is hex).
 fn uplink_cache_namespace(state: &AppState, uplink: &str) -> String {
     let generation = state.inner.config.uplinks.get(uplink).map_or(1, |uplink| uplink.generation);
-    format!("~uplinks/{uplink}/{generation}")
+    let digest = crate::route::uplink_cache_digest(
+        uplink,
+        generation,
+        &state.inner.config.resolution_cache_secret,
+    );
+    format!("~uplinks/{digest}")
 }
 
 /// Load an uplink route's packument: a fresh per-uplink cache entry when one

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -558,6 +558,10 @@ async fn get_two_segments(
     if first == "-" && second == "whoami" {
         return private_no_cache(serve_whoami(&identity));
     }
+    // `/~<uplink>/<pkg>` — unscoped packument through an uplink endpoint.
+    if let Some(uplink) = first.strip_prefix('~').filter(|uplink| !uplink.is_empty()) {
+        return serve_packument_via_uplink(&state, &identity, &headers, uplink, &second).await;
+    }
     if first.starts_with('@') {
         let full = format!("{first}/{second}");
         serve_packument(&state, &identity, &headers, &full).await
@@ -570,11 +574,22 @@ async fn get_three_segments(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
     OriginalUri(uri): OriginalUri,
+    headers: HeaderMap,
     Path((first, second, third)): Path<(String, String, String)>,
 ) -> Response {
     if first == "-" && second == "v1" && third == "search" {
         let query = uri.query().unwrap_or("");
         return serve_search(&state, &identity, query).await;
+    }
+    // `/~<uplink>/@scope/<pkg>` — scoped packument through an uplink endpoint.
+    // (A `/~<uplink>/<pkg>/<version>` version-manifest fetch is not served;
+    // clients read the full packument from the endpoint instead.)
+    if let Some(uplink) = first.strip_prefix('~').filter(|uplink| !uplink.is_empty()) {
+        if second.starts_with('@') {
+            let full = format!("{second}/{third}");
+            return serve_packument_via_uplink(&state, &identity, &headers, uplink, &full).await;
+        }
+        return not_found();
     }
     if second == "-" {
         serve_tarball(&state, &identity, &first, &third).await
@@ -591,6 +606,10 @@ async fn get_tarball_scoped(
     AuthedCaller(identity): AuthedCaller,
     Path((scope, name, filename)): Path<(String, String, String)>,
 ) -> Response {
+    // `/~<uplink>/<pkg>/-/<file>` — unscoped tarball through an uplink endpoint.
+    if let Some(uplink) = scope.strip_prefix('~').filter(|uplink| !uplink.is_empty()) {
+        return serve_tarball_via_uplink(&state, &identity, uplink, &name, &filename).await;
+    }
     if !scope.starts_with('@') {
         return not_found();
     }
@@ -724,13 +743,21 @@ async fn get_four_segments(
     not_found()
 }
 
-/// 5-segment GET: rare for the npm spec — just here as a not-found
-/// catchall so the route compiles and DELETE/PUT can sit on the
-/// same path.
+/// 5-segment GET: `/~<uplink>/@scope/<pkg>/-/<file>` is a scoped tarball
+/// through an uplink endpoint; every other 5-segment GET is a not-found
+/// catchall (the route exists so DELETE/PUT can sit on the same path).
 async fn get_five_segments(
-    State(_state): State<AppState>,
-    Path((_, _, _, _, _)): Path<(String, String, String, String, String)>,
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path((a, b, c, d, e)): Path<(String, String, String, String, String)>,
 ) -> Response {
+    if let Some(uplink) = a.strip_prefix('~').filter(|uplink| !uplink.is_empty())
+        && b.starts_with('@')
+        && d == "-"
+    {
+        let full = format!("{b}/{c}");
+        return serve_tarball_via_uplink(&state, &identity, uplink, &full, &e).await;
+    }
     not_found()
 }
 
@@ -900,7 +927,7 @@ async fn serve_packument(
             match packument_response(
                 &name,
                 &bytes,
-                &state.inner.config,
+                &state.inner.config.public_url,
                 state.inner.osv_index.as_ref(),
                 abbreviated,
             ) {
@@ -949,6 +976,140 @@ async fn serve_version_manifest(
     match serde_json::to_vec(&manifest) {
         Ok(body) => packument_bytes_response(body, "application/json"),
         Err(err) => error_response(&RegistryError::Json(err)),
+    }
+}
+
+/// The `dist.tarball` rewrite base for an uplink's `/~<uplink>/` registry
+/// endpoint, so a served packument points tarball requests back at the same
+/// endpoint (where this server re-checks access and proxies the bytes).
+fn uplink_tarball_base(public_url: &str, uplink: &str) -> String {
+    format!("{}/~{uplink}", public_url.trim_end_matches('/'))
+}
+
+/// Resolve the upstream behind an authorized `/~<uplink>/` endpoint request.
+///
+/// Fails closed: an uplink that does not exist or carries no `access:` policy
+/// is a `404` (it is not a private-route endpoint), and a caller the policy
+/// does not admit is a `403`. Returns the [`Upstream`] to fetch *through* —
+/// `/~<uplink>/` requests never read or write the shared proxy mirror, so a
+/// private uplink's packuments and tarballs can never leak across the public
+/// path or another uplink.
+fn authorized_uplink<'a>(
+    state: &'a AppState,
+    identity: &Identity,
+    uplink: &str,
+) -> Result<&'a Upstream, Box<Response>> {
+    let Some(access) =
+        state.inner.config.uplinks.get(uplink).and_then(|config| config.access.as_ref())
+    else {
+        return Err(Box::new(not_found()));
+    };
+    if !access.allows(identity) {
+        let user =
+            require_caller(identity, "uplink access").unwrap_or_else(|_| "<anonymous>".to_string());
+        return Err(Box::new(error_response(&RegistryError::Forbidden {
+            user,
+            action: "access",
+            resource: format!("uplink {uplink:?}"),
+        })));
+    }
+    state.inner.upstreams.get(uplink).ok_or_else(|| Box::new(not_found()))
+}
+
+/// Serve a packument through an uplink's `/~<uplink>/` endpoint: fetch the
+/// uplink's own copy fresh (never the shared mirror), rewrite its
+/// `dist.tarball` URLs back onto the same endpoint, and apply OSV filtering.
+async fn serve_packument_via_uplink(
+    state: &AppState,
+    identity: &Identity,
+    headers: &HeaderMap,
+    uplink: &str,
+    raw_name: &str,
+) -> Response {
+    let name = match PackageName::parse(raw_name) {
+        Ok(n) => n,
+        Err(err) => return error_response(&err),
+    };
+    let upstream = match authorized_uplink(state, identity, uplink) {
+        Ok(upstream) => upstream,
+        Err(response) => return *response,
+    };
+    let bytes = match upstream.fetch_packument(&name, &CacheValidators::default()).await {
+        Ok(PackumentFetch::Modified(fetched)) => fetched.bytes,
+        Ok(PackumentFetch::NotFound | PackumentFetch::NotModified) => return not_found(),
+        Err(err) => return error_response(&err),
+    };
+    let base = uplink_tarball_base(&state.inner.config.public_url, uplink);
+    match packument_response(
+        &name,
+        &bytes,
+        &base,
+        state.inner.osv_index.as_ref(),
+        wants_abbreviated(headers),
+    ) {
+        Ok(response) => response,
+        Err(err) => error_response(&err),
+    }
+}
+
+/// Serve a tarball through an uplink's `/~<uplink>/` endpoint. The version's
+/// `dist.integrity` is read from the uplink's *own* fresh packument and the
+/// bytes are verified against it while streaming, then the temp file is
+/// removed — a private uplink's tarball is never written to the shared proxy
+/// cache.
+async fn serve_tarball_via_uplink(
+    state: &AppState,
+    identity: &Identity,
+    uplink: &str,
+    raw_name: &str,
+    filename: &str,
+) -> Response {
+    let name = match PackageName::parse(raw_name) {
+        Ok(n) => n,
+        Err(err) => return error_response(&err),
+    };
+    let (filename, name_version) = match name.parse_tarball_name(filename) {
+        Ok(parsed) => parsed,
+        Err(err) => return error_response(&err),
+    };
+    let upstream = match authorized_uplink(state, identity, uplink) {
+        Ok(upstream) => upstream,
+        Err(response) => return *response,
+    };
+    if let Err(err) = ensure_osv_allowed(state, &name, &name_version) {
+        return error_response(&err);
+    }
+    let packument = match upstream.fetch_packument(&name, &CacheValidators::default()).await {
+        Ok(PackumentFetch::Modified(fetched)) => fetched.bytes,
+        Ok(PackumentFetch::NotFound | PackumentFetch::NotModified) => return not_found(),
+        Err(err) => return error_response(&err),
+    };
+    let TarballDist { version, integrity } =
+        match expected_tarball_dist(&packument, &name, &filename) {
+            Ok(Some(dist)) => dist,
+            Ok(None) => return not_found(),
+            Err(err) => return error_response(&err),
+        };
+    if version != name_version
+        && let Err(err) = ensure_osv_allowed(state, &name, &version)
+    {
+        return error_response(&err);
+    }
+    let response = match upstream.fetch_tarball_response(&name, &filename).await {
+        Ok(FetchOutcome::Ok(response)) => response,
+        Ok(FetchOutcome::NotFound) => return not_found(),
+        Err(err) => return error_response(&err),
+    };
+    let write = match state.inner.storage.open_cached_tarball_tmp(&name, &filename).await {
+        Ok(write) => write,
+        Err(err) => return error_response(&err),
+    };
+    match streaming::download_verified_to_temp(response, write, &integrity, MAX_TARBALL_BYTES).await
+    {
+        Ok((file, len, tmp_path)) => {
+            tarball_response(streaming::stream_file_and_remove(file, tmp_path), Some(len))
+        }
+        Err(err) => error_response(&tarball_stream_error(err, &name, &filename)),
     }
 }
 
@@ -3033,13 +3194,13 @@ fn record_cache_status(status: &'static str) {
 fn packument_response(
     name: &PackageName,
     bytes: &[u8],
-    config: &Config,
+    tarball_base: &str,
     osv_index: Option<&Arc<crate::resolver::OsvIndex>>,
     abbreviated: bool,
 ) -> Result<Response, RegistryError> {
     let mut doc: Value = serde_json::from_slice(bytes)?;
     filter_osv_vulnerable_versions(&mut doc, name, osv_index);
-    rewrite_tarball_urls(&mut doc, name, &config.public_url);
+    rewrite_tarball_urls(&mut doc, name, tarball_base);
     let (body, content_type) = if abbreviated {
         let trimmed = abbreviate_packument(&doc, Utc::now());
         (serde_json::to_vec(&trimmed)?, ABBREVIATED_CONTENT_TYPE)

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -538,7 +538,9 @@ async fn get_two_segments(
     }
     // `/~<uplink>/<pkg>` — unscoped packument through an uplink endpoint.
     if let Some(uplink) = first.strip_prefix('~').filter(|uplink| !uplink.is_empty()) {
-        return serve_packument_via_uplink(&state, &identity, &headers, uplink, &second).await;
+        return private_no_cache(
+            serve_packument_via_uplink(&state, &identity, &headers, uplink, &second).await,
+        );
     }
     if first.starts_with('@') {
         let full = format!("{first}/{second}");
@@ -565,7 +567,9 @@ async fn get_three_segments(
     if let Some(uplink) = first.strip_prefix('~').filter(|uplink| !uplink.is_empty()) {
         if second.starts_with('@') {
             let full = format!("{second}/{third}");
-            return serve_packument_via_uplink(&state, &identity, &headers, uplink, &full).await;
+            return private_no_cache(
+                serve_packument_via_uplink(&state, &identity, &headers, uplink, &full).await,
+            );
         }
         return not_found();
     }
@@ -586,7 +590,9 @@ async fn get_tarball_scoped(
 ) -> Response {
     // `/~<uplink>/<pkg>/-/<file>` — unscoped tarball through an uplink endpoint.
     if let Some(uplink) = scope.strip_prefix('~').filter(|uplink| !uplink.is_empty()) {
-        return serve_tarball_via_uplink(&state, &identity, uplink, &name, &filename).await;
+        return private_no_cache(
+            serve_tarball_via_uplink(&state, &identity, uplink, &name, &filename).await,
+        );
     }
     if !scope.starts_with('@') {
         return not_found();
@@ -630,7 +636,9 @@ async fn get_five_segments(
         && d == "-"
     {
         let full = format!("{b}/{c}");
-        return serve_tarball_via_uplink(&state, &identity, uplink, &full, &e).await;
+        return private_no_cache(
+            serve_tarball_via_uplink(&state, &identity, uplink, &full, &e).await,
+        );
     }
     not_found()
 }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -940,7 +940,16 @@ async fn load_uplink_packument(
             }
             Ok(Some(fetched.bytes))
         }
-        PackumentFetch::NotFound | PackumentFetch::NotModified => Ok(None),
+        PackumentFetch::NotFound => Ok(None),
+        // `load_uplink_packument` sends no conditional validators (the uplink
+        // cache refetches stale entries rather than revalidating — see
+        // `Store::read_uplink_packument`), so a well-behaved upstream never
+        // answers 304 here. If one does anyway, "not modified" means the cached
+        // body is current, so serve it (fresh or stale) rather than a spurious
+        // 404 that a client could cache as "package gone".
+        PackumentFetch::NotModified => {
+            state.inner.storage.read_uplink_packument_any(namespace, name).await
+        }
     }
 }
 

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -904,7 +904,9 @@ fn uplink_cache_namespace(state: &AppState, uplink: &str) -> String {
 
 /// Load an uplink route's packument: a fresh per-uplink cache entry when one
 /// exists, otherwise a fetch through the uplink (with its server-side
-/// credential) written back to the same private namespace.
+/// credential) written back to the same private namespace. An uplink with
+/// `cache: false` neither reads nor writes the private cache — it streams the
+/// packument through every time, like the public path's `cache: false` knob.
 async fn load_uplink_packument(
     state: &AppState,
     namespace: &str,
@@ -912,13 +914,19 @@ async fn load_uplink_packument(
     name: &PackageName,
     ttl: Duration,
 ) -> Result<Option<Vec<u8>>, RegistryError> {
-    if let Some(bytes) = state.inner.storage.read_uplink_packument(namespace, name, ttl).await? {
+    if upstream.caches()
+        && let Some(bytes) = state.inner.storage.read_uplink_packument(namespace, name, ttl).await?
+    {
         return Ok(Some(bytes));
     }
     match upstream.fetch_packument(name, &CacheValidators::default()).await? {
         PackumentFetch::Modified(fetched) => {
-            if let Err(err) =
-                state.inner.storage.write_uplink_packument(namespace, name, &fetched.bytes).await
+            if upstream.caches()
+                && let Err(err) = state
+                    .inner
+                    .storage
+                    .write_uplink_packument(namespace, name, &fetched.bytes)
+                    .await
             {
                 tracing::warn!(?err, package = %name.as_str(), "uplink packument cache write failed");
             }
@@ -1010,42 +1018,45 @@ async fn serve_tarball_via_uplink(
         return error_response(&err);
     }
 
-    // Serve a verified private-cache hit without touching the upstream.
-    match state.inner.storage.open_uplink_tarball(&namespace, &name, &filename).await {
-        Ok(Some((file, len))) => {
-            let expected = cached_tarball_integrity(&integrity, len);
-            if state
-                .inner
-                .storage
-                .read_uplink_tarball_integrity(&namespace, &name, &filename)
-                .await
-                .is_some_and(|cached| cached == expected)
-            {
-                return tarball_response(streaming::stream_file(file), Some(len));
-            }
-            match streaming::verify_file(file, &integrity).await {
-                Ok(file) => {
-                    let _ = state
-                        .inner
-                        .storage
-                        .write_uplink_tarball_integrity(&namespace, &name, &filename, &expected)
-                        .await;
+    // Serve a verified private-cache hit without touching the upstream. An
+    // uplink with `cache: false` skips the cache entirely and streams through.
+    if upstream.caches() {
+        match state.inner.storage.open_uplink_tarball(&namespace, &name, &filename).await {
+            Ok(Some((file, len))) => {
+                let expected = cached_tarball_integrity(&integrity, len);
+                if state
+                    .inner
+                    .storage
+                    .read_uplink_tarball_integrity(&namespace, &name, &filename)
+                    .await
+                    .is_some_and(|cached| cached == expected)
+                {
                     return tarball_response(streaming::stream_file(file), Some(len));
                 }
-                Err(err) => {
-                    let err = tarball_stream_error(err, &name, &filename);
-                    tracing::warn!(?err, package = %name.as_str(), %filename, "cached uplink tarball failed verification");
-                    let _ = state
-                        .inner
-                        .storage
-                        .remove_uplink_tarball(&namespace, &name, &filename)
-                        .await;
+                match streaming::verify_file(file, &integrity).await {
+                    Ok(file) => {
+                        let _ = state
+                            .inner
+                            .storage
+                            .write_uplink_tarball_integrity(&namespace, &name, &filename, &expected)
+                            .await;
+                        return tarball_response(streaming::stream_file(file), Some(len));
+                    }
+                    Err(err) => {
+                        let err = tarball_stream_error(err, &name, &filename);
+                        tracing::warn!(?err, package = %name.as_str(), %filename, "cached uplink tarball failed verification");
+                        let _ = state
+                            .inner
+                            .storage
+                            .remove_uplink_tarball(&namespace, &name, &filename)
+                            .await;
+                    }
                 }
             }
-        }
-        Ok(None) => {}
-        Err(err) => {
-            tracing::warn!(?err, package = %name.as_str(), %filename, "uplink tarball cache open failed");
+            Ok(None) => {}
+            Err(err) => {
+                tracing::warn!(?err, package = %name.as_str(), %filename, "uplink tarball cache open failed");
+            }
         }
     }
 
@@ -1059,6 +1070,23 @@ async fn serve_tarball_via_uplink(
             Ok(write) => write,
             Err(err) => return error_response(&err),
         };
+    if !upstream.caches() {
+        // Fetch-through: verify and stream from the temp file, then remove it,
+        // so a `cache: false` uplink's tarball is never persisted.
+        return match streaming::download_verified_to_temp(
+            response,
+            write,
+            &integrity,
+            MAX_TARBALL_BYTES,
+        )
+        .await
+        {
+            Ok((file, len, tmp_path)) => {
+                tarball_response(streaming::stream_file_and_remove(file, tmp_path), Some(len))
+            }
+            Err(err) => error_response(&tarball_stream_error(err, &name, &filename)),
+        };
+    }
     let len =
         match streaming::download_verified_to_cache(response, write, &integrity, MAX_TARBALL_BYTES)
             .await

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1291,7 +1291,7 @@ mod tests;
 /// `resource` names what the 401 is about.
 fn require_caller(identity: &Identity, resource: &str) -> Result<String, RegistryError> {
     match identity {
-        Identity::User { username } => Ok(username.clone()),
+        Identity::User { username, .. } => Ok(username.clone()),
         Identity::Anonymous => {
             Err(RegistryError::Unauthenticated { resource: resource.to_string() })
         }
@@ -2435,7 +2435,7 @@ async fn resolve_caller(
             return Ok(Identity::Anonymous);
         };
         check_token_restrictions(&record, method, peer)?;
-        return Ok(Identity::User { username: record.username });
+        return Ok(state.inner.config.identity_for_user(record.username));
     }
     // Anything that is not a bearer token — Basic, another scheme, or no
     // credentials — carries no request identity. Going through `identify`
@@ -2501,7 +2501,7 @@ fn authorize(
         Identity::Anonymous => {
             Err(RegistryError::Unauthenticated { resource: format!("package {package:?}") })
         }
-        Identity::User { username } => Err(RegistryError::Forbidden {
+        Identity::User { username, .. } => Err(RegistryError::Forbidden {
             user: username.clone(),
             action: action.label(),
             resource: format!("package {package:?}"),

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -3089,24 +3089,33 @@ async fn resolver_disabled() -> Response {
     StatusCode::NOT_FOUND.into_response()
 }
 
-async fn serve_resolve(State(state): State<AppState>, body: axum::body::Bytes) -> Response {
-    // pnpr resolves but serves no file content, so there is no per-package
-    // read gate here: the client fetches every tarball directly from the
-    // registry with its own credentials, and resolution uses the client's
-    // forwarded credentials for private packages.
+async fn serve_resolve(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    body: axum::body::Bytes,
+) -> Response {
+    // pnpr serves no file content, so there is no per-package read gate
+    // here: the client fetches every tarball directly. But the caller's
+    // identity does drive resolution — it selects which pnpr-managed
+    // upstream credentials and hosted packages the resolve may use, and
+    // gates which cached resolutions it may receive.
     let runtime = crate::resolver::Resolver::get_or_init(
         &state.inner.resolver,
         &state.inner.config,
         state.inner.osv_index.clone(),
     );
-    crate::resolver::handle_resolve(runtime, body).await
+    crate::resolver::handle_resolve(runtime, identity, body).await
 }
 
-async fn serve_verify_lockfile(State(state): State<AppState>, body: axum::body::Bytes) -> Response {
+async fn serve_verify_lockfile(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    body: axum::body::Bytes,
+) -> Response {
     let runtime = crate::resolver::Resolver::get_or_init(
         &state.inner.resolver,
         &state.inner.config,
         state.inner.osv_index.clone(),
     );
-    crate::resolver::handle_verify_lockfile(runtime, body).await
+    crate::resolver::handle_verify_lockfile(runtime, identity, body).await
 }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -901,17 +901,24 @@ fn authorized_uplink<'a>(
 /// Serve a packument through an uplink's `/~<uplink>/` endpoint: fetch the
 /// uplink's own copy fresh (never the shared mirror), rewrite its
 /// `dist.tarball` URLs back onto the same endpoint, and apply OSV filtering.
-/// The disposable cache namespace for an uplink's `/~<uplink>/` route,
-/// keyed by the uplink and its rotation generation so its packuments and
-/// tarballs never collide with the public mirror or another uplink, and so a
-/// credential rotation moves to a fresh namespace. The `(uplink, generation)`
-/// is HMAC'd with the server secret, so the on-disk path leaks neither, and a
-/// path-unsafe uplink name can't escape the cache root (the digest is hex).
+/// The disposable cache namespace for an uplink's `/~<uplink>/` route, keyed by
+/// the uplink and a digest of its credential so its packuments and tarballs
+/// never collide with the public mirror or another uplink, and so a credential
+/// rotation moves to a fresh namespace. The `(uplink, credential)` is HMAC'd
+/// with the server secret, so the on-disk path leaks neither, and a path-unsafe
+/// uplink name can't escape the cache root (the digest is hex).
 fn uplink_cache_namespace(state: &AppState, uplink: &str) -> String {
-    let generation = state.inner.config.uplinks.get(uplink).map_or(1, |uplink| uplink.generation);
+    let authorization = state
+        .inner
+        .config
+        .uplinks
+        .get(uplink)
+        .and_then(|uplink| uplink.headers.get(reqwest::header::AUTHORIZATION))
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
     let digest = crate::route::uplink_cache_digest(
         uplink,
-        generation,
+        crate::route::credential_digest(authorization),
         &state.inner.config.resolution_cache_secret,
     );
     format!("~uplinks/{digest}")

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -9,6 +9,7 @@ use crate::{
         PendingAttachment, extract_attachments, iso_from_unix_millis, merge_manifest, now_iso,
         stream_decode_verify_and_write,
     },
+    route::RouteContext,
     storage::{CachedPackument, CachedTarballIntegrity, Storage},
     streaming,
     upstream::{
@@ -32,6 +33,7 @@ use axum::{
 };
 use chrono::Utc;
 use indexmap::IndexMap;
+use pacquet_network::ThrottledClient;
 use serde_json::{Value, json};
 use ssri::Integrity;
 use std::{
@@ -89,6 +91,10 @@ struct AppInner {
     /// Lazily-built engine backing the `/-/pnpr/v0/resolve` endpoint. Built on
     /// first such request so servers that never receive one pay nothing.
     resolver: std::sync::OnceLock<crate::resolver::Resolver>,
+    /// HTTP client used by the resolver's read-only tarball gateway for
+    /// pnpr-managed upstream aliases.
+    gateway_client: Arc<ThrottledClient>,
+    tarball_gateway_routes: crate::resolver::TarballGatewayRoutes,
     /// Local OSV index, loaded before the server accepts requests when
     /// `osv.enabled` is set and a mounted surface consults it.
     osv_index: Option<Arc<crate::resolver::OsvIndex>>,
@@ -255,6 +261,8 @@ fn router_with_auth_and_osv(
             auth,
             package_locks: PackageLocks::new(),
             resolver: std::sync::OnceLock::new(),
+            gateway_client: Arc::new(ThrottledClient::new_for_installs()),
+            tarball_gateway_routes: crate::resolver::TarballGatewayRoutes::default(),
             osv_index,
         }),
     };
@@ -292,6 +300,20 @@ fn router_with_auth_and_osv(
             .route(
                 "/-/pnpr/v0/verify-lockfile",
                 post(serve_verify_lockfile).route_layer(middleware::from_fn_with_state(
+                    state.clone(),
+                    require_resolver_caller,
+                )),
+            )
+            .route(
+                "/-/pnpr/v0/tarballs/alias/{alias}/{generation}/{package}/-/{filename}",
+                get(get_pnpr_alias_tarball).route_layer(middleware::from_fn_with_state(
+                    state.clone(),
+                    require_resolver_caller,
+                )),
+            )
+            .route(
+                "/-/pnpr/v0/tarballs/unknown/{key}/{package}/-/{filename}",
+                get(get_pnpr_unknown_tarball).route_layer(middleware::from_fn_with_state(
                     state.clone(),
                     require_resolver_caller,
                 )),
@@ -574,6 +596,110 @@ async fn get_tarball_scoped(
     }
     let full = format!("{scope}/{name}");
     serve_tarball(&state, &identity, &full, &filename).await
+}
+
+async fn get_pnpr_alias_tarball(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path((alias, generation, raw_name, filename)): Path<(String, String, String, String)>,
+) -> Response {
+    let Ok(generation) = generation.parse::<u64>() else {
+        return error_response(&RegistryError::BadRequest {
+            reason: "upstream alias generation is not a valid integer".to_string(),
+        });
+    };
+    let name = match PackageName::parse(&raw_name) {
+        Ok(name) => name,
+        Err(err) => return error_response(&err),
+    };
+    let (filename, version) = match name.parse_tarball_name(&filename) {
+        Ok(parsed) => parsed,
+        Err(err) => return error_response(&err),
+    };
+    if let Err(err) = ensure_osv_allowed(&state, &name, &version) {
+        return error_response(&err);
+    }
+
+    let context = RouteContext::from_config(&state.inner.config);
+    let Some(alias_config) = context.gateway_alias(&identity, &alias, generation, name.as_str())
+    else {
+        let user = require_caller(&identity, "dependency resolution")
+            .unwrap_or_else(|_| "<anonymous>".to_string());
+        return error_response(&RegistryError::Forbidden {
+            user,
+            action: "access",
+            resource: format!("upstream alias {alias:?}"),
+        });
+    };
+
+    let url = alias_tarball_upstream_url(&alias_config.registry, &name, &filename);
+    let client = state.inner.gateway_client.acquire_for_url(&url).await;
+    let response =
+        match client.get(&url).header("authorization", alias_config.authorization).send().await {
+            Ok(response) => response,
+            Err(source) => return error_response(&RegistryError::Upstream { url, source }),
+        };
+    if response.status() == StatusCode::NOT_FOUND {
+        return not_found();
+    }
+    if !response.status().is_success() {
+        tracing::warn!(
+            status = response.status().as_u16(),
+            package = %name.as_str(),
+            %filename,
+            alias = %alias,
+            "upstream alias tarball gateway fetch failed",
+        );
+        return (StatusCode::BAD_GATEWAY, "upstream tarball gateway request failed")
+            .into_response();
+    }
+    let content_length = response.content_length();
+    tarball_response(Body::from_stream(response.bytes_stream()), content_length)
+}
+
+async fn get_pnpr_unknown_tarball(
+    State(state): State<AppState>,
+    Path((key, raw_name, filename)): Path<(String, String, String)>,
+) -> Response {
+    let name = match PackageName::parse(&raw_name) {
+        Ok(name) => name,
+        Err(err) => return error_response(&err),
+    };
+    let (filename, version) = match name.parse_tarball_name(&filename) {
+        Ok(parsed) => parsed,
+        Err(err) => return error_response(&err),
+    };
+    if let Err(err) = ensure_osv_allowed(&state, &name, &version) {
+        return error_response(&err);
+    }
+    let Some(url) = state.inner.tarball_gateway_routes.get(&key) else {
+        return not_found();
+    };
+
+    let client = state.inner.gateway_client.acquire_for_url(&url).await;
+    let response = match client.get(&url).send().await {
+        Ok(response) => response,
+        Err(source) => return error_response(&RegistryError::Upstream { url, source }),
+    };
+    if response.status() == StatusCode::NOT_FOUND {
+        return not_found();
+    }
+    if !response.status().is_success() {
+        tracing::warn!(
+            status = response.status().as_u16(),
+            package = %name.as_str(),
+            %filename,
+            "unknown tarball gateway fetch failed",
+        );
+        return (StatusCode::BAD_GATEWAY, "upstream tarball gateway request failed")
+            .into_response();
+    }
+    let content_length = response.content_length();
+    tarball_response(Body::from_stream(response.bytes_stream()), content_length)
+}
+
+fn alias_tarball_upstream_url(registry: &str, name: &PackageName, filename: &str) -> String {
+    format!("{}/{}/-/{}", registry.trim_end_matches('/'), name.as_str(), filename)
 }
 
 /// 4-segment GET:
@@ -3094,15 +3220,15 @@ async fn serve_resolve(
     AuthedCaller(identity): AuthedCaller,
     body: axum::body::Bytes,
 ) -> Response {
-    // pnpr serves no file content, so there is no per-package read gate
-    // here: the client fetches every tarball directly. But the caller's
-    // identity does drive resolution — it selects which pnpr-managed
-    // upstream credentials and hosted packages the resolve may use, and
-    // gates which cached resolutions it may receive.
+    // The caller's identity drives both resolution and gateway access:
+    // it selects which pnpr-managed upstream credentials and hosted
+    // packages the resolve may use, and gates which cached resolutions
+    // it may receive.
     let runtime = crate::resolver::Resolver::get_or_init(
         &state.inner.resolver,
         &state.inner.config,
         state.inner.osv_index.clone(),
+        state.inner.tarball_gateway_routes.clone(),
     );
     crate::resolver::handle_resolve(runtime, identity, body).await
 }
@@ -3116,6 +3242,7 @@ async fn serve_verify_lockfile(
         &state.inner.resolver,
         &state.inner.config,
         state.inner.osv_index.clone(),
+        state.inner.tarball_gateway_routes.clone(),
     );
     crate::resolver::handle_verify_lockfile(runtime, identity, body).await
 }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -893,6 +893,41 @@ fn authorized_uplink<'a>(
 /// Serve a packument through an uplink's `/~<uplink>/` endpoint: fetch the
 /// uplink's own copy fresh (never the shared mirror), rewrite its
 /// `dist.tarball` URLs back onto the same endpoint, and apply OSV filtering.
+/// The disposable cache namespace for an uplink's `/~<uplink>/` route,
+/// keyed by the uplink and its rotation generation so its packuments and
+/// tarballs never collide with the public mirror or another uplink, and so a
+/// credential rotation moves to a fresh namespace.
+fn uplink_cache_namespace(state: &AppState, uplink: &str) -> String {
+    let generation = state.inner.config.uplinks.get(uplink).map_or(1, |uplink| uplink.generation);
+    format!("~uplinks/{uplink}/{generation}")
+}
+
+/// Load an uplink route's packument: a fresh per-uplink cache entry when one
+/// exists, otherwise a fetch through the uplink (with its server-side
+/// credential) written back to the same private namespace.
+async fn load_uplink_packument(
+    state: &AppState,
+    namespace: &str,
+    upstream: &Upstream,
+    name: &PackageName,
+    ttl: Duration,
+) -> Result<Option<Vec<u8>>, RegistryError> {
+    if let Some(bytes) = state.inner.storage.read_uplink_packument(namespace, name, ttl).await? {
+        return Ok(Some(bytes));
+    }
+    match upstream.fetch_packument(name, &CacheValidators::default()).await? {
+        PackumentFetch::Modified(fetched) => {
+            if let Err(err) =
+                state.inner.storage.write_uplink_packument(namespace, name, &fetched.bytes).await
+            {
+                tracing::warn!(?err, package = %name.as_str(), "uplink packument cache write failed");
+            }
+            Ok(Some(fetched.bytes))
+        }
+        PackumentFetch::NotFound | PackumentFetch::NotModified => Ok(None),
+    }
+}
+
 async fn serve_packument_via_uplink(
     state: &AppState,
     identity: &Identity,
@@ -908,9 +943,11 @@ async fn serve_packument_via_uplink(
         Ok(upstream) => upstream,
         Err(response) => return *response,
     };
-    let bytes = match upstream.fetch_packument(&name, &CacheValidators::default()).await {
-        Ok(PackumentFetch::Modified(fetched)) => fetched.bytes,
-        Ok(PackumentFetch::NotFound | PackumentFetch::NotModified) => return not_found(),
+    let namespace = uplink_cache_namespace(state, uplink);
+    let ttl = upstream.maxage().unwrap_or(state.inner.config.packument_ttl);
+    let bytes = match load_uplink_packument(state, &namespace, upstream, &name, ttl).await {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) => return not_found(),
         Err(err) => return error_response(&err),
     };
     let base = uplink_tarball_base(&state.inner.config.public_url, uplink);
@@ -927,10 +964,11 @@ async fn serve_packument_via_uplink(
 }
 
 /// Serve a tarball through an uplink's `/~<uplink>/` endpoint. The version's
-/// `dist.integrity` is read from the uplink's *own* fresh packument and the
-/// bytes are verified against it while streaming, then the temp file is
-/// removed — a private uplink's tarball is never written to the shared proxy
-/// cache.
+/// `dist.integrity` is read from the uplink's own packument (served from the
+/// private cache when fresh), and the bytes are verified against it. Both the
+/// packument and the verified tarball are cached under the uplink's private
+/// namespace, so a private uplink's content never lands in the shared proxy
+/// mirror yet is not re-fetched on every request.
 async fn serve_tarball_via_uplink(
     state: &AppState,
     identity: &Identity,
@@ -953,9 +991,11 @@ async fn serve_tarball_via_uplink(
     if let Err(err) = ensure_osv_allowed(state, &name, &name_version) {
         return error_response(&err);
     }
-    let packument = match upstream.fetch_packument(&name, &CacheValidators::default()).await {
-        Ok(PackumentFetch::Modified(fetched)) => fetched.bytes,
-        Ok(PackumentFetch::NotFound | PackumentFetch::NotModified) => return not_found(),
+    let namespace = uplink_cache_namespace(state, uplink);
+    let ttl = upstream.maxage().unwrap_or(state.inner.config.packument_ttl);
+    let packument = match load_uplink_packument(state, &namespace, upstream, &name, ttl).await {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) => return not_found(),
         Err(err) => return error_response(&err),
     };
     let TarballDist { version, integrity } =
@@ -969,21 +1009,81 @@ async fn serve_tarball_via_uplink(
     {
         return error_response(&err);
     }
+
+    // Serve a verified private-cache hit without touching the upstream.
+    match state.inner.storage.open_uplink_tarball(&namespace, &name, &filename).await {
+        Ok(Some((file, len))) => {
+            let expected = cached_tarball_integrity(&integrity, len);
+            if state
+                .inner
+                .storage
+                .read_uplink_tarball_integrity(&namespace, &name, &filename)
+                .await
+                .is_some_and(|cached| cached == expected)
+            {
+                return tarball_response(streaming::stream_file(file), Some(len));
+            }
+            match streaming::verify_file(file, &integrity).await {
+                Ok(file) => {
+                    let _ = state
+                        .inner
+                        .storage
+                        .write_uplink_tarball_integrity(&namespace, &name, &filename, &expected)
+                        .await;
+                    return tarball_response(streaming::stream_file(file), Some(len));
+                }
+                Err(err) => {
+                    let err = tarball_stream_error(err, &name, &filename);
+                    tracing::warn!(?err, package = %name.as_str(), %filename, "cached uplink tarball failed verification");
+                    let _ = state
+                        .inner
+                        .storage
+                        .remove_uplink_tarball(&namespace, &name, &filename)
+                        .await;
+                }
+            }
+        }
+        Ok(None) => {}
+        Err(err) => {
+            tracing::warn!(?err, package = %name.as_str(), %filename, "uplink tarball cache open failed");
+        }
+    }
+
     let response = match upstream.fetch_tarball_response(&name, &filename).await {
         Ok(FetchOutcome::Ok(response)) => response,
         Ok(FetchOutcome::NotFound) => return not_found(),
         Err(err) => return error_response(&err),
     };
-    let write = match state.inner.storage.open_cached_tarball_tmp(&name, &filename).await {
-        Ok(write) => write,
-        Err(err) => return error_response(&err),
-    };
-    match streaming::download_verified_to_temp(response, write, &integrity, MAX_TARBALL_BYTES).await
-    {
-        Ok((file, len, tmp_path)) => {
-            tarball_response(streaming::stream_file_and_remove(file, tmp_path), Some(len))
-        }
-        Err(err) => error_response(&tarball_stream_error(err, &name, &filename)),
+    let write =
+        match state.inner.storage.open_uplink_tarball_tmp(&namespace, &name, &filename).await {
+            Ok(write) => write,
+            Err(err) => return error_response(&err),
+        };
+    let len =
+        match streaming::download_verified_to_cache(response, write, &integrity, MAX_TARBALL_BYTES)
+            .await
+        {
+            Ok(len) => len,
+            Err(err) => return error_response(&tarball_stream_error(err, &name, &filename)),
+        };
+    let _ = state
+        .inner
+        .storage
+        .write_uplink_tarball_integrity(
+            &namespace,
+            &name,
+            &filename,
+            &cached_tarball_integrity(&integrity, len),
+        )
+        .await;
+    match state.inner.storage.open_uplink_tarball(&namespace, &name, &filename).await {
+        Ok(Some((file, len))) => tarball_response(streaming::stream_file(file), Some(len)),
+        Ok(None) => error_response(&tarball_integrity_error(
+            &name,
+            &filename,
+            "verified uplink cache entry disappeared before it could be served".to_string(),
+        )),
+        Err(err) => error_response(&err),
     }
 }
 

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -9,7 +9,6 @@ use crate::{
         PendingAttachment, extract_attachments, iso_from_unix_millis, merge_manifest, now_iso,
         stream_decode_verify_and_write,
     },
-    route::RouteContext,
     storage::{CachedPackument, CachedTarballIntegrity, Storage},
     streaming,
     upstream::{
@@ -33,7 +32,6 @@ use axum::{
 };
 use chrono::Utc;
 use indexmap::IndexMap;
-use pacquet_network::ThrottledClient;
 use serde_json::{Value, json};
 use ssri::Integrity;
 use std::{
@@ -91,10 +89,6 @@ struct AppInner {
     /// Lazily-built engine backing the `/-/pnpr/v0/resolve` endpoint. Built on
     /// first such request so servers that never receive one pay nothing.
     resolver: std::sync::OnceLock<crate::resolver::Resolver>,
-    /// HTTP client used by the resolver's read-only tarball gateway for
-    /// pnpr-managed upstream aliases.
-    gateway_client: Arc<ThrottledClient>,
-    tarball_gateway_routes: crate::resolver::TarballGatewayRoutes,
     /// Local OSV index, loaded before the server accepts requests when
     /// `osv.enabled` is set and a mounted surface consults it.
     osv_index: Option<Arc<crate::resolver::OsvIndex>>,
@@ -261,8 +255,6 @@ fn router_with_auth_and_osv(
             auth,
             package_locks: PackageLocks::new(),
             resolver: std::sync::OnceLock::new(),
-            gateway_client: Arc::new(ThrottledClient::new_for_installs()),
-            tarball_gateway_routes: crate::resolver::TarballGatewayRoutes::default(),
             osv_index,
         }),
     };
@@ -300,20 +292,6 @@ fn router_with_auth_and_osv(
             .route(
                 "/-/pnpr/v0/verify-lockfile",
                 post(serve_verify_lockfile).route_layer(middleware::from_fn_with_state(
-                    state.clone(),
-                    require_resolver_caller,
-                )),
-            )
-            .route(
-                "/-/pnpr/v0/tarballs/alias/{alias}/{generation}/{package}/-/{filename}",
-                get(get_pnpr_alias_tarball).route_layer(middleware::from_fn_with_state(
-                    state.clone(),
-                    require_resolver_caller,
-                )),
-            )
-            .route(
-                "/-/pnpr/v0/tarballs/unknown/{key}/{package}/-/{filename}",
-                get(get_pnpr_unknown_tarball).route_layer(middleware::from_fn_with_state(
                     state.clone(),
                     require_resolver_caller,
                 )),
@@ -615,110 +593,6 @@ async fn get_tarball_scoped(
     }
     let full = format!("{scope}/{name}");
     serve_tarball(&state, &identity, &full, &filename).await
-}
-
-async fn get_pnpr_alias_tarball(
-    State(state): State<AppState>,
-    AuthedCaller(identity): AuthedCaller,
-    Path((alias, generation, raw_name, filename)): Path<(String, String, String, String)>,
-) -> Response {
-    let Ok(generation) = generation.parse::<u64>() else {
-        return error_response(&RegistryError::BadRequest {
-            reason: "upstream alias generation is not a valid integer".to_string(),
-        });
-    };
-    let name = match PackageName::parse(&raw_name) {
-        Ok(name) => name,
-        Err(err) => return error_response(&err),
-    };
-    let (filename, version) = match name.parse_tarball_name(&filename) {
-        Ok(parsed) => parsed,
-        Err(err) => return error_response(&err),
-    };
-    if let Err(err) = ensure_osv_allowed(&state, &name, &version) {
-        return error_response(&err);
-    }
-
-    let context = RouteContext::from_config(&state.inner.config);
-    let Some(alias_config) = context.gateway_alias(&identity, &alias, generation, name.as_str())
-    else {
-        let user = require_caller(&identity, "dependency resolution")
-            .unwrap_or_else(|_| "<anonymous>".to_string());
-        return error_response(&RegistryError::Forbidden {
-            user,
-            action: "access",
-            resource: format!("upstream alias {alias:?}"),
-        });
-    };
-
-    let url = alias_tarball_upstream_url(&alias_config.registry, &name, &filename);
-    let client = state.inner.gateway_client.acquire_for_url(&url).await;
-    let response =
-        match client.get(&url).header("authorization", alias_config.authorization).send().await {
-            Ok(response) => response,
-            Err(source) => return error_response(&RegistryError::Upstream { url, source }),
-        };
-    if response.status() == StatusCode::NOT_FOUND {
-        return not_found();
-    }
-    if !response.status().is_success() {
-        tracing::warn!(
-            status = response.status().as_u16(),
-            package = %name.as_str(),
-            %filename,
-            alias = %alias,
-            "upstream alias tarball gateway fetch failed",
-        );
-        return (StatusCode::BAD_GATEWAY, "upstream tarball gateway request failed")
-            .into_response();
-    }
-    let content_length = response.content_length();
-    tarball_response(Body::from_stream(response.bytes_stream()), content_length)
-}
-
-async fn get_pnpr_unknown_tarball(
-    State(state): State<AppState>,
-    Path((key, raw_name, filename)): Path<(String, String, String)>,
-) -> Response {
-    let name = match PackageName::parse(&raw_name) {
-        Ok(name) => name,
-        Err(err) => return error_response(&err),
-    };
-    let (filename, version) = match name.parse_tarball_name(&filename) {
-        Ok(parsed) => parsed,
-        Err(err) => return error_response(&err),
-    };
-    if let Err(err) = ensure_osv_allowed(&state, &name, &version) {
-        return error_response(&err);
-    }
-    let Some(url) = state.inner.tarball_gateway_routes.get(&key) else {
-        return not_found();
-    };
-
-    let client = state.inner.gateway_client.acquire_for_url(&url).await;
-    let response = match client.get(&url).send().await {
-        Ok(response) => response,
-        Err(source) => return error_response(&RegistryError::Upstream { url, source }),
-    };
-    if response.status() == StatusCode::NOT_FOUND {
-        return not_found();
-    }
-    if !response.status().is_success() {
-        tracing::warn!(
-            status = response.status().as_u16(),
-            package = %name.as_str(),
-            %filename,
-            "unknown tarball gateway fetch failed",
-        );
-        return (StatusCode::BAD_GATEWAY, "upstream tarball gateway request failed")
-            .into_response();
-    }
-    let content_length = response.content_length();
-    tarball_response(Body::from_stream(response.bytes_stream()), content_length)
-}
-
-fn alias_tarball_upstream_url(registry: &str, name: &PackageName, filename: &str) -> String {
-    format!("{}/{}/-/{}", registry.trim_end_matches('/'), name.as_str(), filename)
 }
 
 /// 4-segment GET:
@@ -3389,7 +3263,6 @@ async fn serve_resolve(
         &state.inner.resolver,
         &state.inner.config,
         state.inner.osv_index.clone(),
-        state.inner.tarball_gateway_routes.clone(),
     );
     crate::resolver::handle_resolve(runtime, identity, body).await
 }
@@ -3403,7 +3276,6 @@ async fn serve_verify_lockfile(
         &state.inner.resolver,
         &state.inner.config,
         state.inner.osv_index.clone(),
-        state.inner.tarball_gateway_routes.clone(),
     );
     crate::resolver::handle_verify_lockfile(runtime, identity, body).await
 }

--- a/pnpr/crates/pnpr/src/server/tests.rs
+++ b/pnpr/crates/pnpr/src/server/tests.rs
@@ -6,6 +6,7 @@ use crate::{
     auth::{AuthState, TokenBackend, TokenRecord, UserStore},
     config::Config,
     error::{RegistryError, Result},
+    policy::{AccessList, PackagePolicies, PackagePolicy},
 };
 use async_trait::async_trait;
 use axum::{
@@ -171,10 +172,14 @@ impl TokenBackend for OneToken {
 }
 
 fn app_with_token(tmp: &TempDir, raw: &str, record: TokenRecord) -> axum::Router {
+    let listen = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+    app_with_config_and_token(Config::static_serve(listen, tmp.path().to_path_buf()), raw, record)
+}
+
+fn app_with_config_and_token(config: Config, raw: &str, record: TokenRecord) -> axum::Router {
     let tokens: Arc<dyn TokenBackend> = Arc::new(OneToken { raw: raw.to_string(), record });
     let auth = AuthState { users: Arc::new(UserStore::in_memory()), tokens };
-    let listen = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
-    router_with_auth(Config::static_serve(listen, tmp.path().to_path_buf()), auth)
+    router_with_auth(config, auth)
 }
 
 fn signed(method: Method, path: &str, raw: &str) -> Request<Body> {
@@ -210,6 +215,30 @@ async fn authenticated_identity_reaches_handlers() {
     // An unknown token resolves to anonymous, so whoami is a 401.
     let anon = app.oneshot(signed(Method::GET, "/-/whoami", "unknown")).await.unwrap();
     assert_eq!(anon.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn configured_groups_reach_package_authorization() {
+    let tmp = TempDir::new().unwrap();
+    let listen = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+    let mut config = Config::static_serve(listen, tmp.path().to_path_buf());
+    config.groups.add_user_to_group("alice", "platform");
+    config.policies = PackagePolicies::new(vec![
+        PackagePolicy::new(
+            "@team/*",
+            AccessList::parse("platform"),
+            AccessList::default(),
+            AccessList::default(),
+        )
+        .unwrap(),
+    ]);
+    let app = app_with_config_and_token(config, "tok", record(false, &[]));
+
+    let allowed = app.clone().oneshot(signed(Method::GET, "/@team/missing", "tok")).await.unwrap();
+    assert_eq!(allowed.status(), StatusCode::NOT_FOUND);
+
+    let anonymous = app.oneshot(signed(Method::GET, "/@team/missing", "unknown")).await.unwrap();
+    assert_eq!(anonymous.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -457,6 +457,84 @@ impl Storage {
         self.cached.remove_tarball(name, filename).await
     }
 
+    // --- Per-uplink private cache (the `/~<uplink>/` registry endpoint) ----
+    //
+    // A private uplink's packuments and tarballs are cached under a namespace
+    // derived from the uplink and its rotation generation, kept separate from
+    // the shared public mirror so they can never be served on the public path
+    // or under another uplink. A rotation (new generation) moves to a fresh
+    // namespace, so entries fetched with a since-rotated credential age out.
+
+    /// A fresh cached packument for an uplink route, or `None` when it is
+    /// absent or older than `ttl`. The uplink path refetches a stale entry
+    /// rather than conditionally revalidating it.
+    pub async fn read_uplink_packument(
+        &self,
+        namespace: &str,
+        name: &PackageName,
+        ttl: Duration,
+    ) -> Result<Option<Vec<u8>>> {
+        match self.cached.namespaced(namespace).read_packument_entry(name, ttl).await? {
+            Some(CachedPackument::Fresh(bytes)) => Ok(Some(bytes)),
+            Some(CachedPackument::Stale(_)) | None => Ok(None),
+        }
+    }
+
+    pub async fn write_uplink_packument(
+        &self,
+        namespace: &str,
+        name: &PackageName,
+        bytes: &[u8],
+    ) -> Result<()> {
+        self.cached.namespaced(namespace).write_packument(name, bytes).await
+    }
+
+    pub async fn open_uplink_tarball_tmp(
+        &self,
+        namespace: &str,
+        name: &PackageName,
+        filename: &str,
+    ) -> Result<TarballWrite> {
+        self.cached.namespaced(namespace).open_tarball_tmp(name, filename).await
+    }
+
+    pub async fn open_uplink_tarball(
+        &self,
+        namespace: &str,
+        name: &PackageName,
+        filename: &str,
+    ) -> Result<Option<(fs::File, u64)>> {
+        self.cached.namespaced(namespace).open_tarball(name, filename).await
+    }
+
+    pub async fn read_uplink_tarball_integrity(
+        &self,
+        namespace: &str,
+        name: &PackageName,
+        filename: &str,
+    ) -> Option<CachedTarballIntegrity> {
+        self.cached.namespaced(namespace).read_tarball_integrity(name, filename).await
+    }
+
+    pub async fn write_uplink_tarball_integrity(
+        &self,
+        namespace: &str,
+        name: &PackageName,
+        filename: &str,
+        integrity: &CachedTarballIntegrity,
+    ) -> Result<()> {
+        self.cached.namespaced(namespace).write_tarball_integrity(name, filename, integrity).await
+    }
+
+    pub async fn remove_uplink_tarball(
+        &self,
+        namespace: &str,
+        name: &PackageName,
+        filename: &str,
+    ) -> Result<bool> {
+        self.cached.namespaced(namespace).remove_tarball(name, filename).await
+    }
+
     /// Promote a tmp tarball written by the publish flow to its final
     /// home: a rename on the fs backend, an upload on the S3 backend.
     pub async fn finalize_tarball_slot(&self, slot: TarballSlot) -> Result<()> {
@@ -485,6 +563,13 @@ struct Store {
 impl Store {
     fn new(root: PathBuf) -> Self {
         Self { root }
+    }
+
+    /// A disposable store rooted at a sub-path of this one. Used to give a
+    /// private `/~<uplink>/` route its own cache namespace so its packuments
+    /// and tarballs never collide with the public mirror or another uplink.
+    fn namespaced(&self, prefix: &str) -> Store {
+        Store::new(self.root.join(prefix))
     }
 
     async fn read_packument_entry(

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -480,6 +480,24 @@ impl Storage {
         }
     }
 
+    /// The cached uplink packument regardless of freshness (fresh or stale).
+    /// A defensive fallback for an unsolicited upstream `304`: the uplink path
+    /// sends no conditional validators, so a `304` means "unchanged" and the
+    /// cached body — even past `ttl` — is the right thing to serve rather than
+    /// a spurious `404`.
+    pub async fn read_uplink_packument_any(
+        &self,
+        namespace: &str,
+        name: &PackageName,
+    ) -> Result<Option<Vec<u8>>> {
+        // `Duration::MAX` classifies any existing entry as fresh, so its body
+        // is returned regardless of age (the stale arm can't be reached here).
+        match self.cached.namespaced(namespace).read_packument_entry(name, Duration::MAX).await? {
+            Some(CachedPackument::Fresh(bytes)) => Ok(Some(bytes)),
+            Some(CachedPackument::Stale(_)) | None => Ok(None),
+        }
+    }
+
     pub async fn write_uplink_packument(
         &self,
         namespace: &str,

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -533,7 +533,6 @@ fn breaking_upstream(url: String, max_fails: u32) -> Upstream {
             fail_timeout: Duration::from_mins(5),
             cache: true,
             access: None,
-            generation: 1,
         },
     )
 }

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -532,6 +532,8 @@ fn breaking_upstream(url: String, max_fails: u32) -> Upstream {
             max_fails,
             fail_timeout: Duration::from_mins(5),
             cache: true,
+            access: None,
+            generation: 1,
         },
     )
 }

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -4,7 +4,10 @@ use axum::{
 };
 use flate2::read::GzDecoder;
 use futures_util::stream;
-use pnpr::{AccessSpec, AuthState, Config, PackageAccess, router, router_with_auth};
+use pnpr::{
+    AccessList, AccessSpec, AuthState, Config, PackageAccess, UpstreamAlias, router,
+    router_with_auth,
+};
 use serde_json::{Value, json};
 use ssri::{Algorithm, IntegrityOpts};
 use std::{
@@ -656,6 +659,51 @@ async fn tarball_is_proxied_and_cached() {
 
     packument_mock.assert_async().await;
     mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn alias_gateway_tarball_uses_pnpr_managed_authorization() {
+    let mut upstream = mockito::Server::new_async().await;
+    let bytes = b"alias-gateway-tarball";
+    let tarball_mock = upstream
+        .mock("GET", "/@acme/foo/-/foo-1.0.0.tgz")
+        .match_header("authorization", "Bearer alias-secret")
+        .with_status(200)
+        .with_header("content-type", "application/octet-stream")
+        .with_body(bytes)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
+    config.upstream_aliases.insert(
+        "corp".to_string(),
+        UpstreamAlias {
+            registry: upstream.url(),
+            package: None,
+            authorization: "Bearer alias-secret".to_string(),
+            access: AccessList::parse("alice"),
+            generation: 7,
+        },
+    );
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(config, auth);
+
+    let response = app
+        .oneshot(
+            Request::get("/-/pnpr/v0/tarballs/alias/corp/7/%40acme%2Ffoo/-/foo-1.0.0.tgz")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_bytes(response.into_body()).await, bytes);
+    tarball_mock.assert_async().await;
 }
 
 /// Builds a packument whose single `1.0.0` version points its tarball at

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -4,7 +4,9 @@ use axum::{
 };
 use flate2::read::GzDecoder;
 use futures_util::stream;
-use pnpr::{AccessList, AccessSpec, AuthState, Config, PackageAccess, router, router_with_auth};
+use pnpr::{
+    AccessList, AccessSpec, AuthState, Config, PackageAccess, PublicRoute, router, router_with_auth,
+};
 use serde_json::{Value, json};
 use ssri::{Algorithm, IntegrityOpts};
 use std::{
@@ -284,7 +286,15 @@ async fn authenticated_resolve_preserves_git_dependencies() {
     let tmp = TempDir::new().unwrap();
     let auth = AuthState::in_memory();
     let token = auth.tokens.issue("alice").await.unwrap();
-    let app = router_with_auth(config_for("http://127.0.0.1:1", tmp.path().to_path_buf()), auth);
+    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
+    // A git dependency's host must be on the fetch allowlist for the resolver
+    // to reach it; an off-allowlist URL dependency is rejected at the request
+    // boundary before any fetch.
+    config
+        .route_policy
+        .public
+        .push(PublicRoute { registry: Some(repo_url.clone()), package: None });
+    let app = router_with_auth(config, auth);
     let response = app
         .oneshot(git_resolve_request(&repo_url, Some(&format!("Bearer {token}"))))
         .await

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -847,6 +847,60 @@ async fn uplink_cache_does_not_leak_to_the_public_path() {
     assert_eq!(body_bytes(public.into_body()).await, public_bytes);
 }
 
+#[tokio::test]
+async fn uplink_endpoint_cache_false_streams_without_caching() {
+    let mut upstream = mockito::Server::new_async().await;
+    let bytes = b"uncached-private-uplink-tarball";
+    let packument = json!({
+        "name": "foo",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": { "1.0.0": { "name": "foo", "version": "1.0.0", "dist": {
+            "tarball": format!("{}/foo/-/foo-1.0.0.tgz", upstream.url()),
+            "integrity": sha512_integrity(bytes),
+        } } },
+    });
+    // A `cache: false` uplink endpoint persists nothing, so each request
+    // re-fetches the packument and tarball — the mocks are hit twice.
+    let packument_mock = upstream
+        .mock("GET", "/foo")
+        .with_body(packument.to_string())
+        .expect(2)
+        .create_async()
+        .await;
+    let tarball_mock = upstream
+        .mock("GET", "/foo/-/foo-1.0.0.tgz")
+        .with_header("content-type", "application/octet-stream")
+        .with_body(bytes)
+        .expect(2)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let mut config = uplink_endpoint_config(&upstream.url(), tmp.path().to_path_buf(), "alice");
+    config.uplinks.get_mut("npmjs").expect("default `npmjs` uplink").cache = false;
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(config, auth);
+
+    for _ in 0..2 {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get("/~npmjs/foo/-/foo-1.0.0.tgz")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body_bytes(response.into_body()).await, bytes);
+    }
+
+    packument_mock.assert_async().await;
+    tarball_mock.assert_async().await;
+}
+
 /// Builds a packument whose single `1.0.0` version points its tarball at
 /// `upstream_url`. Used by the multi-uplink tests, which need to control the
 /// upstream the packument is served from independently of the helper that

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -726,7 +726,7 @@ async fn uplink_endpoint_rejects_unauthorized_caller() {
 }
 
 #[tokio::test]
-async fn uplink_endpoint_tarball_is_verified_and_never_persisted_to_shared_cache() {
+async fn uplink_endpoint_tarball_is_verified_and_cached_per_uplink() {
     let mut upstream = mockito::Server::new_async().await;
     let bytes = b"private-uplink-tarball";
     let packument = json!({
@@ -737,15 +737,14 @@ async fn uplink_endpoint_tarball_is_verified_and_never_persisted_to_shared_cache
             "integrity": sha512_integrity(bytes),
         } } },
     });
-    // Two requests, each re-fetching packument + tarball: a `/~<uplink>/` serve
-    // is fetch-through and writes nothing to the shared proxy mirror, so a
-    // private uplink's bytes never persist where the public path or another
-    // uplink could read them. The `expect(2)` proves the absence of caching.
+    // The packument and verified tarball are cached in the uplink's private
+    // namespace, so two tarball requests hit the upstream exactly once each —
+    // the second is served from the private cache, never re-fetched.
     let packument_mock = upstream
         .mock("GET", "/foo")
         .with_status(200)
         .with_body(packument.to_string())
-        .expect(2)
+        .expect(1)
         .create_async()
         .await;
     let tarball_mock = upstream
@@ -753,7 +752,7 @@ async fn uplink_endpoint_tarball_is_verified_and_never_persisted_to_shared_cache
         .with_status(200)
         .with_header("content-type", "application/octet-stream")
         .with_body(bytes)
-        .expect(2)
+        .expect(1)
         .create_async()
         .await;
 
@@ -780,6 +779,72 @@ async fn uplink_endpoint_tarball_is_verified_and_never_persisted_to_shared_cache
 
     packument_mock.assert_async().await;
     tarball_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn uplink_cache_does_not_leak_to_the_public_path() {
+    // The public `**` route proxies through the default `npmjs` uplink to the
+    // public upstream; a separate access-bearing `corp` uplink serves a
+    // *different* upstream at `/~corp/`. After the private `/~corp/foo` tarball
+    // is cached, the public `/foo` request must still serve the public bytes —
+    // proving the private uplink's cache is namespaced, not shared.
+    let mut public_upstream = mockito::Server::new_async().await;
+    let mut private_upstream = mockito::Server::new_async().await;
+    let public_bytes = b"public-foo-tarball";
+    let private_bytes = b"private-corp-foo-tarball";
+
+    for (server, body) in
+        [(&mut public_upstream, &public_bytes[..]), (&mut private_upstream, &private_bytes[..])]
+    {
+        let packument = json!({
+            "name": "foo",
+            "dist-tags": { "latest": "1.0.0" },
+            "versions": { "1.0.0": { "name": "foo", "version": "1.0.0", "dist": {
+                "tarball": format!("{}/foo/-/foo-1.0.0.tgz", server.url()),
+                "integrity": sha512_integrity(body),
+            } } },
+        });
+        server.mock("GET", "/foo").with_body(packument.to_string()).create_async().await;
+        server
+            .mock("GET", "/foo/-/foo-1.0.0.tgz")
+            .with_header("content-type", "application/octet-stream")
+            .with_body(body)
+            .create_async()
+            .await;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for(&public_upstream.url(), tmp.path().to_path_buf());
+    let mut corp = config.uplinks.get("npmjs").expect("default `npmjs` uplink").clone();
+    corp.url = private_upstream.url();
+    corp.access = Some(AccessList::parse("alice"));
+    config.uplinks.insert("corp".to_string(), corp);
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(config, auth);
+
+    // Prime the private cache via the `/~corp/` endpoint.
+    let private = app
+        .clone()
+        .oneshot(
+            Request::get("/~corp/foo/-/foo-1.0.0.tgz")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(private.status(), StatusCode::OK);
+    assert_eq!(body_bytes(private.into_body()).await, private_bytes);
+
+    // The public path must serve the public upstream's bytes, never the
+    // private uplink's cached copy.
+    let public = app
+        .oneshot(Request::get("/foo/-/foo-1.0.0.tgz").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(public.status(), StatusCode::OK);
+    assert_eq!(body_bytes(public.into_body()).await, public_bytes);
 }
 
 /// Builds a packument whose single `1.0.0` version points its tarball at

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -62,7 +62,9 @@ fn git_resolve_request(repo_url: &str, authorization: Option<&str>) -> Request<B
         "dependencies": {
             "git-dependency": format!("git+{repo_url}#main"),
         },
-        "registry": "http://127.0.0.1:1/",
+        // The built-in npmjs route is allowlisted; this resolve only touches a
+        // git dependency, so the registry is validated but never fetched.
+        "registry": "https://registry.npmjs.org/",
         "trustLockfile": true,
         "preferFrozenLockfile": false,
     });

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -4,10 +4,7 @@ use axum::{
 };
 use flate2::read::GzDecoder;
 use futures_util::stream;
-use pnpr::{
-    AccessList, AccessSpec, AuthState, Config, PackageAccess, UpstreamAlias, router,
-    router_with_auth,
-};
+use pnpr::{AccessList, AccessSpec, AuthState, Config, PackageAccess, router, router_with_auth};
 use serde_json::{Value, json};
 use ssri::{Algorithm, IntegrityOpts};
 use std::{
@@ -782,51 +779,6 @@ async fn uplink_endpoint_tarball_is_verified_and_never_persisted_to_shared_cache
     }
 
     packument_mock.assert_async().await;
-    tarball_mock.assert_async().await;
-}
-
-#[tokio::test]
-async fn alias_gateway_tarball_uses_pnpr_managed_authorization() {
-    let mut upstream = mockito::Server::new_async().await;
-    let bytes = b"alias-gateway-tarball";
-    let tarball_mock = upstream
-        .mock("GET", "/@acme/foo/-/foo-1.0.0.tgz")
-        .match_header("authorization", "Bearer alias-secret")
-        .with_status(200)
-        .with_header("content-type", "application/octet-stream")
-        .with_body(bytes)
-        .expect(1)
-        .create_async()
-        .await;
-
-    let tmp = TempDir::new().unwrap();
-    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    config.upstream_aliases.insert(
-        "corp".to_string(),
-        UpstreamAlias {
-            registry: upstream.url(),
-            package: None,
-            authorization: "Bearer alias-secret".to_string(),
-            access: AccessList::parse("alice"),
-            generation: 7,
-        },
-    );
-    let auth = AuthState::in_memory();
-    let token = auth.tokens.issue("alice").await.unwrap();
-    let app = router_with_auth(config, auth);
-
-    let response = app
-        .oneshot(
-            Request::get("/-/pnpr/v0/tarballs/alias/corp/7/%40acme%2Ffoo/-/foo-1.0.0.tgz")
-                .header(header::AUTHORIZATION, format!("Bearer {token}"))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(body_bytes(response.into_body()).await, bytes);
     tarball_mock.assert_async().await;
 }
 

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -703,6 +703,9 @@ async fn uplink_endpoint_serves_packument_with_endpoint_rewritten_tarballs() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
+    // Private content must not be cached or replayed by an intermediary.
+    assert_eq!(response.headers().get(header::CACHE_CONTROL).unwrap(), "private, no-store");
+    assert_eq!(response.headers().get(header::VARY).unwrap(), "Authorization");
     let body: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
     // `dist.tarball` is rewritten back onto the same `/~npmjs/` endpoint, so the
     // URL is canonical for the client's configured registry (integrity-only).

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -661,6 +661,130 @@ async fn tarball_is_proxied_and_cached() {
     mock.assert_async().await;
 }
 
+/// A proxy config whose default `npmjs` uplink is promoted to an
+/// access-bearing private-route uplink, reachable at `/~npmjs/`.
+fn uplink_endpoint_config(upstream_url: &str, storage: PathBuf, access: &str) -> Config {
+    let mut config = config_for(upstream_url, storage);
+    config.public_url = "http://example.test".to_string();
+    config.uplinks.get_mut("npmjs").expect("default `npmjs` uplink").access =
+        Some(AccessList::parse(access));
+    config
+}
+
+#[tokio::test]
+async fn uplink_endpoint_serves_packument_with_endpoint_rewritten_tarballs() {
+    let mut upstream = mockito::Server::new_async().await;
+    let packument = json!({
+        "name": "foo",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": { "1.0.0": { "name": "foo", "version": "1.0.0", "dist": {
+            "tarball": format!("{}/foo/-/foo-1.0.0.tgz", upstream.url()),
+            "integrity": "sha512-deadbeef",
+        } } },
+    });
+    let mock = upstream
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_body(packument.to_string())
+        .expect(1)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let config = uplink_endpoint_config(&upstream.url(), tmp.path().to_path_buf(), "alice");
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(config, auth);
+
+    let response = app
+        .oneshot(
+            Request::get("/~npmjs/foo")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    // `dist.tarball` is rewritten back onto the same `/~npmjs/` endpoint, so the
+    // URL is canonical for the client's configured registry (integrity-only).
+    assert_eq!(
+        body["versions"]["1.0.0"]["dist"]["tarball"],
+        "http://example.test/~npmjs/foo/-/foo-1.0.0.tgz",
+    );
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn uplink_endpoint_rejects_unauthorized_caller() {
+    let tmp = TempDir::new().unwrap();
+    let config = uplink_endpoint_config("http://127.0.0.1:1", tmp.path().to_path_buf(), "alice");
+    let app = router(config);
+    // Anonymous caller is not admitted by the uplink's access policy, and the
+    // request fails closed before any upstream fetch.
+    let response =
+        app.oneshot(Request::get("/~npmjs/foo").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn uplink_endpoint_tarball_is_verified_and_never_persisted_to_shared_cache() {
+    let mut upstream = mockito::Server::new_async().await;
+    let bytes = b"private-uplink-tarball";
+    let packument = json!({
+        "name": "foo",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": { "1.0.0": { "name": "foo", "version": "1.0.0", "dist": {
+            "tarball": format!("{}/foo/-/foo-1.0.0.tgz", upstream.url()),
+            "integrity": sha512_integrity(bytes),
+        } } },
+    });
+    // Two requests, each re-fetching packument + tarball: a `/~<uplink>/` serve
+    // is fetch-through and writes nothing to the shared proxy mirror, so a
+    // private uplink's bytes never persist where the public path or another
+    // uplink could read them. The `expect(2)` proves the absence of caching.
+    let packument_mock = upstream
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_body(packument.to_string())
+        .expect(2)
+        .create_async()
+        .await;
+    let tarball_mock = upstream
+        .mock("GET", "/foo/-/foo-1.0.0.tgz")
+        .with_status(200)
+        .with_header("content-type", "application/octet-stream")
+        .with_body(bytes)
+        .expect(2)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let config = uplink_endpoint_config(&upstream.url(), tmp.path().to_path_buf(), "alice");
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(config, auth);
+
+    for _ in 0..2 {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get("/~npmjs/foo/-/foo-1.0.0.tgz")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body_bytes(response.into_body()).await, bytes);
+    }
+
+    packument_mock.assert_async().await;
+    tarball_mock.assert_async().await;
+}
+
 #[tokio::test]
 async fn alias_gateway_tarball_uses_pnpr_managed_authorization() {
     let mut upstream = mockito::Server::new_async().await;


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#12699 and pnpm/rfcs#11.

This branch makes the pnpr resolver cache authorization-aware and routes private dependencies through **per-uplink registry endpoints** rather than opaque tarball gateways. It implements the route-classification foundation, a **default-deny fetch allowlist** that closes the resolver's SSRF surface, the auth-aware resolution cache (footprint + descriptor-keyed candidates), the descriptor-scoped private metadata mirror, the `/~<uplink>/` endpoint serving with a per-uplink cache, and integrity-only lockfile routing. The optional refinements in issue section 9 (lightweight revocation validation, operator metrics) remain follow-up work.

### Route-classification foundation

- `pacquet-network` exposes an `UpstreamRouteHook` seam so pnpr owns upstream auth selection at the single fetch/auth-selection point, while the CLI path stays unchanged (it installs no hook).
- pnpr classifies each fetch route — public / pnpr-hosted / proxied-uplink — for the caller `Identity`, records a per-resolve **footprint**, rejects inline `user:pass@` URL credentials before fetch, and never forwards the client's own upstream credentials.
- Rust and TypeScript pnpr clients stop sending forwarded upstream credentials in the resolve payload; the server stays tolerant of the field for older clients.

### Fetch allowlist (default-deny) — closes SSRF, supersedes pnpm/pnpm#12675

- Every registry pnpr will fetch from server-side is an **allowlist** derived from config: the built-in npm host, operator-declared public routes, configured uplinks (and their `/~<uplink>/` endpoints), and pnpr's own origin. A client `registry`/`namedRegistries` whose origin matches none of these is **rejected at the request boundary, before any fetch**, by both `/resolve` and `/verify-lockfile`.
- The boundary also covers **direct-URL dependencies**, which fetch outside the registry path: any `http(s)` tarball spec or `git`/`git+…` URL in a dependency, an `overrides` leaf, or an input-lockfile `resolution.tarball` is rejected unless its origin is allowlisted (a `git+` prefix is stripped before the check). Semver ranges and `npm:`/`workspace:`/`file:` aliases never hit the network and are ignored. A direct URL dependency therefore requires the operator to allowlist its origin, the same as any registry.
- Being default-deny rather than denylisting dangerous hosts closes the SSRF surface at the source — a caller can no longer point pnpr at cloud instance metadata or an internal service through a registry **or** a direct URL dependency — which is strictly stronger than the link-local/metadata-host denylist in pnpm/pnpm#12675 and supersedes it (that approach remains useful only as defense-in-depth).
- Operator-declared public routes **fail closed** on a typo: a present-but-unparsable `registry` URL or `package` glob drops the whole rule rather than collapsing to a match-all, so a misconfiguration can only narrow matching, never widen a scoped public route into one that classifies a private registry as public.
- The official npm registry is a **built-in, host-level public route**: a package resolved from `registry.npmjs.org` — scoped or unscoped — is allowlisted and public with no configuration (a private scoped package 404s on the anonymous fetch and is never resolved this way), ahead of any uplink credential for the same origin (public wins). There is no `npmjsPublic`/`npmjsUnscopedPublic` toggle; npmjs flows through the same public-route machinery as operator-declared routes.
- An off-allowlist path can't be smuggled through a `..` segment: a `.`/`..` in the nerf-darted key is rejected, so `//host/base/../admin` can't pass a `//host/base/` path-scoped allow.
- The same allowlist re-validates **redirect hops**: pnpr's resolution HTTP client installs a redirect policy that checks each redirect target against the allowlist (an off-allowlist redirect fails before the fetch, with the target URL redacted to scheme+host so a presigned-URL token can't leak through the error). A residual — DNS-rebinding and **transitive** dependencies fetched during the tree walk (outside the request boundary) — is the connect-time-guard hardening tracked in pnpm/pnpm#12705.
- With off-allowlist registries rejected up front, there is no "unknown route" to resolve anonymously and no non-shareable cache state: every resolved route is either **public** (fetched anonymously, globally shareable) or carries a **private access descriptor**. This removed `RouteClass::Unknown`, the non-shareable footprint tier, and the `MetadataCacheScope::Bypass` metadata-cache tier.

### Uplinks are the private-route credential (folds in `upstreamAliases`)

- A `uplinks:` entry that declares an `access:` policy becomes a pnpr-managed private-route credential. The separate `upstreamAliases` block (and `UpstreamAlias` type) is removed — proxied routes now source their credential from access-bearing uplinks, **matched by registry origin** (no per-credential package glob; an uplink credential covers every package on its registry). One upstream token per uplink is fanned out to a whole team by pnpr authorization.
- Access reuses bearer-token-backed pnpr identities, the package-access `AccessList` model, and the top-level `groups:` team map.
- pnpr selects an authorized uplink at the auth-selection layer, sends only its server-owned credential upstream, and records `uplink + credential-digest` in the footprint — the digest is a SHA-256 of the uplink's `Authorization`, computed once at config load. Rotating the upstream credential changes the digest automatically, moving new private cache entries to a fresh namespace (old entries age out by TTL) with no manual epoch to bump.
- The credential is attached **only** over a matching scheme: an `http://` fetch never receives an `https://` uplink's token (nerf-darting strips the scheme), so a server-owned credential can't be sent in cleartext.

### Tarball routing via `/~<uplink>/` registry endpoints (issue section 7)

- Each access-bearing uplink is exposed as a **read-only registry endpoint** at `https://<pnpr>/~<uplink>/`: packument and tarball reads route through that uplink (gated by its access policy), with `dist.tarball` rewritten back onto the same endpoint. The `~` prefix keeps endpoints out of the package-name path namespace, since a package name cannot begin with `~`.
- The resolver emits a proxied route's tarball as its `/~<uplink>/` endpoint URL; public routes keep their upstream URL (fetched directly from the registry/CDN, never through pnpr); pnpr-hosted packages use pnpr-hosted URLs. A **registry-resolved** package is classified by its *registry* route, not its `dist.tarball` host — so a split-domain private registry (packument and tarball on different hosts) still routes through `/~<uplink>/` instead of leaking the raw upstream tarball URL in a streamed frame.
- An emitted public tarball URL is **sanitized**: inline `user:pass@` userinfo is stripped everywhere, and a registry package's upstream `dist.tarball` also has its query/fragment dropped, so a presigned/tokenized upstream URL (`?X-Amz-Signature=…`) never reaches a client or the shared cache.
- Because an endpoint URL is canonical for a client whose scope points at that endpoint, the lockfile entry collapses to **integrity-only** — the host lives in `.npmrc`, not the lockfile. A project then resolves to the same lockfile whether it goes through `/resolve` or a direct/proxied install, and public packages stay on the CDN purely because the default registry points there. This replaces the previous "rewrite every non-public tarball to a pnpr URL, with a special case for public" behavior.
- `verification_lockfile` reverses `/~<uplink>/` URLs back to upstream so an input lockfile verifies against the real registry, and route classification recognizes pnpr's own `/~<uplink>/` URLs so `/resolve` resolves a scope already pointed at its endpoint through the backing uplink.
- Removed: the opaque per-tarball gateway scheme (`/-/pnpr/v0/tarballs/alias|unknown/…` routes and handlers), its in-memory HMAC `key → URL` map, and the `GatewayAlias` machinery.

### Per-uplink private cache

- Each access-bearing uplink gets a private cache namespace (`~uplinks/<digest>` under the proxy cache root, where `<digest>` is an HMAC of `(uplink, credential)` keyed with the server secret): packuments are served within the freshness window and tarballs are verified once and served from cache thereafter, so a private install caches like a public one rather than re-fetching the packument on every tarball request.
- The namespace keeps a private uplink's content out of the shared mirror, so it can never be served on the public path or under another uplink (covered by a behavioral no-leak test). HMAC'ing the namespace means the on-disk path leaks neither the uplink name nor its credential, and a path-unsafe uplink name can't escape the cache root. Because it's keyed by a digest of the credential, a rotation moves to a fresh namespace.

### Resolution cache: footprint + descriptor-keyed candidates

- The resolver computes a base cache key for both no-lockfile and lockfile-seeded requests; input lockfiles are represented by the stable `hash_lockfile()` digest rather than embedding serialized lockfile data.
- Cached resolutions carry their recorded `Footprint`, last-used time, and descriptor HMAC. Public candidates match every caller; private candidates match only when the caller still satisfies every stored uplink-or-hosted-policy descriptor gate.
- Every resolution is cacheable: with the allowlist in place a footprint is either empty (public, globally shareable) or carries private descriptors that key it.
- Candidate lists are bounded per base key; expired entries are pruned and LRU private candidates are evicted before public ones, so credential rotation or unusual workspaces cannot grow lookup cost without bound. A private candidate is reused only for the alias the caller would actually *select* for the origin (the first authorized one) at the current credential, so overlapping uplink access can't replay a lockfile routed through a different uplink.
- Cached resolutions store already-routed lockfiles, so a private cache hit replays the `/~<uplink>/` endpoint (integrity-only) URLs, never raw private upstream URLs.

### Footprint completeness on metadata fast paths (issue section 4)

- The route hook records each fetch's route at the auth-selection point (`AuthHeaders::for_url_with_package`), which the npm resolver's metadata fast paths bypassed: an in-memory cache hit, an offline/preferOffline disk read, a version-spec exact match, and the publishedBy mtime shortcut each answer a pick straight from cache without selecting auth.
- The on-disk metadata mirror is shared across pnpr requests, so a lockfile-seeded private resolve could be served pinned-version metadata from the shared mirror with no route recorded — leaving the footprint incomplete and the resolution wrongly cached as public, which would let one caller's private resolution be served to another.
- `AuthHeaders::record_route` drives the route hook (classify + record) without issuing a request; `pick_package` calls it up front so every layer — cache hits, all disk fast paths, and the network fetch — contributes to the footprint regardless of which one serves the metadata. It is a no-op when no hook is installed (the CLI) and idempotent on the hook.

### Private metadata cache / lower mirror (issue section 8)

- `MetadataCacheScope` in `pacquet-network` (`Public` / `Private { descriptor_id }`), with read-only `UpstreamRouteHook::metadata_scope` and `AuthHeaders::metadata_scope`. The CLI installs no hook, so every fetch is `Public` and the global mirror is unchanged.
- `mirror::scoped_meta_dir` relocates a private route to `v11/metadata-private/<descriptor-id>/<suffix>`, applied per `(registry, package)` fetch rather than by swapping the whole `cache_dir`.
- Scope is threaded through `pick_package` (mirror path, in-memory cache key, fetch-lock key), `fetch_full_metadata_cached` (conditional headers, 304 reads, write-back), and the verifier's `read_local_meta_time`, closing the private-metadata oracle.
- Fail-closed on denial: `FetchMetadataError::is_access_denied` (401/403/404). A private route never falls back to a cached mirror on a denial; only transport failures fall back, and only within the same namespace. Public routes keep their existing fallback.

## Squash Commit Body

```text
Make the pnpr resolver cache authorization-aware and route private
dependencies through per-uplink registry endpoints.

Add route classification at the single fetch/auth-selection point: pnpr
selects its own server-owned upstream credentials instead of forwarding
client upstream auth, records a per-resolve footprint, and rejects inline
URL credentials. A uplinks: entry that declares an access: policy becomes
the private-route credential (folding in the former upstreamAliases block),
matched by registry origin and exposed as a read-only registry endpoint at
/~<uplink>/. access reuses bearer-token-backed pnpr identities, package
access policy, and static groups; a SHA-256 digest of the uplink's credential
participates in the footprint, so rotating the upstream credential
automatically moves new resolves to a fresh namespace. The credential is
attached only over a matching scheme (no token over plain http).

Gate every server-side fetch behind a default-deny allowlist (built-in npm
host, public routes, configured uplinks and their /~<uplink>/ endpoints, and
pnpr itself). A registry/namedRegistries matching none is rejected at the
request boundary, closing the resolver's SSRF surface at the source and
superseding the link-local denylist. The boundary also covers direct-URL
(http(s)/git, incl. scp-style) dependency specs, overrides, and lockfile
tarballs; a `..` path segment is rejected; and the same allowlist re-validates
every redirect hop. The official npm registry is a built-in host-level public
route (scoped names included), so the npmjsPublic toggle is gone. With no
off-allowlist route to resolve, every route is public or carries a private
descriptor: RouteClass::Unknown, the non-shareable footprint tier, and the
MetadataCacheScope::Bypass tier are removed. Transitive deps fetched during the
tree walk are a connect-time-guard follow-up (pnpm/pnpm#12705).

Route resolver tarball URLs through those endpoints. A proxied route emits
its /~<uplink>/ endpoint URL; public routes keep their upstream URL (fetched
directly from the registry/CDN); pnpr-hosted packages use pnpr-hosted URLs.
An endpoint URL is canonical for a client whose scope
points there, so the lockfile entry stays integrity-only and the host comes
from the client's registry config rather than the lockfile — a project
resolves to the same lockfile through /resolve or a direct/proxied install.
verification_lockfile reverses endpoint URLs to upstream for input-lockfile
verification, and classification recognizes pnpr's own /~<uplink>/ URLs.
The opaque per-tarball gateway scheme and its in-memory key->URL map are
removed.

Serve each access-bearing uplink as a /~<uplink>/ registry endpoint
(packument + tarball, gated by the uplink access policy) with a private
cache namespaced by an HMAC of (uplink, credential), so a private install
caches like a public one, a rotation re-keys automatically, and a private
uplink's content never lands in the shared mirror.

Store bounded candidate lists under an auth-excluded base key instead of a
single lockfile. Public candidates match every caller; private candidates
carry the footprint and descriptor HMAC and are reused only when the caller
still satisfies the stored uplink-or-hosted gates. Compute the base key for
both no-lockfile and lockfile-seeded requests, using hash_lockfile() for
input lockfiles, and evict expired/LRU private candidates before public
ones.

Record metadata fast-path routes into the footprint. The hook only fires at
the auth-selection point, which the npm resolver's metadata fast paths
(in-memory hit, offline disk read, version-spec exact match, publishedBy
mtime shortcut) bypass. AuthHeaders::record_route drives the hook without a
request, called up front in pick_package so every layer contributes to the
footprint.

Scope the npm metadata mirror by private access descriptor. A
MetadataCacheScope (Public / Private) classified per (registry, package)
fetch threads through pick_package, fetch_full_metadata_cached, the mirror
path, in-memory/fetch-lock keys, and the verifier's local-mirror read. A
private route stores its packument under v11/metadata-private/<descriptor-id>/.
Fail closed on 401/403/private-404. The CLI installs no hook, so every fetch
stays Public and the global mirror is unchanged.

Related to pnpm/pnpm#12699 and pnpm/rfcs#11.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting. <!-- The cache/uplink/route work is pnpr server-side (Rust only). Earlier commits updated both Rust and TypeScript pnpr clients to stop forwarding upstream credentials. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. <!-- Existing changeset `.changeset/pnpr-no-forwarded-upstream-credentials.md` covers the published client behavior change. -->
- [x] Added or updated tests. <!-- Route classification, uplink endpoint serving, per-uplink caching, the no-leak isolation check, integrity-only/endpoint URL routing, the resolution cache, and the pnpr-client end-to-end tests are all migrated to the uplink-endpoint design. -->
- [x] Updated the documentation if needed. <!-- The bundled pnpr config sample documents access-bearing uplinks exposed at /~<name>/; resolver/pnpr-client doc comments describe the /~<uplink>/ endpoints. Broader docs for later issue sections remain follow-up work. -->

---
Written by agents (Codex, GPT-5; Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pnpr-managed private route resolving and lockfile verification using authenticated uplinks, including routed tarball URL rewriting.
  * Introduced route-aware caching and scoped mirror storage (public vs private vs bypass) driven by operator policies.
  * Added support for static group-based access affecting which private routes a request can resolve.
* **Bug Fixes**
  * Stopped forwarding upstream registry credentials from clients; pnpr now selects upstream access server-side.
  * Improved fail-closed behavior on unauthorized/access-denied conditions and tightened cache isolation to avoid stale/private leakage.
* **Tests**
  * Expanded coverage for uplinks, route classification, cache scoping, and credential-forwarding removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->