### PR TITLE
feat(cli): port the `bin` command to pacquet

### DIFF
--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -1,6 +1,7 @@
 pub mod add;
 pub mod approve_builds;
 pub mod audit;
+pub mod bin;
 pub mod cache;
 pub mod cat_file;
 pub mod cat_index;

--- a/pacquet/crates/cli/src/cli_args/bin.rs
+++ b/pacquet/crates/cli/src/cli_args/bin.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use pacquet_config::Config;
+use pacquet_config::{Config, check_global_bin_dir};
 use std::path::Path;
 
 use super::global::GlobalError;
@@ -29,21 +29,32 @@ pub struct BinArgs {
 }
 
 impl BinArgs {
-    /// `--global` prints `config.global_bin` (`global-bin-dir ?? <pnpm-home>/bin`),
-    /// erroring with `ERR_PNPM_NO_GLOBAL_BIN_DIR` when no pnpm home resolves.
-    ///
-    /// Divergence from pnpm worth flagging: pnpm's config reader runs
-    /// `checkGlobalBinDir` (the `PATH`-membership check, plus writability for
-    /// every command except `root`) and creates the directory for *every*
-    /// `--global` invocation — `bin` included — before the handler prints
-    /// (config/reader/src/index.ts). pacquet runs `check_global_bin_dir` only in
-    /// its mutating global handlers (`add` / `remove` / `update -g`), so this
-    /// read-only command neither validates `PATH` nor creates the directory,
-    /// matching the sibling `outdated --global`. Porting that validation to the
-    /// config layer for all read-only `-g` commands is left as a follow-up.
+    /// `--global` resolves the global executables directory
+    /// (`global-bin-dir ?? <pnpm-home>/bin`), creates it, and validates it with
+    /// `check_global_bin_dir` — the `PATH`-membership check plus writability
+    /// (pnpm enforces the write check for every command except `root`) — before
+    /// printing, mirroring pnpm's config reader, which runs the same `mkdir` +
+    /// `checkGlobalBinDir` for every `--global` invocation. It errors with
+    /// `ERR_PNPM_NO_GLOBAL_BIN_DIR` when no pnpm home resolves, and with the
+    /// `checkGlobalBinDir` diagnostics (`ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH`,
+    /// `ERR_PNPM_NO_PATH_ENV`, `ERR_PNPM_PNPM_DIR_NOT_WRITABLE`) when the
+    /// directory is unusable.
     pub fn run(self, dir: &Path, config: &Config) -> miette::Result<()> {
         let bin = if self.global {
-            config.global_bin.clone().ok_or(GlobalError::NoGlobalBinDir)?
+            let bin = config.global_bin.clone().ok_or(GlobalError::NoGlobalBinDir)?;
+            // pnpm's config reader `mkdir`s the global bin dir and runs
+            // `checkGlobalBinDir` for every `--global` command before the handler
+            // prints; `globalDirShouldAllowWrite` is true for all but `root`, so
+            // `bin` validates writability too.
+            std::fs::create_dir_all(&bin).map_err(|error| {
+                miette::miette!(
+                    "failed to create the global bin directory {}: {error}",
+                    bin.display(),
+                )
+            })?;
+            check_global_bin_dir(&bin, std::env::var("PATH").ok().as_deref(), true)
+                .map_err(miette::Report::new)?;
+            bin
         } else {
             dir.join("node_modules").join(".bin")
         };

--- a/pacquet/crates/cli/src/cli_args/bin.rs
+++ b/pacquet/crates/cli/src/cli_args/bin.rs
@@ -47,10 +47,8 @@ impl BinArgs {
             // prints; `globalDirShouldAllowWrite` is true for all but `root`, so
             // `bin` validates writability too.
             std::fs::create_dir_all(&bin).map_err(|error| {
-                miette::miette!(
-                    "failed to create the global bin directory {}: {error}",
-                    bin.display(),
-                )
+                let bin_dir = bin.display();
+                miette::miette!("failed to create the global bin directory {bin_dir}: {error}")
             })?;
             check_global_bin_dir(&bin, std::env::var("PATH").ok().as_deref(), true)
                 .map_err(miette::Report::new)?;

--- a/pacquet/crates/cli/src/cli_args/bin.rs
+++ b/pacquet/crates/cli/src/cli_args/bin.rs
@@ -6,21 +6,13 @@ use super::global::GlobalError;
 
 /// `pacquet bin`: print the directory where pnpm installs executables.
 ///
-/// Ports pnpm's `bin` handler, which prints `config.bin`
-/// (<https://github.com/pnpm/pnpm/blob/fc2f33912e/pnpm11/pnpm/src/cmd/bin.ts>).
-/// pnpm resolves that path in its config reader
-/// (<https://github.com/pnpm/pnpm/blob/3425e8011c/pnpm11/config/reader/src/index.ts>):
-/// the local value is `path.join(config.dir, 'node_modules', '.bin')` — the
-/// leaf is the hardcoded `node_modules/.bin`, a configured `modules-dir` is
-/// ignored, and the anchor is `config.dir` (the cwd, not the workspace root) —
-/// while `--global` selects `global-bin-dir ?? <pnpm-home>/bin`, which pacquet
-/// has already resolved into `config.global_bin`.
-///
-/// So this prints `<dir>/node_modules/.bin` from the already-canonicalized
-/// `--dir` (deliberately NOT reading `config.modules_dir`, which pacquet
-/// re-anchors to the workspace root inside a workspace — the same reasoning the
-/// sibling `root` command documents), or the resolved global bin directory
-/// under `--global`.
+/// Locally this is `<dir>/node_modules/.bin`: the `node_modules/.bin` leaf is
+/// hardcoded, so a configured `modules-dir` is ignored, and the anchor is
+/// `--dir` (pnpm's `config.dir`, the cwd, not the workspace root). `--global`
+/// prints the resolved global bin directory instead. Ports pnpm's `bin`
+/// (<https://github.com/pnpm/pnpm/blob/fc2f33912e/pnpm11/pnpm/src/cmd/bin.ts>)
+/// and its config-reader bin resolution
+/// (<https://github.com/pnpm/pnpm/blob/3425e8011c/pnpm11/config/reader/src/index.ts>).
 #[derive(Debug, Args)]
 pub struct BinArgs {
     /// Print the global executables directory
@@ -29,23 +21,12 @@ pub struct BinArgs {
 }
 
 impl BinArgs {
-    /// `--global` resolves the global executables directory
-    /// (`global-bin-dir ?? <pnpm-home>/bin`), creates it, and validates it with
-    /// `check_global_bin_dir` — the `PATH`-membership check plus writability
-    /// (pnpm enforces the write check for every command except `root`) — before
-    /// printing, mirroring pnpm's config reader, which runs the same `mkdir` +
-    /// `checkGlobalBinDir` for every `--global` invocation. It errors with
-    /// `ERR_PNPM_NO_GLOBAL_BIN_DIR` when no pnpm home resolves, and with the
-    /// `checkGlobalBinDir` diagnostics (`ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH`,
-    /// `ERR_PNPM_NO_PATH_ENV`, `ERR_PNPM_PNPM_DIR_NOT_WRITABLE`) when the
-    /// directory is unusable.
     pub fn run(self, dir: &Path, config: &Config) -> miette::Result<()> {
         let bin = if self.global {
             let bin = config.global_bin.clone().ok_or(GlobalError::NoGlobalBinDir)?;
-            // pnpm's config reader `mkdir`s the global bin dir and runs
-            // `checkGlobalBinDir` for every `--global` command before the handler
-            // prints; `globalDirShouldAllowWrite` is true for all but `root`, so
-            // `bin` validates writability too.
+            // Mirror pnpm's config reader: create then validate the global bin
+            // dir for every `--global` command. `should_allow_write` is true for
+            // all but `root`, so `bin` checks writability too.
             std::fs::create_dir_all(&bin).map_err(|error| {
                 let bin_dir = bin.display();
                 miette::miette!("failed to create the global bin directory {bin_dir}: {error}")

--- a/pacquet/crates/cli/src/cli_args/bin.rs
+++ b/pacquet/crates/cli/src/cli_args/bin.rs
@@ -1,0 +1,53 @@
+use clap::Args;
+use pacquet_config::Config;
+use std::path::Path;
+
+use super::global::GlobalError;
+
+/// `pacquet bin`: print the directory where pnpm installs executables.
+///
+/// Ports pnpm's `bin` handler, which prints `config.bin`
+/// (<https://github.com/pnpm/pnpm/blob/fc2f33912e/pnpm11/pnpm/src/cmd/bin.ts>).
+/// pnpm resolves that path in its config reader
+/// (<https://github.com/pnpm/pnpm/blob/3425e8011c/pnpm11/config/reader/src/index.ts>):
+/// the local value is `path.join(config.dir, 'node_modules', '.bin')` — the
+/// leaf is the hardcoded `node_modules/.bin`, a configured `modules-dir` is
+/// ignored, and the anchor is `config.dir` (the cwd, not the workspace root) —
+/// while `--global` selects `global-bin-dir ?? <pnpm-home>/bin`, which pacquet
+/// has already resolved into `config.global_bin`.
+///
+/// So this prints `<dir>/node_modules/.bin` from the already-canonicalized
+/// `--dir` (deliberately NOT reading `config.modules_dir`, which pacquet
+/// re-anchors to the workspace root inside a workspace — the same reasoning the
+/// sibling `root` command documents), or the resolved global bin directory
+/// under `--global`.
+#[derive(Debug, Args)]
+pub struct BinArgs {
+    /// Print the global executables directory
+    #[clap(short = 'g', long)]
+    pub global: bool,
+}
+
+impl BinArgs {
+    /// `--global` prints `config.global_bin` (`global-bin-dir ?? <pnpm-home>/bin`),
+    /// erroring with `ERR_PNPM_NO_GLOBAL_BIN_DIR` when no pnpm home resolves.
+    ///
+    /// Divergence from pnpm worth flagging: pnpm's config reader runs
+    /// `checkGlobalBinDir` (the `PATH`-membership check, plus writability for
+    /// every command except `root`) and creates the directory for *every*
+    /// `--global` invocation — `bin` included — before the handler prints
+    /// (config/reader/src/index.ts). pacquet runs `check_global_bin_dir` only in
+    /// its mutating global handlers (`add` / `remove` / `update -g`), so this
+    /// read-only command neither validates `PATH` nor creates the directory,
+    /// matching the sibling `outdated --global`. Porting that validation to the
+    /// config layer for all read-only `-g` commands is left as a follow-up.
+    pub fn run(self, dir: &Path, config: &Config) -> miette::Result<()> {
+        let bin = if self.global {
+            config.global_bin.clone().ok_or(GlobalError::NoGlobalBinDir)?
+        } else {
+            dir.join("node_modules").join(".bin")
+        };
+        println!("{}", bin.display());
+        Ok(())
+    }
+}

--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -2,6 +2,7 @@ use super::{
     add::AddArgs,
     approve_builds::ApproveBuildsArgs,
     audit::AuditArgs,
+    bin::BinArgs,
     cache::CacheCommand,
     cat_file::CatFileArgs,
     cat_index::CatIndexArgs,
@@ -184,6 +185,8 @@ pub enum CliCommand {
     /// Manage runtimes.
     #[clap(visible_alias = "rt")]
     Runtime(RuntimeArgs),
+    /// Print the directory where pnpm will install executables.
+    Bin(BinArgs),
     /// Print the effective `node_modules` directory.
     Root(RootArgs),
     /// Manage the pnpm configuration files.

--- a/pacquet/crates/cli/src/cli_args/dispatch.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch.rs
@@ -254,6 +254,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::Restart(args) => dispatch_script::restart(ctx, args),
         CliCommand::FindHash(args) => dispatch_query::find_hash(ctx, args),
         CliCommand::Runtime(args) => dispatch_install::runtime(ctx, args),
+        CliCommand::Bin(args) => dispatch_query::bin(ctx, args),
         CliCommand::Root(args) => dispatch_query::root(ctx, args),
         CliCommand::Config(args) => dispatch_query::config(ctx, args),
         CliCommand::PackApp(args) => dispatch_query::pack_app(ctx, args),

--- a/pacquet/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_query.rs
@@ -1,5 +1,6 @@
 use super::{
     audit::{AuditArgs, AuditOutcome},
+    bin::BinArgs,
     cache::CacheCommand,
     cat_file::CatFileArgs,
     cat_index::CatIndexArgs,
@@ -162,6 +163,11 @@ pub(super) fn pack<'a>(ctx: &RunCtx<'a>, args: &PackArgs) -> miette::Result<Comm
     if !output.is_empty() {
         println!("{output}");
     }
+    Ok(Box::pin(std::future::ready(Ok(()))))
+}
+
+pub(super) fn bin<'a>(ctx: &RunCtx<'a>, args: BinArgs) -> miette::Result<CommandFuture<'a>> {
+    args.run(ctx.dir, (ctx.config)()?)?;
     Ok(Box::pin(std::future::ready(Ok(()))))
 }
 

--- a/pacquet/crates/cli/tests/bin.rs
+++ b/pacquet/crates/cli/tests/bin.rs
@@ -53,15 +53,49 @@ fn bin_ignores_a_custom_modules_dir() {
     drop(root);
 }
 
-/// `pacquet bin -g` prints the resolved global executables directory
-/// (`global-bin-dir ?? <pnpm-home>/bin`). This is intentionally NOT a
-/// differential test against real pnpm: pnpm additionally validates the dir is
-/// on `PATH` (erroring otherwise) and creates it, which pacquet's read-only
-/// `-g` commands skip — see `BinArgs::run`. `PNPM_HOME` / `HOME` /
-/// `XDG_CONFIG_HOME` and the `global-bin-dir` config env vars are pinned so the
-/// resolved path is deterministic regardless of the developer's environment.
+/// `pacquet bin -g` resolves the global executables directory
+/// (`global-bin-dir ?? <pnpm-home>/bin`), creates it, and — matching pnpm —
+/// validates it is on `PATH` before printing. `PNPM_HOME` is pinned with its
+/// `bin` prepended to `PATH`; `HOME` / `XDG_CONFIG_HOME` and the
+/// `global-bin-dir` config env vars are pinned so the resolved path is
+/// deterministic. Unix-gated like `global.rs`, since the `PATH` validation is
+/// platform-specific.
+#[cfg(unix)]
 #[test]
-fn bin_global_prints_the_configured_global_bin_dir() {
+fn bin_global_prints_the_global_bin_dir_when_on_path() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+    let pnpm_home = root.path().join("pnpm-home");
+    let global_bin = pnpm_home.join("bin");
+    let existing_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{existing_path}", global_bin.display());
+
+    let output = pacquet
+        .with_env("PNPM_HOME", &pnpm_home)
+        .with_env("HOME", root.path())
+        .with_env("XDG_CONFIG_HOME", root.path().join("xdg-config"))
+        .with_env("PNPM_CONFIG_GLOBAL_BIN_DIR", "")
+        .with_env("pnpm_config_global_bin_dir", "")
+        .with_env("PATH", path)
+        .with_args(["bin", "-g"])
+        .output()
+        .expect("run pacquet bin -g");
+    dbg!(&output);
+    assert!(output.status.success(), "pacquet bin -g should succeed when the dir is on PATH");
+
+    let expected = format!("{}\n", global_bin.display());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
+    // pnpm creates the global bin dir while resolving `--global`; pacquet mirrors that.
+    assert!(global_bin.is_dir(), "pacquet bin -g should create the global bin dir");
+
+    drop(root);
+}
+
+/// `pacquet bin -g` errors like pnpm (`ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH`)
+/// when the resolved global bin directory is not on `PATH`. Unix-gated for the
+/// same `PATH`-format reason as the success case.
+#[cfg(unix)]
+#[test]
+fn bin_global_errors_when_not_in_path() {
     let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
     let pnpm_home = root.path().join("pnpm-home");
 
@@ -69,20 +103,20 @@ fn bin_global_prints_the_configured_global_bin_dir() {
         .with_env("PNPM_HOME", &pnpm_home)
         .with_env("HOME", root.path())
         .with_env("XDG_CONFIG_HOME", root.path().join("xdg-config"))
-        // Neutralize any inherited `global-bin-dir` override so `global_bin`
-        // resolves purely from the pinned `PNPM_HOME` (empty == unset).
         .with_env("PNPM_CONFIG_GLOBAL_BIN_DIR", "")
         .with_env("pnpm_config_global_bin_dir", "")
+        .with_env("PATH", "/usr/bin:/bin")
         .with_args(["bin", "-g"])
         .output()
         .expect("run pacquet bin -g");
     dbg!(&output);
-    assert!(output.status.success(), "pacquet bin -g should succeed");
+    assert!(!output.status.success(), "pacquet bin -g should fail when the dir is not on PATH");
 
-    // `config.global_bin` resolves to `<PNPM_HOME>/bin`, printed verbatim — no
-    // canonicalization, unlike the cwd-anchored local path.
-    let expected = format!("{}\n", pnpm_home.join("bin").display());
-    assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not in PATH") || stderr.contains("ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH"),
+        "stderr should explain the global bin dir is not in PATH: {stderr}",
+    );
 
     drop(root);
 }
@@ -94,7 +128,7 @@ fn bin_global_prints_the_configured_global_bin_dir() {
 /// Skipped on Windows, where pnpm is installed as a `pnpm.cmd` shim and
 /// `std::process::Command` does not honor `PATHEXT`, so `Command::new("pnpm")`
 /// fails with "program not found" (the same reason `pnpm_compatibility.rs` and
-/// `hoist.rs` gate their pnpm-spawning tests). The three tests above spawn only
+/// `hoist.rs` gate their pnpm-spawning tests). The local tests above spawn only
 /// `pacquet`, so they keep running on Windows.
 #[test]
 #[cfg_attr(

--- a/pacquet/crates/cli/tests/bin.rs
+++ b/pacquet/crates/cli/tests/bin.rs
@@ -1,0 +1,144 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use pretty_assertions::assert_eq;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// Canonicalize a path the way the production CLI does. The CLI runs
+/// `dunce::canonicalize` on `--dir`, so the printed path is the resolved
+/// form — e.g. on macOS a `/var/folders/...` temp dir surfaces as
+/// `/private/var/folders/...`. Mirror that so the expected value matches.
+fn canonicalize(path: &Path) -> PathBuf {
+    dunce::canonicalize(path).expect("canonicalize path")
+}
+
+#[test]
+fn bin_prints_the_local_node_modules_bin_dir() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    let output = pacquet.with_args(["bin"]).output().expect("run pacquet bin");
+    dbg!(&output);
+    assert!(output.status.success(), "pacquet bin should succeed");
+
+    // pnpm's `bin` handler prints `config.bin`; the CLI appends a single
+    // trailing newline, the same shape `root` emits.
+    let expected =
+        format!("{}\n", canonicalize(&workspace).join("node_modules").join(".bin").display());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
+
+    drop(root);
+}
+
+#[test]
+fn bin_ignores_a_custom_modules_dir() {
+    // pnpm's `bin` hardcodes the `node_modules/.bin` leaf, so a configured
+    // modules-dir must NOT change its output. pacquet matches by anchoring on
+    // `--dir` and never reading `config.modules_dir` in this command.
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "modulesDir: custom_nm\n")
+        .expect("write pnpm-workspace.yaml");
+
+    let output = pacquet.with_args(["bin"]).output().expect("run pacquet bin");
+    dbg!(&output);
+    assert!(output.status.success(), "pacquet bin should succeed");
+
+    let expected =
+        format!("{}\n", canonicalize(&workspace).join("node_modules").join(".bin").display());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
+
+    drop(root);
+}
+
+/// `pacquet bin -g` prints the resolved global executables directory
+/// (`global-bin-dir ?? <pnpm-home>/bin`). This is intentionally NOT a
+/// differential test against real pnpm: pnpm additionally validates the dir is
+/// on `PATH` (erroring otherwise) and creates it, which pacquet's read-only
+/// `-g` commands skip — see `BinArgs::run`. `PNPM_HOME` / `HOME` /
+/// `XDG_CONFIG_HOME` and the `global-bin-dir` config env vars are pinned so the
+/// resolved path is deterministic regardless of the developer's environment.
+#[test]
+fn bin_global_prints_the_configured_global_bin_dir() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+    let pnpm_home = root.path().join("pnpm-home");
+
+    let output = pacquet
+        .with_env("PNPM_HOME", &pnpm_home)
+        .with_env("HOME", root.path())
+        .with_env("XDG_CONFIG_HOME", root.path().join("xdg-config"))
+        // Neutralize any inherited `global-bin-dir` override so `global_bin`
+        // resolves purely from the pinned `PNPM_HOME` (empty == unset).
+        .with_env("PNPM_CONFIG_GLOBAL_BIN_DIR", "")
+        .with_env("pnpm_config_global_bin_dir", "")
+        .with_args(["bin", "-g"])
+        .output()
+        .expect("run pacquet bin -g");
+    dbg!(&output);
+    assert!(output.status.success(), "pacquet bin -g should succeed");
+
+    // `config.global_bin` resolves to `<PNPM_HOME>/bin`, printed verbatim — no
+    // canonicalization, unlike the cwd-anchored local path.
+    let expected = format!("{}\n", pnpm_home.join("bin").display());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
+
+    drop(root);
+}
+
+/// Differential parity: from a workspace subdirectory pnpm's `bin` prints the
+/// cwd's `node_modules/.bin` (its `config.dir` is the cwd, not the workspace
+/// root). pacquet must print byte-identical output.
+///
+/// Skipped on Windows, where pnpm is installed as a `pnpm.cmd` shim and
+/// `std::process::Command` does not honor `PATHEXT`, so `Command::new("pnpm")`
+/// fails with "program not found" (the same reason `pnpm_compatibility.rs` and
+/// `hoist.rs` gate their pnpm-spawning tests). The three tests above spawn only
+/// `pacquet`, so they keep running on Windows.
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "spawns the external `pnpm` shim (`pnpm.cmd`); std::process::Command can't resolve it via PATHEXT"
+)]
+fn bin_matches_pnpm_from_a_workspace_subdir() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - \"packages/*\"\n")
+        .expect("write pnpm-workspace.yaml");
+    fs::write(workspace.join("package.json"), r#"{ "name": "wsroot", "version": "1.0.0" }"#)
+        .expect("write workspace-root package.json");
+    let member = workspace.join("packages/foo");
+    fs::create_dir_all(&member).expect("create workspace member dir");
+    fs::write(member.join("package.json"), r#"{ "name": "foo", "version": "1.0.0" }"#)
+        .expect("write member package.json");
+
+    let pacquet_out = Command::cargo_bin("pacquet")
+        .expect("find the pacquet binary")
+        .with_current_dir(&member)
+        .with_args(["bin"])
+        .output()
+        .expect("run pacquet bin in the subdir");
+    assert!(pacquet_out.status.success(), "pacquet bin should succeed in the subdir");
+
+    let pnpm_out = Command::new("pnpm")
+        .with_current_dir(&member)
+        .with_args(["bin"])
+        .output()
+        .expect("run pnpm bin in the subdir");
+    assert!(
+        pnpm_out.status.success(),
+        "pnpm bin failed: {}",
+        String::from_utf8_lossy(&pnpm_out.stderr),
+    );
+
+    let pacquet_stdout = String::from_utf8_lossy(&pacquet_out.stdout);
+    let pnpm_stdout = String::from_utf8_lossy(&pnpm_out.stdout);
+    eprintln!("pacquet: {pacquet_stdout:?}\npnpm:    {pnpm_stdout:?}");
+    assert_eq!(
+        pacquet_stdout, pnpm_stdout,
+        "pacquet bin must match pnpm bin from a workspace subdir (cwd, not workspace root)",
+    );
+
+    drop(root);
+}

--- a/pacquet/crates/cli/tests/bin.rs
+++ b/pacquet/crates/cli/tests/bin.rs
@@ -8,10 +8,9 @@ use std::{
     process::Command,
 };
 
-/// Canonicalize a path the way the production CLI does. The CLI runs
-/// `dunce::canonicalize` on `--dir`, so the printed path is the resolved
-/// form — e.g. on macOS a `/var/folders/...` temp dir surfaces as
-/// `/private/var/folders/...`. Mirror that so the expected value matches.
+/// Canonicalize a path the way the production CLI does (`dunce::canonicalize`
+/// on `--dir`), so the expected value matches the resolved form pacquet prints
+/// — e.g. on macOS a `/var/folders/...` temp dir surfaces as `/private/var/...`.
 fn canonicalize(path: &Path) -> PathBuf {
     dunce::canonicalize(path).expect("canonicalize path")
 }
@@ -24,8 +23,6 @@ fn bin_prints_the_local_node_modules_bin_dir() {
     dbg!(&output);
     assert!(output.status.success(), "pacquet bin should succeed");
 
-    // pnpm's `bin` handler prints `config.bin`; the CLI appends a single
-    // trailing newline, the same shape `root` emits.
     let expected =
         format!("{}\n", canonicalize(&workspace).join("node_modules").join(".bin").display());
     assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
@@ -35,9 +32,7 @@ fn bin_prints_the_local_node_modules_bin_dir() {
 
 #[test]
 fn bin_ignores_a_custom_modules_dir() {
-    // pnpm's `bin` hardcodes the `node_modules/.bin` leaf, so a configured
-    // modules-dir must NOT change its output. pacquet matches by anchoring on
-    // `--dir` and never reading `config.modules_dir` in this command.
+    // pnpm hardcodes the `.bin` leaf, so a custom modules-dir is ignored.
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     fs::write(workspace.join("pnpm-workspace.yaml"), "modulesDir: custom_nm\n")
         .expect("write pnpm-workspace.yaml");
@@ -53,12 +48,9 @@ fn bin_ignores_a_custom_modules_dir() {
     drop(root);
 }
 
-/// `pacquet bin -g` resolves the global executables directory
-/// (`global-bin-dir ?? <pnpm-home>/bin`), creates it, and — matching pnpm —
-/// validates it is on `PATH` before printing. `PNPM_HOME` is pinned with its
-/// `bin` prepended to `PATH`; `HOME` / `XDG_CONFIG_HOME` and the
-/// `global-bin-dir` config env vars are pinned so the resolved path is
-/// deterministic. Unix-gated like `global.rs`, since the `PATH` validation is
+/// `pacquet bin -g` resolves, creates, and (matching pnpm) validates the global
+/// bin dir is on `PATH` before printing. The env is pinned so the resolved path
+/// is deterministic. Unix-gated like `global.rs`: the `PATH` validation is
 /// platform-specific.
 #[cfg(unix)]
 #[test]
@@ -84,7 +76,6 @@ fn bin_global_prints_the_global_bin_dir_when_on_path() {
 
     let expected = format!("{}\n", global_bin.display());
     assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
-    // pnpm creates the global bin dir while resolving `--global`; pacquet mirrors that.
     assert!(global_bin.is_dir(), "pacquet bin -g should create the global bin dir");
 
     drop(root);
@@ -123,13 +114,8 @@ fn bin_global_errors_when_not_in_path() {
 
 /// Differential parity: from a workspace subdirectory pnpm's `bin` prints the
 /// cwd's `node_modules/.bin` (its `config.dir` is the cwd, not the workspace
-/// root). pacquet must print byte-identical output.
-///
-/// Skipped on Windows, where pnpm is installed as a `pnpm.cmd` shim and
-/// `std::process::Command` does not honor `PATHEXT`, so `Command::new("pnpm")`
-/// fails with "program not found" (the same reason `pnpm_compatibility.rs` and
-/// `hoist.rs` gate their pnpm-spawning tests). The local tests above spawn only
-/// `pacquet`, so they keep running on Windows.
+/// root). pacquet must match byte-for-byte. Windows-skipped because it spawns
+/// the external `pnpm` shim (see the `ignore` reason).
 #[test]
 #[cfg_attr(
     target_os = "windows",


### PR DESCRIPTION
## Summary

Ports the `bin` command from the TypeScript pnpm CLI to the Rust `pacquet` port, mirroring [`pnpm11/pnpm/src/cmd/bin.ts`](https://github.com/pnpm/pnpm/blob/fc2f33912e/pnpm11/pnpm/src/cmd/bin.ts) and the bin-dir resolution in [`pnpm11/config/reader/src/index.ts`](https://github.com/pnpm/pnpm/blob/3425e8011c/pnpm11/config/reader/src/index.ts).

`pacquet bin` prints the directory where executables are installed:

- locally, `<dir>/node_modules/.bin` — the `node_modules/.bin` leaf is hardcoded (a configured `modules-dir` is ignored) and the path is anchored on the already-canonicalized `--dir`, matching pnpm's `config.dir` (the cwd, not the workspace root). Includes a differential test against the real `pnpm` from a workspace subdirectory.
- with `--global` / `-g`, the resolved global bin directory (`global-bin-dir ?? <pnpm-home>/bin`). Mirroring pnpm's config reader, it creates the directory and validates it with `checkGlobalBinDir` (PATH membership + writability, since `globalDirShouldAllowWrite` is true for every command except `root`) before printing, erroring with `ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH` / `ERR_PNPM_NO_PATH_ENV` / `ERR_PNPM_PNPM_DIR_NOT_WRITABLE`, or `ERR_PNPM_NO_GLOBAL_BIN_DIR` when no pnpm home resolves.

Related to pnpm/pnpm#11633.

## Squash Commit Body

```text
Port pnpm's `bin` command, which prints the directory where executables are
installed.

Locally it prints `<dir>/node_modules/.bin`: the `node_modules/.bin` leaf is
hardcoded, so a configured `modules-dir` is ignored, and the path is anchored
on the already-canonicalized `--dir`, mirroring pnpm's config reader.

`--global` resolves `global-bin-dir ?? <pnpm-home>/bin`, creates it, and runs
`check_global_bin_dir` (PATH membership + writability, since
`globalDirShouldAllowWrite` is true for every command except `root`) before
printing — the same `mkdir` + `checkGlobalBinDir` pnpm's config reader performs
for every `--global` command. Errors mirror pnpm:
`ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH`, `ERR_PNPM_NO_PATH_ENV`,
`ERR_PNPM_PNPM_DIR_NOT_WRITABLE`, and `ERR_PNPM_NO_GLOBAL_BIN_DIR`.

Ported from pnpm's bin.ts and config reader.

Related to pnpm/pnpm#11633.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting.
  - pnpm already has `bin`; this ports it to pacquet. No TypeScript changes needed.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
  - Not needed; pacquet is not published to npm.
- [x] Added or updated tests.
  - 5 integration tests: local `node_modules/.bin`, ignores a custom modules-dir, `-g` prints the validated global bin dir, `-g` errors when not on `PATH`, and a differential test against the real `pnpm` from a workspace subdir. The two `-g` tests are Unix-gated (like `global.rs`) because the `PATH` validation is platform-specific.
- [x] Updated the documentation if needed.
  - None (consistent with sibling command ports).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `bin` CLI subcommand that prints the resolved `node_modules/.bin` (local) or global executables directory.
  * Added `--global` / `-g` to output the global executables directory and create it if needed.
* **Bug Fixes**
  * Improved resolution and validation of the global executables directory against the current `PATH`, with clearer failure behavior when not reachable.
* **Tests**
  * Added integration tests for local, workspace, and global modes (including exact stdout matching, directory creation, and parity with the external `pnpm bin`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->