### PR TITLE
feat(pacquet-cli): implement pnpm peers command

### DIFF
--- a/.changeset/peers-ignore-missing-conflicts.md
+++ b/.changeset/peers-ignore-missing-conflicts.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/deps.inspection.peers-checker": patch
+"pnpm": patch
+---
+
+`pnpm peers` no longer reports a conflict for a missing peer dependency that is ignored via `pnpm.peerDependencyRules.ignoreMissing`.

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -32,6 +32,7 @@ pub mod patch;
 pub mod patch_commit;
 pub mod patch_remove;
 pub(crate) mod patch_state;
+pub mod peers;
 pub mod ping;
 pub mod prefix;
 pub mod prune;

--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -30,6 +30,7 @@ use super::{
     patch::PatchArgs,
     patch_commit::PatchCommitArgs,
     patch_remove::PatchRemoveArgs,
+    peers::PeersArgs,
     ping::PingArgs,
     prefix::PrefixArgs,
     prune::PruneArgs,
@@ -180,6 +181,9 @@ pub enum CliCommand {
     /// Remove existing patch files.
     #[clap(name = "patch-remove")]
     PatchRemove(PatchRemoveArgs),
+    /// Checks for unmet or missing peer dependency issues.
+    #[clap(name = "peers")]
+    Peers(PeersArgs),
     /// Set a script in package.json
     #[clap(visible_alias = "ss")]
     SetScript(SetScriptArgs),

--- a/pacquet/crates/cli/src/cli_args/dispatch.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch.rs
@@ -242,6 +242,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::Patch(args) => dispatch_install::patch(ctx, args),
         CliCommand::PatchCommit(args) => dispatch_install::patch_commit(ctx, args),
         CliCommand::PatchRemove(args) => dispatch_install::patch_remove(ctx, args),
+        CliCommand::Peers(args) => dispatch_query::peers(ctx, args),
         CliCommand::SetScript(args) => dispatch_script::set_script(ctx, args),
         CliCommand::Test => dispatch_script::test(ctx),
         CliCommand::Run(args) => dispatch_script::run(ctx, args),

--- a/pacquet/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_query.rs
@@ -16,6 +16,7 @@ use super::{
     outdated::{OutdatedArgs, OutdatedOutcome},
     pack::PackArgs,
     pack_app::PackAppArgs,
+    peers::PeersArgs,
     ping::PingArgs,
     prefix::PrefixArgs,
     repo::RepoArgs,
@@ -106,6 +107,16 @@ pub(super) fn why<'a>(ctx: &RunCtx<'a>, args: WhyArgs) -> miette::Result<Command
 
 pub(super) fn sbom<'a>(ctx: &RunCtx<'a>, args: SbomArgs) -> miette::Result<CommandFuture<'a>> {
     Ok(Box::pin(args.run((ctx.state)(true)?)))
+}
+
+pub(super) fn peers<'a>(ctx: &RunCtx<'a>, args: PeersArgs) -> miette::Result<CommandFuture<'a>> {
+    let cfg: &Config = (ctx.config)()?;
+    let recursive = ctx.recursive;
+    let dir = ctx.dir;
+    Ok(Box::pin(async move {
+        args.run(cfg, dir, recursive)?;
+        Ok(())
+    }))
 }
 
 // `whoami` is a read-only registry query: it resolves the default registry's

--- a/pacquet/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_query.rs
@@ -16,7 +16,7 @@ use super::{
     outdated::{OutdatedArgs, OutdatedOutcome},
     pack::PackArgs,
     pack_app::PackAppArgs,
-    peers::PeersArgs,
+    peers::{PeersArgs, PeersOutcome},
     ping::PingArgs,
     prefix::PrefixArgs,
     repo::RepoArgs,
@@ -114,7 +114,13 @@ pub(super) fn peers<'a>(ctx: &RunCtx<'a>, args: PeersArgs) -> miette::Result<Com
     let recursive = ctx.recursive;
     let dir = ctx.dir;
     Ok(Box::pin(async move {
-        args.run(cfg, dir, recursive)?;
+        if args.run(cfg, dir, recursive)? == PeersOutcome::IssuesFound {
+            #[expect(
+                clippy::exit,
+                reason = "`peers` exits non-zero when peer issues are found, mirroring pnpm"
+            )]
+            std::process::exit(1);
+        }
         Ok(())
     }))
 }

--- a/pacquet/crates/cli/src/cli_args/peers.rs
+++ b/pacquet/crates/cli/src/cli_args/peers.rs
@@ -182,8 +182,21 @@ fn resolve_importer_id(lockfile_dir: &std::path::Path, dir: &std::path::Path) ->
     }
 }
 
+fn path_is_within(path: &std::path::Path, base: &std::path::Path) -> bool {
+    let (Ok(canonical_path), Ok(canonical_base)) =
+        (dunce::canonicalize(path), dunce::canonicalize(base))
+    else {
+        return false;
+    };
+    canonical_path.starts_with(&canonical_base)
+}
+
 fn resolve_link_version(lockfile_dir: &std::path::Path, link_target: &str) -> Option<String> {
-    let manifest_path = lockfile_dir.join(link_target).join("package.json");
+    let target_dir = lockfile_dir.join(link_target);
+    if !path_is_within(&target_dir, lockfile_dir) {
+        return None;
+    }
+    let manifest_path = target_dir.join("package.json");
     PackageManifest::from_path(manifest_path).ok().and_then(|manifest| {
         manifest.value().get("version").and_then(|v| v.as_str()).map(String::from)
     })
@@ -199,6 +212,9 @@ fn check_linked_package_peers(
     issues: &mut PeerIssues,
 ) {
     let linked_pkg_dir = lockfile_dir.join(importer_id).join(link_target);
+    if !path_is_within(&linked_pkg_dir, lockfile_dir) {
+        return;
+    }
     let manifest_path = linked_pkg_dir.join("package.json");
     let Ok(manifest) = PackageManifest::from_path(manifest_path) else { return };
     let Some(peer_deps) = manifest.value().get("peerDependencies").and_then(|v| v.as_object())
@@ -312,6 +328,9 @@ fn collect_initial_keys(
                 );
 
                 let linked_importer_path = lockfile_dir.join(importer_id).join(link_target);
+                if !path_is_within(&linked_importer_path, lockfile_dir) {
+                    continue;
+                }
                 let linked_importer_id = resolve_importer_id(lockfile_dir, &linked_importer_path);
                 collect_initial_keys(
                     &linked_importer_id,

--- a/pacquet/crates/cli/src/cli_args/peers.rs
+++ b/pacquet/crates/cli/src/cli_args/peers.rs
@@ -354,8 +354,8 @@ fn walk_snapshot(
                 let is_optional = meta
                     .peer_dependencies_meta
                     .as_ref()
-                    .and_then(|m| m.get(peer_name))
-                    .is_some_and(|m| m.optional);
+                    .and_then(|meta_map| meta_map.get(peer_name))
+                    .is_some_and(|peer_meta| peer_meta.optional);
 
                 let Ok(peer_pkg_name) = peer_name.parse::<PkgName>() else { continue };
                 let resolved_ref = snapshot.and_then(|s| {
@@ -424,8 +424,8 @@ fn walk_snapshot(
             let all_deps = snapshot
                 .dependencies
                 .iter()
-                .flat_map(|d| d.iter())
-                .chain(snapshot.optional_dependencies.iter().flat_map(|d| d.iter()));
+                .flat_map(|deps| deps.iter())
+                .chain(snapshot.optional_dependencies.iter().flat_map(|deps| deps.iter()));
 
             for (alias, dep_ref) in all_deps {
                 if let Some(child_key) = dep_ref.resolve(alias) {
@@ -487,96 +487,104 @@ struct Interval {
 }
 
 impl fmt::Display for Interval {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match (&self.lower, &self.upper) {
-            (Bound::Unbounded, Bound::Unbounded) => write!(f, "*"),
-            (Bound::Inclusive(vl), Bound::Unbounded) => write!(f, ">={vl}"),
-            (Bound::Exclusive(vl), Bound::Unbounded) => write!(f, ">{vl}"),
-            (Bound::Unbounded, Bound::Inclusive(vu)) => write!(f, "<={vu}"),
-            (Bound::Unbounded, Bound::Exclusive(vu)) => write!(f, "<{vu}"),
-            (Bound::Inclusive(vl), Bound::Inclusive(vu)) => {
-                if vl == vu {
-                    write!(f, "{vl}")
+            (Bound::Unbounded, Bound::Unbounded) => write!(formatter, "*"),
+            (Bound::Inclusive(version_lower), Bound::Unbounded) => {
+                write!(formatter, ">={version_lower}")
+            }
+            (Bound::Exclusive(version_lower), Bound::Unbounded) => {
+                write!(formatter, ">{version_lower}")
+            }
+            (Bound::Unbounded, Bound::Inclusive(version_upper)) => {
+                write!(formatter, "<={version_upper}")
+            }
+            (Bound::Unbounded, Bound::Exclusive(version_upper)) => {
+                write!(formatter, "<{version_upper}")
+            }
+            (Bound::Inclusive(version_lower), Bound::Inclusive(version_upper)) => {
+                if version_lower == version_upper {
+                    write!(formatter, "{version_lower}")
                 } else {
-                    write!(f, ">={vl} <={vu}")
+                    write!(formatter, ">={version_lower} <={version_upper}")
                 }
             }
-            (Bound::Inclusive(vl), Bound::Exclusive(vu)) => {
-                write!(f, ">={vl} <{vu}")
+            (Bound::Inclusive(version_lower), Bound::Exclusive(version_upper)) => {
+                write!(formatter, ">={version_lower} <{version_upper}")
             }
-            (Bound::Exclusive(vl), Bound::Inclusive(vu)) => {
-                write!(f, ">{vl} <={vu}")
+            (Bound::Exclusive(version_lower), Bound::Inclusive(version_upper)) => {
+                write!(formatter, ">{version_lower} <={version_upper}")
             }
-            (Bound::Exclusive(vl), Bound::Exclusive(vu)) => {
-                write!(f, ">{vl} <{vu}")
-            }
-        }
-    }
-}
-
-fn max_lower(a: &Bound<Version>, b: &Bound<Version>) -> Bound<Version> {
-    match (a, b) {
-        (Bound::Unbounded, other) | (other, Bound::Unbounded) => other.clone(),
-        (Bound::Inclusive(v1), Bound::Inclusive(v2)) => {
-            if v1 >= v2 {
-                Bound::Inclusive(v1.clone())
-            } else {
-                Bound::Inclusive(v2.clone())
-            }
-        }
-        (Bound::Exclusive(v1), Bound::Exclusive(v2)) => {
-            if v1 >= v2 {
-                Bound::Exclusive(v1.clone())
-            } else {
-                Bound::Exclusive(v2.clone())
-            }
-        }
-        (Bound::Inclusive(v1), Bound::Exclusive(v2)) => {
-            if v1 > v2 {
-                Bound::Inclusive(v1.clone())
-            } else {
-                Bound::Exclusive(v2.clone())
-            }
-        }
-        (Bound::Exclusive(v1), Bound::Inclusive(v2)) => {
-            if v1 >= v2 {
-                Bound::Exclusive(v1.clone())
-            } else {
-                Bound::Inclusive(v2.clone())
+            (Bound::Exclusive(version_lower), Bound::Exclusive(version_upper)) => {
+                write!(formatter, ">{version_lower} <{version_upper}")
             }
         }
     }
 }
 
-fn min_upper(a: &Bound<Version>, b: &Bound<Version>) -> Bound<Version> {
-    match (a, b) {
+fn max_lower(left_bound: &Bound<Version>, right_bound: &Bound<Version>) -> Bound<Version> {
+    match (left_bound, right_bound) {
         (Bound::Unbounded, other) | (other, Bound::Unbounded) => other.clone(),
-        (Bound::Inclusive(v1), Bound::Inclusive(v2)) => {
-            if v1 <= v2 {
-                Bound::Inclusive(v1.clone())
+        (Bound::Inclusive(left_version), Bound::Inclusive(right_version)) => {
+            if left_version >= right_version {
+                Bound::Inclusive(left_version.clone())
             } else {
-                Bound::Inclusive(v2.clone())
+                Bound::Inclusive(right_version.clone())
             }
         }
-        (Bound::Exclusive(v1), Bound::Exclusive(v2)) => {
-            if v1 <= v2 {
-                Bound::Exclusive(v1.clone())
+        (Bound::Exclusive(left_version), Bound::Exclusive(right_version)) => {
+            if left_version >= right_version {
+                Bound::Exclusive(left_version.clone())
             } else {
-                Bound::Exclusive(v2.clone())
+                Bound::Exclusive(right_version.clone())
             }
         }
-        (Bound::Inclusive(v1), Bound::Exclusive(v2)) => {
-            if v1 < v2 {
-                Bound::Inclusive(v1.clone())
+        (Bound::Inclusive(left_version), Bound::Exclusive(right_version)) => {
+            if left_version > right_version {
+                Bound::Inclusive(left_version.clone())
             } else {
-                Bound::Exclusive(v2.clone())
+                Bound::Exclusive(right_version.clone())
             }
         }
-        (Bound::Exclusive(v1), Bound::Inclusive(v2)) => {
-            if v1 <= v2 {
-                Bound::Exclusive(v1.clone())
+        (Bound::Exclusive(left_version), Bound::Inclusive(right_version)) => {
+            if left_version >= right_version {
+                Bound::Exclusive(left_version.clone())
             } else {
-                Bound::Inclusive(v2.clone())
+                Bound::Inclusive(right_version.clone())
+            }
+        }
+    }
+}
+
+fn min_upper(left_bound: &Bound<Version>, right_bound: &Bound<Version>) -> Bound<Version> {
+    match (left_bound, right_bound) {
+        (Bound::Unbounded, other) | (other, Bound::Unbounded) => other.clone(),
+        (Bound::Inclusive(left_version), Bound::Inclusive(right_version)) => {
+            if left_version <= right_version {
+                Bound::Inclusive(left_version.clone())
+            } else {
+                Bound::Inclusive(right_version.clone())
+            }
+        }
+        (Bound::Exclusive(left_version), Bound::Exclusive(right_version)) => {
+            if left_version <= right_version {
+                Bound::Exclusive(left_version.clone())
+            } else {
+                Bound::Exclusive(right_version.clone())
+            }
+        }
+        (Bound::Inclusive(left_version), Bound::Exclusive(right_version)) => {
+            if left_version < right_version {
+                Bound::Inclusive(left_version.clone())
+            } else {
+                Bound::Exclusive(right_version.clone())
+            }
+        }
+        (Bound::Exclusive(left_version), Bound::Inclusive(right_version)) => {
+            if left_version <= right_version {
+                Bound::Exclusive(left_version.clone())
+            } else {
+                Bound::Inclusive(right_version.clone())
             }
         }
     }
@@ -585,77 +593,91 @@ fn min_upper(a: &Bound<Version>, b: &Bound<Version>) -> Bound<Version> {
 fn is_valid_interval(lower: &Bound<Version>, upper: &Bound<Version>) -> bool {
     match (lower, upper) {
         (Bound::Unbounded, _) | (_, Bound::Unbounded) => true,
-        (Bound::Inclusive(v1), Bound::Inclusive(v2)) => v1 <= v2,
-        (Bound::Inclusive(v1), Bound::Exclusive(v2)) => v1 < v2,
-        (Bound::Exclusive(v1), Bound::Inclusive(v2)) => v1 < v2,
-        (Bound::Exclusive(v1), Bound::Exclusive(v2)) => v1 < v2,
+        (Bound::Inclusive(left_version), Bound::Inclusive(right_version)) => {
+            left_version <= right_version
+        }
+        (Bound::Inclusive(left_version), Bound::Exclusive(right_version)) => {
+            left_version < right_version
+        }
+        (Bound::Exclusive(left_version), Bound::Inclusive(right_version)) => {
+            left_version < right_version
+        }
+        (Bound::Exclusive(left_version), Bound::Exclusive(right_version)) => {
+            left_version < right_version
+        }
     }
 }
 
-fn normalize_version_str(v: &str) -> String {
-    let v = v.trim();
-    let parts: Vec<&str> = v.split('.').collect();
-    match parts.len() {
+fn normalize_version_str(version_raw: &str) -> String {
+    let version_raw = version_raw.trim();
+    let version_parts: Vec<&str> = version_raw.split('.').collect();
+    match version_parts.len() {
         1 => {
-            let p = parts[0].replace(['x', 'X', '*'], "0");
-            if p.chars().all(|c| c.is_ascii_digit()) { format!("{p}.0.0") } else { v.to_string() }
+            let major = version_parts[0].replace(['x', 'X', '*'], "0");
+            if major.chars().all(|character| character.is_ascii_digit()) {
+                format!("{major}.0.0")
+            } else {
+                version_raw.to_string()
+            }
         }
         2 => {
-            let p0 = parts[0].replace(['x', 'X', '*'], "0");
-            let p1 = parts[1].replace(['x', 'X', '*'], "0");
-            if p0.chars().all(|c| c.is_ascii_digit()) && p1.chars().all(|c| c.is_ascii_digit()) {
-                format!("{p0}.{p1}.0")
+            let major = version_parts[0].replace(['x', 'X', '*'], "0");
+            let minor = version_parts[1].replace(['x', 'X', '*'], "0");
+            if major.chars().all(|character| character.is_ascii_digit())
+                && minor.chars().all(|character| character.is_ascii_digit())
+            {
+                format!("{major}.{minor}.0")
             } else {
-                v.to_string()
+                version_raw.to_string()
             }
         }
         _ => {
-            let p0 = parts[0].replace(['x', 'X', '*'], "0");
-            let p1 = parts[1].replace(['x', 'X', '*'], "0");
-            let p2 = parts[2].replace(['x', 'X', '*'], "0");
-            if p0.chars().all(|c| c.is_ascii_digit())
-                && p1.chars().all(|c| c.is_ascii_digit())
-                && p2.chars().all(|c| c.is_ascii_digit())
+            let major = version_parts[0].replace(['x', 'X', '*'], "0");
+            let minor = version_parts[1].replace(['x', 'X', '*'], "0");
+            let patch = version_parts[2].replace(['x', 'X', '*'], "0");
+            if major.chars().all(|character| character.is_ascii_digit())
+                && minor.chars().all(|character| character.is_ascii_digit())
+                && patch.chars().all(|character| character.is_ascii_digit())
             {
-                let rest = if parts.len() > 3 {
-                    format!(".{}", parts[3..].join("."))
+                let rest = if version_parts.len() > 3 {
+                    format!(".{}", version_parts[3..].join("."))
                 } else {
                     String::new()
                 };
-                format!("{p0}.{p1}.{p2}{rest}")
+                format!("{major}.{minor}.{patch}{rest}")
             } else {
-                v.to_string()
+                version_raw.to_string()
             }
         }
     }
 }
 
-fn parse_comparator(comp: &str) -> Option<Interval> {
-    let comp = comp.trim();
-    if comp == "*" || comp.is_empty() {
+fn parse_comparator(comparator: &str) -> Option<Interval> {
+    let comparator = comparator.trim();
+    if comparator == "*" || comparator.is_empty() {
         return Some(Interval { lower: Bound::Unbounded, upper: Bound::Unbounded });
     }
 
-    let (op, ver_str) = if let Some(rest) = comp.strip_prefix(">=") {
+    let (operator, version_str) = if let Some(rest) = comparator.strip_prefix(">=") {
         ("=>", rest)
-    } else if let Some(rest) = comp.strip_prefix('>') {
+    } else if let Some(rest) = comparator.strip_prefix('>') {
         (">", rest)
-    } else if let Some(rest) = comp.strip_prefix("<=") {
+    } else if let Some(rest) = comparator.strip_prefix("<=") {
         ("<=", rest)
-    } else if let Some(rest) = comp.strip_prefix('<') {
+    } else if let Some(rest) = comparator.strip_prefix('<') {
         ("<", rest)
-    } else if let Some(rest) = comp.strip_prefix('^') {
+    } else if let Some(rest) = comparator.strip_prefix('^') {
         ("^", rest)
-    } else if let Some(rest) = comp.strip_prefix('~') {
+    } else if let Some(rest) = comparator.strip_prefix('~') {
         ("~", rest)
     } else {
-        ("=", comp)
+        ("=", comparator)
     };
 
-    let normalized = normalize_version_str(ver_str);
+    let normalized = normalize_version_str(version_str);
     let version = Version::parse(&normalized).ok()?;
 
-    match op {
+    match operator {
         "=" => Some(Interval {
             lower: Bound::Inclusive(version.clone()),
             upper: Bound::Inclusive(version),
@@ -753,12 +775,12 @@ fn parse_range_to_intervals(range: &str) -> Option<Vec<Interval>> {
     if intervals.is_empty() { None } else { Some(intervals) }
 }
 
-fn intersect_intervals(a: &[Interval], b: &[Interval]) -> Vec<Interval> {
+fn intersect_intervals(left_intervals: &[Interval], right_intervals: &[Interval]) -> Vec<Interval> {
     let mut result = Vec::new();
-    for i in a {
-        for j in b {
-            let lower = max_lower(&i.lower, &j.lower);
-            let upper = min_upper(&i.upper, &j.upper);
+    for left_interval in left_intervals {
+        for right_interval in right_intervals {
+            let lower = max_lower(&left_interval.lower, &right_interval.lower);
+            let upper = min_upper(&left_interval.upper, &right_interval.upper);
             if is_valid_interval(&lower, &upper) {
                 result.push(Interval { lower, upper });
             }
@@ -767,12 +789,13 @@ fn intersect_intervals(a: &[Interval], b: &[Interval]) -> Vec<Interval> {
     result
 }
 
-fn intersect_multiple_ranges(ranges: &[String]) -> Option<String> {
-    if ranges.is_empty() {
+fn intersect_multiple_ranges(version_ranges: &[String]) -> Option<String> {
+    if version_ranges.is_empty() {
         return Some("*".to_string());
     }
-    let mut current_intervals = parse_range_to_intervals(&preprocess_hyphen_ranges(&ranges[0]))?;
-    for range in &ranges[1..] {
+    let mut current_intervals =
+        parse_range_to_intervals(&preprocess_hyphen_ranges(&version_ranges[0]))?;
+    for range in &version_ranges[1..] {
         let next_intervals = parse_range_to_intervals(&preprocess_hyphen_ranges(range))?;
         current_intervals = intersect_intervals(&current_intervals, &next_intervals);
         if current_intervals.is_empty() {
@@ -789,8 +812,8 @@ fn intersect_multiple_ranges(ranges: &[String]) -> Option<String> {
 }
 
 #[cfg(test)]
-fn have_common_version(ranges: &[String]) -> bool {
-    intersect_multiple_ranges(ranges).is_some()
+fn have_common_version(version_ranges: &[String]) -> bool {
+    intersect_multiple_ranges(version_ranges).is_some()
 }
 
 fn merge_missing_peers(missing: &HashMap<String, Vec<MissingPeerIssue>>) -> MergeResult {
@@ -798,20 +821,21 @@ fn merge_missing_peers(missing: &HashMap<String, Vec<MissingPeerIssue>>) -> Merg
     let mut intersections = HashMap::new();
 
     for (peer_name, issues) in missing {
-        if issues.iter().all(|i| i.optional) {
+        if issues.iter().all(|issue| issue.optional) {
             continue;
         }
         if issues.len() == 1 {
             intersections.insert(peer_name.clone(), issues[0].wanted_range.clone());
             continue;
         }
-        let ranges: Vec<&str> = issues.iter().map(|i| i.wanted_range.as_str()).collect();
+        let ranges: Vec<&str> = issues.iter().map(|issue| issue.wanted_range.as_str()).collect();
         let unique: HashSet<&&str> = ranges.iter().collect();
         if unique.len() == 1 {
             intersections.insert(peer_name.clone(), issues[0].wanted_range.clone());
             continue;
         }
-        let range_owned: Vec<String> = issues.iter().map(|i| i.wanted_range.clone()).collect();
+        let range_owned: Vec<String> =
+            issues.iter().map(|issue| issue.wanted_range.clone()).collect();
         if let Some(intersection_str) = intersect_multiple_ranges(&range_owned) {
             intersections.insert(peer_name.clone(), intersection_str);
         } else {
@@ -852,7 +876,9 @@ fn filter_peer_issues(
         let mut filtered_bad: HashMap<String, Vec<BadPeerIssue>> = HashMap::new();
 
         for (peer_name, peer_issues) in &project_issues.missing {
-            if ignore_missing_matcher.matches(peer_name) || peer_issues.iter().all(|i| i.optional) {
+            if ignore_missing_matcher.matches(peer_name)
+                || peer_issues.iter().all(|issue| issue.optional)
+            {
                 continue;
             }
             filtered_missing.insert(peer_name.clone(), peer_issues.clone());

--- a/pacquet/crates/cli/src/cli_args/peers.rs
+++ b/pacquet/crates/cli/src/cli_args/peers.rs
@@ -357,7 +357,7 @@ fn have_common_version(ranges: &[String]) -> bool {
     }
 
     for ver_str in &candidate_versions {
-        if ranges.iter().all(|r| satisfies(ver_str, r)) {
+        if ranges.iter().all(|range| satisfies(ver_str, range)) {
             return true;
         }
     }
@@ -434,14 +434,14 @@ fn filter_peer_issues(
                 .iter()
                 .filter(|issue| {
                     if let Some(ranges) = allow_all_matcher.get(peer_name)
-                        && ranges.iter().any(|r| satisfies(&issue.found_version, r))
+                        && ranges.iter().any(|range| satisfies(&issue.found_version, range))
                     {
                         return false;
                     }
                     if let Some(declaring_parent) = issue.parents.last()
                         && let Some(parent_map) = allow_by_parent.get(&declaring_parent.name)
                         && let Some(ranges) = parent_map.get(peer_name)
-                        && ranges.iter().any(|r| satisfies(&issue.found_version, r))
+                        && ranges.iter().any(|range| satisfies(&issue.found_version, range))
                     {
                         return false;
                     }
@@ -475,7 +475,7 @@ fn parse_allowed_versions(
         if let Some((parent, target)) = selector.split_once('>') {
             let parent_name = parent.trim().to_string();
             let target_name = target.trim().to_string();
-            let ranges: Vec<String> = spec.split("||").map(|s| s.trim().to_string()).collect();
+            let ranges: Vec<String> = spec.split("||").map(|seg| seg.trim().to_string()).collect();
             by_parent
                 .entry(parent_name)
                 .or_default()
@@ -488,7 +488,7 @@ fn parse_allowed_versions(
             } else {
                 selector.clone()
             };
-            let ranges: Vec<String> = spec.split("||").map(|s| s.trim().to_string()).collect();
+            let ranges: Vec<String> = spec.split("||").map(|seg| seg.trim().to_string()).collect();
             match_all.entry(target_name).or_default().extend(ranges);
         }
     }

--- a/pacquet/crates/cli/src/cli_args/peers.rs
+++ b/pacquet/crates/cli/src/cli_args/peers.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt,
 };
 
@@ -44,13 +44,13 @@ struct BadPeerIssue {
 
 #[derive(Debug, Clone, Serialize)]
 struct PeerIssues {
-    bad: HashMap<String, Vec<BadPeerIssue>>,
-    missing: HashMap<String, Vec<MissingPeerIssue>>,
+    bad: BTreeMap<String, Vec<BadPeerIssue>>,
+    missing: BTreeMap<String, Vec<MissingPeerIssue>>,
     conflicts: Vec<String>,
-    intersections: HashMap<String, String>,
+    intersections: BTreeMap<String, String>,
 }
 
-type IssuesByProjects = HashMap<String, PeerIssues>;
+type IssuesByProjects = BTreeMap<String, PeerIssues>;
 
 #[derive(Debug, Args)]
 pub struct PeersArgs {
@@ -61,13 +61,23 @@ pub struct PeersArgs {
     pub lockfile_only: bool,
 }
 
+/// Whether `peers` found any peer dependency issue. The CLI harness maps
+/// [`PeersOutcome::IssuesFound`] to a process exit code of `1`, matching
+/// pnpm; returning the outcome (rather than terminating here) keeps
+/// [`PeersArgs::run`] composable and process termination in one place.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeersOutcome {
+    NoIssues,
+    IssuesFound,
+}
+
 impl PeersArgs {
     pub fn run(
         self,
         config: &Config,
         dir: &std::path::Path,
         recursive: bool,
-    ) -> miette::Result<()> {
+    ) -> miette::Result<PeersOutcome> {
         let lockfile_dir = config.workspace_dir.as_deref().unwrap_or(dir);
 
         let lockfile = if self.lockfile_only {
@@ -82,17 +92,15 @@ impl PeersArgs {
         .into_diagnostic()
         .wrap_err("load lockfile")?;
 
-        let Some(lockfile) = lockfile else {
-            if self.json {
-                println!("{{}}");
-            } else {
-                let dir_str = lockfile_dir.display().to_string();
-                println!("No lockfile found in {}", sanitize(&dir_str));
+        // A missing lockfile yields empty issues, mirroring pnpm's
+        // `checkPeerDependencies`, so both output modes stay on the common
+        // path (`{}` for `--json`, "No peer dependency issues found" otherwise).
+        let issues = match &lockfile {
+            Some(lockfile) => {
+                check_peer_dependencies_from_lockfile(lockfile, lockfile_dir, dir, recursive)
             }
-            return Ok(());
+            None => IssuesByProjects::new(),
         };
-
-        let issues = check_peer_dependencies_from_lockfile(&lockfile, lockfile_dir, dir, recursive);
         let issues = filter_peer_issues(issues, &config.peer_dependency_rules);
 
         let no_issues = issues.values().all(|pi| pi.bad.is_empty() && pi.missing.is_empty());
@@ -106,15 +114,10 @@ impl PeersArgs {
             println!("No peer dependency issues found");
         } else {
             println!("Issues with peer dependencies found\n");
-            print!("{}", render_peer_issues(&issues));
+            println!("{}", render_peer_issues(&issues));
         }
 
-        if !no_issues {
-            #[allow(clippy::exit, reason = "peers exits non-zero on issues, mirroring pnpm")]
-            std::process::exit(1);
-        }
-
-        Ok(())
+        Ok(if no_issues { PeersOutcome::NoIssues } else { PeersOutcome::IssuesFound })
     }
 }
 
@@ -124,10 +127,10 @@ fn check_peer_dependencies_from_lockfile(
     dir: &std::path::Path,
     recursive: bool,
 ) -> IssuesByProjects {
-    let packages = lockfile.packages.as_ref();
-    let snapshots = lockfile.snapshots.as_ref();
-    let Some(snapshots) = snapshots else { return HashMap::new() };
-    let Some(packages) = packages else { return HashMap::new() };
+    let empty_packages = HashMap::new();
+    let empty_snapshots = HashMap::new();
+    let packages = lockfile.packages.as_ref().unwrap_or(&empty_packages);
+    let snapshots = lockfile.snapshots.as_ref().unwrap_or(&empty_snapshots);
 
     let mut importer_ids: Vec<String> = if recursive {
         lockfile.importers.keys().cloned().collect()
@@ -136,16 +139,18 @@ fn check_peer_dependencies_from_lockfile(
     };
     importer_ids.sort();
 
-    let mut result: IssuesByProjects = HashMap::new();
+    let mut result: IssuesByProjects = BTreeMap::new();
+    // Shared across importers so each package is evaluated once, matching
+    // pnpm's lockfile walker, which threads one `walked` set through every
+    // importer's step.
+    let mut visited_packages = HashSet::new();
 
     for importer_id in &importer_ids {
-        let Some(_importer) = lockfile.importers.get(importer_id.as_str()) else { continue };
-
         let mut issues = PeerIssues {
-            bad: HashMap::new(),
-            missing: HashMap::new(),
+            bad: BTreeMap::new(),
+            missing: BTreeMap::new(),
             conflicts: Vec::new(),
-            intersections: HashMap::new(),
+            intersections: BTreeMap::new(),
         };
 
         let mut initial_keys = Vec::new();
@@ -160,7 +165,14 @@ fn check_peer_dependencies_from_lockfile(
             &mut issues,
         );
 
-        walk_snapshot(initial_keys, snapshots, packages, lockfile_dir, &mut issues);
+        walk_snapshot(
+            initial_keys,
+            snapshots,
+            packages,
+            lockfile_dir,
+            &mut visited_packages,
+            &mut issues,
+        );
 
         let merged = merge_missing_peers(&issues.missing);
         issues.conflicts = merged.conflicts;
@@ -193,8 +205,15 @@ fn path_is_within(path: &std::path::Path, base: &std::path::Path) -> bool {
     canonical_path.starts_with(&canonical_base)
 }
 
-fn resolve_link_version(lockfile_dir: &std::path::Path, link_target: &str) -> Option<String> {
-    let target_dir = lockfile_dir.join(link_target);
+/// `base_dir` is the directory the `link:` target is relative to — the
+/// importer's directory for importer dependencies, the lockfile directory for
+/// snapshot dependencies. Targets escaping `lockfile_dir` are rejected.
+fn resolve_link_version(
+    base_dir: &std::path::Path,
+    lockfile_dir: &std::path::Path,
+    link_target: &str,
+) -> Option<String> {
+    let target_dir = base_dir.join(link_target);
     if !path_is_within(&target_dir, lockfile_dir) {
         return None;
     }
@@ -217,7 +236,8 @@ fn check_linked_package_peers(
     lockfile_dir: &std::path::Path,
     issues: &mut PeerIssues,
 ) {
-    let linked_pkg_dir = lockfile_dir.join(importer_id).join(link_target);
+    let importer_dir = lockfile_dir.join(importer_id);
+    let linked_pkg_dir = importer_dir.join(link_target);
     if !path_is_within(&linked_pkg_dir, lockfile_dir) {
         return;
     }
@@ -268,8 +288,9 @@ fn check_linked_package_peers(
                         });
                     }
                 } else if let Some(link_target) = spec.version.as_link_target() {
-                    let found_version = resolve_link_version(lockfile_dir, link_target)
-                        .unwrap_or_else(|| format!("link:{link_target}"));
+                    let found_version =
+                        resolve_link_version(&importer_dir, lockfile_dir, link_target)
+                            .unwrap_or_else(|| format!("link:{link_target}"));
                     if !satisfies(&found_version, peer_range) {
                         issues.bad.entry(peer_name.clone()).or_default().push(BadPeerIssue {
                             parents: current_parents.clone(),
@@ -307,20 +328,18 @@ fn collect_initial_keys(
         return;
     }
     let Some(importer) = lockfile.importers.get(importer_id) else { return };
+    let importer_dir = lockfile_dir.join(importer_id);
 
-    let groups = [
-        (&importer.dependencies, false),
-        (&importer.dev_dependencies, false),
-        (&importer.optional_dependencies, true),
-    ];
+    let groups =
+        [&importer.dependencies, &importer.dev_dependencies, &importer.optional_dependencies];
 
-    for (dep_map, _is_optional) in &groups {
+    for dep_map in groups {
         let Some(dep_map) = dep_map else { continue };
         for (alias, spec) in dep_map {
             if let Some(key) = spec.version.resolved_key(alias) {
                 initial_keys.push((key, parents.to_owned()));
             } else if let Some(link_target) = spec.version.as_link_target() {
-                let linked_version = resolve_link_version(lockfile_dir, link_target)
+                let linked_version = resolve_link_version(&importer_dir, lockfile_dir, link_target)
                     .unwrap_or_else(|| "0.0.0".to_string());
                 let mut next_parents = parents.to_owned();
                 next_parents
@@ -336,7 +355,7 @@ fn collect_initial_keys(
                     issues,
                 );
 
-                let linked_importer_path = lockfile_dir.join(importer_id).join(link_target);
+                let linked_importer_path = importer_dir.join(link_target);
                 if !path_is_within(&linked_importer_path, lockfile_dir) {
                     continue;
                 }
@@ -360,19 +379,21 @@ fn walk_snapshot(
     snapshots: &HashMap<PkgNameVerPeer, SnapshotEntry>,
     packages: &HashMap<PkgNameVerPeer, PackageMetadata>,
     lockfile_dir: &std::path::Path,
+    visited: &mut HashSet<PkgNameVerPeer>,
     issues: &mut PeerIssues,
 ) {
-    let mut visited = HashSet::new();
     let mut stack = initial_keys;
 
     while let Some((key, parents)) = stack.pop() {
+        if !visited.insert(key.clone()) {
+            continue;
+        }
         let pkg_name = key.name.to_string();
         let pkg_version = get_pkg_version(&key, packages);
 
         let mut current_parents = parents.clone();
         current_parents.push(ParentPkg { name: pkg_name, version: pkg_version });
 
-        // 1. Evaluate peer dependencies of the current package
         let base_key = key.without_peer();
         if let Some(meta) = packages.get(&base_key)
             && let Some(peers) = &meta.peer_dependencies
@@ -415,8 +436,9 @@ fn walk_snapshot(
                                 );
                             }
                         } else if let Some(link_target) = dep_ref.as_link_target() {
-                            let found_version = resolve_link_version(lockfile_dir, link_target)
-                                .unwrap_or_else(|| format!("link:{link_target}"));
+                            let found_version =
+                                resolve_link_version(lockfile_dir, lockfile_dir, link_target)
+                                    .unwrap_or_else(|| format!("link:{link_target}"));
                             if !satisfies(&found_version, peer_range) {
                                 issues.bad.entry(peer_name.clone()).or_default().push(
                                     BadPeerIssue {
@@ -445,12 +467,6 @@ fn walk_snapshot(
             }
         }
 
-        // 2. Only recurse if we haven't visited this node yet
-        if !visited.insert(key.clone()) {
-            continue;
-        }
-
-        // 3. Push children to stack
         if let Some(snapshot) = snapshots.get(&key) {
             let all_deps = snapshot
                 .dependencies
@@ -842,9 +858,9 @@ fn intersect_multiple_ranges(version_ranges: &[String]) -> Option<String> {
     )
 }
 
-fn merge_missing_peers(missing: &HashMap<String, Vec<MissingPeerIssue>>) -> MergeResult {
+fn merge_missing_peers(missing: &BTreeMap<String, Vec<MissingPeerIssue>>) -> MergeResult {
     let mut conflicts = Vec::new();
-    let mut intersections = HashMap::new();
+    let mut intersections = BTreeMap::new();
 
     for (peer_name, issues) in missing {
         if issues.iter().all(|issue| issue.optional) {
@@ -874,7 +890,7 @@ fn merge_missing_peers(missing: &HashMap<String, Vec<MissingPeerIssue>>) -> Merg
 
 struct MergeResult {
     conflicts: Vec<String>,
-    intersections: HashMap<String, String>,
+    intersections: BTreeMap<String, String>,
 }
 
 fn filter_peer_issues(
@@ -890,16 +906,15 @@ fn filter_peer_issues(
 
     let ignore_missing_pats = rules.ignore_missing.clone().unwrap_or_default();
     let allow_any_pats = rules.allow_any.clone().unwrap_or_default();
-    let allowed_versions_map: HashMap<String, String> =
-        rules.allowed_versions.clone().unwrap_or_default().into_iter().collect();
+    let allowed_versions_map = rules.allowed_versions.clone().unwrap_or_default();
 
     let (allow_all_matcher, allow_by_parent) = parse_allowed_versions(&allowed_versions_map);
     let ignore_missing_matcher = pacquet_config::matcher::create_matcher(&ignore_missing_pats);
     let allow_any_matcher_rule = pacquet_config::matcher::create_matcher(&allow_any_pats);
 
     for project_issues in issues.values_mut() {
-        let mut filtered_missing: HashMap<String, Vec<MissingPeerIssue>> = HashMap::new();
-        let mut filtered_bad: HashMap<String, Vec<BadPeerIssue>> = HashMap::new();
+        let mut filtered_missing: BTreeMap<String, Vec<MissingPeerIssue>> = BTreeMap::new();
+        let mut filtered_bad: BTreeMap<String, Vec<BadPeerIssue>> = BTreeMap::new();
 
         for (peer_name, peer_issues) in &project_issues.missing {
             if ignore_missing_matcher.matches(peer_name)
@@ -966,7 +981,7 @@ struct ParentRule {
 }
 
 fn parse_allowed_versions(
-    allowed: &HashMap<String, String>,
+    allowed: &BTreeMap<String, String>,
 ) -> (AllowAllMatcher, AllowByParentMatcher) {
     let mut match_all: HashMap<String, Vec<String>> = HashMap::new();
     let mut by_parent: AllowByParentMatcher = HashMap::new();
@@ -1039,8 +1054,7 @@ fn render_peer_issues(issues_by_projects: &IssuesByProjects) -> String {
 }
 
 fn format_required_by(issues: &[impl RequiredByIssue]) -> String {
-    let mut by_range: std::collections::BTreeMap<String, Vec<String>> =
-        std::collections::BTreeMap::new();
+    let mut by_range: BTreeMap<String, Vec<String>> = BTreeMap::new();
     for issue in issues {
         let declaring = issue.parents().last().cloned().unwrap_or_default();
         let pkg = if declaring.name.is_empty() {
@@ -1048,7 +1062,10 @@ fn format_required_by(issues: &[impl RequiredByIssue]) -> String {
         } else {
             format!("{}@{}", declaring.name, declaring.version)
         };
-        by_range.entry(issue.wanted_range().to_string()).or_default().push(pkg);
+        let pkgs = by_range.entry(issue.wanted_range().to_string()).or_default();
+        if !pkgs.contains(&pkg) {
+            pkgs.push(pkg);
+        }
     }
 
     let mut lines: Vec<String> = vec![format!("  {}", cyan("Wanted:"))];
@@ -1084,8 +1101,8 @@ impl RequiredByIssue for BadPeerIssue {
     }
 }
 
-fn group_by_found_version(issues: &[BadPeerIssue]) -> HashMap<String, Vec<BadPeerIssue>> {
-    let mut groups: HashMap<String, Vec<BadPeerIssue>> = HashMap::new();
+fn group_by_found_version(issues: &[BadPeerIssue]) -> BTreeMap<String, Vec<BadPeerIssue>> {
+    let mut groups: BTreeMap<String, Vec<BadPeerIssue>> = BTreeMap::new();
     for issue in issues {
         groups.entry(issue.found_version.clone()).or_default().push(issue.clone());
     }
@@ -1093,7 +1110,7 @@ fn group_by_found_version(issues: &[BadPeerIssue]) -> HashMap<String, Vec<BadPee
 }
 
 fn format_range(range: &str) -> String {
-    if range.contains(' ') || range == "*" { format!("\"{range}\"") } else { range.to_string() }
+    if range.contains(' ') || range == "*" { format!(r#""{range}""#) } else { range.to_string() }
 }
 
 fn bold(text: &str) -> String {
@@ -1108,7 +1125,7 @@ fn dim(text: &str) -> String {
 
 fn yellow_bright(text: &str) -> String {
     let cleaned = sanitize(text);
-    cleaned.as_ref().if_supports_color(Stream::Stdout, |t| t.yellow()).to_string()
+    cleaned.as_ref().if_supports_color(Stream::Stdout, |t| t.bright_yellow()).to_string()
 }
 
 fn red(text: &str) -> String {
@@ -1123,7 +1140,7 @@ fn cyan(text: &str) -> String {
 
 fn cyan_bright(text: &str) -> String {
     let cleaned = sanitize(text);
-    cleaned.as_ref().if_supports_color(Stream::Stdout, |t| t.cyan()).to_string()
+    cleaned.as_ref().if_supports_color(Stream::Stdout, |t| t.bright_cyan()).to_string()
 }
 
 #[cfg(test)]

--- a/pacquet/crates/cli/src/cli_args/peers.rs
+++ b/pacquet/crates/cli/src/cli_args/peers.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 
 use clap::Args;
 use miette::{Context, IntoDiagnostic};
@@ -8,6 +9,8 @@ use serde::Serialize;
 
 use pacquet_config::{Config, PeerDependencyRules};
 use pacquet_lockfile::{Lockfile, PackageMetadata, PkgName, PkgNameVerPeer, SnapshotEntry};
+use pacquet_package_manifest::PackageManifest;
+use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
 
 use crate::cli_args::sanitize::sanitize;
 
@@ -78,7 +81,12 @@ impl PeersArgs {
         .wrap_err("load lockfile")?;
 
         let Some(lockfile) = lockfile else {
-            println!("No lockfile found in {}", lockfile_dir.display());
+            if self.json {
+                println!("{{}}");
+            } else {
+                let dir_str = lockfile_dir.display().to_string();
+                println!("No lockfile found in {}", sanitize(&dir_str));
+            }
             return Ok(());
         };
 
@@ -119,16 +127,17 @@ fn check_peer_dependencies_from_lockfile(
     let Some(snapshots) = snapshots else { return HashMap::new() };
     let Some(packages) = packages else { return HashMap::new() };
 
-    let importer_ids: Vec<String> = if recursive || config_has_workspace(lockfile_dir, dir) {
+    let mut importer_ids: Vec<String> = if recursive {
         lockfile.importers.keys().cloned().collect()
     } else {
         vec![resolve_importer_id(lockfile_dir, dir)]
     };
+    importer_ids.sort();
 
     let mut result: IssuesByProjects = HashMap::new();
 
     for importer_id in &importer_ids {
-        let Some(importer) = lockfile.importers.get(importer_id.as_str()) else { continue };
+        let Some(_importer) = lockfile.importers.get(importer_id.as_str()) else { continue };
 
         let mut issues = PeerIssues {
             bad: HashMap::new(),
@@ -137,22 +146,19 @@ fn check_peer_dependencies_from_lockfile(
             intersections: HashMap::new(),
         };
 
-        let mut visited = HashSet::new();
+        let mut initial_keys = Vec::new();
+        let mut visited_importers = HashSet::new();
+        collect_initial_keys(
+            importer_id,
+            lockfile,
+            lockfile_dir,
+            Vec::new(),
+            &mut initial_keys,
+            &mut visited_importers,
+            &mut issues,
+        );
 
-        let groups = [
-            (&importer.dependencies, false),
-            (&importer.dev_dependencies, false),
-            (&importer.optional_dependencies, true),
-        ];
-
-        for (dep_map, _is_optional) in &groups {
-            let Some(dep_map) = dep_map else { continue };
-            for (alias, spec) in dep_map {
-                if let Some(key) = spec.version.resolved_key(alias) {
-                    walk_snapshot(&key, snapshots, packages, &[], &mut issues, &mut visited);
-                }
-            }
-        }
+        walk_snapshot(initial_keys, snapshots, packages, lockfile_dir, &mut issues);
 
         let merged = merge_missing_peers(&issues.missing);
         issues.conflicts = merged.conflicts;
@@ -162,10 +168,6 @@ fn check_peer_dependencies_from_lockfile(
     }
 
     result
-}
-
-fn config_has_workspace(lockfile_dir: &std::path::Path, dir: &std::path::Path) -> bool {
-    lockfile_dir != dir || lockfile_dir.parent().is_none()
 }
 
 fn resolve_importer_id(lockfile_dir: &std::path::Path, dir: &std::path::Path) -> String {
@@ -180,95 +182,251 @@ fn resolve_importer_id(lockfile_dir: &std::path::Path, dir: &std::path::Path) ->
     }
 }
 
-fn walk_snapshot(
-    key: &PkgNameVerPeer,
-    snapshots: &HashMap<PkgNameVerPeer, SnapshotEntry>,
-    packages: &HashMap<PkgNameVerPeer, PackageMetadata>,
-    parents: &[ParentPkg],
-    issues: &mut PeerIssues,
-    visited: &mut HashSet<PkgNameVerPeer>,
-) {
-    if !visited.insert(key.clone()) {
-        return;
+fn resolve_link_version(lockfile_dir: &std::path::Path, link_target: &str) -> Option<String> {
+    let manifest_path = lockfile_dir.join(link_target).join("package.json");
+    if let Ok(manifest) = PackageManifest::from_path(manifest_path) {
+        if let Some(ver) = manifest.value().get("version").and_then(|v| v.as_str()) {
+            return Some(ver.to_string());
+        }
     }
+    None
+}
 
-    let Some(snapshot) = snapshots.get(key) else { return };
+fn check_linked_package_peers(
+    importer_id: &str,
+    importer: &pacquet_lockfile::ProjectSnapshot,
+    link_target: &str,
+    alias: &str,
+    linked_version: &str,
+    lockfile_dir: &std::path::Path,
+    issues: &mut PeerIssues,
+) {
+    let linked_pkg_dir = lockfile_dir.join(importer_id).join(link_target);
+    let manifest_path = linked_pkg_dir.join("package.json");
+    let Ok(manifest) = PackageManifest::from_path(manifest_path) else { return };
+    let Some(peer_deps) = manifest.value().get("peerDependencies").and_then(|v| v.as_object()) else { return };
 
-    let pkg_name = key.name.to_string();
-    let pkg_version = get_pkg_version(key, packages);
+    let current_parents = vec![ParentPkg {
+        name: alias.to_string(),
+        version: linked_version.to_string(),
+    }];
 
-    let mut current_parents = parents.to_vec();
-    current_parents.push(ParentPkg { name: pkg_name, version: pkg_version });
+    for (peer_name, peer_range_val) in peer_deps {
+        let Some(peer_range) = peer_range_val.as_str() else { continue };
+        let is_optional = manifest
+            .value()
+            .get("peerDependenciesMeta")
+            .and_then(|m| m.get(peer_name))
+            .and_then(|m| m.get("optional"))
+            .and_then(|o| o.as_bool())
+            .unwrap_or(false);
 
-    let base_key = key.without_peer();
-    if let Some(meta) = packages.get(&base_key)
-        && let Some(peers) = &meta.peer_dependencies
-    {
-        for (peer_name, peer_range) in peers {
-            let is_optional = meta
-                .peer_dependencies_meta
-                .as_ref()
-                .and_then(|m| m.get(peer_name))
-                .is_some_and(|m| m.optional);
+        let Ok(peer_pkg_name) = peer_name.parse::<PkgName>() else { continue };
+        let resolved_ref = importer.dependencies.as_ref().and_then(|d| d.get(&peer_pkg_name))
+            .or_else(|| importer.dev_dependencies.as_ref().and_then(|d| d.get(&peer_pkg_name)))
+            .or_else(|| importer.optional_dependencies.as_ref().and_then(|d| d.get(&peer_pkg_name)));
 
-            let Ok(peer_pkg_name) = peer_name.parse::<PkgName>() else { continue };
-            let resolved_ref =
-                snapshot.dependencies.as_ref().and_then(|deps| deps.get(&peer_pkg_name)).or_else(
-                    || {
-                        snapshot
-                            .optional_dependencies
-                            .as_ref()
-                            .and_then(|deps| deps.get(&peer_pkg_name))
-                    },
-                );
-
-            match resolved_ref {
-                Some(dep_ref) => {
-                    if let Some(ver_peer) = dep_ref.ver_peer() {
-                        let version_str = ver_peer.version().to_string();
-                        if !satisfies(&version_str, peer_range) {
-                            issues.bad.entry(peer_name.clone()).or_default().push(BadPeerIssue {
-                                parents: current_parents.clone(),
-                                optional: is_optional,
-                                wanted_range: peer_range.clone(),
-                                found_version: version_str,
-                                resolved_from: Vec::new(),
-                            });
-                        }
-                    } else if let Some(link_target) = dep_ref.as_link_target() {
+        match resolved_ref {
+            Some(spec) => {
+                if let Some(ver_peer) = spec.version.ver_peer() {
+                    let version_str = ver_peer.version().to_string();
+                    if !satisfies(&version_str, peer_range) {
                         issues.bad.entry(peer_name.clone()).or_default().push(BadPeerIssue {
                             parents: current_parents.clone(),
                             optional: is_optional,
-                            wanted_range: peer_range.clone(),
-                            found_version: format!("link:{link_target}"),
+                            wanted_range: peer_range.to_string(),
+                            found_version: version_str,
+                            resolved_from: Vec::new(),
+                        });
+                    }
+                } else if let Some(link_target) = spec.version.as_link_target() {
+                    let found_version = resolve_link_version(lockfile_dir, link_target)
+                        .unwrap_or_else(|| format!("link:{link_target}"));
+                    if !satisfies(&found_version, peer_range) {
+                        issues.bad.entry(peer_name.clone()).or_default().push(BadPeerIssue {
+                            parents: current_parents.clone(),
+                            optional: is_optional,
+                            wanted_range: peer_range.to_string(),
+                            found_version,
                             resolved_from: Vec::new(),
                         });
                     }
                 }
-                None => {
-                    if !is_optional {
-                        issues.missing.entry(peer_name.clone()).or_default().push(
-                            MissingPeerIssue {
-                                parents: current_parents.clone(),
-                                optional: is_optional,
-                                wanted_range: peer_range.clone(),
-                            },
-                        );
-                    }
+            }
+            None => {
+                if !is_optional {
+                    issues.missing.entry(peer_name.clone()).or_default().push(MissingPeerIssue {
+                        parents: current_parents.clone(),
+                        optional: is_optional,
+                        wanted_range: peer_range.to_string(),
+                    });
                 }
             }
         }
     }
+}
 
-    let all_deps = snapshot
-        .dependencies
-        .iter()
-        .flat_map(|d| d.iter())
-        .chain(snapshot.optional_dependencies.iter().flat_map(|d| d.iter()));
+fn collect_initial_keys(
+    importer_id: &str,
+    lockfile: &Lockfile,
+    lockfile_dir: &std::path::Path,
+    parents: Vec<ParentPkg>,
+    initial_keys: &mut Vec<(PkgNameVerPeer, Vec<ParentPkg>)>,
+    visited_importers: &mut HashSet<String>,
+    issues: &mut PeerIssues,
+) {
+    if !visited_importers.insert(importer_id.to_string()) {
+        return;
+    }
+    let Some(importer) = lockfile.importers.get(importer_id) else { return };
 
-    for (alias, dep_ref) in all_deps {
-        if let Some(child_key) = dep_ref.resolve(alias) {
-            walk_snapshot(&child_key, snapshots, packages, &current_parents, issues, visited);
+    let groups = [
+        (&importer.dependencies, false),
+        (&importer.dev_dependencies, false),
+        (&importer.optional_dependencies, true),
+    ];
+
+    for (dep_map, _is_optional) in &groups {
+        let Some(dep_map) = dep_map else { continue };
+        for (alias, spec) in dep_map {
+            if let Some(key) = spec.version.resolved_key(alias) {
+                initial_keys.push((key, parents.clone()));
+            } else if let Some(link_target) = spec.version.as_link_target() {
+                let linked_version = resolve_link_version(lockfile_dir, link_target)
+                    .unwrap_or_else(|| "0.0.0".to_string());
+                let mut next_parents = parents.clone();
+                next_parents.push(ParentPkg {
+                    name: alias.to_string(),
+                    version: linked_version.clone(),
+                });
+
+                check_linked_package_peers(
+                    importer_id,
+                    importer,
+                    link_target,
+                    &alias.to_string(),
+                    &linked_version,
+                    lockfile_dir,
+                    issues,
+                );
+
+                let linked_importer_path = lockfile_dir.join(importer_id).join(link_target);
+                let linked_importer_id = resolve_importer_id(lockfile_dir, &linked_importer_path);
+                collect_initial_keys(
+                    &linked_importer_id,
+                    lockfile,
+                    lockfile_dir,
+                    next_parents,
+                    initial_keys,
+                    visited_importers,
+                    issues,
+                );
+            }
+        }
+    }
+}
+
+fn walk_snapshot(
+    initial_keys: Vec<(PkgNameVerPeer, Vec<ParentPkg>)>,
+    snapshots: &HashMap<PkgNameVerPeer, SnapshotEntry>,
+    packages: &HashMap<PkgNameVerPeer, PackageMetadata>,
+    lockfile_dir: &std::path::Path,
+    issues: &mut PeerIssues,
+) {
+    let mut visited = HashSet::new();
+    let mut stack = initial_keys;
+
+    while let Some((key, parents)) = stack.pop() {
+        let pkg_name = key.name.to_string();
+        let pkg_version = get_pkg_version(&key, packages);
+
+        let mut current_parents = parents.clone();
+        current_parents.push(ParentPkg { name: pkg_name, version: pkg_version });
+
+        // 1. Evaluate peer dependencies of the current package
+        let base_key = key.without_peer();
+        if let Some(meta) = packages.get(&base_key)
+            && let Some(peers) = &meta.peer_dependencies
+        {
+            let snapshot = snapshots.get(&key);
+            for (peer_name, peer_range) in peers {
+                let is_optional = meta
+                    .peer_dependencies_meta
+                    .as_ref()
+                    .and_then(|m| m.get(peer_name))
+                    .is_some_and(|m| m.optional);
+
+                let Ok(peer_pkg_name) = peer_name.parse::<PkgName>() else { continue };
+                let resolved_ref = snapshot.and_then(|s| {
+                    s.dependencies.as_ref().and_then(|deps| deps.get(&peer_pkg_name)).or_else(
+                        || {
+                            s.optional_dependencies
+                                .as_ref()
+                                .and_then(|deps| deps.get(&peer_pkg_name))
+                        },
+                    )
+                });
+
+                match resolved_ref {
+                    Some(dep_ref) => {
+                        if let Some(ver_peer) = dep_ref.ver_peer() {
+                            let version_str = ver_peer.version().to_string();
+                            if !satisfies(&version_str, peer_range) {
+                                issues.bad.entry(peer_name.clone()).or_default().push(BadPeerIssue {
+                                    parents: current_parents.clone(),
+                                    optional: is_optional,
+                                    wanted_range: peer_range.clone(),
+                                    found_version: version_str,
+                                    resolved_from: Vec::new(),
+                                });
+                            }
+                        } else if let Some(link_target) = dep_ref.as_link_target() {
+                            let found_version = resolve_link_version(lockfile_dir, link_target)
+                                .unwrap_or_else(|| format!("link:{link_target}"));
+                            if !satisfies(&found_version, peer_range) {
+                                issues.bad.entry(peer_name.clone()).or_default().push(BadPeerIssue {
+                                    parents: current_parents.clone(),
+                                    optional: is_optional,
+                                    wanted_range: peer_range.clone(),
+                                    found_version,
+                                    resolved_from: Vec::new(),
+                                });
+                            }
+                        }
+                    }
+                    None => {
+                        if !is_optional {
+                            issues.missing.entry(peer_name.clone()).or_default().push(
+                                MissingPeerIssue {
+                                    parents: current_parents.clone(),
+                                    optional: is_optional,
+                                    wanted_range: peer_range.clone(),
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        // 2. Only recurse if we haven't visited this node yet
+        if !visited.insert(key.clone()) {
+            continue;
+        }
+
+        // 3. Push children to stack
+        if let Some(snapshot) = snapshots.get(&key) {
+            let all_deps = snapshot
+                .dependencies
+                .iter()
+                .flat_map(|d| d.iter())
+                .chain(snapshot.optional_dependencies.iter().flat_map(|d| d.iter()));
+
+            for (alias, dep_ref) in all_deps {
+                if let Some(child_key) = dep_ref.resolve(alias) {
+                    stack.push((child_key, current_parents.clone()));
+                }
+            }
         }
     }
 }
@@ -310,6 +468,289 @@ fn satisfies(version: &str, range: &str) -> bool {
     base.satisfies(&parsed_range)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Bound<V> {
+    Inclusive(V),
+    Exclusive(V),
+    Unbounded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Interval {
+    lower: Bound<Version>,
+    upper: Bound<Version>,
+}
+
+impl fmt::Display for Interval {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (&self.lower, &self.upper) {
+            (Bound::Unbounded, Bound::Unbounded) => write!(f, "*"),
+            (Bound::Inclusive(vl), Bound::Unbounded) => write!(f, ">={vl}"),
+            (Bound::Exclusive(vl), Bound::Unbounded) => write!(f, ">{vl}"),
+            (Bound::Unbounded, Bound::Inclusive(vu)) => write!(f, "<={vu}"),
+            (Bound::Unbounded, Bound::Exclusive(vu)) => write!(f, "<{vu}"),
+            (Bound::Inclusive(vl), Bound::Inclusive(vu)) => {
+                if vl == vu {
+                    write!(f, "{vl}")
+                } else {
+                    write!(f, ">={vl} <={vu}")
+                }
+            }
+            (Bound::Inclusive(vl), Bound::Exclusive(vu)) => {
+                write!(f, ">={vl} <{vu}")
+            }
+            (Bound::Exclusive(vl), Bound::Inclusive(vu)) => {
+                write!(f, ">{vl} <={vu}")
+            }
+            (Bound::Exclusive(vl), Bound::Exclusive(vu)) => {
+                write!(f, ">{vl} <{vu}")
+            }
+        }
+    }
+}
+
+fn max_lower(a: &Bound<Version>, b: &Bound<Version>) -> Bound<Version> {
+    match (a, b) {
+        (Bound::Unbounded, other) | (other, Bound::Unbounded) => other.clone(),
+        (Bound::Inclusive(v1), Bound::Inclusive(v2)) => {
+            if v1 >= v2 { Bound::Inclusive(v1.clone()) } else { Bound::Inclusive(v2.clone()) }
+        }
+        (Bound::Exclusive(v1), Bound::Exclusive(v2)) => {
+            if v1 >= v2 { Bound::Exclusive(v1.clone()) } else { Bound::Exclusive(v2.clone()) }
+        }
+        (Bound::Inclusive(v1), Bound::Exclusive(v2)) => {
+            if v1 > v2 { Bound::Inclusive(v1.clone()) } else { Bound::Exclusive(v2.clone()) }
+        }
+        (Bound::Exclusive(v1), Bound::Inclusive(v2)) => {
+            if v1 >= v2 { Bound::Exclusive(v1.clone()) } else { Bound::Inclusive(v2.clone()) }
+        }
+    }
+}
+
+fn min_upper(a: &Bound<Version>, b: &Bound<Version>) -> Bound<Version> {
+    match (a, b) {
+        (Bound::Unbounded, other) | (other, Bound::Unbounded) => other.clone(),
+        (Bound::Inclusive(v1), Bound::Inclusive(v2)) => {
+            if v1 <= v2 { Bound::Inclusive(v1.clone()) } else { Bound::Inclusive(v2.clone()) }
+        }
+        (Bound::Exclusive(v1), Bound::Exclusive(v2)) => {
+            if v1 <= v2 { Bound::Exclusive(v1.clone()) } else { Bound::Exclusive(v2.clone()) }
+        }
+        (Bound::Inclusive(v1), Bound::Exclusive(v2)) => {
+            if v1 < v2 { Bound::Inclusive(v1.clone()) } else { Bound::Exclusive(v2.clone()) }
+        }
+        (Bound::Exclusive(v1), Bound::Inclusive(v2)) => {
+            if v1 <= v2 { Bound::Exclusive(v1.clone()) } else { Bound::Inclusive(v2.clone()) }
+        }
+    }
+}
+
+fn is_valid_interval(lower: &Bound<Version>, upper: &Bound<Version>) -> bool {
+    match (lower, upper) {
+        (Bound::Unbounded, _) | (_, Bound::Unbounded) => true,
+        (Bound::Inclusive(v1), Bound::Inclusive(v2)) => v1 <= v2,
+        (Bound::Inclusive(v1), Bound::Exclusive(v2)) => v1 < v2,
+        (Bound::Exclusive(v1), Bound::Inclusive(v2)) => v1 < v2,
+        (Bound::Exclusive(v1), Bound::Exclusive(v2)) => v1 < v2,
+    }
+}
+
+fn normalize_version_str(v: &str) -> String {
+    let v = v.trim();
+    let parts: Vec<&str> = v.split('.').collect();
+    match parts.len() {
+        1 => {
+            let p = parts[0].replace(['x', 'X', '*'], "0");
+            if p.chars().all(|c| c.is_ascii_digit()) {
+                format!("{p}.0.0")
+            } else {
+                v.to_string()
+            }
+        }
+        2 => {
+            let p0 = parts[0].replace(['x', 'X', '*'], "0");
+            let p1 = parts[1].replace(['x', 'X', '*'], "0");
+            if p0.chars().all(|c| c.is_ascii_digit()) && p1.chars().all(|c| c.is_ascii_digit()) {
+                format!("{p0}.{p1}.0")
+            } else {
+                v.to_string()
+            }
+        }
+        _ => {
+            let p0 = parts[0].replace(['x', 'X', '*'], "0");
+            let p1 = parts[1].replace(['x', 'X', '*'], "0");
+            let p2 = parts[2].replace(['x', 'X', '*'], "0");
+            if p0.chars().all(|c| c.is_ascii_digit()) && p1.chars().all(|c| c.is_ascii_digit()) && p2.chars().all(|c| c.is_ascii_digit()) {
+                let rest = if parts.len() > 3 {
+                    format!(".{}", parts[3..].join("."))
+                } else {
+                    "".to_string()
+                };
+                format!("{p0}.{p1}.{p2}{rest}")
+            } else {
+                v.to_string()
+            }
+        }
+    }
+}
+
+fn parse_comparator(comp: &str) -> Option<Interval> {
+    let comp = comp.trim();
+    if comp == "*" || comp.is_empty() {
+        return Some(Interval { lower: Bound::Unbounded, upper: Bound::Unbounded });
+    }
+
+    let (op, ver_str) = if let Some(rest) = comp.strip_prefix(">=") {
+        ("=>", rest)
+    } else if let Some(rest) = comp.strip_prefix('>') {
+        (">", rest)
+    } else if let Some(rest) = comp.strip_prefix("<=") {
+        ("<=", rest)
+    } else if let Some(rest) = comp.strip_prefix('<') {
+        ("<", rest)
+    } else if let Some(rest) = comp.strip_prefix('^') {
+        ("^", rest)
+    } else if let Some(rest) = comp.strip_prefix('~') {
+        ("~", rest)
+    } else {
+        ("=", comp)
+    };
+
+    let normalized = normalize_version_str(ver_str);
+    let version = Version::parse(&normalized).ok()?;
+
+    match op {
+        "=" => Some(Interval {
+            lower: Bound::Inclusive(version.clone()),
+            upper: Bound::Inclusive(version),
+        }),
+        "=>" => Some(Interval {
+            lower: Bound::Inclusive(version),
+            upper: Bound::Unbounded,
+        }),
+        ">" => Some(Interval {
+            lower: Bound::Exclusive(version),
+            upper: Bound::Unbounded,
+        }),
+        "<=" => Some(Interval {
+            lower: Bound::Unbounded,
+            upper: Bound::Inclusive(version),
+        }),
+        "<" => Some(Interval {
+            lower: Bound::Unbounded,
+            upper: Bound::Exclusive(version),
+        }),
+        "^" => {
+            let upper_version = if version.major > 0 {
+                Version { major: version.major + 1, minor: 0, patch: 0, build: Vec::new(), pre_release: Vec::new() }
+            } else if version.minor > 0 {
+                Version { major: 0, minor: version.minor + 1, patch: 0, build: Vec::new(), pre_release: Vec::new() }
+            } else {
+                Version { major: 0, minor: 0, patch: version.patch + 1, build: Vec::new(), pre_release: Vec::new() }
+            };
+            Some(Interval {
+                lower: Bound::Inclusive(version),
+                upper: Bound::Exclusive(upper_version),
+            })
+        }
+        "~" => {
+            let upper_version = Version {
+                major: version.major,
+                minor: version.minor + 1,
+                patch: 0,
+                build: Vec::new(),
+                pre_release: Vec::new(),
+            };
+            Some(Interval {
+                lower: Bound::Inclusive(version),
+                upper: Bound::Exclusive(upper_version),
+            })
+        }
+        _ => None,
+    }
+}
+
+fn preprocess_hyphen_ranges(range: &str) -> String {
+    let mut parts = Vec::new();
+    for part in range.split("||") {
+        let part = part.trim();
+        if let Some((start, end)) = part.split_once(" - ") {
+            parts.push(format!(">={} <={}", start.trim(), end.trim()));
+        } else {
+            parts.push(part.to_string());
+        }
+    }
+    parts.join(" || ")
+}
+
+fn parse_range_to_intervals(range: &str) -> Option<Vec<Interval>> {
+    let mut intervals = Vec::new();
+    for part in range.split("||") {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let mut part_interval = Interval {
+            lower: Bound::Unbounded,
+            upper: Bound::Unbounded,
+        };
+        for comp in part.split_whitespace() {
+            let comp_interval = parse_comparator(comp)?;
+            let lower = max_lower(&part_interval.lower, &comp_interval.lower);
+            let upper = min_upper(&part_interval.upper, &comp_interval.upper);
+            if !is_valid_interval(&lower, &upper) {
+                part_interval = Interval {
+                    lower: Bound::Inclusive(Version::parse("0.0.0").unwrap()),
+                    upper: Bound::Exclusive(Version::parse("0.0.0").unwrap()),
+                };
+                break;
+            }
+            part_interval = Interval { lower, upper };
+        }
+        if is_valid_interval(&part_interval.lower, &part_interval.upper) {
+            intervals.push(part_interval);
+        }
+    }
+    if intervals.is_empty() {
+        None
+    } else {
+        Some(intervals)
+    }
+}
+
+fn intersect_intervals(a: &[Interval], b: &[Interval]) -> Vec<Interval> {
+    let mut result = Vec::new();
+    for i in a {
+        for j in b {
+            let lower = max_lower(&i.lower, &j.lower);
+            let upper = min_upper(&i.upper, &j.upper);
+            if is_valid_interval(&lower, &upper) {
+                result.push(Interval { lower, upper });
+            }
+        }
+    }
+    result
+}
+
+fn intersect_multiple_ranges(ranges: &[String]) -> Option<String> {
+    if ranges.is_empty() {
+        return Some("*".to_string());
+    }
+    let mut current_intervals = parse_range_to_intervals(&preprocess_hyphen_ranges(&ranges[0]))?;
+    for range in &ranges[1..] {
+        let next_intervals = parse_range_to_intervals(&preprocess_hyphen_ranges(range))?;
+        current_intervals = intersect_intervals(&current_intervals, &next_intervals);
+        if current_intervals.is_empty() {
+            return None;
+        }
+    }
+    Some(current_intervals.iter().map(|i| i.to_string()).collect::<Vec<_>>().join(" || "))
+}
+
+fn have_common_version(ranges: &[String]) -> bool {
+    intersect_multiple_ranges(ranges).is_some()
+}
+
 fn merge_missing_peers(missing: &HashMap<String, Vec<MissingPeerIssue>>) -> MergeResult {
     let mut conflicts = Vec::new();
     let mut intersections = HashMap::new();
@@ -329,8 +770,8 @@ fn merge_missing_peers(missing: &HashMap<String, Vec<MissingPeerIssue>>) -> Merg
             continue;
         }
         let range_owned: Vec<String> = issues.iter().map(|i| i.wanted_range.clone()).collect();
-        if have_common_version(&range_owned) {
-            intersections.insert(peer_name.clone(), issues[0].wanted_range.clone());
+        if let Some(intersection_str) = intersect_multiple_ranges(&range_owned) {
+            intersections.insert(peer_name.clone(), intersection_str);
         } else {
             conflicts.push(peer_name.clone());
         }
@@ -342,53 +783,6 @@ fn merge_missing_peers(missing: &HashMap<String, Vec<MissingPeerIssue>>) -> Merg
 struct MergeResult {
     conflicts: Vec<String>,
     intersections: HashMap<String, String>,
-}
-
-fn have_common_version(ranges: &[String]) -> bool {
-    if ranges.len() <= 1 {
-        return true;
-    }
-
-    let candidate_versions: Vec<String> =
-        ranges.iter().filter_map(|r| extract_candidate_version(r)).collect();
-
-    if candidate_versions.is_empty() {
-        return false;
-    }
-
-    for ver_str in &candidate_versions {
-        if ranges.iter().all(|range| satisfies(ver_str, range)) {
-            return true;
-        }
-    }
-
-    false
-}
-
-fn extract_candidate_version(range_str: &str) -> Option<String> {
-    for segment in range_str.split("||") {
-        let segment = segment.trim();
-        let cleaned = segment
-            .strip_prefix(">=")
-            .or_else(|| segment.strip_prefix('>'))
-            .or_else(|| segment.strip_prefix("<="))
-            .or_else(|| segment.strip_prefix('<'))
-            .or_else(|| segment.strip_prefix('^'))
-            .or_else(|| segment.strip_prefix('~'))
-            .unwrap_or(segment)
-            .trim();
-
-        let cleaned =
-            if let Some((start, _)) = cleaned.split_once(" - ") { start.trim() } else { cleaned };
-
-        let first_word = cleaned.split_whitespace().next().unwrap_or(cleaned);
-        let normalized = first_word.replace(['x', 'X'], "0");
-
-        if normalized != "*" && !normalized.is_empty() && Version::parse(&normalized).is_ok() {
-            return Some(normalized);
-        }
-    }
-    None
 }
 
 fn filter_peer_issues(
@@ -408,26 +802,24 @@ fn filter_peer_issues(
         rules.allowed_versions.clone().unwrap_or_default().into_iter().collect();
 
     let (allow_all_matcher, allow_by_parent) = parse_allowed_versions(&allowed_versions_map);
+    let ignore_missing_matcher = pacquet_config::matcher::create_matcher(&ignore_missing_pats);
+    let allow_any_matcher_rule = pacquet_config::matcher::create_matcher(&allow_any_pats);
 
     for project_issues in issues.values_mut() {
         let mut filtered_missing: HashMap<String, Vec<MissingPeerIssue>> = HashMap::new();
         let mut filtered_bad: HashMap<String, Vec<BadPeerIssue>> = HashMap::new();
-        let mut filtered_intersections: HashMap<String, String> = HashMap::new();
 
         for (peer_name, peer_issues) in &project_issues.missing {
-            if ignore_missing_pats.iter().any(|pat| simple_glob_match(pat, peer_name))
+            if ignore_missing_matcher.matches(peer_name)
                 || peer_issues.iter().all(|i| i.optional)
             {
                 continue;
             }
             filtered_missing.insert(peer_name.clone(), peer_issues.clone());
-            if let Some(range) = project_issues.intersections.get(peer_name) {
-                filtered_intersections.insert(peer_name.clone(), range.clone());
-            }
         }
 
         for (peer_name, peer_issues) in &project_issues.bad {
-            if allow_any_pats.iter().any(|pat| simple_glob_match(pat, peer_name)) {
+            if allow_any_matcher_rule.matches(peer_name) {
                 continue;
             }
             let remaining: Vec<BadPeerIssue> = peer_issues
@@ -438,12 +830,22 @@ fn filter_peer_issues(
                     {
                         return false;
                     }
-                    if let Some(declaring_parent) = issue.parents.last()
-                        && let Some(parent_map) = allow_by_parent.get(&declaring_parent.name)
-                        && let Some(ranges) = parent_map.get(peer_name)
-                        && ranges.iter().any(|range| satisfies(&issue.found_version, range))
-                    {
-                        return false;
+                    if let Some(declaring_parent) = issue.parents.last() {
+                        if let Some(rules) = allow_by_parent.get(&declaring_parent.name) {
+                            for rule in rules {
+                                let range_matches = match &rule.parent_range {
+                                    Some(range) => satisfies(&declaring_parent.version, range),
+                                    None => true,
+                                };
+                                if range_matches {
+                                    if let Some(ranges) = rule.peer_rules.get(peer_name) {
+                                        if ranges.iter().any(|range| satisfies(&issue.found_version, range)) {
+                                            return false;
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                     true
                 })
@@ -456,68 +858,56 @@ fn filter_peer_issues(
 
         project_issues.missing = filtered_missing;
         project_issues.bad = filtered_bad;
-        project_issues.intersections = filtered_intersections;
+        let merged = merge_missing_peers(&project_issues.missing);
+        project_issues.conflicts = merged.conflicts;
+        project_issues.intersections = merged.intersections;
     }
 
     issues
 }
 
 type AllowAllMatcher = HashMap<String, Vec<String>>;
-type AllowByParentMatcher = HashMap<String, HashMap<String, Vec<String>>>;
+type AllowByParentMatcher = HashMap<String, Vec<ParentRule>>;
+
+struct ParentRule {
+    parent_range: Option<String>,
+    peer_rules: HashMap<String, Vec<String>>,
+}
 
 fn parse_allowed_versions(
     allowed: &HashMap<String, String>,
 ) -> (AllowAllMatcher, AllowByParentMatcher) {
     let mut match_all: HashMap<String, Vec<String>> = HashMap::new();
-    let mut by_parent: HashMap<String, HashMap<String, Vec<String>>> = HashMap::new();
+    let mut by_parent: AllowByParentMatcher = HashMap::new();
 
     for (selector, spec) in allowed {
         if let Some((parent, target)) = selector.split_once('>') {
-            let parent_name = parent.trim().to_string();
-            let target_name = target.trim().to_string();
+            let parsed_parent = parse_wanted_dependency(parent.trim());
+            let parent_name = parsed_parent.alias.unwrap_or_else(|| parent.trim().to_string());
+            let parent_range = parsed_parent.bare_specifier;
+
+            let parsed_peer = parse_wanted_dependency(target.trim());
+            let peer_name = parsed_peer.alias.unwrap_or_else(|| target.trim().to_string());
+
             let ranges: Vec<String> = spec.split("||").map(|seg| seg.trim().to_string()).collect();
-            by_parent
-                .entry(parent_name)
-                .or_default()
-                .entry(target_name)
-                .or_default()
-                .extend(ranges);
-        } else {
-            let target_name = if let Some((name, _version)) = selector.split_once('@') {
-                name.to_string()
+
+            let parent_entry = by_parent.entry(parent_name).or_default();
+            if let Some(rule) = parent_entry.iter_mut().find(|r| r.parent_range == parent_range) {
+                rule.peer_rules.entry(peer_name).or_default().extend(ranges);
             } else {
-                selector.clone()
-            };
+                let mut peer_rules = HashMap::new();
+                peer_rules.insert(peer_name, ranges);
+                parent_entry.push(ParentRule { parent_range, peer_rules });
+            }
+        } else {
+            let parsed = parse_wanted_dependency(selector);
+            let target_name = parsed.alias.unwrap_or_else(|| selector.clone());
             let ranges: Vec<String> = spec.split("||").map(|seg| seg.trim().to_string()).collect();
             match_all.entry(target_name).or_default().extend(ranges);
         }
     }
 
     (match_all, by_parent)
-}
-
-fn simple_glob_match(pattern: &str, value: &str) -> bool {
-    if !pattern.contains('*') {
-        return pattern == value;
-    }
-    let segments: Vec<&str> = pattern.split('*').collect();
-    let mut rest = value;
-    for (i, segment) in segments.iter().enumerate() {
-        if segment.is_empty() {
-            continue;
-        }
-        if i == 0 {
-            let Some(stripped) = rest.strip_prefix(segment) else { return false };
-            rest = stripped;
-        } else if i == segments.len() - 1 {
-            return rest.ends_with(segment);
-        } else if let Some(pos) = rest.find(segment) {
-            rest = &rest[pos + segment.len()..];
-        } else {
-            return false;
-        }
-    }
-    true
 }
 
 fn render_peer_issues(issues_by_projects: &IssuesByProjects) -> String {

--- a/pacquet/crates/cli/src/cli_args/peers.rs
+++ b/pacquet/crates/cli/src/cli_args/peers.rs
@@ -184,9 +184,9 @@ fn resolve_importer_id(lockfile_dir: &std::path::Path, dir: &std::path::Path) ->
 
 fn resolve_link_version(lockfile_dir: &std::path::Path, link_target: &str) -> Option<String> {
     let manifest_path = lockfile_dir.join(link_target).join("package.json");
-    PackageManifest::from_path(manifest_path)
-        .ok()
-        .and_then(|manifest| manifest.value().get("version").and_then(|v| v.as_str()).map(String::from))
+    PackageManifest::from_path(manifest_path).ok().and_then(|manifest| {
+        manifest.value().get("version").and_then(|v| v.as_str()).map(String::from)
+    })
 }
 
 fn check_linked_package_peers(
@@ -201,12 +201,13 @@ fn check_linked_package_peers(
     let linked_pkg_dir = lockfile_dir.join(importer_id).join(link_target);
     let manifest_path = linked_pkg_dir.join("package.json");
     let Ok(manifest) = PackageManifest::from_path(manifest_path) else { return };
-    let Some(peer_deps) = manifest.value().get("peerDependencies").and_then(|v| v.as_object()) else { return };
+    let Some(peer_deps) = manifest.value().get("peerDependencies").and_then(|v| v.as_object())
+    else {
+        return;
+    };
 
-    let current_parents = vec![ParentPkg {
-        name: alias.to_string(),
-        version: linked_version.to_string(),
-    }];
+    let current_parents =
+        vec![ParentPkg { name: alias.to_string(), version: linked_version.to_string() }];
 
     for (peer_name, peer_range_val) in peer_deps {
         let Some(peer_range) = peer_range_val.as_str() else { continue };
@@ -219,9 +220,14 @@ fn check_linked_package_peers(
             .unwrap_or(false);
 
         let Ok(peer_pkg_name) = peer_name.parse::<PkgName>() else { continue };
-        let resolved_ref = importer.dependencies.as_ref().and_then(|d| d.get(&peer_pkg_name))
+        let resolved_ref = importer
+            .dependencies
+            .as_ref()
+            .and_then(|d| d.get(&peer_pkg_name))
             .or_else(|| importer.dev_dependencies.as_ref().and_then(|d| d.get(&peer_pkg_name)))
-            .or_else(|| importer.optional_dependencies.as_ref().and_then(|d| d.get(&peer_pkg_name)));
+            .or_else(|| {
+                importer.optional_dependencies.as_ref().and_then(|d| d.get(&peer_pkg_name))
+            });
 
         match resolved_ref {
             Some(spec) => {
@@ -292,10 +298,8 @@ fn collect_initial_keys(
                 let linked_version = resolve_link_version(lockfile_dir, link_target)
                     .unwrap_or_else(|| "0.0.0".to_string());
                 let mut next_parents = parents.to_owned();
-                next_parents.push(ParentPkg {
-                    name: alias.to_string(),
-                    version: linked_version.clone(),
-                });
+                next_parents
+                    .push(ParentPkg { name: alias.to_string(), version: linked_version.clone() });
 
                 check_linked_package_peers(
                     importer_id,
@@ -369,25 +373,29 @@ fn walk_snapshot(
                         if let Some(ver_peer) = dep_ref.ver_peer() {
                             let version_str = ver_peer.version().to_string();
                             if !satisfies(&version_str, peer_range) {
-                                issues.bad.entry(peer_name.clone()).or_default().push(BadPeerIssue {
-                                    parents: current_parents.clone(),
-                                    optional: is_optional,
-                                    wanted_range: peer_range.clone(),
-                                    found_version: version_str,
-                                    resolved_from: Vec::new(),
-                                });
+                                issues.bad.entry(peer_name.clone()).or_default().push(
+                                    BadPeerIssue {
+                                        parents: current_parents.clone(),
+                                        optional: is_optional,
+                                        wanted_range: peer_range.clone(),
+                                        found_version: version_str,
+                                        resolved_from: Vec::new(),
+                                    },
+                                );
                             }
                         } else if let Some(link_target) = dep_ref.as_link_target() {
                             let found_version = resolve_link_version(lockfile_dir, link_target)
                                 .unwrap_or_else(|| format!("link:{link_target}"));
                             if !satisfies(&found_version, peer_range) {
-                                issues.bad.entry(peer_name.clone()).or_default().push(BadPeerIssue {
-                                    parents: current_parents.clone(),
-                                    optional: is_optional,
-                                    wanted_range: peer_range.clone(),
-                                    found_version,
-                                    resolved_from: Vec::new(),
-                                });
+                                issues.bad.entry(peer_name.clone()).or_default().push(
+                                    BadPeerIssue {
+                                        parents: current_parents.clone(),
+                                        optional: is_optional,
+                                        wanted_range: peer_range.clone(),
+                                        found_version,
+                                        resolved_from: Vec::new(),
+                                    },
+                                );
                             }
                         }
                     }
@@ -510,16 +518,32 @@ fn max_lower(a: &Bound<Version>, b: &Bound<Version>) -> Bound<Version> {
     match (a, b) {
         (Bound::Unbounded, other) | (other, Bound::Unbounded) => other.clone(),
         (Bound::Inclusive(v1), Bound::Inclusive(v2)) => {
-            if v1 >= v2 { Bound::Inclusive(v1.clone()) } else { Bound::Inclusive(v2.clone()) }
+            if v1 >= v2 {
+                Bound::Inclusive(v1.clone())
+            } else {
+                Bound::Inclusive(v2.clone())
+            }
         }
         (Bound::Exclusive(v1), Bound::Exclusive(v2)) => {
-            if v1 >= v2 { Bound::Exclusive(v1.clone()) } else { Bound::Exclusive(v2.clone()) }
+            if v1 >= v2 {
+                Bound::Exclusive(v1.clone())
+            } else {
+                Bound::Exclusive(v2.clone())
+            }
         }
         (Bound::Inclusive(v1), Bound::Exclusive(v2)) => {
-            if v1 > v2 { Bound::Inclusive(v1.clone()) } else { Bound::Exclusive(v2.clone()) }
+            if v1 > v2 {
+                Bound::Inclusive(v1.clone())
+            } else {
+                Bound::Exclusive(v2.clone())
+            }
         }
         (Bound::Exclusive(v1), Bound::Inclusive(v2)) => {
-            if v1 >= v2 { Bound::Exclusive(v1.clone()) } else { Bound::Inclusive(v2.clone()) }
+            if v1 >= v2 {
+                Bound::Exclusive(v1.clone())
+            } else {
+                Bound::Inclusive(v2.clone())
+            }
         }
     }
 }
@@ -528,16 +552,32 @@ fn min_upper(a: &Bound<Version>, b: &Bound<Version>) -> Bound<Version> {
     match (a, b) {
         (Bound::Unbounded, other) | (other, Bound::Unbounded) => other.clone(),
         (Bound::Inclusive(v1), Bound::Inclusive(v2)) => {
-            if v1 <= v2 { Bound::Inclusive(v1.clone()) } else { Bound::Inclusive(v2.clone()) }
+            if v1 <= v2 {
+                Bound::Inclusive(v1.clone())
+            } else {
+                Bound::Inclusive(v2.clone())
+            }
         }
         (Bound::Exclusive(v1), Bound::Exclusive(v2)) => {
-            if v1 <= v2 { Bound::Exclusive(v1.clone()) } else { Bound::Exclusive(v2.clone()) }
+            if v1 <= v2 {
+                Bound::Exclusive(v1.clone())
+            } else {
+                Bound::Exclusive(v2.clone())
+            }
         }
         (Bound::Inclusive(v1), Bound::Exclusive(v2)) => {
-            if v1 < v2 { Bound::Inclusive(v1.clone()) } else { Bound::Exclusive(v2.clone()) }
+            if v1 < v2 {
+                Bound::Inclusive(v1.clone())
+            } else {
+                Bound::Exclusive(v2.clone())
+            }
         }
         (Bound::Exclusive(v1), Bound::Inclusive(v2)) => {
-            if v1 <= v2 { Bound::Exclusive(v1.clone()) } else { Bound::Inclusive(v2.clone()) }
+            if v1 <= v2 {
+                Bound::Exclusive(v1.clone())
+            } else {
+                Bound::Inclusive(v2.clone())
+            }
         }
     }
 }
@@ -558,11 +598,7 @@ fn normalize_version_str(v: &str) -> String {
     match parts.len() {
         1 => {
             let p = parts[0].replace(['x', 'X', '*'], "0");
-            if p.chars().all(|c| c.is_ascii_digit()) {
-                format!("{p}.0.0")
-            } else {
-                v.to_string()
-            }
+            if p.chars().all(|c| c.is_ascii_digit()) { format!("{p}.0.0") } else { v.to_string() }
         }
         2 => {
             let p0 = parts[0].replace(['x', 'X', '*'], "0");
@@ -577,7 +613,10 @@ fn normalize_version_str(v: &str) -> String {
             let p0 = parts[0].replace(['x', 'X', '*'], "0");
             let p1 = parts[1].replace(['x', 'X', '*'], "0");
             let p2 = parts[2].replace(['x', 'X', '*'], "0");
-            if p0.chars().all(|c| c.is_ascii_digit()) && p1.chars().all(|c| c.is_ascii_digit()) && p2.chars().all(|c| c.is_ascii_digit()) {
+            if p0.chars().all(|c| c.is_ascii_digit())
+                && p1.chars().all(|c| c.is_ascii_digit())
+                && p2.chars().all(|c| c.is_ascii_digit())
+            {
                 let rest = if parts.len() > 3 {
                     format!(".{}", parts[3..].join("."))
                 } else {
@@ -621,29 +660,35 @@ fn parse_comparator(comp: &str) -> Option<Interval> {
             lower: Bound::Inclusive(version.clone()),
             upper: Bound::Inclusive(version),
         }),
-        "=>" => Some(Interval {
-            lower: Bound::Inclusive(version),
-            upper: Bound::Unbounded,
-        }),
-        ">" => Some(Interval {
-            lower: Bound::Exclusive(version),
-            upper: Bound::Unbounded,
-        }),
-        "<=" => Some(Interval {
-            lower: Bound::Unbounded,
-            upper: Bound::Inclusive(version),
-        }),
-        "<" => Some(Interval {
-            lower: Bound::Unbounded,
-            upper: Bound::Exclusive(version),
-        }),
+        "=>" => Some(Interval { lower: Bound::Inclusive(version), upper: Bound::Unbounded }),
+        ">" => Some(Interval { lower: Bound::Exclusive(version), upper: Bound::Unbounded }),
+        "<=" => Some(Interval { lower: Bound::Unbounded, upper: Bound::Inclusive(version) }),
+        "<" => Some(Interval { lower: Bound::Unbounded, upper: Bound::Exclusive(version) }),
         "^" => {
             let upper_version = if version.major > 0 {
-                Version { major: version.major + 1, minor: 0, patch: 0, build: Vec::new(), pre_release: Vec::new() }
+                Version {
+                    major: version.major + 1,
+                    minor: 0,
+                    patch: 0,
+                    build: Vec::new(),
+                    pre_release: Vec::new(),
+                }
             } else if version.minor > 0 {
-                Version { major: 0, minor: version.minor + 1, patch: 0, build: Vec::new(), pre_release: Vec::new() }
+                Version {
+                    major: 0,
+                    minor: version.minor + 1,
+                    patch: 0,
+                    build: Vec::new(),
+                    pre_release: Vec::new(),
+                }
             } else {
-                Version { major: 0, minor: 0, patch: version.patch + 1, build: Vec::new(), pre_release: Vec::new() }
+                Version {
+                    major: 0,
+                    minor: 0,
+                    patch: version.patch + 1,
+                    build: Vec::new(),
+                    pre_release: Vec::new(),
+                }
             };
             Some(Interval {
                 lower: Bound::Inclusive(version),
@@ -687,10 +732,7 @@ fn parse_range_to_intervals(range: &str) -> Option<Vec<Interval>> {
         if part.is_empty() {
             continue;
         }
-        let mut part_interval = Interval {
-            lower: Bound::Unbounded,
-            upper: Bound::Unbounded,
-        };
+        let mut part_interval = Interval { lower: Bound::Unbounded, upper: Bound::Unbounded };
         for comp in part.split_whitespace() {
             let comp_interval = parse_comparator(comp)?;
             let lower = max_lower(&part_interval.lower, &comp_interval.lower);
@@ -708,11 +750,7 @@ fn parse_range_to_intervals(range: &str) -> Option<Vec<Interval>> {
             intervals.push(part_interval);
         }
     }
-    if intervals.is_empty() {
-        None
-    } else {
-        Some(intervals)
-    }
+    if intervals.is_empty() { None } else { Some(intervals) }
 }
 
 fn intersect_intervals(a: &[Interval], b: &[Interval]) -> Vec<Interval> {
@@ -741,7 +779,13 @@ fn intersect_multiple_ranges(ranges: &[String]) -> Option<String> {
             return None;
         }
     }
-    Some(current_intervals.iter().map(std::string::ToString::to_string).collect::<Vec<_>>().join(" || "))
+    Some(
+        current_intervals
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(" || "),
+    )
 }
 
 #[cfg(test)]
@@ -808,9 +852,7 @@ fn filter_peer_issues(
         let mut filtered_bad: HashMap<String, Vec<BadPeerIssue>> = HashMap::new();
 
         for (peer_name, peer_issues) in &project_issues.missing {
-            if ignore_missing_matcher.matches(peer_name)
-                || peer_issues.iter().all(|i| i.optional)
-            {
+            if ignore_missing_matcher.matches(peer_name) || peer_issues.iter().all(|i| i.optional) {
                 continue;
             }
             filtered_missing.insert(peer_name.clone(), peer_issues.clone());

--- a/pacquet/crates/cli/src/cli_args/peers.rs
+++ b/pacquet/crates/cli/src/cli_args/peers.rs
@@ -1,5 +1,7 @@
-use std::collections::{HashMap, HashSet};
-use std::fmt;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+};
 
 use clap::Args;
 use miette::{Context, IntoDiagnostic};
@@ -198,7 +200,11 @@ fn resolve_link_version(lockfile_dir: &std::path::Path, link_target: &str) -> Op
     }
     let manifest_path = target_dir.join("package.json");
     PackageManifest::from_path(manifest_path).ok().and_then(|manifest| {
-        manifest.value().get("version").and_then(|v| v.as_str()).map(String::from)
+        manifest
+            .value()
+            .get("version")
+            .and_then(|version_val| version_val.as_str())
+            .map(String::from)
     })
 }
 
@@ -217,7 +223,8 @@ fn check_linked_package_peers(
     }
     let manifest_path = linked_pkg_dir.join("package.json");
     let Ok(manifest) = PackageManifest::from_path(manifest_path) else { return };
-    let Some(peer_deps) = manifest.value().get("peerDependencies").and_then(|v| v.as_object())
+    let Some(peer_deps) =
+        manifest.value().get("peerDependencies").and_then(|deps_val| deps_val.as_object())
     else {
         return;
     };
@@ -230,8 +237,8 @@ fn check_linked_package_peers(
         let is_optional = manifest
             .value()
             .get("peerDependenciesMeta")
-            .and_then(|m| m.get(peer_name))
-            .and_then(|m| m.get("optional"))
+            .and_then(|meta_map| meta_map.get(peer_name))
+            .and_then(|peer_meta| peer_meta.get("optional"))
             .and_then(serde_json::Value::as_bool)
             .unwrap_or(false);
 
@@ -239,10 +246,12 @@ fn check_linked_package_peers(
         let resolved_ref = importer
             .dependencies
             .as_ref()
-            .and_then(|d| d.get(&peer_pkg_name))
-            .or_else(|| importer.dev_dependencies.as_ref().and_then(|d| d.get(&peer_pkg_name)))
+            .and_then(|deps| deps.get(&peer_pkg_name))
             .or_else(|| {
-                importer.optional_dependencies.as_ref().and_then(|d| d.get(&peer_pkg_name))
+                importer.dev_dependencies.as_ref().and_then(|deps| deps.get(&peer_pkg_name))
+            })
+            .or_else(|| {
+                importer.optional_dependencies.as_ref().and_then(|deps| deps.get(&peer_pkg_name))
             });
 
         match resolved_ref {
@@ -377,14 +386,17 @@ fn walk_snapshot(
                     .is_some_and(|peer_meta| peer_meta.optional);
 
                 let Ok(peer_pkg_name) = peer_name.parse::<PkgName>() else { continue };
-                let resolved_ref = snapshot.and_then(|s| {
-                    s.dependencies.as_ref().and_then(|deps| deps.get(&peer_pkg_name)).or_else(
-                        || {
-                            s.optional_dependencies
+                let resolved_ref = snapshot.and_then(|snapshot_entry| {
+                    snapshot_entry
+                        .dependencies
+                        .as_ref()
+                        .and_then(|deps| deps.get(&peer_pkg_name))
+                        .or_else(|| {
+                            snapshot_entry
+                                .optional_dependencies
                                 .as_ref()
                                 .and_then(|deps| deps.get(&peer_pkg_name))
-                        },
-                    )
+                        })
                 });
 
                 match resolved_ref {
@@ -493,9 +505,9 @@ fn satisfies(version: &str, range: &str) -> bool {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum Bound<V> {
-    Inclusive(V),
-    Exclusive(V),
+enum Bound<Value> {
+    Inclusive(Value),
+    Exclusive(Value),
     Unbounded,
 }
 
@@ -830,11 +842,6 @@ fn intersect_multiple_ranges(version_ranges: &[String]) -> Option<String> {
     )
 }
 
-#[cfg(test)]
-fn have_common_version(version_ranges: &[String]) -> bool {
-    intersect_multiple_ranges(version_ranges).is_some()
-}
-
 fn merge_missing_peers(missing: &HashMap<String, Vec<MissingPeerIssue>>) -> MergeResult {
     let mut conflicts = Vec::new();
     let mut intersections = HashMap::new();
@@ -976,7 +983,9 @@ fn parse_allowed_versions(
             let ranges: Vec<String> = spec.split("||").map(|seg| seg.trim().to_string()).collect();
 
             let parent_entry = by_parent.entry(parent_name).or_default();
-            if let Some(rule) = parent_entry.iter_mut().find(|r| r.parent_range == parent_range) {
+            if let Some(rule) =
+                parent_entry.iter_mut().find(|rule_entry| rule_entry.parent_range == parent_range)
+            {
                 rule.peer_rules.entry(peer_name).or_default().extend(ranges);
             } else {
                 let mut peer_rules = HashMap::new();

--- a/pacquet/crates/cli/src/cli_args/peers.rs
+++ b/pacquet/crates/cli/src/cli_args/peers.rs
@@ -6,13 +6,12 @@ use node_semver::{Range, Version};
 use owo_colors::{OwoColorize, Stream};
 use serde::Serialize;
 
-use pacquet_config::Config;
-use pacquet_config::PeerDependencyRules;
+use pacquet_config::{Config, PeerDependencyRules};
 use pacquet_lockfile::{Lockfile, PackageMetadata, PkgName, PkgNameVerPeer, SnapshotEntry};
 
 use crate::cli_args::sanitize::sanitize;
 
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Default, Clone, Serialize)]
 struct ParentPkg {
     name: String,
     version: String,

--- a/pacquet/crates/cli/src/cli_args/peers.rs
+++ b/pacquet/crates/cli/src/cli_args/peers.rs
@@ -1,0 +1,648 @@
+use std::collections::{HashMap, HashSet};
+
+use clap::Args;
+use miette::{Context, IntoDiagnostic};
+use node_semver::{Range, Version};
+use owo_colors::{OwoColorize, Stream};
+use serde::Serialize;
+
+use pacquet_config::Config;
+use pacquet_config::PeerDependencyRules;
+use pacquet_lockfile::{Lockfile, PackageMetadata, PkgName, PkgNameVerPeer, SnapshotEntry};
+
+use crate::cli_args::sanitize::sanitize;
+
+#[derive(Debug, Clone, Default, Serialize)]
+struct ParentPkg {
+    name: String,
+    version: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct MissingPeerIssue {
+    parents: Vec<ParentPkg>,
+    optional: bool,
+    #[serde(rename = "wantedRange")]
+    wanted_range: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct BadPeerIssue {
+    parents: Vec<ParentPkg>,
+    optional: bool,
+    #[serde(rename = "wantedRange")]
+    wanted_range: String,
+    #[serde(rename = "foundVersion")]
+    found_version: String,
+    #[serde(rename = "resolvedFrom")]
+    resolved_from: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct PeerIssues {
+    bad: HashMap<String, Vec<BadPeerIssue>>,
+    missing: HashMap<String, Vec<MissingPeerIssue>>,
+    conflicts: Vec<String>,
+    intersections: HashMap<String, String>,
+}
+
+type IssuesByProjects = HashMap<String, PeerIssues>;
+
+#[derive(Debug, Args)]
+pub struct PeersArgs {
+    #[clap(long)]
+    pub json: bool,
+
+    #[clap(long)]
+    pub lockfile_only: bool,
+}
+
+impl PeersArgs {
+    pub fn run(
+        self,
+        config: &Config,
+        dir: &std::path::Path,
+        recursive: bool,
+    ) -> miette::Result<()> {
+        let lockfile_dir = config.workspace_dir.as_deref().unwrap_or(dir);
+
+        let lockfile = if self.lockfile_only {
+            Lockfile::load_wanted_from_dir(lockfile_dir)
+        } else {
+            match Lockfile::load_current_from_virtual_store_dir(&config.virtual_store_dir) {
+                Ok(Some(lf)) => Ok(Some(lf)),
+                Ok(None) => Lockfile::load_wanted_from_dir(lockfile_dir),
+                Err(e) => Err(e),
+            }
+        }
+        .into_diagnostic()
+        .wrap_err("load lockfile")?;
+
+        let Some(lockfile) = lockfile else {
+            println!("No lockfile found in {}", lockfile_dir.display());
+            return Ok(());
+        };
+
+        let issues = check_peer_dependencies_from_lockfile(&lockfile, lockfile_dir, dir, recursive);
+        let issues = filter_peer_issues(issues, &config.peer_dependency_rules);
+
+        let no_issues = issues.values().all(|pi| pi.bad.is_empty() && pi.missing.is_empty());
+
+        if self.json {
+            let output = serde_json::to_string_pretty(&issues)
+                .into_diagnostic()
+                .wrap_err("serialize issues to JSON")?;
+            println!("{output}");
+        } else if no_issues {
+            println!("No peer dependency issues found");
+        } else {
+            println!("Issues with peer dependencies found\n");
+            print!("{}", render_peer_issues(&issues));
+        }
+
+        if !no_issues {
+            #[allow(clippy::exit, reason = "peers exits non-zero on issues, mirroring pnpm")]
+            std::process::exit(1);
+        }
+
+        Ok(())
+    }
+}
+
+fn check_peer_dependencies_from_lockfile(
+    lockfile: &Lockfile,
+    lockfile_dir: &std::path::Path,
+    dir: &std::path::Path,
+    recursive: bool,
+) -> IssuesByProjects {
+    let packages = lockfile.packages.as_ref();
+    let snapshots = lockfile.snapshots.as_ref();
+    let Some(snapshots) = snapshots else { return HashMap::new() };
+    let Some(packages) = packages else { return HashMap::new() };
+
+    let importer_ids: Vec<String> = if recursive || config_has_workspace(lockfile_dir, dir) {
+        lockfile.importers.keys().cloned().collect()
+    } else {
+        vec![resolve_importer_id(lockfile_dir, dir)]
+    };
+
+    let mut result: IssuesByProjects = HashMap::new();
+
+    for importer_id in &importer_ids {
+        let Some(importer) = lockfile.importers.get(importer_id.as_str()) else { continue };
+
+        let mut issues = PeerIssues {
+            bad: HashMap::new(),
+            missing: HashMap::new(),
+            conflicts: Vec::new(),
+            intersections: HashMap::new(),
+        };
+
+        let mut visited = HashSet::new();
+
+        let groups = [
+            (&importer.dependencies, false),
+            (&importer.dev_dependencies, false),
+            (&importer.optional_dependencies, true),
+        ];
+
+        for (dep_map, _is_optional) in &groups {
+            let Some(dep_map) = dep_map else { continue };
+            for (alias, spec) in dep_map {
+                if let Some(key) = spec.version.resolved_key(alias) {
+                    walk_snapshot(&key, snapshots, packages, &[], &mut issues, &mut visited);
+                }
+            }
+        }
+
+        let merged = merge_missing_peers(&issues.missing);
+        issues.conflicts = merged.conflicts;
+        issues.intersections = merged.intersections;
+
+        result.insert(importer_id.clone(), issues);
+    }
+
+    result
+}
+
+fn config_has_workspace(lockfile_dir: &std::path::Path, dir: &std::path::Path) -> bool {
+    lockfile_dir != dir || lockfile_dir.parent().is_none()
+}
+
+fn resolve_importer_id(lockfile_dir: &std::path::Path, dir: &std::path::Path) -> String {
+    if dir == lockfile_dir {
+        Lockfile::ROOT_IMPORTER_KEY.to_string()
+    } else {
+        dir.strip_prefix(lockfile_dir)
+            .ok()
+            .map(|rel| rel.to_string_lossy().replace('\\', "/"))
+            .filter(|id| !id.is_empty())
+            .unwrap_or_else(|| Lockfile::ROOT_IMPORTER_KEY.to_string())
+    }
+}
+
+fn walk_snapshot(
+    key: &PkgNameVerPeer,
+    snapshots: &HashMap<PkgNameVerPeer, SnapshotEntry>,
+    packages: &HashMap<PkgNameVerPeer, PackageMetadata>,
+    parents: &[ParentPkg],
+    issues: &mut PeerIssues,
+    visited: &mut HashSet<PkgNameVerPeer>,
+) {
+    if !visited.insert(key.clone()) {
+        return;
+    }
+
+    let Some(snapshot) = snapshots.get(key) else { return };
+
+    let pkg_name = key.name.to_string();
+    let pkg_version = get_pkg_version(key, packages);
+
+    let mut current_parents = parents.to_vec();
+    current_parents.push(ParentPkg { name: pkg_name, version: pkg_version });
+
+    let base_key = key.without_peer();
+    if let Some(meta) = packages.get(&base_key)
+        && let Some(peers) = &meta.peer_dependencies
+    {
+        for (peer_name, peer_range) in peers {
+            let is_optional = meta
+                .peer_dependencies_meta
+                .as_ref()
+                .and_then(|m| m.get(peer_name))
+                .is_some_and(|m| m.optional);
+
+            let Ok(peer_pkg_name) = peer_name.parse::<PkgName>() else { continue };
+            let resolved_ref =
+                snapshot.dependencies.as_ref().and_then(|deps| deps.get(&peer_pkg_name)).or_else(
+                    || {
+                        snapshot
+                            .optional_dependencies
+                            .as_ref()
+                            .and_then(|deps| deps.get(&peer_pkg_name))
+                    },
+                );
+
+            match resolved_ref {
+                Some(dep_ref) => {
+                    if let Some(ver_peer) = dep_ref.ver_peer() {
+                        let version_str = ver_peer.version().to_string();
+                        if !satisfies(&version_str, peer_range) {
+                            issues.bad.entry(peer_name.clone()).or_default().push(BadPeerIssue {
+                                parents: current_parents.clone(),
+                                optional: is_optional,
+                                wanted_range: peer_range.clone(),
+                                found_version: version_str,
+                                resolved_from: Vec::new(),
+                            });
+                        }
+                    } else if let Some(link_target) = dep_ref.as_link_target() {
+                        issues.bad.entry(peer_name.clone()).or_default().push(BadPeerIssue {
+                            parents: current_parents.clone(),
+                            optional: is_optional,
+                            wanted_range: peer_range.clone(),
+                            found_version: format!("link:{link_target}"),
+                            resolved_from: Vec::new(),
+                        });
+                    }
+                }
+                None => {
+                    if !is_optional {
+                        issues.missing.entry(peer_name.clone()).or_default().push(
+                            MissingPeerIssue {
+                                parents: current_parents.clone(),
+                                optional: is_optional,
+                                wanted_range: peer_range.clone(),
+                            },
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    let all_deps = snapshot
+        .dependencies
+        .iter()
+        .flat_map(|d| d.iter())
+        .chain(snapshot.optional_dependencies.iter().flat_map(|d| d.iter()));
+
+    for (alias, dep_ref) in all_deps {
+        if let Some(child_key) = dep_ref.resolve(alias) {
+            walk_snapshot(&child_key, snapshots, packages, &current_parents, issues, visited);
+        }
+    }
+}
+
+fn get_pkg_version(
+    key: &PkgNameVerPeer,
+    packages: &HashMap<PkgNameVerPeer, PackageMetadata>,
+) -> String {
+    let base_key = key.without_peer();
+    packages
+        .get(&base_key)
+        .and_then(|meta| meta.version.clone())
+        .unwrap_or_else(|| key.suffix.version().to_string())
+}
+
+fn satisfies(version: &str, range: &str) -> bool {
+    if range == "*" {
+        return true;
+    }
+    let Ok(parsed_version) = Version::parse(version) else {
+        return version == range;
+    };
+    let Ok(parsed_range) = Range::parse(range) else {
+        return version == range;
+    };
+    if parsed_version.satisfies(&parsed_range) {
+        return true;
+    }
+    if !parsed_version.is_prerelease() {
+        return false;
+    }
+    let base = Version {
+        major: parsed_version.major,
+        minor: parsed_version.minor,
+        patch: parsed_version.patch,
+        pre_release: Vec::new(),
+        build: Vec::new(),
+    };
+    base.satisfies(&parsed_range)
+}
+
+fn merge_missing_peers(missing: &HashMap<String, Vec<MissingPeerIssue>>) -> MergeResult {
+    let mut conflicts = Vec::new();
+    let mut intersections = HashMap::new();
+
+    for (peer_name, issues) in missing {
+        if issues.iter().all(|i| i.optional) {
+            continue;
+        }
+        if issues.len() == 1 {
+            intersections.insert(peer_name.clone(), issues[0].wanted_range.clone());
+            continue;
+        }
+        let ranges: Vec<&str> = issues.iter().map(|i| i.wanted_range.as_str()).collect();
+        let unique: HashSet<&&str> = ranges.iter().collect();
+        if unique.len() == 1 {
+            intersections.insert(peer_name.clone(), issues[0].wanted_range.clone());
+            continue;
+        }
+        let range_owned: Vec<String> = issues.iter().map(|i| i.wanted_range.clone()).collect();
+        if have_common_version(&range_owned) {
+            intersections.insert(peer_name.clone(), issues[0].wanted_range.clone());
+        } else {
+            conflicts.push(peer_name.clone());
+        }
+    }
+
+    MergeResult { conflicts, intersections }
+}
+
+struct MergeResult {
+    conflicts: Vec<String>,
+    intersections: HashMap<String, String>,
+}
+
+fn have_common_version(ranges: &[String]) -> bool {
+    if ranges.len() <= 1 {
+        return true;
+    }
+
+    let candidate_versions: Vec<String> =
+        ranges.iter().filter_map(|r| extract_candidate_version(r)).collect();
+
+    if candidate_versions.is_empty() {
+        return false;
+    }
+
+    for ver_str in &candidate_versions {
+        if ranges.iter().all(|r| satisfies(ver_str, r)) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn extract_candidate_version(range_str: &str) -> Option<String> {
+    for segment in range_str.split("||") {
+        let segment = segment.trim();
+        let cleaned = segment
+            .strip_prefix(">=")
+            .or_else(|| segment.strip_prefix('>'))
+            .or_else(|| segment.strip_prefix("<="))
+            .or_else(|| segment.strip_prefix('<'))
+            .or_else(|| segment.strip_prefix('^'))
+            .or_else(|| segment.strip_prefix('~'))
+            .unwrap_or(segment)
+            .trim();
+
+        let cleaned =
+            if let Some((start, _)) = cleaned.split_once(" - ") { start.trim() } else { cleaned };
+
+        let first_word = cleaned.split_whitespace().next().unwrap_or(cleaned);
+        let normalized = first_word.replace(['x', 'X'], "0");
+
+        if normalized != "*" && !normalized.is_empty() && Version::parse(&normalized).is_ok() {
+            return Some(normalized);
+        }
+    }
+    None
+}
+
+fn filter_peer_issues(
+    mut issues: IssuesByProjects,
+    rules: &PeerDependencyRules,
+) -> IssuesByProjects {
+    if rules.ignore_missing.is_none()
+        && rules.allow_any.is_none()
+        && rules.allowed_versions.is_none()
+    {
+        return issues;
+    }
+
+    let ignore_missing_pats = rules.ignore_missing.clone().unwrap_or_default();
+    let allow_any_pats = rules.allow_any.clone().unwrap_or_default();
+    let allowed_versions_map: HashMap<String, String> =
+        rules.allowed_versions.clone().unwrap_or_default().into_iter().collect();
+
+    let (allow_all_matcher, allow_by_parent) = parse_allowed_versions(&allowed_versions_map);
+
+    for project_issues in issues.values_mut() {
+        let mut filtered_missing: HashMap<String, Vec<MissingPeerIssue>> = HashMap::new();
+        let mut filtered_bad: HashMap<String, Vec<BadPeerIssue>> = HashMap::new();
+        let mut filtered_intersections: HashMap<String, String> = HashMap::new();
+
+        for (peer_name, peer_issues) in &project_issues.missing {
+            if ignore_missing_pats.iter().any(|pat| simple_glob_match(pat, peer_name))
+                || peer_issues.iter().all(|i| i.optional)
+            {
+                continue;
+            }
+            filtered_missing.insert(peer_name.clone(), peer_issues.clone());
+            if let Some(range) = project_issues.intersections.get(peer_name) {
+                filtered_intersections.insert(peer_name.clone(), range.clone());
+            }
+        }
+
+        for (peer_name, peer_issues) in &project_issues.bad {
+            if allow_any_pats.iter().any(|pat| simple_glob_match(pat, peer_name)) {
+                continue;
+            }
+            let remaining: Vec<BadPeerIssue> = peer_issues
+                .iter()
+                .filter(|issue| {
+                    if let Some(ranges) = allow_all_matcher.get(peer_name)
+                        && ranges.iter().any(|r| satisfies(&issue.found_version, r))
+                    {
+                        return false;
+                    }
+                    if let Some(declaring_parent) = issue.parents.last()
+                        && let Some(parent_map) = allow_by_parent.get(&declaring_parent.name)
+                        && let Some(ranges) = parent_map.get(peer_name)
+                        && ranges.iter().any(|r| satisfies(&issue.found_version, r))
+                    {
+                        return false;
+                    }
+                    true
+                })
+                .cloned()
+                .collect();
+            if !remaining.is_empty() {
+                filtered_bad.insert(peer_name.clone(), remaining);
+            }
+        }
+
+        project_issues.missing = filtered_missing;
+        project_issues.bad = filtered_bad;
+        project_issues.intersections = filtered_intersections;
+    }
+
+    issues
+}
+
+type AllowAllMatcher = HashMap<String, Vec<String>>;
+type AllowByParentMatcher = HashMap<String, HashMap<String, Vec<String>>>;
+
+fn parse_allowed_versions(
+    allowed: &HashMap<String, String>,
+) -> (AllowAllMatcher, AllowByParentMatcher) {
+    let mut match_all: HashMap<String, Vec<String>> = HashMap::new();
+    let mut by_parent: HashMap<String, HashMap<String, Vec<String>>> = HashMap::new();
+
+    for (selector, spec) in allowed {
+        if let Some((parent, target)) = selector.split_once('>') {
+            let parent_name = parent.trim().to_string();
+            let target_name = target.trim().to_string();
+            let ranges: Vec<String> = spec.split("||").map(|s| s.trim().to_string()).collect();
+            by_parent
+                .entry(parent_name)
+                .or_default()
+                .entry(target_name)
+                .or_default()
+                .extend(ranges);
+        } else {
+            let target_name = if let Some((name, _version)) = selector.split_once('@') {
+                name.to_string()
+            } else {
+                selector.clone()
+            };
+            let ranges: Vec<String> = spec.split("||").map(|s| s.trim().to_string()).collect();
+            match_all.entry(target_name).or_default().extend(ranges);
+        }
+    }
+
+    (match_all, by_parent)
+}
+
+fn simple_glob_match(pattern: &str, value: &str) -> bool {
+    if !pattern.contains('*') {
+        return pattern == value;
+    }
+    let segments: Vec<&str> = pattern.split('*').collect();
+    let mut rest = value;
+    for (i, segment) in segments.iter().enumerate() {
+        if segment.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            let Some(stripped) = rest.strip_prefix(segment) else { return false };
+            rest = stripped;
+        } else if i == segments.len() - 1 {
+            return rest.ends_with(segment);
+        } else if let Some(pos) = rest.find(segment) {
+            rest = &rest[pos + segment.len()..];
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+fn render_peer_issues(issues_by_projects: &IssuesByProjects) -> String {
+    let mut sections: Vec<String> = Vec::new();
+
+    for project_issues in issues_by_projects.values() {
+        for (peer_name, issues) in &project_issues.bad {
+            let peer_name_bold = bold(peer_name);
+            let header = format!("{} {}", yellow_bright("✕ unmet peer"), peer_name_bold);
+            let groups = group_by_found_version(issues);
+            for (found_version, group) in &groups {
+                let installed = format!("  {} {}", cyan("Installed:"), dim(found_version));
+                sections.push(format!("{}\n{}\n{}", header, installed, format_required_by(group)));
+            }
+        }
+
+        for (peer_name, issues) in &project_issues.missing {
+            let is_conflict = project_issues.conflicts.contains(peer_name);
+            if !project_issues.intersections.contains_key(peer_name) && !is_conflict {
+                continue;
+            }
+            let peer_name_bold = bold(peer_name);
+            let header = if is_conflict {
+                format!("{} {}", red("✕ conflicting peer"), peer_name_bold)
+            } else {
+                format!("{} {}", red("✕ missing peer"), peer_name_bold)
+            };
+            sections.push(format!("{}\n{}", header, format_required_by(issues)));
+        }
+    }
+
+    if sections.is_empty() {
+        return String::new();
+    }
+    sections.join("\n\n")
+}
+
+fn format_required_by(issues: &[impl RequiredByIssue]) -> String {
+    let mut by_range: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
+    for issue in issues {
+        let declaring = issue.parents().last().cloned().unwrap_or_default();
+        let pkg = if declaring.name.is_empty() {
+            "<unknown>".to_string()
+        } else {
+            format!("{}@{}", declaring.name, declaring.version)
+        };
+        by_range.entry(issue.wanted_range().to_string()).or_default().push(pkg);
+    }
+
+    let mut lines: Vec<String> = vec![format!("  {}", cyan("Wanted:"))];
+    for (range, pkgs) in &by_range {
+        lines.push(format!("    {}{}", cyan_bright(&format_range(range)), cyan(":")));
+        for pkg in pkgs {
+            lines.push(format!("      {}", dim(pkg)));
+        }
+    }
+    lines.join("\n")
+}
+
+trait RequiredByIssue {
+    fn parents(&self) -> &[ParentPkg];
+    fn wanted_range(&self) -> &str;
+}
+
+impl RequiredByIssue for MissingPeerIssue {
+    fn parents(&self) -> &[ParentPkg] {
+        &self.parents
+    }
+    fn wanted_range(&self) -> &str {
+        &self.wanted_range
+    }
+}
+
+impl RequiredByIssue for BadPeerIssue {
+    fn parents(&self) -> &[ParentPkg] {
+        &self.parents
+    }
+    fn wanted_range(&self) -> &str {
+        &self.wanted_range
+    }
+}
+
+fn group_by_found_version(issues: &[BadPeerIssue]) -> HashMap<String, Vec<BadPeerIssue>> {
+    let mut groups: HashMap<String, Vec<BadPeerIssue>> = HashMap::new();
+    for issue in issues {
+        groups.entry(issue.found_version.clone()).or_default().push(issue.clone());
+    }
+    groups
+}
+
+fn format_range(range: &str) -> String {
+    if range.contains(' ') || range == "*" { format!("\"{range}\"") } else { range.to_string() }
+}
+
+fn bold(text: &str) -> String {
+    let cleaned = sanitize(text);
+    cleaned.as_ref().if_supports_color(Stream::Stdout, |t| t.bold()).to_string()
+}
+
+fn dim(text: &str) -> String {
+    let cleaned = sanitize(text);
+    cleaned.as_ref().if_supports_color(Stream::Stdout, |t| t.dimmed()).to_string()
+}
+
+fn yellow_bright(text: &str) -> String {
+    let cleaned = sanitize(text);
+    cleaned.as_ref().if_supports_color(Stream::Stdout, |t| t.yellow()).to_string()
+}
+
+fn red(text: &str) -> String {
+    let cleaned = sanitize(text);
+    cleaned.as_ref().if_supports_color(Stream::Stdout, |t| t.red()).to_string()
+}
+
+fn cyan(text: &str) -> String {
+    let cleaned = sanitize(text);
+    cleaned.as_ref().if_supports_color(Stream::Stdout, |t| t.cyan()).to_string()
+}
+
+fn cyan_bright(text: &str) -> String {
+    let cleaned = sanitize(text);
+    cleaned.as_ref().if_supports_color(Stream::Stdout, |t| t.cyan()).to_string()
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/peers.rs
+++ b/pacquet/crates/cli/src/cli_args/peers.rs
@@ -152,7 +152,7 @@ fn check_peer_dependencies_from_lockfile(
             importer_id,
             lockfile,
             lockfile_dir,
-            Vec::new(),
+            &[],
             &mut initial_keys,
             &mut visited_importers,
             &mut issues,
@@ -184,12 +184,9 @@ fn resolve_importer_id(lockfile_dir: &std::path::Path, dir: &std::path::Path) ->
 
 fn resolve_link_version(lockfile_dir: &std::path::Path, link_target: &str) -> Option<String> {
     let manifest_path = lockfile_dir.join(link_target).join("package.json");
-    if let Ok(manifest) = PackageManifest::from_path(manifest_path) {
-        if let Some(ver) = manifest.value().get("version").and_then(|v| v.as_str()) {
-            return Some(ver.to_string());
-        }
-    }
-    None
+    PackageManifest::from_path(manifest_path)
+        .ok()
+        .and_then(|manifest| manifest.value().get("version").and_then(|v| v.as_str()).map(String::from))
 }
 
 fn check_linked_package_peers(
@@ -218,7 +215,7 @@ fn check_linked_package_peers(
             .get("peerDependenciesMeta")
             .and_then(|m| m.get(peer_name))
             .and_then(|m| m.get("optional"))
-            .and_then(|o| o.as_bool())
+            .and_then(serde_json::Value::as_bool)
             .unwrap_or(false);
 
         let Ok(peer_pkg_name) = peer_name.parse::<PkgName>() else { continue };
@@ -270,7 +267,7 @@ fn collect_initial_keys(
     importer_id: &str,
     lockfile: &Lockfile,
     lockfile_dir: &std::path::Path,
-    parents: Vec<ParentPkg>,
+    parents: &[ParentPkg],
     initial_keys: &mut Vec<(PkgNameVerPeer, Vec<ParentPkg>)>,
     visited_importers: &mut HashSet<String>,
     issues: &mut PeerIssues,
@@ -290,11 +287,11 @@ fn collect_initial_keys(
         let Some(dep_map) = dep_map else { continue };
         for (alias, spec) in dep_map {
             if let Some(key) = spec.version.resolved_key(alias) {
-                initial_keys.push((key, parents.clone()));
+                initial_keys.push((key, parents.to_owned()));
             } else if let Some(link_target) = spec.version.as_link_target() {
                 let linked_version = resolve_link_version(lockfile_dir, link_target)
                     .unwrap_or_else(|| "0.0.0".to_string());
-                let mut next_parents = parents.clone();
+                let mut next_parents = parents.to_owned();
                 next_parents.push(ParentPkg {
                     name: alias.to_string(),
                     version: linked_version.clone(),
@@ -316,7 +313,7 @@ fn collect_initial_keys(
                     &linked_importer_id,
                     lockfile,
                     lockfile_dir,
-                    next_parents,
+                    &next_parents,
                     initial_keys,
                     visited_importers,
                     issues,
@@ -584,7 +581,7 @@ fn normalize_version_str(v: &str) -> String {
                 let rest = if parts.len() > 3 {
                     format!(".{}", parts[3..].join("."))
                 } else {
-                    "".to_string()
+                    String::new()
                 };
                 format!("{p0}.{p1}.{p2}{rest}")
             } else {
@@ -744,9 +741,10 @@ fn intersect_multiple_ranges(ranges: &[String]) -> Option<String> {
             return None;
         }
     }
-    Some(current_intervals.iter().map(|i| i.to_string()).collect::<Vec<_>>().join(" || "))
+    Some(current_intervals.iter().map(std::string::ToString::to_string).collect::<Vec<_>>().join(" || "))
 }
 
+#[cfg(test)]
 fn have_common_version(ranges: &[String]) -> bool {
     intersect_multiple_ranges(ranges).is_some()
 }
@@ -830,20 +828,19 @@ fn filter_peer_issues(
                     {
                         return false;
                     }
-                    if let Some(declaring_parent) = issue.parents.last() {
-                        if let Some(rules) = allow_by_parent.get(&declaring_parent.name) {
-                            for rule in rules {
-                                let range_matches = match &rule.parent_range {
-                                    Some(range) => satisfies(&declaring_parent.version, range),
-                                    None => true,
-                                };
-                                if range_matches {
-                                    if let Some(ranges) = rule.peer_rules.get(peer_name) {
-                                        if ranges.iter().any(|range| satisfies(&issue.found_version, range)) {
-                                            return false;
-                                        }
-                                    }
-                                }
+                    if let Some(declaring_parent) = issue.parents.last()
+                        && let Some(rules) = allow_by_parent.get(&declaring_parent.name)
+                    {
+                        for rule in rules {
+                            let range_matches = match &rule.parent_range {
+                                Some(range) => satisfies(&declaring_parent.version, range),
+                                None => true,
+                            };
+                            if range_matches
+                                && let Some(ranges) = rule.peer_rules.get(peer_name)
+                                && ranges.iter().any(|range| satisfies(&issue.found_version, range))
+                            {
+                                return false;
                             }
                         }
                     }

--- a/pacquet/crates/cli/src/cli_args/peers/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/peers/tests.rs
@@ -1,0 +1,430 @@
+use std::collections::BTreeMap;
+
+use super::*;
+
+#[test]
+fn test_satisfies_exact_version() {
+    assert!(satisfies("1.2.3", "1.2.3"));
+}
+
+#[test]
+fn test_satisfies_caret_range() {
+    assert!(satisfies("1.5.0", "^1.2.3"));
+}
+
+#[test]
+fn test_satisfies_tilde_range() {
+    assert!(satisfies("1.2.5", "~1.2.3"));
+}
+
+#[test]
+fn test_satisfies_star() {
+    assert!(satisfies("2.0.0", "*"));
+}
+
+#[test]
+fn test_satisfies_fails() {
+    assert!(!satisfies("2.0.0", "^1.0.0"));
+}
+
+#[test]
+fn test_satisfies_prerelease_tolerance() {
+    assert!(satisfies("1.0.0-beta", "^1.0.0"));
+}
+
+#[test]
+fn test_satisfies_non_semver() {
+    assert!(satisfies("custom-tag", "custom-tag"));
+    assert!(!satisfies("0.0.0", "github:some/pkg"));
+    assert!(!satisfies("1.0.0", "not-a-range"));
+}
+
+#[test]
+fn test_extract_candidate_version_simple() {
+    assert_eq!(extract_candidate_version("^1.2.3").as_deref(), Some("1.2.3"));
+}
+
+#[test]
+fn test_extract_candidate_version_tilde() {
+    assert_eq!(extract_candidate_version("~4.5.6").as_deref(), Some("4.5.6"));
+}
+
+#[test]
+fn test_extract_candidate_version_exact() {
+    assert_eq!(extract_candidate_version("7.8.9").as_deref(), Some("7.8.9"));
+}
+
+#[test]
+fn test_extract_candidate_version_star() {
+    assert_eq!(extract_candidate_version("*"), None);
+}
+
+#[test]
+fn test_extract_candidate_version_with_x() {
+    assert_eq!(extract_candidate_version("1.x"), None);
+}
+
+#[test]
+fn test_extract_candidate_version_greater_than() {
+    assert_eq!(extract_candidate_version(">=1.2.3").as_deref(), Some("1.2.3"));
+}
+
+#[test]
+fn test_extract_candidate_version_hyphen_range() {
+    assert_eq!(extract_candidate_version("1.2.3 - 2.0.0").as_deref(), Some("1.2.3"));
+}
+
+#[test]
+fn test_extract_candidate_version_invalid() {
+    assert_eq!(extract_candidate_version("latest"), None);
+    assert_eq!(extract_candidate_version(""), None);
+}
+
+#[test]
+fn test_have_common_version_empty() {
+    assert!(have_common_version(&[]));
+}
+
+#[test]
+fn test_have_common_version_single() {
+    assert!(have_common_version(&["^1.0.0".to_string()]));
+}
+
+#[test]
+fn test_have_common_version_matching() {
+    assert!(have_common_version(&["^1.2.3".to_string(), ">=1.0.0".to_string(),]));
+}
+
+#[test]
+fn test_have_common_version_non_matching() {
+    assert!(!have_common_version(&["^1.0.0".to_string(), "^2.0.0".to_string(),]));
+}
+
+#[test]
+fn test_merge_missing_peers_empty() {
+    let result = merge_missing_peers(&HashMap::new());
+    assert!(result.conflicts.is_empty());
+    assert!(result.intersections.is_empty());
+}
+
+#[test]
+fn test_merge_missing_peers_single() {
+    let mut missing: HashMap<String, Vec<MissingPeerIssue>> = HashMap::new();
+    missing.insert(
+        "react".to_string(),
+        vec![MissingPeerIssue {
+            parents: vec![ParentPkg { name: "foo".to_string(), version: "1.0.0".to_string() }],
+            optional: false,
+            wanted_range: "^18.0.0".to_string(),
+        }],
+    );
+    let result = merge_missing_peers(&missing);
+    assert!(result.conflicts.is_empty());
+    assert_eq!(result.intersections.len(), 1);
+    assert_eq!(result.intersections["react"], "^18.0.0");
+}
+
+#[test]
+fn test_merge_missing_peers_same_range() {
+    let mut missing: HashMap<String, Vec<MissingPeerIssue>> = HashMap::new();
+    missing.insert(
+        "react".to_string(),
+        vec![
+            MissingPeerIssue {
+                parents: vec![ParentPkg { name: "foo".to_string(), version: "1.0.0".to_string() }],
+                optional: false,
+                wanted_range: "^18.0.0".to_string(),
+            },
+            MissingPeerIssue {
+                parents: vec![ParentPkg { name: "bar".to_string(), version: "2.0.0".to_string() }],
+                optional: false,
+                wanted_range: "^18.0.0".to_string(),
+            },
+        ],
+    );
+    let result = merge_missing_peers(&missing);
+    assert!(result.conflicts.is_empty());
+    assert_eq!(result.intersections.len(), 1);
+}
+
+#[test]
+fn test_merge_missing_peers_conflicting() {
+    let mut missing: HashMap<String, Vec<MissingPeerIssue>> = HashMap::new();
+    missing.insert(
+        "react".to_string(),
+        vec![
+            MissingPeerIssue {
+                parents: vec![ParentPkg { name: "foo".to_string(), version: "1.0.0".to_string() }],
+                optional: false,
+                wanted_range: "^17.0.0".to_string(),
+            },
+            MissingPeerIssue {
+                parents: vec![ParentPkg { name: "bar".to_string(), version: "2.0.0".to_string() }],
+                optional: false,
+                wanted_range: "^18.0.0".to_string(),
+            },
+        ],
+    );
+    let result = merge_missing_peers(&missing);
+    assert_eq!(result.conflicts.len(), 1);
+    assert!(result.conflicts.contains(&"react".to_string()));
+    assert!(result.intersections.is_empty());
+}
+
+#[test]
+fn test_merge_missing_peers_all_optional_skipped() {
+    let mut missing: HashMap<String, Vec<MissingPeerIssue>> = HashMap::new();
+    missing.insert(
+        "react".to_string(),
+        vec![
+            MissingPeerIssue {
+                parents: vec![ParentPkg { name: "foo".to_string(), version: "1.0.0".to_string() }],
+                optional: true,
+                wanted_range: "^18.0.0".to_string(),
+            },
+            MissingPeerIssue {
+                parents: vec![ParentPkg { name: "bar".to_string(), version: "2.0.0".to_string() }],
+                optional: true,
+                wanted_range: "^18.0.0".to_string(),
+            },
+        ],
+    );
+    let result = merge_missing_peers(&missing);
+    assert!(result.conflicts.is_empty());
+    assert!(result.intersections.is_empty());
+}
+
+#[test]
+fn test_parse_allowed_versions_empty() {
+    let (match_all, by_parent) = parse_allowed_versions(&HashMap::new());
+    assert!(match_all.is_empty());
+    assert!(by_parent.is_empty());
+}
+
+#[test]
+fn test_parse_allowed_versions_global() {
+    let mut allowed = HashMap::new();
+    allowed.insert("react".to_string(), "^18.0.0".to_string());
+    let (match_all, by_parent) = parse_allowed_versions(&allowed);
+    assert_eq!(match_all.len(), 1);
+    assert_eq!(match_all["react"], vec!["^18.0.0"]);
+    assert!(by_parent.is_empty());
+}
+
+#[test]
+fn test_parse_allowed_versions_by_parent() {
+    let mut allowed = HashMap::new();
+    allowed.insert("@foo/bar>react".to_string(), "^18.0.0".to_string());
+    let (match_all, by_parent) = parse_allowed_versions(&allowed);
+    assert!(match_all.is_empty());
+    assert_eq!(by_parent.len(), 1);
+    assert_eq!(by_parent["@foo/bar"]["react"], vec!["^18.0.0"]);
+}
+
+#[test]
+fn test_parse_allowed_versions_mixed() {
+    let mut allowed = HashMap::new();
+    allowed.insert("react".to_string(), "^18.0.0".to_string());
+    allowed.insert("@foo/bar>react".to_string(), "^17.0.0".to_string());
+    let (match_all, by_parent) = parse_allowed_versions(&allowed);
+    assert_eq!(match_all.len(), 1);
+    assert_eq!(by_parent.len(), 1);
+}
+
+#[test]
+fn test_filter_peer_issues_no_rules() {
+    let mut issues: IssuesByProjects = HashMap::new();
+    let mut peer = PeerIssues {
+        bad: HashMap::new(),
+        missing: HashMap::new(),
+        conflicts: Vec::new(),
+        intersections: HashMap::new(),
+    };
+    peer.bad.insert(
+        "react".to_string(),
+        vec![BadPeerIssue {
+            parents: vec![ParentPkg { name: "foo".to_string(), version: "1.0.0".to_string() }],
+            optional: false,
+            wanted_range: "^18.0.0".to_string(),
+            found_version: "17.0.0".to_string(),
+            resolved_from: Vec::new(),
+        }],
+    );
+    issues.insert("project".to_string(), peer);
+    let filtered = filter_peer_issues(
+        issues,
+        &PeerDependencyRules { ignore_missing: None, allow_any: None, allowed_versions: None },
+    );
+    assert_eq!(filtered["project"].bad.len(), 1);
+    assert!(!filtered["project"].bad["react"].is_empty());
+}
+
+#[test]
+fn test_filter_peer_issues_allow_any() {
+    let mut issues: IssuesByProjects = HashMap::new();
+    let mut peer = PeerIssues {
+        bad: HashMap::new(),
+        missing: HashMap::new(),
+        conflicts: Vec::new(),
+        intersections: HashMap::new(),
+    };
+    peer.bad.insert(
+        "react".to_string(),
+        vec![BadPeerIssue {
+            parents: vec![ParentPkg { name: "foo".to_string(), version: "1.0.0".to_string() }],
+            optional: false,
+            wanted_range: "^18.0.0".to_string(),
+            found_version: "17.0.0".to_string(),
+            resolved_from: Vec::new(),
+        }],
+    );
+    issues.insert("project".to_string(), peer);
+    let filtered = filter_peer_issues(
+        issues,
+        &PeerDependencyRules {
+            ignore_missing: None,
+            allow_any: Some(vec!["react".to_string()]),
+            allowed_versions: None,
+        },
+    );
+    assert!(filtered["project"].bad.is_empty());
+}
+
+#[test]
+fn test_filter_peer_issues_allowed_versions() {
+    let mut issues: IssuesByProjects = HashMap::new();
+    let mut peer = PeerIssues {
+        bad: HashMap::new(),
+        missing: HashMap::new(),
+        conflicts: Vec::new(),
+        intersections: HashMap::new(),
+    };
+    peer.bad.insert(
+        "react".to_string(),
+        vec![BadPeerIssue {
+            parents: vec![ParentPkg { name: "foo".to_string(), version: "1.0.0".to_string() }],
+            optional: false,
+            wanted_range: "^18.0.0".to_string(),
+            found_version: "17.0.0".to_string(),
+            resolved_from: Vec::new(),
+        }],
+    );
+    issues.insert("project".to_string(), peer);
+    let mut allowed = BTreeMap::new();
+    allowed.insert("react".to_string(), "^17.0.0".to_string());
+    let filtered = filter_peer_issues(
+        issues,
+        &PeerDependencyRules {
+            ignore_missing: None,
+            allow_any: None,
+            allowed_versions: Some(allowed),
+        },
+    );
+    assert!(filtered["project"].bad.is_empty());
+}
+
+#[test]
+fn test_filter_peer_issues_allowed_versions_not_matching() {
+    let mut issues: IssuesByProjects = HashMap::new();
+    let mut peer = PeerIssues {
+        bad: HashMap::new(),
+        missing: HashMap::new(),
+        conflicts: Vec::new(),
+        intersections: HashMap::new(),
+    };
+    peer.bad.insert(
+        "react".to_string(),
+        vec![BadPeerIssue {
+            parents: vec![ParentPkg { name: "foo".to_string(), version: "1.0.0".to_string() }],
+            optional: false,
+            wanted_range: "^18.0.0".to_string(),
+            found_version: "16.0.0".to_string(),
+            resolved_from: Vec::new(),
+        }],
+    );
+    issues.insert("project".to_string(), peer);
+    let mut allowed = BTreeMap::new();
+    allowed.insert("react".to_string(), "^17.0.0".to_string());
+    let filtered = filter_peer_issues(
+        issues,
+        &PeerDependencyRules {
+            ignore_missing: None,
+            allow_any: None,
+            allowed_versions: Some(allowed),
+        },
+    );
+    assert_eq!(filtered["project"].bad.len(), 1);
+}
+
+#[test]
+fn test_filter_peer_issues_ignore_missing() {
+    let mut issues: IssuesByProjects = HashMap::new();
+    let mut peer = PeerIssues {
+        bad: HashMap::new(),
+        missing: HashMap::new(),
+        conflicts: Vec::new(),
+        intersections: HashMap::new(),
+    };
+    peer.missing.insert(
+        "react".to_string(),
+        vec![MissingPeerIssue {
+            parents: vec![ParentPkg { name: "foo".to_string(), version: "1.0.0".to_string() }],
+            optional: false,
+            wanted_range: "^18.0.0".to_string(),
+        }],
+    );
+    issues.insert("project".to_string(), peer);
+    let filtered = filter_peer_issues(
+        issues,
+        &PeerDependencyRules {
+            ignore_missing: Some(vec!["react".to_string()]),
+            allow_any: None,
+            allowed_versions: None,
+        },
+    );
+    assert!(filtered["project"].missing.is_empty());
+}
+
+#[test]
+fn test_filter_peer_issues_ignore_missing_pattern() {
+    let mut issues: IssuesByProjects = HashMap::new();
+    let mut peer = PeerIssues {
+        bad: HashMap::new(),
+        missing: HashMap::new(),
+        conflicts: Vec::new(),
+        intersections: HashMap::new(),
+    };
+    peer.missing.insert(
+        "@scope/pkg".to_string(),
+        vec![MissingPeerIssue {
+            parents: vec![ParentPkg { name: "foo".to_string(), version: "1.0.0".to_string() }],
+            optional: false,
+            wanted_range: "^1.0.0".to_string(),
+        }],
+    );
+    issues.insert("project".to_string(), peer);
+    let filtered = filter_peer_issues(
+        issues,
+        &PeerDependencyRules {
+            ignore_missing: Some(vec!["@scope/*".to_string()]),
+            allow_any: None,
+            allowed_versions: None,
+        },
+    );
+    assert!(filtered["project"].missing.is_empty());
+}
+
+#[test]
+fn test_format_range_simple() {
+    assert_eq!(format_range("^1.2.3"), "^1.2.3");
+}
+
+#[test]
+fn test_format_range_with_space() {
+    assert_eq!(format_range(">=1.0.0 <2.0.0"), "\">=1.0.0 <2.0.0\"");
+}
+
+#[test]
+fn test_format_range_wildcard() {
+    assert_eq!(format_range("*"), "\"*\"");
+}

--- a/pacquet/crates/cli/src/cli_args/peers/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/peers/tests.rs
@@ -1,6 +1,12 @@
 use std::collections::BTreeMap;
 
-use super::*;
+use pacquet_config::PeerDependencyRules;
+
+use super::{
+    BadPeerIssue, IssuesByProjects, MissingPeerIssue, ParentPkg, PeerIssues, filter_peer_issues,
+    format_range, intersect_multiple_ranges, merge_missing_peers, normalize_version_str,
+    parse_allowed_versions, path_is_within, satisfies,
+};
 
 fn have_common_version(version_ranges: &[String]) -> bool {
     intersect_multiple_ranges(version_ranges).is_some()
@@ -91,14 +97,14 @@ fn test_have_common_version_non_matching() {
 
 #[test]
 fn test_merge_missing_peers_empty() {
-    let result = merge_missing_peers(&HashMap::new());
+    let result = merge_missing_peers(&BTreeMap::new());
     assert!(result.conflicts.is_empty());
     assert!(result.intersections.is_empty());
 }
 
 #[test]
 fn test_merge_missing_peers_single() {
-    let mut missing: HashMap<String, Vec<MissingPeerIssue>> = HashMap::new();
+    let mut missing: BTreeMap<String, Vec<MissingPeerIssue>> = BTreeMap::new();
     missing.insert(
         "react".to_string(),
         vec![MissingPeerIssue {
@@ -115,7 +121,7 @@ fn test_merge_missing_peers_single() {
 
 #[test]
 fn test_merge_missing_peers_same_range() {
-    let mut missing: HashMap<String, Vec<MissingPeerIssue>> = HashMap::new();
+    let mut missing: BTreeMap<String, Vec<MissingPeerIssue>> = BTreeMap::new();
     missing.insert(
         "react".to_string(),
         vec![
@@ -138,7 +144,7 @@ fn test_merge_missing_peers_same_range() {
 
 #[test]
 fn test_merge_missing_peers_conflicting() {
-    let mut missing: HashMap<String, Vec<MissingPeerIssue>> = HashMap::new();
+    let mut missing: BTreeMap<String, Vec<MissingPeerIssue>> = BTreeMap::new();
     missing.insert(
         "react".to_string(),
         vec![
@@ -162,7 +168,7 @@ fn test_merge_missing_peers_conflicting() {
 
 #[test]
 fn test_merge_missing_peers_all_optional_skipped() {
-    let mut missing: HashMap<String, Vec<MissingPeerIssue>> = HashMap::new();
+    let mut missing: BTreeMap<String, Vec<MissingPeerIssue>> = BTreeMap::new();
     missing.insert(
         "react".to_string(),
         vec![
@@ -185,14 +191,14 @@ fn test_merge_missing_peers_all_optional_skipped() {
 
 #[test]
 fn test_parse_allowed_versions_empty() {
-    let (match_all, by_parent) = parse_allowed_versions(&HashMap::new());
+    let (match_all, by_parent) = parse_allowed_versions(&BTreeMap::new());
     assert!(match_all.is_empty());
     assert!(by_parent.is_empty());
 }
 
 #[test]
 fn test_parse_allowed_versions_global() {
-    let mut allowed = HashMap::new();
+    let mut allowed = BTreeMap::new();
     allowed.insert("react".to_string(), "^18.0.0".to_string());
     let (match_all, by_parent) = parse_allowed_versions(&allowed);
     assert_eq!(match_all.len(), 1);
@@ -202,7 +208,7 @@ fn test_parse_allowed_versions_global() {
 
 #[test]
 fn test_parse_allowed_versions_by_parent() {
-    let mut allowed = HashMap::new();
+    let mut allowed = BTreeMap::new();
     allowed.insert("@foo/bar>react".to_string(), "^18.0.0".to_string());
     let (match_all, by_parent) = parse_allowed_versions(&allowed);
     assert!(match_all.is_empty());
@@ -212,7 +218,7 @@ fn test_parse_allowed_versions_by_parent() {
 
 #[test]
 fn test_parse_allowed_versions_mixed() {
-    let mut allowed = HashMap::new();
+    let mut allowed = BTreeMap::new();
     allowed.insert("react".to_string(), "^18.0.0".to_string());
     allowed.insert("@foo/bar>react".to_string(), "^17.0.0".to_string());
     let (match_all, by_parent) = parse_allowed_versions(&allowed);
@@ -222,12 +228,12 @@ fn test_parse_allowed_versions_mixed() {
 
 #[test]
 fn test_filter_peer_issues_no_rules() {
-    let mut issues: IssuesByProjects = HashMap::new();
+    let mut issues: IssuesByProjects = BTreeMap::new();
     let mut peer = PeerIssues {
-        bad: HashMap::new(),
-        missing: HashMap::new(),
+        bad: BTreeMap::new(),
+        missing: BTreeMap::new(),
         conflicts: Vec::new(),
-        intersections: HashMap::new(),
+        intersections: BTreeMap::new(),
     };
     peer.bad.insert(
         "react".to_string(),
@@ -250,12 +256,12 @@ fn test_filter_peer_issues_no_rules() {
 
 #[test]
 fn test_filter_peer_issues_allow_any() {
-    let mut issues: IssuesByProjects = HashMap::new();
+    let mut issues: IssuesByProjects = BTreeMap::new();
     let mut peer = PeerIssues {
-        bad: HashMap::new(),
-        missing: HashMap::new(),
+        bad: BTreeMap::new(),
+        missing: BTreeMap::new(),
         conflicts: Vec::new(),
-        intersections: HashMap::new(),
+        intersections: BTreeMap::new(),
     };
     peer.bad.insert(
         "react".to_string(),
@@ -281,12 +287,12 @@ fn test_filter_peer_issues_allow_any() {
 
 #[test]
 fn test_filter_peer_issues_allowed_versions() {
-    let mut issues: IssuesByProjects = HashMap::new();
+    let mut issues: IssuesByProjects = BTreeMap::new();
     let mut peer = PeerIssues {
-        bad: HashMap::new(),
-        missing: HashMap::new(),
+        bad: BTreeMap::new(),
+        missing: BTreeMap::new(),
         conflicts: Vec::new(),
-        intersections: HashMap::new(),
+        intersections: BTreeMap::new(),
     };
     peer.bad.insert(
         "react".to_string(),
@@ -314,12 +320,12 @@ fn test_filter_peer_issues_allowed_versions() {
 
 #[test]
 fn test_filter_peer_issues_allowed_versions_not_matching() {
-    let mut issues: IssuesByProjects = HashMap::new();
+    let mut issues: IssuesByProjects = BTreeMap::new();
     let mut peer = PeerIssues {
-        bad: HashMap::new(),
-        missing: HashMap::new(),
+        bad: BTreeMap::new(),
+        missing: BTreeMap::new(),
         conflicts: Vec::new(),
-        intersections: HashMap::new(),
+        intersections: BTreeMap::new(),
     };
     peer.bad.insert(
         "react".to_string(),
@@ -347,12 +353,12 @@ fn test_filter_peer_issues_allowed_versions_not_matching() {
 
 #[test]
 fn test_filter_peer_issues_ignore_missing() {
-    let mut issues: IssuesByProjects = HashMap::new();
+    let mut issues: IssuesByProjects = BTreeMap::new();
     let mut peer = PeerIssues {
-        bad: HashMap::new(),
-        missing: HashMap::new(),
+        bad: BTreeMap::new(),
+        missing: BTreeMap::new(),
         conflicts: Vec::new(),
-        intersections: HashMap::new(),
+        intersections: BTreeMap::new(),
     };
     peer.missing.insert(
         "react".to_string(),
@@ -376,12 +382,12 @@ fn test_filter_peer_issues_ignore_missing() {
 
 #[test]
 fn test_filter_peer_issues_ignore_missing_pattern() {
-    let mut issues: IssuesByProjects = HashMap::new();
+    let mut issues: IssuesByProjects = BTreeMap::new();
     let mut peer = PeerIssues {
-        bad: HashMap::new(),
-        missing: HashMap::new(),
+        bad: BTreeMap::new(),
+        missing: BTreeMap::new(),
         conflicts: Vec::new(),
-        intersections: HashMap::new(),
+        intersections: BTreeMap::new(),
     };
     peer.missing.insert(
         "@scope/pkg".to_string(),
@@ -405,12 +411,12 @@ fn test_filter_peer_issues_ignore_missing_pattern() {
 
 #[test]
 fn test_filter_peer_issues_allowed_versions_parent_scoped() {
-    let mut issues: IssuesByProjects = HashMap::new();
+    let mut issues: IssuesByProjects = BTreeMap::new();
     let mut peer = PeerIssues {
-        bad: HashMap::new(),
-        missing: HashMap::new(),
+        bad: BTreeMap::new(),
+        missing: BTreeMap::new(),
         conflicts: Vec::new(),
-        intersections: HashMap::new(),
+        intersections: BTreeMap::new(),
     };
     peer.bad.insert(
         "react".to_string(),

--- a/pacquet/crates/cli/src/cli_args/peers/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/peers/tests.rs
@@ -411,9 +411,7 @@ fn test_filter_peer_issues_allowed_versions_parent_scoped() {
     peer.bad.insert(
         "react".to_string(),
         vec![BadPeerIssue {
-            parents: vec![
-                ParentPkg { name: "@foo/bar".to_string(), version: "1.2.3".to_string() }
-            ],
+            parents: vec![ParentPkg { name: "@foo/bar".to_string(), version: "1.2.3".to_string() }],
             optional: false,
             wanted_range: "^18.0.0".to_string(),
             found_version: "17.0.0".to_string(),

--- a/pacquet/crates/cli/src/cli_args/peers/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/peers/tests.rs
@@ -421,10 +421,10 @@ fn test_format_range_simple() {
 
 #[test]
 fn test_format_range_with_space() {
-    assert_eq!(format_range(">=1.0.0 <2.0.0"), "\">=1.0.0 <2.0.0\"");
+    assert_eq!(format_range(">=1.0.0 <2.0.0"), r#"">=1.0.0 <2.0.0""#);
 }
 
 #[test]
 fn test_format_range_wildcard() {
-    assert_eq!(format_range("*"), "\"*\"");
+    assert_eq!(format_range("*"), r#""*""#);
 }

--- a/pacquet/crates/cli/src/cli_args/peers/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/peers/tests.rs
@@ -40,44 +40,29 @@ fn test_satisfies_non_semver() {
 }
 
 #[test]
-fn test_extract_candidate_version_simple() {
-    assert_eq!(extract_candidate_version("^1.2.3").as_deref(), Some("1.2.3"));
+fn test_normalize_version_str() {
+    assert_eq!(normalize_version_str("1.x"), "1.0.0");
+    assert_eq!(normalize_version_str("1.2.x"), "1.2.0");
+    assert_eq!(normalize_version_str("1"), "1.0.0");
+    assert_eq!(normalize_version_str("1.2.3-beta.0"), "1.2.3-beta.0");
 }
 
 #[test]
-fn test_extract_candidate_version_tilde() {
-    assert_eq!(extract_candidate_version("~4.5.6").as_deref(), Some("4.5.6"));
+fn test_intersect_multiple_ranges_basic() {
+    let r = vec!["^1.2.3".to_string(), ">=1.0.0".to_string()];
+    assert_eq!(intersect_multiple_ranges(&r).as_deref(), Some(">=1.2.3 <2.0.0"));
 }
 
 #[test]
-fn test_extract_candidate_version_exact() {
-    assert_eq!(extract_candidate_version("7.8.9").as_deref(), Some("7.8.9"));
+fn test_intersect_multiple_ranges_conflict() {
+    let r = vec!["^17.0.0".to_string(), "^18.0.0".to_string()];
+    assert_eq!(intersect_multiple_ranges(&r), None);
 }
 
 #[test]
-fn test_extract_candidate_version_star() {
-    assert_eq!(extract_candidate_version("*"), None);
-}
-
-#[test]
-fn test_extract_candidate_version_with_x() {
-    assert_eq!(extract_candidate_version("1.x"), None);
-}
-
-#[test]
-fn test_extract_candidate_version_greater_than() {
-    assert_eq!(extract_candidate_version(">=1.2.3").as_deref(), Some("1.2.3"));
-}
-
-#[test]
-fn test_extract_candidate_version_hyphen_range() {
-    assert_eq!(extract_candidate_version("1.2.3 - 2.0.0").as_deref(), Some("1.2.3"));
-}
-
-#[test]
-fn test_extract_candidate_version_invalid() {
-    assert_eq!(extract_candidate_version("latest"), None);
-    assert_eq!(extract_candidate_version(""), None);
+fn test_intersect_multiple_ranges_exact() {
+    let r = vec!["^16.0.0".to_string(), "16.1.0".to_string()];
+    assert_eq!(intersect_multiple_ranges(&r).as_deref(), Some("16.1.0"));
 }
 
 #[test]
@@ -218,7 +203,7 @@ fn test_parse_allowed_versions_by_parent() {
     let (match_all, by_parent) = parse_allowed_versions(&allowed);
     assert!(match_all.is_empty());
     assert_eq!(by_parent.len(), 1);
-    assert_eq!(by_parent["@foo/bar"]["react"], vec!["^18.0.0"]);
+    assert_eq!(by_parent["@foo/bar"][0].peer_rules["react"], vec!["^18.0.0"]);
 }
 
 #[test]
@@ -412,6 +397,43 @@ fn test_filter_peer_issues_ignore_missing_pattern() {
         },
     );
     assert!(filtered["project"].missing.is_empty());
+}
+
+#[test]
+fn test_filter_peer_issues_allowed_versions_parent_scoped() {
+    let mut issues: IssuesByProjects = HashMap::new();
+    let mut peer = PeerIssues {
+        bad: HashMap::new(),
+        missing: HashMap::new(),
+        conflicts: Vec::new(),
+        intersections: HashMap::new(),
+    };
+    peer.bad.insert(
+        "react".to_string(),
+        vec![BadPeerIssue {
+            parents: vec![
+                ParentPkg { name: "@foo/bar".to_string(), version: "1.2.3".to_string() }
+            ],
+            optional: false,
+            wanted_range: "^18.0.0".to_string(),
+            found_version: "17.0.0".to_string(),
+            resolved_from: Vec::new(),
+        }],
+    );
+    issues.insert("project".to_string(), peer);
+
+    let mut allowed = BTreeMap::new();
+    allowed.insert("@foo/bar@^1.0.0>react".to_string(), "^17.0.0".to_string());
+
+    let filtered = filter_peer_issues(
+        issues,
+        &PeerDependencyRules {
+            ignore_missing: None,
+            allow_any: None,
+            allowed_versions: Some(allowed),
+        },
+    );
+    assert!(filtered["project"].bad.is_empty());
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/peers/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/peers/tests.rs
@@ -2,6 +2,10 @@ use std::collections::BTreeMap;
 
 use super::*;
 
+fn have_common_version(version_ranges: &[String]) -> bool {
+    intersect_multiple_ranges(version_ranges).is_some()
+}
+
 #[test]
 fn test_satisfies_exact_version() {
     assert!(satisfies("1.2.3", "1.2.3"));
@@ -49,20 +53,20 @@ fn test_normalize_version_str() {
 
 #[test]
 fn test_intersect_multiple_ranges_basic() {
-    let r = vec!["^1.2.3".to_string(), ">=1.0.0".to_string()];
-    assert_eq!(intersect_multiple_ranges(&r).as_deref(), Some(">=1.2.3 <2.0.0"));
+    let version_ranges = vec!["^1.2.3".to_string(), ">=1.0.0".to_string()];
+    assert_eq!(intersect_multiple_ranges(&version_ranges).as_deref(), Some(">=1.2.3 <2.0.0"));
 }
 
 #[test]
 fn test_intersect_multiple_ranges_conflict() {
-    let r = vec!["^17.0.0".to_string(), "^18.0.0".to_string()];
-    assert_eq!(intersect_multiple_ranges(&r), None);
+    let version_ranges = vec!["^17.0.0".to_string(), "^18.0.0".to_string()];
+    assert_eq!(intersect_multiple_ranges(&version_ranges), None);
 }
 
 #[test]
 fn test_intersect_multiple_ranges_exact() {
-    let r = vec!["^16.0.0".to_string(), "16.1.0".to_string()];
-    assert_eq!(intersect_multiple_ranges(&r).as_deref(), Some("16.1.0"));
+    let version_ranges = vec!["^16.0.0".to_string(), "16.1.0".to_string()];
+    assert_eq!(intersect_multiple_ranges(&version_ranges).as_deref(), Some("16.1.0"));
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/peers/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/peers/tests.rs
@@ -448,3 +448,20 @@ fn test_format_range_with_space() {
 fn test_format_range_wildcard() {
     assert_eq!(format_range("*"), r#""*""#);
 }
+
+#[test]
+fn test_path_is_within() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let base = temp_dir.path();
+    let sub = base.join("foo");
+    std::fs::create_dir(&sub).unwrap();
+
+    assert!(path_is_within(&sub, base));
+    assert!(path_is_within(base, base));
+
+    let outside = base.join("../bar");
+    assert!(!path_is_within(&outside, base));
+
+    let absolute_outside = std::path::Path::new("/etc");
+    assert!(!path_is_within(absolute_outside, base));
+}

--- a/pnpm11/deps/inspection/peers-checker/src/checkPeerDependencies.ts
+++ b/pnpm11/deps/inspection/peers-checker/src/checkPeerDependencies.ts
@@ -183,7 +183,7 @@ function filterPeerDependencyIssues (
     result[projectId] = {
       bad: filteredBad,
       missing: filteredMissing,
-      conflicts,
+      conflicts: conflicts.filter((peerName) => filteredMissing[peerName] != null),
       intersections: filteredIntersections,
     }
   }

--- a/pnpm11/deps/inspection/peers-checker/test/__fixtures__/with-conflicting-peers/package.json
+++ b/pnpm11/deps/inspection/peers-checker/test/__fixtures__/with-conflicting-peers/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "with-conflicting-peers",
+  "version": "1.0.0",
+  "dependencies": {
+    "needs-react-17": "1.0.0",
+    "needs-react-18": "1.0.0"
+  }
+}

--- a/pnpm11/deps/inspection/peers-checker/test/__fixtures__/with-conflicting-peers/pnpm-lock.yaml
+++ b/pnpm11/deps/inspection/peers-checker/test/__fixtures__/with-conflicting-peers/pnpm-lock.yaml
@@ -1,0 +1,34 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      needs-react-17:
+        specifier: 1.0.0
+        version: 1.0.0
+      needs-react-18:
+        specifier: 1.0.0
+        version: 1.0.0
+
+packages:
+
+  needs-react-17@1.0.0:
+    resolution: {integrity: sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==}
+    peerDependencies:
+      react: ^17.0.0
+
+  needs-react-18@1.0.0:
+    resolution: {integrity: sha512-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb==}
+    peerDependencies:
+      react: ^18.0.0
+
+snapshots:
+
+  needs-react-17@1.0.0: {}
+
+  needs-react-18@1.0.0: {}

--- a/pnpm11/deps/inspection/peers-checker/test/checkPeerDependencies.test.ts
+++ b/pnpm11/deps/inspection/peers-checker/test/checkPeerDependencies.test.ts
@@ -99,6 +99,35 @@ test('respects peerDependencyRules.ignoreMissing', async () => {
   expect(Object.keys(projectIssues.missing)).toHaveLength(0)
 })
 
+test('detects conflicting missing peer dependencies', async () => {
+  const fixture = f.find('with-conflicting-peers')
+  const issues = await checkPeerDependencies([fixture], {
+    lockfileDir: fixture,
+    checkWantedLockfileOnly: true,
+  })
+
+  const projectIssues = issues['.']
+  expect(projectIssues.missing).toHaveProperty('react')
+  expect(projectIssues.missing.react).toHaveLength(2)
+  expect(projectIssues.conflicts).toStrictEqual(['react'])
+  expect(projectIssues.intersections).not.toHaveProperty('react')
+})
+
+test('peerDependencyRules.ignoreMissing also removes the conflicts of ignored peers', async () => {
+  const fixture = f.find('with-conflicting-peers')
+  const issues = await checkPeerDependencies([fixture], {
+    lockfileDir: fixture,
+    checkWantedLockfileOnly: true,
+    peerDependencyRules: {
+      ignoreMissing: ['react'],
+    },
+  })
+
+  const projectIssues = issues['.']
+  expect(Object.keys(projectIssues.missing)).toHaveLength(0)
+  expect(projectIssues.conflicts).toStrictEqual([])
+})
+
 test('returns no issues when there are no peer dependency problems', async () => {
   const fixture = f.find('empty')
   const issues = await checkPeerDependencies([fixture], {


### PR DESCRIPTION
## Summary

Implements the `pnpm peers` command in the Rust pacquet port, matching the TypeScript CLI behavior: it reads the current (or wanted, with `--lockfile-only`) lockfile, walks each importer's dependency graph, and reports unmet and missing peer dependencies. Supports `--json`, `--lockfile-only`, `-r`/`--recursive`, honors `pnpm.peerDependencyRules` (`ignoreMissing`, `allowAny`, `allowedVersions` including parent-scoped selectors), and exits non-zero when issues are found.

Also fixes a bug in the TypeScript `@pnpm/deps.inspection.peers-checker`: a missing peer excluded via `pnpm.peerDependencyRules.ignoreMissing` could still surface as a stale conflict in the JSON output. The pacquet implementation recomputes conflicts after filtering; the TypeScript side now does the equivalent.

Related to: pnpm/pnpm#11633

## Squash Commit Body

```text
Add the peers command to pacquet-cli, which checks for unmet or missing
peer dependency issues by walking the lockfile, mirroring the TypeScript
CLI: one shared visited set across importers so each package is
evaluated once, missing-peer ranges merged via interval intersection to
detect conflicts, peerDependencyRules filtering (ignoreMissing,
allowAny, allowedVersions with parent-scoped selectors), deterministic
BTreeMap-ordered output, and a PeersOutcome mapped to exit code 1 in
the dispatch layer. Importer link: targets resolve relative to the
importer directory and are rejected when they escape the lockfile
directory.

Also fix the TypeScript peers-checker to drop conflicts of missing
peers removed by peerDependencyRules.ignoreMissing, so the JSON output
no longer reports a conflict while the text output reports no issues.

Related to: pnpm/pnpm#11633
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---

Written by an agent (Claude Code, claude-fable-5).
