### PR TITLE
feat(pkg): add `get-published` subcommand to `pnpm pkg`

### DIFF
--- a/.changeset/pack-json-manifest-mode.md
+++ b/.changeset/pack-json-manifest-mode.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/pkg-manifest.commands": minor
+"pnpm": minor
+---
+
+Added `pnpm pkg get --published` to output the publish-transformed manifest without packing or publishing. The `--published` flag applies all publish-time transformations (`publishConfig` overrides, `workspace:` protocol resolution, catalog resolution, script stripping, etc.) and returns the result. Supports field selection (`pnpm pkg get exports --published`) and `--recursive`.

--- a/.changeset/pack-json-manifest-mode.md
+++ b/.changeset/pack-json-manifest-mode.md
@@ -4,3 +4,5 @@
 ---
 
 Added `pnpm pkg get-published` subcommand to output the publish-transformed manifest without packing or publishing. It applies all publish-time transformations (`publishConfig` overrides, `workspace:` protocol resolution, catalog resolution, script stripping, etc.) and returns the result. Supports field selection (`pnpm pkg get-published exports`) and `--recursive`.
+
+pacquet port not needed — `pkg` is outside pacquet's current surface area (dependency-management commands only).

--- a/.changeset/pack-json-manifest-mode.md
+++ b/.changeset/pack-json-manifest-mode.md
@@ -3,4 +3,4 @@
 "pnpm": minor
 ---
 
-Added `pnpm pkg get --published` to output the publish-transformed manifest without packing or publishing. The `--published` flag applies all publish-time transformations (`publishConfig` overrides, `workspace:` protocol resolution, catalog resolution, script stripping, etc.) and returns the result. Supports field selection (`pnpm pkg get exports --published`) and `--recursive`.
+Added `pnpm pkg get-published` subcommand to output the publish-transformed manifest without packing or publishing. It applies all publish-time transformations (`publishConfig` overrides, `workspace:` protocol resolution, catalog resolution, script stripping, etc.) and returns the result. Supports field selection (`pnpm pkg get-published exports`) and `--recursive`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7616,6 +7616,9 @@ importers:
 
   pnpm11/pkg-manifest/commands:
     dependencies:
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: link:../../catalogs/types
       '@pnpm/cli.utils':
         specifier: workspace:*
         version: link:../../cli/utils
@@ -7625,9 +7628,15 @@ importers:
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../core/error
+      '@pnpm/hooks.pnpmfile':
+        specifier: workspace:*
+        version: link:../../hooks/pnpmfile
       '@pnpm/object.property-path':
         specifier: workspace:*
         version: link:../../object/property-path
+      '@pnpm/releasing.exportable-manifest':
+        specifier: workspace:*
+        version: link:../../releasing/exportable-manifest
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../core/types

--- a/pnpm11/pkg-manifest/commands/package.json
+++ b/pnpm11/pkg-manifest/commands/package.json
@@ -32,10 +32,13 @@
     "prepublishOnly": "tsgo --build"
   },
   "dependencies": {
+    "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/cli.utils": "workspace:*",
     "@pnpm/config.reader": "workspace:*",
     "@pnpm/error": "workspace:*",
+    "@pnpm/hooks.pnpmfile": "workspace:*",
     "@pnpm/object.property-path": "workspace:*",
+    "@pnpm/releasing.exportable-manifest": "workspace:*",
     "@pnpm/types": "workspace:*",
     "render-help": "catalog:"
   },

--- a/pnpm11/pkg-manifest/commands/src/pkg.ts
+++ b/pnpm11/pkg-manifest/commands/src/pkg.ts
@@ -149,19 +149,24 @@ async function readPublishedManifest (opts: PkgCommandOptions): Promise<Record<s
 async function resolvePublishDir (projectDir: string, manifest: ProjectManifest): Promise<string> {
   if (!manifest.publishConfig?.directory) return projectDir
   const resolved = path.resolve(projectDir, manifest.publishConfig.directory)
-  let real: string
-  try {
-    real = await fs.realpath(resolved)
-  } catch {
-    real = resolved
-  }
-  if (!real.startsWith(projectDir + path.sep) && real !== projectDir) {
+  const real = await realpathOrIdentity(resolved)
+  const projectReal = await realpathOrIdentity(projectDir)
+  const rel = path.relative(projectReal, real)
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
     throw new PnpmError(
       'PUBLISH_DIR_OUTSIDE_PROJECT',
       `publishConfig.directory "${manifest.publishConfig.directory}" resolves outside the project`
     )
   }
   return real
+}
+
+async function realpathOrIdentity (p: string): Promise<string> {
+  try {
+    return await fs.realpath(p)
+  } catch {
+    return p
+  }
 }
 
 function selectFromManifest (manifest: Record<string, unknown>, args: string[]): unknown {

--- a/pnpm11/pkg-manifest/commands/src/pkg.ts
+++ b/pnpm11/pkg-manifest/commands/src/pkg.ts
@@ -21,7 +21,6 @@ export function cliOptionsTypes (): Record<string, unknown> {
   return {
     dir: types['dir'],
     json: Boolean,
-    published: Boolean,
     recursive: Boolean,
   }
 }
@@ -31,7 +30,6 @@ export const commandNames = ['pkg']
 interface PkgCommandOptions {
   dir: string
   json?: boolean
-  published?: boolean
   recursive?: boolean
   catalogs?: Catalogs
   hooks?: Hooks
@@ -65,6 +63,8 @@ async function runSubcommand (opts: PkgCommandOptions, subcmd: string, args: str
   switch (subcmd) {
     case 'get':
       return pkgGet(opts, args)
+    case 'get-published':
+      return pkgGetPublished(opts, args)
     case 'set':
       return pkgSet(opts, args)
     case 'delete':
@@ -92,9 +92,10 @@ async function handleRecursiveCommand (opts: PkgCommandOptions, subcmd: string, 
     throw new PnpmError('PKG_RECURSIVE_NO_PACKAGES', 'No workspace packages were selected')
   }
 
-  if (subcmd === 'get') {
+  if (subcmd === 'get' || subcmd === 'get-published') {
+    const readFn = subcmd === 'get-published' ? readPublishedManifest : readRawManifest
     const entries = await Promise.all(selectedProjects.map(async ({ package: pkg }) => {
-      const manifest = await readManifest({ ...opts, dir: pkg.rootDir })
+      const manifest = await readFn({ ...opts, dir: pkg.rootDir })
       const pkgName = String(manifest.name ?? path.relative(workspaceDir, pkg.rootDir))
       return [pkgName, selectFromManifest(manifest, args)] as const
     }))
@@ -107,8 +108,14 @@ async function handleRecursiveCommand (opts: PkgCommandOptions, subcmd: string, 
 }
 
 async function pkgGet (opts: PkgCommandOptions, args: string[]): Promise<string> {
-  const manifest = await readManifest(opts)
+  return formatManifestFields(await readRawManifest(opts), args, opts)
+}
 
+async function pkgGetPublished (opts: PkgCommandOptions, args: string[]): Promise<string> {
+  return formatManifestFields(await readPublishedManifest(opts), args, opts)
+}
+
+function formatManifestFields (manifest: Record<string, unknown>, args: string[], opts: PkgCommandOptions): string {
   if (args.length === 1) {
     const value = getObjectValueByPropertyPathString(manifest, args[0])
     if (value === undefined) return ''
@@ -119,12 +126,13 @@ async function pkgGet (opts: PkgCommandOptions, args: string[]): Promise<string>
   return JSON.stringify(selectFromManifest(manifest, args), undefined, 2)
 }
 
-async function readManifest (opts: PkgCommandOptions): Promise<Record<string, unknown>> {
+async function readRawManifest (opts: PkgCommandOptions): Promise<Record<string, unknown>> {
+  return await readProjectManifestOnly(opts.dir) as Record<string, unknown>
+}
+
+async function readPublishedManifest (opts: PkgCommandOptions): Promise<Record<string, unknown>> {
   const manifest = await readProjectManifestOnly(opts.dir) as ProjectManifest
-  if (!opts.published) return manifest as Record<string, unknown>
-  const dir = manifest.publishConfig?.directory
-    ? path.join(opts.dir, manifest.publishConfig.directory)
-    : opts.dir
+  const dir = resolvePublishDir(opts.dir, manifest)
   const sourceManifest = dir !== opts.dir
     ? await readProjectManifestOnly(dir) as ProjectManifest
     : manifest
@@ -135,6 +143,18 @@ async function readManifest (opts: PkgCommandOptions): Promise<Record<string, un
     modulesDir: path.join(opts.dir, 'node_modules'),
     skipManifestObfuscation: opts.skipManifestObfuscation,
   }) as unknown as Record<string, unknown>
+}
+
+function resolvePublishDir (projectDir: string, manifest: ProjectManifest): string {
+  if (!manifest.publishConfig?.directory) return projectDir
+  const resolved = path.resolve(projectDir, manifest.publishConfig.directory)
+  if (!resolved.startsWith(projectDir + path.sep) && resolved !== projectDir) {
+    throw new PnpmError(
+      'PUBLISH_DIR_OUTSIDE_PROJECT',
+      `publishConfig.directory "${manifest.publishConfig.directory}" resolves outside the project`
+    )
+  }
+  return resolved
 }
 
 function selectFromManifest (manifest: Record<string, unknown>, args: string[]): unknown {
@@ -237,6 +257,10 @@ export function help (): string {
             name: 'get [<key> [<key> ...]]',
           },
           {
+            description: 'Retrieves a value from the publish-transformed package.json (with publishConfig overrides, workspace protocol resolution, script stripping, etc. applied)',
+            name: 'get-published [<key> [<key> ...]]',
+          },
+          {
             description: 'Sets a value in package.json',
             name: 'set <key>=<value> [<key>=<value> ...]',
           },
@@ -258,10 +282,6 @@ export function help (): string {
             name: '--json',
           },
           {
-            description: 'When getting, apply publish-time transformations (workspace protocol resolution, publishConfig overrides, script stripping, etc.) before returning the manifest',
-            name: '--published',
-          },
-          {
             description: 'Run on every workspace project or every project selected by a filter',
             name: '--recursive',
             shortAlias: '-r',
@@ -272,11 +292,13 @@ export function help (): string {
     url: docsUrl('pkg'),
     usages: [
       'pnpm pkg get [<key> [<key> ...]]',
+      'pnpm pkg get-published [<key> [<key> ...]]',
       'pnpm pkg set <key>=<value> [<key>=<value> ...]',
       'pnpm pkg delete <key> [<key> ...]',
       'pnpm pkg fix',
       'pnpm pkg set <key>=<value> --json',
       'pnpm -r pkg get name',
+      'pnpm -r pkg get-published exports',
       'pnpm --filter <selector> pkg get name',
       'pnpm -r pkg set version=1.0.0',
     ],

--- a/pnpm11/pkg-manifest/commands/src/pkg.ts
+++ b/pnpm11/pkg-manifest/commands/src/pkg.ts
@@ -1,13 +1,16 @@
 import path from 'node:path'
 
+import type { Catalogs } from '@pnpm/catalogs.types'
 import { docsUrl, readProjectManifest, readProjectManifestOnly } from '@pnpm/cli.utils'
 import { types as allTypes } from '@pnpm/config.reader'
 import { PnpmError } from '@pnpm/error'
+import type { Hooks } from '@pnpm/hooks.pnpmfile'
 import {
   deleteObjectValueByPropertyPathString,
   getObjectValueByPropertyPathString,
   setObjectValueByPropertyPathString,
 } from '@pnpm/object.property-path'
+import { createExportableManifest } from '@pnpm/releasing.exportable-manifest'
 import type { ProjectManifest } from '@pnpm/types'
 import { renderHelp } from 'render-help'
 
@@ -18,6 +21,7 @@ export function cliOptionsTypes (): Record<string, unknown> {
   return {
     dir: types['dir'],
     json: Boolean,
+    published: Boolean,
     recursive: Boolean,
   }
 }
@@ -27,7 +31,12 @@ export const commandNames = ['pkg']
 interface PkgCommandOptions {
   dir: string
   json?: boolean
+  published?: boolean
   recursive?: boolean
+  catalogs?: Catalogs
+  hooks?: Hooks
+  embedReadme?: boolean
+  skipManifestObfuscation?: boolean
   workspaceDir?: string
   selectedProjectsGraph?: Record<string, { package: { rootDir: string, manifest: Record<string, unknown> } }>
 }
@@ -85,7 +94,7 @@ async function handleRecursiveCommand (opts: PkgCommandOptions, subcmd: string, 
 
   if (subcmd === 'get') {
     const entries = await Promise.all(selectedProjects.map(async ({ package: pkg }) => {
-      const manifest = await readProjectManifestOnly(pkg.rootDir) as Record<string, unknown>
+      const manifest = await readManifest({ ...opts, dir: pkg.rootDir })
       const pkgName = String(manifest.name ?? path.relative(workspaceDir, pkg.rootDir))
       return [pkgName, selectFromManifest(manifest, args)] as const
     }))
@@ -98,7 +107,7 @@ async function handleRecursiveCommand (opts: PkgCommandOptions, subcmd: string, 
 }
 
 async function pkgGet (opts: PkgCommandOptions, args: string[]): Promise<string> {
-  const manifest = await readProjectManifestOnly(opts.dir) as Record<string, unknown>
+  const manifest = await readManifest(opts)
 
   if (args.length === 1) {
     const value = getObjectValueByPropertyPathString(manifest, args[0])
@@ -108,6 +117,24 @@ async function pkgGet (opts: PkgCommandOptions, args: string[]): Promise<string>
   }
 
   return JSON.stringify(selectFromManifest(manifest, args), undefined, 2)
+}
+
+async function readManifest (opts: PkgCommandOptions): Promise<Record<string, unknown>> {
+  const manifest = await readProjectManifestOnly(opts.dir) as ProjectManifest
+  if (!opts.published) return manifest as Record<string, unknown>
+  const dir = manifest.publishConfig?.directory
+    ? path.join(opts.dir, manifest.publishConfig.directory)
+    : opts.dir
+  const sourceManifest = dir !== opts.dir
+    ? await readProjectManifestOnly(dir) as ProjectManifest
+    : manifest
+  return await createExportableManifest(dir, sourceManifest, {
+    catalogs: opts.catalogs ?? {},
+    hooks: opts.hooks,
+    embedReadme: opts.embedReadme,
+    modulesDir: path.join(opts.dir, 'node_modules'),
+    skipManifestObfuscation: opts.skipManifestObfuscation,
+  }) as unknown as Record<string, unknown>
 }
 
 function selectFromManifest (manifest: Record<string, unknown>, args: string[]): unknown {
@@ -229,6 +256,10 @@ export function help (): string {
           {
             description: 'When setting, parse the value as JSON. When getting a single key, return its JSON-encoded form instead of the raw value',
             name: '--json',
+          },
+          {
+            description: 'When getting, apply publish-time transformations (workspace protocol resolution, publishConfig overrides, script stripping, etc.) before returning the manifest',
+            name: '--published',
           },
           {
             description: 'Run on every workspace project or every project selected by a filter',

--- a/pnpm11/pkg-manifest/commands/src/pkg.ts
+++ b/pnpm11/pkg-manifest/commands/src/pkg.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import type { Catalogs } from '@pnpm/catalogs.types'
@@ -132,7 +133,7 @@ async function readRawManifest (opts: PkgCommandOptions): Promise<Record<string,
 
 async function readPublishedManifest (opts: PkgCommandOptions): Promise<Record<string, unknown>> {
   const manifest = await readProjectManifestOnly(opts.dir) as ProjectManifest
-  const dir = resolvePublishDir(opts.dir, manifest)
+  const dir = await resolvePublishDir(opts.dir, manifest)
   const sourceManifest = dir !== opts.dir
     ? await readProjectManifestOnly(dir) as ProjectManifest
     : manifest
@@ -145,16 +146,22 @@ async function readPublishedManifest (opts: PkgCommandOptions): Promise<Record<s
   }) as unknown as Record<string, unknown>
 }
 
-function resolvePublishDir (projectDir: string, manifest: ProjectManifest): string {
+async function resolvePublishDir (projectDir: string, manifest: ProjectManifest): Promise<string> {
   if (!manifest.publishConfig?.directory) return projectDir
   const resolved = path.resolve(projectDir, manifest.publishConfig.directory)
-  if (!resolved.startsWith(projectDir + path.sep) && resolved !== projectDir) {
+  let real: string
+  try {
+    real = await fs.realpath(resolved)
+  } catch {
+    real = resolved
+  }
+  if (!real.startsWith(projectDir + path.sep) && real !== projectDir) {
     throw new PnpmError(
       'PUBLISH_DIR_OUTSIDE_PROJECT',
       `publishConfig.directory "${manifest.publishConfig.directory}" resolves outside the project`
     )
   }
-  return resolved
+  return real
 }
 
 function selectFromManifest (manifest: Record<string, unknown>, args: string[]): unknown {

--- a/pnpm11/pkg-manifest/commands/test/pkg.test.ts
+++ b/pnpm11/pkg-manifest/commands/test/pkg.test.ts
@@ -250,7 +250,7 @@ describe('pkg command', () => {
     })
   })
 
-  describe('get --published', () => {
+  describe('get-published subcommand', () => {
     test('applies publishConfig overrides', async () => {
       const manifest = {
         name: 'test-package',
@@ -262,7 +262,7 @@ describe('pkg command', () => {
       }
       fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(manifest, null, 2))
 
-      const result = await handler({ dir: tmpDir, published: true }, ['get', 'main'])
+      const result = await handler({ dir: tmpDir }, ['get-published', 'main'])
       expect(result).toBe('./dist/index.js')
     })
 
@@ -278,7 +278,7 @@ describe('pkg command', () => {
       }
       fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(manifest, null, 2))
 
-      const result = JSON.parse(await handler({ dir: tmpDir, published: true }, ['get', 'scripts']) as string)
+      const result = JSON.parse(await handler({ dir: tmpDir }, ['get-published', 'scripts']) as string)
       expect(result.build).toBe('tsc')
       expect(result.prepublishOnly).toBeUndefined()
       expect(result.prepack).toBeUndefined()
@@ -294,7 +294,7 @@ describe('pkg command', () => {
       }
       fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(manifest, null, 2))
 
-      const result = JSON.parse(await handler({ dir: tmpDir, published: true }, ['get']) as string)
+      const result = JSON.parse(await handler({ dir: tmpDir }, ['get-published']) as string)
       expect(result.pnpm).toBeUndefined()
     })
 
@@ -309,9 +309,23 @@ describe('pkg command', () => {
       }
       fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(manifest, null, 2))
 
-      const result = JSON.parse(await handler({ dir: tmpDir, published: true }, ['get']) as string)
+      const result = JSON.parse(await handler({ dir: tmpDir }, ['get-published']) as string)
       expect(result.main).toBe('./dist/index.js')
       expect(result.name).toBe('test-package')
+    })
+
+    test('rejects publishConfig.directory that escapes the project', async () => {
+      const manifest = {
+        name: 'test-package',
+        version: '1.0.0',
+        publishConfig: {
+          directory: '../../../etc',
+        },
+      }
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(manifest, null, 2))
+
+      await expect(handler({ dir: tmpDir }, ['get-published']))
+        .rejects.toMatchObject({ code: 'ERR_PNPM_PUBLISH_DIR_OUTSIDE_PROJECT' })
     })
   })
 

--- a/pnpm11/pkg-manifest/commands/test/pkg.test.ts
+++ b/pnpm11/pkg-manifest/commands/test/pkg.test.ts
@@ -314,6 +314,32 @@ describe('pkg command', () => {
       expect(result.name).toBe('test-package')
     })
 
+    test('reads from publishConfig.directory subfolder', async () => {
+      const rootManifest = {
+        name: 'root-package',
+        version: '1.0.0',
+        main: './src/index.ts',
+        publishConfig: {
+          directory: 'dist',
+        },
+      }
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(rootManifest, null, 2))
+
+      const distDir = path.join(tmpDir, 'dist')
+      fs.mkdirSync(distDir, { recursive: true })
+      const distManifest = {
+        name: 'root-package',
+        version: '1.0.0',
+        main: './index.js',
+        types: './index.d.ts',
+      }
+      fs.writeFileSync(path.join(distDir, 'package.json'), JSON.stringify(distManifest, null, 2))
+
+      const result = JSON.parse(await handler({ dir: tmpDir }, ['get-published']) as string)
+      expect(result.main).toBe('./index.js')
+      expect(result.types).toBe('./index.d.ts')
+    })
+
     test('rejects publishConfig.directory that escapes the project', async () => {
       const manifest = {
         name: 'test-package',

--- a/pnpm11/pkg-manifest/commands/test/pkg.test.ts
+++ b/pnpm11/pkg-manifest/commands/test/pkg.test.ts
@@ -351,7 +351,10 @@ describe('pkg command', () => {
       fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(manifest, null, 2))
 
       await expect(handler({ dir: tmpDir }, ['get-published']))
-        .rejects.toMatchObject({ code: 'ERR_PNPM_PUBLISH_DIR_OUTSIDE_PROJECT' })
+        .rejects.toMatchObject({
+          code: 'ERR_PNPM_PUBLISH_DIR_OUTSIDE_PROJECT',
+          message: expect.stringContaining('../../../etc'),
+        })
     })
   })
 

--- a/pnpm11/pkg-manifest/commands/test/pkg.test.ts
+++ b/pnpm11/pkg-manifest/commands/test/pkg.test.ts
@@ -250,6 +250,71 @@ describe('pkg command', () => {
     })
   })
 
+  describe('get --published', () => {
+    test('applies publishConfig overrides', async () => {
+      const manifest = {
+        name: 'test-package',
+        version: '1.0.0',
+        main: './src/index.ts',
+        publishConfig: {
+          main: './dist/index.js',
+        },
+      }
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(manifest, null, 2))
+
+      const result = await handler({ dir: tmpDir, published: true }, ['get', 'main'])
+      expect(result).toBe('./dist/index.js')
+    })
+
+    test('strips publish lifecycle scripts', async () => {
+      const manifest = {
+        name: 'test-package',
+        version: '1.0.0',
+        scripts: {
+          build: 'tsc',
+          prepublishOnly: 'npm run build',
+          prepack: 'echo prepack',
+        },
+      }
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(manifest, null, 2))
+
+      const result = JSON.parse(await handler({ dir: tmpDir, published: true }, ['get', 'scripts']) as string)
+      expect(result.build).toBe('tsc')
+      expect(result.prepublishOnly).toBeUndefined()
+      expect(result.prepack).toBeUndefined()
+    })
+
+    test('strips pnpm field', async () => {
+      const manifest = {
+        name: 'test-package',
+        version: '1.0.0',
+        pnpm: {
+          overrides: { foo: '1.0.0' },
+        },
+      }
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(manifest, null, 2))
+
+      const result = JSON.parse(await handler({ dir: tmpDir, published: true }, ['get']) as string)
+      expect(result.pnpm).toBeUndefined()
+    })
+
+    test('returns full transformed manifest with no field args', async () => {
+      const manifest = {
+        name: 'test-package',
+        version: '1.0.0',
+        main: './src/index.ts',
+        publishConfig: {
+          main: './dist/index.js',
+        },
+      }
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(manifest, null, 2))
+
+      const result = JSON.parse(await handler({ dir: tmpDir, published: true }, ['get']) as string)
+      expect(result.main).toBe('./dist/index.js')
+      expect(result.name).toBe('test-package')
+    })
+  })
+
   describe('error handling', () => {
     test('throws error for unknown subcommand', async () => {
       const manifest = { name: 'test-package' }

--- a/pnpm11/pkg-manifest/commands/tsconfig.json
+++ b/pnpm11/pkg-manifest/commands/tsconfig.json
@@ -10,10 +10,13 @@
   ],
   "references": [
     { "path": "../../__utils__/prepare" },
+    { "path": "../../catalogs/types" },
     { "path": "../../cli/utils" },
     { "path": "../../config/reader" },
     { "path": "../../core/error" },
     { "path": "../../core/types" },
-    { "path": "../../object/property-path" }
+    { "path": "../../hooks/pnpmfile" },
+    { "path": "../../object/property-path" },
+    { "path": "../../releasing/exportable-manifest" }
   ]
 }


### PR DESCRIPTION
## Summary

Adds `pnpm pkg get-published` — a lightweight subcommand that outputs the publish-transformed package.json without packing or publishing. It applies all publish-time transformations (`publishConfig` overrides, `workspace:` protocol resolution, catalog resolution, script stripping, etc.) and returns the result.

Supports field selection (`pnpm pkg get-published exports`) and `--recursive`.

## Squash Commit Body

```text
Add `pnpm pkg get-published [<key> ...]` subcommand that reads the local
package.json, applies the same publish-time manifest transformations used by
`pnpm pack` and `pnpm publish` (via createExportableManifest), and prints the
result. No tarballs are created, no scripts are run, and nothing is sent to a
registry.

Validates that publishConfig.directory does not escape the project root.
```

## Checklist

- [x] pacquet port not needed — `pkg` is outside pacquet's current surface area.
- [x] Added a changeset.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pnpm pkg get-published` to output the publish-ready, transformed `package.json`, including recursive support (`-r`).
  * Allows selecting specific fields (e.g., `exports`).
* **Bug Fixes**
  * Applies `publishConfig` overrides in the output.
  * Strips publish lifecycle scripts (e.g., `prepublishOnly`, `prepack`) and omits the `pnpm` field.
  * Supports `publishConfig.directory` with safeguards to prevent using directories outside the project.
* **Documentation**
  * Added release documentation and examples for `get-published`.
* **Tests**
  * Added coverage for transformations, field selection, recursion, directory resolution, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->