### PR TITLE
docs: replicate every user-visible pnpm CLI change in pacquet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ When you change one side, do the equivalent change on the other in the same PR i
 
 "User-visible" means anything that affects the CLI surface or the on-disk contract: command-line flags and defaults, environment-variable handling, lockfile/manifest/state-file format, error codes and messages, log emissions parsed by `@pnpm/cli.default-reporter`, store layout, hook semantics. Pure internal refactors, perf wins, and TS-only test cleanups don't need mirroring.
 
-**Scope caveat:** pacquet's current surface area is the dependency-management commands — `install`, `add`, `update`, and `remove`. Every other command (`publish`, `exec`, `run`, `dlx`, `audit`, etc.) lives only in the TypeScript code, so changes there don't need a pacquet-side port yet. The parity rule will widen as pacquet ports more commands; check what pacquet exposes before deciding whether your change is in scope.
+**Any user-visible change to the TypeScript pnpm CLI must be replicated in pacquet.**
 
 The pacquet-side obligation — pnpm is the source of truth, pacquet ports from it, never the other way around — is spelled out at [`pacquet/AGENTS.md`](./pacquet/AGENTS.md#the-cardinal-rule).
 


### PR DESCRIPTION
## Summary

Updates the "Keep pnpm and pacquet in sync" section of `AGENTS.md`. The old
**Scope caveat** claimed pacquet only implemented the dependency-management
commands (`install`, `add`, `update`, `remove`) and that everything else was
TypeScript-only and didn't need porting. That is well out of date — pacquet has
since ported almost the entire command surface (`run`, `exec`, `dlx`, `audit`,
`patch`, `link`, `deploy`, `prune`, `fetch`, `dedupe`, `import`, `config`,
`store`, `cache`, `setup`, `self-update`, `logout`, `with`, and more; see
`pacquet/crates/cli/src/cli_args/cli_command.rs`).

The stale caveat was giving agents a false "out of scope for pacquet" escape
hatch. It's replaced with a single line stating that any user-visible change to
the TypeScript pnpm CLI must be replicated in pacquet.

## Squash Commit Body

```text
The "Scope caveat" claimed pacquet only implemented install/add/update/remove
and that all other commands were TypeScript-only. pacquet has since ported
nearly the whole command surface, so the caveat was a false out-of-scope escape
hatch. Replace it with a one-line rule: any user-visible change to the
TypeScript pnpm CLI must be replicated in pacquet.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting. (Docs-only
  change to a repo-root guide that governs both stacks; nothing to port.)
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. (Not applicable — docs-only.)
- [ ] Added or updated tests. (Not applicable — docs-only.)
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified repository guidance to keep user-visible CLI behavior consistent across implementations.
  * Updated the scope notes to better explain current command coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->