### PR TITLE
fix: pass workspace packages to outdated resolver (fix pnpm/pnpm#12682)

### DIFF
--- a/.changeset/workspace-outdated-resolver.md
+++ b/.changeset/workspace-outdated-resolver.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/deps.inspection.outdated": patch
+"pnpm": patch
+---
+
+Fixed recursive interactive updates crashing on malformed workspace protocol specifiers.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3589,6 +3589,9 @@ importers:
       '@pnpm/installing.client':
         specifier: workspace:*
         version: link:../../../installing/client
+      '@pnpm/installing.context':
+        specifier: workspace:*
+        version: link:../../../installing/context
       '@pnpm/lockfile.fs':
         specifier: workspace:*
         version: link:../../../lockfile/fs
@@ -3601,6 +3604,9 @@ importers:
       '@pnpm/resolving.npm-resolver':
         specifier: workspace:*
         version: link:../../../resolving/npm-resolver
+      '@pnpm/resolving.resolver-base':
+        specifier: workspace:*
+        version: link:../../../resolving/resolver-base
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../../core/types
@@ -3620,9 +3626,6 @@ importers:
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../../../core/logger
-      '@pnpm/resolving.resolver-base':
-        specifier: workspace:*
-        version: link:../../../resolving/resolver-base
       '@types/ramda':
         specifier: 'catalog:'
         version: 0.31.1

--- a/pnpm11/deps/inspection/outdated/package.json
+++ b/pnpm11/deps/inspection/outdated/package.json
@@ -42,10 +42,12 @@
     "@pnpm/error": "workspace:*",
     "@pnpm/hooks.read-package-hook": "workspace:*",
     "@pnpm/installing.client": "workspace:*",
+    "@pnpm/installing.context": "workspace:*",
     "@pnpm/lockfile.fs": "workspace:*",
     "@pnpm/lockfile.utils": "workspace:*",
     "@pnpm/pkg-manifest.utils": "workspace:*",
     "@pnpm/resolving.npm-resolver": "workspace:*",
+    "@pnpm/resolving.resolver-base": "workspace:*",
     "@pnpm/types": "workspace:*",
     "ramda": "catalog:",
     "semver": "catalog:"
@@ -57,7 +59,6 @@
     "@jest/globals": "catalog:",
     "@pnpm/deps.inspection.outdated": "workspace:*",
     "@pnpm/logger": "workspace:*",
-    "@pnpm/resolving.resolver-base": "workspace:*",
     "@types/ramda": "catalog:",
     "@types/semver": "catalog:"
   },

--- a/pnpm11/deps/inspection/outdated/src/outdated.ts
+++ b/pnpm11/deps/inspection/outdated/src/outdated.ts
@@ -18,6 +18,7 @@ import {
   type ProjectSnapshot,
 } from '@pnpm/lockfile.fs'
 import { getAllDependenciesFromManifest } from '@pnpm/pkg-manifest.utils'
+import type { WorkspacePackages } from '@pnpm/resolving.resolver-base'
 import {
   DEPENDENCIES_FIELDS,
   type DependenciesField,
@@ -58,6 +59,7 @@ export async function outdated (
     publishedBy?: Date
     publishedByExclude?: PackageVersionPolicy
     wantedLockfile: LockfileObject | null
+    workspacePackages?: WorkspacePackages
   }
 ): Promise<OutdatedPackage[]> {
   if (packageHasNoDeps(opts.manifest)) return []
@@ -93,6 +95,7 @@ export async function outdated (
     projectDir: opts.prefix,
     publishedBy: opts.publishedBy,
     publishedByExclude: opts.publishedByExclude,
+    workspacePackages: opts.workspacePackages,
   }
 
   await Promise.all(

--- a/pnpm11/deps/inspection/outdated/src/outdatedDepsOfProjects.ts
+++ b/pnpm11/deps/inspection/outdated/src/outdatedDepsOfProjects.ts
@@ -4,10 +4,12 @@ import type { Catalogs } from '@pnpm/catalogs.types'
 import { createMatcher } from '@pnpm/config.matcher'
 import { getPublishedByPolicy } from '@pnpm/config.version-policy'
 import { type ClientOptions, createResolver } from '@pnpm/installing.client'
+import { arrayOfWorkspacePackagesToMap } from '@pnpm/installing.context'
 import {
   readCurrentLockfile,
   readWantedLockfile,
 } from '@pnpm/lockfile.fs'
+import type { WorkspacePackages } from '@pnpm/resolving.resolver-base'
 import type {
   IncludedDependencies,
   ProjectManifest,
@@ -28,6 +30,7 @@ export type OutdatedDepsOfProjectsOptions = Omit<ClientOptions, 'configByUri' | 
   minimumReleaseAgeExclude?: string[]
   minimumReleaseAgeIgnoreMissingTime?: boolean
   minimumReleaseAgeStrict?: boolean
+  workspacePackages?: WorkspacePackages
 }
 
 export async function outdatedDepsOfProjects (
@@ -40,10 +43,11 @@ export async function outdatedDepsOfProjects (
     include: IncludedDependencies
   }
 ): Promise<OutdatedPackage[][]> {
+  const workspacePackages = opts.workspacePackages ?? arrayOfWorkspacePackagesToMap(pkgs)
   if (!opts.lockfileDir) {
     return unnest(await Promise.all(
       pkgs.map(async (pkg) =>
-        outdatedDepsOfProjects([pkg], args, { ...opts, lockfileDir: pkg.rootDir })
+        outdatedDepsOfProjects([pkg], args, { ...opts, lockfileDir: pkg.rootDir, workspacePackages })
       )
     ))
   }
@@ -79,6 +83,7 @@ export async function outdatedDepsOfProjects (
       publishedBy,
       publishedByExclude,
       wantedLockfile,
+      workspacePackages,
     })
   }))
 }

--- a/pnpm11/deps/inspection/outdated/test/outdated.spec.ts
+++ b/pnpm11/deps/inspection/outdated/test/outdated.spec.ts
@@ -1,7 +1,8 @@
 import { expect, test } from '@jest/globals'
 import { LOCKFILE_VERSION } from '@pnpm/constants'
 import type { ResolveLatestDispatcher } from '@pnpm/installing.client'
-import type { DepPath, PackageManifest, ProjectId } from '@pnpm/types'
+import type { WorkspacePackages } from '@pnpm/resolving.resolver-base'
+import type { DepPath, PackageManifest, ProjectId, ProjectRootDir } from '@pnpm/types'
 
 import { outdated } from '../lib/outdated.js'
 
@@ -1085,5 +1086,61 @@ test('outdated() does not list runtime that is already up to date', async () => 
     wantedLockfile: lockfile,
   })
 
+  expect(outdatedPkgs).toStrictEqual([])
+})
+
+test('outdated() passes workspace packages to resolver for spaced workspace protocol', async () => {
+  const workspacePackages: WorkspacePackages = new Map([
+    ['@repro/a', new Map([
+      ['1.0.0', {
+        rootDir: 'project/packages/a' as ProjectRootDir,
+        manifest: {
+          name: '@repro/a',
+          version: '1.0.0',
+        },
+      }],
+    ])],
+  ])
+  let resolveCalls = 0
+  const resolveLatest: ResolveLatestDispatcher = async (query, resolveOpts) => {
+    resolveCalls++
+    expect(query.wantedDependency).toStrictEqual({
+      alias: '@repro/a',
+      bareSpecifier: 'workspace: *',
+    })
+    expect(resolveOpts.workspacePackages).toBe(workspacePackages)
+    return undefined
+  }
+  const lockfile = {
+    importers: {
+      ['.' as ProjectId]: {
+        dependencies: {
+          '@repro/a': 'link:packages/a',
+        },
+        specifiers: {
+          '@repro/a': 'workspace: *',
+        },
+      },
+    },
+    lockfileVersion: LOCKFILE_VERSION,
+  }
+
+  const outdatedPkgs = await outdated({
+    currentLockfile: lockfile,
+    resolveLatest,
+    lockfileDir: 'project',
+    manifest: {
+      name: '@repro/b',
+      version: '1.0.0',
+      dependencies: {
+        '@repro/a': 'workspace: *',
+      },
+    },
+    prefix: 'project',
+    wantedLockfile: lockfile,
+    workspacePackages,
+  })
+
+  expect(resolveCalls).toBe(1)
   expect(outdatedPkgs).toStrictEqual([])
 })

--- a/pnpm11/deps/inspection/outdated/tsconfig.json
+++ b/pnpm11/deps/inspection/outdated/tsconfig.json
@@ -43,6 +43,9 @@
       "path": "../../../installing/client"
     },
     {
+      "path": "../../../installing/context"
+    },
+    {
       "path": "../../../lockfile/fs"
     },
     {

--- a/pnpm11/installing/commands/src/update/index.ts
+++ b/pnpm11/installing/commands/src/update/index.ts
@@ -12,6 +12,7 @@ import { types as allTypes } from '@pnpm/config.reader'
 import { outdatedDepsOfProjects } from '@pnpm/deps.inspection.outdated'
 import { PnpmError } from '@pnpm/error'
 import { handleGlobalUpdate } from '@pnpm/global.commands'
+import { arrayOfWorkspacePackagesToMap } from '@pnpm/installing.context'
 import type { UpdateMatchingFunction } from '@pnpm/installing.deps-installer'
 import { globalInfo } from '@pnpm/logger'
 import type { IncludedDependencies, PackageVulnerabilityAudit, ProjectRootDir } from '@pnpm/types'
@@ -224,6 +225,7 @@ async function interactiveUpdate (
       retries: opts.fetchRetries,
     },
     timeout: opts.fetchTimeout,
+    workspacePackages: opts.allProjects ? arrayOfWorkspacePackagesToMap(opts.allProjects) : undefined,
   })
   const workspacesEnabled = !!opts.workspaceDir
   const choiceGroups = getUpdateChoices(unnest(outdatedPkgsOfProjects), workspacesEnabled)

--- a/pnpm11/installing/commands/test/update/recursive.ts
+++ b/pnpm11/installing/commands/test/update/recursive.ts
@@ -119,6 +119,83 @@ test('recursive update prod dependencies only', async () => {
   })
 })
 
+test('recursive interactive update handles spaced workspace specifier', async () => {
+  preparePackages([
+    {
+      name: '@repro/a',
+      version: '1.0.0',
+    },
+    {
+      name: '@repro/b',
+      version: '1.0.0',
+
+      dependencies: {
+        '@repro/a': 'workspace: *',
+      },
+    },
+  ])
+
+  const { allProjects, selectedProjectsGraph } = await filterProjectsBySelectorObjectsFromDir(process.cwd(), [])
+  await install.handler({
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    recursive: true,
+    selectedProjectsGraph,
+    workspaceDir: process.cwd(),
+  })
+
+  await expect(update.handler({
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    interactive: true,
+    latest: true,
+    recursive: true,
+    selectedProjectsGraph,
+    workspaceDir: process.cwd(),
+  })).resolves.toBe('All of your dependencies are already up to date')
+})
+
+test('filtered recursive interactive update handles spaced workspace specifier', async () => {
+  preparePackages([
+    {
+      name: '@repro/a',
+      version: '1.0.0',
+    },
+    {
+      name: '@repro/b',
+      version: '1.0.0',
+
+      dependencies: {
+        '@repro/a': 'workspace: *',
+      },
+    },
+  ])
+
+  const { allProjects, selectedProjectsGraph } = await filterProjectsBySelectorObjectsFromDir(process.cwd(), [])
+  await install.handler({
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    recursive: true,
+    selectedProjectsGraph,
+    workspaceDir: process.cwd(),
+  })
+
+  const { selectedProjectsGraph: filteredProjectsGraph } = await filterProjectsBySelectorObjectsFromDir(process.cwd(), [{ namePattern: '@repro/b' }])
+  await expect(update.handler({
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    interactive: true,
+    latest: true,
+    recursive: true,
+    selectedProjectsGraph: filteredProjectsGraph,
+    workspaceDir: process.cwd(),
+  })).resolves.toBe('All of your dependencies are already up to date')
+})
+
 test('recursive update with pattern', async () => {
   const projects = preparePackages([
     {


### PR DESCRIPTION
## Summary

- build a workspace package map for recursive outdated checks before splitting projects by lockfile directory
- pass that map through `outdated()` into the latest resolver so malformed spaced workspace specs do not crash resolution
- add unit and recursive update regressions for `workspace: *`

## Tests

- `pnpm -C pnpm11/deps/inspection/outdated exec cross-env NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" jest test/outdated.spec.ts --runInBand`
- `pnpm -C pnpm11/installing/commands exec cross-env NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" jest test/update/recursive.ts --runInBand`
- `pnpm -C pnpm11/deps/inspection/outdated exec tsgo --build --pretty false && pnpm -C pnpm11/installing/commands exec tsgo --build --pretty false`
- `git diff --check`
- pre-push hook passed: `pnpm run compile-only && pnpm run lint --quiet`; Rust `cargo fmt`, `cargo clippy`, and `cargo doc` also passed. The hook skipped `cargo-dylint` and `taplo` because those optional local tools are not installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in recursive interactive updates when `workspace:` specifiers use spacing (e.g. `workspace: *`).
  * Improved how workspace package context is propagated during outdated checks, improving reliability of interactive `pnpm update` selections.
  * Recursive interactive updates now finish successfully and can correctly report “already up to date.”
* **Tests**
  * Added Jest coverage for recursive interactive `pnpm update` with spaced `workspace:` specifiers, validating the resolved “already up to date” message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->