### PR TITLE
feat(pacquet/cli): apply `--filter` selection in recursive run and exec

### DIFF
--- a/pacquet/crates/cli/src/cli_args/exec.rs
+++ b/pacquet/crates/cli/src/cli_args/exec.rs
@@ -18,12 +18,11 @@ use std::{
 /// Ports pnpm's `exec` command from
 /// <https://github.com/pnpm/pnpm/blob/d4a2b0364c/exec/commands/src/exec.ts>.
 /// The recursive variant (selected by the global `-r` / `--recursive`
-/// flag) runs the command in every workspace project, topologically
-/// sorted and sequential, with `--resume-from` / `--report-summary` /
-/// `--no-bail` (see [`recursive`]). The `--filter` package-selector
-/// narrowing and `--workspace-concurrency` parallelism are not ported yet
-/// — the selected set is every workspace project, matching the recursive
-/// `run` runner and pacquet's currently-unfiltered `install`.
+/// flag) runs the command across the `--filter`-selected workspace
+/// projects, topologically sorted and sequential, with `--resume-from` /
+/// `--report-summary` / `--no-bail` (see [`recursive`]).
+/// `--workspace-concurrency` parallelism is not ported yet, matching the
+/// recursive `run` runner.
 #[derive(Debug, Args)]
 pub struct ExecArgs {
     /// The command to run, followed by its arguments.

--- a/pacquet/crates/cli/src/cli_args/exec.rs
+++ b/pacquet/crates/cli/src/cli_args/exec.rs
@@ -99,9 +99,9 @@ impl ExecArgs {
         Ok(())
     }
 
-    /// Execute the command for every project in the workspace, in
-    /// topological order. The recursive counterpart of [`Self::run`],
-    /// selected when the global `-r` / `--recursive` flag is set.
+    /// Execute the command across the `--filter`-selected workspace
+    /// projects, in topological order. The recursive counterpart of
+    /// [`Self::run`], selected when the global `-r` / `--recursive` flag is set.
     pub fn run_recursive(&self, config: &Config, dir: &Path) -> miette::Result<()> {
         recursive::exec_recursive(self, config, dir)
     }

--- a/pacquet/crates/cli/src/cli_args/exec/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/exec/recursive.rs
@@ -62,22 +62,15 @@ pub fn exec_recursive(args: &ExecArgs, config: &Config, dir: &Path) -> miette::R
     let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
 
     let projects = discover_workspace_projects(workspace_root)?;
-    // An empty workspace (no projects discovered) is reported as
-    // `RECURSIVE_EXEC_NO_PACKAGE`; this guard checks the discovered set,
-    // not the filtered one. (pnpm's own recursive path exits 0 here from
-    // its main dispatch rather than throwing — its same-named throw is on
-    // the non-recursive path, exec.ts:211-213 — a pre-existing pacquet
-    // divergence left untouched.)
+    // Empty workspace errors; an empty `--filter` selection (below) is a
+    // no-op — so this guard is on the discovered set, not the filtered.
     if projects.is_empty() {
         return Err(RecursiveExecError::NoPackage.into());
     }
 
     let graph = select_recursive_projects(&projects, config, dir)?;
-    // A non-empty workspace whose `--filter` selection is empty is a
-    // no-op: pnpm exits 0 from its main dispatch when
-    // `selectedProjectsGraph` is empty (main.ts:306-318), before the
-    // command runs — so `--resume-from` must not error on the empty graph
-    // and `--report-summary` must not write an empty summary.
+    // An empty `--filter` selection is a no-op, matching pnpm's exit-0 for
+    // an empty selectedProjectsGraph.
     if graph.is_empty() {
         return Ok(());
     }

--- a/pacquet/crates/cli/src/cli_args/exec/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/exec/recursive.rs
@@ -1,5 +1,5 @@
-//! Recursive `pacquet exec` — run a command in every project of the
-//! workspace, in topological order.
+//! Recursive `pacquet exec` — run a command across the `--filter`-selected
+//! workspace projects, in topological order.
 //!
 //! Port of the recursive path of pnpm's
 //! [`exec`](https://github.com/pnpm/pnpm/blob/8eb1be4988/exec/commands/src/exec.ts)
@@ -52,8 +52,8 @@ pub enum RecursiveExecError {
     },
 }
 
-/// Run `args.command` across every workspace project, sorted
-/// topologically. `dir` is the canonicalized working directory; the
+/// Run `args.command` across the `--filter`-selected workspace projects,
+/// sorted topologically. `dir` is the canonicalized working directory; the
 /// workspace root (and the directory the summary is written to) is
 /// `config.workspace_dir`, falling back to `dir` when no
 /// `pnpm-workspace.yaml` exists.

--- a/pacquet/crates/cli/src/cli_args/exec/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/exec/recursive.rs
@@ -62,16 +62,25 @@ pub fn exec_recursive(args: &ExecArgs, config: &Config, dir: &Path) -> miette::R
     let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
 
     let projects = discover_workspace_projects(workspace_root)?;
-    // pnpm throws `RECURSIVE_EXEC_NO_PACKAGE` when no package exists in
-    // the workspace at all (exec.ts:211-213). A non-empty workspace whose
-    // `--filter` selection is empty is a no-op (pnpm exits 0 from its main
-    // dispatch before reaching the exec handler), so the check is on the
-    // discovered set, not the filtered one.
+    // An empty workspace (no projects discovered) is reported as
+    // `RECURSIVE_EXEC_NO_PACKAGE`; this guard checks the discovered set,
+    // not the filtered one. (pnpm's own recursive path exits 0 here from
+    // its main dispatch rather than throwing — its same-named throw is on
+    // the non-recursive path, exec.ts:211-213 — a pre-existing pacquet
+    // divergence left untouched.)
     if projects.is_empty() {
         return Err(RecursiveExecError::NoPackage.into());
     }
 
     let graph = select_recursive_projects(&projects, config, dir)?;
+    // A non-empty workspace whose `--filter` selection is empty is a
+    // no-op: pnpm exits 0 from its main dispatch when
+    // `selectedProjectsGraph` is empty (main.ts:306-318), before the
+    // command runs — so `--resume-from` must not error on the empty graph
+    // and `--report-summary` must not write an empty summary.
+    if graph.is_empty() {
+        return Ok(());
+    }
 
     let mut chunks = sort_projects(&graph);
     if let Some(resume_from) = &args.resume_from {

--- a/pacquet/crates/cli/src/cli_args/exec/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/exec/recursive.rs
@@ -6,26 +6,22 @@
 //! handler, reusing the shared graph / summary machinery in
 //! [`crate::cli_args::recursive`].
 //!
-//! Scope versus upstream: projects are sorted topologically (upstream's
-//! default) and run sequentially. `--filter` narrowing of the selected
-//! set and `--workspace-concurrency` parallelism are not ported yet — the
-//! selected set is every workspace project, matching the recursive `run`
-//! runner.
+//! Scope versus upstream: `config.filter` / `config.filter_prod`
+//! (`--filter` / `--filter-prod`, include and exclude selectors) narrow
+//! the selected set via [`select_recursive_projects`]; the selection is
+//! then sorted topologically (upstream's default) and run sequentially.
+//! `--workspace-concurrency` parallelism is not ported yet, matching the
+//! recursive `run` runner.
 
 use super::{ExecArgs, prepare_command, spawn_in_dir};
 use crate::cli_args::recursive::{
-    ExecutionStatus, GraphPkg, Status, count_failures, get_resumed_package_chunks, sort_projects,
-    write_recursive_summary,
+    ExecutionStatus, Status, count_failures, discover_workspace_projects,
+    get_resumed_package_chunks, select_recursive_projects, sort_projects, write_recursive_summary,
 };
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
-use miette::{Context, Diagnostic, IntoDiagnostic};
+use miette::Diagnostic;
 use pacquet_config::Config;
-use pacquet_workspace::{
-    FindWorkspaceProjectsOpts, find_workspace_projects, read_workspace_manifest,
-    workspace_package_patterns,
-};
-use pacquet_workspace_projects_graph::{CreateProjectsGraphOptions, create_projects_graph};
 use std::{
     path::{Path, PathBuf},
     time::Instant,
@@ -65,20 +61,17 @@ pub fn exec_recursive(args: &ExecArgs, config: &Config, dir: &Path) -> miette::R
     let command = prepare_command(args.command.clone())?;
     let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
 
-    let patterns = read_workspace_manifest(workspace_root)
-        .into_diagnostic()
-        .wrap_err("reading pnpm-workspace.yaml")?
-        .map(|manifest| workspace_package_patterns(&manifest));
-    let projects = find_workspace_projects(workspace_root, &FindWorkspaceProjectsOpts { patterns })
-        .wrap_err("finding workspace projects")?;
-    // pnpm throws `RECURSIVE_EXEC_NO_PACKAGE` when the selected set is
-    // empty (exec.ts:207-209).
+    let projects = discover_workspace_projects(workspace_root)?;
+    // pnpm throws `RECURSIVE_EXEC_NO_PACKAGE` when no package exists in
+    // the workspace at all (exec.ts:211-213). A non-empty workspace whose
+    // `--filter` selection is empty is a no-op (pnpm exits 0 from its main
+    // dispatch before reaching the exec handler), so the check is on the
+    // discovered set, not the filtered one.
     if projects.is_empty() {
         return Err(RecursiveExecError::NoPackage.into());
     }
 
-    let adapters = projects.iter().map(|project| GraphPkg { project }).collect();
-    let graph = create_projects_graph(adapters, &CreateProjectsGraphOptions::default()).graph;
+    let graph = select_recursive_projects(&projects, config, dir)?;
 
     let mut chunks = sort_projects(&graph);
     if let Some(resume_from) = &args.resume_from {

--- a/pacquet/crates/cli/src/cli_args/pack.rs
+++ b/pacquet/crates/cli/src/cli_args/pack.rs
@@ -13,7 +13,9 @@
 //! are not surfaced by `Config` yet, so they take their `false` / empty
 //! defaults.
 
-use crate::cli_args::recursive::{GraphPkg, sort_projects};
+use crate::cli_args::recursive::{
+    discover_workspace_projects, select_recursive_projects, sort_projects,
+};
 use clap::Args;
 use miette::Context;
 use pacquet_config::Config;
@@ -21,11 +23,6 @@ use pacquet_pack::{
     Host, PackError, PackOptions, PackResultJson, api, format_pack_output, to_pack_result_json,
 };
 use pacquet_reporter::Reporter;
-use pacquet_workspace::{
-    FindWorkspaceProjectsOpts, find_workspace_projects, read_workspace_manifest,
-    workspace_package_patterns,
-};
-use pacquet_workspace_projects_graph::{CreateProjectsGraphOptions, create_projects_graph};
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -111,15 +108,8 @@ impl PackArgs {
             return Err(miette::Report::new(PackError::OutAndPackDestination));
         }
         let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
-        let patterns = read_workspace_manifest(workspace_root)
-            .map_err(miette::Report::new)
-            .wrap_err("reading pnpm-workspace.yaml")?
-            .map(|manifest| workspace_package_patterns(&manifest));
-        let projects =
-            find_workspace_projects(workspace_root, &FindWorkspaceProjectsOpts { patterns })
-                .wrap_err("finding workspace projects")?;
-        let adapters = projects.iter().map(|project| GraphPkg { project }).collect();
-        let graph = create_projects_graph(adapters, &CreateProjectsGraphOptions::default()).graph;
+        let projects = discover_workspace_projects(workspace_root)?;
+        let graph = select_recursive_projects(&projects, config, dir)?;
         let chunks = sort_projects(&graph);
 
         // In recursive mode upstream resolves `--out` / `--pack-destination`

--- a/pacquet/crates/cli/src/cli_args/pack.rs
+++ b/pacquet/crates/cli/src/cli_args/pack.rs
@@ -92,9 +92,9 @@ impl PackArgs {
         }
     }
 
-    /// Pack every workspace project that declares both a name and a
-    /// version, in topological order. Mirrors the recursive arm of
-    /// pnpm's `handler`.
+    /// Pack each `--filter`-selected workspace project that declares both
+    /// a name and a version, in topological order. Mirrors the recursive
+    /// arm of pnpm's `handler`.
     fn run_recursive<Reporter: self::Reporter>(
         &self,
         dir: &Path,

--- a/pacquet/crates/cli/src/cli_args/pack.rs
+++ b/pacquet/crates/cli/src/cli_args/pack.rs
@@ -68,8 +68,8 @@ pub struct PackArgs {
 }
 
 impl PackArgs {
-    /// Pack the project at `dir` (or every workspace project when
-    /// `recursive`), returning the text/JSON the CLI prints.
+    /// Pack the project at `dir` (or the `--filter`-selected workspace
+    /// projects when `recursive`), returning the text/JSON the CLI prints.
     pub fn run<Reporter: self::Reporter>(
         &self,
         dir: &Path,

--- a/pacquet/crates/cli/src/cli_args/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/recursive.rs
@@ -1,7 +1,7 @@
 //! Shared machinery for the recursive (`-r`) variants of `run` and
-//! `exec`: workspace-project discovery, topological sorting, the
-//! `--resume-from` chunk trimming, and the `pnpm-exec-summary.json`
-//! execution-status report.
+//! `exec`: workspace-project discovery, `--filter` selection,
+//! topological sorting, the `--resume-from` chunk trimming, and the
+//! `pnpm-exec-summary.json` execution-status report.
 //!
 //! Ports the parts of pnpm's
 //! [`exec.ts`](https://github.com/pnpm/pnpm/blob/8eb1be4988/exec/commands/src/exec.ts)
@@ -15,10 +15,17 @@
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
 use miette::{Context, Diagnostic, IntoDiagnostic};
+use pacquet_config::{Config, LinkWorkspacePackages};
 use pacquet_package_manager::graph_sequencer;
 use pacquet_package_manifest::DependencyGroup;
-use pacquet_workspace::Project;
-use pacquet_workspace_projects_graph::{BaseProject, GraphProject, ProjectGraph};
+use pacquet_workspace::{
+    FindWorkspaceProjectsOpts, Project, find_workspace_projects, read_workspace_manifest,
+    workspace_package_patterns,
+};
+use pacquet_workspace_projects_filter::{FilterProjectsOptions, WorkspaceFilter, filter_projects};
+use pacquet_workspace_projects_graph::{
+    BaseProject, CreateProjectsGraphOptions, GraphProject, ProjectGraph, create_projects_graph,
+};
 use serde::Serialize;
 use std::{
     collections::{HashMap, HashSet},
@@ -119,9 +126,81 @@ pub fn count_failures(summary: &IndexMap<PathBuf, ExecutionStatus>) -> usize {
     summary.values().filter(|status| status.status == Status::Failure).count()
 }
 
+/// Read the workspace manifest at `workspace_root` and enumerate its
+/// projects. Shared by recursive `run` and `exec` so both discover the
+/// same set before [`select_recursive_projects`] narrows it.
+pub fn discover_workspace_projects(workspace_root: &Path) -> miette::Result<Vec<Project>> {
+    let patterns = read_workspace_manifest(workspace_root)
+        .into_diagnostic()
+        .wrap_err("reading pnpm-workspace.yaml")?
+        .map(|manifest| workspace_package_patterns(&manifest));
+    find_workspace_projects(workspace_root, &FindWorkspaceProjectsOpts { patterns })
+        .wrap_err("finding workspace projects")
+}
+
+/// Build the `--filter`-selected workspace graph that the recursive
+/// command runs over.
+///
+/// Ports the main-dispatch step pnpm performs before handing the
+/// recursive `run` / `exec` handlers their `selectedProjectsGraph`
+/// (<https://github.com/pnpm/pnpm/blob/8eb1be4988/pnpm/src/main.ts#L260-L323>):
+/// build the graph over every workspace project, then restrict it to the
+/// projects `config.filter` / `config.filter_prod` select — include
+/// selectors unioned, `!`-prefixed excludes subtracted (`pick(difference(
+/// include, exclude), allProjectsGraph)`). With no selectors every project
+/// is selected, matching pnpm's `selectedProjectsGraph: graph`
+/// fall-through. `prefix` is the directory path selectors resolve against
+/// (pnpm's `process.cwd()`).
+pub fn select_recursive_projects<'a>(
+    projects: &'a [Project],
+    config: &Config,
+    prefix: &Path,
+) -> miette::Result<ProjectGraph<GraphPkg<'a>>> {
+    let mut graph = create_projects_graph(
+        projects.iter().map(|project| GraphPkg { project }).collect(),
+        &CreateProjectsGraphOptions::default(),
+    )
+    .graph;
+
+    if config.filter.is_empty() && config.filter_prod.is_empty() {
+        return Ok(graph);
+    }
+
+    let filters: Vec<WorkspaceFilter> =
+        config
+            .filter
+            .iter()
+            .map(|filter| WorkspaceFilter { filter: filter.clone(), follow_prod_deps_only: false })
+            .chain(config.filter_prod.iter().map(|filter| WorkspaceFilter {
+                filter: filter.clone(),
+                follow_prod_deps_only: true,
+            }))
+            .collect();
+    let selected = filter_projects(
+        projects.iter().map(|project| GraphPkg { project }).collect(),
+        &filters,
+        &FilterProjectsOptions {
+            prefix: prefix.to_path_buf(),
+            link_workspace_packages: Some(
+                config.link_workspace_packages != LinkWorkspacePackages::Off,
+            ),
+            use_glob_dir_filtering: false,
+        },
+    )
+    .map_err(miette::Report::new)
+    .wrap_err("filtering workspace projects")?;
+
+    Ok(selected
+        .selected_projects
+        .iter()
+        .filter_map(|root| graph.swap_remove(root).map(|node| (root.clone(), node)))
+        .collect())
+}
+
 /// Adapter that lets a [`Project`] feed `create_projects_graph`. Owns
 /// nothing beyond a borrow of the project; the graph reads the manifest
 /// name, version, and dependency groups through it.
+#[derive(Clone, Copy)]
 pub struct GraphPkg<'a> {
     pub project: &'a Project,
 }

--- a/pacquet/crates/cli/src/cli_args/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/recursive.rs
@@ -138,31 +138,20 @@ pub fn discover_workspace_projects(workspace_root: &Path) -> miette::Result<Vec<
         .wrap_err("finding workspace projects")
 }
 
-/// Build the `--filter`-selected workspace graph that the recursive
-/// command runs over.
+/// Build the `--filter`-selected workspace graph the recursive command
+/// runs over: the project graph restricted to the `config.filter` /
+/// `config.filter_prod` selection (every project when no selector is
+/// given). `prefix` is where path selectors resolve.
 ///
-/// Ports the main-dispatch step pnpm performs before handing the
-/// recursive `run` / `exec` handlers their `selectedProjectsGraph`
-/// (<https://github.com/pnpm/pnpm/blob/8eb1be4988/pnpm/src/main.ts#L260-L323>):
-/// build the graph over every workspace project, then restrict it to the
-/// projects `config.filter` / `config.filter_prod` select — include
-/// selectors unioned, `!`-prefixed excludes subtracted (`pick(difference(
-/// include, exclude), allProjectsGraph)`). With no selectors every project
-/// is selected, matching pnpm's `selectedProjectsGraph: graph`
-/// fall-through. `prefix` is the directory path selectors resolve against
-/// (pnpm's `process.cwd()`).
+/// Ports pnpm's `selectedProjectsGraph` main-dispatch step
+/// (<https://github.com/pnpm/pnpm/blob/8eb1be4988/pnpm/src/main.ts#L260-L323>).
 pub fn select_recursive_projects<'a>(
     projects: &'a [Project],
     config: &Config,
     prefix: &Path,
 ) -> miette::Result<ProjectGraph<GraphPkg<'a>>> {
-    // Resolve the selectors against the same graph options the sort below
-    // uses, so the selected set and the topological order agree on edges —
-    // upstream builds one `linkWorkspacePackages`-aware `allProjectsGraph`
-    // that both `filterWorkspaceProjects` and `sortProjects` read, then
-    // `pick`s the selected subset out of it. (`workspace:` edges form
-    // regardless of the option, so the choice only matters for bare-semver
-    // sibling references.)
+    // Filter against the same graph options the sort uses, so the selected
+    // set and the topological order agree on edges.
     let graph_options = CreateProjectsGraphOptions::default();
     let mut graph = create_projects_graph(
         projects.iter().map(|project| GraphPkg { project }).collect(),

--- a/pacquet/crates/cli/src/cli_args/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/recursive.rs
@@ -15,7 +15,7 @@
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
 use miette::{Context, Diagnostic, IntoDiagnostic};
-use pacquet_config::{Config, LinkWorkspacePackages};
+use pacquet_config::Config;
 use pacquet_package_manager::graph_sequencer;
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_workspace::{
@@ -156,9 +156,17 @@ pub fn select_recursive_projects<'a>(
     config: &Config,
     prefix: &Path,
 ) -> miette::Result<ProjectGraph<GraphPkg<'a>>> {
+    // Resolve the selectors against the same graph options the sort below
+    // uses, so the selected set and the topological order agree on edges —
+    // upstream builds one `linkWorkspacePackages`-aware `allProjectsGraph`
+    // that both `filterWorkspaceProjects` and `sortProjects` read, then
+    // `pick`s the selected subset out of it. (`workspace:` edges form
+    // regardless of the option, so the choice only matters for bare-semver
+    // sibling references.)
+    let graph_options = CreateProjectsGraphOptions::default();
     let mut graph = create_projects_graph(
         projects.iter().map(|project| GraphPkg { project }).collect(),
-        &CreateProjectsGraphOptions::default(),
+        &graph_options,
     )
     .graph;
 
@@ -181,9 +189,7 @@ pub fn select_recursive_projects<'a>(
         &filters,
         &FilterProjectsOptions {
             prefix: prefix.to_path_buf(),
-            link_workspace_packages: Some(
-                config.link_workspace_packages != LinkWorkspacePackages::Off,
-            ),
+            link_workspace_packages: graph_options.link_workspace_packages,
             use_glob_dir_filtering: false,
         },
     )

--- a/pacquet/crates/cli/src/cli_args/run.rs
+++ b/pacquet/crates/cli/src/cli_args/run.rs
@@ -168,9 +168,9 @@ impl RunArgs {
         Ok(())
     }
 
-    /// Execute the subcommand for every project in the workspace, in
-    /// topological order. The recursive counterpart of [`Self::run`],
-    /// selected when the global `-r` / `--recursive` flag is set.
+    /// Execute the subcommand across the `--filter`-selected workspace
+    /// projects, in topological order. The recursive counterpart of
+    /// [`Self::run`], selected when the global `-r` / `--recursive` flag is set.
     pub fn run_recursive(&self, config: &Config, dir: &Path) -> miette::Result<()> {
         recursive::run_recursive(self, config, dir)
     }

--- a/pacquet/crates/cli/src/cli_args/run/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/run/recursive.rs
@@ -91,12 +91,9 @@ pub fn run_recursive(args: &RunArgs, config: &Config, dir: &Path) -> miette::Res
 
     let projects = discover_workspace_projects(workspace_root)?;
     let graph = select_recursive_projects(&projects, config, dir)?;
-    // A non-empty workspace whose `--filter` selection is empty is a
-    // no-op: pnpm exits 0 from its main dispatch when
-    // `selectedProjectsGraph` is empty (main.ts:306-318), before the
-    // no-script check or `--resume-from` / `--report-summary` runs. An
-    // empty workspace falls through to the no-script path below, as it did
-    // before `--filter` was wired in.
+    // An empty `--filter` selection is a no-op, matching pnpm's exit-0 for
+    // an empty selectedProjectsGraph; an empty workspace instead falls
+    // through to the no-script error below.
     if !projects.is_empty() && graph.is_empty() {
         return Ok(());
     }
@@ -225,10 +222,7 @@ pub fn run_recursive(args: &RunArgs, config: &Config, dir: &Path) -> miette::Res
     // `test` is exempt because `pnpm test` falls back to a default and
     // should not error on a workspace with no `test` script; otherwise a
     // recursive run that matched nothing is a user error, unless
-    // `--if-present` opted out of it. The message distinguishes "no
-    // package" from "no selected package" the way pnpm's
-    // `runRecursive.ts:203-210` does, keyed on whether `--filter` narrowed
-    // the set (`selectedProjectsGraph.length === allProjects.length`).
+    // `--if-present` opted out of it.
     if script_name != "test" && has_command == 0 && !args.if_present {
         let script_name = script_name.to_string();
         return Err(if graph.len() == projects.len() {

--- a/pacquet/crates/cli/src/cli_args/run/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/run/recursive.rs
@@ -91,6 +91,15 @@ pub fn run_recursive(args: &RunArgs, config: &Config, dir: &Path) -> miette::Res
 
     let projects = discover_workspace_projects(workspace_root)?;
     let graph = select_recursive_projects(&projects, config, dir)?;
+    // A non-empty workspace whose `--filter` selection is empty is a
+    // no-op: pnpm exits 0 from its main dispatch when
+    // `selectedProjectsGraph` is empty (main.ts:306-318), before the
+    // no-script check or `--resume-from` / `--report-summary` runs. An
+    // empty workspace falls through to the no-script path below, as it did
+    // before `--filter` was wired in.
+    if !projects.is_empty() && graph.is_empty() {
+        return Ok(());
+    }
 
     let mut chunks = sort_projects(&graph);
     if let Some(resume_from) = &args.resume_from {

--- a/pacquet/crates/cli/src/cli_args/run/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/run/recursive.rs
@@ -1,5 +1,5 @@
-//! Recursive `pacquet run` — run a package script in every project of
-//! the workspace, in topological order.
+//! Recursive `pacquet run` — run a package script across the
+//! `--filter`-selected workspace projects, in topological order.
 //!
 //! Port of pnpm's
 //! [`runRecursive`](https://github.com/pnpm/pnpm/blob/8eb1be4988/exec/commands/src/runRecursive.ts)
@@ -73,8 +73,8 @@ pub enum RecursiveRunError {
     ScriptNameRequired,
 }
 
-/// Run `args.command` across every workspace project, sorted
-/// topologically. `dir` is the canonicalized working directory; the
+/// Run `args.command` across the `--filter`-selected workspace projects,
+/// sorted topologically. `dir` is the canonicalized working directory; the
 /// workspace root (and the directory the summary is written to) is
 /// `config.workspace_dir`, falling back to `dir` when no
 /// `pnpm-workspace.yaml` exists.

--- a/pacquet/crates/cli/src/cli_args/run/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/run/recursive.rs
@@ -9,28 +9,24 @@
 //! and the `throwOnCommandFail` failure check from
 //! [`@pnpm/cli.utils`](https://github.com/pnpm/pnpm/blob/8eb1be4988/cli/utils/src/recursiveSummary.ts).
 //!
-//! Scope versus upstream: projects are sorted topologically (upstream's
-//! default) and run sequentially. `--no-sort`, `--reverse`,
-//! `--workspace-concurrency` parallelism, `--filter` narrowing of the
-//! selected set, and the `RegExp` script selector are not ported yet — the
-//! selected set is every workspace project, matching pacquet's
-//! currently-unfiltered `install`.
+//! Scope versus upstream: `config.filter` / `config.filter_prod`
+//! (`--filter` / `--filter-prod`, include and exclude selectors) narrow
+//! the selected set via [`select_recursive_projects`]; the selection is
+//! then sorted topologically (upstream's default) and run sequentially.
+//! `--no-sort`, `--reverse`, `--workspace-concurrency` parallelism, the
+//! `RegExp` script selector, and the main-dispatch auto-exclusion of the
+//! workspace root for `run` / `exec` / `add` / `test` are not ported yet.
 
 use super::{RunArgs, RunContext, run_stages};
 use crate::cli_args::recursive::{
-    ExecutionStatus, GraphPkg, Status, count_failures, get_resumed_package_chunks, sort_projects,
-    write_recursive_summary,
+    ExecutionStatus, Status, count_failures, discover_workspace_projects,
+    get_resumed_package_chunks, select_recursive_projects, sort_projects, write_recursive_summary,
 };
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
-use miette::{Context, Diagnostic, IntoDiagnostic};
+use miette::Diagnostic;
 use pacquet_config::Config;
 use pacquet_package_manager::{make_node_package_map_option, package_map_path_for_execution};
-use pacquet_workspace::{
-    FindWorkspaceProjectsOpts, find_workspace_projects, read_workspace_manifest,
-    workspace_package_patterns,
-};
-use pacquet_workspace_projects_graph::{CreateProjectsGraphOptions, create_projects_graph};
 use std::{
     collections::HashMap,
     env,
@@ -47,6 +43,13 @@ pub enum RecursiveRunError {
     #[display("None of the packages has a \"{script_name}\" script")]
     #[diagnostic(code(ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT))]
     NoScript {
+        #[error(not(source))]
+        script_name: String,
+    },
+
+    #[display("None of the selected packages has a \"{script_name}\" script")]
+    #[diagnostic(code(ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT))]
+    NoSelectedScript {
         #[error(not(source))]
         script_name: String,
     },
@@ -86,15 +89,8 @@ pub fn run_recursive(args: &RunArgs, config: &Config, dir: &Path) -> miette::Res
     };
     let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
 
-    let patterns = read_workspace_manifest(workspace_root)
-        .into_diagnostic()
-        .wrap_err("reading pnpm-workspace.yaml")?
-        .map(|manifest| workspace_package_patterns(&manifest));
-    let projects = find_workspace_projects(workspace_root, &FindWorkspaceProjectsOpts { patterns })
-        .wrap_err("finding workspace projects")?;
-
-    let adapters = projects.iter().map(|project| GraphPkg { project }).collect();
-    let graph = create_projects_graph(adapters, &CreateProjectsGraphOptions::default()).graph;
+    let projects = discover_workspace_projects(workspace_root)?;
+    let graph = select_recursive_projects(&projects, config, dir)?;
 
     let mut chunks = sort_projects(&graph);
     if let Some(resume_from) = &args.resume_from {
@@ -220,9 +216,18 @@ pub fn run_recursive(args: &RunArgs, config: &Config, dir: &Path) -> miette::Res
     // `test` is exempt because `pnpm test` falls back to a default and
     // should not error on a workspace with no `test` script; otherwise a
     // recursive run that matched nothing is a user error, unless
-    // `--if-present` opted out of it.
+    // `--if-present` opted out of it. The message distinguishes "no
+    // package" from "no selected package" the way pnpm's
+    // `runRecursive.ts:203-210` does, keyed on whether `--filter` narrowed
+    // the set (`selectedProjectsGraph.length === allProjects.length`).
     if script_name != "test" && has_command == 0 && !args.if_present {
-        return Err(RecursiveRunError::NoScript { script_name: script_name.to_string() }.into());
+        let script_name = script_name.to_string();
+        return Err(if graph.len() == projects.len() {
+            RecursiveRunError::NoScript { script_name }
+        } else {
+            RecursiveRunError::NoSelectedScript { script_name }
+        }
+        .into());
     }
 
     if args.report_summary {

--- a/pacquet/crates/cli/tests/exec_recursive.rs
+++ b/pacquet/crates/cli/tests/exec_recursive.rs
@@ -72,6 +72,38 @@ fn recursive_exec_runs_command_in_every_project() {
     drop(root);
 }
 
+/// `pacquet -r --filter <name> exec <command>` runs the command only in
+/// the `--filter`-selected project. Threads `config.filter` through the
+/// recursive exec dispatch.
+#[test]
+fn recursive_exec_filter_selects_only_matching_project() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(&workspace, &["project-1", "project-2", "project-3"]);
+
+    pacquet
+        .with_arg("-r")
+        .with_arg("--filter")
+        .with_arg("project-1")
+        .with_arg("exec")
+        .with_arg("touch")
+        .with_arg("ran.txt")
+        .assert()
+        .success();
+
+    assert!(
+        workspace.join("project-1").join("ran.txt").exists(),
+        "the selected project-1 should run the command",
+    );
+    for name in ["project-2", "project-3"] {
+        assert!(
+            !workspace.join(name).join("ran.txt").exists(),
+            "{name} is not selected by --filter and must not run",
+        );
+    }
+
+    drop(root);
+}
+
 /// `--report-summary` writes `pnpm-exec-summary.json` with a `passed`
 /// entry for every project.
 #[test]

--- a/pacquet/crates/cli/tests/exec_recursive.rs
+++ b/pacquet/crates/cli/tests/exec_recursive.rs
@@ -104,6 +104,40 @@ fn recursive_exec_filter_selects_only_matching_project() {
     drop(root);
 }
 
+/// A `--filter` that matches no project is a no-op: recursive exec exits
+/// 0 and writes no summary even with `--report-summary`, matching pnpm's
+/// main-dispatch exit-0 for an empty selection — rather than erroring on
+/// `--resume-from` or emitting an empty summary.
+#[test]
+fn recursive_exec_filter_no_match_is_a_noop() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(&workspace, &["project-1", "project-2"]);
+
+    pacquet
+        .with_arg("-r")
+        .with_arg("--filter")
+        .with_arg("does-not-exist")
+        .with_arg("exec")
+        .with_arg("--report-summary")
+        .with_arg("touch")
+        .with_arg("ran.txt")
+        .assert()
+        .success();
+
+    for name in ["project-1", "project-2"] {
+        assert!(
+            !workspace.join(name).join("ran.txt").exists(),
+            "no project is selected, so {name} should not run",
+        );
+    }
+    assert!(
+        !workspace.join("pnpm-exec-summary.json").exists(),
+        "an empty selection should not write a summary file",
+    );
+
+    drop(root);
+}
+
 /// `--report-summary` writes `pnpm-exec-summary.json` with a `passed`
 /// entry for every project.
 #[test]

--- a/pacquet/crates/cli/tests/pack_recursive.rs
+++ b/pacquet/crates/cli/tests/pack_recursive.rs
@@ -1,0 +1,60 @@
+//! Recursive-pack integration tests. `--filter` must narrow which
+//! projects get packed, routed through the same shared selection path
+//! (`select_recursive_projects`) that `run -r` / `exec -r` use.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use serde_json::json;
+use std::{fs, path::Path};
+
+/// Write a `pnpm-workspace.yaml` listing `names` as packages, plus a
+/// `package.json` (name + version) per name under its own subdirectory.
+fn write_workspace(workspace: &Path, names: &[&str]) {
+    let packages = names.iter().map(|name| format!("  - {name}")).collect::<Vec<_>>();
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        format!("packages:\n{}\n", packages.join("\n")),
+    )
+    .expect("write pnpm-workspace.yaml");
+    for name in names {
+        let dir = workspace.join(name);
+        fs::create_dir_all(&dir).expect("create project dir");
+        fs::write(
+            dir.join("package.json"),
+            json!({ "name": name, "version": "1.0.0" }).to_string(),
+        )
+        .expect("write package.json");
+    }
+}
+
+/// `pacquet -r --filter <name> pack` packs only the `--filter`-selected
+/// project, leaving the rest unpacked — the same selection `run -r` /
+/// `exec -r` apply, since all three share `select_recursive_projects`.
+#[test]
+fn recursive_pack_filter_packs_only_selected_project() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(&workspace, &["project-1", "project-2", "project-3"]);
+    let out = workspace.join("tarballs");
+    fs::create_dir_all(&out).expect("create out dir");
+
+    pacquet
+        .with_arg("-r")
+        .with_arg("--filter")
+        .with_arg("project-1")
+        .with_arg("pack")
+        .with_arg("--pack-destination")
+        .with_arg(out.to_str().expect("utf8 out dir"))
+        .assert()
+        .success();
+
+    assert!(out.join("project-1-1.0.0.tgz").exists(), "the selected project-1 should be packed");
+    for name in ["project-2", "project-3"] {
+        assert!(
+            !out.join(format!("{name}-1.0.0.tgz")).exists(),
+            "{name} is not selected by --filter and must not be packed",
+        );
+    }
+
+    drop(root);
+}

--- a/pacquet/crates/cli/tests/run_recursive.rs
+++ b/pacquet/crates/cli/tests/run_recursive.rs
@@ -240,6 +240,44 @@ fn recursive_run_filter_no_matching_script_reports_no_selected_packages() {
     drop(root);
 }
 
+/// `--filter-prod <name>` narrows the recursive run the same way
+/// `--filter` does, exercising the `follow_prod_deps_only` selector
+/// branch of the shared selection path. For a plain name selector the
+/// production-only dependency walk doesn't change the selected set (the
+/// production graph is only consulted for `...`-style walks), so the
+/// observable result matches the `--filter` case.
+#[test]
+fn recursive_run_filter_prod_selects_only_matching_project() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", build_writes_marker("project-1")),
+            ("project-2", build_writes_marker("project-2")),
+        ],
+    );
+
+    pacquet
+        .with_arg("-r")
+        .with_arg("--filter-prod")
+        .with_arg("project-1")
+        .with_arg("run")
+        .with_arg("build")
+        .assert()
+        .success();
+
+    assert!(
+        workspace.join("project-1").join("ran.txt").exists(),
+        "the --filter-prod-selected project-1 should run",
+    );
+    assert!(
+        !workspace.join("project-2").join("ran.txt").exists(),
+        "project-2 is not selected by --filter-prod and must not run",
+    );
+
+    drop(root);
+}
+
 /// A `--filter` that matches no project is a no-op: the run exits 0
 /// without raising the no-selected-packages error, matching pnpm's
 /// main-dispatch exit-0 for an empty `selectedProjectsGraph`.

--- a/pacquet/crates/cli/tests/run_recursive.rs
+++ b/pacquet/crates/cli/tests/run_recursive.rs
@@ -129,6 +129,117 @@ fn recursive_run_settings_only_workspace_enumerates_root_only() {
     drop(root);
 }
 
+/// `pacquet -r --filter <name> run <script>` runs the script only in the
+/// `--filter`-selected project, leaving the rest untouched. Threads
+/// `config.filter` through the recursive dispatch the way pnpm builds its
+/// `selectedProjectsGraph`.
+#[test]
+fn recursive_run_filter_selects_only_matching_project() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", build_writes_marker("project-1")),
+            ("project-2", build_writes_marker("project-2")),
+            ("project-3", build_writes_marker("project-3")),
+        ],
+    );
+
+    pacquet
+        .with_arg("-r")
+        .with_arg("--filter")
+        .with_arg("project-1")
+        .with_arg("run")
+        .with_arg("build")
+        .assert()
+        .success();
+
+    assert!(
+        workspace.join("project-1").join("ran.txt").exists(),
+        "the selected project-1 should run",
+    );
+    for name in ["project-2", "project-3"] {
+        assert!(
+            !workspace.join(name).join("ran.txt").exists(),
+            "{name} is not selected by --filter and must not run",
+        );
+    }
+
+    drop(root);
+}
+
+/// An exclude selector (`!<name>`) runs the script in every project
+/// except the excluded one — the shape pnpm's release workflow leans on
+/// with `--filter=!pnpm`.
+#[test]
+fn recursive_run_exclude_filter_skips_excluded_project() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", build_writes_marker("project-1")),
+            ("project-2", build_writes_marker("project-2")),
+            ("project-3", build_writes_marker("project-3")),
+        ],
+    );
+
+    pacquet
+        .with_arg("-r")
+        .with_arg("--filter")
+        .with_arg("!project-2")
+        .with_arg("run")
+        .with_arg("build")
+        .assert()
+        .success();
+
+    assert!(workspace.join("project-1").join("ran.txt").exists(), "project-1 should run");
+    assert!(workspace.join("project-3").join("ran.txt").exists(), "project-3 should run");
+    assert!(
+        !workspace.join("project-2").join("ran.txt").exists(),
+        "project-2 is excluded by !project-2 and must not run",
+    );
+
+    drop(root);
+}
+
+/// When `--filter` narrows the set and no *selected* package defines the
+/// script, the error keeps pnpm's `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT` code
+/// but switches to the "None of the selected packages" wording (vs. "None
+/// of the packages" when every project is selected). Mirrors pnpm's
+/// `runRecursive.ts:203-210`.
+#[test]
+fn recursive_run_filter_no_matching_script_reports_no_selected_packages() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", build_writes_marker("project-1")),
+            ("project-2", json!({ "name": "project-2", "version": "1.0.0" })),
+        ],
+    );
+
+    let output = pacquet
+        .with_arg("-r")
+        .with_arg("--filter")
+        .with_arg("project-2")
+        .with_arg("run")
+        .with_arg("build")
+        .output()
+        .expect("spawn pacquet");
+    assert!(!output.status.success(), "a selected package without the script must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT"),
+        "stderr should carry the no-script code, got: {stderr}",
+    );
+    assert!(
+        stderr.contains("None of the selected packages"),
+        "stderr should use the selected-packages wording, got: {stderr}",
+    );
+
+    drop(root);
+}
+
 /// `pacquet -r run --resume-from <pkg>` skips every chunk that sorts
 /// before the chunk containing `<pkg>`. With `project-2` and `project-3`
 /// both depending on `project-1`, the sorted chunks are

--- a/pacquet/crates/cli/tests/run_recursive.rs
+++ b/pacquet/crates/cli/tests/run_recursive.rs
@@ -240,39 +240,36 @@ fn recursive_run_filter_no_matching_script_reports_no_selected_packages() {
     drop(root);
 }
 
-/// `--filter-prod <name>` narrows the recursive run the same way
-/// `--filter` does, exercising the `follow_prod_deps_only` selector
-/// branch of the shared selection path. For a plain name selector the
-/// production-only dependency walk doesn't change the selected set (the
-/// production graph is only consulted for `...`-style walks), so the
-/// observable result matches the `--filter` case.
+/// `--filter-prod <pkg>...` walks production dependencies only, so a
+/// dev-only edge is excluded from the selected set. With `app` depending
+/// on `lib` through `devDependencies`, `--filter-prod app...` runs `app`
+/// but skips `lib` — whereas plain `--filter app...` would run both.
+/// This is what distinguishes `--filter-prod` from `--filter`: the
+/// `follow_prod_deps_only` branch builds the graph with dev edges
+/// dropped, so the `...` dependency walk never reaches `lib`.
 #[test]
-fn recursive_run_filter_prod_selects_only_matching_project() {
+fn recursive_run_filter_prod_follows_production_deps_only() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
-    write_workspace(
-        &workspace,
-        &[
-            ("project-1", build_writes_marker("project-1")),
-            ("project-2", build_writes_marker("project-2")),
-        ],
-    );
+    let mut app = build_writes_marker("app");
+    app["devDependencies"] = json!({ "lib": "1.0.0" });
+    write_workspace(&workspace, &[("lib", build_writes_marker("lib")), ("app", app)]);
 
     pacquet
         .with_arg("-r")
         .with_arg("--filter-prod")
-        .with_arg("project-1")
+        .with_arg("app...")
         .with_arg("run")
         .with_arg("build")
         .assert()
         .success();
 
     assert!(
-        workspace.join("project-1").join("ran.txt").exists(),
-        "the --filter-prod-selected project-1 should run",
+        workspace.join("app").join("ran.txt").exists(),
+        "the --filter-prod-selected app should run",
     );
     assert!(
-        !workspace.join("project-2").join("ran.txt").exists(),
-        "project-2 is not selected by --filter-prod and must not run",
+        !workspace.join("lib").join("ran.txt").exists(),
+        "lib is only a dev dependency of app, so --filter-prod's production-only walk must skip it",
     );
 
     drop(root);

--- a/pacquet/crates/cli/tests/run_recursive.rs
+++ b/pacquet/crates/cli/tests/run_recursive.rs
@@ -240,6 +240,31 @@ fn recursive_run_filter_no_matching_script_reports_no_selected_packages() {
     drop(root);
 }
 
+/// A `--filter` that matches no project is a no-op: the run exits 0
+/// without raising the no-selected-packages error, matching pnpm's
+/// main-dispatch exit-0 for an empty `selectedProjectsGraph`.
+#[test]
+fn recursive_run_filter_no_match_is_a_noop() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(&workspace, &[("project-1", build_writes_marker("project-1"))]);
+
+    pacquet
+        .with_arg("-r")
+        .with_arg("--filter")
+        .with_arg("does-not-exist")
+        .with_arg("run")
+        .with_arg("build")
+        .assert()
+        .success();
+
+    assert!(
+        !workspace.join("project-1").join("ran.txt").exists(),
+        "no project is selected, so nothing should run",
+    );
+
+    drop(root);
+}
+
 /// `pacquet -r run --resume-from <pkg>` skips every chunk that sorts
 /// before the chunk containing `<pkg>`. With `project-2` and `project-3`
 /// both depending on `project-1`, the sorted chunks are

--- a/pacquet/plans/TEST_PORTING.md
+++ b/pacquet/plans/TEST_PORTING.md
@@ -261,8 +261,10 @@ Ported into the new `pacquet-workspace-projects-filter` and
 `pacquet-workspace-projects-graph` crates (the Rust ports of
 `@pnpm/workspace.projects-filter` and `@pnpm/workspace.projects-graph`).
 The CLI `--filter` / `--filter-prod` flags are parsed into
-`Config::filter` / `Config::filter_prod`; narrowing the install to the
-selected projects is still a follow-up (the install fan-out is
+`Config::filter` / `Config::filter_prod`. Recursive `run` / `exec` now
+narrow their selected set through these selectors (via
+`cli_args::recursive::select_recursive_projects`); narrowing the install
+to the selected projects is still a follow-up (the install fan-out is
 unfiltered, so the two `known_failures` hoist stubs below stay).
 
 `parseProjectSelector` (ported as `parse_project_selector::tests`):


### PR DESCRIPTION
## Summary

Wires pnpm's `--filter` / `--filter-prod` workspace selection into pacquet's recursive command path — the primary (titular) blocker from the issue. The recursive `run` / `exec` / `pack` runners used to operate on **every** workspace project; the selectors were parsed into `Config::filter` / `Config::filter_prod` but never narrowed the set.

A shared helper, `cli_args::recursive::select_recursive_projects`, builds the workspace graph over all projects and restricts it to the selection — include selectors unioned, `!`-prefixed excludes (e.g. `!pnpm`) subtracted — mirroring the `selectedProjectsGraph` pnpm hands its recursive handlers in `main.ts`. `run -r`, `exec -r`, **and `pack -r`** all route through it, so `--filter` is one cross-cutting selection path for every recursive command. With no selectors every project is selected, so unfiltered behavior is unchanged. The selectors resolve against the **same** graph options used for the topological sort, so the selected set and run order agree on edges. Recursive `run`'s no-script error now distinguishes "None of the packages" from "None of the selected packages", keyed on whether the filter narrowed the set. When `--filter` narrows a non-empty workspace to **no** projects, recursive `run` / `exec` exit 0 (no-op) instead of erroring on `--resume-from` or writing an empty `--report-summary`, matching pnpm's main-dispatch exit-0 for an empty selection.

The two smaller publish-only prerequisites from the issue (the reusable already-published check and the `pnpm-publish-summary.json` writer) are **not yet in this PR**: they have no consumer in the current tree (recursive publish lives in the separate assembly PR) and would be dead code under the workspace's `-D warnings`, so they land best alongside the publish command that calls them.

Resolves <https://github.com/pnpm/pnpm/issues/12711>.

## Squash Commit Body

```text
The recursive `run` / `exec` / `pack` command path operated on every
workspace project; the `--filter` / `--filter-prod` selectors were parsed
into `Config::filter` / `Config::filter_prod` but never narrowed the set.

Add `select_recursive_projects`, a shared helper that builds the workspace
graph over all projects and restricts it to the selectors' selection
(include selectors unioned, `!`-prefixed excludes subtracted), mirroring
the `selectedProjectsGraph` pnpm hands its recursive handlers in main.ts.
`run -r`, `exec -r`, and `pack -r` all route through it. The selectors
resolve against the same graph options used for the sort, so the selected
set and the topological order agree. With no selectors every project is
selected, so unfiltered behavior is unchanged.

The recursive `run` no-script error now distinguishes "None of the
packages" from "None of the selected packages", keyed on whether the
filter narrowed the set. An empty selection over a non-empty workspace is
a no-op (exit 0) rather than erroring on `--resume-from` or writing an
empty `--report-summary`, matching pnpm's main-dispatch exit-0.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port: this is the pacquet port of behavior the TypeScript CLI already has (`--filter` in recursive `run` / `exec` / `pack`).
- [x] Added or updated tests: integration tests for include-selection, `!`-exclude selection, the `--filter-prod` production-only dependency walk (a dev-only edge is dropped by the `...` selector, so `--filter-prod` cannot collapse to `--filter`), the "None of the selected packages" error, and the empty-selection no-op on `run` / `exec`, plus a `pack -r --filter` selection test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recursive `run`, `exec`, and `pack` now narrow execution to `--filter` / `--filter-prod`-selected workspace projects (topological order, sequential).
  * If the recursive `--filter` matches no projects, the command succeeds without running anything.

* **Bug Fixes**
  * Improved handling and messaging for “no script” cases, distinguishing between “none in selected projects” vs “none in any package.”
  * Prevents `exec` summary output when nothing is selected/executed.

* **Tests**
  * Added integration coverage for filtered recursive `run`, `exec`, and `pack` behaviors (including `--filter-prod` and failure modes).

* **Documentation**
  * Updated recursive command documentation and filtering guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->