### PR TITLE
ci(integrated-benchmark): double the precompile-revisions timeout

### DIFF
--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -254,7 +254,7 @@ jobs:
         # `pnpr` server from its clone, so this also produces the server
         # binaries the boot step needs. More builds than the pacquet-only
         # bench, hence the larger timeout.
-        timeout-minutes: 25
+        timeout-minutes: 50
         run: just integrated-benchmark --reuse-prebuilt-binaries --build-only $BENCHMARK_TARGETS
 
       - name: 'Benchmark: Isolated linker: fresh restore, cold cache + cold store'


### PR DESCRIPTION
> [!NOTE]
> This PR was cherry-picked from <https://github.com/pnpm/pnpm/pull/12691>.
>
> Behind this PR is a human, not an AI agent.

Bump the "Precompile benchmark revisions" step from 25 to 50 minutes; the superset build of pacquet + pnpr revisions has been hitting the limit.

<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
PR <https://github.com/pnpm/pnpm/pull/12691> pull in additional dependencies to
support sigstore and provenance. This caused the build to take longer.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- ~~The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.~~ Irrelevant.
- ~~Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.~~ Irrelevant.
- ~~Added or updated tests.~~ Irrelevant.
- ~~Updated the documentation if needed.~~ Irrelevant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the maximum build time for benchmark precompilation, reducing the chance of timeouts during longer benchmark runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->