### PR TITLE
fix: respect workspace gitignore when packing

### DIFF
--- a/.changeset/quiet-pack-gitignore.md
+++ b/.changeset/quiet-pack-gitignore.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/fs.packlist": patch
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+Fixed `pnpm pack` in workspace packages so it applies `.gitignore` rules from the workspace root when no package-local `.npmignore` is present.

--- a/pacquet/crates/fs-packlist/src/lib.rs
+++ b/pacquet/crates/fs-packlist/src/lib.rs
@@ -435,10 +435,7 @@ fn workspace_ignore_file(pkg_dir: &Path, workspace_dir: Option<&Path>) -> Option
     if pkg_dir.join(".npmignore").is_file() {
         return None;
     }
-    let pkg_dir = fs::canonicalize(pkg_dir).unwrap_or_else(|_| pkg_dir.to_path_buf());
-    let workspace_dir =
-        fs::canonicalize(workspace_dir).unwrap_or_else(|_| workspace_dir.to_path_buf());
-    if pkg_dir == workspace_dir || pkg_dir.strip_prefix(&workspace_dir).is_err() {
+    if pkg_dir == workspace_dir || pkg_dir.strip_prefix(workspace_dir).is_err() {
         return None;
     }
     [".npmignore", ".gitignore"]

--- a/pacquet/crates/fs-packlist/src/lib.rs
+++ b/pacquet/crates/fs-packlist/src/lib.rs
@@ -118,7 +118,35 @@ const ALWAYS_EXCLUDED_SUFFIXES: &[&str] = &[".orig"];
 /// [`fs/packlist/src/index.ts:24-29`](https://github.com/pnpm/pnpm/blob/94240bc046/fs/packlist/src/index.ts#L24-L29)
 /// (paths relative to `pkg_dir`, no leading `./`).
 pub fn packlist(pkg_dir: &Path, manifest: &Value) -> Result<Vec<String>, PacklistError> {
-    let mut out: BTreeSet<String> = collect_own_files(pkg_dir, manifest)?;
+    packlist_with_options(pkg_dir, manifest, PacklistOptions::default())
+}
+
+/// Optional context for packlist computation.
+///
+/// When `workspace_dir` is an ancestor of `pkg_dir` and the package has no
+/// local `.npmignore`, the workspace root `.npmignore` or `.gitignore` is
+/// applied as a fallback in addition to package-local ignore files. `None`, the
+/// package directory itself, an unrelated directory, or a package-local
+/// `.npmignore` keeps the default per-package behavior and does not search
+/// parent directories.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PacklistOptions<'a> {
+    /// Workspace root to consult for top-level publish ignore rules.
+    pub workspace_dir: Option<&'a Path>,
+}
+
+/// Walk `pkg_dir` using [`PacklistOptions`] and return publishable file paths.
+///
+/// This is the workspace-aware variant of [`packlist`]. Workspace ignore rules
+/// are opt-in through `options.workspace_dir`; failures while loading an
+/// applicable workspace ignore file are returned as [`PacklistError`] so callers
+/// do not publish a tarball with silently skipped ignore rules.
+pub fn packlist_with_options(
+    pkg_dir: &Path,
+    manifest: &Value,
+    options: PacklistOptions<'_>,
+) -> Result<Vec<String>, PacklistError> {
+    let mut out: BTreeSet<String> = collect_own_files(pkg_dir, manifest, options)?;
     collect_bundled_files(pkg_dir, manifest, &mut out)?;
     Ok(out.into_iter().collect())
 }
@@ -235,7 +263,7 @@ fn collect_bundled_files(
             .ok()
             .flatten()
             .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
-        for rel in collect_own_files(&dep_dir, &dep_manifest)? {
+        for rel in collect_own_files(&dep_dir, &dep_manifest, PacklistOptions::default())? {
             out.insert(format!("{prefix}/{rel}"));
         }
         for name in nested_bundle_dep_names(&dep_manifest) {
@@ -276,7 +304,11 @@ fn resolve_bundled_dependency(name: &str, from_dir: &Path, root: &Path) -> Optio
 /// allowlist, and the always-included / `main` / `bin` force-includes.
 /// This is the per-package packlist with no `bundleDependencies`
 /// traversal; [`collect_bundled_files`] layers the closure on top.
-fn collect_own_files(pkg_dir: &Path, manifest: &Value) -> Result<BTreeSet<String>, PacklistError> {
+fn collect_own_files(
+    pkg_dir: &Path,
+    manifest: &Value,
+    options: PacklistOptions<'_>,
+) -> Result<BTreeSet<String>, PacklistError> {
     let files_field = manifest.get("files").and_then(Value::as_array);
     let files_matcher: Option<Gitignore> =
         files_field.and_then(|arr| build_files_matcher(pkg_dir, arr));
@@ -301,6 +333,7 @@ fn collect_own_files(pkg_dir: &Path, manifest: &Value) -> Result<BTreeSet<String
     // `.gitignore` even though a git-hosted snapshot's `.git/` has
     // already been deleted by [`crate::GitFetcher`] before this point.
     let mut builder = WalkBuilder::new(pkg_dir);
+    builder.current_dir(pkg_dir);
     builder
         .standard_filters(false)
         .hidden(false)
@@ -315,6 +348,11 @@ fn collect_own_files(pkg_dir: &Path, manifest: &Value) -> Result<BTreeSet<String
         // would leak into the published file set.
         .parents(false)
         .add_custom_ignore_filename(".npmignore");
+    if let Some(ignore_file) = workspace_ignore_file(pkg_dir, options.workspace_dir)
+        && let Some(error) = builder.add_ignore(&ignore_file)
+    {
+        return Err(io_error(pkg_dir, into_io(error)));
+    }
 
     for entry in builder.build() {
         let entry = entry.map_err(|err| io_error(pkg_dir, into_io(err)))?;
@@ -390,6 +428,23 @@ fn collect_own_files(pkg_dir: &Path, manifest: &Value) -> Result<BTreeSet<String
     }
 
     Ok(out)
+}
+
+fn workspace_ignore_file(pkg_dir: &Path, workspace_dir: Option<&Path>) -> Option<PathBuf> {
+    let workspace_dir = workspace_dir?;
+    if pkg_dir.join(".npmignore").is_file() {
+        return None;
+    }
+    let pkg_dir = fs::canonicalize(pkg_dir).unwrap_or_else(|_| pkg_dir.to_path_buf());
+    let workspace_dir =
+        fs::canonicalize(workspace_dir).unwrap_or_else(|_| workspace_dir.to_path_buf());
+    if pkg_dir == workspace_dir || pkg_dir.strip_prefix(&workspace_dir).is_err() {
+        return None;
+    }
+    [".npmignore", ".gitignore"]
+        .into_iter()
+        .map(|name| workspace_dir.join(name))
+        .find(|path| path.is_file())
 }
 
 /// Compile the `manifest.files` allowlist into a single `Gitignore`

--- a/pacquet/crates/fs-packlist/src/tests.rs
+++ b/pacquet/crates/fs-packlist/src/tests.rs
@@ -1,4 +1,4 @@
-use super::packlist;
+use super::{PacklistOptions, packlist, packlist_with_options};
 use serde_json::json;
 use std::{fs, path::Path};
 use tempfile::tempdir;
@@ -202,6 +202,83 @@ fn gitignore_excludes_when_no_npmignore() {
     assert!(
         !out.iter().any(|p| p.starts_with("build/")),
         "`.gitignore` must exclude `build/` when no `.npmignore` exists; received {out:?}",
+    );
+}
+
+#[test]
+fn workspace_root_gitignore_excludes_workspace_package_files() {
+    let dir = tempdir().unwrap();
+    let workspace = dir.path();
+    let pkg = workspace.join("packages/pkg");
+    fs::create_dir_all(&pkg).unwrap();
+    write(workspace, ".gitignore", "ignored.txt\n");
+    touch(&pkg, "package.json");
+    touch(&pkg, "index.js");
+    touch(&pkg, "ignored.txt");
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let without_workspace = packlist(&pkg, &manifest).unwrap();
+    assert!(
+        without_workspace.contains(&"ignored.txt".to_string()),
+        "parent ignores must not leak into packlist by default: {without_workspace:?}",
+    );
+
+    let with_workspace =
+        packlist_with_options(&pkg, &manifest, PacklistOptions { workspace_dir: Some(workspace) })
+            .unwrap();
+    assert!(with_workspace.contains(&"index.js".to_string()));
+    assert!(
+        !with_workspace.contains(&"ignored.txt".to_string()),
+        "workspace root `.gitignore` must exclude `ignored.txt`: {with_workspace:?}",
+    );
+}
+
+#[test]
+fn package_npmignore_suppresses_workspace_root_gitignore() {
+    let dir = tempdir().unwrap();
+    let workspace = dir.path();
+    let pkg = workspace.join("packages/pkg");
+    fs::create_dir_all(&pkg).unwrap();
+    write(workspace, ".gitignore", "ignored.txt\n");
+    write(&pkg, ".npmignore", "dist/\n");
+    touch(&pkg, "package.json");
+    touch(&pkg, "index.js");
+    touch(&pkg, "ignored.txt");
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let with_workspace =
+        packlist_with_options(&pkg, &manifest, PacklistOptions { workspace_dir: Some(workspace) })
+            .unwrap();
+    assert!(with_workspace.contains(&"index.js".to_string()));
+    assert!(
+        with_workspace.contains(&"ignored.txt".to_string()),
+        "package `.npmignore` must suppress workspace root `.gitignore` fallback: {with_workspace:?}",
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn unreadable_workspace_root_gitignore_is_reported() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempdir().unwrap();
+    let workspace = dir.path();
+    let pkg = workspace.join("packages/pkg");
+    fs::create_dir_all(&pkg).unwrap();
+    write(workspace, ".gitignore", "ignored.txt\n");
+    let mut permissions = fs::metadata(workspace.join(".gitignore")).unwrap().permissions();
+    permissions.set_mode(0o000);
+    fs::set_permissions(workspace.join(".gitignore"), permissions).unwrap();
+    touch(&pkg, "package.json");
+    touch(&pkg, "index.js");
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let err =
+        packlist_with_options(&pkg, &manifest, PacklistOptions { workspace_dir: Some(workspace) })
+            .unwrap_err();
+    assert!(
+        err.to_string().contains("I/O error while computing packlist"),
+        "workspace ignore read errors must be returned: {err:?}",
     );
 }
 

--- a/pacquet/crates/fs-packlist/src/tests.rs
+++ b/pacquet/crates/fs-packlist/src/tests.rs
@@ -234,6 +234,32 @@ fn workspace_root_gitignore_excludes_workspace_package_files() {
 }
 
 #[test]
+fn unrelated_workspace_dir_does_not_apply_root_gitignore() {
+    let dir = tempdir().unwrap();
+    let workspace = dir.path();
+    let unrelated = tempdir().unwrap();
+    let pkg = workspace.join("packages/pkg");
+    fs::create_dir_all(&pkg).unwrap();
+    write(unrelated.path(), ".gitignore", "ignored.txt\n");
+    touch(&pkg, "package.json");
+    touch(&pkg, "index.js");
+    touch(&pkg, "ignored.txt");
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let with_unrelated_workspace = packlist_with_options(
+        &pkg,
+        &manifest,
+        PacklistOptions { workspace_dir: Some(unrelated.path()) },
+    )
+    .unwrap();
+    assert!(with_unrelated_workspace.contains(&"index.js".to_string()));
+    assert!(
+        with_unrelated_workspace.contains(&"ignored.txt".to_string()),
+        "unrelated workspace root `.gitignore` must not exclude package files: {with_unrelated_workspace:?}",
+    );
+}
+
+#[test]
 fn package_npmignore_suppresses_workspace_root_gitignore() {
     let dir = tempdir().unwrap();
     let workspace = dir.path();

--- a/pacquet/crates/pack/src/lib.rs
+++ b/pacquet/crates/pack/src/lib.rs
@@ -36,7 +36,7 @@ use pacquet_executor::{
 use pacquet_exportable_manifest::{
     CreateExportableManifestError, CreateExportableManifestOptions, create_exportable_manifest,
 };
-use pacquet_fs_packlist::{PacklistError, packlist};
+use pacquet_fs_packlist::{PacklistError, PacklistOptions, packlist_with_options};
 use pacquet_package_manifest::{PackageManifestError, safe_read_package_json_from_dir};
 use pacquet_reporter::Reporter;
 use pacquet_resolving_parse_wanted_dependency::is_valid_old_npm_package_name;
@@ -285,7 +285,12 @@ where
     let (tarball_name, pack_destination) =
         resolve_output(opts, &normalized_name, &published_version)?;
 
-    let files = packlist(&dir, &publish_manifest).map_err(PackError::Packlist)?;
+    let files = packlist_with_options(
+        &dir,
+        &publish_manifest,
+        PacklistOptions { workspace_dir: opts.workspace_dir.as_deref() },
+    )
+    .map_err(PackError::Packlist)?;
     let mut files_map = build_files_map(&dir, &files);
     inject_workspace_license(opts, &dir, &files, &mut files_map);
 

--- a/pacquet/crates/pack/src/tests.rs
+++ b/pacquet/crates/pack/src/tests.rs
@@ -309,6 +309,109 @@ fn workspace_license_is_injected_into_a_sub_package() {
     assert!(names.contains(&"package/LICENSE".to_string()));
 }
 
+#[test]
+fn workspace_root_gitignore_excludes_sub_package_files() {
+    let workspace = tempdir().unwrap();
+    std::fs::write(workspace.path().join(".gitignore"), "ignored.txt\n").unwrap();
+    let pkg_dir = workspace.path().join("packages").join("foo");
+    std::fs::create_dir_all(&pkg_dir).unwrap();
+    std::fs::write(
+        pkg_dir.join("package.json"),
+        serde_json::to_string(&json!({ "name": "foo", "version": "1.0.0" })).unwrap(),
+    )
+    .unwrap();
+    touch(&pkg_dir, "index.js", "module.exports = true\n");
+    touch(&pkg_dir, "ignored.txt", "ignored\n");
+
+    let opts = PackOptions {
+        dir: pkg_dir.clone(),
+        catalogs: BTreeMap::new(),
+        ignore_scripts: true,
+        unsafe_perm: true,
+        embed_readme: false,
+        pack_gzip_level: None,
+        node_linker: NodeLinker::Isolated,
+        skip_manifest_obfuscation: false,
+        user_agent: "pacquet".to_string(),
+        extra_bin_paths: Vec::new(),
+        extra_env: HashMap::new(),
+        workspace_dir: Some(workspace.path().to_path_buf()),
+        dry_run: false,
+        pack_destination: None,
+        out: None,
+    };
+
+    let result = api::<SilentReporter, Host>(&opts).unwrap();
+    let mut names = tarball_entry_names(&pkg_dir.join("foo-1.0.0.tgz"));
+    names.sort();
+    assert_eq!(result.contents, vec!["index.js".to_string(), "package.json".to_string()]);
+    assert_eq!(names, vec!["package/index.js".to_string(), "package/package.json".to_string()]);
+    assert!(result.contents.contains(&"index.js".to_string()));
+    assert!(
+        !result.contents.contains(&"ignored.txt".to_string()),
+        "workspace root `.gitignore` must exclude `ignored.txt`: {:?}",
+        result.contents,
+    );
+    assert!(names.contains(&"package/index.js".to_string()));
+    assert!(!names.contains(&"package/ignored.txt".to_string()));
+}
+
+#[test]
+fn package_npmignore_suppresses_workspace_root_gitignore() {
+    let workspace = tempdir().unwrap();
+    std::fs::write(workspace.path().join(".gitignore"), "ignored.txt\n").unwrap();
+    let pkg_dir = workspace.path().join("packages").join("foo");
+    std::fs::create_dir_all(&pkg_dir).unwrap();
+    std::fs::write(
+        pkg_dir.join("package.json"),
+        serde_json::to_string(&json!({ "name": "foo", "version": "1.0.0" })).unwrap(),
+    )
+    .unwrap();
+    touch(&pkg_dir, ".npmignore", "dist/\n");
+    touch(&pkg_dir, "index.js", "module.exports = true\n");
+    touch(&pkg_dir, "ignored.txt", "ignored\n");
+
+    let opts = PackOptions {
+        dir: pkg_dir.clone(),
+        catalogs: BTreeMap::new(),
+        ignore_scripts: true,
+        unsafe_perm: true,
+        embed_readme: false,
+        pack_gzip_level: None,
+        node_linker: NodeLinker::Isolated,
+        skip_manifest_obfuscation: false,
+        user_agent: "pacquet".to_string(),
+        extra_bin_paths: Vec::new(),
+        extra_env: HashMap::new(),
+        workspace_dir: Some(workspace.path().to_path_buf()),
+        dry_run: false,
+        pack_destination: None,
+        out: None,
+    };
+
+    let result = api::<SilentReporter, Host>(&opts).unwrap();
+    let mut names = tarball_entry_names(&pkg_dir.join("foo-1.0.0.tgz"));
+    names.sort();
+    assert_eq!(
+        result.contents,
+        vec![
+            ".npmignore".to_string(),
+            "ignored.txt".to_string(),
+            "index.js".to_string(),
+            "package.json".to_string(),
+        ],
+    );
+    assert_eq!(
+        names,
+        vec![
+            "package/.npmignore".to_string(),
+            "package/ignored.txt".to_string(),
+            "package/index.js".to_string(),
+            "package/package.json".to_string(),
+        ],
+    );
+}
+
 /// A symlinked workspace-root `LICENSE` must not be injected: following
 /// it would leak the target's bytes — potentially a file outside the
 /// workspace — into the published tarball.

--- a/pacquet/crates/pack/src/tests.rs
+++ b/pacquet/crates/pack/src/tests.rs
@@ -357,6 +357,56 @@ fn workspace_root_gitignore_excludes_sub_package_files() {
 }
 
 #[test]
+fn unrelated_workspace_dir_does_not_apply_root_gitignore() {
+    let workspace = tempdir().unwrap();
+    let unrelated = tempdir().unwrap();
+    std::fs::write(unrelated.path().join(".gitignore"), "ignored.txt\n").unwrap();
+    let pkg_dir = workspace.path().join("packages").join("foo");
+    std::fs::create_dir_all(&pkg_dir).unwrap();
+    std::fs::write(
+        pkg_dir.join("package.json"),
+        serde_json::to_string(&json!({ "name": "foo", "version": "1.0.0" })).unwrap(),
+    )
+    .unwrap();
+    touch(&pkg_dir, "index.js", "module.exports = true\n");
+    touch(&pkg_dir, "ignored.txt", "ignored\n");
+
+    let opts = PackOptions {
+        dir: pkg_dir.clone(),
+        catalogs: BTreeMap::new(),
+        ignore_scripts: true,
+        unsafe_perm: true,
+        embed_readme: false,
+        pack_gzip_level: None,
+        node_linker: NodeLinker::Isolated,
+        skip_manifest_obfuscation: false,
+        user_agent: "pacquet".to_string(),
+        extra_bin_paths: Vec::new(),
+        extra_env: HashMap::new(),
+        workspace_dir: Some(unrelated.path().to_path_buf()),
+        dry_run: false,
+        pack_destination: None,
+        out: None,
+    };
+
+    let result = api::<SilentReporter, Host>(&opts).unwrap();
+    let mut names = tarball_entry_names(&pkg_dir.join("foo-1.0.0.tgz"));
+    names.sort();
+    assert_eq!(
+        result.contents,
+        vec!["ignored.txt".to_string(), "index.js".to_string(), "package.json".to_string()],
+    );
+    assert_eq!(
+        names,
+        vec![
+            "package/ignored.txt".to_string(),
+            "package/index.js".to_string(),
+            "package/package.json".to_string(),
+        ],
+    );
+}
+
+#[test]
 fn package_npmignore_suppresses_workspace_root_gitignore() {
     let workspace = tempdir().unwrap();
     std::fs::write(workspace.path().join(".gitignore"), "ignored.txt\n").unwrap();

--- a/pnpm11/fs/packlist/src/index.ts
+++ b/pnpm11/fs/packlist/src/index.ts
@@ -44,7 +44,10 @@ export async function packlist (pkgDir: string, opts?: {
 
 function isSubdir (parentDir: string, childDir: string): boolean {
   const relative = path.relative(parentDir, childDir)
-  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative)
+  return relative !== '' &&
+    relative !== '..' &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
 }
 
 function isFile (file: string): boolean {

--- a/pnpm11/fs/packlist/src/index.ts
+++ b/pnpm11/fs/packlist/src/index.ts
@@ -17,15 +17,45 @@ interface TreeNode {
   isLink: boolean
   target: TreeNode
   edgesOut: Map<string, Edge>
+  workspaces?: Map<string, string>
 }
 
 export async function packlist (pkgDir: string, opts?: {
   manifest?: Record<string, unknown>
+  workspaceDir?: string
 }): Promise<string[]> {
+  pkgDir = path.resolve(pkgDir)
   const pkg = opts?.manifest ?? readPackageJson(pkgDir)
   const tree = buildRootTree(pkgDir, pkg)
-  const files = await npmPacklist(tree)
+  const workspaceDir = opts?.workspaceDir == null ? undefined : path.resolve(opts.workspaceDir)
+  const workspacePackage = workspaceDir != null && isSubdir(workspaceDir, pkgDir) && !isFile(path.join(pkgDir, '.npmignore'))
+  const npmPacklistOptions = workspacePackage
+    ? {
+      prefix: workspaceDir,
+      workspaces: [pkgDir],
+    }
+    : undefined
+  if (npmPacklistOptions != null) {
+    tree.workspaces = new Map([[pkgDir, pkgDir]])
+  }
+  const files = await npmPacklist(tree, npmPacklistOptions)
   return files.map((file) => file.replace(/^\.[/\\]/, ''))
+}
+
+function isSubdir (parentDir: string, childDir: string): boolean {
+  const relative = path.relative(parentDir, childDir)
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative)
+}
+
+function isFile (file: string): boolean {
+  try {
+    return fs.statSync(file).isFile()
+  } catch (err: unknown) {
+    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') {
+      return false
+    }
+    throw err
+  }
 }
 
 function buildRootTree (pkgDir: string, pkg: Record<string, unknown>): TreeNode {

--- a/pnpm11/releasing/commands/src/publish/pack.ts
+++ b/pnpm11/releasing/commands/src/publish/pack.ts
@@ -263,6 +263,7 @@ export async function api (opts: PackOptions): Promise<PackResult> {
   }
   const files = await packlist(dir, {
     manifest: publishManifest as Record<string, unknown>,
+    workspaceDir: opts.workspaceDir,
   })
   const filesMap = Object.fromEntries(files.map((file) => [`package/${file}`, path.join(dir, file)]))
   // cspell:disable-next-line

--- a/pnpm11/releasing/commands/test/publish/pack.ts
+++ b/pnpm11/releasing/commands/test/publish/pack.ts
@@ -84,15 +84,15 @@ test('pack a package with scoped name', async () => {
 test('pack: workspace package respects root gitignore', async () => {
   const workspaceDir = tempDir()
   const pkgDir = path.join(workspaceDir, 'packages/pkg')
-  fs.mkdirSync(pkgDir, { recursive: true })
-  fs.writeFileSync(path.join(workspaceDir, '.gitignore'), 'ignored.txt\n', 'utf8')
+  await fs.promises.mkdir(pkgDir, { recursive: true })
+  await fs.promises.writeFile(path.join(workspaceDir, '.gitignore'), 'ignored.txt\n', 'utf8')
   writeYamlFileSync(path.join(workspaceDir, 'pnpm-workspace.yaml'), { packages: ['packages/*'] })
-  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({
+  await fs.promises.writeFile(path.join(pkgDir, 'package.json'), JSON.stringify({
     name: 'workspace-pack-gitignore',
     version: '1.0.0',
   }), 'utf8')
-  fs.writeFileSync(path.join(pkgDir, 'index.js'), 'module.exports = true\n', 'utf8')
-  fs.writeFileSync(path.join(pkgDir, 'ignored.txt'), 'ignored\n', 'utf8')
+  await fs.promises.writeFile(path.join(pkgDir, 'index.js'), 'module.exports = true\n', 'utf8')
+  await fs.promises.writeFile(path.join(pkgDir, 'ignored.txt'), 'ignored\n', 'utf8')
 
   const output = await pack.handler({
     ...DEFAULT_OPTS,
@@ -121,14 +121,14 @@ test('pack: unrelated workspaceDir does not apply root gitignore', async () => {
   const workspaceDir = tempDir()
   const unrelatedDir = tempDir()
   const pkgDir = path.join(workspaceDir, 'pkg')
-  fs.mkdirSync(pkgDir, { recursive: true })
-  fs.writeFileSync(path.join(unrelatedDir, '.gitignore'), 'ignored.txt\n', 'utf8')
-  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({
+  await fs.promises.mkdir(pkgDir, { recursive: true })
+  await fs.promises.writeFile(path.join(unrelatedDir, '.gitignore'), 'ignored.txt\n', 'utf8')
+  await fs.promises.writeFile(path.join(pkgDir, 'package.json'), JSON.stringify({
     name: 'workspace-pack-unrelated-gitignore',
     version: '1.0.0',
   }), 'utf8')
-  fs.writeFileSync(path.join(pkgDir, 'index.js'), 'module.exports = true\n', 'utf8')
-  fs.writeFileSync(path.join(pkgDir, 'ignored.txt'), 'ignored\n', 'utf8')
+  await fs.promises.writeFile(path.join(pkgDir, 'index.js'), 'module.exports = true\n', 'utf8')
+  await fs.promises.writeFile(path.join(pkgDir, 'ignored.txt'), 'ignored\n', 'utf8')
 
   const output = await pack.handler({
     ...DEFAULT_OPTS,
@@ -156,15 +156,15 @@ test('pack: unrelated workspaceDir does not apply root gitignore', async () => {
 test('pack: package npmignore suppresses root gitignore fallback', async () => {
   const workspaceDir = tempDir()
   const pkgDir = path.join(workspaceDir, 'packages/pkg')
-  fs.mkdirSync(pkgDir, { recursive: true })
-  fs.writeFileSync(path.join(workspaceDir, '.gitignore'), 'ignored.txt\n', 'utf8')
-  fs.writeFileSync(path.join(pkgDir, '.npmignore'), 'dist/\n', 'utf8')
-  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({
+  await fs.promises.mkdir(pkgDir, { recursive: true })
+  await fs.promises.writeFile(path.join(workspaceDir, '.gitignore'), 'ignored.txt\n', 'utf8')
+  await fs.promises.writeFile(path.join(pkgDir, '.npmignore'), 'dist/\n', 'utf8')
+  await fs.promises.writeFile(path.join(pkgDir, 'package.json'), JSON.stringify({
     name: 'workspace-pack-npmignore',
     version: '1.0.0',
   }), 'utf8')
-  fs.writeFileSync(path.join(pkgDir, 'index.js'), 'module.exports = true\n', 'utf8')
-  fs.writeFileSync(path.join(pkgDir, 'ignored.txt'), 'ignored\n', 'utf8')
+  await fs.promises.writeFile(path.join(pkgDir, 'index.js'), 'module.exports = true\n', 'utf8')
+  await fs.promises.writeFile(path.join(pkgDir, 'ignored.txt'), 'ignored\n', 'utf8')
 
   const output = await pack.handler({
     ...DEFAULT_OPTS,

--- a/pnpm11/releasing/commands/test/publish/pack.ts
+++ b/pnpm11/releasing/commands/test/publish/pack.ts
@@ -81,6 +81,114 @@ test('pack a package with scoped name', async () => {
   expect(fs.existsSync('pnpm-test-scope-0.0.0.tgz')).toBeTruthy()
 })
 
+test('pack: workspace package respects root gitignore', async () => {
+  const workspaceDir = tempDir()
+  const pkgDir = path.join(workspaceDir, 'packages/pkg')
+  fs.mkdirSync(pkgDir, { recursive: true })
+  fs.writeFileSync(path.join(workspaceDir, '.gitignore'), 'ignored.txt\n', 'utf8')
+  writeYamlFileSync(path.join(workspaceDir, 'pnpm-workspace.yaml'), { packages: ['packages/*'] })
+  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({
+    name: 'workspace-pack-gitignore',
+    version: '1.0.0',
+  }), 'utf8')
+  fs.writeFileSync(path.join(pkgDir, 'index.js'), 'module.exports = true\n', 'utf8')
+  fs.writeFileSync(path.join(pkgDir, 'ignored.txt'), 'ignored\n', 'utf8')
+
+  const output = await pack.handler({
+    ...DEFAULT_OPTS,
+    argv: { original: [] },
+    dir: pkgDir,
+    extraBinPaths: [],
+    json: true,
+    packDestination: pkgDir,
+    workspaceDir,
+  })
+  const packed = JSON.parse(output) as PackResultJson
+  const packedPaths = packed.files.map(({ path }) => path)
+
+  await tar.x({
+    file: path.join(pkgDir, 'workspace-pack-gitignore-1.0.0.tgz'),
+    cwd: pkgDir,
+  })
+
+  expect(packedPaths).toContain('index.js')
+  expect(packedPaths).not.toContain('ignored.txt')
+  expect(fs.existsSync(path.join(pkgDir, 'package/index.js'))).toBeTruthy()
+  expect(fs.existsSync(path.join(pkgDir, 'package/ignored.txt'))).toBeFalsy()
+})
+
+test('pack: unrelated workspaceDir does not apply root gitignore', async () => {
+  const workspaceDir = tempDir()
+  const unrelatedDir = tempDir()
+  const pkgDir = path.join(workspaceDir, 'pkg')
+  fs.mkdirSync(pkgDir, { recursive: true })
+  fs.writeFileSync(path.join(unrelatedDir, '.gitignore'), 'ignored.txt\n', 'utf8')
+  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({
+    name: 'workspace-pack-unrelated-gitignore',
+    version: '1.0.0',
+  }), 'utf8')
+  fs.writeFileSync(path.join(pkgDir, 'index.js'), 'module.exports = true\n', 'utf8')
+  fs.writeFileSync(path.join(pkgDir, 'ignored.txt'), 'ignored\n', 'utf8')
+
+  const output = await pack.handler({
+    ...DEFAULT_OPTS,
+    argv: { original: [] },
+    dir: pkgDir,
+    extraBinPaths: [],
+    json: true,
+    packDestination: pkgDir,
+    workspaceDir: unrelatedDir,
+  })
+  const packed = JSON.parse(output) as PackResultJson
+  const packedPaths = packed.files.map(({ path }) => path)
+
+  await tar.x({
+    file: path.join(pkgDir, 'workspace-pack-unrelated-gitignore-1.0.0.tgz'),
+    cwd: pkgDir,
+  })
+
+  expect(packedPaths).toContain('index.js')
+  expect(packedPaths).toContain('ignored.txt')
+  expect(fs.existsSync(path.join(pkgDir, 'package/index.js'))).toBeTruthy()
+  expect(fs.existsSync(path.join(pkgDir, 'package/ignored.txt'))).toBeTruthy()
+})
+
+test('pack: package npmignore suppresses root gitignore fallback', async () => {
+  const workspaceDir = tempDir()
+  const pkgDir = path.join(workspaceDir, 'packages/pkg')
+  fs.mkdirSync(pkgDir, { recursive: true })
+  fs.writeFileSync(path.join(workspaceDir, '.gitignore'), 'ignored.txt\n', 'utf8')
+  fs.writeFileSync(path.join(pkgDir, '.npmignore'), 'dist/\n', 'utf8')
+  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({
+    name: 'workspace-pack-npmignore',
+    version: '1.0.0',
+  }), 'utf8')
+  fs.writeFileSync(path.join(pkgDir, 'index.js'), 'module.exports = true\n', 'utf8')
+  fs.writeFileSync(path.join(pkgDir, 'ignored.txt'), 'ignored\n', 'utf8')
+
+  const output = await pack.handler({
+    ...DEFAULT_OPTS,
+    argv: { original: [] },
+    dir: pkgDir,
+    extraBinPaths: [],
+    json: true,
+    packDestination: pkgDir,
+    workspaceDir,
+  })
+  const packed = JSON.parse(output) as PackResultJson
+  const packedPaths = packed.files.map(({ path }) => path)
+
+  await tar.x({
+    file: path.join(pkgDir, 'workspace-pack-npmignore-1.0.0.tgz'),
+    cwd: pkgDir,
+  })
+
+  expect(packedPaths).toContain('index.js')
+  expect(packedPaths).toContain('ignored.txt')
+  expect(fs.existsSync(path.join(pkgDir, 'package/index.js'))).toBeTruthy()
+  expect(fs.existsSync(path.join(pkgDir, 'package/ignored.txt'))).toBeTruthy()
+})
+
 test('pack: with dry-run', async () => {
   prepare({
     name: 'test-publish-package.json',


### PR DESCRIPTION
## Summary

- Pass workspace context into the TypeScript packlist path so `pnpm pack` applies workspace-root `.gitignore` rules for sub-packages.
- Mirror the behavior in `pacquet` packlist and pack handling.
- Add regression coverage for both implementations.

Fixes pnpm/pnpm#12560

## Squash Commit Body

```text
Fixes pnpm/pnpm#12560.

Workspace package packing now passes workspace context into the packlist calculation, so root .gitignore rules are applied when packing a sub-package. The pacquet packlist and pack path use the same workspace-aware behavior to keep the Rust port aligned.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace package packing now applies workspace-root ignore rules (preferring `.npmignore` over `.gitignore`) when the package lacks a package-local `.npmignore`.
  * Workspace-root `.gitignore` exclusions are now reflected in both the computed file list and the resulting tarball.
  * Workspace ignore handling is not applied when using an unrelated workspace root.
* **Tests**
  * Added regression coverage for workspace-root `.gitignore` behavior, `.npmignore` precedence, unrelated roots, and error handling for unreadable ignore files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->