### PR TITLE
fix: sync direct dependency workspace overrides

### DIFF
--- a/.changeset/sync-updated-overrides.md
+++ b/.changeset/sync-updated-overrides.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Keep matching workspace overrides in sync when updating direct dependency specifiers.

--- a/pnpm11/installing/commands/src/installDeps.ts
+++ b/pnpm11/installing/commands/src/installDeps.ts
@@ -40,6 +40,7 @@ import { findWorkspaceProjects } from '@pnpm/workspace.projects-reader'
 import { sequenceGraph } from '@pnpm/workspace.projects-sorter'
 import { updateWorkspaceState, type WorkspaceStateSettings } from '@pnpm/workspace.state'
 import { updateWorkspaceManifest } from '@pnpm/workspace.workspace-manifest-writer'
+import { clone } from 'ramda'
 
 import { getPinnedVersion } from './getPinnedVersion.js'
 import { getSaveType } from './getSaveType.js'
@@ -56,6 +57,12 @@ import {
 } from './recursive.js'
 import { makeRunPacquet } from './runPacquet.js'
 import { createWorkspaceSpecs, updateToWorkspacePackagesFromManifest } from './updateWorkspaceDependencies.js'
+import {
+  pickUpdatedLockfileWorkspaceOverrides,
+  pickUpdatedWorkspaceOverrides,
+  type WorkspaceOverrideUpdateConflict,
+  writeUpdatedLockfileOverrides,
+} from './updateWorkspaceOverrides.js'
 import { verifyPacquetIdentity } from './verifyPacquetIdentity.js'
 
 const OVERWRITE_UPDATE_OPTIONS = {
@@ -113,6 +120,7 @@ export type InstallDepsOptions = Pick<Config,
 | 'trustLockfile'
 | 'allowBuilds'
 | 'optional'
+| 'overrides'
 | 'workspaceConcurrency'
 | 'workspaceDir'
 | 'workspacePackagePatterns'
@@ -399,6 +407,7 @@ export async function installDeps (
     }
   }
   if (params?.length) {
+    const manifestBeforeMutation = clone(manifest)
     const mutatedProject = {
       allowNew: opts.allowNew,
       binsDir: opts.bin,
@@ -410,22 +419,49 @@ export async function installDeps (
       rootDir: opts.dir as ProjectRootDir,
       targetDependenciesField: getSaveType(opts),
     }
-    const { updatedCatalogs, updatedProject, ignoredBuilds, resolutionPolicyViolations, dryRunResult } = await mutateModulesInSingleProject(mutatedProject, installOpts)
+    const { updatedCatalogs, updatedOverrides, updatedProject, ignoredBuilds, resolutionPolicyViolations, dryRunResult } = await mutateModulesInSingleProject(mutatedProject, installOpts)
     if (opts.save !== false && !opts.dryRun) {
       // Only pick entries when we'll actually persist. Otherwise the
       // info log would claim we added entries the workspace manifest
       // never saw, and the next install would re-prompt or fail
       // verification.
       const policyUpdates = policyHandlers?.pickManifestUpdates(resolutionPolicyViolations)
-      await Promise.all([
+      const projectsForOverrides = [{
+        before: manifestBeforeMutation,
+        after: updatedProject.manifest,
+      }]
+      const workspaceDir = opts.workspaceDir ?? opts.dir
+      const lockfileDir = opts.lockfileDir ?? workspaceDir
+      const lockfileOptions = {
+        useGitBranchLockfile: opts.useGitBranchLockfile,
+        mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
+      }
+      const onConflict = createWorkspaceOverrideConflictLogger(workspaceDir)
+      const workspaceOverrides = updatedOverrides ??
+        pickUpdatedWorkspaceOverrides(opts.overrides, projectsForOverrides, { onConflict }) ??
+        (opts.useLockfile !== false
+          ? await pickUpdatedLockfileWorkspaceOverrides({
+            lockfileDir,
+            overrides: opts.overrides,
+            projects: projectsForOverrides,
+            ...lockfileOptions,
+            onConflict,
+          })
+          : undefined)
+      const promises: Array<Promise<void>> = [
         writeProjectManifest(updatedProject.manifest),
-        updateWorkspaceManifest(opts.workspaceDir ?? opts.dir, {
+        updateWorkspaceManifest(workspaceDir, {
           updatedCatalogs,
+          updatedOverrides: workspaceOverrides,
           cleanupUnusedCatalogs: opts.cleanupUnusedCatalogs,
           allProjects: opts.allProjects,
           ...policyUpdates,
         }),
-      ])
+      ]
+      if (opts.useLockfile !== false) {
+        promises.push(writeUpdatedLockfileOverrides(lockfileDir, workspaceOverrides, lockfileOptions))
+      }
+      await Promise.all(promises)
     }
     if (!opts.lockfileOnly) {
       await updateWorkspaceState({
@@ -441,7 +477,9 @@ export async function installDeps (
     return dryRunResult
   }
 
-  const { updatedCatalogs, updatedManifest, ignoredBuilds, resolutionPolicyViolations, dryRunResult } = await install(manifest, {
+  const canPickUpdatedWorkspaceOverrides = opts.update === true && opts.overrides != null && Object.keys(opts.overrides).length > 0
+  const manifestBeforeMutation = canPickUpdatedWorkspaceOverrides ? clone(manifest) : manifest
+  const { updatedCatalogs, updatedOverrides, updatedManifest, ignoredBuilds, resolutionPolicyViolations, dryRunResult } = await install(manifest, {
     ...installOpts,
     updatePackageManifest,
     updateMatching,
@@ -453,15 +491,42 @@ export async function installDeps (
   if (opts.save !== false && !opts.dryRun) {
     const policyUpdates = policyHandlers?.pickManifestUpdates(resolutionPolicyViolations)
     if (opts.update === true) {
-      await Promise.all([
+      const projectsForOverrides = [{
+        before: manifestBeforeMutation,
+        after: updatedManifest,
+      }]
+      const workspaceDir = opts.workspaceDir ?? opts.dir
+      const lockfileDir = opts.lockfileDir ?? workspaceDir
+      const lockfileOptions = {
+        useGitBranchLockfile: opts.useGitBranchLockfile,
+        mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
+      }
+      const onConflict = createWorkspaceOverrideConflictLogger(workspaceDir)
+      const workspaceOverrides = updatedOverrides ??
+        (canPickUpdatedWorkspaceOverrides ? pickUpdatedWorkspaceOverrides(opts.overrides, projectsForOverrides, { onConflict }) : undefined) ??
+        (opts.useLockfile !== false && canPickUpdatedWorkspaceOverrides
+          ? await pickUpdatedLockfileWorkspaceOverrides({
+            lockfileDir,
+            overrides: opts.overrides,
+            projects: projectsForOverrides,
+            ...lockfileOptions,
+            onConflict,
+          })
+          : undefined)
+      const promises: Array<Promise<void>> = [
         writeProjectManifest(updatedManifest),
-        updateWorkspaceManifest(opts.workspaceDir ?? opts.dir, {
+        updateWorkspaceManifest(workspaceDir, {
           updatedCatalogs,
+          updatedOverrides: workspaceOverrides,
           cleanupUnusedCatalogs: opts.cleanupUnusedCatalogs,
           allProjects,
           ...policyUpdates,
         }),
-      ])
+      ]
+      if (opts.useLockfile !== false) {
+        promises.push(writeUpdatedLockfileOverrides(lockfileDir, workspaceOverrides, lockfileOptions))
+      }
+      await Promise.all(promises)
     } else if (policyUpdates != null) {
       // Plain `pnpm install` (no --update, no params) wouldn't otherwise touch
       // the workspace manifest. Persist the auto-policy patches anyway so any
@@ -638,5 +703,14 @@ async function restoreWantedLockfileIfMissing (
   } catch (error) {
     logger.debug({ msg: 'Failed to restore pnpm-lock.yaml from the current lockfile', error })
     return false
+  }
+}
+
+function createWorkspaceOverrideConflictLogger (prefix: string): (conflict: WorkspaceOverrideUpdateConflict) => void {
+  return ({ alias, specifiers }) => {
+    logger.warn({
+      message: `Skipping workspace override update for "${alias}" because it resolved to multiple specifiers: ${specifiers.join(', ')}.`,
+      prefix,
+    })
   }
 }

--- a/pnpm11/installing/commands/src/installDeps.ts
+++ b/pnpm11/installing/commands/src/installDeps.ts
@@ -60,6 +60,7 @@ import { createWorkspaceSpecs, updateToWorkspacePackagesFromManifest } from './u
 import {
   pickUpdatedLockfileWorkspaceOverrides,
   pickUpdatedWorkspaceOverrides,
+  shouldWriteUpdatedLockfileOverrides,
   type WorkspaceOverrideUpdateConflict,
   writeUpdatedLockfileOverrides,
 } from './updateWorkspaceOverrides.js'
@@ -458,7 +459,7 @@ export async function installDeps (
           ...policyUpdates,
         }),
       ]
-      if (opts.useLockfile !== false) {
+      if (opts.useLockfile !== false && shouldWriteUpdatedLockfileOverrides(updatedOverrides, workspaceOverrides)) {
         promises.push(writeUpdatedLockfileOverrides(lockfileDir, workspaceOverrides, lockfileOptions))
       }
       await Promise.all(promises)
@@ -523,7 +524,7 @@ export async function installDeps (
           ...policyUpdates,
         }),
       ]
-      if (opts.useLockfile !== false) {
+      if (opts.useLockfile !== false && shouldWriteUpdatedLockfileOverrides(updatedOverrides, workspaceOverrides)) {
         promises.push(writeUpdatedLockfileOverrides(lockfileDir, workspaceOverrides, lockfileOptions))
       }
       await Promise.all(promises)

--- a/pnpm11/installing/commands/src/recursive.ts
+++ b/pnpm11/installing/commands/src/recursive.ts
@@ -65,6 +65,7 @@ import {
   pickUniqueUpdatedWorkspaceOverrides,
   pickUpdatedLockfileWorkspaceOverrides,
   pickUpdatedWorkspaceOverrides,
+  shouldWriteUpdatedLockfileOverrides,
   type WorkspaceOverrideUpdateConflict,
   writeUpdatedLockfileOverrides,
 } from './updateWorkspaceOverrides.js'
@@ -400,7 +401,7 @@ export async function recursive (
         allProjects,
         ...policyUpdates,
       }))
-      if (opts.useLockfile !== false) {
+      if (opts.useLockfile !== false && shouldWriteUpdatedLockfileOverrides(updatedOverrides, workspaceOverrides)) {
         promises.push(writeUpdatedLockfileOverrides(opts.lockfileDir, workspaceOverrides, lockfileOptions))
       }
       await Promise.all(promises)

--- a/pnpm11/installing/commands/src/recursive.ts
+++ b/pnpm11/installing/commands/src/recursive.ts
@@ -53,12 +53,21 @@ import { updateWorkspaceManifest } from '@pnpm/workspace.workspace-manifest-writ
 import { isSubdir } from 'is-subdir'
 import pFilter from 'p-filter'
 import pLimit from 'p-limit'
+import { clone } from 'ramda'
 
 import { getPinnedVersion } from './getPinnedVersion.js'
 import { getSaveType } from './getSaveType.js'
 import { handleIgnoredBuilds } from './handleIgnoredBuilds.js'
 import { type PolicyViolation, setupPolicyHandlers } from './policyHandlers.js'
 import { createWorkspaceSpecs, updateToWorkspacePackagesFromManifest } from './updateWorkspaceDependencies.js'
+import {
+  addUpdatedWorkspaceOverrideCandidates,
+  pickUniqueUpdatedWorkspaceOverrides,
+  pickUpdatedLockfileWorkspaceOverrides,
+  pickUpdatedWorkspaceOverrides,
+  type WorkspaceOverrideUpdateConflict,
+  writeUpdatedLockfileOverrides,
+} from './updateWorkspaceOverrides.js'
 
 export type RecursiveOptions = CreateStoreControllerOptions & Pick<Config,
 | 'bail'
@@ -77,6 +86,7 @@ export type RecursiveOptions = CreateStoreControllerOptions & Pick<Config,
 | 'lockfileOnly'
 | 'modulesDir'
 | 'pnprServer'
+| 'overrides'
 | 'allowBuilds'
 | 'registries'
 | 'runtime'
@@ -139,6 +149,9 @@ export type RecursiveOptions = CreateStoreControllerOptions & Pick<Config,
 | 'ci'
 | 'sort'
 | 'strictDepBuilds'
+| 'useGitBranchLockfile'
+| 'useLockfile'
+| 'mergeGitBranchLockfiles'
 | 'workspaceConcurrency'
   >
 > & Required<
@@ -331,8 +344,15 @@ export async function recursive (
       throw new PnpmError('NO_PACKAGE_IN_DEPENDENCIES',
         'None of the specified packages were found in the dependencies of any of the projects.')
     }
+    const canPickUpdatedWorkspaceOverrides = opts.overrides != null && Object.keys(opts.overrides).length > 0
+    const originalManifestsByRootDir = canPickUpdatedWorkspaceOverrides
+      ? new Map<ProjectRootDir, ProjectManifest>(
+        mutatedImporters.map(({ rootDir }) => [rootDir, clone(manifestsByPath[rootDir].manifest)])
+      )
+      : undefined
     const {
       updatedCatalogs,
+      updatedOverrides,
       updatedProjects: mutatedPkgs,
       ignoredBuilds,
       resolutionPolicyViolations,
@@ -348,15 +368,41 @@ export async function recursive (
       // manifest never saw, and the next install would re-prompt or
       // fail verification.
       const policyUpdates = policyHandlers?.pickManifestUpdates(resolutionPolicyViolations)
+      const projectsForOverrides = canPickUpdatedWorkspaceOverrides
+        ? mutatedPkgs.map(({ originalManifest, manifest, rootDir }) => ({
+          before: originalManifestsByRootDir?.get(rootDir) ?? manifestsByPath[rootDir].manifest,
+          after: originalManifest ?? manifest,
+        }))
+        : []
+      const lockfileOptions = {
+        useGitBranchLockfile: opts.useGitBranchLockfile,
+        mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
+      }
+      const onConflict = createWorkspaceOverrideConflictLogger(opts.workspaceDir)
+      const workspaceOverrides = updatedOverrides ??
+        (canPickUpdatedWorkspaceOverrides ? pickUpdatedWorkspaceOverrides(opts.overrides, projectsForOverrides, { onConflict }) : undefined) ??
+        (opts.useLockfile !== false && canPickUpdatedWorkspaceOverrides
+          ? await pickUpdatedLockfileWorkspaceOverrides({
+            lockfileDir: opts.lockfileDir,
+            overrides: opts.overrides,
+            projects: projectsForOverrides,
+            ...lockfileOptions,
+            onConflict,
+          })
+          : undefined)
       const promises: Array<Promise<void>> = mutatedPkgs.map(async ({ originalManifest, manifest, rootDir }) => {
         return manifestsByPath[rootDir].writeProjectManifest(originalManifest ?? manifest)
       })
       promises.push(updateWorkspaceManifest(opts.workspaceDir, {
         updatedCatalogs,
+        updatedOverrides: workspaceOverrides,
         cleanupUnusedCatalogs: opts.cleanupUnusedCatalogs,
         allProjects,
         ...policyUpdates,
       }))
+      if (opts.useLockfile !== false) {
+        promises.push(writeUpdatedLockfileOverrides(opts.lockfileDir, workspaceOverrides, lockfileOptions))
+      }
       await Promise.all(promises)
     }
     await handleIgnoredBuilds(opts, ignoredBuilds)
@@ -366,6 +412,8 @@ export async function recursive (
   const pkgPaths = (Object.keys(opts.selectedProjectsGraph) as ProjectRootDir[]).sort()
 
   let updatedCatalogs: Catalogs | undefined
+  const updatedOverrideCandidates = new Map<string, Set<string>>()
+  const canPickUpdatedWorkspaceOverrides = opts.overrides != null && Object.keys(opts.overrides).length > 0
 
   const allIgnoredBuilds = new Set<DepPath>()
   // Each per-project install returns its own slice of lockfile-resolution
@@ -407,6 +455,7 @@ export async function recursive (
             currentInput = createWorkspaceSpecs(currentInput, workspacePackages)
           }
         }
+        const manifestBeforeMutation = canPickUpdatedWorkspaceOverrides ? clone(manifest) : manifest
 
         type ActionOpts =
           & Omit<InstallOptions, 'allProjects'>
@@ -417,6 +466,7 @@ export async function recursive (
 
         interface ActionResult {
           updatedCatalogs?: Catalogs
+          updatedOverrides?: Record<string, string>
           updatedManifest: ProjectManifest
           ignoredBuilds: IgnoredBuilds | undefined
           resolutionPolicyViolations?: PolicyViolation[]
@@ -437,6 +487,7 @@ export async function recursive (
               ], opts)
               return {
                 updatedCatalogs: undefined, // there's no reason to add new or update catalogs on `pnpm remove`
+                updatedOverrides: undefined,
                 updatedManifest: mutationResult.updatedProjects[0].manifest,
                 ignoredBuilds: mutationResult.ignoredBuilds,
                 resolutionPolicyViolations: mutationResult.resolutionPolicyViolations,
@@ -453,6 +504,7 @@ export async function recursive (
         const localConfig = getProjectConfig(manifest) ?? {}
         const {
           updatedCatalogs: newCatalogsAddition,
+          updatedOverrides: newOverrides,
           updatedManifest: newManifest,
           ignoredBuilds,
           resolutionPolicyViolations,
@@ -475,7 +527,7 @@ export async function recursive (
             resolutionVerifiers: store.resolutionVerifiers,
           }
         )
-        if (opts.save !== false) {
+        if (opts.save !== false && !opts.dryRun) {
           await writeProjectManifest(newManifest)
           if (newCatalogsAddition) {
             // Per-project additions are partial maps keyed by catalog name then
@@ -483,6 +535,14 @@ export async function recursive (
             // different entries of the same catalog don't clobber each other.
             updatedCatalogs = mergeCatalogs(updatedCatalogs, newCatalogsAddition)
           }
+          const workspaceOverrides = newOverrides ??
+            (canPickUpdatedWorkspaceOverrides
+              ? pickUpdatedWorkspaceOverrides(opts.overrides, [{
+                before: manifestBeforeMutation,
+                after: newManifest,
+              }], { onConflict: createWorkspaceOverrideConflictLogger(rootDir) })
+              : undefined)
+          addUpdatedWorkspaceOverrideCandidates(updatedOverrideCandidates, workspaceOverrides)
         }
         if (ignoredBuilds?.size) {
           for (const depPath of ignoredBuilds) {
@@ -514,13 +574,17 @@ export async function recursive (
     })
   ))
   await handleIgnoredBuilds(opts, allIgnoredBuilds.size ? allIgnoredBuilds : undefined)
-  if (opts.save !== false) {
+  if (opts.save !== false && !opts.dryRun) {
     // Only pick entries when we'll actually persist. Otherwise the
     // info log would claim entries were added that the workspace
     // manifest never saw, mirroring the gate the shared-lockfile
     // branch + installDeps already apply.
+    const updatedOverrides = pickUniqueUpdatedWorkspaceOverrides(updatedOverrideCandidates, {
+      onConflict: createWorkspaceOverrideConflictLogger(opts.workspaceDir),
+    })
     await updateWorkspaceManifest(opts.workspaceDir, {
       updatedCatalogs,
+      updatedOverrides,
       cleanupUnusedCatalogs: opts.cleanupUnusedCatalogs,
       allProjects,
       ...policyHandlers?.pickManifestUpdates(allResolutionPolicyViolations),
@@ -655,4 +719,13 @@ function getImporters (opts: Pick<RecursiveOptions, 'selectedProjectsGraph' | 'i
     rootDirs = rootDirs.filter((rootDir) => !opts.ignoredPackages!.has(rootDir))
   }
   return rootDirs.map((rootDir) => ({ rootDir, rootDirRealPath: opts.selectedProjectsGraph[rootDir].package.rootDirRealPath }))
+}
+
+function createWorkspaceOverrideConflictLogger (prefix: string): (conflict: WorkspaceOverrideUpdateConflict) => void {
+  return ({ alias, specifiers }) => {
+    logger.warn({
+      message: `Skipping workspace override update for "${alias}" because it resolved to multiple specifiers: ${specifiers.join(', ')}.`,
+      prefix,
+    })
+  }
 }

--- a/pnpm11/installing/commands/src/updateWorkspaceOverrides.ts
+++ b/pnpm11/installing/commands/src/updateWorkspaceOverrides.ts
@@ -1,0 +1,189 @@
+import { readWantedLockfile, writeWantedLockfile } from '@pnpm/lockfile.fs'
+import type { ProjectManifest } from '@pnpm/types'
+
+export type WorkspaceOverrideUpdateCandidates = Map<string, Set<string>>
+
+export interface ProjectManifestChange {
+  before: ProjectManifest
+  after: ProjectManifest
+}
+
+export interface WorkspaceOverrideUpdateConflict {
+  alias: string
+  specifiers: string[]
+}
+
+interface WorkspaceOverrideUpdateOptions {
+  onConflict?: (conflict: WorkspaceOverrideUpdateConflict) => void
+}
+
+export interface PickUpdatedLockfileWorkspaceOverridesOptions extends WorkspaceOverrideUpdateOptions {
+  lockfileDir: string
+  overrides: Record<string, string> | undefined
+  projects: ProjectManifestChange[]
+  useGitBranchLockfile?: boolean
+  mergeGitBranchLockfiles?: boolean
+}
+
+interface LockfileWriteOptions extends WorkspaceOverrideUpdateOptions {
+  useGitBranchLockfile?: boolean
+  mergeGitBranchLockfiles?: boolean
+}
+
+export function addUpdatedWorkspaceOverrideCandidates (
+  candidates: WorkspaceOverrideUpdateCandidates,
+  updatedOverrides: Record<string, string> | undefined
+): void {
+  if (updatedOverrides == null) return
+
+  for (const [alias, nextSpecifier] of Object.entries(updatedOverrides)) {
+    if (typeof nextSpecifier !== 'string') continue
+    addUpdatedWorkspaceOverrideCandidate(candidates, alias, nextSpecifier)
+  }
+}
+
+export function pickUniqueUpdatedWorkspaceOverrides (
+  candidates: WorkspaceOverrideUpdateCandidates,
+  opts?: WorkspaceOverrideUpdateOptions
+): Record<string, string> | undefined {
+  const updatedOverrides = createSafeStringRecord()
+  for (const [alias, values] of candidates) {
+    if (values.size !== 1) {
+      opts?.onConflict?.({
+        alias,
+        specifiers: Array.from(values).sort(),
+      })
+      continue
+    }
+    setOwnString(updatedOverrides, alias, Array.from(values)[0]!)
+  }
+
+  return Object.keys(updatedOverrides).length > 0 ? updatedOverrides : undefined
+}
+
+export function pickUpdatedWorkspaceOverrides (
+  overrides: Record<string, string> | undefined,
+  projects: ProjectManifestChange[],
+  opts?: WorkspaceOverrideUpdateOptions
+): Record<string, string> | undefined {
+  if (overrides == null || Object.keys(overrides).length === 0) return undefined
+
+  const candidates: WorkspaceOverrideUpdateCandidates = new Map()
+  for (const { before, after } of projects) {
+    const previousDependencies = getDirectDependenciesForOverrides(before)
+    const nextDependencies = getDirectDependenciesForOverrides(after)
+    for (const [alias, nextSpecifier] of Object.entries(nextDependencies)) {
+      const previousSpecifier = getOwnString(previousDependencies, alias)
+      if (previousSpecifier == null || previousSpecifier === nextSpecifier) continue
+      if (getOwnString(overrides, alias) !== previousSpecifier) continue
+
+      addUpdatedWorkspaceOverrideCandidate(candidates, alias, nextSpecifier)
+    }
+  }
+
+  return pickUniqueUpdatedWorkspaceOverrides(candidates, opts)
+}
+
+export async function pickUpdatedLockfileWorkspaceOverrides ({
+  lockfileDir,
+  overrides,
+  projects,
+  ...opts
+}: PickUpdatedLockfileWorkspaceOverridesOptions): Promise<Record<string, string> | undefined> {
+  if (overrides == null || Object.keys(overrides).length === 0) return undefined
+
+  const wantedLockfile = await readWantedLockfile(lockfileDir, {
+    ignoreIncompatible: false,
+    ...opts,
+  })
+  if (wantedLockfile?.overrides == null) return undefined
+
+  const candidates: WorkspaceOverrideUpdateCandidates = new Map()
+  for (const { before, after } of projects) {
+    const previousDependencies = getDirectDependenciesForOverrides(before)
+    const nextDependencies = getDirectDependenciesForOverrides(after)
+    for (const alias of Object.keys(nextDependencies)) {
+      const previousSpecifier = getOwnString(previousDependencies, alias)
+      const nextDependencySpecifier = getOwnString(nextDependencies, alias)
+      const nextSpecifier = getOwnString(wantedLockfile.overrides, alias)
+      if (previousSpecifier == null || nextDependencySpecifier == null || previousSpecifier === nextDependencySpecifier) continue
+      if (nextSpecifier == null || nextSpecifier !== nextDependencySpecifier) continue
+      if (getOwnString(overrides, alias) !== previousSpecifier) continue
+
+      addUpdatedWorkspaceOverrideCandidate(candidates, alias, nextSpecifier)
+    }
+  }
+
+  return pickUniqueUpdatedWorkspaceOverrides(candidates, opts)
+}
+
+export async function writeUpdatedLockfileOverrides (
+  lockfileDir: string,
+  updatedOverrides: Record<string, string> | undefined,
+  opts?: LockfileWriteOptions
+): Promise<void> {
+  if (updatedOverrides == null || Object.keys(updatedOverrides).length === 0) return
+
+  const wantedLockfile = await readWantedLockfile(lockfileDir, {
+    ignoreIncompatible: false,
+    ...opts,
+  })
+  if (wantedLockfile == null) return
+
+  wantedLockfile.overrides = mergeStringRecords(wantedLockfile.overrides, updatedOverrides)
+  await writeWantedLockfile(lockfileDir, wantedLockfile, opts)
+}
+
+function getDirectDependenciesForOverrides (manifest: ProjectManifest): Record<string, string> {
+  return mergeStringRecords(
+    manifest.devDependencies,
+    manifest.dependencies,
+    manifest.optionalDependencies
+  )
+}
+
+function addUpdatedWorkspaceOverrideCandidate (
+  candidates: WorkspaceOverrideUpdateCandidates,
+  alias: string,
+  nextSpecifier: string
+): void {
+  if (typeof alias !== 'string' || typeof nextSpecifier !== 'string') return
+
+  let values = candidates.get(alias)
+  if (values == null) {
+    values = new Set()
+    candidates.set(alias, values)
+  }
+  values.add(nextSpecifier)
+}
+
+function mergeStringRecords (...records: Array<Record<string, string> | undefined>): Record<string, string> {
+  const result = createSafeStringRecord()
+  for (const record of records) {
+    if (record == null) continue
+    for (const key of Object.keys(record)) {
+      const value = getOwnString(record, key)
+      if (value == null) continue
+      setOwnString(result, key, value)
+    }
+  }
+  return result
+}
+
+function createSafeStringRecord (): Record<string, string> {
+  return Object.create(null) as Record<string, string>
+}
+
+function getOwnString (record: Record<string, string>, key: string): string | undefined {
+  const value = Object.prototype.propertyIsEnumerable.call(record, key) ? record[key] : undefined
+  return typeof value === 'string' ? value : undefined
+}
+
+function setOwnString (record: Record<string, string>, key: string, value: string): void {
+  Object.defineProperty(record, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  })
+}

--- a/pnpm11/installing/commands/src/updateWorkspaceOverrides.ts
+++ b/pnpm11/installing/commands/src/updateWorkspaceOverrides.ts
@@ -134,6 +134,15 @@ export async function writeUpdatedLockfileOverrides (
   await writeWantedLockfile(lockfileDir, wantedLockfile, opts)
 }
 
+export function shouldWriteUpdatedLockfileOverrides (
+  installerUpdatedOverrides: Record<string, string> | undefined,
+  workspaceOverrides: Record<string, string> | undefined
+): boolean {
+  return installerUpdatedOverrides == null &&
+    workspaceOverrides != null &&
+    Object.keys(workspaceOverrides).length > 0
+}
+
 function getDirectDependenciesForOverrides (manifest: ProjectManifest): Record<string, string> {
   return mergeStringRecords(
     manifest.devDependencies,

--- a/pnpm11/installing/commands/test/updateWorkspaceOverrides.test.ts
+++ b/pnpm11/installing/commands/test/updateWorkspaceOverrides.test.ts
@@ -8,6 +8,7 @@ import {
   pickUniqueUpdatedWorkspaceOverrides,
   pickUpdatedLockfileWorkspaceOverrides,
   pickUpdatedWorkspaceOverrides,
+  shouldWriteUpdatedLockfileOverrides,
   type WorkspaceOverrideUpdateCandidates,
   type WorkspaceOverrideUpdateConflict,
 } from '../src/updateWorkspaceOverrides.js'
@@ -101,6 +102,24 @@ test('addUpdatedWorkspaceOverrideCandidates skips non-string runtime values', ()
   })
 
   expect(pickUniqueUpdatedWorkspaceOverrides(candidates)).toBeUndefined()
+})
+
+test('shouldWriteUpdatedLockfileOverrides skips installer-provided updates', () => {
+  expect(shouldWriteUpdatedLockfileOverrides({
+    foo: '^1.1.0',
+  }, {
+    foo: '^1.1.0',
+  })).toBe(false)
+})
+
+test('shouldWriteUpdatedLockfileOverrides writes fallback workspace updates', () => {
+  expect(shouldWriteUpdatedLockfileOverrides(undefined, {
+    foo: '^1.1.0',
+  })).toBe(true)
+})
+
+test('shouldWriteUpdatedLockfileOverrides skips empty fallback updates', () => {
+  expect(shouldWriteUpdatedLockfileOverrides(undefined, {})).toBe(false)
 })
 
 test('pickUpdatedLockfileWorkspaceOverrides requires the updated manifest specifier to match the lockfile override', async () => {

--- a/pnpm11/installing/commands/test/updateWorkspaceOverrides.test.ts
+++ b/pnpm11/installing/commands/test/updateWorkspaceOverrides.test.ts
@@ -1,0 +1,176 @@
+import { expect, test } from '@jest/globals'
+import { writeWantedLockfile } from '@pnpm/lockfile.fs'
+import type { ProjectId } from '@pnpm/types'
+import { temporaryDirectory } from 'tempy'
+
+import {
+  addUpdatedWorkspaceOverrideCandidates,
+  pickUniqueUpdatedWorkspaceOverrides,
+  pickUpdatedLockfileWorkspaceOverrides,
+  pickUpdatedWorkspaceOverrides,
+  type WorkspaceOverrideUpdateCandidates,
+  type WorkspaceOverrideUpdateConflict,
+} from '../src/updateWorkspaceOverrides.js'
+
+test('pickUpdatedWorkspaceOverrides skips conflicting next specifiers', () => {
+  const conflicts: WorkspaceOverrideUpdateConflict[] = []
+  const updatedOverrides = pickUpdatedWorkspaceOverrides({
+    foo: '^1.0.0',
+  }, [
+    {
+      before: { dependencies: { foo: '^1.0.0' } },
+      after: { dependencies: { foo: '^1.1.0' } },
+    },
+    {
+      before: { dependencies: { foo: '^1.0.0' } },
+      after: { dependencies: { foo: '^1.2.0' } },
+    },
+  ], { onConflict: (conflict) => conflicts.push(conflict) })
+
+  expect(updatedOverrides).toBeUndefined()
+  expect(conflicts).toStrictEqual([{
+    alias: 'foo',
+    specifiers: ['^1.1.0', '^1.2.0'],
+  }])
+})
+
+test('pickUpdatedWorkspaceOverrides does not rewrite raw catalog overrides', () => {
+  const updatedOverrides = pickUpdatedWorkspaceOverrides({
+    foo: 'catalog:',
+  }, [{
+    before: { dependencies: { foo: '^1.0.0' } },
+    after: { dependencies: { foo: '^1.1.0' } },
+  }])
+
+  expect(updatedOverrides).toBeUndefined()
+})
+
+test('pickUpdatedWorkspaceOverrides leaves non-matching direct overrides unchanged', () => {
+  const updatedOverrides = pickUpdatedWorkspaceOverrides({
+    foo: '^0.9.0',
+  }, [{
+    before: { dependencies: { foo: '^1.0.0' } },
+    after: { dependencies: { foo: '^1.1.0' } },
+  }])
+
+  expect(updatedOverrides).toBeUndefined()
+})
+
+test('pickUpdatedWorkspaceOverrides treats unsafe aliases as own entries', () => {
+  const updatedOverrides = pickUpdatedWorkspaceOverrides(
+    stringRecord([['__proto__', '^1.0.0']]),
+    [{
+      before: { dependencies: stringRecord([['__proto__', '^1.0.0']]) },
+      after: { dependencies: stringRecord([['__proto__', '^1.1.0']]) },
+    }]
+  )
+
+  expect(updatedOverrides).toBeDefined()
+  expect(Object.getPrototypeOf(updatedOverrides!)).toBeNull()
+  expect(Object.prototype.hasOwnProperty.call(updatedOverrides, '__proto__')).toBe(true)
+  expect(updatedOverrides!['__proto__']).toBe('^1.1.0')
+})
+
+test('pickUniqueUpdatedWorkspaceOverrides skips conflicts when merging per-project updates', () => {
+  const candidates: WorkspaceOverrideUpdateCandidates = new Map()
+  const conflicts: WorkspaceOverrideUpdateConflict[] = []
+
+  addUpdatedWorkspaceOverrideCandidates(candidates, { foo: '^1.1.0' })
+  addUpdatedWorkspaceOverrideCandidates(candidates, { foo: '^1.2.0' })
+  addUpdatedWorkspaceOverrideCandidates(candidates, { bar: '^2.1.0' })
+
+  const updatedOverrides = pickUniqueUpdatedWorkspaceOverrides(candidates, {
+    onConflict: (conflict) => conflicts.push(conflict),
+  })
+
+  expect(Object.getPrototypeOf(updatedOverrides!)).toBeNull()
+  expect(updatedOverrides).toEqual({
+    bar: '^2.1.0',
+  })
+  expect(conflicts).toStrictEqual([{
+    alias: 'foo',
+    specifiers: ['^1.1.0', '^1.2.0'],
+  }])
+})
+
+test('addUpdatedWorkspaceOverrideCandidates skips non-string runtime values', () => {
+  const candidates: WorkspaceOverrideUpdateCandidates = new Map()
+
+  addUpdatedWorkspaceOverrideCandidates(candidates, {
+    foo: 1 as unknown as string,
+  })
+
+  expect(pickUniqueUpdatedWorkspaceOverrides(candidates)).toBeUndefined()
+})
+
+test('pickUpdatedLockfileWorkspaceOverrides requires the updated manifest specifier to match the lockfile override', async () => {
+  const lockfileDir = temporaryDirectory()
+  await writeWantedLockfile(lockfileDir, {
+    importers: {
+      ['.' as ProjectId]: {
+        specifiers: {},
+      },
+    },
+    lockfileVersion: '9.0',
+    overrides: {
+      foo: '^1.2.0',
+    },
+  })
+
+  const updatedOverrides = await pickUpdatedLockfileWorkspaceOverrides({
+    lockfileDir,
+    overrides: {
+      foo: '^1.0.0',
+    },
+    projects: [{
+      before: { dependencies: { foo: '^1.0.0' } },
+      after: { dependencies: { foo: '^1.1.0' } },
+    }],
+  })
+
+  expect(updatedOverrides).toBeUndefined()
+})
+
+test('pickUpdatedLockfileWorkspaceOverrides returns matching updated workspace overrides', async () => {
+  const lockfileDir = temporaryDirectory()
+  await writeWantedLockfile(lockfileDir, {
+    importers: {
+      ['.' as ProjectId]: {
+        specifiers: {},
+      },
+    },
+    lockfileVersion: '9.0',
+    overrides: {
+      foo: '^1.1.0',
+    },
+  })
+
+  const updatedOverrides = await pickUpdatedLockfileWorkspaceOverrides({
+    lockfileDir,
+    overrides: {
+      foo: '^1.0.0',
+    },
+    projects: [{
+      before: { dependencies: { foo: '^1.0.0' } },
+      after: { dependencies: { foo: '^1.1.0' } },
+    }],
+  })
+
+  expect(Object.getPrototypeOf(updatedOverrides!)).toBeNull()
+  expect(updatedOverrides).toEqual({
+    foo: '^1.1.0',
+  })
+})
+
+function stringRecord (entries: Array<[string, string]>): Record<string, string> {
+  const record = Object.create(null) as Record<string, string>
+  for (const [key, value] of entries) {
+    Object.defineProperty(record, key, {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    })
+  }
+  return record
+}

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -8,7 +8,7 @@ import { mergeCatalogs } from '@pnpm/catalogs.config'
 import { parseCatalogProtocol } from '@pnpm/catalogs.protocol-parser'
 import { type CatalogResultMatcher, matchCatalogResolveResult, resolveFromCatalog } from '@pnpm/catalogs.resolver'
 import type { Catalogs } from '@pnpm/catalogs.types'
-import { parseOverrides } from '@pnpm/config.parse-overrides'
+import { parseOverrides, type VersionOverride } from '@pnpm/config.parse-overrides'
 import {
   LAYOUT_VERSION,
   LOCKFILE_MAJOR_VERSION,
@@ -168,6 +168,7 @@ export interface InstallResult {
    * merge this object with the current catalog configs in pnpm-workspace.yaml.
    */
   updatedCatalogs: Catalogs | undefined
+  updatedOverrides: Record<string, string> | undefined
   updatedManifest: ProjectManifest
   ignoredBuilds: IgnoredBuilds | undefined
   /** Forwarded from {@link MutateModulesResult.resolutionPolicyViolations}. */
@@ -188,7 +189,7 @@ export async function install (
     return installViaPnprServer(manifest, rootDir, opts)
   }
 
-  const { updatedCatalogs, updatedProjects: projects, ignoredBuilds, resolutionPolicyViolations, dryRunResult } = await mutateModules(
+  const { updatedCatalogs, updatedOverrides, updatedProjects: projects, ignoredBuilds, resolutionPolicyViolations, dryRunResult } = await mutateModules(
     [
       {
         mutation: 'install',
@@ -210,7 +211,7 @@ export async function install (
       }],
     }
   )
-  return { updatedCatalogs, updatedManifest: projects[0].manifest, ignoredBuilds, resolutionPolicyViolations, dryRunResult }
+  return { updatedCatalogs, updatedOverrides, updatedManifest: projects[0].manifest, ignoredBuilds, resolutionPolicyViolations, dryRunResult }
 }
 
 interface ProjectToBeInstalled {
@@ -232,6 +233,7 @@ export type MutateModulesOptions = InstallOptions & {
 
 export interface MutateModulesInSingleProjectResult {
   updatedCatalogs: Catalogs | undefined
+  updatedOverrides: Record<string, string> | undefined
   updatedProject: UpdatedProject
   ignoredBuilds: IgnoredBuilds | undefined
   /** Forwarded from {@link MutateModulesResult.resolutionPolicyViolations}. */
@@ -269,6 +271,7 @@ export async function mutateModulesInSingleProject (
   )
   return {
     updatedCatalogs: result.updatedCatalogs,
+    updatedOverrides: result.updatedOverrides,
     updatedProject: result.updatedProjects[0],
     ignoredBuilds: result.ignoredBuilds,
     resolutionPolicyViolations: result.resolutionPolicyViolations,
@@ -278,6 +281,7 @@ export async function mutateModulesInSingleProject (
 
 export interface MutateModulesResult {
   updatedCatalogs?: Catalogs
+  updatedOverrides?: Record<string, string>
   updatedProjects: UpdatedProject[]
   stats: InstallationResultStats
   depsRequiringBuild?: DepPath[]
@@ -563,6 +567,7 @@ export async function mutateModules (
 
   return {
     updatedCatalogs: result.updatedCatalogs,
+    updatedOverrides: result.updatedOverrides,
     updatedProjects: result.updatedProjects,
     stats: result.stats ?? { added: 0, removed: 0, linkedToRoot: 0 },
     depsRequiringBuild: result.depsRequiringBuild,
@@ -573,6 +578,7 @@ export async function mutateModules (
 
   interface InnerInstallResult {
     readonly updatedCatalogs?: Catalogs
+    readonly updatedOverrides?: Record<string, string>
     readonly updatedProjects: UpdatedProject[]
     readonly stats?: InstallationResultStats
     readonly depsRequiringBuild?: DepPath[]
@@ -1347,7 +1353,7 @@ export async function addDependenciesToPackage (
   } & InstallMutationOptions
 ): Promise<InstallResult> {
   const rootDir = (opts.dir ?? process.cwd()) as ProjectRootDir
-  const { updatedCatalogs, updatedProjects: projects, ignoredBuilds, resolutionPolicyViolations } = await mutateModules(
+  const { updatedCatalogs, updatedOverrides, updatedProjects: projects, ignoredBuilds, resolutionPolicyViolations } = await mutateModules(
     [
       {
         allowNew: opts.allowNew,
@@ -1375,7 +1381,7 @@ export async function addDependenciesToPackage (
         },
       ],
     })
-  return { updatedCatalogs, updatedManifest: projects[0].manifest, ignoredBuilds, resolutionPolicyViolations }
+  return { updatedCatalogs, updatedOverrides, updatedManifest: projects[0].manifest, ignoredBuilds, resolutionPolicyViolations }
 }
 
 export type ImporterToUpdate = {
@@ -1421,6 +1427,7 @@ function isCheckOnlyInstall (opts: { lockfileCheck?: unknown, dryRun?: boolean }
 
 interface InstallFunctionResult {
   updatedCatalogs?: Catalogs
+  updatedOverrides?: Record<string, string>
   newLockfile: LockfileObject
   projects: UpdatedProject[]
   stats?: InstallationResultStats
@@ -1463,6 +1470,15 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
   const originalLockfileForCheck = isInstallationOnlyForLockfileCheck
     ? clone(ctx.wantedLockfile)
     : null
+  const canPickUpdatedWorkspaceOverrides = opts.parsedOverrides != null &&
+    opts.parsedOverrides.length > 0 &&
+    opts.overrides != null &&
+    Object.keys(opts.overrides).length > 0
+  const originalManifestsById = canPickUpdatedWorkspaceOverrides
+    ? new Map<ProjectId, ProjectManifest>(
+      projects.map(({ id, manifest, originalManifest }) => [id, clone(originalManifest ?? manifest)])
+    )
+    : undefined
 
   ctx.wantedLockfile.importers = ctx.wantedLockfile.importers || {}
   for (const { id } of projects) {
@@ -1664,9 +1680,15 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
   // lockfile `overrides` keeps pointing at the old version while `catalogs`
   // advances, and a later `--frozen-lockfile` install fails with
   // ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
-  if (updatedCatalogs != null && opts.overrides != null && Object.keys(opts.overrides).length > 0) {
+  const updatedOverrides = originalManifestsById == null
+    ? undefined
+    : pickUpdatedWorkspaceOverrides(opts.parsedOverrides, opts.overrides, projects, originalManifestsById, newLockfile)
+  if ((updatedCatalogs != null || updatedOverrides != null) && opts.overrides != null && Object.keys(opts.overrides).length > 0) {
+    const overrides = updatedOverrides == null
+      ? opts.overrides
+      : mergeStringRecords(opts.overrides, updatedOverrides)
     newLockfile.overrides = createOverridesMapFromParsed(
-      parseOverrides(opts.overrides, mergeCatalogs(opts.catalogs, updatedCatalogs))
+      parseOverrides(overrides, updatedCatalogs == null ? opts.catalogs : mergeCatalogs(opts.catalogs, updatedCatalogs))
     )
   }
 
@@ -2031,6 +2053,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
 
   return {
     updatedCatalogs,
+    updatedOverrides,
     newLockfile,
     projects: projects.map(({ id, manifest, rootDir }) => ({
       manifest,
@@ -2049,6 +2072,88 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
 
 function allMutationsAreInstalls (projects: MutatedProject[]): boolean {
   return projects.every((project) => project.mutation === 'install' && !project.update && !project.updateMatching)
+}
+
+function pickUpdatedWorkspaceOverrides (
+  parsedOverrides: VersionOverride[] | undefined,
+  rawOverrides: Record<string, string> | undefined,
+  projects: ImporterToUpdate[],
+  originalManifestsById: Map<ProjectId, ProjectManifest>,
+  lockfile: LockfileObject
+): Record<string, string> | undefined {
+  if (parsedOverrides == null || parsedOverrides.length === 0 || rawOverrides == null || Object.keys(rawOverrides).length === 0) return undefined
+
+  const candidates = new Map<string, Set<string>>()
+  for (const { id } of projects) {
+    const previousManifest = originalManifestsById.get(id)
+    if (previousManifest == null) continue
+
+    const previousDependencies = getDirectDependenciesForOverrides(previousManifest)
+    const nextSpecifiers = lockfile.importers[id]?.specifiers
+    for (let index = 0; index < parsedOverrides.length; index++) {
+      const versionOverride: VersionOverride = parsedOverrides[index]!
+      if (versionOverride.parentPkg != null) continue
+      const alias = versionOverride.targetPkg.name
+      const nextSpecifier = getOwnString(nextSpecifiers, alias)
+      const previousSpecifier = getOwnString(previousDependencies, alias)
+      if (nextSpecifier == null || previousSpecifier == null || previousSpecifier === nextSpecifier) continue
+      if (versionOverride.selector !== alias || getOwnString(rawOverrides, alias) !== previousSpecifier) continue
+
+      let values = candidates.get(alias)
+      if (values == null) {
+        values = new Set()
+        candidates.set(alias, values)
+      }
+      values.add(nextSpecifier)
+    }
+  }
+
+  const updatedOverrides = createSafeStringRecord()
+  for (const [alias, values] of candidates) {
+    if (values.size !== 1) continue
+    setOwnString(updatedOverrides, alias, Array.from(values)[0]!)
+  }
+
+  return Object.keys(updatedOverrides).length > 0 ? updatedOverrides : undefined
+}
+
+function getDirectDependenciesForOverrides (manifest: ProjectManifest): Record<string, string> {
+  return mergeStringRecords(
+    manifest.devDependencies,
+    manifest.dependencies,
+    manifest.optionalDependencies
+  )
+}
+
+function mergeStringRecords (...records: Array<Record<string, string> | undefined>): Record<string, string> {
+  const result = createSafeStringRecord()
+  for (const record of records) {
+    if (record == null) continue
+    for (const key of Object.keys(record)) {
+      const value = getOwnString(record, key)
+      if (value == null) continue
+      setOwnString(result, key, value)
+    }
+  }
+  return result
+}
+
+function createSafeStringRecord (): Record<string, string> {
+  return Object.create(null) as Record<string, string>
+}
+
+function getOwnString (record: Record<string, string> | undefined, key: string): string | undefined {
+  const value = record != null && Object.prototype.propertyIsEnumerable.call(record, key) ? record[key] : undefined
+  return typeof value === 'string' ? value : undefined
+}
+
+function setOwnString (record: Record<string, string>, key: string, value: string): void {
+  Object.defineProperty(record, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  })
 }
 
 /**
@@ -2688,6 +2793,7 @@ async function installViaPnprServer (
     if (opts.lockfileOnly) {
       return {
         updatedCatalogs: undefined,
+        updatedOverrides: undefined,
         updatedManifest: manifest,
         ignoredBuilds: undefined,
         stats: { added: 0, removed: 0, linkedToRoot: 0 },
@@ -2742,6 +2848,7 @@ async function installViaPnprServer (
 
     return {
       updatedCatalogs: undefined,
+      updatedOverrides: undefined,
       updatedManifest: manifest,
       ignoredBuilds,
       // Pacquet doesn't surface a structured stats return; default to

--- a/pnpm11/pnpm/test/update.ts
+++ b/pnpm11/pnpm/test/update.ts
@@ -69,6 +69,76 @@ test('update', async () => {
   expect(pkg.dependencies?.['@pnpm.e2e/foo']).toBe('^100.1.0')
 })
 
+test('update --latest syncs matching workspace overrides', async () => {
+  await addDistTag('@pnpm.e2e/foo', '100.0.0', 'latest')
+
+  const project = prepare({
+    dependencies: {
+      '@pnpm.e2e/foo': '^100.0.0',
+    },
+  })
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    overrides: {
+      '@pnpm.e2e/foo': '^100.0.0',
+      '@pnpm.e2e/bar': '^100.0.0',
+      '@pnpm.e2e/foo>@pnpm.e2e/bar': '^100.0.0',
+    },
+  })
+
+  await execPnpm(['install', '--lockfile-only'])
+
+  await addDistTag('@pnpm.e2e/foo', '100.1.0', 'latest')
+
+  await execPnpm(['update', '--latest'])
+
+  const pkg = await readPackageJsonFromDir(process.cwd())
+  expect(pkg.dependencies?.['@pnpm.e2e/foo']).toBe('^100.1.0')
+
+  const workspaceManifest = readYamlFileSync<any>('pnpm-workspace.yaml') // eslint-disable-line
+  expect(workspaceManifest.overrides?.['@pnpm.e2e/foo']).toBe('^100.1.0')
+  expect(workspaceManifest.overrides?.['@pnpm.e2e/bar']).toBe('^100.0.0')
+  expect(workspaceManifest.overrides?.['@pnpm.e2e/foo>@pnpm.e2e/bar']).toBe('^100.0.0')
+
+  const lockfile = project.readLockfile()
+  expect(lockfile.overrides?.['@pnpm.e2e/foo']).toBe('^100.1.0')
+
+  await execPnpm(['install', '--frozen-lockfile'])
+})
+
+test('update --latest does not rewrite catalog workspace overrides', async () => {
+  await addDistTag('@pnpm.e2e/foo', '100.0.0', 'latest')
+
+  const project = prepare({
+    dependencies: {
+      '@pnpm.e2e/foo': '^100.0.0',
+    },
+  })
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    catalog: {
+      '@pnpm.e2e/foo': '^100.0.0',
+    },
+    overrides: {
+      '@pnpm.e2e/foo': 'catalog:',
+    },
+  })
+
+  await addDistTag('@pnpm.e2e/foo', '100.1.0', 'latest')
+
+  await execPnpm(['update', '--latest'])
+
+  const pkg = await readPackageJsonFromDir(process.cwd())
+  expect(pkg.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
+
+  const workspaceManifest = readYamlFileSync<any>('pnpm-workspace.yaml') // eslint-disable-line
+  expect(workspaceManifest.catalog?.['@pnpm.e2e/foo']).toBe('^100.1.0')
+  expect(workspaceManifest.overrides?.['@pnpm.e2e/foo']).toBe('catalog:')
+
+  const lockfile = project.readLockfile()
+  expect(lockfile.overrides?.['@pnpm.e2e/foo']).toBe('^100.1.0')
+})
+
 test('recursive update --no-save', async () => {
   await addDistTag('@pnpm.e2e/foo', '100.1.0', 'latest')
   preparePackages([


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#12625.

When `pnpm update --latest` changes a direct dependency specifier, matching top-level workspace overrides now move with it instead of leaving `pnpm-workspace.yaml` behind. The update is restricted to exact direct dependency override keys whose value matched the previous manifest specifier, so unrelated and transitive override selectors are preserved.

The TypeScript CLI path is updated. The Rust `pacquet/` port is not affected by this PR because this change wires the existing TypeScript command-layer workspace manifest writer around TypeScript installer results.

## Squash Commit Body

```text
Sync matching workspace overrides when direct dependency specifiers are updated.

`pnpm update --latest` could update package.json and the lockfile override value while leaving the corresponding top-level pnpm-workspace.yaml override at the old specifier. A later frozen install then failed because the workspace manifest and lockfile no longer agreed.

This change carries direct override updates through the installer result and command layer, snapshots manifests before mutation so old and new specifiers can be compared reliably, and updates only exact direct dependency override keys that matched the previous specifier. Parent override selectors and unrelated overrides are left unchanged.

Fixes pnpm/pnpm#12625.
```

## Checklist

- [x] The TypeScript CLI path is updated; the Rust `pacquet/` port is not affected by this workspace-manifest writer change.
- [x] Added a changeset.
- [x] Added or updated tests.

Validation:

- `pnpm exec tsgo --build pnpm11/installing/deps-installer pnpm11/installing/commands pnpm11/pnpm`
- `pnpm exec eslint pnpm11/installing/deps-installer/src/install/index.ts pnpm11/installing/commands/src/installDeps.ts pnpm11/installing/commands/src/recursive.ts pnpm11/installing/commands/src/updateWorkspaceOverrides.ts pnpm11/pnpm/test/update.ts`
- `git diff --check`
- `NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" pnpm --dir pnpm11/pnpm exec jest test/update.ts -t "update --latest syncs matching workspace overrides" --runInBand`
- `NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" pnpm --dir pnpm11/pnpm exec jest test/update.ts -t "update --latest" --runInBand`
- pre-push hook: `pnpm run compile-only && pnpm run lint --quiet`; Rust pre-push checks also completed, with the hook skipping `cargo-dylint` and `taplo` because those optional tools were not installed on PATH.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace `overrides` are now automatically kept in sync during installs and updates, including recursive installs and shared-lockfile workflows.
  * When dependency specifiers change, pnpm derives and persists the corresponding workspace and lockfile `overrides` updates.

* **Bug Fixes**
  * `pnpm update --latest` updates only the matching workspace `overrides` entries and preserves `catalog:`-based override references (including nested selectors).

* **Tests**
  * Added/expanded Jest coverage for workspace `overrides` syncing, `update --latest` behavior, and edge cases for selecting and merging override updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->