### PR TITLE
feat(pacquet/cli): promote `--filter`/`--filter-prod` to recursive mode

### DIFF
--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -105,6 +105,25 @@ pub struct CliArgs {
     pub filter_prod: Vec<String>,
 }
 
+impl CliArgs {
+    /// Promote the command to recursive mode when a `--filter` /
+    /// `--filter-prod` selector is present, even without an explicit
+    /// `-r` / `--recursive`.
+    ///
+    /// Mirrors pnpm's `parse-cli-args`, which sets `options.recursive =
+    /// true` for any command whenever a filter is given
+    /// (<https://github.com/pnpm/pnpm/blob/8eb1be4988/cli/parse-cli-args/src/index.ts#L211-L219>),
+    /// so the promotion applies CLI-wide rather than being special-cased
+    /// per command. Call once on the parsed args before dispatch; both
+    /// the install fast-path bail and [`Self::run`] then observe the
+    /// promoted flag.
+    pub fn promote_recursive_for_filter(&mut self) {
+        if !self.filter.is_empty() || !self.filter_prod.is_empty() {
+            self.recursive = true;
+        }
+    }
+}
+
 #[derive(Debug, Subcommand)]
 pub enum CliCommand {
     /// Initialize a package.json

--- a/pacquet/crates/cli/src/cli_args/exec/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/exec/recursive.rs
@@ -15,7 +15,7 @@
 
 use super::{ExecArgs, prepare_command, spawn_in_dir};
 use crate::cli_args::recursive::{
-    ExecutionStatus, Status, count_failures, discover_workspace_projects,
+    AutoExcludeRoot, ExecutionStatus, Status, count_failures, discover_workspace_projects,
     get_resumed_package_chunks, select_recursive_projects, sort_projects, write_recursive_summary,
 };
 use derive_more::{Display, Error};
@@ -61,14 +61,19 @@ pub fn exec_recursive(args: &ExecArgs, config: &Config, dir: &Path) -> miette::R
     let command = prepare_command(args.command.clone())?;
     let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
 
-    let projects = discover_workspace_projects(workspace_root)?;
+    let (projects, patterns) = discover_workspace_projects(workspace_root)?;
     // Empty workspace errors; an empty `--filter` selection (below) is a
     // no-op — so this guard is on the discovered set, not the filtered.
     if projects.is_empty() {
         return Err(RecursiveExecError::NoPackage.into());
     }
 
-    let graph = select_recursive_projects(&projects, config, dir)?;
+    let graph = select_recursive_projects(
+        &projects,
+        config,
+        dir,
+        AutoExcludeRoot::Enabled { workspace_patterns: patterns.as_deref() },
+    )?;
     // An empty `--filter` selection is a no-op, matching pnpm's exit-0 for
     // an empty selectedProjectsGraph.
     if graph.is_empty() {

--- a/pacquet/crates/cli/src/cli_args/pack.rs
+++ b/pacquet/crates/cli/src/cli_args/pack.rs
@@ -14,7 +14,7 @@
 //! defaults.
 
 use crate::cli_args::recursive::{
-    discover_workspace_projects, select_recursive_projects, sort_projects,
+    AutoExcludeRoot, discover_workspace_projects, select_recursive_projects, sort_projects,
 };
 use clap::Args;
 use miette::Context;
@@ -108,8 +108,11 @@ impl PackArgs {
             return Err(miette::Report::new(PackError::OutAndPackDestination));
         }
         let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
-        let projects = discover_workspace_projects(workspace_root)?;
-        let graph = select_recursive_projects(&projects, config, dir)?;
+        // `pack` is not in pnpm's root-auto-exclusion command set, so the
+        // workspace root stays in the selection (its own name/version
+        // eligibility check still applies below).
+        let (projects, _patterns) = discover_workspace_projects(workspace_root)?;
+        let graph = select_recursive_projects(&projects, config, dir, AutoExcludeRoot::Disabled)?;
         let chunks = sort_projects(&graph);
 
         // In recursive mode upstream resolves `--out` / `--pack-destination`

--- a/pacquet/crates/cli/src/cli_args/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/recursive.rs
@@ -127,28 +127,42 @@ pub fn count_failures(summary: &IndexMap<PathBuf, ExecutionStatus>) -> usize {
 }
 
 /// Read the workspace manifest at `workspace_root` and enumerate its
-/// projects. Shared by recursive `run` and `exec` so both discover the
-/// same set before [`select_recursive_projects`] narrows it.
-pub fn discover_workspace_projects(workspace_root: &Path) -> miette::Result<Vec<Project>> {
+/// projects, returning them alongside the workspace package patterns
+/// (`config.workspacePackagePatterns`). Shared by recursive `run` /
+/// `exec` / `pack` so all discover the same set before
+/// [`select_recursive_projects`] narrows it. The patterns feed the
+/// root-only guard of [`AutoExcludeRoot`]; `None` means no
+/// `pnpm-workspace.yaml` was found.
+pub fn discover_workspace_projects(
+    workspace_root: &Path,
+) -> miette::Result<(Vec<Project>, Option<Vec<String>>)> {
     let patterns = read_workspace_manifest(workspace_root)
         .into_diagnostic()
         .wrap_err("reading pnpm-workspace.yaml")?
         .map(|manifest| workspace_package_patterns(&manifest));
-    find_workspace_projects(workspace_root, &FindWorkspaceProjectsOpts { patterns })
-        .wrap_err("finding workspace projects")
+    let projects = find_workspace_projects(
+        workspace_root,
+        &FindWorkspaceProjectsOpts { patterns: patterns.clone() },
+    )
+    .wrap_err("finding workspace projects")?;
+    Ok((projects, patterns))
 }
 
 /// Build the `--filter`-selected workspace graph the recursive command
 /// runs over: the project graph restricted to the `config.filter` /
 /// `config.filter_prod` selection (every project when no selector is
-/// given). `prefix` is where path selectors resolve.
+/// given). `prefix` is where path selectors resolve. `auto_exclude_root`
+/// controls the main-dispatch auto-exclusion of the workspace root for
+/// `run` / `exec`.
 ///
 /// Ports pnpm's `selectedProjectsGraph` main-dispatch step
-/// (<https://github.com/pnpm/pnpm/blob/8eb1be4988/pnpm/src/main.ts#L260-L323>).
+/// (<https://github.com/pnpm/pnpm/blob/8eb1be4988/pnpm/src/main.ts#L238-L323>),
+/// including the `!{<workspace-root>}` augmentation.
 pub fn select_recursive_projects<'a>(
     projects: &'a [Project],
     config: &Config,
     prefix: &Path,
+    auto_exclude_root: AutoExcludeRoot<'_>,
 ) -> miette::Result<ProjectGraph<GraphPkg<'a>>> {
     // Filter against the same graph options the sort uses, so the selected
     // set and the topological order agree on edges.
@@ -159,11 +173,7 @@ pub fn select_recursive_projects<'a>(
     )
     .graph;
 
-    if config.filter.is_empty() && config.filter_prod.is_empty() {
-        return Ok(graph);
-    }
-
-    let filters: Vec<WorkspaceFilter> =
+    let mut filters: Vec<WorkspaceFilter> =
         config
             .filter
             .iter()
@@ -173,13 +183,30 @@ pub fn select_recursive_projects<'a>(
                 follow_prod_deps_only: true,
             }))
             .collect();
+    if let Some(root_exclusion) = auto_exclude_root.root_exclusion(config, prefix, &filters) {
+        filters.push(root_exclusion);
+    }
+
+    // No selector (and no auto-exclusion) selects every project.
+    if filters.is_empty() {
+        return Ok(graph);
+    }
+
     let selected = filter_projects(
         projects.iter().map(|project| GraphPkg { project }).collect(),
         &filters,
         &FilterProjectsOptions {
             prefix: prefix.to_path_buf(),
             link_workspace_packages: graph_options.link_workspace_packages,
-            use_glob_dir_filtering: false,
+            // pnpm's main dispatch filters with `useGlobDirFiltering:
+            // !config.legacyDirFiltering`, whose default is glob
+            // matching. It is load-bearing for the `!{<workspace-root>}`
+            // augmentation: glob matching excludes only the project whose
+            // dir equals the workspace root, whereas the legacy
+            // subtree match would also drop every nested package.
+            // `legacyDirFiltering` is not surfaced by `Config` yet, so
+            // this stays at pnpm's default.
+            use_glob_dir_filtering: true,
         },
     )
     .map_err(miette::Report::new)
@@ -190,6 +217,71 @@ pub fn select_recursive_projects<'a>(
         .iter()
         .filter_map(|root| graph.swap_remove(root).map(|node| (root.clone(), node)))
         .collect())
+}
+
+/// Whether a recursive command drops the workspace root from an
+/// all-exclusion (or unfiltered) `--filter` selection.
+///
+/// Mirrors the `cmd === 'run' || cmd === 'exec' || cmd === 'add' ||
+/// cmd === 'test'` arm of pnpm's main dispatch
+/// (<https://github.com/pnpm/pnpm/blob/8eb1be4988/pnpm/src/main.ts#L251-L259>),
+/// which appends a `!{<workspace-root>}` selector so a recursive
+/// `run` / `exec` skips the root project unless it is explicitly
+/// included.
+#[derive(Clone, Copy)]
+pub enum AutoExcludeRoot<'a> {
+    /// `run` / `exec` (upstream also `add` / `test`): exclude the root
+    /// when no inclusion selector is present and the workspace is not
+    /// root-only. `workspace_patterns` is
+    /// `config.workspacePackagePatterns`, used for the root-only guard.
+    Enabled { workspace_patterns: Option<&'a [String]> },
+    /// `pack` (upstream's other recursive commands): never auto-exclude.
+    Disabled,
+}
+
+impl AutoExcludeRoot<'_> {
+    /// The `!{<workspace-root>}` selector to append to `existing` (the
+    /// filters built from `--filter` / `--filter-prod`), or `None` when
+    /// the augmentation does not apply.
+    fn root_exclusion(
+        &self,
+        config: &Config,
+        prefix: &Path,
+        existing: &[WorkspaceFilter],
+    ) -> Option<WorkspaceFilter> {
+        let AutoExcludeRoot::Enabled { workspace_patterns } = self else {
+            return None;
+        };
+        // An inclusion selector already pins the selected set, so the
+        // root is kept only if it matches one. Mirrors upstream's
+        // `!filters.some(({ filter }) => !filter.startsWith('!'))`.
+        if existing.iter().any(|filter| !filter.filter.starts_with('!')) {
+            return None;
+        }
+        // A root-only workspace (patterns === ['.']) has no non-root
+        // project to keep, so excluding the root would empty the
+        // selection. Absent patterns mean no `pnpm-workspace.yaml`.
+        let patterns = (*workspace_patterns)?;
+        if is_root_only_patterns(patterns) {
+            return None;
+        }
+        let workspace_root = config.workspace_dir.as_deref().unwrap_or(prefix);
+        let relative = pathdiff::diff_paths(workspace_root, prefix)
+            .map(|path| path.to_string_lossy().into_owned())
+            .filter(|path| !path.is_empty())
+            .unwrap_or_else(|| ".".to_string());
+        Some(WorkspaceFilter {
+            filter: format!("!{{{relative}}}"),
+            follow_prod_deps_only: !config.filter_prod.is_empty(),
+        })
+    }
+}
+
+/// Port of pnpm's
+/// [`isRootOnlyPatterns`](https://github.com/pnpm/pnpm/blob/8eb1be4988/pnpm/src/main.ts#L40-L42):
+/// the workspace enumerates the root project only.
+fn is_root_only_patterns(patterns: &[String]) -> bool {
+    patterns.len() == 1 && patterns[0] == "."
 }
 
 /// Adapter that lets a [`Project`] feed `create_projects_graph`. Owns

--- a/pacquet/crates/cli/src/cli_args/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/recursive.rs
@@ -252,6 +252,10 @@ impl AutoExcludeRoot<'_> {
         let AutoExcludeRoot::Enabled { workspace_patterns } = self else {
             return None;
         };
+        // Upstream additionally suppresses the exclusion under
+        // `--include-workspace-root` and, for `--workspace-root`, pushes
+        // an inclusion `{<root>}` filter instead. pacquet surfaces
+        // neither flag yet, so only this exclusion arm is ported.
         // An inclusion selector already pins the selected set, so the
         // root is kept only if it matches one. Mirrors upstream's
         // `!filters.some(({ filter }) => !filter.startsWith('!'))`.

--- a/pacquet/crates/cli/src/cli_args/run/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/run/recursive.rs
@@ -13,13 +13,14 @@
 //! (`--filter` / `--filter-prod`, include and exclude selectors) narrow
 //! the selected set via [`select_recursive_projects`]; the selection is
 //! then sorted topologically (upstream's default) and run sequentially.
-//! `--no-sort`, `--reverse`, `--workspace-concurrency` parallelism, the
-//! `RegExp` script selector, and the main-dispatch auto-exclusion of the
-//! workspace root for `run` / `exec` / `add` / `test` are not ported yet.
+//! `--no-sort`, `--reverse`, `--workspace-concurrency` parallelism, and
+//! the `RegExp` script selector are not ported yet. The main-dispatch
+//! auto-exclusion of the workspace root is applied via
+//! [`AutoExcludeRoot::Enabled`].
 
 use super::{RunArgs, RunContext, run_stages};
 use crate::cli_args::recursive::{
-    ExecutionStatus, Status, count_failures, discover_workspace_projects,
+    AutoExcludeRoot, ExecutionStatus, Status, count_failures, discover_workspace_projects,
     get_resumed_package_chunks, select_recursive_projects, sort_projects, write_recursive_summary,
 };
 use derive_more::{Display, Error};
@@ -89,8 +90,13 @@ pub fn run_recursive(args: &RunArgs, config: &Config, dir: &Path) -> miette::Res
     };
     let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
 
-    let projects = discover_workspace_projects(workspace_root)?;
-    let graph = select_recursive_projects(&projects, config, dir)?;
+    let (projects, patterns) = discover_workspace_projects(workspace_root)?;
+    let graph = select_recursive_projects(
+        &projects,
+        config,
+        dir,
+        AutoExcludeRoot::Enabled { workspace_patterns: patterns.as_deref() },
+    )?;
     // An empty `--filter` selection is a no-op, matching pnpm's exit-0 for
     // an empty selectedProjectsGraph; an empty workspace instead falls
     // through to the no-script error below.

--- a/pacquet/crates/cli/src/cli_args/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/tests.rs
@@ -67,6 +67,35 @@ fn filter_flag_split_across_subcommand_keeps_only_subcommand_side() {
 }
 
 #[test]
+fn filter_promotes_recursive_without_explicit_flag() {
+    let mut parsed =
+        CliArgs::try_parse_from(["pacquet", "--filter", "@scope/*", "install"]).expect("parses");
+    assert!(!parsed.recursive, "the raw -r flag is absent");
+    parsed.promote_recursive_for_filter();
+    assert!(parsed.recursive, "a --filter selector promotes to recursive");
+}
+
+#[test]
+fn filter_prod_promotes_recursive_without_explicit_flag() {
+    let mut parsed =
+        CliArgs::try_parse_from(["pacquet", "--filter-prod", "app...", "install"]).expect("parses");
+    parsed.promote_recursive_for_filter();
+    assert!(parsed.recursive, "a --filter-prod selector promotes to recursive");
+}
+
+#[test]
+fn no_filter_leaves_recursive_untouched() {
+    let mut parsed = CliArgs::try_parse_from(["pacquet", "install"]).expect("parses");
+    parsed.promote_recursive_for_filter();
+    assert!(!parsed.recursive, "without a filter the command stays non-recursive");
+
+    let mut explicit =
+        CliArgs::try_parse_from(["pacquet", "-r", "install"]).expect("parses -r install");
+    explicit.promote_recursive_for_filter();
+    assert!(explicit.recursive, "an explicit -r is preserved");
+}
+
+#[test]
 fn runtime_alias_and_flags_parse() {
     let parsed = CliArgs::try_parse_from(["pacquet", "rt", "set", "node", "22", "-P"])
         .expect("parses runtime alias");

--- a/pacquet/crates/cli/src/lib.rs
+++ b/pacquet/crates/cli/src/lib.rs
@@ -30,7 +30,12 @@ pub fn main() -> miette::Result<()> {
     // The default reporter's `Done in ... using pacquet v<version>` footer needs
     // the version before the first event (including the fast path's).
     pacquet_default_reporter::set_package_version(pacquet_config::PACQUET_VERSION);
-    let args = CliArgs::parse_from(argv);
+    let mut args = CliArgs::parse_from(argv);
+    // A bare `--filter` / `--filter-prod` puts the command into recursive
+    // mode even without `-r`, matching pnpm's `parse-cli-args`. Applied
+    // once here so every downstream consumer (the install fast-path bail
+    // and `run`'s dispatch) sees the promoted flag.
+    args.promote_recursive_for_filter();
     // An up-to-date `pacquet install` finishes here, without paying for
     // the runtime, the HTTP client, or any worker threads.
     if args.finished_via_install_fast_path(&config_overrides) {

--- a/pacquet/crates/cli/src/lib.rs
+++ b/pacquet/crates/cli/src/lib.rs
@@ -31,10 +31,6 @@ pub fn main() -> miette::Result<()> {
     // the version before the first event (including the fast path's).
     pacquet_default_reporter::set_package_version(pacquet_config::PACQUET_VERSION);
     let mut args = CliArgs::parse_from(argv);
-    // A bare `--filter` / `--filter-prod` puts the command into recursive
-    // mode even without `-r`, matching pnpm's `parse-cli-args`. Applied
-    // once here so every downstream consumer (the install fast-path bail
-    // and `run`'s dispatch) sees the promoted flag.
     args.promote_recursive_for_filter();
     // An up-to-date `pacquet install` finishes here, without paying for
     // the runtime, the HTTP client, or any worker threads.

--- a/pacquet/crates/cli/tests/exec_recursive.rs
+++ b/pacquet/crates/cli/tests/exec_recursive.rs
@@ -104,6 +104,35 @@ fn recursive_exec_filter_selects_only_matching_project() {
     drop(root);
 }
 
+/// A bare `--filter` (no `-r`) enters recursive mode CLI-wide, matching
+/// pnpm's `parse-cli-args` promotion: the command runs only in the
+/// selected project even though `-r` was never passed.
+#[test]
+fn filter_without_recursive_flag_enters_recursive_exec() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(&workspace, &["project-1", "project-2"]);
+
+    pacquet
+        .with_arg("--filter")
+        .with_arg("project-1")
+        .with_arg("exec")
+        .with_arg("touch")
+        .with_arg("ran.txt")
+        .assert()
+        .success();
+
+    assert!(
+        workspace.join("project-1").join("ran.txt").exists(),
+        "the selected project-1 should run the command",
+    );
+    assert!(
+        !workspace.join("project-2").join("ran.txt").exists(),
+        "a bare --filter (no -r) should still scope the exec to the selection",
+    );
+
+    drop(root);
+}
+
 /// A `--filter` that matches no project is a no-op: recursive exec exits
 /// 0 and writes no summary even with `--report-summary`, matching pnpm's
 /// main-dispatch exit-0 for an empty selection — rather than erroring on

--- a/pacquet/crates/cli/tests/exec_recursive.rs
+++ b/pacquet/crates/cli/tests/exec_recursive.rs
@@ -133,6 +133,33 @@ fn filter_without_recursive_flag_enters_recursive_exec() {
     drop(root);
 }
 
+/// A `[<since>]` changed-packages selector is not supported by pacquet's
+/// filter engine yet, so a recursive `exec` surfaces the
+/// `UnsupportedDiffSelector` error instead of swallowing it. This
+/// exercises the error-propagation (`?`) out of `select_recursive_projects`.
+#[test]
+fn recursive_exec_diff_selector_is_unsupported() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(&workspace, &["project-1"]);
+
+    let output = pacquet
+        .with_arg("-r")
+        .with_arg("--filter")
+        .with_arg("[main]")
+        .with_arg("exec")
+        .with_arg("true")
+        .output()
+        .expect("spawn pacquet");
+    assert!(!output.status.success(), "a [<since>] diff selector is unsupported and must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Changed-package filter selectors"),
+        "stderr should explain the diff selector is unsupported, got: {stderr}",
+    );
+
+    drop(root);
+}
+
 /// A `--filter` that matches no project is a no-op: recursive exec exits
 /// 0 and writes no summary even with `--report-summary`, matching pnpm's
 /// main-dispatch exit-0 for an empty selection — rather than erroring on

--- a/pacquet/crates/cli/tests/exec_recursive.rs
+++ b/pacquet/crates/cli/tests/exec_recursive.rs
@@ -147,7 +147,8 @@ fn recursive_exec_diff_selector_is_unsupported() {
         .with_arg("--filter")
         .with_arg("[main]")
         .with_arg("exec")
-        .with_arg("true")
+        .with_arg("touch")
+        .with_arg("ran.txt")
         .output()
         .expect("spawn pacquet");
     assert!(!output.status.success(), "a [<since>] diff selector is unsupported and must fail");
@@ -155,6 +156,10 @@ fn recursive_exec_diff_selector_is_unsupported() {
     assert!(
         stderr.contains("Changed-package filter selectors"),
         "stderr should explain the diff selector is unsupported, got: {stderr}",
+    );
+    assert!(
+        !workspace.join("project-1").join("ran.txt").exists(),
+        "exec must reject the selector before dispatching the command, so no marker is written",
     );
 
     drop(root);

--- a/pacquet/crates/cli/tests/pack_recursive.rs
+++ b/pacquet/crates/cli/tests/pack_recursive.rs
@@ -58,3 +58,34 @@ fn recursive_pack_filter_packs_only_selected_project() {
 
     drop(root);
 }
+
+/// A bare `--filter` (no `-r`) enters recursive mode CLI-wide, matching
+/// pnpm's `parse-cli-args` promotion: only the selected project is
+/// packed even though `-r` was never passed. This is the shape pnpm's
+/// `release.yml` drives publishing with (`pn publish --filter=<pkg>`).
+#[test]
+fn filter_without_recursive_flag_enters_recursive_pack() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(&workspace, &["project-1", "project-2", "project-3"]);
+    let out = workspace.join("tarballs");
+    fs::create_dir_all(&out).expect("create out dir");
+
+    pacquet
+        .with_arg("--filter")
+        .with_arg("project-1")
+        .with_arg("pack")
+        .with_arg("--pack-destination")
+        .with_arg(out.to_str().expect("utf8 out dir"))
+        .assert()
+        .success();
+
+    assert!(out.join("project-1-1.0.0.tgz").exists(), "the selected project-1 should be packed");
+    for name in ["project-2", "project-3"] {
+        assert!(
+            !out.join(format!("{name}-1.0.0.tgz")).exists(),
+            "a bare --filter (no -r) should still scope the pack to the selection",
+        );
+    }
+
+    drop(root);
+}

--- a/pacquet/crates/cli/tests/pack_recursive.rs
+++ b/pacquet/crates/cli/tests/pack_recursive.rs
@@ -89,3 +89,49 @@ fn filter_without_recursive_flag_enters_recursive_pack() {
 
     drop(root);
 }
+
+/// `pack` is not in pnpm's root-auto-exclusion command set, so a recursive
+/// pack over a workspace that has a root project keeps the root: `-r pack`
+/// packs the root package alongside the sub-packages. This is the
+/// `AutoExcludeRoot::Disabled` contract that distinguishes `pack` from
+/// `run` / `exec`.
+#[test]
+fn recursive_pack_includes_workspace_root() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "name": "root-pkg", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write root package.json");
+    for name in ["project-1", "project-2"] {
+        let dir = workspace.join("packages").join(name);
+        fs::create_dir_all(&dir).expect("create package dir");
+        fs::write(
+            dir.join("package.json"),
+            json!({ "name": name, "version": "1.0.0" }).to_string(),
+        )
+        .expect("write package.json");
+    }
+    let out = workspace.join("tarballs");
+    fs::create_dir_all(&out).expect("create out dir");
+
+    pacquet
+        .with_arg("-r")
+        .with_arg("pack")
+        .with_arg("--pack-destination")
+        .with_arg(out.to_str().expect("utf8 out dir"))
+        .assert()
+        .success();
+
+    assert!(
+        out.join("root-pkg-1.0.0.tgz").exists(),
+        "pack is not in the auto-exclusion set, so the workspace root must be packed",
+    );
+    for name in ["project-1", "project-2"] {
+        assert!(out.join(format!("{name}-1.0.0.tgz")).exists(), "{name} should be packed");
+    }
+
+    drop(root);
+}

--- a/pacquet/crates/cli/tests/run_recursive.rs
+++ b/pacquet/crates/cli/tests/run_recursive.rs
@@ -473,6 +473,10 @@ fn recursive_run_diff_selector_is_unsupported() {
         stderr.contains("Changed-package filter selectors"),
         "stderr should explain the diff selector is unsupported, got: {stderr}",
     );
+    assert!(
+        !workspace.join("project-1").join("ran.txt").exists(),
+        "run must reject the selector before invoking the build script, so no marker is written",
+    );
 
     drop(root);
 }

--- a/pacquet/crates/cli/tests/run_recursive.rs
+++ b/pacquet/crates/cli/tests/run_recursive.rs
@@ -202,6 +202,118 @@ fn recursive_run_exclude_filter_skips_excluded_project() {
     drop(root);
 }
 
+/// Write a `packages/*` workspace with a root `package.json` (whose
+/// `build` script writes `root-ran.txt`) plus `project-1` / `project-2`
+/// sub-packages, so a recursive run has both a root project and non-root
+/// projects to choose between.
+fn write_workspace_with_root_and_packages(workspace: &Path) {
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write workspace manifest");
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "root",
+            "version": "1.0.0",
+            "scripts": { "build": "touch root-ran.txt" },
+        })
+        .to_string(),
+    )
+    .expect("write root package.json");
+    for name in ["project-1", "project-2"] {
+        let dir = workspace.join("packages").join(name);
+        fs::create_dir_all(&dir).expect("create package dir");
+        fs::write(dir.join("package.json"), build_writes_marker(name).to_string())
+            .expect("write package.json");
+    }
+}
+
+/// A bare `--filter` (no `-r`) enters recursive mode CLI-wide, matching
+/// pnpm's `parse-cli-args` promotion: the script runs only in the
+/// selected project even though `-r` was never passed.
+#[test]
+fn filter_without_recursive_flag_enters_recursive_run() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", build_writes_marker("project-1")),
+            ("project-2", build_writes_marker("project-2")),
+        ],
+    );
+
+    pacquet
+        .with_arg("--filter")
+        .with_arg("project-1")
+        .with_arg("run")
+        .with_arg("build")
+        .assert()
+        .success();
+
+    assert!(
+        workspace.join("project-1").join("ran.txt").exists(),
+        "the selected project-1 should run",
+    );
+    assert!(
+        !workspace.join("project-2").join("ran.txt").exists(),
+        "a bare --filter (no -r) should still scope the run to the selection",
+    );
+
+    drop(root);
+}
+
+/// In a workspace with both a root project and sub-packages, a default
+/// recursive `run` (no inclusion filter) auto-excludes the workspace
+/// root, mirroring pnpm's `!{<workspace-root>}` augmentation. The
+/// sub-packages run; the root does not.
+#[test]
+fn recursive_run_auto_excludes_workspace_root() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace_with_root_and_packages(&workspace);
+
+    pacquet.with_arg("-r").with_arg("run").with_arg("build").assert().success();
+
+    assert!(workspace.join("packages/project-1/ran.txt").exists(), "project-1 should run");
+    assert!(workspace.join("packages/project-2/ran.txt").exists(), "project-2 should run");
+    assert!(
+        !workspace.join("root-ran.txt").exists(),
+        "the workspace root must be auto-excluded from a default recursive run",
+    );
+
+    drop(root);
+}
+
+/// An all-exclusion selection (`--filter=!<name>`) also drops the
+/// workspace root, mirroring pnpm's release-workflow shape
+/// (`--filter=!pnpm --filter=!@pnpm/exe`): `-r --filter=!project-2 run
+/// build` runs project-1 only — project-2 is excluded by the selector
+/// and the root by the `!{<workspace-root>}` augmentation.
+#[test]
+fn recursive_run_all_exclusion_filter_also_drops_root() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace_with_root_and_packages(&workspace);
+
+    pacquet
+        .with_arg("-r")
+        .with_arg("--filter")
+        .with_arg("!project-2")
+        .with_arg("run")
+        .with_arg("build")
+        .assert()
+        .success();
+
+    assert!(workspace.join("packages/project-1/ran.txt").exists(), "project-1 should run");
+    assert!(
+        !workspace.join("packages/project-2/ran.txt").exists(),
+        "project-2 is excluded by the !project-2 selector",
+    );
+    assert!(
+        !workspace.join("root-ran.txt").exists(),
+        "an all-exclusion selection must also drop the workspace root",
+    );
+
+    drop(root);
+}
+
 /// When `--filter` narrows the set and no *selected* package defines the
 /// script, the error keeps pnpm's `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT` code
 /// but switches to the "None of the selected packages" wording (vs. "None

--- a/pacquet/crates/cli/tests/run_recursive.rs
+++ b/pacquet/crates/cli/tests/run_recursive.rs
@@ -314,6 +314,36 @@ fn recursive_run_all_exclusion_filter_also_drops_root() {
     drop(root);
 }
 
+/// The root auto-exclusion is built relative to `--dir`, so it still
+/// fires when the recursive run is launched from a workspace
+/// subdirectory: with `--dir packages/project-1`, the `!{<workspace-root>}`
+/// selector resolves through a non-trivial relative path (`../..`) rather
+/// than the bare `.`, and the root is still dropped while every non-root
+/// package runs.
+#[test]
+fn recursive_run_from_subdirectory_still_excludes_root() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace_with_root_and_packages(&workspace);
+
+    pacquet
+        .with_arg("--dir")
+        .with_arg("packages/project-1")
+        .with_arg("-r")
+        .with_arg("run")
+        .with_arg("build")
+        .assert()
+        .success();
+
+    assert!(workspace.join("packages/project-1/ran.txt").exists(), "project-1 should run");
+    assert!(workspace.join("packages/project-2/ran.txt").exists(), "project-2 should run");
+    assert!(
+        !workspace.join("root-ran.txt").exists(),
+        "the workspace root must stay excluded even when run from a subdirectory",
+    );
+
+    drop(root);
+}
+
 /// When `--filter` narrows the set and no *selected* package defines the
 /// script, the error keeps pnpm's `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT` code
 /// but switches to the "None of the selected packages" wording (vs. "None

--- a/pacquet/crates/cli/tests/run_recursive.rs
+++ b/pacquet/crates/cli/tests/run_recursive.rs
@@ -344,6 +344,39 @@ fn recursive_run_from_subdirectory_still_excludes_root() {
     drop(root);
 }
 
+/// An all-exclusion `--filter-prod` also drops the workspace root. The
+/// root exclusion inherits `follow_prod_deps_only` from the presence of
+/// `--filter-prod`, so it lands in the same production-only selection
+/// pass as the user's `!project-2`. Both passes are unioned, so if the
+/// exclusion landed in the wrong pass the root (and `project-2`) would be
+/// re-added; this pins them to the same pass.
+#[test]
+fn recursive_run_filter_prod_all_exclusion_also_drops_root() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace_with_root_and_packages(&workspace);
+
+    pacquet
+        .with_arg("-r")
+        .with_arg("--filter-prod")
+        .with_arg("!project-2")
+        .with_arg("run")
+        .with_arg("build")
+        .assert()
+        .success();
+
+    assert!(workspace.join("packages/project-1/ran.txt").exists(), "project-1 should run");
+    assert!(
+        !workspace.join("packages/project-2/ran.txt").exists(),
+        "project-2 is excluded by the !project-2 production selector",
+    );
+    assert!(
+        !workspace.join("root-ran.txt").exists(),
+        "the root exclusion must share the production-only pass, so the root is dropped too",
+    );
+
+    drop(root);
+}
+
 /// When `--filter` narrows the set and no *selected* package defines the
 /// script, the error keeps pnpm's `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT` code
 /// but switches to the "None of the selected packages" wording (vs. "None

--- a/pacquet/crates/cli/tests/run_recursive.rs
+++ b/pacquet/crates/cli/tests/run_recursive.rs
@@ -450,6 +450,33 @@ fn recursive_run_filter_prod_follows_production_deps_only() {
     drop(root);
 }
 
+/// A `[<since>]` changed-packages selector is not supported by pacquet's
+/// filter engine yet, so a recursive `run` surfaces the
+/// `UnsupportedDiffSelector` error instead of swallowing it. This
+/// exercises the error-propagation (`?`) out of `select_recursive_projects`.
+#[test]
+fn recursive_run_diff_selector_is_unsupported() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(&workspace, &[("project-1", build_writes_marker("project-1"))]);
+
+    let output = pacquet
+        .with_arg("-r")
+        .with_arg("--filter")
+        .with_arg("[main]")
+        .with_arg("run")
+        .with_arg("build")
+        .output()
+        .expect("spawn pacquet");
+    assert!(!output.status.success(), "a [<since>] diff selector is unsupported and must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Changed-package filter selectors"),
+        "stderr should explain the diff selector is unsupported, got: {stderr}",
+    );
+
+    drop(root);
+}
+
 /// A `--filter` that matches no project is a no-op: the run exits 0
 /// without raising the no-selected-packages error, matching pnpm's
 /// main-dispatch exit-0 for an empty `selectedProjectsGraph`.


### PR DESCRIPTION
## Summary

Ports pnpm's CLI-wide `--filter` / `--filter-prod` → recursive promotion to pacquet. A bare `--filter` (or `--filter-prod`), without `-r` / `--recursive`, now puts the command into recursive mode for every command, matching pnpm's `parse-cli-args`. This is the prerequisite for driving `release.yml`, which publishes through `pn publish --filter=<pkg>` with no `-r`.

It also ports the `!{<workspace-root>}` augmentation from pnpm's `main.ts`: for `run` / `exec`, an all-exclusion selection (e.g. `--filter=!pnpm --filter=!@pnpm/exe`) or an unfiltered recursive run auto-excludes the workspace root unless the workspace is root-only (`packages === ['.']`). To match that faithfully, the recursive selection now filters with pnpm's default glob directory matching (`useGlobDirFiltering`), so `!{<root>}` drops only the project at the workspace root, not every nested package. `pack` stays out of the auto-exclusion command set, matching pnpm.

`--include-workspace-root` / `--workspace-root` are not handled because pacquet does not surface either flag yet; this is noted in code.

Resolves <https://github.com/pnpm/pnpm/issues/12723>.

## Squash Commit Body

```text
A bare `--filter` / `--filter-prod` (without `-r`/`--recursive`) now puts the
command into recursive mode CLI-wide, matching pnpm's parse-cli-args promotion,
so `pn publish --filter=<pkg>` (as used by release.yml) behaves as a recursive
publish over the filtered set.

Also ports the `!{<workspace-root>}` augmentation from pnpm's main dispatch:
for run/exec, an all-exclusion (or unfiltered) selection auto-excludes the
workspace root unless the workspace is root-only (patterns === ['.']). The
recursive selection now filters with glob directory matching (pnpm's
useGlobDirFiltering default), which is load-bearing for that augmentation: it
excludes only the project at the workspace root, not every nested package.
pack stays out of the auto-exclusion command set, matching pnpm.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port. The TypeScript pnpm CLI already implements this behavior
  (`cli/parse-cli-args` promotion and the `pnpm/src/main.ts` augmentation);
  this PR ports it to pacquet to restore parity.
- [x] Added or updated tests: promotion unit tests; bare-`--filter`
  promotion for `run` / `exec` / `pack`; `run` root auto-exclusion (default,
  all-exclusion, `--filter-prod` all-exclusion, and from a subdirectory);
  `pack` keeping the root; and the unsupported-`[since]`-selector error path
  out of the recursive runners.

<sub>PR description maintained by an agent (Claude Code).</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `--filter` and `--filter-prod` now automatically enable recursive execution, even without `-r`.
  * Recursive project selection now uses `pnpm-workspace.yaml` patterns to more accurately handle workspace roots and exclusions.
* **Bug Fixes**
  * Recursive `pack`, `run`, and `exec` no longer include the workspace root when it shouldn’t be selected.
  * Recursive `exec`/`run` with unsupported diff-style selectors now fails reliably with clear errors.
* **Tests**
  * Added integration tests covering filter-triggered recursion, workspace-root auto-exclusion (including `--dir`), and selector error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->