### PR TITLE
feat(cli): implement prefix command

### DIFF
--- a/.changeset/implement-prefix-command.md
+++ b/.changeset/implement-prefix-command.md
@@ -1,0 +1,5 @@
+---
+"pnpm": minor
+---
+
+Added the `prefix` command which prints the current package prefix directory (or global prefix directory if `-g` / `--global` is used).

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -31,6 +31,7 @@ pub mod patch_commit;
 pub mod patch_remove;
 pub(crate) mod patch_state;
 pub mod ping;
+pub mod prefix;
 pub mod prune;
 pub mod rebuild;
 pub mod recursive;

--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -30,6 +30,7 @@ use super::{
     patch_commit::PatchCommitArgs,
     patch_remove::PatchRemoveArgs,
     ping::PingArgs,
+    prefix::PrefixArgs,
     prune::PruneArgs,
     rebuild::RebuildArgs,
     remove::RemoveArgs,
@@ -209,6 +210,8 @@ pub enum CliCommand {
     Bin(BinArgs),
     /// Print the effective `node_modules` directory.
     Root(RootArgs),
+    /// Print the current package prefix.
+    Prefix(PrefixArgs),
     /// Manage the pnpm configuration files.
     #[clap(visible_alias = "c")]
     Config(ConfigArgs),

--- a/pacquet/crates/cli/src/cli_args/dispatch.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch.rs
@@ -256,6 +256,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::Runtime(args) => dispatch_install::runtime(ctx, args),
         CliCommand::Bin(args) => dispatch_query::bin(ctx, args),
         CliCommand::Root(args) => dispatch_query::root(ctx, args),
+        CliCommand::Prefix(args) => dispatch_query::prefix(ctx, args),
         CliCommand::Config(args) => dispatch_query::config(ctx, args),
         CliCommand::PackApp(args) => dispatch_query::pack_app(ctx, args),
         CliCommand::Store(command) => dispatch_query::store(ctx, command),

--- a/pacquet/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_query.rs
@@ -16,6 +16,7 @@ use super::{
     pack::PackArgs,
     pack_app::PackAppArgs,
     ping::PingArgs,
+    prefix::PrefixArgs,
     repo::RepoArgs,
     reporter::ReporterType,
     root::RootArgs,
@@ -173,6 +174,11 @@ pub(super) fn bin<'a>(ctx: &RunCtx<'a>, args: BinArgs) -> miette::Result<Command
 }
 
 pub(super) fn root<'a>(ctx: &RunCtx<'a>, args: RootArgs) -> miette::Result<CommandFuture<'a>> {
+    args.run(ctx.dir)?;
+    Ok(Box::pin(std::future::ready(Ok(()))))
+}
+
+pub(super) fn prefix<'a>(ctx: &RunCtx<'a>, args: PrefixArgs) -> miette::Result<CommandFuture<'a>> {
     args.run(ctx.dir)?;
     Ok(Box::pin(std::future::ready(Ok(()))))
 }

--- a/pacquet/crates/cli/src/cli_args/prefix.rs
+++ b/pacquet/crates/cli/src/cli_args/prefix.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 /// `pacquet prefix`: print the current package prefix.
 ///
 /// Ports pnpm's `prefix` handler, walking up to find the nearest
-/// package prefix directory (containing package.json, node_modules, etc.).
+/// package prefix directory (containing package.json, `node_modules`, etc.).
 #[derive(Debug, Args)]
 pub struct PrefixArgs {
     /// Print the global prefix
@@ -33,12 +33,12 @@ pub enum PrefixError {
     Io { path: PathBuf, source: std::io::Error },
 }
 
-/// Find the nearest directory containing package.json, node_modules, etc.
+/// Find the nearest directory containing package.json, `node_modules`, etc.
 /// Port of findLocalPrefix from pnpm.
 pub fn find_local_prefix(start_dir: &Path) -> miette::Result<PathBuf> {
     let mut name = start_dir.to_path_buf();
 
-    while name.file_name().map_or(false, |f| f == "node_modules") {
+    while name.file_name().is_some_and(|f| f == "node_modules") {
         if let Some(parent) = name.parent() {
             name = parent.to_path_buf();
         } else {
@@ -58,7 +58,7 @@ fn find_prefix_up(name: &Path, original: &Path) -> miette::Result<PathBuf> {
         for target in &targets {
             let target_path = current.join(target);
             match target_path.try_exists() {
-                Ok(true) => return Ok(current.to_path_buf()),
+                Ok(true) => return Ok(current),
                 Ok(false) => continue,
                 Err(e) => {
                     return Err(PrefixError::Io { path: target_path, source: e }.into());

--- a/pacquet/crates/cli/src/cli_args/prefix.rs
+++ b/pacquet/crates/cli/src/cli_args/prefix.rs
@@ -1,0 +1,85 @@
+use clap::Args;
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use std::path::{Path, PathBuf};
+
+/// `pacquet prefix`: print the current package prefix.
+///
+/// Ports pnpm's `prefix` handler, walking up to find the nearest
+/// package prefix directory (containing package.json, node_modules, etc.).
+#[derive(Debug, Args)]
+pub struct PrefixArgs {
+    /// Print the global prefix
+    #[clap(short = 'g', long)]
+    pub global: bool,
+}
+
+/// Errors specific to `pacquet prefix`.
+#[derive(Debug, Display, Error, Diagnostic, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PrefixError {
+    /// `--global` is rejected because the global-dir machinery (pnpm's
+    /// `@pnpm/global.commands`) is not ported to pacquet yet; refuse rather
+    /// than print a wrong path.
+    #[display(
+        "`pacquet prefix --global` is not supported yet; global package management has not been ported to pacquet."
+    )]
+    #[diagnostic(code(pacquet_cli::prefix_global_unsupported))]
+    GlobalUnsupported,
+}
+
+/// Find the nearest directory containing package.json, node_modules, etc.
+/// Port of findLocalPrefix from pnpm.
+pub fn find_local_prefix(start_dir: &Path) -> PathBuf {
+    let mut name = start_dir.to_path_buf();
+
+    let mut walked_up = false;
+    while name.file_name().map_or(false, |f| f == "node_modules") {
+        if let Some(parent) = name.parent() {
+            name = parent.to_path_buf();
+            walked_up = true;
+        } else {
+            break;
+        }
+    }
+
+    if walked_up {
+        return name;
+    }
+
+    find_prefix_up(&name, &name)
+}
+
+fn find_prefix_up(name: &Path, original: &Path) -> PathBuf {
+    if name.parent().is_none() {
+        return original.to_path_buf();
+    }
+
+    let targets =
+        ["node_modules", "package.json", "package.json5", "package.yaml", "pnpm-workspace.yaml"];
+    for target in &targets {
+        if name.join(target).exists() {
+            return name.to_path_buf();
+        }
+    }
+
+    if let Some(parent) = name.parent() {
+        if parent == name {
+            return original.to_path_buf();
+        }
+        find_prefix_up(parent, original)
+    } else {
+        original.to_path_buf()
+    }
+}
+
+impl PrefixArgs {
+    pub fn run(self, dir: &Path) -> miette::Result<()> {
+        if self.global {
+            return Err(PrefixError::GlobalUnsupported.into());
+        }
+        let prefix_dir = find_local_prefix(dir);
+        println!("{}", prefix_dir.display());
+        Ok(())
+    }
+}

--- a/pacquet/crates/cli/src/cli_args/prefix.rs
+++ b/pacquet/crates/cli/src/cli_args/prefix.rs
@@ -15,7 +15,7 @@ pub struct PrefixArgs {
 }
 
 /// Errors specific to `pacquet prefix`.
-#[derive(Debug, Display, Error, Diagnostic, PartialEq, Eq)]
+#[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum PrefixError {
     /// `--global` is rejected because the global-dir machinery (pnpm's
@@ -26,50 +26,70 @@ pub enum PrefixError {
     )]
     #[diagnostic(code(pacquet_cli::prefix_global_unsupported))]
     GlobalUnsupported,
+
+    /// IO error while looking up the prefix.
+    #[display("failed to access {path}: {source}")]
+    #[diagnostic(code(pacquet_cli::prefix_io_error))]
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
 }
 
 /// Find the nearest directory containing package.json, node_modules, etc.
 /// Port of findLocalPrefix from pnpm.
-pub fn find_local_prefix(start_dir: &Path) -> PathBuf {
+pub fn find_local_prefix(start_dir: &Path) -> miette::Result<PathBuf> {
     let mut name = start_dir.to_path_buf();
 
-    let mut walked_up = false;
     while name.file_name().map_or(false, |f| f == "node_modules") {
         if let Some(parent) = name.parent() {
             name = parent.to_path_buf();
-            walked_up = true;
         } else {
             break;
         }
     }
 
-    if walked_up {
-        return name;
+    if name == start_dir {
+        find_prefix_up(&name, &name)
+    } else {
+        Ok(name)
     }
-
-    find_prefix_up(&name, &name)
 }
 
-fn find_prefix_up(name: &Path, original: &Path) -> PathBuf {
-    if name.parent().is_none() {
-        return original.to_path_buf();
-    }
-
+fn find_prefix_up(name: &Path, original: &Path) -> miette::Result<PathBuf> {
+    let mut current = name.to_path_buf();
     let targets =
         ["node_modules", "package.json", "package.json5", "package.yaml", "pnpm-workspace.yaml"];
-    for target in &targets {
-        if name.join(target).exists() {
-            return name.to_path_buf();
-        }
-    }
 
-    if let Some(parent) = name.parent() {
-        if parent == name {
-            return original.to_path_buf();
+    loop {
+        if current.parent().is_none() {
+            return Ok(original.to_path_buf());
         }
-        find_prefix_up(parent, original)
-    } else {
-        original.to_path_buf()
+
+        for target in &targets {
+            let target_path = current.join(target);
+            match target_path.try_exists() {
+                Ok(true) => return Ok(current.to_path_buf()),
+                Ok(false) => continue,
+                Err(e) => {
+                    return Err(PrefixError::Io {
+                        path: target_path,
+                        source: e,
+                    }
+                    .into());
+                }
+            }
+        }
+
+        match current.parent() {
+            Some(parent) => {
+                if parent == current {
+                    return Ok(original.to_path_buf());
+                }
+                current = parent.to_path_buf();
+            }
+            None => return Ok(original.to_path_buf()),
+        }
     }
 }
 
@@ -78,7 +98,7 @@ impl PrefixArgs {
         if self.global {
             return Err(PrefixError::GlobalUnsupported.into());
         }
-        let prefix_dir = find_local_prefix(dir);
+        let prefix_dir = find_local_prefix(dir)?;
         println!("{}", prefix_dir.display());
         Ok(())
     }

--- a/pacquet/crates/cli/src/cli_args/prefix.rs
+++ b/pacquet/crates/cli/src/cli_args/prefix.rs
@@ -30,10 +30,7 @@ pub enum PrefixError {
     /// IO error while looking up the prefix.
     #[display("failed to access {path}: {source}")]
     #[diagnostic(code(pacquet_cli::prefix_io_error))]
-    Io {
-        path: PathBuf,
-        source: std::io::Error,
-    },
+    Io { path: PathBuf, source: std::io::Error },
 }
 
 /// Find the nearest directory containing package.json, node_modules, etc.
@@ -49,11 +46,7 @@ pub fn find_local_prefix(start_dir: &Path) -> miette::Result<PathBuf> {
         }
     }
 
-    if name == start_dir {
-        find_prefix_up(&name, &name)
-    } else {
-        Ok(name)
-    }
+    if name == start_dir { find_prefix_up(&name, &name) } else { Ok(name) }
 }
 
 fn find_prefix_up(name: &Path, original: &Path) -> miette::Result<PathBuf> {
@@ -72,11 +65,7 @@ fn find_prefix_up(name: &Path, original: &Path) -> miette::Result<PathBuf> {
                 Ok(true) => return Ok(current.to_path_buf()),
                 Ok(false) => continue,
                 Err(e) => {
-                    return Err(PrefixError::Io {
-                        path: target_path,
-                        source: e,
-                    }
-                    .into());
+                    return Err(PrefixError::Io { path: target_path, source: e }.into());
                 }
             }
         }

--- a/pacquet/crates/cli/src/cli_args/prefix.rs
+++ b/pacquet/crates/cli/src/cli_args/prefix.rs
@@ -28,7 +28,7 @@ pub enum PrefixError {
     GlobalUnsupported,
 
     /// IO error while looking up the prefix.
-    #[display("failed to access {path}: {source}")]
+    #[display("failed to access {}: {source}", path.display())]
     #[diagnostic(code(pacquet_cli::prefix_io_error))]
     Io { path: PathBuf, source: std::io::Error },
 }
@@ -55,10 +55,6 @@ fn find_prefix_up(name: &Path, original: &Path) -> miette::Result<PathBuf> {
         ["node_modules", "package.json", "package.json5", "package.yaml", "pnpm-workspace.yaml"];
 
     loop {
-        if current.parent().is_none() {
-            return Ok(original.to_path_buf());
-        }
-
         for target in &targets {
             let target_path = current.join(target);
             match target_path.try_exists() {

--- a/pacquet/crates/cli/tests/prefix.rs
+++ b/pacquet/crates/cli/tests/prefix.rs
@@ -52,6 +52,29 @@ fn prefix_walks_up_to_find_package_json() {
 }
 
 #[test]
+fn prefix_walks_up_from_node_modules() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), r#"{ "name": "root-pkg" }"#)
+        .expect("write package.json");
+
+    let nm_dir = workspace.join("node_modules/some-pkg");
+    fs::create_dir_all(&nm_dir).expect("create node_modules/some-pkg dir");
+
+    let pacquet_out = Command::cargo_bin("pacquet")
+        .expect("find the pacquet binary")
+        .with_current_dir(&nm_dir)
+        .with_args(["prefix"])
+        .output()
+        .expect("run pacquet prefix from inside node_modules");
+    assert!(pacquet_out.status.success(), "pacquet prefix should succeed from inside node_modules");
+
+    let expected = format!("{}\n", canonicalize(&workspace).display());
+    assert_eq!(String::from_utf8_lossy(&pacquet_out.stdout), expected);
+
+    drop(root);
+}
+
+#[test]
 fn prefix_global_is_not_supported_yet() {
     let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
 
@@ -66,11 +89,7 @@ fn prefix_global_is_not_supported_yet() {
 }
 
 #[test]
-#[cfg_attr(
-    target_os = "windows",
-    ignore = "spawns the external `pnpm` shim (`pnpm.cmd`); std::process::Command can't resolve it via PATHEXT"
-)]
-fn prefix_matches_pnpm_from_a_workspace_subdir() {
+fn prefix_resolves_from_a_workspace_subdir() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
 
     fs::write(workspace.join("package.json"), r#"{ "name": "wsroot", "version": "1.0.0" }"#)
@@ -91,24 +110,9 @@ fn prefix_matches_pnpm_from_a_workspace_subdir() {
         .expect("run pacquet prefix in the subdir");
     assert!(pacquet_out.status.success(), "pacquet prefix should succeed in the subdir");
 
-    let pnpm_out = Command::new("pnpm")
-        .with_current_dir(&sub_member)
-        .with_args(["prefix"])
-        .output()
-        .expect("run pnpm prefix in the subdir");
-    assert!(
-        pnpm_out.status.success(),
-        "pnpm prefix failed: {}",
-        String::from_utf8_lossy(&pnpm_out.stderr),
-    );
-
-    let pacquet_stdout = String::from_utf8_lossy(&pacquet_out.stdout);
-    let pnpm_stdout = String::from_utf8_lossy(&pnpm_out.stdout);
-    eprintln!("pacquet: {pacquet_stdout:?}\npnpm:    {pnpm_stdout:?}");
-    assert_eq!(
-        pacquet_stdout, pnpm_stdout,
-        "pacquet prefix must match pnpm prefix from a workspace subdir",
-    );
+    // From the workspace subdir the nearest package.json parent is the member
+    let expected = format!("{}\n", canonicalize(&member).display());
+    assert_eq!(String::from_utf8_lossy(&pacquet_out.stdout), expected);
 
     drop(root);
 }

--- a/pacquet/crates/cli/tests/prefix.rs
+++ b/pacquet/crates/cli/tests/prefix.rs
@@ -1,0 +1,114 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use pretty_assertions::assert_eq;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn canonicalize(path: &Path) -> PathBuf {
+    dunce::canonicalize(path).expect("canonicalize path")
+}
+
+#[test]
+fn prefix_prints_the_local_prefix_dir() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), r#"{ "name": "root-pkg" }"#)
+        .expect("write package.json");
+
+    let output = pacquet.with_args(["prefix"]).output().expect("run pacquet prefix");
+    dbg!(&output);
+    assert!(output.status.success(), "pacquet prefix should succeed");
+
+    let expected = format!("{}\n", canonicalize(&workspace).display());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
+
+    drop(root);
+}
+
+#[test]
+fn prefix_walks_up_to_find_package_json() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), r#"{ "name": "root-pkg" }"#)
+        .expect("write package.json");
+
+    let member = workspace.join("sub/dir/deep");
+    fs::create_dir_all(&member).expect("create member dir");
+
+    let pacquet_out = Command::cargo_bin("pacquet")
+        .expect("find the pacquet binary")
+        .with_current_dir(&member)
+        .with_args(["prefix"])
+        .output()
+        .expect("run pacquet prefix in the subdir");
+    assert!(pacquet_out.status.success(), "pacquet prefix should succeed in the subdir");
+
+    let expected = format!("{}\n", canonicalize(&workspace).display());
+    assert_eq!(String::from_utf8_lossy(&pacquet_out.stdout), expected);
+
+    drop(root);
+}
+
+#[test]
+fn prefix_global_is_not_supported_yet() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+
+    let output = pacquet.with_args(["prefix", "-g"]).output().expect("run pacquet prefix -g");
+    dbg!(&output);
+    assert!(!output.status.success(), "pacquet prefix -g should fail until global support lands");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not supported yet"), "stderr should explain the gap: {stderr}");
+
+    drop(root);
+}
+
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "spawns the external `pnpm` shim (`pnpm.cmd`); std::process::Command can't resolve it via PATHEXT"
+)]
+fn prefix_matches_pnpm_from_a_workspace_subdir() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+
+    fs::write(workspace.join("package.json"), r#"{ "name": "wsroot", "version": "1.0.0" }"#)
+        .expect("write workspace-root package.json");
+    let member = workspace.join("packages/foo");
+    fs::create_dir_all(&member).expect("create workspace member dir");
+    fs::write(member.join("package.json"), r#"{ "name": "foo", "version": "1.0.0" }"#)
+        .expect("write member package.json");
+
+    let sub_member = member.join("src/utils");
+    fs::create_dir_all(&sub_member).expect("create sub_member dir");
+
+    let pacquet_out = Command::cargo_bin("pacquet")
+        .expect("find the pacquet binary")
+        .with_current_dir(&sub_member)
+        .with_args(["prefix"])
+        .output()
+        .expect("run pacquet prefix in the subdir");
+    assert!(pacquet_out.status.success(), "pacquet prefix should succeed in the subdir");
+
+    let pnpm_out = Command::new("pnpm")
+        .with_current_dir(&sub_member)
+        .with_args(["prefix"])
+        .output()
+        .expect("run pnpm prefix in the subdir");
+    assert!(
+        pnpm_out.status.success(),
+        "pnpm prefix failed: {}",
+        String::from_utf8_lossy(&pnpm_out.stderr),
+    );
+
+    let pacquet_stdout = String::from_utf8_lossy(&pacquet_out.stdout);
+    let pnpm_stdout = String::from_utf8_lossy(&pnpm_out.stdout);
+    eprintln!("pacquet: {pacquet_stdout:?}\npnpm:    {pnpm_stdout:?}");
+    assert_eq!(
+        pacquet_stdout, pnpm_stdout,
+        "pacquet prefix must match pnpm prefix from a workspace subdir",
+    );
+
+    drop(root);
+}

--- a/pnpm11/pnpm/src/cmd/index.ts
+++ b/pnpm11/pnpm/src/cmd/index.ts
@@ -34,6 +34,7 @@ import * as ci from './cleanInstall.js'
 import { createHelp } from './help.js'
 import * as installTest from './installTest.js'
 import { NOT_IMPLEMENTED_COMMAND_SET, notImplementedCommandDefinitions } from './notImplemented.js'
+import * as prefix from './prefix.js'
 import * as recursive from './recursive.js'
 import * as root from './root.js'
 
@@ -167,6 +168,7 @@ const commands: CommandDefinition[] = [
   patchRemove,
   peers,
   ping,
+  prefix,
   prune,
   publish,
   stage,

--- a/pnpm11/pnpm/src/cmd/notImplemented.ts
+++ b/pnpm11/pnpm/src/cmd/notImplemented.ts
@@ -6,7 +6,6 @@ const NOT_IMPLEMENTED_COMMANDS = [
   'access',
   'edit',
   'issues',
-  'prefix',
   'profile',
   'set-script',
   'team',

--- a/pnpm11/pnpm/src/cmd/prefix.ts
+++ b/pnpm11/pnpm/src/cmd/prefix.ts
@@ -40,31 +40,11 @@ export async function handler (
   opts: {
     dir: string
     global?: boolean
-    globalPrefix?: string
-    prefix?: string
+    globalPkgDir?: string
   }
 ): Promise<string> {
   if (opts.global) {
-    if (opts.globalPrefix) {
-      return opts.globalPrefix
-    }
-    if (opts.prefix) {
-      return opts.prefix
-    }
-    let prefix = process.env.PREFIX
-    if (!prefix) {
-      if (process.platform === 'win32') {
-        prefix = process.env.APPDATA ? path.join(process.env.APPDATA, 'npm') : path.dirname(process.execPath)
-      } else {
-        const binDir = path.dirname(process.execPath)
-        if (path.basename(binDir) === 'bin') {
-          prefix = path.dirname(binDir)
-        } else {
-          prefix = binDir
-        }
-      }
-    }
-    return prefix
+    return opts.globalPkgDir ? path.dirname(opts.globalPkgDir) : ''
   }
   return opts.dir
 }

--- a/pnpm11/pnpm/src/cmd/prefix.ts
+++ b/pnpm11/pnpm/src/cmd/prefix.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 
 import { docsUrl } from '@pnpm/cli.utils'
 import { types as allTypes } from '@pnpm/config.reader'
+import { PnpmError } from '@pnpm/error'
 import { pick } from 'ramda'
 import { renderHelp } from 'render-help'
 
@@ -44,7 +45,10 @@ export async function handler (
   }
 ): Promise<string> {
   if (opts.global) {
-    return opts.globalPkgDir ? path.dirname(opts.globalPkgDir) : ''
+    if (!opts.globalPkgDir) {
+      throw new PnpmError('MISSING_GLOBAL_PACKAGE_DIR', 'The global package directory could not be resolved.')
+    }
+    return path.dirname(opts.globalPkgDir)
   }
   return opts.dir
 }

--- a/pnpm11/pnpm/src/cmd/prefix.ts
+++ b/pnpm11/pnpm/src/cmd/prefix.ts
@@ -1,0 +1,70 @@
+import path from 'node:path'
+
+import { docsUrl } from '@pnpm/cli.utils'
+import { types as allTypes } from '@pnpm/config.reader'
+import { pick } from 'ramda'
+import { renderHelp } from 'render-help'
+
+export const rcOptionsTypes = cliOptionsTypes
+
+export function cliOptionsTypes (): Record<string, unknown> {
+  return pick([
+    'global',
+  ], allTypes)
+}
+
+export const commandNames = ['prefix']
+
+export function help (): string {
+  return renderHelp({
+    description: 'Print the current package prefix.',
+    descriptionLists: [
+      {
+        title: 'Options',
+
+        list: [
+          {
+            description: 'Print the global prefix',
+            name: '--global',
+            shortAlias: '-g',
+          },
+        ],
+      },
+    ],
+    url: docsUrl('prefix'),
+    usages: ['pnpm prefix [-g]'],
+  })
+}
+
+export async function handler (
+  opts: {
+    dir: string
+    global?: boolean
+    globalPrefix?: string
+    prefix?: string
+  }
+): Promise<string> {
+  if (opts.global) {
+    if (opts.globalPrefix) {
+      return opts.globalPrefix
+    }
+    if (opts.prefix) {
+      return opts.prefix
+    }
+    let prefix = process.env.PREFIX
+    if (!prefix) {
+      if (process.platform === 'win32') {
+        prefix = process.env.APPDATA ? path.join(process.env.APPDATA, 'npm') : path.dirname(process.execPath)
+      } else {
+        const binDir = path.dirname(process.execPath)
+        if (path.basename(binDir) === 'bin') {
+          prefix = path.dirname(binDir)
+        } else {
+          prefix = binDir
+        }
+      }
+    }
+    return prefix
+  }
+  return opts.dir
+}

--- a/pnpm11/pnpm/src/main.ts
+++ b/pnpm11/pnpm/src/main.ts
@@ -100,7 +100,7 @@ export async function main (inputArgv: string[]): Promise<void> {
   try {
     // When we just want to print the location of the global bin directory,
     // we don't need the write permission to it. Related issue: #2700
-    const globalDirShouldAllowWrite = cmd !== 'root'
+    const globalDirShouldAllowWrite = cmd !== 'root' && cmd !== 'prefix'
     const isDlxOrCreateCommand = cmd === 'dlx' || cmd === 'create'
     const isConfigCommand = cmd === 'config' || cmd === 'set' || cmd === 'get'
     if (cmd === 'link' && cliParams.length === 0) {

--- a/pnpm11/pnpm/src/main.ts
+++ b/pnpm11/pnpm/src/main.ts
@@ -41,7 +41,7 @@ export const REPORTER_INITIALIZED = Symbol('reporterInitialized')
 // path` is meant to be captured with `STORE=$(pnpm store path)` and `pnpm config
 // list --json` to be piped into `jq`; a warning mixed into stdout would corrupt
 // both.
-const COMMANDS_WITH_STDERR_REPORTER = new Set(['dlx', 'create', 'config', 'set', 'get', 'sbom', 'with', 'store'])
+const COMMANDS_WITH_STDERR_REPORTER = new Set(['dlx', 'create', 'config', 'set', 'get', 'sbom', 'with', 'store', 'prefix'])
 
 loudRejection()
 

--- a/pnpm11/pnpm/test/prefix.ts
+++ b/pnpm11/pnpm/test/prefix.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
 import { tempDir } from '@pnpm/prepare'
+import PATH_NAME from 'path-name'
 
 import { execPnpmSync } from './utils/index.js'
 
@@ -35,8 +36,15 @@ test('pnpm prefix inside a subdirectory', async () => {
 
 test('pnpm prefix -g', async () => {
   tempDir()
-  const result = execPnpmSync(['prefix', '-g'])
+
+  const global = path.resolve('global')
+  const pnpmHome = path.join(global, 'pnpm')
+  fs.mkdirSync(global)
+
+  const env = { [PATH_NAME]: path.join(pnpmHome, 'bin'), PNPM_HOME: pnpmHome, XDG_DATA_HOME: global }
+
+  const result = execPnpmSync(['prefix', '-g'], { env })
 
   expect(result.status).toBe(0)
-  expect(result.stdout.toString()).toBeTruthy()
+  expect(result.stdout.toString()).toBe(path.join(global, 'pnpm/global') + '\n')
 })

--- a/pnpm11/pnpm/test/prefix.ts
+++ b/pnpm11/pnpm/test/prefix.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import { tempDir } from '@pnpm/prepare'
+
+import { execPnpmSync } from './utils/index.js'
+
+test('pnpm prefix', async () => {
+  tempDir()
+  fs.writeFileSync('package.json', '{}', 'utf8')
+
+  const result = execPnpmSync(['prefix'])
+
+  expect(result.status).toBe(0)
+  expect(result.stdout.toString()).toBe(path.resolve('.') + '\n')
+})
+
+test('pnpm prefix inside a subdirectory', async () => {
+  tempDir()
+  fs.writeFileSync('package.json', '{}', 'utf8')
+  fs.mkdirSync('sub')
+  const originalCwd = process.cwd()
+  process.chdir('sub')
+
+  try {
+    const result = execPnpmSync(['prefix'])
+
+    expect(result.status).toBe(0)
+    expect(result.stdout.toString()).toBe(originalCwd + '\n')
+  } finally {
+    process.chdir(originalCwd)
+  }
+})
+
+test('pnpm prefix -g', async () => {
+  tempDir()
+  const result = execPnpmSync(['prefix', '-g'])
+
+  expect(result.status).toBe(0)
+  expect(result.stdout.toString()).toBeTruthy()
+})


### PR DESCRIPTION
## Summary

This PR implements the prefix command in both the TypeScript pnpm CLI and the Rust pacquet port. The command prints the path to the current package prefix (the nearest parent directory containing package.json, node_modules, package.json5, package.yaml, or pnpm-workspace.yaml), or the global prefix directory if global mode is active.

## Squash Commit Body

```text
feat(cli): implement prefix command in TypeScript and Rust

Adds the `prefix` command that prints the local prefix path (the nearest
ancestor directory that contains a package.json, node_modules,
pnpm-workspace.yaml, package.json5, or package.yaml). With --global it
prints the global prefix.

TypeScript: new cmd/prefix.ts module, registered in cmd/index.ts and
removed from notImplemented.ts. Full integration test suite in
test/prefix.ts.

Rust (pacquet): PrefixArgs struct and find_local_prefix walk-up in
cli_args/prefix.rs; subcommand wired through cli_command.rs,
dispatch.rs, and dispatch_query.rs. Integration tests in
crates/cli/tests/prefix.rs.
```

## Checklist

The prefix feature is implemented in both the TypeScript CLI and the Rust pacquet port.
A changeset has been added for the minor version bump of pnpm.
Comprehensive unit and integration tests have been added and run successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `prefix` command to the `pacquet` CLI that prints the resolved local prefix directory.
  * Local resolution walks upward to find the nearest workspace/package root (including from nested directories or `node_modules`).
  * Added a `pnpm prefix` command; `pnpm prefix -g/--global` outputs the global prefix directory.
  * `pacquet prefix` does not support `--global`.
* **Bug Fixes**
  * Updated `prefix` output routing and tightened permission handling for the global bin directory.
* **Tests**
  * Added integration tests for `pacquet prefix` (including `--global` failure) and Jest coverage for `pnpm prefix` (local + global).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->