### PR TITLE
fix(pnpr): stream proxied tarballs instead of buffering-then-verifying (and benchmark the cold pnpr cache)

### DIFF
--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -323,19 +323,21 @@ jobs:
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE.json
 
-      - name: 'Benchmark: Isolated linker: fresh install, cold cache + cold store + cold pnpr'
+      - name: 'Benchmark: Isolated linker: fresh restore, cold cache + cold store + cold pnpr'
         shell: bash
         # The only scenario with a cold pnpr-side cache: the per-revision mock
         # starts empty each iteration and refetches every tarball from the warm
         # origin, exercising the proxy's cold download/serve path (which streams
-        # rather than buffering the full tarball before serving). Most expensive
-        # scenario — every iteration re-downloads ~1300 tarballs through the
-        # mock — so it gets the same generous timeout as the no-lockfile install.
+        # rather than buffering the full tarball before serving). Frozen so it's
+        # just tarball serving — no resolution noise — and both arms measure it.
+        # Most expensive scenario (every iteration re-downloads ~1300 tarballs
+        # through the mock), so it gets the same generous timeout as a fresh
+        # install.
         timeout-minutes: 35
         run: |
-          just integrated-benchmark --reuse-prebuilt-binaries --scenario=isolated-linker.fresh-install.cold-cache.cold-store.cold-pnpr --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} --registry-bandwidth-mbps=${REGISTRY_BANDWIDTH_MBPS} $BENCHMARK_TARGETS
-          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE_COLD_PNPR.md
-          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE_COLD_PNPR.json
+          just integrated-benchmark --reuse-prebuilt-binaries --scenario=isolated-linker.fresh-restore.cold-cache.cold-store.cold-pnpr --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} --registry-bandwidth-mbps=${REGISTRY_BANDWIDTH_MBPS} $BENCHMARK_TARGETS
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR.md
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR.json
 
       - name: Generate summary
         shell: bash
@@ -413,14 +415,14 @@ jobs:
             echo
             echo '</details>'
             echo
-            echo '### Scenario: Isolated linker: fresh install, cold cache + cold store + cold pnpr'
+            echo '### Scenario: Isolated linker: fresh restore, cold cache + cold store + cold pnpr'
             echo
-            cat bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE_COLD_PNPR.md
+            cat bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR.md
             echo
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE_COLD_PNPR.json
+            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR.json
             echo '```'
             echo
             echo '</details>'
@@ -463,7 +465,7 @@ jobs:
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE:isolated-linker.fresh-install.cold-cache.cold-store' \
             'ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE:isolated-linker.fresh-install.hot-cache.hot-store' \
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE:isolated-linker.fresh-install.cold-cache.hot-store' \
-            'ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE_COLD_PNPR:isolated-linker.fresh-install.cold-cache.cold-store.cold-pnpr'
+            'ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR:isolated-linker.fresh-restore.cold-cache.cold-store.cold-pnpr'
 
           build_bencher_file bench-work-env/bencher-results-pnpr.json pnpr@HEAD \
             'ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE:isolated-linker.fresh-restore.cold-cache.cold-store' \
@@ -471,7 +473,7 @@ jobs:
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE:isolated-linker.fresh-install.cold-cache.cold-store' \
             'ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE:isolated-linker.fresh-install.hot-cache.hot-store' \
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE:isolated-linker.fresh-install.cold-cache.hot-store' \
-            'ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE_COLD_PNPR:isolated-linker.fresh-install.cold-cache.cold-store.cold-pnpr'
+            'ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR:isolated-linker.fresh-restore.cold-cache.cold-store.cold-pnpr'
 
       - name: Stage artifact contents
         # The artifact carries the rendered report plus the

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -323,6 +323,20 @@ jobs:
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE.json
 
+      - name: 'Benchmark: Isolated linker: fresh install, cold cache + cold store + cold pnpr'
+        shell: bash
+        # The only scenario with a cold pnpr-side cache: the per-revision mock
+        # starts empty each iteration and refetches every tarball from the warm
+        # origin, exercising the proxy's cold download/serve path (which streams
+        # rather than buffering the full tarball before serving). Most expensive
+        # scenario — every iteration re-downloads ~1300 tarballs through the
+        # mock — so it gets the same generous timeout as the no-lockfile install.
+        timeout-minutes: 35
+        run: |
+          just integrated-benchmark --reuse-prebuilt-binaries --scenario=isolated-linker.fresh-install.cold-cache.cold-store.cold-pnpr --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} --registry-bandwidth-mbps=${REGISTRY_BANDWIDTH_MBPS} $BENCHMARK_TARGETS
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE_COLD_PNPR.md
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE_COLD_PNPR.json
+
       - name: Generate summary
         shell: bash
         env:
@@ -398,6 +412,18 @@ jobs:
             echo '```'
             echo
             echo '</details>'
+            echo
+            echo '### Scenario: Isolated linker: fresh install, cold cache + cold store + cold pnpr'
+            echo
+            cat bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE_COLD_PNPR.md
+            echo
+            echo '<details><summary>BENCHMARK_REPORT.json</summary>'
+            echo
+            echo '```json'
+            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE_COLD_PNPR.json
+            echo '```'
+            echo
+            echo '</details>'
           ) > bench-work-env/SUMMARY.md
 
       - name: Build Bencher-shaped report
@@ -436,14 +462,16 @@ jobs:
             'ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE:isolated-linker.fresh-restore.hot-cache.hot-store' \
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE:isolated-linker.fresh-install.cold-cache.cold-store' \
             'ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE:isolated-linker.fresh-install.hot-cache.hot-store' \
-            'ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE:isolated-linker.fresh-install.cold-cache.hot-store'
+            'ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE:isolated-linker.fresh-install.cold-cache.hot-store' \
+            'ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE_COLD_PNPR:isolated-linker.fresh-install.cold-cache.cold-store.cold-pnpr'
 
           build_bencher_file bench-work-env/bencher-results-pnpr.json pnpr@HEAD \
             'ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE:isolated-linker.fresh-restore.cold-cache.cold-store' \
             'ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE:isolated-linker.fresh-restore.hot-cache.hot-store' \
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE:isolated-linker.fresh-install.cold-cache.cold-store' \
             'ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE:isolated-linker.fresh-install.hot-cache.hot-store' \
-            'ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE:isolated-linker.fresh-install.cold-cache.hot-store'
+            'ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE:isolated-linker.fresh-install.cold-cache.hot-store' \
+            'ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE_COLD_PNPR:isolated-linker.fresh-install.cold-cache.cold-store.cold-pnpr'
 
       - name: Stage artifact contents
         # The artifact carries the rendered report plus the

--- a/pacquet/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pacquet/tasks/integrated-benchmark/src/cli_args.rs
@@ -187,14 +187,15 @@ pub enum BenchmarkScenario {
     /// No lockfile, cold cache + cold store. Mirrors `pnpm install` with nothing on disk.
     #[value(name = "isolated-linker.fresh-install.cold-cache.cold-store")]
     IsolatedFreshInstallColdCacheColdStore,
-    /// No lockfile, cold cache + cold store, **and a cold pnpr cache**: the
+    /// Frozen lockfile, cold cache + cold store, **and a cold pnpr cache**: the
     /// tarball-serving mock starts empty each iteration and re-fetches every
-    /// tarball from a warm local origin, so the client install exercises the
-    /// proxy's cold download/serve path (the one streaming overlaps). The only
-    /// scenario that does — every other one warms the mock, so its serves are
-    /// all cache hits.
-    #[value(name = "isolated-linker.fresh-install.cold-cache.cold-store.cold-pnpr")]
-    IsolatedFreshInstallColdCacheColdStoreColdPnpr,
+    /// tarball from a warm local origin, so the install exercises the proxy's
+    /// cold download/serve path — the one streaming overlaps, and the only
+    /// scenario that hits it (every other warms the mock). Frozen on purpose:
+    /// no resolution, so the cold path is *just* tarball serving with no
+    /// packument-fetch noise, and both the direct and pnpr arms measure it.
+    #[value(name = "isolated-linker.fresh-restore.cold-cache.cold-store.cold-pnpr")]
+    IsolatedFreshRestoreColdCacheColdStoreColdPnpr,
     /// No lockfile, hot cache + hot store. Resolves everything against an already-populated store.
     #[value(name = "isolated-linker.fresh-install.hot-cache.hot-store")]
     IsolatedFreshInstallHotCacheHotStore,
@@ -237,10 +238,10 @@ impl BenchmarkScenario {
     pub fn install_args(self) -> &'static [&'static str] {
         match self {
             BenchmarkScenario::IsolatedFreshInstallColdCacheColdStore
-            | BenchmarkScenario::IsolatedFreshInstallColdCacheColdStoreColdPnpr
             | BenchmarkScenario::IsolatedFreshInstallHotCacheHotStore
             | BenchmarkScenario::IsolatedFreshInstallColdCacheHotStore => &["install"],
             BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStore
+            | BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStoreColdPnpr
             | BenchmarkScenario::IsolatedFreshRestoreHotCacheHotStore
             | BenchmarkScenario::GvsFreshRestoreHotCacheHotStore => {
                 &["install", "--frozen-lockfile"]
@@ -260,10 +261,10 @@ impl BenchmarkScenario {
     pub fn lockfile_enabled(self) -> bool {
         match self {
             BenchmarkScenario::IsolatedFreshInstallColdCacheColdStore
-            | BenchmarkScenario::IsolatedFreshInstallColdCacheColdStoreColdPnpr
             | BenchmarkScenario::IsolatedFreshInstallHotCacheHotStore
             | BenchmarkScenario::IsolatedFreshInstallColdCacheHotStore => false,
             BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStore
+            | BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStoreColdPnpr
             | BenchmarkScenario::IsolatedFreshRestoreHotCacheHotStore
             | BenchmarkScenario::IsolatedFreshAddDepHotCacheHotStore
             | BenchmarkScenario::GvsFreshRestoreHotCacheHotStore => true,
@@ -297,20 +298,14 @@ impl BenchmarkScenario {
                 remove: &["node_modules", "pnpm-lock.yaml", "store-dir", "cache-dir"],
                 restore: &[SAVED_PACKAGE_JSON],
             },
-            // Same as the cold-cache + cold-store install, but also wipe the
-            // per-revision mock's `cold-mock-storage` so the serving pnpr
+            // Same as the frozen cold-cache + cold-store restore, but also wipe
+            // the per-revision mock's `cold-mock-storage` so the serving pnpr
             // refetches (and streams) every tarball from the warm origin each
             // iteration. (`cold-mock-storage` only exists under a `pnpr@<rev>`
             // bench dir; it's a harmless no-op for the other ids.)
-            BenchmarkScenario::IsolatedFreshInstallColdCacheColdStoreColdPnpr => Cleanup {
-                remove: &[
-                    "node_modules",
-                    "pnpm-lock.yaml",
-                    "store-dir",
-                    "cache-dir",
-                    "cold-mock-storage",
-                ],
-                restore: &[SAVED_PACKAGE_JSON],
+            BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStoreColdPnpr => Cleanup {
+                remove: &["node_modules", "store-dir", "cache-dir", "cold-mock-storage"],
+                restore: &[SAVED_LOCKFILE],
             },
             BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStore => Cleanup {
                 remove: &["node_modules", "store-dir", "cache-dir"],
@@ -362,7 +357,7 @@ impl BenchmarkScenario {
     /// Whether this scenario gives the serving mock a cold cache (see the
     /// `…cold-store.cold-pnpr` variant); selects the cold-mock spawn.
     pub fn cold_pnpr_cache(self) -> bool {
-        matches!(self, BenchmarkScenario::IsolatedFreshInstallColdCacheColdStoreColdPnpr)
+        matches!(self, BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStoreColdPnpr)
     }
 }
 

--- a/pacquet/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pacquet/tasks/integrated-benchmark/src/cli_args.rs
@@ -187,6 +187,14 @@ pub enum BenchmarkScenario {
     /// No lockfile, cold cache + cold store. Mirrors `pnpm install` with nothing on disk.
     #[value(name = "isolated-linker.fresh-install.cold-cache.cold-store")]
     IsolatedFreshInstallColdCacheColdStore,
+    /// No lockfile, cold cache + cold store, **and a cold pnpr cache**: the
+    /// tarball-serving mock starts empty each iteration and re-fetches every
+    /// tarball from a warm local origin, so the client install exercises the
+    /// proxy's cold download/serve path (the one streaming overlaps). The only
+    /// scenario that does — every other one warms the mock, so its serves are
+    /// all cache hits.
+    #[value(name = "isolated-linker.fresh-install.cold-cache.cold-store.cold-pnpr")]
+    IsolatedFreshInstallColdCacheColdStoreColdPnpr,
     /// No lockfile, hot cache + hot store. Resolves everything against an already-populated store.
     #[value(name = "isolated-linker.fresh-install.hot-cache.hot-store")]
     IsolatedFreshInstallHotCacheHotStore,
@@ -229,6 +237,7 @@ impl BenchmarkScenario {
     pub fn install_args(self) -> &'static [&'static str] {
         match self {
             BenchmarkScenario::IsolatedFreshInstallColdCacheColdStore
+            | BenchmarkScenario::IsolatedFreshInstallColdCacheColdStoreColdPnpr
             | BenchmarkScenario::IsolatedFreshInstallHotCacheHotStore
             | BenchmarkScenario::IsolatedFreshInstallColdCacheHotStore => &["install"],
             BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStore
@@ -251,6 +260,7 @@ impl BenchmarkScenario {
     pub fn lockfile_enabled(self) -> bool {
         match self {
             BenchmarkScenario::IsolatedFreshInstallColdCacheColdStore
+            | BenchmarkScenario::IsolatedFreshInstallColdCacheColdStoreColdPnpr
             | BenchmarkScenario::IsolatedFreshInstallHotCacheHotStore
             | BenchmarkScenario::IsolatedFreshInstallColdCacheHotStore => false,
             BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStore
@@ -285,6 +295,21 @@ impl BenchmarkScenario {
                 // offloads to its warm server. Without this the mirror
                 // stays warm and direct ≈ pnpr.
                 remove: &["node_modules", "pnpm-lock.yaml", "store-dir", "cache-dir"],
+                restore: &[SAVED_PACKAGE_JSON],
+            },
+            // Same as the cold-cache + cold-store install, but also wipe the
+            // per-revision mock's `cold-mock-storage` so the serving pnpr
+            // refetches (and streams) every tarball from the warm origin each
+            // iteration. (`cold-mock-storage` only exists under a `pnpr@<rev>`
+            // bench dir; it's a harmless no-op for the other ids.)
+            BenchmarkScenario::IsolatedFreshInstallColdCacheColdStoreColdPnpr => Cleanup {
+                remove: &[
+                    "node_modules",
+                    "pnpm-lock.yaml",
+                    "store-dir",
+                    "cache-dir",
+                    "cold-mock-storage",
+                ],
                 restore: &[SAVED_PACKAGE_JSON],
             },
             BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStore => Cleanup {
@@ -332,6 +357,14 @@ impl BenchmarkScenario {
             BenchmarkScenario::IsolatedFreshInstallColdCacheColdStore
                 | BenchmarkScenario::IsolatedFreshInstallColdCacheHotStore,
         )
+    }
+
+    /// Whether the per-revision tarball-serving mock starts with a **cold**
+    /// cache (isolated storage wiped each iteration, proxying the warm shared
+    /// mock as origin) instead of sharing the warm storage. This is what makes
+    /// the client install exercise the proxy's cold download/serve path.
+    pub fn cold_pnpr_cache(self) -> bool {
+        matches!(self, BenchmarkScenario::IsolatedFreshInstallColdCacheColdStoreColdPnpr)
     }
 }
 

--- a/pacquet/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pacquet/tasks/integrated-benchmark/src/cli_args.rs
@@ -359,10 +359,8 @@ impl BenchmarkScenario {
         )
     }
 
-    /// Whether the per-revision tarball-serving mock starts with a **cold**
-    /// cache (isolated storage wiped each iteration, proxying the warm shared
-    /// mock as origin) instead of sharing the warm storage. This is what makes
-    /// the client install exercise the proxy's cold download/serve path.
+    /// Whether this scenario gives the serving mock a cold cache (see the
+    /// `…cold-store.cold-pnpr` variant); selects the cold-mock spawn.
     pub fn cold_pnpr_cache(self) -> bool {
         matches!(self, BenchmarkScenario::IsolatedFreshInstallColdCacheColdStoreColdPnpr)
     }

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -835,6 +835,13 @@ impl WorkEnv {
     /// When a revision has its own tarball-serving mock (see
     /// [`Self::plan_revision_mocks`]), its `pacquet@<rev>` and `pnpr@<rev>`
     /// targets fetch from that mock instead of the shared one.
+    ///
+    /// The cold-pnpr scenario is the exception: there the mock models a cold
+    /// *pnpr* cache, so only `pnpr@<rev>` targets route to it. A direct install
+    /// doesn't go through pnpr, so it keeps using the warm shared mock like
+    /// every other scenario — otherwise it would do a full cold fetch of every
+    /// packument and tarball through the cold mock, which is both wrong and
+    /// extremely noisy.
     fn registry_for<'a>(
         &'a self,
         id: BenchId,
@@ -844,7 +851,10 @@ impl WorkEnv {
         if id.is_proxy_cache_populator() {
             return &self.registry_cache_populator;
         }
-        if let Some(mock) = id.revision().and_then(|rev| revision_mocks.get(rev)) {
+        let cold_pnpr = self.scenario.is_some_and(BenchmarkScenario::cold_pnpr_cache);
+        let routes_to_mock = if cold_pnpr { id.is_pnpr() } else { id.revision().is_some() };
+        if routes_to_mock && let Some(mock) = id.revision().and_then(|rev| revision_mocks.get(rev))
+        {
             return &mock.url;
         }
         client_registry

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -532,10 +532,8 @@ impl WorkEnv {
         // the emulated registry link instead of bypassing it.
         let cold = self.scenario.is_some_and(BenchmarkScenario::cold_pnpr_cache);
         let process = if cold {
-            // Cold pnpr cache: the mock starts with empty, isolated storage
-            // (wiped between iterations) and proxies the warm shared mock as
-            // its origin, so each install refetches and streams every tarball
-            // through the proxy's cold download path.
+            // Empty, isolated storage (wiped between iterations) proxying the
+            // warm shared mock as origin, so every request is a cache miss.
             let cold_storage = bench_dir.join("cold-mock-storage");
             let config_path = bench_dir.join("cold-mock-config.yaml");
             fs::write(&config_path, cold_mock_config_yaml(&cold_storage, &self.registry))
@@ -1608,10 +1606,9 @@ fn write_pnpr_benchmark_config(
     path
 }
 
-/// A minimal verdaccio-shaped config for the cold pnpr mock: empty isolated
-/// `storage` and a single `**` proxy uplink pointing at the warm origin, so
-/// every request is a cache miss that refetches (and streams) from origin.
-/// Public reads need no auth, matching the bundled mock config.
+/// A minimal verdaccio-shaped config for the cold mock: isolated `storage` and
+/// a single `**` proxy uplink at the warm origin, with public reads needing no
+/// auth (matching the bundled mock config).
 fn cold_mock_config_yaml(storage: &Path, origin: &str) -> String {
     format!(
         "storage: {storage}\n\

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -423,9 +423,13 @@ impl WorkEnv {
         // store + cache (only present for `pnpr@<rev>` targets) — wiping it
         // upfront (but never per-iteration) makes the hyperfine warmup the
         // run that primes the server, so timed runs measure a warm
-        // long-running server even while the client is cold.
+        // long-running server even while the client is cold. `cold-mock-storage`
+        // (only the cold-pnpr scenario) is wiped here too so the warmup run
+        // starts cold even on a reused work-env, not just the timed iterations.
         for dir in self.benchmarked_ids().map(|id| self.bench_dir(id)) {
-            for name in ["node_modules", "store-dir", "cache-dir", "pnpr-storage"] {
+            for name in
+                ["node_modules", "store-dir", "cache-dir", "pnpr-storage", "cold-mock-storage"]
+            {
                 let path = dir.join(name);
                 if path.exists() {
                     remove_dir_all_with_retry(&path).expect("pre-benchmark wipe");
@@ -1610,6 +1614,12 @@ fn write_pnpr_benchmark_config(
 /// a single `**` proxy uplink at the warm origin, with public reads needing no
 /// auth (matching the bundled mock config).
 fn cold_mock_config_yaml(storage: &Path, origin: &str) -> String {
+    // JSON-encode the two interpolated scalars: a JSON string is a valid
+    // double-quoted YAML scalar, so a `#`, space, or other YAML-significant
+    // character in the path or URL can't break or alter the config.
+    let storage = serde_json::to_string(&storage.display().to_string())
+        .expect("encode cold mock storage path");
+    let origin = serde_json::to_string(origin).expect("encode cold mock origin url");
     format!(
         "storage: {storage}\n\
          uplinks:\n  \
@@ -1625,7 +1635,6 @@ fn cold_mock_config_yaml(storage: &Path, origin: &str) -> String {
            type: stdout\n  \
            format: pretty\n  \
            level: error\n",
-        storage = storage.display(),
     )
 }
 

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -834,14 +834,11 @@ impl WorkEnv {
     ///
     /// When a revision has its own tarball-serving mock (see
     /// [`Self::plan_revision_mocks`]), its `pacquet@<rev>` and `pnpr@<rev>`
-    /// targets fetch from that mock instead of the shared one.
-    ///
-    /// The cold-pnpr scenario is the exception: there the mock models a cold
-    /// *pnpr* cache, so only `pnpr@<rev>` targets route to it. A direct install
-    /// doesn't go through pnpr, so it keeps using the warm shared mock like
-    /// every other scenario — otherwise it would do a full cold fetch of every
-    /// packument and tarball through the cold mock, which is both wrong and
-    /// extremely noisy.
+    /// targets fetch from that mock instead of the shared one. In the cold-pnpr
+    /// scenario both arms therefore exercise the cold mock's serve path — the
+    /// direct arm hitting it as a cold pnpr *registry*, the pnpr arm through its
+    /// accelerator — and the frozen lockfile keeps that about tarball serving
+    /// rather than (noisy) cold resolution.
     fn registry_for<'a>(
         &'a self,
         id: BenchId,
@@ -851,10 +848,7 @@ impl WorkEnv {
         if id.is_proxy_cache_populator() {
             return &self.registry_cache_populator;
         }
-        let cold_pnpr = self.scenario.is_some_and(BenchmarkScenario::cold_pnpr_cache);
-        let routes_to_mock = if cold_pnpr { id.is_pnpr() } else { id.revision().is_some() };
-        if routes_to_mock && let Some(mock) = id.revision().and_then(|rev| revision_mocks.get(rev))
-        {
+        if let Some(mock) = id.revision().and_then(|rev| revision_mocks.get(rev)) {
             return &mock.url;
         }
         client_registry
@@ -1624,28 +1618,63 @@ fn write_pnpr_benchmark_config(
 /// a single `**` proxy uplink at the warm origin, with public reads needing no
 /// auth (matching the bundled mock config).
 fn cold_mock_config_yaml(storage: &Path, origin: &str) -> String {
-    // JSON-encode the two interpolated scalars: a JSON string is a valid
-    // double-quoted YAML scalar, so a `#`, space, or other YAML-significant
-    // character in the path or URL can't break or alter the config.
-    let storage = serde_json::to_string(&storage.display().to_string())
-        .expect("encode cold mock storage path");
-    let origin = serde_json::to_string(origin).expect("encode cold mock origin url");
-    format!(
-        "storage: {storage}\n\
-         uplinks:\n  \
-           npmjs:\n    \
-             url: {origin}\n\
-         packages:\n  \
-           '**':\n    \
-             access: $all\n    \
-             publish: $authenticated\n    \
-             unpublish: $authenticated\n    \
-             proxy: npmjs\n\
-         log:\n  \
-           type: stdout\n  \
-           format: pretty\n  \
-           level: error\n",
-    )
+    let config = ColdMockConfig {
+        storage: storage.display().to_string(),
+        uplinks: ColdMockUplinks { npmjs: ColdMockUplink { url: origin.to_string() } },
+        packages: ColdMockPackages {
+            all: ColdMockPackage {
+                access: "$all",
+                publish: "$authenticated",
+                unpublish: "$authenticated",
+                proxy: "npmjs",
+            },
+        },
+        log: ColdMockLog { kind: "stdout", format: "pretty", level: "error" },
+    };
+    serde_saphyr::to_string(&config).expect("serialize cold mock config")
+}
+
+/// A minimal verdaccio-shaped config for the cold mock, serialized rather than
+/// string-formatted so the `storage` path and `origin` URL are escaped and the
+/// structure can't drift.
+#[derive(Serialize)]
+struct ColdMockConfig {
+    storage: String,
+    uplinks: ColdMockUplinks,
+    packages: ColdMockPackages,
+    log: ColdMockLog,
+}
+
+#[derive(Serialize)]
+struct ColdMockUplinks {
+    npmjs: ColdMockUplink,
+}
+
+#[derive(Serialize)]
+struct ColdMockUplink {
+    url: String,
+}
+
+#[derive(Serialize)]
+struct ColdMockPackages {
+    #[serde(rename = "**")]
+    all: ColdMockPackage,
+}
+
+#[derive(Serialize)]
+struct ColdMockPackage {
+    access: &'static str,
+    publish: &'static str,
+    unpublish: &'static str,
+    proxy: &'static str,
+}
+
+#[derive(Serialize)]
+struct ColdMockLog {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    format: &'static str,
+    level: &'static str,
 }
 
 fn pnpr_benchmark_config_yaml(pnpr_storage: &Path, public_route_registries: &[&str]) -> String {

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -527,22 +527,50 @@ impl WorkEnv {
         let stderr = File::create(bench_dir.join("revision-mock.stderr.log"))
             .expect("create revision mock stderr log");
 
-        eprintln!(
-            "Serving {revision}'s tarballs from a mock built from pnpr@{revision} on 127.0.0.1:{mock_port}...",
-        );
         // The mock advertises its tarball URLs at the client-facing proxy
         // URL (`registry.url`), not its own loopback port, so downloads cross
         // the emulated registry link instead of bypassing it.
-        let process = pacquet_registry_mock::pnpr_command_with_binary(
-            &binary,
-            mock_port,
-            Some(&registry.url),
-        )
-        .stdin(Stdio::null())
-        .stdout(stdout)
-        .stderr(stderr)
-        .spawn()
-        .expect("spawn revision mock");
+        let cold = self.scenario.is_some_and(BenchmarkScenario::cold_pnpr_cache);
+        let process = if cold {
+            // Cold pnpr cache: the mock starts with empty, isolated storage
+            // (wiped between iterations) and proxies the warm shared mock as
+            // its origin, so each install refetches and streams every tarball
+            // through the proxy's cold download path.
+            let cold_storage = bench_dir.join("cold-mock-storage");
+            let config_path = bench_dir.join("cold-mock-config.yaml");
+            fs::write(&config_path, cold_mock_config_yaml(&cold_storage, &self.registry))
+                .expect("write cold mock config");
+            eprintln!(
+                "Serving {revision}'s tarballs from a COLD mock built from pnpr@{revision} on 127.0.0.1:{mock_port} (origin {})...",
+                self.registry,
+            );
+            Command::new(&binary)
+                .arg("--config")
+                .arg(&config_path)
+                .arg("--storage")
+                .arg(&cold_storage)
+                .arg("--listen")
+                .arg(format!("127.0.0.1:{mock_port}"))
+                .arg("--public-url")
+                .arg(&registry.url)
+                .arg("--packument-ttl-secs")
+                .arg("31536000")
+                .stdin(Stdio::null())
+                .stdout(stdout)
+                .stderr(stderr)
+                .spawn()
+                .expect("spawn cold revision mock")
+        } else {
+            eprintln!(
+                "Serving {revision}'s tarballs from a mock built from pnpr@{revision} on 127.0.0.1:{mock_port}...",
+            );
+            pacquet_registry_mock::pnpr_command_with_binary(&binary, mock_port, Some(&registry.url))
+                .stdin(Stdio::null())
+                .stdout(stdout)
+                .stderr(stderr)
+                .spawn()
+                .expect("spawn revision mock")
+        };
 
         let mut server = PnprServer { process, latency_proxy: None };
         wait_for_pnpr_ready(mock_port);
@@ -1578,6 +1606,30 @@ fn write_pnpr_benchmark_config(
     let yaml = pnpr_benchmark_config_yaml(pnpr_storage, public_route_registries);
     fs::write(&path, yaml).expect("write pnpr benchmark config");
     path
+}
+
+/// A minimal verdaccio-shaped config for the cold pnpr mock: empty isolated
+/// `storage` and a single `**` proxy uplink pointing at the warm origin, so
+/// every request is a cache miss that refetches (and streams) from origin.
+/// Public reads need no auth, matching the bundled mock config.
+fn cold_mock_config_yaml(storage: &Path, origin: &str) -> String {
+    format!(
+        "storage: {storage}\n\
+         uplinks:\n  \
+           npmjs:\n    \
+             url: {origin}\n\
+         packages:\n  \
+           '**':\n    \
+             access: $all\n    \
+             publish: $authenticated\n    \
+             unpublish: $authenticated\n    \
+             proxy: npmjs\n\
+         log:\n  \
+           type: stdout\n  \
+           format: pretty\n  \
+           level: error\n",
+        storage = storage.display(),
+    )
 }
 
 fn pnpr_benchmark_config_yaml(pnpr_storage: &Path, public_route_registries: &[&str]) -> String {

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1200,11 +1200,9 @@ async fn serve_tarball(
     };
 
     if upstream.caches() {
-        // Stream the download straight to the client while teeing it into the
-        // cache; the entry is promoted only if the full body matches
-        // `dist.integrity`, and the client re-verifies what it receives. This
-        // overlaps the upstream fetch with the client transfer instead of
-        // buffering the whole tarball at the server to verify it first.
+        // Stream the download to the client (see `stream_verified_to_cache`)
+        // rather than buffering the whole tarball at the server to verify it
+        // first, so the upstream fetch and the client transfer overlap.
         let upstream_len = response.content_length();
         match streaming::stream_verified_to_cache(response, write, &integrity, MAX_TARBALL_BYTES) {
             Ok(body) => tarball_response(body, upstream_len),

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1188,7 +1188,7 @@ async fn serve_tarball(
     let upstreams = resolve_upstreams(state, &name);
 
     // A cached tarball is verified against `dist.integrity` on the way in
-    // (`download_verified_to_cache`) and re-verified by the client on receipt,
+    // (`stream_verified_to_cache`) and re-verified by the client on receipt,
     // so a hit can be served without re-hashing.
     let resolved_dist =
         match screen_cached_tarball_osv(state, &name, &filename, &name_version).await {
@@ -1244,25 +1244,15 @@ async fn serve_tarball(
     };
 
     if upstream.caches() {
-        // Verify the freshly-downloaded bytes against `dist.integrity` as they
-        // are written to the cache. That write-time check (plus the install
-        // client's own verification) is why serving cached bytes later needs no
-        // re-hash.
-        if let Err(err) =
-            streaming::download_verified_to_cache(response, write, &integrity, MAX_TARBALL_BYTES)
-                .await
-        {
-            return error_response(&tarball_stream_error(err, &name, &filename));
-        }
-
-        match state.inner.storage.open_cached_tarball(&name, &filename).await {
-            Ok(Some((file, len))) => tarball_response(streaming::stream_file(file), Some(len)),
-            Ok(None) => error_response(&tarball_integrity_error(
-                &name,
-                &filename,
-                "verified cache entry disappeared before it could be served".to_string(),
-            )),
-            Err(err) => error_response(&err),
+        // Stream the download straight to the client while teeing it into the
+        // cache; the entry is promoted only if the full body matches
+        // `dist.integrity`, and the client re-verifies what it receives. This
+        // overlaps the upstream fetch with the client transfer instead of
+        // buffering the whole tarball at the server to verify it first.
+        let upstream_len = response.content_length();
+        match streaming::stream_verified_to_cache(response, write, &integrity, MAX_TARBALL_BYTES) {
+            Ok(body) => tarball_response(body, upstream_len),
+            Err(err) => error_response(&tarball_stream_error(err, &name, &filename)),
         }
     } else {
         match streaming::download_verified_to_temp(response, write, &integrity, MAX_TARBALL_BYTES)

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1094,10 +1094,11 @@ async fn serve_tarball_via_uplink(
     }
     // Stream the download to the client while teeing it into the namespaced
     // cache; the entry is promoted only on an SRI match (see
-    // `stream_verified_to_cache`).
-    let upstream_len = response.content_length();
+    // `stream_verified_to_cache`). No `Content-Length` is set: the upstream's
+    // is attacker-controlled and unverifiable before streaming, so the body is
+    // chunked and the client reads to EOF (then re-verifies the integrity).
     match streaming::stream_verified_to_cache(response, write, &integrity, MAX_TARBALL_BYTES) {
-        Ok(body) => tarball_response(body, upstream_len),
+        Ok(body) => tarball_response(body, None),
         Err(err) => error_response(&tarball_stream_error(err, &name, &filename)),
     }
 }
@@ -1202,10 +1203,12 @@ async fn serve_tarball(
     if upstream.caches() {
         // Stream the download to the client (see `stream_verified_to_cache`)
         // rather than buffering the whole tarball at the server to verify it
-        // first, so the upstream fetch and the client transfer overlap.
-        let upstream_len = response.content_length();
+        // first, so the upstream fetch and the client transfer overlap. No
+        // `Content-Length` is set: the upstream's is attacker-controlled and
+        // unverifiable before streaming, so the body is chunked and the client
+        // reads to EOF (then re-verifies the integrity).
         match streaming::stream_verified_to_cache(response, write, &integrity, MAX_TARBALL_BYTES) {
-            Ok(body) => tarball_response(body, upstream_len),
+            Ok(body) => tarball_response(body, None),
             Err(err) => error_response(&tarball_stream_error(err, &name, &filename)),
         }
     } else {

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -9,7 +9,7 @@ use crate::{
         PendingAttachment, extract_attachments, iso_from_unix_millis, merge_manifest, now_iso,
         stream_decode_verify_and_write,
     },
-    storage::{CachedPackument, CachedTarballIntegrity, Storage},
+    storage::{CachedPackument, Storage},
     streaming,
     upstream::{
         CacheValidators, FetchOutcome, FetchedPackument, PackumentFetch, Upstream,
@@ -1049,40 +1049,14 @@ async fn serve_tarball_via_uplink(
         return error_response(&err);
     }
 
-    // Serve a verified private-cache hit without touching the upstream. An
-    // uplink with `cache: false` skips the cache entirely and streams through.
+    // Serve a cached private-mirror hit directly: the bytes were verified
+    // against `dist.integrity` when written and the client re-verifies what it
+    // receives, so no re-hash is needed — the same trust model the public proxy
+    // path uses. A `cache: false` uplink skips the cache and streams through.
     if upstream.caches() {
         match state.inner.storage.open_uplink_tarball(&namespace, &name, &filename).await {
             Ok(Some((file, len))) => {
-                let expected = cached_tarball_integrity(&integrity, len);
-                if state
-                    .inner
-                    .storage
-                    .read_uplink_tarball_integrity(&namespace, &name, &filename)
-                    .await
-                    .is_some_and(|cached| cached == expected)
-                {
-                    return tarball_response(streaming::stream_file(file), Some(len));
-                }
-                match streaming::verify_file(file, &integrity).await {
-                    Ok(file) => {
-                        let _ = state
-                            .inner
-                            .storage
-                            .write_uplink_tarball_integrity(&namespace, &name, &filename, &expected)
-                            .await;
-                        return tarball_response(streaming::stream_file(file), Some(len));
-                    }
-                    Err(err) => {
-                        let err = tarball_stream_error(err, &name, &filename);
-                        tracing::warn!(?err, package = %name.as_str(), %filename, "cached uplink tarball failed verification");
-                        let _ = state
-                            .inner
-                            .storage
-                            .remove_uplink_tarball(&namespace, &name, &filename)
-                            .await;
-                    }
-                }
+                return tarball_response(streaming::stream_file(file), Some(len));
             }
             Ok(None) => {}
             Err(err) => {
@@ -1118,31 +1092,13 @@ async fn serve_tarball_via_uplink(
             Err(err) => error_response(&tarball_stream_error(err, &name, &filename)),
         };
     }
-    let len =
-        match streaming::download_verified_to_cache(response, write, &integrity, MAX_TARBALL_BYTES)
-            .await
-        {
-            Ok(len) => len,
-            Err(err) => return error_response(&tarball_stream_error(err, &name, &filename)),
-        };
-    let _ = state
-        .inner
-        .storage
-        .write_uplink_tarball_integrity(
-            &namespace,
-            &name,
-            &filename,
-            &cached_tarball_integrity(&integrity, len),
-        )
-        .await;
-    match state.inner.storage.open_uplink_tarball(&namespace, &name, &filename).await {
-        Ok(Some((file, len))) => tarball_response(streaming::stream_file(file), Some(len)),
-        Ok(None) => error_response(&tarball_integrity_error(
-            &name,
-            &filename,
-            "verified uplink cache entry disappeared before it could be served".to_string(),
-        )),
-        Err(err) => error_response(&err),
+    // Stream the download to the client while teeing it into the namespaced
+    // cache; the entry is promoted only on an SRI match (see
+    // `stream_verified_to_cache`).
+    let upstream_len = response.content_length();
+    match streaming::stream_verified_to_cache(response, write, &integrity, MAX_TARBALL_BYTES) {
+        Ok(body) => tarball_response(body, upstream_len),
+        Err(err) => error_response(&tarball_stream_error(err, &name, &filename)),
     }
 }
 
@@ -1399,10 +1355,6 @@ fn tarball_integrity_error(name: &PackageName, filename: &str, reason: String) -
         filename: filename.to_string(),
         reason,
     }
-}
-
-fn cached_tarball_integrity(integrity: &Integrity, len: u64) -> CachedTarballIntegrity {
-    CachedTarballIntegrity { integrity: integrity.to_string(), len }
 }
 
 /// Add a new user or log in an existing one. Mirrors verdaccio's

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -7,7 +7,6 @@ use crate::{
     upstream::{CacheValidators, ValidatorsByUplink},
 };
 use axum::body::Body;
-use serde::{Deserialize, Serialize};
 use std::{
     io::{ErrorKind, SeekFrom},
     path::{Path, PathBuf},
@@ -30,7 +29,6 @@ const PACKUMENT_FILE: &str = "package.json";
 /// revalidate against. The leading dot keeps it out of the
 /// package-listing walk and any static-serve view.
 const PACKUMENT_META_FILE: &str = ".package.json.meta";
-const TARBALL_INTEGRITY_SUFFIX: &str = ".integrity";
 
 /// Per-process counter feeding [`unique_tmp_path`] so two concurrent
 /// writes to the same path don't collide on the same temp filename.
@@ -160,12 +158,6 @@ impl Drop for TarballWrite {
 pub enum CachedPackument {
     Fresh(Vec<u8>),
     Stale(ValidatorsByUplink),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CachedTarballIntegrity {
-    pub integrity: String,
-    pub len: u64,
 }
 
 /// Verdaccio-shaped storage split into two stores with different
@@ -502,34 +494,6 @@ impl Storage {
         self.cached.namespaced(namespace).open_tarball(name, filename).await
     }
 
-    pub async fn read_uplink_tarball_integrity(
-        &self,
-        namespace: &str,
-        name: &PackageName,
-        filename: &str,
-    ) -> Option<CachedTarballIntegrity> {
-        self.cached.namespaced(namespace).read_tarball_integrity(name, filename).await
-    }
-
-    pub async fn write_uplink_tarball_integrity(
-        &self,
-        namespace: &str,
-        name: &PackageName,
-        filename: &str,
-        integrity: &CachedTarballIntegrity,
-    ) -> Result<()> {
-        self.cached.namespaced(namespace).write_tarball_integrity(name, filename, integrity).await
-    }
-
-    pub async fn remove_uplink_tarball(
-        &self,
-        namespace: &str,
-        name: &PackageName,
-        filename: &str,
-    ) -> Result<bool> {
-        self.cached.namespaced(namespace).remove_tarball(name, filename).await
-    }
-
     /// Promote a tmp tarball written by the publish flow to its final
     /// home: a rename on the fs backend, an upload on the S3 backend.
     pub async fn finalize_tarball_slot(&self, slot: TarballSlot) -> Result<()> {
@@ -672,27 +636,6 @@ impl Store {
         Ok(Some((file, len)))
     }
 
-    async fn read_tarball_integrity(
-        &self,
-        name: &PackageName,
-        filename: &str,
-    ) -> Option<CachedTarballIntegrity> {
-        match fs::read(self.tarball_integrity_path(name, filename)).await {
-            Ok(bytes) => serde_json::from_slice(&bytes).ok(),
-            Err(_) => None,
-        }
-    }
-
-    async fn write_tarball_integrity(
-        &self,
-        name: &PackageName,
-        filename: &str,
-        integrity: &CachedTarballIntegrity,
-    ) -> Result<()> {
-        write_atomic(&self.tarball_integrity_path(name, filename), &serde_json::to_vec(integrity)?)
-            .await
-    }
-
     async fn open_tarball_tmp(&self, name: &PackageName, filename: &str) -> Result<TarballWrite> {
         let final_path = self.tarball_path(name, filename);
         if let Some(parent) = final_path.parent() {
@@ -744,14 +687,7 @@ impl Store {
     /// after the packument-update PUT, and a benign 404 here would
     /// surface as a real error to the caller.
     async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
-        let path = self.tarball_path(name, filename);
-        let integrity_path = self.tarball_integrity_path(name, filename);
-        match fs::remove_file(&integrity_path).await {
-            Ok(()) => {}
-            Err(err) if err.kind() == ErrorKind::NotFound => {}
-            Err(err) => return Err(err.into()),
-        }
-        match fs::remove_file(&path).await {
+        match fs::remove_file(self.tarball_path(name, filename)).await {
             Ok(()) => Ok(true),
             Err(err) if err.kind() == ErrorKind::NotFound => Ok(false),
             Err(err) => Err(err.into()),
@@ -816,10 +752,6 @@ impl Store {
 
     fn tarball_path(&self, name: &PackageName, filename: &str) -> PathBuf {
         self.package_dir(name).join(filename)
-    }
-
-    fn tarball_integrity_path(&self, name: &PackageName, filename: &str) -> PathBuf {
-        self.package_dir(name).join(format!("{filename}{TARBALL_INTEGRITY_SUFFIX}"))
     }
 }
 

--- a/pnpr/crates/pnpr/src/streaming.rs
+++ b/pnpr/crates/pnpr/src/streaming.rs
@@ -77,7 +77,7 @@ pub fn stream_verified_to_cache(
     }
     let checker = integrity_checker(integrity).map_err(TarballStreamError::Integrity)?;
     let state = TeeState {
-        url: response.url().to_string(),
+        url: redact_url(response.url()),
         upstream: Box::pin(response.bytes_stream()),
         write: Some(write),
         checker,
@@ -155,6 +155,17 @@ async fn abandon(write: Option<TarballWrite>) {
     if let Some(write) = write {
         write.abandon().await;
     }
+}
+
+/// A log-safe form of the upstream URL: basic-auth userinfo and the query
+/// string (which can carry presigned-redirect tokens) are stripped, since this
+/// URL is only kept to tag failure logs.
+fn redact_url(url: &reqwest::Url) -> String {
+    let mut url = url.clone();
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    url.set_query(None);
+    url.to_string()
 }
 
 /// Carries the in-flight tee through [`stream::unfold`]: the upstream byte

--- a/pnpr/crates/pnpr/src/streaming.rs
+++ b/pnpr/crates/pnpr/src/streaming.rs
@@ -1,8 +1,7 @@
 //! Streaming helpers for the tarball path.
 //!
-//! Four flows live here:
+//! Three flows live here:
 //!
-//! * [`verify_file`] hashes a cache hit before it can be served.
 //! * [`stream_verified_to_cache`] streams an upstream response to the client
 //!   while teeing it into the cache, promoting the entry only if the SRI
 //!   matches the full body.
@@ -14,15 +13,8 @@ use crate::storage::TarballWrite;
 use axum::body::{Body, Bytes};
 use futures_util::{Stream, StreamExt, stream};
 use ssri::{Integrity, IntegrityChecker};
-use std::{
-    io::{self, SeekFrom},
-    path::PathBuf,
-    pin::Pin,
-};
-use tokio::{
-    fs::File,
-    io::{AsyncReadExt, AsyncSeekExt},
-};
+use std::{io, path::PathBuf, pin::Pin};
+use tokio::{fs::File, io::AsyncReadExt};
 
 /// Chunk size for reading from a cached file. 64 KiB keeps syscall
 /// overhead low without buffering a meaningful fraction of a
@@ -55,26 +47,6 @@ pub enum TarballStreamError {
     Io(io::Error),
     Integrity(ssri::Error),
     TooLarge { limit: u64, received: u64 },
-}
-
-/// Hash a cached file against `integrity`, then rewind the same open
-/// file so the caller can stream the exact bytes that were checked.
-pub async fn verify_file(
-    mut file: File,
-    integrity: &Integrity,
-) -> Result<File, TarballStreamError> {
-    let mut checker = integrity_checker(integrity).map_err(TarballStreamError::Integrity)?;
-    let mut buf = vec![0u8; READ_CHUNK];
-    loop {
-        let bytes_read = file.read(&mut buf).await.map_err(TarballStreamError::Io)?;
-        if bytes_read == 0 {
-            break;
-        }
-        checker.input(&buf[..bytes_read]);
-    }
-    checker.result().map_err(TarballStreamError::Integrity)?;
-    file.seek(SeekFrom::Start(0)).await.map_err(TarballStreamError::Io)?;
-    Ok(file)
 }
 
 /// Stream an upstream response to the client while teeing it into `write`
@@ -149,29 +121,6 @@ pub fn stream_verified_to_cache(
         }
     });
     Ok(Body::from_stream(body))
-}
-
-/// Download an upstream response into `write`, verify the complete body, and
-/// atomically promote it to the cache, returning the byte length. No bytes
-/// become cache-visible until the declared SRI matches. Used by the namespaced
-/// `/~<uplink>/` route, which records a length-keyed integrity sidecar and so
-/// needs the verified body buffered before it serves; the public proxy path
-/// streams instead (see [`stream_verified_to_cache`]).
-pub async fn download_verified_to_cache(
-    response: reqwest::Response,
-    mut write: TarballWrite,
-    integrity: &Integrity,
-    max_bytes: u64,
-) -> Result<u64, TarballStreamError> {
-    let len = match download_verified(response, &mut write, integrity, max_bytes).await {
-        Ok(len) => len,
-        Err(err) => {
-            write.abandon().await;
-            return Err(err);
-        }
-    };
-    write.finalize().await.map_err(TarballStreamError::Io)?;
-    Ok(len)
 }
 
 /// Promote a fully-streamed, SRI-matched tarball to the cache, logging (not

--- a/pnpr/crates/pnpr/src/streaming.rs
+++ b/pnpr/crates/pnpr/src/streaming.rs
@@ -68,8 +68,16 @@ pub fn stream_verified_to_cache(
     integrity: &Integrity,
     max_bytes: u64,
 ) -> Result<Body, TarballStreamError> {
+    // Reject an upstream that already declares an oversize body up front, so it
+    // surfaces as an error response instead of a failure mid-stream.
+    if let Some(received) = response.content_length()
+        && received > max_bytes
+    {
+        return Err(TarballStreamError::TooLarge { limit: max_bytes, received });
+    }
     let checker = integrity_checker(integrity).map_err(TarballStreamError::Integrity)?;
     let state = TeeState {
+        url: response.url().to_string(),
         upstream: Box::pin(response.bytes_stream()),
         write: Some(write),
         checker,
@@ -82,8 +90,14 @@ pub fn stream_verified_to_cache(
             Some(Ok(chunk)) => {
                 let received = state.written.saturating_add(chunk.len() as u64);
                 if received > state.max_bytes {
-                    abandon(state.write.take()).await;
                     let limit = state.max_bytes;
+                    tracing::warn!(
+                        url = %state.url,
+                        received,
+                        limit,
+                        "proxied tarball exceeded the size limit mid-stream",
+                    );
+                    abandon(state.write.take()).await;
                     return Some((
                         Err(io::Error::other(format!("tarball exceeds {limit} bytes"))),
                         None,
@@ -108,13 +122,17 @@ pub fn stream_verified_to_cache(
                 Some((Ok(chunk), Some(state)))
             }
             Some(Err(source)) => {
+                tracing::warn!(url = %state.url, ?source, "upstream tarball stream failed mid-download");
                 abandon(state.write.take()).await;
                 Some((Err(io::Error::other(source)), None))
             }
             None => {
                 match state.checker.result() {
                     Ok(_) => finalize(state.write.take()).await,
-                    Err(_) => abandon(state.write.take()).await,
+                    Err(err) => {
+                        tracing::warn!(url = %state.url, ?err, "proxied tarball failed integrity; not caching it");
+                        abandon(state.write.take()).await;
+                    }
                 }
                 None
             }
@@ -143,6 +161,8 @@ async fn abandon(write: Option<TarballWrite>) {
 /// stream, the cache writer (dropped once caching is abandoned), the running
 /// SRI checker, and the size budget.
 struct TeeState {
+    /// The upstream tarball URL, kept only to tag failure logs.
+    url: String,
     upstream: Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>> + Send>>,
     write: Option<TarballWrite>,
     checker: IntegrityChecker,

--- a/pnpr/crates/pnpr/src/streaming.rs
+++ b/pnpr/crates/pnpr/src/streaming.rs
@@ -3,19 +3,21 @@
 //! Four flows live here:
 //!
 //! * [`verify_file`] hashes a cache hit before it can be served.
-//! * [`download_verified_to_cache`] hashes an upstream response into a
-//!   temp file and promotes it only after the declared SRI matches.
+//! * [`stream_verified_to_cache`] streams an upstream response to the client
+//!   while teeing it into the cache, promoting the entry only if the SRI
+//!   matches the full body.
 //! * [`download_verified_to_temp`] hashes an upstream response into a
 //!   temp file for mirror-less pass-through.
 //! * [`stream_file`] yields an already verified file to the response.
 
 use crate::storage::TarballWrite;
 use axum::body::{Body, Bytes};
-use futures_util::{StreamExt, stream};
+use futures_util::{Stream, StreamExt, stream};
 use ssri::{Integrity, IntegrityChecker};
 use std::{
     io::{self, SeekFrom},
     path::PathBuf,
+    pin::Pin,
 };
 use tokio::{
     fs::File,
@@ -75,9 +77,86 @@ pub async fn verify_file(
     Ok(file)
 }
 
-/// Download an upstream response into `write`, verify the complete body,
-/// and atomically promote it to the cache. No bytes become cache-visible
-/// until the declared SRI matches.
+/// Stream an upstream response to the client while teeing it into `write`
+/// and hashing it. The client receives bytes as they arrive — it does not
+/// wait for the whole download to land and verify first — and the cache entry
+/// is promoted only once the declared SRI matches the full body.
+///
+/// SRI can only be checked after the last byte, by which point the body has
+/// already been streamed, so a mismatch can't be turned into an error
+/// response. The guarantees that remain are the ones that matter: a
+/// mismatched (or truncated, or oversize) body is never promoted to the cache,
+/// so it can't poison a future client, and every install client re-verifies
+/// what it received against its own expected integrity and rejects bad bytes.
+/// On any such failure — or a dropped client connection — the temp file is
+/// abandoned (and [`TarballWrite`]'s `Drop` removes it as a backstop).
+pub fn stream_verified_to_cache(
+    response: reqwest::Response,
+    write: TarballWrite,
+    integrity: &Integrity,
+    max_bytes: u64,
+) -> Result<Body, TarballStreamError> {
+    let checker = integrity_checker(integrity).map_err(TarballStreamError::Integrity)?;
+    let state = TeeState {
+        upstream: Box::pin(response.bytes_stream()),
+        write: Some(write),
+        checker,
+        written: 0,
+        max_bytes,
+    };
+    let body = stream::unfold(Some(state), |state| async move {
+        let mut state = state?;
+        match state.upstream.next().await {
+            Some(Ok(chunk)) => {
+                let received = state.written.saturating_add(chunk.len() as u64);
+                if received > state.max_bytes {
+                    abandon(state.write.take()).await;
+                    let limit = state.max_bytes;
+                    return Some((
+                        Err(io::Error::other(format!("tarball exceeds {limit} bytes"))),
+                        None,
+                    ));
+                }
+                if let Some(mut write) = state.write.take() {
+                    // The cache is best-effort: if the temp write fails, stop
+                    // caching but keep streaming to the client.
+                    match write.write_all(&chunk).await {
+                        Ok(()) => state.write = Some(write),
+                        Err(err) => {
+                            tracing::warn!(
+                                ?err,
+                                "tarball cache write failed; serving without caching",
+                            );
+                            write.abandon().await;
+                        }
+                    }
+                }
+                state.checker.input(&chunk);
+                state.written = received;
+                Some((Ok(chunk), Some(state)))
+            }
+            Some(Err(source)) => {
+                abandon(state.write.take()).await;
+                Some((Err(io::Error::other(source)), None))
+            }
+            None => {
+                match state.checker.result() {
+                    Ok(_) => finalize(state.write.take()).await,
+                    Err(_) => abandon(state.write.take()).await,
+                }
+                None
+            }
+        }
+    });
+    Ok(Body::from_stream(body))
+}
+
+/// Download an upstream response into `write`, verify the complete body, and
+/// atomically promote it to the cache, returning the byte length. No bytes
+/// become cache-visible until the declared SRI matches. Used by the namespaced
+/// `/~<uplink>/` route, which records a length-keyed integrity sidecar and so
+/// needs the verified body buffered before it serves; the public proxy path
+/// streams instead (see [`stream_verified_to_cache`]).
 pub async fn download_verified_to_cache(
     response: reqwest::Response,
     mut write: TarballWrite,
@@ -93,6 +172,33 @@ pub async fn download_verified_to_cache(
     };
     write.finalize().await.map_err(TarballStreamError::Io)?;
     Ok(len)
+}
+
+/// Promote a fully-streamed, SRI-matched tarball to the cache, logging (not
+/// failing — the client already has the bytes) if the rename can't complete.
+async fn finalize(write: Option<TarballWrite>) {
+    if let Some(write) = write
+        && let Err(err) = write.finalize().await
+    {
+        tracing::warn!(?err, "promoting verified tarball to cache failed");
+    }
+}
+
+async fn abandon(write: Option<TarballWrite>) {
+    if let Some(write) = write {
+        write.abandon().await;
+    }
+}
+
+/// Carries the in-flight tee through [`stream::unfold`]: the upstream byte
+/// stream, the cache writer (dropped once caching is abandoned), the running
+/// SRI checker, and the size budget.
+struct TeeState {
+    upstream: Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>> + Send>>,
+    write: Option<TarballWrite>,
+    checker: IntegrityChecker,
+    written: u64,
+    max_bytes: u64,
 }
 
 pub async fn download_verified_to_temp(

--- a/pnpr/crates/pnpr/src/streaming/tests.rs
+++ b/pnpr/crates/pnpr/src/streaming/tests.rs
@@ -1,5 +1,6 @@
-use super::{TarballStreamError, download_verified_to_cache, integrity_checker, parse_integrity};
+use super::{integrity_checker, parse_integrity, stream_verified_to_cache};
 use crate::{config::HostedStoreConfig, package_name::PackageName, storage::Storage};
+use futures_util::StreamExt;
 use ssri::{Algorithm, Integrity, IntegrityOpts};
 use std::{path::Path, sync::Arc, time::Duration};
 use tempfile::TempDir;
@@ -131,15 +132,17 @@ async fn cancelling_in_flight_response_body_removes_tmp_file() {
     let name = PackageName::parse("foo").unwrap();
     let write = storage.open_cached_tarball_tmp(&name, "foo-1.0.0.tgz").await.unwrap();
 
-    let download = tokio::spawn(async move {
-        download_verified_to_cache(response, write, &integrity, u64::MAX).await
-    });
+    let body = stream_verified_to_cache(response, write, &integrity, u64::MAX).unwrap();
+    let mut chunks = body.into_data_stream();
+    // Pull the first chunk so the tee writes the body's start to the tmp file.
+    chunks.next().await.expect("first chunk").expect("first chunk is ok");
     let package_dir = cache.join("foo");
     let in_flight = await_nonempty_tarball_tmp(&package_dir).await;
     assert_eq!(in_flight.len(), 1, "expected one in-flight tarball writer");
 
-    download.abort();
-    assert!(download.await.unwrap_err().is_cancelled());
+    // Dropping the body mid-stream models a client disconnect: the tee's
+    // `TarballWrite` is dropped and removes the tmp file.
+    drop(chunks);
     assert!(tarball_tmp_entries(&package_dir).is_empty());
     assert!(!package_dir.join("foo-1.0.0.tgz").exists());
 
@@ -159,9 +162,11 @@ async fn oversized_response_is_rejected_and_tmp_is_removed() {
     let name = PackageName::parse("foo").unwrap();
     let write = storage.open_cached_tarball_tmp(&name, "foo-1.0.0.tgz").await.unwrap();
 
-    let err = download_verified_to_cache(response, write, &integrity, 3).await.unwrap_err();
-    assert!(matches!(err, TarballStreamError::TooLarge { limit: 3, received } if received > 3));
+    let body = stream_verified_to_cache(response, write, &integrity, 3).unwrap();
+    // The body errors once the stream exceeds the 3-byte budget...
+    assert!(axum::body::to_bytes(body, usize::MAX).await.is_err());
 
+    // ...and the partial download is never promoted to the cache.
     let package_dir = cache.join("foo");
     assert!(tarball_tmp_entries(&package_dir).is_empty());
     assert!(!package_dir.join("foo-1.0.0.tgz").exists());

--- a/pnpr/crates/pnpr/src/streaming/tests.rs
+++ b/pnpr/crates/pnpr/src/streaming/tests.rs
@@ -1,4 +1,4 @@
-use super::{integrity_checker, parse_integrity, stream_verified_to_cache};
+use super::{TarballStreamError, integrity_checker, parse_integrity, stream_verified_to_cache};
 use crate::{config::HostedStoreConfig, package_name::PackageName, storage::Storage};
 use futures_util::StreamExt;
 use ssri::{Algorithm, Integrity, IntegrityOpts};
@@ -162,11 +162,12 @@ async fn oversized_response_is_rejected_and_tmp_is_removed() {
     let name = PackageName::parse("foo").unwrap();
     let write = storage.open_cached_tarball_tmp(&name, "foo-1.0.0.tgz").await.unwrap();
 
-    let body = stream_verified_to_cache(response, write, &integrity, 3).unwrap();
-    // The body errors once the stream exceeds the 3-byte budget...
-    assert!(axum::body::to_bytes(body, usize::MAX).await.is_err());
+    // An upstream that declares an oversize body is rejected up front, before
+    // any bytes stream, so the caller turns it into an error response.
+    let err = stream_verified_to_cache(response, write, &integrity, 3).unwrap_err();
+    assert!(matches!(err, TarballStreamError::TooLarge { limit: 3, received } if received > 3));
 
-    // ...and the partial download is never promoted to the cache.
+    // The temp file the rejected writer held is removed (its `Drop`).
     let package_dir = cache.join("foo");
     assert!(tarball_tmp_entries(&package_dir).is_empty());
     assert!(!package_dir.join("foo-1.0.0.tgz").exists());

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -1425,7 +1425,7 @@ async fn tarball_route_preserves_basename_and_binds_to_declaring_version() {
 }
 
 #[tokio::test]
-async fn tampered_upstream_tarball_is_rejected_and_not_cached() {
+async fn tampered_upstream_tarball_is_served_but_never_cached() {
     let mut upstream = mockito::Server::new_async().await;
     let good_bytes = b"good-tarball-bytes";
     let poison_bytes = b"poisoned-cache-bytes";
@@ -1468,10 +1468,9 @@ async fn tampered_upstream_tarball_is_rejected_and_not_cached() {
     let cache_path = storage.join(".pnpr-cache").join("poisoned").join("poisoned-1.0.0.tgz");
 
     // Upstream serves bytes that don't match the version's `dist.integrity`.
-    // Verification happens as the bytes are written to the cache, so the
-    // poisoned tarball is rejected and never lands in the cache. (Serving from
-    // the cache later is trusted precisely because nothing unverified is ever
-    // written to it.)
+    // They are streamed to the client (which re-verifies and rejects them),
+    // but the SRI mismatch on the full body means they are never promoted to
+    // the cache — so they can't poison a later request.
     let app = router(config_for(&upstream.url(), storage.clone()));
     let packument_response =
         app.clone().oneshot(Request::get("/poisoned").body(Body::empty()).unwrap()).await.unwrap();
@@ -1481,7 +1480,10 @@ async fn tampered_upstream_tarball_is_rejected_and_not_cached() {
         .oneshot(Request::get("/poisoned/-/poisoned-1.0.0.tgz").body(Body::empty()).unwrap())
         .await
         .unwrap();
-    assert_eq!(tarball_response.status(), StatusCode::BAD_GATEWAY);
+    assert_eq!(tarball_response.status(), StatusCode::OK);
+    // Draining the body runs the end-of-stream SRI check, which abandons the
+    // cache temp on the mismatch.
+    assert_eq!(body_bytes(tarball_response.into_body()).await, poison_bytes);
     assert!(!cache_path.exists(), "unverified tarball must not be written to the cache");
 
     let cached_response = router(config_for("http://127.0.0.1:1", storage))
@@ -2179,15 +2181,20 @@ async fn upstream_stream_error_clears_cache() {
         .oneshot(Request::get("/foo/-/foo-1.0.0.tgz").body(Body::empty()).unwrap())
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    // The status line is sent before the upstream truncation is known, so the
+    // failure surfaces as a body error mid-stream rather than a status code.
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        axum::body::to_bytes(response.into_body(), usize::MAX).await.is_err(),
+        "a truncated upstream body must surface as a body error",
+    );
 
-    // The incomplete body is rejected before a response or cache entry
-    // can expose its bytes.
+    // The incomplete body is never promoted to the cache.
     assert!(await_no_tgz(&cache_dir.join(".pnpr-cache").join("foo"), Duration::from_secs(1)).await);
 }
 
 #[tokio::test]
-async fn verified_tarball_is_cached_before_response_is_served() {
+async fn proxied_tarball_streams_to_client_and_is_cached() {
     let mut upstream = mockito::Server::new_async().await;
     let bytes = vec![0xEE_u8; 512 * 1024];
     let _packument_mock = mock_packument_for_tarball(&mut upstream, "big", "1.0.0", &bytes).await;
@@ -2207,10 +2214,10 @@ async fn verified_tarball_is_cached_before_response_is_served() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
+    // The client receives the body as it streams; draining it runs the
+    // end-of-stream SRI check that promotes the verified bytes to the cache.
+    assert_eq!(body_bytes(response.into_body()).await, bytes);
 
-    // The response is not constructed until the complete upstream body
-    // has passed verification and cache finalization.
-    drop(response);
     let cache_path = cache_dir.join(".pnpr-cache").join("big").join("big-1.0.0.tgz");
     assert_eq!(std::fs::read(cache_path).unwrap(), bytes);
 }


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#12709. That PR fixed the **warm**-cache serve path; this one fixes the **cold** pnpr cache and adds the benchmark scenario that exercises it.

This is primarily a **correctness / architecture fix**, not a headline perf win (see the Benchmark result below). On a cache miss the proxy used to download the whole tarball into the cache, verify its SRI, and only then open the finished file to stream it — a head-of-line stall on every cold fetch: the client waited for the full upstream fetch **plus** a verify pass before receiving a single byte, with no overlap between the upstream fetch and the client transfer. Buffer-then-verify is simply the wrong model for a streaming proxy.

### What changed

- **Stream proxied tarballs while verifying** (`stream_verified_to_cache`). The upstream response is streamed straight to the client while it's teed into the cache temp and hashed; the cache entry is promoted only once the full body matches `dist.integrity`. The upstream fetch and the client transfer now overlap.

  SRI can only be checked after the last byte — by which point the body is already on the wire — so a bad upstream tarball can no longer be turned into a `BAD_GATEWAY`. The guarantees that remain are the ones that matter: a mismatched / truncated / oversize body is **never promoted to the cache** (so it can't poison a later client), and every install client re-verifies what it receives against its own expected integrity and rejects bad bytes. A dropped client connection abandons the temp (with `TarballWrite::Drop` as a backstop). This is the same trust model #12709 established for the cached-serve path.

- **Converge the namespaced `/~<uplink>/` route onto the same model.** The expected integrity comes from the packument in both cases — neither route downloads a tarball to *learn* it — so the namespaced route's "verify-before-serve" (re-hash cache hits behind a `{integrity, len}` sidecar, buffer downloads) bought nothing the public path doesn't get from streaming + client re-verification. It now serves hits directly and streams downloads too, and the dead `*_uplink_tarball_integrity` sidecar machinery (`CachedTarballIntegrity`, `.integrity` files, `verify_file`, `download_verified_to_cache`) is removed.

- **Don't forward the upstream `Content-Length`.** A streamed proxy response no longer asserts the upstream's `Content-Length` (which is attacker-controlled and unverifiable before the body streams); the body is chunked and the client reads to EOF, then re-verifies. The upstream length is still used internally only for the early oversize rejection.

- **Add a cold-pnpr-cache benchmark scenario** (`isolated-linker.fresh-restore.cold-cache.cold-store.cold-pnpr`). Every existing scenario warms the mock, so its serves are all cache hits — none exercised the cold download/serve path, meaning the streaming fix wouldn't move any current benchmark. The new scenario gives the per-revision tarball-serving mock empty, isolated storage (wiped each iteration) proxying the warm shared mock as a fast local origin, so each install refetches and streams every tarball through the proxy's cold path. It runs **frozen** (`--frozen-lockfile`, hence `fresh-restore`) so cold-resolution variance doesn't drown the serve-path delta. Wired into CI and both Bencher testbeds.

### Benchmark result

Honest, latest CI run (commit `b9d4aa8cfc`, 10 runs each, 50 ms link / 200 Mbit cap) for the cold-pnpr scenario:

| Target | Mean | σ |
|---|---|---|
| **pnpr@HEAD** (streaming) | **5.215 s** | ±0.087 |
| pnpr@main (buffer-then-verify) | 5.319 s | ±0.152 |

`pnpr@HEAD ran 1.02 ± 0.03 times faster than pnpr@main` — a ~2% improvement that sits **within the noise band**. That's expected: this fixture is many *small* tarballs over a latency-dominated link, the worst case for showing the win, since the overlap streaming buys scales with tarball size. The number is the floor, not the ceiling; HEAD is never slower than main on any arm, and `pnpr@HEAD` posted the tightest variance of the four. The merge case rests on the architecture/security fixes above, with the benchmark confirming **no regression** rather than claiming a large speedup.

### Out of scope

A packument with no usable `dist.integrity` (legacy shasum-only or absent) still can't be served on either route — that needs a fetch-to-compute and is tracked in pnpm/pnpm#12727.

pnpr-only (Rust registry server); no TypeScript / pacquet CLI surface, so nothing to mirror and no changeset.

## Squash Commit Body

```text
On a cache miss the proxy buffered the whole tarball into the cache, verified
its SRI, and only then streamed the finished file — a head-of-line stall on
every cold fetch: the client waited for the full upstream fetch plus a verify
pass before the first byte, with no overlap. Buffer-then-verify is the wrong
model for a streaming proxy.

Stream the upstream response to the client while teeing it into the cache and
hashing it (stream_verified_to_cache); promote the cache entry only once the
full body matches dist.integrity. A mismatched/truncated/oversize body is never
cached and the client re-verifies what it receives, so a bad upstream tarball
can't poison a later client — it just can't be turned into a BAD_GATEWAY, since
SRI is only known after the body is already streamed.

Converge the namespaced /~<uplink>/ route onto the same model (the integrity is
known from the packument either way), removing the now-dead uplink integrity
sidecar machinery. Stop forwarding the upstream Content-Length on streamed
responses (attacker-controlled, unverifiable before streaming; kept only for
the internal early oversize check). Add a cold-pnpr-cache benchmark scenario
that actually exercises the cold download/serve path (every other scenario
warms the mock); it runs frozen so resolution variance doesn't mask the
serve-path delta.

The measured speedup on that scenario is modest and within noise (this fixture
is small tarballs over a latency-bound link); the change is a correctness fix,
and the benchmark confirms no regression.

Out of scope: packuments with no usable dist.integrity (pnpm/pnpm#12727).
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. *(pnpr-only; no CLI surface to mirror.)*
- [x] Added or updated tests. *(streaming success/tampered/truncated/oversize/cancel coverage; namespaced behavior; new benchmark scenario.)*

---
Written by an agent (Claude Code, claude-opus-4-8).
