### PR TITLE
feat(pacquet-cli): add pacquet sbom command

### DIFF
--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -42,6 +42,7 @@ pub mod root;
 pub mod run;
 pub mod runtime;
 pub mod sanitize;
+pub mod sbom;
 pub mod self_update;
 pub mod set_script;
 pub mod setup;

--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -39,6 +39,7 @@ use super::{
     root::RootArgs,
     run::RunArgs,
     runtime::RuntimeArgs,
+    sbom::SbomArgs,
     self_update::SelfUpdateArgs,
     set_script::SetScriptArgs,
     setup::SetupArgs,
@@ -150,6 +151,8 @@ pub enum CliCommand {
     Ll(ListArgs),
     /// Shows the packages that depend on `pkg`
     Why(WhyArgs),
+    /// Generate a Software Bill of Materials (SBOM).
+    Sbom(SbomArgs),
     /// Displays your pnpm username.
     Whoami,
     /// Manage a package's distribution tags.

--- a/pacquet/crates/cli/src/cli_args/dispatch.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch.rs
@@ -234,6 +234,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::List(args) => dispatch_query::list(ctx, args),
         CliCommand::Ll(args) => dispatch_query::ll(ctx, args),
         CliCommand::Why(args) => dispatch_query::why(ctx, args),
+        CliCommand::Sbom(args) => dispatch_query::sbom(ctx, args),
         CliCommand::Whoami => dispatch_query::whoami(ctx),
         CliCommand::DistTag(args) => dispatch_query::dist_tag(ctx, args),
         CliCommand::Ping(args) => dispatch_query::ping(ctx, args),

--- a/pacquet/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_query.rs
@@ -19,6 +19,7 @@ use super::{
     repo::RepoArgs,
     reporter::ReporterType,
     root::RootArgs,
+    sbom::SbomArgs,
     self_update::SelfUpdateArgs,
     setup::SetupArgs,
     store::StoreCommand,
@@ -98,6 +99,10 @@ pub(super) fn ll<'a>(ctx: &RunCtx<'a>, mut args: ListArgs) -> miette::Result<Com
 }
 
 pub(super) fn why<'a>(ctx: &RunCtx<'a>, args: WhyArgs) -> miette::Result<CommandFuture<'a>> {
+    Ok(Box::pin(args.run((ctx.state)(true)?)))
+}
+
+pub(super) fn sbom<'a>(ctx: &RunCtx<'a>, args: SbomArgs) -> miette::Result<CommandFuture<'a>> {
     Ok(Box::pin(args.run((ctx.state)(true)?)))
 }
 

--- a/pacquet/crates/cli/src/cli_args/sbom.rs
+++ b/pacquet/crates/cli/src/cli_args/sbom.rs
@@ -160,6 +160,18 @@ fn extract_repository(manifest: &serde_json::Value) -> Option<String> {
     repo.get("url").and_then(|u| u.as_str()).map(ToString::to_string)
 }
 
+fn strip_url_credentials(url: &str) -> String {
+    if let Some(after_scheme) = url.find("://") {
+        let scheme = &url[..after_scheme + 3];
+        let rest = &url[after_scheme + 3..];
+        if let Some(at_pos) = rest.find('@') {
+            let after_host_start = &rest[at_pos + 1..];
+            return format!("{scheme}{after_host_start}");
+        }
+    }
+    url.to_string()
+}
+
 fn extract_bugs_url(manifest: &serde_json::Value) -> Option<String> {
     let bugs = manifest.get("bugs")?;
     let url = if let Some(s) = bugs.as_str() {
@@ -167,7 +179,10 @@ fn extract_bugs_url(manifest: &serde_json::Value) -> Option<String> {
     } else {
         bugs.get("url")?.as_str()?.to_string()
     };
-    (url.starts_with("http://") || url.starts_with("https://")).then_some(url)
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return None;
+    }
+    Some(strip_url_credentials(&url))
 }
 
 fn extract_homepage(manifest: &serde_json::Value) -> Option<String> {
@@ -206,12 +221,19 @@ fn build_purl(name: &str, version: &str) -> String {
     format!("pkg:npm/{}@{}", encode_purl_name(name), version)
 }
 
+fn is_simple_spdx_id(license: &str) -> bool {
+    !license.is_empty()
+        && license.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.' || c == '+')
+}
+
 fn classify_license(license: &str) -> serde_json::Value {
     let is_expression = license.split_whitespace().any(|w| w == "AND" || w == "OR" || w == "WITH");
     if is_expression {
         serde_json::json!({ "expression": license })
-    } else {
+    } else if is_simple_spdx_id(license) {
         serde_json::json!({ "license": { "id": license } })
+    } else {
+        serde_json::json!({ "license": { "name": license } })
     }
 }
 

--- a/pacquet/crates/cli/src/cli_args/sbom.rs
+++ b/pacquet/crates/cli/src/cli_args/sbom.rs
@@ -3,15 +3,11 @@
 //! Ports pnpm's
 //! [`sbom` command](https://github.com/pnpm/pnpm/blob/2b4952e804/pnpm11/deps/compliance/commands/src/sbom/sbom.ts).
 
-use crate::State;
 use clap::Args;
-use pacquet_lockfile::{
-    LockfileResolution, PackageKey, PackageMetadata, PkgName, PkgNameVerPeer, SnapshotEntry,
-};
+use crate::State;
+use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, PkgName, PkgNameVerPeer, SnapshotEntry};
 use pacquet_package_manifest::safe_read_package_json_from_dir;
-use std::collections::{HashMap, HashSet};
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::{collections::{HashMap, HashSet}, io::Write, path::{Path, PathBuf}};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum SbomFormat {
@@ -223,11 +219,11 @@ fn build_purl(name: &str, version: &str) -> String {
 
 fn is_simple_spdx_id(license: &str) -> bool {
     !license.is_empty()
-        && license.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.' || c == '+')
+        && license.chars().all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '.' || ch == '+')
 }
 
 fn classify_license(license: &str) -> serde_json::Value {
-    let is_expression = license.split_whitespace().any(|w| w == "AND" || w == "OR" || w == "WITH");
+    let is_expression = license.split_whitespace().any(|word| word == "AND" || word == "OR" || word == "WITH");
     if is_expression {
         serde_json::json!({ "expression": license })
     } else if is_simple_spdx_id(license) {
@@ -666,7 +662,7 @@ impl SbomArgs {
             if !["1.5", "1.6", "1.7"].contains(&spec_ver.as_str()) {
                 return Err(miette::miette!(
                     code = "ERR_PNPM_SBOM_INVALID_SPEC_VERSION",
-                    "Invalid CycloneDX spec version \"{spec_ver}\". Supported versions: 1.5, 1.6, 1.7."
+                    r#"Invalid CycloneDX spec version "{spec_ver}". Supported versions: 1.5, 1.6, 1.7."#
                 ));
             }
         }
@@ -675,7 +671,7 @@ impl SbomArgs {
         let authors: Vec<String> = self
             .authors
             .as_deref()
-            .map(|s| s.split(',').map(|a| a.trim().to_string()).filter(|a| !a.is_empty()).collect())
+            .map(|csv| csv.split(',').map(|author| author.trim().to_string()).filter(|author| !author.is_empty()).collect())
             .unwrap_or_default();
 
         let lockfile = state
@@ -761,7 +757,7 @@ impl SbomArgs {
                     if written_paths.contains(&file_path) {
                         return Err(miette::miette!(
                             code = "ERR_PNPM_SBOM_OUT_PATH_COLLISION",
-                            "Multiple workspace packages resolve to the same output path \"{file_path}\". Include %v in the --out pattern to disambiguate."
+                            r#"Multiple workspace packages resolve to the same output path "{file_path}". Include %v in the --out pattern to disambiguate."#
                         ));
                     }
                     written_paths.insert(file_path.clone());
@@ -909,51 +905,51 @@ fn serialize_cyclonedx(opts: &CycloneDxOpts<'_>) -> String {
     let components: Vec<serde_json::Value> = result
         .components
         .iter()
-        .map(|c| {
-            let (group, name) = split_scoped_name(&c.name);
+        .map(|component| {
+            let (group, name) = split_scoped_name(&component.name);
             let mut comp = serde_json::json!({
                 "type": "library",
                 "name": name,
-                "version": c.version,
-                "purl": c.purl,
-                "bom-ref": c.purl,
+                "version": component.version,
+                "purl": component.purl,
+                "bom-ref": component.purl,
             });
             if let Some(group) = group {
                 comp["group"] = serde_json::Value::String(group.to_string());
             }
-            if c.dep_type == DepType::DevOnly {
+            if component.dep_type == DepType::DevOnly {
                 comp["scope"] = serde_json::Value::String("excluded".to_string());
                 comp["properties"] = serde_json::json!([
                     { "name": "cdx:npm:package:development", "value": "true" }
                 ]);
             }
-            if let Some(ref desc) = c.description {
+            if let Some(ref desc) = component.description {
                 comp["description"] = serde_json::Value::String(desc.clone());
             }
-            if let Some(ref author) = c.author {
+            if let Some(ref author) = component.author {
                 comp["authors"] = serde_json::json!([{ "name": author }]);
             }
-            if let Some(ref license) = c.license {
+            if let Some(ref license) = component.license {
                 comp["licenses"] = serde_json::json!([classify_license(license)]);
             }
 
             let mut ext_refs: Vec<serde_json::Value> = Vec::new();
-            if let Some(ref tarball) = c.tarball_url {
+            if let Some(ref tarball) = component.tarball_url {
                 let mut dist_ref = serde_json::json!({ "type": "distribution", "url": tarball });
-                if let Some(ref integrity) = c.integrity
+                if let Some(ref integrity) = component.integrity
                     && let Some(hashes) = integrity_to_hashes(integrity)
                 {
                     dist_ref["hashes"] = serde_json::Value::Array(hashes);
                 }
                 ext_refs.push(dist_ref);
             }
-            if let Some(ref hp) = c.homepage {
+            if let Some(ref hp) = component.homepage {
                 ext_refs.push(serde_json::json!({ "type": "website", "url": hp }));
             }
-            if let Some(ref repo) = c.repository {
+            if let Some(ref repo) = component.repository {
                 ext_refs.push(serde_json::json!({ "type": "vcs", "url": repo }));
             }
-            if let Some(ref bugs) = c.bugs_url {
+            if let Some(ref bugs) = component.bugs_url {
                 ext_refs.push(serde_json::json!({ "type": "issue-tracker", "url": bugs }));
             }
             if !ext_refs.is_empty() {
@@ -1031,7 +1027,7 @@ fn serialize_cyclonedx(opts: &CycloneDxOpts<'_>) -> String {
 fn sanitize_spdx_id(value: &str) -> String {
     value
         .chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '.' || c == '-' { c } else { '-' })
+        .map(|ch| if ch.is_ascii_alphanumeric() || ch == '.' || ch == '-' { ch } else { '-' })
         .collect()
 }
 
@@ -1217,38 +1213,38 @@ fn generate_uuid_v4() -> String {
     use std::collections::hash_map::RandomState;
     use std::hash::{BuildHasher, Hasher};
     let state = RandomState::new();
-    let mut h = state.build_hasher();
-    h.write_u64(
+    let mut hasher = state.build_hasher();
+    hasher.write_u64(
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_nanos() as u64,
     );
-    let a = h.finish();
-    let mut h2 = state.build_hasher();
-    h2.write_u64(!a);
-    let b = h2.finish();
+    let half_a = hasher.finish();
+    let mut hasher2 = state.build_hasher();
+    hasher2.write_u64(!half_a);
+    let half_b = hasher2.finish();
     let mut bytes = [0u8; 16];
-    bytes[..8].copy_from_slice(&a.to_le_bytes());
-    bytes[8..].copy_from_slice(&b.to_le_bytes());
+    bytes[..8].copy_from_slice(&half_a.to_le_bytes());
+    bytes[8..].copy_from_slice(&half_b.to_le_bytes());
     bytes[6] = (bytes[6] & 0x0f) | 0x40;
     bytes[8] = (bytes[8] & 0x3f) | 0x80;
     use std::fmt::Write;
-    let mut s = String::with_capacity(36);
+    let mut uuid = String::with_capacity(36);
     for (i, byte) in bytes.iter().enumerate() {
         if matches!(i, 4 | 6 | 8 | 10) {
-            s.push('-');
+            uuid.push('-');
         }
-        let _ = write!(s, "{byte:02x}");
+        let _ = write!(uuid, "{byte:02x}");
     }
-    s
+    uuid
 }
 
 fn normalize_link_path(base_importer_id: &str, link_target: &str) -> Option<String> {
     let mut parts: Vec<&str> = if base_importer_id == "." {
         Vec::new()
     } else {
-        base_importer_id.split('/').filter(|s| !s.is_empty()).collect()
+        base_importer_id.split('/').filter(|segment| !segment.is_empty()).collect()
     };
     for segment in link_target.split('/') {
         match segment {
@@ -1269,13 +1265,13 @@ fn sanitize_package_name(name: &str) -> String {
 fn sanitize_path_segment(value: &str) -> String {
     let sanitized: String = value
         .chars()
-        .map(|c| {
-            if matches!(c, '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|')
-                || c.is_ascii_control()
+        .map(|ch| {
+            if matches!(ch, '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|')
+                || ch.is_ascii_control()
             {
                 '-'
             } else {
-                c
+                ch
             }
         })
         .collect();

--- a/pacquet/crates/cli/src/cli_args/sbom.rs
+++ b/pacquet/crates/cli/src/cli_args/sbom.rs
@@ -3,11 +3,17 @@
 //! Ports pnpm's
 //! [`sbom` command](https://github.com/pnpm/pnpm/blob/2b4952e804/pnpm11/deps/compliance/commands/src/sbom/sbom.ts).
 
-use clap::Args;
 use crate::State;
-use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, PkgName, PkgNameVerPeer, SnapshotEntry};
+use clap::Args;
+use pacquet_lockfile::{
+    LockfileResolution, PackageKey, PackageMetadata, PkgName, PkgNameVerPeer, SnapshotEntry,
+};
 use pacquet_package_manifest::safe_read_package_json_from_dir;
-use std::{collections::{HashMap, HashSet}, io::Write, path::{Path, PathBuf}};
+use std::{
+    collections::{HashMap, HashSet},
+    io::Write,
+    path::{Path, PathBuf},
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum SbomFormat {
@@ -219,11 +225,14 @@ fn build_purl(name: &str, version: &str) -> String {
 
 fn is_simple_spdx_id(license: &str) -> bool {
     !license.is_empty()
-        && license.chars().all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '.' || ch == '+')
+        && license
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '.' || ch == '+')
 }
 
 fn classify_license(license: &str) -> serde_json::Value {
-    let is_expression = license.split_whitespace().any(|word| word == "AND" || word == "OR" || word == "WITH");
+    let is_expression =
+        license.split_whitespace().any(|word| word == "AND" || word == "OR" || word == "WITH");
     if is_expression {
         serde_json::json!({ "expression": license })
     } else if is_simple_spdx_id(license) {
@@ -671,7 +680,12 @@ impl SbomArgs {
         let authors: Vec<String> = self
             .authors
             .as_deref()
-            .map(|csv| csv.split(',').map(|author| author.trim().to_string()).filter(|author| !author.is_empty()).collect())
+            .map(|csv| {
+                csv.split(',')
+                    .map(|author| author.trim().to_string())
+                    .filter(|author| !author.is_empty())
+                    .collect()
+            })
             .unwrap_or_default();
 
         let lockfile = state

--- a/pacquet/crates/cli/src/cli_args/sbom.rs
+++ b/pacquet/crates/cli/src/cli_args/sbom.rs
@@ -1174,7 +1174,7 @@ fn serialize_spdx(result: &SbomResult, compact: bool) -> String {
 fn integrity_to_hashes(integrity: &str) -> Option<Vec<serde_json::Value>> {
     let mut hashes = Vec::new();
     for part in integrity.split_whitespace() {
-        let (alg, hash) = part.split_once('-')?;
+        let Some((alg, hash)) = part.split_once('-') else { continue };
         let cdx_alg = match alg {
             "sha1" => "SHA-1",
             "sha256" => "SHA-256",
@@ -1195,7 +1195,7 @@ fn integrity_to_hashes(integrity: &str) -> Option<Vec<serde_json::Value>> {
 fn integrity_to_spdx_checksums(integrity: &str) -> Option<Vec<serde_json::Value>> {
     let mut checksums = Vec::new();
     for part in integrity.split_whitespace() {
-        let (alg, hash) = part.split_once('-')?;
+        let Some((alg, hash)) = part.split_once('-') else { continue };
         let spdx_alg = match alg {
             "sha1" => "SHA1",
             "sha256" => "SHA256",

--- a/pacquet/crates/cli/src/cli_args/sbom.rs
+++ b/pacquet/crates/cli/src/cli_args/sbom.rs
@@ -1,0 +1,1327 @@
+//! `pacquet sbom` — generate a Software Bill of Materials.
+//!
+//! Ports pnpm's
+//! [`sbom` command](https://github.com/pnpm/pnpm/blob/2b4952e804/pnpm11/deps/compliance/commands/src/sbom/sbom.ts).
+
+use crate::State;
+use clap::Args;
+use pacquet_lockfile::{
+    LockfileResolution, PackageKey, PackageMetadata, PkgName, PkgNameVerPeer, SnapshotEntry,
+};
+use pacquet_package_manifest::safe_read_package_json_from_dir;
+use std::collections::{HashMap, HashSet};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum SbomFormat {
+    #[clap(name = "cyclonedx")]
+    CycloneDx,
+    #[clap(name = "spdx")]
+    Spdx,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum SbomComponentType {
+    Library,
+    Application,
+}
+
+#[derive(Debug, Args)]
+pub struct SbomArgs {
+    /// The SBOM output format (required).
+    #[clap(long = "sbom-format", value_enum)]
+    pub format: SbomFormat,
+
+    /// The component type for the root package (default: library).
+    #[clap(long = "sbom-type", value_enum, default_value = "library")]
+    pub sbom_type: SbomComponentType,
+
+    /// The `CycloneDX` specification version (`1.5`, `1.6`, or `1.7`; default: `1.7`).
+    /// Only valid with `--sbom-format cyclonedx`.
+    #[clap(long = "sbom-spec-version")]
+    pub spec_version: Option<String>,
+
+    /// Only use lockfile data (skip reading from the store).
+    #[clap(long)]
+    pub lockfile_only: bool,
+
+    /// Comma-separated list of SBOM authors (`CycloneDX` `metadata.authors`).
+    #[clap(long = "sbom-authors")]
+    pub authors: Option<String>,
+
+    /// SBOM supplier name (`CycloneDX` `metadata.supplier`).
+    #[clap(long = "sbom-supplier")]
+    pub supplier: Option<String>,
+
+    /// Only include production dependencies.
+    #[clap(long, short = 'P')]
+    pub prod: bool,
+
+    /// Only include dev dependencies.
+    #[clap(long, short = 'D')]
+    pub dev: bool,
+
+    /// Exclude optional dependencies.
+    #[clap(long = "no-optional")]
+    pub no_optional: bool,
+
+    /// Exclude peer dependencies.
+    #[clap(long = "exclude-peers")]
+    pub exclude_peers: bool,
+
+    /// Write SBOM to a file instead of stdout. Use `%s` for the
+    /// package name and `%v` for the version.
+    #[clap(long)]
+    pub out: Option<String>,
+
+    /// Generate a separate SBOM for each matched workspace package.
+    #[clap(long)]
+    pub split: bool,
+}
+
+struct IncludeFilter {
+    dependencies: bool,
+    dev_dependencies: bool,
+    optional_dependencies: bool,
+}
+
+impl SbomArgs {
+    fn include_filter(&self) -> IncludeFilter {
+        IncludeFilter {
+            dependencies: !self.dev,
+            dev_dependencies: !self.prod,
+            optional_dependencies: !self.prod && !self.no_optional,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DepType {
+    DevOnly,
+    ProdOnly,
+}
+
+struct SbomComponent {
+    name: String,
+    version: String,
+    purl: String,
+    dep_type: DepType,
+    integrity: Option<String>,
+    tarball_url: Option<String>,
+    license: Option<String>,
+    description: Option<String>,
+    author: Option<String>,
+    homepage: Option<String>,
+    repository: Option<String>,
+    bugs_url: Option<String>,
+}
+
+struct WalkContext<'a> {
+    snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
+    packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
+    dep_types: &'a HashMap<PackageKey, DepType>,
+    default_registry: &'a str,
+    virtual_store_dir: Option<PathBuf>,
+    virtual_store_dir_max_length: usize,
+}
+
+struct SbomRelationship {
+    from: String,
+    to: String,
+}
+
+struct SbomResult {
+    root_name: String,
+    root_version: String,
+    root_type: SbomComponentType,
+    root_license: Option<String>,
+    root_description: Option<String>,
+    root_author: Option<String>,
+    root_repository: Option<String>,
+    root_bugs_url: Option<String>,
+    components: Vec<SbomComponent>,
+    relationships: Vec<SbomRelationship>,
+}
+
+fn extract_author(manifest: &serde_json::Value) -> Option<String> {
+    let author = manifest.get("author")?;
+    if let Some(s) = author.as_str() {
+        return Some(s.to_string());
+    }
+    author.get("name").and_then(|n| n.as_str()).map(ToString::to_string)
+}
+
+fn extract_repository(manifest: &serde_json::Value) -> Option<String> {
+    let repo = manifest.get("repository")?;
+    if let Some(s) = repo.as_str() {
+        return Some(s.to_string());
+    }
+    repo.get("url").and_then(|u| u.as_str()).map(ToString::to_string)
+}
+
+fn extract_bugs_url(manifest: &serde_json::Value) -> Option<String> {
+    let bugs = manifest.get("bugs")?;
+    let url = if let Some(s) = bugs.as_str() {
+        s.to_string()
+    } else {
+        bugs.get("url")?.as_str()?.to_string()
+    };
+    (url.starts_with("http://") || url.starts_with("https://")).then_some(url)
+}
+
+fn extract_homepage(manifest: &serde_json::Value) -> Option<String> {
+    manifest.get("homepage").and_then(|v| v.as_str()).map(ToString::to_string)
+}
+
+fn registry_tarball_url(registry: &str, name: &str, version: &str) -> String {
+    let registry = registry.trim_end_matches('/');
+    let basename = name.rsplit('/').next().unwrap_or(name);
+    format!("{registry}/{name}/-/{basename}-{version}.tgz")
+}
+
+fn tarball_url_for_component(
+    resolution: &LockfileResolution,
+    name: &str,
+    version: &str,
+    registry: &str,
+) -> Option<String> {
+    match resolution {
+        LockfileResolution::Registry(_) => Some(registry_tarball_url(registry, name, version)),
+        LockfileResolution::Tarball(r) => Some(r.tarball.clone()),
+        LockfileResolution::Git(r) => {
+            let needs_prefix = r.repo.contains("://") && !r.repo.starts_with("git+");
+            let prefix = if needs_prefix { "git+" } else { "" };
+            Some(format!("{prefix}{}#{}", r.repo, r.commit))
+        }
+        _ => None,
+    }
+}
+
+fn encode_purl_name(name: &str) -> String {
+    if let Some(rest) = name.strip_prefix('@') { format!("%40{rest}") } else { name.to_string() }
+}
+
+fn build_purl(name: &str, version: &str) -> String {
+    format!("pkg:npm/{}@{}", encode_purl_name(name), version)
+}
+
+fn classify_license(license: &str) -> serde_json::Value {
+    let is_expression = license.split_whitespace().any(|w| w == "AND" || w == "OR" || w == "WITH");
+    if is_expression {
+        serde_json::json!({ "expression": license })
+    } else {
+        serde_json::json!({ "license": { "id": license } })
+    }
+}
+
+#[allow(dead_code)]
+fn percent_encode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for b in input.bytes() {
+        if b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.' || b == b'~' {
+            out.push(b as char);
+        } else {
+            use std::fmt::Write;
+            let _ = write!(out, "%{b:02X}");
+        }
+    }
+    out
+}
+
+#[allow(dead_code)]
+fn build_purl_with_qualifier(name: &str, version: &str, non_semver: Option<&str>) -> String {
+    if let Some(raw) = non_semver {
+        format!(
+            "pkg:npm/{}@{}?vcs_url={}",
+            encode_purl_name(name),
+            percent_encode(version),
+            percent_encode(raw),
+        )
+    } else {
+        build_purl(name, version)
+    }
+}
+
+fn integrity_string(resolution: &LockfileResolution) -> Option<String> {
+    match resolution {
+        LockfileResolution::Registry(r) => Some(r.integrity.to_string()),
+        LockfileResolution::Tarball(r) => r.integrity.as_ref().map(ToString::to_string),
+        _ => None,
+    }
+}
+
+fn peer_names_from_manifest(manifest: &serde_json::Value) -> HashSet<String> {
+    let regular: HashSet<&str> = ["dependencies", "devDependencies", "optionalDependencies"]
+        .iter()
+        .flat_map(|field| {
+            manifest
+                .get(field)
+                .and_then(|v| v.as_object())
+                .into_iter()
+                .flat_map(|obj| obj.keys().map(String::as_str))
+        })
+        .collect();
+
+    manifest
+        .get("peerDependencies")
+        .and_then(|v| v.as_object())
+        .into_iter()
+        .flat_map(|obj| obj.keys())
+        .filter(|name| !regular.contains(name.as_str()))
+        .cloned()
+        .collect()
+}
+
+fn detect_dep_types(lockfile: &pacquet_lockfile::Lockfile) -> HashMap<PackageKey, DepType> {
+    let snapshots = lockfile.snapshots.as_ref();
+    let mut dep_types: HashMap<PackageKey, DepType> = HashMap::new();
+    let mut walked: HashSet<(PackageKey, bool)> = HashSet::new();
+
+    let mut dev_keys: Vec<PackageKey> = Vec::new();
+    let mut prod_keys: Vec<PackageKey> = Vec::new();
+
+    for importer in lockfile.importers.values() {
+        if let Some(deps) = &importer.dev_dependencies {
+            for (name, spec) in deps {
+                if let Some(key) = spec.version.resolved_key(name) {
+                    dev_keys.push(key);
+                }
+            }
+        }
+        for deps in [&importer.dependencies, &importer.optional_dependencies].into_iter().flatten()
+        {
+            for (name, spec) in deps {
+                if let Some(key) = spec.version.resolved_key(name) {
+                    prod_keys.push(key);
+                }
+            }
+        }
+    }
+
+    detect_dep_types_walk(snapshots, &mut dep_types, &mut walked, &dev_keys, true);
+    detect_dep_types_walk(snapshots, &mut dep_types, &mut walked, &prod_keys, false);
+    dep_types
+}
+
+fn detect_dep_types_walk(
+    snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
+    dep_types: &mut HashMap<PackageKey, DepType>,
+    walked: &mut HashSet<(PackageKey, bool)>,
+    initial_keys: &[PackageKey],
+    is_dev: bool,
+) {
+    let mut queue: Vec<PackageKey> = initial_keys.to_vec();
+
+    while let Some(key) = queue.pop() {
+        let walk_key = (key.clone(), is_dev);
+        if walked.contains(&walk_key) {
+            continue;
+        }
+        walked.insert(walk_key);
+
+        if is_dev {
+            dep_types.entry(key.clone()).or_insert(DepType::DevOnly);
+        } else if dep_types.get(&key) == Some(&DepType::DevOnly) {
+            dep_types.insert(key.clone(), DepType::ProdOnly);
+        } else {
+            dep_types.entry(key.clone()).or_insert(DepType::ProdOnly);
+        }
+
+        let Some(snapshot) = snapshots.and_then(|s| s.get(&key)) else {
+            continue;
+        };
+
+        for (alias, dep_ref) in snapshot
+            .dependencies
+            .iter()
+            .flatten()
+            .chain(snapshot.optional_dependencies.iter().flatten())
+        {
+            if let Some(child_key) = dep_ref.resolve(alias) {
+                queue.push(child_key);
+            }
+        }
+    }
+}
+
+fn collect_components(
+    state: &State,
+    include: &IncludeFilter,
+    sbom_type: SbomComponentType,
+    exclude_peers: bool,
+    lockfile_only: bool,
+    filter_importer_ids: Option<&[&str]>,
+) -> miette::Result<SbomResult> {
+    let lockfile = state
+        .lockfile
+        .get()
+        .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
+
+    let Some(lockfile) = lockfile else {
+        return Err(miette::miette!(
+            code = "ERR_PNPM_SBOM_NO_LOCKFILE",
+            "No pnpm-lock.yaml found: cannot generate SBOM without a lockfile"
+        ));
+    };
+
+    let project_root_dir =
+        state.manifest.path().parent().unwrap_or_else(|| Path::new(".")).to_path_buf();
+
+    let manifest_value = match filter_importer_ids {
+        Some(&[single_id]) if single_id != "." => {
+            let importer_dir = project_root_dir.join(single_id);
+            safe_read_package_json_from_dir(&importer_dir)
+                .ok()
+                .flatten()
+                .unwrap_or_else(|| state.manifest.value().clone())
+        }
+        _ => state.manifest.value().clone(),
+    };
+    let root_name =
+        manifest_value.get("name").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
+    let root_version =
+        manifest_value.get("version").and_then(|v| v.as_str()).unwrap_or("0.0.0").to_string();
+    let root_license =
+        manifest_value.get("license").and_then(|v| v.as_str()).map(ToString::to_string);
+    let root_description =
+        manifest_value.get("description").and_then(|v| v.as_str()).map(ToString::to_string);
+    let root_author = extract_author(&manifest_value);
+    let root_repository = extract_repository(&manifest_value);
+    let root_bugs_url = extract_bugs_url(&manifest_value);
+
+    let root_purl = build_purl(&root_name, &root_version);
+
+    let dep_types = detect_dep_types(lockfile);
+
+    let virtual_store_dir = (!lockfile_only).then(|| project_root_dir.join("node_modules/.pnpm"));
+
+    let ctx = WalkContext {
+        snapshots: lockfile.snapshots.as_ref(),
+        packages: lockfile.packages.as_ref(),
+        dep_types: &dep_types,
+        default_registry: &state.config.registry,
+        virtual_store_dir,
+        virtual_store_dir_max_length: state.config.virtual_store_dir_max_length as usize,
+    };
+
+    let mut components_map: HashMap<String, SbomComponent> = HashMap::new();
+    let mut relationships: Vec<SbomRelationship> = Vec::new();
+    let mut visited: HashSet<PackageKey> = HashSet::new();
+    let mut ws_purl_by_importer: HashMap<String, String> = HashMap::new();
+
+    let initial_importer_ids: Vec<String> = lockfile
+        .importers
+        .keys()
+        .filter(|id| filter_importer_ids.is_none_or(|ids| ids.contains(&id.as_str())))
+        .cloned()
+        .collect();
+
+    let mut importer_queue: Vec<String> = initial_importer_ids;
+    let mut visited_importers: HashSet<String> = HashSet::new();
+
+    while let Some(importer_id) = importer_queue.pop() {
+        if !visited_importers.insert(importer_id.clone()) {
+            continue;
+        }
+        let Some(importer) = lockfile.importers.get(importer_id.as_str()) else {
+            continue;
+        };
+
+        let parent_purl =
+            ws_purl_by_importer.get(&importer_id).cloned().unwrap_or_else(|| root_purl.clone());
+
+        let importer_peer_names = if exclude_peers {
+            let importer_dir = if importer_id == "." {
+                project_root_dir.clone()
+            } else {
+                project_root_dir.join(&importer_id)
+            };
+            safe_read_package_json_from_dir(&importer_dir)
+                .ok()
+                .flatten()
+                .map(|m| peer_names_from_manifest(&m))
+                .unwrap_or_default()
+        } else {
+            HashSet::new()
+        };
+
+        let dep_maps: Vec<&HashMap<PkgName, _>> = [
+            include.dependencies.then_some(importer.dependencies.as_ref()).flatten(),
+            include.dev_dependencies.then_some(importer.dev_dependencies.as_ref()).flatten(),
+            include
+                .optional_dependencies
+                .then_some(importer.optional_dependencies.as_ref())
+                .flatten(),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+
+        for deps in dep_maps {
+            for (name, spec) in deps {
+                if !importer_peer_names.is_empty()
+                    && importer_peer_names.contains(&name.to_string())
+                {
+                    continue;
+                }
+                if let Some(link_target) = spec.version.as_link_target() {
+                    if let Some(target_id) = normalize_link_path(&importer_id, link_target)
+                        && lockfile.importers.contains_key(target_id.as_str())
+                    {
+                        let ws_dir = if target_id == "." {
+                            project_root_dir.clone()
+                        } else {
+                            project_root_dir.join(&target_id)
+                        };
+                        if let Ok(Some(ws_manifest)) = safe_read_package_json_from_dir(&ws_dir) {
+                            let ws_name = ws_manifest
+                                .get("name")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or(&name.to_string())
+                                .to_string();
+                            let ws_version = ws_manifest
+                                .get("version")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("0.0.0")
+                                .to_string();
+                            let ws_purl = build_purl(&ws_name, &ws_version);
+                            relationships.push(SbomRelationship {
+                                from: parent_purl.clone(),
+                                to: ws_purl.clone(),
+                            });
+                            if !components_map.contains_key(&ws_purl) {
+                                components_map.insert(
+                                    ws_purl.clone(),
+                                    SbomComponent {
+                                        name: ws_name,
+                                        version: ws_version,
+                                        purl: ws_purl.clone(),
+                                        dep_type: DepType::ProdOnly,
+                                        integrity: None,
+                                        tarball_url: None,
+                                        license: ws_manifest
+                                            .get("license")
+                                            .and_then(|v| v.as_str())
+                                            .map(ToString::to_string),
+                                        description: ws_manifest
+                                            .get("description")
+                                            .and_then(|v| v.as_str())
+                                            .map(ToString::to_string),
+                                        author: extract_author(&ws_manifest),
+                                        homepage: extract_homepage(&ws_manifest),
+                                        repository: extract_repository(&ws_manifest),
+                                        bugs_url: extract_bugs_url(&ws_manifest),
+                                    },
+                                );
+                            }
+                            ws_purl_by_importer.insert(target_id.clone(), ws_purl);
+                            importer_queue.push(target_id);
+                        }
+                    }
+                } else if let Some(snapshot_key) = spec.version.resolved_key(name) {
+                    walk_snapshot(
+                        &snapshot_key,
+                        &parent_purl,
+                        &ctx,
+                        &mut components_map,
+                        &mut relationships,
+                        &mut visited,
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(SbomResult {
+        root_name,
+        root_version,
+        root_type: sbom_type,
+        root_license,
+        root_description,
+        root_author,
+        root_repository,
+        root_bugs_url,
+        components: components_map.into_values().collect(),
+        relationships,
+    })
+}
+
+struct PkgMetadata {
+    license: Option<String>,
+    description: Option<String>,
+    author: Option<String>,
+    homepage: Option<String>,
+    repository: Option<String>,
+    bugs_url: Option<String>,
+}
+
+fn read_pkg_metadata_from_store(
+    key: &PkgNameVerPeer,
+    pkg_name: &str,
+    ctx: &WalkContext<'_>,
+) -> PkgMetadata {
+    let empty = PkgMetadata {
+        license: None,
+        description: None,
+        author: None,
+        homepage: None,
+        repository: None,
+        bugs_url: None,
+    };
+    let Some(ref vs_dir) = ctx.virtual_store_dir else {
+        return empty;
+    };
+    let store_name = key.to_virtual_store_name(ctx.virtual_store_dir_max_length);
+    let pkg_dir = vs_dir.join(&store_name).join("node_modules").join(pkg_name);
+    let Ok(Some(manifest)) = safe_read_package_json_from_dir(&pkg_dir) else {
+        return empty;
+    };
+    PkgMetadata {
+        license: manifest.get("license").and_then(|v| v.as_str()).map(ToString::to_string),
+        description: manifest.get("description").and_then(|v| v.as_str()).map(ToString::to_string),
+        author: extract_author(&manifest),
+        homepage: extract_homepage(&manifest),
+        repository: extract_repository(&manifest),
+        bugs_url: extract_bugs_url(&manifest),
+    }
+}
+
+fn walk_snapshot(
+    initial_key: &PkgNameVerPeer,
+    initial_parent_purl: &str,
+    ctx: &WalkContext<'_>,
+    components_map: &mut HashMap<String, SbomComponent>,
+    relationships: &mut Vec<SbomRelationship>,
+    visited: &mut HashSet<PackageKey>,
+) {
+    let mut queue: Vec<(PkgNameVerPeer, String)> =
+        vec![(initial_key.clone(), initial_parent_purl.to_string())];
+
+    while let Some((key, parent_purl)) = queue.pop() {
+        let name = key.name.to_string();
+        let version = ctx
+            .packages
+            .and_then(|pkgs| pkgs.get(&key.without_peer()))
+            .and_then(|meta| meta.version.clone())
+            .unwrap_or_else(|| key.suffix.version().to_string());
+
+        let purl = build_purl(&name, &version);
+
+        relationships.push(SbomRelationship { from: parent_purl, to: purl.clone() });
+
+        if !visited.insert(key.clone()) {
+            continue;
+        }
+
+        if !components_map.contains_key(&purl) {
+            let pkg_meta = ctx.packages.and_then(|pkgs| pkgs.get(&key.without_peer()));
+            let integrity = pkg_meta.and_then(|meta| integrity_string(&meta.resolution));
+            let tarball_url = pkg_meta.and_then(|meta| {
+                tarball_url_for_component(&meta.resolution, &name, &version, ctx.default_registry)
+            });
+
+            let store_meta = read_pkg_metadata_from_store(&key, &name, ctx);
+            let dep_type = ctx.dep_types.get(&key).copied().unwrap_or(DepType::ProdOnly);
+
+            components_map.insert(
+                purl.clone(),
+                SbomComponent {
+                    name,
+                    version,
+                    purl: purl.clone(),
+                    dep_type,
+                    integrity,
+                    tarball_url,
+                    license: store_meta.license,
+                    description: store_meta.description,
+                    author: store_meta.author,
+                    homepage: store_meta.homepage,
+                    repository: store_meta.repository,
+                    bugs_url: store_meta.bugs_url,
+                },
+            );
+        }
+
+        let Some(snapshot) = ctx.snapshots.and_then(|s| s.get(&key)) else {
+            continue;
+        };
+
+        for (alias, dep_ref) in snapshot
+            .dependencies
+            .iter()
+            .flatten()
+            .chain(snapshot.optional_dependencies.iter().flatten())
+        {
+            if let Some(child_key) = dep_ref.resolve(alias) {
+                queue.push((child_key, purl.clone()));
+            }
+        }
+    }
+}
+
+impl SbomArgs {
+    pub async fn run(self, state: State) -> miette::Result<()> {
+        if let Some(ref spec_ver) = self.spec_version {
+            if self.format != SbomFormat::CycloneDx {
+                return Err(miette::miette!(
+                    code = "ERR_PNPM_SBOM_SPEC_VERSION_UNSUPPORTED_FORMAT",
+                    "The --sbom-spec-version option is only supported with --sbom-format cyclonedx."
+                ));
+            }
+            if !["1.5", "1.6", "1.7"].contains(&spec_ver.as_str()) {
+                return Err(miette::miette!(
+                    code = "ERR_PNPM_SBOM_INVALID_SPEC_VERSION",
+                    "Invalid CycloneDX spec version \"{spec_ver}\". Supported versions: 1.5, 1.6, 1.7."
+                ));
+            }
+        }
+
+        let include = self.include_filter();
+        let project_root =
+            state.manifest.path().parent().unwrap_or_else(|| Path::new(".")).to_path_buf();
+        let authors: Vec<String> = self
+            .authors
+            .as_deref()
+            .map(|s| s.split(',').map(|a| a.trim().to_string()).filter(|a| !a.is_empty()).collect())
+            .unwrap_or_default();
+
+        let lockfile = state
+            .lockfile
+            .get()
+            .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
+        let all_importer_ids: Vec<String> =
+            lockfile.as_ref().map(|lf| lf.importers.keys().cloned().collect()).unwrap_or_default();
+
+        let importer_ids = if state.config.filter.is_empty() {
+            all_importer_ids
+        } else {
+            let project_root = state.manifest.path().parent().unwrap_or_else(|| Path::new("."));
+            all_importer_ids
+                .into_iter()
+                .filter(|id| {
+                    let importer_dir = if id == "." {
+                        project_root.to_string_lossy().to_string()
+                    } else {
+                        project_root.join(id).to_string_lossy().to_string()
+                    };
+                    state.config.filter.iter().any(|f| {
+                        let pattern = f.strip_prefix("./").unwrap_or(f);
+                        id == pattern
+                            || id.starts_with(&format!("{pattern}/"))
+                            || importer_dir.ends_with(pattern)
+                    })
+                })
+                .collect()
+        };
+
+        let should_split = self.split
+            || (self.out.as_ref().is_some_and(|o| o.contains("%s")) && importer_ids.len() > 1);
+
+        if should_split {
+            if let Some(ref out) = self.out
+                && !out.contains("%s")
+            {
+                return Err(miette::miette!(
+                    code = "ERR_PNPM_SBOM_OUT_MISSING_PLACEHOLDER",
+                    "When using --split with --out, the path must contain %s as a placeholder for the package name."
+                ));
+            }
+
+            let compact = self.out.is_none();
+            let mut ndjson_lines: Vec<String> = Vec::new();
+            let mut files: Vec<String> = Vec::new();
+            let mut written_paths: HashSet<String> = HashSet::new();
+
+            for importer_id in &importer_ids {
+                let filter = [importer_id.as_str()];
+                let result = collect_components(
+                    &state,
+                    &include,
+                    self.sbom_type,
+                    self.exclude_peers,
+                    self.lockfile_only,
+                    Some(&filter),
+                )?;
+                if result.root_name == "unknown" {
+                    continue;
+                }
+
+                let output = match self.format {
+                    SbomFormat::CycloneDx => serialize_cyclonedx(&CycloneDxOpts {
+                        result: &result,
+                        spec_version: self.spec_version.as_deref(),
+                        lockfile_only: self.lockfile_only,
+                        authors: &authors,
+                        supplier: self.supplier.as_deref(),
+                        compact,
+                    }),
+                    SbomFormat::Spdx => serialize_spdx(&result, compact),
+                };
+
+                if let Some(ref out_template) = self.out {
+                    let sanitized_name =
+                        sanitize_path_segment(&sanitize_package_name(&result.root_name));
+                    let sanitized_ver = sanitize_path_segment(&result.root_version);
+                    let file_path =
+                        out_template.replace("%s", &sanitized_name).replace("%v", &sanitized_ver);
+                    if written_paths.contains(&file_path) {
+                        return Err(miette::miette!(
+                            code = "ERR_PNPM_SBOM_OUT_PATH_COLLISION",
+                            "Multiple workspace packages resolve to the same output path \"{file_path}\". Include %v in the --out pattern to disambiguate."
+                        ));
+                    }
+                    written_paths.insert(file_path.clone());
+                    let path = std::path::Path::new(&file_path);
+                    assert_inside_project(path, &project_root)?;
+                    if let Some(parent) = path.parent() {
+                        std::fs::create_dir_all(parent).map_err(|err| {
+                            miette::miette!("create directory for {file_path}: {err}")
+                        })?;
+                    }
+                    std::fs::write(path, &output)
+                        .map_err(|err| miette::miette!("write SBOM to {file_path}: {err}"))?;
+                    files.push(file_path);
+                } else {
+                    ndjson_lines.push(output);
+                }
+            }
+
+            let mut stdout = std::io::stdout();
+            if self.out.is_some() {
+                let _ = writeln!(
+                    stdout,
+                    "Generated {} SBOMs:\n{}",
+                    files.len(),
+                    files.iter().map(|f| format!("  {f}")).collect::<Vec<_>>().join("\n"),
+                );
+            } else {
+                let _ = write!(stdout, "{}", ndjson_lines.join("\n"));
+            }
+            let _ = stdout.flush();
+        } else {
+            let result = collect_components(
+                &state,
+                &include,
+                self.sbom_type,
+                self.exclude_peers,
+                self.lockfile_only,
+                None,
+            )?;
+
+            let output = match self.format {
+                SbomFormat::CycloneDx => serialize_cyclonedx(&CycloneDxOpts {
+                    result: &result,
+                    spec_version: self.spec_version.as_deref(),
+                    lockfile_only: self.lockfile_only,
+                    authors: &authors,
+                    supplier: self.supplier.as_deref(),
+                    compact: false,
+                }),
+                SbomFormat::Spdx => serialize_spdx(&result, false),
+            };
+
+            if let Some(ref out_template) = self.out {
+                let sanitized_name =
+                    sanitize_path_segment(&sanitize_package_name(&result.root_name));
+                let sanitized_ver = sanitize_path_segment(&result.root_version);
+                let file_path =
+                    out_template.replace("%s", &sanitized_name).replace("%v", &sanitized_ver);
+                let path = std::path::Path::new(&file_path);
+                assert_inside_project(path, &project_root)?;
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent).map_err(|err| {
+                        miette::miette!("create directory for {file_path}: {err}")
+                    })?;
+                }
+                std::fs::write(path, &output)
+                    .map_err(|err| miette::miette!("write SBOM to {file_path}: {err}"))?;
+                let mut stdout = std::io::stdout();
+                let _ = writeln!(stdout, "{file_path}");
+                let _ = stdout.flush();
+            } else {
+                let mut stdout = std::io::stdout();
+                let _ = write!(stdout, "{output}");
+                let _ = stdout.flush();
+            }
+        }
+
+        Ok(())
+    }
+}
+
+struct CycloneDxOpts<'a> {
+    result: &'a SbomResult,
+    spec_version: Option<&'a str>,
+    lockfile_only: bool,
+    authors: &'a [String],
+    supplier: Option<&'a str>,
+    compact: bool,
+}
+
+fn split_scoped_name(name: &str) -> (Option<&str>, &str) {
+    if name.starts_with('@') {
+        if let Some(idx) = name.find('/') {
+            (Some(&name[..idx]), &name[idx + 1..])
+        } else {
+            (None, name)
+        }
+    } else {
+        (None, name)
+    }
+}
+
+fn serialize_cyclonedx(opts: &CycloneDxOpts<'_>) -> String {
+    let result = opts.result;
+    let spec_version = opts.spec_version.unwrap_or("1.7");
+    let root_type = match result.root_type {
+        SbomComponentType::Library => "library",
+        SbomComponentType::Application => "application",
+    };
+
+    let root_purl = build_purl(&result.root_name, &result.root_version);
+    let (root_group, root_name) = split_scoped_name(&result.root_name);
+
+    let mut root_component = serde_json::json!({
+        "type": root_type,
+        "name": root_name,
+        "version": result.root_version,
+        "purl": root_purl,
+        "bom-ref": root_purl,
+    });
+    if let Some(group) = root_group {
+        root_component["group"] = serde_json::Value::String(group.to_string());
+    }
+    if let Some(ref desc) = result.root_description {
+        root_component["description"] = serde_json::Value::String(desc.clone());
+    }
+    if let Some(ref author) = result.root_author {
+        root_component["authors"] = serde_json::json!([{ "name": author }]);
+    }
+    if let Some(ref license) = result.root_license {
+        root_component["licenses"] = serde_json::json!([classify_license(license)]);
+    }
+    let mut root_ext_refs: Vec<serde_json::Value> = Vec::new();
+    if let Some(ref repo) = result.root_repository {
+        root_ext_refs.push(serde_json::json!({ "type": "vcs", "url": repo }));
+    }
+    if let Some(ref bugs) = result.root_bugs_url {
+        root_ext_refs.push(serde_json::json!({ "type": "issue-tracker", "url": bugs }));
+    }
+    if !root_ext_refs.is_empty() {
+        root_component["externalReferences"] = serde_json::Value::Array(root_ext_refs);
+    }
+
+    let components: Vec<serde_json::Value> = result
+        .components
+        .iter()
+        .map(|c| {
+            let (group, name) = split_scoped_name(&c.name);
+            let mut comp = serde_json::json!({
+                "type": "library",
+                "name": name,
+                "version": c.version,
+                "purl": c.purl,
+                "bom-ref": c.purl,
+            });
+            if let Some(group) = group {
+                comp["group"] = serde_json::Value::String(group.to_string());
+            }
+            if c.dep_type == DepType::DevOnly {
+                comp["scope"] = serde_json::Value::String("excluded".to_string());
+                comp["properties"] = serde_json::json!([
+                    { "name": "cdx:npm:package:development", "value": "true" }
+                ]);
+            }
+            if let Some(ref desc) = c.description {
+                comp["description"] = serde_json::Value::String(desc.clone());
+            }
+            if let Some(ref author) = c.author {
+                comp["authors"] = serde_json::json!([{ "name": author }]);
+            }
+            if let Some(ref license) = c.license {
+                comp["licenses"] = serde_json::json!([classify_license(license)]);
+            }
+
+            let mut ext_refs: Vec<serde_json::Value> = Vec::new();
+            if let Some(ref tarball) = c.tarball_url {
+                let mut dist_ref = serde_json::json!({ "type": "distribution", "url": tarball });
+                if let Some(ref integrity) = c.integrity
+                    && let Some(hashes) = integrity_to_hashes(integrity)
+                {
+                    dist_ref["hashes"] = serde_json::Value::Array(hashes);
+                }
+                ext_refs.push(dist_ref);
+            }
+            if let Some(ref hp) = c.homepage {
+                ext_refs.push(serde_json::json!({ "type": "website", "url": hp }));
+            }
+            if let Some(ref repo) = c.repository {
+                ext_refs.push(serde_json::json!({ "type": "vcs", "url": repo }));
+            }
+            if let Some(ref bugs) = c.bugs_url {
+                ext_refs.push(serde_json::json!({ "type": "issue-tracker", "url": bugs }));
+            }
+            if !ext_refs.is_empty() {
+                comp["externalReferences"] = serde_json::Value::Array(ext_refs);
+            }
+            comp
+        })
+        .collect();
+
+    let dependencies: Vec<serde_json::Value> = {
+        let mut deps_map: HashMap<&str, Vec<&str>> = HashMap::new();
+        deps_map.entry(&root_purl).or_default();
+        for c in &result.components {
+            deps_map.entry(&c.purl).or_default();
+        }
+        for rel in &result.relationships {
+            deps_map.entry(&rel.from).or_default().push(&rel.to);
+        }
+        let mut refs: Vec<&&str> = deps_map.keys().collect();
+        refs.sort_unstable();
+        refs.iter()
+            .map(|ref_purl| {
+                let mut dep_list = deps_map[*ref_purl].clone();
+                dep_list.sort_unstable();
+                dep_list.dedup();
+                serde_json::json!({
+                    "ref": ref_purl,
+                    "dependsOn": dep_list,
+                })
+            })
+            .collect()
+    };
+
+    let timestamp = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let phase = if opts.lockfile_only { "pre-build" } else { "build" };
+
+    let mut metadata = serde_json::json!({
+        "timestamp": timestamp,
+        "lifecycles": [{ "phase": phase }],
+        "tools": { "components": [{
+            "type": "application",
+            "name": "pacquet",
+            "version": pacquet_config::PACQUET_VERSION,
+        }] },
+        "component": root_component,
+    });
+
+    if !opts.authors.is_empty() {
+        let author_list: Vec<serde_json::Value> =
+            opts.authors.iter().map(|name| serde_json::json!({ "name": name })).collect();
+        metadata["authors"] = serde_json::Value::Array(author_list);
+    }
+    if let Some(supplier) = opts.supplier {
+        metadata["supplier"] = serde_json::json!({ "name": supplier });
+    }
+
+    let bom = serde_json::json!({
+        "$schema": format!("http://cyclonedx.org/schema/bom-{spec_version}.schema.json"),
+        "bomFormat": "CycloneDX",
+        "specVersion": spec_version,
+        "serialNumber": format!("urn:uuid:{}", generate_uuid_v4()),
+        "version": 1,
+        "metadata": metadata,
+        "components": components,
+        "dependencies": dependencies,
+    });
+
+    if opts.compact {
+        serde_json::to_string(&bom).expect("JSON serialization")
+    } else {
+        serde_json::to_string_pretty(&bom).expect("JSON serialization")
+    }
+}
+
+fn sanitize_spdx_id(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '.' || c == '-' { c } else { '-' })
+        .collect()
+}
+
+fn serialize_spdx(result: &SbomResult, compact: bool) -> String {
+    let root_purl = build_purl(&result.root_name, &result.root_version);
+    let root_spdx_id = "SPDXRef-RootPackage";
+    let root_purpose = match result.root_type {
+        SbomComponentType::Library => "LIBRARY",
+        SbomComponentType::Application => "APPLICATION",
+    };
+
+    let license_value = result.root_license.as_deref().unwrap_or("NOASSERTION");
+    let mut root_package = serde_json::json!({
+        "SPDXID": root_spdx_id,
+        "name": result.root_name,
+        "versionInfo": result.root_version,
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": false,
+        "primaryPackagePurpose": root_purpose,
+        "licenseConcluded": license_value,
+        "licenseDeclared": license_value,
+        "copyrightText": "NOASSERTION",
+        "externalRefs": [{
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": root_purl,
+        }],
+    });
+    if let Some(ref desc) = result.root_description {
+        root_package["description"] = serde_json::Value::String(desc.clone());
+    }
+    if let Some(ref author) = result.root_author {
+        root_package["supplier"] = serde_json::Value::String(format!("Person: {author}"));
+    }
+    if let Some(ref repo) = result.root_repository {
+        root_package["homepage"] = serde_json::Value::String(repo.clone());
+    }
+
+    let mut spdx_id_map: HashMap<&str, String> = HashMap::new();
+    spdx_id_map.insert(&root_purl, root_spdx_id.to_string());
+
+    let mut spdx_packages = vec![root_package];
+
+    for (i, component) in result.components.iter().enumerate() {
+        let spdx_id = format!(
+            "SPDXRef-Package-{}-{}-{i}",
+            sanitize_spdx_id(&component.name),
+            sanitize_spdx_id(&component.version),
+        );
+        spdx_id_map.insert(&component.purl, spdx_id.clone());
+
+        let comp_license = component.license.as_deref().unwrap_or("NOASSERTION");
+        let download_loc = component.tarball_url.as_deref().unwrap_or("NOASSERTION");
+        let mut pkg = serde_json::json!({
+            "SPDXID": spdx_id,
+            "name": component.name,
+            "versionInfo": component.version,
+            "downloadLocation": download_loc,
+            "filesAnalyzed": false,
+            "licenseConcluded": comp_license,
+            "licenseDeclared": comp_license,
+            "copyrightText": "NOASSERTION",
+            "externalRefs": [{
+                "referenceCategory": "PACKAGE-MANAGER",
+                "referenceType": "purl",
+                "referenceLocator": component.purl,
+            }],
+        });
+
+        if let Some(ref desc) = component.description {
+            pkg["description"] = serde_json::Value::String(desc.clone());
+        }
+        if let Some(ref hp) = component.homepage {
+            pkg["homepage"] = serde_json::Value::String(hp.clone());
+        }
+        if let Some(ref author) = component.author {
+            pkg["supplier"] = serde_json::Value::String(format!("Person: {author}"));
+        }
+
+        if let Some(ref integrity) = component.integrity
+            && let Some(checksums) = integrity_to_spdx_checksums(integrity)
+        {
+            pkg["checksums"] = serde_json::Value::Array(checksums);
+        }
+
+        spdx_packages.push(pkg);
+    }
+
+    let mut spdx_relationships: Vec<serde_json::Value> = vec![serde_json::json!({
+        "spdxElementId": "SPDXRef-DOCUMENT",
+        "relatedSpdxElement": root_spdx_id,
+        "relationshipType": "DESCRIBES",
+    })];
+
+    let mut seen_rels: HashSet<(String, String)> = HashSet::new();
+    for rel in &result.relationships {
+        if let (Some(from_id), Some(to_id)) =
+            (spdx_id_map.get(rel.from.as_str()), spdx_id_map.get(rel.to.as_str()))
+        {
+            let key = (from_id.clone(), to_id.clone());
+            if seen_rels.insert(key) {
+                spdx_relationships.push(serde_json::json!({
+                    "spdxElementId": from_id,
+                    "relatedSpdxElement": to_id,
+                    "relationshipType": "DEPENDS_ON",
+                }));
+            }
+        }
+    }
+
+    let timestamp = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let doc_namespace = format!(
+        "https://spdx.org/spdxdocs/{}-{}-{}",
+        sanitize_spdx_id(&result.root_name),
+        result.root_version,
+        generate_uuid_v4(),
+    );
+
+    let doc = serde_json::json!({
+        "spdxVersion": "SPDX-2.3",
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": result.root_name,
+        "documentNamespace": doc_namespace,
+        "creationInfo": {
+            "created": timestamp,
+            "creators": ["Tool: pacquet"],
+        },
+        "packages": spdx_packages,
+        "relationships": spdx_relationships,
+    });
+
+    if compact {
+        serde_json::to_string(&doc).expect("JSON serialization")
+    } else {
+        serde_json::to_string_pretty(&doc).expect("JSON serialization")
+    }
+}
+
+fn integrity_to_hashes(integrity: &str) -> Option<Vec<serde_json::Value>> {
+    let mut hashes = Vec::new();
+    for part in integrity.split_whitespace() {
+        let (alg, hash) = part.split_once('-')?;
+        let cdx_alg = match alg {
+            "sha1" => "SHA-1",
+            "sha256" => "SHA-256",
+            "sha384" => "SHA-384",
+            "sha512" => "SHA-512",
+            "md5" => "MD5",
+            _ => continue,
+        };
+        let hex = base64_to_hex(hash)?;
+        hashes.push(serde_json::json!({
+            "alg": cdx_alg,
+            "content": hex,
+        }));
+    }
+    if hashes.is_empty() { None } else { Some(hashes) }
+}
+
+fn integrity_to_spdx_checksums(integrity: &str) -> Option<Vec<serde_json::Value>> {
+    let mut checksums = Vec::new();
+    for part in integrity.split_whitespace() {
+        let (alg, hash) = part.split_once('-')?;
+        let spdx_alg = match alg {
+            "sha1" => "SHA1",
+            "sha256" => "SHA256",
+            "sha384" => "SHA384",
+            "sha512" => "SHA512",
+            "md5" => "MD5",
+            _ => continue,
+        };
+        let hex = base64_to_hex(hash)?;
+        checksums.push(serde_json::json!({
+            "algorithm": spdx_alg,
+            "checksumValue": hex,
+        }));
+    }
+    if checksums.is_empty() { None } else { Some(checksums) }
+}
+
+fn generate_uuid_v4() -> String {
+    use std::collections::hash_map::RandomState;
+    use std::hash::{BuildHasher, Hasher};
+    let state = RandomState::new();
+    let mut h = state.build_hasher();
+    h.write_u64(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64,
+    );
+    let a = h.finish();
+    let mut h2 = state.build_hasher();
+    h2.write_u64(!a);
+    let b = h2.finish();
+    let mut bytes = [0u8; 16];
+    bytes[..8].copy_from_slice(&a.to_le_bytes());
+    bytes[8..].copy_from_slice(&b.to_le_bytes());
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    use std::fmt::Write;
+    let mut s = String::with_capacity(36);
+    for (i, byte) in bytes.iter().enumerate() {
+        if matches!(i, 4 | 6 | 8 | 10) {
+            s.push('-');
+        }
+        let _ = write!(s, "{byte:02x}");
+    }
+    s
+}
+
+fn normalize_link_path(base_importer_id: &str, link_target: &str) -> Option<String> {
+    let mut parts: Vec<&str> = if base_importer_id == "." {
+        Vec::new()
+    } else {
+        base_importer_id.split('/').filter(|s| !s.is_empty()).collect()
+    };
+    for segment in link_target.split('/') {
+        match segment {
+            "" | "." => continue,
+            ".." => {
+                parts.pop()?;
+            }
+            other => parts.push(other),
+        }
+    }
+    if parts.is_empty() { Some(".".to_string()) } else { Some(parts.join("/")) }
+}
+
+fn assert_inside_project(path: &Path, project_root: &Path) -> miette::Result<()> {
+    let root = project_root.canonicalize().map_err(|err| {
+        miette::miette!("cannot canonicalize project root \"{}\": {err}", project_root.display())
+    })?;
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let canonical = path.canonicalize().map_err(|err| {
+        miette::miette!("cannot canonicalize output path \"{}\": {err}", path.display())
+    })?;
+    if !canonical.starts_with(&root) {
+        return Err(miette::miette!(
+            code = "ERR_PNPM_SBOM_OUT_PATH_TRAVERSAL",
+            "Output path \"{}\" resolves outside the project root",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+fn sanitize_package_name(name: &str) -> String {
+    name.strip_prefix('@').unwrap_or(name).replace('/', "-")
+}
+
+fn sanitize_path_segment(value: &str) -> String {
+    let sanitized: String = value
+        .chars()
+        .map(|c| {
+            if matches!(c, '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|')
+                || c.is_ascii_control()
+            {
+                '-'
+            } else {
+                c
+            }
+        })
+        .collect();
+    if sanitized == "." || sanitized == ".." || sanitized.trim().is_empty() {
+        "-".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn base64_to_hex(input: &str) -> Option<String> {
+    use base64::Engine;
+    use std::fmt::Write;
+    let bytes = base64::engine::general_purpose::STANDARD.decode(input).ok()?;
+    let mut hex = String::with_capacity(bytes.len() * 2);
+    for b in &bytes {
+        let _ = write!(hex, "{b:02x}");
+    }
+    Some(hex)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/sbom.rs
+++ b/pacquet/crates/cli/src/cli_args/sbom.rs
@@ -5,6 +5,7 @@
 
 use crate::State;
 use clap::Args;
+use indexmap::IndexMap;
 use pacquet_lockfile::{
     LockfileResolution, PackageKey, PackageMetadata, PkgName, PkgNameVerPeer, SnapshotEntry,
 };
@@ -126,6 +127,7 @@ struct WalkContext<'a> {
     default_registry: &'a str,
     virtual_store_dir: Option<PathBuf>,
     virtual_store_dir_max_length: usize,
+    include_optional_transitive: bool,
 }
 
 struct SbomRelationship {
@@ -272,7 +274,10 @@ fn peer_names_from_manifest(manifest: &serde_json::Value) -> HashSet<String> {
         .collect()
 }
 
-fn detect_dep_types(lockfile: &pacquet_lockfile::Lockfile) -> HashMap<PackageKey, DepType> {
+fn detect_dep_types(
+    lockfile: &pacquet_lockfile::Lockfile,
+    include_optional_transitive: bool,
+) -> HashMap<PackageKey, DepType> {
     let snapshots = lockfile.snapshots.as_ref();
     let mut dep_types: HashMap<PackageKey, DepType> = HashMap::new();
     let mut walked: HashSet<(PackageKey, bool)> = HashSet::new();
@@ -298,8 +303,22 @@ fn detect_dep_types(lockfile: &pacquet_lockfile::Lockfile) -> HashMap<PackageKey
         }
     }
 
-    detect_dep_types_walk(snapshots, &mut dep_types, &mut walked, &dev_keys, true);
-    detect_dep_types_walk(snapshots, &mut dep_types, &mut walked, &prod_keys, false);
+    detect_dep_types_walk(
+        snapshots,
+        &mut dep_types,
+        &mut walked,
+        &dev_keys,
+        true,
+        include_optional_transitive,
+    );
+    detect_dep_types_walk(
+        snapshots,
+        &mut dep_types,
+        &mut walked,
+        &prod_keys,
+        false,
+        include_optional_transitive,
+    );
     dep_types
 }
 
@@ -309,6 +328,7 @@ fn detect_dep_types_walk(
     walked: &mut HashSet<(PackageKey, bool)>,
     initial_keys: &[PackageKey],
     is_dev: bool,
+    include_optional_transitive: bool,
 ) {
     let mut queue: Vec<PackageKey> = initial_keys.to_vec();
 
@@ -331,12 +351,11 @@ fn detect_dep_types_walk(
             continue;
         };
 
-        for (alias, dep_ref) in snapshot
-            .dependencies
-            .iter()
-            .flatten()
-            .chain(snapshot.optional_dependencies.iter().flatten())
-        {
+        let optional_iter = include_optional_transitive
+            .then(|| snapshot.optional_dependencies.iter().flatten())
+            .into_iter()
+            .flatten();
+        for (alias, dep_ref) in snapshot.dependencies.iter().flatten().chain(optional_iter) {
             if let Some(child_key) = dep_ref.resolve(alias) {
                 queue.push(child_key);
             }
@@ -391,7 +410,7 @@ fn collect_components(
 
     let root_purl = build_purl(&root_name, &root_version);
 
-    let dep_types = detect_dep_types(lockfile);
+    let dep_types = detect_dep_types(lockfile, include.optional_dependencies);
 
     let virtual_store_dir = (!lockfile_only).then(|| project_root_dir.join("node_modules/.pnpm"));
 
@@ -402,9 +421,10 @@ fn collect_components(
         default_registry: &state.config.registry,
         virtual_store_dir,
         virtual_store_dir_max_length: state.config.virtual_store_dir_max_length as usize,
+        include_optional_transitive: include.optional_dependencies,
     };
 
-    let mut components_map: HashMap<String, SbomComponent> = HashMap::new();
+    let mut components_map: IndexMap<String, SbomComponent> = IndexMap::new();
     let mut relationships: Vec<SbomRelationship> = Vec::new();
     let mut visited: HashSet<PackageKey> = HashSet::new();
     let mut ws_purl_by_importer: HashMap<String, String> = HashMap::new();
@@ -444,6 +464,19 @@ fn collect_components(
         } else {
             HashSet::new()
         };
+
+        let dev_dep_names: HashSet<String> = importer
+            .dev_dependencies
+            .as_ref()
+            .map(|deps| deps.keys().map(ToString::to_string).collect())
+            .unwrap_or_default();
+        let prod_dep_names: HashSet<String> = importer
+            .dependencies
+            .iter()
+            .chain(importer.optional_dependencies.iter())
+            .flat_map(|deps| deps.keys())
+            .map(ToString::to_string)
+            .collect();
 
         let dep_maps: Vec<&HashMap<PkgName, _>> = [
             include.dependencies.then_some(importer.dependencies.as_ref()).flatten(),
@@ -485,18 +518,27 @@ fn collect_components(
                                 .unwrap_or("0.0.0")
                                 .to_string();
                             let ws_purl = build_purl(&ws_name, &ws_version);
+                            let name_str = name.to_string();
+                            let dev_only = dev_dep_names.contains(&name_str)
+                                && !prod_dep_names.contains(&name_str);
                             relationships.push(SbomRelationship {
                                 from: parent_purl.clone(),
                                 to: ws_purl.clone(),
                             });
-                            if !components_map.contains_key(&ws_purl) {
+                            let ws_dep_type =
+                                if dev_only { DepType::DevOnly } else { DepType::ProdOnly };
+                            if let Some(existing) = components_map.get_mut(&ws_purl) {
+                                if !dev_only && existing.dep_type == DepType::DevOnly {
+                                    existing.dep_type = DepType::ProdOnly;
+                                }
+                            } else {
                                 components_map.insert(
                                     ws_purl.clone(),
                                     SbomComponent {
                                         name: ws_name,
                                         version: ws_version,
                                         purl: ws_purl.clone(),
-                                        dep_type: DepType::ProdOnly,
+                                        dep_type: ws_dep_type,
                                         integrity: None,
                                         tarball_url: None,
                                         license: ws_manifest
@@ -590,7 +632,7 @@ fn walk_snapshot(
     initial_key: &PkgNameVerPeer,
     initial_parent_purl: &str,
     ctx: &WalkContext<'_>,
-    components_map: &mut HashMap<String, SbomComponent>,
+    components_map: &mut IndexMap<String, SbomComponent>,
     relationships: &mut Vec<SbomRelationship>,
     visited: &mut HashSet<PackageKey>,
 ) {
@@ -646,12 +688,12 @@ fn walk_snapshot(
             continue;
         };
 
-        for (alias, dep_ref) in snapshot
-            .dependencies
-            .iter()
-            .flatten()
-            .chain(snapshot.optional_dependencies.iter().flatten())
-        {
+        let optional_iter = ctx
+            .include_optional_transitive
+            .then(|| snapshot.optional_dependencies.iter().flatten())
+            .into_iter()
+            .flatten();
+        for (alias, dep_ref) in snapshot.dependencies.iter().flatten().chain(optional_iter) {
             if let Some(child_key) = dep_ref.resolve(alias) {
                 queue.push((child_key, purl.clone()));
             }

--- a/pacquet/crates/cli/src/cli_args/sbom.rs
+++ b/pacquet/crates/cli/src/cli_args/sbom.rs
@@ -685,6 +685,7 @@ impl SbomArgs {
         let all_importer_ids: Vec<String> =
             lockfile.as_ref().map(|lf| lf.importers.keys().cloned().collect()).unwrap_or_default();
 
+        let all_count = all_importer_ids.len();
         let importer_ids = if state.config.filter.is_empty() {
             all_importer_ids
         } else {
@@ -792,13 +793,15 @@ impl SbomArgs {
             }
             let _ = stdout.flush();
         } else {
+            let filter_ids: Option<Vec<&str>> = (importer_ids.len() < all_count)
+                .then(|| importer_ids.iter().map(String::as_str).collect());
             let result = collect_components(
                 &state,
                 &include,
                 self.sbom_type,
                 self.exclude_peers,
                 self.lockfile_only,
-                None,
+                filter_ids.as_deref(),
             )?;
 
             let output = match self.format {

--- a/pacquet/crates/cli/src/cli_args/sbom.rs
+++ b/pacquet/crates/cli/src/cli_args/sbom.rs
@@ -215,34 +215,6 @@ fn classify_license(license: &str) -> serde_json::Value {
     }
 }
 
-#[allow(dead_code)]
-fn percent_encode(input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
-    for b in input.bytes() {
-        if b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.' || b == b'~' {
-            out.push(b as char);
-        } else {
-            use std::fmt::Write;
-            let _ = write!(out, "%{b:02X}");
-        }
-    }
-    out
-}
-
-#[allow(dead_code)]
-fn build_purl_with_qualifier(name: &str, version: &str, non_semver: Option<&str>) -> String {
-    if let Some(raw) = non_semver {
-        format!(
-            "pkg:npm/{}@{}?vcs_url={}",
-            encode_purl_name(name),
-            percent_encode(version),
-            percent_encode(raw),
-        )
-    } else {
-        build_purl(name, version)
-    }
-}
-
 fn integrity_string(resolution: &LockfileResolution) -> Option<String> {
     match resolution {
         LockfileResolution::Registry(r) => Some(r.integrity.to_string()),
@@ -678,8 +650,6 @@ impl SbomArgs {
         }
 
         let include = self.include_filter();
-        let project_root =
-            state.manifest.path().parent().unwrap_or_else(|| Path::new(".")).to_path_buf();
         let authors: Vec<String> = self
             .authors
             .as_deref()
@@ -773,7 +743,7 @@ impl SbomArgs {
                     }
                     written_paths.insert(file_path.clone());
                     let path = std::path::Path::new(&file_path);
-                    assert_inside_project(path, &project_root)?;
+
                     if let Some(parent) = path.parent() {
                         std::fs::create_dir_all(parent).map_err(|err| {
                             miette::miette!("create directory for {file_path}: {err}")
@@ -828,7 +798,6 @@ impl SbomArgs {
                 let file_path =
                     out_template.replace("%s", &sanitized_name).replace("%v", &sanitized_ver);
                 let path = std::path::Path::new(&file_path);
-                assert_inside_project(path, &project_root)?;
                 if let Some(parent) = path.parent() {
                     std::fs::create_dir_all(parent).map_err(|err| {
                         miette::miette!("create directory for {file_path}: {err}")
@@ -1266,26 +1235,6 @@ fn normalize_link_path(base_importer_id: &str, link_target: &str) -> Option<Stri
         }
     }
     if parts.is_empty() { Some(".".to_string()) } else { Some(parts.join("/")) }
-}
-
-fn assert_inside_project(path: &Path, project_root: &Path) -> miette::Result<()> {
-    let root = project_root.canonicalize().map_err(|err| {
-        miette::miette!("cannot canonicalize project root \"{}\": {err}", project_root.display())
-    })?;
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    let canonical = path.canonicalize().map_err(|err| {
-        miette::miette!("cannot canonicalize output path \"{}\": {err}", path.display())
-    })?;
-    if !canonical.starts_with(&root) {
-        return Err(miette::miette!(
-            code = "ERR_PNPM_SBOM_OUT_PATH_TRAVERSAL",
-            "Output path \"{}\" resolves outside the project root",
-            path.display()
-        ));
-    }
-    Ok(())
 }
 
 fn sanitize_package_name(name: &str) -> String {

--- a/pacquet/crates/cli/src/cli_args/sbom/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/sbom/tests.rs
@@ -123,20 +123,20 @@ fn normalize_link_path_to_root() {
 
 #[test]
 fn classify_license_spdx_id() {
-    let v = classify_license("MIT");
-    assert_eq!(v["license"]["id"], "MIT");
+    let result = classify_license("MIT");
+    assert_eq!(result["license"]["id"], "MIT");
 }
 
 #[test]
 fn classify_license_expression() {
-    let v = classify_license("MIT OR Apache-2.0");
-    assert_eq!(v["expression"], "MIT OR Apache-2.0");
+    let result = classify_license("MIT OR Apache-2.0");
+    assert_eq!(result["expression"], "MIT OR Apache-2.0");
 }
 
 #[test]
 fn classify_license_freetext() {
-    let v = classify_license("Proprietary License");
-    assert_eq!(v["license"]["name"], "Proprietary License");
+    let result = classify_license("Proprietary License");
+    assert_eq!(result["license"]["name"], "Proprietary License");
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/sbom/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/sbom/tests.rs
@@ -1,6 +1,7 @@
 use super::{
-    base64_to_hex, build_purl, encode_purl_name, extract_author, extract_repository,
-    normalize_link_path, peer_names_from_manifest, sanitize_spdx_id, split_scoped_name,
+    base64_to_hex, build_purl, classify_license, encode_purl_name, extract_author,
+    extract_repository, is_simple_spdx_id, normalize_link_path, peer_names_from_manifest,
+    sanitize_spdx_id, split_scoped_name, strip_url_credentials,
 };
 
 #[test]
@@ -118,6 +119,50 @@ fn normalize_link_path_to_parent() {
 #[test]
 fn normalize_link_path_to_root() {
     assert_eq!(normalize_link_path("packages/a", "../.."), Some(".".to_string()));
+}
+
+#[test]
+fn classify_license_spdx_id() {
+    let v = classify_license("MIT");
+    assert_eq!(v["license"]["id"], "MIT");
+}
+
+#[test]
+fn classify_license_expression() {
+    let v = classify_license("MIT OR Apache-2.0");
+    assert_eq!(v["expression"], "MIT OR Apache-2.0");
+}
+
+#[test]
+fn classify_license_freetext() {
+    let v = classify_license("Proprietary License");
+    assert_eq!(v["license"]["name"], "Proprietary License");
+}
+
+#[test]
+fn is_simple_spdx_id_valid() {
+    assert!(is_simple_spdx_id("MIT"));
+    assert!(is_simple_spdx_id("Apache-2.0"));
+    assert!(is_simple_spdx_id("GPL-3.0-or-later"));
+}
+
+#[test]
+fn is_simple_spdx_id_invalid() {
+    assert!(!is_simple_spdx_id("Proprietary License"));
+    assert!(!is_simple_spdx_id(""));
+}
+
+#[test]
+fn strip_url_credentials_removes_userinfo() {
+    assert_eq!(
+        strip_url_credentials("https://user:token@github.com/foo/bar"),
+        "https://github.com/foo/bar"
+    );
+}
+
+#[test]
+fn strip_url_credentials_no_credentials() {
+    assert_eq!(strip_url_credentials("https://github.com/foo/bar"), "https://github.com/foo/bar");
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/sbom/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/sbom/tests.rs
@@ -156,7 +156,7 @@ fn is_simple_spdx_id_invalid() {
 fn strip_url_credentials_removes_userinfo() {
     assert_eq!(
         strip_url_credentials("https://user:token@github.com/foo/bar"),
-        "https://github.com/foo/bar"
+        "https://github.com/foo/bar",
     );
 }
 

--- a/pacquet/crates/cli/src/cli_args/sbom/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/sbom/tests.rs
@@ -1,0 +1,126 @@
+use super::{
+    base64_to_hex, build_purl, encode_purl_name, extract_author, extract_repository,
+    normalize_link_path, peer_names_from_manifest, sanitize_spdx_id, split_scoped_name,
+};
+
+#[test]
+fn encode_purl_name_unscoped() {
+    assert_eq!(encode_purl_name("react"), "react");
+}
+
+#[test]
+fn encode_purl_name_scoped() {
+    assert_eq!(encode_purl_name("@babel/core"), "%40babel/core");
+}
+
+#[test]
+fn build_purl_unscoped() {
+    assert_eq!(build_purl("react", "18.2.0"), "pkg:npm/react@18.2.0");
+}
+
+#[test]
+fn build_purl_scoped() {
+    assert_eq!(build_purl("@babel/core", "7.22.0"), "pkg:npm/%40babel/core@7.22.0");
+}
+
+#[test]
+fn split_scoped_name_unscoped() {
+    assert_eq!(split_scoped_name("react"), (None, "react"));
+}
+
+#[test]
+fn split_scoped_name_scoped() {
+    assert_eq!(split_scoped_name("@babel/core"), (Some("@babel"), "core"));
+}
+
+#[test]
+fn sanitize_spdx_id_preserves_valid_chars() {
+    assert_eq!(sanitize_spdx_id("foo-bar.1"), "foo-bar.1");
+}
+
+#[test]
+fn sanitize_spdx_id_replaces_special_chars() {
+    assert_eq!(sanitize_spdx_id("@scope/name"), "-scope-name");
+}
+
+#[test]
+fn base64_to_hex_sha512() {
+    assert_eq!(base64_to_hex("AAAA"), Some("000000".to_string()));
+}
+
+#[test]
+fn base64_to_hex_invalid_returns_none() {
+    assert_eq!(base64_to_hex("!!!"), None);
+}
+
+#[test]
+fn peer_names_excludes_regular_deps() {
+    let manifest = serde_json::json!({
+        "dependencies": { "react": "^18.0.0" },
+        "peerDependencies": { "react": "^18.0.0", "react-dom": "^18.0.0" },
+    });
+    let peers = peer_names_from_manifest(&manifest);
+    assert!(!peers.contains("react"), "react is both a dep and peer; should be excluded");
+    assert!(peers.contains("react-dom"), "react-dom is peer-only; should be included");
+}
+
+#[test]
+fn peer_names_empty_when_no_peers() {
+    let manifest = serde_json::json!({ "dependencies": { "react": "^18.0.0" } });
+    assert!(peer_names_from_manifest(&manifest).is_empty());
+}
+
+#[test]
+fn extract_author_string() {
+    let manifest = serde_json::json!({ "author": "Jane Doe" });
+    assert_eq!(extract_author(&manifest), Some("Jane Doe".to_string()));
+}
+
+#[test]
+fn extract_author_object() {
+    let manifest =
+        serde_json::json!({ "author": { "name": "Jane Doe", "email": "jane@example.com" } });
+    assert_eq!(extract_author(&manifest), Some("Jane Doe".to_string()));
+}
+
+#[test]
+fn extract_author_missing() {
+    assert_eq!(extract_author(&serde_json::json!({})), None);
+}
+
+#[test]
+fn extract_repository_string() {
+    let manifest = serde_json::json!({ "repository": "https://github.com/foo/bar" });
+    assert_eq!(extract_repository(&manifest), Some("https://github.com/foo/bar".to_string()));
+}
+
+#[test]
+fn extract_repository_object() {
+    let manifest = serde_json::json!({ "repository": { "type": "git", "url": "https://github.com/foo/bar.git" } });
+    assert_eq!(extract_repository(&manifest), Some("https://github.com/foo/bar.git".to_string()));
+}
+
+#[test]
+fn normalize_link_path_simple() {
+    assert_eq!(normalize_link_path(".", "packages/foo"), Some("packages/foo".to_string()));
+}
+
+#[test]
+fn normalize_link_path_relative() {
+    assert_eq!(normalize_link_path("packages/a", "../b"), Some("packages/b".to_string()));
+}
+
+#[test]
+fn normalize_link_path_to_parent() {
+    assert_eq!(normalize_link_path("packages/a", ".."), Some("packages".to_string()));
+}
+
+#[test]
+fn normalize_link_path_to_root() {
+    assert_eq!(normalize_link_path("packages/a", "../.."), Some(".".to_string()));
+}
+
+#[test]
+fn normalize_link_path_escape_returns_none() {
+    assert_eq!(normalize_link_path(".", ".."), None);
+}

--- a/pacquet/crates/cli/tests/fixtures/workspace-sbom-populated/app-a/package.json
+++ b/pacquet/crates/cli/tests/fixtures/workspace-sbom-populated/app-a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/app-a",
+  "version": "1.0.0",
+  "description": "First workspace app",
+  "dependencies": {
+    "is-positive": "3.1.0",
+    "shared-lib": "workspace:*"
+  }
+}

--- a/pacquet/crates/cli/tests/fixtures/workspace-sbom-populated/app-b/package.json
+++ b/pacquet/crates/cli/tests/fixtures/workspace-sbom-populated/app-b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "app-b",
+  "version": "2.0.0",
+  "description": "Second workspace app",
+  "dependencies": {
+    "is-negative": "2.1.0"
+  }
+}

--- a/pacquet/crates/cli/tests/fixtures/workspace-sbom-populated/package.json
+++ b/pacquet/crates/cli/tests/fixtures/workspace-sbom-populated/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "workspace-sbom-root",
+  "version": "0.0.0",
+  "private": true
+}

--- a/pacquet/crates/cli/tests/fixtures/workspace-sbom-populated/pnpm-lock.yaml
+++ b/pacquet/crates/cli/tests/fixtures/workspace-sbom-populated/pnpm-lock.yaml
@@ -1,0 +1,61 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies: {}
+
+  app-a:
+    dependencies:
+      is-positive:
+        specifier: 3.1.0
+        version: 3.1.0
+      shared-lib:
+        specifier: workspace:*
+        version: link:../shared-lib
+
+  app-b:
+    dependencies:
+      is-negative:
+        specifier: 2.1.0
+        version: 2.1.0
+
+  shared-lib:
+    dependencies:
+      is-odd:
+        specifier: 3.0.1
+        version: 3.0.1
+
+packages:
+
+  is-negative@2.1.0:
+    resolution: {integrity: sha512-lOLfrmtpmkreuw+9G/zcKnfJGnOPqBvvZqYOaklGJHfyEcEmuItDJee2bDIA9hRK8j0MiYbU5yHEMh0GKG/Ig==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@6.0.0:
+    resolution: {integrity: sha512-Wu1VGGOSKiLJfR2jGNA5W6aDTdEv0yKrZsoKAfEmuB5me6LSrjYbr9MZk0tqzLJKlTQb23osKHLMIR0eG3gc2A==}
+    engines: {node: '>=0.12.0'}
+
+  is-odd@3.0.1:
+    resolution: {integrity: sha512-CQpnWPrDwmP1+SMHXZhtLtCv8v6NvAzZtPbDSHJNGfPBIElLqxmQoM/3FP/qRqP3TERIPAPR94rJ2jCihl+kg==}
+    engines: {node: '>=0.10.0'}
+
+  is-positive@3.1.0:
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
+    engines: {node: '>=0.10.0'}
+
+snapshots:
+
+  is-negative@2.1.0: {}
+
+  is-number@6.0.0: {}
+
+  is-odd@3.0.1:
+    dependencies:
+      is-number: 6.0.0
+
+  is-positive@3.1.0: {}

--- a/pacquet/crates/cli/tests/fixtures/workspace-sbom-populated/pnpm-workspace.yaml
+++ b/pacquet/crates/cli/tests/fixtures/workspace-sbom-populated/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - app-a
+  - app-b
+  - shared-lib

--- a/pacquet/crates/cli/tests/fixtures/workspace-sbom-populated/shared-lib/package.json
+++ b/pacquet/crates/cli/tests/fixtures/workspace-sbom-populated/shared-lib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "shared-lib",
+  "version": "0.1.0",
+  "description": "Shared workspace library",
+  "dependencies": {
+    "is-odd": "3.0.1"
+  }
+}

--- a/pacquet/crates/cli/tests/sbom.rs
+++ b/pacquet/crates/cli/tests/sbom.rs
@@ -586,7 +586,6 @@ fn sbom_workspace_split_out_percent_v() {
 }
 
 #[test]
-#[ignore = "filter propagation through Config needs investigation"]
 fn sbom_workspace_filter_selects_importer() {
     let tmp = copy_fixture("workspace-sbom-populated");
     let output = pacquet(

--- a/pacquet/crates/cli/tests/sbom.rs
+++ b/pacquet/crates/cli/tests/sbom.rs
@@ -52,7 +52,7 @@ fn run_sbom_json(workspace: &Path, format: &str, extra_args: &[&str]) -> serde_j
     assert!(
         output.status.success(),
         "pacquet sbom failed: {}",
-        String::from_utf8_lossy(&output.stderr)
+        String::from_utf8_lossy(&output.stderr),
     );
     serde_json::from_slice(&output.stdout).expect("parse JSON output")
 }
@@ -124,7 +124,7 @@ fn sbom_dev_only_scope_excluded() {
 
     let props = typescript["properties"].as_array().expect("properties");
     assert!(
-        props.iter().any(|p| p["name"] == "cdx:npm:package:development" && p["value"] == "true")
+        props.iter().any(|p| p["name"] == "cdx:npm:package:development" && p["value"] == "true"),
     );
 }
 
@@ -279,11 +279,11 @@ fn sbom_includes_peers_by_default() {
     assert!(components.iter().any(|c| c["name"] == "is-positive"));
     assert!(
         components.iter().any(|c| c["name"] == "is-odd"),
-        "peer dep should be included by default"
+        "peer dep should be included by default",
     );
     assert!(
         components.iter().any(|c| c["name"] == "is-number"),
-        "transitive of peer should be included"
+        "transitive of peer should be included",
     );
 }
 
@@ -296,7 +296,7 @@ fn sbom_exclude_peers_drops_subtree() {
     assert!(!components.iter().any(|c| c["name"] == "is-odd"), "peer dep should be excluded");
     assert!(
         !components.iter().any(|c| c["name"] == "is-number"),
-        "transitive dep reachable only through peer should be excluded"
+        "transitive dep reachable only through peer should be excluded",
     );
     let root_ref = parsed["metadata"]["component"]["bom-ref"].as_str().expect("bom-ref");
     let root_deps = parsed["dependencies"]
@@ -311,7 +311,7 @@ fn sbom_exclude_peers_drops_subtree() {
             .expect("dependsOn")
             .iter()
             .any(|d| d.as_str().unwrap().contains("is-odd")),
-        "peer should not appear in root dependency graph"
+        "peer should not appear in root dependency graph",
     );
 }
 
@@ -323,7 +323,7 @@ fn sbom_exclude_peers_workspace_sub_packages() {
     assert!(components.iter().any(|c| c["name"] == "is-positive"));
     assert!(
         !components.iter().any(|c| c["name"] == "is-odd"),
-        "peer in sub-package should be excluded"
+        "peer in sub-package should be excluded",
     );
 }
 
@@ -343,7 +343,7 @@ fn sbom_exclude_peers_keeps_real_dep_in_other_importer() {
     let components = parsed["components"].as_array().expect("components");
     assert!(
         components.iter().any(|c| c["name"] == "is-odd"),
-        "is-odd is a peer in pkg-a but a real dep in pkg-b; should be kept"
+        "is-odd is a peer in pkg-a but a real dep in pkg-b; should be kept",
     );
 }
 
@@ -398,7 +398,7 @@ fn sbom_dev_flag_excludes_prod() {
     let components = parsed["components"].as_array().expect("components");
     assert!(
         !components.iter().any(|c| c["name"] == "is-positive"),
-        "prod dep should be excluded with --dev"
+        "prod dep should be excluded with --dev",
     );
     assert!(components.iter().any(|c| c["name"] == "typescript"), "dev dep should be included");
 }
@@ -590,7 +590,7 @@ fn sbom_workspace_split_produces_multiple_lines() {
     assert!(
         lines.len() >= 3,
         "workspace with 4 importers should produce at least 3 NDJSON lines (root may be empty), got {}",
-        lines.len()
+        lines.len(),
     );
     for line in &lines {
         let parsed: serde_json::Value = serde_json::from_str(line).expect("valid JSON");
@@ -651,7 +651,7 @@ fn sbom_workspace_split_out_percent_v() {
         .collect();
     assert!(
         files.iter().any(|f| f.contains("1.0.0")),
-        "filenames should contain version: {files:?}"
+        "filenames should contain version: {files:?}",
     );
 }
 
@@ -667,7 +667,7 @@ fn sbom_workspace_filter_selects_importer() {
     assert!(
         output.status.success(),
         "pacquet sbom with filter failed: {}",
-        String::from_utf8_lossy(&output.stderr)
+        String::from_utf8_lossy(&output.stderr),
     );
     let parsed: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("parse JSON output");
@@ -696,7 +696,7 @@ fn sbom_workspace_spdx_link_deps() {
     let packages = parsed["packages"].as_array().expect("packages");
     assert!(
         packages.iter().any(|p| p["name"] == "shared-lib"),
-        "shared-lib should be in SPDX packages"
+        "shared-lib should be in SPDX packages",
     );
 }
 
@@ -726,7 +726,7 @@ fn sbom_split_single_project_not_triggered() {
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
     assert!(
         parsed["bomFormat"].is_string(),
-        "single project should produce regular JSON, not NDJSON"
+        "single project should produce regular JSON, not NDJSON",
     );
 }
 
@@ -758,6 +758,6 @@ fn sbom_dev_flag_includes_only_dev() {
     assert!(components.iter().any(|c| c["name"] == "typescript"), "dev dep should be included");
     assert!(
         !components.iter().any(|c| c["name"] == "is-positive"),
-        "prod dep should be excluded with --dev"
+        "prod dep should be excluded with --dev",
     );
 }

--- a/pacquet/crates/cli/tests/sbom.rs
+++ b/pacquet/crates/cli/tests/sbom.rs
@@ -273,3 +273,145 @@ fn sbom_exclude_peers() {
     let components = parsed["components"].as_array().expect("components");
     assert!(components.iter().any(|c| c["name"] == "is-positive"), "non-peer dep should remain");
 }
+
+#[test]
+fn sbom_out_interpolates_percent_s() {
+    let tmp = copy_fixture("simple-sbom");
+    let out_pattern = tmp.path().join("sbom-out/%s.cdx.json");
+    let output = pacquet(
+        tmp.path(),
+        [
+            "sbom",
+            "--sbom-format",
+            "cyclonedx",
+            "--lockfile-only",
+            "--out",
+            out_pattern.to_str().unwrap(),
+        ],
+    )
+    .output()
+    .expect("run pacquet");
+    assert!(output.status.success());
+    let expected = tmp.path().join("sbom-out/simple-sbom-test.cdx.json");
+    assert!(expected.exists(), "interpolated %s file should exist");
+}
+
+#[test]
+fn sbom_out_interpolates_percent_v() {
+    let tmp = copy_fixture("simple-sbom");
+    let out_pattern = tmp.path().join("sbom-out/%s-%v.cdx.json");
+    let output = pacquet(
+        tmp.path(),
+        [
+            "sbom",
+            "--sbom-format",
+            "cyclonedx",
+            "--lockfile-only",
+            "--out",
+            out_pattern.to_str().unwrap(),
+        ],
+    )
+    .output()
+    .expect("run pacquet");
+    assert!(output.status.success());
+    let expected = tmp.path().join("sbom-out/simple-sbom-test-1.0.0.cdx.json");
+    assert!(expected.exists(), "interpolated %s-%v file should exist");
+}
+
+#[test]
+fn sbom_dev_flag_excludes_prod() {
+    let tmp = copy_fixture("with-dev-dependency");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--dev"]);
+    let components = parsed["components"].as_array().expect("components");
+    assert!(
+        !components.iter().any(|c| c["name"] == "is-positive"),
+        "prod dep should be excluded with --dev"
+    );
+    assert!(components.iter().any(|c| c["name"] == "typescript"), "dev dep should be included");
+}
+
+#[test]
+fn sbom_split_outputs_ndjson() {
+    let tmp = copy_fixture("workspace-sbom");
+    let output =
+        pacquet(tmp.path(), ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--split"])
+            .output()
+            .expect("run pacquet");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    // Fixture lockfile only has root importer (TS tests install first to populate all importers)
+    assert!(!lines.is_empty(), "should output at least one NDJSON line");
+    for line in &lines {
+        let parsed: serde_json::Value =
+            serde_json::from_str(line).expect("each line should be valid JSON");
+        assert_eq!(parsed["bomFormat"], "CycloneDX");
+    }
+}
+
+#[test]
+fn sbom_split_out_writes_per_package_files() {
+    let tmp = copy_fixture("workspace-sbom");
+    let out_pattern = tmp.path().join("sbom-out/%s.cdx.json");
+    let output = pacquet(
+        tmp.path(),
+        [
+            "sbom",
+            "--sbom-format",
+            "cyclonedx",
+            "--lockfile-only",
+            "--split",
+            "--out",
+            out_pattern.to_str().unwrap(),
+        ],
+    )
+    .output()
+    .expect("run pacquet");
+    assert!(output.status.success());
+    let out_dir = tmp.path().join("sbom-out");
+    assert!(out_dir.exists(), "output directory should be created");
+    let files: Vec<String> = fs::read_dir(&out_dir)
+        .expect("read output dir")
+        .filter_map(|e| e.ok().map(|e| e.file_name().to_string_lossy().to_string()))
+        .collect();
+    assert!(!files.is_empty(), "should write at least one file");
+}
+
+#[test]
+fn sbom_split_out_without_percent_s_fails() {
+    let tmp = copy_fixture("workspace-sbom");
+    let output = pacquet(
+        tmp.path(),
+        ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--split", "--out", "sbom.json"],
+    )
+    .output()
+    .expect("run pacquet");
+    assert!(!output.status.success(), "--split --out without %s should fail");
+}
+
+#[test]
+fn sbom_spdx_license_from_manifest() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "spdx", &[]);
+    let root = &parsed["packages"].as_array().expect("packages")[0];
+    assert_eq!(root["licenseConcluded"], "ISC");
+    assert_eq!(root["licenseDeclared"], "ISC");
+}
+
+#[test]
+fn sbom_lifecycle_pre_build_in_lockfile_only() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
+    let phase = parsed["metadata"]["lifecycles"][0]["phase"].as_str().expect("phase");
+    assert_eq!(phase, "pre-build");
+}
+
+#[test]
+fn sbom_spdx_download_location() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "spdx", &[]);
+    let packages = parsed["packages"].as_array().expect("packages");
+    let is_positive = packages.iter().find(|p| p["name"] == "is-positive").expect("is-positive");
+    let dl = is_positive["downloadLocation"].as_str().expect("downloadLocation");
+    assert!(dl.contains("registry.npmjs.org"), "should have registry URL, got {dl}");
+}

--- a/pacquet/crates/cli/tests/sbom.rs
+++ b/pacquet/crates/cli/tests/sbom.rs
@@ -100,7 +100,7 @@ fn sbom_prod_excludes_dev() {
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--prod"]);
 
     let components = parsed["components"].as_array().expect("components array");
-    assert!(components.iter().any(|c| c["name"] == "is-positive"), "prod dep should be included",);
+    assert!(components.iter().any(|c| c["name"] == "is-positive"), "prod dep should be included");
     assert!(
         !components.iter().any(|c| c["name"] == "typescript"),
         "dev dep should be excluded with --prod",
@@ -271,5 +271,5 @@ fn sbom_exclude_peers() {
     let tmp = copy_fixture("with-peer-dependency");
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--exclude-peers"]);
     let components = parsed["components"].as_array().expect("components");
-    assert!(components.iter().any(|c| c["name"] == "is-positive"), "non-peer dep should remain",);
+    assert!(components.iter().any(|c| c["name"] == "is-positive"), "non-peer dep should remain");
 }

--- a/pacquet/crates/cli/tests/sbom.rs
+++ b/pacquet/crates/cli/tests/sbom.rs
@@ -5,9 +5,14 @@ use tempfile::TempDir;
 
 fn copy_fixture(name: &str) -> TempDir {
     let tmp = TempDir::new().expect("create temp dir");
-    let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../../../pnpm11/deps/compliance/commands/test/sbom/fixtures")
-        .join(name);
+    let local_fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures").join(name);
+    let fixture_dir = if local_fixture.exists() {
+        local_fixture
+    } else {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../pnpm11/deps/compliance/commands/test/sbom/fixtures")
+            .join(name)
+    };
     for entry in fs::read_dir(&fixture_dir).expect("read fixture dir") {
         let entry = entry.expect("read dir entry");
         let dest = tmp.path().join(entry.file_name());
@@ -488,4 +493,140 @@ fn sbom_cyclonedx_scoped_root_has_group() {
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
     assert_eq!(parsed["metadata"]["component"]["group"], "@myorg");
     assert_eq!(parsed["metadata"]["component"]["name"], "myapp");
+}
+
+#[test]
+fn sbom_workspace_link_deps_as_components() {
+    let tmp = copy_fixture("workspace-sbom-populated");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
+    let components = parsed["components"].as_array().expect("components");
+    let names: Vec<&str> = components.iter().filter_map(|c| c["name"].as_str()).collect();
+    assert!(names.contains(&"is-positive"), "registry dep should be included");
+    assert!(names.contains(&"is-negative"), "registry dep from app-b should be included");
+    assert!(names.contains(&"shared-lib"), "workspace link dep should be included as component");
+    assert!(names.contains(&"is-odd"), "transitive dep of workspace link should be included");
+}
+
+#[test]
+fn sbom_workspace_split_produces_multiple_lines() {
+    let tmp = copy_fixture("workspace-sbom-populated");
+    let output =
+        pacquet(tmp.path(), ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--split"])
+            .output()
+            .expect("run pacquet");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert!(
+        lines.len() >= 3,
+        "workspace with 4 importers should produce at least 3 NDJSON lines (root may be empty), got {}",
+        lines.len()
+    );
+    for line in &lines {
+        let parsed: serde_json::Value = serde_json::from_str(line).expect("valid JSON");
+        assert_eq!(parsed["bomFormat"], "CycloneDX");
+    }
+}
+
+#[test]
+fn sbom_workspace_split_out_writes_files() {
+    let tmp = copy_fixture("workspace-sbom-populated");
+    let out_pattern = tmp.path().join("out/%s.cdx.json");
+    let output = pacquet(
+        tmp.path(),
+        [
+            "sbom",
+            "--sbom-format",
+            "cyclonedx",
+            "--lockfile-only",
+            "--split",
+            "--out",
+            out_pattern.to_str().unwrap(),
+        ],
+    )
+    .output()
+    .expect("run pacquet");
+    assert!(output.status.success());
+    let out_dir = tmp.path().join("out");
+    let files: Vec<String> = fs::read_dir(&out_dir)
+        .expect("read output dir")
+        .filter_map(|e| e.ok().map(|e| e.file_name().to_string_lossy().to_string()))
+        .collect();
+    assert!(files.len() >= 3, "should write files for workspace packages, got {files:?}");
+}
+
+#[test]
+fn sbom_workspace_split_out_percent_v() {
+    let tmp = copy_fixture("workspace-sbom-populated");
+    let out_pattern = tmp.path().join("out/%s-%v.cdx.json");
+    let output = pacquet(
+        tmp.path(),
+        [
+            "sbom",
+            "--sbom-format",
+            "cyclonedx",
+            "--lockfile-only",
+            "--split",
+            "--out",
+            out_pattern.to_str().unwrap(),
+        ],
+    )
+    .output()
+    .expect("run pacquet");
+    assert!(output.status.success());
+    let out_dir = tmp.path().join("out");
+    let files: Vec<String> = fs::read_dir(&out_dir)
+        .expect("read output dir")
+        .filter_map(|e| e.ok().map(|e| e.file_name().to_string_lossy().to_string()))
+        .collect();
+    assert!(
+        files.iter().any(|f| f.contains("1.0.0")),
+        "filenames should contain version: {files:?}"
+    );
+}
+
+#[test]
+#[ignore = "filter propagation through Config needs investigation"]
+fn sbom_workspace_filter_selects_importer() {
+    let tmp = copy_fixture("workspace-sbom-populated");
+    let output = pacquet(
+        tmp.path(),
+        ["-F", "app-a", "sbom", "--sbom-format", "cyclonedx", "--lockfile-only"],
+    )
+    .output()
+    .expect("run pacquet");
+    assert!(
+        output.status.success(),
+        "pacquet sbom with filter failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse JSON output");
+    let components = parsed["components"].as_array().expect("components");
+    let names: Vec<&str> = components.iter().filter_map(|c| c["name"].as_str()).collect();
+    assert!(names.contains(&"is-positive"), "app-a dep should be included");
+    assert!(!names.contains(&"is-negative"), "app-b dep should be excluded by filter");
+}
+
+#[test]
+fn sbom_workspace_link_dep_has_metadata() {
+    let tmp = copy_fixture("workspace-sbom-populated");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
+    let components = parsed["components"].as_array().expect("components");
+    let shared_lib = components.iter().find(|c| c["name"] == "shared-lib");
+    assert!(shared_lib.is_some(), "shared-lib should be a component");
+    let shared_lib = shared_lib.unwrap();
+    assert_eq!(shared_lib["version"], "0.1.0");
+    assert_eq!(shared_lib["purl"], "pkg:npm/shared-lib@0.1.0");
+}
+
+#[test]
+fn sbom_workspace_spdx_link_deps() {
+    let tmp = copy_fixture("workspace-sbom-populated");
+    let parsed = run_sbom_json(tmp.path(), "spdx", &[]);
+    let packages = parsed["packages"].as_array().expect("packages");
+    assert!(
+        packages.iter().any(|p| p["name"] == "shared-lib"),
+        "shared-lib should be in SPDX packages"
+    );
 }

--- a/pacquet/crates/cli/tests/sbom.rs
+++ b/pacquet/crates/cli/tests/sbom.rs
@@ -415,3 +415,77 @@ fn sbom_spdx_download_location() {
     let dl = is_positive["downloadLocation"].as_str().expect("downloadLocation");
     assert!(dl.contains("registry.npmjs.org"), "should have registry URL, got {dl}");
 }
+
+#[test]
+fn sbom_authors_in_metadata() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--sbom-authors", "Alice, Bob"]);
+    let authors = parsed["metadata"]["authors"].as_array().expect("authors");
+    assert_eq!(authors.len(), 2);
+    assert_eq!(authors[0]["name"], "Alice");
+    assert_eq!(authors[1]["name"], "Bob");
+}
+
+#[test]
+fn sbom_supplier_in_metadata() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--sbom-supplier", "ACME Corp"]);
+    assert_eq!(parsed["metadata"]["supplier"]["name"], "ACME Corp");
+}
+
+#[test]
+fn sbom_no_optional_excludes_optional() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--no-optional"]);
+    assert_eq!(parsed["bomFormat"], "CycloneDX");
+}
+
+#[test]
+fn sbom_schema_url_matches_spec_version() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--sbom-spec-version", "1.5"]);
+    let schema = parsed["$schema"].as_str().expect("$schema");
+    assert!(schema.contains("1.5"), "schema should match spec version 1.5, got {schema}");
+}
+
+#[test]
+fn sbom_spdx_root_has_purpose() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "spdx", &[]);
+    let root = &parsed["packages"].as_array().expect("packages")[0];
+    assert_eq!(root["primaryPackagePurpose"], "LIBRARY");
+}
+
+#[test]
+fn sbom_spdx_application_type_purpose() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "spdx", &["--sbom-type", "application"]);
+    let root = &parsed["packages"].as_array().expect("packages")[0];
+    assert_eq!(root["primaryPackagePurpose"], "APPLICATION");
+}
+
+#[test]
+fn sbom_spdx_document_namespace_has_uuid() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "spdx", &[]);
+    let ns = parsed["documentNamespace"].as_str().expect("documentNamespace");
+    assert!(ns.contains("spdx.org/spdxdocs/"), "namespace should contain spdx.org");
+    let parts: Vec<&str> = ns.rsplitn(2, '-').collect();
+    assert!(parts[0].len() >= 8, "namespace should end with UUID-like suffix");
+}
+
+#[test]
+fn sbom_cyclonedx_scoped_root_has_group() {
+    let tmp = copy_fixture("workspace-sbom");
+    // workspace-sbom root has name "workspace-sbom-root" (unscoped)
+    // but app-a is "@test/app-a" - we need a scoped root to test group
+    // Create a temp fixture with scoped name
+    fs::write(
+        tmp.path().join("package.json"),
+        r#"{"name":"@myorg/myapp","version":"2.0.0","license":"MIT"}"#,
+    )
+    .unwrap();
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
+    assert_eq!(parsed["metadata"]["component"]["group"], "@myorg");
+    assert_eq!(parsed["metadata"]["component"]["name"], "myapp");
+}

--- a/pacquet/crates/cli/tests/sbom.rs
+++ b/pacquet/crates/cli/tests/sbom.rs
@@ -44,7 +44,11 @@ fn run_sbom_json(workspace: &Path, format: &str, extra_args: &[&str]) -> serde_j
     let mut args = vec!["sbom", "--sbom-format", format, "--lockfile-only"];
     args.extend_from_slice(extra_args);
     let output = pacquet(workspace, args).output().expect("run pacquet");
-    assert!(output.status.success(), "pacquet sbom failed: {}", String::from_utf8_lossy(&output.stderr));
+    assert!(
+        output.status.success(),
+        "pacquet sbom failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     serde_json::from_slice(&output.stdout).expect("parse JSON output")
 }
 
@@ -61,7 +65,8 @@ fn sbom_cyclonedx_basic() {
     let components = parsed["components"].as_array().expect("components array");
     assert!(!components.is_empty());
 
-    let is_positive = components.iter().find(|c| c["name"] == "is-positive").expect("find is-positive");
+    let is_positive =
+        components.iter().find(|c| c["name"] == "is-positive").expect("find is-positive");
     assert_eq!(is_positive["purl"], "pkg:npm/is-positive@3.1.0");
     assert_eq!(is_positive["version"], "3.1.0");
 }
@@ -95,9 +100,11 @@ fn sbom_prod_excludes_dev() {
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--prod"]);
 
     let components = parsed["components"].as_array().expect("components array");
-    let names: Vec<&str> = components.iter().filter_map(|c| c["name"].as_str()).collect();
-    assert!(names.contains(&"is-positive"), "prod dep should be included");
-    assert!(!names.contains(&"typescript"), "dev dep should be excluded with --prod");
+    assert!(components.iter().any(|c| c["name"] == "is-positive"), "prod dep should be included",);
+    assert!(
+        !components.iter().any(|c| c["name"] == "typescript"),
+        "dev dep should be excluded with --prod",
+    );
 }
 
 #[test]
@@ -106,11 +113,14 @@ fn sbom_dev_only_scope_excluded() {
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
 
     let components = parsed["components"].as_array().expect("components array");
-    let typescript = components.iter().find(|c| c["name"] == "typescript").expect("find typescript");
+    let typescript =
+        components.iter().find(|c| c["name"] == "typescript").expect("find typescript");
     assert_eq!(typescript["scope"], "excluded");
 
     let props = typescript["properties"].as_array().expect("properties");
-    assert!(props.iter().any(|p| p["name"] == "cdx:npm:package:development" && p["value"] == "true"));
+    assert!(
+        props.iter().any(|p| p["name"] == "cdx:npm:package:development" && p["value"] == "true")
+    );
 }
 
 #[test]
@@ -124,18 +134,24 @@ fn sbom_spec_version_1_6() {
 #[test]
 fn sbom_invalid_spec_version_fails() {
     let tmp = copy_fixture("simple-sbom");
-    let output = pacquet(tmp.path(), ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--sbom-spec-version", "2.0"])
-        .output()
-        .expect("run pacquet");
+    let output = pacquet(
+        tmp.path(),
+        ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--sbom-spec-version", "2.0"],
+    )
+    .output()
+    .expect("run pacquet");
     assert!(!output.status.success());
 }
 
 #[test]
 fn sbom_spec_version_with_spdx_fails() {
     let tmp = copy_fixture("simple-sbom");
-    let output = pacquet(tmp.path(), ["sbom", "--sbom-format", "spdx", "--lockfile-only", "--sbom-spec-version", "1.6"])
-        .output()
-        .expect("run pacquet");
+    let output = pacquet(
+        tmp.path(),
+        ["sbom", "--sbom-format", "spdx", "--lockfile-only", "--sbom-spec-version", "1.6"],
+    )
+    .output()
+    .expect("run pacquet");
     assert!(!output.status.success());
 }
 
@@ -176,9 +192,10 @@ fn sbom_dependencies_present() {
     let deps = parsed["dependencies"].as_array().expect("dependencies array");
     assert!(!deps.is_empty());
 
-    let root_dep = deps.iter().find(|d| {
-        d["ref"].as_str().unwrap().contains("simple-sbom-test")
-    }).expect("root in dependencies");
+    let root_dep = deps
+        .iter()
+        .find(|d| d["ref"].as_str().unwrap().contains("simple-sbom-test"))
+        .expect("root in dependencies");
     let depends_on = root_dep["dependsOn"].as_array().expect("dependsOn");
     assert!(depends_on.iter().any(|d| d.as_str().unwrap().contains("is-positive")));
 }
@@ -231,7 +248,14 @@ fn sbom_out_writes_file() {
     let out_path = tmp.path().join("sbom.json");
     let output = pacquet(
         tmp.path(),
-        ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--out", out_path.to_str().unwrap()],
+        [
+            "sbom",
+            "--sbom-format",
+            "cyclonedx",
+            "--lockfile-only",
+            "--out",
+            out_path.to_str().unwrap(),
+        ],
     )
     .output()
     .expect("run pacquet");
@@ -247,6 +271,5 @@ fn sbom_exclude_peers() {
     let tmp = copy_fixture("with-peer-dependency");
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--exclude-peers"]);
     let components = parsed["components"].as_array().expect("components");
-    let names: Vec<&str> = components.iter().filter_map(|c| c["name"].as_str()).collect();
-    assert!(names.contains(&"is-positive"), "non-peer dep should remain");
+    assert!(components.iter().any(|c| c["name"] == "is-positive"), "non-peer dep should remain",);
 }

--- a/pacquet/crates/cli/tests/sbom.rs
+++ b/pacquet/crates/cli/tests/sbom.rs
@@ -272,11 +272,79 @@ fn sbom_out_writes_file() {
 }
 
 #[test]
-fn sbom_exclude_peers() {
+fn sbom_includes_peers_by_default() {
+    let tmp = copy_fixture("with-peer-dependency");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
+    let components = parsed["components"].as_array().expect("components");
+    assert!(components.iter().any(|c| c["name"] == "is-positive"));
+    assert!(
+        components.iter().any(|c| c["name"] == "is-odd"),
+        "peer dep should be included by default"
+    );
+    assert!(
+        components.iter().any(|c| c["name"] == "is-number"),
+        "transitive of peer should be included"
+    );
+}
+
+#[test]
+fn sbom_exclude_peers_drops_subtree() {
     let tmp = copy_fixture("with-peer-dependency");
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--exclude-peers"]);
     let components = parsed["components"].as_array().expect("components");
     assert!(components.iter().any(|c| c["name"] == "is-positive"), "non-peer dep should remain");
+    assert!(!components.iter().any(|c| c["name"] == "is-odd"), "peer dep should be excluded");
+    assert!(
+        !components.iter().any(|c| c["name"] == "is-number"),
+        "transitive dep reachable only through peer should be excluded"
+    );
+    let root_ref = parsed["metadata"]["component"]["bom-ref"].as_str().expect("bom-ref");
+    let root_deps = parsed["dependencies"]
+        .as_array()
+        .expect("deps")
+        .iter()
+        .find(|d| d["ref"] == root_ref)
+        .expect("root deps");
+    assert!(
+        !root_deps["dependsOn"]
+            .as_array()
+            .expect("dependsOn")
+            .iter()
+            .any(|d| d.as_str().unwrap().contains("is-odd")),
+        "peer should not appear in root dependency graph"
+    );
+}
+
+#[test]
+fn sbom_exclude_peers_workspace_sub_packages() {
+    let tmp = copy_fixture("with-peer-workspace");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--exclude-peers"]);
+    let components = parsed["components"].as_array().expect("components");
+    assert!(components.iter().any(|c| c["name"] == "is-positive"));
+    assert!(
+        !components.iter().any(|c| c["name"] == "is-odd"),
+        "peer in sub-package should be excluded"
+    );
+}
+
+#[test]
+fn sbom_exclude_peers_tolerates_malformed_manifest() {
+    let tmp = copy_fixture("with-peer-workspace");
+    fs::write(tmp.path().join("packages/pkg-a/package.json"), "{ not valid json").unwrap();
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--exclude-peers"]);
+    let components = parsed["components"].as_array().expect("components");
+    assert!(components.iter().any(|c| c["name"] == "is-positive"), "should still produce output");
+}
+
+#[test]
+fn sbom_exclude_peers_keeps_real_dep_in_other_importer() {
+    let tmp = copy_fixture("with-peer-and-real-dep");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--exclude-peers"]);
+    let components = parsed["components"].as_array().expect("components");
+    assert!(
+        components.iter().any(|c| c["name"] == "is-odd"),
+        "is-odd is a peer in pkg-a but a real dep in pkg-b; should be kept"
+    );
 }
 
 #[test]
@@ -439,10 +507,12 @@ fn sbom_supplier_in_metadata() {
 }
 
 #[test]
-fn sbom_no_optional_excludes_optional() {
+fn sbom_no_optional_does_not_break_output() {
     let tmp = copy_fixture("simple-sbom");
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--no-optional"]);
     assert_eq!(parsed["bomFormat"], "CycloneDX");
+    let components = parsed["components"].as_array().expect("components");
+    assert!(components.iter().any(|c| c["name"] == "is-positive"), "prod dep still present");
 }
 
 #[test]
@@ -627,5 +697,67 @@ fn sbom_workspace_spdx_link_deps() {
     assert!(
         packages.iter().any(|p| p["name"] == "shared-lib"),
         "shared-lib should be in SPDX packages"
+    );
+}
+
+#[test]
+fn sbom_missing_lockfile_fails() {
+    let tmp = TempDir::new().expect("create temp dir");
+    fs::write(tmp.path().join("package.json"), r#"{"name":"no-lockfile","version":"1.0.0"}"#)
+        .unwrap();
+    let output = pacquet(tmp.path(), ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only"])
+        .output()
+        .expect("run pacquet");
+    assert!(!output.status.success(), "should fail without lockfile");
+}
+
+#[test]
+fn sbom_prod_scope_undefined_for_prod_components() {
+    let tmp = copy_fixture("with-dev-dependency");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
+    let components = parsed["components"].as_array().expect("components");
+    let is_positive = components.iter().find(|c| c["name"] == "is-positive").expect("is-positive");
+    assert!(is_positive.get("scope").is_none(), "prod components should not have scope field");
+}
+
+#[test]
+fn sbom_split_single_project_not_triggered() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
+    assert!(
+        parsed["bomFormat"].is_string(),
+        "single project should produce regular JSON, not NDJSON"
+    );
+}
+
+#[test]
+fn sbom_workspace_split_each_line_has_correct_root() {
+    let tmp = copy_fixture("workspace-sbom-populated");
+    let output =
+        pacquet(tmp.path(), ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--split"])
+            .output()
+            .expect("run pacquet");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let boms: Vec<serde_json::Value> = stdout
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str(l).expect("valid JSON"))
+        .collect();
+    let root_names: Vec<&str> =
+        boms.iter().filter_map(|b| b["metadata"]["component"]["name"].as_str()).collect();
+    assert!(root_names.contains(&"app-a"), "split should include app-a");
+    assert!(root_names.contains(&"app-b"), "split should include app-b");
+}
+
+#[test]
+fn sbom_dev_flag_includes_only_dev() {
+    let tmp = copy_fixture("with-dev-dependency");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--dev"]);
+    let components = parsed["components"].as_array().expect("components");
+    assert!(components.iter().any(|c| c["name"] == "typescript"), "dev dep should be included");
+    assert!(
+        !components.iter().any(|c| c["name"] == "is-positive"),
+        "prod dep should be excluded with --dev"
     );
 }

--- a/pacquet/crates/cli/tests/sbom.rs
+++ b/pacquet/crates/cli/tests/sbom.rs
@@ -1,0 +1,252 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use std::{ffi::OsStr, fs, path::Path, process::Command};
+use tempfile::TempDir;
+
+fn copy_fixture(name: &str) -> TempDir {
+    let tmp = TempDir::new().expect("create temp dir");
+    let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../pnpm11/deps/compliance/commands/test/sbom/fixtures")
+        .join(name);
+    for entry in fs::read_dir(&fixture_dir).expect("read fixture dir") {
+        let entry = entry.expect("read dir entry");
+        let dest = tmp.path().join(entry.file_name());
+        if entry.file_type().expect("file type").is_dir() {
+            copy_dir_recursive(&entry.path(), &dest);
+        } else {
+            fs::copy(entry.path(), dest).expect("copy file");
+        }
+    }
+    tmp
+}
+
+fn copy_dir_recursive(src: &Path, dest: &Path) {
+    fs::create_dir_all(dest).expect("create dir");
+    for entry in fs::read_dir(src).expect("read dir") {
+        let entry = entry.expect("read entry");
+        let target = dest.join(entry.file_name());
+        if entry.file_type().expect("file type").is_dir() {
+            copy_dir_recursive(&entry.path(), &target);
+        } else {
+            fs::copy(entry.path(), target).expect("copy file");
+        }
+    }
+}
+
+fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
+    Command::cargo_bin("pacquet")
+        .expect("find the pacquet binary")
+        .with_current_dir(workspace)
+        .with_args(args)
+}
+
+fn run_sbom_json(workspace: &Path, format: &str, extra_args: &[&str]) -> serde_json::Value {
+    let mut args = vec!["sbom", "--sbom-format", format, "--lockfile-only"];
+    args.extend_from_slice(extra_args);
+    let output = pacquet(workspace, args).output().expect("run pacquet");
+    assert!(output.status.success(), "pacquet sbom failed: {}", String::from_utf8_lossy(&output.stderr));
+    serde_json::from_slice(&output.stdout).expect("parse JSON output")
+}
+
+#[test]
+fn sbom_cyclonedx_basic() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
+
+    assert_eq!(parsed["bomFormat"], "CycloneDX");
+    assert_eq!(parsed["specVersion"], "1.7");
+    assert_eq!(parsed["metadata"]["component"]["name"], "simple-sbom-test");
+    assert_eq!(parsed["metadata"]["component"]["version"], "1.0.0");
+
+    let components = parsed["components"].as_array().expect("components array");
+    assert!(!components.is_empty());
+
+    let is_positive = components.iter().find(|c| c["name"] == "is-positive").expect("find is-positive");
+    assert_eq!(is_positive["purl"], "pkg:npm/is-positive@3.1.0");
+    assert_eq!(is_positive["version"], "3.1.0");
+}
+
+#[test]
+fn sbom_spdx_basic() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "spdx", &[]);
+
+    assert_eq!(parsed["spdxVersion"], "SPDX-2.3");
+    assert_eq!(parsed["dataLicense"], "CC0-1.0");
+
+    let packages = parsed["packages"].as_array().expect("packages array");
+    assert!(packages.len() > 1);
+
+    let root = &packages[0];
+    assert_eq!(root["name"], "simple-sbom-test");
+    assert_eq!(root["versionInfo"], "1.0.0");
+}
+
+#[test]
+fn sbom_missing_format_fails() {
+    let tmp = copy_fixture("simple-sbom");
+    let output = pacquet(tmp.path(), ["sbom"]).output().expect("run pacquet");
+    assert!(!output.status.success());
+}
+
+#[test]
+fn sbom_prod_excludes_dev() {
+    let tmp = copy_fixture("with-dev-dependency");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--prod"]);
+
+    let components = parsed["components"].as_array().expect("components array");
+    let names: Vec<&str> = components.iter().filter_map(|c| c["name"].as_str()).collect();
+    assert!(names.contains(&"is-positive"), "prod dep should be included");
+    assert!(!names.contains(&"typescript"), "dev dep should be excluded with --prod");
+}
+
+#[test]
+fn sbom_dev_only_scope_excluded() {
+    let tmp = copy_fixture("with-dev-dependency");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
+
+    let components = parsed["components"].as_array().expect("components array");
+    let typescript = components.iter().find(|c| c["name"] == "typescript").expect("find typescript");
+    assert_eq!(typescript["scope"], "excluded");
+
+    let props = typescript["properties"].as_array().expect("properties");
+    assert!(props.iter().any(|p| p["name"] == "cdx:npm:package:development" && p["value"] == "true"));
+}
+
+#[test]
+fn sbom_spec_version_1_6() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--sbom-spec-version", "1.6"]);
+    assert_eq!(parsed["specVersion"], "1.6");
+    assert!(parsed["$schema"].as_str().unwrap().contains("1.6"));
+}
+
+#[test]
+fn sbom_invalid_spec_version_fails() {
+    let tmp = copy_fixture("simple-sbom");
+    let output = pacquet(tmp.path(), ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--sbom-spec-version", "2.0"])
+        .output()
+        .expect("run pacquet");
+    assert!(!output.status.success());
+}
+
+#[test]
+fn sbom_spec_version_with_spdx_fails() {
+    let tmp = copy_fixture("simple-sbom");
+    let output = pacquet(tmp.path(), ["sbom", "--sbom-format", "spdx", "--lockfile-only", "--sbom-spec-version", "1.6"])
+        .output()
+        .expect("run pacquet");
+    assert!(!output.status.success());
+}
+
+#[test]
+fn sbom_application_type() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--sbom-type", "application"]);
+    assert_eq!(parsed["metadata"]["component"]["type"], "application");
+}
+
+#[test]
+fn sbom_has_serial_number() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
+    let serial = parsed["serialNumber"].as_str().expect("serialNumber");
+    assert!(serial.starts_with("urn:uuid:"), "serialNumber should start with urn:uuid:");
+}
+
+#[test]
+fn sbom_has_timestamp() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
+    assert!(parsed["metadata"]["timestamp"].is_string());
+}
+
+#[test]
+fn sbom_has_tools() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
+    let tools = parsed["metadata"]["tools"]["components"].as_array().expect("tools");
+    assert!(tools.iter().any(|t| t["name"] == "pacquet"));
+}
+
+#[test]
+fn sbom_dependencies_present() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
+    let deps = parsed["dependencies"].as_array().expect("dependencies array");
+    assert!(!deps.is_empty());
+
+    let root_dep = deps.iter().find(|d| {
+        d["ref"].as_str().unwrap().contains("simple-sbom-test")
+    }).expect("root in dependencies");
+    let depends_on = root_dep["dependsOn"].as_array().expect("dependsOn");
+    assert!(depends_on.iter().any(|d| d.as_str().unwrap().contains("is-positive")));
+}
+
+#[test]
+fn sbom_root_license() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
+    let licenses = parsed["metadata"]["component"]["licenses"].as_array().expect("licenses");
+    assert!(!licenses.is_empty());
+}
+
+#[test]
+fn sbom_root_description() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
+    assert!(parsed["metadata"]["component"]["description"].is_string());
+}
+
+#[test]
+fn sbom_spdx_creation_info() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "spdx", &[]);
+    assert!(parsed["creationInfo"]["created"].is_string());
+    let creators = parsed["creationInfo"]["creators"].as_array().expect("creators");
+    assert!(creators.iter().any(|c| c.as_str().unwrap().contains("pacquet")));
+}
+
+#[test]
+fn sbom_spdx_describes_relationship() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "spdx", &[]);
+    let rels = parsed["relationships"].as_array().expect("relationships");
+    assert!(rels.iter().any(|r| r["relationshipType"] == "DESCRIBES"));
+}
+
+#[test]
+fn sbom_component_has_distribution_ref() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
+    let components = parsed["components"].as_array().expect("components");
+    let is_positive = components.iter().find(|c| c["name"] == "is-positive").expect("is-positive");
+    let ext_refs = is_positive["externalReferences"].as_array().expect("externalReferences");
+    assert!(ext_refs.iter().any(|r| r["type"] == "distribution"));
+}
+
+#[test]
+fn sbom_out_writes_file() {
+    let tmp = copy_fixture("simple-sbom");
+    let out_path = tmp.path().join("sbom.json");
+    let output = pacquet(
+        tmp.path(),
+        ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--out", out_path.to_str().unwrap()],
+    )
+    .output()
+    .expect("run pacquet");
+    assert!(output.status.success());
+    assert!(out_path.exists(), "output file should be created");
+    let content: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&out_path).unwrap()).expect("valid JSON");
+    assert_eq!(content["bomFormat"], "CycloneDX");
+}
+
+#[test]
+fn sbom_exclude_peers() {
+    let tmp = copy_fixture("with-peer-dependency");
+    let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--exclude-peers"]);
+    let components = parsed["components"].as_array().expect("components");
+    let names: Vec<&str> = components.iter().filter_map(|c| c["name"].as_str()).collect();
+    assert!(names.contains(&"is-positive"), "non-peer dep should remain");
+}

--- a/pacquet/crates/cli/tests/sbom.rs
+++ b/pacquet/crates/cli/tests/sbom.rs
@@ -71,7 +71,7 @@ fn sbom_cyclonedx_basic() {
     assert!(!components.is_empty());
 
     let is_positive =
-        components.iter().find(|c| c["name"] == "is-positive").expect("find is-positive");
+        components.iter().find(|comp| comp["name"] == "is-positive").expect("find is-positive");
     assert_eq!(is_positive["purl"], "pkg:npm/is-positive@3.1.0");
     assert_eq!(is_positive["version"], "3.1.0");
 }
@@ -105,9 +105,12 @@ fn sbom_prod_excludes_dev() {
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--prod"]);
 
     let components = parsed["components"].as_array().expect("components array");
-    assert!(components.iter().any(|c| c["name"] == "is-positive"), "prod dep should be included");
     assert!(
-        !components.iter().any(|c| c["name"] == "typescript"),
+        components.iter().any(|comp| comp["name"] == "is-positive"),
+        "prod dep should be included",
+    );
+    assert!(
+        !components.iter().any(|comp| comp["name"] == "typescript"),
         "dev dep should be excluded with --prod",
     );
 }
@@ -119,12 +122,14 @@ fn sbom_dev_only_scope_excluded() {
 
     let components = parsed["components"].as_array().expect("components array");
     let typescript =
-        components.iter().find(|c| c["name"] == "typescript").expect("find typescript");
+        components.iter().find(|comp| comp["name"] == "typescript").expect("find typescript");
     assert_eq!(typescript["scope"], "excluded");
 
     let props = typescript["properties"].as_array().expect("properties");
     assert!(
-        props.iter().any(|p| p["name"] == "cdx:npm:package:development" && p["value"] == "true"),
+        props
+            .iter()
+            .any(|prop| prop["name"] == "cdx:npm:package:development" && prop["value"] == "true"),
     );
 }
 
@@ -187,7 +192,7 @@ fn sbom_has_tools() {
     let tmp = copy_fixture("simple-sbom");
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
     let tools = parsed["metadata"]["tools"]["components"].as_array().expect("tools");
-    assert!(tools.iter().any(|t| t["name"] == "pacquet"));
+    assert!(tools.iter().any(|tool| tool["name"] == "pacquet"));
 }
 
 #[test]
@@ -199,10 +204,10 @@ fn sbom_dependencies_present() {
 
     let root_dep = deps
         .iter()
-        .find(|d| d["ref"].as_str().unwrap().contains("simple-sbom-test"))
+        .find(|dep| dep["ref"].as_str().unwrap().contains("simple-sbom-test"))
         .expect("root in dependencies");
     let depends_on = root_dep["dependsOn"].as_array().expect("dependsOn");
-    assert!(depends_on.iter().any(|d| d.as_str().unwrap().contains("is-positive")));
+    assert!(depends_on.iter().any(|dep| dep.as_str().unwrap().contains("is-positive")));
 }
 
 #[test]
@@ -226,7 +231,7 @@ fn sbom_spdx_creation_info() {
     let parsed = run_sbom_json(tmp.path(), "spdx", &[]);
     assert!(parsed["creationInfo"]["created"].is_string());
     let creators = parsed["creationInfo"]["creators"].as_array().expect("creators");
-    assert!(creators.iter().any(|c| c.as_str().unwrap().contains("pacquet")));
+    assert!(creators.iter().any(|creator| creator.as_str().unwrap().contains("pacquet")));
 }
 
 #[test]
@@ -234,7 +239,7 @@ fn sbom_spdx_describes_relationship() {
     let tmp = copy_fixture("simple-sbom");
     let parsed = run_sbom_json(tmp.path(), "spdx", &[]);
     let rels = parsed["relationships"].as_array().expect("relationships");
-    assert!(rels.iter().any(|r| r["relationshipType"] == "DESCRIBES"));
+    assert!(rels.iter().any(|rel| rel["relationshipType"] == "DESCRIBES"));
 }
 
 #[test]
@@ -242,9 +247,10 @@ fn sbom_component_has_distribution_ref() {
     let tmp = copy_fixture("simple-sbom");
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
     let components = parsed["components"].as_array().expect("components");
-    let is_positive = components.iter().find(|c| c["name"] == "is-positive").expect("is-positive");
+    let is_positive =
+        components.iter().find(|comp| comp["name"] == "is-positive").expect("is-positive");
     let ext_refs = is_positive["externalReferences"].as_array().expect("externalReferences");
-    assert!(ext_refs.iter().any(|r| r["type"] == "distribution"));
+    assert!(ext_refs.iter().any(|ext_ref| ext_ref["type"] == "distribution"));
 }
 
 #[test]
@@ -276,13 +282,13 @@ fn sbom_includes_peers_by_default() {
     let tmp = copy_fixture("with-peer-dependency");
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
     let components = parsed["components"].as_array().expect("components");
-    assert!(components.iter().any(|c| c["name"] == "is-positive"));
+    assert!(components.iter().any(|comp| comp["name"] == "is-positive"));
     assert!(
-        components.iter().any(|c| c["name"] == "is-odd"),
+        components.iter().any(|comp| comp["name"] == "is-odd"),
         "peer dep should be included by default",
     );
     assert!(
-        components.iter().any(|c| c["name"] == "is-number"),
+        components.iter().any(|comp| comp["name"] == "is-number"),
         "transitive of peer should be included",
     );
 }
@@ -292,10 +298,13 @@ fn sbom_exclude_peers_drops_subtree() {
     let tmp = copy_fixture("with-peer-dependency");
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--exclude-peers"]);
     let components = parsed["components"].as_array().expect("components");
-    assert!(components.iter().any(|c| c["name"] == "is-positive"), "non-peer dep should remain");
-    assert!(!components.iter().any(|c| c["name"] == "is-odd"), "peer dep should be excluded");
     assert!(
-        !components.iter().any(|c| c["name"] == "is-number"),
+        components.iter().any(|comp| comp["name"] == "is-positive"),
+        "non-peer dep should remain",
+    );
+    assert!(!components.iter().any(|comp| comp["name"] == "is-odd"), "peer dep should be excluded");
+    assert!(
+        !components.iter().any(|comp| comp["name"] == "is-number"),
         "transitive dep reachable only through peer should be excluded",
     );
     let root_ref = parsed["metadata"]["component"]["bom-ref"].as_str().expect("bom-ref");
@@ -303,14 +312,14 @@ fn sbom_exclude_peers_drops_subtree() {
         .as_array()
         .expect("deps")
         .iter()
-        .find(|d| d["ref"] == root_ref)
+        .find(|dep| dep["ref"] == root_ref)
         .expect("root deps");
     assert!(
         !root_deps["dependsOn"]
             .as_array()
             .expect("dependsOn")
             .iter()
-            .any(|d| d.as_str().unwrap().contains("is-odd")),
+            .any(|dep| dep.as_str().unwrap().contains("is-odd")),
         "peer should not appear in root dependency graph",
     );
 }
@@ -320,9 +329,9 @@ fn sbom_exclude_peers_workspace_sub_packages() {
     let tmp = copy_fixture("with-peer-workspace");
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--exclude-peers"]);
     let components = parsed["components"].as_array().expect("components");
-    assert!(components.iter().any(|c| c["name"] == "is-positive"));
+    assert!(components.iter().any(|comp| comp["name"] == "is-positive"));
     assert!(
-        !components.iter().any(|c| c["name"] == "is-odd"),
+        !components.iter().any(|comp| comp["name"] == "is-odd"),
         "peer in sub-package should be excluded",
     );
 }
@@ -333,7 +342,10 @@ fn sbom_exclude_peers_tolerates_malformed_manifest() {
     fs::write(tmp.path().join("packages/pkg-a/package.json"), "{ not valid json").unwrap();
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--exclude-peers"]);
     let components = parsed["components"].as_array().expect("components");
-    assert!(components.iter().any(|c| c["name"] == "is-positive"), "should still produce output");
+    assert!(
+        components.iter().any(|comp| comp["name"] == "is-positive"),
+        "should still produce output",
+    );
 }
 
 #[test]
@@ -342,7 +354,7 @@ fn sbom_exclude_peers_keeps_real_dep_in_other_importer() {
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--exclude-peers"]);
     let components = parsed["components"].as_array().expect("components");
     assert!(
-        components.iter().any(|c| c["name"] == "is-odd"),
+        components.iter().any(|comp| comp["name"] == "is-odd"),
         "is-odd is a peer in pkg-a but a real dep in pkg-b; should be kept",
     );
 }
@@ -397,10 +409,13 @@ fn sbom_dev_flag_excludes_prod() {
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--dev"]);
     let components = parsed["components"].as_array().expect("components");
     assert!(
-        !components.iter().any(|c| c["name"] == "is-positive"),
+        !components.iter().any(|comp| comp["name"] == "is-positive"),
         "prod dep should be excluded with --dev",
     );
-    assert!(components.iter().any(|c| c["name"] == "typescript"), "dev dep should be included");
+    assert!(
+        components.iter().any(|comp| comp["name"] == "typescript"),
+        "dev dep should be included",
+    );
 }
 
 #[test]
@@ -412,7 +427,7 @@ fn sbom_split_outputs_ndjson() {
             .expect("run pacquet");
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    let lines: Vec<&str> = stdout.lines().filter(|line| !line.is_empty()).collect();
     // Fixture lockfile only has root importer (TS tests install first to populate all importers)
     assert!(!lines.is_empty(), "should output at least one NDJSON line");
     for line in &lines {
@@ -445,7 +460,7 @@ fn sbom_split_out_writes_per_package_files() {
     assert!(out_dir.exists(), "output directory should be created");
     let files: Vec<String> = fs::read_dir(&out_dir)
         .expect("read output dir")
-        .filter_map(|e| e.ok().map(|e| e.file_name().to_string_lossy().to_string()))
+        .filter_map(|entry| entry.ok().map(|entry| entry.file_name().to_string_lossy().to_string()))
         .collect();
     assert!(!files.is_empty(), "should write at least one file");
 }
@@ -484,7 +499,8 @@ fn sbom_spdx_download_location() {
     let tmp = copy_fixture("simple-sbom");
     let parsed = run_sbom_json(tmp.path(), "spdx", &[]);
     let packages = parsed["packages"].as_array().expect("packages");
-    let is_positive = packages.iter().find(|p| p["name"] == "is-positive").expect("is-positive");
+    let is_positive =
+        packages.iter().find(|pkg| pkg["name"] == "is-positive").expect("is-positive");
     let dl = is_positive["downloadLocation"].as_str().expect("downloadLocation");
     assert!(dl.contains("registry.npmjs.org"), "should have registry URL, got {dl}");
 }
@@ -512,7 +528,7 @@ fn sbom_no_optional_does_not_break_output() {
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--no-optional"]);
     assert_eq!(parsed["bomFormat"], "CycloneDX");
     let components = parsed["components"].as_array().expect("components");
-    assert!(components.iter().any(|c| c["name"] == "is-positive"), "prod dep still present");
+    assert!(components.iter().any(|comp| comp["name"] == "is-positive"), "prod dep still present");
 }
 
 #[test]
@@ -570,7 +586,7 @@ fn sbom_workspace_link_deps_as_components() {
     let tmp = copy_fixture("workspace-sbom-populated");
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
     let components = parsed["components"].as_array().expect("components");
-    let names: Vec<&str> = components.iter().filter_map(|c| c["name"].as_str()).collect();
+    let names: Vec<&str> = components.iter().filter_map(|comp| comp["name"].as_str()).collect();
     assert!(names.contains(&"is-positive"), "registry dep should be included");
     assert!(names.contains(&"is-negative"), "registry dep from app-b should be included");
     assert!(names.contains(&"shared-lib"), "workspace link dep should be included as component");
@@ -586,7 +602,7 @@ fn sbom_workspace_split_produces_multiple_lines() {
             .expect("run pacquet");
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    let lines: Vec<&str> = stdout.lines().filter(|line| !line.is_empty()).collect();
     assert!(
         lines.len() >= 3,
         "workspace with 4 importers should produce at least 3 NDJSON lines (root may be empty), got {}",
@@ -620,7 +636,7 @@ fn sbom_workspace_split_out_writes_files() {
     let out_dir = tmp.path().join("out");
     let files: Vec<String> = fs::read_dir(&out_dir)
         .expect("read output dir")
-        .filter_map(|e| e.ok().map(|e| e.file_name().to_string_lossy().to_string()))
+        .filter_map(|entry| entry.ok().map(|entry| entry.file_name().to_string_lossy().to_string()))
         .collect();
     assert!(files.len() >= 3, "should write files for workspace packages, got {files:?}");
 }
@@ -647,10 +663,10 @@ fn sbom_workspace_split_out_percent_v() {
     let out_dir = tmp.path().join("out");
     let files: Vec<String> = fs::read_dir(&out_dir)
         .expect("read output dir")
-        .filter_map(|e| e.ok().map(|e| e.file_name().to_string_lossy().to_string()))
+        .filter_map(|entry| entry.ok().map(|entry| entry.file_name().to_string_lossy().to_string()))
         .collect();
     assert!(
-        files.iter().any(|f| f.contains("1.0.0")),
+        files.iter().any(|file| file.contains("1.0.0")),
         "filenames should contain version: {files:?}",
     );
 }
@@ -672,7 +688,7 @@ fn sbom_workspace_filter_selects_importer() {
     let parsed: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("parse JSON output");
     let components = parsed["components"].as_array().expect("components");
-    let names: Vec<&str> = components.iter().filter_map(|c| c["name"].as_str()).collect();
+    let names: Vec<&str> = components.iter().filter_map(|comp| comp["name"].as_str()).collect();
     assert!(names.contains(&"is-positive"), "app-a dep should be included");
     assert!(!names.contains(&"is-negative"), "app-b dep should be excluded by filter");
 }
@@ -682,7 +698,7 @@ fn sbom_workspace_link_dep_has_metadata() {
     let tmp = copy_fixture("workspace-sbom-populated");
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
     let components = parsed["components"].as_array().expect("components");
-    let shared_lib = components.iter().find(|c| c["name"] == "shared-lib");
+    let shared_lib = components.iter().find(|comp| comp["name"] == "shared-lib");
     assert!(shared_lib.is_some(), "shared-lib should be a component");
     let shared_lib = shared_lib.unwrap();
     assert_eq!(shared_lib["version"], "0.1.0");
@@ -695,7 +711,7 @@ fn sbom_workspace_spdx_link_deps() {
     let parsed = run_sbom_json(tmp.path(), "spdx", &[]);
     let packages = parsed["packages"].as_array().expect("packages");
     assert!(
-        packages.iter().any(|p| p["name"] == "shared-lib"),
+        packages.iter().any(|pkg| pkg["name"] == "shared-lib"),
         "shared-lib should be in SPDX packages",
     );
 }
@@ -716,7 +732,8 @@ fn sbom_prod_scope_undefined_for_prod_components() {
     let tmp = copy_fixture("with-dev-dependency");
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
     let components = parsed["components"].as_array().expect("components");
-    let is_positive = components.iter().find(|c| c["name"] == "is-positive").expect("is-positive");
+    let is_positive =
+        components.iter().find(|comp| comp["name"] == "is-positive").expect("is-positive");
     assert!(is_positive.get("scope").is_none(), "prod components should not have scope field");
 }
 
@@ -741,11 +758,11 @@ fn sbom_workspace_split_each_line_has_correct_root() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let boms: Vec<serde_json::Value> = stdout
         .lines()
-        .filter(|l| !l.is_empty())
-        .map(|l| serde_json::from_str(l).expect("valid JSON"))
+        .filter(|line| !line.is_empty())
+        .map(|line| serde_json::from_str(line).expect("valid JSON"))
         .collect();
     let root_names: Vec<&str> =
-        boms.iter().filter_map(|b| b["metadata"]["component"]["name"].as_str()).collect();
+        boms.iter().filter_map(|bom| bom["metadata"]["component"]["name"].as_str()).collect();
     assert!(root_names.contains(&"app-a"), "split should include app-a");
     assert!(root_names.contains(&"app-b"), "split should include app-b");
 }
@@ -755,9 +772,12 @@ fn sbom_dev_flag_includes_only_dev() {
     let tmp = copy_fixture("with-dev-dependency");
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--dev"]);
     let components = parsed["components"].as_array().expect("components");
-    assert!(components.iter().any(|c| c["name"] == "typescript"), "dev dep should be included");
     assert!(
-        !components.iter().any(|c| c["name"] == "is-positive"),
+        components.iter().any(|comp| comp["name"] == "typescript"),
+        "dev dep should be included",
+    );
+    assert!(
+        !components.iter().any(|comp| comp["name"] == "is-positive"),
         "prod dep should be excluded with --dev",
     );
 }


### PR DESCRIPTION
Port of pnpm's `sbom` command to pacquet. Generates CycloneDX (1.5-1.7) and SPDX 2.3 SBOMs from the lockfile.

Ref: https://github.com/pnpm/pnpm/issues/11633

| Feature | Status |
|---|---|
| Lockfile dependency graph walking | done |
| PURL generation (scoped + unscoped) | done |
| Dev-only dep type detection (`detectDepTypes`) | done |
| Package metadata from virtual store | done |
| CycloneDX serializer (1.5/1.6/1.7) | done |
| SPDX 2.3 serializer | done |
| `--prod`/`--dev`/`--no-optional` filtering | done |
| `--exclude-peers` (per-importer) | done |
| `--out` with `%s`/`%v` interpolation | done |
| `--lockfile-only` mode | done |
| `--sbom-authors`/`--sbom-supplier` | done |
| `--sbom-spec-version` validation | done |
| `serialNumber` / `documentNamespace` UUIDs | done |
| License classification (id vs expression) | done |
| External refs (distribution, vcs, website, issue-tracker) | done |
| Integrity hashes on distribution ext ref | done |
| Workspace `link:` deps as components | done |
| `--split` (per-workspace-package SBOMs) | done |
| Per-importer `--exclude-peers` | done |
| `recursiveByDefault` + `--filter` | done |
| Registry tarball URL construction | done |
| Path traversal guard on `--out` | done |
| Iterative graph walks (no stack overflow) | done |

Output verified 1:1 against pnpm's sbom on test fixtures and real projects up to around 3000 components. Normalized JSON (sort keys, strip timestamps/UUIDs/tool name) matches exactly; only difference is dependency array ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `sbom` command to generate software bills of materials from project lockfile data.
  * Supports CycloneDX or SPDX output, dependency filtering, workspace splitting, and writing results to stdout or files.
* **Tests**
  * Added broad coverage for SBOM output formats, option handling, validation errors, workspace behavior, and file generation.
  * Included fixture workspaces to validate end-to-end SBOM generation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->