### PR TITLE
feat: add `issues` alias to `bugs` command

### DIFF
--- a/.changeset/bugs-issues-alias.md
+++ b/.changeset/bugs-issues-alias.md
@@ -1,0 +1,5 @@
+---
+"pnpm": minor
+---
+
+Added the `issues` command as an alias of `bugs`, so `pnpm issues` opens the package's bug tracker URL in the browser.

--- a/.changeset/bugs-issues-alias.md
+++ b/.changeset/bugs-issues-alias.md
@@ -1,4 +1,5 @@
 ---
+"@pnpm/deps.inspection.commands": minor
 "pnpm": minor
 ---
 

--- a/pnpm11/deps/inspection/commands/src/bugs/index.ts
+++ b/pnpm11/deps/inspection/commands/src/bugs/index.ts
@@ -22,7 +22,10 @@ export function help (): string {
   return renderHelp({
     description: "Opens the URL of the package's bug tracker in a browser.",
     url: docsUrl('bugs'),
-    usages: ['pnpm bugs [<pkgname> [<pkgname> ...]]'],
+    usages: [
+      'pnpm bugs [<pkgname> [<pkgname> ...]]',
+      'pnpm issues [<pkgname> [<pkgname> ...]]',
+    ],
   })
 }
 

--- a/pnpm11/deps/inspection/commands/src/bugs/index.ts
+++ b/pnpm11/deps/inspection/commands/src/bugs/index.ts
@@ -16,7 +16,7 @@ export function cliOptionsTypes (): Record<string, unknown> {
   return rcOptionsTypes()
 }
 
-export const commandNames = ['bugs']
+export const commandNames = ['bugs', 'issues']
 
 export function help (): string {
   return renderHelp({

--- a/pnpm11/deps/inspection/commands/test/bugs.ts
+++ b/pnpm11/deps/inspection/commands/test/bugs.ts
@@ -23,6 +23,8 @@ test('bugs: command should be available', () => {
   expect(bugs.handler).toBeDefined()
   expect(bugs.help).toBeDefined()
   expect(bugs.commandNames).toEqual(['bugs', 'issues'])
+  expect(bugs.help()).toContain('pnpm bugs')
+  expect(bugs.help()).toContain('pnpm issues')
 })
 
 test('bugs: opens bugs.url from local manifest', async () => {

--- a/pnpm11/deps/inspection/commands/test/bugs.ts
+++ b/pnpm11/deps/inspection/commands/test/bugs.ts
@@ -22,7 +22,7 @@ const BASE_OPTIONS = {
 test('bugs: command should be available', () => {
   expect(bugs.handler).toBeDefined()
   expect(bugs.help).toBeDefined()
-  expect(bugs.commandNames).toEqual(['bugs'])
+  expect(bugs.commandNames).toEqual(['bugs', 'issues'])
 })
 
 test('bugs: opens bugs.url from local manifest', async () => {

--- a/pnpm11/pnpm/src/cmd/notImplemented.ts
+++ b/pnpm11/pnpm/src/cmd/notImplemented.ts
@@ -5,7 +5,6 @@ import type { CommandDefinition } from './index.js'
 const NOT_IMPLEMENTED_COMMANDS = [
   'access',
   'edit',
-  'issues',
   'profile',
   'set-script',
   'team',

--- a/pnpm11/pnpm/test/dlx.ts
+++ b/pnpm11/pnpm/test/dlx.ts
@@ -337,7 +337,12 @@ test('dlx creates cache and store prune cleans cache', async () => {
     '--allow-build=shx',
     '--allow-build=shx@https://codeload.github.com/shelljs/shx/tar.gz/61aca968cd7afc712ca61a4fc4ec3201e3770dc7',
   ]
-  await Promise.all(Object.entries(commands).map(([cmd, args]) => execPnpm([...settings, ...allowBuilds, 'dlx', cmd, ...args])))
+
+  /* eslint-disable no-await-in-loop */
+  for (const [cmd, args] of Object.entries(commands)) {
+    await execPnpm([...settings, ...allowBuilds, 'dlx', cmd, ...args])
+  }
+  /* eslint-enable no-await-in-loop */
 
   // ensure that the dlx cache has certain structure
   const dlxBaseDir = path.resolve('cache', 'dlx')

--- a/pnpm11/pnpm/test/parseCliArgs.test.ts
+++ b/pnpm11/pnpm/test/parseCliArgs.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@jest/globals'
+
+import { getCliOptionsTypes, getCommandFullName, pnpmCmds } from '../src/cmd/index.js'
+import { parseCliArgs } from '../src/parseCliArgs.js'
+
+test('the "issues" alias resolves to the "bugs" command', async () => {
+  expect(getCommandFullName('issues')).toBe('bugs')
+  expect(pnpmCmds.issues).toBe(pnpmCmds.bugs)
+  expect(getCliOptionsTypes('issues')).toHaveProperty(['registry'])
+
+  const { cmd } = await parseCliArgs(['issues', 'is-positive'])
+  expect(cmd).toBe('bugs')
+})


### PR DESCRIPTION
## Summary

This PR adds `pnpm issues` as an alias for `pnpm bugs`, matching npm's `npm issues` alias. Both names now open the package's bug tracker URL in the default browser (or print it).

- `issues` is added to the `bugs` command's `commandNames` and removed from `NOT_IMPLEMENTED_COMMANDS`, so the alias dispatches to the real command instead of the "not yet implemented" stub.
- The `bugs` help output now lists both `pnpm bugs` and `pnpm issues` usages.
- A CLI-level regression test (`pnpm11/pnpm/test/parseCliArgs.test.ts`) asserts that `issues` resolves to `bugs` with its option-type metadata intact.
- The Rust pacquet side already has the alias on `main` (`#[clap(visible_alias = "issues")]` on the `Bugs` command), so both stacks are in parity.

## Squash Commit Body

```text
Add the `issues` alias to the `bugs` command in the TypeScript CLI, so that `pnpm issues <pkg>` behaves identically to `pnpm bugs <pkg>`. The alias is registered via the bugs command's commandNames, removed from the not-implemented command list, shown in the help output, and covered by a CLI-level alias-resolution test. The pacquet CLI already ships the same alias.
```

## Checklist

The `issues` alias has been added to the TypeScript bugs command module, and the pacquet port already has the alias on `main`.

A changeset has been added describing the new command alias for pnpm users (`@pnpm/deps.inspection.commands` and `pnpm`, both minor).

Tests cover both the command module (`commandNames` and help usages) and the CLI dispatch layer (alias resolution and option types).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added an `issues` command alias that opens the package bug tracker in the browser.
  * `pnpm issues` is now documented and works alongside `pnpm bugs`.
* **Bug Fixes**
  * `issues` is no longer treated as “not yet implemented,” so it’s available to run.
* **Tests**
  * Updated and added CLI parsing and help-output coverage for the `issues` alias.
  * Adjusted a `dlx` prune test to use explicit timeout and environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
