### PR TITLE
feat(pnpr): stream sized package frames from verify-lockfile

### DIFF
--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -6,11 +6,12 @@ use pacquet_config::NodeLinker;
 use pacquet_lockfile::{Lockfile, LockfileResolution, MaybeLazyLockfile};
 use pacquet_package_manager::{
     Install, InstallFrozenLockfileError, LockfileVerificationOverride, TarballPrefetcher,
-    UpToDateFastPathCheck, UpdateSeedPolicy, install_already_up_to_date,
+    UpToDateFastPathCheck, UpdateSeedPolicy, install_already_up_to_date, registry_prefetch_targets,
 };
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_pnpr_client::{PnprClient, PnprClientError, ResolveOptions, VerifyLockfileOptions};
 use pacquet_reporter::Reporter;
+use std::collections::HashMap;
 
 const BENCHMARK_PNPR_SERVER_REGISTRY_ENV: &str = "PACQUET_BENCHMARK_PNPR_SERVER_REGISTRY";
 const BENCHMARK_PNPR_TARBALL_REWRITE_FROM_ENV: &str = "PACQUET_BENCHMARK_PNPR_TARBALL_REWRITE_FROM";
@@ -711,27 +712,61 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
             .get()
             .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?
     {
-        let prefetcher = TarballPrefetcher::new(
-            state.config,
-            &state.http_client,
-            &state.tarball_mem_cache,
-            None,
-            &lockfile_dir.to_string_lossy(),
-        )
-        .await;
-        prefetcher.prefetch_lockfile(lockfile, state.config).await;
-        tokio::task::yield_now().await;
+        let prefetcher = std::sync::Arc::new(
+            TarballPrefetcher::new(
+                state.config,
+                &state.http_client,
+                &state.tarball_mem_cache,
+                None,
+                &lockfile_dir.to_string_lossy(),
+            )
+            .await,
+        );
 
         let lockfile_verification_override: Option<LockfileVerificationOverride<'_>> =
             if link.trust_lockfile {
+                // No verification runs, so no sized frames arrive — prefetch the
+                // whole lockfile up front, unprioritized.
+                prefetcher.prefetch_lockfile(lockfile, state.config).await;
+                tokio::task::yield_now().await;
                 None
             } else {
                 let verify_opts = VerifyLockfileOptions::from_resolve_options(&opts)
                     .expect("frozen pnpr verification requires the loaded lockfile");
                 let verify_client = PnprClient::new(pnpr_server);
+                let prefetcher = std::sync::Arc::clone(&prefetcher);
+                let config = state.config;
                 Some(Box::pin(async move {
-                    match verify_client.verify_lockfile(verify_opts).await {
-                        Ok(()) => Ok(()),
+                    // Drive the prefetch from the verify stream's sized `package`
+                    // frames so the largest pending tarballs start first. Each
+                    // frame is joined to the client's own lockfile entry by
+                    // `integrity` — the frame's URL is `route_url`'d and would
+                    // miss the materialization pass's mem-cache key.
+                    let targets = registry_prefetch_targets(lockfile, config);
+                    let by_integrity: HashMap<&str, &_> =
+                        targets.iter().map(|target| (target.integrity.as_str(), target)).collect();
+                    let verdict = verify_client
+                        .verify_lockfile_streaming(verify_opts, |pkg| {
+                            if let Some(target) = by_integrity.get(pkg.integrity.as_str()) {
+                                prefetcher.prefetch(
+                                    target.package_id.clone(),
+                                    target.package_url.clone(),
+                                    &target.integrity,
+                                    pkg.unpacked_size,
+                                    pkg.file_count,
+                                );
+                            }
+                        })
+                        .await;
+                    match verdict {
+                        Ok(()) => {
+                            // Completeness backstop: a verdict-cache hit streams no
+                            // frames and a partial fan-out frames only some entries.
+                            // Cover the rest unprioritized — already-spawned URLs and
+                            // store-resident entries are filtered out.
+                            prefetcher.prefetch_lockfile(lockfile, config).await;
+                            Ok(())
+                        }
                         Err(PnprClientError::Verification(verify_err)) => {
                             Err(InstallFrozenLockfileError::LockfileVerification(verify_err))
                         }
@@ -785,7 +820,13 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
         // best-effort — a dropped row only costs a later re-download.
         result.wrap_err("restoring dependencies from the local lockfile via pnpr verification")?;
 
-        prefetcher.shutdown().await;
+        // The verification override (the only other strong ref, on the verify
+        // path) has completed and been dropped by the await above, so this
+        // reclaims sole ownership to drain the store-index writer.
+        std::sync::Arc::into_inner(prefetcher)
+            .expect("prefetcher Arc still shared after install completed")
+            .shutdown()
+            .await;
 
         return Ok(());
     }

--- a/pacquet/crates/package-manager/src/tarball_prefetch.rs
+++ b/pacquet/crates/package-manager/src/tarball_prefetch.rs
@@ -34,19 +34,59 @@ use std::{collections::HashSet, sync::Arc};
 /// One registry lockfile entry [`TarballPrefetcher::prefetch_lockfile`]
 /// may spawn a download for, staged so the whole batch can be filtered
 /// through a single store-index existence probe first.
-struct PendingPrefetch {
-    store_key: String,
-    package_id: String,
-    package_url: String,
-    integrity: String,
+///
+/// `package_url` is the key the materialization pass looks up in the mem
+/// cache, so a prefetch must spawn under it; `integrity` joins a
+/// `/-/pnpr/v0/verify-lockfile` `package` frame's streamed dist sizes back
+/// to this entry (the frame's own `tarball` URL is `route_url`'d and need
+/// not match `package_url`).
+pub struct RegistryPrefetchTarget {
+    pub store_key: String,
+    pub package_id: String,
+    pub package_url: String,
+    pub integrity: String,
+}
+
+/// Registry-resolved prefetch targets for a frozen lockfile, in iteration
+/// order. Registry resolutions only — the one shape the materialization
+/// pass reuses from the shared mem cache (see
+/// [`TarballPrefetcher::prefetch_lockfile`]). The store-hit filter is
+/// applied separately ([`TarballPrefetcher::prefetch_lockfile`] batches it);
+/// a caller driving prefetch from streamed sizes joins by `integrity` and
+/// relies on the per-download store check instead.
+pub fn registry_prefetch_targets(
+    lockfile: &Lockfile,
+    config: &Config,
+) -> Vec<RegistryPrefetchTarget> {
+    let Some(packages) = lockfile.packages.as_ref() else {
+        return Vec::new();
+    };
+    let mut targets = Vec::with_capacity(packages.len());
+    for (package_key, metadata) in packages {
+        if !matches!(&metadata.resolution, LockfileResolution::Registry(_)) {
+            continue;
+        }
+        let (tarball_url, integrity) =
+            tarball_url_and_integrity(&metadata.resolution, package_key, config)
+                .expect("registry resolutions always carry an integrity");
+        let package_id = package_key.without_peer().to_string();
+        let integrity = integrity.to_string();
+        targets.push(RegistryPrefetchTarget {
+            store_key: store_index_key(&integrity, &package_id),
+            package_id,
+            package_url: tarball_url.into_owned(),
+            integrity,
+        });
+    }
+    targets
 }
 
 /// Drop every pending entry whose `(integrity, package_id)` row already
 /// exists in `index.db`, with one batched existence probe.
 async fn without_store_hits(
     index: Option<SharedReadonlyStoreIndex>,
-    pending: Vec<PendingPrefetch>,
-) -> Vec<PendingPrefetch> {
+    pending: Vec<RegistryPrefetchTarget>,
+) -> Vec<RegistryPrefetchTarget> {
     let Some(index) = index else {
         return pending;
     };
@@ -290,30 +330,16 @@ impl TarballPrefetcher {
     /// gone missing is skipped here too; the materialization pass's
     /// per-snapshot cache-miss fallback re-downloads it.
     pub async fn prefetch_lockfile(&self, lockfile: &Lockfile, config: &Config) {
-        let Some(packages) = lockfile.packages.as_ref() else {
+        let pending = registry_prefetch_targets(lockfile, config);
+        if pending.is_empty() {
             return;
-        };
-        let mut pending = Vec::with_capacity(packages.len());
-        for (package_key, metadata) in packages {
-            if !matches!(&metadata.resolution, LockfileResolution::Registry(_)) {
-                continue;
-            }
-            let (tarball_url, integrity) =
-                tarball_url_and_integrity(&metadata.resolution, package_key, config)
-                    .expect("registry resolutions always carry an integrity");
-            let package_id = package_key.without_peer().to_string();
-            let integrity = integrity.to_string();
-            pending.push(PendingPrefetch {
-                store_key: store_index_key(&integrity, &package_id),
-                package_id,
-                package_url: tarball_url.into_owned(),
-                integrity,
-            });
         }
         for entry in without_store_hits(self.store_index.clone(), pending).await {
-            let PendingPrefetch { package_id, package_url, integrity, .. } = entry;
+            let RegistryPrefetchTarget { package_id, package_url, integrity, .. } = entry;
             // The lockfile records no dist size hints, so the downloads
-            // queue without a work estimate.
+            // queue without a work estimate. A caller with sizes streamed
+            // from `/-/pnpr/v0/verify-lockfile` drives [`Self::prefetch`]
+            // directly instead (joining frames by `integrity`).
             self.prefetch(package_id, package_url, &integrity, None, None);
         }
     }

--- a/pacquet/crates/package-manager/src/tarball_prefetch/tests.rs
+++ b/pacquet/crates/package-manager/src/tarball_prefetch/tests.rs
@@ -1,4 +1,4 @@
-use super::{PendingPrefetch, without_store_hits};
+use super::{RegistryPrefetchTarget, without_store_hits};
 use pacquet_store_dir::{CafsFileInfo, PackageFilesIndex, StoreIndex, store_index_key};
 use std::collections::HashMap;
 use tempfile::tempdir;
@@ -23,8 +23,8 @@ fn sample_index() -> PackageFilesIndex {
     }
 }
 
-fn pending(package_id: &str, integrity: &str) -> PendingPrefetch {
-    PendingPrefetch {
+fn pending(package_id: &str, integrity: &str) -> RegistryPrefetchTarget {
+    RegistryPrefetchTarget {
         store_key: store_index_key(integrity, package_id),
         package_id: package_id.to_string(),
         package_url: format!("https://registry.example.com/{package_id}.tgz"),

--- a/pacquet/crates/pnpr-client/src/lib.rs
+++ b/pacquet/crates/pnpr-client/src/lib.rs
@@ -241,10 +241,26 @@ impl PnprClient {
 
     /// Ask the server to verify a lockfile under the client's registry
     /// and policy settings, without resolving or echoing the lockfile
-    /// back.
+    /// back, ignoring any streamed `package` frames. Equivalent to
+    /// [`Self::verify_lockfile_streaming`] with a no-op callback.
     pub async fn verify_lockfile(
         &self,
         opts: VerifyLockfileOptions,
+    ) -> Result<(), PnprClientError> {
+        self.verify_lockfile_streaming(opts, |_| {}).await
+    }
+
+    /// Verify a lockfile, invoking `on_package` once per sized `package`
+    /// frame the server streams ahead of the verdict — *before* the trust
+    /// verdict arrives — so the caller can prioritize its largest pending
+    /// tarball downloads. The frame's `tarball` URL is `route_url`'d and is
+    /// not guaranteed to match the caller's mem-cache key; join each frame
+    /// to the local lockfile by `integrity`. Returns once the terminal
+    /// verdict frame arrives (`Ok(())` on a clean pass).
+    pub async fn verify_lockfile_streaming(
+        &self,
+        opts: VerifyLockfileOptions,
+        mut on_package: impl FnMut(ResolvedPackage),
     ) -> Result<(), PnprClientError> {
         let request = serde_json::json!({
             "registry": opts.registry,
@@ -285,6 +301,25 @@ impl PnprClient {
                     continue;
                 }
                 match parse_verify_frame(line)? {
+                    VerifyFrame::Package {
+                        id,
+                        name,
+                        version,
+                        integrity,
+                        tarball,
+                        unpacked_size,
+                        file_count,
+                    } => {
+                        on_package(ResolvedPackage {
+                            id,
+                            name,
+                            version,
+                            integrity,
+                            tarball,
+                            unpacked_size,
+                            file_count,
+                        });
+                    }
                     VerifyFrame::Done => return Ok(()),
                     VerifyFrame::Error { message } => {
                         return Err(PnprClientError::Server(message));
@@ -438,12 +473,32 @@ enum Frame {
     },
 }
 
+/// One NDJSON frame from `/-/pnpr/v0/verify-lockfile`. When the verification
+/// fan-out fetched packument metadata the server streams sized `package`
+/// frames ahead of the verdict (mirroring the resolve frozen fast path), so
+/// the client can prioritize its largest pending tarball downloads; exactly
+/// one terminal frame (`done` / `error` / `violations`) closes the response.
 #[derive(Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum VerifyFrame {
+    Package {
+        id: String,
+        name: String,
+        version: String,
+        integrity: String,
+        tarball: String,
+        #[serde(rename = "unpackedSize", default)]
+        unpacked_size: Option<usize>,
+        #[serde(rename = "fileCount", default)]
+        file_count: Option<usize>,
+    },
     Done,
-    Error { message: String },
-    Violations { violations: Vec<WireViolation> },
+    Error {
+        message: String,
+    },
+    Violations {
+        violations: Vec<WireViolation>,
+    },
 }
 
 #[derive(Deserialize)]

--- a/pacquet/crates/pnpr-client/tests/integration.rs
+++ b/pacquet/crates/pnpr-client/tests/integration.rs
@@ -460,6 +460,47 @@ async fn verify_lockfile_endpoint_accepts_a_clean_input_lockfile() {
     client.verify_lockfile(verify_opts).await.expect("lockfile should verify");
 }
 
+/// When the verification fan-out fetches packument metadata, the verify
+/// endpoint streams sized `package` frames ahead of the verdict — the same
+/// frames the resolve frozen fast path emits — so a frozen restore can
+/// prioritize its largest pending downloads. A permissive `minimumReleaseAge`
+/// forces the fan-out while still passing.
+#[tokio::test]
+async fn verify_lockfile_endpoint_streams_package_frames_before_the_verdict() {
+    let registry = TestRegistry::start();
+    let (pnpr_url, pnpr_auth, _storage) = start_pnpr(&registry.url()).await;
+
+    let client = PnprClient::new(pnpr_url);
+
+    let first = client
+        .resolve(options(&registry.url(), &pnpr_auth, deps([("@foo/no-deps", "1.0.0")])))
+        .await
+        .expect("first install");
+
+    let mut opts = options(&registry.url(), &pnpr_auth, deps([("@foo/no-deps", "1.0.0")]));
+    opts.lockfile = Some(first.lockfile);
+    opts.minimum_release_age = Some(1);
+    opts.minimum_release_age_ignore_missing_time = true;
+    let verify_opts =
+        VerifyLockfileOptions::from_resolve_options(&opts).expect("lockfile is present");
+
+    let mut streamed: Vec<String> = Vec::new();
+    client
+        .verify_lockfile_streaming(verify_opts, |pkg| {
+            assert!(!pkg.integrity.is_empty(), "a package frame carries an integrity");
+            assert!(pkg.tarball.starts_with("http"), "a package frame carries a tarball URL");
+            assert_eq!(pkg.id, format!("{}@{}", pkg.name, pkg.version), "id is name@version");
+            streamed.push(pkg.id);
+        })
+        .await
+        .expect("clean lockfile should verify");
+
+    assert!(
+        !streamed.is_empty(),
+        "verify-lockfile should stream at least one sized package frame before the verdict",
+    );
+}
+
 #[tokio::test]
 async fn verify_lockfile_endpoint_rejects_policy_violation() {
     let registry = TestRegistry::start();

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -19,8 +19,11 @@
 //!   ([pnpm/pnpm#12230](https://github.com/pnpm/pnpm/issues/12230)).
 //! * `POST /-/pnpr/v0/verify-lockfile` — verify an already-fresh client
 //!   lockfile under the same policy without resolving. A frozen restore
-//!   can start local fetch/materialization immediately and only use this
-//!   endpoint as the trust verdict.
+//!   can start local fetch/materialization immediately and use this
+//!   endpoint as the trust verdict. When the verification fan-out fetched
+//!   packument metadata it also emits the same sized `package` frames the
+//!   resolve frozen fast path does, ahead of the verdict, so the client can
+//!   prioritize its largest pending tarball downloads.
 //!
 //! pnpr is a stateless resolver: it stores no tarballs. Public tarballs
 //! can still be fetched directly from their upstream registry, while a
@@ -506,10 +509,12 @@ pub(crate) async fn handle_resolve(
 }
 
 /// Handle `POST /-/pnpr/v0/verify-lockfile`: verify the client's input
-/// lockfile under the client's policy, returning only a terminal NDJSON
-/// verdict frame. The client already knows the lockfile is fresh for
-/// the current manifests, so this endpoint deliberately does not
-/// resolve or echo the lockfile back.
+/// lockfile under the client's policy. The client already knows the
+/// lockfile is fresh for the current manifests, so this endpoint does not
+/// resolve or echo the lockfile back; it returns a terminal NDJSON verdict
+/// frame, optionally preceded by sized `package` frames (see
+/// [`verify_done_with_frames`]) when the verification fan-out observed
+/// dist sizes.
 pub(crate) async fn handle_verify_lockfile(
     runtime: &Resolver,
     identity: Identity,
@@ -554,10 +559,21 @@ pub(crate) async fn handle_verify_lockfile(
     let input_lockfile = tarball_router.verification_lockfile(input_lockfile);
 
     match verify_input_lockfile(runtime, config, &request_auth, &input_lockfile).await {
-        // The dist stats the verifier observed feed `/-/pnpr/v0/resolve`'s sized
-        // `package` frames; this endpoint's client prefetches from its own
-        // lockfile before the verdict arrives, so only the verdict is sent.
-        Ok(_) => verify_done_or_osv_violations(runtime.osv_index.as_ref(), &input_lockfile),
+        // When the verifier's metadata fan-out observed dist sizes, emit the
+        // same sized `package` frames `/-/pnpr/v0/resolve`'s frozen fast path
+        // does, ahead of the verdict, so the client can prioritize its largest
+        // pending tarball downloads. The client joins each frame to its own
+        // lockfile by `integrity` (the announced URL is `route_url`'d and need
+        // not match the client's mem-cache key). A verdict-cache hit fetched no
+        // metadata, so there are no sizes and the bare verdict is sent.
+        Ok(Some(dist_stats)) => verify_done_with_frames(
+            runtime.osv_index.as_ref(),
+            config,
+            &tarball_router,
+            &input_lockfile,
+            &dist_stats,
+        ),
+        Ok(None) => verify_done_or_osv_violations(runtime.osv_index.as_ref(), &input_lockfile),
         Err(VerifyFailure::Internal(response)) => response,
         Err(VerifyFailure::Violations(violations)) => {
             ndjson_single_frame(&violations_frame(&violations))
@@ -1096,6 +1112,31 @@ fn verify_done_or_osv_violations(
     } else {
         ndjson_single_frame(&violations_frame(&violations))
     }
+}
+
+/// Terminal verdict for `/-/pnpr/v0/verify-lockfile`, preceded by the sized
+/// `package` frames `/-/pnpr/v0/resolve`'s frozen fast path emits. The
+/// verifier's metadata fan-out already fetched each packument to check the
+/// client's policy, so the observed `dist_stats` come for free — surfacing
+/// them lets the client prioritize its largest pending tarball downloads.
+/// OSV violations suppress the frames: a vulnerable lockfile must not seed
+/// any download. The verdict frame is always last.
+fn verify_done_with_frames(
+    osv_index: Option<&Arc<OsvIndex>>,
+    config: &PacquetConfig,
+    tarball_router: &TarballRouter,
+    lockfile: &Lockfile,
+    dist_stats: &ObservedDistStats,
+) -> Response {
+    if let Some(osv_index) = osv_index {
+        let violations = osv_violations_for_lockfile(osv_index, lockfile);
+        if !violations.is_empty() {
+            return ndjson_single_frame(&violations_frame(&violations));
+        }
+    }
+    let mut frames = frozen_package_frames(config, tarball_router, lockfile, dist_stats);
+    frames.push(verify_done_frame());
+    ndjson_frames(&frames)
 }
 
 fn osv_violations_for_lockfile(index: &OsvIndex, lockfile: &Lockfile) -> Vec<serde_json::Value> {


### PR DESCRIPTION
## Summary

`/-/pnpr/v0/verify-lockfile` already runs a packument metadata fan-out to check the client's policy (`minimumReleaseAge`, `trustPolicy`), so it observes each package's `dist.unpackedSize` / `fileCount` — but it discarded them and returned only the verdict. This surfaces them as the same sized `package` frames the resolve frozen fast path emits, ahead of the verdict, so a **frozen restore** can prioritize its largest pending tarball downloads. The data comes for free: no extra fetches, the verifier already had it one line away from where it's now used.

Three layers:

- **Server (`pnpr`)** — `handle_verify_lockfile` keeps the verifier's `ObservedDistStats` and, when present, prepends `frozen_package_frames` before the `done` frame (new `verify_done_with_frames`). OSV violations still suppress the frames — a vulnerable lockfile must not seed any download. A verdict-cache hit fetched no metadata, so it still sends the bare verdict.
- **Client (`pacquet-pnpr-client`)** — adds a `Package` variant to `VerifyFrame` and a `verify_lockfile_streaming(opts, on_package)` method; `verify_lockfile` becomes the no-op-callback wrapper.
- **Install (`pacquet-cli`)** — on the frozen verify path, drives the tarball prefetch from the verify stream's frames instead of firing the whole lockfile up front unprioritized.

### Why the install side had to be reworked (not just "reprioritized")

The priority semaphore (`pacquet-network`) fixes a download's weight at **queue-registration** time — there's no API to bump an already-queued waiter. And `prefetch_lockfile` used to fire every download up front with `None` sizes ("the lockfile records no dist size hints"). So a frame arriving later could not reprioritize a download that already registered. The prefetch has to *learn the size before it spawns*, which is why the frozen path now drives prefetch from the stream.

Each frame is joined to the client's own lockfile entry **by `integrity`**, not by the frame's URL: the announced `tarball` URL is `route_url`'d and would miss the materialization pass's mem-cache key, whereas the client's own `tarball_url_and_integrity` *is* that key. A completeness backstop (`prefetch_lockfile` after the stream, deduped by spawned URL + store probe) covers the verdict-cache-hit and partial-fan-out cases.

### Open question for review / benchmarking ⚠️

In the **no-policy** frozen install (no `minimumReleaseAge`, no `trustPolicy`), the verifier fetches no metadata, so no frames arrive. The completeness backstop then prefetches after the verify round-trip returns, instead of up front — a ~1-RTT later start with **no offsetting size benefit** in that case. Options to weigh:

1. Land as-is (simplest; ~1-RTT regression only when no supply-chain policy is configured).
2. Gate frame-driving on the client having a metadata-triggering policy, keeping the up-front prefetch otherwise.

I kept it as (1) for the draft so the stream-driven path is exercised end to end; happy to switch to (2) if the benchmark shows the no-policy start delay matters. Cold-store frozen-restore numbers with a `minimumReleaseAge` policy are the case this is meant to help (largest-first ordering when the connection pool is saturated).

Minor known cost: a framed entry that is already store-resident still spawns a download task that no-ops against the store (the batched store probe only runs in the backstop). Acceptable; called out for completeness.

## Squash Commit Body

```text
feat(pnpr): stream sized package frames from verify-lockfile

The /-/pnpr/v0/verify-lockfile endpoint already runs a packument metadata
fan-out to check the client's policy (minimumReleaseAge, trustPolicy), so it
observes each package's dist.unpackedSize / fileCount — but it discarded them
and returned only the verdict. Surface them as the same sized `package` frames
the resolve frozen fast path emits, ahead of the verdict, so a frozen restore
can prioritize its largest pending tarball downloads. No extra fetches; the
verifier already had the data.

Server (pnpr): handle_verify_lockfile keeps the verifier's ObservedDistStats
and, when present, prepends frozen_package_frames before the done frame. OSV
violations still suppress the frames. A verdict-cache hit sends the bare verdict.

Client (pacquet-pnpr-client): add a Package variant to VerifyFrame and a
verify_lockfile_streaming(opts, on_package) method; verify_lockfile becomes the
no-op-callback wrapper.

Install (pacquet-cli): on the frozen verify path, drive the tarball prefetch
from the verify stream's frames instead of firing the whole lockfile up front
unprioritized. Each frame is joined to the client's own lockfile entry by
integrity (the announced URL is route_url'd and would miss the materialization
pass's mem-cache key). A completeness backstop covers the verdict-cache-hit and
partial-fan-out cases. The priority semaphore fixes a download's weight at
queue-registration time, so reprioritizing an already-queued download isn't
possible — the prefetch has to learn the size before it spawns.

Rust-only: the TS pnpr client calls /resolve only and skips package frames, so
there is no TS counterpart to mirror.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. — _Rust-only change (pnpr server + pacquet client); the TS pnpr client calls `/resolve` only and skips `package` frames, so there is nothing to mirror._
- [x] Added a changeset if this PR changes any published package. — _N/A: no published (TypeScript) package changes; changesets are TS-only in this repo._
- [x] Added or updated tests. — _`verify_lockfile_endpoint_streams_package_frames_before_the_verdict` integration test; existing frozen-install e2e and prefetcher unit tests still pass._
- [x] Updated the documentation if needed. — _Module + handler doc comments updated; no user-facing docs affected._

---
Written by an agent (Claude Code, claude-opus-4-8).