### PR TITLE
fix: avoid passing infinite width to cli-truncate when streaming lifecycle output

### DIFF
--- a/.changeset/fix-stream-lifecycle-truncate.md
+++ b/.changeset/fix-stream-lifecycle-truncate.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/cli.default-reporter": patch
+"pnpm": patch
+---
+
+Fixed a crash when streaming lifecycle script output (e.g. with `--stream`). The reporter no longer passes an infinite width to `cli-truncate`, which the latest version rejects.

--- a/.changeset/fix-stream-lifecycle-truncate.md
+++ b/.changeset/fix-stream-lifecycle-truncate.md
@@ -1,6 +1,0 @@
----
-"@pnpm/cli.default-reporter": patch
-"pnpm": patch
----
-
-Fixed a crash when streaming lifecycle script output (e.g. with `--stream`). The reporter no longer passes an infinite width to `cli-truncate`, which the latest version rejects.

--- a/pnpm11/cli/default-reporter/src/reporterForClient/reportLifecycleScripts.ts
+++ b/pnpm11/cli/default-reporter/src/reporterForClient/reportLifecycleScripts.ts
@@ -277,6 +277,9 @@ function formatLine (maxWidth: number, logObj: LifecycleLog): string {
 
 function cutLine (line: string | undefined, maxLength: number): string {
   if (!line) return ''
+  // Streamed lifecycle output is printed in full (maxLength is Infinity).
+  // cli-truncate rejects a non-finite width, so skip truncation in that case.
+  if (!Number.isFinite(maxLength)) return line
   return cliTruncate(line, maxLength)
 }
 


### PR DESCRIPTION
## Summary

Fixes the red `main` CI (all `Test` jobs were failing). `cli-truncate` was bumped to `6.1.0` in pnpm/pnpm#12692, and that version rejects a non-finite width. `streamLifecycleOutput` passes `Infinity` to `cutLine`/`cliTruncate` to mean "do not truncate" streamed lifecycle output, so the reporter crashed with `TypeError: Expected \`columns\` to be a finite number, got Infinity`.

This broke `@pnpm/cli.default-reporter`'s `reportingLifecycleScripts` unit tests as well as several pnpm e2e tests that stream lifecycle output (`--parallel`, `--stream`, `-r --no-bail run`), since the crash swallowed the expected output.

`cutLine` now returns the line unchanged when the requested width is not finite, restoring the previous "no truncation" semantics.

## Squash Commit Body

```text
cli-truncate 6.1.0 rejects a non-finite width. streamLifecycleOutput passes
Infinity to cutLine/cliTruncate to mean "do not truncate", which crashed the
reporter. Guard cutLine against non-finite widths so streamed lifecycle output
is printed in full instead of throwing.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. — TypeScript-only: this is a JS dependency (`cli-truncate`) behavior; pacquet does not use it.
- [x] Added or updated tests. — Existing `reportingLifecycleScripts` tests cover the streaming path and now pass.

No changeset: the broken build this fixes (the `cli-truncate` bump) was never released, so there is no release note to add.

---
Written by an agent (Claude Code, claude-opus-4-8).