### PR TITLE
fix: honor the requested version when updating a transitive dependency

### DIFF
--- a/.changeset/update-transitive-dep-to-exact-version.md
+++ b/.changeset/update-transitive-dep-to-exact-version.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.commands": patch
+"pnpm": patch
+---
+
+Fixed `pnpm update <dep>@<version>` installing the highest in-range version instead of the requested one when `<dep>` is only present as a transitive dependency. The requested exact version is now preferred during resolution. Closes pnpm/pnpm#12744.

--- a/pnpm11/installing/commands/src/installDeps.ts
+++ b/pnpm11/installing/commands/src/installDeps.ts
@@ -40,6 +40,7 @@ import { findWorkspaceProjects } from '@pnpm/workspace.projects-reader'
 import { sequenceGraph } from '@pnpm/workspace.projects-sorter'
 import { updateWorkspaceState, type WorkspaceStateSettings } from '@pnpm/workspace.state'
 import { updateWorkspaceManifest } from '@pnpm/workspace.workspace-manifest-writer'
+import getVersionSelectorType from 'version-selector-type'
 
 import { getPinnedVersion } from './getPinnedVersion.js'
 import { getSaveType } from './getSaveType.js'
@@ -50,6 +51,7 @@ import {
   createMatcher,
   makeIgnorePatterns,
   matchDependencies,
+  parseUpdateParam,
   recursive,
   type RecursiveOptions,
   type UpdateDepsMatcher,
@@ -374,6 +376,7 @@ export async function installDeps (
     updateMatching = (pkgName: string, version?: string) => version != null && packageVulnerabilityAudit.isVulnerable(pkgName, version)
   }
   if (updateMatch != null) {
+    const updateSpecs = params
     params = matchDependencies(updateMatch, manifest, includeDirect)
     if (params.length === 0) {
       if (opts.latest) return
@@ -385,6 +388,15 @@ export async function installDeps (
       // Don't update package.json in this case, and limit updates to only matching dependencies
       updatePackageManifest = false
       updateMatching = (pkgName: string) => updateMatch!(pkgName) != null
+      // updateMatching only flags a dependency for re-resolution; it can't carry
+      // the version from `<dep>@<version>`, so prefer that version explicitly.
+      const preferredVersions = getPreferredVersionsForUpdateSpecs(updateSpecs)
+      if (Object.keys(preferredVersions).length > 0) {
+        installOpts.preferredVersions = {
+          ...installOpts.preferredVersions,
+          ...preferredVersions,
+        }
+      }
     }
   }
 
@@ -584,6 +596,22 @@ function getVulnerabilityPenalty (severity: VulnerabilitySeverity): number {
       // Treat unrecognized severity as the lowest severity
     default: return -1100
   }
+}
+
+function getPreferredVersionsForUpdateSpecs (updateSpecs: string[]): PreferredVersions {
+  // Null-prototype map so a crafted package name (e.g. `__proto__`) is a plain
+  // key rather than a prototype-pollution vector.
+  const preferredVersions = Object.create(null) as PreferredVersions
+  for (const spec of updateSpecs) {
+    const { pattern, versionSpec } = parseUpdateParam(spec)
+    if (versionSpec == null || pattern.includes('*') || pattern.startsWith('!')) continue
+    // Only an exact version of a single named package can be preferred.
+    const selector = getVersionSelectorType(versionSpec)
+    if (selector?.type !== 'version') continue
+    preferredVersions[pattern] = preferredVersions[pattern] ?? {}
+    preferredVersions[pattern][selector.normalized] = 'version'
+  }
+  return preferredVersions
 }
 
 function preferNonvulnerablePackageVersions (packageVulnerabilityAudit: PackageVulnerabilityAudit): PreferredVersions {

--- a/pnpm11/installing/commands/test/update/update.ts
+++ b/pnpm11/installing/commands/test/update/update.ts
@@ -139,6 +139,59 @@ test('update transitive dependency when mixed with a direct dependency selector'
   expect(lockfile.packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0']).toBeTruthy()
 })
 
+test('update a transitive dependency to an explicitly requested version', async () => {
+  // @pnpm.e2e/pkg-with-good-optional depends on @pnpm.e2e/dep-of-pkg-with-1-dep via "*".
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
+
+  const project = prepare({
+    dependencies: {
+      '@pnpm.e2e/pkg-with-good-optional': '1.0.0',
+    },
+  })
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+  })
+
+  expect(project.readLockfile().packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0']).toBeTruthy()
+
+  // 101.0.0 is now the latest, but the update requests 100.1.0, which must win.
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '101.0.0', distTag: 'latest' })
+
+  await update.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+  }, ['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0'])
+
+  const lockfile = project.readLockfile()
+
+  expect(lockfile.packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0']).toBeTruthy()
+  expect(lockfile.packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0']).toBeFalsy()
+  expect(lockfile.packages['@pnpm.e2e/dep-of-pkg-with-1-dep@101.0.0']).toBeFalsy()
+})
+
+test('update with a version does not pollute Object.prototype via a crafted package name', async () => {
+  const project = prepare({
+    dependencies: {
+      '@pnpm.e2e/foo': '1.0.0',
+    },
+  })
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+  })
+
+  await update.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+  }, ['__proto__@1.0.0'])
+
+  expect(({} as Record<string, unknown>)['1.0.0']).toBeUndefined()
+  expect(project.readLockfile().packages['@pnpm.e2e/foo@1.0.0']).toBeTruthy()
+})
+
 test('update: fail when both "latest" and "workspace" are true', async () => {
   preparePackages([
     {


### PR DESCRIPTION
fixes #12744

`pnpm update <dep>@<version>` ignores `<version>` when `<dep>` exists only as a transitive dependency: it re-resolves the dependency to the highest version in range instead of the requested one.

## Reproduction

A project depends on `@swc/cli`, which depends on `piscina` (`^4.3.1`) transitively. With `piscina` resolved to an older in-range version (e.g. `4.5.0`):

```
pnpm update piscina@4.9.0
# expected: piscina 4.9.0
# actual:   piscina 4.9.3 (highest in range)
```

The requested version is dropped whether it is higher or lower than the currently resolved one.

## Root cause

When an update selector matches no direct dependency, `installDeps` treats it as a transitive-only update and builds an `updateMatching` predicate:

```ts
updateMatching = (pkgName) => updateMatch(pkgName) != null
```

`updateMatching` only flags a package for re-resolution — it returns a boolean and cannot carry the version parsed from `<dep>@<version>`. The version is therefore discarded and the resolver falls back to the highest version in range.

## Fix

For a transitive-only update whose selector pins an exact version, pass that version through `preferredVersions` so the resolver prefers it during re-resolution — the same mechanism `getExactSinglePreferredVersions` and the audit-fix path already use. Version ranges, dist-tags, glob and negation selectors are left to normal resolution.

## Scope

This covers the non-recursive `pnpm update <dep>@<version>` from the reproduction. Recursive (`-r`) updates of a transitive dependency by name, and range/tag selectors, are unchanged.

## Test

Added a regression test that pins a transitive dependency, then updates it to an explicit in-range version and asserts the requested version is installed rather than the latest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updating a transitive dependency with an explicit version now installs that exact version, rather than selecting a different in-range match.
  * Dependency resolution now more reliably preserves explicitly requested version selectors, improving lockfile accuracy.
  * Prevented Object prototype pollution when processing crafted update specifications.
* **Tests**
  * Added coverage for exact-version transitive updates and for prototype-safety with malicious package spec inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->