### PR TITLE
perf(npm-resolver): cache disk-loaded metadata in memory on offline resolution

### DIFF
--- a/.changeset/offline-metadata-in-memory-cache.md
+++ b/.changeset/offline-metadata-in-memory-cache.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"pnpm": patch
+---
+
+Sped up offline and `--prefer-offline` resolution on large workspaces (e.g. `pnpm dedupe --offline`, `pnpm install --offline`). Package metadata loaded from the local cache is now kept in memory, so each package's metadata is parsed once per command instead of once per dependent that references it.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -83,7 +83,6 @@ jobs:
 
     - name: Run benchmarks
       id: bench
-      continue-on-error: true
       run: |
         set -o pipefail
         ./pnpm11/benchmarks/bench.sh 2>&1 | tee bench-output.txt

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -327,6 +327,22 @@ jobs:
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE.json
 
+      - name: 'Benchmark: Isolated linker: fresh resolve, hot cache, offline'
+        shell: bash
+        # Offline re-resolution from the warm on-disk packument mirror:
+        # `install --offline --lockfile-only` with the lockfile removed per
+        # iteration (an online pre-warm pass primes the mirror first). No
+        # network and no linking, so the timed work is almost purely mirror
+        # reads + packument parsing — the series that guards offline /
+        # prefer-offline resolution, e.g. the disk-to-memory metadata
+        # promotion of pnpm/pnpm#12760. Cheapest scenario per iteration, so
+        # 15 min is ample.
+        timeout-minutes: 15
+        run: |
+          just integrated-benchmark --reuse-prebuilt-binaries --scenario=isolated-linker.fresh-resolve.hot-cache.offline --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} --registry-bandwidth-mbps=${REGISTRY_BANDWIDTH_MBPS} $BENCHMARK_TARGETS
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESOLVE_HOT_CACHE_OFFLINE.md
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESOLVE_HOT_CACHE_OFFLINE.json
+
       - name: 'Benchmark: Isolated linker: fresh restore, cold cache + cold store + cold pnpr'
         shell: bash
         # The only scenario with a cold pnpr-side cache: the per-revision mock
@@ -457,6 +473,18 @@ jobs:
             echo
             echo '</details>'
             echo
+            echo '### Scenario: Isolated linker: fresh resolve, hot cache, offline'
+            echo
+            cat bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESOLVE_HOT_CACHE_OFFLINE.md
+            echo
+            echo '<details><summary>BENCHMARK_REPORT.json</summary>'
+            echo
+            echo '```json'
+            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESOLVE_HOT_CACHE_OFFLINE.json
+            echo '```'
+            echo
+            echo '</details>'
+            echo
             echo '### Scenario: Isolated linker: fresh restore, cold cache + cold store + cold pnpr'
             echo
             cat bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR.md
@@ -475,7 +503,7 @@ jobs:
         # Bencher's shell_hyperfine adapter accepts, one per testbed. For
         # each, keep only the chosen target's result from each scenario
         # and rename `.command` to the scenario name, so Bencher names the
-        # benchmark after the scenario. Both tools run all five scenarios,
+        # benchmark after the scenario. Both tools run every scenario,
         # so the `pacquet` testbed gets `pacquet@HEAD` and the `pnpr`
         # testbed gets `pnpr@HEAD`, each across the same scenario set.
         shell: bash
@@ -507,6 +535,7 @@ jobs:
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE:isolated-linker.fresh-install.cold-cache.cold-store' \
             'ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE:isolated-linker.fresh-install.hot-cache.hot-store' \
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE:isolated-linker.fresh-install.cold-cache.hot-store' \
+            'ISOLATED_FRESH_RESOLVE_HOT_CACHE_OFFLINE:isolated-linker.fresh-resolve.hot-cache.offline' \
             'ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR:isolated-linker.fresh-restore.cold-cache.cold-store.cold-pnpr'
 
           build_bencher_file bench-work-env/bencher-results-pnpr.json pnpr@HEAD \
@@ -515,6 +544,7 @@ jobs:
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE:isolated-linker.fresh-install.cold-cache.cold-store' \
             'ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE:isolated-linker.fresh-install.hot-cache.hot-store' \
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE:isolated-linker.fresh-install.cold-cache.hot-store' \
+            'ISOLATED_FRESH_RESOLVE_HOT_CACHE_OFFLINE:isolated-linker.fresh-resolve.hot-cache.offline' \
             'ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR:isolated-linker.fresh-restore.cold-cache.cold-store.cold-pnpr'
 
       - name: Stage artifact contents

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -813,7 +813,7 @@ impl NpmResolutionVerifier {
         cell.get_or_init(|| async {
             // Fast path: if the resolver already pulled the full packument
             // during the same install (`{registry}\x00{name}:full` or
-            // `…:full:filtered` key in the shared metaCache, populated
+            // `...:full:filtered` key in the shared metaCache, populated
             // when `pick_package` upgrades for `minimumReleaseAge`),
             // reuse it. The filtered form is accepted: `clear_meta`
             // keeps `time`, per-version `_npmUser`, and `dist`, which is

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -667,7 +667,7 @@ impl NpmResolutionVerifier {
         };
         let value = cell
             .get_or_init(|| async {
-                if let Some(shared) = self.read_shared_meta(name) {
+                if let Some(shared) = self.read_shared_meta(registry, name) {
                     return Ok(project_abbreviated_meta(&shared));
                 }
                 let opts = FetchFullMetadataCachedOptions {
@@ -694,15 +694,22 @@ impl NpmResolutionVerifier {
     }
 
     /// Try the resolver's shared [`PackageMetaCache`] for a packument
-    /// the abbreviated projection can derive from. Prefer the
-    /// `name:full` entry: it's a strict superset of the abbreviated
-    /// shape, so a hit there subsumes the bare `name` entry.
-    fn read_shared_meta(&self, name: &PkgName) -> Option<Arc<Package>> {
+    /// the abbreviated projection can derive from. The resolver keys
+    /// entries by registry plus name (see `metadata_cache_key`), with a
+    /// `:full` / `:full:filtered` suffix depending on its own metadata
+    /// mode, so try full, filtered full, then abbreviated — a full form
+    /// is a strict superset of the abbreviated shape, and `clear_meta`
+    /// keeps every field the projection reads. Private-scoped entries
+    /// carry a descriptor prefix the verifier can't reproduce; those
+    /// simply miss and fall through to the verifier's own fetch chain.
+    fn read_shared_meta(&self, registry: &str, name: &PkgName) -> Option<Arc<Package>> {
         let cache = self.meta_cache.as_ref()?;
         let name_str = name.to_string();
+        let key = package_key(registry, &name_str);
         cache
-            .get(&format!("{name_str}:full"))
-            .or_else(|| cache.get(&name_str))
+            .get(&format!("{key}:full"))
+            .or_else(|| cache.get(&format!("{key}:full:filtered")))
+            .or_else(|| cache.get(&key))
             .map(|cached| cached.meta)
             .filter(|meta| meta.name == name_str)
     }
@@ -805,14 +812,19 @@ impl NpmResolutionVerifier {
         };
         cell.get_or_init(|| async {
             // Fast path: if the resolver already pulled the full packument
-            // during the same install (`{registry}\x00{name}:full` key in
-            // the shared metaCache, populated when `pick_package` upgrades
-            // for `minimumReleaseAge`), reuse it. Abbreviated entries are
-            // rejected here — `fail_if_trust_downgraded` needs per-version
-            // `time` and per-version trust evidence, both of which only
-            // the full form carries.
-            let shared =
-                self.meta_cache.as_ref().and_then(|cache| cache.get(&format!("{key}:full")));
+            // during the same install (`{registry}\x00{name}:full` or
+            // `…:full:filtered` key in the shared metaCache, populated
+            // when `pick_package` upgrades for `minimumReleaseAge`),
+            // reuse it. The filtered form is accepted: `clear_meta`
+            // keeps `time`, per-version `_npmUser`, and `dist`, which is
+            // everything `fail_if_trust_downgraded` reads. Abbreviated
+            // entries are rejected — they lack per-version `time` and
+            // trust evidence.
+            let shared = self.meta_cache.as_ref().and_then(|cache| {
+                cache
+                    .get(&format!("{key}:full"))
+                    .or_else(|| cache.get(&format!("{key}:full:filtered")))
+            });
             if let Some(cached) = shared {
                 return Ok(Arc::new(project_trust_meta(cached.meta.as_ref())));
             }

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -703,6 +703,7 @@ impl NpmResolutionVerifier {
         cache
             .get(&format!("{name_str}:full"))
             .or_else(|| cache.get(&name_str))
+            .map(|cached| cached.meta)
             .filter(|meta| meta.name == name_str)
     }
 
@@ -812,8 +813,8 @@ impl NpmResolutionVerifier {
             // the full form carries.
             let shared =
                 self.meta_cache.as_ref().and_then(|cache| cache.get(&format!("{key}:full")));
-            if let Some(meta) = shared {
-                return Ok(Arc::new(project_trust_meta(meta.as_ref())));
+            if let Some(cached) = shared {
+                return Ok(Arc::new(project_trust_meta(cached.meta.as_ref())));
             }
             // Project the packument to just the fields `fail_if_trust_downgraded`
             // reads before stashing in the cache. The full document — dependency

--- a/pacquet/crates/resolving-npm-resolver/src/lib.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/lib.rs
@@ -60,10 +60,10 @@ pub use parse_bare_specifier::{
     parse_named_registry_specifier_to_registry_package_spec,
 };
 pub use pick_package::{
-    InMemoryPackageMetaCache, MirrorPersistError, PackageMetaCache, PackumentFetchLocker,
-    PickPackageContext, PickPackageError, PickPackageOptions, PickPackageResult,
-    PickedManifestCache, persist_meta_to_mirror, pick_package, shared_in_memory_cache,
-    shared_packument_fetch_locker, shared_picked_manifest_cache,
+    CachedPackument, InMemoryPackageMetaCache, MirrorPersistError, PackageMetaCache,
+    PackumentFetchLocker, PickPackageContext, PickPackageError, PickPackageOptions,
+    PickPackageResult, PickedManifestCache, persist_meta_to_mirror, pick_package,
+    shared_in_memory_cache, shared_packument_fetch_locker, shared_picked_manifest_cache,
 };
 pub use pick_package_from_meta::{
     PickPackageFromMetaError, PickPackageFromMetaOptions, PickVersionByVersionRangeOptions,

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -558,10 +558,11 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             let (picked_meta, picked) =
                 pick_from_meta(&picker_opts, spec, Arc::clone(&meta), opts.blocked_versions)?;
             if picked.is_some() {
-                // A later cache hit re-runs the same release-age upgrade
-                // check, so behavior is unchanged. The upgrade branch
-                // above already cached the registry-validated document;
-                // don't downgrade it to an unverified marking.
+                // A cache hit re-runs the release-age upgrade check, so
+                // serving this meta from memory can't bypass the upgrade.
+                // The upgrade branch above already cached the registry-
+                // validated document; don't downgrade it to an unverified
+                // marking.
                 if !upgrade.upgraded && !opts.dry_run {
                     ctx.meta_cache.set_unverified(cache_key.clone(), Arc::clone(&meta));
                 }

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -79,7 +79,7 @@ use crate::{
 /// A cached packument together with its registry-verification state.
 /// The two travel as one value so a reader can never pair a packument
 /// with the verification state of a concurrent overwrite.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone)]
 pub struct CachedPackument {
     pub meta: Arc<Package>,
     /// `false` when the packument was parsed straight from the

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -51,7 +51,7 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use dashmap::{DashMap, DashSet};
+use dashmap::DashMap;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::version_policy::{PackageVersionPolicy, PolicyMatch};
@@ -76,6 +76,18 @@ use crate::{
     registry_url::to_registry_url,
 };
 
+/// A cached packument together with its registry-verification state.
+/// The two travel as one value so a reader can never pair a packument
+/// with the verification state of a concurrent overwrite.
+#[derive(Clone, Debug)]
+pub struct CachedPackument {
+    pub meta: Arc<Package>,
+    /// `false` when the packument was parsed straight from the
+    /// on-disk mirror without a validating registry round-trip (see
+    /// [`PackageMetaCache::set_unverified`]).
+    pub registry_verified: bool,
+}
+
 /// In-memory packument cache the orchestrator consults before any
 /// disk read. A thin map abstraction so a long-lived install can
 /// share one cache across many [`pick_package`] calls.
@@ -86,12 +98,12 @@ use crate::{
 /// contention shows up in benchmarks.
 pub trait PackageMetaCache: Send + Sync {
     /// Shared handle to the cached packument for `key`, or `None`
-    /// when the cache hasn't seen it. Returned as
+    /// when the cache hasn't seen it. The packument is carried as
     /// [`Arc<Package>`] so cross-resolve sharing of a popular
     /// packument (`react`, `lodash`, ...) doesn't deep-clone the
     /// full versions map on every consumer's hit. Returns shared
     /// references, not copies.
-    fn get(&self, key: &str) -> Option<Arc<Package>>;
+    fn get(&self, key: &str) -> Option<CachedPackument>;
     /// Insert/overwrite `meta` under `key`. The orchestrator inserts
     /// after a fresh fetch and after any disk-fast-path that returns
     /// successfully — populating the cache from the disk read avoids
@@ -103,34 +115,27 @@ pub trait PackageMetaCache: Send + Sync {
     /// [`Arc<Package>`] so callers can share the same handle they
     /// hand back to [`PickPackageResult`] without an extra clone.
     ///
-    /// Clears any registry-unverified marker a previous
-    /// [`PackageMetaCache::set_unverified`] left on `key`: the caller
-    /// vouches that `meta` came from (or was revalidated by) the
-    /// registry.
+    /// The caller vouches that `meta` came from (or was revalidated
+    /// by) the registry: the entry replaces any registry-unverified
+    /// one a previous [`PackageMetaCache::set_unverified`] stored
+    /// under `key`.
     fn set(&self, key: String, meta: Arc<Package>);
 
-    /// Like [`PackageMetaCache::set`], but remembers the entry as
+    /// Like [`PackageMetaCache::set`], but stores the entry as
     /// registry-unverified: it was parsed straight from the on-disk
     /// mirror without a validating registry round-trip, so it may
     /// predate versions the registry has. [`pick_package`] uses the
-    /// marker to fall through to a conditional registry request —
+    /// state to fall through to a conditional registry request —
     /// instead of failing the pick — when a cache hit on such an entry
     /// can't satisfy the requested spec and the resolver isn't offline.
     /// The verified [`PackageMetaCache::set`] the fetch then performs
-    /// clears the marker, so each package revalidates at most once.
+    /// replaces the entry, so each package revalidates at most once.
     ///
-    /// The default implementation drops the marker (every entry reads
-    /// as verified), which keeps custom caches on the terminal
-    /// cache-hit behavior: a failed pick on a hit is a failed pick.
+    /// The default implementation stores the entry as verified, which
+    /// keeps custom caches on the terminal cache-hit behavior: a
+    /// failed pick on a hit is a failed pick.
     fn set_unverified(&self, key: String, meta: Arc<Package>) {
         self.set(key, meta);
-    }
-
-    /// Whether the entry under `key` was stored via
-    /// [`PackageMetaCache::set_unverified`] and hasn't since been
-    /// replaced through a verified [`PackageMetaCache::set`].
-    fn is_unverified(&self, _key: &str) -> bool {
-        false
     }
 }
 
@@ -201,32 +206,20 @@ pub fn shared_picked_manifest_cache() -> PickedManifestCache {
 /// top contention point of a warm-resolve time profile.
 #[derive(Debug, Default)]
 pub struct InMemoryPackageMetaCache {
-    inner: DashMap<String, Arc<Package>>,
-    /// Keys whose current entry came through
-    /// [`PackageMetaCache::set_unverified`]. Marker and entry are not
-    /// updated atomically; a concurrent reader can at worst observe a
-    /// stale marker, costing one redundant revalidation or one
-    /// terminal (pre-marker behavior) pick — never a wrong pick.
-    unverified: DashSet<String>,
+    inner: DashMap<String, CachedPackument>,
 }
 
 impl PackageMetaCache for InMemoryPackageMetaCache {
-    fn get(&self, key: &str) -> Option<Arc<Package>> {
-        self.inner.get(key).map(|entry| Arc::clone(entry.value()))
+    fn get(&self, key: &str) -> Option<CachedPackument> {
+        self.inner.get(key).map(|entry| entry.value().clone())
     }
 
     fn set(&self, key: String, meta: Arc<Package>) {
-        self.unverified.remove(&key);
-        self.inner.insert(key, meta);
+        self.inner.insert(key, CachedPackument { meta, registry_verified: true });
     }
 
     fn set_unverified(&self, key: String, meta: Arc<Package>) {
-        self.unverified.insert(key.clone());
-        self.inner.insert(key, meta);
-    }
-
-    fn is_unverified(&self, key: &str) -> bool {
-        self.unverified.contains(key)
+        self.inner.insert(key, CachedPackument { meta, registry_verified: false });
     }
 }
 
@@ -766,12 +759,14 @@ async fn handle_cache_hit<Cache: PackageMetaCache>(
     use_filtered_full_metadata: bool,
     cache_key: &str,
     pkg_mirror: Option<&Path>,
-    cached: Arc<Package>,
+    cached: CachedPackument,
 ) -> Result<Option<PickPackageResult>, PickPackageError> {
     let upgrade =
-        maybe_upgrade_abbreviated_meta_for_release_age(ctx, spec, opts, full_metadata, cached)
+        maybe_upgrade_abbreviated_meta_for_release_age(ctx, spec, opts, full_metadata, cached.meta)
             .await?;
     let meta = upgrade.meta;
+    // The upgrade fetch (re)validated the packument against the registry.
+    let registry_verified = cached.registry_verified || upgrade.upgraded;
     if upgrade.upgraded && !opts.dry_run {
         if let Some(path) = pkg_mirror {
             persist_upgraded_to_mirror(path, &meta, use_filtered_full_metadata);
@@ -779,7 +774,7 @@ async fn handle_cache_hit<Cache: PackageMetaCache>(
         ctx.meta_cache.set(cache_key.to_string(), Arc::clone(&meta));
     }
     let (meta, picked) = pick_from_meta(picker_opts, spec, meta, opts.blocked_versions)?;
-    if picked.is_none() && !ctx.offline && ctx.meta_cache.is_unverified(cache_key) {
+    if picked.is_none() && !ctx.offline && !registry_verified {
         return Ok(None);
     }
     Ok(Some(PickPackageResult { meta, picked_package: picked }))

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -131,12 +131,10 @@ pub trait PackageMetaCache: Send + Sync {
     /// The verified [`PackageMetaCache::set`] the fetch then performs
     /// replaces the entry, so each package revalidates at most once.
     ///
-    /// The default implementation stores the entry as verified, which
-    /// keeps custom caches on the terminal cache-hit behavior: a
-    /// failed pick on a hit is a failed pick.
-    fn set_unverified(&self, key: String, meta: Arc<Package>) {
-        self.set(key, meta);
-    }
+    /// Required (no default) on purpose: an implementation that stored
+    /// these entries as verified would silently turn a recoverable
+    /// stale-mirror miss into a terminal "no matching version".
+    fn set_unverified(&self, key: String, meta: Arc<Package>);
 }
 
 /// Per-`(registry, package_name)` fetch serializer: a map of

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -51,7 +51,7 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::version_policy::{PackageVersionPolicy, PolicyMatch};
@@ -102,7 +102,36 @@ pub trait PackageMetaCache: Send + Sync {
     /// accepted; the next install starts a fresh cache. Takes
     /// [`Arc<Package>`] so callers can share the same handle they
     /// hand back to [`PickPackageResult`] without an extra clone.
+    ///
+    /// Clears any registry-unverified marker a previous
+    /// [`PackageMetaCache::set_unverified`] left on `key`: the caller
+    /// vouches that `meta` came from (or was revalidated by) the
+    /// registry.
     fn set(&self, key: String, meta: Arc<Package>);
+
+    /// Like [`PackageMetaCache::set`], but remembers the entry as
+    /// registry-unverified: it was parsed straight from the on-disk
+    /// mirror without a validating registry round-trip, so it may
+    /// predate versions the registry has. [`pick_package`] uses the
+    /// marker to fall through to a conditional registry request —
+    /// instead of failing the pick — when a cache hit on such an entry
+    /// can't satisfy the requested spec and the resolver isn't offline.
+    /// The verified [`PackageMetaCache::set`] the fetch then performs
+    /// clears the marker, so each package revalidates at most once.
+    ///
+    /// The default implementation drops the marker (every entry reads
+    /// as verified), which keeps custom caches on the terminal
+    /// cache-hit behavior: a failed pick on a hit is a failed pick.
+    fn set_unverified(&self, key: String, meta: Arc<Package>) {
+        self.set(key, meta);
+    }
+
+    /// Whether the entry under `key` was stored via
+    /// [`PackageMetaCache::set_unverified`] and hasn't since been
+    /// replaced through a verified [`PackageMetaCache::set`].
+    fn is_unverified(&self, _key: &str) -> bool {
+        false
+    }
 }
 
 /// Per-`(registry, package_name)` fetch serializer: a map of
@@ -173,6 +202,12 @@ pub fn shared_picked_manifest_cache() -> PickedManifestCache {
 #[derive(Debug, Default)]
 pub struct InMemoryPackageMetaCache {
     inner: DashMap<String, Arc<Package>>,
+    /// Keys whose current entry came through
+    /// [`PackageMetaCache::set_unverified`]. Marker and entry are not
+    /// updated atomically; a concurrent reader can at worst observe a
+    /// stale marker, costing one redundant revalidation or one
+    /// terminal (pre-marker behavior) pick — never a wrong pick.
+    unverified: DashSet<String>,
 }
 
 impl PackageMetaCache for InMemoryPackageMetaCache {
@@ -181,7 +216,17 @@ impl PackageMetaCache for InMemoryPackageMetaCache {
     }
 
     fn set(&self, key: String, meta: Arc<Package>) {
+        self.unverified.remove(&key);
         self.inner.insert(key, meta);
+    }
+
+    fn set_unverified(&self, key: String, meta: Arc<Package>) {
+        self.unverified.insert(key.clone());
+        self.inner.insert(key, meta);
+    }
+
+    fn is_unverified(&self, key: &str) -> bool {
+        self.unverified.contains(key)
     }
 }
 
@@ -428,8 +473,9 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     let use_mem_cache = !opts.update_checksums;
 
     // 1. In-memory cache.
-    if use_mem_cache && let Some(cached) = ctx.meta_cache.get(&cache_key) {
-        return handle_cache_hit(
+    if use_mem_cache
+        && let Some(cached) = ctx.meta_cache.get(&cache_key)
+        && let Some(result) = handle_cache_hit(
             ctx,
             spec,
             opts,
@@ -440,7 +486,9 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             pkg_mirror.as_deref(),
             cached,
         )
-        .await;
+        .await?
+    {
+        return Ok(result);
     }
 
     let limit = {
@@ -457,8 +505,9 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     // this re-check, every duplicate caller would still fall
     // through to the disk + network path even though they were
     // waiting precisely for the winner's fetch to complete.
-    if use_mem_cache && let Some(cached) = ctx.meta_cache.get(&cache_key) {
-        return handle_cache_hit(
+    if use_mem_cache
+        && let Some(cached) = ctx.meta_cache.get(&cache_key)
+        && let Some(result) = handle_cache_hit(
             ctx,
             spec,
             opts,
@@ -469,7 +518,9 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             pkg_mirror.as_deref(),
             cached,
         )
-        .await;
+        .await?
+    {
+        return Ok(result);
     }
 
     let mut meta_cached_in_store: Option<Arc<Package>> = None;
@@ -480,6 +531,12 @@ pub async fn pick_package<Cache: PackageMetaCache>(
 
         if ctx.offline {
             if let Some(meta) = meta_cached_in_store {
+                // maybe_upgrade_abbreviated_meta_for_release_age
+                // short-circuits when offline, so a later cache hit
+                // returns this same meta without any network access.
+                if !opts.dry_run {
+                    ctx.meta_cache.set_unverified(cache_key.clone(), Arc::clone(&meta));
+                }
                 let (meta, picked) =
                     pick_from_meta(&picker_opts, spec, meta, opts.blocked_versions)?;
                 return Ok(PickPackageResult { meta, picked_package: picked });
@@ -510,6 +567,13 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             let (picked_meta, picked) =
                 pick_from_meta(&picker_opts, spec, Arc::clone(&meta), opts.blocked_versions)?;
             if picked.is_some() {
+                // A later cache hit re-runs the same release-age upgrade
+                // check, so behavior is unchanged. The upgrade branch
+                // above already cached the registry-validated document;
+                // don't downgrade it to an unverified marking.
+                if !upgrade.upgraded && !opts.dry_run {
+                    ctx.meta_cache.set_unverified(cache_key.clone(), Arc::clone(&meta));
+                }
                 return Ok(PickPackageResult { meta: picked_meta, picked_package: picked });
             }
             // Fall through to fetch when disk had the meta but no
@@ -552,7 +616,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
                 // the next install starts a fresh cache and
                 // re-evaluates the disk shortcut.
                 if !opts.dry_run {
-                    ctx.meta_cache.set(cache_key.clone(), Arc::clone(meta));
+                    ctx.meta_cache.set_unverified(cache_key.clone(), Arc::clone(meta));
                 }
                 return Ok(PickPackageResult { meta: picked_meta, picked_package: Some(picked) });
             }
@@ -677,6 +741,12 @@ pub async fn pick_package<Cache: PackageMetaCache>(
 /// re-fetching). Extracting it keeps the two call sites identical so
 /// the upgrade-and-persist side-effects can't drift.
 ///
+/// Returns `Ok(None)` when the hit must not be terminal: the entry is
+/// a registry-unverified disk promotion (see
+/// [`PackageMetaCache::set_unverified`]) whose pick failed, and the
+/// resolver isn't offline. The caller then falls through to the disk +
+/// network flow, whose fetch replaces the entry with a verified one.
+///
 /// The argument list is wide because the helper consumes everything
 /// the per-call frame already computed (cache key, derived
 /// `full_metadata`, pre-resolved mirror path, picker options).
@@ -697,7 +767,7 @@ async fn handle_cache_hit<Cache: PackageMetaCache>(
     cache_key: &str,
     pkg_mirror: Option<&Path>,
     cached: Arc<Package>,
-) -> Result<PickPackageResult, PickPackageError> {
+) -> Result<Option<PickPackageResult>, PickPackageError> {
     let upgrade =
         maybe_upgrade_abbreviated_meta_for_release_age(ctx, spec, opts, full_metadata, cached)
             .await?;
@@ -709,7 +779,10 @@ async fn handle_cache_hit<Cache: PackageMetaCache>(
         ctx.meta_cache.set(cache_key.to_string(), Arc::clone(&meta));
     }
     let (meta, picked) = pick_from_meta(picker_opts, spec, meta, opts.blocked_versions)?;
-    Ok(PickPackageResult { meta, picked_package: picked })
+    if picked.is_none() && !ctx.offline && ctx.meta_cache.is_unverified(cache_key) {
+        return Ok(None);
+    }
+    Ok(Some(PickPackageResult { meta, picked_package: picked }))
 }
 
 /// Same fields as [`PickPackageOptions`] minus the dispatcher-only

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -52,6 +52,28 @@ const PACKAGE_BODY: &str = r#"{
     }
 }"#;
 
+/// [`PACKAGE_BODY`] as it looked before 1.1.0 was published — for
+/// seeding a mirror that predates a version the registry has.
+const STALE_PACKAGE_BODY: &str = r#"{
+    "name": "acme",
+    "dist-tags": { "latest": "1.0.0" },
+    "modified": "2024-01-15T12:00:00.000Z",
+    "time": {
+        "1.0.0": "2024-01-10T08:30:00.000Z"
+    },
+    "versions": {
+        "1.0.0": {
+            "name": "acme",
+            "version": "1.0.0",
+            "dist": {
+                "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                "shasum": "0000000000000000000000000000000000000000",
+                "tarball": "https://registry/acme-1.0.0.tgz"
+            }
+        }
+    }
+}"#;
+
 fn range_spec(name: &str, range: &str) -> RegistryPackageSpec {
     RegistryPackageSpec {
         name: name.to_string(),
@@ -265,6 +287,159 @@ async fn offline_without_mirror_errors() {
         .await
         .expect_err("offline + no mirror = error");
     assert!(matches!(err, PickPackageError::NoOfflineMeta { .. }), "got {err:?}");
+}
+
+/// A second offline resolve succeeds after the mirror file is deleted,
+/// proving the first resolve promoted the disk-loaded packument into
+/// the in-memory cache instead of re-reading disk per dependent.
+#[tokio::test]
+async fn offline_promotes_disk_loaded_packument_into_memory_cache() {
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = "https://registry.example.com/".to_string();
+    let preloaded: pacquet_registry::Package =
+        serde_json::from_str(PACKAGE_BODY).expect("parse packument");
+    persist_meta_to_mirror(cache_dir.path(), ABBREVIATED_META_DIR, &registry, &preloaded)
+        .expect("warm mirror");
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: true,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+    let spec = range_spec("acme", "^1.0.0");
+
+    let first = pick_package(&ctx, &spec, &default_opts(&registry)).await.expect("ok");
+    assert_eq!(first.picked_package.expect("picked").version.to_string(), "1.1.0");
+    let cache_key =
+        metadata_cache_key(&MetadataCacheScope::Public, &registry, "acme", false, false);
+    assert!(meta_cache.get(&cache_key).is_some());
+
+    let mirror = get_pkg_mirror_path(cache_dir.path(), ABBREVIATED_META_DIR, &registry, "acme")
+        .expect("mirror path");
+    std::fs::remove_file(mirror).expect("remove mirror");
+    let second = pick_package(&ctx, &spec, &default_opts(&registry)).await.expect("ok");
+    assert_eq!(second.picked_package.expect("picked").version.to_string(), "1.1.0");
+}
+
+/// Prefer-offline sibling of
+/// [`offline_promotes_disk_loaded_packument_into_memory_cache`]; the
+/// `expect(0)` mock additionally proves neither resolve touched the
+/// registry.
+#[tokio::test]
+async fn prefer_offline_promotes_disk_loaded_packument_into_memory_cache() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server.mock("GET", "/acme").with_status(500).expect(0).create_async().await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let preloaded: pacquet_registry::Package =
+        serde_json::from_str(PACKAGE_BODY).expect("parse packument");
+    persist_meta_to_mirror(cache_dir.path(), ABBREVIATED_META_DIR, &registry, &preloaded)
+        .expect("warm mirror");
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: true,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+    let spec = range_spec("acme", "^1.0.0");
+
+    let first = pick_package(&ctx, &spec, &default_opts(&registry)).await.expect("ok");
+    assert_eq!(first.picked_package.expect("picked").version.to_string(), "1.1.0");
+    let cache_key =
+        metadata_cache_key(&MetadataCacheScope::Public, &registry, "acme", false, false);
+    assert!(meta_cache.get(&cache_key).is_some());
+
+    let mirror = get_pkg_mirror_path(cache_dir.path(), ABBREVIATED_META_DIR, &registry, "acme")
+        .expect("mirror path");
+    std::fs::remove_file(mirror).expect("remove mirror");
+    let second = pick_package(&ctx, &spec, &default_opts(&registry)).await.expect("ok");
+    assert_eq!(second.picked_package.expect("picked").version.to_string(), "1.1.0");
+    mock.assert_async().await;
+}
+
+/// The first resolve picking 1.0.0 proves it was served from the stale
+/// mirror (the registry would offer 1.1.0). The promoted entry can't
+/// satisfy `^1.1.0`, so the second resolve must fall back to the
+/// registry instead of failing the pick. The fetch replaces the entry
+/// with a verified one, so the third resolve short-circuits on the
+/// cache — `expect(1)` fails if it fetched again.
+#[tokio::test]
+async fn stale_disk_promoted_entry_falls_back_to_registry_under_prefer_offline() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_header("etag", r#"W/"fresh""#)
+        .with_body(PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let stale: pacquet_registry::Package =
+        serde_json::from_str(STALE_PACKAGE_BODY).expect("parse packument");
+    persist_meta_to_mirror(cache_dir.path(), ABBREVIATED_META_DIR, &registry, &stale)
+        .expect("warm mirror");
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: true,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+
+    let first = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
+        .await
+        .expect("ok");
+    assert_eq!(first.picked_package.expect("picked").version.to_string(), "1.0.0");
+
+    let second = pick_package(&ctx, &range_spec("acme", "^1.1.0"), &default_opts(&registry))
+        .await
+        .expect("ok");
+    assert_eq!(second.picked_package.expect("picked").version.to_string(), "1.1.0");
+
+    let third = pick_package(&ctx, &range_spec("acme", "^1.1.0"), &default_opts(&registry))
+        .await
+        .expect("ok");
+    assert_eq!(third.picked_package.expect("picked").version.to_string(), "1.1.0");
+    mock.assert_async().await;
 }
 
 #[tokio::test]

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -289,6 +289,20 @@ async fn offline_without_mirror_errors() {
     assert!(matches!(err, PickPackageError::NoOfflineMeta { .. }), "got {err:?}");
 }
 
+/// The verification state lives inside the cache entry, so an
+/// overwrite can never be observed with the previous entry's state.
+#[test]
+fn meta_cache_tracks_registry_verification_per_entry() {
+    let cache = InMemoryPackageMetaCache::default();
+    let meta: pacquet_registry::Package =
+        serde_json::from_str(PACKAGE_BODY).expect("parse packument");
+    let meta = Arc::new(meta);
+    cache.set_unverified("k".to_string(), Arc::clone(&meta));
+    assert!(!cache.get("k").expect("entry").registry_verified);
+    cache.set("k".to_string(), meta);
+    assert!(cache.get("k").expect("entry").registry_verified);
+}
+
 /// A second offline resolve succeeds after the mirror file is deleted,
 /// proving the first resolve promoted the disk-loaded packument into
 /// the in-memory cache instead of re-reading disk per dependent.

--- a/pacquet/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pacquet/tasks/integrated-benchmark/src/cli_args.rs
@@ -218,6 +218,18 @@ pub enum BenchmarkScenario {
     /// `pnpm add <dep>` against an existing lockfile, hot cache + hot store.
     #[value(name = "isolated-linker.fresh-add-dep.hot-cache.hot-store")]
     IsolatedFreshAddDepHotCacheHotStore,
+    /// Hot metadata mirror, fully offline resolution, no linking: the
+    /// measured command is `install --offline --lockfile-only` with
+    /// `pnpm-lock.yaml` removed per iteration, so every timed run
+    /// re-resolves the whole tree from the on-disk packument mirror.
+    /// With no network and no materialization, mirror reads and
+    /// packument parsing dominate — the series that guards offline /
+    /// prefer-offline resolution (e.g. the disk-to-memory metadata
+    /// promotion). The measured command can't prime the mirror itself
+    /// (`--offline` fails on a cold one), so an online pre-warm pass
+    /// runs first (see [`Self::prewarm_install_args`]).
+    #[value(name = "isolated-linker.fresh-resolve.hot-cache.offline")]
+    IsolatedFreshResolveHotCacheOffline,
     /// Frozen lockfile, hot cache + hot store, `enableGlobalVirtualStore: true` with a pre-warmed GVS.
     #[value(name = "gvs-linker.fresh-restore.hot-cache.hot-store")]
     GvsFreshRestoreHotCacheHotStore,
@@ -247,6 +259,22 @@ impl BenchmarkScenario {
                 &["install", "--frozen-lockfile"]
             }
             BenchmarkScenario::IsolatedFreshAddDepHotCacheHotStore => &["add", "is-odd"],
+            BenchmarkScenario::IsolatedFreshResolveHotCacheOffline => {
+                &["install", "--offline", "--lockfile-only"]
+            }
+        }
+    }
+
+    /// Arguments of the online install that primes `cache-dir` /
+    /// `store-dir` before hyperfine runs, for scenarios whose measured
+    /// command can't do its own priming (an `--offline` run against the
+    /// freshly wiped mirror fails). `None` for every other scenario:
+    /// hyperfine's warmup run primes whatever their per-iteration
+    /// cleanup preserves.
+    pub fn prewarm_install_args(self) -> Option<&'static [&'static str]> {
+        match self {
+            BenchmarkScenario::IsolatedFreshResolveHotCacheOffline => Some(&["install"]),
+            _ => None,
         }
     }
 
@@ -267,19 +295,30 @@ impl BenchmarkScenario {
             | BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStoreColdPnpr
             | BenchmarkScenario::IsolatedFreshRestoreHotCacheHotStore
             | BenchmarkScenario::IsolatedFreshAddDepHotCacheHotStore
+            | BenchmarkScenario::IsolatedFreshResolveHotCacheOffline
             | BenchmarkScenario::GvsFreshRestoreHotCacheHotStore => true,
         }
     }
 
     /// Whether to seed a `pnpm-lock.yaml` into the bench dir during
     /// init. The two install variants skip this; the restore, add-dep,
-    /// and GVS variants need it.
+    /// and GVS variants need it. The fresh-resolve variant keeps the
+    /// lockfile *enabled* but seeds none: a seeded lockfile would let
+    /// the online pre-warm pass skip resolution, leaving the metadata
+    /// mirror cold for the measured offline runs.
+    pub fn seeds_lockfile(self) -> bool {
+        self.lockfile_enabled()
+            && !matches!(self, BenchmarkScenario::IsolatedFreshResolveHotCacheOffline)
+    }
+
+    /// The `pnpm-lock.yaml` contents to seed during init, when
+    /// [`Self::seeds_lockfile`] says the scenario wants one.
     pub fn lockfile<Text, LoadLockfile>(self, load_lockfile: LoadLockfile) -> Option<String>
     where
         Text: Into<String>,
         LoadLockfile: FnOnce() -> Text,
     {
-        self.lockfile_enabled().then(|| load_lockfile().into())
+        self.seeds_lockfile().then(|| load_lockfile().into())
     }
 
     /// Per-iteration cleanup (paths to remove and saved copies to
@@ -331,6 +370,12 @@ impl BenchmarkScenario {
             },
             BenchmarkScenario::GvsFreshRestoreHotCacheHotStore => {
                 Cleanup { remove: &["node_modules"], restore: &[SAVED_LOCKFILE] }
+            }
+            // Only the lockfile: `--lockfile-only` never touches
+            // `node_modules`, and the warm `cache-dir` / `store-dir` the
+            // pre-warm pass populated are the scenario's contract.
+            BenchmarkScenario::IsolatedFreshResolveHotCacheOffline => {
+                Cleanup { remove: &["pnpm-lock.yaml"], restore: &[] }
             }
         }
     }

--- a/pacquet/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pacquet/tasks/integrated-benchmark/src/cli_args.rs
@@ -371,11 +371,15 @@ impl BenchmarkScenario {
             BenchmarkScenario::GvsFreshRestoreHotCacheHotStore => {
                 Cleanup { remove: &["node_modules"], restore: &[SAVED_LOCKFILE] }
             }
-            // Only the lockfile: `--lockfile-only` never touches
-            // `node_modules`, and the warm `cache-dir` / `store-dir` the
-            // pre-warm pass populated are the scenario's contract.
+            // `node_modules` is wiped alongside the lockfile even though
+            // `--lockfile-only` never writes it: a populated `node_modules`
+            // left by the pre-warm pass lets the install's up-to-date
+            // short-circuit skip resolution entirely ("Already up to
+            // date"), and the timed runs would measure a no-op. The warm
+            // `cache-dir` / `store-dir` the pre-warm populated are the
+            // scenario's contract and survive.
             BenchmarkScenario::IsolatedFreshResolveHotCacheOffline => {
-                Cleanup { remove: &["pnpm-lock.yaml"], restore: &[] }
+                Cleanup { remove: &["node_modules", "pnpm-lock.yaml"], restore: &[] }
             }
         }
     }

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -219,14 +219,24 @@ impl WorkEnv {
                 "./pacquet/target/release/pacquet".to_string()
             }
             BenchId::PnpmRevision(_) => {
-                // Prefer `pnpm.mjs`, fall back to `pnpm.cjs`. Resolved
-                // at script runtime so the existence check sees the
-                // bundle produced by `pnpm run compile-only`, not the empty
-                // tree visible during `init()`. Mirrors
-                // `resolve_pnpm_bin` in `benchmarks/bench.sh`.
-                let mjs = "./pnpm-source/pnpm/dist/pnpm.mjs";
-                let cjs = "./pnpm-source/pnpm/dist/pnpm.cjs";
-                format!(r#"node "$([ -f {mjs} ] && echo {mjs} || echo {cjs})""#)
+                // Take the first bundle that exists: `pnpm.mjs` over
+                // `pnpm.cjs`, and the `pnpm11/` layout (where the
+                // TypeScript CLI lives) over the pre-move root layout
+                // (still produced by revisions that predate the move,
+                // e.g. a `pnpm@v10` target). Resolved at script runtime
+                // so the existence check sees the bundle produced by
+                // `pnpm run compile-only`, not the empty tree visible
+                // during `init()`.
+                let candidates = [
+                    "./pnpm-source/pnpm11/pnpm/dist/pnpm.mjs",
+                    "./pnpm-source/pnpm11/pnpm/dist/pnpm.cjs",
+                    "./pnpm-source/pnpm/dist/pnpm.mjs",
+                    "./pnpm-source/pnpm/dist/pnpm.cjs",
+                ]
+                .join(" ");
+                format!(
+                    r#"node "$(for f in {candidates}; do if [ -f "$f" ]; then echo "$f"; break; fi; done)""#
+                )
             }
             BenchId::Static(_) => "pnpm".to_string(),
         }
@@ -500,20 +510,6 @@ impl WorkEnv {
             }
         }
 
-        // Offline scenarios can't let hyperfine's warmup prime the caches —
-        // the measured `--offline` command fails against the mirror the
-        // pre-benchmark wipe above just emptied — so run the online priming
-        // script once per target first. The per-iteration cleanup below
-        // preserves what it primes.
-        if scenario.prewarm_install_args().is_some() {
-            for id in self.benchmarked_ids() {
-                eprintln!("Pre-warming caches for {id}...");
-                Command::new("bash")
-                    .arg(self.prewarm_script_path(id))
-                    .pipe_mut(executor(PREWARM_SCRIPT));
-            }
-        }
-
         // hyperfine runs `--prepare` before *each* timed invocation, so
         // cleanup must cover every bench dir we're about to measure.
         //
@@ -527,6 +523,30 @@ impl WorkEnv {
         let cleanup = scenario.cleanup();
         let cleanup_command =
             build_cleanup_command(&cleanup, self.benchmarked_ids(), |id| self.bench_dir(id));
+
+        // Offline scenarios can't let hyperfine's warmup prime the caches —
+        // the measured `--offline` command fails against the mirror the
+        // pre-benchmark wipe above just emptied — so run the online priming
+        // script once per target first. The per-iteration cleanup runs
+        // before the priming too: a reused work-env can carry a lockfile or
+        // `node_modules` from a previous scenario, and either would let the
+        // priming install skip the full resolution that populates the
+        // metadata mirror (a locked install fetches tarballs, not
+        // packuments; an up-to-date `node_modules` short-circuits the
+        // install outright).
+        if scenario.prewarm_install_args().is_some() {
+            Command::new("bash")
+                .current_dir(self.root())
+                .arg("-c")
+                .arg(&cleanup_command)
+                .pipe_mut(executor("prewarm cleanup"));
+            for id in self.benchmarked_ids() {
+                eprintln!("Pre-warming caches for {id}...");
+                Command::new("bash")
+                    .arg(self.prewarm_script_path(id))
+                    .pipe_mut(executor(PREWARM_SCRIPT));
+            }
+        }
 
         let mut command = Command::new("hyperfine");
         command.current_dir(self.root()).arg("--prepare").arg(&cleanup_command);

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -28,6 +28,7 @@ use std::{
 };
 
 const BENCHMARK_OUTPUT_LOG: &str = "BENCHMARK_OUTPUT.ndjson";
+const PREWARM_SCRIPT: &str = "prewarm.bash";
 const BENCHMARK_DIAGNOSTICS_JSON: &str = "BENCHMARK_DIAGNOSTICS.json";
 const BENCHMARK_DIAGNOSTICS_MD: &str = "BENCHMARK_DIAGNOSTICS.md";
 const PNPR_DIRECT_RATIO_MAX: f64 = 1.05;
@@ -142,6 +143,12 @@ impl WorkEnv {
 
     fn script_path(&self, id: BenchId) -> PathBuf {
         self.bench_dir(id).join("install.bash")
+    }
+
+    /// Path of the untimed online priming script, written only for
+    /// scenarios with [`BenchmarkScenario::prewarm_install_args`].
+    fn prewarm_script_path(&self, id: BenchId) -> PathBuf {
+        self.bench_dir(id).join(PREWARM_SCRIPT)
     }
 
     fn bash_command(&self, id: BenchId) -> String {
@@ -490,6 +497,20 @@ impl WorkEnv {
             for id in self.benchmarked_ids() {
                 eprintln!("Pre-warming GVS for {id}...");
                 Command::new("bash").arg(self.script_path(id)).pipe_mut(executor("install.bash"));
+            }
+        }
+
+        // Offline scenarios can't let hyperfine's warmup prime the caches —
+        // the measured `--offline` command fails against the mirror the
+        // pre-benchmark wipe above just emptied — so run the online priming
+        // script once per target first. The per-iteration cleanup below
+        // preserves what it primes.
+        if scenario.prewarm_install_args().is_some() {
+            for id in self.benchmarked_ids() {
+                eprintln!("Pre-warming caches for {id}...");
+                Command::new("bash")
+                    .arg(self.prewarm_script_path(id))
+                    .pipe_mut(executor(PREWARM_SCRIPT));
             }
         }
 
@@ -1868,11 +1889,36 @@ fn may_create_lockfile(dst_dir: &Path, scenario: BenchmarkScenario, src_dir: Opt
 /// through it. The `source` fails loudly under `errexit` if the file is
 /// missing, rather than silently falling back to a direct install.
 fn create_install_script(dir: &Path, scenario: BenchmarkScenario, command: &str, id: BenchId) {
-    let path = dir.join("install.bash");
-    let capture_pacquet_metrics = id.is_pacquet_like();
+    // The proxy-cache populator must reach the registry, so a scenario
+    // whose measured args are offline hands it the online pre-warm args.
+    let args = if id.is_proxy_cache_populator() {
+        scenario.prewarm_install_args().unwrap_or_else(|| scenario.install_args())
+    } else {
+        scenario.install_args()
+    };
+    write_bench_script(dir, "install.bash", command, id, args, id.is_pacquet_like());
+    if let Some(prewarm_args) = scenario.prewarm_install_args() {
+        // Untimed online priming run (see
+        // `BenchmarkScenario::prewarm_install_args`). Metrics capture is
+        // off so the priming run can't pollute the diagnostics log the
+        // timed runs append to.
+        write_bench_script(dir, PREWARM_SCRIPT, command, id, prewarm_args, false);
+    }
+}
+
+fn write_bench_script(
+    dir: &Path,
+    file_name: &str,
+    command: &str,
+    id: BenchId,
+    args: &[&str],
+    capture_pacquet_metrics: bool,
+) {
+    let path = dir.join(file_name);
 
     eprintln!("Creating script {path:?}...");
-    let mut file = File::create(&path).expect("create install.bash");
+    let mut file =
+        File::create(&path).unwrap_or_else(|error| panic!("create {file_name}: {error}"));
 
     writeln!(file, "#!/bin/bash").unwrap();
     writeln!(file, "set -o errexit -o nounset -o pipefail").unwrap();
@@ -1898,7 +1944,7 @@ fn create_install_script(dir: &Path, scenario: BenchmarkScenario, command: &str,
     if capture_pacquet_metrics {
         write!(file, " --reporter ndjson").unwrap();
     }
-    for arg in scenario.install_args() {
+    for arg in args {
         write!(file, " {arg}").unwrap();
     }
     if capture_pacquet_metrics {

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -235,7 +235,7 @@ impl WorkEnv {
                 ]
                 .join(" ");
                 format!(
-                    r#"node "$(for f in {candidates}; do if [ -f "$f" ]; then echo "$f"; break; fi; done)""#
+                    r#"node "$(for f in {candidates}; do if [ -f "$f" ]; then echo "$f"; break; fi; done)""#,
                 )
             }
             BenchId::Static(_) => "pnpm".to_string(),

--- a/pacquet/tasks/integrated-benchmark/src/work_env/tests.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env/tests.rs
@@ -1,9 +1,49 @@
 use super::{
-    BenchmarkScenario, HyperfineCommand, PhaseEvent, collect_pnpr_direct_ratios,
-    non_trivial_cold_batch, pnpr_auth_config_key, pnpr_benchmark_config_yaml, read_phase_events,
-    render_diagnostics_markdown, requires_fresh_pnpr_cold_batch_metrics, summarize_phase_events,
+    BenchId, BenchmarkScenario, HyperfineCommand, PhaseEvent, collect_pnpr_direct_ratios,
+    create_install_script, non_trivial_cold_batch, pnpr_auth_config_key,
+    pnpr_benchmark_config_yaml, read_phase_events, render_diagnostics_markdown,
+    requires_fresh_pnpr_cold_batch_metrics, summarize_phase_events,
 };
 use std::{collections::HashMap, fs};
+
+#[test]
+fn offline_scenario_writes_online_prewarm_script() {
+    let dir = std::env::temp_dir()
+        .join(format!("pacquet-integrated-benchmark-offline-prewarm-{}", std::process::id()));
+    fs::create_dir_all(&dir).expect("create script test dir");
+
+    create_install_script(
+        &dir,
+        BenchmarkScenario::IsolatedFreshResolveHotCacheOffline,
+        "pnpm",
+        BenchId::PnpmRevision("HEAD"),
+    );
+    let install = fs::read_to_string(dir.join("install.bash")).expect("read install.bash");
+    let prewarm = fs::read_to_string(dir.join("prewarm.bash")).expect("read prewarm.bash");
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(install.contains("install --offline --lockfile-only"), "install = {install}");
+    // The priming run must reach the registry: a plain online install.
+    assert!(prewarm.ends_with("exec pnpm install\n"), "prewarm = {prewarm}");
+}
+
+#[test]
+fn online_scenario_writes_no_prewarm_script() {
+    let dir = std::env::temp_dir()
+        .join(format!("pacquet-integrated-benchmark-online-prewarm-{}", std::process::id()));
+    fs::create_dir_all(&dir).expect("create script test dir");
+
+    create_install_script(
+        &dir,
+        BenchmarkScenario::IsolatedFreshRestoreHotCacheHotStore,
+        "pnpm",
+        BenchId::PnpmRevision("HEAD"),
+    );
+    let has_prewarm = dir.join("prewarm.bash").exists();
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(!has_prewarm);
+}
 
 #[test]
 fn phase_event_parser_reads_flat_and_nested_json_trace_fields() {

--- a/pnpm11/benchmarks/README.md
+++ b/pnpm11/benchmarks/README.md
@@ -17,7 +17,7 @@ stay consistent with the pacquet benchmark.
 ## Usage
 
 ```sh
-./benchmarks/bench.sh
+./pnpm11/benchmarks/bench.sh
 ```
 
 The script:
@@ -25,7 +25,7 @@ The script:
 1. Builds the `integrated-benchmark` binary in release mode.
 2. Clones the current repo into the temp work-env once per revision
    (`HEAD` and `main`) and runs `pnpm install && pnpm run compile-only`
-   in each to produce `pnpm/dist/pnpm.mjs`. `compile-only` skips the
+   in each to produce `pnpm11/pnpm/dist/pnpm.mjs`. `compile-only` skips the
    `update-manifests` pass that the root `compile` script does — it
    would rewrite tracked files and trigger a second install per
    revision, neither of which the bench needs.
@@ -46,11 +46,11 @@ leading segment groups runs by linker mode. Today there are two
 groups (`isolated-linker.*` and `gvs-linker.*`); future scenarios
 will add `hoisted-linker.*` and `pnp-linker.*`.
 
-The restore/install/add scenarios start with `node_modules` wiped —
-"fresh" names that target state; future variants that begin with a
-populated `node_modules` will use a different action prefix. The
-fresh-resolve scenario measures `--lockfile-only` resolution and never
-touches `node_modules`.
+Every current scenario starts with `node_modules` wiped — "fresh"
+names that target state; future variants that begin with a populated
+`node_modules` will use a different action prefix. (For fresh-resolve
+the wipe also keeps the install's up-to-date short-circuit from
+skipping the measured resolution.)
 
 | # | Slug | Lockfile | Cache | Store | Description |
 |---|---|---|---|---|---|

--- a/pnpm11/benchmarks/README.md
+++ b/pnpm11/benchmarks/README.md
@@ -1,7 +1,7 @@
 # pnpm Benchmarks
 
 Compares `pnpm install` performance between the current branch (`HEAD`) and
-`main`, across the six scenarios listed below.
+`main`, across the scenarios listed below.
 
 This wrapper builds both pnpm revisions and runs hyperfine through the
 shared Rust orchestrator at
@@ -46,9 +46,11 @@ leading segment groups runs by linker mode. Today there are two
 groups (`isolated-linker.*` and `gvs-linker.*`); future scenarios
 will add `hoisted-linker.*` and `pnp-linker.*`.
 
-Every current scenario starts with `node_modules` wiped — "fresh"
-names that target state; future variants that begin with a populated
-`node_modules` will use a different action prefix.
+The restore/install/add scenarios start with `node_modules` wiped —
+"fresh" names that target state; future variants that begin with a
+populated `node_modules` will use a different action prefix. The
+fresh-resolve scenario measures `--lockfile-only` resolution and never
+touches `node_modules`.
 
 | # | Slug | Lockfile | Cache | Store | Description |
 |---|---|---|---|---|---|
@@ -57,7 +59,8 @@ names that target state; future variants that begin with a populated
 | 3 | `isolated-linker.fresh-install.hot-cache.hot-store` | ✗ | hot | hot | Resolve from scratch with both directories hot |
 | 4 | `isolated-linker.fresh-restore.cold-cache.cold-store` | ✔ frozen | cold | cold | Restore from lockfile with cold disks (typical CI shape) |
 | 5 | `isolated-linker.fresh-install.cold-cache.cold-store` | ✗ | cold | cold | True cold start — no lockfile, nothing cached |
-| 6 | `gvs-linker.fresh-restore.hot-cache.hot-store` | ✔ frozen | hot | hot + GVS | Frozen-lockfile restore with `enableGlobalVirtualStore: true`, pre-warmed GVS |
+| 6 | `isolated-linker.fresh-resolve.hot-cache.offline` | ✗ (removed per run) | hot | n/a | `install --offline --lockfile-only`: full re-resolution from the warm on-disk packument mirror — no network, no linking; guards offline/prefer-offline resolution (an online pre-warm pass primes the mirror first) |
+| 7 | `gvs-linker.fresh-restore.hot-cache.hot-store` | ✔ frozen | hot | hot + GVS | Frozen-lockfile restore with `enableGlobalVirtualStore: true`, pre-warmed GVS |
 
 All scenarios use `--ignore-scripts` and isolated store/cache directories per revision.
 

--- a/pnpm11/benchmarks/bench.sh
+++ b/pnpm11/benchmarks/bench.sh
@@ -12,10 +12,13 @@ set -euo pipefail
 #
 # Env vars: WARMUP (default 1), RUNS (default 10).
 #
-# Usage: ./benchmarks/bench.sh
+# Usage: ./pnpm11/benchmarks/bench.sh (from the repo root)
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-FIXTURE_DIR="$REPO_ROOT/benchmarks/fixture"
+# This script lives at `pnpm11/benchmarks/`; the git root — where the
+# Rust workspace and the orchestrator's `Cargo.toml` live — is two
+# levels up.
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+FIXTURE_DIR="$REPO_ROOT/pnpm11/benchmarks/fixture"
 WARMUP="${WARMUP:-1}"
 RUNS="${RUNS:-10}"
 BENCH_DIR="$(mktemp -d "${TMPDIR:-/tmp}/pnpm-bench.XXXXXX")"
@@ -44,12 +47,12 @@ fi
 
 # Scenario list: `slug:Display label`. The slug matches the
 # orchestrator's `--scenario` value (the clap-derived kebab-case name
-# from `BenchmarkScenario`). The restore/install/add scenarios start
-# with `node_modules` wiped — "Fresh" names that target state; the
-# fresh-resolve scenario measures `--lockfile-only` resolution and
-# never touches `node_modules`. "Isolated linker" names the
-# `nodeLinker` mode; alternatives (`hoisted`, `pnp`) and populated-
-# node_modules counterparts are reserved for future scenarios.
+# from `BenchmarkScenario`). Every scenario starts with `node_modules`
+# wiped — "Fresh" names that target state (for fresh-resolve it also
+# keeps the up-to-date short-circuit from skipping the measured
+# resolution). "Isolated linker" names the `nodeLinker` mode;
+# alternatives (`hoisted`, `pnp`) and populated-node_modules
+# counterparts are reserved for future scenarios.
 SCENARIOS=(
   "isolated-linker.fresh-restore.hot-cache.hot-store:Isolated linker: fresh restore, hot cache + hot store"
   "isolated-linker.fresh-add-dep.hot-cache.hot-store:Isolated linker: fresh add new dep, hot cache + hot store"

--- a/pnpm11/benchmarks/bench.sh
+++ b/pnpm11/benchmarks/bench.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Thin wrapper around `pacquet/tasks/integrated-benchmark`. Builds two
 # pnpm revisions (the current branch and `main`) and runs hyperfine for
-# each of the six scenarios that used to live in this script.
+# each scenario in the list below.
 #
 # Scenarios, registry choice, and runner behaviour are preserved exactly
 # as before; the orchestration logic is shared with the pacquet bench.
@@ -44,8 +44,10 @@ fi
 
 # Scenario list: `slug:Display label`. The slug matches the
 # orchestrator's `--scenario` value (the clap-derived kebab-case name
-# from `BenchmarkScenario`). All six start with `node_modules` wiped
-# — "Fresh" names that target state. "Isolated linker" names the
+# from `BenchmarkScenario`). The restore/install/add scenarios start
+# with `node_modules` wiped — "Fresh" names that target state; the
+# fresh-resolve scenario measures `--lockfile-only` resolution and
+# never touches `node_modules`. "Isolated linker" names the
 # `nodeLinker` mode; alternatives (`hoisted`, `pnp`) and populated-
 # node_modules counterparts are reserved for future scenarios.
 SCENARIOS=(
@@ -54,6 +56,7 @@ SCENARIOS=(
   "isolated-linker.fresh-install.hot-cache.hot-store:Isolated linker: fresh install, hot cache + hot store"
   "isolated-linker.fresh-restore.cold-cache.cold-store:Isolated linker: fresh restore, cold cache + cold store"
   "isolated-linker.fresh-install.cold-cache.cold-store:Isolated linker: fresh install, cold cache + cold store"
+  "isolated-linker.fresh-resolve.hot-cache.offline:Isolated linker: fresh resolve, hot cache, offline"
   "gvs-linker.fresh-restore.hot-cache.hot-store:GVS linker: fresh restore, hot cache + hot store"
 )
 

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -251,9 +251,17 @@ export async function pickPackage (
       metaCachedInStore = await limit(async () => loadMeta(pkgMirror))
 
       if (ctx.offline) {
-        if (metaCachedInStore != null) return {
-          meta: metaCachedInStore,
-          pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, metaCachedInStore),
+        if (metaCachedInStore != null) {
+          // Cache the parsed metadata in memory so repeat resolutions of the
+          // same package (common across a large dependency graph) don't re-read
+          // and re-parse the on-disk mirror. maybeUpgradeAbbreviatedMetaForReleaseAge
+          // short-circuits when offline, so the top-level cache hit path returns
+          // the same meta without any network access.
+          ctx.metaCache.set(cacheKey, metaCachedInStore)
+          return {
+            meta: metaCachedInStore,
+            pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, metaCachedInStore),
+          }
         }
 
         throw new PnpmError('NO_OFFLINE_META', `Failed to resolve ${toRaw(spec)} in package mirror ${pkgMirror}`)
@@ -273,6 +281,11 @@ export async function pickPackage (
         }
         const pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, metaCachedInStore)
         if (pickedPackage) {
+          // Cache the (possibly abbreviated) parsed metadata in memory so repeat
+          // resolutions of the same package don't re-read and re-parse the mirror.
+          // On a later cache hit the top-level path re-runs the same
+          // maybeUpgradeAbbreviatedMetaForReleaseAge check, so behavior is unchanged.
+          ctx.metaCache.set(cacheKey, metaCachedInStore)
           return {
             meta: metaCachedInStore,
             pickedPackage,

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -180,6 +180,31 @@ function pickMatchingVersionFinal (
   }
 }
 
+/**
+ * Packuments promoted into the in-memory cache straight from the on-disk
+ * mirror, without registry validation. The mirror may predate versions the
+ * registry has, so when a cache hit on such an entry can't satisfy the
+ * requested spec (and the resolver isn't offline), `pickPackage` falls
+ * through to the regular flow — a conditional registry request — instead of
+ * failing the pick, exactly as it would have before the entry was promoted.
+ * Network-fetched and 304-revalidated packuments are never in this set, so
+ * hits on them keep returning directly even when the pick fails (the caller
+ * then falls back to workspace packages or reports no matching version).
+ */
+const unverifiedDiskPackuments = new WeakSet<PackageMeta>()
+
+/**
+ * Promote a packument parsed from the on-disk mirror into the in-memory
+ * cache, so repeat resolutions of the same package (common across a large
+ * dependency graph) don't re-read and re-parse the mirror. The entry is
+ * remembered as disk-sourced (see {@link unverifiedDiskPackuments}) because it
+ * never went through registry validation.
+ */
+function cacheDiskLoadedMeta (metaCache: PackageMetaCache, cacheKey: string, meta: PackageMeta): void {
+  unverifiedDiskPackuments.add(meta)
+  metaCache.set(cacheKey, meta)
+}
+
 export async function pickPackage (
   ctx: {
     fetch: (pkgName: string, opts: { registry: string, authHeaderValue?: string, fullMetadata?: boolean, etag?: string, modified?: string }) => Promise<FetchMetadataResult | FetchMetadataNotModifiedResult>
@@ -239,10 +264,17 @@ export async function pickPackage (
         : persistUpgradedMeta(ctx, pkgMirror, upgrade.upgradedFrom)
       ctx.metaCache.set(cacheKey, metaForCache)
     }
-    return {
-      meta: metaForCache,
-      pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, metaForCache),
+    const pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, metaForCache)
+    if (pickedPackage != null || ctx.offline === true || !unverifiedDiskPackuments.has(metaForCache)) {
+      return {
+        meta: metaForCache,
+        pickedPackage,
+      }
     }
+    // The cached packument came from the disk mirror without registry
+    // validation and can't satisfy this spec — it may simply predate the
+    // wanted version. Fall through to the regular flow, which revalidates
+    // against the registry (see unverifiedDiskPackuments).
   }
 
   return runLimited(pkgMirror, async (limit) => {
@@ -252,12 +284,10 @@ export async function pickPackage (
 
       if (ctx.offline) {
         if (metaCachedInStore != null) {
-          // Cache the parsed metadata in memory so repeat resolutions of the
-          // same package (common across a large dependency graph) don't re-read
-          // and re-parse the on-disk mirror. maybeUpgradeAbbreviatedMetaForReleaseAge
-          // short-circuits when offline, so the top-level cache hit path returns
-          // the same meta without any network access.
-          ctx.metaCache.set(cacheKey, metaCachedInStore)
+          // maybeUpgradeAbbreviatedMetaForReleaseAge short-circuits when
+          // offline, so a later in-memory cache hit returns this same meta
+          // without any network access.
+          cacheDiskLoadedMeta(ctx.metaCache, cacheKey, metaCachedInStore)
           return {
             meta: metaCachedInStore,
             pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, metaCachedInStore),
@@ -281,11 +311,14 @@ export async function pickPackage (
         }
         const pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, metaCachedInStore)
         if (pickedPackage) {
-          // Cache the (possibly abbreviated) parsed metadata in memory so repeat
-          // resolutions of the same package don't re-read and re-parse the mirror.
           // On a later cache hit the top-level path re-runs the same
-          // maybeUpgradeAbbreviatedMetaForReleaseAge check, so behavior is unchanged.
-          ctx.metaCache.set(cacheKey, metaCachedInStore)
+          // maybeUpgradeAbbreviatedMetaForReleaseAge check, so behavior is
+          // unchanged. When the upgrade branch above already cached the
+          // registry-validated upgraded meta, don't overwrite it with a
+          // disk-sourced marking.
+          if (upgrade.upgradedFrom == null) {
+            cacheDiskLoadedMeta(ctx.metaCache, cacheKey, metaCachedInStore)
+          }
           return {
             meta: metaCachedInStore,
             pickedPackage,
@@ -302,7 +335,7 @@ export async function pickPackage (
         try {
           const pickedPackage = pickMatchingVersionFast(pickerOpts, spec, metaCachedInStore)
           if (pickedPackage) {
-            ctx.metaCache.set(cacheKey, metaCachedInStore)
+            cacheDiskLoadedMeta(ctx.metaCache, cacheKey, metaCachedInStore)
             return {
               meta: metaCachedInStore,
               pickedPackage,

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -25,6 +25,14 @@ import {
 import { toRaw } from './toRaw.js'
 
 export interface PackageMetaCache {
+  /**
+   * Must return the same object reference that `set` stored for the key: the
+   * resolver tracks whether a cached packument was validated against the
+   * registry by object identity (see `unverifiedDiskPackuments`). In a cache
+   * that clones or deserializes on read, that provenance is lost and recovery
+   * degrades — a stale disk-promoted entry that can't satisfy a spec fails
+   * the pick instead of falling through to the registry.
+   */
   get: (key: string) => PackageMeta | undefined
   set: (key: string, meta: PackageMeta) => void
   has: (key: string) => boolean

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -279,10 +279,8 @@ export async function pickPackage (
         pickedPackage,
       }
     }
-    // The cached packument came from the disk mirror without registry
-    // validation and can't satisfy this spec — it may simply predate the
-    // wanted version. Fall through to the regular flow, which revalidates
-    // against the registry (see unverifiedDiskPackuments).
+    // Disk-promoted meta that can't satisfy the spec: fall through and
+    // revalidate against the registry (see unverifiedDiskPackuments).
   }
 
   return runLimited(pkgMirror, async (limit) => {
@@ -319,9 +317,9 @@ export async function pickPackage (
         }
         const pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, metaCachedInStore)
         if (pickedPackage) {
-          // On a later cache hit the top-level path re-runs the same
-          // maybeUpgradeAbbreviatedMetaForReleaseAge check, so behavior is
-          // unchanged. When the upgrade branch above already cached the
+          // A cache hit re-runs maybeUpgradeAbbreviatedMetaForReleaseAge, so
+          // serving this meta from memory can't bypass the release-age
+          // upgrade. When the upgrade branch above already cached the
           // registry-validated upgraded meta, don't overwrite it with a
           // disk-sourced marking.
           if (upgrade.upgradedFrom == null) {

--- a/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
@@ -1,3 +1,5 @@
+import { rmSync } from 'node:fs'
+
 import { expect, test } from '@jest/globals'
 import { ABBREVIATED_META_DIR } from '@pnpm/constants'
 import type { PackageMeta } from '@pnpm/resolving.registry.types'
@@ -94,4 +96,60 @@ test('updateChecksums bypasses the in-memory cache so a disk-promoted entry cann
   // cache now holds a disk-sourced entry for this package.
   await pickPackage(ctx, spec, { registry: REGISTRY, dryRun: false, updateChecksums: true, preferredVersionSelectors: undefined })
   expect(fetchedNames).toEqual(['foo'])
+})
+
+test('offline resolution promotes the disk-loaded packument into the in-memory cache', async () => {
+  const meta = fooMeta()
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, REGISTRY, 'foo')
+  await saveMeta(pkgMirror, prepareJsonForDisk(meta, undefined))
+
+  const ctx = {
+    fetch: async () => {
+      throw new Error('offline resolution must not hit the network')
+    },
+    metaCache: createMetaCache(),
+    cacheDir,
+    offline: true,
+  }
+  // A range spec avoids the exact-version fast path, so resolution goes through
+  // the offline branch that loads the packument from disk.
+  const spec: RegistryPackageSpec = { type: 'range', name: 'foo', fetchSpec: '^1.0.0' }
+  const opts = { registry: REGISTRY, dryRun: false, preferredVersionSelectors: undefined }
+
+  const first = await pickPackage(ctx, spec, opts)
+  expect(first.pickedPackage?.version).toBe('1.0.0')
+  expect(ctx.metaCache.has(getPkgMetaCacheKey(REGISTRY, 'foo', false, false))).toBe(true)
+
+  // Delete the on-disk mirror: a second resolve must still succeed, proving it
+  // is served from the in-memory cache instead of re-reading and re-parsing disk.
+  rmSync(pkgMirror)
+  const second = await pickPackage(ctx, spec, opts)
+  expect(second.pickedPackage?.version).toBe('1.0.0')
+})
+
+test('prefer-offline resolution promotes the disk-loaded packument into the in-memory cache', async () => {
+  const meta = fooMeta()
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, REGISTRY, 'foo')
+  await saveMeta(pkgMirror, prepareJsonForDisk(meta, undefined))
+
+  const ctx = {
+    fetch: async () => {
+      throw new Error('prefer-offline resolution must not hit the network when the cache is warm')
+    },
+    metaCache: createMetaCache(),
+    cacheDir,
+    preferOffline: true,
+  }
+  const spec: RegistryPackageSpec = { type: 'range', name: 'foo', fetchSpec: '^1.0.0' }
+  const opts = { registry: REGISTRY, dryRun: false, preferredVersionSelectors: undefined }
+
+  const first = await pickPackage(ctx, spec, opts)
+  expect(first.pickedPackage?.version).toBe('1.0.0')
+  expect(ctx.metaCache.has(getPkgMetaCacheKey(REGISTRY, 'foo', false, false))).toBe(true)
+
+  rmSync(pkgMirror)
+  const second = await pickPackage(ctx, spec, opts)
+  expect(second.pickedPackage?.version).toBe('1.0.0')
 })

--- a/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
@@ -153,3 +153,44 @@ test('prefer-offline resolution promotes the disk-loaded packument into the in-m
   const second = await pickPackage(ctx, spec, opts)
   expect(second.pickedPackage?.version).toBe('1.0.0')
 })
+
+test('a disk-promoted cache entry that cannot satisfy the spec falls back to the registry under prefer-offline', async () => {
+  const staleMeta = fooMeta()
+  const freshMeta = fooMeta()
+  freshMeta.versions['2.0.0'] = {
+    ...staleMeta.versions['1.0.0'],
+    version: '2.0.0',
+    dist: {
+      ...staleMeta.versions['1.0.0'].dist,
+      tarball: 'https://registry.npmjs.org/foo/-/foo-2.0.0.tgz',
+    },
+  }
+  freshMeta['dist-tags'].latest = '2.0.0'
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, REGISTRY, 'foo')
+  await saveMeta(pkgMirror, prepareJsonForDisk(staleMeta, undefined))
+
+  const fetchedNames: string[] = []
+  const ctx = {
+    fetch: async (pkgName: string) => {
+      fetchedNames.push(pkgName)
+      return { meta: freshMeta, jsonText: JSON.stringify(freshMeta), etag: undefined }
+    },
+    metaCache: createMetaCache(),
+    cacheDir,
+    preferOffline: true,
+  }
+  const opts = { registry: REGISTRY, dryRun: false, preferredVersionSelectors: undefined }
+
+  // The first resolve is satisfied by the stale on-disk mirror and promotes it
+  // into the in-memory cache.
+  const first = await pickPackage(ctx, { type: 'range', name: 'foo', fetchSpec: '^1.0.0' }, opts)
+  expect(first.pickedPackage?.version).toBe('1.0.0')
+  expect(fetchedNames).toHaveLength(0)
+
+  // A range the promoted (registry-unverified) entry can't satisfy must fall
+  // back to the registry instead of failing the pick.
+  const second = await pickPackage(ctx, { type: 'range', name: 'foo', fetchSpec: '^2.0.0' }, opts)
+  expect(second.pickedPackage?.version).toBe('2.0.0')
+  expect(fetchedNames).toEqual(['foo'])
+})


### PR DESCRIPTION
## Summary

When resolving with `--offline` or `--prefer-offline`, `pickPackage` loaded a package's metadata from the on-disk cache mirror but never stored it in the in-memory `metaCache`, so every subsequent resolution of the same package — once per dependent that references it — re-read and re-parsed the full packument from disk. On a large monorepo at Microsoft this meant 23,746 metadata loads for 5,124 distinct packages (66.8 GB of JSON parsed), and `pnpm dedupe --offline` dropped from **~140 s to ~75 s (~1.9×)** with a byte-identical lockfile once fixed. The pathological case is high fan-in to shared packages combined with very large packuments (30–42 MB abbreviated documents for internal packages with thousands of versions).

This PR stores the parsed metadata in the in-memory cache on the offline and prefer-offline disk-return paths, so each package's metadata is parsed at most once per command. The cache is the existing bounded LRU (max 10,000 entries, 120 s TTL); the online and network paths are untouched.

Review of the change surfaced follow-up work that also landed here:

- **Stale-cache fall-through (TypeScript, 9279c8af42).** Promoted disk metadata made the top-of-function cache hit terminal: a promoted packument that predated a later-requested range turned a previously-recoverable network fallback into `ERR_PNPM_NO_MATCHING_VERSION`. Registry-unverified disk promotions are now tracked in a `WeakSet`, and a cache hit whose pick fails on such an entry falls through to the regular network-validating flow (unless offline). The pre-existing exact-version fast path had the same latent failure mode and is covered by the same marking. Each package revalidates at most once — a 304-revalidated or network-fetched packument is never marked.
- **Pacquet counterpart (e30f7cc370, 23b9ac8eb2, e1a308f8dd).** The same promotion and fall-through semantics for `pacquet`, with the verification state carried inside the cache value (`CachedPackument { meta, registry_verified }`) so a reader can never pair a packument with the verification state of a concurrent overwrite. `PackageMetaCache::set_unverified` is a required trait method so custom cache implementations can't silently inherit the terminal cache-hit behavior. Pacquet's version-spec and publishedBy-mtime fast paths — which already promoted disk metadata into the memory cache — gain the same recovery.
- **Verifier shared-cache reads registry-qualified (5580124763).** Pacquet's `read_shared_meta` queried bare `name`/`name:full` keys while the resolver stores registry-qualified ones, so the verifier's shared-cache fast path could never hit; it now mirrors the TypeScript `readSharedMeta` (`:full` → `:full:filtered` → abbreviated). Pre-existing, found by review of the touched reads.
- **Benchmark coverage (30d02b0420, 0303fc8b42).** No existing scenario exercised `--offline`/`--prefer-offline`. A new `isolated-linker.fresh-resolve.hot-cache.offline` scenario measures `install --offline --lockfile-only` against a warm mirror (with an untimed online pre-warm pass, since `--offline` can't prime a cold mirror), wired into the shared orchestrator, `pnpm11/benchmarks/bench.sh`, and the pacquet CI benchmark + Bencher uploads. Getting it to measure real work also revived the pnpm benchmark pipeline, silently dead since the `pnpm11/` move (`REPO_ROOT` mis-resolution, pre-move bundle path, `continue-on-error` masking), and taught the scenario to wipe `node_modules` so the up-to-date short-circuit can't skip the measured resolution. With that in place the scenario shows this PR directly: **`pnpm@HEAD` 2.41 s vs `pnpm@main` 3.17 s (1.31×)**, mirror reads 2,625 → 1,297. The pacquet arms tie by design — pacquet's deps-resolver memoizes per wanted dependency, so the redundant-parse amplification never occurs there.

Verified end-to-end: byte-identical `pnpm-lock.yaml` on the large monorepo, regression tests on both stacks that fail without their fixes, full dependent-package suites green (925 TS tests; 282 resolver + 677 verifier/package-manager Rust tests), and a live-registry benchmark run of the new scenario.

## Squash Commit Body

```text
When resolving with --offline or --prefer-offline, pickPackage loaded a
package's metadata from the on-disk cache mirror but never stored it in
the in-memory metaCache, so every subsequent resolution of the same
package (once per dependent that references it) re-read and re-parsed
the full packument from disk. Store the parsed metadata in the
in-memory cache on those disk-return paths, so each package's metadata
is parsed at most once per command. On a large monorepo this collapses
23,746 metadata loads to 5,124 (66.8 GB of JSON parsed to 8.8 GB) and
takes pnpm dedupe --offline from ~140s to ~75s with a byte-identical
lockfile. The cache is the existing bounded LRU; online and network
paths are untouched.

Promotion alone would have made the top-of-function cache hit terminal:
a disk-promoted packument that predates a later-requested range would
turn a previously-recoverable network fallback into
ERR_PNPM_NO_MATCHING_VERSION. Track registry-unverified disk promotions
(a WeakSet keyed by object identity in TypeScript; a registry_verified
flag carried inside the cache value in pacquet, so meta and state are
read atomically) and let a cache hit whose pick fails on such an entry
fall through to the regular network-validating flow unless offline. The
revalidating fetch stores a verified entry, so each package revalidates
at most once. The pre-existing exact-version fast paths on both stacks
had the same latent failure mode and are covered by the same marking.
Pacquet's PackageMetaCache::set_unverified is a required trait method
so custom cache implementations cannot silently inherit the terminal
behavior, and the TypeScript PackageMetaCache documents the
object-identity contract its WeakSet relies on.

Also registry-qualify pacquet's verifier shared-meta-cache reads
(read_shared_meta queried bare name keys while the resolver stores
registry-qualified ones, so the fast path could never hit), mirroring
the TypeScript readSharedMeta lookup order.

Add an isolated-linker.fresh-resolve.hot-cache.offline benchmark
scenario (install --offline --lockfile-only against a warm mirror, with
an untimed online pre-warm pass and per-iteration node_modules +
lockfile wipes so the up-to-date short-circuit cannot skip the measured
resolution) to guard offline resolution on all Bencher testbeds. Fixing
it to measure real work also revived the pnpm benchmark pipeline,
silently dead since the pnpm11/ move: bench.sh resolved REPO_ROOT to
pnpm11/ where no Cargo.toml exists, the orchestrator probed the
pre-move pnpm/dist bundle path, and continue-on-error masked every
failure as a green run. The scenario measures this change directly:
pnpm@HEAD resolves the fixture offline in 2.41s vs 3.17s for pnpm@main
(1.31x), with metadata-mirror reads dropping from 2625 to 1297.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Description restructured per the PR template by an agent (Claude Code, claude-fable-5); the Summary incorporates the original author's measurements and analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved package resolution speed for offline and `--prefer-offline` workflows in large workspaces by reusing cached package metadata within a single command, reducing repeated parsing.

* **Bug Fixes**
  * Offline and `--prefer-offline` resolutions now properly promote disk-loaded package metadata into the in-memory cache, keeping it available for subsequent lookups.

* **Tests**
  * Added coverage to ensure metadata cache promotion works for both offline and prefer-offline resolution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
