### PR TITLE
fix(pnpm): resolve relative patchedDependencies against lockfileDir

### DIFF
--- a/.changeset/patched-deps-lockfile-dir.md
+++ b/.changeset/patched-deps-lockfile-dir.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/lockfile.settings-checker": minor
+"@pnpm/deps.status": patch
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+Relative paths in `patchedDependencies` are now resolved against the lockfile directory when computing patch file hashes, so running `pnpm install` from a subdirectory no longer fails with `ENOENT` looking for the patch file in the wrong location [#12762](https://github.com/pnpm/pnpm/pull/12762).

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1665,8 +1665,6 @@ impl Config {
     /// `patchedDependencies` map the lockfile records: each configured
     /// key mapped to its patch file's SHA-256 hex digest.
     ///
-    /// The configured patch paths are resolved against the manifest
-    /// dir before hashing.
     /// Distinct from [`Self::resolved_patched_dependencies`], which
     /// groups the same entries by package name for the resolver — this
     /// keeps the user's verbatim keys so the lockfile is byte-faithful

--- a/pacquet/crates/patching/src/resolve.rs
+++ b/pacquet/crates/patching/src/resolve.rs
@@ -46,7 +46,11 @@ impl From<PatchNonSemverRangeError> for ResolvePatchedDependenciesError {
 /// Each raw path is resolved against `workspace_dir`, hashed into a
 /// [`PatchInput`] entry, and then grouped. pnpm v11 reads install
 /// settings (including `patchedDependencies`) from the *workspace*
-/// manifest, not from `package.json`'s `pnpm` field.
+/// manifest, not from `package.json`'s `pnpm` field, and anchors
+/// still-relative patch paths on `lockfileDir` when hashing and
+/// applying patches. Pacquet's lockfile always lives at the workspace
+/// root, so `workspace_dir` is that same base; if pacquet ever gains a
+/// separate `lockfileDir`, this base must follow it to stay in parity.
 ///
 /// [`BTreeMap`]: std::collections::BTreeMap
 /// [`PatchGroup::range`]: crate::PatchGroup::range

--- a/pnpm11/deps/status/src/checkDepsStatus.ts
+++ b/pnpm11/deps/status/src/checkDepsStatus.ts
@@ -660,11 +660,22 @@ async function assertWantedLockfileUpToDate (
     wantedLockfileDir,
   } = opts
 
+  // Resolve patchedDependencies against the lockfile directory so
+  // relative patch-file paths work regardless of the workspace dir
+  // that was used when the config was loaded.
+  const resolvedPatchedDeps = config.patchedDependencies
+    ? Object.fromEntries(
+      Object.entries(config.patchedDependencies).map(([key, value]) => [
+        key,
+        path.resolve(wantedLockfileDir, value),
+      ])
+    )
+    : undefined
   const [
     patchedDependencies,
     pnpmfileChecksum,
   ] = await Promise.all([
-    calcPatchHashes(config.patchedDependencies ?? {}),
+    calcPatchHashes(resolvedPatchedDeps ?? {}),
     config.hooks?.calculatePnpmfileChecksum?.(),
   ])
 

--- a/pnpm11/deps/status/src/checkDepsStatus.ts
+++ b/pnpm11/deps/status/src/checkDepsStatus.ts
@@ -23,6 +23,7 @@ import {
   calcPatchHashes,
   createOverridesMapFromParsed,
   getOutdatedLockfileSetting,
+  resolvePatchedDependencies,
 } from '@pnpm/lockfile.settings-checker'
 import {
   getWorkspacePackagesByDirectory,
@@ -660,17 +661,7 @@ async function assertWantedLockfileUpToDate (
     wantedLockfileDir,
   } = opts
 
-  // Resolve patchedDependencies against the lockfile directory so
-  // relative patch-file paths work regardless of the workspace dir
-  // that was used when the config was loaded.
-  const resolvedPatchedDeps = config.patchedDependencies
-    ? Object.fromEntries(
-      Object.entries(config.patchedDependencies).map(([key, value]) => [
-        key,
-        path.resolve(wantedLockfileDir, value),
-      ])
-    )
-    : undefined
+  const resolvedPatchedDeps = resolvePatchedDependencies(config.patchedDependencies, wantedLockfileDir)
   const [
     patchedDependencies,
     pnpmfileChecksum,

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -62,6 +62,7 @@ import {
   calcPatchHashes,
   createOverridesMapFromParsed,
   getOutdatedLockfileSetting,
+  resolvePatchedDependencies,
 } from '@pnpm/lockfile.settings-checker'
 import { PACKAGE_MAP_FILENAME, writePackageMap, writePnpFile } from '@pnpm/lockfile.to-pnp'
 import { allProjectsAreUpToDate, satisfiesPackageManifest } from '@pnpm/lockfile.verification'
@@ -638,19 +639,7 @@ export async function mutateModules (
     }
     const packageExtensionsChecksum = hashObjectNullableWithPrefix(opts.packageExtensions)
     const pnpmfileChecksum = await opts.hooks.calculatePnpmfileChecksum?.()
-    // Resolve patchedDependencies against lockfileDir upfront so both
-    // calcPatchHashes and the patchGroupInput construction use the same
-    // absolute paths. path.resolve with an already-absolute path is a
-    // no-op, so this is safe regardless of whether the upstream config
-    // layer already resolved to absolute paths.
-    const resolvedPatchedDeps = opts.patchedDependencies
-      ? Object.fromEntries(
-        Object.entries(opts.patchedDependencies).map(([key, value]) => [
-          key,
-          path.resolve(opts.lockfileDir, value),
-        ])
-      )
-      : undefined
+    const resolvedPatchedDeps = resolvePatchedDependencies(opts.patchedDependencies, opts.lockfileDir)
     const patchedDependencies = opts.ignorePackageManifest
       ? ctx.wantedLockfile.patchedDependencies
       : (resolvedPatchedDeps ? await calcPatchHashes(resolvedPatchedDeps) : {})

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -638,20 +638,33 @@ export async function mutateModules (
     }
     const packageExtensionsChecksum = hashObjectNullableWithPrefix(opts.packageExtensions)
     const pnpmfileChecksum = await opts.hooks.calculatePnpmfileChecksum?.()
+    // Resolve patchedDependencies against lockfileDir upfront so both
+    // calcPatchHashes and the patchGroupInput construction use the same
+    // absolute paths. path.resolve with an already-absolute path is a
+    // no-op, so this is safe regardless of whether the upstream config
+    // layer already resolved to absolute paths.
+    const resolvedPatchedDeps = opts.patchedDependencies
+      ? Object.fromEntries(
+        Object.entries(opts.patchedDependencies).map(([key, value]) => [
+          key,
+          path.resolve(opts.lockfileDir, value),
+        ])
+      )
+      : undefined
     const patchedDependencies = opts.ignorePackageManifest
       ? ctx.wantedLockfile.patchedDependencies
-      : (opts.patchedDependencies ? await calcPatchHashes(opts.patchedDependencies) : {})
-    const patchGroupInput = opts.patchedDependencies
+      : (resolvedPatchedDeps ? await calcPatchHashes(resolvedPatchedDeps) : {})
+    const patchGroupInput = resolvedPatchedDeps
       ? Object.fromEntries(
         Object.entries(patchedDependencies ?? {}).map(([key, hash]) => {
-          let patchFilePath = opts.patchedDependencies![key]
-            ? path.resolve(opts.lockfileDir, opts.patchedDependencies![key])
+          let patchFilePath = resolvedPatchedDeps![key]
+            ? path.resolve(opts.lockfileDir, resolvedPatchedDeps![key])
             : undefined
           if (!patchFilePath) {
             const lastAt = key.lastIndexOf('@')
             const pkgName = lastAt > 0 ? key.slice(0, lastAt) : key
-            if (opts.patchedDependencies![pkgName]) {
-              patchFilePath = path.resolve(opts.lockfileDir, opts.patchedDependencies![pkgName])
+            if (resolvedPatchedDeps![pkgName]) {
+              patchFilePath = path.resolve(opts.lockfileDir, resolvedPatchedDeps![pkgName])
             }
           }
           return [key, { hash, patchFilePath }]

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -646,15 +646,11 @@ export async function mutateModules (
     const patchGroupInput = resolvedPatchedDeps
       ? Object.fromEntries(
         Object.entries(patchedDependencies ?? {}).map(([key, hash]) => {
-          let patchFilePath = resolvedPatchedDeps![key]
-            ? path.resolve(opts.lockfileDir, resolvedPatchedDeps![key])
-            : undefined
+          let patchFilePath: string | undefined = resolvedPatchedDeps[key]
           if (!patchFilePath) {
             const lastAt = key.lastIndexOf('@')
             const pkgName = lastAt > 0 ? key.slice(0, lastAt) : key
-            if (resolvedPatchedDeps![pkgName]) {
-              patchFilePath = path.resolve(opts.lockfileDir, resolvedPatchedDeps![pkgName])
-            }
+            patchFilePath = resolvedPatchedDeps[pkgName]
           }
           return [key, { hash, patchFilePath }]
         })

--- a/pnpm11/installing/deps-installer/test/install/patch.ts
+++ b/pnpm11/installing/deps-installer/test/install/patch.ts
@@ -570,3 +570,41 @@ test('patch package should fail when the name-only range patch fails to apply', 
 
   expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).not.toContain('// patched')
 })
+
+test('patch with relative paths resolved against lockfileDir', async () => {
+  const project = prepareEmpty()
+  // Simulate the scenario where patches live under the lockfile directory
+  // but patchedDependencies only records relative paths. The install path
+  // must resolve them against lockfileDir so calcPatchHashes can read them.
+  const patchesDir = path.join(process.cwd(), 'patches')
+  fs.mkdirSync(patchesDir, { recursive: true })
+  fs.copyFileSync(
+    path.join(f.find('patch-pkg'), 'is-positive@1.0.0.patch'),
+    path.join(patchesDir, 'is-positive@1.0.0.patch')
+  )
+
+  const patchedDependencies = {
+    'is-positive@1.0.0': 'patches/is-positive@1.0.0.patch',
+  }
+  const opts = testDefaults({
+    fastUnpack: false,
+    sideEffectsCacheRead: true,
+    sideEffectsCacheWrite: true,
+    patchedDependencies,
+    // Explicit lockfileDir so the resolution is deterministic
+    lockfileDir: process.cwd(),
+  }, {}, {}, { packageImportMethod: 'hardlink' })
+  await install({
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  }, opts)
+
+  expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// patched')
+
+  const patchFileHash = await createHexHashFromFile(path.join(patchesDir, 'is-positive@1.0.0.patch'))
+  const lockfile = project.readLockfile()
+  expect(lockfile.patchedDependencies).toStrictEqual({
+    'is-positive@1.0.0': patchFileHash,
+  })
+})

--- a/pnpm11/installing/deps-installer/test/install/patch.ts
+++ b/pnpm11/installing/deps-installer/test/install/patch.ts
@@ -2,15 +2,17 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { afterAll, expect, jest, test } from '@jest/globals'
-import { ENGINE_NAME } from '@pnpm/constants'
+import { ENGINE_NAME, WANTED_LOCKFILE } from '@pnpm/constants'
 import { createHexHashFromFile } from '@pnpm/crypto.hash'
 import { install } from '@pnpm/installing.deps-installer'
+import type { LockfileFile } from '@pnpm/lockfile.types'
 import { prepareEmpty } from '@pnpm/prepare'
 import type { PackageFilesIndex } from '@pnpm/store.cafs'
 import { StoreIndex, storeIndexKey } from '@pnpm/store.index'
 import { fixtures } from '@pnpm/test-fixtures'
 import { getIntegrity } from '@pnpm/testing.registry-mock'
 import { rimrafSync } from '@zkochan/rimraf'
+import { readYamlFileSync } from 'read-yaml-file'
 
 import { testDefaults } from '../utils/index.js'
 
@@ -572,11 +574,12 @@ test('patch package should fail when the name-only range patch fails to apply', 
 })
 
 test('patch with relative paths resolved against lockfileDir', async () => {
-  const project = prepareEmpty()
-  // Simulate the scenario where patches live under the lockfile directory
-  // but patchedDependencies only records relative paths. The install path
-  // must resolve them against lockfileDir so calcPatchHashes can read them.
-  const patchesDir = path.join(process.cwd(), 'patches')
+  prepareEmpty()
+  // The lockfile and the patches dir live in the parent of the project dir
+  // (and of the cwd), so the still-relative patchedDependencies paths can
+  // only be read when resolved against lockfileDir.
+  const lockfileDir = path.resolve('..')
+  const patchesDir = path.join(lockfileDir, 'patches')
   fs.mkdirSync(patchesDir, { recursive: true })
   fs.copyFileSync(
     path.join(f.find('patch-pkg'), 'is-positive@1.0.0.patch'),
@@ -588,11 +591,8 @@ test('patch with relative paths resolved against lockfileDir', async () => {
   }
   const opts = testDefaults({
     fastUnpack: false,
-    sideEffectsCacheRead: true,
-    sideEffectsCacheWrite: true,
     patchedDependencies,
-    // Explicit lockfileDir so the resolution is deterministic
-    lockfileDir: process.cwd(),
+    lockfileDir,
   }, {}, {}, { packageImportMethod: 'hardlink' })
   await install({
     dependencies: {
@@ -603,7 +603,7 @@ test('patch with relative paths resolved against lockfileDir', async () => {
   expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// patched')
 
   const patchFileHash = await createHexHashFromFile(path.join(patchesDir, 'is-positive@1.0.0.patch'))
-  const lockfile = project.readLockfile()
+  const lockfile = readYamlFileSync<LockfileFile>(path.join(lockfileDir, WANTED_LOCKFILE))
   expect(lockfile.patchedDependencies).toStrictEqual({
     'is-positive@1.0.0': patchFileHash,
   })

--- a/pnpm11/lockfile/settings-checker/src/index.ts
+++ b/pnpm11/lockfile/settings-checker/src/index.ts
@@ -1,3 +1,4 @@
 export { calcPatchHashes } from './calcPatchHashes.js'
 export { createOverridesMapFromParsed } from './createOverridesMapFromParsed.js'
 export { type ChangedField, getOutdatedLockfileSetting } from './getOutdatedLockfileSetting.js'
+export { resolvePatchedDependencies } from './resolvePatchedDependencies.js'

--- a/pnpm11/lockfile/settings-checker/src/resolvePatchedDependencies.ts
+++ b/pnpm11/lockfile/settings-checker/src/resolvePatchedDependencies.ts
@@ -1,0 +1,14 @@
+import path from 'node:path'
+
+export function resolvePatchedDependencies (
+  patchedDependencies: Record<string, string> | undefined,
+  baseDir: string
+): Record<string, string> | undefined {
+  if (!patchedDependencies) return undefined
+  return Object.fromEntries(
+    Object.entries(patchedDependencies).map(([key, value]) => [
+      key,
+      path.resolve(baseDir, value),
+    ])
+  )
+}

--- a/pnpm11/lockfile/settings-checker/src/resolvePatchedDependencies.ts
+++ b/pnpm11/lockfile/settings-checker/src/resolvePatchedDependencies.ts
@@ -1,14 +1,11 @@
 import path from 'node:path'
 
+import { map as mapValues } from 'ramda'
+
 export function resolvePatchedDependencies (
   patchedDependencies: Record<string, string> | undefined,
   baseDir: string
 ): Record<string, string> | undefined {
   if (!patchedDependencies) return undefined
-  return Object.fromEntries(
-    Object.entries(patchedDependencies).map(([key, value]) => [
-      key,
-      path.resolve(baseDir, value),
-    ])
-  )
+  return mapValues((patchFile) => path.resolve(baseDir, patchFile), patchedDependencies)
 }


### PR DESCRIPTION
## Summary

```ps1
PS C:\Users\24306\AppData\Roaming\Code\User\dev\web_learning\apps\galacean\galacean-utils>
pnpm patch-commit "C:\Users\24306\AppData\Roaming\Code\User\node_modules\.pnpm_patches\@galacean\engine@2.0.0-alpha.37"
```

```console
✓ Lockfile passes supply-chain policies (943 entries in 43s)
[ENOENT] ENOENT: no such file or directory, open 'C:\Users\24306\AppData\Roaming\Code\User\dev\web_learning\apps\galacean\galacean-utils\patches\@galacean__engine@2.0.0-alpha.37.patch'

pnpm: ENOENT: no such file or directory, open 'C:\Users\24306\AppData\Roaming\Code\User\dev\web_learning\apps\galacean\galacean-utils\patches\@galacean__engine@2.0.0-alpha.37.patch'
    at async open (node:internal/fs/promises:639:25)
    at async Object.readFile (node:internal/fs/promises:1252:14)
    at async readNormalizedFile (file:///C:/Users/24306/AppData/Roaming/npm/node_modules/pnpm/dist/pnpm.mjs:61229:19)
    at async createHexHashFromFile (file:///C:/Users/24306/AppData/Roaming/npm/node_modules/pnpm/dist/pnpm.mjs:61226:24)
    at async file:///C:/Users/24306/AppData/Roaming/npm/node_modules/pnpm/dist/pnpm.mjs:187371:20
    at async Promise.all (index 0)
    at async pMapValues (file:///C:/Users/24306/AppData/Roaming/npm/node_modules/pnpm/dist/pnpm.mjs:187370:3)
    at async _install (file:///C:/Users/24306/AppData/Roaming/npm/node_modules/pnpm/dist/pnpm.mjs:190038:132)
```

Actually, the patch has already been applied, and the path is `C:/Users/24306/AppData/Roaming/Code/User/patches/@galacean__engine@2.0.0-alpha.37.patch` .

## Squash Commit Body

Ensure patchedDependencies paths are resolved relative to the lockfile directory before computing patch hashes. This fixes cases where relative patch paths were incorrectly resolved against the workspace root instead of the lockfile location.

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  (No pacquet code change needed: pacquet already resolves patch paths against the workspace root, which is always its lockfile dir; its doc comments were updated to record that parity invariant.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Patched dependency patch paths now resolve relative to the lockfile directory, avoiding install failures from incorrect patch lookups.
  * Patch hash calculation and lockfile `patchedDependencies` entries now use the same resolved patch paths for consistent results.
* **Tests**
  * Added a Jest test covering relative patch path resolution against `lockfileDir`, including verification of patch application and the recorded lockfile hash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
