### PR TITLE
fix: make why --exclude-peers skip peer dependency edges

### DIFF
--- a/.changeset/why-exclude-peer-dependents.md
+++ b/.changeset/why-exclude-peer-dependents.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/deps.inspection.tree-builder": patch
+"@pnpm/deps.inspection.list": patch
+"@pnpm/deps.inspection.commands": patch
+"pnpm": patch
+---
+
+Fixed `pnpm why --exclude-peers` to exclude peer dependency edges from the reverse dependency tree.

--- a/pnpm11/deps/inspection/commands/src/listing/why.ts
+++ b/pnpm11/deps/inspection/commands/src/listing/why.ts
@@ -80,6 +80,7 @@ export async function handler (
     reportAs,
     modulesDir: opts.modulesDir,
     checkWantedLockfileOnly: opts.lockfileOnly,
+    excludePeerDependencies: opts.excludePeers,
     finders,
   })
 }

--- a/pnpm11/deps/inspection/list/src/index.ts
+++ b/pnpm11/deps/inspection/list/src/index.ts
@@ -240,6 +240,7 @@ export async function whyForPackages (
     reportAs?: 'parseable' | 'tree' | 'json'
     modulesDir?: string
     finders?: Finder[]
+    excludePeerDependencies?: boolean
   }
 ): Promise<string> {
   const reportAs = opts.reportAs ?? 'tree'
@@ -273,6 +274,7 @@ export async function whyForPackages (
     modulesDir: opts.modulesDir,
     registries: opts.registries,
     finders: opts.finders,
+    excludePeerDependencies: opts.excludePeerDependencies,
     importerInfoMap,
     lockfile,
   })

--- a/pnpm11/deps/inspection/tree-builder/src/buildDependentsTree.ts
+++ b/pnpm11/deps/inspection/tree-builder/src/buildDependentsTree.ts
@@ -25,6 +25,7 @@ interface ReverseEdge {
   parentSerialized: string
   parentNodeId: TreeNodeId
   alias: string
+  isPeer: boolean
 }
 
 export interface DependentNode {
@@ -66,6 +67,7 @@ interface WalkContext {
   importerInfoMap: Map<string, ImporterInfo>
   resolvedPackageNodes: Map<string, { path: string, readManifest: () => DependencyManifest }>
   nameFormatter?: (info: { name: string, version: string, manifest: DependencyManifest }) => string | undefined
+  excludePeerDependencies?: boolean
   /** Tracks nodes on the current path for cycle detection. Mutated during walk. */
   visited: Set<string>
   /** Tracks nodes already fully expanded, for deduplication across branches. */
@@ -84,6 +86,7 @@ export async function buildDependentsTree (
     importerInfoMap: Map<string, ImporterInfo>
     lockfile: LockfileObject
     nameFormatter?: (info: { name: string, version: string, manifest: DependencyManifest }) => string | undefined
+    excludePeerDependencies?: boolean
   }
 ): Promise<DependentsTree[]> {
   const modulesDir = await realpathMissing(path.join(opts.lockfileDir, opts.modulesDir ?? 'node_modules'))
@@ -150,6 +153,7 @@ export async function buildDependentsTree (
     importerInfoMap: opts.importerInfoMap,
     resolvedPackageNodes,
     nameFormatter: opts.nameFormatter,
+    excludePeerDependencies: opts.excludePeerDependencies,
     visited: new Set(),
     expanded: new Set(),
   }
@@ -185,6 +189,7 @@ export async function buildDependentsTree (
     ctx.visited = new Set([serialized])
     ctx.expanded = new Set()
     const dependents = walkReverse(serialized, ctx)
+    if (opts.excludePeerDependencies && dependents.length === 0) continue
     const peersSuffixHash = peersSuffixHashFromDepPath(depPath)
 
     const displayName = opts.nameFormatter
@@ -232,6 +237,7 @@ function invertGraph (graph: DependencyGraph): Map<string, ReverseEdge[]> {
         parentSerialized,
         parentNodeId: node.nodeId,
         alias: edge.alias,
+        isPeer: node.peers.has(edge.alias),
       })
     }
   }
@@ -311,6 +317,8 @@ function walkReverse (
   const dependents: DependentNode[] = []
 
   for (const edge of sortedEdges) {
+    if (ctx.excludePeerDependencies && edge.isPeer) continue
+
     // Cycle detection: this node is already on our current path
     if (ctx.visited.has(edge.parentSerialized)) {
       const parentNode = ctx.graph.nodes.get(edge.parentSerialized)

--- a/pnpm11/deps/inspection/tree-builder/test/buildDependentsTree.test.ts
+++ b/pnpm11/deps/inspection/tree-builder/test/buildDependentsTree.test.ts
@@ -23,7 +23,13 @@ function refToRelativeOrThrow (reference: string, pkgName: string): DepPath {
  *
  * Returns the lockfileDir path and a cleanup function.
  */
-function createMockProject (packages: Record<string, { version: string, manifest: Record<string, unknown>, deps?: string[] }>): {
+function createMockProject (packages: Record<string, {
+  version: string
+  manifest: Record<string, unknown>
+  deps?: string[]
+  peerDeps?: string[]
+  topLevel?: boolean
+}>): {
   lockfileDir: string
   currentPackages: PackageSnapshots
   importers: Record<ProjectId, ProjectSnapshot>
@@ -55,6 +61,7 @@ function createMockProject (packages: Record<string, { version: string, manifest
     currentPackages[depPath] = {
       resolution: { integrity: `${pkgName}-mock-integrity` },
       dependencies: deps,
+      peerDependencies: Object.fromEntries((info.peerDeps ?? []).map(dep => [dep, '*'])),
     }
   }
 
@@ -74,6 +81,7 @@ function createMockProject (packages: Record<string, { version: string, manifest
   // Single root importer that depends on all top-level packages
   const rootDeps: Record<string, string> = {}
   for (const [pkgName, info] of Object.entries(packages)) {
+    if (info.topLevel === false) continue
     rootDeps[pkgName] = info.version
   }
 
@@ -95,6 +103,85 @@ function createMockProject (packages: Record<string, { version: string, manifest
 }
 
 describe('buildDependentsTree', () => {
+  test('excludes peer dependency edges from reverse trees', async () => {
+    const { lockfileDir, currentPackages, importers, cleanup } = createMockProject({
+      peer: {
+        version: '1.0.0',
+        manifest: {},
+        topLevel: false,
+      },
+      parent: {
+        version: '1.0.0(peer@1.0.0)',
+        manifest: {},
+        deps: ['peer'],
+        peerDeps: ['peer'],
+      },
+    })
+
+    try {
+      const importerInfoMap = new Map([
+        ['.', { name: 'my-project', version: '0.0.0' }],
+      ])
+
+      const trees = await buildDependentsTree(['peer'], [lockfileDir], {
+        lockfileDir,
+        excludePeerDependencies: true,
+        importerInfoMap,
+        lockfile: {
+          lockfileVersion: '9.0',
+          importers,
+          packages: currentPackages,
+        },
+      })
+
+      expect(trees).toHaveLength(0)
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('keeps non-peer dependency edges when excluding peers from reverse trees', async () => {
+    const { lockfileDir, currentPackages, importers, cleanup } = createMockProject({
+      peer: {
+        version: '1.0.0',
+        manifest: {},
+      },
+      parent: {
+        version: '1.0.0(peer@1.0.0)',
+        manifest: {},
+        deps: ['peer'],
+        peerDeps: ['peer'],
+      },
+    })
+
+    try {
+      const importerInfoMap = new Map([
+        ['.', { name: 'my-project', version: '0.0.0' }],
+      ])
+
+      const trees = await buildDependentsTree(['peer'], [lockfileDir], {
+        lockfileDir,
+        excludePeerDependencies: true,
+        importerInfoMap,
+        lockfile: {
+          lockfileVersion: '9.0',
+          importers,
+          packages: currentPackages,
+        },
+      })
+
+      expect(trees).toHaveLength(1)
+      expect(trees[0].dependents).toEqual([
+        expect.objectContaining({
+          name: 'my-project',
+          depField: 'dependencies',
+        }),
+      ])
+    } finally {
+      cleanup()
+    }
+  })
+
   describe('nameFormatter', () => {
     test('populates displayName on matched root and intermediate nodes', async () => {
       const { lockfileDir, currentPackages, importers, cleanup } = createMockProject({


### PR DESCRIPTION
## Summary

Fix `pnpm why --exclude-peers` so reverse dependency trees exclude peer dependency
edges.

`pnpm why` now builds a reverse dependency tree. The reverse graph was not
carrying whether an edge came from a peer dependency, and the CLI handler was not
passing `excludePeerDependencies` through to the dependents tree builder. As a
result, `pnpm why --prod --exclude-peers` could still show a package that was
only present as a resolved peer.

## Changes

- Pass `excludePeerDependencies` from the `why` command to `whyForPackages` and
  `buildDependentsTree`.
- Preserve peer-edge information when building the reverse graph.
- Skip peer edges while walking reverse dependents when peers are excluded.
- Add regression coverage for peer-only and mixed direct+peer dependency paths.

## Repro

Public repro repository: https://github.com/DrBearZay/pnpm-why-exclude-peers-repro

Minimal repository contents:

```text
.
├── package.json
├── pnpm-lock.yaml
└── pnpm-workspace.yaml
```

```json
{
  "name": "pnpm-why-exclude-peers-repro",
  "version": "1.0.0",
  "private": true,
  "packageManager": "pnpm@11.9.0",
  "dependencies": {
    "@electron-toolkit/utils": "4.0.0"
  },
  "devDependencies": {
    "electron": "39.7.0"
  }
}
```

`@electron-toolkit/utils@4.0.0` declares `electron` as a peer dependency. The
root project provides `electron@39.7.0` only from `devDependencies`.

The lockfile records that peer-resolved package instance like this:

```yaml
'@electron-toolkit/utils@4.0.0':
  peerDependencies:
    electron: '>=13.0.0'

'@electron-toolkit/utils@4.0.0(electron@39.7.0)':
  dependencies:
    electron: 39.7.0
```

Since `electron` is only reached as a resolved peer from a production dependency,
`--exclude-peers` should remove it from the result.

## Actual output

```sh
$ corepack pnpm@10.9.0 why electron --prod --exclude-peers

$ corepack pnpm@10.9.0 list electron --prod --depth Infinity --exclude-peers

$ corepack pnpm@11.9.0 why electron --prod --exclude-peers
electron@39.7.0
└─┬ @electron-toolkit/utils@4.0.0
  └── pnpm-why-exclude-peers-repro@1.0.0 (dependencies)

Found 1 version of electron

$ corepack pnpm@11.9.0 list electron --prod --depth Infinity --exclude-peers
```

`pnpm@11.9.0 list --exclude-peers` agrees with `pnpm@10.9.0` and prints
nothing. Only `pnpm@11.9.0 why --exclude-peers` reports `electron`, so the
regression appears to be in the reverse-tree `why` path.

## Verification

```sh
corepack pnpm@11.9.0 --filter @pnpm/deps.inspection.tree-builder compile
corepack pnpm@11.9.0 --filter @pnpm/deps.inspection.list compile
corepack pnpm@11.9.0 --filter @pnpm/deps.inspection.commands compile
corepack pnpm@11.9.0 --filter @pnpm/deps.inspection.tree-builder test -- buildDependentsTree.test.ts
node /private/tmp/verify-pnpm-why-peer.mjs
```
