### PR TITLE
perf(npm-resolver): normalize non-abbreviated registry metadata before caching

### DIFF
--- a/.changeset/normalize-abbreviated-metadata-on-ingest.md
+++ b/.changeset/normalize-abbreviated-metadata-on-ingest.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"pnpm": patch
+---
+
+Sped up resolution and reduced memory use against registries that do not implement npm's abbreviated metadata format (for example, Azure DevOps Artifacts). Such registries ignore the `application/vnd.npm.install-v1+json` request and return the full package document — including per-version fields the installer never reads (`scripts`, `exports`, `devDependencies`, custom `package.json` fields, etc.). pnpm now normalizes this down to the abbreviated field set before writing it to the on-disk metadata cache, so subsequent resolutions read and parse a much smaller document. On a large workspace whose feed serves full documents, this roughly halved `pnpm dedupe --offline` time and cut peak memory, with no change to resolution output.

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -381,6 +381,7 @@ export async function pickPackage (
 
       let meta = fetchResult.meta
       let resultToSave: FetchMetadataResult = fetchResult
+      let upgradedToFull = false
 
       // When minimumReleaseAge is active and we fetched abbreviated metadata,
       // check if the package was recently modified and needs full metadata
@@ -424,16 +425,27 @@ export async function pickPackage (
           if (!fullFetchResult.notModified) {
             resultToSave = fullFetchResult
             meta = fullFetchResult.meta
+            upgradedToFull = true
           }
         }
       }
 
-      if (ctx.filterMetadata) {
+      // Normalize the abbreviated slot down to the abbreviated field set.
+      // filterMetadata already does this for the full-metadata slot. Some
+      // registries (e.g. Azure DevOps Artifacts) ignore the abbreviated Accept
+      // header and return the full document; clearMeta drops the fields the
+      // resolver never reads (scripts, exports, readme, custom fields), so the
+      // abbreviated mirror stays small and parses fast on later resolutions.
+      // clearMeta keeps every abbreviated field (and top-level time), so
+      // resolution output is unchanged. Scoped to plain abbreviated results:
+      // full-metadata and minimumReleaseAge-upgraded documents are left as-is.
+      const normalizeAbbreviated = !fullMetadata && !upgradedToFull
+      if (ctx.filterMetadata || normalizeAbbreviated) {
         meta = clearMeta(meta)
       }
       if (!opts.dryRun) {
         // Serialize before setting meta.etag so it only lives in the headers line, not the body.
-        const jsonForDisk = ctx.filterMetadata
+        const jsonForDisk = (ctx.filterMetadata || normalizeAbbreviated)
           ? prepareJsonForDisk(meta, resultToSave.etag)
           : prepareJsonForDisk(resultToSave.meta, resultToSave.etag, resultToSave.jsonText)
         runLimited(pkgMirror, (limit) => limit(async () => {
@@ -554,7 +566,7 @@ function persistUpgradedMeta (
 
 function clearMeta (pkg: PackageMeta): PackageMeta {
   const versions: PackageMeta['versions'] = {}
-  for (const [version, info] of Object.entries(pkg.versions)) {
+  for (const [version, info] of Object.entries(pkg.versions ?? {})) {
     // The list taken from https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#abbreviated-version-object
     // with the addition of 'libc'
     versions[version] = pick([

--- a/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
@@ -95,3 +95,53 @@ test('updateChecksums bypasses the in-memory cache so a disk-promoted entry cann
   await pickPackage(ctx, spec, { registry: REGISTRY, dryRun: false, updateChecksums: true, preferredVersionSelectors: undefined })
   expect(fetchedNames).toEqual(['foo'])
 })
+
+test('abbreviated metadata is normalized to the abbreviated field set before caching', async () => {
+  // Simulate a registry (e.g. Azure DevOps Artifacts) that ignores the
+  // abbreviated Accept header and returns the full package.json per version,
+  // including fields the resolver never reads.
+  const meta = {
+    _id: 'foo',
+    _rev: '1-abc',
+    readme: 'x'.repeat(1000),
+    name: 'foo',
+    'dist-tags': { latest: '1.0.0' },
+    versions: {
+      '1.0.0': {
+        name: 'foo',
+        version: '1.0.0',
+        dependencies: { bar: '^1.0.0' },
+        devDependencies: { typescript: '^5.0.0' },
+        scripts: { build: 'tsc', postinstall: 'node ./install.js' },
+        exports: { '.': './index.js' },
+        description: 'a package',
+        dist: {
+          tarball: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
+          integrity: 'sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==',
+        },
+      },
+    },
+  } as unknown as PackageMeta
+
+  const cacheDir = temporaryDirectory()
+  const ctx = {
+    fetch: async () => ({ meta, jsonText: JSON.stringify(meta), etag: undefined }),
+    metaCache: createMetaCache(),
+    cacheDir,
+  }
+  const spec: RegistryPackageSpec = { type: 'range', name: 'foo', fetchSpec: '^1.0.0' }
+
+  const res = await pickPackage(ctx, spec, { registry: REGISTRY, dryRun: false, preferredVersionSelectors: undefined })
+  expect(res.pickedPackage?.version).toBe('1.0.0')
+
+  // The returned/cached meta is normalized: non-install fields dropped, install
+  // fields kept, so resolution is unchanged.
+  const cachedVersion = res.meta.versions['1.0.0'] as unknown as Record<string, unknown>
+  expect(cachedVersion.scripts).toBeUndefined()
+  expect(cachedVersion.exports).toBeUndefined()
+  expect(cachedVersion.description).toBeUndefined()
+  expect((res.meta as unknown as Record<string, unknown>).readme).toBeUndefined()
+  expect((res.meta as unknown as Record<string, unknown>)._id).toBeUndefined()
+  expect(cachedVersion.dependencies).toEqual({ bar: '^1.0.0' })
+  expect(cachedVersion.dist).toBeDefined()
+})


### PR DESCRIPTION
## Summary

pnpm requests **abbreviated** package metadata (`Accept: application/vnd.npm.install-v1+json`) — the slim document with only the fields needed to install. Some registries **ignore that header and return the full document** (npm's abbreviated format is a vendor convention, not something every registry implements). Azure DevOps Artifacts is one such registry: it always returns the full CouchDB document, including per-version `scripts`, `exports`, `devDependencies`, `readme`, and arbitrary custom `package.json` fields.

pnpm stored that response **verbatim** in the abbreviated metadata cache, so every later resolution re-read and re-parsed all of those unused fields.

This PR normalizes the abbreviated slot down to the abbreviated field set before caching, by reusing the existing `clearMeta` helper (previously applied only for `filterMetadata`). The resolver already ignores the dropped fields, so resolution output is **byte-identical** — the cache just gets much smaller and faster to parse.

## The problem, concretely

On a large monorepo at Microsoft whose workspace resolves against an Azure DevOps Artifacts feed, one internal package's abbreviated metadata was **39.7 MB** — of which only ~**12%** is install-relevant:

| field (summed over all versions) | share of document |
|---|---|
| `scripts` | **51%** |
| `devDependencies` | 15% |
| `exports` | 9% |
| `dependencies` (needed) | 9% |
| custom fields (`_id`, `readme`, dev-tooling config, …) | ~13% |
| `dist` (needed) | 2% |

The same package on the public npm registry (which honors the abbreviated header) is **0.52 MB**. I confirmed the registry behavior directly: requesting that package from Azure DevOps with `Accept: application/vnd.npm.install-v1+json` returns byte-for-byte the same response as `Accept: application/json` — it does no content negotiation. The public npm registry returns 3.5× less for the abbreviated header.

Because dedupe/resolution parses each package's metadata (potentially once per dependent), the extra ~88% of every document dominates wall time and heap.

## The fix

`clearMeta` already reduces a document to the [abbreviated version object](https://github.com/npm/registry/blob/main/docs/responses/package-metadata.md) field set (plus `libc`, and top-level `time`/`dist-tags`/`modified`). It was only applied on the `filterMetadata` (full-slot) path. This PR applies it to the abbreviated slot as well, so anything cached there conforms to the abbreviated shape regardless of what the registry actually sent:

- Scoped to plain abbreviated results — full-metadata requests and `minimumReleaseAge`-upgraded documents are untouched.
- `clearMeta` is made null-safe for packages with no versions (unpublished), which the abbreviated path can now reach.

## Why resolution is unchanged

`clearMeta` keeps every field the resolver reads (`dependencies`/`optionalDependencies`/`peerDependencies*`/`dist`/`engines`/ `cpu`/`os`/`libc`/`bin`/`bundleDependencies`/`deprecated`/`hasInstallScript`/ `_npmUser`) and the top-level `time` (so `minimumReleaseAge` still works). The only registry-manifest read of a dropped field is `resolveDependencies.ts` reading `pkg.scripts?.prepare`, which is guarded by `resolvedVia === 'git-repository'` — never reached for registry packages (git dependencies get their manifest from the cloned repo, not the packument).

Validated end-to-end: `pnpm dedupe --offline` on the affected monorepo produces a **byte-identical `pnpm-lock.yaml`** whether the cached metadata is full or normalized.

## Performance

Warm-cache `pnpm dedupe --lockfile-only --offline` on that monorepo (~5,000 external packages), best of repeated runs:

| metadata cache | wall | peak RSS |
|---|---|---|
| full (before) | ~138 s | 3.59 GB |
| normalized (after) | **~67 s** | **2.54 GB** |

~2.1× faster and ~29% less memory, from ~55% smaller abbreviated documents overall (the large full-document packages shrink to ~12%; already-abbreviated public packages are unchanged).

## Testing

- New unit test in `metaCache.test.ts`: a registry that returns the full document (with `scripts`, `exports`, `readme`, etc.) results in a normalized cached document (unused fields dropped, install fields kept). Fails on `main`, passes here.
- `@pnpm/resolving.npm-resolver`: full suite passes (234 tests), compile + lint clean.
- Full changed-package closure (`--filter=...[origin/main]`): passes (one `deps.inspection.commands` `outdated` test is environment-flaky and fails identically on `main`, unrelated to this change).

## Notes

- This only touches how pnpm **persists** abbreviated metadata; the wire request is unchanged.
- Registries that already honor the abbreviated header (npmjs.org) are unaffected in content — `clearMeta` keeps exactly the fields they already send.
- A natural follow-up is to apply the same normalization to the full-metadata slot for non-`filterMetadata` resolvers, which would also shrink the `metadata-full` cache; left out here to keep the change focused.

