### PR TITLE
fix(pnpr): repair registry-mock routing and migrate tests off real-npm writes

### DIFF
--- a/pnpm11/installing/commands/test/update/interactive.ts
+++ b/pnpm11/installing/commands/test/update/interactive.ts
@@ -66,19 +66,19 @@ test('interactively update', async () => {
   const project = prepare({
     dependencies: {
       // has 1.0.0 and 1.0.1 that satisfy this range
-      'is-negative': '^1.0.0',
+      '@pnpm.e2e/multi-version-a': '^1.0.0',
       // only 2.0.0 satisfies this range
-      'is-positive': '^2.0.0',
-      // has many versions that satisfy ^3.0.0
-      micromatch: '^3.0.0',
+      '@pnpm.e2e/multi-version-b': '^2.0.0',
+      // has several versions that satisfy ^3.0.0
+      '@pnpm.e2e/multi-version-c': '^3.0.0',
     },
   })
 
   const storeDir = path.resolve('pnpm-store')
 
   await Promise.all([
-    addDistTag({ package: 'is-negative', version: '2.1.0', distTag: 'latest' }),
-    addDistTag({ package: 'micromatch', version: '4.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/multi-version-a', version: '2.1.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/multi-version-c', version: '4.0.0', distTag: 'latest' }),
   ])
 
   await add.handler(
@@ -90,10 +90,10 @@ test('interactively update', async () => {
       save: false,
       storeDir,
     },
-    ['is-negative@1.0.0', 'is-positive@2.0.0', 'micromatch@3.0.0']
+    ['@pnpm.e2e/multi-version-a@1.0.0', '@pnpm.e2e/multi-version-b@2.0.0', '@pnpm.e2e/multi-version-c@3.0.0']
   )
 
-  mockCheckbox.mockResolvedValue(['is-negative'])
+  mockCheckbox.mockResolvedValue(['@pnpm.e2e/multi-version-a'])
 
   mockCheckbox.mockClear()
   // Update to compatible versions
@@ -114,14 +114,14 @@ test('interactively update', async () => {
     new Separator(chalk.bold('── dependencies ──')),
     new Separator('  Package                                                    Current   Target            URL '),
     {
-      name: `is-negative                                                  1.0.0 ❯ 1.0.${chalk.greenBright.bold('1')}                 `,
-      value: 'is-negative',
-      short: 'is-negative',
+      name: `@pnpm.e2e/multi-version-a                                    1.0.0 ❯ 1.0.${chalk.greenBright.bold('1')}                 `,
+      value: '@pnpm.e2e/multi-version-a',
+      short: '@pnpm.e2e/multi-version-a',
     },
     {
-      name: `micromatch                                                   3.0.0 ❯ 3.${chalk.yellowBright.bold('1.10')}                `,
-      value: 'micromatch',
-      short: 'micromatch',
+      name: `@pnpm.e2e/multi-version-c                                    3.0.0 ❯ 3.${chalk.yellowBright.bold('1.10')}                `,
+      value: '@pnpm.e2e/multi-version-c',
+      short: '@pnpm.e2e/multi-version-c',
     },
   ])
   expect(mockCheckbox).toHaveBeenCalledWith(
@@ -139,14 +139,14 @@ test('interactively update', async () => {
   {
     const lockfile = project.readLockfile()
 
-    expect(lockfile.packages['micromatch@3.0.0']).toBeTruthy()
-    expect(lockfile.packages['is-negative@1.0.1']).toBeTruthy()
-    expect(lockfile.packages['is-positive@2.0.0']).toBeTruthy()
+    expect(lockfile.packages['@pnpm.e2e/multi-version-c@3.0.0']).toBeTruthy()
+    expect(lockfile.packages['@pnpm.e2e/multi-version-a@1.0.1']).toBeTruthy()
+    expect(lockfile.packages['@pnpm.e2e/multi-version-b@2.0.0']).toBeTruthy()
   }
 
   // Update to latest versions
   mockCheckbox.mockClear()
-  mockCheckbox.mockResolvedValue(['is-negative'])
+  mockCheckbox.mockResolvedValue(['@pnpm.e2e/multi-version-a'])
   await update.handler({
     ...DEFAULT_OPTIONS,
     cacheDir: path.resolve('cache'),
@@ -165,19 +165,19 @@ test('interactively update', async () => {
     new Separator(chalk.bold('── dependencies ──')),
     new Separator('  Package                                                    Current   Target            URL '),
     {
-      name: `is-negative                                                  1.0.1 ❯ ${chalk.redBright.bold('2.1.0')}                 `,
-      value: 'is-negative',
-      short: 'is-negative',
+      name: `@pnpm.e2e/multi-version-a                                    1.0.1 ❯ ${chalk.redBright.bold('2.1.0')}                 `,
+      value: '@pnpm.e2e/multi-version-a',
+      short: '@pnpm.e2e/multi-version-a',
     },
     {
-      name: `is-positive                                                  2.0.0 ❯ ${chalk.redBright.bold('3.1.0')}                 `,
-      value: 'is-positive',
-      short: 'is-positive',
+      name: `@pnpm.e2e/multi-version-b                                    2.0.0 ❯ ${chalk.redBright.bold('3.1.0')}                 `,
+      value: '@pnpm.e2e/multi-version-b',
+      short: '@pnpm.e2e/multi-version-b',
     },
     {
-      name: `micromatch                                                   3.0.0 ❯ ${chalk.redBright.bold('4.0.0')}                 `,
-      value: 'micromatch',
-      short: 'micromatch',
+      name: `@pnpm.e2e/multi-version-c                                    3.0.0 ❯ ${chalk.redBright.bold('4.0.0')}                 `,
+      value: '@pnpm.e2e/multi-version-c',
+      short: '@pnpm.e2e/multi-version-c',
     },
   ])
   expect(mockCheckbox).toHaveBeenCalledWith(
@@ -193,9 +193,9 @@ test('interactively update', async () => {
   {
     const lockfile = project.readLockfile()
 
-    expect(lockfile.packages['micromatch@3.0.0']).toBeTruthy()
-    expect(lockfile.packages['is-negative@2.1.0']).toBeTruthy()
-    expect(lockfile.packages['is-positive@2.0.0']).toBeTruthy()
+    expect(lockfile.packages['@pnpm.e2e/multi-version-c@3.0.0']).toBeTruthy()
+    expect(lockfile.packages['@pnpm.e2e/multi-version-a@2.1.0']).toBeTruthy()
+    expect(lockfile.packages['@pnpm.e2e/multi-version-b@2.0.0']).toBeTruthy()
   }
 })
 

--- a/pnpm11/installing/deps-installer/test/hoistedNodeLinker/install.ts
+++ b/pnpm11/installing/deps-installer/test/hoistedNodeLinker/install.ts
@@ -58,26 +58,26 @@ test('installing with hoisted node-linker and no lockfile', async () => {
   expect(fs.existsSync('pnpm-lock.yaml')).toBeFalsy()
 })
 
-test('overwriting (is-positive@3.0.0 with is-positive@latest)', async () => {
-  await addDistTag({ package: 'is-positive', version: '3.1.0', distTag: 'latest' })
+test('overwriting (@pnpm.e2e/multi-version-b@3.0.0 with @pnpm.e2e/multi-version-b@latest)', async () => {
+  await addDistTag({ package: '@pnpm.e2e/multi-version-b', version: '3.1.0', distTag: 'latest' })
   const project = prepareEmpty()
   const { updatedManifest: manifest } = await addDependenciesToPackage(
     {},
-    ['is-positive@3.0.0'],
+    ['@pnpm.e2e/multi-version-b@3.0.0'],
     testDefaults({ nodeLinker: 'hoisted', save: true })
   )
 
-  project.storeHas('is-positive', '3.0.0')
+  project.storeHas('@pnpm.e2e/multi-version-b', '3.0.0')
 
   const { updatedManifest } = await addDependenciesToPackage(
     manifest,
-    ['is-positive@latest'],
+    ['@pnpm.e2e/multi-version-b@latest'],
     testDefaults({ nodeLinker: 'hoisted', save: true })
   )
 
-  project.storeHas('is-positive', '3.1.0')
-  expect(updatedManifest.dependencies?.['is-positive']).toBe('3.1.0')
-  expect(loadJsonFileSync<{ version: string }>('node_modules/is-positive/package.json').version).toBe('3.1.0')
+  project.storeHas('@pnpm.e2e/multi-version-b', '3.1.0')
+  expect(updatedManifest.dependencies?.['@pnpm.e2e/multi-version-b']).toBe('3.1.0')
+  expect(loadJsonFileSync<{ version: string }>('node_modules/@pnpm.e2e/multi-version-b/package.json').version).toBe('3.1.0')
 })
 
 test('overwriting existing files in node_modules', async () => {

--- a/pnpm11/installing/deps-installer/test/install/misc.ts
+++ b/pnpm11/installing/deps-installer/test/install/misc.ts
@@ -357,18 +357,18 @@ if (foo.name !== '@pnpm.e2e/foo') {
   ])
 })
 
-test('no dependencies (lodash)', async () => {
+test('no dependencies (@pnpm.e2e/function-with-clone)', async () => {
   const project = prepareEmpty()
   const reporter = jest.fn()
 
-  await addDistTag({ package: 'lodash', version: '4.1.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/function-with-clone', version: '4.1.0', distTag: 'latest' })
 
   await addDependenciesToPackage(
     {
       name: 'project',
       version: '0.0.0',
     },
-    ['lodash@4.0.0'],
+    ['@pnpm.e2e/function-with-clone@4.0.0'],
     testDefaults({ fastUnpack: false, reporter })
   )
 
@@ -418,8 +418,8 @@ test('no dependencies (lodash)', async () => {
     added: expect.objectContaining({
       dependencyType: 'prod',
       latest: '4.1.0',
-      name: 'lodash',
-      realName: 'lodash',
+      name: '@pnpm.e2e/function-with-clone',
+      realName: '@pnpm.e2e/function-with-clone',
       version: '4.0.0',
     }),
     level: 'debug',
@@ -431,14 +431,14 @@ test('no dependencies (lodash)', async () => {
     name: 'pnpm:package-manifest',
     updated: {
       dependencies: {
-        lodash: '4.0.0',
+        '@pnpm.e2e/function-with-clone': '4.0.0',
       },
       name: 'project',
       version: '0.0.0',
     } as ProjectManifest,
   }))
 
-  const m = project.requireModule('lodash')
+  const m = project.requireModule('@pnpm.e2e/function-with-clone')
   expect(typeof m).toBe('function')
   expect(typeof m.clone).toBe('function')
 })
@@ -657,18 +657,18 @@ test('overwriting (magic-hook@2.0.0 and @0.1.0)', async () => {
   expect(m.version).toBe('0.1.0')
 })
 
-test('overwriting (is-positive@3.0.0 with is-positive@latest)', async () => {
-  await addDistTag({ package: 'is-positive', version: '3.1.0', distTag: 'latest' })
+test('overwriting (@pnpm.e2e/multi-version-b@3.0.0 with @pnpm.e2e/multi-version-b@latest)', async () => {
+  await addDistTag({ package: '@pnpm.e2e/multi-version-b', version: '3.1.0', distTag: 'latest' })
   const project = prepareEmpty()
-  const { updatedManifest: manifest } = await addDependenciesToPackage({}, ['is-positive@3.0.0'], testDefaults({ save: true }))
-  expect(manifest.dependencies?.['is-positive']).toBe('3.0.0')
+  const { updatedManifest: manifest } = await addDependenciesToPackage({}, ['@pnpm.e2e/multi-version-b@3.0.0'], testDefaults({ save: true }))
+  expect(manifest.dependencies?.['@pnpm.e2e/multi-version-b']).toBe('3.0.0')
 
-  project.storeHas('is-positive', '3.0.0')
+  project.storeHas('@pnpm.e2e/multi-version-b', '3.0.0')
 
-  const { updatedManifest } = await addDependenciesToPackage(manifest, ['is-positive@latest'], testDefaults({ save: true }))
+  const { updatedManifest } = await addDependenciesToPackage(manifest, ['@pnpm.e2e/multi-version-b@latest'], testDefaults({ save: true }))
 
-  project.storeHas('is-positive', '3.1.0')
-  expect(updatedManifest.dependencies?.['is-positive']).toBe('3.1.0')
+  project.storeHas('@pnpm.e2e/multi-version-b', '3.1.0')
+  expect(updatedManifest.dependencies?.['@pnpm.e2e/multi-version-b']).toBe('3.1.0')
 })
 
 // Covers https://github.com/pnpm/pnpm/issues/2188
@@ -773,21 +773,21 @@ test('circular deps', async () => {
 })
 
 test('concurrent circular deps', async () => {
-  // es5-ext is an external package from the registry
-  // the latest dist-tag is overridden to have a stable test
-  await addDistTag({ package: 'es5-ext', version: '0.10.31', distTag: 'latest' })
-  await addDistTag({ package: 'es6-iterator', version: '2.0.1', distTag: 'latest' })
+  // the latest dist-tag points above the installed version so the circular
+  // dependency resolves two versions of the same package concurrently
+  await addDistTag({ package: '@pnpm.e2e/circular-ext', version: '0.10.31', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/circular-iterator', version: '2.0.1', distTag: 'latest' })
 
   const project = prepareEmpty()
-  await addDependenciesToPackage({}, ['es6-iterator@2.0.0'], testDefaults({ fastUnpack: false }))
+  await addDependenciesToPackage({}, ['@pnpm.e2e/circular-iterator@2.0.0'], testDefaults({ fastUnpack: false }))
 
-  const m = project.requireModule('es6-iterator')
+  const m = project.requireModule('@pnpm.e2e/circular-iterator')
 
   expect(m).toBeTruthy()
-  expect(fs.existsSync(path.resolve('node_modules/.pnpm/es6-iterator@2.0.0/node_modules/es5-ext'))).toBeTruthy()
-  expect(fs.existsSync(path.resolve('node_modules/.pnpm/es6-iterator@2.0.1/node_modules/es5-ext'))).toBeTruthy()
-  expect(fs.existsSync(path.resolve('node_modules/.pnpm/es5-ext@0.10.31/node_modules/es6-iterator'))).toBeTruthy()
-  expect(fs.existsSync(path.resolve('node_modules/.pnpm/es5-ext@0.10.31/node_modules/es6-symbol'))).toBeTruthy()
+  expect(fs.existsSync(path.resolve('node_modules/.pnpm/@pnpm.e2e+circular-iterator@2.0.0/node_modules/@pnpm.e2e/circular-ext'))).toBeTruthy()
+  expect(fs.existsSync(path.resolve('node_modules/.pnpm/@pnpm.e2e+circular-iterator@2.0.1/node_modules/@pnpm.e2e/circular-ext'))).toBeTruthy()
+  expect(fs.existsSync(path.resolve('node_modules/.pnpm/@pnpm.e2e+circular-ext@0.10.31/node_modules/@pnpm.e2e/circular-iterator'))).toBeTruthy()
+  expect(fs.existsSync(path.resolve('node_modules/.pnpm/@pnpm.e2e+circular-ext@0.10.31/node_modules/@pnpm.e2e/circular-symbol'))).toBeTruthy()
 })
 
 test('concurrent installation of the same packages', async () => {

--- a/pnpm11/installing/deps-installer/test/install/multipleImporters.ts
+++ b/pnpm11/installing/deps-installer/test/install/multipleImporters.ts
@@ -970,7 +970,6 @@ test('partial installation in a monorepo does not remove dependencies of other w
 })
 
 test('adding a new dependency with the workspace: protocol', async () => {
-  await addDistTag({ package: 'foo', version: '1.0.0', distTag: 'latest' })
   prepareEmpty()
 
   const { updatedProjects } = await mutateModules([
@@ -1004,7 +1003,6 @@ test('adding a new dependency with the workspace: protocol', async () => {
 })
 
 test('adding a new dependency with the workspace: protocol and save-workspace-protocol is "rolling"', async () => {
-  await addDistTag({ package: 'foo', version: '1.0.0', distTag: 'latest' })
   prepareEmpty()
 
   const { updatedProjects } = await mutateModules([

--- a/pnpm11/installing/deps-installer/test/install/updatingPkgJson.ts
+++ b/pnpm11/installing/deps-installer/test/install/updatingPkgJson.ts
@@ -21,37 +21,37 @@ test('save to package.json (is-positive@^1.0.0)', async () => {
 
 // NOTE: this works differently for global installations. See similar tests in global.ts
 test("don't override existing spec in package.json on named installation", async () => {
-  await addDistTag({ package: 'is-negative', version: '2.1.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/multi-version-a', version: '2.1.0', distTag: 'latest' })
   const project = prepareEmpty()
   let { updatedManifest: manifest } = await addDependenciesToPackage({
     dependencies: {
-      'is-negative': '^1.0.0', // this will be updated
+      '@pnpm.e2e/multi-version-a': '^1.0.0', // this will be updated
       'is-positive': '^2.0.0', // this will be kept as no newer version is available from the range
       sec: 'sindresorhus/sec#main',
     },
   }, ['is-positive'], testDefaults())
-  manifest = (await addDependenciesToPackage(manifest, ['is-negative@latest'], testDefaults())).updatedManifest
+  manifest = (await addDependenciesToPackage(manifest, ['@pnpm.e2e/multi-version-a@latest'], testDefaults())).updatedManifest
   manifest = (await addDependenciesToPackage(manifest, ['sec'], testDefaults())).updatedManifest
 
   expect(project.requireModule('is-positive/package.json').version).toBe('2.0.0')
-  expect(project.requireModule('is-negative/package.json').version).toBe('2.1.0')
+  expect(project.requireModule('@pnpm.e2e/multi-version-a/package.json').version).toBe('2.1.0')
 
   expect(manifest.dependencies).toStrictEqual({
-    'is-negative': '^2.1.0',
+    '@pnpm.e2e/multi-version-a': '^2.1.0',
     'is-positive': '^2.0.0',
     sec: 'sindresorhus/sec#main',
   })
 })
 
-test('saveDev scoped module to package.json (@rstacruz/tap-spec)', async () => {
-  await addDistTag({ package: '@rstacruz/tap-spec', version: '4.1.1', distTag: 'latest' })
+test('saveDev scoped module to package.json (@scoped/exports-function)', async () => {
+  await addDistTag({ package: '@scoped/exports-function', version: '4.1.1', distTag: 'latest' })
   const project = prepareEmpty()
-  const { updatedManifest: manifest } = await addDependenciesToPackage({}, ['@rstacruz/tap-spec'], testDefaults({ fastUnpack: false, targetDependenciesField: 'devDependencies' }))
+  const { updatedManifest: manifest } = await addDependenciesToPackage({}, ['@scoped/exports-function'], testDefaults({ fastUnpack: false, targetDependenciesField: 'devDependencies' }))
 
-  const m = project.requireModule('@rstacruz/tap-spec')
+  const m = project.requireModule('@scoped/exports-function')
   expect(typeof m).toBe('function')
 
-  expect(manifest.devDependencies).toStrictEqual({ '@rstacruz/tap-spec': '^4.1.1' })
+  expect(manifest.devDependencies).toStrictEqual({ '@scoped/exports-function': '^4.1.1' })
 })
 
 test('dependency should not be added to package.json if it is already there', async () => {

--- a/pnpm11/installing/deps-installer/test/lockfile.ts
+++ b/pnpm11/installing/deps-installer/test/lockfile.ts
@@ -1389,20 +1389,23 @@ packages:
 })
 
 // Covers https://github.com/pnpm/pnpm/issues/2928
+// @pnpm.e2e/has-build-metadata-dep depends on
+// `@pnpm.e2e/has-build-metadata@^0.5.0-alpha.51+f10fea0` — a range carrying
+// build metadata, which must not leak into the lockfile.
 test('build metadata is always ignored in versions and the lockfile is not flickering because of them', async () => {
-  await addDistTag({ package: '@monorepolint/core', version: '0.5.0-alpha.51', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/has-build-metadata', version: '0.5.0-alpha.51', distTag: 'latest' })
   const project = prepareEmpty()
 
   const { updatedManifest: manifest } = await addDependenciesToPackage({},
     [
-      '@monorepolint/cli@0.5.0-alpha.51',
+      '@pnpm.e2e/has-build-metadata-dep@0.5.0-alpha.51',
     ], testDefaults({ lockfileOnly: true }))
 
-  const depPath = '@monorepolint/core@0.5.0-alpha.51'
+  const depPath = '@pnpm.e2e/has-build-metadata@0.5.0-alpha.51'
   const initialLockfile = project.readLockfile()
   const initialPkgEntry = initialLockfile.packages[depPath]
   expect(initialPkgEntry?.resolution).toStrictEqual({
-    integrity: 'sha512-ihFonHDppOZyG717OW6Bamd37mI2gQHjd09buTjbKhRX8NAHsTbRUKwp39ZYVI5AYgLF1eDlLpgOY4dHy2xGQw==',
+    integrity: getIntegrity('@pnpm.e2e/has-build-metadata', '0.5.0-alpha.51'),
   })
 
   await addDependenciesToPackage(manifest, ['is-positive'], testDefaults({ lockfileOnly: true }))

--- a/pnpm11/registry-access/commands/test/search.ts
+++ b/pnpm11/registry-access/commands/test/search.ts
@@ -17,16 +17,16 @@ test('search: missing query throws error', async () => {
 })
 
 test('search: returns formatted output with package name and npmx.dev URL', async () => {
-  const result = await search.handler(SEARCH_OPTS, ['is-positive'])
+  const result = await search.handler(SEARCH_OPTS, ['create-touch-file-one-bin'])
   expect(typeof result).toBe('string')
-  expect(result).toContain('is-positive')
+  expect(result).toContain('create-touch-file-one-bin')
   expect(result).toContain('Version ')
-  expect(result).toContain('https://npmx.dev/package/is-positive')
+  expect(result).toContain('https://npmx.dev/package/create-touch-file-one-bin')
   expect(result).not.toContain('npm.im')
 })
 
 test('search: --json returns parsed package array', async () => {
-  const result = await search.handler({ ...SEARCH_OPTS, json: true }, ['is-positive'])
+  const result = await search.handler({ ...SEARCH_OPTS, json: true }, ['create-touch-file-one-bin'])
   const parsed = JSON.parse(result)
   expect(Array.isArray(parsed)).toBe(true)
   expect(parsed.length).toBeGreaterThan(0)
@@ -44,7 +44,7 @@ test('search: non-OK registry response throws SEARCH_FAILED', async () => {
     search.handler({
       ...SEARCH_OPTS,
       registries: { default: `${REGISTRY_URL}/nonexistent-registry-path/` },
-    }, ['is-positive'])
+    }, ['create-touch-file-one-bin'])
   ).rejects.toMatchObject({ code: 'ERR_PNPM_SEARCH_FAILED' })
 })
 

--- a/pnpm11/releasing/commands/test/publish/batchPublish.test.ts
+++ b/pnpm11/releasing/commands/test/publish/batchPublish.test.ts
@@ -197,7 +197,7 @@ test('batch publish against a real pnpr registry publishes every package', async
     version: '1.0.0',
   }
   const pkg2 = {
-    name: `batch-e2e-project-2-${SUFFIX}`,
+    name: `@pnpmtest/batch-e2e-project-2-${SUFFIX}`,
     version: '1.2.3',
   }
   preparePackages([pkg1, pkg2])

--- a/pnpm11/releasing/commands/test/publish/publish.ts
+++ b/pnpm11/releasing/commands/test/publish/publish.ts
@@ -303,7 +303,7 @@ test('publish: package with all possible fields in publishConfig', async () => {
 })
 
 test('publish: package with publishConfig.registry overrides the default registry', async () => {
-  const pkgName = `test-publish-config-registry-${Date.now()}`
+  const pkgName = `@pnpmtest/test-publish-config-registry-${Date.now()}`
   prepare({
     name: pkgName,
     version: '1.0.0',
@@ -1044,7 +1044,7 @@ test('publish from a tarball', async () => {
 })
 
 test('publish --json: writes per-package summary to stdout', async () => {
-  const pkgName = `test-publish-json-${Date.now()}`
+  const pkgName = `@pnpmtest/test-publish-json-${Date.now()}`
   prepare({ name: pkgName, version: '0.0.0' })
 
   const result = await publish.handler({
@@ -1061,7 +1061,7 @@ test('publish --json: writes per-package summary to stdout', async () => {
     id: `${pkgName}@0.0.0`,
     name: pkgName,
     version: '0.0.0',
-    filename: `${pkgName}-0.0.0.tgz`,
+    filename: `${pkgName.substring(1).replace('/', '-')}-0.0.0.tgz`,
     bundled: [],
   })
   expect(summary.size).toEqual(expect.any(Number))

--- a/pnpm11/testing/registry-mock/src/index.ts
+++ b/pnpm11/testing/registry-mock/src/index.ts
@@ -99,14 +99,17 @@ export function getIntegrity (pkgName: string, pkgVersion: string): string {
       'Tests that call getIntegrity must run under the with-registry jest preset.'
     )
   }
-  const candidatePaths = [
-    path.join(storage, pkgName, 'package.json'),
-    ...listPublicProxyNamespaces(path.join(storage, PROXY_CACHE_DIR, '~public'))
-      .map((namespace) => path.join(namespace, pkgName, 'package.json')),
-  ]
   const maxRetries = 4
   let delay = 200 // milliseconds
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    // Rebuilt on every attempt: the proxy-cache namespace directory itself is
+    // created lazily along with the first cached packument, so it may not
+    // exist yet on the first attempt.
+    const candidatePaths = [
+      path.join(storage, pkgName, 'package.json'),
+      ...listPublicProxyNamespaces(path.join(storage, PROXY_CACHE_DIR, '~public'))
+        .map((namespace) => path.join(namespace, pkgName, 'package.json')),
+    ]
     const content = readPackument(candidatePaths)
     if (content) {
       return content.versions[pkgVersion].dist.integrity

--- a/pnpm11/testing/registry-mock/src/index.ts
+++ b/pnpm11/testing/registry-mock/src/index.ts
@@ -86,9 +86,10 @@ type Packument = { versions: Record<string, { dist: { integrity: string } }> }
  * `PNPM_REGISTRY_MOCK_STORAGE` by the with-registry jest globalSetup.
  *
  * Hosted (fixture) packuments live at `<storage>/<pkg>/package.json`; upstream
- * packages are proxied into `<storage>/.pnpr-cache/<pkg>/package.json`, written
- * lazily on first request — so both are tried and the read is retried while the
- * cache write is still in flight.
+ * packages are proxied into a per-upstream namespace of the cache mirror
+ * (`<storage>/.pnpr-cache/~public/<digest>/<pkg>/package.json`), written
+ * lazily on first request — so every namespace is tried and the read is
+ * retried while the cache write is still in flight.
  */
 export function getIntegrity (pkgName: string, pkgVersion: string): string {
   const storage = process.env.PNPM_REGISTRY_MOCK_STORAGE
@@ -100,7 +101,8 @@ export function getIntegrity (pkgName: string, pkgVersion: string): string {
   }
   const candidatePaths = [
     path.join(storage, pkgName, 'package.json'),
-    path.join(storage, PROXY_CACHE_DIR, pkgName, 'package.json'),
+    ...listPublicProxyNamespaces(path.join(storage, PROXY_CACHE_DIR, '~public'))
+      .map((namespace) => path.join(namespace, pkgName, 'package.json')),
   ]
   const maxRetries = 4
   let delay = 200 // milliseconds
@@ -114,6 +116,20 @@ export function getIntegrity (pkgName: string, pkgVersion: string): string {
     delay *= 2
   }
   throw new Error(`Failed to read package.json for ${pkgName}@${pkgVersion} after ${maxRetries} attempts`)
+}
+
+// The public proxy cache is namespaced per upstream mount by a digest of its
+// name and URL, which the test side cannot compute — so enumerate whatever
+// namespaces exist (for the registry mock, at most one: npmjs).
+function listPublicProxyNamespaces (publicCacheDir: string): string[] {
+  let entries: string[]
+  try {
+    entries = fs.readdirSync(publicCacheDir)
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw err
+  }
+  return entries.map((entry) => path.join(publicCacheDir, entry))
 }
 
 // Returns the first readable packument among the candidates, or `undefined` when

--- a/pnpm11/testing/registry-mock/src/index.ts
+++ b/pnpm11/testing/registry-mock/src/index.ts
@@ -125,14 +125,16 @@ export function getIntegrity (pkgName: string, pkgVersion: string): string {
 // name and URL, which the test side cannot compute — so enumerate whatever
 // namespaces exist (for the registry mock, at most one: npmjs).
 function listPublicProxyNamespaces (publicCacheDir: string): string[] {
-  let entries: string[]
+  let entries: fs.Dirent[]
   try {
-    entries = fs.readdirSync(publicCacheDir)
+    entries = fs.readdirSync(publicCacheDir, { withFileTypes: true })
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return []
     throw err
   }
-  return entries.map((entry) => path.join(publicCacheDir, entry))
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(publicCacheDir, entry.name))
 }
 
 // Returns the first readable packument among the candidates, or `undefined` when

--- a/pnpr/.fixtures/packages/@pnpm.e2e/circular-ext/0.10.31/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/circular-ext/0.10.31/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@pnpm.e2e/circular-ext",
+  "version": "0.10.31",
+  "dependencies": {
+    "@pnpm.e2e/circular-iterator": "^2.0.1",
+    "@pnpm.e2e/circular-symbol": "^3.1.0"
+  }
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/circular-iterator/2.0.0/index.js
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/circular-iterator/2.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = function circularIterator () {}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/circular-iterator/2.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/circular-iterator/2.0.0/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@pnpm.e2e/circular-iterator",
+  "version": "2.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "@pnpm.e2e/circular-ext": "^0.10.14"
+  }
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/circular-iterator/2.0.1/index.js
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/circular-iterator/2.0.1/index.js
@@ -1,0 +1,1 @@
+module.exports = function circularIterator () {}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/circular-iterator/2.0.1/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/circular-iterator/2.0.1/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@pnpm.e2e/circular-iterator",
+  "version": "2.0.1",
+  "main": "index.js",
+  "dependencies": {
+    "@pnpm.e2e/circular-ext": "^0.10.14"
+  }
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/circular-symbol/3.1.1/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/circular-symbol/3.1.1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@pnpm.e2e/circular-symbol",
+  "version": "3.1.1",
+  "dependencies": {
+    "@pnpm.e2e/circular-ext": "^0.10.14"
+  }
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/function-with-clone/4.0.0/index.js
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/function-with-clone/4.0.0/index.js
@@ -1,0 +1,2 @@
+module.exports = function functionWithClone () {}
+module.exports.clone = function clone () {}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/function-with-clone/4.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/function-with-clone/4.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@pnpm.e2e/function-with-clone",
+  "version": "4.0.0",
+  "main": "index.js"
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/function-with-clone/4.1.0/index.js
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/function-with-clone/4.1.0/index.js
@@ -1,0 +1,2 @@
+module.exports = function functionWithClone () {}
+module.exports.clone = function clone () {}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/function-with-clone/4.1.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/function-with-clone/4.1.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@pnpm.e2e/function-with-clone",
+  "version": "4.1.0",
+  "main": "index.js"
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/has-build-metadata-dep/0.5.0-alpha.51/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/has-build-metadata-dep/0.5.0-alpha.51/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@pnpm.e2e/has-build-metadata-dep",
+  "version": "0.5.0-alpha.51",
+  "dependencies": {
+    "@pnpm.e2e/has-build-metadata": "^0.5.0-alpha.51+f10fea0"
+  }
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/has-build-metadata/0.5.0-alpha.51/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/has-build-metadata/0.5.0-alpha.51/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pnpm.e2e/has-build-metadata",
+  "version": "0.5.0-alpha.51"
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-a/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-a/1.0.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pnpm.e2e/multi-version-a",
+  "version": "1.0.0"
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-a/1.0.1/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-a/1.0.1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pnpm.e2e/multi-version-a",
+  "version": "1.0.1"
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-a/2.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-a/2.0.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pnpm.e2e/multi-version-a",
+  "version": "2.0.0"
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-a/2.1.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-a/2.1.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pnpm.e2e/multi-version-a",
+  "version": "2.1.0"
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-b/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-b/1.0.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pnpm.e2e/multi-version-b",
+  "version": "1.0.0"
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-b/2.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-b/2.0.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pnpm.e2e/multi-version-b",
+  "version": "2.0.0"
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-b/3.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-b/3.0.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pnpm.e2e/multi-version-b",
+  "version": "3.0.0"
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-b/3.1.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-b/3.1.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pnpm.e2e/multi-version-b",
+  "version": "3.1.0"
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-c/3.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-c/3.0.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pnpm.e2e/multi-version-c",
+  "version": "3.0.0"
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-c/3.1.10/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-c/3.1.10/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pnpm.e2e/multi-version-c",
+  "version": "3.1.10"
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-c/4.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/multi-version-c/4.0.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pnpm.e2e/multi-version-c",
+  "version": "4.0.0"
+}

--- a/pnpr/.fixtures/packages/@scoped/exports-function/4.1.1/index.js
+++ b/pnpr/.fixtures/packages/@scoped/exports-function/4.1.1/index.js
@@ -1,0 +1,1 @@
+module.exports = function exportsFunction () {}

--- a/pnpr/.fixtures/packages/@scoped/exports-function/4.1.1/package.json
+++ b/pnpr/.fixtures/packages/@scoped/exports-function/4.1.1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@scoped/exports-function",
+  "version": "4.1.1",
+  "main": "index.js"
+}

--- a/pnpr/crates/pnpr/config.yaml
+++ b/pnpr/crates/pnpr/config.yaml
@@ -97,15 +97,78 @@ mounts:
     type: router
     routes:
       - patterns:
+          # Scopes seeded from the in-repo fixture sources
+          # (`pnpr/.fixtures/packages/`). Scopes shared with real, active npm
+          # scopes (`@pnpm`, `@zkochan`) are routed by exact name instead —
+          # see below — so proxied dependency trees can still pull the scope's
+          # other real packages from npm.
           - '@foo/*'
           - '@having/*'
           - '@jsr/*'
-          - '@pnpm/*'
           - '@pnpm.e2e/*'
           - '@private/*'
           - '@scoped/*'
-          - '@zkochan/*'
           - 'create-touch-file-one-bin'
+          # The fixture packages in the real `@pnpm` and `@zkochan` scopes,
+          # each routed by exact name.
+          - '@pnpm/plugin-pnpmfile'
+          - '@pnpm/postinstall-modifies-source'
+          - '@pnpm/x'
+          - '@pnpm/xyz'
+          - '@pnpm/xyz-parent'
+          - '@pnpm/xyz-parent-parent'
+          - '@pnpm/xyz-parent-parent-parent'
+          - '@pnpm/xyz-parent-parent-parent-parent'
+          - '@pnpm/xyz-parent-parent-with-xyz'
+          - '@pnpm/y'
+          - '@pnpm/z'
+          - '@zkochan/test-pnpm-issue219'
+          # Names tests publish to the mock and then read back. Exact names
+          # only — an unscoped prefix wildcard would swallow real npm packages
+          # that proxied dependency trees need (`test-*` would capture
+          # `test-exclude`). A test publishing a new unscoped name must add it
+          # here; publishing dynamically-suffixed names belongs in the
+          # `@pnpmtest` scope.
+          - '@pnpmtest/*'
+          - 'batch-dry-1'
+          - 'batch-dry-2'
+          - 'batch-no-recursive'
+          - 'batch-pkg-2'
+          - 'batch-unsupported-1'
+          - 'project-100'
+          - 'project-200'
+          - 'publish_config_directory_dist_package'
+          - 'test-deprecate-package'
+          - 'test-deprecate-specific'
+          - 'test-dist-tag-add'
+          - 'test-dist-tag-add-default'
+          - 'test-dist-tag-ls'
+          - 'test-dist-tag-ls-default'
+          - 'test-dist-tag-rm'
+          - 'test-dist-tag-rm-latest'
+          - 'test-dist-tag-rm-missing'
+          - 'test-publish-config'
+          - 'test-publish-config-directory'
+          - 'test-publish-config-installation'
+          - 'test-publish-helper-token-basic.json'
+          - 'test-publish-helper-token-bearer.json'
+          - 'test-publish-package-oidc.json'
+          - 'test-publish-package.json'
+          - 'test-publish-package.json5'
+          - 'test-publish-package.yaml'
+          - 'test-publish-scripts'
+          - 'test-publish-skip-manifest-obfuscation'
+          - 'test-publish-skip-manifest-obfuscation-installation'
+          - 'test-publish-tarball'
+          - 'test-publish-with-ignore-scripts'
+          - 'test-publish-with-scripts'
+          - 'test-undeprecate-pkg'
+          - 'test-unpublish-force'
+          - 'test-unpublish-no-force'
+          - 'test-unpublish-no-ver'
+          - 'test-unpublish-version'
+          - 'workspace-package-with-default-catalog'
+          - 'workspace-package-with-named-catalog'
         source: local
       - patterns: ['**']
         source: npmjs
@@ -113,9 +176,11 @@ mounts:
 # The path-less base URL (`https://<pnpr>/`) aliases this mount.
 defaultTarget: main
 
-# Per-package access control (an ACL layer, independent of routing). The
-# default for an unmatched package is open reads + authenticated writes;
-# these rules tighten specific fixtures to authenticated-only.
+# Per-package access control (an ACL layer, independent of routing). With no
+# matching rule the built-in default allows authenticated publish but admits
+# no one to unpublish, so the `**` rule below keeps every non-tightened
+# package open for reads and authenticated for both write kinds — the
+# `@pnpm/registry-mock` contract the tests rely on.
 packages:
   '@private/*':
     access: $authenticated
@@ -124,6 +189,11 @@ packages:
 
   '@pnpm.e2e/needs-auth':
     access: $authenticated
+    publish: $authenticated
+    unpublish: $authenticated
+
+  '**':
+    access: $all
     publish: $authenticated
     unpublish: $authenticated
 

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1148,16 +1148,29 @@ fn default_true() -> bool {
 /// The package-name patterns that [`Config::proxy`] routes to its flat-root
 /// hosted org rather than the npm upstream: the registry-mock fixture scopes
 /// plus the one unscoped fixture. Kept in sync with the bundled `config.yaml`
-/// router and the fixtures under `pnpr/.fixtures/packages`.
+/// router and the fixtures under `pnpr/.fixtures/packages`. The fixture
+/// packages living in real, active npm scopes (`@pnpm`, `@zkochan`) are
+/// routed by exact name so the rest of those scopes keeps proxying npm
+/// (dependency trees of proxied packages pull real `@pnpm/*` packages).
 const REGISTRY_MOCK_LOCAL_PATTERNS: &[&str] = &[
     "@foo/*",
     "@having/*",
     "@jsr/*",
-    "@pnpm/*",
     "@pnpm.e2e/*",
     "@private/*",
     "@scoped/*",
-    "@zkochan/*",
+    "@pnpm/plugin-pnpmfile",
+    "@pnpm/postinstall-modifies-source",
+    "@pnpm/x",
+    "@pnpm/xyz",
+    "@pnpm/xyz-parent",
+    "@pnpm/xyz-parent-parent",
+    "@pnpm/xyz-parent-parent-parent",
+    "@pnpm/xyz-parent-parent-parent-parent",
+    "@pnpm/xyz-parent-parent-with-xyz",
+    "@pnpm/y",
+    "@pnpm/z",
+    "@zkochan/test-pnpm-issue219",
     "create-touch-file-one-bin",
 ];
 

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -437,16 +437,23 @@ fn from_default_yaml_parses_bundled_file() {
     assert!(config.uplinks.contains_key("npmjs"));
     assert_eq!(config.uplinks["npmjs"].url, "https://registry.npmjs.org/");
     assert_eq!(config.auth.htpasswd.max_users, super::MaxUsers::Disabled);
-    // The bundled file routes fixture scopes to the local hosted org and
-    // everything else to npmjs.
-    assert_eq!(
-        config.mounts.resolve_default("@pnpm.e2e/foo"),
-        Resolved::Concrete { mount: "local", kind: ConcreteKind::Hosted },
-    );
-    assert_eq!(
-        config.mounts.resolve_default("lodash"),
-        Resolved::Concrete { mount: "npmjs", kind: ConcreteKind::Upstream },
-    );
+    // The bundled file routes fixture scopes, the fixture packages living in
+    // real npm scopes, and test-published names to the local hosted org, and
+    // everything else — including the rest of those real scopes — to npmjs.
+    for local in ["@pnpm.e2e/foo", "@pnpm/y", "test-publish-tarball", "project-100"] {
+        assert_eq!(
+            config.mounts.resolve_default(local),
+            Resolved::Concrete { mount: "local", kind: ConcreteKind::Hosted },
+            "{local} must be hosted",
+        );
+    }
+    for upstream in ["react", "lodash", "test-exclude", "@pnpm/error"] {
+        assert_eq!(
+            config.mounts.resolve_default(upstream),
+            Resolved::Concrete { mount: "npmjs", kind: ConcreteKind::Upstream },
+            "{upstream} must proxy npm",
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

The registry-mounts merge (pnpm/pnpm#12747) broke the TypeScript test suite, unnoticed because TS CI was path-filter-skipped on that pnpr-only merge ([diagnosis on pnpm/pnpm#12698](https://github.com/pnpm/pnpm/pull/12698#issuecomment-4867668565)). Two contract breaks with the old verdaccio-style mock:

1. **Writes to upstream-routed names are rejected.** Tests dist-tagged real npm packages (`is-negative`, `is-positive`, `lodash`, `micromatch`, `es5-ext`, `es6-iterator`, `@rstacruz/tap-spec`, `@monorepolint/core`) and published unscoped names; the old server materialized an overlay on first write, the mount model rejects the write by design.
2. **Fixture-scope routes claimed real npm scopes with no fall-through.** `@zkochan/*` → local 404'd `@zkochan/async-regex-replace`; `@pnpm/*` → local 404'd real `@pnpm/error`/`@pnpm/git-resolver` pulled by a huge-package test.

The mount model and the mock stay exactly as they are — no overlay, no mirror feature, provenance stays declared. The fix is config + test migration:

**pnpr config (first commit):**
- Fixture packages living in real npm scopes (`@pnpm`, `@zkochan`) are routed by exact name; the rest of those scopes proxies npm again.
- Every unscoped name tests publish is enumerated exactly; `@pnpmtest/*` covers dynamically-suffixed publish names. Deliberately no unscoped prefix wildcards — a `test-*` route would swallow the real `test-exclude` from istanbul's dependency tree.
- The `'**'` ACL entry the migration dropped is restored (the built-in default admits no one to unpublish, so unpublish tests got 403).

**Test migration (second commit):** every test that *writes* to a real npm package now uses a dedicated in-repo fixture — `@pnpm.e2e/multi-version-{a,b,c}` for the update/dist-tag flows, `@pnpm.e2e/circular-{iterator,ext,symbol}` for the concurrent-circular-deps test, `@pnpm.e2e/function-with-clone` where the test executes the installed code, `@scoped/exports-function` for the scoped devDeps-save test, `@pnpm.e2e/has-build-metadata{,-dep}` for the build-metadata lockfile test (hardcoded real-npm integrity → `getIntegrity()`), and dynamically-suffixed publish names move into `@pnpmtest/`. Read-only usages of real npm packages are untouched and keep proxying. `getIntegrity()` also learns the proxy cache's post-mounts layout (`.pnpr-cache/~public/<digest>/`), which the patch tests rely on.

Verified locally against the real mock: `installing/commands` 31/31 suites (the two original CI failures pass), `installing/deps-installer` 76/76 (787 tests, incl. patch, circular, catalogs), `installing/deps-restorer`, `registry-access/commands` 9/9, `releasing/commands` 23/23 (publish, recursive, batch), `cache/commands` 3/3. pnpr: 568/568, clippy/fmt/dylint clean.

## Squash Commit Body

```text
The registry mounts model (pnpm/pnpm#12747) routes every package to exactly
one declared origin with no cross-origin fall-through, and rejects writes to
upstream-routed names. The TypeScript test suite relied on the old
verdaccio-style overlay in ways TS CI never caught (it was
path-filter-skipped on the pnpr-only merge): tests dist-tagged and published
over real npm packages, and the fixture-scope routes (@zkochan/*, @pnpm/*)
claimed real npm scopes whose other packages tests still pull through the
proxy.

Keep the mount model and the mock as they are; fix the config and migrate
the tests:

- Route fixture packages living in real npm scopes by exact name, so the
  rest of those scopes proxies npm again. Enumerate the unscoped names
  tests publish (no unscoped prefix wildcards - test-* would swallow the
  real test-exclude package); dynamically-suffixed publish names move into
  the @pnpmtest scope. Restore the '**' ACL entry the migration dropped -
  the built-in default admits no one to unpublish.
- Migrate every test that writes to a real npm package onto a dedicated
  fixture: @pnpm.e2e/multi-version-{a,b,c} for update/dist-tag flows,
  @pnpm.e2e/circular-{iterator,ext,symbol} for the concurrent circular
  install, @pnpm.e2e/function-with-clone where the installed code is
  executed, @scoped/exports-function for the scoped devDeps save,
  @pnpm.e2e/has-build-metadata{,-dep} for the build-metadata range of
  pnpm/pnpm#2928 (hardcoded real-npm integrity becomes getIntegrity()).
  Read-only usages of real npm packages keep proxying, untouched.
- getIntegrity() in the registry-mock helper learns the proxy cache's
  post-mounts layout (.pnpr-cache/~public/<digest>/), which the patch
  tests depend on for proxied packages.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting. *(Test infrastructure only: pnpr config + TS tests/fixtures. pacquet's in-process registry is unchanged — its tests never write to these packages.)*
- [x] Added or updated tests. *(The change is test migration; the pnpr config test pins the new routing.)*

<!-- Removed: changeset (no published package changes — test infrastructure only), documentation (internal test tooling; documented in config comments). -->

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tightened package routing for fixture-scoped packages by using more precise allowlisting rules for when content is served locally versus from the upstream registry.
  * Updated default access control behavior so unmatched packages remain broadly readable while publishing/unpublishing requires authentication.

* **Bug Fixes**
  * Updated install/update scenarios to reflect new multi-version fixture coverage, including overwrite behavior and dependency updates.
  * Refreshed search and lockfile expectations to keep build metadata from leaking into the lockfile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->