### PR TITLE
fix(pnpr): overlay mounts so the registry-mock proxies and accepts writes for non-hosted packages

### DIFF
--- a/.changeset/pnpr-hosted-overlay-mount.md
+++ b/.changeset/pnpr-hosted-overlay-mount.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": minor
+---
+
+A hosted mount can now declare `mirror: <upstream-mount>` to act as an **overlay**: a read for a name the mount does not host is served (and cached) from the declared upstream, and a dist-tag or publish write that finds no hosted packument materializes the upstream's first. The backing is a single origin named in config and validated at load — not a router existence-based fall-through — so the mount model's declared-provenance rule still holds. The bundled registry-mock config now uses this shape (a single `local` mount mirrored on `npmjs`), which restores dist-tag and publish writes against packages proxied from npm and lets reads of any non-hosted name fall through to npm.

--- a/pnpr/crates/pnpr/config.yaml
+++ b/pnpr/crates/pnpr/config.yaml
@@ -71,47 +71,35 @@ middlewares:
 web:
   enable: false
 
-# Registry mounts: the only routing surface. Every addressable origin is a
-# mount exposed at `/~<mount>/`, and provenance is declared, never inferred —
-# a package resolves to exactly one declared concrete origin, with no
-# cross-origin fall-through (not on "not found", not on "unavailable"). This
-# is the `@pnpm/registry-mock` shape: the fixture scopes are served from the
-# local hosted store, and everything else proxies the public npm registry.
+# Registry mounts: the only routing surface. Provenance is declared, never
+# inferred — a package resolves to exactly one declared concrete origin. This
+# is the `@pnpm/registry-mock` shape: the `local` hosted store is seeded from
+# the in-repo fixtures and mirrors the public npm registry, so a package the
+# fixtures host (or a test has published or dist-tagged) is served
+# authoritatively from `local`, and every other name falls through to npmjs.
+# That mirror is the one declared form of cross-origin content the model
+# permits — the backing is a single origin named here, validated at load, not
+# a router existence-based fall-through (see `HostedConfig::mirror`).
 mounts:
-  # The locally-hosted fixtures (and anything published here). With no `org`,
-  # this mount namespaces onto the flat `storage` root, where the fixtures are
-  # seeded.
+  # The locally-hosted fixtures (and anything published or dist-tagged here).
+  # With no `org`, this mount namespaces onto the flat `storage` root, where
+  # the fixtures are seeded. Mirroring `npmjs` makes it an overlay: a read for
+  # a name the overlay does not host is served (and cached) from npmjs, and a
+  # dist-tag write against a proxied name materializes its packument here
+  # first — so tests can pin a real package (`is-positive`, `lodash`, …) to a
+  # chosen version while still resolving its full upstream version list.
   local:
     type: hosted
+    mirror: npmjs
     access: $all
   # The public npm registry.
   npmjs:
     type: upstream
     url: https://registry.npmjs.org/
     public: true
-  # One URL routing each package to exactly one source by the first matching
-  # pattern. The fixture scopes are authoritative-local; everything else is
-  # npm. A router refuses to start on a shadowed route, so the `**` catch-all
-  # must stay last.
-  main:
-    type: router
-    routes:
-      - patterns:
-          - '@foo/*'
-          - '@having/*'
-          - '@jsr/*'
-          - '@pnpm/*'
-          - '@pnpm.e2e/*'
-          - '@private/*'
-          - '@scoped/*'
-          - '@zkochan/*'
-          - 'create-touch-file-one-bin'
-        source: local
-      - patterns: ['**']
-        source: npmjs
 
 # The path-less base URL (`https://<pnpr>/`) aliases this mount.
-defaultTarget: main
+defaultTarget: local
 
 # Per-package access control (an ACL layer, independent of routing). The
 # default for an unmatched package is open reads + authenticated writes;

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -152,9 +152,10 @@ pub struct Config {
     pub hosted: IndexMap<String, HostedConfig>,
 }
 
-/// A resolved hosted mount: the `org` namespace it serves and the access policy
-/// applied to every package under it. Per-package ACLs in [`Config::policies`]
-/// compose on top (logical AND) for finer control.
+/// A resolved hosted mount: the `org` namespace it serves, the access policy
+/// applied to every package under it, and an optional declared upstream
+/// **mirror** that turns the mount into an overlay. Per-package ACLs in
+/// [`Config::policies`] compose on top (logical AND) for finer control.
 #[derive(Debug, Clone)]
 pub struct HostedConfig {
     /// The storage/serving namespace, so two hosted mounts holding the same
@@ -165,6 +166,19 @@ pub struct HostedConfig {
     /// not-found either way. Defaults to `$all` (a public hosted mount) when
     /// the mount omits `access:`.
     pub access: AccessList,
+    /// When set, this hosted mount is an **overlay** over the named upstream
+    /// mount: a read for a package the overlay does not host falls through to
+    /// the mirror (served, and cached, exactly like a routed upstream read),
+    /// and a write (dist-tag, publish) that finds no hosted packument
+    /// materializes the mirror's packument into the hosted store first.
+    ///
+    /// This is the one declared form of cross-origin content the mount model
+    /// permits — distinct from the router's forbidden existence-based
+    /// fall-through — because the backing is a single origin named in config
+    /// and validated at load, not inferred from which source happens to have
+    /// the package. Routing still resolves a name to exactly one concrete
+    /// source; the mirror is a serving-layer property of a hosted source.
+    pub mirror: Option<String>,
 }
 
 /// Which fetch routes the resolution cache treats as public. The official
@@ -926,6 +940,11 @@ struct HostedFile {
     /// Who may read this mount's packages. Omitted ⇒ `$all`.
     #[serde(default)]
     access: Option<AccessSpec>,
+    /// The upstream mount this hosted mount mirrors — turning it into an
+    /// overlay. Omitted ⇒ a pure hosted mount (no upstream fall-through). See
+    /// [`HostedConfig::mirror`].
+    #[serde(default)]
+    mirror: Option<String>,
 }
 
 /// Disk shape of an `upstream:` mount — one external origin. Mirrors an
@@ -1147,8 +1166,13 @@ fn default_true() -> bool {
 
 /// The package-name patterns that [`Config::proxy`] routes to its flat-root
 /// hosted org rather than the npm upstream: the registry-mock fixture scopes
-/// plus the one unscoped fixture. Kept in sync with the bundled `config.yaml`
-/// router and the fixtures under `pnpr/.fixtures/packages`.
+/// plus the one unscoped fixture. This is the *pre-overlay* routing shape;
+/// the bundled `config.yaml` instead makes `local` an overlay mirrored on
+/// `npmjs` (so any name falls through to npmjs and dist-tags materialize),
+/// which [`Config::proxy`] deliberately does not replicate — pacquet's tests
+/// don't dist-tag upstream packages, and keeping the pure-upstream `**` route
+/// here avoids changing their behavior. Kept in sync with the fixtures under
+/// `pnpr/.fixtures/packages`.
 const REGISTRY_MOCK_LOCAL_PATTERNS: &[&str] = &[
     "@foo/*",
     "@having/*",
@@ -1168,13 +1192,16 @@ impl Config {
     /// proxy-mode default.
     pub const DEFAULT_PACKUMENT_TTL: Duration = Duration::from_mins(5);
 
-    /// Build a proxy-mode config in the registry-mock shape: the fixture scopes
-    /// (and the one unscoped fixture) resolve to a flat-root hosted org over
-    /// `storage`, while every other name proxies to the `npmjs` upstream. The
-    /// path-less base aliases the `main` router. Kept for callers that don't use
-    /// YAML config (notably pacquet's test registry, whose fixtures are served
-    /// locally while real npm packages fall through to npmjs). The local pattern
-    /// set mirrors the bundled `config.yaml` router.
+    /// Build a proxy-mode config in the pre-overlay registry-mock shape: the
+    /// fixture scopes (and the one unscoped fixture) resolve to a flat-root
+    /// hosted org over `storage`, while every other name proxies to the
+    /// `npmjs` upstream. The path-less base aliases the `main` router. This is
+    /// the shape pacquet's test registry uses; the bundled `config.yaml`
+    /// served to the TypeScript CLI's e2e registry instead makes `local` an
+    /// overlay mirrored on `npmjs` (see [`HostedConfig::mirror`]) so dist-tag
+    /// writes against proxied packages materialize — behavior pacquet's tests
+    /// don't need and that is omitted here to avoid changing theirs. The local
+    /// pattern set is `REGISTRY_MOCK_LOCAL_PATTERNS`.
     #[must_use]
     pub fn proxy(listen: SocketAddr, storage: PathBuf) -> Self {
         let mut uplinks = IndexMap::new();
@@ -1185,7 +1212,7 @@ impl Config {
         let mut hosted = IndexMap::new();
         hosted.insert(
             "local".to_string(),
-            HostedConfig { org: String::new(), access: AccessList::parse("$all") },
+            HostedConfig { org: String::new(), access: AccessList::parse("$all"), mirror: None },
         );
         let local_patterns = REGISTRY_MOCK_LOCAL_PATTERNS
             .iter()
@@ -1240,7 +1267,7 @@ impl Config {
         let mut hosted = IndexMap::new();
         hosted.insert(
             "local".to_string(),
-            HostedConfig { org: String::new(), access: AccessList::parse("$all") },
+            HostedConfig { org: String::new(), access: AccessList::parse("$all"), mirror: None },
         );
         let graph = [
             ("local".to_string(), MountKind::Hosted),
@@ -1654,7 +1681,10 @@ fn build_mounts(
                     .access
                     .as_ref()
                     .map_or_else(|| AccessList::parse("$all"), AccessSpec::to_access_list);
-                hosted.insert(name.clone(), HostedConfig { org: mount.org, access });
+                hosted.insert(
+                    name.clone(),
+                    HostedConfig { org: mount.org, access, mirror: mount.mirror },
+                );
                 graph.insert(name, MountKind::Hosted);
             }
             MountFile::Upstream(upstream) => {
@@ -1672,6 +1702,7 @@ fn build_mounts(
     }
     let mounts = Mounts::new(graph, default_target);
     mounts.validate().map_err(|err| mount_err(&err))?;
+    validate_hosted_mirrors(&mounts, &hosted)?;
     Ok((hosted, mounts))
 }
 
@@ -1696,6 +1727,31 @@ fn validate_mount_name(name: &str) -> Result<(), RegistryError> {
              `\\`, `:`, `%`, `?`, `#`, whitespace, or control characters",
         ),
     })
+}
+
+/// A hosted mount's `mirror` must name a defined `upstream` mount — the only
+/// kind whose content an overlay can defer to. A mirror pointing at another
+/// hosted mount (including itself) or a router, or at a name that is not a
+/// mount at all, is rejected at load rather than turning into a silent
+/// no-op or a routing surprise. The check runs after [`Mounts::validate`], so
+/// the graph (and every declared upstream) already exists.
+fn validate_hosted_mirrors(
+    mounts: &Mounts,
+    hosted: &IndexMap<String, HostedConfig>,
+) -> Result<(), RegistryError> {
+    for (name, cfg) in hosted {
+        if let Some(mirror) = &cfg.mirror
+            && !matches!(mounts.get(mirror), Some(MountKind::Upstream))
+        {
+            return Err(RegistryError::InvalidConfig {
+                reason: format!(
+                    "hosted mount {name:?} mirrors {mirror:?}, which is not a defined `upstream` \
+                     mount; a mirror must name one",
+                ),
+            });
+        }
+    }
+    Ok(())
 }
 
 /// A hosted mount's `org` becomes a storage path/key segment (`Storage::for_hosted`),

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -437,15 +437,18 @@ fn from_default_yaml_parses_bundled_file() {
     assert!(config.uplinks.contains_key("npmjs"));
     assert_eq!(config.uplinks["npmjs"].url, "https://registry.npmjs.org/");
     assert_eq!(config.auth.htpasswd.max_users, super::MaxUsers::Disabled);
-    // The bundled file routes fixture scopes to the local hosted org and
-    // everything else to npmjs.
+    // The bundled file makes `local` a single overlay mount mirrored on npmjs:
+    // every name — fixture scope or not — resolves to the hosted `local`, whose
+    // serving layer falls through to the npmjs mirror for anything it does not
+    // host (and materializes the packument on a dist-tag write).
+    assert_eq!(config.hosted["local"].mirror.as_deref(), Some("npmjs"));
     assert_eq!(
         config.mounts.resolve_default("@pnpm.e2e/foo"),
         Resolved::Concrete { mount: "local", kind: ConcreteKind::Hosted },
     );
     assert_eq!(
         config.mounts.resolve_default("lodash"),
-        Resolved::Concrete { mount: "npmjs", kind: ConcreteKind::Upstream },
+        Resolved::Concrete { mount: "local", kind: ConcreteKind::Hosted },
     );
 }
 
@@ -979,6 +982,51 @@ mounts:
     let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
         .expect_err("two hosted mounts on the same org must be rejected");
     assert!(err.to_string().contains("reuses the `org`"), "unexpected error: {err}");
+}
+
+/// A hosted mount's `mirror` must name a defined `upstream` mount — the only
+/// kind whose content an overlay can defer to. Pointing it at another hosted
+/// mount, or at a name that is not a mount at all, fails at load.
+#[test]
+fn from_yaml_str_rejects_hosted_mirror_that_is_not_a_defined_upstream() {
+    for (label, yaml) in [
+        (
+            "another hosted mount",
+            "storage: ./s\nmounts:\n  local:\n    type: hosted\n    mirror: other\n  other:\n    \
+             type: hosted\n    org: other\n",
+        ),
+        (
+            "an undefined mount",
+            "storage: ./s\nmounts:\n  local:\n    type: hosted\n    mirror: ghost\n",
+        ),
+    ] {
+        let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
+            .expect_err("a hosted mirror must name a defined upstream mount ({label})");
+        assert!(
+            err.to_string().contains("not a defined `upstream` mount"),
+            "unexpected error for {label}: {err}",
+        );
+    }
+}
+
+/// A hosted mount mirroring a defined upstream mount parses and is recorded on
+/// the resolved [`HostedConfig`].
+#[test]
+fn from_yaml_str_parses_hosted_mirror_over_an_upstream_mount() {
+    let yaml = "\
+storage: ./s
+mounts:
+  local:
+    type: hosted
+    mirror: npmjs
+  npmjs:
+    type: upstream
+    url: https://registry.npmjs.org/
+    public: true
+defaultTarget: local
+";
+    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+    assert_eq!(config.hosted["local"].mirror.as_deref(), Some("npmjs"));
 }
 
 /// A hosted `org` becomes a storage path segment, so a traversal-y value —

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1386,13 +1386,24 @@ async fn load_packument_for_read(
             if let Err(err) = authorize(state, identity, name.as_str(), Action::Access) {
                 return Err(Box::new(error_response(&err)));
             }
-            state
+            let hosted = state
                 .inner
                 .storage
                 .for_hosted(&org)
                 .read_hosted_packument(name)
                 .await
-                .map_err(|err| Box::new(error_response(&err)))
+                .map_err(|err| Box::new(error_response(&err)))?;
+            match hosted {
+                Some(bytes) => Ok(Some(bytes)),
+                // Overlay miss falls through to the declared upstream mirror;
+                // a pure hosted mount has no fallback.
+                None => match hosted_mirror(state, &source) {
+                    Some(uplink) => {
+                        load_upstream_packument_for(state, identity, &uplink, name).await
+                    }
+                    None => Ok(None),
+                },
+            }
         }
         MountSource::NotFound => Ok(None),
     }
@@ -1784,6 +1795,14 @@ fn accessible_hosted_namespace(
         .map(|org| org.org.clone())
 }
 
+/// The upstream mount a hosted `source` mirrors, when it is an overlay. `None`
+/// for a pure hosted mount. A read or write that misses the hosted store
+/// consults this mirror rather than failing — the declared form of
+/// cross-origin content the mount model permits (see [`crate::config::HostedConfig::mirror`]).
+fn hosted_mirror(state: &AppState, source: &str) -> Option<String> {
+    state.inner.config.hosted.get(source).and_then(|hosted| hosted.mirror.clone())
+}
+
 async fn serve_hosted_packument(
     state: &AppState,
     identity: &Identity,
@@ -1798,8 +1817,6 @@ async fn serve_hosted_packument(
     if let Err(err) = authorize(state, identity, name.as_str(), Action::Access) {
         return error_response(&err);
     }
-    // A hosted org has no upstream fallback: a package it does not host is a
-    // definitive not-found. Reads come from the org's own storage namespace.
     match state.inner.storage.for_hosted(&org).read_hosted_packument(name).await {
         Ok(Some(bytes)) => match packument_response(
             name,
@@ -1811,7 +1828,17 @@ async fn serve_hosted_packument(
             Ok(response) => response,
             Err(err) => error_response(&err),
         },
-        Ok(None) => not_found(),
+        Ok(None) => match hosted_mirror(state, source) {
+            // Overlay miss: fall through to the declared upstream mirror,
+            // served (and cached) exactly like a routed upstream read.
+            Some(uplink) => {
+                serve_packument_via_uplink(state, identity, headers, &uplink, name, tarball_base)
+                    .await
+            }
+            // A pure hosted org has no upstream fallback: a package it does not
+            // host is a definitive not-found.
+            None => not_found(),
+        },
         Err(err) => error_response(&err),
     }
 }
@@ -1826,19 +1853,32 @@ async fn serve_hosted_tarball(
     let Some(org) = accessible_hosted_namespace(state, identity, source) else {
         return not_found();
     };
-    let (filename, name_version) = match name.parse_tarball_name(filename) {
-        Ok(parsed) => parsed,
-        Err(err) => return error_response(&err),
-    };
     if let Err(err) = authorize(state, identity, name.as_str(), Action::Access) {
         return error_response(&err);
     }
-    if let Err(err) = ensure_osv_allowed(state, name, &name_version) {
-        return error_response(&err);
-    }
-    match state.inner.storage.for_hosted(&org).open_hosted_tarball(name, &filename).await {
+    let mirror = hosted_mirror(state, source);
+    // Try the hosted store first under the canonical filename. An overlay
+    // defers to its mirror on a miss — and also when the basename is a
+    // non-canonical upstream form the hosted path cannot parse (hosted
+    // tarballs are always written under their canonical name).
+    let hosted_open = match name.parse_tarball_name(filename) {
+        Ok((canonical, name_version)) => {
+            if let Err(err) = ensure_osv_allowed(state, name, &name_version) {
+                return error_response(&err);
+            }
+            state.inner.storage.for_hosted(&org).open_hosted_tarball(name, &canonical).await
+        }
+        Err(err) if mirror.is_none() => return error_response(&err),
+        Err(_) => Ok(None),
+    };
+    match hosted_open {
         Ok(Some((body, len))) => tarball_response(body, len),
-        Ok(None) => not_found(),
+        Ok(None) => match mirror {
+            Some(uplink) => {
+                serve_tarball_via_uplink(state, identity, &uplink, name.as_str(), filename).await
+            }
+            None => not_found(),
+        },
         Err(err) => {
             tracing::warn!(?err, package = %name.as_str(), %filename, "hosted tarball open failed");
             error_response(&err)
@@ -2256,8 +2296,10 @@ fn hosted_storage(state: &AppState, org: Option<&str>) -> Storage {
 
 /// Where a publish of `package` writes, given an optional explicit `/~<mount>/`.
 enum PublishTarget {
-    /// Write into this hosted storage namespace.
-    Org(String),
+    /// Write into this hosted storage namespace. The resolved `mount` id is
+    /// carried alongside so the write path can consult the mount's declared
+    /// mirror (an overlay materializes the upstream packument on a miss).
+    Org { mount: String, org: String },
     /// The resolved target is not a hosted org; reject with this reason.
     Reject(String),
     /// The addressed mount or route does not exist (or the path-less base has
@@ -2281,7 +2323,7 @@ fn resolve_publish_target(
 ) -> PublishTarget {
     let from_source = |source: MountSource, context: &str| match source {
         MountSource::Hosted(mount) => match accessible_hosted_namespace(state, identity, &mount) {
-            Some(org) => PublishTarget::Org(org),
+            Some(org) => PublishTarget::Org { mount, org },
             None => PublishTarget::NotFound,
         },
         MountSource::Upstream(_) => PublishTarget::Reject(format!(
@@ -2343,7 +2385,7 @@ async fn publish_package(
     // closed when the target is an upstream, an unknown mount, or a hosted
     // mount whose access list denies the caller.
     let org = match resolve_publish_target(state, identity, mount, name.as_str()) {
-        PublishTarget::Org(org) => Some(org),
+        PublishTarget::Org { org, .. } => Some(org),
         PublishTarget::Reject(reason) => {
             return error_response(&RegistryError::BadRequest { reason });
         }
@@ -2449,7 +2491,7 @@ async fn serve_batch_publish(
         // default target (a router default routes by name; a concrete/absent
         // default keeps the legacy flat store).
         let org = match resolve_publish_target(&state, &identity, None, doc.name.as_str()) {
-            PublishTarget::Org(org) => Some(org),
+            PublishTarget::Org { org, .. } => Some(org),
             PublishTarget::Reject(reason) => {
                 for stage in staged {
                     cleanup_tmp_slots(stage.slots).await;
@@ -2878,7 +2920,7 @@ async fn update_packument(
         }
     }
     let org = match resolve_write_org(state, identity, mount, &name) {
-        Ok(org) => org,
+        Ok((org, _)) => org,
         Err(response) => return *response,
     };
     let storage = hosted_storage(state, Some(&org));
@@ -3096,7 +3138,7 @@ async fn delete_package(
         return error_response(&err);
     }
     let org = match resolve_write_org(state, identity, mount, &name) {
-        Ok(org) => org,
+        Ok((org, _)) => org,
         Err(response) => return *response,
     };
     // Serialize against same-package publishers so a delete can't race a
@@ -3138,7 +3180,7 @@ async fn delete_tarball(
         return error_response(&err);
     }
     let org = match resolve_write_org(state, identity, mount, &name) {
-        Ok(org) => org,
+        Ok((org, _)) => org,
         Err(response) => return *response,
     };
     // Serialize against same-package publishers so a delete can't race a
@@ -3247,9 +3289,10 @@ where
         return error_response(&err);
     }
     // A dist-tag change is a write, so it routes to a hosted namespace like
-    // a publish — a name routed to an upstream is rejected.
-    let org = match resolve_write_org(state, identity, mount, &name) {
-        Ok(org) => org,
+    // a publish — a name routed to a pure upstream is rejected; an overlay
+    // routes here too, and is handled by the materialize-on-miss branch below.
+    let (org, mirror) = match resolve_write_org(state, identity, mount, &name) {
+        Ok(target) => target,
         Err(response) => return *response,
     };
     let storage = hosted_storage(state, Some(&org));
@@ -3258,14 +3301,28 @@ where
     // on this instance (held until this function returns).
     let _packument_guard = state.inner.package_locks.lock(name.as_str()).await;
 
-    // A hosted org has no upstream, so a dist-tag change starts from the org's
-    // own packument; a package it does not host can't be tagged.
+    // A pure hosted org has no upstream, so a dist-tag change starts from the
+    // org's own packument; a package it does not host can't be tagged. An
+    // overlay instead materializes its mirror's packument on a miss, so the
+    // first dist-tag change against a proxied package starts from its real
+    // version list rather than 404ing.
     let mut packument: Value = match storage.read_hosted_packument(&name).await {
         Ok(Some(bytes)) => match serde_json::from_slice(&bytes) {
             Ok(v) => v,
             Err(err) => return error_response(&RegistryError::Json(err)),
         },
-        Ok(None) => return not_found(),
+        Ok(None) => match &mirror {
+            Some(uplink) => match load_upstream_packument_for(state, identity, uplink, &name).await
+            {
+                Ok(Some(bytes)) => match serde_json::from_slice(&bytes) {
+                    Ok(v) => v,
+                    Err(err) => return error_response(&RegistryError::Json(err)),
+                },
+                Ok(None) => return not_found(),
+                Err(response) => return *response,
+            },
+            None => return not_found(),
+        },
         Err(err) => return error_response(&err),
     };
 
@@ -3320,19 +3377,20 @@ where
 // --------------------------------------------------------------------
 
 /// Resolve the hosted storage namespace a non-publish write (dist-tag,
-/// unpublish, packument update) targets, or the [`Response`] to return. A
-/// write routes like a publish: through the addressed `/~<mount>/` (or,
-/// path-less, the default-target mount) to a hosted org, rejecting a name
-/// routed to an upstream and 404ing when the path-less base has no default
-/// target or the mount's access list denies the caller.
+/// unpublish, packument update) targets, plus that mount's declared mirror (if
+/// it is an overlay), or the [`Response`] to return. A write routes like a
+/// publish: through the addressed `/~<mount>/` (or, path-less, the
+/// default-target mount) to a hosted org, rejecting a name routed to an
+/// upstream and 404ing when the path-less base has no default target or the
+/// mount's access list denies the caller.
 fn resolve_write_org(
     state: &AppState,
     identity: &Identity,
     mount: Option<&str>,
     name: &PackageName,
-) -> Result<String, Box<Response>> {
+) -> Result<(String, Option<String>), Box<Response>> {
     match resolve_publish_target(state, identity, mount, name.as_str()) {
-        PublishTarget::Org(org) => Ok(org),
+        PublishTarget::Org { mount, org } => Ok((org, hosted_mirror(state, &mount))),
         PublishTarget::Reject(reason) => {
             Err(Box::new(error_response(&RegistryError::BadRequest { reason })))
         }

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -38,6 +38,28 @@ fn config_for(upstream: &str, storage: PathBuf) -> Config {
     config
 }
 
+/// The registry-mock's bundled `config.yaml` shape: a single `local` hosted
+/// mount mirrored on `npmjs` (an overlay), aliased by the path-less base with
+/// no router. A hosted name is served from `local`; anything else falls through
+/// to the `npmjs` mirror, and a dist-tag write against a proxied name
+/// materializes its packument into `local`.
+fn overlay_config(upstream_url: &str, storage: PathBuf) -> Config {
+    let listen = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 4873));
+    let mut config = Config::proxy(listen, storage);
+    config.uplinks.get_mut("npmjs").expect("default `npmjs` uplink").url = upstream_url.to_string();
+    config.public_url = "http://example.test".to_string();
+    config.packument_ttl = Duration::from_mins(1);
+    config.hosted.get_mut("local").expect("default `local` mount").mirror =
+        Some("npmjs".to_string());
+    config.mounts = Mounts::new(
+        vec![("local".to_string(), MountKind::Hosted), ("npmjs".to_string(), MountKind::Upstream)]
+            .into_iter()
+            .collect(),
+        Some("local".to_string()),
+    );
+    config
+}
+
 /// A public upstream mount caches under `.pnpr-cache/~public/<digest>/<pkg>/`.
 /// The proxy tests use a single `npmjs` mount, so there is one digest dir; this
 /// resolves the per-package cache dir under it. When nothing is cached yet it
@@ -2740,7 +2762,7 @@ async fn hosted_mount_serves_only_what_it_hosts() {
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
     config.hosted.insert(
         "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("$all") },
+        HostedConfig { org: "acme".to_string(), access: AccessList::parse("$all"), mirror: None },
     );
     config.mounts =
         Mounts::new(vec![("acme".to_string(), MountKind::Hosted)].into_iter().collect(), None);
@@ -2772,7 +2794,7 @@ async fn private_hosted_hides_existence_from_unauthorized_caller() {
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
     config.hosted.insert(
         "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice") },
+        HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice"), mirror: None },
     );
     config.mounts =
         Mounts::new(vec![("acme".to_string(), MountKind::Hosted)].into_iter().collect(), None);
@@ -2813,7 +2835,7 @@ async fn private_hosted_org_masks_before_the_package_acl() {
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
     config.hosted.insert(
         "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice") },
+        HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice"), mirror: None },
     );
     config.mounts =
         Mounts::new(vec![("acme".to_string(), MountKind::Hosted)].into_iter().collect(), None);
@@ -2851,7 +2873,7 @@ async fn private_hosted_org_masks_dist_tags_before_the_package_acl() {
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
     config.hosted.insert(
         "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice") },
+        HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice"), mirror: None },
     );
     // The path-less base aliases the "acme" hosted mount, so `/-/package/...`
     // resolves to it.
@@ -2885,7 +2907,11 @@ async fn publish_to_hosted_round_trips_in_its_own_namespace() {
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
     config.hosted.insert(
         "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("$authenticated") },
+        HostedConfig {
+            org: "acme".to_string(),
+            access: AccessList::parse("$authenticated"),
+            mirror: None,
+        },
     );
     // npmjs already exists (from config_for); add a hosted org + a router that
     // sends `@acme/*` to it and everything else to npmjs, aliased path-less.
@@ -3010,7 +3036,7 @@ async fn private_hosted_mount_denies_writes_from_non_members() {
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
     config.hosted.insert(
         "corp".to_string(),
-        HostedConfig { org: "corp".to_string(), access: AccessList::parse("alice") },
+        HostedConfig { org: "corp".to_string(), access: AccessList::parse("alice"), mirror: None },
     );
     // `/~corp/` addresses the mount directly; the path-less base aliases it,
     // so the path-less dist-tag and unpublish writes route there too.
@@ -3106,7 +3132,7 @@ async fn search_does_not_enumerate_a_private_flat_root_mount() {
     config.hosted.clear();
     config.hosted.insert(
         "corp".to_string(),
-        HostedConfig { org: String::new(), access: AccessList::parse("alice") },
+        HostedConfig { org: String::new(), access: AccessList::parse("alice"), mirror: None },
     );
     config.mounts = Mounts::new(
         vec![("corp".to_string(), MountKind::Hosted)].into_iter().collect(),
@@ -3156,7 +3182,11 @@ async fn mount_addressed_surface_serves_dist_tags_unpublish_whoami_search_and_ve
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
     config.hosted.insert(
         "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("$authenticated") },
+        HostedConfig {
+            org: "acme".to_string(),
+            access: AccessList::parse("$authenticated"),
+            mirror: None,
+        },
     );
     // No default target: the mount is addressable only at `/~acme/`.
     config.mounts =
@@ -3333,7 +3363,7 @@ async fn pathless_private_mount_responses_carry_private_cache_headers() {
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
     config.hosted.insert(
         "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice") },
+        HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice"), mirror: None },
     );
     config.mounts = Mounts::new(
         vec![("acme".to_string(), MountKind::Hosted)].into_iter().collect(),
@@ -3373,7 +3403,7 @@ async fn pathless_private_mount_responses_carry_private_cache_headers() {
     let mut config = config_for("http://127.0.0.1:1", tmp_public.path().to_path_buf());
     config.hosted.insert(
         "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("$all") },
+        HostedConfig { org: "acme".to_string(), access: AccessList::parse("$all"), mirror: None },
     );
     config.mounts = Mounts::new(
         vec![("acme".to_string(), MountKind::Hosted)].into_iter().collect(),
@@ -3401,7 +3431,7 @@ async fn pathless_acl_gated_package_carries_private_cache_headers() {
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
     config.hosted.insert(
         "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("$all") },
+        HostedConfig { org: "acme".to_string(), access: AccessList::parse("$all"), mirror: None },
     );
     config.mounts = Mounts::new(
         vec![("acme".to_string(), MountKind::Hosted)].into_iter().collect(),
@@ -3596,4 +3626,187 @@ async fn identity_endpoints_are_served_under_any_mount_prefix() {
             app.clone().oneshot(Request::get(path).body(Body::empty()).unwrap()).await.unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "GET {path}");
     }
+}
+
+// ---------------------------------------------------------------------------
+// Overlay mounts: a hosted mount with a declared `mirror` upstream. A hosted
+// name is served from the hosted store; a miss falls through to the mirror;
+// a dist-tag write against a proxied name materializes the mirror's packument.
+// ---------------------------------------------------------------------------
+
+/// A read for a name the overlay does not host falls through to its mirror,
+/// served (and cached) exactly like a routed upstream read.
+#[tokio::test]
+async fn overlay_read_falls_through_to_the_mirror() {
+    let mut upstream = mockito::Server::new_async().await;
+    upstream
+        .mock("GET", "/is-positive")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "name": "is-positive",
+                "dist-tags": { "latest": "1.0.0" },
+                "versions": { "1.0.0": {
+                    "name": "is-positive", "version": "1.0.0",
+                    "dist": { "tarball": "http://example.test/is-positive/-/is-positive-1.0.0.tgz" },
+                } },
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let app = router_with_auth(
+        overlay_config(&upstream.url(), tmp.path().to_path_buf()),
+        AuthState::in_memory(),
+    );
+
+    let resp =
+        app.oneshot(Request::get("/is-positive").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp.into_body()).await;
+    assert_eq!(body["dist-tags"]["latest"], "1.0.0");
+}
+
+/// A hosted package wins over the mirror: the upstream is never contacted.
+/// The mirror points at a dead address so any fall-through would surface as a
+/// connection error rather than a 200.
+#[tokio::test]
+async fn overlay_read_prefers_hosted_content_over_the_mirror() {
+    let tmp = TempDir::new().unwrap();
+    seed_hosted(tmp.path(), "foo");
+    let app = router_with_auth(
+        overlay_config("http://127.0.0.1:1", tmp.path().to_path_buf()),
+        AuthState::in_memory(),
+    );
+
+    let resp = app.oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp.into_body()).await;
+    assert_eq!(body["dist-tags"]["latest"], "1.0.0");
+}
+
+/// A dist-tag write against a proxied package materializes the mirror's
+/// packument into the hosted store — the override sticks and the mirror's
+/// version list is preserved (matching the pre-mount registry-mock behavior
+/// the test suite was written against).
+#[tokio::test]
+async fn overlay_dist_tag_materializes_the_mirror_packument() {
+    let mut upstream = mockito::Server::new_async().await;
+    let packument = json!({
+        "name": "is-positive",
+        "dist-tags": { "latest": "3.0.0" },
+        "versions": {
+            "1.0.0": { "name": "is-positive", "version": "1.0.0", "dist": {
+                "tarball": format!("{}/is-positive/-/is-positive-1.0.0.tgz", upstream.url()),
+                "shasum": "aa",
+            } },
+            "3.0.0": { "name": "is-positive", "version": "3.0.0", "dist": {
+                "tarball": format!("{}/is-positive/-/is-positive-3.0.0.tgz", upstream.url()),
+                "shasum": "bb",
+            } },
+        },
+    });
+    let packument_mock = upstream
+        .mock("GET", "/is-positive")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(packument.to_string())
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(overlay_config(&upstream.url(), tmp.path().to_path_buf()), auth);
+
+    assert!(!tmp.path().join("is-positive/package.json").exists(), "nothing hosted yet");
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::put("/-/package/is-positive/dist-tags/latest")
+                .header("content-type", "application/json")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(b"\"1.0.0\"".to_vec()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let stored: Value = serde_json::from_str(
+        &std::fs::read_to_string(tmp.path().join("is-positive/package.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(stored["dist-tags"]["latest"], "1.0.0", "the override stuck");
+    assert!(
+        stored["versions"].get("3.0.0").is_some(),
+        "the mirror's version list is preserved on materialization",
+    );
+
+    // A subsequent read serves the materialized packument (hosted-first), so
+    // the override is visible to clients resolving through the registry.
+    let read =
+        app.oneshot(Request::get("/is-positive").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(read.status(), StatusCode::OK);
+    let body = body_json(read.into_body()).await;
+    assert_eq!(body["dist-tags"]["latest"], "1.0.0");
+    assert!(body["versions"].get("3.0.0").is_some());
+
+    packument_mock.assert_async().await;
+}
+
+/// A tarball for a version that exists only on the mirror is fetched through
+/// the mirror (and verified against its packument), so a materialized
+/// packument's other versions stay installable.
+#[tokio::test]
+async fn overlay_tarball_falls_through_to_the_mirror() {
+    let tarball_bytes = b"is-positive-1.0.0-tarball";
+    let integrity = sha512_integrity(tarball_bytes);
+    let mut upstream = mockito::Server::new_async().await;
+    upstream
+        .mock("GET", "/is-positive")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "name": "is-positive",
+                "dist-tags": { "latest": "1.0.0" },
+                "versions": { "1.0.0": {
+                    "name": "is-positive", "version": "1.0.0",
+                    "dist": {
+                        "tarball": format!("{}/is-positive/-/is-positive-1.0.0.tgz", upstream.url()),
+                        "integrity": integrity,
+                    },
+                } },
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+    upstream
+        .mock("GET", "/is-positive/-/is-positive-1.0.0.tgz")
+        .with_status(200)
+        .with_header("content-type", "application/octet-stream")
+        .with_body(tarball_bytes)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let app = router_with_auth(
+        overlay_config(&upstream.url(), tmp.path().to_path_buf()),
+        AuthState::in_memory(),
+    );
+
+    let resp = app
+        .oneshot(Request::get("/is-positive/-/is-positive-1.0.0.tgz").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(body_bytes(resp.into_body()).await, tarball_bytes);
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Follow-up to the CI-status comment on pnpm/pnpm#12698. PR pnpm/pnpm#12747 ("registry mounts as the only routing model") broke the registry-mock the TS e2e suite runs against in two ways — both pre-existing on `main`, masked because `pnpm -r test` bails at the first failing project so CI only surfaced the `installing/commands` update tests:

1. **Reads of real npm packages routed to the hosted store 404.** The `@zkochan/*` scope route sent `@zkochan/async-regex-replace` (and `@zkochan/foo`, `@zkochan/logger`) to the `local` hosted mount, which only has the `@zkochan/test-pnpm-issue219` fixture. With no cross-origin fall-through, they 404.
2. **dist-tag/publish writes against upstream-routed packages are rejected.** Tests dist-tag real npm packages (`is-positive`, `is-negative`, `lodash`, `foo`, `micromatch`, `es5-ext`, `es6-iterator`, `@rstacruz/tap-spec`, `@monorepolint/core`) and publish unscoped names (`registry-access/commands`, `releasing/commands`). All route to the `npmjs` upstream and are rejected with "cannot publish … it routes to an upstream registry; name a hosted mount." The pre-mounts server materialized the upstream packument into hosted storage on first dist-tag write; the pure model rejects the write. A full audit shows this breaks the entire `registry-access/commands` and `releasing/commands` publish/dist-tag/deprecate/unpublish suites — not just the two CI-visible failures.

### Fix — a declared overlay mount

Added an opt-in `mirror:` field on a hosted mount. When set, the mount is an **overlay**:

- a read for a name the overlay does not host falls through to the declared upstream (served and cached exactly like a routed upstream read);
- a dist-tag write against a proxied name materializes the upstream's packument into the hosted store first, so the override sticks and the upstream version list is preserved.

Routing/classification in `mount.rs` is **untouched** — the mirror is a single origin named in config and validated at load, so the mount model's declared-provenance rule still holds. This is the one declared form of cross-origin content the model permits, distinct from the router's forbidden existence-based fall-through.

The bundled `pnpr/crates/pnpr/config.yaml` becomes a single `local` mount mirrored on `npmjs` (`defaultTarget: local`, no router), which fixes both regressions for every scope at once and retires the brittle scope-allowlist entirely.

`Config::proxy` — which backs pacquet's test registry and pnpr's own Rust tests — is **deliberately left on the pure-upstream shape**. That suite is green, and an audit confirmed no publish there lands on a real upstream name, so changing it would only add risk.

### Why not the alternatives

- *Restore the old hosted-first-then-proxy for the mock only (a boolean flag):* the only non-hacky version of that is the overlay mount itself.
- *Keep the router and grow the scope allowlist (`@pnpmtest`, `@rstacruz`, `@monorepolint`, …):* open-ended whack-a-mole; every future test that invents a new scope hits the same wall.
- *Rewrite the tests to dist-tag only fixtures:* large, and changes what the tests exercise (they deliberately pin real packages to deterministic versions).

## Squash Commit Body

```text
Follow-up to the CI-status comment on pnpm/pnpm#12698.

PR pnpm/pnpm#12747 made the mount model the only routing surface and forbade
cross-origin fall-through, breaking the registry-mock the TS e2e suite runs
against in two ways, both pre-existing on main and masked because
`pnpm -r test` bails at the first failing project:

1. Reads of real npm packages routed to the hosted store (notably
   `@zkochan/async-regex-replace`, caught by the `@zkochan/*` scope route)
   404'd — the hosted store has only `@zkochan/test-pnpm-issue219`.
2. dist-tag and publish writes against packages routed to the npmjs upstream
   (`is-positive`, `lodash`, `foo`, `micromatch`, `es5-ext`, `es6-iterator`,
   `@rstacruz/tap-spec`, `@monorepolint/core`, and the whole
   registry-access/releasing command test suite) were rejected. The pre-mount
   server materialized the upstream packument into hosted storage on first
   dist-tag write; the pure model rejects the write instead.

Add an opt-in `mirror` field on a hosted mount: when set, the mount is an
overlay. A read for a name the overlay does not host falls through to the
declared upstream (served and cached like a routed upstream read); a dist-tag
write against a proxied name materializes the upstream's packument into the
hosted store first, so the override sticks and the upstream version list is
preserved. Routing/classification in mount.rs is untouched — the mirror is a
single origin named in config and validated at load, so the declared-provenance
rule still holds.

The bundled config.yaml becomes a single `local` mount mirrored on npmjs
(defaultTarget: local, no router), which fixes both regressions for every
scope at once. Config::proxy — pacquet's and pnpr's own Rust test registry —
is left on the pure-upstream shape, since that suite is green and no publish
there lands on a real upstream name.

pnpr tests: 569 passed. The TS e2e failures need the rebuilt pnpr binary run
against the with-registry jest preset, which was not exercised locally.
```

## Checklist

- [x] Added a changeset (`pnpm changeset`) — `.changeset/pnpr-hosted-overlay-mount.md`.
- [x] Added or updated tests — 4 overlay behavior tests (read fallback, hosted-preferred, dist-tag materialize, tarball fallback) + 2 mirror-validation tests; updated the bundled-config assertion.
- [x] Updated the documentation if needed — inline doc comments on `HostedConfig::mirror`, the `config.yaml` mount block, and `Config::proxy` cover the new behavior; no separate docs to update.

The TypeScript-CLI / `pacquet/` parity checklist item does not apply: this is a `pnpr`-only change, and `pnpr` is a registry server with no pnpm-CLI or pacquet counterpart (see `pnpr/AGENTS.md`).

---

Written by an agent (opencode, glm-5.2).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hosted mounts can now mirror an upstream registry, letting missing package data fall through to the upstream source.
  * Reads and tarball fetches now work through the mirror when content isn’t available locally.

* **Bug Fixes**
  * Restored dist-tag and publish behavior for packages proxied from the public registry.
  * Improved package resolution so hosted content still takes precedence, while mirrored content is used as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->