### PR TITLE
feat(pnpr): derive the registry surface from declared mounts

### DIFF
--- a/pnpr/crates/pnpr/config.yaml
+++ b/pnpr/crates/pnpr/config.yaml
@@ -40,11 +40,12 @@ storage: ./storage
 #  mysql:
 #    url: ${PNPR_MYSQL_URL}
 #    maxConnections: 16
-# Feature toggles for pnpr's two surfaces. Both are enabled by default;
-# disable one to carve down what this server exposes. At least one must
-# stay enabled. (`/-/ping` is always served.)
-#registry:          # npm registry: packument/tarball reads, publish,
-#  enabled: true    # unpublish, dist-tag, search, user/login endpoints
+# The npm-registry surface (packument/tarball reads, publish, unpublish,
+# dist-tag, search) is served iff at least one mount is declared under
+# `mounts:` below; `--disable-registry` turns it off per tier. The install
+# accelerator has its own toggle. Something must be served: mounts, or the
+# resolver. (`/-/ping` and the login/token account endpoints are always
+# served.)
 #resolver:          # install accelerator: /-/pnpr, /-/pnpr/v0/resolve,
 #  enabled: true    # and /-/pnpr/v0/verify-lockfile
 secret: pnpm-registry-mock-secret-key-32

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1009,11 +1009,6 @@ struct ConfigFile {
     /// pnpr-only local OSV database settings.
     #[serde(default)]
     osv: OsvFile,
-    /// Removed key, rejected in any form (see
-    /// [`reject_removed_registry_key`]). The npm-registry surface is
-    /// derived from `mounts:` instead.
-    #[serde(default, rename = "registry", deserialize_with = "reject_removed_registry_key")]
-    _registry: Option<()>,
     /// pnpr-only feature toggle for the resolver surface. On unless
     /// explicitly disabled; absent on a stock verdaccio config, so it
     /// stays enabled there. `Option` so a bare `resolver:` (which YAML
@@ -1150,23 +1145,6 @@ impl Default for FeatureFile {
 
 fn default_true() -> bool {
     true
-}
-
-/// Reject the removed top-level `registry:` key in any form (a mapping,
-/// a scalar, or a bare `registry:` null). The parser is otherwise lenient
-/// about unknown keys (so a verdaccio config drops in untouched), but this
-/// one used to disable a surface: silently ignoring `registry: {enabled:
-/// false}` would serve the full npm-registry surface a config explicitly
-/// disclaimed — a fail-open — so it errors with migration guidance instead.
-fn reject_removed_registry_key<'de, De>(_deserializer: De) -> Result<Option<()>, De::Error>
-where
-    De: serde::Deserializer<'de>,
-{
-    Err(serde::de::Error::custom(
-        "the `registry:` key has been removed: the npm-registry surface is served \
-         iff at least one mount is declared under `mounts:`; delete the `registry:` \
-         block (use `--disable-registry` for a per-tier override)",
-    ))
 }
 
 /// The package-name patterns that [`Config::proxy`] routes to its flat-root

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -120,9 +120,10 @@ pub struct Config {
     /// known vulnerable npm package versions without live API calls.
     pub osv: OsvConfig,
     /// The npm-registry surface: packument and tarball reads, publish,
-    /// unpublish, dist-tag, search, and the user/login endpoints. Enabled
-    /// by default; disable it to run a stateless resolver tier in front
-    /// of an existing registry. See [`RegistryFeature`].
+    /// unpublish, dist-tag, and search. Derived, not configured: the
+    /// surface is served iff at least one mount is declared, minus the
+    /// `--disable-registry` per-tier override (a stateless resolver tier
+    /// in front of an existing registry). See [`RegistryFeature`].
     pub registry: RegistryFeature,
     /// The install-accelerator surface: the `/-/pnpr` handshake and the
     /// `/-/pnpr/v0/resolve` / `/-/pnpr/v0/verify-lockfile` endpoints. Enabled by
@@ -187,7 +188,10 @@ pub struct PublicRoute {
     pub package: Option<String>,
 }
 
-/// Toggle for the npm-registry surface. A dedicated type — rather than a
+/// State of the npm-registry surface. There is no YAML toggle for it:
+/// the surface is served iff at least one mount is declared under
+/// `mounts:` (no mounts ⇒ nothing to serve), minus the per-tier
+/// `--disable-registry` CLI override. A dedicated type — rather than a
 /// bare `bool` on [`Config`] — so finer-grained registry sub-features
 /// (e.g. disabling `publish` for a read-only mirror) can be added here
 /// without changing the config shape.
@@ -227,7 +231,8 @@ impl Default for ResolverFeature {
 /// strict (a `uplink.auth` block with an unresolvable token is a config
 /// error): applying `--disable-registry` only after parsing would still
 /// force a resolver-only tier to carry upstream secrets. A `true` field
-/// forces the corresponding surface off regardless of the config file.
+/// forces the corresponding surface off regardless of what the config
+/// file declares.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct FeatureOverrides {
     pub disable_registry: bool,
@@ -1004,13 +1009,16 @@ struct ConfigFile {
     /// pnpr-only local OSV database settings.
     #[serde(default)]
     osv: OsvFile,
-    /// pnpr-only feature toggles for the two server surfaces. Each is on
-    /// unless explicitly disabled; absent on a stock verdaccio config, so
-    /// both stay enabled there. `Option` so a bare `registry:` (which
-    /// YAML parses as null) is accepted as "default" rather than failing
-    /// to deserialize into the struct.
-    #[serde(default)]
-    registry: Option<FeatureFile>,
+    /// Removed key, rejected in any form (see
+    /// [`reject_removed_registry_key`]). The npm-registry surface is
+    /// derived from `mounts:` instead.
+    #[serde(default, rename = "registry", deserialize_with = "reject_removed_registry_key")]
+    _registry: Option<()>,
+    /// pnpr-only feature toggle for the resolver surface. On unless
+    /// explicitly disabled; absent on a stock verdaccio config, so it
+    /// stays enabled there. `Option` so a bare `resolver:` (which YAML
+    /// parses as null) is accepted as "default" rather than failing to
+    /// deserialize into the struct.
     #[serde(default)]
     resolver: Option<FeatureFile>,
     /// pnpr registry mounts: hosted, upstream, and router origins, each
@@ -1119,14 +1127,13 @@ struct OsvFile {
     path: Option<String>,
 }
 
-/// Disk shape of a `registry:` / `resolver:` feature block. A bare
-/// `enabled` today; per-surface sub-feature keys can be added later. The
-/// field and the whole-block defaults are both `enabled: true`, so
-/// omitting the block — or writing `registry:` with no body — keeps the
-/// surface on.
-/// `deny_unknown_fields` so a typo like `registry: { enable: false }`
+/// Disk shape of the `resolver:` feature block. A bare `enabled` today;
+/// sub-feature keys can be added later. The field and the whole-block
+/// defaults are both `enabled: true`, so omitting the block — or writing
+/// `resolver:` with no body — keeps the surface on.
+/// `deny_unknown_fields` so a typo like `resolver: { enable: false }`
 /// (note: `enable`, not `enabled`) is a loud config error rather than
-/// silently leaving the surface enabled — these toggles scope which
+/// silently leaving the surface enabled — the toggle scopes which
 /// endpoints are exposed, so a silent default-on is a security footgun.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1143,6 +1150,23 @@ impl Default for FeatureFile {
 
 fn default_true() -> bool {
     true
+}
+
+/// Reject the removed top-level `registry:` key in any form (a mapping,
+/// a scalar, or a bare `registry:` null). The parser is otherwise lenient
+/// about unknown keys (so a verdaccio config drops in untouched), but this
+/// one used to disable a surface: silently ignoring `registry: {enabled:
+/// false}` would serve the full npm-registry surface a config explicitly
+/// disclaimed — a fail-open — so it errors with migration guidance instead.
+fn reject_removed_registry_key<'de, De>(_deserializer: De) -> Result<Option<()>, De::Error>
+where
+    De: serde::Deserializer<'de>,
+{
+    Err(serde::de::Error::custom(
+        "the `registry:` key has been removed: the npm-registry surface is served \
+         iff at least one mount is declared under `mounts:`; delete the `registry:` \
+         block (use `--disable-registry` for a per-tier override)",
+    ))
 }
 
 /// The package-name patterns that [`Config::proxy`] routes to its flat-root
@@ -1497,13 +1521,13 @@ impl Config {
         let groups = build_groups(&file.groups);
         let policies = build_policies(&file.packages)?;
         let osv = build_osv_config(&file.osv, base_dir);
-        // Effective enablement folds the CLI overrides in here, so the
-        // registry-only work below (uplink resolution) is skipped whether
-        // the surface was disabled in the config file or on the command
-        // line.
-        let registry = RegistryFeature {
-            enabled: file.registry.unwrap_or_default().enabled && !overrides.disable_registry,
-        };
+        // The npm-registry surface is derived, not configured: served iff
+        // at least one mount is declared (no mounts ⇒ nothing to serve),
+        // minus the per-tier `--disable-registry` override. Folding the
+        // override in here lets the registry-only work below (uplink
+        // credential resolution) key off effective enablement.
+        let registry =
+            RegistryFeature { enabled: !file.mounts.is_empty() && !overrides.disable_registry };
         let resolver = ResolverFeature {
             enabled: file.resolver.unwrap_or_default().enabled && !overrides.disable_resolver,
         };
@@ -1546,15 +1570,19 @@ impl Config {
         Ok(config)
     }
 
-    /// At least one top-level surface must be served; a server with both
-    /// `registry` and `resolver` disabled would answer only `/-/ping`.
-    /// Checked at config load and again after CLI overrides.
+    /// At least one top-level surface must be served; a server with no
+    /// registry surface (no mounts declared, or `--disable-registry`) and
+    /// the resolver disabled would answer only `/-/ping` and the account
+    /// endpoints. Checked at config load and again in the serve/router
+    /// entry points for programmatically built configs.
     pub fn ensure_a_feature_is_enabled(&self) -> Result<(), RegistryError> {
         if self.registry.enabled || self.resolver.enabled {
             Ok(())
         } else {
             Err(RegistryError::InvalidConfig {
-                reason: "at least one of `registry` or `resolver` must be enabled".to_string(),
+                reason: "nothing to serve: the npm-registry surface is off (no `mounts:` \
+                         declared, or `--disable-registry`) and the resolver is disabled"
+                    .to_string(),
             })
         }
     }

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -266,7 +266,7 @@ fn removed_registry_key_is_rejected_in_any_form() {
         assert!(matches!(err, RegistryError::InvalidConfig { .. }));
         assert!(
             err.to_string().contains("`registry:` key has been removed"),
-            "for {yaml:?}: {err}"
+            "for {yaml:?}: {err}",
         );
     }
 }

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -254,24 +254,6 @@ fn resolver_block_present_but_empty_defaults_to_enabled() {
 }
 
 #[test]
-fn removed_registry_key_is_rejected_in_any_form() {
-    // `registry: {enabled: false}` used to disable the surface. The parser
-    // is lenient about unknown keys (verdaccio compat), but silently
-    // ignoring this one would fail open — mounts would serve a registry the
-    // config explicitly disclaimed — so any `registry:` key must be a loud
-    // config error with migration guidance.
-    for yaml in ["registry:\n  enabled: false\n", "registry:\n", "registry: {}\n"] {
-        let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
-            .expect_err("the removed `registry:` key must be rejected");
-        assert!(matches!(err, RegistryError::InvalidConfig { .. }));
-        assert!(
-            err.to_string().contains("`registry:` key has been removed"),
-            "for {yaml:?}: {err}",
-        );
-    }
-}
-
-#[test]
 fn cli_disabling_both_surfaces_with_bundled_config_errors_without_panicking() {
     // No config file → the bundled branch. Disabling both surfaces via
     // CLI must surface a clean error, not panic on the bundled `expect`.

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -227,43 +227,48 @@ mounts:
 }
 
 #[test]
-fn features_default_to_enabled_when_absent() {
+fn registry_surface_is_derived_from_declared_mounts() {
+    // No mounts ⇒ nothing to serve on the npm-registry surface; declaring
+    // one turns the surface on. There is no YAML toggle in between.
     let config = Config::from_yaml_str("{}", Path::new("/x"), listen(), None).unwrap();
-    assert!(config.registry.enabled);
+    assert!(!config.registry.enabled);
     assert!(config.resolver.enabled);
-}
 
-#[test]
-fn feature_blocks_present_but_empty_default_to_enabled() {
-    // A bare `registry:` parses as YAML null and `resolver: {}` as an
-    // empty map; both must mean "enabled", not fail to deserialize.
-    let yaml = "registry:\nresolver: {}\n";
-    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    assert!(config.registry.enabled);
-    assert!(config.resolver.enabled);
-}
-
-#[test]
-fn resolver_only_skips_uplink_resolution() {
-    // With the registry disabled, an uplink whose auth token can't be
-    // resolved must not fail config load — no registry route uses uplinks,
-    // so a resolver-only tier shouldn't need upstream secrets.
-    let yaml = r"
-registry:
-  enabled: false
-uplinks:
-  npmjs:
-    url: https://registry.npmjs.org/
-    auth:
-      type: bearer
-      token_env: PNPR_DEFINITELY_UNSET_TOKEN_VAR
-packages:
-  '**':
-    proxy: npmjs
+    let yaml = "
+mounts:
+  npmjs: { type: upstream, url: https://registry.npmjs.org/, public: true }
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    assert!(!config.registry.enabled);
-    assert!(config.uplinks.is_empty());
+    assert!(config.registry.enabled);
+    assert!(config.resolver.enabled);
+}
+
+#[test]
+fn resolver_block_present_but_empty_defaults_to_enabled() {
+    // A bare `resolver:` parses as YAML null and `resolver: {}` as an
+    // empty map; both must mean "enabled", not fail to deserialize.
+    for yaml in ["resolver:\n", "resolver: {}\n"] {
+        let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+        assert!(config.resolver.enabled, "for {yaml:?}");
+    }
+}
+
+#[test]
+fn removed_registry_key_is_rejected_in_any_form() {
+    // `registry: {enabled: false}` used to disable the surface. The parser
+    // is lenient about unknown keys (verdaccio compat), but silently
+    // ignoring this one would fail open — mounts would serve a registry the
+    // config explicitly disclaimed — so any `registry:` key must be a loud
+    // config error with migration guidance.
+    for yaml in ["registry:\n  enabled: false\n", "registry:\n", "registry: {}\n"] {
+        let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
+            .expect_err("the removed `registry:` key must be rejected");
+        assert!(matches!(err, RegistryError::InvalidConfig { .. }));
+        assert!(
+            err.to_string().contains("`registry:` key has been removed"),
+            "for {yaml:?}: {err}"
+        );
+    }
 }
 
 #[test]
@@ -277,64 +282,37 @@ fn cli_disabling_both_surfaces_with_bundled_config_errors_without_panicking() {
 }
 
 #[test]
-fn cli_disable_registry_skips_uplink_resolution() {
-    // The config file enables the registry, but `--disable-registry`
-    // (a CLI override) turns it off. Uplink resolution must be skipped
-    // based on the *effective* enablement, so an unresolvable auth token
-    // doesn't fail startup of a resolver-only tier driven by the flag.
-    let yaml = r"
-uplinks:
-  npmjs:
-    url: https://registry.npmjs.org/
-    auth:
-      type: bearer
-      token_env: PNPR_DEFINITELY_UNSET_TOKEN_VAR
-packages:
-  '**':
-    proxy: npmjs
-";
-    let overrides = FeatureOverrides { disable_registry: true, disable_resolver: false };
-    let config =
-        Config::from_yaml_str_with_overrides(yaml, Path::new("/x"), listen(), None, overrides)
-            .expect("a CLI-disabled registry must skip strict uplink resolution");
-    assert!(!config.registry.enabled);
-    assert!(config.uplinks.is_empty());
-}
-
-#[test]
 fn unknown_key_in_feature_block_is_a_config_error() {
     // A typo'd `enable` (vs `enabled`) must fail loudly rather than
     // silently leaving the surface enabled.
-    let yaml = "registry:\n  enable: false\n";
+    let yaml = "resolver:\n  enable: false\n";
     let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
         .expect_err("an unknown key in a feature block must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
 }
 
 #[test]
-fn from_yaml_str_parses_feature_toggles() {
-    let yaml = r"
-registry:
-  enabled: false
+fn from_yaml_str_parses_the_resolver_toggle() {
+    let yaml = "
+mounts:
+  npmjs: { type: upstream, url: https://registry.npmjs.org/, public: true }
 resolver:
-  enabled: true
+  enabled: false
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    assert!(!config.registry.enabled);
-    assert!(config.resolver.enabled);
+    assert!(config.registry.enabled);
+    assert!(!config.resolver.enabled);
 }
 
 #[test]
-fn disabling_both_features_is_a_config_error() {
-    let yaml = r"
-registry:
-  enabled: false
-resolver:
-  enabled: false
-";
+fn nothing_to_serve_is_a_config_error() {
+    // No mounts (⇒ no registry surface) and the resolver disabled leaves
+    // only `/-/ping` and the account endpoints — a misconfiguration.
+    let yaml = "resolver:\n  enabled: false\n";
     let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
         .expect_err("a server with neither surface enabled must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
+    assert!(err.to_string().contains("nothing to serve"), "unexpected error: {err}");
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -53,8 +53,8 @@ struct Args {
     osv_db: Option<PathBuf>,
 
     /// Disable the npm-registry surface (packument/tarball reads, publish,
-    /// unpublish, dist-tag, search, and the user/login endpoints).
-    /// Overrides `registry.enabled` from the loaded config.
+    /// unpublish, dist-tag, search) on this tier. Without the flag the
+    /// surface is served whenever the loaded config declares `mounts:`.
     #[arg(long)]
     disable_registry: bool,
 

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -54,7 +54,8 @@ struct Args {
 
     /// Disable the npm-registry surface (packument/tarball reads, publish,
     /// unpublish, dist-tag, search) on this tier. Without the flag the
-    /// surface is served whenever the loaded config declares `mounts:`.
+    /// surface is served whenever the loaded config declares at least one
+    /// mount under `mounts:`.
     #[arg(long)]
     disable_registry: bool,
 

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -981,8 +981,10 @@ async fn delete_seven_segments(
 // Account routes — adduser/login, whoami, profile, token list and
 // revocation, logout. Mounted on every tier (see the router construction
 // in `router_with_auth_and_osv`). Each has a `/~<prefix>/`-addressed twin
-// whose `/{prefix}/...` route pattern also matches a non-`~` first segment;
-// that shape is not an account URL and 404s.
+// whose `/{prefix}/...` route pattern also matches a non-`~` first
+// segment; that shape is not an account URL, so the handler 404s it —
+// though route-level layers still run first (an oversized body to a
+// non-`~` login path is the body cap's 413, not a 404).
 // --------------------------------------------------------------------
 
 /// Whether `prefix` is a `/~<prefix>/`-style first segment — the only

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -426,7 +426,7 @@ fn router_with_auth_and_osv(
                         target: "pnpr::access",
                         "request",
                         method = %request.method(),
-                        uri = %request.uri(),
+                        uri = %loggable_uri(request.uri()),
                         // Filled in by `record_cache_status` for packument
                         // reads (e.g. `cache=hit`); stays absent otherwise.
                         cache = tracing::field::Empty,
@@ -444,6 +444,23 @@ fn router_with_auth_and_osv(
                 .on_failure(()),
         )
         .with_state(state)
+}
+
+/// The request URI as recorded in the access log. npm's logout protocol
+/// (`DELETE .../-/user/token/{token}`, path-less or under a `/~<prefix>/`)
+/// puts the raw bearer token in the URL path, and a reusable credential
+/// must never reach a log line, so everything after that marker is
+/// redacted. Every other URI is logged verbatim; a false positive (a
+/// registry path that merely embeds the marker) is redacted too, which
+/// only costs log detail on a request no route serves.
+fn loggable_uri(uri: &axum::http::Uri) -> String {
+    const TOKEN_MARKER: &str = "/-/user/token/";
+    match uri.path().find(TOKEN_MARKER) {
+        Some(index) => {
+            format!("{}<redacted>", &uri.path()[..index + TOKEN_MARKER.len()])
+        }
+        None => uri.to_string(),
+    }
 }
 
 /// Bind to `config.listen` and serve forever. Loads auth state before

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -221,10 +221,10 @@ fn load_active_osv_index(
     }
 }
 
-/// Run startup side effects and load auth backends for surfaces that
-/// consult caller identity. The registry needs publish-journal recovery;
-/// both the registry and resolver need auth because resolver requests
-/// control outbound dependency-resolution work.
+/// Run startup side effects and load the auth backends. The registry
+/// needs publish-journal recovery; auth loads on every tier because the
+/// account endpoints (which mint and manage tokens) are always served,
+/// and both mounted surfaces consult caller identity.
 async fn load_startup_auth(config: &Config) -> crate::error::Result<AuthState> {
     if config.registry.enabled {
         crate::journal::recover_publish_journal(config).await?;
@@ -276,6 +276,33 @@ fn router_with_auth_and_osv(
     // so an operator can run resolver-only, registry-only, or both. The
     // config guarantees at least one is enabled.
     let mut router = Router::new().route("/-/ping", get(serve_ping));
+    // The account endpoints — adduser/login, whoami, profile, token
+    // listing/revocation, logout — are pnpr account management, not
+    // npm-registry functionality: they mint and manage the tokens every
+    // authenticated surface demands, so they ride every tier alongside
+    // `/-/ping`. A resolver-only tier can then issue its own credentials
+    // (`pnpm login --registry https://<resolver-host>/`) instead of
+    // depending on a registry-serving replica that shares the auth backend.
+    //
+    // Each endpoint also answers under any `/~<prefix>/`, so a client whose
+    // registry URL is a mount endpoint can log in against it. The identity
+    // endpoints are global and consult no mount state; a mount-table lookup
+    // would gate nothing while turning the 401-vs-404 split into an
+    // existence oracle for private mount names that the content handlers
+    // carefully mask.
+    router = router
+        .route("/-/whoami", get(get_whoami))
+        .route("/{prefix}/-/whoami", get(get_whoami_prefixed))
+        .route("/-/user/{user}", put(put_login))
+        .route("/{prefix}/-/user/{user}", put(put_login_prefixed))
+        .route("/-/user/token/{token}", delete(delete_session_token))
+        .route("/{prefix}/-/user/token/{token}", delete(delete_session_token_prefixed))
+        .route("/-/npm/v1/user", get(get_profile))
+        .route("/{prefix}/-/npm/v1/user", get(get_profile_prefixed))
+        .route("/-/npm/v1/tokens", get(get_token_list))
+        .route("/{prefix}/-/npm/v1/tokens", get(get_token_list_prefixed))
+        .route("/-/npm/v1/tokens/token/{key}", delete(delete_token_by_key))
+        .route("/{prefix}/-/npm/v1/tokens/token/{key}", delete(delete_token_by_key_prefixed));
     // The install-accelerator (resolver) surface, all under the reserved
     // `/-/pnpr` namespace. `/-/pnpr` is the capability handshake (404 on a
     // plain registry); `/-/pnpr/v0/resolve` and `/-/pnpr/v0/verify-lockfile`
@@ -312,9 +339,10 @@ fn router_with_auth_and_osv(
         router = router.route("/-/pnpr", any(resolver_disabled));
     }
     // The npm-registry surface: every packument/tarball read, publish,
-    // unpublish, dist-tag, search, and the user/login endpoint. When the
-    // feature is disabled, none of these routes are mounted — not merely
-    // hidden — so a resolver-only tier exposes no registry surface at all.
+    // unpublish, dist-tag, and search. When the surface is off (no mounts
+    // declared, or `--disable-registry`), none of these routes are mounted
+    // — not merely hidden — so a resolver-only tier exposes no registry
+    // surface at all.
     if registry_enabled {
         router = router
             // Batch publish: one request carrying many packages' publish
@@ -428,11 +456,12 @@ pub async fn serve(config: Config) -> crate::error::Result<()> {
     Ok(())
 }
 
-/// Log which surfaces are mounted at startup. A misconfiguration — most
-/// importantly a typo'd `registry:` / `resolver:` block name, which the
-/// intentionally verdaccio-lenient config parser silently ignores and so
-/// leaves the surface at its default-enabled state — is then immediately
-/// visible to the operator rather than only discoverable by probing.
+/// Log which surfaces are mounted at startup. A misconfiguration — a
+/// `mounts:` block that didn't parse the way the operator meant, or a
+/// typo'd `resolver:` block name, which the intentionally
+/// verdaccio-lenient config parser silently ignores and so leaves the
+/// surface at its default-enabled state — is then immediately visible to
+/// the operator rather than only discoverable by probing.
 fn log_enabled_surfaces(config: &Config) {
     tracing::info!(
         registry = config.registry.enabled,
@@ -552,9 +581,6 @@ async fn get_two_segments(
     headers: HeaderMap,
     Path((first, second)): Path<(String, String)>,
 ) -> Response {
-    if first == "-" && second == "whoami" {
-        return private_no_cache(serve_whoami(&identity));
-    }
     // `/~<mount>/<pkg>` — unscoped packument through a mount endpoint. The
     // tarball base is the client's `/~<mount>/` URL so the rewritten URLs stay
     // canonical for the registry the client actually addressed.
@@ -590,20 +616,10 @@ async fn get_three_segments(
         return private_no_cache(serve_search(&state, &identity, None, query).await);
     }
     if let Some(mount) = first.strip_prefix('~').filter(|mount| !mount.is_empty()) {
-        // `/~<mount>/-/whoami` — caller identity through a mount endpoint, so
-        // `npm whoami --registry .../~<mount>/` works like the path-less base.
-        //
-        // The identity endpoints (whoami here; adduser, logout, profile, and
-        // the token endpoints in their segment handlers) are global and serve
-        // no mount content, so they answer under *any* `/~<prefix>/` without
-        // consulting the mount table. A lookup would gate nothing — identity
-        // is server-wide — while turning the 401-vs-404 split into an
-        // existence oracle for private mount names that the content paths
-        // carefully mask.
+        // The account endpoints (whoami, adduser, logout, profile, tokens)
+        // live on dedicated always-mounted routes; a `/~<mount>/-/…` path
+        // that still reaches this handler names no mount content.
         if second == "-" {
-            if third == "whoami" {
-                return private_no_cache(serve_whoami(&identity));
-            }
             return not_found();
         }
         let base = uplink_tarball_base(&state.inner.config.public_url, mount);
@@ -659,9 +675,6 @@ async fn get_tarball_scoped(
 
 /// 4-segment GET:
 /// * `/-/package/{pkg}/dist-tags` — packument's `dist-tags` object.
-/// * `/-/npm/v1/user` — caller's profile (`npm profile get`).
-/// * `/-/npm/v1/tokens` — list bearer tokens for the caller
-///   (`npm token list`).
 /// * `/~<mount>/-/v1/search` — search through a mount endpoint.
 /// * `/~<mount>/@scope/{pkg}/{version}` — scoped version manifest through a
 ///   mount endpoint.
@@ -674,12 +687,6 @@ async fn get_four_segments(
     if a == "-" && b == "package" && d == "dist-tags" {
         let response = get_dist_tags(&state, &identity, None, &c).await;
         return private_if_caller_gated(&state, &c, response);
-    }
-    if a == "-" && b == "npm" && c == "v1" && d == "user" {
-        return private_no_cache(serve_profile(&identity));
-    }
-    if a == "-" && b == "npm" && c == "v1" && d == "tokens" {
-        return private_no_cache(list_tokens(&state, &identity).await);
     }
     if let Some(mount) = a.strip_prefix('~').filter(|mount| !mount.is_empty()) {
         if b == "-" && c == "v1" && d == "search" {
@@ -702,9 +709,6 @@ async fn get_four_segments(
 ///   endpoint.
 /// * `/~<mount>/-/package/<pkg>/dist-tags` — dist-tags through a mount
 ///   endpoint.
-/// * `/~<prefix>/-/npm/v1/user` and `/~<prefix>/-/npm/v1/tokens` — the
-///   global profile and token-list endpoints, served under any `~` prefix
-///   (identity endpoints skip the mount lookup — see [`get_three_segments`]).
 ///
 /// Every other 5-segment GET is a not-found catchall (the route exists so
 /// DELETE/PUT can sit on the same path).
@@ -722,12 +726,6 @@ async fn get_five_segments(
         }
         if b == "-" && c == "package" && e == "dist-tags" {
             return private_no_cache(get_dist_tags(&state, &identity, Some(mount), &d).await);
-        }
-        if b == "-" && c == "npm" && d == "v1" && e == "user" {
-            return private_no_cache(serve_profile(&identity));
-        }
-        if b == "-" && c == "npm" && d == "v1" && e == "tokens" {
-            return private_no_cache(list_tokens(&state, &identity).await);
         }
     }
     not_found()
@@ -768,7 +766,6 @@ async fn put_two_segments(
     not_found()
 }
 
-/// `PUT /-/user/org.couchdb.user:{name}` — adduser / login.
 /// `PUT /{pkg}/-rev/{rev}` — packument update (partial unpublish).
 async fn put_three_segments(
     State(state): State<AppState>,
@@ -776,14 +773,6 @@ async fn put_three_segments(
     Path((first, second, third)): Path<(String, String, String)>,
     body: axum::body::Bytes,
 ) -> Response {
-    if first == "-"
-        && second == "user"
-        && let Some(name) = third.strip_prefix("org.couchdb.user:")
-    {
-        // adduser/login authenticates from the request body, not the
-        // caller's existing identity.
-        return add_user(&state, name, &body).await;
-    }
     // `PUT /~<mount>/@scope/<pkg>` — publish a scoped package through a mount.
     if let Some(mount) = first.strip_prefix('~').filter(|mount| !mount.is_empty())
         && second.starts_with('@')
@@ -805,29 +794,17 @@ async fn put_three_segments(
 /// * `/~<mount>/{pkg}/-rev/{rev}` — packument update (partial unpublish)
 ///   through a mount endpoint. Scoped packages arrive percent-encoded as a
 ///   single `@scope%2Fname` segment, like the path-less 3-segment form.
-/// * `/~<prefix>/-/user/org.couchdb.user:{name}` — the global adduser/login,
-///   served under any `~` prefix so `pnpm login` against a mount-URL registry
-///   works (identity endpoints skip the mount lookup — see
-///   [`get_three_segments`]).
 async fn put_four_segments(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
     Path((a, b, c, d)): Path<(String, String, String, String)>,
     body: axum::body::Bytes,
 ) -> Response {
-    if let Some(mount) = a.strip_prefix('~').filter(|mount| !mount.is_empty()) {
-        if b == "-"
-            && c == "user"
-            && let Some(name) = d.strip_prefix("org.couchdb.user:")
-        {
-            // Like the path-less form, adduser/login authenticates from the
-            // request body, not the caller's existing identity.
-            return add_user(&state, name, &body).await;
-        }
-        if c == "-rev" {
-            let _ = d; // revision token is unused
-            return update_packument(&state, &identity, Some(mount), &b, &body).await;
-        }
+    if let Some(mount) = a.strip_prefix('~').filter(|mount| !mount.is_empty())
+        && c == "-rev"
+    {
+        let _ = d; // revision token is unused
+        return update_packument(&state, &identity, Some(mount), &b, &body).await;
     }
     not_found()
 }
@@ -880,9 +857,6 @@ async fn put_six_segments(
 }
 
 /// 4-segment DELETE:
-/// * `/-/user/token/{tok}` — npm logout. `{tok}` is the raw bearer token
-///   sent verbatim. We hash it and remove the matching row from the token
-///   store.
 /// * `/~<mount>/{pkg}/-rev/{rev}` — remove the entire package through a
 ///   mount endpoint (scoped packages arrive percent-encoded as one
 ///   `@scope%2Fname` segment).
@@ -891,9 +865,6 @@ async fn delete_four_segments(
     AuthedCaller(identity): AuthedCaller,
     Path((a, b, c, d)): Path<(String, String, String, String)>,
 ) -> Response {
-    if a == "-" && b == "user" && c == "token" {
-        return private_no_cache(logout(&state, &identity, &d).await);
-    }
     if let Some(mount) = a.strip_prefix('~').filter(|mount| !mount.is_empty())
         && c == "-rev"
     {
@@ -907,9 +878,6 @@ async fn delete_four_segments(
 /// * `/-/package/{pkg}/dist-tags/{tag}` — remove a dist-tag.
 /// * `/{pkg}/-/{filename}/-rev/{rev}` — remove an unscoped tarball
 ///   (one step of `pnpm unpublish <pkg>@<version>`).
-/// * `/~<prefix>/-/user/token/{tok}` — the global logout, served under any
-///   `~` prefix (identity endpoints skip the mount lookup — see
-///   [`get_three_segments`]).
 async fn delete_five_segments(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
@@ -917,13 +885,6 @@ async fn delete_five_segments(
 ) -> Response {
     if a == "-" && b == "package" && d == "dist-tags" {
         return remove_dist_tag(&state, &identity, None, &c, &e).await;
-    }
-    if a.strip_prefix('~').is_some_and(|mount| !mount.is_empty())
-        && b == "-"
-        && c == "user"
-        && d == "token"
-    {
-        return private_no_cache(logout(&state, &identity, &e).await);
     }
     if b == "-" && d == "-rev" {
         let _ = e; // revision token is unused
@@ -939,8 +900,6 @@ async fn delete_five_segments(
 ///   form (`http://host/@scope/name/-/name-1.0.0.tgz`), so the
 ///   request lands here unencoded rather than as a 5-seg
 ///   `@scope%2Fname` URL.
-/// * `/-/npm/v1/tokens/token/{key}` — revoke a bearer token by its
-///   listing-side `key` (`npm token revoke`).
 /// * `/~<mount>/-/package/{pkg}/dist-tags/{tag}` — remove a dist-tag
 ///   through a mount endpoint.
 /// * `/~<mount>/{pkg}/-/{filename}/-rev/{rev}` — remove an unscoped
@@ -950,9 +909,6 @@ async fn delete_six_segments(
     AuthedCaller(identity): AuthedCaller,
     Path((a, b, c, d, e, f)): Path<(String, String, String, String, String, String)>,
 ) -> Response {
-    if a == "-" && b == "npm" && c == "v1" && d == "tokens" && e == "token" {
-        return private_no_cache(revoke_token_by_key(&state, &identity, &f).await);
-    }
     if a.starts_with('@') && c == "-" && e == "-rev" {
         let _ = f; // revision token is unused
         let full = format!("{a}/{b}");
@@ -974,25 +930,143 @@ async fn delete_six_segments(
 /// * `/~<mount>/{scope}/{name}/-/{filename}/-rev/{rev}` — remove a scoped
 ///   tarball through a mount endpoint (the unencoded literal-slash form the
 ///   pnpm unpublish flow reconstructs from the packument's tarball URL).
-/// * `/~<prefix>/-/npm/v1/tokens/token/{key}` — the global token revocation,
-///   served under any `~` prefix (identity endpoints skip the mount lookup —
-///   see [`get_three_segments`]).
 async fn delete_seven_segments(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
     Path((a, b, c, d, e, f, g)): Path<(String, String, String, String, String, String, String)>,
 ) -> Response {
-    if let Some(mount) = a.strip_prefix('~').filter(|mount| !mount.is_empty()) {
-        if b == "-" && c == "npm" && d == "v1" && e == "tokens" && f == "token" {
-            return private_no_cache(revoke_token_by_key(&state, &identity, &g).await);
-        }
-        if b.starts_with('@') && d == "-" && f == "-rev" {
-            let _ = g; // revision token is unused
-            let full = format!("{b}/{c}");
-            return delete_tarball(&state, &identity, Some(mount), &full, &e).await;
-        }
+    if let Some(mount) = a.strip_prefix('~').filter(|mount| !mount.is_empty())
+        && b.starts_with('@')
+        && d == "-"
+        && f == "-rev"
+    {
+        let _ = g; // revision token is unused
+        let full = format!("{b}/{c}");
+        return delete_tarball(&state, &identity, Some(mount), &full, &e).await;
     }
     not_found()
+}
+
+// --------------------------------------------------------------------
+// Account routes — adduser/login, whoami, profile, token list and
+// revocation, logout. Mounted on every tier (see the router construction
+// in `router_with_auth_and_osv`). Each has a `/~<prefix>/`-addressed twin
+// whose `/{prefix}/…` route pattern also matches a non-`~` first segment;
+// that shape is not an account URL and 404s.
+// --------------------------------------------------------------------
+
+/// Whether `prefix` is a `/~<prefix>/`-style first segment — the only
+/// shape the prefixed account routes serve.
+fn is_tilde_prefix(prefix: &str) -> bool {
+    prefix.strip_prefix('~').is_some_and(|rest| !rest.is_empty())
+}
+
+async fn get_whoami(AuthedCaller(identity): AuthedCaller) -> Response {
+    private_no_cache(serve_whoami(&identity))
+}
+
+async fn get_whoami_prefixed(
+    AuthedCaller(identity): AuthedCaller,
+    Path(prefix): Path<String>,
+) -> Response {
+    if !is_tilde_prefix(&prefix) {
+        return not_found();
+    }
+    private_no_cache(serve_whoami(&identity))
+}
+
+/// `PUT /-/user/org.couchdb.user:{name}` — adduser / login. Authenticates
+/// from the request body, not the caller's existing identity.
+async fn put_login(
+    State(state): State<AppState>,
+    Path(user): Path<String>,
+    body: axum::body::Bytes,
+) -> Response {
+    match user.strip_prefix("org.couchdb.user:") {
+        Some(name) => add_user(&state, name, &body).await,
+        None => not_found(),
+    }
+}
+
+async fn put_login_prefixed(
+    State(state): State<AppState>,
+    Path((prefix, user)): Path<(String, String)>,
+    body: axum::body::Bytes,
+) -> Response {
+    if !is_tilde_prefix(&prefix) {
+        return not_found();
+    }
+    put_login(State(state), Path(user), body).await
+}
+
+async fn delete_session_token(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path(token): Path<String>,
+) -> Response {
+    private_no_cache(logout(&state, &identity, &token).await)
+}
+
+async fn delete_session_token_prefixed(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path((prefix, token)): Path<(String, String)>,
+) -> Response {
+    if !is_tilde_prefix(&prefix) {
+        return not_found();
+    }
+    private_no_cache(logout(&state, &identity, &token).await)
+}
+
+async fn get_profile(AuthedCaller(identity): AuthedCaller) -> Response {
+    private_no_cache(serve_profile(&identity))
+}
+
+async fn get_profile_prefixed(
+    AuthedCaller(identity): AuthedCaller,
+    Path(prefix): Path<String>,
+) -> Response {
+    if !is_tilde_prefix(&prefix) {
+        return not_found();
+    }
+    private_no_cache(serve_profile(&identity))
+}
+
+async fn get_token_list(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+) -> Response {
+    private_no_cache(list_tokens(&state, &identity).await)
+}
+
+async fn get_token_list_prefixed(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path(prefix): Path<String>,
+) -> Response {
+    if !is_tilde_prefix(&prefix) {
+        return not_found();
+    }
+    private_no_cache(list_tokens(&state, &identity).await)
+}
+
+async fn delete_token_by_key(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path(key): Path<String>,
+) -> Response {
+    private_no_cache(revoke_token_by_key(&state, &identity, &key).await)
+}
+
+async fn delete_token_by_key_prefixed(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path((prefix, key)): Path<(String, String)>,
+) -> Response {
+    if !is_tilde_prefix(&prefix) {
+        return not_found();
+    }
+    private_no_cache(revoke_token_by_key(&state, &identity, &key).await)
 }
 
 // --------------------------------------------------------------------

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -69,6 +69,13 @@ const MAX_TARBALL_BYTES: u64 = 100 * 1024 * 1024;
 /// route, so future write endpoints inherit the same ceiling.
 const MAX_PUBLISH_BODY_BYTES: usize = MAX_TARBALL_BYTES as usize;
 
+/// Cap adduser/login bodies far below the publish ceiling. The body is a
+/// small couchdb-user JSON document, and login is the one body-accepting
+/// endpoint reachable anonymously on every tier — letting it inherit the
+/// 100 MiB publish limit would hand unauthenticated callers a cheap
+/// buffer-and-parse amplifier.
+const MAX_LOGIN_BODY_BYTES: usize = 64 * 1024;
+
 #[derive(Clone)]
 struct AppState {
     inner: Arc<AppInner>,
@@ -293,8 +300,14 @@ fn router_with_auth_and_osv(
     router = router
         .route("/-/whoami", get(get_whoami))
         .route("/{prefix}/-/whoami", get(get_whoami_prefixed))
-        .route("/-/user/{user}", put(put_login))
-        .route("/{prefix}/-/user/{user}", put(put_login_prefixed))
+        .route(
+            "/-/user/{user}",
+            put(put_login).route_layer(DefaultBodyLimit::max(MAX_LOGIN_BODY_BYTES)),
+        )
+        .route(
+            "/{prefix}/-/user/{user}",
+            put(put_login_prefixed).route_layer(DefaultBodyLimit::max(MAX_LOGIN_BODY_BYTES)),
+        )
         .route("/-/user/token/{token}", delete(delete_session_token))
         .route("/{prefix}/-/user/token/{token}", delete(delete_session_token_prefixed))
         .route("/-/npm/v1/user", get(get_profile))

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -617,7 +617,7 @@ async fn get_three_segments(
     }
     if let Some(mount) = first.strip_prefix('~').filter(|mount| !mount.is_empty()) {
         // The account endpoints (whoami, adduser, logout, profile, tokens)
-        // live on dedicated always-mounted routes; a `/~<mount>/-/…` path
+        // live on dedicated always-mounted routes; a `/~<mount>/-/...` path
         // that still reaches this handler names no mount content.
         if second == "-" {
             return not_found();
@@ -951,7 +951,7 @@ async fn delete_seven_segments(
 // Account routes — adduser/login, whoami, profile, token list and
 // revocation, logout. Mounted on every tier (see the router construction
 // in `router_with_auth_and_osv`). Each has a `/~<prefix>/`-addressed twin
-// whose `/{prefix}/…` route pattern also matches a non-`~` first segment;
+// whose `/{prefix}/...` route pattern also matches a non-`~` first segment;
 // that shape is not an account URL and 404s.
 // --------------------------------------------------------------------
 

--- a/pnpr/crates/pnpr/src/server/tests.rs
+++ b/pnpr/crates/pnpr/src/server/tests.rs
@@ -319,3 +319,16 @@ async fn forwarded_header_cannot_satisfy_a_cidr_restriction() {
     };
     assert_eq!(status(app, request).await, StatusCode::FORBIDDEN);
 }
+
+#[test]
+fn access_log_uri_redacts_the_logout_token_segment() {
+    let redact = |raw: &str| super::loggable_uri(&raw.parse().unwrap());
+    assert_eq!(redact("/-/user/token/npm_secret-token-value"), "/-/user/token/<redacted>");
+    assert_eq!(
+        redact("/~corp/-/user/token/npm_secret-token-value"),
+        "/~corp/-/user/token/<redacted>",
+    );
+    // Everything else is logged verbatim, query string included.
+    assert_eq!(redact("/foo/-/foo-1.0.0.tgz"), "/foo/-/foo-1.0.0.tgz");
+    assert_eq!(redact("/-/v1/search?text=foo"), "/-/v1/search?text=foo");
+}

--- a/pnpr/crates/pnpr/tests/auth_user_endpoints.rs
+++ b/pnpr/crates/pnpr/tests/auth_user_endpoints.rs
@@ -154,6 +154,19 @@ async fn adduser_issues_token_for_canonical_username() {
 }
 
 #[tokio::test]
+async fn oversized_login_body_is_rejected() {
+    // Login is the one body-accepting endpoint reachable anonymously on
+    // every tier, so it carries its own body cap (64 KiB) instead of
+    // inheriting the 100 MiB publish ceiling.
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+
+    let body = adduser_body("alice", &"x".repeat(65 * 1024));
+    let response = app.oneshot(put_json("/-/user/org.couchdb.user:alice", body)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
 async fn whoami_returns_401_when_unauthenticated() {
     let tmp = TempDir::new().unwrap();
     let app = router(static_config(tmp.path().to_path_buf()));

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -2498,7 +2498,16 @@ async fn resolver_only_serves_resolver_endpoints_and_refuses_registry_routes() {
         .unwrap();
     assert_eq!(logged_in.status(), StatusCode::CREATED);
     let token = body_json(logged_in.into_body()).await["token"].as_str().unwrap().to_string();
-    for path in ["/-/whoami", "/-/npm/v1/user", "/-/npm/v1/tokens"] {
+    // The `/~<prefix>/`-addressed twins answer too — they must not depend on
+    // the (absent) registry segment routes.
+    for path in [
+        "/-/whoami",
+        "/-/npm/v1/user",
+        "/-/npm/v1/tokens",
+        "/~corp/-/whoami",
+        "/~corp/-/npm/v1/user",
+        "/~corp/-/npm/v1/tokens",
+    ] {
         let response = app
             .clone()
             .oneshot(
@@ -2511,6 +2520,17 @@ async fn resolver_only_serves_resolver_endpoints_and_refuses_registry_routes() {
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK, "GET {path}");
     }
+    let prefixed_login = app
+        .clone()
+        .oneshot(
+            Request::put("/~corp/-/user/org.couchdb.user:alice")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&registration).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(prefixed_login.status(), StatusCode::CREATED);
 
     // The minted token authenticates against the resolver surface itself.
     let verify = app

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -2434,6 +2434,7 @@ async fn resolver_only_serves_resolver_endpoints_and_refuses_registry_routes() {
     let tmp = TempDir::new().unwrap();
     let mut config = config_for("http://upstream.invalid", tmp.path().to_path_buf());
     config.registry.enabled = false;
+    config.auth.htpasswd.max_users = MaxUsers::Unlimited;
     let app = router(config);
 
     // The resolver surface stays reachable. `/-/ping` and the capability
@@ -2472,6 +2473,58 @@ async fn resolver_only_serves_resolver_endpoints_and_refuses_registry_routes() {
         .await
         .unwrap();
     assert_eq!(batch_publish.status(), StatusCode::NOT_FOUND);
+
+    // The account endpoints ride every tier: a resolver-only tier mints and
+    // manages the tokens its own resolver surface demands, so `pnpm login
+    // --registry https://<resolver-host>/` works without a registry-serving
+    // replica that shares the auth backend.
+    let registration = json!({
+        "_id": "org.couchdb.user:alice",
+        "name": "alice",
+        "password": "secret",
+        "email": "alice@example.test",
+        "type": "user",
+        "roles": [],
+    });
+    let logged_in = app
+        .clone()
+        .oneshot(
+            Request::put("/-/user/org.couchdb.user:alice")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&registration).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(logged_in.status(), StatusCode::CREATED);
+    let token = body_json(logged_in.into_body()).await["token"].as_str().unwrap().to_string();
+    for path in ["/-/whoami", "/-/npm/v1/user", "/-/npm/v1/tokens"] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get(path)
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "GET {path}");
+    }
+
+    // The minted token authenticates against the resolver surface itself.
+    let verify = app
+        .clone()
+        .oneshot(
+            Request::post("/-/pnpr/v0/verify-lockfile")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(verify.status(), StatusCode::UNAUTHORIZED);
+    assert_ne!(verify.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#12767.

Removes pnpr's top-level `registry:` config key and derives the npm-registry surface from declared structure instead: the surface is served **iff at least one mount is declared under `mounts:`**, minus the per-tier `--disable-registry` override. The `resolver:` toggle stays — it is the only expression of a genuinely non-derivable operator choice and duplicates nothing. A leftover `registry:` key in a config is simply ignored like any other unknown key (pnpr is pre-1.0; no compatibility shim).

- **Account endpoints move out of the registry surface.** adduser/login, whoami, profile, token listing/revocation, and logout now live on dedicated routes mounted on every tier (path-less and under any `/~<prefix>/`), so a resolver-only tier mints and manages the tokens its own resolver surface demands: `pnpm login --registry https://<resolver-host>/` works without a registry-serving replica sharing the auth backend. No new exposure — minting stays gated by `auth.htpasswd.max_users` and existing-user passwords, and token validation already ran on every tier.
- **The startup check becomes "nothing to serve":** no mounts (or registry disabled by flag) and the resolver disabled is a config error. The mount graph is still built and validated on every tier, and a flag-disabled registry still skips strict upstream-credential resolution.

Verified end-to-end: a no-mounts config starts a resolver-only tier (`registry=false resolver=true`), serves `/-/ping`, the `/-/pnpr` handshake, login/whoami/token-list (also under `/~corp/`), and 404s packument reads; a mounts config derives `registry=true` and `--disable-registry` overrides it; a stale `registry: {enabled: false}` next to mounts is ignored and derivation wins; the nothing-to-serve config fails startup with a precise error.

Docs follow-up (pnpm.io): pnpr `configuration.md` (drop the `registry:` section), `endpoints.md` (move the user/token endpoint table out of the registry-gated group), `cli.md` (`--disable-registry` wording), and the install-acceleration login note.

Review follow-ups (`ac932a09ab`, `9efb0503ba`): the anonymous-reachable adduser/login route now carries its own 64 KiB body cap instead of inheriting the 100 MiB publish ceiling, and the access log redacts the raw bearer token that npm's logout protocol places in the URL path (`uri=/-/user/token/<redacted>`).

## Squash Commit Body

```text
The top-level `registry:` config key duplicated information the config
already carries and could contradict it: `mounts:` together with
`registry: {enabled: false}` declared structure and then disclaimed it.
The npm-registry surface is now served iff at least one mount is
declared under `mounts:`, minus the per-tier `--disable-registry`
override. The `registry:` key is gone; a leftover one is ignored like
any other unknown key by the verdaccio-lenient parser. The `resolver:`
toggle stays: it is the only expression of a genuinely non-derivable
operator choice and duplicates nothing.

The account endpoints (adduser/login, whoami, profile, token listing
and revocation, logout) move out of the registry surface onto
dedicated always-mounted routes: they are pnpr account management, not
package-registry functionality, and a resolver-only tier must be able
to mint the tokens its own resolver surface demands
(`pnpm login --registry https://<resolver-host>/`).

The at-least-one-surface startup check becomes a nothing-to-serve
error: no mounts (or the registry disabled by flag) and the resolver
disabled. The mount graph is still built and validated on every tier,
and a registry surface disabled by flag still skips strict upstream
credential resolution.

Closes pnpm/pnpm#12767
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. *(pnpr-only server change; no pnpm/pacquet counterpart exists.)*
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. *(pnpm.io pnpr docs listed above need a follow-up PR in the pnpm.io repo once this lands.)*

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account and token-related endpoints are now consistently available on every tier, with login requests capped to prevent oversized payloads.
* **Bug Fixes**
  * npm-registry surface availability is derived from declared `mounts`; `--disable-registry` forces it off, with improved “nothing to serve” validation when resolver/registry can’t run.
  * HTTP access logs now redact logout token segments to avoid leaking bearer tokens.
* **Documentation**
  * Updated configuration comments and `--disable-registry` CLI help to clarify mounts vs resolver/registry behavior.
* **Tests**
  * Added oversized login-body rejection coverage and expanded authenticated endpoint/token-flow verification; added unit coverage for access-log redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
