### PR TITLE
fix(pack): compute packed summary before postpack cleanup

### DIFF
--- a/.changeset/forty-emus-run.md
+++ b/.changeset/forty-emus-run.md
@@ -1,5 +1,5 @@
 ---
 "@pnpm/releasing.commands": patch
+"pnpm": patch
 ---
-
 Fixed pnpm pack and pnpm publish failing when prepack generates files that are included in the package and postpack cleans them up.

--- a/.changeset/forty-emus-run.md
+++ b/.changeset/forty-emus-run.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/releasing.commands": patch
+---
+
+Fixed pnpm pack and pnpm publish failing when prepack generates files that are included in the package and postpack cleans them up.

--- a/.changeset/spicy-lions-guard.md
+++ b/.changeset/spicy-lions-guard.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+`pnpm pack` and `pnpm publish` no longer follow a symlinked workspace `LICENSE` file when injecting it into a package that has no license of its own. Following the symlink could pack bytes from outside the workspace into the published tarball.

--- a/pacquet/crates/pack/src/lib.rs
+++ b/pacquet/crates/pack/src/lib.rs
@@ -291,14 +291,19 @@ where
         .into_bytes();
 
     let dest_dir = resolve_dest_dir(&dir, pack_destination.as_deref());
-    let unpacked_size = unpacked_size::<Sys>(&files_map, manifest_json.len() as u64)?;
-    let contents = packed_contents(&files_map);
-
     if !opts.dry_run {
         Sys::create_dir_all(&dest_dir).map_err(|source| PackError::CreateDir {
             path: dest_dir.display().to_string(),
             source,
         })?;
+    }
+
+    // The size pass must run before `postpack`, which may delete
+    // prepack-generated files that were packed. See pnpm/pnpm#12775.
+    let unpacked_size = unpacked_size::<Sys>(&files_map, manifest_json.len() as u64)?;
+    let contents = packed_contents(&files_map);
+
+    if !opts.dry_run {
         let bins = executable_sources(&publish_manifest, &manifest, &dir);
         let dest_file = dest_dir.join(&tarball_name);
         Sys::atomic_write(&dest_file, &mut |writer| {

--- a/pacquet/crates/pack/src/lib.rs
+++ b/pacquet/crates/pack/src/lib.rs
@@ -291,6 +291,7 @@ where
         .into_bytes();
 
     let dest_dir = resolve_dest_dir(&dir, pack_destination.as_deref());
+
     if !opts.dry_run {
         Sys::create_dir_all(&dest_dir).map_err(|source| PackError::CreateDir {
             path: dest_dir.display().to_string(),

--- a/pacquet/crates/pack/src/lib.rs
+++ b/pacquet/crates/pack/src/lib.rs
@@ -291,6 +291,8 @@ where
         .into_bytes();
 
     let dest_dir = resolve_dest_dir(&dir, pack_destination.as_deref());
+    let unpacked_size = unpacked_size::<Sys>(&files_map, manifest_json.len() as u64)?;
+    let contents = packed_contents(&files_map);
 
     if !opts.dry_run {
         Sys::create_dir_all(&dest_dir).map_err(|source| PackError::CreateDir {
@@ -318,8 +320,6 @@ where
     }
 
     let tarball_path = packed_tarball_path(&opts.dir, &dir, &dest_dir, &tarball_name);
-    let unpacked_size = unpacked_size::<Sys>(&files_map, manifest_json.len() as u64)?;
-    let contents = packed_contents(&files_map);
 
     Ok(PackResult { published_manifest: publish_manifest, contents, tarball_path, unpacked_size })
 }

--- a/pacquet/crates/pack/src/tests.rs
+++ b/pacquet/crates/pack/src/tests.rs
@@ -478,6 +478,11 @@ fn runs_prepack_prepare_and_postpack() {
     assert!(dir.path().join("postpack.ran").exists(), "postpack should have run");
 }
 
+/// Regression test for <https://github.com/pnpm/pnpm/issues/12775>: the
+/// packed summary (`contents` / `unpacked_size`) is computed while
+/// prepack-generated files still exist on disk, so a `postpack` that
+/// cleans them up cannot fail the pack. Unix-gated like the other
+/// script-running tests, since it shells out through the platform shell.
 #[cfg(unix)]
 #[test]
 fn includes_prepack_generated_files_removed_by_postpack() {
@@ -499,6 +504,7 @@ fn includes_prepack_generated_files_removed_by_postpack() {
     assert!(!dir.path().join("generated.txt").exists(), "postpack should clean the generated file");
 
     let names = tarball_entry_names(&dir.path().join("foo-1.0.0.tgz"));
+    dbg!(&names);
     assert!(names.contains(&"package/generated.txt".to_string()));
 }
 

--- a/pacquet/crates/pack/src/tests.rs
+++ b/pacquet/crates/pack/src/tests.rs
@@ -478,6 +478,30 @@ fn runs_prepack_prepare_and_postpack() {
     assert!(dir.path().join("postpack.ran").exists(), "postpack should have run");
 }
 
+#[cfg(unix)]
+#[test]
+fn includes_prepack_generated_files_removed_by_postpack() {
+    let (dir, mut opts) = fixture(&json!({
+        "name": "foo",
+        "version": "1.0.0",
+        "files": ["generated.txt"],
+        "scripts": {
+            "prepack": "printf 'generated during prepack' > generated.txt",
+            "postpack": "rm -f generated.txt",
+        },
+    }));
+    opts.ignore_scripts = false;
+
+    let result = api::<SilentReporter, Host>(&opts).unwrap();
+
+    assert_eq!(result.contents, vec!["generated.txt".to_string(), "package.json".into()]);
+    assert!(dir.path().join("foo-1.0.0.tgz").is_file());
+    assert!(!dir.path().join("generated.txt").exists(), "postpack should clean the generated file");
+
+    let names = tarball_entry_names(&dir.path().join("foo-1.0.0.tgz"));
+    assert!(names.contains(&"package/generated.txt".to_string()));
+}
+
 /// With scripts enabled but the manifest declaring none of the
 /// requested lifecycle scripts (here an empty `prepack`), `script_body`
 /// yields `None` and `run_scripts_if_present` returns early, so packing

--- a/pnpm11/releasing/commands/src/publish/pack.ts
+++ b/pnpm11/releasing/commands/src/publish/pack.ts
@@ -280,6 +280,26 @@ export async function api (opts: PackOptions): Promise<PackResult> {
       filesMap[`package/${license}`] = path.join(opts.workspaceDir, license)
     }
   }
+  // Derive `contents` and `unpackedSize` from `filesMap` (the full set of tar entries) rather than
+  // from `files` (the packlist subset) so that:
+  //   - workspace LICENSE files appended to `filesMap` after the packlist call are included; and
+  //   - `package.yaml` / `package.json5` entries are reported under the name they actually have in
+  //     the tar (`package.json`), since `packPkg()` rewrites them.
+  const sizes = await Promise.all(Object.entries(filesMap).map(async ([name, source]) => {
+    if (/^package\/package\.(?:json|json5|yaml)$/.test(name)) {
+      return Buffer.byteLength(JSON.stringify(publishManifest, null, 2))
+    }
+    const stat = await fs.promises.stat(source)
+    return stat.size
+  }))
+  const unpackedSize = sizes.reduce((acc, size) => acc + size, 0)
+  const packedContents = Array.from(new Set(
+    Object.keys(filesMap).map((name) =>
+      /^package\/package\.(?:json|json5|yaml)$/.test(name)
+        ? 'package.json'
+        : name.replace(/^package\//, '')
+    )
+  )).sort((a, b) => a.localeCompare(b, 'en'))
   const destDir = packDestination
     ? (path.isAbsolute(packDestination) ? packDestination : path.join(dir, packDestination ?? '.'))
     : dir
@@ -307,26 +327,6 @@ export async function api (opts: PackOptions): Promise<PackResult> {
   } else {
     packedTarballPath = path.relative(opts.dir, path.join(dir, tarballName))
   }
-  // Derive `contents` and `unpackedSize` from `filesMap` (the full set of tar entries) rather than
-  // from `files` (the packlist subset) so that:
-  //   - workspace LICENSE files appended to `filesMap` after the packlist call are included; and
-  //   - `package.yaml` / `package.json5` entries are reported under the name they actually have in
-  //     the tar (`package.json`), since `packPkg()` rewrites them.
-  const sizes = await Promise.all(Object.entries(filesMap).map(async ([name, source]) => {
-    if (/^package\/package\.(?:json|json5|yaml)$/.test(name)) {
-      return Buffer.byteLength(JSON.stringify(publishManifest, null, 2))
-    }
-    const stat = await fs.promises.stat(source)
-    return stat.size
-  }))
-  const unpackedSize = sizes.reduce((acc, size) => acc + size, 0)
-  const packedContents = Array.from(new Set(
-    Object.keys(filesMap).map((name) =>
-      /^package\/package\.(?:json|json5|yaml)$/.test(name)
-        ? 'package.json'
-        : name.replace(/^package\//, '')
-    )
-  )).sort((a, b) => a.localeCompare(b, 'en'))
   return {
     publishedManifest: publishManifest,
     contents: packedContents,

--- a/pnpm11/releasing/commands/src/publish/pack.ts
+++ b/pnpm11/releasing/commands/src/publish/pack.ts
@@ -280,13 +280,21 @@ export async function api (opts: PackOptions): Promise<PackResult> {
       filesMap[`package/${license}`] = path.join(opts.workspaceDir, license)
     }
   }
+  const destDir = packDestination
+    ? (path.isAbsolute(packDestination) ? packDestination : path.join(dir, packDestination ?? '.'))
+    : dir
+  if (!opts.dryRun) {
+    await fs.promises.mkdir(destDir, { recursive: true })
+  }
   // Derive `contents` and `unpackedSize` from `filesMap` (the full set of tar entries) rather than
   // from `files` (the packlist subset) so that:
   //   - workspace LICENSE files appended to `filesMap` after the packlist call are included; and
   //   - `package.yaml` / `package.json5` entries are reported under the name they actually have in
   //     the tar (`package.json`), since `packPkg()` rewrites them.
+  // The `stat()` pass must run before `postpack`, which may delete prepack-generated files that
+  // were packed. See https://github.com/pnpm/pnpm/issues/12775.
   const sizes = await Promise.all(Object.entries(filesMap).map(async ([name, source]) => {
-    if (/^package\/package\.(?:json|json5|yaml)$/.test(name)) {
+    if (isManifestEntry(name)) {
       return Buffer.byteLength(JSON.stringify(publishManifest, null, 2))
     }
     const stat = await fs.promises.stat(source)
@@ -295,16 +303,12 @@ export async function api (opts: PackOptions): Promise<PackResult> {
   const unpackedSize = sizes.reduce((acc, size) => acc + size, 0)
   const packedContents = Array.from(new Set(
     Object.keys(filesMap).map((name) =>
-      /^package\/package\.(?:json|json5|yaml)$/.test(name)
+      isManifestEntry(name)
         ? 'package.json'
         : name.replace(/^package\//, '')
     )
   )).sort((a, b) => a.localeCompare(b, 'en'))
-  const destDir = packDestination
-    ? (path.isAbsolute(packDestination) ? packDestination : path.join(dir, packDestination ?? '.'))
-    : dir
   if (!opts.dryRun) {
-    await fs.promises.mkdir(destDir, { recursive: true })
     await packPkg({
       destFile: path.join(destDir, tarballName),
       filesMap,
@@ -343,6 +347,13 @@ export interface PackResult {
   unpackedSize: number
 }
 
+// True when a `package/<path>` tar key names the package manifest, which is
+// packed as a single serialized `package/package.json` entry and reported as
+// `package.json` in the contents listing regardless of the source file name.
+function isManifestEntry (name: string): boolean {
+  return name === 'package/package.json' || name === 'package/package.json5' || name === 'package/package.yaml'
+}
+
 function stripBuildMetadata (version: string): string {
   const plusIndex = version.indexOf('+')
   return plusIndex === -1 ? version : version.slice(0, plusIndex)
@@ -379,7 +390,7 @@ async function packPkg (opts: {
   await Promise.all(Object.entries(filesMap).map(async ([name, source]) => {
     const isExecutable = bins.some((bin) => path.relative(bin, source) === '')
     const mode = isExecutable ? 0o755 : 0o644
-    if (/^package\/package\.(?:json|json5|yaml)$/.test(name)) {
+    if (isManifestEntry(name)) {
       pack.entry({ mode, mtime, name: 'package/package.json' }, JSON.stringify(manifest, null, 2))
       return
     }

--- a/pnpm11/releasing/commands/src/publish/pack.ts
+++ b/pnpm11/releasing/commands/src/publish/pack.ts
@@ -275,10 +275,18 @@ export async function api (opts: PackOptions): Promise<PackResult> {
   const filesMap = Object.fromEntries(files.map((file) => [`package/${file}`, path.join(dir, file)]))
   // cspell:disable-next-line
   if (opts.workspaceDir != null && dir !== opts.workspaceDir && !files.some((file) => /LICEN[CS]E(?:\..+)?/i.test(file))) {
-    const licenses = await glob([LICENSE_GLOB], { cwd: opts.workspaceDir, expandDirectories: false })
-    for (const license of licenses) {
-      filesMap[`package/${license}`] = path.join(opts.workspaceDir, license)
-    }
+    const { workspaceDir } = opts
+    const licenses = await glob([LICENSE_GLOB], { cwd: workspaceDir, expandDirectories: false })
+    await Promise.all(licenses.map(async (license) => {
+      const licensePath = path.join(workspaceDir, license)
+      // Only inject a regular file. A symlink could point outside the workspace and leak its
+      // target's bytes into the published tarball, so `lstat()` (which does not follow symlinks)
+      // rejects it — matching pacquet's inject_workspace_license.
+      const stats = await fs.promises.lstat(licensePath)
+      if (stats.isFile()) {
+        filesMap[`package/${license}`] = licensePath
+      }
+    }))
   }
   const destDir = packDestination
     ? (path.isAbsolute(packDestination) ? packDestination : path.join(dir, packDestination ?? '.'))

--- a/pnpm11/releasing/commands/test/publish/pack.ts
+++ b/pnpm11/releasing/commands/test/publish/pack.ts
@@ -367,6 +367,34 @@ test('pack: runs prepack, prepare, and postpack', async () => {
   expect(fs.existsSync('postpack')).toBeTruthy()
 })
 
+test('pack: includes prepack-generated files removed by postpack', async () => {
+  prepare({
+    name: 'prepack-generated-postpack-cleaned',
+    version: '0.0.0',
+    files: ['generated.txt'],
+    scripts: {
+      prepack: 'node -e "require(\'fs\').writeFileSync(\'generated.txt\', \'generated during prepack\')"',
+      postpack: 'node -e "require(\'fs\').rmSync(\'generated.txt\', { force: true })"',
+    },
+  })
+
+  const output = await pack.handler({
+    ...DEFAULT_OPTS,
+    argv: { original: [] },
+    dir: process.cwd(),
+    extraBinPaths: [],
+    packDestination: process.cwd(),
+  })
+
+  expect(output).toContain('generated.txt')
+  expect(fs.existsSync('prepack-generated-postpack-cleaned-0.0.0.tgz')).toBeTruthy()
+  expect(fs.existsSync('generated.txt')).toBeFalsy()
+
+  await tar.x({ file: 'prepack-generated-postpack-cleaned-0.0.0.tgz' })
+
+  expect(fs.existsSync('package/generated.txt')).toBeTruthy()
+})
+
 const modeIsExecutable = (mode: number) => (mode & 0o111) === 0o111
 
 ;(process.platform === 'win32' ? test.skip : test)('the mode of executable is changed', async () => {

--- a/pnpm11/releasing/commands/test/publish/pack.ts
+++ b/pnpm11/releasing/commands/test/publish/pack.ts
@@ -395,6 +395,38 @@ test('pack: includes prepack-generated files removed by postpack', async () => {
   expect(fs.existsSync('package/generated.txt')).toBeTruthy()
 })
 
+// A symlinked workspace-root LICENSE must not be injected: following it would
+// leak the target's bytes — potentially a file outside the workspace — into
+// the published tarball.
+;(process.platform === 'win32' ? test.skip : test)('pack: does not inject a symlinked workspace LICENSE', async () => {
+  preparePackages([
+    {
+      name: 'project',
+      version: '1.0.0',
+    },
+  ])
+
+  const workspaceDir = process.cwd()
+  writeYamlFileSync('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
+  fs.writeFileSync('secret.txt', 'host secret', 'utf8')
+  fs.symlinkSync(path.join(workspaceDir, 'secret.txt'), path.join(workspaceDir, 'LICENSE'))
+
+  process.chdir('project')
+  const output = await pack.handler({
+    ...DEFAULT_OPTS,
+    argv: { original: [] },
+    dir: process.cwd(),
+    extraBinPaths: [],
+    workspaceDir,
+  })
+
+  expect(output).not.toContain('LICENSE')
+
+  await tar.x({ file: 'project-1.0.0.tgz' })
+
+  expect(fs.existsSync('package/LICENSE')).toBeFalsy()
+})
+
 const modeIsExecutable = (mode: number) => (mode & 0o111) === 0o111
 
 ;(process.platform === 'win32' ? test.skip : test)('the mode of executable is changed', async () => {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Fixes a `pnpm pack` / `pnpm publish` regression where packages can fail if `prepack` generates a file that is included in the tarball and `postpack` removes it afterward.

pnpm was writing the tarball successfully, then running `postpack`, then computing the packed summary by calling `stat()` on source files. If `postpack` cleaned up a generated file, that summary step failed with `ENOENT`.

This PR computes `contents` and `unpackedSize` before `postpack` runs, while the packed source files still exist.

Fixes #12775


Review follow-ups pushed to this PR:

- The destination directory is now created before the packed-summary size pass in both stacks, so a failing destination does not pay the per-entry `stat()` cost.
- The manifest tar-entry check in the TypeScript CLI is extracted into a shared `isManifestEntry()` helper (mirroring pacquet's `is_manifest_entry`).
- Security fix (Qodo finding): the workspace `LICENSE` injection now only injects regular files. A symlinked workspace `LICENSE` could previously leak bytes from outside the workspace into the published tarball. pacquet already rejected symlinks; the TypeScript CLI now matches, with a regression test and changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm pack` and `pnpm publish` failing when `prepack` generates files that are later removed by `postpack`.
  * Improved alignment between the reported package `contents`/size and the actual tarball contents, ensuring lifecycle-generated files are tracked correctly.
* **Tests**
  * Added Unix-only tests to verify `prepack`-generated files are included in the CLI output and tarball, even when cleaned up by `postpack`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
