### PR TITLE
feat(pnpr): declare patterns on registries, reduce routers to ordered sources

### DIFF
--- a/pacquet/crates/cli/tests/pnpr_install.rs
+++ b/pacquet/crates/cli/tests/pnpr_install.rs
@@ -2,7 +2,7 @@
 //!
 //! Runs the real `pacquet` binary against a mocked fixtures registry,
 //! with an in-process `pnpr` hosting the fast-path endpoints. The pnpr
-//! server's own uplink is left at the default; the client sends the
+//! server's own upstream is left at the default; the client sends the
 //! registry it wants resolved from (the mock, which the server allowlists
 //! as a public route), so a passing test proves resolution used the
 //! client-supplied registry. The client then links `node_modules` from the

--- a/pacquet/crates/pnpr-client/src/lib.rs
+++ b/pacquet/crates/pnpr-client/src/lib.rs
@@ -13,8 +13,8 @@
 //!
 //! The resolver itself is stateless — it materializes no store and the
 //! `/resolve` endpoint persists no tarballs. Resolved tarballs are fetched
-//! from upstream public URLs or, for a private proxied route, an uplink's
-//! `/~<uplink>/` registry endpoint (which may cache them server-side under
+//! from upstream public URLs or, for a private proxied route, an upstream's
+//! `/~<name>/` registry endpoint (which may cache them server-side under
 //! its own private namespace).
 
 use std::collections::BTreeMap;

--- a/pacquet/crates/pnpr-client/tests/integration.rs
+++ b/pacquet/crates/pnpr-client/tests/integration.rs
@@ -5,13 +5,13 @@
 //! `/-/pnpr/v0/resolve` endpoints. The client sends the registry it wants
 //! resolved from (allowlisted on the server), proving resolution uses the
 //! client-supplied registry. Public routes keep their upstream tarball URLs;
-//! a private proxied route is returned as its uplink's `/~<uplink>/`
+//! a private proxied route is returned as its upstream's `/~<name>/`
 //! registry-endpoint URL.
 //!
 //! The client authenticates to pnpr with a bearer token but never
 //! forwards its own upstream registry credentials. Private upstream
 //! content resolves only when the pnpr server is configured with an
-//! access-bearing uplink the caller is authorized to use.
+//! access-bearing upstream the caller is authorized to use.
 
 use std::{
     collections::BTreeMap,
@@ -38,30 +38,30 @@ async fn start_pnpr(registry_url: &str) -> (String, String, TempDir) {
 }
 
 /// Like [`start_pnpr`] but registers operator-managed access-bearing
-/// uplinks, so the server can fetch private upstream content on behalf of
+/// upstreams, so the server can fetch private upstream content on behalf of
 /// an authorized caller without the client forwarding any credential. A
-/// uplink's origin is itself allowlisted, so no public route is needed.
-async fn start_pnpr_with_uplinks(
-    uplinks: Vec<(String, pnpr::UplinkConfig)>,
+/// upstream's origin is itself allowlisted, so no public route is needed.
+async fn start_pnpr_with_upstreams(
+    upstreams: Vec<(String, pnpr::UpstreamConfig)>,
 ) -> (String, String, TempDir) {
-    start_pnpr_inner(None, uplinks, Vec::new()).await
+    start_pnpr_inner(None, upstreams, Vec::new()).await
 }
 
-/// Like [`start_pnpr_with_uplinks`] but pins `public_url` so a lockfile
+/// Like [`start_pnpr_with_upstreams`] but pins `public_url` so a lockfile
 /// produced by one instance can be verified by another fresh instance: a
-/// `/~<uplink>/` endpoint URL is reversed to its upstream by matching the
+/// `/~<name>/` endpoint URL is reversed to its upstream by matching the
 /// verifying server's own `public_url`, which a real single-pnpr deployment
 /// shares across resolve and verify.
-async fn start_pnpr_with_uplinks_at(
+async fn start_pnpr_with_upstreams_at(
     public_url: &str,
-    uplinks: Vec<(String, pnpr::UplinkConfig)>,
+    upstreams: Vec<(String, pnpr::UpstreamConfig)>,
 ) -> (String, String, TempDir) {
-    start_pnpr_inner(Some(public_url.to_string()), uplinks, Vec::new()).await
+    start_pnpr_inner(Some(public_url.to_string()), upstreams, Vec::new()).await
 }
 
 async fn start_pnpr_inner(
     public_url: Option<String>,
-    uplinks: Vec<(String, pnpr::UplinkConfig)>,
+    upstreams: Vec<(String, pnpr::UpstreamConfig)>,
     public_registries: Vec<String>,
 ) -> (String, String, TempDir) {
     let storage = TempDir::new().expect("pnpr storage tempdir");
@@ -71,8 +71,8 @@ async fn start_pnpr_inner(
     let mut config = pnpr::Config::proxy(addr, storage.path().to_path_buf());
     config.public_url = public_url.unwrap_or_else(|| format!("http://{addr}"));
     config.auth.htpasswd.max_users = pnpr::MaxUsers::Unlimited;
-    for (name, uplink) in uplinks {
-        config.uplinks.insert(name, uplink);
+    for (name, upstream) in upstreams {
+        config.upstreams.insert(name, upstream);
     }
     for registry in public_registries {
         config
@@ -91,9 +91,9 @@ async fn start_pnpr_inner(
     (base_url, format!("Bearer {token}"), storage)
 }
 
-/// An access-bearing uplink that serves `registry_url` with `token`, usable
+/// An access-bearing upstream that serves `registry_url` with `token`, usable
 /// by any authenticated pnpr caller (exposed at `/~test-registry/`).
-fn registry_uplink(registry_url: &str, token: &str) -> (String, pnpr::UplinkConfig) {
+fn registry_upstream(registry_url: &str, token: &str) -> (String, pnpr::UpstreamConfig) {
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert(
         reqwest::header::AUTHORIZATION,
@@ -102,13 +102,13 @@ fn registry_uplink(registry_url: &str, token: &str) -> (String, pnpr::UplinkConf
     );
     (
         "test-registry".to_string(),
-        pnpr::UplinkConfig {
+        pnpr::UpstreamConfig {
             url: registry_url.to_string(),
             headers,
             maxage: None,
-            timeout: pnpr::UplinkConfig::DEFAULT_TIMEOUT,
-            max_fails: pnpr::UplinkConfig::DEFAULT_MAX_FAILS,
-            fail_timeout: pnpr::UplinkConfig::DEFAULT_FAIL_TIMEOUT,
+            timeout: pnpr::UpstreamConfig::DEFAULT_TIMEOUT,
+            max_fails: pnpr::UpstreamConfig::DEFAULT_MAX_FAILS,
+            fail_timeout: pnpr::UpstreamConfig::DEFAULT_FAIL_TIMEOUT,
             cache: true,
             access: Some(pnpr::AccessList::parse("$authenticated")),
         },
@@ -168,7 +168,7 @@ fn deps<const COUNT: usize>(entries: [(&str, &str); COUNT]) -> BTreeMap<String, 
 
 /// Register a user with an npm-compatible registry and return its bearer
 /// token. The pnpr fixture authenticates its own caller with this token;
-/// an access-bearing uplink uses one as its server-side credential.
+/// an access-bearing upstream uses one as its server-side credential.
 async fn register_token(registry_url: &str, username: &str) -> String {
     let body = serde_json::json!({ "name": username, "password": "password123" });
     let response = reqwest::Client::new()
@@ -240,19 +240,19 @@ async fn sends_the_identity_header_but_no_upstream_credentials() {
 /// End-to-end: the test registry gates `@pnpm.e2e/needs-auth` behind
 /// `$authenticated`. The client never forwards its own credentials, so
 /// resolving it works only when the pnpr server is configured with an
-/// uplink for that registry that the caller is
+/// upstream for that registry that the caller is
 /// authorized to use.
 #[tokio::test]
-async fn an_uplink_resolves_a_private_package() {
+async fn an_upstream_resolves_a_private_package() {
     let registry = TestRegistry::start();
     let token = register_token(&registry.url(), "needs-auth-forwarder").await;
     let (pnpr_url, pnpr_auth, _storage) =
-        start_pnpr_with_uplinks(vec![registry_uplink(&registry.url(), &token)]).await;
+        start_pnpr_with_upstreams(vec![registry_upstream(&registry.url(), &token)]).await;
 
     let client = PnprClient::new(pnpr_url);
 
     let opts = options(&registry.url(), &pnpr_auth, deps([("@pnpm.e2e/needs-auth", "1.0.0")]));
-    let outcome = client.resolve(opts).await.expect("the uplink should resolve it");
+    let outcome = client.resolve(opts).await.expect("the upstream should resolve it");
     let packages = outcome.lockfile.packages.as_ref().expect("lockfile has packages");
     assert!(
         packages.keys().any(|key| key.to_string().starts_with("@pnpm.e2e/needs-auth@1.0.0")),
@@ -261,12 +261,12 @@ async fn an_uplink_resolves_a_private_package() {
     );
 }
 
-/// The same install against a server with no matching uplink
+/// The same install against a server with no matching upstream
 /// fails: the client forwards no credential and pnpr has none to select,
 /// so the gated packument can only be fetched anonymously — which the
 /// registry refuses.
 #[tokio::test]
-async fn a_private_package_fails_without_an_uplink() {
+async fn a_private_package_fails_without_an_upstream() {
     let registry = TestRegistry::start();
     let (pnpr_url, pnpr_auth, _storage) = start_pnpr(&registry.url()).await;
 
@@ -276,7 +276,7 @@ async fn a_private_package_fails_without_an_uplink() {
     let Err(PnprClientError::Server(message)) = client.resolve(opts).await else {
         panic!("expected the gated install to fail with a server error");
     };
-    assert!(message.contains("401"), "expected an auth denial without an uplink, got: {message}");
+    assert!(message.contains("401"), "expected an auth denial without an upstream, got: {message}");
 }
 
 #[tokio::test]
@@ -301,7 +301,7 @@ async fn resolves_a_package() {
     assert!(outcome.stats.total_packages >= 1);
 }
 
-/// An unknown route (no uplink, no public rule) has no managed credential,
+/// An unknown route (no upstream, no public rule) has no managed credential,
 /// so it was resolved anonymously and pnpr mints no gateway URL: the
 /// resolution keeps its registry resolution, and the client fetches the
 /// tarball directly from the upstream the same way pnpr did.
@@ -490,22 +490,22 @@ async fn verify_lockfile_endpoint_rejects_policy_violation() {
 }
 
 /// The verification fan-out fetches each entry's packument, so a gated
-/// package verifies only when the pnpr server has an uplink for the
+/// package verifies only when the pnpr server has an upstream for the
 /// registry — and fails closed against a server without one. Each verify
 /// targets a fresh pnpr so neither the whole-lockfile verdict cache nor the
 /// metadata mirror warmed by an earlier call can satisfy it without
-/// exercising the uplink. The resolve and aliased-verify instances share a
-/// `public_url` so the verifier can reverse the lockfile's `/~<uplink>/`
+/// exercising the upstream. The resolve and aliased-verify instances share a
+/// `public_url` so the verifier can reverse the lockfile's `/~<name>/`
 /// tarball URLs back to upstream — what a real single-pnpr deployment does.
 #[tokio::test]
-async fn verify_lockfile_endpoint_uses_uplinks() {
+async fn verify_lockfile_endpoint_uses_upstreams() {
     let registry = TestRegistry::start();
     let token = register_token(&registry.url(), "needs-auth-verifier").await;
     let shared_public_url = "http://pnpr.verify.test";
 
-    let (resolve_pnpr_url, resolve_auth, _resolve_storage) = start_pnpr_with_uplinks_at(
+    let (resolve_pnpr_url, resolve_auth, _resolve_storage) = start_pnpr_with_upstreams_at(
         shared_public_url,
-        vec![registry_uplink(&registry.url(), &token)],
+        vec![registry_upstream(&registry.url(), &token)],
     )
     .await;
     let mut resolve_opts =
@@ -520,10 +520,10 @@ async fn verify_lockfile_endpoint_uses_uplinks() {
     resolve_opts.minimum_release_age = Some(1);
     resolve_opts.minimum_release_age_ignore_missing_time = false;
 
-    // A fresh pnpr that carries the uplink verifies the gated entry.
-    let (aliased_pnpr_url, aliased_auth, _aliased_storage) = start_pnpr_with_uplinks_at(
+    // A fresh pnpr that carries the upstream verifies the gated entry.
+    let (aliased_pnpr_url, aliased_auth, _aliased_storage) = start_pnpr_with_upstreams_at(
         shared_public_url,
-        vec![registry_uplink(&registry.url(), &token)],
+        vec![registry_upstream(&registry.url(), &token)],
     )
     .await;
     let mut aliased_opts = resolve_opts.clone();
@@ -533,9 +533,9 @@ async fn verify_lockfile_endpoint_uses_uplinks() {
     PnprClient::new(aliased_pnpr_url)
         .verify_lockfile(verify_opts)
         .await
-        .expect("the uplink should let the gated entry verify");
+        .expect("the upstream should let the gated entry verify");
 
-    // A pnpr without the uplink has no credential to select, so the gated
+    // A pnpr without the upstream has no credential to select, so the gated
     // entry's metadata fetch must fail closed.
     let (plain_pnpr_url, plain_auth, _plain_storage) = start_pnpr(&registry.url()).await;
     let mut plain_opts = resolve_opts.clone();
@@ -544,7 +544,7 @@ async fn verify_lockfile_endpoint_uses_uplinks() {
         VerifyLockfileOptions::from_resolve_options(&plain_opts).expect("lockfile is present");
     assert!(
         PnprClient::new(plain_pnpr_url).verify_lockfile(plain_verify_opts).await.is_err(),
-        "without an uplink the gated entry's metadata fetch must fail closed",
+        "without an upstream the gated entry's metadata fetch must fail closed",
     );
 }
 

--- a/pacquet/crates/testing-utils/src/registry.rs
+++ b/pacquet/crates/testing-utils/src/registry.rs
@@ -44,14 +44,14 @@ impl TestRegistryInstance {
         let storage = pnpr_fixtures::ensure_storage();
         // Proxy mode: `@pnpm.e2e` fixtures are served from local storage, while
         // real npm packages (`is-positive`, `is-negative`, etc.) fall through to
-        // the npm uplink — matching how registry-mock served pacquet's tests.
+        // the npm upstream — matching how registry-mock served pacquet's tests.
         let mut config = Config::proxy(listen, storage.to_path_buf());
         config.public_url = url.trim_end_matches('/').to_string();
         // Registration is opt-in; tests that forward credentials create
         // accounts via adduser against this registry.
         config.auth.htpasswd.max_users = pnpr::MaxUsers::Unlimited;
         // A long TTL keeps the fixture packuments (whose `time` values are static)
-        // from being treated as stale and refetched from the uplink.
+        // from being treated as stale and refetched from the upstream.
         config.packument_ttl = std::time::Duration::from_hours(8760);
         thread::Builder::new()
             .name("pacquet-test-registry".to_string())

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -1654,24 +1654,27 @@ fn write_pnpr_benchmark_config(
 /// A config for the cold mock: isolated `storage` and a single public upstream
 /// at the warm origin, so every request is a cache miss proxied through to it.
 ///
-/// The routing is expressed in *two* shapes so one file drives every
-/// benchmarked `pnpr` binary regardless of revision: the `mounts:` +
-/// `defaultTarget:` mount model that current `pnpr` reads, and the legacy
+/// The routing is expressed in *three* shapes so one file drives every
+/// benchmarked `pnpr` binary regardless of revision: the `registries:` +
+/// `defaultRegistry:` model that current `pnpr` reads, the `mounts:` +
+/// `defaultTarget:` shape the registries model replaced, and the legacy
 /// `uplinks:` + `packages: proxy:` shape that a `pnpr` built before the mount
-/// model reads. Each server ignores the block it doesn't recognize — neither
-/// `ConfigFile` sets `deny_unknown_fields`, and neither `PackageAccess` does
-/// either — so both proxy every request to the same `origin`.
+/// model reads. Each server ignores the blocks it doesn't recognize — no
+/// revision's `ConfigFile` or `PackageAccess` sets `deny_unknown_fields` —
+/// so all of them proxy every request to the same `origin`.
 fn cold_mock_config_yaml(storage: &Path, origin: &str) -> String {
     let mut packages = HashMap::new();
     packages.insert("**", ColdMockPackageAccess { access: "$all", proxy: "npmjs" });
+    let upstream =
+        || ColdMockUpstreamEntry { kind: "upstream", url: origin.to_string(), public: true };
     let config = ColdMockConfig {
         storage: storage.display().to_string(),
         uplinks: ColdMockUplinks { npmjs: ColdMockUplink { url: origin.to_string() } },
         packages,
-        mounts: ColdMockMounts {
-            npmjs: ColdMockMount { kind: "upstream", url: origin.to_string(), public: true },
-        },
+        mounts: ColdMockUpstreamTable { npmjs: upstream() },
         default_target: "npmjs",
+        registries: ColdMockUpstreamTable { npmjs: upstream() },
+        default_registry: "npmjs",
         log: ColdMockLog { kind: "stdout", format: "pretty", level: "error" },
     };
     serde_saphyr::to_string(&config).expect("serialize cold mock config")
@@ -1684,9 +1687,12 @@ struct ColdMockConfig {
     storage: String,
     uplinks: ColdMockUplinks,
     packages: HashMap<&'static str, ColdMockPackageAccess>,
-    mounts: ColdMockMounts,
+    mounts: ColdMockUpstreamTable,
     #[serde(rename = "defaultTarget")]
     default_target: &'static str,
+    registries: ColdMockUpstreamTable,
+    #[serde(rename = "defaultRegistry")]
+    default_registry: &'static str,
     log: ColdMockLog,
 }
 
@@ -1706,15 +1712,17 @@ struct ColdMockPackageAccess {
     proxy: &'static str,
 }
 
+/// The `mounts:` / `registries:` table — the same single-upstream entry under
+/// either key, since the registries model kept the tagged-entry shape.
 #[derive(Serialize)]
-struct ColdMockMounts {
-    npmjs: ColdMockMount,
+struct ColdMockUpstreamTable {
+    npmjs: ColdMockUpstreamEntry,
 }
 
-/// One `mounts:` entry in the new mount model: the `type:` tag selects the kind
+/// One `mounts:`/`registries:` entry: the `type:` tag selects the kind
 /// (`upstream` here), and the kind's fields sit alongside it.
 #[derive(Serialize)]
-struct ColdMockMount {
+struct ColdMockUpstreamEntry {
     #[serde(rename = "type")]
     kind: &'static str,
     url: String,

--- a/pacquet/tasks/registry-mock/src/pnpr_command.rs
+++ b/pacquet/tasks/registry-mock/src/pnpr_command.rs
@@ -102,7 +102,7 @@ pub fn pnpr_command_with_binary(bin: &Path, port: u16, public_url: Option<&str>)
     };
     let mut cmd = Command::new(bin);
     // `pnpr` defaults to its bundled verdaccio-shaped config
-    // (npmjs uplink + `**` proxy rule), which matches what the mock
+    // (npmjs upstream + `**` proxy rule), which matches what the mock
     // needs — no `-c` override required. We only pin the runtime
     // bits the bundled config can't know about.
     cmd.arg("--storage")

--- a/pacquet/tasks/registry-mock/src/pnpr_command.rs
+++ b/pacquet/tasks/registry-mock/src/pnpr_command.rs
@@ -101,9 +101,10 @@ pub fn pnpr_command_with_binary(bin: &Path, port: u16, public_url: Option<&str>)
         default_public_url.trim_end_matches('/')
     };
     let mut cmd = Command::new(bin);
-    // `pnpr` defaults to its bundled verdaccio-shaped config
-    // (npmjs upstream + `**` proxy rule), which matches what the mock
-    // needs — no `-c` override required. We only pin the runtime
+    // `pnpr` defaults to its bundled registry-mock config (the fixture
+    // namespace served from local hosted storage, everything else proxied
+    // through the pattern-less npmjs upstream), which is exactly what the
+    // mock needs — no `-c` override required. We only pin the runtime
     // bits the bundled config can't know about.
     cmd.arg("--storage")
         .arg(runtime_storage())

--- a/pnpr/crates/pnpr/config.yaml
+++ b/pnpr/crates/pnpr/config.yaml
@@ -41,9 +41,9 @@ storage: ./storage
 #    url: ${PNPR_MYSQL_URL}
 #    maxConnections: 16
 # The npm-registry surface (packument/tarball reads, publish, unpublish,
-# dist-tag, search) is served iff at least one mount is declared under
-# `mounts:` below; `--disable-registry` turns it off per tier. The install
-# accelerator has its own toggle. Something must be served: mounts, or the
+# dist-tag, search) is served iff at least one registry is declared under
+# `registries:` below; `--disable-registry` turns it off per tier. The install
+# accelerator has its own toggle. Something must be served: registries, or the
 # resolver. (`/-/ping` and the login/token account endpoints are always
 # served.)
 #resolver:          # install accelerator: /-/pnpr, /-/pnpr/v0/resolve,
@@ -59,7 +59,7 @@ auth:
 
 # Optional static group/team memberships. Every access list accepts these
 # group names anywhere it accepts usernames — the per-package `packages:`
-# policies and the mount-level `access:` lists alike.
+# policies and the registry-level `access:` lists alike.
 #groups:
 #  platform: alice bob
 
@@ -72,19 +72,19 @@ middlewares:
 web:
   enable: false
 
-# Registry mounts: the only routing surface. Every addressable origin is a
-# mount exposed at `/~<mount>/`, and provenance is declared, never inferred —
-# every concrete mount declares the package-name patterns it serves (its
+# Registries: the only routing surface. Every addressable origin is a
+# registry exposed at `/~<name>/`, and provenance is declared, never inferred —
+# every concrete registry declares the package-name patterns it serves (its
 # namespace, enforced on every path to it), a package resolves to exactly one
 # declared concrete origin, and there is no cross-origin fall-through (not on
 # "not found", not on "unavailable"). This is the `@pnpm/registry-mock` shape:
 # the fixture scopes are served from the local hosted store, and everything
 # else proxies the public npm registry.
-mounts:
+registries:
   # The locally-hosted fixtures (and anything published here). With no `org`,
-  # this mount namespaces onto the flat `storage` root, where the fixtures are
-  # seeded. `patterns:` is the mount's declared namespace: only these names
-  # can be served from or published to this mount, so a name outside it can
+  # this registry namespaces onto the flat `storage` root, where the fixtures are
+  # seeded. `patterns:` is the registry's declared namespace: only these names
+  # can be served from or published to this registry, so a name outside it can
   # never squat here and later shadow its real origin.
   local:
     type: hosted
@@ -175,8 +175,8 @@ mounts:
     type: router
     sources: [local, npmjs]
 
-# The path-less base URL (`https://<pnpr>/`) aliases this mount.
-defaultTarget: main
+# The path-less base URL (`https://<pnpr>/`) aliases this registry.
+defaultRegistry: main
 
 # Per-package access control (an ACL layer, independent of routing). With no
 # matching rule the built-in default allows authenticated publish but admits

--- a/pnpr/crates/pnpr/config.yaml
+++ b/pnpr/crates/pnpr/config.yaml
@@ -74,105 +74,106 @@ web:
 
 # Registry mounts: the only routing surface. Every addressable origin is a
 # mount exposed at `/~<mount>/`, and provenance is declared, never inferred —
-# a package resolves to exactly one declared concrete origin, with no
-# cross-origin fall-through (not on "not found", not on "unavailable"). This
-# is the `@pnpm/registry-mock` shape: the fixture scopes are served from the
-# local hosted store, and everything else proxies the public npm registry.
+# every concrete mount declares the package-name patterns it serves (its
+# namespace, enforced on every path to it), a package resolves to exactly one
+# declared concrete origin, and there is no cross-origin fall-through (not on
+# "not found", not on "unavailable"). This is the `@pnpm/registry-mock` shape:
+# the fixture scopes are served from the local hosted store, and everything
+# else proxies the public npm registry.
 mounts:
   # The locally-hosted fixtures (and anything published here). With no `org`,
   # this mount namespaces onto the flat `storage` root, where the fixtures are
-  # seeded.
+  # seeded. `patterns:` is the mount's declared namespace: only these names
+  # can be served from or published to this mount, so a name outside it can
+  # never squat here and later shadow its real origin.
   local:
     type: hosted
     access: $all
-  # The public npm registry.
+    patterns:
+      # Scopes seeded from the in-repo fixture sources
+      # (`pnpr/.fixtures/packages/`). Scopes shared with real, active npm
+      # scopes (`@pnpm`, `@zkochan`) are claimed by exact name instead — see
+      # below — so proxied dependency trees can still pull the scope's other
+      # real packages from npm.
+      - '@foo/*'
+      - '@having/*'
+      - '@jsr/*'
+      - '@pnpm.e2e/*'
+      - '@private/*'
+      - '@scoped/*'
+      - 'create-touch-file-one-bin'
+      # The fixture packages in the real `@pnpm` and `@zkochan` scopes, each
+      # claimed by exact name.
+      - '@pnpm/plugin-pnpmfile'
+      - '@pnpm/postinstall-modifies-source'
+      - '@pnpm/x'
+      - '@pnpm/xyz'
+      - '@pnpm/xyz-parent'
+      - '@pnpm/xyz-parent-parent'
+      - '@pnpm/xyz-parent-parent-parent'
+      - '@pnpm/xyz-parent-parent-parent-parent'
+      - '@pnpm/xyz-parent-parent-with-xyz'
+      - '@pnpm/y'
+      - '@pnpm/z'
+      - '@zkochan/test-pnpm-issue219'
+      # Names tests publish to the mock and then read back. Exact names only —
+      # an unscoped prefix wildcard would swallow real npm packages that
+      # proxied dependency trees need (`test-*` would capture `test-exclude`).
+      # A test publishing a new unscoped name must add it here; publishing
+      # dynamically-suffixed names belongs in the `@pnpmtest` scope.
+      - '@pnpmtest/*'
+      - 'batch-dry-1'
+      - 'batch-dry-2'
+      - 'batch-no-recursive'
+      - 'batch-pkg-2'
+      - 'batch-unsupported-1'
+      - 'project-100'
+      - 'project-200'
+      - 'publish_config_directory_dist_package'
+      - 'test-deprecate-package'
+      - 'test-deprecate-specific'
+      - 'test-dist-tag-add'
+      - 'test-dist-tag-add-default'
+      - 'test-dist-tag-ls'
+      - 'test-dist-tag-ls-default'
+      - 'test-dist-tag-rm'
+      - 'test-dist-tag-rm-latest'
+      - 'test-dist-tag-rm-missing'
+      - 'test-publish-config'
+      - 'test-publish-config-directory'
+      - 'test-publish-config-installation'
+      - 'test-publish-helper-token-basic.json'
+      - 'test-publish-helper-token-bearer.json'
+      - 'test-publish-package-oidc.json'
+      - 'test-publish-package.json'
+      - 'test-publish-package.json5'
+      - 'test-publish-package.yaml'
+      - 'test-publish-scripts'
+      - 'test-publish-skip-manifest-obfuscation'
+      - 'test-publish-skip-manifest-obfuscation-installation'
+      - 'test-publish-tarball'
+      - 'test-publish-with-ignore-scripts'
+      - 'test-publish-with-scripts'
+      - 'test-undeprecate-pkg'
+      - 'test-unpublish-force'
+      - 'test-unpublish-no-force'
+      - 'test-unpublish-no-ver'
+      - 'test-unpublish-version'
+      - 'workspace-package-with-default-catalog'
+      - 'workspace-package-with-named-catalog'
+  # The public npm registry. No `patterns:` — it serves every name, the
+  # catch-all in any router, so it must be listed last in `sources:` below.
   npmjs:
     type: upstream
     url: https://registry.npmjs.org/
     public: true
-  # One URL routing each package to exactly one source by the first matching
-  # pattern. The fixture scopes are authoritative-local; everything else is
-  # npm. A router refuses to start on a shadowed route, so the `**` catch-all
-  # must stay last.
+  # One URL routing each package to the first listed source whose declared
+  # patterns claim it. The fixture names are authoritative-local; everything
+  # else is npm. A router refuses to start on an unreachable source, so the
+  # pattern-less catch-all must stay last.
   main:
     type: router
-    routes:
-      - patterns:
-          # Scopes seeded from the in-repo fixture sources
-          # (`pnpr/.fixtures/packages/`). Scopes shared with real, active npm
-          # scopes (`@pnpm`, `@zkochan`) are routed by exact name instead —
-          # see below — so proxied dependency trees can still pull the scope's
-          # other real packages from npm.
-          - '@foo/*'
-          - '@having/*'
-          - '@jsr/*'
-          - '@pnpm.e2e/*'
-          - '@private/*'
-          - '@scoped/*'
-          - 'create-touch-file-one-bin'
-          # The fixture packages in the real `@pnpm` and `@zkochan` scopes,
-          # each routed by exact name.
-          - '@pnpm/plugin-pnpmfile'
-          - '@pnpm/postinstall-modifies-source'
-          - '@pnpm/x'
-          - '@pnpm/xyz'
-          - '@pnpm/xyz-parent'
-          - '@pnpm/xyz-parent-parent'
-          - '@pnpm/xyz-parent-parent-parent'
-          - '@pnpm/xyz-parent-parent-parent-parent'
-          - '@pnpm/xyz-parent-parent-with-xyz'
-          - '@pnpm/y'
-          - '@pnpm/z'
-          - '@zkochan/test-pnpm-issue219'
-          # Names tests publish to the mock and then read back. Exact names
-          # only — an unscoped prefix wildcard would swallow real npm packages
-          # that proxied dependency trees need (`test-*` would capture
-          # `test-exclude`). A test publishing a new unscoped name must add it
-          # here; publishing dynamically-suffixed names belongs in the
-          # `@pnpmtest` scope.
-          - '@pnpmtest/*'
-          - 'batch-dry-1'
-          - 'batch-dry-2'
-          - 'batch-no-recursive'
-          - 'batch-pkg-2'
-          - 'batch-unsupported-1'
-          - 'project-100'
-          - 'project-200'
-          - 'publish_config_directory_dist_package'
-          - 'test-deprecate-package'
-          - 'test-deprecate-specific'
-          - 'test-dist-tag-add'
-          - 'test-dist-tag-add-default'
-          - 'test-dist-tag-ls'
-          - 'test-dist-tag-ls-default'
-          - 'test-dist-tag-rm'
-          - 'test-dist-tag-rm-latest'
-          - 'test-dist-tag-rm-missing'
-          - 'test-publish-config'
-          - 'test-publish-config-directory'
-          - 'test-publish-config-installation'
-          - 'test-publish-helper-token-basic.json'
-          - 'test-publish-helper-token-bearer.json'
-          - 'test-publish-package-oidc.json'
-          - 'test-publish-package.json'
-          - 'test-publish-package.json5'
-          - 'test-publish-package.yaml'
-          - 'test-publish-scripts'
-          - 'test-publish-skip-manifest-obfuscation'
-          - 'test-publish-skip-manifest-obfuscation-installation'
-          - 'test-publish-tarball'
-          - 'test-publish-with-ignore-scripts'
-          - 'test-publish-with-scripts'
-          - 'test-undeprecate-pkg'
-          - 'test-unpublish-force'
-          - 'test-unpublish-no-force'
-          - 'test-unpublish-no-ver'
-          - 'test-unpublish-version'
-          - 'workspace-package-with-default-catalog'
-          - 'workspace-package-with-named-catalog'
-        source: local
-      - patterns: ['**']
-        source: npmjs
+    sources: [local, npmjs]
 
 # The path-less base URL (`https://<pnpr>/`) aliases this mount.
 defaultTarget: main

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::RegistryError,
-    mount::{MountConfigError, MountKind, Mounts, PackagePattern},
     policy::{AccessGroups, AccessList, Identity, PackagePolicies, PackagePolicy},
+    registry::{PackagePattern, Registries, Registry, RegistryConfigError},
     s3::{S3Settings, build_s3_store},
 };
 use indexmap::IndexMap;
@@ -71,15 +71,15 @@ pub struct Config {
     /// [`Self::storage`]; set the YAML `cache:` key (or `--cache`) to
     /// an absolute path to put it on separate, ephemeral disk.
     pub cache_storage: PathBuf,
-    /// Upstream-mount backends, keyed by mount id. Built from the `mounts:`
-    /// `upstream` entries and consumed by the `/~<mount>/` serving and route
+    /// Upstream-registry backends, keyed by registry id. Built from the `registries:`
+    /// `upstream` entries and consumed by the `/~<name>/` serving and route
     /// classification.
     pub uplinks: IndexMap<String, UplinkConfig>,
     /// The raw per-package `access` / `publish` / `unpublish` rules from the
     /// YAML `packages:` block, in declared order. [`Self::policies`] is the
     /// compiled form the server enforces; this keeps the declared shape for
     /// introspection. Access control only — routing a package to its origin
-    /// is the mount graph's job ([`Self::mounts`]).
+    /// is the registry graph's job ([`Self::registries`]).
     pub packages: IndexMap<String, PackageAccess>,
     /// Optional static group memberships used by named access tokens in
     /// package policies and upstream aliases.
@@ -121,7 +121,7 @@ pub struct Config {
     pub osv: OsvConfig,
     /// The npm-registry surface: packument and tarball reads, publish,
     /// unpublish, dist-tag, and search. Derived, not configured: the
-    /// surface is served iff at least one mount is declared, minus the
+    /// surface is served iff at least one registry is declared, minus the
     /// `--disable-registry` per-tier override (a stateless resolver tier
     /// in front of an existing registry). See [`RegistryFeature`].
     pub registry: RegistryFeature,
@@ -140,33 +140,33 @@ pub struct Config {
     /// 32-byte value from the OS CSPRNG at startup (private entries then
     /// live only for this process's lifetime).
     pub resolution_cache_secret: Arc<[u8]>,
-    /// The validated registry-mount routing graph: every addressable origin
-    /// (`/~<mount>/`) plus the optional path-less default target. Concrete
-    /// upstream mounts are backed by [`Self::uplinks`]; hosted mounts by
+    /// The validated registry routing graph: every addressable origin
+    /// (`/~<name>/`) plus the optional path-less default target. Concrete
+    /// upstream registries are backed by [`Self::uplinks`]; hosted registries by
     /// [`Self::hosted`]; each declares the package-name patterns it serves,
     /// and a router selects the first of its sources whose patterns claim the
     /// name. Built and validated at config load — a misordered or
     /// self-referential router fails startup rather than serving the wrong
     /// origin.
-    pub mounts: Mounts,
-    /// Hosted mounts, keyed by mount id. Each owns an `org` storage/serving
-    /// namespace and an access policy gating its packages. The only mount kind
+    pub registries: Registries,
+    /// Hosted registries, keyed by registry id. Each owns an `org` storage/serving
+    /// namespace and an access policy gating its packages. The only registry kind
     /// that accepts writes.
     pub hosted: IndexMap<String, HostedConfig>,
 }
 
-/// A resolved hosted mount: the `org` namespace it serves and the access policy
+/// A resolved hosted registry: the `org` namespace it serves and the access policy
 /// applied to every package under it. Per-package ACLs in [`Config::policies`]
 /// compose on top (logical AND) for finer control.
 #[derive(Debug, Clone)]
 pub struct HostedConfig {
-    /// The storage/serving namespace, so two hosted mounts holding the same
+    /// The storage/serving namespace, so two hosted registries holding the same
     /// `name@version` never collide. Empty (`""`) ⇒ the flat `storage` root.
     pub org: String,
-    /// Who may reach this mount at all — gates reads *and* the write routing
+    /// Who may reach this registry at all — gates reads *and* the write routing
     /// (publish, dist-tag, unpublish), with a denied caller masked as
-    /// not-found either way. Defaults to `$all` (a public hosted mount) when
-    /// the mount omits `access:`.
+    /// not-found either way. Defaults to `$all` (a public hosted registry) when
+    /// the registry omits `access:`.
     pub access: AccessList,
 }
 
@@ -191,8 +191,8 @@ pub struct PublicRoute {
 }
 
 /// State of the npm-registry surface. There is no YAML toggle for it:
-/// the surface is served iff at least one mount is declared under
-/// `mounts:` (no mounts ⇒ nothing to serve), minus the per-tier
+/// the surface is served iff at least one registry is declared under
+/// `registries:` (no registries ⇒ nothing to serve), minus the per-tier
 /// `--disable-registry` CLI override. A dedicated type — rather than a
 /// bare `bool` on [`Config`] — so finer-grained registry sub-features
 /// (e.g. disabling `publish` for a read-only mirror) can be added here
@@ -578,10 +578,10 @@ impl fmt::Debug for RedactedHeaders<'_> {
     }
 }
 
-/// The serving knobs of an upstream mount, in verdaccio's uplink shape for
+/// The serving knobs of an upstream registry, in verdaccio's uplink shape for
 /// the subset pnpr implements: `url`, an `auth:` block, and a free-form
-/// `headers:` map. Built from an `upstream:` mount entry
-/// ([`resolve_upstream_mount`]) and resolved into [`UplinkConfig`] by
+/// `headers:` map. Built from an `upstream:` registry entry
+/// ([`resolve_upstream_registry`]) and resolved into [`UplinkConfig`] by
 /// [`resolve_uplink`].
 #[derive(Debug, Deserialize)]
 struct UplinkFile {
@@ -845,8 +845,8 @@ fn non_empty_token(token: &str) -> Option<String> {
 /// permission lists (built-in groups like `$all` / `$authenticated` /
 /// `$anonymous`, plus usernames / group names), compiled into the
 /// [`PackagePolicies`] that gate reads and writes. These are an access-control
-/// layer only — routing a package to its origin is the job of the mount graph
-/// (the `mount` module), not of `packages:`.
+/// layer only — routing a package to its origin is the job of the registry graph
+/// (the `registry` module), not of `packages:`.
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct PackageAccess {
     pub access: Option<AccessSpec>,
@@ -908,38 +908,38 @@ struct PublicRouteFile {
     package: Option<String>,
 }
 
-/// Disk shape of one `mounts:` entry, discriminated by an internal `type:` tag
+/// Disk shape of one `registries:` entry, discriminated by an internal `type:` tag
 /// (`hosted` / `upstream` / `router`). The tag selects exactly one kind, so
 /// "declared none or more than one" is unrepresentable — no runtime count check.
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
-enum MountFile {
+enum RegistryFile {
     Hosted(HostedFile),
     // Boxed: `UpstreamFile` is far larger than the other kinds, so an unboxed
-    // variant would bloat every `MountFile`.
+    // variant would bloat every `RegistryFile`.
     Upstream(Box<UpstreamFile>),
     Router(RouterFile),
 }
 
-/// Disk shape of a `hosted:` mount.
+/// Disk shape of a `hosted:` registry.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct HostedFile {
-    /// Storage namespace for this mount's packages, so two hosted mounts can
+    /// Storage namespace for this registry's packages, so two hosted registries can
     /// hold the same `name@version` without colliding. Omitted ⇒ the flat
     /// `storage` root (`""`).
     #[serde(default)]
     org: String,
-    /// Who may read this mount's packages. Omitted ⇒ `$all`.
+    /// Who may read this registry's packages. Omitted ⇒ `$all`.
     #[serde(default)]
     access: Option<AccessSpec>,
-    /// The names this mount serves and accepts publishes for. Omitted ⇒ every
+    /// The names this registry serves and accepts publishes for. Omitted ⇒ every
     /// name.
     #[serde(default)]
     patterns: Vec<String>,
 }
 
-/// Disk shape of an `upstream:` mount — one external origin. Mirrors an
+/// Disk shape of an `upstream:` registry — one external origin. Mirrors an
 /// uplink's tuning knobs plus `public` (an anonymous, no-credential origin)
 /// and `access` (which pnpr callers may reach a private one).
 #[derive(Debug, Deserialize)]
@@ -964,18 +964,18 @@ struct UpstreamFile {
     fail_timeout: Option<Interval>,
     #[serde(default)]
     cache: Option<bool>,
-    /// Which pnpr callers may reach this mount at `/~<mount>/`. Required for a
+    /// Which pnpr callers may reach this registry at `/~<name>/`. Required for a
     /// non-`public` upstream (otherwise no one could be authorized to use it).
     #[serde(default)]
     access: Option<AccessSpec>,
-    /// The names that may be requested through this mount. Omitted ⇒ every
+    /// The names that may be requested through this registry. Omitted ⇒ every
     /// name. Bounding a private upstream stops an authorized caller from
     /// pulling arbitrary public names through its server-owned credential.
     #[serde(default)]
     patterns: Vec<String>,
 }
 
-/// Disk shape of a `router:` mount: an ordered list of concrete mount names.
+/// Disk shape of a `router:` registry: an ordered list of concrete registry names.
 /// The first source whose declared patterns claim a package serves it.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1018,15 +1018,15 @@ struct ConfigFile {
     /// deserialize into the struct.
     #[serde(default)]
     resolver: Option<FeatureFile>,
-    /// pnpr registry mounts: hosted, upstream, and router origins, each
-    /// exposed at `/~<mount>/`. The only routing surface — there is no legacy
+    /// pnpr registries: hosted, upstream, and router origins, each
+    /// exposed at `/~<name>/`. The only routing surface — there is no legacy
     /// `uplinks:`/`packages: proxy:` fallback.
     #[serde(default)]
-    mounts: IndexMap<String, MountFile>,
-    /// The mount the path-less base URL aliases. Absent ⇒ the bare host has no
-    /// registry and clients must address a `/~<mount>/`.
-    #[serde(default, rename = "defaultTarget")]
-    default_target: Option<String>,
+    registries: IndexMap<String, RegistryFile>,
+    /// The registry the path-less base URL aliases. Absent ⇒ the bare host has no
+    /// registry and clients must address a `/~<name>/`.
+    #[serde(default, rename = "defaultRegistry")]
+    default_registry: Option<String>,
     #[serde(default)]
     packages: IndexMap<String, PackageAccess>,
     /// pnpr-only static groups: each key is a group/team name and each
@@ -1152,7 +1152,7 @@ fn default_true() -> bool {
 /// The namespace [`Config::proxy`] declares on its flat-root hosted org, so
 /// those names resolve locally rather than to the npm upstream: the
 /// registry-mock fixture scopes plus the one unscoped fixture. Kept in sync
-/// with the bundled `config.yaml` `local` mount and the fixtures under
+/// with the bundled `config.yaml` `local` registry and the fixtures under
 /// `pnpr/.fixtures/packages`. The fixture packages living in real, active npm
 /// scopes (`@pnpm`, `@zkochan`) are claimed by exact name so the rest of
 /// those scopes keeps proxying npm (dependency trees of proxied packages pull
@@ -1193,7 +1193,7 @@ impl Config {
     /// router. Kept for callers that don't use YAML config (notably pacquet's
     /// test registry, whose fixtures are served locally while real npm packages
     /// fall through to npmjs). The local pattern set mirrors the bundled
-    /// `config.yaml` `local` mount.
+    /// `config.yaml` `local` registry.
     #[must_use]
     pub fn proxy(listen: SocketAddr, storage: PathBuf) -> Self {
         let mut uplinks = IndexMap::new();
@@ -1209,18 +1209,18 @@ impl Config {
         let local_patterns = REGISTRY_MOCK_LOCAL_PATTERNS
             .iter()
             .map(|pattern| {
-                PackagePattern::parse(pattern).expect("valid built-in fixture mount pattern")
+                PackagePattern::parse(pattern).expect("valid built-in fixture registry pattern")
             })
             .collect();
         let graph = [
-            ("local".to_string(), MountKind::Hosted { patterns: local_patterns }),
-            ("npmjs".to_string(), MountKind::Upstream { patterns: Vec::new() }),
+            ("local".to_string(), Registry::Hosted { patterns: local_patterns }),
+            ("npmjs".to_string(), Registry::Upstream { patterns: Vec::new() }),
             (
                 "main".to_string(),
-                MountKind::Router { sources: vec!["local".to_string(), "npmjs".to_string()] },
+                Registry::Router { sources: vec!["local".to_string(), "npmjs".to_string()] },
             ),
         ];
-        let mounts = Mounts::new(graph.into_iter().collect(), Some("main".to_string()));
+        let registries = Registries::new(graph.into_iter().collect(), Some("main".to_string()));
         Self {
             listen,
             public_url: format!("http://{listen}"),
@@ -1240,13 +1240,13 @@ impl Config {
             resolver: ResolverFeature::default(),
             route_policy: RoutePolicy::default(),
             resolution_cache_secret: random_secret(),
-            mounts,
+            registries,
             hosted,
         }
     }
 
     /// Build a static-mode config that serves `storage` verbatim: one
-    /// pattern-less hosted mount over the storage root (an empty `org`
+    /// pattern-less hosted registry over the storage root (an empty `org`
     /// namespace == the flat root), the sole source of a router that the
     /// path-less base aliases. Every package resolves to that one hosted
     /// origin — no upstream, no fall-through.
@@ -1258,10 +1258,10 @@ impl Config {
             HostedConfig { org: String::new(), access: AccessList::parse("$all") },
         );
         let graph = [
-            ("local".to_string(), MountKind::Hosted { patterns: Vec::new() }),
-            ("main".to_string(), MountKind::Router { sources: vec!["local".to_string()] }),
+            ("local".to_string(), Registry::Hosted { patterns: Vec::new() }),
+            ("main".to_string(), Registry::Router { sources: vec!["local".to_string()] }),
         ];
-        let mounts = Mounts::new(graph.into_iter().collect(), Some("main".to_string()));
+        let registries = Registries::new(graph.into_iter().collect(), Some("main".to_string()));
         Self {
             listen,
             public_url: format!("http://{listen}"),
@@ -1281,7 +1281,7 @@ impl Config {
             resolver: ResolverFeature::default(),
             route_policy: RoutePolicy::default(),
             resolution_cache_secret: random_secret(),
-            mounts,
+            registries,
             hosted,
         }
     }
@@ -1492,26 +1492,30 @@ impl Config {
         let policies = build_policies(&file.packages)?;
         let osv = build_osv_config(&file.osv, base_dir);
         // The npm-registry surface is derived, not configured: served iff
-        // at least one mount is declared (no mounts ⇒ nothing to serve),
+        // at least one registry is declared (no registries ⇒ nothing to serve),
         // minus the per-tier `--disable-registry` override. Folding the
         // override in here lets the registry-only work below (uplink
         // credential resolution) key off effective enablement.
         let registry =
-            RegistryFeature { enabled: !file.mounts.is_empty() && !overrides.disable_registry };
+            RegistryFeature { enabled: !file.registries.is_empty() && !overrides.disable_registry };
         let resolver = ResolverFeature {
             enabled: file.resolver.unwrap_or_default().enabled && !overrides.disable_resolver,
         };
-        // Upstream mounts (and the credentials some carry) are resolved by
-        // `build_mounts` below into this map. Resolving an upstream mount's
+        // Upstream registries (and the credentials some carry) are resolved by
+        // `build_registries` below into this map. Resolving an upstream registry's
         // `auth` is strict — an unresolvable token is a config error — so a
-        // resolver-only server (which mounts no registry routes) skips the
+        // resolver-only server (which registries no registry routes) skips the
         // credential resolution rather than carry upstream secrets it never
-        // uses. The mount *graph* is still built and validated either way, so
+        // uses. The registry *graph* is still built and validated either way, so
         // a misconfigured router or org fails startup on every tier, not only
         // when the registry surface happens to be enabled.
         let mut uplinks: IndexMap<String, UplinkConfig> = IndexMap::new();
-        let (hosted, mounts) =
-            build_mounts(&mut uplinks, file.mounts, file.default_target, registry.enabled)?;
+        let (hosted, registries) = build_registries(
+            &mut uplinks,
+            file.registries,
+            file.default_registry,
+            registry.enabled,
+        )?;
         let route_policy = build_route_policy(file.routes);
         let resolution_cache_secret = resolution_secret(file.secret.as_deref())?;
         let config = Self {
@@ -1533,7 +1537,7 @@ impl Config {
             resolver,
             route_policy,
             resolution_cache_secret,
-            mounts,
+            registries,
             hosted,
         };
         config.ensure_a_feature_is_enabled()?;
@@ -1541,7 +1545,7 @@ impl Config {
     }
 
     /// At least one top-level surface must be served; a server with no
-    /// registry surface (no mounts declared, or `--disable-registry`) and
+    /// registry surface (no registries declared, or `--disable-registry`) and
     /// the resolver disabled would answer only `/-/ping` and the account
     /// endpoints. Checked at config load and again in the serve/router
     /// entry points for programmatically built configs.
@@ -1550,7 +1554,7 @@ impl Config {
             Ok(())
         } else {
             Err(RegistryError::InvalidConfig {
-                reason: "nothing to serve: the npm-registry surface is off (no `mounts:` \
+                reason: "nothing to serve: the npm-registry surface is off (no `registries:` \
                          declared, or `--disable-registry`) and the resolver is disabled"
                     .to_string(),
             })
@@ -1602,99 +1606,99 @@ fn build_route_policy(file: Option<RoutesFile>) -> RoutePolicy {
     }
 }
 
-/// Turn a static [`MountConfigError`] into the server-wide config error so a
-/// bad mount set fails startup and config reload like any other.
-fn mount_err(err: &MountConfigError) -> RegistryError {
+/// Turn a static [`RegistryConfigError`] into the server-wide config error so a
+/// bad registry set fails startup and config reload like any other.
+fn registry_err(err: &RegistryConfigError) -> RegistryError {
     RegistryError::InvalidConfig { reason: err.to_string() }
 }
 
-/// Build the validated [`Mounts`] graph (and the hosted table) from the
-/// resolved uplinks and the `mounts:` block. Every uplink is an upstream
-/// mount; `mounts:` adds hosted, further upstream, and router mounts.
-/// Upstream mounts declared under `mounts:` are folded into `uplinks` so they
+/// Build the validated [`Registries`] graph (and the hosted table) from the
+/// resolved uplinks and the `registries:` block. Every uplink is an upstream
+/// registry; `registries:` adds hosted, further upstream, and router registries.
+/// Upstream registries declared under `registries:` are folded into `uplinks` so they
 /// reuse the same serving and route-classification machinery. Fails closed on
-/// any name collision, malformed mount, or invalid routing graph.
+/// any name collision, malformed registry, or invalid routing graph.
 ///
 /// With `resolve_upstreams` false (the registry surface is disabled), an
-/// upstream mount still joins the graph for validation but its credentials
+/// upstream registry still joins the graph for validation but its credentials
 /// and serving config are not resolved — a resolver-only tier must not fail
 /// on (or carry) upstream secrets it never uses.
-fn build_mounts(
+fn build_registries(
     uplinks: &mut IndexMap<String, UplinkConfig>,
-    mount_files: IndexMap<String, MountFile>,
-    default_target: Option<String>,
+    registry_files: IndexMap<String, RegistryFile>,
+    default_registry: Option<String>,
     resolve_upstreams: bool,
-) -> Result<(IndexMap<String, HostedConfig>, Mounts), RegistryError> {
+) -> Result<(IndexMap<String, HostedConfig>, Registries), RegistryError> {
     let mut hosted = IndexMap::new();
-    let mut graph: IndexMap<String, MountKind> = IndexMap::new();
-    // Every configured uplink is, by definition, an upstream mount addressable
+    let mut graph: IndexMap<String, Registry> = IndexMap::new();
+    // Every configured uplink is, by definition, an upstream registry addressable
     // at `/~<uplink>/`. No declared patterns ⇒ it serves every name.
     for name in uplinks.keys() {
-        validate_mount_name(name)?;
-        graph.insert(name.clone(), MountKind::Upstream { patterns: Vec::new() });
+        validate_registry_name(name)?;
+        graph.insert(name.clone(), Registry::Upstream { patterns: Vec::new() });
     }
-    for (name, file) in mount_files {
-        validate_mount_name(&name)?;
+    for (name, file) in registry_files {
+        validate_registry_name(&name)?;
         if graph.contains_key(&name) {
             return Err(RegistryError::InvalidConfig {
                 reason: format!(
-                    "mount {name:?} collides with another mount or uplink of the same name",
+                    "registry {name:?} collides with another registry or uplink of the same name",
                 ),
             });
         }
         match file {
-            MountFile::Hosted(mount) => {
-                validate_org_namespace(&name, &mount.org)?;
-                // Two hosted mounts sharing an `org` would read and write the
+            RegistryFile::Hosted(registry) => {
+                validate_org_namespace(&name, &registry.org)?;
+                // Two hosted registries sharing an `org` would read and write the
                 // same storage namespace, so a package published to one would
                 // surface through the other — breaking the declared-provenance
                 // isolation. Reject the collision at load.
                 if let Some((other, _)) = hosted
                     .iter()
-                    .find(|(_, existing): &(_, &HostedConfig)| existing.org == mount.org)
+                    .find(|(_, existing): &(_, &HostedConfig)| existing.org == registry.org)
                 {
                     return Err(RegistryError::InvalidConfig {
                         reason: format!(
-                            "hosted mount {name:?} reuses the `org` namespace {:?} already claimed \
-                             by mount {other:?}; two hosted mounts cannot share a namespace",
-                            mount.org,
+                            "hosted registry {name:?} reuses the `org` namespace {:?} already claimed \
+                             by registry {other:?}; two hosted registries cannot share a namespace",
+                            registry.org,
                         ),
                     });
                 }
-                let access = mount
+                let access = registry
                     .access
                     .as_ref()
                     .map_or_else(|| AccessList::parse("$all"), AccessSpec::to_access_list);
-                let patterns = build_patterns(&name, &mount.patterns)?;
-                hosted.insert(name.clone(), HostedConfig { org: mount.org, access });
-                graph.insert(name, MountKind::Hosted { patterns });
+                let patterns = build_patterns(&name, &registry.patterns)?;
+                hosted.insert(name.clone(), HostedConfig { org: registry.org, access });
+                graph.insert(name, Registry::Hosted { patterns });
             }
-            MountFile::Upstream(upstream) => {
+            RegistryFile::Upstream(upstream) => {
                 let patterns = build_patterns(&name, &upstream.patterns)?;
                 if resolve_upstreams {
-                    let resolved = resolve_upstream_mount::<SystemEnv>(&name, *upstream)?;
+                    let resolved = resolve_upstream_registry::<SystemEnv>(&name, *upstream)?;
                     uplinks.insert(name.clone(), resolved);
                 }
-                graph.insert(name, MountKind::Upstream { patterns });
+                graph.insert(name, Registry::Upstream { patterns });
             }
-            MountFile::Router(router) => {
-                graph.insert(name, MountKind::Router { sources: router.sources });
+            RegistryFile::Router(router) => {
+                graph.insert(name, Registry::Router { sources: router.sources });
             }
         }
     }
-    let mounts = Mounts::new(graph, default_target);
-    mounts.validate().map_err(|err| mount_err(&err))?;
-    Ok((hosted, mounts))
+    let registries = Registries::new(graph, default_registry);
+    registries.validate().map_err(|err| registry_err(&err))?;
+    Ok((hosted, registries))
 }
 
-/// A mount's name is addressed as the single URL path segment `/~<name>/` and
+/// A registry's name is addressed as the single URL path segment `/~<name>/` and
 /// is embedded verbatim into rewritten `dist.tarball` URLs, so it must be one
 /// URL-safe segment. A name that can't survive that round trip is rejected at
-/// load rather than becoming an unreachable mount (`/` splits it across
+/// load rather than becoming an unreachable registry (`/` splits it across
 /// segments), a URL-parsing ambiguity (`?`, `#`, `%`, whitespace, control
 /// characters), or a path-meaningful component intermediaries may normalize
 /// away (`.`, `..`, a Windows drive prefix).
-fn validate_mount_name(name: &str) -> Result<(), RegistryError> {
+fn validate_registry_name(name: &str) -> Result<(), RegistryError> {
     let safe = crate::package_name::is_safe_path_segment(name)
         && !name.contains(['%', '?', '#'])
         && !name.contains(|ch: char| ch.is_whitespace() || ch.is_control());
@@ -1703,14 +1707,14 @@ fn validate_mount_name(name: &str) -> Result<(), RegistryError> {
     }
     Err(RegistryError::InvalidConfig {
         reason: format!(
-            "mount name {name:?} is not a single URL-safe path segment: it is served at \
+            "registry name {name:?} is not a single URL-safe path segment: it is served at \
              `/~<name>/`, so it cannot be empty, `.` or `..`, start with `.`, or contain `/`, \
              `\\`, `:`, `%`, `?`, `#`, whitespace, or control characters",
         ),
     })
 }
 
-/// A hosted mount's `org` becomes a storage path/key segment (`Storage::for_hosted`),
+/// A hosted registry's `org` becomes a storage path/key segment (`Storage::for_hosted`),
 /// so it must be empty (the flat root) or one safe component under the same
 /// rules as every other on-disk segment (no separators, traversal, leading
 /// dot, or Windows drive prefix) — otherwise a crafted config could read or
@@ -1725,33 +1729,36 @@ fn validate_org_namespace(name: &str, org: &str) -> Result<(), RegistryError> {
     }
     Err(RegistryError::InvalidConfig {
         reason: format!(
-            "hosted mount {name:?} has an invalid `org` {org:?}: it must be a single path-safe \
+            "hosted registry {name:?} has an invalid `org` {org:?}: it must be a single path-safe \
              segment (no `/`, `\\`, `:`, leading `.`, or traversal)",
         ),
     })
 }
 
-/// Compile a concrete mount's `patterns:` list into the decidable
+/// Compile a concrete registry's `patterns:` list into the decidable
 /// [`PackagePattern`] language. Duplicate patterns and the routing-graph
-/// checks are handled later by [`Mounts::validate`] once the whole graph
+/// checks are handled later by [`Registries::validate`] once the whole graph
 /// exists.
-fn build_patterns(mount: &str, patterns: &[String]) -> Result<Vec<PackagePattern>, RegistryError> {
+fn build_patterns(
+    registry: &str,
+    patterns: &[String],
+) -> Result<Vec<PackagePattern>, RegistryError> {
     patterns
         .iter()
         .map(|pattern| {
             PackagePattern::parse(pattern).map_err(|err| RegistryError::InvalidConfig {
-                reason: format!("mount {mount:?}: {err}"),
+                reason: format!("registry {registry:?}: {err}"),
             })
         })
         .collect()
 }
 
-/// Resolve an `upstream:` mount into the shared [`UplinkConfig`] runtime shape.
+/// Resolve an `upstream:` registry into the shared [`UplinkConfig`] runtime shape.
 /// A `public` upstream is anonymous and world-readable (no credential, no
 /// access gate); a non-`public` one must declare `access:` naming who may
-/// reach it at `/~<mount>/`. Declaring both `public` and `auth` is rejected —
+/// reach it at `/~<name>/`. Declaring both `public` and `auth` is rejected —
 /// a public origin sends no credential.
-fn resolve_upstream_mount<Sys: EnvVar>(
+fn resolve_upstream_registry<Sys: EnvVar>(
     name: &str,
     file: UpstreamFile,
 ) -> Result<UplinkConfig, RegistryError> {
@@ -1762,7 +1769,7 @@ fn resolve_upstream_mount<Sys: EnvVar>(
     if file.public && file.auth.is_some() {
         return Err(RegistryError::InvalidConfig {
             reason: format!(
-                "upstream mount {name:?} is `public` but also declares `auth`; a public origin \
+                "upstream registry {name:?} is `public` but also declares `auth`; a public origin \
                  sends no credential",
             ),
         });
@@ -1770,7 +1777,7 @@ fn resolve_upstream_mount<Sys: EnvVar>(
     if file.public && file.access.is_some() {
         return Err(RegistryError::InvalidConfig {
             reason: format!(
-                "upstream mount {name:?} is `public` but also declares `access`; a public origin \
+                "upstream registry {name:?} is `public` but also declares `access`; a public origin \
                  is reachable anonymously",
             ),
         });
@@ -1779,10 +1786,10 @@ fn resolve_upstream_mount<Sys: EnvVar>(
         // A public origin is fetched anonymously, so it sends no request headers
         // at all. Rejecting *any* custom header (not just `Authorization`) closes
         // the door on a credential smuggled through `X-Api-Key`, a cookie, or any
-        // other header on a mount that is meant to be reachable anonymously.
+        // other header on a registry that is meant to be reachable anonymously.
         return Err(RegistryError::InvalidConfig {
             reason: format!(
-                "upstream mount {name:?} is `public` but declares custom `headers`; a public \
+                "upstream registry {name:?} is `public` but declares custom `headers`; a public \
                  origin is fetched anonymously and sends none",
             ),
         });
@@ -1790,7 +1797,7 @@ fn resolve_upstream_mount<Sys: EnvVar>(
     if !file.public && file.access.is_none() {
         return Err(RegistryError::InvalidConfig {
             reason: format!(
-                "upstream mount {name:?} must set `public: true` or declare `access:` (who may \
+                "upstream registry {name:?} must set `public: true` or declare `access:` (who may \
                  reach it at /~{name}/)",
             ),
         });

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1504,7 +1504,7 @@ impl Config {
         // Upstream registries (and the credentials some carry) are resolved by
         // `build_registries` below into this map. Resolving an upstream registry's
         // `auth` is strict — an unresolvable token is a config error — so a
-        // resolver-only server (which registries no registry routes) skips the
+        // resolver-only server (which serves no registry routes) skips the
         // credential resolution rather than carry upstream secrets it never
         // uses. The registry *graph* is still built and validated either way, so
         // a misconfigured router or org fails startup on every tier, not only

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::RegistryError,
-    mount::{MountConfigError, MountKind, Mounts, PackagePattern, Route},
+    mount::{MountConfigError, MountKind, Mounts, PackagePattern},
     policy::{AccessGroups, AccessList, Identity, PackagePolicies, PackagePolicy},
     s3::{S3Settings, build_s3_store},
 };
@@ -143,9 +143,11 @@ pub struct Config {
     /// The validated registry-mount routing graph: every addressable origin
     /// (`/~<mount>/`) plus the optional path-less default target. Concrete
     /// upstream mounts are backed by [`Self::uplinks`]; hosted mounts by
-    /// [`Self::hosted`]; routers map package patterns to one of those.
-    /// Built and validated at config load — a misordered or self-referential
-    /// router fails startup rather than serving the wrong origin.
+    /// [`Self::hosted`]; each declares the package-name patterns it serves,
+    /// and a router selects the first of its sources whose patterns claim the
+    /// name. Built and validated at config load — a misordered or
+    /// self-referential router fails startup rather than serving the wrong
+    /// origin.
     pub mounts: Mounts,
     /// Hosted mounts, keyed by mount id. Each owns an `org` storage/serving
     /// namespace and an access policy gating its packages. The only mount kind
@@ -931,6 +933,10 @@ struct HostedFile {
     /// Who may read this mount's packages. Omitted ⇒ `$all`.
     #[serde(default)]
     access: Option<AccessSpec>,
+    /// The names this mount serves and accepts publishes for. Omitted ⇒ every
+    /// name.
+    #[serde(default)]
+    patterns: Vec<String>,
 }
 
 /// Disk shape of an `upstream:` mount — one external origin. Mirrors an
@@ -962,24 +968,20 @@ struct UpstreamFile {
     /// non-`public` upstream (otherwise no one could be authorized to use it).
     #[serde(default)]
     access: Option<AccessSpec>,
+    /// The names that may be requested through this mount. Omitted ⇒ every
+    /// name. Bounding a private upstream stops an authorized caller from
+    /// pulling arbitrary public names through its server-owned credential.
+    #[serde(default)]
+    patterns: Vec<String>,
 }
 
-/// Disk shape of a `router:` mount.
+/// Disk shape of a `router:` mount: an ordered list of concrete mount names.
+/// The first source whose declared patterns claim a package serves it.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RouterFile {
     #[serde(default)]
-    routes: Vec<RouteFile>,
-}
-
-/// Disk shape of one router route: package-name patterns mapped to a single
-/// concrete source mount.
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RouteFile {
-    #[serde(default)]
-    patterns: Vec<String>,
-    source: String,
+    sources: Vec<String>,
 }
 
 /// Disk shape of the YAML file. Fields verdaccio supports but
@@ -1147,13 +1149,14 @@ fn default_true() -> bool {
     true
 }
 
-/// The package-name patterns that [`Config::proxy`] routes to its flat-root
-/// hosted org rather than the npm upstream: the registry-mock fixture scopes
-/// plus the one unscoped fixture. Kept in sync with the bundled `config.yaml`
-/// router and the fixtures under `pnpr/.fixtures/packages`. The fixture
-/// packages living in real, active npm scopes (`@pnpm`, `@zkochan`) are
-/// routed by exact name so the rest of those scopes keeps proxying npm
-/// (dependency trees of proxied packages pull real `@pnpm/*` packages).
+/// The namespace [`Config::proxy`] declares on its flat-root hosted org, so
+/// those names resolve locally rather than to the npm upstream: the
+/// registry-mock fixture scopes plus the one unscoped fixture. Kept in sync
+/// with the bundled `config.yaml` `local` mount and the fixtures under
+/// `pnpr/.fixtures/packages`. The fixture packages living in real, active npm
+/// scopes (`@pnpm`, `@zkochan`) are claimed by exact name so the rest of
+/// those scopes keeps proxying npm (dependency trees of proxied packages pull
+/// real `@pnpm/*` packages).
 const REGISTRY_MOCK_LOCAL_PATTERNS: &[&str] = &[
     "@foo/*",
     "@having/*",
@@ -1184,12 +1187,13 @@ impl Config {
     pub const DEFAULT_PACKUMENT_TTL: Duration = Duration::from_mins(5);
 
     /// Build a proxy-mode config in the registry-mock shape: the fixture scopes
-    /// (and the one unscoped fixture) resolve to a flat-root hosted org over
-    /// `storage`, while every other name proxies to the `npmjs` upstream. The
-    /// path-less base aliases the `main` router. Kept for callers that don't use
-    /// YAML config (notably pacquet's test registry, whose fixtures are served
-    /// locally while real npm packages fall through to npmjs). The local pattern
-    /// set mirrors the bundled `config.yaml` router.
+    /// (and the one unscoped fixture) are the declared namespace of a flat-root
+    /// hosted org over `storage`, while every other name proxies to the
+    /// pattern-less `npmjs` upstream. The path-less base aliases the `main`
+    /// router. Kept for callers that don't use YAML config (notably pacquet's
+    /// test registry, whose fixtures are served locally while real npm packages
+    /// fall through to npmjs). The local pattern set mirrors the bundled
+    /// `config.yaml` `local` mount.
     #[must_use]
     pub fn proxy(listen: SocketAddr, storage: PathBuf) -> Self {
         let mut uplinks = IndexMap::new();
@@ -1205,20 +1209,15 @@ impl Config {
         let local_patterns = REGISTRY_MOCK_LOCAL_PATTERNS
             .iter()
             .map(|pattern| {
-                PackagePattern::parse(pattern).expect("valid built-in fixture route pattern")
+                PackagePattern::parse(pattern).expect("valid built-in fixture mount pattern")
             })
             .collect();
         let graph = [
-            ("local".to_string(), MountKind::Hosted),
-            ("npmjs".to_string(), MountKind::Upstream),
+            ("local".to_string(), MountKind::Hosted { patterns: local_patterns }),
+            ("npmjs".to_string(), MountKind::Upstream { patterns: Vec::new() }),
             (
                 "main".to_string(),
-                MountKind::Router {
-                    routes: vec![
-                        Route { patterns: local_patterns, source: "local".to_string() },
-                        Route { patterns: vec![PackagePattern::All], source: "npmjs".to_string() },
-                    ],
-                },
+                MountKind::Router { sources: vec!["local".to_string(), "npmjs".to_string()] },
             ),
         ];
         let mounts = Mounts::new(graph.into_iter().collect(), Some("main".to_string()));
@@ -1246,10 +1245,11 @@ impl Config {
         }
     }
 
-    /// Build a static-mode config that serves `storage` verbatim: one hosted
-    /// mount over the storage root (an empty `org` namespace == the flat root),
-    /// routed to by a `**` router that the path-less base aliases. Every package
-    /// resolves to that one hosted origin — no upstream, no fall-through.
+    /// Build a static-mode config that serves `storage` verbatim: one
+    /// pattern-less hosted mount over the storage root (an empty `org`
+    /// namespace == the flat root), the sole source of a router that the
+    /// path-less base aliases. Every package resolves to that one hosted
+    /// origin — no upstream, no fall-through.
     #[must_use]
     pub fn static_serve(listen: SocketAddr, storage: PathBuf) -> Self {
         let mut hosted = IndexMap::new();
@@ -1258,16 +1258,8 @@ impl Config {
             HostedConfig { org: String::new(), access: AccessList::parse("$all") },
         );
         let graph = [
-            ("local".to_string(), MountKind::Hosted),
-            (
-                "main".to_string(),
-                MountKind::Router {
-                    routes: vec![Route {
-                        patterns: vec![PackagePattern::All],
-                        source: "local".to_string(),
-                    }],
-                },
-            ),
+            ("local".to_string(), MountKind::Hosted { patterns: Vec::new() }),
+            ("main".to_string(), MountKind::Router { sources: vec!["local".to_string()] }),
         ];
         let mounts = Mounts::new(graph.into_iter().collect(), Some("main".to_string()));
         Self {
@@ -1636,10 +1628,10 @@ fn build_mounts(
     let mut hosted = IndexMap::new();
     let mut graph: IndexMap<String, MountKind> = IndexMap::new();
     // Every configured uplink is, by definition, an upstream mount addressable
-    // at `/~<uplink>/`.
+    // at `/~<uplink>/`. No declared patterns ⇒ it serves every name.
     for name in uplinks.keys() {
         validate_mount_name(name)?;
-        graph.insert(name.clone(), MountKind::Upstream);
+        graph.insert(name.clone(), MountKind::Upstream { patterns: Vec::new() });
     }
     for (name, file) in mount_files {
         validate_mount_name(&name)?;
@@ -1673,19 +1665,20 @@ fn build_mounts(
                     .access
                     .as_ref()
                     .map_or_else(|| AccessList::parse("$all"), AccessSpec::to_access_list);
+                let patterns = build_patterns(&name, &mount.patterns)?;
                 hosted.insert(name.clone(), HostedConfig { org: mount.org, access });
-                graph.insert(name, MountKind::Hosted);
+                graph.insert(name, MountKind::Hosted { patterns });
             }
             MountFile::Upstream(upstream) => {
+                let patterns = build_patterns(&name, &upstream.patterns)?;
                 if resolve_upstreams {
                     let resolved = resolve_upstream_mount::<SystemEnv>(&name, *upstream)?;
                     uplinks.insert(name.clone(), resolved);
                 }
-                graph.insert(name, MountKind::Upstream);
+                graph.insert(name, MountKind::Upstream { patterns });
             }
             MountFile::Router(router) => {
-                let routes = build_routes(&name, router.routes)?;
-                graph.insert(name, MountKind::Router { routes });
+                graph.insert(name, MountKind::Router { sources: router.sources });
             }
         }
     }
@@ -1738,22 +1731,17 @@ fn validate_org_namespace(name: &str, org: &str) -> Result<(), RegistryError> {
     })
 }
 
-/// Compile one router's `routes:` block, parsing each pattern into the decidable
-/// [`PackagePattern`] language. Source-mount validity (defined, concrete, not
-/// self) is checked later by [`Mounts::validate`] once the whole graph exists.
-fn build_routes(router: &str, routes: Vec<RouteFile>) -> Result<Vec<Route>, RegistryError> {
-    routes
-        .into_iter()
-        .map(|route| {
-            let patterns = route
-                .patterns
-                .iter()
-                .map(|pattern| PackagePattern::parse(pattern).map_err(|err| mount_err(&err)))
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|err| RegistryError::InvalidConfig {
-                    reason: format!("router {router:?}: {err}"),
-                })?;
-            Ok(Route { patterns, source: route.source })
+/// Compile a concrete mount's `patterns:` list into the decidable
+/// [`PackagePattern`] language. Duplicate patterns and the routing-graph
+/// checks are handled later by [`Mounts::validate`] once the whole graph
+/// exists.
+fn build_patterns(mount: &str, patterns: &[String]) -> Result<Vec<PackagePattern>, RegistryError> {
+    patterns
+        .iter()
+        .map(|pattern| {
+            PackagePattern::parse(pattern).map_err(|err| RegistryError::InvalidConfig {
+                reason: format!("mount {mount:?}: {err}"),
+            })
         })
         .collect()
 }

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1561,6 +1561,22 @@ impl Config {
         }
     }
 
+    /// Ready the registry graph for serving: fold every uplink into the graph
+    /// as a pattern-less upstream registry, then validate the whole graph.
+    /// YAML loading already declares each uplink in the graph and validates
+    /// it; this covers embedders that insert [`Self::uplinks`] entries (or
+    /// build [`Self::registries`]) programmatically, so [`Registries::resolve`]
+    /// is the only dispatch table for `/~<name>/` traffic and a
+    /// programmatically-built graph fails closed like a YAML load. An
+    /// embedder that wants a namespace bound on an uplink declares its
+    /// registry entry (with patterns) before serving.
+    pub fn ensure_valid_registry_graph(&mut self) -> Result<(), RegistryError> {
+        for name in self.uplinks.keys() {
+            self.registries.ensure_upstream(name);
+        }
+        self.registries.validate().map_err(|err| registry_err(&err))
+    }
+
     /// Build the caller identity used by access policies after a bearer
     /// token has authenticated `username`.
     #[must_use]

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1577,6 +1577,20 @@ impl Config {
     pub fn ensure_valid_registry_graph(&mut self) -> Result<(), RegistryError> {
         for name in self.upstreams.keys() {
             self.registries.ensure_upstream(name);
+            // The fold never overwrites, so a graph entry already declared
+            // under this name must actually be the upstream — otherwise two
+            // different origins would share one `/~<name>/` identity, with
+            // the dormant upstream's credential still offered by the
+            // resolver. YAML loading rejects the same collision while
+            // building the graph.
+            if !matches!(self.registries.get(name), Some(Registry::Upstream { .. })) {
+                return Err(RegistryError::InvalidConfig {
+                    reason: format!(
+                        "upstream registry {name:?} collides with a non-upstream registry of \
+                         the same name",
+                    ),
+                });
+            }
         }
         for name in self.registries.names() {
             validate_registry_name(name)?;
@@ -1613,6 +1627,20 @@ impl Config {
         for (index, (name, hosted)) in self.hosted.iter().enumerate() {
             validate_registry_name(name)?;
             validate_org_namespace(name, &hosted.org)?;
+            // The mirror of the upstream collision above: a hosted serving row
+            // under a name the graph declares as a different kind would leave
+            // `/~<name>/` serving one origin while the row describes another.
+            // (A row with no graph entry at all is merely dormant.)
+            if let Some(kind) = self.registries.get(name)
+                && !matches!(kind, Registry::Hosted { .. })
+            {
+                return Err(RegistryError::InvalidConfig {
+                    reason: format!(
+                        "hosted registry {name:?} collides with a non-hosted registry of the \
+                         same name",
+                    ),
+                });
+            }
             if let Some((other, _)) =
                 self.hosted.iter().take(index).find(|(_, existing)| existing.org == hosted.org)
             {

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1619,6 +1619,21 @@ impl Config {
                 return Err(org_collision_error(name, &hosted.org, other));
             }
         }
+        for (name, upstream) in &self.upstreams {
+            // Mirror the YAML rule (`resolve_upstream_registry`): an upstream
+            // with no `access:` gate is publicly reachable at `/~<name>/`, and
+            // a public origin sends no request headers — any header can carry
+            // a credential, and an ungated endpoint would let every caller
+            // spend it (a confused deputy).
+            if upstream.access.is_none() && !upstream.headers.is_empty() {
+                return Err(RegistryError::InvalidConfig {
+                    reason: format!(
+                        "upstream registry {name:?} sends custom headers but declares no \
+                         `access:` gate; a publicly reachable upstream must send none",
+                    ),
+                });
+            }
+        }
         self.registries.validate().map_err(|err| registry_err(&err))
     }
 

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1196,7 +1196,7 @@ impl Config {
     /// test registry, whose fixtures are served locally while real npm packages
     /// fall through to npmjs). The local pattern set mirrors the fixture
     /// subset of the bundled `config.yaml` `local` registry
-    /// ([`REGISTRY_MOCK_LOCAL_PATTERNS`]); the YAML additionally claims the
+    /// (`REGISTRY_MOCK_LOCAL_PATTERNS`); the YAML additionally claims the
     /// exact names the TS test suite publishes, which never reach this
     /// constructor.
     #[must_use]

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -20,7 +20,7 @@ use std::{
 /// The bundled verdaccio-shaped YAML config, mirrored from
 /// `@pnpm/registry-mock`'s `registry/config.yaml`. Other crates can
 /// pull this in directly when they need pnpr's defaults
-/// (uplinks, package routing) without reading a file from disk —
+/// (upstreams, package routing) without reading a file from disk —
 /// e.g. test mocks that want to run with the standard `**` -> `npmjs`
 /// routing applied.
 pub const DEFAULT_CONFIG_YAML: &str = include_str!("../config.yaml");
@@ -43,7 +43,7 @@ pub enum ConfigSource {
 /// Runtime configuration for the pnpm registry server.
 ///
 /// The persisted (YAML) shape follows verdaccio's `config.yaml` —
-/// `storage`, `uplinks`, `packages` — restricted to the subset
+/// `storage`, `upstreams`, `packages` — restricted to the subset
 /// pnpr implements (no web UI, auth, plugins, or logs
 /// routing).
 ///
@@ -74,7 +74,7 @@ pub struct Config {
     /// Upstream-registry backends, keyed by registry id. Built from the `registries:`
     /// `upstream` entries and consumed by the `/~<name>/` serving and route
     /// classification.
-    pub uplinks: IndexMap<String, UplinkConfig>,
+    pub upstreams: IndexMap<String, UpstreamConfig>,
     /// The raw per-package `access` / `publish` / `unpublish` rules from the
     /// YAML `packages:` block, in declared order. [`Self::policies`] is the
     /// compiled form the server enforces; this keeps the declared shape for
@@ -85,7 +85,7 @@ pub struct Config {
     /// package policies and upstream aliases.
     pub groups: AccessGroups,
     /// How long a cached packument is considered fresh before it is
-    /// re-fetched from the resolved uplink. Ignored when no uplink
+    /// re-fetched from the resolved upstream. Ignored when no upstream
     /// matches.
     pub packument_ttl: Duration,
     /// Per-package access, publish, and unpublish rules. [`Config::from_yaml`]
@@ -142,7 +142,7 @@ pub struct Config {
     pub resolution_cache_secret: Arc<[u8]>,
     /// The validated registry routing graph: every addressable origin
     /// (`/~<name>/`) plus the optional path-less default target. Concrete
-    /// upstream registries are backed by [`Self::uplinks`]; hosted registries by
+    /// upstream registries are backed by [`Self::upstreams`]; hosted registries by
     /// [`Self::hosted`]; each declares the package-name patterns it serves,
     /// and a router selects the first of its sources whose patterns claim the
     /// name. Built and validated at config load — a misordered or
@@ -229,8 +229,8 @@ impl Default for ResolverFeature {
 
 /// CLI-level overrides for the feature toggles, applied *during* config
 /// parse so the effective surface enablement is known before any
-/// registry-only work runs. This matters because uplink resolution is
-/// strict (a `uplink.auth` block with an unresolvable token is a config
+/// registry-only work runs. This matters because upstream resolution is
+/// strict (a `upstream.auth` block with an unresolvable token is a config
 /// error): applying `--disable-registry` only after parsing would still
 /// force a resolver-only tier to carry upstream secrets. A `true` field
 /// forces the corresponding surface off regardless of what the config
@@ -481,52 +481,52 @@ impl LogLevel {
     }
 }
 
-/// Runtime uplink declaration: the upstream `url`, the request headers
-/// pnpr attaches to every fetch it makes to that uplink, and the
-/// verdaccio per-uplink tuning knobs (`maxage`, `timeout`, `max_fails`,
+/// Runtime upstream declaration: the upstream `url`, the request headers
+/// pnpr attaches to every fetch it makes to that upstream, and the
+/// verdaccio per-upstream tuning knobs (`maxage`, `timeout`, `max_fails`,
 /// `fail_timeout`, `cache`).
 ///
 /// [`Self::headers`] is resolved once, at config load, from the YAML
 /// `auth:` block (an `Authorization` header derived from
 /// `type`/`token`/`token_env`) merged with the `headers:` map. The
-/// parse-time shape lives in `UplinkFile`; `resolve_uplink` turns
+/// parse-time shape lives in `UpstreamConfigFile`; `resolve_upstream_config` turns
 /// one into the other. Verdaccio fields pnpr doesn't model yet
 /// (agent options, `strict_ssl`, ...) are accepted and dropped.
 #[derive(Clone)]
-pub struct UplinkConfig {
+pub struct UpstreamConfig {
     pub url: String,
     /// Auth + custom headers, fully resolved and ready to attach to
-    /// every request pnpr makes to this uplink.
+    /// every request pnpr makes to this upstream.
     pub headers: HeaderMap,
-    /// Per-uplink packument freshness window (verdaccio's `maxage`).
+    /// Per-upstream packument freshness window (verdaccio's `maxage`).
     /// `None` when the YAML omits it — the proxy then falls back to the
     /// global [`Config::packument_ttl`], so the existing
-    /// `--packument-ttl-secs` flag still governs uplinks that don't set
+    /// `--packument-ttl-secs` flag still governs upstreams that don't set
     /// their own.
     pub maxage: Option<Duration>,
-    /// Per-request deadline for every fetch to this uplink (verdaccio's
+    /// Per-request deadline for every fetch to this upstream (verdaccio's
     /// `timeout`). Defaults to [`Self::DEFAULT_TIMEOUT`].
     pub timeout: Duration,
-    /// Consecutive failures before the uplink is treated as down
+    /// Consecutive failures before the upstream is treated as down
     /// (verdaccio's `max_fails`). Defaults to [`Self::DEFAULT_MAX_FAILS`].
     pub max_fails: u32,
-    /// How long a down uplink stays down before pnpr retries it
+    /// How long a down upstream stays down before pnpr retries it
     /// (verdaccio's `fail_timeout`). Defaults to
     /// [`Self::DEFAULT_FAIL_TIMEOUT`].
     pub fail_timeout: Duration,
-    /// Whether tarballs fetched from this uplink are written to the local
+    /// Whether tarballs fetched from this upstream are written to the local
     /// mirror (verdaccio's `cache`). `false` streams them through
     /// uncached. Defaults to `true`.
     pub cache: bool,
-    /// Which pnpr callers may select this uplink as a proxied private-route
+    /// Which pnpr callers may select this upstream as a proxied private-route
     /// credential, and reach it through its `/~<name>/` registry endpoint.
-    /// `None` means the uplink is registry-proxy only and is never offered as
-    /// a resolver private-route credential — only uplinks that declare
+    /// `None` means the upstream is registry-proxy only and is never offered as
+    /// a resolver private-route credential — only upstreams that declare
     /// `access:` participate in route classification.
     pub access: Option<AccessList>,
 }
 
-impl UplinkConfig {
+impl UpstreamConfig {
     /// Verdaccio's `timeout` default (`30s`).
     pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
     /// Verdaccio's `max_fails` default (`2`).
@@ -534,7 +534,7 @@ impl UplinkConfig {
     /// Verdaccio's `fail_timeout` default (`5m`).
     pub const DEFAULT_FAIL_TIMEOUT: Duration = Duration::from_mins(5);
 
-    /// Build a bare uplink with just a URL and headers, all tuning knobs
+    /// Build a bare upstream with just a URL and headers, all tuning knobs
     /// at their verdaccio defaults. Used by the programmatic
     /// [`Config::proxy`] constructor and tests.
     pub(crate) fn with_defaults(url: String, headers: HeaderMap) -> Self {
@@ -551,9 +551,9 @@ impl UplinkConfig {
     }
 }
 
-impl fmt::Debug for UplinkConfig {
+impl fmt::Debug for UpstreamConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("UplinkConfig")
+        f.debug_struct("UpstreamConfig")
             .field("url", &self.url)
             .field("headers", &RedactedHeaders(&self.headers))
             .field("maxage", &self.maxage)
@@ -567,7 +567,7 @@ impl fmt::Debug for UplinkConfig {
 }
 
 /// Wraps a [`HeaderMap`] so its `Debug` lists header names with values
-/// redacted. Uplink headers carry credentials (an `Authorization`, or
+/// redacted. Upstream headers carry credentials (an `Authorization`, or
 /// an API key in a custom header), and those must never reach a log
 /// line, span, or diagnostic dump.
 pub(crate) struct RedactedHeaders<'a>(pub(crate) &'a HeaderMap);
@@ -578,21 +578,21 @@ impl fmt::Debug for RedactedHeaders<'_> {
     }
 }
 
-/// The serving knobs of an upstream registry, in verdaccio's uplink shape for
+/// The serving knobs of an upstream registry, in verdaccio's upstream shape for
 /// the subset pnpr implements: `url`, an `auth:` block, and a free-form
 /// `headers:` map. Built from an `upstream:` registry entry
-/// ([`resolve_upstream_registry`]) and resolved into [`UplinkConfig`] by
-/// [`resolve_uplink`].
+/// ([`resolve_upstream_registry`]) and resolved into [`UpstreamConfig`] by
+/// [`resolve_upstream_config`].
 #[derive(Debug, Deserialize)]
-struct UplinkFile {
+struct UpstreamConfigFile {
     url: String,
     #[serde(default)]
-    auth: Option<UplinkAuthFile>,
+    auth: Option<UpstreamAuthFile>,
     #[serde(default)]
     headers: IndexMap<String, String>,
     /// Verdaccio interval strings (`"2m"`, `"30s"`, `"1h30m"`) or a bare
     /// number of seconds; parsed by [`parse_interval`] in
-    /// [`resolve_uplink`]. Kept as raw strings here so an unparsable
+    /// [`resolve_upstream_config`]. Kept as raw strings here so an unparsable
     /// value surfaces as a config error rather than a serde failure.
     #[serde(default)]
     maxage: Option<Interval>,
@@ -604,8 +604,8 @@ struct UplinkFile {
     fail_timeout: Option<Interval>,
     #[serde(default)]
     cache: Option<bool>,
-    /// Which pnpr callers may select this uplink as a proxied private-route
-    /// credential. Its presence is what promotes a plain proxy uplink into a
+    /// Which pnpr callers may select this upstream as a proxied private-route
+    /// credential. Its presence is what promotes a plain proxy upstream into a
     /// resolver private-route credential exposed at `/~<name>/`.
     #[serde(default)]
     access: Option<AccessSpec>,
@@ -647,12 +647,12 @@ impl<'de> Deserialize<'de> for Interval {
     }
 }
 
-/// The YAML `auth:` block on an uplink. `token` takes priority over
+/// The YAML `auth:` block on an upstream. `token` takes priority over
 /// `token_env`; either resolves to the credential placed in the
-/// `Authorization` header, encoded per [`UplinkAuthType`].
+/// `Authorization` header, encoded per [`UpstreamAuthType`].
 #[derive(Debug, Deserialize)]
-struct UplinkAuthFile {
-    r#type: UplinkAuthType,
+struct UpstreamAuthFile {
+    r#type: UpstreamAuthType,
     #[serde(default)]
     token: Option<String>,
     #[serde(default)]
@@ -665,7 +665,7 @@ struct UplinkAuthFile {
 /// token is already a base64 `user:pass`).
 #[derive(Debug, Clone, Copy, Deserialize)]
 #[serde(rename_all = "lowercase")]
-enum UplinkAuthType {
+enum UpstreamAuthType {
     Bearer,
     Basic,
 }
@@ -694,7 +694,7 @@ impl TokenEnv {
     }
 }
 
-/// Resolve one parsed [`UplinkFile`] into a runtime [`UplinkConfig`],
+/// Resolve one parsed [`UpstreamConfigFile`] into a runtime [`UpstreamConfig`],
 /// baking the `auth:` credential and `headers:` map into a single
 /// [`HeaderMap`]. Reads env vars (for `token_env`) through `Sys` so
 /// the resolution is testable.
@@ -705,37 +705,37 @@ impl TokenEnv {
 /// merge order. A configured `auth:` block that resolves to no token,
 /// an unknown header name, or a non-ASCII header value is a config
 /// error rather than a silent unauthenticated request.
-fn resolve_uplink<Sys: EnvVar>(
+fn resolve_upstream_config<Sys: EnvVar>(
     name: &str,
-    file: UplinkFile,
-) -> Result<UplinkConfig, RegistryError> {
+    file: UpstreamConfigFile,
+) -> Result<UpstreamConfig, RegistryError> {
     let mut headers = HeaderMap::new();
     if let Some(auth) = &file.auth {
         let token =
-            resolve_uplink_token::<Sys>(auth).ok_or_else(|| RegistryError::InvalidConfig {
+            resolve_upstream_token::<Sys>(auth).ok_or_else(|| RegistryError::InvalidConfig {
                 reason: format!(
-                    "uplink {name:?} has an auth block but no token could be resolved \
+                    "upstream {name:?} has an auth block but no token could be resolved \
                      (set auth.token or point auth.token_env at a set env var)",
                 ),
             })?;
         let value = match auth.r#type {
-            UplinkAuthType::Bearer => format!("Bearer {token}"),
-            UplinkAuthType::Basic => format!("Basic {token}"),
+            UpstreamAuthType::Bearer => format!("Bearer {token}"),
+            UpstreamAuthType::Basic => format!("Basic {token}"),
         };
         let value = HeaderValue::from_str(&value).map_err(|_| RegistryError::InvalidConfig {
-            reason: format!("uplink {name:?} auth token is not a valid header value"),
+            reason: format!("upstream {name:?} auth token is not a valid header value"),
         })?;
         headers.insert(AUTHORIZATION, value);
     }
     for (raw_name, raw_value) in &file.headers {
         let header_name = HeaderName::from_bytes(raw_name.as_bytes()).map_err(|_| {
             RegistryError::InvalidConfig {
-                reason: format!("uplink {name:?} has an invalid header name {raw_name:?}"),
+                reason: format!("upstream {name:?} has an invalid header name {raw_name:?}"),
             }
         })?;
         let header_value =
             HeaderValue::from_str(raw_value).map_err(|_| RegistryError::InvalidConfig {
-                reason: format!("uplink {name:?} header {raw_name:?} has an invalid value"),
+                reason: format!("upstream {name:?} header {raw_name:?} has an invalid value"),
             })?;
         headers.insert(header_name, header_value);
     }
@@ -749,22 +749,22 @@ fn resolve_uplink<Sys: EnvVar>(
         raw.as_ref()
             .map(|Interval(value)| {
                 parse_interval(value).ok_or_else(|| RegistryError::InvalidConfig {
-                    reason: format!("uplink {name:?} has an invalid {field} interval {value:?}"),
+                    reason: format!("upstream {name:?} has an invalid {field} interval {value:?}"),
                 })
             })
             .transpose()
     };
     let maxage = parse_field("maxage", &file.maxage)?;
-    let timeout = parse_field("timeout", &file.timeout)?.unwrap_or(UplinkConfig::DEFAULT_TIMEOUT);
+    let timeout = parse_field("timeout", &file.timeout)?.unwrap_or(UpstreamConfig::DEFAULT_TIMEOUT);
     let fail_timeout = parse_field("fail_timeout", &file.fail_timeout)?
-        .unwrap_or(UplinkConfig::DEFAULT_FAIL_TIMEOUT);
+        .unwrap_or(UpstreamConfig::DEFAULT_FAIL_TIMEOUT);
 
-    Ok(UplinkConfig {
+    Ok(UpstreamConfig {
         url: file.url,
         headers,
         maxage,
         timeout,
-        max_fails: file.max_fails.unwrap_or(UplinkConfig::DEFAULT_MAX_FAILS),
+        max_fails: file.max_fails.unwrap_or(UpstreamConfig::DEFAULT_MAX_FAILS),
         fail_timeout,
         cache: file.cache.unwrap_or(true),
         access: file.access.as_ref().map(AccessSpec::to_access_list),
@@ -827,9 +827,9 @@ fn parse_interval(raw: &str) -> Option<Duration> {
     Duration::try_from_secs_f64(total_seconds).ok()
 }
 
-/// Pick the credential for an uplink's `auth:` block: an explicit
+/// Pick the credential for an upstream's `auth:` block: an explicit
 /// `token` wins; otherwise read the env var named by `token_env`.
-fn resolve_uplink_token<Sys: EnvVar>(auth: &UplinkAuthFile) -> Option<String> {
+fn resolve_upstream_token<Sys: EnvVar>(auth: &UpstreamAuthFile) -> Option<String> {
     if let Some(token) = &auth.token {
         return non_empty_token(token);
     }
@@ -940,7 +940,7 @@ struct HostedFile {
 }
 
 /// Disk shape of an `upstream:` registry — one external origin. Mirrors an
-/// uplink's tuning knobs plus `public` (an anonymous, no-credential origin)
+/// upstream's tuning knobs plus `public` (an anonymous, no-credential origin)
 /// and `access` (which pnpr callers may reach a private one).
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -951,7 +951,7 @@ struct UpstreamFile {
     #[serde(default)]
     public: bool,
     #[serde(default)]
-    auth: Option<UplinkAuthFile>,
+    auth: Option<UpstreamAuthFile>,
     #[serde(default)]
     headers: IndexMap<String, String>,
     #[serde(default)]
@@ -1020,7 +1020,7 @@ struct ConfigFile {
     resolver: Option<FeatureFile>,
     /// pnpr registries: hosted, upstream, and router origins, each
     /// exposed at `/~<name>/`. The only routing surface — there is no legacy
-    /// `uplinks:`/`packages: proxy:` fallback.
+    /// `upstreams:`/`packages: proxy:` fallback.
     #[serde(default)]
     registries: IndexMap<String, RegistryFile>,
     /// The registry the path-less base URL aliases. Absent ⇒ the bare host has no
@@ -1196,10 +1196,13 @@ impl Config {
     /// `config.yaml` `local` registry.
     #[must_use]
     pub fn proxy(listen: SocketAddr, storage: PathBuf) -> Self {
-        let mut uplinks = IndexMap::new();
-        uplinks.insert(
+        let mut upstreams = IndexMap::new();
+        upstreams.insert(
             "npmjs".to_string(),
-            UplinkConfig::with_defaults("https://registry.npmjs.org".to_string(), HeaderMap::new()),
+            UpstreamConfig::with_defaults(
+                "https://registry.npmjs.org".to_string(),
+                HeaderMap::new(),
+            ),
         );
         let mut hosted = IndexMap::new();
         hosted.insert(
@@ -1226,7 +1229,7 @@ impl Config {
             public_url: format!("http://{listen}"),
             cache_storage: default_cache_dir(&storage),
             storage,
-            uplinks,
+            upstreams,
             packages: IndexMap::new(),
             groups: AccessGroups::default(),
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
@@ -1267,7 +1270,7 @@ impl Config {
             public_url: format!("http://{listen}"),
             cache_storage: default_cache_dir(&storage),
             storage,
-            uplinks: IndexMap::new(),
+            upstreams: IndexMap::new(),
             packages: IndexMap::new(),
             groups: AccessGroups::default(),
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
@@ -1412,7 +1415,7 @@ impl Config {
 
     /// Like [`Self::resolve`] but applies CLI [`FeatureOverrides`] during
     /// parse, so a surface disabled on the command line skips its parse-time
-    /// work (e.g. strict uplink token resolution) — not just its routes. The
+    /// work (e.g. strict upstream token resolution) — not just its routes. The
     /// binary uses this; tests and embedders that don't override features
     /// call [`Self::resolve`].
     pub fn resolve_with_overrides(
@@ -1494,7 +1497,7 @@ impl Config {
         // The npm-registry surface is derived, not configured: served iff
         // at least one registry is declared (no registries ⇒ nothing to serve),
         // minus the per-tier `--disable-registry` override. Folding the
-        // override in here lets the registry-only work below (uplink
+        // override in here lets the registry-only work below (upstream
         // credential resolution) key off effective enablement.
         let registry =
             RegistryFeature { enabled: !file.registries.is_empty() && !overrides.disable_registry };
@@ -1509,9 +1512,9 @@ impl Config {
         // uses. The registry *graph* is still built and validated either way, so
         // a misconfigured router or org fails startup on every tier, not only
         // when the registry surface happens to be enabled.
-        let mut uplinks: IndexMap<String, UplinkConfig> = IndexMap::new();
+        let mut upstreams: IndexMap<String, UpstreamConfig> = IndexMap::new();
         let (hosted, registries) = build_registries(
-            &mut uplinks,
+            &mut upstreams,
             file.registries,
             file.default_registry,
             registry.enabled,
@@ -1523,7 +1526,7 @@ impl Config {
             public_url,
             storage,
             cache_storage,
-            uplinks,
+            upstreams,
             packages: file.packages,
             groups,
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
@@ -1561,22 +1564,51 @@ impl Config {
         }
     }
 
-    /// Ready the registry graph for serving: fold every uplink into the graph
+    /// Ready the registry graph for serving: fold every upstream into the graph
     /// as a pattern-less upstream registry, then apply every invariant YAML
     /// loading enforces — URL-safe registry names, path-safe and collision-free
     /// hosted `org` namespaces, and the graph validation itself. This covers
-    /// embedders that build [`Self::uplinks`], [`Self::hosted`], or
+    /// embedders that build [`Self::upstreams`], [`Self::hosted`], or
     /// [`Self::registries`] programmatically, so [`Registries::resolve`] is the
     /// only dispatch table for `/~<name>/` traffic and a programmatically-built
     /// config fails closed like a YAML load. An embedder that wants a
-    /// namespace bound on an uplink declares its registry entry (with
+    /// namespace bound on an upstream declares its registry entry (with
     /// patterns) before serving.
     pub fn ensure_valid_registry_graph(&mut self) -> Result<(), RegistryError> {
-        for name in self.uplinks.keys() {
+        for name in self.upstreams.keys() {
             self.registries.ensure_upstream(name);
         }
         for name in self.registries.names() {
             validate_registry_name(name)?;
+            // A concrete registry needs its serving config — a hosted graph
+            // entry without its `hosted` table row (or an upstream without
+            // its serving entry) would answer every request not-found at
+            // runtime. YAML loading builds both sides together; catch a
+            // programmatically-built mismatch at startup. Upstream backing
+            // is only required when the registry surface is enabled: a
+            // resolver-only tier deliberately skips upstream (credential)
+            // resolution and never serves `/~<name>/` content.
+            match self.registries.get(name) {
+                Some(Registry::Hosted { .. }) if !self.hosted.contains_key(name) => {
+                    return Err(RegistryError::InvalidConfig {
+                        reason: format!(
+                            "hosted registry {name:?} has no entry in the hosted serving table; \
+                             every request to it would be not-found",
+                        ),
+                    });
+                }
+                Some(Registry::Upstream { .. })
+                    if self.registry.enabled && !self.upstreams.contains_key(name) =>
+                {
+                    return Err(RegistryError::InvalidConfig {
+                        reason: format!(
+                            "upstream registry {name:?} has no serving config (URL, credentials); \
+                             every request to it would fail",
+                        ),
+                    });
+                }
+                _ => {}
+            }
         }
         for (index, (name, hosted)) in self.hosted.iter().enumerate() {
             validate_registry_name(name)?;
@@ -1642,9 +1674,9 @@ fn registry_err(err: &RegistryConfigError) -> RegistryError {
 }
 
 /// Build the validated [`Registries`] graph (and the hosted table) from the
-/// resolved uplinks and the `registries:` block. Every uplink is an upstream
+/// resolved upstreams and the `registries:` block. Every upstream is an upstream
 /// registry; `registries:` adds hosted, further upstream, and router registries.
-/// Upstream registries declared under `registries:` are folded into `uplinks` so they
+/// Upstream registries declared under `registries:` are folded into `upstreams` so they
 /// reuse the same serving and route-classification machinery. Fails closed on
 /// any name collision, malformed registry, or invalid routing graph.
 ///
@@ -1653,16 +1685,16 @@ fn registry_err(err: &RegistryConfigError) -> RegistryError {
 /// and serving config are not resolved — a resolver-only tier must not fail
 /// on (or carry) upstream secrets it never uses.
 fn build_registries(
-    uplinks: &mut IndexMap<String, UplinkConfig>,
+    upstreams: &mut IndexMap<String, UpstreamConfig>,
     registry_files: IndexMap<String, RegistryFile>,
     default_registry: Option<String>,
     resolve_upstreams: bool,
 ) -> Result<(IndexMap<String, HostedConfig>, Registries), RegistryError> {
     let mut hosted: IndexMap<String, HostedConfig> = IndexMap::new();
     let mut graph: IndexMap<String, Registry> = IndexMap::new();
-    // Every configured uplink is, by definition, an upstream registry addressable
-    // at `/~<uplink>/`. No declared patterns ⇒ it serves every name.
-    for name in uplinks.keys() {
+    // Every configured upstream is, by definition, an upstream registry addressable
+    // at `/~<name>/`. No declared patterns ⇒ it serves every name.
+    for name in upstreams.keys() {
         validate_registry_name(name)?;
         graph.insert(name.clone(), Registry::Upstream { patterns: Vec::new() });
     }
@@ -1671,7 +1703,7 @@ fn build_registries(
         if graph.contains_key(&name) {
             return Err(RegistryError::InvalidConfig {
                 reason: format!(
-                    "registry {name:?} collides with another registry or uplink of the same name",
+                    "registry {name:?} collides with another registry or upstream of the same name",
                 ),
             });
         }
@@ -1696,7 +1728,7 @@ fn build_registries(
                 let patterns = build_patterns(&name, &upstream.patterns)?;
                 if resolve_upstreams {
                     let resolved = resolve_upstream_registry::<SystemEnv>(&name, *upstream)?;
-                    uplinks.insert(name.clone(), resolved);
+                    upstreams.insert(name.clone(), resolved);
                 }
                 graph.insert(name, Registry::Upstream { patterns });
             }
@@ -1785,7 +1817,7 @@ fn build_patterns(
         .collect()
 }
 
-/// Resolve an `upstream:` registry into the shared [`UplinkConfig`] runtime shape.
+/// Resolve an `upstream:` registry into the shared [`UpstreamConfig`] runtime shape.
 /// A `public` upstream is anonymous and world-readable (no credential, no
 /// access gate); a non-`public` one must declare `access:` naming who may
 /// reach it at `/~<name>/`. Declaring both `public` and `auth` is rejected —
@@ -1793,7 +1825,7 @@ fn build_patterns(
 fn resolve_upstream_registry<Sys: EnvVar>(
     name: &str,
     file: UpstreamFile,
-) -> Result<UplinkConfig, RegistryError> {
+) -> Result<UpstreamConfig, RegistryError> {
     // A public origin is anonymous and shared, so every credential-bearing or
     // access-gating knob contradicts `public: true` and must fail closed rather
     // than be silently ignored (which would send a credential to, or expose, a
@@ -1835,7 +1867,7 @@ fn resolve_upstream_registry<Sys: EnvVar>(
         });
     }
     let access = if file.public { None } else { file.access };
-    let uplink_file = UplinkFile {
+    let upstream_config_file = UpstreamConfigFile {
         url: file.url,
         auth: file.auth,
         headers: file.headers,
@@ -1846,7 +1878,7 @@ fn resolve_upstream_registry<Sys: EnvVar>(
         cache: file.cache,
         access,
     };
-    resolve_uplink::<Sys>(name, uplink_file)
+    resolve_upstream_config::<Sys>(name, upstream_config_file)
 }
 
 fn build_groups(file: &IndexMap<String, AccessSpec>) -> AccessGroups {

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1562,17 +1562,30 @@ impl Config {
     }
 
     /// Ready the registry graph for serving: fold every uplink into the graph
-    /// as a pattern-less upstream registry, then validate the whole graph.
-    /// YAML loading already declares each uplink in the graph and validates
-    /// it; this covers embedders that insert [`Self::uplinks`] entries (or
-    /// build [`Self::registries`]) programmatically, so [`Registries::resolve`]
-    /// is the only dispatch table for `/~<name>/` traffic and a
-    /// programmatically-built graph fails closed like a YAML load. An
-    /// embedder that wants a namespace bound on an uplink declares its
-    /// registry entry (with patterns) before serving.
+    /// as a pattern-less upstream registry, then apply every invariant YAML
+    /// loading enforces — URL-safe registry names, path-safe and collision-free
+    /// hosted `org` namespaces, and the graph validation itself. This covers
+    /// embedders that build [`Self::uplinks`], [`Self::hosted`], or
+    /// [`Self::registries`] programmatically, so [`Registries::resolve`] is the
+    /// only dispatch table for `/~<name>/` traffic and a programmatically-built
+    /// config fails closed like a YAML load. An embedder that wants a
+    /// namespace bound on an uplink declares its registry entry (with
+    /// patterns) before serving.
     pub fn ensure_valid_registry_graph(&mut self) -> Result<(), RegistryError> {
         for name in self.uplinks.keys() {
             self.registries.ensure_upstream(name);
+        }
+        for name in self.registries.names() {
+            validate_registry_name(name)?;
+        }
+        for (index, (name, hosted)) in self.hosted.iter().enumerate() {
+            validate_registry_name(name)?;
+            validate_org_namespace(name, &hosted.org)?;
+            if let Some((other, _)) =
+                self.hosted.iter().take(index).find(|(_, existing)| existing.org == hosted.org)
+            {
+                return Err(org_collision_error(name, &hosted.org, other));
+            }
         }
         self.registries.validate().map_err(|err| registry_err(&err))
     }
@@ -1645,7 +1658,7 @@ fn build_registries(
     default_registry: Option<String>,
     resolve_upstreams: bool,
 ) -> Result<(IndexMap<String, HostedConfig>, Registries), RegistryError> {
-    let mut hosted = IndexMap::new();
+    let mut hosted: IndexMap<String, HostedConfig> = IndexMap::new();
     let mut graph: IndexMap<String, Registry> = IndexMap::new();
     // Every configured uplink is, by definition, an upstream registry addressable
     // at `/~<uplink>/`. No declared patterns ⇒ it serves every name.
@@ -1665,21 +1678,11 @@ fn build_registries(
         match file {
             RegistryFile::Hosted(registry) => {
                 validate_org_namespace(&name, &registry.org)?;
-                // Two hosted registries sharing an `org` would read and write the
-                // same storage namespace, so a package published to one would
-                // surface through the other — breaking the declared-provenance
-                // isolation. Reject the collision at load.
                 if let Some((other, _)) = hosted
                     .iter()
                     .find(|(_, existing): &(_, &HostedConfig)| existing.org == registry.org)
                 {
-                    return Err(RegistryError::InvalidConfig {
-                        reason: format!(
-                            "hosted registry {name:?} reuses the `org` namespace {:?} already claimed \
-                             by registry {other:?}; two hosted registries cannot share a namespace",
-                            registry.org,
-                        ),
-                    });
+                    return Err(org_collision_error(&name, &registry.org, other));
                 }
                 let access = registry
                     .access
@@ -1705,6 +1708,19 @@ fn build_registries(
     let registries = Registries::new(graph, default_registry);
     registries.validate().map_err(|err| registry_err(&err))?;
     Ok((hosted, registries))
+}
+
+/// Two hosted registries sharing an `org` would read and write the same
+/// storage namespace, so a package published to one would surface through the
+/// other — breaking the declared-provenance isolation. Rejected at load,
+/// whether the config came from YAML or an embedder.
+fn org_collision_error(name: &str, org: &str, other: &str) -> RegistryError {
+    RegistryError::InvalidConfig {
+        reason: format!(
+            "hosted registry {name:?} reuses the `org` namespace {org:?} already claimed by \
+             registry {other:?}; two hosted registries cannot share a namespace",
+        ),
+    }
 }
 
 /// A registry's name is addressed as the single URL path segment `/~<name>/` and

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1152,11 +1152,13 @@ fn default_true() -> bool {
 /// The namespace [`Config::proxy`] declares on its flat-root hosted org, so
 /// those names resolve locally rather than to the npm upstream: the
 /// registry-mock fixture scopes plus the one unscoped fixture. Kept in sync
-/// with the bundled `config.yaml` `local` registry and the fixtures under
-/// `pnpr/.fixtures/packages`. The fixture packages living in real, active npm
-/// scopes (`@pnpm`, `@zkochan`) are claimed by exact name so the rest of
-/// those scopes keeps proxying npm (dependency trees of proxied packages pull
-/// real `@pnpm/*` packages).
+/// with the fixtures under `pnpr/.fixtures/packages` and with the
+/// fixture-scope subset of the bundled `config.yaml` `local` registry — the
+/// YAML additionally claims the exact names the TS test suite publishes,
+/// which pacquet's in-process registry never sees. The fixture packages
+/// living in real, active npm scopes (`@pnpm`, `@zkochan`) are claimed by
+/// exact name so the rest of those scopes keeps proxying npm (dependency
+/// trees of proxied packages pull real `@pnpm/*` packages).
 const REGISTRY_MOCK_LOCAL_PATTERNS: &[&str] = &[
     "@foo/*",
     "@having/*",
@@ -1192,8 +1194,11 @@ impl Config {
     /// pattern-less `npmjs` upstream. The path-less base aliases the `main`
     /// router. Kept for callers that don't use YAML config (notably pacquet's
     /// test registry, whose fixtures are served locally while real npm packages
-    /// fall through to npmjs). The local pattern set mirrors the bundled
-    /// `config.yaml` `local` registry.
+    /// fall through to npmjs). The local pattern set mirrors the fixture
+    /// subset of the bundled `config.yaml` `local` registry
+    /// ([`REGISTRY_MOCK_LOCAL_PATTERNS`]); the YAML additionally claims the
+    /// exact names the TS test suite publishes, which never reach this
+    /// constructor.
     #[must_use]
     pub fn proxy(listen: SocketAddr, storage: PathBuf) -> Self {
         let mut upstreams = IndexMap::new();

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -258,7 +258,7 @@ registries:
     let upstream = &config.upstreams["npmjs"];
     assert_eq!(
         upstream.headers.get(AUTHORIZATION).unwrap().to_str().unwrap(),
-        "Bearer secret-token"
+        "Bearer secret-token",
     );
     assert_eq!(upstream.headers.get("x-org").unwrap().to_str().unwrap(), "acme");
 }

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML, FeatureOverrides, HostedStoreConfig,
-    Interval, LogFormat, LogLevel, TokenEnv, UplinkAuthFile, UplinkAuthType, UplinkConfig,
-    UplinkFile, config_file_in, parse_interval, resolve_relative, resolve_uplink,
+    Interval, LogFormat, LogLevel, TokenEnv, UpstreamAuthFile, UpstreamAuthType, UpstreamConfig,
+    UpstreamConfigFile, config_file_in, parse_interval, resolve_relative, resolve_upstream_config,
 };
 use crate::{error::RegistryError, policy::Identity};
 use indexmap::IndexMap;
@@ -29,8 +29,11 @@ impl EnvVar for FakeEnv {
     }
 }
 
-fn uplink_file(auth: Option<UplinkAuthFile>, headers: IndexMap<String, String>) -> UplinkFile {
-    UplinkFile {
+fn upstream_config_file(
+    auth: Option<UpstreamAuthFile>,
+    headers: IndexMap<String, String>,
+) -> UpstreamConfigFile {
+    UpstreamConfigFile {
         url: "https://upstream.test/".to_string(),
         auth,
         headers,
@@ -43,171 +46,202 @@ fn uplink_file(auth: Option<UplinkAuthFile>, headers: IndexMap<String, String>) 
     }
 }
 
-fn auth_header(uplink: &super::UplinkConfig) -> Option<&str> {
-    uplink.headers.get(AUTHORIZATION).map(|value| value.to_str().unwrap())
+fn auth_header(upstream: &super::UpstreamConfig) -> Option<&str> {
+    upstream.headers.get(AUTHORIZATION).map(|value| value.to_str().unwrap())
 }
 
 #[test]
-fn uplink_bearer_token_becomes_bearer_authorization() {
-    let auth = UplinkAuthFile {
-        r#type: UplinkAuthType::Bearer,
+fn upstream_bearer_token_becomes_bearer_authorization() {
+    let auth = UpstreamAuthFile {
+        r#type: UpstreamAuthType::Bearer,
         token: Some("abc123".to_string()),
         token_env: None,
     };
-    let uplink = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
-        .expect("bearer token resolves");
-    assert_eq!(auth_header(&uplink), Some("Bearer abc123"));
+    let upstream = resolve_upstream_config::<FakeEnv>(
+        "npmjs",
+        upstream_config_file(Some(auth), IndexMap::new()),
+    )
+    .expect("bearer token resolves");
+    assert_eq!(auth_header(&upstream), Some("Bearer abc123"));
 }
 
 #[test]
-fn uplink_basic_token_becomes_basic_authorization_verbatim() {
-    let auth = UplinkAuthFile {
-        r#type: UplinkAuthType::Basic,
+fn upstream_basic_token_becomes_basic_authorization_verbatim() {
+    let auth = UpstreamAuthFile {
+        r#type: UpstreamAuthType::Basic,
         token: Some("dXNlcjpwYXNz".to_string()),
         token_env: None,
     };
-    let uplink = resolve_uplink::<FakeEnv>("priv", uplink_file(Some(auth), IndexMap::new()))
-        .expect("basic token resolves");
-    assert_eq!(auth_header(&uplink), Some("Basic dXNlcjpwYXNz"));
+    let upstream = resolve_upstream_config::<FakeEnv>(
+        "priv",
+        upstream_config_file(Some(auth), IndexMap::new()),
+    )
+    .expect("basic token resolves");
+    assert_eq!(auth_header(&upstream), Some("Basic dXNlcjpwYXNz"));
 }
 
 #[test]
-fn uplink_token_env_true_reads_npm_token() {
-    let auth = UplinkAuthFile {
-        r#type: UplinkAuthType::Bearer,
+fn upstream_token_env_true_reads_npm_token() {
+    let auth = UpstreamAuthFile {
+        r#type: UpstreamAuthType::Bearer,
         token: None,
         token_env: Some(TokenEnv::Flag(true)),
     };
-    let uplink = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
-        .expect("token_env: true reads NPM_TOKEN");
-    assert_eq!(auth_header(&uplink), Some("Bearer default-env-token"));
+    let upstream = resolve_upstream_config::<FakeEnv>(
+        "npmjs",
+        upstream_config_file(Some(auth), IndexMap::new()),
+    )
+    .expect("token_env: true reads NPM_TOKEN");
+    assert_eq!(auth_header(&upstream), Some("Bearer default-env-token"));
 }
 
 #[test]
-fn uplink_token_env_named_reads_that_var() {
-    let auth = UplinkAuthFile {
-        r#type: UplinkAuthType::Bearer,
+fn upstream_token_env_named_reads_that_var() {
+    let auth = UpstreamAuthFile {
+        r#type: UpstreamAuthType::Bearer,
         token: None,
         token_env: Some(TokenEnv::Named("CUSTOM_TOKEN".to_string())),
     };
-    let uplink = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
-        .expect("named token_env reads that var");
-    assert_eq!(auth_header(&uplink), Some("Bearer custom-env-token"));
+    let upstream = resolve_upstream_config::<FakeEnv>(
+        "npmjs",
+        upstream_config_file(Some(auth), IndexMap::new()),
+    )
+    .expect("named token_env reads that var");
+    assert_eq!(auth_header(&upstream), Some("Bearer custom-env-token"));
 }
 
 #[test]
-fn uplink_literal_token_beats_token_env() {
-    let auth = UplinkAuthFile {
-        r#type: UplinkAuthType::Bearer,
+fn upstream_literal_token_beats_token_env() {
+    let auth = UpstreamAuthFile {
+        r#type: UpstreamAuthType::Bearer,
         token: Some("literal".to_string()),
         token_env: Some(TokenEnv::Named("CUSTOM_TOKEN".to_string())),
     };
-    let uplink = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
-        .expect("literal token wins");
-    assert_eq!(auth_header(&uplink), Some("Bearer literal"));
+    let upstream = resolve_upstream_config::<FakeEnv>(
+        "npmjs",
+        upstream_config_file(Some(auth), IndexMap::new()),
+    )
+    .expect("literal token wins");
+    assert_eq!(auth_header(&upstream), Some("Bearer literal"));
 }
 
 #[test]
-fn uplink_custom_headers_are_forwarded() {
+fn upstream_custom_headers_are_forwarded() {
     let headers = IndexMap::from_iter([("x-custom".to_string(), "value".to_string())]);
-    let uplink = resolve_uplink::<FakeEnv>("npmjs", uplink_file(None, headers))
+    let upstream = resolve_upstream_config::<FakeEnv>("npmjs", upstream_config_file(None, headers))
         .expect("custom headers resolve");
-    assert_eq!(uplink.headers.get("x-custom").unwrap().to_str().unwrap(), "value");
-    assert!(auth_header(&uplink).is_none());
+    assert_eq!(upstream.headers.get("x-custom").unwrap().to_str().unwrap(), "value");
+    assert!(auth_header(&upstream).is_none());
 }
 
 #[test]
-fn uplink_custom_authorization_header_overrides_auth_block() {
-    let auth = UplinkAuthFile {
-        r#type: UplinkAuthType::Bearer,
+fn upstream_custom_authorization_header_overrides_auth_block() {
+    let auth = UpstreamAuthFile {
+        r#type: UpstreamAuthType::Bearer,
         token: Some("from-auth".to_string()),
         token_env: None,
     };
     let headers =
         IndexMap::from_iter([("authorization".to_string(), "Basic override".to_string())]);
-    let uplink = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), headers))
-        .expect("custom header overrides auth-derived one");
-    assert_eq!(auth_header(&uplink), Some("Basic override"));
+    let upstream =
+        resolve_upstream_config::<FakeEnv>("npmjs", upstream_config_file(Some(auth), headers))
+            .expect("custom header overrides auth-derived one");
+    assert_eq!(auth_header(&upstream), Some("Basic override"));
 }
 
 #[test]
-fn uplink_auth_without_resolvable_token_is_a_config_error() {
-    let auth = UplinkAuthFile {
-        r#type: UplinkAuthType::Bearer,
+fn upstream_auth_without_resolvable_token_is_a_config_error() {
+    let auth = UpstreamAuthFile {
+        r#type: UpstreamAuthType::Bearer,
         token: None,
         token_env: Some(TokenEnv::Named("UNSET_VAR".to_string())),
     };
-    let err = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
-        .expect_err("missing token must error");
+    let err = resolve_upstream_config::<FakeEnv>(
+        "npmjs",
+        upstream_config_file(Some(auth), IndexMap::new()),
+    )
+    .expect_err("missing token must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
 }
 
 #[test]
-fn uplink_auth_with_empty_literal_token_is_a_config_error() {
-    let auth = UplinkAuthFile {
-        r#type: UplinkAuthType::Bearer,
+fn upstream_auth_with_empty_literal_token_is_a_config_error() {
+    let auth = UpstreamAuthFile {
+        r#type: UpstreamAuthType::Bearer,
         token: Some(String::new()),
         token_env: None,
     };
-    let err = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
-        .expect_err("an empty token must error");
+    let err = resolve_upstream_config::<FakeEnv>(
+        "npmjs",
+        upstream_config_file(Some(auth), IndexMap::new()),
+    )
+    .expect_err("an empty token must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
 }
 
 #[test]
-fn uplink_auth_with_empty_env_token_is_a_config_error() {
-    let auth = UplinkAuthFile {
-        r#type: UplinkAuthType::Bearer,
+fn upstream_auth_with_empty_env_token_is_a_config_error() {
+    let auth = UpstreamAuthFile {
+        r#type: UpstreamAuthType::Bearer,
         token: None,
         token_env: Some(TokenEnv::Named("EMPTY_TOKEN".to_string())),
     };
-    let err = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
-        .expect_err("an empty env token must error");
+    let err = resolve_upstream_config::<FakeEnv>(
+        "npmjs",
+        upstream_config_file(Some(auth), IndexMap::new()),
+    )
+    .expect_err("an empty env token must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
 }
 
 #[test]
-fn uplink_token_env_false_resolves_no_token_and_is_a_config_error() {
-    let auth = UplinkAuthFile {
-        r#type: UplinkAuthType::Bearer,
+fn upstream_token_env_false_resolves_no_token_and_is_a_config_error() {
+    let auth = UpstreamAuthFile {
+        r#type: UpstreamAuthType::Bearer,
         token: None,
         token_env: Some(TokenEnv::Flag(false)),
     };
-    let err = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
-        .expect_err("token_env: false reads nothing, so an auth block must error");
+    let err = resolve_upstream_config::<FakeEnv>(
+        "npmjs",
+        upstream_config_file(Some(auth), IndexMap::new()),
+    )
+    .expect_err("token_env: false reads nothing, so an auth block must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
 }
 
 #[test]
-fn uplink_auth_token_with_control_char_is_a_config_error() {
-    let auth = UplinkAuthFile {
-        r#type: UplinkAuthType::Bearer,
+fn upstream_auth_token_with_control_char_is_a_config_error() {
+    let auth = UpstreamAuthFile {
+        r#type: UpstreamAuthType::Bearer,
         token: Some("bad\ntoken".to_string()),
         token_env: None,
     };
-    let err = resolve_uplink::<FakeEnv>("npmjs", uplink_file(Some(auth), IndexMap::new()))
-        .expect_err("a token that is not a valid header value must error");
+    let err = resolve_upstream_config::<FakeEnv>(
+        "npmjs",
+        upstream_config_file(Some(auth), IndexMap::new()),
+    )
+    .expect_err("a token that is not a valid header value must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
 }
 
 #[test]
-fn uplink_invalid_custom_header_name_is_a_config_error() {
+fn upstream_invalid_custom_header_name_is_a_config_error() {
     let headers = IndexMap::from_iter([("bad header".to_string(), "value".to_string())]);
-    let err = resolve_uplink::<FakeEnv>("npmjs", uplink_file(None, headers))
+    let err = resolve_upstream_config::<FakeEnv>("npmjs", upstream_config_file(None, headers))
         .expect_err("a header name with a space must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
 }
 
 #[test]
-fn uplink_invalid_custom_header_value_is_a_config_error() {
+fn upstream_invalid_custom_header_value_is_a_config_error() {
     let headers = IndexMap::from_iter([("x-custom".to_string(), "bad\nvalue".to_string())]);
-    let err = resolve_uplink::<FakeEnv>("npmjs", uplink_file(None, headers))
+    let err = resolve_upstream_config::<FakeEnv>("npmjs", upstream_config_file(None, headers))
         .expect_err("a header value with a control char must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
 }
 
 #[test]
-fn from_yaml_str_resolves_uplink_auth_and_headers() {
+fn from_yaml_str_resolves_upstream_auth_and_headers() {
     let yaml = r"
 registries:
   npmjs:
@@ -221,9 +255,12 @@ registries:
       X-Org: acme
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    let uplink = &config.uplinks["npmjs"];
-    assert_eq!(uplink.headers.get(AUTHORIZATION).unwrap().to_str().unwrap(), "Bearer secret-token");
-    assert_eq!(uplink.headers.get("x-org").unwrap().to_str().unwrap(), "acme");
+    let upstream = &config.upstreams["npmjs"];
+    assert_eq!(
+        upstream.headers.get(AUTHORIZATION).unwrap().to_str().unwrap(),
+        "Bearer secret-token"
+    );
+    assert_eq!(upstream.headers.get("x-org").unwrap().to_str().unwrap(), "acme");
 }
 
 #[test]
@@ -313,9 +350,9 @@ registries:
     timeout: 45
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    let uplink = &config.uplinks["npmjs"];
-    assert_eq!(uplink.maxage, Some(Duration::from_mins(10)));
-    assert_eq!(uplink.timeout, Duration::from_secs(45));
+    let upstream = &config.upstreams["npmjs"];
+    assert_eq!(upstream.maxage, Some(Duration::from_mins(10)));
+    assert_eq!(upstream.timeout, Duration::from_secs(45));
 }
 
 #[test]
@@ -357,7 +394,7 @@ fn resolve_relative_joins_relative_paths_to_base() {
 fn proxy_constructor_serves_fixtures_locally_and_proxies_the_rest() {
     use crate::registry::{ConcreteKind, Resolved};
     let config = Config::proxy(listen(), PathBuf::from("/tmp"));
-    assert!(config.uplinks.contains_key("npmjs"));
+    assert!(config.upstreams.contains_key("npmjs"));
     assert_eq!(config.registries.default_registry(), Some("main"));
     // The flat-root hosted org serves the registry-mock fixture scopes.
     assert_eq!(config.hosted["local"].org, "");
@@ -380,7 +417,7 @@ fn proxy_constructor_serves_fixtures_locally_and_proxies_the_rest() {
 fn static_constructor_serves_everything_from_one_hosted() {
     use crate::registry::{ConcreteKind, Resolved};
     let config = Config::static_serve(listen(), PathBuf::from("/tmp"));
-    assert!(config.uplinks.is_empty());
+    assert!(config.upstreams.is_empty());
     // Everything routes to the single local hosted registry, which serves the
     // flat storage root (its `org` namespace is empty).
     assert_eq!(config.hosted["local"].org, "");
@@ -394,8 +431,8 @@ fn static_constructor_serves_everything_from_one_hosted() {
 fn from_default_yaml_parses_bundled_file() {
     use crate::registry::{ConcreteKind, Resolved};
     let config = Config::from_default_yaml(Path::new("/tmp"), listen(), None);
-    assert!(config.uplinks.contains_key("npmjs"));
-    assert_eq!(config.uplinks["npmjs"].url, "https://registry.npmjs.org/");
+    assert!(config.upstreams.contains_key("npmjs"));
+    assert_eq!(config.upstreams["npmjs"].url, "https://registry.npmjs.org/");
     assert_eq!(config.auth.htpasswd.max_users, super::MaxUsers::Disabled);
     // The bundled file routes fixture scopes, the fixture packages living in
     // real npm scopes, and test-published names to the local hosted org, and
@@ -427,28 +464,28 @@ fn default_yaml_const_matches_what_from_default_parses() {
 
 #[test]
 fn from_yaml_str_storage_is_resolved_relative_to_base_dir() {
-    let yaml = "storage: ./store\nuplinks: {}\npackages: {}\n";
+    let yaml = "storage: ./store\npackages: {}\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert_eq!(config.storage, PathBuf::from("/etc/pnpr/./store"));
 }
 
 #[test]
 fn from_yaml_str_absolute_storage_is_left_alone() {
-    let yaml = "storage: /var/lib/pnpr\nuplinks: {}\npackages: {}\n";
+    let yaml = "storage: /var/lib/pnpr\npackages: {}\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert_eq!(config.storage, PathBuf::from("/var/lib/pnpr"));
 }
 
 #[test]
 fn cache_storage_defaults_to_subdir_of_storage() {
-    let yaml = "storage: /var/lib/pnpr\nuplinks: {}\npackages: {}\n";
+    let yaml = "storage: /var/lib/pnpr\npackages: {}\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert_eq!(config.cache_storage, PathBuf::from("/var/lib/pnpr/.pnpr-cache"));
 }
 
 #[test]
 fn explicit_cache_key_overrides_the_default() {
-    let yaml = "storage: /var/lib/pnpr\ncache: /scratch/pnpr\nuplinks: {}\npackages: {}\n";
+    let yaml = "storage: /var/lib/pnpr\ncache: /scratch/pnpr\npackages: {}\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert_eq!(config.storage, PathBuf::from("/var/lib/pnpr"));
     assert_eq!(config.cache_storage, PathBuf::from("/scratch/pnpr"));
@@ -456,7 +493,7 @@ fn explicit_cache_key_overrides_the_default() {
 
 #[test]
 fn relative_cache_key_is_resolved_against_base_dir() {
-    let yaml = "storage: ./store\ncache: ./cache\nuplinks: {}\npackages: {}\n";
+    let yaml = "storage: ./store\ncache: ./cache\npackages: {}\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert_eq!(config.cache_storage, PathBuf::from("/etc/pnpr/./cache"));
 }
@@ -464,7 +501,7 @@ fn relative_cache_key_is_resolved_against_base_dir() {
 #[test]
 fn osv_config_defaults_off_and_resolves_relative_path() {
     let defaulted = Config::from_yaml_str(
-        "uplinks: {}\npackages: {}\n",
+        "upstreams: {}\npackages: {}\n",
         Path::new("/etc/pnpr"),
         listen(),
         None,
@@ -473,7 +510,7 @@ fn osv_config_defaults_off_and_resolves_relative_path() {
     assert!(!defaulted.osv.enabled);
     assert_eq!(defaulted.osv.path, None);
 
-    let yaml = "osv:\n  enabled: true\n  path: ./osv/npm/all.zip\nuplinks: {}\npackages: {}\n";
+    let yaml = "osv:\n  enabled: true\n  path: ./osv/npm/all.zip\npackages: {}\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert!(config.osv.enabled);
     assert_eq!(config.osv.path, Some(PathBuf::from("/etc/pnpr/./osv/npm/all.zip")));
@@ -481,7 +518,7 @@ fn osv_config_defaults_off_and_resolves_relative_path() {
 
 #[test]
 fn hosted_store_defaults_to_fs_without_an_s3_block() {
-    let yaml = "storage: /var/lib/pnpr\nuplinks: {}\npackages: {}\n";
+    let yaml = "storage: /var/lib/pnpr\npackages: {}\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert!(matches!(config.hosted_store, HostedStoreConfig::Fs));
 }
@@ -497,7 +534,7 @@ s3:
   prefix: packages
   accessKeyId: AKIA-test
   secretAccessKey: secret-test
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
@@ -509,20 +546,20 @@ packages: {}
 
 #[test]
 fn s3_block_without_a_bucket_is_a_config_error() {
-    let yaml = "storage: /x\ns3:\n  region: auto\nuplinks: {}\npackages: {}\n";
+    let yaml = "storage: /x\ns3:\n  region: auto\npackages: {}\n";
     assert!(Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).is_err());
 }
 
 #[test]
 fn backend_defaults_to_local_without_a_block() {
-    let yaml = "storage: /var/lib/pnpr\nuplinks: {}\npackages: {}\n";
+    let yaml = "storage: /var/lib/pnpr\npackages: {}\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert!(matches!(config.backend, BackendConfig::Local));
 }
 
 #[test]
 fn backend_block_rejects_empty_selection() {
-    let yaml = "storage: /var/lib/pnpr\nbackend: {}\nuplinks: {}\npackages: {}\n";
+    let yaml = "storage: /var/lib/pnpr\nbackend: {}\npackages: {}\n";
     let err = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None)
         .expect_err("an empty backend block must not fall back to local");
     assert!(
@@ -538,7 +575,7 @@ storage: /var/lib/pnpr
 backend:
   sqlite:
     url: sqlite:///var/lib/pnpr/auth.db
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None)
@@ -557,7 +594,7 @@ backend:
   libsql:
     url: libsql://db.turso.io
     authToken: tok-secret
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
@@ -577,7 +614,7 @@ storage: /var/lib/pnpr
 backend:
   libsql:
     url: http://127.0.0.1:8080
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
@@ -599,7 +636,7 @@ backend:
     url: libsql://db.turso.io
     replicaPath: auth-replica.db
     syncIntervalSecs: 15
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
@@ -624,7 +661,7 @@ backend:
   libsql:
     url: libsql://db.turso.io
     replicaPath: /var/lib/pnpr/auth-replica.db
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
@@ -647,7 +684,7 @@ backend:
     maxConnections: 12
     timeout: 5s
     startupTimeout: 2m
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
@@ -669,7 +706,7 @@ storage: /var/lib/pnpr
 backend:
   postgresql:
     url: postgresql://pnpr:secret@db.example/pnpr
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
@@ -694,7 +731,7 @@ storage: /var/lib/pnpr
 backend:
   mysql:
     url: mysql://pnpr:secret@db.example/pnpr
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
@@ -720,7 +757,7 @@ backend:
   mysql:
     url: mysql://pnpr:secret@db.example/pnpr
     startupTimeout: 0
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None)
@@ -739,7 +776,7 @@ backend:
   postgres:
     url: postgres://pnpr:secret@db.example/pnpr
     timeout: 0
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None)
@@ -759,7 +796,7 @@ backend:
     url: libsql://db.turso.io
   postgres:
     url: postgres://pnpr:secret@db.example/pnpr
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None)
@@ -780,7 +817,7 @@ web:
   enable: false
 plugins: ../node_modules
 secret: a-sufficiently-long-secret-value
-uplinks:
+upstreams:
   npmjs:
     url: https://registry.npmjs.org/
 packages:
@@ -795,7 +832,7 @@ packages:
 
 /// A router registry routes each package to exactly one concrete source — the
 /// first listed source whose declared patterns claim it — the safe
-/// alternative to a multi-uplink fallback chain.
+/// alternative to a multi-upstream fallback chain.
 #[test]
 fn from_yaml_str_router_routes_each_package_to_one_source() {
     let yaml = "\
@@ -816,12 +853,12 @@ registries:
 defaultRegistry: main
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    // Both upstream registries are exposed as uplinks for serving.
-    assert!(config.uplinks.contains_key("npmjs"));
-    assert!(config.uplinks.contains_key("corp"));
+    // Both upstream registries are exposed as upstreams for serving.
+    assert!(config.upstreams.contains_key("npmjs"));
+    assert!(config.upstreams.contains_key("corp"));
     // The public upstream carries no credential gate; the private one does.
-    assert!(config.uplinks["npmjs"].access.is_none());
-    assert!(config.uplinks["corp"].access.is_some());
+    assert!(config.upstreams["npmjs"].access.is_none());
+    assert!(config.upstreams["corp"].access.is_some());
     assert_eq!(config.registries.default_registry(), Some("main"));
     assert!(config.registries.is_router("main"));
     match config.registries.resolve("main", "@corp/secret") {
@@ -1062,7 +1099,7 @@ registries:
     let config =
         Config::from_yaml_str_with_overrides(yaml, Path::new("/x"), listen(), None, overrides)
             .expect("a resolver-only tier must not fail on unused upstream credentials");
-    assert!(config.uplinks.is_empty(), "credentials must not be resolved or carried");
+    assert!(config.upstreams.is_empty(), "credentials must not be resolved or carried");
     assert!(config.registries.get("main").is_some(), "the graph is still built and validated");
 }
 
@@ -1074,7 +1111,7 @@ fn from_yaml_str_rejects_unknown_registry_type() {
 storage: ./s
 registries:
   npmjs:
-    type: uplink
+    type: mirror
     url: https://registry.npmjs.org/
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
@@ -1086,14 +1123,14 @@ registries:
 
 #[test]
 fn from_yaml_str_public_url_defaults_to_listen_when_none_passed() {
-    let yaml = "storage: ./s\nuplinks: {}\npackages: {}\n";
+    let yaml = "storage: ./s\npackages: {}\n";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
     assert_eq!(config.public_url, format!("http://{}", listen()));
 }
 
 #[test]
 fn from_yaml_str_public_url_override_wins() {
-    let yaml = "storage: ./s\nuplinks: {}\npackages: {}\n";
+    let yaml = "storage: ./s\npackages: {}\n";
     let config = Config::from_yaml_str(
         yaml,
         Path::new("/x"),
@@ -1111,7 +1148,7 @@ fn from_yaml_path_round_trips_through_tempfile() {
     // resolved against the *config file's* parent dir.
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("registry.yml");
-    std::fs::write(&config_path, "storage: ./store\nuplinks: {}\npackages: {}\n").unwrap();
+    std::fs::write(&config_path, "storage: ./store\npackages: {}\n").unwrap();
     let config = Config::from_yaml(&config_path, listen(), None).unwrap();
     assert_eq!(config.storage, dir.path().join("./store"));
 }
@@ -1138,7 +1175,7 @@ storage: ./s
 auth:
   htpasswd:
     file: ./htpasswd
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
@@ -1149,7 +1186,7 @@ packages: {}
 
 #[test]
 fn auth_block_absent_disables_registration_by_default() {
-    let yaml = "storage: ./s\nuplinks: {}\npackages: {}\n";
+    let yaml = "storage: ./s\npackages: {}\n";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
     assert!(config.auth.htpasswd.file.is_none());
     assert!(config.auth.tokens.file.is_none());
@@ -1164,7 +1201,7 @@ storage: ./s
 auth:
   htpasswd:
     file: ./htpasswd
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
@@ -1180,7 +1217,7 @@ auth:
     file: ./htpasswd
   tokens:
     file: /var/lib/pnpr/tokens.sqlite
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
@@ -1195,7 +1232,7 @@ auth:
   htpasswd:
     file: ./htpasswd
     max_users: -1
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
@@ -1210,7 +1247,7 @@ auth:
   htpasswd:
     file: ./htpasswd
     max_users: 5
-uplinks: {}
+upstreams: {}
 packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
@@ -1219,7 +1256,7 @@ packages: {}
 
 #[test]
 fn logs_default_when_yaml_omits_block() {
-    let yaml = "storage: ./s\nuplinks: {}\npackages: {}\n";
+    let yaml = "storage: ./s\npackages: {}\n";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
     assert_eq!(config.logs.format, LogFormat::Pretty);
     assert_eq!(config.logs.level, LogLevel::Info);
@@ -1234,7 +1271,7 @@ fn log_unsupported_sink_type_is_recorded_but_flagged_unsupported() {
     // and the binary warns at startup. Format/level still apply.
     let yaml = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages: {}
 log:
   type: file
@@ -1250,7 +1287,7 @@ log:
 fn log_pretty_and_level_picked_from_singular_block() {
     let yaml = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages: {}
 log:
   type: stdout
@@ -1266,7 +1303,7 @@ log:
 fn log_json_format_parses() {
     let yaml = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages: {}
 log:
   type: stdout
@@ -1285,7 +1322,7 @@ fn log_legacy_plural_list_is_ignored() {
     // is silently dropped and defaults apply.
     let yaml = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages: {}
 logs:
   - type: stdout
@@ -1302,7 +1339,7 @@ fn log_missing_fields_fall_back_to_defaults() {
     // Only `type:` is given. Format and level default individually.
     let yaml = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages: {}
 log:
   type: stdout
@@ -1348,7 +1385,7 @@ fn config_file_in_returns_none_when_file_is_missing() {
 fn config_file_in_returns_path_when_file_exists() {
     let dir = tempfile::tempdir().unwrap();
     let expected = dir.path().join("config.yaml");
-    std::fs::write(&expected, "storage: ./s\nuplinks: {}\npackages: {}\n").unwrap();
+    std::fs::write(&expected, "storage: ./s\npackages: {}\n").unwrap();
     let resolved = config_file_in(Some(dir.path().to_path_buf())).expect("file is present");
     assert_eq!(resolved, expected);
 }
@@ -1379,7 +1416,7 @@ fn config_file_in_resolved_file_round_trips_through_from_yaml() {
     let yaml = format!(
         "\
 storage: {storage}
-uplinks:
+upstreams:
   npmjs: {{ url: https://registry.npmjs.org/ }}
 packages:
   '**':
@@ -1467,14 +1504,14 @@ fn write_yaml(dir: &Path, name: &str, contents: &str) -> PathBuf {
     path
 }
 
-const MINIMAL_YAML: &str = "storage: ./s\nuplinks: {}\npackages: {}\n";
+const MINIMAL_YAML: &str = "storage: ./s\npackages: {}\n";
 
 #[test]
 fn resolve_bundled_when_no_path_supplied() {
     let (config, source) = Config::resolve(None, None, listen(), None).unwrap();
     assert_eq!(source, ConfigSource::Bundled);
-    // The bundled config has the `npmjs` uplink + `**` route.
-    assert!(config.uplinks.contains_key("npmjs"));
+    // The bundled config has the `npmjs` upstream + `**` route.
+    assert!(config.upstreams.contains_key("npmjs"));
 }
 
 #[test]
@@ -1508,12 +1545,12 @@ fn resolve_cli_wins_over_default_path() {
     let cli = write_yaml(
         tmp.path(),
         "explicit.yml",
-        &format!("storage: {}\nuplinks: {{}}\npackages: {{}}\n", cli_storage.display()),
+        &format!("storage: {}\npackages: {{}}\n", cli_storage.display()),
     );
     let default = write_yaml(
         tmp.path(),
         "default.yml",
-        &format!("storage: {}\nuplinks: {{}}\npackages: {{}}\n", default_storage.display()),
+        &format!("storage: {}\npackages: {{}}\n", default_storage.display()),
     );
     let (config, source) = Config::resolve(Some(&cli), Some(&default), listen(), None).unwrap();
     assert_eq!(source, ConfigSource::Cli(cli));
@@ -1572,7 +1609,7 @@ fn yaml_with_no_storage_uses_default_storage_string() {
     // `storage:` is absent entirely — `default_storage_string`
     // supplies `"./storage"`, which `resolve_relative` then joins
     // to the config-file's parent dir.
-    let yaml = "uplinks: {}\npackages: {}\n";
+    let yaml = "upstreams: {}\npackages: {}\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert_eq!(config.storage, PathBuf::from("/etc/pnpr/./storage"));
 }
@@ -1586,7 +1623,7 @@ fn yaml_log_block_with_no_type_field_uses_default_log_type() {
     // to reflect the supplied format/level).
     let yaml = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages: {}
 log:
   format: json
@@ -1608,7 +1645,7 @@ fn policies_are_derived_from_packages_block() {
     // runtime policy — not a hard-coded default set.
     let yaml = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages:
   '@secret/*':
     access: $authenticated
@@ -1635,7 +1672,7 @@ fn policy_first_matching_rule_wins() {
     // wins for a scoped package even though both match.
     let yaml = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages:
   '@secret/*':
     access: $authenticated
@@ -1651,7 +1688,7 @@ packages:
 fn policy_missing_access_and_publish_default_to_all_and_authenticated() {
     let yaml = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages:
   'lodash': {}
 ";
@@ -1668,7 +1705,7 @@ packages:
 fn policy_missing_unpublish_denies_destructive_writes() {
     let yaml = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages:
   '@team/*':
     publish: alice
@@ -1685,7 +1722,7 @@ packages:
 fn policy_empty_unpublish_denies_destructive_writes() {
     let as_null = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages:
   '@team/*':
     publish: $authenticated
@@ -1693,7 +1730,7 @@ packages:
 ";
     let as_empty_string = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages:
   '@team/*':
     publish: $authenticated
@@ -1701,7 +1738,7 @@ packages:
 ";
     let as_empty_sequence = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages:
   '@team/*':
     publish: $authenticated
@@ -1720,7 +1757,7 @@ packages:
 fn policy_anonymous_token_is_wired() {
     let yaml = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages:
   '@anon/*':
     access: $anonymous
@@ -1737,7 +1774,7 @@ fn policy_usernames_grant_per_user_access() {
     // a config error.
     let yaml = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages:
   '@team/*':
     access: alice bob
@@ -1783,7 +1820,7 @@ registries:
     assert!(!team.access.allows(&carol));
     assert!(!team.access.allows(&Identity::Anonymous));
 
-    let access = config.uplinks["corp"].access.as_ref().expect("uplink declares access");
+    let access = config.upstreams["corp"].access.as_ref().expect("upstream declares access");
     assert!(access.allows(&alice));
     assert!(access.allows(&bob));
     assert!(!access.allows(&carol));
@@ -1795,14 +1832,14 @@ fn policy_access_list_accepts_string_and_sequence_forms() {
     // sequence; they must compile to the same token list.
     let as_string = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages:
   '@team/*':
     access: alice bob
 ";
     let as_sequence = "\
 storage: ./s
-uplinks: {}
+upstreams: {}
 packages:
   '@team/*':
     access: [alice, bob]
@@ -1845,39 +1882,41 @@ fn parse_interval_rejects_garbage() {
 }
 
 #[test]
-fn resolve_uplink_defaults_knobs_to_verdaccio_values() {
-    let uplink = resolve_uplink::<FakeEnv>("npmjs", uplink_file(None, IndexMap::new())).unwrap();
+fn resolve_upstream_config_defaults_knobs_to_verdaccio_values() {
+    let upstream =
+        resolve_upstream_config::<FakeEnv>("npmjs", upstream_config_file(None, IndexMap::new()))
+            .unwrap();
     // An unset `maxage` defers to the global packument TTL (`None` here),
     // while the rest fall back to verdaccio's documented defaults.
-    assert_eq!(uplink.maxage, None);
-    assert_eq!(uplink.timeout, UplinkConfig::DEFAULT_TIMEOUT);
-    assert_eq!(uplink.max_fails, UplinkConfig::DEFAULT_MAX_FAILS);
-    assert_eq!(uplink.fail_timeout, UplinkConfig::DEFAULT_FAIL_TIMEOUT);
-    assert!(uplink.cache);
+    assert_eq!(upstream.maxage, None);
+    assert_eq!(upstream.timeout, UpstreamConfig::DEFAULT_TIMEOUT);
+    assert_eq!(upstream.max_fails, UpstreamConfig::DEFAULT_MAX_FAILS);
+    assert_eq!(upstream.fail_timeout, UpstreamConfig::DEFAULT_FAIL_TIMEOUT);
+    assert!(upstream.cache);
 }
 
 #[test]
-fn resolve_uplink_parses_explicit_knobs() {
+fn resolve_upstream_config_parses_explicit_knobs() {
     use std::time::Duration;
-    let mut file = uplink_file(None, IndexMap::new());
+    let mut file = upstream_config_file(None, IndexMap::new());
     file.maxage = Some(Interval("10m".to_string()));
     file.timeout = Some(Interval("45s".to_string()));
     file.max_fails = Some(5);
     file.fail_timeout = Some(Interval("1m".to_string()));
     file.cache = Some(false);
-    let uplink = resolve_uplink::<FakeEnv>("npmjs", file).unwrap();
-    assert_eq!(uplink.maxage, Some(Duration::from_mins(10)));
-    assert_eq!(uplink.timeout, Duration::from_secs(45));
-    assert_eq!(uplink.max_fails, 5);
-    assert_eq!(uplink.fail_timeout, Duration::from_mins(1));
-    assert!(!uplink.cache);
+    let upstream = resolve_upstream_config::<FakeEnv>("npmjs", file).unwrap();
+    assert_eq!(upstream.maxage, Some(Duration::from_mins(10)));
+    assert_eq!(upstream.timeout, Duration::from_secs(45));
+    assert_eq!(upstream.max_fails, 5);
+    assert_eq!(upstream.fail_timeout, Duration::from_mins(1));
+    assert!(!upstream.cache);
 }
 
 #[test]
-fn resolve_uplink_rejects_an_unparsable_interval() {
-    let mut file = uplink_file(None, IndexMap::new());
+fn resolve_upstream_config_rejects_an_unparsable_interval() {
+    let mut file = upstream_config_file(None, IndexMap::new());
     file.maxage = Some(Interval("whenever".to_string()));
-    let err = resolve_uplink::<FakeEnv>("npmjs", file).unwrap_err();
+    let err = resolve_upstream_config::<FakeEnv>("npmjs", file).unwrap_err();
     assert!(
         matches!(err, RegistryError::InvalidConfig { reason } if reason.contains("maxage")),
         "expected an InvalidConfig naming the offending field",
@@ -1924,7 +1963,7 @@ routes:
 }
 
 #[test]
-fn uplink_resolves_bearer_auth_and_access() {
+fn upstream_resolves_bearer_auth_and_access() {
     let yaml = r"
 registries:
   corp:
@@ -1936,16 +1975,16 @@ registries:
       token: corp-token
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    let uplink = &config.uplinks["corp"];
-    assert_eq!(uplink.url, "https://npm.corp.example/");
-    assert_eq!(auth_header(uplink), Some("Bearer corp-token"));
-    let access = uplink.access.as_ref().expect("uplink declares access");
+    let upstream = &config.upstreams["corp"];
+    assert_eq!(upstream.url, "https://npm.corp.example/");
+    assert_eq!(auth_header(upstream), Some("Bearer corp-token"));
+    let access = upstream.access.as_ref().expect("upstream declares access");
     assert!(access.allows(&user("alice")));
     assert!(!access.allows(&Identity::Anonymous));
 }
 
 #[test]
-fn uplink_resolves_basic_auth_and_access() {
+fn upstream_resolves_basic_auth_and_access() {
     let yaml = r"
 registries:
   corp:
@@ -1957,9 +1996,9 @@ registries:
       token: dXNlcjpwYXNz
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    let uplink = &config.uplinks["corp"];
-    assert_eq!(auth_header(uplink), Some("Basic dXNlcjpwYXNz"));
-    let access = uplink.access.as_ref().expect("uplink declares access");
+    let upstream = &config.upstreams["corp"];
+    assert_eq!(auth_header(upstream), Some("Basic dXNlcjpwYXNz"));
+    let access = upstream.access.as_ref().expect("upstream declares access");
     assert!(access.allows(&user("bob")));
     assert!(!access.allows(&Identity::Anonymous));
 }
@@ -1976,7 +2015,7 @@ registries:
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
     // A public upstream registry is reachable anonymously and carries no access
     // policy or upstream credential.
-    assert!(config.uplinks["corp"].access.is_none());
+    assert!(config.upstreams["corp"].access.is_none());
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -794,7 +794,8 @@ packages:
 }
 
 /// A router mount routes each package to exactly one concrete source — the
-/// safe alternative to a multi-uplink fallback chain.
+/// first listed source whose declared patterns claim it — the safe
+/// alternative to a multi-uplink fallback chain.
 #[test]
 fn from_yaml_str_router_routes_each_package_to_one_source() {
     let yaml = "\
@@ -808,13 +809,10 @@ mounts:
     type: upstream
     url: https://npm.corp.example/
     access: $authenticated
+    patterns: ['@corp/*']
   main:
     type: router
-    routes:
-      - patterns: ['@corp/*']
-        source: corp
-      - patterns: ['**']
-        source: npmjs
+    sources: [corp, npmjs]
 defaultTarget: main
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
@@ -836,26 +834,52 @@ defaultTarget: main
     }
 }
 
-/// A misordered router (catch-all before a narrower private route) fails config
-/// load rather than silently serving a private scope from the public source.
+/// A misordered router (the pattern-less catch-all listed before a narrower
+/// private source) fails config load rather than silently serving a private
+/// scope from the public source.
 #[test]
 fn from_yaml_str_rejects_misordered_router() {
     let yaml = "\
 storage: ./s
 mounts:
   npmjs: { type: upstream, url: https://registry.npmjs.org/, public: true }
-  acme: { type: hosted, org: acme }
+  acme: { type: hosted, org: acme, patterns: ['@acme/*'] }
   main:
     type: router
-    routes:
-      - patterns: ['**']
-        source: npmjs
-      - patterns: ['@acme/*']
-        source: acme
+    sources: [npmjs, acme]
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
         .expect_err("misordered router must be rejected");
     assert!(err.to_string().contains("unreachable"), "unexpected error: {err}");
+}
+
+/// An unsupported wildcard in a mount's `patterns:` fails config load, named
+/// for the offending mount, rather than becoming a claim that never matches.
+#[test]
+fn from_yaml_str_rejects_invalid_mount_pattern() {
+    let yaml = "\
+storage: ./s
+mounts:
+  acme: { type: hosted, org: acme, patterns: ['@acme/ba*r'] }
+";
+    let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
+        .expect_err("an unsupported mount pattern must be rejected");
+    let message = err.to_string();
+    assert!(message.contains("acme"), "expected the mount named, got: {message}");
+    assert!(message.contains("@acme/ba*r"), "expected the pattern named, got: {message}");
+}
+
+/// A duplicate pattern within one mount's namespace fails config load.
+#[test]
+fn from_yaml_str_rejects_duplicate_mount_pattern() {
+    let yaml = "\
+storage: ./s
+mounts:
+  acme: { type: hosted, org: acme, patterns: ['@acme/*', '@acme/*'] }
+";
+    let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
+        .expect_err("a duplicate mount pattern must be rejected");
+    assert!(err.to_string().contains("more than once"), "unexpected error: {err}");
 }
 
 /// `defaultTarget` naming an undefined mount fails closed.
@@ -1003,9 +1027,7 @@ storage: ./s
 mounts:
   main:
     type: router
-    routes:
-      - patterns: ['**']
-        source: ghost
+    sources: [ghost]
 ";
     let overrides = FeatureOverrides { disable_registry: true, disable_resolver: false };
     let err =
@@ -1032,9 +1054,7 @@ mounts:
       token_env: PNPR_DEFINITELY_UNSET_TOKEN_VAR
   main:
     type: router
-    routes:
-      - patterns: ['**']
-        source: corp
+    sources: [corp]
 ";
     let overrides = FeatureOverrides { disable_registry: true, disable_resolver: false };
     let config =

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -209,7 +209,7 @@ fn uplink_invalid_custom_header_value_is_a_config_error() {
 #[test]
 fn from_yaml_str_resolves_uplink_auth_and_headers() {
     let yaml = r"
-mounts:
+registries:
   npmjs:
     type: upstream
     url: https://registry.npmjs.org/
@@ -227,15 +227,15 @@ mounts:
 }
 
 #[test]
-fn registry_surface_is_derived_from_declared_mounts() {
-    // No mounts ⇒ nothing to serve on the npm-registry surface; declaring
+fn registry_surface_is_derived_from_declared_registries() {
+    // No registries ⇒ nothing to serve on the npm-registry surface; declaring
     // one turns the surface on. There is no YAML toggle in between.
     let config = Config::from_yaml_str("{}", Path::new("/x"), listen(), None).unwrap();
     assert!(!config.registry.enabled);
     assert!(config.resolver.enabled);
 
     let yaml = "
-mounts:
+registries:
   npmjs: { type: upstream, url: https://registry.npmjs.org/, public: true }
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
@@ -276,7 +276,7 @@ fn unknown_key_in_feature_block_is_a_config_error() {
 #[test]
 fn from_yaml_str_parses_the_resolver_toggle() {
     let yaml = "
-mounts:
+registries:
   npmjs: { type: upstream, url: https://registry.npmjs.org/, public: true }
 resolver:
   enabled: false
@@ -288,7 +288,7 @@ resolver:
 
 #[test]
 fn nothing_to_serve_is_a_config_error() {
-    // No mounts (⇒ no registry surface) and the resolver disabled leaves
+    // No registries (⇒ no registry surface) and the resolver disabled leaves
     // only `/-/ping` and the account endpoints — a misconfiguration.
     let yaml = "resolver:\n  enabled: false\n";
     let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
@@ -304,7 +304,7 @@ fn from_yaml_str_accepts_string_and_bare_number_intervals() {
     // both); the bare number must read as seconds rather than failing to
     // deserialize against the `Option<String>`-shaped field.
     let yaml = r"
-mounts:
+registries:
   npmjs:
     type: upstream
     url: https://registry.npmjs.org/
@@ -355,44 +355,44 @@ fn resolve_relative_joins_relative_paths_to_base() {
 
 #[test]
 fn proxy_constructor_serves_fixtures_locally_and_proxies_the_rest() {
-    use crate::mount::{ConcreteKind, Resolved};
+    use crate::registry::{ConcreteKind, Resolved};
     let config = Config::proxy(listen(), PathBuf::from("/tmp"));
     assert!(config.uplinks.contains_key("npmjs"));
-    assert_eq!(config.mounts.default_target(), Some("main"));
+    assert_eq!(config.registries.default_registry(), Some("main"));
     // The flat-root hosted org serves the registry-mock fixture scopes.
     assert_eq!(config.hosted["local"].org, "");
     assert_eq!(
-        config.mounts.resolve_default("@pnpm.e2e/dep-of-pkg-with-1-dep"),
-        Resolved::Concrete { mount: "local", kind: ConcreteKind::Hosted },
+        config.registries.resolve_default("@pnpm.e2e/dep-of-pkg-with-1-dep"),
+        Resolved::Concrete { registry: "local", kind: ConcreteKind::Hosted },
     );
     assert_eq!(
-        config.mounts.resolve_default("create-touch-file-one-bin"),
-        Resolved::Concrete { mount: "local", kind: ConcreteKind::Hosted },
+        config.registries.resolve_default("create-touch-file-one-bin"),
+        Resolved::Concrete { registry: "local", kind: ConcreteKind::Hosted },
     );
     // Everything else proxies to the npm upstream.
     assert_eq!(
-        config.mounts.resolve_default("is-positive"),
-        Resolved::Concrete { mount: "npmjs", kind: ConcreteKind::Upstream },
+        config.registries.resolve_default("is-positive"),
+        Resolved::Concrete { registry: "npmjs", kind: ConcreteKind::Upstream },
     );
 }
 
 #[test]
 fn static_constructor_serves_everything_from_one_hosted() {
-    use crate::mount::{ConcreteKind, Resolved};
+    use crate::registry::{ConcreteKind, Resolved};
     let config = Config::static_serve(listen(), PathBuf::from("/tmp"));
     assert!(config.uplinks.is_empty());
-    // Everything routes to the single local hosted mount, which serves the
+    // Everything routes to the single local hosted registry, which serves the
     // flat storage root (its `org` namespace is empty).
     assert_eq!(config.hosted["local"].org, "");
     assert_eq!(
-        config.mounts.resolve_default("anything"),
-        Resolved::Concrete { mount: "local", kind: ConcreteKind::Hosted },
+        config.registries.resolve_default("anything"),
+        Resolved::Concrete { registry: "local", kind: ConcreteKind::Hosted },
     );
 }
 
 #[test]
 fn from_default_yaml_parses_bundled_file() {
-    use crate::mount::{ConcreteKind, Resolved};
+    use crate::registry::{ConcreteKind, Resolved};
     let config = Config::from_default_yaml(Path::new("/tmp"), listen(), None);
     assert!(config.uplinks.contains_key("npmjs"));
     assert_eq!(config.uplinks["npmjs"].url, "https://registry.npmjs.org/");
@@ -402,15 +402,15 @@ fn from_default_yaml_parses_bundled_file() {
     // everything else — including the rest of those real scopes — to npmjs.
     for local in ["@pnpm.e2e/foo", "@pnpm/y", "test-publish-tarball", "project-100"] {
         assert_eq!(
-            config.mounts.resolve_default(local),
-            Resolved::Concrete { mount: "local", kind: ConcreteKind::Hosted },
+            config.registries.resolve_default(local),
+            Resolved::Concrete { registry: "local", kind: ConcreteKind::Hosted },
             "{local} must be hosted",
         );
     }
     for upstream in ["react", "lodash", "test-exclude", "@pnpm/error"] {
         assert_eq!(
-            config.mounts.resolve_default(upstream),
-            Resolved::Concrete { mount: "npmjs", kind: ConcreteKind::Upstream },
+            config.registries.resolve_default(upstream),
+            Resolved::Concrete { registry: "npmjs", kind: ConcreteKind::Upstream },
             "{upstream} must proxy npm",
         );
     }
@@ -793,14 +793,14 @@ packages:
     assert_eq!(config.auth.htpasswd.max_users, super::MaxUsers::Disabled);
 }
 
-/// A router mount routes each package to exactly one concrete source — the
+/// A router registry routes each package to exactly one concrete source — the
 /// first listed source whose declared patterns claim it — the safe
 /// alternative to a multi-uplink fallback chain.
 #[test]
 fn from_yaml_str_router_routes_each_package_to_one_source() {
     let yaml = "\
 storage: ./s
-mounts:
+registries:
   npmjs:
     type: upstream
     url: https://registry.npmjs.org/
@@ -813,23 +813,23 @@ mounts:
   main:
     type: router
     sources: [corp, npmjs]
-defaultTarget: main
+defaultRegistry: main
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    // Both upstream mounts are exposed as uplinks for serving.
+    // Both upstream registries are exposed as uplinks for serving.
     assert!(config.uplinks.contains_key("npmjs"));
     assert!(config.uplinks.contains_key("corp"));
     // The public upstream carries no credential gate; the private one does.
     assert!(config.uplinks["npmjs"].access.is_none());
     assert!(config.uplinks["corp"].access.is_some());
-    assert_eq!(config.mounts.default_target(), Some("main"));
-    assert!(config.mounts.is_router("main"));
-    match config.mounts.resolve("main", "@corp/secret") {
-        crate::mount::Resolved::Concrete { mount, .. } => assert_eq!(mount, "corp"),
+    assert_eq!(config.registries.default_registry(), Some("main"));
+    assert!(config.registries.is_router("main"));
+    match config.registries.resolve("main", "@corp/secret") {
+        crate::registry::Resolved::Concrete { registry, .. } => assert_eq!(registry, "corp"),
         other => panic!("expected @corp/* -> corp, got {other:?}"),
     }
-    match config.mounts.resolve("main", "lodash") {
-        crate::mount::Resolved::Concrete { mount, .. } => assert_eq!(mount, "npmjs"),
+    match config.registries.resolve("main", "lodash") {
+        crate::registry::Resolved::Concrete { registry, .. } => assert_eq!(registry, "npmjs"),
         other => panic!("expected lodash -> npmjs, got {other:?}"),
     }
 }
@@ -841,7 +841,7 @@ defaultTarget: main
 fn from_yaml_str_rejects_misordered_router() {
     let yaml = "\
 storage: ./s
-mounts:
+registries:
   npmjs: { type: upstream, url: https://registry.npmjs.org/, public: true }
   acme: { type: hosted, org: acme, patterns: ['@acme/*'] }
   main:
@@ -853,55 +853,55 @@ mounts:
     assert!(err.to_string().contains("unreachable"), "unexpected error: {err}");
 }
 
-/// An unsupported wildcard in a mount's `patterns:` fails config load, named
-/// for the offending mount, rather than becoming a claim that never matches.
+/// An unsupported wildcard in a registry's `patterns:` fails config load, named
+/// for the offending registry, rather than becoming a claim that never matches.
 #[test]
-fn from_yaml_str_rejects_invalid_mount_pattern() {
+fn from_yaml_str_rejects_invalid_registry_pattern() {
     let yaml = "\
 storage: ./s
-mounts:
+registries:
   acme: { type: hosted, org: acme, patterns: ['@acme/ba*r'] }
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
-        .expect_err("an unsupported mount pattern must be rejected");
+        .expect_err("an unsupported registry pattern must be rejected");
     let message = err.to_string();
-    assert!(message.contains("acme"), "expected the mount named, got: {message}");
+    assert!(message.contains("acme"), "expected the registry named, got: {message}");
     assert!(message.contains("@acme/ba*r"), "expected the pattern named, got: {message}");
 }
 
-/// A duplicate pattern within one mount's namespace fails config load.
+/// A duplicate pattern within one registry's namespace fails config load.
 #[test]
-fn from_yaml_str_rejects_duplicate_mount_pattern() {
+fn from_yaml_str_rejects_duplicate_registry_pattern() {
     let yaml = "\
 storage: ./s
-mounts:
+registries:
   acme: { type: hosted, org: acme, patterns: ['@acme/*', '@acme/*'] }
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
-        .expect_err("a duplicate mount pattern must be rejected");
+        .expect_err("a duplicate registry pattern must be rejected");
     assert!(err.to_string().contains("more than once"), "unexpected error: {err}");
 }
 
-/// `defaultTarget` naming an undefined mount fails closed.
+/// `defaultRegistry` naming an undefined registry fails closed.
 #[test]
-fn from_yaml_str_rejects_undefined_default_target() {
+fn from_yaml_str_rejects_undefined_default_registry() {
     let yaml = "\
 storage: ./s
-mounts:
+registries:
   npmjs: { type: upstream, url: https://registry.npmjs.org/, public: true }
-defaultTarget: ghost
+defaultRegistry: ghost
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
         .expect_err("undefined default target must be rejected");
-    assert!(err.to_string().contains("defaultTarget"), "unexpected error: {err}");
+    assert!(err.to_string().contains("defaultRegistry"), "unexpected error: {err}");
 }
 
-/// A non-`public` upstream mount must declare who may reach it.
+/// A non-`public` upstream registry must declare who may reach it.
 #[test]
 fn from_yaml_str_rejects_private_upstream_without_access() {
     let yaml = "\
 storage: ./s
-mounts:
+registries:
   corp:
     type: upstream
     url: https://npm.corp.example/
@@ -917,7 +917,7 @@ mounts:
 fn from_yaml_str_rejects_public_upstream_with_access() {
     let yaml = "\
 storage: ./s
-mounts:
+registries:
   npmjs:
     type: upstream
     url: https://registry.npmjs.org/
@@ -938,7 +938,7 @@ fn from_yaml_str_rejects_public_upstream_with_custom_headers() {
         let yaml = format!(
             "\
 storage: ./s
-mounts:
+registries:
   npmjs:
     type: upstream
     url: https://registry.npmjs.org/
@@ -953,13 +953,13 @@ mounts:
     }
 }
 
-/// Two hosted mounts sharing an `org` namespace would alias the same storage, so
+/// Two hosted registries sharing an `org` namespace would alias the same storage, so
 /// the collision must be rejected at load.
 #[test]
 fn from_yaml_str_rejects_duplicate_hosted_org() {
     let yaml = "\
 storage: ./s
-mounts:
+registries:
   acme:
     type: hosted
     org: shared
@@ -968,7 +968,7 @@ mounts:
     org: shared
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
-        .expect_err("two hosted mounts on the same org must be rejected");
+        .expect_err("two hosted registries on the same org must be rejected");
     assert!(err.to_string().contains("reuses the `org`"), "unexpected error: {err}");
 }
 
@@ -979,7 +979,8 @@ mounts:
 #[test]
 fn from_yaml_str_rejects_hosted_org_path_traversal() {
     for org in ["../../etc", "C:acme", "a/b"] {
-        let yaml = format!("storage: ./s\nmounts:\n  evil:\n    type: hosted\n    org: {org}\n");
+        let yaml =
+            format!("storage: ./s\nregistries:\n  evil:\n    type: hosted\n    org: {org}\n");
         let err = Config::from_yaml_str(&yaml, Path::new("/x"), listen(), None)
             .expect_err("a traversal-y hosted org must be rejected");
         assert!(err.to_string().contains("path-safe"), "unexpected error for {org:?}: {err}");
@@ -992,23 +993,24 @@ fn from_yaml_str_rejects_hosted_org_path_traversal() {
 #[test]
 fn from_yaml_str_rejects_dot_prefixed_hosted_org() {
     for org in [".pnpr-cache", ".pnpr-journal", ".hidden"] {
-        let yaml = format!("storage: ./s\nmounts:\n  sneaky:\n    type: hosted\n    org: {org}\n");
+        let yaml =
+            format!("storage: ./s\nregistries:\n  sneaky:\n    type: hosted\n    org: {org}\n");
         let err = Config::from_yaml_str(&yaml, Path::new("/x"), listen(), None)
             .expect_err("a dot-prefixed hosted org must be rejected");
         assert!(err.to_string().contains("path-safe"), "unexpected error for {org:?}: {err}");
     }
 }
 
-/// A mount name is addressed as the single URL path segment `/~<name>/` and is
+/// A registry name is addressed as the single URL path segment `/~<name>/` and is
 /// embedded in rewritten tarball URLs, so a name that cannot survive that
 /// round trip (separators, traversal, URL delimiters, whitespace) must fail at
-/// load instead of becoming an unreachable or URL-ambiguous mount.
+/// load instead of becoming an unreachable or URL-ambiguous registry.
 #[test]
-fn from_yaml_str_rejects_url_unsafe_mount_names() {
+fn from_yaml_str_rejects_url_unsafe_registry_names() {
     for name in ["'a/b'", "'..'", "'.hidden'", "'a b'", "'a%2Fb'", "'a?b'", "'a#b'", "'C:d'"] {
-        let yaml = format!("storage: ./s\nmounts:\n  {name}:\n    type: hosted\n");
+        let yaml = format!("storage: ./s\nregistries:\n  {name}:\n    type: hosted\n");
         let err = Config::from_yaml_str(&yaml, Path::new("/x"), listen(), None)
-            .expect_err("a URL-unsafe mount name must be rejected");
+            .expect_err("a URL-unsafe registry name must be rejected");
         assert!(
             err.to_string().contains("URL-safe path segment"),
             "unexpected error for {name}: {err}",
@@ -1017,14 +1019,14 @@ fn from_yaml_str_rejects_url_unsafe_mount_names() {
 }
 
 /// `--disable-registry` skips upstream-credential resolution but still
-/// validates the mount graph, so a misconfigured router fails startup on a
+/// validates the registry graph, so a misconfigured router fails startup on a
 /// resolver-only tier too instead of surfacing only when the registry is
 /// re-enabled.
 #[test]
-fn cli_disable_registry_still_validates_the_mount_graph() {
+fn cli_disable_registry_still_validates_the_registry_graph() {
     let yaml = "\
 storage: ./s
-mounts:
+registries:
   main:
     type: router
     sources: [ghost]
@@ -1032,19 +1034,19 @@ mounts:
     let overrides = FeatureOverrides { disable_registry: true, disable_resolver: false };
     let err =
         Config::from_yaml_str_with_overrides(yaml, Path::new("/x"), listen(), None, overrides)
-            .expect_err("a broken mount graph must fail even with the registry disabled");
+            .expect_err("a broken registry graph must fail even with the registry disabled");
     assert!(err.to_string().contains("ghost"), "unexpected error: {err}");
 }
 
-/// With the registry disabled, an upstream mount whose credential cannot
+/// With the registry disabled, an upstream registry whose credential cannot
 /// resolve must not fail startup — the tier never talks to that upstream. The
-/// mount still joins the (validated) graph; only its serving config is
+/// registry still joins the (validated) graph; only its serving config is
 /// skipped.
 #[test]
-fn cli_disable_registry_skips_upstream_mount_credentials_but_keeps_the_graph() {
+fn cli_disable_registry_skips_upstream_registry_credentials_but_keeps_the_graph() {
     let yaml = "\
 storage: ./s
-mounts:
+registries:
   corp:
     type: upstream
     url: https://corp.example/npm/
@@ -1061,22 +1063,22 @@ mounts:
         Config::from_yaml_str_with_overrides(yaml, Path::new("/x"), listen(), None, overrides)
             .expect("a resolver-only tier must not fail on unused upstream credentials");
     assert!(config.uplinks.is_empty(), "credentials must not be resolved or carried");
-    assert!(config.mounts.get("main").is_some(), "the graph is still built and validated");
+    assert!(config.registries.get("main").is_some(), "the graph is still built and validated");
 }
 
-/// The internally-tagged mount enum names the valid kinds, so a typo'd `type:`
+/// The internally-tagged registry enum names the valid kinds, so a typo'd `type:`
 /// fails to load rather than being silently misrouted.
 #[test]
-fn from_yaml_str_rejects_unknown_mount_type() {
+fn from_yaml_str_rejects_unknown_registry_type() {
     let yaml = "\
 storage: ./s
-mounts:
+registries:
   npmjs:
     type: uplink
     url: https://registry.npmjs.org/
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
-        .expect_err("an unknown mount `type:` must be rejected");
+        .expect_err("an unknown registry `type:` must be rejected");
     let message = err.to_string();
     assert!(message.contains("hosted"), "expected the valid kinds listed, got: {message}");
     assert!(message.contains("upstream"), "expected the valid kinds listed, got: {message}");
@@ -1761,7 +1763,7 @@ groups:
 packages:
   '@team/*':
     access: platform
-mounts:
+registries:
   corp:
     type: upstream
     url: https://npm.corp.example/
@@ -1924,7 +1926,7 @@ routes:
 #[test]
 fn uplink_resolves_bearer_auth_and_access() {
     let yaml = r"
-mounts:
+registries:
   corp:
     type: upstream
     url: https://npm.corp.example/
@@ -1945,7 +1947,7 @@ mounts:
 #[test]
 fn uplink_resolves_basic_auth_and_access() {
     let yaml = r"
-mounts:
+registries:
   corp:
     type: upstream
     url: https://npm.corp.example/
@@ -1963,16 +1965,16 @@ mounts:
 }
 
 #[test]
-fn public_upstream_mount_carries_no_access_credential() {
+fn public_upstream_registry_carries_no_access_credential() {
     let yaml = r"
-mounts:
+registries:
   corp:
     type: upstream
     url: https://npm.corp.example/
     public: true
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    // A public upstream mount is reachable anonymously and carries no access
+    // A public upstream registry is reachable anonymously and carries no access
     // policy or upstream credential.
     assert!(config.uplinks["corp"].access.is_none());
 }

--- a/pnpr/crates/pnpr/src/error.rs
+++ b/pnpr/crates/pnpr/src/error.rs
@@ -19,16 +19,16 @@ pub enum RegistryError {
         body: String,
     },
 
-    /// The uplink's circuit breaker is open: it reached `max_fails`
+    /// The upstream's circuit breaker is open: it reached `max_fails`
     /// consecutive failures and is still inside its `fail_timeout`
     /// cooldown, so pnpr short-circuits the request instead of hammering
     /// a known-down upstream. The packument path turns this into a
     /// stale-cache fallback; with nothing cached it surfaces as 503.
-    #[display("Upstream {uplink} is temporarily unavailable (circuit open)")]
+    #[display("Upstream {upstream} is temporarily unavailable (circuit open)")]
     #[from(skip)]
     UpstreamUnavailable {
         #[error(not(source))]
-        uplink: String,
+        upstream: String,
     },
 
     #[display("EINTEGRITY: tarball {filename:?} for package {package:?}: {reason}")]

--- a/pnpr/crates/pnpr/src/error/tests.rs
+++ b/pnpr/crates/pnpr/src/error/tests.rs
@@ -167,7 +167,7 @@ fn is_transient_upstream_error_only_for_availability_failures() {
     }
 
     // An open circuit is an availability failure too.
-    let circuit_open = RegistryError::UpstreamUnavailable { uplink: "npmjs".to_string() };
+    let circuit_open = RegistryError::UpstreamUnavailable { upstream: "npmjs".to_string() };
     assert!(circuit_open.is_transient_upstream_error());
 
     // Every 4xx is an authoritative response about this request — including

--- a/pnpr/crates/pnpr/src/journal.rs
+++ b/pnpr/crates/pnpr/src/journal.rs
@@ -66,7 +66,7 @@ struct ManifestPackage {
     /// Hosted-org storage namespace this package publishes into, or `None` for
     /// the flat (path-less) hosted store. Recovery namespaces the roll-forward
     /// by it so a crash mid-commit promotes into the right org. Defaulted for
-    /// back-compat with journals written before org mounts existed.
+    /// back-compat with journals written before org registries existed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     org: Option<String>,
     /// File inside the transaction directory holding the merged

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -11,10 +11,10 @@ mod auth;
 mod config;
 mod error;
 mod journal;
-mod mount;
 mod package_name;
 mod policy;
 mod publish;
+mod registry;
 mod resolver;
 mod route;
 mod s3;
@@ -37,8 +37,10 @@ pub use config::{
 };
 pub use error::{RegistryError, Result};
 pub use journal::recover_publish_journal;
-pub use mount::{ConcreteKind, MountConfigError, MountKind, Mounts, PackagePattern, Resolved};
 pub use policy::{AccessList, AccessToken, Identity, PackagePolicies, PackagePolicy};
+pub use registry::{
+    ConcreteKind, PackagePattern, Registries, Registry, RegistryConfigError, Resolved,
+};
 pub use server::{
     router, router_with_auth, serve, serve_listener, try_router, try_router_with_auth,
 };

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -37,9 +37,7 @@ pub use config::{
 };
 pub use error::{RegistryError, Result};
 pub use journal::recover_publish_journal;
-pub use mount::{
-    ConcreteKind, MountConfigError, MountKind, Mounts, PackagePattern, Resolved, Route,
-};
+pub use mount::{ConcreteKind, MountConfigError, MountKind, Mounts, PackagePattern, Resolved};
 pub use policy::{AccessList, AccessToken, Identity, PackagePolicies, PackagePolicy};
 pub use server::{
     router, router_with_auth, serve, serve_listener, try_router, try_router_with_auth,

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -32,7 +32,7 @@ pub use config::{
     AccessSpec, AuthConfig, BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML,
     FeatureOverrides, HostedConfig, HostedStoreConfig, HtpasswdConfig, LibsqlSettings, LogConfig,
     LogFormat, LogLevel, MaxUsers, OsvConfig, PackageAccess, PublicRoute, RegistryFeature,
-    ResolverFeature, RoutePolicy, SqlBackendSettings, TokensConfig, UplinkConfig,
+    ResolverFeature, RoutePolicy, SqlBackendSettings, TokensConfig, UpstreamConfig,
     default_cache_dir,
 };
 pub use error::{RegistryError, Result};

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -6,7 +6,7 @@ use tracing_subscriber::EnvFilter;
 #[derive(Debug, Parser)]
 #[command(name = "pnpr", version, about = "pnpm-compatible npm registry server")]
 struct Args {
-    /// Path to a verdaccio-shaped YAML config (storage, uplinks,
+    /// Path to a verdaccio-shaped YAML config (storage, upstreams,
     /// packages, log). When omitted, the global `config.yaml` in
     /// pnpr's config dir (pnpm's config-dir rules, under `pnpr`) is
     /// used if it exists, otherwise the bundled default config.
@@ -71,7 +71,7 @@ async fn main() -> miette::Result<()> {
     let args = Args::parse();
     let auto_path = Config::auto_config_path();
     // Pass the surface-disable flags into parsing so a CLI-disabled surface
-    // skips its parse-time work too (e.g. strict uplink token resolution),
+    // skips its parse-time work too (e.g. strict upstream token resolution),
     // not just its routes — applying them after `resolve` would be too late.
     let overrides = pnpr::FeatureOverrides {
         disable_registry: args.disable_registry,

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -55,7 +55,7 @@ struct Args {
     /// Disable the npm-registry surface (packument/tarball reads, publish,
     /// unpublish, dist-tag, search) on this tier. Without the flag the
     /// surface is served whenever the loaded config declares at least one
-    /// mount under `mounts:`.
+    /// registry under `registries:`.
     #[arg(long)]
     disable_registry: bool,
 

--- a/pnpr/crates/pnpr/src/mount.rs
+++ b/pnpr/crates/pnpr/src/mount.rs
@@ -3,33 +3,39 @@
 //! A **registry mount** is an addressable npm-registry surface exposed at
 //! `https://<pnpr>/~<mount>/`. There are two concrete kinds — a pnpr-hosted
 //! registry and a single-origin upstream registry — plus one composite, a
-//! **router**, that maps package-name patterns to a single concrete source.
+//! **router**, an ordered list of concrete mounts behind one URL.
 //!
 //! The model is governed by one invariant: **provenance is declared, never
-//! inferred.** A package resolves to exactly one declared concrete origin, and
-//! no configuration can express a cross-origin fall-through. A router's first
-//! matching route is authoritative; later routes are never consulted, and a
-//! matched source's "not found" or "unavailable" is final. There is no
+//! inferred.** Every concrete mount declares the package-name patterns it
+//! serves — its namespace — and that namespace is enforced on the mount
+//! itself, on every path to it: an unclaimed name is a definitive not-found
+//! before storage or the upstream is consulted, whether the request came
+//! through a router or addressed the mount directly. A router selects the
+//! first listed source whose patterns claim the name — authoritatively. It can
+//! order competing claims, but it can never assign a name to a mount that does
+//! not claim it, so no configuration can express a cross-origin fall-through:
+//! a selected source's "not found" or "unavailable" is final. There is no
 //! existence-based fallback, no mirror group, and no multi-endpoint failover.
 //!
-//! Because routing is first-match-in-order, route order is load-bearing: a
+//! Because selection is first-source-in-order, source order is load-bearing: a
 //! misordered router is the one way a configuration mistake could silently send
 //! a private scope to a public origin. [`Mounts::validate`] rejects that class
-//! at config load (and reload) — shadowed/unreachable routes, duplicate
-//! patterns, and sources that are unknown, self-referential, or not concrete.
-//! The check is static because [`PackagePattern`]'s coverage relation is
-//! decidable for this deliberately small glob language.
+//! at config load (and reload) — shadowed/unreachable sources, duplicate
+//! sources and patterns, and sources that are unknown, self-referential, or
+//! not concrete. The check is static because [`PackagePattern`]'s coverage
+//! relation is decidable for this deliberately small glob language.
 
 use crate::package_name::PackageName;
 use indexmap::IndexMap;
 use std::fmt;
 
-/// A package-name routing pattern.
+/// A package-name pattern: one member of a concrete mount's declared
+/// namespace.
 ///
 /// Deliberately a small, **decidable** language so [`Self::covers`] can decide
 /// statically whether one pattern matches a superset of another — the property
-/// [`Mounts::validate`] relies on to detect shadowed routes. A general glob
-/// (`wax`) would make coverage undecidable, so router patterns are restricted
+/// [`Mounts::validate`] relies on to detect shadowed sources. A general glob
+/// (`wax`) would make coverage undecidable, so mount patterns are restricted
 /// to these four shapes; an unrecognized wildcard is a parse error rather than
 /// a silently-narrowing literal.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -46,12 +52,12 @@ pub enum PackagePattern {
 }
 
 impl PackagePattern {
-    /// Parse a router pattern. Rejects any `*` that is not one of the three
+    /// Parse a mount pattern. Rejects any `*` that is not one of the three
     /// recognized wildcard shapes (`**`, `@*/*`, `@<scope>/*`), and any
     /// remaining literal that is not a well-formed package name — so an
     /// unsupported glob or a typo like `@acme` (meaning `@acme/*`) fails
     /// loudly instead of being read as a literal name that silently never
-    /// matches and lets the scope fall through to a later route.
+    /// matches and lets the scope land on a later router source.
     pub fn parse(pattern: &str) -> Result<Self, MountConfigError> {
         let invalid = || MountConfigError::InvalidPattern { pattern: pattern.to_string() };
         if pattern.is_empty() {
@@ -97,7 +103,7 @@ impl PackagePattern {
     }
 
     /// Whether this pattern matches every package the `other` pattern matches
-    /// (i.e. `self` ⊇ `other`). Decides route shadowing in [`Mounts::validate`].
+    /// (i.e. `self` ⊇ `other`). Decides source shadowing in [`Mounts::validate`].
     ///
     /// A union of earlier patterns can only shadow `other` through a single
     /// member: the one unbounded case — many `@<scope>/*` covering `@*/*` —
@@ -144,44 +150,47 @@ fn scoped_name(package: &str) -> Option<(&str, &str)> {
     (!scope.is_empty() && !name.is_empty()).then_some((scope, name))
 }
 
-/// One router route: package-name patterns mapped to a single concrete source
-/// mount. Evaluated in declared order; the first route with a matching pattern
-/// is authoritative.
-#[derive(Debug, Clone)]
-pub struct Route {
-    pub patterns: Vec<PackagePattern>,
-    /// A [`MountKind::Hosted`] or [`MountKind::Upstream`] mount id — never
-    /// another router (enforced by [`Mounts::validate`]).
-    pub source: String,
-}
-
-impl Route {
-    /// Whether any of this route's patterns matches `package`.
-    fn matches(&self, package: &str) -> bool {
-        self.patterns.iter().any(|pattern| pattern.matches(package))
-    }
-}
-
 /// The routing role of a mount. The per-mount serving details (upstream URL,
 /// credentials, access policy, org id) live in the `config` module; this
 /// captures only what routing and validation need.
+///
+/// A concrete mount's `patterns` are its declared namespace: the names it
+/// serves and accepts publishes for, and the claim routers derive their
+/// selection from. An empty list claims every name — the catch-all in any
+/// router.
 #[derive(Debug, Clone)]
 pub enum MountKind {
     /// A pnpr-hosted registry: the authoritative origin for the packages it
     /// stores, and the only kind that accepts writes. Reads and writes are
     /// scoped to the mount's own storage namespace (its optional `org`).
-    Hosted,
+    Hosted { patterns: Vec<PackagePattern> },
     /// Exactly one external origin. One URL, one credential generation, one
     /// cache namespace — not a chain and not a set of endpoints.
-    Upstream,
-    /// Maps package-name patterns to concrete mounts in declared order.
-    Router { routes: Vec<Route> },
+    Upstream { patterns: Vec<PackagePattern> },
+    /// An ordered list of concrete mounts. A package resolves to the first
+    /// source whose declared patterns claim it.
+    Router { sources: Vec<String> },
 }
 
 impl MountKind {
     fn is_concrete(&self) -> bool {
-        matches!(self, MountKind::Hosted | MountKind::Upstream)
+        matches!(self, MountKind::Hosted { .. } | MountKind::Upstream { .. })
     }
+
+    /// A concrete mount's declared namespace; `None` for a router (a router
+    /// has no namespace of its own — it derives one from its sources).
+    fn patterns(&self) -> Option<&[PackagePattern]> {
+        match self {
+            MountKind::Hosted { patterns } | MountKind::Upstream { patterns } => Some(patterns),
+            MountKind::Router { .. } => None,
+        }
+    }
+}
+
+/// Whether a concrete mount's declared namespace claims `package`. An empty
+/// pattern list claims every name.
+fn namespace_claims(patterns: &[PackagePattern], package: &str) -> bool {
+    patterns.is_empty() || patterns.iter().any(|pattern| pattern.matches(package))
 }
 
 /// The kind of a concrete (non-router) source a request resolved to.
@@ -194,11 +203,14 @@ pub enum ConcreteKind {
 /// The outcome of resolving a request `(mount, package)` to a concrete origin.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Resolved<'a> {
-    /// Resolved to exactly one concrete source mount.
+    /// Resolved to exactly one concrete source mount whose declared patterns
+    /// claim the package.
     Concrete { mount: &'a str, kind: ConcreteKind },
-    /// A router matched no route for this package. The request is a definitive
-    /// `404`; the router never falls through to another origin.
-    NoRoute,
+    /// No declared namespace claims this package: the addressed concrete
+    /// mount's patterns don't cover it, or none of a router's sources claim
+    /// it. A definitive `404` on reads and a rejection on writes, answered
+    /// before storage or any upstream is consulted — never a fall-through.
+    Unclaimed,
     /// The addressed mount id is not defined.
     UnknownMount,
 }
@@ -241,34 +253,57 @@ impl Mounts {
     }
 
     /// Resolve a request addressed to `mount` for `package` to its single
-    /// concrete origin. A concrete mount resolves to itself; a router resolves
-    /// by first matching route (authoritatively — a non-matching router is
-    /// [`Resolved::NoRoute`], never a fall-through).
+    /// concrete origin, enforcing every concrete mount's declared namespace at
+    /// the mount itself. A concrete mount resolves to itself only when its
+    /// patterns claim the package; a router resolves to the first source whose
+    /// patterns claim it (authoritatively — an unclaimed package is
+    /// [`Resolved::Unclaimed`], never a fall-through).
     #[must_use]
     pub fn resolve<'a>(&'a self, mount: &str, package: &str) -> Resolved<'a> {
         let Some((mount_id, kind)) = self.mounts.get_key_value(mount) else {
             return Resolved::UnknownMount;
         };
         match kind {
-            MountKind::Hosted => Resolved::Concrete { mount: mount_id, kind: ConcreteKind::Hosted },
-            MountKind::Upstream => {
-                Resolved::Concrete { mount: mount_id, kind: ConcreteKind::Upstream }
-            }
-            MountKind::Router { routes } => {
-                let Some(route) = routes.iter().find(|route| route.matches(package)) else {
-                    return Resolved::NoRoute;
-                };
-                // Validation guarantees every route source is a defined concrete
-                // mount, so the lookup and the kind classification cannot miss.
-                match self.mounts.get_key_value(&route.source) {
-                    Some((source_id, MountKind::Hosted)) => {
-                        Resolved::Concrete { mount: source_id, kind: ConcreteKind::Hosted }
-                    }
-                    Some((source_id, MountKind::Upstream)) => {
-                        Resolved::Concrete { mount: source_id, kind: ConcreteKind::Upstream }
-                    }
-                    _ => Resolved::UnknownMount,
+            MountKind::Hosted { patterns } => {
+                if namespace_claims(patterns, package) {
+                    Resolved::Concrete { mount: mount_id, kind: ConcreteKind::Hosted }
+                } else {
+                    Resolved::Unclaimed
                 }
+            }
+            MountKind::Upstream { patterns } => {
+                if namespace_claims(patterns, package) {
+                    Resolved::Concrete { mount: mount_id, kind: ConcreteKind::Upstream }
+                } else {
+                    Resolved::Unclaimed
+                }
+            }
+            MountKind::Router { sources } => {
+                // Validation guarantees every source is a defined concrete
+                // mount; a non-concrete entry here can only mean the graph was
+                // built without validation, and it simply never matches.
+                for source in sources {
+                    match self.mounts.get_key_value(source) {
+                        Some((source_id, MountKind::Hosted { patterns }))
+                            if namespace_claims(patterns, package) =>
+                        {
+                            return Resolved::Concrete {
+                                mount: source_id,
+                                kind: ConcreteKind::Hosted,
+                            };
+                        }
+                        Some((source_id, MountKind::Upstream { patterns }))
+                            if namespace_claims(patterns, package) =>
+                        {
+                            return Resolved::Concrete {
+                                mount: source_id,
+                                kind: ConcreteKind::Upstream,
+                            };
+                        }
+                        _ => {}
+                    }
+                }
+                Resolved::Unclaimed
             }
         }
     }
@@ -285,7 +320,7 @@ impl Mounts {
     }
 
     /// Validate the whole mount set, failing closed on any configuration that
-    /// could route a private name to the wrong origin or leave a route dead.
+    /// could route a private name to the wrong origin or leave a source dead.
     /// Run at config load and on reload.
     pub fn validate(&self) -> Result<(), MountConfigError> {
         if let Some(target) = &self.default_target
@@ -294,92 +329,122 @@ impl Mounts {
             return Err(MountConfigError::UndefinedDefaultTarget { target: target.clone() });
         }
         for (name, kind) in &self.mounts {
-            if let MountKind::Router { routes } = kind {
-                // A router with no routes can never match any package — every
-                // request through it is a 404. That's only ever a config
-                // mistake (a hosted/upstream mount was probably intended), so
-                // reject it like an empty route.
-                if routes.is_empty() {
-                    return Err(MountConfigError::EmptyRouter { router: name.clone() });
+            match kind {
+                MountKind::Hosted { patterns } | MountKind::Upstream { patterns } => {
+                    validate_namespace(name, patterns)?;
                 }
-                self.validate_router(name, routes)?;
+                MountKind::Router { sources } => {
+                    // A router with no sources can never serve any package —
+                    // every request through it is a 404. That's only ever a
+                    // config mistake (a hosted/upstream mount was probably
+                    // intended), so reject it.
+                    if sources.is_empty() {
+                        return Err(MountConfigError::EmptyRouter { router: name.clone() });
+                    }
+                    self.validate_router(name, sources)?;
+                }
             }
         }
         Ok(())
     }
 
-    fn validate_router(&self, router: &str, routes: &[Route]) -> Result<(), MountConfigError> {
+    fn validate_router(&self, router: &str, sources: &[String]) -> Result<(), MountConfigError> {
+        // A pattern-less source claims every name; represent that claim as an
+        // explicit `**` so coverage against and by earlier sources is decided
+        // by the same relation as any declared pattern.
+        const CATCH_ALL: &[PackagePattern] = &[PackagePattern::All];
+        let mut seen_sources: Vec<&str> = Vec::new();
         let mut seen_patterns: Vec<&PackagePattern> = Vec::new();
-        for (index, route) in routes.iter().enumerate() {
-            if route.patterns.is_empty() {
-                return Err(MountConfigError::EmptyRoute { router: router.to_string(), index });
-            }
+        for (index, source) in sources.iter().enumerate() {
             // The source must resolve to a defined concrete mount: an unknown
             // name, the router itself, or another router are all rejected, so a
-            // route can only ever land on a real origin (no nesting, no cycles).
-            if route.source == router {
+            // router can only ever land on a real origin (no nesting, no cycles).
+            if source == router {
                 return Err(MountConfigError::SelfReferentialRouter { router: router.to_string() });
             }
-            match self.mounts.get(&route.source) {
+            let kind = match self.mounts.get(source) {
                 None => {
                     return Err(MountConfigError::UnknownSource {
                         router: router.to_string(),
-                        source: route.source.clone(),
+                        source: source.clone(),
                     });
                 }
-                Some(source) if !source.is_concrete() => {
+                Some(kind) if !kind.is_concrete() => {
                     return Err(MountConfigError::NonConcreteSource {
                         router: router.to_string(),
-                        source: route.source.clone(),
+                        source: source.clone(),
                     });
                 }
-                Some(_) => {}
+                Some(kind) => kind,
+            };
+            if seen_sources.contains(&source.as_str()) {
+                return Err(MountConfigError::DuplicateSource {
+                    router: router.to_string(),
+                    source: source.clone(),
+                });
             }
-            // A route is unreachable when every one of its patterns is already
-            // covered by some pattern in an earlier route — the misordered-`**`
-            // hazard and its general form. Reject it so a shadowed private route
-            // is a startup error, not a silent public fall-through.
-            if route
-                .patterns
+            seen_sources.push(source);
+            let patterns = match kind.patterns() {
+                Some([]) | None => CATCH_ALL,
+                Some(patterns) => patterns,
+            };
+            // A source is unreachable when every name it claims is already
+            // claimed by an earlier source — the misordered-catch-all hazard
+            // and its general form. Reject it so a shadowed private source is
+            // a startup error, not a silent public fall-through.
+            if patterns
                 .iter()
                 .all(|pattern| seen_patterns.iter().any(|earlier| earlier.covers(pattern)))
             {
-                return Err(MountConfigError::UnreachableRoute {
+                return Err(MountConfigError::UnreachableSource {
                     router: router.to_string(),
                     index,
-                    source: route.source.clone(),
+                    source: source.clone(),
                 });
             }
-            for pattern in &route.patterns {
-                // A pattern strictly narrower than an earlier route's pattern can
-                // never match — every package it claims is already routed away.
-                // The whole-route check above only fires when *all* of a route's
-                // patterns are covered; catch the partial case here so one
-                // shadowed pattern in an otherwise-reachable route can't silently
-                // send a private package to the origin an earlier `**`/scope route
-                // points at. Strict (`earlier != pattern`) so an exact repeat
-                // stays the clearer `DuplicatePattern` below rather than a shadow.
-                if let Some(earlier) = seen_patterns
-                    .iter()
-                    .find(|&&earlier| earlier != pattern && earlier.covers(pattern))
+            for pattern in patterns {
+                // A pattern covered by an earlier source's pattern can never be
+                // selected in this router — every package it claims is already
+                // routed away. The whole-source check above only fires when
+                // *all* of a source's patterns are covered; catch the partial
+                // case here so one dead claim of an otherwise-reachable source
+                // can't silently send a private package to the origin an
+                // earlier catch-all/scope claim points at. An identical claim
+                // by two sources is the same defect: whichever is listed later
+                // never receives the name, which is genuinely ambiguous
+                // provenance the operator must resolve in the declared
+                // namespaces, not by order.
+                if let Some(earlier) =
+                    seen_patterns.iter().find(|&&earlier| earlier.covers(pattern))
                 {
                     return Err(MountConfigError::ShadowedPattern {
                         router: router.to_string(),
+                        source: source.clone(),
                         pattern: pattern.to_string(),
                         by: earlier.to_string(),
                     });
                 }
-                if seen_patterns.contains(&pattern) {
-                    return Err(MountConfigError::DuplicatePattern {
-                        router: router.to_string(),
-                        pattern: pattern.to_string(),
-                    });
-                }
-                seen_patterns.push(pattern);
             }
+            // Extend the seen set only after the per-pattern pass: a source's
+            // own patterns may overlap each other (a mount-level redundancy,
+            // not a routing defect) without shadowing anything across sources.
+            seen_patterns.extend(patterns);
         }
         Ok(())
     }
+}
+
+/// Reject a duplicate pattern within one concrete mount's declared namespace.
+fn validate_namespace(mount: &str, patterns: &[PackagePattern]) -> Result<(), MountConfigError> {
+    for (index, pattern) in patterns.iter().enumerate() {
+        if patterns[..index].contains(pattern) {
+            return Err(MountConfigError::DuplicatePattern {
+                mount: mount.to_string(),
+                pattern: pattern.to_string(),
+            });
+        }
+    }
+    Ok(())
 }
 
 /// A static mount-configuration defect. Surfaced by [`Mounts::validate`] and by
@@ -387,30 +452,32 @@ impl Mounts {
 /// `InvalidConfig` so a bad mount set fails server startup and config reload.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MountConfigError {
-    /// An unsupported wildcard in a router pattern.
+    /// An unsupported wildcard in a mount pattern.
     InvalidPattern { pattern: String },
-    /// A wildcard-free router pattern that is not a well-formed package name,
+    /// A wildcard-free mount pattern that is not a well-formed package name,
     /// so it could never match any request.
     ExactPatternNotAName { pattern: String },
     /// `defaultTarget` names a mount that does not exist.
     UndefinedDefaultTarget { target: String },
-    /// A router route has no patterns, so it can never match.
-    EmptyRoute { router: String, index: usize },
-    /// A router has no routes at all, so it can never match any package.
+    /// A router has no sources at all, so it can never serve any package.
     EmptyRouter { router: String },
-    /// A router route lists the router itself as its source.
+    /// A router lists itself as a source.
     SelfReferentialRouter { router: String },
-    /// A router route's source is not a defined mount.
+    /// A router source is not a defined mount.
     UnknownSource { router: String, source: String },
-    /// A router route's source is another router, not a concrete mount.
+    /// A router source is another router, not a concrete mount.
     NonConcreteSource { router: String, source: String },
-    /// Two router routes declare the same pattern.
-    DuplicatePattern { router: String, pattern: String },
-    /// A router route is fully shadowed by earlier routes and can never match.
-    UnreachableRoute { router: String, index: usize, source: String },
-    /// A single router pattern is strictly covered by an earlier route's
-    /// pattern, so it can never match even though the rest of its route can.
-    ShadowedPattern { router: String, pattern: String, by: String },
+    /// A router lists the same source more than once.
+    DuplicateSource { router: String, source: String },
+    /// A concrete mount declares the same pattern more than once.
+    DuplicatePattern { mount: String, pattern: String },
+    /// A router source's claims are fully covered by earlier sources, so it
+    /// can never be selected.
+    UnreachableSource { router: String, index: usize, source: String },
+    /// A single pattern of a later source is covered by an earlier source's
+    /// pattern, so it can never be selected in this router even though the
+    /// rest of its source stays reachable.
+    ShadowedPattern { router: String, source: String, pattern: String, by: String },
 }
 
 impl fmt::Display for MountConfigError {
@@ -418,50 +485,51 @@ impl fmt::Display for MountConfigError {
         match self {
             MountConfigError::InvalidPattern { pattern } => write!(
                 f,
-                "unsupported router pattern {pattern:?}: use an exact name, `@scope/*`, `@*/*`, \
+                "unsupported mount pattern {pattern:?}: use an exact name, `@scope/*`, `@*/*`, \
                  or `**`",
             ),
             MountConfigError::ExactPatternNotAName { pattern } => write!(
                 f,
-                "router pattern {pattern:?} is not a valid package name, so it can never match; \
-                 to route every package in a scope use `@scope/*`",
+                "mount pattern {pattern:?} is not a valid package name, so it can never match; \
+                 to claim every package in a scope use `@scope/*`",
             ),
             MountConfigError::UndefinedDefaultTarget { target } => {
                 write!(f, "defaultTarget {target:?} is not a defined mount")
             }
-            MountConfigError::EmptyRoute { router, index } => {
-                write!(f, "router {router:?} route #{index} has no patterns", index = index + 1)
-            }
             MountConfigError::EmptyRouter { router } => write!(
                 f,
-                "router {router:?} has no routes, so it can never match any package; add routes \
-                 or remove the mount",
+                "router {router:?} has no sources, so it can never serve any package; add \
+                 sources or remove the mount",
             ),
             MountConfigError::SelfReferentialRouter { router } => {
-                write!(f, "router {router:?} lists itself as a route source")
+                write!(f, "router {router:?} lists itself as a source")
             }
             MountConfigError::UnknownSource { router, source } => {
-                write!(f, "router {router:?} route source {source:?} is not a defined mount")
+                write!(f, "router {router:?} source {source:?} is not a defined mount")
             }
             MountConfigError::NonConcreteSource { router, source } => write!(
                 f,
-                "router {router:?} route source {source:?} is itself a router; a route must target \
-                 a hosted or upstream mount",
+                "router {router:?} source {source:?} is itself a router; a source must be a \
+                 hosted or upstream mount",
             ),
-            MountConfigError::DuplicatePattern { router, pattern } => {
-                write!(f, "router {router:?} declares pattern {pattern:?} more than once")
+            MountConfigError::DuplicateSource { router, source } => {
+                write!(f, "router {router:?} lists source {source:?} more than once")
             }
-            MountConfigError::UnreachableRoute { router, index, source } => write!(
+            MountConfigError::DuplicatePattern { mount, pattern } => {
+                write!(f, "mount {mount:?} declares pattern {pattern:?} more than once")
+            }
+            MountConfigError::UnreachableSource { router, index, source } => write!(
                 f,
-                "router {router:?} route #{index} (source {source:?}) is unreachable: earlier \
-                 routes already match every package it would; reorder it before the routes that \
+                "router {router:?} source #{index} ({source:?}) is unreachable: earlier sources \
+                 already claim every package it would serve; list it before the sources that \
                  shadow it, or remove it",
                 index = index + 1,
             ),
-            MountConfigError::ShadowedPattern { router, pattern, by } => write!(
+            MountConfigError::ShadowedPattern { router, source, pattern, by } => write!(
                 f,
-                "router {router:?} pattern {pattern:?} is unreachable: earlier pattern {by:?} \
-                 already matches every package it would; reorder it before {by:?} or remove it",
+                "router {router:?} can never select source {source:?} for its pattern \
+                 {pattern:?}: an earlier source's pattern {by:?} already claims every package it \
+                 would; reorder the sources or adjust the declared namespaces",
             ),
         }
     }

--- a/pnpr/crates/pnpr/src/mount/tests.rs
+++ b/pnpr/crates/pnpr/src/mount/tests.rs
@@ -1,14 +1,23 @@
-use super::{ConcreteKind, MountConfigError, MountKind, Mounts, PackagePattern, Resolved, Route};
+use super::{ConcreteKind, MountConfigError, MountKind, Mounts, PackagePattern, Resolved};
 
 fn pattern(raw: &str) -> PackagePattern {
     PackagePattern::parse(raw).expect("pattern parses")
 }
 
-fn route(patterns: &[&str], source: &str) -> Route {
-    Route {
-        patterns: patterns.iter().map(|raw| pattern(raw)).collect(),
-        source: source.to_string(),
-    }
+fn patterns(raws: &[&str]) -> Vec<PackagePattern> {
+    raws.iter().map(|raw| pattern(raw)).collect()
+}
+
+fn hosted(raws: &[&str]) -> MountKind {
+    MountKind::Hosted { patterns: patterns(raws) }
+}
+
+fn upstream(raws: &[&str]) -> MountKind {
+    MountKind::Upstream { patterns: patterns(raws) }
+}
+
+fn router(sources: &[&str]) -> MountKind {
+    MountKind::Router { sources: sources.iter().map(ToString::to_string).collect() }
 }
 
 fn mounts(entries: Vec<(&str, MountKind)>, default_target: Option<&str>) -> Mounts {
@@ -39,8 +48,8 @@ fn rejects_unsupported_wildcards() {
 
 /// A wildcard-free pattern that is not a well-formed package name can never
 /// match a request, so a typo like `@acme` (meaning `@acme/*`) must be a
-/// config error rather than a literal that silently lets the scope fall
-/// through to a later route.
+/// config error rather than a literal that silently keeps the scope out of
+/// the mount's namespace.
 #[test]
 fn rejects_exact_pattern_that_is_not_a_package_name() {
     for raw in ["@acme", "@acme/", "@/foo", ".hidden", "a/b/c", "@scope/../up"] {
@@ -136,8 +145,8 @@ fn covers_agrees_with_matches_on_malformed_scoped_exacts() {
 // --- resolution ------------------------------------------------------------
 
 #[test]
-fn concrete_mount_resolves_to_itself() {
-    let registry = mounts(vec![("acme", MountKind::Hosted), ("npmjs", MountKind::Upstream)], None);
+fn pattern_less_concrete_mount_resolves_to_itself_for_any_name() {
+    let registry = mounts(vec![("acme", hosted(&[])), ("npmjs", upstream(&[]))], None);
     assert_eq!(
         registry.resolve("acme", "@acme/foo"),
         Resolved::Concrete { mount: "acme", kind: ConcreteKind::Hosted },
@@ -148,29 +157,40 @@ fn concrete_mount_resolves_to_itself() {
     );
 }
 
+/// The namespace is enforced on the mount itself: addressing a concrete mount
+/// directly (`/~<mount>/`) with a name outside its declared patterns is a
+/// definitive unclaimed, before storage or the upstream would be consulted.
+#[test]
+fn concrete_mount_does_not_resolve_an_unclaimed_name() {
+    let registry =
+        mounts(vec![("acme", hosted(&["@acme/*"])), ("corp", upstream(&["@corp/*"]))], None);
+    assert_eq!(
+        registry.resolve("acme", "@acme/foo"),
+        Resolved::Concrete { mount: "acme", kind: ConcreteKind::Hosted },
+    );
+    assert_eq!(registry.resolve("acme", "@typo/foo"), Resolved::Unclaimed);
+    // A private upstream's bound: a public name can't be pulled through it.
+    assert_eq!(
+        registry.resolve("corp", "@corp/foo"),
+        Resolved::Concrete { mount: "corp", kind: ConcreteKind::Upstream },
+    );
+    assert_eq!(registry.resolve("corp", "lodash"), Resolved::Unclaimed);
+}
+
 #[test]
 fn unknown_mount_resolves_to_unknown() {
-    let registry = mounts(vec![("npmjs", MountKind::Upstream)], None);
+    let registry = mounts(vec![("npmjs", upstream(&[]))], None);
     assert_eq!(registry.resolve("nope", "react"), Resolved::UnknownMount);
 }
 
 #[test]
-fn router_resolves_first_matching_route_authoritatively() {
+fn router_resolves_first_claiming_source_authoritatively() {
     let registry = mounts(
         vec![
-            ("acme", MountKind::Hosted),
-            ("corp", MountKind::Upstream),
-            ("npmjs", MountKind::Upstream),
-            (
-                "main",
-                MountKind::Router {
-                    routes: vec![
-                        route(&["@acme/*"], "acme"),
-                        route(&["@corp/*"], "corp"),
-                        route(&["**"], "npmjs"),
-                    ],
-                },
-            ),
+            ("acme", hosted(&["@acme/*"])),
+            ("corp", upstream(&["@corp/*"])),
+            ("npmjs", upstream(&[])),
+            ("main", router(&["acme", "corp", "npmjs"])),
         ],
         Some("main"),
     );
@@ -190,19 +210,14 @@ fn router_resolves_first_matching_route_authoritatively() {
 }
 
 #[test]
-fn router_earlier_route_wins_over_later_catch_all() {
-    // `@acme/*` is private (hosted); the `**` catch-all must never be consulted
-    // for an `@acme/*` name even though it would also match.
+fn router_earlier_source_wins_over_later_catch_all() {
+    // `@acme/*` is private (hosted); the pattern-less catch-all must never be
+    // consulted for an `@acme/*` name even though it would also claim it.
     let registry = mounts(
         vec![
-            ("acme", MountKind::Hosted),
-            ("npmjs", MountKind::Upstream),
-            (
-                "main",
-                MountKind::Router {
-                    routes: vec![route(&["@acme/*"], "acme"), route(&["**"], "npmjs")],
-                },
-            ),
+            ("acme", hosted(&["@acme/*"])),
+            ("npmjs", upstream(&[])),
+            ("main", router(&["acme", "npmjs"])),
         ],
         None,
     );
@@ -213,26 +228,15 @@ fn router_earlier_route_wins_over_later_catch_all() {
 }
 
 #[test]
-fn router_with_no_matching_route_is_no_route_not_fallthrough() {
-    let registry = mounts(
-        vec![
-            ("acme", MountKind::Hosted),
-            ("main", MountKind::Router { routes: vec![route(&["@acme/*"], "acme")] }),
-        ],
-        None,
-    );
-    assert_eq!(registry.resolve("main", "lodash"), Resolved::NoRoute);
+fn router_with_no_claiming_source_is_unclaimed_not_fallthrough() {
+    let registry = mounts(vec![("acme", hosted(&["@acme/*"])), ("main", router(&["acme"]))], None);
+    assert_eq!(registry.resolve("main", "lodash"), Resolved::Unclaimed);
 }
 
 #[test]
 fn resolve_default_uses_default_target() {
-    let registry = mounts(
-        vec![
-            ("npmjs", MountKind::Upstream),
-            ("main", MountKind::Router { routes: vec![route(&["**"], "npmjs")] }),
-        ],
-        Some("main"),
-    );
+    let registry =
+        mounts(vec![("npmjs", upstream(&[])), ("main", router(&["npmjs"]))], Some("main"));
     assert_eq!(
         registry.resolve_default("react"),
         Resolved::Concrete { mount: "npmjs", kind: ConcreteKind::Upstream },
@@ -241,31 +245,20 @@ fn resolve_default_uses_default_target() {
 
 #[test]
 fn resolve_default_without_target_is_unknown() {
-    let registry = mounts(vec![("npmjs", MountKind::Upstream)], None);
+    let registry = mounts(vec![("npmjs", upstream(&[]))], None);
     assert_eq!(registry.resolve_default("react"), Resolved::UnknownMount);
 }
 
 // --- validation ------------------------------------------------------------
 
-fn router_mount(routes: Vec<Route>) -> MountKind {
-    MountKind::Router { routes }
-}
-
 #[test]
 fn valid_config_passes() {
     let registry = mounts(
         vec![
-            ("acme", MountKind::Hosted),
-            ("corp", MountKind::Upstream),
-            ("npmjs", MountKind::Upstream),
-            (
-                "main",
-                router_mount(vec![
-                    route(&["@acme/*"], "acme"),
-                    route(&["@corp/*"], "corp"),
-                    route(&["**"], "npmjs"),
-                ]),
-            ),
+            ("acme", hosted(&["@acme/*"])),
+            ("corp", upstream(&["@corp/*"])),
+            ("npmjs", upstream(&[])),
+            ("main", router(&["acme", "corp", "npmjs"])),
         ],
         Some("main"),
     );
@@ -274,7 +267,7 @@ fn valid_config_passes() {
 
 #[test]
 fn rejects_undefined_default_target() {
-    let registry = mounts(vec![("npmjs", MountKind::Upstream)], Some("ghost"));
+    let registry = mounts(vec![("npmjs", upstream(&[]))], Some("ghost"));
     assert_eq!(
         registry.validate(),
         Err(MountConfigError::UndefinedDefaultTarget { target: "ghost".to_string() }),
@@ -282,47 +275,48 @@ fn rejects_undefined_default_target() {
 }
 
 #[test]
-fn rejects_catch_all_before_narrower_route() {
-    // The dangerous common mistake: `**` first shadows a later private scope.
+fn rejects_pattern_less_source_before_narrower_source() {
+    // The dangerous common mistake: the catch-all listed first shadows a later
+    // private scope.
     let registry = mounts(
         vec![
-            ("acme", MountKind::Hosted),
-            ("npmjs", MountKind::Upstream),
-            ("main", router_mount(vec![route(&["**"], "npmjs"), route(&["@acme/*"], "acme")])),
+            ("acme", hosted(&["@acme/*"])),
+            ("npmjs", upstream(&[])),
+            ("main", router(&["npmjs", "acme"])),
         ],
         None,
     );
     assert!(matches!(
         registry.validate(),
-        Err(MountConfigError::UnreachableRoute { index: 1, .. }),
+        Err(MountConfigError::UnreachableSource { index: 1, .. }),
     ));
 }
 
 #[test]
-fn rejects_route_shadowed_by_broader_scope() {
+fn rejects_source_shadowed_by_broader_scope() {
     let registry = mounts(
         vec![
-            ("acme", MountKind::Hosted),
-            ("other", MountKind::Upstream),
-            ("main", router_mount(vec![route(&["@*/*"], "other"), route(&["@acme/*"], "acme")])),
+            ("other", upstream(&["@*/*"])),
+            ("acme", hosted(&["@acme/*"])),
+            ("main", router(&["other", "acme"])),
         ],
         None,
     );
     assert!(matches!(
         registry.validate(),
-        Err(MountConfigError::UnreachableRoute { index: 1, .. }),
+        Err(MountConfigError::UnreachableSource { index: 1, .. }),
     ));
 }
 
 #[test]
-fn allows_narrower_route_before_broader() {
-    // `@acme/foo` exact before `@acme/*` is fine — the exact matches strictly
-    // less, so the scope route is still reachable for every other name.
+fn allows_narrower_source_before_broader() {
+    // `@acme/foo` exact before `@acme/*` is fine — the exact claims strictly
+    // less, so the scope source is still reachable for every other name.
     let registry = mounts(
         vec![
-            ("a", MountKind::Hosted),
-            ("b", MountKind::Upstream),
-            ("main", router_mount(vec![route(&["@acme/foo"], "a"), route(&["@acme/*"], "b")])),
+            ("a", hosted(&["@acme/foo"])),
+            ("b", upstream(&["@acme/*"])),
+            ("main", router(&["a", "b"])),
         ],
         None,
     );
@@ -331,21 +325,14 @@ fn allows_narrower_route_before_broader() {
 
 #[test]
 fn allows_sibling_scopes_before_any_scoped() {
-    // `@a/*` and `@b/*` do not (and cannot) cover `@*/*`, so the broad route
+    // `@a/*` and `@b/*` do not (and cannot) cover `@*/*`, so the broad source
     // stays reachable.
     let registry = mounts(
         vec![
-            ("a", MountKind::Hosted),
-            ("b", MountKind::Hosted),
-            ("rest", MountKind::Upstream),
-            (
-                "main",
-                router_mount(vec![
-                    route(&["@a/*"], "a"),
-                    route(&["@b/*"], "b"),
-                    route(&["@*/*"], "rest"),
-                ]),
-            ),
+            ("a", hosted(&["@a/*"])),
+            ("b", hosted(&["@b/*"])),
+            ("rest", upstream(&["@*/*"])),
+            ("main", router(&["a", "b", "rest"])),
         ],
         None,
     );
@@ -353,23 +340,17 @@ fn allows_sibling_scopes_before_any_scoped() {
 }
 
 #[test]
-fn rejects_partially_shadowed_route() {
-    // The later route stays reachable through `plainpkg` (which `@*/*` cannot
-    // cover), but its `@secret/foo` pattern is swallowed by the earlier `@*/*`
-    // route. That one pattern must be rejected by name — otherwise requests for
-    // `@secret/foo` silently fall through to the public upstream instead of the
-    // private mount, and the whole-route unreachability check never fires.
+fn rejects_partially_shadowed_source() {
+    // The later source stays reachable through `plainpkg` (which `@*/*` cannot
+    // cover), but its `@secret/foo` claim is swallowed by the earlier `@*/*`
+    // source. That one pattern must be rejected by name — otherwise requests
+    // for `@secret/foo` silently go to the public upstream instead of the
+    // private mount, and the whole-source unreachability check never fires.
     let registry = mounts(
         vec![
-            ("public", MountKind::Upstream),
-            ("private", MountKind::Hosted),
-            (
-                "main",
-                router_mount(vec![
-                    route(&["@*/*"], "public"),
-                    route(&["@secret/foo", "plainpkg"], "private"),
-                ]),
-            ),
+            ("public", upstream(&["@*/*"])),
+            ("private", hosted(&["@secret/foo", "plainpkg"])),
+            ("main", router(&["public", "private"])),
         ],
         None,
     );
@@ -379,55 +360,95 @@ fn rejects_partially_shadowed_route() {
     ));
 }
 
+/// Two mounts claiming the same pattern cannot be ordered: whichever is listed
+/// later never receives the name. That's ambiguous provenance the operator has
+/// to resolve in the declared namespaces, not by source order.
 #[test]
-fn rejects_duplicate_pattern() {
+fn rejects_identical_claim_across_two_sources() {
     let registry = mounts(
         vec![
-            ("a", MountKind::Hosted),
-            ("b", MountKind::Upstream),
-            ("main", router_mount(vec![route(&["@acme/*"], "a"), route(&["@acme/*"], "b")])),
-        ],
-        None,
-    );
-    // A duplicate scope pattern is also unreachable; either diagnosis is a
-    // rejection, but the duplicate check runs first within a route's loop only
-    // after the reachability check, so the broader (unreachable) error wins.
-    assert!(registry.validate().is_err());
-}
-
-#[test]
-fn rejects_duplicate_pattern_when_reachable() {
-    // Two routes whose union is reachable but that share an exact pattern: the
-    // second route is reachable via its other pattern, so the duplicate-pattern
-    // check is what fires.
-    let registry = mounts(
-        vec![
-            ("a", MountKind::Hosted),
-            ("b", MountKind::Hosted),
-            ("rest", MountKind::Upstream),
-            (
-                "main",
-                router_mount(vec![
-                    route(&["@a/foo"], "a"),
-                    route(&["@a/foo", "@b/*"], "b"),
-                    route(&["**"], "rest"),
-                ]),
-            ),
+            ("a", hosted(&["@a/foo"])),
+            ("b", hosted(&["@a/foo", "@b/*"])),
+            ("main", router(&["a", "b"])),
         ],
         None,
     );
     assert_eq!(
         registry.validate(),
-        Err(MountConfigError::DuplicatePattern {
+        Err(MountConfigError::ShadowedPattern {
             router: "main".to_string(),
+            source: "b".to_string(),
             pattern: "@a/foo".to_string(),
+            by: "@a/foo".to_string(),
+        }),
+    );
+}
+
+/// Namespaces that overlap in both directions can't be saved by reordering —
+/// either order leaves one source's claim dead, so both orders are rejected.
+#[test]
+fn rejects_bidirectionally_overlapping_sources_in_either_order() {
+    let entries = |sources: &[&str]| {
+        vec![
+            ("a", hosted(&["@x/*", "@y/foo"])),
+            ("b", hosted(&["@y/*", "@x/foo"])),
+            ("main", router(sources)),
+        ]
+    };
+    assert!(matches!(
+        mounts(entries(&["a", "b"]), None).validate(),
+        Err(MountConfigError::ShadowedPattern { .. }),
+    ));
+    assert!(matches!(
+        mounts(entries(&["b", "a"]), None).validate(),
+        Err(MountConfigError::ShadowedPattern { .. }),
+    ));
+}
+
+/// A mount may declare internally redundant patterns (`@acme/*` plus an exact
+/// `@acme/foo`); the union is the namespace, and using the mount in a router
+/// must not report the mount as shadowing itself.
+#[test]
+fn allows_a_source_whose_own_patterns_overlap() {
+    let registry = mounts(
+        vec![
+            ("a", hosted(&["@acme/*", "@acme/foo"])),
+            ("npmjs", upstream(&[])),
+            ("main", router(&["a", "npmjs"])),
+        ],
+        None,
+    );
+    assert_eq!(registry.validate(), Ok(()));
+}
+
+#[test]
+fn rejects_duplicate_pattern_within_one_mount() {
+    let registry = mounts(vec![("a", hosted(&["@acme/*", "@acme/*"]))], None);
+    assert_eq!(
+        registry.validate(),
+        Err(MountConfigError::DuplicatePattern {
+            mount: "a".to_string(),
+            pattern: "@acme/*".to_string(),
+        }),
+    );
+}
+
+#[test]
+fn rejects_duplicate_source() {
+    let registry =
+        mounts(vec![("npmjs", upstream(&["@a/*"])), ("main", router(&["npmjs", "npmjs"]))], None);
+    assert_eq!(
+        registry.validate(),
+        Err(MountConfigError::DuplicateSource {
+            router: "main".to_string(),
+            source: "npmjs".to_string(),
         }),
     );
 }
 
 #[test]
 fn rejects_unknown_source() {
-    let registry = mounts(vec![("main", router_mount(vec![route(&["**"], "ghost")]))], None);
+    let registry = mounts(vec![("main", router(&["ghost"]))], None);
     assert_eq!(
         registry.validate(),
         Err(MountConfigError::UnknownSource {
@@ -439,7 +460,7 @@ fn rejects_unknown_source() {
 
 #[test]
 fn rejects_self_referential_router() {
-    let registry = mounts(vec![("main", router_mount(vec![route(&["**"], "main")]))], None);
+    let registry = mounts(vec![("main", router(&["main"]))], None);
     assert_eq!(
         registry.validate(),
         Err(MountConfigError::SelfReferentialRouter { router: "main".to_string() }),
@@ -450,9 +471,9 @@ fn rejects_self_referential_router() {
 fn rejects_router_targeting_another_router() {
     let registry = mounts(
         vec![
-            ("npmjs", MountKind::Upstream),
-            ("inner", router_mount(vec![route(&["**"], "npmjs")])),
-            ("outer", router_mount(vec![route(&["**"], "inner")])),
+            ("npmjs", upstream(&[])),
+            ("inner", router(&["npmjs"])),
+            ("outer", router(&["inner"])),
         ],
         None,
     );
@@ -466,27 +487,12 @@ fn rejects_router_targeting_another_router() {
 }
 
 #[test]
-fn rejects_router_with_no_routes() {
-    // An empty router can never match any package; it is only ever a config
-    // mistake, so validation rejects it like an empty route.
-    let registry = mounts(vec![("main", router_mount(vec![]))], None);
+fn rejects_router_with_no_sources() {
+    // An empty router can never serve any package; it is only ever a config
+    // mistake, so validation rejects it.
+    let registry = mounts(vec![("main", router(&[]))], None);
     assert_eq!(
         registry.validate(),
         Err(MountConfigError::EmptyRouter { router: "main".to_string() }),
-    );
-}
-
-#[test]
-fn rejects_empty_route() {
-    let registry = mounts(
-        vec![
-            ("npmjs", MountKind::Upstream),
-            ("main", router_mount(vec![Route { patterns: vec![], source: "npmjs".to_string() }])),
-        ],
-        None,
-    );
-    assert_eq!(
-        registry.validate(),
-        Err(MountConfigError::EmptyRoute { router: "main".to_string(), index: 0 }),
     );
 }

--- a/pnpr/crates/pnpr/src/package_name.rs
+++ b/pnpr/crates/pnpr/src/package_name.rs
@@ -91,7 +91,7 @@ fn is_safe_segment(segment: &str) -> bool {
 
 /// Whether `filename` is safe to use as a single on-disk path segment (no
 /// traversal, no separators, no absolute-path or Windows drive prefixes). The
-/// uplink tarball path uses it to admit a non-canonical basename preserved
+/// upstream tarball path uses it to admit a non-canonical basename preserved
 /// from an upstream `dist.tarball` (see `rewrite_tarball_urls`) into the
 /// cache layout — the packument match is what authorizes the name; this only
 /// keeps it on disk safely.

--- a/pnpr/crates/pnpr/src/registry.rs
+++ b/pnpr/crates/pnpr/src/registry.rs
@@ -252,6 +252,17 @@ impl Registries {
         matches!(self.registries.get(registry), Some(Registry::Router { .. }))
     }
 
+    /// Insert `name` as a pattern-less upstream registry when it is not
+    /// already declared, so the server can fold a programmatically-added
+    /// uplink into the graph and keep [`Self::resolve`] the only dispatch
+    /// table for `/~<name>/` traffic. An embedder that wants a namespace
+    /// bound on an uplink declares its own entry (with patterns) first.
+    pub fn ensure_upstream(&mut self, name: &str) {
+        if !self.registries.contains_key(name) {
+            self.registries.insert(name.to_string(), Registry::Upstream { patterns: Vec::new() });
+        }
+    }
+
     /// Resolve a request addressed to `registry` for `package` to its single
     /// concrete origin, enforcing every concrete registry's declared namespace at
     /// the registry itself. A concrete registry resolves to itself only when its

--- a/pnpr/crates/pnpr/src/registry.rs
+++ b/pnpr/crates/pnpr/src/registry.rs
@@ -1,25 +1,25 @@
-//! Registry mounts: the routing graph and its static validation.
+//! Registries: the routing graph and its static validation.
 //!
-//! A **registry mount** is an addressable npm-registry surface exposed at
-//! `https://<pnpr>/~<mount>/`. There are two concrete kinds — a pnpr-hosted
+//! A **registry** is an addressable npm-registry surface exposed at
+//! `https://<pnpr>/~<name>/`. There are two concrete kinds — a pnpr-hosted
 //! registry and a single-origin upstream registry — plus one composite, a
-//! **router**, an ordered list of concrete mounts behind one URL.
+//! **router**, an ordered list of concrete registries behind one URL.
 //!
 //! The model is governed by one invariant: **provenance is declared, never
-//! inferred.** Every concrete mount declares the package-name patterns it
-//! serves — its namespace — and that namespace is enforced on the mount
+//! inferred.** Every concrete registry declares the package-name patterns it
+//! serves — its namespace — and that namespace is enforced on the registry
 //! itself, on every path to it: an unclaimed name is a definitive not-found
 //! before storage or the upstream is consulted, whether the request came
-//! through a router or addressed the mount directly. A router selects the
+//! through a router or addressed the registry directly. A router selects the
 //! first listed source whose patterns claim the name — authoritatively. It can
-//! order competing claims, but it can never assign a name to a mount that does
+//! order competing claims, but it can never assign a name to a registry that does
 //! not claim it, so no configuration can express a cross-origin fall-through:
 //! a selected source's "not found" or "unavailable" is final. There is no
 //! existence-based fallback, no mirror group, and no multi-endpoint failover.
 //!
 //! Because selection is first-source-in-order, source order is load-bearing: a
 //! misordered router is the one way a configuration mistake could silently send
-//! a private scope to a public origin. [`Mounts::validate`] rejects that class
+//! a private scope to a public origin. [`Registries::validate`] rejects that class
 //! at config load (and reload) — shadowed/unreachable sources, duplicate
 //! sources and patterns, and sources that are unknown, self-referential, or
 //! not concrete. The check is static because [`PackagePattern`]'s coverage
@@ -29,13 +29,13 @@ use crate::package_name::PackageName;
 use indexmap::IndexMap;
 use std::fmt;
 
-/// A package-name pattern: one member of a concrete mount's declared
+/// A package-name pattern: one member of a concrete registry's declared
 /// namespace.
 ///
 /// Deliberately a small, **decidable** language so [`Self::covers`] can decide
 /// statically whether one pattern matches a superset of another — the property
-/// [`Mounts::validate`] relies on to detect shadowed sources. A general glob
-/// (`wax`) would make coverage undecidable, so mount patterns are restricted
+/// [`Registries::validate`] relies on to detect shadowed sources. A general glob
+/// (`wax`) would make coverage undecidable, so registry patterns are restricted
 /// to these four shapes; an unrecognized wildcard is a parse error rather than
 /// a silently-narrowing literal.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -52,14 +52,14 @@ pub enum PackagePattern {
 }
 
 impl PackagePattern {
-    /// Parse a mount pattern. Rejects any `*` that is not one of the three
+    /// Parse a registry pattern. Rejects any `*` that is not one of the three
     /// recognized wildcard shapes (`**`, `@*/*`, `@<scope>/*`), and any
     /// remaining literal that is not a well-formed package name — so an
     /// unsupported glob or a typo like `@acme` (meaning `@acme/*`) fails
     /// loudly instead of being read as a literal name that silently never
     /// matches and lets the scope land on a later router source.
-    pub fn parse(pattern: &str) -> Result<Self, MountConfigError> {
-        let invalid = || MountConfigError::InvalidPattern { pattern: pattern.to_string() };
+    pub fn parse(pattern: &str) -> Result<Self, RegistryConfigError> {
+        let invalid = || RegistryConfigError::InvalidPattern { pattern: pattern.to_string() };
         if pattern.is_empty() {
             return Err(invalid());
         }
@@ -82,7 +82,7 @@ impl PackagePattern {
             return Err(invalid());
         }
         if PackageName::parse(pattern).is_err() {
-            return Err(MountConfigError::ExactPatternNotAName { pattern: pattern.to_string() });
+            return Err(RegistryConfigError::ExactPatternNotAName { pattern: pattern.to_string() });
         }
         Ok(PackagePattern::Exact(pattern.to_string()))
     }
@@ -103,7 +103,7 @@ impl PackagePattern {
     }
 
     /// Whether this pattern matches every package the `other` pattern matches
-    /// (i.e. `self` ⊇ `other`). Decides source shadowing in [`Mounts::validate`].
+    /// (i.e. `self` ⊇ `other`). Decides source shadowing in [`Registries::validate`].
     ///
     /// A union of earlier patterns can only shadow `other` through a single
     /// member: the one unbounded case — many `@<scope>/*` covering `@*/*` —
@@ -150,44 +150,44 @@ fn scoped_name(package: &str) -> Option<(&str, &str)> {
     (!scope.is_empty() && !name.is_empty()).then_some((scope, name))
 }
 
-/// The routing role of a mount. The per-mount serving details (upstream URL,
+/// The routing role of a registry. The per-registry serving details (upstream URL,
 /// credentials, access policy, org id) live in the `config` module; this
 /// captures only what routing and validation need.
 ///
-/// A concrete mount's `patterns` are its declared namespace: the names it
+/// A concrete registry's `patterns` are its declared namespace: the names it
 /// serves and accepts publishes for, and the claim routers derive their
 /// selection from. An empty list claims every name — the catch-all in any
 /// router.
 #[derive(Debug, Clone)]
-pub enum MountKind {
+pub enum Registry {
     /// A pnpr-hosted registry: the authoritative origin for the packages it
     /// stores, and the only kind that accepts writes. Reads and writes are
-    /// scoped to the mount's own storage namespace (its optional `org`).
+    /// scoped to the registry's own storage namespace (its optional `org`).
     Hosted { patterns: Vec<PackagePattern> },
     /// Exactly one external origin. One URL, one credential generation, one
     /// cache namespace — not a chain and not a set of endpoints.
     Upstream { patterns: Vec<PackagePattern> },
-    /// An ordered list of concrete mounts. A package resolves to the first
+    /// An ordered list of concrete registries. A package resolves to the first
     /// source whose declared patterns claim it.
     Router { sources: Vec<String> },
 }
 
-impl MountKind {
+impl Registry {
     fn is_concrete(&self) -> bool {
-        matches!(self, MountKind::Hosted { .. } | MountKind::Upstream { .. })
+        matches!(self, Registry::Hosted { .. } | Registry::Upstream { .. })
     }
 
-    /// A concrete mount's declared namespace; `None` for a router (a router
+    /// A concrete registry's declared namespace; `None` for a router (a router
     /// has no namespace of its own — it derives one from its sources).
     fn patterns(&self) -> Option<&[PackagePattern]> {
         match self {
-            MountKind::Hosted { patterns } | MountKind::Upstream { patterns } => Some(patterns),
-            MountKind::Router { .. } => None,
+            Registry::Hosted { patterns } | Registry::Upstream { patterns } => Some(patterns),
+            Registry::Router { .. } => None,
         }
     }
 }
 
-/// Whether a concrete mount's declared namespace claims `package`. An empty
+/// Whether a concrete registry's declared namespace claims `package`. An empty
 /// pattern list claims every name.
 fn namespace_claims(patterns: &[PackagePattern], package: &str) -> bool {
     patterns.is_empty() || patterns.iter().any(|pattern| pattern.matches(package))
@@ -200,103 +200,103 @@ pub enum ConcreteKind {
     Upstream,
 }
 
-/// The outcome of resolving a request `(mount, package)` to a concrete origin.
+/// The outcome of resolving a request `(registry, package)` to a concrete origin.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Resolved<'a> {
-    /// Resolved to exactly one concrete source mount whose declared patterns
+    /// Resolved to exactly one concrete source registry whose declared patterns
     /// claim the package.
-    Concrete { mount: &'a str, kind: ConcreteKind },
+    Concrete { registry: &'a str, kind: ConcreteKind },
     /// No declared namespace claims this package: the addressed concrete
-    /// mount's patterns don't cover it, or none of a router's sources claim
+    /// registry's patterns don't cover it, or none of a router's sources claim
     /// it. A definitive `404` on reads and a rejection on writes, answered
     /// before storage or any upstream is consulted — never a fall-through.
     Unclaimed,
-    /// The addressed mount id is not defined.
-    UnknownMount,
+    /// The addressed registry id is not defined.
+    UnknownRegistry,
 }
 
-/// The validated set of registry mounts plus the optional path-less default
+/// The validated set of registries plus the optional path-less default
 /// target. Built and validated by the `config` module at load time.
 #[derive(Debug, Default, Clone)]
-pub struct Mounts {
-    mounts: IndexMap<String, MountKind>,
-    /// The mount the path-less base URL (`https://<pnpr>/`) aliases. `None`
-    /// disables the path-less base entirely — clients must address a mount.
-    default_target: Option<String>,
+pub struct Registries {
+    registries: IndexMap<String, Registry>,
+    /// The registry the path-less base URL (`https://<pnpr>/`) aliases. `None`
+    /// disables the path-less base entirely — clients must address a registry.
+    default_registry: Option<String>,
 }
 
-impl Mounts {
+impl Registries {
     #[must_use]
-    pub fn new(mounts: IndexMap<String, MountKind>, default_target: Option<String>) -> Self {
-        Self { mounts, default_target }
+    pub fn new(registries: IndexMap<String, Registry>, default_registry: Option<String>) -> Self {
+        Self { registries, default_registry }
     }
 
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.mounts.is_empty()
+        self.registries.is_empty()
     }
 
     #[must_use]
-    pub fn get(&self, mount: &str) -> Option<&MountKind> {
-        self.mounts.get(mount)
+    pub fn get(&self, registry: &str) -> Option<&Registry> {
+        self.registries.get(registry)
     }
 
     #[must_use]
-    pub fn default_target(&self) -> Option<&str> {
-        self.default_target.as_deref()
+    pub fn default_registry(&self) -> Option<&str> {
+        self.default_registry.as_deref()
     }
 
-    /// Whether `mount` is a defined router.
+    /// Whether `registry` is a defined router.
     #[must_use]
-    pub fn is_router(&self, mount: &str) -> bool {
-        matches!(self.mounts.get(mount), Some(MountKind::Router { .. }))
+    pub fn is_router(&self, registry: &str) -> bool {
+        matches!(self.registries.get(registry), Some(Registry::Router { .. }))
     }
 
-    /// Resolve a request addressed to `mount` for `package` to its single
-    /// concrete origin, enforcing every concrete mount's declared namespace at
-    /// the mount itself. A concrete mount resolves to itself only when its
+    /// Resolve a request addressed to `registry` for `package` to its single
+    /// concrete origin, enforcing every concrete registry's declared namespace at
+    /// the registry itself. A concrete registry resolves to itself only when its
     /// patterns claim the package; a router resolves to the first source whose
     /// patterns claim it (authoritatively — an unclaimed package is
     /// [`Resolved::Unclaimed`], never a fall-through).
     #[must_use]
-    pub fn resolve<'a>(&'a self, mount: &str, package: &str) -> Resolved<'a> {
-        let Some((mount_id, kind)) = self.mounts.get_key_value(mount) else {
-            return Resolved::UnknownMount;
+    pub fn resolve<'a>(&'a self, registry: &str, package: &str) -> Resolved<'a> {
+        let Some((registry_id, kind)) = self.registries.get_key_value(registry) else {
+            return Resolved::UnknownRegistry;
         };
         match kind {
-            MountKind::Hosted { patterns } => {
+            Registry::Hosted { patterns } => {
                 if namespace_claims(patterns, package) {
-                    Resolved::Concrete { mount: mount_id, kind: ConcreteKind::Hosted }
+                    Resolved::Concrete { registry: registry_id, kind: ConcreteKind::Hosted }
                 } else {
                     Resolved::Unclaimed
                 }
             }
-            MountKind::Upstream { patterns } => {
+            Registry::Upstream { patterns } => {
                 if namespace_claims(patterns, package) {
-                    Resolved::Concrete { mount: mount_id, kind: ConcreteKind::Upstream }
+                    Resolved::Concrete { registry: registry_id, kind: ConcreteKind::Upstream }
                 } else {
                     Resolved::Unclaimed
                 }
             }
-            MountKind::Router { sources } => {
+            Registry::Router { sources } => {
                 // Validation guarantees every source is a defined concrete
-                // mount; a non-concrete entry here can only mean the graph was
+                // registry; a non-concrete entry here can only mean the graph was
                 // built without validation, and it simply never matches.
                 for source in sources {
-                    match self.mounts.get_key_value(source) {
-                        Some((source_id, MountKind::Hosted { patterns }))
+                    match self.registries.get_key_value(source) {
+                        Some((source_id, Registry::Hosted { patterns }))
                             if namespace_claims(patterns, package) =>
                         {
                             return Resolved::Concrete {
-                                mount: source_id,
+                                registry: source_id,
                                 kind: ConcreteKind::Hosted,
                             };
                         }
-                        Some((source_id, MountKind::Upstream { patterns }))
+                        Some((source_id, Registry::Upstream { patterns }))
                             if namespace_claims(patterns, package) =>
                         {
                             return Resolved::Concrete {
-                                mount: source_id,
+                                registry: source_id,
                                 kind: ConcreteKind::Upstream,
                             };
                         }
@@ -310,36 +310,36 @@ impl Mounts {
 
     /// Resolve a request to the path-less base (`https://<pnpr>/`) through the
     /// configured default target. With no default target the path-less base is
-    /// disabled, so every package is [`Resolved::UnknownMount`].
+    /// disabled, so every package is [`Resolved::UnknownRegistry`].
     #[must_use]
     pub fn resolve_default<'a>(&'a self, package: &str) -> Resolved<'a> {
-        match self.default_target.as_deref() {
+        match self.default_registry.as_deref() {
             Some(target) => self.resolve(target, package),
-            None => Resolved::UnknownMount,
+            None => Resolved::UnknownRegistry,
         }
     }
 
-    /// Validate the whole mount set, failing closed on any configuration that
+    /// Validate the whole registry set, failing closed on any configuration that
     /// could route a private name to the wrong origin or leave a source dead.
     /// Run at config load and on reload.
-    pub fn validate(&self) -> Result<(), MountConfigError> {
-        if let Some(target) = &self.default_target
-            && !self.mounts.contains_key(target)
+    pub fn validate(&self) -> Result<(), RegistryConfigError> {
+        if let Some(target) = &self.default_registry
+            && !self.registries.contains_key(target)
         {
-            return Err(MountConfigError::UndefinedDefaultTarget { target: target.clone() });
+            return Err(RegistryConfigError::UndefinedDefaultRegistry { target: target.clone() });
         }
-        for (name, kind) in &self.mounts {
+        for (name, kind) in &self.registries {
             match kind {
-                MountKind::Hosted { patterns } | MountKind::Upstream { patterns } => {
+                Registry::Hosted { patterns } | Registry::Upstream { patterns } => {
                     validate_namespace(name, patterns)?;
                 }
-                MountKind::Router { sources } => {
+                Registry::Router { sources } => {
                     // A router with no sources can never serve any package —
                     // every request through it is a 404. That's only ever a
-                    // config mistake (a hosted/upstream mount was probably
+                    // config mistake (a hosted/upstream registry was probably
                     // intended), so reject it.
                     if sources.is_empty() {
-                        return Err(MountConfigError::EmptyRouter { router: name.clone() });
+                        return Err(RegistryConfigError::EmptyRouter { router: name.clone() });
                     }
                     self.validate_router(name, sources)?;
                 }
@@ -348,7 +348,7 @@ impl Mounts {
         Ok(())
     }
 
-    fn validate_router(&self, router: &str, sources: &[String]) -> Result<(), MountConfigError> {
+    fn validate_router(&self, router: &str, sources: &[String]) -> Result<(), RegistryConfigError> {
         // A pattern-less source claims every name; represent that claim as an
         // explicit `**` so coverage against and by earlier sources is decided
         // by the same relation as any declared pattern.
@@ -356,21 +356,23 @@ impl Mounts {
         let mut seen_sources: Vec<&str> = Vec::new();
         let mut seen_patterns: Vec<&PackagePattern> = Vec::new();
         for (index, source) in sources.iter().enumerate() {
-            // The source must resolve to a defined concrete mount: an unknown
+            // The source must resolve to a defined concrete registry: an unknown
             // name, the router itself, or another router are all rejected, so a
             // router can only ever land on a real origin (no nesting, no cycles).
             if source == router {
-                return Err(MountConfigError::SelfReferentialRouter { router: router.to_string() });
+                return Err(RegistryConfigError::SelfReferentialRouter {
+                    router: router.to_string(),
+                });
             }
-            let kind = match self.mounts.get(source) {
+            let kind = match self.registries.get(source) {
                 None => {
-                    return Err(MountConfigError::UnknownSource {
+                    return Err(RegistryConfigError::UnknownSource {
                         router: router.to_string(),
                         source: source.clone(),
                     });
                 }
                 Some(kind) if !kind.is_concrete() => {
-                    return Err(MountConfigError::NonConcreteSource {
+                    return Err(RegistryConfigError::NonConcreteSource {
                         router: router.to_string(),
                         source: source.clone(),
                     });
@@ -378,7 +380,7 @@ impl Mounts {
                 Some(kind) => kind,
             };
             if seen_sources.contains(&source.as_str()) {
-                return Err(MountConfigError::DuplicateSource {
+                return Err(RegistryConfigError::DuplicateSource {
                     router: router.to_string(),
                     source: source.clone(),
                 });
@@ -396,7 +398,7 @@ impl Mounts {
                 .iter()
                 .all(|pattern| seen_patterns.iter().any(|earlier| earlier.covers(pattern)))
             {
-                return Err(MountConfigError::UnreachableSource {
+                return Err(RegistryConfigError::UnreachableSource {
                     router: router.to_string(),
                     index,
                     source: source.clone(),
@@ -417,7 +419,7 @@ impl Mounts {
                 if let Some(earlier) =
                     seen_patterns.iter().find(|&&earlier| earlier.covers(pattern))
                 {
-                    return Err(MountConfigError::ShadowedPattern {
+                    return Err(RegistryConfigError::ShadowedPattern {
                         router: router.to_string(),
                         source: source.clone(),
                         pattern: pattern.to_string(),
@@ -426,7 +428,7 @@ impl Mounts {
                 }
             }
             // Extend the seen set only after the per-pattern pass: a source's
-            // own patterns may overlap each other (a mount-level redundancy,
+            // own patterns may overlap each other (a registry-level redundancy,
             // not a routing defect) without shadowing anything across sources.
             seen_patterns.extend(patterns);
         }
@@ -434,12 +436,15 @@ impl Mounts {
     }
 }
 
-/// Reject a duplicate pattern within one concrete mount's declared namespace.
-fn validate_namespace(mount: &str, patterns: &[PackagePattern]) -> Result<(), MountConfigError> {
+/// Reject a duplicate pattern within one concrete registry's declared namespace.
+fn validate_namespace(
+    registry: &str,
+    patterns: &[PackagePattern],
+) -> Result<(), RegistryConfigError> {
     for (index, pattern) in patterns.iter().enumerate() {
         if patterns[..index].contains(pattern) {
-            return Err(MountConfigError::DuplicatePattern {
-                mount: mount.to_string(),
+            return Err(RegistryConfigError::DuplicatePattern {
+                registry: registry.to_string(),
                 pattern: pattern.to_string(),
             });
         }
@@ -447,30 +452,30 @@ fn validate_namespace(mount: &str, patterns: &[PackagePattern]) -> Result<(), Mo
     Ok(())
 }
 
-/// A static mount-configuration defect. Surfaced by [`Mounts::validate`] and by
+/// A static registry-configuration defect. Surfaced by [`Registries::validate`] and by
 /// [`PackagePattern::parse`]; the `config` module turns it into an
-/// `InvalidConfig` so a bad mount set fails server startup and config reload.
+/// `InvalidConfig` so a bad registry set fails server startup and config reload.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MountConfigError {
-    /// An unsupported wildcard in a mount pattern.
+pub enum RegistryConfigError {
+    /// An unsupported wildcard in a registry pattern.
     InvalidPattern { pattern: String },
-    /// A wildcard-free mount pattern that is not a well-formed package name,
+    /// A wildcard-free registry pattern that is not a well-formed package name,
     /// so it could never match any request.
     ExactPatternNotAName { pattern: String },
-    /// `defaultTarget` names a mount that does not exist.
-    UndefinedDefaultTarget { target: String },
+    /// `defaultRegistry` names a registry that does not exist.
+    UndefinedDefaultRegistry { target: String },
     /// A router has no sources at all, so it can never serve any package.
     EmptyRouter { router: String },
     /// A router lists itself as a source.
     SelfReferentialRouter { router: String },
-    /// A router source is not a defined mount.
+    /// A router source is not a defined registry.
     UnknownSource { router: String, source: String },
-    /// A router source is another router, not a concrete mount.
+    /// A router source is another router, not a concrete registry.
     NonConcreteSource { router: String, source: String },
     /// A router lists the same source more than once.
     DuplicateSource { router: String, source: String },
-    /// A concrete mount declares the same pattern more than once.
-    DuplicatePattern { mount: String, pattern: String },
+    /// A concrete registry declares the same pattern more than once.
+    DuplicatePattern { registry: String, pattern: String },
     /// A router source's claims are fully covered by earlier sources, so it
     /// can never be selected.
     UnreachableSource { router: String, index: usize, source: String },
@@ -480,52 +485,52 @@ pub enum MountConfigError {
     ShadowedPattern { router: String, source: String, pattern: String, by: String },
 }
 
-impl fmt::Display for MountConfigError {
+impl fmt::Display for RegistryConfigError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            MountConfigError::InvalidPattern { pattern } => write!(
+            RegistryConfigError::InvalidPattern { pattern } => write!(
                 f,
-                "unsupported mount pattern {pattern:?}: use an exact name, `@scope/*`, `@*/*`, \
+                "unsupported registry pattern {pattern:?}: use an exact name, `@scope/*`, `@*/*`, \
                  or `**`",
             ),
-            MountConfigError::ExactPatternNotAName { pattern } => write!(
+            RegistryConfigError::ExactPatternNotAName { pattern } => write!(
                 f,
-                "mount pattern {pattern:?} is not a valid package name, so it can never match; \
+                "registry pattern {pattern:?} is not a valid package name, so it can never match; \
                  to claim every package in a scope use `@scope/*`",
             ),
-            MountConfigError::UndefinedDefaultTarget { target } => {
-                write!(f, "defaultTarget {target:?} is not a defined mount")
+            RegistryConfigError::UndefinedDefaultRegistry { target } => {
+                write!(f, "defaultRegistry {target:?} is not a defined registry")
             }
-            MountConfigError::EmptyRouter { router } => write!(
+            RegistryConfigError::EmptyRouter { router } => write!(
                 f,
                 "router {router:?} has no sources, so it can never serve any package; add \
-                 sources or remove the mount",
+                 sources or remove the registry",
             ),
-            MountConfigError::SelfReferentialRouter { router } => {
+            RegistryConfigError::SelfReferentialRouter { router } => {
                 write!(f, "router {router:?} lists itself as a source")
             }
-            MountConfigError::UnknownSource { router, source } => {
-                write!(f, "router {router:?} source {source:?} is not a defined mount")
+            RegistryConfigError::UnknownSource { router, source } => {
+                write!(f, "router {router:?} source {source:?} is not a defined registry")
             }
-            MountConfigError::NonConcreteSource { router, source } => write!(
+            RegistryConfigError::NonConcreteSource { router, source } => write!(
                 f,
                 "router {router:?} source {source:?} is itself a router; a source must be a \
-                 hosted or upstream mount",
+                 hosted or upstream registry",
             ),
-            MountConfigError::DuplicateSource { router, source } => {
+            RegistryConfigError::DuplicateSource { router, source } => {
                 write!(f, "router {router:?} lists source {source:?} more than once")
             }
-            MountConfigError::DuplicatePattern { mount, pattern } => {
-                write!(f, "mount {mount:?} declares pattern {pattern:?} more than once")
+            RegistryConfigError::DuplicatePattern { registry, pattern } => {
+                write!(f, "registry {registry:?} declares pattern {pattern:?} more than once")
             }
-            MountConfigError::UnreachableSource { router, index, source } => write!(
+            RegistryConfigError::UnreachableSource { router, index, source } => write!(
                 f,
                 "router {router:?} source #{index} ({source:?}) is unreachable: earlier sources \
                  already claim every package it would serve; list it before the sources that \
                  shadow it, or remove it",
                 index = index + 1,
             ),
-            MountConfigError::ShadowedPattern { router, source, pattern, by } => write!(
+            RegistryConfigError::ShadowedPattern { router, source, pattern, by } => write!(
                 f,
                 "router {router:?} can never select source {source:?} for its pattern \
                  {pattern:?}: an earlier source's pattern {by:?} already claims every package it \
@@ -535,7 +540,7 @@ impl fmt::Display for MountConfigError {
     }
 }
 
-impl std::error::Error for MountConfigError {}
+impl std::error::Error for RegistryConfigError {}
 
 #[cfg(test)]
 mod tests;

--- a/pnpr/crates/pnpr/src/registry.rs
+++ b/pnpr/crates/pnpr/src/registry.rs
@@ -268,9 +268,9 @@ impl Registries {
 
     /// Insert `name` as a pattern-less upstream registry when it is not
     /// already declared, so the server can fold a programmatically-added
-    /// uplink into the graph and keep [`Self::resolve`] the only dispatch
+    /// upstream into the graph and keep [`Self::resolve`] the only dispatch
     /// table for `/~<name>/` traffic. An embedder that wants a namespace
-    /// bound on an uplink declares its own entry (with patterns) first.
+    /// bound on an upstream declares its own entry (with patterns) first.
     pub fn ensure_upstream(&mut self, name: &str) {
         if !self.registries.contains_key(name) {
             self.registries.insert(name.to_string(), Registry::Upstream { patterns: Vec::new() });

--- a/pnpr/crates/pnpr/src/registry.rs
+++ b/pnpr/crates/pnpr/src/registry.rs
@@ -70,10 +70,19 @@ impl PackagePattern {
             return Ok(PackagePattern::AnyScoped);
         }
         if let Some(scope) = pattern.strip_prefix('@').and_then(|rest| rest.strip_suffix("/*")) {
-            // A single, concrete scope: `@acme/*`. The scope itself may not
-            // contain a wildcard or a further path separator.
-            if scope.is_empty() || scope.contains('*') || scope.contains('/') {
+            // A single, concrete scope: `@acme/*`. A wildcard inside the
+            // scope is an unsupported glob; a scope that request parsing
+            // (`PackageName::parse`) would reject — `@.acme`, `@..`, a
+            // separator — is a claim no valid package name can ever match,
+            // so both fail loudly instead of becoming a dead pattern that
+            // silently lets the scope land on a later router source.
+            if scope.contains('*') {
                 return Err(invalid());
+            }
+            if !crate::package_name::is_safe_path_segment(scope) {
+                return Err(RegistryConfigError::ScopePatternNotAScope {
+                    pattern: pattern.to_string(),
+                });
             }
             return Ok(PackagePattern::Scope(scope.to_string()));
         }
@@ -473,6 +482,9 @@ pub enum RegistryConfigError {
     /// A wildcard-free registry pattern that is not a well-formed package name,
     /// so it could never match any request.
     ExactPatternNotAName { pattern: String },
+    /// A `@<scope>/*` pattern whose scope no well-formed package name can
+    /// carry, so it could never match any request.
+    ScopePatternNotAScope { pattern: String },
     /// `defaultRegistry` names a registry that does not exist.
     UndefinedDefaultRegistry { target: String },
     /// A router has no sources at all, so it can never serve any package.
@@ -508,6 +520,11 @@ impl fmt::Display for RegistryConfigError {
                 f,
                 "registry pattern {pattern:?} is not a valid package name, so it can never match; \
                  to claim every package in a scope use `@scope/*`",
+            ),
+            RegistryConfigError::ScopePatternNotAScope { pattern } => write!(
+                f,
+                "registry pattern {pattern:?} does not name a valid scope, so it can never match \
+                 any package",
             ),
             RegistryConfigError::UndefinedDefaultRegistry { target } => {
                 write!(f, "defaultRegistry {target:?} is not a defined registry")

--- a/pnpr/crates/pnpr/src/registry.rs
+++ b/pnpr/crates/pnpr/src/registry.rs
@@ -255,6 +255,11 @@ impl Registries {
         self.default_registry.as_deref()
     }
 
+    /// The declared registry names, in declaration order.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.registries.keys().map(String::as_str)
+    }
+
     /// Whether `registry` is a defined router.
     #[must_use]
     pub fn is_router(&self, registry: &str) -> bool {

--- a/pnpr/crates/pnpr/src/registry/tests.rs
+++ b/pnpr/crates/pnpr/src/registry/tests.rs
@@ -63,6 +63,24 @@ fn rejects_exact_pattern_that_is_not_a_package_name() {
     }
 }
 
+/// A `@<scope>/*` pattern whose scope request parsing (`PackageName::parse`)
+/// would reject is a claim no valid package name can ever match. It must be a
+/// config error rather than a dead pattern — a mistyped private-scope claim
+/// that never matches would silently let the names it was meant to cover land
+/// on a later (often public) router source.
+#[test]
+fn rejects_scope_pattern_whose_scope_is_not_a_valid_scope() {
+    for raw in ["@.acme/*", "@../*", "@/*", "@a/b/*", "@a:b/*"] {
+        assert!(
+            matches!(
+                PackagePattern::parse(raw),
+                Err(RegistryConfigError::ScopePatternNotAScope { .. }),
+            ),
+            "expected {raw:?} to be rejected as an invalid scope",
+        );
+    }
+}
+
 // --- PackagePattern::matches -----------------------------------------------
 
 #[test]

--- a/pnpr/crates/pnpr/src/registry/tests.rs
+++ b/pnpr/crates/pnpr/src/registry/tests.rs
@@ -1,4 +1,4 @@
-use super::{ConcreteKind, MountConfigError, MountKind, Mounts, PackagePattern, Resolved};
+use super::{ConcreteKind, PackagePattern, Registries, Registry, RegistryConfigError, Resolved};
 
 fn pattern(raw: &str) -> PackagePattern {
     PackagePattern::parse(raw).expect("pattern parses")
@@ -8,21 +8,21 @@ fn patterns(raws: &[&str]) -> Vec<PackagePattern> {
     raws.iter().map(|raw| pattern(raw)).collect()
 }
 
-fn hosted(raws: &[&str]) -> MountKind {
-    MountKind::Hosted { patterns: patterns(raws) }
+fn hosted(raws: &[&str]) -> Registry {
+    Registry::Hosted { patterns: patterns(raws) }
 }
 
-fn upstream(raws: &[&str]) -> MountKind {
-    MountKind::Upstream { patterns: patterns(raws) }
+fn upstream(raws: &[&str]) -> Registry {
+    Registry::Upstream { patterns: patterns(raws) }
 }
 
-fn router(sources: &[&str]) -> MountKind {
-    MountKind::Router { sources: sources.iter().map(ToString::to_string).collect() }
+fn router(sources: &[&str]) -> Registry {
+    Registry::Router { sources: sources.iter().map(ToString::to_string).collect() }
 }
 
-fn mounts(entries: Vec<(&str, MountKind)>, default_target: Option<&str>) -> Mounts {
+fn registries(entries: Vec<(&str, Registry)>, default_registry: Option<&str>) -> Registries {
     let map = entries.into_iter().map(|(name, kind)| (name.to_string(), kind)).collect();
-    Mounts::new(map, default_target.map(str::to_string))
+    Registries::new(map, default_registry.map(str::to_string))
 }
 
 // --- PackagePattern::parse -------------------------------------------------
@@ -40,7 +40,7 @@ fn parses_recognized_shapes() {
 fn rejects_unsupported_wildcards() {
     for raw in ["", "foo*", "@acme/*/extra", "@*/foo", "*", "@acme/ba*r", "a*b"] {
         assert!(
-            matches!(PackagePattern::parse(raw), Err(MountConfigError::InvalidPattern { .. })),
+            matches!(PackagePattern::parse(raw), Err(RegistryConfigError::InvalidPattern { .. })),
             "expected {raw:?} to be rejected",
         );
     }
@@ -49,14 +49,14 @@ fn rejects_unsupported_wildcards() {
 /// A wildcard-free pattern that is not a well-formed package name can never
 /// match a request, so a typo like `@acme` (meaning `@acme/*`) must be a
 /// config error rather than a literal that silently keeps the scope out of
-/// the mount's namespace.
+/// the registry's namespace.
 #[test]
 fn rejects_exact_pattern_that_is_not_a_package_name() {
     for raw in ["@acme", "@acme/", "@/foo", ".hidden", "a/b/c", "@scope/../up"] {
         assert!(
             matches!(
                 PackagePattern::parse(raw),
-                Err(MountConfigError::ExactPatternNotAName { .. }),
+                Err(RegistryConfigError::ExactPatternNotAName { .. }),
             ),
             "expected {raw:?} to be rejected as not a package name",
         );
@@ -83,7 +83,7 @@ fn matches_by_shape() {
 
 /// A scoped pattern requires a real `@scope/name`; a bare `@scope`, an empty
 /// scope, or an empty name must not match, so such an input isn't misrouted to a
-/// scoped mount.
+/// scoped registry.
 #[test]
 fn scoped_patterns_require_a_name_segment() {
     for malformed in ["@acme", "@acme/", "@/foo", "@"] {
@@ -145,47 +145,47 @@ fn covers_agrees_with_matches_on_malformed_scoped_exacts() {
 // --- resolution ------------------------------------------------------------
 
 #[test]
-fn pattern_less_concrete_mount_resolves_to_itself_for_any_name() {
-    let registry = mounts(vec![("acme", hosted(&[])), ("npmjs", upstream(&[]))], None);
+fn pattern_less_concrete_registry_resolves_to_itself_for_any_name() {
+    let registry = registries(vec![("acme", hosted(&[])), ("npmjs", upstream(&[]))], None);
     assert_eq!(
         registry.resolve("acme", "@acme/foo"),
-        Resolved::Concrete { mount: "acme", kind: ConcreteKind::Hosted },
+        Resolved::Concrete { registry: "acme", kind: ConcreteKind::Hosted },
     );
     assert_eq!(
         registry.resolve("npmjs", "react"),
-        Resolved::Concrete { mount: "npmjs", kind: ConcreteKind::Upstream },
+        Resolved::Concrete { registry: "npmjs", kind: ConcreteKind::Upstream },
     );
 }
 
-/// The namespace is enforced on the mount itself: addressing a concrete mount
-/// directly (`/~<mount>/`) with a name outside its declared patterns is a
+/// The namespace is enforced on the registry itself: addressing a concrete registry
+/// directly (`/~<name>/`) with a name outside its declared patterns is a
 /// definitive unclaimed, before storage or the upstream would be consulted.
 #[test]
-fn concrete_mount_does_not_resolve_an_unclaimed_name() {
+fn concrete_registry_does_not_resolve_an_unclaimed_name() {
     let registry =
-        mounts(vec![("acme", hosted(&["@acme/*"])), ("corp", upstream(&["@corp/*"]))], None);
+        registries(vec![("acme", hosted(&["@acme/*"])), ("corp", upstream(&["@corp/*"]))], None);
     assert_eq!(
         registry.resolve("acme", "@acme/foo"),
-        Resolved::Concrete { mount: "acme", kind: ConcreteKind::Hosted },
+        Resolved::Concrete { registry: "acme", kind: ConcreteKind::Hosted },
     );
     assert_eq!(registry.resolve("acme", "@typo/foo"), Resolved::Unclaimed);
     // A private upstream's bound: a public name can't be pulled through it.
     assert_eq!(
         registry.resolve("corp", "@corp/foo"),
-        Resolved::Concrete { mount: "corp", kind: ConcreteKind::Upstream },
+        Resolved::Concrete { registry: "corp", kind: ConcreteKind::Upstream },
     );
     assert_eq!(registry.resolve("corp", "lodash"), Resolved::Unclaimed);
 }
 
 #[test]
-fn unknown_mount_resolves_to_unknown() {
-    let registry = mounts(vec![("npmjs", upstream(&[]))], None);
-    assert_eq!(registry.resolve("nope", "react"), Resolved::UnknownMount);
+fn unknown_registry_resolves_to_unknown() {
+    let registry = registries(vec![("npmjs", upstream(&[]))], None);
+    assert_eq!(registry.resolve("nope", "react"), Resolved::UnknownRegistry);
 }
 
 #[test]
 fn router_resolves_first_claiming_source_authoritatively() {
-    let registry = mounts(
+    let registry = registries(
         vec![
             ("acme", hosted(&["@acme/*"])),
             ("corp", upstream(&["@corp/*"])),
@@ -197,15 +197,15 @@ fn router_resolves_first_claiming_source_authoritatively() {
 
     assert_eq!(
         registry.resolve("main", "@acme/foo"),
-        Resolved::Concrete { mount: "acme", kind: ConcreteKind::Hosted },
+        Resolved::Concrete { registry: "acme", kind: ConcreteKind::Hosted },
     );
     assert_eq!(
         registry.resolve("main", "@corp/foo"),
-        Resolved::Concrete { mount: "corp", kind: ConcreteKind::Upstream },
+        Resolved::Concrete { registry: "corp", kind: ConcreteKind::Upstream },
     );
     assert_eq!(
         registry.resolve("main", "lodash"),
-        Resolved::Concrete { mount: "npmjs", kind: ConcreteKind::Upstream },
+        Resolved::Concrete { registry: "npmjs", kind: ConcreteKind::Upstream },
     );
 }
 
@@ -213,7 +213,7 @@ fn router_resolves_first_claiming_source_authoritatively() {
 fn router_earlier_source_wins_over_later_catch_all() {
     // `@acme/*` is private (hosted); the pattern-less catch-all must never be
     // consulted for an `@acme/*` name even though it would also claim it.
-    let registry = mounts(
+    let registry = registries(
         vec![
             ("acme", hosted(&["@acme/*"])),
             ("npmjs", upstream(&[])),
@@ -223,37 +223,38 @@ fn router_earlier_source_wins_over_later_catch_all() {
     );
     assert_eq!(
         registry.resolve("main", "@acme/secret"),
-        Resolved::Concrete { mount: "acme", kind: ConcreteKind::Hosted },
+        Resolved::Concrete { registry: "acme", kind: ConcreteKind::Hosted },
     );
 }
 
 #[test]
 fn router_with_no_claiming_source_is_unclaimed_not_fallthrough() {
-    let registry = mounts(vec![("acme", hosted(&["@acme/*"])), ("main", router(&["acme"]))], None);
+    let registry =
+        registries(vec![("acme", hosted(&["@acme/*"])), ("main", router(&["acme"]))], None);
     assert_eq!(registry.resolve("main", "lodash"), Resolved::Unclaimed);
 }
 
 #[test]
-fn resolve_default_uses_default_target() {
+fn resolve_default_uses_default_registry() {
     let registry =
-        mounts(vec![("npmjs", upstream(&[])), ("main", router(&["npmjs"]))], Some("main"));
+        registries(vec![("npmjs", upstream(&[])), ("main", router(&["npmjs"]))], Some("main"));
     assert_eq!(
         registry.resolve_default("react"),
-        Resolved::Concrete { mount: "npmjs", kind: ConcreteKind::Upstream },
+        Resolved::Concrete { registry: "npmjs", kind: ConcreteKind::Upstream },
     );
 }
 
 #[test]
 fn resolve_default_without_target_is_unknown() {
-    let registry = mounts(vec![("npmjs", upstream(&[]))], None);
-    assert_eq!(registry.resolve_default("react"), Resolved::UnknownMount);
+    let registry = registries(vec![("npmjs", upstream(&[]))], None);
+    assert_eq!(registry.resolve_default("react"), Resolved::UnknownRegistry);
 }
 
 // --- validation ------------------------------------------------------------
 
 #[test]
 fn valid_config_passes() {
-    let registry = mounts(
+    let registry = registries(
         vec![
             ("acme", hosted(&["@acme/*"])),
             ("corp", upstream(&["@corp/*"])),
@@ -266,11 +267,11 @@ fn valid_config_passes() {
 }
 
 #[test]
-fn rejects_undefined_default_target() {
-    let registry = mounts(vec![("npmjs", upstream(&[]))], Some("ghost"));
+fn rejects_undefined_default_registry() {
+    let registry = registries(vec![("npmjs", upstream(&[]))], Some("ghost"));
     assert_eq!(
         registry.validate(),
-        Err(MountConfigError::UndefinedDefaultTarget { target: "ghost".to_string() }),
+        Err(RegistryConfigError::UndefinedDefaultRegistry { target: "ghost".to_string() }),
     );
 }
 
@@ -278,7 +279,7 @@ fn rejects_undefined_default_target() {
 fn rejects_pattern_less_source_before_narrower_source() {
     // The dangerous common mistake: the catch-all listed first shadows a later
     // private scope.
-    let registry = mounts(
+    let registry = registries(
         vec![
             ("acme", hosted(&["@acme/*"])),
             ("npmjs", upstream(&[])),
@@ -288,13 +289,13 @@ fn rejects_pattern_less_source_before_narrower_source() {
     );
     assert!(matches!(
         registry.validate(),
-        Err(MountConfigError::UnreachableSource { index: 1, .. }),
+        Err(RegistryConfigError::UnreachableSource { index: 1, .. }),
     ));
 }
 
 #[test]
 fn rejects_source_shadowed_by_broader_scope() {
-    let registry = mounts(
+    let registry = registries(
         vec![
             ("other", upstream(&["@*/*"])),
             ("acme", hosted(&["@acme/*"])),
@@ -304,7 +305,7 @@ fn rejects_source_shadowed_by_broader_scope() {
     );
     assert!(matches!(
         registry.validate(),
-        Err(MountConfigError::UnreachableSource { index: 1, .. }),
+        Err(RegistryConfigError::UnreachableSource { index: 1, .. }),
     ));
 }
 
@@ -312,7 +313,7 @@ fn rejects_source_shadowed_by_broader_scope() {
 fn allows_narrower_source_before_broader() {
     // `@acme/foo` exact before `@acme/*` is fine — the exact claims strictly
     // less, so the scope source is still reachable for every other name.
-    let registry = mounts(
+    let registry = registries(
         vec![
             ("a", hosted(&["@acme/foo"])),
             ("b", upstream(&["@acme/*"])),
@@ -327,7 +328,7 @@ fn allows_narrower_source_before_broader() {
 fn allows_sibling_scopes_before_any_scoped() {
     // `@a/*` and `@b/*` do not (and cannot) cover `@*/*`, so the broad source
     // stays reachable.
-    let registry = mounts(
+    let registry = registries(
         vec![
             ("a", hosted(&["@a/*"])),
             ("b", hosted(&["@b/*"])),
@@ -345,8 +346,8 @@ fn rejects_partially_shadowed_source() {
     // cover), but its `@secret/foo` claim is swallowed by the earlier `@*/*`
     // source. That one pattern must be rejected by name — otherwise requests
     // for `@secret/foo` silently go to the public upstream instead of the
-    // private mount, and the whole-source unreachability check never fires.
-    let registry = mounts(
+    // private registry, and the whole-source unreachability check never fires.
+    let registry = registries(
         vec![
             ("public", upstream(&["@*/*"])),
             ("private", hosted(&["@secret/foo", "plainpkg"])),
@@ -356,16 +357,16 @@ fn rejects_partially_shadowed_source() {
     );
     assert!(matches!(
         registry.validate(),
-        Err(MountConfigError::ShadowedPattern { pattern, .. }) if pattern == "@secret/foo",
+        Err(RegistryConfigError::ShadowedPattern { pattern, .. }) if pattern == "@secret/foo",
     ));
 }
 
-/// Two mounts claiming the same pattern cannot be ordered: whichever is listed
+/// Two registries claiming the same pattern cannot be ordered: whichever is listed
 /// later never receives the name. That's ambiguous provenance the operator has
 /// to resolve in the declared namespaces, not by source order.
 #[test]
 fn rejects_identical_claim_across_two_sources() {
-    let registry = mounts(
+    let registry = registries(
         vec![
             ("a", hosted(&["@a/foo"])),
             ("b", hosted(&["@a/foo", "@b/*"])),
@@ -375,7 +376,7 @@ fn rejects_identical_claim_across_two_sources() {
     );
     assert_eq!(
         registry.validate(),
-        Err(MountConfigError::ShadowedPattern {
+        Err(RegistryConfigError::ShadowedPattern {
             router: "main".to_string(),
             source: "b".to_string(),
             pattern: "@a/foo".to_string(),
@@ -396,21 +397,21 @@ fn rejects_bidirectionally_overlapping_sources_in_either_order() {
         ]
     };
     assert!(matches!(
-        mounts(entries(&["a", "b"]), None).validate(),
-        Err(MountConfigError::ShadowedPattern { .. }),
+        registries(entries(&["a", "b"]), None).validate(),
+        Err(RegistryConfigError::ShadowedPattern { .. }),
     ));
     assert!(matches!(
-        mounts(entries(&["b", "a"]), None).validate(),
-        Err(MountConfigError::ShadowedPattern { .. }),
+        registries(entries(&["b", "a"]), None).validate(),
+        Err(RegistryConfigError::ShadowedPattern { .. }),
     ));
 }
 
-/// A mount may declare internally redundant patterns (`@acme/*` plus an exact
-/// `@acme/foo`); the union is the namespace, and using the mount in a router
-/// must not report the mount as shadowing itself.
+/// A registry may declare internally redundant patterns (`@acme/*` plus an exact
+/// `@acme/foo`); the union is the namespace, and using the registry in a router
+/// must not report the registry as shadowing itself.
 #[test]
 fn allows_a_source_whose_own_patterns_overlap() {
-    let registry = mounts(
+    let registry = registries(
         vec![
             ("a", hosted(&["@acme/*", "@acme/foo"])),
             ("npmjs", upstream(&[])),
@@ -422,12 +423,12 @@ fn allows_a_source_whose_own_patterns_overlap() {
 }
 
 #[test]
-fn rejects_duplicate_pattern_within_one_mount() {
-    let registry = mounts(vec![("a", hosted(&["@acme/*", "@acme/*"]))], None);
+fn rejects_duplicate_pattern_within_one_registry() {
+    let registry = registries(vec![("a", hosted(&["@acme/*", "@acme/*"]))], None);
     assert_eq!(
         registry.validate(),
-        Err(MountConfigError::DuplicatePattern {
-            mount: "a".to_string(),
+        Err(RegistryConfigError::DuplicatePattern {
+            registry: "a".to_string(),
             pattern: "@acme/*".to_string(),
         }),
     );
@@ -435,11 +436,13 @@ fn rejects_duplicate_pattern_within_one_mount() {
 
 #[test]
 fn rejects_duplicate_source() {
-    let registry =
-        mounts(vec![("npmjs", upstream(&["@a/*"])), ("main", router(&["npmjs", "npmjs"]))], None);
+    let registry = registries(
+        vec![("npmjs", upstream(&["@a/*"])), ("main", router(&["npmjs", "npmjs"]))],
+        None,
+    );
     assert_eq!(
         registry.validate(),
-        Err(MountConfigError::DuplicateSource {
+        Err(RegistryConfigError::DuplicateSource {
             router: "main".to_string(),
             source: "npmjs".to_string(),
         }),
@@ -448,10 +451,10 @@ fn rejects_duplicate_source() {
 
 #[test]
 fn rejects_unknown_source() {
-    let registry = mounts(vec![("main", router(&["ghost"]))], None);
+    let registry = registries(vec![("main", router(&["ghost"]))], None);
     assert_eq!(
         registry.validate(),
-        Err(MountConfigError::UnknownSource {
+        Err(RegistryConfigError::UnknownSource {
             router: "main".to_string(),
             source: "ghost".to_string(),
         }),
@@ -460,16 +463,16 @@ fn rejects_unknown_source() {
 
 #[test]
 fn rejects_self_referential_router() {
-    let registry = mounts(vec![("main", router(&["main"]))], None);
+    let registry = registries(vec![("main", router(&["main"]))], None);
     assert_eq!(
         registry.validate(),
-        Err(MountConfigError::SelfReferentialRouter { router: "main".to_string() }),
+        Err(RegistryConfigError::SelfReferentialRouter { router: "main".to_string() }),
     );
 }
 
 #[test]
 fn rejects_router_targeting_another_router() {
-    let registry = mounts(
+    let registry = registries(
         vec![
             ("npmjs", upstream(&[])),
             ("inner", router(&["npmjs"])),
@@ -479,7 +482,7 @@ fn rejects_router_targeting_another_router() {
     );
     assert_eq!(
         registry.validate(),
-        Err(MountConfigError::NonConcreteSource {
+        Err(RegistryConfigError::NonConcreteSource {
             router: "outer".to_string(),
             source: "inner".to_string(),
         }),
@@ -490,9 +493,9 @@ fn rejects_router_targeting_another_router() {
 fn rejects_router_with_no_sources() {
     // An empty router can never serve any package; it is only ever a config
     // mistake, so validation rejects it.
-    let registry = mounts(vec![("main", router(&[]))], None);
+    let registry = registries(vec![("main", router(&[]))], None);
     assert_eq!(
         registry.validate(),
-        Err(MountConfigError::EmptyRouter { router: "main".to_string() }),
+        Err(RegistryConfigError::EmptyRouter { router: "main".to_string() }),
     );
 }

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -24,7 +24,7 @@
 //!
 //! pnpr is a stateless resolver: it stores no tarballs. Public tarballs
 //! can still be fetched directly from their upstream registry, while a
-//! private proxied route is rewritten to the uplink's `/~<uplink>/`
+//! private proxied route is rewritten to the upstream's `/~<name>/`
 //! registry endpoint so upstream URLs and credentials stay server-side.
 //!
 //! The client's `registry`, `namedRegistries`, `overrides`, and the
@@ -39,7 +39,7 @@
 //! authenticates to pnpr (its request `Authorization` identifies the
 //! caller) but does not forward its own upstream registry credentials:
 //! pnpr selects upstream auth from its route policy (see [`crate::route`]),
-//! so private dependencies resolve via a pnpr-managed uplink credential or
+//! so private dependencies resolve via a pnpr-managed upstream credential or
 //! fail closed.
 
 pub(crate) mod osv;
@@ -123,11 +123,11 @@ pub(crate) struct Resolver {
     verdict_cache: Option<VerdictCache>,
     osv_index: Option<Arc<OsvIndex>>,
     /// Route-classification inputs (public/private rules, pnpr-managed
-    /// uplink credentials, hosted origin, package policy), resolved once
+    /// upstream credentials, hosted origin, package policy), resolved once
     /// from the server config and combined per request with the caller's
     /// identity to drive auth selection and footprint recording.
     route_context: Arc<RouteContext>,
-    /// Public URL clients use for pnpr-hosted and `/~<uplink>/` endpoint
+    /// Public URL clients use for pnpr-hosted and `/~<name>/` endpoint
     /// tarball URLs.
     public_url: String,
     /// HMAC secret namespacing a private footprint's cache descriptor.
@@ -346,7 +346,7 @@ fn intern_config(
 /// `violations` if the input lockfile failed the client's policy. The
 /// short-circuit paths (frozen reuse, cache hit) emit only the terminal
 /// `done` frame. A private proxied tarball is announced through its
-/// uplink's `/~<uplink>/` registry endpoint rather than its upstream URL.
+/// upstream's `/~<name>/` registry endpoint rather than its upstream URL.
 pub(crate) async fn handle_resolve(
     runtime: &Resolver,
     identity: Identity,
@@ -774,7 +774,7 @@ impl TarballRouter {
     /// tarball from a different host than the packument, so classifying by the
     /// tarball URL would misread a private package as public and leak its raw
     /// upstream URL. Classifying by the registry origin keeps a private
-    /// package on its `/~<uplink>/` endpoint; a public one still emits its real
+    /// package on its `/~<name>/` endpoint; a public one still emits its real
     /// (anonymously fetchable) tarball URL for a direct CDN download.
     fn route_registry_url(&self, package: &str, version: &str, tarball_url: &str) -> String {
         let registry = pick_registry_for_package(&self.registries, package, None);
@@ -790,7 +790,7 @@ impl TarballRouter {
                 package,
                 &tarball_filename(package, version, tarball_url),
             ),
-            RouteClass::Proxied { alias, .. } => uplink_endpoint_tarball_url(
+            RouteClass::Proxied { alias, .. } => upstream_endpoint_tarball_url(
                 &self.public_url,
                 &alias,
                 package,
@@ -864,7 +864,7 @@ impl TarballRouter {
                 package,
                 &tarball_filename(package, version, tarball_url),
             ),
-            RouteClass::Proxied { alias, .. } => uplink_endpoint_tarball_url(
+            RouteClass::Proxied { alias, .. } => upstream_endpoint_tarball_url(
                 &self.public_url,
                 &alias,
                 package,
@@ -873,16 +873,16 @@ impl TarballRouter {
         }
     }
 
-    /// Reverse a `/~<uplink>/<pkg>/-/<file>` endpoint tarball URL back to its
+    /// Reverse a `/~<name>/<pkg>/-/<file>` endpoint tarball URL back to its
     /// upstream URL so an input lockfile carrying endpoint URLs can be verified
     /// against the real registry. Returns `None` for any other URL, and for an
     /// endpoint the caller is not authorized for (so verification cannot be
-    /// used as an oracle for an uplink the caller cannot reach).
+    /// used as an oracle for an upstream the caller cannot reach).
     fn upstream_endpoint_tarball_url(&self, tarball_url: &str) -> Option<String> {
         let prefix = format!("{}/~", self.public_url.trim_end_matches('/'));
         let route = tarball_url.strip_prefix(&prefix)?;
-        let (uplink, rest) = route.split_once('/')?;
-        let registry = self.context.uplink_registry(&self.identity, uplink)?;
+        let (upstream, rest) = route.split_once('/')?;
+        let registry = self.context.upstream_registry(&self.identity, upstream)?;
         Some(format!("{}/{rest}", registry.trim_end_matches('/')))
     }
 }
@@ -903,17 +903,17 @@ fn pnpr_tarball_url(public_url: &str, package: &str, filename: &str) -> String {
     format!("{}/{package}/-/{filename}", public_url.trim_end_matches('/'))
 }
 
-/// The `/~<uplink>/<package>/-/<filename>` registry-endpoint URL a proxied
+/// The `/~<name>/<package>/-/<filename>` registry-endpoint URL a proxied
 /// route's tarball is served through. Canonical for a client whose scope is
-/// configured at `https://<pnpr>/~<uplink>/`, so the lockfile entry collapses
+/// configured at `https://<pnpr>/~<name>/`, so the lockfile entry collapses
 /// to integrity-only; the upstream URL and credential stay server-side.
-fn uplink_endpoint_tarball_url(
+fn upstream_endpoint_tarball_url(
     public_url: &str,
-    uplink: &str,
+    upstream: &str,
     package: &str,
     filename: &str,
 ) -> String {
-    format!("{}/~{uplink}/{package}/-/{filename}", public_url.trim_end_matches('/'))
+    format!("{}/~{upstream}/{package}/-/{filename}", public_url.trim_end_matches('/'))
 }
 
 /// NDJSON content type for the `/-/pnpr/v0/resolve` response. One JSON object
@@ -1474,7 +1474,7 @@ fn forbidden_off_allowlist(target: &str) -> Response {
         StatusCode::FORBIDDEN,
         &format!(
             "{target:?} is not allowed by this pnpr server; the operator must declare its \
-             registry as a public route or an uplink",
+             registry as a public route or an upstream",
         ),
     )
 }

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -49,8 +49,8 @@ impl From<std::io::Error> for ResolveError {
 
 /// Resolve a request lockfile-only and return the produced lockfile.
 /// The store is intentionally left untouched (no tarball is fetched):
-/// tarball downloads happen later from upstream URLs or an uplink's
-/// `/~<uplink>/` registry endpoint.
+/// tarball downloads happen later from upstream URLs or an upstream's
+/// `/~<name>/` registry endpoint.
 ///
 /// A single-project request resolves one root (`.`) importer. A
 /// multi-project request is reconstructed as a real workspace in the

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -17,7 +17,7 @@ use super::{
     resolution_cache_key, store_resolution,
 };
 use crate::{
-    config::{Config as RegistryConfig, PublicRoute, UplinkConfig},
+    config::{Config as RegistryConfig, PublicRoute, UpstreamConfig},
     policy::{AccessList, Identity, PackagePolicies, PackagePolicy},
     route::{Footprint, PrivateAccessDescriptor, RouteContext},
 };
@@ -73,22 +73,22 @@ fn user(name: &str) -> Identity {
     Identity::user(name)
 }
 
-/// The standard token test uplinks carry; the credential digest it produces is
-/// what [`private_alias_footprint`] records, so a footprint and an uplink built
+/// The standard token test upstreams carry; the credential digest it produces is
+/// what [`private_alias_footprint`] records, so a footprint and an upstream built
 /// with it share a credential epoch.
 const ALIAS_TOKEN: &str = "Bearer alias-secret";
 
-fn uplink_with_access(registry: &str, access: &str) -> UplinkConfig {
-    uplink_with_token(registry, access, ALIAS_TOKEN)
+fn upstream_with_access(registry: &str, access: &str) -> UpstreamConfig {
+    upstream_with_token(registry, access, ALIAS_TOKEN)
 }
 
-fn uplink_with_token(registry: &str, access: &str, token: &'static str) -> UplinkConfig {
+fn upstream_with_token(registry: &str, access: &str, token: &'static str) -> UpstreamConfig {
     let mut headers = reqwest::header::HeaderMap::new();
     headers
         .insert(reqwest::header::AUTHORIZATION, reqwest::header::HeaderValue::from_static(token));
-    let mut uplink = UplinkConfig::with_defaults(registry.to_string(), headers);
-    uplink.access = Some(AccessList::parse(access));
-    uplink
+    let mut upstream = UpstreamConfig::with_defaults(registry.to_string(), headers);
+    upstream.access = Some(AccessList::parse(access));
+    upstream
 }
 
 fn private_alias_footprint(alias: &str) -> Footprint {
@@ -295,8 +295,8 @@ fn private_cached_resolution_requires_current_alias_authorization() {
 
     let mut config = registry_config();
     config
-        .uplinks
-        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "alice"));
+        .upstreams
+        .insert("corp".to_string(), upstream_with_access("https://npm.corp.example/", "alice"));
     let context = RouteContext::from_config(&config);
     assert!(
         cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_some(),
@@ -308,9 +308,9 @@ fn private_cached_resolution_requires_current_alias_authorization() {
     // Rotate the upstream credential (new token → new credential digest). The
     // resolution cached under the old credential must no longer be reused, even
     // for a still-authorized caller.
-    config.uplinks.insert(
+    config.upstreams.insert(
         "corp".to_string(),
-        uplink_with_token("https://npm.corp.example/", "alice", "Bearer rotated-secret"),
+        upstream_with_token("https://npm.corp.example/", "alice", "Bearer rotated-secret"),
     );
     let rotated = RouteContext::from_config(&config);
     assert!(
@@ -333,9 +333,9 @@ fn same_alias_authorized_users_share_private_resolution_cache() {
     ));
 
     let mut config = registry_config();
-    config.uplinks.insert(
+    config.upstreams.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated"),
+        upstream_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let context = RouteContext::from_config(&config);
 
@@ -367,16 +367,16 @@ fn revoked_alias_access_stops_matching_private_resolution_hits() {
 
     let mut config = registry_config();
     config
-        .uplinks
-        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "alice"));
+        .upstreams
+        .insert("corp".to_string(), upstream_with_access("https://npm.corp.example/", "alice"));
     let context = RouteContext::from_config(&config);
     assert!(
         cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_some(),
     );
 
     config
-        .uplinks
-        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "bob"));
+        .upstreams
+        .insert("corp".to_string(), upstream_with_access("https://npm.corp.example/", "bob"));
     let context = RouteContext::from_config(&config);
     assert!(
         cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_none(),
@@ -439,9 +439,9 @@ fn public_lockfile_routing_keeps_registry_resolutions_compact() {
 fn private_alias_lockfile_routing_uses_gateway_url() {
     let pacquet_config = config_for_registry("https://npm.corp.example/");
     let mut registry = registry_config();
-    registry.uplinks.insert(
+    registry.upstreams.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated"),
+        upstream_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let router = tarball_router(&registry, user("alice"));
 
@@ -462,9 +462,9 @@ fn private_alias_lockfile_routing_uses_gateway_url() {
 fn private_alias_lockfile_routing_encodes_scoped_packages_as_one_gateway_segment() {
     let pacquet_config = config_for_registry("https://npm.corp.example/");
     let mut registry = registry_config();
-    registry.uplinks.insert(
+    registry.upstreams.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated"),
+        upstream_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let router = tarball_router(&registry, user("alice"));
 
@@ -490,7 +490,7 @@ fn unknown_lockfile_routing_leaves_resolution_unrewritten() {
     let input = lockfile("1.0.0");
     let routed = router.route_lockfile(&pacquet_config, &input);
 
-    // An unknown route has no uplink and no managed credential, so pnpr mints
+    // An unknown route has no upstream and no managed credential, so pnpr mints
     // no gateway URL: the integrity-only registry resolution is left untouched
     // (the client fetches the upstream tarball directly, as it was resolved
     // anonymously), never rewritten into an explicit tarball URL.
@@ -642,8 +642,8 @@ fn private_cached_resolution_keeps_routed_tarball_urls() {
     let pacquet_config = config_for_registry("https://npm.corp.example/");
     let mut registry = registry_config();
     registry
-        .uplinks
-        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "alice"));
+        .upstreams
+        .insert("corp".to_string(), upstream_with_access("https://npm.corp.example/", "alice"));
     let router = tarball_router(&registry, user("alice"));
     let routed = router.route_lockfile(&pacquet_config, &lockfile("1.0.0"));
 
@@ -741,9 +741,9 @@ fn package_frames_route_private_alias_tarballs_to_gateway() {
     use pacquet_package_manager::ResolvedPackageHint;
 
     let mut registry = registry_config();
-    registry.uplinks.insert(
+    registry.upstreams.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated"),
+        upstream_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let router = tarball_router(&registry, user("alice"));
     let frame = super::package_frame(
@@ -770,9 +770,9 @@ fn package_frame_routes_split_domain_registry_tarball_by_registry() {
     use pacquet_package_manager::ResolvedPackageHint;
 
     let mut registry = registry_config();
-    registry.uplinks.insert(
+    registry.upstreams.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated"),
+        upstream_with_access("https://npm.corp.example/", "$authenticated"),
     );
     // The package resolves from the private corp registry, but its packument's
     // dist.tarball lives on a *different* host (a split-domain CDN).
@@ -883,9 +883,9 @@ fn frozen_package_frames_route_private_alias_tarballs_to_gateway() {
     let lockfile = lockfile("1.0.0");
     let stats = observed_dist_stats_sink();
     let mut registry = registry_config();
-    registry.uplinks.insert(
+    registry.upstreams.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated"),
+        upstream_with_access("https://npm.corp.example/", "$authenticated"),
     );
 
     let frames = super::frozen_package_frames(

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -33,7 +33,7 @@ use sha2::{Digest, Sha256};
 use wax::{Glob, Program};
 
 use crate::{
-    config::{Config, PublicRoute, UplinkConfig},
+    config::{Config, PublicRoute, UpstreamConfig},
     policy::{AccessList, Identity, PackagePolicies},
 };
 
@@ -50,7 +50,7 @@ pub enum RouteClass {
     Hosted { policy_id: String },
     /// A proxied upstream route served with a pnpr-managed credential
     /// alias the caller is authorized to use. [`credential_digest`] is a hash
-    /// of the uplink's `Authorization`, so rotating the credential changes it
+    /// of the upstream's `Authorization`, so rotating the credential changes it
     /// (see [`credential_digest`]).
     Proxied { alias: String, credential_digest: String },
 }
@@ -62,7 +62,7 @@ pub enum RouteClass {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum PrivateAccessDescriptor {
     /// Proxied route via a pnpr-managed upstream alias. [`credential_digest`]
-    /// hashes the uplink's `Authorization`, so rotating the credential moves
+    /// hashes the upstream's `Authorization`, so rotating the credential moves
     /// future hits to a new namespace — no manual epoch counter to bump.
     Alias { alias: String, credential_digest: String },
     /// pnpr-hosted route, gated by re-running the named package access
@@ -95,28 +95,28 @@ impl PrivateAccessDescriptor {
     }
 }
 
-/// The HMAC digest namespacing an uplink's private cache (packuments and
+/// The HMAC digest namespacing an upstream's private cache (packuments and
 /// tarballs), identical to the metadata-mirror descriptor id for the same
-/// `(uplink, credential)`. Keyed by the server `secret` so the on-disk path
-/// reveals neither the uplink name nor its credential, and so a path-unsafe
-/// uplink name (`..`, `/`) can never escape the cache root — the digest is
+/// `(upstream, credential)`. Keyed by the server `secret` so the on-disk path
+/// reveals neither the upstream name nor its credential, and so a path-unsafe
+/// upstream name (`..`, `/`) can never escape the cache root — the digest is
 /// hex. The digest passed here is a [`headers_credential_digest`] over the
-/// uplink's attached headers, so rotating any credential moves to a fresh
+/// upstream's attached headers, so rotating any credential moves to a fresh
 /// namespace.
 #[must_use]
-pub(crate) fn uplink_cache_digest(
-    uplink: &str,
+pub(crate) fn upstream_cache_digest(
+    upstream: &str,
     credential_digest: String,
     secret: &[u8],
 ) -> String {
-    PrivateAccessDescriptor::Alias { alias: uplink.to_string(), credential_digest }
+    PrivateAccessDescriptor::Alias { alias: upstream.to_string(), credential_digest }
         .digest_id(secret)
 }
 
-/// A hash of an uplink's `Authorization` header value, used as the credential
+/// A hash of an upstream's `Authorization` header value, used as the credential
 /// epoch in [`PrivateAccessDescriptor::Alias`]. Rotating the upstream
 /// credential changes this automatically, re-keying every private cache the
-/// uplink owns — so a rotation invalidates old-credential content with no
+/// upstream owns — so a rotation invalidates old-credential content with no
 /// manual step to forget. The raw token never appears: it's a one-way SHA-256
 /// (then HMAC-keyed with the server secret by [`PrivateAccessDescriptor::digest_id`]
 /// before it reaches disk).
@@ -125,10 +125,10 @@ pub(crate) fn credential_digest(authorization: &str) -> String {
     hex(&Sha256::digest(authorization.as_bytes()))
 }
 
-/// A hash of an uplink's *effective credential material* — every request header
+/// A hash of an upstream's *effective credential material* — every request header
 /// it attaches upstream, not just `Authorization` — used as the credential epoch
 /// in [`PrivateAccessDescriptor::Alias`]. pnpr supports credentials carried in
-/// custom headers, so rotating any of them must re-key the uplink's private
+/// custom headers, so rotating any of them must re-key the upstream's private
 /// cache; keying on `Authorization` alone would keep serving old-credential
 /// content after such a rotation.
 ///
@@ -216,11 +216,11 @@ pub struct RouteContext {
     public_routes: Vec<RouteMatcher>,
     /// pnpr-managed upstream credential aliases, in declared order.
     aliases: Vec<ResolvedAlias>,
-    /// Nerf-darted origin of every configured uplink (access-bearing or a
-    /// plain mirror), forming the uplink half of the fetch allowlist. A
+    /// Nerf-darted origin of every configured upstream (access-bearing or a
+    /// plain mirror), forming the upstream half of the fetch allowlist. A
     /// plain mirror needs no credential, so it has no [`ResolvedAlias`]; it
     /// is still a configured registry pnpr may fetch from anonymously.
-    uplink_origins: Vec<String>,
+    upstream_origins: Vec<String>,
     /// Package access policy, used to decide whether a pnpr-hosted route
     /// is public (admits everyone) or private, and to gate hosted hits.
     policies: PackagePolicies,
@@ -243,12 +243,12 @@ struct ResolvedAlias {
     credential_digest: String,
     registry: String,
     /// Nerf-darted upstream origin the alias serves. Routing is by origin
-    /// alone — an uplink credential covers every package on its registry.
+    /// alone — an upstream credential covers every package on its registry.
     origin: String,
-    /// The uplink registry's URL scheme (`https`/`http`). The credential is
+    /// The upstream registry's URL scheme (`https`/`http`). The credential is
     /// attached only to a fetch of this same scheme: nerf-darting strips the
     /// scheme from [`Self::origin`], so without this check an `http://host`
-    /// fetch would match an `https://host` uplink and send its token in clear.
+    /// fetch would match an `https://host` upstream and send its token in clear.
     scheme: String,
     /// The fully-formed `Authorization` header value the alias sends
     /// upstream (`Bearer ...` / `Basic ...`).
@@ -258,7 +258,7 @@ struct ResolvedAlias {
 }
 
 impl fmt::Debug for ResolvedAlias {
-    /// Redacts [`Self::authorization`] — it carries the uplink's server-owned
+    /// Redacts [`Self::authorization`] — it carries the upstream's server-owned
     /// upstream credential, which must never reach a log line or panic dump.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ResolvedAlias")
@@ -280,25 +280,25 @@ impl RouteContext {
         let hosted_origin = nerf_prefix(&config.public_url);
         // The official npm registry is a built-in public route, so it is both
         // allowlisted and classified public without any operator config (and
-        // ahead of any uplink credential for the same origin — public wins).
+        // ahead of any upstream credential for the same origin — public wins).
         let public_routes = std::iter::once(RouteMatcher::npmjs())
             .chain(config.route_policy.public.iter().filter_map(RouteMatcher::from_public_route))
             .collect();
-        // Proxied-route credentials come from `uplinks:` entries that declare
+        // Proxied-route credentials come from `upstreams:` entries that declare
         // an `access:` policy. They are matched by registry origin and exposed
         // to clients at `/~<name>/`.
         let aliases = config
-            .uplinks
+            .upstreams
             .iter()
-            .filter_map(|(name, uplink)| ResolvedAlias::from_uplink(name, uplink))
+            .filter_map(|(name, upstream)| ResolvedAlias::from_upstream(name, upstream))
             .collect();
-        let uplink_origins =
-            config.uplinks.values().filter_map(|uplink| nerf_prefix(&uplink.url)).collect();
+        let upstream_origins =
+            config.upstreams.values().filter_map(|upstream| nerf_prefix(&upstream.url)).collect();
         Self {
             hosted_origin,
             public_routes,
             aliases,
-            uplink_origins,
+            upstream_origins,
             policies: config.policies.clone(),
         }
     }
@@ -327,20 +327,21 @@ impl RouteContext {
         if let Some(hosted) = self.hosted_origin.as_deref()
             && fetch.starts_with(hosted)
         {
-            // A fetch to pnpr's own `/~<uplink>/` endpoint addresses that
-            // uplink, not a hosted package (a package name can never begin
-            // with `~`). Authorized callers resolve through the uplink;
-            // everyone else — and an unknown uplink — gets an anonymous
+            // A fetch to pnpr's own `/~<name>/` endpoint addresses that
+            // upstream, not a hosted package (a package name can never begin
+            // with `~`). Authorized callers resolve through the upstream;
+            // everyone else — and an unknown upstream — gets an anonymous
             // fetch the endpoint itself rejects, rather than falling through
             // to the hosted-package policy.
             if let Some(rest) = fetch.strip_prefix(hosted)
-                && let Some(uplink) = rest.strip_prefix('~').and_then(|rest| rest.split('/').next())
-                && !uplink.is_empty()
+                && let Some(upstream) =
+                    rest.strip_prefix('~').and_then(|rest| rest.split('/').next())
+                && !upstream.is_empty()
             {
                 return match self
                     .aliases
                     .iter()
-                    .find(|alias| alias.name == uplink && alias.access.allows(identity))
+                    .find(|alias| alias.name == upstream && alias.access.allows(identity))
                 {
                     Some(alias) => RouteClass::Proxied {
                         alias: alias.name.clone(),
@@ -355,9 +356,9 @@ impl RouteContext {
         if let Some(alias) = self.select_alias(identity, &fetch)
             && scheme_of(url) == Some(alias.scheme.as_str())
         {
-            // Scheme must match the uplink's: nerf-darting strips it, so an
+            // Scheme must match the upstream's: nerf-darting strips it, so an
             // `http://host` fetch would otherwise be handed an `https://host`
-            // uplink's server-owned credential and leak it in cleartext. A
+            // upstream's server-owned credential and leak it in cleartext. A
             // scheme mismatch falls through to an anonymous public fetch (which
             // fails closed upstream if the resource is actually private).
             return RouteClass::Proxied {
@@ -375,8 +376,8 @@ impl RouteContext {
 
     /// Whether pnpr is permitted to fetch from `url`'s registry at all. The
     /// allowlist is the union of every configured route: the built-in npm
-    /// host, operator-declared public routes, configured uplink origins, and
-    /// pnpr's own origin (which serves its hosted packages and `/~<uplink>/`
+    /// host, operator-declared public routes, configured upstream origins, and
+    /// pnpr's own origin (which serves its hosted packages and `/~<name>/`
     /// endpoints). A client `registry`/`namedRegistries` matching none of
     /// these is rejected before any server-side fetch — the resolver's SSRF
     /// boundary — so there is no "unknown registry" to resolve anonymously.
@@ -403,7 +404,7 @@ impl RouteContext {
         {
             return true;
         }
-        self.uplink_origins.iter().any(|origin| fetch.starts_with(origin))
+        self.upstream_origins.iter().any(|origin| fetch.starts_with(origin))
     }
 
     /// A pnpr-hosted route is public when its package access policy
@@ -447,10 +448,10 @@ impl RouteContext {
                 // this exact alias for its origin — the first authorized alias
                 // [`Self::select_alias`] returns there — and its credential
                 // still hashes to the same digest. Not merely an alias the
-                // caller is authorized for: with overlapping uplink access
+                // caller is authorized for: with overlapping upstream access
                 // (several aliases on one origin a caller can use), an
                 // authorization-only check could replay a lockfile routed
-                // through a different `/~<uplink>/` endpoint than this caller
+                // through a different `/~<name>/` endpoint than this caller
                 // resolves through. A since-removed alias (`find` → `None`) or
                 // a rotated credential also fails closed here.
                 self.aliases.iter().find(|candidate| candidate.name == alias.as_str()).is_some_and(
@@ -469,13 +470,13 @@ impl RouteContext {
     }
 
     /// The upstream registry an authorized caller reaches through the
-    /// `/~<uplink>/` endpoint, used to reverse an endpoint tarball URL back to
+    /// `/~<name>/` endpoint, used to reverse an endpoint tarball URL back to
     /// its upstream when verifying an input lockfile. Returns `None` when the
-    /// uplink is unknown or the caller is not authorized for it.
-    pub(crate) fn uplink_registry(&self, identity: &Identity, uplink: &str) -> Option<String> {
+    /// upstream is unknown or the caller is not authorized for it.
+    pub(crate) fn upstream_registry(&self, identity: &Identity, upstream: &str) -> Option<String> {
         self.aliases
             .iter()
-            .find(|candidate| candidate.name == uplink && candidate.access.allows(identity))
+            .find(|candidate| candidate.name == upstream && candidate.access.allows(identity))
             .map(|candidate| candidate.registry.clone())
     }
 }
@@ -490,7 +491,7 @@ impl RouteMatcher {
     /// `404`s — so a successfully-resolved npmjs route is public and globally
     /// shareable. Prepended to the operator-declared routes in
     /// [`RouteContext::from_config`], so it is allowlisted and public without
-    /// any config, and ahead of any uplink credential for the same origin.
+    /// any config, and ahead of any upstream credential for the same origin.
     fn npmjs() -> Self {
         Self { origin: Some(NPMJS_ORIGIN.to_string()), package: None }
     }
@@ -532,20 +533,20 @@ impl RouteMatcher {
 }
 
 impl ResolvedAlias {
-    /// Build a proxied-route alias from a `uplinks:` entry. An uplink
+    /// Build a proxied-route alias from a `upstreams:` entry. An upstream
     /// participates in route classification only when it declares both an
     /// `access:` policy and a resolved `Authorization` credential; routing is
     /// by registry origin, so no package glob is attached.
-    fn from_uplink(name: &str, uplink: &UplinkConfig) -> Option<Self> {
-        let access = uplink.access.clone()?;
+    fn from_upstream(name: &str, upstream: &UpstreamConfig) -> Option<Self> {
+        let access = upstream.access.clone()?;
         let authorization =
-            uplink.headers.get(AUTHORIZATION).and_then(|value| value.to_str().ok())?.to_string();
+            upstream.headers.get(AUTHORIZATION).and_then(|value| value.to_str().ok())?.to_string();
         Some(Self {
             name: name.to_string(),
             credential_digest: credential_digest(&authorization),
-            registry: uplink.url.clone(),
-            origin: nerf_prefix(&uplink.url)?,
-            scheme: scheme_of(&uplink.url)?.to_string(),
+            registry: upstream.url.clone(),
+            origin: nerf_prefix(&upstream.url)?,
+            scheme: scheme_of(&upstream.url)?.to_string(),
             authorization,
             access,
         })
@@ -681,7 +682,7 @@ pub(crate) fn strip_url_credentials(url: &str) -> String {
 /// (`?X-Amz-Signature=…`, `?token=…`). A genuinely public tarball is fetched by
 /// its bare path and verified by SRI regardless, so the sanitized URL still
 /// works; one that truly needed a token was never a public route and must be
-/// configured as an uplink (whose tarballs route through `/~<uplink>/`, keeping
+/// configured as an upstream (whose tarballs route through `/~<name>/`, keeping
 /// the token server-side). Unlike a client-supplied direct-tarball spec — whose
 /// query is the caller's own intent — this is untrusted upstream metadata.
 #[must_use]
@@ -705,9 +706,9 @@ fn compile_glob(pattern: &str) -> Option<Glob<'static>> {
 /// (`//host[:port]/`), the prefix every fetch under it shares. `None`
 /// for an unparsable URL.
 /// The nerf-darted registry prefix used to match fetches to a hosted, public,
-/// or proxied-uplink route. Path-preserving (`//host/base/`), unlike a bare
+/// or proxied-upstream route. Path-preserving (`//host/base/`), unlike a bare
 /// host: a pnpr served under a path prefix (`https://host/pnpr/`) still
-/// recognizes its own `/pnpr/~<uplink>/` endpoints, and a public/uplink route
+/// recognizes its own `/pnpr/~<name>/` endpoints, and a public/upstream route
 /// declared for `https://host/base/` does not also match a sibling
 /// `https://host/other/` path on the same host.
 fn nerf_prefix(url: &str) -> Option<String> {

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -133,7 +133,7 @@ fn allows_registry_is_a_default_deny_allowlist() {
     });
     let context = RouteContext::from_config(&config);
 
-    // Allowed: the built-in npm host, a declared public route, a upstream
+    // Allowed: the built-in npm host, a declared public route, an upstream
     // origin, and pnpr's own origin (its `/~<name>/` endpoints).
     assert!(context.allows_registry("https://registry.npmjs.org/"));
     assert!(context.allows_registry("https://public.mirror.example/@scope/pkg"));

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -9,7 +9,7 @@ use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 
 use super::{Footprint, PrivateAccessDescriptor, RouteClass, RouteContext, RouteHook};
 use crate::{
-    config::{Config, PublicRoute, UplinkConfig},
+    config::{Config, PublicRoute, UpstreamConfig},
     policy::{AccessList, Identity, PackagePolicies},
 };
 
@@ -123,9 +123,9 @@ fn npmjs_host_is_public_including_scoped() {
 #[test]
 fn allows_registry_is_a_default_deny_allowlist() {
     let mut config = base_config();
-    config.uplinks.insert(
+    config.upstreams.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated"),
+        upstream_with_access("https://npm.corp.example/", "$authenticated"),
     );
     config.route_policy.public.push(PublicRoute {
         registry: Some("https://public.mirror.example/".to_string()),
@@ -133,8 +133,8 @@ fn allows_registry_is_a_default_deny_allowlist() {
     });
     let context = RouteContext::from_config(&config);
 
-    // Allowed: the built-in npm host, a declared public route, a uplink
-    // origin, and pnpr's own origin (its `/~<uplink>/` endpoints).
+    // Allowed: the built-in npm host, a declared public route, a upstream
+    // origin, and pnpr's own origin (its `/~<name>/` endpoints).
     assert!(context.allows_registry("https://registry.npmjs.org/"));
     assert!(context.allows_registry("https://public.mirror.example/@scope/pkg"));
     assert!(context.allows_registry("https://npm.corp.example/@acme/widget"));
@@ -153,10 +153,10 @@ fn allows_registry_is_a_default_deny_allowlist() {
 
 #[test]
 fn the_builtin_npmjs_route_is_always_allowlisted_and_public() {
-    // Even a deployment that declares no uplinks and no public routes still
+    // Even a deployment that declares no upstreams and no public routes still
     // resolves from the official npm registry: it's a built-in public route.
     let mut config = base_config();
-    config.uplinks.clear();
+    config.upstreams.clear();
     let context = RouteContext::from_config(&config);
 
     assert!(context.allows_registry("https://registry.npmjs.org/lodash"));
@@ -212,7 +212,7 @@ fn public_route_with_an_invalid_field_fails_closed_instead_of_matching_all() {
     // A typo'd registry URL must not collapse to a match-any public rule
     // that would classify a private registry's packages as Public.
     let mut config = base_config();
-    config.uplinks.clear();
+    config.upstreams.clear();
     config.route_policy.public.push(PublicRoute {
         registry: Some("not a url".to_string()),
         package: Some("@public/*".to_string()),
@@ -229,7 +229,7 @@ fn public_route_with_an_invalid_field_fails_closed_instead_of_matching_all() {
 
     // An invalid package glob drops the rule the same way.
     let mut config = base_config();
-    config.uplinks.clear();
+    config.upstreams.clear();
     config.route_policy.public.push(PublicRoute {
         registry: Some("https://npm.corp.example/".to_string()),
         package: Some("[".to_string()),
@@ -238,39 +238,39 @@ fn public_route_with_an_invalid_field_fails_closed_instead_of_matching_all() {
     assert!(!context.allows_registry("https://npm.corp.example/@secret/pkg"));
 }
 
-/// The standard bearer token every test uplink uses, and the credential digest
+/// The standard bearer token every test upstream uses, and the credential digest
 /// it produces — what a `RouteClass::Proxied` / `PrivateAccessDescriptor::Alias`
-/// for such an uplink carries.
-const UPLINK_TOKEN: &str = "Bearer uplink-secret";
+/// for such an upstream carries.
+const UPLINK_TOKEN: &str = "Bearer upstream-secret";
 
 fn corp_credential() -> String {
     super::credential_digest(UPLINK_TOKEN)
 }
 
-/// A *different* credential digest, standing in for the same uplink after its
+/// A *different* credential digest, standing in for the same upstream after its
 /// upstream credential has been rotated.
 fn rotated_credential() -> String {
     super::credential_digest("Bearer rotated-secret")
 }
 
-fn uplink_with_access(registry: &str, access: &str) -> UplinkConfig {
+fn upstream_with_access(registry: &str, access: &str) -> UpstreamConfig {
     let mut headers = HeaderMap::new();
-    headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer uplink-secret"));
-    let mut uplink = UplinkConfig::with_defaults(registry.to_string(), headers);
-    uplink.access = Some(AccessList::parse(access));
-    uplink
+    headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer upstream-secret"));
+    let mut upstream = UpstreamConfig::with_defaults(registry.to_string(), headers);
+    upstream.access = Some(AccessList::parse(access));
+    upstream
 }
 
 #[test]
-fn uplink_with_access_is_a_proxied_route_matched_by_origin() {
+fn upstream_with_access_is_a_proxied_route_matched_by_origin() {
     let mut config = base_config();
-    config.uplinks.insert(
+    config.upstreams.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated"),
+        upstream_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let context = RouteContext::from_config(&config);
 
-    // An authorized caller selects the uplink as a proxied route.
+    // An authorized caller selects the upstream as a proxied route.
     assert_eq!(
         context.classify(
             &user("alice"),
@@ -280,7 +280,7 @@ fn uplink_with_access_is_a_proxied_route_matched_by_origin() {
         RouteClass::Proxied { alias: "corp".to_string(), credential_digest: corp_credential() },
     );
     // Routing is by registry origin, not a package glob, so any package on
-    // that origin matches the same uplink.
+    // that origin matches the same upstream.
     assert_eq!(
         context.classify(&user("alice"), "https://npm.corp.example/lodash", Some("lodash")),
         RouteClass::Proxied { alias: "corp".to_string(), credential_digest: corp_credential() },
@@ -295,20 +295,20 @@ fn uplink_with_access_is_a_proxied_route_matched_by_origin() {
 }
 
 #[test]
-fn uplink_credential_is_not_attached_over_a_mismatched_scheme() {
+fn upstream_credential_is_not_attached_over_a_mismatched_scheme() {
     let mut config = base_config();
-    config.uplinks.insert(
+    config.upstreams.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated"),
+        upstream_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let context = RouteContext::from_config(&config);
 
-    // An https fetch matches the https uplink and gets the managed credential.
+    // An https fetch matches the https upstream and gets the managed credential.
     assert_eq!(
         context.classify(&user("alice"), "https://npm.corp.example/lodash", Some("lodash")),
         RouteClass::Proxied { alias: "corp".to_string(), credential_digest: corp_credential() },
     );
-    // A plain-http fetch to the same origin must NOT receive the https uplink's
+    // A plain-http fetch to the same origin must NOT receive the https upstream's
     // server-owned token (nerf-darting strips the scheme); it falls through to
     // an anonymous public fetch instead.
     assert_eq!(
@@ -318,26 +318,26 @@ fn uplink_credential_is_not_attached_over_a_mismatched_scheme() {
 }
 
 #[test]
-fn self_uplink_endpoint_url_classifies_as_proxied_for_authorized_caller() {
+fn self_upstream_endpoint_url_classifies_as_proxied_for_authorized_caller() {
     let mut config = base_config();
-    config.uplinks.insert(
+    config.upstreams.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated"),
+        upstream_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let context = RouteContext::from_config(&config);
     // A request to pnpr's own `/~corp/` endpoint resolves through the corp
-    // uplink, using its current credential (the URL carries none).
+    // upstream, using its current credential (the URL carries none).
     let url = format!("{}/~corp/@acme%2fwidget", config.public_url);
     assert_eq!(
         context.classify(&user("alice"), &url, Some("@acme/widget")),
         RouteClass::Proxied { alias: "corp".to_string(), credential_digest: corp_credential() },
     );
-    // An unauthorized caller gets no managed credential: a `/~<uplink>/` URL
-    // is an uplink endpoint, never a hosted package, so it does not fall
+    // An unauthorized caller gets no managed credential: a `/~<name>/` URL
+    // is an upstream endpoint, never a hosted package, so it does not fall
     // through to the hosted-package policy; the anonymous fetch the endpoint
     // itself rejects is the fail-closed point.
     assert_eq!(context.classify(&anon(), &url, Some("@acme/widget")), RouteClass::Public);
-    // An unknown uplink name is treated the same way.
+    // An unknown upstream name is treated the same way.
     let ghost = format!("{}/~ghost/@acme%2fwidget", config.public_url);
     assert_eq!(context.classify(&user("alice"), &ghost, Some("@acme/widget")), RouteClass::Public);
 }
@@ -347,9 +347,9 @@ fn self_endpoint_recognized_when_pnpr_is_served_under_a_path_prefix() {
     let mut config = base_config();
     // pnpr deployed behind a reverse proxy under a `/pnpr/` sub-path.
     config.public_url = "https://host.example/pnpr/".to_string();
-    config.uplinks.insert(
+    config.upstreams.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated"),
+        upstream_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let context = RouteContext::from_config(&config);
     // The path-preserving hosted prefix still recognizes the `/pnpr/~corp/`
@@ -365,16 +365,16 @@ fn self_endpoint_recognized_when_pnpr_is_served_under_a_path_prefix() {
 }
 
 #[test]
-fn uplink_without_access_is_an_anonymous_route() {
+fn upstream_without_access_is_an_anonymous_route() {
     let mut config = base_config();
     let mut headers = HeaderMap::new();
-    headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer uplink-secret"));
-    // A plain proxy uplink that does not declare `access:` is never offered
+    headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer upstream-secret"));
+    // A plain proxy upstream that does not declare `access:` is never offered
     // as a resolver private-route credential, but its origin is still
     // allowlisted (a configured registry) and fetched anonymously.
-    config.uplinks.insert(
+    config.upstreams.insert(
         "mirror".to_string(),
-        UplinkConfig::with_defaults("https://npm.corp.example/".to_string(), headers),
+        UpstreamConfig::with_defaults("https://npm.corp.example/".to_string(), headers),
     );
     let context = RouteContext::from_config(&config);
     assert!(context.allows_registry("https://npm.corp.example/lodash"));
@@ -389,8 +389,8 @@ fn proxied_alias_accepts_configured_group_identity() {
     let mut config = base_config();
     config.groups.add_user_to_group("alice", "platform");
     config
-        .uplinks
-        .insert("corp".to_string(), uplink_with_access("https://npm.corp.example/", "platform"));
+        .upstreams
+        .insert("corp".to_string(), upstream_with_access("https://npm.corp.example/", "platform"));
     let context = RouteContext::from_config(&config);
     let url = "https://npm.corp.example/@acme%2fwidget";
 
@@ -436,17 +436,17 @@ fn hosted_route_follows_package_access_policy() {
 }
 
 #[test]
-fn overlapping_uplink_access_reuses_only_the_selected_alias() {
+fn overlapping_upstream_access_reuses_only_the_selected_alias() {
     let mut config = base_config();
-    // Two uplinks serving the same origin; `primary` is declared first, so
+    // Two upstreams serving the same origin; `primary` is declared first, so
     // `select_alias` picks it for a caller authorized for both.
-    config.uplinks.insert(
+    config.upstreams.insert(
         "primary".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated"),
+        upstream_with_access("https://npm.corp.example/", "$authenticated"),
     );
-    config.uplinks.insert(
+    config.upstreams.insert(
         "secondary".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated"),
+        upstream_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let context = RouteContext::from_config(&config);
 
@@ -510,9 +510,9 @@ fn footprint_digest_is_stable_and_namespaced() {
 #[test]
 fn route_hook_records_routes_and_returns_alias_credential() {
     let mut config = base_config();
-    config.uplinks.insert(
+    config.upstreams.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated"),
+        upstream_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let footprint = std::sync::Arc::new(std::sync::Mutex::new(Footprint::default()));
     let hook = RouteHook::new(
@@ -524,10 +524,10 @@ fn route_hook_records_routes_and_returns_alias_credential() {
 
     // Public fetch: no upstream credential, no private footprint entry.
     assert_eq!(hook.authorize("https://registry.npmjs.org/lodash", Some("lodash")), None);
-    // Private proxied fetch: the uplink credential is returned and recorded.
+    // Private proxied fetch: the upstream credential is returned and recorded.
     assert_eq!(
         hook.authorize("https://npm.corp.example/@acme%2fwidget", Some("@acme/widget")),
-        Some("Bearer uplink-secret".to_string()),
+        Some("Bearer upstream-secret".to_string()),
     );
 
     let footprint = footprint.lock().unwrap();
@@ -538,9 +538,9 @@ fn route_hook_records_routes_and_returns_alias_credential() {
 #[test]
 fn metadata_scope_maps_route_classes() {
     let mut config = base_config();
-    config.uplinks.insert(
+    config.upstreams.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated"),
+        upstream_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let footprint = std::sync::Arc::new(std::sync::Mutex::new(Footprint::default()));
     let hook = RouteHook::new(
@@ -578,9 +578,9 @@ fn metadata_scope_maps_route_classes() {
 #[test]
 fn authorized_alias_users_share_metadata_scope() {
     let mut config = base_config();
-    config.uplinks.insert(
+    config.upstreams.insert(
         "corp".to_string(),
-        uplink_with_access("https://npm.corp.example/", "$authenticated"),
+        upstream_with_access("https://npm.corp.example/", "$authenticated"),
     );
     let context = Arc::new(RouteContext::from_config(&config));
     let secret = Arc::from(b"server-secret".as_slice());

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -241,10 +241,10 @@ fn public_route_with_an_invalid_field_fails_closed_instead_of_matching_all() {
 /// The standard bearer token every test upstream uses, and the credential digest
 /// it produces — what a `RouteClass::Proxied` / `PrivateAccessDescriptor::Alias`
 /// for such an upstream carries.
-const UPLINK_TOKEN: &str = "Bearer upstream-secret";
+const UPSTREAM_TOKEN: &str = "Bearer upstream-secret";
 
 fn corp_credential() -> String {
-    super::credential_digest(UPLINK_TOKEN)
+    super::credential_digest(UPSTREAM_TOKEN)
 }
 
 /// A *different* credential digest, standing in for the same upstream after its

--- a/pnpr/crates/pnpr/src/s3.rs
+++ b/pnpr/crates/pnpr/src/s3.rs
@@ -142,7 +142,7 @@ impl S3Store {
     }
 
     /// A view of this store with `segment` appended to the key prefix, giving a
-    /// hosted mount its own object-key namespace under the same bucket.
+    /// hosted registry its own object-key namespace under the same bucket.
     /// Staging scratch is shared (its tmp filenames are already unique).
     #[must_use]
     pub fn namespaced(&self, segment: &str) -> S3Store {

--- a/pnpr/crates/pnpr/src/search.rs
+++ b/pnpr/crates/pnpr/src/search.rs
@@ -73,7 +73,7 @@ pub fn parse_size(query_string: &str, default_size: usize) -> usize {
 /// filter, applied before any packument is read so a filtered name costs
 /// no I/O. Returns at most `limit` entries in npm search v1 `objects`
 /// shape (`{ package: {...}, score: {...}, searchScore }`); the server
-/// aggregates entries across the namespaces a mount serves and builds the
+/// aggregates entries across the namespaces a registry serves and builds the
 /// response body. Errors reading individual packuments are tolerated — a
 /// malformed packument just doesn't match anything. Works against both
 /// the local-directory and the S3-backed hosted store.

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -83,16 +83,16 @@ struct AppState {
 
 struct AppInner {
     storage: Storage,
-    /// One [`Upstream`] per declared uplink, keyed by the same name
-    /// used in [`Config::uplinks`]. Built once at router construction
+    /// One [`Upstream`] per declared upstream, keyed by the same name
+    /// used in [`Config::upstreams`]. Built once at router construction
     /// time so each request avoids re-allocating a `ThrottledClient`.
     upstreams: IndexMap<String, Upstream>,
-    /// The disposable cache namespace of each uplink, keyed like
+    /// The disposable cache namespace of each upstream, keyed like
     /// [`Self::upstreams`]. A pure function of the config (see
-    /// [`compute_uplink_cache_namespace`]), precomputed here so the
-    /// per-request path doesn't re-sort and re-hash the uplink's headers on
+    /// [`compute_upstream_cache_namespace`]), precomputed here so the
+    /// per-request path doesn't re-sort and re-hash the upstream's headers on
     /// every packument and tarball served through an upstream registry.
-    uplink_cache_namespaces: IndexMap<String, String>,
+    upstream_cache_namespaces: IndexMap<String, String>,
     config: Config,
     auth: AuthState,
     /// Serializes the read-modify-write packument flows per package so
@@ -249,28 +249,28 @@ fn router_with_auth_and_osv(
         Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone());
     let registry_enabled = config.registry.enabled;
     let resolver_enabled = config.resolver.enabled;
-    // Only the registry routes consult the uplinks, so a resolver-only
+    // Only the registry routes consult the upstreams, so a resolver-only
     // server builds none — skipping a `ThrottledClient` allocation per
-    // configured uplink.
+    // configured upstream.
     let upstreams: IndexMap<String, Upstream> = if registry_enabled {
         config
-            .uplinks
+            .upstreams
             .iter()
-            .map(|(name, uplink)| (name.clone(), Upstream::new(name, uplink)))
+            .map(|(name, upstream)| (name.clone(), Upstream::new(name, upstream)))
             .collect()
     } else {
         IndexMap::new()
     };
-    let uplink_cache_namespaces = config
-        .uplinks
+    let upstream_cache_namespaces = config
+        .upstreams
         .keys()
-        .map(|name| (name.clone(), compute_uplink_cache_namespace(&config, name)))
+        .map(|name| (name.clone(), compute_upstream_cache_namespace(&config, name)))
         .collect();
     let state = AppState {
         inner: Arc::new(AppInner {
             storage,
             upstreams,
-            uplink_cache_namespaces,
+            upstream_cache_namespaces,
             config,
             auth,
             package_locks: PackageLocks::new(),
@@ -618,7 +618,7 @@ async fn get_two_segments(
     // tarball base is the client's `/~<name>/` URL so the rewritten URLs stay
     // canonical for the registry the client actually addressed.
     if let Some(registry) = first.strip_prefix('~').filter(|registry| !registry.is_empty()) {
-        let base = uplink_tarball_base(&state.inner.config.public_url, registry);
+        let base = upstream_tarball_base(&state.inner.config.public_url, registry);
         return private_no_cache(
             serve_registry_packument(&state, &identity, &headers, registry, &second, &base).await,
         );
@@ -655,7 +655,7 @@ async fn get_three_segments(
         if second == "-" {
             return not_found();
         }
-        let base = uplink_tarball_base(&state.inner.config.public_url, registry);
+        let base = upstream_tarball_base(&state.inner.config.public_url, registry);
         if second.starts_with('@') {
             // `/~<name>/@scope%2Fname/<version>` — version manifest for an
             // encoded scoped package through a registry endpoint.
@@ -731,7 +731,7 @@ async fn get_four_segments(
         }
         if b.starts_with('@') && !b.contains('/') {
             let full = format!("{b}/{c}");
-            let base = uplink_tarball_base(&state.inner.config.public_url, registry);
+            let base = upstream_tarball_base(&state.inner.config.public_url, registry);
             return private_no_cache(
                 serve_registry_version_manifest(&state, &identity, registry, &full, &d, &base)
                     .await,
@@ -1222,27 +1222,27 @@ async fn serve_registry_version_manifest(
     }
 }
 
-/// The `dist.tarball` rewrite base for an uplink's `/~<uplink>/` registry
+/// The `dist.tarball` rewrite base for an upstream's `/~<name>/` registry
 /// endpoint, so a served packument points tarball requests back at the same
 /// endpoint (where this server re-checks access and proxies the bytes).
-fn uplink_tarball_base(public_url: &str, uplink: &str) -> String {
-    format!("{}/~{uplink}", public_url.trim_end_matches('/'))
+fn upstream_tarball_base(public_url: &str, upstream: &str) -> String {
+    format!("{}/~{upstream}", public_url.trim_end_matches('/'))
 }
 
-/// Resolve the upstream behind an authorized `/~<uplink>/` endpoint request.
+/// Resolve the upstream behind an authorized `/~<name>/` endpoint request.
 ///
-/// Fails closed: an uplink that does not exist or carries no `access:` policy
+/// Fails closed: an upstream that does not exist or carries no `access:` policy
 /// is a `404` (it is not a private-route endpoint), and a caller the policy
 /// does not admit is a `403`. Returns the [`Upstream`] to fetch *through* —
-/// `/~<uplink>/` requests never read or write the shared proxy mirror, so a
-/// private uplink's packuments and tarballs can never leak across the public
-/// path or another uplink.
-fn authorized_uplink<'a>(
+/// `/~<name>/` requests never read or write the shared proxy mirror, so a
+/// private upstream's packuments and tarballs can never leak across the public
+/// path or another upstream.
+fn authorized_upstream<'a>(
     state: &'a AppState,
     identity: &Identity,
-    uplink: &str,
+    upstream: &str,
 ) -> Result<&'a Upstream, Box<Response>> {
-    let Some(config) = state.inner.config.uplinks.get(uplink) else {
+    let Some(config) = state.inner.config.upstreams.get(upstream) else {
         return Err(Box::new(not_found()));
     };
     // A private upstream registry gates by its `access:` list; a public registry
@@ -1251,28 +1251,28 @@ fn authorized_uplink<'a>(
     if let Some(access) = config.access.as_ref()
         && !access.allows(identity)
     {
-        let user =
-            require_caller(identity, "uplink access").unwrap_or_else(|_| "<anonymous>".to_string());
+        let user = require_caller(identity, "upstream access")
+            .unwrap_or_else(|_| "<anonymous>".to_string());
         return Err(Box::new(error_response(&RegistryError::Forbidden {
             user,
             action: "access",
-            resource: format!("uplink {uplink:?}"),
+            resource: format!("upstream {upstream:?}"),
         })));
     }
-    state.inner.upstreams.get(uplink).ok_or_else(|| Box::new(not_found()))
+    state.inner.upstreams.get(upstream).ok_or_else(|| Box::new(not_found()))
 }
 
 /// The disposable cache namespace for an upstream registry's `/~<name>/` route —
-/// the entry precomputed in [`AppInner::uplink_cache_namespaces`], falling back
-/// to a fresh computation only for a name outside [`Config::uplinks`] (which
+/// the entry precomputed in [`AppInner::upstream_cache_namespaces`], falling back
+/// to a fresh computation only for a name outside [`Config::upstreams`] (which
 /// the registry dispatch never produces).
-fn uplink_cache_namespace(state: &AppState, uplink: &str) -> String {
+fn upstream_cache_namespace(state: &AppState, upstream: &str) -> String {
     state
         .inner
-        .uplink_cache_namespaces
-        .get(uplink)
+        .upstream_cache_namespaces
+        .get(upstream)
         .cloned()
-        .unwrap_or_else(|| compute_uplink_cache_namespace(&state.inner.config, uplink))
+        .unwrap_or_else(|| compute_upstream_cache_namespace(&state.inner.config, upstream))
 }
 
 /// Compute an upstream registry's disposable cache namespace, so its packuments
@@ -1296,28 +1296,29 @@ fn uplink_cache_namespace(state: &AppState, uplink: &str) -> String {
 /// is integrity-verified, so it uses a *stable* namespace
 /// (`~public/<digest-of-registry-name-and-url>`) that is shared across process
 /// restarts.
-fn compute_uplink_cache_namespace(config: &Config, uplink: &str) -> String {
-    let url = config.uplinks.get(uplink).map_or("", |uplink_config| uplink_config.url.as_str());
-    if let Some(uplink_config) = config.uplinks.get(uplink)
-        && uplink_config.access.is_some()
+fn compute_upstream_cache_namespace(config: &Config, upstream: &str) -> String {
+    let url =
+        config.upstreams.get(upstream).map_or("", |upstream_config| upstream_config.url.as_str());
+    if let Some(upstream_config) = config.upstreams.get(upstream)
+        && upstream_config.access.is_some()
     {
         // The credential epoch covers the origin URL and every header the
-        // uplink attaches upstream, not just `Authorization`, so repointing
+        // upstream attaches upstream, not just `Authorization`, so repointing
         // the URL or rotating a credential carried in a custom header moves
         // the private cache to a fresh namespace. The NUL separator keeps
         // `(url, headers)` pairs unambiguous — a URL cannot contain NUL.
         let epoch = crate::route::credential_digest(&format!(
             "{url}\0{}",
-            crate::route::headers_credential_digest(&uplink_config.headers),
+            crate::route::headers_credential_digest(&upstream_config.headers),
         ));
         let digest =
-            crate::route::uplink_cache_digest(uplink, epoch, &config.resolution_cache_secret);
-        return format!("~uplinks/{digest}");
+            crate::route::upstream_cache_digest(upstream, epoch, &config.resolution_cache_secret);
+        return format!("~upstreams/{digest}");
     }
     // Public registry: a stable, secret-free namespace keyed by the registry name
     // and its origin URL (hashed so a path-unsafe value can't escape the
     // cache root).
-    format!("~public/{}", crate::route::credential_digest(&format!("{uplink}\0{url}")))
+    format!("~public/{}", crate::route::credential_digest(&format!("{upstream}\0{url}")))
 }
 
 /// Await `fut`, emitting its duration as a `pnpr::serve_timing` debug event
@@ -1344,11 +1345,11 @@ async fn timed<Fut: Future>(phase: &'static str, package: &str, fut: Fut) -> Fut
     out
 }
 
-/// Load an uplink route's packument: a fresh per-registry cache entry when one
+/// Load an upstream route's packument: a fresh per-registry cache entry when one
 /// exists, otherwise a fetch through the registry (with its server-side credential)
 /// written back to the same namespace. A registry with `cache: false` neither reads
 /// nor writes the cache — it streams everything through, refetching each time.
-async fn load_uplink_packument(
+async fn load_upstream_packument(
     state: &AppState,
     namespace: &str,
     upstream: &Upstream,
@@ -1359,7 +1360,7 @@ async fn load_uplink_packument(
         && let Some(bytes) = timed(
             "packument:cache_read",
             name.as_str(),
-            state.inner.storage.read_uplink_packument(namespace, name, ttl),
+            state.inner.storage.read_upstream_packument(namespace, name, ttl),
         )
         .await?
     {
@@ -1387,7 +1388,7 @@ async fn load_uplink_packument(
             if err.is_transient_upstream_error()
                 && upstream.caches()
                 && let Some(bytes) =
-                    state.inner.storage.read_uplink_packument_any(namespace, name).await?
+                    state.inner.storage.read_upstream_packument_any(namespace, name).await?
             {
                 // `log_message()` (not `?err`): an upstream error embeds the
                 // request URL, which can carry credentials (basic-auth userinfo,
@@ -1408,10 +1409,10 @@ async fn load_uplink_packument(
                 && let Err(err) = state
                     .inner
                     .storage
-                    .write_uplink_packument(namespace, name, &fetched.bytes)
+                    .write_upstream_packument(namespace, name, &fetched.bytes)
                     .await
             {
-                tracing::warn!(?err, package = %name.as_str(), "uplink packument cache write failed");
+                tracing::warn!(?err, package = %name.as_str(), "upstream packument cache write failed");
             }
             Ok(Some(fetched.bytes))
         }
@@ -1421,7 +1422,7 @@ async fn load_uplink_packument(
             // outlive every TTL and a later transient outage could resurrect
             // the unpublished package through the stale-if-error fallback.
             if upstream.caches()
-                && let Err(err) = state.inner.storage.remove_uplink_package(namespace, name).await
+                && let Err(err) = state.inner.storage.remove_upstream_package(namespace, name).await
             {
                 tracing::warn!(
                     ?err,
@@ -1431,14 +1432,14 @@ async fn load_uplink_packument(
             }
             Ok(None)
         }
-        // `load_uplink_packument` sends no conditional validators (the uplink
+        // `load_upstream_packument` sends no conditional validators (the upstream
         // cache refetches stale entries rather than revalidating — see
-        // `Store::read_uplink_packument`), so a well-behaved upstream never
+        // `Store::read_upstream_packument`), so a well-behaved upstream never
         // answers 304 here. If one does anyway, "not modified" means the cached
         // body is current, so serve it (fresh or stale) rather than a spurious
         // 404 that a client could cache as "package gone".
         PackumentFetch::NotModified => {
-            state.inner.storage.read_uplink_packument_any(namespace, name).await
+            state.inner.storage.read_upstream_packument_any(namespace, name).await
         }
     }
 }
@@ -1450,13 +1451,13 @@ async fn load_uplink_packument(
 async fn load_upstream_packument_for(
     state: &AppState,
     identity: &Identity,
-    uplink: &str,
+    upstream: &str,
     name: &PackageName,
 ) -> Result<Option<Vec<u8>>, Box<Response>> {
-    let upstream = authorized_uplink(state, identity, uplink)?;
-    let namespace = uplink_cache_namespace(state, uplink);
+    let namespace = upstream_cache_namespace(state, upstream);
+    let upstream = authorized_upstream(state, identity, upstream)?;
     let ttl = upstream.maxage().unwrap_or(state.inner.config.packument_ttl);
-    load_uplink_packument(state, &namespace, upstream, name, ttl)
+    load_upstream_packument(state, &namespace, upstream, name, ttl)
         .await
         .map_err(|err| Box::new(error_response(&err)))
 }
@@ -1511,15 +1512,15 @@ async fn load_packument_for_read(
     }
 }
 
-async fn serve_packument_via_uplink(
+async fn serve_packument_via_upstream(
     state: &AppState,
     identity: &Identity,
     headers: &HeaderMap,
-    uplink: &str,
+    upstream: &str,
     name: &PackageName,
     tarball_base: &str,
 ) -> Response {
-    let bytes = match load_upstream_packument_for(state, identity, uplink, name).await {
+    let bytes = match load_upstream_packument_for(state, identity, upstream, name).await {
         Ok(Some(bytes)) => bytes,
         Ok(None) => return not_found(),
         Err(response) => return *response,
@@ -1536,16 +1537,16 @@ async fn serve_packument_via_uplink(
     }
 }
 
-/// Serve a tarball through an uplink's `/~<uplink>/` endpoint. The version's
-/// `dist.integrity` is read from the uplink's own packument (served from the
+/// Serve a tarball through an upstream's `/~<name>/` endpoint. The version's
+/// `dist.integrity` is read from the upstream's own packument (served from the
 /// private cache when fresh), and the bytes are verified against it. Both the
-/// packument and the verified tarball are cached under the uplink's private
-/// namespace, so a private uplink's content never lands in the shared proxy
+/// packument and the verified tarball are cached under the upstream's private
+/// namespace, so a private upstream's content never lands in the shared proxy
 /// mirror yet is not re-fetched on every request.
-async fn serve_tarball_via_uplink(
+async fn serve_tarball_via_upstream(
     state: &AppState,
     identity: &Identity,
-    uplink: &str,
+    upstream: &str,
     raw_name: &str,
     filename: &str,
 ) -> Response {
@@ -1569,7 +1570,8 @@ async fn serve_tarball_via_uplink(
             (filename.to_string(), None)
         }
     };
-    let upstream = match authorized_uplink(state, identity, uplink) {
+    let namespace = upstream_cache_namespace(state, upstream);
+    let upstream = match authorized_upstream(state, identity, upstream) {
         Ok(upstream) => upstream,
         Err(response) => return *response,
     };
@@ -1581,7 +1583,6 @@ async fn serve_tarball_via_uplink(
     {
         return error_response(&err);
     }
-    let namespace = uplink_cache_namespace(state, uplink);
     let ttl = upstream.maxage().unwrap_or(state.inner.config.packument_ttl);
     // Serve a cached hit before touching the packument: a cached entry was
     // bound to a declared version and verified against `dist.integrity` when
@@ -1600,17 +1601,17 @@ async fn serve_tarball_via_uplink(
     // of new bytes; end-to-end SRI (the client's lockfile) is the authority
     // on what it accepts. Only OSV screening needs the packument-resolved
     // version first, so with OSV enabled the cache read waits for the bind
-    // below. A `cache: false` uplink skips the cache and streams through.
+    // below. A `cache: false` upstream skips the cache and streams through.
     if upstream.caches()
         && state.inner.osv_index.is_none()
-        && let Some(response) = cached_uplink_tarball(state, &namespace, &name, &filename).await
+        && let Some(response) = cached_upstream_tarball(state, &namespace, &name, &filename).await
     {
         return response;
     }
     let packument = match timed(
         "tarball:packument_load",
         name.as_str(),
-        load_uplink_packument(state, &namespace, upstream, &name, ttl),
+        load_upstream_packument(state, &namespace, upstream, &name, ttl),
     )
     .await
     {
@@ -1631,7 +1632,7 @@ async fn serve_tarball_via_uplink(
     }
     if upstream.caches()
         && state.inner.osv_index.is_some()
-        && let Some(response) = cached_uplink_tarball(state, &namespace, &name, &filename).await
+        && let Some(response) = cached_upstream_tarball(state, &namespace, &name, &filename).await
     {
         return response;
     }
@@ -1648,13 +1649,13 @@ async fn serve_tarball_via_uplink(
         Err(err) => return error_response(&err),
     };
     let write =
-        match state.inner.storage.open_uplink_tarball_tmp(&namespace, &name, &filename).await {
+        match state.inner.storage.open_upstream_tarball_tmp(&namespace, &name, &filename).await {
             Ok(write) => write,
             Err(err) => return error_response(&err),
         };
     if !upstream.caches() {
         // Fetch-through: verify and stream from the temp file, then remove it,
-        // so a `cache: false` uplink's tarball is never persisted.
+        // so a `cache: false` upstream's tarball is never persisted.
         return match streaming::download_verified_to_temp(
             response,
             write,
@@ -1680,10 +1681,10 @@ async fn serve_tarball_via_uplink(
     }
 }
 
-/// The response for a cached uplink tarball, or `None` on a cache miss. A
+/// The response for a cached upstream tarball, or `None` on a cache miss. A
 /// cache-open fault is logged and treated as a miss so the caller falls back
 /// to the upstream fetch rather than failing the request.
-async fn cached_uplink_tarball(
+async fn cached_upstream_tarball(
     state: &AppState,
     namespace: &str,
     name: &PackageName,
@@ -1692,14 +1693,14 @@ async fn cached_uplink_tarball(
     match timed(
         "tarball:cache_read",
         name.as_str(),
-        state.inner.storage.open_uplink_tarball(namespace, name, filename),
+        state.inner.storage.open_upstream_tarball(namespace, name, filename),
     )
     .await
     {
         Ok(Some((file, len))) => Some(tarball_response(streaming::stream_file(file), Some(len))),
         Ok(None) => None,
         Err(err) => {
-            tracing::warn!(?err, package = %name.as_str(), %filename, "uplink tarball cache open failed");
+            tracing::warn!(?err, package = %name.as_str(), %filename, "upstream tarball cache open failed");
             None
         }
     }
@@ -1714,7 +1715,7 @@ async fn cached_uplink_tarball(
 // router selects the first source whose patterns claim the name. An unclaimed
 // name is a definitive 404 (never a fall-through to another origin), and a
 // selected-but-unavailable upstream surfaces an *error* rather than a 404
-// (the via-uplink path returns `UpstreamUnavailable`), so a down private
+// (the via-upstream path returns `UpstreamUnavailable`), so a down private
 // source can never be reported as "not found" and pushed onto a public origin
 // one layer out.
 // --------------------------------------------------------------------
@@ -1723,7 +1724,7 @@ async fn cached_uplink_tarball(
 /// held across an `await` without borrowing the config.
 enum RegistrySource {
     /// An upstream registry (public or private), served via its `/~<source>/`
-    /// uplink machinery. The id is a key in [`Config::uplinks`].
+    /// upstream machinery. The id is a key in [`Config::upstreams`].
     Upstream(String),
     /// A hosted registry, served from the hosted store.
     Hosted(String),
@@ -1757,9 +1758,9 @@ fn resolve_registry_source(state: &AppState, registry: &str, package: &str) -> R
         // origin, and never a storage or upstream consultation.
         Resolved::Unclaimed => RegistrySource::Unclaimed,
         // The graph is the only dispatch table: server construction folds
-        // every configured uplink into it (`ensure_valid_registry_graph`), so
+        // every configured upstream into it (`ensure_valid_registry_graph`), so
         // a name it doesn't know is a definitive not-found — there is no
-        // uplink-table side door that would skip namespace enforcement.
+        // upstream-table side door that would skip namespace enforcement.
         Resolved::UnknownRegistry => RegistrySource::NotFound,
     }
 }
@@ -1777,9 +1778,12 @@ fn resolves_to_private_source(state: &AppState, registry: &str, package: &str) -
             .hosted
             .get(&source)
             .is_some_and(|hosted| !hosted.access.allows(&Identity::Anonymous)),
-        RegistrySource::Upstream(source) => {
-            state.inner.config.uplinks.get(&source).is_some_and(|uplink| uplink.access.is_some())
-        }
+        RegistrySource::Upstream(source) => state
+            .inner
+            .config
+            .upstreams
+            .get(&source)
+            .is_some_and(|upstream| upstream.access.is_some()),
         RegistrySource::Unclaimed | RegistrySource::NotFound => false,
     }
 }
@@ -1834,7 +1838,8 @@ async fn serve_registry_packument(
             if let Err(err) = authorize(state, identity, name.as_str(), Action::Access) {
                 return error_response(&err);
             }
-            serve_packument_via_uplink(state, identity, headers, &source, &name, tarball_base).await
+            serve_packument_via_upstream(state, identity, headers, &source, &name, tarball_base)
+                .await
         }
         // A hosted registry masks first: a private org 404s an unauthorized caller
         // (see `accessible_hosted_namespace`) *before* the per-package ACL could
@@ -1867,7 +1872,7 @@ async fn serve_registry_tarball(
             if let Err(err) = authorize(state, identity, name.as_str(), Action::Access) {
                 return error_response(&err);
             }
-            serve_tarball_via_uplink(state, identity, &source, name.as_str(), filename).await
+            serve_tarball_via_upstream(state, identity, &source, name.as_str(), filename).await
         }
         // Hosted masks first (private-org 404) then applies the ACL, inside
         // `serve_hosted_tarball` — see `serve_registry_packument`.
@@ -2420,9 +2425,9 @@ fn resolve_publish_target(
         }
         // A write can never land on an upstream — but the upstream's `access:`
         // gates the write endpoints exactly as it gates reads, so a caller the
-        // upstream denies gets the read path's 403 (`authorized_uplink`), not
+        // upstream denies gets the read path's 403 (`authorized_upstream`), not
         // a rejection that narrates where the name routes.
-        RegistrySource::Upstream(source) => match authorized_uplink(state, identity, &source) {
+        RegistrySource::Upstream(source) => match authorized_upstream(state, identity, &source) {
             Err(response) => PublishTarget::Denied(response),
             Ok(_) => PublishTarget::Reject(format!(
                 "cannot publish {package:?} {context}: it routes to an upstream registry; name \

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -3,13 +3,13 @@ use crate::{
     config::Config,
     error::RegistryError,
     journal::JournaledPublish,
-    mount::{ConcreteKind, MountKind, Resolved},
     package_name::PackageName,
     policy::Identity,
     publish::{
         PendingAttachment, extract_attachments, iso_from_unix_millis, merge_manifest, now_iso,
         stream_decode_verify_and_write,
     },
+    registry::{ConcreteKind, Registry, Resolved},
     storage::Storage,
     streaming,
     upstream::{
@@ -91,7 +91,7 @@ struct AppInner {
     /// [`Self::upstreams`]. A pure function of the config (see
     /// [`compute_uplink_cache_namespace`]), precomputed here so the
     /// per-request path doesn't re-sort and re-hash the uplink's headers on
-    /// every packument and tarball served through an upstream mount.
+    /// every packument and tarball served through an upstream registry.
     uplink_cache_namespaces: IndexMap<String, String>,
     config: Config,
     auth: AuthState,
@@ -292,10 +292,10 @@ fn router_with_auth_and_osv(
     // depending on a registry-serving replica that shares the auth backend.
     //
     // Each endpoint also answers under any `/~<prefix>/`, so a client whose
-    // registry URL is a mount endpoint can log in against it. The identity
-    // endpoints are global and consult no mount state; a mount-table lookup
+    // registry URL is a registry endpoint can log in against it. The identity
+    // endpoints are global and consult no registry state; a registry-table lookup
     // would gate nothing while turning the 401-vs-404 split into an
-    // existence oracle for private mount names that the content handlers
+    // existence oracle for private registry names that the content handlers
     // carefully mask.
     router = router
         .route("/-/whoami", get(get_whoami))
@@ -352,7 +352,7 @@ fn router_with_auth_and_osv(
         router = router.route("/-/pnpr", any(resolver_disabled));
     }
     // The npm-registry surface: every packument/tarball read, publish,
-    // unpublish, dist-tag, and search. When the surface is off (no mounts
+    // unpublish, dist-tag, and search. When the surface is off (no registries
     // declared, or `--disable-registry`), none of these routes are mounted
     // — not merely hidden — so a resolver-only tier exposes no registry
     // surface at all.
@@ -378,10 +378,10 @@ fn router_with_auth_and_osv(
                 get(get_five_segments).put(put_five_segments).delete(delete_five_segments),
             )
             // Scoped tarball delete: `DELETE /@scope/name/-/<basename-version>.tgz/-rev/<rev>`,
-            // plus the mount-addressed dist-tag write and unscoped tarball delete.
+            // plus the registry-addressed dist-tag write and unscoped tarball delete.
             .route("/{a}/{b}/{c}/{d}/{e}/{f}", put(put_six_segments).delete(delete_six_segments))
-            // Mount-addressed scoped tarball delete:
-            // `DELETE /~<mount>/@scope/name/-/<file>/-rev/<rev>`
+            // Registry-addressed scoped tarball delete:
+            // `DELETE /~<name>/@scope/name/-/<file>/-rev/<rev>`
             .route("/{a}/{b}/{c}/{d}/{e}/{f}/{g}", delete(delete_seven_segments));
     }
     router
@@ -487,7 +487,7 @@ pub async fn serve(config: Config) -> crate::error::Result<()> {
 }
 
 /// Log which surfaces are mounted at startup. A misconfiguration — a
-/// `mounts:` block that didn't parse the way the operator meant, or a
+/// `registries:` block that didn't parse the way the operator meant, or a
 /// typo'd `resolver:` block name, which the intentionally
 /// verdaccio-lenient config parser silently ignores and so leaves the
 /// surface at its default-enabled state — is then immediately visible to
@@ -611,13 +611,13 @@ async fn get_two_segments(
     headers: HeaderMap,
     Path((first, second)): Path<(String, String)>,
 ) -> Response {
-    // `/~<mount>/<pkg>` — unscoped packument through a mount endpoint. The
-    // tarball base is the client's `/~<mount>/` URL so the rewritten URLs stay
+    // `/~<name>/<pkg>` — unscoped packument through a registry endpoint. The
+    // tarball base is the client's `/~<name>/` URL so the rewritten URLs stay
     // canonical for the registry the client actually addressed.
-    if let Some(mount) = first.strip_prefix('~').filter(|mount| !mount.is_empty()) {
-        let base = uplink_tarball_base(&state.inner.config.public_url, mount);
+    if let Some(registry) = first.strip_prefix('~').filter(|registry| !registry.is_empty()) {
+        let base = uplink_tarball_base(&state.inner.config.public_url, registry);
         return private_no_cache(
-            serve_mount_packument(&state, &identity, &headers, mount, &second, &base).await,
+            serve_registry_packument(&state, &identity, &headers, registry, &second, &base).await,
         );
     }
     if first.starts_with('@') {
@@ -641,38 +641,41 @@ async fn get_three_segments(
 ) -> Response {
     if first == "-" && second == "v1" && third == "search" {
         let query = uri.query().unwrap_or("");
-        // Search results are filtered per caller (mount access + per-package
+        // Search results are filtered per caller (registry access + per-package
         // ACL), so they must never land in a shared HTTP cache.
         return private_no_cache(serve_search(&state, &identity, None, query).await);
     }
-    if let Some(mount) = first.strip_prefix('~').filter(|mount| !mount.is_empty()) {
+    if let Some(registry) = first.strip_prefix('~').filter(|registry| !registry.is_empty()) {
         // The account endpoints (whoami, adduser, logout, profile, tokens)
-        // live on dedicated always-mounted routes; a `/~<mount>/-/...` path
-        // that still reaches this handler names no mount content.
+        // live on dedicated always-mounted routes; a `/~<name>/-/...` path
+        // that still reaches this handler names no registry content.
         if second == "-" {
             return not_found();
         }
-        let base = uplink_tarball_base(&state.inner.config.public_url, mount);
+        let base = uplink_tarball_base(&state.inner.config.public_url, registry);
         if second.starts_with('@') {
-            // `/~<mount>/@scope%2Fname/<version>` — version manifest for an
-            // encoded scoped package through a mount endpoint.
+            // `/~<name>/@scope%2Fname/<version>` — version manifest for an
+            // encoded scoped package through a registry endpoint.
             if second.contains('/') {
                 return private_no_cache(
-                    serve_mount_version_manifest(&state, &identity, mount, &second, &third, &base)
-                        .await,
+                    serve_registry_version_manifest(
+                        &state, &identity, registry, &second, &third, &base,
+                    )
+                    .await,
                 );
             }
-            // `/~<mount>/@scope/<pkg>` — scoped packument through a mount.
+            // `/~<name>/@scope/<pkg>` — scoped packument through a registry.
             let full = format!("{second}/{third}");
             return private_no_cache(
-                serve_mount_packument(&state, &identity, &headers, mount, &full, &base).await,
+                serve_registry_packument(&state, &identity, &headers, registry, &full, &base).await,
             );
         }
-        // `/~<mount>/<pkg>/<version-or-tag>` — unscoped version manifest
-        // through a mount endpoint. (The unscoped tarball shape
-        // `/~<mount>/<pkg>/-/<file>` is a distinct literal-`-` route.)
+        // `/~<name>/<pkg>/<version-or-tag>` — unscoped version manifest
+        // through a registry endpoint. (The unscoped tarball shape
+        // `/~<name>/<pkg>/-/<file>` is a distinct literal-`-` route.)
         return private_no_cache(
-            serve_mount_version_manifest(&state, &identity, mount, &second, &third, &base).await,
+            serve_registry_version_manifest(&state, &identity, registry, &second, &third, &base)
+                .await,
         );
     }
     if second == "-" {
@@ -690,10 +693,10 @@ async fn get_tarball_scoped(
     AuthedCaller(identity): AuthedCaller,
     Path((scope, name, filename)): Path<(String, String, String)>,
 ) -> Response {
-    // `/~<mount>/<pkg>/-/<file>` — unscoped tarball through a mount endpoint.
-    if let Some(mount) = scope.strip_prefix('~').filter(|mount| !mount.is_empty()) {
+    // `/~<name>/<pkg>/-/<file>` — unscoped tarball through a registry endpoint.
+    if let Some(registry) = scope.strip_prefix('~').filter(|registry| !registry.is_empty()) {
         return private_no_cache(
-            serve_mount_tarball(&state, &identity, mount, &name, &filename).await,
+            serve_registry_tarball(&state, &identity, registry, &name, &filename).await,
         );
     }
     if !scope.starts_with('@') {
@@ -705,9 +708,9 @@ async fn get_tarball_scoped(
 
 /// 4-segment GET:
 /// * `/-/package/{pkg}/dist-tags` — packument's `dist-tags` object.
-/// * `/~<mount>/-/v1/search` — search through a mount endpoint.
-/// * `/~<mount>/@scope/{pkg}/{version}` — scoped version manifest through a
-///   mount endpoint.
+/// * `/~<name>/-/v1/search` — search through a registry endpoint.
+/// * `/~<name>/@scope/{pkg}/{version}` — scoped version manifest through a
+///   registry endpoint.
 async fn get_four_segments(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
@@ -718,16 +721,17 @@ async fn get_four_segments(
         let response = get_dist_tags(&state, &identity, None, &c).await;
         return private_if_caller_gated(&state, &c, response);
     }
-    if let Some(mount) = a.strip_prefix('~').filter(|mount| !mount.is_empty()) {
+    if let Some(registry) = a.strip_prefix('~').filter(|registry| !registry.is_empty()) {
         if b == "-" && c == "v1" && d == "search" {
             let query = uri.query().unwrap_or("");
-            return private_no_cache(serve_search(&state, &identity, Some(mount), query).await);
+            return private_no_cache(serve_search(&state, &identity, Some(registry), query).await);
         }
         if b.starts_with('@') && !b.contains('/') {
             let full = format!("{b}/{c}");
-            let base = uplink_tarball_base(&state.inner.config.public_url, mount);
+            let base = uplink_tarball_base(&state.inner.config.public_url, registry);
             return private_no_cache(
-                serve_mount_version_manifest(&state, &identity, mount, &full, &d, &base).await,
+                serve_registry_version_manifest(&state, &identity, registry, &full, &d, &base)
+                    .await,
             );
         }
     }
@@ -735,9 +739,9 @@ async fn get_four_segments(
 }
 
 /// 5-segment GET:
-/// * `/~<mount>/@scope/<pkg>/-/<file>` — scoped tarball through a mount
+/// * `/~<name>/@scope/<pkg>/-/<file>` — scoped tarball through a registry
 ///   endpoint.
-/// * `/~<mount>/-/package/<pkg>/dist-tags` — dist-tags through a mount
+/// * `/~<name>/-/package/<pkg>/dist-tags` — dist-tags through a registry
 ///   endpoint.
 ///
 /// Every other 5-segment GET is a not-found catchall (the route exists so
@@ -747,15 +751,15 @@ async fn get_five_segments(
     AuthedCaller(identity): AuthedCaller,
     Path((a, b, c, d, e)): Path<(String, String, String, String, String)>,
 ) -> Response {
-    if let Some(mount) = a.strip_prefix('~').filter(|mount| !mount.is_empty()) {
+    if let Some(registry) = a.strip_prefix('~').filter(|registry| !registry.is_empty()) {
         if b.starts_with('@') && d == "-" {
             let full = format!("{b}/{c}");
             return private_no_cache(
-                serve_mount_tarball(&state, &identity, mount, &full, &e).await,
+                serve_registry_tarball(&state, &identity, registry, &full, &e).await,
             );
         }
         if b == "-" && c == "package" && e == "dist-tags" {
-            return private_no_cache(get_dist_tags(&state, &identity, Some(mount), &d).await);
+            return private_no_cache(get_dist_tags(&state, &identity, Some(registry), &d).await);
         }
     }
     not_found()
@@ -776,8 +780,8 @@ async fn put_one_segment(
 }
 
 /// `PUT /{first}/{second}` — publish a scoped package
-/// (`/@scope/name`), or an unscoped package through a mount endpoint
-/// (`/~<mount>/<pkg>`). The `/-/package/{pkg}` shape never lands here
+/// (`/@scope/name`), or an unscoped package through a registry endpoint
+/// (`/~<name>/<pkg>`). The `/-/package/{pkg}` shape never lands here
 /// because that's at least 4 segments.
 async fn put_two_segments(
     State(state): State<AppState>,
@@ -785,9 +789,9 @@ async fn put_two_segments(
     Path((first, second)): Path<(String, String)>,
     body: axum::body::Bytes,
 ) -> Response {
-    // `PUT /~<mount>/<pkg>` — publish an unscoped package through a mount.
-    if let Some(mount) = first.strip_prefix('~').filter(|mount| !mount.is_empty()) {
-        return publish_package(&state, &identity, Some(mount), &second, body).await;
+    // `PUT /~<name>/<pkg>` — publish an unscoped package through a registry.
+    if let Some(registry) = first.strip_prefix('~').filter(|registry| !registry.is_empty()) {
+        return publish_package(&state, &identity, Some(registry), &second, body).await;
     }
     if first.starts_with('@') {
         let full = format!("{first}/{second}");
@@ -803,12 +807,12 @@ async fn put_three_segments(
     Path((first, second, third)): Path<(String, String, String)>,
     body: axum::body::Bytes,
 ) -> Response {
-    // `PUT /~<mount>/@scope/<pkg>` — publish a scoped package through a mount.
-    if let Some(mount) = first.strip_prefix('~').filter(|mount| !mount.is_empty())
+    // `PUT /~<name>/@scope/<pkg>` — publish a scoped package through a registry.
+    if let Some(registry) = first.strip_prefix('~').filter(|registry| !registry.is_empty())
         && second.starts_with('@')
     {
         let full = format!("{second}/{third}");
-        return publish_package(&state, &identity, Some(mount), &full, body).await;
+        return publish_package(&state, &identity, Some(registry), &full, body).await;
     }
     if second == "-rev" {
         // `third` is the opaque revision token the client sent back.
@@ -821,8 +825,8 @@ async fn put_three_segments(
 }
 
 /// 4-segment PUT:
-/// * `/~<mount>/{pkg}/-rev/{rev}` — packument update (partial unpublish)
-///   through a mount endpoint. Scoped packages arrive percent-encoded as a
+/// * `/~<name>/{pkg}/-rev/{rev}` — packument update (partial unpublish)
+///   through a registry endpoint. Scoped packages arrive percent-encoded as a
 ///   single `@scope%2Fname` segment, like the path-less 3-segment form.
 async fn put_four_segments(
     State(state): State<AppState>,
@@ -830,11 +834,11 @@ async fn put_four_segments(
     Path((a, b, c, d)): Path<(String, String, String, String)>,
     body: axum::body::Bytes,
 ) -> Response {
-    if let Some(mount) = a.strip_prefix('~').filter(|mount| !mount.is_empty())
+    if let Some(registry) = a.strip_prefix('~').filter(|registry| !registry.is_empty())
         && c == "-rev"
     {
         let _ = d; // revision token is unused
-        return update_packument(&state, &identity, Some(mount), &b, &body).await;
+        return update_packument(&state, &identity, Some(registry), &b, &body).await;
     }
     not_found()
 }
@@ -868,38 +872,38 @@ async fn put_five_segments(
     not_found()
 }
 
-/// `PUT /~<mount>/-/package/{pkg}/dist-tags/{tag}` — add/update a dist-tag
-/// through a mount endpoint.
+/// `PUT /~<name>/-/package/{pkg}/dist-tags/{tag}` — add/update a dist-tag
+/// through a registry endpoint.
 async fn put_six_segments(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
     Path((a, b, c, d, e, f)): Path<(String, String, String, String, String, String)>,
     body: axum::body::Bytes,
 ) -> Response {
-    if let Some(mount) = a.strip_prefix('~').filter(|mount| !mount.is_empty())
+    if let Some(registry) = a.strip_prefix('~').filter(|registry| !registry.is_empty())
         && b == "-"
         && c == "package"
         && e == "dist-tags"
     {
-        return set_dist_tag(&state, &identity, Some(mount), &d, &f, &body).await;
+        return set_dist_tag(&state, &identity, Some(registry), &d, &f, &body).await;
     }
     not_found()
 }
 
 /// 4-segment DELETE:
-/// * `/~<mount>/{pkg}/-rev/{rev}` — remove the entire package through a
-///   mount endpoint (scoped packages arrive percent-encoded as one
+/// * `/~<name>/{pkg}/-rev/{rev}` — remove the entire package through a
+///   registry endpoint (scoped packages arrive percent-encoded as one
 ///   `@scope%2Fname` segment).
 async fn delete_four_segments(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
     Path((a, b, c, d)): Path<(String, String, String, String)>,
 ) -> Response {
-    if let Some(mount) = a.strip_prefix('~').filter(|mount| !mount.is_empty())
+    if let Some(registry) = a.strip_prefix('~').filter(|registry| !registry.is_empty())
         && c == "-rev"
     {
         let _ = d; // revision token is unused
-        return delete_package(&state, &identity, Some(mount), &b).await;
+        return delete_package(&state, &identity, Some(registry), &b).await;
     }
     not_found()
 }
@@ -930,10 +934,10 @@ async fn delete_five_segments(
 ///   form (`http://host/@scope/name/-/name-1.0.0.tgz`), so the
 ///   request lands here unencoded rather than as a 5-seg
 ///   `@scope%2Fname` URL.
-/// * `/~<mount>/-/package/{pkg}/dist-tags/{tag}` — remove a dist-tag
-///   through a mount endpoint.
-/// * `/~<mount>/{pkg}/-/{filename}/-rev/{rev}` — remove an unscoped
-///   tarball through a mount endpoint.
+/// * `/~<name>/-/package/{pkg}/dist-tags/{tag}` — remove a dist-tag
+///   through a registry endpoint.
+/// * `/~<name>/{pkg}/-/{filename}/-rev/{rev}` — remove an unscoped
+///   tarball through a registry endpoint.
 async fn delete_six_segments(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
@@ -944,35 +948,35 @@ async fn delete_six_segments(
         let full = format!("{a}/{b}");
         return delete_tarball(&state, &identity, None, &full, &d).await;
     }
-    if let Some(mount) = a.strip_prefix('~').filter(|mount| !mount.is_empty()) {
+    if let Some(registry) = a.strip_prefix('~').filter(|registry| !registry.is_empty()) {
         if b == "-" && c == "package" && e == "dist-tags" {
-            return remove_dist_tag(&state, &identity, Some(mount), &d, &f).await;
+            return remove_dist_tag(&state, &identity, Some(registry), &d, &f).await;
         }
         if c == "-" && e == "-rev" {
             let _ = f; // revision token is unused
-            return delete_tarball(&state, &identity, Some(mount), &b, &d).await;
+            return delete_tarball(&state, &identity, Some(registry), &b, &d).await;
         }
     }
     not_found()
 }
 
 /// 7-segment DELETE:
-/// * `/~<mount>/{scope}/{name}/-/{filename}/-rev/{rev}` — remove a scoped
-///   tarball through a mount endpoint (the unencoded literal-slash form the
+/// * `/~<name>/{scope}/{name}/-/{filename}/-rev/{rev}` — remove a scoped
+///   tarball through a registry endpoint (the unencoded literal-slash form the
 ///   pnpm unpublish flow reconstructs from the packument's tarball URL).
 async fn delete_seven_segments(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
     Path((a, b, c, d, e, f, g)): Path<(String, String, String, String, String, String, String)>,
 ) -> Response {
-    if let Some(mount) = a.strip_prefix('~').filter(|mount| !mount.is_empty())
+    if let Some(registry) = a.strip_prefix('~').filter(|registry| !registry.is_empty())
         && b.starts_with('@')
         && d == "-"
         && f == "-rev"
     {
         let _ = g; // revision token is unused
         let full = format!("{b}/{c}");
-        return delete_tarball(&state, &identity, Some(mount), &full, &e).await;
+        return delete_tarball(&state, &identity, Some(registry), &full, &e).await;
     }
     not_found()
 }
@@ -1111,15 +1115,15 @@ async fn serve_packument(
     headers: &HeaderMap,
     raw_name: &str,
 ) -> Response {
-    // The path-less base is an alias for the default-target mount: every
-    // request routes through the mount graph (authoritatively, no
+    // The path-less base is an alias for the default-target registry: every
+    // request routes through the registry graph (authoritatively, no
     // fall-through). With no default target the bare host has no registry.
-    match default_target_mount(state) {
+    match default_registry_target(state) {
         Some(target) => {
             // The path-less base: tarball URLs stay canonical for the bare host.
             let base = state.inner.config.public_url.clone();
             let response =
-                serve_mount_packument(state, identity, headers, &target, raw_name, &base).await;
+                serve_registry_packument(state, identity, headers, &target, raw_name, &base).await;
             private_if_caller_gated(state, raw_name, response)
         }
         None => not_found(),
@@ -1132,10 +1136,10 @@ async fn serve_version_manifest(
     raw_name: &str,
     version_or_tag: &str,
 ) -> Response {
-    match default_target_mount(state) {
+    match default_registry_target(state) {
         Some(target) => {
             let base = state.inner.config.public_url.clone();
-            let response = serve_mount_version_manifest(
+            let response = serve_registry_version_manifest(
                 state,
                 identity,
                 &target,
@@ -1151,13 +1155,13 @@ async fn serve_version_manifest(
 }
 
 /// Serve a single version's manifest (`GET <base>/<pkg>/<version-or-tag>`)
-/// through the mount graph. Resolves the package to its one concrete origin,
+/// through the registry graph. Resolves the package to its one concrete origin,
 /// loads that origin's packument, and extracts the requested version with its
 /// `dist.tarball` rewritten onto the same origin's base.
-async fn serve_mount_version_manifest(
+async fn serve_registry_version_manifest(
     state: &AppState,
     identity: &Identity,
-    mount: &str,
+    registry: &str,
     raw_name: &str,
     version_or_tag: &str,
     tarball_base: &str,
@@ -1166,9 +1170,9 @@ async fn serve_mount_version_manifest(
         Ok(n) => n,
         Err(err) => return error_response(&err),
     };
-    let bytes = match resolve_mount_source(state, mount, name.as_str()) {
-        MountSource::Upstream(source) => {
-            // Per-package ACL before serving — see `serve_mount_packument`.
+    let bytes = match resolve_registry_source(state, registry, name.as_str()) {
+        RegistrySource::Upstream(source) => {
+            // Per-package ACL before serving — see `serve_registry_packument`.
             if let Err(err) = authorize(state, identity, name.as_str(), Action::Access) {
                 return error_response(&err);
             }
@@ -1178,9 +1182,9 @@ async fn serve_mount_version_manifest(
                 Err(response) => return *response,
             }
         }
-        MountSource::Hosted(source) => {
+        RegistrySource::Hosted(source) => {
             // Mask first: a private org 404s an unauthorized caller before the
-            // per-package ACL could reveal existence — see `serve_mount_packument`.
+            // per-package ACL could reveal existence — see `serve_registry_packument`.
             let Some(org) = accessible_hosted_namespace(state, identity, &source) else {
                 return not_found();
             };
@@ -1193,7 +1197,7 @@ async fn serve_mount_version_manifest(
                 Err(err) => return error_response(&err),
             }
         }
-        MountSource::Unclaimed | MountSource::NotFound => return not_found(),
+        RegistrySource::Unclaimed | RegistrySource::NotFound => return not_found(),
     };
     let packument: Value = match serde_json::from_slice(&bytes) {
         Ok(v) => v,
@@ -1238,8 +1242,8 @@ fn authorized_uplink<'a>(
     let Some(config) = state.inner.config.uplinks.get(uplink) else {
         return Err(Box::new(not_found()));
     };
-    // A private upstream mount gates by its `access:` list; a public mount
-    // (no access) is reachable by anyone at its `/~<mount>/` URL, its upstream
+    // A private upstream registry gates by its `access:` list; a public registry
+    // (no access) is reachable by anyone at its `/~<name>/` URL, its upstream
     // credential (if any) staying server-side either way.
     if let Some(access) = config.access.as_ref()
         && !access.allows(identity)
@@ -1255,10 +1259,10 @@ fn authorized_uplink<'a>(
     state.inner.upstreams.get(uplink).ok_or_else(|| Box::new(not_found()))
 }
 
-/// The disposable cache namespace for an upstream mount's `/~<mount>/` route —
+/// The disposable cache namespace for an upstream registry's `/~<name>/` route —
 /// the entry precomputed in [`AppInner::uplink_cache_namespaces`], falling back
 /// to a fresh computation only for a name outside [`Config::uplinks`] (which
-/// the mount dispatch never produces).
+/// the registry dispatch never produces).
 fn uplink_cache_namespace(state: &AppState, uplink: &str) -> String {
     state
         .inner
@@ -1268,26 +1272,26 @@ fn uplink_cache_namespace(state: &AppState, uplink: &str) -> String {
         .unwrap_or_else(|| compute_uplink_cache_namespace(&state.inner.config, uplink))
 }
 
-/// Compute an upstream mount's disposable cache namespace, so its packuments
-/// and tarballs never collide with another mount's.
+/// Compute an upstream registry's disposable cache namespace, so its packuments
+/// and tarballs never collide with another registry's.
 ///
-/// Both shapes fold in the mount's upstream **URL**: the cache is a mirror of
-/// one declared origin, so repointing a mount's `url:` moves to a fresh
+/// Both shapes fold in the registry's upstream **URL**: the cache is a mirror of
+/// one declared origin, so repointing a registry's `url:` moves to a fresh
 /// namespace and bytes fetched from the previous origin can never answer for
 /// the new one. The cache-first warm tarball path depends on this — it serves
 /// a cached entry without re-binding it against the current packument.
 ///
-/// A **private** mount — any that declares `access:` (so it is not `public`; the
-/// config loader forbids a public mount from carrying any credential) — is
-/// namespaced by an HMAC over `(mount, url, credential)` keyed with
-/// the server secret: the on-disk path leaks neither the mount name nor the
+/// A **private** registry — any that declares `access:` (so it is not `public`; the
+/// config loader forbids a public registry from carrying any credential) — is
+/// namespaced by an HMAC over `(registry, url, credential)` keyed with
+/// the server secret: the on-disk path leaks neither the registry name nor the
 /// credential, and a credential rotation moves to a fresh namespace. Keying on
 /// the declared visibility rather than on the presence of an `Authorization`
-/// header keeps a mount whose credential rides a *custom* header (or which
+/// header keeps a registry whose credential rides a *custom* header (or which
 /// gates access without an upstream credential) out of the guessable public
-/// namespace. A **public** mount has nothing private to protect and its content
+/// namespace. A **public** registry has nothing private to protect and its content
 /// is integrity-verified, so it uses a *stable* namespace
-/// (`~public/<digest-of-mount-name-and-url>`) that is shared across process
+/// (`~public/<digest-of-registry-name-and-url>`) that is shared across process
 /// restarts.
 fn compute_uplink_cache_namespace(config: &Config, uplink: &str) -> String {
     let url = config.uplinks.get(uplink).map_or("", |uplink_config| uplink_config.url.as_str());
@@ -1307,7 +1311,7 @@ fn compute_uplink_cache_namespace(config: &Config, uplink: &str) -> String {
             crate::route::uplink_cache_digest(uplink, epoch, &config.resolution_cache_secret);
         return format!("~uplinks/{digest}");
     }
-    // Public mount: a stable, secret-free namespace keyed by the mount name
+    // Public registry: a stable, secret-free namespace keyed by the registry name
     // and its origin URL (hashed so a path-unsafe value can't escape the
     // cache root).
     format!("~public/{}", crate::route::credential_digest(&format!("{uplink}\0{url}")))
@@ -1337,9 +1341,9 @@ async fn timed<Fut: Future>(phase: &'static str, package: &str, fut: Fut) -> Fut
     out
 }
 
-/// Load an uplink route's packument: a fresh per-mount cache entry when one
-/// exists, otherwise a fetch through the mount (with its server-side credential)
-/// written back to the same namespace. A mount with `cache: false` neither reads
+/// Load an uplink route's packument: a fresh per-registry cache entry when one
+/// exists, otherwise a fetch through the registry (with its server-side credential)
+/// written back to the same namespace. A registry with `cache: false` neither reads
 /// nor writes the cache — it streams everything through, refetching each time.
 async fn load_uplink_packument(
     state: &AppState,
@@ -1370,7 +1374,7 @@ async fn load_uplink_packument(
         // unreachable, serve the last cached body for this same origin rather
         // than failing. This preserves availability during a transient outage
         // and is not a cross-origin fall-through — the bytes came from this very
-        // mount. A clean `NotFound` is an `Ok` variant below, so it never lands
+        // registry. A clean `NotFound` is an `Ok` variant below, so it never lands
         // here and stays an authoritative 404.
         Err(err) => {
             // Only mask a *transient* availability failure (transport, 5xx, open
@@ -1436,8 +1440,8 @@ async fn load_uplink_packument(
     }
 }
 
-/// Authorize and load an upstream mount's packument bytes (from its per-mount
-/// private cache, else a fresh fetch through the mount), or a [`Response`]
+/// Authorize and load an upstream registry's packument bytes (from its per-registry
+/// private cache, else a fresh fetch through the registry), or a [`Response`]
 /// error the caller should return. Shared by the packument and version-manifest
 /// serving paths.
 async fn load_upstream_packument_for(
@@ -1454,8 +1458,8 @@ async fn load_upstream_packument_for(
         .map_err(|err| Box::new(error_response(&err)))
 }
 
-/// Load a package's packument bytes through the addressed `/~<mount>/` (or,
-/// path-less, the default-target mount) — resolving to one concrete origin and
+/// Load a package's packument bytes through the addressed `/~<name>/` (or,
+/// path-less, the default-target registry) — resolving to one concrete origin and
 /// reading there, with no fall-through. `Ok(None)` is a definitive not-found
 /// (unknown package, no route, no default target, or an unauthorized private
 /// hosted org). Used by the readers that aren't
@@ -1463,29 +1467,29 @@ async fn load_upstream_packument_for(
 async fn load_packument_for_read(
     state: &AppState,
     identity: &Identity,
-    mount: Option<&str>,
+    registry: Option<&str>,
     name: &PackageName,
 ) -> Result<Option<Vec<u8>>, Box<Response>> {
-    let target = match mount {
-        Some(mount) => mount.to_string(),
-        None => match default_target_mount(state) {
+    let target = match registry {
+        Some(registry) => registry.to_string(),
+        None => match default_registry_target(state) {
             Some(target) => target,
             None => return Ok(None),
         },
     };
-    // The per-package access ACL applies to every mount-served read, upstream or
+    // The per-package access ACL applies to every registry-served read, upstream or
     // hosted — otherwise a restricted package would leak (e.g. its dist-tags)
     // through these path-less readers. It runs *after* the hosted-org visibility
     // gate, though, so a private org still 404-masks an unauthorized caller
-    // rather than revealing existence via a 401/403 (see `serve_mount_packument`).
-    match resolve_mount_source(state, &target, name.as_str()) {
-        MountSource::Upstream(source) => {
+    // rather than revealing existence via a 401/403 (see `serve_registry_packument`).
+    match resolve_registry_source(state, &target, name.as_str()) {
+        RegistrySource::Upstream(source) => {
             if let Err(err) = authorize(state, identity, name.as_str(), Action::Access) {
                 return Err(Box::new(error_response(&err)));
             }
             load_upstream_packument_for(state, identity, &source, name).await
         }
-        MountSource::Hosted(source) => {
+        RegistrySource::Hosted(source) => {
             let Some(org) = accessible_hosted_namespace(state, identity, &source) else {
                 return Ok(None);
             };
@@ -1500,7 +1504,7 @@ async fn load_packument_for_read(
                 .await
                 .map_err(|err| Box::new(error_response(&err)))
         }
-        MountSource::Unclaimed | MountSource::NotFound => Ok(None),
+        RegistrySource::Unclaimed | RegistrySource::NotFound => Ok(None),
     }
 }
 
@@ -1699,10 +1703,10 @@ async fn cached_uplink_tarball(
 }
 
 // --------------------------------------------------------------------
-// Registry-mount dispatch. A `/~<mount>/` request resolves the package to
-// exactly one concrete origin through the validated mount graph
-// ([`crate::mount`]) and serves it there — authoritatively. Every concrete
-// mount's declared `patterns:` are enforced here, before storage or any
+// Registry dispatch. A `/~<name>/` request resolves the package to
+// exactly one concrete origin through the validated registry graph
+// ([`crate::registry`]) and serves it there — authoritatively. Every concrete
+// registry's declared `patterns:` are enforced here, before storage or any
 // upstream is consulted, on the direct address and through a router alike; a
 // router selects the first source whose patterns claim the name. An unclaimed
 // name is a definitive 404 (never a fall-through to another origin), and a
@@ -1712,73 +1716,73 @@ async fn cached_uplink_tarball(
 // one layer out.
 // --------------------------------------------------------------------
 
-/// The concrete origin a `/~<mount>/` request resolved to, owned so it can be
+/// The concrete origin a `/~<name>/` request resolved to, owned so it can be
 /// held across an `await` without borrowing the config.
-enum MountSource {
-    /// An upstream mount (public or private), served via its `/~<source>/`
+enum RegistrySource {
+    /// An upstream registry (public or private), served via its `/~<source>/`
     /// uplink machinery. The id is a key in [`Config::uplinks`].
     Upstream(String),
-    /// A hosted mount, served from the hosted store.
+    /// A hosted registry, served from the hosted store.
     Hosted(String),
-    /// No declared namespace claims the package — the addressed mount's
+    /// No declared namespace claims the package — the addressed registry's
     /// patterns don't cover it, or none of a router's sources claim it. A
     /// definitive 404 on reads; writes reject it with a reason instead, so a
     /// typo'd scope fails loudly rather than 404-ing later.
     Unclaimed,
-    /// The mount id is unknown — a definitive not-found with no fall-through.
+    /// The registry id is unknown — a definitive not-found with no fall-through.
     NotFound,
 }
 
-/// The mount the path-less base (`https://<pnpr>/`) aliases, owned so it can be
+/// The registry the path-less base (`https://<pnpr>/`) aliases, owned so it can be
 /// held across an `await`. `None` disables the path-less base entirely — the
 /// bare host has no registry and every request is a not-found, so clients must
-/// address a `/~<mount>/`. There is no legacy hosted-then-proxy path: a
-/// path-less request resolves through the mount graph or it does not resolve.
-fn default_target_mount(state: &AppState) -> Option<String> {
-    state.inner.config.mounts.default_target().map(str::to_string)
+/// address a `/~<name>/`. There is no legacy hosted-then-proxy path: a
+/// path-less request resolves through the registry graph or it does not resolve.
+fn default_registry_target(state: &AppState) -> Option<String> {
+    state.inner.config.registries.default_registry().map(str::to_string)
 }
 
-fn resolve_mount_source(state: &AppState, mount: &str, package: &str) -> MountSource {
-    match state.inner.config.mounts.resolve(mount, package) {
-        Resolved::Concrete { mount, kind: ConcreteKind::Upstream } => {
-            MountSource::Upstream(mount.to_string())
+fn resolve_registry_source(state: &AppState, registry: &str, package: &str) -> RegistrySource {
+    match state.inner.config.registries.resolve(registry, package) {
+        Resolved::Concrete { registry, kind: ConcreteKind::Upstream } => {
+            RegistrySource::Upstream(registry.to_string())
         }
-        Resolved::Concrete { mount, kind: ConcreteKind::Hosted } => {
-            MountSource::Hosted(mount.to_string())
+        Resolved::Concrete { registry, kind: ConcreteKind::Hosted } => {
+            RegistrySource::Hosted(registry.to_string())
         }
         // An unclaimed name is definitive — never a fall-through to another
         // origin, and never a storage or upstream consultation.
-        Resolved::Unclaimed => MountSource::Unclaimed,
-        // Every configured uplink is an upstream mount addressable at
+        Resolved::Unclaimed => RegistrySource::Unclaimed,
+        // Every configured uplink is an upstream registry addressable at
         // `/~<uplink>/`, even one inserted programmatically without rebuilding
-        // the mount graph; fall back to that before declaring not-found.
-        Resolved::UnknownMount => {
-            if state.inner.config.uplinks.contains_key(mount) {
-                MountSource::Upstream(mount.to_string())
+        // the registry graph; fall back to that before declaring not-found.
+        Resolved::UnknownRegistry => {
+            if state.inner.config.uplinks.contains_key(registry) {
+                RegistrySource::Upstream(registry.to_string())
             } else {
-                MountSource::NotFound
+                RegistrySource::NotFound
             }
         }
     }
 }
 
-/// Whether the concrete origin `package` resolves to through `mount` serves
-/// caller-gated content: a hosted mount whose access list denies anonymous
-/// callers, or an upstream mount that declares `access:`. Responses from such
+/// Whether the concrete origin `package` resolves to through `registry` serves
+/// caller-gated content: a hosted registry whose access list denies anonymous
+/// callers, or an upstream registry that declares `access:`. Responses from such
 /// an origin vary by `Authorization` and must never land in a shared HTTP
-/// cache, whichever URL surface (path-less or `/~<mount>/`) served them.
-fn resolves_to_private_source(state: &AppState, mount: &str, package: &str) -> bool {
-    match resolve_mount_source(state, mount, package) {
-        MountSource::Hosted(source) => state
+/// cache, whichever URL surface (path-less or `/~<name>/`) served them.
+fn resolves_to_private_source(state: &AppState, registry: &str, package: &str) -> bool {
+    match resolve_registry_source(state, registry, package) {
+        RegistrySource::Hosted(source) => state
             .inner
             .config
             .hosted
             .get(&source)
             .is_some_and(|hosted| !hosted.access.allows(&Identity::Anonymous)),
-        MountSource::Upstream(source) => {
+        RegistrySource::Upstream(source) => {
             state.inner.config.uplinks.get(&source).is_some_and(|uplink| uplink.access.is_some())
         }
-        MountSource::Unclaimed | MountSource::NotFound => false,
+        RegistrySource::Unclaimed | RegistrySource::NotFound => false,
     }
 }
 
@@ -1786,7 +1790,7 @@ fn resolves_to_private_source(state: &AppState, mount: &str, package: &str) -> b
 /// vary by caller — the default-target resolution for `package` lands on a
 /// private source, or the per-package ACL denies anonymous access (so the
 /// same URL answers 200 or 403 depending on `Authorization`, even through a
-/// public mount). These are the same headers the `/~<mount>/` surface applies
+/// public registry). These are the same headers the `/~<name>/` surface applies
 /// unconditionally, so the two URL surfaces for the same content get the same
 /// defense against a shared HTTP cache replaying an authenticated response to
 /// an anonymous caller. A publicly-readable resolution stays cacheable: the
@@ -1797,7 +1801,7 @@ fn private_if_caller_gated(state: &AppState, package: &str, response: Response) 
     if acl_gated {
         return private_no_cache(response);
     }
-    match default_target_mount(state) {
+    match default_registry_target(state) {
         Some(target) if resolves_to_private_source(state, &target, package) => {
             private_no_cache(response)
         }
@@ -1805,12 +1809,12 @@ fn private_if_caller_gated(state: &AppState, package: &str, response: Response) 
     }
 }
 
-/// Serve a packument addressed to `/~<mount>/<pkg>` through the mount graph.
-async fn serve_mount_packument(
+/// Serve a packument addressed to `/~<name>/<pkg>` through the registry graph.
+async fn serve_registry_packument(
     state: &AppState,
     identity: &Identity,
     headers: &HeaderMap,
-    mount: &str,
+    registry: &str,
     raw_name: &str,
     tarball_base: &str,
 ) -> Response {
@@ -1819,13 +1823,13 @@ async fn serve_mount_packument(
         Err(err) => return error_response(&err),
     };
     // `tarball_base` is the URL the *client* addressed (the path-less host or a
-    // `/~<mount>/`), not the resolved source's `/~<source>/`. The served
+    // `/~<name>/`), not the resolved source's `/~<source>/`. The served
     // packument's `dist.tarball` URLs must stay canonical for that base so a
     // client's lockfile drops them — persisting the resolved source path would
-    // bake the mount name in and break lockfile portability.
-    match resolve_mount_source(state, mount, name.as_str()) {
-        MountSource::Upstream(source) => {
-            // The per-package access ACL applies to every mount-served read, so
+    // bake the registry name in and break lockfile portability.
+    match resolve_registry_source(state, registry, name.as_str()) {
+        RegistrySource::Upstream(source) => {
+            // The per-package access ACL applies to every registry-served read, so
             // an access-gated name can't be read through a public upstream.
             // Checked before serving so the decision precedes any
             // existence-revealing signal like an OSV 403.
@@ -1834,24 +1838,24 @@ async fn serve_mount_packument(
             }
             serve_packument_via_uplink(state, identity, headers, &source, &name, tarball_base).await
         }
-        // A hosted mount masks first: a private org 404s an unauthorized caller
+        // A hosted registry masks first: a private org 404s an unauthorized caller
         // (see `accessible_hosted_namespace`) *before* the per-package ACL could
         // return a 401/403 that reveals the package exists — the ACL is applied
         // inside `serve_hosted_packument` only after the visibility gate passes.
-        MountSource::Hosted(source) => {
+        RegistrySource::Hosted(source) => {
             serve_hosted_packument(state, identity, headers, &source, &name, tarball_base).await
         }
-        MountSource::Unclaimed | MountSource::NotFound => not_found(),
+        RegistrySource::Unclaimed | RegistrySource::NotFound => not_found(),
     }
 }
 
-/// Serve a tarball addressed to `/~<mount>/<pkg>/-/<file>` through the mount
+/// Serve a tarball addressed to `/~<name>/<pkg>/-/<file>` through the registry
 /// graph. Routing is deterministic by package name, so the tarball resolves to
 /// the same concrete source the packument did.
-async fn serve_mount_tarball(
+async fn serve_registry_tarball(
     state: &AppState,
     identity: &Identity,
-    mount: &str,
+    registry: &str,
     raw_name: &str,
     filename: &str,
 ) -> Response {
@@ -1859,26 +1863,26 @@ async fn serve_mount_tarball(
         Ok(n) => n,
         Err(err) => return error_response(&err),
     };
-    match resolve_mount_source(state, mount, name.as_str()) {
-        MountSource::Upstream(source) => {
-            // Per-package ACL before serving — see `serve_mount_packument`.
+    match resolve_registry_source(state, registry, name.as_str()) {
+        RegistrySource::Upstream(source) => {
+            // Per-package ACL before serving — see `serve_registry_packument`.
             if let Err(err) = authorize(state, identity, name.as_str(), Action::Access) {
                 return error_response(&err);
             }
             serve_tarball_via_uplink(state, identity, &source, name.as_str(), filename).await
         }
         // Hosted masks first (private-org 404) then applies the ACL, inside
-        // `serve_hosted_tarball` — see `serve_mount_packument`.
-        MountSource::Hosted(source) => {
+        // `serve_hosted_tarball` — see `serve_registry_packument`.
+        RegistrySource::Hosted(source) => {
             serve_hosted_tarball(state, identity, &source, &name, filename).await
         }
-        MountSource::Unclaimed | MountSource::NotFound => not_found(),
+        RegistrySource::Unclaimed | RegistrySource::NotFound => not_found(),
     }
 }
 
-/// The storage namespace of the hosted mount `source` when `identity` may
-/// access it, else `None`. The mount's `access` list gates reads and writes
-/// alike — a caller who may not read a hosted mount may not publish, tag, or
+/// The storage namespace of the hosted registry `source` when `identity` may
+/// access it, else `None`. The registry's `access` list gates reads and writes
+/// alike — a caller who may not read a hosted registry may not publish, tag, or
 /// unpublish into it either. A denied caller is treated as not-found, so a
 /// private org's package existence is not revealed. The org policy composes
 /// (logical AND) with the per-package [`Config::policies`] applied by the
@@ -1965,11 +1969,12 @@ async fn serve_tarball(
     raw_name: &str,
     filename: &str,
 ) -> Response {
-    // The path-less base is an alias for the default-target mount — see
+    // The path-less base is an alias for the default-target registry — see
     // `serve_packument`. With no default target the bare host has no registry.
-    match default_target_mount(state) {
+    match default_registry_target(state) {
         Some(target) => {
-            let response = serve_mount_tarball(state, identity, &target, raw_name, filename).await;
+            let response =
+                serve_registry_tarball(state, identity, &target, raw_name, filename).await;
             private_if_caller_gated(state, raw_name, response)
         }
         None => not_found(),
@@ -2367,70 +2372,73 @@ fn hosted_storage(state: &AppState, org: Option<&str>) -> Storage {
     }
 }
 
-/// Where a publish of `package` writes, given an optional explicit `/~<mount>/`.
+/// Where a publish of `package` writes, given an optional explicit `/~<name>/`.
 enum PublishTarget {
     /// Write into this hosted storage namespace.
     Org(String),
     /// The resolved target is not a hosted org; reject with this reason.
     Reject(String),
-    /// The addressed mount or route does not exist (or the path-less base has
+    /// The addressed registry or route does not exist (or the path-less base has
     /// no default target).
     NotFound,
 }
 
-/// Resolve where a publish lands. A write may only target a hosted mount
+/// Resolve where a publish lands. A write may only target a hosted registry
 /// whose declared patterns claim the name: a selection of an upstream is
-/// rejected ("name a hosted mount"), never silently landing on an upstream,
+/// rejected ("name a hosted registry"), never silently landing on an upstream,
 /// and an unclaimed name is rejected with the reason — so a typo'd scope
-/// fails loudly at publish time instead of storing a name the mount's
-/// namespace can never serve. The mount's `access` list gates the write
-/// exactly as it gates reads — a caller the mount denies gets the same
-/// not-found mask as on a read, so a private mount neither accepts the write
+/// fails loudly at publish time instead of storing a name the registry's
+/// namespace can never serve. The registry's `access` list gates the write
+/// exactly as it gates reads — a caller the registry denies gets the same
+/// not-found mask as on a read, so a private registry neither accepts the write
 /// nor reveals that it exists. The path-less base routes through its
-/// default-target mount; with no default target the bare host has no registry
+/// default-target registry; with no default target the bare host has no registry
 /// and the publish is a not-found, exactly like a read.
 fn resolve_publish_target(
     state: &AppState,
     identity: &Identity,
-    mount: Option<&str>,
+    registry: Option<&str>,
     package: &str,
 ) -> PublishTarget {
-    let from_source = |source: MountSource, context: &str| match source {
-        MountSource::Hosted(mount) => match accessible_hosted_namespace(state, identity, &mount) {
-            Some(org) => PublishTarget::Org(org),
-            None => PublishTarget::NotFound,
-        },
-        MountSource::Upstream(_) => PublishTarget::Reject(format!(
+    let from_source = |source: RegistrySource, context: &str| match source {
+        RegistrySource::Hosted(registry) => {
+            match accessible_hosted_namespace(state, identity, &registry) {
+                Some(org) => PublishTarget::Org(org),
+                None => PublishTarget::NotFound,
+            }
+        }
+        RegistrySource::Upstream(_) => PublishTarget::Reject(format!(
             "cannot publish {package:?} {context}: it routes to an upstream registry; name a \
-             hosted mount",
+             hosted registry",
         )),
-        MountSource::Unclaimed => PublishTarget::Reject(format!(
-            "cannot publish {package:?} {context}: no mount's declared `patterns:` claim this \
+        RegistrySource::Unclaimed => PublishTarget::Reject(format!(
+            "cannot publish {package:?} {context}: no registry's declared `patterns:` claim this \
              package name",
         )),
-        MountSource::NotFound => PublishTarget::NotFound,
+        RegistrySource::NotFound => PublishTarget::NotFound,
     };
-    match mount {
-        Some(mount) => from_source(
-            resolve_mount_source(state, mount, package),
-            &format!("through mount {mount:?}"),
+    match registry {
+        Some(registry) => from_source(
+            resolve_registry_source(state, registry, package),
+            &format!("through registry {registry:?}"),
         ),
-        None => match default_target_mount(state) {
-            Some(target) => {
-                from_source(resolve_mount_source(state, &target, package), "to the path-less base")
-            }
+        None => match default_registry_target(state) {
+            Some(target) => from_source(
+                resolve_registry_source(state, &target, package),
+                "to the path-less base",
+            ),
             None => PublishTarget::NotFound,
         },
     }
 }
 
-/// `PUT /:pkg` (path-less) or `PUT /~<mount>/:pkg` — publish a new version (or
+/// `PUT /:pkg` (path-less) or `PUT /~<name>/:pkg` — publish a new version (or
 /// republish). Body is the full packument with `_attachments` carrying the
 /// tarball bytes base64-encoded.
 async fn publish_package(
     state: &AppState,
     identity: &Identity,
-    mount: Option<&str>,
+    registry: Option<&str>,
     raw_name: &str,
     body: axum::body::Bytes,
 ) -> Response {
@@ -2460,9 +2468,9 @@ async fn publish_package(
     }
 
     // Route the write to its hosted namespace (or the flat store), failing
-    // closed when the target is an upstream, an unknown mount, or a hosted
-    // mount whose access list denies the caller.
-    let org = match resolve_publish_target(state, identity, mount, name.as_str()) {
+    // closed when the target is an upstream, an unknown registry, or a hosted
+    // registry whose access list denies the caller.
+    let org = match resolve_publish_target(state, identity, registry, name.as_str()) {
         PublishTarget::Org(org) => Some(org),
         PublishTarget::Reject(reason) => {
             return error_response(&RegistryError::BadRequest { reason });
@@ -2739,7 +2747,7 @@ async fn stage_publish(
         }
     }
 
-    // A hosted mount has no upstream, so a publish seeds the merge only from
+    // A hosted registry has no upstream, so a publish seeds the merge only from
     // the org's own hosted packument; a brand-new package starts from `None`.
     let existing: Option<Value> = hosted.clone();
     let merged = merge_manifest(existing.as_ref(), &incoming, hosted.as_ref(), now_iso);
@@ -2884,13 +2892,13 @@ async fn cleanup_tmp_slots(slots: Vec<crate::storage::TarballSlot>) {
 /// proxy can't deliver because npm's search is fuzzy and returns
 /// dozens of unrelated matches for almost anything).
 ///
-/// Results are served through the mount graph and gated exactly like the
+/// Results are served through the registry graph and gated exactly like the
 /// packument and tarball GETs:
 ///
-/// * Only the hosted mounts the addressed registry serves are scanned (see
-///   [`hosted_search_sources`]), each gated by its **mount access list** — a
-///   caller a mount denies gets nothing from it, the same existence mask the
-///   read paths apply. Without this, search would enumerate a private mount's
+/// * Only the hosted registries the addressed registry serves are scanned (see
+///   [`hosted_search_sources`]), each gated by its **registry access list** — a
+///   caller a registry denies gets nothing from it, the same existence mask the
+///   read paths apply. Without this, search would enumerate a private registry's
 ///   packages by name/version/description while the packument GET correctly
 ///   404s.
 /// * Under a router, a name is kept only when the router actually **routes it
@@ -2904,7 +2912,7 @@ async fn cleanup_tmp_slots(slots: Vec<crate::storage::TarballSlot>) {
 async fn serve_search(
     state: &AppState,
     identity: &Identity,
-    mount: Option<&str>,
+    registry: Option<&str>,
     query_string: &str,
 ) -> Response {
     let result = |objects: Vec<Value>| {
@@ -2920,12 +2928,13 @@ async fn serve_search(
     let Some(text) = crate::search::parse_query(query_string) else {
         return result(Vec::new());
     };
-    let Some(mount) = mount.map(str::to_string).or_else(|| default_target_mount(state)) else {
+    let Some(registry) = registry.map(str::to_string).or_else(|| default_registry_target(state))
+    else {
         return result(Vec::new());
     };
     let size = crate::search::parse_size(query_string, 20);
     let mut objects: Vec<Value> = Vec::new();
-    for source in hosted_search_sources(state, &mount) {
+    for source in hosted_search_sources(state, &registry) {
         if objects.len() >= size {
             break;
         }
@@ -2937,8 +2946,8 @@ async fn serve_search(
         // synchronously against it inside the scan.
         let keep = |name: &str| {
             matches!(
-                resolve_mount_source(state, &mount, name),
-                MountSource::Hosted(resolved) if resolved == source,
+                resolve_registry_source(state, &registry, name),
+                RegistrySource::Hosted(resolved) if resolved == source,
             ) && authorize(state, identity, name, Action::Access).is_ok()
         };
         match crate::search::run_local_search(&storage, &text, size - objects.len(), keep).await {
@@ -2949,29 +2958,29 @@ async fn serve_search(
     result(objects)
 }
 
-/// The hosted mounts a search addressed to `mount` scans, in source order.
-/// A hosted mount scans itself; a router scans each of its hosted sources; an
-/// upstream mount scans nothing — search is local-only, never proxied (an
-/// upstream is reached only through its own mount, by exact package name;
+/// The hosted registries a search addressed to `registry` scans, in source order.
+/// A hosted registry scans itself; a router scans each of its hosted sources; an
+/// upstream registry scans nothing — search is local-only, never proxied (an
+/// upstream is reached only through its own registry, by exact package name;
 /// there is no cross-origin search merge).
-fn hosted_search_sources(state: &AppState, mount: &str) -> Vec<String> {
-    match state.inner.config.mounts.get(mount) {
-        Some(MountKind::Hosted { .. }) => vec![mount.to_string()],
-        Some(MountKind::Router { sources }) => sources
+fn hosted_search_sources(state: &AppState, registry: &str) -> Vec<String> {
+    match state.inner.config.registries.get(registry) {
+        Some(Registry::Hosted { .. }) => vec![registry.to_string()],
+        Some(Registry::Router { sources }) => sources
             .iter()
             .filter(|source| {
                 matches!(
-                    state.inner.config.mounts.get(source.as_str()),
-                    Some(MountKind::Hosted { .. }),
+                    state.inner.config.registries.get(source.as_str()),
+                    Some(Registry::Hosted { .. }),
                 )
             })
             .cloned()
             .collect(),
-        Some(MountKind::Upstream { .. }) | None => Vec::new(),
+        Some(Registry::Upstream { .. }) | None => Vec::new(),
     }
 }
 
-/// `PUT /:pkg/-rev/:rev` (path-less) or `PUT /~<mount>/:pkg/-rev/:rev` —
+/// `PUT /:pkg/-rev/:rev` (path-less) or `PUT /~<name>/:pkg/-rev/:rev` —
 /// overwrite the on-disk packument with the client-supplied body. pnpm uses
 /// this in the partial-unpublish flow: it fetches the packument, removes the
 /// unpublished version from `versions` / `dist-tags`, then PUTs the result
@@ -2983,7 +2992,7 @@ fn hosted_search_sources(state: &AppState, mount: &str) -> Vec<String> {
 async fn update_packument(
     state: &AppState,
     identity: &Identity,
-    mount: Option<&str>,
+    registry: Option<&str>,
     raw_name: &str,
     body: &[u8],
 ) -> Response {
@@ -2996,7 +3005,7 @@ async fn update_packument(
             return error_response(&err);
         }
     }
-    let org = match resolve_write_org(state, identity, mount, &name) {
+    let org = match resolve_write_org(state, identity, registry, &name) {
         Ok(org) => org,
         Err(response) => return *response,
     };
@@ -3198,13 +3207,13 @@ fn require_object_dist(manifest: &Value, version: &str) -> Option<RegistryError>
     })
 }
 
-/// `DELETE /:pkg/-rev/:rev` (path-less) or `DELETE /~<mount>/:pkg/-rev/:rev`
+/// `DELETE /:pkg/-rev/:rev` (path-less) or `DELETE /~<name>/:pkg/-rev/:rev`
 /// — remove the entire package directory, packument and all tarballs. Used
 /// by `pnpm unpublish --force`.
 async fn delete_package(
     state: &AppState,
     identity: &Identity,
-    mount: Option<&str>,
+    registry: Option<&str>,
     raw_name: &str,
 ) -> Response {
     let name = match PackageName::parse(raw_name) {
@@ -3214,7 +3223,7 @@ async fn delete_package(
     if let Err(err) = authorize(state, identity, name.as_str(), Action::Unpublish) {
         return error_response(&err);
     }
-    let org = match resolve_write_org(state, identity, mount, &name) {
+    let org = match resolve_write_org(state, identity, registry, &name) {
         Ok(org) => org,
         Err(response) => return *response,
     };
@@ -3241,7 +3250,7 @@ async fn delete_package(
 async fn delete_tarball(
     state: &AppState,
     identity: &Identity,
-    mount: Option<&str>,
+    registry: Option<&str>,
     raw_name: &str,
     filename: &str,
 ) -> Response {
@@ -3256,7 +3265,7 @@ async fn delete_tarball(
     if let Err(err) = authorize(state, identity, name.as_str(), Action::Unpublish) {
         return error_response(&err);
     }
-    let org = match resolve_write_org(state, identity, mount, &name) {
+    let org = match resolve_write_org(state, identity, registry, &name) {
         Ok(org) => org,
         Err(response) => return *response,
     };
@@ -3276,19 +3285,19 @@ async fn delete_tarball(
 }
 
 /// `GET /-/package/:pkg/dist-tags` (path-less) or
-/// `GET /~<mount>/-/package/:pkg/dist-tags` — return the packument's
+/// `GET /~<name>/-/package/:pkg/dist-tags` — return the packument's
 /// `dist-tags` object.
 async fn get_dist_tags(
     state: &AppState,
     identity: &Identity,
-    mount: Option<&str>,
+    registry: Option<&str>,
     raw_name: &str,
 ) -> Response {
     let name = match PackageName::parse(raw_name) {
         Ok(n) => n,
         Err(err) => return error_response(&err),
     };
-    let bytes = match load_packument_for_read(state, identity, mount, &name).await {
+    let bytes = match load_packument_for_read(state, identity, registry, &name).await {
         Ok(Some(bytes)) => bytes,
         Ok(None) => return not_found(),
         Err(response) => return *response,
@@ -3308,17 +3317,17 @@ async fn get_dist_tags(
 }
 
 /// `PUT /-/package/:pkg/dist-tags/:tag` (path-less) or
-/// `PUT /~<mount>/-/package/:pkg/dist-tags/:tag` — set a dist-tag. Body is
+/// `PUT /~<name>/-/package/:pkg/dist-tags/:tag` — set a dist-tag. Body is
 /// a JSON-encoded version string (e.g. `"1.0.0"`).
 async fn set_dist_tag(
     state: &AppState,
     identity: &Identity,
-    mount: Option<&str>,
+    registry: Option<&str>,
     raw_name: &str,
     tag: &str,
     body: &[u8],
 ) -> Response {
-    update_dist_tag(state, identity, mount, raw_name, tag, |tags| {
+    update_dist_tag(state, identity, registry, raw_name, tag, |tags| {
         let version: String = match serde_json::from_slice(body) {
             Ok(s) => s,
             Err(err) => return Err(RegistryError::Json(err)),
@@ -3332,11 +3341,11 @@ async fn set_dist_tag(
 async fn remove_dist_tag(
     state: &AppState,
     identity: &Identity,
-    mount: Option<&str>,
+    registry: Option<&str>,
     raw_name: &str,
     tag: &str,
 ) -> Response {
-    update_dist_tag(state, identity, mount, raw_name, tag, |tags| {
+    update_dist_tag(state, identity, registry, raw_name, tag, |tags| {
         tags.remove(tag);
         Ok(())
     })
@@ -3350,7 +3359,7 @@ async fn remove_dist_tag(
 async fn update_dist_tag<Mutate>(
     state: &AppState,
     identity: &Identity,
-    mount: Option<&str>,
+    registry: Option<&str>,
     raw_name: &str,
     tag: &str,
     mutate: Mutate,
@@ -3367,7 +3376,7 @@ where
     }
     // A dist-tag change is a write, so it routes to a hosted namespace like
     // a publish — a name routed to an upstream is rejected.
-    let org = match resolve_write_org(state, identity, mount, &name) {
+    let org = match resolve_write_org(state, identity, registry, &name) {
         Ok(org) => org,
         Err(response) => return *response,
     };
@@ -3440,17 +3449,17 @@ where
 
 /// Resolve the hosted storage namespace a non-publish write (dist-tag,
 /// unpublish, packument update) targets, or the [`Response`] to return. A
-/// write routes like a publish: through the addressed `/~<mount>/` (or,
-/// path-less, the default-target mount) to a hosted org, rejecting a name
+/// write routes like a publish: through the addressed `/~<name>/` (or,
+/// path-less, the default-target registry) to a hosted org, rejecting a name
 /// routed to an upstream and 404ing when the path-less base has no default
-/// target or the mount's access list denies the caller.
+/// target or the registry's access list denies the caller.
 fn resolve_write_org(
     state: &AppState,
     identity: &Identity,
-    mount: Option<&str>,
+    registry: Option<&str>,
     name: &PackageName,
 ) -> Result<String, Box<Response>> {
-    match resolve_publish_target(state, identity, mount, name.as_str()) {
+    match resolve_publish_target(state, identity, registry, name.as_str()) {
         PublishTarget::Org(org) => Ok(org),
         PublishTarget::Reject(reason) => {
             Err(Box::new(error_response(&RegistryError::BadRequest { reason })))

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1193,7 +1193,7 @@ async fn serve_mount_version_manifest(
                 Err(err) => return error_response(&err),
             }
         }
-        MountSource::NotFound => return not_found(),
+        MountSource::Unclaimed | MountSource::NotFound => return not_found(),
     };
     let packument: Value = match serde_json::from_slice(&bytes) {
         Ok(v) => v,
@@ -1500,7 +1500,7 @@ async fn load_packument_for_read(
                 .await
                 .map_err(|err| Box::new(error_response(&err)))
         }
-        MountSource::NotFound => Ok(None),
+        MountSource::Unclaimed | MountSource::NotFound => Ok(None),
     }
 }
 
@@ -1701,12 +1701,15 @@ async fn cached_uplink_tarball(
 // --------------------------------------------------------------------
 // Registry-mount dispatch. A `/~<mount>/` request resolves the package to
 // exactly one concrete origin through the validated mount graph
-// ([`crate::mount`]) and serves it there — authoritatively. A router's first
-// matching route wins; a non-matching router is a definitive 404 (never a
-// fall-through to another origin), and a matched-but-unavailable upstream
-// surfaces an *error* rather than a 404 (the via-uplink path returns
-// `UpstreamUnavailable`), so a down private source can never be reported as
-// "not found" and pushed onto a public origin one layer out.
+// ([`crate::mount`]) and serves it there — authoritatively. Every concrete
+// mount's declared `patterns:` are enforced here, before storage or any
+// upstream is consulted, on the direct address and through a router alike; a
+// router selects the first source whose patterns claim the name. An unclaimed
+// name is a definitive 404 (never a fall-through to another origin), and a
+// selected-but-unavailable upstream surfaces an *error* rather than a 404
+// (the via-uplink path returns `UpstreamUnavailable`), so a down private
+// source can never be reported as "not found" and pushed onto a public origin
+// one layer out.
 // --------------------------------------------------------------------
 
 /// The concrete origin a `/~<mount>/` request resolved to, owned so it can be
@@ -1717,8 +1720,12 @@ enum MountSource {
     Upstream(String),
     /// A hosted mount, served from the hosted store.
     Hosted(String),
-    /// The mount id is unknown, or a router matched no route — a definitive
-    /// not-found with no fall-through.
+    /// No declared namespace claims the package — the addressed mount's
+    /// patterns don't cover it, or none of a router's sources claim it. A
+    /// definitive 404 on reads; writes reject it with a reason instead, so a
+    /// typo'd scope fails loudly rather than 404-ing later.
+    Unclaimed,
+    /// The mount id is unknown — a definitive not-found with no fall-through.
     NotFound,
 }
 
@@ -1739,9 +1746,9 @@ fn resolve_mount_source(state: &AppState, mount: &str, package: &str) -> MountSo
         Resolved::Concrete { mount, kind: ConcreteKind::Hosted } => {
             MountSource::Hosted(mount.to_string())
         }
-        // A router that matched no route is a definitive not-found — never a
-        // fall-through to another origin.
-        Resolved::NoRoute => MountSource::NotFound,
+        // An unclaimed name is definitive — never a fall-through to another
+        // origin, and never a storage or upstream consultation.
+        Resolved::Unclaimed => MountSource::Unclaimed,
         // Every configured uplink is an upstream mount addressable at
         // `/~<uplink>/`, even one inserted programmatically without rebuilding
         // the mount graph; fall back to that before declaring not-found.
@@ -1771,7 +1778,7 @@ fn resolves_to_private_source(state: &AppState, mount: &str, package: &str) -> b
         MountSource::Upstream(source) => {
             state.inner.config.uplinks.get(&source).is_some_and(|uplink| uplink.access.is_some())
         }
-        MountSource::NotFound => false,
+        MountSource::Unclaimed | MountSource::NotFound => false,
     }
 }
 
@@ -1834,7 +1841,7 @@ async fn serve_mount_packument(
         MountSource::Hosted(source) => {
             serve_hosted_packument(state, identity, headers, &source, &name, tarball_base).await
         }
-        MountSource::NotFound => not_found(),
+        MountSource::Unclaimed | MountSource::NotFound => not_found(),
     }
 }
 
@@ -1865,7 +1872,7 @@ async fn serve_mount_tarball(
         MountSource::Hosted(source) => {
             serve_hosted_tarball(state, identity, &source, &name, filename).await
         }
-        MountSource::NotFound => not_found(),
+        MountSource::Unclaimed | MountSource::NotFound => not_found(),
     }
 }
 
@@ -2371,14 +2378,17 @@ enum PublishTarget {
     NotFound,
 }
 
-/// Resolve where a publish lands. A write may only target a hosted mount:
-/// a route to an upstream is rejected ("name a hosted mount"), never silently
-/// landing on an upstream. The mount's `access` list gates the write exactly
-/// as it gates reads — a caller the mount denies gets the same not-found mask
-/// as on a read, so a private mount neither accepts the write nor reveals that
-/// it exists. The path-less base routes through its default-target mount; with
-/// no default target the bare host has no registry and the publish is a
-/// not-found, exactly like a read.
+/// Resolve where a publish lands. A write may only target a hosted mount
+/// whose declared patterns claim the name: a selection of an upstream is
+/// rejected ("name a hosted mount"), never silently landing on an upstream,
+/// and an unclaimed name is rejected with the reason — so a typo'd scope
+/// fails loudly at publish time instead of storing a name the mount's
+/// namespace can never serve. The mount's `access` list gates the write
+/// exactly as it gates reads — a caller the mount denies gets the same
+/// not-found mask as on a read, so a private mount neither accepts the write
+/// nor reveals that it exists. The path-less base routes through its
+/// default-target mount; with no default target the bare host has no registry
+/// and the publish is a not-found, exactly like a read.
 fn resolve_publish_target(
     state: &AppState,
     identity: &Identity,
@@ -2393,6 +2403,10 @@ fn resolve_publish_target(
         MountSource::Upstream(_) => PublishTarget::Reject(format!(
             "cannot publish {package:?} {context}: it routes to an upstream registry; name a \
              hosted mount",
+        )),
+        MountSource::Unclaimed => PublishTarget::Reject(format!(
+            "cannot publish {package:?} {context}: no mount's declared `patterns:` claim this \
+             package name",
         )),
         MountSource::NotFound => PublishTarget::NotFound,
     };
@@ -2935,26 +2949,25 @@ async fn serve_search(
     result(objects)
 }
 
-/// The hosted mounts a search addressed to `mount` scans, in route order.
-/// A hosted mount scans itself; a router scans each distinct hosted route
-/// source; an upstream mount scans nothing — search is local-only, never
-/// proxied (an upstream is reached only through its own mount, by exact
-/// package name; there is no cross-origin search merge).
+/// The hosted mounts a search addressed to `mount` scans, in source order.
+/// A hosted mount scans itself; a router scans each of its hosted sources; an
+/// upstream mount scans nothing — search is local-only, never proxied (an
+/// upstream is reached only through its own mount, by exact package name;
+/// there is no cross-origin search merge).
 fn hosted_search_sources(state: &AppState, mount: &str) -> Vec<String> {
     match state.inner.config.mounts.get(mount) {
-        Some(MountKind::Hosted) => vec![mount.to_string()],
-        Some(MountKind::Router { routes }) => {
-            let mut sources: Vec<String> = Vec::new();
-            for route in routes {
-                if matches!(state.inner.config.mounts.get(&route.source), Some(MountKind::Hosted))
-                    && !sources.contains(&route.source)
-                {
-                    sources.push(route.source.clone());
-                }
-            }
-            sources
-        }
-        Some(MountKind::Upstream) | None => Vec::new(),
+        Some(MountKind::Hosted { .. }) => vec![mount.to_string()],
+        Some(MountKind::Router { sources }) => sources
+            .iter()
+            .filter(|source| {
+                matches!(
+                    state.inner.config.mounts.get(source.as_str()),
+                    Some(MountKind::Hosted { .. }),
+                )
+            })
+            .cloned()
+            .collect(),
+        Some(MountKind::Upstream { .. }) | None => Vec::new(),
     }
 }
 

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -205,11 +205,12 @@ pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
 }
 
 /// Fallible counterpart to [`router_with_auth`].
-pub fn try_router_with_auth(config: Config, auth: AuthState) -> crate::error::Result<Router> {
+pub fn try_router_with_auth(mut config: Config, auth: AuthState) -> crate::error::Result<Router> {
     // Enforce the "at least one surface enabled" invariant for embedders
     // that build and serve the router themselves rather than going through
     // `serve`/`serve_listener`.
     config.ensure_a_feature_is_enabled()?;
+    config.ensure_valid_registry_graph()?;
     let osv_index = load_active_osv_index(&config)?;
     Ok(router_with_auth_and_osv(config, auth, osv_index))
 }
@@ -467,12 +468,13 @@ fn loggable_uri(uri: &axum::http::Uri) -> String {
 /// binding so a startup-time auth error surfaces before we accept any
 /// client connections. Registry startup additionally recovers the publish
 /// journal.
-pub async fn serve(config: Config) -> crate::error::Result<()> {
+pub async fn serve(mut config: Config) -> crate::error::Result<()> {
     // Enforce the "at least one surface" invariant here too, not only at
     // YAML load / CLI: embedders build `Config` programmatically and call
     // straight into `serve`, so a both-disabled config must fail loudly
     // rather than start a server that only answers `/-/ping`.
     config.ensure_a_feature_is_enabled()?;
+    config.ensure_valid_registry_graph()?;
     log_enabled_surfaces(&config);
     let osv_index = load_active_osv_index(&config)?;
     let auth = load_startup_auth(&config).await?;
@@ -506,11 +508,12 @@ fn log_enabled_surfaces(config: &Config) {
 /// address, and then hand that listener here without a bind/drop/rebind
 /// race.
 pub async fn serve_listener(
-    config: Config,
+    mut config: Config,
     listener: tokio::net::TcpListener,
 ) -> crate::error::Result<()> {
     let listen = listener.local_addr()?;
     config.ensure_a_feature_is_enabled()?;
+    config.ensure_valid_registry_graph()?;
     log_enabled_surfaces(&config);
     let osv_index = load_active_osv_index(&config)?;
     // Load the configured auth backends here too — going through `router`
@@ -1753,16 +1756,11 @@ fn resolve_registry_source(state: &AppState, registry: &str, package: &str) -> R
         // An unclaimed name is definitive — never a fall-through to another
         // origin, and never a storage or upstream consultation.
         Resolved::Unclaimed => RegistrySource::Unclaimed,
-        // Every configured uplink is an upstream registry addressable at
-        // `/~<uplink>/`, even one inserted programmatically without rebuilding
-        // the registry graph; fall back to that before declaring not-found.
-        Resolved::UnknownRegistry => {
-            if state.inner.config.uplinks.contains_key(registry) {
-                RegistrySource::Upstream(registry.to_string())
-            } else {
-                RegistrySource::NotFound
-            }
-        }
+        // The graph is the only dispatch table: server construction folds
+        // every configured uplink into it (`ensure_valid_registry_graph`), so
+        // a name it doesn't know is a definitive not-found — there is no
+        // uplink-table side door that would skip namespace enforcement.
+        Resolved::UnknownRegistry => RegistrySource::NotFound,
     }
 }
 
@@ -2390,17 +2388,26 @@ enum PublishTarget {
 /// fails loudly at publish time instead of storing a name the registry's
 /// namespace can never serve. The registry's `access` list gates the write
 /// exactly as it gates reads — a caller the registry denies gets the same
-/// not-found mask as on a read, so a private registry neither accepts the write
-/// nor reveals that it exists. The path-less base routes through its
-/// default-target registry; with no default target the bare host has no registry
-/// and the publish is a not-found, exactly like a read.
+/// not-found mask as on a read, whether the name is claimed or not
+/// ([`registry_visible_to_caller`] gates the loud rejection), so a private
+/// registry neither accepts the write nor reveals that it exists. The
+/// path-less base routes through its default-target registry; with no default
+/// target the bare host has no registry and the publish is a not-found,
+/// exactly like a read.
 fn resolve_publish_target(
     state: &AppState,
     identity: &Identity,
     registry: Option<&str>,
     package: &str,
 ) -> PublishTarget {
-    let from_source = |source: RegistrySource, context: &str| match source {
+    let (target, context) = match registry {
+        Some(registry) => (registry.to_string(), format!("through registry {registry:?}")),
+        None => match default_registry_target(state) {
+            Some(target) => (target, "to the path-less base".to_string()),
+            None => return PublishTarget::NotFound,
+        },
+    };
+    match resolve_registry_source(state, &target, package) {
         RegistrySource::Hosted(registry) => {
             match accessible_hosted_namespace(state, identity, &registry) {
                 Some(org) => PublishTarget::Org(org),
@@ -2411,24 +2418,43 @@ fn resolve_publish_target(
             "cannot publish {package:?} {context}: it routes to an upstream registry; name a \
              hosted registry",
         )),
-        RegistrySource::Unclaimed => PublishTarget::Reject(format!(
-            "cannot publish {package:?} {context}: no registry's declared `patterns:` claim this \
-             package name",
-        )),
+        // The loud rejection explains a config fact about the addressed
+        // registry, so only a caller the registry is visible to gets it;
+        // anyone else keeps the same not-found mask a read gives, so an
+        // off-pattern probe cannot distinguish a private registry from an
+        // undefined one.
+        RegistrySource::Unclaimed => {
+            if registry_visible_to_caller(state, identity, &target) {
+                PublishTarget::Reject(format!(
+                    "cannot publish {package:?} {context}: no registry's declared `patterns:` \
+                     claim this package name",
+                ))
+            } else {
+                PublishTarget::NotFound
+            }
+        }
         RegistrySource::NotFound => PublishTarget::NotFound,
+    }
+}
+
+/// Whether `identity` may learn that the registry `name` exists. A hosted
+/// registry is masked behind its access list — a denied caller sees the same
+/// not-found as for an undefined name on every read, so nothing on the write
+/// path may answer differently. An upstream registry is not masked (a denied
+/// caller gets an explicit 403 on reads), and a router is visible whenever
+/// any of its sources is.
+fn registry_visible_to_caller(state: &AppState, identity: &Identity, name: &str) -> bool {
+    let concrete_visible = |name: &str| match state.inner.config.registries.get(name) {
+        Some(Registry::Hosted { .. }) => {
+            accessible_hosted_namespace(state, identity, name).is_some()
+        }
+        Some(Registry::Upstream { .. }) => true,
+        Some(Registry::Router { .. }) | None => false,
     };
-    match registry {
-        Some(registry) => from_source(
-            resolve_registry_source(state, registry, package),
-            &format!("through registry {registry:?}"),
-        ),
-        None => match default_registry_target(state) {
-            Some(target) => from_source(
-                resolve_registry_source(state, &target, package),
-                "to the path-less base",
-            ),
-            None => PublishTarget::NotFound,
-        },
+    match state.inner.config.registries.get(name) {
+        Some(Registry::Router { sources }) => sources.iter().any(|source| concrete_visible(source)),
+        Some(_) => concrete_visible(name),
+        None => false,
     }
 }
 

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -2376,6 +2376,10 @@ enum PublishTarget {
     Org(String),
     /// The resolved target is not a hosted org; reject with this reason.
     Reject(String),
+    /// The resolved upstream registry denies this caller; answer with the
+    /// same response its reads give (a 403), before any rejection that would
+    /// narrate routing config.
+    Denied(Box<Response>),
     /// The addressed registry or route does not exist (or the path-less base has
     /// no default target).
     NotFound,
@@ -2414,10 +2418,17 @@ fn resolve_publish_target(
                 None => PublishTarget::NotFound,
             }
         }
-        RegistrySource::Upstream(_) => PublishTarget::Reject(format!(
-            "cannot publish {package:?} {context}: it routes to an upstream registry; name a \
-             hosted registry",
-        )),
+        // A write can never land on an upstream — but the upstream's `access:`
+        // gates the write endpoints exactly as it gates reads, so a caller the
+        // upstream denies gets the read path's 403 (`authorized_uplink`), not
+        // a rejection that narrates where the name routes.
+        RegistrySource::Upstream(source) => match authorized_uplink(state, identity, &source) {
+            Err(response) => PublishTarget::Denied(response),
+            Ok(_) => PublishTarget::Reject(format!(
+                "cannot publish {package:?} {context}: it routes to an upstream registry; name \
+                 a hosted registry",
+            )),
+        },
         // The loud rejection explains a config fact about the addressed
         // registry, so only a caller the registry is visible to gets it;
         // anyone else keeps the same not-found mask a read gives, so an
@@ -2501,6 +2512,7 @@ async fn publish_package(
         PublishTarget::Reject(reason) => {
             return error_response(&RegistryError::BadRequest { reason });
         }
+        PublishTarget::Denied(response) => return *response,
         PublishTarget::NotFound => return not_found(),
     };
 
@@ -2609,6 +2621,12 @@ async fn serve_batch_publish(
                     cleanup_tmp_slots(stage.slots).await;
                 }
                 return error_response(&RegistryError::BadRequest { reason });
+            }
+            PublishTarget::Denied(response) => {
+                for stage in staged {
+                    cleanup_tmp_slots(stage.slots).await;
+                }
+                return *response;
             }
             PublishTarget::NotFound => {
                 for stage in staged {
@@ -3490,6 +3508,7 @@ fn resolve_write_org(
         PublishTarget::Reject(reason) => {
             Err(Box::new(error_response(&RegistryError::BadRequest { reason })))
         }
+        PublishTarget::Denied(response) => Err(response),
         PublishTarget::NotFound => Err(Box::new(not_found())),
     }
 }

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -140,7 +140,7 @@ impl Drop for TarballWrite {
 /// (potentially multi-MB) body when it isn't needed:
 ///
 /// * `Fresh` — within the TTL; the body is read and ready to serve.
-/// * `Stale` — past the TTL. The body is left on disk; a per-mount cache
+/// * `Stale` — past the TTL. The body is left on disk; a per-registry cache
 ///   refetches a stale entry rather than revalidating it, so the caller treats
 ///   `Stale` as a miss.
 #[derive(Debug)]
@@ -266,7 +266,7 @@ impl HostedStore {
         }
     }
 
-    /// A view rooted under `segment`, giving a hosted mount its own
+    /// A view rooted under `segment`, giving a hosted registry its own
     /// storage namespace so two orgs hosting the same `name@version` never
     /// collide on disk (or on object keys).
     fn namespaced(&self, segment: &str) -> HostedStore {
@@ -301,9 +301,9 @@ impl Storage {
     }
 
     /// A view whose hosted store is namespaced under `org`, so a hosted
-    /// mount's packages live in their own storage namespace — two orgs hosting
+    /// registry's packages live in their own storage namespace — two orgs hosting
     /// the same `name@version` can't collide. The disposable proxy cache is
-    /// shared (org mounts never touch it). Used by hosted serving and the
+    /// shared (org registries never touch it). Used by hosted serving and the
     /// org-routed publish flow; the flat (un-namespaced) store remains the
     /// legacy path-less hosted surface.
     #[must_use]

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -29,7 +29,7 @@ const PACKUMENT_FILE: &str = "package.json";
 static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 const MAX_TEMP_CREATE_ATTEMPTS: usize = 16;
 
-/// Handle returned from [`Storage::open_uplink_tarball_tmp`]. The caller
+/// Handle returned from [`Storage::open_upstream_tarball_tmp`]. The caller
 /// writes through [`Self::write_all`] (and on success calls [`Self::finalize`] to
 /// atomically promote the temp file to the final cache path). The temp
 /// path remains armed until promotion succeeds, so cancellation and
@@ -325,7 +325,7 @@ impl Storage {
 
     /// Open a tarball from the authoritative hosted store. Hosted
     /// publish writes verify their SRI before finalization, and static
-    /// storage remains operator-controlled rather than an uplink cache.
+    /// storage remains operator-controlled rather than an upstream cache.
     pub async fn open_hosted_tarball(
         &self,
         name: &PackageName,
@@ -367,18 +367,18 @@ impl Storage {
         Ok(hosted || cached)
     }
 
-    // --- Per-uplink private cache (the `/~<uplink>/` registry endpoint) ----
+    // --- Per-upstream private cache (the `/~<name>/` registry endpoint) ----
     //
-    // A private uplink's packuments and tarballs are cached under a namespace
-    // derived from the uplink and its rotation generation, kept separate from
+    // A private upstream's packuments and tarballs are cached under a namespace
+    // derived from the upstream and its rotation generation, kept separate from
     // the shared public mirror so they can never be served on the public path
-    // or under another uplink. A rotation (new generation) moves to a fresh
+    // or under another upstream. A rotation (new generation) moves to a fresh
     // namespace, so entries fetched with a since-rotated credential age out.
 
-    /// A fresh cached packument for an uplink route, or `None` when it is
-    /// absent or older than `ttl`. The uplink path refetches a stale entry
+    /// A fresh cached packument for an upstream route, or `None` when it is
+    /// absent or older than `ttl`. The upstream path refetches a stale entry
     /// rather than conditionally revalidating it.
-    pub async fn read_uplink_packument(
+    pub async fn read_upstream_packument(
         &self,
         namespace: &str,
         name: &PackageName,
@@ -390,12 +390,12 @@ impl Storage {
         }
     }
 
-    /// The cached uplink packument regardless of freshness (fresh or stale).
-    /// A defensive fallback for an unsolicited upstream `304`: the uplink path
+    /// The cached upstream packument regardless of freshness (fresh or stale).
+    /// A defensive fallback for an unsolicited upstream `304`: the upstream path
     /// sends no conditional validators, so a `304` means "unchanged" and the
     /// cached body — even past `ttl` — is the right thing to serve rather than
     /// a spurious `404`.
-    pub async fn read_uplink_packument_any(
+    pub async fn read_upstream_packument_any(
         &self,
         namespace: &str,
         name: &PackageName,
@@ -408,7 +408,7 @@ impl Storage {
         }
     }
 
-    pub async fn write_uplink_packument(
+    pub async fn write_upstream_packument(
         &self,
         namespace: &str,
         name: &PackageName,
@@ -417,16 +417,20 @@ impl Storage {
         self.cached.namespaced(namespace).write_packument(name, bytes).await
     }
 
-    /// Purge an uplink's cached entry for `name` — the packument and any
+    /// Purge an upstream's cached entry for `name` — the packument and any
     /// cached tarballs. Called on a definitive upstream 404: without the
     /// purge, the stale entry would linger past its TTL and a later transient
     /// outage could resurrect the unpublished package through the
     /// stale-if-error fallback.
-    pub async fn remove_uplink_package(&self, namespace: &str, name: &PackageName) -> Result<bool> {
+    pub async fn remove_upstream_package(
+        &self,
+        namespace: &str,
+        name: &PackageName,
+    ) -> Result<bool> {
         self.cached.namespaced(namespace).remove_package(name).await
     }
 
-    pub async fn open_uplink_tarball_tmp(
+    pub async fn open_upstream_tarball_tmp(
         &self,
         namespace: &str,
         name: &PackageName,
@@ -435,7 +439,7 @@ impl Storage {
         self.cached.namespaced(namespace).open_tarball_tmp(name, filename).await
     }
 
-    pub async fn open_uplink_tarball(
+    pub async fn open_upstream_tarball(
         &self,
         namespace: &str,
         name: &PackageName,
@@ -475,8 +479,8 @@ impl Store {
     }
 
     /// A disposable store rooted at a sub-path of this one. Used to give a
-    /// private `/~<uplink>/` route its own cache namespace so its packuments
-    /// and tarballs never collide with the public mirror or another uplink.
+    /// private `/~<name>/` route its own cache namespace so its packuments
+    /// and tarballs never collide with the public mirror or another upstream.
     fn namespaced(&self, prefix: &str) -> Store {
         Store::new(self.root.join(prefix))
     }

--- a/pnpr/crates/pnpr/src/streaming/tests.rs
+++ b/pnpr/crates/pnpr/src/streaming/tests.rs
@@ -131,7 +131,7 @@ async fn cancelling_in_flight_response_body_removes_tmp_file() {
     let storage = Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), cache.clone());
     let name = PackageName::parse("foo").unwrap();
     let write =
-        storage.open_uplink_tarball_tmp("~public/test", &name, "foo-1.0.0.tgz").await.unwrap();
+        storage.open_upstream_tarball_tmp("~public/test", &name, "foo-1.0.0.tgz").await.unwrap();
 
     let body = stream_verified_to_cache(response, write, &integrity, u64::MAX).unwrap();
     let mut chunks = body.into_data_stream();
@@ -162,7 +162,7 @@ async fn oversized_response_is_rejected_and_tmp_is_removed() {
     let storage = Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), cache.clone());
     let name = PackageName::parse("foo").unwrap();
     let write =
-        storage.open_uplink_tarball_tmp("~public/test", &name, "foo-1.0.0.tgz").await.unwrap();
+        storage.open_upstream_tarball_tmp("~public/test", &name, "foo-1.0.0.tgz").await.unwrap();
 
     // An upstream that declares an oversize body is rejected up front, before
     // any bytes stream, so the caller turns it into an error response.

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{RedactedHeaders, UplinkConfig},
+    config::{RedactedHeaders, UpstreamConfig},
     error::{RegistryError, Result},
     package_name::PackageName,
 };
@@ -20,7 +20,7 @@ use std::{
 /// Wraps a shared [`ThrottledClient`] (so the registry inherits pnpm's
 /// tuned reqwest defaults: `User-Agent: pnpm`, HTTP/1.1, hickory DNS,
 /// pool/timeout tuning, concurrency semaphore, and per-registry TLS
-/// routing if it's ever wired in later) and adds the per-uplink glue a
+/// routing if it's ever wired in later) and adds the per-upstream glue a
 /// proxy needs: building the upstream URL, applying verdaccio's
 /// `timeout`/`max_fails`/`fail_timeout` knobs, and fishing the packument
 /// or tarball response out of it.
@@ -28,24 +28,24 @@ use std::{
 pub struct Upstream {
     client: Arc<ThrottledClient>,
     base: String,
-    /// The configured uplink name (the YAML `uplinks:` key). Surfaced in
-    /// client-facing errors so an open circuit names the uplink rather
+    /// The configured upstream name (the YAML `upstreams:` key). Surfaced in
+    /// client-facing errors so an open circuit names the upstream rather
     /// than leaking its upstream URL.
     name: String,
-    /// Resolved per-uplink request headers (auth + custom) attached to
-    /// every fetch. Empty for an uplink with no `auth:`/`headers:`.
+    /// Resolved per-upstream request headers (auth + custom) attached to
+    /// every fetch. Empty for an upstream with no `auth:`/`headers:`.
     headers: HeaderMap,
     /// Per-request deadline (verdaccio's `timeout`).
     timeout: Duration,
-    /// Per-uplink packument freshness window (verdaccio's `maxage`), or
+    /// Per-upstream packument freshness window (verdaccio's `maxage`), or
     /// `None` to defer to the global [`crate::config::Config::packument_ttl`].
     maxage: Option<Duration>,
-    /// Whether tarballs from this uplink are written to the local mirror
+    /// Whether tarballs from this upstream are written to the local mirror
     /// (verdaccio's `cache`).
     cache: bool,
     /// Shared failure tracker implementing verdaccio's
     /// `max_fails`/`fail_timeout` circuit breaker. Behind an [`Arc`] so
-    /// every clone of this `Upstream` (the registry holds one per uplink
+    /// every clone of this `Upstream` (the registry holds one per upstream
     /// and clones it per request) updates the same counters.
     breaker: Arc<CircuitBreaker>,
 }
@@ -66,7 +66,7 @@ impl fmt::Debug for Upstream {
 }
 
 /// Verdaccio's `max_fails` / `fail_timeout` circuit breaker. After
-/// `max_fails` consecutive failures the uplink is considered down and
+/// `max_fails` consecutive failures the upstream is considered down and
 /// requests short-circuit, until `fail_timeout` elapses since the last
 /// failure — a single probe is then allowed through, and its success
 /// resets the breaker or its failure restarts the cooldown.
@@ -83,7 +83,7 @@ impl fmt::Debug for Upstream {
 /// check and its timestamp can never be observed half-updated. The lock
 /// is held only for trivial field reads/writes (never across the network
 /// request), so contention is negligible; a poisoned lock is recovered
-/// rather than propagated as a panic, keeping a failing uplink from
+/// rather than propagated as a panic, keeping a failing upstream from
 /// taking the registry down.
 #[derive(Debug)]
 struct CircuitBreaker {
@@ -189,11 +189,11 @@ pub enum PackumentFetch {
 }
 
 impl Upstream {
-    /// Build an uplink client from its name (the YAML `uplinks:` key) and
-    /// resolved [`UplinkConfig`], baking in the per-uplink
+    /// Build an upstream client from its name (the YAML `upstreams:` key) and
+    /// resolved [`UpstreamConfig`], baking in the per-upstream
     /// `timeout`/`maxage`/`cache` knobs and arming the
     /// `max_fails`/`fail_timeout` circuit breaker.
-    pub fn new(name: &str, config: &UplinkConfig) -> Self {
+    pub fn new(name: &str, config: &UpstreamConfig) -> Self {
         Self {
             client: Arc::new(ThrottledClient::new_for_installs()),
             base: config.url.clone(),
@@ -206,13 +206,13 @@ impl Upstream {
         }
     }
 
-    /// Per-uplink packument freshness window (`maxage`), or `None` to
+    /// Per-upstream packument freshness window (`maxage`), or `None` to
     /// defer to the global [`crate::config::Config::packument_ttl`].
     pub fn maxage(&self) -> Option<Duration> {
         self.maxage
     }
 
-    /// Whether tarballs from this uplink should be written to the local
+    /// Whether tarballs from this upstream should be written to the local
     /// mirror (`cache: true`). When `false` the caller streams the body
     /// straight through without caching it.
     pub fn caches(&self) -> bool {
@@ -251,7 +251,7 @@ impl Upstream {
         }
         let response = self.run(request, &url).await?;
         if response.status() == StatusCode::NOT_FOUND {
-            // A 404 is an authoritative answer, not an uplink failure.
+            // A 404 is an authoritative answer, not an upstream failure.
             self.breaker.record_success();
             return Ok(PackumentFetch::NotFound);
         }
@@ -304,12 +304,12 @@ impl Upstream {
 
     /// Fail fast with [`RegistryError::UpstreamUnavailable`] when the
     /// breaker is open, so callers never pay a request to a known-down
-    /// uplink.
+    /// upstream.
     fn ensure_available(&self) -> Result<()> {
         if self.breaker.try_acquire() {
             return Ok(());
         }
-        Err(RegistryError::UpstreamUnavailable { uplink: self.name.clone() })
+        Err(RegistryError::UpstreamUnavailable { upstream: self.name.clone() })
     }
 
     /// Send a built request, mapping a transport error to

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -158,7 +158,7 @@ pub enum FetchOutcome<Payload> {
 
 /// Conditional-GET validators sent on a packument refresh (an `ETag` /
 /// `Last-Modified` replayed as `If-None-Match` / `If-Modified-Since`). A
-/// per-mount cache refetches a stale entry rather than revalidating it, so in
+/// per-registry cache refetches a stale entry rather than revalidating it, so in
 /// practice the default (empty) value is always sent; the type stays so the
 /// fetch path can grow conditional revalidation again without a signature
 /// change.

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -2,16 +2,16 @@ use super::{
     CacheValidators, CircuitBreaker, FetchOutcome, PackumentFetch, Upstream, abbreviate_packument,
     extract_version_manifest, rewrite_tarball_urls, tarball_basename,
 };
-use crate::{config::UplinkConfig, error::RegistryError, package_name::PackageName};
+use crate::{config::UpstreamConfig, error::RegistryError, package_name::PackageName};
 use chrono::{DateTime, TimeZone, Utc};
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use serde_json::json;
 use std::time::Duration;
 
-/// Build an [`Upstream`] pointing at `url` with `headers`, all per-uplink
+/// Build an [`Upstream`] pointing at `url` with `headers`, all per-upstream
 /// tuning knobs at their verdaccio defaults.
 fn upstream(url: String, headers: HeaderMap) -> Upstream {
-    Upstream::new("npmjs", &UplinkConfig::with_defaults(url, headers))
+    Upstream::new("npmjs", &UpstreamConfig::with_defaults(url, headers))
 }
 
 /// Fixed "current time" for abbreviation tests so the `time`-map
@@ -21,7 +21,7 @@ fn now() -> DateTime<Utc> {
 }
 
 /// Build a header map carrying a bearer `Authorization` plus one
-/// custom header — the resolved per-uplink set an [`Upstream`] is
+/// custom header — the resolved per-upstream set an [`Upstream`] is
 /// expected to attach to every request.
 fn auth_and_custom_headers() -> HeaderMap {
     let mut headers = HeaderMap::new();
@@ -521,11 +521,11 @@ fn coarsens_time_entries_by_age() {
 fn breaking_upstream(url: String, max_fails: u32) -> Upstream {
     Upstream::new(
         "npmjs",
-        &UplinkConfig {
+        &UpstreamConfig {
             url,
             headers: HeaderMap::new(),
             maxage: None,
-            timeout: UplinkConfig::DEFAULT_TIMEOUT,
+            timeout: UpstreamConfig::DEFAULT_TIMEOUT,
             max_fails,
             fail_timeout: Duration::from_mins(5),
             cache: true,

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -35,12 +35,12 @@ fn static_config_with_packages(dir: &TempDir, packages_block: &str) -> (Config, 
     // Route everything to one local hosted over the flat storage root (an
     // empty `org` namespace), so publishes/reads resolve through the path-less
     // base and the per-package ACL in `packages_block` gates them.
-    let mounts_block = "mounts:\n  \
+    let registries_block = "registries:\n  \
         local:\n    type: hosted\n    org: \"\"\n    access: $all\n  \
         main:\n    type: router\n    sources: [local]\n\
-        defaultTarget: main\n";
+        defaultRegistry: main\n";
     let yaml =
-        format!("storage: {}\n{mounts_block}packages:\n{packages_block}\n", storage.display());
+        format!("storage: {}\n{registries_block}packages:\n{packages_block}\n", storage.display());
     let config_path = dir.path().join("config.yaml");
     std::fs::write(&config_path, yaml).unwrap();
     let mut config =

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -1427,7 +1427,7 @@ async fn search_augment_skips_when_upstream_404s() {
     let tmp = TempDir::new().unwrap();
     let listen = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0));
     let mut config = Config::proxy(listen, tmp.path().to_path_buf());
-    config.uplinks.get_mut("npmjs").expect("default `npmjs` uplink").url = upstream.url();
+    config.upstreams.get_mut("npmjs").expect("default `npmjs` upstream").url = upstream.url();
     config.public_url = "http://example.test".to_string();
     config.packument_ttl = Duration::from_mins(1);
     let app = router(config);

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -37,7 +37,7 @@ fn static_config_with_packages(dir: &TempDir, packages_block: &str) -> (Config, 
     // base and the per-package ACL in `packages_block` gates them.
     let mounts_block = "mounts:\n  \
         local:\n    type: hosted\n    org: \"\"\n    access: $all\n  \
-        main:\n    type: router\n    routes:\n      - patterns: ['**']\n        source: local\n\
+        main:\n    type: router\n    sources: [local]\n\
         defaultTarget: main\n";
     let yaml =
         format!("storage: {}\n{mounts_block}packages:\n{packages_block}\n", storage.display());

--- a/pnpr/crates/pnpr/tests/policy.rs
+++ b/pnpr/crates/pnpr/tests/policy.rs
@@ -27,12 +27,12 @@ fn config_from_yaml(packages_block: &str) -> (TempDir, Config) {
     // Route everything to one local hosted over the flat storage root (an
     // empty `org` namespace), so the path-less base resolves and the per-package
     // ACL in `packages_block` gates the request.
-    let mounts_block = "mounts:\n  \
+    let registries_block = "registries:\n  \
         local:\n    type: hosted\n    org: \"\"\n    access: $all\n  \
         main:\n    type: router\n    sources: [local]\n\
-        defaultTarget: main\n";
+        defaultRegistry: main\n";
     let yaml = format!(
-        "storage: {}\nauth:\n  htpasswd:\n    max_users: 100\n{mounts_block}{packages_block}\n",
+        "storage: {}\nauth:\n  htpasswd:\n    max_users: 100\n{registries_block}{packages_block}\n",
         storage.display(),
     );
     let path = dir.path().join("config.yaml");

--- a/pnpr/crates/pnpr/tests/policy.rs
+++ b/pnpr/crates/pnpr/tests/policy.rs
@@ -29,7 +29,7 @@ fn config_from_yaml(packages_block: &str) -> (TempDir, Config) {
     // ACL in `packages_block` gates the request.
     let mounts_block = "mounts:\n  \
         local:\n    type: hosted\n    org: \"\"\n    access: $all\n  \
-        main:\n    type: router\n    routes:\n      - patterns: ['**']\n        source: local\n\
+        main:\n    type: router\n    sources: [local]\n\
         defaultTarget: main\n";
     let yaml = format!(
         "storage: {}\nauth:\n  htpasswd:\n    max_users: 100\n{mounts_block}{packages_block}\n",

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -3218,6 +3218,52 @@ async fn building_the_server_rejects_an_invalid_programmatic_registry_graph() {
     assert!(err.to_string().contains("ghost"), "unexpected error: {err}");
 }
 
+/// The programmatic path enforces the same name/org safety as YAML loading:
+/// a hosted `org` that could escape the storage root fails server startup.
+#[tokio::test]
+async fn building_the_server_rejects_an_unsafe_programmatic_hosted_org() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
+    config.hosted.insert(
+        "evil".to_string(),
+        HostedConfig { org: "../escape".to_string(), access: AccessList::parse("$all") },
+    );
+    let err = pnpr::try_router(config).expect_err("a path-escaping org must fail startup");
+    assert!(err.to_string().contains("org"), "unexpected error: {err}");
+}
+
+/// The write endpoints gate on a private upstream's `access:` exactly as
+/// reads do: a denied caller gets the read path's 403, not a 400 rejection
+/// that narrates where the name routes.
+#[tokio::test]
+async fn publish_to_a_private_upstream_is_denied_before_the_upstream_rejection() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
+    let mut corp = config.uplinks.get("npmjs").expect("default `npmjs` uplink").clone();
+    corp.access = Some(AccessList::parse("alice"));
+    config.uplinks.insert("corp".to_string(), corp);
+    let auth = AuthState::in_memory();
+    let member = auth.tokens.issue("alice").await.unwrap();
+    let outsider = auth.tokens.issue("mallory").await.unwrap();
+    let app = router_with_auth(config, auth);
+
+    let publish_as = |token: &str| {
+        Request::put("/~corp/lodash")
+            .header("content-type", "application/json")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::from(json!({ "name": "lodash", "versions": {} }).to_string()))
+            .unwrap()
+    };
+
+    let denied = app.clone().oneshot(publish_as(&outsider)).await.unwrap();
+    assert_eq!(denied.status(), StatusCode::FORBIDDEN);
+
+    // The admitted caller still can't write to an upstream, but the answer is
+    // the clear rejection rather than an access denial.
+    let rejected = app.oneshot(publish_as(&member)).await.unwrap();
+    assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
+}
+
 /// The registry's access list gates writes exactly as it gates reads (RFC
 /// "registries", implementation point 9). An authenticated non-member
 /// passes the default per-package publish policy (`$authenticated`), so

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -32,7 +32,7 @@ use tower::ServiceExt;
 fn config_for(upstream: &str, storage: PathBuf) -> Config {
     let listen = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 4873));
     let mut config = Config::proxy(listen, storage);
-    config.uplinks.get_mut("npmjs").expect("default `npmjs` uplink").url = upstream.to_string();
+    config.upstreams.get_mut("npmjs").expect("default `npmjs` upstream").url = upstream.to_string();
     config.public_url = "http://example.test".to_string();
     config.packument_ttl = Duration::from_mins(1);
     config
@@ -652,10 +652,10 @@ async fn osv_filters_packument_identity_mismatches() {
 }
 
 #[tokio::test]
-async fn uplink_auth_and_custom_headers_are_forwarded_upstream() {
+async fn upstream_auth_and_custom_headers_are_forwarded_upstream() {
     let mut upstream = mockito::Server::new_async().await;
     // The mock only matches when both headers are present, so a passing
-    // request proves the resolved per-uplink headers reached upstream.
+    // request proves the resolved per-upstream headers reached upstream.
     let mock = upstream
         .mock("GET", "/foo")
         .match_header("authorization", "Bearer secret-token")
@@ -668,9 +668,9 @@ async fn uplink_auth_and_custom_headers_are_forwarded_upstream() {
 
     let tmp = TempDir::new().unwrap();
     let mut config = config_for(&upstream.url(), tmp.path().to_path_buf());
-    let uplink = config.uplinks.get_mut("npmjs").expect("default `npmjs` uplink");
-    uplink.headers.insert("authorization", "Bearer secret-token".parse().unwrap());
-    uplink.headers.insert("x-org", "acme".parse().unwrap());
+    let upstream = config.upstreams.get_mut("npmjs").expect("default `npmjs` upstream");
+    upstream.headers.insert("authorization", "Bearer secret-token".parse().unwrap());
+    upstream.headers.insert("x-org", "acme".parse().unwrap());
     let app = router(config);
 
     let response = app.oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
@@ -738,18 +738,18 @@ async fn tarball_is_proxied_and_cached() {
     mock.assert_async().await;
 }
 
-/// A proxy config whose default `npmjs` uplink is promoted to an
-/// access-bearing private-route uplink, reachable at `/~npmjs/`.
-fn uplink_endpoint_config(upstream_url: &str, storage: PathBuf, access: &str) -> Config {
+/// A proxy config whose default `npmjs` upstream is promoted to an
+/// access-bearing private-route upstream, reachable at `/~npmjs/`.
+fn upstream_endpoint_config(upstream_url: &str, storage: PathBuf, access: &str) -> Config {
     let mut config = config_for(upstream_url, storage);
     config.public_url = "http://example.test".to_string();
-    config.uplinks.get_mut("npmjs").expect("default `npmjs` uplink").access =
+    config.upstreams.get_mut("npmjs").expect("default `npmjs` upstream").access =
         Some(AccessList::parse(access));
     config
 }
 
 #[tokio::test]
-async fn uplink_endpoint_serves_packument_with_endpoint_rewritten_tarballs() {
+async fn upstream_endpoint_serves_packument_with_endpoint_rewritten_tarballs() {
     let mut upstream = mockito::Server::new_async().await;
     let packument = json!({
         "name": "foo",
@@ -768,7 +768,7 @@ async fn uplink_endpoint_serves_packument_with_endpoint_rewritten_tarballs() {
         .await;
 
     let tmp = TempDir::new().unwrap();
-    let config = uplink_endpoint_config(&upstream.url(), tmp.path().to_path_buf(), "alice");
+    let config = upstream_endpoint_config(&upstream.url(), tmp.path().to_path_buf(), "alice");
     let auth = AuthState::in_memory();
     let token = auth.tokens.issue("alice").await.unwrap();
     let app = router_with_auth(config, auth);
@@ -797,11 +797,11 @@ async fn uplink_endpoint_serves_packument_with_endpoint_rewritten_tarballs() {
 }
 
 #[tokio::test]
-async fn uplink_endpoint_rejects_unauthorized_caller() {
+async fn upstream_endpoint_rejects_unauthorized_caller() {
     let tmp = TempDir::new().unwrap();
-    let config = uplink_endpoint_config("http://127.0.0.1:1", tmp.path().to_path_buf(), "alice");
+    let config = upstream_endpoint_config("http://127.0.0.1:1", tmp.path().to_path_buf(), "alice");
     let app = router(config);
-    // Anonymous caller is not admitted by the uplink's access policy, and the
+    // Anonymous caller is not admitted by the upstream's access policy, and the
     // request fails closed before any upstream fetch.
     let response =
         app.oneshot(Request::get("/~npmjs/foo").body(Body::empty()).unwrap()).await.unwrap();
@@ -809,9 +809,9 @@ async fn uplink_endpoint_rejects_unauthorized_caller() {
 }
 
 #[tokio::test]
-async fn uplink_endpoint_tarball_is_verified_and_cached_per_uplink() {
+async fn upstream_endpoint_tarball_is_verified_and_cached_per_upstream() {
     let mut upstream = mockito::Server::new_async().await;
-    let bytes = b"private-uplink-tarball";
+    let bytes = b"private-upstream-tarball";
     let packument = json!({
         "name": "foo",
         "dist-tags": { "latest": "1.0.0" },
@@ -820,7 +820,7 @@ async fn uplink_endpoint_tarball_is_verified_and_cached_per_uplink() {
             "integrity": sha512_integrity(bytes),
         } } },
     });
-    // The packument and verified tarball are cached in the uplink's private
+    // The packument and verified tarball are cached in the upstream's private
     // namespace, so two tarball requests hit the upstream exactly once each —
     // the second is served from the private cache, never re-fetched.
     let packument_mock = upstream
@@ -840,7 +840,7 @@ async fn uplink_endpoint_tarball_is_verified_and_cached_per_uplink() {
         .await;
 
     let tmp = TempDir::new().unwrap();
-    let config = uplink_endpoint_config(&upstream.url(), tmp.path().to_path_buf(), "alice");
+    let config = upstream_endpoint_config(&upstream.url(), tmp.path().to_path_buf(), "alice");
     let auth = AuthState::in_memory();
     let token = auth.tokens.issue("alice").await.unwrap();
     let app = router_with_auth(config, auth);
@@ -865,12 +865,12 @@ async fn uplink_endpoint_tarball_is_verified_and_cached_per_uplink() {
 }
 
 #[tokio::test]
-async fn uplink_cache_does_not_leak_to_the_public_path() {
-    // The public `**` route proxies through the default `npmjs` uplink to the
-    // public upstream; a separate access-bearing `corp` uplink serves a
+async fn upstream_cache_does_not_leak_to_the_public_path() {
+    // The public `**` route proxies through the default `npmjs` upstream to the
+    // public upstream; a separate access-bearing `corp` upstream serves a
     // *different* upstream at `/~corp/`. After the private `/~corp/foo` tarball
     // is cached, the public `/foo` request must still serve the public bytes —
-    // proving the private uplink's cache is namespaced, not shared.
+    // proving the private upstream's cache is namespaced, not shared.
     let mut public_upstream = mockito::Server::new_async().await;
     let mut private_upstream = mockito::Server::new_async().await;
     let public_bytes = b"public-foo-tarball";
@@ -898,10 +898,10 @@ async fn uplink_cache_does_not_leak_to_the_public_path() {
 
     let tmp = TempDir::new().unwrap();
     let mut config = config_for(&public_upstream.url(), tmp.path().to_path_buf());
-    let mut corp = config.uplinks.get("npmjs").expect("default `npmjs` uplink").clone();
+    let mut corp = config.upstreams.get("npmjs").expect("default `npmjs` upstream").clone();
     corp.url = private_upstream.url();
     corp.access = Some(AccessList::parse("alice"));
-    config.uplinks.insert("corp".to_string(), corp);
+    config.upstreams.insert("corp".to_string(), corp);
     let auth = AuthState::in_memory();
     let token = auth.tokens.issue("alice").await.unwrap();
     let app = router_with_auth(config, auth);
@@ -921,7 +921,7 @@ async fn uplink_cache_does_not_leak_to_the_public_path() {
     assert_eq!(body_bytes(private.into_body()).await, private_bytes);
 
     // The public path must serve the public upstream's bytes, never the
-    // private uplink's cached copy.
+    // private upstream's cached copy.
     let public = app
         .oneshot(Request::get("/foo/-/foo-1.0.0.tgz").body(Body::empty()).unwrap())
         .await
@@ -935,7 +935,7 @@ async fn uplink_cache_does_not_leak_to_the_public_path() {
 /// upstream — packument or tarball, including via the cache-first tarball
 /// path — can never answer for the new one under the same registry name.
 #[tokio::test]
-async fn repointing_an_uplink_url_abandons_the_old_origins_cache() {
+async fn repointing_an_upstream_url_abandons_the_old_origins_cache() {
     let mut old_origin = mockito::Server::new_async().await;
     let mut new_origin = mockito::Server::new_async().await;
     let old_bytes = b"old-origin-foo-tarball";
@@ -981,9 +981,9 @@ async fn repointing_an_uplink_url_abandons_the_old_origins_cache() {
 }
 
 #[tokio::test]
-async fn uplink_endpoint_cache_false_streams_without_caching() {
+async fn upstream_endpoint_cache_false_streams_without_caching() {
     let mut upstream = mockito::Server::new_async().await;
-    let bytes = b"uncached-private-uplink-tarball";
+    let bytes = b"uncached-private-upstream-tarball";
     let packument = json!({
         "name": "foo",
         "dist-tags": { "latest": "1.0.0" },
@@ -992,7 +992,7 @@ async fn uplink_endpoint_cache_false_streams_without_caching() {
             "integrity": sha512_integrity(bytes),
         } } },
     });
-    // A `cache: false` uplink endpoint persists nothing, so each request
+    // A `cache: false` upstream endpoint persists nothing, so each request
     // re-fetches the packument and tarball — the mocks are hit twice.
     let packument_mock = upstream
         .mock("GET", "/foo")
@@ -1009,8 +1009,8 @@ async fn uplink_endpoint_cache_false_streams_without_caching() {
         .await;
 
     let tmp = TempDir::new().unwrap();
-    let mut config = uplink_endpoint_config(&upstream.url(), tmp.path().to_path_buf(), "alice");
-    config.uplinks.get_mut("npmjs").expect("default `npmjs` uplink").cache = false;
+    let mut config = upstream_endpoint_config(&upstream.url(), tmp.path().to_path_buf(), "alice");
+    config.upstreams.get_mut("npmjs").expect("default `npmjs` upstream").cache = false;
     let auth = AuthState::in_memory();
     let token = auth.tokens.issue("alice").await.unwrap();
     let app = router_with_auth(config, auth);
@@ -1301,7 +1301,7 @@ async fn tarball_route_preserves_basename_and_binds_to_declaring_version() {
     // cached entry; the `expect(1)` mocks prove the upstream is never
     // consulted again. (A *different* URL would be a repoint, which
     // deliberately abandons this cache — see
-    // `repointing_an_uplink_url_abandons_the_old_origins_cache`.)
+    // `repointing_an_upstream_url_abandons_the_old_origins_cache`.)
     let restarted = router(config_for(&upstream.url(), storage));
     let replay = restarted.oneshot(Request::get(route).body(Body::empty()).unwrap()).await.unwrap();
     assert_eq!(replay.status(), StatusCode::OK);
@@ -2312,12 +2312,12 @@ async fn tarball_is_not_gzipped_even_when_accepted() {
     mock.assert_async().await;
 }
 
-/// A per-uplink `maxage` shorter than the global `packument_ttl` governs
+/// A per-upstream `maxage` shorter than the global `packument_ttl` governs
 /// freshness: with a generous global TTL the second request would be a
 /// cache hit, but `maxage: 0` forces a revalidation, so the upstream is
 /// hit twice.
 #[tokio::test]
-async fn per_uplink_maxage_overrides_global_packument_ttl() {
+async fn per_upstream_maxage_overrides_global_packument_ttl() {
     let mut upstream = mockito::Server::new_async().await;
     let packument = json!({ "name": "foo", "versions": {} });
     let mock = upstream
@@ -2330,10 +2330,10 @@ async fn per_uplink_maxage_overrides_global_packument_ttl() {
 
     let tmp = TempDir::new().unwrap();
     let mut config = config_for(&upstream.url(), tmp.path().to_path_buf());
-    // Global TTL stays generous (a minute); the per-uplink maxage of zero
+    // Global TTL stays generous (a minute); the per-upstream maxage of zero
     // is what must take effect and make every read stale.
     config.packument_ttl = Duration::from_mins(1);
-    config.uplinks.get_mut("npmjs").expect("default `npmjs` uplink").maxage =
+    config.upstreams.get_mut("npmjs").expect("default `npmjs` upstream").maxage =
         Some(Duration::from_millis(0));
     let app = router(config);
 
@@ -2347,11 +2347,11 @@ async fn per_uplink_maxage_overrides_global_packument_ttl() {
     mock.assert_async().await;
 }
 
-/// A `cache: false` uplink streams tarballs through without writing them
+/// A `cache: false` upstream streams tarballs through without writing them
 /// to the local mirror: a second request re-fetches from the upstream
 /// (so the mock is hit twice) and no `.tgz` is left in the cache dir.
 #[tokio::test]
-async fn cache_false_uplink_streams_tarball_without_mirroring() {
+async fn cache_false_upstream_streams_tarball_without_mirroring() {
     let mut upstream = mockito::Server::new_async().await;
     let bytes = b"uncached-tarball-bytes";
     // A `cache: false` registry streams everything through, so each of the two
@@ -2368,7 +2368,7 @@ async fn cache_false_uplink_streams_tarball_without_mirroring() {
     let tmp = TempDir::new().unwrap();
     let cache_dir = tmp.path().to_path_buf();
     let mut config = config_for(&upstream.url(), cache_dir.clone());
-    config.uplinks.get_mut("npmjs").expect("default `npmjs` uplink").cache = false;
+    config.upstreams.get_mut("npmjs").expect("default `npmjs` upstream").cache = false;
     let app = router(config);
 
     for _ in 0..2 {
@@ -2386,7 +2386,7 @@ async fn cache_false_uplink_streams_tarball_without_mirroring() {
     let package_dir = public_cache_pkg(&cache_dir, "foo");
     assert!(
         tarball_cache_entries(&package_dir).is_empty(),
-        "a cache:false uplink must not write tarballs to the mirror",
+        "a cache:false upstream must not write tarballs to the mirror",
     );
 
     packument_mock.assert_async().await;
@@ -2394,7 +2394,7 @@ async fn cache_false_uplink_streams_tarball_without_mirroring() {
 }
 
 #[tokio::test]
-async fn cache_false_uplink_rejects_tampered_tarball_without_mirroring() {
+async fn cache_false_upstream_rejects_tampered_tarball_without_mirroring() {
     let mut upstream = mockito::Server::new_async().await;
     let good_bytes = b"good-uncached-tarball";
     let poison_bytes = b"poisoned-uncached-tarball";
@@ -2411,7 +2411,7 @@ async fn cache_false_uplink_rejects_tampered_tarball_without_mirroring() {
     let tmp = TempDir::new().unwrap();
     let cache_dir = tmp.path().to_path_buf();
     let mut config = config_for(&upstream.url(), cache_dir.clone());
-    config.uplinks.get_mut("npmjs").expect("default `npmjs` uplink").cache = false;
+    config.upstreams.get_mut("npmjs").expect("default `npmjs` upstream").cache = false;
     let app = router(config);
 
     let response = app
@@ -2644,9 +2644,9 @@ async fn mock_package(server: &mut mockito::Server, pkg: &str, marker: &str) -> 
 /// aliased by the path-less base.
 fn router_config(npmjs_url: &str, corp_url: &str, storage: PathBuf) -> Config {
     let mut config = config_for(npmjs_url, storage);
-    let mut corp = config.uplinks.get("npmjs").expect("default `npmjs` uplink").clone();
+    let mut corp = config.upstreams.get("npmjs").expect("default `npmjs` upstream").clone();
     corp.url = corp_url.to_string();
-    config.uplinks.insert("corp".to_string(), corp);
+    config.upstreams.insert("corp".to_string(), corp);
     let graph = vec![
         ("npmjs".to_string(), Registry::Upstream { patterns: vec![] }),
         (
@@ -2719,9 +2719,10 @@ async fn router_not_found_does_not_fall_through_to_public() {
 
     let tmp = TempDir::new().unwrap();
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    let mut corp_uplink = config.uplinks.get("npmjs").expect("default `npmjs` uplink").clone();
-    corp_uplink.url = corp.url();
-    config.uplinks.insert("corp".to_string(), corp_uplink);
+    let mut corp_upstream =
+        config.upstreams.get("npmjs").expect("default `npmjs` upstream").clone();
+    corp_upstream.url = corp.url();
+    config.upstreams.insert("corp".to_string(), corp_upstream);
     let graph = vec![
         (
             "corp".to_string(),
@@ -2764,9 +2765,10 @@ async fn router_unavailable_source_errors_not_404() {
     let tmp = TempDir::new().unwrap();
     // Point `corp` at a closed port so every fetch is a transport failure.
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    let mut corp_uplink = config.uplinks.get("npmjs").expect("default `npmjs` uplink").clone();
-    corp_uplink.url = "http://127.0.0.1:1".to_string();
-    config.uplinks.insert("corp".to_string(), corp_uplink);
+    let mut corp_upstream =
+        config.upstreams.get("npmjs").expect("default `npmjs` upstream").clone();
+    corp_upstream.url = "http://127.0.0.1:1".to_string();
+    config.upstreams.insert("corp".to_string(), corp_upstream);
     let graph = vec![
         (
             "corp".to_string(),
@@ -3201,7 +3203,7 @@ async fn off_pattern_publish_is_masked_for_callers_the_registry_denies() {
 }
 
 /// A programmatically-built registry graph gets the same fail-closed
-/// validation as a YAML load: server construction folds every uplink into
+/// validation as a YAML load: server construction folds every upstream into
 /// the graph and rejects an invalid graph instead of serving it.
 #[tokio::test]
 async fn building_the_server_rejects_an_invalid_programmatic_registry_graph() {
@@ -3216,6 +3218,36 @@ async fn building_the_server_rejects_an_invalid_programmatic_registry_graph() {
     let err =
         pnpr::try_router(config).expect_err("an unknown router source must fail server startup");
     assert!(err.to_string().contains("ghost"), "unexpected error: {err}");
+}
+
+/// A concrete registry declared in the graph without its serving config
+/// would answer every request not-found at runtime; server construction
+/// rejects the mismatch instead.
+#[tokio::test]
+async fn building_the_server_rejects_a_concrete_registry_without_serving_config() {
+    let tmp = TempDir::new().unwrap();
+
+    // A hosted graph entry with no hosted-table row.
+    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
+    config.registries = Registries::new(
+        vec![("ghost-org".to_string(), Registry::Hosted { patterns: vec![] })]
+            .into_iter()
+            .collect(),
+        None,
+    );
+    let err = pnpr::try_router(config).expect_err("a backing-less hosted registry must fail");
+    assert!(err.to_string().contains("ghost-org"), "unexpected error: {err}");
+
+    // An upstream graph entry with no upstream serving config.
+    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
+    config.registries = Registries::new(
+        vec![("phantom".to_string(), Registry::Upstream { patterns: vec![] })]
+            .into_iter()
+            .collect(),
+        None,
+    );
+    let err = pnpr::try_router(config).expect_err("a backing-less upstream registry must fail");
+    assert!(err.to_string().contains("phantom"), "unexpected error: {err}");
 }
 
 /// The programmatic path enforces the same name/org safety as YAML loading:
@@ -3239,9 +3271,9 @@ async fn building_the_server_rejects_an_unsafe_programmatic_hosted_org() {
 async fn publish_to_a_private_upstream_is_denied_before_the_upstream_rejection() {
     let tmp = TempDir::new().unwrap();
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    let mut corp = config.uplinks.get("npmjs").expect("default `npmjs` uplink").clone();
+    let mut corp = config.upstreams.get("npmjs").expect("default `npmjs` upstream").clone();
     corp.access = Some(AccessList::parse("alice"));
-    config.uplinks.insert("corp".to_string(), corp);
+    config.upstreams.insert("corp".to_string(), corp);
     let auth = AuthState::in_memory();
     let member = auth.tokens.issue("alice").await.unwrap();
     let outsider = auth.tokens.issue("mallory").await.unwrap();

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -3278,6 +3278,38 @@ async fn building_the_server_rejects_a_concrete_registry_without_serving_config(
     assert!(err.to_string().contains("phantom"), "unexpected error: {err}");
 }
 
+/// One name cannot identify two different origins: serving config left under
+/// a name the graph declares as a different kind fails construction,
+/// mirroring the YAML collision rejection.
+#[tokio::test]
+async fn building_the_server_rejects_a_name_shared_by_two_registry_kinds() {
+    let tmp = TempDir::new().unwrap();
+
+    // Upstream serving config under a name the graph declares as hosted.
+    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
+    config.registries = Registries::new(
+        vec![("npmjs".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
+        None,
+    );
+    let err = pnpr::try_router(config).expect_err("an upstream/hosted name collision must fail");
+    assert!(err.to_string().contains("collides"), "unexpected error: {err}");
+
+    // A hosted serving row under a name the graph declares as a router.
+    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
+    config.hosted.insert(
+        "corp".to_string(),
+        HostedConfig { org: "corp".to_string(), access: AccessList::parse("$all") },
+    );
+    config.registries = Registries::new(
+        vec![("corp".to_string(), Registry::Router { sources: vec!["npmjs".to_string()] })]
+            .into_iter()
+            .collect(),
+        None,
+    );
+    let err = pnpr::try_router(config).expect_err("a hosted/router name collision must fail");
+    assert!(err.to_string().contains("collides"), "unexpected error: {err}");
+}
+
 /// The programmatic path enforces the same name/org safety as YAML loading:
 /// a hosted `org` that could escape the storage root fails server startup.
 #[tokio::test]

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -6,7 +6,7 @@ use flate2::read::GzDecoder;
 use futures_util::stream;
 use pnpr::{
     AccessList, AuthState, Config, HostedConfig, MaxUsers, MountKind, Mounts, PackagePattern,
-    PackagePolicies, PackagePolicy, PublicRoute, Route, router, router_with_auth,
+    PackagePolicies, PackagePolicy, PublicRoute, router, router_with_auth,
 };
 use serde_json::{Value, json};
 use ssri::{Algorithm, IntegrityOpts};
@@ -2639,31 +2639,23 @@ async fn mock_package(server: &mut mockito::Server, pkg: &str, marker: &str) -> 
     body
 }
 
-/// Build a config with two public upstream mounts and a `main` router that
-/// sends `@corp/*` to `corp` and everything else to `npmjs`, aliased by the
-/// path-less base.
+/// Build a config with two public upstream mounts — `corp` claiming `@corp/*`
+/// and a pattern-less `npmjs` catch-all — and a `main` router over them,
+/// aliased by the path-less base.
 fn router_config(npmjs_url: &str, corp_url: &str, storage: PathBuf) -> Config {
     let mut config = config_for(npmjs_url, storage);
     let mut corp = config.uplinks.get("npmjs").expect("default `npmjs` uplink").clone();
     corp.url = corp_url.to_string();
     config.uplinks.insert("corp".to_string(), corp);
     let graph = vec![
-        ("npmjs".to_string(), MountKind::Upstream),
-        ("corp".to_string(), MountKind::Upstream),
+        ("npmjs".to_string(), MountKind::Upstream { patterns: vec![] }),
+        (
+            "corp".to_string(),
+            MountKind::Upstream { patterns: vec![PackagePattern::parse("@corp/*").unwrap()] },
+        ),
         (
             "main".to_string(),
-            MountKind::Router {
-                routes: vec![
-                    Route {
-                        patterns: vec![PackagePattern::parse("@corp/*").unwrap()],
-                        source: "corp".to_string(),
-                    },
-                    Route {
-                        patterns: vec![PackagePattern::parse("**").unwrap()],
-                        source: "npmjs".to_string(),
-                    },
-                ],
-            },
+            MountKind::Router { sources: vec!["corp".to_string(), "npmjs".to_string()] },
         ),
     ];
     let mounts = Mounts::new(graph.into_iter().collect(), Some("main".to_string()));
@@ -2715,11 +2707,15 @@ async fn router_routes_each_package_to_its_declared_source() {
 
 #[tokio::test]
 async fn router_not_found_does_not_fall_through_to_public() {
-    // A router whose only route is the private `@corp/*` scope. A public name
-    // it does not route must be a definitive 404 — never served from a public
-    // origin — which is the dependency-confusion vector closed by construction.
+    // A router whose only source claims the private `@corp/*` scope. A public
+    // name no source claims must be a definitive 404 — never served from a
+    // public origin — which is the dependency-confusion vector closed by
+    // construction. The same namespace bound holds on the mount's own URL:
+    // `/~corp/lodash` is a 404 answered before the upstream (and its
+    // server-owned credential) is consulted.
     let mut corp = mockito::Server::new_async().await;
     let _ = mock_package(&mut corp, "@corp/secret", "private").await;
+    let off_pattern_fetch = corp.mock("GET", "/lodash").expect(0).create_async().await;
 
     let tmp = TempDir::new().unwrap();
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
@@ -2727,21 +2723,16 @@ async fn router_not_found_does_not_fall_through_to_public() {
     corp_uplink.url = corp.url();
     config.uplinks.insert("corp".to_string(), corp_uplink);
     let graph = vec![
-        ("corp".to_string(), MountKind::Upstream),
         (
-            "main".to_string(),
-            MountKind::Router {
-                routes: vec![Route {
-                    patterns: vec![PackagePattern::parse("@corp/*").unwrap()],
-                    source: "corp".to_string(),
-                }],
-            },
+            "corp".to_string(),
+            MountKind::Upstream { patterns: vec![PackagePattern::parse("@corp/*").unwrap()] },
         ),
+        ("main".to_string(), MountKind::Router { sources: vec!["corp".to_string()] }),
     ];
     config.mounts = Mounts::new(graph.into_iter().collect(), Some("main".to_string()));
     let app = router_with_auth(config, AuthState::in_memory());
 
-    // The matched private scope still serves.
+    // The claimed private scope still serves.
     let matched = app
         .clone()
         .oneshot(Request::get("/~main/@corp/secret").body(Body::empty()).unwrap())
@@ -2749,10 +2740,20 @@ async fn router_not_found_does_not_fall_through_to_public() {
         .unwrap();
     assert_eq!(matched.status(), StatusCode::OK);
 
-    // An unrouted public name is a definitive not-found, not a fall-through.
-    let unrouted =
-        app.oneshot(Request::get("/~main/lodash").body(Body::empty()).unwrap()).await.unwrap();
-    assert_eq!(unrouted.status(), StatusCode::NOT_FOUND);
+    // An unclaimed public name is a definitive not-found, not a fall-through.
+    let unclaimed = app
+        .clone()
+        .oneshot(Request::get("/~main/lodash").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(unclaimed.status(), StatusCode::NOT_FOUND);
+
+    // Addressing the upstream mount directly is bounded the same way, without
+    // an upstream fetch.
+    let direct =
+        app.oneshot(Request::get("/~corp/lodash").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(direct.status(), StatusCode::NOT_FOUND);
+    off_pattern_fetch.assert_async().await;
 }
 
 #[tokio::test]
@@ -2767,16 +2768,11 @@ async fn router_unavailable_source_errors_not_404() {
     corp_uplink.url = "http://127.0.0.1:1".to_string();
     config.uplinks.insert("corp".to_string(), corp_uplink);
     let graph = vec![
-        ("corp".to_string(), MountKind::Upstream),
         (
-            "main".to_string(),
-            MountKind::Router {
-                routes: vec![Route {
-                    patterns: vec![PackagePattern::parse("@corp/*").unwrap()],
-                    source: "corp".to_string(),
-                }],
-            },
+            "corp".to_string(),
+            MountKind::Upstream { patterns: vec![PackagePattern::parse("@corp/*").unwrap()] },
         ),
+        ("main".to_string(), MountKind::Router { sources: vec!["corp".to_string()] }),
     ];
     config.mounts = Mounts::new(graph.into_iter().collect(), Some("main".to_string()));
     let app = router_with_auth(config, AuthState::in_memory());
@@ -2815,8 +2811,10 @@ async fn hosted_mount_serves_only_what_it_hosts() {
         "acme".to_string(),
         HostedConfig { org: "acme".to_string(), access: AccessList::parse("$all") },
     );
-    config.mounts =
-        Mounts::new(vec![("acme".to_string(), MountKind::Hosted)].into_iter().collect(), None);
+    config.mounts = Mounts::new(
+        vec![("acme".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
+        None,
+    );
     let app = router_with_auth(config, AuthState::in_memory());
 
     // A hosted package is served from the org mount.
@@ -2847,8 +2845,10 @@ async fn private_hosted_hides_existence_from_unauthorized_caller() {
         "acme".to_string(),
         HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice") },
     );
-    config.mounts =
-        Mounts::new(vec![("acme".to_string(), MountKind::Hosted)].into_iter().collect(), None);
+    config.mounts = Mounts::new(
+        vec![("acme".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
+        None,
+    );
     let auth = AuthState::in_memory();
     let token = auth.tokens.issue("alice").await.unwrap();
     let app = router_with_auth(config, auth);
@@ -2888,8 +2888,10 @@ async fn private_hosted_org_masks_before_the_package_acl() {
         "acme".to_string(),
         HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice") },
     );
-    config.mounts =
-        Mounts::new(vec![("acme".to_string(), MountKind::Hosted)].into_iter().collect(), None);
+    config.mounts = Mounts::new(
+        vec![("acme".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
+        None,
+    );
     // A per-package ACL that also denies the anonymous caller. Without the
     // visibility-first ordering this would return 401/403 and leak existence.
     config.policies = PackagePolicies::new(vec![
@@ -2929,7 +2931,7 @@ async fn private_hosted_org_masks_dist_tags_before_the_package_acl() {
     // The path-less base aliases the "acme" hosted mount, so `/-/package/...`
     // resolves to it.
     config.mounts = Mounts::new(
-        vec![("acme".to_string(), MountKind::Hosted)].into_iter().collect(),
+        vec![("acme".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("acme".to_string()),
     );
     config.policies = PackagePolicies::new(vec![
@@ -2960,25 +2962,18 @@ async fn publish_to_hosted_round_trips_in_its_own_namespace() {
         "acme".to_string(),
         HostedConfig { org: "acme".to_string(), access: AccessList::parse("$authenticated") },
     );
-    // npmjs already exists (from config_for); add a hosted org + a router that
-    // sends `@acme/*` to it and everything else to npmjs, aliased path-less.
+    // npmjs already exists (from config_for); add a hosted org claiming
+    // `@acme/*` + a router over it and the pattern-less npmjs catch-all,
+    // aliased path-less.
     let graph = vec![
-        ("npmjs".to_string(), MountKind::Upstream),
-        ("acme".to_string(), MountKind::Hosted),
+        ("npmjs".to_string(), MountKind::Upstream { patterns: vec![] }),
+        (
+            "acme".to_string(),
+            MountKind::Hosted { patterns: vec![PackagePattern::parse("@acme/*").unwrap()] },
+        ),
         (
             "main".to_string(),
-            MountKind::Router {
-                routes: vec![
-                    Route {
-                        patterns: vec![PackagePattern::parse("@acme/*").unwrap()],
-                        source: "acme".to_string(),
-                    },
-                    Route {
-                        patterns: vec![PackagePattern::parse("**").unwrap()],
-                        source: "npmjs".to_string(),
-                    },
-                ],
-            },
+            MountKind::Router { sources: vec!["acme".to_string(), "npmjs".to_string()] },
         ),
     ];
     config.mounts = Mounts::new(graph.into_iter().collect(), Some("main".to_string()));
@@ -3069,6 +3064,99 @@ async fn publish_to_hosted_round_trips_in_its_own_namespace() {
     assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
 }
 
+/// A hosted mount's declared `patterns:` are enforced on the mount itself, on
+/// every path to it: an off-pattern publish is rejected and an off-pattern
+/// read is a definitive 404 — through a router and at the mount's own
+/// `/~<mount>/` URL alike — so a typo'd scope can never squat in the hosted
+/// store and later surface as authoritative.
+#[tokio::test]
+async fn hosted_mount_patterns_bound_publish_and_reads_on_every_path() {
+    use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
+    config.hosted.insert(
+        "acme".to_string(),
+        HostedConfig { org: "acme".to_string(), access: AccessList::parse("$authenticated") },
+    );
+    // `acme` claims only `@acme/*`; the router has no other source, and the
+    // path-less base aliases the router.
+    let graph = vec![
+        (
+            "acme".to_string(),
+            MountKind::Hosted { patterns: vec![PackagePattern::parse("@acme/*").unwrap()] },
+        ),
+        ("main".to_string(), MountKind::Router { sources: vec!["acme".to_string()] }),
+    ];
+    let mounts = Mounts::new(graph.into_iter().collect(), Some("main".to_string()));
+    mounts.validate().expect("patterned hosted config is valid");
+    config.mounts = mounts;
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(config, auth);
+
+    let publish_body = |pkg: &str| {
+        let tarball = b"typo-bytes";
+        let bare = pkg.rsplit('/').next().unwrap();
+        json!({
+            "name": pkg,
+            "dist-tags": { "latest": "1.0.0" },
+            "versions": { "1.0.0": { "name": pkg, "version": "1.0.0", "dist": {
+                "tarball": format!("http://example.test/{pkg}/-/{bare}-1.0.0.tgz"),
+                "integrity": sha512_integrity(tarball),
+            } } },
+            "_attachments": { format!("{pkg}-1.0.0.tgz"): {
+                "content_type": "application/octet-stream",
+                "data": BASE64.encode(tarball),
+                "length": tarball.len(),
+            } },
+        })
+        .to_string()
+    };
+    let publish_to = |url: &str, pkg: &str| {
+        Request::put(url)
+            .header("content-type", "application/json")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::from(publish_body(pkg)))
+            .unwrap()
+    };
+
+    // An off-pattern publish is rejected on the mount's own URL, through the
+    // router, and via the path-less base — and nothing lands in the store.
+    for (url, pkg) in [
+        ("/~acme/@typo/widget", "@typo/widget"),
+        ("/~main/@typo/widget", "@typo/widget"),
+        ("/@typo%2Fwidget", "@typo/widget"),
+    ] {
+        let rejected = app.clone().oneshot(publish_to(url, pkg)).await.unwrap();
+        assert_eq!(rejected.status(), StatusCode::BAD_REQUEST, "publish {url} must be rejected");
+    }
+    assert!(
+        !tmp.path().join("acme/@typo/widget/package.json").exists(),
+        "an off-pattern publish must write nothing",
+    );
+
+    // A claimed name publishes normally through the mount's own URL.
+    let accepted = app.clone().oneshot(publish_to("/~acme/@acme/widget", "@acme/widget")).await;
+    assert_eq!(accepted.unwrap().status(), StatusCode::CREATED);
+
+    // An off-pattern read is a definitive 404 on both addresses, before the
+    // hosted store is consulted.
+    for url in ["/~acme/@typo/widget", "/~main/@typo/widget"] {
+        let read = app
+            .clone()
+            .oneshot(
+                Request::get(url)
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(read.status(), StatusCode::NOT_FOUND, "read {url} must 404");
+    }
+}
+
 /// The mount's access list gates writes exactly as it gates reads (RFC
 /// "registry mounts", implementation point 9). An authenticated non-member
 /// passes the default per-package publish policy (`$authenticated`), so
@@ -3088,7 +3176,7 @@ async fn private_hosted_mount_denies_writes_from_non_members() {
     // `/~corp/` addresses the mount directly; the path-less base aliases it,
     // so the path-less dist-tag and unpublish writes route there too.
     config.mounts = Mounts::new(
-        vec![("corp".to_string(), MountKind::Hosted)].into_iter().collect(),
+        vec![("corp".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("corp".to_string()),
     );
     let auth = AuthState::in_memory();
@@ -3182,7 +3270,7 @@ async fn search_does_not_enumerate_a_private_flat_root_mount() {
         HostedConfig { org: String::new(), access: AccessList::parse("alice") },
     );
     config.mounts = Mounts::new(
-        vec![("corp".to_string(), MountKind::Hosted)].into_iter().collect(),
+        vec![("corp".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("corp".to_string()),
     );
     let auth = AuthState::in_memory();
@@ -3232,8 +3320,10 @@ async fn mount_addressed_surface_serves_dist_tags_unpublish_whoami_search_and_ve
         HostedConfig { org: "acme".to_string(), access: AccessList::parse("$authenticated") },
     );
     // No default target: the mount is addressable only at `/~acme/`.
-    config.mounts =
-        Mounts::new(vec![("acme".to_string(), MountKind::Hosted)].into_iter().collect(), None);
+    config.mounts = Mounts::new(
+        vec![("acme".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
+        None,
+    );
     let auth = AuthState::in_memory();
     let token = auth.tokens.issue("alice").await.unwrap();
     let app = router_with_auth(config, auth);
@@ -3409,7 +3499,7 @@ async fn pathless_private_mount_responses_carry_private_cache_headers() {
         HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice") },
     );
     config.mounts = Mounts::new(
-        vec![("acme".to_string(), MountKind::Hosted)].into_iter().collect(),
+        vec![("acme".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("acme".to_string()),
     );
     let auth = AuthState::in_memory();
@@ -3449,7 +3539,7 @@ async fn pathless_private_mount_responses_carry_private_cache_headers() {
         HostedConfig { org: "acme".to_string(), access: AccessList::parse("$all") },
     );
     config.mounts = Mounts::new(
-        vec![("acme".to_string(), MountKind::Hosted)].into_iter().collect(),
+        vec![("acme".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("acme".to_string()),
     );
     let app = router_with_auth(config, AuthState::in_memory());
@@ -3477,7 +3567,7 @@ async fn pathless_acl_gated_package_carries_private_cache_headers() {
         HostedConfig { org: "acme".to_string(), access: AccessList::parse("$all") },
     );
     config.mounts = Mounts::new(
-        vec![("acme".to_string(), MountKind::Hosted)].into_iter().collect(),
+        vec![("acme".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("acme".to_string()),
     );
     config.policies = PackagePolicies::new(vec![

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -5,8 +5,8 @@ use axum::{
 use flate2::read::GzDecoder;
 use futures_util::stream;
 use pnpr::{
-    AccessList, AuthState, Config, HostedConfig, MaxUsers, MountKind, Mounts, PackagePattern,
-    PackagePolicies, PackagePolicy, PublicRoute, router, router_with_auth,
+    AccessList, AuthState, Config, HostedConfig, MaxUsers, PackagePattern, PackagePolicies,
+    PackagePolicy, PublicRoute, Registries, Registry, router, router_with_auth,
 };
 use serde_json::{Value, json};
 use ssri::{Algorithm, IntegrityOpts};
@@ -38,13 +38,13 @@ fn config_for(upstream: &str, storage: PathBuf) -> Config {
     config
 }
 
-/// A public upstream mount caches under `.pnpr-cache/~public/<digest>/<pkg>/`.
-/// The proxy tests use a single `npmjs` mount, so there is one digest dir; this
+/// A public upstream registry caches under `.pnpr-cache/~public/<digest>/<pkg>/`.
+/// The proxy tests use a single `npmjs` registry, so there is one digest dir; this
 /// resolves the per-package cache dir under it. When nothing is cached yet it
 /// returns a path that does not exist, so existence assertions read naturally.
 fn public_cache_pkg(cache_root: &Path, pkg: &str) -> PathBuf {
     let public = cache_root.join(".pnpr-cache").join("~public");
-    // The public cache holds one digest directory per public mount. These tests
+    // The public cache holds one digest directory per public registry. These tests
     // configure exactly one, so require at most one *directory* (ignoring stray
     // files and `read_dir` order) instead of trusting the first entry.
     let mut digest_dirs: Vec<PathBuf> = std::fs::read_dir(&public)
@@ -57,7 +57,7 @@ fn public_cache_pkg(cache_root: &Path, pkg: &str) -> PathBuf {
     digest_dirs.sort();
     assert!(
         digest_dirs.len() <= 1,
-        "expected at most one ~public mount namespace, found {digest_dirs:?}",
+        "expected at most one ~public registry namespace, found {digest_dirs:?}",
     );
     digest_dirs.first().cloned().unwrap_or_else(|| public.join("__none__")).join(pkg)
 }
@@ -387,8 +387,8 @@ async fn mock_packument_for_tarball(
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(packument.to_string())
-        // At least once: a `cache: true` mount fetches the packument a single
-        // time (then caches); a `cache: false` mount refetches per request.
+        // At least once: a `cache: true` registry fetches the packument a single
+        // time (then caches); a `cache: false` registry refetches per request.
         .expect_at_least(1)
         .create_async()
         .await
@@ -930,10 +930,10 @@ async fn uplink_cache_does_not_leak_to_the_public_path() {
     assert_eq!(body_bytes(public.into_body()).await, public_bytes);
 }
 
-/// Repointing a mount's `url:` must abandon the previous origin's cache: the
+/// Repointing a registry's `url:` must abandon the previous origin's cache: the
 /// namespace is keyed by the origin, so a warm entry fetched from the old
 /// upstream — packument or tarball, including via the cache-first tarball
-/// path — can never answer for the new one under the same mount name.
+/// path — can never answer for the new one under the same registry name.
 #[tokio::test]
 async fn repointing_an_uplink_url_abandons_the_old_origins_cache() {
     let mut old_origin = mockito::Server::new_async().await;
@@ -969,7 +969,7 @@ async fn repointing_an_uplink_url_abandons_the_old_origins_cache() {
     assert_eq!(primed.status(), StatusCode::OK);
     assert_eq!(body_bytes(primed.into_body()).await, old_bytes);
 
-    // Same storage, same mount name, new `url:` — the fresh entries must come
+    // Same storage, same registry name, new `url:` — the fresh entries must come
     // from the new origin, not the still-fresh cache of the old one.
     let app = router(config_for(&new_origin.url(), tmp.path().to_path_buf()));
     let repointed = app
@@ -2354,7 +2354,7 @@ async fn per_uplink_maxage_overrides_global_packument_ttl() {
 async fn cache_false_uplink_streams_tarball_without_mirroring() {
     let mut upstream = mockito::Server::new_async().await;
     let bytes = b"uncached-tarball-bytes";
-    // A `cache: false` mount streams everything through, so each of the two
+    // A `cache: false` registry streams everything through, so each of the two
     // requests refetches the packument as well as the tarball.
     let packument_mock = mock_packument_for_tarball(&mut upstream, "foo", "1.0.0", bytes).await;
     let mock = upstream
@@ -2606,7 +2606,7 @@ async fn registry_only_serves_registry_and_refuses_resolver_endpoints() {
 }
 
 // --------------------------------------------------------------------
-// Registry-mount routing (RFC: registry mounts for pnpr).
+// Registry routing (RFC: registries for pnpr).
 // --------------------------------------------------------------------
 
 /// Mock a one-version packument plus its tarball for `pkg` on `server`,
@@ -2639,7 +2639,7 @@ async fn mock_package(server: &mut mockito::Server, pkg: &str, marker: &str) -> 
     body
 }
 
-/// Build a config with two public upstream mounts — `corp` claiming `@corp/*`
+/// Build a config with two public upstream registries — `corp` claiming `@corp/*`
 /// and a pattern-less `npmjs` catch-all — and a `main` router over them,
 /// aliased by the path-less base.
 fn router_config(npmjs_url: &str, corp_url: &str, storage: PathBuf) -> Config {
@@ -2648,19 +2648,19 @@ fn router_config(npmjs_url: &str, corp_url: &str, storage: PathBuf) -> Config {
     corp.url = corp_url.to_string();
     config.uplinks.insert("corp".to_string(), corp);
     let graph = vec![
-        ("npmjs".to_string(), MountKind::Upstream { patterns: vec![] }),
+        ("npmjs".to_string(), Registry::Upstream { patterns: vec![] }),
         (
             "corp".to_string(),
-            MountKind::Upstream { patterns: vec![PackagePattern::parse("@corp/*").unwrap()] },
+            Registry::Upstream { patterns: vec![PackagePattern::parse("@corp/*").unwrap()] },
         ),
         (
             "main".to_string(),
-            MountKind::Router { sources: vec!["corp".to_string(), "npmjs".to_string()] },
+            Registry::Router { sources: vec!["corp".to_string(), "npmjs".to_string()] },
         ),
     ];
-    let mounts = Mounts::new(graph.into_iter().collect(), Some("main".to_string()));
-    mounts.validate().expect("router config is valid");
-    config.mounts = mounts;
+    let registries = Registries::new(graph.into_iter().collect(), Some("main".to_string()));
+    registries.validate().expect("router config is valid");
+    config.registries = registries;
     config
 }
 
@@ -2710,7 +2710,7 @@ async fn router_not_found_does_not_fall_through_to_public() {
     // A router whose only source claims the private `@corp/*` scope. A public
     // name no source claims must be a definitive 404 — never served from a
     // public origin — which is the dependency-confusion vector closed by
-    // construction. The same namespace bound holds on the mount's own URL:
+    // construction. The same namespace bound holds on the registry's own URL:
     // `/~corp/lodash` is a 404 answered before the upstream (and its
     // server-owned credential) is consulted.
     let mut corp = mockito::Server::new_async().await;
@@ -2725,11 +2725,11 @@ async fn router_not_found_does_not_fall_through_to_public() {
     let graph = vec![
         (
             "corp".to_string(),
-            MountKind::Upstream { patterns: vec![PackagePattern::parse("@corp/*").unwrap()] },
+            Registry::Upstream { patterns: vec![PackagePattern::parse("@corp/*").unwrap()] },
         ),
-        ("main".to_string(), MountKind::Router { sources: vec!["corp".to_string()] }),
+        ("main".to_string(), Registry::Router { sources: vec!["corp".to_string()] }),
     ];
-    config.mounts = Mounts::new(graph.into_iter().collect(), Some("main".to_string()));
+    config.registries = Registries::new(graph.into_iter().collect(), Some("main".to_string()));
     let app = router_with_auth(config, AuthState::in_memory());
 
     // The claimed private scope still serves.
@@ -2748,7 +2748,7 @@ async fn router_not_found_does_not_fall_through_to_public() {
         .unwrap();
     assert_eq!(unclaimed.status(), StatusCode::NOT_FOUND);
 
-    // Addressing the upstream mount directly is bounded the same way, without
+    // Addressing the upstream registry directly is bounded the same way, without
     // an upstream fetch.
     let direct =
         app.oneshot(Request::get("/~corp/lodash").body(Body::empty()).unwrap()).await.unwrap();
@@ -2770,11 +2770,11 @@ async fn router_unavailable_source_errors_not_404() {
     let graph = vec![
         (
             "corp".to_string(),
-            MountKind::Upstream { patterns: vec![PackagePattern::parse("@corp/*").unwrap()] },
+            Registry::Upstream { patterns: vec![PackagePattern::parse("@corp/*").unwrap()] },
         ),
-        ("main".to_string(), MountKind::Router { sources: vec!["corp".to_string()] }),
+        ("main".to_string(), Registry::Router { sources: vec!["corp".to_string()] }),
     ];
-    config.mounts = Mounts::new(graph.into_iter().collect(), Some("main".to_string()));
+    config.registries = Registries::new(graph.into_iter().collect(), Some("main".to_string()));
     let app = router_with_auth(config, AuthState::in_memory());
 
     let response = app
@@ -2801,7 +2801,7 @@ fn seed_hosted(storage: &Path, pkg: &str) {
 }
 
 #[tokio::test]
-async fn hosted_mount_serves_only_what_it_hosts() {
+async fn hosted_registry_serves_only_what_it_hosts() {
     let tmp = TempDir::new().unwrap();
     // The org "acme" stores under its own namespace (`<storage>/acme/`).
     seed_hosted(&tmp.path().join("acme"), "@acme/widget");
@@ -2811,13 +2811,13 @@ async fn hosted_mount_serves_only_what_it_hosts() {
         "acme".to_string(),
         HostedConfig { org: "acme".to_string(), access: AccessList::parse("$all") },
     );
-    config.mounts = Mounts::new(
-        vec![("acme".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
+    config.registries = Registries::new(
+        vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         None,
     );
     let app = router_with_auth(config, AuthState::in_memory());
 
-    // A hosted package is served from the org mount.
+    // A hosted package is served from the org registry.
     let hit = app
         .clone()
         .oneshot(Request::get("/~acme/@acme/widget").body(Body::empty()).unwrap())
@@ -2845,8 +2845,8 @@ async fn private_hosted_hides_existence_from_unauthorized_caller() {
         "acme".to_string(),
         HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice") },
     );
-    config.mounts = Mounts::new(
-        vec![("acme".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
+    config.registries = Registries::new(
+        vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         None,
     );
     let auth = AuthState::in_memory();
@@ -2876,7 +2876,7 @@ async fn private_hosted_hides_existence_from_unauthorized_caller() {
 }
 
 /// A private org's 404 mask must win over a *denying per-package ACL* on every
-/// mount-served read path: otherwise the ACL's 401/403 would fire first and
+/// registry-served read path: otherwise the ACL's 401/403 would fire first and
 /// reveal that the package exists.
 #[tokio::test]
 async fn private_hosted_org_masks_before_the_package_acl() {
@@ -2888,8 +2888,8 @@ async fn private_hosted_org_masks_before_the_package_acl() {
         "acme".to_string(),
         HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice") },
     );
-    config.mounts = Mounts::new(
-        vec![("acme".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
+    config.registries = Registries::new(
+        vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         None,
     );
     // A per-package ACL that also denies the anonymous caller. Without the
@@ -2917,7 +2917,7 @@ async fn private_hosted_org_masks_before_the_package_acl() {
 }
 
 /// The same 404-before-ACL masking must hold on the path-less `dist-tags` reader
-/// (`load_packument_for_read`), which resolves through the default-target mount.
+/// (`load_packument_for_read`), which resolves through the default-target registry.
 #[tokio::test]
 async fn private_hosted_org_masks_dist_tags_before_the_package_acl() {
     let tmp = TempDir::new().unwrap();
@@ -2928,10 +2928,10 @@ async fn private_hosted_org_masks_dist_tags_before_the_package_acl() {
         "acme".to_string(),
         HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice") },
     );
-    // The path-less base aliases the "acme" hosted mount, so `/-/package/...`
+    // The path-less base aliases the "acme" hosted registry, so `/-/package/...`
     // resolves to it.
-    config.mounts = Mounts::new(
-        vec![("acme".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
+    config.registries = Registries::new(
+        vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("acme".to_string()),
     );
     config.policies = PackagePolicies::new(vec![
@@ -2966,17 +2966,17 @@ async fn publish_to_hosted_round_trips_in_its_own_namespace() {
     // `@acme/*` + a router over it and the pattern-less npmjs catch-all,
     // aliased path-less.
     let graph = vec![
-        ("npmjs".to_string(), MountKind::Upstream { patterns: vec![] }),
+        ("npmjs".to_string(), Registry::Upstream { patterns: vec![] }),
         (
             "acme".to_string(),
-            MountKind::Hosted { patterns: vec![PackagePattern::parse("@acme/*").unwrap()] },
+            Registry::Hosted { patterns: vec![PackagePattern::parse("@acme/*").unwrap()] },
         ),
         (
             "main".to_string(),
-            MountKind::Router { sources: vec!["acme".to_string(), "npmjs".to_string()] },
+            Registry::Router { sources: vec!["acme".to_string(), "npmjs".to_string()] },
         ),
     ];
-    config.mounts = Mounts::new(graph.into_iter().collect(), Some("main".to_string()));
+    config.registries = Registries::new(graph.into_iter().collect(), Some("main".to_string()));
     let auth = AuthState::in_memory();
     let token = auth.tokens.issue("alice").await.unwrap();
     let app = router_with_auth(config, auth);
@@ -3064,13 +3064,13 @@ async fn publish_to_hosted_round_trips_in_its_own_namespace() {
     assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
 }
 
-/// A hosted mount's declared `patterns:` are enforced on the mount itself, on
+/// A hosted registry's declared `patterns:` are enforced on the registry itself, on
 /// every path to it: an off-pattern publish is rejected and an off-pattern
-/// read is a definitive 404 — through a router and at the mount's own
-/// `/~<mount>/` URL alike — so a typo'd scope can never squat in the hosted
+/// read is a definitive 404 — through a router and at the registry's own
+/// `/~<name>/` URL alike — so a typo'd scope can never squat in the hosted
 /// store and later surface as authoritative.
 #[tokio::test]
-async fn hosted_mount_patterns_bound_publish_and_reads_on_every_path() {
+async fn hosted_registry_patterns_bound_publish_and_reads_on_every_path() {
     use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 
     let tmp = TempDir::new().unwrap();
@@ -3084,13 +3084,13 @@ async fn hosted_mount_patterns_bound_publish_and_reads_on_every_path() {
     let graph = vec![
         (
             "acme".to_string(),
-            MountKind::Hosted { patterns: vec![PackagePattern::parse("@acme/*").unwrap()] },
+            Registry::Hosted { patterns: vec![PackagePattern::parse("@acme/*").unwrap()] },
         ),
-        ("main".to_string(), MountKind::Router { sources: vec!["acme".to_string()] }),
+        ("main".to_string(), Registry::Router { sources: vec!["acme".to_string()] }),
     ];
-    let mounts = Mounts::new(graph.into_iter().collect(), Some("main".to_string()));
-    mounts.validate().expect("patterned hosted config is valid");
-    config.mounts = mounts;
+    let registries = Registries::new(graph.into_iter().collect(), Some("main".to_string()));
+    registries.validate().expect("patterned hosted config is valid");
+    config.registries = registries;
     let auth = AuthState::in_memory();
     let token = auth.tokens.issue("alice").await.unwrap();
     let app = router_with_auth(config, auth);
@@ -3121,7 +3121,7 @@ async fn hosted_mount_patterns_bound_publish_and_reads_on_every_path() {
             .unwrap()
     };
 
-    // An off-pattern publish is rejected on the mount's own URL, through the
+    // An off-pattern publish is rejected on the registry's own URL, through the
     // router, and via the path-less base — and nothing lands in the store.
     for (url, pkg) in [
         ("/~acme/@typo/widget", "@typo/widget"),
@@ -3136,7 +3136,7 @@ async fn hosted_mount_patterns_bound_publish_and_reads_on_every_path() {
         "an off-pattern publish must write nothing",
     );
 
-    // A claimed name publishes normally through the mount's own URL.
+    // A claimed name publishes normally through the registry's own URL.
     let accepted = app.clone().oneshot(publish_to("/~acme/@acme/widget", "@acme/widget")).await;
     assert_eq!(accepted.unwrap().status(), StatusCode::CREATED);
 
@@ -3157,14 +3157,14 @@ async fn hosted_mount_patterns_bound_publish_and_reads_on_every_path() {
     }
 }
 
-/// The mount's access list gates writes exactly as it gates reads (RFC
-/// "registry mounts", implementation point 9). An authenticated non-member
+/// The registry's access list gates writes exactly as it gates reads (RFC
+/// "registries", implementation point 9). An authenticated non-member
 /// passes the default per-package publish policy (`$authenticated`), so
-/// without the mount-level gate they could publish into — or retag and
+/// without the registry-level gate they could publish into — or retag and
 /// unpublish from — a private hosted org. The denial is the same 404 mask
-/// reads use, so the write path reveals nothing about the mount either.
+/// reads use, so the write path reveals nothing about the registry either.
 #[tokio::test]
-async fn private_hosted_mount_denies_writes_from_non_members() {
+async fn private_hosted_registry_denies_writes_from_non_members() {
     use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 
     let tmp = TempDir::new().unwrap();
@@ -3173,10 +3173,10 @@ async fn private_hosted_mount_denies_writes_from_non_members() {
         "corp".to_string(),
         HostedConfig { org: "corp".to_string(), access: AccessList::parse("alice") },
     );
-    // `/~corp/` addresses the mount directly; the path-less base aliases it,
+    // `/~corp/` addresses the registry directly; the path-less base aliases it,
     // so the path-less dist-tag and unpublish writes route there too.
-    config.mounts = Mounts::new(
-        vec![("corp".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
+    config.registries = Registries::new(
+        vec![("corp".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("corp".to_string()),
     );
     let auth = AuthState::in_memory();
@@ -3215,7 +3215,7 @@ async fn private_hosted_mount_denies_writes_from_non_members() {
     };
 
     // The non-member publish is masked with 404 — not 401/403, which would
-    // reveal the private mount exists — and nothing lands on disk.
+    // reveal the private registry exists — and nothing lands on disk.
     let denied = app.clone().oneshot(publish_as(&outsider)).await.unwrap();
     assert_eq!(denied.status(), StatusCode::NOT_FOUND);
     assert!(
@@ -3251,26 +3251,26 @@ async fn private_hosted_mount_denies_writes_from_non_members() {
     assert_eq!(retag_allowed.status(), StatusCode::CREATED);
 }
 
-/// Search scans the flat hosted store, so it must apply the owning mount's
-/// access list, not only the per-package ACL: a private flat-root mount
+/// Search scans the flat hosted store, so it must apply the owning registry's
+/// access list, not only the per-package ACL: a private flat-root registry
 /// (`org: ""`) is 404-masked on packument reads and must not be enumerable
 /// by name/version/description through `/-/v1/search`.
 #[tokio::test]
-async fn search_does_not_enumerate_a_private_flat_root_mount() {
+async fn search_does_not_enumerate_a_private_flat_root_registry() {
     let tmp = TempDir::new().unwrap();
     // The flat root (`org: ""`) stores directly under `storage`.
     seed_hosted(tmp.path(), "@corp/secret-tool");
 
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    // Replace the default public flat-root mount (`local`) with a private one;
+    // Replace the default public flat-root registry (`local`) with a private one;
     // any surviving `$all` flat-root entry would defeat the gate under test.
     config.hosted.clear();
     config.hosted.insert(
         "corp".to_string(),
         HostedConfig { org: String::new(), access: AccessList::parse("alice") },
     );
-    config.mounts = Mounts::new(
-        vec![("corp".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
+    config.registries = Registries::new(
+        vec![("corp".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("corp".to_string()),
     );
     let auth = AuthState::in_memory();
@@ -3287,7 +3287,7 @@ async fn search_does_not_enumerate_a_private_flat_root_mount() {
     };
 
     // Neither the anonymous caller nor an authenticated non-member can
-    // enumerate the private mount's packages.
+    // enumerate the private registry's packages.
     for authorization in [None, Some(format!("Bearer {outsider}"))] {
         let response = app.clone().oneshot(search_with(authorization)).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
@@ -3303,14 +3303,15 @@ async fn search_does_not_enumerate_a_private_flat_root_mount() {
     assert_eq!(body["objects"][0]["package"]["name"], json!("@corp/secret-tool"));
 }
 
-/// Every registry operation routes through the mount graph when addressed as
-/// `/~<mount>/...` (RFC "registry mounts", implementation point 7): dist-tag
+/// Every registry operation routes through the registry graph when addressed as
+/// `/~<name>/...` (RFC "registries", implementation point 7): dist-tag
 /// read/add/remove, whoami, search, the version manifest, and the whole
-/// unpublish flow. The mount here is deliberately *not* reachable from any
-/// default target — without the mount-addressed surface these operations
+/// unpublish flow. The registry here is deliberately *not* reachable from any
+/// default target — without the registry-addressed surface these operations
 /// would be impossible for it.
 #[tokio::test]
-async fn mount_addressed_surface_serves_dist_tags_unpublish_whoami_search_and_version_manifest() {
+async fn registry_addressed_surface_serves_dist_tags_unpublish_whoami_search_and_version_manifest()
+{
     use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 
     let tmp = TempDir::new().unwrap();
@@ -3319,9 +3320,9 @@ async fn mount_addressed_surface_serves_dist_tags_unpublish_whoami_search_and_ve
         "acme".to_string(),
         HostedConfig { org: "acme".to_string(), access: AccessList::parse("$authenticated") },
     );
-    // No default target: the mount is addressable only at `/~acme/`.
-    config.mounts = Mounts::new(
-        vec![("acme".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
+    // No default target: the registry is addressable only at `/~acme/`.
+    config.registries = Registries::new(
+        vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         None,
     );
     let auth = AuthState::in_memory();
@@ -3331,7 +3332,7 @@ async fn mount_addressed_surface_serves_dist_tags_unpublish_whoami_search_and_ve
         request.header(header::AUTHORIZATION, format!("Bearer {token}"))
     };
 
-    // Seed the mount through its own publish endpoint.
+    // Seed the registry through its own publish endpoint.
     let tarball = b"acme-widget-bytes";
     let publish_body = json!({
         "name": "@acme/widget",
@@ -3358,7 +3359,7 @@ async fn mount_addressed_surface_serves_dist_tags_unpublish_whoami_search_and_ve
         .unwrap();
     assert_eq!(publish.status(), StatusCode::CREATED);
 
-    // dist-tags read through the mount.
+    // dist-tags read through the registry.
     let tags = app
         .clone()
         .oneshot(
@@ -3404,7 +3405,7 @@ async fn mount_addressed_surface_serves_dist_tags_unpublish_whoami_search_and_ve
         .unwrap();
     assert_eq!(remove.status(), StatusCode::CREATED);
 
-    // whoami through the mount.
+    // whoami through the registry.
     let whoami = app
         .clone()
         .oneshot(authed(Request::get("/~acme/-/whoami")).body(Body::empty()).unwrap())
@@ -3413,8 +3414,8 @@ async fn mount_addressed_surface_serves_dist_tags_unpublish_whoami_search_and_ve
     assert_eq!(whoami.status(), StatusCode::OK);
     assert_eq!(body_json(whoami.into_body()).await["username"], json!("alice"));
 
-    // Search through the mount finds the hosted package; the anonymous
-    // caller (whom the mount denies) gets an empty result.
+    // Search through the registry finds the hosted package; the anonymous
+    // caller (whom the registry denies) gets an empty result.
     let search = app
         .clone()
         .oneshot(
@@ -3432,8 +3433,8 @@ async fn mount_addressed_surface_serves_dist_tags_unpublish_whoami_search_and_ve
         .unwrap();
     assert_eq!(body_json(anon_search.into_body()).await["total"], json!(0));
 
-    // Version manifest through the mount, with `dist.tarball` rewritten onto
-    // the mount's own base.
+    // Version manifest through the registry, with `dist.tarball` rewritten onto
+    // the registry's own base.
     let manifest = app
         .clone()
         .oneshot(authed(Request::get("/~acme/@acme/widget/1.0.0")).body(Body::empty()).unwrap())
@@ -3448,7 +3449,7 @@ async fn mount_addressed_surface_serves_dist_tags_unpublish_whoami_search_and_ve
 
     // The unpublish flow: PUT back a packument without the version, delete
     // its tarball (the unencoded scoped 7-segment form), then delete the
-    // package — all through the mount.
+    // package — all through the registry.
     let put_back = app
         .clone()
         .oneshot(
@@ -3484,12 +3485,12 @@ async fn mount_addressed_surface_serves_dist_tags_unpublish_whoami_search_and_ve
     assert!(!tmp.path().join("acme/@acme/widget").exists());
 }
 
-/// Path-less responses resolved to a private mount carry the same
+/// Path-less responses resolved to a private registry carry the same
 /// `Cache-Control: private, no-store` / `Vary: Authorization` headers the
-/// `/~<mount>/` surface applies — same content, same defense against a shared
+/// `/~<name>/` surface applies — same content, same defense against a shared
 /// HTTP cache. A public resolution stays cacheable.
 #[tokio::test]
-async fn pathless_private_mount_responses_carry_private_cache_headers() {
+async fn pathless_private_registry_responses_carry_private_cache_headers() {
     let tmp = TempDir::new().unwrap();
     seed_hosted(&tmp.path().join("acme"), "@acme/widget");
 
@@ -3498,8 +3499,8 @@ async fn pathless_private_mount_responses_carry_private_cache_headers() {
         "acme".to_string(),
         HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice") },
     );
-    config.mounts = Mounts::new(
-        vec![("acme".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
+    config.registries = Registries::new(
+        vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("acme".to_string()),
     );
     let auth = AuthState::in_memory();
@@ -3530,7 +3531,7 @@ async fn pathless_private_mount_responses_carry_private_cache_headers() {
         );
     }
 
-    // Control: the same content behind a public mount stays cacheable.
+    // Control: the same content behind a public registry stays cacheable.
     let tmp_public = TempDir::new().unwrap();
     seed_hosted(&tmp_public.path().join("acme"), "@acme/widget");
     let mut config = config_for("http://127.0.0.1:1", tmp_public.path().to_path_buf());
@@ -3538,8 +3539,8 @@ async fn pathless_private_mount_responses_carry_private_cache_headers() {
         "acme".to_string(),
         HostedConfig { org: "acme".to_string(), access: AccessList::parse("$all") },
     );
-    config.mounts = Mounts::new(
-        vec![("acme".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
+    config.registries = Registries::new(
+        vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("acme".to_string()),
     );
     let app = router_with_auth(config, AuthState::in_memory());
@@ -3553,7 +3554,7 @@ async fn pathless_private_mount_responses_carry_private_cache_headers() {
 }
 
 /// A per-package ACL that denies anonymous callers makes the path-less
-/// response vary by `Authorization` even when the source mount itself is
+/// response vary by `Authorization` even when the source registry itself is
 /// public, so it must carry the private-cache headers — otherwise a shared
 /// HTTP cache could replay an authenticated 200 to an anonymous caller.
 #[tokio::test]
@@ -3566,8 +3567,8 @@ async fn pathless_acl_gated_package_carries_private_cache_headers() {
         "acme".to_string(),
         HostedConfig { org: "acme".to_string(), access: AccessList::parse("$all") },
     );
-    config.mounts = Mounts::new(
-        vec![("acme".to_string(), MountKind::Hosted { patterns: vec![] })].into_iter().collect(),
+    config.registries = Registries::new(
+        vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("acme".to_string()),
     );
     config.policies = PackagePolicies::new(vec![
@@ -3650,20 +3651,20 @@ async fn upstream_404_purges_cached_packument() {
 
 /// The identity endpoints — adduser/login, whoami, profile, token list,
 /// logout, token revoke — are global, so they are served under *any*
-/// `/~<prefix>/` without consulting the mount table: clients derive these
+/// `/~<prefix>/` without consulting the registry table: clients derive these
 /// URLs from their configured registry URL, so `pnpm login --registry
 /// .../~corp/` must work even when nothing named `corp` is mounted. Skipping
 /// the lookup also keeps them from becoming an existence oracle for private
-/// mount names (a defined and an undefined mount must not answer
+/// registry names (a defined and an undefined registry must not answer
 /// differently).
 #[tokio::test]
-async fn identity_endpoints_are_served_under_any_mount_prefix() {
+async fn identity_endpoints_are_served_under_any_registry_prefix() {
     let tmp = TempDir::new().unwrap();
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
     config.auth.htpasswd.max_users = MaxUsers::Unlimited;
     let app = router(config);
 
-    // Login against a mount prefix that is NOT a defined mount.
+    // Login against a registry prefix that is NOT a defined registry.
     let registration = json!({
         "_id": "org.couchdb.user:alice",
         "name": "alice",
@@ -3753,7 +3754,7 @@ async fn identity_endpoints_are_served_under_any_mount_prefix() {
     assert_eq!(stale.status(), StatusCode::UNAUTHORIZED);
 
     // No existence oracle: anonymous whoami answers 401 identically whether
-    // or not the prefix names a real mount (`npmjs` is defined by config_for).
+    // or not the prefix names a real registry (`npmjs` is defined by config_for).
     for path in ["/~corp/-/whoami", "/~npmjs/-/whoami"] {
         let response =
             app.clone().oneshot(Request::get(path).body(Body::empty()).unwrap()).await.unwrap();

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -3157,6 +3157,67 @@ async fn hosted_registry_patterns_bound_publish_and_reads_on_every_path() {
     }
 }
 
+/// The off-pattern publish rejection explains a config fact about the
+/// addressed registry, so it is only for callers the registry admits: a
+/// denied caller gets the same 404 mask every read gives, and an unclaimed
+/// probe cannot distinguish a private registry from an undefined one.
+#[tokio::test]
+async fn off_pattern_publish_is_masked_for_callers_the_registry_denies() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
+    config.hosted.insert(
+        "corp".to_string(),
+        HostedConfig { org: "corp".to_string(), access: AccessList::parse("alice") },
+    );
+    config.registries = Registries::new(
+        vec![(
+            "corp".to_string(),
+            Registry::Hosted { patterns: vec![PackagePattern::parse("@corp/*").unwrap()] },
+        )]
+        .into_iter()
+        .collect(),
+        None,
+    );
+    let auth = AuthState::in_memory();
+    let member = auth.tokens.issue("alice").await.unwrap();
+    let outsider = auth.tokens.issue("mallory").await.unwrap();
+    let app = router_with_auth(config, auth);
+
+    let publish_as = |token: &str| {
+        Request::put("/~corp/@typo/widget")
+            .header("content-type", "application/json")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::from(json!({ "name": "@typo/widget", "versions": {} }).to_string()))
+            .unwrap()
+    };
+
+    // The denied caller sees exactly what an undefined registry would give.
+    let masked = app.clone().oneshot(publish_as(&outsider)).await.unwrap();
+    assert_eq!(masked.status(), StatusCode::NOT_FOUND);
+
+    // The member gets the loud off-pattern rejection.
+    let rejected = app.oneshot(publish_as(&member)).await.unwrap();
+    assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
+}
+
+/// A programmatically-built registry graph gets the same fail-closed
+/// validation as a YAML load: server construction folds every uplink into
+/// the graph and rejects an invalid graph instead of serving it.
+#[tokio::test]
+async fn building_the_server_rejects_an_invalid_programmatic_registry_graph() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
+    config.registries = Registries::new(
+        vec![("main".to_string(), Registry::Router { sources: vec!["ghost".to_string()] })]
+            .into_iter()
+            .collect(),
+        None,
+    );
+    let err =
+        pnpr::try_router(config).expect_err("an unknown router source must fail server startup");
+    assert!(err.to_string().contains("ghost"), "unexpected error: {err}");
+}
+
 /// The registry's access list gates writes exactly as it gates reads (RFC
 /// "registries", implementation point 9). An authenticated non-member
 /// passes the default per-package publish policy (`$authenticated`), so

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -671,11 +671,39 @@ async fn upstream_auth_and_custom_headers_are_forwarded_upstream() {
     let upstream = config.upstreams.get_mut("npmjs").expect("default `npmjs` upstream");
     upstream.headers.insert("authorization", "Bearer secret-token".parse().unwrap());
     upstream.headers.insert("x-org", "acme".parse().unwrap());
-    let app = router(config);
+    // A credentialed upstream must be access-gated (server construction
+    // enforces it), so the read authenticates as an admitted caller.
+    upstream.access = Some(AccessList::parse("$authenticated"));
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(config, auth);
 
-    let response = app.oneshot(Request::get("/foo").body(Body::empty()).unwrap()).await.unwrap();
+    let response = app
+        .oneshot(
+            Request::get("/foo")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     mock.assert_async().await;
+}
+
+/// Mirrors the YAML rule at the programmatic layer: an upstream reachable
+/// without an `access:` gate may not send custom headers — any header can
+/// carry a credential, and an ungated `/~<name>/` would let every caller
+/// spend it.
+#[tokio::test]
+async fn building_the_server_rejects_an_ungated_credentialed_upstream() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
+    let upstream = config.upstreams.get_mut("npmjs").expect("default `npmjs` upstream");
+    upstream.headers.insert("x-api-key", "secret".parse().unwrap());
+    let err =
+        pnpr::try_router(config).expect_err("an ungated credentialed upstream must fail startup");
+    assert!(err.to_string().contains("npmjs"), "unexpected error: {err}");
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Implements the revised model from pnpm/rfcs#16 in pnpr, replacing the route-level-pattern shape (landed by pnpm/pnpm#12747) outright — pnpr is pre-1.0, so there is no compatibility mode and no migration for the old keys.

- **Mounts are renamed to registries.** Per the RFC's updated Rationale, the unit is simply a named **registry**: the YAML surface is now `registries:` / `defaultRegistry:` (was `mounts:` / `defaultTarget:`), and the Rust surface follows the RFC's sketch (`MountKind` → `Registry`, `Mounts` → `Registries`, `MountConfigError` → `RegistryConfigError`, the `mount` module → `registry`, `Config.mounts` → `Config.registries`, "name a hosted registry" errors, `/~<name>/` in docs). The axum-level "routes are mounted" wording stays — that's framework vocabulary, not the renamed concept.
- **Patterns move onto the concrete registries.** Hosted and upstream registries take an optional `patterns:` list (same four-shape decidable language: `**`, `@*/*`, `@scope/*`, exact name; omitted = every name). This is the registry's declared namespace — its routing claim and its request filter in one declaration.
- **Routers collapse to ordered `sources:` lists.** A package resolves to the first listed source whose patterns claim it, authoritatively. A pattern-less source claims every name (the catch-all) and must be listed last. A router can order competing claims but can never assign a name to a registry that doesn't claim it.
- **The namespace is enforced at the registry, on every path to it.** An off-pattern read is a definitive 404 answered before storage or the upstream is consulted; an off-pattern publish is rejected with a clear 400 naming the reason — through a router, via the path-less base, and at the registry's own `/~<name>/` URL alike. This closes the open hosted namespace (no dormant stored state that a later config edit or direct address would surface as authoritative, and a typo'd scope fails loudly at publish time) and stops an authorized caller from pulling arbitrary public names through a private upstream's server-owned credential.
- **Validation** uses the same `covers()` machinery: unreachable sources (all claims covered by earlier sources' union, including a non-last pattern-less source), per-pattern shadowing across sources (identical claims by two sources are rejected, so namespaces that overlap in both directions fail in either order — genuinely ambiguous provenance), duplicate sources per router, duplicate patterns per registry, plus the carried-over unknown-source / self-reference / router-as-source / empty-router checks. A registry's own internally redundant patterns are allowed and don't count as self-shadowing.

Implementation choice: patterns live only in the registry graph (`Config::registries`), not duplicated into the hosted/uplink tables — enforcement happens in `Registries::resolve`, which every read, write, search, and cache-header decision already flows through, so the namespace really is one declaration. The bundled `config.yaml` moves the registry-mock fixture list onto the `local` registry (`main` becomes `sources: [local, npmjs]`), and `Config::proxy` / `Config::static_serve` build the equivalent graphs programmatically.

Tests: the registry unit suite is reworked for the new shapes and validation matrix; config tests cover registry-level `patterns:` parsing, duplicate/invalid pattern rejection, the `registries:` / `defaultRegistry:` keys, and the misordered-`sources:` startup failure; new server e2e tests pin off-pattern publish rejection and read 404s on every path (with an `expect(0)` mock proving a bounded upstream is never contacted for an unclaimed name), plus the existing no-fall-through, source-down-is-5xx, masking, and cache-header suites. 575 pnpr tests pass, and the pacquet e2e tests that drive a live pnpr server (`pnpr_install`) pass. A review round hardened two edges: server construction now folds every programmatic uplink into the registry graph and validates it (the per-request uplink fallback in dispatch is gone, so `Registries::resolve` is the only dispatch table), and the off-pattern publish rejection is gated on registry visibility so a denied caller gets the same 404 mask as on reads instead of a private-registry-revealing 400. Further rounds validate programmatic configs exactly like YAML loads (URL-safe names, path-safe and collision-free hosted orgs, scope patterns no package name could match, and concrete graph entries without backing serving config all fail startup), gate writes to private upstreams on their `access:` list (the read path's 403) before any routing rejection, and rename the remaining verdaccio-era "uplink" vocabulary to "upstream" (`UpstreamConfig`, `Config.upstreams`, the `~upstreams/` private cache namespace) — "uplink" survives only where compatibility demands it (the `_uplinks` verdaccio storage field and the legacy `uplinks:` YAML the benchmark emits for pre-registries binaries).

## Squash Commit Body

```text
Implements the revised model from pnpm/rfcs#16, replacing the
route-level-pattern shape outright (pre-1.0, no compatibility mode).

The config surface is renamed per the RFC: `mounts:` -> `registries:`,
`defaultTarget:` -> `defaultRegistry:`, and the Rust types follow
(`MountKind` -> `Registry`, `Mounts` -> `Registries`, the `mount` module
-> `registry`). The vocabulary is now: registry — a named surface pnpr
serves; origin — the external URL an upstream registry fetches from.

Hosted and upstream registries take an optional `patterns:` list — their
declared namespace (omitted = every name) — and a router collapses to an
ordered `sources:` list: a package resolves to the first listed source
whose patterns claim it. The namespace is enforced at the registry, on
every path to it: an off-pattern read is a definitive 404 answered before
storage or the upstream is consulted, and an off-pattern publish is
rejected with a clear reason — through a router and at the registry's own
`/~<name>/` URL alike. This closes the open hosted namespace (no dormant
stored state that a later source edit would surface as authoritative) and
stops an authorized caller from pulling arbitrary public names through a
private upstream's server-owned credential.

Validation translates to the same `covers()` machinery: unreachable
sources (all claims covered by earlier sources' union, including a
non-last pattern-less source), per-pattern shadowing across sources
(identical claims by two sources rejected, so bidirectionally-overlapping
namespaces fail in either order), duplicate sources per router, duplicate
patterns per registry, plus the carried-over unknown/self-referential/
router-as-source/empty-router checks. A registry's own internally
redundant patterns are allowed and do not count as self-shadowing.

Patterns live only in the registry graph (`Config::registries`), not
duplicated into the hosted/uplink tables: enforcement happens in
`Registries::resolve`, which every read, write, search, and cache-header
decision flows through, so the namespace is one declaration. The bundled
config.yaml moves the registry-mock fixture list onto the `local`
registry, and `Config::proxy` / `Config::static_serve` build the
equivalent graphs programmatically.
```

## Checklist

- [x] pnpr-only change: the registry server has no TypeScript-CLI or `pacquet/` counterpart to mirror (per `pnpr/AGENTS.md`), and per the RFC there are no lockfile or client-visible protocol changes.
- [x] Added or updated tests.
- [x] Updated the documentation if needed (bundled `config.yaml` comments and module docs; the design doc is the RFC itself, pnpm/rfcs#16).

---
Written by an agent (Claude Code, claude-fable-5).
