### PR TITLE
Expose web authentication `authUrl` and `doneUrl` in JSON error output when OTP is required in a non-interactive terminal

### DIFF
--- a/.changeset/webauth-json-urls.md
+++ b/.changeset/webauth-json-urls.md
@@ -1,6 +1,6 @@
 ---
-"@pnpm/network.web-auth": patch
-"pnpm": patch
+"@pnpm/network.web-auth": minor
+"pnpm": minor
 ---
 
-Expose web authentication `authUrl` and `doneUrl` in JSON error output when OTP is required in a non-interactive terminal.
+Expose web authentication `authUrl` and `doneUrl` in JSON error output when OTP is required in a non-interactive terminal [#12724](https://github.com/pnpm/pnpm/issues/12724).

--- a/.changeset/webauth-json-urls.md
+++ b/.changeset/webauth-json-urls.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/network.web-auth": patch
+"pnpm": patch
+---
+
+Expose web authentication `authUrl` and `doneUrl` in JSON error output when OTP is required in a non-interactive terminal.

--- a/pacquet/crates/network-web-auth/src/with_otp_handling.rs
+++ b/pacquet/crates/network-web-auth/src/with_otp_handling.rs
@@ -141,9 +141,23 @@ impl OtpNonInteractiveError {
     }
 }
 
+/// Canonical serialization of an `http`/`https` URL with any userinfo
+/// (`user:pass@`) stripped; `None` for an unparsable URL or any other scheme.
+///
+/// These URLs come from the registry and get displayed, opened in a browser,
+/// and carried on errors for machine consumption: the scheme restriction
+/// keeps a malicious registry from injecting e.g. a `javascript:` URL into
+/// something that opens it, and stripping userinfo keeps credential-shaped
+/// data out of logs (the capability tokens automation needs live in the
+/// path/query, which are preserved).
 fn canonical_http_url(value: &str) -> Option<String> {
-    let parsed = url::Url::parse(value).ok()?;
-    matches!(parsed.scheme(), "http" | "https").then(|| parsed.to_string())
+    let mut parsed = url::Url::parse(value).ok()?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return None;
+    }
+    parsed.set_username("").ok()?;
+    parsed.set_password(None).ok()?;
+    Some(parsed.to_string())
 }
 
 /// The registry asked for an OTP a second time after one was already
@@ -229,8 +243,15 @@ where
         return Err(WithOtpError::NonInteractive(OtpNonInteractiveError::new(challenge.body)));
     }
 
-    let otp = match challenge.body {
+    let web_auth_urls = match &challenge.body {
         Some(OtpErrorBody { auth_url: Some(auth_url), done_url: Some(done_url) }) => {
+            canonical_http_url(auth_url).zip(canonical_http_url(done_url))
+        }
+        _ => None,
+    };
+
+    let otp = match web_auth_urls {
+        Some((auth_url, done_url)) => {
             let qr_code = generate_qr_code(&auth_url).map_err(WithOtpError::QrCode)?;
             global_info::<Reporter>(&format!(
                 "Authenticate your account at:\n{auth_url}\n\n{qr_code}",
@@ -245,12 +266,14 @@ where
                 .map(Some)
                 .map_err(WithOtpError::Timeout)?
         }
-        _ => match Sys::input("This operation requires a one-time password.\nEnter OTP:").await {
-            Ok(value) => value.filter(|otp| !otp.is_empty()),
-            // The user aborted the prompt: re-throw the original challenge.
-            Err(PromptError::Cancelled) => return Err(WithOtpError::Operation(error)),
-            Err(other) => return Err(WithOtpError::Prompt(other)),
-        },
+        None => {
+            match Sys::input("This operation requires a one-time password.\nEnter OTP:").await {
+                Ok(value) => value.filter(|otp| !otp.is_empty()),
+                // The user aborted the prompt: re-throw the original challenge.
+                Err(PromptError::Cancelled) => return Err(WithOtpError::Operation(error)),
+                Err(other) => return Err(WithOtpError::Prompt(other)),
+            }
+        }
     };
 
     let Some(otp) = otp else {

--- a/pacquet/crates/network-web-auth/src/with_otp_handling.rs
+++ b/pacquet/crates/network-web-auth/src/with_otp_handling.rs
@@ -121,7 +121,24 @@ fn js_typeof(value: &Value) -> &'static str {
          --otp option if you are using a classic one-time password (OTP)"
     )
 )]
-pub struct OtpNonInteractiveError;
+pub struct OtpNonInteractiveError {
+    #[error(not(source))]
+    pub auth_url: Option<String>,
+    #[error(not(source))]
+    pub done_url: Option<String>,
+}
+
+impl OtpNonInteractiveError {
+    #[must_use]
+    pub fn new(body: Option<OtpErrorBody>) -> Self {
+        match body {
+            Some(OtpErrorBody { auth_url, done_url }) => {
+                OtpNonInteractiveError { auth_url, done_url }
+            }
+            None => OtpNonInteractiveError { auth_url: None, done_url: None },
+        }
+    }
+}
 
 /// The registry asked for an OTP a second time after one was already
 /// supplied (`ERR_PNPM_OTP_SECOND_CHALLENGE`).
@@ -203,7 +220,7 @@ where
     };
 
     if !Sys::stdin_is_tty() || !Sys::stdout_is_tty() {
-        return Err(WithOtpError::NonInteractive(OtpNonInteractiveError));
+        return Err(WithOtpError::NonInteractive(OtpNonInteractiveError::new(challenge.body)));
     }
 
     let otp = match challenge.body {

--- a/pacquet/crates/network-web-auth/src/with_otp_handling.rs
+++ b/pacquet/crates/network-web-auth/src/with_otp_handling.rs
@@ -132,12 +132,18 @@ impl OtpNonInteractiveError {
     #[must_use]
     pub fn new(body: Option<OtpErrorBody>) -> Self {
         match body {
-            Some(OtpErrorBody { auth_url, done_url }) => {
-                OtpNonInteractiveError { auth_url, done_url }
-            }
+            Some(OtpErrorBody { auth_url, done_url }) => OtpNonInteractiveError {
+                auth_url: auth_url.as_deref().and_then(canonical_http_url),
+                done_url: done_url.as_deref().and_then(canonical_http_url),
+            },
             None => OtpNonInteractiveError { auth_url: None, done_url: None },
         }
     }
+}
+
+fn canonical_http_url(value: &str) -> Option<String> {
+    let parsed = url::Url::parse(value).ok()?;
+    matches!(parsed.scheme(), "http" | "https").then(|| parsed.to_string())
 }
 
 /// The registry asked for an OTP a second time after one was already

--- a/pacquet/crates/network-web-auth/src/with_otp_handling/tests.rs
+++ b/pacquet/crates/network-web-auth/src/with_otp_handling/tests.rs
@@ -312,6 +312,34 @@ async fn preserves_web_auth_urls_on_non_interactive_error() {
 }
 
 #[tokio::test]
+async fn omits_non_http_web_auth_urls_on_non_interactive_error() {
+    reset();
+    STDIN_TTY.with(|tty| tty.set(false));
+
+    let error = with_otp_handling::<Fake, UnexpectedReporter, String, TestError, _>(
+        WebAuthFetchOptions::default(),
+        async |_otp| {
+            Err(TestError::Otp {
+                body: Some(OtpErrorBody {
+                    auth_url: Some("javascript:alert(1)".to_owned()),
+                    done_url: Some("file:///tmp/token".to_owned()),
+                }),
+            })
+        },
+    )
+    .await
+    .expect_err("an error");
+
+    match error {
+        WithOtpError::NonInteractive(error) => {
+            assert_eq!(error.auth_url, None);
+            assert_eq!(error.done_url, None);
+        }
+        other => panic!("expected non-interactive error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn classic_flow_prompts_for_otp_and_retries_operation() {
     reset();
     set_input(InputResponse::Value(Some("654321".to_owned())));

--- a/pacquet/crates/network-web-auth/src/with_otp_handling/tests.rs
+++ b/pacquet/crates/network-web-auth/src/with_otp_handling/tests.rs
@@ -312,6 +312,40 @@ async fn preserves_web_auth_urls_on_non_interactive_error() {
 }
 
 #[tokio::test]
+async fn strips_credentials_from_web_auth_urls_on_non_interactive_error() {
+    reset();
+    STDIN_TTY.with(|tty| tty.set(false));
+
+    let error = with_otp_handling::<Fake, UnexpectedReporter, String, TestError, _>(
+        WebAuthFetchOptions::default(),
+        async |_otp| {
+            Err(TestError::Otp {
+                body: Some(OtpErrorBody {
+                    auth_url: Some("https://user:secret@registry.npmjs.org/auth/abc".to_owned()),
+                    done_url: Some(
+                        "https://user:secret@registry.npmjs.org/auth/abc/done?authId=xyz"
+                            .to_owned(),
+                    ),
+                }),
+            })
+        },
+    )
+    .await
+    .expect_err("an error");
+
+    match error {
+        WithOtpError::NonInteractive(error) => {
+            assert_eq!(error.auth_url.as_deref(), Some("https://registry.npmjs.org/auth/abc"));
+            assert_eq!(
+                error.done_url.as_deref(),
+                Some("https://registry.npmjs.org/auth/abc/done?authId=xyz"),
+            );
+        }
+        other => panic!("expected non-interactive error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn omits_non_http_web_auth_urls_on_non_interactive_error() {
     reset();
     STDIN_TTY.with(|tty| tty.set(false));
@@ -491,6 +525,36 @@ async fn web_auth_flow_polls_done_url_and_uses_returned_token() {
         "the auth URL should be surfaced, got {:?}",
         infos(),
     );
+}
+
+#[tokio::test]
+async fn web_auth_flow_falls_back_to_classic_prompt_when_urls_are_not_http() {
+    reset();
+    set_input(InputResponse::Value(Some("manual-code".to_owned())));
+    let calls = Rc::new(Cell::new(0));
+    let counter = Rc::clone(&calls);
+
+    let result = with_otp_handling::<Fake, RecordingReporter, String, TestError, _>(
+        WebAuthFetchOptions::default(),
+        async move |otp| {
+            counter.set(counter.get() + 1);
+            if counter.get() == 1 {
+                Err(TestError::Otp {
+                    body: Some(OtpErrorBody {
+                        auth_url: Some("javascript:alert(1)".to_owned()),
+                        done_url: Some("file:///tmp/token".to_owned()),
+                    }),
+                })
+            } else {
+                assert_eq!(otp, Some("manual-code"));
+                Ok("done".to_owned())
+            }
+        },
+    )
+    .await
+    .expect("a result");
+
+    assert_eq!(result, "done");
 }
 
 #[tokio::test]

--- a/pacquet/crates/network-web-auth/src/with_otp_handling/tests.rs
+++ b/pacquet/crates/network-web-auth/src/with_otp_handling/tests.rs
@@ -291,6 +291,27 @@ async fn throws_non_interactive_error_when_stdout_is_not_interactive() {
 }
 
 #[tokio::test]
+async fn preserves_web_auth_urls_on_non_interactive_error() {
+    reset();
+    STDIN_TTY.with(|tty| tty.set(false));
+
+    let error = with_otp_handling::<Fake, UnexpectedReporter, String, TestError, _>(
+        WebAuthFetchOptions::default(),
+        async |_otp| Err(TestError::Otp { body: web_auth_body() }),
+    )
+    .await
+    .expect_err("an error");
+
+    match error {
+        WithOtpError::NonInteractive(error) => {
+            assert_eq!(error.auth_url.as_deref(), Some("https://registry.npmjs.org/auth/abc"));
+            assert_eq!(error.done_url.as_deref(), Some("https://registry.npmjs.org/auth/abc/done"));
+        }
+        other => panic!("expected non-interactive error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn classic_flow_prompts_for_otp_and_retries_operation() {
     reset();
     set_input(InputResponse::Value(Some("654321".to_owned())));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7827,6 +7827,9 @@ importers:
       '@pnpm/network.fetch':
         specifier: workspace:*
         version: link:../network/fetch
+      '@pnpm/network.web-auth':
+        specifier: workspace:*
+        version: link:../network/web-auth
       '@pnpm/nopt':
         specifier: 'catalog:'
         version: 0.3.1

--- a/pnpm11/network/web-auth/src/index.ts
+++ b/pnpm11/network/web-auth/src/index.ts
@@ -15,6 +15,7 @@ export {
 } from './promptBrowserOpen.js'
 export { WebAuthTimeoutError } from './WebAuthTimeoutError.js'
 export {
+  canonicalHttpUrl,
   isOtpError,
   type OtpContext,
   type OtpEnquirer,

--- a/pnpm11/network/web-auth/src/withOtpHandling.ts
+++ b/pnpm11/network/web-auth/src/withOtpHandling.ts
@@ -84,7 +84,7 @@ export async function withOtpHandling<T> ({
   } catch (error) {
     if (!isOtpError(error)) throw error
     if (!process.stdin.isTTY || !process.stdout.isTTY) {
-      throw new OtpNonInteractiveError()
+      throw new OtpNonInteractiveError(error.body)
     }
 
     let otp: string | undefined
@@ -176,10 +176,19 @@ export class SyntheticOtpError extends Error implements OtpError {
 }
 
 export class OtpNonInteractiveError extends PnpmError {
-  constructor () {
+  readonly authUrl?: string
+  readonly doneUrl?: string
+
+  constructor (body?: OtpErrorBody) {
     super('OTP_NON_INTERACTIVE', 'The registry requires additional authentication, but pnpm is not running in an interactive terminal', {
       hint: 'Re-run this command in an interactive terminal to complete authentication, or provide the --otp option if you are using a classic one-time password (OTP)',
     })
+    if (typeof body?.authUrl === 'string') {
+      this.authUrl = body.authUrl
+    }
+    if (typeof body?.doneUrl === 'string') {
+      this.doneUrl = body.doneUrl
+    }
   }
 }
 

--- a/pnpm11/network/web-auth/src/withOtpHandling.ts
+++ b/pnpm11/network/web-auth/src/withOtpHandling.ts
@@ -183,12 +183,24 @@ export class OtpNonInteractiveError extends PnpmError {
     super('OTP_NON_INTERACTIVE', 'The registry requires additional authentication, but pnpm is not running in an interactive terminal', {
       hint: 'Re-run this command in an interactive terminal to complete authentication, or provide the --otp option if you are using a classic one-time password (OTP)',
     })
-    if (typeof body?.authUrl === 'string') {
-      this.authUrl = body.authUrl
+    const authUrl = canonicalHttpUrl(body?.authUrl)
+    if (authUrl != null) {
+      this.authUrl = authUrl
     }
-    if (typeof body?.doneUrl === 'string') {
-      this.doneUrl = body.doneUrl
+    const doneUrl = canonicalHttpUrl(body?.doneUrl)
+    if (doneUrl != null) {
+      this.doneUrl = doneUrl
     }
+  }
+}
+
+function canonicalHttpUrl (value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : undefined
+  } catch {
+    return undefined
   }
 }
 

--- a/pnpm11/network/web-auth/src/withOtpHandling.ts
+++ b/pnpm11/network/web-auth/src/withOtpHandling.ts
@@ -89,16 +89,18 @@ export async function withOtpHandling<T> ({
 
     let otp: string | undefined
 
-    if (error.body?.authUrl && error.body?.doneUrl) {
-      const qrCode = generateQrCode(error.body.authUrl)
-      globalInfo(`Authenticate your account at:\n${error.body.authUrl}\n\n${qrCode}`)
+    const authUrl = canonicalHttpUrl(error.body?.authUrl)
+    const doneUrl = canonicalHttpUrl(error.body?.doneUrl)
+    if (authUrl != null && doneUrl != null) {
+      const qrCode = generateQrCode(authUrl)
+      globalInfo(`Authenticate your account at:\n${authUrl}\n\n${qrCode}`)
       const pollPromise = pollForWebAuthToken({
         context,
-        doneUrl: error.body.doneUrl,
+        doneUrl,
         fetchOptions,
       })
       otp = await promptBrowserOpen({
-        authUrl: error.body.authUrl,
+        authUrl,
         context,
         pollPromise,
       })
@@ -195,16 +197,25 @@ export class OtpNonInteractiveError extends PnpmError {
 }
 
 /**
- * Returns the canonical serialization of an `http:`/`https:` URL, or
- * `undefined` for a non-string, an unparsable URL, or any other scheme
- * (so a registry cannot inject e.g. a `javascript:` URL into output that
- * automation may open).
+ * Returns the canonical serialization of an `http:`/`https:` URL with any
+ * userinfo (`user:pass@`) stripped, or `undefined` for a non-string, an
+ * unparsable URL, or any other scheme.
+ *
+ * These URLs come from the registry and get displayed, opened in a browser,
+ * and emitted in parseable error output: the scheme restriction keeps a
+ * malicious registry from injecting e.g. a `javascript:` URL into something
+ * that opens it, and stripping userinfo keeps credential-shaped data out of
+ * logs (the capability tokens automation needs live in the path/query, which
+ * are preserved).
  */
 export function canonicalHttpUrl (value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined
   try {
     const url = new URL(value)
-    return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : undefined
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined
+    url.username = ''
+    url.password = ''
+    return url.href
   } catch {
     return undefined
   }

--- a/pnpm11/network/web-auth/src/withOtpHandling.ts
+++ b/pnpm11/network/web-auth/src/withOtpHandling.ts
@@ -194,7 +194,13 @@ export class OtpNonInteractiveError extends PnpmError {
   }
 }
 
-function canonicalHttpUrl (value: unknown): string | undefined {
+/**
+ * Returns the canonical serialization of an `http:`/`https:` URL, or
+ * `undefined` for a non-string, an unparsable URL, or any other scheme
+ * (so a registry cannot inject e.g. a `javascript:` URL into output that
+ * automation may open).
+ */
+export function canonicalHttpUrl (value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined
   try {
     const url = new URL(value)

--- a/pnpm11/network/web-auth/test/withOtpHandling.test.ts
+++ b/pnpm11/network/web-auth/test/withOtpHandling.test.ts
@@ -119,6 +119,29 @@ describe('withOtpHandling', () => {
       })
   })
 
+  it('omits non-http webauth URLs on OtpNonInteractiveError', async () => {
+    const context = createOtpMockContext({
+      process: { stdin: { isTTY: false } },
+    })
+    const operation = async () => {
+      throw Object.assign(new Error('otp'), {
+        code: 'EOTP',
+        body: {
+          authUrl: 'javascript:alert(1)',
+          doneUrl: 'file:///tmp/token',
+        },
+      })
+    }
+    try {
+      await withOtpHandling({ context, fetchOptions, operation })
+      throw new Error('Expected withOtpHandling to throw')
+    } catch (error) {
+      expect(error).toBeInstanceOf(OtpNonInteractiveError)
+      expect((error as OtpNonInteractiveError).authUrl).toBeUndefined()
+      expect((error as OtpNonInteractiveError).doneUrl).toBeUndefined()
+    }
+  })
+
   describe('classic OTP flow', () => {
     it('prompts for OTP and retries operation', async () => {
       let callCount = 0

--- a/pnpm11/network/web-auth/test/withOtpHandling.test.ts
+++ b/pnpm11/network/web-auth/test/withOtpHandling.test.ts
@@ -99,6 +99,26 @@ describe('withOtpHandling', () => {
       .rejects.toBeInstanceOf(OtpNonInteractiveError)
   })
 
+  it('preserves webauth URLs on OtpNonInteractiveError', async () => {
+    const context = createOtpMockContext({
+      process: { stdin: { isTTY: false } },
+    })
+    const operation = async () => {
+      throw Object.assign(new Error('otp'), {
+        code: 'EOTP',
+        body: {
+          authUrl: 'https://registry.npmjs.org/auth/abc',
+          doneUrl: 'https://registry.npmjs.org/auth/abc/done',
+        },
+      })
+    }
+    await expect(withOtpHandling({ context, fetchOptions, operation }))
+      .rejects.toMatchObject({
+        authUrl: 'https://registry.npmjs.org/auth/abc',
+        doneUrl: 'https://registry.npmjs.org/auth/abc/done',
+      })
+  })
+
   describe('classic OTP flow', () => {
     it('prompts for OTP and retries operation', async () => {
       let callCount = 0

--- a/pnpm11/network/web-auth/test/withOtpHandling.test.ts
+++ b/pnpm11/network/web-auth/test/withOtpHandling.test.ts
@@ -119,6 +119,26 @@ describe('withOtpHandling', () => {
       })
   })
 
+  it('strips credentials from webauth URLs on OtpNonInteractiveError', async () => {
+    const context = createOtpMockContext({
+      process: { stdin: { isTTY: false } },
+    })
+    const operation = async () => {
+      throw Object.assign(new Error('otp'), {
+        code: 'EOTP',
+        body: {
+          authUrl: 'https://user:secret@registry.npmjs.org/auth/abc',
+          doneUrl: 'https://user:secret@registry.npmjs.org/auth/abc/done?authId=xyz',
+        },
+      })
+    }
+    await expect(withOtpHandling({ context, fetchOptions, operation }))
+      .rejects.toMatchObject({
+        authUrl: 'https://registry.npmjs.org/auth/abc',
+        doneUrl: 'https://registry.npmjs.org/auth/abc/done?authId=xyz',
+      })
+  })
+
   it('omits non-http webauth URLs on OtpNonInteractiveError', async () => {
     const context = createOtpMockContext({
       process: { stdin: { isTTY: false } },
@@ -301,6 +321,32 @@ describe('withOtpHandling', () => {
             throw Object.assign(new Error('otp'), {
               code: 'EOTP',
               body: { doneUrl: 'https://registry.npmjs.org/auth/abc/done' },
+            })
+          }
+          expect(otp).toBe('manual-code')
+          return 'done'
+        },
+      })
+      expect(result).toBe('done')
+    })
+
+    it('falls back to classic prompt when webauth URLs are not http(s)', async () => {
+      let callCount = 0
+      const context = createOtpMockContext({
+        enquirer: { input: async () => 'manual-code' },
+      })
+      const result = await withOtpHandling({
+        context,
+        fetchOptions,
+        operation: async otp => {
+          callCount++
+          if (callCount === 1) {
+            throw Object.assign(new Error('otp'), {
+              code: 'EOTP',
+              body: {
+                authUrl: 'javascript:alert(1)',
+                doneUrl: 'file:///tmp/token',
+              },
             })
           }
           expect(otp).toBe('manual-code')

--- a/pnpm11/pnpm/package.json
+++ b/pnpm11/pnpm/package.json
@@ -112,6 +112,7 @@
     "@pnpm/lockfile.types": "workspace:*",
     "@pnpm/logger": "workspace:*",
     "@pnpm/network.fetch": "workspace:*",
+    "@pnpm/network.web-auth": "workspace:*",
     "@pnpm/nopt": "catalog:",
     "@pnpm/patching.commands": "workspace:*",
     "@pnpm/pkg-manifest.commands": "workspace:*",

--- a/pnpm11/pnpm/src/errorHandler.ts
+++ b/pnpm11/pnpm/src/errorHandler.ts
@@ -1,6 +1,7 @@
 import { promisify } from 'node:util'
 
 import { logger } from '@pnpm/logger'
+import { canonicalHttpUrl } from '@pnpm/network.web-auth'
 import pidTree from 'pidtree'
 
 import { exit } from './exit.js'
@@ -81,7 +82,7 @@ async function killProcesses (status: number): Promise<void> {
   await exit(status)
 }
 
-function getWebAuthUrls (error: Error & { code?: string; authUrl?: unknown, doneUrl?: unknown }): { authUrl?: string, doneUrl?: string } | undefined {
+function getWebAuthUrls (error: Error & { code?: string, authUrl?: unknown, doneUrl?: unknown }): { authUrl?: string, doneUrl?: string } | undefined {
   if (error.code !== 'ERR_PNPM_OTP_NON_INTERACTIVE') return undefined
   const urls: { authUrl?: string, doneUrl?: string } = {}
   const authUrl = canonicalHttpUrl(error.authUrl)
@@ -93,14 +94,4 @@ function getWebAuthUrls (error: Error & { code?: string; authUrl?: unknown, done
     urls.doneUrl = doneUrl
   }
   return urls
-}
-
-function canonicalHttpUrl (value: unknown): string | undefined {
-  if (typeof value !== 'string') return undefined
-  try {
-    const url = new URL(value)
-    return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : undefined
-  } catch {
-    return undefined
-  }
 }

--- a/pnpm11/pnpm/src/errorHandler.ts
+++ b/pnpm11/pnpm/src/errorHandler.ts
@@ -81,13 +81,26 @@ async function killProcesses (status: number): Promise<void> {
   await exit(status)
 }
 
-function getWebAuthUrls (error: Error & { authUrl?: unknown, doneUrl?: unknown }): { authUrl?: string, doneUrl?: string } {
+function getWebAuthUrls (error: Error & { code?: string; authUrl?: unknown, doneUrl?: unknown }): { authUrl?: string, doneUrl?: string } | undefined {
+  if (error.code !== 'ERR_PNPM_OTP_NON_INTERACTIVE') return undefined
   const urls: { authUrl?: string, doneUrl?: string } = {}
-  if (typeof error.authUrl === 'string') {
-    urls.authUrl = error.authUrl
+  const authUrl = canonicalHttpUrl(error.authUrl)
+  if (authUrl != null) {
+    urls.authUrl = authUrl
   }
-  if (typeof error.doneUrl === 'string') {
-    urls.doneUrl = error.doneUrl
+  const doneUrl = canonicalHttpUrl(error.doneUrl)
+  if (doneUrl != null) {
+    urls.doneUrl = doneUrl
   }
   return urls
+}
+
+function canonicalHttpUrl (value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : undefined
+  } catch {
+    return undefined
+  }
 }

--- a/pnpm11/pnpm/src/errorHandler.ts
+++ b/pnpm11/pnpm/src/errorHandler.ts
@@ -27,6 +27,7 @@ export async function errorHandler (error: Error & { code?: string }): Promise<v
       error: {
         code: error.code ?? error.name,
         message: error.message,
+        ...getWebAuthUrls(error),
       },
     }, null, 2))
   } else if (global[REPORTER_INITIALIZED] !== 'silent') {
@@ -78,4 +79,15 @@ async function killProcesses (status: number): Promise<void> {
     // ignore error here
   }
   await exit(status)
+}
+
+function getWebAuthUrls (error: Error & { authUrl?: unknown, doneUrl?: unknown }): { authUrl?: string, doneUrl?: string } {
+  const urls: { authUrl?: string, doneUrl?: string } = {}
+  if (typeof error.authUrl === 'string') {
+    urls.authUrl = error.authUrl
+  }
+  if (typeof error.doneUrl === 'string') {
+    urls.doneUrl = error.doneUrl
+  }
+  return urls
 }

--- a/pnpm11/pnpm/test/errorHandler.test.ts
+++ b/pnpm11/pnpm/test/errorHandler.test.ts
@@ -1,3 +1,6 @@
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+
 import { expect, test } from '@jest/globals'
 import { prepare, preparePackages } from '@pnpm/prepare'
 import { fixtures } from '@pnpm/test-fixtures'
@@ -5,7 +8,7 @@ import getPort from 'get-port'
 import isWindows from 'is-windows'
 import { writeYamlFileSync } from 'write-yaml-file'
 
-import { execPnpmSync } from './utils/index.js'
+import { execPnpmSync, spawnPnpm } from './utils/index.js'
 import { isPortInUse } from './utils/isPortInUse.js'
 
 const f = fixtures(import.meta.dirname)
@@ -24,6 +27,74 @@ test('should print json format error when publish --json failed', async () => {
   const { error } = JSON.parse(stdout.toString())
   expect(error?.code).toBe('ERR_PNPM_PACKAGE_VERSION_NOT_FOUND')
   expect(error?.message).toBe('Package version is not defined in the package.json.')
+})
+
+test('should print webauth URLs in json format error when OTP is required non-interactively', async () => {
+  prepare({
+    name: 'test-dist-tag-webauth',
+    version: '1.0.0',
+  })
+
+  const requests: Array<{ method: string | undefined, url: string | undefined }> = []
+  const server = http.createServer((req, res) => {
+    requests.push({
+      method: req.method,
+      url: req.url,
+    })
+    res.writeHead(401, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({
+      authUrl: 'https://registry.npmjs.org/-/auth/login/abc123',
+      doneUrl: 'https://registry.npmjs.org/-/auth/done/abc123',
+    }))
+  })
+
+  try {
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', resolve)
+    })
+    const { port } = server.address() as AddressInfo
+    const proc = spawnPnpm([
+      'dist-tag',
+      'add',
+      'test-dist-tag-webauth@1.0.0',
+      'beta',
+      '--json',
+      `--registry=http://127.0.0.1:${port}/`,
+    ])
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+    proc.stdout!.on('data', (chunk: Buffer) => stdout.push(chunk))
+    proc.stderr!.on('data', (chunk: Buffer) => stderr.push(chunk))
+    const status = await new Promise<number | null>((resolve, reject) => {
+      proc.on('error', reject)
+      proc.on('close', (code: number | null, signal: string | null) => {
+        if (signal) {
+          reject(new Error(`Killed by signal ${signal}\n\n${Buffer.concat([...stdout, ...stderr]).toString()}`))
+        } else {
+          resolve(code)
+        }
+      })
+    })
+
+    expect(status).toBe(1)
+    expect(requests).toEqual([{
+      method: 'PUT',
+      url: '/-/package/test-dist-tag-webauth/dist-tags/beta',
+    }])
+    const { error } = JSON.parse(Buffer.concat(stdout).toString())
+    expect(error).toMatchObject({
+      code: 'ERR_PNPM_OTP_NON_INTERACTIVE',
+      authUrl: 'https://registry.npmjs.org/-/auth/login/abc123',
+      doneUrl: 'https://registry.npmjs.org/-/auth/done/abc123',
+    })
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err)
+        else resolve()
+      })
+    })
+  }
 })
 
 test('should print json format error when add dependency on workspace root', async () => {

--- a/pnpm11/pnpm/test/errorHandler.test.ts
+++ b/pnpm11/pnpm/test/errorHandler.test.ts
@@ -8,7 +8,7 @@ import getPort from 'get-port'
 import isWindows from 'is-windows'
 import { writeYamlFileSync } from 'write-yaml-file'
 
-import { execPnpmSync, spawnPnpm } from './utils/index.js'
+import { execPnpmSync, spawnPnpm, waitForPnpmExit } from './utils/index.js'
 import { isPortInUse } from './utils/isPortInUse.js'
 
 const f = fixtures(import.meta.dirname)
@@ -31,7 +31,7 @@ test('should print json format error when publish --json failed', async () => {
 
 test('should print webauth URLs in json format error when OTP is required non-interactively', async () => {
   prepare({
-    name: 'test-dist-tag-webauth',
+    name: 'test-publish-webauth',
     version: '1.0.0',
   })
 
@@ -41,7 +41,10 @@ test('should print webauth URLs in json format error when OTP is required non-in
       method: req.method,
       url: req.url,
     })
-    res.writeHead(401, { 'content-type': 'application/json' })
+    res.writeHead(401, {
+      'content-type': 'application/json',
+      'www-authenticate': 'OTP',
+    })
     res.end(JSON.stringify({
       authUrl: 'https://registry.npmjs.org/-/auth/login/abc123',
       doneUrl: 'https://registry.npmjs.org/-/auth/done/abc123',
@@ -49,39 +52,25 @@ test('should print webauth URLs in json format error when OTP is required non-in
   })
 
   try {
-    await new Promise<void>((resolve) => {
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
       server.listen(0, '127.0.0.1', resolve)
     })
     const { port } = server.address() as AddressInfo
     const proc = spawnPnpm([
-      'dist-tag',
-      'add',
-      'test-dist-tag-webauth@1.0.0',
-      'beta',
+      'publish',
       '--json',
+      '--no-git-checks',
       `--registry=http://127.0.0.1:${port}/`,
     ])
-    const stdout: Buffer[] = []
-    const stderr: Buffer[] = []
-    proc.stdout!.on('data', (chunk: Buffer) => stdout.push(chunk))
-    proc.stderr!.on('data', (chunk: Buffer) => stderr.push(chunk))
-    const status = await new Promise<number | null>((resolve, reject) => {
-      proc.on('error', reject)
-      proc.on('close', (code: number | null, signal: string | null) => {
-        if (signal) {
-          reject(new Error(`Killed by signal ${signal}\n\n${Buffer.concat([...stdout, ...stderr]).toString()}`))
-        } else {
-          resolve(code)
-        }
-      })
-    })
+    const { status, stdout } = await waitForPnpmExit(proc)
 
     expect(status).toBe(1)
     expect(requests).toEqual([{
       method: 'PUT',
-      url: '/-/package/test-dist-tag-webauth/dist-tags/beta',
+      url: '/test-publish-webauth',
     }])
-    const { error } = JSON.parse(Buffer.concat(stdout).toString())
+    const { error } = JSON.parse(stdout.toString())
     expect(error).toMatchObject({
       code: 'ERR_PNPM_OTP_NON_INTERACTIVE',
       authUrl: 'https://registry.npmjs.org/-/auth/login/abc123',

--- a/pnpm11/pnpm/test/utils/execPnpm.ts
+++ b/pnpm11/pnpm/test/utils/execPnpm.ts
@@ -77,6 +77,44 @@ export function spawnPnpm (
   })
 }
 
+/**
+ * Collects the output of a process started with {@link spawnPnpm} until it
+ * exits, killing it if it doesn't exit within the timeout. Unlike
+ * {@link execPnpm}, a non-zero exit code is returned rather than thrown, so
+ * callers can assert on failing invocations.
+ */
+export async function waitForPnpmExit (
+  proc: NodeChildProcess,
+  opts?: {
+    timeout?: number // timeout in ms
+  }
+): Promise<{ status: number | null, stdout: Buffer, stderr: Buffer }> {
+  return new Promise((resolve, reject) => {
+    const timeoutId = registerProcessTimeout(proc, opts?.timeout ?? DEFAULT_EXEC_PNPM_TIMEOUT, reject)
+
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+    proc.stdout?.on('data', (chunk: Buffer) => {
+      stdout.push(chunk)
+    })
+    proc.stderr?.on('data', (chunk: Buffer) => {
+      stderr.push(chunk)
+    })
+
+    proc.on('error', reject)
+
+    proc.on('close', (code: number | null, signal: string | null) => {
+      clearTimeout(timeoutId)
+
+      if (signal) {
+        reject(new Error(`Killed by signal ${signal}\n\n${Buffer.concat([...stdout, ...stderr]).toString()}`))
+      } else {
+        resolve({ status: code, stdout: Buffer.concat(stdout), stderr: Buffer.concat(stderr) })
+      }
+    })
+  })
+}
+
 export async function execPnpx (args: string[]): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const proc = spawnPnpx(args)

--- a/pnpm11/pnpm/test/utils/index.ts
+++ b/pnpm11/pnpm/test/utils/index.ts
@@ -9,6 +9,7 @@ import {
   pnpxBinLocation,
   spawnPnpm,
   spawnPnpx,
+  waitForPnpmExit,
 } from './execPnpm.js'
 import { pathToLocalPkg } from './localPkg.js'
 import testDefaults from './testDefaults.js'
@@ -26,4 +27,5 @@ export {
   spawnPnpm,
   spawnPnpx,
   testDefaults,
+  waitForPnpmExit,
 }

--- a/pnpm11/pnpm/tsconfig.json
+++ b/pnpm11/pnpm/tsconfig.json
@@ -126,6 +126,9 @@
       "path": "../network/fetch"
     },
     {
+      "path": "../network/web-auth"
+    },
+    {
       "path": "../patching/commands"
     },
     {


### PR DESCRIPTION
## Summary

Expose web-auth OTP challenge URLs in `--json` error output when pnpm is running non-interactively.

When the registry returns `authUrl` and `doneUrl`, pnpm now preserves them on the non-interactive OTP error and includes them as `error.authUrl` and `error.doneUrl` in JSON output. This lets wrapper tools complete the web-auth flow.

This is a change equivalent to https://github.com/npm/cli/pull/8952
closes https://github.com/pnpm/pnpm/issues/12724

## Squash Commit Body

```text
Preserve web-auth OTP challenge URLs when OTP handling fails because pnpm is not running in an interactive terminal.

The web-auth layer now carries authUrl and doneUrl from the registry challenge onto OtpNonInteractiveError. The pnpm error handler includes those fields in parseable JSON error output when present.

The same URL preservation was added to pacquet's web-auth error type to keep the two implementations aligned. Tests cover the TS and Rust web-auth layers and the pnpm JSON error output path.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * When OTP is required in a non-interactive terminal, JSON error output now includes `authUrl` and `doneUrl` (as valid `http`/`https` URLs).
* **Bug Fixes**
  * Credentials embedded in these URLs are removed; non-`http`/`https` values are omitted.
  * Web-auth URL handling now falls back to the classic OTP prompt when URL schemes aren’t `http`/`https`.
* **Tests**
  * Added coverage for URL preservation/omission behavior and updated publish/HTTP-server scenarios.
* **Chores**
  * Updated release configuration for the relevant web-auth packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->