### PR TITLE
feat(pnpr): merge the namespace and the ACL into per-registry packages: maps (RFC pnpm/rfcs#17)

### DIFF
--- a/pacquet/crates/pnpr-client/tests/integration.rs
+++ b/pacquet/crates/pnpr-client/tests/integration.rs
@@ -111,6 +111,7 @@ fn registry_upstream(registry_url: &str, token: &str) -> (String, pnpr::Upstream
             fail_timeout: pnpr::UpstreamConfig::DEFAULT_FAIL_TIMEOUT,
             cache: true,
             access: Some(pnpr::AccessList::parse("$authenticated")),
+            rules: pnpr::PackageRules::default(),
         },
     )
 }

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -1654,23 +1654,22 @@ fn write_pnpr_benchmark_config(
 /// A config for the cold mock: isolated `storage` and a single public upstream
 /// at the warm origin, so every request is a cache miss proxied through to it.
 ///
-/// The routing is expressed in *three* shapes so one file drives every
-/// benchmarked `pnpr` binary regardless of revision: the `registries:` +
-/// `defaultRegistry:` model that current `pnpr` reads, the `mounts:` +
-/// `defaultTarget:` shape the registries model replaced, and the legacy
-/// `uplinks:` + `packages: proxy:` shape that a `pnpr` built before the mount
-/// model reads. Each server ignores the blocks it doesn't recognize — no
-/// revision's `ConfigFile` or `PackageAccess` sets `deny_unknown_fields` —
-/// so all of them proxy every request to the same `origin`.
+/// The routing is expressed in *two* shapes so one file drives every
+/// benchmarked `pnpr` binary back to the mount model: the `registries:` +
+/// `defaultRegistry:` model that current `pnpr` reads, and the `mounts:` +
+/// `defaultTarget:` shape it replaced. Each server ignores the block it
+/// doesn't recognize, so both proxy every request to the same `origin`. The
+/// pre-mount `uplinks:` + `packages: proxy:` shape can no longer ride along:
+/// current `pnpr` deliberately *rejects* a top-level `packages:` block at
+/// startup (per-package rules live on each registry now, and silently
+/// dropping a formerly-enforced ACL would be a security regression), so a
+/// revision older than the mount model cannot share a config file with
+/// current ones.
 fn cold_mock_config_yaml(storage: &Path, origin: &str) -> String {
-    let mut packages = HashMap::new();
-    packages.insert("**", ColdMockPackageAccess { access: "$all", proxy: "npmjs" });
     let upstream =
         || ColdMockUpstreamEntry { kind: "upstream", url: origin.to_string(), public: true };
     let config = ColdMockConfig {
         storage: storage.display().to_string(),
-        uplinks: ColdMockUplinks { npmjs: ColdMockUplink { url: origin.to_string() } },
-        packages,
         mounts: ColdMockUpstreamTable { npmjs: upstream() },
         default_target: "npmjs",
         registries: ColdMockUpstreamTable { npmjs: upstream() },
@@ -1685,8 +1684,6 @@ fn cold_mock_config_yaml(storage: &Path, origin: &str) -> String {
 #[derive(Serialize)]
 struct ColdMockConfig {
     storage: String,
-    uplinks: ColdMockUplinks,
-    packages: HashMap<&'static str, ColdMockPackageAccess>,
     mounts: ColdMockUpstreamTable,
     #[serde(rename = "defaultTarget")]
     default_target: &'static str,
@@ -1694,22 +1691,6 @@ struct ColdMockConfig {
     #[serde(rename = "defaultRegistry")]
     default_registry: &'static str,
     log: ColdMockLog,
-}
-
-#[derive(Serialize)]
-struct ColdMockUplinks {
-    npmjs: ColdMockUplink,
-}
-
-#[derive(Serialize)]
-struct ColdMockUplink {
-    url: String,
-}
-
-#[derive(Serialize)]
-struct ColdMockPackageAccess {
-    access: &'static str,
-    proxy: &'static str,
 }
 
 /// The `mounts:` / `registries:` table — the same single-upstream entry under

--- a/pnpr/crates/pnpr/config.yaml
+++ b/pnpr/crates/pnpr/config.yaml
@@ -83,121 +83,111 @@ web:
 registries:
   # The locally-hosted fixtures (and anything published here). With no `org`,
   # this registry namespaces onto the flat `storage` root, where the fixtures are
-  # seeded. `patterns:` is the registry's declared namespace: only these names
-  # can be served from or published to this registry, so a name outside it can
-  # never squat here and later shadow its real origin.
+  # seeded. The `packages:` map is the registry's declared namespace (its key
+  # set) plus the per-package access rules (its values): only these names can
+  # be served from or published to this registry — so a name outside it can
+  # never squat here and later shadow its real origin — and each name is
+  # gated by its most specific matching key, whatever the key order. The
+  # `unpublish: $authenticated` value keeps the `@pnpm/registry-mock`
+  # contract (destructive writes open to any authenticated user), which the
+  # per-registry default (unpublish denied) would otherwise tighten.
   local:
     type: hosted
     access: $all
-    patterns:
+    packages:
       # Scopes seeded from the in-repo fixture sources
       # (`pnpr/.fixtures/packages/`). Scopes shared with real, active npm
       # scopes (`@pnpm`, `@zkochan`) are claimed by exact name instead — see
       # below — so proxied dependency trees can still pull the scope's other
       # real packages from npm.
-      - '@foo/*'
-      - '@having/*'
-      - '@jsr/*'
-      - '@pnpm.e2e/*'
-      - '@private/*'
-      - '@scoped/*'
-      - 'create-touch-file-one-bin'
+      '@foo/*': &default-rules { unpublish: $authenticated }
+      '@having/*': *default-rules
+      '@jsr/*': *default-rules
+      '@pnpm.e2e/*': *default-rules
+      '@private/*': &authenticated
+        access: $authenticated
+        publish: $authenticated
+        unpublish: $authenticated
+      '@scoped/*': *default-rules
+      'create-touch-file-one-bin': *default-rules
       # The fixture packages in the real `@pnpm` and `@zkochan` scopes, each
       # claimed by exact name.
-      - '@pnpm/plugin-pnpmfile'
-      - '@pnpm/postinstall-modifies-source'
-      - '@pnpm/x'
-      - '@pnpm/xyz'
-      - '@pnpm/xyz-parent'
-      - '@pnpm/xyz-parent-parent'
-      - '@pnpm/xyz-parent-parent-parent'
-      - '@pnpm/xyz-parent-parent-parent-parent'
-      - '@pnpm/xyz-parent-parent-with-xyz'
-      - '@pnpm/y'
-      - '@pnpm/z'
-      - '@zkochan/test-pnpm-issue219'
+      '@pnpm/plugin-pnpmfile': *default-rules
+      '@pnpm/postinstall-modifies-source': *default-rules
+      '@pnpm/x': *default-rules
+      '@pnpm/xyz': *default-rules
+      '@pnpm/xyz-parent': *default-rules
+      '@pnpm/xyz-parent-parent': *default-rules
+      '@pnpm/xyz-parent-parent-parent': *default-rules
+      '@pnpm/xyz-parent-parent-parent-parent': *default-rules
+      '@pnpm/xyz-parent-parent-with-xyz': *default-rules
+      '@pnpm/y': *default-rules
+      '@pnpm/z': *default-rules
+      '@zkochan/test-pnpm-issue219': *default-rules
       # Names tests publish to the mock and then read back. Exact names only —
       # an unscoped prefix wildcard would swallow real npm packages that
       # proxied dependency trees need (`test-*` would capture `test-exclude`).
       # A test publishing a new unscoped name must add it here; publishing
       # dynamically-suffixed names belongs in the `@pnpmtest` scope.
-      - '@pnpmtest/*'
-      - 'batch-dry-1'
-      - 'batch-dry-2'
-      - 'batch-no-recursive'
-      - 'batch-pkg-2'
-      - 'batch-unsupported-1'
-      - 'project-100'
-      - 'project-200'
-      - 'publish_config_directory_dist_package'
-      - 'test-deprecate-package'
-      - 'test-deprecate-specific'
-      - 'test-dist-tag-add'
-      - 'test-dist-tag-add-default'
-      - 'test-dist-tag-ls'
-      - 'test-dist-tag-ls-default'
-      - 'test-dist-tag-rm'
-      - 'test-dist-tag-rm-latest'
-      - 'test-dist-tag-rm-missing'
-      - 'test-publish-config'
-      - 'test-publish-config-directory'
-      - 'test-publish-config-installation'
-      - 'test-publish-helper-token-basic.json'
-      - 'test-publish-helper-token-bearer.json'
-      - 'test-publish-package-oidc.json'
-      - 'test-publish-package.json'
-      - 'test-publish-package.json5'
-      - 'test-publish-package.yaml'
-      - 'test-publish-scripts'
-      - 'test-publish-skip-manifest-obfuscation'
-      - 'test-publish-skip-manifest-obfuscation-installation'
-      - 'test-publish-tarball'
-      - 'test-publish-with-ignore-scripts'
-      - 'test-publish-with-scripts'
-      - 'test-undeprecate-pkg'
-      - 'test-unpublish-force'
-      - 'test-unpublish-no-force'
-      - 'test-unpublish-no-ver'
-      - 'test-unpublish-version'
-      - 'workspace-package-with-default-catalog'
-      - 'workspace-package-with-named-catalog'
-  # The public npm registry. No `patterns:` — it serves every name, the
+      '@pnpmtest/*': *default-rules
+      'batch-dry-1': *default-rules
+      'batch-dry-2': *default-rules
+      'batch-no-recursive': *default-rules
+      'batch-pkg-2': *default-rules
+      'batch-unsupported-1': *default-rules
+      'project-100': *default-rules
+      'project-200': *default-rules
+      'publish_config_directory_dist_package': *default-rules
+      'test-deprecate-package': *default-rules
+      'test-deprecate-specific': *default-rules
+      'test-dist-tag-add': *default-rules
+      'test-dist-tag-add-default': *default-rules
+      'test-dist-tag-ls': *default-rules
+      'test-dist-tag-ls-default': *default-rules
+      'test-dist-tag-rm': *default-rules
+      'test-dist-tag-rm-latest': *default-rules
+      'test-dist-tag-rm-missing': *default-rules
+      'test-publish-config': *default-rules
+      'test-publish-config-directory': *default-rules
+      'test-publish-config-installation': *default-rules
+      'test-publish-helper-token-basic.json': *default-rules
+      'test-publish-helper-token-bearer.json': *default-rules
+      'test-publish-package-oidc.json': *default-rules
+      'test-publish-package.json': *default-rules
+      'test-publish-package.json5': *default-rules
+      'test-publish-package.yaml': *default-rules
+      'test-publish-scripts': *default-rules
+      'test-publish-skip-manifest-obfuscation': *default-rules
+      'test-publish-skip-manifest-obfuscation-installation': *default-rules
+      'test-publish-tarball': *default-rules
+      'test-publish-with-ignore-scripts': *default-rules
+      'test-publish-with-scripts': *default-rules
+      'test-undeprecate-pkg': *default-rules
+      'test-unpublish-force': *default-rules
+      'test-unpublish-no-force': *default-rules
+      'test-unpublish-no-ver': *default-rules
+      'test-unpublish-version': *default-rules
+      'workspace-package-with-default-catalog': *default-rules
+      'workspace-package-with-named-catalog': *default-rules
+      # Tightened by exact name: wins over the '@pnpm.e2e/*' scope key by
+      # specificity, whatever the key order.
+      '@pnpm.e2e/needs-auth': *authenticated
+  # The public npm registry. No `packages:` map — it serves every name, the
   # catch-all in any router, so it must be listed last in `sources:` below.
   npmjs:
     type: upstream
     url: https://registry.npmjs.org/
     public: true
   # One URL routing each package to the first listed source whose declared
-  # patterns claim it. The fixture names are authoritative-local; everything
+  # packages claim it. The fixture names are authoritative-local; everything
   # else is npm. A router refuses to start on an unreachable source, so the
-  # pattern-less catch-all must stay last.
+  # map-less catch-all must stay last.
   main:
     type: router
     sources: [local, npmjs]
 
 # The path-less base URL (`https://<pnpr>/`) aliases this registry.
 defaultRegistry: main
-
-# Per-package access control (an ACL layer, independent of routing). With no
-# matching rule the built-in default allows authenticated publish but admits
-# no one to unpublish, so the `**` rule below keeps every non-tightened
-# package open for reads and authenticated for both write kinds — the
-# `@pnpm/registry-mock` contract the tests rely on.
-packages:
-  '@private/*':
-    access: $authenticated
-    publish: $authenticated
-    unpublish: $authenticated
-
-  '@pnpm.e2e/needs-auth':
-    access: $authenticated
-    publish: $authenticated
-    unpublish: $authenticated
-
-  '**':
-    access: $all
-    publish: $authenticated
-    unpublish: $authenticated
 
 # log settings (verdaccio 6+ shape: a single `log:` object, not a list)
 log:

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::RegistryError,
-    policy::{AccessGroups, AccessList, Identity, PackagePolicies, PackagePolicy},
+    policy::{AccessGroups, AccessList, Identity, PackageRule, PackageRules},
     registry::{PackagePattern, Registries, Registry, RegistryConfigError},
     s3::{S3Settings, build_s3_store},
 };
@@ -75,12 +75,6 @@ pub struct Config {
     /// `upstream` entries and consumed by the `/~<name>/` serving and route
     /// classification.
     pub upstreams: IndexMap<String, UpstreamConfig>,
-    /// The raw per-package `access` / `publish` / `unpublish` rules from the
-    /// YAML `packages:` block, in declared order. [`Self::policies`] is the
-    /// compiled form the server enforces; this keeps the declared shape for
-    /// introspection. Access control only — routing a package to its origin
-    /// is the registry graph's job ([`Self::registries`]).
-    pub packages: IndexMap<String, PackageAccess>,
     /// Optional static group memberships used by named access tokens in
     /// package policies and upstream aliases.
     pub groups: AccessGroups,
@@ -88,14 +82,6 @@ pub struct Config {
     /// re-fetched from the resolved upstream. Ignored when no upstream
     /// matches.
     pub packument_ttl: Duration,
-    /// Per-package access, publish, and unpublish rules. [`Config::from_yaml`]
-    /// compiles these from the YAML `packages:` block (each entry's
-    /// `access` / `publish` / `unpublish` tokens); the programmatic
-    /// [`Config::proxy`] / [`Config::static_serve`] constructors use
-    /// [`PackagePolicies::registry_mock_defaults`] instead, enforcing
-    /// the `@private/*` and `@pnpm.e2e/needs-auth` rules
-    /// `@pnpm/registry-mock` applied under verdaccio.
-    pub policies: PackagePolicies,
     /// Where to read/write the htpasswd-format user file and the
     /// token database. Both stores are in-memory when their paths
     /// are `None`, matching the original `@pnpm/registry-mock` mode
@@ -155,19 +141,20 @@ pub struct Config {
     pub hosted: IndexMap<String, HostedConfig>,
 }
 
-/// A resolved hosted registry: the `org` namespace it serves and the access policy
-/// applied to every package under it. Per-package ACLs in [`Config::policies`]
-/// compose on top (logical AND) for finer control.
+/// A resolved hosted registry: the `org` namespace it serves and its
+/// `packages:` rules — the namespace it claims plus the per-package
+/// `access` / `publish` / `unpublish` policies, with the registry-level
+/// `access:` as the default an entry's omitted fields fall back to.
 #[derive(Debug, Clone)]
 pub struct HostedConfig {
     /// The storage/serving namespace, so two hosted registries holding the same
     /// `name@version` never collide. Empty (`""`) ⇒ the flat `storage` root.
     pub org: String,
-    /// Who may reach this registry at all — gates reads *and* the write routing
-    /// (publish, dist-tag, unpublish), with a denied caller masked as
-    /// not-found either way. Defaults to `$all` (a public hosted registry) when
-    /// the registry omits `access:`.
-    pub access: AccessList,
+    /// The registry's `packages:` map: namespace and per-package rules in one
+    /// declaration, selected by specificity. The effective `access` gates
+    /// reads *and* the write routing (publish, dist-tag, unpublish), with a
+    /// denied caller masked as not-found either way.
+    pub rules: PackageRules,
 }
 
 /// Which fetch routes the resolution cache treats as public. The official
@@ -524,6 +511,12 @@ pub struct UpstreamConfig {
     /// a resolver private-route credential — only upstreams that declare
     /// `access:` participate in route classification.
     pub access: Option<AccessList>,
+    /// The registry's `packages:` map: the namespace it claims plus
+    /// per-package `access` refinements (a `publish`/`unpublish` value is a
+    /// config error — no write can land on an upstream). The registry-level
+    /// gate ([`Self::access`], or `$all` for a public upstream) is the default
+    /// an entry's omitted `access` falls back to.
+    pub rules: PackageRules,
 }
 
 impl UpstreamConfig {
@@ -547,6 +540,7 @@ impl UpstreamConfig {
             fail_timeout: Self::DEFAULT_FAIL_TIMEOUT,
             cache: true,
             access: None,
+            rules: PackageRules::default(),
         }
     }
 }
@@ -562,6 +556,7 @@ impl fmt::Debug for UpstreamConfig {
             .field("fail_timeout", &self.fail_timeout)
             .field("cache", &self.cache)
             .field("access", &self.access)
+            .field("rules", &self.rules)
             .finish()
     }
 }
@@ -768,6 +763,10 @@ fn resolve_upstream_config<Sys: EnvVar>(
         fail_timeout,
         cache: file.cache.unwrap_or(true),
         access: file.access.as_ref().map(AccessSpec::to_access_list),
+        // The `packages:` rules are attached by the caller
+        // (`build_registries`) — this resolver only handles the serving
+        // knobs shared with programmatic construction.
+        rules: PackageRules::default(),
     })
 }
 
@@ -841,13 +840,14 @@ fn non_empty_token(token: &str) -> Option<String> {
     (!token.trim().is_empty()).then(|| token.to_string())
 }
 
-/// Per-package access rules: `access` / `publish` / `unpublish` are verdaccio
+/// One `packages:` map value: `access` / `publish` / `unpublish` are verdaccio
 /// permission lists (built-in groups like `$all` / `$authenticated` /
-/// `$anonymous`, plus usernames / group names), compiled into the
-/// [`PackagePolicies`] that gate reads and writes. These are an access-control
-/// layer only — routing a package to its origin is the job of the registry graph
-/// (the `registry` module), not of `packages:`.
+/// `$anonymous`, plus usernames / group names), compiled into the owning
+/// registry's [`PackageRules`]. An omitted field falls back to the
+/// registry-level default. The map key set doubles as the registry's declared
+/// namespace, so one declaration routes, filters, and authorizes.
 #[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PackageAccess {
     pub access: Option<AccessSpec>,
     pub publish: Option<AccessSpec>,
@@ -930,13 +930,17 @@ struct HostedFile {
     /// `storage` root (`""`).
     #[serde(default)]
     org: String,
-    /// Who may read this registry's packages. Omitted ⇒ `$all`.
+    /// The registry-level default: who may read this registry's packages when
+    /// no `packages:` entry refines it. Omitted ⇒ `$all`.
     #[serde(default)]
     access: Option<AccessSpec>,
-    /// The names this registry serves and accepts publishes for. Omitted ⇒ every
-    /// name.
+    /// The names this registry serves and accepts publishes for — its
+    /// namespace — with optional per-package `access`/`publish`/`unpublish`
+    /// rules as values (`{}` or null ⇒ the registry defaults). The most
+    /// specific matching key wins; key order carries no meaning. Omitted ⇒
+    /// every name, default rules.
     #[serde(default)]
-    patterns: Vec<String>,
+    packages: IndexMap<String, Option<PackageAccess>>,
 }
 
 /// Disk shape of an `upstream:` registry — one external origin. Mirrors an
@@ -968,11 +972,14 @@ struct UpstreamFile {
     /// non-`public` upstream (otherwise no one could be authorized to use it).
     #[serde(default)]
     access: Option<AccessSpec>,
-    /// The names that may be requested through this registry. Omitted ⇒ every
-    /// name. Bounding a private upstream stops an authorized caller from
-    /// pulling arbitrary public names through its server-owned credential.
+    /// The names that may be requested through this registry — its namespace —
+    /// with optional per-package `access` refinements as values (`{}` or null
+    /// ⇒ the registry default; a `publish`/`unpublish` value is a config
+    /// error, since no write can land on an upstream). Omitted ⇒ every name.
+    /// Bounding a private upstream stops an authorized caller from pulling
+    /// arbitrary public names through its server-owned credential.
     #[serde(default)]
-    patterns: Vec<String>,
+    packages: IndexMap<String, Option<PackageAccess>>,
 }
 
 /// Disk shape of a `router:` registry: an ordered list of concrete registry names.
@@ -1027,8 +1034,14 @@ struct ConfigFile {
     /// registry and clients must address a `/~<name>/`.
     #[serde(default, rename = "defaultRegistry")]
     default_registry: Option<String>,
+    /// The removed top-level ACL block, kept only to *reject* it loudly.
+    /// Per-package rules live on each registry's `packages:` map now; a
+    /// config still carrying the global block previously enforced access
+    /// with it, so silently dropping the key (the fate of unknown verdaccio
+    /// fields) would be a security regression — private packages would
+    /// quietly open up on upgrade.
     #[serde(default)]
-    packages: IndexMap<String, PackageAccess>,
+    packages: Option<serde::de::IgnoredAny>,
     /// pnpr-only static groups: each key is a group/team name and each
     /// value is the list of pnpr usernames in that group.
     #[serde(default)]
@@ -1181,6 +1194,36 @@ const REGISTRY_MOCK_LOCAL_PATTERNS: &[&str] = &[
     "create-touch-file-one-bin",
 ];
 
+/// The `local` hosted registry's `packages:` rules in the registry-mock
+/// shape: the fixture namespace (`REGISTRY_MOCK_LOCAL_PATTERNS`) with
+/// default rules, `@private/*` and `@pnpm.e2e/needs-auth` restricted to
+/// authenticated callers (the rules `@pnpm/registry-mock` applied under
+/// verdaccio), and unpublish open to any authenticated user so the
+/// fixture-rewriting test flows keep working. The exact
+/// `@pnpm.e2e/needs-auth` key wins over the `@pnpm.e2e/*` scope key by
+/// specificity.
+fn registry_mock_rules() -> PackageRules {
+    let authenticated = || Some(AccessList::parse("$authenticated"));
+    let mut rules: Vec<PackageRule> = REGISTRY_MOCK_LOCAL_PATTERNS
+        .iter()
+        .map(|pattern| PackageRule {
+            pattern: PackagePattern::parse(pattern)
+                .expect("valid built-in fixture registry pattern"),
+            access: (*pattern == "@private/*").then(authenticated).flatten(),
+            publish: (*pattern == "@private/*").then(authenticated).flatten(),
+            unpublish: (*pattern == "@private/*").then(authenticated).flatten(),
+        })
+        .collect();
+    rules.push(PackageRule {
+        pattern: PackagePattern::parse("@pnpm.e2e/needs-auth")
+            .expect("valid built-in fixture registry pattern"),
+        access: authenticated(),
+        publish: authenticated(),
+        unpublish: authenticated(),
+    });
+    PackageRules::new(rules, None).with_default_unpublish(AccessList::parse("$authenticated"))
+}
+
 impl Config {
     /// Default `listen` when one isn't supplied by the caller.
     pub const DEFAULT_LISTEN: &'static str = "127.0.0.1:7677";
@@ -1209,17 +1252,10 @@ impl Config {
                 HeaderMap::new(),
             ),
         );
+        let rules = registry_mock_rules();
+        let local_patterns = rules.patterns();
         let mut hosted = IndexMap::new();
-        hosted.insert(
-            "local".to_string(),
-            HostedConfig { org: String::new(), access: AccessList::parse("$all") },
-        );
-        let local_patterns = REGISTRY_MOCK_LOCAL_PATTERNS
-            .iter()
-            .map(|pattern| {
-                PackagePattern::parse(pattern).expect("valid built-in fixture registry pattern")
-            })
-            .collect();
+        hosted.insert("local".to_string(), HostedConfig { org: String::new(), rules });
         let graph = [
             ("local".to_string(), Registry::Hosted { patterns: local_patterns }),
             ("npmjs".to_string(), Registry::Upstream { patterns: Vec::new() }),
@@ -1235,10 +1271,8 @@ impl Config {
             cache_storage: default_cache_dir(&storage),
             storage,
             upstreams,
-            packages: IndexMap::new(),
             groups: AccessGroups::default(),
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
-            policies: PackagePolicies::registry_mock_defaults(),
             auth: AuthConfig::default(),
             logs: LogConfig::default(),
             hosted_store: HostedStoreConfig::Fs,
@@ -1261,9 +1295,15 @@ impl Config {
     #[must_use]
     pub fn static_serve(listen: SocketAddr, storage: PathBuf) -> Self {
         let mut hosted = IndexMap::new();
+        // The graph entry below is pattern-less — static mode claims and
+        // serves every name in `storage` — while the rules still carry the
+        // registry-mock protections (`@private/*`, `@pnpm.e2e/needs-auth`,
+        // authenticated unpublish). Programmatic configs may split the
+        // namespace (graph) from the rules like this; YAML derives both from
+        // one `packages:` map.
         hosted.insert(
             "local".to_string(),
-            HostedConfig { org: String::new(), access: AccessList::parse("$all") },
+            HostedConfig { org: String::new(), rules: registry_mock_rules() },
         );
         let graph = [
             ("local".to_string(), Registry::Hosted { patterns: Vec::new() }),
@@ -1276,10 +1316,8 @@ impl Config {
             cache_storage: default_cache_dir(&storage),
             storage,
             upstreams: IndexMap::new(),
-            packages: IndexMap::new(),
             groups: AccessGroups::default(),
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
-            policies: PackagePolicies::registry_mock_defaults(),
             auth: AuthConfig::default(),
             logs: LogConfig::default(),
             hosted_store: HostedStoreConfig::Fs,
@@ -1497,7 +1535,18 @@ impl Config {
         let auth = build_auth_config(&file.auth, base_dir);
         let logs = build_log_config(file.log.as_ref());
         let groups = build_groups(&file.groups);
-        let policies = build_policies(&file.packages)?;
+        // The global ACL block is gone, not ignorable: it used to *enforce*
+        // access, so dropping it like an unknown verdaccio key would silently
+        // open previously-gated packages on upgrade. Fail loudly instead,
+        // naming the replacement.
+        if file.packages.is_some() {
+            return Err(RegistryError::InvalidConfig {
+                reason: "the top-level `packages:` block was removed: declare per-package rules \
+                         on the registry that serves them, as `registries.<name>.packages` \
+                         (pattern keys, `access`/`publish`/`unpublish` values)"
+                    .to_string(),
+            });
+        }
         let osv = build_osv_config(&file.osv, base_dir);
         // The npm-registry surface is derived, not configured: served iff
         // at least one registry is declared (no registries ⇒ nothing to serve),
@@ -1532,10 +1581,8 @@ impl Config {
             storage,
             cache_storage,
             upstreams,
-            packages: file.packages,
             groups,
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
-            policies,
             auth,
             logs,
             hosted_store,
@@ -1764,18 +1811,33 @@ fn build_registries(
                 {
                     return Err(org_collision_error(&name, &registry.org, other));
                 }
-                let access = registry
-                    .access
-                    .as_ref()
-                    .map_or_else(|| AccessList::parse("$all"), AccessSpec::to_access_list);
-                let patterns = build_patterns(&name, &registry.patterns)?;
-                hosted.insert(name.clone(), HostedConfig { org: registry.org, access });
+                let access = registry.access.as_ref().map(AccessSpec::to_access_list);
+                let rules = build_rules(&name, &registry.packages, access)?;
+                let patterns = rules.patterns();
+                hosted.insert(name.clone(), HostedConfig { org: registry.org, rules });
                 graph.insert(name, Registry::Hosted { patterns });
             }
             RegistryFile::Upstream(upstream) => {
-                let patterns = build_patterns(&name, &upstream.patterns)?;
+                // The registry-level default the rules fall back to: the
+                // upstream's `access:` gate, or `$all` for a public origin.
+                // Built before the `resolve_upstreams` fork so the graph
+                // carries the namespace on every tier, and so a
+                // `publish`/`unpublish` value — a write rule on a registry no
+                // write can land on — fails startup on every tier too.
+                let access = upstream.access.as_ref().map(AccessSpec::to_access_list);
+                let rules = build_rules(&name, &upstream.packages, access)?;
+                if rules.refines_writes() {
+                    return Err(RegistryError::InvalidConfig {
+                        reason: format!(
+                            "upstream registry {name:?} declares `publish`/`unpublish` rules in \
+                             its `packages:` map; writes can never land on an upstream",
+                        ),
+                    });
+                }
+                let patterns = rules.patterns();
                 if resolve_upstreams {
-                    let resolved = resolve_upstream_registry::<SystemEnv>(&name, *upstream)?;
+                    let mut resolved = resolve_upstream_registry::<SystemEnv>(&name, *upstream)?;
+                    resolved.rules = rules;
                     upstreams.insert(name.clone(), resolved);
                 }
                 graph.insert(name, Registry::Upstream { patterns });
@@ -1847,22 +1909,35 @@ fn validate_org_namespace(name: &str, org: &str) -> Result<(), RegistryError> {
     })
 }
 
-/// Compile a concrete registry's `patterns:` list into the decidable
-/// [`PackagePattern`] language. Duplicate patterns and the routing-graph
-/// checks are handled later by [`Registries::validate`] once the whole graph
-/// exists.
-fn build_patterns(
+/// Compile a concrete registry's `packages:` map into its [`PackageRules`]:
+/// keys parsed into the decidable [`PackagePattern`] language, values into
+/// per-package permission rules (`{}`/null ⇒ all fields default). Selection
+/// is by specificity, so key order carries no meaning; a duplicate key is the
+/// only within-registry error, and the YAML parser already rejects literal
+/// duplicates in one mapping — the check here guards the graph invariant for
+/// any other construction path. Routing-graph checks are handled later by
+/// [`Registries::validate`] once the whole graph exists.
+fn build_rules(
     registry: &str,
-    patterns: &[String],
-) -> Result<Vec<PackagePattern>, RegistryError> {
-    patterns
+    packages: &IndexMap<String, Option<PackageAccess>>,
+    default_access: Option<AccessList>,
+) -> Result<PackageRules, RegistryError> {
+    let rules = packages
         .iter()
-        .map(|pattern| {
-            PackagePattern::parse(pattern).map_err(|err| RegistryError::InvalidConfig {
-                reason: format!("registry {registry:?}: {err}"),
+        .map(|(pattern, rule)| {
+            let pattern = PackagePattern::parse(pattern).map_err(|err| {
+                RegistryError::InvalidConfig { reason: format!("registry {registry:?}: {err}") }
+            })?;
+            let rule = rule.as_ref();
+            Ok(PackageRule {
+                pattern,
+                access: rule.and_then(|r| r.access.as_ref()).map(AccessSpec::to_access_list),
+                publish: rule.and_then(|r| r.publish.as_ref()).map(AccessSpec::to_access_list),
+                unpublish: rule.and_then(|r| r.unpublish.as_ref()).map(AccessSpec::to_access_list),
             })
         })
-        .collect()
+        .collect::<Result<Vec<_>, RegistryError>>()?;
+    Ok(PackageRules::new(rules, default_access))
 }
 
 /// Resolve an `upstream:` registry into the shared [`UpstreamConfig`] runtime shape.
@@ -2082,38 +2157,6 @@ fn build_log_config(entry: Option<&LogEntryFile>) -> LogConfig {
         level: entry.level.unwrap_or_default(),
         sink: entry.r#type.clone(),
     }
-}
-
-/// Compile the YAML `packages:` rules into the runtime
-/// [`PackagePolicies`], in declared order (first match wins). A
-/// missing `access` defaults to `$all`, a missing `publish` to
-/// `$authenticated`, and a missing, empty, or null `unpublish` denies
-/// destructive writes. The same safe fallback [`PackagePolicies`]
-/// applies to packages no rule matches. Errors only on an invalid glob
-/// pattern — any token string is a valid group/username, as in
-/// verdaccio.
-fn build_policies(
-    packages: &IndexMap<String, PackageAccess>,
-) -> Result<PackagePolicies, RegistryError> {
-    let rules = packages
-        .iter()
-        .map(|(pattern, access)| {
-            let access_list = access
-                .access
-                .as_ref()
-                .map_or_else(|| AccessList::parse("$all"), AccessSpec::to_access_list);
-            let publish_list = access
-                .publish
-                .as_ref()
-                .map_or_else(|| AccessList::parse("$authenticated"), AccessSpec::to_access_list);
-            let unpublish_list = access
-                .unpublish
-                .as_ref()
-                .map_or_else(AccessList::default, AccessSpec::to_access_list);
-            PackagePolicy::new(pattern, access_list, publish_list, unpublish_list)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    Ok(PackagePolicies::new(rules))
 }
 
 /// Join `config.yaml` onto a resolved config directory and keep the

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1195,7 +1195,7 @@ const REGISTRY_MOCK_LOCAL_PATTERNS: &[&str] = &[
 ];
 
 /// The `local` hosted registry's `packages:` rules in the registry-mock
-/// shape: the fixture namespace (`REGISTRY_MOCK_LOCAL_PATTERNS`) with
+/// shape: the fixture namespace ([`REGISTRY_MOCK_LOCAL_PATTERNS`]) with
 /// default rules, `@private/*` and `@pnpm.e2e/needs-auth` restricted to
 /// authenticated callers (the rules `@pnpm/registry-mock` applied under
 /// verdaccio), and unpublish open to any authenticated user so the
@@ -1928,12 +1928,18 @@ fn build_rules(
             let pattern = PackagePattern::parse(pattern).map_err(|err| {
                 RegistryError::InvalidConfig { reason: format!("registry {registry:?}: {err}") }
             })?;
-            let rule = rule.as_ref();
+            let fields = rule.as_ref();
             Ok(PackageRule {
                 pattern,
-                access: rule.and_then(|r| r.access.as_ref()).map(AccessSpec::to_access_list),
-                publish: rule.and_then(|r| r.publish.as_ref()).map(AccessSpec::to_access_list),
-                unpublish: rule.and_then(|r| r.unpublish.as_ref()).map(AccessSpec::to_access_list),
+                access: fields
+                    .and_then(|fields| fields.access.as_ref())
+                    .map(AccessSpec::to_access_list),
+                publish: fields
+                    .and_then(|fields| fields.publish.as_ref())
+                    .map(AccessSpec::to_access_list),
+                unpublish: fields
+                    .and_then(|fields| fields.unpublish.as_ref())
+                    .map(AccessSpec::to_access_list),
             })
         })
         .collect::<Result<Vec<_>, RegistryError>>()?;

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1039,9 +1039,11 @@ struct ConfigFile {
     /// config still carrying the global block previously enforced access
     /// with it, so silently dropping the key (the fate of unknown verdaccio
     /// fields) would be a security regression — private packages would
-    /// quietly open up on upgrade.
-    #[serde(default)]
-    packages: Option<serde::de::IgnoredAny>,
+    /// quietly open up on upgrade. Presence-detected through a custom
+    /// deserializer because a plain `Option` maps a *bare* `packages:`
+    /// (YAML null) to `None`, which would slip past the rejection.
+    #[serde(default, deserialize_with = "detect_removed_packages_block")]
+    packages: Option<RemovedPackagesBlock>,
     /// pnpr-only static groups: each key is a group/team name and each
     /// value is the list of pnpr usernames in that group.
     #[serde(default)]
@@ -1063,6 +1065,24 @@ struct ConfigFile {
     /// intentionally not accepted.
     #[serde(default)]
     log: Option<LogEntryFile>,
+}
+
+/// Marker for a present top-level `packages:` key, whatever its value.
+#[derive(Debug)]
+struct RemovedPackagesBlock;
+
+/// `Some` whenever the `packages:` key is present — including `packages:`
+/// with no value (YAML null), which `Option<IgnoredAny>` would map to
+/// `None` and let slip past the loud rejection. The value itself is
+/// consumed and discarded; only presence matters.
+fn detect_removed_packages_block<'de, De>(
+    deserializer: De,
+) -> Result<Option<RemovedPackagesBlock>, De::Error>
+where
+    De: serde::Deserializer<'de>,
+{
+    serde::de::IgnoredAny::deserialize(deserializer)?;
+    Ok(Some(RemovedPackagesBlock))
 }
 
 /// The YAML `log:` object. Mirrors verdaccio 6's logger config.

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1803,6 +1803,22 @@ packages:
         ),
         "unexpected error: {err}",
     );
+
+    // A *bare* `packages:` (YAML null) and an empty block are the same
+    // removed key and must be rejected identically — a plain `Option`
+    // would map null to "absent" and let it slip through.
+    for stub in ["packages:\n", "packages: {}\n", "packages: ~\n"] {
+        let yaml = format!("storage: ./s\nregistries:\n  local:\n    type: hosted\n{stub}");
+        let err = Config::from_yaml_str(&yaml, Path::new("/x"), listen(), None)
+            .expect_err("a present top-level packages: key must be rejected");
+        assert!(
+            matches!(
+                &err,
+                RegistryError::InvalidConfig { reason } if reason.contains("top-level `packages:`"),
+            ),
+            "unexpected error for {stub:?}: {err}",
+        );
+    }
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -359,9 +359,6 @@ registries:
 fn from_yaml_str_tolerates_unresolved_env_var_references() {
     let yaml = r"
 storage: ${PNPR_UNSET_VAR_FOR_TEST}./store
-packages:
-  '**':
-    proxy: npmjs
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
         .expect("an unresolved ${VAR} is replaced with empty, not an error");
@@ -464,28 +461,28 @@ fn default_yaml_const_matches_what_from_default_parses() {
 
 #[test]
 fn from_yaml_str_storage_is_resolved_relative_to_base_dir() {
-    let yaml = "storage: ./store\npackages: {}\n";
+    let yaml = "storage: ./store\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert_eq!(config.storage, PathBuf::from("/etc/pnpr/./store"));
 }
 
 #[test]
 fn from_yaml_str_absolute_storage_is_left_alone() {
-    let yaml = "storage: /var/lib/pnpr\npackages: {}\n";
+    let yaml = "storage: /var/lib/pnpr\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert_eq!(config.storage, PathBuf::from("/var/lib/pnpr"));
 }
 
 #[test]
 fn cache_storage_defaults_to_subdir_of_storage() {
-    let yaml = "storage: /var/lib/pnpr\npackages: {}\n";
+    let yaml = "storage: /var/lib/pnpr\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert_eq!(config.cache_storage, PathBuf::from("/var/lib/pnpr/.pnpr-cache"));
 }
 
 #[test]
 fn explicit_cache_key_overrides_the_default() {
-    let yaml = "storage: /var/lib/pnpr\ncache: /scratch/pnpr\npackages: {}\n";
+    let yaml = "storage: /var/lib/pnpr\ncache: /scratch/pnpr\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert_eq!(config.storage, PathBuf::from("/var/lib/pnpr"));
     assert_eq!(config.cache_storage, PathBuf::from("/scratch/pnpr"));
@@ -493,24 +490,19 @@ fn explicit_cache_key_overrides_the_default() {
 
 #[test]
 fn relative_cache_key_is_resolved_against_base_dir() {
-    let yaml = "storage: ./store\ncache: ./cache\npackages: {}\n";
+    let yaml = "storage: ./store\ncache: ./cache\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert_eq!(config.cache_storage, PathBuf::from("/etc/pnpr/./cache"));
 }
 
 #[test]
 fn osv_config_defaults_off_and_resolves_relative_path() {
-    let defaulted = Config::from_yaml_str(
-        "upstreams: {}\npackages: {}\n",
-        Path::new("/etc/pnpr"),
-        listen(),
-        None,
-    )
-    .unwrap();
+    let defaulted =
+        Config::from_yaml_str("upstreams: {}\n", Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert!(!defaulted.osv.enabled);
     assert_eq!(defaulted.osv.path, None);
 
-    let yaml = "osv:\n  enabled: true\n  path: ./osv/npm/all.zip\npackages: {}\n";
+    let yaml = "osv:\n  enabled: true\n  path: ./osv/npm/all.zip\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert!(config.osv.enabled);
     assert_eq!(config.osv.path, Some(PathBuf::from("/etc/pnpr/./osv/npm/all.zip")));
@@ -518,7 +510,7 @@ fn osv_config_defaults_off_and_resolves_relative_path() {
 
 #[test]
 fn hosted_store_defaults_to_fs_without_an_s3_block() {
-    let yaml = "storage: /var/lib/pnpr\npackages: {}\n";
+    let yaml = "storage: /var/lib/pnpr\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert!(matches!(config.hosted_store, HostedStoreConfig::Fs));
 }
@@ -535,7 +527,6 @@ s3:
   accessKeyId: AKIA-test
   secretAccessKey: secret-test
 upstreams: {}
-packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     match config.hosted_store {
@@ -546,20 +537,20 @@ packages: {}
 
 #[test]
 fn s3_block_without_a_bucket_is_a_config_error() {
-    let yaml = "storage: /x\ns3:\n  region: auto\npackages: {}\n";
+    let yaml = "storage: /x\ns3:\n  region: auto\n";
     assert!(Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).is_err());
 }
 
 #[test]
 fn backend_defaults_to_local_without_a_block() {
-    let yaml = "storage: /var/lib/pnpr\npackages: {}\n";
+    let yaml = "storage: /var/lib/pnpr\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert!(matches!(config.backend, BackendConfig::Local));
 }
 
 #[test]
 fn backend_block_rejects_empty_selection() {
-    let yaml = "storage: /var/lib/pnpr\nbackend: {}\npackages: {}\n";
+    let yaml = "storage: /var/lib/pnpr\nbackend: {}\n";
     let err = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None)
         .expect_err("an empty backend block must not fall back to local");
     assert!(
@@ -576,7 +567,6 @@ backend:
   sqlite:
     url: sqlite:///var/lib/pnpr/auth.db
 upstreams: {}
-packages: {}
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None)
         .expect_err("an unknown backend key must not fall back to local");
@@ -595,7 +585,6 @@ backend:
     url: libsql://db.turso.io
     authToken: tok-secret
 upstreams: {}
-packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     match config.backend {
@@ -615,7 +604,6 @@ backend:
   libsql:
     url: http://127.0.0.1:8080
 upstreams: {}
-packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     match config.backend {
@@ -637,7 +625,6 @@ backend:
     replicaPath: auth-replica.db
     syncIntervalSecs: 15
 upstreams: {}
-packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     match config.backend {
@@ -662,7 +649,6 @@ backend:
     url: libsql://db.turso.io
     replicaPath: /var/lib/pnpr/auth-replica.db
 upstreams: {}
-packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     match config.backend {
@@ -685,7 +671,6 @@ backend:
     timeout: 5s
     startupTimeout: 2m
 upstreams: {}
-packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     match config.backend {
@@ -707,7 +692,6 @@ backend:
   postgresql:
     url: postgresql://pnpr:secret@db.example/pnpr
 upstreams: {}
-packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     match config.backend {
@@ -732,7 +716,6 @@ backend:
   mysql:
     url: mysql://pnpr:secret@db.example/pnpr
 upstreams: {}
-packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     match config.backend {
@@ -758,7 +741,6 @@ backend:
     url: mysql://pnpr:secret@db.example/pnpr
     startupTimeout: 0
 upstreams: {}
-packages: {}
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None)
         .expect_err("zero startup timeout must not be accepted");
@@ -777,7 +759,6 @@ backend:
     url: postgres://pnpr:secret@db.example/pnpr
     timeout: 0
 upstreams: {}
-packages: {}
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None)
         .expect_err("zero timeout must not be accepted");
@@ -797,7 +778,6 @@ backend:
   postgres:
     url: postgres://pnpr:secret@db.example/pnpr
 upstreams: {}
-packages: {}
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None)
         .expect_err("a backend block must not select two databases");
@@ -820,10 +800,6 @@ secret: a-sufficiently-long-secret-value
 upstreams:
   npmjs:
     url: https://registry.npmjs.org/
-packages:
-  '**':
-    access: $all
-    proxy: npmjs
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
     // The unimplemented sections parse silently and the config is usable.
@@ -846,7 +822,7 @@ registries:
     type: upstream
     url: https://npm.corp.example/
     access: $authenticated
-    patterns: ['@corp/*']
+    packages: { '@corp/*': {} }
   main:
     type: router
     sources: [corp, npmjs]
@@ -880,7 +856,7 @@ fn from_yaml_str_rejects_misordered_router() {
 storage: ./s
 registries:
   npmjs: { type: upstream, url: https://registry.npmjs.org/, public: true }
-  acme: { type: hosted, org: acme, patterns: ['@acme/*'] }
+  acme: { type: hosted, org: acme, packages: { '@acme/*': {} } }
   main:
     type: router
     sources: [npmjs, acme]
@@ -890,14 +866,14 @@ registries:
     assert!(err.to_string().contains("unreachable"), "unexpected error: {err}");
 }
 
-/// An unsupported wildcard in a registry's `patterns:` fails config load, named
+/// An unsupported wildcard key in a registry's `packages:` fails config load, named
 /// for the offending registry, rather than becoming a claim that never matches.
 #[test]
 fn from_yaml_str_rejects_invalid_registry_pattern() {
     let yaml = "\
 storage: ./s
 registries:
-  acme: { type: hosted, org: acme, patterns: ['@acme/ba*r'] }
+  acme: { type: hosted, org: acme, packages: { '@acme/ba*r': {} } }
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
         .expect_err("an unsupported registry pattern must be rejected");
@@ -906,17 +882,18 @@ registries:
     assert!(message.contains("@acme/ba*r"), "expected the pattern named, got: {message}");
 }
 
-/// A duplicate pattern within one registry's namespace fails config load.
+/// A duplicate key within one registry's `packages:` map fails config load —
+/// the one within-registry error (selection is by specificity, so nothing
+/// else about the map can be a defect).
 #[test]
 fn from_yaml_str_rejects_duplicate_registry_pattern() {
     let yaml = "\
 storage: ./s
 registries:
-  acme: { type: hosted, org: acme, patterns: ['@acme/*', '@acme/*'] }
+  acme: { type: hosted, org: acme, packages: { '@acme/*': {}, '@acme/*': {} } }
 ";
-    let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
-        .expect_err("a duplicate registry pattern must be rejected");
-    assert!(err.to_string().contains("more than once"), "unexpected error: {err}");
+    Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
+        .expect_err("a duplicate packages key must be rejected");
 }
 
 /// `defaultRegistry` naming an undefined registry fails closed.
@@ -1123,14 +1100,14 @@ registries:
 
 #[test]
 fn from_yaml_str_public_url_defaults_to_listen_when_none_passed() {
-    let yaml = "storage: ./s\npackages: {}\n";
+    let yaml = "storage: ./s\n";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
     assert_eq!(config.public_url, format!("http://{}", listen()));
 }
 
 #[test]
 fn from_yaml_str_public_url_override_wins() {
-    let yaml = "storage: ./s\npackages: {}\n";
+    let yaml = "storage: ./s\n";
     let config = Config::from_yaml_str(
         yaml,
         Path::new("/x"),
@@ -1148,7 +1125,7 @@ fn from_yaml_path_round_trips_through_tempfile() {
     // resolved against the *config file's* parent dir.
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("registry.yml");
-    std::fs::write(&config_path, "storage: ./store\npackages: {}\n").unwrap();
+    std::fs::write(&config_path, "storage: ./store\n").unwrap();
     let config = Config::from_yaml(&config_path, listen(), None).unwrap();
     assert_eq!(config.storage, dir.path().join("./store"));
 }
@@ -1176,7 +1153,6 @@ auth:
   htpasswd:
     file: ./htpasswd
 upstreams: {}
-packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert_eq!(config.auth.htpasswd.file.as_deref(), Some(Path::new("/etc/pnpr/./htpasswd")));
@@ -1186,7 +1162,7 @@ packages: {}
 
 #[test]
 fn auth_block_absent_disables_registration_by_default() {
-    let yaml = "storage: ./s\npackages: {}\n";
+    let yaml = "storage: ./s\n";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
     assert!(config.auth.htpasswd.file.is_none());
     assert!(config.auth.tokens.file.is_none());
@@ -1202,7 +1178,6 @@ auth:
   htpasswd:
     file: ./htpasswd
 upstreams: {}
-packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
     assert_eq!(config.auth.htpasswd.max_users, super::MaxUsers::Disabled);
@@ -1218,7 +1193,6 @@ auth:
   tokens:
     file: /var/lib/pnpr/tokens.sqlite
 upstreams: {}
-packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert_eq!(config.auth.tokens.file.as_deref(), Some(Path::new("/var/lib/pnpr/tokens.sqlite")));
@@ -1233,7 +1207,6 @@ auth:
     file: ./htpasswd
     max_users: -1
 upstreams: {}
-packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
     assert_eq!(config.auth.htpasswd.max_users, super::MaxUsers::Disabled);
@@ -1248,7 +1221,6 @@ auth:
     file: ./htpasswd
     max_users: 5
 upstreams: {}
-packages: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
     assert_eq!(config.auth.htpasswd.max_users, super::MaxUsers::Limited(5));
@@ -1256,7 +1228,7 @@ packages: {}
 
 #[test]
 fn logs_default_when_yaml_omits_block() {
-    let yaml = "storage: ./s\npackages: {}\n";
+    let yaml = "storage: ./s\n";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
     assert_eq!(config.logs.format, LogFormat::Pretty);
     assert_eq!(config.logs.level, LogLevel::Info);
@@ -1272,7 +1244,6 @@ fn log_unsupported_sink_type_is_recorded_but_flagged_unsupported() {
     let yaml = "\
 storage: ./s
 upstreams: {}
-packages: {}
 log:
   type: file
   format: json
@@ -1288,7 +1259,6 @@ fn log_pretty_and_level_picked_from_singular_block() {
     let yaml = "\
 storage: ./s
 upstreams: {}
-packages: {}
 log:
   type: stdout
   format: pretty
@@ -1304,7 +1274,6 @@ fn log_json_format_parses() {
     let yaml = "\
 storage: ./s
 upstreams: {}
-packages: {}
 log:
   type: stdout
   format: json
@@ -1323,7 +1292,6 @@ fn log_legacy_plural_list_is_ignored() {
     let yaml = "\
 storage: ./s
 upstreams: {}
-packages: {}
 logs:
   - type: stdout
     format: json
@@ -1340,7 +1308,6 @@ fn log_missing_fields_fall_back_to_defaults() {
     let yaml = "\
 storage: ./s
 upstreams: {}
-packages: {}
 log:
   type: stdout
 ";
@@ -1385,7 +1352,7 @@ fn config_file_in_returns_none_when_file_is_missing() {
 fn config_file_in_returns_path_when_file_exists() {
     let dir = tempfile::tempdir().unwrap();
     let expected = dir.path().join("config.yaml");
-    std::fs::write(&expected, "storage: ./s\npackages: {}\n").unwrap();
+    std::fs::write(&expected, "storage: ./s\n").unwrap();
     let resolved = config_file_in(Some(dir.path().to_path_buf())).expect("file is present");
     assert_eq!(resolved, expected);
 }
@@ -1418,9 +1385,6 @@ fn config_file_in_resolved_file_round_trips_through_from_yaml() {
 storage: {storage}
 upstreams:
   npmjs: {{ url: https://registry.npmjs.org/ }}
-packages:
-  '**':
-    proxy: npmjs
 log:
   type: stdout
   format: json
@@ -1504,7 +1468,7 @@ fn write_yaml(dir: &Path, name: &str, contents: &str) -> PathBuf {
     path
 }
 
-const MINIMAL_YAML: &str = "storage: ./s\npackages: {}\n";
+const MINIMAL_YAML: &str = "storage: ./s\n";
 
 #[test]
 fn resolve_bundled_when_no_path_supplied() {
@@ -1542,16 +1506,10 @@ fn resolve_cli_wins_over_default_path() {
     let tmp = tempfile::tempdir().unwrap();
     let cli_storage = tmp.path().join("from-cli");
     let default_storage = tmp.path().join("from-default");
-    let cli = write_yaml(
-        tmp.path(),
-        "explicit.yml",
-        &format!("storage: {}\npackages: {{}}\n", cli_storage.display()),
-    );
-    let default = write_yaml(
-        tmp.path(),
-        "default.yml",
-        &format!("storage: {}\npackages: {{}}\n", default_storage.display()),
-    );
+    let cli =
+        write_yaml(tmp.path(), "explicit.yml", &format!("storage: {}\n", cli_storage.display()));
+    let default =
+        write_yaml(tmp.path(), "default.yml", &format!("storage: {}\n", default_storage.display()));
     let (config, source) = Config::resolve(Some(&cli), Some(&default), listen(), None).unwrap();
     assert_eq!(source, ConfigSource::Cli(cli));
     // Confirms the *content* came from the CLI file, not the default.
@@ -1609,7 +1567,7 @@ fn yaml_with_no_storage_uses_default_storage_string() {
     // `storage:` is absent entirely — `default_storage_string`
     // supplies `"./storage"`, which `resolve_relative` then joins
     // to the config-file's parent dir.
-    let yaml = "upstreams: {}\npackages: {}\n";
+    let yaml = "upstreams: {}\n";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     assert_eq!(config.storage, PathBuf::from("/etc/pnpr/./storage"));
 }
@@ -1624,7 +1582,6 @@ fn yaml_log_block_with_no_type_field_uses_default_log_type() {
     let yaml = "\
 storage: ./s
 upstreams: {}
-packages: {}
 log:
   format: json
   level: warn
@@ -1637,29 +1594,29 @@ log:
     assert!(config.logs.sink_is_supported());
 }
 
-// ----- policy wiring from YAML ------------------------------------------
+// ----- per-registry `packages:` rules from YAML -------------------------
+
+/// A one-hosted-registry config whose `packages:` map is the given YAML
+/// fragment (indented under `packages:`).
+fn hosted_rules_config(packages: &str) -> Config {
+    let yaml = format!(
+        "storage: ./s\nregistries:\n  local:\n    type: hosted\n    packages:\n{packages}",
+    );
+    Config::from_yaml_str(&yaml, Path::new("/x"), listen(), None).unwrap()
+}
 
 #[test]
-fn policies_are_derived_from_packages_block() {
-    // The `access` / `publish` tokens in each entry drive the
-    // runtime policy — not a hard-coded default set.
-    let yaml = "\
-storage: ./s
-upstreams: {}
-packages:
-  '@secret/*':
-    access: $authenticated
-    publish: $authenticated
-    unpublish: admin
-  '**':
-    access: $all
-    publish: $authenticated
-";
-    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    let secret = config.policies.for_package("@secret/thing");
+fn rules_are_derived_from_the_registry_packages_map() {
+    // The `access` / `publish` tokens in each entry drive the runtime
+    // rules — not a hard-coded default set.
+    let config = hosted_rules_config(
+        "      '@secret/*':\n        access: $authenticated\n        publish: $authenticated\n        unpublish: admin\n      '**':\n        access: $all\n        publish: $authenticated\n",
+    );
+    let rules = &config.hosted["local"].rules;
+    let secret = rules.for_package("@secret/thing");
     assert!(!secret.access.allows(&Identity::Anonymous));
     assert!(secret.access.allows(&user("alice")));
-    let public = config.policies.for_package("lodash");
+    let public = rules.for_package("lodash");
     assert!(public.access.allows(&Identity::Anonymous));
     assert!(!public.publish.allows(&Identity::Anonymous));
     assert!(!secret.unpublish.allows(&user("alice")));
@@ -1667,51 +1624,61 @@ packages:
 }
 
 #[test]
-fn policy_first_matching_rule_wins() {
-    // `@secret/*` is declared before the `**` catch-all, so it
-    // wins for a scoped package even though both match.
-    let yaml = "\
-storage: ./s
-upstreams: {}
-packages:
-  '@secret/*':
-    access: $authenticated
-  '**':
-    access: $all
-";
-    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    assert!(!config.policies.for_package("@secret/x").access.allows(&Identity::Anonymous));
-    assert!(config.policies.for_package("anything").access.allows(&Identity::Anonymous));
+fn most_specific_key_wins_regardless_of_declaration_order() {
+    // Selection is by specificity, not key order: a formatter or `yq`
+    // round-trip that reorders the YAML mapping must not change which
+    // access rule applies. The same two keys, both orders, same answers.
+    let scope_then_catch_all =
+        "      '@secret/*':\n        access: $authenticated\n      '**':\n        access: $all\n";
+    let catch_all_then_scope =
+        "      '**':\n        access: $all\n      '@secret/*':\n        access: $authenticated\n";
+    for packages in [scope_then_catch_all, catch_all_then_scope] {
+        let config = hosted_rules_config(packages);
+        let rules = &config.hosted["local"].rules;
+        assert!(!rules.for_package("@secret/x").access.allows(&Identity::Anonymous), "{packages}",);
+        assert!(rules.for_package("anything").access.allows(&Identity::Anonymous), "{packages}");
+    }
 }
 
 #[test]
-fn policy_missing_access_and_publish_default_to_all_and_authenticated() {
-    let yaml = "\
-storage: ./s
-upstreams: {}
-packages:
-  'lodash': {}
-";
-    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    let effective = config.policies.for_package("lodash");
-    assert!(effective.access.allows(&Identity::Anonymous));
-    assert!(!effective.publish.allows(&Identity::Anonymous));
-    assert!(effective.publish.allows(&user("alice")));
-    assert!(!effective.unpublish.allows(&Identity::Anonymous));
-    assert!(!effective.unpublish.allows(&user("alice")));
+fn empty_and_null_map_values_mean_default_rules() {
+    for value in ["{}", "", "~"] {
+        let config = hosted_rules_config(&format!("      'lodash': {value}\n"));
+        let rules = &config.hosted["local"].rules;
+        let effective = rules.for_package("lodash");
+        assert!(effective.access.allows(&Identity::Anonymous), "value {value:?}");
+        assert!(!effective.publish.allows(&Identity::Anonymous), "value {value:?}");
+        assert!(effective.publish.allows(&user("alice")), "value {value:?}");
+        assert!(!effective.unpublish.allows(&user("alice")), "value {value:?}");
+    }
 }
 
 #[test]
-fn policy_missing_unpublish_denies_destructive_writes() {
+fn registry_level_access_is_the_default_for_omitted_fields() {
     let yaml = "\
 storage: ./s
-upstreams: {}
-packages:
-  '@team/*':
-    publish: alice
+registries:
+  local:
+    type: hosted
+    access: team
+    packages:
+      '@team/*': {}
+      '@team/open':
+        access: $all
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    let team = config.policies.for_package("@team/x");
+    let rules = &config.hosted["local"].rules;
+    // Omitted `access` falls back to the registry-level default...
+    assert!(rules.for_package("@team/x").access.allows(&user("team")));
+    assert!(!rules.for_package("@team/x").access.allows(&user("carol")));
+    // ...while the more specific key overrides it.
+    assert!(rules.for_package("@team/open").access.allows(&Identity::Anonymous));
+}
+
+#[test]
+fn rule_missing_unpublish_denies_destructive_writes() {
+    let config = hosted_rules_config("      '@team/*':\n        publish: alice\n");
+    let team = config.hosted["local"].rules.for_package("@team/x");
     assert!(team.publish.allows(&user("alice")));
     assert!(!team.publish.allows(&user("bob")));
     assert!(!team.unpublish.allows(&user("alice")));
@@ -1719,69 +1686,37 @@ packages:
 }
 
 #[test]
-fn policy_empty_unpublish_denies_destructive_writes() {
-    let as_null = "\
-storage: ./s
-upstreams: {}
-packages:
-  '@team/*':
-    publish: $authenticated
-    unpublish:
-";
-    let as_empty_string = "\
-storage: ./s
-upstreams: {}
-packages:
-  '@team/*':
-    publish: $authenticated
-    unpublish: ''
-";
-    let as_empty_sequence = "\
-storage: ./s
-upstreams: {}
-packages:
-  '@team/*':
-    publish: $authenticated
-    unpublish: []
-";
-    for yaml in [as_null, as_empty_string, as_empty_sequence] {
-        let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-        let team = config.policies.for_package("@team/x");
-        assert!(team.publish.allows(&user("alice")), "{yaml}");
-        assert!(!team.unpublish.allows(&Identity::Anonymous), "{yaml}");
-        assert!(!team.unpublish.allows(&user("alice")), "{yaml}");
+fn rule_empty_unpublish_denies_destructive_writes() {
+    let as_null = "      '@team/*':\n        publish: $authenticated\n        unpublish:\n";
+    let as_empty_string =
+        "      '@team/*':\n        publish: $authenticated\n        unpublish: ''\n";
+    let as_empty_sequence =
+        "      '@team/*':\n        publish: $authenticated\n        unpublish: []\n";
+    for packages in [as_null, as_empty_string, as_empty_sequence] {
+        let config = hosted_rules_config(packages);
+        let team = config.hosted["local"].rules.for_package("@team/x");
+        assert!(team.publish.allows(&user("alice")), "{packages}");
+        assert!(!team.unpublish.allows(&Identity::Anonymous), "{packages}");
+        assert!(!team.unpublish.allows(&user("alice")), "{packages}");
     }
 }
 
 #[test]
-fn policy_anonymous_token_is_wired() {
-    let yaml = "\
-storage: ./s
-upstreams: {}
-packages:
-  '@anon/*':
-    access: $anonymous
-";
-    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    let anon = config.policies.for_package("@anon/x");
+fn rule_anonymous_token_is_wired() {
+    let config = hosted_rules_config("      '@anon/*':\n        access: $anonymous\n");
+    let anon = config.hosted["local"].rules.for_package("@anon/x");
     assert!(anon.access.allows(&Identity::Anonymous));
     assert!(!anon.access.allows(&user("alice")));
 }
 
 #[test]
-fn policy_usernames_grant_per_user_access() {
+fn rule_usernames_grant_per_user_access() {
     // Bare names are usernames/groups (verdaccio-style), no longer
     // a config error.
-    let yaml = "\
-storage: ./s
-upstreams: {}
-packages:
-  '@team/*':
-    access: alice bob
-    publish: alice
-";
-    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    let team = config.policies.for_package("@team/x");
+    let config = hosted_rules_config(
+        "      '@team/*':\n        access: alice bob\n        publish: alice\n",
+    );
+    let team = config.hosted["local"].rules.for_package("@team/x");
     assert!(team.access.allows(&user("alice")));
     assert!(team.access.allows(&user("bob")));
     assert!(!team.access.allows(&user("carol")));
@@ -1797,10 +1732,12 @@ groups:
   platform: alice bob
   release:
     - carol
-packages:
-  '@team/*':
-    access: platform
 registries:
+  local:
+    type: hosted
+    packages:
+      '@team/*':
+        access: platform
   corp:
     type: upstream
     url: https://npm.corp.example/
@@ -1814,7 +1751,8 @@ registries:
     let bob = config.identity_for_user("bob");
     let carol = config.identity_for_user("carol");
 
-    let team = config.policies.for_package("@team/widget");
+    let rules = &config.hosted["local"].rules;
+    let team = rules.for_package("@team/widget");
     assert!(team.access.allows(&alice));
     assert!(team.access.allows(&bob));
     assert!(!team.access.allows(&carol));
@@ -1827,30 +1765,116 @@ registries:
 }
 
 #[test]
-fn policy_access_list_accepts_string_and_sequence_forms() {
+fn rule_access_list_accepts_string_and_sequence_forms() {
     // verdaccio accepts both a space-separated string and a YAML
     // sequence; they must compile to the same token list.
-    let as_string = "\
-storage: ./s
-upstreams: {}
-packages:
-  '@team/*':
-    access: alice bob
-";
-    let as_sequence = "\
-storage: ./s
-upstreams: {}
-packages:
-  '@team/*':
-    access: [alice, bob]
-";
-    for yaml in [as_string, as_sequence] {
-        let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-        let access = config.policies.for_package("@team/x").access;
-        assert!(access.allows(&user("alice")), "{yaml}");
-        assert!(access.allows(&user("bob")), "{yaml}");
-        assert!(!access.allows(&user("carol")), "{yaml}");
+    let as_string = "      '@team/*':\n        access: alice bob\n";
+    let as_sequence = "      '@team/*':\n        access: [alice, bob]\n";
+    for packages in [as_string, as_sequence] {
+        let config = hosted_rules_config(packages);
+        let access = config.hosted["local"].rules.for_package("@team/x").access;
+        assert!(access.allows(&user("alice")), "{packages}");
+        assert!(access.allows(&user("bob")), "{packages}");
+        assert!(!access.allows(&user("carol")), "{packages}");
     }
+}
+
+#[test]
+fn top_level_packages_block_is_a_startup_error() {
+    // The removed global ACL must not be silently dropped like an unknown
+    // verdaccio key: it used to *enforce* access, so ignoring it would
+    // quietly open previously-gated packages on upgrade.
+    let yaml = "\
+storage: ./s
+registries:
+  local:
+    type: hosted
+packages:
+  '@secret/*':
+    access: $authenticated
+";
+    let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap_err();
+    assert!(
+        matches!(
+            &err,
+            RegistryError::InvalidConfig { reason }
+                if reason.contains("top-level `packages:`")
+                    && reason.contains("registries.<name>.packages"),
+        ),
+        "unexpected error: {err}",
+    );
+}
+
+#[test]
+fn upstream_write_rules_are_rejected() {
+    // No write can land on an upstream, so a `publish`/`unpublish` value in
+    // its `packages:` map is a config mistake — and it fails on every tier,
+    // whether or not the registry surface resolves upstream credentials.
+    let yaml = "\
+storage: ./s
+registries:
+  corp:
+    type: upstream
+    url: https://npm.corp.example/
+    public: true
+    packages:
+      '@corp/*':
+        publish: $authenticated
+";
+    let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap_err();
+    assert!(
+        matches!(
+            &err,
+            RegistryError::InvalidConfig { reason }
+                if reason.contains("publish") && reason.contains("upstream"),
+        ),
+        "unexpected error: {err}",
+    );
+}
+
+#[test]
+fn public_upstream_allows_per_package_access_rules() {
+    // `public: true` describes the upstream *fetch* (anonymous, no
+    // credential, no registry-level access default). A per-package `access`
+    // rule still gates who may read the name through pnpr.
+    let yaml = "\
+storage: ./s
+registries:
+  npmjs:
+    type: upstream
+    url: https://registry.npmjs.org/
+    public: true
+    packages:
+      '@internal/*':
+        access: $authenticated
+      '**': {}
+";
+    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+    let rules = &config.upstreams["npmjs"].rules;
+    assert!(!rules.for_package("@internal/x").access.allows(&Identity::Anonymous));
+    assert!(rules.for_package("@internal/x").access.allows(&user("alice")));
+    assert!(rules.for_package("lodash").access.allows(&Identity::Anonymous));
+}
+
+#[test]
+fn upstream_packages_map_bounds_the_namespace() {
+    let yaml = "\
+storage: ./s
+registries:
+  corp:
+    type: upstream
+    url: https://npm.corp.example/
+    access: $authenticated
+    packages:
+      '@corp/*': {}
+";
+    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+    use crate::registry::{ConcreteKind, Resolved};
+    assert_eq!(
+        config.registries.resolve("corp", "@corp/tool"),
+        Resolved::Concrete { registry: "corp", kind: ConcreteKind::Upstream },
+    );
+    assert_eq!(config.registries.resolve("corp", "lodash"), Resolved::Unclaimed);
 }
 
 #[test]
@@ -1928,13 +1952,26 @@ fn bundled_default_config_enforces_its_protections() {
     // The bundled YAML is the only place the registry-mock protections are
     // declared, so building from it must yield every one of them.
     let config = Config::from_default_yaml(Path::new("/tmp"), listen(), None);
-    let needs_auth = config.policies.for_package("@pnpm.e2e/needs-auth");
+    let rules = &config.hosted["local"].rules;
+    // The exact needs-auth key wins over the '@pnpm.e2e/*' scope key by
+    // specificity (both are declared, in either order).
+    let needs_auth = rules.for_package("@pnpm.e2e/needs-auth");
     assert!(!needs_auth.access.allows(&Identity::Anonymous));
     assert!(needs_auth.access.allows(&user("alice")));
-    assert!(!config.policies.for_package("@private/foo").access.allows(&Identity::Anonymous));
-    let public = config.policies.for_package("lodash");
+    assert!(!rules.for_package("@private/foo").access.allows(&Identity::Anonymous));
+    let public = rules.for_package("@pnpm.e2e/no-deps");
     assert!(public.access.allows(&Identity::Anonymous));
     assert!(!public.publish.allows(&Identity::Anonymous));
+    // The registry-mock contract: any authenticated user may unpublish.
+    assert!(public.unpublish.allows(&user("alice")));
+    assert!(!public.unpublish.allows(&Identity::Anonymous));
+    // `lodash` is not local: it is unclaimed by the hosted registry and
+    // resolves to the npmjs catch-all through the router.
+    use crate::registry::{ConcreteKind, Resolved};
+    assert_eq!(
+        config.registries.resolve_default("lodash"),
+        Resolved::Concrete { registry: "npmjs", kind: ConcreteKind::Upstream },
+    );
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1635,7 +1635,7 @@ fn most_specific_key_wins_regardless_of_declaration_order() {
     for packages in [scope_then_catch_all, catch_all_then_scope] {
         let config = hosted_rules_config(packages);
         let rules = &config.hosted["local"].rules;
-        assert!(!rules.for_package("@secret/x").access.allows(&Identity::Anonymous), "{packages}",);
+        assert!(!rules.for_package("@secret/x").access.allows(&Identity::Anonymous), "{packages}");
         assert!(rules.for_package("anything").access.allows(&Identity::Anonymous), "{packages}");
     }
 }

--- a/pnpr/crates/pnpr/src/error.rs
+++ b/pnpr/crates/pnpr/src/error.rs
@@ -53,14 +53,6 @@ pub enum RegistryError {
         filename: String,
     },
 
-    #[display("Package policy pattern {pattern:?} is invalid: {reason}")]
-    #[from(skip)]
-    InvalidPolicyPattern {
-        #[error(not(source))]
-        pattern: String,
-        reason: String,
-    },
-
     /// The YAML config could not be parsed. Startup-only — this never
     /// surfaces over HTTP, but `Config` parsing shares this error type.
     #[display("Invalid config: {reason}")]
@@ -242,7 +234,6 @@ impl RegistryError {
             RegistryError::TarballIntegrity { .. } => "tarball_integrity",
             RegistryError::InvalidPackageName { .. } => "invalid_package_name",
             RegistryError::InvalidTarballName { .. } => "invalid_tarball_name",
-            RegistryError::InvalidPolicyPattern { .. } => "invalid_policy_pattern",
             RegistryError::InvalidConfig { .. } => "invalid_config",
             RegistryError::Unauthenticated { .. } => "unauthenticated",
             RegistryError::Forbidden { .. } => "forbidden",
@@ -319,7 +310,6 @@ impl RegistryError {
             RegistryError::UpstreamUnavailable { .. } => StatusCode::SERVICE_UNAVAILABLE,
             RegistryError::InvalidPackageName { .. }
             | RegistryError::InvalidTarballName { .. }
-            | RegistryError::InvalidPolicyPattern { .. }
             | RegistryError::InvalidConfig { .. }
             | RegistryError::InvalidAttachment { .. }
             | RegistryError::BadRequest { .. } => StatusCode::BAD_REQUEST,

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -37,7 +37,7 @@ pub use config::{
 };
 pub use error::{RegistryError, Result};
 pub use journal::recover_publish_journal;
-pub use policy::{AccessList, AccessToken, Identity, PackagePolicies, PackagePolicy};
+pub use policy::{AccessList, AccessToken, Identity, PackageRule, PackageRules};
 pub use registry::{
     ConcreteKind, PackagePattern, Registries, Registry, RegistryConfigError, Resolved,
 };

--- a/pnpr/crates/pnpr/src/policy.rs
+++ b/pnpr/crates/pnpr/src/policy.rs
@@ -334,6 +334,21 @@ impl PackageRules {
     pub fn default_access(&self) -> &AccessList {
         &self.default_access
     }
+
+    /// Whether *any* name this registry serves could admit `identity`: the
+    /// registry-level default does, or some explicit entry's `access` does.
+    /// The search scan's fast path — a caller no rule could ever admit gets
+    /// the empty result without enumerating the registry's storage, so a
+    /// blanket-masked registry leaks neither package names nor its size
+    /// through scan timing.
+    #[must_use]
+    pub fn any_access_admits(&self, identity: &Identity) -> bool {
+        self.default_access.allows(identity)
+            || self
+                .rules
+                .iter()
+                .any(|rule| rule.access.as_ref().is_some_and(|access| access.allows(identity)))
+    }
 }
 
 #[cfg(test)]

--- a/pnpr/crates/pnpr/src/policy.rs
+++ b/pnpr/crates/pnpr/src/policy.rs
@@ -1,6 +1,11 @@
-//! Per-package access rules. Mirrors verdaccio's `packages:` config:
-//! a list of glob patterns, each with `access` / `publish` permission
-//! lists. The first matching pattern wins.
+//! Per-package access rules: each concrete registry's `packages:` map,
+//! keyed by [`PackagePattern`] with `access` / `publish` / `unpublish`
+//! permission lists as values. Selection is by **specificity**, not
+//! declaration order — an exact name beats `@scope/*` beats `@*/*` beats
+//! `**` — because a YAML mapping is formally unordered and key order must
+//! not decide which access rule applies. The restricted pattern language
+//! makes that selection total: for any one name, at most one key per
+//! specificity tier can match, so every name has exactly one winning entry.
 //!
 //! Each permission is a list of tokens (verdaccio's space-separated
 //! groups); a request is allowed when the caller's identity satisfies
@@ -13,9 +18,8 @@
 //! usernames from group names.
 
 use std::collections::{BTreeMap, BTreeSet};
-use wax::{Glob, Program};
 
-use crate::error::RegistryError;
+use crate::registry::PackagePattern;
 
 /// A single token in an access list.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -144,125 +148,138 @@ impl Identity {
     }
 }
 
-/// One entry in the access policy list. `pattern` is a wax glob
-/// compiled from the verdaccio-style key (e.g. `@private/*`,
-/// `@pnpm.e2e/needs-auth`, `**`). `access` controls who can read the
-/// packument and tarballs; `publish` controls who can publish or
-/// change dist-tags; `unpublish` controls destructive writes.
+/// One entry of a registry's `packages:` map: a namespace claim
+/// ([`PackagePattern`] key) plus optional per-package rules. `access`
+/// controls who can read the packument and tarballs; `publish` controls
+/// who can publish or change dist-tags; `unpublish` controls destructive
+/// writes. An omitted field falls back to the registry-level default
+/// carried by the owning [`PackageRules`].
 #[derive(Debug, Clone)]
-pub struct PackagePolicy {
-    pattern: Glob<'static>,
-    pub access: AccessList,
-    pub publish: AccessList,
-    pub unpublish: AccessList,
+pub struct PackageRule {
+    pub pattern: PackagePattern,
+    pub access: Option<AccessList>,
+    pub publish: Option<AccessList>,
+    pub unpublish: Option<AccessList>,
 }
 
-impl PackagePolicy {
-    pub fn new(
-        pattern: &str,
-        access: AccessList,
-        publish: AccessList,
-        unpublish: AccessList,
-    ) -> Result<Self, RegistryError> {
-        let glob = Glob::new(pattern)
-            .map_err(|err| RegistryError::InvalidPolicyPattern {
-                pattern: pattern.to_string(),
-                reason: err.to_string(),
-            })?
-            .into_owned();
-        Ok(Self { pattern: glob, access, publish, unpublish })
-    }
-
-    fn matches(&self, package: &str) -> bool {
-        self.pattern.is_match(package)
-    }
-}
-
-/// Ordered list of [`PackagePolicy`] rules. First match wins,
-/// matching verdaccio's evaluation order — order in the config is
-/// significant, since the catch-all `**` is almost always last.
+/// One concrete registry's `packages:` map: its namespace (the key set)
+/// and its per-package rules (the values), with the registry-level
+/// defaults an entry's omitted fields fall back to.
+///
+/// Selection is by **specificity** — the most specific matching key wins,
+/// and key order carries no meaning (see the module docs). No entry can be
+/// dead: an exact key carves its name out of a scope key, which still
+/// serves the rest, so there is no shadowed-entry validation inside a
+/// registry; a duplicate key is the only error (rejected at config load).
 #[derive(Debug, Clone)]
-pub struct PackagePolicies {
-    rules: Vec<PackagePolicy>,
-    /// Applied to packages no rule matches: reads open, writes require
-    /// auth. Owned here so [`Self::for_package`] can hand back a
-    /// borrow.
+pub struct PackageRules {
+    rules: Vec<PackageRule>,
+    /// Fallbacks for fields the winning entry omits (and for every name
+    /// when the map itself is empty = the registry claims every name).
     default_access: AccessList,
     default_publish: AccessList,
     default_unpublish: AccessList,
 }
 
-impl Default for PackagePolicies {
+impl Default for PackageRules {
+    /// The safe defaults with no rules: every name claimed, reads open,
+    /// publishes require auth, destructive writes denied.
     fn default() -> Self {
-        Self::new(Vec::new())
+        Self::new(Vec::new(), None)
     }
 }
 
-/// Effective permissions for one package, borrowed from the matched
-/// rule (or the defaults when none matched).
+/// Effective permissions for one package, borrowed from the winning
+/// entry (each field falling back to the registry-level default).
 #[derive(Debug, Clone, Copy)]
 pub struct Effective<'a> {
     pub access: &'a AccessList,
     pub publish: &'a AccessList,
     pub unpublish: &'a AccessList,
+    /// Whether `access` came from an explicit `packages:` entry rather than
+    /// the registry-level default. Drives how a hosted denial answers: an
+    /// explicitly gated name is declared, discoverable config and rejects
+    /// loudly (401/403, so a client can prompt for auth), while a
+    /// default-gated name is masked as not-found — a blanket-private
+    /// registry never reveals which names exist.
+    pub access_is_explicit: bool,
 }
 
-impl PackagePolicies {
+impl PackageRules {
+    /// Build a registry's rules. `default_access` is the registry-level
+    /// `access:` (its omission = `$all`); publish defaults to
+    /// `$authenticated` and unpublish to nobody, the safe defaults.
     #[must_use]
-    pub fn new(rules: Vec<PackagePolicy>) -> Self {
+    pub fn new(rules: Vec<PackageRule>, default_access: Option<AccessList>) -> Self {
         Self {
             rules,
-            default_access: AccessList::parse("$all"),
+            default_access: default_access.unwrap_or_else(|| AccessList::parse("$all")),
             default_publish: AccessList::parse("$authenticated"),
             default_unpublish: AccessList::default(),
         }
     }
 
-    /// `@pnpm/registry-mock`'s defaults, hard-coded so an out-of-the
-    /// box `Config` already enforces the same access rules verdaccio
-    /// did. The relevant patterns from `registry-mock`'s `config.yaml`:
-    ///
-    /// * `@private/*` — authenticated access + publish + unpublish
-    /// * `@pnpm.e2e/needs-auth` — authenticated access + publish + unpublish
-    /// * everything else — $all access, $authenticated publish + unpublish
+    /// Override the registry-level unpublish default (nobody). Used by the
+    /// programmatic registry-mock constructors, whose fixtures exercise
+    /// unpublish flows with any authenticated user.
     #[must_use]
-    pub fn registry_mock_defaults() -> Self {
-        let rules = [
-            ("@private/*", "$authenticated", "$authenticated", "$authenticated"),
-            ("@pnpm.e2e/needs-auth", "$authenticated", "$authenticated", "$authenticated"),
-            ("**", "$all", "$authenticated", "$authenticated"),
-        ];
-        let rules = rules
-            .into_iter()
-            .map(|(pattern, access, publish, unpublish)| {
-                PackagePolicy::new(
-                    pattern,
-                    AccessList::parse(access),
-                    AccessList::parse(publish),
-                    AccessList::parse(unpublish),
-                )
-                .expect("registry-mock defaults compile")
-            })
-            .collect();
-        Self::new(rules)
+    pub fn with_default_unpublish(mut self, unpublish: AccessList) -> Self {
+        self.default_unpublish = unpublish;
+        self
     }
 
+    /// Add one entry to the map. Selection stays order-free (specificity);
+    /// duplicate keys are the caller's to avoid — YAML loading rejects them.
+    /// For tests and embedders that build rules programmatically.
+    pub fn push_rule(&mut self, rule: PackageRule) {
+        self.rules.push(rule);
+    }
+
+    /// The namespace this registry declares: the map's key set. Empty =
+    /// every name. Feeds the routing graph, which enforces the claim on
+    /// every path to the registry.
+    #[must_use]
+    pub fn patterns(&self) -> Vec<PackagePattern> {
+        self.rules.iter().map(|rule| rule.pattern.clone()).collect()
+    }
+
+    /// Whether any rule carries the given field, i.e. the map refines that
+    /// permission somewhere. Lets config validation reject `publish:` /
+    /// `unpublish:` values on an upstream registry, where no write can land.
+    #[must_use]
+    pub fn refines_writes(&self) -> bool {
+        self.rules.iter().any(|rule| rule.publish.is_some() || rule.unpublish.is_some())
+    }
+
+    /// The effective permissions for `package`: the **most specific**
+    /// matching entry's fields, each falling back to the registry-level
+    /// default. Selection is order-free — the restricted pattern language
+    /// guarantees at most one matching key per specificity tier, so the
+    /// winner is unique regardless of where it appears in the map.
     #[must_use]
     pub fn for_package(&self, package: &str) -> Effective<'_> {
-        for rule in &self.rules {
-            if rule.matches(package) {
-                return Effective {
-                    access: &rule.access,
-                    publish: &rule.publish,
-                    unpublish: &rule.unpublish,
-                };
-            }
-        }
+        let winner = self
+            .rules
+            .iter()
+            .filter(|rule| rule.pattern.matches(package))
+            .max_by_key(|rule| rule.pattern.specificity());
+        let explicit_access = winner.and_then(|rule| rule.access.as_ref());
         Effective {
-            access: &self.default_access,
-            publish: &self.default_publish,
-            unpublish: &self.default_unpublish,
+            access: explicit_access.unwrap_or(&self.default_access),
+            publish: winner.and_then(|rule| rule.publish.as_ref()).unwrap_or(&self.default_publish),
+            unpublish: winner
+                .and_then(|rule| rule.unpublish.as_ref())
+                .unwrap_or(&self.default_unpublish),
+            access_is_explicit: explicit_access.is_some(),
         }
+    }
+
+    /// The registry-level default `access:` — who may reach the registry
+    /// when no per-package entry refines it. Write-path masking uses this
+    /// for names the registry does not claim (there is no entry to consult).
+    #[must_use]
+    pub fn default_access(&self) -> &AccessList {
+        &self.default_access
     }
 }
 

--- a/pnpr/crates/pnpr/src/policy.rs
+++ b/pnpr/crates/pnpr/src/policy.rs
@@ -174,11 +174,65 @@ pub struct PackageRule {
 #[derive(Debug, Clone)]
 pub struct PackageRules {
     rules: Vec<PackageRule>,
+    /// Winner lookup by specificity tier, rebuilt whenever the rule set
+    /// changes: at most one key per tier can match a given name, so the
+    /// most specific match resolves with map lookups instead of a scan of
+    /// every rule — `for_package` runs on every read, write, search hit,
+    /// and route classification.
+    index: RuleIndex,
     /// Fallbacks for fields the winning entry omits (and for every name
     /// when the map itself is empty = the registry claims every name).
     default_access: AccessList,
     default_publish: AccessList,
     default_unpublish: AccessList,
+}
+
+/// Positions of the rules by pattern shape, mirroring the specificity
+/// chain: an exact key beats the name's scope key beats `@*/*` beats `**`.
+/// Duplicate keys never coexist here — YAML loading and the routing-graph
+/// validation both reject them — so each slot holds the one possible rule.
+#[derive(Debug, Default, Clone)]
+struct RuleIndex {
+    exact: BTreeMap<String, usize>,
+    scopes: BTreeMap<String, usize>,
+    any_scoped: Option<usize>,
+    all: Option<usize>,
+}
+
+impl RuleIndex {
+    fn build(rules: &[PackageRule]) -> Self {
+        let mut index = Self::default();
+        for (position, rule) in rules.iter().enumerate() {
+            match &rule.pattern {
+                PackagePattern::Exact(name) => {
+                    index.exact.insert(name.clone(), position);
+                }
+                PackagePattern::Scope(scope) => {
+                    index.scopes.insert(scope.clone(), position);
+                }
+                PackagePattern::AnyScoped => index.any_scoped = Some(position),
+                PackagePattern::All => index.all = Some(position),
+            }
+        }
+        index
+    }
+
+    /// The winning rule's position for `package`: the most specific tier
+    /// with a matching key.
+    fn winner(&self, package: &str) -> Option<usize> {
+        if let Some(&position) = self.exact.get(package) {
+            return Some(position);
+        }
+        if let Some(scope) = PackagePattern::scope_of(package) {
+            if let Some(&position) = self.scopes.get(scope) {
+                return Some(position);
+            }
+            if let Some(position) = self.any_scoped {
+                return Some(position);
+            }
+        }
+        self.all
+    }
 }
 
 impl Default for PackageRules {
@@ -212,6 +266,7 @@ impl PackageRules {
     #[must_use]
     pub fn new(rules: Vec<PackageRule>, default_access: Option<AccessList>) -> Self {
         Self {
+            index: RuleIndex::build(&rules),
             rules,
             default_access: default_access.unwrap_or_else(|| AccessList::parse("$all")),
             default_publish: AccessList::parse("$authenticated"),
@@ -233,6 +288,7 @@ impl PackageRules {
     /// For tests and embedders that build rules programmatically.
     pub fn push_rule(&mut self, rule: PackageRule) {
         self.rules.push(rule);
+        self.index = RuleIndex::build(&self.rules);
     }
 
     /// The namespace this registry declares: the map's key set. Empty =
@@ -255,14 +311,11 @@ impl PackageRules {
     /// matching entry's fields, each falling back to the registry-level
     /// default. Selection is order-free — the restricted pattern language
     /// guarantees at most one matching key per specificity tier, so the
-    /// winner is unique regardless of where it appears in the map.
+    /// winner is unique regardless of where it appears in the map — and
+    /// indexed, so it costs tier lookups rather than a scan of every rule.
     #[must_use]
     pub fn for_package(&self, package: &str) -> Effective<'_> {
-        let winner = self
-            .rules
-            .iter()
-            .filter(|rule| rule.pattern.matches(package))
-            .max_by_key(|rule| rule.pattern.specificity());
+        let winner = self.index.winner(package).map(|position| &self.rules[position]);
         let explicit_access = winner.and_then(|rule| rule.access.as_ref());
         Effective {
             access: explicit_access.unwrap_or(&self.default_access),

--- a/pnpr/crates/pnpr/src/policy/tests.rs
+++ b/pnpr/crates/pnpr/src/policy/tests.rs
@@ -1,4 +1,28 @@
-use super::{AccessList, AccessToken, Identity, PackagePolicies};
+use super::{AccessList, AccessToken, Identity, PackageRule, PackageRules};
+use crate::registry::PackagePattern;
+
+fn rule(pattern: &str, access: Option<&str>) -> PackageRule {
+    PackageRule {
+        pattern: PackagePattern::parse(pattern).expect("test pattern parses"),
+        access: access.map(AccessList::parse),
+        publish: access.map(AccessList::parse),
+        unpublish: access.map(AccessList::parse),
+    }
+}
+
+/// The registry-mock shape from `Config::proxy`, reduced to what these
+/// selection tests exercise.
+fn registry_mock_rules() -> PackageRules {
+    PackageRules::new(
+        vec![
+            rule("@pnpm.e2e/*", None),
+            rule("@pnpm.e2e/needs-auth", Some("$authenticated")),
+            rule("@private/*", Some("$authenticated")),
+        ],
+        None,
+    )
+    .with_default_unpublish(AccessList::parse("$authenticated"))
+}
 
 fn user(name: &str) -> Identity {
     Identity::user(name)
@@ -75,7 +99,7 @@ fn empty_list_admits_no_one() {
 
 #[test]
 fn defaults_match_registry_mock_config() {
-    let policies = PackagePolicies::registry_mock_defaults();
+    let policies = registry_mock_rules();
 
     let needs_auth = policies.for_package("@pnpm.e2e/needs-auth");
     assert!(!needs_auth.access.allows(&Identity::Anonymous));
@@ -93,16 +117,82 @@ fn defaults_match_registry_mock_config() {
 }
 
 #[test]
-fn first_matching_rule_wins() {
-    let policies = PackagePolicies::registry_mock_defaults();
-    // `@private/foo` matches `@private/*` first, not the `**`
-    // catch-all: anonymous reads are denied.
-    assert!(!policies.for_package("@private/foo").access.allows(&Identity::Anonymous));
+fn most_specific_rule_wins_regardless_of_key_order() {
+    // The exact key beats the scope key whichever is declared first: the
+    // specificity chain (exact > @scope/* > @*/* > **) makes selection
+    // order-free, so a YAML round-trip that reorders mapping keys cannot
+    // change which access rule applies.
+    let scope_first = PackageRules::new(
+        vec![rule("@acme/*", Some("$all")), rule("@acme/secret", Some("$authenticated"))],
+        None,
+    );
+    let exact_first = PackageRules::new(
+        vec![rule("@acme/secret", Some("$authenticated")), rule("@acme/*", Some("$all"))],
+        None,
+    );
+    for rules in [&scope_first, &exact_first] {
+        assert!(!rules.for_package("@acme/secret").access.allows(&Identity::Anonymous));
+        assert!(rules.for_package("@acme/other").access.allows(&Identity::Anonymous));
+    }
+}
+
+#[test]
+fn specificity_chain_orders_all_four_tiers() {
+    let rules = PackageRules::new(
+        vec![
+            rule("**", Some("everyone")),
+            rule("@*/*", Some("scoped")),
+            rule("@acme/*", Some("acme")),
+            rule("@acme/exact", Some("exact")),
+        ],
+        None,
+    );
+    assert!(rules.for_package("@acme/exact").access.allows(&user("exact")));
+    assert!(!rules.for_package("@acme/exact").access.allows(&user("acme")));
+    assert!(rules.for_package("@acme/other").access.allows(&user("acme")));
+    assert!(rules.for_package("@beta/pkg").access.allows(&user("scoped")));
+    assert!(rules.for_package("unscoped").access.allows(&user("everyone")));
+}
+
+#[test]
+fn omitted_rule_fields_fall_back_to_registry_default_not_broader_keys() {
+    // The exact key wins and omits `access`; the fallback is the
+    // registry-level default, never the broader scope key's field.
+    let rules = PackageRules::new(
+        vec![
+            PackageRule {
+                pattern: PackagePattern::parse("@acme/*").expect("parses"),
+                access: Some(AccessList::parse("$authenticated")),
+                publish: None,
+                unpublish: None,
+            },
+            PackageRule {
+                pattern: PackagePattern::parse("@acme/open").expect("parses"),
+                access: None,
+                publish: None,
+                unpublish: None,
+            },
+        ],
+        None, // registry default access: $all
+    );
+    // `@acme/open`: exact key wins, omits access -> registry default ($all).
+    assert!(rules.for_package("@acme/open").access.allows(&Identity::Anonymous));
+    // Other scope names: scope key wins with its own access.
+    assert!(!rules.for_package("@acme/foo").access.allows(&Identity::Anonymous));
+}
+
+#[test]
+fn unclaimed_name_still_answers_with_defaults() {
+    // `for_package` on a name outside the key set answers with the
+    // registry defaults; namespace enforcement (404 before this lookup)
+    // is the routing graph's job, not the rules'.
+    let rules = PackageRules::new(vec![rule("@acme/*", Some("$authenticated"))], None);
+    assert!(rules.for_package("unclaimed").access.allows(&Identity::Anonymous));
 }
 
 #[test]
 fn falls_back_to_safe_defaults_when_no_rules_match() {
-    let policies = PackagePolicies::new(vec![]);
+    let policies = PackageRules::default();
     let effective = policies.for_package("anything");
     assert!(effective.access.allows(&Identity::Anonymous));
     assert!(!effective.publish.allows(&Identity::Anonymous));

--- a/pnpr/crates/pnpr/src/registry.rs
+++ b/pnpr/crates/pnpr/src/registry.rs
@@ -112,6 +112,14 @@ impl PackagePattern {
         }
     }
 
+    /// The scope of a well-formed scoped package name (`@acme/foo` →
+    /// `acme`), without its leading `@`; `None` for an unscoped or
+    /// malformed name. The scope-tier key a specificity lookup consults.
+    #[must_use]
+    pub fn scope_of(package: &str) -> Option<&str> {
+        scoped_name(package).map(|(scope, _)| scope)
+    }
+
     /// Whether this pattern matches `package`.
     #[must_use]
     pub fn matches(&self, package: &str) -> bool {

--- a/pnpr/crates/pnpr/src/registry.rs
+++ b/pnpr/crates/pnpr/src/registry.rs
@@ -96,6 +96,22 @@ impl PackagePattern {
         Ok(PackagePattern::Exact(pattern.to_string()))
     }
 
+    /// How specific this pattern is: an exact name beats `@scope/*` beats
+    /// `@*/*` beats `**`. For any one package name, the patterns that can
+    /// match it form a strict chain — at most one per tier can exist in a
+    /// duplicate-free set — so most-specific-match selection is total and
+    /// order-free. That is what lets a registry's `packages:` map be a YAML
+    /// mapping whose key order carries no meaning.
+    #[must_use]
+    pub fn specificity(&self) -> u8 {
+        match self {
+            PackagePattern::All => 0,
+            PackagePattern::AnyScoped => 1,
+            PackagePattern::Scope(_) => 2,
+            PackagePattern::Exact(_) => 3,
+        }
+    }
+
     /// Whether this pattern matches `package`.
     #[must_use]
     pub fn matches(&self, package: &str) -> bool {

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -18,7 +18,7 @@ use super::{
 };
 use crate::{
     config::{Config as RegistryConfig, PublicRoute, UpstreamConfig},
-    policy::{AccessList, Identity, PackagePolicies, PackagePolicy},
+    policy::{AccessList, Identity, PackageRule, PackageRules},
     route::{Footprint, PrivateAccessDescriptor, RouteContext},
 };
 
@@ -100,22 +100,28 @@ fn private_alias_footprint(alias: &str) -> Footprint {
     footprint
 }
 
-fn private_hosted_footprint(policy_id: &str) -> Footprint {
+fn private_hosted_footprint(registry: &str, package: &str) -> Footprint {
     let mut footprint = Footprint::default();
-    footprint.add(PrivateAccessDescriptor::Hosted { policy_id: policy_id.to_string() });
+    // Registry-qualified, matching `hosted_policy_id` in the route module.
+    footprint.add(PrivateAccessDescriptor::Hosted { policy_id: format!("{registry}\0{package}") });
     footprint
 }
 
-fn package_policies(pattern: &str, access: &str) -> PackagePolicies {
-    PackagePolicies::new(vec![
-        PackagePolicy::new(
-            pattern,
-            AccessList::parse(access),
-            AccessList::parse("$authenticated"),
-            AccessList::default(),
-        )
-        .expect("policy parses"),
-    ])
+/// Replace the `local` hosted registry's rules with a single-pattern map
+/// whose `access` is `access`, so a test can rotate who may read a hosted
+/// package.
+fn set_local_hosted_rules(config: &mut RegistryConfig, pattern: &str, access: &str) {
+    use crate::registry::PackagePattern;
+    let rules = PackageRules::new(
+        vec![PackageRule {
+            pattern: PackagePattern::parse(pattern).expect("test pattern parses"),
+            access: Some(AccessList::parse(access)),
+            publish: Some(AccessList::parse("$authenticated")),
+            unpublish: None,
+        }],
+        None,
+    );
+    config.hosted.get_mut("local").expect("proxy config has a local hosted registry").rules = rules;
 }
 
 fn lockfile(version: &str) -> Lockfile {
@@ -395,13 +401,13 @@ fn revoked_hosted_package_access_stops_matching_private_resolution_hits() {
         &cache,
         Duration::from_mins(1),
         key.clone(),
-        private_hosted_footprint("@private/pkg"),
+        private_hosted_footprint("local", "@private/pkg"),
         b"secret",
         &lockfile,
     ));
 
     let mut config = registry_config();
-    config.policies = package_policies("@private/*", "alice");
+    set_local_hosted_rules(&mut config, "@private/*", "alice");
     let context = RouteContext::from_config(&config);
     assert!(
         cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_some(),
@@ -410,7 +416,7 @@ fn revoked_hosted_package_access_stops_matching_private_resolution_hits() {
         cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("bob")).is_none(),
     );
 
-    config.policies = package_policies("@private/*", "bob");
+    set_local_hosted_rules(&mut config, "@private/*", "bob");
     let context = RouteContext::from_config(&config);
     assert!(
         cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_none(),

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -96,6 +96,7 @@ fn private_alias_footprint(alias: &str) -> Footprint {
     footprint.add(PrivateAccessDescriptor::Alias {
         alias: alias.to_string(),
         credential_digest: crate::route::credential_digest(ALIAS_TOKEN),
+        package: None,
     });
     footprint
 }
@@ -389,6 +390,56 @@ fn revoked_alias_access_stops_matching_private_resolution_hits() {
     );
     assert!(
         cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("bob")).is_some(),
+    );
+}
+
+#[test]
+fn package_qualified_alias_descriptor_rechecks_upstream_rules_on_replay() {
+    use crate::policy::{PackageRule, PackageRules};
+    use crate::registry::PackagePattern;
+
+    let cache = Mutex::new(HashMap::new());
+    let key = "base".to_string();
+    let lockfile = lockfile("1.0.0");
+    // A resolution that touched an explicitly refined name records the
+    // package-qualified descriptor (what `RouteHook` would produce).
+    let mut footprint = Footprint::default();
+    footprint.add(PrivateAccessDescriptor::Alias {
+        alias: "corp".to_string(),
+        credential_digest: crate::route::credential_digest(ALIAS_TOKEN),
+        package: Some("@corp/secret".to_string()),
+    });
+    assert!(store_resolution(
+        &cache,
+        Duration::from_mins(1),
+        key.clone(),
+        footprint,
+        b"secret",
+        &lockfile,
+    ));
+
+    let mut config = registry_config();
+    let mut upstream = upstream_with_access("https://npm.corp.example/", "$authenticated");
+    upstream.rules = PackageRules::new(
+        vec![PackageRule {
+            pattern: PackagePattern::parse("@corp/secret").expect("test pattern parses"),
+            access: Some(AccessList::parse("alice")),
+            publish: None,
+            unpublish: None,
+        }],
+        Some(AccessList::parse("$authenticated")),
+    );
+    config.upstreams.insert("corp".to_string(), upstream);
+    let context = RouteContext::from_config(&config);
+
+    // Alice satisfies the per-package refinement: the hit replays.
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("alice")).is_some(),
+    );
+    // Bob passes the registry-level alias gate but the refinement denies
+    // him: replay must be exactly as strict as a fresh resolve, so no hit.
+    assert!(
+        cached_resolution(&cache, Duration::from_mins(1), &key, &context, &user("bob")).is_none(),
     );
 }
 

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -232,6 +232,14 @@ pub struct RouteContext {
     /// pnpr-hosted route is public (its effective access admits everyone)
     /// or private, and to gate hosted cache hits for the caller.
     hosted_rules: IndexMap<String, PackageRules>,
+    /// Each upstream registry's `packages:` rules. Alias selection is
+    /// per-package-aware: a caller the upstream's effective access denies
+    /// for a name is never handed the server-owned credential for it, so a
+    /// fresh resolve fails closed exactly where the serving endpoint would
+    /// deny the read. (Cache *replay* granularity stays registry-scoped:
+    /// the alias descriptor covers every name the alias resolves, shared
+    /// among callers the registry-level `access:` admits.)
+    upstream_rules: IndexMap<String, PackageRules>,
 }
 
 #[derive(Debug, Clone)]
@@ -307,6 +315,11 @@ impl RouteContext {
             .iter()
             .map(|(name, hosted)| (name.clone(), hosted.rules.clone()))
             .collect();
+        let upstream_rules = config
+            .upstreams
+            .iter()
+            .map(|(name, upstream)| (name.clone(), upstream.rules.clone()))
+            .collect();
         Self {
             hosted_origin,
             public_routes,
@@ -314,7 +327,19 @@ impl RouteContext {
             upstream_origins,
             registries: config.registries.clone(),
             hosted_rules,
+            upstream_rules,
         }
+    }
+
+    /// Whether the upstream registry's effective per-package access admits
+    /// `identity` for `package`. A non-package fetch and an upstream with no
+    /// rules entry (a programmatically folded one) gate at the registry
+    /// level only, which alias selection already checked.
+    fn upstream_admits(&self, registry: &str, identity: &Identity, package: Option<&str>) -> bool {
+        let (Some(package), Some(rules)) = (package, self.upstream_rules.get(registry)) else {
+            return true;
+        };
+        rules.for_package(package).access.allows(identity)
     }
 
     /// Classify a single fetch to `url` for `package` (`None` for a
@@ -358,10 +383,16 @@ impl RouteContext {
                     .iter()
                     .find(|alias| alias.name == registry && alias.access.allows(identity))
                 {
-                    return RouteClass::Proxied {
-                        alias: alias.name.clone(),
-                        credential_digest: alias.credential_digest.clone(),
-                    };
+                    // Per-package refinement: a name the upstream's rules
+                    // deny this caller gets no credential — the anonymous
+                    // fetch fails closed at the endpoint, matching serving.
+                    if self.upstream_admits(&alias.name, identity, package) {
+                        return RouteClass::Proxied {
+                            alias: alias.name.clone(),
+                            credential_digest: alias.credential_digest.clone(),
+                        };
+                    }
+                    return RouteClass::Public;
                 }
                 if self.hosted_rules.contains_key(registry) {
                     return self.classify_hosted(identity, registry, package);
@@ -385,7 +416,11 @@ impl RouteContext {
                         .aliases
                         .iter()
                         .find(|alias| alias.name == registry && alias.access.allows(identity))
-                    {
+                        .filter(|alias| {
+                            // Per-package refinement — see the `/~<name>/`
+                            // branch above.
+                            self.upstream_admits(&alias.name, identity, Some(package))
+                        }) {
                         Some(alias) => RouteClass::Proxied {
                             alias: alias.name.clone(),
                             credential_digest: alias.credential_digest.clone(),
@@ -402,7 +437,7 @@ impl RouteContext {
             };
         }
 
-        if let Some(alias) = self.select_alias(identity, &fetch)
+        if let Some(alias) = self.select_alias(identity, &fetch, package)
             && scheme_of(url) == Some(alias.scheme.as_str())
         {
             // Scheme must match the upstream's: nerf-darting strips it, so an
@@ -496,10 +531,17 @@ impl RouteContext {
         }
     }
 
-    fn select_alias(&self, identity: &Identity, fetch: &str) -> Option<&ResolvedAlias> {
-        self.aliases
-            .iter()
-            .find(|alias| fetch.starts_with(&alias.origin) && alias.access.allows(identity))
+    fn select_alias(
+        &self,
+        identity: &Identity,
+        fetch: &str,
+        package: Option<&str>,
+    ) -> Option<&ResolvedAlias> {
+        self.aliases.iter().find(|alias| {
+            fetch.starts_with(&alias.origin)
+                && alias.access.allows(identity)
+                && self.upstream_admits(&alias.name, identity, package)
+        })
     }
 
     pub(crate) fn allows_descriptor(
@@ -518,13 +560,20 @@ impl RouteContext {
                 // authorization-only check could replay a lockfile routed
                 // through a different `/~<name>/` endpoint than this caller
                 // resolves through. A since-removed alias (`find` → `None`) or
-                // a rotated credential also fails closed here.
+                // a rotated credential also fails closed here. Replay
+                // granularity is registry-scoped by design — the descriptor
+                // names no package, so the gate is the registry-level alias
+                // selection (`package: None`), shared among the callers the
+                // upstream's `access:` admits; per-package `access`
+                // refinements bound fresh resolves and every serving read.
                 self.aliases.iter().find(|candidate| candidate.name == alias.as_str()).is_some_and(
                     |candidate| {
-                        self.select_alias(identity, &candidate.origin).is_some_and(|selected| {
-                            selected.name == alias.as_str()
-                                && selected.credential_digest == *credential_digest
-                        })
+                        self.select_alias(identity, &candidate.origin, None).is_some_and(
+                            |selected| {
+                                selected.name == alias.as_str()
+                                    && selected.credential_digest == *credential_digest
+                            },
+                        )
                     },
                 )
             }

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -66,7 +66,12 @@ pub(crate) enum PrivateAccessDescriptor {
     /// Proxied route via a pnpr-managed upstream alias. [`credential_digest`]
     /// hashes the upstream's `Authorization`, so rotating the credential moves
     /// future hits to a new namespace — no manual epoch counter to bump.
-    Alias { alias: String, credential_digest: String },
+    /// `package` is set only when the upstream's rules **explicitly refine**
+    /// this name's `access`: the descriptor then re-checks that per-package
+    /// gate on cache replay, so a caller the refinement denies cannot obtain
+    /// through the cache what a fresh resolve refuses them. Unrefined names
+    /// share the plain registry-scoped descriptor (`package: None`).
+    Alias { alias: String, credential_digest: String, package: Option<String> },
     /// pnpr-hosted route, gated by re-running the named package access
     /// policy for the caller.
     Hosted { policy_id: String },
@@ -79,8 +84,11 @@ impl PrivateAccessDescriptor {
     /// policy of the same text).
     fn key_input(&self) -> String {
         match self {
-            PrivateAccessDescriptor::Alias { alias, credential_digest } => {
+            PrivateAccessDescriptor::Alias { alias, credential_digest, package: None } => {
                 format!("alias\0{alias}\0{credential_digest}")
+            }
+            PrivateAccessDescriptor::Alias { alias, credential_digest, package: Some(package) } => {
+                format!("alias\0{alias}\0{credential_digest}\0{package}")
             }
             PrivateAccessDescriptor::Hosted { policy_id } => format!("hosted\0{policy_id}"),
         }
@@ -111,7 +119,7 @@ pub(crate) fn upstream_cache_digest(
     credential_digest: String,
     secret: &[u8],
 ) -> String {
-    PrivateAccessDescriptor::Alias { alias: upstream.to_string(), credential_digest }
+    PrivateAccessDescriptor::Alias { alias: upstream.to_string(), credential_digest, package: None }
         .digest_id(secret)
 }
 
@@ -342,6 +350,16 @@ impl RouteContext {
         rules.for_package(package).access.allows(identity)
     }
 
+    /// The descriptor package qualifier for a proxied fetch: `Some(package)`
+    /// only when the upstream's rules explicitly refine this name's access,
+    /// so the cache descriptor re-checks that refinement on replay. Names
+    /// the registry-level gate alone covers stay registry-scoped, keeping
+    /// the common footprint one descriptor per alias.
+    fn alias_package_qualifier(&self, alias: &str, package: Option<&str>) -> Option<String> {
+        let (package, rules) = (package?, self.upstream_rules.get(alias)?);
+        rules.for_package(package).access_is_explicit.then(|| package.to_string())
+    }
+
     /// Classify a single fetch to `url` for `package` (`None` for a
     /// non-package fetch), for `identity`. Precedence follows the RFC:
     /// public wins and suppresses auth; then pnpr-hosted; then an
@@ -550,7 +568,7 @@ impl RouteContext {
         descriptor: &PrivateAccessDescriptor,
     ) -> bool {
         match descriptor {
-            PrivateAccessDescriptor::Alias { alias, credential_digest } => {
+            PrivateAccessDescriptor::Alias { alias, credential_digest, package } => {
                 // Reuse the cached resolution only if `identity` would *select*
                 // this exact alias for its origin — the first authorized alias
                 // [`Self::select_alias`] returns there — and its credential
@@ -560,20 +578,20 @@ impl RouteContext {
                 // authorization-only check could replay a lockfile routed
                 // through a different `/~<name>/` endpoint than this caller
                 // resolves through. A since-removed alias (`find` → `None`) or
-                // a rotated credential also fails closed here. Replay
-                // granularity is registry-scoped by design — the descriptor
-                // names no package, so the gate is the registry-level alias
-                // selection (`package: None`), shared among the callers the
-                // upstream's `access:` admits; per-package `access`
-                // refinements bound fresh resolves and every serving read.
+                // a rotated credential also fails closed here. A descriptor
+                // carrying a package qualifier (recorded when the upstream's
+                // rules explicitly refine that name) re-checks the per-package
+                // gate through `select_alias`, so cache replay is exactly as
+                // strict as a fresh resolve; unqualified descriptors gate at
+                // the registry level, shared among the callers the upstream's
+                // `access:` admits.
                 self.aliases.iter().find(|candidate| candidate.name == alias.as_str()).is_some_and(
                     |candidate| {
-                        self.select_alias(identity, &candidate.origin, None).is_some_and(
-                            |selected| {
+                        self.select_alias(identity, &candidate.origin, package.as_deref())
+                            .is_some_and(|selected| {
                                 selected.name == alias.as_str()
                                     && selected.credential_digest == *credential_digest
-                            },
-                        )
+                            })
                     },
                 )
             }
@@ -740,7 +758,10 @@ impl UpstreamRouteHook for RouteHook {
                     .iter()
                     .find(|candidate| candidate.name == alias)
                     .map(|candidate| candidate.authorization.clone());
-                self.record(PrivateAccessDescriptor::Alias { alias, credential_digest });
+                // Package-qualified only when the upstream's rules explicitly
+                // refine this name, so replay re-checks the refinement.
+                let package = self.context.alias_package_qualifier(&alias, package);
+                self.record(PrivateAccessDescriptor::Alias { alias, credential_digest, package });
                 authorization
             }
         }
@@ -756,8 +777,11 @@ impl UpstreamRouteHook for RouteHook {
                     .digest_id(&self.secret),
             },
             RouteClass::Proxied { alias, credential_digest } => MetadataCacheScope::Private {
-                descriptor_id: PrivateAccessDescriptor::Alias { alias, credential_digest }
-                    .digest_id(&self.secret),
+                descriptor_id: {
+                    let package = self.context.alias_package_qualifier(&alias, package);
+                    PrivateAccessDescriptor::Alias { alias, credential_digest, package }
+                        .digest_id(&self.secret)
+                },
             },
         }
     }

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -27,6 +27,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use indexmap::IndexMap;
 use pacquet_network::{MetadataCacheScope, UpstreamRouteHook, nerf_dart};
 use reqwest::header::{AUTHORIZATION, HeaderMap};
 use sha2::{Digest, Sha256};
@@ -34,7 +35,8 @@ use wax::{Glob, Program};
 
 use crate::{
     config::{Config, PublicRoute, UpstreamConfig},
-    policy::{AccessList, Identity, PackagePolicies},
+    policy::{AccessList, Identity, PackageRules},
+    registry::{ConcreteKind, Registries, Resolved},
 };
 
 /// The classification of a single fetch route.
@@ -221,9 +223,15 @@ pub struct RouteContext {
     /// plain mirror needs no credential, so it has no [`ResolvedAlias`]; it
     /// is still a configured registry pnpr may fetch from anonymously.
     upstream_origins: Vec<String>,
-    /// Package access policy, used to decide whether a pnpr-hosted route
-    /// is public (admits everyone) or private, and to gate hosted hits.
-    policies: PackagePolicies,
+    /// The registry routing graph, used to resolve a path-less fetch to the
+    /// concrete registry that serves it — the same dispatch the serving
+    /// endpoints use, so classification and serving can't disagree about a
+    /// package's origin.
+    registries: Registries,
+    /// Each hosted registry's `packages:` rules, used to decide whether a
+    /// pnpr-hosted route is public (its effective access admits everyone)
+    /// or private, and to gate hosted cache hits for the caller.
+    hosted_rules: IndexMap<String, PackageRules>,
 }
 
 #[derive(Debug, Clone)]
@@ -294,12 +302,18 @@ impl RouteContext {
             .collect();
         let upstream_origins =
             config.upstreams.values().filter_map(|upstream| nerf_prefix(&upstream.url)).collect();
+        let hosted_rules = config
+            .hosted
+            .iter()
+            .map(|(name, hosted)| (name.clone(), hosted.rules.clone()))
+            .collect();
         Self {
             hosted_origin,
             public_routes,
             aliases,
             upstream_origins,
-            policies: config.policies.clone(),
+            registries: config.registries.clone(),
+            hosted_rules,
         }
     }
 
@@ -328,29 +342,64 @@ impl RouteContext {
             && fetch.starts_with(hosted)
         {
             // A fetch to pnpr's own `/~<name>/` endpoint addresses that
-            // upstream, not a hosted package (a package name can never begin
-            // with `~`). Authorized callers resolve through the upstream;
-            // everyone else — and an unknown upstream — gets an anonymous
-            // fetch the endpoint itself rejects, rather than falling through
-            // to the hosted-package policy.
+            // registry directly (a package name can never begin with `~`):
+            // an access-bearing upstream resolves through its alias for
+            // authorized callers, a hosted registry through its own rules.
+            // Everyone else — and an unknown name — gets an anonymous fetch
+            // the endpoint itself rejects, rather than falling through to
+            // another registry's policy.
             if let Some(rest) = fetch.strip_prefix(hosted)
-                && let Some(upstream) =
+                && let Some(registry) =
                     rest.strip_prefix('~').and_then(|rest| rest.split('/').next())
-                && !upstream.is_empty()
+                && !registry.is_empty()
             {
-                return match self
+                if let Some(alias) = self
                     .aliases
                     .iter()
-                    .find(|alias| alias.name == upstream && alias.access.allows(identity))
+                    .find(|alias| alias.name == registry && alias.access.allows(identity))
                 {
-                    Some(alias) => RouteClass::Proxied {
+                    return RouteClass::Proxied {
                         alias: alias.name.clone(),
                         credential_digest: alias.credential_digest.clone(),
-                    },
-                    None => RouteClass::Public,
-                };
+                    };
+                }
+                if self.hosted_rules.contains_key(registry) {
+                    return self.classify_hosted(identity, registry, package);
+                }
+                return RouteClass::Public;
             }
-            return self.classify_hosted(identity, package);
+            // A path-less fetch resolves through the graph's default
+            // registry — the same dispatch the serving endpoints use — to
+            // the one concrete registry that serves this package.
+            let Some(package) = package else {
+                // A non-package fetch against pnpr itself carries no private
+                // package data to key.
+                return RouteClass::Public;
+            };
+            return match self.registries.resolve_default(package) {
+                Resolved::Concrete { registry, kind: ConcreteKind::Hosted } => {
+                    self.classify_hosted(identity, registry, Some(package))
+                }
+                Resolved::Concrete { registry, kind: ConcreteKind::Upstream } => {
+                    match self
+                        .aliases
+                        .iter()
+                        .find(|alias| alias.name == registry && alias.access.allows(identity))
+                    {
+                        Some(alias) => RouteClass::Proxied {
+                            alias: alias.name.clone(),
+                            credential_digest: alias.credential_digest.clone(),
+                        },
+                        // A public upstream source (no alias) is an anonymous
+                        // public fetch; an unauthorized caller falls through
+                        // to one the endpoint fails closed on.
+                        None => RouteClass::Public,
+                    }
+                }
+                // Unclaimed or no default registry: the endpoint answers
+                // not-found, so there is no private content to key.
+                Resolved::Unclaimed | Resolved::UnknownRegistry => RouteClass::Public,
+            };
         }
 
         if let Some(alias) = self.select_alias(identity, &fetch)
@@ -407,21 +456,32 @@ impl RouteContext {
         self.upstream_origins.iter().any(|origin| fetch.starts_with(origin))
     }
 
-    /// A pnpr-hosted route is public when its package access policy
-    /// admits an anonymous caller; otherwise it is private and gated by
-    /// re-running that policy for the caller.
-    fn classify_hosted(&self, identity: &Identity, package: Option<&str>) -> RouteClass {
+    /// A pnpr-hosted route is public when the hosted registry's effective
+    /// access for the package admits an anonymous caller; otherwise it is
+    /// private and gated by re-running that registry's rules for the caller.
+    /// The descriptor is registry-qualified — the same `name@version` on two
+    /// hosted registries is two different packages, so their cache entries
+    /// must never share a key.
+    fn classify_hosted(
+        &self,
+        identity: &Identity,
+        registry: &str,
+        package: Option<&str>,
+    ) -> RouteClass {
         let Some(package) = package else {
             // A non-package fetch against pnpr itself carries no private
             // package data to key.
             return RouteClass::Public;
         };
-        let access = self.policies.for_package(package).access;
+        let Some(rules) = self.hosted_rules.get(registry) else {
+            return RouteClass::Public;
+        };
+        let access = rules.for_package(package).access;
         if access.allows(&Identity::Anonymous) {
             return RouteClass::Public;
         }
         if access.allows(identity) {
-            RouteClass::Hosted { policy_id: package.to_string() }
+            RouteClass::Hosted { policy_id: hosted_policy_id(registry, package) }
         } else {
             // The caller can't read this hosted package: classify it as an
             // anonymous public fetch with no managed credential, which the
@@ -464,7 +524,16 @@ impl RouteContext {
                 )
             }
             PrivateAccessDescriptor::Hosted { policy_id } => {
-                self.policies.for_package(policy_id).access.allows(identity)
+                // The id is registry-qualified (see `hosted_policy_id`); a
+                // descriptor that doesn't parse — including one written by a
+                // pre-registry-scoped build — fails closed and re-resolves.
+                match policy_id.split_once('\0') {
+                    Some((registry, package)) => self
+                        .hosted_rules
+                        .get(registry)
+                        .is_some_and(|rules| rules.for_package(package).access.allows(identity)),
+                    None => false,
+                }
             }
         }
     }
@@ -479,6 +548,13 @@ impl RouteContext {
             .find(|candidate| candidate.name == upstream && candidate.access.allows(identity))
             .map(|candidate| candidate.registry.clone())
     }
+}
+
+/// The registry-qualified id of one hosted package's access decision, stored
+/// in [`PrivateAccessDescriptor::Hosted`]. `\0` separates the components so a
+/// registry name (URL-safe, never NUL) can't alias into a package name.
+fn hosted_policy_id(registry: &str, package: &str) -> String {
+    format!("{registry}\0{package}")
 }
 
 /// Nerf-darted origin of the official npm registry, the built-in public route.

--- a/pnpr/crates/pnpr/src/route.rs
+++ b/pnpr/crates/pnpr/src/route.rs
@@ -459,9 +459,14 @@ impl RouteContext {
     /// A pnpr-hosted route is public when the hosted registry's effective
     /// access for the package admits an anonymous caller; otherwise it is
     /// private and gated by re-running that registry's rules for the caller.
-    /// The descriptor is registry-qualified — the same `name@version` on two
-    /// hosted registries is two different packages, so their cache entries
-    /// must never share a key.
+    /// This is the same effective-access lookup the serving gate
+    /// (`hosted_gate`) admits with, so classification and serving cannot
+    /// disagree about *whether* a caller may read a name — the serving
+    /// tiers only vary the denial's shape (mask vs. 401/403), and every
+    /// denial classifies as an anonymous public fetch the endpoint fails
+    /// closed on. The descriptor is registry-qualified — the same
+    /// `name@version` on two hosted registries is two different packages,
+    /// so their cache entries must never share a key.
     fn classify_hosted(
         &self,
         identity: &Identity,

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -262,6 +262,45 @@ fn upstream_with_access(registry: &str, access: &str) -> UpstreamConfig {
 }
 
 #[test]
+fn upstream_per_package_rules_gate_alias_selection() {
+    use crate::policy::{PackageRule, PackageRules};
+    use crate::registry::PackagePattern;
+
+    let mut config = base_config();
+    let mut upstream = upstream_with_access("https://npm.corp.example/", "$authenticated");
+    // The registry admits every authenticated caller, but `@corp/secret`
+    // is refined down to alice.
+    upstream.rules = PackageRules::new(
+        vec![PackageRule {
+            pattern: PackagePattern::parse("@corp/secret").expect("test pattern parses"),
+            access: Some(AccessList::parse("alice")),
+            publish: None,
+            unpublish: None,
+        }],
+        Some(AccessList::parse("$authenticated")),
+    );
+    config.upstreams.insert("corp".to_string(), upstream);
+    let context = RouteContext::from_config(&config);
+
+    let url = "https://npm.corp.example/@corp%2fsecret";
+    // Alice is admitted by the per-package rule: proxied with the credential.
+    assert!(matches!(
+        context.classify(&user("alice"), url, Some("@corp/secret")),
+        RouteClass::Proxied { .. },
+    ));
+    // Bob holds registry-level access but the per-package rule denies him:
+    // no credential is handed out, matching the serving endpoint's denial —
+    // his anonymous fetch fails closed instead of warming a private cache.
+    assert_eq!(context.classify(&user("bob"), url, Some("@corp/secret")), RouteClass::Public);
+    // Other names on the registry stay proxied for bob.
+    assert!(matches!(
+        context
+            .classify(&user("bob"), "https://npm.corp.example/@corp%2ftool", Some("@corp/tool"),),
+        RouteClass::Proxied { .. },
+    ));
+}
+
+#[test]
 fn upstream_with_access_is_a_proxied_route_matched_by_origin() {
     let mut config = base_config();
     config.upstreams.insert(

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -495,6 +495,7 @@ fn overlapping_upstream_access_reuses_only_the_selected_alias() {
     via_primary.add(PrivateAccessDescriptor::Alias {
         alias: "primary".to_string(),
         credential_digest: corp_credential(),
+        package: None,
     });
     assert!(via_primary.allows(&context, &user("alice")));
 
@@ -504,6 +505,7 @@ fn overlapping_upstream_access_reuses_only_the_selected_alias() {
     via_secondary.add(PrivateAccessDescriptor::Alias {
         alias: "secondary".to_string(),
         credential_digest: corp_credential(),
+        package: None,
     });
     assert!(!via_secondary.allows(&context, &user("alice")));
 }
@@ -517,6 +519,7 @@ fn footprint_digest_is_stable_and_namespaced() {
     footprint.add(PrivateAccessDescriptor::Alias {
         alias: "corp".to_string(),
         credential_digest: corp_credential(),
+        package: None,
     });
     assert!(!footprint.is_public());
     let digest = footprint.digest(b"secret").expect("private footprint has a digest");
@@ -526,6 +529,7 @@ fn footprint_digest_is_stable_and_namespaced() {
     rotated.add(PrivateAccessDescriptor::Alias {
         alias: "corp".to_string(),
         credential_digest: rotated_credential(),
+        package: None,
     });
     assert_ne!(digest, rotated.digest(b"secret").unwrap());
 
@@ -537,6 +541,7 @@ fn footprint_digest_is_stable_and_namespaced() {
     one_order.add(PrivateAccessDescriptor::Alias {
         alias: "x".to_string(),
         credential_digest: corp_credential(),
+        package: None,
     });
     one_order.add(PrivateAccessDescriptor::Hosted { policy_id: "@p/*".to_string() });
     let mut other_order = Footprint::default();
@@ -544,6 +549,7 @@ fn footprint_digest_is_stable_and_namespaced() {
     other_order.add(PrivateAccessDescriptor::Alias {
         alias: "x".to_string(),
         credential_digest: corp_credential(),
+        package: None,
     });
     assert_eq!(one_order.digest(b"k"), other_order.digest(b"k"));
 }
@@ -608,7 +614,8 @@ fn metadata_scope_maps_route_classes() {
         descriptor_id,
         PrivateAccessDescriptor::Alias {
             alias: "corp".to_string(),
-            credential_digest: corp_credential()
+            credential_digest: corp_credential(),
+            package: None,
         }
         .digest_id(b"server-secret"),
     );
@@ -650,7 +657,8 @@ fn authorized_alias_users_share_metadata_scope() {
         descriptor_id,
         PrivateAccessDescriptor::Alias {
             alias: "corp".to_string(),
-            credential_digest: corp_credential()
+            credential_digest: corp_credential(),
+            package: None,
         }
         .digest_id(b"server-secret"),
     );
@@ -661,12 +669,22 @@ fn descriptor_digest_id_depends_on_secret() {
     let descriptor = PrivateAccessDescriptor::Alias {
         alias: "corp".to_string(),
         credential_digest: corp_credential(),
+        package: None,
     };
     assert_ne!(descriptor.digest_id(b"secret-a"), descriptor.digest_id(b"secret-b"));
     // Generation rotation moves the namespace.
     let rotated = PrivateAccessDescriptor::Alias {
         alias: "corp".to_string(),
         credential_digest: rotated_credential(),
+        package: None,
     };
     assert_ne!(descriptor.digest_id(b"secret-a"), rotated.digest_id(b"secret-a"));
+    // A package-qualified descriptor (an explicitly refined name) keys its
+    // own namespace, distinct from the registry-scoped one.
+    let qualified = PrivateAccessDescriptor::Alias {
+        alias: "corp".to_string(),
+        credential_digest: corp_credential(),
+        package: Some("@corp/secret".to_string()),
+    };
+    assert_ne!(descriptor.digest_id(b"secret-a"), qualified.digest_id(b"secret-a"));
 }

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -10,7 +10,7 @@ use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use super::{Footprint, PrivateAccessDescriptor, RouteClass, RouteContext, RouteHook};
 use crate::{
     config::{Config, PublicRoute, UpstreamConfig},
-    policy::{AccessList, Identity, PackagePolicies},
+    policy::{AccessList, Identity},
 };
 
 fn base_config() -> Config {
@@ -409,7 +409,9 @@ fn proxied_alias_accepts_configured_group_identity() {
 fn hosted_route_follows_package_access_policy() {
     let mut config = base_config();
     config.public_url = "https://pnpr.example/".to_string();
-    config.policies = PackagePolicies::registry_mock_defaults();
+    // `Config::proxy` carries the registry-mock rules on the `local` hosted
+    // registry: `@private/*` requires auth, the rest of the fixture
+    // namespace is open.
     let context = RouteContext::from_config(&config);
 
     // `@private/*` requires auth: private+gated for an authorized caller. An
@@ -422,7 +424,7 @@ fn hosted_route_follows_package_access_policy() {
             "https://pnpr.example/@private%2fpkg",
             Some("@private/pkg")
         ),
-        RouteClass::Hosted { policy_id: "@private/pkg".to_string() },
+        RouteClass::Hosted { policy_id: "local\0@private/pkg".to_string() },
     );
     assert_eq!(
         context.classify(&anon(), "https://pnpr.example/@private%2fpkg", Some("@private/pkg")),

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -4,7 +4,7 @@ use crate::{
     error::RegistryError,
     journal::JournaledPublish,
     package_name::PackageName,
-    policy::Identity,
+    policy::{Identity, PackageRules},
     publish::{
         PendingAttachment, extract_attachments, iso_from_unix_millis, merge_manifest, now_iso,
         stream_decode_verify_and_write,
@@ -37,7 +37,7 @@ use ssri::Integrity;
 use std::{
     collections::HashSet,
     net::{IpAddr, SocketAddr},
-    sync::Arc,
+    sync::{Arc, LazyLock},
     time::Duration,
 };
 use tower_http::{
@@ -1173,27 +1173,29 @@ async fn serve_registry_version_manifest(
         Ok(n) => n,
         Err(err) => return error_response(&err),
     };
-    let bytes = match resolve_registry_source(state, registry, name.as_str()) {
+    let resolved_source = resolve_registry_source(state, registry, name.as_str());
+    let bytes = match &resolved_source {
         RegistrySource::Upstream(source) => {
-            // Per-package ACL before serving — see `serve_registry_packument`.
-            if let Err(err) = authorize(state, identity, name.as_str(), Action::Access) {
+            // The upstream registry's per-package rules gate the read — see
+            // `serve_registry_packument`.
+            if let Err(err) =
+                authorize(state, identity, &resolved_source, name.as_str(), Action::Access)
+            {
                 return error_response(&err);
             }
-            match load_upstream_packument_for(state, identity, &source, &name).await {
+            match load_upstream_packument_for(state, identity, source, &name).await {
                 Ok(Some(bytes)) => bytes,
                 Ok(None) => return not_found(),
                 Err(response) => return *response,
             }
         }
         RegistrySource::Hosted(source) => {
-            // Mask first: a private org 404s an unauthorized caller before the
-            // per-package ACL could reveal existence — see `serve_registry_packument`.
-            let Some(org) = accessible_hosted_namespace(state, identity, &source) else {
-                return not_found();
+            // The hosted gate answers a denial itself — a not-found mask or
+            // an explicit-rule 401/403 — see `serve_registry_packument`.
+            let org = match hosted_read_namespace(state, identity, source, name.as_str()) {
+                Ok(org) => org,
+                Err(response) => return *response,
             };
-            if let Err(err) = authorize(state, identity, name.as_str(), Action::Access) {
-                return error_response(&err);
-            }
             match state.inner.storage.for_hosted(&org).read_hosted_packument(&name).await {
                 Ok(Some(bytes)) => bytes,
                 Ok(None) => return not_found(),
@@ -1481,25 +1483,27 @@ async fn load_packument_for_read(
             None => return Ok(None),
         },
     };
-    // The per-package access ACL applies to every registry-served read, upstream or
-    // hosted — otherwise a restricted package would leak (e.g. its dist-tags)
-    // through these path-less readers. It runs *after* the hosted-org visibility
-    // gate, though, so a private org still 404-masks an unauthorized caller
-    // rather than revealing existence via a 401/403 (see `serve_registry_packument`).
-    match resolve_registry_source(state, &target, name.as_str()) {
+    // The resolved registry's per-package rules apply to every served read,
+    // upstream or hosted — otherwise a restricted package would leak (e.g.
+    // its dist-tags) through these path-less readers. A hosted denial is a
+    // not-found mask rather than a 401/403 that reveals existence (see
+    // `serve_registry_packument`).
+    let resolved_source = resolve_registry_source(state, &target, name.as_str());
+    match &resolved_source {
         RegistrySource::Upstream(source) => {
-            if let Err(err) = authorize(state, identity, name.as_str(), Action::Access) {
+            if let Err(err) =
+                authorize(state, identity, &resolved_source, name.as_str(), Action::Access)
+            {
                 return Err(Box::new(error_response(&err)));
             }
-            load_upstream_packument_for(state, identity, &source, name).await
+            load_upstream_packument_for(state, identity, source, name).await
         }
         RegistrySource::Hosted(source) => {
-            let Some(org) = accessible_hosted_namespace(state, identity, &source) else {
-                return Ok(None);
+            let org = match hosted_gate(state, identity, source, name.as_str()) {
+                HostedGate::Allowed(org) => org,
+                HostedGate::MaskNotFound => return Ok(None),
+                HostedGate::Denied(err) => return Err(Box::new(error_response(&err))),
             };
-            if let Err(err) = authorize(state, identity, name.as_str(), Action::Access) {
-                return Err(Box::new(error_response(&err)));
-            }
             state
                 .inner
                 .storage
@@ -1772,37 +1776,34 @@ fn resolve_registry_source(state: &AppState, registry: &str, package: &str) -> R
 /// cache, whichever URL surface (path-less or `/~<name>/`) served them.
 fn resolves_to_private_source(state: &AppState, registry: &str, package: &str) -> bool {
     match resolve_registry_source(state, registry, package) {
-        RegistrySource::Hosted(source) => state
-            .inner
-            .config
-            .hosted
-            .get(&source)
-            .is_some_and(|hosted| !hosted.access.allows(&Identity::Anonymous)),
-        RegistrySource::Upstream(source) => state
-            .inner
-            .config
-            .upstreams
-            .get(&source)
-            .is_some_and(|upstream| upstream.access.is_some()),
+        RegistrySource::Hosted(source) => {
+            state.inner.config.hosted.get(&source).is_some_and(|hosted| {
+                !hosted.rules.for_package(package).access.allows(&Identity::Anonymous)
+            })
+        }
+        // A private upstream (registry-level `access:`) is caller-gated for
+        // every name; a public one can still gate individual names through a
+        // per-package `access` rule.
+        RegistrySource::Upstream(source) => {
+            state.inner.config.upstreams.get(&source).is_some_and(|upstream| {
+                upstream.access.is_some()
+                    || !upstream.rules.for_package(package).access.allows(&Identity::Anonymous)
+            })
+        }
         RegistrySource::Unclaimed | RegistrySource::NotFound => false,
     }
 }
 
 /// Apply the private-cache headers to a path-less response whenever it can
 /// vary by caller — the default-target resolution for `package` lands on a
-/// private source, or the per-package ACL denies anonymous access (so the
-/// same URL answers 200 or 403 depending on `Authorization`, even through a
+/// source whose effective per-package access denies anonymous callers (so the
+/// same URL answers differently depending on `Authorization`, even through a
 /// public registry). These are the same headers the `/~<name>/` surface applies
 /// unconditionally, so the two URL surfaces for the same content get the same
 /// defense against a shared HTTP cache replaying an authenticated response to
 /// an anonymous caller. A publicly-readable resolution stays cacheable: the
 /// path-less base is the hot install path.
 fn private_if_caller_gated(state: &AppState, package: &str, response: Response) -> Response {
-    let acl_gated =
-        !state.inner.config.policies.for_package(package).access.allows(&Identity::Anonymous);
-    if acl_gated {
-        return private_no_cache(response);
-    }
     match default_registry_target(state) {
         Some(target) if resolves_to_private_source(state, &target, package) => {
             private_no_cache(response)
@@ -1829,24 +1830,26 @@ async fn serve_registry_packument(
     // packument's `dist.tarball` URLs must stay canonical for that base so a
     // client's lockfile drops them — persisting the resolved source path would
     // bake the registry name in and break lockfile portability.
-    match resolve_registry_source(state, registry, name.as_str()) {
+    let resolved_source = resolve_registry_source(state, registry, name.as_str());
+    match &resolved_source {
         RegistrySource::Upstream(source) => {
-            // The per-package access ACL applies to every registry-served read, so
-            // an access-gated name can't be read through a public upstream.
-            // Checked before serving so the decision precedes any
-            // existence-revealing signal like an OSV 403.
-            if let Err(err) = authorize(state, identity, name.as_str(), Action::Access) {
+            // The upstream registry's per-package rules gate every served
+            // read, so an access-gated name can't be read even through a
+            // public upstream. Checked before serving so the decision
+            // precedes any existence-revealing signal like an OSV 403.
+            if let Err(err) =
+                authorize(state, identity, &resolved_source, name.as_str(), Action::Access)
+            {
                 return error_response(&err);
             }
-            serve_packument_via_upstream(state, identity, headers, &source, &name, tarball_base)
+            serve_packument_via_upstream(state, identity, headers, source, &name, tarball_base)
                 .await
         }
-        // A hosted registry masks first: a private org 404s an unauthorized caller
-        // (see `accessible_hosted_namespace`) *before* the per-package ACL could
-        // return a 401/403 that reveals the package exists — the ACL is applied
-        // inside `serve_hosted_packument` only after the visibility gate passes.
+        // A hosted denial answers per its gate tier (see `hosted_gate`): a
+        // registry-default denial is a not-found mask, an explicit
+        // `packages:` entry denies loudly so clients can prompt for auth.
         RegistrySource::Hosted(source) => {
-            serve_hosted_packument(state, identity, headers, &source, &name, tarball_base).await
+            serve_hosted_packument(state, identity, headers, source, &name, tarball_base).await
         }
         RegistrySource::Unclaimed | RegistrySource::NotFound => not_found(),
     }
@@ -1866,42 +1869,90 @@ async fn serve_registry_tarball(
         Ok(n) => n,
         Err(err) => return error_response(&err),
     };
-    match resolve_registry_source(state, registry, name.as_str()) {
+    let resolved_source = resolve_registry_source(state, registry, name.as_str());
+    match &resolved_source {
         RegistrySource::Upstream(source) => {
-            // Per-package ACL before serving — see `serve_registry_packument`.
-            if let Err(err) = authorize(state, identity, name.as_str(), Action::Access) {
+            // Per-package rules before serving — see `serve_registry_packument`.
+            if let Err(err) =
+                authorize(state, identity, &resolved_source, name.as_str(), Action::Access)
+            {
                 return error_response(&err);
             }
-            serve_tarball_via_upstream(state, identity, &source, name.as_str(), filename).await
+            serve_tarball_via_upstream(state, identity, source, name.as_str(), filename).await
         }
-        // Hosted masks first (private-org 404) then applies the ACL, inside
-        // `serve_hosted_tarball` — see `serve_registry_packument`.
+        // A hosted denial is a not-found mask, inside `serve_hosted_tarball`
+        // — see `serve_registry_packument`.
         RegistrySource::Hosted(source) => {
-            serve_hosted_tarball(state, identity, &source, &name, filename).await
+            serve_hosted_tarball(state, identity, source, &name, filename).await
         }
         RegistrySource::Unclaimed | RegistrySource::NotFound => not_found(),
     }
 }
 
-/// The storage namespace of the hosted registry `source` when `identity` may
-/// access it, else `None`. The registry's `access` list gates reads and writes
-/// alike — a caller who may not read a hosted registry may not publish, tag, or
-/// unpublish into it either. A denied caller is treated as not-found, so a
-/// private org's package existence is not revealed. The org policy composes
-/// (logical AND) with the per-package [`Config::policies`] applied by the
-/// serving and publish paths.
-fn accessible_hosted_namespace(
+/// How a hosted registry answers a read of `package` for `identity`:
+/// admitted with the storage namespace to read from, or denied one of two
+/// ways. The two denial shapes preserve the two authorization tiers the
+/// merged `packages:` map folds together: an **explicit** entry's `access`
+/// is declared, discoverable config — deny loudly (401/403, so a client can
+/// prompt for credentials, the registry-mock `needs-auth` contract) — while
+/// the registry-level **default** masks as not-found, so a blanket-private
+/// registry never reveals which names exist.
+enum HostedGate {
+    Allowed(String),
+    /// The registry default denies the caller: indistinguishable from an
+    /// absent package.
+    MaskNotFound,
+    /// An explicit `packages:` entry denies the caller: 401 for an
+    /// anonymous caller (authenticate and retry), 403 for an authenticated
+    /// one outside the allowed set.
+    Denied(RegistryError),
+}
+
+/// Evaluate the hosted read gate: the effective per-package `access` (most
+/// specific `packages:` entry, falling back to the registry-level default)
+/// gates reads and the write routing alike — a caller who may not read a
+/// hosted package may not publish, tag, or unpublish it either.
+fn hosted_gate(state: &AppState, identity: &Identity, source: &str, package: &str) -> HostedGate {
+    let Some(hosted) = state.inner.config.hosted.get(source) else {
+        return HostedGate::MaskNotFound;
+    };
+    let effective = hosted.rules.for_package(package);
+    if effective.access.allows(identity) {
+        return HostedGate::Allowed(hosted.org.clone());
+    }
+    // Loud denial only inside a registry the caller may see: the explicit
+    // entry gates this name, but the registry-level default admits the
+    // caller to the registry itself. When the default denies them too, the
+    // mask below wins — an explicit rule on a blanket-private registry must
+    // not become an existence probe.
+    if effective.access_is_explicit && hosted.rules.default_access().allows(identity) {
+        return HostedGate::Denied(match identity {
+            Identity::Anonymous => {
+                RegistryError::Unauthenticated { resource: format!("package {package:?}") }
+            }
+            Identity::User { username, .. } => RegistryError::Forbidden {
+                user: username.clone(),
+                action: "access",
+                resource: format!("package {package:?}"),
+            },
+        });
+    }
+    HostedGate::MaskNotFound
+}
+
+/// [`hosted_gate`] flattened to a `Result` for the readers: the org to read
+/// from, or the response to answer with.
+fn hosted_read_namespace(
     state: &AppState,
     identity: &Identity,
     source: &str,
-) -> Option<String> {
-    state
-        .inner
-        .config
-        .hosted
-        .get(source)
-        .filter(|org| org.access.allows(identity))
-        .map(|org| org.org.clone())
+    package: &str,
+) -> Result<String, Box<Response>> {
+    match hosted_gate(state, identity, source, package) {
+        HostedGate::Allowed(org) => Ok(org),
+        HostedGate::MaskNotFound => Err(Box::new(not_found())),
+        HostedGate::Denied(err) => Err(Box::new(error_response(&err))),
+    }
 }
 
 async fn serve_hosted_packument(
@@ -1912,12 +1963,10 @@ async fn serve_hosted_packument(
     name: &PackageName,
     tarball_base: &str,
 ) -> Response {
-    let Some(org) = accessible_hosted_namespace(state, identity, source) else {
-        return not_found();
+    let org = match hosted_read_namespace(state, identity, source, name.as_str()) {
+        Ok(org) => org,
+        Err(response) => return *response,
     };
-    if let Err(err) = authorize(state, identity, name.as_str(), Action::Access) {
-        return error_response(&err);
-    }
     // A hosted org has no upstream fallback: a package it does not host is a
     // definitive not-found. Reads come from the org's own storage namespace.
     match state.inner.storage.for_hosted(&org).read_hosted_packument(name).await {
@@ -1943,16 +1992,14 @@ async fn serve_hosted_tarball(
     name: &PackageName,
     filename: &str,
 ) -> Response {
-    let Some(org) = accessible_hosted_namespace(state, identity, source) else {
-        return not_found();
+    let org = match hosted_read_namespace(state, identity, source, name.as_str()) {
+        Ok(org) => org,
+        Err(response) => return *response,
     };
     let (filename, name_version) = match name.parse_tarball_name(filename) {
         Ok(parsed) => parsed,
         Err(err) => return error_response(&err),
     };
-    if let Err(err) = authorize(state, identity, name.as_str(), Action::Access) {
-        return error_response(&err);
-    }
     if let Err(err) = ensure_osv_allowed(state, name, &name_version) {
         return error_response(&err);
     }
@@ -2377,8 +2424,10 @@ fn hosted_storage(state: &AppState, org: Option<&str>) -> Storage {
 
 /// Where a publish of `package` writes, given an optional explicit `/~<name>/`.
 enum PublishTarget {
-    /// Write into this hosted storage namespace.
-    Org(String),
+    /// Write into the hosted registry `source`'s storage namespace `org`.
+    /// The source name is carried so the write's `publish`/`unpublish`
+    /// authorization can consult that registry's `packages:` rules.
+    Hosted { source: String, org: String },
     /// The resolved target is not a hosted org; reject with this reason.
     Reject(String),
     /// The resolved upstream registry denies this caller; answer with the
@@ -2418,9 +2467,10 @@ fn resolve_publish_target(
     };
     match resolve_registry_source(state, &target, package) {
         RegistrySource::Hosted(registry) => {
-            match accessible_hosted_namespace(state, identity, &registry) {
-                Some(org) => PublishTarget::Org(org),
-                None => PublishTarget::NotFound,
+            match hosted_gate(state, identity, &registry, package) {
+                HostedGate::Allowed(org) => PublishTarget::Hosted { source: registry, org },
+                HostedGate::MaskNotFound => PublishTarget::NotFound,
+                HostedGate::Denied(err) => PublishTarget::Denied(Box::new(error_response(&err))),
             }
         }
         // A write can never land on an upstream — but the upstream's `access:`
@@ -2461,9 +2511,15 @@ fn resolve_publish_target(
 /// any of its sources is.
 fn registry_visible_to_caller(state: &AppState, identity: &Identity, name: &str) -> bool {
     let concrete_visible = |name: &str| match state.inner.config.registries.get(name) {
-        Some(Registry::Hosted { .. }) => {
-            accessible_hosted_namespace(state, identity, name).is_some()
-        }
+        // The name being probed is unclaimed, so there is no per-package
+        // entry to consult: the registry-level default `access:` decides
+        // whether the caller may learn the registry exists at all.
+        Some(Registry::Hosted { .. }) => state
+            .inner
+            .config
+            .hosted
+            .get(name)
+            .is_some_and(|hosted| hosted.rules.default_access().allows(identity)),
         Some(Registry::Upstream { .. }) => true,
         Some(Registry::Router { .. }) | None => false,
     };
@@ -2509,22 +2565,14 @@ async fn publish_package(
         });
     }
 
-    // Route the write to its hosted namespace (or the flat store), failing
-    // closed when the target is an upstream, an unknown registry, or a hosted
-    // registry whose access list denies the caller.
-    let org = match resolve_publish_target(state, identity, registry, name.as_str()) {
-        PublishTarget::Org(org) => Some(org),
-        PublishTarget::Reject(reason) => {
-            return error_response(&RegistryError::BadRequest { reason });
-        }
-        PublishTarget::Denied(response) => return *response,
-        PublishTarget::NotFound => return not_found(),
-    };
-
-    let validated = match validate_publish_doc(state, identity, name, incoming).await {
-        Ok(validated) => validated,
-        Err(err) => return error_response(&err),
-    };
+    // Routing, masking, and the publish rule all run inside
+    // `validate_publish_doc`: the write resolves to a hosted registry (or
+    // fails closed), and that registry's `packages:` rules authorize it.
+    let (validated, target) =
+        match validate_publish_doc(state, identity, registry, name, incoming).await {
+            Ok(validated) => validated,
+            Err(response) => return *response,
+        };
 
     // Serialize the read-merge-write against other writers of this same
     // package on this instance, so a concurrent publish can't read the
@@ -2532,7 +2580,7 @@ async fn publish_package(
     // Held until this function returns, past the packument write below.
     let _packument_guard = state.inner.package_locks.lock(validated.name.as_str()).await;
 
-    let staged = match stage_publish(state, validated, &now_iso(), org.as_deref()).await {
+    let staged = match stage_publish(state, validated, &now_iso(), Some(&target.org)).await {
         Ok(staged) => staged,
         Err(err) => return error_response(&err),
     };
@@ -2601,46 +2649,27 @@ async fn serve_batch_publish(
                 reason: format!("duplicate package {:?} in `packages`", name.as_str()),
             });
         }
-        match validate_publish_doc(&state, &identity, name, doc).await {
+        // The batch endpoint is path-less, so each package routes via the
+        // default target; validation resolves that route and checks the
+        // resolved hosted registry's publish rule per document.
+        match validate_publish_doc(&state, &identity, None, name, doc).await {
             Ok(doc) => validated.push(doc),
-            Err(err) => return error_response(&err),
+            Err(response) => return *response,
         }
     }
 
     // Hold every affected package's lock across the whole
     // stage-and-commit, so concurrent writers of any package in the
     // batch serialize with us just like with a single publish.
-    let names: Vec<&str> = validated.iter().map(|doc| doc.name.as_str()).collect();
+    let names: Vec<&str> = validated.iter().map(|(doc, _)| doc.name.as_str()).collect();
     let _guards = state.inner.package_locks.lock_many(&names).await;
 
     let now = now_iso();
     let mut staged: Vec<StagedPublish> = Vec::with_capacity(validated.len());
-    for doc in validated {
-        // The batch endpoint is path-less, so each package routes via the
-        // default target (a router default routes by name; a concrete/absent
-        // default keeps the legacy flat store).
-        let org = match resolve_publish_target(&state, &identity, None, doc.name.as_str()) {
-            PublishTarget::Org(org) => Some(org),
-            PublishTarget::Reject(reason) => {
-                for stage in staged {
-                    cleanup_tmp_slots(stage.slots).await;
-                }
-                return error_response(&RegistryError::BadRequest { reason });
-            }
-            PublishTarget::Denied(response) => {
-                for stage in staged {
-                    cleanup_tmp_slots(stage.slots).await;
-                }
-                return *response;
-            }
-            PublishTarget::NotFound => {
-                for stage in staged {
-                    cleanup_tmp_slots(stage.slots).await;
-                }
-                return not_found();
-            }
-        };
-        match stage_publish(&state, doc, &now, org.as_deref()).await {
+    for (doc, target) in validated {
+        // Each document's write target was resolved during validation, so a
+        // routing failure surfaced before any tarball was staged.
+        match stage_publish(&state, doc, &now, Some(&target.org)).await {
             Ok(stage) => staged.push(stage),
             Err(err) => {
                 for stage in staged {
@@ -2685,11 +2714,37 @@ struct PreparedAttachment {
 async fn validate_publish_doc(
     state: &AppState,
     identity: &Identity,
+    registry: Option<&str>,
+    name: PackageName,
+    incoming: Value,
+) -> Result<(ValidatedPublish, WriteTarget), Box<Response>> {
+    // Route the write to its hosted registry first (masking a denied caller
+    // as not-found, rejecting an upstream target), then check that
+    // registry's `publish` rule for this package — so routing failures
+    // surface before any 401/403 that would reveal a masked name exists.
+    let target = resolve_write_target(state, identity, registry, &name)?;
+    authorize(
+        state,
+        identity,
+        &RegistrySource::Hosted(target.source.clone()),
+        name.as_str(),
+        Action::Publish,
+    )
+    .map_err(|err| Box::new(error_response(&err)))?;
+
+    let (validated, target) = validate_publish_attachments(name, incoming, target)
+        .map_err(|err| Box::new(error_response(&err)))?;
+    Ok((validated, target))
+}
+
+/// The attachment half of [`validate_publish_doc`], split out so the
+/// routing/authorization half above can use `?` on `Box<Response>` while
+/// this half keeps plain [`RegistryError`]s.
+fn validate_publish_attachments(
     name: PackageName,
     mut incoming: Value,
-) -> Result<ValidatedPublish, RegistryError> {
-    authorize(state, identity, name.as_str(), Action::Publish)?;
-
+    target: WriteTarget,
+) -> Result<(ValidatedPublish, WriteTarget), RegistryError> {
     let attachments = extract_attachments(&mut incoming)?;
 
     // Resolve each attachment's canonical disk filename + matching
@@ -2711,7 +2766,7 @@ async fn validate_publish_doc(
             .unwrap_or(Value::Null);
         prepared.push(PreparedAttachment { attachment, canonical, version, dist });
     }
-    Ok(ValidatedPublish { name, incoming, prepared })
+    Ok((ValidatedPublish { name, incoming, prepared }, target))
 }
 
 /// A publish whose packument is merged and whose tarballs are fully
@@ -2987,17 +3042,21 @@ async fn serve_search(
         if objects.len() >= size {
             break;
         }
-        let Some(org) = accessible_hosted_namespace(state, identity, &source) else {
+        let Some(org) = state.inner.config.hosted.get(&source).map(|hosted| hosted.org.clone())
+        else {
             continue;
         };
         let storage = hosted_storage(state, Some(&org));
         // The caller was resolved once by the middleware; both filters run
-        // synchronously against it inside the scan.
+        // synchronously against it inside the scan. Visibility is
+        // per-package: each hit is gated by this hosted registry's effective
+        // access for that name, so a per-package rule can open (or close) a
+        // name regardless of the registry-level default.
         let keep = |name: &str| {
             matches!(
                 resolve_registry_source(state, &registry, name),
                 RegistrySource::Hosted(resolved) if resolved == source,
-            ) && authorize(state, identity, name, Action::Access).is_ok()
+            ) && matches!(hosted_gate(state, identity, &source, name), HostedGate::Allowed(_))
         };
         match crate::search::run_local_search(&storage, &text, size - objects.len(), keep).await {
             Ok(mut entries) => objects.append(&mut entries),
@@ -3049,15 +3108,17 @@ async fn update_packument(
         Ok(n) => n,
         Err(err) => return error_response(&err),
     };
+    let target = match resolve_write_target(state, identity, registry, &name) {
+        Ok(target) => target,
+        Err(response) => return *response,
+    };
+    let source = RegistrySource::Hosted(target.source.clone());
     for action in [Action::Publish, Action::Unpublish] {
-        if let Err(err) = authorize(state, identity, name.as_str(), action) {
+        if let Err(err) = authorize(state, identity, &source, name.as_str(), action) {
             return error_response(&err);
         }
     }
-    let org = match resolve_write_org(state, identity, registry, &name) {
-        Ok(org) => org,
-        Err(response) => return *response,
-    };
+    let org = target.org;
     let storage = hosted_storage(state, Some(&org));
     let mut packument: Value = match serde_json::from_slice(body) {
         Ok(v) => v,
@@ -3269,13 +3330,20 @@ async fn delete_package(
         Ok(n) => n,
         Err(err) => return error_response(&err),
     };
-    if let Err(err) = authorize(state, identity, name.as_str(), Action::Unpublish) {
-        return error_response(&err);
-    }
-    let org = match resolve_write_org(state, identity, registry, &name) {
-        Ok(org) => org,
+    let target = match resolve_write_target(state, identity, registry, &name) {
+        Ok(target) => target,
         Err(response) => return *response,
     };
+    if let Err(err) = authorize(
+        state,
+        identity,
+        &RegistrySource::Hosted(target.source.clone()),
+        name.as_str(),
+        Action::Unpublish,
+    ) {
+        return error_response(&err);
+    }
+    let org = target.org;
     // Serialize against same-package publishers so a delete can't race a
     // stage-and-commit and remove the package mid-write.
     let _packument_guard = state.inner.package_locks.lock(name.as_str()).await;
@@ -3311,13 +3379,20 @@ async fn delete_tarball(
         Ok(c) => c,
         Err(err) => return error_response(&err),
     };
-    if let Err(err) = authorize(state, identity, name.as_str(), Action::Unpublish) {
-        return error_response(&err);
-    }
-    let org = match resolve_write_org(state, identity, registry, &name) {
-        Ok(org) => org,
+    let target = match resolve_write_target(state, identity, registry, &name) {
+        Ok(target) => target,
         Err(response) => return *response,
     };
+    if let Err(err) = authorize(
+        state,
+        identity,
+        &RegistrySource::Hosted(target.source.clone()),
+        name.as_str(),
+        Action::Unpublish,
+    ) {
+        return error_response(&err);
+    }
+    let org = target.org;
     // Serialize against same-package publishers so a delete can't race a
     // stage-and-commit and remove a tarball mid-write.
     let _packument_guard = state.inner.package_locks.lock(name.as_str()).await;
@@ -3420,15 +3495,23 @@ where
         Ok(n) => n,
         Err(err) => return error_response(&err),
     };
-    if let Err(err) = authorize(state, identity, name.as_str(), Action::Publish) {
-        return error_response(&err);
-    }
     // A dist-tag change is a write, so it routes to a hosted namespace like
-    // a publish — a name routed to an upstream is rejected.
-    let org = match resolve_write_org(state, identity, registry, &name) {
-        Ok(org) => org,
+    // a publish — a name routed to an upstream is rejected — and the
+    // resolved registry's `publish` rule gates it.
+    let target = match resolve_write_target(state, identity, registry, &name) {
+        Ok(target) => target,
         Err(response) => return *response,
     };
+    if let Err(err) = authorize(
+        state,
+        identity,
+        &RegistrySource::Hosted(target.source.clone()),
+        name.as_str(),
+        Action::Publish,
+    ) {
+        return error_response(&err);
+    }
+    let org = target.org;
     let storage = hosted_storage(state, Some(&org));
 
     // Serialize the read-modify-write against other same-package writers
@@ -3502,20 +3585,27 @@ where
 /// path-less, the default-target registry) to a hosted org, rejecting a name
 /// routed to an upstream and 404ing when the path-less base has no default
 /// target or the registry's access list denies the caller.
-fn resolve_write_org(
+fn resolve_write_target(
     state: &AppState,
     identity: &Identity,
     registry: Option<&str>,
     name: &PackageName,
-) -> Result<String, Box<Response>> {
+) -> Result<WriteTarget, Box<Response>> {
     match resolve_publish_target(state, identity, registry, name.as_str()) {
-        PublishTarget::Org(org) => Ok(org),
+        PublishTarget::Hosted { source, org } => Ok(WriteTarget { source, org }),
         PublishTarget::Reject(reason) => {
             Err(Box::new(error_response(&RegistryError::BadRequest { reason })))
         }
         PublishTarget::Denied(response) => Err(response),
         PublishTarget::NotFound => Err(Box::new(not_found())),
     }
+}
+
+/// The hosted registry a write resolved to: its name (for the
+/// `publish`/`unpublish` rule lookup) and its storage namespace.
+struct WriteTarget {
+    source: String,
+    org: String,
 }
 
 /// What the caller is trying to do with a package. Drives which
@@ -3653,18 +3743,41 @@ fn check_token_restrictions(
     Ok(())
 }
 
-/// Check an already-resolved `identity` against the per-package rule.
-/// Returns `Ok(())` when the call is allowed; otherwise the appropriate
-/// `Unauthenticated` / `Forbidden` error. The identity is resolved once by
-/// [`authenticate`], so every handler — including the search endpoint that
-/// filters many packages — authorizes synchronously against it.
+/// The `packages:` rules of the concrete registry a request resolved to.
+/// Authorization is entirely registry-scoped — there is no global,
+/// name-keyed ACL — so every check consults the one registry that serves
+/// the package. The fallback (safe defaults: reads open, publishes need
+/// auth, destructive writes denied) only fires for a programmatically
+/// built config whose serving tables miss the graph entry.
+fn source_rules<'a>(state: &'a AppState, source: &RegistrySource) -> &'a PackageRules {
+    static SAFE_DEFAULTS: LazyLock<PackageRules> = LazyLock::new(PackageRules::default);
+    match source {
+        RegistrySource::Hosted(name) => {
+            state.inner.config.hosted.get(name).map(|hosted| &hosted.rules)
+        }
+        RegistrySource::Upstream(name) => {
+            state.inner.config.upstreams.get(name).map(|upstream| &upstream.rules)
+        }
+        RegistrySource::Unclaimed | RegistrySource::NotFound => None,
+    }
+    .unwrap_or(&SAFE_DEFAULTS)
+}
+
+/// Check an already-resolved `identity` against the resolved source
+/// registry's per-package rule (the most specific `packages:` entry, its
+/// omitted fields falling back to the registry defaults). Returns `Ok(())`
+/// when the call is allowed; otherwise the appropriate `Unauthenticated` /
+/// `Forbidden` error. The identity is resolved once by [`authenticate`], so
+/// every handler — including the search endpoint that filters many packages —
+/// authorizes synchronously against it.
 fn authorize(
     state: &AppState,
     identity: &Identity,
+    source: &RegistrySource,
     package: &str,
     action: Action,
 ) -> Result<(), RegistryError> {
-    let effective = state.inner.config.policies.for_package(package);
+    let effective = source_rules(state, source).for_package(package);
     let list = match action {
         Action::Access => effective.access,
         Action::Publish => effective.publish,

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -3042,10 +3042,16 @@ async fn serve_search(
         if objects.len() >= size {
             break;
         }
-        let Some(org) = state.inner.config.hosted.get(&source).map(|hosted| hosted.org.clone())
-        else {
+        let Some(hosted) = state.inner.config.hosted.get(&source) else {
             continue;
         };
+        // Fast path: a caller no rule of this registry could ever admit
+        // gets the empty result without a storage scan — the blanket mask
+        // must not become an enumeration (or scan-timing) primitive.
+        if !hosted.rules.any_access_admits(identity) {
+            continue;
+        }
+        let org = hosted.org.clone();
         let storage = hosted_storage(state, Some(&org));
         // The caller was resolved once by the middleware; both filters run
         // synchronously against it inside the scan. Visibility is

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1782,8 +1782,13 @@ fn resolves_to_private_source(state: &AppState, registry: &str, package: &str) -
             })
         }
         // A private upstream (registry-level `access:`) is caller-gated for
-        // every name; a public one can still gate individual names through a
-        // per-package `access` rule.
+        // *every* name — unlike a hosted registry, its registry-level gate is
+        // enforced independently at serving (`authorized_upstream` runs
+        // before per-package rules on every upstream read), so a per-package
+        // `access: $all` entry cannot open a name on it and `access.is_some()`
+        // alone already means the response varies by caller. A public
+        // upstream can still gate individual names through a per-package
+        // `access` rule.
         RegistrySource::Upstream(source) => {
             state.inner.config.upstreams.get(&source).is_some_and(|upstream| {
                 upstream.access.is_some()

--- a/pnpr/crates/pnpr/src/server/tests.rs
+++ b/pnpr/crates/pnpr/src/server/tests.rs
@@ -6,7 +6,7 @@ use crate::{
     auth::{AuthState, TokenBackend, TokenRecord, UserStore},
     config::Config,
     error::{RegistryError, Result},
-    policy::{AccessList, PackagePolicies, PackagePolicy},
+    policy::{AccessList, PackageRule, PackageRules},
 };
 use async_trait::async_trait;
 use axum::{
@@ -223,20 +223,31 @@ async fn configured_groups_reach_package_authorization() {
     let listen = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
     let mut config = Config::static_serve(listen, tmp.path().to_path_buf());
     config.groups.add_user_to_group("alice", "platform");
-    config.policies = PackagePolicies::new(vec![
-        PackagePolicy::new(
-            "@team/*",
-            AccessList::parse("platform"),
-            AccessList::default(),
-            AccessList::default(),
-        )
-        .unwrap(),
-    ]);
-    let app = app_with_config_and_token(config, "tok", record(false, &[]));
+    use crate::registry::PackagePattern;
+    config.hosted.get_mut("local").unwrap().rules = PackageRules::new(
+        vec![PackageRule {
+            pattern: PackagePattern::parse("@team/*").unwrap(),
+            access: Some(AccessList::parse("platform")),
+            publish: None,
+            unpublish: None,
+        }],
+        None,
+    );
+    // Group membership reaches the per-package rule evaluation.
+    let alice = config.identity_for_user("alice");
+    let carol = config.identity_for_user("carol");
+    let rules = &config.hosted["local"].rules;
+    assert!(rules.for_package("@team/x").access.allows(&alice));
+    assert!(!rules.for_package("@team/x").access.allows(&carol));
 
+    // Over HTTP: the group member reaches storage (404, the package is
+    // absent); a caller denied by the *explicit* `@team/*` entry is
+    // rejected loudly — 401 for anonymous, so clients can prompt for
+    // credentials — rather than masked (masking is the registry-level
+    // default's behavior, not an explicit entry's).
+    let app = app_with_config_and_token(config, "tok", record(false, &[]));
     let allowed = app.clone().oneshot(signed(Method::GET, "/@team/missing", "tok")).await.unwrap();
     assert_eq!(allowed.status(), StatusCode::NOT_FOUND);
-
     let anonymous = app.oneshot(signed(Method::GET, "/@team/missing", "unknown")).await.unwrap();
     assert_eq!(anonymous.status(), StatusCode::UNAUTHORIZED);
 }

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -530,6 +530,7 @@ fn breaking_upstream(url: String, max_fails: u32) -> Upstream {
             fail_timeout: Duration::from_mins(5),
             cache: true,
             access: None,
+            rules: crate::policy::PackageRules::default(),
         },
     )
 }

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -33,14 +33,25 @@ fn static_config_with_packages(dir: &TempDir, packages_block: &str) -> (Config, 
     let storage = dir.path().join("storage");
     std::fs::create_dir_all(&storage).unwrap();
     // Route everything to one local hosted over the flat storage root (an
-    // empty `org` namespace), so publishes/reads resolve through the path-less
-    // base and the per-package ACL in `packages_block` gates them.
-    let registries_block = "registries:\n  \
-        local:\n    type: hosted\n    org: \"\"\n    access: $all\n  \
-        main:\n    type: router\n    sources: [local]\n\
-        defaultRegistry: main\n";
-    let yaml =
-        format!("storage: {}\n{registries_block}packages:\n{packages_block}\n", storage.display());
+    // empty `org` namespace), so publishes/reads resolve through the
+    // path-less base and the per-package rules in `packages_block` gate
+    // them. The callers indent keys by two spaces; re-indent under
+    // `registries.local.packages`, and add a `'**'` catch-all with the
+    // default rules so the namespace stays name-unbounded like the old
+    // static shape.
+    let nested: String = packages_block
+        .lines()
+        .map(|line| if line.trim().is_empty() { line.to_string() } else { format!("    {line}") })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let yaml = format!(
+        "storage: {}\nregistries:\n  \
+         local:\n    type: hosted\n    org: \"\"\n    access: $all\n    packages:\n\
+         {nested}\n      '**': {{}}\n  \
+         main:\n    type: router\n    sources: [local]\n\
+         defaultRegistry: main\n",
+        storage.display(),
+    );
     let config_path = dir.path().join("config.yaml");
     std::fs::write(&config_path, yaml).unwrap();
     let mut config =

--- a/pnpr/crates/pnpr/tests/policy.rs
+++ b/pnpr/crates/pnpr/tests/policy.rs
@@ -1,6 +1,7 @@
-//! Integration tests for the YAML-driven access policy: the
-//! `packages:` `access` / `publish` tokens compile into the runtime
-//! policy and gate requests, including the `$anonymous` rule.
+//! Integration tests for the YAML-driven access rules: a registry's
+//! `packages:` map (`access` / `publish` values on pattern keys) compiles
+//! into that registry's runtime rules and gates requests, including the
+//! `$anonymous` rule and the explicit-entry 401/403 answers.
 //! Static-mode (no upstream) to keep the tests hermetic.
 
 use axum::{
@@ -17,22 +18,31 @@ fn listen() -> SocketAddr {
     SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 4873))
 }
 
-/// Write a `config.yaml` (with `packages_block` spliced in) into a
-/// fresh tempdir and load it through the real `from_yaml` path, so
-/// the test exercises YAML parsing → policy compilation end to end.
+/// Write a `config.yaml` (with `packages_block` spliced onto the `local`
+/// hosted registry) into a fresh tempdir and load it through the real
+/// `from_yaml` path, so the test exercises YAML parsing → rules compilation
+/// end to end.
 fn config_from_yaml(packages_block: &str) -> (TempDir, Config) {
     let dir = TempDir::new().unwrap();
     let storage = dir.path().join("storage");
     std::fs::create_dir_all(&storage).unwrap();
     // Route everything to one local hosted over the flat storage root (an
-    // empty `org` namespace), so the path-less base resolves and the per-package
-    // ACL in `packages_block` gates the request.
-    let registries_block = "registries:\n  \
-        local:\n    type: hosted\n    org: \"\"\n    access: $all\n  \
-        main:\n    type: router\n    sources: [local]\n\
-        defaultRegistry: main\n";
+    // empty `org` namespace), so the path-less base resolves and the
+    // registry's own `packages:` rules gate the request. The callers pass a
+    // top-level-shaped block ("packages:\n  '<key>': ..."); nest it under
+    // the registry by re-indenting.
+    let nested: String = packages_block
+        .strip_prefix("packages:\n")
+        .expect("callers pass a packages: block")
+        .lines()
+        .map(|line| format!("    {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
     let yaml = format!(
-        "storage: {}\nauth:\n  htpasswd:\n    max_users: 100\n{registries_block}{packages_block}\n",
+        "storage: {}\nauth:\n  htpasswd:\n    max_users: 100\nregistries:\n  \
+         local:\n    type: hosted\n    org: \"\"\n    access: $all\n    packages:\n{nested}\n  \
+         main:\n    type: router\n    sources: [local]\n\
+         defaultRegistry: main\n",
         storage.display(),
     );
     let path = dir.path().join("config.yaml");

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -2931,8 +2931,9 @@ async fn private_hosted_org_masks_before_the_package_acl() {
         None,
     );
     // A per-package rule that also denies the anonymous caller. In the
-    // merged model there is no separate ACL layer to mis-order: a hosted
-    // read denial is a not-found mask by construction.
+    // merged model there is no separate ACL layer whose ordering could
+    // leak: a caller the registry-level default denies is masked as
+    // not-found for every name, explicitly ruled or not.
     config
         .hosted
         .get_mut("acme")

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -5,8 +5,8 @@ use axum::{
 use flate2::read::GzDecoder;
 use futures_util::stream;
 use pnpr::{
-    AccessList, AuthState, Config, HostedConfig, MaxUsers, PackagePattern, PackagePolicies,
-    PackagePolicy, PublicRoute, Registries, Registry, router, router_with_auth,
+    AccessList, AuthState, Config, HostedConfig, MaxUsers, PackagePattern, PackageRule,
+    PackageRules, PublicRoute, Registries, Registry, router, router_with_auth,
 };
 use serde_json::{Value, json};
 use ssri::{Algorithm, IntegrityOpts};
@@ -36,6 +36,28 @@ fn config_for(upstream: &str, storage: PathBuf) -> Config {
     config.public_url = "http://example.test".to_string();
     config.packument_ttl = Duration::from_mins(1);
     config
+}
+
+/// A hosted registry whose `packages:` map is empty (claims every name) with
+/// the given registry-level default `access:`. Unpublish defaults to any
+/// authenticated user, the registry-mock contract these fixtures always ran
+/// under (the safe per-registry default would deny destructive writes).
+fn hosted_with_access(org: &str, access: &str) -> HostedConfig {
+    HostedConfig {
+        org: org.to_string(),
+        rules: PackageRules::new(Vec::new(), Some(AccessList::parse(access)))
+            .with_default_unpublish(AccessList::parse("$authenticated")),
+    }
+}
+
+/// One `packages:` entry carrying only an `access` rule.
+fn access_rule(pattern: &str, access: &str) -> PackageRule {
+    PackageRule {
+        pattern: PackagePattern::parse(pattern).expect("test pattern parses"),
+        access: Some(AccessList::parse(access)),
+        publish: None,
+        unpublish: None,
+    }
 }
 
 /// A public upstream registry caches under `.pnpr-cache/~public/<digest>/<pkg>/`.
@@ -544,15 +566,10 @@ async fn upstream_dist_tags_enforce_package_access() {
 
     let tmp = TempDir::new().unwrap();
     let mut config = config_for(&upstream.url(), tmp.path().to_path_buf());
-    config.policies = PackagePolicies::new(vec![
-        PackagePolicy::new(
-            "restricted",
-            AccessList::parse("$authenticated"),
-            AccessList::default(),
-            AccessList::default(),
-        )
-        .expect("policy compiles"),
-    ]);
+    // The gate lives on the upstream registry's own `packages:` rules: an
+    // access-restricted name can't be read even through a public upstream.
+    config.upstreams.get_mut("npmjs").expect("default `npmjs` upstream").rules =
+        PackageRules::new(vec![access_rule("restricted", "$authenticated")], None);
     let app = router(config);
 
     let response = app
@@ -2837,10 +2854,7 @@ async fn hosted_registry_serves_only_what_it_hosts() {
     seed_hosted(&tmp.path().join("acme"), "@acme/widget");
 
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    config.hosted.insert(
-        "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("$all") },
-    );
+    config.hosted.insert("acme".to_string(), hosted_with_access("acme", "$all"));
     config.registries = Registries::new(
         vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         None,
@@ -2871,10 +2885,7 @@ async fn private_hosted_hides_existence_from_unauthorized_caller() {
     seed_hosted(&tmp.path().join("acme"), "@acme/widget");
 
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    config.hosted.insert(
-        "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice") },
-    );
+    config.hosted.insert("acme".to_string(), hosted_with_access("acme", "alice"));
     config.registries = Registries::new(
         vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         None,
@@ -2914,25 +2925,20 @@ async fn private_hosted_org_masks_before_the_package_acl() {
     seed_hosted(&tmp.path().join("acme"), "@acme/widget");
 
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    config.hosted.insert(
-        "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice") },
-    );
+    config.hosted.insert("acme".to_string(), hosted_with_access("acme", "alice"));
     config.registries = Registries::new(
         vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         None,
     );
-    // A per-package ACL that also denies the anonymous caller. Without the
-    // visibility-first ordering this would return 401/403 and leak existence.
-    config.policies = PackagePolicies::new(vec![
-        PackagePolicy::new(
-            "@acme/widget",
-            AccessList::parse("$authenticated"),
-            AccessList::default(),
-            AccessList::default(),
-        )
-        .expect("policy compiles"),
-    ]);
+    // A per-package rule that also denies the anonymous caller. In the
+    // merged model there is no separate ACL layer to mis-order: a hosted
+    // read denial is a not-found mask by construction.
+    config
+        .hosted
+        .get_mut("acme")
+        .expect("hosted acme")
+        .rules
+        .push_rule(access_rule("@acme/widget", "$authenticated"));
     let app = router_with_auth(config, AuthState::in_memory());
 
     for path in [
@@ -2954,25 +2960,19 @@ async fn private_hosted_org_masks_dist_tags_before_the_package_acl() {
     seed_hosted(&tmp.path().join("acme"), "@acme/widget");
 
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    config.hosted.insert(
-        "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice") },
-    );
+    config.hosted.insert("acme".to_string(), hosted_with_access("acme", "alice"));
     // The path-less base aliases the "acme" hosted registry, so `/-/package/...`
     // resolves to it.
     config.registries = Registries::new(
         vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("acme".to_string()),
     );
-    config.policies = PackagePolicies::new(vec![
-        PackagePolicy::new(
-            "@acme/widget",
-            AccessList::parse("$authenticated"),
-            AccessList::default(),
-            AccessList::default(),
-        )
-        .expect("policy compiles"),
-    ]);
+    config
+        .hosted
+        .get_mut("acme")
+        .expect("hosted acme")
+        .rules
+        .push_rule(access_rule("@acme/widget", "$authenticated"));
     let app = router_with_auth(config, AuthState::in_memory());
 
     let resp = app
@@ -2988,10 +2988,7 @@ async fn publish_to_hosted_round_trips_in_its_own_namespace() {
 
     let tmp = TempDir::new().unwrap();
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    config.hosted.insert(
-        "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("$authenticated") },
-    );
+    config.hosted.insert("acme".to_string(), hosted_with_access("acme", "$authenticated"));
     // npmjs already exists (from config_for); add a hosted org claiming
     // `@acme/*` + a router over it and the pattern-less npmjs catch-all,
     // aliased path-less.
@@ -3105,10 +3102,7 @@ async fn hosted_registry_patterns_bound_publish_and_reads_on_every_path() {
 
     let tmp = TempDir::new().unwrap();
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    config.hosted.insert(
-        "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("$authenticated") },
-    );
+    config.hosted.insert("acme".to_string(), hosted_with_access("acme", "$authenticated"));
     // `acme` claims only `@acme/*`; the router has no other source, and the
     // path-less base aliases the router.
     let graph = vec![
@@ -3195,10 +3189,7 @@ async fn hosted_registry_patterns_bound_publish_and_reads_on_every_path() {
 async fn off_pattern_publish_is_masked_for_callers_the_registry_denies() {
     let tmp = TempDir::new().unwrap();
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    config.hosted.insert(
-        "corp".to_string(),
-        HostedConfig { org: "corp".to_string(), access: AccessList::parse("alice") },
-    );
+    config.hosted.insert("corp".to_string(), hosted_with_access("corp", "alice"));
     config.registries = Registries::new(
         vec![(
             "corp".to_string(),
@@ -3296,10 +3287,7 @@ async fn building_the_server_rejects_a_name_shared_by_two_registry_kinds() {
 
     // A hosted serving row under a name the graph declares as a router.
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    config.hosted.insert(
-        "corp".to_string(),
-        HostedConfig { org: "corp".to_string(), access: AccessList::parse("$all") },
-    );
+    config.hosted.insert("corp".to_string(), hosted_with_access("corp", "$all"));
     config.registries = Registries::new(
         vec![("corp".to_string(), Registry::Router { sources: vec!["npmjs".to_string()] })]
             .into_iter()
@@ -3316,10 +3304,7 @@ async fn building_the_server_rejects_a_name_shared_by_two_registry_kinds() {
 async fn building_the_server_rejects_an_unsafe_programmatic_hosted_org() {
     let tmp = TempDir::new().unwrap();
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    config.hosted.insert(
-        "evil".to_string(),
-        HostedConfig { org: "../escape".to_string(), access: AccessList::parse("$all") },
-    );
+    config.hosted.insert("evil".to_string(), hosted_with_access("../escape", "$all"));
     let err = pnpr::try_router(config).expect_err("a path-escaping org must fail startup");
     assert!(err.to_string().contains("org"), "unexpected error: {err}");
 }
@@ -3368,10 +3353,7 @@ async fn private_hosted_registry_denies_writes_from_non_members() {
 
     let tmp = TempDir::new().unwrap();
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    config.hosted.insert(
-        "corp".to_string(),
-        HostedConfig { org: "corp".to_string(), access: AccessList::parse("alice") },
-    );
+    config.hosted.insert("corp".to_string(), hosted_with_access("corp", "alice"));
     // `/~corp/` addresses the registry directly; the path-less base aliases it,
     // so the path-less dist-tag and unpublish writes route there too.
     config.registries = Registries::new(
@@ -3464,10 +3446,7 @@ async fn search_does_not_enumerate_a_private_flat_root_registry() {
     // Replace the default public flat-root registry (`local`) with a private one;
     // any surviving `$all` flat-root entry would defeat the gate under test.
     config.hosted.clear();
-    config.hosted.insert(
-        "corp".to_string(),
-        HostedConfig { org: String::new(), access: AccessList::parse("alice") },
-    );
+    config.hosted.insert("corp".to_string(), hosted_with_access("", "alice"));
     config.registries = Registries::new(
         vec![("corp".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("corp".to_string()),
@@ -3515,10 +3494,7 @@ async fn registry_addressed_surface_serves_dist_tags_unpublish_whoami_search_and
 
     let tmp = TempDir::new().unwrap();
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    config.hosted.insert(
-        "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("$authenticated") },
-    );
+    config.hosted.insert("acme".to_string(), hosted_with_access("acme", "$authenticated"));
     // No default target: the registry is addressable only at `/~acme/`.
     config.registries = Registries::new(
         vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
@@ -3694,10 +3670,7 @@ async fn pathless_private_registry_responses_carry_private_cache_headers() {
     seed_hosted(&tmp.path().join("acme"), "@acme/widget");
 
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    config.hosted.insert(
-        "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("alice") },
-    );
+    config.hosted.insert("acme".to_string(), hosted_with_access("acme", "alice"));
     config.registries = Registries::new(
         vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("acme".to_string()),
@@ -3734,10 +3707,7 @@ async fn pathless_private_registry_responses_carry_private_cache_headers() {
     let tmp_public = TempDir::new().unwrap();
     seed_hosted(&tmp_public.path().join("acme"), "@acme/widget");
     let mut config = config_for("http://127.0.0.1:1", tmp_public.path().to_path_buf());
-    config.hosted.insert(
-        "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("$all") },
-    );
+    config.hosted.insert("acme".to_string(), hosted_with_access("acme", "$all"));
     config.registries = Registries::new(
         vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("acme".to_string()),
@@ -3762,23 +3732,17 @@ async fn pathless_acl_gated_package_carries_private_cache_headers() {
     seed_hosted(&tmp.path().join("acme"), "@acme/widget");
 
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    config.hosted.insert(
-        "acme".to_string(),
-        HostedConfig { org: "acme".to_string(), access: AccessList::parse("$all") },
-    );
+    config.hosted.insert("acme".to_string(), hosted_with_access("acme", "$all"));
     config.registries = Registries::new(
         vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
         Some("acme".to_string()),
     );
-    config.policies = PackagePolicies::new(vec![
-        PackagePolicy::new(
-            "@acme/widget",
-            AccessList::parse("$authenticated"),
-            AccessList::default(),
-            AccessList::default(),
-        )
-        .expect("policy compiles"),
-    ]);
+    config
+        .hosted
+        .get_mut("acme")
+        .expect("hosted acme")
+        .rules
+        .push_rule(access_rule("@acme/widget", "$authenticated"));
     let auth = AuthState::in_memory();
     let token = auth.tokens.issue("alice").await.unwrap();
     let app = router_with_auth(config, auth);


### PR DESCRIPTION
## Summary

Implements the revised registries model from pnpm/rfcs#17 as a **full replacement** of the interim `patterns:`-plus-global-ACL shape (pre-1.0, no compatibility mode).

### One declaration: the per-registry `packages:` map

Every concrete registry (hosted or upstream) declares one `packages:` map whose **keys are its namespace** (replacing the `patterns:` list) and whose **values are the per-package `access`/`publish`/`unpublish` rules** (replacing the top-level `packages:` ACL, scoped to the one registry that serves the name). One declaration routes, filters, and authorizes. The registry-level `access:` is the default an entry's omitted fields fall back to; `publish` defaults to `$authenticated` and `unpublish` to nobody.

```yaml
registries:
  local:
    type: hosted
    access: $all
    packages:
      '@private/*': { access: $authenticated, publish: $authenticated, unpublish: $authenticated }
      '@pnpm.e2e/*': { unpublish: $authenticated }
      '@pnpm.e2e/needs-auth': { access: $authenticated, publish: $authenticated, unpublish: $authenticated }
```

### Specificity selection — key order carries no meaning

The most specific matching key wins: an exact name beats `@scope/*` beats `@*/*` beats `**`. YAML mappings are formally unordered, so a formatter or `yq` round-trip must not change which access rule applies; the restricted pattern language makes the winner unique (at most one matching key per tier), no entry can be dead, and a duplicate key is the only within-registry error. Router `sources:` stay an ordered list with their unreachable-source/shadowed-claim validation intact.

### The removed global ACL fails loudly

A config still containing a top-level `packages:` block is a **startup error** naming the per-registry replacement. It used to *enforce* access, so dropping it like an unknown verdaccio key would silently open previously gated packages on upgrade.

### Upstream rules

`public: true` keeps describing the upstream *fetch* (no credential, no headers, no registry-level `access:` default), but per-package `access` rules are now permitted on a public upstream — they gate who may read the name *through pnpr*, not how pnpr fetches it. `publish`/`unpublish` values on any upstream are rejected on every tier: no write can land there.

### Hosted denials answer by tier

The *decision* is always the effective per-package access — an explicit entry fully decides its names, including **opening** one name (`access: $all`) on an otherwise-private registry. Only the *shape of a denial* is tiered, preserving both prior behaviors through one mechanism: a caller the **registry-level default** also denies is masked with `404` — a blanket-private registry never confirms which names exist, even explicitly ruled ones — while an **explicit entry** denying a caller the default admits rejects loudly (`401` anonymous / `403` authenticated), so clients can prompt for credentials (the registry-mock `needs-auth` contract the pnpm e2e suite relies on).

### Resolver classification follows the graph

Path-less fetches classify through the registry graph — the same dispatch serving uses — so a fetch resolving to an upstream source classifies through that upstream's alias, and hosted private-access descriptors are **registry-qualified** (`registry\0package`): the same `name@version` on two hosted registries can never share a cache key. Unqualified descriptors from older builds fail closed and re-resolve.

### Review-round additions

- **Per-package-aware alias selection** (route classification): a caller the upstream's effective access denies for a name is never handed the server-owned credential — fresh resolves fail closed where serving would deny; cache replay stays registry-scoped by design (documented at the descriptor gate).
- **Indexed rule lookup**: `for_package` resolves the winner via per-tier maps instead of scanning every rule.
- **Search fast path restored**: a hosted registry no rule of which could admit the caller is skipped without a storage scan, so the blanket mask can't be used for enumeration or scan-timing.

### Config surface

The bundled `config.yaml` moves the fixture namespace and old ACL into the `local` registry's map (YAML anchors keep the per-key `unpublish` contract readable); `Config::proxy` / `Config::static_serve` carry the registry-mock rules programmatically; registry-mock keeps working with no task or fixture-seed changes.

## Checklist

- [x] pnpr is a standalone server; the RFC's client/lockfile changes are deliberately out of scope (implements the pnpr side of pnpm/rfcs#17 only).
- [x] No changeset: server-only change, no published npm package behavior changes.
- [x] Added or updated tests: specificity selection (including key-reorder stability via YAML), top-level `packages:` rejection, upstream write-rule rejection, public-upstream per-package access, upstream namespace bounds, tiered hosted denials; existing suites migrated to the map shape. 585 pnpr tests pass; clippy, rustfmt, and rustdoc clean; workspace check clean.
- [x] Updated the documentation (bundled `config.yaml` documents the map shape).

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-registry `packages` rules now drive access, publish, and unpublish for both hosted and upstream registries.
  * Rule matching is deterministic by specificity (exact, scope, scoped-wildcard, catch-all), including registry default fallback behavior.
* **Bug Fixes**
  * Authorization and privacy gating are now based on the resolved concrete registry source, improving private access correctness and masking.
  * Configuration validation now rejects unsupported top-level package declarations and invalid/duplicate `packages` entries.
* **Tests**
  * Updated and expanded coverage for the new rules-driven YAML shape, routing/authorization semantics, and publish/write gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->