### PR TITLE
fix(completion): complete workspaces with -F alias as for --filter

### DIFF
--- a/.changeset/completion-filter-alias.md
+++ b/.changeset/completion-filter-alias.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/cli.commands": patch
+"pnpm": patch
+---
+
+Fixed shell tab completion not suggesting workspaces after the `-F` alias for `--filter` option.

--- a/pnpm11/cli/commands/src/completion/complete.ts
+++ b/pnpm11/cli/commands/src/completion/complete.ts
@@ -32,7 +32,7 @@ export async function complete (
 
   // Autocompleting option values
   if (input.currentTypedWordType !== 'option') {
-    if (input.lastOption === '--filter') {
+    if (input.lastOption === '--filter' || input.lastOption === '-F') {
       const workspaceDir = await findWorkspaceDir(process.cwd()) ?? process.cwd()
       const workspaceManifest = await readWorkspaceManifest(workspaceDir)
       const allProjects = await findWorkspaceProjects(workspaceDir, {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

Fixed shell tab completion not suggesting workspaces after the `-F` alias for `--filter` option.

Tested manually with this command, that now outputs workspaces instead of nothing:
```
COMP_CWORD=2 COMP_LINE="pnpm -F " COMP_POINT=8 SHELL=zsh node ./pnpm11/pnpm/dist/pnpm.mjs completion-server
```

A more robust implementation could be to resolve aliases with `universalShorthands` but since it seems that the new Rust cli is in development, maybe it doesn't make sense to do it.


## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests.
- [ ] Updated the documentation if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shell tab completion now suggests workspace names when using the `-F` shortcut for filtering, matching the behavior of the full option.
  * Completion results for filtering are more consistent across both the short and long option forms.
* **Chores**
  * Added patch-level release metadata for the affected packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->