### PR TITLE
feat(pnpr): pnpr-native access control — strict token grammar and registry-scoped teams

### DIFF
--- a/pnpm/crates/pnpr-client/tests/integration.rs
+++ b/pnpm/crates/pnpr-client/tests/integration.rs
@@ -110,7 +110,7 @@ fn registry_upstream(registry_url: &str, token: &str) -> (String, pnpr::Upstream
             max_fails: pnpr::UpstreamConfig::DEFAULT_MAX_FAILS,
             fail_timeout: pnpr::UpstreamConfig::DEFAULT_FAIL_TIMEOUT,
             cache: true,
-            access: Some(pnpr::AccessList::parse("$authenticated")),
+            access: Some(pnpr::AccessList::from_tokens(["$authenticated"])),
             rules: pnpr::PackageRules::default(),
         },
     )

--- a/pnpr/crates/pnpr/config.yaml
+++ b/pnpr/crates/pnpr/config.yaml
@@ -57,11 +57,13 @@ auth:
     # (registration disabled); set a non-negative cap to allow registration.
     max_users: -1
 
-# Optional static group/team memberships. Every access list accepts these
-# group names anywhere it accepts usernames — the per-package `packages:`
-# policies and the registry-level `access:` lists alike.
-#groups:
-#  platform: [alice, bob]
+# Teams — named user sets — are declared per registry (a `teams:` map on a
+# hosted or upstream registry under `registries:` below) and referenced from
+# that registry's access lists as `team:<name>`; a bare token is always a
+# username. e.g.
+#    teams:
+#      platform: [alice, bob]
+#    access: team:platform
 
 plugins: ../node_modules
 

--- a/pnpr/crates/pnpr/config.yaml
+++ b/pnpr/crates/pnpr/config.yaml
@@ -61,7 +61,7 @@ auth:
 # group names anywhere it accepts usernames — the per-package `packages:`
 # policies and the registry-level `access:` lists alike.
 #groups:
-#  platform: alice bob
+#  platform: [alice, bob]
 
 plugins: ../node_modules
 

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1016,7 +1016,7 @@ fn validate_access_token(token: &str) -> Result<(), String> {
     if let Some((kind, name)) = token.split_once(':') {
         return match kind {
             "team" if name.contains(':') => {
-                Err(format!("access token {token:?} is malformed; a team name cannot contain `:`",))
+                Err(format!("access token {token:?} is malformed; a team name cannot contain `:`"))
             }
             "team" if !name.is_empty() => Ok(()),
             "team" => Err(format!("access token {token:?} names no team; write `team:<name>`")),

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -909,12 +909,13 @@ impl AccessSpec {
         Ok(AccessList::new(tokens))
     }
 
-    /// The `teams:` membership reading: each entry is one username, in
-    /// declared order. Unlike [`Self::to_access_list`] the entries are not
-    /// access tokens — usernames get shape validation only.
+    /// The `teams:` membership reading: each entry is one username
+    /// ([`validate_member_name`]), in declared order. Unlike
+    /// [`Self::to_access_list`] the entries are not access tokens — a
+    /// built-in group or `team:` reference among the members is an error.
     fn member_names(&self) -> Result<&[String], String> {
         for member in self.entries() {
-            validate_single_token(member)?;
+            validate_member_name(member)?;
         }
         Ok(self.entries())
     }
@@ -971,6 +972,29 @@ fn validate_team_name(team: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// A team member is one plain username. The built-in groups — in any
+/// spelling — and typed tokens are rejected: `[$authenticated]` in a member
+/// list would otherwise silently become a user literally named
+/// `$authenticated`, narrowing the team to a name nobody holds, the same
+/// trap [`validate_access_token`] closes for access lists.
+fn validate_member_name(member: &str) -> Result<(), String> {
+    validate_single_token(member)?;
+    let bare = member.strip_prefix('@').unwrap_or(member);
+    if member.starts_with('$') || matches!(bare, "all" | "authenticated" | "anonymous") {
+        return Err(format!(
+            "team member {member:?} is not a username; the built-in groups belong in the \
+             access lists themselves (e.g. `access: [$authenticated]`)",
+        ));
+    }
+    if member.contains(':') {
+        return Err(format!(
+            "team member {member:?} is not a username; a team cannot include another team — \
+             list its users, or share one roster with a YAML anchor",
+        ));
+    }
+    Ok(())
+}
+
 /// Reject an access-list entry that is not exactly one recognized token: an
 /// unknown `$...` built-in, an unknown `<type>:` prefix (only `team:` exists;
 /// htpasswd forbids `:` in usernames, so the character is free to reserve),
@@ -991,6 +1015,9 @@ fn validate_access_token(token: &str) -> Result<(), String> {
     }
     if let Some((kind, name)) = token.split_once(':') {
         return match kind {
+            "team" if name.contains(':') => {
+                Err(format!("access token {token:?} is malformed; a team name cannot contain `:`",))
+            }
             "team" if !name.is_empty() => Ok(()),
             "team" => Err(format!("access token {token:?} names no team; write `team:<name>`")),
             "group" | "groups" => Err(format!(

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -972,10 +972,10 @@ fn validate_team_name(team: &str) -> Result<(), String> {
 }
 
 /// Reject an access-list entry that is not exactly one recognized token: an
-/// unknown `$…` built-in, an unknown `<type>:` prefix (only `team:` exists;
+/// unknown `$...` built-in, an unknown `<type>:` prefix (only `team:` exists;
 /// htpasswd forbids `:` in usernames, so the character is free to reserve),
 /// or one of verdaccio's alias spellings of the built-ins (`@all`, bare
-/// `all`, …), which must not silently become a username that admits nobody.
+/// `all`, ...), which must not silently become a username that admits nobody.
 /// This loud rejection at the YAML boundary is what lets `AccessToken`
 /// parsing stay infallible.
 fn validate_access_token(token: &str) -> Result<(), String> {
@@ -1005,7 +1005,7 @@ fn validate_access_token(token: &str) -> Result<(), String> {
     }
     let bare = token.strip_prefix('@').unwrap_or(token);
     if matches!(bare, "all" | "authenticated" | "anonymous") {
-        return Err(format!("unknown access token {token:?}; did you mean \"${bare}\"?"));
+        return Err(format!(r#"unknown access token {token:?}; did you mean "${bare}"?"#));
     }
     Ok(())
 }

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::RegistryError,
-    policy::{AccessGroups, AccessList, Identity, PackageRule, PackageRules},
+    policy::{AccessGroups, AccessList, AccessToken, Identity, PackageRule, PackageRules},
     registry::{PackagePattern, Registries, Registry, RegistryConfigError},
     s3::{S3Settings, build_s3_store},
 };
@@ -753,6 +753,12 @@ fn resolve_upstream_config<Sys: EnvVar>(
     let timeout = parse_field("timeout", &file.timeout)?.unwrap_or(UpstreamConfig::DEFAULT_TIMEOUT);
     let fail_timeout = parse_field("fail_timeout", &file.fail_timeout)?
         .unwrap_or(UpstreamConfig::DEFAULT_FAIL_TIMEOUT);
+    let access =
+        file.access.as_ref().map(AccessSpec::to_access_list).transpose().map_err(|reason| {
+            RegistryError::InvalidConfig {
+                reason: format!("upstream {name:?} has an invalid `access` list: {reason}"),
+            }
+        })?;
 
     Ok(UpstreamConfig {
         url: file.url,
@@ -762,7 +768,7 @@ fn resolve_upstream_config<Sys: EnvVar>(
         max_fails: file.max_fails.unwrap_or(UpstreamConfig::DEFAULT_MAX_FAILS),
         fail_timeout,
         cache: file.cache.unwrap_or(true),
-        access: file.access.as_ref().map(AccessSpec::to_access_list),
+        access,
         // The `packages:` rules are attached by the caller
         // (`build_registries`) — this resolver only handles the serving
         // knobs shared with programmatic construction.
@@ -840,9 +846,9 @@ fn non_empty_token(token: &str) -> Option<String> {
     (!token.trim().is_empty()).then(|| token.to_string())
 }
 
-/// One `packages:` map value: `access` / `publish` / `unpublish` are verdaccio
-/// permission lists (built-in groups like `$all` / `$authenticated` /
-/// `$anonymous`, plus usernames / group names), compiled into the owning
+/// One `packages:` map value: `access` / `publish` / `unpublish` are
+/// permission lists (the built-in `$all` / `$authenticated` / `$anonymous`
+/// pseudo-groups, plus usernames / group names), compiled into the owning
 /// registry's [`PackageRules`]. An omitted field falls back to the
 /// registry-level default. The map key set doubles as the registry's declared
 /// namespace, so one declaration routes, filters, and authorizes.
@@ -854,10 +860,12 @@ pub struct PackageAccess {
     pub unpublish: Option<AccessSpec>,
 }
 
-/// A YAML string-or-list value. Verdaccio accepts either a single
-/// space-separated string (`access: $authenticated admin`) or a sequence
-/// (`access: [$authenticated, admin]`); both normalize to the same ordered
-/// token list.
+/// A YAML permission value: a sequence of tokens, or a scalar naming exactly
+/// one token. Every entry is taken verbatim — there is no whitespace
+/// splitting inside a scalar or a sequence element, so a multi-token list
+/// must be a YAML sequence (`access: [$authenticated, admin]`). Verdaccio's
+/// space-separated form (`access: $authenticated admin`) is rejected with a
+/// pointer at the sequence syntax rather than silently misread as one token.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum AccessSpec {
@@ -866,30 +874,78 @@ pub enum AccessSpec {
 }
 
 impl AccessSpec {
-    fn to_access_list(&self) -> AccessList {
+    /// The declared entries: the scalar form is one entry, the sequence
+    /// form one per element.
+    fn entries(&self) -> &[String] {
         match self {
-            AccessSpec::One(spec) => AccessList::parse(spec),
-            // Each element may itself be space-separated; flatten so
-            // `[a b, c]` and `[a, b, c]` agree.
-            AccessSpec::Many(items) => {
-                AccessList::from_tokens(items.iter().flat_map(|item| item.split_whitespace()))
-            }
+            AccessSpec::One(entry) => std::slice::from_ref(entry),
+            AccessSpec::Many(entries) => entries,
         }
     }
 
-    /// The tokens in declared order, each element flattened on whitespace
-    /// (so `[a b, c]` and `[a, b, c]` agree). Unlike [`Self::to_access_list`]
-    /// — which builds an unordered permission *set* — this preserves order,
-    /// for consumers (the `groups:` membership lists) where the declared
-    /// sequence is meaningful.
-    fn to_ordered_tokens(&self) -> Vec<&str> {
-        match self {
-            AccessSpec::One(spec) => spec.split_whitespace().collect(),
-            AccessSpec::Many(items) => {
-                items.iter().flat_map(|item| item.split_whitespace()).collect()
-            }
+    /// Compile into an [`AccessList`], rejecting any entry that is not a
+    /// single well-formed token ([`validate_access_token`]). The returned
+    /// error is the reason only; the caller prefixes the registry/field
+    /// context it alone knows.
+    fn to_access_list(&self) -> Result<AccessList, String> {
+        for entry in self.entries() {
+            validate_access_token(entry)?;
         }
+        Ok(AccessList::from_tokens(self.entries()))
     }
+
+    /// The `groups:` membership reading: each entry is one username, in
+    /// declared order. Unlike [`Self::to_access_list`] the entries are not
+    /// access tokens — usernames get shape validation only.
+    fn member_names(&self) -> Result<&[String], String> {
+        for member in self.entries() {
+            validate_single_token(member)?;
+        }
+        Ok(self.entries())
+    }
+}
+
+/// Reject an access-list entry that is not exactly one recognized token: an
+/// unknown `$…` built-in, or one of verdaccio's alias spellings of the
+/// built-ins (`@all`, bare `all`, …), which must not silently become a
+/// user/group name that admits nobody. This loud rejection at the YAML
+/// boundary is what lets `AccessToken` parsing stay infallible.
+fn validate_access_token(token: &str) -> Result<(), String> {
+    validate_single_token(token)?;
+    if let Some(builtin) = token.strip_prefix('$') {
+        if !matches!(builtin, "all" | "authenticated" | "anonymous") {
+            return Err(format!(
+                "unknown built-in access token {token:?}; the built-in groups are `$all`, \
+                 `$authenticated`, and `$anonymous`",
+            ));
+        }
+        return Ok(());
+    }
+    let bare = token.strip_prefix('@').unwrap_or(token);
+    if matches!(bare, "all" | "authenticated" | "anonymous") {
+        return Err(format!("unknown access token {token:?}; did you mean \"${bare}\"?"));
+    }
+    Ok(())
+}
+
+/// Reject a value that is not exactly one token: the empty string, or a
+/// string containing whitespace (a space-separated list must be a YAML
+/// sequence instead).
+fn validate_single_token(token: &str) -> Result<(), String> {
+    if token.is_empty() {
+        return Err(
+            "an empty string is not a token; use `[]` to admit no one, or omit the field for \
+             the default"
+                .to_string(),
+        );
+    }
+    if token.contains(char::is_whitespace) {
+        return Err(format!(
+            "{token:?} contains whitespace; write one token per YAML sequence item \
+             (e.g. `[alice, bob]`)",
+        ));
+    }
+    Ok(())
 }
 
 /// Disk shape of the `routes:` block.
@@ -1223,7 +1279,7 @@ const REGISTRY_MOCK_LOCAL_PATTERNS: &[&str] = &[
 /// `@pnpm.e2e/needs-auth` key wins over the `@pnpm.e2e/*` scope key by
 /// specificity.
 fn registry_mock_rules() -> PackageRules {
-    let authenticated = || Some(AccessList::parse("$authenticated"));
+    let authenticated = || Some(AccessList::from_tokens(["$authenticated"]));
     let mut rules: Vec<PackageRule> = REGISTRY_MOCK_LOCAL_PATTERNS
         .iter()
         .map(|pattern| PackageRule {
@@ -1241,7 +1297,8 @@ fn registry_mock_rules() -> PackageRules {
         publish: authenticated(),
         unpublish: authenticated(),
     });
-    PackageRules::new(rules, None).with_default_unpublish(AccessList::parse("$authenticated"))
+    PackageRules::new(rules, None)
+        .with_default_unpublish(AccessList::from_tokens(["$authenticated"]))
 }
 
 impl Config {
@@ -1554,7 +1611,7 @@ impl Config {
         let public_url = public_url.unwrap_or_else(|| format!("http://{listen}"));
         let auth = build_auth_config(&file.auth, base_dir);
         let logs = build_log_config(file.log.as_ref());
-        let groups = build_groups(&file.groups);
+        let groups = build_groups(&file.groups)?;
         // The global ACL block is gone, not ignorable: it used to *enforce*
         // access, so dropping it like an unknown verdaccio key would silently
         // open previously-gated packages on upgrade. Fail loudly instead,
@@ -1831,7 +1888,7 @@ fn build_registries(
                 {
                     return Err(org_collision_error(&name, &registry.org, other));
                 }
-                let access = registry.access.as_ref().map(AccessSpec::to_access_list);
+                let access = registry_access_list(&name, registry.access.as_ref())?;
                 let rules = build_rules(&name, &registry.packages, access)?;
                 let patterns = rules.patterns();
                 hosted.insert(name.clone(), HostedConfig { org: registry.org, rules });
@@ -1844,7 +1901,7 @@ fn build_registries(
                 // carries the namespace on every tier, and so a
                 // `publish`/`unpublish` value — a write rule on a registry no
                 // write can land on — fails startup on every tier too.
-                let access = upstream.access.as_ref().map(AccessSpec::to_access_list);
+                let access = registry_access_list(&name, upstream.access.as_ref())?;
                 let rules = build_rules(&name, &upstream.packages, access)?;
                 if rules.refines_writes() {
                     return Err(RegistryError::InvalidConfig {
@@ -1883,6 +1940,19 @@ fn org_collision_error(name: &str, org: &str, other: &str) -> RegistryError {
              registry {other:?}; two hosted registries cannot share a namespace",
         ),
     }
+}
+
+/// Compile a `registries:` entry's registry-level `access:` value, naming the
+/// registry in the error.
+fn registry_access_list(
+    name: &str,
+    spec: Option<&AccessSpec>,
+) -> Result<Option<AccessList>, RegistryError> {
+    spec.map(AccessSpec::to_access_list).transpose().map_err(|reason| {
+        RegistryError::InvalidConfig {
+            reason: format!("registry {name:?} has an invalid `access` list: {reason}"),
+        }
+    })
 }
 
 /// A registry's name is addressed as the single URL path segment `/~<name>/` and
@@ -1944,22 +2014,25 @@ fn build_rules(
 ) -> Result<PackageRules, RegistryError> {
     let rules = packages
         .iter()
-        .map(|(pattern, rule)| {
-            let pattern = PackagePattern::parse(pattern).map_err(|err| {
+        .map(|(key, rule)| {
+            let pattern = PackagePattern::parse(key).map_err(|err| {
                 RegistryError::InvalidConfig { reason: format!("registry {registry:?}: {err}") }
             })?;
             let fields = rule.as_ref();
+            let list = |field: &str, spec: Option<&AccessSpec>| {
+                spec.map(AccessSpec::to_access_list).transpose().map_err(|reason| {
+                    RegistryError::InvalidConfig {
+                        reason: format!(
+                            "registry {registry:?}: {key:?} has an invalid `{field}` list: {reason}",
+                        ),
+                    }
+                })
+            };
             Ok(PackageRule {
                 pattern,
-                access: fields
-                    .and_then(|fields| fields.access.as_ref())
-                    .map(AccessSpec::to_access_list),
-                publish: fields
-                    .and_then(|fields| fields.publish.as_ref())
-                    .map(AccessSpec::to_access_list),
-                unpublish: fields
-                    .and_then(|fields| fields.unpublish.as_ref())
-                    .map(AccessSpec::to_access_list),
+                access: list("access", fields.and_then(|fields| fields.access.as_ref()))?,
+                publish: list("publish", fields.and_then(|fields| fields.publish.as_ref()))?,
+                unpublish: list("unpublish", fields.and_then(|fields| fields.unpublish.as_ref()))?,
             })
         })
         .collect::<Result<Vec<_>, RegistryError>>()?;
@@ -2030,14 +2103,28 @@ fn resolve_upstream_registry<Sys: EnvVar>(
     resolve_upstream_config::<Sys>(name, upstream_config_file)
 }
 
-fn build_groups(file: &IndexMap<String, AccessSpec>) -> AccessGroups {
+fn build_groups(file: &IndexMap<String, AccessSpec>) -> Result<AccessGroups, RegistryError> {
     let mut groups = AccessGroups::default();
     for (group, members) in file {
-        for username in members.to_ordered_tokens() {
+        // A group is only useful as a `Named` token in access lists, so its
+        // name gets the same validation as a token — a name that shadows a
+        // built-in or could never be written in a list must not be declared.
+        validate_access_token(group)
+            .and_then(|()| match AccessToken::from(group.as_str()) {
+                AccessToken::Named(_) => Ok(()),
+                _ => Err(format!("group name {group:?} shadows a built-in access token")),
+            })
+            .map_err(|reason| RegistryError::InvalidConfig {
+                reason: format!("invalid `groups` name: {reason}"),
+            })?;
+        let members = members.member_names().map_err(|reason| RegistryError::InvalidConfig {
+            reason: format!("group {group:?} has an invalid member list: {reason}"),
+        })?;
+        for username in members {
             groups.add_user_to_group(username, group);
         }
     }
-    groups
+    Ok(groups)
 }
 
 /// Minimum length for an operator-configured `secret:`. A shorter value makes

--- a/pnpr/crates/pnpr/src/config.rs
+++ b/pnpr/crates/pnpr/src/config.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::RegistryError,
-    policy::{AccessGroups, AccessList, AccessToken, Identity, PackageRule, PackageRules},
+    policy::{AccessList, AccessToken, PackageRule, PackageRules},
     registry::{PackagePattern, Registries, Registry, RegistryConfigError},
     s3::{S3Settings, build_s3_store},
 };
@@ -10,6 +10,7 @@ use pacquet_env_replace::{EnvVar, SystemEnv, env_replace_lossy};
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderName, HeaderValue};
 use serde::Deserialize;
 use std::{
+    collections::BTreeSet,
     fmt,
     net::SocketAddr,
     path::{Path, PathBuf},
@@ -75,9 +76,6 @@ pub struct Config {
     /// `upstream` entries and consumed by the `/~<name>/` serving and route
     /// classification.
     pub upstreams: IndexMap<String, UpstreamConfig>,
-    /// Optional static group memberships used by named access tokens in
-    /// package policies and upstream aliases.
-    pub groups: AccessGroups,
     /// How long a cached packument is considered fresh before it is
     /// re-fetched from the resolved upstream. Ignored when no upstream
     /// matches.
@@ -703,6 +701,7 @@ impl TokenEnv {
 fn resolve_upstream_config<Sys: EnvVar>(
     name: &str,
     file: UpstreamConfigFile,
+    teams: &Teams,
 ) -> Result<UpstreamConfig, RegistryError> {
     let mut headers = HeaderMap::new();
     if let Some(auth) = &file.auth {
@@ -753,12 +752,11 @@ fn resolve_upstream_config<Sys: EnvVar>(
     let timeout = parse_field("timeout", &file.timeout)?.unwrap_or(UpstreamConfig::DEFAULT_TIMEOUT);
     let fail_timeout = parse_field("fail_timeout", &file.fail_timeout)?
         .unwrap_or(UpstreamConfig::DEFAULT_FAIL_TIMEOUT);
-    let access =
-        file.access.as_ref().map(AccessSpec::to_access_list).transpose().map_err(|reason| {
-            RegistryError::InvalidConfig {
-                reason: format!("upstream {name:?} has an invalid `access` list: {reason}"),
-            }
-        })?;
+    let access = file.access.as_ref().map(|spec| spec.to_access_list(teams)).transpose().map_err(
+        |reason| RegistryError::InvalidConfig {
+            reason: format!("upstream {name:?} has an invalid `access` list: {reason}"),
+        },
+    )?;
 
     Ok(UpstreamConfig {
         url: file.url,
@@ -848,10 +846,11 @@ fn non_empty_token(token: &str) -> Option<String> {
 
 /// One `packages:` map value: `access` / `publish` / `unpublish` are
 /// permission lists (the built-in `$all` / `$authenticated` / `$anonymous`
-/// pseudo-groups, plus usernames / group names), compiled into the owning
-/// registry's [`PackageRules`]. An omitted field falls back to the
-/// registry-level default. The map key set doubles as the registry's declared
-/// namespace, so one declaration routes, filters, and authorizes.
+/// pseudo-groups, bare usernames, and `team:<name>` references to the owning
+/// registry's declared teams), compiled into the owning registry's
+/// [`PackageRules`]. An omitted field falls back to the registry-level
+/// default. The map key set doubles as the registry's declared namespace, so
+/// one declaration routes, filters, and authorizes.
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PackageAccess {
@@ -884,17 +883,33 @@ impl AccessSpec {
     }
 
     /// Compile into an [`AccessList`], rejecting any entry that is not a
-    /// single well-formed token ([`validate_access_token`]). The returned
-    /// error is the reason only; the caller prefixes the registry/field
-    /// context it alone knows.
-    fn to_access_list(&self) -> Result<AccessList, String> {
+    /// single well-formed token ([`validate_access_token`]) and resolving
+    /// `team:` references against the owning registry's declared `teams` —
+    /// an undeclared team is an error, so a typo cannot silently become a
+    /// grant to nobody. The returned error is the reason only; the caller
+    /// prefixes the registry/field context it alone knows.
+    fn to_access_list(&self, teams: &Teams) -> Result<AccessList, String> {
+        let mut tokens = Vec::with_capacity(self.entries().len());
         for entry in self.entries() {
             validate_access_token(entry)?;
+            tokens.push(match entry.strip_prefix("team:") {
+                Some(team) => {
+                    let members = teams.get(team).ok_or_else(|| {
+                        format!(
+                            "access token {entry:?} references a team this registry does not \
+                             declare{}",
+                            declared_teams(teams),
+                        )
+                    })?;
+                    AccessToken::Team { name: team.to_string(), members: members.clone() }
+                }
+                None => AccessToken::from(entry.as_str()),
+            });
         }
-        Ok(AccessList::from_tokens(self.entries()))
+        Ok(AccessList::new(tokens))
     }
 
-    /// The `groups:` membership reading: each entry is one username, in
+    /// The `teams:` membership reading: each entry is one username, in
     /// declared order. Unlike [`Self::to_access_list`] the entries are not
     /// access tokens — usernames get shape validation only.
     fn member_names(&self) -> Result<&[String], String> {
@@ -905,11 +920,64 @@ impl AccessSpec {
     }
 }
 
+/// A registry's declared teams — its `teams:` map compiled to name →
+/// member-set. Only alive while that registry's access lists are compiled:
+/// a `team:` token captures the member set, so nothing at runtime consults
+/// the map (see [`AccessToken::Team`]).
+type Teams = IndexMap<String, BTreeSet<String>>;
+
+/// The declared team names for an undeclared-reference error, so a typo'd
+/// `team:` token points at what exists.
+fn declared_teams(teams: &Teams) -> String {
+    if teams.is_empty() {
+        return " (it declares no `teams:`)".to_string();
+    }
+    let names = teams.keys().map(|name| format!("{name:?}")).collect::<Vec<_>>().join(", ");
+    format!("; its declared teams are {names}")
+}
+
+/// Compile one registry's `teams:` map, validating team names (they must be
+/// writable after `team:` in a token) and member lists.
+fn build_teams(
+    registry: &str,
+    file: &IndexMap<String, AccessSpec>,
+) -> Result<Teams, RegistryError> {
+    let mut teams = Teams::default();
+    for (team, members) in file {
+        validate_team_name(team).map_err(|reason| RegistryError::InvalidConfig {
+            reason: format!("registry {registry:?} has an invalid team name: {reason}"),
+        })?;
+        let members = members.member_names().map_err(|reason| RegistryError::InvalidConfig {
+            reason: format!(
+                "registry {registry:?} team {team:?} has an invalid member list: {reason}",
+            ),
+        })?;
+        teams.insert(team.clone(), members.iter().cloned().collect());
+    }
+    Ok(teams)
+}
+
+/// A team name is only useful spliced into a `team:<name>` token, so it must
+/// survive that grammar: one token, no `:` (which would read as another
+/// prefix), no `$` sigil (reserved for the built-in groups).
+fn validate_team_name(team: &str) -> Result<(), String> {
+    validate_single_token(team)?;
+    if team.contains(':') || team.starts_with('$') {
+        return Err(format!(
+            "team name {team:?} cannot contain `:` or start with `$`; it is referenced from \
+             access lists as `team:{team}`",
+        ));
+    }
+    Ok(())
+}
+
 /// Reject an access-list entry that is not exactly one recognized token: an
-/// unknown `$…` built-in, or one of verdaccio's alias spellings of the
-/// built-ins (`@all`, bare `all`, …), which must not silently become a
-/// user/group name that admits nobody. This loud rejection at the YAML
-/// boundary is what lets `AccessToken` parsing stay infallible.
+/// unknown `$…` built-in, an unknown `<type>:` prefix (only `team:` exists;
+/// htpasswd forbids `:` in usernames, so the character is free to reserve),
+/// or one of verdaccio's alias spellings of the built-ins (`@all`, bare
+/// `all`, …), which must not silently become a username that admits nobody.
+/// This loud rejection at the YAML boundary is what lets `AccessToken`
+/// parsing stay infallible.
 fn validate_access_token(token: &str) -> Result<(), String> {
     validate_single_token(token)?;
     if let Some(builtin) = token.strip_prefix('$') {
@@ -920,6 +988,20 @@ fn validate_access_token(token: &str) -> Result<(), String> {
             ));
         }
         return Ok(());
+    }
+    if let Some((kind, name)) = token.split_once(':') {
+        return match kind {
+            "team" if !name.is_empty() => Ok(()),
+            "team" => Err(format!("access token {token:?} names no team; write `team:<name>`")),
+            "group" | "groups" => Err(format!(
+                "unknown access token type {kind:?} in {token:?}; teams are declared per \
+                 registry — did you mean \"team:{name}\"?",
+            )),
+            _ => Err(format!(
+                "unknown access token type {kind:?} in {token:?}; the only typed token is \
+                 `team:<name>` (a bare token is a username)",
+            )),
+        };
     }
     let bare = token.strip_prefix('@').unwrap_or(token);
     if matches!(bare, "all" | "authenticated" | "anonymous") {
@@ -990,6 +1072,12 @@ struct HostedFile {
     /// no `packages:` entry refines it. Omitted ⇒ `$all`.
     #[serde(default)]
     access: Option<AccessSpec>,
+    /// This registry's teams: each key is a team name, each value the list
+    /// of member usernames. Referenced from this registry's access lists as
+    /// `team:<name>` — teams are registry-scoped, never shared across
+    /// registries (YAML anchors cover a shared roster in one file).
+    #[serde(default)]
+    teams: IndexMap<String, AccessSpec>,
     /// The names this registry serves and accepts publishes for — its
     /// namespace — with optional per-package `access`/`publish`/`unpublish`
     /// rules as values (`{}` or null ⇒ the registry defaults). The most
@@ -1028,6 +1116,10 @@ struct UpstreamFile {
     /// non-`public` upstream (otherwise no one could be authorized to use it).
     #[serde(default)]
     access: Option<AccessSpec>,
+    /// This registry's teams, exactly as on a hosted registry — referenced
+    /// from `access` and the per-package refinements as `team:<name>`.
+    #[serde(default)]
+    teams: IndexMap<String, AccessSpec>,
     /// The names that may be requested through this registry — its namespace —
     /// with optional per-package `access` refinements as values (`{}` or null
     /// ⇒ the registry default; a `publish`/`unpublish` value is a config
@@ -1098,12 +1190,15 @@ struct ConfigFile {
     /// quietly open up on upgrade. Presence-detected through a custom
     /// deserializer because a plain `Option` maps a *bare* `packages:`
     /// (YAML null) to `None`, which would slip past the rejection.
-    #[serde(default, deserialize_with = "detect_removed_packages_block")]
+    #[serde(default, deserialize_with = "detect_removed_block")]
     packages: Option<RemovedPackagesBlock>,
-    /// pnpr-only static groups: each key is a group/team name and each
-    /// value is the list of pnpr usernames in that group.
-    #[serde(default)]
-    groups: IndexMap<String, AccessSpec>,
+    /// The removed top-level `groups:` block, kept only to *reject* it
+    /// loudly. Teams are declared per registry (`registries.<name>.teams`)
+    /// and referenced as `team:<name>`; a config still carrying the global
+    /// block previously granted access through its group names, so it must
+    /// be migrated, not silently dropped.
+    #[serde(default, deserialize_with = "detect_removed_block")]
+    groups: Option<RemovedGroupsBlock>,
     /// pnpr-only: which fetch routes the resolution cache treats as
     /// public. Absent on a stock verdaccio config (built-in defaults
     /// apply).
@@ -1124,21 +1219,24 @@ struct ConfigFile {
 }
 
 /// Marker for a present top-level `packages:` key, whatever its value.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct RemovedPackagesBlock;
 
-/// `Some` whenever the `packages:` key is present — including `packages:`
-/// with no value (YAML null), which `Option<IgnoredAny>` would map to
-/// `None` and let slip past the loud rejection. The value itself is
-/// consumed and discarded; only presence matters.
-fn detect_removed_packages_block<'de, De>(
-    deserializer: De,
-) -> Result<Option<RemovedPackagesBlock>, De::Error>
+/// Marker for a present top-level `groups:` key, whatever its value.
+#[derive(Debug, Default)]
+struct RemovedGroupsBlock;
+
+/// `Some` whenever the key is present — including a key with no value
+/// (YAML null), which `Option<IgnoredAny>` would map to `None` and let
+/// slip past the loud rejection. The value itself is consumed and
+/// discarded; only presence matters.
+fn detect_removed_block<'de, De, Marker>(deserializer: De) -> Result<Option<Marker>, De::Error>
 where
     De: serde::Deserializer<'de>,
+    Marker: Default,
 {
     serde::de::IgnoredAny::deserialize(deserializer)?;
-    Ok(Some(RemovedPackagesBlock))
+    Ok(Some(Marker::default()))
 }
 
 /// The YAML `log:` object. Mirrors verdaccio 6's logger config.
@@ -1348,7 +1446,6 @@ impl Config {
             cache_storage: default_cache_dir(&storage),
             storage,
             upstreams,
-            groups: AccessGroups::default(),
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
             auth: AuthConfig::default(),
             logs: LogConfig::default(),
@@ -1393,7 +1490,6 @@ impl Config {
             cache_storage: default_cache_dir(&storage),
             storage,
             upstreams: IndexMap::new(),
-            groups: AccessGroups::default(),
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
             auth: AuthConfig::default(),
             logs: LogConfig::default(),
@@ -1611,16 +1707,24 @@ impl Config {
         let public_url = public_url.unwrap_or_else(|| format!("http://{listen}"));
         let auth = build_auth_config(&file.auth, base_dir);
         let logs = build_log_config(file.log.as_ref());
-        let groups = build_groups(&file.groups)?;
-        // The global ACL block is gone, not ignorable: it used to *enforce*
-        // access, so dropping it like an unknown verdaccio key would silently
-        // open previously-gated packages on upgrade. Fail loudly instead,
-        // naming the replacement.
+        // The global ACL and group blocks are gone, not ignorable: they used
+        // to *enforce* and *grant* access, so dropping either like an unknown
+        // verdaccio key would silently change who may reach what on upgrade.
+        // Fail loudly instead, naming the replacement.
         if file.packages.is_some() {
             return Err(RegistryError::InvalidConfig {
                 reason: "the top-level `packages:` block was removed: declare per-package rules \
                          on the registry that serves them, as `registries.<name>.packages` \
                          (pattern keys, `access`/`publish`/`unpublish` values)"
+                    .to_string(),
+            });
+        }
+        if file.groups.is_some() {
+            return Err(RegistryError::InvalidConfig {
+                reason: "the top-level `groups:` block was removed: declare teams on the \
+                         registry that uses them, as `registries.<name>.teams` (team-name keys, \
+                         member-list values), and reference them from that registry's access \
+                         lists as `team:<name>`"
                     .to_string(),
             });
         }
@@ -1658,7 +1762,6 @@ impl Config {
             storage,
             cache_storage,
             upstreams,
-            groups,
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
             auth,
             logs,
@@ -1793,13 +1896,6 @@ impl Config {
         }
         self.registries.validate().map_err(|err| registry_err(&err))
     }
-
-    /// Build the caller identity used by access policies after a bearer
-    /// token has authenticated `username`.
-    #[must_use]
-    pub fn identity_for_user(&self, username: impl Into<String>) -> Identity {
-        self.groups.identity_for(username.into())
-    }
 }
 
 /// Build the runtime [`AuthConfig`] from the YAML `auth:` block.
@@ -1888,8 +1984,9 @@ fn build_registries(
                 {
                     return Err(org_collision_error(&name, &registry.org, other));
                 }
-                let access = registry_access_list(&name, registry.access.as_ref())?;
-                let rules = build_rules(&name, &registry.packages, access)?;
+                let teams = build_teams(&name, &registry.teams)?;
+                let access = registry_access_list(&name, registry.access.as_ref(), &teams)?;
+                let rules = build_rules(&name, &registry.packages, access, &teams)?;
                 let patterns = rules.patterns();
                 hosted.insert(name.clone(), HostedConfig { org: registry.org, rules });
                 graph.insert(name, Registry::Hosted { patterns });
@@ -1901,8 +1998,9 @@ fn build_registries(
                 // carries the namespace on every tier, and so a
                 // `publish`/`unpublish` value — a write rule on a registry no
                 // write can land on — fails startup on every tier too.
-                let access = registry_access_list(&name, upstream.access.as_ref())?;
-                let rules = build_rules(&name, &upstream.packages, access)?;
+                let teams = build_teams(&name, &upstream.teams)?;
+                let access = registry_access_list(&name, upstream.access.as_ref(), &teams)?;
+                let rules = build_rules(&name, &upstream.packages, access, &teams)?;
                 if rules.refines_writes() {
                     return Err(RegistryError::InvalidConfig {
                         reason: format!(
@@ -1913,7 +2011,8 @@ fn build_registries(
                 }
                 let patterns = rules.patterns();
                 if resolve_upstreams {
-                    let mut resolved = resolve_upstream_registry::<SystemEnv>(&name, *upstream)?;
+                    let mut resolved =
+                        resolve_upstream_registry::<SystemEnv>(&name, *upstream, &teams)?;
                     resolved.rules = rules;
                     upstreams.insert(name.clone(), resolved);
                 }
@@ -1947,8 +2046,9 @@ fn org_collision_error(name: &str, org: &str, other: &str) -> RegistryError {
 fn registry_access_list(
     name: &str,
     spec: Option<&AccessSpec>,
+    teams: &Teams,
 ) -> Result<Option<AccessList>, RegistryError> {
-    spec.map(AccessSpec::to_access_list).transpose().map_err(|reason| {
+    spec.map(|spec| spec.to_access_list(teams)).transpose().map_err(|reason| {
         RegistryError::InvalidConfig {
             reason: format!("registry {name:?} has an invalid `access` list: {reason}"),
         }
@@ -2011,6 +2111,7 @@ fn build_rules(
     registry: &str,
     packages: &IndexMap<String, Option<PackageAccess>>,
     default_access: Option<AccessList>,
+    teams: &Teams,
 ) -> Result<PackageRules, RegistryError> {
     let rules = packages
         .iter()
@@ -2020,7 +2121,7 @@ fn build_rules(
             })?;
             let fields = rule.as_ref();
             let list = |field: &str, spec: Option<&AccessSpec>| {
-                spec.map(AccessSpec::to_access_list).transpose().map_err(|reason| {
+                spec.map(|spec| spec.to_access_list(teams)).transpose().map_err(|reason| {
                     RegistryError::InvalidConfig {
                         reason: format!(
                             "registry {registry:?}: {key:?} has an invalid `{field}` list: {reason}",
@@ -2047,6 +2148,7 @@ fn build_rules(
 fn resolve_upstream_registry<Sys: EnvVar>(
     name: &str,
     file: UpstreamFile,
+    teams: &Teams,
 ) -> Result<UpstreamConfig, RegistryError> {
     // A public origin is anonymous and shared, so every credential-bearing or
     // access-gating knob contradicts `public: true` and must fail closed rather
@@ -2100,31 +2202,7 @@ fn resolve_upstream_registry<Sys: EnvVar>(
         cache: file.cache,
         access,
     };
-    resolve_upstream_config::<Sys>(name, upstream_config_file)
-}
-
-fn build_groups(file: &IndexMap<String, AccessSpec>) -> Result<AccessGroups, RegistryError> {
-    let mut groups = AccessGroups::default();
-    for (group, members) in file {
-        // A group is only useful as a `Named` token in access lists, so its
-        // name gets the same validation as a token — a name that shadows a
-        // built-in or could never be written in a list must not be declared.
-        validate_access_token(group)
-            .and_then(|()| match AccessToken::from(group.as_str()) {
-                AccessToken::Named(_) => Ok(()),
-                _ => Err(format!("group name {group:?} shadows a built-in access token")),
-            })
-            .map_err(|reason| RegistryError::InvalidConfig {
-                reason: format!("invalid `groups` name: {reason}"),
-            })?;
-        let members = members.member_names().map_err(|reason| RegistryError::InvalidConfig {
-            reason: format!("group {group:?} has an invalid member list: {reason}"),
-        })?;
-        for username in members {
-            groups.add_user_to_group(username, group);
-        }
-    }
-    Ok(groups)
+    resolve_upstream_config::<Sys>(name, upstream_config_file, teams)
 }
 
 /// Minimum length for an operator-configured `secret:`. A shorter value makes

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1938,10 +1938,21 @@ fn team_declarations_are_validated() {
     // grammar cannot express is rejected at declaration.
     let sigil_name = "    teams:\n      $all: [alice]\n";
     let colon_name = "    teams:\n      'a:b': [alice]\n";
+    // A member is a plain username: a built-in group — in any spelling —
+    // would silently become a user nobody is named after, and a `team:`
+    // reference would be an unsupported nested team.
+    let builtin_member = "    teams:\n      platform: [$all]\n";
+    let alias_member = "    teams:\n      platform: [authenticated]\n";
+    let at_alias_member = "    teams:\n      platform: ['@all']\n";
+    let nested_team_member = "    teams:\n      platform: ['team:release']\n";
     for (teams, needle) in [
         (split_members, r#""alice bob""#),
         (sigil_name, "cannot contain `:` or start with `$`"),
         (colon_name, "cannot contain `:` or start with `$`"),
+        (builtin_member, "built-in groups belong in the access lists"),
+        (alias_member, "built-in groups belong in the access lists"),
+        (at_alias_member, "built-in groups belong in the access lists"),
+        (nested_team_member, "cannot include another team"),
     ] {
         let yaml = format!("storage: ./s\nregistries:\n  local:\n    type: hosted\n{teams}");
         let err = Config::from_yaml_str(&yaml, Path::new("/x"), listen(), None).unwrap_err();
@@ -1963,6 +1974,7 @@ fn typed_token_grammar_is_validated() {
         ("group:platform", r#"did you mean "team:platform""#),
         ("org:corp", "the only typed token is `team:<name>`"),
         ("'team:'", "names no team"),
+        ("team:a:b", "a team name cannot contain `:`"),
     ] {
         let err = hosted_rules_err(&format!("      '@team/*':\n        access: {token}\n"));
         assert!(

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1786,7 +1786,7 @@ registries:
         matches!(
             &err,
             RegistryError::InvalidConfig { reason }
-                if reason.contains("registry \"corp\"")
+                if reason.contains(r#"registry "corp""#)
                     && reason.contains("does not declare")
                     && reason.contains("no `teams:`"),
         ),
@@ -1833,7 +1833,7 @@ registries:
             &err,
             RegistryError::InvalidConfig { reason }
                 if reason.contains("team:platfrom")
-                    && reason.contains("\"platform\", \"release\""),
+                    && reason.contains(r#""platform", "release""#),
         ),
         "unexpected error: {err}",
     );
@@ -1861,7 +1861,7 @@ fn rule_space_separated_access_list_is_a_config_error() {
             matches!(
                 &err,
                 RegistryError::InvalidConfig { reason }
-                    if reason.contains("\"alice bob\"") && reason.contains("[alice, bob]"),
+                    if reason.contains(r#""alice bob""#) && reason.contains("[alice, bob]"),
             ),
             "unexpected error for {packages:?}: {err}",
         );
@@ -1903,7 +1903,7 @@ fn rule_unknown_builtin_token_is_a_config_error() {
         matches!(
             &err,
             RegistryError::InvalidConfig { reason }
-                if reason.contains("unknown built-in access token \"$team\""),
+                if reason.contains(r#"unknown built-in access token "$team""#),
         ),
         "unexpected error: {err}",
     );
@@ -1923,7 +1923,7 @@ registries:
         matches!(
             &err,
             RegistryError::InvalidConfig { reason }
-                if reason.contains("registry \"local\"") && reason.contains("$all"),
+                if reason.contains(r#"registry "local""#) && reason.contains("$all"),
         ),
         "unexpected error: {err}",
     );
@@ -1939,7 +1939,7 @@ fn team_declarations_are_validated() {
     let sigil_name = "    teams:\n      $all: [alice]\n";
     let colon_name = "    teams:\n      'a:b': [alice]\n";
     for (teams, needle) in [
-        (split_members, "\"alice bob\""),
+        (split_members, r#""alice bob""#),
         (sigil_name, "cannot contain `:` or start with `$`"),
         (colon_name, "cannot contain `:` or start with `$`"),
     ] {
@@ -1960,7 +1960,7 @@ fn typed_token_grammar_is_validated() {
     // Only `team:` exists as a token type; `group:` gets a pointer at it,
     // and an empty team reference is named as such.
     for (token, needle) in [
-        ("group:platform", "did you mean \"team:platform\""),
+        ("group:platform", r#"did you mean "team:platform""#),
         ("org:corp", "the only typed token is `team:<name>`"),
         ("'team:'", "names no team"),
     ] {

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1,7 +1,8 @@
 use super::{
     BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML, FeatureOverrides, HostedStoreConfig,
-    Interval, LogFormat, LogLevel, TokenEnv, UpstreamAuthFile, UpstreamAuthType, UpstreamConfig,
-    UpstreamConfigFile, config_file_in, parse_interval, resolve_relative, resolve_upstream_config,
+    Interval, LogFormat, LogLevel, Teams, TokenEnv, UpstreamAuthFile, UpstreamAuthType,
+    UpstreamConfig, UpstreamConfigFile, config_file_in, parse_interval, resolve_relative,
+    resolve_upstream_config,
 };
 use crate::{error::RegistryError, policy::Identity};
 use indexmap::IndexMap;
@@ -50,6 +51,12 @@ fn auth_header(upstream: &super::UpstreamConfig) -> Option<&str> {
     upstream.headers.get(AUTHORIZATION).map(|value| value.to_str().unwrap())
 }
 
+/// [`resolve_upstream_config`] with no declared teams, as every serving-knob
+/// case here has.
+fn resolve_upstream(name: &str, file: UpstreamConfigFile) -> Result<UpstreamConfig, RegistryError> {
+    resolve_upstream_config::<FakeEnv>(name, file, &Teams::default())
+}
+
 #[test]
 fn upstream_bearer_token_becomes_bearer_authorization() {
     let auth = UpstreamAuthFile {
@@ -57,11 +64,8 @@ fn upstream_bearer_token_becomes_bearer_authorization() {
         token: Some("abc123".to_string()),
         token_env: None,
     };
-    let upstream = resolve_upstream_config::<FakeEnv>(
-        "npmjs",
-        upstream_config_file(Some(auth), IndexMap::new()),
-    )
-    .expect("bearer token resolves");
+    let upstream = resolve_upstream("npmjs", upstream_config_file(Some(auth), IndexMap::new()))
+        .expect("bearer token resolves");
     assert_eq!(auth_header(&upstream), Some("Bearer abc123"));
 }
 
@@ -72,11 +76,8 @@ fn upstream_basic_token_becomes_basic_authorization_verbatim() {
         token: Some("dXNlcjpwYXNz".to_string()),
         token_env: None,
     };
-    let upstream = resolve_upstream_config::<FakeEnv>(
-        "priv",
-        upstream_config_file(Some(auth), IndexMap::new()),
-    )
-    .expect("basic token resolves");
+    let upstream = resolve_upstream("priv", upstream_config_file(Some(auth), IndexMap::new()))
+        .expect("basic token resolves");
     assert_eq!(auth_header(&upstream), Some("Basic dXNlcjpwYXNz"));
 }
 
@@ -87,11 +88,8 @@ fn upstream_token_env_true_reads_npm_token() {
         token: None,
         token_env: Some(TokenEnv::Flag(true)),
     };
-    let upstream = resolve_upstream_config::<FakeEnv>(
-        "npmjs",
-        upstream_config_file(Some(auth), IndexMap::new()),
-    )
-    .expect("token_env: true reads NPM_TOKEN");
+    let upstream = resolve_upstream("npmjs", upstream_config_file(Some(auth), IndexMap::new()))
+        .expect("token_env: true reads NPM_TOKEN");
     assert_eq!(auth_header(&upstream), Some("Bearer default-env-token"));
 }
 
@@ -102,11 +100,8 @@ fn upstream_token_env_named_reads_that_var() {
         token: None,
         token_env: Some(TokenEnv::Named("CUSTOM_TOKEN".to_string())),
     };
-    let upstream = resolve_upstream_config::<FakeEnv>(
-        "npmjs",
-        upstream_config_file(Some(auth), IndexMap::new()),
-    )
-    .expect("named token_env reads that var");
+    let upstream = resolve_upstream("npmjs", upstream_config_file(Some(auth), IndexMap::new()))
+        .expect("named token_env reads that var");
     assert_eq!(auth_header(&upstream), Some("Bearer custom-env-token"));
 }
 
@@ -117,18 +112,15 @@ fn upstream_literal_token_beats_token_env() {
         token: Some("literal".to_string()),
         token_env: Some(TokenEnv::Named("CUSTOM_TOKEN".to_string())),
     };
-    let upstream = resolve_upstream_config::<FakeEnv>(
-        "npmjs",
-        upstream_config_file(Some(auth), IndexMap::new()),
-    )
-    .expect("literal token wins");
+    let upstream = resolve_upstream("npmjs", upstream_config_file(Some(auth), IndexMap::new()))
+        .expect("literal token wins");
     assert_eq!(auth_header(&upstream), Some("Bearer literal"));
 }
 
 #[test]
 fn upstream_custom_headers_are_forwarded() {
     let headers = IndexMap::from_iter([("x-custom".to_string(), "value".to_string())]);
-    let upstream = resolve_upstream_config::<FakeEnv>("npmjs", upstream_config_file(None, headers))
+    let upstream = resolve_upstream("npmjs", upstream_config_file(None, headers))
         .expect("custom headers resolve");
     assert_eq!(upstream.headers.get("x-custom").unwrap().to_str().unwrap(), "value");
     assert!(auth_header(&upstream).is_none());
@@ -143,9 +135,8 @@ fn upstream_custom_authorization_header_overrides_auth_block() {
     };
     let headers =
         IndexMap::from_iter([("authorization".to_string(), "Basic override".to_string())]);
-    let upstream =
-        resolve_upstream_config::<FakeEnv>("npmjs", upstream_config_file(Some(auth), headers))
-            .expect("custom header overrides auth-derived one");
+    let upstream = resolve_upstream("npmjs", upstream_config_file(Some(auth), headers))
+        .expect("custom header overrides auth-derived one");
     assert_eq!(auth_header(&upstream), Some("Basic override"));
 }
 
@@ -156,11 +147,8 @@ fn upstream_auth_without_resolvable_token_is_a_config_error() {
         token: None,
         token_env: Some(TokenEnv::Named("UNSET_VAR".to_string())),
     };
-    let err = resolve_upstream_config::<FakeEnv>(
-        "npmjs",
-        upstream_config_file(Some(auth), IndexMap::new()),
-    )
-    .expect_err("missing token must error");
+    let err = resolve_upstream("npmjs", upstream_config_file(Some(auth), IndexMap::new()))
+        .expect_err("missing token must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
 }
 
@@ -171,11 +159,8 @@ fn upstream_auth_with_empty_literal_token_is_a_config_error() {
         token: Some(String::new()),
         token_env: None,
     };
-    let err = resolve_upstream_config::<FakeEnv>(
-        "npmjs",
-        upstream_config_file(Some(auth), IndexMap::new()),
-    )
-    .expect_err("an empty token must error");
+    let err = resolve_upstream("npmjs", upstream_config_file(Some(auth), IndexMap::new()))
+        .expect_err("an empty token must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
 }
 
@@ -186,11 +171,8 @@ fn upstream_auth_with_empty_env_token_is_a_config_error() {
         token: None,
         token_env: Some(TokenEnv::Named("EMPTY_TOKEN".to_string())),
     };
-    let err = resolve_upstream_config::<FakeEnv>(
-        "npmjs",
-        upstream_config_file(Some(auth), IndexMap::new()),
-    )
-    .expect_err("an empty env token must error");
+    let err = resolve_upstream("npmjs", upstream_config_file(Some(auth), IndexMap::new()))
+        .expect_err("an empty env token must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
 }
 
@@ -201,11 +183,8 @@ fn upstream_token_env_false_resolves_no_token_and_is_a_config_error() {
         token: None,
         token_env: Some(TokenEnv::Flag(false)),
     };
-    let err = resolve_upstream_config::<FakeEnv>(
-        "npmjs",
-        upstream_config_file(Some(auth), IndexMap::new()),
-    )
-    .expect_err("token_env: false reads nothing, so an auth block must error");
+    let err = resolve_upstream("npmjs", upstream_config_file(Some(auth), IndexMap::new()))
+        .expect_err("token_env: false reads nothing, so an auth block must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
 }
 
@@ -216,18 +195,15 @@ fn upstream_auth_token_with_control_char_is_a_config_error() {
         token: Some("bad\ntoken".to_string()),
         token_env: None,
     };
-    let err = resolve_upstream_config::<FakeEnv>(
-        "npmjs",
-        upstream_config_file(Some(auth), IndexMap::new()),
-    )
-    .expect_err("a token that is not a valid header value must error");
+    let err = resolve_upstream("npmjs", upstream_config_file(Some(auth), IndexMap::new()))
+        .expect_err("a token that is not a valid header value must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
 }
 
 #[test]
 fn upstream_invalid_custom_header_name_is_a_config_error() {
     let headers = IndexMap::from_iter([("bad header".to_string(), "value".to_string())]);
-    let err = resolve_upstream_config::<FakeEnv>("npmjs", upstream_config_file(None, headers))
+    let err = resolve_upstream("npmjs", upstream_config_file(None, headers))
         .expect_err("a header name with a space must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
 }
@@ -235,7 +211,7 @@ fn upstream_invalid_custom_header_name_is_a_config_error() {
 #[test]
 fn upstream_invalid_custom_header_value_is_a_config_error() {
     let headers = IndexMap::from_iter([("x-custom".to_string(), "bad\nvalue".to_string())]);
-    let err = resolve_upstream_config::<FakeEnv>("npmjs", upstream_config_file(None, headers))
+    let err = resolve_upstream("npmjs", upstream_config_file(None, headers))
         .expect_err("a header value with a control char must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
 }
@@ -1747,30 +1723,30 @@ fn rule_usernames_grant_per_user_access() {
 }
 
 #[test]
-fn groups_grant_package_and_alias_access() {
+fn teams_grant_package_and_upstream_access() {
     let yaml = r"
-groups:
-  platform: [alice, bob]
-  release:
-    - carol
 registries:
   local:
     type: hosted
+    teams:
+      platform: [alice, bob]
     packages:
       '@team/*':
-        access: platform
+        access: team:platform
   corp:
     type: upstream
     url: https://npm.corp.example/
-    access: platform
+    teams:
+      partners: [alice]
+    access: team:partners
     auth:
       type: bearer
       token: corp-token
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-    let alice = config.identity_for_user("alice");
-    let bob = config.identity_for_user("bob");
-    let carol = config.identity_for_user("carol");
+    let alice = Identity::user("alice");
+    let bob = Identity::user("bob");
+    let carol = Identity::user("carol");
 
     let rules = &config.hosted["local"].rules;
     let team = rules.for_package("@team/widget");
@@ -1781,8 +1757,86 @@ registries:
 
     let access = config.upstreams["corp"].access.as_ref().expect("upstream declares access");
     assert!(access.allows(&alice));
-    assert!(access.allows(&bob));
-    assert!(!access.allows(&carol));
+    assert!(!access.allows(&bob));
+}
+
+#[test]
+fn teams_are_scoped_to_their_registry() {
+    // `corp` cannot reference `local`'s team: an access list resolves only
+    // against the owning registry's `teams:` map, so cross-registry reuse
+    // is a loud config error (share a roster with a YAML anchor instead).
+    let yaml = r"
+registries:
+  local:
+    type: hosted
+    teams:
+      platform: [alice]
+    packages:
+      '@team/*':
+        access: team:platform
+  corp:
+    type: hosted
+    org: corp
+    packages:
+      '@corp/*':
+        access: team:platform
+";
+    let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap_err();
+    assert!(
+        matches!(
+            &err,
+            RegistryError::InvalidConfig { reason }
+                if reason.contains("registry \"corp\"")
+                    && reason.contains("does not declare")
+                    && reason.contains("no `teams:`"),
+        ),
+        "unexpected error: {err}",
+    );
+}
+
+#[test]
+fn bare_token_matching_a_team_name_stays_a_username() {
+    // A bare token is a username even when a team of the same name exists;
+    // only the explicit `team:` form reaches the member set.
+    let yaml = r"
+registries:
+  local:
+    type: hosted
+    teams:
+      platform: [alice]
+    packages:
+      '@team/*':
+        access: platform
+";
+    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+    let access = config.hosted["local"].rules.for_package("@team/x").access;
+    assert!(access.allows(&Identity::user("platform")));
+    assert!(!access.allows(&Identity::user("alice")));
+}
+
+#[test]
+fn undeclared_team_reference_names_the_declared_teams() {
+    let yaml = r"
+registries:
+  local:
+    type: hosted
+    teams:
+      platform: [alice]
+      release: [carol]
+    packages:
+      '@team/*':
+        access: team:platfrom
+";
+    let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap_err();
+    assert!(
+        matches!(
+            &err,
+            RegistryError::InvalidConfig { reason }
+                if reason.contains("team:platfrom")
+                    && reason.contains("\"platform\", \"release\""),
+        ),
+        "unexpected error: {err}",
+    );
 }
 
 #[test]
@@ -1876,20 +1930,20 @@ registries:
 }
 
 #[test]
-fn group_declarations_are_validated() {
-    // A group member list is one username per entry — never a
+fn team_declarations_are_validated() {
+    // A team member list is one username per entry — never a
     // space-separated string.
-    let split_members = "groups:\n  platform: alice bob\n";
-    // A group named like a built-in (or its alias spellings) could never
-    // be referenced from an access list, so declaring one is an error.
-    let reserved_name = "groups:\n  authenticated: [alice]\n";
-    let builtin_name = "groups:\n  $all: [alice]\n";
-    for (yaml, needle) in [
+    let split_members = "    teams:\n      platform: alice bob\n";
+    // A team name is spliced into `team:<name>` tokens, so a name the
+    // grammar cannot express is rejected at declaration.
+    let sigil_name = "    teams:\n      $all: [alice]\n";
+    let colon_name = "    teams:\n      'a:b': [alice]\n";
+    for (teams, needle) in [
         (split_members, "\"alice bob\""),
-        (reserved_name, "did you mean"),
-        (builtin_name, "shadows a built-in"),
+        (sigil_name, "cannot contain `:` or start with `$`"),
+        (colon_name, "cannot contain `:` or start with `$`"),
     ] {
-        let yaml = format!("storage: ./s\nregistries:\n  local:\n    type: hosted\n{yaml}");
+        let yaml = format!("storage: ./s\nregistries:\n  local:\n    type: hosted\n{teams}");
         let err = Config::from_yaml_str(&yaml, Path::new("/x"), listen(), None).unwrap_err();
         assert!(
             matches!(
@@ -1897,6 +1951,47 @@ fn group_declarations_are_validated() {
                 RegistryError::InvalidConfig { reason } if reason.contains(needle),
             ),
             "unexpected error for {yaml:?}: {err}",
+        );
+    }
+}
+
+#[test]
+fn typed_token_grammar_is_validated() {
+    // Only `team:` exists as a token type; `group:` gets a pointer at it,
+    // and an empty team reference is named as such.
+    for (token, needle) in [
+        ("group:platform", "did you mean \"team:platform\""),
+        ("org:corp", "the only typed token is `team:<name>`"),
+        ("'team:'", "names no team"),
+    ] {
+        let err = hosted_rules_err(&format!("      '@team/*':\n        access: {token}\n"));
+        assert!(
+            matches!(
+                &err,
+                RegistryError::InvalidConfig { reason } if reason.contains(needle),
+            ),
+            "unexpected error for {token:?}: {err}",
+        );
+    }
+}
+
+#[test]
+fn top_level_groups_block_is_a_startup_error() {
+    // The removed global block must not be silently dropped: its group
+    // names used to grant access, so a stale config must be migrated to
+    // per-registry `teams:`, not booted with silently changed grants.
+    for stub in ["groups:\n  platform: [alice]\n", "groups:\n", "groups: {}\n"] {
+        let yaml = format!("storage: ./s\nregistries:\n  local:\n    type: hosted\n{stub}");
+        let err = Config::from_yaml_str(&yaml, Path::new("/x"), listen(), None)
+            .expect_err("a present top-level groups: key must be rejected");
+        assert!(
+            matches!(
+                &err,
+                RegistryError::InvalidConfig { reason }
+                    if reason.contains("top-level `groups:`")
+                        && reason.contains("registries.<name>.teams"),
+            ),
+            "unexpected error for {stub:?}: {err}",
         );
     }
 }
@@ -2045,9 +2140,7 @@ fn parse_interval_rejects_garbage() {
 
 #[test]
 fn resolve_upstream_config_defaults_knobs_to_verdaccio_values() {
-    let upstream =
-        resolve_upstream_config::<FakeEnv>("npmjs", upstream_config_file(None, IndexMap::new()))
-            .unwrap();
+    let upstream = resolve_upstream("npmjs", upstream_config_file(None, IndexMap::new())).unwrap();
     // An unset `maxage` defers to the global packument TTL (`None` here),
     // while the rest fall back to verdaccio's documented defaults.
     assert_eq!(upstream.maxage, None);
@@ -2066,7 +2159,7 @@ fn resolve_upstream_config_parses_explicit_knobs() {
     file.max_fails = Some(5);
     file.fail_timeout = Some(Interval("1m".to_string()));
     file.cache = Some(false);
-    let upstream = resolve_upstream_config::<FakeEnv>("npmjs", file).unwrap();
+    let upstream = resolve_upstream("npmjs", file).unwrap();
     assert_eq!(upstream.maxage, Some(Duration::from_mins(10)));
     assert_eq!(upstream.timeout, Duration::from_secs(45));
     assert_eq!(upstream.max_fails, 5);
@@ -2078,7 +2171,7 @@ fn resolve_upstream_config_parses_explicit_knobs() {
 fn resolve_upstream_config_rejects_an_unparsable_interval() {
     let mut file = upstream_config_file(None, IndexMap::new());
     file.maxage = Some(Interval("whenever".to_string()));
-    let err = resolve_upstream_config::<FakeEnv>("npmjs", file).unwrap_err();
+    let err = resolve_upstream("npmjs", file).unwrap_err();
     assert!(
         matches!(err, RegistryError::InvalidConfig { reason } if reason.contains("maxage")),
         "expected an InvalidConfig naming the offending field",

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1825,14 +1825,14 @@ registries:
       release: [carol]
     packages:
       '@team/*':
-        access: team:platfrom
+        access: team:platfrm
 ";
     let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap_err();
     assert!(
         matches!(
             &err,
             RegistryError::InvalidConfig { reason }
-                if reason.contains("team:platfrom")
+                if reason.contains("team:platfrm")
                     && reason.contains(r#""platform", "release""#),
         ),
         "unexpected error: {err}",

--- a/pnpr/crates/pnpr/src/config/tests.rs
+++ b/pnpr/crates/pnpr/src/config/tests.rs
@@ -1605,6 +1605,15 @@ fn hosted_rules_config(packages: &str) -> Config {
     Config::from_yaml_str(&yaml, Path::new("/x"), listen(), None).unwrap()
 }
 
+/// The same one-hosted-registry config as [`hosted_rules_config`], for
+/// the `packages:` fragments that must fail to load.
+fn hosted_rules_err(packages: &str) -> RegistryError {
+    let yaml = format!(
+        "storage: ./s\nregistries:\n  local:\n    type: hosted\n    packages:\n{packages}",
+    );
+    Config::from_yaml_str(&yaml, Path::new("/x"), listen(), None).unwrap_err()
+}
+
 #[test]
 fn rules_are_derived_from_the_registry_packages_map() {
     // The `access` / `publish` tokens in each entry drive the runtime
@@ -1688,17 +1697,30 @@ fn rule_missing_unpublish_denies_destructive_writes() {
 #[test]
 fn rule_empty_unpublish_denies_destructive_writes() {
     let as_null = "      '@team/*':\n        publish: $authenticated\n        unpublish:\n";
-    let as_empty_string =
-        "      '@team/*':\n        publish: $authenticated\n        unpublish: ''\n";
     let as_empty_sequence =
         "      '@team/*':\n        publish: $authenticated\n        unpublish: []\n";
-    for packages in [as_null, as_empty_string, as_empty_sequence] {
+    for packages in [as_null, as_empty_sequence] {
         let config = hosted_rules_config(packages);
         let team = config.hosted["local"].rules.for_package("@team/x");
         assert!(team.publish.allows(&user("alice")), "{packages}");
         assert!(!team.unpublish.allows(&Identity::Anonymous), "{packages}");
         assert!(!team.unpublish.allows(&user("alice")), "{packages}");
     }
+}
+
+#[test]
+fn rule_empty_string_value_is_a_config_error() {
+    // `''` is neither a token nor an unambiguous empty list; the error
+    // names both spellings the author could have meant.
+    let err = hosted_rules_err("      '@team/*':\n        unpublish: ''\n");
+    assert!(
+        matches!(
+            &err,
+            RegistryError::InvalidConfig { reason }
+                if reason.contains("`unpublish`") && reason.contains("use `[]`"),
+        ),
+        "unexpected error: {err}",
+    );
 }
 
 #[test]
@@ -1711,10 +1733,9 @@ fn rule_anonymous_token_is_wired() {
 
 #[test]
 fn rule_usernames_grant_per_user_access() {
-    // Bare names are usernames/groups (verdaccio-style), no longer
-    // a config error.
+    // Bare names are usernames/groups, not a config error.
     let config = hosted_rules_config(
-        "      '@team/*':\n        access: alice bob\n        publish: alice\n",
+        "      '@team/*':\n        access: [alice, bob]\n        publish: alice\n",
     );
     let team = config.hosted["local"].rules.for_package("@team/x");
     assert!(team.access.allows(&user("alice")));
@@ -1729,7 +1750,7 @@ fn rule_usernames_grant_per_user_access() {
 fn groups_grant_package_and_alias_access() {
     let yaml = r"
 groups:
-  platform: alice bob
+  platform: [alice, bob]
   release:
     - carol
 registries:
@@ -1765,17 +1786,118 @@ registries:
 }
 
 #[test]
-fn rule_access_list_accepts_string_and_sequence_forms() {
-    // verdaccio accepts both a space-separated string and a YAML
-    // sequence; they must compile to the same token list.
-    let as_string = "      '@team/*':\n        access: alice bob\n";
-    let as_sequence = "      '@team/*':\n        access: [alice, bob]\n";
-    for packages in [as_string, as_sequence] {
-        let config = hosted_rules_config(packages);
-        let access = config.hosted["local"].rules.for_package("@team/x").access;
-        assert!(access.allows(&user("alice")), "{packages}");
-        assert!(access.allows(&user("bob")), "{packages}");
-        assert!(!access.allows(&user("carol")), "{packages}");
+fn rule_scalar_access_value_is_one_token() {
+    let config = hosted_rules_config("      '@team/*':\n        access: alice\n");
+    let access = config.hosted["local"].rules.for_package("@team/x").access;
+    assert!(access.allows(&user("alice")));
+    assert!(!access.allows(&user("bob")));
+}
+
+#[test]
+fn rule_space_separated_access_list_is_a_config_error() {
+    // Verdaccio's space-separated form must not be silently misread as a
+    // single token that admits nobody; the error points at the YAML
+    // sequence spelling.
+    for packages in [
+        "      '@team/*':\n        access: alice bob\n",
+        "      '@team/*':\n        access: [alice bob]\n",
+    ] {
+        let err = hosted_rules_err(packages);
+        assert!(
+            matches!(
+                &err,
+                RegistryError::InvalidConfig { reason }
+                    if reason.contains("\"alice bob\"") && reason.contains("[alice, bob]"),
+            ),
+            "unexpected error for {packages:?}: {err}",
+        );
+    }
+}
+
+#[test]
+fn rule_alias_spellings_of_builtins_are_config_errors() {
+    // Verdaccio also accepted `@`-prefixed and bare spellings of the
+    // built-in groups. Treating them as user/group names would silently
+    // flip `access: all` from world-readable to deny-everyone, so they
+    // are rejected with the `$` spelling instead.
+    for (token, suggestion) in [
+        ("all", "$all"),
+        ("'@all'", "$all"),
+        ("authenticated", "$authenticated"),
+        ("'@authenticated'", "$authenticated"),
+        ("anonymous", "$anonymous"),
+        ("'@anonymous'", "$anonymous"),
+    ] {
+        let err = hosted_rules_err(&format!("      '@team/*':\n        access: {token}\n"));
+        assert!(
+            matches!(
+                &err,
+                RegistryError::InvalidConfig { reason }
+                    if reason.contains("did you mean") && reason.contains(suggestion),
+            ),
+            "unexpected error for {token:?}: {err}",
+        );
+    }
+}
+
+#[test]
+fn rule_unknown_builtin_token_is_a_config_error() {
+    // The `$` namespace is reserved for the built-in groups, so a typo'd
+    // built-in cannot silently become a name that admits nobody.
+    let err = hosted_rules_err("      '@team/*':\n        access: $team\n");
+    assert!(
+        matches!(
+            &err,
+            RegistryError::InvalidConfig { reason }
+                if reason.contains("unknown built-in access token \"$team\""),
+        ),
+        "unexpected error: {err}",
+    );
+}
+
+#[test]
+fn registry_level_access_list_is_validated_too() {
+    let yaml = "\
+storage: ./s
+registries:
+  local:
+    type: hosted
+    access: all
+";
+    let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap_err();
+    assert!(
+        matches!(
+            &err,
+            RegistryError::InvalidConfig { reason }
+                if reason.contains("registry \"local\"") && reason.contains("$all"),
+        ),
+        "unexpected error: {err}",
+    );
+}
+
+#[test]
+fn group_declarations_are_validated() {
+    // A group member list is one username per entry — never a
+    // space-separated string.
+    let split_members = "groups:\n  platform: alice bob\n";
+    // A group named like a built-in (or its alias spellings) could never
+    // be referenced from an access list, so declaring one is an error.
+    let reserved_name = "groups:\n  authenticated: [alice]\n";
+    let builtin_name = "groups:\n  $all: [alice]\n";
+    for (yaml, needle) in [
+        (split_members, "\"alice bob\""),
+        (reserved_name, "did you mean"),
+        (builtin_name, "shadows a built-in"),
+    ] {
+        let yaml = format!("storage: ./s\nregistries:\n  local:\n    type: hosted\n{yaml}");
+        let err = Config::from_yaml_str(&yaml, Path::new("/x"), listen(), None).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                RegistryError::InvalidConfig { reason } if reason.contains(needle),
+            ),
+            "unexpected error for {yaml:?}: {err}",
+        );
     }
 }
 
@@ -2022,7 +2144,7 @@ registries:
   corp:
     type: upstream
     url: https://npm.corp.example/
-    access: $authenticated alice
+    access: [$authenticated, alice]
     auth:
       type: bearer
       token: corp-token

--- a/pnpr/crates/pnpr/src/policy.rs
+++ b/pnpr/crates/pnpr/src/policy.rs
@@ -44,7 +44,7 @@ pub enum AccessToken {
 /// Only the `$`-sigiled spellings are built-ins; any other token is a
 /// username, which can only *narrow* access, so this stays infallible.
 /// Near-miss spellings (verdaccio's `@all`/bare aliases, an unknown
-/// `$…`) and `team:` references are handled at YAML load (`AccessSpec`
+/// `$...`) and `team:` references are handled at YAML load (`AccessSpec`
 /// in the config module): the former are rejected, the latter resolved
 /// against the registry's declared teams. A programmatic caller passing
 /// one of those spellings just gets a username that matches nobody.

--- a/pnpr/crates/pnpr/src/policy.rs
+++ b/pnpr/crates/pnpr/src/policy.rs
@@ -7,15 +7,13 @@
 //! makes that selection total: for any one name, at most one key per
 //! specificity tier can match, so every name has exactly one winning entry.
 //!
-//! Each permission is a list of tokens (verdaccio's space-separated
-//! groups); a request is allowed when the caller's identity satisfies
-//! any token in the list. Tokens are the built-in pseudo-groups
-//! (`$all`, `$authenticated`, `$anonymous`, plus their `@`/bare
-//! aliases) or a *name*. A name token matches either the authenticated
-//! username or any group attached to that identity. pnpr's static
-//! `groups:` config adds group membership on top of htpasswd users,
-//! matching verdaccio's model where access lists do not distinguish
-//! usernames from group names.
+//! Each permission is a list of tokens; a request is allowed when the
+//! caller's identity satisfies any token in the list. Tokens are the
+//! built-in pseudo-groups (`$all`, `$authenticated`, `$anonymous`) or a
+//! *name*. A name token matches either the authenticated username or
+//! any group attached to that identity — access lists do not
+//! distinguish usernames from group names. pnpr's static `groups:`
+//! config adds group membership on top of htpasswd users.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -24,44 +22,43 @@ use crate::registry::PackagePattern;
 /// A single token in an access list.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AccessToken {
-    /// `$all` / `@all` / `all` — anyone, authenticated or not.
+    /// `$all` — anyone, authenticated or not.
     All,
-    /// `$authenticated` / `@authenticated` / `authenticated` — any
-    /// caller carrying valid Bearer or Basic credentials.
+    /// `$authenticated` — any caller carrying valid Bearer or Basic
+    /// credentials.
     Authenticated,
-    /// `$anonymous` / `@anonymous` / `anonymous` — only callers
-    /// *without* valid credentials.
+    /// `$anonymous` — only callers *without* valid credentials.
     Anonymous,
     /// A username or group name. Matches an authenticated caller whose
     /// username or group membership equals it.
     Named(String),
 }
 
+/// Only the `$`-sigiled spellings are built-ins; any other token is a
+/// name, which can only *narrow* access, so this stays infallible.
+/// Near-miss spellings (verdaccio's `@all`/bare aliases, an unknown
+/// `$…`) are rejected earlier, at YAML load (`AccessSpec` in the config
+/// module) — a programmatic caller passing one just gets a name that
+/// matches nobody.
 impl From<&str> for AccessToken {
     fn from(token: &str) -> Self {
         match token {
-            "$all" | "@all" | "all" => AccessToken::All,
-            "$authenticated" | "@authenticated" | "authenticated" => AccessToken::Authenticated,
-            "$anonymous" | "@anonymous" | "anonymous" => AccessToken::Anonymous,
+            "$all" => AccessToken::All,
+            "$authenticated" => AccessToken::Authenticated,
+            "$anonymous" => AccessToken::Anonymous,
             name => AccessToken::Named(name.to_string()),
         }
     }
 }
 
 /// One `access` / `publish` permission: the set of tokens that satisfy
-/// it. An empty list admits no one (verdaccio's empty `unpublish:`).
+/// it. An empty list admits no one (an explicit `unpublish: []`).
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct AccessList(Vec<AccessToken>);
 
 impl AccessList {
-    /// Build from a verdaccio space-separated permission string
-    /// (e.g. `"$authenticated admin"`).
-    #[must_use]
-    pub fn parse(spec: &str) -> Self {
-        Self::from_tokens(spec.split_whitespace())
-    }
-
-    /// Build from already-separated tokens (e.g. a YAML sequence).
+    /// Build from individual tokens (e.g. the elements of a YAML
+    /// sequence). Each string is one token, taken verbatim.
     pub fn from_tokens<Tokens, Token>(tokens: Tokens) -> Self
     where
         Tokens: IntoIterator<Item = Token>,
@@ -268,8 +265,8 @@ impl PackageRules {
         Self {
             index: RuleIndex::build(&rules),
             rules,
-            default_access: default_access.unwrap_or_else(|| AccessList::parse("$all")),
-            default_publish: AccessList::parse("$authenticated"),
+            default_access: default_access.unwrap_or_else(|| AccessList::from_tokens(["$all"])),
+            default_publish: AccessList::from_tokens(["$authenticated"]),
             default_unpublish: AccessList::default(),
         }
     }

--- a/pnpr/crates/pnpr/src/policy.rs
+++ b/pnpr/crates/pnpr/src/policy.rs
@@ -9,11 +9,12 @@
 //!
 //! Each permission is a list of tokens; a request is allowed when the
 //! caller's identity satisfies any token in the list. Tokens are the
-//! built-in pseudo-groups (`$all`, `$authenticated`, `$anonymous`) or a
-//! *name*. A name token matches either the authenticated username or
-//! any group attached to that identity — access lists do not
-//! distinguish usernames from group names. pnpr's static `groups:`
-//! config adds group membership on top of htpasswd users.
+//! built-in pseudo-groups (`$all`, `$authenticated`, `$anonymous`), a
+//! bare *username*, or a `team:<name>` reference to a team the owning
+//! registry declares. Teams are registry-scoped — the registry is the
+//! tenant, so it owns its principal sets — and a `team:` token is
+//! resolved to the declared member set when the config is loaded, so
+//! evaluation needs only the caller's identity.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -29,24 +30,31 @@ pub enum AccessToken {
     Authenticated,
     /// `$anonymous` — only callers *without* valid credentials.
     Anonymous,
-    /// A username or group name. Matches an authenticated caller whose
-    /// username or group membership equals it.
-    Named(String),
+    /// A bare token: a username. Matches an authenticated caller whose
+    /// username equals it — never a team name; teams are referenced with
+    /// the explicit `team:` form.
+    User(String),
+    /// A `team:<name>` reference, resolved to the owning registry's
+    /// declared member set at config load (an undeclared team is a config
+    /// error there). Matches an authenticated caller whose username is a
+    /// member. `name` is kept for diagnostics only.
+    Team { name: String, members: BTreeSet<String> },
 }
 
 /// Only the `$`-sigiled spellings are built-ins; any other token is a
-/// name, which can only *narrow* access, so this stays infallible.
+/// username, which can only *narrow* access, so this stays infallible.
 /// Near-miss spellings (verdaccio's `@all`/bare aliases, an unknown
-/// `$…`) are rejected earlier, at YAML load (`AccessSpec` in the config
-/// module) — a programmatic caller passing one just gets a name that
-/// matches nobody.
+/// `$…`) and `team:` references are handled at YAML load (`AccessSpec`
+/// in the config module): the former are rejected, the latter resolved
+/// against the registry's declared teams. A programmatic caller passing
+/// one of those spellings just gets a username that matches nobody.
 impl From<&str> for AccessToken {
     fn from(token: &str) -> Self {
         match token {
             "$all" => AccessToken::All,
             "$authenticated" => AccessToken::Authenticated,
             "$anonymous" => AccessToken::Anonymous,
-            name => AccessToken::Named(name.to_string()),
+            name => AccessToken::User(name.to_string()),
         }
     }
 }
@@ -57,8 +65,16 @@ impl From<&str> for AccessToken {
 pub struct AccessList(Vec<AccessToken>);
 
 impl AccessList {
-    /// Build from individual tokens (e.g. the elements of a YAML
-    /// sequence). Each string is one token, taken verbatim.
+    /// Build from already-resolved tokens (the config loader's path,
+    /// where `team:` references have been resolved to member sets).
+    pub(crate) fn new(tokens: Vec<AccessToken>) -> Self {
+        Self(tokens)
+    }
+
+    /// Build from individual built-in or username tokens (e.g. the
+    /// elements of a YAML sequence). Each string is one token, taken
+    /// verbatim; `team:` references cannot be built this way — they need
+    /// the owning registry's team declarations (see [`Self::new`]).
     pub fn from_tokens<Tokens, Token>(tokens: Tokens) -> Self
     where
         Tokens: IntoIterator<Item = Token>,
@@ -79,52 +95,22 @@ impl AccessList {
     }
 }
 
-/// Static group memberships layered onto authenticated pnpr users.
-/// Values are keyed by username so resolving a caller identity stays a
-/// single lookup after the bearer token has been validated.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct AccessGroups {
-    by_user: BTreeMap<String, BTreeSet<String>>,
-}
-
-impl AccessGroups {
-    pub(crate) fn add_user_to_group(&mut self, username: &str, group: &str) {
-        self.by_user.entry(username.to_string()).or_default().insert(group.to_string());
-    }
-
-    #[must_use]
-    pub fn identity_for(&self, username: String) -> Identity {
-        let groups = self.by_user.get(&username).cloned().unwrap_or_default();
-        Identity::User { username, groups }
-    }
-}
-
 /// The resolved caller identity an [`AccessList`] is evaluated against.
+/// Just the authenticated username (or its absence): team membership
+/// lives in the [`AccessToken::Team`] tokens, resolved at config load,
+/// so identity carries no memberships.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Identity {
     /// No valid credentials were presented.
     Anonymous,
-    /// Authenticated as `username`, with any configured static groups.
-    User { username: String, groups: BTreeSet<String> },
+    /// Authenticated as `username`.
+    User { username: String },
 }
 
 impl Identity {
     #[must_use]
     pub fn user(username: impl Into<String>) -> Self {
-        Self::User { username: username.into(), groups: BTreeSet::new() }
-    }
-
-    #[must_use]
-    pub fn user_with_groups<User, Groups, Group>(username: User, groups: Groups) -> Self
-    where
-        User: Into<String>,
-        Groups: IntoIterator<Item = Group>,
-        Group: Into<String>,
-    {
-        Self::User {
-            username: username.into(),
-            groups: groups.into_iter().map(Into::into).collect(),
-        }
+        Self::User { username: username.into() }
     }
 
     #[must_use]
@@ -137,8 +123,9 @@ impl Identity {
             (AccessToken::All, _) => true,
             (AccessToken::Authenticated, Identity::User { .. }) => true,
             (AccessToken::Anonymous, Identity::Anonymous) => true,
-            (AccessToken::Named(name), Identity::User { username, groups }) => {
-                name == username || groups.contains(name)
+            (AccessToken::User(name), Identity::User { username }) => name == username,
+            (AccessToken::Team { members, .. }, Identity::User { username }) => {
+                members.contains(username)
             }
             _ => false,
         }

--- a/pnpr/crates/pnpr/src/policy.rs
+++ b/pnpr/crates/pnpr/src/policy.rs
@@ -74,7 +74,8 @@ impl AccessList {
     /// Build from individual built-in or username tokens (e.g. the
     /// elements of a YAML sequence). Each string is one token, taken
     /// verbatim; `team:` references cannot be built this way — they need
-    /// the owning registry's team declarations (see [`Self::new`]).
+    /// the owning registry's team declarations (the config loader
+    /// resolves them and builds the list with `Self::new`).
     pub fn from_tokens<Tokens, Token>(tokens: Tokens) -> Self
     where
         Tokens: IntoIterator<Item = Token>,

--- a/pnpr/crates/pnpr/src/policy/tests.rs
+++ b/pnpr/crates/pnpr/src/policy/tests.rs
@@ -1,12 +1,16 @@
 use super::{AccessList, AccessToken, Identity, PackageRule, PackageRules};
 use crate::registry::PackagePattern;
 
+fn list(token: &str) -> AccessList {
+    AccessList::from_tokens([token])
+}
+
 fn rule(pattern: &str, access: Option<&str>) -> PackageRule {
     PackageRule {
         pattern: PackagePattern::parse(pattern).expect("test pattern parses"),
-        access: access.map(AccessList::parse),
-        publish: access.map(AccessList::parse),
-        unpublish: access.map(AccessList::parse),
+        access: access.map(list),
+        publish: access.map(list),
+        unpublish: access.map(list),
     }
 }
 
@@ -21,7 +25,7 @@ fn registry_mock_rules() -> PackageRules {
         ],
         None,
     )
-    .with_default_unpublish(AccessList::parse("$authenticated"))
+    .with_default_unpublish(list("$authenticated"))
 }
 
 fn user(name: &str) -> Identity {
@@ -31,40 +35,42 @@ fn user(name: &str) -> Identity {
 #[test]
 fn token_parsing_maps_builtins_and_names() {
     assert_eq!(AccessToken::from("$all"), AccessToken::All);
-    assert_eq!(AccessToken::from("@all"), AccessToken::All);
-    assert_eq!(AccessToken::from("all"), AccessToken::All);
     assert_eq!(AccessToken::from("$authenticated"), AccessToken::Authenticated);
     assert_eq!(AccessToken::from("$anonymous"), AccessToken::Anonymous);
-    assert_eq!(AccessToken::from("@anonymous"), AccessToken::Anonymous);
-    // Anything else is a username / group name (no longer an error).
     assert_eq!(AccessToken::from("admin"), AccessToken::Named("admin".to_string()));
+    // Only the `$`-sigiled spellings are built-ins. The alias spellings
+    // verdaccio accepted are plain names here — YAML loading rejects them
+    // before they reach this constructor, and a programmatic caller just
+    // gets a name that matches nobody (deny-safe).
+    assert_eq!(AccessToken::from("@all"), AccessToken::Named("@all".to_string()));
+    assert_eq!(AccessToken::from("all"), AccessToken::Named("all".to_string()));
+    assert_eq!(AccessToken::from("authenticated"), AccessToken::Named("authenticated".to_string()),);
 }
 
 #[test]
 fn all_admits_everyone() {
-    let list = AccessList::parse("$all");
+    let list = list("$all");
     assert!(list.allows(&Identity::Anonymous));
     assert!(list.allows(&user("alice")));
 }
 
 #[test]
 fn authenticated_admits_only_logged_in() {
-    let list = AccessList::parse("$authenticated");
+    let list = list("$authenticated");
     assert!(!list.allows(&Identity::Anonymous));
     assert!(list.allows(&user("alice")));
 }
 
 #[test]
 fn anonymous_admits_only_logged_out() {
-    let list = AccessList::parse("$anonymous");
+    let list = list("$anonymous");
     assert!(list.allows(&Identity::Anonymous));
     assert!(!list.allows(&user("alice")));
 }
 
 #[test]
 fn usernames_grant_per_user_access() {
-    // verdaccio's per-user access: list the usernames directly.
-    let list = AccessList::parse("alice bob");
+    let list = AccessList::from_tokens(["alice", "bob"]);
     assert!(list.allows(&user("alice")));
     assert!(list.allows(&user("bob")));
     assert!(!list.allows(&user("carol")));
@@ -73,7 +79,7 @@ fn usernames_grant_per_user_access() {
 
 #[test]
 fn groups_grant_named_access() {
-    let list = AccessList::parse("platform");
+    let list = list("platform");
     assert!(list.allows(&Identity::user_with_groups("alice", ["platform"])));
     assert!(list.allows(&user("platform")));
     assert!(!list.allows(&Identity::user_with_groups("bob", ["release"])));
@@ -82,16 +88,16 @@ fn groups_grant_named_access() {
 
 #[test]
 fn mixed_token_list_is_a_union() {
-    // `$authenticated admin` — any logged-in user OR (redundantly)
+    // `[$authenticated, admin]` — any logged-in user OR (redundantly)
     // the `admin` name; satisfied by any authenticated caller.
-    let list = AccessList::parse("$authenticated admin");
+    let list = AccessList::from_tokens(["$authenticated", "admin"]);
     assert!(list.allows(&user("carol")));
     assert!(!list.allows(&Identity::Anonymous));
 }
 
 #[test]
 fn empty_list_admits_no_one() {
-    let list = AccessList::parse("");
+    let list = AccessList::default();
     assert!(list.is_empty());
     assert!(!list.allows(&Identity::Anonymous));
     assert!(!list.allows(&user("alice")));
@@ -162,7 +168,7 @@ fn omitted_rule_fields_fall_back_to_registry_default_not_broader_keys() {
         vec![
             PackageRule {
                 pattern: PackagePattern::parse("@acme/*").expect("parses"),
-                access: Some(AccessList::parse("$authenticated")),
+                access: Some(list("$authenticated")),
                 publish: None,
                 unpublish: None,
             },

--- a/pnpr/crates/pnpr/src/policy/tests.rs
+++ b/pnpr/crates/pnpr/src/policy/tests.rs
@@ -33,18 +33,18 @@ fn user(name: &str) -> Identity {
 }
 
 #[test]
-fn token_parsing_maps_builtins_and_names() {
+fn token_parsing_maps_builtins_and_usernames() {
     assert_eq!(AccessToken::from("$all"), AccessToken::All);
     assert_eq!(AccessToken::from("$authenticated"), AccessToken::Authenticated);
     assert_eq!(AccessToken::from("$anonymous"), AccessToken::Anonymous);
-    assert_eq!(AccessToken::from("admin"), AccessToken::Named("admin".to_string()));
+    assert_eq!(AccessToken::from("admin"), AccessToken::User("admin".to_string()));
     // Only the `$`-sigiled spellings are built-ins. The alias spellings
-    // verdaccio accepted are plain names here — YAML loading rejects them
-    // before they reach this constructor, and a programmatic caller just
-    // gets a name that matches nobody (deny-safe).
-    assert_eq!(AccessToken::from("@all"), AccessToken::Named("@all".to_string()));
-    assert_eq!(AccessToken::from("all"), AccessToken::Named("all".to_string()));
-    assert_eq!(AccessToken::from("authenticated"), AccessToken::Named("authenticated".to_string()),);
+    // verdaccio accepted are plain usernames here — YAML loading rejects
+    // them before they reach this constructor, and a programmatic caller
+    // just gets a username that matches nobody (deny-safe).
+    assert_eq!(AccessToken::from("@all"), AccessToken::User("@all".to_string()));
+    assert_eq!(AccessToken::from("all"), AccessToken::User("all".to_string()));
+    assert_eq!(AccessToken::from("authenticated"), AccessToken::User("authenticated".to_string()));
 }
 
 #[test]
@@ -78,11 +78,26 @@ fn usernames_grant_per_user_access() {
 }
 
 #[test]
-fn groups_grant_named_access() {
+fn team_tokens_admit_members_only() {
+    let list = AccessList::new(vec![AccessToken::Team {
+        name: "platform".to_string(),
+        members: ["alice".to_string()].into(),
+    }]);
+    assert!(list.allows(&user("alice")));
+    assert!(!list.allows(&user("bob")));
+    // The team's *name* is not a username: a user who happens to be called
+    // like the team gains nothing.
+    assert!(!list.allows(&user("platform")));
+    assert!(!list.allows(&Identity::Anonymous));
+}
+
+#[test]
+fn bare_tokens_are_usernames_not_team_names() {
+    // `platform` as a bare token admits only the user of that name — team
+    // membership is reachable exclusively through a `team:` token.
     let list = list("platform");
-    assert!(list.allows(&Identity::user_with_groups("alice", ["platform"])));
     assert!(list.allows(&user("platform")));
-    assert!(!list.allows(&Identity::user_with_groups("bob", ["release"])));
+    assert!(!list.allows(&user("alice")));
     assert!(!list.allows(&Identity::Anonymous));
 }
 

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -87,7 +87,7 @@ fn upstream_with_token(registry: &str, access: &str, token: &'static str) -> Ups
     headers
         .insert(reqwest::header::AUTHORIZATION, reqwest::header::HeaderValue::from_static(token));
     let mut upstream = UpstreamConfig::with_defaults(registry.to_string(), headers);
-    upstream.access = Some(AccessList::parse(access));
+    upstream.access = Some(AccessList::from_tokens([access]));
     upstream
 }
 
@@ -116,8 +116,8 @@ fn set_local_hosted_rules(config: &mut RegistryConfig, pattern: &str, access: &s
     let rules = PackageRules::new(
         vec![PackageRule {
             pattern: PackagePattern::parse(pattern).expect("test pattern parses"),
-            access: Some(AccessList::parse(access)),
-            publish: Some(AccessList::parse("$authenticated")),
+            access: Some(AccessList::from_tokens([access])),
+            publish: Some(AccessList::from_tokens(["$authenticated"])),
             unpublish: None,
         }],
         None,
@@ -423,11 +423,11 @@ fn package_qualified_alias_descriptor_rechecks_upstream_rules_on_replay() {
     upstream.rules = PackageRules::new(
         vec![PackageRule {
             pattern: PackagePattern::parse("@corp/secret").expect("test pattern parses"),
-            access: Some(AccessList::parse("alice")),
+            access: Some(AccessList::from_tokens(["alice"])),
             publish: None,
             unpublish: None,
         }],
-        Some(AccessList::parse("$authenticated")),
+        Some(AccessList::from_tokens(["$authenticated"])),
     );
     config.upstreams.insert("corp".to_string(), upstream);
     let context = RouteContext::from_config(&config);

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -257,7 +257,7 @@ fn upstream_with_access(registry: &str, access: &str) -> UpstreamConfig {
     let mut headers = HeaderMap::new();
     headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer upstream-secret"));
     let mut upstream = UpstreamConfig::with_defaults(registry.to_string(), headers);
-    upstream.access = Some(AccessList::parse(access));
+    upstream.access = Some(AccessList::from_tokens([access]));
     upstream
 }
 
@@ -273,11 +273,11 @@ fn upstream_per_package_rules_gate_alias_selection() {
     upstream.rules = PackageRules::new(
         vec![PackageRule {
             pattern: PackagePattern::parse("@corp/secret").expect("test pattern parses"),
-            access: Some(AccessList::parse("alice")),
+            access: Some(AccessList::from_tokens(["alice"])),
             publish: None,
             unpublish: None,
         }],
-        Some(AccessList::parse("$authenticated")),
+        Some(AccessList::from_tokens(["$authenticated"])),
     );
     config.upstreams.insert("corp".to_string(), upstream);
     let context = RouteContext::from_config(&config);

--- a/pnpr/crates/pnpr/src/route/tests.rs
+++ b/pnpr/crates/pnpr/src/route/tests.rs
@@ -424,24 +424,25 @@ fn upstream_without_access_is_an_anonymous_route() {
 }
 
 #[test]
-fn proxied_alias_accepts_configured_group_identity() {
+fn proxied_alias_accepts_team_member_identity() {
+    use crate::policy::{AccessList, AccessToken};
+
     let mut config = base_config();
-    config.groups.add_user_to_group("alice", "platform");
-    config
-        .upstreams
-        .insert("corp".to_string(), upstream_with_access("https://npm.corp.example/", "platform"));
+    let mut upstream = upstream_with_access("https://npm.corp.example/", "$authenticated");
+    upstream.access = Some(AccessList::new(vec![AccessToken::Team {
+        name: "platform".to_string(),
+        members: ["alice".to_string()].into(),
+    }]));
+    config.upstreams.insert("corp".to_string(), upstream);
     let context = RouteContext::from_config(&config);
     let url = "https://npm.corp.example/@acme%2fwidget";
 
     assert_eq!(
-        context.classify(&config.identity_for_user("alice"), url, Some("@acme/widget")),
+        context.classify(&user("alice"), url, Some("@acme/widget")),
         RouteClass::Proxied { alias: "corp".to_string(), credential_digest: corp_credential() },
     );
-    // A caller outside the alias's group gets no managed credential.
-    assert_eq!(
-        context.classify(&config.identity_for_user("bob"), url, Some("@acme/widget")),
-        RouteClass::Public,
-    );
+    // A caller outside the alias's team gets no managed credential.
+    assert_eq!(context.classify(&user("bob"), url, Some("@acme/widget")), RouteClass::Public);
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -3734,7 +3734,7 @@ async fn resolve_caller(
             return Ok(Identity::Anonymous);
         };
         check_token_restrictions(&record, method, peer)?;
-        return Ok(state.inner.config.identity_for_user(record.username));
+        return Ok(Identity::user(record.username));
     }
     // Anything that is not a bearer token — Basic, another scheme, or no
     // credentials — carries no request identity. Going through `identify`

--- a/pnpr/crates/pnpr/src/server/tests.rs
+++ b/pnpr/crates/pnpr/src/server/tests.rs
@@ -227,7 +227,7 @@ async fn configured_groups_reach_package_authorization() {
     config.hosted.get_mut("local").unwrap().rules = PackageRules::new(
         vec![PackageRule {
             pattern: PackagePattern::parse("@team/*").unwrap(),
-            access: Some(AccessList::parse("platform")),
+            access: Some(AccessList::from_tokens(["platform"])),
             publish: None,
             unpublish: None,
         }],

--- a/pnpr/crates/pnpr/src/server/tests.rs
+++ b/pnpr/crates/pnpr/src/server/tests.rs
@@ -218,29 +218,32 @@ async fn authenticated_identity_reaches_handlers() {
 }
 
 #[tokio::test]
-async fn configured_groups_reach_package_authorization() {
+async fn team_tokens_reach_package_authorization() {
     let tmp = TempDir::new().unwrap();
     let listen = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
     let mut config = Config::static_serve(listen, tmp.path().to_path_buf());
-    config.groups.add_user_to_group("alice", "platform");
+    use crate::policy::{AccessToken, Identity};
     use crate::registry::PackagePattern;
     config.hosted.get_mut("local").unwrap().rules = PackageRules::new(
         vec![PackageRule {
             pattern: PackagePattern::parse("@team/*").unwrap(),
-            access: Some(AccessList::from_tokens(["platform"])),
+            access: Some(AccessList::new(vec![AccessToken::Team {
+                name: "platform".to_string(),
+                members: ["alice".to_string()].into(),
+            }])),
             publish: None,
             unpublish: None,
         }],
         None,
     );
-    // Group membership reaches the per-package rule evaluation.
-    let alice = config.identity_for_user("alice");
-    let carol = config.identity_for_user("carol");
+    // Team membership reaches the per-package rule evaluation.
+    let alice = Identity::user("alice");
+    let carol = Identity::user("carol");
     let rules = &config.hosted["local"].rules;
     assert!(rules.for_package("@team/x").access.allows(&alice));
     assert!(!rules.for_package("@team/x").access.allows(&carol));
 
-    // Over HTTP: the group member reaches storage (404, the package is
+    // Over HTTP: the team member reaches storage (404, the package is
     // absent); a caller denied by the *explicit* `@team/*` entry is
     // rejected loudly — 401 for anonymous, so clients can prompt for
     // credentials — rather than masked (masking is the registry-level

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -45,8 +45,8 @@ fn config_for(upstream: &str, storage: PathBuf) -> Config {
 fn hosted_with_access(org: &str, access: &str) -> HostedConfig {
     HostedConfig {
         org: org.to_string(),
-        rules: PackageRules::new(Vec::new(), Some(AccessList::parse(access)))
-            .with_default_unpublish(AccessList::parse("$authenticated")),
+        rules: PackageRules::new(Vec::new(), Some(AccessList::from_tokens([access])))
+            .with_default_unpublish(AccessList::from_tokens(["$authenticated"])),
     }
 }
 
@@ -54,7 +54,7 @@ fn hosted_with_access(org: &str, access: &str) -> HostedConfig {
 fn access_rule(pattern: &str, access: &str) -> PackageRule {
     PackageRule {
         pattern: PackagePattern::parse(pattern).expect("test pattern parses"),
-        access: Some(AccessList::parse(access)),
+        access: Some(AccessList::from_tokens([access])),
         publish: None,
         unpublish: None,
     }
@@ -690,7 +690,7 @@ async fn upstream_auth_and_custom_headers_are_forwarded_upstream() {
     upstream.headers.insert("x-org", "acme".parse().unwrap());
     // A credentialed upstream must be access-gated (server construction
     // enforces it), so the read authenticates as an admitted caller.
-    upstream.access = Some(AccessList::parse("$authenticated"));
+    upstream.access = Some(AccessList::from_tokens(["$authenticated"]));
     let auth = AuthState::in_memory();
     let token = auth.tokens.issue("alice").await.unwrap();
     let app = router_with_auth(config, auth);
@@ -789,7 +789,7 @@ fn upstream_endpoint_config(upstream_url: &str, storage: PathBuf, access: &str) 
     let mut config = config_for(upstream_url, storage);
     config.public_url = "http://example.test".to_string();
     config.upstreams.get_mut("npmjs").expect("default `npmjs` upstream").access =
-        Some(AccessList::parse(access));
+        Some(AccessList::from_tokens([access]));
     config
 }
 
@@ -945,7 +945,7 @@ async fn upstream_cache_does_not_leak_to_the_public_path() {
     let mut config = config_for(&public_upstream.url(), tmp.path().to_path_buf());
     let mut corp = config.upstreams.get("npmjs").expect("default `npmjs` upstream").clone();
     corp.url = private_upstream.url();
-    corp.access = Some(AccessList::parse("alice"));
+    corp.access = Some(AccessList::from_tokens(["alice"]));
     config.upstreams.insert("corp".to_string(), corp);
     let auth = AuthState::in_memory();
     let token = auth.tokens.issue("alice").await.unwrap();
@@ -3318,7 +3318,7 @@ async fn publish_to_a_private_upstream_is_denied_before_the_upstream_rejection()
     let tmp = TempDir::new().unwrap();
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
     let mut corp = config.upstreams.get("npmjs").expect("default `npmjs` upstream").clone();
-    corp.access = Some(AccessList::parse("alice"));
+    corp.access = Some(AccessList::from_tokens(["alice"]));
     config.upstreams.insert("corp".to_string(), corp);
     let auth = AuthState::in_memory();
     let member = auth.tokens.issue("alice").await.unwrap();


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Now that pnpr's routing config is fully pnpr-native (`registries:`, per-registry `packages:` maps), this PR moves the *access-control declaration* off verdaccio syntax too, in two steps.

**Commit 1 — strict token grammar.**

- Only the `$`-sigiled built-ins are recognized: `$all`, `$authenticated`, `$anonymous`. Verdaccio's `@`-prefixed and bare alias spellings (`@all`, `all`, ...) are rejected at config load with a `did you mean "$all"?` error — previously a team literally named `authenticated` silently resolved to the pseudo-group and *widened* access. The `$` namespace is reserved, so a typo'd built-in is a startup error, not a token that admits nobody.
- No more whitespace-splitting: a YAML scalar is exactly one token, and a multi-token list must be a YAML sequence (`access: [alice, bob]`). Verdaccio's `access: $authenticated admin` fails loudly with a pointer at the sequence spelling. An empty-string value is an error pointing at `[]` (deny everyone) or omission (the default).

**Commit 2 — registry-scoped teams replace the global `groups:` block.**

- Teams are the only principal-set concept and belong to the registry (the tenant): each hosted or upstream registry declares its own `teams:` map and references it from its access lists as `team:<name>`. A roster shared across registries is a YAML anchor, not a global namespace.
- Bare tokens are usernames only. Under the global-groups model a bare token matched a username *or* a group, so with open registration anyone could register a username equal to a group name and inherit its grants. The explicit `team:` form closes that escalation.
- Typos cannot fail open or silently deny: `group:x` errors with `did you mean "team:x"?`, unknown `<type>:` prefixes are rejected (htpasswd forbids `:` in usernames, so the character is free to reserve), and a `team:` reference to an undeclared team is a startup error listing the declared teams.
- `team:` tokens are resolved to their member sets at config load, so `AccessList::allows(&identity)` keeps its signature: `Identity` drops its groups field, and route classification, search, and the resolver are untouched.
- The removed top-level `groups:` block is rejected loudly (same treatment as the removed top-level `packages:` block), since silently dropping it would change who may reach what on upgrade.

Example of the new surface:

```yaml
registries:
  private:
    type: hosted
    teams:
      eng: [alice, bob, carol]
      release: [carol]
    access: team:eng
    packages:
      '@corp/*':
        publish: team:eng
        unpublish: team:release
```

All rejection paths and the happy path were exercised against the real binary (startup errors shown above are actual output shapes). Deliberately out of scope, to be decided separately: renaming/defaulting the hosted `org:` storage namespace (changing its default silently relocates existing hosted storage on upgrade, so it needs a migration story), and the cosmetic layer (`access` -> `read` verb question, remaining snake_case knobs like `max_users`/`max_fails`).

## Squash Commit Body

```text
pnpr's access-control declaration is now pnpr-native, matching the
already-native routing config.

Token grammar: only the $-sigiled built-ins ($all, $authenticated,
$anonymous) are recognized; verdaccio's @-prefixed and bare alias
spellings are rejected at config load with a did-you-mean error, and
the $ namespace is reserved so a typo'd built-in cannot silently
become a username that admits nobody. Access lists and member lists
no longer whitespace-split: a YAML scalar is one token, multi-token
lists are YAML sequences, and an empty-string value is an error
pointing at [] or omission.

Teams: the global groups: block is replaced by registry-scoped teams.
Each hosted or upstream registry declares its own teams: map and
references it from its access lists as team:<name>; a bare token is a
username only. This closes the escalation where open registration let
anyone claim a username equal to a group name and inherit its grants,
and it makes cross-registry reuse explicit (YAML anchors) instead of a
global namespace. group:<name> gets a pointer at team:<name>, unknown
<type>: prefixes are rejected (htpasswd forbids ':' in usernames), and
an undeclared team reference is a startup error listing the declared
teams.

team: references are resolved to member sets at config load, so
access-list evaluation still needs only the caller's identity:
Identity drops its groups field and route classification, search, and
the resolver are untouched. The removed top-level groups: block is
rejected loudly, like the removed top-level packages: block, because
silently dropping it would change who may reach what on upgrade.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  (pnpr-only: the registry server has no TypeScript or pacquet counterpart.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. (Not applicable: pnpr is Rust and not released through changesets.)
- [x] Added or updated tests.
- [x] Updated the documentation if needed. (The bundled `config.yaml` — the
  operator-facing reference — documents the new syntax; no pnpm.io pages
  cover pnpr config yet.)

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added registry-scoped teams for reusable access controls.
  * Team members can authorize access using `team:<name>` tokens.
* **Bug Fixes**
  * Improved authorization for authenticated callers to match the caller identity carried by bearer tokens.
* **Validation & Behavior Changes**
  * Access-list formats are now strictly validated (sequence-based tokens); legacy/ambiguous configurations are rejected with migration guidance.
  * Unknown or invalid team references and incorrect token spellings now fail loudly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->