### PR TITLE
feat(pacquet-cli): implement pkg command

### DIFF
--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -34,6 +34,7 @@ pub mod patch_remove;
 pub(crate) mod patch_state;
 pub mod peers;
 pub mod ping;
+pub mod pkg;
 pub mod prefix;
 pub mod prune;
 pub mod rebuild;

--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -32,6 +32,7 @@ use super::{
     patch_remove::PatchRemoveArgs,
     peers::PeersArgs,
     ping::PingArgs,
+    pkg::PkgArgs,
     prefix::PrefixArgs,
     prune::PruneArgs,
     rebuild::RebuildArgs,
@@ -223,6 +224,8 @@ pub enum CliCommand {
     /// Manage the pnpm configuration files.
     #[clap(visible_alias = "c")]
     Config(ConfigArgs),
+    /// Manages your package.json.
+    Pkg(PkgArgs),
     /// Pack a `CommonJS` entry file into a standalone executable for one or more target platforms.
     #[clap(name = "pack-app")]
     PackApp(PackAppArgs),

--- a/pacquet/crates/cli/src/cli_args/dispatch.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch.rs
@@ -258,6 +258,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::Root(args) => dispatch_query::root(ctx, args),
         CliCommand::Prefix(args) => dispatch_query::prefix(ctx, args),
         CliCommand::Config(args) => dispatch_query::config(ctx, args),
+        CliCommand::Pkg(args) => dispatch_script::pkg(ctx, args),
         CliCommand::PackApp(args) => dispatch_query::pack_app(ctx, args),
         CliCommand::Store(command) => dispatch_query::store(ctx, command),
         CliCommand::Cache(command) => dispatch_query::cache(ctx, command),

--- a/pacquet/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_script.rs
@@ -29,7 +29,11 @@ pub(super) fn set_script<'a>(
 }
 
 pub(super) fn pkg<'a>(ctx: &RunCtx<'a>, args: PkgArgs) -> miette::Result<CommandFuture<'a>> {
-    let result = args.run(ctx.manifest_path);
+    let result = if ctx.recursive {
+        args.run_recursive((ctx.config)()?, ctx.dir)
+    } else {
+        args.run(ctx.manifest_path)
+    };
     Ok(Box::pin(std::future::ready(result)))
 }
 

--- a/pacquet/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_script.rs
@@ -1,6 +1,7 @@
 use super::{
     dispatch::{CommandFuture, RunCtx},
     exec::ExecArgs,
+    pkg::PkgArgs,
     reporter::ReporterType,
     restart::RestartArgs,
     run::RunArgs,
@@ -23,6 +24,11 @@ pub(super) fn set_script<'a>(
     ctx: &RunCtx<'a>,
     args: SetScriptArgs,
 ) -> miette::Result<CommandFuture<'a>> {
+    let result = args.run(ctx.manifest_path);
+    Ok(Box::pin(std::future::ready(result)))
+}
+
+pub(super) fn pkg<'a>(ctx: &RunCtx<'a>, args: PkgArgs) -> miette::Result<CommandFuture<'a>> {
     let result = args.run(ctx.manifest_path);
     Ok(Box::pin(std::future::ready(result)))
 }

--- a/pacquet/crates/cli/src/cli_args/pkg.rs
+++ b/pacquet/crates/cli/src/cli_args/pkg.rs
@@ -1,8 +1,12 @@
+use crate::cli_args::recursive::{
+    AutoExcludeRoot, discover_workspace_projects, select_recursive_projects,
+};
 use clap::{Args, Subcommand};
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic};
-use pacquet_config::property_path::{
-    self, Segment, get_object_value_by_property_path, parse_property_path,
+use pacquet_config::{
+    Config,
+    property_path::{self, Segment, get_object_value_by_property_path, parse_property_path},
 };
 use pacquet_package_manifest::PackageManifest;
 use serde_json::{Map, Value};
@@ -44,6 +48,14 @@ pub enum PkgError {
     #[display("Cannot use an empty property path")]
     #[diagnostic(code(ERR_PNPM_PKG_EMPTY_PROPERTY_PATH))]
     EmptyPath,
+
+    #[display("Cannot run recursively outside of a workspace")]
+    #[diagnostic(code(ERR_PNPM_PKG_RECURSIVE_NO_ROOT))]
+    RecursiveNoRoot,
+
+    #[display("No workspace packages were selected")]
+    #[diagnostic(code(ERR_PNPM_PKG_RECURSIVE_NO_PACKAGES))]
+    RecursiveNoPackages,
 }
 
 #[derive(Debug, Args)]
@@ -106,6 +118,97 @@ impl PkgArgs {
             }
             PkgSubcommand::Fix => {
                 pkg_fix(manifest_path)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Run the pkg command across `--filter`-selected workspace projects.
+    pub fn run_recursive(self, config: &Config, dir: &Path) -> miette::Result<()> {
+        let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
+        if config.workspace_dir.is_none() {
+            return Err(PkgError::RecursiveNoRoot.into());
+        }
+        let (projects, _patterns) =
+            discover_workspace_projects(workspace_root).wrap_err("discover workspace projects")?;
+        let selection =
+            select_recursive_projects(&projects, config, dir, AutoExcludeRoot::Disabled)?;
+        if selection.selected.is_empty() {
+            return Err(PkgError::RecursiveNoPackages.into());
+        }
+        match self.command {
+            PkgSubcommand::Get(args) => {
+                let mut entries = Map::new();
+                for node in selection.selected.values() {
+                    let manifest = &node.package.project.manifest;
+                    let pkg_name =
+                        manifest.value().get("name").and_then(Value::as_str).map_or_else(
+                            || {
+                                node.package
+                                    .project
+                                    .root_dir
+                                    .strip_prefix(workspace_root)
+                                    .unwrap_or(&node.package.project.root_dir)
+                                    .display()
+                                    .to_string()
+                            },
+                            String::from,
+                        );
+                    let value = select_from_manifest(manifest.value(), &args.keys)?;
+                    entries.insert(pkg_name, value);
+                }
+                let output = serde_json::to_string_pretty(&Value::Object(entries))
+                    .map_err(|e| miette::miette!("{e}"))?;
+                println!("{output}");
+            }
+            PkgSubcommand::Set(args) => {
+                for node in selection.selected.values() {
+                    let mut manifest = PackageManifest::from_path(
+                        node.package.project.root_dir.join("package.json"),
+                    )
+                    .wrap_err("reading package.json")?;
+                    let value = manifest.value_mut();
+                    for pair in &args.pairs {
+                        let eq_index = pair
+                            .find('=')
+                            .ok_or_else(|| PkgError::SetInvalidArg { arg: pair.clone() })?;
+                        let key = &pair[..eq_index];
+                        let raw_value = &pair[eq_index + 1..];
+                        let parsed_value: Value = if self.json {
+                            serde_json::from_str(raw_value).map_err(|_| PkgError::SetJsonParse {
+                                value: raw_value.to_string(),
+                            })?
+                        } else {
+                            Value::String(raw_value.to_string())
+                        };
+                        set_object_value_by_property_path(value, key, parsed_value)?;
+                    }
+                    manifest.save().wrap_err("saving package.json")?;
+                }
+            }
+            PkgSubcommand::Delete(args) => {
+                for node in selection.selected.values() {
+                    let mut manifest = PackageManifest::from_path(
+                        node.package.project.root_dir.join("package.json"),
+                    )
+                    .wrap_err("reading package.json")?;
+                    let value = manifest.value_mut();
+                    for key in &args.keys {
+                        delete_object_value_by_property_path(value, key)?;
+                    }
+                    manifest.save().wrap_err("saving package.json")?;
+                }
+            }
+            PkgSubcommand::Fix => {
+                for node in selection.selected.values() {
+                    let mut manifest = PackageManifest::from_path(
+                        node.package.project.root_dir.join("package.json"),
+                    )
+                    .wrap_err("reading package.json")?;
+                    let value = manifest.value_mut();
+                    fix_manifest(value);
+                    manifest.save().wrap_err("saving package.json")?;
+                }
             }
         }
         Ok(())

--- a/pacquet/crates/cli/src/cli_args/pkg.rs
+++ b/pacquet/crates/cli/src/cli_args/pkg.rs
@@ -40,6 +40,10 @@ pub enum PkgError {
     #[display("Cannot set property on a non-object or non-array value at path")]
     #[diagnostic(code(ERR_PNPM_PKG_SET_PATH_ERROR))]
     SetPathError { path: String },
+
+    #[display("Cannot use an empty property path")]
+    #[diagnostic(code(ERR_PNPM_PKG_EMPTY_PROPERTY_PATH))]
+    EmptyPath,
 }
 
 #[derive(Debug, Args)]
@@ -119,7 +123,13 @@ fn pkg_get(manifest_path: &Path, keys: &[String], json: bool) -> miette::Result<
 fn get_output(manifest: &Value, keys: &[String], json: bool) -> miette::Result<String> {
     if keys.len() == 1 {
         let key = &keys[0];
+        if key.is_empty() {
+            return Err(PkgError::EmptyPath.into());
+        }
         let segments = parse_property_path(key).map_err(PkgError::InvalidPropertyPath)?;
+        if segments.is_empty() {
+            return Err(PkgError::EmptyPath.into());
+        }
         match get_object_value_by_property_path(manifest, &segments) {
             None => Ok(String::new()),
             Some(found) => {
@@ -136,24 +146,23 @@ fn get_output(manifest: &Value, keys: &[String], json: bool) -> miette::Result<S
             }
         }
     } else {
-        let selected = select_from_manifest(manifest, keys);
+        let selected = select_from_manifest(manifest, keys)?;
         serde_json::to_string_pretty(&selected).map_err(|e| miette::miette!("{e}"))
     }
 }
 
-fn select_from_manifest(manifest: &Value, keys: &[String]) -> Value {
+fn select_from_manifest(manifest: &Value, keys: &[String]) -> miette::Result<Value> {
     if keys.is_empty() {
-        return manifest.clone();
+        return Ok(manifest.clone());
     }
     let mut result = Map::new();
     for key in keys {
-        let value = parse_property_path(key)
-            .ok()
-            .and_then(|segments| get_object_value_by_property_path(manifest, &segments))
-            .map_or(Value::Null, std::borrow::ToOwned::to_owned);
-        result.insert(key.clone(), value);
+        let segments = parse_property_path(key).map_err(PkgError::InvalidPropertyPath)?;
+        if let Some(found) = get_object_value_by_property_path(manifest, &segments) {
+            result.insert(key.clone(), found.clone());
+        }
     }
-    Value::Object(result)
+    Ok(Value::Object(result))
 }
 
 fn pkg_set(manifest_path: &Path, pairs: &[String], json: bool) -> miette::Result<()> {
@@ -184,11 +193,14 @@ fn pkg_delete(manifest_path: &Path, keys: &[String]) -> miette::Result<()> {
     if keys.is_empty() {
         return Err(PkgError::DeleteMissingArgs.into());
     }
+    for key in keys {
+        check_unsafe_key_in_path(key)?;
+    }
     let mut manifest =
         PackageManifest::from_path(manifest_path.to_path_buf()).wrap_err("reading package.json")?;
     let value = manifest.value_mut();
     for key in keys {
-        delete_object_value_by_property_path(value, key);
+        delete_object_value_by_property_path(value, key)?;
     }
     manifest.save().wrap_err("saving package.json")?;
     Ok(())
@@ -244,8 +256,21 @@ fn check_unsafe_key_in_path(key: &str) -> Result<(), PkgError> {
     Ok(())
 }
 
-fn set_path_err(path: &str) -> miette::Report {
-    miette::Report::new(PkgError::SetPathError { path: path.to_string() })
+pub(crate) const MAX_ARRAY_INDEX: usize = 1 << 20;
+
+fn validate_index(idx: f64) -> Result<usize, PkgError> {
+    if idx.fract() != 0.0 || idx.is_sign_negative() || !idx.is_finite() {
+        return Err(PkgError::SetPathError { path: idx.to_string() });
+    }
+    let index = idx as usize;
+    if index > MAX_ARRAY_INDEX {
+        return Err(PkgError::SetPathError { path: idx.to_string() });
+    }
+    Ok(index)
+}
+
+fn idx_to_string(idx: f64) -> String {
+    if idx.fract() == 0.0 && idx.is_finite() { format!("{}", idx as i64) } else { idx.to_string() }
 }
 
 fn set_object_value_by_property_path(
@@ -253,82 +278,168 @@ fn set_object_value_by_property_path(
     path: &str,
     value: Value,
 ) -> miette::Result<()> {
+    if path.is_empty() {
+        return Err(PkgError::EmptyPath.into());
+    }
     check_unsafe_key_in_path(path)?;
     let segments = parse_property_path(path)
         .map_err(|err| miette::Report::new(PkgError::InvalidPropertyPath(err)))?;
     if segments.is_empty() {
-        return Ok(());
+        return Err(PkgError::EmptyPath.into());
     }
     let last_idx = segments.len() - 1;
     let mut current = root;
-    for segment in &segments[..last_idx] {
-        match segment {
+    for i in 0..last_idx {
+        let needs_array = matches!(&segments[i + 1], Segment::Index(_));
+        match &segments[i] {
             Segment::Key(k) => {
-                let obj = current.as_object_mut().ok_or_else(|| set_path_err(path))?;
-                current = obj.entry(k.clone()).or_insert_with(|| Value::Object(Map::new()));
+                if !current.is_object() {
+                    *current = Value::Object(Map::new());
+                }
+                let obj = current.as_object_mut().unwrap();
+                let entry = obj.get_mut(k);
+                let is_good = entry
+                    .is_some_and(|val| if needs_array { val.is_array() } else { val.is_object() });
+                if !is_good {
+                    let replacement = if needs_array {
+                        Value::Array(Vec::new())
+                    } else {
+                        Value::Object(Map::new())
+                    };
+                    obj.insert(k.clone(), replacement);
+                }
+                current = obj.get_mut(k).unwrap();
             }
             Segment::Index(idx) => {
-                let index = *idx as usize;
-                let arr = current.as_array_mut().ok_or_else(|| set_path_err(path))?;
-                if index >= arr.len() {
-                    arr.resize(index + 1, Value::Null);
+                let index = validate_index(*idx)?;
+                if current.is_object() {
+                    let key = idx_to_string(*idx);
+                    let obj = current.as_object_mut().unwrap();
+                    let entry = obj.get_mut(&key);
+                    let is_good = entry.is_some_and(|val| {
+                        if needs_array { val.is_array() } else { val.is_object() }
+                    });
+                    if !is_good {
+                        let replacement = if needs_array {
+                            Value::Array(Vec::new())
+                        } else {
+                            Value::Object(Map::new())
+                        };
+                        obj.insert(key.clone(), replacement);
+                    }
+                    current = obj.get_mut(&key).unwrap();
+                } else if current.is_array() {
+                    let arr = current.as_array_mut().unwrap();
+                    if index >= arr.len() {
+                        arr.resize(index.saturating_add(1), Value::Null);
+                    }
+                    let entry = &mut arr[index];
+                    let is_good = if needs_array { entry.is_array() } else { entry.is_object() };
+                    if !is_good {
+                        *entry = if needs_array {
+                            Value::Array(Vec::new())
+                        } else {
+                            Value::Object(Map::new())
+                        };
+                    }
+                    current = &mut arr[index];
+                } else {
+                    let replacement = if needs_array {
+                        let mut arr = Vec::with_capacity(index.saturating_add(1));
+                        arr.resize(index.saturating_add(1), Value::Null);
+                        Value::Array(arr)
+                    } else {
+                        let mut map = Map::new();
+                        map.insert(idx_to_string(*idx), Value::Null);
+                        Value::Object(map)
+                    };
+                    *current = replacement;
                 }
-                current = &mut arr[index];
             }
         }
     }
     match &segments[last_idx] {
         Segment::Key(k) => {
-            let obj = current.as_object_mut().ok_or_else(|| set_path_err(path))?;
-            obj.insert(k.clone(), value);
+            if !current.is_object() {
+                *current = Value::Object(Map::new());
+            }
+            current.as_object_mut().unwrap().insert(k.clone(), value);
         }
         Segment::Index(idx) => {
-            let index = *idx as usize;
-            let arr = current.as_array_mut().ok_or_else(|| set_path_err(path))?;
-            if index >= arr.len() {
-                arr.resize(index + 1, Value::Null);
+            let index = validate_index(*idx)?;
+            if current.is_object() {
+                current.as_object_mut().unwrap().insert(idx_to_string(*idx), value);
+            } else if current.is_array() {
+                let arr = current.as_array_mut().unwrap();
+                if index >= arr.len() {
+                    arr.resize(index.saturating_add(1), Value::Null);
+                }
+                arr[index] = value;
+            } else {
+                let mut arr = Vec::with_capacity(index.saturating_add(1));
+                arr.resize(index.saturating_add(1), Value::Null);
+                arr[index] = value;
+                *current = Value::Array(arr);
             }
-            arr[index] = value;
         }
     }
     Ok(())
 }
 
-fn delete_object_value_by_property_path(root: &mut Value, path: &str) -> bool {
-    let Ok(segments) = parse_property_path(path) else { return false };
+fn delete_object_value_by_property_path(root: &mut Value, path: &str) -> miette::Result<bool> {
+    let segments = parse_property_path(path)
+        .map_err(|err| miette::Report::new(PkgError::InvalidPropertyPath(err)))?;
     if segments.is_empty() {
-        return false;
+        return Ok(false);
     }
+    check_unsafe_key_in_path(path)?;
     let last_idx = segments.len() - 1;
     let mut current = root;
     for segment in &segments[..last_idx] {
         match segment {
             Segment::Key(k) => {
-                let Some(obj) = current.as_object_mut() else { return false };
-                let Some(next) = obj.get_mut(k) else { return false };
+                let Some(obj) = current.as_object_mut() else { return Ok(false) };
+                let Some(next) = obj.get_mut(k) else { return Ok(false) };
                 current = next;
             }
             Segment::Index(idx) => {
-                let index = *idx as usize;
-                let Some(arr) = current.as_array_mut() else { return false };
-                let Some(next) = arr.get_mut(index) else { return false };
-                current = next;
+                let index = validate_index(*idx)?;
+                if current.is_object() {
+                    let key = idx_to_string(*idx);
+                    let Some(obj) = current.as_object_mut() else { return Ok(false) };
+                    let Some(next) = obj.get_mut(&key) else { return Ok(false) };
+                    current = next;
+                } else if current.is_array() {
+                    let Some(arr) = current.as_array_mut() else { return Ok(false) };
+                    let Some(next) = arr.get_mut(index) else { return Ok(false) };
+                    current = next;
+                } else {
+                    return Ok(false);
+                }
             }
         }
     }
     match &segments[last_idx] {
         Segment::Key(k) => {
-            let Some(obj) = current.as_object_mut() else { return false };
-            obj.remove(k).is_some()
+            let Some(obj) = current.as_object_mut() else { return Ok(false) };
+            Ok(obj.remove(k).is_some())
         }
         Segment::Index(idx) => {
-            let index = *idx as usize;
-            let Some(arr) = current.as_array_mut() else { return false };
-            if index < arr.len() {
-                arr.remove(index);
-                true
+            let index = validate_index(*idx)?;
+            if current.is_object() {
+                let key = idx_to_string(*idx);
+                let Some(obj) = current.as_object_mut() else { return Ok(false) };
+                Ok(obj.remove(&key).is_some())
+            } else if current.is_array() {
+                let Some(arr) = current.as_array_mut() else { return Ok(false) };
+                if index < arr.len() {
+                    arr.remove(index);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
             } else {
-                false
+                Ok(false)
             }
         }
     }

--- a/pacquet/crates/cli/src/cli_args/pkg.rs
+++ b/pacquet/crates/cli/src/cli_args/pkg.rs
@@ -1,0 +1,338 @@
+use clap::{Args, Subcommand};
+use derive_more::{Display, Error};
+use miette::{Context, Diagnostic};
+use pacquet_config::property_path::{
+    self, Segment, get_object_value_by_property_path, parse_property_path,
+};
+use pacquet_package_manifest::PackageManifest;
+use serde_json::{Map, Value};
+use std::path::Path;
+
+const UNSAFE_KEYS: [&str; 3] = ["__proto__", "constructor", "prototype"];
+
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum PkgError {
+    #[display("Missing key=value pairs")]
+    #[diagnostic(code(ERR_PNPM_PKG_SET_MISSING_ARGS))]
+    SetMissingArgs,
+
+    #[display(r#"Invalid argument "{arg}". Expected key=value format"#)]
+    #[diagnostic(code(ERR_PNPM_PKG_SET_INVALID_ARG))]
+    SetInvalidArg { arg: String },
+
+    #[display(r#"Failed to parse value as JSON: "{value}""#)]
+    #[diagnostic(code(ERR_PNPM_PKG_SET_JSON_PARSE))]
+    SetJsonParse { value: String },
+
+    #[display("Missing keys to delete")]
+    #[diagnostic(code(ERR_PNPM_PKG_DELETE_MISSING_ARGS))]
+    DeleteMissingArgs,
+
+    #[display(r#"Key "{key}" is not allowed in a property path"#)]
+    #[diagnostic(code(ERR_PNPM_UNSAFE_PROPERTY_PATH_KEY))]
+    UnsafeKey { key: String },
+
+    #[display("Invalid property path: {_0}")]
+    #[diagnostic(code(ERR_PNPM_PKG_INVALID_PROPERTY_PATH))]
+    InvalidPropertyPath(#[error(not(source))] property_path::ParsePropertyPathError),
+
+    #[display("Cannot set property on a non-object or non-array value at path")]
+    #[diagnostic(code(ERR_PNPM_PKG_SET_PATH_ERROR))]
+    SetPathError { path: String },
+}
+
+#[derive(Debug, Args)]
+pub struct PkgArgs {
+    #[clap(subcommand)]
+    pub command: PkgSubcommand,
+
+    /// When setting, parse the value as JSON. When getting a single key,
+    /// return its JSON-encoded form instead of the raw value.
+    #[clap(long, global = true)]
+    pub json: bool,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum PkgSubcommand {
+    /// Retrieves a value from package.json.
+    Get(PkgGetArgs),
+    /// Sets a value in package.json.
+    Set(PkgSetArgs),
+    /// Deletes a key from package.json.
+    Delete(PkgDeleteArgs),
+    /// Auto corrects common errors in package.json.
+    Fix,
+}
+
+#[derive(Debug, Args)]
+pub struct PkgGetArgs {
+    /// Keys to retrieve from package.json.
+    pub keys: Vec<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct PkgSetArgs {
+    /// key=value pairs to set in package.json.
+    #[clap(required = true)]
+    pub pairs: Vec<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct PkgDeleteArgs {
+    /// Keys to delete from package.json.
+    #[clap(required = true)]
+    pub keys: Vec<String>,
+}
+
+impl PkgArgs {
+    pub fn run(self, manifest_path: &Path) -> miette::Result<()> {
+        match self.command {
+            PkgSubcommand::Get(args) => {
+                let output = pkg_get(manifest_path, &args.keys, self.json)?;
+                if !output.is_empty() {
+                    println!("{output}");
+                }
+            }
+            PkgSubcommand::Set(args) => {
+                pkg_set(manifest_path, &args.pairs, self.json)?;
+            }
+            PkgSubcommand::Delete(args) => {
+                pkg_delete(manifest_path, &args.keys)?;
+            }
+            PkgSubcommand::Fix => {
+                pkg_fix(manifest_path)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn pkg_get(manifest_path: &Path, keys: &[String], json: bool) -> miette::Result<String> {
+    let manifest =
+        PackageManifest::from_path(manifest_path.to_path_buf()).wrap_err("reading package.json")?;
+    let value = manifest.value();
+    let result = get_output(value, keys, json)?;
+    Ok(result)
+}
+
+fn get_output(manifest: &Value, keys: &[String], json: bool) -> miette::Result<String> {
+    if keys.len() == 1 {
+        let key = &keys[0];
+        let segments = parse_property_path(key).map_err(PkgError::InvalidPropertyPath)?;
+        match get_object_value_by_property_path(manifest, &segments) {
+            None => Ok(String::new()),
+            Some(found) => {
+                if json {
+                    serde_json::to_string_pretty(found).map_err(|e| miette::miette!("{e}"))
+                } else {
+                    match found {
+                        Value::String(s) => Ok(s.clone()),
+                        other => {
+                            serde_json::to_string_pretty(other).map_err(|e| miette::miette!("{e}"))
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        let selected = select_from_manifest(manifest, keys);
+        serde_json::to_string_pretty(&selected).map_err(|e| miette::miette!("{e}"))
+    }
+}
+
+fn select_from_manifest(manifest: &Value, keys: &[String]) -> Value {
+    if keys.is_empty() {
+        return manifest.clone();
+    }
+    let mut result = Map::new();
+    for key in keys {
+        let value = parse_property_path(key)
+            .ok()
+            .and_then(|segments| get_object_value_by_property_path(manifest, &segments))
+            .map_or(Value::Null, std::borrow::ToOwned::to_owned);
+        result.insert(key.clone(), value);
+    }
+    Value::Object(result)
+}
+
+fn pkg_set(manifest_path: &Path, pairs: &[String], json: bool) -> miette::Result<()> {
+    if pairs.is_empty() {
+        return Err(PkgError::SetMissingArgs.into());
+    }
+    let mut manifest =
+        PackageManifest::from_path(manifest_path.to_path_buf()).wrap_err("reading package.json")?;
+    let value = manifest.value_mut();
+    for pair in pairs {
+        let eq_index =
+            pair.find('=').ok_or_else(|| PkgError::SetInvalidArg { arg: pair.clone() })?;
+        let key = &pair[..eq_index];
+        let raw_value = &pair[eq_index + 1..];
+        let parsed_value: Value = if json {
+            serde_json::from_str(raw_value)
+                .map_err(|_| PkgError::SetJsonParse { value: raw_value.to_string() })?
+        } else {
+            Value::String(raw_value.to_string())
+        };
+        set_object_value_by_property_path(value, key, parsed_value)?;
+    }
+    manifest.save().wrap_err("saving package.json")?;
+    Ok(())
+}
+
+fn pkg_delete(manifest_path: &Path, keys: &[String]) -> miette::Result<()> {
+    if keys.is_empty() {
+        return Err(PkgError::DeleteMissingArgs.into());
+    }
+    let mut manifest =
+        PackageManifest::from_path(manifest_path.to_path_buf()).wrap_err("reading package.json")?;
+    let value = manifest.value_mut();
+    for key in keys {
+        delete_object_value_by_property_path(value, key);
+    }
+    manifest.save().wrap_err("saving package.json")?;
+    Ok(())
+}
+
+fn pkg_fix(manifest_path: &Path) -> miette::Result<()> {
+    let mut manifest =
+        PackageManifest::from_path(manifest_path.to_path_buf()).wrap_err("reading package.json")?;
+    let value = manifest.value_mut();
+    fix_manifest(value);
+    manifest.save().wrap_err("saving package.json")?;
+    Ok(())
+}
+
+fn fix_manifest(value: &mut Value) {
+    let Some(obj) = value.as_object_mut() else { return };
+    if let Some(name) = obj.get("name")
+        && !name.is_string()
+    {
+        obj.remove("name");
+    }
+    if let Some(version) = obj.get("version")
+        && !version.is_string()
+    {
+        obj.remove("version");
+    }
+    for field in
+        &["dependencies", "devDependencies", "optionalDependencies", "peerDependencies", "scripts"]
+    {
+        if let Some(val) = obj.get(*field)
+            && !val.is_object()
+        {
+            obj.remove(*field);
+        }
+    }
+    if let Some(bin) = obj.get("bin")
+        && !bin.is_string()
+        && !bin.is_object()
+    {
+        obj.remove("bin");
+    }
+}
+
+fn check_unsafe_key_in_path(key: &str) -> Result<(), PkgError> {
+    let segments = parse_property_path(key).map_err(PkgError::InvalidPropertyPath)?;
+    for segment in &segments {
+        if let Segment::Key(k) = segment
+            && UNSAFE_KEYS.contains(&k.as_str())
+        {
+            return Err(PkgError::UnsafeKey { key: k.clone() });
+        }
+    }
+    Ok(())
+}
+
+fn set_path_err(path: &str) -> miette::Report {
+    miette::Report::new(PkgError::SetPathError { path: path.to_string() })
+}
+
+fn set_object_value_by_property_path(
+    root: &mut Value,
+    path: &str,
+    value: Value,
+) -> miette::Result<()> {
+    check_unsafe_key_in_path(path)?;
+    let segments = parse_property_path(path)
+        .map_err(|err| miette::Report::new(PkgError::InvalidPropertyPath(err)))?;
+    if segments.is_empty() {
+        return Ok(());
+    }
+    let last_idx = segments.len() - 1;
+    let mut current = root;
+    for segment in &segments[..last_idx] {
+        match segment {
+            Segment::Key(k) => {
+                let obj = current.as_object_mut().ok_or_else(|| set_path_err(path))?;
+                current = obj.entry(k.clone()).or_insert_with(|| Value::Object(Map::new()));
+            }
+            Segment::Index(idx) => {
+                let index = *idx as usize;
+                let arr = current.as_array_mut().ok_or_else(|| set_path_err(path))?;
+                if index >= arr.len() {
+                    arr.resize(index + 1, Value::Null);
+                }
+                current = &mut arr[index];
+            }
+        }
+    }
+    match &segments[last_idx] {
+        Segment::Key(k) => {
+            let obj = current.as_object_mut().ok_or_else(|| set_path_err(path))?;
+            obj.insert(k.clone(), value);
+        }
+        Segment::Index(idx) => {
+            let index = *idx as usize;
+            let arr = current.as_array_mut().ok_or_else(|| set_path_err(path))?;
+            if index >= arr.len() {
+                arr.resize(index + 1, Value::Null);
+            }
+            arr[index] = value;
+        }
+    }
+    Ok(())
+}
+
+fn delete_object_value_by_property_path(root: &mut Value, path: &str) -> bool {
+    let Ok(segments) = parse_property_path(path) else { return false };
+    if segments.is_empty() {
+        return false;
+    }
+    let last_idx = segments.len() - 1;
+    let mut current = root;
+    for segment in &segments[..last_idx] {
+        match segment {
+            Segment::Key(k) => {
+                let Some(obj) = current.as_object_mut() else { return false };
+                let Some(next) = obj.get_mut(k) else { return false };
+                current = next;
+            }
+            Segment::Index(idx) => {
+                let index = *idx as usize;
+                let Some(arr) = current.as_array_mut() else { return false };
+                let Some(next) = arr.get_mut(index) else { return false };
+                current = next;
+            }
+        }
+    }
+    match &segments[last_idx] {
+        Segment::Key(k) => {
+            let Some(obj) = current.as_object_mut() else { return false };
+            obj.remove(k).is_some()
+        }
+        Segment::Index(idx) => {
+            let index = *idx as usize;
+            let Some(arr) = current.as_array_mut() else { return false };
+            if index < arr.len() {
+                arr.remove(index);
+                true
+            } else {
+                false
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/pkg/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/pkg/tests.rs
@@ -338,6 +338,6 @@ fn test_get_output_rejects_empty_key() {
 #[test]
 fn test_delete_with_numeric_key_on_object() {
     let mut value = json!({ "123": "number-key" });
-    assert!(delete_object_value_by_property_path(&mut value, "[123]").unwrap(),);
+    assert!(delete_object_value_by_property_path(&mut value, "[123]").unwrap());
     assert!(value.get("123").is_none());
 }

--- a/pacquet/crates/cli/src/cli_args/pkg/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/pkg/tests.rs
@@ -1,0 +1,251 @@
+use super::{
+    delete_object_value_by_property_path, fix_manifest, get_output,
+    set_object_value_by_property_path,
+};
+use serde_json::{Value, json};
+
+#[test]
+fn test_get_single_key() {
+    let manifest = json!({
+        "name": "test-pkg",
+        "version": "1.0.0",
+        "scripts": {
+            "test": "echo test"
+        }
+    });
+    let result = get_output(&manifest, &["version".to_string()], false).unwrap();
+    assert_eq!(result, "1.0.0");
+}
+
+#[test]
+fn test_get_single_key_json() {
+    let manifest = json!({
+        "name": "test-pkg",
+        "description": "hello",
+    });
+    let result = get_output(&manifest, &["description".to_string()], true).unwrap();
+    assert_eq!(result, r#""hello""#);
+}
+
+#[test]
+fn test_get_single_key_nested() {
+    let manifest = json!({
+        "scripts": {
+            "test": "echo test"
+        }
+    });
+    let result = get_output(&manifest, &["scripts.test".to_string()], false).unwrap();
+    assert_eq!(result, "echo test");
+}
+
+#[test]
+fn test_get_single_key_object() {
+    let manifest = json!({
+        "scripts": {
+            "test": "echo test"
+        }
+    });
+    let result = get_output(&manifest, &["scripts".to_string()], false).unwrap();
+    assert_eq!(result, "{\n  \"test\": \"echo test\"\n}");
+}
+
+#[test]
+fn test_get_missing_key() {
+    let manifest = json!({
+        "name": "test-pkg"
+    });
+    let result = get_output(&manifest, &["nonexistent".to_string()], false).unwrap();
+    assert_eq!(result, "");
+}
+
+#[test]
+fn test_get_multiple_keys() {
+    let manifest = json!({
+        "name": "test-pkg",
+        "version": "1.0.0",
+        "description": "a test"
+    });
+    let result =
+        get_output(&manifest, &["name".to_string(), "version".to_string()], false).unwrap();
+    let parsed: Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(parsed["name"], "test-pkg");
+    assert_eq!(parsed["version"], "1.0.0");
+    assert!(parsed.get("description").is_none());
+}
+
+#[test]
+fn test_get_no_keys_returns_full_manifest() {
+    let manifest = json!({
+        "name": "test-pkg",
+        "version": "1.0.0"
+    });
+    let result = get_output(&manifest, &[] as &[String], false).unwrap();
+    assert_eq!(result, "{\n  \"name\": \"test-pkg\",\n  \"version\": \"1.0.0\"\n}");
+}
+
+#[test]
+fn test_get_multiple_keys_returns_json_object() {
+    let manifest = json!({
+        "name": "test-pkg",
+        "version": "1.0.0"
+    });
+    let keys: Vec<String> = vec!["name".to_string(), "version".to_string()];
+    let result = get_output(&manifest, &keys, false).unwrap();
+    let parsed: Value = serde_json::from_str(&result).unwrap();
+    assert_eq!(parsed["name"], "test-pkg");
+    assert_eq!(parsed["version"], "1.0.0");
+}
+
+#[test]
+fn test_fix_removes_invalid_name() {
+    let mut manifest = json!({
+        "name": 123,
+        "version": "1.0.0"
+    });
+    fix_manifest(&mut manifest);
+    assert!(manifest.get("name").is_none());
+    assert_eq!(manifest["version"], "1.0.0");
+}
+
+#[test]
+fn test_fix_keeps_valid_name() {
+    let mut manifest = json!({
+        "name": "valid-pkg",
+        "version": "1.0.0"
+    });
+    fix_manifest(&mut manifest);
+    assert_eq!(manifest["name"], "valid-pkg");
+}
+
+#[test]
+fn test_fix_removes_invalid_dependencies() {
+    let mut manifest = json!({
+        "dependencies": "not-an-object"
+    });
+    fix_manifest(&mut manifest);
+    assert!(manifest.get("dependencies").is_none());
+}
+
+#[test]
+fn test_fix_removes_array_bin() {
+    let mut manifest = json!({
+        "bin": ["should", "be", "string", "or", "object"]
+    });
+    fix_manifest(&mut manifest);
+    assert!(manifest.get("bin").is_none());
+}
+
+#[test]
+fn test_fix_keeps_string_bin() {
+    let mut manifest = json!({
+        "bin": "./bin.js"
+    });
+    fix_manifest(&mut manifest);
+    assert_eq!(manifest["bin"], "./bin.js");
+}
+
+#[test]
+fn test_fix_keeps_object_bin() {
+    let mut manifest = json!({
+        "bin": {"myapp": "./bin.js"}
+    });
+    fix_manifest(&mut manifest);
+    assert_eq!(manifest["bin"]["myapp"], "./bin.js");
+}
+
+#[test]
+fn test_delete_key() {
+    let mut value = json!({
+        "name": "test-pkg",
+        "version": "1.0.0"
+    });
+    assert!(delete_object_value_by_property_path(&mut value, "version"));
+    assert!(value.get("version").is_none());
+    assert_eq!(value["name"], "test-pkg");
+}
+
+#[test]
+fn test_delete_nested_key() {
+    let mut value = json!({
+        "scripts": {
+            "test": "echo test",
+            "build": "tsc"
+        }
+    });
+    assert!(delete_object_value_by_property_path(&mut value, "scripts.build"));
+    assert!(value["scripts"].get("build").is_none());
+    assert_eq!(value["scripts"]["test"], "echo test");
+}
+
+#[test]
+fn test_delete_missing_key() {
+    let mut value = json!({
+        "name": "test-pkg"
+    });
+    assert!(!delete_object_value_by_property_path(&mut value, "nonexistent"));
+}
+
+#[test]
+fn test_delete_array_index() {
+    let mut value = json!({
+        "files": ["a", "b", "c"]
+    });
+    assert!(delete_object_value_by_property_path(&mut value, "files[1]"));
+    assert_eq!(value["files"], json!(["a", "c"]));
+}
+
+#[test]
+fn test_set_key_value() {
+    let mut value = json!({
+        "name": "old"
+    });
+    set_object_value_by_property_path(&mut value, "name", json!("new")).unwrap();
+    assert_eq!(value["name"], "new");
+}
+
+#[test]
+fn test_set_new_key() {
+    let mut value = json!({
+        "name": "test-pkg"
+    });
+    set_object_value_by_property_path(&mut value, "version", json!("2.0.0")).unwrap();
+    assert_eq!(value["version"], "2.0.0");
+}
+
+#[test]
+fn test_set_nested_key() {
+    let mut value = json!({
+        "scripts": {
+            "test": "echo test"
+        }
+    });
+    set_object_value_by_property_path(&mut value, "scripts.build", json!("tsc")).unwrap();
+    assert_eq!(value["scripts"]["build"], "tsc");
+}
+
+#[test]
+fn test_set_creates_intermediate_objects() {
+    let mut value = json!({
+        "name": "test-pkg"
+    });
+    set_object_value_by_property_path(&mut value, "scripts.test", json!("jest")).unwrap();
+    assert_eq!(value["scripts"]["test"], "jest");
+}
+
+#[test]
+fn test_set_array_index() {
+    let mut value = json!({
+        "files": ["a", "b"]
+    });
+    set_object_value_by_property_path(&mut value, "files[0]", json!("x")).unwrap();
+    assert_eq!(value["files"][0], "x");
+}
+
+#[test]
+fn test_set_array_new_index() {
+    let mut value = json!({
+        "files": ["a"]
+    });
+    set_object_value_by_property_path(&mut value, "files[2]", json!("c")).unwrap();
+    assert_eq!(value["files"], json!(["a", null, "c"]));
+}

--- a/pacquet/crates/cli/src/cli_args/pkg/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/pkg/tests.rs
@@ -159,7 +159,7 @@ fn test_delete_key() {
         "name": "test-pkg",
         "version": "1.0.0"
     });
-    assert!(delete_object_value_by_property_path(&mut value, "version"));
+    assert!(delete_object_value_by_property_path(&mut value, "version").unwrap());
     assert!(value.get("version").is_none());
     assert_eq!(value["name"], "test-pkg");
 }
@@ -172,7 +172,7 @@ fn test_delete_nested_key() {
             "build": "tsc"
         }
     });
-    assert!(delete_object_value_by_property_path(&mut value, "scripts.build"));
+    assert!(delete_object_value_by_property_path(&mut value, "scripts.build").unwrap());
     assert!(value["scripts"].get("build").is_none());
     assert_eq!(value["scripts"]["test"], "echo test");
 }
@@ -182,7 +182,7 @@ fn test_delete_missing_key() {
     let mut value = json!({
         "name": "test-pkg"
     });
-    assert!(!delete_object_value_by_property_path(&mut value, "nonexistent"));
+    assert!(!delete_object_value_by_property_path(&mut value, "nonexistent").unwrap());
 }
 
 #[test]
@@ -190,7 +190,7 @@ fn test_delete_array_index() {
     let mut value = json!({
         "files": ["a", "b", "c"]
     });
-    assert!(delete_object_value_by_property_path(&mut value, "files[1]"));
+    assert!(delete_object_value_by_property_path(&mut value, "files[1]").unwrap());
     assert_eq!(value["files"], json!(["a", "c"]));
 }
 
@@ -248,4 +248,96 @@ fn test_set_array_new_index() {
     });
     set_object_value_by_property_path(&mut value, "files[2]", json!("c")).unwrap();
     assert_eq!(value["files"], json!(["a", null, "c"]));
+}
+
+#[test]
+fn test_set_rejects_unsafe_key() {
+    let mut value = json!({ "name": "test-pkg" });
+    let result = set_object_value_by_property_path(&mut value, "__proto__.polluted", json!(true));
+    assert!(result.is_err());
+    assert!(value.get("__proto__").is_none());
+}
+
+#[test]
+fn test_set_rejects_constructor_key() {
+    let mut value = json!({ "name": "test-pkg" });
+    let result = set_object_value_by_property_path(
+        &mut value,
+        "constructor.prototype.polluted",
+        json!(true),
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_set_creates_array_from_scratch() {
+    let mut value = json!({});
+    set_object_value_by_property_path(&mut value, "keywords[0]", json!("cli")).unwrap();
+    assert_eq!(value["keywords"], json!(["cli"]));
+}
+
+#[test]
+fn test_set_creates_array_intermediate() {
+    let mut value = json!({});
+    set_object_value_by_property_path(&mut value, "keywords[0].name", json!("cli")).unwrap();
+    assert_eq!(value["keywords"][0]["name"], "cli");
+}
+
+#[test]
+fn test_set_replaces_scalar_with_object() {
+    let mut value = json!({ "foo": "bar" });
+    set_object_value_by_property_path(&mut value, "foo.baz", json!("qux")).unwrap();
+    assert_eq!(value["foo"]["baz"], "qux");
+}
+
+#[test]
+fn test_set_replaces_scalar_with_array() {
+    let mut value = json!({ "foo": "bar" });
+    set_object_value_by_property_path(&mut value, "foo[0]", json!("qux")).unwrap();
+    assert_eq!(value["foo"][0], "qux");
+}
+
+#[test]
+fn test_set_rejects_empty_path() {
+    let mut value = json!({ "name": "test-pkg" });
+    let result = set_object_value_by_property_path(&mut value, "", json!("value"));
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("empty property path"));
+}
+
+#[test]
+fn test_set_rejects_too_large_index() {
+    let mut value = json!({});
+    let big_idx = format!("x[{}]", super::MAX_ARRAY_INDEX + 1);
+    let result = set_object_value_by_property_path(&mut value, &big_idx, json!("value"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_delete_rejects_unsafe_key() {
+    let mut value = json!({ "name": "test-pkg" });
+    let result = delete_object_value_by_property_path(&mut value, "__proto__.polluted");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_set_numeric_key_on_object() {
+    let mut value = json!({ "0": "existing" });
+    set_object_value_by_property_path(&mut value, "[0]", json!("replaced")).unwrap();
+    assert_eq!(value["0"], "replaced");
+}
+
+#[test]
+fn test_get_output_rejects_empty_key() {
+    let manifest = json!({ "name": "test-pkg" });
+    let result = get_output(&manifest, &[String::new()], false);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_delete_with_numeric_key_on_object() {
+    let mut value = json!({ "123": "number-key" });
+    assert!(delete_object_value_by_property_path(&mut value, "[123]").unwrap(),);
+    assert!(value.get("123").is_none());
 }


### PR DESCRIPTION
## Summary

Implement the `pnpm pkg` command in Rust for the pacquet CLI, ported from the TypeScript implementation at `pnpm/pkg-manifest/commands/src/pkg.ts`. The command manages `package.json` through four subcommands: `get`, `set`, `delete`, and `fix`. This implementation provides native Rust subcommand dispatch via clap instead of the TypeScript approach of parsing positional arguments, while preserving identical observable behavior. 

Related to: https://github.com/pnpm/pnpm/issues/11633.

## Squash Commit Body

```text
Port the pkg command from the TypeScript CLI to the Rust pacquet CLI.

The `pnpm pkg get` subcommand retrieves values from package.json using
property-path syntax (dot and bracket notation). With no keys it returns the
full manifest; with one key it returns the raw string value or a JSON-encoded
value; with multiple keys it returns a JSON object of the selected keys.

The `pnpm pkg set` subcommand writes values to package.json using
key=value syntax. The --json flag parses the value as JSON. Intermediate
objects are created automatically for dot-separated paths. Unsafe keys
(__proto__, constructor, prototype) are rejected.

The `pnpm pkg delete` subcommand removes keys from package.json using
property-path syntax. Array indices splice the element rather than leaving
a hole.

The `pnpm pkg fix` subcommand auto-corrects common errors in package.json:
it removes name/version fields with non-string types, dependency/script fields
with non-object types, and bin fields that are neither a string nor an object.
```

## Checklist

- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `pkg` CLI command to view, update, delete, and fix `package.json`.
  * Supports property-path reads/writes (including nested objects/arrays) with optional pretty JSON handling.
  * Adds recursive operations across workspace projects when selected via configuration/filter options.
* **Bug Fixes**
  * Strengthened property-path validation to prevent prototype-pollution-style keys and unsafe segments.
  * Improved `fix` normalization by removing fields that don’t match expected shapes.
* **Tests**
  * Added unit tests covering get/set/delete, recursive behavior helpers, and safety/edge-case validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->