### PR TITLE
fix(release): keep the pack-app config inside the packed project

### DIFF
--- a/pnpm11/pnpm/artifacts/exe/package.json
+++ b/pnpm11/pnpm/artifacts/exe/package.json
@@ -54,22 +54,6 @@
     "@zkochan/cmd-shim": "catalog:",
     "execa": "catalog:"
   },
-  "pnpm": {
-    "app": {
-      "entry": "../../pnpm.cjs",
-      "outputDir": "..",
-      "outputName": "pnpm",
-      "targets": [
-        "win32-x64",
-        "linux-x64",
-        "darwin-arm64",
-        "linux-arm64",
-        "win32-arm64",
-        "linux-x64-musl",
-        "linux-arm64-musl"
-      ]
-    }
-  },
   "jest": {
     "preset": "@pnpm/jest-config"
   },

--- a/pnpm11/pnpm/artifacts/exe/scripts/build-artifacts.ts
+++ b/pnpm11/pnpm/artifacts/exe/scripts/build-artifacts.ts
@@ -12,8 +12,8 @@ const pnpmRootDir = path.resolve(exeDir, '..', '..')
 // non-Apple-Silicon-Mac dev box (Intel Mac, Windows, etc.) — build only the
 // two baseline targets so dev-local runs stay fast. The defaults (entry,
 // outputDir, outputName, targets) live in the "pnpm.app" object of
-// pnpm/artifacts/exe/package.json — CLI --target flags replace that list when
-// we want to narrow it. darwin-x64 is intentionally absent from the matrix on
+// pnpm/package.json — CLI --target flags replace that list when we want to
+// narrow it. darwin-x64 is intentionally absent from the matrix on
 // every host: Node.js SEA injection produces a binary that segfaults on
 // Intel Macs (pnpm/pnpm#11423, nodejs/node#62893).
 const isM1Mac = process.platform === 'darwin' && process.arch === 'arm64'
@@ -39,7 +39,7 @@ if (!buildFullMatrix) {
 // bundle rather than whatever pnpm happens to be on PATH.
 const pnpmBundle = path.join(pnpmRootDir, 'dist', 'pnpm.mjs')
 execa.sync(process.execPath, [pnpmBundle, 'with', 'current', ...packAppArgs], {
-  cwd: exeDir,
+  cwd: pnpmRootDir,
   stdio: 'inherit',
 })
 

--- a/pnpm11/pnpm/package.json
+++ b/pnpm11/pnpm/package.json
@@ -187,6 +187,22 @@
   "engines": {
     "node": ">=22.13"
   },
+  "pnpm": {
+    "app": {
+      "entry": "pnpm.cjs",
+      "outputDir": "artifacts",
+      "outputName": "pnpm",
+      "targets": [
+        "win32-x64",
+        "linux-x64",
+        "darwin-arm64",
+        "linux-arm64",
+        "win32-arm64",
+        "linux-x64-musl",
+        "linux-arm64-musl"
+      ]
+    }
+  },
   "jest": {
     "collectCoverage": false,
     "preset": "@pnpm/jest-config/with-registry"


### PR DESCRIPTION
## Summary

The [11.10.0 Release job](https://github.com/pnpm/pnpm/actions/runs/28716654373/job/85159520954) failed at the "Publish `@pnpm/exe`" step with `ERR_PNPM_PACK_APP_ENTRY_OUTSIDE_PROJECT`. The pack-app hardening introduced in pnpm/pnpm#12669 rejects entry and output-dir paths that escape the project directory, and our own `@pnpm/exe` build config used exactly that shape: `entry: "../../pnpm.cjs"` and `outputDir: ".."` relative to `pnpm11/pnpm/artifacts/exe`. This path is only exercised by the Release workflow, which is why CI didn't catch it before the release ran.

Fix: keep the guard strict and restructure the config so nothing escapes the project.

- Move the `pnpm.app` block to `pnpm11/pnpm/package.json` with `entry: "pnpm.cjs"` and `outputDir: "artifacts"` (the app being packed *is* pnpm, so the config now lives on the package that owns the entry).
- Run pack-app from the pnpm package root in `build-artifacts.ts` (`cwd: pnpmRootDir` instead of `exeDir`).

Output paths are unchanged: binaries still land in `pnpm11/pnpm/artifacts/<target>/pnpm`, so the copy/publish steps downstream are unaffected. The `pnpm` field is stripped from `package.json` on publish, so nothing new ships in the published `pnpm` package, and the config reader already whitelists `pnpm.app` as an actively-read key (no unknown-field warning on install).

Verified by running `node dist/pnpm.mjs pack-app --runtime node@26.0.0 --target darwin-arm64` from `pnpm11/pnpm` — the invocation shape `build-artifacts.ts` now produces. Both guards pass and the SEA binary is built at the same output path as before.

Loosening the guard to a workspace-root anchor was considered and rejected: it would re-allow embedding files from outside the packed project (e.g. a workspace-root `.npmrc`) into a distributable binary, and would require mirroring the behavior change in pacquet's pack-app port.

## Squash Commit Body

```text
The Release job for 11.10.0 failed at the Publish @pnpm/exe step with
ERR_PNPM_PACK_APP_ENTRY_OUTSIDE_PROJECT: the pack-app hardening from
pnpm/pnpm#12669 rejects entry/output paths that escape the project
directory, and the @pnpm/exe build config used exactly that shape
(entry "../../pnpm.cjs", outputDir ".." relative to
pnpm11/pnpm/artifacts/exe).

Move the pnpm.app config to pnpm11/pnpm/package.json (entry "pnpm.cjs",
outputDir "artifacts") and run pack-app from the pnpm package root in
build-artifacts.ts. Output paths are unchanged
(pnpm11/pnpm/artifacts/<target>/pnpm), and the guard stays strict
instead of being loosened to a workspace-root anchor, which would
re-allow embedding files from outside the packed project.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  *(No pacquet change needed: the pack-app guard itself is untouched; this
  only moves pnpm11 release configuration.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. *(No changeset: the `pnpm` field is stripped on publish and
  `scripts/` is not in `@pnpm/exe`'s files list, so published package
  contents are unchanged.)*
- [x] Added or updated tests. *(No new tests: release-workflow-only
  configuration; verified by running pack-app end-to-end locally.)*
- [x] Updated the documentation if needed. *(Not needed.)*

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the packaged CLI build process so generated artifacts are created from the correct project location.
  * Updated the supported build targets for the distributed app, helping ensure broader platform coverage.
  * Clarified build notes around target selection and platform exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->