### PR TITLE
chore(release): stage the wrapper packages in the Rust release workflow

### DIFF
--- a/.github/workflows/pacquet-release-to-npm.yml
+++ b/.github/workflows/pacquet-release-to-npm.yml
@@ -3,8 +3,10 @@ name: Release pnpm (Rust)
 # Manual-trigger only: patches the version into pacquet/npm/pnpm/package.json,
 # generates the per-platform packages, and publishes (no git tag / release asset
 # — npm is the artifact store). Ships the Rust port under two names, `pnpm` and
-# `@pnpm/exe`, both depending on the `@pnpm/exe.<target>` natives. The `tag`
-# defaults to `next-12` so a release never touches the production `latest`.
+# `@pnpm/exe`, both depending on the `@pnpm/exe.<target>` natives. The natives
+# go live directly; the two wrappers are only staged and must be approved with
+# `pnpm stage approve` to go live. The `tag` defaults to `next-12` so a release
+# never touches the production `latest`.
 on:
   workflow_dispatch:
     inputs:
@@ -207,15 +209,40 @@ jobs:
           cat pacquet/npm/pnpm/package.json
           for package in pacquet/npm/pacquet-* pacquet/npm/pnpm*; do cat $package/package.json ; echo ; done
 
-      - name: Publish npm packages
-        # Auth via npm trusted publishing (the `id-token: write` OIDC token), so
-        # no NPM_TOKEN; `--provenance` attests each tarball. The trailing slash
-        # publishes the directory. The glob covers the native sub-packages (build
-        # dirs `pacquet-*`, published as `@pnpm/exe.<target>`) plus the `pnpm` and
-        # `@pnpm/exe` (`pnpm-exe`) wrappers.
+      # The publish is split into two steps because npm allows a single trusted
+      # publisher per package, and `pnpm` / `@pnpm/exe` have theirs bound to
+      # release.yml (the v11 TS releases). The `@pnpm/exe.<target>` natives are
+      # published only from this workflow, so they use trusted publishing and go
+      # live immediately; the two wrappers are only *staged* with the static
+      # token and go live when a maintainer runs `pnpm stage approve <stage-id>`
+      # (that's where the OTP is consumed, so no proof-of-presence is needed
+      # here). Publishing the natives first keeps the wrappers' exact-version
+      # optionalDependencies installable at approval time. `--provenance` works
+      # in both steps — it needs only the `id-token: write` OIDC token, not
+      # trusted publishing. The steps must stay separate: `pnpm publish` skips
+      # OIDC as soon as a static `_authToken` is configured (see
+      # https://github.com/pnpm/pnpm/pull/11495), so the token must not be
+      # visible while the natives publish.
+      - name: Publish native packages (trusted publishing)
+        # The trailing slash publishes the directory. The build dirs `pacquet-*`
+        # are published as `@pnpm/exe.<target>`.
         env:
           TAG: ${{ inputs.tag }}
         run: |
-          for package in pacquet/npm/pacquet-* pacquet/npm/pnpm*; do
+          for package in pacquet/npm/pacquet-*; do
             pnpm publish "$package/" --tag "$TAG" --access public --provenance --no-git-checks
+          done
+
+      - name: Stage pnpm and @pnpm/exe wrappers (static token)
+        env:
+          TAG: ${{ inputs.tag }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -o pipefail
+          trap 'pnpm config delete "//registry.npmjs.org/:_authToken" || true' EXIT
+          pnpm config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}"
+          for package in pacquet/npm/pnpm*; do
+            # tee the output (which includes the stage id) into the job summary
+            # so the approver doesn't have to dig through the raw log.
+            pnpm stage publish "$package/" --tag "$TAG" --access public --provenance --no-git-checks | tee -a "$GITHUB_STEP_SUMMARY"
           done


### PR DESCRIPTION
## Summary

The "Release pnpm (Rust)" workflow failed on its first publish attempt ([run 28718351330](https://github.com/pnpm/pnpm/actions/runs/28718351330)): it authenticated everything via npm trusted publishing, but npm allows only one trusted publisher per package, and `pnpm` / `@pnpm/exe` already have theirs bound to `release.yml` (the v11 TS releases). The OIDC token exchange returned 404, pnpm skipped OIDC, and the unauthenticated PUT failed.

This splits the publish step in two:

1. **Natives via trusted publishing.** The `@pnpm/exe.<target>` packages are published only by this workflow, so their trusted publishers can be pointed at `pacquet-release-to-npm.yml` (environment `release`) without conflict. They go live directly.
2. **Wrappers via staged publishing.** `pnpm` and `@pnpm/exe` are uploaded with `pnpm stage publish` using the static `NPM_TOKEN`. Nothing goes live from CI for those two names — a maintainer promotes them with `pnpm stage approve <stage-id> --otp`, which is where the proof-of-presence is consumed. The stage ids are teed into the job summary for the approver.

`--provenance` keeps working in both steps since it only needs the `id-token: write` OIDC token, not trusted publishing. The steps must stay separate because `pnpm publish` skips OIDC as soon as a static `_authToken` is configured (pnpm/pnpm#11495). `set -o pipefail` guards the `tee` pipe because the runner's default bash is `-e` without `pipefail`.

Depends on pnpm/pnpm#12805: the root `.pnpmfile.cjs` `beforePacking` hook currently rejects the v12 wrapper manifests (they intentionally declare `optionalDependencies` on the natives); that PR version-gates the hook so they pass through untouched.

Registry-side prerequisites (manual, not part of this PR): configure trusted publishers for the eight `@pnpm/exe.<target>` packages against this workflow file, and ensure `NPM_TOKEN` has staged-publish rights on `pnpm` and `@pnpm/exe`.

## Squash Commit Body

```text
The Rust release workflow authenticated every publish via npm trusted
publishing, but npm allows a single trusted publisher per package and
pnpm / @pnpm/exe have theirs bound to release.yml (the v11 TS
releases). The OIDC token exchange therefore returned 404, pnpm skipped
OIDC, and the unauthenticated PUT failed with E404.

Split the publish into two steps:

1. The @pnpm/exe.<target> natives are published only from this
   workflow, so they keep trusted publishing and go live directly.
2. The pnpm and @pnpm/exe wrappers are staged with `pnpm stage publish`
   using the static NPM_TOKEN. Nothing goes live from CI for those two
   names; a maintainer promotes them with
   `pnpm stage approve <stage-id> --otp`, which is where the
   proof-of-presence is consumed. Stage ids are teed into the job
   summary for the approver.

The steps must stay separate because pnpm publish skips OIDC as soon
as a static _authToken is configured (pnpm/pnpm#11495). --provenance
keeps working in both steps: it needs only the id-token: write OIDC
token, not trusted publishing. set -o pipefail guards the tee pipe
because the runner's default bash is -e without pipefail.

Depends on the pnpmfile version-gate from pnpm/pnpm#12805.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  (CI-workflow-only change; no CLI code touched, nothing to port.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. (Not needed — no published package is changed.)

---
Written by an agent (Claude Code, claude-fable-5).
