### PR TITLE
fix(release): declare the MIT license in the generated native packages

### DIFF
--- a/pacquet/npm/pnpm/scripts/generate-packages.mjs
+++ b/pacquet/npm/pnpm/scripts/generate-packages.mjs
@@ -46,6 +46,7 @@ function generateNativePackage(target) {
   const manifestData = {
     name: packageName,
     version,
+    license: "MIT",
     os: [target.platform],
     cpu: [target.arch],
     repository: {


### PR DESCRIPTION
## Summary

The generated `@pnpm/exe.<target>` native manifests carried no `license` field, so npm showed them as unlicensed. The v11 platform artifact packages (`pnpm11/pnpm/artifacts/*`) all declare `license: MIT`, and the two v12 wrappers (`pnpm`, `@pnpm/exe`) already inherit it from the committed `pacquet/npm/pnpm/package.json` — the natives were the only gap. This adds `license: "MIT"` to the manifests produced by `generate-packages.mjs`.

Verified by running the generator with an injected version and dummy binaries (as the release workflow does): all ten packages — the eight natives plus both wrappers — now carry `license: MIT`.

## Squash Commit Body

```text
The generated @pnpm/exe.<target> manifests carried no license field,
so npm showed the natives as unlicensed. The v11 platform artifact
packages all declare MIT; the two wrappers already inherit it from the
committed manifest.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  (Release-packaging script only; the v11 artifact packages already declare MIT.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. (Not needed — the affected packages are published by the release
  workflow, not via changesets.)

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added MIT license metadata to generated package manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->