### PR TITLE
fix(cli): print the bare version for --version and -v

### DIFF
--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -61,10 +61,18 @@ use std::path::PathBuf;
 #[clap(name = "pnpm")]
 #[clap(bin_name = "pnpm")]
 #[clap(version = pacquet_config::PACQUET_VERSION)]
+#[clap(disable_version_flag = true)]
 #[clap(about = "Experimental package manager for node.js")]
 pub struct CliArgs {
     #[clap(subcommand)]
     pub command: CliCommand,
+
+    /// Print the pnpm version.
+    // Replaces clap's built-in flag, whose short form is `-V` and whose
+    // output is prefixed; pnpm uses `-v` and prints the bare version in
+    // `main` when the `Version` action raises `DisplayVersion`.
+    #[clap(short = 'v', long = "version", action = clap::ArgAction::Version)]
+    pub version: Option<bool>,
 
     /// Set working directory.
     #[clap(short = 'C', long, default_value = ".")]

--- a/pacquet/crates/cli/src/cli_args/dispatch.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch.rs
@@ -101,8 +101,17 @@ impl CliArgs {
             return Ok(());
         }
 
-        let CliArgs { command, dir, npmrc_auth_file, recursive, reporter, filter, filter_prod } =
-            self;
+        // `version` short-circuits in `main`, never reaching dispatch.
+        let CliArgs {
+            command,
+            dir,
+            npmrc_auth_file,
+            recursive,
+            reporter,
+            filter,
+            filter_prod,
+            version: _,
+        } = self;
 
         // Canonicalize `--dir` so the bunyan-envelope `prefix` emitted by
         // the reporter is the same absolute, symlink-resolved path that

--- a/pacquet/crates/cli/src/lib.rs
+++ b/pacquet/crates/cli/src/lib.rs
@@ -30,7 +30,15 @@ pub fn main() -> miette::Result<()> {
     // The default reporter's `Done in ... using pacquet v<version>` footer needs
     // the version before the first event (including the fast path's).
     pacquet_default_reporter::set_package_version(pacquet_config::PACQUET_VERSION);
-    let mut args = CliArgs::parse_from(argv);
+    let mut args = match CliArgs::try_parse_from(argv) {
+        Ok(args) => args,
+        // pnpm prints the bare version, not clap's "pnpm <version>" rendering.
+        Err(err) if err.kind() == clap::error::ErrorKind::DisplayVersion => {
+            println!("{}", pacquet_config::PACQUET_VERSION);
+            return Ok(());
+        }
+        Err(err) => err.exit(),
+    };
     args.promote_recursive_for_filter();
     // An up-to-date `pacquet install` finishes here, without paying for
     // the runtime, the HTTP client, or any worker threads.

--- a/pacquet/crates/cli/tests/version.rs
+++ b/pacquet/crates/cli/tests/version.rs
@@ -1,0 +1,33 @@
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn version_flag_prints_the_bare_version() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+
+    let output = pacquet.with_arg("--version").output().expect("run pacquet --version");
+    dbg!(&output);
+    assert!(output.status.success(), "pacquet --version should succeed");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        format!("{}\n", pacquet_config::PACQUET_VERSION),
+    );
+
+    drop(root);
+}
+
+#[test]
+fn short_version_flag_prints_the_bare_version() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+
+    let output = pacquet.with_arg("-v").output().expect("run pacquet -v");
+    dbg!(&output);
+    assert!(output.status.success(), "pacquet -v should succeed");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        format!("{}\n", pacquet_config::PACQUET_VERSION),
+    );
+
+    drop(root);
+}


### PR DESCRIPTION
## Summary

`pacquet --version` printed clap's default rendering, `pnpm 12.0.0-alpha.0`, while the TypeScript CLI prints the bare version (`11.10.0`) — a user-visible parity gap that breaks scripts parsing `pnpm --version` output. Clap's built-in flag also only accepted `-V`, whereas pnpm's short form is `-v`.

This replaces clap's built-in version flag with an explicit `-v`/`--version` arg using `ArgAction::Version`, and catches clap's `DisplayVersion` short-circuit in `main` to print `PACQUET_VERSION` without the `"pnpm "` prefix. `-V` is now rejected, matching the TS CLI (which doesn't recognize it either). Verified on the built binary: `--version` and `-v` both print `12.0.0-alpha.0` bare, and `--help` lists the flag.

Not covered yet: the TS CLI's short-circuit also honors `--version` after a known command name (e.g. `pnpm install --version` prints the version); pacquet still rejects that as an unknown argument, as it did before this change.

## Squash Commit Body

```text
Clap's built-in version flag rendered "pnpm 12.0.0-alpha.0" and only
accepted -V, while pnpm prints the bare version (12.0.0-alpha.0) and
accepts -v - scripts that parse pnpm --version output would break on
the prefix. Replace the built-in flag with a -v/--version arg using the
Version action and catch clap's DisplayVersion short-circuit in main to
print PACQUET_VERSION without clap's "name version" rendering.

The TypeScript CLI already prints the bare version (main.ts logs
packageManager.version), so no TS-side change is needed. Not covered
yet: pnpm's short-circuit also honors --version after a known command
name (e.g. pnpm install --version), which pacquet still rejects as an
unknown argument.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  (The TS CLI already prints the bare version; this fixes the pacquet side.
  The `pnpm <cmd> --version` short-circuit remains unported, as noted above.)
- [x] Added or updated tests. (`pacquet/crates/cli/tests/version.rs` covers
  `--version` and `-v` output.)

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for both `-v` and `--version` to print the app’s version as plain text and exit successfully.
* **Bug Fixes**
  * Improved CLI version handling so `-v/--version` cleanly short-circuits without normal command dispatch, while other argument errors continue to exit as before.
* **Tests**
  * Added integration tests confirming exact `-v/--version` stdout matches the configured version string (including trailing newline).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->