### PR TITLE
fix(cli): support top-level command fallback

### DIFF
--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -279,4 +279,6 @@ pub enum CliCommand {
     /// single invocation, ignoring the "packageManager" and
     /// "devEngines.packageManager" fields of the project's manifest.
     With(WithArgs),
+    #[clap(external_subcommand)]
+    External(Vec<String>),
 }

--- a/pacquet/crates/cli/src/cli_args/dispatch.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch.rs
@@ -255,6 +255,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::SetScript(args) => dispatch_script::set_script(ctx, args),
         CliCommand::Test => dispatch_script::test(ctx),
         CliCommand::Run(args) => dispatch_script::run(ctx, args),
+        CliCommand::External(command) => dispatch_script::fallback(ctx, command),
         CliCommand::Exec(args) => dispatch_script::exec(ctx, args),
         CliCommand::Dlx(args) => dispatch_install::dlx(ctx, args),
         CliCommand::Create(args) => dispatch_install::create(ctx, args),

--- a/pacquet/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_script.rs
@@ -45,6 +45,27 @@ pub(super) fn run<'a>(ctx: &RunCtx<'a>, args: RunArgs) -> miette::Result<Command
     Ok(Box::pin(std::future::ready(Ok(()))))
 }
 
+pub(super) fn fallback<'a>(
+    ctx: &RunCtx<'a>,
+    command: Vec<String>,
+) -> miette::Result<CommandFuture<'a>> {
+    let mut command = command.into_iter();
+    let args = RunArgs {
+        command: command.next(),
+        args: command.collect(),
+        if_present: false,
+        resume_from: None,
+        report_summary: false,
+        no_bail: false,
+    };
+    if ctx.recursive {
+        args.run_recursive((ctx.config)()?, ctx.dir)?;
+    } else {
+        args.run_fallback(ctx.dir, (ctx.config)()?, matches!(ctx.reporter, ReporterType::Silent))?;
+    }
+    Ok(Box::pin(std::future::ready(Ok(()))))
+}
+
 pub(super) fn exec<'a>(ctx: &RunCtx<'a>, args: ExecArgs) -> miette::Result<CommandFuture<'a>> {
     if ctx.recursive {
         args.run_recursive((ctx.config)()?, ctx.dir)?;

--- a/pacquet/crates/cli/src/cli_args/run.rs
+++ b/pacquet/crates/cli/src/cli_args/run.rs
@@ -1,3 +1,4 @@
+use super::exec::ExecArgs;
 use clap::Args;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
@@ -92,6 +93,20 @@ impl RunArgs {
     /// meaningful for the recursive path (see [`Self::run_recursive`])
     /// and are ignored here.
     pub fn run(self, dir: &Path, config: &Config, silent: bool) -> miette::Result<()> {
+        self.run_inner(dir, config, silent, false)
+    }
+
+    pub fn run_fallback(self, dir: &Path, config: &Config, silent: bool) -> miette::Result<()> {
+        self.run_inner(dir, config, silent, true)
+    }
+
+    fn run_inner(
+        self,
+        dir: &Path,
+        config: &Config,
+        silent: bool,
+        fallback_to_exec: bool,
+    ) -> miette::Result<()> {
         let RunArgs { command, args, if_present, .. } = self;
         let manifest =
             PackageManifest::from_path(dir.join("package.json")).map_err(RunError::Manifest)?;
@@ -113,6 +128,16 @@ impl RunArgs {
         if specified.is_empty() {
             if if_present {
                 return Ok(());
+            }
+            if fallback_to_exec {
+                return ExecArgs {
+                    command: std::iter::once(script_name).chain(args).collect(),
+                    shell_mode: false,
+                    resume_from: None,
+                    report_summary: false,
+                    no_bail: false,
+                }
+                .run(dir, config);
             }
             return Err(RunError::NoScript {
                 script: script_name.clone(),

--- a/pacquet/crates/cli/src/cli_args/run.rs
+++ b/pacquet/crates/cli/src/cli_args/run.rs
@@ -108,12 +108,18 @@ impl RunArgs {
         fallback_to_exec: bool,
     ) -> miette::Result<()> {
         let RunArgs { command, args, if_present, .. } = self;
-        let manifest =
-            PackageManifest::from_path(dir.join("package.json")).map_err(RunError::Manifest)?;
-
         let Some(script_name) = command else {
+            let manifest =
+                PackageManifest::from_path(dir.join("package.json")).map_err(RunError::Manifest)?;
             println!("{}", render_project_commands(manifest.value()));
             return Ok(());
+        };
+        let manifest = match PackageManifest::from_path(dir.join("package.json")) {
+            Ok(manifest) => manifest,
+            Err(PackageManifestError::NoImporterManifestFound(_)) if fallback_to_exec => {
+                return exec_fallback(script_name, args, dir, config);
+            }
+            Err(err) => return Err(RunError::Manifest(err).into()),
         };
 
         let mut specified = specified_scripts(manifest.value(), &script_name);
@@ -130,14 +136,7 @@ impl RunArgs {
                 return Ok(());
             }
             if fallback_to_exec {
-                return ExecArgs {
-                    command: std::iter::once(script_name).chain(args).collect(),
-                    shell_mode: false,
-                    resume_from: None,
-                    report_summary: false,
-                    no_bail: false,
-                }
-                .run(dir, config);
+                return exec_fallback(script_name, args, dir, config);
             }
             return Err(RunError::NoScript {
                 script: script_name.clone(),
@@ -193,6 +192,22 @@ impl RunArgs {
     pub fn run_recursive(&self, config: &Config, dir: &Path) -> miette::Result<()> {
         recursive::run_recursive(self, config, dir)
     }
+}
+
+fn exec_fallback(
+    script_name: String,
+    args: Vec<String>,
+    dir: &Path,
+    config: &Config,
+) -> miette::Result<()> {
+    ExecArgs {
+        command: std::iter::once(script_name).chain(args).collect(),
+        shell_mode: false,
+        resume_from: None,
+        report_summary: false,
+        no_bail: false,
+    }
+    .run(dir, config)
 }
 
 /// Shared inputs for running a script, threaded through

--- a/pacquet/crates/cli/src/cli_args/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/tests.rs
@@ -159,6 +159,32 @@ fn install_command_parses_i_alias() {
 }
 
 #[test]
+fn unknown_top_level_command_parses_as_external() {
+    let parsed = CliArgs::try_parse_from([
+        "pacquet",
+        "commitlint",
+        "--edit",
+        "--config=commitlint.config.cjs",
+    ])
+    .expect("parses external command");
+    let CliCommand::External(command) = parsed.command else {
+        panic!("expected external command");
+    };
+    assert_eq!(command, ["commitlint", "--edit", "--config=commitlint.config.cjs"]);
+}
+
+#[test]
+fn unknown_top_level_command_preserves_global_options() {
+    let parsed = CliArgs::try_parse_from(["pacquet", "--dir", "project", "commitlint"])
+        .expect("parses external command with globals");
+    let CliCommand::External(command) = parsed.command else {
+        panic!("expected external command");
+    };
+    assert_eq!(parsed.dir, std::path::PathBuf::from("project"));
+    assert_eq!(command, ["commitlint"]);
+}
+
+#[test]
 fn parse_package_manager_handles_unscoped_scoped_and_url_references() {
     // Unscoped `name@version`.
     assert_eq!(

--- a/pacquet/crates/cli/src/config_overrides.rs
+++ b/pacquet/crates/cli/src/config_overrides.rs
@@ -109,7 +109,9 @@ impl ConfigOverrides {
 fn external_command_index(argv: &[OsString]) -> Option<usize> {
     let mut index = 1;
     while index < argv.len() {
-        let arg = argv[index].to_str()?;
+        let Some(arg) = argv[index].to_str() else {
+            return Some(index);
+        };
         if arg == "--" {
             return None;
         }

--- a/pacquet/crates/cli/src/config_overrides.rs
+++ b/pacquet/crates/cli/src/config_overrides.rs
@@ -1,3 +1,5 @@
+use crate::cli_args::CliArgs;
+use clap::CommandFactory;
 use pacquet_config::Config;
 use std::{
     collections::BTreeMap,
@@ -35,9 +37,15 @@ impl ConfigOverrides {
     where
         Argv: IntoIterator<Item = OsString>,
     {
+        let argv = argv.into_iter().collect::<Vec<_>>();
+        let external_command_index = external_command_index(&argv);
         let mut overrides = Self::default();
         let mut remaining = Vec::new();
-        for arg in argv {
+        for (index, arg) in argv.into_iter().enumerate() {
+            if external_command_index.is_some_and(|command_index| index > command_index) {
+                remaining.push(arg);
+                continue;
+            }
             match classify(&arg) {
                 ConfigToken::WellFormed { key, value } => overrides.set(key, value),
                 ConfigToken::Malformed => {}
@@ -96,6 +104,55 @@ impl ConfigOverrides {
             config.shared_workspace_lockfile = value;
         }
     }
+}
+
+fn external_command_index(argv: &[OsString]) -> Option<usize> {
+    let mut index = 1;
+    while index < argv.len() {
+        let arg = argv[index].to_str()?;
+        if arg == "--" {
+            return None;
+        }
+        if arg.starts_with("--config.") {
+            index += 1;
+            continue;
+        }
+        if let Some(width) = global_option_width(arg) {
+            index += width;
+            continue;
+        }
+        if arg.starts_with('-') {
+            index += 1;
+            continue;
+        }
+        return (!is_known_top_level_command(arg)).then_some(index);
+    }
+    None
+}
+
+fn global_option_width(arg: &str) -> Option<usize> {
+    if matches!(arg, "-r" | "-v") {
+        return Some(1);
+    }
+    if matches!(arg, "-C" | "-F") {
+        return Some(2);
+    }
+    if arg.starts_with("-C") || arg.starts_with("-F") {
+        return Some(1);
+    }
+    let name = arg.strip_prefix("--")?;
+    let (name, has_value) = name.split_once('=').map_or((name, false), |(name, _)| (name, true));
+    let consumes_value = matches!(
+        name,
+        "dir" | "filter" | "filter-prod" | "npmrc-auth-file" | "reporter" | "userconfig",
+    );
+    Some(if consumes_value && !has_value { 2 } else { 1 })
+}
+
+fn is_known_top_level_command(name: &str) -> bool {
+    CliArgs::command().get_subcommands().any(|command| {
+        command.get_name() == name || command.get_all_aliases().any(|alias| alias == name)
+    })
 }
 
 enum ConfigToken<'a> {

--- a/pacquet/crates/cli/src/config_overrides/tests.rs
+++ b/pacquet/crates/cli/src/config_overrides/tests.rs
@@ -96,6 +96,26 @@ fn config_tokens_after_external_command_stay_in_argv() {
     assert_eq!(config.registry, "https://example.test/");
 }
 
+#[cfg(unix)]
+#[test]
+fn non_utf8_token_stops_config_token_extraction() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let non_utf8 = OsString::from_vec(vec![0xff]);
+    let (overrides, remaining) = ConfigOverrides::extract(vec![
+        OsString::from("pacquet"),
+        OsString::from("--config.registry=https://example.test/"),
+        non_utf8.clone(),
+        OsString::from("--config.foo=bar"),
+    ]);
+    let expected = vec![OsString::from("pacquet"), non_utf8, OsString::from("--config.foo=bar")];
+    assert_eq!(remaining, expected);
+
+    let mut config = Config::default();
+    overrides.apply(&mut config);
+    assert_eq!(config.registry, "https://example.test/");
+}
+
 #[test]
 fn malformed_tokens_are_dropped() {
     let (_, remaining) =

--- a/pacquet/crates/cli/src/config_overrides/tests.rs
+++ b/pacquet/crates/cli/src/config_overrides/tests.rs
@@ -80,6 +80,23 @@ fn unknown_keys_are_dropped_silently() {
 }
 
 #[test]
+fn config_tokens_after_external_command_stay_in_argv() {
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "--config.registry=https://example.test/",
+        "--dir",
+        "project",
+        "commitlint",
+        "--config.foo=bar",
+    ]));
+    let expected = argv(["pacquet", "--dir", "project", "commitlint", "--config.foo=bar"]);
+    assert_eq!(remaining, expected);
+    let mut config = Config::default();
+    overrides.apply(&mut config);
+    assert_eq!(config.registry, "https://example.test/");
+}
+
+#[test]
 fn malformed_tokens_are_dropped() {
     let (_, remaining) =
         ConfigOverrides::extract(argv(["--config.registry", "--config.=missing-key", "install"]));

--- a/pacquet/crates/cli/tests/run.rs
+++ b/pacquet/crates/cli/tests/run.rs
@@ -390,6 +390,24 @@ fn top_level_fallback_runs_local_bin_when_script_is_missing() {
     drop(root);
 }
 
+#[cfg(unix)]
+#[test]
+fn top_level_fallback_runs_local_bin_without_package_json() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let bin_dir = workspace.join("node_modules").join(".bin");
+    fs::create_dir_all(&bin_dir).expect("create node_modules/.bin");
+    let marker = workspace.join("args.txt");
+    write_executable(
+        &bin_dir.join("commitlint"),
+        &format!("#!/bin/sh\nprintf '%s\\n' \"$@\" > \"{}\"\n", marker.display()),
+    );
+
+    pacquet.with_args(["commitlint", "--edit", "COMMIT_EDITMSG"]).assert().success();
+    assert_eq!(fs::read_to_string(&marker).expect("read marker"), "--edit\nCOMMIT_EDITMSG\n");
+
+    drop(root);
+}
+
 /// With a non-silent reporter (the default, or e.g. `--reporter=ndjson`),
 /// `pacquet run` echoes `$ <script>` to stderr before spawning the script —
 /// matching pnpm's `runLifecycleHook.ts:110`

--- a/pacquet/crates/cli/tests/run.rs
+++ b/pacquet/crates/cli/tests/run.rs
@@ -408,6 +408,24 @@ fn top_level_fallback_runs_local_bin_without_package_json() {
     drop(root);
 }
 
+#[cfg(unix)]
+#[test]
+fn top_level_fallback_forwards_dotted_config_args_to_local_bin() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let bin_dir = workspace.join("node_modules").join(".bin");
+    fs::create_dir_all(&bin_dir).expect("create node_modules/.bin");
+    let marker = workspace.join("args.txt");
+    write_executable(
+        &bin_dir.join("commitlint"),
+        &format!("#!/bin/sh\nprintf '%s\\n' \"$@\" > \"{}\"\n", marker.display()),
+    );
+
+    pacquet.with_args(["commitlint", "--config.foo=bar"]).assert().success();
+    assert_eq!(fs::read_to_string(&marker).expect("read marker"), "--config.foo=bar\n");
+
+    drop(root);
+}
+
 /// With a non-silent reporter (the default, or e.g. `--reporter=ndjson`),
 /// `pacquet run` echoes `$ <script>` to stderr before spawning the script —
 /// matching pnpm's `runLifecycleHook.ts:110`

--- a/pacquet/crates/cli/tests/run.rs
+++ b/pacquet/crates/cli/tests/run.rs
@@ -332,6 +332,64 @@ fn run_finds_local_bin_on_path() {
     drop(root);
 }
 
+#[cfg(unix)]
+#[test]
+fn top_level_fallback_runs_script_before_local_bin() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let bin_dir = workspace.join("node_modules").join(".bin");
+    fs::create_dir_all(&bin_dir).expect("create node_modules/.bin");
+    let marker = workspace.join("source.txt");
+    write_executable(
+        &bin_dir.join("commitlint"),
+        &format!("#!/bin/sh\nprintf bin > \"{}\"\n", marker.display()),
+    );
+    let manifest = json!({
+        "name": "test",
+        "version": "0.0.0",
+        "scripts": {
+            "commitlint": format!(r#"printf script > "{}""#, marker.display()),
+        },
+    })
+    .to_string();
+    fs::write(workspace.join("package.json"), manifest).expect("write package.json");
+
+    pacquet.with_arg("commitlint").assert().success();
+    assert_eq!(fs::read_to_string(&marker).expect("read marker"), "script");
+
+    drop(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn top_level_fallback_runs_local_bin_when_script_is_missing() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let bin_dir = workspace.join("node_modules").join(".bin");
+    fs::create_dir_all(&bin_dir).expect("create node_modules/.bin");
+    let marker = workspace.join("args.txt");
+    write_executable(
+        &bin_dir.join("commitlint"),
+        &format!("#!/bin/sh\nprintf '%s\\n' \"$@\" > \"{}\"\n", marker.display()),
+    );
+    let manifest = json!({
+        "name": "test",
+        "version": "0.0.0",
+        "scripts": {},
+    })
+    .to_string();
+    fs::write(workspace.join("package.json"), manifest).expect("write package.json");
+
+    pacquet
+        .with_args(["commitlint", "--edit", "--config=commitlint.config.cjs"])
+        .assert()
+        .success();
+    assert_eq!(
+        fs::read_to_string(&marker).expect("read marker"),
+        "--edit\n--config=commitlint.config.cjs\n",
+    );
+
+    drop(root);
+}
+
 /// With a non-silent reporter (the default, or e.g. `--reporter=ndjson`),
 /// `pacquet run` echoes `$ <script>` to stderr before spawning the script —
 /// matching pnpm's `runLifecycleHook.ts:110`

--- a/pacquet/crates/cli/tests/run_recursive.rs
+++ b/pacquet/crates/cli/tests/run_recursive.rs
@@ -100,6 +100,36 @@ fn recursive_run_executes_script_in_every_project() {
 }
 
 #[test]
+fn top_level_fallback_enters_recursive_run() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let commitlint_writes_marker = |name: &str| {
+        json!({
+            "name": name,
+            "version": "1.0.0",
+            "scripts": { "commitlint": "touch ran.txt" },
+        })
+    };
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", commitlint_writes_marker("project-1")),
+            ("project-2", commitlint_writes_marker("project-2")),
+        ],
+    );
+
+    pacquet.with_arg("-r").with_arg("commitlint").assert().success();
+
+    for name in ["project-1", "project-2"] {
+        assert!(
+            workspace.join(name).join("ran.txt").exists(),
+            "{name} commitlint script should have run through recursive fallback",
+        );
+    }
+
+    drop(root);
+}
+
+#[test]
 fn recursive_run_settings_only_workspace_enumerates_root_only() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     fs::write(

--- a/pacquet/crates/cli/tests/run_recursive.rs
+++ b/pacquet/crates/cli/tests/run_recursive.rs
@@ -23,6 +23,13 @@ fn write_workspace(workspace: &Path, manifests: &[(&str, Value)]) {
     }
 }
 
+fn write_executable(path: &Path, body: &str) {
+    fs::write(path, body).expect("write executable");
+    let mut perms = fs::metadata(path).expect("stat executable").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).expect("chmod +x");
+}
+
 /// Map each summary entry to `(basename, status)` so assertions don't
 /// depend on the absolute tempdir path used as the key.
 fn summary_statuses(workspace: &Path) -> HashMap<String, String> {
@@ -106,7 +113,9 @@ fn top_level_fallback_enters_recursive_run() {
         json!({
             "name": name,
             "version": "1.0.0",
-            "scripts": { "commitlint": "touch ran.txt" },
+            "scripts": {
+                "commitlint": r#"node -e "require('fs').writeFileSync('ran.txt', '')""#,
+            },
         })
     };
     write_workspace(
@@ -123,6 +132,39 @@ fn top_level_fallback_enters_recursive_run() {
         assert!(
             workspace.join(name).join("ran.txt").exists(),
             "{name} commitlint script should have run through recursive fallback",
+        );
+    }
+
+    drop(root);
+}
+
+#[test]
+fn top_level_fallback_does_not_exec_local_bin_recursively() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", json!({ "name": "project-1", "version": "1.0.0", "scripts": {} })),
+            ("project-2", json!({ "name": "project-2", "version": "1.0.0", "scripts": {} })),
+        ],
+    );
+    for name in ["project-1", "project-2"] {
+        let bin_dir = workspace.join(name).join("node_modules").join(".bin");
+        fs::create_dir_all(&bin_dir).expect("create node_modules/.bin");
+        write_executable(&bin_dir.join("commitlint"), "#!/bin/sh\ntouch bin-ran.txt\n");
+    }
+
+    let output = pacquet.with_arg("-r").with_arg("commitlint").output().expect("spawn pacquet");
+    assert!(!output.status.success(), "recursive shorthand without matching scripts must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT"),
+        "recursive shorthand must report the recursive no-script error, got: {stderr}",
+    );
+    for name in ["project-1", "project-2"] {
+        assert!(
+            !workspace.join(name).join("bin-ran.txt").exists(),
+            "{name} local binary must not run from recursive shorthand",
         );
     }
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Pacquet now matches the TypeScript pnpm shorthand for unknown top-level commands. `pnpm <name>` first tries a matching package script, and when no script exists it executes `<name>` from `node_modules/.bin` through the existing exec path.

This fixes hooks such as `pnpm commitlint --edit --config=commitlint.config.cjs` when the repository uses the Rust pnpm binary.

## Squash Commit Body

```text
Pacquet did not implement pnpm's top-level fallback command behavior. The TypeScript CLI parses an unknown top-level token as `run`, then falls through to `exec` when no matching script exists. That lets commands like `pnpm commitlint --edit ...` resolve local bins from `node_modules/.bin`.

Add an external clap subcommand for pacquet, route it through the existing run dispatcher, and fall through to the existing exec implementation only when no script matches. Scripts still take precedence over local bins, matching pnpm.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unknown top-level commands are now accepted and passed through as external commands.
  * Invoking `pacquet <name>` now prefers a matching `package.json` script when present, otherwise falls back to executing the local binary.
  * In recursive mode, this fallback behavior is applied across workspace projects.
* **Bug Fixes**
  * `--config.*` and other global options are no longer incorrectly consumed when an external command begins.
  * Fallback forwarding preserves positional and dotted config-style arguments more reliably.
* **Tests**
  * Added unit tests and Unix-only integration coverage for parsing, fallback resolution, recursive behavior, and argument forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->