### PR TITLE
fix(cli): accept a --no-<flag> negation for every boolean flag

### DIFF
--- a/pacquet/crates/cli/src/boolean_negations.rs
+++ b/pacquet/crates/cli/src/boolean_negations.rs
@@ -1,0 +1,75 @@
+//! Generic `--no-<flag>` support for every boolean flag.
+//!
+//! pnpm parses its CLI with `nopt`, which auto-accepts a `--no-<name>`
+//! negation for every option typed as `Boolean` — so `pnpm install
+//! --no-frozen-lockfile`, `--no-lockfile-only`, `--no-dry-run`, etc. all
+//! parse even though only the positive spelling is documented. pacquet's
+//! clap flags are plain `#[clap(long)] bool`s, which accept only the
+//! positive form, so any forwarded `--no-<bool>` aborts the parser with
+//! "unexpected argument".
+//!
+//! Rather than hand-write a paired `--no-` flag per boolean (and keep them
+//! in sync forever), [`with_boolean_negations`] walks the built clap
+//! [`Command`] and, for every boolean flag that doesn't already have a
+//! `--no-` sibling, adds a hidden negation that `overrides_with` the
+//! positive flag. Last-one-wins override semantics mean `--no-foo` leaves
+//! the field at its `false` default and `--foo --no-foo` resolves to
+//! `false`, matching nopt. Because the negations are real clap args, the
+//! grammar stays intact — trailing pass-through args (`run`, `exec`,
+//! `dlx`) and value-taking flags are unaffected.
+
+use clap::{Arg, ArgAction, Command};
+use std::collections::HashSet;
+
+/// Add a hidden `--no-<flag>` negation for every boolean flag in `cmd`
+/// (recursively, across all subcommands) that lacks one. See the module
+/// docs for why this mirrors pnpm/nopt.
+pub fn with_boolean_negations(mut cmd: Command) -> Command {
+    let existing_longs: HashSet<String> =
+        cmd.get_arguments().filter_map(|arg| arg.get_long().map(String::from)).collect();
+
+    let negations: Vec<(clap::Id, String, bool)> = cmd
+        .get_arguments()
+        .filter(|arg| matches!(arg.get_action(), ArgAction::SetTrue))
+        .filter_map(|arg| {
+            let long = arg.get_long()?;
+            // Skip explicit negations (`--no-optional`, `--no-runtime`, ...)
+            // and any positive flag that already ships its own `--no-`
+            // counterpart. The latter also covers a global flag already
+            // seen from an ancestor command on this recursion, so its
+            // negation isn't added twice.
+            if long.starts_with("no-") || existing_longs.contains(&format!("no-{long}")) {
+                return None;
+            }
+            Some((arg.get_id().clone(), format!("no-{long}"), arg.is_global_set()))
+        })
+        .collect();
+
+    for (positive_id, negated_long, is_global) in negations {
+        let negated_id = format!("__negated__{negated_long}");
+        cmd = cmd.mut_arg(positive_id.clone(), |arg| arg.overrides_with(negated_id.clone()));
+        // A global source flag propagates into every subcommand, so its
+        // negation must too — otherwise the override reference dangles at
+        // the subcommand level.
+        let mut negation = Arg::new(negated_id)
+            .long(negated_long)
+            .action(ArgAction::SetTrue)
+            .hide(true)
+            .overrides_with(positive_id);
+        if is_global {
+            negation = negation.global(true);
+        }
+        cmd = cmd.arg(negation);
+    }
+
+    let subcommand_names: Vec<String> =
+        cmd.get_subcommands().map(|sub| sub.get_name().to_string()).collect();
+    for name in subcommand_names {
+        cmd = cmd.mut_subcommand(name, with_boolean_negations);
+    }
+
+    cmd
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/boolean_negations/tests.rs
+++ b/pacquet/crates/cli/src/boolean_negations/tests.rs
@@ -1,0 +1,98 @@
+use super::with_boolean_negations;
+use crate::cli_args::CliArgs;
+use clap::{CommandFactory, FromArgMatches};
+
+/// Resolve a boolean flag on the `install` subcommand after parsing
+/// `argv` through the negation-augmented command, exercising the same
+/// path `main` uses.
+fn install_flag(argv: &[&str], flag_id: &str) -> Result<bool, clap::Error> {
+    let matches = with_boolean_negations(CliArgs::command()).try_get_matches_from(argv)?;
+    let (name, install) = matches.subcommand().expect("a subcommand");
+    assert_eq!(name, "install");
+    Ok(install.get_flag(flag_id))
+}
+
+/// Parse `argv` through the negation-augmented command all the way back
+/// into `CliArgs`, so top-level (global) flags can be inspected.
+fn parse(argv: &[&str]) -> Result<CliArgs, clap::Error> {
+    with_boolean_negations(CliArgs::command())
+        .try_get_matches_from(argv)
+        .and_then(|matches| CliArgs::from_arg_matches(&matches))
+}
+
+#[test]
+fn no_frozen_lockfile_parses_and_leaves_the_flag_off() {
+    let frozen = install_flag(&["pnpm", "install", "--no-frozen-lockfile"], "frozen_lockfile")
+        .expect("--no-frozen-lockfile should parse");
+    assert!(!frozen);
+}
+
+#[test]
+fn positive_frozen_lockfile_still_sets_the_flag() {
+    let frozen = install_flag(&["pnpm", "install", "--frozen-lockfile"], "frozen_lockfile")
+        .expect("--frozen-lockfile should parse");
+    assert!(frozen);
+}
+
+#[test]
+fn last_negation_wins_over_earlier_positive() {
+    let frozen = install_flag(
+        &["pnpm", "install", "--frozen-lockfile", "--no-frozen-lockfile"],
+        "frozen_lockfile",
+    )
+    .expect("both flags together should parse");
+    assert!(!frozen);
+}
+
+#[test]
+fn last_positive_wins_over_earlier_negation() {
+    let frozen = install_flag(
+        &["pnpm", "install", "--no-frozen-lockfile", "--frozen-lockfile"],
+        "frozen_lockfile",
+    )
+    .expect("both flags together should parse");
+    assert!(frozen);
+}
+
+#[test]
+fn negation_covers_other_boolean_flags() {
+    for (argv, id) in [
+        (["pnpm", "install", "--no-lockfile-only"], "lockfile_only"),
+        (["pnpm", "install", "--no-dry-run"], "dry_run"),
+        (["pnpm", "install", "--no-ignore-scripts"], "ignore_scripts"),
+    ] {
+        let value = install_flag(&argv, id).expect("boolean negation should parse");
+        assert!(!value, "{id} should be off");
+    }
+}
+
+#[test]
+fn explicit_negations_are_not_shadowed() {
+    let value = install_flag(
+        &["pnpm", "install", "--no-prefer-frozen-lockfile"],
+        "no_prefer_frozen_lockfile",
+    )
+    .expect("the hand-written --no-prefer-frozen-lockfile should still parse");
+    assert!(value);
+}
+
+#[test]
+fn genuinely_unknown_flag_still_errors() {
+    let error = install_flag(&["pnpm", "install", "--no-such-flag"], "frozen_lockfile")
+        .expect_err("an unknown flag must still be rejected");
+    assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
+}
+
+#[test]
+fn global_flag_negation_propagates_into_subcommands() {
+    // `--recursive` is a global bool defined on the root command; its
+    // generated `--no-recursive` must be global too so it parses under a
+    // subcommand and resolves the flag off (the `is_global_set()` branch).
+    let off = parse(&["pnpm", "install", "--no-recursive"]).expect("--no-recursive should parse");
+    assert!(!off.recursive);
+    let on = parse(&["pnpm", "install", "--recursive"]).expect("--recursive should parse");
+    assert!(on.recursive);
+    let toggled = parse(&["pnpm", "install", "--recursive", "--no-recursive"])
+        .expect("both flags together should parse");
+    assert!(!toggled.recursive);
+}

--- a/pacquet/crates/cli/src/cli_args/deploy.rs
+++ b/pacquet/crates/cli/src/cli_args/deploy.rs
@@ -1,6 +1,6 @@
 use crate::{
     State,
-    cli_args::install::{InstallArgs, NodeLinkerArg},
+    cli_args::install::{InstallArgs, NodeLinkerArg, resolve_bool_override},
 };
 use clap::Args;
 use derive_more::{Display, Error};
@@ -338,7 +338,11 @@ impl DeployArgs {
             .supported_architectures
             .apply_to(config.supported_architectures.clone());
         let skip_runtimes = config.skip_runtimes || self.install_args.no_runtime;
-        let trust_lockfile = config.trust_lockfile || self.install_args.trust_lockfile;
+        let trust_lockfile = resolve_bool_override(
+            self.install_args.trust_lockfile,
+            self.install_args.no_trust_lockfile,
+            config.trust_lockfile,
+        );
         let lockfile_path = config.lockfile.then(|| deploy_dir.join(Lockfile::FILE_NAME));
         let prefer_frozen_lockfile = frozen_lockfile.then_some(true).or(Some(false));
         let dependency_groups =

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -102,10 +102,10 @@ pub struct InstallArgs {
 
     /// Force-enable `preferFrozenLockfile` for this invocation.
     /// Overrides `pnpm-workspace.yaml` / `PNPM_CONFIG_PREFER_FROZEN_LOCKFILE`.
-    /// Mirrors pnpm's `--prefer-frozen-lockfile`. Conflicts with
-    /// [`Self::no_prefer_frozen_lockfile`] so a single invocation
-    /// can't both force-on and force-off.
-    #[clap(long = "prefer-frozen-lockfile")]
+    /// Mirrors pnpm's `--prefer-frozen-lockfile`. Paired with
+    /// [`Self::no_prefer_frozen_lockfile`] by mutual `overrides_with`, so
+    /// both spellings in one argv resolve last-one-wins (nopt semantics).
+    #[clap(long = "prefer-frozen-lockfile", overrides_with = "no_prefer_frozen_lockfile")]
     pub prefer_frozen_lockfile: bool,
 
     /// Force-disable `preferFrozenLockfile` for this invocation.
@@ -113,7 +113,7 @@ pub struct InstallArgs {
     /// Mirrors pnpm's `--no-prefer-frozen-lockfile`. Useful for CI
     /// runs that want to force a re-resolve against the registry
     /// without setting the flag globally.
-    #[clap(long = "no-prefer-frozen-lockfile", conflicts_with = "prefer_frozen_lockfile")]
+    #[clap(long = "no-prefer-frozen-lockfile", overrides_with = "prefer_frozen_lockfile")]
     pub no_prefer_frozen_lockfile: bool,
 
     /// Skip the per-importer `package.json` ↔ `pnpm-lock.yaml`
@@ -152,11 +152,17 @@ pub struct InstallArgs {
     /// `--ignore-scripts`.
     ///
     /// Merged into `config.ignore_scripts` at the CLI dispatch in
-    /// `cli_args.rs` (it only ever enables, never toggles a yaml `true`
-    /// back off), so the install reads it from the config like every
-    /// other build-script setting.
-    #[clap(long = "ignore-scripts")]
+    /// `cli_args.rs`, so the install reads it from the config like every
+    /// other build-script setting. Paired with [`Self::no_ignore_scripts`],
+    /// the CLI inverse, by mutual `overrides_with` (last-one-wins).
+    #[clap(long = "ignore-scripts", overrides_with = "no_ignore_scripts")]
     pub ignore_scripts: bool,
+
+    /// Force-enable lifecycle scripts for this invocation, overriding a
+    /// `pnpm-workspace.yaml` / `.npmrc` `ignoreScripts: true`. Mirrors
+    /// pnpm's `--no-ignore-scripts`.
+    #[clap(long = "no-ignore-scripts", overrides_with = "ignore_scripts")]
+    pub no_ignore_scripts: bool,
 
     /// Override `nodeLinker` from `pnpm-workspace.yaml` /
     /// `.npmrc`. `None` (flag not passed) leaves the config's value
@@ -178,23 +184,35 @@ pub struct InstallArgs {
     /// fetches. Stage 2's resolver will extend the gate to the
     /// metadata path.
     ///
-    /// Overrides `offline` from `pnpm-workspace.yaml`: any
-    /// `--offline` upgrades a yaml `false` to `true`, but cannot
-    /// turn an explicit yaml `true` back off.
-    #[clap(long)]
+    /// Overrides `offline` from `pnpm-workspace.yaml`. Paired with
+    /// [`Self::no_offline`], the CLI inverse that forces a yaml `true`
+    /// back off, by mutual `overrides_with` (last-one-wins).
+    #[clap(long, overrides_with = "no_offline")]
     pub offline: bool,
+
+    /// Force-disable offline mode for this invocation, overriding a
+    /// `pnpm-workspace.yaml` `offline: true`. Mirrors pnpm's
+    /// `--no-offline`.
+    #[clap(long = "no-offline", overrides_with = "offline")]
+    pub no_offline: bool,
 
     /// Open the package store read-only (immutable) and skip all store
     /// writes. For installs against a store on a read-only filesystem
     /// (e.g. a Nix store); pair with `--offline --frozen-lockfile`.
     /// Mirrors pnpm's `--frozen-store`. Overrides `frozenStore` from
-    /// `pnpm-workspace.yaml`: any `--frozen-store` upgrades a yaml
-    /// `false` to `true`, but cannot turn an explicit yaml `true` back
-    /// off. (pnpm additionally rejects `--frozen-store` combined with
-    /// `--force`; pacquet has no `force` flow yet, so there is nothing
-    /// to conflict with — the guard ports alongside `force`.)
-    #[clap(long = "frozen-store")]
+    /// `pnpm-workspace.yaml`. Paired with [`Self::no_frozen_store`], the
+    /// CLI inverse, by mutual `overrides_with` (last-one-wins). (pnpm
+    /// additionally rejects `--frozen-store` combined with `--force`;
+    /// pacquet has no `force` flow yet, so there is nothing to conflict
+    /// with — the guard ports alongside `force`.)
+    #[clap(long = "frozen-store", overrides_with = "no_frozen_store")]
     pub frozen_store: bool,
+
+    /// Force-disable the read-only store for this invocation, overriding
+    /// a `pnpm-workspace.yaml` `frozenStore: true`. Mirrors pnpm's
+    /// `--no-frozen-store`.
+    #[clap(long = "no-frozen-store", overrides_with = "frozen_store")]
+    pub no_frozen_store: bool,
 
     /// Prefer cached artifacts over network fetches when both have
     /// what's needed. The `--prefer-offline` flag biases the
@@ -203,16 +221,31 @@ pub struct InstallArgs {
     /// local store via the warm prefetch + `index.db` lookups, so
     /// the flag is a no-op for artifact fetches today. Field exists
     /// so yaml / CLI parse cleanly; Stage 2's resolver will honor it
-    /// on the metadata path.
-    #[clap(long)]
+    /// on the metadata path. Paired with [`Self::no_prefer_offline`], the
+    /// CLI inverse, by mutual `overrides_with` (last-one-wins).
+    #[clap(long, overrides_with = "no_prefer_offline")]
     pub prefer_offline: bool,
+
+    /// Force-disable prefer-offline for this invocation, overriding a
+    /// `pnpm-workspace.yaml` `preferOffline: true`. Mirrors pnpm's
+    /// `--no-prefer-offline`.
+    #[clap(long = "no-prefer-offline", overrides_with = "prefer_offline")]
+    pub no_prefer_offline: bool,
 
     /// Skip the lockfile supply-chain verification pass entirely.
     /// Overrides `pnpm-workspace.yaml#trustLockfile`. Mirrors pnpm's
     /// `--trust-lockfile`. See [`pacquet_config::Config::trust_lockfile`].
     /// Added for [pnpm/pnpm#11860](https://github.com/pnpm/pnpm/issues/11860).
-    #[clap(long = "trust-lockfile")]
+    /// Paired with [`Self::no_trust_lockfile`], the CLI inverse, by mutual
+    /// `overrides_with` (last-one-wins).
+    #[clap(long = "trust-lockfile", overrides_with = "no_trust_lockfile")]
     pub trust_lockfile: bool,
+
+    /// Force the supply-chain verification pass to run for this
+    /// invocation, overriding a `pnpm-workspace.yaml` `trustLockfile: true`.
+    /// Mirrors pnpm's `--no-trust-lockfile`.
+    #[clap(long = "no-trust-lockfile", overrides_with = "trust_lockfile")]
+    pub no_trust_lockfile: bool,
 
     /// Refresh the integrity checksums recorded in `pnpm-lock.yaml`
     /// from the registry. Mirrors pnpm's `--update-checksums`. Skips
@@ -266,6 +299,17 @@ pub struct InstallArgs {
     pub pnpr_server: Option<String>,
 }
 
+/// Resolve a boolean whose CLI surface is a `--flag` / `--no-flag` pair
+/// against the yaml/`.npmrc` `config` value. The pair's mutual
+/// `overrides_with` collapses both spellings in one argv to the
+/// last-specified, so at most one of `force_on` / `force_off` is ever
+/// set: a set flag wins over `config` in its own direction and an unset
+/// pair falls through to it. Mirrors pnpm, where a CLI boolean overrides
+/// the workspace/`.npmrc` value either way (nopt's `--no-` negation).
+pub(crate) fn resolve_bool_override(force_on: bool, force_off: bool, config: bool) -> bool {
+    force_on || (config && !force_off)
+}
+
 impl InstallArgs {
     pub(crate) fn for_patch_manifest_change() -> Self {
         Self {
@@ -283,11 +327,16 @@ impl InstallArgs {
             ignore_manifest_check: false,
             no_runtime: false,
             ignore_scripts: false,
+            no_ignore_scripts: false,
             node_linker: None,
             offline: false,
+            no_offline: false,
             frozen_store: false,
+            no_frozen_store: false,
             prefer_offline: false,
+            no_prefer_offline: false,
             trust_lockfile: false,
+            no_trust_lockfile: false,
             update_checksums: false,
             workspace_concurrency: None,
             network_concurrency: None,
@@ -377,16 +426,22 @@ impl InstallArgs {
             no_prefer_frozen_lockfile,
             ignore_manifest_check,
             no_runtime,
-            // Read from `config.ignore_scripts` (the CLI flag was already
-            // merged in by the dispatch in `cli_args.rs`), not from here.
+            // The `ignore_scripts` / `offline` / `frozen_store` /
+            // `prefer_offline` flags and their `--no-` inverses are
+            // resolved against config by `apply_install_cli_config` in the
+            // dispatch (`cli_args.rs`), so the install reads them from
+            // `config`, not from here.
             ignore_scripts: _,
+            no_ignore_scripts: _,
             node_linker,
             offline: _,
-            // Read from `config.frozen_store` (the CLI flag was already
-            // merged in by the dispatch in `cli_args.rs`), not from here.
+            no_offline: _,
             frozen_store: _,
+            no_frozen_store: _,
             prefer_offline: _,
+            no_prefer_offline: _,
             trust_lockfile,
+            no_trust_lockfile,
             update_checksums,
             workspace_concurrency: _,
             network_concurrency: _,
@@ -399,9 +454,10 @@ impl InstallArgs {
 
         // `--prefer-frozen-lockfile` / `--no-prefer-frozen-lockfile`
         // map to `Option<bool>`: `Some(true)` / `Some(false)` when
-        // either flag is set, `None` otherwise (use config). Clap's
-        // `conflicts_with` on the off-flag ensures the two aren't
-        // both set, so the precedence here is straightforward.
+        // either flag is set, `None` otherwise (use config). The pair's
+        // mutual `overrides_with` collapses both spellings to the
+        // last-specified, so at most one is set and the precedence here
+        // is straightforward.
         let prefer_frozen_lockfile = if prefer_frozen_lockfile {
             Some(true)
         } else if no_prefer_frozen_lockfile {
@@ -425,11 +481,14 @@ impl InstallArgs {
         // matching pnpm's stance on the same flag.
         let skip_runtimes = config.skip_runtimes || no_runtime;
 
-        // Same shape as `skip_runtimes`: yaml `trustLockfile: true`
-        // or the CLI flag turns the verification skip on. There's no
-        // CLI inverse — relax the yaml value if you need to flip it
-        // back off for a single invocation.
-        let trust_lockfile = config.trust_lockfile || trust_lockfile;
+        // `--trust-lockfile` / `--no-trust-lockfile` override the yaml
+        // `trustLockfile` in either direction; an unset pair falls
+        // through to it. Forcing the verification pass back on from the
+        // CLI matters for security: a repo-controlled
+        // `pnpm-workspace.yaml` can't pin `trustLockfile: true` past a
+        // user's explicit `--no-trust-lockfile`.
+        let trust_lockfile =
+            resolve_bool_override(trust_lockfile, no_trust_lockfile, config.trust_lockfile);
 
         // `--node-linker` flag (if passed) overrides the
         // yaml/npmrc value for this invocation. Mirrors pnpm's

--- a/pacquet/crates/cli/src/cli_args/pipelines.rs
+++ b/pacquet/crates/cli/src/cli_args/pipelines.rs
@@ -1,7 +1,7 @@
 use super::{
     dedupe::{self, DedupeArgs},
     deploy::DeployArgs,
-    install::InstallArgs,
+    install::{InstallArgs, resolve_bool_override},
     package_manager::{PackageManagerToSync, package_manager_to_sync},
     prune::PruneArgs,
 };
@@ -99,10 +99,13 @@ pub(crate) fn derive_config_root_and_package_manager_to_sync(
 }
 
 pub(crate) fn apply_install_cli_config(cfg: &mut Config, args: &InstallArgs) {
-    cfg.offline = cfg.offline || args.offline;
-    cfg.prefer_offline = cfg.prefer_offline || args.prefer_offline;
-    cfg.frozen_store = cfg.frozen_store || args.frozen_store;
-    cfg.ignore_scripts = cfg.ignore_scripts || args.ignore_scripts;
+    cfg.offline = resolve_bool_override(args.offline, args.no_offline, cfg.offline);
+    cfg.prefer_offline =
+        resolve_bool_override(args.prefer_offline, args.no_prefer_offline, cfg.prefer_offline);
+    cfg.frozen_store =
+        resolve_bool_override(args.frozen_store, args.no_frozen_store, cfg.frozen_store);
+    cfg.ignore_scripts =
+        resolve_bool_override(args.ignore_scripts, args.no_ignore_scripts, cfg.ignore_scripts);
     cfg.workspace_concurrency = args.resolve_workspace_concurrency(cfg.workspace_concurrency);
     if let Some(network_concurrency) = args.network_concurrency {
         cfg.network_concurrency = network_concurrency;
@@ -219,7 +222,8 @@ impl PrunePipeline {
         // - `--ignore-scripts` from the CLI wins over any value the
         //   hooks set via `WorkspaceSettings::apply_to`.
         cfg.modules_cache_max_age = 0;
-        cfg.ignore_scripts = cfg.ignore_scripts || args.ignore_scripts;
+        cfg.ignore_scripts =
+            resolve_bool_override(args.ignore_scripts, args.no_ignore_scripts, cfg.ignore_scripts);
         let cfg: &'static Config = cfg;
         let state = State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
         args.run::<Reporter>(state).await

--- a/pacquet/crates/cli/src/cli_args/prune.rs
+++ b/pacquet/crates/cli/src/cli_args/prune.rs
@@ -13,13 +13,19 @@ pub struct PruneArgs {
     dev: bool,
     #[clap(long)]
     no_optional: bool,
-    #[clap(long = "ignore-scripts")]
+    #[clap(long = "ignore-scripts", overrides_with = "no_ignore_scripts")]
     pub ignore_scripts: bool,
+    /// Force-enable lifecycle scripts for this invocation, overriding a
+    /// `pnpm-workspace.yaml` / `.npmrc` `ignoreScripts: true`. Mirrors
+    /// pnpm's `--no-ignore-scripts`. Paired with `ignore_scripts` by
+    /// mutual `overrides_with` (last-one-wins).
+    #[clap(long = "no-ignore-scripts", overrides_with = "ignore_scripts")]
+    pub no_ignore_scripts: bool,
 }
 
 impl PruneArgs {
     fn dependency_groups(&self) -> impl Iterator<Item = DependencyGroup> {
-        let &PruneArgs { prod, dev, no_optional, ignore_scripts: _ } = self;
+        let &PruneArgs { prod, dev, no_optional, ignore_scripts: _, no_ignore_scripts: _ } = self;
         let has_both = prod == dev;
         let has_prod = has_both || prod;
         let has_dev = has_both || dev;

--- a/pacquet/crates/cli/src/cli_args/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/tests.rs
@@ -1,12 +1,20 @@
 use super::{
     CliArgs,
     cli_command::CliCommand,
+    install::{InstallArgs, resolve_bool_override},
     package_manager::{
         current_source_pnpm_version, package_manager_to_sync, parse_package_manager,
     },
 };
 use clap::Parser;
 use tempfile::TempDir;
+
+fn install_args(argv: &[&str]) -> InstallArgs {
+    match CliArgs::try_parse_from(argv).expect("parses").command {
+        CliCommand::Install(install) => install,
+        other => panic!("expected install, got {other:?}"),
+    }
+}
 
 #[test]
 fn recursive_default_is_false() {
@@ -206,4 +214,47 @@ fn package_manager_to_sync_preserves_dev_engine_specifier() {
         package_manager.version,
         current_source_pnpm_version().expect("source pnpm version"),
     );
+}
+
+#[test]
+fn resolve_bool_override_tri_state() {
+    // force_on wins, force_off wins over a config `true`, and an unset
+    // pair falls through to config — in both config polarities.
+    assert!(resolve_bool_override(true, false, false), "force_on over config false");
+    assert!(resolve_bool_override(true, false, true), "force_on over config true");
+    assert!(!resolve_bool_override(false, true, true), "force_off over config true");
+    assert!(!resolve_bool_override(false, true, false), "force_off over config false");
+    assert!(resolve_bool_override(false, false, true), "unset falls through to config true");
+    assert!(!resolve_bool_override(false, false, false), "unset falls through to config false");
+}
+
+#[test]
+fn trust_lockfile_pair_resolves_last_one_wins() {
+    assert!(install_args(&["pacquet", "install", "--no-trust-lockfile"]).no_trust_lockfile);
+    assert!(install_args(&["pacquet", "install", "--trust-lockfile"]).trust_lockfile);
+
+    // Both spellings in one argv must not error (pnpm forwards raw tokens);
+    // mutual `overrides_with` collapses them to the last-specified.
+    let last_off = install_args(&["pacquet", "install", "--trust-lockfile", "--no-trust-lockfile"]);
+    assert!(last_off.no_trust_lockfile && !last_off.trust_lockfile, "--no wins when last");
+    let last_on = install_args(&["pacquet", "install", "--no-trust-lockfile", "--trust-lockfile"]);
+    assert!(last_on.trust_lockfile && !last_on.no_trust_lockfile, "--trust wins when last");
+}
+
+#[test]
+fn config_merged_boolean_negations_parse() {
+    // Each config-OR-merged boolean now exposes an explicit `--no-` inverse
+    // so the CLI can force a yaml `true` back off, matching pnpm.
+    let args = install_args(&[
+        "pacquet",
+        "install",
+        "--no-offline",
+        "--no-prefer-offline",
+        "--no-frozen-store",
+        "--no-ignore-scripts",
+    ]);
+    assert!(args.no_offline);
+    assert!(args.no_prefer_offline);
+    assert!(args.no_frozen_store);
+    assert!(args.no_ignore_scripts);
 }

--- a/pacquet/crates/cli/src/lib.rs
+++ b/pacquet/crates/cli/src/lib.rs
@@ -1,3 +1,4 @@
+mod boolean_negations;
 mod cli_args;
 mod config_deps;
 mod config_overrides;
@@ -5,7 +6,8 @@ mod job_control;
 mod state;
 mod with_current;
 
-use clap::Parser;
+use boolean_negations::with_boolean_negations;
+use clap::{CommandFactory, FromArgMatches};
 use cli_args::CliArgs;
 use config_overrides::ConfigOverrides;
 use miette::set_panic_hook;
@@ -30,7 +32,13 @@ pub fn main() -> miette::Result<()> {
     // The default reporter's `Done in ... using pacquet v<version>` footer needs
     // the version before the first event (including the fast path's).
     pacquet_default_reporter::set_package_version(pacquet_config::PACQUET_VERSION);
-    let mut args = match CliArgs::try_parse_from(argv) {
+    // Parse through a command augmented with a `--no-<flag>` negation for
+    // every boolean flag, so pnpm's forwarded negations (`--no-frozen-lockfile`,
+    // etc.) parse the same way nopt accepts them upstream. See `boolean_negations`.
+    let mut args = match with_boolean_negations(CliArgs::command())
+        .try_get_matches_from(argv)
+        .and_then(|matches| CliArgs::from_arg_matches(&matches))
+    {
         Ok(args) => args,
         // pnpm prints the bare version, not clap's "pnpm <version>" rendering.
         Err(err) if err.kind() == clap::error::ErrorKind::DisplayVersion => {

--- a/pnpm11/installing/commands/src/runPacquet.ts
+++ b/pnpm11/installing/commands/src/runPacquet.ts
@@ -288,16 +288,19 @@ function pacquetSupportsResolution (version: string | undefined): boolean {
  * surface pnpm itself accepts on `install`, so the flags don't need
  * reshaping.
  *
- * Flags we always inject ourselves (`--frozen-lockfile`,
+ * Flags we manage ourselves (`--frozen-lockfile`,
  * `--ignore-manifest-check`) are dropped in every form the user can
  * type them — positive (`--frozen-lockfile`), negated
- * (`--no-frozen-lockfile`), and any `=value` form. Pacquet's clap
- * defines these as plain `#[clap(long)] bool` flags, so a duplicate
- * `--frozen-lockfile` or a conflicting `--no-frozen-lockfile`
- * crashes the parser with "used multiple times" / "unexpected
- * argument". The user's `--no-frozen-lockfile` intent is already
- * honored upstream (pnpm did a fresh resolve before delegating);
- * pacquet's role here is just lockfile-driven materialization.
+ * (`--no-frozen-lockfile`), and any `=value` form. pnpm resolves the
+ * frozen-lockfile setting itself and encodes the decision in the mode
+ * it hands pacquet: a resolving install (pacquet resolves and writes
+ * the lockfile, no `--frozen-lockfile` injected) or a frozen
+ * materialization (pacquet is pinned to the lockfile via an injected
+ * `--frozen-lockfile`) — see `frozenArgs` in `makeRun`. Forwarding the
+ * user's own token would contradict that choice: pacquet accepts a
+ * `--no-<flag>` negation for every boolean flag with last-one-wins
+ * override semantics, so a user `--no-frozen-lockfile` sitting next to
+ * our injected `--frozen-lockfile` would flip the pinning back off.
  *
  * `--reporter` is stripped in any form (`--reporter=foo`,
  * `--reporter foo`): pacquet's `reporter` is a clap value option


### PR DESCRIPTION
## Summary

The Rust pnpm (v12/pacquet) aborted on `pnpm install --no-frozen-lockfile` with `error: unexpected argument '--no-frozen-lockfile' found`, which broke the [pnpm.io benchmark run](https://github.com/pnpm/pnpm.io/actions/runs/28723300427/job/85176265423).

pnpm's TypeScript CLI parses with `nopt`, which auto-accepts a `--no-<name>` negation for **every** option typed as `Boolean`. Pacquet's flags are plain `#[clap(long)] bool`s that only accept the positive spelling, so the same gap exists for `--no-lockfile-only`, `--no-dry-run`, `--no-offline`, `--no-ignore-scripts`, and every other boolean flag — not just `--no-frozen-lockfile`.

### Generic negation layer

Rather than hand-write a paired `--no-` flag per boolean, this adds a generic augmentation layer (`with_boolean_negations`) that walks the built clap `Command` tree and, for every boolean flag lacking a `--no-` sibling, adds a hidden negation that `overrides_with` the positive flag. Last-one-wins override semantics reproduce nopt exactly. Because the negations are real clap args, the grammar stays intact — trailing pass-through args (`run`, `exec`, `dlx`) and value-taking flags are unaffected, explicit hand-written negations (`--no-optional`, `--no-prefer-frozen-lockfile`) are left untouched, and genuinely unknown flags still error.

### Force-off parity for config-merged booleans

Five booleans (`trust-lockfile`, `offline`, `prefer-offline`, `frozen-store`, `ignore-scripts`) were resolved as `config_value || cli_flag`, so pacquet could never turn a yaml `true` back off from the CLI. Left to the generic negation alone, `--no-<flag>` would parse but silently no-op against a config `true` — a footgun for the security-sensitive `trustLockfile`, where a repo-controlled `pnpm-workspace.yaml` could keep verification disabled past a user's explicit `--no-trust-lockfile` (raised by Qodo in review). Each now exposes an explicit tri-state `--no-` flag (which also makes the generic layer skip it), resolved via a shared `resolve_bool_override(force_on, force_off, config)`: force-on wins, force-off wins over a config `true`, an unset pair falls through to config — matching pnpm, where a CLI boolean overrides the workspace/`.npmrc` value in either direction.

### TypeScript side

The only TS edit refreshes a now-stale comment in `runPacquet.ts`: pnpm resolves the frozen-lockfile setting itself and encodes it in the delegation mode it hands pacquet (a resolving install, or a frozen materialization with an injected `--frozen-lockfile`), so it strips the user's own frozen-lockfile token to avoid contradicting that choice via pacquet's new last-wins negation override. pnpm's CLI already accepts all these `--no-<bool>` negations with force-off semantics, so this PR closes a pacquet parity gap rather than opening one.

## Squash Commit Body

```text
See the commit message on 90877fe.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `--no-<flag>` options across many boolean CLI settings, including install, prune, and global flags.
  * Boolean flags now follow last-one-wins behavior when both enabled and disabled forms are provided.

* **Bug Fixes**
  * Improved handling of lockfile, offline, scripts, and trust-related options so explicit disables are respected instead of being merged incorrectly.
  * Fixed flag behavior in subcommands so global negations work consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->