### PR TITLE
feat(pacquet): support global runtime install

### DIFF
--- a/.changeset/validate-runtime-name.md
+++ b/.changeset/validate-runtime-name.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-`pnpm runtime set <name> <version>` now rejects a runtime name that is not `node`, `deno`, or `bun`. Previously an unsupported name (including a comma-separated list or a path-like value such as `./foo`) was forwarded to `pnpm add`, where it could be misread as a list of packages or a local directory and install unintended packages or bins.
+`pnpm runtime set <name> <version>` now validates its arguments: the name must be `node`, `deno`, or `bun`, and the version must not contain a comma. Previously these were interpolated straight into a `pnpm add` selector, where an unsupported name or a comma (e.g. `node 22,is-positive`) could be misread as a list of packages or a local directory and install unintended packages or bins.

--- a/.changeset/validate-runtime-name.md
+++ b/.changeset/validate-runtime-name.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/engine.runtime.commands": patch
+"pnpm": patch
+---
+
+`pnpm runtime set <name> <version>` now rejects a runtime name that is not `node`, `deno`, or `bun`. Previously an unsupported name (including a comma-separated list or a path-like value such as `./foo`) was forwarded to `pnpm add`, where it could be misread as a list of packages or a local directory and install unintended packages or bins.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4054,6 +4054,7 @@ dependencies = [
  "pacquet-cmd-shim",
  "pacquet-crypto-hash",
  "pacquet-fs",
+ "pacquet-package-manifest",
  "pacquet-resolving-deps-resolver",
  "serde_json",
  "tempfile",

--- a/pacquet/crates/cli/src/cli_args/dispatch.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::{State, config_overrides::ConfigOverrides};
 use miette::{Context, IntoDiagnostic};
-use pacquet_config::{Config, Host};
+use pacquet_config::{Config, Host, default_pnpm_home_dir};
 use pacquet_reporter::{ExecutionTimeLog, LogEvent, LogLevel};
 use std::{future::Future, path::Path, pin::Pin};
 
@@ -29,6 +29,10 @@ pub(crate) struct RunCtx<'a> {
     pub(crate) reporter: ReporterType,
     pub(crate) recursive: bool,
     pub(crate) config: &'a (dyn Fn() -> miette::Result<&'static mut Config> + Sync),
+    /// Like [`Self::config`] but anchored at the pnpm home dir instead of
+    /// `--dir`, so a `-g` install can't inherit the caller project's
+    /// `.npmrc` network / TLS / registry settings.
+    pub(crate) global_config: &'a (dyn Fn() -> miette::Result<&'static mut Config> + Sync),
     pub(crate) state: &'a (dyn Fn(bool) -> miette::Result<State> + Sync),
 }
 
@@ -153,31 +157,25 @@ impl CliArgs {
                 | CliCommand::PatchRemove(_),
         );
         let manifest_path = dir.join("package.json");
-        // Resolve `.npmrc` / `pnpm-workspace.yaml` from the canonicalized
-        // `--dir` rather than the process cwd, matching pnpm 11 (which
-        // builds its `localPrefix` from `cliOptions.dir`, not `cwd`).
+        // Load config anchored at `anchor`, reading `.npmrc` /
+        // `pnpm-workspace.yaml` from there.
         //
-        // Production callers turbofish `Host` explicitly so the
-        // dependency-injection plumbing is visible at the call site.
-        // See [pnpm/pacquet#339](https://github.com/pnpm/pacquet/issues/339)
-        // for the pattern and rationale.
-        let config = || -> miette::Result<&'static mut Config> {
-            // Seed `npmrc_auth_file` from the CLI flag before
-            // `current()` reads `.npmrc`, so the override redirects the
-            // user-level read. Mirrors pnpm's `--npmrc-auth-file`.
+        // Seed `npmrc_auth_file` from the CLI flag before `current()` reads
+        // `.npmrc`, so the override redirects the user-level read. Mirrors
+        // pnpm's `--npmrc-auth-file`. Production callers turbofish `Host`
+        // explicitly so the dependency-injection plumbing is visible at the
+        // call site. See
+        // [pnpm/pacquet#339](https://github.com/pnpm/pacquet/issues/339).
+        let load_config = |anchor: &Path| -> miette::Result<&'static mut Config> {
             Config { npmrc_auth_file: npmrc_auth_file.clone(), ..Config::default() }
-                .current::<Host>(&dir)
+                .current::<Host>(anchor)
                 .map(|mut cfg| {
                     config_overrides.apply(&mut cfg);
-                    // `--recursive` / `-r` is CLI-only upstream (not a
-                    // `.npmrc` / yaml key), so it is set here from the
-                    // global flag rather than through the yaml / env
-                    // overlay. Mirrors pnpm's `Config.recursive`.
+                    // `--recursive` / `--filter` / `--filter-prod` are
+                    // CLI-only upstream (not `.npmrc` / yaml keys), so the
+                    // global flags are threaded in here. Mirrors pnpm's
+                    // `Config.recursive` / `.filter` / `.filterProd`.
                     cfg.recursive = recursive;
-                    // `--filter` / `--filter-prod` are likewise CLI-only
-                    // (pnpm's `Config.filter` / `Config.filterProd`),
-                    // so the parsed selector strings are threaded in
-                    // from the global flags here.
                     cfg.filter.clone_from(&filter);
                     cfg.filter_prod.clone_from(&filter_prod);
                     Config::leak(cfg)
@@ -185,6 +183,21 @@ impl CliArgs {
                 .map_err(miette::Report::new)
                 .wrap_err("load configuration")
         };
+        // Resolve `.npmrc` / `pnpm-workspace.yaml` from the canonicalized
+        // `--dir` rather than the process cwd, matching pnpm 11 (which
+        // builds its `localPrefix` from `cliOptions.dir`, not `cwd`).
+        let config = || load_config(&dir);
+        // A `-g` install is isolated from the caller's project: pnpm runs it
+        // with `cwd` = the pnpm home dir, so a project `.npmrc` cannot
+        // influence the network / TLS / registry decisions of a *global*
+        // install. Mirror that by anchoring the global-install config at the
+        // pnpm home (resolved from `PNPM_HOME` / platform defaults, never the
+        // project). Falls back to the `--dir` anchor when the home can't be
+        // determined — the global command then fails at the missing-global-
+        // bin-dir check regardless.
+        let pnpm_home_dir = default_pnpm_home_dir::<Host>();
+        let global_config_anchor = pnpm_home_dir.as_deref().unwrap_or(&dir);
+        let global_config = || load_config(global_config_anchor);
         // `require_lockfile` is the "this subcommand cannot run without a
         // lockfile loaded" signal, used by `State::init` to override
         // `config.lockfile=false`. Only `install --frozen-lockfile` needs
@@ -203,6 +216,7 @@ impl CliArgs {
             reporter,
             recursive,
             config: &config,
+            global_config: &global_config,
             state: &state,
         };
         route(command, &ctx)?.await?;

--- a/pacquet/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_install.rs
@@ -316,7 +316,17 @@ pub(super) fn runtime<'a>(
     ctx: &RunCtx<'a>,
     args: RuntimeArgs,
 ) -> miette::Result<CommandFuture<'a>> {
-    args.reject_unsupported_global()?;
+    if args.global {
+        let config = (ctx.config)()?;
+        let dir = ctx.dir;
+        return Ok(match ctx.reporter {
+            ReporterType::Default | ReporterType::AppendOnly => {
+                Box::pin(args.run_global::<DefaultReporter>(config, dir))
+            }
+            ReporterType::Ndjson => Box::pin(args.run_global::<NdjsonReporter>(config, dir)),
+            ReporterType::Silent => Box::pin(args.run_global::<SilentReporter>(config, dir)),
+        });
+    }
     let command_state = (ctx.state)(false)?;
     Ok(match ctx.reporter {
         ReporterType::Default | ReporterType::AppendOnly => {

--- a/pacquet/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_install.rs
@@ -32,7 +32,7 @@ use pacquet_reporter::{NdjsonReporter, SilentReporter};
 
 pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<CommandFuture<'a>> {
     if args.global {
-        let config = (ctx.config)()?;
+        let config = (ctx.global_config)()?;
         let dir = ctx.dir;
         return Ok(match ctx.reporter {
             ReporterType::Default | ReporterType::AppendOnly => {
@@ -54,7 +54,7 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
 
 pub(super) fn update<'a>(ctx: &RunCtx<'a>, args: UpdateArgs) -> miette::Result<CommandFuture<'a>> {
     if args.global {
-        let config = (ctx.config)()?;
+        let config = (ctx.global_config)()?;
         return Ok(match ctx.reporter {
             ReporterType::Default | ReporterType::AppendOnly => {
                 Box::pin(args.run_global::<DefaultReporter>(config))
@@ -75,7 +75,7 @@ pub(super) fn update<'a>(ctx: &RunCtx<'a>, args: UpdateArgs) -> miette::Result<C
 
 pub(super) fn remove<'a>(ctx: &RunCtx<'a>, args: RemoveArgs) -> miette::Result<CommandFuture<'a>> {
     if args.global {
-        global::handle_global_remove((ctx.config)()?, &args.package_names)?;
+        global::handle_global_remove((ctx.global_config)()?, &args.package_names)?;
         return Ok(Box::pin(std::future::ready(Ok(()))));
     }
     let command_state = (ctx.state)(false)?;
@@ -317,7 +317,7 @@ pub(super) fn runtime<'a>(
     args: RuntimeArgs,
 ) -> miette::Result<CommandFuture<'a>> {
     if args.global {
-        let config = (ctx.config)()?;
+        let config = (ctx.global_config)()?;
         let dir = ctx.dir;
         return Ok(match ctx.reporter {
             ReporterType::Default | ReporterType::AppendOnly => {

--- a/pacquet/crates/cli/src/cli_args/global.rs
+++ b/pacquet/crates/cli/src/cli_args/global.rs
@@ -286,7 +286,15 @@ async fn run_group_install<Reporter: self::Reporter + 'static>(
     // `lockfileDir = installDir`). `outdated -g` / `update -g` read these
     // pins to determine the currently-installed versions.
     cfg.lockfile = true;
-    cfg.workspace_dir = None;
+    // Pin the group's workspace root to its own install dir (pnpm's
+    // `rootProjectManifestDir: installDir`, `workspaceDir: undefined`). The
+    // install dir sits *under* the global packages dir, which carries a
+    // `pnpm-workspace.yaml` of global settings (`allowBuilds`, `catalog`,
+    // ...). Leaving this unset would let the install pipeline walk up, adopt
+    // that file as the workspace, and then fail trying to enumerate its
+    // non-existent root project. Anchoring here keeps the group install an
+    // isolated single project.
+    cfg.workspace_dir = Some(install_dir.clone());
     cfg.supported_architectures = supported_architectures;
 
     // Build-script policy for global installs comes from the global packages

--- a/pacquet/crates/cli/src/cli_args/global.rs
+++ b/pacquet/crates/cli/src/cli_args/global.rs
@@ -16,7 +16,7 @@ use crate::{
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pacquet_cmd_shim::{Host as CmdShimHost, link_bins_of_packages_with_excludes, remove_bin};
-use pacquet_config::{Config, WorkspaceSettings, check_global_bin_dir};
+use pacquet_config::{CatalogMode, Config, WorkspaceSettings, check_global_bin_dir};
 use pacquet_fs::{force_symlink_dir, is_subdir, lexical_normalize};
 use pacquet_global::{
     GlobalPackageInfo, check_global_bin_conflicts, clean_orphaned_install_dirs,
@@ -296,6 +296,21 @@ async fn run_group_install<Reporter: self::Reporter + 'static>(
     // isolated single project.
     cfg.workspace_dir = Some(install_dir.clone());
     cfg.supported_architectures = supported_architectures;
+
+    // A global install is isolated from the caller's project, so it must
+    // not inherit that project's dependency-graph configuration. pnpm
+    // achieves this by running the install with `cwd` = the pnpm home dir;
+    // pacquet clones the caller's already-loaded config, so drop those
+    // project-scoped resolution settings explicitly. Inheriting `overrides`
+    // is what surfaced as `ERR_PNPM_CATALOG_IN_OVERRIDES` — a repo override
+    // referencing a `catalog:` the isolated install (with no catalogs) no
+    // longer resolves — and inheriting `catalogMode: strict` would likewise
+    // reject the install against an empty catalog.
+    cfg.overrides = None;
+    cfg.catalogs = None;
+    cfg.catalog_mode = CatalogMode::default();
+    cfg.package_extensions = None;
+    cfg.patched_dependencies = None;
 
     // Build-script policy for global installs comes from the global packages
     // directory, never the caller's repo — otherwise a repo-controlled

--- a/pacquet/crates/cli/src/cli_args/global.rs
+++ b/pacquet/crates/cli/src/cli_args/global.rs
@@ -376,7 +376,20 @@ async fn prompt_approve_global_builds<Reporter: self::Reporter + 'static>(
     }
 
     let manifest_path = install_dir.join("package.json");
-    let config_fn = || -> miette::Result<&'static mut Config> { Ok(Config::leak(config.clone())) };
+    let config_fn = || -> miette::Result<&'static mut Config> {
+        // `prepare` persists the `allowBuilds` decision to
+        // `config.workspace_dir`, falling back to the passed dir (the global
+        // packages dir). The group install pins `workspace_dir` to the
+        // ephemeral install dir; clear it here so the decision lands in the
+        // stable global packages dir, where the next global install reads it
+        // back — rather than in a throwaway install group.
+        let mut cfg = config.clone();
+        cfg.workspace_dir = None;
+        Ok(Config::leak(cfg))
+    };
+    // The rebuild stays anchored at the install dir (keeping `config`'s
+    // `workspace_dir`), so its install pipeline doesn't walk up into the
+    // global settings workspace.
     let state_fn = |require_lockfile: bool| -> miette::Result<State> {
         State::init(manifest_path.clone(), Config::leak(config.clone()), require_lockfile)
             .wrap_err("initialize the global approve-builds state")

--- a/pacquet/crates/cli/src/cli_args/global.rs
+++ b/pacquet/crates/cli/src/cli_args/global.rs
@@ -21,14 +21,14 @@ use pacquet_fs::{force_symlink_dir, is_subdir, lexical_normalize};
 use pacquet_global::{
     GlobalPackageInfo, check_global_bin_conflicts, clean_orphaned_install_dirs,
     create_global_cache_key, create_install_dir, find_global_package, get_hash_link,
-    get_installed_bin_names, read_installed_packages, scan_global_packages,
+    get_installed_bin_names, read_direct_dependency_aliases, read_installed_packages,
+    scan_global_packages,
 };
 use pacquet_package_is_installable::SupportedArchitectures;
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_registry::PinnedVersion;
 use pacquet_reporter::Reporter;
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
-use serde_json::Value;
 use std::{
     collections::HashSet,
     fs,
@@ -107,7 +107,7 @@ pub async fn handle_global_add<Reporter: self::Reporter + 'static>(
         .await?;
 
         let pkgs = read_installed_packages(&install_dir);
-        let aliases = read_aliases(&install_dir);
+        let aliases = read_direct_dependency_aliases(&install_dir);
 
         let bins_to_skip = match check_global_bin_conflicts(
             &global_pkg_dir,
@@ -430,21 +430,6 @@ fn bin_names_of_other_groups(
         }
     }
     Ok(names)
-}
-
-/// The direct-dependency aliases of an install directory's `package.json`.
-fn read_aliases(install_dir: &Path) -> Vec<String> {
-    let Ok(text) = fs::read_to_string(install_dir.join("package.json")) else {
-        return Vec::new();
-    };
-    let Ok(value) = serde_json::from_str::<Value>(&text) else {
-        return Vec::new();
-    };
-    value
-        .get("dependencies")
-        .and_then(Value::as_object)
-        .map(|deps| deps.keys().cloned().collect())
-        .unwrap_or_default()
 }
 
 /// Build the registry map (`{ default, ...scoped }`) hashed into the

--- a/pacquet/crates/cli/src/cli_args/runtime.rs
+++ b/pacquet/crates/cli/src/cli_args/runtime.rs
@@ -6,7 +6,7 @@ use clap::Args;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::Config;
-use pacquet_package_manifest::DependencyGroup;
+use pacquet_package_manifest::{DependencyGroup, is_runtime_alias};
 use pacquet_registry::PinnedVersion;
 use pacquet_reporter::Reporter;
 use std::path::Path;
@@ -49,6 +49,13 @@ pub enum RuntimeError {
     )]
     #[diagnostic(code(ERR_PNPM_MISSING_RUNTIME_NAME))]
     MissingRuntimeName,
+
+    #[display(r#""{name}" is not a supported runtime. Supported runtimes are: node, deno, bun"#)]
+    #[diagnostic(code(ERR_PNPM_INVALID_RUNTIME_NAME))]
+    InvalidRuntimeName {
+        #[error(not(source))]
+        name: String,
+    },
 }
 
 #[derive(Debug)]
@@ -111,6 +118,13 @@ impl RuntimeArgs {
             .map(|name| name.trim())
             .filter(|name| !name.is_empty())
             .ok_or(RuntimeError::MissingRuntimeName)?;
+        // The runtime name is interpolated into an `add` selector, so reject
+        // anything that isn't a known runtime before it can be misread as a
+        // comma-separated package list or a local path by the global-add
+        // pipeline.
+        if !is_runtime_alias(runtime_name) {
+            return Err(RuntimeError::InvalidRuntimeName { name: runtime_name.to_string() });
+        }
         let version_spec = self.params.get(2).map_or("", |version| version.trim());
         let dependency_group = if self.save_dev || !self.save_prod {
             DependencyGroup::Dev

--- a/pacquet/crates/cli/src/cli_args/runtime.rs
+++ b/pacquet/crates/cli/src/cli_args/runtime.rs
@@ -1,10 +1,15 @@
-use crate::{State, cli_args::add::add_package};
+use crate::{
+    State,
+    cli_args::{add::add_package, global::handle_global_add},
+};
 use clap::Args;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
+use pacquet_config::Config;
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_registry::PinnedVersion;
 use pacquet_reporter::Reporter;
+use std::path::Path;
 
 /// Manage runtimes.
 #[derive(Debug, Args)]
@@ -44,12 +49,6 @@ pub enum RuntimeError {
     )]
     #[diagnostic(code(ERR_PNPM_MISSING_RUNTIME_NAME))]
     MissingRuntimeName,
-
-    #[display(
-        "`pacquet runtime set --global` is not supported yet; global runtime installation has not been ported to pacquet."
-    )]
-    #[diagnostic(code(pacquet_cli::runtime_global_unsupported))]
-    GlobalUnsupported,
 }
 
 #[derive(Debug)]
@@ -59,14 +58,9 @@ struct RuntimeSetRequest {
 }
 
 impl RuntimeArgs {
-    pub fn reject_unsupported_global(&self) -> Result<(), RuntimeError> {
-        if self.global {
-            return Err(RuntimeError::GlobalUnsupported);
-        }
-        Ok(())
-    }
-
-    /// Execute the subcommand.
+    /// Execute the subcommand, installing the runtime into the current
+    /// project. Mirrors pnpm's `runtime set`, which runs
+    /// `pnpm add <name>@runtime:<version>` in the project directory.
     pub async fn run<Reporter: self::Reporter + 'static>(self, state: State) -> miette::Result<()> {
         let request = self.set_request()?;
         add_package::<Reporter, _, _>(
@@ -78,6 +72,29 @@ impl RuntimeArgs {
             None,
             || std::iter::once(request.dependency_group),
         )
+        .await
+    }
+
+    /// `pnpm runtime set <name> <version> -g`: install the runtime into the
+    /// global packages directory and link its binary into the global bin
+    /// directory. Mirrors pnpm's `runtime set … -g`, which runs
+    /// `pnpm add <name>@runtime:<version> --global` against the pnpm home
+    /// directory. `--save-dev` / `--save-prod` are ignored for a global
+    /// install — like every `pnpm add -g`, the global group always saves to
+    /// `dependencies`.
+    pub async fn run_global<Reporter: self::Reporter + 'static>(
+        self,
+        config: &'static Config,
+        dir: &Path,
+    ) -> miette::Result<()> {
+        let request = self.set_request()?;
+        Box::pin(handle_global_add::<Reporter>(
+            config,
+            std::slice::from_ref(&request.package_name),
+            PinnedVersion::Major,
+            config.supported_architectures.clone(),
+            dir,
+        ))
         .await
     }
 

--- a/pacquet/crates/cli/src/cli_args/runtime.rs
+++ b/pacquet/crates/cli/src/cli_args/runtime.rs
@@ -56,6 +56,13 @@ pub enum RuntimeError {
         #[error(not(source))]
         name: String,
     },
+
+    #[display(r#"Invalid runtime version "{version}": a version cannot contain a comma"#)]
+    #[diagnostic(code(ERR_PNPM_INVALID_RUNTIME_VERSION))]
+    InvalidRuntimeVersion {
+        #[error(not(source))]
+        version: String,
+    },
 }
 
 #[derive(Debug)]
@@ -126,6 +133,14 @@ impl RuntimeArgs {
             return Err(RuntimeError::InvalidRuntimeName { name: runtime_name.to_string() });
         }
         let version_spec = self.params.get(2).map_or("", |version| version.trim());
+        // The version is interpolated into the same `<name>@runtime:<version>`
+        // selector, which the global-add pipeline splits on commas. Reject a
+        // comma so `runtime set node 22,evil -g` can't smuggle in a second
+        // install target. No valid runtime version (semver, dist-tag,
+        // channel) contains one.
+        if version_spec.contains(',') {
+            return Err(RuntimeError::InvalidRuntimeVersion { version: version_spec.to_string() });
+        }
         let dependency_group = if self.save_dev || !self.save_prod {
             DependencyGroup::Dev
         } else {

--- a/pacquet/crates/cli/src/cli_args/runtime/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/runtime/tests.rs
@@ -68,9 +68,13 @@ fn set_request_fails_without_runtime_name() {
 }
 
 #[test]
-fn global_is_rejected_before_state_initialization() {
-    let err = RuntimeArgs { global: true, ..args(&["set", "node", "22"]) }
-        .reject_unsupported_global()
-        .unwrap_err();
-    assert_eq!(err, RuntimeError::GlobalUnsupported);
+fn global_install_builds_the_same_runtime_selector() {
+    // `--global` routes through `run_global`, which reuses `set_request`
+    // to build the `<name>@runtime:<version>` selector. The
+    // `--save-dev` / `--save-prod` group is irrelevant globally (the
+    // global group always saves to `dependencies`), so only the selector
+    // is asserted here.
+    let request =
+        RuntimeArgs { global: true, ..args(&["set", "node", "22"]) }.set_request().unwrap();
+    assert_eq!(request.package_name, "node@runtime:22");
 }

--- a/pacquet/crates/cli/src/cli_args/runtime/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/runtime/tests.rs
@@ -68,6 +68,24 @@ fn set_request_fails_without_runtime_name() {
 }
 
 #[test]
+fn set_request_rejects_unsupported_runtime_names() {
+    // An unknown runtime, plus the comma-list and local-path forms the
+    // global-add pipeline would otherwise misread as extra install targets.
+    for name in ["python", "node,is-positive", "./evil", "file:./evil"] {
+        let err = args(&["set", name, "22"]).set_request().unwrap_err();
+        assert_eq!(err, RuntimeError::InvalidRuntimeName { name: name.to_string() });
+    }
+}
+
+#[test]
+fn set_request_accepts_every_supported_runtime() {
+    for name in ["node", "deno", "bun"] {
+        let request = args(&["set", name, "22"]).set_request().unwrap();
+        assert_eq!(request.package_name, format!("{name}@runtime:22"));
+    }
+}
+
+#[test]
 fn global_install_builds_the_same_runtime_selector() {
     // `--global` routes through `run_global`, which reuses `set_request`
     // to build the `<name>@runtime:<version>` selector. The

--- a/pacquet/crates/cli/src/cli_args/runtime/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/runtime/tests.rs
@@ -78,6 +78,14 @@ fn set_request_rejects_unsupported_runtime_names() {
 }
 
 #[test]
+fn set_request_rejects_a_comma_in_the_version() {
+    // The version is interpolated into the comma-splittable selector, so a
+    // comma could smuggle in a second global install target.
+    let err = args(&["set", "node", "22,is-positive"]).set_request().unwrap_err();
+    assert_eq!(err, RuntimeError::InvalidRuntimeVersion { version: "22,is-positive".to_string() });
+}
+
+#[test]
 fn set_request_accepts_every_supported_runtime() {
     for name in ["node", "deno", "bun"] {
         let request = args(&["set", name, "22"]).set_request().unwrap();

--- a/pacquet/crates/cli/tests/global.rs
+++ b/pacquet/crates/cli/tests/global.rs
@@ -13,23 +13,27 @@ use std::{
     process::Command,
 };
 
-/// Create the global bin directory and seed the pnpm-home `.npmrc` with the
-/// mocked registry / store / cache. A `-g` install anchors its config at the
-/// pnpm home (not the caller project), so its network + store settings must
-/// be reachable from there rather than the workspace `.npmrc`.
+/// Create the global bin directory and seed the pnpm home with the mocked
+/// registry / store / cache. A `-g` install anchors its config at the pnpm
+/// home (not the caller project), so its network + store settings must be
+/// reachable from there rather than the workspace. The registry goes in
+/// `.npmrc`; `storeDir` / `cacheDir` go in `pnpm-workspace.yaml` (pnpm reads
+/// those from the yaml, not `.npmrc`), pinning a per-test store so a build's
+/// side-effects cache can't leak across runs.
 #[cfg(unix)]
 fn prepare_global_home(pnpm_home: &Path, npmrc_info: &AddMockedRegistry) {
     fs::create_dir_all(pnpm_home.join("bin")).expect("create global bin dir");
+    fs::write(pnpm_home.join(".npmrc"), format!("registry={}\n", npmrc_info.mock_instance.url()))
+        .expect("seed the pnpm-home npmrc");
     fs::write(
-        pnpm_home.join(".npmrc"),
+        pnpm_home.join("pnpm-workspace.yaml"),
         format!(
-            "registry={}\nstore-dir={}\ncache-dir={}\n",
-            npmrc_info.mock_instance.url(),
+            "storeDir: {}\ncacheDir: {}\nenableGlobalVirtualStore: false\n",
             npmrc_info.store_dir.display(),
             npmrc_info.cache_dir.display(),
         ),
     )
-    .expect("seed the pnpm-home npmrc");
+    .expect("seed the pnpm-home workspace yaml");
 }
 
 /// Build a fresh `pacquet` command in `workspace` with `PNPM_HOME` set and
@@ -116,6 +120,56 @@ fn global_add_list_remove_round_trip() {
         symlink_entries(&global_pkg_dir).is_empty(),
         "remove -g should delete the hash symlink",
     );
+
+    drop(npmrc_info);
+    drop(root);
+}
+
+/// A build approved during a global install must persist to the stable
+/// global packages directory (where the next global install reads it back),
+/// not to the throwaway per-group install dir. Regression test: the group
+/// install pins `workspace_dir` to the install dir, which `approve-builds`
+/// would otherwise use as the `allowBuilds` write target.
+#[cfg(unix)]
+#[test]
+fn global_add_persists_build_approvals_to_the_global_packages_dir() {
+    use assert_cmd::assert::OutputAssertExt;
+
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    let pnpm_home = root.path().join("pnpm-home");
+    let global_pkg_dir = pnpm_home.join("global").join("v11");
+    prepare_global_home(&pnpm_home, &npmrc_info);
+
+    global_command(&workspace, &pnpm_home)
+        .with_env("PNPM_AUTO_APPROVE_BUILDS_FOR_TESTS", "1")
+        .with_arg("add")
+        .with_arg("-g")
+        .with_arg("@pnpm.e2e/install-script-example")
+        .assert()
+        .success();
+
+    let global_yaml = fs::read_to_string(global_pkg_dir.join("pnpm-workspace.yaml"))
+        .expect("allowBuilds should persist to the global packages dir");
+    assert!(
+        global_yaml.contains("allowBuilds:")
+            && global_yaml.contains("@pnpm.e2e/install-script-example"),
+        "the global packages dir should hold the allowBuilds decision: {global_yaml}",
+    );
+
+    // No per-group install dir should carry the decision.
+    for entry in fs::read_dir(&global_pkg_dir).expect("read global packages dir").flatten() {
+        if entry.file_type().is_ok_and(|file_type| file_type.is_dir())
+            && let Ok(text) = fs::read_to_string(entry.path().join("pnpm-workspace.yaml"))
+        {
+            assert!(
+                !text.contains("allowBuilds:"),
+                "an install group must not carry the allowBuilds decision: {}",
+                entry.path().display(),
+            );
+        }
+    }
 
     drop(npmrc_info);
     drop(root);

--- a/pacquet/crates/cli/tests/global.rs
+++ b/pacquet/crates/cli/tests/global.rs
@@ -100,6 +100,46 @@ fn global_add_list_remove_round_trip() {
     drop(root);
 }
 
+/// A global install must ignore the `pnpm-workspace.yaml` of global
+/// settings (`allowBuilds`, `catalog`, ...) that lives in the global packages
+/// directory: the per-group install dir sits under it, so an install that
+/// walked up and adopted it as a workspace would fail enumerating its
+/// non-existent root project. Regression test for that walk-up.
+#[cfg(unix)]
+#[test]
+fn global_add_ignores_ambient_global_workspace_yaml() {
+    use assert_cmd::assert::OutputAssertExt;
+
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    let pnpm_home = root.path().join("pnpm-home");
+    let global_bin = pnpm_home.join("bin");
+    let global_pkg_dir = pnpm_home.join("global").join("v11");
+    fs::create_dir_all(&global_bin).expect("create global bin dir");
+    fs::create_dir_all(&global_pkg_dir).expect("create global packages dir");
+    fs::write(
+        global_pkg_dir.join("pnpm-workspace.yaml"),
+        "allowBuilds:\n  esbuild: true\ncatalog:\n  node: 'lts@runtime:'\n",
+    )
+    .expect("write ambient global workspace yaml");
+
+    global_command(&workspace, &pnpm_home)
+        .with_arg("add")
+        .with_arg("-g")
+        .with_arg("@foo/touch-file-one-bin")
+        .assert()
+        .success();
+
+    assert!(
+        global_bin.join("touch-file-one-bin").exists(),
+        "the package's bin should be linked even with a global-settings workspace yaml present",
+    );
+
+    drop(npmrc_info);
+    drop(root);
+}
+
 /// `pacquet list -g` with nothing installed reports the empty state rather
 /// than erroring. No registry needed.
 #[test]

--- a/pacquet/crates/cli/tests/global.rs
+++ b/pacquet/crates/cli/tests/global.rs
@@ -4,12 +4,33 @@
 
 use assert_cmd::cargo::CommandCargoExt;
 use command_extra::CommandExtra;
+#[cfg(unix)]
+use pacquet_testing_utils::bin::AddMockedRegistry;
 use pacquet_testing_utils::bin::CommandTempCwd;
 use std::{
     fs,
     path::{Path, PathBuf},
     process::Command,
 };
+
+/// Create the global bin directory and seed the pnpm-home `.npmrc` with the
+/// mocked registry / store / cache. A `-g` install anchors its config at the
+/// pnpm home (not the caller project), so its network + store settings must
+/// be reachable from there rather than the workspace `.npmrc`.
+#[cfg(unix)]
+fn prepare_global_home(pnpm_home: &Path, npmrc_info: &AddMockedRegistry) {
+    fs::create_dir_all(pnpm_home.join("bin")).expect("create global bin dir");
+    fs::write(
+        pnpm_home.join(".npmrc"),
+        format!(
+            "registry={}\nstore-dir={}\ncache-dir={}\n",
+            npmrc_info.mock_instance.url(),
+            npmrc_info.store_dir.display(),
+            npmrc_info.cache_dir.display(),
+        ),
+    )
+    .expect("seed the pnpm-home npmrc");
+}
 
 /// Build a fresh `pacquet` command in `workspace` with `PNPM_HOME` set and
 /// the global bin directory prepended to `PATH` (so `checkGlobalBinDir`
@@ -51,7 +72,7 @@ fn global_add_list_remove_round_trip() {
     let pnpm_home = root.path().join("pnpm-home");
     let global_bin = pnpm_home.join("bin");
     let global_pkg_dir = pnpm_home.join("global").join("v11");
-    fs::create_dir_all(&global_bin).expect("create global bin dir");
+    prepare_global_home(&pnpm_home, &npmrc_info);
 
     // add -g
     global_command(&workspace, &pnpm_home)
@@ -116,7 +137,7 @@ fn global_add_ignores_ambient_global_workspace_yaml() {
     let pnpm_home = root.path().join("pnpm-home");
     let global_bin = pnpm_home.join("bin");
     let global_pkg_dir = pnpm_home.join("global").join("v11");
-    fs::create_dir_all(&global_bin).expect("create global bin dir");
+    prepare_global_home(&pnpm_home, &npmrc_info);
     fs::create_dir_all(&global_pkg_dir).expect("create global packages dir");
     fs::write(
         global_pkg_dir.join("pnpm-workspace.yaml"),
@@ -162,7 +183,7 @@ fn global_add_ignores_caller_project_overrides() {
 
     let pnpm_home = root.path().join("pnpm-home");
     let global_bin = pnpm_home.join("bin");
-    fs::create_dir_all(&global_bin).expect("create global bin dir");
+    prepare_global_home(&pnpm_home, &npmrc_info);
 
     global_command(&workspace, &pnpm_home)
         .with_arg("add")
@@ -174,6 +195,43 @@ fn global_add_ignores_caller_project_overrides() {
     assert!(
         global_bin.join("touch-file-one-bin").exists(),
         "the global install should ignore the caller project's overrides / catalog mode",
+    );
+
+    drop(npmrc_info);
+    drop(root);
+}
+
+/// A global install must not use the caller project's `.npmrc` for network
+/// settings — a repo `.npmrc` could otherwise redirect the registry or
+/// downgrade TLS for a global runtime/package fetch. pnpm runs the install
+/// with `cwd` = the pnpm home; pacquet anchors the global-install config
+/// there. Pointing the caller project at a dead registry proves the global
+/// install ignores it and uses the trusted (pnpm-home) registry instead.
+#[cfg(unix)]
+#[test]
+fn global_add_ignores_caller_project_npmrc_registry() {
+    use assert_cmd::assert::OutputAssertExt;
+
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    let pnpm_home = root.path().join("pnpm-home");
+    let global_bin = pnpm_home.join("bin");
+    prepare_global_home(&pnpm_home, &npmrc_info);
+
+    fs::write(workspace.join(".npmrc"), "registry=http://127.0.0.1:1/\n")
+        .expect("overwrite caller project npmrc with a dead registry");
+
+    global_command(&workspace, &pnpm_home)
+        .with_arg("add")
+        .with_arg("-g")
+        .with_arg("@foo/touch-file-one-bin")
+        .assert()
+        .success();
+
+    assert!(
+        global_bin.join("touch-file-one-bin").exists(),
+        "the global install must ignore the caller project's .npmrc registry",
     );
 
     drop(npmrc_info);

--- a/pacquet/crates/cli/tests/global.rs
+++ b/pacquet/crates/cli/tests/global.rs
@@ -140,6 +140,46 @@ fn global_add_ignores_ambient_global_workspace_yaml() {
     drop(root);
 }
 
+/// A global install must not inherit the caller project's dependency-graph
+/// configuration. A project `overrides` entry that references a `catalog:`
+/// — resolved against the caller's catalogs, which the isolated global
+/// install does not see — would otherwise fail the install with
+/// `ERR_PNPM_CATALOG_IN_OVERRIDES`. `catalogMode: strict` is included for
+/// the same reason. Regression test for that leak.
+#[cfg(unix)]
+#[test]
+fn global_add_ignores_caller_project_overrides() {
+    use assert_cmd::assert::OutputAssertExt;
+
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "catalogMode: strict\noverrides:\n  is-positive: 'catalog:'\n",
+    )
+    .expect("write caller project workspace yaml");
+
+    let pnpm_home = root.path().join("pnpm-home");
+    let global_bin = pnpm_home.join("bin");
+    fs::create_dir_all(&global_bin).expect("create global bin dir");
+
+    global_command(&workspace, &pnpm_home)
+        .with_arg("add")
+        .with_arg("-g")
+        .with_arg("@foo/touch-file-one-bin")
+        .assert()
+        .success();
+
+    assert!(
+        global_bin.join("touch-file-one-bin").exists(),
+        "the global install should ignore the caller project's overrides / catalog mode",
+    );
+
+    drop(npmrc_info);
+    drop(root);
+}
+
 /// `pacquet list -g` with nothing installed reports the empty state rather
 /// than erroring. No registry needed.
 #[test]

--- a/pacquet/crates/global/Cargo.toml
+++ b/pacquet/crates/global/Cargo.toml
@@ -14,6 +14,7 @@ repository.workspace = true
 pacquet-cmd-shim                = { workspace = true }
 pacquet-crypto-hash             = { workspace = true }
 pacquet-fs                      = { workspace = true }
+pacquet-package-manifest        = { workspace = true }
 pacquet-resolving-deps-resolver = { workspace = true }
 
 derive_more = { workspace = true }

--- a/pacquet/crates/global/src/lib.rs
+++ b/pacquet/crates/global/src/lib.rs
@@ -13,6 +13,7 @@ mod global_package_dir;
 mod list;
 mod scan;
 
+use pacquet_package_manifest::convert_engines_runtime_to_dependencies;
 use serde_json::Value;
 use std::path::Path;
 
@@ -24,13 +25,25 @@ pub use global_package_dir::{create_install_dir, get_hash_link, resolve_install_
 pub use list::{ListReportAs, list_global_packages};
 pub use scan::{
     GlobalPackageInfo, InstalledGlobalPackage, clean_orphaned_install_dirs, find_global_package,
-    get_global_package_details, get_installed_bin_names, read_installed_packages,
-    scan_global_packages,
+    get_global_package_details, get_installed_bin_names, read_direct_dependency_aliases,
+    read_installed_packages, scan_global_packages,
 };
 
 /// Read and parse a `package.json` from `dir`, returning `None` on any
 /// read or parse failure. Mirrors pnpm's `safeReadPackageJsonFromDir`.
+///
+/// A downloaded runtime (`node`/`deno`/`bun`) is stored under
+/// `devEngines.runtime` / `engines.runtime` on disk, not under a
+/// dependency field — the manifest writer folds `<name>: runtime:<v>`
+/// into it on save. Reifying it back into `dependencies` /
+/// `devDependencies` here (the same conversion
+/// [`pacquet_package_manifest::PackageManifest`] applies on read) lets
+/// every global scanner and bin-linker treat an installed runtime as the
+/// direct dependency it is.
 pub(crate) fn read_package_json(dir: &Path) -> Option<Value> {
     let text = std::fs::read_to_string(dir.join("package.json")).ok()?;
-    serde_json::from_str(&text).ok()
+    let mut value: Value = serde_json::from_str(&text).ok()?;
+    convert_engines_runtime_to_dependencies(&mut value, "devEngines", "devDependencies");
+    convert_engines_runtime_to_dependencies(&mut value, "engines", "dependencies");
+    Some(value)
 }

--- a/pacquet/crates/global/src/scan.rs
+++ b/pacquet/crates/global/src/scan.rs
@@ -137,6 +137,16 @@ pub fn read_installed_packages(install_dir: &Path) -> Vec<PackageBinSource> {
         .collect()
 }
 
+/// The validated direct-dependency aliases of an install directory's
+/// `package.json`. A downloaded runtime pinned via `devEngines.runtime` /
+/// `engines.runtime` is reified into a dependency alias when the manifest
+/// is read, so it is included alongside regular dependencies.
+#[must_use]
+pub fn read_direct_dependency_aliases(install_dir: &Path) -> Vec<String> {
+    let Some(manifest) = read_package_json(install_dir) else { return Vec::new() };
+    dependencies_of(&manifest).into_iter().map(|(alias, _)| alias).collect()
+}
+
 /// Remove install directories under `global_dir` that no hash symlink
 /// points at. A 5-minute safety window avoids racing a concurrent install
 /// which has created its dir but not yet its symlink.
@@ -209,3 +219,6 @@ fn dependencies_of(manifest: &Value) -> Vec<(String, String)> {
         })
         .unwrap_or_default()
 }
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/global/src/scan/tests.rs
+++ b/pacquet/crates/global/src/scan/tests.rs
@@ -62,6 +62,18 @@ fn engines_runtime_without_download_is_not_treated_as_installed() {
     assert!(read_installed_packages(tmp.path()).is_empty());
 }
 
+#[test]
+fn ordinary_engines_node_range_is_not_reified() {
+    // A plain `engines.node` version constraint (very common in real
+    // packages) is not a downloaded runtime, so reification must leave it
+    // out of the dependency aliases and installed packages entirely.
+    let tmp = TempDir::new().unwrap();
+    write_json(&tmp.path().join("package.json"), &json!({ "engines": { "node": ">=18" } }));
+
+    assert!(read_direct_dependency_aliases(tmp.path()).is_empty());
+    assert!(read_installed_packages(tmp.path()).is_empty());
+}
+
 #[cfg(unix)]
 #[test]
 fn scan_finds_a_globally_installed_runtime() {

--- a/pacquet/crates/global/src/scan/tests.rs
+++ b/pacquet/crates/global/src/scan/tests.rs
@@ -1,0 +1,79 @@
+use super::{
+    find_global_package, get_installed_bin_names, read_direct_dependency_aliases,
+    read_installed_packages, scan_global_packages,
+};
+use serde_json::json;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn write_json(path: &Path, value: &serde_json::Value) {
+    std::fs::create_dir_all(path.parent().expect("json path has a parent")).unwrap();
+    std::fs::write(path, serde_json::to_string_pretty(value).unwrap()).unwrap();
+}
+
+/// Populate `install_dir` as a global group holding a downloaded Node.js
+/// runtime: the manifest stores it under `engines.runtime` (the shape the
+/// manifest writer folds `node: runtime:<v>` into), and the runtime is
+/// materialized under `node_modules/node` with a synthesized `bin`.
+fn write_runtime_group(install_dir: &Path) {
+    write_json(
+        &install_dir.join("package.json"),
+        &json!({
+            "engines": {
+                "runtime": { "name": "node", "version": "22.11.0", "onFail": "download" },
+            },
+        }),
+    );
+    write_json(
+        &install_dir.join("node_modules/node/package.json"),
+        &json!({ "name": "node", "version": "22.11.0", "bin": { "node": "bin/node" } }),
+    );
+}
+
+#[test]
+fn runtime_engines_are_reified_as_a_direct_dependency() {
+    let tmp = TempDir::new().unwrap();
+    write_runtime_group(tmp.path());
+
+    assert_eq!(read_direct_dependency_aliases(tmp.path()), vec!["node".to_string()]);
+
+    let pkgs = read_installed_packages(tmp.path());
+    assert_eq!(pkgs.len(), 1);
+    assert_eq!(pkgs[0].location, tmp.path().join("node_modules/node"));
+    assert_eq!(pkgs[0].manifest.get("bin"), Some(&json!({ "node": "bin/node" })));
+}
+
+#[test]
+fn engines_runtime_without_download_is_not_treated_as_installed() {
+    // A group whose manifest merely declares an engine *check*
+    // (`onFail: "warn"`) has not downloaded a runtime, so it must not be
+    // reified into a dependency and mistaken for an installed runtime.
+    let tmp = TempDir::new().unwrap();
+    write_json(
+        &tmp.path().join("package.json"),
+        &json!({
+            "engines": {
+                "runtime": { "name": "node", "version": "22.11.0", "onFail": "warn" },
+            },
+        }),
+    );
+
+    assert!(read_direct_dependency_aliases(tmp.path()).is_empty());
+    assert!(read_installed_packages(tmp.path()).is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn scan_finds_a_globally_installed_runtime() {
+    let global_dir = TempDir::new().unwrap();
+    let install_dir = global_dir.path().join("install-abc");
+    write_runtime_group(&install_dir);
+    std::os::unix::fs::symlink(&install_dir, global_dir.path().join("hashkey")).unwrap();
+
+    let groups = scan_global_packages(global_dir.path()).unwrap();
+    assert_eq!(groups.len(), 1);
+    assert!(groups[0].has_alias("node"));
+    assert_eq!(get_installed_bin_names(&groups[0]), vec!["node".to_string()]);
+
+    assert!(find_global_package(global_dir.path(), "node").unwrap().is_some());
+}

--- a/pacquet/crates/package-manifest/src/lib.rs
+++ b/pacquet/crates/package-manifest/src/lib.rs
@@ -336,6 +336,13 @@ impl PackageManifest {
 /// `engines.runtime` reification.
 const RUNTIME_NAMES: [&str; 3] = ["node", "deno", "bun"];
 
+/// Whether `alias` names a runtime pnpm can download and manage
+/// (`node` / `deno` / `bun`).
+#[must_use]
+pub fn is_runtime_alias(alias: &str) -> bool {
+    RUNTIME_NAMES.contains(&alias)
+}
+
 /// Reify `devEngines.runtime` / `engines.runtime` entries with
 /// `onFail: "download"` into the matching `devDependencies` /
 /// `dependencies` slot as `runtime:<version>` specifiers.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4103,6 +4103,9 @@ importers:
       '@pnpm/network.fetch':
         specifier: workspace:*
         version: link:../../../network/fetch
+      '@pnpm/types':
+        specifier: workspace:*
+        version: link:../../../core/types
       render-help:
         specifier: 'catalog:'
         version: 2.0.0

--- a/pnpm11/engine/runtime/commands/package.json
+++ b/pnpm11/engine/runtime/commands/package.json
@@ -38,6 +38,7 @@
     "@pnpm/error": "workspace:*",
     "@pnpm/exec.pnpm-cli-runner": "workspace:*",
     "@pnpm/network.fetch": "workspace:*",
+    "@pnpm/types": "workspace:*",
     "render-help": "catalog:"
   },
   "peerDependencies": {

--- a/pnpm11/engine/runtime/commands/src/runtime/runtime.ts
+++ b/pnpm11/engine/runtime/commands/src/runtime/runtime.ts
@@ -111,6 +111,13 @@ function runtimeSet (opts: RuntimeCommandOptions, params: string[]): void {
   }
 
   const versionSpec = params[1]?.trim()
+  // The version is interpolated into the same selector, which the global-add
+  // pipeline splits on commas. Reject a comma so `runtime set node 22,evil -g`
+  // can't smuggle in a second install target. No valid runtime version
+  // (semver, dist-tag, channel) contains one.
+  if (versionSpec?.includes(',')) {
+    throw new PnpmError('INVALID_RUNTIME_VERSION', `Invalid runtime version "${versionSpec}": a version cannot contain a comma`)
+  }
 
   const args = ['add', `${runtimeName}@runtime:${versionSpec ?? ''}`]
   // Default to `devEngines.runtime`; the manifest writer maps a

--- a/pnpm11/engine/runtime/commands/src/runtime/runtime.ts
+++ b/pnpm11/engine/runtime/commands/src/runtime/runtime.ts
@@ -2,6 +2,7 @@ import { docsUrl } from '@pnpm/cli.utils'
 import type { Config } from '@pnpm/config.reader'
 import { PnpmError } from '@pnpm/error'
 import { runPnpmCli } from '@pnpm/exec.pnpm-cli-runner'
+import { isRuntimeAlias, RUNTIME_NAMES } from '@pnpm/types'
 import { renderHelp } from 'render-help'
 
 export type RuntimeCommandOptions = Pick<Config,
@@ -101,6 +102,12 @@ function runtimeSet (opts: RuntimeCommandOptions, params: string[]): void {
   const runtimeName = params[0]?.trim()
   if (!runtimeName) {
     throw new PnpmError('MISSING_RUNTIME_NAME', '"pnpm runtime set <name> <version>" requires a runtime name (e.g. node, deno, bun)')
+  }
+  // The runtime name is interpolated into an `add` selector, so reject
+  // anything that isn't a known runtime before it can be misread as a
+  // comma-separated package list or a local path by the install pipeline.
+  if (!isRuntimeAlias(runtimeName)) {
+    throw new PnpmError('INVALID_RUNTIME_NAME', `"${runtimeName}" is not a supported runtime. Supported runtimes are: ${RUNTIME_NAMES.join(', ')}`)
   }
 
   const versionSpec = params[1]?.trim()

--- a/pnpm11/engine/runtime/commands/test/runtime.test.ts
+++ b/pnpm11/engine/runtime/commands/test/runtime.test.ts
@@ -172,3 +172,16 @@ test.each([
 
   expect(mockRunPnpmCli).not.toHaveBeenCalled()
 })
+
+test('fail if the version contains a comma', async () => {
+  await expect(
+    runtime.handler({
+      bin: '/usr/local/bin',
+      dir: '/tmp/project',
+      global: true,
+      pnpmHomeDir: '/tmp/pnpm-home',
+    }, ['set', 'node', '22,is-positive'])
+  ).rejects.toEqual(new PnpmError('INVALID_RUNTIME_VERSION', 'Invalid runtime version "22,is-positive": a version cannot contain a comma'))
+
+  expect(mockRunPnpmCli).not.toHaveBeenCalled()
+})

--- a/pnpm11/engine/runtime/commands/test/runtime.test.ts
+++ b/pnpm11/engine/runtime/commands/test/runtime.test.ts
@@ -154,3 +154,21 @@ test('fail if runtime name is missing', async () => {
 
   expect(mockRunPnpmCli).not.toHaveBeenCalled()
 })
+
+test.each([
+  ['an unknown runtime', 'python'],
+  ['a comma-separated package list', 'node,is-positive'],
+  ['a relative local path', './evil'],
+  ['a file: local path', 'file:./evil'],
+])('fail if the runtime name is %s', async (_description, runtimeName) => {
+  await expect(
+    runtime.handler({
+      bin: '/usr/local/bin',
+      dir: '/tmp/project',
+      global: true,
+      pnpmHomeDir: '/tmp/pnpm-home',
+    }, ['set', runtimeName, '22'])
+  ).rejects.toEqual(new PnpmError('INVALID_RUNTIME_NAME', `"${runtimeName}" is not a supported runtime. Supported runtimes are: node, deno, bun`))
+
+  expect(mockRunPnpmCli).not.toHaveBeenCalled()
+})

--- a/pnpm11/engine/runtime/commands/tsconfig.json
+++ b/pnpm11/engine/runtime/commands/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../../../core/logger"
     },
     {
+      "path": "../../../core/types"
+    },
+    {
       "path": "../../../exec/pnpm-cli-runner"
     },
     {


### PR DESCRIPTION
## Summary

`pnpm runtime set <name> <version> -g` now installs a runtime (Node/Deno/Bun) into the global packages directory and links its binary into the global bin directory, matching the TypeScript pnpm CLI. Previously pacquet rejected `runtime set --global` with a "not supported yet" stub.

The `` `<name>@runtime:<version>` `` selector is routed through the existing global-add pipeline. The one wrinkle: pacquet's manifest writer folds a `runtime:<version>` dependency into `engines.runtime` on save, so a globally-installed runtime is stored under `engines.runtime` with an empty `dependencies` map. The global scanner and bin-linker read `dependencies`, so without a fix they would link no binary. The global crate now reifies `engines.runtime` / `devEngines.runtime` back into dependencies when reading a group manifest — the same conversion the package-manifest reader already applies on read — so `list -g`, `remove -g`, and `update -g` see the runtime too.

The TypeScript pnpm CLI already ships this feature, so this PR brings pacquet to parity and needs no TypeScript-side change.

Verified end-to-end: `runtime set node 22 -g` downloads Node 22.23.1 and links `node` into the global bin dir (`node --version` → `v22.23.1`); `list -g` shows `node@22.23.1`; `remove -g node` unlinks it.

**Follow-ups from review:**

- **Argument validation for `runtime set`** (both stacks): the runtime name must be `node`/`deno`/`bun`, and the version must not contain a comma. Without this, `node,is-positive`, `./foo`, or `22,evil` could be misread by the global-add pipeline as a package list / local path and install unintended packages. Errors are `ERR_PNPM_INVALID_RUNTIME_NAME` / `ERR_PNPM_INVALID_RUNTIME_VERSION`, with tests and a changeset.
- **Global-install config isolation** (pacquet-only; the TS CLI already isolates via its `cwd`-anchored re-spawn): a `-g` install now (a) pins its workspace root to the install dir so it can't adopt the global-settings `pnpm-workspace.yaml`, (b) drops the caller project's `overrides`/`catalogs`/`catalogMode`/etc., and (c) anchors its config at the pnpm home so a project `.npmrc` can't steer the network/TLS/registry of a global fetch. Each is covered by a regression test that fails without the fix.

## Squash Commit Body

```text
`pnpm runtime set <name> <version> -g` now installs the runtime
(Node/Deno/Bun) into the global packages directory and links its binary
into the global bin directory, matching the TypeScript pnpm CLI. It
previously errored with a "not supported yet" stub.

The `<name>@runtime:<version>` selector is routed through the existing
global-add pipeline. The wrinkle: pacquet's manifest writer folds a
`runtime:<version>` dependency into `engines.runtime` on save, so a
globally-installed runtime lands under `engines.runtime` with an empty
`dependencies` map. The global scanner and bin-linker read `dependencies`,
so without a fix they would link no binary. The global crate now reifies
`engines.runtime` / `devEngines.runtime` back into dependencies when
reading a group manifest — the same conversion the package manifest
reader already applies — so an installed runtime is treated as the direct
dependency it is. `list -g`, `remove -g`, and `update -g` therefore see
it too.

The TypeScript pnpm CLI already ships this feature, so this brings pacquet
to parity and needs no TypeScript change; pacquet crates are unpublished,
so no changeset is required.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  (The TypeScript CLI already ships `runtime set -g`; this PR brings the
  Rust `pacquet/` port to parity. No TypeScript-side change is needed.)
- [x] Added or updated tests. (Global-crate reify unit tests plus the
  runtime-command selector test; verified the full install/list/remove
  lifecycle end-to-end.)
- [x] Updated the documentation if needed. (The `pnpm runtime set -g`
  behavior is already documented; this is a parity port with no
  user-visible surface change.)

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Global installs and updates now use the correct global configuration, improving `-g` behavior.
  * Runtime selection now supports global installation and shows clearer errors for unsupported runtime names.

* **Bug Fixes**
  * Global installs now ignore unrelated workspace files and caller-specific overrides.
  * Runtime version input is validated more strictly to prevent unintended install targets.
  * Global package scanning now detects runtime-based installs more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->