### PR TITLE
fix(init): pnpm init writes invalid devEngines version

### DIFF
--- a/pnpm11/workspace/commands/src/init.ts
+++ b/pnpm11/workspace/commands/src/init.ts
@@ -111,7 +111,7 @@ export async function handler (opts: InitOptions, params?: string[]): Promise<st
       ...packageJson.devEngines,
       packageManager: {
         name: 'pnpm',
-        version: `^${packageManager.version}`,
+        version: `${packageManager.version}`,
         onFail: 'download',
       },
     }

--- a/pnpm11/workspace/commands/src/init.ts
+++ b/pnpm11/workspace/commands/src/init.ts
@@ -111,7 +111,7 @@ export async function handler (opts: InitOptions, params?: string[]): Promise<st
       ...packageJson.devEngines,
       packageManager: {
         name: 'pnpm',
-        version: `${packageManager.version}`,
+        version: packageManager.version,
         onFail: 'download',
       },
     }

--- a/pnpm11/workspace/commands/test/init.test.ts
+++ b/pnpm11/workspace/commands/test/init.test.ts
@@ -118,7 +118,7 @@ test('init a new package.json at the workspace root adds devEngines', async () =
   const manifest = loadJsonFileSync<ProjectManifest>(path.resolve('package.json'))
   expect(manifest.devEngines?.packageManager).toEqual({
     name: 'pnpm',
-    version: expect.stringMatching(/^\^\d+\.\d+\.\d+/),
+    version: expect.stringMatching(/^\d+\.\d+\.\d+/),
     onFail: 'download',
   })
 })

--- a/pnpm11/workspace/commands/test/init.test.ts
+++ b/pnpm11/workspace/commands/test/init.test.ts
@@ -77,7 +77,7 @@ test('init a new package.json with init-package-manager=true', async () => {
   expect(manifest).not.toHaveProperty('packageManager')
   expect(manifest.devEngines?.packageManager).toEqual({
     name: 'pnpm',
-    version: expect.stringMatching(/^\^\d+\.\d+\.\d+/),
+    version: expect.stringMatching(/^\d+\.\d+\.\d+/),
     onFail: 'download',
   })
 })


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
󰍲 | ~\code\kysely-test | 2s
 ❯ pnpm init
Wrote to C:\Users\cscnk52\code\kysely-test\package.json

{
  "name": "kysely-test",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "keywords": [],
  "author": "",
  "license": "ISC",
  "devEngines": {
    "packageManager": {
      "name": "pnpm",
      "version": "^11.10.0",
      "onFail": "download"
    }
  },
  "type": "module"
}

󰍲 | ~\code\kysely-test | 📦 v1.0.0 |  v26.4.0
 ❯ pnpm i kysely
Invalid package manager specification in package.json (pnpm@^11.10.0); expected a semver version
```

There should be `11.10.0`, not have `^`.

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests.
- [ ] Updated the documentation if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm init` now records the selected package manager version exactly (e.g., `X.Y.Z`) rather than converting it to a caret-prefixed semver range.
  * Newly generated project metadata is more consistent with the chosen version.
* **Tests**
  * Updated Jest expectations for init behavior when package manager auto-detection is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->