### PR TITLE
fix(pacquet): resolve caller catalogs in dlx overrides and find runtime bins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3664,6 +3664,7 @@ dependencies = [
  "pacquet-catalogs-config",
  "pacquet-cmd-shim",
  "pacquet-config",
+ "pacquet-config-parse-overrides",
  "pacquet-crypto-hash",
  "pacquet-default-reporter",
  "pacquet-deps-path",

--- a/pacquet/crates/cli/Cargo.toml
+++ b/pacquet/crates/cli/Cargo.toml
@@ -32,6 +32,7 @@ pacquet-lockfile                          = { workspace = true }
 pacquet-modules-yaml                      = { workspace = true }
 pacquet-network                           = { workspace = true }
 pacquet-config                            = { workspace = true }
+pacquet-config-parse-overrides            = { workspace = true }
 pacquet-default-reporter                  = { workspace = true }
 pacquet-deps-path                         = { workspace = true }
 pacquet-pack                              = { workspace = true }

--- a/pacquet/crates/cli/src/cli_args/dlx.rs
+++ b/pacquet/crates/cli/src/cli_args/dlx.rs
@@ -5,12 +5,14 @@ use crate::{
 use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
+use pacquet_catalogs_config::get_catalogs_from_workspace_manifest;
 use pacquet_cmd_shim::{Host as CmdShimHost, get_bins_from_package_manifest};
 use pacquet_config::Config;
+use pacquet_config_parse_overrides::parse_overrides_iter;
 use pacquet_crypto_hash::create_short_hash;
 use pacquet_fs::force_symlink_dir;
 use pacquet_package_is_installable::SupportedArchitectures;
-use pacquet_package_manifest::DependencyGroup;
+use pacquet_package_manifest::{DependencyGroup, convert_engines_runtime_to_dependencies};
 use pacquet_registry::PinnedVersion;
 use pacquet_reporter::Reporter;
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
@@ -261,6 +263,28 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
     // The cache install is always fresh, so no lockfile is loaded from
     // the process working directory.
     config.lockfile = false;
+    // The cache install inherits the caller project's `overrides` (pnpm's
+    // dlx likewise runs its install with the invoking project's
+    // already-loaded config), and a `catalog:` value in them resolves
+    // against the caller's catalogs. Those catalogs are only reachable
+    // through `workspace_dir`, which is severed right below — resolve the
+    // references now, or the install would look them up against an empty
+    // catalog set and fail with ERR_PNPM_CATALOG_IN_OVERRIDES.
+    if let (Some(overrides), Some(workspace_dir)) =
+        (config.overrides.as_ref(), config.workspace_dir.as_deref())
+    {
+        let workspace_manifest =
+            pacquet_workspace::read_workspace_manifest(workspace_dir).into_diagnostic()?;
+        let catalogs = get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
+            .into_diagnostic()
+            .wrap_err("reading the caller's catalogs for the dlx install")?;
+        let resolved = parse_overrides_iter(overrides.iter(), &catalogs)
+            .map_err(miette::Report::new)?
+            .into_iter()
+            .map(|entry| (entry.selector, entry.new_bare_specifier))
+            .collect();
+        config.overrides = Some(resolved);
+    }
     // The throwaway cache project is not part of the caller's
     // workspace. If a caller has a settings-only pnpm-workspace.yaml,
     // carrying its workspace root here makes the install enumerate that
@@ -485,7 +509,13 @@ fn get_bin_name(cached_dir: &Path) -> Result<String, DlxError> {
 
 /// The first key of the installed manifest's `dependencies`.
 fn get_pkg_name(cached_dir: &Path) -> Result<String, DlxError> {
-    let manifest = read_json(&cached_dir.join("package.json"))?;
+    let mut manifest = read_json(&cached_dir.join("package.json"))?;
+    // The manifest writer records a `runtime:` dependency (e.g.
+    // `pnpm dlx node@runtime:26.4.0`) as `engines.runtime` on disk;
+    // reify it back into the dependency map — the same conversion the
+    // manifest reader applies — so the runtime is discoverable here.
+    convert_engines_runtime_to_dependencies(&mut manifest, "devEngines", "devDependencies");
+    convert_engines_runtime_to_dependencies(&mut manifest, "engines", "dependencies");
     manifest
         .get("dependencies")
         .and_then(Value::as_object)

--- a/pacquet/crates/cli/src/cli_args/dlx.rs
+++ b/pacquet/crates/cli/src/cli_args/dlx.rs
@@ -272,6 +272,7 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
     // catalog set and fail with ERR_PNPM_CATALOG_IN_OVERRIDES.
     if let (Some(overrides), Some(workspace_dir)) =
         (config.overrides.as_ref(), config.workspace_dir.as_deref())
+        && overrides.values().any(|spec| spec.starts_with("catalog:"))
     {
         let workspace_manifest =
             pacquet_workspace::read_workspace_manifest(workspace_dir).into_diagnostic()?;

--- a/pacquet/crates/cli/src/cli_args/dlx/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/dlx/tests.rs
@@ -250,3 +250,31 @@ fn get_bin_name_errors_on_ambiguous_bins() {
     );
     assert!(matches!(get_bin_name(dir.path()), Err(DlxError::MultipleBins { .. })));
 }
+
+/// A dlx-installed runtime (`pnpm dlx node@runtime:<version>`) is recorded
+/// in the cache manifest as `engines.runtime` by the manifest writer's
+/// round-trip, not under `dependencies` — the installed package must still
+/// be found there.
+#[test]
+fn get_bin_name_finds_a_runtime_recorded_as_engines_runtime() {
+    let dir = tempdir().expect("temp dir");
+    fs::write(
+        dir.path().join("package.json"),
+        serde_json::json!({
+            "name": "dlx",
+            "version": "0.0.0",
+            "dependencies": {},
+            "engines": {
+                "runtime": { "name": "node", "version": "26.4.0", "onFail": "download" },
+            },
+        })
+        .to_string(),
+    )
+    .expect("write root manifest");
+    write_pkg(
+        dir.path(),
+        "node",
+        serde_json::json!({ "name": "node", "version": "26.4.0", "bin": { "node": "bin/node" } }),
+    );
+    assert_eq!(get_bin_name(dir.path()).expect("bin name"), "node");
+}

--- a/pacquet/crates/cli/tests/dlx.rs
+++ b/pacquet/crates/cli/tests/dlx.rs
@@ -59,3 +59,32 @@ fn dlx_installs_and_runs_packages_bin() {
 
     drop(root);
 }
+
+/// The dlx cache install inherits the caller project's `overrides` (pnpm's
+/// dlx runs its install with the invoking project's already-loaded config),
+/// so a `catalog:` value in them must resolve against the caller's catalogs
+/// even though the cache install itself has no workspace. Regression test
+/// for `ERR_PNPM_CATALOG_IN_OVERRIDES` failing every dlx invocation from
+/// such a project. `catalogMode: strict` is included because it is likewise
+/// inherited and must not break the throwaway install.
+#[cfg(unix)]
+#[test]
+fn dlx_resolves_caller_catalog_references_in_overrides() {
+    let CommandTempCwd { pacquet, root, workspace, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    std::fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "catalog:\n  is-positive: 3.1.0\ncatalogMode: strict\noverrides:\n  is-positive: 'catalog:'\n",
+    )
+    .expect("write caller project workspace yaml");
+
+    pacquet.with_arg("dlx").with_arg("@foo/touch-file-one-bin").assert().success();
+
+    assert!(
+        workspace.join("touch.txt").exists(),
+        "the package's bin should run in the process cwd and write `touch.txt`",
+    );
+
+    drop(root);
+}


### PR DESCRIPTION
## Summary

`pnpm dlx` (`pnx`) in the Rust CLI failed in two independent ways when invoked from a project like pnpm/pnpm itself, which is why the "Compile TypeScript" step (`pnx node@runtime:26.4.0 …` in `compile-only`) failed on the TS CI of pnpm/pnpm#12811 after updating the package manager to v12.0.0-alpha.1:

1. **`ERR_PNPM_CATALOG_IN_OVERRIDES` on every dlx invocation.** The dlx cache install inherits the caller project's `overrides`, but severs `workspace_dir` before installing, so `catalog:` values in those overrides (e.g. `hosted-git-info@1: 'catalog:'` in this repo) were resolved against an empty catalog set. The TypeScript CLI doesn't have this problem because its dlx runs the install with the invoking project's already-loaded config, where overrides and catalogs stay consistent. The fix resolves the `catalog:` references against the caller's catalogs before the workspace link is severed. The caller's catalogs are deliberately *not* injected into `config.catalogs`, because that would shadow the prepare-dir catalog write-back that `catalogMode: strict` relies on.

2. **`ERR_PNPM_DLX_NO_DEP` for runtime specs.** `pnpm dlx node@runtime:26.4.0 <script>` installed the runtime but then couldn't find it: the manifest writer round-trips the added runtime dependency to `engines.runtime`, leaving `dependencies` empty, and dlx's bin discovery reads the raw `dependencies` map. The fix applies the manifest reader's `engines.runtime` → dependencies conversion when reading the cache manifest. The TypeScript CLI avoids this because its dlx never pre-writes a cache manifest, so its manifest write takes the raw fallback in `createProjectManifestWriter` and keeps the runtime entry under `dependencies` on disk.

Verified end-to-end: with this repo's exact `pnpm-workspace.yaml` (catalog overrides + `catalogMode: strict`) and a fresh store, `pacquet dlx node@runtime:26.4.0 --version` now prints `v26.4.0`.

**Known follow-up (pre-existing, out of scope):** a store whose node-runtime CAS index was written by an older tool version without the synthesized `package.json` still breaks `dlx node@runtime:<version>` (the materialized slot has no manifest, so no `.bin` link is created). The TypeScript CLI tolerates exactly this state via the `getBinName` fallback in `dlx.ts` plus resolution-driven bin linking; pacquet doesn't yet. Fresh stores and stores populated by current pnpm v11 or v12 are unaffected (both verified).

## Squash Commit Body

```text
pnpm dlx (pnx) failed in two ways when run from a project such as
pnpm/pnpm itself:

1. The dlx cache install inherits the caller project's `overrides`, but
   severs `workspace_dir` before installing, so `catalog:` values in
   those overrides were resolved against an empty catalog set and every
   dlx invocation failed with ERR_PNPM_CATALOG_IN_OVERRIDES. Resolve the
   references against the caller's catalogs before the workspace link is
   severed. This matches the TypeScript CLI, which runs the dlx install
   with the invoking project's already-loaded config, where overrides
   and catalogs stay consistent. The caller's catalogs are deliberately
   not injected into `config.catalogs`: that would shadow the
   prepare-dir catalog write-back that `catalogMode: strict` relies on.

2. `pnpm dlx node@runtime:26.4.0 <script>` installed the runtime but
   then failed with ERR_PNPM_DLX_NO_DEP: the manifest writer round-trips
   the added runtime dependency to `engines.runtime`, leaving
   `dependencies` empty, and dlx's bin discovery reads the raw
   `dependencies` map. Apply the manifest reader's `engines.runtime`
   to dependencies conversion when reading the cache manifest. The
   TypeScript CLI avoids this because its dlx never pre-writes a cache
   manifest, so its manifest write takes the raw fallback and keeps the
   runtime entry under `dependencies` on disk.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  (pacquet-only fix — the TypeScript CLI already behaves correctly; both
  failure modes are pacquet regressions against it.)
- [x] Added or updated tests. (Integration test for the catalog-overrides
  inheritance and a unit test for the runtime manifest shape; both verified
  to fail without their fix.)

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `dlx` package selection so runtime entries are recognized even when stored in manifest runtime fields.
  * Fixed catalog-based override resolution during temporary cache installs, so commands work correctly when overrides reference catalogs.
* **Tests**
  * Added regression tests covering catalog override resolution and runtime-based bin lookup in `dlx`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->