### PR TITLE
chore(rust): strip aggressive optimization to improve compile time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,8 +264,6 @@ wildcard_dependencies   = "warn"
 
 [profile.release]
 opt-level     = 3
-lto           = "fat"
-codegen-units = 1
 strip         = "symbols"
 debug         = false
 panic         = "abort"   # Let it crash and force ourselves to write safe Rust.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,10 +263,10 @@ redundant_feature_names = "warn"
 wildcard_dependencies   = "warn"
 
 [profile.release]
-opt-level     = 3
-strip         = "symbols"
-debug         = false
-panic         = "abort"   # Let it crash and force ourselves to write safe Rust.
+opt-level = 3
+strip     = "symbols"
+debug     = false
+panic     = "abort"   # Let it crash and force ourselves to write safe Rust.
 
 # Use the `--profile release-debug` flag to show symbols in release mode.
 # e.g. `cargo build --profile release-debug`


### PR DESCRIPTION
## Summary

Before this PR, on a workstation with 64 GB of RAM and 28 CPU cores, the clean compilation of all dependency crates and all workspace crates (sans the final binary) takes about 1 minute. The linking time of the final binary take about 7 minutes.

Unlike the crates, the linking time doesn't benefit from incremental compilation.

As a consequence, the benchmark CI also take a long time to finish.

This PR removes the aggressive optimization from the `--release` mode. It makes the assumption that micro-optimization doesn't affect the overall performance significantly.

An alternative approach is to define a profile named `benchmark` separated from the `release` profile. But this would also mean that the benchmarks no longer measure the final binary actually released.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Reduce linking time at the expense of insignificant performance impact.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Updated release build settings to streamline compilation while preserving optimized, stripped production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->