### PR TITLE
fix(pacquet-cli): install exe wrapper for with downgrades

### DIFF
--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -74,6 +74,14 @@ pub struct CliArgs {
     #[clap(short = 'v', long = "version", action = clap::ArgAction::Version)]
     pub version: Option<bool>,
 
+    /// Force colored output.
+    #[clap(long, global = true)]
+    pub color: bool,
+
+    /// Automatically answer yes to prompts.
+    #[clap(short = 'y', long, global = true)]
+    pub yes: bool,
+
     /// Set working directory.
     #[clap(short = 'C', long, default_value = ".")]
     pub dir: PathBuf,

--- a/pacquet/crates/cli/src/cli_args/dispatch.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch.rs
@@ -115,6 +115,8 @@ impl CliArgs {
             filter,
             filter_prod,
             version: _,
+            color: _,
+            yes: _,
         } = self;
 
         // Canonicalize `--dir` so the bunyan-envelope `prefix` emitted by

--- a/pacquet/crates/cli/src/cli_args/self_update.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update.rs
@@ -230,7 +230,7 @@ async fn handler<Reporter: self::Reporter + 'static>(
     ))
     .await?;
 
-    link_into_global_bin(config, &result.install_dir)?;
+    link_into_global_bin(config, &result.install_dir, result.package_name)?;
 
     if result.already_existed {
         return Ok(Some(format!(
@@ -407,7 +407,11 @@ fn read_project_pinned_pnpm_version(lockfile_dir: &Path, spec: Option<&str>) -> 
 /// Link the installed engine's bins into the global bin directory and
 /// record its cache-keyed hash symlink (so `pnpm ls -g` and `store prune`
 /// see it).
-fn link_into_global_bin(config: &Config, install_dir: &Path) -> miette::Result<()> {
+fn link_into_global_bin(
+    config: &Config,
+    install_dir: &Path,
+    package_name: &str,
+) -> miette::Result<()> {
     let global_bin = config.global_bin.clone().ok_or(SelfUpdateError::NoGlobalDir)?;
     let global_pkg_dir = config.global_pkg_dir.clone().ok_or(SelfUpdateError::NoGlobalDir)?;
 
@@ -416,7 +420,7 @@ fn link_into_global_bin(config: &Config, install_dir: &Path) -> miette::Result<(
         .map_err(miette::Report::new)
         .wrap_err("link the updated pnpm bins")?;
 
-    let aliases = vec![install_pnpm::PNPM_PACKAGE_NAME.to_string()];
+    let aliases = vec![package_name.to_string()];
     let cache_hash = create_global_cache_key(&aliases, &registries_for_cache_key(config));
     let hash_link = get_hash_link(&global_pkg_dir, &cache_hash);
     force_symlink_dir(install_dir, &hash_link)

--- a/pacquet/crates/cli/src/cli_args/self_update.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update.rs
@@ -203,8 +203,8 @@ async fn handler<Reporter: self::Reporter + 'static>(
     );
 
     let env_root = config.global_pkg_dir.clone().ok_or(SelfUpdateError::NoGlobalDir)?;
-    // Resolve integrities (pnpm + @pnpm/exe + platform binary) into the
-    // env lockfile so the engine identity can be verified before install.
+    // Resolve integrities into the env lockfile so the engine identity can
+    // be verified before install.
     Box::pin(config_deps::sync_package_manager_dependencies(
         config,
         &env_root,

--- a/pacquet/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -1,10 +1,10 @@
 //! Install pnpm into the global packages directory for a self-update.
 //!
 //! The engine is installed into a fresh directory under the global
-//! packages dir (visible to `pnpm ls -g`), the host's native platform
-//! binary is linked into the wrapper (replicating the wrapper's
-//! preinstall, which is skipped because the engine is installed with
-//! scripts disabled), and the caller links the bins + hash symlink.
+//! packages dir (visible to `pnpm ls -g`), native target installs have the
+//! host's platform binary linked into the wrapper (replicating the wrapper's
+//! preinstall, which is skipped because the engine is installed with scripts
+//! disabled), and the caller links the bins + hash symlink.
 
 use crate::{State, cli_args::add::add_package};
 use miette::{Context, IntoDiagnostic};
@@ -28,11 +28,19 @@ use super::SelfUpdateError;
 pub(crate) const PNPM_PACKAGE_NAME: &str = "pnpm";
 pub(crate) const PNPM_EXE_PACKAGE_NAME: &str = "@pnpm/exe";
 
+const PNPM_EXE_INTRODUCED: (u64, u64, u64) = (6, 17, 1);
+
 /// The package-manager components marked buildable when installing the
 /// engine (`{ '@pnpm/exe': true, 'pnpm': true }`), so the `ENGINE_NAME` is
 /// folded into their global-virtual-store hash and each platform resolves
 /// to its own slot instead of colliding.
 pub(crate) const PNPM_ALLOW_BUILDS: [&str; 2] = ["pnpm", "@pnpm/exe"];
+
+#[derive(Clone, Copy)]
+pub(crate) struct PnpmPackageToInstall {
+    pub name: &'static str,
+    pub links_native_binary: bool,
+}
 
 pub(super) struct InstallPnpmResult {
     pub install_dir: PathBuf,
@@ -49,7 +57,8 @@ pub(super) async fn install_pnpm<Reporter: self::Reporter + 'static>(
     version: &str,
     supported_architectures: Option<SupportedArchitectures>,
 ) -> miette::Result<InstallPnpmResult> {
-    let package_name = pnpm_package_name_to_install(version);
+    let package = pnpm_package_to_install(version);
+    let package_name = package.name;
     let global_pkg_dir = base_config.global_pkg_dir.clone().ok_or(SelfUpdateError::NoGlobalDir)?;
     fs::create_dir_all(&global_pkg_dir)
         .into_diagnostic()
@@ -61,7 +70,9 @@ pub(super) async fn install_pnpm<Reporter: self::Reporter + 'static>(
         .wrap_err("scan global packages")?
         && installed_version(&existing.install_dir, package_name).as_deref() == Some(version)
     {
-        link_exe_platform_binary(&existing.install_dir, package_name)?;
+        if package.links_native_binary {
+            link_exe_platform_binary(&existing.install_dir, package_name)?;
+        }
         return Ok(InstallPnpmResult {
             install_dir: existing.install_dir,
             package_name,
@@ -81,7 +92,13 @@ pub(super) async fn install_pnpm<Reporter: self::Reporter + 'static>(
         false,
     ))
     .await
-    .and_then(|()| link_exe_platform_binary(&install_dir, package_name));
+    .and_then(|()| {
+        if package.links_native_binary {
+            link_exe_platform_binary(&install_dir, package_name)
+        } else {
+            Ok(())
+        }
+    });
     if let Err(err) = outcome {
         let _ = fs::remove_dir_all(&install_dir);
         return Err(err);
@@ -98,12 +115,22 @@ fn installed_version(install_dir: &Path, package_name: &str) -> Option<String> {
     value.get("version").and_then(Value::as_str).map(ToString::to_string)
 }
 
-pub(crate) fn pnpm_package_name_to_install(pnpm_version: &str) -> &'static str {
-    if node_semver::Version::parse(pnpm_version).is_ok_and(|version| version.major >= 12) {
-        PNPM_PACKAGE_NAME
-    } else {
-        PNPM_EXE_PACKAGE_NAME
+pub(crate) fn pnpm_package_to_install(pnpm_version: &str) -> PnpmPackageToInstall {
+    let Some(version) = node_semver::Version::parse(pnpm_version).ok() else {
+        return PnpmPackageToInstall { name: PNPM_EXE_PACKAGE_NAME, links_native_binary: true };
+    };
+    if version.major >= 12 {
+        return PnpmPackageToInstall { name: PNPM_PACKAGE_NAME, links_native_binary: true };
     }
+    if version_gte(&version, PNPM_EXE_INTRODUCED) {
+        PnpmPackageToInstall { name: PNPM_EXE_PACKAGE_NAME, links_native_binary: true }
+    } else {
+        PnpmPackageToInstall { name: PNPM_PACKAGE_NAME, links_native_binary: false }
+    }
+}
+
+fn version_gte(version: &node_semver::Version, minimum: (u64, u64, u64)) -> bool {
+    (version.major, version.minor, version.patch) >= minimum
 }
 
 /// Install a pnpm engine wrapper into a fresh group directory, mirroring the

--- a/pacquet/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -319,6 +319,8 @@ pub(crate) fn link_exe_platform_binary(
         .ok_or_else(|| {
             miette::miette!("no @pnpm/exe.{platform}-{arch} native binary was found for this host")
         })?;
+    let native_source_root = native_source_trust_root(&install_real_dir, wrapper_pkg_name);
+    let src = validate_native_binary_source(&src, &native_source_root)?;
     let dest = wrapper_real_dir.join(executable);
     force_link(&src, &dest)
         .into_diagnostic()
@@ -337,6 +339,65 @@ pub(crate) fn link_exe_platform_binary(
         rewrite_windows_bin_field(&wrapper_real_dir);
     }
     Ok(())
+}
+
+fn native_source_trust_root(install_real_dir: &Path, wrapper_pkg_name: &str) -> PathBuf {
+    // In the global virtual store, the wrapper and platform binary live
+    // in sibling slots under `links`; self-update installs keep both
+    // under the one install dir.
+    global_virtual_store_root_from_slot(install_real_dir, wrapper_pkg_name)
+        .unwrap_or_else(|| install_real_dir.to_path_buf())
+}
+
+fn global_virtual_store_root_from_slot(slot_dir: &Path, package_name: &str) -> Option<PathBuf> {
+    let mut cursor = slot_dir.parent()?;
+    let version = cursor.file_name()?.to_str()?;
+    node_semver::Version::parse(version).ok()?;
+
+    cursor = cursor.parent()?;
+    let mut package_segments = package_name.split('/').rev();
+    let name = package_segments.next()?;
+    if cursor.file_name()?.to_str()? != name {
+        return None;
+    }
+    for segment in package_segments {
+        cursor = cursor.parent()?;
+        if cursor.file_name()?.to_str()? != segment {
+            return None;
+        }
+    }
+
+    let root = cursor.parent()?;
+    (root.file_name()?.to_str()? == "links").then(|| root.to_path_buf())
+}
+
+fn validate_native_binary_source(src: &Path, source_root: &Path) -> miette::Result<PathBuf> {
+    let src_display = src.display().to_string();
+    let link_meta = fs::symlink_metadata(src)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("inspect the native pnpm binary at {src_display}"))?;
+    if link_meta.file_type().is_symlink() {
+        return Err(miette::miette!("the native pnpm binary at {src_display} is a symlink"));
+    }
+    let src_real = fs::canonicalize(src)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("resolve the native pnpm binary at {src_display}"))?;
+    if !src_real.starts_with(source_root) {
+        let source_root_display = source_root.display().to_string();
+        return Err(miette::miette!(
+            "the native pnpm binary at {src_display} resolves outside {source_root_display}"
+        ));
+    }
+    let src_real_display = src_real.display().to_string();
+    let meta = fs::metadata(&src_real)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("inspect the native pnpm binary at {src_real_display}"))?;
+    if !meta.is_file() {
+        return Err(miette::miette!(
+            "the native pnpm binary at {src_real_display} is not a regular file"
+        ));
+    }
+    Ok(src_real)
 }
 
 pub(crate) fn package_dir(install_dir: &Path, package_name: &str) -> PathBuf {

--- a/pacquet/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -24,9 +24,9 @@ use std::{
 use super::SelfUpdateError;
 
 /// From v12 the unscoped `pnpm` package is itself the native engine
-/// (equal content to `@pnpm/exe`), so a self-update always converges on
-/// installing `pnpm`.
+/// (equal content to `@pnpm/exe`), so v12+ installs converge on `pnpm`.
 pub(crate) const PNPM_PACKAGE_NAME: &str = "pnpm";
+pub(crate) const PNPM_EXE_PACKAGE_NAME: &str = "@pnpm/exe";
 
 /// The package-manager components marked buildable when installing the
 /// engine (`{ '@pnpm/exe': true, 'pnpm': true }`), so the `ENGINE_NAME` is
@@ -36,10 +36,11 @@ pub(crate) const PNPM_ALLOW_BUILDS: [&str; 2] = ["pnpm", "@pnpm/exe"];
 
 pub(super) struct InstallPnpmResult {
     pub install_dir: PathBuf,
+    pub package_name: &'static str,
     pub already_existed: bool,
 }
 
-/// Install `pnpm@<version>` into the global packages directory. Returns
+/// Install the target pnpm engine into the global packages directory. Returns
 /// the install directory and whether the requested version was already
 /// present (in which case nothing is downloaded and the caller just
 /// relinks it).
@@ -48,18 +49,24 @@ pub(super) async fn install_pnpm<Reporter: self::Reporter + 'static>(
     version: &str,
     supported_architectures: Option<SupportedArchitectures>,
 ) -> miette::Result<InstallPnpmResult> {
+    let package_name = pnpm_package_name_to_install(version);
     let global_pkg_dir = base_config.global_pkg_dir.clone().ok_or(SelfUpdateError::NoGlobalDir)?;
     fs::create_dir_all(&global_pkg_dir)
         .into_diagnostic()
         .wrap_err("create the global packages directory")?;
     clean_orphaned_install_dirs(&global_pkg_dir);
 
-    if let Some(existing) = find_global_package(&global_pkg_dir, PNPM_PACKAGE_NAME)
+    if let Some(existing) = find_global_package(&global_pkg_dir, package_name)
         .into_diagnostic()
         .wrap_err("scan global packages")?
-        && installed_version(&existing.install_dir).as_deref() == Some(version)
+        && installed_version(&existing.install_dir, package_name).as_deref() == Some(version)
     {
-        return Ok(InstallPnpmResult { install_dir: existing.install_dir, already_existed: true });
+        link_exe_platform_binary(&existing.install_dir, package_name)?;
+        return Ok(InstallPnpmResult {
+            install_dir: existing.install_dir,
+            package_name,
+            already_existed: true,
+        });
     }
 
     let install_dir = create_install_dir(&global_pkg_dir)
@@ -68,29 +75,38 @@ pub(super) async fn install_pnpm<Reporter: self::Reporter + 'static>(
     let outcome = Box::pin(run_install::<Reporter>(
         base_config,
         &install_dir,
+        package_name,
         version,
         supported_architectures,
         false,
     ))
     .await
-    .and_then(|()| link_exe_platform_binary(&install_dir, PNPM_PACKAGE_NAME));
+    .and_then(|()| link_exe_platform_binary(&install_dir, package_name));
     if let Err(err) = outcome {
         let _ = fs::remove_dir_all(&install_dir);
         return Err(err);
     }
-    Ok(InstallPnpmResult { install_dir, already_existed: false })
+    Ok(InstallPnpmResult { install_dir, package_name, already_existed: false })
 }
 
-/// The `version` recorded in `<install_dir>/node_modules/pnpm/package.json`,
-/// or `None` when the install is absent or unreadable.
-fn installed_version(install_dir: &Path) -> Option<String> {
-    let pkg_json = install_dir.join("node_modules").join(PNPM_PACKAGE_NAME).join("package.json");
+/// The installed wrapper's recorded version, or `None` when the install is
+/// absent or unreadable.
+fn installed_version(install_dir: &Path, package_name: &str) -> Option<String> {
+    let pkg_json = package_dir(install_dir, package_name).join("package.json");
     let text = fs::read_to_string(pkg_json).ok()?;
     let value: Value = serde_json::from_str(&text).ok()?;
     value.get("version").and_then(Value::as_str).map(ToString::to_string)
 }
 
-/// Install `pnpm@<version>` into a fresh group directory, mirroring the
+pub(crate) fn pnpm_package_name_to_install(pnpm_version: &str) -> &'static str {
+    if node_semver::Version::parse(pnpm_version).is_ok_and(|version| version.major >= 12) {
+        PNPM_PACKAGE_NAME
+    } else {
+        PNPM_EXE_PACKAGE_NAME
+    }
+}
+
+/// Install a pnpm engine wrapper into a fresh group directory, mirroring the
 /// global-add group install but with scripts disabled (the native binary
 /// is linked manually afterwards) and no build-approval prompt.
 ///
@@ -105,6 +121,7 @@ fn installed_version(install_dir: &Path) -> Option<String> {
 pub(crate) async fn run_install<Reporter: self::Reporter + 'static>(
     base_config: &'static Config,
     install_dir: &Path,
+    package_name: &str,
     version: &str,
     supported_architectures: Option<SupportedArchitectures>,
     enable_global_virtual_store: bool,
@@ -158,7 +175,7 @@ pub(crate) async fn run_install<Reporter: self::Reporter + 'static>(
         .wrap_err("initialize the self-update install state")?;
     add_package::<Reporter, _, _>(
         state,
-        &format!("{PNPM_PACKAGE_NAME}@{version}"),
+        &format!("{package_name}@{version}"),
         PinnedVersion::Patch,
         None,
         false,
@@ -229,10 +246,7 @@ pub(crate) fn link_exe_platform_binary(
     install_dir: &Path,
     wrapper_pkg_name: &str,
 ) -> miette::Result<()> {
-    let mut wrapper_dir = install_dir.join("node_modules");
-    for segment in wrapper_pkg_name.split('/') {
-        wrapper_dir.push(segment);
-    }
+    let wrapper_dir = package_dir(install_dir, wrapper_pkg_name);
     if !wrapper_dir.exists() {
         let wrapper_display = wrapper_dir.display();
         return Err(miette::miette!("the installed pnpm wrapper is missing at {wrapper_display}"));
@@ -284,6 +298,14 @@ pub(crate) fn link_exe_platform_binary(
         rewrite_windows_bin_field(&wrapper_dir);
     }
     Ok(())
+}
+
+pub(crate) fn package_dir(install_dir: &Path, package_name: &str) -> PathBuf {
+    let mut package_dir = install_dir.join("node_modules");
+    for segment in package_name.split('/') {
+        package_dir.push(segment);
+    }
+    package_dir
 }
 
 /// Hard-link `src` to `dest`, replacing any existing file. Marks the

--- a/pacquet/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -287,9 +287,21 @@ pub(crate) fn link_exe_platform_binary(
     // real virtual store, not via a `node_modules` walk (which a
     // repo-controlled store-dir could shadow). `@pnpm/exe`'s parent is
     // already `@pnpm`; the unscoped `pnpm` descends into `@pnpm`.
+    let install_real_dir = fs::canonicalize(install_dir)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("resolve the pnpm install dir at {}", install_dir.display()))?;
     let wrapper_real_dir = fs::canonicalize(&wrapper_dir)
         .into_diagnostic()
         .wrap_err_with(|| format!("resolve the pnpm wrapper at {}", wrapper_dir.display()))?;
+    if !wrapper_real_dir.starts_with(&install_real_dir) {
+        let wrapper_display = wrapper_dir.display();
+        let install_display = install_dir.display();
+        return Err(miette::miette!(
+            "the installed pnpm wrapper at {} resolves outside {}",
+            wrapper_display,
+            install_display
+        ));
+    }
     let parent = wrapper_real_dir
         .parent()
         .ok_or_else(|| miette::miette!("the pnpm wrapper has no parent directory"))?;
@@ -307,7 +319,7 @@ pub(crate) fn link_exe_platform_binary(
         .ok_or_else(|| {
             miette::miette!("no @pnpm/exe.{platform}-{arch} native binary was found for this host")
         })?;
-    let dest = wrapper_dir.join(executable);
+    let dest = wrapper_real_dir.join(executable);
     force_link(&src, &dest)
         .into_diagnostic()
         .wrap_err("link the native pnpm binary into the wrapper")?;
@@ -318,11 +330,11 @@ pub(crate) fn link_exe_platform_binary(
         // target under MSYS2 / Git Bash. The native binary detects which
         // name it was launched as and prepends `dlx` for pnpx / pnx.
         for alias in ["pn", "pnpx", "pnx"] {
-            force_link(&src, &wrapper_dir.join(format!("{alias}.exe")))
+            force_link(&src, &wrapper_real_dir.join(format!("{alias}.exe")))
                 .into_diagnostic()
                 .wrap_err_with(|| format!("link the {alias} alias into the wrapper"))?;
         }
-        rewrite_windows_bin_field(&wrapper_dir);
+        rewrite_windows_bin_field(&wrapper_real_dir);
     }
     Ok(())
 }

--- a/pacquet/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
@@ -119,6 +119,49 @@ fn rejects_wrapper_symlink_that_escapes_the_install_dir() {
     assert_eq!(fs::read(outside_wrapper.join("pnpm")).expect("read outside file"), b"outside");
 }
 
+#[cfg(unix)]
+#[test]
+fn rejects_native_binary_symlink_that_escapes_the_install_dir() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let outside = tempfile::tempdir().expect("outside tempdir");
+    let outside_binary = outside.path().join("pnpm");
+    fs::write(&outside_binary, b"outside").expect("write outside binary");
+    fake_engine_install(temp.path(), false);
+
+    let platform_dir = exe_platform_pkg_dir_name_next(host_platform(), host_arch(), host_libc());
+    let src_dir = temp.path().join("node_modules").join("@pnpm").join(platform_dir);
+    fs::create_dir_all(&src_dir).expect("create platform dir");
+    std::os::unix::fs::symlink(&outside_binary, src_dir.join("pnpm"))
+        .expect("symlink native binary outside install dir");
+
+    let err =
+        link_exe_platform_binary(temp.path(), "pnpm").expect_err("escaped native source rejected");
+    assert!(err.to_string().contains("is a symlink"), "unexpected error: {err:?}");
+    assert!(!package_dir(temp.path(), "pnpm").join("pnpm").exists());
+    assert_eq!(fs::read(outside_binary).expect("read outside file"), b"outside");
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_native_binary_scope_symlink_that_escapes_the_install_dir() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let outside = tempfile::tempdir().expect("outside tempdir");
+    fake_engine_install(temp.path(), false);
+
+    let platform_dir = exe_platform_pkg_dir_name_next(host_platform(), host_arch(), host_libc());
+    let outside_scope = outside.path().join("@pnpm");
+    let outside_platform_dir = outside_scope.join(platform_dir);
+    fs::create_dir_all(&outside_platform_dir).expect("create outside platform dir");
+    fs::write(outside_platform_dir.join("pnpm"), b"outside").expect("write outside binary");
+    std::os::unix::fs::symlink(&outside_scope, temp.path().join("node_modules").join("@pnpm"))
+        .expect("symlink native scope outside install dir");
+
+    let err =
+        link_exe_platform_binary(temp.path(), "pnpm").expect_err("escaped native source rejected");
+    assert!(err.to_string().contains("resolves outside"), "unexpected error: {err:?}");
+    assert!(!package_dir(temp.path(), "pnpm").join("pnpm").exists());
+}
+
 #[test]
 fn link_errors_when_the_native_binary_is_missing() {
     let temp = tempfile::tempdir().expect("tempdir");

--- a/pacquet/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
@@ -44,6 +44,7 @@ fn native_binary_linking_matches_pnpm_engine_layout() {
     assert!(pnpm_package_to_install("6.17.1").links_native_binary);
     assert!(!pnpm_package_to_install("6.16.0").links_native_binary);
     assert!(!pnpm_package_to_install("5.18.10").links_native_binary);
+    assert!(pnpm_package_to_install("not-semver").links_native_binary);
 }
 
 /// Lay out a fake engine install: the `pnpm` wrapper and, under
@@ -97,6 +98,25 @@ fn links_the_host_platform_binary_into_scoped_exe_wrapper() {
     let dest = package_dir(temp.path(), PNPM_EXE_PACKAGE_NAME).join("pnpm");
     assert!(dest.exists(), "the native binary is linked into the scoped wrapper");
     assert_eq!(fs::read(&dest).expect("read linked binary"), b"#!/bin/sh\necho pnpm\n");
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_wrapper_symlink_that_escapes_the_install_dir() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let outside = tempfile::tempdir().expect("outside tempdir");
+    let outside_wrapper = outside.path().join("exe");
+    fs::create_dir_all(&outside_wrapper).expect("create outside wrapper");
+    fs::write(outside_wrapper.join("pnpm"), b"outside").expect("write outside placeholder");
+
+    fs::create_dir_all(temp.path().join("node_modules").join("@pnpm")).expect("create scope dir");
+    std::os::unix::fs::symlink(&outside_wrapper, package_dir(temp.path(), PNPM_EXE_PACKAGE_NAME))
+        .expect("symlink wrapper outside install dir");
+
+    let err = link_exe_platform_binary(temp.path(), PNPM_EXE_PACKAGE_NAME)
+        .expect_err("escaped wrapper must be rejected");
+    assert!(err.to_string().contains("resolves outside"), "unexpected error: {err:?}");
+    assert_eq!(fs::read(outside_wrapper.join("pnpm")).expect("read outside file"), b"outside");
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
@@ -1,4 +1,8 @@
-use super::{exe_platform_pkg_dir_name, exe_platform_pkg_dir_name_next, link_exe_platform_binary};
+use super::{
+    PNPM_EXE_PACKAGE_NAME, PNPM_PACKAGE_NAME, exe_platform_pkg_dir_name,
+    exe_platform_pkg_dir_name_next, link_exe_platform_binary, package_dir,
+    pnpm_package_name_to_install,
+};
 use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
 use std::fs;
 
@@ -22,12 +26,28 @@ fn next_platform_dir_names() {
     assert_eq!(exe_platform_pkg_dir_name_next("linux", "arm64", "musl"), "exe.linux-arm64-musl");
 }
 
+#[test]
+fn target_package_name_matches_pnpm_engine_layout() {
+    assert_eq!(pnpm_package_name_to_install("12.0.0-alpha.1"), PNPM_PACKAGE_NAME);
+    assert_eq!(pnpm_package_name_to_install("12.0.0"), PNPM_PACKAGE_NAME);
+    assert_eq!(pnpm_package_name_to_install("11.10.0"), PNPM_EXE_PACKAGE_NAME);
+    assert_eq!(pnpm_package_name_to_install("not-semver"), PNPM_EXE_PACKAGE_NAME);
+}
+
 /// Lay out a fake engine install: the `pnpm` wrapper and, under
 /// `@pnpm/<host-platform-dir>`, the native binary the wrapper's preinstall
 /// would normally link.
 fn fake_engine_install(install_dir: &std::path::Path, with_native_binary: bool) {
+    fake_engine_install_for(install_dir, PNPM_PACKAGE_NAME, with_native_binary);
+}
+
+fn fake_engine_install_for(
+    install_dir: &std::path::Path,
+    wrapper_pkg_name: &str,
+    with_native_binary: bool,
+) {
     let node_modules = install_dir.join("node_modules");
-    fs::create_dir_all(node_modules.join("pnpm")).expect("create wrapper dir");
+    fs::create_dir_all(package_dir(install_dir, wrapper_pkg_name)).expect("create wrapper dir");
     if with_native_binary {
         let platform_dir =
             exe_platform_pkg_dir_name_next(host_platform(), host_arch(), host_libc());
@@ -52,6 +72,19 @@ fn links_the_host_platform_binary_into_the_wrapper() {
     assert_eq!(fs::read(&dest).expect("read linked binary"), b"#!/bin/sh\necho pnpm\n");
     let mode = fs::metadata(&dest).expect("stat linked binary").permissions().mode();
     assert_eq!(mode & 0o777, 0o755, "the linked binary is executable");
+}
+
+#[cfg(unix)]
+#[test]
+fn links_the_host_platform_binary_into_scoped_exe_wrapper() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    fake_engine_install_for(temp.path(), PNPM_EXE_PACKAGE_NAME, true);
+
+    link_exe_platform_binary(temp.path(), PNPM_EXE_PACKAGE_NAME).expect("linking should succeed");
+
+    let dest = package_dir(temp.path(), PNPM_EXE_PACKAGE_NAME).join("pnpm");
+    assert!(dest.exists(), "the native binary is linked into the scoped wrapper");
+    assert_eq!(fs::read(&dest).expect("read linked binary"), b"#!/bin/sh\necho pnpm\n");
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
@@ -1,7 +1,6 @@
 use super::{
     PNPM_EXE_PACKAGE_NAME, PNPM_PACKAGE_NAME, exe_platform_pkg_dir_name,
-    exe_platform_pkg_dir_name_next, link_exe_platform_binary, package_dir,
-    pnpm_package_name_to_install,
+    exe_platform_pkg_dir_name_next, link_exe_platform_binary, package_dir, pnpm_package_to_install,
 };
 use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
 use std::fs;
@@ -28,10 +27,23 @@ fn next_platform_dir_names() {
 
 #[test]
 fn target_package_name_matches_pnpm_engine_layout() {
-    assert_eq!(pnpm_package_name_to_install("12.0.0-alpha.1"), PNPM_PACKAGE_NAME);
-    assert_eq!(pnpm_package_name_to_install("12.0.0"), PNPM_PACKAGE_NAME);
-    assert_eq!(pnpm_package_name_to_install("11.10.0"), PNPM_EXE_PACKAGE_NAME);
-    assert_eq!(pnpm_package_name_to_install("not-semver"), PNPM_EXE_PACKAGE_NAME);
+    assert_eq!(pnpm_package_to_install("12.0.0-alpha.1").name, PNPM_PACKAGE_NAME);
+    assert_eq!(pnpm_package_to_install("12.0.0").name, PNPM_PACKAGE_NAME);
+    assert_eq!(pnpm_package_to_install("11.10.0").name, PNPM_EXE_PACKAGE_NAME);
+    assert_eq!(pnpm_package_to_install("10.34.4").name, PNPM_EXE_PACKAGE_NAME);
+    assert_eq!(pnpm_package_to_install("6.17.1").name, PNPM_EXE_PACKAGE_NAME);
+    assert_eq!(pnpm_package_to_install("6.16.0").name, PNPM_PACKAGE_NAME);
+    assert_eq!(pnpm_package_to_install("5.18.10").name, PNPM_PACKAGE_NAME);
+    assert_eq!(pnpm_package_to_install("not-semver").name, PNPM_EXE_PACKAGE_NAME);
+}
+
+#[test]
+fn native_binary_linking_matches_pnpm_engine_layout() {
+    assert!(pnpm_package_to_install("12.0.0-alpha.1").links_native_binary);
+    assert!(pnpm_package_to_install("11.10.0").links_native_binary);
+    assert!(pnpm_package_to_install("6.17.1").links_native_binary);
+    assert!(!pnpm_package_to_install("6.16.0").links_native_binary);
+    assert!(!pnpm_package_to_install("5.18.10").links_native_binary);
 }
 
 /// Lay out a fake engine install: the `pnpm` wrapper and, under

--- a/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
+++ b/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
@@ -25,7 +25,8 @@ use std::{
 use crate::{
     cli_args::self_update::{
         install_pnpm::{
-            PNPM_ALLOW_BUILDS, PNPM_PACKAGE_NAME, link_exe_platform_binary, run_install,
+            PNPM_ALLOW_BUILDS, link_exe_platform_binary, package_dir, pnpm_package_name_to_install,
+            run_install,
         },
         verify_engine::verify_pnpm_engine_identity,
     },
@@ -45,6 +46,7 @@ pub(super) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
     spec: &str,
     version: &str,
 ) -> miette::Result<PathBuf> {
+    let package_name = pnpm_package_name_to_install(version);
     // Resolve `pnpm` + `@pnpm/exe` + their closure into the env lockfile
     // (a no-op when this spec+version is already recorded there).
     config_deps::sync_package_manager_dependencies(config, env_root, spec, version, false).await?;
@@ -61,10 +63,11 @@ pub(super) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
     // with the same hashing the install pipeline uses, so a stale or wrong
     // computation merely misses the cache (the idempotent install below
     // then re-derives the slot from the install's own symlink).
-    if let Some(slot) = compute_pnpm_slot(config, &env, version) {
-        let pkg_dir = slot.join("node_modules").join(PNPM_PACKAGE_NAME);
+    if let Some(slot) = compute_engine_slot(config, &env, package_name, version) {
+        let pkg_dir = package_dir(&slot, package_name);
         let bin_dir = slot.join("bin");
         if pkg_dir.join("package.json").exists() {
+            link_exe_platform_binary(&slot, package_name)?;
             if !bin_dir.exists() {
                 link_bins(&pkg_dir, &bin_dir)?;
             }
@@ -90,12 +93,13 @@ pub(super) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
     let slot = Box::pin(run_install::<Reporter>(
         config,
         &tmp_install_dir,
+        package_name,
         version,
         config.supported_architectures.clone(),
         true,
     ))
     .await
-    .and_then(|()| resolve_slot(&tmp_install_dir));
+    .and_then(|()| resolve_slot(&tmp_install_dir, package_name));
     // The temp directory held only symlinks into the GVS, so removing it
     // does not touch the installed engine. Refuse to recurse through a
     // symlink at the temp path as defense-in-depth — even though the store
@@ -104,21 +108,26 @@ pub(super) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
     let _ = remove_dir_if_not_symlink(&tmp_install_dir);
     let slot = slot?;
 
-    let pkg_dir = slot.join("node_modules").join(PNPM_PACKAGE_NAME);
+    let pkg_dir = package_dir(&slot, package_name);
     let bin_dir = slot.join("bin");
     // Replicate the wrapper's preinstall (skipped because the engine is
     // installed with scripts disabled): link the host's native binary.
-    link_exe_platform_binary(&slot, PNPM_PACKAGE_NAME)?;
+    link_exe_platform_binary(&slot, package_name)?;
     link_bins(&pkg_dir, &bin_dir)?;
     Ok(bin_dir)
 }
 
-/// The global-virtual-store slot `pnpm@<version>` resolves to, or `None`
+/// The global-virtual-store slot the selected engine wrapper resolves to, or `None`
 /// when it can't be derived (e.g. the engine snapshot is missing or the
 /// allow-build policy fails to compile). Drives only the cache-hit
 /// short-circuit, so `None` is a safe "treat as a miss".
-fn compute_pnpm_slot(config: &Config, env: &EnvLockfile, version: &str) -> Option<PathBuf> {
-    let wanted: PackageKey = format!("{PNPM_PACKAGE_NAME}@{version}").parse().ok()?;
+fn compute_engine_slot(
+    config: &Config,
+    env: &EnvLockfile,
+    package_name: &str,
+    version: &str,
+) -> Option<PathBuf> {
+    let wanted: PackageKey = format!("{package_name}@{version}").parse().ok()?;
     let key = env.snapshots.keys().find(|key| key.without_peer() == wanted)?.clone();
 
     let mut cfg = config.clone();
@@ -140,19 +149,24 @@ fn compute_pnpm_slot(config: &Config, env: &EnvLockfile, version: &str) -> Optio
     Some(layout.slot_dir(&key))
 }
 
-/// Derive the engine's GVS slot from the install's own `pnpm` symlink
-/// (`<install_dir>/node_modules/pnpm` → `<slot>/node_modules/pnpm`). This
+/// Derive the engine's GVS slot from the install's own wrapper symlink. This
 /// is the ground truth after an install, independent of any hash
 /// recomputation.
-fn resolve_slot(install_dir: &Path) -> miette::Result<PathBuf> {
-    let link = install_dir.join("node_modules").join(PNPM_PACKAGE_NAME);
+fn resolve_slot(install_dir: &Path, package_name: &str) -> miette::Result<PathBuf> {
+    let link = package_dir(install_dir, package_name);
     let real = fs::canonicalize(&link)
         .into_diagnostic()
         .wrap_err_with(|| format!("resolve the installed pnpm at {}", link.display()))?;
-    real.parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
+    slot_from_package_dir(&real, package_name)
         .ok_or_else(|| miette::miette!("could not locate the pnpm global-virtual-store slot"))
+}
+
+pub(super) fn slot_from_package_dir(package_dir: &Path, package_name: &str) -> Option<PathBuf> {
+    let mut slot = package_dir;
+    for _ in package_name.split('/') {
+        slot = slot.parent()?;
+    }
+    slot.parent().map(Path::to_path_buf)
 }
 
 /// Link `pnpm`'s declared bins into `bin_dir` after the engine install.

--- a/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
+++ b/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
@@ -4,9 +4,9 @@
 //! The engine lands in `<store>/links/...` (shared across `pnpm with`
 //! invocations and, unlike `self-update`, not registered in the global
 //! packages directory, so `pnpm ls -g` does not see it), its registry
-//! signature is verified on a genuine download, and its native platform
-//! binary + bins are linked into a `bin/` directory the caller prepends to
-//! `PATH`.
+//! signature is verified on a genuine download, native target installs have
+//! their platform binary linked, and the package bins are linked into a
+//! `bin/` directory the caller prepends to `PATH`.
 
 use miette::{Context, IntoDiagnostic};
 use pacquet_cmd_shim::{Host as CmdShimHost, PackageBinSource, link_bins_of_packages};
@@ -25,7 +25,7 @@ use std::{
 use crate::{
     cli_args::self_update::{
         install_pnpm::{
-            PNPM_ALLOW_BUILDS, link_exe_platform_binary, package_dir, pnpm_package_name_to_install,
+            PNPM_ALLOW_BUILDS, link_exe_platform_binary, package_dir, pnpm_package_to_install,
             run_install,
         },
         verify_engine::verify_pnpm_engine_identity,
@@ -46,9 +46,10 @@ pub(super) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
     spec: &str,
     version: &str,
 ) -> miette::Result<PathBuf> {
-    let package_name = pnpm_package_name_to_install(version);
-    // Resolve `pnpm` + `@pnpm/exe` + their closure into the env lockfile
-    // (a no-op when this spec+version is already recorded there).
+    let package = pnpm_package_to_install(version);
+    let package_name = package.name;
+    // Resolve the package-manager closure into the env lockfile (a no-op
+    // when this spec+version is already recorded there).
     config_deps::sync_package_manager_dependencies(config, env_root, spec, version, false).await?;
     let env = EnvLockfile::read(env_root)
         .map_err(miette::Report::new)
@@ -67,7 +68,9 @@ pub(super) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
         let pkg_dir = package_dir(&slot, package_name);
         let bin_dir = slot.join("bin");
         if pkg_dir.join("package.json").exists() {
-            link_exe_platform_binary(&slot, package_name)?;
+            if package.links_native_binary {
+                link_exe_platform_binary(&slot, package_name)?;
+            }
             if !bin_dir.exists() {
                 link_bins(&pkg_dir, &bin_dir)?;
             }
@@ -110,9 +113,11 @@ pub(super) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
 
     let pkg_dir = package_dir(&slot, package_name);
     let bin_dir = slot.join("bin");
-    // Replicate the wrapper's preinstall (skipped because the engine is
-    // installed with scripts disabled): link the host's native binary.
-    link_exe_platform_binary(&slot, package_name)?;
+    if package.links_native_binary {
+        // Replicate the wrapper's preinstall (skipped because the engine is
+        // installed with scripts disabled): link the host's native binary.
+        link_exe_platform_binary(&slot, package_name)?;
+    }
     link_bins(&pkg_dir, &bin_dir)?;
     Ok(bin_dir)
 }

--- a/pacquet/crates/cli/src/cli_args/with/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/with/tests.rs
@@ -1,4 +1,5 @@
 use super::{WithError, prepend_to_path};
+use crate::cli_args::with::install_pnpm_to_store::slot_from_package_dir;
 use std::path::Path;
 
 #[test]
@@ -13,4 +14,20 @@ fn prepend_to_path_accepts_a_normal_bin_dir() {
     let dir = if cfg!(windows) { r"C:\store\bin" } else { "/store/bin" };
     let path = prepend_to_path(Path::new(dir)).expect("a normal dir is accepted");
     assert!(path.to_string_lossy().starts_with(dir));
+}
+
+#[test]
+fn resolves_unscoped_package_dir_to_global_virtual_store_slot() {
+    let slot = Path::new("/store/links/hash");
+    let package_dir = slot.join("node_modules").join("pnpm");
+
+    assert_eq!(slot_from_package_dir(&package_dir, "pnpm").as_deref(), Some(slot));
+}
+
+#[test]
+fn resolves_scoped_package_dir_to_global_virtual_store_slot() {
+    let slot = Path::new("/store/links/hash");
+    let package_dir = slot.join("node_modules").join("@pnpm").join("exe");
+
+    assert_eq!(slot_from_package_dir(&package_dir, "@pnpm/exe").as_deref(), Some(slot));
 }

--- a/pacquet/crates/cli/src/config_deps.rs
+++ b/pacquet/crates/cli/src/config_deps.rs
@@ -50,7 +50,7 @@ pub async fn install_config_deps<Reporter: self::Reporter>(
     resolve_and_install::<Reporter>(config, config_dependencies, root_dir, frozen_lockfile).await
 }
 
-/// Resolve `pnpm` / `@pnpm/exe` into the env lockfile's
+/// Resolve the package-manager engine dependencies into the env lockfile's
 /// `packageManagerDependencies` block before the wanted lockfile is
 /// loaded.
 pub async fn sync_package_manager_dependencies(

--- a/pacquet/crates/cli/src/with_current.rs
+++ b/pacquet/crates/cli/src/with_current.rs
@@ -18,7 +18,7 @@ use std::ffi::OsString;
 /// option (known value-takers like `--dir` / `--reporter`, and any unknown
 /// flag) is assumed to consume its successor: a non-boolean (including
 /// unknown) option is treated as value-consuming.
-const BOOLEAN_LONG_OPTIONS: &[&str] = &["recursive"];
+const BOOLEAN_LONG_OPTIONS: &[&str] = &["color", "recursive", "yes"];
 
 /// Global short options that take a value (`-C` = `--dir`, `-F` =
 /// `--filter`), so the next token is the value, not the subcommand. Other

--- a/pacquet/crates/cli/src/with_current/tests.rs
+++ b/pacquet/crates/cli/src/with_current/tests.rs
@@ -31,6 +31,12 @@ fn preserves_global_flags_before_with() {
         plan(argv(&["--recursive", "with", "current", "install"])).expect("plan");
     assert!(force);
     assert_eq!(strings(&rewritten), vec!["pnpm", "--recursive", "install"]);
+
+    for flag in ["--color", "--yes"] {
+        let (rewritten, force) = plan(argv(&[flag, "with", "current", "--version"])).expect("plan");
+        assert!(force);
+        assert_eq!(strings(&rewritten), vec!["pnpm", flag, "--version"]);
+    }
 }
 
 #[test]
@@ -93,7 +99,9 @@ fn option_value_consumption_matches_pnpm() {
     assert!(option_consumes_value("-C"));
     assert!(option_consumes_value("-F"));
     // Booleans, `--no-` negations, inline `=` values, and boolean shorts do not.
+    assert!(!option_consumes_value("--color"));
     assert!(!option_consumes_value("--recursive"));
+    assert!(!option_consumes_value("--yes"));
     assert!(!option_consumes_value("--no-something"));
     assert!(!option_consumes_value("--reporter=ndjson"));
     assert!(!option_consumes_value("-r"));

--- a/pacquet/crates/cli/tests/with.rs
+++ b/pacquet/crates/cli/tests/with.rs
@@ -1,40 +1,184 @@
-//! `pacquet with <version|current> <args...>` runs pnpm at a specific
-//! version (or the currently running one) for a single invocation,
-//! ignoring the project's `packageManager` / `devEngines.packageManager`
-//! pin.
-//!
-//! These cover the network-free surface of the command: the usage errors
-//! and the `with current` argv rewrite. The end-to-end `with <version>`
-//! download path is not covered here because the mock registry does not
-//! serve the `pnpm` / `@pnpm/exe` engine packages (the same reason
-//! `self-update` has no end-to-end install test).
+//! Ports `pnpm11/pnpm/test/withCommand.test.ts`.
 
 use command_extra::CommandExtra;
-use pacquet_testing_utils::bin::CommandTempCwd;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::{
+    fs,
+    path::Path,
+    process::{Command, Output},
+};
+
+const PINNED_PNPM_VERSION: &str = "9.3.0";
 
 #[test]
-fn with_requires_a_version_spec() {
+fn with_current_runs_the_currently_active_pnpm_even_when_project_pins_a_different_version() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &serde_json::json!({ "packageManager": "pnpm@9.3.0" }));
+
+    let output = test_command(pacquet, root.path())
+        .with_args(["with", "current", "--version"])
+        .output()
+        .expect("run pacquet with current --version");
+    dbg!(&output);
+    assert_success(&output);
+    assert_current_version(&output);
+    assert!(!stdout(&output).contains("9.3.0"));
+
+    drop(root);
+}
+
+#[test]
+fn with_current_bypasses_the_package_manager_check_when_an_unrelated_manager_is_pinned() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &serde_json::json!({ "packageManager": "yarn@4.0.0" }));
+
+    let output = test_command(pacquet, root.path())
+        .with_args(["with", "current", "--version"])
+        .output()
+        .expect("run pacquet with current --version");
+    dbg!(&output);
+    assert_success(&output);
+    assert!(!stderr(&output).contains("This project is configured to use yarn"));
+
+    drop(root);
+}
+
+#[test]
+fn with_current_bypasses_dev_engines_package_manager_with_on_fail_download() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(
+        &workspace,
+        &serde_json::json!({
+            "devEngines": {
+                "packageManager": {
+                    "name": "pnpm",
+                    "version": "9.3.0",
+                    "onFail": "download",
+                },
+            },
+        }),
+    );
+
+    let output = test_command(pacquet, root.path())
+        .with_args(["with", "current", "--version"])
+        .output()
+        .expect("run pacquet with current --version");
+    dbg!(&output);
+    assert_success(&output);
+    assert_current_version(&output);
+    assert!(!stdout(&output).contains("9.3.0"));
+
+    drop(root);
+}
+
+#[test]
+fn with_forwards_subsequent_args_to_the_child_pnpm() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &serde_json::json!({ "name": "project", "version": "1.0.0" }));
+
+    let output = test_command(pacquet, root.path())
+        .with_args(["with", "current", "--version"])
+        .output()
+        .expect("run pacquet with current --version");
+    dbg!(&output);
+    assert_success(&output);
+    assert_semver_like(stdout(&output).trim());
+
+    drop(root);
+}
+
+#[test]
+fn with_current_dispatches_the_inner_command_after_a_global_boolean_flag() {
+    for flag in ["--color", "--yes"] {
+        let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+        write_manifest(&workspace, &serde_json::json!({ "name": "project", "version": "1.0.0" }));
+
+        let output = test_command(pacquet, root.path())
+            .with_args([flag, "with", "current", "--version"])
+            .output()
+            .expect("run pacquet with current --version after a global boolean flag");
+        dbg!(&output);
+        assert_success(&output);
+        assert_semver_like(stdout(&output).trim());
+
+        drop(root);
+    }
+}
+
+#[test]
+fn with_fails_when_no_spec_is_provided() {
     let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
 
-    let output = pacquet.with_args(["with"]).output().expect("run pacquet with");
+    let output =
+        test_command(pacquet, root.path()).with_args(["with"]).output().expect("run pacquet with");
     dbg!(&output);
     assert!(!output.status.success(), "pacquet with (no spec) should fail");
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = stderr(&output);
     assert!(stderr.contains("Missing version argument"), "stderr should explain the gap: {stderr}");
 
     drop(root);
 }
 
 #[test]
+fn with_version_downloads_and_runs_the_specified_pnpm_version() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_manifest(&workspace, &serde_json::json!({ "name": "project", "version": "1.0.0" }));
+
+    let registry_arg = format!("--config.registry={}", mock_instance.url());
+    let output = test_command(pacquet, root.path())
+        .args([registry_arg.as_str(), "with", PINNED_PNPM_VERSION, "help"])
+        .output()
+        .expect("run pacquet with a specified pnpm version");
+    dbg!(&output);
+    assert_success(&output);
+    assert!(
+        stdout(&output).contains("Version 9.3.0"),
+        "downloaded pnpm help should show the requested version; stdout:\n{}",
+        stdout(&output),
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn with_version_ignores_the_package_manager_pin_and_uses_the_requested_version() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_manifest(&workspace, &serde_json::json!({ "packageManager": "pnpm@9.1.0" }));
+
+    let registry_arg = format!("--config.registry={}", mock_instance.url());
+    let output = test_command(pacquet, root.path())
+        .args([registry_arg.as_str(), "with", PINNED_PNPM_VERSION, "help"])
+        .output()
+        .expect("run pacquet with a specified pnpm version");
+    dbg!(&output);
+    assert_success(&output);
+    let stdout = stdout(&output);
+    assert!(
+        stdout.contains("Version 9.3.0"),
+        "downloaded pnpm help should show the requested version; stdout:\n{stdout}",
+    );
+    assert!(!stdout.contains("Version 9.1.0"), "the packageManager pin must be ignored");
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn with_current_requires_a_command() {
     let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
 
-    let output = pacquet.with_args(["with", "current"]).output().expect("run pacquet with current");
+    let output = test_command(pacquet, root.path())
+        .with_args(["with", "current"])
+        .output()
+        .expect("run pacquet with current");
     dbg!(&output);
     assert!(!output.status.success(), "pacquet with current (no command) should fail");
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = stderr(&output);
     assert!(
         stderr.contains(r#"Missing command after "current""#),
         "stderr should explain the gap: {stderr}",
@@ -43,26 +187,53 @@ fn with_current_requires_a_command() {
     drop(root);
 }
 
-#[test]
-fn with_current_runs_the_inner_command() {
-    // `with current <cmd>` is rewritten to a direct `<cmd>` dispatch, so an
-    // unknown inner command surfaces clap's error for that command — proof
-    // the `with current` tokens were stripped and `<cmd>` reached the
-    // parser, rather than being swallowed by the `with` subcommand.
-    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+fn test_command(mut command: Command, root: &Path) -> Command {
+    command.env("PNPM_HOME", root.join("pnpm-home"));
+    command.env("HOME", root);
+    command.env("XDG_CONFIG_HOME", root.join("xdg-config"));
+    command.env_remove("COREPACK_ROOT");
+    command.env_remove("pnpm_config_pm_on_fail");
+    command.env_remove("PNPM_CONFIG_PM_ON_FAIL");
+    command
+}
 
-    let output = pacquet
-        .with_args(["with", "current", "this-command-does-not-exist"])
-        .output()
-        .expect("run pacquet with current <cmd>");
-    dbg!(&output);
-    assert!(!output.status.success(), "an unknown inner command should fail");
+fn write_manifest(workspace: &Path, manifest: &serde_json::Value) {
+    fs::write(workspace.join("package.json"), manifest.to_string()).expect("write package.json");
+}
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
+fn assert_success(output: &Output) {
     assert!(
-        stderr.contains("this-command-does-not-exist") || stderr.contains("unrecognized"),
-        "the inner command should reach the parser: {stderr}",
+        output.status.success(),
+        "command should succeed\nstdout:\n{}\nstderr:\n{}",
+        stdout(output),
+        stderr(output),
     );
+}
 
-    drop(root);
+fn assert_current_version(output: &Output) {
+    assert_eq!(stdout(output).trim(), pacquet_config::PACQUET_VERSION);
+}
+
+fn assert_semver_like(value: &str) {
+    let mut parts = value.split('.');
+    assert!(
+        parts
+            .next()
+            .is_some_and(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit()))
+            && parts
+                .next()
+                .is_some_and(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit()))
+            && parts
+                .next()
+                .is_some_and(|part| part.chars().next().is_some_and(|c| c.is_ascii_digit())),
+        "expected a semver-looking version, got {value:?}",
+    );
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
 }

--- a/pacquet/crates/env-installer/src/resolve_package_manager_integrities.rs
+++ b/pacquet/crates/env-installer/src/resolve_package_manager_integrities.rs
@@ -27,7 +27,12 @@ pub async fn resolve_package_manager_integrities(
         .map_err(ConfigDepError::ReadLockfile)?
         .unwrap_or_else(EnvLockfile::create);
     let package_manager_deps = package_manager_deps(pnpm_version);
-    if is_package_manager_resolved(&env_lockfile, wanted_specifier, pnpm_version) {
+    if is_package_manager_resolved_with_deps(
+        &env_lockfile,
+        wanted_specifier,
+        pnpm_version,
+        package_manager_deps,
+    ) {
         return Ok(());
     }
     if opts.frozen_lockfile {
@@ -106,6 +111,20 @@ pub fn is_package_manager_resolved(
     wanted_specifier: &str,
     pnpm_version: &str,
 ) -> bool {
+    is_package_manager_resolved_with_deps(
+        env_lockfile,
+        wanted_specifier,
+        pnpm_version,
+        package_manager_deps(pnpm_version),
+    )
+}
+
+fn is_package_manager_resolved_with_deps(
+    env_lockfile: &EnvLockfile,
+    wanted_specifier: &str,
+    pnpm_version: &str,
+    package_manager_deps: &[&str],
+) -> bool {
     let Some(pm_deps) = env_lockfile
         .importers
         .get(EnvLockfile::ROOT_IMPORTER_KEY)
@@ -113,7 +132,6 @@ pub fn is_package_manager_resolved(
     else {
         return false;
     };
-    let package_manager_deps = package_manager_deps(pnpm_version);
     pm_deps.len() == package_manager_deps.len()
         && package_manager_deps.iter().all(|name| {
             pm_deps.get(*name).is_some_and(|dep| {

--- a/pacquet/crates/env-installer/src/resolve_package_manager_integrities.rs
+++ b/pacquet/crates/env-installer/src/resolve_package_manager_integrities.rs
@@ -13,7 +13,9 @@ use pacquet_lockfile::{
 use pacquet_resolving_resolver_base::{ResolveOptions, ResolveResult, Resolver, WantedDependency};
 use std::{collections::HashMap, path::PathBuf};
 
-const PACKAGE_MANAGER_DEPS: [&str; 2] = ["pnpm", "@pnpm/exe"];
+const PACKAGE_MANAGER_DEPS_WITH_EXE: [&str; 2] = ["pnpm", "@pnpm/exe"];
+const PACKAGE_MANAGER_DEPS_JS_ONLY: [&str; 1] = ["pnpm"];
+const PNPM_EXE_INTRODUCED: (u64, u64, u64) = (6, 17, 1);
 
 pub async fn resolve_package_manager_integrities(
     wanted_specifier: &str,
@@ -24,6 +26,7 @@ pub async fn resolve_package_manager_integrities(
     let mut env_lockfile = EnvLockfile::read(opts.root_dir)
         .map_err(ConfigDepError::ReadLockfile)?
         .unwrap_or_else(EnvLockfile::create);
+    let package_manager_deps = package_manager_deps(pnpm_version);
     if is_package_manager_resolved(&env_lockfile, wanted_specifier, pnpm_version) {
         return Ok(());
     }
@@ -35,7 +38,7 @@ pub async fn resolve_package_manager_integrities(
 
     let mut package_manager_dependencies = std::collections::BTreeMap::new();
     let mut resolved = Vec::new();
-    for name in PACKAGE_MANAGER_DEPS {
+    for name in package_manager_deps {
         let package = resolve_dep(name, pnpm_version, false, resolver, opts).await?;
         package_manager_dependencies.insert(
             name.to_string(),
@@ -110,14 +113,30 @@ pub fn is_package_manager_resolved(
     else {
         return false;
     };
-    pm_deps.len() == PACKAGE_MANAGER_DEPS.len()
-        && PACKAGE_MANAGER_DEPS.iter().all(|name| {
+    let package_manager_deps = package_manager_deps(pnpm_version);
+    pm_deps.len() == package_manager_deps.len()
+        && package_manager_deps.iter().all(|name| {
             pm_deps.get(*name).is_some_and(|dep| {
                 dep.specifier == wanted_specifier
                     && dep.version == pnpm_version
                     && package_manager_entry_exists(env_lockfile, name, &dep.version)
             })
         })
+}
+
+fn package_manager_deps(pnpm_version: &str) -> &'static [&'static str] {
+    if pnpm_exe_package_exists(pnpm_version) {
+        &PACKAGE_MANAGER_DEPS_WITH_EXE
+    } else {
+        &PACKAGE_MANAGER_DEPS_JS_ONLY
+    }
+}
+
+fn pnpm_exe_package_exists(pnpm_version: &str) -> bool {
+    let Some(version) = node_semver::Version::parse(pnpm_version).ok() else {
+        return true;
+    };
+    (version.major, version.minor, version.patch) >= PNPM_EXE_INTRODUCED
 }
 
 fn package_manager_entry_exists(env_lockfile: &EnvLockfile, name: &str, version: &str) -> bool {

--- a/pacquet/crates/env-installer/src/tests.rs
+++ b/pacquet/crates/env-installer/src/tests.rs
@@ -382,6 +382,54 @@ async fn resolves_package_manager_dependencies_without_exe_before_it_was_publish
 }
 
 #[tokio::test]
+async fn resolves_package_manager_dependencies_with_exe_at_first_published_version() {
+    let harness = harness();
+    let root = TempDir::new().unwrap();
+    let resolver = FixtureResolver::new()
+        .package(serde_json::json!({
+            "name": "pnpm",
+            "version": "6.17.1",
+            "bin": { "pnpm": "bin/pnpm.cjs", "pnpx": "bin/pnpx.cjs" },
+        }))
+        .package(serde_json::json!({
+            "name": "@pnpm/exe",
+            "version": "6.17.1",
+            "bin": { "pnpm": "pnpm" },
+            "optionalDependencies": { "@pnpm/macos-arm64": "6.17.1" },
+        }))
+        .package(serde_json::json!({
+            "name": "@pnpm/macos-arm64",
+            "version": "6.17.1",
+            "cpu": ["arm64"],
+            "os": ["darwin"],
+        }));
+
+    resolve_package_manager_integrities(
+        "^6.0.0",
+        "6.17.1",
+        &resolver,
+        &options(&harness, root.path(), false),
+    )
+    .await
+    .unwrap();
+
+    let env = EnvLockfile::read(root.path()).unwrap().expect("env lockfile written");
+    let pm_deps = env.importers[EnvLockfile::ROOT_IMPORTER_KEY]
+        .package_manager_dependencies
+        .as_ref()
+        .expect("package manager deps recorded");
+    assert_eq!(pm_deps.len(), 2);
+    assert_eq!(pm_deps["pnpm"].version, "6.17.1");
+    assert_eq!(pm_deps["@pnpm/exe"].version, "6.17.1");
+
+    let exe_key: PackageKey = "@pnpm/exe@6.17.1".parse().unwrap();
+    let platform_key: PackageKey = "@pnpm/macos-arm64@6.17.1".parse().unwrap();
+    assert!(env.packages.contains_key(&exe_key));
+    assert!(env.packages.contains_key(&platform_key));
+    assert!(is_package_manager_resolved(&env, "^6.0.0", "6.17.1"));
+}
+
+#[tokio::test]
 async fn rejects_optional_subdep_with_non_exact_version() {
     let harness = harness();
     let (resolver, _cache) = build_resolver(&harness.registry_url);

--- a/pacquet/crates/env-installer/src/tests.rs
+++ b/pacquet/crates/env-installer/src/tests.rs
@@ -346,6 +346,42 @@ async fn resolves_package_manager_dependencies_graph() {
 }
 
 #[tokio::test]
+async fn resolves_package_manager_dependencies_without_exe_before_it_was_published() {
+    let harness = harness();
+    let root = TempDir::new().unwrap();
+    let resolver = FixtureResolver::new().package(serde_json::json!({
+        "name": "pnpm",
+        "version": "6.16.0",
+        "bin": { "pnpm": "bin/pnpm.cjs", "pnpx": "bin/pnpx.cjs" },
+    }));
+
+    resolve_package_manager_integrities(
+        "^6.0.0",
+        "6.16.0",
+        &resolver,
+        &options(&harness, root.path(), false),
+    )
+    .await
+    .unwrap();
+
+    let env = EnvLockfile::read(root.path()).unwrap().expect("env lockfile written");
+    let pm_deps = env.importers[EnvLockfile::ROOT_IMPORTER_KEY]
+        .package_manager_dependencies
+        .as_ref()
+        .expect("package manager deps recorded");
+    assert_eq!(pm_deps.len(), 1);
+    assert_eq!(pm_deps["pnpm"].specifier, "^6.0.0");
+    assert_eq!(pm_deps["pnpm"].version, "6.16.0");
+    assert!(!pm_deps.contains_key("@pnpm/exe"));
+
+    let pnpm_key: PackageKey = "pnpm@6.16.0".parse().unwrap();
+    assert!(env.packages.contains_key(&pnpm_key));
+    assert!(env.snapshots.contains_key(&pnpm_key));
+    assert!(is_package_manager_resolved(&env, "^6.0.0", "6.16.0"));
+    assert!(!is_package_manager_resolved(&env, "^6.0.0", "6.17.1"));
+}
+
+#[tokio::test]
 async fn rejects_optional_subdep_with_non_exact_version() {
     let harness = harness();
     let (resolver, _cache) = build_resolver(&harness.registry_url);


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Fixes the Rust `pacquet` `with` downgrade path so it selects the right package layout for the resolved pnpm version:

- JS-only `pnpm` for versions before `@pnpm/exe` existed.
- Native `@pnpm/exe` for `6.17.1` through v11, using the legacy platform artifact names like `@pnpm/macos-arm64`.
- Native unscoped `pnpm` for v12+, using the `@pnpm/exe.<platform>` artifact names.

The install path also relinks the host native binary on cache hits, so a partially linked global-virtual-store slot is repaired instead of reused broken.

Related to https://github.com/pnpm/pnpm/issues/11633.

## Squash Commit Body

```text
Pacquet previously installed the unscoped pnpm package for every `pn with <version>` target. That works for v12+, where pnpm itself carries the native engine layout, but pnpm versions from 6.17.1 through v11 need the scoped `@pnpm/exe` wrapper package. Installing the unscoped package for those versions leaves the wrapper without the host native binary and fails at runtime with "no @pnpm/exe.<platform> native binary was found for this host".

Select the engine package from the resolved target version. Versions before `@pnpm/exe` was published use the JS `pnpm` package and skip native relinking. Versions from 6.17.1 through v11 use `@pnpm/exe` and link legacy platform artifacts such as `@pnpm/macos-arm64`. v12 and newer use unscoped `pnpm` and link the newer `@pnpm/exe.<platform>` artifacts.

Share that selection between self-update and `with`, use it when computing and resolving global-virtual-store slots, and derive scoped package slots by walking the full package path. Relink native platform binaries on cache hits as well as fresh installs so a previously incomplete slot is repaired before it is reused.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global CLI options `--color` and `--yes` / `-y`, and updated `with current` handling and option parsing to preserve these flags.
* **Bug Fixes**
  * Improved self-update and pnpm installation to select the correct pnpm engine wrapper based on the requested version and correctly link native binaries.
  * Refined global linking/cache/slot derivation for the versioned engine layout and added protections against unsafe wrapper/native symlinks.
  * Enhanced env lockfile package-manager integrity resolution/verification for pnpm setups with and without `@pnpm/exe`.
* **Tests**
  * Expanded unit and CLI coverage for pnpm engine mapping, binary linking, slot derivation, lockfile scenarios, and broader `with` command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
