### PR TITLE
fix: switch pacquet to project package manager version

### DIFF
--- a/.changeset/env-lockfile-symlink.md
+++ b/.changeset/env-lockfile-symlink.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/lockfile.fs": patch
+"pnpm": patch
+---
+
+Reject symlinked `pnpm-lock.yaml` files when reading or writing the env lockfile document.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4115,6 +4115,7 @@ dependencies = [
  "pacquet-catalogs-types",
  "pacquet-crypto-hash",
  "pacquet-diagnostics",
+ "pacquet-fs",
  "pacquet-package-manifest",
  "pipe-trait",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4111,6 +4111,7 @@ version = "0.0.1"
 dependencies = [
  "derive_more",
  "indexmap 2.14.0",
+ "libc",
  "node-semver",
  "pacquet-catalogs-types",
  "pacquet-crypto-hash",

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -68,6 +68,7 @@ mod dispatch_script;
 mod package_manager;
 mod pipelines;
 mod reporter;
+pub(crate) mod switch_cli_version;
 
 pub(crate) use cli_command::CliArgs;
 

--- a/pacquet/crates/cli/src/cli_args/package_manager.rs
+++ b/pacquet/crates/cli/src/cli_args/package_manager.rs
@@ -157,7 +157,7 @@ pub(crate) fn exact_version(version: &str) -> Option<String> {
     (parsed.to_string() == version).then(|| version.to_string())
 }
 
-fn version_satisfies(version: &str, wanted_range: &str) -> bool {
+pub(crate) fn version_satisfies(version: &str, wanted_range: &str) -> bool {
     let Ok(version) = node_semver::Version::parse(version) else {
         return false;
     };

--- a/pacquet/crates/cli/src/cli_args/package_manager.rs
+++ b/pacquet/crates/cli/src/cli_args/package_manager.rs
@@ -2,6 +2,13 @@ use miette::IntoDiagnostic;
 use serde_json::Value;
 use std::{fs, io::ErrorKind, path::Path};
 
+pub(crate) const PACKAGE_MANAGER_SWITCH_ENV_VARS: [&str; 4] = [
+    "npm_config_manage_package_manager_versions",
+    "NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS",
+    "pnpm_config_manage_package_manager_versions",
+    "PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS",
+];
+
 #[derive(Debug)]
 pub(crate) struct WantedPackageManager {
     pub(crate) name: String,

--- a/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
@@ -1,0 +1,419 @@
+use super::{
+    cli_command::{CliArgs, CliCommand},
+    package_manager::{
+        WantedPackageManager, read_manifest_json, should_persist_package_manager_lockfile,
+        version_satisfies, wanted_package_manager,
+    },
+    with::{
+        PackageManagerCheck,
+        install_pnpm_to_store::{install_pnpm_from_env, install_pnpm_to_store},
+        spawn_pnpm,
+    },
+};
+use crate::{config_deps, config_overrides::ConfigOverrides};
+use miette::{Context, IntoDiagnostic};
+use pacquet_config::{Config, Host, PACQUET_VERSION, PmOnFail};
+use pacquet_lockfile::{EnvLockfile, LockfileResolution, PackageKey};
+use pacquet_reporter::SilentReporter;
+use std::{
+    ffi::{OsStr, OsString},
+    path::{Path, PathBuf},
+};
+
+const PACKAGE_MANAGER_DEPS: [&str; 2] = ["pnpm", "@pnpm/exe"];
+
+pub(crate) async fn maybe_switch(
+    args: &CliArgs,
+    config_overrides: &ConfigOverrides,
+    child_argv: &[OsString],
+) -> miette::Result<bool> {
+    if should_skip_command(&args.command) {
+        return Ok(false);
+    }
+    maybe_switch_from_input(&SwitchInput::from_cli_args(args), config_overrides, child_argv).await
+}
+
+pub(crate) async fn maybe_switch_for_version_flag(
+    argv: &[OsString],
+    config_overrides: &ConfigOverrides,
+    child_argv: &[OsString],
+) -> miette::Result<bool> {
+    maybe_switch_from_input(&SwitchInput::from_version_argv(argv), config_overrides, child_argv)
+        .await
+}
+
+#[expect(clippy::exit, reason = "delegated pnpm must preserve the child exit code")]
+async fn maybe_switch_from_input(
+    input: &SwitchInput,
+    config_overrides: &ConfigOverrides,
+    child_argv: &[OsString],
+) -> miette::Result<bool> {
+    if input.command.as_deref().is_some_and(should_skip_command_name)
+        || package_manager_switch_disabled()
+        || std::env::var_os("COREPACK_ROOT").is_some()
+    {
+        return Ok(false);
+    }
+    let dir = dunce::canonicalize(&input.dir).into_diagnostic().wrap_err_with(|| {
+        format!("canonicalizing the `--dir` argument: {}", input.dir.display())
+    })?;
+    let mut config = Config { npmrc_auth_file: input.npmrc_auth_file.clone(), ..Config::default() }
+        .current::<Host>(&dir)
+        .map_err(miette::Report::new)
+        .wrap_err("load configuration")?;
+    config_overrides.apply(&mut config);
+
+    let root_dir = config.workspace_dir.clone().unwrap_or_else(|| dir.clone());
+    let Some(target) = switch_target(&config, &root_dir)? else {
+        return Ok(false);
+    };
+    if version_satisfies(PACQUET_VERSION, &target.spec) {
+        return Ok(false);
+    }
+
+    let config = Config::leak(config);
+    let (version, bin_dir) = match target.source {
+        SwitchSource::LockedEnv { env, version } => {
+            if version == PACQUET_VERSION {
+                return Ok(false);
+            }
+            let bin_dir =
+                Box::pin(install_pnpm_from_env::<SilentReporter>(config, &env, &version)).await?;
+            (version, bin_dir)
+        }
+        SwitchSource::Resolve { env_root } => {
+            let resolved =
+                config_deps::resolve_pnpm_version(config, &target.spec).await?.ok_or_else(
+                    || miette::miette!(r#"Cannot resolve pnpm version for "{}""#, target.spec),
+                )?;
+            if resolved.version == PACQUET_VERSION {
+                return Ok(false);
+            }
+            let bin_dir = Box::pin(install_pnpm_to_store::<SilentReporter>(
+                config,
+                &env_root,
+                &target.spec,
+                &resolved.version,
+            ))
+            .await?;
+            (resolved.version, bin_dir)
+        }
+    };
+
+    let status = spawn_pnpm(&bin_dir, child_argv.iter(), PackageManagerCheck::Enabled)
+        .wrap_err_with(|| format!("switch pnpm to v{version}"))?;
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+    Ok(true)
+}
+
+fn switch_target(config: &Config, root_dir: &Path) -> miette::Result<Option<SwitchTarget>> {
+    let Some(manifest) = read_manifest_json(&root_dir.join("package.json"))? else {
+        return Ok(None);
+    };
+    let Some(mut pm) = wanted_package_manager(&manifest) else {
+        return Ok(None);
+    };
+    if pm.name != "pnpm" {
+        return Ok(None);
+    }
+    let Some(spec) = pm.version.clone() else {
+        return Ok(None);
+    };
+    let on_fail = effective_on_fail(config, &pm);
+    if on_fail != PmOnFail::Download {
+        return Ok(None);
+    }
+    pm.on_fail = Some(on_fail_str(on_fail).to_string());
+
+    let persist_lockfile = should_persist_package_manager_lockfile(&pm);
+    if persist_lockfile
+        && let Some(env) =
+            EnvLockfile::read(root_dir).map_err(miette::Report::new).wrap_err_with(|| {
+                format!("read the package-manager env lockfile in {}", root_dir.display())
+            })?
+        && let Some(version) = locked_package_manager_version(&env, &spec)
+    {
+        return Ok(Some(SwitchTarget { spec, source: SwitchSource::LockedEnv { env, version } }));
+    }
+
+    let env_root = if persist_lockfile {
+        root_dir.to_path_buf()
+    } else {
+        config.global_pkg_dir.clone().ok_or_else(|| {
+            miette::miette!(
+                r#"Unable to find the global packages directory. Run "pnpm setup" to create it automatically, or set the global-bin-dir setting, or the PNPM_HOME env variable."#,
+            )
+        })?
+    };
+    Ok(Some(SwitchTarget { spec, source: SwitchSource::Resolve { env_root } }))
+}
+
+fn locked_package_manager_version(env: &EnvLockfile, wanted_range: &str) -> Option<String> {
+    let version = env
+        .importers
+        .get(EnvLockfile::ROOT_IMPORTER_KEY)?
+        .package_manager_dependencies
+        .as_ref()?
+        .get("pnpm")?
+        .version
+        .clone();
+    (version_satisfies(&version, wanted_range) && package_manager_entries_exist(env, &version))
+        .then_some(version)
+}
+
+fn package_manager_entries_exist(env: &EnvLockfile, version: &str) -> bool {
+    PACKAGE_MANAGER_DEPS.iter().all(|name| {
+        let Ok(key) = format!("{name}@{version}").parse::<PackageKey>() else {
+            return false;
+        };
+        env.snapshots.contains_key(&key)
+            && env.packages.get(&key).is_some_and(|metadata| {
+                matches!(&metadata.resolution, LockfileResolution::Registry(_))
+            })
+    })
+}
+
+fn effective_on_fail(config: &Config, pm: &WantedPackageManager) -> PmOnFail {
+    config.pm_on_fail.unwrap_or(match pm.on_fail.as_deref() {
+        Some("ignore") => PmOnFail::Ignore,
+        Some("warn") => PmOnFail::Warn,
+        Some("error") => PmOnFail::Error,
+        Some("download") | None => PmOnFail::Download,
+        Some(_) => PmOnFail::Download,
+    })
+}
+
+fn on_fail_str(on_fail: PmOnFail) -> &'static str {
+    match on_fail {
+        PmOnFail::Download => "download",
+        PmOnFail::Error => "error",
+        PmOnFail::Warn => "warn",
+        PmOnFail::Ignore => "ignore",
+    }
+}
+
+fn should_skip_command(command: &CliCommand) -> bool {
+    matches!(
+        command,
+        CliCommand::Completion(_)
+            | CliCommand::CompletionServer(_)
+            | CliCommand::Runtime(_)
+            | CliCommand::SelfUpdate(_)
+            | CliCommand::Setup(_)
+            | CliCommand::Store(_)
+            | CliCommand::With(_),
+    )
+}
+
+fn should_skip_command_name(command: &str) -> bool {
+    matches!(
+        command,
+        "completion"
+            | "completion-server"
+            | "env"
+            | "runtime"
+            | "rt"
+            | "self-update"
+            | "setup"
+            | "store"
+            | "with",
+    )
+}
+
+fn package_manager_switch_disabled() -> bool {
+    [
+        "npm_config_manage_package_manager_versions",
+        "NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS",
+        "pnpm_config_manage_package_manager_versions",
+        "PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS",
+    ]
+    .into_iter()
+    .any(env_var_is_false)
+}
+
+fn env_var_is_false(name: &str) -> bool {
+    std::env::var_os(name)
+        .and_then(|value| value.into_string().ok())
+        .is_some_and(|value| matches!(value.to_ascii_lowercase().as_str(), "false" | "0"))
+}
+
+struct SwitchTarget {
+    spec: String,
+    source: SwitchSource,
+}
+
+enum SwitchSource {
+    LockedEnv { env: EnvLockfile, version: String },
+    Resolve { env_root: PathBuf },
+}
+
+struct SwitchInput {
+    dir: PathBuf,
+    npmrc_auth_file: Option<PathBuf>,
+    command: Option<String>,
+}
+
+impl SwitchInput {
+    fn from_cli_args(args: &CliArgs) -> Self {
+        Self {
+            dir: args.dir.clone(),
+            npmrc_auth_file: args.npmrc_auth_file.clone(),
+            command: Some(command_name(&args.command).to_string()),
+        }
+    }
+
+    fn from_version_argv(argv: &[OsString]) -> Self {
+        let mut input = Self { dir: PathBuf::from("."), npmrc_auth_file: None, command: None };
+        let mut index = 1;
+        while index < argv.len() {
+            let Some(token) = argv[index].to_str() else {
+                input.command = Some(String::new());
+                break;
+            };
+            if token == "--" {
+                break;
+            }
+            if !token.starts_with('-') {
+                input.command = Some(token.to_string());
+                break;
+            }
+            if let Some(value) =
+                short_value(token, "-C", argv.get(index + 1).map(OsString::as_os_str))
+            {
+                input.dir = PathBuf::from(value);
+                index += if token == "-C" { 2 } else { 1 };
+                continue;
+            }
+            if let Some((value, width)) =
+                long_value(token, "dir", argv.get(index + 1).map(OsString::as_os_str))
+            {
+                input.dir = PathBuf::from(value);
+                index += width;
+                continue;
+            }
+            if let Some((value, width)) =
+                long_value(token, "npmrc-auth-file", argv.get(index + 1).map(OsString::as_os_str))
+                    .or_else(|| {
+                        long_value(
+                            token,
+                            "userconfig",
+                            argv.get(index + 1).map(OsString::as_os_str),
+                        )
+                    })
+            {
+                input.npmrc_auth_file = Some(PathBuf::from(value));
+                index += width;
+                continue;
+            }
+            index += if value_taking_global_option(token) { 2 } else { 1 };
+        }
+        input
+    }
+}
+
+fn command_name(command: &CliCommand) -> &'static str {
+    match command {
+        CliCommand::Init => "init",
+        CliCommand::Add(_) => "add",
+        CliCommand::Install(_) => "install",
+        CliCommand::Update(_) => "update",
+        CliCommand::Outdated(_) => "outdated",
+        CliCommand::Audit(_) => "audit",
+        CliCommand::Bugs(_) => "bugs",
+        CliCommand::List(_) => "list",
+        CliCommand::Ll(_) => "ll",
+        CliCommand::Why(_) => "why",
+        CliCommand::Sbom(_) => "sbom",
+        CliCommand::Whoami => "whoami",
+        CliCommand::DistTag(_) => "dist-tag",
+        CliCommand::Ping(_) => "ping",
+        CliCommand::Rebuild(_) => "rebuild",
+        CliCommand::Pack(_) => "pack",
+        CliCommand::Remove(_) => "remove",
+        CliCommand::Patch(_) => "patch",
+        CliCommand::PatchCommit(_) => "patch-commit",
+        CliCommand::PatchRemove(_) => "patch-remove",
+        CliCommand::Peers(_) => "peers",
+        CliCommand::SetScript(_) => "set-script",
+        CliCommand::Test => "test",
+        CliCommand::Run(_) => "run",
+        CliCommand::External(_) => "external",
+        CliCommand::Exec(_) => "exec",
+        CliCommand::Dlx(_) => "dlx",
+        CliCommand::Create(_) => "create",
+        CliCommand::Start => "start",
+        CliCommand::Stop(_) => "stop",
+        CliCommand::Restart(_) => "restart",
+        CliCommand::FindHash(_) => "find-hash",
+        CliCommand::Runtime(_) => "runtime",
+        CliCommand::Bin(_) => "bin",
+        CliCommand::Root(_) => "root",
+        CliCommand::Prefix(_) => "prefix",
+        CliCommand::Config(_) => "config",
+        CliCommand::PackApp(_) => "pack-app",
+        CliCommand::Store(_) => "store",
+        CliCommand::Cache(_) => "cache",
+        CliCommand::CatFile(_) => "cat-file",
+        CliCommand::CatIndex(_) => "cat-index",
+        CliCommand::IgnoredBuilds(_) => "ignored-builds",
+        CliCommand::ApproveBuilds(_) => "approve-builds",
+        CliCommand::Link(_) => "link",
+        CliCommand::Import(_) => "import",
+        CliCommand::Dedupe(_) => "dedupe",
+        CliCommand::Deploy(_) => "deploy",
+        CliCommand::Prune(_) => "prune",
+        CliCommand::Fetch(_) => "fetch",
+        CliCommand::Unlink(_) => "unlink",
+        CliCommand::Docs(_) => "docs",
+        CliCommand::Repo(_) => "repo",
+        CliCommand::SelfUpdate(_) => "self-update",
+        CliCommand::Setup(_) => "setup",
+        CliCommand::Logout(_) => "logout",
+        CliCommand::With(_) => "with",
+        CliCommand::Completion(_) => "completion",
+        CliCommand::CompletionServer(_) => "completion-server",
+    }
+}
+
+fn short_value<'a>(token: &'a str, option: &str, next: Option<&'a OsStr>) -> Option<&'a OsStr> {
+    if token == option {
+        return next;
+    }
+    token.strip_prefix(option).filter(|value| !value.is_empty()).map(OsStr::new)
+}
+
+fn long_value<'a>(
+    token: &'a str,
+    option: &str,
+    next: Option<&'a OsStr>,
+) -> Option<(&'a OsStr, usize)> {
+    let name = token.strip_prefix("--")?;
+    if name == option {
+        return next.map(|value| (value, 2));
+    }
+    name.strip_prefix(option)
+        .and_then(|rest| rest.strip_prefix('='))
+        .map(OsStr::new)
+        .map(|value| (value, 1))
+}
+
+fn value_taking_global_option(token: &str) -> bool {
+    if matches!(token, "-F") {
+        return true;
+    }
+    if token.starts_with("-F") {
+        return false;
+    }
+    let Some(name) = token.strip_prefix("--") else {
+        return false;
+    };
+    if name.contains('=') {
+        return false;
+    }
+    matches!(name, "filter" | "filter-prod" | "npmrc-auth-file" | "reporter" | "userconfig")
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
@@ -30,14 +30,22 @@ pub(crate) fn switch_plan(
     if should_skip_command(&args.command) {
         return Ok(None);
     }
-    switch_plan_from_input(&SwitchInput::from_cli_args(args), config_overrides)
+    switch_plan_from_input(
+        &SwitchInput::from_cli_args(args),
+        config_overrides,
+        SwitchProcessState::current(),
+    )
 }
 
 pub(crate) fn switch_plan_for_version_flag(
     argv: &[OsString],
     config_overrides: &ConfigOverrides,
 ) -> miette::Result<Option<SwitchPlan>> {
-    switch_plan_from_input(&SwitchInput::from_version_argv(argv), config_overrides)
+    switch_plan_from_input(
+        &SwitchInput::from_version_argv(argv),
+        config_overrides,
+        SwitchProcessState::current(),
+    )
 }
 
 #[expect(clippy::exit, reason = "delegated pnpm must preserve the child exit code")]
@@ -86,10 +94,11 @@ pub(crate) async fn execute_switch(
 fn switch_plan_from_input(
     input: &SwitchInput,
     config_overrides: &ConfigOverrides,
+    process_state: SwitchProcessState,
 ) -> miette::Result<Option<SwitchPlan>> {
     if input.command.as_deref().is_some_and(should_skip_command_name)
-        || package_manager_switch_disabled()
-        || std::env::var_os("COREPACK_ROOT").is_some()
+        || process_state.package_manager_switch_disabled
+        || process_state.executed_by_corepack
     {
         return Ok(None);
     }
@@ -348,6 +357,21 @@ fn env_var_is_false(name: &str) -> bool {
     std::env::var_os(name)
         .and_then(|value| value.into_string().ok())
         .is_some_and(|value| matches!(value.to_ascii_lowercase().as_str(), "false" | "0"))
+}
+
+#[derive(Clone, Copy)]
+struct SwitchProcessState {
+    package_manager_switch_disabled: bool,
+    executed_by_corepack: bool,
+}
+
+impl SwitchProcessState {
+    fn current() -> Self {
+        Self {
+            package_manager_switch_disabled: package_manager_switch_disabled(),
+            executed_by_corepack: std::env::var_os("COREPACK_ROOT").is_some(),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
@@ -1,8 +1,8 @@
 use super::{
     cli_command::{CliArgs, CliCommand},
     package_manager::{
-        WantedPackageManager, read_manifest_json, should_persist_package_manager_lockfile,
-        version_satisfies, wanted_package_manager,
+        PACKAGE_MANAGER_SWITCH_ENV_VARS, WantedPackageManager, read_manifest_json,
+        should_persist_package_manager_lockfile, version_satisfies, wanted_package_manager,
     },
     self_update::install_pnpm::pnpm_package_to_install,
     with::{
@@ -343,14 +343,7 @@ fn should_skip_command_name(command: &str) -> bool {
 }
 
 fn package_manager_switch_disabled() -> bool {
-    [
-        "npm_config_manage_package_manager_versions",
-        "NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS",
-        "pnpm_config_manage_package_manager_versions",
-        "PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS",
-    ]
-    .into_iter()
-    .any(env_var_is_false)
+    PACKAGE_MANAGER_SWITCH_ENV_VARS.into_iter().any(env_var_is_false)
 }
 
 fn env_var_is_false(name: &str) -> bool {

--- a/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
@@ -4,6 +4,7 @@ use super::{
         WantedPackageManager, read_manifest_json, should_persist_package_manager_lockfile,
         version_satisfies, wanted_package_manager,
     },
+    self_update::install_pnpm::pnpm_package_to_install,
     with::{
         PackageManagerCheck,
         install_pnpm_to_store::{install_pnpm_from_env, install_pnpm_to_store},
@@ -22,59 +23,32 @@ use std::{
     path::{Path, PathBuf},
 };
 
-const PACKAGE_MANAGER_DEPS: [&str; 2] = ["pnpm", "@pnpm/exe"];
-
-pub(crate) async fn maybe_switch(
+pub(crate) fn switch_plan(
     args: &CliArgs,
     config_overrides: &ConfigOverrides,
-    child_argv: &[OsString],
-) -> miette::Result<bool> {
+) -> miette::Result<Option<SwitchPlan>> {
     if should_skip_command(&args.command) {
-        return Ok(false);
+        return Ok(None);
     }
-    maybe_switch_from_input(&SwitchInput::from_cli_args(args), config_overrides, child_argv).await
+    switch_plan_from_input(&SwitchInput::from_cli_args(args), config_overrides)
 }
 
-pub(crate) async fn maybe_switch_for_version_flag(
+pub(crate) fn switch_plan_for_version_flag(
     argv: &[OsString],
     config_overrides: &ConfigOverrides,
-    child_argv: &[OsString],
-) -> miette::Result<bool> {
-    maybe_switch_from_input(&SwitchInput::from_version_argv(argv), config_overrides, child_argv)
-        .await
+) -> miette::Result<Option<SwitchPlan>> {
+    switch_plan_from_input(&SwitchInput::from_version_argv(argv), config_overrides)
 }
 
 #[expect(clippy::exit, reason = "delegated pnpm must preserve the child exit code")]
-async fn maybe_switch_from_input(
-    input: &SwitchInput,
-    config_overrides: &ConfigOverrides,
+pub(crate) async fn execute_switch(
+    plan: SwitchPlan,
     child_argv: &[OsString],
 ) -> miette::Result<bool> {
-    if input.command.as_deref().is_some_and(should_skip_command_name)
-        || package_manager_switch_disabled()
-        || std::env::var_os("COREPACK_ROOT").is_some()
-    {
-        return Ok(false);
-    }
-    let dir = dunce::canonicalize(&input.dir).into_diagnostic().wrap_err_with(|| {
-        format!("canonicalizing the `--dir` argument: {}", input.dir.display())
-    })?;
-    let mut config = Config { npmrc_auth_file: input.npmrc_auth_file.clone(), ..Config::default() }
-        .current::<Host>(&dir)
-        .map_err(miette::Report::new)
-        .wrap_err("load configuration")?;
-    config_overrides.apply(&mut config);
-
-    let root_dir = config.workspace_dir.clone().unwrap_or_else(|| dir.clone());
-    let Some(target) = switch_target(&config, &root_dir)? else {
-        return Ok(false);
-    };
-    if version_satisfies(PACQUET_VERSION, &target.spec) {
-        return Ok(false);
-    }
-
+    let SwitchPlan { config, target } = plan;
+    let SwitchTarget { spec, source } = target;
     let config = Config::leak(config);
-    let (version, bin_dir) = match target.source {
+    let (version, bin_dir) = match source {
         SwitchSource::LockedEnv { env, version } => {
             if version == PACQUET_VERSION {
                 return Ok(false);
@@ -84,17 +58,16 @@ async fn maybe_switch_from_input(
             (version, bin_dir)
         }
         SwitchSource::Resolve { env_root } => {
-            let resolved =
-                config_deps::resolve_pnpm_version(config, &target.spec).await?.ok_or_else(
-                    || miette::miette!(r#"Cannot resolve pnpm version for "{}""#, target.spec),
-                )?;
+            let resolved = config_deps::resolve_pnpm_version(config, &spec)
+                .await?
+                .ok_or_else(|| miette::miette!(r#"Cannot resolve pnpm version for "{}""#, spec))?;
             if resolved.version == PACQUET_VERSION {
                 return Ok(false);
             }
             let bin_dir = Box::pin(install_pnpm_to_store::<SilentReporter>(
                 config,
                 &env_root,
-                &target.spec,
+                &spec,
                 &resolved.version,
             ))
             .await?;
@@ -108,6 +81,35 @@ async fn maybe_switch_from_input(
         std::process::exit(status.code().unwrap_or(1));
     }
     Ok(true)
+}
+
+fn switch_plan_from_input(
+    input: &SwitchInput,
+    config_overrides: &ConfigOverrides,
+) -> miette::Result<Option<SwitchPlan>> {
+    if input.command.as_deref().is_some_and(should_skip_command_name)
+        || package_manager_switch_disabled()
+        || std::env::var_os("COREPACK_ROOT").is_some()
+    {
+        return Ok(None);
+    }
+    let dir = dunce::canonicalize(&input.dir).into_diagnostic().wrap_err_with(|| {
+        format!("canonicalizing the `--dir` argument: {}", input.dir.display())
+    })?;
+    let mut config = Config { npmrc_auth_file: input.npmrc_auth_file.clone(), ..Config::default() }
+        .current::<Host>(&dir)
+        .map_err(miette::Report::new)
+        .wrap_err("load configuration")?;
+    config_overrides.apply(&mut config);
+
+    let root_dir = config.workspace_dir.clone().unwrap_or_else(|| dir.clone());
+    let Some(target) = switch_target(&config, &root_dir)? else {
+        return Ok(None);
+    };
+    if version_satisfies(PACQUET_VERSION, &target.spec) {
+        return Ok(None);
+    }
+    Ok(Some(SwitchPlan { config, target }))
 }
 
 fn switch_target(config: &Config, root_dir: &Path) -> miette::Result<Option<SwitchTarget>> {
@@ -183,9 +185,12 @@ fn package_manager_dependencies_are_resolved(env: &EnvLockfile, version: &str) -
     else {
         return false;
     };
-    PACKAGE_MANAGER_DEPS
-        .iter()
-        .all(|name| dependencies.get(*name).is_some_and(|dep| dep.version == version))
+    if dependencies.get("pnpm").is_none_or(|dep| dep.version != version) {
+        return false;
+    }
+    let wrapper_pkg_name = pnpm_package_to_install(version).name;
+    wrapper_pkg_name == "pnpm"
+        || dependencies.get(wrapper_pkg_name).is_some_and(|dep| dep.version == version)
 }
 
 fn assert_package_manager_lockfile_uses_registry_resolutions(
@@ -350,6 +355,11 @@ fn env_var_is_false(name: &str) -> bool {
 struct SwitchTarget {
     spec: String,
     source: SwitchSource,
+}
+
+pub(crate) struct SwitchPlan {
+    config: Config,
+    target: SwitchTarget,
 }
 
 enum SwitchSource {

--- a/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
@@ -13,10 +13,12 @@ use super::{
 use crate::{config_deps, config_overrides::ConfigOverrides};
 use miette::{Context, IntoDiagnostic};
 use pacquet_config::{Config, Host, PACQUET_VERSION, PmOnFail};
-use pacquet_lockfile::{EnvLockfile, LockfileResolution, PackageKey};
+use pacquet_lockfile::{EnvLockfile, LockfileResolution, PackageKey, PackageMetadata, VersionPart};
 use pacquet_reporter::SilentReporter;
 use std::{
+    collections::HashSet,
     ffi::{OsStr, OsString},
+    fmt::Display,
     path::{Path, PathBuf},
 };
 
@@ -133,7 +135,7 @@ fn switch_target(config: &Config, root_dir: &Path) -> miette::Result<Option<Swit
             EnvLockfile::read(root_dir).map_err(miette::Report::new).wrap_err_with(|| {
                 format!("read the package-manager env lockfile in {}", root_dir.display())
             })?
-        && let Some(version) = locked_package_manager_version(&env, &spec)
+        && let Some(version) = locked_package_manager_version(&env, &spec)?
     {
         return Ok(Some(SwitchTarget { spec, source: SwitchSource::LockedEnv { env, version } }));
     }
@@ -150,29 +152,135 @@ fn switch_target(config: &Config, root_dir: &Path) -> miette::Result<Option<Swit
     Ok(Some(SwitchTarget { spec, source: SwitchSource::Resolve { env_root } }))
 }
 
-fn locked_package_manager_version(env: &EnvLockfile, wanted_range: &str) -> Option<String> {
-    let version = env
+fn locked_package_manager_version(
+    env: &EnvLockfile,
+    wanted_range: &str,
+) -> miette::Result<Option<String>> {
+    let Some(version) = env
         .importers
-        .get(EnvLockfile::ROOT_IMPORTER_KEY)?
-        .package_manager_dependencies
-        .as_ref()?
-        .get("pnpm")?
-        .version
-        .clone();
-    (version_satisfies(&version, wanted_range) && package_manager_entries_exist(env, &version))
-        .then_some(version)
+        .get(EnvLockfile::ROOT_IMPORTER_KEY)
+        .and_then(|importer| importer.package_manager_dependencies.as_ref())
+        .and_then(|dependencies| dependencies.get("pnpm"))
+        .map(|dependency| dependency.version.clone())
+    else {
+        return Ok(None);
+    };
+    if !version_satisfies(&version, wanted_range) {
+        return Ok(None);
+    }
+    if !package_manager_dependencies_are_resolved(env, &version) {
+        return Ok(None);
+    }
+    assert_package_manager_lockfile_uses_registry_resolutions(env)?;
+    Ok(Some(version))
 }
 
-fn package_manager_entries_exist(env: &EnvLockfile, version: &str) -> bool {
-    PACKAGE_MANAGER_DEPS.iter().all(|name| {
-        let Ok(key) = format!("{name}@{version}").parse::<PackageKey>() else {
-            return false;
-        };
-        env.snapshots.contains_key(&key)
-            && env.packages.get(&key).is_some_and(|metadata| {
-                matches!(&metadata.resolution, LockfileResolution::Registry(_))
-            })
-    })
+fn package_manager_dependencies_are_resolved(env: &EnvLockfile, version: &str) -> bool {
+    let Some(dependencies) = env
+        .importers
+        .get(EnvLockfile::ROOT_IMPORTER_KEY)
+        .and_then(|importer| importer.package_manager_dependencies.as_ref())
+    else {
+        return false;
+    };
+    PACKAGE_MANAGER_DEPS
+        .iter()
+        .all(|name| dependencies.get(*name).is_some_and(|dep| dep.version == version))
+}
+
+fn assert_package_manager_lockfile_uses_registry_resolutions(
+    env: &EnvLockfile,
+) -> miette::Result<()> {
+    let Some(package_manager_dependencies) = env
+        .importers
+        .get(EnvLockfile::ROOT_IMPORTER_KEY)
+        .and_then(|importer| importer.package_manager_dependencies.as_ref())
+    else {
+        return Err(miette::miette!(
+            "The packageManager dependencies were not found in pnpm-lock.yaml"
+        ));
+    };
+
+    let mut visited = HashSet::new();
+    for (name, dependency) in package_manager_dependencies {
+        let key = format!("{name}@{}", dependency.version)
+            .parse::<PackageKey>()
+            .map_err(|_| invalid_package_manager_lockfile(name))?;
+        assert_registry_package_manager_dependency(env, &key, &mut visited)?;
+    }
+    Ok(())
+}
+
+fn assert_registry_package_manager_dependency(
+    env: &EnvLockfile,
+    key: &PackageKey,
+    visited: &mut HashSet<PackageKey>,
+) -> miette::Result<()> {
+    if !visited.insert(key.clone()) {
+        return Ok(());
+    }
+
+    let package_key = key.without_peer();
+    let package_info =
+        env.packages.get(&package_key).ok_or_else(|| invalid_package_manager_lockfile(key))?;
+    let snapshot = env.snapshots.get(key).ok_or_else(|| invalid_package_manager_lockfile(key))?;
+
+    assert_registry_package_path(key, package_info)?;
+    assert_integrity_only_resolution(key, &package_info.resolution)?;
+
+    for dependencies in
+        [&snapshot.dependencies, &snapshot.optional_dependencies].into_iter().flatten()
+    {
+        for (name, reference) in dependencies {
+            let next_key =
+                reference.resolve(name).ok_or_else(|| invalid_package_manager_lockfile(key))?;
+            assert_registry_package_manager_dependency(env, &next_key, visited)?;
+        }
+    }
+    Ok(())
+}
+
+fn assert_registry_package_path(
+    key: &PackageKey,
+    package_info: &PackageMetadata,
+) -> miette::Result<()> {
+    if key.suffix.prefix() != pacquet_lockfile::Prefix::None
+        || !matches!(key.suffix.version(), VersionPart::Semver(_))
+    {
+        return Err(invalid_package_manager_lockfile(key));
+    }
+    if let Some(version) = &package_info.version
+        && version != &key.suffix.without_peer().to_string()
+    {
+        return Err(invalid_package_manager_lockfile(key));
+    }
+    Ok(())
+}
+
+fn assert_integrity_only_resolution(
+    key: &PackageKey,
+    resolution: &LockfileResolution,
+) -> miette::Result<()> {
+    match resolution {
+        LockfileResolution::Registry(resolution)
+            if !resolution.integrity.to_string().is_empty() =>
+        {
+            Ok(())
+        }
+        LockfileResolution::Registry(_)
+        | LockfileResolution::Tarball(_)
+        | LockfileResolution::Directory(_)
+        | LockfileResolution::Git(_)
+        | LockfileResolution::Binary(_)
+        | LockfileResolution::Variations(_) => Err(invalid_package_manager_lockfile(key)),
+    }
+}
+
+fn invalid_package_manager_lockfile(dep_path: impl Display) -> miette::Report {
+    miette::miette!(
+        r#"The packageManager dependency "{}" in pnpm-lock.yaml must use a registry package path and an integrity-only resolution"#,
+        dep_path,
+    )
 }
 
 fn effective_on_fail(config: &Config, pm: &WantedPackageManager) -> PmOnFail {

--- a/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
@@ -207,39 +207,37 @@ fn assert_package_manager_lockfile_uses_registry_resolutions(
     };
 
     let mut visited = HashSet::new();
+    let mut pending = Vec::with_capacity(package_manager_dependencies.len());
     for (name, dependency) in package_manager_dependencies {
         let key = format!("{name}@{}", dependency.version)
             .parse::<PackageKey>()
             .map_err(|_| invalid_package_manager_lockfile(name))?;
-        assert_registry_package_manager_dependency(env, &key, &mut visited)?;
-    }
-    Ok(())
-}
-
-fn assert_registry_package_manager_dependency(
-    env: &EnvLockfile,
-    key: &PackageKey,
-    visited: &mut HashSet<PackageKey>,
-) -> miette::Result<()> {
-    if !visited.insert(key.clone()) {
-        return Ok(());
+        pending.push(key);
     }
 
-    let package_key = key.without_peer();
-    let package_info =
-        env.packages.get(&package_key).ok_or_else(|| invalid_package_manager_lockfile(key))?;
-    let snapshot = env.snapshots.get(key).ok_or_else(|| invalid_package_manager_lockfile(key))?;
+    while let Some(key) = pending.pop() {
+        if !visited.insert(key.clone()) {
+            continue;
+        }
 
-    assert_registry_package_path(key, package_info)?;
-    assert_integrity_only_resolution(key, &package_info.resolution)?;
+        let package_key = key.without_peer();
+        let package_info =
+            env.packages.get(&package_key).ok_or_else(|| invalid_package_manager_lockfile(&key))?;
+        let snapshot =
+            env.snapshots.get(&key).ok_or_else(|| invalid_package_manager_lockfile(&key))?;
 
-    for dependencies in
-        [&snapshot.dependencies, &snapshot.optional_dependencies].into_iter().flatten()
-    {
-        for (name, reference) in dependencies {
-            let next_key =
-                reference.resolve(name).ok_or_else(|| invalid_package_manager_lockfile(key))?;
-            assert_registry_package_manager_dependency(env, &next_key, visited)?;
+        assert_registry_package_path(&key, package_info)?;
+        assert_integrity_only_resolution(&key, &package_info.resolution)?;
+
+        for dependencies in
+            [&snapshot.dependencies, &snapshot.optional_dependencies].into_iter().flatten()
+        {
+            for (name, reference) in dependencies {
+                let next_key = reference
+                    .resolve(name)
+                    .ok_or_else(|| invalid_package_manager_lockfile(&key))?;
+                pending.push(next_key);
+            }
         }
     }
     Ok(())
@@ -352,6 +350,7 @@ fn env_var_is_false(name: &str) -> bool {
         .is_some_and(|value| matches!(value.to_ascii_lowercase().as_str(), "false" | "0"))
 }
 
+#[derive(Debug)]
 struct SwitchTarget {
     spec: String,
     source: SwitchSource,
@@ -362,6 +361,7 @@ pub(crate) struct SwitchPlan {
     target: SwitchTarget,
 }
 
+#[derive(Debug)]
 enum SwitchSource {
     LockedEnv { env: EnvLockfile, version: String },
     Resolve { env_root: PathBuf },

--- a/pacquet/crates/cli/src/cli_args/switch_cli_version/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version/tests.rs
@@ -1,6 +1,10 @@
 use super::{SwitchInput, SwitchSource, switch_target};
-use pacquet_config::Config;
-use std::{ffi::OsString, fs, path::PathBuf};
+use pacquet_config::{Config, PmOnFail};
+use std::{
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+};
 use tempfile::TempDir;
 
 #[test]
@@ -21,13 +25,12 @@ fn version_argv_reads_dir_and_auth_file() {
 #[test]
 fn switch_target_prefers_locked_dev_engine_version() {
     let root = TempDir::new().expect("tmp dir");
-    fs::write(
-        root.path().join("package.json"),
+    write_manifest(
+        root.path(),
         r#"{"devEngines":{"packageManager":{"name":"pnpm","version":"^11.0.0-rc.5","onFail":"download"}}}"#,
-    )
-    .expect("write manifest");
-    fs::write(
-        root.path().join("pnpm-lock.yaml"),
+    );
+    write_lockfile(
+        root.path(),
         r"---
 lockfileVersion: '9.0'
 
@@ -58,8 +61,7 @@ snapshots:
   pnpm@11.1.2: {}
 ---
 ",
-    )
-    .expect("write lockfile");
+    );
 
     let target = switch_target(&Config::default(), root.path()).expect("target").expect("switch");
 
@@ -69,3 +71,283 @@ snapshots:
     };
     assert_eq!(version, "11.1.2");
 }
+
+#[test]
+fn switch_target_accepts_peer_suffixed_package_manager_lockfile() {
+    let root = TempDir::new().expect("tmp dir");
+    write_dev_engine_manifest(root.path(), "9.3.0");
+    write_lockfile(root.path(), LOCKED_9_3_0_WITH_PEER_SUFFIX);
+
+    let target = switch_target(&Config::default(), root.path()).expect("target").expect("switch");
+
+    let SwitchSource::LockedEnv { version, .. } = target.source else {
+        panic!("expected locked env target");
+    };
+    assert_eq!(version, "9.3.0");
+}
+
+#[test]
+fn switch_target_rejects_package_manager_lockfile_resolution_with_non_integrity_fields() {
+    let root = TempDir::new().expect("tmp dir");
+    write_dev_engine_manifest(root.path(), "9.3.0");
+    write_lockfile(root.path(), LOCKED_9_3_0_WITH_TARBALL_RESOLUTION);
+
+    let error = switch_target_error(root.path());
+
+    assert!(error.to_string().contains("integrity-only resolution"), "unexpected error: {error:?}");
+}
+
+#[test]
+fn switch_target_rejects_package_manager_lockfile_dependency_with_non_registry_dep_path() {
+    let root = TempDir::new().expect("tmp dir");
+    write_dev_engine_manifest(root.path(), "9.3.0");
+    write_lockfile(root.path(), LOCKED_9_3_0_WITH_FILE_DEP_PATH);
+
+    let error = switch_target_error(root.path());
+
+    assert!(error.to_string().contains("registry package path"), "unexpected error: {error:?}");
+}
+
+#[test]
+fn switch_target_reresolves_when_locked_version_no_longer_satisfies_range() {
+    let root = TempDir::new().expect("tmp dir");
+    write_dev_engine_manifest(root.path(), ">=9.1.2 <9.1.4");
+    write_lockfile(root.path(), LOCKED_9_1_1);
+
+    let target = switch_target(&Config::default(), root.path()).expect("target").expect("switch");
+
+    assert_eq!(target.spec, ">=9.1.2 <9.1.4");
+    let SwitchSource::Resolve { env_root } = target.source else {
+        panic!("expected resolve target");
+    };
+    assert_eq!(env_root, root.path());
+}
+
+#[test]
+fn switch_target_uses_global_env_for_legacy_package_manager_field() {
+    let root = TempDir::new().expect("tmp dir");
+    let global_pkg_dir = root.path().join("pnpm-home").join("global");
+    write_manifest(root.path(), r#"{"packageManager":"pnpm@9.3.0"}"#);
+
+    let target = switch_target(
+        &Config { global_pkg_dir: Some(global_pkg_dir.clone()), ..Config::default() },
+        root.path(),
+    )
+    .expect("target")
+    .expect("switch");
+
+    let SwitchSource::Resolve { env_root } = target.source else {
+        panic!("expected resolve target");
+    };
+    assert_eq!(target.spec, "9.3.0");
+    assert_eq!(env_root, global_pkg_dir);
+}
+
+#[test]
+fn switch_target_respects_pm_on_fail_ignore() {
+    let root = TempDir::new().expect("tmp dir");
+    write_manifest(root.path(), r#"{"packageManager":"pnpm@9.3.0"}"#);
+
+    let target = switch_target(
+        &Config {
+            pm_on_fail: Some(PmOnFail::Ignore),
+            global_pkg_dir: Some(root.path().join("pnpm-home").join("global")),
+            ..Config::default()
+        },
+        root.path(),
+    )
+    .expect("target");
+
+    assert!(target.is_none());
+}
+
+#[test]
+fn switch_target_does_not_switch_dev_engine_without_download() {
+    let root = TempDir::new().expect("tmp dir");
+    write_manifest(
+        root.path(),
+        r#"{"devEngines":{"packageManager":{"name":"pnpm","version":"9.3.0","onFail":"error"}}}"#,
+    );
+
+    let target = switch_target(&Config::default(), root.path()).expect("target");
+
+    assert!(target.is_none());
+}
+
+fn write_dev_engine_manifest(root: &Path, version: &str) {
+    write_manifest(
+        root,
+        &format!(
+            r#"{{"devEngines":{{"packageManager":{{"name":"pnpm","version":"{version}","onFail":"download"}}}}}}"#,
+        ),
+    );
+}
+
+fn write_manifest(root: &Path, content: &str) {
+    fs::write(root.join("package.json"), content).expect("write manifest");
+}
+
+fn write_lockfile(root: &Path, content: &str) {
+    fs::write(root.join("pnpm-lock.yaml"), content).expect("write lockfile");
+}
+
+fn switch_target_error(root: &Path) -> miette::Report {
+    match switch_target(&Config::default(), root) {
+        Ok(_) => panic!("expected poisoned lockfile to fail"),
+        Err(error) => error,
+    }
+}
+
+const LOCKED_9_3_0_WITH_PEER_SUFFIX: &str = r"---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 9.3.0
+        version: 9.3.0
+      pnpm:
+        specifier: 9.3.0
+        version: 9.3.0
+
+packages:
+
+  '@pnpm/exe@9.3.0':
+    resolution: {integrity: sha512-di6YvqPO/2jvih6kCJ8r0ySzQNjQWrBXPEfqEHtrmwOamuNALnfASwhFBwEtMjWmaA8QG7TqAg2qEvAe+8cBkQ==}
+
+  '@pnpm/linux-x64@9.3.0':
+    resolution: {integrity: sha512-di6YvqPO/2jvih6kCJ8r0ySzQNjQWrBXPEfqEHtrmwOamuNALnfASwhFBwEtMjWmaA8QG7TqAg2qEvAe+8cBkQ==}
+
+  peer-provider@1.0.0:
+    resolution: {integrity: sha512-di6YvqPO/2jvih6kCJ8r0ySzQNjQWrBXPEfqEHtrmwOamuNALnfASwhFBwEtMjWmaA8QG7TqAg2qEvAe+8cBkQ==}
+
+  pnpm@9.3.0:
+    resolution: {integrity: sha512-QVocwll0cx51RVwUaDcb50xapft2IbUNQFbSIkUWCfEUEvI/1gLmFp8eBgRmZB95hZfhvpYaEGiINqZ7FlaUmQ==}
+
+snapshots:
+
+  '@pnpm/exe@9.3.0':
+    optionalDependencies:
+      '@pnpm/linux-x64': 9.3.0(peer-provider@1.0.0)
+
+  '@pnpm/linux-x64@9.3.0(peer-provider@1.0.0)':
+    dependencies:
+      peer-provider: 1.0.0
+    optional: true
+
+  peer-provider@1.0.0: {}
+
+  pnpm@9.3.0: {}
+---
+";
+
+const LOCKED_9_3_0_WITH_TARBALL_RESOLUTION: &str = r"---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 9.3.0
+        version: 9.3.0
+      pnpm:
+        specifier: 9.3.0
+        version: 9.3.0
+
+packages:
+
+  '@pnpm/exe@9.3.0':
+    resolution: {integrity: sha512-di6YvqPO/2jvih6kCJ8r0ySzQNjQWrBXPEfqEHtrmwOamuNALnfASwhFBwEtMjWmaA8QG7TqAg2qEvAe+8cBkQ==}
+
+  '@pnpm/linux-x64@9.3.0':
+    resolution: {integrity: sha512-di6YvqPO/2jvih6kCJ8r0ySzQNjQWrBXPEfqEHtrmwOamuNALnfASwhFBwEtMjWmaA8QG7TqAg2qEvAe+8cBkQ==, tarball: https://evil.example.com/pnpm-linux-x64.tgz}
+
+  pnpm@9.3.0:
+    resolution: {integrity: sha512-QVocwll0cx51RVwUaDcb50xapft2IbUNQFbSIkUWCfEUEvI/1gLmFp8eBgRmZB95hZfhvpYaEGiINqZ7FlaUmQ==}
+
+snapshots:
+
+  '@pnpm/exe@9.3.0':
+    optionalDependencies:
+      '@pnpm/linux-x64': 9.3.0
+
+  '@pnpm/linux-x64@9.3.0':
+    optional: true
+
+  pnpm@9.3.0: {}
+---
+";
+
+const LOCKED_9_3_0_WITH_FILE_DEP_PATH: &str = r"---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 9.3.0
+        version: 9.3.0
+      pnpm:
+        specifier: 9.3.0
+        version: 9.3.0
+
+packages:
+
+  '@pnpm/exe@9.3.0':
+    resolution: {integrity: sha512-di6YvqPO/2jvih6kCJ8r0ySzQNjQWrBXPEfqEHtrmwOamuNALnfASwhFBwEtMjWmaA8QG7TqAg2qEvAe+8cBkQ==}
+
+  payload@file:../payload.tgz:
+    resolution: {integrity: sha512-di6YvqPO/2jvih6kCJ8r0ySzQNjQWrBXPEfqEHtrmwOamuNALnfASwhFBwEtMjWmaA8QG7TqAg2qEvAe+8cBkQ==}
+
+  pnpm@9.3.0:
+    resolution: {integrity: sha512-QVocwll0cx51RVwUaDcb50xapft2IbUNQFbSIkUWCfEUEvI/1gLmFp8eBgRmZB95hZfhvpYaEGiINqZ7FlaUmQ==}
+
+snapshots:
+
+  '@pnpm/exe@9.3.0': {}
+
+  payload@file:../payload.tgz: {}
+
+  pnpm@9.3.0:
+    dependencies:
+      payload: file:../payload.tgz
+---
+";
+
+const LOCKED_9_1_1: &str = r"---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: '>=9.1.0 <9.1.2'
+        version: 9.1.1
+      pnpm:
+        specifier: '>=9.1.0 <9.1.2'
+        version: 9.1.1
+
+packages:
+
+  '@pnpm/exe@9.1.1':
+    resolution: {integrity: sha512-di6YvqPO/2jvih6kCJ8r0ySzQNjQWrBXPEfqEHtrmwOamuNALnfASwhFBwEtMjWmaA8QG7TqAg2qEvAe+8cBkQ==}
+
+  pnpm@9.1.1:
+    resolution: {integrity: sha512-QVocwll0cx51RVwUaDcb50xapft2IbUNQFbSIkUWCfEUEvI/1gLmFp8eBgRmZB95hZfhvpYaEGiINqZ7FlaUmQ==}
+
+snapshots:
+
+  '@pnpm/exe@9.1.1': {}
+
+  pnpm@9.1.1: {}
+---
+";

--- a/pacquet/crates/cli/src/cli_args/switch_cli_version/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version/tests.rs
@@ -1,4 +1,5 @@
-use super::{SwitchInput, SwitchSource, switch_target};
+use super::{SwitchInput, SwitchProcessState, SwitchSource, switch_plan_from_input, switch_target};
+use crate::config_overrides::ConfigOverrides;
 use pacquet_config::{Config, PmOnFail};
 use std::{
     ffi::OsString,
@@ -68,6 +69,21 @@ fn version_argv_reads_dir_auth_file_and_command_forms() {
         );
         assert_eq!(input.command.as_deref(), case.command, "case: {}", case.name);
     }
+}
+
+#[test]
+fn switch_plan_skips_when_executed_by_corepack() {
+    let input =
+        SwitchInput { dir: PathBuf::from("missing-project"), npmrc_auth_file: None, command: None };
+
+    let plan = switch_plan_from_input(
+        &input,
+        &ConfigOverrides::default(),
+        SwitchProcessState { package_manager_switch_disabled: false, executed_by_corepack: true },
+    )
+    .expect("switch plan");
+
+    assert!(plan.is_none(), "unexpected switch plan when executed by Corepack");
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/switch_cli_version/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version/tests.rs
@@ -8,18 +8,66 @@ use std::{
 use tempfile::TempDir;
 
 #[test]
-fn version_argv_reads_dir_and_auth_file() {
-    let input = SwitchInput::from_version_argv(&[
-        OsString::from("pnpm"),
-        OsString::from("--dir"),
-        OsString::from("/tmp/project"),
-        OsString::from("--npmrc-auth-file=auth.ini"),
-        OsString::from("--version"),
-    ]);
+fn version_argv_reads_dir_auth_file_and_command_forms() {
+    struct Case {
+        name: &'static str,
+        argv: &'static [&'static str],
+        dir: &'static str,
+        npmrc_auth_file: Option<&'static str>,
+        command: Option<&'static str>,
+    }
 
-    assert_eq!(input.dir, PathBuf::from("/tmp/project"));
-    assert_eq!(input.npmrc_auth_file, Some(PathBuf::from("auth.ini")));
-    assert_eq!(input.command, None);
+    let cases = [
+        Case {
+            name: "separate long dir and equals auth file",
+            argv: &["pnpm", "--dir", "/tmp/project", "--npmrc-auth-file=auth.ini", "--version"],
+            dir: "/tmp/project",
+            npmrc_auth_file: Some("auth.ini"),
+            command: None,
+        },
+        Case {
+            name: "short dir",
+            argv: &["pnpm", "-C", "/tmp/short-dir", "--version"],
+            dir: "/tmp/short-dir",
+            npmrc_auth_file: None,
+            command: None,
+        },
+        Case {
+            name: "equals dir and userconfig alias",
+            argv: &["pnpm", "--dir=/tmp/equals-dir", "--userconfig", "user.ini", "--version"],
+            dir: "/tmp/equals-dir",
+            npmrc_auth_file: Some("user.ini"),
+            command: None,
+        },
+        Case {
+            name: "separator stops command detection",
+            argv: &["pnpm", "--dir=/tmp/separator", "--", "run"],
+            dir: "/tmp/separator",
+            npmrc_auth_file: None,
+            command: None,
+        },
+        Case {
+            name: "value-taking global option is skipped",
+            argv: &["pnpm", "--filter", "pkg", "--reporter", "append-only", "install"],
+            dir: ".",
+            npmrc_auth_file: None,
+            command: Some("install"),
+        },
+    ];
+
+    for case in cases {
+        let argv = case.argv.iter().copied().map(OsString::from).collect::<Vec<_>>();
+        let input = SwitchInput::from_version_argv(&argv);
+
+        assert_eq!(input.dir, PathBuf::from(case.dir), "case: {}", case.name);
+        assert_eq!(
+            input.npmrc_auth_file,
+            case.npmrc_auth_file.map(PathBuf::from),
+            "case: {}",
+            case.name,
+        );
+        assert_eq!(input.command.as_deref(), case.command, "case: {}", case.name);
+    }
 }
 
 #[test]
@@ -172,7 +220,7 @@ fn switch_target_respects_pm_on_fail_ignore() {
     )
     .expect("target");
 
-    assert!(target.is_none());
+    assert!(target.is_none(), "unexpected switch target: {target:?}");
 }
 
 #[test]
@@ -185,7 +233,7 @@ fn switch_target_does_not_switch_dev_engine_without_download() {
 
     let target = switch_target(&Config::default(), root.path()).expect("target");
 
-    assert!(target.is_none());
+    assert!(target.is_none(), "unexpected switch target: {target:?}");
 }
 
 fn write_dev_engine_manifest(root: &Path, version: &str) {

--- a/pacquet/crates/cli/src/cli_args/switch_cli_version/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version/tests.rs
@@ -87,6 +87,20 @@ fn switch_target_accepts_peer_suffixed_package_manager_lockfile() {
 }
 
 #[test]
+fn switch_target_accepts_v12_lockfile_without_legacy_wrapper_entry() {
+    let root = TempDir::new().expect("tmp dir");
+    write_manifest(root.path(), r#"{"packageManager":"pnpm@99.0.0"}"#);
+    write_lockfile(root.path(), LOCKED_99_0_0);
+
+    let target = switch_target(&Config::default(), root.path()).expect("target").expect("switch");
+
+    let SwitchSource::LockedEnv { version, .. } = target.source else {
+        panic!("expected locked env target");
+    };
+    assert_eq!(version, "99.0.0");
+}
+
+#[test]
 fn switch_target_rejects_package_manager_lockfile_resolution_with_non_integrity_fields() {
     let root = TempDir::new().expect("tmp dir");
     write_dev_engine_manifest(root.path(), "9.3.0");
@@ -349,5 +363,28 @@ snapshots:
   '@pnpm/exe@9.1.1': {}
 
   pnpm@9.1.1: {}
+---
+";
+
+const LOCKED_99_0_0: &str = r"---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 99.0.0
+        version: 99.0.0
+
+packages:
+
+  pnpm@99.0.0:
+    resolution: {integrity: sha512-QVocwll0cx51RVwUaDcb50xapft2IbUNQFbSIkUWCfEUEvI/1gLmFp8eBgRmZB95hZfhvpYaEGiINqZ7FlaUmQ==}
+
+snapshots:
+
+  pnpm@99.0.0: {}
 ---
 ";

--- a/pacquet/crates/cli/src/cli_args/switch_cli_version/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version/tests.rs
@@ -1,0 +1,71 @@
+use super::{SwitchInput, SwitchSource, switch_target};
+use pacquet_config::Config;
+use std::{ffi::OsString, fs, path::PathBuf};
+use tempfile::TempDir;
+
+#[test]
+fn version_argv_reads_dir_and_auth_file() {
+    let input = SwitchInput::from_version_argv(&[
+        OsString::from("pnpm"),
+        OsString::from("--dir"),
+        OsString::from("/tmp/project"),
+        OsString::from("--npmrc-auth-file=auth.ini"),
+        OsString::from("--version"),
+    ]);
+
+    assert_eq!(input.dir, PathBuf::from("/tmp/project"));
+    assert_eq!(input.npmrc_auth_file, Some(PathBuf::from("auth.ini")));
+    assert_eq!(input.command, None);
+}
+
+#[test]
+fn switch_target_prefers_locked_dev_engine_version() {
+    let root = TempDir::new().expect("tmp dir");
+    fs::write(
+        root.path().join("package.json"),
+        r#"{"devEngines":{"packageManager":{"name":"pnpm","version":"^11.0.0-rc.5","onFail":"download"}}}"#,
+    )
+    .expect("write manifest");
+    fs::write(
+        root.path().join("pnpm-lock.yaml"),
+        r"---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 11.1.2
+        version: 11.1.2
+      pnpm:
+        specifier: 11.1.2
+        version: 11.1.2
+
+packages:
+
+  '@pnpm/exe@11.1.2':
+    resolution: {integrity: sha512-di6YvqPO/2jvih6kCJ8r0ySzQNjQWrBXPEfqEHtrmwOamuNALnfASwhFBwEtMjWmaA8QG7TqAg2qEvAe+8cBkQ==}
+
+  pnpm@11.1.2:
+    resolution: {integrity: sha512-QVocwll0cx51RVwUaDcb50xapft2IbUNQFbSIkUWCfEUEvI/1gLmFp8eBgRmZB95hZfhvpYaEGiINqZ7FlaUmQ==}
+
+snapshots:
+
+  '@pnpm/exe@11.1.2': {}
+
+  pnpm@11.1.2: {}
+---
+",
+    )
+    .expect("write lockfile");
+
+    let target = switch_target(&Config::default(), root.path()).expect("target").expect("switch");
+
+    assert_eq!(target.spec, "^11.0.0-rc.5");
+    let SwitchSource::LockedEnv { version, .. } = target.source else {
+        panic!("expected locked env target");
+    };
+    assert_eq!(version, "11.1.2");
+}

--- a/pacquet/crates/cli/src/cli_args/with.rs
+++ b/pacquet/crates/cli/src/cli_args/with.rs
@@ -18,7 +18,7 @@ use pacquet_config::Config;
 use pacquet_reporter::Reporter;
 use std::{ffi::OsString, fs, path::Path, process::Command};
 
-use crate::config_deps;
+use crate::{cli_args::package_manager::PACKAGE_MANAGER_SWITCH_ENV_VARS, config_deps};
 
 /// Errors specific to `pacquet with`. The codes carry the shared
 /// `ERR_PNPM_` prefix.
@@ -134,7 +134,7 @@ where
     cmd.env_remove("PATH");
     cmd.env_remove("Path");
     cmd.env("PATH", &path);
-    cmd.env("npm_config_manage_package_manager_versions", "false");
+    disable_package_manager_switching(&mut cmd);
     if matches!(package_manager_check, PackageManagerCheck::Disabled) {
         // The child pnpm must skip the packageManager / devEngines check so the
         // requested version stays active. `COREPACK_ROOT` is honored by every
@@ -148,6 +148,12 @@ where
     }
 
     cmd.status().into_diagnostic().wrap_err("run the requested pnpm version")
+}
+
+fn disable_package_manager_switching(cmd: &mut Command) {
+    for name in PACKAGE_MANAGER_SWITCH_ENV_VARS {
+        cmd.env(name, "false");
+    }
 }
 
 /// Prepend `dir` to the current process `PATH`, rejecting a `dir` that

--- a/pacquet/crates/cli/src/cli_args/with.rs
+++ b/pacquet/crates/cli/src/cli_args/with.rs
@@ -9,7 +9,7 @@
 //! version / range / dist-tag spec, which it resolves, installs into the
 //! global virtual store, and spawns.
 
-mod install_pnpm_to_store;
+pub(crate) mod install_pnpm_to_store;
 
 use clap::Args;
 use derive_more::{Display, Error};
@@ -90,7 +90,7 @@ impl WithArgs {
         ))
         .await?;
 
-        let status = spawn_pnpm(&bin_dir, args)?;
+        let status = spawn_pnpm(&bin_dir, args, PackageManagerCheck::Disabled)?;
         if !status.success() {
             // Propagate the child's exit code. A signal-terminated child
             // has no code; fall back to 1, matching pnpm's `exitCode ?? 1`.
@@ -100,9 +100,23 @@ impl WithArgs {
     }
 }
 
-/// Spawn the downloaded `pnpm` with `bin_dir` prepended to `PATH` and the
-/// child's package-manager check disabled, inheriting stdio.
-fn spawn_pnpm(bin_dir: &Path, args: &[String]) -> miette::Result<std::process::ExitStatus> {
+#[derive(Clone, Copy)]
+pub(crate) enum PackageManagerCheck {
+    Enabled,
+    Disabled,
+}
+
+/// Spawn the downloaded `pnpm` with `bin_dir` prepended to `PATH`,
+/// inheriting stdio.
+pub(crate) fn spawn_pnpm<Args, Arg>(
+    bin_dir: &Path,
+    args: Args,
+    package_manager_check: PackageManagerCheck,
+) -> miette::Result<std::process::ExitStatus>
+where
+    Args: IntoIterator<Item = Arg>,
+    Arg: AsRef<std::ffi::OsStr>,
+{
     let path = prepend_to_path(bin_dir)?;
     // Resolve `pnpm` strictly within `bin_dir`, never the full PATH, so a
     // missing or broken shim is an error rather than silently falling
@@ -120,15 +134,18 @@ fn spawn_pnpm(bin_dir: &Path, args: &[String]) -> miette::Result<std::process::E
     cmd.env_remove("PATH");
     cmd.env_remove("Path");
     cmd.env("PATH", &path);
-    // The child pnpm must skip the packageManager / devEngines check so the
-    // requested version stays active. `COREPACK_ROOT` is honored by every
-    // pnpm release that supports corepack (older versions skip the check
-    // whenever it is set); `pnpm_config_pm_on_fail=ignore` is the
-    // principled override for releases that ship the `pmOnFail` setting.
-    if std::env::var_os("COREPACK_ROOT").is_none() {
-        cmd.env("COREPACK_ROOT", "pnpm-with");
+    cmd.env("npm_config_manage_package_manager_versions", "false");
+    if matches!(package_manager_check, PackageManagerCheck::Disabled) {
+        // The child pnpm must skip the packageManager / devEngines check so the
+        // requested version stays active. `COREPACK_ROOT` is honored by every
+        // pnpm release that supports corepack (older versions skip the check
+        // whenever it is set); `pnpm_config_pm_on_fail=ignore` is the
+        // principled override for releases that ship the `pmOnFail` setting.
+        if std::env::var_os("COREPACK_ROOT").is_none() {
+            cmd.env("COREPACK_ROOT", "pnpm-with");
+        }
+        cmd.env("pnpm_config_pm_on_fail", "ignore");
     }
-    cmd.env("pnpm_config_pm_on_fail", "ignore");
 
     cmd.status().into_diagnostic().wrap_err("run the requested pnpm version")
 }

--- a/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
+++ b/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
@@ -238,28 +238,4 @@ fn unique_suffix() -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn cache_hit_relinks_missing_pnpm_bin() {
-        let root = tempfile::TempDir::new().expect("tmp dir");
-        let slot = root.path().join("slot");
-        let pkg_dir = package_dir(&slot, "pnpm");
-        fs::create_dir_all(pkg_dir.join("bin")).expect("create package bin dir");
-        fs::write(
-            pkg_dir.join("package.json"),
-            r#"{"name":"pnpm","version":"6.16.0","bin":{"pnpm":"bin/pnpm.cjs"}}"#,
-        )
-        .expect("write manifest");
-        fs::write(pkg_dir.join("bin").join("pnpm.cjs"), "#!/usr/bin/env node\n")
-            .expect("write pnpm bin");
-        let bin_dir = slot.join("bin");
-        fs::create_dir_all(&bin_dir).expect("create stale bin dir");
-
-        let linked = link_cached_engine_bins(&slot, "pnpm", false).expect("link bins");
-
-        assert_eq!(linked, bin_dir);
-        assert!(bin_dir.join("pnpm").exists());
-    }
-}
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
+++ b/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
@@ -15,6 +15,7 @@ use pacquet_graph_hasher::{detect_node_major, engine_name};
 use pacquet_lockfile::{EnvLockfile, PackageKey};
 use pacquet_package_manager::{AllowBuildPolicy, VirtualStoreLayout};
 use pacquet_reporter::Reporter;
+use pacquet_store_dir::StoreDir;
 use serde_json::Value;
 use std::{
     fs,
@@ -46,6 +47,7 @@ pub(crate) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
     spec: &str,
     version: &str,
 ) -> miette::Result<PathBuf> {
+    let config = package_manager_engine_config(config)?.leak();
     fs::create_dir_all(env_root).into_diagnostic().wrap_err_with(|| {
         format!("create the package-manager env directory at {}", env_root.display())
     })?;
@@ -62,6 +64,15 @@ pub(crate) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
 }
 
 pub(crate) async fn install_pnpm_from_env<Reporter: self::Reporter + 'static>(
+    config: &'static Config,
+    env: &EnvLockfile,
+    version: &str,
+) -> miette::Result<PathBuf> {
+    let config = package_manager_engine_config(config)?.leak();
+    install_pnpm_from_env_with_config::<Reporter>(config, env, version).await
+}
+
+async fn install_pnpm_from_env_with_config<Reporter: self::Reporter + 'static>(
     config: &'static Config,
     env: &EnvLockfile,
     version: &str,
@@ -123,6 +134,26 @@ pub(crate) async fn install_pnpm_from_env<Reporter: self::Reporter + 'static>(
     }
     link_bins(&pkg_dir, &bin_dir)?;
     Ok(bin_dir)
+}
+
+fn package_manager_engine_config(config: &Config) -> miette::Result<Config> {
+    let global_pkg_dir = config.global_pkg_dir.as_ref().ok_or_else(|| {
+        miette::miette!(
+            r#"Unable to find the global packages directory. Run "pnpm setup" to create it automatically, or set the global-bin-dir setting, or the PNPM_HOME env variable."#,
+        )
+    })?;
+    let mut config = config.clone();
+    config.store_dir = StoreDir::new(package_manager_engine_store_root(global_pkg_dir));
+    config.global_virtual_store_dir = config.store_dir.links();
+    Ok(config)
+}
+
+fn package_manager_engine_store_root(global_pkg_dir: &Path) -> PathBuf {
+    global_pkg_dir
+        .parent()
+        .and_then(Path::parent)
+        .unwrap_or(global_pkg_dir)
+        .join("package-manager-store")
 }
 
 fn link_cached_engine_bins(

--- a/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
+++ b/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
@@ -33,21 +33,19 @@ use crate::{
     config_deps,
 };
 
-/// Install `pnpm@<version>` into the global virtual store and return the
-/// directory holding the linked `pnpm` binary.
+/// Install the pnpm engine for `version` into the global virtual store and
+/// return the directory holding the linked `pnpm` binary.
 ///
 /// `env_root` is where the package-manager env lockfile (the resolved
 /// `pnpm` + `@pnpm/exe` closure) is written, under the pnpm home
 /// directory. `spec` is the user's bare specifier (a version, range,
 /// or dist-tag) and `version` the exact version it resolved to.
-pub(super) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
+pub(crate) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
     config: &'static Config,
     env_root: &Path,
     spec: &str,
     version: &str,
 ) -> miette::Result<PathBuf> {
-    let package = pnpm_package_to_install(version);
-    let package_name = package.name;
     // Resolve the package-manager closure into the env lockfile (a no-op
     // when this spec+version is already recorded there).
     config_deps::sync_package_manager_dependencies(config, env_root, spec, version, false).await?;
@@ -57,14 +55,23 @@ pub(super) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
         .ok_or_else(|| {
             miette::miette!("the package-manager env lockfile is missing after resolution")
         })?;
+    install_pnpm_from_env::<Reporter>(config, &env, version).await
+}
 
+pub(crate) async fn install_pnpm_from_env<Reporter: self::Reporter + 'static>(
+    config: &'static Config,
+    env: &EnvLockfile,
+    version: &str,
+) -> miette::Result<PathBuf> {
+    let package = pnpm_package_to_install(version);
+    let package_name = package.name;
     // Cache hit: when the engine already sits in its GVS slot, skip both
     // the signature check and the install — short-circuit on the engine's
     // `package.json` already existing. The slot is computed
     // with the same hashing the install pipeline uses, so a stale or wrong
     // computation merely misses the cache (the idempotent install below
     // then re-derives the slot from the install's own symlink).
-    if let Some(slot) = compute_engine_slot(config, &env, package_name, version) {
+    if let Some(slot) = compute_engine_slot(config, env, package_name, version) {
         let pkg_dir = package_dir(&slot, package_name);
         let bin_dir = slot.join("bin");
         if pkg_dir.join("package.json").exists() {
@@ -80,7 +87,7 @@ pub(super) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
 
     // Genuine download: verify the engine's registry signature before
     // installing or executing it.
-    verify_pnpm_engine_identity(&env, version, config)
+    verify_pnpm_engine_identity(env, version, config)
         .await
         .map_err(miette::Report::new)
         .wrap_err("verify the pnpm engine identity")?;

--- a/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
+++ b/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
@@ -46,6 +46,9 @@ pub(crate) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
     spec: &str,
     version: &str,
 ) -> miette::Result<PathBuf> {
+    fs::create_dir_all(env_root).into_diagnostic().wrap_err_with(|| {
+        format!("create the package-manager env directory at {}", env_root.display())
+    })?;
     // Resolve the package-manager closure into the env lockfile (a no-op
     // when this spec+version is already recorded there).
     config_deps::sync_package_manager_dependencies(config, env_root, spec, version, false).await?;

--- a/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
+++ b/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
@@ -76,15 +76,8 @@ pub(crate) async fn install_pnpm_from_env<Reporter: self::Reporter + 'static>(
     // then re-derives the slot from the install's own symlink).
     if let Some(slot) = compute_engine_slot(config, env, package_name, version) {
         let pkg_dir = package_dir(&slot, package_name);
-        let bin_dir = slot.join("bin");
         if pkg_dir.join("package.json").exists() {
-            if package.links_native_binary {
-                link_exe_platform_binary(&slot, package_name)?;
-            }
-            if !bin_dir.exists() {
-                link_bins(&pkg_dir, &bin_dir)?;
-            }
-            return Ok(bin_dir);
+            return link_cached_engine_bins(&slot, package_name, package.links_native_binary);
         }
     }
 
@@ -127,6 +120,20 @@ pub(crate) async fn install_pnpm_from_env<Reporter: self::Reporter + 'static>(
         // Replicate the wrapper's preinstall (skipped because the engine is
         // installed with scripts disabled): link the host's native binary.
         link_exe_platform_binary(&slot, package_name)?;
+    }
+    link_bins(&pkg_dir, &bin_dir)?;
+    Ok(bin_dir)
+}
+
+fn link_cached_engine_bins(
+    slot: &Path,
+    package_name: &str,
+    links_native_binary: bool,
+) -> miette::Result<PathBuf> {
+    let pkg_dir = package_dir(slot, package_name);
+    let bin_dir = slot.join("bin");
+    if links_native_binary {
+        link_exe_platform_binary(slot, package_name)?;
     }
     link_bins(&pkg_dir, &bin_dir)?;
     Ok(bin_dir)
@@ -228,4 +235,31 @@ fn unique_suffix() -> String {
     let nanos =
         SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |elapsed| elapsed.as_nanos());
     format!("{}-{nanos}", std::process::id())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_hit_relinks_missing_pnpm_bin() {
+        let root = tempfile::TempDir::new().expect("tmp dir");
+        let slot = root.path().join("slot");
+        let pkg_dir = package_dir(&slot, "pnpm");
+        fs::create_dir_all(pkg_dir.join("bin")).expect("create package bin dir");
+        fs::write(
+            pkg_dir.join("package.json"),
+            r#"{"name":"pnpm","version":"6.16.0","bin":{"pnpm":"bin/pnpm.cjs"}}"#,
+        )
+        .expect("write manifest");
+        fs::write(pkg_dir.join("bin").join("pnpm.cjs"), "#!/usr/bin/env node\n")
+            .expect("write pnpm bin");
+        let bin_dir = slot.join("bin");
+        fs::create_dir_all(&bin_dir).expect("create stale bin dir");
+
+        let linked = link_cached_engine_bins(&slot, "pnpm", false).expect("link bins");
+
+        assert_eq!(linked, bin_dir);
+        assert!(bin_dir.join("pnpm").exists());
+    }
 }

--- a/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store/tests.rs
@@ -1,0 +1,24 @@
+use super::{link_cached_engine_bins, package_dir};
+use std::fs;
+
+#[test]
+fn cache_hit_relinks_missing_pnpm_bin() {
+    let root = tempfile::TempDir::new().expect("tmp dir");
+    let slot = root.path().join("slot");
+    let pkg_dir = package_dir(&slot, "pnpm");
+    fs::create_dir_all(pkg_dir.join("bin")).expect("create package bin dir");
+    fs::write(
+        pkg_dir.join("package.json"),
+        r#"{"name":"pnpm","version":"6.16.0","bin":{"pnpm":"bin/pnpm.cjs"}}"#,
+    )
+    .expect("write manifest");
+    fs::write(pkg_dir.join("bin").join("pnpm.cjs"), "#!/usr/bin/env node\n")
+        .expect("write pnpm bin");
+    let bin_dir = slot.join("bin");
+    fs::create_dir_all(&bin_dir).expect("create stale bin dir");
+
+    let linked = link_cached_engine_bins(&slot, "pnpm", false).expect("link bins");
+
+    assert_eq!(linked, bin_dir);
+    assert!(bin_dir.join("pnpm").exists());
+}

--- a/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/with/install_pnpm_to_store/tests.rs
@@ -1,5 +1,8 @@
-use super::{link_cached_engine_bins, package_dir};
-use std::fs;
+use super::{link_cached_engine_bins, package_dir, package_manager_engine_config};
+use pacquet_config::Config;
+use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
+use pacquet_store_dir::StoreDir;
+use std::{fs, path::Path};
 
 #[test]
 fn cache_hit_relinks_missing_pnpm_bin() {
@@ -20,5 +23,92 @@ fn cache_hit_relinks_missing_pnpm_bin() {
     let linked = link_cached_engine_bins(&slot, "pnpm", false).expect("link bins");
 
     assert_eq!(linked, bin_dir);
-    assert!(bin_dir.join("pnpm").exists());
+    let pnpm_bin = bin_dir.join("pnpm");
+    assert!(pnpm_bin.exists(), "expected pnpm bin at {}", pnpm_bin.display());
+}
+
+#[test]
+fn cache_hit_relinks_legacy_wrapper_native_binary() {
+    let root = tempfile::TempDir::new().expect("tmp dir");
+    let slot = root.path().join("slot");
+    let pkg_dir = package_dir(&slot, "@pnpm/exe");
+    fs::create_dir_all(&pkg_dir).expect("create wrapper dir");
+    fs::write(
+        pkg_dir.join("package.json"),
+        r#"{"name":"@pnpm/exe","version":"11.1.2","bin":{"pnpm":"pnpm"}}"#,
+    )
+    .expect("write manifest");
+    write_host_native_binaries(&slot);
+    let bin_dir = slot.join("bin");
+    fs::create_dir_all(&bin_dir).expect("create stale bin dir");
+
+    let linked = link_cached_engine_bins(&slot, "@pnpm/exe", true).expect("link bins");
+
+    assert_eq!(linked, bin_dir);
+    let wrapper_bin = pkg_dir.join(host_executable());
+    assert!(wrapper_bin.exists(), "expected native wrapper at {}", wrapper_bin.display());
+    let pnpm_bin = bin_dir.join("pnpm");
+    assert!(pnpm_bin.exists(), "expected pnpm bin at {}", pnpm_bin.display());
+}
+
+#[test]
+fn package_manager_engine_config_uses_global_store() {
+    let root = tempfile::TempDir::new().expect("tmp dir");
+    let project_store_root = root.path().join("repo-controlled-store");
+    let global_pkg_dir = root.path().join("pnpm-home").join("global").join("v11");
+    let config = Config {
+        global_pkg_dir: Some(global_pkg_dir),
+        store_dir: StoreDir::new(&project_store_root),
+        ..Config::default()
+    };
+
+    let engine_config = package_manager_engine_config(&config).expect("engine config");
+
+    let expected_store_root =
+        root.path().join("pnpm-home").join("package-manager-store").join("v11");
+    assert_eq!(engine_config.store_dir.root(), expected_store_root.as_path());
+    assert!(
+        !engine_config.store_dir.root().starts_with(&project_store_root),
+        "engine store must not use project store at {}",
+        project_store_root.display(),
+    );
+}
+
+fn write_host_native_binaries(slot: &Path) {
+    let executable = host_executable();
+    for platform_dir_name in platform_package_dir_names() {
+        let platform_dir = slot.join("node_modules").join("@pnpm").join(platform_dir_name);
+        fs::create_dir_all(&platform_dir).expect("create platform dir");
+        fs::write(platform_dir.join(executable), b"#!/bin/sh\necho pnpm\n")
+            .expect("write native binary");
+    }
+}
+
+fn host_executable() -> &'static str {
+    if host_platform() == "win32" { "pnpm.exe" } else { "pnpm" }
+}
+
+fn platform_package_dir_names() -> [String; 2] {
+    let platform = host_platform();
+    let architecture = normalized_arch(platform, host_arch());
+    let libc = host_libc();
+    let legacy_platform = match platform {
+        "darwin" => "macos",
+        "win32" => "win",
+        "linux" if libc == "musl" => "linuxstatic",
+        "linux" => "linux",
+        other => other,
+    };
+    let libc_suffix = if platform == "linux" && libc == "musl" { "-musl" } else { "" };
+    [
+        format!("{legacy_platform}-{architecture}"),
+        format!("exe.{platform}-{architecture}{libc_suffix}"),
+    ]
+}
+
+fn normalized_arch<'architecture>(
+    platform: &str,
+    architecture: &'architecture str,
+) -> &'architecture str {
+    if platform == "win32" && architecture == "ia32" { "x86" } else { architecture }
 }

--- a/pacquet/crates/cli/src/cli_args/with/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/with/tests.rs
@@ -26,12 +26,23 @@ fn child_pnpm_disables_all_package_manager_switch_env_variants() {
     disable_package_manager_switching(&mut command);
 
     for name in PACKAGE_MANAGER_SWITCH_ENV_VARS {
-        let value = command
-            .get_envs()
-            .find(|(key, _)| *key == OsStr::new(name))
-            .and_then(|(_, value)| value);
+        let value = command_env_value(&command, name);
         assert_eq!(value, Some(OsStr::new("false")), "expected {name}=false");
     }
+}
+
+fn command_env_value<'command>(command: &'command Command, name: &str) -> Option<&'command OsStr> {
+    command.get_envs().find(|(key, _)| env_key_matches(key, name)).and_then(|(_, value)| value)
+}
+
+#[cfg(windows)]
+fn env_key_matches(key: &OsStr, name: &str) -> bool {
+    key.to_str().is_some_and(|key| key.eq_ignore_ascii_case(name))
+}
+
+#[cfg(not(windows))]
+fn env_key_matches(key: &OsStr, name: &str) -> bool {
+    key == OsStr::new(name)
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/with/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/with/tests.rs
@@ -1,6 +1,9 @@
-use super::{WithError, prepend_to_path};
-use crate::cli_args::with::install_pnpm_to_store::slot_from_package_dir;
-use std::path::Path;
+use super::{WithError, disable_package_manager_switching, prepend_to_path};
+use crate::cli_args::{
+    package_manager::PACKAGE_MANAGER_SWITCH_ENV_VARS,
+    with::install_pnpm_to_store::slot_from_package_dir,
+};
+use std::{ffi::OsStr, path::Path, process::Command};
 
 #[test]
 fn prepend_to_path_rejects_a_delimiter_in_the_bin_dir() {
@@ -14,6 +17,21 @@ fn prepend_to_path_accepts_a_normal_bin_dir() {
     let dir = if cfg!(windows) { r"C:\store\bin" } else { "/store/bin" };
     let path = prepend_to_path(Path::new(dir)).expect("a normal dir is accepted");
     assert!(path.to_string_lossy().starts_with(dir));
+}
+
+#[test]
+fn child_pnpm_disables_all_package_manager_switch_env_variants() {
+    let mut command = Command::new("pnpm");
+
+    disable_package_manager_switching(&mut command);
+
+    for name in PACKAGE_MANAGER_SWITCH_ENV_VARS {
+        let value = command
+            .get_envs()
+            .find(|(key, _)| *key == OsStr::new(name))
+            .and_then(|(_, value)| value);
+        assert_eq!(value, Some(OsStr::new("false")), "expected {name}=false");
+    }
 }
 
 #[test]

--- a/pacquet/crates/cli/src/lib.rs
+++ b/pacquet/crates/cli/src/lib.rs
@@ -44,13 +44,12 @@ pub fn main() -> miette::Result<()> {
         Ok(args) => args,
         // pnpm prints the bare version, not clap's "pnpm <version>" rendering.
         Err(err) if err.kind() == clap::error::ErrorKind::DisplayVersion => {
-            if block_on_runtime(
+            if let Some(plan) = cli_args::switch_cli_version::switch_plan_for_version_flag(
+                &argv,
+                &config_overrides,
+            )? && block_on_runtime(
                 "pacquet-switch",
-                cli_args::switch_cli_version::maybe_switch_for_version_flag(
-                    &argv,
-                    &config_overrides,
-                    &child_argv,
-                ),
+                cli_args::switch_cli_version::execute_switch(plan, &child_argv),
             )? {
                 return Ok(());
             }
@@ -60,10 +59,12 @@ pub fn main() -> miette::Result<()> {
         Err(err) => err.exit(),
     };
     args.promote_recursive_for_filter();
-    if block_on_runtime(
-        "pacquet-switch",
-        cli_args::switch_cli_version::maybe_switch(&args, &config_overrides, &child_argv),
-    )? {
+    if let Some(plan) = cli_args::switch_cli_version::switch_plan(&args, &config_overrides)?
+        && block_on_runtime(
+            "pacquet-switch",
+            cli_args::switch_cli_version::execute_switch(plan, &child_argv),
+        )?
+    {
         return Ok(());
     }
     // An up-to-date `pacquet install` finishes here, without paying for

--- a/pacquet/crates/cli/src/lib.rs
+++ b/pacquet/crates/cli/src/lib.rs
@@ -13,7 +13,7 @@ use config_overrides::ConfigOverrides;
 use miette::set_panic_hook;
 use pacquet_diagnostics::enable_tracing_by_env;
 use state::State;
-use std::{ffi::OsString, path::Path};
+use std::{ffi::OsString, future::Future, path::Path};
 
 pub fn main() -> miette::Result<()> {
     enable_tracing_by_env();
@@ -23,7 +23,9 @@ pub fn main() -> miette::Result<()> {
     // arbitrary, so a `--config.registry=...` from pnpm's forwarded flags
     // would otherwise error out as "unexpected argument". Each extracted
     // token is layered onto `Config` after `.npmrc` / yaml run.
-    let (config_overrides, argv) = ConfigOverrides::extract(argv_with_alias_subcommand());
+    let argv_with_alias = argv_with_alias_subcommand();
+    let child_argv = argv_with_alias.iter().skip(1).cloned().collect::<Vec<_>>();
+    let (config_overrides, argv) = ConfigOverrides::extract(argv_with_alias);
     // `pnpm with current <cmd>` is sugar for running `<cmd>` in-process with
     // the packageManager / devEngines check disabled; rewrite argv before
     // clap parses it. A version spec (`pnpm with 10 <cmd>`) is left for the
@@ -36,18 +38,34 @@ pub fn main() -> miette::Result<()> {
     // every boolean flag, so pnpm's forwarded negations (`--no-frozen-lockfile`,
     // etc.) parse the same way nopt accepts them upstream. See `boolean_negations`.
     let mut args = match with_boolean_negations(CliArgs::command())
-        .try_get_matches_from(argv)
+        .try_get_matches_from(argv.clone())
         .and_then(|matches| CliArgs::from_arg_matches(&matches))
     {
         Ok(args) => args,
         // pnpm prints the bare version, not clap's "pnpm <version>" rendering.
         Err(err) if err.kind() == clap::error::ErrorKind::DisplayVersion => {
+            if block_on_runtime(
+                "pacquet-switch",
+                cli_args::switch_cli_version::maybe_switch_for_version_flag(
+                    &argv,
+                    &config_overrides,
+                    &child_argv,
+                ),
+            )? {
+                return Ok(());
+            }
             println!("{}", pacquet_config::PACQUET_VERSION);
             return Ok(());
         }
         Err(err) => err.exit(),
     };
     args.promote_recursive_for_filter();
+    if block_on_runtime(
+        "pacquet-switch",
+        cli_args::switch_cli_version::maybe_switch(&args, &config_overrides, &child_argv),
+    )? {
+        return Ok(());
+    }
     // An up-to-date `pacquet install` finishes here, without paying for
     // the runtime, the HTTP client, or any worker threads.
     if args.finished_via_install_fast_path(&config_overrides) {
@@ -67,29 +85,40 @@ pub fn main() -> miette::Result<()> {
     // default to 8 MiB, so the limit trips on Windows first). Run it on a
     // thread with a generous, platform-uniform stack instead of the OS
     // default main-thread stack.
-    std::thread::Builder::new()
-        .name("pacquet-main".to_string())
-        .stack_size(MAIN_STACK_SIZE)
-        .spawn(move || {
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .expect("build the tokio runtime")
-                // Boxed for `clippy::large_futures`: the command future
-                // exceeds the lint's stack-size threshold.
-                .block_on(Box::pin(args.run(&config_overrides)))
-        })
-        .expect("spawn the pacquet-main thread")
-        .join()
-        // Re-raise a panic from the worker on this thread so the process
-        // still aborts with the original message and backtrace.
-        .unwrap_or_else(|payload| std::panic::resume_unwind(payload))
+    block_on_runtime("pacquet-main", args.run(&config_overrides))
 }
 
 /// Stack size for the thread the command runs on. Generous headroom over
 /// the 8 MiB Linux/macOS default so the deep install call chain has the
 /// same room on every platform, including Windows (1 MiB default).
 const MAIN_STACK_SIZE: usize = 32 * 1024 * 1024;
+
+fn block_on_runtime<Work, Output>(thread_name: &str, work: Work) -> Output
+where
+    Work: Future<Output = Output> + Send,
+    Output: Send,
+{
+    std::thread::scope(|scope| {
+        let handle = std::thread::Builder::new()
+            .name(thread_name.to_string())
+            .stack_size(MAIN_STACK_SIZE)
+            .spawn_scoped(scope, move || {
+                tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build the tokio runtime")
+                    // Boxed for `clippy::large_futures`: the command future
+                    // exceeds the lint's stack-size threshold.
+                    .block_on(Box::pin(work))
+            })
+            .expect("spawn the pacquet runtime thread");
+        handle
+            .join()
+            // Re-raise a panic from the worker on this thread so the process
+            // still aborts with the original message and backtrace.
+            .unwrap_or_else(|payload| std::panic::resume_unwind(payload))
+    })
+}
 
 /// Process argv with a leading `dlx` injected when launched as `pnpx`/`pnx`
 /// (shorthand for `pnpm dlx`), mirroring pnpm's `buildArgv`. Only the Windows

--- a/pacquet/crates/cli/tests/version.rs
+++ b/pacquet/crates/cli/tests/version.rs
@@ -1,6 +1,7 @@
 use command_extra::CommandExtra;
-use pacquet_testing_utils::bin::CommandTempCwd;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use pretty_assertions::assert_eq;
+use std::{fs, path::Path, process::Command};
 
 #[test]
 fn version_flag_prints_the_bare_version() {
@@ -30,4 +31,34 @@ fn short_version_flag_prints_the_bare_version() {
     );
 
     drop(root);
+}
+
+#[test]
+fn version_flag_switches_to_project_package_manager_version() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(workspace.join("package.json"), r#"{"packageManager":"pnpm@9.3.0"}"#)
+        .expect("write package.json");
+
+    let output = test_command(pacquet, root.path())
+        .env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .args(["--version"])
+        .output()
+        .expect("run pacquet --version");
+    dbg!(&output);
+    assert!(output.status.success(), "pacquet --version should succeed");
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "9.3.0\n");
+
+    drop((root, mock_instance));
+}
+
+fn test_command(mut command: Command, root: &Path) -> Command {
+    command.env("PNPM_HOME", root.join("pnpm-home"));
+    command.env("HOME", root);
+    command.env("XDG_CONFIG_HOME", root.join("xdg-config"));
+    command.env_remove("COREPACK_ROOT");
+    command.env_remove("pnpm_config_pm_on_fail");
+    command.env_remove("PNPM_CONFIG_PM_ON_FAIL");
+    command
 }

--- a/pacquet/crates/lockfile/Cargo.toml
+++ b/pacquet/crates/lockfile/Cargo.toml
@@ -19,6 +19,7 @@ pacquet-package-manifest = { workspace = true }
 
 derive_more      = { workspace = true }
 indexmap         = { workspace = true }
+libc             = { workspace = true }
 node-semver      = { workspace = true }
 pipe-trait       = { workspace = true }
 serde            = { workspace = true }

--- a/pacquet/crates/lockfile/Cargo.toml
+++ b/pacquet/crates/lockfile/Cargo.toml
@@ -14,6 +14,7 @@ repository.workspace  = true
 pacquet-catalogs-types   = { workspace = true }
 pacquet-crypto-hash      = { workspace = true }
 pacquet-diagnostics      = { workspace = true }
+pacquet-fs               = { workspace = true }
 pacquet-package-manifest = { workspace = true }
 
 derive_more      = { workspace = true }

--- a/pacquet/crates/lockfile/src/env_lockfile.rs
+++ b/pacquet/crates/lockfile/src/env_lockfile.rs
@@ -21,10 +21,13 @@ use pacquet_fs::write_atomic;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap},
-    fs,
-    io::{self, ErrorKind},
+    fs::{self, File},
+    io::{self, ErrorKind, Read as _},
     path::Path,
 };
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt as _;
 
 /// The resolved `{ specifier, version }` pair recorded for each config
 /// (or package-manager) dependency under an importer.
@@ -104,11 +107,10 @@ impl EnvLockfile {
     ///   importer (and its `configDependencies` map) exists.
     pub fn read(root_dir: &Path) -> Result<Option<Self>, LoadLockfileError> {
         let path = root_dir.join(Lockfile::FILE_NAME);
-        ensure_lockfile_is_not_symlink(&path).map_err(LoadLockfileError::ReadFile)?;
-        let content = match fs::read_to_string(&path) {
-            Ok(content) => content,
-            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
-            Err(error) => return Err(LoadLockfileError::ReadFile(error)),
+        let Some(content) =
+            read_lockfile_to_string_no_follow(&path).map_err(LoadLockfileError::ReadFile)?
+        else {
+            return Ok(None);
         };
         let Some(env_doc) = extract_env_document(&content) else {
             return Ok(None);
@@ -126,27 +128,64 @@ impl EnvLockfile {
         let path = root_dir.join(Lockfile::FILE_NAME);
         ensure_lockfile_is_not_symlink(&path).map_err(SaveLockfileError::WriteFile)?;
         let env_yaml = serialize_yaml::to_string(self).map_err(SaveLockfileError::SerializeYaml)?;
-        let main_doc = match fs::read_to_string(&path) {
-            Ok(existing) => extract_main_document(&existing).to_string(),
-            Err(error) if error.kind() == ErrorKind::NotFound => String::new(),
-            Err(error) => return Err(SaveLockfileError::WriteFile(error)),
-        };
+        let main_doc = read_lockfile_to_string_no_follow(&path)
+            .map_err(SaveLockfileError::WriteFile)?
+            .map_or_else(String::new, |existing| extract_main_document(&existing).to_string());
         let combined =
             format!("{YAML_DOCUMENT_START}{env_yaml}{YAML_DOCUMENT_SEPARATOR}{main_doc}");
         write_atomic(&path, combined.as_bytes()).map_err(SaveLockfileError::WriteFile)
     }
 }
 
+fn read_lockfile_to_string_no_follow(path: &Path) -> io::Result<Option<String>> {
+    let mut file = match open_lockfile_no_follow(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let mut content = String::new();
+    #[expect(
+        clippy::verbose_file_reads,
+        reason = "Reading from the no-follow file handle avoids reopening the lockfile by path."
+    )]
+    file.read_to_string(&mut content)?;
+    Ok(Some(content))
+}
+
+#[cfg(unix)]
+fn open_lockfile_no_follow(path: &Path) -> io::Result<File> {
+    fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|error| normalize_no_follow_error(path, error))
+}
+
+#[cfg(not(unix))]
+fn open_lockfile_no_follow(path: &Path) -> io::Result<File> {
+    ensure_lockfile_is_not_symlink(path)?;
+    File::open(path)
+}
+
+#[cfg(unix)]
+fn normalize_no_follow_error(path: &Path, error: io::Error) -> io::Error {
+    if error.raw_os_error() == Some(libc::ELOOP) { symlinked_lockfile_error(path) } else { error }
+}
+
 fn ensure_lockfile_is_not_symlink(path: &Path) -> io::Result<()> {
     match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_symlink() => Err(io::Error::new(
-            ErrorKind::InvalidInput,
-            format!("refusing to read or write symlinked lockfile at {}", path.display()),
-        )),
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(symlinked_lockfile_error(path)),
         Ok(_) => Ok(()),
         Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error),
     }
+}
+
+fn symlinked_lockfile_error(path: &Path) -> io::Error {
+    io::Error::new(
+        ErrorKind::InvalidInput,
+        format!("refusing to read or write symlinked lockfile at {}", path.display()),
+    )
 }
 
 #[cfg(test)]

--- a/pacquet/crates/lockfile/src/env_lockfile.rs
+++ b/pacquet/crates/lockfile/src/env_lockfile.rs
@@ -17,11 +17,12 @@ use crate::{
     extract_env_document, extract_main_document, serialize_yaml,
     yaml_documents::{YAML_DOCUMENT_SEPARATOR, YAML_DOCUMENT_START},
 };
+use pacquet_fs::write_atomic;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap},
     fs,
-    io::ErrorKind,
+    io::{self, ErrorKind},
     path::Path,
 };
 
@@ -103,6 +104,7 @@ impl EnvLockfile {
     ///   importer (and its `configDependencies` map) exists.
     pub fn read(root_dir: &Path) -> Result<Option<Self>, LoadLockfileError> {
         let path = root_dir.join(Lockfile::FILE_NAME);
+        ensure_lockfile_is_not_symlink(&path).map_err(LoadLockfileError::ReadFile)?;
         let content = match fs::read_to_string(&path) {
             Ok(content) => content,
             Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
@@ -122,6 +124,7 @@ impl EnvLockfile {
     /// document. Emits `---\n${envYaml}\n---\n${mainDoc}`.
     pub fn write(&self, root_dir: &Path) -> Result<(), SaveLockfileError> {
         let path = root_dir.join(Lockfile::FILE_NAME);
+        ensure_lockfile_is_not_symlink(&path).map_err(SaveLockfileError::WriteFile)?;
         let env_yaml = serialize_yaml::to_string(self).map_err(SaveLockfileError::SerializeYaml)?;
         let main_doc = match fs::read_to_string(&path) {
             Ok(existing) => extract_main_document(&existing).to_string(),
@@ -130,7 +133,19 @@ impl EnvLockfile {
         };
         let combined =
             format!("{YAML_DOCUMENT_START}{env_yaml}{YAML_DOCUMENT_SEPARATOR}{main_doc}");
-        fs::write(&path, combined).map_err(SaveLockfileError::WriteFile)
+        write_atomic(&path, combined.as_bytes()).map_err(SaveLockfileError::WriteFile)
+    }
+}
+
+fn ensure_lockfile_is_not_symlink(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("refusing to read or write symlinked lockfile at {}", path.display()),
+        )),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
     }
 }
 

--- a/pacquet/crates/lockfile/src/env_lockfile/tests.rs
+++ b/pacquet/crates/lockfile/src/env_lockfile/tests.rs
@@ -1,4 +1,4 @@
-use super::{EnvLockfile, SpecifierAndResolution};
+use super::{EnvLockfile, SpecifierAndResolution, read_lockfile_to_string_no_follow};
 use crate::{
     Lockfile, LockfileResolution, PackageKey, PackageMetadata, RegistryResolution, SnapshotEntry,
     extract_env_document,
@@ -99,6 +99,22 @@ fn read_rejects_symlinked_lockfile() {
     let error = EnvLockfile::read(dir.path()).expect_err("symlinked lockfile must fail");
 
     assert!(error.to_string().contains("symlinked lockfile"), "unexpected error: {error:?}");
+}
+
+#[cfg(unix)]
+#[test]
+fn no_follow_read_rejects_symlinked_lockfile() {
+    let dir = TempDir::new().unwrap();
+    let real_lockfile = dir.path().join("real-lockfile.yaml");
+    std::fs::write(&real_lockfile, "target content").unwrap();
+    let lockfile_path = dir.path().join(Lockfile::FILE_NAME);
+    std::os::unix::fs::symlink(&real_lockfile, &lockfile_path).unwrap();
+
+    let error = read_lockfile_to_string_no_follow(&lockfile_path)
+        .expect_err("symlinked lockfile must fail");
+
+    assert!(error.to_string().contains("symlinked lockfile"), "unexpected error: {error:?}");
+    assert_eq!(std::fs::read_to_string(real_lockfile).unwrap(), "target content");
 }
 
 #[cfg(unix)]

--- a/pacquet/crates/lockfile/src/env_lockfile/tests.rs
+++ b/pacquet/crates/lockfile/src/env_lockfile/tests.rs
@@ -84,6 +84,39 @@ fn write_preserves_existing_main_document() {
     assert!(loaded.root_project().is_some());
 }
 
+#[cfg(unix)]
+#[test]
+fn read_rejects_symlinked_lockfile() {
+    let dir = TempDir::new().unwrap();
+    let real_lockfile = dir.path().join("real-lockfile.yaml");
+    std::fs::write(
+        &real_lockfile,
+        "---\nlockfileVersion: '9.0'\nimporters:\n  .:\n    configDependencies: {}\npackages: {}\nsnapshots: {}\n---\n",
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(&real_lockfile, dir.path().join(Lockfile::FILE_NAME)).unwrap();
+
+    let error = EnvLockfile::read(dir.path()).expect_err("symlinked lockfile must fail");
+
+    assert!(error.to_string().contains("symlinked lockfile"), "unexpected error: {error:?}");
+}
+
+#[cfg(unix)]
+#[test]
+fn write_rejects_symlinked_lockfile_without_touching_target() {
+    let dir = TempDir::new().unwrap();
+    let real_lockfile = dir.path().join("real-lockfile.yaml");
+    std::fs::write(&real_lockfile, "target content").unwrap();
+    let lockfile_path = dir.path().join(Lockfile::FILE_NAME);
+    std::os::unix::fs::symlink(&real_lockfile, &lockfile_path).unwrap();
+
+    let error = sample_env_lockfile().write(dir.path()).expect_err("symlinked lockfile must fail");
+
+    assert!(error.to_string().contains("symlinked lockfile"), "unexpected error: {error:?}");
+    assert!(std::fs::symlink_metadata(&lockfile_path).unwrap().file_type().is_symlink());
+    assert_eq!(std::fs::read_to_string(real_lockfile).unwrap(), "target content");
+}
+
 #[test]
 fn saving_main_lockfile_preserves_env_document() {
     let dir = TempDir::new().unwrap();

--- a/pnpm11/lockfile/fs/src/envLockfile.ts
+++ b/pnpm11/lockfile/fs/src/envLockfile.ts
@@ -1,6 +1,4 @@
-import { promises as fs } from 'node:fs'
 import path from 'node:path'
-import util from 'node:util'
 
 import { LOCKFILE_VERSION, WANTED_LOCKFILE } from '@pnpm/constants'
 import type { EnvLockfile } from '@pnpm/lockfile.types'
@@ -9,7 +7,7 @@ import writeFileAtomic from 'write-file-atomic'
 
 import { sortLockfileKeys } from './sortLockfileKeys.js'
 import { lockfileYamlDump } from './write.js'
-import { extractMainDocument, streamReadFirstYamlDocument } from './yamlDocuments.js'
+import { extractMainDocument, readLockfileToStringNoFollow, streamReadFirstYamlDocument } from './yamlDocuments.js'
 
 export function createEnvLockfile (): EnvLockfile {
   return {
@@ -61,16 +59,8 @@ export async function writeEnvLockfile (rootDir: string, lockfile: EnvLockfile):
   const sorted = sortLockfileKeys(lockfile)
   const envYaml = lockfileYamlDump(sorted)
 
-  // Read existing main lockfile document to preserve it
-  let mainDoc = ''
-  try {
-    const existing = await fs.readFile(lockfilePath, 'utf8')
-    mainDoc = extractMainDocument(existing)
-  } catch (err: unknown) {
-    if (!(util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT')) {
-      throw err
-    }
-  }
+  const existing = await readLockfileToStringNoFollow(lockfilePath)
+  const mainDoc = existing == null ? '' : extractMainDocument(existing)
 
   const combined = `---\n${envYaml}\n---\n${mainDoc}`
   return writeFileAtomic(lockfilePath, combined)

--- a/pnpm11/lockfile/fs/src/yamlDocuments.ts
+++ b/pnpm11/lockfile/fs/src/yamlDocuments.ts
@@ -1,13 +1,16 @@
-import { type FileHandle, open } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { type FileHandle, lstat, open } from 'node:fs/promises'
 import { StringDecoder } from 'node:string_decoder'
 import util from 'node:util'
 
+import { PnpmError } from '@pnpm/error'
 import stripBom from 'strip-bom'
 
 export const YAML_DOCUMENT_SEPARATOR = '\n---\n'
 export const YAML_DOCUMENT_START = '---\n'
 
 const READ_BUFFER_SIZE = 64 * 1024
+const LOCKFILE_READ_FLAGS = constants.O_RDONLY | (process.platform === 'win32' ? 0 : constants.O_NOFOLLOW)
 
 /**
  * Reads the first YAML document from a multi-document YAML file using streaming.
@@ -20,7 +23,7 @@ export async function streamReadFirstYamlDocument (filePath: string, readBufferS
   let buffer = ''
   let firstChunk = true
   try {
-    fileHandle = await open(filePath, 'r')
+    fileHandle = await openLockfileNoFollow(filePath)
     const decoder = new StringDecoder('utf8')
     const readBuffer = Buffer.allocUnsafe(normalizeReadBufferSize(readBufferSize))
     let position = 0
@@ -60,6 +63,52 @@ export async function streamReadFirstYamlDocument (filePath: string, readBufferS
   } finally {
     await fileHandle?.close().catch(() => {})
   }
+}
+
+export async function readLockfileToStringNoFollow (filePath: string): Promise<string | null> {
+  let fileHandle: FileHandle | undefined
+  try {
+    fileHandle = await openLockfileNoFollow(filePath)
+    return await fileHandle.readFile('utf8')
+  } catch (err: unknown) {
+    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') {
+      return null
+    }
+    throw err
+  } finally {
+    await fileHandle?.close().catch(() => {})
+  }
+}
+
+async function openLockfileNoFollow (filePath: string): Promise<FileHandle> {
+  await ensureLockfileIsNotSymlink(filePath)
+  try {
+    return await open(filePath, LOCKFILE_READ_FLAGS)
+  } catch (err: unknown) {
+    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ELOOP') {
+      throw symlinkedLockfileError(filePath)
+    }
+    throw err
+  }
+}
+
+async function ensureLockfileIsNotSymlink (filePath: string): Promise<void> {
+  let stat
+  try {
+    stat = await lstat(filePath)
+  } catch (err: unknown) {
+    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') {
+      return
+    }
+    throw err
+  }
+  if (stat.isSymbolicLink()) {
+    throw symlinkedLockfileError(filePath)
+  }
+}
+
+function symlinkedLockfileError (filePath: string): PnpmError {
+  return new PnpmError('LOCKFILE_IS_SYMLINK', `Refusing to read or write symlinked lockfile at ${filePath}`)
 }
 
 function canRejectDocumentStart (buffer: string): boolean {

--- a/pnpm11/lockfile/fs/test/envLockfile.test.ts
+++ b/pnpm11/lockfile/fs/test/envLockfile.test.ts
@@ -1,0 +1,31 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import { WANTED_LOCKFILE } from '@pnpm/constants'
+import { createEnvLockfile, readEnvLockfile, writeEnvLockfile } from '@pnpm/lockfile.fs'
+import { temporaryDirectory } from 'tempy'
+
+const testOnNonWindows = process.platform === 'win32' ? test.skip : test
+
+testOnNonWindows('readEnvLockfile rejects a symlinked lockfile', async () => {
+  const dir = temporaryDirectory()
+  const realLockfile = path.join(dir, 'real-lockfile.yaml')
+  fs.writeFileSync(realLockfile, '---\nlockfileVersion: "9.0"\nimporters:\n  .:\n    configDependencies: {}\npackages: {}\nsnapshots: {}\n---\n')
+  fs.symlinkSync(realLockfile, path.join(dir, WANTED_LOCKFILE), 'file')
+
+  await expect(readEnvLockfile(dir)).rejects.toThrow(/symlinked lockfile/)
+})
+
+testOnNonWindows('writeEnvLockfile rejects a symlinked lockfile without touching the target', async () => {
+  const dir = temporaryDirectory()
+  const realLockfile = path.join(dir, 'real-lockfile.yaml')
+  fs.writeFileSync(realLockfile, 'target content')
+  const lockfilePath = path.join(dir, WANTED_LOCKFILE)
+  fs.symlinkSync(realLockfile, lockfilePath, 'file')
+
+  await expect(writeEnvLockfile(dir, createEnvLockfile())).rejects.toThrow(/symlinked lockfile/)
+
+  expect(fs.lstatSync(lockfilePath).isSymbolicLink()).toBe(true)
+  expect(fs.readFileSync(realLockfile, 'utf8')).toBe('target content')
+})

--- a/pnpm11/lockfile/fs/test/yamlDocuments.test.ts
+++ b/pnpm11/lockfile/fs/test/yamlDocuments.test.ts
@@ -9,6 +9,8 @@ import {
   streamReadFirstYamlDocument,
 } from '../lib/yamlDocuments.js'
 
+const testOnNonWindows = process.platform === 'win32' ? test.skip : test
+
 describe('streamReadFirstYamlDocument', () => {
   test('returns the first document content from a two-document file', async () => {
     const dir = temporaryDirectory()
@@ -119,6 +121,16 @@ describe('streamReadFirstYamlDocument', () => {
     fs.writeFileSync(filePath, content)
     const result = await streamReadFirstYamlDocument(filePath)
     expect(result).toBe('foo: bar')
+  })
+
+  testOnNonWindows('rejects a symlinked lockfile', async () => {
+    const dir = temporaryDirectory()
+    const realLockfile = path.join(dir, 'real-lockfile.yaml')
+    const lockfilePath = path.join(dir, 'pnpm-lock.yaml')
+    fs.writeFileSync(realLockfile, '---\nfoo: bar\n---\nlockfileVersion: 9.0\n')
+    fs.symlinkSync(realLockfile, lockfilePath, 'file')
+
+    await expect(streamReadFirstYamlDocument(lockfilePath)).rejects.toThrow(/symlinked lockfile/)
   })
 })
 


### PR DESCRIPTION
## Summary

Fixes pacquet's package-manager version switch so `pnpm --version` is delegated to the project-selected pnpm version instead of always printing pacquet's own embedded version.

This matches the TypeScript CLI behavior: package-manager switching runs before command dispatch and before printing `--version`. The no-switch path now uses a synchronous switch plan first, so the existing up-to-date install fast path does not pay for a Tokio runtime unless a switch is actually needed.

For projects using `devEngines.packageManager`, pacquet now reuses the package-manager env lockfile only when it pins a satisfying pnpm version and the recorded `packageManagerDependencies` graph is complete and integrity-backed. The lockfile validation walks that graph iteratively, avoiding recursive stack growth on attacker-controlled lockfiles.

Also makes the shared engine installer choose the legacy `@pnpm/exe` wrapper for pnpm versions before v12 and the unscoped `pnpm` wrapper for v12+, which is the same package-layout split involved in https://github.com/pnpm/pnpm/pull/12820. Cache hits now relink the pnpm bins instead of trusting a preexisting `bin/` directory.

The auto-switch engine install/cache path now ignores repo-controlled `storeDir` and uses a package-manager engine store derived from the trusted pnpm home. Package-manager env lockfile reads and writes reject symlinked `pnpm-lock.yaml` files, and env lockfile writes are atomic.

Ported the related TypeScript coverage gap into pacquet, including lockfile reuse/rejection cases, `packageManager` vs `devEngines.packageManager` behavior, `onFail` handling, version-flag argv parsing, cache-hit bin repair, legacy wrapper cache-hit relinking, trusted-store derivation, symlinked env-lockfile rejection, and an integration regression for `pacquet --version` switching to the project-declared pnpm version.

No changeset: this is a Rust pacquet parity fix, not a TypeScript published package change.

## Squash Commit Body

```text
Run pacquet's package-manager version switch before printing --version or dispatching commands, so projects that declare pnpm via packageManager or devEngines.packageManager get the selected pnpm version even for version-only invocations.

Plan switching synchronously before entering Tokio, so ordinary no-switch invocations and the up-to-date install fast path avoid the runtime/thread startup cost.

Prefer the package-manager env lockfile for persistent package-manager declarations when it already pins a satisfying pnpm version and has a complete, integrity-backed packageManagerDependencies graph, matching the TypeScript CLI's lockfile-first behavior while rejecting stale or non-registry lockfile entries. Validate the package-manager dependency graph iteratively rather than recursively.

Share the existing pnpm engine installer with the switch path, but make it version-aware: pnpm versions before v12 execute through the legacy @pnpm/exe wrapper while v12 and newer execute through the unscoped pnpm wrapper. Cache hits relink missing pnpm bins before returning.

Run auto-switch engine cache lookups and installs from a trusted package-manager engine store derived from the pnpm home instead of the project storeDir, so repo-controlled workspace settings cannot redirect executable cache hits. Reject symlinked env lockfiles before reading or writing them, and write env lockfile updates atomically.

The switch is skipped for commands that manage package-manager state directly, under Corepack, and when manage-package-manager-versions is explicitly disabled.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic pnpm version switching for delegated commands based on the project’s declared `packageManager` before running.
  * Enhanced `--version` to reflect the project’s `package.json` when switching is successful.
* **Bug Fixes**
  * Improved switching correctness by better gating on CLI context and engine signals, and by avoiding switching when the current version already satisfies the requested range.
  * Strengthened manifest/lockfile validation to prevent selecting an incorrect pnpm version.
* **Tests**
  * Expanded coverage for `--version`, switch planning/argument parsing edge cases, and lockfile-derived switching/reuse scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Written by an agent (Codex, GPT-5).