### PR TITLE
fix(pacquet): stop printing skipped optional dependency warnings

### DIFF
--- a/pacquet/crates/default-reporter/src/state.rs
+++ b/pacquet/crates/default-reporter/src/state.rs
@@ -10,8 +10,7 @@ use pacquet_reporter::{
     AddedRoot, ContextLog, DependencyType, ExecutionTimeLog, FetchingProgressMessage, HookLog,
     IgnoredScriptsLog, InstallingConfigDepsLog, InstallingConfigDepsStatus, LifecycleMessage,
     LifecycleStdio, LockfileVerificationMessage, LogEvent, LogLevel, PackageImportMethod,
-    PackageManifestMessage, ProgressMessage, RemovedRoot, RequestRetryLog, SkippedOptionalPackage,
-    Stage, StatsMessage,
+    PackageManifestMessage, ProgressMessage, RemovedRoot, RequestRetryLog, Stage, StatsMessage,
 };
 use serde_json::Value;
 
@@ -300,15 +299,11 @@ impl ReporterState {
             LogEvent::Summary(_) => self.on_summary(),
             LogEvent::Lifecycle(log) => self.on_lifecycle(&log.message),
             LogEvent::IgnoredScripts(log) => self.on_ignored_scripts(log),
-            LogEvent::SkippedOptionalDependency(log) => {
-                let pkg = match &log.package {
-                    SkippedOptionalPackage::Installed { id, .. } => id.clone(),
-                    SkippedOptionalPackage::ResolutionFailure { bare_specifier, .. } => {
-                        bare_specifier.clone()
-                    }
-                };
-                self.push_warning(&format!("Skipping optional dependency {pkg}"));
-            }
+            // Upstream's `reportSkippedOptionalDependencies` only prints top-level
+            // resolution failures (its filter needs a `parents: []`); the emits
+            // pacquet produces carry no `parents`, so upstream drops them from the
+            // console. Consume without rendering to match.
+            LogEvent::SkippedOptionalDependency(_) => {}
             LogEvent::InstallingConfigDeps(log) => self.on_config_deps(log),
             LogEvent::LockfileVerification(log) => self.on_lockfile_verification(&log.message),
             LogEvent::RequestRetry(log) => self.on_request_retry(log),

--- a/pacquet/crates/default-reporter/tests/render.rs
+++ b/pacquet/crates/default-reporter/tests/render.rs
@@ -10,8 +10,9 @@ use pacquet_default_reporter::{
 use pacquet_reporter::{
     AddedRoot, ContextLog, DependencyType, ExecutionTimeLog, GlobalLog, HookLog, LifecycleLog,
     LifecycleMessage, LifecycleStdio, LogEvent, LogLevel, PackageImportMethod,
-    PackageImportMethodLog, PnpmLog, ProgressLog, ProgressMessage, RootLog, RootMessage, Stage,
-    StageLog, StatsLog, StatsMessage, SummaryLog,
+    PackageImportMethodLog, PnpmLog, ProgressLog, ProgressMessage, RootLog, RootMessage,
+    SkippedOptionalDependencyLog, SkippedOptionalPackage, SkippedOptionalReason, Stage, StageLog,
+    StatsLog, StatsMessage, SummaryLog,
 };
 
 const CWD: &str = "/repo";
@@ -286,6 +287,39 @@ fn warnings_collapse_after_five() {
     assert_eq!(lines.len(), 6);
     assert_eq!(lines[0], "[WARN] something");
     assert_eq!(lines[5], "[WARN] 1 other warnings");
+}
+
+/// Upstream keeps the console silent for the skipped-optional emits pacquet
+/// produces (they carry no `parents`), so this channel must render nothing.
+#[test]
+fn skipped_optional_dependency_renders_nothing() {
+    let mut reporter = state(false);
+    let skipped = |reason, id: &str, name: &str, version: &str| {
+        LogEvent::SkippedOptionalDependency(SkippedOptionalDependencyLog {
+            level: LogLevel::Debug,
+            details: Some("incompatible".to_string()),
+            package: SkippedOptionalPackage::Installed {
+                id: id.to_string(),
+                name: name.to_string(),
+                version: version.to_string(),
+            },
+            prefix: CWD.to_string(),
+            reason,
+        })
+    };
+    let frame = render(
+        &mut reporter,
+        vec![
+            skipped(
+                SkippedOptionalReason::UnsupportedPlatform,
+                "fsevents@2.3.3",
+                "fsevents",
+                "2.3.3",
+            ),
+            skipped(SkippedOptionalReason::BuildFailure, "esbuild@0.20.0", "esbuild", "0.20.0"),
+        ],
+    );
+    assert!(frame.is_empty(), "skipped-optional events must not render, got: {frame:?}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The Rust CLI (pacquet) printed a `Skipping optional dependency <pkg>` **warning** for every skipped optional dependency during install. The TypeScript pnpm CLI does not print this.

In `@pnpm/cli.default-reporter`, `reportSkippedOptionalDependencies` only surfaces a skipped optional dependency on the console when it is a **direct** dependency of the workspace root that failed to **resolve** — its filter requires `parents.length === 0` and `prefix === cwd`, and only the resolver's `resolution_failure` emit carries a `parents` array. The installability re-check (`unsupported_engine` / `unsupported_platform`, via `packageIsInstallable`) and the build-failure emits omit `parents` entirely, so upstream keeps the console silent for them. A build failure that is skipped as optional is instead reported through the lifecycle channel's `(skipped as optional)` note, which pacquet already renders.

Pacquet's install path is lockfile-driven and has no resolver, so every event it emits on the `pnpm:skipped-optional-dependency` channel is one upstream would filter out of the console. This PR makes pacquet's default reporter consume the event without rendering, so the console output matches the TypeScript CLI.

The wire event still fires (`Reporter::emit` is unchanged), so `--reporter=ndjson` output is unaffected — this only changes the human-readable default reporter, exactly as upstream does (the upstream `logger.debug` always fires to NDJSON/the log file but the default reporter filters it from the console).

This is a pacquet-only fix that brings it in line with the existing TypeScript behavior; no TypeScript change is needed.

## Squash Commit Body

```text
`@pnpm/cli.default-reporter`'s `reportSkippedOptionalDependencies` only
surfaces a skipped optional dependency on the console when it is a direct
dependency of the workspace root that failed to resolve — its filter requires
`parents.length === 0` and `prefix === cwd`, and only the resolver's
`resolution_failure` emit carries a `parents` array. The installability
re-check (unsupported engine/platform) and build-failure emits omit `parents`,
so upstream keeps the console silent for them.

Pacquet was rendering a `Skipping optional dependency <pkg>` warning for every
`pnpm:skipped-optional-dependency` event, which upstream never prints. Since
pacquet's install path is lockfile-driven with no resolver, every event it
emits on this channel is one upstream filters out. Consume the event in the
default reporter without rendering so the console output matches the TypeScript
CLI. The wire event still fires, so `--reporter=ndjson` output is unchanged, and
a build failure skipped as optional still surfaces through the lifecycle
channel's "(skipped as optional)" note.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting. _(pacquet-only fix to match existing TypeScript behavior; no TypeScript change needed.)_
- [x] Added or updated tests. _(New `skipped_optional_dependency_renders_nothing` frame-level test.)_

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Optional dependency “skipped” log events no longer show console warnings and no longer render any install output.
  * Reporter output now matches the expected upstream filtering behavior for these events.
* **Tests**
  * Added a frame-level test covering skipped optional dependency cases (e.g., unsupported platform, build failure) to verify the reporter renders nothing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->