### PR TITLE
fix(pacquet): persist the synthesized runtime package.json into the store index

### DIFF
--- a/pacquet/crates/env-installer/src/install_config_deps.rs
+++ b/pacquet/crates/env-installer/src/install_config_deps.rs
@@ -191,6 +191,7 @@ async fn materialize<Reporter: self::Reporter>(
         ignore_file_pattern: None,
         offline: opts.offline,
         progress_reported: None,
+        append_manifest: None,
     }
     .run_without_mem_cache::<Reporter>()
     .await

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
@@ -309,6 +309,7 @@ impl InstallPackageBySnapshot<'_> {
                     ignore_file_pattern: None,
                     offline: config.offline,
                     progress_reported: progress_reported.cloned(),
+                    append_manifest: None,
                 };
                 // Reuse an in-flight or completed background download
                 // through the shared mem cache when one is provided;
@@ -752,7 +753,18 @@ async fn fetch_binary_resolution_to_cas<Reporter: self::Reporter>(
     ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
 ) -> Result<HashMap<String, PathBuf>, InstallPackageBySnapshotError> {
     let package_id = package_key.without_peer().to_string();
-    let mut cas_paths = match binary.archive {
+
+    // Synthesize the `package.json` runtime archives (Node.js / Bun /
+    // Deno) don't ship, and hand it to the fetcher as `append_manifest`.
+    // The fetcher folds it into both this install's `cas_paths` and the
+    // persisted store-index row (its `files` map and bundled `manifest`),
+    // so a later *warm* install — which materializes straight from the
+    // row and never re-runs this function — still lands a `package.json`
+    // slot and lets the bin linker find the runtime's bin. The object
+    // carries `name`, `version`, and `bin` — the three fields pacquet's
+    // bin linking and `dlx` look at.
+    let manifest_bytes = synthesize_runtime_manifest_bytes(package_key, binary)?;
+    let cas_paths = match binary.archive {
         BinaryArchive::Tarball => DownloadTarballToStore {
             http_client,
             store_dir: &config.store_dir,
@@ -774,6 +786,7 @@ async fn fetch_binary_resolution_to_cas<Reporter: self::Reporter>(
             // Cold-batch binary tarball download: emits `fetched`
             // directly, so no network-fetched tracking is needed.
             progress_reported: None,
+            append_manifest: Some(&manifest_bytes),
         }
         .run_without_mem_cache::<Reporter>()
         .await
@@ -795,35 +808,13 @@ async fn fetch_binary_resolution_to_cas<Reporter: self::Reporter>(
             archive_prefix: binary.prefix.as_deref(),
             ignore_file_pattern,
             offline: config.offline,
+            append_manifest: Some(&manifest_bytes),
         }
         .run_without_mem_cache::<Reporter>()
         .await
         .map_err(InstallPackageBySnapshotError::DownloadTarball)?,
     };
 
-    // Synthesize the package.json for the runtime archive and import
-    // it through the same CAS write path the rest of the archive
-    // takes. Runtime archives don't ship their own `package.json`,
-    // so the existing bin-link step (which reads the manifest off
-    // the slot's `package.json`) has nothing to consume by default.
-    // The synthesized object has `name`, `version`, and `bin` — the
-    // three fields pacquet's `link_bins_of_packages` actually looks
-    // at. Writing the bytes through `write_cas_file` keeps the
-    // import path uniform with every other CAS-imported file and
-    // means the bytes are content-addressed (so two runtimes with
-    // the same `(name, version, bin)` share one blob).
-    let manifest_bytes = synthesize_runtime_manifest_bytes(package_key, binary)?;
-    let (cas_path, _hash) =
-        config.store_dir.write_cas_file(&manifest_bytes, false).map_err(|err| {
-            InstallPackageBySnapshotError::DownloadTarball(TarballError::WriteCasFile(err))
-        })?;
-    if let Some(previous) = cas_paths.insert("package.json".to_string(), cas_path) {
-        tracing::warn!(
-            ?previous,
-            ?package_id,
-            "synthesized package.json displaced an existing entry — runtime archives are not expected to ship a package.json",
-        );
-    }
     Ok(cas_paths)
 }
 

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot/tests.rs
@@ -585,3 +585,185 @@ async fn cold_batch_falls_back_when_prefetch_failed() {
 
     drop(store_tmp);
 }
+
+/// A minimal runtime archive: one executable at `<top>/bin/node` and no
+/// `package.json`. Real Node.js / Bun / Deno archives likewise ship no
+/// manifest of their own; the synthesized `bin` comes from the
+/// resolution, not the archive, so the payload is deliberately trivial.
+fn build_runtime_tarball_fixture() -> Vec<u8> {
+    use flate2::{Compression, write::GzEncoder};
+    use std::io::Write;
+
+    let script = b"#!/bin/sh\necho v22.0.0\n";
+    let mut tar_builder = tar::Builder::new(Vec::new());
+    let mut header = tar::Header::new_gnu();
+    header.set_size(script.len() as u64);
+    header.set_mode(0o755);
+    tar_builder
+        .append_data(&mut header, "node-v22.0.0-fixture/bin/node", &script[..])
+        .expect("append the fixture bin entry");
+    let tar_bytes = tar_builder.into_inner().expect("finalize the fixture tar");
+
+    let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+    gz.write_all(&tar_bytes).expect("gzip the fixture tar");
+    gz.finish().expect("finish the gzip stream")
+}
+
+/// End-to-end regression for the CI failure on pnpm/pnpm#12811, mirroring
+/// the core of `installing/deps-installer/test/install/nodeRuntime.ts:209`
+/// (`installing Node.js runtime`): a cold install, then `rimraf
+/// node_modules` + an offline reinstall. A runtime archive ships no
+/// `package.json`, so pacquet synthesizes one — and it must be baked into
+/// the persisted store-index row, not just this install's `cas_paths`.
+/// Pre-fix the row recorded neither the `package.json` file nor a bundled
+/// `manifest`, so a later *warm* install (which materializes straight from
+/// the row and never re-runs `fetch_binary_resolution_to_cas`) landed a
+/// manifest-less slot and `pnpm dlx node@runtime:<v>` died in `getBinName`
+/// with `dlx_read_manifest`.
+#[tokio::test]
+async fn installing_a_runtime_persists_the_synthesized_manifest_into_the_store_index_row() {
+    use pacquet_store_dir::{
+        SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, store_index_key,
+    };
+    use std::sync::atomic::AtomicU8;
+
+    let archive_tmp = tempfile::tempdir().expect("tempdir");
+    let tarball_path = archive_tmp.path().join("node-fixture.tar.gz");
+    let tarball_bytes = build_runtime_tarball_fixture();
+    std::fs::write(&tarball_path, &tarball_bytes).expect("write the fixture tarball");
+    let integrity = ssri::IntegrityOpts::new()
+        .algorithm(ssri::Algorithm::Sha512)
+        .chain(&tarball_bytes)
+        .result();
+
+    let store_tmp = tempfile::tempdir().expect("tempdir");
+    // `offline: true` is safe — a `file:` URL bypasses the offline gate,
+    // and it guarantees the install never reaches the network.
+    let config = leaked_offline_config("https://registry.test", store_tmp.path());
+    let (writer, writer_task) = StoreIndexWriter::spawn(&config.store_dir);
+
+    let package_key: PackageKey = "node@runtime:22.0.0".parse().expect("parse runtime key");
+    let metadata = pacquet_lockfile::PackageMetadata {
+        resolution: LockfileResolution::Binary(BinaryResolution {
+            url: format!("file:{}", tarball_path.display()),
+            integrity: integrity.clone(),
+            bin: BinarySpec::Map(std::collections::BTreeMap::from([(
+                "node".to_string(),
+                "bin/node".to_string(),
+            )])),
+            archive: BinaryArchive::Tarball,
+            prefix: None,
+        }),
+        version: Some("22.0.0".to_string()),
+        has_bin: Some(true),
+        engines: None,
+        cpu: None,
+        os: None,
+        libc: None,
+        deprecated: None,
+        prepare: None,
+        bundled_dependencies: None,
+        peer_dependencies: None,
+        peer_dependencies_meta: None,
+    };
+    let snapshot = pacquet_lockfile::SnapshotEntry::default();
+    let layout = crate::VirtualStoreLayout::legacy(store_tmp.path().join("vstore"), 120);
+    let allow_build_policy = crate::AllowBuildPolicy::new(
+        std::collections::HashSet::default(),
+        std::collections::HashSet::default(),
+        false,
+    );
+    let skipped = crate::SkippedSnapshots::new();
+    let logged_methods = AtomicU8::new(0);
+    let verified_files_cache = SharedVerifiedFilesCache::default();
+
+    // Cold install: fetch the fixture, synthesize the manifest, queue the row.
+    let cold_cas_paths = super::InstallPackageBySnapshot {
+        http_client: &pacquet_network::ThrottledClient::default(),
+        config,
+        layout: &layout,
+        store_index: None,
+        store_index_writer: Some(&writer),
+        prefetched_cas_paths: None,
+        progress_reported: None,
+        tarball_mem_cache: None,
+        verified_files_cache: &verified_files_cache,
+        logged_methods: &logged_methods,
+        requester: "/project",
+        package_key: &package_key,
+        metadata: &metadata,
+        snapshot: &snapshot,
+        allow_build_policy: &allow_build_policy,
+        skipped: &skipped,
+        workspace_root: store_tmp.path(),
+        node_linker: pacquet_config::NodeLinker::Hoisted,
+        defer_link: false,
+        link_concurrency_probe: None,
+    }
+    .run::<pacquet_reporter::SilentReporter>()
+    .await
+    .expect("cold runtime install");
+    assert!(cold_cas_paths.contains_key("package.json"), "the cold slot gets the manifest");
+
+    // Flush the store-index writer so the row is durable before read-back.
+    drop(writer);
+    writer_task.await.expect("join the writer task").expect("flush the store index");
+
+    // The persisted row must carry the synthesized `package.json` in both
+    // its `files` map and its bundled `manifest` — the pre-fix gap that a
+    // warm materialization would inherit.
+    let index_key =
+        store_index_key(&integrity.to_string(), &package_key.without_peer().to_string());
+    let row = StoreIndex::open_in(&config.store_dir)
+        .expect("open the store index")
+        .get(&index_key)
+        .expect("read the runtime row")
+        .expect("the runtime row was persisted");
+    assert!(row.files.contains_key("package.json"), "the row records the synthesized package.json");
+    let manifest = row.manifest.expect("the row records a bundled manifest");
+    assert_eq!(
+        manifest.get("bin").and_then(|bin| bin.get("node")).and_then(serde_json::Value::as_str),
+        Some("bin/node"),
+        "the bundled manifest carries the runtime bin",
+    );
+
+    // Warm reinstall — nodeRuntime.ts's `rimraf node_modules` + offline
+    // reinstall. Delete the archive so the store is the only possible
+    // source, then materialize straight from the persisted row. The slot
+    // must still get the `package.json`; pre-fix the row lacked it.
+    std::fs::remove_file(&tarball_path).expect("remove the fixture so only the store can serve");
+    let warm_index = StoreIndex::shared_readonly_in(&config.store_dir);
+    let warm_verified = SharedVerifiedFilesCache::default();
+    let warm_logged = AtomicU8::new(0);
+    let warm_cas_paths = super::InstallPackageBySnapshot {
+        http_client: &pacquet_network::ThrottledClient::default(),
+        config,
+        layout: &layout,
+        store_index: warm_index.as_ref(),
+        store_index_writer: None,
+        prefetched_cas_paths: None,
+        progress_reported: None,
+        tarball_mem_cache: None,
+        verified_files_cache: &warm_verified,
+        logged_methods: &warm_logged,
+        requester: "/project",
+        package_key: &package_key,
+        metadata: &metadata,
+        snapshot: &snapshot,
+        allow_build_policy: &allow_build_policy,
+        skipped: &skipped,
+        workspace_root: store_tmp.path(),
+        node_linker: pacquet_config::NodeLinker::Hoisted,
+        defer_link: false,
+        link_concurrency_probe: None,
+    }
+    .run::<pacquet_reporter::SilentReporter>()
+    .await
+    .expect("warm runtime reinstall reads the store, not the network");
+    assert!(
+        warm_cas_paths.contains_key("package.json"),
+        "the warm reinstall re-materializes the manifest from the persisted row",
+    );
+
+    drop((store_tmp, archive_tmp));
+}

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot/tests.rs
@@ -613,13 +613,13 @@ fn build_runtime_tarball_fixture() -> Vec<u8> {
 /// the core of `installing/deps-installer/test/install/nodeRuntime.ts:209`
 /// (`installing Node.js runtime`): a cold install, then `rimraf
 /// node_modules` + an offline reinstall. A runtime archive ships no
-/// `package.json`, so pacquet synthesizes one — and it must be baked into
-/// the persisted store-index row, not just this install's `cas_paths`.
-/// Pre-fix the row recorded neither the `package.json` file nor a bundled
-/// `manifest`, so a later *warm* install (which materializes straight from
-/// the row and never re-runs `fetch_binary_resolution_to_cas`) landed a
-/// manifest-less slot and `pnpm dlx node@runtime:<v>` died in `getBinName`
-/// with `dlx_read_manifest`.
+/// `package.json`, so pacquet synthesizes one, and it must be baked into
+/// the persisted store-index row rather than only this install's
+/// `cas_paths`: a warm install materializes the runtime straight from that
+/// row and never re-runs `fetch_binary_resolution_to_cas`, so a row that
+/// omits the `package.json` file and bundled `manifest` yields a
+/// manifest-less slot and makes `pnpm dlx node@runtime:<v>` fail in
+/// `getBinName` with `dlx_read_manifest`.
 #[tokio::test]
 async fn installing_a_runtime_persists_the_synthesized_manifest_into_the_store_index_row() {
     use pacquet_store_dir::{
@@ -710,8 +710,8 @@ async fn installing_a_runtime_persists_the_synthesized_manifest_into_the_store_i
     writer_task.await.expect("join the writer task").expect("flush the store index");
 
     // The persisted row must carry the synthesized `package.json` in both
-    // its `files` map and its bundled `manifest` — the pre-fix gap that a
-    // warm materialization would inherit.
+    // its `files` map and its bundled `manifest` — this is the copy a warm
+    // materialization reads back.
     let index_key =
         store_index_key(&integrity.to_string(), &package_key.without_peer().to_string());
     let row = StoreIndex::open_in(&config.store_dir)
@@ -729,8 +729,8 @@ async fn installing_a_runtime_persists_the_synthesized_manifest_into_the_store_i
 
     // Warm reinstall — nodeRuntime.ts's `rimraf node_modules` + offline
     // reinstall. Delete the archive so the store is the only possible
-    // source, then materialize straight from the persisted row. The slot
-    // must still get the `package.json`; pre-fix the row lacked it.
+    // source, then materialize straight from the persisted row; the slot's
+    // `package.json` can come only from that row.
     std::fs::remove_file(&tarball_path).expect("remove the fixture so only the store can serve");
     let warm_index = StoreIndex::shared_readonly_in(&config.store_dir);
     let warm_verified = SharedVerifiedFilesCache::default();

--- a/pacquet/crates/package-manager/src/install_package_from_registry.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry.rs
@@ -178,6 +178,7 @@ impl InstallPackageFromRegistry<'_> {
                 // progress directly; no resolve-time prefetch shares a
                 // dedupe set with it.
                 progress_reported: None,
+                append_manifest: None,
             }
             .run_with_mem_cache::<Reporter>(tarball_mem_cache)
             .await

--- a/pacquet/crates/package-manager/src/patch.rs
+++ b/pacquet/crates/package-manager/src/patch.rs
@@ -241,6 +241,7 @@ impl WritePackageForPatch<'_> {
                 ignore_file_pattern: None,
                 offline: config.offline,
                 progress_reported: None,
+                append_manifest: None,
             }
             .run_with_mem_cache::<Reporter>(tarball_mem_cache)
             .await

--- a/pacquet/crates/package-manager/src/prefetching_resolver.rs
+++ b/pacquet/crates/package-manager/src/prefetching_resolver.rs
@@ -332,6 +332,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
                 ignore_file_pattern: None,
                 offline,
                 progress_reported: Some(progress_reported),
+                append_manifest: None,
             }
             .run_with_mem_cache::<Reporter>(&mem_cache)
             .await;

--- a/pacquet/crates/package-manager/src/tarball_prefetch.rs
+++ b/pacquet/crates/package-manager/src/tarball_prefetch.rs
@@ -135,6 +135,7 @@ pub(crate) fn spawn_tarball_download(download: TarballDownload) {
             // against — the frozen materialization install emits its own
             // progress as it consumes each tarball from the mem cache.
             progress_reported: None,
+            append_manifest: None,
         }
         .run_with_mem_cache::<SilentReporter>(&mem_cache)
         .await;

--- a/pacquet/crates/tarball/src/lib.rs
+++ b/pacquet/crates/tarball/src/lib.rs
@@ -597,6 +597,54 @@ fn write_cas_entry(
     Ok((file.cleaned_path.clone(), file_path, info))
 }
 
+/// Fold a synthesized `package.json` (pnpm's `appendManifest`) into a
+/// freshly extracted archive's CAFS output. Runtime archives (Node.js /
+/// Bun / Deno) carry no `package.json`, so the bytes are written to the
+/// content-addressed store and recorded in both `cas_paths` (this
+/// install's slot) and the persisted `pkg_files_idx` — its `files` map
+/// *and* its bundled `manifest`. Baking the manifest into the store-index
+/// row is what lets a later warm materialization land a `package.json`
+/// slot and lets the warm-batch bin linker find the runtime's bin without
+/// a disk round-trip.
+///
+/// A no-op when the archive already carries a `package.json` (matches
+/// pnpm's `manifest == null` guard), so ordinary npm tarballs are
+/// untouched.
+fn apply_append_manifest(
+    store_dir: &StoreDir,
+    manifest_bytes: &[u8],
+    cas_paths: &mut HashMap<String, PathBuf>,
+    pkg_files_idx: &mut PackageFilesIndex,
+) -> Result<(), TarballError> {
+    if pkg_files_idx.files.contains_key("package.json") {
+        return Ok(());
+    }
+    let (cas_path, file_hash) =
+        store_dir.write_cas_file(manifest_bytes, false).map_err(TarballError::WriteCasFile)?;
+    let checked_at =
+        UNIX_EPOCH.elapsed().ok().and_then(|elapsed| u64::try_from(elapsed.as_millis()).ok());
+    let info = CafsFileInfo {
+        digest: format!("{file_hash:x}"),
+        // A synthesized manifest is a plain, non-executable data file;
+        // `0o644` is the same canonical mode `add_files_from_dir` reports
+        // for a non-executable entry (and pnpm's Windows-host default).
+        mode: 0o644,
+        size: manifest_bytes.len() as u64,
+        checked_at,
+    };
+    cas_paths.insert("package.json".to_string(), cas_path);
+    pkg_files_idx.files.insert("package.json".to_string(), info);
+    // Surface the synthesized manifest as the row's bundled manifest so
+    // the warm-batch bin linker reads the bin here instead of stat-ing the
+    // slot. Only when the archive supplied none, mirroring pnpm's guard.
+    if pkg_files_idx.manifest.is_none()
+        && let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(manifest_bytes)
+    {
+        pkg_files_idx.manifest = normalize_bundled_manifest(&parsed);
+    }
+    Ok(())
+}
+
 /// Walk decompressed tar bytes, writing each regular-file entry into
 /// the CAFS and returning the `{in-tarball path → CAFS path}` map plus
 /// the per-tarball [`PackageFilesIndex`] row to hand off to the shared
@@ -1457,6 +1505,18 @@ pub struct DownloadTarballToStore<'a> {
     /// threads this set through, because resolve-time prefetches can
     /// otherwise report the same package again in the warm batch.
     pub progress_reported: Option<SharedReportedProgressKeys>,
+    /// Synthesized `package.json` to fold into the freshly extracted
+    /// archive, mirroring pnpm's `appendManifest`. Runtime archives
+    /// (Node.js / Bun / Deno) ship no manifest of their own, so without
+    /// this the store-index row records no `package.json`: every later
+    /// *warm* materialization then lands a manifest-less slot, and the
+    /// warm-batch bin linker (which reads `PackageFilesIndex.manifest`)
+    /// links no bin. When `Some`, the bytes are written to the CAFS and
+    /// recorded in the row's `files` map and bundled `manifest` before
+    /// the row is queued, so warm and cold installs see the same slot.
+    /// `None` (ordinary registry/tarball packages) is a no-op — they
+    /// carry their own `package.json`. See `apply_append_manifest`.
+    pub append_manifest: Option<&'a [u8]>,
 }
 
 /// Project [`TarballError`] onto pnpm's `requestRetryLogger`'s
@@ -2213,6 +2273,7 @@ impl<'a> DownloadTarballToStore<'a> {
             prefetched_cas_paths,
             retry_opts,
             auth_headers,
+            append_manifest,
             ..
         } = self;
         let store_index = self.store_index.clone();
@@ -2313,7 +2374,7 @@ impl<'a> DownloadTarballToStore<'a> {
         // re-fetch instead of aborting the install
         // (<https://github.com/pnpm/pacquet/issues/259>). Only HTTP 401 / 403 / 404 fail fast — see
         // [`is_transient_error`].
-        let (_computed_integrity, cas_paths, pkg_files_idx) =
+        let (_computed_integrity, mut cas_paths, mut pkg_files_idx) =
             fetch_and_extract_with_retry::<Reporter>(
                 http_client,
                 package_url,
@@ -2329,6 +2390,12 @@ impl<'a> DownloadTarballToStore<'a> {
                 progress_key,
             )
             .await?;
+
+        // Fold the synthesized runtime `package.json` into the row before
+        // it is persisted, so warm reinstalls (which read the row) get it.
+        if let Some(manifest_bytes) = append_manifest {
+            apply_append_manifest(store_dir, manifest_bytes, &mut cas_paths, &mut pkg_files_idx)?;
+        }
 
         // Hand the per-tarball files index off to the shared writer task
         // from <https://github.com/pnpm/pacquet/pull/265> *after* the retry loop returns, so transient failures
@@ -2752,6 +2819,11 @@ pub struct DownloadZipArchiveToStore<'a> {
     /// [`TarballError::NoOfflineTarball`] rather than hitting the
     /// network.
     pub offline: bool,
+    /// Synthesized `package.json` to fold into the extracted archive.
+    /// See [`DownloadTarballToStore::append_manifest`] — same
+    /// `appendManifest` semantics for the zip path, used for the
+    /// runtime archives (e.g. Deno / Bun) that arrive as zips.
+    pub append_manifest: Option<&'a [u8]>,
 }
 
 impl DownloadZipArchiveToStore<'_> {
@@ -2775,6 +2847,7 @@ impl DownloadZipArchiveToStore<'_> {
             retry_opts,
             auth_headers,
             archive_prefix,
+            append_manifest,
             ..
         } = self;
         let store_index = self.store_index.clone();
@@ -2831,7 +2904,7 @@ impl DownloadZipArchiveToStore<'_> {
 
         tracing::info!(target: "pacquet::download", ?package_url, "New cache (zip)");
 
-        let (cas_paths, pkg_files_idx) = fetch_and_extract_zip_with_retry::<Reporter>(
+        let (mut cas_paths, mut pkg_files_idx) = fetch_and_extract_zip_with_retry::<Reporter>(
             http_client,
             package_url,
             package_integrity,
@@ -2844,6 +2917,12 @@ impl DownloadZipArchiveToStore<'_> {
             ignore_file_pattern,
         )
         .await?;
+
+        // Fold the synthesized runtime `package.json` into the row before
+        // it is persisted, so warm reinstalls (which read the row) get it.
+        if let Some(manifest_bytes) = append_manifest {
+            apply_append_manifest(store_dir, manifest_bytes, &mut cas_paths, &mut pkg_files_idx)?;
+        }
 
         let index_key = store_index_key(&package_integrity.to_string(), package_id);
         if let Some(writer) = store_index_writer {

--- a/pacquet/crates/tarball/src/tests.rs
+++ b/pacquet/crates/tarball/src/tests.rs
@@ -1,10 +1,10 @@
 use super::{
     DownloadTarballToStore, FetchTarballForResolution, HttpStatusError, MemCache, NetworkError,
     PrefetchedCasPaths, RetryOpts, SharedReportedProgressKeys, TarballError, VerifyChecksumError,
-    allocate_local_tarball_buffer, allocate_tarball_buffer, download_priority,
-    extract_tarball_entries, extract_zip_entries, fetch_and_extract_with_retry, is_transient_error,
-    local_file_tarball_path, normalize_bundled_manifest, open_local_tarball, prefetch_cas_paths,
-    read_local_tarball_buffer,
+    allocate_local_tarball_buffer, allocate_tarball_buffer, apply_append_manifest,
+    download_priority, extract_tarball_entries, extract_zip_entries, fetch_and_extract_with_retry,
+    is_transient_error, local_file_tarball_path, normalize_bundled_manifest, open_local_tarball,
+    prefetch_cas_paths, read_local_tarball_buffer,
 };
 use pacquet_network::{AuthHeaders, ThrottledClient, UNPRIORITIZED};
 use pacquet_reporter::SilentReporter;
@@ -188,6 +188,7 @@ async fn packages_under_orgs_should_work() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
+        append_manifest: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -252,6 +253,7 @@ async fn network_fetch_records_progress_key() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: Some(SharedReportedProgressKeys::clone(&progress_reported)),
+        append_manifest: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -288,6 +290,7 @@ async fn should_throw_error_on_checksum_mismatch() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
+        append_manifest: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -371,6 +374,7 @@ async fn reuses_cached_cas_paths_when_index_entry_is_live() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: Some(SharedReportedProgressKeys::clone(&progress_reported)),
+        append_manifest: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -438,6 +442,7 @@ async fn reuses_prefetched_cas_paths_when_provided() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
+        append_manifest: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -719,6 +724,7 @@ async fn falls_through_when_cafs_file_missing() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
+        append_manifest: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -780,6 +786,7 @@ async fn falls_through_when_digest_is_malformed() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
+        append_manifest: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -846,6 +853,7 @@ async fn falls_through_when_cafs_path_is_a_directory() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
+        append_manifest: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -922,6 +930,7 @@ async fn falls_through_when_cafs_path_is_a_symlink() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
+        append_manifest: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -1273,6 +1282,7 @@ async fn run_without_mem_cache_reads_local_file_tarball() {
         ignore_file_pattern: None,
         offline: true,
         progress_reported: None,
+        append_manifest: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -1667,6 +1677,7 @@ fn run_with_mem_cache_does_not_deadlock_on_dashmap_shard_contention() {
                     ignore_file_pattern: None,
                     offline: false,
                     progress_reported: None,
+                    append_manifest: None,
                 };
 
                 // Spawn each task and yield once before the next so the
@@ -1961,6 +1972,7 @@ async fn mem_cache_hit_emits_found_in_store_against_callers_reporter() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
+        append_manifest: None,
     }
     .run_with_mem_cache::<pacquet_reporter::SilentReporter>(&mem_cache)
     .await
@@ -1990,6 +2002,7 @@ async fn mem_cache_hit_emits_found_in_store_against_callers_reporter() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
+        append_manifest: None,
     }
     .run_with_mem_cache::<RecordingReporter>(&mem_cache)
     .await
@@ -2086,6 +2099,7 @@ async fn mem_cache_hit_skips_package_status_when_progress_already_reported() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: Some(SharedReportedProgressKeys::clone(&progress_reported)),
+        append_manifest: None,
     }
     .run_with_mem_cache::<RecordingReporter>(&mem_cache)
     .await
@@ -2124,6 +2138,7 @@ async fn mem_cache_hit_skips_package_status_when_progress_already_reported() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: Some(SharedReportedProgressKeys::clone(&progress_reported)),
+        append_manifest: None,
     }
     .run_with_mem_cache::<RecordingReporter>(&mem_cache)
     .await
@@ -2206,6 +2221,7 @@ async fn run_with_mem_cache_recovers_from_owning_fetch_error() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
+        append_manifest: None,
     };
 
     // Drive both calls concurrently. One hits the `else` branch and
@@ -2493,6 +2509,7 @@ async fn found_in_store_event_fires_on_cache_hit() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
+        append_manifest: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -2533,6 +2550,7 @@ async fn found_in_store_event_fires_on_cache_hit() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
+        append_manifest: None,
     }
     .run_without_mem_cache::<RecordingReporter>()
     .await
@@ -2920,6 +2938,7 @@ async fn offline_mode_skips_network_on_cache_miss() {
         ignore_file_pattern: None,
         offline: true,
         progress_reported: None,
+        append_manifest: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -2992,6 +3011,7 @@ async fn offline_mode_still_uses_prefetched_cache() {
         ignore_file_pattern: None,
         offline: true,
         progress_reported: None,
+        append_manifest: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -3188,4 +3208,54 @@ fn download_priority_never_reaches_the_latency_sentinel() {
     let priority = download_priority(Some(usize::MAX), Some(usize::MAX));
     assert!(priority < UNPRIORITIZED);
     assert_eq!(priority, UNPRIORITIZED - 1);
+}
+
+/// A runtime archive (Node.js / Bun / Deno) ships no `package.json`, so
+/// `apply_append_manifest` must bake the synthesized manifest into the
+/// persisted store-index row — both its `files` map and its bundled
+/// `manifest` — and into this install's `cas_paths`. Without the row
+/// entry, a later *warm* materialization reads a `package.json`-less row
+/// and `pnpm dlx node@runtime:<v>` fails with `dlx_read_manifest`.
+#[test]
+fn apply_append_manifest_folds_the_synthesized_manifest_into_the_row() {
+    let (_keep, store_path) = tempdir_with_leaked_path();
+    let manifest_bytes =
+        br#"{"name":"node","version":"26.4.0","bin":{"node":"bin/node"}}"#.to_vec();
+    let mut cas_paths = HashMap::new();
+    let mut idx = PackageFilesIndex { algo: "sha512".to_string(), ..Default::default() };
+
+    apply_append_manifest(store_path, &manifest_bytes, &mut cas_paths, &mut idx)
+        .expect("write the synthesized manifest into the CAS");
+
+    // This install's slot materializes the manifest...
+    assert!(cas_paths.contains_key("package.json"), "cas_paths gains package.json");
+    // ...and so does the persisted row, so warm reinstalls get it too.
+    let file = idx.files.get("package.json").expect("row records the package.json file");
+    assert_eq!(file.size, manifest_bytes.len() as u64);
+    assert!(!file.digest.is_empty(), "the synthesized file is content-addressed");
+    // The bundled manifest carries the runtime's bin so the warm-batch
+    // bin linker links it without stat-ing the slot's package.json.
+    let manifest = idx.manifest.expect("row records the bundled manifest");
+    assert_eq!(manifest.get("bin"), Some(&serde_json::json!({ "node": "bin/node" })));
+}
+
+/// An ordinary npm tarball already carries its own `package.json`;
+/// `apply_append_manifest` must leave it untouched (pnpm's `manifest ==
+/// null` guard) rather than displacing the real manifest with a
+/// synthesized one.
+#[test]
+fn apply_append_manifest_is_a_noop_when_the_archive_ships_a_package_json() {
+    let (_keep, store_path) = tempdir_with_leaked_path();
+    let existing =
+        CafsFileInfo { digest: "kept".to_string(), mode: 0o644, size: 3, checked_at: None };
+    let mut idx = PackageFilesIndex { algo: "sha512".to_string(), ..Default::default() };
+    idx.files.insert("package.json".to_string(), existing);
+    let mut cas_paths = HashMap::new();
+
+    apply_append_manifest(store_path, br#"{"name":"node"}"#, &mut cas_paths, &mut idx)
+        .expect("a no-op still returns Ok");
+
+    assert!(cas_paths.is_empty(), "the real package.json is not overwritten in cas_paths");
+    assert_eq!(idx.files["package.json"].digest, "kept", "the row's real file entry is kept");
+    assert!(idx.manifest.is_none(), "the archive's manifest handling is left alone");
 }

--- a/pacquet/plans/TEST_PORTING.md
+++ b/pacquet/plans/TEST_PORTING.md
@@ -575,12 +575,19 @@ The runtime lockfile *format* (importer `version: runtime:<ver>`, the
 `nodeRuntime.ts:236-269`) is covered at pacquet's adapter/resolver layer by
 `dependencies_graph_to_lockfile::tests::runtime_dependency_strips_importer_prefix_and_records_package_version`
 and `node_resolver::tests::bin_spec_is_a_named_map`. The full
-install-and-reinstall integration tests below are still unported (they
-download real runtime artifacts).
+install-and-reinstall integration tests below are still unported end-to-end
+against a real mirror (they download real runtime artifacts), but the
+*cold-install → wipe → offline-reinstall* regression at their core — a
+runtime archive ships no `package.json`, so the synthesized manifest must
+be baked into the persisted store-index row for the warm reinstall to
+re-materialize it (pnpm/pnpm#12811) — is covered without the network by
+`install_package_by_snapshot::tests::installing_a_runtime_persists_the_synthesized_manifest_into_the_store_index_row`
+(drives `InstallPackageBySnapshot` on a `Binary` resolution pointing at a
+local `file:` runtime-archive fixture).
 
 Node runtime tests:
 
-- [ ] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:209` `installing Node.js runtime` includes frozen/offline reinstall after deleting `node_modules`.
+- [ ] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:209` `installing Node.js runtime` includes frozen/offline reinstall after deleting `node_modules`. _(Regression core — the offline reinstall re-materializing the synthesized `package.json` — is covered by `installing_a_runtime_persists_the_synthesized_manifest_into_the_store_index_row`; the real-download lockfile-shape / musl-variant / npm+corepack-filter assertions remain unported.)_
 - [ ] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:332` `installing node.js runtime fails if offline mode is used and node.js not found locally`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:339` `installing Node.js runtime from RC channel`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:346` `installing Node.js runtime fails if integrity check fails` verifies frozen integrity failure.

--- a/pacquet/tasks/micro-benchmark/src/main.rs
+++ b/pacquet/tasks/micro-benchmark/src/main.rs
@@ -55,6 +55,7 @@ fn bench_tarball(criterion: &mut Criterion, server: &mut ServerGuard, fixtures_f
                 ignore_file_pattern: None,
                 offline: false,
                 progress_reported: None,
+                append_manifest: None,
             }
             .run_without_mem_cache::<pacquet_reporter::SilentReporter>()
             .await


### PR DESCRIPTION
## Summary

Fixes the `TS CI / Compile & Lint` failure seen after bumping the repo to the
Rust pnpm alpha (Related to pnpm/pnpm#12811). The `compile-only` script runs
`pnpm dlx node@runtime:26.4.0 …`, which died with:

```
Error: pacquet_cli::dlx_read_manifest
  × Failed to read the installed manifest at …/node_modules/node/package.json:
    No such file or directory (os error 2)
```

**Root cause.** Runtime archives (Node.js / Bun / Deno) ship no `package.json`,
so pacquet synthesizes one (`name`, `version`, `bin`). That synthesized
manifest was only added to the **in-memory** `cas_paths` in
`fetch_binary_resolution_to_cas`, *after* the download had already queued the
store-index row. The persisted `PackageFilesIndex` therefore recorded no
`package.json` and no bundled `manifest`.

A **cold** fetch masks this — the current install's slot still gets the
manifest from `cas_paths`. But a later **warm** install materializes the
runtime straight from the store-index row (via the warm-batch prefetch, which
never calls `fetch_binary_resolution_to_cas`), so the slot lands without a
`package.json` and the warm-batch bin linker finds no bin. That is exactly the
CI sequence: the root install cold-fetches `node@runtime:26.4.0`, then the
later `pnpm dlx node@runtime:26.4.0` warm-reads the manifest-less row and dies
in `getBinName`.

**Fix.** Thread the synthesized manifest into the two binary download paths as
`append_manifest`, mirroring pnpm's `appendManifest`: fold it into the
extracted output's `cas_paths`, the row's `files` map, and its bundled
`manifest` **before** the row is persisted. Warm and cold installs now land the
same slot. This brings pacquet in line with the TypeScript stack, which already
bakes `appendManifest` into the files index via `addManifestToCafs` — no
TypeScript change is needed.

Verified end-to-end by reproducing the CI two-step (`install` then warm `dlx
node@runtime:26.4.0 --version`) against an isolated store: it fails on the
pre-fix binary with `dlx_read_manifest` and succeeds (`v26.4.0`) on the fixed
binary.

**Regression test.** `installing_a_runtime_persists_the_synthesized_manifest_into_the_store_index_row`
(`install_package_by_snapshot/tests.rs`) ports the core of
`installing/deps-installer/test/install/nodeRuntime.ts:209` (cold install →
`rimraf node_modules` → offline reinstall) network-free: it drives
`InstallPackageBySnapshot` on a `Binary` resolution pointing at a local `file:`
runtime-archive fixture, asserts the persisted store-index row carries the
synthesized `package.json` in both `files` and the bundled `manifest`, and that
a warm/offline reinstall (fixture deleted) re-materializes it. Confirmed to fail
when the fix is neutered. Plus unit tests for `apply_append_manifest`. The
real-download lockfile-shape / musl-variant assertions of `nodeRuntime.ts`
remain unported — tracked in `pacquet/plans/TEST_PORTING.md`.

> Note: CI will only turn green once a new alpha built from this fix is
> released and the repo's package-manager version is bumped to it.

> Follow-up (out of scope): a store whose runtime row was written by a *pre-fix*
> tool still lacks the manifest and won't be rewritten on a warm hit. Matching
> pnpm's `getBinName` fallback (plus resolution-driven bin links) would harden
> that case; it needs its own change.

## Squash Commit Body

```text
Runtime archives (Node.js / Bun / Deno) ship no package.json, so pacquet
synthesizes one carrying name, version, and bin. That synthesized manifest was
only added to the in-memory cas_paths in fetch_binary_resolution_to_cas, after
the download had already queued the store-index row, so the persisted
PackageFilesIndex recorded no package.json and no bundled manifest.

A cold fetch masks this — the current install's slot still gets the manifest
from cas_paths. But a warm install materializes the runtime straight from the
store-index row (via the warm-batch prefetch, which never calls
fetch_binary_resolution_to_cas), so the slot lands without a package.json and
the warm-batch bin linker finds no bin. That is the CI failure on
pnpm/pnpm#12811: the root install cold-fetches node@runtime:26.4.0 and the
later pnpm dlx node@runtime:26.4.0 warm-reads the manifest-less row and dies in
getBinName with dlx_read_manifest.

Thread the synthesized manifest into the two binary download paths as
append_manifest, mirroring pnpm's appendManifest: fold it into the extracted
output's cas_paths, the row's files map, and its bundled manifest before the
row is persisted, so warm and cold installs land the same slot. This brings
pacquet in line with the TypeScript stack, which already bakes appendManifest
into the files index via addManifestToCafs.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting. _(pacquet
  only — the TypeScript stack already has this behavior via `appendManifest`.)_
- [x] Added or updated tests. _(A network-free e2e regression test porting
  `nodeRuntime.ts:209`'s cold→wipe→offline-reinstall core, plus unit tests for
  `apply_append_manifest`; verified against the pre-fix/fixed binaries and by
  neutering the fix.)_

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of runtime archive installs (Node.js, Bun, Deno) when the archive omits `package.json`: pacquet now persists the synthesized `package.json` and bundled runtime manifest into the stored index during import, enabling correct warm reinstalls and offline use.
  * If the archive already includes a real `package.json`, existing behavior remains unchanged to avoid duplicate/incorrect metadata.

* **Tests**
  * Added an end-to-end offline regression test covering synthesized manifest persistence and re-materialization on reinstall.

* **Documentation**
  * Updated runtime installation test notes to match current coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->