### PR TITLE
fix(deps-resolver): don't reuse a locked optional peer with no visible provider

### DIFF
--- a/.changeset/optional-peer-lockfile-drift.md
+++ b/.changeset/optional-peer-lockfile-drift.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+`pnpm install` no longer re-propagates an optional transitive peer dependency onto unrelated packages when regenerating the lockfile after a manifest edit. The locked-peer-context reuse pass now skips an optional peer whose provider is not visible in the resolving package's scope, matching a fresh resolution and `pnpm dedupe`. This fixes lockfile drift where an unrelated `pnpm install` would add peer suffixes that `pnpm dedupe` would immediately remove.

--- a/pnpm11/installing/deps-resolver/src/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/src/resolvePeers.ts
@@ -501,6 +501,16 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
       const currentPeerDepPath = ctx.pathsByNodeId.get(peerNodeId)
       if (currentPeerDepPath != null && currentPeerDepPath !== previousPeerDepPath) continue
       if (hasCurrentPeerProviderThatMustWin(peerName, parentPkgs, ctx)) continue
+      // An optional peer only binds when a provider is actually visible in the
+      // resolving package's scope; a fresh resolution / `pnpm dedupe` leaves it
+      // unbound otherwise. `parentPkgs` holds the peer providers visible from
+      // the current ancestor chain, so if it has no entry for an optional peer,
+      // reusing the locked provider would bind it laterally to a provider in an
+      // unrelated sibling subtree, spuriously adding a peer suffix that a fresh
+      // resolution never produces. Required peers may still reuse a locked
+      // lateral provider — that is the context preservation this pass exists for.
+      // See https://github.com/pnpm/pnpm/issues/12756.
+      if (peerDependency.optional === true && parentPkgs[peerName] == null) continue
       const lockedPeer = toPkgByName([{
         alias: peerName,
         node: ctx.dependenciesTree.get(peerNodeId)!,

--- a/pnpm11/installing/deps-resolver/test/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/test/resolvePeers.ts
@@ -1112,6 +1112,64 @@ describe('locked peer provider preferences', () => {
     expect(preferred.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeTruthy()
     expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
   })
+
+  test('does not reuse a locked provider for an optional peer that is not visible in scope', async () => {
+    // Regression test for https://github.com/pnpm/pnpm/issues/12756. The
+    // consumer's peer is OPTIONAL and its only provider (peer@2.0.0) lives in an
+    // unrelated sibling subtree (under retainer), so it is not visible from the
+    // consumer's own scope. A fresh resolution leaves the optional peer unbound,
+    // so the locked-context reuse pass must not re-bind it — doing so would add
+    // a `(peer@2.0.0)` suffix that `pnpm install` produces but `pnpm dedupe`
+    // does not, drifting the lockfile. Contrast with the childless-consumer test
+    // above, where the peer is required and reusing the lateral provider is
+    // correct.
+    const optionalConsumerPkg = {
+      ...consumerPkg,
+      peerDependencies: {
+        peer: { version: '>=1', optional: true },
+      },
+    }
+    const dependenciesTree = new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+      [retainerNodeId, {
+        children: { peer: retainedPeerNodeId },
+        installable: true,
+        resolvedPackage: retainerPkg,
+        depth: 0,
+      }],
+      [retainedPeerNodeId, {
+        children: {},
+        installable: true,
+        previousDepPath: 'peer/2.0.0' as DepPath,
+        resolvedPackage: peer2Pkg,
+        depth: 1,
+      }],
+      [wrapperNodeId, {
+        children: { consumer: consumerNodeId },
+        installable: true,
+        resolvedPackage: wrapperPkg,
+        depth: 0,
+      }],
+      [consumerNodeId, {
+        children: {},
+        installable: true,
+        lockedPeerContext: { peer: 'peer/2.0.0' as DepPath },
+        resolvedPackage: optionalConsumerPkg,
+        depth: 1,
+      }],
+    ])
+    const resolutionOpts = options(dependenciesTree, new Map([
+      ['retainer', retainerNodeId],
+      ['wrapper', wrapperNodeId],
+    ]))
+    const initial = await resolvePeers(resolutionOpts)
+    const preferred = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+
+    expect(preferred.dependenciesGraph['consumer/1.0.0' as DepPath]).toBeTruthy()
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+  })
 })
 
 describe('dedupePeers', () => {


### PR DESCRIPTION
**Closed in favor of #13109**

## Summary

Fixes pnpm/pnpm#12756 — a writable `pnpm install` re-propagates an **optional** transitive peer onto unrelated packages after a manifest edit, producing lockfile churn that a follow-up `pnpm dedupe` immediately undoes.

The fix is one guard in the locked-peer-context reuse pass: an optional peer is only re-bound from the lockfile when a provider for it is actually visible in the resolving package's scope — matching a fresh resolution and `pnpm dedupe`.

## The bug

Starting from a `dedupe`-stable lockfile, removing one unrelated dependency and running `pnpm install` adds a spurious peer suffix:

```yaml
# before (dedupe-stable)                # after `pnpm install` (BUG)
agent-base@6.0.2:                       agent-base@6.0.2(supports-color@5.5.0):
  dependencies:                           dependencies:
    debug: 4.4.3(supports-color@5.5.0)      debug: 4.4.3(supports-color@5.5.0)
  transitivePeerDependencies:             transitivePeerDependencies:
    - supports-color                        - supports-color
```

`agent-base` has no peer dependencies of its own, yet it gains a `(supports-color@5.5.0)` suffix. In a small repro this is one line; in a large monorepo a single manifest edit rewrote **hundreds** of lockfile lines (134 unrelated packages gaining the suffix). `pnpm dedupe` removes them all, but running `dedupe` in CI is expensive — so a `dedupe`-stable lockfile can't be maintained with `install` alone.

Minimal reproduction: https://github.com/astegmaier/playground-pnpm-lockfile-drift-bug

## How the regression emerged

Bisected to **pnpm@11.5.2**, introduced by pnpm/pnpm#12083 — *"prefer locked peer contexts during resolution by default"*. That change added a second peer-resolution pass that reuses the peer contexts already recorded in the lockfile, so a writable install keeps a locked provider instead of collapsing contexts.

For a **required** peer that is exactly what we want. But the reuse pass finds the locked provider through a **global** lookup (`nodeIdsByPreviousDepPath`), not through the resolving node's own visible scope. For an **optional** peer whose provider lives in an unrelated sibling subtree, the pass pins it anyway — binding a peer that a fresh resolution would have left unbound, and pushing a peer suffix onto the (previously suffix-free) consumer.

Every release from 11.5.2 through 11.10.0 reproduces it; 11.5.1 and earlier are clean.

## The fix

`installing/deps-resolver/src/resolvePeers.ts`, inside the locked-peer-context reuse block:

```ts
if (peerDependency.optional === true && parentPkgs[peerName] == null) continue
```

`parentPkgs` holds the peer providers reachable from the current node's ancestor chain. An optional peer only binds when a provider is visible there; if `parentPkgs` has no entry for it, a fresh resolution / `pnpm dedupe` leaves it unbound, so the reuse pass must not re-bind it either.

### Worked example (the diagram above)

- `debug` optionally peer-depends on `supports-color`.
- A sibling package brings in both `debug` and `supports-color`, so the lockfile has a shared `debug@4.4.3(supports-color@5.5.0)` snapshot whose locked context records `supports-color`.
- `agent-base` depends only on `debug`; `supports-color` is **not** visible in `agent-base`'s subtree.

When the reuse pass processes `debug` under `agent-base`, it finds the `supports-color` provider node globally and, before this fix, pins it — so `debug`'s optional peer binds inside `agent-base`'s context and the suffix propagates up to `agent-base`. With the fix, `parentPkgs['supports-color'] == null` for that node, so the optional peer is left to normal resolution (resolved from the shared/hoisted context, as a `transitivePeerDependency`) and `agent-base` stays suffix-free — identical to `pnpm dedupe`.

## Why it's safe

- **Narrowly scoped.** The guard only affects the reuse pass, which only runs on writable installs when the tree already contains locked peer contexts. It changes behavior solely for an optional peer that has *no visible provider* — precisely the case a fresh resolution leaves unbound.
- **Required peers are untouched.** They still reuse a locked lateral provider, preserving the context-stability behavior pnpm/pnpm#12083 added (its `abc-parent-with-ab` two-context scenario and the childless-consumer required-peer case both still pass).
- **`install` now matches `dedupe`.** On the minimal repro the drift goes from 5→3 suffix positions to a stable 3/3; on a large real-world monorepo a manifest edit that previously rewrote 400+ lines now yields only the minimal change, and `pnpm install` produces a byte-identical lockfile to `pnpm dedupe`.

## Tests

- New unit regression test in `installing/deps-resolver/test/resolvePeers.ts` (*"does not reuse a locked provider for an optional peer that is not visible in scope"*), verified red without the fix and green with it, alongside the existing locked-peer-context tests.
- Full `@pnpm/installing.deps-resolver` unit suite and the end-to-end peer-dependency suites pass, including the pnpm/pnpm#12083 context-preservation cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented optional peer dependencies from being reused across unrelated package scopes after manifest changes.
  * Reduced lockfile drift so installs no longer add peer suffixes that are later removed by dependency cleanup.
  * Kept dependency resolution aligned with a fresh install and deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->