### PR TITLE
fix: pnpm cache delete removes a package from all metadata cache directories

### DIFF
--- a/.changeset/cache-delete-all-metadata-dirs.md
+++ b/.changeset/cache-delete-all-metadata-dirs.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/cache.commands": patch
+"pnpm": patch
+---
+
+`pnpm cache delete` now removes a package's metadata from every metadata cache directory (`metadata`, `metadata-full`, and `metadata-full-filtered`), instead of only the one the current resolution mode reads. Previously a package cached under a different mode (e.g. `metadata-full-filtered`) was left behind. Closes pnpm/pnpm#12753.

--- a/pnpm/crates/cli/src/cli_args/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/cache.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use miette::IntoDiagnostic;
 use pacquet_config::{Config, ResolutionMode};
 use pacquet_resolving_npm_resolver::mirror::{
-    ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, get_registry_name, load_meta,
+    ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, get_registry_name, load_meta,
 };
 use pacquet_store_dir::StoreIndex;
 use serde_json::json;
@@ -128,15 +128,26 @@ impl CacheCommand {
                 }
             }
             CacheCommand::Delete { packages } => {
-                if !cache_dir.exists() {
-                    return Ok(());
+                // A package's metadata can be cached under any of the metadata
+                // directories depending on the resolution mode used when it was
+                // fetched, so delete from all of them, not only the one the
+                // current mode reads.
+                let mut deleted: Vec<String> = Vec::new();
+                for meta_dir in [ABBREVIATED_META_DIR, FULL_META_DIR, FULL_FILTERED_META_DIR] {
+                    let dir = config.cache_dir.join(meta_dir);
+                    if !dir.exists() {
+                        continue;
+                    }
+                    let meta_files = Self::find_metadata_files(config, &dir, &packages)?;
+                    for meta_file in &meta_files {
+                        fs::remove_file(dir.join(meta_file)).into_diagnostic()?;
+                    }
+                    deleted.extend(meta_files);
                 }
-                let meta_files = Self::find_metadata_files(config, &cache_dir, &packages)?;
-                for meta_file in &meta_files {
-                    fs::remove_file(cache_dir.join(meta_file)).into_diagnostic()?;
-                }
-                if !meta_files.is_empty() {
-                    println!("{}", meta_files.join("\n"));
+                deleted.sort();
+                deleted.dedup();
+                if !deleted.is_empty() {
+                    println!("{}", deleted.join("\n"));
                 }
             }
             CacheCommand::View { package } => {

--- a/pnpm/crates/cli/tests/cache.rs
+++ b/pnpm/crates/cli/tests/cache.rs
@@ -126,7 +126,11 @@ fn should_delete_packages_from_all_metadata_dirs() {
         pacquet_resolving_npm_resolver::mirror::get_registry_name(&url_str).unwrap();
     // A package can be cached under any metadata directory depending on the
     // resolution mode used at fetch time, so all of them must be cleared.
-    let meta_dirs = ["v11/metadata", "v11/metadata-full", "v11/metadata-full-filtered"];
+    let meta_dirs = [
+        pacquet_resolving_npm_resolver::mirror::ABBREVIATED_META_DIR,
+        pacquet_resolving_npm_resolver::mirror::FULL_META_DIR,
+        pacquet_resolving_npm_resolver::mirror::FULL_FILTERED_META_DIR,
+    ];
     for meta_dir in meta_dirs {
         let dir = cwd.npmrc_info.cache_dir.join(meta_dir).join(&registry_name);
         fs::create_dir_all(&dir).unwrap();

--- a/pnpm/crates/cli/tests/cache.rs
+++ b/pnpm/crates/cli/tests/cache.rs
@@ -118,6 +118,31 @@ fn should_delete_packages() {
 }
 
 #[test]
+fn should_delete_packages_from_all_metadata_dirs() {
+    let cwd = CommandTempCwd::init().add_mocked_registry();
+
+    let url_str = cwd.npmrc_info.mock_instance.url();
+    let registry_name =
+        pacquet_resolving_npm_resolver::mirror::get_registry_name(&url_str).unwrap();
+    // A package can be cached under any metadata directory depending on the
+    // resolution mode used at fetch time, so all of them must be cleared.
+    let meta_dirs = ["v11/metadata", "v11/metadata-full", "v11/metadata-full-filtered"];
+    for meta_dir in meta_dirs {
+        let dir = cwd.npmrc_info.cache_dir.join(meta_dir).join(&registry_name);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("is-positive.jsonl"), "{}").unwrap();
+    }
+
+    cwd.pacquet.with_arg("cache").with_arg("delete").with_arg("is-positive").assert().success();
+
+    for meta_dir in meta_dirs {
+        let file =
+            cwd.npmrc_info.cache_dir.join(meta_dir).join(&registry_name).join("is-positive.jsonl");
+        assert!(!file.exists(), "expected {file:?} to be deleted");
+    }
+}
+
+#[test]
 fn should_view_package_cache() {
     let cwd = CommandTempCwd::init().add_mocked_registry();
     let cache_dir = cwd.npmrc_info.cache_dir.join("v11").join("metadata");

--- a/pnpm11/cache/commands/src/cache.cmd.ts
+++ b/pnpm11/cache/commands/src/cache.cmd.ts
@@ -8,7 +8,7 @@ import {
 } from '@pnpm/cache.api'
 import { docsUrl } from '@pnpm/cli.utils'
 import { type Config, type ConfigContext, types as allTypes } from '@pnpm/config.reader'
-import { ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR } from '@pnpm/constants'
+import { ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR } from '@pnpm/constants'
 import { PnpmError } from '@pnpm/error'
 import { getStorePath } from '@pnpm/store.path'
 import { pick } from 'ramda'
@@ -78,12 +78,20 @@ export async function handler (opts: CacheCommandOptions, params: string[]): Pro
         cacheDir,
         registry: opts.cliOptions['registry'],
       }, params.slice(1))
-    case 'delete':
-      return cacheDelete({
-        ...opts,
-        cacheDir,
-        registry: opts.cliOptions['registry'],
-      }, params.slice(1))
+    case 'delete': {
+      // A package's metadata can be cached under any of the metadata directories
+      // depending on the resolution mode used when it was fetched.
+      const deleted = await Promise.all(
+        [ABBREVIATED_META_DIR, FULL_META_DIR, FULL_FILTERED_META_DIR].map((metaDir) =>
+          cacheDelete({
+            ...opts,
+            cacheDir: path.join(opts.cacheDir, metaDir),
+            registry: opts.cliOptions['registry'],
+          }, params.slice(1))
+        )
+      )
+      return [...new Set(deleted.flatMap((result) => result.split('\n')).filter(Boolean))].sort().join('\n')
+    }
     case 'view': {
       if (!params[1]) {
         throw new PnpmError('MISSING_PACKAGE_NAME', '`pnpm cache view` requires the package name')

--- a/pnpm11/cache/commands/test/cacheDelete.cmd.test.ts
+++ b/pnpm11/cache/commands/test/cacheDelete.cmd.test.ts
@@ -1,7 +1,9 @@
+import fs from 'node:fs'
 import path from 'node:path'
 
 import { beforeEach, describe, expect, test } from '@jest/globals'
 import { cache } from '@pnpm/cache.commands'
+import { ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR } from '@pnpm/constants'
 import { prepare } from '@pnpm/prepare'
 import { REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import { rimrafSync } from '@zkochan/rimraf'
@@ -53,5 +55,48 @@ describe('cache delete', () => {
 
     expect(result).toBe(`localhost+${REGISTRY_MOCK_PORT}/is-negative.jsonl
 registry.npmjs.org/is-negative.jsonl`)
+  })
+})
+
+describe('cache delete across metadata directories', () => {
+  test('deletes a package from every metadata cache directory, not only the one the current mode reads', async () => {
+    prepare()
+    const cacheDir = path.resolve('cache')
+    const registryName = 'registry.npmjs.org'
+    const metaDirs = [ABBREVIATED_META_DIR, FULL_META_DIR, FULL_FILTERED_META_DIR]
+    const sentinel = (metaDir: string) => path.join(cacheDir, metaDir, registryName, '@vue', 'compiler-core.jsonl')
+    for (const metaDir of metaDirs) {
+      fs.mkdirSync(path.dirname(sentinel(metaDir)), { recursive: true })
+      fs.writeFileSync(sentinel(metaDir), '')
+    }
+
+    const result = await cache.handler({
+      cacheDir,
+      cliOptions: {},
+      pnpmHomeDir: cacheDir,
+    }, ['delete', '@vue/compiler-core'])
+
+    for (const metaDir of metaDirs) {
+      expect(fs.existsSync(sentinel(metaDir))).toBe(false)
+    }
+    expect(result).toBe(`${registryName}/@vue/compiler-core.jsonl`)
+  })
+
+  test('deletes metadata cached under a non-current mode even when the other directories are absent', async () => {
+    prepare()
+    const cacheDir = path.resolve('cache')
+    // The default mode reads `metadata`, but the package is only cached under
+    // `metadata-full-filtered` and the other directories don't exist.
+    const sentinel = path.join(cacheDir, FULL_FILTERED_META_DIR, 'registry.npmjs.org', '@vue', 'compiler-core.jsonl')
+    fs.mkdirSync(path.dirname(sentinel), { recursive: true })
+    fs.writeFileSync(sentinel, '')
+
+    await cache.handler({
+      cacheDir,
+      cliOptions: {},
+      pnpmHomeDir: cacheDir,
+    }, ['delete', '@vue/compiler-core'])
+
+    expect(fs.existsSync(sentinel)).toBe(false)
   })
 })


### PR DESCRIPTION
Fixes #12753.

## The bug

`pnpm cache delete <pkg>` leaves the package's metadata behind in some cache
directories. Per the issue: a package cached under `v11/metadata-full-filtered/`
(e.g. `@vue/compiler-core.jsonl`) is not removed by
`pnpm cache delete @vue/compiler-core`.

## Root cause

`cache` stores registry metadata under three directories depending on the
resolution mode used when it was fetched — `v11/metadata` (`ABBREVIATED_META_DIR`),
`v11/metadata-full` (`FULL_META_DIR`), and `v11/metadata-full-filtered`
(`FULL_FILTERED_META_DIR`). `delete`, however, resolves a single `cacheDir` from
the *current* mode and clears only that one
(`pnpm11/cache/commands/src/cache.cmd.ts`):

```ts
const cacheType = (opts.resolutionMode === 'time-based' && !opts.registrySupportsTimeField)
  ? FULL_FILTERED_META_DIR
  : ABBREVIATED_META_DIR
const cacheDir = path.join(opts.cacheDir, cacheType)
// ...
case 'delete':
  return cacheDelete({ ...opts, cacheDir, registry: opts.cliOptions['registry'] }, params.slice(1))
```

So metadata cached under a different mode is never deleted, and `FULL_META_DIR`
is never selected at all.

## The fix

`cache delete` now runs `cacheDelete` against all three metadata directories and
returns the de-duplicated union of what it removed. No new dependency:
`FULL_META_DIR` is already exported from `@pnpm/constants`.

The change is confined to the `delete` branch. `list` / `view` /
`list-registries` intentionally stay mode-scoped reads — a package must be
*deletable* regardless of which mode it was cached under, whereas aggregating the
read commands across directories is a separate behavior change and out of scope
for #12753.

## Testing

`jest test/cacheDelete.cmd.test.ts` (in `pnpm11/cache/commands`). Two
deterministic tests were added (no registry mock, since the delete path only
globs and unlinks — it never reads file content):

- one seeds a metadata sentinel for a package in all three directories, runs
  `cache delete <pkg>`, and asserts it is removed from every one and that the
  returned list is the de-duplicated path;
- one seeds only `metadata-full-filtered` (the reporter's case) and asserts the
  package is removed even when the other directories are absent.

The same tests, before and after the fix:

**Before** (fail — the non-selected directories keep the file):

```
● cache delete across metadata directories › deletes a package from every metadata cache directory...
  Expected: false
  Received: true
Tests: 2 failed, 1 skipped, 3 total
```

**After** (pass):

```
Tests: 1 skipped, 2 passed, 3 total
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm cache delete` now removes a package’s cached metadata from all supported metadata cache directory variants, regardless of the active resolution mode.
  * Prevents stale metadata from lingering in alternate cache locations.
  * Consolidates deletion output into a clean, de-duplicated, sorted list.

* **Tests**
  * Added unit and CLI integration coverage to verify deletion across abbreviated, full, and full-filtered metadata directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->