### PR TITLE
fix(pnpr): prevent stale hosted packument writes

### DIFF
--- a/pnpr/crates/pnpr/src/error.rs
+++ b/pnpr/crates/pnpr/src/error.rs
@@ -124,6 +124,13 @@ pub enum RegistryError {
         version: String,
     },
 
+    #[display("Hosted packument for package {package:?} changed while writing")]
+    #[from(skip)]
+    PackumentWriteConflict {
+        #[error(not(source))]
+        package: String,
+    },
+
     #[display(
         "Package {package}@{version} is listed in the local OSV database as vulnerable ({advisories})"
     )]
@@ -251,6 +258,7 @@ impl RegistryError {
             RegistryError::InvalidAttachment { .. } => "invalid_attachment",
             RegistryError::BadRequest { .. } => "bad_request",
             RegistryError::VersionAlreadyPublished { .. } => "version_already_published",
+            RegistryError::PackumentWriteConflict { .. } => "packument_write_conflict",
             RegistryError::OsvVulnerability { .. } => "osv_vulnerability",
             RegistryError::RegistrationDisabled => "registration_disabled",
             RegistryError::TooManyUsers { .. } => "too_many_users",
@@ -324,7 +332,8 @@ impl RegistryError {
             | RegistryError::InvalidConfig { .. }
             | RegistryError::InvalidAttachment { .. }
             | RegistryError::BadRequest { .. } => StatusCode::BAD_REQUEST,
-            RegistryError::VersionAlreadyPublished { .. } => StatusCode::CONFLICT,
+            RegistryError::VersionAlreadyPublished { .. }
+            | RegistryError::PackumentWriteConflict { .. } => StatusCode::CONFLICT,
             RegistryError::Unauthenticated { .. } => StatusCode::UNAUTHORIZED,
             RegistryError::Forbidden { .. } => StatusCode::FORBIDDEN,
             RegistryError::TeamsConfigManaged { .. } => StatusCode::FORBIDDEN,

--- a/pnpr/crates/pnpr/src/journal.rs
+++ b/pnpr/crates/pnpr/src/journal.rs
@@ -36,6 +36,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::HashSet,
     io::ErrorKind,
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
@@ -230,6 +231,7 @@ async fn roll_forward(storage: &Storage, dir: &Path) -> Result<()> {
             Some(org) => storage.for_hosted(org),
             None => storage.clone(),
         };
+        let mut conflicted: HashSet<&str> = HashSet::new();
         for tarball in &package.tarballs {
             // A missing tmp file was already promoted before the crash, so
             // skip it. But never read an I/O error as "missing": that would
@@ -245,15 +247,23 @@ async fn roll_forward(storage: &Storage, dir: &Path) -> Result<()> {
                 );
                 match store.finalize_tarball_slot(slot).await? {
                     TarballFinalize::Written | TarballFinalize::AlreadyIdentical => {}
-                    // Another replica already promoted a different tarball for
-                    // this version. Don't overwrite it; the re-merge below keeps
-                    // that winner's immutable version, so ours is dropped.
-                    TarballFinalize::Conflict => {}
+                    // Another replica already promoted a *different* tarball for
+                    // this version. Its bytes are immutable, so we must not
+                    // overwrite them — and we must not advertise our integrity
+                    // against them either. Drop our staged copy and record the
+                    // filename so the merge below excludes the version we lost.
+                    TarballFinalize::Conflict => {
+                        let _ = fs::remove_file(&tarball.tmp_path).await;
+                        conflicted.insert(tarball.filename.as_str());
+                    }
                 }
             }
         }
-        let journaled: serde_json::Value =
+        let mut journaled: serde_json::Value =
             serde_json::from_slice(&fs::read(dir.join(&package.packument_file)).await?)?;
+        if !conflicted.is_empty() {
+            drop_conflicted_versions(&mut journaled, &conflicted);
+        }
         write_merged_packument(&store, &name, &journaled).await?;
     }
     fs::remove_dir_all(dir).await?;
@@ -281,6 +291,36 @@ async fn write_merged_packument(
         )
         .await?;
     Ok(())
+}
+
+/// Drop from a journaled manifest every version whose staged tarball lost a
+/// compare-and-swap to another replica. The bytes at that (immutable) version
+/// key belong to the winner, so re-merging our `dist`/integrity for the version
+/// would advertise metadata that no longer matches the hosted tarball. Versions
+/// are matched to `conflicted` staged filenames by their `dist.tarball`
+/// basename; a version we cannot match is left in place.
+fn drop_conflicted_versions(journaled: &mut serde_json::Value, conflicted: &HashSet<&str>) {
+    let Some(versions) = journaled.get_mut("versions").and_then(serde_json::Value::as_object_mut)
+    else {
+        return;
+    };
+    versions.retain(|_version, manifest| {
+        let filename = manifest
+            .get("dist")
+            .and_then(|dist| dist.get("tarball"))
+            .and_then(serde_json::Value::as_str)
+            .map(tarball_basename);
+        match filename {
+            Some(filename) => !conflicted.contains(filename),
+            None => true,
+        }
+    });
+}
+
+/// The final path segment of a `dist.tarball` URL — the on-disk tarball
+/// filename that a staged slot is keyed by.
+fn tarball_basename(tarball_url: &str) -> &str {
+    tarball_url.rsplit('/').next().unwrap_or(tarball_url)
 }
 
 /// Discard an unsealed transaction: nothing of it ever became visible,
@@ -325,5 +365,40 @@ async fn sync_dir(dir: &Path) {
         && let Ok(file) = fs::File::open(dir).await
     {
         let _ = file.sync_all().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::drop_conflicted_versions;
+    use serde_json::json;
+    use std::collections::HashSet;
+
+    #[test]
+    fn drop_conflicted_versions_removes_only_the_lost_versions() {
+        let mut journaled = json!({
+            "versions": {
+                "1.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-1.0.0.tgz" } },
+                "2.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-2.0.0.tgz" } },
+                // A version with no resolvable tarball basename is kept as-is.
+                "3.0.0": { "dist": {} },
+            }
+        });
+        let conflicted: HashSet<&str> = std::iter::once("pkg-1.0.0.tgz").collect();
+
+        drop_conflicted_versions(&mut journaled, &conflicted);
+
+        let versions = journaled["versions"].as_object().unwrap();
+        assert!(!versions.contains_key("1.0.0"));
+        assert!(versions.contains_key("2.0.0"));
+        assert!(versions.contains_key("3.0.0"));
+    }
+
+    #[test]
+    fn drop_conflicted_versions_tolerates_a_missing_versions_map() {
+        let mut journaled = json!({ "name": "pkg" });
+        let conflicted: HashSet<&str> = std::iter::once("pkg-1.0.0.tgz").collect();
+        drop_conflicted_versions(&mut journaled, &conflicted);
+        assert_eq!(journaled, json!({ "name": "pkg" }));
     }
 }

--- a/pnpr/crates/pnpr/src/journal.rs
+++ b/pnpr/crates/pnpr/src/journal.rs
@@ -27,12 +27,11 @@
 
 use crate::{
     config::Config,
-    error::{RegistryError, Result},
+    error::Result,
     package_name::PackageName,
     publish::{merge_manifest, now_iso},
     storage::{
-        PackumentWrite, RECOVERY_PACKUMENT_WRITE_RETRIES, Storage, TarballSlot, unique_tmp_path,
-        wait_after_packument_write_conflict,
+        RECOVERY_PACKUMENT_WRITE_RETRIES, Storage, TarballFinalize, TarballSlot, unique_tmp_path,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -244,7 +243,13 @@ async fn roll_forward(storage: &Storage, dir: &Path) -> Result<()> {
                     name.clone(),
                     tarball.filename.clone(),
                 );
-                store.finalize_tarball_slot(slot).await?;
+                match store.finalize_tarball_slot(slot).await? {
+                    TarballFinalize::Written | TarballFinalize::AlreadyIdentical => {}
+                    // Another replica already promoted a different tarball for
+                    // this version. Don't overwrite it; the re-merge below keeps
+                    // that winner's immutable version, so ours is dropped.
+                    TarballFinalize::Conflict => {}
+                }
             }
         }
         let journaled: serde_json::Value =
@@ -260,29 +265,22 @@ async fn write_merged_packument(
     name: &PackageName,
     journaled: &serde_json::Value,
 ) -> Result<()> {
-    for attempt in 0..RECOVERY_PACKUMENT_WRITE_RETRIES {
-        let existing_packument = store.read_hosted_packument_for_update(name).await?;
-        let (existing_bytes, version) = match existing_packument {
-            Some(packument) => (Some(packument.bytes), Some(packument.version)),
-            None => (None, None),
-        };
-        let existing: Option<serde_json::Value> = match existing_bytes.as_deref() {
-            Some(bytes) => Some(serde_json::from_slice(bytes)?),
-            None => None,
-        };
-        let merged = merge_manifest(existing.as_ref(), journaled, existing.as_ref(), &now_iso());
-        let merged_bytes = serde_json::to_vec_pretty(&merged)?;
-        match store.write_hosted_packument_if_current(name, &merged_bytes, version.as_ref()).await?
-        {
-            PackumentWrite::Written => return Ok(()),
-            PackumentWrite::Conflict => {
-                if attempt + 1 < RECOVERY_PACKUMENT_WRITE_RETRIES {
-                    wait_after_packument_write_conflict(attempt).await;
-                }
-            }
-        }
-    }
-    Err(RegistryError::PackumentWriteConflict { package: name.as_str().to_string() })
+    store
+        .update_hosted_packument_with_retry(
+            name,
+            RECOVERY_PACKUMENT_WRITE_RETRIES,
+            |existing_bytes| {
+                let existing: Option<serde_json::Value> = match existing_bytes {
+                    Some(bytes) => Some(serde_json::from_slice(bytes)?),
+                    None => None,
+                };
+                let merged =
+                    merge_manifest(existing.as_ref(), journaled, existing.as_ref(), &now_iso());
+                Ok(Some(serde_json::to_vec_pretty(&merged)?))
+            },
+        )
+        .await?;
+    Ok(())
 }
 
 /// Discard an unsealed transaction: nothing of it ever became visible,

--- a/pnpr/crates/pnpr/src/journal.rs
+++ b/pnpr/crates/pnpr/src/journal.rs
@@ -33,11 +33,12 @@ use crate::{
     storage::{
         RECOVERY_PACKUMENT_WRITE_RETRIES, Storage, TarballFinalize, TarballSlot, unique_tmp_path,
     },
+    upstream::tarball_basename,
 };
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
-    io::ErrorKind,
+    io::{self, ErrorKind},
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
     time::{SystemTime, UNIX_EPOCH},
@@ -140,7 +141,7 @@ impl PublishJournal {
             });
         }
         write_synced(&dir.join(MANIFEST_FILE), &serde_json::to_vec_pretty(&manifest)?).await?;
-        sync_dir(&dir).await;
+        let _ = sync_dir(&dir).await;
         // The seal itself: a single same-directory rename, atomic on
         // POSIX. Recovery treats a directory without this marker as an
         // aborted transaction and rolls it back.
@@ -148,7 +149,7 @@ impl PublishJournal {
         let marker_tmp = unique_tmp_path(&marker);
         write_synced(&marker_tmp, b"").await?;
         fs::rename(&marker_tmp, &marker).await?;
-        sync_dir(&dir).await;
+        let _ = sync_dir(&dir).await;
         Ok(SealedTxn { dir })
     }
 
@@ -222,6 +223,7 @@ pub async fn recover_publish_journal(config: &Config) -> Result<()> {
 /// instead of overwriting it.
 async fn roll_forward(storage: &Storage, dir: &Path) -> Result<()> {
     let manifest: Manifest = serde_json::from_slice(&fs::read(dir.join(MANIFEST_FILE)).await?)?;
+    let mut conflicted_tmp_paths = Vec::new();
     for package in &manifest.packages {
         let name = PackageName::parse(&package.name)?;
         // Roll forward into the package's hosted namespace (or the flat
@@ -247,13 +249,12 @@ async fn roll_forward(storage: &Storage, dir: &Path) -> Result<()> {
                 );
                 match store.finalize_tarball_slot(slot).await? {
                     TarballFinalize::Written | TarballFinalize::AlreadyIdentical => {}
-                    // Another replica already promoted a *different* tarball for
-                    // this version. Its bytes are immutable, so we must not
-                    // overwrite them — and we must not advertise our integrity
-                    // against them either. Drop our staged copy and record the
-                    // filename so the merge below excludes the version we lost.
+                    // 다른 replica가 같은 버전의 다른 tarball을 먼저 확정했다.
+                    // winner의 bytes는 immutable이므로 덮어쓰거나 우리 integrity를
+                    // 노출하면 안 된다. 재시도에서도 충돌을 다시 감지하도록 임시
+                    // 파일은 유지하고, 아래 merge에서 제외할 filename을 기록한다.
                     TarballFinalize::Conflict => {
-                        let _ = fs::remove_file(&tarball.tmp_path).await;
+                        conflicted_tmp_paths.push(tarball.tmp_path.as_path());
                         conflicted.insert(tarball.filename.as_str());
                     }
                 }
@@ -266,8 +267,25 @@ async fn roll_forward(storage: &Storage, dir: &Path) -> Result<()> {
         }
         write_merged_packument(&store, &name, &journaled).await?;
     }
+    // journal을 먼저 제거해야 중간 실패가 충돌 상태 없는 재시도를 만들지 않는다.
     fs::remove_dir_all(dir).await?;
+    // 부모 디렉터리까지 동기화되어 journal 삭제가 내구성을 얻은 뒤에만 충돌 tmp를 지운다.
+    // 동기화 실패 시 tmp를 남겨 crash 후 journal이 다시 보이더라도 충돌을 재현할 수 있게 한다.
+    let journal_removal_is_durable = match dir.parent() {
+        Some(parent) => sync_dir(parent).await.is_ok(),
+        None => false,
+    };
+    cleanup_conflicted_tmp_paths(&conflicted_tmp_paths, journal_removal_is_durable).await;
     Ok(())
+}
+
+async fn cleanup_conflicted_tmp_paths(tmp_paths: &[&Path], journal_removal_is_durable: bool) {
+    if !journal_removal_is_durable {
+        return;
+    }
+    for tmp_path in tmp_paths {
+        let _ = fs::remove_file(tmp_path).await;
+    }
 }
 
 async fn write_merged_packument(
@@ -304,23 +322,28 @@ fn drop_conflicted_versions(journaled: &mut serde_json::Value, conflicted: &Hash
     else {
         return;
     };
-    versions.retain(|_version, manifest| {
+    let mut removed_versions = HashSet::new();
+    versions.retain(|version, manifest| {
         let filename = manifest
             .get("dist")
             .and_then(|dist| dist.get("tarball"))
             .and_then(serde_json::Value::as_str)
-            .map(tarball_basename);
-        match filename {
-            Some(filename) => !conflicted.contains(filename),
-            None => true,
+            .and_then(tarball_basename);
+        let keep = filename.is_none_or(|filename| !conflicted.contains(filename));
+        if !keep {
+            removed_versions.insert(version.clone());
         }
+        keep
     });
-}
 
-/// The final path segment of a `dist.tarball` URL — the on-disk tarball
-/// filename that a staged slot is keyed by.
-fn tarball_basename(tarball_url: &str) -> &str {
-    tarball_url.rsplit('/').next().unwrap_or(tarball_url)
+    if let Some(tags) = journaled.get_mut("dist-tags").and_then(serde_json::Value::as_object_mut) {
+        tags.retain(|_, version| {
+            version.as_str().is_none_or(|version| !removed_versions.contains(version))
+        });
+    }
+    if let Some(time) = journaled.get_mut("time").and_then(serde_json::Value::as_object_mut) {
+        time.retain(|version, _| !removed_versions.contains(version));
+    }
 }
 
 /// Discard an unsealed transaction: nothing of it ever became visible,
@@ -356,16 +379,15 @@ async fn write_synced(path: &Path, bytes: &[u8]) -> Result<()> {
     Ok(())
 }
 
-/// Flush directory entries (file creations and renames) to disk.
-/// Best-effort: directory fsync isn't available everywhere (Windows
-/// can't open directories as files), and a lost dir entry only widens
-/// the crash window back to what it was without the journal.
-async fn sync_dir(dir: &Path) {
-    if cfg!(unix)
-        && let Ok(file) = fs::File::open(dir).await
-    {
-        let _ = file.sync_all().await;
-    }
+#[cfg(unix)]
+async fn sync_dir(dir: &Path) -> io::Result<()> {
+    fs::File::open(dir).await?.sync_all().await
+}
+
+#[cfg(not(unix))]
+async fn sync_dir(_dir: &Path) -> io::Result<()> {
+    // 표준 API로 디렉터리 엔트리의 내구성을 확인할 수 없는 플랫폼은 안전하게 미지원 처리한다.
+    Err(io::Error::new(ErrorKind::Unsupported, "directory sync is not supported"))
 }
 
 #[cfg(test)]

--- a/pnpr/crates/pnpr/src/journal.rs
+++ b/pnpr/crates/pnpr/src/journal.rs
@@ -27,10 +27,10 @@
 
 use crate::{
     config::Config,
-    error::Result,
+    error::{RegistryError, Result},
     package_name::PackageName,
     publish::{merge_manifest, now_iso},
-    storage::{Storage, TarballSlot, unique_tmp_path},
+    storage::{PackumentWrite, Storage, TarballSlot, unique_tmp_path},
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -50,6 +50,7 @@ pub(crate) const JOURNAL_DIR: &str = ".pnpr-journal";
 
 const COMMIT_MARKER: &str = "commit";
 const MANIFEST_FILE: &str = "manifest.json";
+const PACKUMENT_WRITE_RETRIES: usize = 8;
 
 /// Per-process counter feeding [`txn_id`] so two transactions sealed in
 /// the same millisecond get distinct directories.
@@ -246,17 +247,36 @@ async fn roll_forward(storage: &Storage, dir: &Path) -> Result<()> {
         }
         let journaled: serde_json::Value =
             serde_json::from_slice(&fs::read(dir.join(&package.packument_file)).await?)?;
-        let existing: Option<serde_json::Value> = match store.read_hosted_packument(&name).await? {
-            Some(bytes) => Some(serde_json::from_slice(&bytes)?),
-            None => None,
-        };
-        // `existing` is the hosted packument here, so it is also the
-        // immutability reference.
-        let merged = merge_manifest(existing.as_ref(), &journaled, existing.as_ref(), &now_iso());
-        store.write_hosted_packument(&name, &serde_json::to_vec_pretty(&merged)?).await?;
+        write_merged_packument(&store, &name, &journaled).await?;
     }
     fs::remove_dir_all(dir).await?;
     Ok(())
+}
+
+async fn write_merged_packument(
+    store: &Storage,
+    name: &PackageName,
+    journaled: &serde_json::Value,
+) -> Result<()> {
+    for _ in 0..PACKUMENT_WRITE_RETRIES {
+        let existing_packument = store.read_hosted_packument_for_update(name).await?;
+        let (existing_bytes, version) = match existing_packument {
+            Some(packument) => (Some(packument.bytes), Some(packument.version)),
+            None => (None, None),
+        };
+        let existing: Option<serde_json::Value> = match existing_bytes.as_deref() {
+            Some(bytes) => Some(serde_json::from_slice(bytes)?),
+            None => None,
+        };
+        let merged = merge_manifest(existing.as_ref(), journaled, existing.as_ref(), &now_iso());
+        let merged_bytes = serde_json::to_vec_pretty(&merged)?;
+        match store.write_hosted_packument_if_current(name, &merged_bytes, version.as_ref()).await?
+        {
+            PackumentWrite::Written => return Ok(()),
+            PackumentWrite::Conflict => {}
+        }
+    }
+    Err(RegistryError::PackumentWriteConflict { package: name.as_str().to_string() })
 }
 
 /// Discard an unsealed transaction: nothing of it ever became visible,

--- a/pnpr/crates/pnpr/src/journal.rs
+++ b/pnpr/crates/pnpr/src/journal.rs
@@ -30,7 +30,10 @@ use crate::{
     error::{RegistryError, Result},
     package_name::PackageName,
     publish::{merge_manifest, now_iso},
-    storage::{PackumentWrite, Storage, TarballSlot, unique_tmp_path},
+    storage::{
+        PackumentWrite, RECOVERY_PACKUMENT_WRITE_RETRIES, Storage, TarballSlot, unique_tmp_path,
+        wait_after_packument_write_conflict,
+    },
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -50,7 +53,6 @@ pub(crate) const JOURNAL_DIR: &str = ".pnpr-journal";
 
 const COMMIT_MARKER: &str = "commit";
 const MANIFEST_FILE: &str = "manifest.json";
-const PACKUMENT_WRITE_RETRIES: usize = 8;
 
 /// Per-process counter feeding [`txn_id`] so two transactions sealed in
 /// the same millisecond get distinct directories.
@@ -258,7 +260,7 @@ async fn write_merged_packument(
     name: &PackageName,
     journaled: &serde_json::Value,
 ) -> Result<()> {
-    for _ in 0..PACKUMENT_WRITE_RETRIES {
+    for attempt in 0..RECOVERY_PACKUMENT_WRITE_RETRIES {
         let existing_packument = store.read_hosted_packument_for_update(name).await?;
         let (existing_bytes, version) = match existing_packument {
             Some(packument) => (Some(packument.bytes), Some(packument.version)),
@@ -273,7 +275,11 @@ async fn write_merged_packument(
         match store.write_hosted_packument_if_current(name, &merged_bytes, version.as_ref()).await?
         {
             PackumentWrite::Written => return Ok(()),
-            PackumentWrite::Conflict => {}
+            PackumentWrite::Conflict => {
+                if attempt + 1 < RECOVERY_PACKUMENT_WRITE_RETRIES {
+                    wait_after_packument_write_conflict(attempt).await;
+                }
+            }
         }
     }
     Err(RegistryError::PackumentWriteConflict { package: name.as_str().to_string() })

--- a/pnpr/crates/pnpr/src/journal.rs
+++ b/pnpr/crates/pnpr/src/journal.rs
@@ -369,36 +369,4 @@ async fn sync_dir(dir: &Path) {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::drop_conflicted_versions;
-    use serde_json::json;
-    use std::collections::HashSet;
-
-    #[test]
-    fn drop_conflicted_versions_removes_only_the_lost_versions() {
-        let mut journaled = json!({
-            "versions": {
-                "1.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-1.0.0.tgz" } },
-                "2.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-2.0.0.tgz" } },
-                // A version with no resolvable tarball basename is kept as-is.
-                "3.0.0": { "dist": {} },
-            }
-        });
-        let conflicted: HashSet<&str> = std::iter::once("pkg-1.0.0.tgz").collect();
-
-        drop_conflicted_versions(&mut journaled, &conflicted);
-
-        let versions = journaled["versions"].as_object().unwrap();
-        assert!(!versions.contains_key("1.0.0"));
-        assert!(versions.contains_key("2.0.0"));
-        assert!(versions.contains_key("3.0.0"));
-    }
-
-    #[test]
-    fn drop_conflicted_versions_tolerates_a_missing_versions_map() {
-        let mut journaled = json!({ "name": "pkg" });
-        let conflicted: HashSet<&str> = std::iter::once("pkg-1.0.0.tgz").collect();
-        drop_conflicted_versions(&mut journaled, &conflicted);
-        assert_eq!(journaled, json!({ "name": "pkg" }));
-    }
-}
+mod tests;

--- a/pnpr/crates/pnpr/src/journal/tests.rs
+++ b/pnpr/crates/pnpr/src/journal/tests.rs
@@ -1,0 +1,31 @@
+use super::drop_conflicted_versions;
+use serde_json::json;
+use std::collections::HashSet;
+
+#[test]
+fn drop_conflicted_versions_removes_only_the_lost_versions() {
+    let mut journaled = json!({
+        "versions": {
+            "1.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-1.0.0.tgz" } },
+            "2.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-2.0.0.tgz" } },
+            // A version with no resolvable tarball basename is kept as-is.
+            "3.0.0": { "dist": {} },
+        }
+    });
+    let conflicted: HashSet<&str> = std::iter::once("pkg-1.0.0.tgz").collect();
+
+    drop_conflicted_versions(&mut journaled, &conflicted);
+
+    let versions = journaled["versions"].as_object().unwrap();
+    assert!(!versions.contains_key("1.0.0"));
+    assert!(versions.contains_key("2.0.0"));
+    assert!(versions.contains_key("3.0.0"));
+}
+
+#[test]
+fn drop_conflicted_versions_tolerates_a_missing_versions_map() {
+    let mut journaled = json!({ "name": "pkg" });
+    let conflicted: HashSet<&str> = std::iter::once("pkg-1.0.0.tgz").collect();
+    drop_conflicted_versions(&mut journaled, &conflicted);
+    assert_eq!(journaled, json!({ "name": "pkg" }));
+}

--- a/pnpr/crates/pnpr/src/journal/tests.rs
+++ b/pnpr/crates/pnpr/src/journal/tests.rs
@@ -1,6 +1,17 @@
-use super::drop_conflicted_versions;
+use super::{
+    JournaledPublish, MANIFEST_FILE, Manifest, cleanup_conflicted_tmp_paths,
+    drop_conflicted_versions, roll_forward, sync_dir,
+};
+use crate::{
+    config::HostedStoreConfig,
+    package_name::PackageName,
+    storage::{Storage, TarballFinalize},
+};
+use object_store::{ObjectStore, memory::InMemory};
 use serde_json::json;
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
+use tempfile::tempdir;
+use tokio::fs;
 
 #[test]
 fn drop_conflicted_versions_removes_only_the_lost_versions() {
@@ -28,4 +39,180 @@ fn drop_conflicted_versions_tolerates_a_missing_versions_map() {
     let conflicted: HashSet<&str> = std::iter::once("pkg-1.0.0.tgz").collect();
     drop_conflicted_versions(&mut journaled, &conflicted);
     assert_eq!(journaled, json!({ "name": "pkg" }));
+}
+
+#[test]
+fn drop_conflicted_versions_uses_shared_tarball_url_semantics() {
+    let mut journaled = json!({
+        "versions": {
+            "1.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-1.0.0.tgz?sig=x" } },
+            "2.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-2.0.0.tgz#fragment" } },
+            "3.0.0": { "dist": { "tarball": "http://host/pkg/-/" } },
+        }
+    });
+    let conflicted: HashSet<&str> = ["pkg-1.0.0.tgz", "pkg-2.0.0.tgz"].into_iter().collect();
+
+    drop_conflicted_versions(&mut journaled, &conflicted);
+
+    let versions = journaled["versions"].as_object().unwrap();
+    let remaining_versions: Vec<_> = versions.keys().map(String::as_str).collect();
+    assert_eq!(remaining_versions, vec!["3.0.0"]);
+}
+
+#[test]
+fn drop_conflicted_versions_removes_references_to_lost_versions() {
+    let mut journaled = json!({
+        "versions": {
+            "1.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-1.0.0.tgz" } },
+            "2.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-2.0.0.tgz" } },
+        },
+        "dist-tags": {
+            "latest": "1.0.0",
+            "next": "2.0.0",
+            "opaque": 42,
+        },
+        "time": {
+            "1.0.0": "2026-07-01T00:00:00.000Z",
+            "2.0.0": "2026-07-02T00:00:00.000Z",
+            "modified": "2026-07-03T00:00:00.000Z",
+        },
+    });
+    let conflicted: HashSet<&str> = std::iter::once("pkg-1.0.0.tgz").collect();
+
+    drop_conflicted_versions(&mut journaled, &conflicted);
+
+    assert_eq!(journaled["dist-tags"], json!({ "next": "2.0.0", "opaque": 42 }));
+    assert_eq!(
+        journaled["time"],
+        json!({
+            "2.0.0": "2026-07-02T00:00:00.000Z",
+            "modified": "2026-07-03T00:00:00.000Z",
+        }),
+    );
+}
+
+#[tokio::test]
+async fn cleanup_keeps_conflicted_tmp_when_journal_removal_is_not_durable() {
+    let tmp = tempdir().unwrap();
+    let tmp_path = tmp.path().join("conflicted.tmp");
+    fs::write(&tmp_path, b"loser").await.unwrap();
+
+    cleanup_conflicted_tmp_paths(&[tmp_path.as_path()], false).await;
+
+    assert!(fs::try_exists(tmp_path).await.unwrap());
+}
+
+#[tokio::test]
+async fn cleanup_removes_conflicted_tmp_when_journal_removal_is_durable() {
+    let tmp = tempdir().unwrap();
+    let tmp_path = tmp.path().join("conflicted.tmp");
+    fs::write(&tmp_path, b"loser").await.unwrap();
+
+    cleanup_conflicted_tmp_paths(&[tmp_path.as_path()], true).await;
+
+    assert!(!fs::try_exists(tmp_path).await.unwrap());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn sync_dir_reports_success_for_a_directory() {
+    let tmp = tempdir().unwrap();
+
+    sync_dir(tmp.path()).await.unwrap();
+}
+
+#[tokio::test]
+async fn roll_forward_preserves_tarball_conflict_across_a_later_package_failure() {
+    let tmp = tempdir().unwrap();
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let storage = Storage::new(
+        &HostedStoreConfig::S3 { store: object_store, prefix: String::new() },
+        tmp.path().join("hosted"),
+        tmp.path().join("cache"),
+    );
+    let conflicted_name = PackageName::parse("conflicted-pkg").unwrap();
+    let later_name = PackageName::parse("later-pkg").unwrap();
+    let filename = "conflicted-pkg-1.0.0.tgz";
+
+    let winner = storage.reserve_hosted_tarball(&conflicted_name, filename).await.unwrap();
+    fs::write(&winner.tmp_path, b"winner").await.unwrap();
+    assert_eq!(storage.finalize_tarball_slot(winner).await.unwrap(), TarballFinalize::Written,);
+
+    let loser = storage.reserve_hosted_tarball(&conflicted_name, filename).await.unwrap();
+    fs::write(&loser.tmp_path, b"loser").await.unwrap();
+    let loser_tmp_path = loser.tmp_path.clone();
+    let conflicted_slots = [loser];
+    let conflicted_packument = serde_json::to_vec(&json!({
+        "name": "conflicted-pkg",
+        "versions": {
+            "1.0.0": {
+                "version": "1.0.0",
+                "dist": {
+                    "tarball": "http://host/conflicted-pkg/-/conflicted-pkg-1.0.0.tgz",
+                    "integrity": "loser",
+                },
+            },
+        },
+        "dist-tags": { "latest": "1.0.0" },
+        "time": {
+            "1.0.0": "2026-07-01T00:00:00.000Z",
+            "modified": "2026-07-01T00:00:00.000Z",
+        },
+    }))
+    .unwrap();
+    let entries = [
+        JournaledPublish {
+            name: &conflicted_name,
+            org: None,
+            packument: &conflicted_packument,
+            slots: &conflicted_slots,
+        },
+        JournaledPublish { name: &later_name, org: None, packument: b"not-json", slots: &[] },
+    ];
+    let txn = storage.publish_journal().seal(&entries).await.unwrap();
+    let txn_dir = txn.dir.clone();
+
+    drop(txn.roll_forward(&storage).await.unwrap_err());
+    assert!(
+        fs::try_exists(&loser_tmp_path).await.unwrap(),
+        "충돌한 임시 tarball은 트랜잭션 재시도를 위해 남아 있어야 합니다",
+    );
+    assert!(
+        fs::try_exists(&txn_dir).await.unwrap(),
+        "뒤 패키지가 실패하면 journal이 재시도를 위해 남아 있어야 합니다",
+    );
+
+    let manifest: Manifest =
+        serde_json::from_slice(&fs::read(txn_dir.join(MANIFEST_FILE)).await.unwrap()).unwrap();
+    let later_packument = json!({
+        "name": "later-pkg",
+        "versions": {
+            "2.0.0": { "version": "2.0.0" },
+        },
+    });
+    let later =
+        manifest.packages.iter().find(|package| package.name == later_name.as_str()).unwrap();
+    fs::write(txn_dir.join(&later.packument_file), serde_json::to_vec(&later_packument).unwrap())
+        .await
+        .unwrap();
+
+    roll_forward(&storage, &txn_dir).await.unwrap();
+
+    let conflicted_hosted = storage.read_hosted_packument(&conflicted_name).await.unwrap().unwrap();
+    let conflicted_hosted: serde_json::Value = serde_json::from_slice(&conflicted_hosted).unwrap();
+    assert_eq!(conflicted_hosted["versions"], json!({}));
+    assert_eq!(conflicted_hosted["dist-tags"], json!({}));
+    assert_eq!(conflicted_hosted["time"].get("1.0.0"), None);
+    let later_hosted = storage.read_hosted_packument(&later_name).await.unwrap().unwrap();
+    let later_hosted: serde_json::Value = serde_json::from_slice(&later_hosted).unwrap();
+    assert_eq!(later_hosted["versions"]["2.0.0"]["version"], "2.0.0");
+    #[cfg(unix)]
+    assert!(
+        !fs::try_exists(&loser_tmp_path).await.unwrap(),
+        "내구성 있는 journal 삭제 뒤에는 충돌한 임시 tarball을 정리해야 합니다",
+    );
+    assert!(
+        !fs::try_exists(&txn_dir).await.unwrap(),
+        "완료된 트랜잭션은 journal을 제거해야 합니다",
+    );
 }

--- a/pnpr/crates/pnpr/src/journal/tests.rs
+++ b/pnpr/crates/pnpr/src/journal/tests.rs
@@ -136,7 +136,7 @@ async fn roll_forward_preserves_tarball_conflict_across_a_later_package_failure(
 
     let winner = storage.reserve_hosted_tarball(&conflicted_name, filename).await.unwrap();
     fs::write(&winner.tmp_path, b"winner").await.unwrap();
-    assert_eq!(storage.finalize_tarball_slot(winner).await.unwrap(), TarballFinalize::Written,);
+    assert_eq!(storage.finalize_tarball_slot(winner).await.unwrap(), TarballFinalize::Written);
 
     let loser = storage.reserve_hosted_tarball(&conflicted_name, filename).await.unwrap();
     fs::write(&loser.tmp_path, b"loser").await.unwrap();

--- a/pnpr/crates/pnpr/src/s3.rs
+++ b/pnpr/crates/pnpr/src/s3.rs
@@ -21,7 +21,8 @@ use crate::{
 use axum::body::Body;
 use futures_util::StreamExt;
 use object_store::{
-    ObjectStore, ObjectStoreExt, PutPayload, aws::AmazonS3Builder, path::Path as ObjectPath,
+    ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload, UpdateVersion,
+    aws::AmazonS3Builder, path::Path as ObjectPath,
 };
 use serde::Deserialize;
 use std::{
@@ -131,6 +132,12 @@ pub struct S3Store {
     staging_dir: PathBuf,
 }
 
+#[derive(Debug)]
+pub(crate) struct S3PackumentForUpdate {
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) version: UpdateVersion,
+}
+
 /// Subdirectory of the proxy-cache root where hosted tarballs are
 /// staged before upload. Its own directory keeps the decode/verify tmp
 /// files away from the cache's `<pkg>/` package directories.
@@ -175,9 +182,49 @@ impl S3Store {
         }
     }
 
-    pub async fn write_packument(&self, name: &PackageName, bytes: &[u8]) -> Result<()> {
-        self.store.put(&self.packument_key(name), PutPayload::from(bytes.to_vec())).await?;
-        Ok(())
+    pub(crate) async fn read_packument_for_update(
+        &self,
+        name: &PackageName,
+    ) -> Result<Option<S3PackumentForUpdate>> {
+        match self.store.get(&self.packument_key(name)).await {
+            Ok(result) => {
+                let version = UpdateVersion {
+                    e_tag: result.meta.e_tag.clone(),
+                    version: result.meta.version.clone(),
+                };
+                Ok(Some(S3PackumentForUpdate { bytes: result.bytes().await?.to_vec(), version }))
+            }
+            Err(object_store::Error::NotFound { .. }) => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    pub(crate) async fn write_packument_if_current(
+        &self,
+        name: &PackageName,
+        bytes: &[u8],
+        version: Option<&UpdateVersion>,
+    ) -> Result<bool> {
+        let mode = match version {
+            Some(version) => PutMode::Update(version.clone()),
+            None => PutMode::Create,
+        };
+        match self
+            .store
+            .put_opts(
+                &self.packument_key(name),
+                PutPayload::from(bytes.to_vec()),
+                PutOptions { mode, ..PutOptions::default() },
+            )
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(
+                object_store::Error::AlreadyExists { .. }
+                | object_store::Error::Precondition { .. },
+            ) => Ok(false),
+            Err(err) => Err(err.into()),
+        }
     }
 
     /// Open a hosted tarball for streaming. `Ok(None)` means the object

--- a/pnpr/crates/pnpr/src/s3.rs
+++ b/pnpr/crates/pnpr/src/s3.rs
@@ -262,10 +262,39 @@ impl S3Store {
         tmp_path: &Path,
         name: &PackageName,
         filename: &str,
-    ) -> Result<()> {
+    ) -> Result<crate::storage::TarballFinalize> {
+        use crate::storage::TarballFinalize;
         let bytes = fs::read(tmp_path).await?;
-        self.store.put(&self.tarball_key(name, filename), PutPayload::from(bytes)).await?;
-        Ok(())
+        let key = self.tarball_key(name, filename);
+        // Create-only. A published version's tarball is immutable, so an object
+        // already at this key belongs to a concurrent publisher of the same
+        // version. Overwriting it would corrupt that artifact against the
+        // integrity its packument records, so tolerate only byte-identical
+        // content and otherwise report a conflict.
+        match self
+            .store
+            .put_opts(
+                &key,
+                PutPayload::from(bytes),
+                PutOptions { mode: PutMode::Create, ..PutOptions::default() },
+            )
+            .await
+        {
+            Ok(_) => Ok(TarballFinalize::Written),
+            Err(
+                object_store::Error::AlreadyExists { .. }
+                | object_store::Error::Precondition { .. },
+            ) => {
+                let ours = fs::read(tmp_path).await?;
+                let existing = self.store.get(&key).await?.bytes().await?;
+                if existing.as_ref() == ours.as_slice() {
+                    Ok(TarballFinalize::AlreadyIdentical)
+                } else {
+                    Ok(TarballFinalize::Conflict)
+                }
+            }
+            Err(err) => Err(err.into()),
+        }
     }
 
     pub async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {

--- a/pnpr/crates/pnpr/src/s3.rs
+++ b/pnpr/crates/pnpr/src/s3.rs
@@ -221,6 +221,7 @@ impl S3Store {
             Ok(_) => Ok(true),
             Err(
                 object_store::Error::AlreadyExists { .. }
+                | object_store::Error::NotFound { .. }
                 | object_store::Error::Precondition { .. },
             ) => Ok(false),
             Err(err) => Err(err.into()),

--- a/pnpr/crates/pnpr/src/s3/tests.rs
+++ b/pnpr/crates/pnpr/src/s3/tests.rs
@@ -93,6 +93,27 @@ async fn stale_packument_update_is_rejected() {
 }
 
 #[tokio::test]
+async fn deleted_packument_update_is_rejected() {
+    let (store, _staging) = store_with_prefix("");
+    let name = pkg("removed-racer");
+    write_packument(&store, &name, br#"{"name":"removed-racer"}"#).await;
+
+    let read = store.read_packument_for_update(&name).await.unwrap().unwrap();
+    store.remove_package(&name).await.unwrap();
+
+    let written = store
+        .write_packument_if_current(
+            &name,
+            br#"{"name":"removed-racer","versions":{"1.0.0":{"version":"1.0.0"}}}"#,
+            Some(&read.version),
+        )
+        .await
+        .unwrap();
+    assert!(!written);
+    assert!(store.read_packument(&name).await.unwrap().is_none());
+}
+
+#[tokio::test]
 async fn tarball_uploads_streams_and_reports_length() {
     let (store, _staging) = store_with_prefix("");
     let name = pkg("is-positive");

--- a/pnpr/crates/pnpr/src/s3/tests.rs
+++ b/pnpr/crates/pnpr/src/s3/tests.rs
@@ -114,6 +114,36 @@ async fn deleted_packument_update_is_rejected() {
 }
 
 #[tokio::test]
+async fn concurrent_tarball_finalize_does_not_overwrite() {
+    use crate::storage::TarballFinalize;
+    let (store, _staging) = store_with_prefix("");
+    let name = pkg("racer");
+    let file = "racer-1.0.0.tgz";
+
+    let tmp = store.staging_tmp_path(&name, file).await.unwrap();
+    tokio::fs::write(&tmp, b"tarball A").await.unwrap();
+    assert_eq!(store.upload_tarball(&tmp, &name, file).await.unwrap(), TarballFinalize::Written);
+
+    // Re-promoting byte-identical content is a tolerated no-op, so idempotent
+    // journal roll-forward and concurrent identical publishes don't conflict.
+    let tmp = store.staging_tmp_path(&name, file).await.unwrap();
+    tokio::fs::write(&tmp, b"tarball A").await.unwrap();
+    assert_eq!(
+        store.upload_tarball(&tmp, &name, file).await.unwrap(),
+        TarballFinalize::AlreadyIdentical,
+    );
+
+    // Different bytes for the same version's key are rejected without
+    // overwriting the first writer's tarball.
+    let tmp = store.staging_tmp_path(&name, file).await.unwrap();
+    tokio::fs::write(&tmp, b"tarball B").await.unwrap();
+    assert_eq!(store.upload_tarball(&tmp, &name, file).await.unwrap(), TarballFinalize::Conflict);
+
+    let (body, _len) = store.open_tarball(&name, file).await.unwrap().unwrap();
+    assert_eq!(collect(body).await, b"tarball A");
+}
+
+#[tokio::test]
 async fn tarball_uploads_streams_and_reports_length() {
     let (store, _staging) = store_with_prefix("");
     let name = pkg("is-positive");

--- a/pnpr/crates/pnpr/src/s3/tests.rs
+++ b/pnpr/crates/pnpr/src/s3/tests.rs
@@ -42,15 +42,53 @@ async fn upload(store: &S3Store, name: &PackageName, filename: &str, bytes: &[u8
     store.upload_tarball(&tmp, name, filename).await.expect("upload");
 }
 
+async fn write_packument(store: &S3Store, name: &PackageName, bytes: &[u8]) {
+    assert!(store.write_packument_if_current(name, bytes, None).await.unwrap());
+}
+
 #[tokio::test]
 async fn packument_roundtrips_and_missing_is_none() {
     let (store, _staging) = store_with_prefix("");
     let name = pkg("is-positive");
     assert_eq!(store.read_packument(&name).await.unwrap(), None);
-    store.write_packument(&name, br#"{"name":"is-positive"}"#).await.unwrap();
+    write_packument(&store, &name, br#"{"name":"is-positive"}"#).await;
     assert_eq!(
         store.read_packument(&name).await.unwrap().as_deref(),
         Some(&br#"{"name":"is-positive"}"#[..]),
+    );
+}
+
+#[tokio::test]
+async fn stale_packument_update_is_rejected() {
+    let (store, _staging) = store_with_prefix("");
+    let name = pkg("racer");
+    store.write_packument_if_current(&name, br#"{"name":"racer"}"#, None).await.unwrap();
+
+    let first_read = store.read_packument_for_update(&name).await.unwrap().unwrap();
+    let second_read = store.read_packument_for_update(&name).await.unwrap().unwrap();
+
+    let first_written = store
+        .write_packument_if_current(
+            &name,
+            br#"{"name":"racer","versions":{"1.0.0":{"version":"1.0.0"}}}"#,
+            Some(&first_read.version),
+        )
+        .await
+        .unwrap();
+    assert!(first_written);
+
+    let second_written = store
+        .write_packument_if_current(
+            &name,
+            br#"{"name":"racer","versions":{"2.0.0":{"version":"2.0.0"}}}"#,
+            Some(&second_read.version),
+        )
+        .await
+        .unwrap();
+    assert!(!second_written);
+    assert_eq!(
+        store.read_packument(&name).await.unwrap().as_deref(),
+        Some(&br#"{"name":"racer","versions":{"1.0.0":{"version":"1.0.0"}}}"#[..]),
     );
 }
 
@@ -72,7 +110,7 @@ async fn tarball_uploads_streams_and_reports_length() {
 async fn scoped_keys_and_prefix_are_honored() {
     let (store, _staging) = store_with_prefix("packages");
     let name = pkg("@scope/thing");
-    store.write_packument(&name, br#"{"name":"@scope/thing"}"#).await.unwrap();
+    write_packument(&store, &name, br#"{"name":"@scope/thing"}"#).await;
     upload(&store, &name, "thing-1.0.0.tgz", b"scoped tarball").await;
 
     let (body, _len) = store.open_tarball(&name, "thing-1.0.0.tgz").await.unwrap().unwrap();
@@ -84,7 +122,7 @@ async fn scoped_keys_and_prefix_are_honored() {
 async fn remove_tarball_then_package() {
     let (store, _staging) = store_with_prefix("");
     let name = pkg("is-positive");
-    store.write_packument(&name, b"{}").await.unwrap();
+    write_packument(&store, &name, b"{}").await;
     upload(&store, &name, "is-positive-1.0.0.tgz", b"payload").await;
 
     assert!(store.remove_tarball(&name, "is-positive-1.0.0.tgz").await.unwrap());
@@ -101,8 +139,8 @@ async fn remove_tarball_then_package() {
 async fn lists_hosted_package_names() {
     for prefix in ["", "packages"] {
         let (store, _staging) = store_with_prefix(prefix);
-        store.write_packument(&pkg("is-positive"), b"{}").await.unwrap();
-        store.write_packument(&pkg("@scope/thing"), b"{}").await.unwrap();
+        write_packument(&store, &pkg("is-positive"), b"{}").await;
+        write_packument(&store, &pkg("@scope/thing"), b"{}").await;
         // A stray tarball-only key must not be mistaken for a package.
         upload(&store, &pkg("is-positive"), "is-positive-1.0.0.tgz", b"x").await;
 

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -3082,9 +3082,10 @@ async fn commit_publishes(
                 match store.finalize_tarball_slot(slot).await? {
                     TarballFinalize::Written | TarballFinalize::AlreadyIdentical => {}
                     // A concurrent replica already promoted a different tarball
-                    // for this version. Its bytes are immutable, so surface a
-                    // conflict instead of advertising our integrity against
-                    // them; the seal's roll-forward keeps the winner's version.
+                    // for this version. Its bytes are immutable, so abort the
+                    // apply rather than advertise our integrity against them.
+                    // The seal's roll-forward re-runs from the journal, where it
+                    // drops the version we lost and re-merges the rest.
                     TarballFinalize::Conflict => {
                         return Err(RegistryError::PackumentWriteConflict {
                             package: stage.name.as_str().to_string(),

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -11,8 +11,8 @@ use crate::{
     },
     registry::{ConcreteKind, Registry, Resolved},
     storage::{
-        HostedPackumentVersion, PACKUMENT_WRITE_RETRIES, PackumentWrite, Storage,
-        wait_after_packument_write_conflict,
+        HostedPackumentVersion, PACKUMENT_WRITE_RETRIES, PackumentUpdate, PackumentWrite, Storage,
+        TarballFinalize,
     },
     streaming,
     upstream::{
@@ -3079,7 +3079,18 @@ async fn commit_publishes(
             // so an inline failure and a startup roll-forward land identically.
             let store = hosted_storage(state, stage.org.as_deref());
             for slot in stage.slots {
-                store.finalize_tarball_slot(slot).await?;
+                match store.finalize_tarball_slot(slot).await? {
+                    TarballFinalize::Written | TarballFinalize::AlreadyIdentical => {}
+                    // A concurrent replica already promoted a different tarball
+                    // for this version. Its bytes are immutable, so surface a
+                    // conflict instead of advertising our integrity against
+                    // them; the seal's roll-forward keeps the winner's version.
+                    TarballFinalize::Conflict => {
+                        return Err(RegistryError::PackumentWriteConflict {
+                            package: stage.name.as_str().to_string(),
+                        });
+                    }
+                }
             }
             match store
                 .write_hosted_packument_if_current(
@@ -3090,6 +3101,14 @@ async fn commit_publishes(
                 .await?
             {
                 PackumentWrite::Written => {}
+                // Tarballs are already promoted at this point. A conflict means
+                // another replica advanced the packument since staging, so the
+                // base version is stale. Surfacing it drops into the seal's
+                // roll-forward path (the caller), which re-reads the current
+                // packument and re-merges this transaction's journaled manifest —
+                // re-referencing the promoted tarballs — rather than leaving them
+                // orphaned. Only if roll-forward and startup recovery both never
+                // converge would a promoted tarball stay unreferenced.
                 PackumentWrite::Conflict => {
                     return Err(RegistryError::PackumentWriteConflict {
                         package: stage.name.as_str().to_string(),
@@ -3683,71 +3702,47 @@ where
     // on this instance (held until this function returns).
     let _packument_guard = state.inner.package_locks.lock(name.as_str()).await;
 
-    let mut written = false;
-    for attempt in 0..PACKUMENT_WRITE_RETRIES {
-        let hosted_packument = match storage.read_hosted_packument_for_update(&name).await {
-            Ok(Some(packument)) => packument,
-            Ok(None) => return not_found(),
-            Err(err) => return error_response(&err),
-        };
-        let mut packument: Value = match serde_json::from_slice(&hosted_packument.bytes) {
-            Ok(value) => value,
-            Err(err) => return error_response(&RegistryError::Json(err)),
-        };
-
-        let Some(packument_obj) = packument.as_object_mut() else {
-            return error_response(&RegistryError::BadRequest {
-                reason: "stored packument is not an object".to_string(),
-            });
-        };
-        let tags_entry = packument_obj
-            .entry("dist-tags".to_string())
-            .or_insert_with(|| Value::Object(serde_json::Map::new()));
-        let Some(tags) = tags_entry.as_object_mut() else {
-            return error_response(&RegistryError::BadRequest {
-                reason: "stored dist-tags is not an object".to_string(),
-            });
-        };
-        if let Err(err) = mutate(tags) {
-            return error_response(&err);
-        }
-        let _ = tag;
-        // Refresh `time.modified` so clients do not lag behind a
-        // dist-tag change when deciding packument freshness.
-        let time_entry = packument_obj
-            .entry("time".to_string())
-            .or_insert_with(|| Value::Object(serde_json::Map::new()));
-        let Some(time_obj) = time_entry.as_object_mut() else {
-            return error_response(&RegistryError::BadRequest {
-                reason: "stored time is not an object".to_string(),
-            });
-        };
-        time_obj.insert("modified".to_string(), Value::String(now_iso()));
-        let new_bytes = match serde_json::to_vec_pretty(&packument) {
-            Ok(b) => b,
-            Err(err) => return error_response(&RegistryError::Json(err)),
-        };
-        match storage
-            .write_hosted_packument_if_current(&name, &new_bytes, Some(&hosted_packument.version))
-            .await
-        {
-            Ok(PackumentWrite::Written) => {
-                written = true;
-                break;
-            }
-            Ok(PackumentWrite::Conflict) => {
-                if attempt + 1 < PACKUMENT_WRITE_RETRIES {
-                    wait_after_packument_write_conflict(attempt).await;
-                }
-                continue;
-            }
-            Err(err) => return error_response(&err),
-        }
-    }
-    if !written {
-        return error_response(&RegistryError::PackumentWriteConflict {
-            package: name.as_str().to_string(),
-        });
+    let _ = tag; // the tag name is captured by the `mutate` closure.
+    let outcome = storage
+        .update_hosted_packument_with_retry(&name, PACKUMENT_WRITE_RETRIES, |existing_bytes| {
+            // A hosted org has no upstream, so a dist-tag change starts from the
+            // org's own packument; a package it does not host can't be tagged.
+            let Some(bytes) = existing_bytes else {
+                return Ok(None);
+            };
+            let mut packument: Value = serde_json::from_slice(bytes)?;
+            let Some(packument_obj) = packument.as_object_mut() else {
+                return Err(RegistryError::BadRequest {
+                    reason: "stored packument is not an object".to_string(),
+                });
+            };
+            let tags_entry = packument_obj
+                .entry("dist-tags".to_string())
+                .or_insert_with(|| Value::Object(serde_json::Map::new()));
+            let Some(tags) = tags_entry.as_object_mut() else {
+                return Err(RegistryError::BadRequest {
+                    reason: "stored dist-tags is not an object".to_string(),
+                });
+            };
+            mutate(tags)?;
+            // Refresh `time.modified` so clients do not lag behind a
+            // dist-tag change when deciding packument freshness.
+            let time_entry = packument_obj
+                .entry("time".to_string())
+                .or_insert_with(|| Value::Object(serde_json::Map::new()));
+            let Some(time_obj) = time_entry.as_object_mut() else {
+                return Err(RegistryError::BadRequest {
+                    reason: "stored time is not an object".to_string(),
+                });
+            };
+            time_obj.insert("modified".to_string(), Value::String(now_iso()));
+            Ok(Some(serde_json::to_vec_pretty(&packument)?))
+        })
+        .await;
+    match outcome {
+        Ok(PackumentUpdate::Written) => {}
+        Ok(PackumentUpdate::NotFound) => return not_found(),
+        Err(err) => return error_response(&err),
     }
     let body = json!({ "ok": true });
     let bytes = serde_json::to_vec(&body).expect("static-shape JSON serializes");

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -3706,8 +3706,8 @@ where
             return error_response(&err);
         }
         let _ = tag;
-        // dist-tag 변경 뒤에도 클라이언트의 신선도 판단이 뒤처지지 않게
-        // `time.modified`를 갱신한다.
+        // Refresh `time.modified` so clients do not lag behind a
+        // dist-tag change when deciding packument freshness.
         let time_entry = packument_obj
             .entry("time".to_string())
             .or_insert_with(|| Value::Object(serde_json::Map::new()));

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -10,7 +10,7 @@ use crate::{
         stream_decode_verify_and_write,
     },
     registry::{ConcreteKind, Registry, Resolved},
-    storage::Storage,
+    storage::{HostedPackumentVersion, PackumentWrite, Storage},
     streaming,
     upstream::{
         CacheValidators, FetchOutcome, PackumentFetch, Upstream, abbreviate_packument,
@@ -68,6 +68,7 @@ const MAX_TARBALL_BYTES: u64 = 100 * 1024 * 1024;
 /// [`DefaultBodyLimit::max`] on the router rather than on each
 /// route, so future write endpoints inherit the same ceiling.
 const MAX_PUBLISH_BODY_BYTES: usize = MAX_TARBALL_BYTES as usize;
+const PACKUMENT_WRITE_RETRIES: usize = 8;
 
 /// Cap adduser/login bodies far below the publish ceiling. The body is a
 /// small couchdb-user JSON document, and login is the one body-accepting
@@ -2894,6 +2895,7 @@ fn validate_publish_attachments(
 struct StagedPublish {
     name: PackageName,
     merged_bytes: Vec<u8>,
+    base_version: Option<HostedPackumentVersion>,
     slots: Vec<crate::storage::TarballSlot>,
     /// Hosted-org storage namespace this publish targets, or `None` for the
     /// flat (path-less) hosted store. Threaded into the commit and journal so
@@ -2915,7 +2917,11 @@ async fn stage_publish(
     let ValidatedPublish { name, incoming, prepared } = doc;
     let storage = hosted_storage(state, org);
 
-    let hosted_bytes = storage.read_hosted_packument(&name).await?;
+    let hosted_packument = storage.read_hosted_packument_for_update(&name).await?;
+    let (hosted_bytes, base_version) = match hosted_packument {
+        Some(packument) => (Some(packument.bytes), Some(packument.version)),
+        None => (None, None),
+    };
     let hosted: Option<Value> = match hosted_bytes.as_deref().map(serde_json::from_slice) {
         Some(Ok(value)) => Some(value),
         Some(Err(err)) => return Err(RegistryError::Json(err)),
@@ -3014,7 +3020,13 @@ async fn stage_publish(
             }
         }
     }
-    Ok(StagedPublish { name, merged_bytes, slots: written_slots, org: org.map(str::to_string) })
+    Ok(StagedPublish {
+        name,
+        merged_bytes,
+        base_version,
+        slots: written_slots,
+        org: org.map(str::to_string),
+    })
 }
 
 /// Make every staged publish visible. The full intent — merged
@@ -3067,7 +3079,21 @@ async fn commit_publishes(
             for slot in stage.slots {
                 store.finalize_tarball_slot(slot).await?;
             }
-            store.write_hosted_packument(&stage.name, &stage.merged_bytes).await?;
+            match store
+                .write_hosted_packument_if_current(
+                    &stage.name,
+                    &stage.merged_bytes,
+                    stage.base_version.as_ref(),
+                )
+                .await?
+            {
+                PackumentWrite::Written => {}
+                PackumentWrite::Conflict => {
+                    return Err(RegistryError::PackumentWriteConflict {
+                        package: stage.name.as_str().to_string(),
+                    });
+                }
+            }
         }
         Ok::<(), RegistryError>(())
     }
@@ -3271,16 +3297,40 @@ async fn update_packument(
     // packument writers (publish / dist-tag), so the client-supplied
     // rewrite can't interleave with a concurrent merge.
     let _packument_guard = state.inner.package_locks.lock(name.as_str()).await;
-    if let Some(err) = enforce_published_version_immutability(&storage, &name, &mut packument).await
-    {
+    let hosted_packument = match storage.read_hosted_packument_for_update(&name).await {
+        Ok(Some(packument)) => packument,
+        Ok(None) => {
+            return error_response(&RegistryError::BadRequest {
+                reason: format!(
+                    "cannot update {:?}: it has no published packument to unpublish from",
+                    name.as_str(),
+                ),
+            });
+        }
+        Err(err) => return error_response(&err),
+    };
+    let hosted: Value = match serde_json::from_slice(&hosted_packument.bytes) {
+        Ok(value) => value,
+        Err(err) => return error_response(&RegistryError::Json(err)),
+    };
+    if let Some(err) = enforce_published_version_immutability(&hosted, &name, &mut packument) {
         return error_response(&err);
     }
     let bytes = match serde_json::to_vec_pretty(&packument) {
         Ok(b) => b,
         Err(err) => return error_response(&RegistryError::Json(err)),
     };
-    if let Err(err) = storage.write_hosted_packument(&name, &bytes).await {
-        return error_response(&err);
+    match storage
+        .write_hosted_packument_if_current(&name, &bytes, Some(&hosted_packument.version))
+        .await
+    {
+        Ok(PackumentWrite::Written) => {}
+        Ok(PackumentWrite::Conflict) => {
+            return error_response(&RegistryError::PackumentWriteConflict {
+                package: name.as_str().to_string(),
+            });
+        }
+        Err(err) => return error_response(&err),
     }
     let body = json!({ "ok": true });
     let bytes = serde_json::to_vec(&body).expect("static-shape JSON serializes");
@@ -3309,27 +3359,11 @@ async fn update_packument(
 ///
 /// Returns the rejection, or `None` when the body is acceptable (after any
 /// restores). Must hold the package lock so a concurrent publish can't race it.
-async fn enforce_published_version_immutability(
-    storage: &Storage,
+fn enforce_published_version_immutability(
+    hosted: &Value,
     name: &PackageName,
     incoming: &mut Value,
 ) -> Option<RegistryError> {
-    let hosted: Value = match storage.read_hosted_packument(name).await {
-        // Fail closed: a corrupt packument must not silently disable the gate.
-        Ok(Some(bytes)) => match serde_json::from_slice(&bytes) {
-            Ok(value) => value,
-            Err(err) => return Some(RegistryError::Json(err)),
-        },
-        Ok(None) => {
-            return Some(RegistryError::BadRequest {
-                reason: format!(
-                    "cannot update {:?}: it has no published packument to unpublish from",
-                    name.as_str(),
-                ),
-            });
-        }
-        Err(err) => return Some(err),
-    };
     // None (no versions to enforce) means "accept", not "error" here.
     let incoming_versions = incoming.get("versions").and_then(Value::as_object)?;
     let hosted_versions = hosted.get("versions").and_then(Value::as_object);
@@ -3614,7 +3648,7 @@ async fn update_dist_tag<Mutate>(
     mutate: Mutate,
 ) -> Response
 where
-    Mutate: FnOnce(&mut serde_json::Map<String, Value>) -> Result<(), RegistryError>,
+    Mutate: Fn(&mut serde_json::Map<String, Value>) -> Result<(), RegistryError>,
 {
     let name = match PackageName::parse(raw_name) {
         Ok(n) => n,
@@ -3643,53 +3677,66 @@ where
     // on this instance (held until this function returns).
     let _packument_guard = state.inner.package_locks.lock(name.as_str()).await;
 
-    // A hosted org has no upstream, so a dist-tag change starts from the org's
-    // own packument; a package it does not host can't be tagged.
-    let mut packument: Value = match storage.read_hosted_packument(&name).await {
-        Ok(Some(bytes)) => match serde_json::from_slice(&bytes) {
-            Ok(v) => v,
+    let mut written = false;
+    for _ in 0..PACKUMENT_WRITE_RETRIES {
+        let hosted_packument = match storage.read_hosted_packument_for_update(&name).await {
+            Ok(Some(packument)) => packument,
+            Ok(None) => return not_found(),
+            Err(err) => return error_response(&err),
+        };
+        let mut packument: Value = match serde_json::from_slice(&hosted_packument.bytes) {
+            Ok(value) => value,
             Err(err) => return error_response(&RegistryError::Json(err)),
-        },
-        Ok(None) => return not_found(),
-        Err(err) => return error_response(&err),
-    };
+        };
 
-    let Some(packument_obj) = packument.as_object_mut() else {
-        return error_response(&RegistryError::BadRequest {
-            reason: "stored packument is not an object".to_string(),
-        });
-    };
-    let tags_entry = packument_obj
-        .entry("dist-tags".to_string())
-        .or_insert_with(|| Value::Object(serde_json::Map::new()));
-    let Some(tags) = tags_entry.as_object_mut() else {
-        return error_response(&RegistryError::BadRequest {
-            reason: "stored dist-tags is not an object".to_string(),
-        });
-    };
-    if let Err(err) = mutate(tags) {
-        return error_response(&err);
+        let Some(packument_obj) = packument.as_object_mut() else {
+            return error_response(&RegistryError::BadRequest {
+                reason: "stored packument is not an object".to_string(),
+            });
+        };
+        let tags_entry = packument_obj
+            .entry("dist-tags".to_string())
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+        let Some(tags) = tags_entry.as_object_mut() else {
+            return error_response(&RegistryError::BadRequest {
+                reason: "stored dist-tags is not an object".to_string(),
+            });
+        };
+        if let Err(err) = mutate(tags) {
+            return error_response(&err);
+        }
+        let _ = tag;
+        // dist-tag 변경 뒤에도 클라이언트의 신선도 판단이 뒤처지지 않게
+        // `time.modified`를 갱신한다.
+        let time_entry = packument_obj
+            .entry("time".to_string())
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+        let Some(time_obj) = time_entry.as_object_mut() else {
+            return error_response(&RegistryError::BadRequest {
+                reason: "stored time is not an object".to_string(),
+            });
+        };
+        time_obj.insert("modified".to_string(), Value::String(now_iso()));
+        let new_bytes = match serde_json::to_vec_pretty(&packument) {
+            Ok(b) => b,
+            Err(err) => return error_response(&RegistryError::Json(err)),
+        };
+        match storage
+            .write_hosted_packument_if_current(&name, &new_bytes, Some(&hosted_packument.version))
+            .await
+        {
+            Ok(PackumentWrite::Written) => {
+                written = true;
+                break;
+            }
+            Ok(PackumentWrite::Conflict) => continue,
+            Err(err) => return error_response(&err),
+        }
     }
-    let _ = tag; // tag name is used by the mutate closure
-    // Refresh `time.modified` so clients that rely on it for
-    // freshness (pacquet's pick_package, npm's abbreviated-packument
-    // staleness check) don't see the post-mutation packument as
-    // older than its dist-tag change.
-    let time_entry = packument_obj
-        .entry("time".to_string())
-        .or_insert_with(|| Value::Object(serde_json::Map::new()));
-    let Some(time_obj) = time_entry.as_object_mut() else {
-        return error_response(&RegistryError::BadRequest {
-            reason: "stored time is not an object".to_string(),
+    if !written {
+        return error_response(&RegistryError::PackumentWriteConflict {
+            package: name.as_str().to_string(),
         });
-    };
-    time_obj.insert("modified".to_string(), Value::String(now_iso()));
-    let new_bytes = match serde_json::to_vec_pretty(&packument) {
-        Ok(b) => b,
-        Err(err) => return error_response(&RegistryError::Json(err)),
-    };
-    if let Err(err) = storage.write_hosted_packument(&name, &new_bytes).await {
-        return error_response(&err);
     }
     let body = json!({ "ok": true });
     let bytes = serde_json::to_vec(&body).expect("static-shape JSON serializes");

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -10,7 +10,10 @@ use crate::{
         stream_decode_verify_and_write,
     },
     registry::{ConcreteKind, Registry, Resolved},
-    storage::{HostedPackumentVersion, PackumentWrite, Storage},
+    storage::{
+        HostedPackumentVersion, PACKUMENT_WRITE_RETRIES, PackumentWrite, Storage,
+        wait_after_packument_write_conflict,
+    },
     streaming,
     upstream::{
         CacheValidators, FetchOutcome, PackumentFetch, Upstream, abbreviate_packument,
@@ -68,7 +71,6 @@ const MAX_TARBALL_BYTES: u64 = 100 * 1024 * 1024;
 /// [`DefaultBodyLimit::max`] on the router rather than on each
 /// route, so future write endpoints inherit the same ceiling.
 const MAX_PUBLISH_BODY_BYTES: usize = MAX_TARBALL_BYTES as usize;
-const PACKUMENT_WRITE_RETRIES: usize = 8;
 
 /// Cap adduser/login bodies far below the publish ceiling. The body is a
 /// small couchdb-user JSON document, and login is the one body-accepting
@@ -3610,10 +3612,14 @@ async fn set_dist_tag(
     tag: &str,
     body: &[u8],
 ) -> Response {
-    update_dist_tag(state, identity, registry, raw_name, tag, |tags| {
-        let version: String = match serde_json::from_slice(body) {
-            Ok(s) => s,
-            Err(err) => return Err(RegistryError::Json(err)),
+    let mut parsed_version: Option<String> = None;
+    update_dist_tag(state, identity, registry, raw_name, tag, move |tags| {
+        let version = if let Some(version) = parsed_version.as_ref() {
+            version.clone()
+        } else {
+            let version: String = serde_json::from_slice(body).map_err(RegistryError::Json)?;
+            parsed_version = Some(version.clone());
+            version
         };
         tags.insert(tag.to_string(), Value::String(version));
         Ok(())
@@ -3645,10 +3651,10 @@ async fn update_dist_tag<Mutate>(
     registry: Option<&str>,
     raw_name: &str,
     tag: &str,
-    mutate: Mutate,
+    mut mutate: Mutate,
 ) -> Response
 where
-    Mutate: Fn(&mut serde_json::Map<String, Value>) -> Result<(), RegistryError>,
+    Mutate: FnMut(&mut serde_json::Map<String, Value>) -> Result<(), RegistryError>,
 {
     let name = match PackageName::parse(raw_name) {
         Ok(n) => n,
@@ -3678,7 +3684,7 @@ where
     let _packument_guard = state.inner.package_locks.lock(name.as_str()).await;
 
     let mut written = false;
-    for _ in 0..PACKUMENT_WRITE_RETRIES {
+    for attempt in 0..PACKUMENT_WRITE_RETRIES {
         let hosted_packument = match storage.read_hosted_packument_for_update(&name).await {
             Ok(Some(packument)) => packument,
             Ok(None) => return not_found(),
@@ -3729,7 +3735,12 @@ where
                 written = true;
                 break;
             }
-            Ok(PackumentWrite::Conflict) => continue,
+            Ok(PackumentWrite::Conflict) => {
+                if attempt + 1 < PACKUMENT_WRITE_RETRIES {
+                    wait_after_packument_write_conflict(attempt).await;
+                }
+                continue;
+            }
             Err(err) => return error_response(&err),
         }
     }

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -238,6 +238,8 @@ impl HostedStore {
         }
     }
 
+    /// FS has no hosted packument CAS and always returns `Written`.
+    /// `Conflict` is only returned by the S3 object-version path.
     async fn write_packument_if_current(
         &self,
         name: &PackageName,

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -340,10 +340,12 @@ impl HostedStore {
             }
             HostedStore::S3(store) => {
                 let outcome = store.upload_tarball(tmp_path, name, filename).await?;
-                // Consume the staged tmp whatever the outcome: a Conflict means
-                // another replica owns the object, so retrying our overwrite
-                // would be wrong, and there is nothing left to promote.
-                let _ = fs::remove_file(tmp_path).await;
+                // Keep the staged tmp on a Conflict so journal roll-forward can
+                // re-detect it and exclude the version whose bytes we don't own;
+                // once the object is ours there is nothing left to promote.
+                if outcome != TarballFinalize::Conflict {
+                    let _ = fs::remove_file(tmp_path).await;
+                }
                 Ok(outcome)
             }
         }

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -6,6 +6,7 @@ use crate::{
     streaming,
 };
 use axum::body::Body;
+use object_store::UpdateVersion;
 use std::{
     io::{ErrorKind, SeekFrom},
     path::{Path, PathBuf},
@@ -192,6 +193,24 @@ enum HostedStore {
     S3(S3Store),
 }
 
+#[derive(Debug)]
+pub(crate) struct HostedPackumentForUpdate {
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) version: HostedPackumentVersion,
+}
+
+#[derive(Debug)]
+pub(crate) enum HostedPackumentVersion {
+    Fs,
+    S3(UpdateVersion),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PackumentWrite {
+    Written,
+    Conflict,
+}
+
 impl HostedStore {
     async fn read_packument(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
         match self {
@@ -200,10 +219,47 @@ impl HostedStore {
         }
     }
 
-    async fn write_packument(&self, name: &PackageName, bytes: &[u8]) -> Result<()> {
+    async fn read_packument_for_update(
+        &self,
+        name: &PackageName,
+    ) -> Result<Option<HostedPackumentForUpdate>> {
         match self {
-            HostedStore::Fs(store) => store.write_packument(name, bytes).await,
-            HostedStore::S3(store) => store.write_packument(name, bytes).await,
+            HostedStore::Fs(store) => Ok(store.read_packument_any_age(name).await?.map(|bytes| {
+                HostedPackumentForUpdate { bytes, version: HostedPackumentVersion::Fs }
+            })),
+            HostedStore::S3(store) => {
+                Ok(store.read_packument_for_update(name).await?.map(|packument| {
+                    HostedPackumentForUpdate {
+                        bytes: packument.bytes,
+                        version: HostedPackumentVersion::S3(packument.version),
+                    }
+                }))
+            }
+        }
+    }
+
+    async fn write_packument_if_current(
+        &self,
+        name: &PackageName,
+        bytes: &[u8],
+        version: Option<&HostedPackumentVersion>,
+    ) -> Result<PackumentWrite> {
+        match self {
+            HostedStore::Fs(store) => {
+                store.write_packument(name, bytes).await?;
+                Ok(PackumentWrite::Written)
+            }
+            HostedStore::S3(store) => {
+                let version = match version {
+                    Some(HostedPackumentVersion::S3(version)) => Some(version),
+                    Some(HostedPackumentVersion::Fs) | None => None,
+                };
+                if store.write_packument_if_current(name, bytes, version).await? {
+                    Ok(PackumentWrite::Written)
+                } else {
+                    Ok(PackumentWrite::Conflict)
+                }
+            }
         }
     }
 
@@ -347,8 +403,20 @@ impl Storage {
         self.hosted.read_packument(name).await
     }
 
-    pub async fn write_hosted_packument(&self, name: &PackageName, bytes: &[u8]) -> Result<()> {
-        self.hosted.write_packument(name, bytes).await
+    pub(crate) async fn read_hosted_packument_for_update(
+        &self,
+        name: &PackageName,
+    ) -> Result<Option<HostedPackumentForUpdate>> {
+        self.hosted.read_packument_for_update(name).await
+    }
+
+    pub(crate) async fn write_hosted_packument_if_current(
+        &self,
+        name: &PackageName,
+        bytes: &[u8],
+        version: Option<&HostedPackumentVersion>,
+    ) -> Result<PackumentWrite> {
+        self.hosted.write_packument_if_current(name, bytes, version).await
     }
 
     /// Open a tarball from the authoritative hosted store. Hosted

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -29,6 +29,21 @@ const PACKUMENT_FILE: &str = "package.json";
 /// on POSIX as long as src and dest sit in the same directory (they do).
 static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 const MAX_TEMP_CREATE_ATTEMPTS: usize = 16;
+pub(crate) const PACKUMENT_WRITE_RETRIES: usize = 8;
+pub(crate) const RECOVERY_PACKUMENT_WRITE_RETRIES: usize = 32;
+const PACKUMENT_WRITE_CONFLICT_DELAY_MS: u64 = 5;
+const MAX_PACKUMENT_WRITE_CONFLICT_DELAY_MS: u64 = 250;
+
+pub(crate) fn packument_write_conflict_delay(attempt: usize) -> Duration {
+    let delay = PACKUMENT_WRITE_CONFLICT_DELAY_MS
+        .saturating_mul(1_u64 << attempt.min(6))
+        .min(MAX_PACKUMENT_WRITE_CONFLICT_DELAY_MS);
+    Duration::from_millis(delay)
+}
+
+pub(crate) async fn wait_after_packument_write_conflict(attempt: usize) {
+    tokio::time::sleep(packument_write_conflict_delay(attempt)).await;
+}
 
 /// Handle returned from [`Storage::open_upstream_tarball_tmp`]. The caller
 /// writes through [`Self::write_all`] (and on success calls [`Self::finalize`] to

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -226,6 +226,31 @@ pub(crate) enum PackumentWrite {
     Conflict,
 }
 
+/// Outcome of [`Storage::update_hosted_packument_with_retry`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PackumentUpdate {
+    Written,
+    /// The `build` closure reported that the packument does not exist
+    /// (returned `Ok(None)`), so there was nothing to update.
+    NotFound,
+}
+
+/// Outcome of promoting a staged tarball into the hosted store.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TarballFinalize {
+    /// The tarball was promoted: created on S3, or renamed into place on the
+    /// single-node FS backend, which owns its store exclusively.
+    Written,
+    /// An object with byte-identical content already occupied the key, so
+    /// promotion was a no-op. Safe — the published artifact is exactly ours.
+    AlreadyIdentical,
+    /// A *different* object already occupies the key: a concurrent publisher
+    /// won this version's tarball. A published version's tarball is immutable,
+    /// so the caller must not overwrite it and should surface a write conflict
+    /// rather than advertise an integrity that no longer matches the bytes.
+    Conflict,
+}
+
 impl HostedStore {
     async fn read_packument(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
         match self {
@@ -307,13 +332,19 @@ impl HostedStore {
         tmp_path: &Path,
         name: &PackageName,
         filename: &str,
-    ) -> Result<()> {
+    ) -> Result<TarballFinalize> {
         match self {
-            HostedStore::Fs(store) => store.finalize_tarball(tmp_path, name, filename).await,
+            HostedStore::Fs(store) => {
+                store.finalize_tarball(tmp_path, name, filename).await?;
+                Ok(TarballFinalize::Written)
+            }
             HostedStore::S3(store) => {
-                store.upload_tarball(tmp_path, name, filename).await?;
+                let outcome = store.upload_tarball(tmp_path, name, filename).await?;
+                // Consume the staged tmp whatever the outcome: a Conflict means
+                // another replica owns the object, so retrying our overwrite
+                // would be wrong, and there is nothing left to promote.
                 let _ = fs::remove_file(tmp_path).await;
-                Ok(())
+                Ok(outcome)
             }
         }
     }
@@ -434,6 +465,47 @@ impl Storage {
         version: Option<&HostedPackumentVersion>,
     ) -> Result<PackumentWrite> {
         self.hosted.write_packument_if_current(name, bytes, version).await
+    }
+
+    /// Read the hosted packument, transform it, and conditionally write it
+    /// back under compare-and-swap, retrying on conflict with capped backoff.
+    ///
+    /// `build` receives the current hosted bytes (`None` when the packument is
+    /// absent) and returns the bytes to write, or `Ok(None)` to abort as
+    /// [`PackumentUpdate::NotFound`]; a `build` error aborts without retrying.
+    /// After `retries` conflicts the write is surfaced as
+    /// [`RegistryError::PackumentWriteConflict`]. Both the dist-tag request
+    /// path and journal roll-forward go through here so their conflict handling
+    /// stays in one place.
+    pub(crate) async fn update_hosted_packument_with_retry<Build>(
+        &self,
+        name: &PackageName,
+        retries: usize,
+        mut build: Build,
+    ) -> Result<PackumentUpdate>
+    where
+        Build: FnMut(Option<&[u8]>) -> Result<Option<Vec<u8>>>,
+    {
+        for attempt in 0..retries {
+            let existing = self.read_hosted_packument_for_update(name).await?;
+            let (existing_bytes, version) = match existing {
+                Some(packument) => (Some(packument.bytes), Some(packument.version)),
+                None => (None, None),
+            };
+            let Some(new_bytes) = build(existing_bytes.as_deref())? else {
+                return Ok(PackumentUpdate::NotFound);
+            };
+            match self.write_hosted_packument_if_current(name, &new_bytes, version.as_ref()).await?
+            {
+                PackumentWrite::Written => return Ok(PackumentUpdate::Written),
+                PackumentWrite::Conflict => {
+                    if attempt + 1 < retries {
+                        wait_after_packument_write_conflict(attempt).await;
+                    }
+                }
+            }
+        }
+        Err(RegistryError::PackumentWriteConflict { package: name.as_str().to_string() })
     }
 
     /// Open a tarball from the authoritative hosted store. Hosted
@@ -563,7 +635,7 @@ impl Storage {
 
     /// Promote a tmp tarball written by the publish flow to its final
     /// home: a rename on the fs backend, an upload on the S3 backend.
-    pub async fn finalize_tarball_slot(&self, slot: TarballSlot) -> Result<()> {
+    pub async fn finalize_tarball_slot(&self, slot: TarballSlot) -> Result<TarballFinalize> {
         self.hosted.finalize_tarball(&slot.tmp_path, &slot.name, &slot.filename).await
     }
 

--- a/pnpr/crates/pnpr/src/storage/tests.rs
+++ b/pnpr/crates/pnpr/src/storage/tests.rs
@@ -12,6 +12,14 @@ fn pkg(name: &str) -> PackageName {
     PackageName::parse(name).unwrap()
 }
 
+#[test]
+fn packument_write_conflict_delay_caps_growth() {
+    assert_eq!(super::packument_write_conflict_delay(0).as_millis(), 5);
+    assert_eq!(super::packument_write_conflict_delay(1).as_millis(), 10);
+    assert_eq!(super::packument_write_conflict_delay(6).as_millis(), 250);
+    assert_eq!(super::packument_write_conflict_delay(32).as_millis(), 250);
+}
+
 #[tokio::test]
 async fn hosted_tarball_under_non_directory_package_path_is_an_error() {
     let tmp = TempDir::new().unwrap();

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -975,12 +975,12 @@ async fn dist_tag_mutations_refresh_time_modified() {
 }
 
 #[tokio::test]
-async fn dist_tag_set_requires_auth() {
+async fn dist_tag_set_requires_auth_before_body_parsing() {
     let tmp = TempDir::new().unwrap();
     let app = router(static_config(tmp.path().to_path_buf()));
     let request = Request::put("/-/package/anything/dist-tags/latest")
         .header("content-type", "application/json")
-        .body(Body::from(serde_json::to_string("1.0.0").unwrap()))
+        .body(Body::from("not json"))
         .unwrap();
     let response = app.oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Fix a lost-update risk in pnpr's S3-backed hosted store when multiple replicas update the
same hosted packument, and close the related tarball-overwrite race.

- Add conditional S3 packument writes using object-store update versions.
- Thread read-for-update metadata through hosted storage so publish, dist-tag updates, and
  partial unpublish reject or retry stale writes.
- Rework journal roll-forward to reread and re-merge before conditional writes.
- Share the packument read-modify-write conflict-retry loop between dist-tag updates and
  journal roll-forward through a single `Storage::update_hosted_packument_with_retry` helper.
- Make S3 tarball finalize compare-and-swap (`PutMode::Create`, byte-identical-tolerant): a
  losing concurrent same-version publish can no longer overwrite the winner's tarball and
  corrupt it against the integrity the winner's packument records.
- Add regression tests for stale/deleted S3 packument updates and for the tarball overwrite guard.

This is a pnpr registry-server-only change; no TypeScript CLI or pacquet porting is needed.

Verified with:

- `cargo fmt --package pnpr -- --check`
- `cargo clippy -p pnpr --all-targets -- --deny warnings`
- `cargo test -p pnpr` (full suite: 617 passed)
- `cargo test -p pnpr stale_packument_update_is_rejected`
- `cargo test -p pnpr concurrent_tarball_finalize_does_not_overwrite`
- `cargo test -p pnpr --test s3_backend`
- `cargo test -p pnpr --test journal_recovery`
- `cargo test -p pnpr --test batch_publish`
- `cargo test -p pnpr --test staged_publish`
- `cargo test -p pnpr --test auth_publish`
- `cargo test -p pnpr dist_tag`

## Squash Commit Body

```text
S3-backed pnpr deployments can run multiple stateless replicas against the same hosted
object store. The in-process package lock only serializes one replica, so the old
read/merge/write path could let a stale packument overwrite a newer merge.

Add a hosted packument read-for-update path that captures object-store update versions and
use conditional S3 writes for hosted packuments. Publish, partial unpublish, and dist-tag
writes now use that conditional write path; dist-tag writes retry after conflicts because
their mutation can be replayed on a fresh packument. The dist-tag request path and journal
roll-forward share one Storage::update_hosted_packument_with_retry helper so their
conflict/backoff handling stays in a single place.

Tarball finalize on the S3 backend is now compare-and-swap: it promotes with
PutMode::Create, tolerates a byte-identical object, and refuses to overwrite a different
object left by a concurrent same-version publisher. commit_publishes surfaces that as an
HTTP 409 before writing its packument, and journal roll-forward keeps the winner's
immutable version, so a losing publish can no longer corrupt the winner's tarball.

Publish commit journal recovery now rereads the current hosted packument, re-merges the
journaled manifest, and retries conditional writes.
Repeated conflicts surface as HTTP 409 rather than silently losing another writer's update.
The local fs backend keeps its existing single-process behavior because the production
shared-store race is specific to S3-backed replicas.

Regression tests verify that a stale S3 packument update is rejected and that a concurrent
tarball finalize with different bytes is refused without overwriting the first writer.
```

## Checklist

- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).
Follow-up review fixes (retry-loop dedup, tarball compare-and-swap) by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optimistic/conditional hosted packument writes (including version-aware updates) to safely handle concurrent metadata changes.
  * Updated dist-tag updates and journal recovery roll-forward to use retry-based conflict handling with capped backoff.
* **Bug Fixes**
  * Prevents overwriting newer packument metadata when concurrent writes occur.
  * Consistently reports packument write conflicts as **HTTP 409 Conflict**; improves partial unpublish behavior and validation.
* **Tests**
  * Added coverage for rejecting stale/deleted packument updates and capped conflict backoff delay growth.
  * Updated dist-tag auth test to verify authorization is checked before request parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
