### PR TITLE
fix(config): allow tokenHelper to be set in the global auth.ini

### DIFF
--- a/.changeset/allow-tokenhelper-in-global-auth-ini.md
+++ b/.changeset/allow-tokenhelper-in-global-auth-ini.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+A `tokenHelper` set in the global pnpm `auth.ini` is no longer rejected as project-level configuration. The guard that blocks `tokenHelper` from a project `.npmrc` only treated `~/.npmrc` as a trusted source, so a helper written to `auth.ini` (for example by `pnpm config set`) failed on every command and could not even be removed with `pnpm config delete`. A `tokenHelper` in a workspace or project `.npmrc` is still rejected.

--- a/.changeset/pacquet-token-helper.md
+++ b/.changeset/pacquet-token-helper.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Added support for the `tokenHelper` auth setting, matching the TypeScript CLI. A `tokenHelper` configured in `~/.npmrc` or the global pnpm `auth.ini` names a command pacquet runs to obtain a registry token; the command runs lazily (only when a request to that registry is actually made) and its output becomes the `Authorization` header. A `tokenHelper` in a workspace or project `.npmrc`, or supplied through a URL-scoped environment variable, is refused so a checked-in config can't run an arbitrary command.

--- a/.changeset/pacquet-token-helper.md
+++ b/.changeset/pacquet-token-helper.md
@@ -2,4 +2,4 @@
 "pacquet": minor
 ---
 
-Added support for the `tokenHelper` auth setting, matching the TypeScript CLI. A `tokenHelper` configured in `~/.npmrc` or the global pnpm `auth.ini` names a command pacquet runs to obtain a registry token; the command runs lazily (only when a request to that registry is actually made) and its output becomes the `Authorization` header. A `tokenHelper` in a workspace or project `.npmrc`, or supplied through a URL-scoped environment variable, is refused so a checked-in config can't run an arbitrary command.
+Added support for the `tokenHelper` auth setting, matching the TypeScript CLI. A `tokenHelper` configured in `~/.npmrc` or the global pnpm `auth.ini` names a command pacquet runs to obtain a registry token; the command runs lazily (only when a request to that registry is actually made), is given a 60-second time limit, and its output becomes the `Authorization` header. A `tokenHelper` in a workspace or project `.npmrc`, or supplied through a URL-scoped environment variable, is refused so a checked-in config can't run an arbitrary command.

--- a/.changeset/token-helper-timeout.md
+++ b/.changeset/token-helper-timeout.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/network.auth-header": patch
+"pnpm": patch
+---
+
+A `tokenHelper` command is now given a 60-second time limit. A helper that hangs (deadlock, stuck I/O) is killed and reported as an error instead of leaving the command waiting forever.

--- a/pnpm/crates/config/README.md
+++ b/pnpm/crates/config/README.md
@@ -36,7 +36,7 @@ For more information, read [pnpm docs about .npmrc](https://pnpm.io/npmrc)
 |------|--------------------|-------|
 | ✅    | registry           |       |
 |      | <URL>:_authToken   |       |
-|      | <URL>:_tokenHelper |       |
+| ✅    | <URL>:tokenHelper  | Trusted sources only; executed lazily on lookup. |
 
 # Request Settings
 

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -2133,7 +2133,14 @@ impl Config {
         for lower in trusted_sources {
             trusted_auth.merge_under(lower);
         }
-        self.package_manager_bootstrap = build_package_manager_bootstrap::<Sys>(trusted_auth);
+
+        // A `tokenHelper` names an executable, so it is honored only from a
+        // trusted, non-repo source. Reject one that a workspace or project
+        // `.npmrc` contributed by comparing the full merge against the
+        // trusted-only merge before either is consumed below.
+        crate::npmrc_auth::enforce_token_helper_trust(&npmrc_auth, &trusted_auth)?;
+
+        self.package_manager_bootstrap = build_package_manager_bootstrap::<Sys>(trusted_auth)?;
 
         npmrc_auth.apply_registry_and_warn(&mut self);
         // Proxy cascade fires unconditionally — even when no `.npmrc`
@@ -2284,7 +2291,7 @@ impl Config {
         // so this is independent of the final `config.registry` (which
         // yaml may have overridden) — the security boundary holds even
         // when the workspace points the default registry elsewhere.
-        npmrc_auth.build_auth_headers(&mut self);
+        npmrc_auth.build_auth_headers(&mut self)?;
 
         // Re-resolve `store_dir` against the project's volume when no
         // explicit source (global config.yaml, pnpm-workspace.yaml,
@@ -2381,7 +2388,7 @@ fn collect_explicit_settings(
 /// minus the repository-controlled sources.
 fn build_package_manager_bootstrap<Sys: EnvVar>(
     mut trusted_auth: NpmrcAuth,
-) -> PackageManagerBootstrap {
+) -> Result<PackageManagerBootstrap, LoadWorkspaceYamlError> {
     // The full-config fold already surfaced these sources' `${VAR}` warnings;
     // drop the duplicates this second pass would log.
     trusted_auth.warnings.clear();
@@ -2390,15 +2397,15 @@ fn build_package_manager_bootstrap<Sys: EnvVar>(
     trusted_auth.apply_json_env_registries(&mut config);
     trusted_auth.apply_proxy_cascade::<Sys>(&mut config);
     trusted_auth.apply_tls_and_local_address(&mut config);
-    trusted_auth.build_auth_headers(&mut config);
-    PackageManagerBootstrap {
+    trusted_auth.build_auth_headers(&mut config)?;
+    Ok(PackageManagerBootstrap {
         registry: config.registry,
         registries: config.registries,
         proxy: config.proxy,
         tls: config.tls,
         tls_by_uri: config.tls_by_uri,
         auth_headers: config.auth_headers,
-    }
+    })
 }
 
 /// Read the text of the `.npmrc` in `dir`, returning `None` for anything

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -579,8 +579,8 @@ impl NpmrcAuth {
     /// [`AuthHeaders`] (run lazily on lookup) rather than a baked header;
     /// like pnpm's `credsToHeader`, a `tokenHelper` wins over any static
     /// token on the same registry. Fails with
-    /// [`TokenHelperUnsupportedCharacterError`] if a honored helper's
-    /// value contains a reserved character.
+    /// [`LoadWorkspaceYamlError::TokenHelperUnsupportedCharacter`] if a
+    /// honored helper's value contains a reserved character.
     pub fn build_auth_headers(self, config: &mut Config) -> Result<(), LoadWorkspaceYamlError> {
         let mut auth_header_by_uri: HashMap<String, String> = HashMap::new();
         let mut auth_header_by_scope_by_uri: HashMap<String, HashMap<String, String>> =

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -1,4 +1,4 @@
-use crate::{Config, api::EnvVar};
+use crate::{Config, api::EnvVar, workspace_yaml::LoadWorkspaceYamlError};
 use indexmap::IndexMap;
 use pacquet_env_replace::env_replace_lossy;
 use pacquet_network::{
@@ -121,6 +121,14 @@ pub(crate) struct RawCreds {
     pub username: Option<String>,
     /// `_password=` value (base64-encoded password, per npm convention).
     pub password: Option<String>,
+    /// `tokenHelper=` value: the raw command line naming an executable
+    /// pnpm runs to obtain the registry token. Kept as the raw string
+    /// here; validated (reserved characters) and split into a command
+    /// at [`NpmrcAuth::build_auth_headers`] time. Only honored from a
+    /// trusted, non-repo source (see the trust guard in
+    /// [`crate::Config::current`]); a project/workspace `.npmrc`
+    /// carrying one is rejected.
+    pub token_helper: Option<String>,
 }
 
 #[derive(Clone, Copy)]
@@ -135,6 +143,7 @@ impl RawCreds {
             && self.auth_pair_base64.is_none()
             && self.username.is_none()
             && self.password.is_none()
+            && self.token_helper.is_none()
     }
 
     /// Fill any field that is `None` here from `lower`. Used when
@@ -145,6 +154,7 @@ impl RawCreds {
         self.auth_pair_base64 = self.auth_pair_base64.take().or(lower.auth_pair_base64);
         self.username = self.username.take().or(lower.username);
         self.password = self.password.take().or(lower.password);
+        self.token_helper = self.token_helper.take().or(lower.token_helper);
     }
 }
 
@@ -417,7 +427,7 @@ impl NpmrcAuth {
                 _ => {}
             }
 
-            if let Some((uri, suffix)) = split_creds_key(&key) {
+            if let Some((uri, suffix)) = split_ini_creds_key(&key) {
                 let entry = auth.creds_entry_mut(uri);
                 apply_creds_field(entry, suffix, value);
                 continue;
@@ -564,9 +574,19 @@ impl NpmrcAuth {
     /// Phase 2: compute and store the final [`AuthHeaders`] map,
     /// keying default-registry creds at `config.registry`'s nerf-darted
     /// URI.
-    pub fn build_auth_headers(self, config: &mut Config) {
+    ///
+    /// A `tokenHelper` credential becomes an un-executed command in the
+    /// [`AuthHeaders`] (run lazily on lookup) rather than a baked header;
+    /// like pnpm's `credsToHeader`, a `tokenHelper` wins over any static
+    /// token on the same registry. Fails with
+    /// [`TokenHelperUnsupportedCharacterError`] if a honored helper's
+    /// value contains a reserved character.
+    pub fn build_auth_headers(self, config: &mut Config) -> Result<(), LoadWorkspaceYamlError> {
         let mut auth_header_by_uri: HashMap<String, String> = HashMap::new();
         let mut auth_header_by_scope_by_uri: HashMap<String, HashMap<String, String>> =
+            HashMap::new();
+        let mut token_helper_by_uri: HashMap<String, Vec<String>> = HashMap::new();
+        let mut token_helper_by_scope_by_uri: HashMap<String, HashMap<String, Vec<String>>> =
             HashMap::new();
         // Raw `_authToken` per nerf-darted registry URI, default scope
         // only, preserved alongside the baked header for `pnpm logout`.
@@ -579,7 +599,16 @@ impl NpmrcAuth {
                 {
                     auth_tokens_by_uri.insert(uri.clone(), token.clone());
                 }
-                if let Some(header) = creds_to_header(&raw) {
+                if let Some(command) = parse_token_helper_field(raw.token_helper.as_deref())? {
+                    if scope == DEFAULT_REGISTRY_SCOPE {
+                        token_helper_by_uri.insert(uri.clone(), command);
+                    } else {
+                        token_helper_by_scope_by_uri
+                            .entry(uri.clone())
+                            .or_default()
+                            .insert(scope, command);
+                    }
+                } else if let Some(header) = creds_to_header(&raw) {
                     if scope == DEFAULT_REGISTRY_SCOPE {
                         auth_header_by_uri.insert(uri.clone(), header);
                     } else {
@@ -596,14 +625,23 @@ impl NpmrcAuth {
             if let Some(token) = &self.default_creds.auth_token {
                 auth_tokens_by_uri.insert(default_uri.clone(), token.clone());
             }
-            if let Some(header) = creds_to_header(&self.default_creds) {
+            if let Some(command) =
+                parse_token_helper_field(self.default_creds.token_helper.as_deref())?
+            {
+                token_helper_by_uri.insert(default_uri, command);
+            } else if let Some(header) = creds_to_header(&self.default_creds) {
                 auth_header_by_uri.insert(default_uri, header);
             }
         }
 
         config.auth_tokens_by_uri = auth_tokens_by_uri;
-        config.auth_headers =
-            Arc::new(AuthHeaders::from_parts(auth_header_by_uri, auth_header_by_scope_by_uri));
+        config.auth_headers = Arc::new(AuthHeaders::from_parts_with_token_helpers(
+            auth_header_by_uri,
+            auth_header_by_scope_by_uri,
+            token_helper_by_uri,
+            token_helper_by_scope_by_uri,
+        ));
+        Ok(())
     }
 
     /// Pin this source file's **unscoped** credentials (`_authToken`,
@@ -763,7 +801,7 @@ impl NpmrcAuth {
         self.apply_registry_and_warn(config);
         self.apply_proxy_cascade::<Sys>(config);
         self.apply_tls_and_local_address(config);
-        self.build_auth_headers(config);
+        self.build_auth_headers(config).expect("valid tokenHelper in test .npmrc");
     }
 
     fn creds_entry_mut(&mut self, uri: &str) -> &mut RawCreds {
@@ -887,6 +925,78 @@ fn creds_to_header(creds: &RawCreds) -> Option<String> {
     None
 }
 
+/// Reject a `tokenHelper` that a workspace or project `.npmrc` contributed.
+///
+/// `full` is the merged config including the project `.npmrc`; `trusted`
+/// is the same merge minus the project source (mirroring pnpm's
+/// `userConfig` vs `trustedConfig` split). A `tokenHelper` present in
+/// `full` but not reproducible verbatim from `trusted` — because the
+/// project source added it, or overrode a trusted one with a different
+/// command — is repository-controlled and rejected. A project value that
+/// exactly equals the trusted one is harmless and allowed, matching pnpm.
+pub(crate) fn enforce_token_helper_trust(
+    full: &NpmrcAuth,
+    trusted: &NpmrcAuth,
+) -> Result<(), LoadWorkspaceYamlError> {
+    for (uri, by_scope) in &full.creds_by_scope_by_uri {
+        for (scope, raw) in by_scope {
+            let Some(value) = &raw.token_helper else { continue };
+            let trusted_value = trusted
+                .creds_by_scope_by_uri
+                .get(uri)
+                .and_then(|by_scope| by_scope.get(scope))
+                .and_then(|raw| raw.token_helper.as_deref());
+            if trusted_value != Some(value.as_str()) {
+                return Err(LoadWorkspaceYamlError::TokenHelperInProjectConfig {
+                    key: token_helper_key(uri, scope),
+                });
+            }
+        }
+    }
+    // `default_creds` is normally emptied by `rescope_unscoped` before the
+    // merge; guard it too for the paths that skip rescoping.
+    if let Some(value) = &full.default_creds.token_helper
+        && trusted.default_creds.token_helper.as_deref() != Some(value.as_str())
+    {
+        return Err(LoadWorkspaceYamlError::TokenHelperInProjectConfig {
+            key: "tokenHelper".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+/// Reconstruct a representative `.npmrc` key from a nerf-darted registry
+/// URI and scope, for the [`LoadWorkspaceYamlError::TokenHelperInProjectConfig`]
+/// message.
+fn token_helper_key(uri: &str, scope: &str) -> String {
+    if scope == DEFAULT_REGISTRY_SCOPE {
+        format!("{uri}:tokenHelper")
+    } else {
+        format!("{uri}:{scope}:tokenHelper")
+    }
+}
+
+/// Characters pnpm reserves in a `tokenHelper` value for future quoting /
+/// interpolation support; their presence is an error.
+const TOKEN_HELPER_RESERVED_CHARACTERS: [char; 5] = ['$', '%', '`', '"', '\''];
+
+/// Parse an optional raw `tokenHelper` value into `[program, ...args]`,
+/// returning `Ok(None)` when unset or empty (no command to run). Rejects
+/// a reserved character. Mirrors pnpm's `parseTokenHelper`.
+fn parse_token_helper_field(
+    raw: Option<&str>,
+) -> Result<Option<Vec<String>>, LoadWorkspaceYamlError> {
+    let Some(raw) = raw else { return Ok(None) };
+    let source = raw.trim();
+    if let Some(character) =
+        source.chars().find(|character| TOKEN_HELPER_RESERVED_CHARACTERS.contains(character))
+    {
+        return Err(LoadWorkspaceYamlError::TokenHelperUnsupportedCharacter { character });
+    }
+    let command: Vec<String> = source.split_whitespace().map(str::to_owned).collect();
+    Ok((!command.is_empty()).then_some(command))
+}
+
 /// Decode a standard base64 string. Used for the `_password` field
 /// where npm stores the raw password base64-encoded; falls back to
 /// returning `None` so the caller can keep the raw value verbatim
@@ -916,12 +1026,26 @@ fn base64_decode(input: &str) -> Option<String> {
     String::from_utf8(bytes).ok()
 }
 
-/// Auth-suffix keys recognised on a `//host[:port]/path/:` prefix.
+/// Auth-suffix keys recognised on a `//host[:port]/path/:` prefix in
+/// **any** source, including URL-scoped environment variables.
+///
+/// `tokenHelper` is deliberately absent: it names an executable, so it
+/// is only ever honored from a trusted `.npmrc` / `auth.ini` file (see
+/// [`INI_CREDS_SUFFIXES`]), never from the environment — mirroring
+/// pnpm, which drops a `//host/:tokenHelper` env var outright.
 const CREDS_SUFFIXES: &[&str] = &["_authToken", "_auth", "_password", "username"];
 
+/// Auth-suffix keys recognised when parsing an `.npmrc` / `auth.ini`
+/// file. Adds `tokenHelper` to [`CREDS_SUFFIXES`]; the file-vs-env
+/// split is the boundary the trust guard relies on.
+const INI_CREDS_SUFFIXES: &[&str] =
+    &["_authToken", "_auth", "_password", "username", "tokenHelper"];
+
 fn is_auth_value_key(key: &str) -> bool {
-    matches!(key, "_authToken" | "_auth" | "_password" | "username" | "cert" | "key")
-        || split_creds_key(key).is_some()
+    matches!(
+        key,
+        "_authToken" | "_auth" | "_password" | "username" | "tokenHelper" | "cert" | "key",
+    ) || split_ini_creds_key(key).is_some()
         || split_inline_identity_key(key).is_some()
 }
 
@@ -945,11 +1069,24 @@ fn parse_url_scoped_env_name(name: &str) -> Option<(bool, &str)> {
     None
 }
 
-fn split_creds_key(key: &str) -> Option<(&str, &str)> {
+fn split_creds_key(key: &str) -> Option<(&str, &'static str)> {
+    split_creds_key_in(key, CREDS_SUFFIXES)
+}
+
+/// Like [`split_creds_key`] but also recognises `:tokenHelper`. Used only
+/// on `.npmrc` / `auth.ini` file keys, never on environment variables.
+fn split_ini_creds_key(key: &str) -> Option<(&str, &'static str)> {
+    split_creds_key_in(key, INI_CREDS_SUFFIXES)
+}
+
+fn split_creds_key_in<'a>(
+    key: &'a str,
+    suffixes: &[&'static str],
+) -> Option<(&'a str, &'static str)> {
     if !key.starts_with("//") {
         return None;
     }
-    for suffix in CREDS_SUFFIXES {
+    for suffix in suffixes {
         let needle = format!(":{suffix}");
         if let Some(stripped) = key.strip_suffix(needle.as_str()) {
             return Some((stripped, suffix));
@@ -1008,6 +1145,7 @@ fn apply_creds_field(creds: &mut RawCreds, field: &str, value: String) {
         "_auth" => creds.auth_pair_base64 = Some(value),
         "username" => creds.username = Some(value),
         "_password" => creds.password = Some(value),
+        "tokenHelper" => creds.token_helper = Some(value),
         _ => {}
     }
 }

--- a/pnpm/crates/config/src/npmrc_auth/tests.rs
+++ b/pnpm/crates/config/src/npmrc_auth/tests.rs
@@ -247,7 +247,7 @@ fn build_auth_headers_keys_default_token_to_registry_uri() {
         },
         ..Default::default()
     };
-    auth.build_auth_headers(&mut config);
+    auth.build_auth_headers(&mut config).expect("no tokenHelper");
     assert_eq!(
         config.auth_tokens_by_uri.get("//registry.npmjs.org/").map(String::as_str),
         Some("top-secret"),

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -1092,6 +1092,87 @@ pub fn auth_ini_without_registry_falls_back_to_npmjs_default() {
     assert_eq!(config.auth_headers.for_url("https://trusted.example.com/pkg"), None);
 }
 
+/// A `tokenHelper` set in the global pnpm `auth.ini` (a trusted, non-repo
+/// source) is honored: its command runs lazily on lookup and its stdout
+/// becomes the `Authorization` header. `/bin/echo` is a real binary, so
+/// this exercises the whole path end to end (Unix only).
+#[cfg(unix)]
+#[test]
+pub fn token_helper_in_global_auth_ini_is_honored() {
+    let project = tempdir().expect("project tempdir");
+    let config_home = tempdir().expect("config-home tempdir");
+    let pnpm_dir = config_home.path().join("pnpm");
+    fs::create_dir_all(&pnpm_dir).expect("create pnpm config dir");
+    write_file(
+        &pnpm_dir.join("auth.ini"),
+        "//registry.example.com/:tokenHelper=/bin/echo s3cr3t\n",
+    );
+
+    set_fake_env(&[("XDG_CONFIG_HOME", config_home.path().to_str().unwrap())]);
+    let config =
+        Config::default().current::<FakeEnv>(project.path()).expect("load config with tokenHelper");
+
+    assert_eq!(
+        config.auth_headers.for_url("https://registry.example.com/pkg").as_deref(),
+        Some("Bearer s3cr3t"),
+    );
+}
+
+/// A `tokenHelper` in a project `.npmrc` is rejected: a checked-in
+/// `.npmrc` must not be able to run an arbitrary command.
+#[test]
+pub fn token_helper_in_project_npmrc_is_rejected() {
+    let project = tempdir().expect("project tempdir");
+    write_file(
+        &project.path().join(".npmrc"),
+        "//registry.example.com/:tokenHelper=/bin/echo s3cr3t\n",
+    );
+
+    set_fake_env(&[]);
+    let error = Config::default()
+        .current::<FakeEnv>(project.path())
+        .expect_err("project tokenHelper must be rejected");
+    assert!(
+        matches!(error, LoadWorkspaceYamlError::TokenHelperInProjectConfig { .. }),
+        "got {error:?}",
+    );
+}
+
+/// A trusted `tokenHelper` carrying a reserved character (here `$`, which
+/// pnpm reserves for future interpolation) is rejected at config load.
+#[test]
+pub fn token_helper_with_reserved_character_is_rejected() {
+    let project = tempdir().expect("project tempdir");
+    let config_home = tempdir().expect("config-home tempdir");
+    let pnpm_dir = config_home.path().join("pnpm");
+    fs::create_dir_all(&pnpm_dir).expect("create pnpm config dir");
+    write_file(&pnpm_dir.join("auth.ini"), "//registry.example.com/:tokenHelper=echo $SECRET\n");
+
+    set_fake_env(&[("XDG_CONFIG_HOME", config_home.path().to_str().unwrap())]);
+    let error = Config::default()
+        .current::<FakeEnv>(project.path())
+        .expect_err("reserved character must be rejected");
+    assert!(
+        matches!(error, LoadWorkspaceYamlError::TokenHelperUnsupportedCharacter { character: '$' }),
+        "got {error:?}",
+    );
+}
+
+/// A `tokenHelper` supplied through a URL-scoped environment variable is
+/// dropped, not honored: the environment layer must never run an arbitrary
+/// command. Mirrors pnpm dropping `//host/:tokenHelper` env vars.
+#[test]
+pub fn token_helper_from_url_scoped_env_is_not_honored() {
+    let project = tempdir().expect("project tempdir");
+
+    set_fake_env(&[("npm_config_//registry.example.com/:tokenHelper", "/bin/echo s3cr3t")]);
+    let config = Config::default()
+        .current::<FakeEnv>(project.path())
+        .expect("env tokenHelper is dropped, not an error");
+
+    assert_eq!(config.auth_headers.for_url("https://registry.example.com/pkg"), None);
+}
+
 /// `default_store_dir`'s `PNPM_HOME` branch, exercised through the
 /// generic capability seam — no process-environment mutation, no
 /// `EnvGuard` lock, no `unsafe` block. With the DI seam from

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -547,6 +547,28 @@ pub enum LoadWorkspaceYamlError {
         #[error(source)]
         source: serde_json::Error,
     },
+    /// A `tokenHelper` was configured in a workspace or project `.npmrc`.
+    /// It names an executable, so it is only honored from a trusted,
+    /// non-repo source (`~/.npmrc` or the global `auth.ini`); a
+    /// checked-in `.npmrc` must not be able to run an arbitrary command.
+    #[display("tokenHelper must not be configured in project-level .npmrc")]
+    #[diagnostic(
+        code(ERR_PNPM_TOKEN_HELPER_IN_PROJECT_CONFIG),
+        help(
+            "The key {key:?} was found in project config. Move it to ~/.npmrc or the global pnpm auth.ini."
+        )
+    )]
+    TokenHelperInProjectConfig { key: String },
+    /// A honored `tokenHelper` value contained a character pnpm reserves
+    /// for future quoting / interpolation support.
+    #[display("Unexpected character {character:?} in tokenHelper")]
+    #[diagnostic(
+        code(ERR_PNPM_TOKEN_HELPER_UNSUPPORTED_CHARACTER),
+        help(
+            "Try wrapping the current command in a script whose name does not contain unsupported characters."
+        )
+    )]
+    TokenHelperUnsupportedCharacter { character: char },
 }
 
 impl WorkspaceSettings {

--- a/pnpm/crates/network/src/auth.rs
+++ b/pnpm/crates/network/src/auth.rs
@@ -15,10 +15,11 @@
 //! its own subdomain or path, place a key at that host or prefix in
 //! `.npmrc`; if it redirects across hosts, no header is attached.
 
+use crate::token_helper::{TokenHelperRunner, execute_token_helper, run_token_helper_command};
 use std::{
     collections::{BTreeMap, HashMap},
     fmt,
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 pub const DEFAULT_REGISTRY_SCOPE: &str = "@";
@@ -91,14 +92,15 @@ pub enum MetadataCacheScope {
 /// [`AuthHeaders::for_url`].
 #[derive(Default, Clone)]
 pub struct AuthHeaders {
-    /// Keys are the nerf-darted form (`//host[:port]/path/`). Values
-    /// are ready-to-send header values like `Bearer abc123` or
-    /// `Basic Zm9vOmJhcg==`.
-    by_uri: HashMap<String, String>,
+    /// Keys are the nerf-darted form (`//host[:port]/path/`). Each value
+    /// is either a ready-to-send header (`Bearer abc123`,
+    /// `Basic Zm9vOmJhcg==`) or an un-executed `tokenHelper` command,
+    /// resolved lazily on lookup (see [`AuthEntry`]).
+    by_uri: HashMap<String, AuthEntry>,
     /// Package-scope credentials keyed as
     /// `scoped_by_scope[scope][registry_uri]`, where `registry_uri` is
     /// the nerf-darted registry URL without the trailing scope segment.
-    scoped_by_scope: HashMap<String, HashMap<String, String>>,
+    scoped_by_scope: HashMap<String, HashMap<String, AuthEntry>>,
     /// The longest key in `by_uri` measured in `/`-separated parts. The
     /// lookup walks from this depth down to 3 (the `//host/` floor).
     max_parts: usize,
@@ -109,6 +111,36 @@ pub struct AuthHeaders {
     /// the client-forwarded credentials above are ignored. See
     /// [`UpstreamRouteHook`].
     route_hook: Option<Arc<dyn UpstreamRouteHook>>,
+    /// Set iff any entry is an [`AuthEntry::TokenHelper`]. Surfaced in the
+    /// [`fmt::Debug`] output (never the values) so a resolve trace shows
+    /// at a glance whether any helper is configured. The lookup hot path
+    /// touches the resolution cache only on a `TokenHelper` match, so a
+    /// map of only baked headers pays nothing regardless.
+    has_token_helpers: bool,
+    /// Memoizes each resolved `tokenHelper`: a helper runs at most once
+    /// per process, keyed by its map key. `Some(header)` on success,
+    /// `None` on failure (so a failed helper is never retried and never
+    /// falls back to sending a different credential). Shared across
+    /// [`Clone`]s so the memo survives an `Arc` unwrap-and-rebuild.
+    resolved_token_helpers: Arc<Mutex<HashMap<String, Option<String>>>>,
+    /// Runner used to execute a `tokenHelper`. `None` uses the real
+    /// process spawner; tests inject a fake via
+    /// [`AuthHeaders::with_token_helper_runner`].
+    token_helper_runner: Option<TokenHelperRunner>,
+}
+
+/// One resolved credential slot: either a baked header value or a
+/// `tokenHelper` command still to be executed. Keeping both in the same
+/// map preserves pnpm's single longest-path-prefix lookup — a
+/// `tokenHelper` at `//host/` and a static token at `//host/path/`
+/// compete by prefix length exactly as two static tokens would.
+#[derive(Clone)]
+enum AuthEntry {
+    /// A ready-to-send `Authorization` header value.
+    Header(String),
+    /// A `[program, ...args]` command, executed lazily to a `Bearer …`
+    /// (or scheme-carrying) header on first matching lookup.
+    TokenHelper(Vec<String>),
 }
 
 impl fmt::Debug for AuthHeaders {
@@ -119,6 +151,7 @@ impl fmt::Debug for AuthHeaders {
         f.debug_struct("AuthHeaders")
             .field("by_uri", &self.by_uri.len())
             .field("scoped_by_scope", &self.scoped_by_scope.len())
+            .field("has_token_helpers", &self.has_token_helpers)
             .field("route_hook", &self.route_hook.is_some())
             .finish_non_exhaustive()
     }
@@ -189,14 +222,63 @@ impl AuthHeaders {
         by_uri: HashMap<String, String>,
         scoped_by_uri: HashMap<String, HashMap<String, String>>,
     ) -> Self {
-        let by_uri: HashMap<String, String> =
-            by_uri.into_iter().map(|(uri, value)| (normalize_auth_key(uri), value)).collect();
-        let mut scoped_by_scope: HashMap<String, HashMap<String, String>> = HashMap::new();
-        let mut max_scoped_parts_by_scope: HashMap<String, usize> = HashMap::new();
+        Self::from_parts_with_token_helpers(by_uri, scoped_by_uri, HashMap::new(), HashMap::new())
+    }
+
+    /// Build an [`AuthHeaders`] from baked header maps plus un-executed
+    /// `tokenHelper` command maps. A `tokenHelper` at a given key wins
+    /// over a baked header at the same key (pnpm resolves `tokenHelper`
+    /// before a static token). The helper commands are run lazily on
+    /// lookup.
+    #[must_use]
+    pub fn from_parts_with_token_helpers(
+        by_uri: HashMap<String, String>,
+        scoped_by_uri: HashMap<String, HashMap<String, String>>,
+        token_helper_by_uri: HashMap<String, Vec<String>>,
+        token_helper_scoped_by_uri: HashMap<String, HashMap<String, Vec<String>>>,
+    ) -> Self {
+        let mut by_uri_entries: HashMap<String, AuthEntry> = by_uri
+            .into_iter()
+            .map(|(uri, value)| (normalize_auth_key(uri), AuthEntry::Header(value)))
+            .collect();
+        for (uri, command) in token_helper_by_uri {
+            by_uri_entries.insert(normalize_auth_key(uri), AuthEntry::TokenHelper(command));
+        }
+
+        let mut scoped_entries: HashMap<String, HashMap<String, AuthEntry>> = HashMap::new();
         for (uri, scoped) in scoped_by_uri {
             let uri = normalize_auth_key(uri);
+            let entry = scoped_entries.entry(uri).or_default();
+            for (scope, value) in scoped {
+                entry.insert(scope, AuthEntry::Header(value));
+            }
+        }
+        for (uri, scoped) in token_helper_scoped_by_uri {
+            let uri = normalize_auth_key(uri);
+            let entry = scoped_entries.entry(uri).or_default();
+            for (scope, command) in scoped {
+                entry.insert(scope, AuthEntry::TokenHelper(command));
+            }
+        }
+
+        Self::from_entry_parts(by_uri_entries, scoped_entries)
+    }
+
+    /// Assemble the lookup indices from already-wrapped [`AuthEntry`]
+    /// maps: the per-scope longest-key counts, the top-level
+    /// `max_parts`, and the `has_token_helpers` gate.
+    fn from_entry_parts(
+        by_uri: HashMap<String, AuthEntry>,
+        scoped_by_uri: HashMap<String, HashMap<String, AuthEntry>>,
+    ) -> Self {
+        let mut scoped_by_scope: HashMap<String, HashMap<String, AuthEntry>> = HashMap::new();
+        let mut max_scoped_parts_by_scope: HashMap<String, usize> = HashMap::new();
+        let mut has_token_helpers =
+            by_uri.values().any(|entry| matches!(entry, AuthEntry::TokenHelper(_)));
+        for (uri, scoped) in scoped_by_uri {
             let parts = uri.split('/').count();
             for (scope, value) in scoped {
+                has_token_helpers |= matches!(value, AuthEntry::TokenHelper(_));
                 max_scoped_parts_by_scope
                     .entry(scope.clone())
                     .and_modify(|max| *max = (*max).max(parts))
@@ -211,7 +293,19 @@ impl AuthHeaders {
             max_parts,
             max_scoped_parts_by_scope,
             route_hook: None,
+            has_token_helpers,
+            resolved_token_helpers: Arc::default(),
+            token_helper_runner: None,
         }
+    }
+
+    /// Override the runner used to execute `tokenHelper` commands. The
+    /// dependency-injection seam for tests: production leaves it unset
+    /// and spawns real processes.
+    #[must_use]
+    pub fn with_token_helper_runner(mut self, runner: TokenHelperRunner) -> Self {
+        self.token_helper_runner = Some(runner);
+        self
     }
 
     /// Build an [`AuthHeaders`] from the structured pnpr wire shape:
@@ -238,19 +332,26 @@ impl AuthHeaders {
     /// this lookup, suitable for forwarding to a pnpr resolver.
     #[must_use]
     pub fn to_by_scope(&self) -> AuthHeadersByScope {
+        // A `tokenHelper` entry has no static string to forward — it would
+        // have to be executed — so it is skipped here. This map feeds the
+        // pnpr wire shape, which carries only resolved header strings.
         let mut result = AuthHeadersByScope::new();
-        for (uri, value) in &self.by_uri {
-            result
-                .entry(uri.clone())
-                .or_default()
-                .insert(DEFAULT_REGISTRY_SCOPE.to_owned(), value.clone());
+        for (uri, entry) in &self.by_uri {
+            if let AuthEntry::Header(value) = entry {
+                result
+                    .entry(uri.clone())
+                    .or_default()
+                    .insert(DEFAULT_REGISTRY_SCOPE.to_owned(), value.clone());
+            }
         }
         for (scope, scoped_by_uri) in &self.scoped_by_scope {
-            for (registry_uri, value) in scoped_by_uri {
-                result
-                    .entry(registry_uri.clone())
-                    .or_default()
-                    .insert(scope.clone(), value.clone());
+            for (registry_uri, entry) in scoped_by_uri {
+                if let AuthEntry::Header(value) = entry {
+                    result
+                        .entry(registry_uri.clone())
+                        .or_default()
+                        .insert(scope.clone(), value.clone());
+                }
             }
         }
         result
@@ -340,28 +441,40 @@ impl AuthHeaders {
         if let Some(basic) = parsed.basic_auth_header() {
             return Some(basic);
         }
+        // Each lookup returns `None` when no key matched (so the walk
+        // falls through to the next candidate) and `Some(_)` when a key
+        // matched — even `Some(None)`, a matched `tokenHelper` that failed
+        // to resolve. A match is final: pnpm's most-specific key owns the
+        // decision, so a failed helper must not fall back to a shorter
+        // prefix or a different scope and send another credential.
         if let Some(scope) = package_scope(pkg_name) {
-            if let Some(value) = self.lookup_scope_by_nerf(&parsed, scope) {
-                return Some(value.to_owned());
+            if let Some(resolved) = self.lookup_scope_by_nerf(&parsed, scope) {
+                return resolved;
             }
             if parsed.port.is_some() {
                 let stripped = parsed.with_port_stripped();
-                if let Some(value) = self.lookup_scope_by_nerf(&stripped, scope) {
-                    return Some(value.to_owned());
+                if let Some(resolved) = self.lookup_scope_by_nerf(&stripped, scope) {
+                    return resolved;
                 }
             }
         }
-        if let Some(value) = self.lookup_by_nerf(&parsed) {
-            return Some(value.to_owned());
+        if let Some(resolved) = self.lookup_by_nerf(&parsed) {
+            return resolved;
         }
         if parsed.port.is_some() {
             let stripped = parsed.with_port_stripped();
-            return self.lookup_by_nerf(&stripped).map(str::to_owned);
+            if let Some(resolved) = self.lookup_by_nerf(&stripped) {
+                return resolved;
+            }
         }
         None
     }
 
-    fn lookup_scope_by_nerf(&self, parsed: &ParsedUrl<'_>, scope: &str) -> Option<&str> {
+    /// Walk package-scope keys for `scope` longest-prefix first. Returns
+    /// `None` when nothing matched and `Some(resolved)` when a key
+    /// matched (the inner `Option` is the resolved header, `None` if a
+    /// matched `tokenHelper` failed).
+    fn lookup_scope_by_nerf(&self, parsed: &ParsedUrl<'_>, scope: &str) -> Option<Option<String>> {
         let scoped_by_uri = self.scoped_by_scope.get(scope)?;
         let max_scoped_parts = self.max_scoped_parts_by_scope.get(scope).copied()?;
         let nerfed = parsed.nerf_dart();
@@ -369,14 +482,14 @@ impl AuthHeaders {
         let upper = parts.len().min(max_scoped_parts);
         for i in (3..upper).rev() {
             let key = format!("{}/", parts[..i].join("/"));
-            if let Some(value) = scoped_by_uri.get(&key) {
-                return Some(value.as_str());
+            if let Some(entry) = scoped_by_uri.get(&key) {
+                return Some(self.resolve_entry(&key, scope, entry));
             }
         }
         None
     }
 
-    fn lookup_by_nerf(&self, parsed: &ParsedUrl<'_>) -> Option<&str> {
+    fn lookup_by_nerf(&self, parsed: &ParsedUrl<'_>) -> Option<Option<String>> {
         if self.by_uri.is_empty() {
             return None;
         }
@@ -393,11 +506,47 @@ impl AuthHeaders {
         // never match.
         for i in (3..upper).rev() {
             let key = format!("{}/", parts[..i].join("/"));
-            if let Some(value) = self.by_uri.get(&key) {
-                return Some(value.as_str());
+            if let Some(entry) = self.by_uri.get(&key) {
+                return Some(self.resolve_entry(&key, DEFAULT_REGISTRY_SCOPE, entry));
             }
         }
         None
+    }
+
+    /// Resolve a matched [`AuthEntry`] to a header value. A baked header
+    /// is cloned; a `tokenHelper` is executed once and memoized (keyed by
+    /// `scope` + map key so the same command at two registries still runs
+    /// per registry). A helper failure logs and yields `None` — pacquet
+    /// never sends a wrong, partial, or stale credential.
+    fn resolve_entry(&self, key: &str, scope: &str, entry: &AuthEntry) -> Option<String> {
+        match entry {
+            AuthEntry::Header(value) => Some(value.clone()),
+            AuthEntry::TokenHelper(command) => {
+                let cache_key = format!("{scope}\u{0}{key}");
+                let mut cache = self
+                    .resolved_token_helpers
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if let Some(cached) = cache.get(&cache_key) {
+                    return cached.clone();
+                }
+                let runner = self.token_helper_runner.unwrap_or(run_token_helper_command);
+                let resolved = match execute_token_helper(command, runner) {
+                    Ok(header) => Some(header),
+                    Err(error) => {
+                        let program = command.first().map_or("", String::as_str);
+                        tracing::error!(
+                            target: "pacquet::auth",
+                            "token helper {program:?} failed; the request will be sent without \
+                             authentication: {error}",
+                        );
+                        None
+                    }
+                };
+                cache.insert(cache_key, resolved.clone());
+                resolved
+            }
+        }
     }
 }
 

--- a/pnpm/crates/network/src/auth.rs
+++ b/pnpm/crates/network/src/auth.rs
@@ -19,7 +19,7 @@ use crate::token_helper::{TokenHelperRunner, execute_token_helper, run_token_hel
 use std::{
     collections::{BTreeMap, HashMap},
     fmt,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
 };
 
 pub const DEFAULT_REGISTRY_SCOPE: &str = "@";
@@ -90,6 +90,12 @@ pub enum MetadataCacheScope {
 /// Construct via [`AuthHeaders::from_parts`], [`AuthHeaders::from_creds_map`],
 /// [`AuthHeaders::from_map`], or [`AuthHeaders::default`] (empty). Look up via
 /// [`AuthHeaders::for_url`].
+/// Memo of resolved `tokenHelper` results keyed by `scope + map key`. Each
+/// entry is a per-key [`OnceLock`] so a resolving subprocess runs without the
+/// shared [`Mutex`] held. See the `resolved_token_helpers` field on
+/// [`AuthHeaders`].
+type TokenHelperCache = Arc<Mutex<HashMap<String, Arc<OnceLock<Option<String>>>>>>;
+
 #[derive(Default, Clone)]
 pub struct AuthHeaders {
     /// Keys are the nerf-darted form (`//host[:port]/path/`). Each value
@@ -118,11 +124,14 @@ pub struct AuthHeaders {
     /// map of only baked headers pays nothing regardless.
     has_token_helpers: bool,
     /// Memoizes each resolved `tokenHelper`: a helper runs at most once
-    /// per process, keyed by its map key. `Some(header)` on success,
-    /// `None` on failure (so a failed helper is never retried and never
-    /// falls back to sending a different credential). Shared across
-    /// [`Clone`]s so the memo survives an `Arc` unwrap-and-rebuild.
-    resolved_token_helpers: Arc<Mutex<HashMap<String, Option<String>>>>,
+    /// per process, keyed by its map key. Each key maps to a per-key
+    /// [`OnceLock`] so the resolving subprocess runs without the shared
+    /// [`Mutex`] held — one slow helper can't block another registry's
+    /// lookup. `Some(header)` on success, `None` on failure (so a failed
+    /// helper is never retried and never falls back to sending a different
+    /// credential). Shared across [`Clone`]s so the memo survives an `Arc`
+    /// unwrap-and-rebuild.
+    resolved_token_helpers: TokenHelperCache,
     /// Runner used to execute a `tokenHelper`. `None` uses the real
     /// process spawner; tests inject a fake via
     /// [`AuthHeaders::with_token_helper_runner`].
@@ -523,28 +532,35 @@ impl AuthHeaders {
             AuthEntry::Header(value) => Some(value.clone()),
             AuthEntry::TokenHelper(command) => {
                 let cache_key = format!("{scope}\u{0}{key}");
-                let mut cache = self
-                    .resolved_token_helpers
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                if let Some(cached) = cache.get(&cache_key) {
-                    return cached.clone();
-                }
-                let runner = self.token_helper_runner.unwrap_or(run_token_helper_command);
-                let resolved = match execute_token_helper(command, runner) {
-                    Ok(header) => Some(header),
-                    Err(error) => {
-                        let program = command.first().map_or("", String::as_str);
-                        tracing::error!(
-                            target: "pacquet::auth",
-                            "token helper {program:?} failed; the request will be sent without \
-                             authentication: {error}",
-                        );
-                        None
-                    }
+                // Take the per-key cell out under the global lock, then
+                // release it *before* running the helper. Holding the lock
+                // across the (up to `TOKEN_HELPER_TIMEOUT`) subprocess would
+                // block every other registry's lookup on one slow helper.
+                // `OnceLock` still serializes concurrent first-lookups of the
+                // *same* key, so the command runs at most once.
+                let cell = {
+                    let mut cache = self
+                        .resolved_token_helpers
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    Arc::clone(cache.entry(cache_key).or_default())
                 };
-                cache.insert(cache_key, resolved.clone());
-                resolved
+                cell.get_or_init(|| {
+                    let runner = self.token_helper_runner.unwrap_or(run_token_helper_command);
+                    match execute_token_helper(command, runner) {
+                        Ok(header) => Some(header),
+                        Err(error) => {
+                            let program = command.first().map_or("", String::as_str);
+                            tracing::error!(
+                                target: "pacquet::auth",
+                                "token helper {program:?} failed; the request will be sent \
+                                 without authentication: {error}",
+                            );
+                            None
+                        }
+                    }
+                })
+                .clone()
             }
         }
     }

--- a/pnpm/crates/network/src/auth/tests.rs
+++ b/pnpm/crates/network/src/auth/tests.rs
@@ -2,11 +2,76 @@ use super::{
     AuthHeaders, DEFAULT_REGISTRY_SCOPE, UpstreamRouteHook, base64_encode, nerf_dart,
     redact_and_sanitize, redact_url_credentials,
 };
+use crate::TokenHelperOutput;
 use pretty_assertions::assert_eq;
-use std::sync::{
-    Arc,
-    atomic::{AtomicUsize, Ordering},
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
 };
+
+fn token_helper_by_uri(uri: &str, command: &[&str]) -> HashMap<String, Vec<String>> {
+    std::iter::once((
+        uri.to_owned(),
+        command.iter().map(|part| (*part).to_owned()).collect::<Vec<String>>(),
+    ))
+    .collect()
+}
+
+#[test]
+fn token_helper_is_executed_lazily_and_memoized() {
+    // A `fn` runner can't capture, so count through a test-local static;
+    // nextest runs each test in its own process, so it stays isolated.
+    static CALLS: AtomicUsize = AtomicUsize::new(0);
+    fn runner(command: &[String]) -> std::io::Result<TokenHelperOutput> {
+        CALLS.fetch_add(1, Ordering::Relaxed);
+        assert_eq!(command, ["helper", "--flag"]);
+        Ok(TokenHelperOutput {
+            success: true,
+            stdout: "s3cr3t\n".to_owned(),
+            stderr: String::new(),
+        })
+    }
+
+    let auth = AuthHeaders::from_parts_with_token_helpers(
+        HashMap::new(),
+        HashMap::new(),
+        token_helper_by_uri("//reg.com/", &["helper", "--flag"]),
+        HashMap::new(),
+    )
+    .with_token_helper_runner(runner);
+
+    // Constructing the map never runs the helper.
+    assert_eq!(CALLS.load(Ordering::Relaxed), 0);
+    assert_eq!(auth.for_url("https://reg.com/pkg"), Some("Bearer s3cr3t".to_owned()));
+    // A second matching lookup reuses the memoized token.
+    assert_eq!(auth.for_url("https://reg.com/other"), Some("Bearer s3cr3t".to_owned()));
+    assert_eq!(CALLS.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn a_failing_token_helper_sends_no_credential_and_does_not_fall_back() {
+    fn runner(_: &[String]) -> std::io::Result<TokenHelperOutput> {
+        Ok(TokenHelperOutput { success: false, stdout: String::new(), stderr: "boom".to_owned() })
+    }
+
+    // A static token sits at the host root; a failing helper at the deeper
+    // path prefix must NOT fall back to it — the most-specific key owns the
+    // decision, exactly as a resolved helper would.
+    let auth = AuthHeaders::from_parts_with_token_helpers(
+        std::iter::once(("//reg.com/".to_owned(), "Bearer root-token".to_owned())).collect(),
+        HashMap::new(),
+        token_helper_by_uri("//reg.com/path/", &["helper"]),
+        HashMap::new(),
+    )
+    .with_token_helper_runner(runner);
+
+    assert_eq!(auth.for_url("https://reg.com/path/pkg"), None);
+    // A request that doesn't match the helper prefix still gets the static token.
+    assert_eq!(auth.for_url("https://reg.com/pkg"), Some("Bearer root-token".to_owned()));
+}
 
 /// Records every `(url, package)` it is asked about and answers with a
 /// fixed header, so a test can assert the hook — not the client

--- a/pnpm/crates/network/src/auth/tests.rs
+++ b/pnpm/crates/network/src/auth/tests.rs
@@ -8,8 +8,10 @@ use std::{
     collections::HashMap,
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
+    thread,
+    time::{Duration, Instant},
 };
 
 fn token_helper_by_uri(uri: &str, command: &[&str]) -> HashMap<String, Vec<String>> {
@@ -49,6 +51,54 @@ fn token_helper_is_executed_lazily_and_memoized() {
     // A second matching lookup reuses the memoized token.
     assert_eq!(auth.for_url("https://reg.com/other"), Some("Bearer s3cr3t".to_owned()));
     assert_eq!(CALLS.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn a_slow_token_helper_does_not_block_a_second_registry_lookup() {
+    // The runner for `//slow.example/` spins until the `//fast.example/`
+    // lookup has finished (or a generous deadline). If the resolution cache
+    // lock were held across the subprocess, the fast lookup would block on
+    // that lock, the flag would never flip, and the slow helper would run
+    // for the full deadline — so the fast lookup completing promptly proves
+    // the lock is released while a helper runs.
+    static FAST_DONE: AtomicBool = AtomicBool::new(false);
+    fn runner(command: &[String]) -> std::io::Result<TokenHelperOutput> {
+        if command[0] == "slow" {
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while !FAST_DONE.load(Ordering::Acquire) && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(5));
+            }
+        }
+        Ok(TokenHelperOutput {
+            success: true,
+            stdout: format!("{}-token", command[0]),
+            stderr: String::new(),
+        })
+    }
+
+    let mut helpers = token_helper_by_uri("//slow.example/", &["slow"]);
+    helpers.extend(token_helper_by_uri("//fast.example/", &["fast"]));
+    let auth = Arc::new(
+        AuthHeaders::from_parts_with_token_helpers(
+            HashMap::new(),
+            HashMap::new(),
+            helpers,
+            HashMap::new(),
+        )
+        .with_token_helper_runner(runner),
+    );
+
+    let slow_auth = Arc::clone(&auth);
+    let slow = thread::spawn(move || slow_auth.for_url("https://slow.example/pkg"));
+
+    let started = Instant::now();
+    let fast = auth.for_url("https://fast.example/pkg");
+    let fast_elapsed = started.elapsed();
+    FAST_DONE.store(true, Ordering::Release);
+
+    assert_eq!(fast, Some("Bearer fast-token".to_owned()));
+    assert!(fast_elapsed < Duration::from_secs(5), "fast lookup blocked for {fast_elapsed:?}");
+    assert_eq!(slow.join().expect("slow thread"), Some("Bearer slow-token".to_owned()));
 }
 
 #[test]

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -6,12 +6,14 @@ mod retry;
 #[cfg(test)]
 mod tests;
 mod tls;
+mod token_helper;
 
 pub use auth::{
     AuthHeaders, AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE, MetadataCacheScope, UpstreamRouteHook,
     base64_encode, nerf_dart, redact_and_sanitize, redact_url_credentials,
 };
 pub use limited_body::{LimitedBody, read_limited_body};
+pub use token_helper::{TokenHelperOutput, TokenHelperRunner};
 pub use url_encoding::{encode_package_name, encode_uri_component};
 
 mod url_encoding;

--- a/pnpm/crates/network/src/token_helper.rs
+++ b/pnpm/crates/network/src/token_helper.rs
@@ -1,0 +1,141 @@
+//! Lazy execution of a configured `tokenHelper` command into an
+//! `Authorization` header value.
+//!
+//! `tokenHelper` names an executable pnpm runs to obtain a registry
+//! token. [`AuthHeaders`](crate::AuthHeaders) stores the parsed command
+//! and runs it — at most once, memoized — only when a lookup actually
+//! resolves to that registry, so a command never spawns for a pnpm
+//! invocation that makes no matching request. The mapping from the
+//! command's stdout to a header mirrors pnpm's `executeTokenHelper`.
+
+use std::{io, process::Command};
+
+/// Captured output of a `tokenHelper` subprocess.
+#[derive(Debug, Clone)]
+pub struct TokenHelperOutput {
+    pub success: bool,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Runs a `tokenHelper` command line (`[program, ...args]`) and captures
+/// its output. Injected into [`AuthHeaders`](crate::AuthHeaders) so tests
+/// can drive the execution branches without spawning a real process;
+/// production uses `run_token_helper_command`.
+pub type TokenHelperRunner = fn(&[String]) -> io::Result<TokenHelperOutput>;
+
+/// Failure while turning a `tokenHelper` into a header. The `Display`
+/// text carries pnpm's error code so a `tokenHelper` misconfiguration is
+/// as recognizable in pacquet's logs as in pnpm's thrown error.
+#[derive(Debug)]
+pub enum TokenHelperError {
+    /// The command could not be spawned at all.
+    Spawn { program: String, source: io::Error },
+    /// The command exited non-zero (`ERR_PNPM_TOKEN_HELPER_ERROR_STATUS`).
+    ErrorStatus { program: String },
+    /// The command exited zero but printed nothing
+    /// (`ERR_PNPM_TOKEN_HELPER_EMPTY_TOKEN`).
+    EmptyToken { program: String },
+}
+
+impl std::fmt::Display for TokenHelperError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TokenHelperError::Spawn { program, source } => {
+                write!(f, "Failed to run {program:?} as a token helper: {source}")
+            }
+            TokenHelperError::ErrorStatus { program } => write!(
+                f,
+                "ERR_PNPM_TOKEN_HELPER_ERROR_STATUS: Error running {program:?} as a token helper",
+            ),
+            TokenHelperError::EmptyToken { program } => write!(
+                f,
+                "ERR_PNPM_TOKEN_HELPER_EMPTY_TOKEN: Token helper {program:?} returned an empty token",
+            ),
+        }
+    }
+}
+
+/// Execute `command` via `run` and map its stdout to an `Authorization`
+/// header value, mirroring pnpm's `executeTokenHelper`:
+/// - a non-zero exit is [`TokenHelperError::ErrorStatus`];
+/// - an empty stdout (after trailing-whitespace trim) is
+///   [`TokenHelperError::EmptyToken`];
+/// - a token that already begins with an auth scheme (`^[A-Za-z]+ `) is
+///   returned verbatim; otherwise it is prefixed with `Bearer `.
+pub fn execute_token_helper(
+    command: &[String],
+    run: TokenHelperRunner,
+) -> Result<String, TokenHelperError> {
+    let Some(program) = command.first() else {
+        return Err(TokenHelperError::EmptyToken { program: String::new() });
+    };
+    let output = run(command)
+        .map_err(|source| TokenHelperError::Spawn { program: program.clone(), source })?;
+    if !output.success {
+        return Err(TokenHelperError::ErrorStatus { program: program.clone() });
+    }
+    let token = output.stdout.trim_end();
+    if token.is_empty() {
+        return Err(TokenHelperError::EmptyToken { program: program.clone() });
+    }
+    if starts_with_auth_scheme(token) {
+        Ok(token.to_owned())
+    } else {
+        Ok(format!("Bearer {token}"))
+    }
+}
+
+/// Production runner: spawn `command` and capture its output. On Windows a
+/// `.bat`/`.cmd` program is run through `cmd /C` (those files need a
+/// shell), matching pnpm's `shell` handling.
+pub fn run_token_helper_command(command: &[String]) -> io::Result<TokenHelperOutput> {
+    let Some((program, args)) = command.split_first() else {
+        return Ok(TokenHelperOutput {
+            success: true,
+            stdout: String::new(),
+            stderr: String::new(),
+        });
+    };
+    let output = build_command(program, args).output()?;
+    Ok(TokenHelperOutput {
+        success: output.status.success(),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+}
+
+#[cfg(windows)]
+fn build_command(program: &str, args: &[String]) -> Command {
+    let lowercased = program.to_ascii_lowercase();
+    if lowercased.ends_with(".bat") || lowercased.ends_with(".cmd") {
+        let mut command = Command::new("cmd");
+        command.arg("/C").arg(program).args(args);
+        return command;
+    }
+    let mut command = Command::new(program);
+    command.args(args);
+    command
+}
+
+#[cfg(not(windows))]
+fn build_command(program: &str, args: &[String]) -> Command {
+    let mut command = Command::new(program);
+    command.args(args);
+    command
+}
+
+/// Whether `token` begins with an auth scheme: one or more ASCII letters
+/// immediately followed by a space, e.g. `Bearer …` or `Basic …`. Mirrors
+/// pnpm's `/^[A-Z]+ /i`.
+fn starts_with_auth_scheme(token: &str) -> bool {
+    let bytes = token.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() && bytes[index].is_ascii_alphabetic() {
+        index += 1;
+    }
+    index > 0 && bytes.get(index) == Some(&b' ')
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/network/src/token_helper.rs
+++ b/pnpm/crates/network/src/token_helper.rs
@@ -10,7 +10,7 @@
 
 use std::{
     io::{self, Read},
-    process::{Command, Stdio},
+    process::{Child, Command, Stdio},
     thread,
     time::{Duration, Instant},
 };
@@ -136,11 +136,16 @@ fn run_token_helper_command_with_timeout(
     };
     // Close stdin (a helper that reads it gets EOF instead of blocking)
     // and pipe stdout/stderr so the reader threads below can drain them.
-    let mut child = build_command(program, args)
+    let child = build_command(program, args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;
+    // Guard the child so an early return or a panic (e.g. a failed
+    // `thread::spawn` below) can't leak the process: `ChildGuard` kills it
+    // on drop until we disarm it after reaping. std has no `kill_on_drop`.
+    let mut guard = ChildGuard(Some(child));
+    let child = guard.0.as_mut().expect("child just spawned");
 
     // Drain both pipes on their own threads: a helper that fills the
     // stdout (or stderr) buffer would otherwise block on the write while
@@ -155,8 +160,7 @@ fn run_token_helper_command_with_timeout(
             break status;
         }
         if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
+            // Leaving `guard` armed kills the still-running child on drop.
             return Err(io::Error::new(
                 io::ErrorKind::TimedOut,
                 "token helper exceeded its time limit",
@@ -164,12 +168,36 @@ fn run_token_helper_command_with_timeout(
         }
         thread::sleep(Duration::from_millis(20));
     };
+    // The child is reaped; disarm so the guard can't signal a pid the OS
+    // may already have recycled.
+    guard.disarm();
 
     Ok(TokenHelperOutput {
         success: status.success(),
         stdout: stdout.join().unwrap_or_default(),
         stderr: stderr.join().unwrap_or_default(),
     })
+}
+
+/// Kills the wrapped [`Child`] on drop unless [`Self::disarm`]ed first, so a
+/// panic or early return before the process is reaped can't leave it
+/// orphaned. Once the caller has reaped the child (a completed `try_wait`),
+/// it disarms — killing a reaped pid could target a recycled process.
+struct ChildGuard(Option<Child>);
+
+impl ChildGuard {
+    fn disarm(&mut self) {
+        self.0 = None;
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.0.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
 }
 
 /// Spawn a thread that reads `pipe` to end-of-stream as lossy UTF-8. A

--- a/pnpm/crates/network/src/token_helper.rs
+++ b/pnpm/crates/network/src/token_helper.rs
@@ -8,7 +8,21 @@
 //! invocation that makes no matching request. The mapping from the
 //! command's stdout to a header mirrors pnpm's `executeTokenHelper`.
 
-use std::{io, process::Command};
+use std::{
+    io::{self, Read},
+    process::{Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+/// Seconds a `tokenHelper` command may run before it is killed.
+const TOKEN_HELPER_TIMEOUT_SECS: u64 = 60;
+
+/// How long a `tokenHelper` command may run before it is killed. A helper
+/// only prints a token, so this is a generous bound that turns a hung
+/// helper (deadlock, stuck I/O) into a clear error instead of an install
+/// that hangs forever. Matches the TypeScript CLI's `tokenHelper` timeout.
+pub const TOKEN_HELPER_TIMEOUT: Duration = Duration::from_secs(TOKEN_HELPER_TIMEOUT_SECS);
 
 /// Captured output of a `tokenHelper` subprocess.
 #[derive(Debug, Clone)]
@@ -31,6 +45,9 @@ pub type TokenHelperRunner = fn(&[String]) -> io::Result<TokenHelperOutput>;
 pub enum TokenHelperError {
     /// The command could not be spawned at all.
     Spawn { program: String, source: io::Error },
+    /// The command did not finish within [`TOKEN_HELPER_TIMEOUT`] and was
+    /// killed (`ERR_PNPM_TOKEN_HELPER_TIMEOUT`).
+    Timeout { program: String },
     /// The command exited non-zero (`ERR_PNPM_TOKEN_HELPER_ERROR_STATUS`).
     ErrorStatus { program: String },
     /// The command exited zero but printed nothing
@@ -44,6 +61,11 @@ impl std::fmt::Display for TokenHelperError {
             TokenHelperError::Spawn { program, source } => {
                 write!(f, "Failed to run {program:?} as a token helper: {source}")
             }
+            TokenHelperError::Timeout { program } => write!(
+                f,
+                "ERR_PNPM_TOKEN_HELPER_TIMEOUT: Token helper {program:?} timed out after {} ms",
+                TOKEN_HELPER_TIMEOUT.as_millis(),
+            ),
             TokenHelperError::ErrorStatus { program } => write!(
                 f,
                 "ERR_PNPM_TOKEN_HELPER_ERROR_STATUS: Error running {program:?} as a token helper",
@@ -70,8 +92,13 @@ pub fn execute_token_helper(
     let Some(program) = command.first() else {
         return Err(TokenHelperError::EmptyToken { program: String::new() });
     };
-    let output = run(command)
-        .map_err(|source| TokenHelperError::Spawn { program: program.clone(), source })?;
+    let output = run(command).map_err(|source| {
+        if source.kind() == io::ErrorKind::TimedOut {
+            TokenHelperError::Timeout { program: program.clone() }
+        } else {
+            TokenHelperError::Spawn { program: program.clone(), source }
+        }
+    })?;
     if !output.success {
         return Err(TokenHelperError::ErrorStatus { program: program.clone() });
     }
@@ -86,10 +113,20 @@ pub fn execute_token_helper(
     }
 }
 
-/// Production runner: spawn `command` and capture its output. On Windows a
-/// `.bat`/`.cmd` program is run through `cmd /C` (those files need a
-/// shell), matching pnpm's `shell` handling.
+/// Production runner: spawn `command`, capture its output, and enforce
+/// [`TOKEN_HELPER_TIMEOUT`]. On Windows a `.bat`/`.cmd` program is run
+/// through `cmd /C` (those files need a shell), matching pnpm's `shell`
+/// handling.
 pub fn run_token_helper_command(command: &[String]) -> io::Result<TokenHelperOutput> {
+    run_token_helper_command_with_timeout(command, TOKEN_HELPER_TIMEOUT)
+}
+
+/// [`run_token_helper_command`] with an explicit deadline, so tests can
+/// drive the timeout branch without waiting the full production bound.
+fn run_token_helper_command_with_timeout(
+    command: &[String],
+    timeout: Duration,
+) -> io::Result<TokenHelperOutput> {
     let Some((program, args)) = command.split_first() else {
         return Ok(TokenHelperOutput {
             success: true,
@@ -97,11 +134,52 @@ pub fn run_token_helper_command(command: &[String]) -> io::Result<TokenHelperOut
             stderr: String::new(),
         });
     };
-    let output = build_command(program, args).output()?;
+    // Close stdin (a helper that reads it gets EOF instead of blocking)
+    // and pipe stdout/stderr so the reader threads below can drain them.
+    let mut child = build_command(program, args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    // Drain both pipes on their own threads: a helper that fills the
+    // stdout (or stderr) buffer would otherwise block on the write while
+    // the parent waits on the other pipe — a deadlock the poll loop can't
+    // break.
+    let stdout = read_pipe(child.stdout.take());
+    let stderr = read_pipe(child.stderr.take());
+
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "token helper exceeded its time limit",
+            ));
+        }
+        thread::sleep(Duration::from_millis(20));
+    };
+
     Ok(TokenHelperOutput {
-        success: output.status.success(),
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        success: status.success(),
+        stdout: stdout.join().unwrap_or_default(),
+        stderr: stderr.join().unwrap_or_default(),
+    })
+}
+
+/// Spawn a thread that reads `pipe` to end-of-stream as lossy UTF-8. A
+/// read error or absent pipe yields the empty string.
+fn read_pipe<Pipe: Read + Send + 'static>(pipe: Option<Pipe>) -> thread::JoinHandle<String> {
+    thread::spawn(move || {
+        let Some(mut pipe) = pipe else { return String::new() };
+        let mut buffer = Vec::new();
+        let _ = pipe.read_to_end(&mut buffer);
+        String::from_utf8_lossy(&buffer).into_owned()
     })
 }
 

--- a/pnpm/crates/network/src/token_helper/tests.rs
+++ b/pnpm/crates/network/src/token_helper/tests.rs
@@ -6,6 +6,31 @@ fn ok_stdout(stdout: &str) -> io::Result<TokenHelperOutput> {
 }
 
 #[test]
+fn a_timed_out_runner_maps_to_the_timeout_error() {
+    let command = vec!["helper".to_owned()];
+    let error = execute_token_helper(&command, |_| Err(io::Error::from(io::ErrorKind::TimedOut)))
+        .expect_err("a timed-out helper must fail");
+    assert!(matches!(error, TokenHelperError::Timeout { .. }), "got {error:?}");
+}
+
+/// A helper that never returns is killed at the deadline instead of
+/// hanging forever. Uses a real `sleep` (Unix) far longer than the
+/// tiny test timeout, so the test only passes if the kill actually fires.
+#[cfg(unix)]
+#[test]
+fn a_hung_command_is_killed_at_the_deadline() {
+    use std::time::{Duration, Instant};
+
+    let command = vec!["/bin/sh".to_owned(), "-c".to_owned(), "sleep 10".to_owned()];
+    let started = Instant::now();
+    let result = super::run_token_helper_command_with_timeout(&command, Duration::from_millis(200));
+    let elapsed = started.elapsed();
+
+    assert_eq!(result.expect_err("must time out").kind(), io::ErrorKind::TimedOut);
+    assert!(elapsed < Duration::from_secs(5), "returned only after {elapsed:?} — was it killed?");
+}
+
+#[test]
 fn prepends_bearer_to_a_raw_token() {
     let command = vec!["helper".to_owned()];
     let header = execute_token_helper(&command, |_| ok_stdout("s3cr3t\n")).expect("token resolves");

--- a/pnpm/crates/network/src/token_helper/tests.rs
+++ b/pnpm/crates/network/src/token_helper/tests.rs
@@ -1,0 +1,58 @@
+use super::{TokenHelperError, TokenHelperOutput, execute_token_helper};
+use std::io;
+
+fn ok_stdout(stdout: &str) -> io::Result<TokenHelperOutput> {
+    Ok(TokenHelperOutput { success: true, stdout: stdout.to_owned(), stderr: String::new() })
+}
+
+#[test]
+fn prepends_bearer_to_a_raw_token() {
+    let command = vec!["helper".to_owned()];
+    let header = execute_token_helper(&command, |_| ok_stdout("s3cr3t\n")).expect("token resolves");
+    assert_eq!(header, "Bearer s3cr3t");
+}
+
+#[test]
+fn keeps_a_token_that_already_carries_a_scheme() {
+    let command = vec!["helper".to_owned()];
+    let header = execute_token_helper(&command, |_| ok_stdout("Basic dXNlcjpwYXNz"))
+        .expect("token resolves");
+    assert_eq!(header, "Basic dXNlcjpwYXNz");
+}
+
+#[test]
+fn passes_the_full_command_to_the_runner() {
+    let command = vec!["helper".to_owned(), "--flag".to_owned(), "value".to_owned()];
+    let header = execute_token_helper(&command, |received| {
+        assert_eq!(received, ["helper", "--flag", "value"]);
+        ok_stdout("tok")
+    })
+    .expect("token resolves");
+    assert_eq!(header, "Bearer tok");
+}
+
+#[test]
+fn a_non_zero_exit_is_an_error_status() {
+    let command = vec!["helper".to_owned()];
+    let error = execute_token_helper(&command, |_| {
+        Ok(TokenHelperOutput { success: false, stdout: String::new(), stderr: "boom".to_owned() })
+    })
+    .expect_err("non-zero exit must fail");
+    assert!(matches!(error, TokenHelperError::ErrorStatus { .. }), "got {error:?}");
+}
+
+#[test]
+fn an_empty_token_is_an_error() {
+    let command = vec!["helper".to_owned()];
+    let error =
+        execute_token_helper(&command, |_| ok_stdout("   \n")).expect_err("empty token must fail");
+    assert!(matches!(error, TokenHelperError::EmptyToken { .. }), "got {error:?}");
+}
+
+#[test]
+fn a_spawn_failure_is_surfaced() {
+    let command = vec!["helper".to_owned()];
+    let error = execute_token_helper(&command, |_| Err(io::Error::from(io::ErrorKind::NotFound)))
+        .expect_err("spawn failure must surface");
+    assert!(matches!(error, TokenHelperError::Spawn { .. }), "got {error:?}");
+}

--- a/pnpm/crates/publish/src/execute_token_helper.rs
+++ b/pnpm/crates/publish/src/execute_token_helper.rs
@@ -1,14 +1,13 @@
 //! run a configured `tokenHelper` command and
 //! return the auth token it prints.
 //!
-//! Not yet wired into the publish auth path. Upstream resolves the publish
-//! `Authorization` per-command (`extractToken`: static `_authToken`, else this
-//! helper). Pacquet instead reuses the shared, pre-resolved
-//! [`AuthHeaders`](pacquet_network::AuthHeaders) map, which carries finished
-//! header strings and no `tokenHelper` slot. Surfacing per-registry
-//! `tokenHelper` credentials so this helper can feed the publish PUT is a
-//! config/network-layer change tracked in `plans/TEST_PORTING.md`; until then a
-//! `tokenHelper`-only registry is unauthenticated on publish.
+//! The publish PUT now authenticates through the shared
+//! [`AuthHeaders`](pacquet_network::AuthHeaders) map, which carries an
+//! un-executed `tokenHelper` command per registry and runs it lazily on
+//! lookup (see `pacquet_network::token_helper`) — so a `tokenHelper`-only
+//! registry is authenticated on publish without this helper. This
+//! function is retained for the publish-specific path that needs the bare
+//! token (no `Bearer` scheme) rather than a finished header value.
 
 use std::io;
 

--- a/pnpm/plans/TEST_PORTING.md
+++ b/pnpm/plans/TEST_PORTING.md
@@ -502,10 +502,10 @@ Auth header tests:
 - [x] `TypeScript repo: network/auth-header/test/getAuthHeadersFromConfig.test.ts:32` `should convert auth token to Bearer header`
 - [x] `TypeScript repo: network/auth-header/test/getAuthHeadersFromConfig.test.ts:42` `should convert basicAuth to Basic header`
 - [x] `TypeScript repo: network/auth-header/test/getAuthHeadersFromConfig.test.ts:50` `should handle default registry auth (empty key)`
-- [ ] `TypeScript repo: network/auth-header/test/getAuthHeadersFromConfig.test.ts:58` `should execute tokenHelper`
-- [ ] `TypeScript repo: network/auth-header/test/getAuthHeadersFromConfig.test.ts:66` `should prepend Bearer to raw token from tokenHelper`
-- [ ] `TypeScript repo: network/auth-header/test/getAuthHeadersFromConfig.test.ts:74` `should throw an error if the token helper fails`
-- [ ] `TypeScript repo: network/auth-header/test/getAuthHeadersFromConfig.test.ts:79` `should throw an error if the token helper returns an empty token`
+- [x] `TypeScript repo: network/auth-header/test/getAuthHeadersFromConfig.test.ts:58` `should execute tokenHelper`
+- [x] `TypeScript repo: network/auth-header/test/getAuthHeadersFromConfig.test.ts:66` `should prepend Bearer to raw token from tokenHelper`
+- [x] `TypeScript repo: network/auth-header/test/getAuthHeadersFromConfig.test.ts:74` `should throw an error if the token helper fails`
+- [x] `TypeScript repo: network/auth-header/test/getAuthHeadersFromConfig.test.ts:79` `should throw an error if the token helper returns an empty token`
 - [x] `TypeScript repo: network/auth-header/test/getAuthHeaderByURI.ts:11` `getAuthHeaderByURI()`
 - [x] `TypeScript repo: network/auth-header/test/getAuthHeaderByURI.ts:22` `getAuthHeaderByURI() basic auth without settings`
 - [x] `TypeScript repo: network/auth-header/test/getAuthHeaderByURI.ts:30` `getAuthHeaderByURI() basic auth with settings`
@@ -521,7 +521,7 @@ Auth config parsing and precedence tests:
 - [x] `TypeScript repo: config/reader/test/parseCreds.test.ts:15` `authToken`
 - [x] `TypeScript repo: config/reader/test/parseCreds.test.ts:23` `authPairBase64`
 - [x] `TypeScript repo: config/reader/test/parseCreds.test.ts:49` `authUsername and authPassword`
-- [ ] `TypeScript repo: config/reader/test/parseCreds.test.ts:69` `tokenHelper`
+- [x] `TypeScript repo: config/reader/test/parseCreds.test.ts:69` `tokenHelper`
 
 Fetcher tests:
 

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -364,8 +364,10 @@ export async function getConfig (opts: {
   )
   pnpmConfig.configByUri = { ...networkConfigs.configByUri }
 
-  // tokenHelper must only come from user-level config (~/.npmrc or global auth.ini),
-  // not project-level, to prevent project .npmrc from executing arbitrary commands.
+  // tokenHelper names an executable pnpm runs, so it must only come from trusted,
+  // non-repo config sources (~/.npmrc and the global auth.ini) — never from a
+  // workspace or project .npmrc, which could otherwise execute arbitrary commands.
+  // trustedConfig merges exactly those trusted sources and excludes the repo ones.
   const trustedConfig = npmrcResult.trustedConfig as Record<string, string>
   for (const [key, value] of Object.entries(pnpmConfig.authConfig)) {
     if (!key.endsWith('tokenHelper') && key !== 'tokenHelper') continue

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -366,10 +366,10 @@ export async function getConfig (opts: {
 
   // tokenHelper must only come from user-level config (~/.npmrc or global auth.ini),
   // not project-level, to prevent project .npmrc from executing arbitrary commands.
-  const userConfig = npmrcResult.userConfig as Record<string, string>
+  const trustedConfig = npmrcResult.trustedConfig as Record<string, string>
   for (const [key, value] of Object.entries(pnpmConfig.authConfig)) {
     if (!key.endsWith('tokenHelper') && key !== 'tokenHelper') continue
-    if (!(key in userConfig) || userConfig[key] !== value) {
+    if (!(key in trustedConfig) || trustedConfig[key] !== value) {
       throw new PnpmError('TOKEN_HELPER_IN_PROJECT_CONFIG',
         'tokenHelper must not be configured in project-level .npmrc',
         { hint: `The key "${key}" was found in project config. Move it to ~/.npmrc or the global pnpm auth.ini.` })

--- a/pnpm11/config/reader/src/loadNpmrcFiles.ts
+++ b/pnpm11/config/reader/src/loadNpmrcFiles.ts
@@ -227,11 +227,11 @@ function readUrlScopedEnvConfig (env: Record<string, string | undefined>): Recor
     const match = URL_SCOPED_ENV_RE.exec(envKey)
     if (match == null) continue
     const key = match[1]
-    // `tokenHelper` names an executable pnpm runs. It is only allowed from a
-    // user-level config file (enforced by the TOKEN_HELPER_IN_PROJECT_CONFIG
-    // check in index.ts, which validates against the user `.npmrc`). The env
-    // layer isn't that file, so honoring `//host/:tokenHelper` here would
-    // trip that guard — never admit it.
+    // `tokenHelper` names an executable pnpm runs, so it must never be honored
+    // from the environment. The TOKEN_HELPER_IN_PROJECT_CONFIG check in index.ts
+    // validates against the trusted config, and that config already includes
+    // this env-scoped layer — so admitting `//host/:tokenHelper` here would let
+    // an env var pass the guard and silently run an arbitrary command. Drop it.
     if (key.endsWith(':tokenHelper')) continue
     const target = envKey.slice(0, 5).toLowerCase() === 'pnpm_' ? pnpmScoped : npmScoped
     target[key] = value

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -1171,6 +1171,55 @@ test('a tokenHelper set via a URL-scoped env var is not honored (no project-conf
   expect(config.authConfig['//env-test.example/:tokenHelper']).toBeUndefined()
 })
 
+test('a tokenHelper set in the global pnpm auth.ini is honored (not treated as project config)', async () => {
+  prepareEmpty()
+
+  // A tokenHelper configured via `pnpm config set` lands in the global pnpm
+  // auth.ini (trusted config), not ~/.npmrc, so it must be accepted.
+  const configHome = path.resolve('xdg-config')
+  fs.mkdirSync(path.join(configHome, 'pnpm'), { recursive: true })
+  fs.writeFileSync(
+    path.join(configHome, 'pnpm', 'auth.ini'),
+    '//registry.example.com/:tokenHelper=/bin/echo'
+  )
+
+  const originalXdg = process.env.XDG_CONFIG_HOME
+  process.env.XDG_CONFIG_HOME = configHome
+  try {
+    const { config } = await getConfig({
+      cliOptions: {},
+      env: {
+        ...env,
+        XDG_CONFIG_HOME: configHome,
+      },
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+    })
+
+    expect(config.authConfig['//registry.example.com/:tokenHelper']).toBe('/bin/echo')
+  } finally {
+    if (originalXdg != null) {
+      process.env.XDG_CONFIG_HOME = originalXdg
+    } else {
+      delete process.env.XDG_CONFIG_HOME
+    }
+  }
+})
+
+test('a tokenHelper set in a project .npmrc is rejected', async () => {
+  prepareEmpty()
+
+  // A project-level .npmrc must never be trusted to run a tokenHelper binary.
+  fs.writeFileSync('.npmrc', '//registry.example.com/:tokenHelper=/bin/echo', 'utf8')
+
+  await expect(getConfig({
+    cliOptions: {},
+    env,
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })).rejects.toMatchObject({
+    code: 'ERR_PNPM_TOKEN_HELPER_IN_PROJECT_CONFIG',
+  })
+})
+
 test('URL-scoped auth from the environment overrides a project .npmrc for the same host', async () => {
   prepareEmpty()
 

--- a/pnpm11/network/auth-header/src/getAuthHeadersFromConfig.ts
+++ b/pnpm11/network/auth-header/src/getAuthHeadersFromConfig.ts
@@ -74,12 +74,22 @@ function credsToHeader (creds?: Creds): string | undefined {
   return undefined
 }
 
-function executeTokenHelper (tokenHelper: TokenHelper): string {
+// A token helper only prints a token, so this is a generous bound that turns a
+// hung helper (deadlock, stuck I/O) into a clear error instead of a command
+// that hangs forever. Matches pacquet's `TOKEN_HELPER_TIMEOUT`.
+const TOKEN_HELPER_TIMEOUT = 60_000
+
+export function executeTokenHelper (tokenHelper: TokenHelper, timeoutMs: number = TOKEN_HELPER_TIMEOUT): string {
   const [cmd, ...args] = tokenHelper
   // On Windows, .bat/.cmd files require a shell to execute.
   const shell = process.platform === 'win32' && /\.(?:bat|cmd)$/i.test(cmd)
-  const spawnResult = spawnSync(cmd, args, { stdio: 'pipe', shell })
+  const spawnResult = spawnSync(cmd, args, { stdio: 'pipe', shell, timeout: timeoutMs })
 
+  // A helper that outlives the timeout is killed; spawnSync then reports the
+  // kill signal rather than a clean exit, so surface it as a distinct error.
+  if (spawnResult.error != null && (spawnResult.error as NodeJS.ErrnoException).code === 'ETIMEDOUT') {
+    throw new PnpmError('TOKEN_HELPER_TIMEOUT', `Token helper "${cmd}" timed out after ${timeoutMs} ms`)
+  }
   if (spawnResult.status !== 0) {
     throw new PnpmError('TOKEN_HELPER_ERROR_STATUS', `Error running "${cmd}" as a token helper. Exit code ${spawnResult.status?.toString() ?? ''}`)
   }

--- a/pnpm11/network/auth-header/test/getAuthHeadersFromConfig.test.ts
+++ b/pnpm11/network/auth-header/test/getAuthHeadersFromConfig.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 
 import { describe, expect, it } from '@jest/globals'
 
-import { getAuthHeadersByScope, getAuthHeadersFromCreds } from '../src/getAuthHeadersFromConfig.js'
+import { executeTokenHelper, getAuthHeadersByScope, getAuthHeadersFromCreds } from '../src/getAuthHeadersFromConfig.js'
 
 const osTokenHelper = {
   linux: path.join(import.meta.dirname, 'utils/test-exec.js'),
@@ -84,6 +84,12 @@ describe('getAuthHeadersFromCreds()', () => {
     expect(() => getAuthHeadersFromCreds({
       '//reg.com/': { '@': { tokenHelper: [osEmptyTokenHelper[osFamily]] } },
     })).toThrow('returned an empty token')
+  })
+  it('should throw an error if the token helper exceeds the timeout', () => {
+    // A helper that sleeps far longer than the (short, test-supplied) timeout
+    // is killed. `process.execPath` keeps this cross-platform without a fixture.
+    expect(() => executeTokenHelper([process.execPath, '-e', 'setTimeout(() => {}, 30000)'], 500))
+      .toThrow('timed out')
   })
   it('should return empty object when no auth infos', () => {
     const result = getAuthHeadersFromCreds({})


### PR DESCRIPTION
### What

Allow a `tokenHelper` configured in the global pnpm `auth.ini` to be used, instead of rejecting it as project-level configuration.

Closes #12759.

### Why

The guard that blocks `tokenHelper` from a project `.npmrc` (so a checked-in `.npmrc` can't run an arbitrary command) validated the helper against `userConfig`, which only contains `~/.npmrc`. But `pnpm config set` writes a `tokenHelper` to the global `auth.ini`, which flows into `trustedConfig`, not `userConfig`. As a result a legitimately configured `tokenHelper` was rejected on every command with `ERR_PNPM_TOKEN_HELPER_IN_PROJECT_CONFIG`, and `pnpm config delete` failed as well. The guard's own comment already says the helper may come from "`~/.npmrc` or global auth.ini".

### How

Validate against `trustedConfig` instead of `userConfig`. `trustedConfig` merges the trusted sources (including `~/.npmrc` and the global `auth.ini`) but excludes workspace and project `.npmrc` files, so the global helper is accepted while a project-level one is still rejected.

Tests in `config/reader` cover both paths: a `tokenHelper` in the global `auth.ini` is honored, and a `tokenHelper` in a project `.npmrc` still throws `ERR_PNPM_TOKEN_HELPER_IN_PROJECT_CONFIG`.


### Pacquet parity

Pacquet had no `tokenHelper` support at all, so this PR also ports the whole feature to the Rust stack (matching the cardinal rule that user-visible changes land in both stacks):

- **Config layer** (`pnpm/crates/config`): parse `//host/:tokenHelper` (scoped and default forms too) from trusted `.npmrc` / `auth.ini` sources only; reject a project/workspace helper via the same full-vs-trusted comparison used on the TypeScript side; and reject reserved characters — surfacing the same `ERR_PNPM_TOKEN_HELPER_IN_PROJECT_CONFIG` / `ERR_PNPM_TOKEN_HELPER_UNSUPPORTED_CHARACTER` codes.
- **Network layer** (`pnpm/crates/network`): `AuthHeaders` carries the un-executed command per registry and runs it lazily on lookup, memoized (runs at most once, and never for a command that makes no matching request). Baked headers keep their eager, lock-free hot path; a header is emitted only on success, so a failing helper sends no credential.
- **Known divergence**: because `AuthHeaders::for_url` is infallible and there is no single network seam, a helper failure surfaces as a loud error plus an unauthenticated request rather than pnpm's hard whole-command abort.
- **Known divergence — execution timing**: pnpm runs every configured registry's `tokenHelper` when it builds the auth-header lookup (so a helper for a registry never contacted still runs); pacquet runs each helper lazily on the first request to that registry (per-registry, memoized, and never on a command that makes no matching request). Both bound execution at 60s.

Covered by new Rust unit + integration tests (parse, trust guard, reserved-char, env-drop, lazy execution / memoization, and an end-to-end `/bin/echo` run).

---
Pacquet port added by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `tokenHelper` from the user’s global pnpm `auth.ini` is now trusted, while project/workspace `.npmrc` `tokenHelper` values remain blocked.
  * `tokenHelper` execution is lazy and registry-scoped, rejects unsupported inputs, and now has a 60-second timeout.
* **New Features**
  * Pacquet gained “minor” `tokenHelper` support for retrieving registry tokens on demand.
* **Tests**
  * Added/expanded coverage for global accept vs project reject, lazy execution + memoization, reserved-character rejection, URL-scoped env ignoring, and helper timeout/error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

