### PR TITLE
fix(outdated): skip local lockfile refs

### DIFF
--- a/.changeset/outdated-skip-local-links.md
+++ b/.changeset/outdated-skip-local-links.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/deps.inspection.outdated": patch
+"pnpm": patch
+---
+
+`pnpm outdated` no longer checks the registry for dependencies that are resolved from local `link:`, `file:`, or `workspace:` references in the lockfile.

--- a/.changeset/outdated-skip-local-links.md
+++ b/.changeset/outdated-skip-local-links.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-`pnpm outdated` no longer checks the registry for dependencies that are resolved from local `link:`, `file:`, or `workspace:` references in the lockfile.
+`pnpm outdated` no longer checks the registry for dependencies that are resolved from local `link:`, `file:`, or `workspace:` references in the lockfile [#12827](https://github.com/pnpm/pnpm/issues/12827).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,6 +3958,7 @@ dependencies = [
  "tabled",
  "tar",
  "tempfile",
+ "text-block-macros",
  "tokio",
  "tracing",
  "url",

--- a/pacquet/crates/cli/Cargo.toml
+++ b/pacquet/crates/cli/Cargo.toml
@@ -102,6 +102,7 @@ mockito           = { workspace = true }
 pretty_assertions = { workspace = true }
 serde-saphyr      = { workspace = true }
 tar               = { workspace = true }
+text-block-macros = { workspace = true }
 walkdir           = { workspace = true }
 
 [lints]

--- a/pacquet/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/outdated/tests.rs
@@ -1,9 +1,12 @@
 use super::{
-    Change, OutdatedDependencyOptions, OutdatedPackage, classify, render_json, render_latest,
-    sort_outdated,
+    Change, OutdatedDependencyOptions, OutdatedPackage, classify, current_versions_from_lockfile,
+    render_json, render_latest, sort_outdated,
 };
 use node_semver::Version;
+use pacquet_lockfile::Lockfile;
 use pacquet_package_manifest::DependencyGroup;
+use std::collections::HashMap;
+use text_block_macros::text_block;
 
 fn v(text: &str) -> Version {
     text.parse().expect("parse semver")
@@ -19,6 +22,33 @@ fn pkg(name: &str, current: &str, target: &str, group: DependencyGroup) -> Outda
         deprecated: None,
         homepage: None,
     }
+}
+
+// Mirrors `outdated() skips dependencies resolved from local refs` in
+// `pnpm11/deps/inspection/outdated/test/outdated.spec.ts`: a dependency
+// resolved to a local `link:`/`file:` ref has no lockfile-pinned semver,
+// so `collect_outdated` drops it before any registry fetch even when its
+// manifest specifier is a plain semver range.
+#[test]
+fn current_versions_omit_local_refs() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    devDependencies:"
+        "      private-workspace-pkg:"
+        "        specifier: ^1.0.0"
+        "        version: link:../private-workspace-pkg"
+        "      injected-pkg:"
+        "        specifier: ^1.0.0"
+        "        version: file:../injected-pkg"
+        "      is-positive:"
+        "        specifier: ^1.0.0"
+        "        version: 1.0.0"
+    })
+    .expect("parse fixture lockfile");
+    let versions = current_versions_from_lockfile(Some(&lockfile), &[DependencyGroup::Dev]);
+    assert_eq!(versions, HashMap::from([("is-positive".to_string(), v("1.0.0"))]));
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/outdated/tests.rs
@@ -26,9 +26,9 @@ fn pkg(name: &str, current: &str, target: &str, group: DependencyGroup) -> Outda
 
 // Mirrors `outdated() skips dependencies resolved from local refs` in
 // `pnpm11/deps/inspection/outdated/test/outdated.spec.ts`: a dependency
-// resolved to a local `link:`/`file:` ref has no lockfile-pinned semver,
-// so `collect_outdated` drops it before any registry fetch even when its
-// manifest specifier is a plain semver range.
+// resolved to a local `link:`/`file:`/`workspace:` ref has no
+// lockfile-pinned semver, so `collect_outdated` drops it before any
+// registry fetch even when its manifest specifier is a plain semver range.
 #[test]
 fn current_versions_omit_local_refs() {
     let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
@@ -42,12 +42,16 @@ fn current_versions_omit_local_refs() {
         "      injected-pkg:"
         "        specifier: ^1.0.0"
         "        version: file:../injected-pkg"
+        "      workspace-pkg:"
+        "        specifier: ^1.0.0"
+        "        version: workspace:../workspace-pkg"
         "      is-positive:"
         "        specifier: ^1.0.0"
         "        version: 1.0.0"
     })
     .expect("parse fixture lockfile");
     let versions = current_versions_from_lockfile(Some(&lockfile), &[DependencyGroup::Dev]);
+    dbg!(&versions);
     assert_eq!(versions, HashMap::from([("is-positive".to_string(), v("1.0.0"))]));
 }
 

--- a/pnpm11/deps/inspection/outdated/src/outdated.ts
+++ b/pnpm11/deps/inspection/outdated/src/outdated.ts
@@ -117,6 +117,7 @@ export async function outdated (
           if (ignoreDependenciesMatcher?.(alias)) return
 
           const currentRef = (currentLockfile.importers[importerId] as ProjectSnapshot)?.[depType]?.[alias]
+          if (isLocalRef(wantedRef)) return
           const wantedRelative = dp.refToRelative(wantedRef, alias)
           const currentRelative = currentRef ? dp.refToRelative(currentRef, alias) : null
           const wantedSnapshot = wantedRelative != null ? opts.wantedLockfile!.packages?.[wantedRelative] : undefined
@@ -194,6 +195,10 @@ function packageHasNoDeps (manifest: ProjectManifest): boolean {
 
 function isEmpty (obj: object): boolean {
   return Object.keys(obj).length === 0
+}
+
+function isLocalRef (ref: string): boolean {
+  return ref.startsWith('link:') || ref.startsWith('file:') || ref.startsWith('workspace:')
 }
 
 // Pick a clean display string for a lockfile ref.

--- a/pnpm11/deps/inspection/outdated/src/outdated.ts
+++ b/pnpm11/deps/inspection/outdated/src/outdated.ts
@@ -114,10 +114,10 @@ export async function outdated (
         pkgs.map(async (alias) => {
           if (!allDeps[alias]) return
           const wantedRef = opts.wantedLockfile!.importers[importerId][depType]![alias]
+          if (isLocalRef(wantedRef)) return
           if (ignoreDependenciesMatcher?.(alias)) return
 
           const currentRef = (currentLockfile.importers[importerId] as ProjectSnapshot)?.[depType]?.[alias]
-          if (isLocalRef(wantedRef)) return
           const wantedRelative = dp.refToRelative(wantedRef, alias)
           const currentRelative = currentRef ? dp.refToRelative(currentRef, alias) : null
           const wantedSnapshot = wantedRelative != null ? opts.wantedLockfile!.packages?.[wantedRelative] : undefined
@@ -197,6 +197,11 @@ function isEmpty (obj: object): boolean {
   return Object.keys(obj).length === 0
 }
 
+// A dependency whose wanted ref is local resolves to a directory on disk
+// even when its manifest specifier is a plain semver range (e.g. a
+// workspace package matched by `link-workspace-packages`). Such a package
+// may not be published at all, so there is no registry "latest" to compare
+// against.
 function isLocalRef (ref: string): boolean {
   return ref.startsWith('link:') || ref.startsWith('file:') || ref.startsWith('workspace:')
 }

--- a/pnpm11/deps/inspection/outdated/test/outdated.spec.ts
+++ b/pnpm11/deps/inspection/outdated/test/outdated.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@jest/globals'
+import { expect, jest, test } from '@jest/globals'
 import { LOCKFILE_VERSION } from '@pnpm/constants'
 import type { ResolveLatestDispatcher } from '@pnpm/installing.client'
 import type { DepPath, PackageManifest, ProjectId } from '@pnpm/types'
@@ -61,6 +61,54 @@ async function getLatestManifest (packageName: string): Promise<PackageManifest 
 }
 
 const resolveLatest = makeResolveLatest(getLatestManifest)
+
+test('outdated() skips dependencies resolved from local refs', async () => {
+  const resolveLatest = jest.fn<ResolveLatestDispatcher>(async () => {
+    throw new Error('local dependency should not resolve latest from the registry')
+  })
+
+  const outdatedPkgs = await outdated({
+    currentLockfile: {
+      importers: {
+        ['.' as ProjectId]: {
+          devDependencies: {
+            'private-workspace-pkg': 'link:../private-workspace-pkg',
+          },
+          specifiers: {
+            'private-workspace-pkg': '^1.0.0',
+          },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+    },
+    resolveLatest,
+    lockfileDir: 'project',
+    manifest: {
+      name: 'wanted-shrinkwrap',
+      version: '1.0.0',
+      devDependencies: {
+        'private-workspace-pkg': '^1.0.0',
+      },
+    },
+    prefix: 'project',
+    wantedLockfile: {
+      importers: {
+        ['.' as ProjectId]: {
+          devDependencies: {
+            'private-workspace-pkg': 'link:../private-workspace-pkg',
+          },
+          specifiers: {
+            'private-workspace-pkg': '^1.0.0',
+          },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+    },
+  })
+
+  expect(outdatedPkgs).toStrictEqual([])
+  expect(resolveLatest).not.toHaveBeenCalled()
+})
 
 test('outdated()', async () => {
   const outdatedPkgs = await outdated({

--- a/pnpm11/deps/inspection/outdated/test/outdated.spec.ts
+++ b/pnpm11/deps/inspection/outdated/test/outdated.spec.ts
@@ -110,6 +110,69 @@ test('outdated() skips dependencies resolved from local refs', async () => {
   expect(resolveLatest).not.toHaveBeenCalled()
 })
 
+test('outdated() still checks the registry when only the current ref is local', async () => {
+  const outdatedPkgs = await outdated({
+    currentLockfile: {
+      importers: {
+        ['.' as ProjectId]: {
+          devDependencies: {
+            'is-positive': 'link:../is-positive',
+          },
+          specifiers: {
+            'is-positive': '^1.0.0',
+          },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+    },
+    resolveLatest,
+    lockfileDir: 'project',
+    manifest: {
+      name: 'wanted-shrinkwrap',
+      version: '1.0.0',
+      devDependencies: {
+        'is-positive': '^1.0.0',
+      },
+    },
+    prefix: 'project',
+    wantedLockfile: {
+      importers: {
+        ['.' as ProjectId]: {
+          devDependencies: {
+            'is-positive': '1.0.0',
+          },
+          specifiers: {
+            'is-positive': '^1.0.0',
+          },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        ['is-positive@1.0.0' as DepPath]: {
+          resolution: {
+            integrity: 'sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==',
+          },
+        },
+      },
+    },
+  })
+
+  expect(outdatedPkgs).toStrictEqual([
+    {
+      alias: 'is-positive',
+      belongsTo: 'devDependencies',
+      current: 'link:../is-positive',
+      latestManifest: {
+        name: 'is-positive',
+        version: '3.1.0',
+      },
+      packageName: 'is-positive',
+      wanted: '1.0.0',
+      workspace: 'wanted-shrinkwrap',
+    },
+  ])
+})
+
 test('outdated()', async () => {
   const outdatedPkgs = await outdated({
     currentLockfile: {


### PR DESCRIPTION
## Summary

`pnpm outdated` now skips dependencies whose lockfile ref is local (`link:`, `file:`, or `workspace:`), even when the manifest specifier is a plain semver range.

This covers workspace-linked packages such as:

```yaml
devDependencies:
  private-workspace-pkg:
    specifier: ^1.0.0
    version: link:../private-workspace-pkg
```

In that shape the dependency is already resolved locally, so asking the registry for a latest version can fail for private workspace packages that are not published. Refs pnpm/pnpm#12827.

Follow-up commits after review:

- The local-ref early return runs before any other per-dependency work, and the `isLocalRef` helper documents why local refs have no registry "latest".
- Added a test locking in the other side of the behavior: a dependency whose *current* ref is local but whose *wanted* ref is a registry version is still checked and reported (addresses CodeRabbit's suggestion).
- **pacquet parity:** pacquet's `outdated` already skips local refs — `ImporterDepVersion::ver_peer()` returns `None` for `link:`/`file:`, so `collect_outdated` drops those deps before any registry fetch. This PR adds a Rust test (`current_versions_omit_local_refs`) proving that behavior, so both stacks now cover the same scenario. No pacquet behavior change was needed; the TypeScript fix brings pnpm in line with pacquet.

## Verification

- `pnpm --filter @pnpm/deps.inspection.outdated test test/outdated.spec.ts` — 14/14 pass; the regression test fails without the fix.
- `pnpm --filter @pnpm/deps.inspection.commands test` outdated suites — 27/27 pass.
- `cargo nextest run -p pacquet-cli -E 'test(/outdated::tests/)'` — 11/11 pass; `cargo clippy -D warnings`, `cargo fmt --check`, and `taplo format --check` clean.
- End-to-end with the rebuilt bundle: a workspace containing an unpublished package linked via `linkWorkspacePackages` with a `^1.0.0` specifier — `pnpm -r outdated` exits 0 with no registry error.
- `pnpm run lint --quiet` and the pre-push hook (rustfmt, taplo, clippy, cargo doc, dylint) completed during push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `pnpm outdated` to avoid registry checks for dependencies resolved via local references (`link:`, `file:`, `workspace:`), preventing misleading outdated results.
  * Preserved correct behavior when local refs exist in the current lockfile but the “wanted” resolution maps to registry versions.
* **Tests**
  * Added unit tests for `pnpm outdated` covering local-reference skipping and ensuring latest-resolution logic is not invoked when it shouldn’t be.
  * Added tests for lockfile current-version extraction to omit local-reference entries while keeping registry-pinned versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->