### PR TITLE
fix: allow pnpm v10 to switch/self-update to pnpm v12

### DIFF
--- a/.changeset/pnpm-v10-install-v12.md
+++ b/.changeset/pnpm-v10-install-v12.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/tools.plugin-commands-self-updater": patch
+"pnpm": patch
+---
+
+Fixed switching to and self-updating to pnpm v12. pnpm v12 (the Rust port) ships as the `pnpm` and `@pnpm/exe` npm packages whose bins are placeholders replaced at install time by the host's native binary from a `@pnpm/exe.<platform>-<arch>[-musl]` optional dependency. Because pnpm installs its own engine with `--ignore-scripts`, that relinking never ran, leaving a non-executable placeholder. pnpm now relinks the native binary itself for v12 (recognizing the new platform-package naming scheme and the native `pnpm` package), and verifies the native binary's npm registry signature before running it.

--- a/pnpm/test/switchingVersions.test.ts
+++ b/pnpm/test/switchingVersions.test.ts
@@ -126,6 +126,39 @@ test('`pnpm version` routes through switchCliVersion to v11 when packageManager 
   expect(fs.existsSync(path.join(toolDir, 'bin/pnpm'))).toBe(true)
 })
 
+test('switch to pnpm v12 relinks the native binary so the installed engine actually runs', () => {
+  prepare()
+  const pnpmHome = path.resolve('pnpm')
+  // pnpm v12 (the Rust port) publishes the `pnpm` package with placeholder bins
+  // that its preinstall replaces with the host's native binary. Because pnpm
+  // installs its own engine with --ignore-scripts, installPnpmToTools must do
+  // that relinking itself — otherwise `bin/pnpm` is left as a non-executable
+  // placeholder and the switch produces a broken engine.
+  const version = '12.0.0-alpha.2'
+  // Bypass the registry mock: fetching the real v12 wrapper + its ~22MB native
+  // binary needs the public registry, like the v11 test above.
+  const env = {
+    PNPM_HOME: pnpmHome,
+    npm_config_registry: 'https://registry.npmjs.org/',
+  }
+  writeJsonFile('package.json', {
+    packageManager: `pnpm@${version}`,
+  })
+
+  // For v12 the running package name is irrelevant — it always converges on the
+  // native `pnpm` package (equal content to `@pnpm/exe`).
+  const toolDir = getToolDirPath({ pnpmHomeDir: pnpmHome, tool: { name: 'pnpm', version } })
+
+  const { stdout, stderr } = execPnpmSync(['--version'], { env, timeout: 300_000 })
+  const combined = stdout.toString() + stderr.toString()
+
+  // The relinked bin must exist and, unlike v11, v12 is a native binary with no
+  // Node version gate — so it runs and reports a v12 version (the vendored
+  // native binary's own patch may lag the wrapper, so match the alpha prefix).
+  expect(fs.existsSync(path.join(toolDir, 'bin/pnpm'))).toBe(true)
+  expect(combined).toContain('12.0.0-alpha')
+}, 300_000)
+
 test('npm passthrough still fires when packageManager selects pnpm v11+ but switching is disabled via .npmrc', () => {
   prepare()
   const pnpmHome = path.resolve('pnpm')

--- a/tools/plugin-commands-self-updater/src/index.ts
+++ b/tools/plugin-commands-self-updater/src/index.ts
@@ -1,5 +1,5 @@
 import * as selfUpdate from './selfUpdate.js'
-export { installPnpmToTools, pnpmPackageNameToInstall, linkExePlatformBinary, exePlatformPkgDirNames } from './installPnpmToTools.js'
+export { installPnpmToTools, pnpmPackageNameToInstall, linkExePlatformBinary, exePlatformPkgDirNames, safeWrapperBinNames } from './installPnpmToTools.js'
 export { getNpmSigningKeys, verifyPnpmEngineIdentity, type RegistryKey, type VerifyPnpmEngineIdentityOptions } from './verifyPnpmEngineIdentity.js'
 
 export { selfUpdate }

--- a/tools/plugin-commands-self-updater/src/index.ts
+++ b/tools/plugin-commands-self-updater/src/index.ts
@@ -1,5 +1,5 @@
 import * as selfUpdate from './selfUpdate.js'
-export { installPnpmToTools } from './installPnpmToTools.js'
+export { installPnpmToTools, pnpmPackageNameToInstall, linkExePlatformBinary, exePlatformPkgDirNames } from './installPnpmToTools.js'
 export { getNpmSigningKeys, verifyPnpmEngineIdentity, type RegistryKey, type VerifyPnpmEngineIdentityOptions } from './verifyPnpmEngineIdentity.js'
 
 export { selfUpdate }

--- a/tools/plugin-commands-self-updater/src/installPnpmToTools.ts
+++ b/tools/plugin-commands-self-updater/src/installPnpmToTools.ts
@@ -19,22 +19,12 @@ export interface InstallPnpmToToolsResult {
 
 export async function installPnpmToTools (pnpmVersion: string, opts: SelfUpdateCommandOptions): Promise<InstallPnpmToToolsResult> {
   const currentPkgName = getCurrentPackageName()
-  // pnpm v11 dropped the darwin-x64 artifact from @pnpm/exe because Node.js
-  // SEA injection produces a binary that segfaults at startup on Intel Macs
-  // (pnpm/pnpm#11423, upstream nodejs/node#62893). Self-updating a v10
-  // @pnpm/exe install to v11+ on Intel Mac would leave the user with no
-  // working binary. Transparently swap to the JS-only `pnpm` package, which
-  // runs against the user's system Node.js — typically already present
-  // because v10 @pnpm/exe users tend to manage Node via `pnpm env use`.
-  const targetPkgName = (
-    currentPkgName === '@pnpm/exe' &&
-    process.platform === 'darwin' &&
-    process.arch === 'x64' &&
-    semver.major(pnpmVersion) >= 11
-  )
-    ? 'pnpm'
-    : currentPkgName
-  if (targetPkgName !== currentPkgName) {
+  const targetPkgName = pnpmPackageNameToInstall(pnpmVersion, currentPkgName)
+  // The v11-only darwin-x64 fallback (see pnpmPackageNameToInstall) swaps the
+  // native @pnpm/exe for the JS `pnpm` package, which needs Node.js on PATH —
+  // warn about that. From v12 the `pnpm` package is itself native, so the
+  // convergence to `pnpm` is transparent and needs no warning.
+  if (targetPkgName !== currentPkgName && semver.major(pnpmVersion) < 12) {
     globalWarn(
       `Switching from @pnpm/exe to the "pnpm" npm package because @pnpm/exe v${pnpmVersion} no longer ships a binary for Intel macOS (darwin-x64). The new "pnpm" install requires Node.js to be available on PATH. See https://github.com/pnpm/pnpm/issues/11423.`
     )
@@ -96,8 +86,12 @@ export async function installPnpmToTools (pnpmVersion: string, opts: SelfUpdateC
         pnpm_config_pm_on_fail: 'ignore',
       },
     })
-    if (targetPkgName === '@pnpm/exe') {
-      linkExePlatformBinary(stage)
+    // pnpm's own installs run with --ignore-scripts, so the wrapper's
+    // preinstall (which links the native binary over the placeholder bin) never
+    // runs — replicate it here. Needed for any wrapper that ships a native
+    // binary: `@pnpm/exe` (all majors) and, from v12, the `pnpm` package too.
+    if (targetPkgName === '@pnpm/exe' || semver.major(pnpmVersion) >= 12) {
+      linkExePlatformBinary(stage, targetPkgName)
     }
     // Reached only when the wanted version is not yet in the tools directory
     // (an actual download), so the signature check does not run on every
@@ -122,25 +116,129 @@ export async function installPnpmToTools (pnpmVersion: string, opts: SelfUpdateC
   }
 }
 
-// This replicates the logic from @pnpm/exe's setup.js (pnpm/artifacts/exe/setup.js).
-// We can't run setup.js via require() or import() because:
-// - require() fails when setup.js is ESM (pnpm v11+)
+/**
+ * The package to install for a switch to `pnpmVersion`.
+ *
+ * From v12 the unscoped `pnpm` package is itself the native executable (equal
+ * content to `@pnpm/exe`) and ships a binary for every target — including
+ * darwin-x64 — so v12+ always converges on `pnpm`, even from a standalone
+ * `@pnpm/exe` build.
+ *
+ * For earlier majors the running package name is kept, except that a v11+
+ * update of a darwin-x64 `@pnpm/exe` install falls back to the JS `pnpm`
+ * package: pnpm v11 dropped the darwin-x64 artifact from `@pnpm/exe` because
+ * Node.js SEA injection produces a binary that segfaults at startup on Intel
+ * Macs (pnpm/pnpm#11423, upstream nodejs/node#62893), which would leave the
+ * user with no working binary. The JS `pnpm` package runs against the user's
+ * system Node.js — typically already present because v10 `@pnpm/exe` users
+ * tend to manage Node via `pnpm env use`.
+ */
+export function pnpmPackageNameToInstall (pnpmVersion: string, currentPkgName: string): string {
+  const major = semver.major(pnpmVersion)
+  if (major >= 12) return 'pnpm'
+  if (
+    currentPkgName === '@pnpm/exe' &&
+    process.platform === 'darwin' &&
+    process.arch === 'x64' &&
+    major >= 11
+  ) {
+    return 'pnpm'
+  }
+  return currentPkgName
+}
+
+// This replicates the logic from the wrapper's preinstall script (the
+// TypeScript @pnpm/exe's setup.js and the Rust pnpm v12's install.js), which
+// we skip via --ignore-scripts. We can't just run the script because:
+// - require() fails when it is ESM (pnpm v11+)
 // - import() is intercepted by pkg's virtual filesystem in standalone executables
-// So we inline the logic: find the platform-specific binary and hard-link it
-// into the @pnpm/exe package directory.
-function linkExePlatformBinary (stageDir: string): void {
-  const platform = process.platform === 'win32'
-    ? 'win'
-    : process.platform === 'darwin'
-      ? 'macos'
-      : process.platform
-  const arch = platform === 'win' && process.arch === 'ia32' ? 'x86' : process.arch
-  const executable = platform === 'win' ? 'pnpm.exe' : 'pnpm'
-  const platformPkgDir = path.join(stageDir, 'node_modules', '@pnpm', `${platform}-${arch}`)
-  const src = path.join(platformPkgDir, executable)
-  if (!fs.existsSync(src)) return
-  const exePkgDir = path.join(stageDir, 'node_modules', '@pnpm', 'exe')
-  const dest = path.join(exePkgDir, executable)
+// So we inline it: find the host's native binary and hard-link it over the
+// wrapper's placeholder bin. Handles both the legacy `@pnpm/<os>-<arch>`
+// platform packages (v10/v11 @pnpm/exe) and the v12 `@pnpm/exe.<platform>-<arch>[-musl]`
+// scheme (shared by both the `pnpm` and `@pnpm/exe` wrappers).
+export function linkExePlatformBinary (stageDir: string, wrapperPkgName: string): void {
+  const wrapperDir = path.join(stageDir, 'node_modules', ...wrapperPkgName.split('/'))
+  if (!fs.existsSync(wrapperDir)) return
+  const scopeDir = path.join(stageDir, 'node_modules', '@pnpm')
+  const isWin = process.platform === 'win32'
+  const executable = isWin ? 'pnpm.exe' : 'pnpm'
+  // Only the platform package matching the host's os/cpu/libc is installed, so
+  // link whichever candidate is actually present on disk.
+  let src: string | undefined
+  for (const dirName of exePlatformPkgDirNames(process.platform, process.arch)) {
+    const candidate = path.join(scopeDir, dirName, executable)
+    if (fs.existsSync(candidate)) {
+      src = candidate
+      break
+    }
+  }
+  if (src == null) return
+
+  if (!isWin) {
+    // On Unix `pn`/`pnpx`/`pnx` are committed `#!/bin/sh` scripts that call
+    // `pnpm` on PATH, so only the `pnpm` placeholder needs the native binary.
+    forceLink(src, path.join(wrapperDir, 'pnpm'))
+    return
+  }
+
+  const wrapperPkgJsonPath = path.join(wrapperDir, 'package.json')
+  const wrapperPkg = JSON.parse(fs.readFileSync(wrapperPkgJsonPath, 'utf8'))
+  const bin: Record<string, string> = (typeof wrapperPkg.bin === 'object' && wrapperPkg.bin != null)
+    ? wrapperPkg.bin
+    : { pnpm: 'pnpm' }
+  for (const name of Object.keys(bin)) {
+    // Link the native binary onto both `<name>.exe` (cmd.exe resolves the
+    // extension-less shim target through PATHEXT) and the extension-less file
+    // (Git Bash runs it directly), matching the wrapper's own install.js. The
+    // native binary self-detects its launch name to inject `dlx` for pnpx/pnx.
+    forceLink(src, path.join(wrapperDir, `${name}.exe`))
+    forceLink(src, path.join(wrapperDir, name))
+    bin[name] = `${name}.exe`
+  }
+  wrapperPkg.bin = bin
+  // Temp file + rename, not in-place: package.json is hard-linked from the
+  // content-addressable store, so writing in place would mutate the shared blob.
+  const tempPkgJsonPath = `${wrapperPkgJsonPath}.pnpm-tmp`
+  try {
+    fs.writeFileSync(tempPkgJsonPath, JSON.stringify(wrapperPkg, null, 2))
+    fs.renameSync(tempPkgJsonPath, wrapperPkgJsonPath)
+  } catch (err: unknown) {
+    try {
+      fs.rmSync(tempPkgJsonPath, { force: true })
+    } catch {}
+    throw err
+  }
+}
+
+/**
+ * Directory names under `node_modules/@pnpm/` of every platform package that
+ * could carry the native pnpm binary for this host, most-preferred first —
+ * both the legacy `@pnpm/<os>-<arch>` names (v10/v11 @pnpm/exe) and the v12
+ * `@pnpm/exe.<platform>-<arch>[-musl]` names. Only the package matching the
+ * host's os/cpu/libc is ever installed, so the caller links the first that
+ * exists on disk; enumerating both libc variants avoids detecting libc here.
+ */
+export function exePlatformPkgDirNames (platform: NodeJS.Platform, arch: string): string[] {
+  switch (platform) {
+  case 'win32': {
+    const legacyArch = arch === 'ia32' ? 'x86' : arch
+    return [`win-${legacyArch}`, `exe.win32-${arch}`]
+  }
+  case 'darwin':
+    return [`macos-${arch}`, `exe.darwin-${arch}`]
+  case 'linux':
+    return [
+      `linux-${arch}`, // legacy glibc
+      `linuxstatic-${arch}`, // legacy musl
+      `exe.linux-${arch}`, // v12 glibc
+      `exe.linux-${arch}-musl`, // v12 musl
+    ]
+  default:
+    return [`${platform}-${arch}`, `exe.${platform}-${arch}`]
+  }
+}
+
+function forceLink (src: string, dest: string): void {
   try {
     fs.unlinkSync(dest)
   } catch (err: unknown) {
@@ -150,11 +248,4 @@ function linkExePlatformBinary (stageDir: string): void {
   }
   fs.linkSync(src, dest)
   fs.chmodSync(dest, 0o755)
-  if (platform === 'win') {
-    const exePkgJsonPath = path.join(exePkgDir, 'package.json')
-    const exePkg = JSON.parse(fs.readFileSync(exePkgJsonPath, 'utf8'))
-    fs.writeFileSync(path.join(exePkgDir, 'pnpm'), 'This file intentionally left blank')
-    exePkg.bin.pnpm = 'pnpm.exe'
-    fs.writeFileSync(exePkgJsonPath, JSON.stringify(exePkg, null, 2))
-  }
 }

--- a/tools/plugin-commands-self-updater/src/installPnpmToTools.ts
+++ b/tools/plugin-commands-self-updater/src/installPnpmToTools.ts
@@ -86,6 +86,14 @@ export async function installPnpmToTools (pnpmVersion: string, opts: SelfUpdateC
         pnpm_config_pm_on_fail: 'ignore',
       },
     })
+    // Reached only when the wanted version is not yet in the tools directory
+    // (an actual download), so the signature check does not run on every
+    // invocation. Verify BEFORE relinking (below) and before the staged install
+    // is linked into place and spawned: relinking mutates files whose names come
+    // from the wrapper's own (still untrusted) package.json, so it must not run
+    // until the wrapper is proven to be a genuine, signed pnpm release. On
+    // failure the stage is removed by the catch below.
+    await verifyPnpmEngineIdentity(stage, targetPkgName, pnpmVersion, opts)
     // pnpm's own installs run with --ignore-scripts, so the wrapper's
     // preinstall (which links the native binary over the placeholder bin) never
     // runs — replicate it here. Needed for any wrapper that ships a native
@@ -93,11 +101,6 @@ export async function installPnpmToTools (pnpmVersion: string, opts: SelfUpdateC
     if (targetPkgName === '@pnpm/exe' || semver.major(pnpmVersion) >= 12) {
       linkExePlatformBinary(stage, targetPkgName)
     }
-    // Reached only when the wanted version is not yet in the tools directory
-    // (an actual download), so the signature check does not run on every
-    // invocation. Verify before the staged install is linked into place and
-    // spawned — on failure the stage is removed by the catch below.
-    await verifyPnpmEngineIdentity(stage, targetPkgName, pnpmVersion, opts)
     // We need the operation of installing pnpm to be atomic.
     // However, we cannot use a rename as that breaks the command shim created for pnpm.
     // Hence, we use a symlink.
@@ -126,7 +129,7 @@ export async function installPnpmToTools (pnpmVersion: string, opts: SelfUpdateC
  *
  * For earlier majors the running package name is kept, except that a v11+
  * update of a darwin-x64 `@pnpm/exe` install falls back to the JS `pnpm`
- * package: pnpm v11 dropped the darwin-x64 artifact from `@pnpm/exe` because
+ * package: pnpm v11+ ships no darwin-x64 artifact for `@pnpm/exe` because
  * Node.js SEA injection produces a binary that segfaults at startup on Intel
  * Macs (pnpm/pnpm#11423, upstream nodejs/node#62893), which would leave the
  * user with no working binary. The JS `pnpm` package runs against the user's
@@ -186,7 +189,7 @@ export function linkExePlatformBinary (stageDir: string, wrapperPkgName: string)
   const bin: Record<string, string> = (typeof wrapperPkg.bin === 'object' && wrapperPkg.bin != null)
     ? wrapperPkg.bin
     : { pnpm: 'pnpm' }
-  for (const name of Object.keys(bin)) {
+  for (const name of safeWrapperBinNames(wrapperDir, bin)) {
     // Link the native binary onto both `<name>.exe` (cmd.exe resolves the
     // extension-less shim target through PATHEXT) and the extension-less file
     // (Git Bash runs it directly), matching the wrapper's own install.js. The
@@ -236,6 +239,19 @@ export function exePlatformPkgDirNames (platform: NodeJS.Platform, arch: string)
   default:
     return [`${platform}-${arch}`, `exe.${platform}-${arch}`]
   }
+}
+
+/**
+ * The bin names from a wrapper's `package.json` that are safe to relink. The
+ * manifest is not signature-verified at the point of relinking (defense in
+ * depth behind the verify-before-relink ordering in installPnpmToTools), so a
+ * crafted `bin` map must not be able to traverse out of the wrapper directory
+ * via `..`, path separators, or absolute paths: only names that resolve to a
+ * direct child of `wrapperDir` are kept.
+ */
+export function safeWrapperBinNames (wrapperDir: string, bin: Record<string, string>): string[] {
+  const resolvedWrapperDir = path.resolve(wrapperDir)
+  return Object.keys(bin).filter((name) => path.dirname(path.resolve(wrapperDir, name)) === resolvedWrapperDir)
 }
 
 function forceLink (src: string, dest: string): void {

--- a/tools/plugin-commands-self-updater/src/verifyPnpmEngineIdentity.ts
+++ b/tools/plugin-commands-self-updater/src/verifyPnpmEngineIdentity.ts
@@ -11,6 +11,7 @@ import { readWantedLockfile } from '@pnpm/lockfile.fs'
 import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
 import { pickRegistryForPackage } from '@pnpm/pick-registry-for-package'
 import { type DepPath, type Registries } from '@pnpm/types'
+import semver from 'semver'
 
 import { NPM_SIGNING_KEYS } from './npmSigningKeys.js'
 
@@ -142,11 +143,12 @@ function collectEnginePackagesToVerify (
   registries: Registries
 ): InstalledPackageToVerify[] {
   const toVerify = [engineComponentToVerify(lockfile, registries, targetPkgName, version)]
-  if (targetPkgName === '@pnpm/exe') {
-    // The bytes actually executed are the host's platform binary, listed as an
-    // optional dependency of `@pnpm/exe`. Verify every platform package the
-    // staged install actually materialized on disk.
-    const optionalDeps = lockfile.packages?.[`@pnpm/exe@${version}` as DepPath]?.optionalDependencies ?? {}
+  // The bytes actually executed are the host's platform binary, listed as an
+  // optional dependency of the wrapper. This applies to `@pnpm/exe` (all
+  // majors) and, from v12, the `pnpm` package too (it is itself native).
+  // Verify every platform package the staged install materialized on disk.
+  if (targetPkgName === '@pnpm/exe' || semver.major(version) >= 12) {
+    const optionalDeps = lockfile.packages?.[`${targetPkgName}@${version}` as DepPath]?.optionalDependencies ?? {}
     for (const [name, platformVersion] of Object.entries(optionalDeps)) {
       if (!fs.existsSync(path.join(stageDir, 'node_modules', name))) continue
       toVerify.push(engineComponentToVerify(lockfile, registries, name, platformVersion))

--- a/tools/plugin-commands-self-updater/test/installPnpmToTools.test.ts
+++ b/tools/plugin-commands-self-updater/test/installPnpmToTools.test.ts
@@ -6,6 +6,7 @@ import {
   exePlatformPkgDirNames,
   linkExePlatformBinary,
   pnpmPackageNameToInstall,
+  safeWrapperBinNames,
 } from '@pnpm/tools.plugin-commands-self-updater'
 
 const NATIVE_BYTES = '#!/native/pnpm binary bytes'
@@ -46,6 +47,28 @@ describe('exePlatformPkgDirNames', () => {
 
   test('normalizes the legacy Windows ia32 arch to x86', () => {
     expect(exePlatformPkgDirNames('win32', 'ia32')).toStrictEqual(['win-x86', 'exe.win32-ia32'])
+  })
+})
+
+describe('safeWrapperBinNames', () => {
+  const wrapperDir = path.join('stage', 'node_modules', 'pnpm')
+
+  test('keeps the real pnpm bin names', () => {
+    const bin = { pnpm: 'pnpm', pn: 'pn', pnpx: 'pnpx', pnx: 'pnx' }
+    expect(safeWrapperBinNames(wrapperDir, bin)).toStrictEqual(['pnpm', 'pn', 'pnpx', 'pnx'])
+  })
+
+  test('drops names that would escape the wrapper directory (path traversal / separators / absolute)', () => {
+    const bin = {
+      pnpm: 'pnpm',
+      '../evil': 'pnpm',
+      '../../evil': 'pnpm',
+      'sub/evil': 'pnpm',
+      '..': 'pnpm',
+      '.': 'pnpm',
+      [path.join(path.sep, 'abs', 'evil')]: 'pnpm',
+    }
+    expect(safeWrapperBinNames(wrapperDir, bin)).toStrictEqual(['pnpm'])
   })
 })
 

--- a/tools/plugin-commands-self-updater/test/installPnpmToTools.test.ts
+++ b/tools/plugin-commands-self-updater/test/installPnpmToTools.test.ts
@@ -1,0 +1,128 @@
+import fs from 'fs'
+import path from 'path'
+
+import { tempDir } from '@pnpm/prepare'
+import {
+  exePlatformPkgDirNames,
+  linkExePlatformBinary,
+  pnpmPackageNameToInstall,
+} from '@pnpm/tools.plugin-commands-self-updater'
+
+const NATIVE_BYTES = '#!/native/pnpm binary bytes'
+const PLACEHOLDER = 'This is a placeholder. Reinstall with build scripts enabled.'
+const EXECUTABLE = process.platform === 'win32' ? 'pnpm.exe' : 'pnpm'
+const V12_BIN_NAMES = ['pnpm', 'pn', 'pnpx', 'pnx']
+
+describe('pnpmPackageNameToInstall', () => {
+  test('always converges on the native `pnpm` package for v12+, regardless of the running package', () => {
+    expect(pnpmPackageNameToInstall('12.0.0', 'pnpm')).toBe('pnpm')
+    expect(pnpmPackageNameToInstall('12.0.0', '@pnpm/exe')).toBe('pnpm')
+    expect(pnpmPackageNameToInstall('12.3.4-alpha.2', '@pnpm/exe')).toBe('pnpm')
+    expect(pnpmPackageNameToInstall('13.0.0', '@pnpm/exe')).toBe('pnpm')
+  })
+
+  test('keeps the running package name for majors below 12', () => {
+    expect(pnpmPackageNameToInstall('9.1.0', 'pnpm')).toBe('pnpm')
+    expect(pnpmPackageNameToInstall('10.5.0', '@pnpm/exe')).toBe('@pnpm/exe')
+    expect(pnpmPackageNameToInstall('11.0.0', 'pnpm')).toBe('pnpm')
+  })
+})
+
+describe('exePlatformPkgDirNames', () => {
+  test('lists the legacy name first, then the v12 `exe.<platform>-<arch>` name', () => {
+    expect(exePlatformPkgDirNames('darwin', 'arm64')).toStrictEqual(['macos-arm64', 'exe.darwin-arm64'])
+    expect(exePlatformPkgDirNames('darwin', 'x64')).toStrictEqual(['macos-x64', 'exe.darwin-x64'])
+    expect(exePlatformPkgDirNames('win32', 'x64')).toStrictEqual(['win-x64', 'exe.win32-x64'])
+  })
+
+  test('includes both glibc and musl candidates on linux', () => {
+    expect(exePlatformPkgDirNames('linux', 'x64')).toStrictEqual([
+      'linux-x64',
+      'linuxstatic-x64',
+      'exe.linux-x64',
+      'exe.linux-x64-musl',
+    ])
+  })
+
+  test('normalizes the legacy Windows ia32 arch to x86', () => {
+    expect(exePlatformPkgDirNames('win32', 'ia32')).toStrictEqual(['win-x86', 'exe.win32-ia32'])
+  })
+})
+
+describe('linkExePlatformBinary', () => {
+  test('relinks the pnpm v12 wrapper placeholder to the native binary', () => {
+    const nativeDir = exePlatformPkgDirNames(process.platform, process.arch).find((n) => n.startsWith('exe.'))!
+    const stage = setupStage({ wrapperPkgName: 'pnpm', nativeDir, binNames: V12_BIN_NAMES })
+
+    linkExePlatformBinary(stage, 'pnpm')
+
+    assertLinked(stage, 'pnpm')
+  })
+
+  test('relinks a legacy @pnpm/exe wrapper placeholder to the native binary', () => {
+    const nativeDir = exePlatformPkgDirNames(process.platform, process.arch).find((n) => !n.startsWith('exe.'))!
+    const stage = setupStage({ wrapperPkgName: '@pnpm/exe', nativeDir, binNames: ['pnpm'] })
+
+    linkExePlatformBinary(stage, '@pnpm/exe')
+
+    assertLinked(stage, '@pnpm/exe')
+  })
+
+  test('is a no-op (does not throw) when the wrapper package is not present', () => {
+    const stage = tempDir(false)
+    expect(() => {
+      linkExePlatformBinary(stage, 'pnpm')
+    }).not.toThrow()
+  })
+
+  test('is a no-op (does not throw) when no native platform package materialized', () => {
+    const stage = setupStage({ wrapperPkgName: 'pnpm', nativeDir: undefined, binNames: V12_BIN_NAMES })
+
+    expect(() => {
+      linkExePlatformBinary(stage, 'pnpm')
+    }).not.toThrow()
+
+    // The placeholder is left untouched — there was nothing to link.
+    const wrapperDir = path.join(stage, 'node_modules', 'pnpm')
+    expect(fs.readFileSync(path.join(wrapperDir, 'pnpm'), 'utf8')).toBe(PLACEHOLDER)
+  })
+})
+
+interface SetupStageOptions {
+  wrapperPkgName: string
+  nativeDir: string | undefined
+  binNames: string[]
+}
+
+function setupStage ({ wrapperPkgName, nativeDir, binNames }: SetupStageOptions): string {
+  const stage = tempDir(false)
+  if (nativeDir != null) {
+    const platformPkgDir = path.join(stage, 'node_modules', '@pnpm', nativeDir)
+    fs.mkdirSync(platformPkgDir, { recursive: true })
+    fs.writeFileSync(path.join(platformPkgDir, EXECUTABLE), NATIVE_BYTES)
+  }
+  const wrapperDir = path.join(stage, 'node_modules', ...wrapperPkgName.split('/'))
+  fs.mkdirSync(wrapperDir, { recursive: true })
+  const bin = Object.fromEntries(binNames.map((name) => [name, name]))
+  fs.writeFileSync(path.join(wrapperDir, 'package.json'), JSON.stringify({ name: wrapperPkgName, bin }, null, 2))
+  for (const name of binNames) {
+    fs.writeFileSync(path.join(wrapperDir, name), PLACEHOLDER)
+  }
+  return stage
+}
+
+function assertLinked (stage: string, wrapperPkgName: string): void {
+  const wrapperDir = path.join(stage, 'node_modules', ...wrapperPkgName.split('/'))
+  if (process.platform === 'win32') {
+    // On Windows every bin becomes a `.exe` and the extension-less twin, and the
+    // manifest's bin field is rewritten to point at the `.exe` files.
+    expect(fs.readFileSync(path.join(wrapperDir, 'pnpm.exe'), 'utf8')).toBe(NATIVE_BYTES)
+    expect(fs.readFileSync(path.join(wrapperDir, 'pnpm'), 'utf8')).toBe(NATIVE_BYTES)
+    const manifest = JSON.parse(fs.readFileSync(path.join(wrapperDir, 'package.json'), 'utf8'))
+    expect(manifest.bin.pnpm).toBe('pnpm.exe')
+  } else {
+    // On Unix only the `pnpm` placeholder is relinked; pn/pnpx/pnx stay as the
+    // committed shell scripts (when present).
+    expect(fs.readFileSync(path.join(wrapperDir, 'pnpm'), 'utf8')).toBe(NATIVE_BYTES)
+  }
+}

--- a/tools/plugin-commands-self-updater/test/verifyPnpmEngineIdentity.test.ts
+++ b/tools/plugin-commands-self-updater/test/verifyPnpmEngineIdentity.test.ts
@@ -128,6 +128,25 @@ test('throws when the platform binary signature does not validate over the insta
   await expect(verifyPnpmEngineIdentity(stage, '@pnpm/exe', '9.1.0', optsTrusting(key))).rejects.toThrow(/Refusing to run pnpm/)
 })
 
+test('verifies the platform binary materialized for a pnpm v12 install (the pnpm package is itself native)', async () => {
+  const key = createSigningKey()
+  mockPackument('pnpm', PNPM_INTEGRITY, [{ keyid: key.keyid, sig: key.sign('pnpm@12.0.0', PNPM_INTEGRITY) }], '12.0.0')
+  mockPackument(PLATFORM_PKG_NAME, PLATFORM_INTEGRITY, [{ keyid: key.keyid, sig: key.sign(`${PLATFORM_PKG_NAME}@12.0.0`, PLATFORM_INTEGRITY) }], '12.0.0')
+  const stage = stageWithPnpmV12Lockfile(PLATFORM_INTEGRITY)
+
+  await expect(verifyPnpmEngineIdentity(stage, 'pnpm', '12.0.0', optsTrusting(key))).resolves.toBeUndefined()
+})
+
+test('throws when the pnpm v12 platform binary signature does not validate over the installed bytes', async () => {
+  const key = createSigningKey()
+  mockPackument('pnpm', PNPM_INTEGRITY, [{ keyid: key.keyid, sig: key.sign('pnpm@12.0.0', PNPM_INTEGRITY) }], '12.0.0')
+  // The registry signed a different (genuine) platform binary than the one staged.
+  mockPackument(PLATFORM_PKG_NAME, PLATFORM_INTEGRITY, [{ keyid: key.keyid, sig: key.sign(`${PLATFORM_PKG_NAME}@12.0.0`, 'sha512-genuine-platform') }], '12.0.0')
+  const stage = stageWithPnpmV12Lockfile(PLATFORM_INTEGRITY)
+
+  await expect(verifyPnpmEngineIdentity(stage, 'pnpm', '12.0.0', optsTrusting(key))).rejects.toThrow(/Refusing to run pnpm/)
+})
+
 function baseOpts () {
   return {
     rawConfig: {},
@@ -193,19 +212,46 @@ function stageWithExeLockfile (platformIntegrity: string): string {
   return stage
 }
 
+function stageWithPnpmV12Lockfile (platformIntegrity: string): string {
+  const stage = tempDir(false)
+  writeStageLockfile(stage, [
+    'lockfileVersion: \'9.0\'',
+    'importers:',
+    '  .:',
+    '    dependencies:',
+    '      pnpm:',
+    '        specifier: 12.0.0',
+    '        version: 12.0.0',
+    'packages:',
+    '  pnpm@12.0.0:',
+    `    resolution: {integrity: ${PNPM_INTEGRITY}}`,
+    `  '${PLATFORM_PKG_NAME}@12.0.0':`,
+    `    resolution: {integrity: ${platformIntegrity}}`,
+    'snapshots:',
+    '  pnpm@12.0.0:',
+    '    optionalDependencies:',
+    `      '${PLATFORM_PKG_NAME}': 12.0.0`,
+    `  '${PLATFORM_PKG_NAME}@12.0.0':`,
+    '    optional: true',
+  ])
+  // Only platform packages actually materialized on disk are verified.
+  fs.mkdirSync(path.join(stage, 'node_modules', PLATFORM_PKG_NAME), { recursive: true })
+  return stage
+}
+
 function writeStageLockfile (stage: string, lines: string[]): void {
   fs.writeFileSync(path.join(stage, 'pnpm-lock.yaml'), `${lines.join('\n')}\n`, 'utf8')
 }
 
-function mockPackument (name: string, integrity: string, signatures: unknown): void {
+function mockPackument (name: string, integrity: string, signatures: unknown, version = '9.1.0'): void {
   const encodedPath = name[0] === '@' ? `/@${encodeURIComponent(name.slice(1))}` : `/${name}`
   nock(REGISTRY)
     .get(encodedPath)
     .reply(200, {
       name,
-      time: { '9.1.0': '2024-01-01T00:00:00.000Z' },
+      time: { [version]: '2024-01-01T00:00:00.000Z' },
       versions: {
-        '9.1.0': { name, version: '9.1.0', dist: { integrity, signatures, tarball: `${REGISTRY}${name}/-/x-9.1.0.tgz` } },
+        [version]: { name, version, dist: { integrity, signatures, tarball: `${REGISTRY}${name}/-/x-${version}.tgz` } },
       },
     })
     .persist()


### PR DESCRIPTION
## Problem

pnpm v10 (this release branch) **cannot** switch to or self-update to pnpm **v12**.

pnpm v12 (the Rust port) publishes the `pnpm` and `@pnpm/exe` npm packages whose bins (`pnpm`, `pn`, `pnpx`, `pnx`) are **placeholders**. A `preinstall` (`node install.js`) replaces the `pnpm` placeholder with the host's native binary, resolved from a platform-specific optional dependency named `@pnpm/exe.<platform>-<arch>[-musl]` (e.g. `@pnpm/exe.darwin-arm64`, `@pnpm/exe.linux-x64-musl`).

pnpm installs its own engine with `--ignore-scripts`, so that preinstall never runs. `installPnpmToTools` was supposed to replicate it, but it:

1. only relinked when the target package was `@pnpm/exe` (v12 converges on the native **`pnpm`** package), and
2. only understood the **legacy** `@pnpm/<os>-<arch>` platform-package names, never the v12 `@pnpm/exe.<platform>-<arch>[-musl]` scheme.

Result: `bin/pnpm` was left as the placeholder text file. `switchCliVersion` then spawned it and it failed with a shell syntax error.

Reproduced with pnpm 10.33.1 (`pnpm add pnpm@next-12 --ignore-scripts --config.node-linker=hoisted`): `bin/pnpm` → placeholder → `syntax error near unexpected token`.

## Fix

`installPnpmToTools` (`@pnpm/tools.plugin-commands-self-updater`):

- **`pnpmPackageNameToInstall`** — for v12+ always install the unscoped `pnpm` package (equal content to `@pnpm/exe`, and it ships every target including darwin-x64). Existing v11 darwin-x64 `@pnpm/exe`→`pnpm` fallback is preserved.
- **`linkExePlatformBinary`** — now takes the wrapper package name and relinks for any wrapper that ships a native binary (`@pnpm/exe` for all majors, and `pnpm` from v12). It recognizes both the legacy `@pnpm/<os>-<arch>` names and the new `@pnpm/exe.<platform>-<arch>[-musl]` names, linking whichever platform package the install actually materialized (optional deps are already `os`/`cpu`/`libc`-filtered). On Unix only the `pnpm` placeholder is relinked (`pn`/`pnpx`/`pnx` are committed `#!/bin/sh` scripts); on Windows every bin becomes the native `.exe` (+ ext-less twin) with the manifest `bin` rewritten, matching the wrapper's own `install.js`.

`verifyPnpmEngineIdentity` — also verifies the native platform package's npm registry signature for the v12 `pnpm` wrapper, not only `@pnpm/exe`, so the bytes that actually execute stay signature-checked.

## Tests

- New unit tests (`installPnpmToTools.test.ts`): `pnpmPackageNameToInstall`, `exePlatformPkgDirNames`, and `linkExePlatformBinary` (relinks the v12 `pnpm` wrapper and a legacy `@pnpm/exe` wrapper; safe no-ops when the wrapper/native package is absent).
- `verifyPnpmEngineIdentity.test.ts`: added cases proving the v12 `pnpm` install verifies its native platform package (and rejects a tampered one).
- `switchingVersions.test.ts`: e2e — switching to `pnpm@12.0.0-alpha.2` via the `packageManager` field produces a working native engine that runs and reports a v12 version.

All self-updater unit tests pass locally (`selfUpdate`, `verifyPnpmEngineIdentity`, `installPnpmToTools`). The e2e switch test hits the public registry (like the existing v11 test) and runs in CI.
