### PR TITLE
ci: build the musl NAPI addon with dynamic CRT linking

### DIFF
--- a/.github/workflows/pacquet-release-to-npm.yml
+++ b/.github/workflows/pacquet-release-to-npm.yml
@@ -124,9 +124,18 @@ jobs:
         # libc at load time (this is what napi-rs does for musl prebuilds). The
         # CLI binary keeps `crt-static` — it's built in the separate step above,
         # so it stays fully static for portability across musl distros.
+        #
+        # Set RUSTFLAGS only for musl: an empty RUSTFLAGS is not a no-op — Cargo
+        # treats it as an override that discards any `rustflags` from
+        # `.cargo/config.toml`, so we leave it unset on every other target.
+        shell: bash
         env:
-          RUSTFLAGS: ${{ contains(matrix.target, 'musl') && '-C target-feature=-crt-static' || '' }}
-        run: cross build -p pacquet-napi --profile napi-release --target=${{ matrix.target }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          if [[ "$TARGET" == *musl* ]]; then
+            export RUSTFLAGS="-C target-feature=-crt-static"
+          fi
+          cross build -p pacquet-napi --profile napi-release --target="$TARGET"
 
       - name: Prepare NAPI addon
         shell: bash

--- a/.github/workflows/pacquet-release-to-npm.yml
+++ b/.github/workflows/pacquet-release-to-npm.yml
@@ -118,6 +118,14 @@ jobs:
         run: cross build -p pacquet-cli --bin pacquet --release --target=${{ matrix.target }}
 
       - name: Build NAPI addon with cross
+        # musl targets enable `crt-static` by default, but a `cdylib` (the
+        # `.node` addon) can't be produced with a statically linked CRT. Disable
+        # it so the addon builds as a shared object that dynamically links musl
+        # libc at load time (this is what napi-rs does for musl prebuilds). The
+        # CLI binary keeps `crt-static` — it's built in the separate step above,
+        # so it stays fully static for portability across musl distros.
+        env:
+          RUSTFLAGS: ${{ contains(matrix.target, 'musl') && '-C target-feature=-crt-static' || '' }}
         run: cross build -p pacquet-napi --profile napi-release --target=${{ matrix.target }}
 
       - name: Prepare NAPI addon


### PR DESCRIPTION
## Summary

The [`Release pnpm (Rust)` workflow](https://github.com/pnpm/pnpm/actions/runs/28856913145/job/85585627178) fails on both musl legs (`linux-x64-musl`, `linux-arm64-musl`) at the **Build NAPI addon with cross** step:

```
error: cannot produce cdylib for `pacquet-napi v0.0.1` as the target
`x86_64-unknown-linux-musl` does not support these crate types
```

musl targets link the CRT statically by default (`crt-static` is on), which is incompatible with the `cdylib` crate type used by the `.node` addon. Because the matrix uses fail-fast, the first musl leg to fail cancels every other target too, so the whole release goes red.

This passes `-C target-feature=-crt-static` when building the addon — but **only for musl targets** — so the addon links dynamically against musl libc at load time. This is exactly how napi-rs builds its own musl prebuilds. The `pacquet` CLI binary is built in a separate step and keeps `crt-static`, so it stays fully static for portability across musl distros.

`cross` forwards `RUSTFLAGS` into its build container by default, so scoping the flag to this step is sufficient and leaves the CLI build untouched.

## Squash Commit Body

```text
The 'Release pnpm (Rust)' workflow failed on the musl legs with
"cannot produce cdylib for pacquet-napi ... as the target
x86_64-unknown-linux-musl does not support these crate types". musl
targets link the CRT statically by default (crt-static), which is
incompatible with the cdylib crate type used by the .node addon.

Pass '-C target-feature=-crt-static' when building the addon, but only
for musl targets, so it links dynamically against musl libc at load
time - matching how napi-rs builds its musl prebuilds. The CLI binary
is built in a separate step and keeps crt-static, so it stays fully
static for portability across musl distros.
```

## Checklist

- [x] The change is CI-only (release workflow); it has no CLI surface, so there is nothing to mirror between the TypeScript CLI and the Rust `pacquet/` port.
- [x] No changeset — this touches no published package.
- [x] No tests — the change is a GitHub Actions workflow and is exercised by the next release run.
- [x] No documentation changes needed.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the release build process for Linux musl targets, helping avoid packaging issues during native addon builds.
  * Updated build settings so musl-compatible releases use the correct Rust compilation flags, while other targets continue unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->