### PR TITLE
fix: honor trustPolicy in pnpm self-update, and recover from unusable cached engine slots

### DIFF
--- a/.changeset/self-update-trust-policy.md
+++ b/.changeset/self-update-trust-policy.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/engine.pm.commands": patch
+"pnpm": patch
+---
+
+`pnpm self-update` now honors `trustPolicy=no-downgrade`. It resolves the target pnpm version against full registry metadata, so it refuses to switch to a version whose supply-chain trust evidence is weaker than an earlier-published one, the same way a regular install does.

--- a/pacquet/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -68,11 +68,8 @@ pub(super) async fn install_pnpm<Reporter: self::Reporter + 'static>(
     if let Some(existing) = find_global_package(&global_pkg_dir, package_name)
         .into_diagnostic()
         .wrap_err("scan global packages")?
-        && installed_version(&existing.install_dir, package_name).as_deref() == Some(version)
+        && reuse_cached_engine(&existing.install_dir, package, version)
     {
-        if package.links_native_binary {
-            link_exe_platform_binary(&existing.install_dir, package_name)?;
-        }
         return Ok(InstallPnpmResult {
             install_dir: existing.install_dir,
             package_name,
@@ -113,6 +110,33 @@ fn installed_version(install_dir: &Path, package_name: &str) -> Option<String> {
     let text = fs::read_to_string(pkg_json).ok()?;
     let value: Value = serde_json::from_str(&text).ok()?;
     value.get("version").and_then(Value::as_str).map(ToString::to_string)
+}
+
+/// Whether an existing global slot at `install_dir` can be reused for
+/// `version` instead of reinstalling: it records the target version and,
+/// for native engines, its wrapper's platform binary relinks cleanly.
+///
+/// The relink is best-effort *on the reuse decision only* — it does not
+/// weaken any check. [`link_exe_platform_binary`]'s wrapper-containment
+/// guard still runs and still refuses to link when the wrapper resolves
+/// outside `install_dir`; on refusal it links nothing. This helper simply
+/// reports that refusal as "not reusable" (returning `false`) instead of
+/// propagating it as a hard error, so the caller falls through to a fresh
+/// install rather than aborting the whole self-update. Nothing from the
+/// rejected slot is linked or executed: the fresh install downloads and
+/// signature-verifies the engine into a new self-contained slot (see
+/// `verify_pnpm_engine_identity` in the `self-update` handler), and the
+/// rejected slot is never returned.
+///
+/// A slot whose wrapper escapes the slot is what an older global-virtual-
+/// store layout legitimately produces (the wrapper symlinks into the
+/// shared `<store>/links` tree), so this recovery is the common upgrade
+/// path, not only an adversarial one.
+fn reuse_cached_engine(install_dir: &Path, package: PnpmPackageToInstall, version: &str) -> bool {
+    if installed_version(install_dir, package.name).as_deref() != Some(version) {
+        return false;
+    }
+    !package.links_native_binary || link_exe_platform_binary(install_dir, package.name).is_ok()
 }
 
 pub(crate) fn pnpm_package_to_install(pnpm_version: &str) -> PnpmPackageToInstall {

--- a/pacquet/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     PNPM_EXE_PACKAGE_NAME, PNPM_PACKAGE_NAME, exe_platform_pkg_dir_name,
     exe_platform_pkg_dir_name_next, link_exe_platform_binary, package_dir, pnpm_package_to_install,
+    reuse_cached_engine,
 };
 use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
 use std::fs;
@@ -170,4 +171,56 @@ fn link_errors_when_the_native_binary_is_missing() {
     fake_engine_install(temp.path(), false);
 
     assert!(link_exe_platform_binary(temp.path(), "pnpm").is_err());
+}
+
+/// Write a wrapper `package.json` recording `version` so
+/// [`super::installed_version`] reads it back.
+fn write_wrapper_version(install_dir: &std::path::Path, wrapper_pkg_name: &str, version: &str) {
+    let manifest = format!(r#"{{"name":"{wrapper_pkg_name}","version":"{version}"}}"#);
+    fs::write(package_dir(install_dir, wrapper_pkg_name).join("package.json"), manifest)
+        .expect("write wrapper package.json");
+}
+
+#[cfg(unix)]
+#[test]
+fn reuse_cached_engine_accepts_a_healthy_slot() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    fake_engine_install_for(temp.path(), PNPM_EXE_PACKAGE_NAME, true);
+    write_wrapper_version(temp.path(), PNPM_EXE_PACKAGE_NAME, "11.10.0");
+
+    assert!(reuse_cached_engine(temp.path(), pnpm_package_to_install("11.10.0"), "11.10.0"));
+    // The relink repaired the slot in place: the native binary is now linked.
+    assert!(package_dir(temp.path(), PNPM_EXE_PACKAGE_NAME).join("pnpm").exists());
+}
+
+#[test]
+fn reuse_cached_engine_rejects_a_version_mismatch() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    fake_engine_install_for(temp.path(), PNPM_EXE_PACKAGE_NAME, true);
+    write_wrapper_version(temp.path(), PNPM_EXE_PACKAGE_NAME, "11.9.0");
+
+    assert!(!reuse_cached_engine(temp.path(), pnpm_package_to_install("11.10.0"), "11.10.0"));
+}
+
+/// A slot left by an older layout whose wrapper symlink escapes the slot
+/// (e.g. into a shared global virtual store) must not be reused — the
+/// caller falls through to a fresh install instead of aborting the whole
+/// self-update on the wrapper-containment guard.
+#[cfg(unix)]
+#[test]
+fn reuse_cached_engine_rejects_a_wrapper_that_escapes_the_slot() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let outside = tempfile::tempdir().expect("outside tempdir");
+    let outside_wrapper = outside.path().join("exe");
+    fs::create_dir_all(&outside_wrapper).expect("create outside wrapper");
+    fs::write(outside_wrapper.join("package.json"), r#"{"name":"@pnpm/exe","version":"11.10.0"}"#)
+        .expect("write outside wrapper manifest");
+
+    fs::create_dir_all(temp.path().join("node_modules").join("@pnpm")).expect("create scope dir");
+    std::os::unix::fs::symlink(&outside_wrapper, package_dir(temp.path(), PNPM_EXE_PACKAGE_NAME))
+        .expect("symlink wrapper outside slot");
+
+    // The recorded version matches, but the wrapper resolves outside the
+    // slot, so the slot is not reusable.
+    assert!(!reuse_cached_engine(temp.path(), pnpm_package_to_install("11.10.0"), "11.10.0"));
 }

--- a/pacquet/crates/cli/src/config_deps.rs
+++ b/pacquet/crates/cli/src/config_deps.rs
@@ -70,6 +70,7 @@ pub async fn sync_package_manager_dependencies(
 
 /// The version `pnpm self-update` resolved a specifier to, plus whether
 /// the pick violated the active maturity/trust policy.
+#[derive(Debug)]
 pub struct ResolvedPnpm {
     pub version: String,
     /// `true` when the resolver picked a version despite the maturity
@@ -80,9 +81,16 @@ pub struct ResolvedPnpm {
 
 /// Resolve `pnpm@<bare_specifier>` against the trusted package-manager
 /// bootstrap registry (never the repository-controlled project
-/// registries), applying the same `minimumReleaseAge` / `trustPolicy`
+/// registries), applying the same `minimumReleaseAge` and `trustPolicy`
 /// gates the install path uses. Returns `None` when the specifier cannot
 /// be resolved. Backs `pacquet self-update`'s "check for updates" probe.
+///
+/// The metadata mode follows [`Config::requires_full_metadata_for_resolution`]
+/// (via [`EnvInstallerContext`]), so under `trustPolicy=no-downgrade` or
+/// `resolutionMode=time-based` the probe fetches the full packument the
+/// trust and maturity checks need — the same resolver behaviour as a
+/// regular install, rather than a self-update-specific abbreviated-metadata
+/// path that would fail closed with "missing time".
 pub async fn resolve_pnpm_version(
     config: &Config,
     bare_specifier: &str,
@@ -92,7 +100,7 @@ pub async fn resolve_pnpm_version(
     // `minimumReleaseAge` cutoff, computed the same way as the install
     // path's `PickPolicy::from_config`. When the age is configured, a
     // failure to compute the cutoff fails closed rather than silently
-    // disabling the maturity gate — self-update is a trust decision.
+    // disabling the maturity gate — self-update is security-sensitive.
     let published_by = match config.resolved_minimum_release_age() {
         Some(minutes) => {
             let minutes = i64::try_from(minutes)
@@ -293,8 +301,14 @@ impl EnvInstallerContext {
             offline: config.offline,
             prefer_offline: config.prefer_offline,
             ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
-            full_metadata: false,
-            filter_metadata: false,
+            // Derive the metadata mode from config exactly as the install
+            // resolver does (via `PickPolicy`), so resolving the pnpm engine
+            // (or a config dependency) under `resolutionMode=time-based` /
+            // `trustPolicy=no-downgrade` fetches the full packument the
+            // `minimumReleaseAge` and trust checks need — instead of failing
+            // closed on abbreviated metadata that omits `time`.
+            full_metadata: config.requires_full_metadata_for_resolution(),
+            filter_metadata: config.requires_full_metadata_for_resolution(),
             retry_opts,
         };
 
@@ -470,3 +484,6 @@ fn hook_logger<Reporter: self::Reporter>(pnpmfile: &Path, prefix: &str) -> LogFn
         }));
     })
 }
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/config_deps/tests.rs
+++ b/pacquet/crates/cli/src/config_deps/tests.rs
@@ -117,6 +117,40 @@ const ABBREVIATED_BODY: &str = r#"{
     }
 }"#;
 
+/// Abbreviated packument that *does* carry `time` — what a registry with
+/// `registrySupportsTimeField=true` serves. It still omits the trust
+/// evidence (`_npmUser` / `dist.attestations`) that no abbreviated
+/// packument carries, so a no-downgrade check run against it would see no
+/// evidence and miss the downgrade.
+const ABBREVIATED_WITH_TIME_BODY: &str = r#"{
+    "name": "pnpm",
+    "dist-tags": { "latest": "1.1.0" },
+    "time": {
+        "1.0.0": "2024-01-10T08:30:00.000Z",
+        "1.1.0": "2024-12-10T08:30:00.000Z"
+    },
+    "versions": {
+        "1.0.0": {
+            "name": "pnpm",
+            "version": "1.0.0",
+            "dist": {
+                "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                "shasum": "0000000000000000000000000000000000000000",
+                "tarball": "https://registry/pnpm-1.0.0.tgz"
+            }
+        },
+        "1.1.0": {
+            "name": "pnpm",
+            "version": "1.1.0",
+            "dist": {
+                "integrity": "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+                "shasum": "1111111111111111111111111111111111111111",
+                "tarball": "https://registry/pnpm-1.1.0.tgz"
+            }
+        }
+    }
+}"#;
+
 fn no_downgrade_config(registry: String, cache_dir: &Path) -> Config {
     let mut config = Config {
         trust_policy: TrustPolicy::NoDowngrade,
@@ -197,4 +231,43 @@ async fn resolve_pnpm_version_resolves_a_clean_update_under_no_downgrade() {
 
     assert_eq!(resolved.version, "1.1.0");
     assert!(!resolved.policy_violation);
+}
+
+/// `registrySupportsTimeField=true` (abbreviated metadata carries `time`)
+/// must NOT let the no-downgrade check settle for abbreviated metadata:
+/// abbreviated still omits the trust evidence, so the check would see none
+/// and miss the downgrade. The probe must fetch full metadata regardless of
+/// `registrySupportsTimeField` and reject the downgrade.
+#[tokio::test]
+async fn resolve_pnpm_version_forces_full_metadata_for_no_downgrade_despite_registry_time_field() {
+    let mut server = mockito::Server::new_async().await;
+    let _full = server
+        .mock("GET", "/pnpm")
+        .match_header("accept", ACCEPT_FULL)
+        .with_status(200)
+        .with_body(FULL_DOWNGRADE_BODY)
+        .create_async()
+        .await;
+    // Abbreviated here carries `time` (as a `registrySupportsTimeField`
+    // registry would) but no trust evidence. If the probe wrongly settled
+    // for it, the downgrade would be missed and resolution would succeed.
+    let _abbreviated = server
+        .mock("GET", "/pnpm")
+        .match_header("accept", ACCEPT_ABBREVIATED)
+        .with_status(200)
+        .with_body(ABBREVIATED_WITH_TIME_BODY)
+        .create_async()
+        .await;
+    let cache_dir = tempfile::TempDir::new().expect("cache tempdir");
+    let mut config = no_downgrade_config(format!("{}/", server.url()), cache_dir.path());
+    config.registry_supports_time_field = true;
+
+    let err = resolve_pnpm_version(&config, "^1.0.0")
+        .await
+        .expect_err("the downgrade must be rejected even with registrySupportsTimeField");
+    let report = format!("{err:?}");
+    assert!(
+        report.contains("trust downgrade"),
+        "expected a trust-downgrade rejection, got: {report}",
+    );
 }

--- a/pacquet/crates/cli/src/config_deps/tests.rs
+++ b/pacquet/crates/cli/src/config_deps/tests.rs
@@ -1,0 +1,200 @@
+use std::path::Path;
+
+use pacquet_config::{Config, TrustPolicy};
+
+use super::resolve_pnpm_version;
+
+/// `Accept` header the resolver sends for full metadata
+/// (`ACCEPT_FULL_DOC`); only the full packument carries the per-version
+/// `time` map and trust evidence the no-downgrade check reads.
+const ACCEPT_FULL: &str = "application/json; q=1.0, */*";
+
+/// `Accept` header the resolver sends for abbreviated metadata
+/// (`ACCEPT_ABBREVIATED_DOC`) — what the probe would use if it did *not*
+/// derive full metadata from the trust policy.
+const ACCEPT_ABBREVIATED: &str =
+    "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*";
+
+/// Full `pnpm` packument: carries the per-version `time` map. `1.0.0` has
+/// stronger trust evidence (`trustedPublisher` + provenance) than the
+/// later `1.1.0` (none) — a trust downgrade the no-downgrade check must
+/// reject once it can see `time`.
+const FULL_DOWNGRADE_BODY: &str = r#"{
+    "name": "pnpm",
+    "dist-tags": { "latest": "1.1.0" },
+    "time": {
+        "1.0.0": "2024-01-10T08:30:00.000Z",
+        "1.1.0": "2024-12-10T08:30:00.000Z"
+    },
+    "versions": {
+        "1.0.0": {
+            "name": "pnpm",
+            "version": "1.0.0",
+            "_npmUser": {
+                "name": "alice",
+                "trustedPublisher": { "id": "github", "oidcConfigId": "release" }
+            },
+            "dist": {
+                "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                "shasum": "0000000000000000000000000000000000000000",
+                "tarball": "https://registry/pnpm-1.0.0.tgz",
+                "attestations": {
+                    "provenance": { "predicateType": "https://slsa.dev/provenance/v1" }
+                }
+            }
+        },
+        "1.1.0": {
+            "name": "pnpm",
+            "version": "1.1.0",
+            "dist": {
+                "integrity": "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+                "shasum": "1111111111111111111111111111111111111111",
+                "tarball": "https://registry/pnpm-1.1.0.tgz"
+            }
+        }
+    }
+}"#;
+
+/// Full `pnpm` packument with no trust downgrade: neither version carries
+/// trust evidence, and `time` is present. Resolving `^1.0.0` picks `1.1.0`
+/// and the no-downgrade check passes.
+const FULL_CLEAN_BODY: &str = r#"{
+    "name": "pnpm",
+    "dist-tags": { "latest": "1.1.0" },
+    "time": {
+        "1.0.0": "2024-01-10T08:30:00.000Z",
+        "1.1.0": "2024-12-10T08:30:00.000Z"
+    },
+    "versions": {
+        "1.0.0": {
+            "name": "pnpm",
+            "version": "1.0.0",
+            "dist": {
+                "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                "shasum": "0000000000000000000000000000000000000000",
+                "tarball": "https://registry/pnpm-1.0.0.tgz"
+            }
+        },
+        "1.1.0": {
+            "name": "pnpm",
+            "version": "1.1.0",
+            "dist": {
+                "integrity": "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+                "shasum": "1111111111111111111111111111111111111111",
+                "tarball": "https://registry/pnpm-1.1.0.tgz"
+            }
+        }
+    }
+}"#;
+
+/// Abbreviated packument: no `time` map. Served only to the abbreviated
+/// `Accept` header, so the probe reaches it only if it *fails* to request
+/// full metadata — in which case the trust check fails closed with
+/// "missing time". A test that instead sees a "trust downgrade" (or a
+/// clean resolve) proves the probe requested full metadata.
+const ABBREVIATED_BODY: &str = r#"{
+    "name": "pnpm",
+    "dist-tags": { "latest": "1.1.0" },
+    "versions": {
+        "1.0.0": {
+            "name": "pnpm",
+            "version": "1.0.0",
+            "dist": {
+                "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                "shasum": "0000000000000000000000000000000000000000",
+                "tarball": "https://registry/pnpm-1.0.0.tgz"
+            }
+        },
+        "1.1.0": {
+            "name": "pnpm",
+            "version": "1.1.0",
+            "dist": {
+                "integrity": "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+                "shasum": "1111111111111111111111111111111111111111",
+                "tarball": "https://registry/pnpm-1.1.0.tgz"
+            }
+        }
+    }
+}"#;
+
+fn no_downgrade_config(registry: String, cache_dir: &Path) -> Config {
+    let mut config = Config {
+        trust_policy: TrustPolicy::NoDowngrade,
+        cache_dir: cache_dir.to_path_buf(),
+        ..Config::default()
+    };
+    config.package_manager_bootstrap.registry = registry;
+    config
+}
+
+/// Under `trustPolicy=no-downgrade`, the self-update probe must resolve
+/// against **full** metadata — the same as a regular install — so the
+/// no-downgrade check actually runs. It reaches the full packument (with
+/// `time`), sees the downgrade, and rejects it. If the probe fetched
+/// abbreviated metadata it would instead fail closed with "missing time";
+/// if it skipped the check it would resolve `1.1.0` with no error.
+#[tokio::test]
+async fn resolve_pnpm_version_fetches_full_metadata_and_rejects_a_downgrade() {
+    let mut server = mockito::Server::new_async().await;
+    let _full = server
+        .mock("GET", "/pnpm")
+        .match_header("accept", ACCEPT_FULL)
+        .with_status(200)
+        .with_body(FULL_DOWNGRADE_BODY)
+        .create_async()
+        .await;
+    let _abbreviated = server
+        .mock("GET", "/pnpm")
+        .match_header("accept", ACCEPT_ABBREVIATED)
+        .with_status(200)
+        .with_body(ABBREVIATED_BODY)
+        .create_async()
+        .await;
+    let cache_dir = tempfile::TempDir::new().expect("cache tempdir");
+    let config = no_downgrade_config(format!("{}/", server.url()), cache_dir.path());
+
+    let err = resolve_pnpm_version(&config, "^1.0.0")
+        .await
+        .expect_err("a trust downgrade must be rejected");
+    let report = format!("{err:?}");
+    assert!(
+        report.contains("trust downgrade"),
+        "expected a trust-downgrade rejection, got: {report}",
+    );
+    assert!(
+        !report.contains("missing time"),
+        "the probe must fetch full metadata, not fail closed on abbreviated: {report}",
+    );
+}
+
+/// A normal (non-downgrade) target still resolves under
+/// `trustPolicy=no-downgrade`: the probe fetches full metadata, the check
+/// passes, and it picks the highest in range.
+#[tokio::test]
+async fn resolve_pnpm_version_resolves_a_clean_update_under_no_downgrade() {
+    let mut server = mockito::Server::new_async().await;
+    let _full = server
+        .mock("GET", "/pnpm")
+        .match_header("accept", ACCEPT_FULL)
+        .with_status(200)
+        .with_body(FULL_CLEAN_BODY)
+        .create_async()
+        .await;
+    let _abbreviated = server
+        .mock("GET", "/pnpm")
+        .match_header("accept", ACCEPT_ABBREVIATED)
+        .with_status(200)
+        .with_body(ABBREVIATED_BODY)
+        .create_async()
+        .await;
+    let cache_dir = tempfile::TempDir::new().expect("cache tempdir");
+    let config = no_downgrade_config(format!("{}/", server.url()), cache_dir.path());
+
+    let resolved = resolve_pnpm_version(&config, "^1.0.0")
+        .await
+        .expect("a clean update must resolve")
+        .expect("a matching pnpm version resolves");
+
+    assert_eq!(resolved.version, "1.1.0");
+    assert!(!resolved.policy_violation);
+}

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1557,18 +1557,27 @@ impl Config {
     /// Whether version resolution must fetch the full packument to obtain
     /// per-version `time` and trust evidence.
     ///
-    /// Full metadata is required when time-based resolution or the
-    /// no-downgrade trust check is active and the registry doesn't already
-    /// serve `time` in its abbreviated metadata. Mirrors pnpm's
-    /// `(time-based || no-downgrade) && !registrySupportsTimeField`. The
-    /// install resolver, `pacquet add`'s pre-resolution, and the
-    /// `self-update` / `pnpm with` engine probe all derive their metadata
-    /// mode from here so none of them can drift.
+    /// The `no-downgrade` trust check reads per-version trust evidence
+    /// (`_npmUser` / `dist.attestations`) that the abbreviated packument
+    /// *never* carries — `registrySupportsTimeField` only concerns the
+    /// `time` field — so it always requires the full packument. Time-based
+    /// resolution needs only `time`, which abbreviated metadata carries
+    /// when the registry advertises it, so it is gated on
+    /// `!registrySupportsTimeField`.
+    ///
+    /// `minimumReleaseAge` is intentionally absent: the resolver upgrades
+    /// abbreviated metadata to full on demand for the maturity check (see
+    /// `maybe_upgrade_abbreviated_meta_for_release_age`), so it doesn't
+    /// need the full packument requested up front.
+    ///
+    /// The install resolver (`PickPolicy`), `pacquet add`'s pre-resolution,
+    /// and the `self-update` / `pnpm with` engine probe all derive their
+    /// metadata mode from here so none of them can drift.
     #[must_use]
     pub fn requires_full_metadata_for_resolution(&self) -> bool {
-        (self.resolution_mode == ResolutionMode::TimeBased
-            || self.trust_policy == TrustPolicy::NoDowngrade)
-            && !self.registry_supports_time_field
+        self.trust_policy == TrustPolicy::NoDowngrade
+            || (self.resolution_mode == ResolutionMode::TimeBased
+                && !self.registry_supports_time_field)
     }
 
     /// Registry map in pnpm's `Registries` shape: `default` plus the

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1554,6 +1554,23 @@ impl Config {
         self.minimum_release_age.filter(|&minutes| minutes > 0)
     }
 
+    /// Whether version resolution must fetch the full packument to obtain
+    /// per-version `time` and trust evidence.
+    ///
+    /// Full metadata is required when time-based resolution or the
+    /// no-downgrade trust check is active and the registry doesn't already
+    /// serve `time` in its abbreviated metadata. Mirrors pnpm's
+    /// `(time-based || no-downgrade) && !registrySupportsTimeField`. The
+    /// install resolver, `pacquet add`'s pre-resolution, and the
+    /// `self-update` / `pnpm with` engine probe all derive their metadata
+    /// mode from here so none of them can drift.
+    #[must_use]
+    pub fn requires_full_metadata_for_resolution(&self) -> bool {
+        (self.resolution_mode == ResolutionMode::TimeBased
+            || self.trust_policy == TrustPolicy::NoDowngrade)
+            && !self.registry_supports_time_field
+    }
+
     /// Registry map in pnpm's `Registries` shape: `default` plus the
     /// configured scoped routes keyed by `@scope`.
     #[must_use]

--- a/pacquet/crates/package-manager/src/resolution_policy.rs
+++ b/pacquet/crates/package-manager/src/resolution_policy.rs
@@ -6,7 +6,7 @@
 
 use chrono::{DateTime, Utc};
 use pacquet_config::{
-    Config, ResolutionMode, TrustPolicy,
+    Config, ResolutionMode,
     version_policy::{PackageVersionPolicy, VersionPolicyError, create_package_version_policy},
 };
 
@@ -75,8 +75,7 @@ impl PickPolicy {
     ) -> Result<Self, VersionPolicyError> {
         let time_based = config.resolution_mode == ResolutionMode::TimeBased;
         let pick_lowest_direct = config.resolution_mode.picks_lowest_direct();
-        let full_metadata = (time_based || config.trust_policy == TrustPolicy::NoDowngrade)
-            && !config.registry_supports_time_field;
+        let full_metadata = config.requires_full_metadata_for_resolution();
         // On overflow we leave the policy inactive for this run — better
         // than silently producing a cutoff in the wrong direction.
         let published_by = config.resolved_minimum_release_age().and_then(|minutes| {

--- a/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
@@ -80,17 +80,16 @@ export async function handler (
     throw new PnpmError('CANT_SELF_UPDATE_IN_COREPACK', 'You should update pnpm with corepack')
   }
   globalInfo('Checking for updates...')
-  // Resolve the engine version exactly as a regular install would: fetch
-  // full metadata when a policy needs the per-version `time` (and trust
-  // evidence), which abbreviated metadata omits. Without this the
-  // `minimumReleaseAge` and `trustPolicy: 'no-downgrade'` checks below fail
-  // closed against real npm. Mirrors the same computation in `dlx`.
+  // Resolve the engine version exactly as a regular install would. The
+  // no-downgrade trust check reads per-version trust evidence (`_npmUser` /
+  // `dist.attestations`) that abbreviated metadata never carries — so it
+  // always needs full metadata, regardless of `registrySupportsTimeField`
+  // (which only concerns the `time` field). Time-based resolution needs
+  // only `time`. `minimumReleaseAge` is handled by the resolver's on-demand
+  // abbreviated→full upgrade, so it isn't requested up front here.
   const fullMetadata = (
-    (
-      opts.resolutionMode === 'time-based' ||
-      opts.trustPolicy === 'no-downgrade' ||
-      Boolean(opts.minimumReleaseAge)
-    ) && !opts.registrySupportsTimeField
+    opts.trustPolicy === 'no-downgrade' ||
+    (opts.resolutionMode === 'time-based' && !opts.registrySupportsTimeField)
   )
   const { resolve: baseResolve } = createResolver({
     ...opts,

--- a/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
@@ -5,7 +5,7 @@ import { linkBins } from '@pnpm/bins.linker'
 import { isExecutedByCorepack, packageManager } from '@pnpm/cli.meta'
 import { docsUrl } from '@pnpm/cli.utils'
 import { type Config, type ConfigContext, parsePackageManager, shouldPersistLockfile, types as allTypes } from '@pnpm/config.reader'
-import { getPublishedByPolicy } from '@pnpm/config.version-policy'
+import { createPackageVersionPolicyOrThrow, getPublishedByPolicy } from '@pnpm/config.version-policy'
 import { PnpmError } from '@pnpm/error'
 import { createResolver, makeResolutionStrict } from '@pnpm/installing.client'
 import { resolvePackageManagerIntegrities } from '@pnpm/installing.env-installer'
@@ -80,9 +80,23 @@ export async function handler (
     throw new PnpmError('CANT_SELF_UPDATE_IN_COREPACK', 'You should update pnpm with corepack')
   }
   globalInfo('Checking for updates...')
+  // Resolve the engine version exactly as a regular install would: fetch
+  // full metadata when a policy needs the per-version `time` (and trust
+  // evidence), which abbreviated metadata omits. Without this the
+  // `minimumReleaseAge` and `trustPolicy: 'no-downgrade'` checks below fail
+  // closed against real npm. Mirrors the same computation in `dlx`.
+  const fullMetadata = (
+    (
+      opts.resolutionMode === 'time-based' ||
+      opts.trustPolicy === 'no-downgrade' ||
+      Boolean(opts.minimumReleaseAge)
+    ) && !opts.registrySupportsTimeField
+  )
   const { resolve: baseResolve } = createResolver({
     ...opts,
     configByUri: opts.configByUri,
+    fullMetadata,
+    filterMetadata: fullMetadata,
     ignoreMissingTimeField: opts.minimumReleaseAgeIgnoreMissingTime,
   })
   // self-update has nowhere to "defer to" either — wrap the resolver
@@ -110,6 +124,15 @@ export async function handler (
     projectDir: opts.dir,
     publishedBy,
     publishedByExclude,
+    // Unlike `dlx` (whose real install re-resolves through the store
+    // controller), this `resolve` is self-update's only version selection,
+    // so the trust policy has to be passed here for the no-downgrade check
+    // to run.
+    trustPolicy: opts.trustPolicy,
+    trustPolicyExclude: opts.trustPolicyExclude
+      ? createPackageVersionPolicyOrThrow(opts.trustPolicyExclude, 'trustPolicyExclude')
+      : undefined,
+    trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
   })
   if (!resolution?.manifest) {
     throw new PnpmError('CANNOT_RESOLVE_PNPM', `Cannot find "${bareSpecifier}" version of pnpm`)

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -294,6 +294,55 @@ test('self-update respects minimumReleaseAge for implicit latest resolution', as
   expect(JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')).packageManager).toBe('pnpm@9.0.0')
 })
 
+test('self-update rejects a trust downgrade under trustPolicy=no-downgrade', async () => {
+  const opts = prepare()
+  const registry = opts.registries.default
+  const now = Date.now()
+  // The earlier 9.0.5 was published with strong trust evidence (trusted
+  // publisher + provenance); the later 9.1.0 has none — a trust downgrade
+  // the no-downgrade policy must refuse to switch to.
+  const metadata = {
+    name: 'pnpm',
+    'dist-tags': { latest: '9.1.0' },
+    time: {
+      '9.0.5': new Date(now - 48 * 60 * 60 * 1000).toISOString(),
+      '9.1.0': new Date(now - 8 * 60 * 60 * 1000).toISOString(),
+    },
+    versions: {
+      '9.0.5': {
+        name: 'pnpm',
+        version: '9.0.5',
+        _npmUser: {
+          name: 'pnpm-bot',
+          trustedPublisher: { id: 'github', oidcConfigId: 'release' },
+        },
+        dist: {
+          shasum: '217063ce3fcbf44f3051666f38b810f1ddefee4a',
+          tarball: `${registry}pnpm/-/pnpm-9.0.5.tgz`,
+          integrity: 'sha512-Z/WHmRapKT5c8FnCOFPVcb6vT3U8cH9AyyK+1fsVeMaq07bEEHzLO6CzW+AD62IaFkcayDbIe+tT+dVLtGEnJA==',
+          attestations: { provenance: { predicateType: 'https://slsa.dev/provenance/v1' } },
+        },
+      },
+      '9.1.0': {
+        name: 'pnpm',
+        version: '9.1.0',
+        dist: {
+          shasum: '217063ce3fcbf44f3051666f38b810f1ddefee4a',
+          tarball: `${registry}pnpm/-/pnpm-9.1.0.tgz`,
+          integrity: 'sha512-Z/WHmRapKT5c8FnCOFPVcb6vT3U8cH9AyyK+1fsVeMaq07bEEHzLO6CzW+AD62IaFkcayDbIe+tT+dVLtGEnJA==',
+        },
+      },
+    },
+  }
+  getMockAgent().get(registry.replace(/\/$/, ''))
+    .intercept({ path: '/pnpm', method: 'GET' })
+    .reply(200, metadata).persist()
+
+  await expect(
+    selfUpdate.handler({ ...opts, trustPolicy: 'no-downgrade' }, [])
+  ).rejects.toThrow(/High-risk trust downgrade/)
+})
+
 test('self-update does not write packageManagerDependencies when package manager onFail is ignore', async () => {
   const opts = prepare({
     devEngines: {


### PR DESCRIPTION
## Summary

Two `pnpm self-update` fixes. The first is cross-stack (TypeScript + pacquet); the second is pacquet-only.

### 1. Honor `trustPolicy=no-downgrade` when resolving the pnpm engine

`pnpm self-update` resolved the target pnpm version with a self-update-specific resolver that fetched **abbreviated** registry metadata (which omits per-version `time`) and, depending on the stack, either crashed or silently skipped the no-downgrade trust check:

- **pacquet** passed `trustPolicy` into the resolve but the resolver was hard-wired to abbreviated metadata, so the check failed closed on every self-update:
  ```
  Error:   × resolve pnpm@12.0.0-alpha.3
    ╰─▶ trust check failed: missing time for version 12.0.0-alpha.3 of pnpm in metadata
  ```
- the **TypeScript CLI** never passed `trustPolicy` into its resolve at all, so `trustPolicy=no-downgrade` was not enforced when picking the pnpm version.

The fix resolves the engine version the same way a regular install does, instead of special-casing self-update — derive the metadata mode from config and pass the trust policy through:

- **pacquet**: added `Config::requires_full_metadata_for_resolution` and use it in both `PickPolicy` (install path) and the env-installer resolver (`resolve_pnpm_version`); restored `trust_policy*` on the resolve options. Under `resolutionMode=time-based` / `trustPolicy=no-downgrade` the probe now fetches the full packument the checks need. `no-downgrade` always fetches full metadata — even when `registrySupportsTimeField` is set — because abbreviated metadata omits the trust evidence (`_npmUser`/`dist.attestations`) the check reads, not just `time`.
- **TypeScript**: compute `fullMetadata` in `selfUpdate.ts` (mirroring `dlx`) and pass `fullMetadata`/`filterMetadata` to `createResolver`; pass `trustPolicy`/`trustPolicyExclude`/`trustPolicyIgnoreAfter` into the `resolve()` call (self-update's `resolve` is its sole version selection, unlike `dlx`, whose real install re-resolves through the store controller).

Tests on both stacks: a trust-downgraded pnpm is rejected under `no-downgrade`, and a clean update still resolves. The pacquet test serves abbreviated metadata (no `time`) to the abbreviated `Accept` header, so it also proves the probe requests full metadata rather than failing closed.

### 2. Recover when a cached engine slot is unusable (pacquet)

`pnpm self-update <= v11` aborted with:
```
Error:   × the installed pnpm wrapper at <slot>/node_modules/@pnpm/exe resolves outside <slot>
```
when an existing global `@pnpm/exe` slot from an older layout symlinks its wrapper outside the per-slot directory (e.g. into the shared global virtual store). On a version cache-hit, `link_exe_platform_binary`'s containment guard rejected the wrapper and the `?` aborted the whole self-update.

The cache-hit relink is now **best-effort**: `reuse_cached_engine` reports a relink failure as "not reusable", so the caller falls through to a fresh, self-contained, signature-verified install instead of aborting. **The containment guard is unchanged** — it still refuses to link a wrapper that escapes the slot, and nothing from the rejected slot is linked or executed.

Both errors were reproduced with the built binary and confirmed fixed. A focused security review of the diff found no newly-introduced vulnerabilities (guards preserved; fresh-install fallback is signature-verified; the no-downgrade gate is now enforced *more* consistently, not less).

## Squash Commit Body

```text
Two pnpm self-update fixes:

1. Honor trustPolicy=no-downgrade when resolving the pnpm engine. Both
   stacks now resolve the engine version like a regular install — deriving
   the metadata mode from config (full metadata under time-based /
   no-downgrade) and passing the trust policy into the resolve — instead of
   a self-update-specific abbreviated-metadata path. Fixes pacquet's "trust
   check failed: missing time" crash and the TypeScript CLI silently not
   enforcing the policy. pacquet centralizes the metadata decision in
   Config::requires_full_metadata_for_resolution, shared with PickPolicy.

2. (pacquet) Reinstall pnpm when a cached engine slot's wrapper resolves
   outside its slot (older global-virtual-store layout). The cache-hit
   native-binary relink is now best-effort: on the containment guard's
   refusal, fall through to a fresh signature-verified install rather than
   aborting self-update. The guard itself is unchanged.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  Fix 1 lands in both stacks. Fix 2 addresses a pacquet-only mechanism
  (the `@pnpm/exe` native-binary relink guard) with no TypeScript
  counterpart.
- [x] Added a changeset (`@pnpm/engine.pm.commands` + `pnpm`, patch) for
  the user-visible self-update trust-policy change.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-4-8).