### PR TITLE
fix: allow standalone pnpm downgrades

### DIFF
--- a/.changeset/standalone-downgrade-pnpm.md
+++ b/.changeset/standalone-downgrade-pnpm.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/global.commands": patch
+"pnpm": patch
+---
+
+Fixed standalone installer downgrades from pnpm v12 to v11.

--- a/pacquet/crates/cli/src/cli_args/global.rs
+++ b/pacquet/crates/cli/src/cli_args/global.rs
@@ -108,12 +108,15 @@ pub async fn handle_global_add<Reporter: self::Reporter + 'static>(
 
         let pkgs = read_installed_packages(&install_dir);
         let aliases = read_direct_dependency_aliases(&install_dir);
+        let aliases_to_replace = replacement_aliases(&aliases);
 
         let bins_to_skip = match check_global_bin_conflicts(
             &global_pkg_dir,
             &global_bin_dir,
             &pkgs,
-            |existing: &GlobalPackageInfo| aliases.iter().any(|alias| existing.has_alias(alias)),
+            |existing: &GlobalPackageInfo| {
+                aliases_to_replace.iter().any(|alias| existing.has_alias(alias))
+            },
         ) {
             Ok(skip) => skip,
             Err(error) => {
@@ -122,7 +125,7 @@ pub async fn handle_global_add<Reporter: self::Reporter + 'static>(
             }
         };
 
-        remove_existing_global_installs(&global_pkg_dir, &global_bin_dir, &aliases)
+        remove_existing_global_installs(&global_pkg_dir, &global_bin_dir, &aliases_to_replace)
             .into_diagnostic()
             .wrap_err("remove existing global installs")?;
 
@@ -428,6 +431,20 @@ fn remove_existing_global_installs(
         remove_group(global_pkg_dir, global_bin_dir, pkg, &protected);
     }
     Ok(())
+}
+
+fn replacement_aliases(aliases: &[String]) -> Vec<String> {
+    const PNPM_CLI_PACKAGE_ALIASES: [&str; 2] = ["pnpm", "@pnpm/exe"];
+
+    let mut expanded = aliases.to_vec();
+    if aliases.iter().any(|alias| PNPM_CLI_PACKAGE_ALIASES.contains(&alias.as_str())) {
+        for alias in PNPM_CLI_PACKAGE_ALIASES {
+            if !expanded.iter().any(|existing| existing == alias) {
+                expanded.push(alias.to_string());
+            }
+        }
+    }
+    expanded
 }
 
 /// Remove a group's bins (except those in `protected`, owned by a surviving

--- a/pacquet/crates/cli/src/cli_args/global.rs
+++ b/pacquet/crates/cli/src/cli_args/global.rs
@@ -115,7 +115,7 @@ pub async fn handle_global_add<Reporter: self::Reporter + 'static>(
             &global_bin_dir,
             &pkgs,
             |existing: &GlobalPackageInfo| {
-                aliases_to_replace.iter().any(|alias| existing.has_alias(alias))
+                should_replace_existing_package(existing, &aliases, &aliases_to_replace)
             },
         ) {
             Ok(skip) => skip,
@@ -125,9 +125,14 @@ pub async fn handle_global_add<Reporter: self::Reporter + 'static>(
             }
         };
 
-        remove_existing_global_installs(&global_pkg_dir, &global_bin_dir, &aliases_to_replace)
-            .into_diagnostic()
-            .wrap_err("remove existing global installs")?;
+        remove_existing_global_installs(
+            &global_pkg_dir,
+            &global_bin_dir,
+            &aliases,
+            &aliases_to_replace,
+        )
+        .into_diagnostic()
+        .wrap_err("remove existing global installs")?;
 
         let cache_hash = create_global_cache_key(&aliases, &registries_with_default(config));
         let hash_link = get_hash_link(&global_pkg_dir, &cache_hash);
@@ -413,11 +418,13 @@ fn remove_existing_global_installs(
     global_pkg_dir: &Path,
     global_bin_dir: &Path,
     aliases: &[String],
+    aliases_to_replace: &[String],
 ) -> std::io::Result<()> {
     let mut to_remove: Vec<GlobalPackageInfo> = Vec::new();
     let mut seen = HashSet::new();
-    for alias in aliases {
+    for alias in aliases_to_replace {
         if let Some(pkg) = find_global_package(global_pkg_dir, alias)?
+            && should_replace_existing_package(&pkg, aliases, aliases_to_replace)
             && seen.insert(pkg.hash.clone())
         {
             to_remove.push(pkg);
@@ -437,7 +444,7 @@ fn replacement_aliases(aliases: &[String]) -> Vec<String> {
     const PNPM_CLI_PACKAGE_ALIASES: [&str; 2] = ["pnpm", "@pnpm/exe"];
 
     let mut expanded = aliases.to_vec();
-    if aliases.iter().any(|alias| PNPM_CLI_PACKAGE_ALIASES.contains(&alias.as_str())) {
+    if aliases.iter().any(|alias| is_pnpm_cli_package_alias(alias)) {
         for alias in PNPM_CLI_PACKAGE_ALIASES {
             if !expanded.iter().any(|existing| existing == alias) {
                 expanded.push(alias.to_string());
@@ -445,6 +452,26 @@ fn replacement_aliases(aliases: &[String]) -> Vec<String> {
         }
     }
     expanded
+}
+
+fn should_replace_existing_package(
+    pkg: &GlobalPackageInfo,
+    aliases: &[String],
+    aliases_to_replace: &[String],
+) -> bool {
+    if aliases.iter().any(|alias| pkg.has_alias(alias)) {
+        return true;
+    }
+    is_pnpm_cli_only_group(pkg) && aliases_to_replace.iter().any(|alias| pkg.has_alias(alias))
+}
+
+fn is_pnpm_cli_only_group(pkg: &GlobalPackageInfo) -> bool {
+    !pkg.dependencies.is_empty()
+        && pkg.dependencies.iter().all(|(alias, _)| is_pnpm_cli_package_alias(alias))
+}
+
+fn is_pnpm_cli_package_alias(alias: &str) -> bool {
+    matches!(alias, "pnpm" | "@pnpm/exe")
 }
 
 /// Remove a group's bins (except those in `protected`, owned by a surviving

--- a/pacquet/crates/cli/src/cli_args/global/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/global/tests.rs
@@ -1,4 +1,4 @@
-use super::{is_windows_drive_path, split_comma_separated};
+use super::{is_windows_drive_path, replacement_aliases, split_comma_separated};
 use std::path::Path;
 
 #[test]
@@ -22,4 +22,18 @@ fn detects_windows_drive_paths() {
     assert!(is_windows_drive_path(r"C:\foo"));
     assert!(is_windows_drive_path("d:/bar"));
     assert!(!is_windows_drive_path("foo"));
+}
+
+#[test]
+fn pnpm_package_aliases_replace_each_other() {
+    assert_eq!(replacement_aliases(&["@pnpm/exe".to_string()]), vec!["@pnpm/exe", "pnpm"]);
+    assert_eq!(replacement_aliases(&["pnpm".to_string()]), vec!["pnpm", "@pnpm/exe"]);
+}
+
+#[test]
+fn unrelated_aliases_are_not_expanded() {
+    assert_eq!(
+        replacement_aliases(&["eslint".to_string(), "typescript".to_string()]),
+        vec!["eslint", "typescript"],
+    );
 }

--- a/pacquet/crates/cli/src/cli_args/global/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/global/tests.rs
@@ -1,5 +1,9 @@
-use super::{is_windows_drive_path, replacement_aliases, split_comma_separated};
-use std::path::Path;
+use super::{
+    is_windows_drive_path, replacement_aliases, should_replace_existing_package,
+    split_comma_separated,
+};
+use pacquet_global::GlobalPackageInfo;
+use std::path::{Path, PathBuf};
 
 #[test]
 fn comma_splits_into_selectors() {
@@ -36,4 +40,44 @@ fn unrelated_aliases_are_not_expanded() {
         replacement_aliases(&["eslint".to_string(), "typescript".to_string()]),
         vec!["eslint", "typescript"],
     );
+}
+
+#[test]
+fn pnpm_alias_equivalence_only_replaces_pnpm_cli_groups() {
+    let aliases = vec!["@pnpm/exe".to_string()];
+    let aliases_to_replace = replacement_aliases(&aliases);
+
+    assert!(should_replace_existing_package(
+        &global_package(&["pnpm"]),
+        &aliases,
+        &aliases_to_replace,
+    ));
+    assert!(!should_replace_existing_package(
+        &global_package(&["pnpm", "eslint"]),
+        &aliases,
+        &aliases_to_replace,
+    ));
+}
+
+#[test]
+fn exact_aliases_still_replace_mixed_groups() {
+    let aliases = vec!["@pnpm/exe".to_string()];
+    let aliases_to_replace = replacement_aliases(&aliases);
+
+    assert!(should_replace_existing_package(
+        &global_package(&["@pnpm/exe", "eslint"]),
+        &aliases,
+        &aliases_to_replace,
+    ));
+}
+
+fn global_package(aliases: &[&str]) -> GlobalPackageInfo {
+    GlobalPackageInfo {
+        hash: "hash".to_string(),
+        install_dir: PathBuf::from("/global/hash"),
+        dependencies: aliases
+            .iter()
+            .map(|alias| ((*alias).to_string(), "1.0.0".to_string()))
+            .collect(),
+    }
 }

--- a/pnpm11/global/commands/src/globalAdd.ts
+++ b/pnpm11/global/commands/src/globalAdd.ts
@@ -160,7 +160,7 @@ async function installGroup (
   }
 
   // Remove any existing global installations of these aliases
-  await removeExistingGlobalInstalls(globalDir, globalBinDir, aliases, replacementAliases)
+  await removeExistingGlobalInstalls({ globalDir, globalBinDir, aliases, replacementAliases })
 
   // Compute cache key and create hash symlink pointing to install dir
   const cacheHash = createGlobalCacheKey({
@@ -248,11 +248,15 @@ function resolveLocalParam (param: string, baseDir: string): string {
 }
 
 async function removeExistingGlobalInstalls (
-  globalDir: string,
-  globalBinDir: string,
-  aliases: string[],
-  replacementAliases: string[]
+  opts: {
+    globalDir: string
+    globalBinDir: string
+    aliases: string[]
+    replacementAliases: string[]
+  }
 ): Promise<void> {
+  const { globalDir, globalBinDir, aliases, replacementAliases } = opts
+
   // Collect unique groups to remove (dedup by hash)
   const groupsToRemove = new Map<string, ReturnType<typeof getInstalledBinNames>>()
   for (const alias of replacementAliases) {

--- a/pnpm11/global/commands/src/globalAdd.ts
+++ b/pnpm11/global/commands/src/globalAdd.ts
@@ -140,6 +140,7 @@ async function installGroup (
   // Read resolved aliases from the installed package.json
   const pkgJson = readPackageJsonFromDirRawSync(installDir)
   const aliases = Object.keys(pkgJson.dependencies ?? {})
+  const replacementAliases = getReplacementAliases(aliases)
 
   // Check for bin name conflicts with other global packages
   // (must happen before removeExistingGlobalInstalls so we don't lose existing packages on failure)
@@ -150,7 +151,7 @@ async function installGroup (
       globalDir,
       globalBinDir,
       newPkgs: pkgs,
-      shouldSkip: (pkg) => aliases.some((alias) => alias in pkg.dependencies),
+      shouldSkip: (pkg) => replacementAliases.some((alias) => alias in pkg.dependencies),
     })
   } catch (err) {
     await fs.promises.rm(installDir, { recursive: true, force: true })
@@ -158,7 +159,7 @@ async function installGroup (
   }
 
   // Remove any existing global installations of these aliases
-  await removeExistingGlobalInstalls(globalDir, globalBinDir, aliases)
+  await removeExistingGlobalInstalls(globalDir, globalBinDir, replacementAliases)
 
   // Compute cache key and create hash symlink pointing to install dir
   const cacheHash = createGlobalCacheKey({
@@ -171,6 +172,13 @@ async function installGroup (
   // Link bins from installed packages into global bin dir
   await linkBinsOfPackages(pkgs, globalBinDir, { excludeBins: binsToSkip })
   await opts.updateResolutionPolicyManifest?.(resolutionPolicyViolations, globalDir)
+}
+
+const PNPM_CLI_PACKAGE_ALIASES = ['pnpm', '@pnpm/exe']
+
+export function getReplacementAliases (aliases: string[]): string[] {
+  if (!aliases.some((alias) => PNPM_CLI_PACKAGE_ALIASES.includes(alias))) return aliases
+  return [...new Set([...aliases, ...PNPM_CLI_PACKAGE_ALIASES])]
 }
 
 function splitCommaSeparated (param: string, baseDir: string): string[] {

--- a/pnpm11/global/commands/src/globalAdd.ts
+++ b/pnpm11/global/commands/src/globalAdd.ts
@@ -12,6 +12,7 @@ import {
   findGlobalPackage,
   getHashLink,
   getInstalledBinNames,
+  type GlobalPackageInfo,
 } from '@pnpm/global.packages'
 import { readPackageJsonFromDirRawSync } from '@pnpm/pkg-manifest.reader'
 import type { CreateStoreControllerOptions } from '@pnpm/store.connection-manager'
@@ -151,7 +152,7 @@ async function installGroup (
       globalDir,
       globalBinDir,
       newPkgs: pkgs,
-      shouldSkip: (pkg) => replacementAliases.some((alias) => alias in pkg.dependencies),
+      shouldSkip: (pkg) => shouldReplaceExistingGlobalInstall(pkg, aliases, replacementAliases),
     })
   } catch (err) {
     await fs.promises.rm(installDir, { recursive: true, force: true })
@@ -159,7 +160,7 @@ async function installGroup (
   }
 
   // Remove any existing global installations of these aliases
-  await removeExistingGlobalInstalls(globalDir, globalBinDir, replacementAliases)
+  await removeExistingGlobalInstalls(globalDir, globalBinDir, aliases, replacementAliases)
 
   // Compute cache key and create hash symlink pointing to install dir
   const cacheHash = createGlobalCacheKey({
@@ -179,6 +180,20 @@ const PNPM_CLI_PACKAGE_ALIASES = ['pnpm', '@pnpm/exe']
 export function getReplacementAliases (aliases: string[]): string[] {
   if (!aliases.some((alias) => PNPM_CLI_PACKAGE_ALIASES.includes(alias))) return aliases
   return [...new Set([...aliases, ...PNPM_CLI_PACKAGE_ALIASES])]
+}
+
+export function shouldReplaceExistingGlobalInstall (
+  pkg: GlobalPackageInfo,
+  aliases: string[],
+  replacementAliases: string[]
+): boolean {
+  if (aliases.some((alias) => alias in pkg.dependencies)) return true
+  return isPnpmCliOnlyGroup(pkg) && replacementAliases.some((alias) => alias in pkg.dependencies)
+}
+
+function isPnpmCliOnlyGroup (pkg: GlobalPackageInfo): boolean {
+  const aliases = Object.keys(pkg.dependencies)
+  return aliases.length > 0 && aliases.every((alias) => PNPM_CLI_PACKAGE_ALIASES.includes(alias))
 }
 
 function splitCommaSeparated (param: string, baseDir: string): string[] {
@@ -235,13 +250,18 @@ function resolveLocalParam (param: string, baseDir: string): string {
 async function removeExistingGlobalInstalls (
   globalDir: string,
   globalBinDir: string,
-  aliases: string[]
+  aliases: string[],
+  replacementAliases: string[]
 ): Promise<void> {
   // Collect unique groups to remove (dedup by hash)
   const groupsToRemove = new Map<string, ReturnType<typeof getInstalledBinNames>>()
-  for (const alias of aliases) {
+  for (const alias of replacementAliases) {
     const existing = findGlobalPackage(globalDir, alias)
-    if (existing && !groupsToRemove.has(existing.hash)) {
+    if (
+      existing &&
+      shouldReplaceExistingGlobalInstall(existing, aliases, replacementAliases) &&
+      !groupsToRemove.has(existing.hash)
+    ) {
       groupsToRemove.set(existing.hash, getInstalledBinNames(existing))
     }
   }

--- a/pnpm11/global/commands/test/globalAdd.test.ts
+++ b/pnpm11/global/commands/test/globalAdd.test.ts
@@ -51,7 +51,7 @@ jest.unstable_mockModule('../src/installGlobalPackages.js', () => ({ installGlob
 jest.unstable_mockModule('../src/promptApproveGlobalBuilds.js', () => ({ promptApproveGlobalBuilds }))
 jest.unstable_mockModule('../src/readInstalledPackages.js', () => ({ readInstalledPackages }))
 
-const { getReplacementAliases, handleGlobalAdd } = await import('../src/globalAdd.js')
+const { getReplacementAliases, handleGlobalAdd, shouldReplaceExistingGlobalInstall } = await import('../src/globalAdd.js')
 
 test('global add treats pnpm and @pnpm/exe as replacement aliases', () => {
   expect(getReplacementAliases(['@pnpm/exe'])).toStrictEqual(['@pnpm/exe', 'pnpm'])
@@ -60,6 +60,39 @@ test('global add treats pnpm and @pnpm/exe as replacement aliases', () => {
 
 test('global add does not expand unrelated replacement aliases', () => {
   expect(getReplacementAliases(['eslint', 'typescript'])).toStrictEqual(['eslint', 'typescript'])
+})
+
+test('global add only uses pnpm alias equivalence for pnpm-only existing groups', () => {
+  const aliases = ['@pnpm/exe']
+  const replacementAliases = getReplacementAliases(aliases)
+
+  expect(shouldReplaceExistingGlobalInstall({
+    dependencies: { pnpm: '12.0.0-alpha.2' },
+    hash: 'old-pnpm',
+    installDir: '/global/v11/old-pnpm',
+  }, aliases, replacementAliases)).toBe(true)
+  expect(shouldReplaceExistingGlobalInstall({
+    dependencies: {
+      pnpm: '12.0.0-alpha.2',
+      eslint: '^9.0.0',
+    },
+    hash: 'mixed-group',
+    installDir: '/global/v11/mixed-group',
+  }, aliases, replacementAliases)).toBe(false)
+})
+
+test('global add still replaces exact aliases in mixed existing groups', () => {
+  const aliases = ['@pnpm/exe']
+  const replacementAliases = getReplacementAliases(aliases)
+
+  expect(shouldReplaceExistingGlobalInstall({
+    dependencies: {
+      '@pnpm/exe': 'file:/tmp/pnpm',
+      eslint: '^9.0.0',
+    },
+    hash: 'mixed-exact-group',
+    installDir: '/global/v11/mixed-exact-group',
+  }, aliases, replacementAliases)).toBe(true)
 })
 
 test('global add replaces an existing pnpm install when installing @pnpm/exe', async () => {

--- a/pnpm11/global/commands/test/globalAdd.test.ts
+++ b/pnpm11/global/commands/test/globalAdd.test.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import { expect, jest, test } from '@jest/globals'
 import type { GlobalPackageInfo } from '@pnpm/global.packages'
 import type { DependencyManifest } from '@pnpm/types'
@@ -118,7 +120,7 @@ test('global add replaces an existing pnpm install when installing @pnpm/exe', a
 
   expect(findGlobalPackage).toHaveBeenCalledWith('/global/v11', '@pnpm/exe')
   expect(findGlobalPackage).toHaveBeenCalledWith('/global/v11', 'pnpm')
-  expect(removeBin).toHaveBeenCalledWith('/global/bin/pnpm')
+  expect(removeBin).toHaveBeenCalledWith(path.join('/global/bin', 'pnpm'))
   expect(symlinkDir).toHaveBeenCalledWith('/global/v11/new', '/global/v11/new-hash', { overwrite: true })
   expect(linkBinsOfPackages).toHaveBeenCalledWith([], '/global/bin', { excludeBins: new Set() })
 })

--- a/pnpm11/global/commands/test/globalAdd.test.ts
+++ b/pnpm11/global/commands/test/globalAdd.test.ts
@@ -1,0 +1,91 @@
+import { expect, jest, test } from '@jest/globals'
+import type { GlobalPackageInfo } from '@pnpm/global.packages'
+import type { DependencyManifest } from '@pnpm/types'
+
+type CheckGlobalBinConflictsOptions = {
+  globalDir: string
+  globalBinDir: string
+  newPkgs: Array<{ manifest: DependencyManifest, location: string }>
+  shouldSkip: (pkg: GlobalPackageInfo) => boolean
+}
+
+const linkBinsOfPackages = jest.fn<(pkgs: unknown[], globalBinDir: string, opts: { excludeBins: Set<string> }) => Promise<void>>().mockResolvedValue(undefined)
+const removeBin = jest.fn<(cmd: string) => Promise<void>>().mockResolvedValue(undefined)
+const cleanOrphanedInstallDirs = jest.fn()
+const createGlobalCacheKey = jest.fn().mockReturnValue('new-hash')
+const createInstallDir = jest.fn().mockReturnValue('/global/v11/new')
+const findGlobalPackage = jest.fn<(globalDir: string, alias: string) => GlobalPackageInfo | null>()
+const getHashLink = jest.fn((globalDir: string, hash: string) => `${globalDir}/${hash}`)
+const getInstalledBinNames = jest.fn<() => Promise<string[]>>().mockResolvedValue(['pnpm'])
+const scanGlobalPackages = jest.fn().mockReturnValue([])
+const readPackageJsonFromDirRawSync = jest.fn().mockReturnValue({
+  dependencies: { '@pnpm/exe': 'file:/tmp/pnpm' },
+})
+const checkGlobalBinConflicts = jest.fn<(opts: CheckGlobalBinConflictsOptions) => Promise<Set<string>>>().mockResolvedValue(new Set())
+const installGlobalPackages = jest.fn<(...args: unknown[]) => Promise<{ ignoredBuilds: undefined, resolutionPolicyViolations: [] }>>()
+  .mockResolvedValue({ ignoredBuilds: undefined, resolutionPolicyViolations: [] })
+const promptApproveGlobalBuilds = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
+const readInstalledPackages = jest.fn<() => Promise<[]>>().mockResolvedValue([])
+const summaryDebug = jest.fn()
+const symlinkDir = jest.fn<(src: string, dest: string, opts: { overwrite: boolean }) => Promise<void>>().mockResolvedValue(undefined)
+
+jest.unstable_mockModule('@pnpm/bins.linker', () => ({ linkBinsOfPackages }))
+jest.unstable_mockModule('@pnpm/bins.remover', () => ({ removeBin }))
+jest.unstable_mockModule('@pnpm/core-loggers', () => ({ summaryLogger: { debug: summaryDebug } }))
+jest.unstable_mockModule('@pnpm/global.packages', () => ({
+  cleanOrphanedInstallDirs,
+  createGlobalCacheKey,
+  createInstallDir,
+  findGlobalPackage,
+  getHashLink,
+  getInstalledBinNames,
+  scanGlobalPackages,
+}))
+jest.unstable_mockModule('@pnpm/pkg-manifest.reader', () => ({
+  readPackageJsonFromDirRawSync,
+}))
+jest.unstable_mockModule('is-subdir', () => ({ isSubdir: () => true }))
+jest.unstable_mockModule('symlink-dir', () => ({ symlinkDir }))
+jest.unstable_mockModule('../src/checkGlobalBinConflicts.js', () => ({ checkGlobalBinConflicts }))
+jest.unstable_mockModule('../src/installGlobalPackages.js', () => ({ installGlobalPackages }))
+jest.unstable_mockModule('../src/promptApproveGlobalBuilds.js', () => ({ promptApproveGlobalBuilds }))
+jest.unstable_mockModule('../src/readInstalledPackages.js', () => ({ readInstalledPackages }))
+
+const { getReplacementAliases, handleGlobalAdd } = await import('../src/globalAdd.js')
+
+test('global add treats pnpm and @pnpm/exe as replacement aliases', () => {
+  expect(getReplacementAliases(['@pnpm/exe'])).toStrictEqual(['@pnpm/exe', 'pnpm'])
+  expect(getReplacementAliases(['pnpm'])).toStrictEqual(['pnpm', '@pnpm/exe'])
+})
+
+test('global add does not expand unrelated replacement aliases', () => {
+  expect(getReplacementAliases(['eslint', 'typescript'])).toStrictEqual(['eslint', 'typescript'])
+})
+
+test('global add replaces an existing pnpm install when installing @pnpm/exe', async () => {
+  const existingPnpm = {
+    dependencies: { pnpm: '12.0.0-alpha.2' },
+    hash: 'old-pnpm',
+    installDir: '/global/v11/old-pnpm',
+  }
+  findGlobalPackage.mockImplementation((_globalDir: string, alias: string) => {
+    return alias === 'pnpm' ? existingPnpm : null
+  })
+  checkGlobalBinConflicts.mockImplementation(async (opts) => {
+    expect(opts.shouldSkip(existingPnpm)).toBe(true)
+    return new Set()
+  })
+
+  await handleGlobalAdd({
+    bin: '/global/bin',
+    dir: '/project',
+    globalPkgDir: '/global/v11',
+    registries: {},
+  } as any, ['file:/tmp/pnpm'], {}) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  expect(findGlobalPackage).toHaveBeenCalledWith('/global/v11', '@pnpm/exe')
+  expect(findGlobalPackage).toHaveBeenCalledWith('/global/v11', 'pnpm')
+  expect(removeBin).toHaveBeenCalledWith('/global/bin/pnpm')
+  expect(symlinkDir).toHaveBeenCalledWith('/global/v11/new', '/global/v11/new-hash', { overwrite: true })
+  expect(linkBinsOfPackages).toHaveBeenCalledWith([], '/global/bin', { excludeBins: new Set() })
+})


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Allows standalone installs to replace an existing global pnpm entry when the package identity changes between `pnpm` and `@pnpm/exe`. This fixes downgrading from pnpm v12 to pnpm v11 through the standalone installer without weakening bin-conflict checks for unrelated global packages.

The same replacement alias handling is mirrored in pacquet.

## Squash Commit Body

```text
Treat pnpm and `@pnpm/exe` as equivalent replacement aliases during isolated global installs.

The standalone installer for pnpm v11 installs the downloaded binary as a local `@pnpm/exe` package, while pnpm v12 records the global CLI as `pnpm`. Before this change, the global bin conflict check saw both packages as distinct owners of the `pnpm` bin and failed before the existing install could be removed.

Expand the replacement alias set only for the pnpm-managed package pair before conflict checking and removal. The install still hashes and records the actual resolved aliases, and unrelated bin conflicts continue to fail.

Mirror the same behavior in pacquet.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed standalone installer downgrades when moving from pnpm v12 to v11.
  * Improved global install conflict handling for pnpm CLI alias variants, so switching between `pnpm` and `@pnpm/exe` replaces the correct existing global install.
* **Tests**
  * Added/expanded unit and Jest coverage for pnpm alias expansion and replacement behavior, including bin-conflict scenarios during global add operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->