### PR TITLE
fix(pacquet): support pnpm repo CI scripts

### DIFF
--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -156,13 +156,13 @@ pub struct CliArgs {
 impl CliArgs {
     pub fn validate_command_scoped_global_options(&self) -> Result<(), clap::Error> {
         if self.resume_from.is_some() {
-            self.validate_script_scoped_global_option("--resume-from")?;
+            self.validate_run_scoped_global_option("--resume-from")?;
         }
         if self.report_summary {
-            self.validate_script_scoped_global_option("--report-summary")?;
+            self.validate_report_summary_global_option()?;
         }
         if self.no_bail {
-            self.validate_script_scoped_global_option("--no-bail")?;
+            self.validate_run_scoped_global_option("--no-bail")?;
         }
         Ok(())
     }
@@ -181,15 +181,27 @@ impl CliArgs {
         }
     }
 
-    fn validate_script_scoped_global_option(&self, option: &str) -> Result<(), clap::Error> {
+    fn validate_run_scoped_global_option(&self, option: &str) -> Result<(), clap::Error> {
         if matches!(
             self.command,
-            CliCommand::Run(_) | CliCommand::Exec(_) | CliCommand::External(_),
+            CliCommand::Run(_)
+                | CliCommand::Exec(_)
+                | CliCommand::External(_)
+                | CliCommand::Test
+                | CliCommand::Start
+                | CliCommand::Stop(_),
         ) {
             return Ok(());
         }
         Err(Self::command()
             .error(ErrorKind::UnknownArgument, format!("unexpected argument '{option}' found")))
+    }
+
+    fn validate_report_summary_global_option(&self) -> Result<(), clap::Error> {
+        if matches!(self.command, CliCommand::Publish(_)) {
+            return Ok(());
+        }
+        self.validate_run_scoped_global_option("--report-summary")
     }
 }
 

--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -127,6 +127,30 @@ pub struct CliArgs {
     /// [`pacquet_config::Config::filter_prod`].
     #[clap(long = "filter-prod", global = true)]
     pub filter_prod: Vec<String>,
+
+    /// Keep recursive workspace projects sorted topologically.
+    #[clap(long = "sort", global = true, overrides_with = "no_sort")]
+    pub sort: bool,
+
+    /// Run recursive workspace projects in workspace order.
+    #[clap(long = "no-sort", global = true, overrides_with = "sort")]
+    pub no_sort: bool,
+
+    /// Maximum number of workspace projects to process in parallel.
+    #[clap(long = "workspace-concurrency", global = true)]
+    pub workspace_concurrency: Option<i32>,
+
+    /// Recursive only: resume execution from the given package.
+    #[clap(long = "resume-from", global = true)]
+    pub resume_from: Option<String>,
+
+    /// Recursive only: write a `pnpm-exec-summary.json` execution report.
+    #[clap(long = "report-summary", global = true)]
+    pub report_summary: bool,
+
+    /// Recursive only: keep going after a project fails.
+    #[clap(long = "no-bail", global = true)]
+    pub no_bail: bool,
 }
 
 impl CliArgs {

--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -54,7 +54,7 @@ use super::{
     why::WhyArgs,
     with::WithArgs,
 };
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand, error::ErrorKind};
 use pacquet_default_reporter::SummaryScope;
 use std::path::PathBuf;
 
@@ -141,19 +141,32 @@ pub struct CliArgs {
     pub workspace_concurrency: Option<i32>,
 
     /// Recursive only: resume execution from the given package.
-    #[clap(long = "resume-from", global = true)]
+    #[clap(long = "resume-from", global = true, hide = true)]
     pub resume_from: Option<String>,
 
     /// Recursive only: write a `pnpm-exec-summary.json` execution report.
-    #[clap(long = "report-summary", global = true)]
+    #[clap(long = "report-summary", global = true, hide = true)]
     pub report_summary: bool,
 
     /// Recursive only: keep going after a project fails.
-    #[clap(long = "no-bail", global = true)]
+    #[clap(long = "no-bail", global = true, hide = true)]
     pub no_bail: bool,
 }
 
 impl CliArgs {
+    pub fn validate_command_scoped_global_options(&self) -> Result<(), clap::Error> {
+        if self.resume_from.is_some() {
+            self.validate_script_scoped_global_option("--resume-from")?;
+        }
+        if self.report_summary {
+            self.validate_script_scoped_global_option("--report-summary")?;
+        }
+        if self.no_bail {
+            self.validate_script_scoped_global_option("--no-bail")?;
+        }
+        Ok(())
+    }
+
     /// Promote the command to recursive mode when a `--filter` /
     /// `--filter-prod` selector is present, even without an explicit
     /// `-r` / `--recursive`.
@@ -166,6 +179,17 @@ impl CliArgs {
         if !self.filter.is_empty() || !self.filter_prod.is_empty() {
             self.recursive = true;
         }
+    }
+
+    fn validate_script_scoped_global_option(&self, option: &str) -> Result<(), clap::Error> {
+        if matches!(
+            self.command,
+            CliCommand::Run(_) | CliCommand::Exec(_) | CliCommand::External(_),
+        ) {
+            return Ok(());
+        }
+        Err(Self::command()
+            .error(ErrorKind::UnknownArgument, format!("unexpected argument '{option}' found")))
     }
 }
 

--- a/pacquet/crates/cli/src/cli_args/dispatch.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch.rs
@@ -29,6 +29,10 @@ pub(crate) struct RunCtx<'a> {
     pub(crate) manifest_path: &'a Path,
     pub(crate) reporter: ReporterType,
     pub(crate) recursive: bool,
+    pub(crate) recursive_resume_from: Option<&'a str>,
+    pub(crate) recursive_report_summary: bool,
+    pub(crate) recursive_no_bail: bool,
+    pub(crate) recursive_sort: bool,
     pub(crate) config: &'a (dyn Fn() -> miette::Result<&'static mut Config> + Sync),
     /// Like [`Self::config`] but anchored at the pnpm home dir instead of
     /// `--dir`, so a `-g` install can't inherit the caller project's
@@ -118,6 +122,12 @@ impl CliArgs {
             version: _,
             color: _,
             yes: _,
+            sort: _,
+            no_sort,
+            workspace_concurrency,
+            resume_from,
+            report_summary,
+            no_bail,
         } = self;
 
         // Canonicalize `--dir` so the bunyan-envelope `prefix` emitted by
@@ -181,6 +191,10 @@ impl CliArgs {
                     cfg.recursive = recursive;
                     cfg.filter.clone_from(&filter);
                     cfg.filter_prod.clone_from(&filter_prod);
+                    if let Some(workspace_concurrency) = workspace_concurrency {
+                        cfg.workspace_concurrency =
+                            pacquet_config::resolve_child_concurrency(Some(workspace_concurrency));
+                    }
                     Config::leak(cfg)
                 })
                 .map_err(miette::Report::new)
@@ -218,6 +232,10 @@ impl CliArgs {
             manifest_path: &manifest_path,
             reporter,
             recursive,
+            recursive_resume_from: resume_from.as_deref(),
+            recursive_report_summary: report_summary,
+            recursive_no_bail: no_bail,
+            recursive_sort: !no_sort,
             config: &config,
             global_config: &global_config,
             state: &state,

--- a/pacquet/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_query.rs
@@ -202,11 +202,12 @@ pub(super) fn pack<'a>(ctx: &RunCtx<'a>, args: &PackArgs) -> miette::Result<Comm
 /// boxed [`CommandFuture`] not `Send`.
 pub(super) fn publish<'a>(
     ctx: &RunCtx<'a>,
-    args: PublishArgs,
+    mut args: PublishArgs,
 ) -> miette::Result<CommandFuture<'a>> {
     let config = (ctx.config)()?;
     let dir = ctx.dir;
     let recursive = ctx.recursive;
+    args.report_summary |= ctx.recursive_report_summary;
     Ok(match ctx.reporter {
         ReporterType::Default | ReporterType::AppendOnly => {
             Box::pin(args.run::<DefaultReporter>(dir, config, recursive))

--- a/pacquet/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_script.rs
@@ -38,6 +38,7 @@ pub(super) fn test<'a>(ctx: &RunCtx<'a>) -> miette::Result<CommandFuture<'a>> {
 }
 
 pub(super) fn run<'a>(ctx: &RunCtx<'a>, args: RunArgs) -> miette::Result<CommandFuture<'a>> {
+    let args = with_recursive_run_options(ctx, args);
     if ctx.recursive {
         args.run_recursive((ctx.config)()?, ctx.dir)?;
     } else {
@@ -58,7 +59,9 @@ pub(super) fn fallback<'a>(
         resume_from: None,
         report_summary: false,
         no_bail: false,
+        sort: true,
     };
+    let args = with_recursive_run_options(ctx, args);
     if ctx.recursive {
         args.run_recursive((ctx.config)()?, ctx.dir)?;
     } else {
@@ -68,12 +71,29 @@ pub(super) fn fallback<'a>(
 }
 
 pub(super) fn exec<'a>(ctx: &RunCtx<'a>, args: ExecArgs) -> miette::Result<CommandFuture<'a>> {
+    let args = with_recursive_exec_options(ctx, args);
     if ctx.recursive {
         args.run_recursive((ctx.config)()?, ctx.dir)?;
     } else {
         args.run(ctx.dir, (ctx.config)()?)?;
     }
     Ok(Box::pin(std::future::ready(Ok(()))))
+}
+
+fn with_recursive_run_options(ctx: &RunCtx<'_>, mut args: RunArgs) -> RunArgs {
+    args.resume_from = ctx.recursive_resume_from.map(str::to_string);
+    args.report_summary = ctx.recursive_report_summary;
+    args.no_bail = ctx.recursive_no_bail;
+    args.sort = ctx.recursive_sort;
+    args
+}
+
+fn with_recursive_exec_options(ctx: &RunCtx<'_>, mut args: ExecArgs) -> ExecArgs {
+    args.resume_from = ctx.recursive_resume_from.map(str::to_string);
+    args.report_summary = ctx.recursive_report_summary;
+    args.no_bail = ctx.recursive_no_bail;
+    args.sort = ctx.recursive_sort;
+    args
 }
 
 pub(super) fn start<'a>(ctx: &RunCtx<'a>) -> miette::Result<CommandFuture<'a>> {

--- a/pacquet/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_script.rs
@@ -8,9 +8,7 @@ use super::{
     stop::StopArgs,
 };
 use miette::Context;
-use pacquet_executor::execute_shell;
 use pacquet_package_manifest::PackageManifest;
-use pacquet_workspace::read_project_manifest_only;
 
 pub(super) fn init<'a>(ctx: &RunCtx<'a>) -> miette::Result<CommandFuture<'a>> {
     let result = PackageManifest::init(ctx.manifest_path).wrap_err("initialize package.json");
@@ -29,12 +27,7 @@ pub(super) fn set_script<'a>(
 }
 
 pub(super) fn test<'a>(ctx: &RunCtx<'a>) -> miette::Result<CommandFuture<'a>> {
-    let manifest = read_project_manifest_only(ctx.dir)
-        .wrap_err("getting the package manifest in current directory")?;
-    if let Some(script) = manifest.script("test", false)? {
-        execute_shell(script).wrap_err(format!(r#"executing command: "{script}""#))?;
-    }
-    Ok(Box::pin(std::future::ready(Ok(()))))
+    run(ctx, run_args_for_script("test"))
 }
 
 pub(super) fn run<'a>(ctx: &RunCtx<'a>, args: RunArgs) -> miette::Result<CommandFuture<'a>> {
@@ -97,16 +90,16 @@ fn with_recursive_exec_options(ctx: &RunCtx<'_>, mut args: ExecArgs) -> ExecArgs
 }
 
 pub(super) fn start<'a>(ctx: &RunCtx<'a>) -> miette::Result<CommandFuture<'a>> {
-    let manifest = read_project_manifest_only(ctx.dir)
-        .wrap_err("getting the package manifest in current directory")?;
-    let command = manifest.script("start", true)?.unwrap_or("node server.js");
-    execute_shell(command).wrap_err(format!(r#"executing command: "{command}""#))?;
-    Ok(Box::pin(std::future::ready(Ok(()))))
+    run(ctx, run_args_for_script("start"))
 }
 
 pub(super) fn stop<'a>(ctx: &RunCtx<'a>, args: StopArgs) -> miette::Result<CommandFuture<'a>> {
-    args.run(ctx.dir, (ctx.config)()?, matches!(ctx.reporter, ReporterType::Silent))?;
-    Ok(Box::pin(std::future::ready(Ok(()))))
+    if ctx.recursive {
+        run(ctx, args.into_run_args())
+    } else {
+        args.run(ctx.dir, (ctx.config)()?, matches!(ctx.reporter, ReporterType::Silent))?;
+        Ok(Box::pin(std::future::ready(Ok(()))))
+    }
 }
 
 pub(super) fn restart<'a>(
@@ -115,4 +108,16 @@ pub(super) fn restart<'a>(
 ) -> miette::Result<CommandFuture<'a>> {
     args.run(ctx.dir, (ctx.config)()?, matches!(ctx.reporter, ReporterType::Silent))?;
     Ok(Box::pin(std::future::ready(Ok(()))))
+}
+
+fn run_args_for_script(command: &str) -> RunArgs {
+    RunArgs {
+        command: Some(command.to_string()),
+        args: Vec::new(),
+        if_present: false,
+        resume_from: None,
+        report_summary: false,
+        no_bail: false,
+        sort: true,
+    }
 }

--- a/pacquet/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_script.rs
@@ -10,6 +10,7 @@ use super::{
 use miette::Context;
 use pacquet_executor::execute_shell;
 use pacquet_package_manifest::PackageManifest;
+use pacquet_workspace::read_project_manifest_only;
 
 pub(super) fn init<'a>(ctx: &RunCtx<'a>) -> miette::Result<CommandFuture<'a>> {
     let result = PackageManifest::init(ctx.manifest_path).wrap_err("initialize package.json");
@@ -28,8 +29,8 @@ pub(super) fn set_script<'a>(
 }
 
 pub(super) fn test<'a>(ctx: &RunCtx<'a>) -> miette::Result<CommandFuture<'a>> {
-    let manifest = PackageManifest::from_path(ctx.manifest_path.to_path_buf())
-        .wrap_err("getting the package.json in current directory")?;
+    let manifest = read_project_manifest_only(ctx.dir)
+        .wrap_err("getting the package manifest in current directory")?;
     if let Some(script) = manifest.script("test", false)? {
         execute_shell(script).wrap_err(format!(r#"executing command: "{script}""#))?;
     }
@@ -76,8 +77,8 @@ pub(super) fn exec<'a>(ctx: &RunCtx<'a>, args: ExecArgs) -> miette::Result<Comma
 }
 
 pub(super) fn start<'a>(ctx: &RunCtx<'a>) -> miette::Result<CommandFuture<'a>> {
-    let manifest = PackageManifest::from_path(ctx.manifest_path.to_path_buf())
-        .wrap_err("getting the package.json in current directory")?;
+    let manifest = read_project_manifest_only(ctx.dir)
+        .wrap_err("getting the package manifest in current directory")?;
     let command = manifest.script("start", true)?.unwrap_or("node server.js");
     execute_shell(command).wrap_err(format!(r#"executing command: "{command}""#))?;
     Ok(Box::pin(std::future::ready(Ok(()))))

--- a/pacquet/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_script.rs
@@ -27,7 +27,7 @@ pub(super) fn set_script<'a>(
 }
 
 pub(super) fn test<'a>(ctx: &RunCtx<'a>) -> miette::Result<CommandFuture<'a>> {
-    run(ctx, run_args_for_script("test"))
+    run(ctx, run_args_for_script("test", true))
 }
 
 pub(super) fn run<'a>(ctx: &RunCtx<'a>, args: RunArgs) -> miette::Result<CommandFuture<'a>> {
@@ -90,7 +90,7 @@ fn with_recursive_exec_options(ctx: &RunCtx<'_>, mut args: ExecArgs) -> ExecArgs
 }
 
 pub(super) fn start<'a>(ctx: &RunCtx<'a>) -> miette::Result<CommandFuture<'a>> {
-    run(ctx, run_args_for_script("start"))
+    run(ctx, run_args_for_script("start", false))
 }
 
 pub(super) fn stop<'a>(ctx: &RunCtx<'a>, args: StopArgs) -> miette::Result<CommandFuture<'a>> {
@@ -110,11 +110,11 @@ pub(super) fn restart<'a>(
     Ok(Box::pin(std::future::ready(Ok(()))))
 }
 
-fn run_args_for_script(command: &str) -> RunArgs {
+fn run_args_for_script(command: &str, if_present: bool) -> RunArgs {
     RunArgs {
         command: Some(command.to_string()),
         args: Vec::new(),
-        if_present: false,
+        if_present,
         resume_from: None,
         report_summary: false,
         no_bail: false,

--- a/pacquet/crates/cli/src/cli_args/exec.rs
+++ b/pacquet/crates/cli/src/cli_args/exec.rs
@@ -6,7 +6,7 @@ use miette::Diagnostic;
 use pacquet_config::Config;
 use pacquet_executor::{push_script_arg, select_shell};
 use pacquet_package_manager::{make_node_package_map_option, package_map_path_for_execution};
-use pacquet_package_manifest::PackageManifest;
+use pacquet_workspace::safe_read_project_manifest_only;
 use std::{
     ffi::{OsStr, OsString},
     path::{Path, PathBuf},
@@ -189,17 +189,12 @@ pub(super) fn spawn_in_dir(
     cmd.status().map_err(|source| ExecError::Spawn { command: command[0].clone(), source })
 }
 
-/// Read the `name` field of the project's `package.json`, if any.
+/// Read the `name` field of the project's package manifest, if any.
 ///
 /// Used only to stamp `PNPM_PACKAGE_NAME`; a missing or nameless manifest
 /// is not an error for `exec` (it can run a command in any directory).
 fn read_package_name(dir: &Path) -> Option<String> {
-    PackageManifest::from_path(dir.join("package.json"))
-        .ok()?
-        .value()
-        .get("name")?
-        .as_str()
-        .map(str::to_string)
+    safe_read_project_manifest_only(dir).ok()??.value().get("name")?.as_str().map(str::to_string)
 }
 
 /// Prepend `dirs` to the current process `PATH`.

--- a/pacquet/crates/cli/src/cli_args/exec.rs
+++ b/pacquet/crates/cli/src/cli_args/exec.rs
@@ -34,18 +34,22 @@ pub struct ExecArgs {
 
     /// Recursive only: resume execution from the given package, skipping
     /// every earlier project in the topological order.
-    #[clap(long = "resume-from")]
+    #[clap(skip)]
     pub resume_from: Option<String>,
 
     /// Recursive only: write a `pnpm-exec-summary.json` execution report
     /// to the workspace root.
-    #[clap(long = "report-summary")]
+    #[clap(skip)]
     pub report_summary: bool,
 
     /// Recursive only: keep going after a project fails instead of
     /// stopping at the first failure.
-    #[clap(long = "no-bail")]
+    #[clap(skip)]
     pub no_bail: bool,
+
+    /// Sort recursive workspace projects topologically before running.
+    #[clap(skip = true)]
+    pub sort: bool,
 }
 
 /// Errors from `pacquet exec`.

--- a/pacquet/crates/cli/src/cli_args/exec/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/exec/recursive.rs
@@ -7,8 +7,9 @@
 //! `config.filter` / `config.filter_prod` (`--filter` / `--filter-prod`,
 //! include and exclude selectors) narrow the selected set via
 //! [`select_recursive_projects`]; the selection is then sorted
-//! topologically and run sequentially. `--workspace-concurrency`
-//! parallelism is not ported yet, matching the recursive `run` runner.
+//! topologically by default, or kept in workspace order under `--no-sort`,
+//! and run sequentially. `--workspace-concurrency` parallelism is not ported
+//! yet, matching the recursive `run` runner.
 
 use super::{ExecArgs, prepare_command, spawn_in_dir};
 use crate::cli_args::recursive::{
@@ -78,12 +79,16 @@ pub fn exec_recursive(args: &ExecArgs, config: &Config, dir: &Path) -> miette::R
         return Ok(());
     }
 
-    let mut chunks = sort_filtered_projects(
-        graph,
-        selection.full_graph(),
-        selection.prod_all.as_ref(),
-        &selection.prod_only_selected,
-    );
+    let mut chunks = if args.sort {
+        sort_filtered_projects(
+            graph,
+            selection.full_graph(),
+            selection.prod_all.as_ref(),
+            &selection.prod_only_selected,
+        )
+    } else {
+        graph.keys().cloned().map(|root| vec![root]).collect()
+    };
     if let Some(resume_from) = &args.resume_from {
         chunks = get_resumed_package_chunks(resume_from, chunks, graph)?;
     }

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -253,20 +253,6 @@ pub struct InstallArgs {
     #[clap(long = "update-checksums")]
     pub update_checksums: bool,
 
-    /// Maximum number of workspace projects to process in parallel.
-    /// Mirrors pnpm's `--workspace-concurrency`. Overrides the
-    /// `workspaceConcurrency` value resolved from `pnpm-workspace.yaml` /
-    /// global `config.yaml` / `PNPM_CONFIG_WORKSPACE_CONCURRENCY` for
-    /// this invocation. A non-positive value is read as
-    /// `parallelism - |value|` (floored at 1). `None` (flag absent)
-    /// leaves the config-resolved value in place.
-    ///
-    /// Applied to [`pacquet_config::Config::workspace_concurrency`] at
-    /// the CLI dispatch in [`crate::cli_args::CliArgs::run`]; see that
-    /// field for why it has no consumption point on `install` yet.
-    #[clap(long = "workspace-concurrency")]
-    pub workspace_concurrency: Option<i32>,
-
     /// Maximum number of concurrent network requests during install.
     /// Mirrors pnpm's `--network-concurrency`; overrides the
     /// `networkConcurrency` value resolved from `pnpm-workspace.yaml` /
@@ -338,7 +324,6 @@ impl InstallArgs {
             trust_lockfile: false,
             no_trust_lockfile: false,
             update_checksums: false,
-            workspace_concurrency: None,
             network_concurrency: None,
             fetch_timeout: None,
             user_agent: None,
@@ -443,7 +428,6 @@ impl InstallArgs {
             trust_lockfile,
             no_trust_lockfile,
             update_checksums,
-            workspace_concurrency: _,
             network_concurrency: _,
             fetch_timeout: _,
             user_agent: _,
@@ -571,19 +555,6 @@ impl InstallArgs {
         .wrap_err("installing dependencies")?;
 
         Ok(())
-    }
-
-    /// Effective `workspaceConcurrency` for this invocation: the
-    /// `--workspace-concurrency` flag when passed (resolved through
-    /// [`pacquet_config::resolve_child_concurrency`], so a non-positive
-    /// value means `parallelism - |value|`, floored at 1), otherwise
-    /// the already-resolved `config_value` from `pnpm-workspace.yaml` /
-    /// global `config.yaml` / `PNPM_CONFIG_WORKSPACE_CONCURRENCY`.
-    pub(crate) fn resolve_workspace_concurrency(&self, config_value: u32) -> u32 {
-        match self.workspace_concurrency {
-            Some(value) => pacquet_config::resolve_child_concurrency(Some(value)),
-            None => config_value,
-        }
     }
 }
 

--- a/pacquet/crates/cli/src/cli_args/install/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/install/tests.rs
@@ -6,7 +6,6 @@ use clap::Parser;
 use pacquet_config::NodeLinker;
 use pacquet_lockfile::{LockfileResolution, TarballResolution};
 use pacquet_package_manifest::DependencyGroup;
-use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
 
 #[test]
@@ -134,53 +133,6 @@ fn frozen_store_flag_parses() {
     let parsed = InstallArgsHarness::try_parse_from(["pacquet-test", "--frozen-store"])
         .expect("parses --frozen-store");
     assert!(parsed.args.frozen_store, "flag present → true");
-}
-
-#[test]
-fn workspace_concurrency_default_is_none() {
-    let parsed = ["pacquet-test"].pipe(InstallArgsHarness::try_parse_from).expect("parses");
-    assert_eq!(parsed.args.workspace_concurrency, None, "flag absent → None");
-}
-
-#[test]
-fn workspace_concurrency_parses_positive() {
-    let parsed = ["pacquet-test", "--workspace-concurrency", "3"]
-        .pipe(InstallArgsHarness::try_parse_from)
-        .expect("parses --workspace-concurrency 3");
-    assert_eq!(parsed.args.workspace_concurrency, Some(3));
-}
-
-#[test]
-fn workspace_concurrency_parses_negative() {
-    let parsed = ["pacquet-test", "--workspace-concurrency=-1"]
-        .pipe(InstallArgsHarness::try_parse_from)
-        .expect("parses --workspace-concurrency=-1");
-    assert_eq!(parsed.args.workspace_concurrency, Some(-1));
-}
-
-#[test]
-fn resolve_workspace_concurrency_keeps_config_value_when_flag_absent() {
-    let args = ["pacquet-test"].pipe(InstallArgsHarness::try_parse_from).expect("parses").args;
-    assert_eq!(args.resolve_workspace_concurrency(7), 7);
-}
-
-#[test]
-fn resolve_workspace_concurrency_positive_flag_overrides_config() {
-    let args = ["pacquet-test", "--workspace-concurrency", "3"]
-        .pipe(InstallArgsHarness::try_parse_from)
-        .expect("parses")
-        .args;
-    assert_eq!(args.resolve_workspace_concurrency(7), 3);
-}
-
-#[test]
-fn resolve_workspace_concurrency_negative_flag_resolves_to_offset() {
-    let args = ["pacquet-test", "--workspace-concurrency=-1"]
-        .pipe(InstallArgsHarness::try_parse_from)
-        .expect("parses")
-        .args;
-    let expected = pacquet_config::available_parallelism().saturating_sub(1).max(1);
-    assert_eq!(args.resolve_workspace_concurrency(7), expected);
 }
 
 /// `NodeLinkerArg::into_config` maps every variant 1:1 to the

--- a/pacquet/crates/cli/src/cli_args/pipelines.rs
+++ b/pacquet/crates/cli/src/cli_args/pipelines.rs
@@ -106,7 +106,6 @@ pub(crate) fn apply_install_cli_config(cfg: &mut Config, args: &InstallArgs) {
         resolve_bool_override(args.frozen_store, args.no_frozen_store, cfg.frozen_store);
     cfg.ignore_scripts =
         resolve_bool_override(args.ignore_scripts, args.no_ignore_scripts, cfg.ignore_scripts);
-    cfg.workspace_concurrency = args.resolve_workspace_concurrency(cfg.workspace_concurrency);
     if let Some(network_concurrency) = args.network_concurrency {
         cfg.network_concurrency = network_concurrency;
     }

--- a/pacquet/crates/cli/src/cli_args/restart.rs
+++ b/pacquet/crates/cli/src/cli_args/restart.rs
@@ -36,6 +36,7 @@ impl RestartArgs {
                 resume_from: None,
                 report_summary: false,
                 no_bail: false,
+                sort: true,
             }
             .run(dir, config, silent)?;
         }

--- a/pacquet/crates/cli/src/cli_args/run.rs
+++ b/pacquet/crates/cli/src/cli_args/run.rs
@@ -5,7 +5,8 @@ use miette::Diagnostic;
 use pacquet_config::Config;
 use pacquet_executor::{RunScript, ScriptsPrependNodePath, run_script};
 use pacquet_package_manager::{make_node_package_map_option, package_map_path_for_execution};
-use pacquet_package_manifest::{PackageManifest, PackageManifestError};
+use pacquet_package_manifest::PackageManifest;
+use pacquet_workspace::{ReadProjectManifestOnlyError, read_project_manifest_only};
 use serde_json::Value;
 use std::{
     collections::HashMap,
@@ -56,7 +57,7 @@ pub struct RunArgs {
 #[non_exhaustive]
 pub enum RunError {
     #[diagnostic(transparent)]
-    Manifest(#[error(source)] PackageManifestError),
+    Manifest(#[error(source)] ReadProjectManifestOnlyError),
 
     #[display("Missing script: {script}")]
     #[diagnostic(code(ERR_PNPM_NO_SCRIPT), help("{hint}"))]
@@ -109,14 +110,15 @@ impl RunArgs {
     ) -> miette::Result<()> {
         let RunArgs { command, args, if_present, .. } = self;
         let Some(script_name) = command else {
-            let manifest =
-                PackageManifest::from_path(dir.join("package.json")).map_err(RunError::Manifest)?;
+            let manifest = read_project_manifest_only(dir).map_err(RunError::Manifest)?;
             println!("{}", render_project_commands(manifest.value()));
             return Ok(());
         };
-        let manifest = match PackageManifest::from_path(dir.join("package.json")) {
+        let manifest = match read_project_manifest_only(dir) {
             Ok(manifest) => manifest,
-            Err(PackageManifestError::NoImporterManifestFound(_)) if fallback_to_exec => {
+            Err(ReadProjectManifestOnlyError::NoImporterManifestFound { .. })
+                if fallback_to_exec =>
+            {
                 return exec_fallback(script_name, args, dir, config);
             }
             Err(err) => return Err(RunError::Manifest(err).into()),

--- a/pacquet/crates/cli/src/cli_args/run.rs
+++ b/pacquet/crates/cli/src/cli_args/run.rs
@@ -234,8 +234,8 @@ pub(super) struct RunContext<'a> {
 /// Resolve `name` to a runnable main script body, or `Ok(None)` when
 /// there's nothing to run (the manifest has no truthy `scripts[name]`
 /// and `name` isn't `start`). An absent (or empty) `start` falls back
-/// to `node server.js` provided `server.js` exists in the process cwd;
-/// otherwise [`RunError::NoScriptOrServer`].
+/// to `node server.js` provided `server.js` exists in the script
+/// execution directory; otherwise [`RunError::NoScriptOrServer`].
 fn resolve_main_script(ctx: &RunContext<'_>, name: &str) -> Result<Option<String>, RunError> {
     let get_script = |key: &str| -> Option<String> {
         ctx.manifest
@@ -249,7 +249,7 @@ fn resolve_main_script(ctx: &RunContext<'_>, name: &str) -> Result<Option<String
     match get_script(name) {
         Some(body) if !body.is_empty() => Ok(Some(body)),
         _ if name == "start" => {
-            if !ctx.init_cwd.join("server.js").exists() {
+            if !ctx.dir.join("server.js").exists() {
                 return Err(RunError::NoScriptOrServer);
             }
             Ok(Some("node server.js".to_string()))

--- a/pacquet/crates/cli/src/cli_args/run.rs
+++ b/pacquet/crates/cli/src/cli_args/run.rs
@@ -34,21 +34,25 @@ pub struct RunArgs {
     /// Run the script starting from the given package, skipping every
     /// package that sorts before it. Only meaningful together with the
     /// global `-r` / `--recursive` flag (the `--resume-from` flag).
-    #[clap(long = "resume-from")]
+    #[clap(skip)]
     pub resume_from: Option<String>,
 
     /// Save the execution result of every package to
     /// `pnpm-exec-summary.json`. Only meaningful together with the
     /// global `-r` / `--recursive` flag (the `--report-summary` flag).
-    #[clap(long = "report-summary")]
+    #[clap(skip)]
     pub report_summary: bool,
 
     /// Keep running the remaining packages after a script fails instead
     /// of aborting on the first failure. Only meaningful together with
     /// the global `-r` / `--recursive` flag (the `--no-bail` flag;
     /// recursive runs bail by default).
-    #[clap(long = "no-bail")]
+    #[clap(skip)]
     pub no_bail: bool,
+
+    /// Sort recursive workspace projects topologically before running.
+    #[clap(skip = true)]
+    pub sort: bool,
 }
 
 /// Errors from `pacquet run`, including the hidden-script rejections from
@@ -208,6 +212,7 @@ fn exec_fallback(
         resume_from: None,
         report_summary: false,
         no_bail: false,
+        sort: true,
     }
     .run(dir, config)
 }

--- a/pacquet/crates/cli/src/cli_args/run/recursive.rs
+++ b/pacquet/crates/cli/src/cli_args/run/recursive.rs
@@ -4,10 +4,11 @@
 //! `config.filter` / `config.filter_prod` (`--filter` / `--filter-prod`,
 //! include and exclude selectors) narrow the selected set via
 //! [`select_recursive_projects`]; the selection is then sorted
-//! topologically (the default) and run sequentially. `--no-sort`,
-//! `--reverse`, `--workspace-concurrency` parallelism, and the `RegExp`
-//! script selector are not supported yet. The main-dispatch auto-exclusion
-//! of the workspace root is applied via [`AutoExcludeRoot::Enabled`].
+//! topologically by default, or kept in workspace order under `--no-sort`,
+//! and run sequentially. `--reverse`, `--workspace-concurrency` parallelism,
+//! and the `RegExp` script selector are not supported yet. The main-dispatch
+//! auto-exclusion of the workspace root is applied via
+//! [`AutoExcludeRoot::Enabled`].
 
 use super::{RunArgs, RunContext, run_stages};
 use crate::cli_args::recursive::{
@@ -94,12 +95,16 @@ pub fn run_recursive(args: &RunArgs, config: &Config, dir: &Path) -> miette::Res
         return Ok(());
     }
 
-    let mut chunks = sort_filtered_projects(
-        graph,
-        selection.full_graph(),
-        selection.prod_all.as_ref(),
-        &selection.prod_only_selected,
-    );
+    let mut chunks = if args.sort {
+        sort_filtered_projects(
+            graph,
+            selection.full_graph(),
+            selection.prod_all.as_ref(),
+            &selection.prod_only_selected,
+        )
+    } else {
+        graph.keys().cloned().map(|root| vec![root]).collect()
+    };
     if let Some(resume_from) = &args.resume_from {
         chunks = get_resumed_package_chunks(resume_from, chunks, graph)?;
     }

--- a/pacquet/crates/cli/src/cli_args/stop.rs
+++ b/pacquet/crates/cli/src/cli_args/stop.rs
@@ -29,6 +29,7 @@ impl StopArgs {
             resume_from: None,
             report_summary: false,
             no_bail: false,
+            sort: true,
         }
         .run(dir, config, silent)
     }

--- a/pacquet/crates/cli/src/cli_args/stop.rs
+++ b/pacquet/crates/cli/src/cli_args/stop.rs
@@ -15,12 +15,7 @@ pub struct StopArgs {
 }
 
 impl StopArgs {
-    pub fn run(
-        self,
-        dir: &std::path::Path,
-        config: &pacquet_config::Config,
-        silent: bool,
-    ) -> miette::Result<()> {
+    pub(crate) fn into_run_args(self) -> RunArgs {
         let StopArgs { args, if_present } = self;
         RunArgs {
             command: Some("stop".to_string()),
@@ -31,7 +26,15 @@ impl StopArgs {
             no_bail: false,
             sort: true,
         }
-        .run(dir, config, silent)
+    }
+
+    pub fn run(
+        self,
+        dir: &std::path::Path,
+        config: &pacquet_config::Config,
+        silent: bool,
+    ) -> miette::Result<()> {
+        self.into_run_args().run(dir, config, silent)
     }
 }
 

--- a/pacquet/crates/cli/src/cli_args/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/tests.rs
@@ -87,7 +87,39 @@ fn recursive_run_flags_parse_before_fallback_command() {
     assert!(parsed.no_sort);
     assert_eq!(parsed.workspace_concurrency, Some(1));
     assert!(parsed.report_summary);
-    assert!(matches!(parsed.command, CliCommand::External(command) if command == [".test"]));
+    assert!(
+        matches!(&parsed.command, CliCommand::External(command) if command.as_slice() == [".test"]),
+    );
+    parsed.validate_command_scoped_global_options().expect("recursive fallback flags are valid");
+}
+
+#[test]
+fn script_scoped_global_flags_parse_before_script_commands() {
+    for argv in [
+        ["pacquet", "--report-summary", "run", "build"].as_slice(),
+        ["pacquet", "--resume-from", "pkg", "exec", "echo"].as_slice(),
+        ["pacquet", "--no-bail", "run", "build"].as_slice(),
+        ["pacquet", "-r", "--report-summary", ".test"].as_slice(),
+    ] {
+        let parsed = CliArgs::try_parse_from(argv).expect("parses script-scoped global flag");
+        parsed.validate_command_scoped_global_options().expect("script command accepts flag");
+    }
+}
+
+#[test]
+fn script_scoped_global_flags_reject_unrelated_commands() {
+    for argv in [
+        ["pacquet", "install", "--report-summary"].as_slice(),
+        ["pacquet", "install", "--resume-from", "pkg"].as_slice(),
+        ["pacquet", "install", "--no-bail"].as_slice(),
+    ] {
+        let parsed =
+            CliArgs::try_parse_from(argv).expect("global parser accepts compatibility flag");
+        let err = parsed
+            .validate_command_scoped_global_options()
+            .expect_err("non-script command rejects flag");
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+    }
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/tests.rs
@@ -99,10 +99,24 @@ fn script_scoped_global_flags_parse_before_script_commands() {
         ["pacquet", "--report-summary", "run", "build"].as_slice(),
         ["pacquet", "--resume-from", "pkg", "exec", "echo"].as_slice(),
         ["pacquet", "--no-bail", "run", "build"].as_slice(),
+        ["pacquet", "--report-summary", "test"].as_slice(),
+        ["pacquet", "--resume-from", "pkg", "start"].as_slice(),
+        ["pacquet", "--no-bail", "stop"].as_slice(),
         ["pacquet", "-r", "--report-summary", ".test"].as_slice(),
     ] {
         let parsed = CliArgs::try_parse_from(argv).expect("parses script-scoped global flag");
         parsed.validate_command_scoped_global_options().expect("script command accepts flag");
+    }
+}
+
+#[test]
+fn report_summary_global_flag_parses_for_publish() {
+    for argv in [
+        ["pacquet", "--report-summary", "publish"].as_slice(),
+        ["pacquet", "publish", "--report-summary"].as_slice(),
+    ] {
+        let parsed = CliArgs::try_parse_from(argv).expect("parses report-summary for publish");
+        parsed.validate_command_scoped_global_options().expect("publish accepts report-summary");
     }
 }
 
@@ -112,6 +126,10 @@ fn script_scoped_global_flags_reject_unrelated_commands() {
         ["pacquet", "install", "--report-summary"].as_slice(),
         ["pacquet", "install", "--resume-from", "pkg"].as_slice(),
         ["pacquet", "install", "--no-bail"].as_slice(),
+        ["pacquet", "restart", "--report-summary"].as_slice(),
+        ["pacquet", "restart", "--no-bail"].as_slice(),
+        ["pacquet", "publish", "--resume-from", "pkg"].as_slice(),
+        ["pacquet", "publish", "--no-bail"].as_slice(),
     ] {
         let parsed =
             CliArgs::try_parse_from(argv).expect("global parser accepts compatibility flag");

--- a/pacquet/crates/cli/src/cli_args/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/tests.rs
@@ -73,6 +73,35 @@ fn filter_flag_is_global_and_parses_before_subcommand() {
 }
 
 #[test]
+fn recursive_run_flags_parse_before_fallback_command() {
+    let parsed = CliArgs::try_parse_from([
+        "pacquet",
+        "--no-sort",
+        "--workspace-concurrency=1",
+        "-r",
+        "--report-summary",
+        ".test",
+    ])
+    .expect("parses recursive fallback flags");
+    assert!(parsed.recursive);
+    assert!(parsed.no_sort);
+    assert_eq!(parsed.workspace_concurrency, Some(1));
+    assert!(parsed.report_summary);
+    assert!(matches!(parsed.command, CliCommand::External(command) if command == [".test"]));
+}
+
+#[test]
+fn workspace_concurrency_parses_as_global_option() {
+    let positive = CliArgs::try_parse_from(["pacquet", "--workspace-concurrency", "3", "install"])
+        .expect("parses --workspace-concurrency 3");
+    assert_eq!(positive.workspace_concurrency, Some(3));
+
+    let negative = CliArgs::try_parse_from(["pacquet", "install", "--workspace-concurrency=-1"])
+        .expect("parses --workspace-concurrency=-1 after subcommand");
+    assert_eq!(negative.workspace_concurrency, Some(-1));
+}
+
+#[test]
 fn filter_flag_split_across_subcommand_keeps_only_subcommand_side() {
     let parsed = CliArgs::try_parse_from(["pacquet", "-F", "a", "install", "-F", "b"])
         .expect("parses split -F");

--- a/pacquet/crates/cli/src/lib.rs
+++ b/pacquet/crates/cli/src/lib.rs
@@ -58,6 +58,9 @@ pub fn main() -> miette::Result<()> {
         }
         Err(err) => err.exit(),
     };
+    if let Err(err) = args.validate_command_scoped_global_options() {
+        err.exit();
+    }
     args.promote_recursive_for_filter();
     if let Some(plan) = cli_args::switch_cli_version::switch_plan(&args, &config_overrides)?
         && block_on_runtime(

--- a/pacquet/crates/cli/tests/completion.rs
+++ b/pacquet/crates/cli/tests/completion.rs
@@ -174,7 +174,7 @@ fn completion_server_filters_option_prefixes() {
         .expect("run pacquet completion-server");
     let reply = stdout(output);
 
-    assert_eq!(reply.lines().collect::<Vec<_>>(), ["--report-summary", "--reporter"]);
+    assert_eq!(reply.lines().collect::<Vec<_>>(), ["--reporter"]);
 }
 
 #[test]

--- a/pacquet/crates/cli/tests/completion.rs
+++ b/pacquet/crates/cli/tests/completion.rs
@@ -174,7 +174,7 @@ fn completion_server_filters_option_prefixes() {
         .expect("run pacquet completion-server");
     let reply = stdout(output);
 
-    assert_eq!(reply.lines().collect::<Vec<_>>(), ["--reporter"]);
+    assert_eq!(reply.lines().collect::<Vec<_>>(), ["--report-summary", "--reporter"]);
 }
 
 #[test]

--- a/pacquet/crates/cli/tests/run.rs
+++ b/pacquet/crates/cli/tests/run.rs
@@ -359,6 +359,34 @@ fn top_level_fallback_runs_script_before_local_bin() {
     drop(root);
 }
 
+#[test]
+fn top_level_fallback_runs_package_yaml_script_with_dir() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let fixtures = workspace.join("fixtures");
+    fs::create_dir_all(&fixtures).expect("create fixtures dir");
+    let marker = workspace.join("prepared.txt");
+    fs::write(
+        fixtures.join("package.yaml"),
+        r#"name: fixtures
+version: 0.0.0
+scripts:
+  prepareFixtures: node -e "require('fs').writeFileSync(process.env.MARKER_PATH, 'prepared')"
+"#,
+    )
+    .expect("write package.yaml");
+
+    pacquet
+        .with_env("MARKER_PATH", marker.to_string_lossy().as_ref())
+        .with_arg("--dir")
+        .with_arg(&fixtures)
+        .with_arg("prepareFixtures")
+        .assert()
+        .success();
+    assert_eq!(fs::read_to_string(&marker).expect("read marker"), "prepared");
+
+    drop(root);
+}
+
 #[cfg(unix)]
 #[test]
 fn top_level_fallback_runs_local_bin_when_script_is_missing() {

--- a/pacquet/crates/cli/tests/run.rs
+++ b/pacquet/crates/cli/tests/run.rs
@@ -504,9 +504,8 @@ fn run_start_falls_back_to_node_server_js_when_present() {
     })
     .to_string();
     fs::write(workspace.join("package.json"), manifest).expect("write package.json");
-    // `server.js` is probed via `existsSync('server.js')`, resolved
-    // against the process cwd (which `CommandTempCwd` sets to the
-    // workspace), so the file goes here, not under any project subdir.
+    // `server.js` is probed in the same directory where the script
+    // runs, which `CommandTempCwd` sets to the workspace for this case.
     fs::write(workspace.join("server.js"), "// placeholder").expect("write server.js");
 
     let shim_dir = workspace.join("shim");
@@ -526,6 +525,47 @@ fn run_start_falls_back_to_node_server_js_when_present() {
 
     let written = fs::read_to_string(&marker).expect("read marker");
     assert_eq!(written, "server.js");
+
+    drop(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn run_start_fallback_uses_dir_for_server_js_probe() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let project = workspace.join("project");
+    fs::create_dir_all(&project).expect("create project");
+    let manifest = json!({
+        "name": "test",
+        "version": "0.0.0",
+    })
+    .to_string();
+    fs::write(project.join("package.json"), manifest).expect("write package.json");
+    fs::write(project.join("server.js"), "// placeholder").expect("write server.js");
+
+    let shim_dir = workspace.join("shim");
+    fs::create_dir_all(&shim_dir).expect("create shim dir");
+    let marker = workspace.join("node-cwd-and-args.txt");
+    write_executable(
+        &shim_dir.join("node"),
+        &format!("#!/bin/sh\nprintf '%s\\n%s' \"$(pwd)\" \"$*\" > \"{}\"\n", marker.display()),
+    );
+
+    let existing_path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", shim_dir.display(), existing_path);
+    std::process::Command::cargo_bin("pacquet")
+        .expect("find pacquet binary")
+        .with_current_dir(&workspace)
+        .with_env("PATH", new_path)
+        .with_arg("--dir")
+        .with_arg(&project)
+        .with_arg("start")
+        .assert()
+        .success();
+
+    let written = fs::read_to_string(&marker).expect("read marker");
+    let project = fs::canonicalize(project).expect("canonicalize project");
+    assert_eq!(written, format!("{}\nserver.js", project.display()));
 
     drop(root);
 }

--- a/pacquet/crates/cli/tests/run_recursive.rs
+++ b/pacquet/crates/cli/tests/run_recursive.rs
@@ -648,6 +648,39 @@ fn recursive_run_filter_no_match_is_a_noop() {
     drop(root);
 }
 
+#[test]
+fn recursive_run_no_sort_uses_workspace_order() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            (
+                "app",
+                json!({
+                    "name": "app",
+                    "version": "1.0.0",
+                    "scripts": { "build": "echo app >> ../order.log" },
+                    "dependencies": { "lib": "workspace:*" },
+                }),
+            ),
+            ("lib", build_appends_run_order("lib")),
+        ],
+    );
+
+    pacquet
+        .with_arg("--no-sort")
+        .with_arg("-r")
+        .with_arg("run")
+        .with_arg("build")
+        .assert()
+        .success();
+
+    let order = fs::read_to_string(workspace.join("order.log")).expect("read order log");
+    assert_eq!(order, "app\nlib\n");
+
+    drop(root);
+}
+
 /// `pacquet -r run --resume-from <pkg>` skips every chunk that sorts
 /// before the chunk containing `<pkg>`. With `project-2` and `project-3`
 /// both depending on `project-1`, the sorted chunks are

--- a/pacquet/crates/cli/tests/run_recursive.rs
+++ b/pacquet/crates/cli/tests/run_recursive.rs
@@ -139,6 +139,52 @@ fn top_level_fallback_enters_recursive_run() {
 }
 
 #[test]
+fn recursive_lifecycle_aliases_use_recursive_run_options() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let lifecycle_scripts = |name: &str| {
+        json!({
+            "name": name,
+            "version": "1.0.0",
+            "scripts": {
+                "test": "touch test-ran.txt",
+                "start": "touch start-ran.txt",
+                "stop": "touch stop-ran.txt",
+            },
+        })
+    };
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", lifecycle_scripts("project-1")),
+            ("project-2", lifecycle_scripts("project-2")),
+        ],
+    );
+
+    for (command, marker) in
+        [("test", "test-ran.txt"), ("start", "start-ran.txt"), ("stop", "stop-ran.txt")]
+    {
+        let _ = fs::remove_file(workspace.join("pnpm-exec-summary.json"));
+        std::process::Command::cargo_bin("pacquet")
+            .expect("find pacquet binary")
+            .with_current_dir(&workspace)
+            .with_arg("-r")
+            .with_arg("--report-summary")
+            .with_arg(command)
+            .assert()
+            .success();
+
+        for name in ["project-1", "project-2"] {
+            assert!(workspace.join(name).join(marker).exists(), "{command} should run in {name}");
+        }
+        let statuses = summary_statuses(&workspace);
+        assert_eq!(statuses.get("project-1").map(String::as_str), Some("passed"));
+        assert_eq!(statuses.get("project-2").map(String::as_str), Some("passed"));
+    }
+
+    drop(root);
+}
+
+#[test]
 fn top_level_fallback_does_not_exec_local_bin_recursively() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     write_workspace(

--- a/pacquet/crates/cli/tests/test_command.rs
+++ b/pacquet/crates/cli/tests/test_command.rs
@@ -24,3 +24,17 @@ fn test_runs_declared_test_script() {
 
     drop(root);
 }
+
+#[test]
+fn test_skips_missing_test_script() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let manifest = json!({
+        "name": "test-command",
+        "version": "0.0.0",
+    });
+    fs::write(workspace.join("package.json"), manifest.to_string()).expect("write package.json");
+
+    pacquet.with_arg("test").assert().success();
+
+    drop(root);
+}

--- a/pacquet/crates/workspace/src/project_manifest.rs
+++ b/pacquet/crates/workspace/src/project_manifest.rs
@@ -1,16 +1,17 @@
-//! Read a project's `package.json`.
+//! Read a project's package manifest.
 //!
-//! pnpm also supports `package.json5` and `package.yaml` and returns a
-//! writer closure that preserves formatting. Pacquet doesn't consume
-//! either alternative format yet, and the install pipeline never writes
-//! the manifest back — so this handles `package.json` only and has no
-//! writer closure. Adding the other formats is a follow-up if real
-//! workspaces in the wild use them.
+//! pnpm also supports `package.json5` and returns a writer closure that
+//! preserves formatting. Pacquet does not consume JSON5 yet, and the
+//! install pipeline never writes the manifest back through this reader,
+//! so this handles `package.json` plus read-only `package.yaml`.
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_package_manifest::{PackageManifest, PackageManifestError};
-use std::path::{Path, PathBuf};
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
 
 /// Error type of [`read_exact_project_manifest`].
 #[derive(Debug, Display, Error, Diagnostic)]
@@ -18,6 +19,22 @@ use std::path::{Path, PathBuf};
 pub enum ReadProjectManifestError {
     #[diagnostic(transparent)]
     Read(#[error(source)] PackageManifestError),
+
+    #[display("Failed to read {}: {source}", path.display())]
+    #[diagnostic(code(pacquet_workspace::read_project_manifest))]
+    ReadFile {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display("Failed to parse {}: {source}", path.display())]
+    #[diagnostic(code(pacquet_workspace::parse_project_manifest))]
+    ParseYaml {
+        path: PathBuf,
+        #[error(source)]
+        source: Box<serde_saphyr::Error>,
+    },
 
     #[display("Not supported manifest name {basename:?}")]
     #[diagnostic(code(pacquet_workspace::unsupported_project_manifest))]
@@ -29,34 +46,29 @@ pub enum ReadProjectManifestError {
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum ReadProjectManifestOnlyError {
-    // pnpm's variant of this message lists `package.yaml` and
-    // `package.json5` alongside `package.json`. Pacquet only probes
-    // `package.json` today, so the diagnostic mentions just that one —
-    // bring back the alternatives when the readers do.
-    #[display("No package.json was found in {:?}", project_dir.display())]
+    #[display("No package.json or package.yaml was found in {:?}", project_dir.display())]
     #[diagnostic(code(pacquet_workspace::no_importer_manifest_found))]
     NoImporterManifestFound { project_dir: PathBuf },
 
     #[diagnostic(transparent)]
-    Read(#[error(source)] PackageManifestError),
+    Read(#[error(source)] ReadProjectManifestError),
 }
 
 /// Read the manifest under `project_dir`.
 ///
-/// Returns the manifest plus the basename that was loaded. Today the
-/// only supported basename is `package.json`; the function returns the
-/// basename so callers can stay structurally the same when
-/// `package.json5` / `package.yaml` support lands.
+/// Returns the manifest plus the basename that was loaded.
 pub fn try_read_project_manifest(
     project_dir: &Path,
 ) -> Result<Option<(&'static str, PackageManifest)>, ReadProjectManifestOnlyError> {
-    let json_path = project_dir.join("package.json");
-    if !json_path.is_file() {
-        return Ok(None);
+    for basename in ["package.json", "package.yaml"] {
+        let manifest_path = project_dir.join(basename);
+        if manifest_path.is_file() {
+            let manifest = read_exact_project_manifest(&manifest_path)
+                .map_err(ReadProjectManifestOnlyError::Read)?;
+            return Ok(Some((basename, manifest)));
+        }
     }
-    let manifest =
-        PackageManifest::from_path(json_path).map_err(ReadProjectManifestOnlyError::Read)?;
-    Ok(Some(("package.json", manifest)))
+    Ok(None)
 }
 
 /// Strict version: error when no manifest is found.
@@ -80,8 +92,7 @@ pub fn safe_read_project_manifest_only(
 }
 
 /// Read a manifest from an explicit path, probing the basename to pick
-/// a parser. Pacquet only supports `package.json`; other basenames are
-/// rejected with the same wording pnpm uses.
+/// a parser.
 pub fn read_exact_project_manifest(
     manifest_path: &Path,
 ) -> Result<PackageManifest, ReadProjectManifestError> {
@@ -92,8 +103,20 @@ pub fn read_exact_project_manifest(
     match basename.as_str() {
         "package.json" => PackageManifest::from_path(manifest_path.to_path_buf())
             .map_err(ReadProjectManifestError::Read),
+        "package.yaml" => read_package_yaml(manifest_path),
         _ => Err(ReadProjectManifestError::UnsupportedName { basename }),
     }
+}
+
+fn read_package_yaml(path: &Path) -> Result<PackageManifest, ReadProjectManifestError> {
+    let text = fs::read_to_string(path).map_err(|source| ReadProjectManifestError::ReadFile {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let value = serde_saphyr::from_str(&text).map_err(|source| {
+        ReadProjectManifestError::ParseYaml { path: path.to_path_buf(), source: Box::new(source) }
+    })?;
+    Ok(PackageManifest::from_value(path.to_path_buf(), value))
 }
 
 #[cfg(test)]

--- a/pacquet/crates/workspace/src/project_manifest/tests.rs
+++ b/pacquet/crates/workspace/src/project_manifest/tests.rs
@@ -10,6 +10,10 @@ fn write_manifest(dir: &std::path::Path, body: &str) {
     fs::write(dir.join("package.json"), body).unwrap();
 }
 
+fn write_yaml_manifest(dir: &std::path::Path, body: &str) {
+    fs::write(dir.join("package.yaml"), body).unwrap();
+}
+
 #[test]
 fn try_read_returns_manifest_when_present() {
     let tmp = TempDir::new().unwrap();
@@ -17,6 +21,25 @@ fn try_read_returns_manifest_when_present() {
     let result = try_read_project_manifest(tmp.path()).unwrap().unwrap();
     assert_eq!(result.0, "package.json");
     assert_eq!(result.1.value().get("name").and_then(|v| v.as_str()), Some("alpha"));
+}
+
+#[test]
+fn try_read_returns_yaml_manifest_when_json_is_missing() {
+    let tmp = TempDir::new().unwrap();
+    write_yaml_manifest(tmp.path(), "name: alpha\nversion: 1.2.3\n");
+    let result = try_read_project_manifest(tmp.path()).unwrap().unwrap();
+    assert_eq!(result.0, "package.yaml");
+    assert_eq!(result.1.value().get("name").and_then(|v| v.as_str()), Some("alpha"));
+}
+
+#[test]
+fn try_read_prefers_json_over_yaml() {
+    let tmp = TempDir::new().unwrap();
+    write_manifest(tmp.path(), r#"{"name": "json", "version": "1.2.3"}"#);
+    write_yaml_manifest(tmp.path(), "name: yaml\nversion: 1.2.3\n");
+    let result = try_read_project_manifest(tmp.path()).unwrap().unwrap();
+    assert_eq!(result.0, "package.json");
+    assert_eq!(result.1.value().get("name").and_then(|v| v.as_str()), Some("json"));
 }
 
 #[test]
@@ -46,12 +69,12 @@ fn strict_read_errors_when_missing() {
 #[test]
 fn read_exact_rejects_other_basenames() {
     let tmp = TempDir::new().unwrap();
-    let path = tmp.path().join("package.yaml");
+    let path = tmp.path().join("package.json5");
     fs::write(&path, "name: alpha\n").unwrap();
     match read_exact_project_manifest(&path) {
         Ok(_) => panic!("expected UnsupportedName"),
         Err(ReadProjectManifestError::UnsupportedName { basename }) => {
-            assert_eq!(basename, "package.yaml");
+            assert_eq!(basename, "package.json5");
         }
         Err(err) => panic!("unexpected error: {err}"),
     }
@@ -62,6 +85,15 @@ fn read_exact_accepts_package_json() {
     let tmp = TempDir::new().unwrap();
     let path = tmp.path().join("package.json");
     fs::write(&path, r#"{"name": "beta", "version": "0.1.0"}"#).unwrap();
+    let manifest = read_exact_project_manifest(&path).unwrap();
+    assert_eq!(manifest.value().get("name").and_then(|v| v.as_str()), Some("beta"));
+}
+
+#[test]
+fn read_exact_accepts_package_yaml() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("package.yaml");
+    fs::write(&path, "name: beta\nversion: 0.1.0\n").unwrap();
     let manifest = read_exact_project_manifest(&path).unwrap();
     assert_eq!(manifest.value().get("name").and_then(|v| v.as_str()), Some("beta"));
 }

--- a/pacquet/crates/workspace/src/projects.rs
+++ b/pacquet/crates/workspace/src/projects.rs
@@ -119,12 +119,13 @@ pub fn find_workspace_projects_no_check(
             if body.starts_with('/') {
                 continue;
             }
-            let normalized = normalize_pattern(body);
-            Glob::new(&normalized).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
-                pattern: pattern.clone(),
-                message: err.to_string(),
-            })?;
-            user_negation_globs.push(normalized);
+            for normalized in normalize_manifest_patterns(body) {
+                Glob::new(&normalized).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
+                    pattern: pattern.clone(),
+                    message: err.to_string(),
+                })?;
+                user_negation_globs.push(normalized);
+            }
         } else {
             include_patterns.push(pattern);
         }
@@ -150,39 +151,41 @@ pub fn find_workspace_projects_no_check(
 
     let mut manifest_paths: BTreeSet<PathBuf> = BTreeSet::new();
     for pattern in include_patterns {
-        let normalized = normalize_pattern(pattern);
-        let glob =
-            Glob::new(&normalized).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
-                pattern: pattern.to_string(),
-                message: err.to_string(),
-            })?;
-
-        let walk = glob.walk(workspace_root).not(ignore_template.clone()).map_err(|err| {
-            FindWorkspaceProjectsError::InvalidGlob {
-                pattern: pattern.to_string(),
-                message: err.to_string(),
+        for normalized in normalize_manifest_patterns(pattern) {
+            if is_literal_pattern(&normalized) && !workspace_root.join(&normalized).is_file() {
+                continue;
             }
-        })?;
+            let glob =
+                Glob::new(&normalized).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
+                    pattern: pattern.to_string(),
+                    message: err.to_string(),
+                })?;
 
-        for entry in walk {
-            let entry = entry.map_err(|err| FindWorkspaceProjectsError::Walk {
-                root: workspace_root.to_path_buf(),
-                source: std::io::Error::other(err.to_string()),
+            let walk = glob.walk(workspace_root).not(ignore_template.clone()).map_err(|err| {
+                FindWorkspaceProjectsError::InvalidGlob {
+                    pattern: pattern.to_string(),
+                    message: err.to_string(),
+                }
             })?;
-            manifest_paths.insert(entry.path().to_path_buf());
+
+            for entry in walk {
+                let entry = entry.map_err(|err| FindWorkspaceProjectsError::Walk {
+                    root: workspace_root.to_path_buf(),
+                    source: std::io::Error::other(err.to_string()),
+                })?;
+                manifest_paths.insert(entry.path().to_path_buf());
+            }
         }
     }
 
-    let root_manifest = workspace_root.join("package.json");
-    if root_manifest.is_file() {
-        manifest_paths.insert(root_manifest);
+    for basename in PROJECT_MANIFEST_BASENAMES {
+        let root_manifest = workspace_root.join(basename);
+        if root_manifest.is_file() {
+            manifest_paths.insert(root_manifest);
+        }
     }
 
     // Sort lexicographically by `rootDir` (= parent of the manifest).
-    // `BTreeSet` already sorts by full path, but the contract is "by
-    // dir then by basename"; with our basename always being
-    // `package.json` the two orderings coincide. Keep the explicit
-    // sort below to make the contract visible.
     let mut sorted: Vec<PathBuf> = manifest_paths.into_iter().collect();
     sorted.sort_by(|left, right| {
         let dir_left = left.parent().unwrap_or_else(|| Path::new(""));
@@ -191,7 +194,12 @@ pub fn find_workspace_projects_no_check(
     });
 
     let mut projects = Vec::with_capacity(sorted.len());
+    let mut seen_roots = BTreeSet::new();
     for manifest_path in sorted {
+        let root_dir = manifest_path.parent().unwrap_or(workspace_root).to_path_buf();
+        if seen_roots.contains(&root_dir) {
+            continue;
+        }
         let manifest = match read_exact_project_manifest(&manifest_path) {
             Ok(m) => m,
             // Swallow ENOENT mid-walk (a file vanished between listing
@@ -205,12 +213,17 @@ pub fn find_workspace_projects_no_check(
             {
                 continue;
             }
+            Err(ReadProjectManifestError::ReadFile { source, .. })
+                if source.kind() == ErrorKind::NotFound =>
+            {
+                continue;
+            }
             Err(ReadProjectManifestError::Read(PackageManifestError::NoImporterManifestFound(
                 _,
             ))) => continue,
             Err(err) => return Err(FindWorkspaceProjectsError::ReadManifest(err)),
         };
-        let root_dir = manifest_path.parent().unwrap_or(workspace_root).to_path_buf();
+        seen_roots.insert(root_dir.clone());
         projects.push(Project { root_dir, manifest });
     }
 
@@ -222,19 +235,20 @@ pub fn find_workspace_projects_no_check(
 /// `**/tests/**` directories that the lower-level package-finding path
 /// excludes.
 const IGNORE_PATTERNS: &[&str] = &["**/node_modules/**", "**/bower_components/**"];
+const PROJECT_MANIFEST_BASENAMES: &[&str] = &["package.json", "package.yaml"];
 
-fn normalize_pattern(pattern: &str) -> String {
-    // Each user pattern is suffixed with the manifest basename so the
-    // glob matches manifest files rather than directories. Pacquet only
-    // supports `package.json` today; the `{json,yaml,json5}` brace
-    // expansion is dropped to match the [`project_manifest`] reader.
+fn normalize_manifest_patterns(pattern: &str) -> Vec<String> {
+    // Each user pattern is suffixed with every supported manifest basename
+    // so the glob matches manifest files rather than directories.
     let trimmed = pattern.trim_end_matches('/');
-    if trimmed.is_empty() {
-        // `.` and `''` both mean "match the workspace root itself".
-        "package.json".to_string()
-    } else {
-        format!("{trimmed}/package.json")
+    if trimmed.is_empty() || trimmed == "." {
+        return Vec::new();
     }
+    PROJECT_MANIFEST_BASENAMES.iter().map(|basename| format!("{trimmed}/{basename}")).collect()
+}
+
+fn is_literal_pattern(pattern: &str) -> bool {
+    !pattern.chars().any(|ch| matches!(ch, '*' | '?' | '[' | ']' | '{' | '}'))
 }
 
 #[cfg(test)]

--- a/pacquet/crates/workspace/src/projects/tests.rs
+++ b/pacquet/crates/workspace/src/projects/tests.rs
@@ -10,6 +10,12 @@ fn make_project(root: &std::path::Path, rel: &str, name: &str) {
         .unwrap();
 }
 
+fn make_yaml_project(root: &std::path::Path, rel: &str, name: &str) {
+    let dir = root.join(rel);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("package.yaml"), format!("name: {name}\nversion: 0.0.1\n")).unwrap();
+}
+
 #[test]
 fn expands_packages_glob() {
     let tmp = TempDir::new().unwrap();
@@ -28,6 +34,64 @@ fn expands_packages_glob() {
         .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
         .collect();
     assert_eq!(names, vec!["root".to_string(), "alpha".to_string(), "beta".to_string()]);
+}
+
+#[test]
+fn expands_packages_glob_to_package_yaml() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_yaml_project(tmp.path(), "packages/alpha", "alpha");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/*".to_string()]) },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["root".to_string(), "alpha".to_string()]);
+}
+
+#[test]
+fn direct_package_pattern_does_not_require_every_manifest_format() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/alpha", "alpha");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/alpha".to_string()]) },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["root".to_string(), "alpha".to_string()]);
+}
+
+#[test]
+fn package_json_wins_when_both_manifest_files_exist() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/alpha", "json-alpha");
+    make_yaml_project(tmp.path(), "packages/alpha", "yaml-alpha");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/*".to_string()]) },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["root".to_string(), "json-alpha".to_string()]);
 }
 
 #[test]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Pacquet now reads `package.yaml` as a project manifest in the shared workspace manifest reader. Script commands (`run`, top-level shorthand fallback, `test`, `start`, and `stop`) use that reader, so `pnpm --dir=pnpm11/__fixtures__ prepareFixtures` works when the target project only has `package.yaml`.

Workspace project discovery also matches `package.yaml` projects while preserving `package.json` precedence when both files exist.

Pacquet also parses recursive script options before a fallback script command, matching pnpm's CI shape for `pn --no-sort --workspace-concurrency=1 -r --report-summary .test`. `--no-sort` now preserves workspace order for recursive `run` and `exec`, lifecycle aliases that TypeScript pnpm treats like run scripts (`test`, `start`, and `stop`) accept the same recursive script flags, and unrelated commands still reject them. `publish --report-summary` is preserved when it is captured by the shared parser, so filtered publish jobs can write an empty summary instead of failing during argument validation.

Related to pnpm/pnpm#12811.

## Squash Commit Body

```text
Pacquet's script dispatch still assumed a project manifest was always package.json. The pnpm/pnpm v12 CI update runs pnpm --dir=pnpm11/__fixtures__ prepareFixtures, and that fixture declares its scripts in package.yaml. The TypeScript CLI reads package.yaml through the project manifest reader, so pacquet fell through to exec and reported the command missing.

Add read-only package.yaml support to pacquet's shared project-manifest reader, teach workspace project discovery to match both package.json and package.yaml while keeping package.json precedence, and route script execution through that reader. This makes shorthand script fallback, run, test, start, and PNPM_PACKAGE_NAME stamping behave consistently for YAML manifests.

The next CI step also invokes the shorthand recursive script form as pn --no-sort --workspace-concurrency=1 -r --report-summary .test. Parse these recursive script options at the top level so fallback commands receive them, apply workspace-concurrency through the shared config, and implement --no-sort ordering for recursive run and exec by preserving workspace order. Validate the shared parser so unrelated commands still reject script-only flags, while test/start/stop accept the run-compatible recursive flags and publish keeps --report-summary for filtered publish summaries.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. TypeScript pnpm already supports `package.yaml` project manifests and the recursive script option shape; this PR fills the pacquet gaps.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace commands now recognize both `package.json` and `package.yaml`.
  * Recursive `run`/`exec` now support `--sort` / `--no-sort` ordering controls.
  * Added `--workspace-concurrency` for supported recursive commands.

* **Bug Fixes**
  * Improved manifest discovery and precedence when both manifest formats are present.
  * Script selection and fallback behavior now align with ordering when sorting is disabled.
  * Stricter validation for scoped recursive flags at command boundaries.

* **Chores**
  * Removed install-time workspace concurrency support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->