### PR TITLE
feat(pacquet): expose linkWorkspacePackages in the @pnpm/napi binding

### DIFF
--- a/pacquet/crates/napi/src/config.rs
+++ b/pacquet/crates/napi/src/config.rs
@@ -34,7 +34,8 @@ use std::{
 use dashmap::DashMap;
 use indexmap::IndexMap;
 use pacquet_config::{
-    Config, GetHomeDir, Host, LoadWorkspaceYamlError, NodeLinker, PackageImportMethod,
+    Config, GetHomeDir, Host, LinkWorkspacePackages, LoadWorkspaceYamlError, NodeLinker,
+    PackageImportMethod,
 };
 use pacquet_network::{AuthHeaders, ProxyConfig, TlsConfig};
 use pacquet_store_dir::StoreDir;
@@ -52,6 +53,10 @@ pub struct ConfigOverlay {
     pub proxy: Option<ProxyConfig>,
     pub tls: Option<TlsConfig>,
     pub node_linker: Option<NodeLinker>,
+    /// `linkWorkspacePackages` — whether a bare-semver dependency may resolve
+    /// to a workspace package by name. `Off` (the default) matches only
+    /// `workspace:`-prefixed ranges.
+    pub link_workspace_packages: Option<LinkWorkspacePackages>,
     pub package_import_method: Option<PackageImportMethod>,
     pub virtual_store_dir_max_length: Option<u64>,
     pub hoist_pattern: Option<Vec<String>>,
@@ -261,6 +266,9 @@ fn build_config(dir: &Path, overlay: &ConfigOverlay) -> Result<Config, LoadWorks
     }
     if let Some(node_linker) = overlay.node_linker {
         config.node_linker = node_linker;
+    }
+    if let Some(link_workspace_packages) = overlay.link_workspace_packages {
+        config.link_workspace_packages = link_workspace_packages;
     }
     if let Some(method) = overlay.package_import_method {
         config.package_import_method = method;

--- a/pacquet/crates/napi/src/install.rs
+++ b/pacquet/crates/napi/src/install.rs
@@ -56,6 +56,10 @@ pub struct InstallOptions {
     pub proxy_config: Option<ProxyConfigInput>,
     pub network_config: Option<NetworkConfigInput>,
     pub node_linker: Option<String>,
+    /// `linkWorkspacePackages` — `true` / `false` / `"deep"`. When enabled, a
+    /// bare-semver dependency may resolve to a workspace package by name (not
+    /// only `workspace:`-prefixed ranges).
+    pub link_workspace_packages: Option<serde_json::Value>,
     pub hoist_pattern: Option<Vec<String>>,
     pub public_hoist_pattern: Option<Vec<String>>,
     pub external_dependencies: Option<Vec<String>>,
@@ -416,6 +420,9 @@ fn build_overlay(options: &InstallOptions) -> napi::Result<ConfigOverlay> {
         proxy: options.proxy_config.as_ref().map(build_proxy_config).transpose()?,
         tls: network_config.map(build_tls_config).transpose()?,
         node_linker: options.node_linker.as_deref().and_then(parse_node_linker),
+        link_workspace_packages: parse_link_workspace_packages(
+            options.link_workspace_packages.as_ref(),
+        )?,
         package_import_method: options
             .package_import_method
             .as_deref()
@@ -598,6 +605,25 @@ fn parse_node_linker(value: &str) -> Option<pacquet_config::NodeLinker> {
         "pnp" => Some(pacquet_config::NodeLinker::Pnp),
         _ => None,
     }
+}
+
+/// Parse the JS `linkWorkspacePackages` value (`true` / `false` / `"deep"`)
+/// into a [`pacquet_config::LinkWorkspacePackages`], reusing the config
+/// crate's `Deserialize`. Rejects any other value.
+fn parse_link_workspace_packages(
+    value: Option<&serde_json::Value>,
+) -> napi::Result<Option<pacquet_config::LinkWorkspacePackages>> {
+    value
+        .map(|value| {
+            serde_json::from_value::<pacquet_config::LinkWorkspacePackages>(value.clone()).map_err(
+                |error| {
+                    napi::Error::from_reason(format!(
+                        r#"invalid linkWorkspacePackages (expected true, false, or "deep"): {error}"#,
+                    ))
+                },
+            )
+        })
+        .transpose()
 }
 
 fn parse_import_method(value: &str) -> Option<pacquet_config::PackageImportMethod> {

--- a/pacquet/crates/napi/src/install/tests.rs
+++ b/pacquet/crates/napi/src/install/tests.rs
@@ -87,6 +87,34 @@ fn build_overlay_maps_supported_install_options() {
 }
 
 #[test]
+fn build_overlay_parses_link_workspace_packages() {
+    use pacquet_config::LinkWorkspacePackages;
+
+    let mut options = install_options();
+    options.link_workspace_packages = Some(serde_json::json!("deep"));
+    assert_eq!(
+        build_overlay(&options).expect("overlay").link_workspace_packages,
+        Some(LinkWorkspacePackages::Deep),
+    );
+
+    options.link_workspace_packages = Some(serde_json::json!(true));
+    assert_eq!(
+        build_overlay(&options).expect("overlay").link_workspace_packages,
+        Some(LinkWorkspacePackages::DirectOnly),
+    );
+
+    options.link_workspace_packages = Some(serde_json::json!(false));
+    assert_eq!(
+        build_overlay(&options).expect("overlay").link_workspace_packages,
+        Some(LinkWorkspacePackages::Off),
+    );
+
+    // Anything other than a boolean or "deep" is rejected.
+    options.link_workspace_packages = Some(serde_json::json!("shallow"));
+    assert!(build_overlay(&options).is_err());
+}
+
+#[test]
 fn unsupported_install_options_fail_closed() {
     let mut options = install_options();
     options.auth_config = Some([("token".to_string(), "secret".to_string())].into());
@@ -143,6 +171,7 @@ fn install_options() -> InstallOptions {
         proxy_config: None,
         network_config: None,
         node_linker: None,
+        link_workspace_packages: None,
         hoist_pattern: None,
         public_hoist_pattern: None,
         external_dependencies: None,

--- a/pacquet/npm/napi/index.d.ts
+++ b/pacquet/npm/napi/index.d.ts
@@ -90,6 +90,12 @@ export interface InstallOptions extends SharedEngineOptions {
   projects: NodeApiProject[]
   storeDir?: string
   nodeLinker?: 'hoisted' | 'isolated'
+  /**
+   * pnpm's `linkWorkspacePackages`. When `true`/`'deep'`, a bare-semver
+   * dependency (including an auto-installed peer) may resolve to a workspace
+   * package by name; `false` (the default) matches only `workspace:` ranges.
+   */
+  linkWorkspacePackages?: boolean | 'deep'
   hoistPattern?: string[]
   publicHoistPattern?: string[]
   /** Packages linked from outside the workspace; excluded from hoisting/pruning. */


### PR DESCRIPTION
## Summary

Exposes pnpm's `linkWorkspacePackages` (`true` / `false` / `"deep"`) as an
install option on the `@pnpm/napi` binding (added in pnpm/pnpm#12822), mapping it
onto `Config::link_workspace_packages` via the config crate's existing
`Deserialize`. **The default stays `false`, so nothing changes for existing
callers.**

## Motivation

The binding exposes most install options but was missing `linkWorkspacePackages`,
so programmatic consumers had no way to opt into it — the engine was pinned to the
`Off` default. This surfaced in a real consumer (Bit): a component whose **only**
reference to a sibling workspace component is a `peerDependency`, with
`autoInstallPeers: true`, fails to install. The auto-installed peer is a
bare-semver range, so with `link-workspace-packages: false` it resolves against
the registry and 404s — **exactly as stock pnpm does** with the same setting. The
fix on the consumer side is to set `linkWorkspacePackages: 'deep'` (as pnpm users
do), which requires the binding to accept it.

This is a binding-completeness change, not a behavior change: `pacquet` with
`linkWorkspacePackages` set behaves identically to the pnpm CLI with the same
config; the engine's resolution semantics are untouched.

## Verification

- Unit test: `linkWorkspacePackages` parses `true` → `DirectOnly`, `false` →
  `Off`, `"deep"` → `Deep`, and rejects anything else.
- Runtime (two-importer workspace, one peer-depending on the other, the peer
  unpublished):
  - default / omitted → still **404s** (matches stock pnpm — no divergence),
  - `linkWorkspacePackages: 'deep'` → the peer **resolves from the workspace**.
- `cargo fmt --check`, `clippy -D warnings`, `cargo doc -D warnings`, and
  `cargo dylint` all clean; `pacquet-napi` tests green.

Ref: pnpm/pnpm#12822.

---
Written by an agent (Claude Code, claude-fable-5), on behalf of @zkochan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new install option, `linkWorkspacePackages`, including `true`, `false`, and `"deep"` values.
  * Workspace package resolution can now be enabled so bare semver dependencies may resolve to matching workspace packages by name.

* **Bug Fixes**
  * The new install setting is now correctly carried through configuration and applied during installation.
  * Invalid values for the option are now rejected with a clear error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->