### PR TITLE
feat(pacquet): support custom fetchers from pnpmfile

### DIFF
--- a/.changeset/custom-fetcher-delegation.md
+++ b/.changeset/custom-fetcher-delegation.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/hooks.types": minor
+"@pnpm/fetching.pick-fetcher": minor
+"pnpm": minor
+---
+
+Custom fetchers exported from a pnpmfile can now delegate by returning a `{ delegate: <resolution> }` envelope: pnpm rewrites the package's resolution to the delegated shape and runs the built-in fetcher on it. This is the portable delegation form that also works in pacquet, where `cafs` and `fetchers` cannot be passed to the hook. Related to [pnpm/pnpm#11685](https://github.com/pnpm/pnpm/issues/11685).

--- a/pacquet/crates/cli/src/cli_args/cat_index.rs
+++ b/pacquet/crates/cli/src/cli_args/cat_index.rs
@@ -177,7 +177,12 @@ fn metadata_store_index_keys(pkg_id: &str, metadata: &PackageMetadata) -> Vec<St
         LockfileResolution::Binary(resolution) => {
             vec![store_index_key(&resolution.integrity.to_string(), pkg_id)]
         }
-        LockfileResolution::Directory(_) | LockfileResolution::Variations(_) => Vec::new(),
+        // Custom resolutions delegate to a rewritten resolution at
+        // install time; the store-index key belongs to that rewritten
+        // shape, which isn't recoverable from the lockfile entry.
+        LockfileResolution::Directory(_)
+        | LockfileResolution::Variations(_)
+        | LockfileResolution::Custom(_) => Vec::new(),
     }
 }
 

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -1039,9 +1039,12 @@ fn rewrite_resolution_registry(
                 rewrite_resolution_registry(&mut variant.resolution, rewrite);
             }
         }
+        // Custom resolutions are opaque — the benchmark rewrite can't
+        // know which of their fields (if any) is a registry URL.
         LockfileResolution::Directory(_)
         | LockfileResolution::Git(_)
-        | LockfileResolution::Registry(_) => {}
+        | LockfileResolution::Registry(_)
+        | LockfileResolution::Custom(_) => {}
     }
 }
 

--- a/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
@@ -284,7 +284,8 @@ fn assert_integrity_only_resolution(
         | LockfileResolution::Directory(_)
         | LockfileResolution::Git(_)
         | LockfileResolution::Binary(_)
-        | LockfileResolution::Variations(_) => Err(invalid_package_manager_lockfile(key)),
+        | LockfileResolution::Variations(_)
+        | LockfileResolution::Custom(_) => Err(invalid_package_manager_lockfile(key)),
     }
 }
 

--- a/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
@@ -511,6 +511,7 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Setup(_) => "setup",
         CliCommand::Logout(_) => "logout",
         CliCommand::With(_) => "with",
+        CliCommand::Pkg(_) => "pkg",
         CliCommand::Completion(_) => "completion",
         CliCommand::CompletionServer(_) => "completion-server",
     }

--- a/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
@@ -511,7 +511,6 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Setup(_) => "setup",
         CliCommand::Logout(_) => "logout",
         CliCommand::With(_) => "with",
-        CliCommand::Pkg(_) => "pkg",
         CliCommand::Completion(_) => "completion",
         CliCommand::CompletionServer(_) => "completion-server",
     }

--- a/pacquet/crates/cli/tests/custom_fetchers.rs
+++ b/pacquet/crates/cli/tests/custom_fetchers.rs
@@ -1,0 +1,132 @@
+//! Custom fetchers from a `.pnpmfile.cjs` `fetchers` export, end to
+//! end: a custom resolver writes a custom-typed resolution into the
+//! lockfile, and the sibling fetcher claims it and delegates to the
+//! built-in tarball path — on the fresh-resolve install, on a frozen
+//! reinstall, and failing loudly when the fetcher is removed.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::{fs, path::Path, process::Command};
+
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+}
+
+fn write_manifest(workspace: &Path) {
+    let manifest = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/dep-of-pkg-with-1-dep": "100.0.0",
+        },
+    });
+    fs::write(workspace.join("package.json"), manifest.to_string()).expect("write package.json");
+}
+
+/// A resolver that claims `@pnpm.e2e/dep-of-pkg-with-1-dep` and
+/// resolves it to a `custom:e2e` resolution carrying the registry's
+/// real tarball URL and integrity, plus a fetcher that delegates that
+/// resolution back to the built-in tarball path. The fetcher uses the
+/// TS-parity hook signature `fetch(cafs, resolution, opts, fetchers)`.
+fn custom_type_pnpmfile(registry_url: &str, with_fetcher: bool) -> String {
+    let fetchers = if with_fetcher {
+        r"
+  fetchers: [
+    {
+      canFetch (pkgId, resolution) {
+        return resolution.type === 'custom:e2e';
+      },
+      fetch (cafs, resolution, opts, fetchers) {
+        return { delegate: { tarball: resolution.url, integrity: resolution.integrity } };
+      },
+    },
+  ],
+"
+    } else {
+        ""
+    };
+    format!(
+        r"module.exports = {{
+  resolvers: [
+    {{
+      canResolve (wanted) {{
+        return wanted.alias === '@pnpm.e2e/dep-of-pkg-with-1-dep';
+      }},
+      async resolve () {{
+        const response = await fetch('{registry_url}@pnpm.e2e%2Fdep-of-pkg-with-1-dep');
+        const meta = await response.json();
+        const picked = meta.versions['100.1.0'];
+        return {{
+          id: '@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0',
+          manifest: picked,
+          resolution: {{
+            type: 'custom:e2e',
+            url: picked.dist.tarball,
+            integrity: picked.dist.integrity,
+          }},
+        }};
+      }},
+    }},
+  ],{fetchers}
+}}
+",
+    )
+}
+
+fn installed_version(workspace: &Path) -> String {
+    let manifest_path = workspace.join("node_modules/@pnpm.e2e/dep-of-pkg-with-1-dep/package.json");
+    let manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(manifest_path).expect("read installed manifest"))
+            .expect("parse installed manifest");
+    manifest["version"].as_str().expect("version is a string").to_string()
+}
+
+#[test]
+fn custom_fetcher_delegates_a_custom_typed_resolution_on_fresh_and_frozen_installs() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace);
+    fs::write(workspace.join(".pnpmfile.cjs"), custom_type_pnpmfile(&mock_instance.url(), true))
+        .expect("write pnpmfile");
+
+    // Fresh resolve: the custom resolver writes the custom-typed
+    // resolution, and the fetcher must delegate it during the same
+    // install's fetch phase.
+    pacquet.with_arg("install").assert().success();
+    assert_eq!(installed_version(&workspace), "100.1.0");
+    let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read lockfile");
+    assert!(
+        lockfile.contains("type: custom:e2e"),
+        "lockfile records the custom-typed resolution: {lockfile}",
+    );
+
+    // Frozen reinstall: the lockfile is the source of truth now, so the
+    // fetcher (loaded by the frozen path) is the only way to
+    // materialize the custom-typed entry.
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+    assert_eq!(installed_version(&workspace), "100.1.0");
+
+    drop((root, mock_instance)); // cleanup
+}
+
+#[test]
+fn custom_typed_resolution_without_a_fetcher_fails_the_install() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace);
+    fs::write(workspace.join(".pnpmfile.cjs"), custom_type_pnpmfile(&mock_instance.url(), false))
+        .expect("write pnpmfile");
+
+    let output = pacquet.with_arg("install").assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr).into_owned();
+    assert!(
+        stderr.contains("Cannot fetch dependency with custom resolution type \"custom:e2e\""),
+        "stderr: {stderr}",
+    );
+
+    drop((root, mock_instance)); // cleanup
+}

--- a/pacquet/crates/cli/tests/custom_fetchers.rs
+++ b/pacquet/crates/cli/tests/custom_fetchers.rs
@@ -124,7 +124,7 @@ fn custom_typed_resolution_without_a_fetcher_fails_the_install() {
     let output = pacquet.with_arg("install").assert().failure();
     let stderr = String::from_utf8_lossy(&output.get_output().stderr).into_owned();
     assert!(
-        stderr.contains("Cannot fetch dependency with custom resolution type \"custom:e2e\""),
+        stderr.contains(r#"Cannot fetch dependency with custom resolution type "custom:e2e""#),
         "stderr: {stderr}",
     );
 

--- a/pacquet/crates/hooks/src/custom_fetcher_adapter.rs
+++ b/pacquet/crates/hooks/src/custom_fetcher_adapter.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use crate::{CustomFetcher, HookError};
+
+/// Adapts a slice of [`CustomFetcher`] instances to a single "pick fetcher"
+/// call: iterate the custom fetchers in declared order, return the first
+/// one that claims the package via `can_fetch`.
+///
+/// This mirrors the TypeScript `pickFetcher` logic in
+/// `fetching/pick-fetcher/lib/index.js`, where custom fetchers are tried
+/// before built-in fetchers.
+pub struct CustomFetcherPicker {
+    fetchers: Vec<Arc<dyn CustomFetcher>>,
+}
+
+impl CustomFetcherPicker {
+    #[must_use]
+    pub fn new(fetchers: Vec<Arc<dyn CustomFetcher>>) -> Self {
+        Self { fetchers }
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.fetchers.is_empty()
+    }
+
+    /// Consult each custom fetcher's `can_fetch` in declared order. Returns
+    /// `Some(fetch_result)` from the first fetcher that claims the package,
+    /// or `None` if no custom fetcher handles it (the caller falls through to
+    /// built-in fetchers).
+    pub async fn try_fetch(
+        &self,
+        pkg_id: &str,
+        resolution: &Value,
+        opts: &Value,
+    ) -> Result<Option<Value>, HookError> {
+        for fetcher in &self.fetchers {
+            if !fetcher.has_can_fetch() || !fetcher.has_fetch() {
+                continue;
+            }
+            if fetcher.can_fetch(pkg_id, resolution.clone()).await? {
+                let result = fetcher.fetch(pkg_id, resolution.clone(), opts.clone()).await?;
+                return Ok(Some(result));
+            }
+        }
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/hooks/src/custom_fetcher_adapter.rs
+++ b/pacquet/crates/hooks/src/custom_fetcher_adapter.rs
@@ -9,8 +9,8 @@ use crate::{CustomFetcher, HookError};
 /// one that claims the package via `can_fetch`.
 ///
 /// This mirrors the TypeScript `pickFetcher` logic in
-/// `fetching/pick-fetcher/lib/index.js`, where custom fetchers are tried
-/// before built-in fetchers.
+/// `pnpm11/fetching/pick-fetcher/src/index.ts`, where custom fetchers are
+/// tried before built-in fetchers.
 pub struct CustomFetcherPicker {
     fetchers: Vec<Arc<dyn CustomFetcher>>,
 }

--- a/pacquet/crates/hooks/src/custom_fetcher_adapter/tests.rs
+++ b/pacquet/crates/hooks/src/custom_fetcher_adapter/tests.rs
@@ -1,0 +1,164 @@
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use super::CustomFetcherPicker;
+use crate::{CustomFetcher, HookError};
+
+struct ScriptedFetcher {
+    can_fetch: bool,
+    response: Value,
+    can_fetch_calls: AtomicUsize,
+    fetch_calls: AtomicUsize,
+    seen_pkg_ids: Mutex<Vec<String>>,
+    seen_resolutions: Mutex<Vec<Value>>,
+    seen_opts: Mutex<Vec<Value>>,
+}
+
+impl ScriptedFetcher {
+    fn answering(response: Value) -> Self {
+        ScriptedFetcher {
+            can_fetch: true,
+            response,
+            can_fetch_calls: AtomicUsize::new(0),
+            fetch_calls: AtomicUsize::new(0),
+            seen_pkg_ids: Mutex::new(Vec::new()),
+            seen_resolutions: Mutex::new(Vec::new()),
+            seen_opts: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl CustomFetcher for ScriptedFetcher {
+    async fn can_fetch(&self, pkg_id: &str, resolution: Value) -> Result<bool, HookError> {
+        self.can_fetch_calls.fetch_add(1, Ordering::SeqCst);
+        self.seen_pkg_ids.lock().unwrap().push(pkg_id.to_string());
+        self.seen_resolutions.lock().unwrap().push(resolution);
+        Ok(self.can_fetch)
+    }
+
+    async fn fetch(
+        &self,
+        _pkg_id: &str,
+        _resolution: Value,
+        opts: Value,
+    ) -> Result<Value, HookError> {
+        self.fetch_calls.fetch_add(1, Ordering::SeqCst);
+        self.seen_opts.lock().unwrap().push(opts);
+        Ok(self.response.clone())
+    }
+}
+
+fn fetch_result() -> Value {
+    json!({
+        "filesIndex": {
+            "package.json": { "integrity": "sha512-abc123", "mode": 420 },
+            "index.js": { "integrity": "sha512-def456", "mode": 420 },
+        }
+    })
+}
+
+#[tokio::test]
+async fn returns_result_from_first_matching_fetcher() {
+    let fetcher = Arc::new(ScriptedFetcher::answering(fetch_result()));
+    let picker = CustomFetcherPicker::new(vec![Arc::clone(&fetcher) as Arc<dyn CustomFetcher>]);
+
+    let resolution = json!({ "type": "@custom/registry", "url": "https://example.com/pkg" });
+    let opts = json!({ "manifest": { "name": "foo", "version": "1.0.0" } });
+
+    let result = picker.try_fetch("foo@1.0.0", &resolution, &opts).await.unwrap();
+
+    assert!(result.is_some());
+    assert_eq!(result.unwrap(), fetch_result());
+    assert_eq!(fetcher.can_fetch_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(fetcher.fetch_calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn returns_none_when_no_fetcher_claims_package() {
+    let fetcher = Arc::new(ScriptedFetcher {
+        can_fetch: false,
+        ..ScriptedFetcher::answering(fetch_result())
+    });
+    let picker = CustomFetcherPicker::new(vec![Arc::clone(&fetcher) as Arc<dyn CustomFetcher>]);
+
+    let resolution = json!({ "type": "@custom/registry" });
+    let opts = json!({});
+
+    let result = picker.try_fetch("foo@1.0.0", &resolution, &opts).await.unwrap();
+
+    assert!(result.is_none());
+    assert_eq!(fetcher.can_fetch_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(fetcher.fetch_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn tries_fetchers_in_order_stops_at_first_match() {
+    let first =
+        Arc::new(ScriptedFetcher { can_fetch: false, ..ScriptedFetcher::answering(json!({})) });
+    let second = Arc::new(ScriptedFetcher::answering(fetch_result()));
+    let third = Arc::new(ScriptedFetcher::answering(json!({"other": true})));
+
+    let picker = CustomFetcherPicker::new(vec![
+        Arc::clone(&first) as Arc<dyn CustomFetcher>,
+        Arc::clone(&second) as Arc<dyn CustomFetcher>,
+        Arc::clone(&third) as Arc<dyn CustomFetcher>,
+    ]);
+
+    let resolution = json!({ "tarball": "https://example.com/foo.tgz" });
+    let opts = json!({});
+
+    let result = picker.try_fetch("foo@1.0.0", &resolution, &opts).await.unwrap();
+
+    assert_eq!(result.unwrap(), fetch_result());
+    assert_eq!(first.can_fetch_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(first.fetch_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(second.can_fetch_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(second.fetch_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        third.can_fetch_calls.load(Ordering::SeqCst),
+        0,
+        "must not consult fetchers after a match"
+    );
+}
+
+#[tokio::test]
+async fn skips_fetcher_without_can_fetch() {
+    let fetcher = Arc::new(NoCanFetchFetcher);
+    let picker = CustomFetcherPicker::new(vec![fetcher]);
+
+    let result = picker.try_fetch("foo@1.0.0", &json!({}), &json!({})).await.unwrap();
+
+    assert!(result.is_none());
+}
+
+struct NoCanFetchFetcher;
+
+#[async_trait]
+impl CustomFetcher for NoCanFetchFetcher {
+    fn has_can_fetch(&self) -> bool {
+        false
+    }
+
+    async fn can_fetch(&self, _: &str, _: Value) -> Result<bool, HookError> {
+        panic!("should not be called");
+    }
+
+    async fn fetch(&self, _: &str, _: Value, _: Value) -> Result<Value, HookError> {
+        panic!("should not be called");
+    }
+}
+
+#[tokio::test]
+async fn empty_picker_returns_none() {
+    let picker = CustomFetcherPicker::new(vec![]);
+    assert!(picker.is_empty());
+
+    let result = picker.try_fetch("foo@1.0.0", &json!({}), &json!({})).await.unwrap();
+    assert!(result.is_none());
+}

--- a/pacquet/crates/hooks/src/custom_fetcher_adapter/tests.rs
+++ b/pacquet/crates/hooks/src/custom_fetcher_adapter/tests.rs
@@ -123,7 +123,7 @@ async fn tries_fetchers_in_order_stops_at_first_match() {
     assert_eq!(
         third.can_fetch_calls.load(Ordering::SeqCst),
         0,
-        "must not consult fetchers after a match"
+        "must not consult fetchers after a match",
     );
 }
 

--- a/pacquet/crates/hooks/src/lib.rs
+++ b/pacquet/crates/hooks/src/lib.rs
@@ -133,6 +133,12 @@ pub trait PnpmfileHooks: Send + Sync {
 /// returns `true`, `fetch` is called. Currently only delegation is supported:
 /// the fetcher returns `{ "delegate": <LockfileResolution> }` to rewrite the
 /// resolution and fall through to the built-in fetch path.
+///
+/// The pnpmfile hook is invoked with the same positional arguments as the
+/// TypeScript CLI's `CustomFetcher.fetch(cafs, resolution, opts, fetchers)`
+/// (`pnpm11/hooks/types/src/index.ts`); `cafs` and `fetchers` are `null`
+/// placeholders because they cannot cross the worker IPC boundary, which is
+/// how a portable fetcher knows to delegate instead of fetching directly.
 #[async_trait]
 pub trait CustomFetcher: Send + Sync {
     fn has_can_fetch(&self) -> bool {
@@ -151,8 +157,12 @@ pub trait CustomFetcher: Send + Sync {
     ///
     /// - `{ "delegate": <resolution> }` — rewrites the lockfile resolution and
     ///   falls through to the built-in fetch path for the rewritten value.
-    /// - Any other shape (or `None` from the picker) — the built-in fetch path
-    ///   runs with the original resolution unchanged.
+    /// - Any other shape fails the install (`custom_fetcher_failed`): a fetcher
+    ///   that claims a package via [`CustomFetcher::can_fetch`] must delegate,
+    ///   because direct content fetch isn't supported yet.
+    ///
+    /// The built-in fetch path runs with the original resolution unchanged
+    /// only when no fetcher claims the package.
     async fn fetch(&self, pkg_id: &str, resolution: Value, opts: Value)
     -> Result<Value, HookError>;
 }

--- a/pacquet/crates/hooks/src/lib.rs
+++ b/pacquet/crates/hooks/src/lib.rs
@@ -130,8 +130,9 @@ pub trait PnpmfileHooks: Send + Sync {
 /// A custom fetcher exported from a pnpmfile's `fetchers` array.
 ///
 /// Custom fetchers are consulted before the built-in fetchers. If `can_fetch`
-/// returns `true`, the package is fetched via `fetch` instead of the standard
-/// tarball/git/directory path.
+/// returns `true`, `fetch` is called. Currently only delegation is supported:
+/// the fetcher returns `{ "delegate": <LockfileResolution> }` to rewrite the
+/// resolution and fall through to the built-in fetch path.
 #[async_trait]
 pub trait CustomFetcher: Send + Sync {
     fn has_can_fetch(&self) -> bool {
@@ -145,9 +146,13 @@ pub trait CustomFetcher: Send + Sync {
     /// Determines whether this fetcher handles the given package.
     async fn can_fetch(&self, pkg_id: &str, resolution: Value) -> Result<bool, HookError>;
 
-    /// Fetches the package and returns a files-index value describing the
-    /// extracted contents. The returned JSON is a map of relative archive
-    /// paths to objects containing `integrity` and optional `mode`.
+    /// Calls the fetcher hook. The returned JSON envelope is interpreted by the
+    /// installer:
+    ///
+    /// - `{ "delegate": <resolution> }` — rewrites the lockfile resolution and
+    ///   falls through to the built-in fetch path for the rewritten value.
+    /// - Any other shape (or `None` from the picker) — the built-in fetch path
+    ///   runs with the original resolution unchanged.
     async fn fetch(&self, pkg_id: &str, resolution: Value, opts: Value)
     -> Result<Value, HookError>;
 }

--- a/pacquet/crates/hooks/src/lib.rs
+++ b/pacquet/crates/hooks/src/lib.rs
@@ -3,6 +3,7 @@ use derive_more::Display;
 use serde_json::Value;
 use std::sync::Arc;
 
+pub mod custom_fetcher_adapter;
 pub mod custom_resolver_adapter;
 pub mod finder;
 pub mod node_runtime;
@@ -118,6 +119,37 @@ pub trait PnpmfileHooks: Send + Sync {
     async fn get_custom_resolvers(&self) -> Result<Vec<Arc<dyn CustomResolver>>, HookError> {
         Ok(vec![])
     }
+
+    /// Get custom fetchers exported from the pnpmfile's top-level
+    /// `fetchers` array.
+    async fn get_custom_fetchers(&self) -> Result<Vec<Arc<dyn CustomFetcher>>, HookError> {
+        Ok(vec![])
+    }
+}
+
+/// A custom fetcher exported from a pnpmfile's `fetchers` array.
+///
+/// Custom fetchers are consulted before the built-in fetchers. If `can_fetch`
+/// returns `true`, the package is fetched via `fetch` instead of the standard
+/// tarball/git/directory path.
+#[async_trait]
+pub trait CustomFetcher: Send + Sync {
+    fn has_can_fetch(&self) -> bool {
+        true
+    }
+
+    fn has_fetch(&self) -> bool {
+        true
+    }
+
+    /// Determines whether this fetcher handles the given package.
+    async fn can_fetch(&self, pkg_id: &str, resolution: Value) -> Result<bool, HookError>;
+
+    /// Fetches the package and returns a files-index value describing the
+    /// extracted contents. The returned JSON is a map of relative archive
+    /// paths to objects containing `integrity` and optional `mode`.
+    async fn fetch(&self, pkg_id: &str, resolution: Value, opts: Value)
+    -> Result<Value, HookError>;
 }
 
 /// A custom resolver exported from a pnpmfile. The pnpmfile interface's

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -341,6 +341,19 @@ impl crate::PnpmfileHooks for NodeJsHooks {
             })
             .collect())
     }
+
+    async fn get_custom_fetchers(&self) -> Result<Vec<Arc<dyn crate::CustomFetcher>>, HookError> {
+        let worker = self.worker().await?;
+        let capabilities = worker.get_fetcher_capabilities().await?;
+        Ok(capabilities
+            .into_iter()
+            .enumerate()
+            .map(|(index, capabilities)| {
+                Arc::new(NodeJsCustomFetcher { worker: Arc::clone(&worker), index, capabilities })
+                    as Arc<dyn crate::CustomFetcher>
+            })
+            .collect())
+    }
 }
 
 pub struct NodeJsCustomResolver {
@@ -402,6 +415,52 @@ impl crate::CustomResolver for NodeJsCustomResolver {
             )
             .await?;
         Ok(res.as_bool().unwrap_or(false))
+    }
+}
+
+pub struct NodeJsCustomFetcher {
+    worker: Arc<NodeWorker>,
+    index: usize,
+    capabilities: crate::worker::FetcherCapabilities,
+}
+
+#[async_trait]
+impl crate::CustomFetcher for NodeJsCustomFetcher {
+    fn has_can_fetch(&self) -> bool {
+        self.capabilities.can_fetch
+    }
+
+    fn has_fetch(&self) -> bool {
+        self.capabilities.fetch
+    }
+
+    async fn can_fetch(&self, pkg_id: &str, resolution: Value) -> Result<bool, HookError> {
+        let res = self
+            .worker
+            .call_fetcher(
+                self.index,
+                "canFetch",
+                serde_json::json!([pkg_id, resolution]),
+                Arc::new(|_| {}),
+            )
+            .await?;
+        Ok(res.as_bool().unwrap_or(false))
+    }
+
+    async fn fetch(
+        &self,
+        pkg_id: &str,
+        resolution: Value,
+        opts: Value,
+    ) -> Result<Value, HookError> {
+        self.worker
+            .call_fetcher(
+                self.index,
+                "fetch",
+                serde_json::json!([pkg_id, resolution, opts]),
+                Arc::new(|_| {}),
+            )
+            .await
     }
 }
 

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -449,15 +449,20 @@ impl crate::CustomFetcher for NodeJsCustomFetcher {
 
     async fn fetch(
         &self,
-        pkg_id: &str,
+        _pkg_id: &str,
         resolution: Value,
         opts: Value,
     ) -> Result<Value, HookError> {
+        // Positional parity with the TypeScript hook signature
+        // `fetch(cafs, resolution, opts, fetchers)`: `cafs` and
+        // `fetchers` cannot cross the IPC boundary, so they are `null`
+        // placeholders — a portable pnpmfile fetcher detects their
+        // absence and answers with `{ delegate: <resolution> }`.
         self.worker
             .call_fetcher(
                 self.index,
                 "fetch",
-                serde_json::json!([pkg_id, resolution, opts]),
+                serde_json::json!([Value::Null, resolution, opts, Value::Null]),
                 Arc::new(|_| {}),
             )
             .await

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -444,7 +444,7 @@ impl crate::CustomFetcher for NodeJsCustomFetcher {
                 Arc::new(|_| {}),
             )
             .await?;
-        Ok(res.as_bool().unwrap_or(false))
+        Ok(!res.is_null() && res != false)
     }
 
     async fn fetch(

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -444,7 +444,7 @@ impl crate::CustomFetcher for NodeJsCustomFetcher {
                 Arc::new(|_| {}),
             )
             .await?;
-        Ok(!res.is_null() && res != false)
+        Ok(is_js_truthy(&res))
     }
 
     async fn fetch(
@@ -461,6 +461,17 @@ impl crate::CustomFetcher for NodeJsCustomFetcher {
                 Arc::new(|_| {}),
             )
             .await
+    }
+}
+
+/// Match JavaScript's truthiness rules for JSON-representable values.
+/// Falsy: `null`, `false`, `0`, `""`. Everything else is truthy.
+fn is_js_truthy(value: &Value) -> bool {
+    match value {
+        Value::Null | Value::Bool(false) => false,
+        Value::Number(n) => n.as_f64() != Some(0.0),
+        Value::String(s) => !s.is_empty(),
+        _ => true,
     }
 }
 

--- a/pacquet/crates/hooks/src/worker.rs
+++ b/pacquet/crates/hooks/src/worker.rs
@@ -48,6 +48,15 @@ pub struct ResolverCapabilities {
     pub should_refresh_resolution: bool,
 }
 
+/// Which optional methods one custom fetcher in the pnpmfile's
+/// `fetchers` array implements.
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FetcherCapabilities {
+    pub can_fetch: bool,
+    pub fetch: bool,
+}
+
 struct Pending {
     log: LogFn,
     done: oneshot::Sender<Result<Value, String>>,
@@ -190,6 +199,37 @@ impl NodeWorker {
         serde_json::from_value(value).map_err(|err| self.exec_err(err.to_string()))
     }
 
+    /// Call `method` on the custom fetcher at `index` in the pnpmfile's
+    /// `fetchers` array, forwarding any `context.log(...)` to `log`.
+    pub async fn call_fetcher(
+        &self,
+        index: usize,
+        method: &str,
+        payload: Value,
+        log: LogFn,
+    ) -> Result<Value, HookError> {
+        self.request(
+            method,
+            serde_json::json!({
+                "target": "fetcher",
+                "index": index,
+                "method": method,
+                "payload": payload,
+            }),
+            log,
+        )
+        .await
+    }
+
+    /// Get the capabilities of every custom fetcher exported by the
+    /// pnpmfile's `fetchers` array, in array order.
+    pub async fn get_fetcher_capabilities(&self) -> Result<Vec<FetcherCapabilities>, HookError> {
+        let value = self
+            .request("fetchers", serde_json::json!({ "target": "fetchers" }), Arc::new(|_| {}))
+            .await?;
+        serde_json::from_value(value).map_err(|err| self.exec_err(err.to_string()))
+    }
+
     /// Send one request `body` (an object the worker dispatches on) and
     /// await its reply, stamping in the request id and routing any
     /// `context.log(...)` lines to `log`. `label` names the request in a
@@ -290,6 +330,26 @@ async function handle(line) {{
       }}
       const args = req.payload || [];
       const res = await resolver[req.method](...args);
+      send({{ ok: res === undefined ? null : res }});
+      return;
+    }}
+    if (req.target === 'fetchers') {{
+      const fetchers = mod && mod.fetchers;
+      send({{ ok: (Array.isArray(fetchers) ? fetchers.map((f) => ({{
+        canFetch: typeof f.canFetch === 'function',
+        fetch: typeof f.fetch === 'function',
+      }})) : []) }});
+      return;
+    }}
+    if (req.target === 'fetcher') {{
+      const fetchers = mod && mod.fetchers;
+      const fetcher = Array.isArray(fetchers) ? fetchers[req.index] : null;
+      if (!fetcher || typeof fetcher[req.method] !== 'function') {{
+        send({{ ok: null }});
+        return;
+      }}
+      const args = req.payload || [];
+      const res = await fetcher[req.method](...args);
       send({{ ok: res === undefined ? null : res }});
       return;
     }}

--- a/pacquet/crates/hooks/src/worker.rs
+++ b/pacquet/crates/hooks/src/worker.rs
@@ -336,8 +336,8 @@ async function handle(line) {{
     if (req.target === 'fetchers') {{
       const fetchers = mod && mod.fetchers;
       send({{ ok: (Array.isArray(fetchers) ? fetchers.map((f) => ({{
-        canFetch: typeof f.canFetch === 'function',
-        fetch: typeof f.fetch === 'function',
+        canFetch: f != null && typeof f.canFetch === 'function',
+        fetch: f != null && typeof f.fetch === 'function',
       }})) : []) }});
       return;
     }}

--- a/pacquet/crates/hooks/tests/node_hooks.rs
+++ b/pacquet/crates/hooks/tests/node_hooks.rs
@@ -823,3 +823,108 @@ export const fetchers = [{
     let result = fetchers[0].fetch("x@1.0.0", resolution, serde_json::json!({})).await.unwrap();
     assert_eq!(result["filesIndex"]["main.js"]["integrity"], "sha512-esm");
 }
+
+#[tokio::test]
+async fn custom_fetcher_delegate_response_round_trips() {
+    let tmp = TempDir::new().expect("temp dir");
+    let pnpmfile_path = tmp.path().join(".pnpmfile.cjs");
+    std::fs::write(
+        &pnpmfile_path,
+        r#"
+module.exports = {
+  fetchers: [{
+    canFetch (pkgId, resolution) {
+      return resolution.type === '@custom/proxy';
+    },
+    fetch (pkgId, resolution, opts) {
+      return {
+        delegate: {
+          type: "tarball",
+          tarball: resolution.proxyUrl,
+          integrity: "sha512-delegated",
+        },
+      };
+    },
+  }],
+}
+"#,
+    )
+    .expect("write pnpmfile");
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks::new(pnpmfile_path);
+    let fetchers = hooks.get_custom_fetchers().await.expect("load fetchers");
+
+    let resolution = serde_json::json!({
+        "type": "@custom/proxy",
+        "proxyUrl": "https://proxy.example.com/foo-1.0.0.tgz",
+    });
+    assert!(fetchers[0].can_fetch("foo@1.0.0", resolution.clone()).await.unwrap());
+    let result = fetchers[0].fetch("foo@1.0.0", resolution, serde_json::json!({})).await.unwrap();
+    assert_eq!(result["delegate"]["tarball"], "https://proxy.example.com/foo-1.0.0.tgz");
+    assert_eq!(result["delegate"]["integrity"], "sha512-delegated");
+}
+
+#[tokio::test]
+async fn custom_fetcher_null_entries_are_skipped() {
+    let tmp = TempDir::new().expect("temp dir");
+    let pnpmfile_path = tmp.path().join(".pnpmfile.cjs");
+    std::fs::write(
+        &pnpmfile_path,
+        r"
+module.exports = {
+  fetchers: [
+    null,
+    undefined,
+    { canFetch() { return true; }, fetch() { return { delegate: {} }; } },
+  ],
+}
+",
+    )
+    .expect("write pnpmfile");
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks::new(pnpmfile_path);
+    let fetchers = hooks.get_custom_fetchers().await.expect("load fetchers");
+
+    assert_eq!(fetchers.len(), 3);
+    assert!(!fetchers[0].has_can_fetch());
+    assert!(!fetchers[0].has_fetch());
+    assert!(!fetchers[1].has_can_fetch());
+    assert!(!fetchers[1].has_fetch());
+    assert!(fetchers[2].has_can_fetch());
+    assert!(fetchers[2].has_fetch());
+}
+
+#[tokio::test]
+async fn custom_fetcher_can_fetch_truthy_values() {
+    let tmp = TempDir::new().expect("temp dir");
+    let pnpmfile_path = tmp.path().join(".pnpmfile.cjs");
+    std::fs::write(
+        &pnpmfile_path,
+        r#"
+module.exports = {
+  fetchers: [
+    { canFetch() { return 1; }, fetch() { return { delegate: {} }; } },
+    { canFetch() { return "yes"; }, fetch() { return { delegate: {} }; } },
+    { canFetch() { return 0; }, fetch() { return { delegate: {} }; } },
+    { canFetch() { return ""; }, fetch() { return { delegate: {} }; } },
+  ],
+}
+"#,
+    )
+    .expect("write pnpmfile");
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks::new(pnpmfile_path);
+    let fetchers = hooks.get_custom_fetchers().await.expect("load fetchers");
+    let empty_resolution = serde_json::json!({});
+
+    assert!(
+        fetchers[0].can_fetch("a@1.0.0", empty_resolution.clone()).await.unwrap(),
+        "1 is truthy",
+    );
+    assert!(
+        fetchers[1].can_fetch("a@1.0.0", empty_resolution.clone()).await.unwrap(),
+        r#""yes" is truthy"#,
+    );
+    assert!(
+        !fetchers[2].can_fetch("a@1.0.0", empty_resolution.clone()).await.unwrap(),
+        "0 is falsy",
+    );
+    assert!(!fetchers[3].can_fetch("a@1.0.0", empty_resolution).await.unwrap(), r#""" is falsy"#,);
+}

--- a/pacquet/crates/hooks/tests/node_hooks.rs
+++ b/pacquet/crates/hooks/tests/node_hooks.rs
@@ -926,5 +926,5 @@ module.exports = {
         !fetchers[2].can_fetch("a@1.0.0", empty_resolution.clone()).await.unwrap(),
         "0 is falsy",
     );
-    assert!(!fetchers[3].can_fetch("a@1.0.0", empty_resolution).await.unwrap(), r#""" is falsy"#,);
+    assert!(!fetchers[3].can_fetch("a@1.0.0", empty_resolution).await.unwrap(), r#""" is falsy"#);
 }

--- a/pacquet/crates/hooks/tests/node_hooks.rs
+++ b/pacquet/crates/hooks/tests/node_hooks.rs
@@ -672,3 +672,154 @@ async fn custom_resolver_errors_propagate() {
 
     assert!(err.to_string().contains("refresh check crashed"), "got: {err}");
 }
+
+// --- Custom fetcher integration tests ---
+
+fn write_custom_fetchers_pnpmfile(dir: &std::path::Path) -> std::path::PathBuf {
+    let pnpmfile_path = dir.join(".pnpmfile.cjs");
+    std::fs::write(
+        &pnpmfile_path,
+        r"
+module.exports = {
+  fetchers: [
+    {
+      canFetch (pkgId, resolution) {
+        return resolution.type === '@custom/local';
+      },
+      fetch (pkgId, resolution, opts) {
+        return {
+          filesIndex: {
+            'package.json': {
+              integrity: 'sha512-abc123',
+              mode: 420,
+            },
+            'index.js': {
+              integrity: 'sha512-def456',
+              mode: 420,
+            },
+          },
+          receivedPkgId: pkgId,
+          receivedUrl: resolution.url,
+        };
+      },
+    },
+    {
+      canFetch () { return false; },
+    },
+  ],
+}
+",
+    )
+    .expect("write pnpmfile");
+    pnpmfile_path
+}
+
+#[tokio::test]
+async fn get_custom_fetchers_reports_per_fetcher_capabilities() {
+    let tmp = TempDir::new().expect("temp dir");
+    let hooks =
+        pacquet_hooks::node_runtime::NodeJsHooks::new(write_custom_fetchers_pnpmfile(tmp.path()));
+
+    let fetchers = hooks.get_custom_fetchers().await.expect("load fetchers");
+
+    assert_eq!(fetchers.len(), 2);
+    assert!(fetchers[0].has_can_fetch());
+    assert!(fetchers[0].has_fetch());
+    assert!(fetchers[1].has_can_fetch());
+    assert!(!fetchers[1].has_fetch());
+}
+
+#[tokio::test]
+async fn get_custom_fetchers_is_empty_without_fetchers_export() {
+    let tmp = TempDir::new().expect("temp dir");
+    let pnpmfile_path = tmp.path().join(".pnpmfile.cjs");
+    std::fs::write(&pnpmfile_path, "module.exports = { hooks: {} }").expect("write pnpmfile");
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks::new(pnpmfile_path);
+
+    let fetchers = hooks.get_custom_fetchers().await.expect("load fetchers");
+
+    assert!(fetchers.is_empty());
+}
+
+#[tokio::test]
+async fn custom_fetcher_round_trips_can_fetch_and_fetch() {
+    let tmp = TempDir::new().expect("temp dir");
+    let hooks =
+        pacquet_hooks::node_runtime::NodeJsHooks::new(write_custom_fetchers_pnpmfile(tmp.path()));
+    let fetchers = hooks.get_custom_fetchers().await.expect("load fetchers");
+    let resolution =
+        serde_json::json!({ "type": "@custom/local", "url": "https://example.com/pkg" });
+
+    assert!(fetchers[0].can_fetch("foo@1.0.0", resolution.clone()).await.expect("canFetch"),);
+    assert!(
+        !fetchers[0]
+            .can_fetch("foo@1.0.0", serde_json::json!({ "type": "tarball" }))
+            .await
+            .expect("canFetch"),
+    );
+
+    let opts = serde_json::json!({ "manifest": { "name": "foo" } });
+    let result = fetchers[0].fetch("foo@1.0.0", resolution, opts).await.expect("fetch");
+    assert_eq!(result["filesIndex"]["package.json"]["integrity"], "sha512-abc123");
+    assert_eq!(result["receivedPkgId"], "foo@1.0.0");
+    assert_eq!(result["receivedUrl"], "https://example.com/pkg");
+}
+
+#[tokio::test]
+async fn custom_fetcher_errors_propagate() {
+    let tmp = TempDir::new().expect("temp dir");
+    let pnpmfile_path = tmp.path().join(".pnpmfile.cjs");
+    std::fs::write(
+        &pnpmfile_path,
+        r"
+module.exports = {
+  fetchers: [{
+    canFetch () { return true; },
+    fetch () { throw new Error('fetch crashed'); },
+  }],
+}
+",
+    )
+    .expect("write pnpmfile");
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks::new(pnpmfile_path);
+    let fetchers = hooks.get_custom_fetchers().await.expect("load fetchers");
+
+    let err = fetchers[0]
+        .fetch("foo@1.0.0", serde_json::json!({}), serde_json::json!({}))
+        .await
+        .expect_err("throwing fetch must surface as an error");
+
+    assert!(err.to_string().contains("fetch crashed"), "got: {err}");
+}
+
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "Node.js ESM import() on Windows resolves absolute paths differently"
+)]
+#[tokio::test]
+async fn custom_fetcher_works_with_mjs_pnpmfile() {
+    let tmp = TempDir::new().expect("temp dir");
+    let pnpmfile_path = tmp.path().join(".pnpmfile.mjs");
+    std::fs::write(
+        &pnpmfile_path,
+        r"
+export const fetchers = [{
+  canFetch (pkgId, resolution) {
+    return resolution.type === '@custom/esm';
+  },
+  fetch (pkgId, resolution) {
+    return { filesIndex: { 'main.js': { integrity: 'sha512-esm' } } };
+  },
+}];
+",
+    )
+    .expect("write pnpmfile");
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks::new(pnpmfile_path);
+    let fetchers = hooks.get_custom_fetchers().await.expect("load fetchers");
+
+    assert_eq!(fetchers.len(), 1);
+    let resolution = serde_json::json!({ "type": "@custom/esm" });
+    assert!(fetchers[0].can_fetch("x@1.0.0", resolution.clone()).await.unwrap());
+    let result = fetchers[0].fetch("x@1.0.0", resolution, serde_json::json!({})).await.unwrap();
+    assert_eq!(result["filesIndex"]["main.js"]["integrity"], "sha512-esm");
+}

--- a/pacquet/crates/hooks/tests/node_hooks.rs
+++ b/pacquet/crates/hooks/tests/node_hooks.rs
@@ -686,7 +686,7 @@ module.exports = {
       canFetch (pkgId, resolution) {
         return resolution.type === '@custom/local';
       },
-      fetch (pkgId, resolution, opts) {
+      fetch (cafs, resolution, opts, fetchers) {
         return {
           filesIndex: {
             'package.json': {
@@ -698,8 +698,10 @@ module.exports = {
               mode: 420,
             },
           },
-          receivedPkgId: pkgId,
+          receivedNullCafs: cafs === null,
+          receivedNullFetchers: fetchers === null,
           receivedUrl: resolution.url,
+          receivedOpts: opts,
         };
       },
     },
@@ -758,11 +760,15 @@ async fn custom_fetcher_round_trips_can_fetch_and_fetch() {
             .expect("canFetch"),
     );
 
-    let opts = serde_json::json!({ "manifest": { "name": "foo" } });
-    let result = fetchers[0].fetch("foo@1.0.0", resolution, opts).await.expect("fetch");
+    let opts = serde_json::json!({ "pkg": { "name": "foo", "version": "1.0.0" } });
+    let result = fetchers[0].fetch("foo@1.0.0", resolution, opts.clone()).await.expect("fetch");
     assert_eq!(result["filesIndex"]["package.json"]["integrity"], "sha512-abc123");
-    assert_eq!(result["receivedPkgId"], "foo@1.0.0");
+    // TS-parity positions: `cafs` / `fetchers` are null placeholders
+    // over IPC, `resolution` and `opts` arrive in the TS slots.
+    assert_eq!(result["receivedNullCafs"], true);
+    assert_eq!(result["receivedNullFetchers"], true);
     assert_eq!(result["receivedUrl"], "https://example.com/pkg");
+    assert_eq!(result["receivedOpts"], opts);
 }
 
 #[tokio::test]
@@ -807,7 +813,7 @@ export const fetchers = [{
   canFetch (pkgId, resolution) {
     return resolution.type === '@custom/esm';
   },
-  fetch (pkgId, resolution) {
+  fetch (cafs, resolution) {
     return { filesIndex: { 'main.js': { integrity: 'sha512-esm' } } };
   },
 }];
@@ -836,10 +842,9 @@ module.exports = {
     canFetch (pkgId, resolution) {
       return resolution.type === '@custom/proxy';
     },
-    fetch (pkgId, resolution, opts) {
+    fetch (cafs, resolution, opts, fetchers) {
       return {
         delegate: {
-          type: "tarball",
           tarball: resolution.proxyUrl,
           integrity: "sha512-delegated",
         },

--- a/pacquet/crates/hooks/tests/node_hooks.rs
+++ b/pacquet/crates/hooks/tests/node_hooks.rs
@@ -750,7 +750,7 @@ async fn custom_fetcher_round_trips_can_fetch_and_fetch() {
     let resolution =
         serde_json::json!({ "type": "@custom/local", "url": "https://example.com/pkg" });
 
-    assert!(fetchers[0].can_fetch("foo@1.0.0", resolution.clone()).await.expect("canFetch"),);
+    assert!(fetchers[0].can_fetch("foo@1.0.0", resolution.clone()).await.expect("canFetch"));
     assert!(
         !fetchers[0]
             .can_fetch("foo@1.0.0", serde_json::json!({ "type": "tarball" }))

--- a/pacquet/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
+++ b/pacquet/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
@@ -298,9 +298,13 @@ fn is_registry_shaped_resolution(resolution: &LockfileResolution) -> bool {
             .variants
             .iter()
             .all(|variant| is_registry_shaped_resolution(&variant.resolution)),
+        // Custom resolutions are opaque to the npm verifier — they are
+        // fetched by a pnpmfile custom fetcher, never bound to the
+        // registry's `dist.tarball`.
         LockfileResolution::Directory(_)
         | LockfileResolution::Git(_)
-        | LockfileResolution::Binary(_) => false,
+        | LockfileResolution::Binary(_)
+        | LockfileResolution::Custom(_) => false,
     }
 }
 

--- a/pacquet/crates/lockfile/src/resolution.rs
+++ b/pacquet/crates/lockfile/src/resolution.rs
@@ -1,4 +1,4 @@
-use derive_more::{From, TryInto};
+use derive_more::{Display, From, TryInto};
 use pipe_trait::Pipe;
 use serde::{Deserialize, Serialize};
 use ssri::Integrity;
@@ -162,6 +162,60 @@ pub struct VariationsResolution {
     pub variants: Vec<PlatformAssetResolution>,
 }
 
+/// The `type` tag of a [`CustomResolution`]. Any tag other than the
+/// built-in kinds (`directory`, `git`, `binary`, `variations`) is
+/// custom — matching `classifyResolution` in
+/// `pnpm11/resolving/resolver-base/src/index.ts`, which routes every
+/// unrecognized `type` to the custom fetch path. Rejecting the built-in
+/// tags here keeps a malformed built-in resolution (e.g. a `git` entry
+/// missing `commit`) a hard parse error instead of silently
+/// reclassifying it as custom.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Display)]
+#[serde(try_from = "String", into = "String")]
+pub struct CustomResolutionType(String);
+
+impl CustomResolutionType {
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for CustomResolutionType {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            "directory" | "git" | "binary" | "variations" => {
+                Err(format!("`{value}` is a built-in resolution type, not a custom one"))
+            }
+            _ => Ok(Self(value)),
+        }
+    }
+}
+
+impl From<CustomResolutionType> for String {
+    fn from(value: CustomResolutionType) -> Self {
+        value.0
+    }
+}
+
+/// A resolution whose `type` is not one of the built-in kinds —
+/// produced by a custom resolver from a pnpmfile and fetchable only by
+/// a custom fetcher. The object is preserved verbatim (key order
+/// included, via `serde_json`'s `preserve_order`) so the pnpmfile's
+/// fetcher sees exactly what its resolver wrote to the lockfile.
+///
+/// Mirrors the TypeScript `CustomResolution` in
+/// `pnpm11/resolving/resolver-base/src/index.ts`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CustomResolution {
+    #[serde(rename = "type")]
+    pub resolution_type: CustomResolutionType,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
 /// Host triple used to pick a variant out of a [`VariationsResolution`].
 ///
 /// `libc`'s tri-state encodes the `string | null | undefined` shape:
@@ -232,6 +286,7 @@ pub enum LockfileResolution {
     Git(GitResolution),
     Binary(BinaryResolution),
     Variations(VariationsResolution),
+    Custom(CustomResolution),
 }
 
 impl LockfileResolution {
@@ -245,10 +300,13 @@ impl LockfileResolution {
             // Directory / Git resolutions have no integrity.
             // Variations is a meta-shape — the integrity lives on the
             // picked variant's inner resolution, so callers must
-            // resolve through `pick_variant` first.
+            // resolve through `pick_variant` first. Custom resolutions
+            // are opaque — whatever integrity scheme they carry belongs
+            // to the custom fetcher, not the built-in verification.
             LockfileResolution::Directory(_)
             | LockfileResolution::Git(_)
-            | LockfileResolution::Variations(_) => None,
+            | LockfileResolution::Variations(_)
+            | LockfileResolution::Custom(_) => None,
         }
     }
 
@@ -394,12 +452,19 @@ enum TaggedResolution {
 }
 
 /// Intermediate helper type for serde.
+///
+/// `Custom` must stay the last untagged variant: it accepts any object
+/// with a non-built-in `type` tag, so every built-in shape has to get
+/// its chance to match (or to *fail loudly* — [`CustomResolutionType`]
+/// rejects built-in tags, keeping a malformed built-in resolution a
+/// parse error rather than a silent reclassification) first.
 #[derive(Serialize, Deserialize, From, TryInto)]
 #[serde(untagged)]
 enum ResolutionSerde {
     Tarball(TarballResolution),
     Registry(RegistryResolution),
     Tagged(TaggedResolution),
+    Custom(CustomResolution),
 }
 
 impl From<ResolutionSerde> for LockfileResolution {
@@ -419,6 +484,7 @@ impl From<ResolutionSerde> for LockfileResolution {
             ResolutionSerde::Tagged(TaggedResolution::Git(resolution)) => resolution.into(),
             ResolutionSerde::Tagged(TaggedResolution::Binary(resolution)) => resolution.into(),
             ResolutionSerde::Tagged(TaggedResolution::Variations(resolution)) => resolution.into(),
+            ResolutionSerde::Custom(resolution) => resolution.into(),
         }
     }
 }
@@ -523,6 +589,7 @@ impl From<LockfileResolution> for ResolutionSerde {
             LockfileResolution::Variations(resolution) => {
                 resolution.pipe(TaggedResolution::from).into()
             }
+            LockfileResolution::Custom(resolution) => resolution.into(),
         }
     }
 }

--- a/pacquet/crates/lockfile/src/resolution.rs
+++ b/pacquet/crates/lockfile/src/resolution.rs
@@ -170,7 +170,7 @@ pub struct VariationsResolution {
 /// tags here keeps a malformed built-in resolution (e.g. a `git` entry
 /// missing `commit`) a hard parse error instead of silently
 /// reclassifying it as custom.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Display)]
+#[derive(Debug, Display, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct CustomResolutionType(String);
 
@@ -206,7 +206,7 @@ impl From<CustomResolutionType> for String {
 /// included, via `serde_json`'s `preserve_order`) so the pnpmfile's
 /// fetcher sees exactly what its resolver wrote to the lockfile.
 ///
-/// Mirrors the TypeScript `CustomResolution` in
+/// Mirrors the TypeScript interface of the same name in
 /// `pnpm11/resolving/resolver-base/src/index.ts`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CustomResolution {

--- a/pacquet/crates/lockfile/src/resolution/tests.rs
+++ b/pacquet/crates/lockfile/src/resolution/tests.rs
@@ -748,7 +748,7 @@ fn serialize_custom_resolution() {
     let received = render_resolution(&custom_cdn_resolution());
     eprintln!("RECEIVED:\n{received}");
     let expected = format!(
-        "resolution: {{integrity: {SHA512}, type: custom:cdn, url: https://cdn.example.com/pkg.tgz}}"
+        "resolution: {{integrity: {SHA512}, type: custom:cdn, url: https://cdn.example.com/pkg.tgz}}",
     );
     assert_eq!(received, expected);
 }

--- a/pacquet/crates/lockfile/src/resolution/tests.rs
+++ b/pacquet/crates/lockfile/src/resolution/tests.rs
@@ -710,3 +710,73 @@ fn to_lockfile_form_keeps_tarball_with_trailing_scheme_separator() {
         }),
     );
 }
+
+// --- Custom resolutions ---
+
+fn custom_cdn_resolution() -> LockfileResolution {
+    let mut extra = serde_json::Map::new();
+    extra.insert(
+        "url".to_string(),
+        serde_json::Value::String("https://cdn.example.com/pkg.tgz".to_string()),
+    );
+    extra.insert("integrity".to_string(), serde_json::Value::String(SHA512.to_string()));
+    LockfileResolution::Custom(super::CustomResolution {
+        resolution_type: "custom:cdn".to_string().try_into().expect("custom type tag"),
+        extra,
+    })
+}
+
+#[test]
+fn deserialize_custom_resolution_preserves_unknown_fields() {
+    let yaml = text_block! {
+        "type: custom:cdn"
+        "url: https://cdn.example.com/pkg.tgz"
+        "region: eu-west-1"
+    };
+    let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
+    dbg!(&received);
+    let LockfileResolution::Custom(custom) = &received else {
+        panic!("expected a custom resolution, got {received:?}");
+    };
+    assert_eq!(custom.resolution_type.as_str(), "custom:cdn");
+    assert_eq!(custom.extra["url"], "https://cdn.example.com/pkg.tgz");
+    assert_eq!(custom.extra["region"], "eu-west-1");
+}
+
+#[test]
+fn serialize_custom_resolution() {
+    let received = render_resolution(&custom_cdn_resolution());
+    eprintln!("RECEIVED:\n{received}");
+    let expected = format!(
+        "resolution: {{integrity: {SHA512}, type: custom:cdn, url: https://cdn.example.com/pkg.tgz}}"
+    );
+    assert_eq!(received, expected);
+}
+
+/// Custom resolutions enter pacquet as `serde_json::Value`s from a
+/// pnpmfile custom resolver, so the JSON path must round-trip them
+/// exactly (field set and `type` tag included).
+#[test]
+fn custom_resolution_round_trips_through_json() {
+    let resolution = custom_cdn_resolution();
+    let value = serde_json::to_value(&resolution).unwrap();
+    dbg!(&value);
+    assert_eq!(value["type"], "custom:cdn");
+    let parsed: LockfileResolution = serde_json::from_value(value).unwrap();
+    assert_eq!(parsed, resolution);
+}
+
+/// A malformed built-in resolution must stay a parse error: the custom
+/// passthrough accepts only non-built-in `type` tags, so a `git` entry
+/// missing its `commit` cannot silently reclassify as custom and dodge
+/// the strict built-in shape checks.
+#[test]
+fn deserialize_rejects_malformed_builtin_resolution() {
+    let yaml = text_block! {
+        "type: git"
+        "repo: https://github.com/user/repo.git"
+    };
+    let received = serde_saphyr::from_str::<LockfileResolution>(yaml);
+    dbg!(&received);
+    assert!(received.is_err(), "a git resolution without a commit must not parse");
+}

--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -1223,6 +1223,11 @@ fn snapshot_cache_key(
                 _ => Ok(None),
             }
         }
+        // Custom resolutions have no built-in warm-cache key — the
+        // cold path consults the pnpmfile custom fetchers, and the
+        // delegated resolution (unknowable here) determines the row
+        // that gets written.
+        LockfileResolution::Custom(_) => Ok(None),
     }
 }
 

--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -7,6 +7,7 @@ use futures_util::future;
 use miette::Diagnostic;
 use pacquet_config::{Config, NodeLinker, PackageImportMethod};
 use pacquet_deps_path::get_pkg_id_with_patch_hash;
+use pacquet_hooks::custom_fetcher_adapter::CustomFetcherPicker;
 use pacquet_lockfile::{
     LockfileResolution, PackageKey, PackageMetadata, PkgIdWithPatchHash, PkgName, PkgNameVerPeer,
     SnapshotEntry, select_platform_variant,
@@ -27,7 +28,7 @@ use std::{
     collections::{HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
-    sync::atomic::AtomicU8,
+    sync::{Arc, atomic::AtomicU8},
 };
 
 /// Bundled package manifests recovered from the `SQLite` store index
@@ -174,6 +175,9 @@ pub struct CreateVirtualStore<'a> {
     /// the fresh-resolve path's [`crate::PrefetchingResolver`] (closing
     /// <https://github.com/pnpm/pnpm/issues/12241>); `None` otherwise.
     pub tarball_mem_cache: Option<&'a std::sync::Arc<MemCache>>,
+    /// Custom fetchers from `.pnpmfile.mjs`. Consulted per snapshot
+    /// before the built-in resolution-type dispatch.
+    pub custom_fetcher_picker: Option<&'a Arc<CustomFetcherPicker>>,
     #[cfg(test)]
     pub(crate) link_concurrency_probe:
         Option<&'a crate::create_virtual_dir_by_snapshot::tests::LinkConcurrencyProbe>,
@@ -223,6 +227,7 @@ impl CreateVirtualStore<'_> {
             node_linker,
             progress_reported,
             tarball_mem_cache,
+            custom_fetcher_picker,
             #[cfg(test)]
             link_concurrency_probe,
         } = self;
@@ -801,6 +806,7 @@ impl CreateVirtualStore<'_> {
                         skipped,
                         workspace_root,
                         node_linker,
+                        custom_fetcher_picker,
                         // The slot link is deferred to the parallel pass
                         // below so it doesn't serialize inside this
                         // cooperative `try_join_all` task.

--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -1280,7 +1280,8 @@ fn is_fetch_side_failure(err: &InstallPackageBySnapshotError) -> bool {
         err,
         InstallPackageBySnapshotError::DownloadTarball(_)
             | InstallPackageBySnapshotError::GitFetch(_)
-            | InstallPackageBySnapshotError::DirectoryFetch(_),
+            | InstallPackageBySnapshotError::DirectoryFetch(_)
+            | InstallPackageBySnapshotError::CustomFetcher(_),
     )
 }
 

--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -175,7 +175,7 @@ pub struct CreateVirtualStore<'a> {
     /// the fresh-resolve path's [`crate::PrefetchingResolver`] (closing
     /// <https://github.com/pnpm/pnpm/issues/12241>); `None` otherwise.
     pub tarball_mem_cache: Option<&'a std::sync::Arc<MemCache>>,
-    /// Custom fetchers from `.pnpmfile.mjs`. Consulted per snapshot
+    /// Custom fetchers from the pnpmfile. Consulted per snapshot
     /// before the built-in resolution-type dispatch.
     pub custom_fetcher_picker: Option<&'a Arc<CustomFetcherPicker>>,
     #[cfg(test)]

--- a/pacquet/crates/package-manager/src/create_virtual_store/tests.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store/tests.rs
@@ -185,6 +185,7 @@ async fn cold_batch_links_slots_in_parallel() {
         node_linker: NodeLinker::Isolated,
         progress_reported: &progress_reported,
         tarball_mem_cache: Some(&mem_cache),
+        custom_fetcher_picker: None,
         link_concurrency_probe: Some(&probe),
     }
     .run::<SilentReporter>()

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -952,6 +952,7 @@ where
                 node_linker,
                 progress_reported: &progress_reported,
                 tarball_mem_cache,
+                custom_fetcher_picker: None,
                 #[cfg(test)]
                 link_concurrency_probe: None,
             }

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -934,6 +934,7 @@ where
             .await
             .map_err(InstallFrozenLockfileError::LockfileVerification)
         };
+        let custom_fetcher_picker = load_custom_fetcher_picker(workspace_root).await;
         let create_virtual_store_fut = async {
             CreateVirtualStore {
                 http_client,
@@ -952,7 +953,7 @@ where
                 node_linker,
                 progress_reported: &progress_reported,
                 tarball_mem_cache,
-                custom_fetcher_picker: None,
+                custom_fetcher_picker: custom_fetcher_picker.as_ref(),
                 #[cfg(test)]
                 link_concurrency_probe: None,
             }
@@ -1800,6 +1801,20 @@ pub(crate) fn find_own_runtime_node_major(snapshot: &SnapshotEntry) -> Option<u3
         return Some(ver_peer.version_semver()?.major as u32);
     }
     None
+}
+
+/// Load custom fetchers from the pnpmfile at `lockfile_dir`, if any.
+/// Returns `None` when no pnpmfile exists or exports no fetchers, so
+/// the install path can skip the IPC overhead entirely.
+async fn load_custom_fetcher_picker(
+    lockfile_dir: &Path,
+) -> Option<Arc<pacquet_hooks::custom_fetcher_adapter::CustomFetcherPicker>> {
+    let hook = pacquet_hooks::finder::load_pnpmfile(lockfile_dir)?;
+    let fetchers = hook.get_custom_fetchers().await.ok()?;
+    if fetchers.is_empty() {
+        return None;
+    }
+    Some(Arc::new(pacquet_hooks::custom_fetcher_adapter::CustomFetcherPicker::new(fetchers)))
 }
 
 #[cfg(test)]

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -195,6 +195,13 @@ pub enum InstallFrozenLockfileError {
     #[diagnostic(transparent)]
     CreateVirtualStore(#[error(source)] CreateVirtualStoreError),
 
+    /// The pnpmfile threw while loading its custom `fetchers` export.
+    /// A throwing pnpmfile aborts the install, matching the
+    /// custom-resolver load on the fresh-lockfile path.
+    #[display("{_0}")]
+    #[diagnostic(code(PNPMFILE_FAIL))]
+    CustomFetcherHook(#[error(not(source))] pacquet_hooks::HookError),
+
     #[diagnostic(transparent)]
     SymlinkDirectDependencies(#[error(source)] SymlinkDirectDependenciesError),
 
@@ -934,7 +941,7 @@ where
             .await
             .map_err(InstallFrozenLockfileError::LockfileVerification)
         };
-        let custom_fetcher_picker = load_custom_fetcher_picker(workspace_root).await;
+        let custom_fetcher_picker = load_custom_fetcher_picker(workspace_root).await?;
         let create_virtual_store_fut = async {
             CreateVirtualStore {
                 http_client,
@@ -1804,23 +1811,30 @@ pub(crate) fn find_own_runtime_node_major(snapshot: &SnapshotEntry) -> Option<u3
 }
 
 /// Load custom fetchers from the pnpmfile at `lockfile_dir`, if any.
-/// Returns `None` when no pnpmfile exists or exports no fetchers, so
-/// the install path can skip the IPC overhead entirely.
+/// Returns `Ok(None)` when no pnpmfile exists or it exports no
+/// fetchers, so the install path can skip the IPC overhead entirely.
+/// A pnpmfile that fails to load or evaluate aborts the install, like
+/// the custom-resolver load on the fresh-lockfile path.
 async fn load_custom_fetcher_picker(
     lockfile_dir: &Path,
-) -> Option<Arc<pacquet_hooks::custom_fetcher_adapter::CustomFetcherPicker>> {
-    let hook = pacquet_hooks::finder::load_pnpmfile(lockfile_dir)?;
-    let fetchers = match hook.get_custom_fetchers().await {
-        Ok(f) => f,
-        Err(err) => {
-            tracing::warn!(%err, "failed to load custom fetchers from pnpmfile");
-            return None;
-        }
+) -> Result<
+    Option<Arc<pacquet_hooks::custom_fetcher_adapter::CustomFetcherPicker>>,
+    InstallFrozenLockfileError,
+> {
+    let Some(hook) = pacquet_hooks::finder::load_pnpmfile(lockfile_dir) else {
+        return Ok(None);
     };
+    let fetchers = hook.get_custom_fetchers().await.map_err(|err| {
+        tracing::error!(
+            target: "pacquet::install",
+            "Failed to get custom fetchers from pnpmfile: {err}",
+        );
+        InstallFrozenLockfileError::CustomFetcherHook(err)
+    })?;
     if fetchers.is_empty() {
-        return None;
+        return Ok(None);
     }
-    Some(Arc::new(pacquet_hooks::custom_fetcher_adapter::CustomFetcherPicker::new(fetchers)))
+    Ok(Some(Arc::new(pacquet_hooks::custom_fetcher_adapter::CustomFetcherPicker::new(fetchers))))
 }
 
 #[cfg(test)]

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -1810,7 +1810,13 @@ async fn load_custom_fetcher_picker(
     lockfile_dir: &Path,
 ) -> Option<Arc<pacquet_hooks::custom_fetcher_adapter::CustomFetcherPicker>> {
     let hook = pacquet_hooks::finder::load_pnpmfile(lockfile_dir)?;
-    let fetchers = hook.get_custom_fetchers().await.ok()?;
+    let fetchers = match hook.get_custom_fetchers().await {
+        Ok(f) => f,
+        Err(err) => {
+            tracing::warn!(%err, "failed to load custom fetchers from pnpmfile");
+            return None;
+        }
+    };
     if fetchers.is_empty() {
         return None;
     }

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile/tests.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile/tests.rs
@@ -50,3 +50,62 @@ fn empty_dependencies_yields_none() {
     let snapshot = SnapshotEntry::default();
     assert_eq!(find_own_runtime_node_major(&snapshot), None);
 }
+
+// --- load_custom_fetcher_picker ---
+
+#[tokio::test]
+async fn load_custom_fetcher_picker_is_none_without_a_pnpmfile() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let picker = super::load_custom_fetcher_picker(tmp.path())
+        .await
+        .expect("a missing pnpmfile is not an error");
+    assert!(picker.is_none());
+}
+
+#[tokio::test]
+async fn load_custom_fetcher_picker_is_none_when_pnpmfile_exports_no_fetchers() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(tmp.path().join(".pnpmfile.cjs"), "module.exports = { hooks: {} }\n")
+        .expect("write pnpmfile");
+    let picker = super::load_custom_fetcher_picker(tmp.path())
+        .await
+        .expect("a fetchers-less pnpmfile is not an error");
+    assert!(picker.is_none());
+}
+
+#[tokio::test]
+async fn load_custom_fetcher_picker_returns_a_picker_for_exported_fetchers() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        tmp.path().join(".pnpmfile.cjs"),
+        "module.exports = { fetchers: [{ canFetch () { return false }, fetch () { return null } }] }\n",
+    )
+    .expect("write pnpmfile");
+    let picker = super::load_custom_fetcher_picker(tmp.path())
+        .await
+        .expect("a well-formed fetchers export must load")
+        .expect("one exported fetcher must yield a picker");
+    assert!(!picker.is_empty());
+}
+
+/// A pnpmfile that fails to evaluate aborts the install rather than
+/// silently proceeding without custom fetchers — a package whose fetch
+/// the pnpmfile was meant to intercept must not fall through to the
+/// built-in dispatch.
+#[tokio::test]
+async fn load_custom_fetcher_picker_propagates_a_broken_pnpmfile() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(tmp.path().join(".pnpmfile.cjs"), "throw new Error('pnpmfile exploded')\n")
+        .expect("write pnpmfile");
+    let Err(err) = super::load_custom_fetcher_picker(tmp.path()).await else {
+        panic!("a throwing pnpmfile must fail the load");
+    };
+    assert!(
+        matches!(
+            &err,
+            super::InstallFrozenLockfileError::CustomFetcherHook(hook_err)
+                if hook_err.to_string().contains("pnpmfile exploded"),
+        ),
+        "expected the pnpmfile error to propagate, got {err:?}",
+    );
+}

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
@@ -10,6 +10,7 @@ use pacquet_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
 use pacquet_fs::lexical_normalize;
 use pacquet_git_fetcher::{GitFetchOutput, GitFetcher, GitFetcherError, GitHostedTarballFetcher};
 use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
+use pacquet_hooks::custom_fetcher_adapter::CustomFetcherPicker;
 use pacquet_lockfile::{
     BinaryArchive, BinaryResolution, BinarySpec, DirectoryResolution, LockfileResolution,
     PackageKey, PackageMetadata, PlatformSelector, SnapshotEntry, select_platform_variant,
@@ -112,6 +113,10 @@ pub struct InstallPackageBySnapshot<'a> {
     /// land in the store, so this is purely about whether the
     /// virtual-store slot gets materialized.
     pub node_linker: NodeLinker,
+    /// Custom fetchers from `.pnpmfile.mjs`'s `fetchers` export.
+    /// Consulted before the built-in resolution-type dispatch; `None`
+    /// when no pnpmfile exports fetchers.
+    pub custom_fetcher_picker: Option<&'a Arc<CustomFetcherPicker>>,
     /// When `true`, return the fetched CAS paths without populating the
     /// virtual-store slot ([`CreateVirtualDirBySnapshot`]) — the caller
     /// links them itself in a separate parallel pass. The cold batch in
@@ -165,6 +170,11 @@ pub enum InstallPackageBySnapshotError {
     /// `includeOnlyPackageFiles` mode.
     #[diagnostic(transparent)]
     DirectoryFetch(#[error(source)] DirectoryFetcherError),
+
+    /// A custom fetcher from `.pnpmfile.mjs` threw or returned an error.
+    #[display("Custom fetcher failed: {_0}")]
+    #[diagnostic(code(pacquet_package_manager::custom_fetcher_failed))]
+    CustomFetcher(#[error(not(source))] String),
 
     /// No variant in a [`LockfileResolution::Variations`] matches the
     /// host triple `(os, cpu, libc?)`. Surfaces with the host triple
@@ -257,6 +267,7 @@ impl InstallPackageBySnapshot<'_> {
             skipped,
             workspace_root,
             node_linker,
+            custom_fetcher_picker,
             defer_link,
             #[cfg(test)]
             link_concurrency_probe,
@@ -285,10 +296,40 @@ impl InstallPackageBySnapshot<'_> {
             }
         };
 
-        let cas_paths: HashMap<String, PathBuf> = match &metadata.resolution {
+        // Consult custom fetchers before the built-in dispatch. A custom
+        // fetcher that returns a `delegate` field triggers the standard
+        // tarball download with the rewritten resolution rather than
+        // replacing the fetch entirely.
+        let effective_resolution: Option<LockfileResolution> =
+            if let Some(picker) = custom_fetcher_picker {
+                let resolution_value =
+                    serde_json::to_value(&metadata.resolution).unwrap_or(serde_json::Value::Null);
+                let opts_value = serde_json::json!({
+                    "packageKey": package_key.to_string(),
+                    "version": metadata.version,
+                });
+                match picker.try_fetch(&package_id, &resolution_value, &opts_value).await {
+                    Ok(Some(result)) => {
+                        if let Some(delegate) = result.get("delegate") {
+                            serde_json::from_value(delegate.clone()).ok()
+                        } else {
+                            None
+                        }
+                    }
+                    Ok(None) => None,
+                    Err(err) => {
+                        return Err(InstallPackageBySnapshotError::CustomFetcher(err.to_string()));
+                    }
+                }
+            } else {
+                None
+            };
+        let resolution = effective_resolution.as_ref().unwrap_or(&metadata.resolution);
+
+        let cas_paths: HashMap<String, PathBuf> = match resolution {
             LockfileResolution::Tarball(_) | LockfileResolution::Registry(_) => {
                 let (tarball_url, integrity) =
-                    tarball_url_and_integrity(&metadata.resolution, package_key, config)?;
+                    tarball_url_and_integrity(resolution, package_key, config)?;
                 let tarball_url = local_file_tarball_install_url(tarball_url, self.workspace_root);
                 let download = DownloadTarballToStore {
                     http_client,
@@ -332,9 +373,7 @@ impl InstallPackageBySnapshot<'_> {
                 // warm store, so remote tarballs must take the standalone
                 // path.
                 let raw_cas_paths = match tarball_mem_cache {
-                    Some(mem_cache)
-                        if matches!(&metadata.resolution, LockfileResolution::Registry(_)) =>
-                    {
+                    Some(mem_cache) if matches!(resolution, LockfileResolution::Registry(_)) => {
                         // `clone()` is cheap (refs + `Arc`s) and lets us
                         // retry through `run_without_mem_cache` below if
                         // the shared download failed.
@@ -357,7 +396,7 @@ impl InstallPackageBySnapshot<'_> {
                 // `remoteTarballFetcher`, because the host's archive
                 // endpoint doesn't run `prepare`/`prepublish*` and
                 // the file set typically needs packlist filtering.
-                if let LockfileResolution::Tarball(t) = &metadata.resolution
+                if let LockfileResolution::Tarball(t) = resolution
                     && t.git_hosted == Some(true)
                 {
                     // `built` tracks `!ignore_scripts`, in lock-step

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
@@ -317,7 +317,10 @@ impl InstallPackageBySnapshot<'_> {
                             ))
                         })?)
                     } else {
-                        None
+                        return Err(InstallPackageBySnapshotError::CustomFetcher(format!(
+                            "custom fetcher claimed {package_id} but returned an unhandled \
+                             response (expected {{ \"delegate\": ... }})",
+                        )));
                     }
                 }
                 Ok(None) => None,

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
@@ -296,38 +296,38 @@ impl InstallPackageBySnapshot<'_> {
             }
         };
 
-        let effective_resolution: Option<LockfileResolution> =
-            if let Some(picker) = custom_fetcher_picker {
-                let resolution_value =
-                    serde_json::to_value(&metadata.resolution).map_err(|err| {
-                        InstallPackageBySnapshotError::CustomFetcher(format!(
-                            "failed to serialize resolution for {package_id}: {err}",
-                        ))
-                    })?;
-                let opts_value = serde_json::json!({
-                    "packageKey": package_key.to_string(),
-                    "version": metadata.version,
-                });
-                match picker.try_fetch(&package_id, &resolution_value, &opts_value).await {
-                    Ok(Some(result)) => {
-                        if let Some(delegate) = result.get("delegate") {
-                            Some(serde_json::from_value(delegate.clone()).map_err(|err| {
-                                InstallPackageBySnapshotError::CustomFetcher(format!(
-                                    "invalid delegate resolution for {package_id}: {err}",
-                                ))
-                            })?)
-                        } else {
-                            None
-                        }
-                    }
-                    Ok(None) => None,
-                    Err(err) => {
-                        return Err(InstallPackageBySnapshotError::CustomFetcher(err.to_string()));
+        let effective_resolution: Option<LockfileResolution> = if let Some(picker) =
+            custom_fetcher_picker
+        {
+            let resolution_value = serde_json::to_value(&metadata.resolution).map_err(|err| {
+                InstallPackageBySnapshotError::CustomFetcher(format!(
+                    "failed to serialize resolution for {package_id}: {err}",
+                ))
+            })?;
+            let opts_value = serde_json::json!({
+                "packageKey": package_key.to_string(),
+                "version": metadata.version,
+            });
+            match picker.try_fetch(&package_id, &resolution_value, &opts_value).await {
+                Ok(Some(result)) => {
+                    if let Some(delegate) = result.get("delegate") {
+                        Some(serde_json::from_value(delegate.clone()).map_err(|err| {
+                            InstallPackageBySnapshotError::CustomFetcher(format!(
+                                "invalid delegate resolution for {package_id}: {err}",
+                            ))
+                        })?)
+                    } else {
+                        None
                     }
                 }
-            } else {
-                None
-            };
+                Ok(None) => None,
+                Err(err) => {
+                    return Err(InstallPackageBySnapshotError::CustomFetcher(err.to_string()));
+                }
+            }
+        } else {
+            None
+        };
         let resolution = effective_resolution.as_ref().unwrap_or(&metadata.resolution);
 
         let cas_paths: HashMap<String, PathBuf> = match resolution {

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
@@ -296,14 +296,14 @@ impl InstallPackageBySnapshot<'_> {
             }
         };
 
-        // Consult custom fetchers before the built-in dispatch. A custom
-        // fetcher that returns a `delegate` field triggers the standard
-        // tarball download with the rewritten resolution rather than
-        // replacing the fetch entirely.
         let effective_resolution: Option<LockfileResolution> =
             if let Some(picker) = custom_fetcher_picker {
                 let resolution_value =
-                    serde_json::to_value(&metadata.resolution).unwrap_or(serde_json::Value::Null);
+                    serde_json::to_value(&metadata.resolution).map_err(|err| {
+                        InstallPackageBySnapshotError::CustomFetcher(format!(
+                            "failed to serialize resolution for {package_id}: {err}",
+                        ))
+                    })?;
                 let opts_value = serde_json::json!({
                     "packageKey": package_key.to_string(),
                     "version": metadata.version,
@@ -311,7 +311,11 @@ impl InstallPackageBySnapshot<'_> {
                 match picker.try_fetch(&package_id, &resolution_value, &opts_value).await {
                     Ok(Some(result)) => {
                         if let Some(delegate) = result.get("delegate") {
-                            serde_json::from_value(delegate.clone()).ok()
+                            Some(serde_json::from_value(delegate.clone()).map_err(|err| {
+                                InstallPackageBySnapshotError::CustomFetcher(format!(
+                                    "invalid delegate resolution for {package_id}: {err}",
+                                ))
+                            })?)
                         } else {
                             None
                         }

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
@@ -176,6 +176,16 @@ pub enum InstallPackageBySnapshotError {
     #[diagnostic(code(pacquet_package_manager::custom_fetcher_failed))]
     CustomFetcher(#[error(not(source))] String),
 
+    /// A custom-typed resolution reached the built-in dispatch — no
+    /// pnpmfile custom fetcher claimed it. Message and code mirror the
+    /// TypeScript `pickFetcher` in
+    /// `pnpm11/fetching/pick-fetcher/src/index.ts`.
+    #[display(
+        "Cannot fetch dependency with custom resolution type \"{resolution_type}\". Custom resolutions must be handled by custom fetchers."
+    )]
+    #[diagnostic(code(UNSUPPORTED_RESOLUTION_TYPE))]
+    UnsupportedResolutionType { resolution_type: String },
+
     /// No variant in a [`LockfileResolution::Variations`] matches the
     /// host triple `(os, cpu, libc?)`. Surfaces with the host triple
     /// plus the list of advertised target triples so the user can see
@@ -304,9 +314,18 @@ impl InstallPackageBySnapshot<'_> {
                     "failed to serialize resolution for {package_id}: {err}",
                 ))
             })?;
+            // Shaped like the TypeScript `FetchOptions` subset a
+            // delegating fetcher can use (`pkg`, `lockfileDir`), so one
+            // pnpmfile works on both stacks.
             let opts_value = serde_json::json!({
-                "packageKey": package_key.to_string(),
-                "version": metadata.version,
+                "pkg": {
+                    "name": package_key.name.to_string(),
+                    "version": metadata
+                        .version
+                        .clone()
+                        .unwrap_or_else(|| package_key.suffix.version().to_string()),
+                },
+                "lockfileDir": workspace_root,
             });
             match picker.try_fetch(&package_id, &resolution_value, &opts_value).await {
                 Ok(Some(result)) => {
@@ -518,6 +537,7 @@ impl InstallPackageBySnapshot<'_> {
                             LockfileResolution::Directory(_) => "directory",
                             LockfileResolution::Git(_) => "git",
                             LockfileResolution::Variations(_) => "variations",
+                            LockfileResolution::Custom(_) => "custom",
                             // Already matched above; reach is unreachable.
                             LockfileResolution::Binary(_) => "binary",
                         },
@@ -567,6 +587,14 @@ impl InstallPackageBySnapshot<'_> {
                 .await
                 .map_err(InstallPackageBySnapshotError::GitFetch)?;
                 cas_paths
+            }
+            // A custom fetcher had its chance above (`try_fetch`) and
+            // either declined or wasn't loaded; without one there is
+            // no way to materialize a custom-typed resolution.
+            LockfileResolution::Custom(custom) => {
+                return Err(InstallPackageBySnapshotError::UnsupportedResolutionType {
+                    resolution_type: custom.resolution_type.to_string(),
+                });
             }
         };
 
@@ -670,14 +698,15 @@ pub fn tarball_url_and_integrity<'a>(
             Ok((Cow::Owned(tarball_url), &registry_resolution.integrity))
         }
         // Caller (`run`) only invokes this helper for the tarball /
-        // registry arms; git, directory, binary, and variations
-        // resolutions never reach here. Return an unreachable-style
-        // error so a future caller that forgets to gate gets a
-        // clear panic in debug.
+        // registry arms; git, directory, binary, variations, and
+        // custom resolutions never reach here. Return an
+        // unreachable-style error so a future caller that forgets to
+        // gate gets a clear panic in debug.
         LockfileResolution::Directory(_)
         | LockfileResolution::Git(_)
         | LockfileResolution::Binary(_)
-        | LockfileResolution::Variations(_) => {
+        | LockfileResolution::Variations(_)
+        | LockfileResolution::Custom(_) => {
             unreachable!("tarball_url_and_integrity called with non-tarball resolution");
         }
     }

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
@@ -113,7 +113,7 @@ pub struct InstallPackageBySnapshot<'a> {
     /// land in the store, so this is purely about whether the
     /// virtual-store slot gets materialized.
     pub node_linker: NodeLinker,
-    /// Custom fetchers from `.pnpmfile.mjs`'s `fetchers` export.
+    /// Custom fetchers from the pnpmfile's `fetchers` export.
     /// Consulted before the built-in resolution-type dispatch; `None`
     /// when no pnpmfile exports fetchers.
     pub custom_fetcher_picker: Option<&'a Arc<CustomFetcherPicker>>,
@@ -171,7 +171,7 @@ pub enum InstallPackageBySnapshotError {
     #[diagnostic(transparent)]
     DirectoryFetch(#[error(source)] DirectoryFetcherError),
 
-    /// A custom fetcher from `.pnpmfile.mjs` threw or returned an error.
+    /// A custom fetcher from the pnpmfile threw or returned an error.
     #[display("Custom fetcher failed: {_0}")]
     #[diagnostic(code(pacquet_package_manager::custom_fetcher_failed))]
     CustomFetcher(#[error(not(source))] String),

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot/tests.rs
@@ -589,6 +589,303 @@ async fn cold_batch_falls_back_when_prefetch_failed() {
     drop(store_tmp);
 }
 
+/// A test-double custom fetcher: claims (or declines) every package and
+/// answers `fetch` with one scripted envelope, so each test below pins
+/// one branch of the delegate handling in
+/// [`super::InstallPackageBySnapshot::run`].
+struct ScriptedCustomFetcher {
+    claims: bool,
+    response: Result<serde_json::Value, pacquet_hooks::HookError>,
+}
+
+#[async_trait::async_trait]
+impl pacquet_hooks::CustomFetcher for ScriptedCustomFetcher {
+    async fn can_fetch(
+        &self,
+        _pkg_id: &str,
+        _resolution: serde_json::Value,
+    ) -> Result<bool, pacquet_hooks::HookError> {
+        Ok(self.claims)
+    }
+
+    async fn fetch(
+        &self,
+        _pkg_id: &str,
+        _resolution: serde_json::Value,
+        _opts: serde_json::Value,
+    ) -> Result<serde_json::Value, pacquet_hooks::HookError> {
+        self.response.clone()
+    }
+}
+
+fn scripted_picker(
+    claims: bool,
+    response: Result<serde_json::Value, pacquet_hooks::HookError>,
+) -> std::sync::Arc<pacquet_hooks::custom_fetcher_adapter::CustomFetcherPicker> {
+    std::sync::Arc::new(pacquet_hooks::custom_fetcher_adapter::CustomFetcherPicker::new(vec![
+        std::sync::Arc::new(ScriptedCustomFetcher { claims, response }),
+    ]))
+}
+
+/// Run one snapshot install for `foo@1.0.0` with the given custom
+/// fetcher picker. Hoisted linker + no store index keeps the run to the
+/// fetch-dispatch branch under test, mirroring the mem-cache tests
+/// above.
+async fn run_snapshot_install_with_picker(
+    config: &'static Config,
+    metadata: &pacquet_lockfile::PackageMetadata,
+    picker: &std::sync::Arc<pacquet_hooks::custom_fetcher_adapter::CustomFetcherPicker>,
+    tarball_mem_cache: Option<&std::sync::Arc<pacquet_tarball::MemCache>>,
+    workspace_root: &std::path::Path,
+) -> Result<std::collections::HashMap<String, std::path::PathBuf>, InstallPackageBySnapshotError> {
+    let package_key: PackageKey = "foo@1.0.0".parse().expect("parse key");
+    let layout = crate::VirtualStoreLayout::legacy(workspace_root.join("vstore"), 120);
+    let allow_build_policy = crate::AllowBuildPolicy::new(
+        std::collections::HashSet::default(),
+        std::collections::HashSet::default(),
+        false,
+    );
+    let skipped = crate::SkippedSnapshots::new();
+    let logged_methods = std::sync::atomic::AtomicU8::new(0);
+    let verified_files_cache = pacquet_store_dir::SharedVerifiedFilesCache::default();
+    let snapshot = pacquet_lockfile::SnapshotEntry::default();
+
+    super::InstallPackageBySnapshot {
+        http_client: &pacquet_network::ThrottledClient::default(),
+        config,
+        layout: &layout,
+        store_index: None,
+        store_index_writer: None,
+        prefetched_cas_paths: None,
+        progress_reported: None,
+        tarball_mem_cache,
+        verified_files_cache: &verified_files_cache,
+        logged_methods: &logged_methods,
+        requester: "/project",
+        package_key: &package_key,
+        metadata,
+        snapshot: &snapshot,
+        allow_build_policy: &allow_build_policy,
+        skipped: &skipped,
+        workspace_root,
+        node_linker: pacquet_config::NodeLinker::Hoisted,
+        custom_fetcher_picker: Some(picker),
+        defer_link: false,
+        link_concurrency_probe: None,
+    }
+    .run::<pacquet_reporter::SilentReporter>()
+    .await
+}
+
+/// The original resolution is a remote tarball that `offline: true`
+/// would reject; the fetcher delegates to a registry resolution whose
+/// derived URL is seeded in the mem cache. The install can only return
+/// the seeded CAS map if the delegate replaced the original resolution
+/// (the mem-cache reuse is gated on registry resolutions, and the
+/// original URL was never seeded).
+#[tokio::test]
+async fn custom_fetcher_delegate_rewrites_the_resolution() {
+    use pacquet_tarball::{CacheValue, MemCache};
+    use std::{collections::HashMap, path::PathBuf, sync::Arc};
+
+    let store_tmp = tempfile::tempdir().expect("tempdir");
+    let config = leaked_offline_config("https://registry.test", store_tmp.path());
+
+    let mut metadata = registry_metadata();
+    metadata.resolution = LockfileResolution::Tarball(pacquet_lockfile::TarballResolution {
+        tarball: "https://original.test/foo-1.0.0.tgz".to_string(),
+        integrity: Some(DUMMY_SHA512.parse().expect("parse integrity")),
+        git_hosted: None,
+        path: None,
+    });
+
+    let seeded: HashMap<String, PathBuf> =
+        HashMap::from([("package.json".to_string(), store_tmp.path().join("blob"))]);
+    let mem_cache = Arc::new(MemCache::default());
+    mem_cache.insert(
+        "https://registry.test/foo/-/foo-1.0.0.tgz".to_string(),
+        Arc::new(tokio::sync::RwLock::new(CacheValue::Available(Arc::new(seeded.clone())))),
+    );
+
+    let picker =
+        scripted_picker(true, Ok(serde_json::json!({ "delegate": { "integrity": DUMMY_SHA512 } })));
+
+    let cas_paths = run_snapshot_install_with_picker(
+        config,
+        &metadata,
+        &picker,
+        Some(&mem_cache),
+        store_tmp.path(),
+    )
+    .await
+    .expect("the delegated registry resolution must drive the fetch");
+
+    assert_eq!(cas_paths, seeded);
+
+    drop(store_tmp);
+}
+
+/// A fetcher whose `canFetch` declines must leave the original
+/// resolution in force: the install returns the CAS map seeded under
+/// the *original* registry URL. The scripted response would error if
+/// `fetch` ran (`can_fetch = false` must short-circuit it).
+#[tokio::test]
+async fn custom_fetcher_declining_falls_through_to_the_original_resolution() {
+    use pacquet_tarball::{CacheValue, MemCache};
+    use std::{collections::HashMap, path::PathBuf, sync::Arc};
+
+    let store_tmp = tempfile::tempdir().expect("tempdir");
+    let config = leaked_offline_config("https://registry.test", store_tmp.path());
+    let metadata = registry_metadata();
+
+    let seeded: HashMap<String, PathBuf> =
+        HashMap::from([("package.json".to_string(), store_tmp.path().join("blob"))]);
+    let mem_cache = Arc::new(MemCache::default());
+    mem_cache.insert(
+        "https://registry.test/foo/-/foo-1.0.0.tgz".to_string(),
+        Arc::new(tokio::sync::RwLock::new(CacheValue::Available(Arc::new(seeded.clone())))),
+    );
+
+    let picker = scripted_picker(
+        false,
+        Err(pacquet_hooks::HookError::Execution {
+            pnpmfile: ".pnpmfile.cjs".to_string(),
+            message: "fetch must not run for a declined package".to_string(),
+        }),
+    );
+
+    let cas_paths = run_snapshot_install_with_picker(
+        config,
+        &metadata,
+        &picker,
+        Some(&mem_cache),
+        store_tmp.path(),
+    )
+    .await
+    .expect("a declined package must take the built-in path unchanged");
+
+    assert_eq!(cas_paths, seeded);
+
+    drop(store_tmp);
+}
+
+/// A claiming fetcher that answers with anything other than
+/// `{ "delegate": ... }` fails the install — direct content fetch is
+/// not supported yet, so silently ignoring the response would make the
+/// fetcher a no-op.
+#[tokio::test]
+async fn custom_fetcher_unhandled_response_fails_the_install() {
+    let store_tmp = tempfile::tempdir().expect("tempdir");
+    let config = leaked_offline_config("https://registry.test", store_tmp.path());
+    let metadata = registry_metadata();
+
+    let picker = scripted_picker(true, Ok(serde_json::json!({ "filesIndex": {} })));
+
+    let err = run_snapshot_install_with_picker(config, &metadata, &picker, None, store_tmp.path())
+        .await
+        .expect_err("a non-delegate response must fail the install");
+
+    assert!(
+        matches!(
+            &err,
+            InstallPackageBySnapshotError::CustomFetcher(message)
+                if message.contains("unhandled response"),
+        ),
+        "expected the unhandled-response error, got {err:?}",
+    );
+
+    drop(store_tmp);
+}
+
+/// A delegate payload that doesn't parse as a lockfile resolution is a
+/// custom-fetcher error, not a silent fall-through to the original
+/// resolution.
+#[tokio::test]
+async fn custom_fetcher_invalid_delegate_fails_the_install() {
+    let store_tmp = tempfile::tempdir().expect("tempdir");
+    let config = leaked_offline_config("https://registry.test", store_tmp.path());
+    let metadata = registry_metadata();
+
+    let picker = scripted_picker(true, Ok(serde_json::json!({ "delegate": { "garbage": true } })));
+
+    let err = run_snapshot_install_with_picker(config, &metadata, &picker, None, store_tmp.path())
+        .await
+        .expect_err("a malformed delegate must fail the install");
+
+    assert!(
+        matches!(
+            &err,
+            InstallPackageBySnapshotError::CustomFetcher(message)
+                if message.contains("invalid delegate resolution"),
+        ),
+        "expected the invalid-delegate error, got {err:?}",
+    );
+
+    drop(store_tmp);
+}
+
+/// A delegate that is itself custom-typed is rejected — delegation is
+/// single-step, mirroring the TypeScript `pickFetcher`, which throws
+/// `ERR_PNPM_UNSUPPORTED_RESOLUTION_TYPE` for a custom-typed delegate.
+#[tokio::test]
+async fn custom_fetcher_custom_typed_delegate_is_rejected() {
+    let store_tmp = tempfile::tempdir().expect("tempdir");
+    let config = leaked_offline_config("https://registry.test", store_tmp.path());
+    let metadata = registry_metadata();
+
+    let picker =
+        scripted_picker(true, Ok(serde_json::json!({ "delegate": { "type": "custom:other" } })));
+
+    let err = run_snapshot_install_with_picker(config, &metadata, &picker, None, store_tmp.path())
+        .await
+        .expect_err("a custom-typed delegate must fail the install");
+
+    assert!(
+        matches!(
+            &err,
+            InstallPackageBySnapshotError::UnsupportedResolutionType { resolution_type }
+                if resolution_type == "custom:other",
+        ),
+        "expected the unsupported-resolution-type error, got {err:?}",
+    );
+
+    drop(store_tmp);
+}
+
+/// A throwing fetcher hook surfaces as
+/// [`InstallPackageBySnapshotError::CustomFetcher`] with the hook's
+/// message, so an optional snapshot can swallow it via
+/// `is_fetch_side_failure` and a required one aborts with context.
+#[tokio::test]
+async fn custom_fetcher_hook_error_propagates() {
+    let store_tmp = tempfile::tempdir().expect("tempdir");
+    let config = leaked_offline_config("https://registry.test", store_tmp.path());
+    let metadata = registry_metadata();
+
+    let picker = scripted_picker(
+        true,
+        Err(pacquet_hooks::HookError::Execution {
+            pnpmfile: ".pnpmfile.cjs".to_string(),
+            message: "fetch crashed".to_string(),
+        }),
+    );
+
+    let err = run_snapshot_install_with_picker(config, &metadata, &picker, None, store_tmp.path())
+        .await
+        .expect_err("a throwing fetcher must fail the install");
+
+    assert!(
+        matches!(
+            &err,
+            InstallPackageBySnapshotError::CustomFetcher(message)
+                if message.contains("fetch crashed"),
+        ),
+        "expected the hook error to propagate, got {err:?}",
+    );
+
+    drop(store_tmp);
+}
+
 /// A minimal runtime archive: one executable at `<top>/bin/node` and no
 /// `package.json`. Real Node.js / Bun / Deno archives likewise ship no
 /// manifest of their own; the synthesized `bin` comes from the
@@ -771,4 +1068,91 @@ async fn installing_a_runtime_persists_the_synthesized_manifest_into_the_store_i
     );
 
     drop((store_tmp, archive_tmp));
+}
+
+fn custom_resolution_metadata(resolution_type: &str) -> pacquet_lockfile::PackageMetadata {
+    let mut extra = serde_json::Map::new();
+    extra.insert(
+        "url".to_string(),
+        serde_json::Value::String("https://example.test/foo-1.0.0.tgz".to_string()),
+    );
+    let mut metadata = registry_metadata();
+    metadata.resolution = LockfileResolution::Custom(pacquet_lockfile::CustomResolution {
+        resolution_type: resolution_type.to_string().try_into().expect("custom type tag"),
+        extra,
+    });
+    metadata
+}
+
+/// The headline custom-fetcher scenario: a lockfile entry with a
+/// custom resolution type is claimed by the pnpmfile fetcher, which
+/// delegates to a registry resolution the built-in path can fetch
+/// (seeded in the mem cache here). The fetcher's `canFetch` must see
+/// the custom `type` tag exactly as the lockfile spells it.
+#[tokio::test]
+async fn custom_typed_resolution_installs_via_delegating_fetcher() {
+    use pacquet_tarball::{CacheValue, MemCache};
+    use std::{collections::HashMap, path::PathBuf, sync::Arc};
+
+    let store_tmp = tempfile::tempdir().expect("tempdir");
+    let config = leaked_offline_config("https://registry.test", store_tmp.path());
+    let metadata = custom_resolution_metadata("@my-org/custom");
+
+    let seeded: HashMap<String, PathBuf> =
+        HashMap::from([("package.json".to_string(), store_tmp.path().join("blob"))]);
+    let mem_cache = Arc::new(MemCache::default());
+    mem_cache.insert(
+        "https://registry.test/foo/-/foo-1.0.0.tgz".to_string(),
+        Arc::new(tokio::sync::RwLock::new(CacheValue::Available(Arc::new(seeded.clone())))),
+    );
+
+    let picker =
+        scripted_picker(true, Ok(serde_json::json!({ "delegate": { "integrity": DUMMY_SHA512 } })));
+
+    let cas_paths = run_snapshot_install_with_picker(
+        config,
+        &metadata,
+        &picker,
+        Some(&mem_cache),
+        store_tmp.path(),
+    )
+    .await
+    .expect("a delegating fetcher must install a custom-typed resolution");
+
+    assert_eq!(cas_paths, seeded);
+
+    drop(store_tmp);
+}
+
+/// A custom-typed resolution that no fetcher claims cannot be
+/// materialized: the built-in dispatch rejects it with the same
+/// message and code as the TypeScript `pickFetcher`
+/// (`ERR_PNPM_UNSUPPORTED_RESOLUTION_TYPE`).
+#[tokio::test]
+async fn custom_typed_resolution_without_a_claiming_fetcher_fails() {
+    let store_tmp = tempfile::tempdir().expect("tempdir");
+    let config = leaked_offline_config("https://registry.test", store_tmp.path());
+    let metadata = custom_resolution_metadata("custom:cdn");
+
+    let picker = scripted_picker(false, Ok(serde_json::Value::Null));
+
+    let err = run_snapshot_install_with_picker(config, &metadata, &picker, None, store_tmp.path())
+        .await
+        .expect_err("an unclaimed custom resolution must fail the install");
+
+    assert!(
+        matches!(
+            &err,
+            InstallPackageBySnapshotError::UnsupportedResolutionType { resolution_type }
+                if resolution_type == "custom:cdn",
+        ),
+        "expected the unsupported-resolution-type error, got {err:?}",
+    );
+    assert_eq!(
+        err.to_string(),
+        "Cannot fetch dependency with custom resolution type \"custom:cdn\". \
+         Custom resolutions must be handled by custom fetchers.",
+    );
+
+    drop(store_tmp);
 }

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot/tests.rs
@@ -1150,8 +1150,7 @@ async fn custom_typed_resolution_without_a_claiming_fetcher_fails() {
     );
     assert_eq!(
         err.to_string(),
-        "Cannot fetch dependency with custom resolution type \"custom:cdn\". \
-         Custom resolutions must be handled by custom fetchers.",
+        r#"Cannot fetch dependency with custom resolution type "custom:cdn". Custom resolutions must be handled by custom fetchers."#,
     );
 
     drop(store_tmp);

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot/tests.rs
@@ -422,6 +422,7 @@ async fn cold_batch_reuses_in_flight_prefetch_from_mem_cache() {
         // only the download-coordination branch and gets the CAS map
         // back directly.
         node_linker: pacquet_config::NodeLinker::Hoisted,
+        custom_fetcher_picker: None,
         defer_link: false,
         link_concurrency_probe: None,
     }
@@ -495,6 +496,7 @@ async fn without_mem_cache_skips_coordination_and_downloads() {
         skipped: &skipped,
         workspace_root: store_tmp.path(),
         node_linker: pacquet_config::NodeLinker::Hoisted,
+        custom_fetcher_picker: None,
         defer_link: false,
         link_concurrency_probe: None,
     }
@@ -568,6 +570,7 @@ async fn cold_batch_falls_back_when_prefetch_failed() {
         skipped: &skipped,
         workspace_root: store_tmp.path(),
         node_linker: pacquet_config::NodeLinker::Hoisted,
+        custom_fetcher_picker: None,
         defer_link: false,
         link_concurrency_probe: None,
     }
@@ -697,6 +700,7 @@ async fn installing_a_runtime_persists_the_synthesized_manifest_into_the_store_i
         skipped: &skipped,
         workspace_root: store_tmp.path(),
         node_linker: pacquet_config::NodeLinker::Hoisted,
+        custom_fetcher_picker: None,
         defer_link: false,
         link_concurrency_probe: None,
     }
@@ -754,6 +758,7 @@ async fn installing_a_runtime_persists_the_synthesized_manifest_into_the_store_i
         skipped: &skipped,
         workspace_root: store_tmp.path(),
         node_linker: pacquet_config::NodeLinker::Hoisted,
+        custom_fetcher_picker: None,
         defer_link: false,
         link_concurrency_probe: None,
     }

--- a/pacquet/crates/package-manager/src/install_package_from_registry.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry.rs
@@ -264,7 +264,8 @@ pub(crate) fn extract_tarball(
         | LockfileResolution::Directory(_)
         | LockfileResolution::Git(_)
         | LockfileResolution::Binary(_)
-        | LockfileResolution::Variations(_) => {
+        | LockfileResolution::Variations(_)
+        | LockfileResolution::Custom(_) => {
             Err(InstallPackageFromRegistryError::UnsupportedResolution {
                 detail: format!("{resolution:?}"),
             })

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -380,6 +380,13 @@ pub enum InstallWithFreshLockfileError {
     #[diagnostic(code(PNPMFILE_FAIL))]
     CustomResolverHook(#[error(not(source))] pacquet_hooks::HookError),
 
+    /// The pnpmfile threw while loading its custom `fetchers` export.
+    /// Same fatality rule as [`Self::CustomResolverHook`] and the
+    /// frozen-lockfile path's custom-fetcher load.
+    #[display("{_0}")]
+    #[diagnostic(code(PNPMFILE_FAIL))]
+    CustomFetcherHook(#[error(not(source))] pacquet_hooks::HookError),
+
     /// A custom resolver's `shouldRefreshResolution` hook threw while
     /// checking whether to force re-resolution. A throwing hook aborts
     /// the install.
@@ -742,6 +749,26 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             } else {
                 vec![]
             };
+        // Loaded alongside the custom resolvers (same worker, same
+        // fatality rule) and consumed by `CreateVirtualStore` below —
+        // a custom resolver typically writes the custom-typed
+        // resolutions its sibling fetcher materializes.
+        let custom_fetcher_picker: Option<
+            Arc<pacquet_hooks::custom_fetcher_adapter::CustomFetcherPicker>,
+        > = if let Some(ref hook) = pnpmfile_hook {
+            let fetchers = hook.get_custom_fetchers().await.map_err(|err| {
+                tracing::error!(
+                    target: "pacquet::install",
+                    "Failed to get custom fetchers from pnpmfile: {err}",
+                );
+                InstallWithFreshLockfileError::CustomFetcherHook(err)
+            })?;
+            (!fetchers.is_empty()).then(|| {
+                Arc::new(pacquet_hooks::custom_fetcher_adapter::CustomFetcherPicker::new(fetchers))
+            })
+        } else {
+            None
+        };
 
         // Chain order:
         // custom resolvers → npm → jsr (folded into npm) → git →
@@ -1590,7 +1617,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             // routing the cold batch through the mem cache fixes by
             // reusing the in-flight download instead.
             tarball_mem_cache: Some(&tarball_mem_cache),
-            custom_fetcher_picker: None,
+            custom_fetcher_picker: custom_fetcher_picker.as_ref(),
             #[cfg(test)]
             link_concurrency_probe: None,
         }

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1590,6 +1590,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             // routing the cold batch through the mem cache fixes by
             // reusing the in-flight download instead.
             tarball_mem_cache: Some(&tarball_mem_cache),
+            custom_fetcher_picker: None,
             #[cfg(test)]
             link_concurrency_probe: None,
         }

--- a/pacquet/crates/package-manager/src/patch.rs
+++ b/pacquet/crates/package-manager/src/patch.rs
@@ -409,6 +409,7 @@ fn resolution_kind(resolution: &LockfileResolution) -> &'static str {
         LockfileResolution::Git(_) => "git",
         LockfileResolution::Binary(_) => "binary",
         LockfileResolution::Variations(_) => "variations",
+        LockfileResolution::Custom(_) => "custom",
     }
 }
 

--- a/pacquet/crates/resolving-deps-resolver/src/lockfile_reuse.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/lockfile_reuse.rs
@@ -162,11 +162,14 @@ pub(crate) fn synthesize_reused_result(
         LockfileResolution::Registry(_) => {}
         LockfileResolution::Tarball(tarball)
             if tarball.integrity.is_some() && tarball.git_hosted != Some(true) => {}
+        // Custom resolutions fall through with the rest: reuse would
+        // bypass the pnpmfile custom resolver that owns them.
         LockfileResolution::Tarball(_)
         | LockfileResolution::Directory(_)
         | LockfileResolution::Git(_)
         | LockfileResolution::Binary(_)
-        | LockfileResolution::Variations(_) => return None,
+        | LockfileResolution::Variations(_)
+        | LockfileResolution::Custom(_) => return None,
     }
     let name_ver = PkgNameVer::new(metadata_key.name.clone(), version);
     let manifest = synthesize_manifest(&name_ver, metadata);

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -888,10 +888,13 @@ fn npm_registry_tarball(resolution: &LockfileResolution) -> Option<Option<&str>>
             }
             Some(Some(t.tarball.as_str()))
         }
+        // Custom resolutions have no packument lookup — the pnpmfile
+        // custom resolver, not the npm registry, is their authority.
         LockfileResolution::Directory(_)
         | LockfileResolution::Git(_)
         | LockfileResolution::Binary(_)
-        | LockfileResolution::Variations(_) => None,
+        | LockfileResolution::Variations(_)
+        | LockfileResolution::Custom(_) => None,
     }
 }
 

--- a/pnpm11/fetching/pick-fetcher/src/index.ts
+++ b/pnpm11/fetching/pick-fetcher/src/index.ts
@@ -8,7 +8,7 @@ import type {
   FetchResult,
   GitFetcher,
 } from '@pnpm/fetching.fetcher-base'
-import type { CustomFetcher } from '@pnpm/hooks.types'
+import type { CustomFetcher, CustomFetcherDelegation } from '@pnpm/hooks.types'
 import { type AtomicResolution, classifyResolution } from '@pnpm/resolving.resolver-base'
 import type { Cafs } from '@pnpm/store.cafs-types'
 
@@ -37,8 +37,21 @@ export async function pickFetcher (
             ? customFetcher.resolutionNeedsFetch.bind(customFetcher)
             : undefined
           return Object.assign(
-            async (cafs: Cafs, resolution: AtomicResolution, fetchOpts: FetchOptions): Promise<FetchResult> =>
-              customFetcher.fetch!(cafs, resolution, fetchOpts, fetcherByHostingType),
+            async (cafs: Cafs, resolution: AtomicResolution, fetchOpts: FetchOptions): Promise<FetchResult> => {
+              const result = await customFetcher.fetch!(cafs, resolution, fetchOpts, fetcherByHostingType)
+              if (isCustomFetcherDelegation(result)) {
+                // The `{ delegate }` envelope is the portable delegation form
+                // (it also works over pacquet's pnpmfile IPC, where `cafs` and
+                // `fetchers` cannot be passed): rewrite the resolution and run
+                // the built-in fetcher on the rewritten shape. A custom-typed
+                // `delegate` is rejected by `pickBuiltinFetcher`, keeping
+                // delegation single-step.
+                const delegate = result.delegate as AtomicResolution
+                const fetch = pickBuiltinFetcher(fetcherByHostingType, delegate) as FetchFunction
+                return fetch(cafs, delegate, fetchOpts)
+              }
+              return result
+            },
             { resolutionNeedsFetch }
           ) as FetchFunction
         }
@@ -46,6 +59,14 @@ export async function pickFetcher (
     }
   }
 
+  return pickBuiltinFetcher(fetcherByHostingType, resolution)
+}
+
+function isCustomFetcherDelegation (result: FetchResult | CustomFetcherDelegation): result is CustomFetcherDelegation {
+  return result != null && typeof result === 'object' && 'delegate' in result && !('filesMap' in result)
+}
+
+function pickBuiltinFetcher (fetcherByHostingType: Fetchers, resolution: AtomicResolution): PickedFetcher {
   const fetcherType = classifyResolution(resolution)
   if (fetcherType === 'custom') {
     throw new PnpmError(

--- a/pnpm11/fetching/pick-fetcher/test/customFetch.ts
+++ b/pnpm11/fetching/pick-fetcher/test/customFetch.ts
@@ -389,6 +389,87 @@ describe('custom fetcher implementation examples', () => {
       expect(result.filesMap.get('package.json')).toBeTruthy()
     })
 
+    test('custom fetcher can delegate by returning a { delegate } envelope', async () => {
+      clearDispatcherCache()
+      const mockAgent = new MockAgent()
+      mockAgent.disableNetConnect()
+      setGlobalDispatcher(mockAgent)
+
+      const tarballContent = fs.readFileSync(tarballPath)
+      const mockPool = mockAgent.get('http://localhost:4873')
+      mockPool.intercept({ path: '/enveloped-pkg.tgz', method: 'GET' }).reply(200, tarballContent, {
+        headers: { 'content-length': String(tarballContent.length) },
+      })
+
+      try {
+        const storeDir = temporaryDirectory()
+        const cafs = createCafsStore(storeDir)
+        const filesIndexFile = path.join(storeDir, 'index.json')
+
+        const fetchFromRegistry = createFetchFromRegistry({})
+        const tarballFetchers = createTarballFetcher(
+          fetchFromRegistry,
+          () => undefined,
+          { storeIndex }
+        )
+
+        // The envelope form works without touching `cafs` or `fetchers`, so
+        // the same pnpmfile fetcher also runs under pacquet's IPC bridge.
+        const customFetcher = createMockCustomFetcher(
+          (_pkgId, resolution) => resolution.type === 'custom:url',
+          (_cafs, resolution) => ({
+            delegate: {
+              tarball: (resolution as any).customUrl, // eslint-disable-line @typescript-eslint/no-explicit-any
+              integrity: tarballIntegrity,
+            },
+          })
+        )
+
+        const customResolution = createMockResolution({
+          type: 'custom:url',
+          customUrl: `${registry}enveloped-pkg.tgz`,
+        })
+
+        const fetcher = await pickFetcher(
+          tarballFetchers as Fetchers,
+          customResolution,
+          { customFetchers: [customFetcher], packageId: 'enveloped-pkg@1.0.0' }
+        )
+
+        const result = await fetcher(
+          cafs,
+          customResolution,
+          createMockFetchOptions({ filesIndexFile, lockfileDir: process.cwd() })
+        )
+
+        expect(result.filesMap.get('package.json')).toBeTruthy()
+      } finally {
+        await mockAgent.close()
+        setGlobalDispatcher(originalDispatcher)
+      }
+    })
+
+    test('a { delegate } envelope with a custom-typed resolution is rejected', async () => {
+      const customFetcher = createMockCustomFetcher(
+        () => true,
+        () => ({
+          delegate: createMockResolution({ type: 'custom:other' }),
+        })
+      )
+
+      const customResolution = createMockResolution({ type: 'custom:url' })
+
+      const fetcher = await pickFetcher(
+        createMockFetchers(),
+        customResolution,
+        { customFetchers: [customFetcher], packageId: 'pkg@1.0.0' }
+      )
+
+      await expect(
+        fetcher(createMockCafs(), customResolution, createMockFetchOptions())
+      ).rejects.toThrow('Cannot fetch dependency with custom resolution type "custom:other"')
+    })
+
     test('custom fetcher can transform resolution before delegating to tarball fetcher', async () => {
       clearDispatcherCache()
       const mockAgent = new MockAgent()

--- a/pnpm11/hooks/types/src/index.ts
+++ b/pnpm11/hooks/types/src/index.ts
@@ -86,6 +86,23 @@ export interface CustomResolver {
   shouldRefreshResolution?: (depPath: string, pkgSnapshot: PackageSnapshot) => boolean | Promise<boolean>
 }
 
+/**
+ * Portable delegation envelope a custom fetcher may return instead of a
+ * `FetchResult`: pnpm rewrites the package's resolution to `delegate` and
+ * runs the built-in fetch path on it. The delegated resolution must be a
+ * complete fetchable shape (e.g. `{ tarball, integrity }`) — a custom-typed
+ * `delegate` is rejected to keep delegation single-step.
+ *
+ * This is the only fetch strategy that works in both pnpm and pacquet: the
+ * Rust CLI invokes pnpmfile fetchers over IPC where `cafs` and `fetchers`
+ * cannot exist (both arrive as `null` there), so a fetcher that supports
+ * both stacks should return this envelope rather than calling `fetchers.*`
+ * directly.
+ */
+export interface CustomFetcherDelegation {
+  delegate: Resolution
+}
+
 export interface CustomFetcher extends ResolutionFetchContract {
   /**
    * Called to determine if this fetcher should handle fetching a package.
@@ -104,15 +121,17 @@ export interface CustomFetcher extends ResolutionFetchContract {
    *
    * The fetchers parameter provides access to pnpm's standard fetchers, allowing you
    * to delegate to them (e.g., transform a custom resolution to a tarball URL and use
-   * fetchers.remoteTarball).
+   * fetchers.remoteTarball). Alternatively, return a
+   * {@link CustomFetcherDelegation} envelope and pnpm performs the delegation
+   * itself — the portable form that also works in pacquet.
    *
    * @param cafs - The content-addressable file system to add package files to
    * @param resolution - The resolution object containing fetch information
    * @param opts - Fetch options including package manifest
    * @param fetchers - Standard pnpm fetchers available for delegation (remoteTarball, localTarball, git, etc.)
-   * @returns FetchResult with files index and other package information
+   * @returns FetchResult with files index and other package information, or a delegation envelope
    */
-  fetch?: (cafs: Cafs, resolution: Resolution, opts: FetchOptions, fetchers: Fetchers) => FetchResult | Promise<FetchResult>
+  fetch?: (cafs: Cafs, resolution: Resolution, opts: FetchOptions, fetchers: Fetchers) => FetchResult | CustomFetcherDelegation | Promise<FetchResult | CustomFetcherDelegation>
 }
 
 export {

--- a/pnpm11/installing/deps-installer/test/install/customFetchers.ts
+++ b/pnpm11/installing/deps-installer/test/install/customFetchers.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@jest/globals'
+import type { CustomFetcher, CustomResolver } from '@pnpm/hooks.types'
+import { addDependenciesToPackage } from '@pnpm/installing.deps-installer'
+import { prepareEmpty } from '@pnpm/prepare'
+import { getIntegrity, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
+
+import { testDefaults } from '../utils/index.js'
+
+// Mirrors pacquet's `crates/cli/tests/custom_fetchers.rs`: a custom resolver
+// writes a custom-typed resolution and the sibling fetcher materializes it by
+// returning the portable `{ delegate }` envelope — the shape that works
+// identically in both stacks.
+
+test('custom fetcher delegates a custom-typed resolution via the { delegate } envelope', async () => {
+  const project = prepareEmpty()
+
+  const customResolver: CustomResolver = {
+    canResolve: (descriptor) => descriptor.alias === '@pnpm.e2e/dep-of-pkg-with-1-dep',
+    resolve: async () => ({
+      id: '@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0',
+      resolution: {
+        type: 'custom:e2e',
+        url: `http://localhost:${REGISTRY_MOCK_PORT}/@pnpm.e2e/dep-of-pkg-with-1-dep/-/dep-of-pkg-with-1-dep-100.0.0.tgz`,
+        integrity: getIntegrity('@pnpm.e2e/dep-of-pkg-with-1-dep', '100.0.0'),
+      },
+    }),
+  }
+
+  let fetchCalls = 0
+  const delegatingFetcher: CustomFetcher = {
+    canFetch: (_pkgId, resolution) => resolution.type === 'custom:e2e',
+    fetch: (_cafs, resolution) => {
+      fetchCalls++
+      return {
+        delegate: {
+          tarball: (resolution as { url: string }).url,
+          integrity: (resolution as { integrity: string }).integrity,
+        },
+      }
+    },
+  }
+
+  await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'],
+    testDefaults({
+      customResolvers: [customResolver],
+      customFetchers: [delegatingFetcher],
+    })
+  )
+
+  expect(fetchCalls).toBe(1)
+  project.has('@pnpm.e2e/dep-of-pkg-with-1-dep')
+})
+
+test('a custom-typed resolution without a claiming fetcher fails the install', async () => {
+  prepareEmpty()
+
+  const customResolver: CustomResolver = {
+    canResolve: (descriptor) => descriptor.alias === '@pnpm.e2e/dep-of-pkg-with-1-dep',
+    resolve: async () => ({
+      id: '@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0',
+      resolution: {
+        type: 'custom:e2e',
+        url: `http://localhost:${REGISTRY_MOCK_PORT}/@pnpm.e2e/dep-of-pkg-with-1-dep/-/dep-of-pkg-with-1-dep-100.0.0.tgz`,
+        integrity: getIntegrity('@pnpm.e2e/dep-of-pkg-with-1-dep', '100.0.0'),
+      },
+    }),
+  }
+
+  await expect(
+    addDependenciesToPackage(
+      {},
+      ['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'],
+      testDefaults({
+        customResolvers: [customResolver],
+      })
+    )
+  ).rejects.toThrow('Cannot fetch dependency with custom resolution type "custom:e2e"')
+})

--- a/pnpm11/installing/deps-installer/test/utils/testDefaults.ts
+++ b/pnpm11/installing/deps-installer/test/utils/testDefaults.ts
@@ -1,4 +1,4 @@
-import type { CustomResolver } from '@pnpm/hooks.types'
+import type { CustomFetcher, CustomResolver } from '@pnpm/hooks.types'
 import type { InstallOptions } from '@pnpm/installing.deps-installer'
 import type { ResolutionVerifier } from '@pnpm/resolving.resolver-base'
 import type { StoreController } from '@pnpm/store.controller-types'
@@ -15,6 +15,7 @@ export function testDefaults<T> (
     prefix?: string
     registries?: Registries
     customResolvers?: CustomResolver[]
+    customFetchers?: CustomFetcher[]
     minimumReleaseAge?: number
     minimumReleaseAgeStrict?: boolean
     minimumReleaseAgeExclude?: string[]
@@ -44,11 +45,18 @@ export function testDefaults<T> (
     clientOptions: {
       ...(opts?.registries != null ? { registries: opts.registries } : {}),
       customResolvers: opts?.customResolvers,
+      customFetchers: opts?.customFetchers,
       ...policyClientOptions,
       ...resolveOpts,
       ...fetchOpts,
     },
-    storeOptions: storeOpts,
+    // The real CLI hands customFetchers to both the client and the package
+    // store (see store/connection-manager's createNewStoreController); the
+    // package store is where the package requester picks them up.
+    storeOptions: {
+      customFetchers: opts?.customFetchers,
+      ...storeOpts,
+    },
   })
   const result = {
     cacheDir,

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -1184,10 +1184,13 @@ fn is_osv_checkable_resolution(resolution: &LockfileResolution) -> bool {
         LockfileResolution::Tarball(tarball) => {
             is_http_tarball_url(&tarball.tarball) && !is_git_hosted_tarball_url(&tarball.tarball)
         }
+        // Custom resolutions are not registry artifacts, so OSV has
+        // no `name@version` advisory coordinates for them.
         LockfileResolution::Directory(_)
         | LockfileResolution::Git(_)
         | LockfileResolution::Binary(_)
-        | LockfileResolution::Variations(_) => false,
+        | LockfileResolution::Variations(_)
+        | LockfileResolution::Custom(_) => false,
     }
 }
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Adds support for custom fetchers exported from `.pnpmfile.cjs` / `.pnpmfile.mjs` in pacquet, closing the parity gap with the TypeScript CLI's `CustomFetcher` interface, and adds the portable `{ delegate }` envelope to the TypeScript `pickFetcher` so one pnpmfile fetcher works on both stacks. Related to pnpm/pnpm#11685 (which proposes the WASM plugin path as a follow-up; this PR implements the JS path as a prerequisite).

A user can now export a `fetchers` array from their pnpmfile and pair it with a custom resolver that writes custom-typed resolutions into the lockfile:

```js
module.exports = {
  fetchers: [{
    canFetch (pkgId, resolution) {
      return resolution.type === 'custom:cdn';
    },
    // TS-parity signature; under pacquet `cafs` and `fetchers` are null,
    // which is how a portable fetcher knows to delegate.
    fetch (cafs, resolution, opts, fetchers) {
      return { delegate: { tarball: resolution.url, integrity: resolution.integrity } };
    },
  }],
};
```

Both CLIs consult these before their built-in dispatch. Delegation (rewriting the resolution and falling through to the standard tarball path) is supported via the `{ delegate: <resolution> }` return shape in both stacks; the TypeScript CLI additionally keeps its direct-fetch path (`fetchers.remoteTarball(...)` etc.).

## Squash Commit Body

```text
Support custom fetchers from pnpmfiles in pacquet, with delegate-envelope parity in the TypeScript CLI (related to pnpm/pnpm#11685)

Pacquet already supported custom resolvers via its Node.js worker IPC but
lacked the fetcher counterpart. This extends the same protocol pattern:

- Define a CustomFetcher trait and get_custom_fetchers() on PnpmfileHooks
- Add fetchers/fetcher target dispatch to the worker's NDJSON protocol
  and JS runner, mirroring the existing resolver path; the hook is
  invoked with the TS-parity args fetch(cafs, resolution, opts, fetchers)
  (cafs/fetchers are null over IPC)
- Implement NodeJsCustomFetcher bridging the trait to the worker
- Create CustomFetcherPicker for consulting fetchers in declared order
- Consult custom fetchers before the built-in dispatch on both the
  frozen-lockfile and fresh-lockfile install paths; hook-load failures
  abort the install (PNPMFILE_FAIL)
- Support delegation: { delegate: <resolution> } rewrites the resolution
  for the standard tarball/git path; non-delegate responses and
  custom-typed delegates fail the install
- lockfile: add LockfileResolution::Custom preserving custom-typed
  resolution objects verbatim, so custom resolvers/fetchers can round-trip
  them; unclaimed custom-typed resolutions fail with the TS-parity
  UNSUPPORTED_RESOLUTION_TYPE error
- TypeScript: pickFetcher now accepts the { delegate: <resolution> }
  envelope from custom fetchers (the portable delegation form), and
  hooks.types exports CustomFetcherDelegation

Full CAS fetch in pacquet (where a fetcher produces file content directly
rather than delegating) requires a streaming protocol extension
(separate follow-up).
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  *Pacquet gains custom fetchers; the TypeScript CLI gains the shared
  `{ delegate }` envelope. Direct content fetch in pacquet needs a
  streaming IPC extension and remains a follow-up.*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. *Covers `@pnpm/hooks.types`, `@pnpm/fetching.pick-fetcher`, and `pnpm`.*
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-fable-5).
