### PR TITLE
fix(pacquet): support recursive project listing

### DIFF
--- a/pacquet/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_query.rs
@@ -92,13 +92,13 @@ pub(super) fn audit<'a>(ctx: &RunCtx<'a>, args: AuditArgs) -> miette::Result<Com
 }
 
 pub(super) fn list<'a>(ctx: &RunCtx<'a>, args: ListArgs) -> miette::Result<CommandFuture<'a>> {
-    args.run((ctx.config)()?, ctx.dir)?;
+    args.run((ctx.config)()?, ctx.dir, ctx.recursive)?;
     Ok(Box::pin(std::future::ready(Ok(()))))
 }
 
 pub(super) fn ll<'a>(ctx: &RunCtx<'a>, mut args: ListArgs) -> miette::Result<CommandFuture<'a>> {
     args.long = true;
-    args.run((ctx.config)()?, ctx.dir)?;
+    args.run((ctx.config)()?, ctx.dir, ctx.recursive)?;
     Ok(Box::pin(std::future::ready(Ok(()))))
 }
 

--- a/pacquet/crates/cli/src/cli_args/list.rs
+++ b/pacquet/crates/cli/src/cli_args/list.rs
@@ -706,8 +706,9 @@ pub(crate) fn print_label(dep: &DepNode, color: &dyn Fn(&str) -> String) -> Stri
 }
 
 pub(crate) fn name_at_version(name: &str, version: &str) -> String {
+    let name = sanitize(name);
     if version.is_empty() {
-        name.to_string()
+        name.into_owned()
     } else {
         format!("{}{}", name, gray(&format!("@{version}")))
     }

--- a/pacquet/crates/cli/src/cli_args/list.rs
+++ b/pacquet/crates/cli/src/cli_args/list.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use clap::Args;
@@ -12,7 +12,10 @@ pub(crate) use pacquet_lockfile::PkgNameVerPeer;
 use pacquet_lockfile::{Lockfile, PkgName, ProjectSnapshot, SnapshotEntry};
 use serde_json::{Map, Value, json};
 
-use crate::cli_args::sanitize::sanitize;
+use crate::cli_args::{
+    recursive::{AutoExcludeRoot, discover_workspace_projects, select_recursive_projects},
+    sanitize::sanitize,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum RecursionLimit {
@@ -71,9 +74,12 @@ pub struct ListArgs {
 }
 
 impl ListArgs {
-    pub fn run(self, config: &Config, dir: &Path) -> miette::Result<()> {
+    pub fn run(self, config: &Config, dir: &Path, recursive: bool) -> miette::Result<()> {
         if self.global {
             return self.run_global(config);
+        }
+        if recursive {
+            return self.run_recursive(config, dir);
         }
         self.run_local(config, dir)
     }
@@ -101,7 +107,55 @@ impl ListArgs {
         Ok(())
     }
 
+    fn run_recursive(&self, config: &Config, dir: &Path) -> miette::Result<()> {
+        let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
+        let (projects, _) = discover_workspace_projects(workspace_root)?;
+        let selection =
+            select_recursive_projects(&projects, config, dir, AutoExcludeRoot::Disabled)?;
+
+        let roots = if self.depth == RecursionLimit::ProjectsOnly {
+            selection
+                .selected
+                .values()
+                .map(|node| project_only_root(node.package.project))
+                .collect::<Vec<_>>()
+        } else {
+            let mut roots = Vec::new();
+            for project_dir in selection.selected.keys() {
+                if let LocalRootResult::Root(root) = self.local_root(config, project_dir)? {
+                    roots.push(root);
+                }
+            }
+            roots
+        };
+
+        self.print_roots(&roots);
+        Ok(())
+    }
+
     fn run_local(&self, config: &Config, dir: &Path) -> miette::Result<()> {
+        match self.local_root(config, dir)? {
+            LocalRootResult::Root(root) => self.print_roots(&[root]),
+            LocalRootResult::NoLockfile { lockfile_dir } => {
+                if self.packages.is_empty() {
+                    println!("No lockfile found in {}", lockfile_dir.display());
+                } else {
+                    println!("No matching packages found");
+                }
+            }
+            LocalRootResult::NoPackages => {
+                if self.packages.is_empty() {
+                    println!("No packages found");
+                } else {
+                    println!("No matching packages found");
+                }
+            }
+            LocalRootResult::NoMatchingPackages => println!("No matching packages found"),
+        }
+        Ok(())
+    }
+
+    fn local_root(&self, config: &Config, dir: &Path) -> miette::Result<LocalRootResult> {
         let lockfile_dir = config.workspace_dir.as_deref().unwrap_or(dir);
         let lockfile_result = if self.lockfile_only {
             Lockfile::load_wanted_from_dir(lockfile_dir)
@@ -113,12 +167,7 @@ impl ListArgs {
             }
         };
         let Some(lockfile) = lockfile_result.into_diagnostic().wrap_err("load lockfile")? else {
-            if self.packages.is_empty() {
-                println!("No lockfile found in {}", lockfile_dir.display());
-            } else {
-                println!("No matching packages found");
-            }
-            return Ok(());
+            return Ok(LocalRootResult::NoLockfile { lockfile_dir: lockfile_dir.to_path_buf() });
         };
 
         let importer_id: String = if dir == lockfile_dir {
@@ -133,12 +182,7 @@ impl ListArgs {
         let Some(importer) =
             lockfile.importers.get(&importer_id).or_else(|| lockfile.root_project())
         else {
-            if self.packages.is_empty() {
-                println!("No packages found");
-            } else {
-                println!("No matching packages found");
-            }
-            return Ok(());
+            return Ok(LocalRootResult::NoPackages);
         };
 
         let manifest_path = dir.join("package.json");
@@ -171,8 +215,7 @@ impl ListArgs {
                 && tree.dev_dependencies.is_empty()
                 && tree.optional_dependencies.is_empty()
             {
-                println!("No matching packages found");
-                return Ok(());
+                return Ok(LocalRootResult::NoMatchingPackages);
             }
         }
 
@@ -186,21 +229,46 @@ impl ListArgs {
             optional_dependencies: tree.optional_dependencies,
         };
 
+        Ok(LocalRootResult::Root(root))
+    }
+
+    fn print_roots(&self, roots: &[LocalTreeRoot]) {
         if self.json {
-            let output = render_local_json(&root);
+            let output = match roots {
+                [root] => render_local_json(root),
+                _ => render_local_roots_json(roots),
+            };
             println!("{output}");
         } else if self.parseable {
-            let output = render_local_parseable(&root, self.long);
-            println!("{output}");
+            let output = roots
+                .iter()
+                .map(|root| render_local_parseable(root, self.long))
+                .filter(|output| !output.is_empty())
+                .collect::<Vec<_>>()
+                .join("\n");
+            if !output.is_empty() {
+                println!("{output}");
+            }
         } else {
-            let output = render_local_tree(&root, self.long);
+            let joiner = if self.depth == RecursionLimit::ProjectsOnly { "\n" } else { "\n\n" };
+            let output = roots
+                .iter()
+                .map(|root| render_local_tree(root, self.long))
+                .filter(|output| !output.is_empty())
+                .collect::<Vec<_>>()
+                .join(joiner);
             if !output.is_empty() {
                 println!("{output}");
             }
         }
-
-        Ok(())
     }
+}
+
+enum LocalRootResult {
+    Root(LocalTreeRoot),
+    NoLockfile { lockfile_dir: PathBuf },
+    NoPackages,
+    NoMatchingPackages,
 }
 
 #[derive(Debug, Clone)]
@@ -224,6 +292,19 @@ pub(crate) struct LocalTreeRoot {
     pub(crate) dependencies: Vec<DepNode>,
     pub(crate) dev_dependencies: Vec<DepNode>,
     pub(crate) optional_dependencies: Vec<DepNode>,
+}
+
+fn project_only_root(project: &pacquet_workspace::Project) -> LocalTreeRoot {
+    let manifest = project.manifest.value();
+    LocalTreeRoot {
+        name: manifest.get("name").and_then(Value::as_str).map(str::to_string),
+        version: manifest.get("version").and_then(Value::as_str).map(str::to_string),
+        private: manifest.get("private").and_then(Value::as_bool),
+        path: project.root_dir.to_string_lossy().into_owned(),
+        dependencies: Vec::new(),
+        dev_dependencies: Vec::new(),
+        optional_dependencies: Vec::new(),
+    }
 }
 
 struct BuiltTree {
@@ -683,6 +764,15 @@ fn render_archy(node: &TreeNode, connector: &str, prefix: &str, out: &mut String
 }
 
 pub(crate) fn render_local_json(root: &LocalTreeRoot) -> String {
+    render_local_roots_json(std::slice::from_ref(root))
+}
+
+fn render_local_roots_json(roots: &[LocalTreeRoot]) -> String {
+    let root_objs = roots.iter().map(local_root_to_json).collect::<Vec<_>>();
+    serde_json::to_string_pretty(&root_objs).expect("serialize local list")
+}
+
+fn local_root_to_json(root: &LocalTreeRoot) -> Value {
     let mut deps_map = Map::new();
     for dep in &root.dependencies {
         deps_map.insert(dep.alias.clone(), dep_to_json(dep));
@@ -716,7 +806,7 @@ pub(crate) fn render_local_json(root: &LocalTreeRoot) -> String {
         root_obj.insert("optionalDependencies".to_string(), Value::Object(opt_map));
     }
 
-    serde_json::to_string_pretty(&json!([root_obj])).expect("serialize local list")
+    Value::Object(root_obj)
 }
 
 pub(crate) fn dep_to_json(dep: &DepNode) -> Value {

--- a/pacquet/crates/cli/src/cli_args/list.rs
+++ b/pacquet/crates/cli/src/cli_args/list.rs
@@ -51,7 +51,7 @@ pub struct ListArgs {
     #[clap(long)]
     pub parseable: bool,
 
-    #[clap(long, default_value = "0", value_parser = parse_depth)]
+    #[clap(long, default_value = "0", value_parser = parse_depth, allow_hyphen_values = true)]
     pub depth: RecursionLimit,
 
     #[clap(short = 'P', long = "prod")]

--- a/pacquet/crates/cli/src/cli_args/list/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/list/tests.rs
@@ -227,6 +227,22 @@ fn render_local_tree_empty_returns_root_line() {
 }
 
 #[test]
+fn render_local_tree_sanitizes_root_name_without_deps() {
+    let root = LocalTreeRoot {
+        name: Some("bad\u{1b}[31m-name".into()),
+        version: Some("0.0.0".into()),
+        private: Some(false),
+        path: "/nowhere".into(),
+        dependencies: vec![],
+        dev_dependencies: vec![],
+        optional_dependencies: vec![],
+    };
+    let output = render_local_tree(&root, false);
+    assert!(!output.contains('\u{1b}'));
+    assert!(output.contains("bad[31m-name"));
+}
+
+#[test]
 fn render_local_json_basic() {
     let root = LocalTreeRoot {
         name: Some("pkg".into()),

--- a/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
@@ -488,6 +488,7 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Root(_) => "root",
         CliCommand::Prefix(_) => "prefix",
         CliCommand::Config(_) => "config",
+        CliCommand::Pkg(_) => "pkg",
         CliCommand::PackApp(_) => "pack-app",
         CliCommand::Store(_) => "store",
         CliCommand::Cache(_) => "cache",

--- a/pacquet/crates/cli/src/cli_args/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/tests.rs
@@ -2,6 +2,7 @@ use super::{
     CliArgs,
     cli_command::CliCommand,
     install::{InstallArgs, resolve_bool_override},
+    list::RecursionLimit,
     package_manager::{
         current_source_pnpm_version, package_manager_to_sync, parse_package_manager,
     },
@@ -138,6 +139,18 @@ fn script_scoped_global_flags_reject_unrelated_commands() {
             .expect_err("non-script command rejects flag");
         assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
     }
+}
+
+#[test]
+fn recursive_list_accepts_depth_minus_one_as_separate_value() {
+    let parsed = CliArgs::try_parse_from(["pacquet", "-r", "list", "--depth", "-1", "--json"])
+        .expect("parses recursive list with --depth -1");
+    assert!(parsed.recursive);
+    let CliCommand::List(args) = parsed.command else {
+        panic!("expected list command");
+    };
+    assert_eq!(args.depth, RecursionLimit::ProjectsOnly);
+    assert!(args.json);
 }
 
 #[test]

--- a/pacquet/crates/cli/tests/list.rs
+++ b/pacquet/crates/cli/tests/list.rs
@@ -1,0 +1,76 @@
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use serde_json::{Value, json};
+use std::{collections::BTreeSet, fs, path::Path};
+
+fn write_workspace(workspace: &Path, manifests: &[(&str, Value)]) {
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "root",
+            "version": "1.0.0",
+            "private": true,
+        })
+        .to_string(),
+    )
+    .expect("write root package.json");
+    for (name, manifest) in manifests {
+        let dir = workspace.join("packages").join(name);
+        fs::create_dir_all(&dir).expect("create package dir");
+        fs::write(dir.join("package.json"), manifest.to_string()).expect("write package.json");
+    }
+}
+
+#[test]
+fn recursive_list_depth_minus_one_json_lists_workspace_projects() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            (
+                "project-1",
+                json!({
+                    "name": "project-1",
+                    "version": "1.0.0",
+                    "scripts": { ".test": "jest" },
+                }),
+            ),
+            (
+                "project-2",
+                json!({
+                    "name": "project-2",
+                    "version": "1.0.0",
+                    "scripts": { ".test": "jest" },
+                }),
+            ),
+        ],
+    );
+
+    let output = pacquet
+        .with_arg("-r")
+        .with_arg("list")
+        .with_arg("--depth")
+        .with_arg("-1")
+        .with_arg("--json")
+        .output()
+        .expect("spawn pacquet list");
+
+    assert!(
+        output.status.success(),
+        "recursive list should succeed:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let packages: Vec<Value> = serde_json::from_slice(&output.stdout).expect("parse list JSON");
+    let names = packages
+        .iter()
+        .map(|pkg| pkg["name"].as_str().expect("package name").to_string())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        names,
+        BTreeSet::from(["project-1".to_string(), "project-2".to_string(), "root".to_string()]),
+    );
+
+    drop(root);
+}

--- a/pacquet/crates/cli/tests/list.rs
+++ b/pacquet/crates/cli/tests/list.rs
@@ -1,7 +1,7 @@
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::CommandTempCwd;
 use serde_json::{Value, json};
-use std::{collections::BTreeSet, fs, path::Path};
+use std::{collections::BTreeSet, fs, path::Path, process::Command};
 
 fn write_workspace(workspace: &Path, manifests: &[(&str, Value)]) {
     fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
@@ -21,6 +21,26 @@ fn write_workspace(workspace: &Path, manifests: &[(&str, Value)]) {
         fs::create_dir_all(&dir).expect("create package dir");
         fs::write(dir.join("package.json"), manifest.to_string()).expect("write package.json");
     }
+}
+
+fn recursive_project_names(pacquet: Command, extra_args: &[&str]) -> BTreeSet<String> {
+    let output = pacquet
+        .with_arg("-r")
+        .with_arg("list")
+        .with_args(extra_args)
+        .with_arg("--depth")
+        .with_arg("-1")
+        .with_arg("--json")
+        .output()
+        .expect("spawn pacquet list");
+
+    assert!(
+        output.status.success(),
+        "recursive list should succeed:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let packages: Vec<Value> = serde_json::from_slice(&output.stdout).expect("parse list JSON");
+    packages.iter().map(|pkg| pkg["name"].as_str().expect("package name").to_string()).collect()
 }
 
 #[test]
@@ -48,25 +68,27 @@ fn recursive_list_depth_minus_one_json_lists_workspace_projects() {
         ],
     );
 
-    let output = pacquet
-        .with_arg("-r")
-        .with_arg("list")
-        .with_arg("--depth")
-        .with_arg("-1")
-        .with_arg("--json")
-        .output()
-        .expect("spawn pacquet list");
-
-    assert!(
-        output.status.success(),
-        "recursive list should succeed:\n{}",
-        String::from_utf8_lossy(&output.stderr),
+    let names = recursive_project_names(pacquet, &[]);
+    assert_eq!(
+        names,
+        BTreeSet::from(["project-1".to_string(), "project-2".to_string(), "root".to_string()]),
     );
-    let packages: Vec<Value> = serde_json::from_slice(&output.stdout).expect("parse list JSON");
-    let names = packages
-        .iter()
-        .map(|pkg| pkg["name"].as_str().expect("package name").to_string())
-        .collect::<BTreeSet<_>>();
+
+    drop(root);
+}
+
+#[test]
+fn recursive_list_depth_minus_one_json_keeps_project_only_output_with_package_params() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", json!({ "name": "project-1", "version": "1.0.0" })),
+            ("project-2", json!({ "name": "project-2", "version": "1.0.0" })),
+        ],
+    );
+
+    let names = recursive_project_names(pacquet, &["does-not-exist"]);
     assert_eq!(
         names,
         BTreeSet::from(["project-1".to_string(), "project-2".to_string(), "root".to_string()]),


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Pacquet now handles the recursive list shape used by the pnpm repo TS CI chunker: `pn -r list --depth -1 --json`.

The fix has four parts:

- `list --depth -1` accepts `-1` as a separate value, matching TypeScript pnpm.
- `list`/`ll` honor recursive dispatch and enumerate the selected workspace projects instead of listing only the current directory.
- Tree-mode root labels sanitize package names before printing dependency-free roots. This is pacquet-side hardening to match pacquet's existing terminal-output sanitizer; the TypeScript `nameAtVersion()` helper still prints raw names and can be aligned separately if maintainers want that broader parity change.
- The new `pkg` command from current `main` is included in the version-switch command-name mapping, fixing the PR merge-commit Dylint failure.

This fixes the pnpm v12 CI path in pnpm/pnpm#12811 where switching the script to `--depth=-1` avoided the parser error but made Windows chunks select `0 of 0` tests.

## Squash Commit Body

```text
Support the recursive project-listing path used by the pnpm repo CI test chunker.

Pacquet's `list` depth parser already treated `-1` as project-only mode, but clap rejected `--depth -1` before the parser saw it. In addition, `dispatch_query::list` ignored the recursive flag, so `pn -r list --depth=-1 --json` returned only the workspace root. The chunker then found no `.test` scripts and skipped every Windows chunk.

Allow hyphen-prefixed depth values, pass the recursive flag into `list` and `ll`, and render selected workspace projects for recursive project-only listings. This matches TypeScript pnpm for `pn -r list --depth -1 --json` and keeps filtered recursive selection on the shared workspace filtering path.

Sanitize root package names in tree-mode labels before printing dependency-free roots, matching pacquet's existing terminal-output sanitizer for other list labels. The TypeScript list helper still prints raw names and can be aligned in a separate TS changeset if maintainers want exact parity for that hardening.

Also map the current `pkg` command in the version-switch command-name helper so the merge commit remains exhaustive under Dylint.

Adds parser, integration, and renderer regressions for the CI command shape, package-param project-only parity, and root-label sanitization.

Related to pnpm/pnpm#12811.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pacquet list`/`ll` recursive mode so it’s properly applied to listing runs.
  * Fixed `--depth` parsing for negative values (including `--depth -1`), including with `--json`.
  * Corrected command-name mapping for `pkg` when applying switch-skipping logic.
* **New Features**
  * Improved recursive workspace listing with consistent results across JSON and non-JSON output.
  * Updated local JSON rendering for listing roots and sanitized displayed names to avoid ANSI/control characters.
  * Expanded `--depth` parsing to accept hyphenated values.
* **Tests**
  * Added unit and integration coverage for recursive `--json`, negative depth behavior, and ANSI-safe rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->