### PR TITLE
fix(pacquet-cli): handle Pkg variant in command_name match

### DIFF
--- a/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
@@ -488,6 +488,7 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Root(_) => "root",
         CliCommand::Prefix(_) => "prefix",
         CliCommand::Config(_) => "config",
+        CliCommand::Pkg(_) => "pkg",
         CliCommand::PackApp(_) => "pack-app",
         CliCommand::Store(_) => "store",
         CliCommand::Cache(_) => "cache",


### PR DESCRIPTION
## Summary

Every Rust CI job on `main` is currently red (Clippy, Doc, Dylint, and Test on
ubuntu/macos/windows). They all fail with the same compile error:

```
error[E0004]: non-exhaustive patterns: `&CliCommand::Pkg(_)` not covered
   --> pacquet/crates/cli/src/cli_args/switch_cli_version.rs:452:11
```

The `pkg` command (pnpm/pnpm#12795) added a `CliCommand::Pkg(PkgArgs)` variant
but did not extend the exhaustive `match` in `command_name`, so `pacquet-cli`
no longer compiles. Since every Rust job needs `pacquet-cli` to build, the one
missing match arm takes down the whole Rust CI matrix.

This adds the missing `CliCommand::Pkg(_) => "pkg"` arm, restoring compilation.

Failing run: https://github.com/pnpm/pnpm/actions/runs/28902352920

## Squash Commit Body

```text
The pkg command (pnpm/pnpm#12795) added a CliCommand::Pkg variant but did not
extend the exhaustive match in command_name, breaking every Rust CI job with a
non-exhaustive-patterns compile error. Add the missing arm mapping Pkg to
"pkg".
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting. _(pacquet-only
  compile fix — no user-visible behavior change, nothing to mirror in the TS CLI.)_
- [x] Added or updated tests. _(A compile error caught by every existing Rust job;
  no new test needed — CI green proves the fix.)_

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command detection so `pkg` commands are recognized correctly when deciding whether to switch package managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->