### PR TITLE
feat(pacquet): implement search command natively in Rust

### DIFF
--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -49,6 +49,7 @@ pub mod run;
 pub mod runtime;
 pub mod sanitize;
 pub mod sbom;
+pub mod search;
 pub mod self_update;
 pub mod set_script;
 pub mod setup;

--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -45,6 +45,7 @@ use super::{
     run::RunArgs,
     runtime::RuntimeArgs,
     sbom::SbomArgs,
+    search::SearchArgs,
     self_update::SelfUpdateArgs,
     set_script::SetScriptArgs,
     setup::SetupArgs,
@@ -242,6 +243,9 @@ pub enum CliCommand {
     DistTag(DistTagArgs),
     /// Test connectivity to the configured registry.
     Ping(PingArgs),
+    /// Search for packages in the registry.
+    #[clap(visible_aliases = ["s", "se", "find"])]
+    Search(SearchArgs),
     /// Rebuild a package.
     #[clap(visible_alias = "rb")]
     Rebuild(RebuildArgs),

--- a/pacquet/crates/cli/src/cli_args/dispatch.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch.rs
@@ -280,6 +280,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::Whoami => dispatch_query::whoami(ctx),
         CliCommand::DistTag(args) => dispatch_query::dist_tag(ctx, args),
         CliCommand::Ping(args) => dispatch_query::ping(ctx, args),
+        CliCommand::Search(args) => dispatch_query::search(ctx, args),
         CliCommand::Rebuild(args) => dispatch_install::rebuild(ctx, args),
         CliCommand::Pack(args) => dispatch_query::pack(ctx, &args),
         CliCommand::Publish(args) => dispatch_query::publish(ctx, args),

--- a/pacquet/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch_query.rs
@@ -24,6 +24,7 @@ use super::{
     reporter::ReporterType,
     root::RootArgs,
     sbom::SbomArgs,
+    search::SearchArgs,
     self_update::SelfUpdateArgs,
     setup::SetupArgs,
     store::StoreCommand,
@@ -400,4 +401,15 @@ pub(super) fn find_hash<'a>(
 ) -> miette::Result<CommandFuture<'a>> {
     args.run(|| (ctx.config)().map(|m| &*m))?;
     Ok(Box::pin(std::future::ready(Ok(()))))
+}
+
+pub(super) fn search<'a>(ctx: &RunCtx<'a>, args: SearchArgs) -> miette::Result<CommandFuture<'a>> {
+    let cfg: &Config = (ctx.config)()?;
+    Ok(Box::pin(async move {
+        let output = args.run(cfg).await?;
+        if !output.is_empty() {
+            println!("{output}");
+        }
+        Ok(())
+    }))
 }

--- a/pacquet/crates/cli/src/cli_args/search.rs
+++ b/pacquet/crates/cli/src/cli_args/search.rs
@@ -45,30 +45,30 @@ pub struct SearchArgs {
     pub query: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SearchAuthor {
     #[serde(default)]
     pub name: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum AuthorInfo {
     Object(SearchAuthor),
     String(String),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SearchPublisher {
     pub username: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SearchMaintainer {
     pub username: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SearchPackage {
     pub name: String,
     pub version: String,
@@ -220,7 +220,8 @@ fn format_package(pkg: &SearchPackage) -> String {
     if let Some(ref maintainers) = pkg.maintainers
         && !maintainers.is_empty()
     {
-        let usernames: Vec<String> = maintainers.iter().map(|m| m.username.clone()).collect();
+        let usernames: Vec<String> =
+            maintainers.iter().map(|maintainer| maintainer.username.clone()).collect();
         lines.push(format!("Maintainers: {}", usernames.join(", ")));
     }
 

--- a/pacquet/crates/cli/src/cli_args/search.rs
+++ b/pacquet/crates/cli/src/cli_args/search.rs
@@ -1,0 +1,246 @@
+//! `pacquet search` — search for packages in the registry.
+
+use crate::cli_args::registry_client::build_registry_client;
+use crate::cli_args::sanitize::sanitize;
+use clap::Args;
+use derive_more::{Display, Error};
+use miette::{Diagnostic, IntoDiagnostic, WrapErr};
+use owo_colors::{OwoColorize, Stream};
+use pacquet_config::Config;
+use pacquet_network::{RetryOpts, redact_and_sanitize, send_with_retry};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum SearchError {
+    #[display("Search query is required. Usage: pnpm search <keyword>")]
+    #[diagnostic(code(ERR_PNPM_MISSING_SEARCH_QUERY))]
+    MissingQuery,
+
+    #[display("Search failed with status {status}: {status_text}{detail}")]
+    #[diagnostic(code(ERR_PNPM_SEARCH_FAILED))]
+    SearchFailed { status: u16, status_text: String, detail: String },
+
+    #[display("Network request failed: {message}")]
+    #[diagnostic(code(ERR_PNPM_SEARCH_FAILED))]
+    NetworkError { message: String },
+}
+
+#[derive(Debug, Args)]
+pub struct SearchArgs {
+    /// Show search results in JSON format.
+    #[clap(long)]
+    pub json: bool,
+
+    /// Maximum number of results to show (default: 20).
+    #[clap(long = "search-limit")]
+    pub search_limit: Option<u32>,
+
+    /// Registry URL to search in.
+    #[clap(long)]
+    pub registry: Option<String>,
+
+    /// Search query terms.
+    pub query: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SearchAuthor {
+    #[serde(default)]
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum AuthorInfo {
+    Object(SearchAuthor),
+    String(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SearchPublisher {
+    pub username: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SearchMaintainer {
+    pub username: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SearchPackage {
+    pub name: String,
+    pub version: String,
+    pub description: Option<String>,
+    pub date: Option<String>,
+    pub author: Option<AuthorInfo>,
+    pub publisher: Option<SearchPublisher>,
+    pub maintainers: Option<Vec<SearchMaintainer>>,
+    pub keywords: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RawSearchResult {
+    pub package: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RegistrySearchResponse {
+    pub objects: Vec<RawSearchResult>,
+}
+
+impl SearchArgs {
+    pub async fn run(&self, config: &Config) -> miette::Result<String> {
+        let query_string = self.query.join(" ");
+        if query_string.is_empty() {
+            return Err(SearchError::MissingQuery.into());
+        }
+
+        let registry_url = self.registry.as_deref().unwrap_or(&config.registry);
+        // Add a trailing slash before joining so a registry with a path
+        // prefix keeps it.
+        let normalized_registry_url = if registry_url.ends_with('/') {
+            registry_url.to_owned()
+        } else {
+            format!("{registry_url}/")
+        };
+
+        let base_url = url::Url::parse(&normalized_registry_url)
+            .map_err(|err| SearchError::NetworkError { message: err.to_string() })?;
+        let mut search_url = base_url
+            .join("./-/v1/search")
+            .map_err(|err| SearchError::NetworkError { message: err.to_string() })?;
+
+        search_url
+            .query_pairs_mut()
+            .append_pair("text", &query_string)
+            .append_pair("size", &self.search_limit.unwrap_or(20).to_string());
+
+        let auth_header = config.auth_headers.for_url(&normalized_registry_url);
+        let http_client = build_registry_client(config)?;
+
+        let retry_opts = RetryOpts {
+            retries: config.fetch_retries,
+            factor: config.fetch_retry_factor,
+            min_timeout: Duration::from_millis(config.fetch_retry_mintimeout),
+            max_timeout: Duration::from_millis(config.fetch_retry_maxtimeout),
+        };
+
+        let (client, response) =
+            send_with_retry(&http_client, search_url.as_str(), retry_opts, |client| {
+                let mut request = client.get(search_url.as_str());
+                if let Some(ref header) = auth_header {
+                    request = request.header("authorization", header.as_str());
+                }
+                request
+            })
+            .await
+            .map_err(|error| SearchError::NetworkError {
+                message: redact_and_sanitize(&error.to_string()),
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_body = response.text().await.unwrap_or_default().trim().to_string();
+            let detail =
+                if error_body.is_empty() { String::new() } else { format!(". {error_body}") };
+            return Err(SearchError::SearchFailed {
+                status: status.as_u16(),
+                status_text: status.canonical_reason().unwrap_or_default().to_string(),
+                detail,
+            }
+            .into());
+        }
+
+        let data = response
+            .json::<RegistrySearchResponse>()
+            .await
+            .into_diagnostic()
+            .wrap_err("parsing the search response")?;
+
+        drop(client);
+
+        if self.json {
+            let packages: Vec<&serde_json::Value> =
+                data.objects.iter().map(|obj| &obj.package).collect();
+            return Ok(serde_json::to_string_pretty(&packages)
+                .map_err(|err| SearchError::NetworkError { message: err.to_string() })?);
+        }
+
+        if data.objects.is_empty() {
+            return Ok("No packages found".to_string());
+        }
+
+        let mut formatted_packages = Vec::new();
+        for obj in data.objects {
+            let pkg: SearchPackage = serde_json::from_value(obj.package)
+                .map_err(|err| SearchError::NetworkError { message: err.to_string() })?;
+            formatted_packages.push(format_package(&pkg));
+        }
+
+        Ok(formatted_packages.join("\n\n"))
+    }
+}
+
+fn format_package(pkg: &SearchPackage) -> String {
+    let author = if let Some(ref author_info) = pkg.author {
+        match author_info {
+            AuthorInfo::Object(author_obj) => author_obj.name.clone(),
+            AuthorInfo::String(author_str) => author_str.clone(),
+        }
+    } else if let Some(ref publisher) = pkg.publisher {
+        publisher.username.clone()
+    } else {
+        String::new()
+    };
+
+    let date = if let Some(ref date_str) = pkg.date {
+        date_str.split('T').next().unwrap_or("").to_owned()
+    } else {
+        String::new()
+    };
+
+    let mut lines = Vec::new();
+    lines.push(bold(&pkg.name));
+
+    if let Some(ref desc) = pkg.description {
+        lines.push(sanitize(desc).into_owned());
+    }
+
+    let mut version_line = vec![format!("Version {}", pkg.version)];
+    if !date.is_empty() {
+        version_line.push(format!("published {date}"));
+    }
+    if !author.is_empty() {
+        version_line.push(format!("by {author}"));
+    }
+    lines.push(version_line.join(" "));
+
+    if let Some(ref maintainers) = pkg.maintainers
+        && !maintainers.is_empty()
+    {
+        let usernames: Vec<String> = maintainers.iter().map(|m| m.username.clone()).collect();
+        lines.push(format!("Maintainers: {}", usernames.join(", ")));
+    }
+
+    if let Some(ref keywords) = pkg.keywords
+        && !keywords.is_empty()
+    {
+        lines.push(format!("Keywords: {}", keywords.join(", ")));
+    }
+
+    lines.push(bright_blue(&format!("https://npmx.dev/package/{}", pkg.name)));
+
+    lines.join("\n")
+}
+
+fn bold(text: &str) -> String {
+    let cleaned = sanitize(text);
+    cleaned.as_ref().if_supports_color(Stream::Stdout, |t| t.bold()).to_string()
+}
+
+fn bright_blue(text: &str) -> String {
+    let cleaned = sanitize(text);
+    cleaned.as_ref().if_supports_color(Stream::Stdout, |t| t.bright_blue()).to_string()
+}

--- a/pacquet/crates/cli/src/cli_args/search.rs
+++ b/pacquet/crates/cli/src/cli_args/search.rs
@@ -1,7 +1,6 @@
 //! `pacquet search` — search for packages in the registry.
 
-use crate::cli_args::registry_client::build_registry_client;
-use crate::cli_args::sanitize::sanitize;
+use crate::cli_args::{registry_client::build_registry_client, sanitize::sanitize};
 use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Diagnostic, IntoDiagnostic, WrapErr};

--- a/pacquet/crates/cli/src/cli_args/search.rs
+++ b/pacquet/crates/cli/src/cli_args/search.rs
@@ -142,8 +142,11 @@ impl SearchArgs {
         if !response.status().is_success() {
             let status = response.status();
             let error_body = response.text().await.unwrap_or_default().trim().to_string();
-            let detail =
-                if error_body.is_empty() { String::new() } else { format!(". {error_body}") };
+            let detail = if error_body.is_empty() {
+                String::new()
+            } else {
+                format!(". {}", sanitize(&error_body))
+            };
             return Err(SearchError::SearchFailed {
                 status: status.as_u16(),
                 status_text: status.canonical_reason().unwrap_or_default().to_string(),
@@ -207,27 +210,31 @@ fn format_package(pkg: &SearchPackage) -> String {
         lines.push(sanitize(desc).into_owned());
     }
 
-    let mut version_line = vec![format!("Version {}", pkg.version)];
+    let mut version_line = vec![format!("Version {}", sanitize(&pkg.version))];
     if !date.is_empty() {
         version_line.push(format!("published {date}"));
     }
     if !author.is_empty() {
-        version_line.push(format!("by {author}"));
+        version_line.push(format!("by {}", sanitize(&author)));
     }
     lines.push(version_line.join(" "));
 
     if let Some(ref maintainers) = pkg.maintainers
         && !maintainers.is_empty()
     {
-        let usernames: Vec<String> =
-            maintainers.iter().map(|maintainer| maintainer.username.clone()).collect();
+        let usernames: Vec<String> = maintainers
+            .iter()
+            .map(|maintainer| sanitize(&maintainer.username).into_owned())
+            .collect();
         lines.push(format!("Maintainers: {}", usernames.join(", ")));
     }
 
     if let Some(ref keywords) = pkg.keywords
         && !keywords.is_empty()
     {
-        lines.push(format!("Keywords: {}", keywords.join(", ")));
+        let sanitized_keywords: Vec<String> =
+            keywords.iter().map(|keyword| sanitize(keyword).into_owned()).collect();
+        lines.push(format!("Keywords: {}", sanitized_keywords.join(", ")));
     }
 
     lines.push(bright_blue(&format!("https://npmx.dev/package/{}", pkg.name)));

--- a/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pacquet/crates/cli/src/cli_args/switch_cli_version.rs
@@ -464,6 +464,7 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Whoami => "whoami",
         CliCommand::DistTag(_) => "dist-tag",
         CliCommand::Ping(_) => "ping",
+        CliCommand::Search(_) => "search",
         CliCommand::Rebuild(_) => "rebuild",
         CliCommand::Pack(_) => "pack",
         CliCommand::Publish(_) => "publish",

--- a/pacquet/crates/cli/tests/search.rs
+++ b/pacquet/crates/cli/tests/search.rs
@@ -1,0 +1,262 @@
+//! Tests for `pacquet search`.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use mockito::Matcher;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use std::{
+    fs,
+    net::TcpListener,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+}
+
+fn empty_auth_file(root: &Path) -> PathBuf {
+    let auth_file = root.join("auth-npmrc");
+    fs::write(&auth_file, "").expect("write empty auth .npmrc");
+    auth_file
+}
+
+fn run_search(
+    workspace: &Path,
+    auth_file: &Path,
+    registry: &str,
+    args: &[&str],
+) -> std::process::Output {
+    // Write fetchRetries=0 and fetchRetryMintimeout=0 to project pnpm-workspace.yaml
+    fs::write(workspace.join("pnpm-workspace.yaml"), "fetchRetries: 0\nfetchRetryMintimeout: 0\n")
+        .expect("write project pnpm-workspace.yaml");
+
+    pacquet_at(workspace)
+        .with_arg("--npmrc-auth-file")
+        .with_arg(auth_file)
+        .with_arg("search")
+        .with_arg("--registry")
+        .with_arg(registry)
+        .with_args(args)
+        .output()
+        .expect("spawn pacquet search")
+}
+
+fn unreachable_registry() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind a probe socket");
+    let port = listener.local_addr().expect("read the probe socket address").port();
+    drop(listener);
+    format!("http://127.0.0.1:{port}/")
+}
+
+#[test]
+fn missing_query_throws_error() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let auth_file = empty_auth_file(root.path());
+    let server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+
+    let output = run_search(&workspace, &auth_file, &registry, &[]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERR_PNPM_MISSING_SEARCH_QUERY"));
+    assert!(stderr.contains("Search query is required"));
+    drop(root);
+}
+
+#[test]
+fn returns_formatted_output_with_package_name_and_npmx_dev_url() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+
+    let mock_body = r#"{
+        "objects": [
+            {
+                "package": {
+                    "name": "create-touch-file-one-bin",
+                    "version": "1.0.0",
+                    "description": "A test description",
+                    "date": "2026-07-08T12:00:00.000Z",
+                    "author": { "name": "John Doe" },
+                    "keywords": ["test", "touch"]
+                }
+            }
+        ]
+    }"#;
+
+    let mock = server
+        .mock("GET", "/-/v1/search")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("text".into(), "create-touch-file-one-bin".into()),
+            Matcher::UrlEncoded("size".into(), "20".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_body)
+        .create();
+
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_search(&workspace, &auth_file, &registry, &["create-touch-file-one-bin"]);
+
+    mock.assert();
+    assert!(
+        output.status.success(),
+        "search must succeed (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("create-touch-file-one-bin"));
+    assert!(stdout.contains("A test description"));
+    assert!(stdout.contains("Version 1.0.0 published 2026-07-08 by John Doe"));
+    assert!(stdout.contains("Keywords: test, touch"));
+    assert!(stdout.contains("https://npmx.dev/package/create-touch-file-one-bin"));
+
+    drop(root);
+}
+
+#[test]
+fn json_flag_returns_parsed_package_array() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+
+    let mock_body = r#"{
+        "objects": [
+            {
+                "package": {
+                    "name": "create-touch-file-one-bin",
+                    "version": "1.0.0",
+                    "extra_custom_field": "hello"
+                }
+            }
+        ]
+    }"#;
+
+    let mock = server
+        .mock("GET", "/-/v1/search")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("text".into(), "create-touch-file-one-bin".into()),
+            Matcher::UrlEncoded("size".into(), "5".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_body)
+        .create();
+
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_search(
+        &workspace,
+        &auth_file,
+        &registry,
+        &["--json", "--search-limit", "5", "create-touch-file-one-bin"],
+    );
+
+    mock.assert();
+    assert!(
+        output.status.success(),
+        "search must succeed (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("output must be valid JSON");
+    assert!(parsed.is_array());
+    let arr = parsed.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["name"], "create-touch-file-one-bin");
+    assert_eq!(arr[0]["version"], "1.0.0");
+    assert_eq!(arr[0]["extra_custom_field"], "hello");
+
+    drop(root);
+}
+
+#[test]
+fn empty_results_returns_no_packages_found() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+
+    let mock_body = r#"{
+        "objects": []
+    }"#;
+
+    let mock = server
+        .mock("GET", "/-/v1/search")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("text".into(), "nonexistent-package".into()),
+            Matcher::UrlEncoded("size".into(), "20".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_body)
+        .create();
+
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_search(&workspace, &auth_file, &registry, &["nonexistent-package"]);
+
+    mock.assert();
+    assert!(
+        output.status.success(),
+        "search must succeed (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim(), "No packages found");
+
+    drop(root);
+}
+
+#[test]
+fn non_ok_registry_response_throws_search_failed() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+
+    let mock = server
+        .mock("GET", "/-/v1/search")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("text".into(), "some-package".into()),
+            Matcher::UrlEncoded("size".into(), "20".into()),
+        ]))
+        .with_status(500)
+        .with_body("Internal Server Error Details")
+        .create();
+
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_search(&workspace, &auth_file, &registry, &["some-package"]);
+
+    mock.assert();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERR_PNPM_SEARCH_FAILED"));
+    assert!(stderr.contains("Search failed with status 500: Internal Server Error"));
+    assert!(stderr.contains("Internal Server"));
+    assert!(stderr.contains("Error Details"));
+
+    drop(root);
+}
+
+#[test]
+fn fails_on_a_network_failure() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let auth_file = empty_auth_file(root.path());
+    let registry = unreachable_registry();
+
+    let output = run_search(&workspace, &auth_file, &registry, &["some-package"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERR_PNPM_SEARCH_FAILED"));
+    assert!(stderr.contains("Network request failed"));
+
+    drop(root);
+}


### PR DESCRIPTION
## Summary

Implements the `search` command (and its aliases `s`, `se`, `find`) natively in Rust inside `pacquet`. This is part of the Rustification effort 
Related to pnpm/pnpm#11633.

## Squash Commit Body

```text
Implement the search / s / se / find command in pacquet. The command resolves the registry URL from config or CLI overrides, executes a GET request against the registry's search endpoint with the search query and limit, and pretty-prints the formatted output. Includes support for `--json` format matching the TypeScript output. Also includes a comprehensive integration test suite.
Related to pnpm/pnpm#11633
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. (The command is already present in the TS codebase; this PR implements the Rust equivalent).
- [x] Added or updated tests.

---
Written by an agent (Antigravity, gemini-3.5-flash).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `pacquet search` CLI command (aliases: `s`, `se`, `find`).
  * Supports `--json` (JSON output), `--search-limit`, and `--registry` to control results and the registry source.

* **Bug Fixes**
  * Improved validation and messaging for missing queries.
  * Added clear handling for empty results, HTTP failures (with status/body details), and network failures.
  * Enhanced human output with package metadata and an `npmx.dev` link.

* **Tests**
  * Added integration tests covering success, empty results, JSON output, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->