### PR TITLE
fix: don't silently drop locked optional deps on resolution failure

### DIFF
--- a/.changeset/optional-locked-resolution-failure.md
+++ b/.changeset/optional-locked-resolution-failure.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fail instead of silently removing an optional dependency's locked entries from `pnpm-lock.yaml` when the registry cannot resolve it. Previously, when registry metadata lacked a version that the lockfile already pinned (for example, a mirror that had not synced a recent release yet), `pnpm install` and `pnpm dedupe` silently dropped the optional dependency's entries — emptying maps such as the platform binaries of `@napi-rs/canvas` — so the lockfile differed between machines and frozen installs on other hosts had nothing to link [#12853](https://github.com/pnpm/pnpm/issues/12853).

--- a/pacquet/crates/default-reporter/src/state.rs
+++ b/pacquet/crates/default-reporter/src/state.rs
@@ -14,7 +14,8 @@ use pacquet_reporter::{
     AddedRoot, ContextLog, DependencyType, ExecutionTimeLog, FetchingProgressMessage, HookLog,
     IgnoredScriptsLog, InstallingConfigDepsLog, InstallingConfigDepsStatus, LifecycleMessage,
     LifecycleStdio, LockfileVerificationMessage, LogEvent, LogLevel, PackageImportMethod,
-    PackageManifestMessage, ProgressMessage, RemovedRoot, RequestRetryLog, Stage, StatsMessage,
+    PackageManifestMessage, ProgressMessage, RemovedRoot, RequestRetryLog,
+    SkippedOptionalDependencyLog, SkippedOptionalPackage, Stage, StatsMessage,
 };
 use serde_json::Value;
 
@@ -323,11 +324,7 @@ impl ReporterState {
             LogEvent::Summary(_) => self.on_summary(),
             LogEvent::Lifecycle(log) => self.on_lifecycle(&log.message),
             LogEvent::IgnoredScripts(log) => self.on_ignored_scripts(log),
-            // Upstream's `reportSkippedOptionalDependencies` only prints top-level
-            // resolution failures (its filter needs a `parents: []`); the emits
-            // pacquet produces carry no `parents`, so upstream drops them from the
-            // console. Consume without rendering to match.
-            LogEvent::SkippedOptionalDependency(_) => {}
+            LogEvent::SkippedOptionalDependency(log) => self.on_skipped_optional(log),
             LogEvent::InstallingConfigDeps(log) => self.on_config_deps(log),
             LogEvent::LockfileVerification(log) => self.on_lockfile_verification(&log.message),
             LogEvent::RequestRetry(log) => self.on_request_retry(log),
@@ -1027,6 +1024,30 @@ impl ReporterState {
         let mut slot = std::mem::take(&mut self.exec_slot);
         self.frame.emit(&mut slot, msg, true);
         self.exec_slot = slot;
+    }
+
+    /// Mirrors pnpm's `reportSkippedOptionalDependencies`: only a skip
+    /// whose `parents` chain is present and empty (a direct optional
+    /// dependency of the current project) renders; transitive and
+    /// parent-less skips stay debug-only.
+    fn on_skipped_optional(&mut self, log: &SkippedOptionalDependencyLog) {
+        if log.prefix != self.cwd || !log.parents.as_ref().is_some_and(Vec::is_empty) {
+            return;
+        }
+        let pkg = match &log.package {
+            SkippedOptionalPackage::Installed { id, .. } => id.clone(),
+            SkippedOptionalPackage::ResolutionFailure {
+                name: Some(name),
+                version: Some(version),
+                ..
+            } => format!("{name}@{version}"),
+            SkippedOptionalPackage::ResolutionFailure { bare_specifier, .. } => {
+                bare_specifier.clone()
+            }
+        };
+        self.push_block(format!(
+            "info: {pkg} is an optional dependency and failed compatibility check. Excluding it from installation."
+        ));
     }
 
     /// Renders a `pnpm:hook` event as `hook: message`, matching pnpm's

--- a/pacquet/crates/default-reporter/src/state.rs
+++ b/pacquet/crates/default-reporter/src/state.rs
@@ -1046,7 +1046,7 @@ impl ReporterState {
             }
         };
         self.push_block(format!(
-            "info: {pkg} is an optional dependency and failed compatibility check. Excluding it from installation."
+            "info: {pkg} is an optional dependency and failed compatibility check. Excluding it from installation.",
         ));
     }
 

--- a/pacquet/crates/default-reporter/tests/render.rs
+++ b/pacquet/crates/default-reporter/tests/render.rs
@@ -481,7 +481,7 @@ fn skipped_optional_resolution_failure_renders_only_top_level() {
     let frame = render(&mut reporter, vec![skipped(Vec::new(), CWD)]);
     assert_eq!(
         frame,
-        "info: broken@^1.0.0 is an optional dependency and failed compatibility check. Excluding it from installation."
+        "info: broken@^1.0.0 is an optional dependency and failed compatibility check. Excluding it from installation.",
     );
 
     let mut reporter = state(false);

--- a/pacquet/crates/default-reporter/tests/render.rs
+++ b/pacquet/crates/default-reporter/tests/render.rs
@@ -13,7 +13,8 @@ use pacquet_reporter::{
     LifecycleMessage, LifecycleStdio, LogEvent, LogLevel, PackageImportMethod,
     PackageImportMethodLog, PackageManifestLog, PackageManifestMessage, PnpmLog, ProgressLog,
     ProgressMessage, RootLog, RootMessage, SkippedOptionalDependencyLog, SkippedOptionalPackage,
-    SkippedOptionalReason, Stage, StageLog, StatsLog, StatsMessage, SummaryLog,
+    SkippedOptionalParent, SkippedOptionalReason, Stage, StageLog, StatsLog, StatsMessage,
+    SummaryLog,
 };
 
 const CWD: &str = "/repo";
@@ -421,8 +422,8 @@ fn warnings_collapse_after_five() {
     assert_eq!(lines[5], "[WARN] 1 other warnings");
 }
 
-/// Upstream keeps the console silent for the skipped-optional emits pacquet
-/// produces (they carry no `parents`), so this channel must render nothing.
+/// Upstream keeps the console silent for skipped-optional emits without a
+/// `parents` chain (build/platform skips), so those must render nothing.
 #[test]
 fn skipped_optional_dependency_renders_nothing() {
     let mut reporter = state(false);
@@ -435,6 +436,7 @@ fn skipped_optional_dependency_renders_nothing() {
                 name: name.to_string(),
                 version: version.to_string(),
             },
+            parents: None,
             prefix: CWD.to_string(),
             reason,
         })
@@ -452,6 +454,48 @@ fn skipped_optional_dependency_renders_nothing() {
         ],
     );
     assert!(frame.is_empty(), "skipped-optional events must not render, got: {frame:?}");
+}
+
+/// A resolution-failure skip on a direct optional dependency
+/// (`parents: []`, prefix == cwd) renders the same info line as
+/// upstream's `reportSkippedOptionalDependencies`; a transitive skip
+/// (non-empty `parents`) stays silent.
+#[test]
+fn skipped_optional_resolution_failure_renders_only_top_level() {
+    let skipped = |parents: Vec<SkippedOptionalParent>, prefix: &str| {
+        LogEvent::SkippedOptionalDependency(SkippedOptionalDependencyLog {
+            level: LogLevel::Debug,
+            details: Some("No matching version found for broken@^1.0.0".to_string()),
+            package: SkippedOptionalPackage::ResolutionFailure {
+                name: Some("broken".to_string()),
+                version: Some("^1.0.0".to_string()),
+                bare_specifier: "^1.0.0".to_string(),
+            },
+            parents: Some(parents),
+            prefix: prefix.to_string(),
+            reason: SkippedOptionalReason::ResolutionFailure,
+        })
+    };
+
+    let mut reporter = state(false);
+    let frame = render(&mut reporter, vec![skipped(Vec::new(), CWD)]);
+    assert_eq!(
+        frame,
+        "info: broken@^1.0.0 is an optional dependency and failed compatibility check. Excluding it from installation."
+    );
+
+    let mut reporter = state(false);
+    let parent = SkippedOptionalParent {
+        id: "parent@1.0.0".to_string(),
+        name: "parent".to_string(),
+        version: "1.0.0".to_string(),
+    };
+    let frame = render(&mut reporter, vec![skipped(vec![parent], CWD)]);
+    assert!(frame.is_empty(), "transitive skips must not render, got: {frame:?}");
+
+    let mut reporter = state(false);
+    let frame = render(&mut reporter, vec![skipped(Vec::new(), "/somewhere/else")]);
+    assert!(frame.is_empty(), "other prefixes must not render, got: {frame:?}");
 }
 
 #[test]

--- a/pacquet/crates/env-installer/src/install_config_deps.rs
+++ b/pacquet/crates/env-installer/src/install_config_deps.rs
@@ -319,6 +319,7 @@ fn is_compatible<Reporter: self::Reporter>(
                     name: subdep.name.clone(),
                     version: subdep.version.clone(),
                 },
+                parents: None,
                 prefix: opts.root_dir.to_string_lossy().into_owned(),
                 reason: match error.skip_reason() {
                     pacquet_package_is_installable::SkipReason::UnsupportedEngine => {

--- a/pacquet/crates/package-manager/src/build_modules.rs
+++ b/pacquet/crates/package-manager/src/build_modules.rs
@@ -890,6 +890,7 @@ fn build_one_snapshot<Reporter: self::Reporter>(
                                             name,
                                             version,
                                         },
+                                        parents: None,
                                         prefix: lockfile_dir.to_string_lossy().into_owned(),
                                         reason: SkippedOptionalReason::BuildFailure,
                                     },
@@ -940,6 +941,7 @@ fn build_one_snapshot<Reporter: self::Reporter>(
                     name,
                     version,
                 },
+                parents: None,
                 prefix: lockfile_dir.to_string_lossy().into_owned(),
                 reason: SkippedOptionalReason::BuildFailure,
             }));
@@ -1017,6 +1019,7 @@ fn build_one_snapshot<Reporter: self::Reporter>(
                                 name,
                                 version,
                             },
+                            parents: None,
                             prefix: lockfile_dir.to_string_lossy().into_owned(),
                             reason: SkippedOptionalReason::BuildFailure,
                         },

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -21,7 +21,10 @@ use pacquet_hooks::finder;
 use pacquet_lockfile::{Lockfile, LockfileResolution, SaveLockfileError};
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
-use pacquet_reporter::{HookLog, LogEvent, LogLevel, Reporter, Stage, StageLog};
+use pacquet_reporter::{
+    HookLog, LogEvent, LogLevel, Reporter, SkippedOptionalDependencyLog, SkippedOptionalPackage,
+    SkippedOptionalParent, SkippedOptionalReason, Stage, StageLog,
+};
 use pacquet_resolving_default_resolver::DefaultResolver;
 use pacquet_resolving_deps_resolver::{
     ManifestHook, ResolveDependencyTreeError, ResolveImporterError, ResolveImporterOptions,
@@ -1098,6 +1101,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             manifest_hook: manifest_hook.clone(),
             pnpmfile_hook,
             read_package_log,
+            skipped_optional_log: Some(skipped_optional_log_fn::<Reporter>()),
             pick_lowest_direct,
             time_based,
             // Hand the resolver the prior lockfile so it can reuse
@@ -2070,6 +2074,38 @@ fn hook_log_fn<Reporter: self::Reporter>(
             hook: hook.to_string(),
             message,
             prefix: prefix.clone(),
+        }));
+    })
+}
+
+/// Build the resolver's skipped-optional-dependency sink: each
+/// notification emits a `pnpm:skipped-optional-dependency` debug event
+/// with `reason=resolution_failure` through the install's reporter,
+/// matching pnpm's `skippedOptionalDependencyLogger.debug` payload.
+fn skipped_optional_log_fn<Reporter: self::Reporter>()
+-> pacquet_resolving_deps_resolver::SkippedOptionalLogFn {
+    Arc::new(|skipped: pacquet_resolving_deps_resolver::SkippedOptionalDependency| {
+        Reporter::emit(&LogEvent::SkippedOptionalDependency(SkippedOptionalDependencyLog {
+            level: LogLevel::Debug,
+            details: Some(skipped.details),
+            package: SkippedOptionalPackage::ResolutionFailure {
+                name: skipped.name,
+                version: skipped.version,
+                bare_specifier: skipped.bare_specifier,
+            },
+            parents: Some(
+                skipped
+                    .parents
+                    .into_iter()
+                    .map(|parent| SkippedOptionalParent {
+                        id: parent.id,
+                        name: parent.name,
+                        version: parent.version,
+                    })
+                    .collect(),
+            ),
+            prefix: skipped.prefix,
+            reason: SkippedOptionalReason::ResolutionFailure,
         }));
     })
 }

--- a/pacquet/crates/package-manager/src/installability.rs
+++ b/pacquet/crates/package-manager/src/installability.rs
@@ -650,6 +650,7 @@ fn emit_skipped<Reporter: self::Reporter>(
         level: LogLevel::Debug,
         details: Some(details),
         package: SkippedOptionalPackage::Installed { id: pkg_id.to_string(), name, version },
+        parents: None,
         prefix: prefix.to_string(),
         reason: wire_reason,
     }));

--- a/pacquet/crates/reporter/src/lib.rs
+++ b/pacquet/crates/reporter/src/lib.rs
@@ -570,15 +570,32 @@ pub struct IgnoredScriptsLog {
 /// real safety, so it's left to convention until a site actually
 /// pairs the wrong shapes.
 ///
-/// `parents` is a TODO and is omitted here.
+/// `parents` co-varies with `reason` the same way `package` does:
+/// only the resolver-side `resolution_failure` emit carries it
+/// (empty for a direct optional dependency of the importer); every
+/// other emit site omits it, matching pnpm's payloads.
 #[derive(Debug, Clone, Serialize)]
 pub struct SkippedOptionalDependencyLog {
     pub level: LogLevel,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub details: Option<String>,
     pub package: SkippedOptionalPackage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parents: Option<Vec<SkippedOptionalParent>>,
     pub prefix: String,
     pub reason: SkippedOptionalReason,
+}
+
+/// One ancestor on a `resolution_failure` skip's `parents` chain: a
+/// resolved package between the importer and the failing optional
+/// edge. The default reporter renders only skips whose chain is empty
+/// (a direct optional dependency), matching pnpm's
+/// `reportSkippedOptionalDependencies`.
+#[derive(Debug, Clone, Serialize)]
+pub struct SkippedOptionalParent {
+    pub id: String,
+    pub name: String,
+    pub version: String,
 }
 
 /// Package identifier carried on a [`SkippedOptionalDependencyLog`].
@@ -591,9 +608,8 @@ pub struct SkippedOptionalDependencyLog {
 ///   `build_modules.rs`.
 /// - [`SkippedOptionalPackage::ResolutionFailure`] —
 ///   `{ name?, version?, bareSpecifier }` for `resolution_failure`.
-///   Defined for the resolver-side emit. Pacquet has no resolver yet
-///   so this variant is wire-shape-only in slice 4 — wired so a
-///   future resolver port can land without re-touching this type.
+///   Emitted by the deps resolver's skipped-optional sink when an
+///   optional dependency's resolution failure drops the edge.
 ///
 /// `#[serde(untagged)]` so each variant serializes as its own object
 /// shape — a union of two `package: { ... }` types.
@@ -604,8 +620,10 @@ pub enum SkippedOptionalPackage {
     /// emit (installability + build-failure).
     Installed { id: String, name: String, version: String },
     /// `{ name?, version?, bareSpecifier }` shape used by the
-    /// resolver-side `resolution_failure` emit. `name` and `version`
-    /// are optional and stay `None` when the resolver fails before it
+    /// resolver-side `resolution_failure` emit (the deps resolver's
+    /// skipped-optional sink wired in
+    /// `install_with_fresh_lockfile.rs`). `name` and `version` are
+    /// optional and stay `None` when the resolver fails before it
     /// could resolve those fields.
     ResolutionFailure {
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -617,10 +635,9 @@ pub enum SkippedOptionalPackage {
     },
 }
 
-/// Discriminator on a [`SkippedOptionalDependencyLog`]. Only
-/// `BuildFailure` lands at pacquet's current emit sites; the others
-/// are kept in the enum for forward compatibility so callers don't
-/// have to widen the type when more reasons are wired up.
+/// Discriminator on a [`SkippedOptionalDependencyLog`]. See
+/// [`SkippedOptionalPackage`] for which emit site pairs with which
+/// reason.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SkippedOptionalReason {

--- a/pacquet/crates/reporter/src/tests.rs
+++ b/pacquet/crates/reporter/src/tests.rs
@@ -11,8 +11,8 @@ use crate::{
     LockfileVerificationMessage, LogEvent, LogLevel, PackageImportMethod, PackageImportMethodLog,
     PackageManifestLog, PackageManifestMessage, PnpmLog, ProgressLog, ProgressMessage, RemovedRoot,
     Reporter, RequestRetryError, RequestRetryLog, RootLog, RootMessage, SilentReporter,
-    SkippedOptionalDependencyLog, SkippedOptionalPackage, SkippedOptionalReason, Stage, StageLog,
-    StatsLog, StatsMessage, SummaryLog,
+    SkippedOptionalDependencyLog, SkippedOptionalPackage, SkippedOptionalParent,
+    SkippedOptionalReason, Stage, StageLog, StatsLog, StatsMessage, SummaryLog,
 };
 
 /// Context log serializes with the camelCase field names
@@ -675,6 +675,7 @@ fn skipped_optional_dependency_event_matches_pnpm_wire_shape() {
             name: "foo".to_string(),
             version: "1.0.0".to_string(),
         },
+        parents: None,
         prefix: "/projects/x".to_string(),
         reason: SkippedOptionalReason::BuildFailure,
     });
@@ -693,6 +694,7 @@ fn skipped_optional_dependency_event_matches_pnpm_wire_shape() {
     assert_eq!(json["package"]["id"], "/foo/1.0.0");
     assert_eq!(json["package"]["name"], "foo");
     assert_eq!(json["package"]["version"], "1.0.0");
+    assert!(json.get("parents").is_none(), "non-resolver emits carry no parents, got {json:?}");
 }
 
 /// `details` is optional upstream and must be omitted from the wire
@@ -707,6 +709,7 @@ fn skipped_optional_omits_absent_details() {
             name: "bar".to_string(),
             version: "2.0.0".to_string(),
         },
+        parents: None,
         prefix: "/projects/y".to_string(),
         reason: SkippedOptionalReason::BuildFailure,
     });
@@ -755,6 +758,11 @@ fn skipped_optional_resolution_failure_event_matches_pnpm_wire_shape() {
             version: Some("1.2.3".to_string()),
             bare_specifier: "^1.2.0".to_string(),
         },
+        parents: Some(vec![SkippedOptionalParent {
+            id: "parent@2.0.0".to_string(),
+            name: "parent".to_string(),
+            version: "2.0.0".to_string(),
+        }]),
         prefix: "/projects/x".to_string(),
         reason: SkippedOptionalReason::ResolutionFailure,
     });
@@ -771,6 +779,10 @@ fn skipped_optional_resolution_failure_event_matches_pnpm_wire_shape() {
     assert_eq!(json["package"]["name"], "foo");
     assert_eq!(json["package"]["version"], "1.2.3");
     assert_eq!(json["package"]["bareSpecifier"], "^1.2.0");
+    assert_eq!(
+        json["parents"],
+        serde_json::json!([{ "id": "parent@2.0.0", "name": "parent", "version": "2.0.0" }]),
+    );
 }
 
 /// `name` and `version` are upstream-optional on the
@@ -786,6 +798,7 @@ fn skipped_optional_resolution_failure_omits_absent_name_and_version() {
             version: None,
             bare_specifier: "git+ssh://broken-url".to_string(),
         },
+        parents: Some(Vec::new()),
         prefix: "/projects/y".to_string(),
         reason: SkippedOptionalReason::ResolutionFailure,
     });
@@ -799,6 +812,7 @@ fn skipped_optional_resolution_failure_omits_absent_name_and_version() {
     assert!(json["package"].get("name").is_none(), "name omitted when absent, got {json:?}");
     assert!(json["package"].get("version").is_none(), "version omitted when absent, got {json:?}");
     assert_eq!(json["package"]["bareSpecifier"], "git+ssh://broken-url");
+    assert_eq!(json["parents"], serde_json::json!([]), "an empty chain serializes as []");
 }
 
 /// All four reason variants serialize as the `snake_case` strings

--- a/pacquet/crates/resolving-deps-resolver/src/lib.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/lib.rs
@@ -84,7 +84,8 @@ pub use hoist_peers::{
 pub use node_id::NodeId;
 pub use pacquet_deps_path::DepPath;
 pub use resolve_dependency_tree::{
-    ManifestHook, ResolveDependencyTreeError, ResolveDependencyTreeOptions, TreeCtx,
+    ManifestHook, ResolveDependencyTreeError, ResolveDependencyTreeOptions,
+    SkippedOptionalDependency, SkippedOptionalDependencyParent, SkippedOptionalLogFn, TreeCtx,
     UpdateReuseScope, WorkspaceTreeCtx, extend_tree, resolve_dependency_tree,
 };
 pub use resolve_importer::{

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -168,6 +168,43 @@ impl std::fmt::Debug for ResolveDependencyTreeOptions {
 /// single `Arc::clone` reaches every recursive call.
 pub type ManifestHook = Arc<dyn Fn(Arc<Value>) -> Arc<Value> + Send + Sync>;
 
+/// One skipped-optional-dependency notification from the tree walker:
+/// an optional dependency failed to resolve and the walker dropped the
+/// edge instead of failing the install. Mirrors the package payload of
+/// the `pnpm:skipped-optional-dependency` (`reason=resolution_failure`)
+/// debug log so the install layer can forward it to the reporter wire.
+#[derive(Debug, Clone)]
+pub struct SkippedOptionalDependency {
+    /// Rendering of the resolution error that caused the skip.
+    pub details: String,
+    /// The edge's install alias, when it carries one.
+    pub name: Option<String>,
+    /// The wanted specifier, present only when [`Self::name`] is.
+    pub version: Option<String>,
+    /// The wanted specifier.
+    pub bare_specifier: String,
+    /// The resolved packages between the importer and the failing
+    /// edge, importer first. Empty for a direct optional dependency —
+    /// the default reporter renders only those.
+    pub parents: Vec<SkippedOptionalDependencyParent>,
+    /// The project directory the failing edge was resolved for.
+    pub prefix: String,
+}
+
+/// One ancestor on a [`SkippedOptionalDependency::parents`] chain.
+#[derive(Debug, Clone)]
+pub struct SkippedOptionalDependencyParent {
+    /// The ancestor's `pkgIdWithPatchHash`.
+    pub id: String,
+    pub name: String,
+    pub version: String,
+}
+
+/// Sink for [`SkippedOptionalDependency`] notifications, pre-bound to
+/// the install's reporter so the resolver stays reporter-agnostic. See
+/// [`crate::WorkspaceResolveOptions::skipped_optional_log`].
+pub type SkippedOptionalLogFn = Arc<dyn Fn(SkippedOptionalDependency) + Send + Sync>;
+
 /// Error envelope returned by the tree walker.
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum ResolveDependencyTreeError {
@@ -175,6 +212,18 @@ pub enum ResolveDependencyTreeError {
     /// The inner error is the boxed type the resolver returned.
     #[display("Failed to resolve dependency: {_0}")]
     Resolve(#[error(not(source))] String),
+
+    /// An optional dependency failed to resolve while the wanted
+    /// lockfile still holds a package entry satisfying the wanted
+    /// range. Rethrown loudly instead of skipped, because skipping
+    /// would erase the locked entries and make the lockfile differ
+    /// depending on which machine ran the install
+    /// (<https://github.com/pnpm/pnpm/issues/12853>).
+    #[display("{_0}")]
+    #[diagnostic(help(
+        "This optional dependency is not skipped, because the lockfile contains a resolution for it. Skipping it would remove the locked entries, making the lockfile differ depending on which machine ran the install. If the version was intentionally removed from the registry, update the dependent package or remove the entries from the lockfile."
+    ))]
+    LockedOptionalResolutionFailure(#[error(not(source))] Box<ResolveDependencyTreeError>),
 
     /// No resolver in the chain claimed the spec, raised with the
     /// `SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER` code.
@@ -550,6 +599,10 @@ pub struct WorkspaceTreeCtx {
     /// pnpmfile path. `None` leaves hook logging a no-op. See
     /// [`WorkspaceTreeCtx::with_read_package_log`].
     read_package_log: Option<pacquet_hooks::LogFn>,
+    /// Sink for skipped-optional-dependency notifications. `None`
+    /// keeps the skip behavior but drops the notification. See
+    /// [`SkippedOptionalLogFn`].
+    skipped_optional_log: Option<SkippedOptionalLogFn>,
     /// The install's `autoInstallPeers` setting. When `true`,
     /// [`fn@resolve_node`] drops a resolved package's `dependencies`
     /// entries that are shadowed by its own `peerDependencies`, so the
@@ -624,6 +677,7 @@ impl Default for WorkspaceTreeCtx {
             subtree_reusable: Mutex::new(HashMap::new()),
             pnpmfile_hook: None,
             read_package_log: None,
+            skipped_optional_log: None,
             auto_install_peers: false,
             registries: HashMap::new(),
             first_importer_by_pkg: Mutex::new(HashMap::new()),
@@ -753,6 +807,17 @@ impl WorkspaceTreeCtx {
     #[must_use]
     pub fn with_read_package_log(mut self, read_package_log: Option<pacquet_hooks::LogFn>) -> Self {
         self.read_package_log = read_package_log;
+        self
+    }
+
+    /// Attach the sink skipped-optional-dependency notifications are
+    /// forwarded to. See [`SkippedOptionalLogFn`].
+    #[must_use]
+    pub fn with_skipped_optional_log(
+        mut self,
+        skipped_optional_log: Option<SkippedOptionalLogFn>,
+    ) -> Self {
+        self.skipped_optional_log = skipped_optional_log;
         self
     }
 
@@ -1354,8 +1419,46 @@ where
         overlay_versions.clone(),
     );
     let result =
-        resolve_wanted_cached(ctx, resolver, &wanted, opts, pick_overlay.as_ref(), cache_key)
-            .await?;
+        match resolve_wanted_cached(ctx, resolver, &wanted, opts, pick_overlay.as_ref(), cache_key)
+            .await
+        {
+            Ok(result) => result,
+            // A resolution failure on an optional edge drops the edge
+            // instead of failing the install — unless the wanted lockfile
+            // already holds a satisfying entry, where the silent skip would
+            // erase the locked entries (see
+            // `wanted_lockfile_contains_satisfying_entry`). Hook errors
+            // keep aborting even for optional edges.
+            Err(
+                err @ (ResolveDependencyTreeError::Resolve(_)
+                | ResolveDependencyTreeError::SpecNotSupported { .. }),
+            ) if wanted.optional.unwrap_or(false) => {
+                if wanted_lockfile_contains_satisfying_entry(
+                    ctx.workspace.wanted_lockfile.as_deref(),
+                    &wanted,
+                ) {
+                    return Err(ResolveDependencyTreeError::LockedOptionalResolutionFailure(
+                        Box::new(err),
+                    ));
+                }
+                if let Some(log) = ctx.workspace.skipped_optional_log.as_ref() {
+                    log(SkippedOptionalDependency {
+                        details: err.to_string(),
+                        name: wanted.alias.clone(),
+                        version: wanted
+                            .alias
+                            .is_some()
+                            .then(|| wanted.bare_specifier.clone())
+                            .flatten(),
+                        bare_specifier: wanted.bare_specifier.clone().unwrap_or_default(),
+                        parents: pkgs_info_from_ids(ctx, ancestor_ids),
+                        prefix: opts.project_dir.display().to_string(),
+                    });
+                }
+                return Ok(NodeSeed::Done(None));
+            }
+            Err(err) => return Err(err),
+        };
 
     if let Some(violation) = result.policy_violation.clone() {
         lock_recoverable(&ctx.workspace.policy_violations).push(violation);
@@ -2106,6 +2209,91 @@ fn update_excludes(scope: &UpdateReuseScope, name: &str) -> bool {
         // same here for completeness.
         UpdateReuseScope::None => true,
         UpdateReuseScope::Except(names) => names.contains(name),
+    }
+}
+
+/// Whether the wanted lockfile already holds a package entry that
+/// satisfies the wanted dependency. An optional dependency that fails
+/// to resolve is normally skipped, but when a locked resolution exists
+/// the failure is environmental (e.g. a registry mirror that hasn't
+/// synced the release yet) rather than a genuinely uninstallable
+/// package. Silently skipping in that case would erase the locked
+/// entries, making the lockfile differ across machines from identical
+/// inputs and leaving frozen installs on other hosts with nothing to
+/// link (<https://github.com/pnpm/pnpm/issues/12853>).
+///
+/// Only plain semver specifiers are checked; exotic specifiers (git,
+/// catalogs, tags, URLs) keep the skip-on-failure behavior.
+///
+/// The check is deliberately by package name and range rather than by
+/// the current edge's locked snapshot ref: a satisfying entry locked
+/// via any edge means the registry served this package in-range
+/// before, so failing loudly instead of skipping is the right outcome
+/// even when the failing edge itself was never locked. This matches
+/// the TypeScript resolver's `wantedLockfileContainsSatisfyingEntry`.
+fn wanted_lockfile_contains_satisfying_entry(
+    lockfile: Option<&pacquet_lockfile::Lockfile>,
+    wanted: &WantedDependency,
+) -> bool {
+    let Some(packages) = lockfile.and_then(|lockfile| lockfile.packages.as_ref()) else {
+        return false;
+    };
+    let Some(alias) = wanted.alias.as_deref().filter(|alias| !alias.is_empty()) else {
+        return false;
+    };
+    let (pkg_name, range) =
+        unwrap_package_name(alias, wanted.bare_specifier.as_deref().unwrap_or_default());
+    let Ok(range) = range.parse::<node_semver::Range>() else {
+        return false;
+    };
+    let Ok(pkg_name) = PkgName::parse(pkg_name) else {
+        return false;
+    };
+    packages.keys().any(|key| {
+        key.name == pkg_name
+            && key.suffix.version_semver().is_some_and(|version| range.satisfies(version))
+    })
+}
+
+/// Map an ancestor-id chain to the `parents` payload of a
+/// skipped-optional-dependency notification, resolving each
+/// `pkgIdWithPatchHash` through the shared packages map (the
+/// counterpart of pnpm's `getPkgsInfoFromIds`).
+fn pkgs_info_from_ids(
+    ctx: &TreeCtx,
+    ancestor_ids: &[String],
+) -> Vec<SkippedOptionalDependencyParent> {
+    let packages = lock_recoverable(&ctx.workspace.packages);
+    ancestor_ids
+        .iter()
+        .map(|id| {
+            let name_ver = packages.get(id).and_then(|pkg| pkg.result.name_ver.as_ref());
+            SkippedOptionalDependencyParent {
+                id: id.clone(),
+                name: name_ver.map(|name_ver| name_ver.name.to_string()).unwrap_or_default(),
+                version: name_ver.map(|name_ver| name_ver.suffix.to_string()).unwrap_or_default(),
+            }
+        })
+        .collect()
+}
+
+/// Normalize an `npm:` alias specifier into the real package name and
+/// the wanted range (`("is-positive", "^1.0.0")` for the edge
+/// `my-alias@npm:is-positive@^1.0.0`; the range is `"*"` for the
+/// spec-less `npm:is-positive` form). A specifier without the `npm:`
+/// prefix is returned as-is: the alias is the real package name.
+///
+/// Mirrors the TypeScript resolver's `unwrapPackageName`; unlike
+/// [`fn@real_package_name_of`] it also yields the range and does not
+/// special-case the `npm:<range>` form, so the locked-entry check
+/// matches its TypeScript counterpart byte for byte.
+fn unwrap_package_name<'a>(alias: &'a str, bare_specifier: &'a str) -> (&'a str, &'a str) {
+    let Some(rest) = bare_specifier.strip_prefix("npm:") else {
+        return (alias, bare_specifier);
+    };
+    match rest.rfind('@') {
+        None | Some(0) => (rest, "*"),
+        Some(index) => (&rest[..index], &rest[index + 1..]),
     }
 }
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -102,6 +102,12 @@ pub struct WorkspaceResolveOptions {
     /// logging a no-op.
     pub read_package_log: Option<pacquet_hooks::LogFn>,
 
+    /// Sink for skipped-optional-dependency notifications, pre-bound to
+    /// the install's reporter (the install layer forwards each one as a
+    /// `pnpm:skipped-optional-dependency` `resolution_failure` debug
+    /// log). `None` keeps the skip behavior but drops the notification.
+    pub skipped_optional_log: Option<crate::SkippedOptionalLogFn>,
+
     /// The install's `autoInstallPeers` setting, threaded onto the
     /// shared [`WorkspaceTreeCtx`] so the tree walk drops
     /// peer-shadowed `dependencies` entries. Also overrides every
@@ -155,6 +161,7 @@ where
         manifest_hook,
         pnpmfile_hook,
         read_package_log,
+        skipped_optional_log,
         pick_lowest_direct,
         time_based,
         wanted_lockfile,
@@ -169,6 +176,7 @@ where
             .with_update_reuse_scope(update_reuse_scope)
             .with_pnpmfile_hook(pnpmfile_hook)
             .with_read_package_log(read_package_log)
+            .with_skipped_optional_log(skipped_optional_log)
             .with_auto_install_peers(auto_install_peers)
             .with_registries(registries),
     );

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -185,6 +185,7 @@ fn workspace_opts(pick_lowest_direct: bool, time_based: bool) -> WorkspaceResolv
         manifest_hook: None,
         pnpmfile_hook: None,
         read_package_log: None,
+        skipped_optional_log: None,
         pick_lowest_direct,
         time_based,
         wanted_lockfile: None,
@@ -640,4 +641,201 @@ async fn shared_subtree_miss_unsatisfied_by_first_importer_still_hoists() {
             "{importer} hoists the peer the first walk could not satisfy",
         );
     }
+}
+
+/// Resolver fed from a `(alias, range)` → `ResolveResult` table whose
+/// chain fails for the aliases in `failing`, mimicking a registry
+/// whose packument no longer serves any satisfying version.
+struct FailingAliasResolver {
+    table: HashMap<(String, String), ResolveResult>,
+    failing: std::collections::HashSet<String>,
+}
+
+impl Resolver for FailingAliasResolver {
+    fn resolve<'a>(
+        &'a self,
+        wanted: &'a WantedDependency,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveFuture<'a> {
+        let alias = wanted.alias.clone().unwrap_or_default();
+        let range = wanted.bare_specifier.clone().unwrap_or_default();
+        let failing = self.failing.contains(&alias);
+        let result = self.table.get(&(alias.clone(), range.clone())).cloned();
+        Box::pin(async move {
+            if failing {
+                return Err(format!("No matching version found for {alias}@{range}").into());
+            }
+            Ok::<_, ResolveError>(result)
+        })
+    }
+
+    fn resolve_latest<'a>(
+        &'a self,
+        _query: &'a LatestQuery,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveLatestFuture<'a> {
+        Box::pin(async { Ok(None) })
+    }
+}
+
+/// One importer whose manifest carries a resolvable regular dep
+/// (`kept`) and an optional dep (`broken`) whose resolution fails.
+fn optional_failure_fixture() -> (tempfile::TempDir, PackageManifest, FailingAliasResolver) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("package.json");
+    let json = serde_json::json!({
+        "name": "root",
+        "version": "0.0.0",
+        "dependencies": { "kept": "^1.0.0" },
+        "optionalDependencies": { "broken": "^1.0.0" },
+    });
+    std::fs::write(&path, serde_json::to_string(&json).unwrap()).expect("write package.json");
+    let manifest = PackageManifest::from_path(path).expect("parse package.json");
+    let resolver = FailingAliasResolver {
+        table: HashMap::from([(
+            ("kept".to_string(), "^1.0.0".to_string()),
+            fake_result(
+                "kept",
+                "1.0.0",
+                None,
+                serde_json::json!({ "name": "kept", "version": "1.0.0" }),
+            ),
+        )]),
+        failing: std::collections::HashSet::from(["broken".to_string()]),
+    };
+    (tmp, manifest, resolver)
+}
+
+/// A wanted lockfile whose `packages:` map holds exactly one entry.
+fn lockfile_with_package(key: &str) -> pacquet_lockfile::Lockfile {
+    use pacquet_lockfile::{
+        ComVer, LockfileVersion, PackageMetadata, PkgNameVerPeer, TarballResolution,
+    };
+    let key: PkgNameVerPeer = key.parse().expect("parse package key");
+    let metadata = PackageMetadata {
+        resolution: LockfileResolution::Tarball(TarballResolution {
+            tarball: format!("https://registry.example/{key}.tgz"),
+            integrity: None,
+            git_hosted: None,
+            path: None,
+        }),
+        version: None,
+        engines: None,
+        cpu: None,
+        os: None,
+        libc: None,
+        deprecated: None,
+        has_bin: None,
+        prepare: None,
+        bundled_dependencies: None,
+        peer_dependencies: None,
+        peer_dependencies_meta: None,
+    };
+    pacquet_lockfile::Lockfile {
+        lockfile_version: LockfileVersion::<9>::try_from(ComVer::new(9, 0)).expect("lockfile v9"),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers: HashMap::new(),
+        packages: Some(HashMap::from([(key, metadata)])),
+        snapshots: None,
+    }
+}
+
+#[tokio::test]
+async fn skips_an_optional_dependency_whose_resolution_fails_with_no_locked_entry() {
+    let (_tmp, manifest, resolver) = optional_failure_fixture();
+    let importers = [WorkspaceImporter { id: ".".to_string(), manifest: &manifest }];
+    let skipped = std::sync::Arc::new(Mutex::new(Vec::new()));
+    let mut opts = workspace_opts(false, false);
+    opts.skipped_optional_log = Some(std::sync::Arc::new({
+        let skipped = std::sync::Arc::clone(&skipped);
+        move |notification| skipped.lock().unwrap().push(notification)
+    }));
+    let result = resolve_workspace(
+        &resolver,
+        &importers,
+        &[DependencyGroup::Prod, DependencyGroup::Optional],
+        opts,
+        |_| importer_opts(std::path::PathBuf::from("/repo"), None),
+    )
+    .await
+    .expect("resolution failure of an optional dependency is skipped");
+
+    let direct = &result.peers.direct_dependencies_by_importer["."];
+    assert!(direct.contains_key("kept"), "the regular dep resolves: {direct:?}");
+    assert!(!direct.contains_key("broken"), "the failing optional edge is dropped: {direct:?}");
+    let skipped = skipped.lock().unwrap();
+    assert_eq!(skipped.len(), 1);
+    assert_eq!(skipped[0].name.as_deref(), Some("broken"));
+    assert_eq!(skipped[0].version.as_deref(), Some("^1.0.0"));
+    assert_eq!(skipped[0].bare_specifier, "^1.0.0");
+    assert!(
+        skipped[0].parents.is_empty(),
+        "a direct optional dep has an empty parents chain: {:?}",
+        skipped[0].parents,
+    );
+    assert_eq!(skipped[0].prefix, "/repo");
+    assert!(
+        skipped[0].details.contains("No matching version found for broken@^1.0.0"),
+        "details carry the resolver error: {}",
+        skipped[0].details,
+    );
+}
+
+// Covers https://github.com/pnpm/pnpm/issues/12853: a wanted lockfile
+// that already resolved the optional dependency must fail the install
+// loudly instead of silently dropping the locked entries.
+#[tokio::test]
+async fn fails_on_an_optional_dependency_that_cannot_be_resolved_with_a_satisfying_locked_entry() {
+    let (_tmp, manifest, resolver) = optional_failure_fixture();
+    let importers = [WorkspaceImporter { id: ".".to_string(), manifest: &manifest }];
+    let mut opts = workspace_opts(false, false);
+    opts.wanted_lockfile = Some(std::sync::Arc::new(lockfile_with_package("broken@1.2.0")));
+    // Model `pacquet dedupe`: the prior lockfile rides along for the
+    // locked-entry check but nothing is reused from it.
+    opts.update_reuse_scope = crate::UpdateReuseScope::None;
+    let result = resolve_workspace(
+        &resolver,
+        &importers,
+        &[DependencyGroup::Prod, DependencyGroup::Optional],
+        opts,
+        |_| importer_opts(std::path::PathBuf::from("/repo"), None),
+    )
+    .await;
+
+    let Err(crate::ResolveImporterError::Resolve(err)) = result else {
+        panic!("a locked optional dependency must fail loudly");
+    };
+    let help = miette::Diagnostic::help(&err).expect("carries the lockfile hint").to_string();
+    assert!(help.contains("the lockfile contains a resolution for it"), "unexpected hint: {help}");
+    assert!(
+        matches!(err, crate::ResolveDependencyTreeError::LockedOptionalResolutionFailure(_)),
+        "unexpected error: {err}",
+    );
+}
+
+#[tokio::test]
+async fn skips_an_optional_dependency_when_the_locked_entry_does_not_satisfy_the_wanted_range() {
+    let (_tmp, manifest, resolver) = optional_failure_fixture();
+    let importers = [WorkspaceImporter { id: ".".to_string(), manifest: &manifest }];
+    let mut opts = workspace_opts(false, false);
+    opts.wanted_lockfile = Some(std::sync::Arc::new(lockfile_with_package("broken@0.9.0")));
+    opts.update_reuse_scope = crate::UpdateReuseScope::None;
+    let result = resolve_workspace(
+        &resolver,
+        &importers,
+        &[DependencyGroup::Prod, DependencyGroup::Optional],
+        opts,
+        |_| importer_opts(std::path::PathBuf::from("/repo"), None),
+    )
+    .await
+    .expect("an out-of-range locked entry keeps the skip behavior");
+
+    let direct = &result.peers.direct_dependencies_by_importer["."];
+    assert!(!direct.contains_key("broken"), "the failing optional edge is dropped: {direct:?}");
 }

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -787,7 +787,7 @@ async fn skips_an_optional_dependency_whose_resolution_fails_with_no_locked_entr
     );
 }
 
-// Covers https://github.com/pnpm/pnpm/issues/12853: a wanted lockfile
+// Covers <https://github.com/pnpm/pnpm/issues/12853>: a wanted lockfile
 // that already resolved the optional dependency must fail the install
 // loudly instead of silently dropping the locked entries.
 #[tokio::test]

--- a/pnpm11/installing/deps-installer/test/install/optionalDependencies.ts
+++ b/pnpm11/installing/deps-installer/test/install/optionalDependencies.ts
@@ -219,6 +219,101 @@ function createMetadataStrippingRegistryProxy (): http.Server {
   })
 }
 
+// Covers https://github.com/pnpm/pnpm/issues/12853: a registry that can no
+// longer serve the locked version of an optional dependency (e.g. a stale
+// mirror that hasn't synced a recent release) must not cause the locked
+// entries to be silently erased from the lockfile. That would make the
+// lockfile depend on which machine ran the install, and a frozen install on
+// another machine would find no entry to link.
+test('fail on an optional dependency that cannot be resolved when the lockfile has a satisfying locked entry', async () => {
+  const project = prepareEmpty()
+  const manifest = {
+    dependencies: {
+      '@pnpm.e2e/has-many-optional-deps': '1.0.0',
+    },
+  }
+  await install(manifest, testDefaults())
+
+  const lockfileBefore = project.readLockfile()
+  expect(lockfileBefore.snapshots['@pnpm.e2e/has-many-optional-deps@1.0.0'].optionalDependencies).toStrictEqual({
+    '@pnpm.e2e/darwin-arm64': '1.0.0',
+    '@pnpm.e2e/darwin-x64': '1.0.0',
+    '@pnpm.e2e/linux-arm64': '1.0.0',
+    '@pnpm.e2e/linux-x64': '1.0.0',
+    '@pnpm.e2e/windows-x64': '1.0.0',
+  })
+
+  const server = createVersionHidingRegistryProxy([
+    '@pnpm.e2e/darwin-arm64',
+    '@pnpm.e2e/darwin-x64',
+    '@pnpm.e2e/linux-arm64',
+    '@pnpm.e2e/linux-x64',
+    '@pnpm.e2e/windows-x64',
+  ], '1.0.0')
+  await new Promise<void>((resolve) => {
+    server.listen(0, resolve)
+  })
+  const registryProxy = `http://localhost:${(server.address() as AddressInfo).port}/`
+  try {
+    // dedupe re-resolves every package from registry metadata, so it hits the
+    // stale packuments even though the lockfile already pins the versions.
+    await expect(install(manifest, testDefaults({
+      dedupe: true,
+      registries: { default: registryProxy },
+    }))).rejects.toMatchObject({
+      code: expect.stringMatching(/^ERR_PNPM_NO_(MATCHING_VERSION|VERSIONS)$/),
+      hint: expect.stringContaining('the lockfile contains a resolution for it'),
+    })
+  } finally {
+    server.closeAllConnections()
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err == null) {
+          resolve()
+        } else {
+          reject(err)
+        }
+      })
+    })
+  }
+
+  expect(project.readLockfile()).toStrictEqual(lockfileBefore)
+})
+
+// Simulates a registry mirror whose packuments predate a release: the version
+// is missing from the version list even though other packages already
+// reference it. Everything else is forwarded to the registry mock.
+function createVersionHidingRegistryProxy (pkgNames: string[], hiddenVersion: string): http.Server {
+  const hiddenPkgPaths = new Set(pkgNames.map((pkgName) => `/${pkgName.replace('/', '%2F')}`))
+  return http.createServer((req, res) => {
+    (async () => {
+      const upstream = await fetch(`http://localhost:${REGISTRY_MOCK_PORT}${req.url}`, {
+        method: req.method,
+        headers: { accept: req.headers.accept ?? '*/*' },
+      })
+      const contentType = upstream.headers.get('content-type') ?? ''
+      if (hiddenPkgPaths.has(req.url!) && contentType.includes('json')) {
+        const doc = await upstream.json() as { versions?: Record<string, unknown>, time?: Record<string, string>, 'dist-tags'?: Record<string, string> }
+        delete doc.versions?.[hiddenVersion]
+        delete doc.time?.[hiddenVersion]
+        for (const [distTag, version] of Object.entries(doc['dist-tags'] ?? {})) {
+          if (version === hiddenVersion) {
+            delete doc['dist-tags']![distTag]
+          }
+        }
+        res.writeHead(upstream.status, { 'content-type': 'application/json' })
+        res.end(JSON.stringify(doc))
+      } else {
+        res.writeHead(upstream.status, { 'content-type': contentType })
+        res.end(Buffer.from(await upstream.arrayBuffer()))
+      }
+    })().catch((err) => {
+      res.writeHead(500)
+      res.end(String(err))
+    })
+  })
+}
+
 test('skip optional dependency that does not support the current Node version', async () => {
   const project = prepareEmpty()
   const reporter = jest.fn()

--- a/pnpm11/installing/deps-installer/test/install/optionalDependencies.ts
+++ b/pnpm11/installing/deps-installer/test/install/optionalDependencies.ts
@@ -284,7 +284,7 @@ test('fail on an optional dependency that cannot be resolved when the lockfile h
 // is missing from the version list even though other packages already
 // reference it. Everything else is forwarded to the registry mock.
 function createVersionHidingRegistryProxy (pkgNames: string[], hiddenVersion: string): http.Server {
-  const hiddenPkgPaths = new Set(pkgNames.map((pkgName) => `/${pkgName.replace('/', '%2F')}`))
+  const hiddenPkgPaths = new Set(pkgNames.map((pkgName) => `/${pkgName}`))
   return http.createServer((req, res) => {
     (async () => {
       const upstream = await fetch(`http://localhost:${REGISTRY_MOCK_PORT}${req.url}`, {
@@ -292,7 +292,7 @@ function createVersionHidingRegistryProxy (pkgNames: string[], hiddenVersion: st
         headers: { accept: req.headers.accept ?? '*/*' },
       })
       const contentType = upstream.headers.get('content-type') ?? ''
-      if (hiddenPkgPaths.has(req.url!) && contentType.includes('json')) {
+      if (hiddenPkgPaths.has(decodeURIComponent(req.url!)) && contentType.includes('json')) {
         const doc = await upstream.json() as { versions?: Record<string, unknown>, time?: Record<string, string>, 'dist-tags'?: Record<string, string> }
         delete doc.versions?.[hiddenVersion]
         delete doc.time?.[hiddenVersion]
@@ -308,7 +308,7 @@ function createVersionHidingRegistryProxy (pkgNames: string[], hiddenVersion: st
         res.end(Buffer.from(await upstream.arrayBuffer()))
       }
     })().catch((err) => {
-      res.writeHead(500)
+      res.writeHead(500, { 'content-type': 'text/plain' })
       res.end(String(err))
     })
   })

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -2178,6 +2178,15 @@ async function resolveDependency (
  *
  * Only plain semver specifiers are checked; exotic specifiers (git, catalogs,
  * tags, URLs) keep the skip-on-failure behavior.
+ *
+ * The check is deliberately by package name and range rather than by the
+ * current edge's locked dep path. `pnpm dedupe` — the flow where the erasure
+ * bites — clears every per-snapshot dependency map before resolving
+ * (`forgetResolutionsOfAllPrevWantedDeps`), so on this code path no edge-level
+ * lockfile linkage exists to key on; only the package entries survive. A
+ * satisfying entry locked via any edge also means the registry served this
+ * package in-range before, so failing loudly instead of skipping is the right
+ * outcome even when the failing edge itself was never locked.
  */
 function wantedLockfileContainsSatisfyingEntry (lockfile: LockfileObject, wantedDependency: WantedDependency): boolean {
   if (!wantedDependency.alias) return false

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -67,6 +67,7 @@ import { nextNodeId, type NodeId } from './nextNodeId.js'
 import { parentIdsContainSequence } from './parentIdsContainSequence.js'
 import { replaceVersionInBareSpecifier } from './replaceVersionInBareSpecifier.js'
 import type { CatalogLookupMetadata } from './resolveDependencyTree.js'
+import { unwrapPackageName } from './unwrapPackageName.js'
 import { wantedDepIsLocallyAvailable } from './wantedDepIsLocallyAvailable.js'
 
 export type { WantedDependency }
@@ -1848,14 +1849,21 @@ async function resolveDependency (
         version: wantedDependency.alias ? wantedDependency.bareSpecifier : undefined,
       }
       if (wantedDependency.optional && err.code !== 'ERR_PNPM_TRUST_DOWNGRADE') {
-        skippedOptionalDependencyLogger.debug({
-          details: err.toString(),
-          package: wantedDependencyDetails,
-          parents: getPkgsInfoFromIds(options.parentIds, ctx.resolvedPkgsById),
-          prefix: options.prefix,
-          reason: 'resolution_failure',
-        })
-        return null
+        if (!wantedLockfileContainsSatisfyingEntry(ctx.wantedLockfile, wantedDependency)) {
+          skippedOptionalDependencyLogger.debug({
+            details: err.toString(),
+            package: wantedDependencyDetails,
+            parents: getPkgsInfoFromIds(options.parentIds, ctx.resolvedPkgsById),
+            prefix: options.prefix,
+            reason: 'resolution_failure',
+          })
+          return null
+        }
+        if (err.hint == null) {
+          err.hint = 'This optional dependency is not skipped, because the lockfile contains a resolution for it. ' +
+            'Skipping it would remove the locked entries, making the lockfile differ depending on which machine ran the install. ' +
+            'If the version was intentionally removed from the registry, update the dependent package or remove the entries from the lockfile.'
+        }
       }
       err.package = wantedDependencyDetails
       err.prefix = options.prefix
@@ -2156,6 +2164,29 @@ async function resolveDependency (
   } finally {
     finishPackageResolution()
   }
+}
+
+/**
+ * Whether the wanted lockfile already holds a package entry that satisfies the
+ * wanted dependency. An optional dependency that fails to resolve is normally
+ * skipped, but when a locked resolution exists the failure is environmental
+ * (e.g. a registry mirror that hasn't synced the release yet) rather than a
+ * genuinely uninstallable package. Silently skipping in that case would erase
+ * the locked entries, making the lockfile differ across machines from
+ * identical inputs and leaving frozen installs on other hosts with nothing to
+ * link (https://github.com/pnpm/pnpm/issues/12853).
+ *
+ * Only plain semver specifiers are checked; exotic specifiers (git, catalogs,
+ * tags, URLs) keep the skip-on-failure behavior.
+ */
+function wantedLockfileContainsSatisfyingEntry (lockfile: LockfileObject, wantedDependency: WantedDependency): boolean {
+  if (!wantedDependency.alias) return false
+  const { pkgName, bareSpecifier } = unwrapPackageName(wantedDependency.alias, wantedDependency.bareSpecifier)
+  if (semver.validRange(bareSpecifier) == null) return false
+  return Object.keys(lockfile.packages ?? {}).some((depPath) => {
+    const parsed = dp.parse(depPath)
+    return parsed.name === pkgName && parsed.version != null && semver.satisfies(parsed.version, bareSpecifier)
+  })
 }
 
 export function getManifestFromResponse (


### PR DESCRIPTION
## Summary

Closes [pnpm/pnpm#12853](https://github.com/pnpm/pnpm/issues/12853).

When re-resolution of an **optional** dependency fails, the resolver silently skips it (`pnpm:skipped-optional-dependency`, `reason=resolution_failure`) — even when `pnpm-lock.yaml` already holds a locked resolution for that dependency. The parent's snapshot is then rewritten without those edges and `pruneSharedLockfile` erases the now-orphaned entries. This is how `@napi-rs/canvas@1.0.2` in the issue ends up serialized as `'@napi-rs/canvas@1.0.2': {}` with all 11 platform-binary entries removed.

The most common trigger is registry metadata that differs between machines — for example a mirror whose packument for the platform-binary packages hasn't synced a recently published version yet (the `1.0.2` binaries were 8 days old when the issue was filed, and only the freshly published version is affected, which matches the issue's observation that the older `@napi-rs/canvas@0.1.100` survived). During `pnpm dedupe` every package re-resolves from registry metadata, so all 11 exact-pinned binaries fail resolution at once and are dropped from the lockfile in one run, while a machine with a healthy registry restores them — the two hosts fight over the lockfile indefinitely, which the reporter perceived as OS-dependence. I verified that the minimal repro from the issue produces byte-identical lockfiles on macOS arm64 and Linux arm64 against a healthy registry, and that a stale packument reproduces the emptied snapshot exactly.

With this change, the resolution error is rethrown instead of swallowed when the wanted lockfile already contains an entry satisfying the wanted range: the install fails loudly and the lockfile stays intact. An optional dependency that never resolved (no locked entry) keeps the skip-on-failure behavior, so genuinely unresolvable optional deps still install fine. This follows the same pattern as pnpm/pnpm#10289 and pnpm/pnpm#10211, which stopped silently skipping optional deps for policy failures.

Verified end-to-end with the issue's reproduction against a proxy serving stale packuments: before, `pnpm dedupe` silently rewrote the snapshot to `{}`; after, it fails with `ERR_PNPM_NO_MATCHING_VERSION` naming the dependency path, and the lockfile keeps all 11 platform binaries. A healthy registry dedupe still succeeds.

**pacquet parity:** pacquet previously failed loudly on *every* optional-dependency resolution failure (its resolver never had the silent skip). This PR now aligns the two stacks on both cases: pacquet skips a never-locked unresolvable optional dep like pnpm — emitting the same `pnpm:skipped-optional-dependency` (`reason=resolution_failure`) payload including the `parents` chain (newly added to the wire type), with the default reporter rendering the same top-level info line — and keeps failing loudly, now with the same hint, when the wanted lockfile holds a satisfying entry. Covered by resolver-level tests mirroring the TypeScript regression test (locked entry → loud failure with the hint; never-locked → skip with the notification payload; out-of-range locked entry → still skips). One wording gap remains: the loud failure's message text differs (`ERR_PNPM_NO_MATCHING_VERSION` vs pacquet's stringified resolver-chain error, and miette prints `help:` where pnpm prints `hint:`) — that is pacquet's pre-existing error-rendering shape, left for a follow-up.

## Squash Commit Body

```text
When re-resolution of an optional dependency fails (for example, a
registry mirror whose packument has not synced the pinned version yet),
the resolver silently skipped the dependency. The parent's snapshot was
then rewritten without the edge and the pruner erased the locked
entries, so identical inputs produced different lockfiles depending on
which machine ran the install, and a frozen install on another host had
no entry to link for the affected package.

Rethrow the resolution error instead of skipping when the wanted
lockfile already holds an entry that satisfies the wanted range. An
optional dependency that never resolved keeps the skip-on-failure
behavior.

pacquet previously failed loudly on every optional-dependency
resolution failure. It now skips never-locked optional deps like pnpm,
emitting the same skipped-optional-dependency log (with the parents
chain and the same top-level reporter output), and keeps the loud
failure — with the same hint — when the lockfile holds a satisfying
entry, so the two stacks agree on both cases.

Closes pnpm/pnpm#12853
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed optional dependency handling so installs fail (instead of silently changing the lockfile) when a locked optional dependency can’t be resolved.
  * Prevents lockfile divergence and missing links in frozen installs when optional dependency versions are no longer available.

* **New Features**
  * Improved reporting for skipped optional dependencies, including more precise context for resolution-failure skips.

* **Tests**
  * Added regression coverage for locked optional-dependency invariance when registry metadata hides a previously locked version.
  * Added resolver scenarios verifying whether optional edges are skipped or installation fails based on lockfile satisfaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
