### PR TITLE
fix: allow git build approvals by repository

### DIFF
--- a/.changeset/allow-git-repo-builds.md
+++ b/.changeset/allow-git-repo-builds.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/building.policy": patch
+"pnpm": patch
+---
+
+Allow `allowBuilds` entries for git-hosted packages to match by repository URL without pinning the resolved commit hash. This lets trusted git repositories keep running their build scripts after branch updates without approving each new commit, while package-name-only rules still do not approve git-hosted artifacts.

--- a/pacquet/crates/package-manager/src/build_modules.rs
+++ b/pacquet/crates/package-manager/src/build_modules.rs
@@ -103,6 +103,8 @@ pub struct AllowBuildPolicy {
     expanded_disallowed: HashSet<String>,
     allowed_dep_paths: HashSet<String>,
     disallowed_dep_paths: HashSet<String>,
+    allowed_git_repos: HashSet<String>,
+    disallowed_git_repos: HashSet<String>,
     dangerously_allow_all: bool,
 }
 
@@ -122,6 +124,8 @@ impl AllowBuildPolicy {
             expanded_disallowed,
             allowed_dep_paths: HashSet::new(),
             disallowed_dep_paths: HashSet::new(),
+            allowed_git_repos: HashSet::new(),
+            disallowed_git_repos: HashSet::new(),
             dangerously_allow_all,
         }
     }
@@ -139,6 +143,8 @@ impl AllowBuildPolicy {
             expanded_disallowed,
             allowed_dep_paths,
             disallowed_dep_paths,
+            allowed_git_repos: HashSet::new(),
+            disallowed_git_repos: HashSet::new(),
             dangerously_allow_all,
         }
     }
@@ -153,8 +159,16 @@ impl AllowBuildPolicy {
         let mut disallowed_specs: Vec<&str> = Vec::new();
         let mut allowed_dep_paths = HashSet::new();
         let mut disallowed_dep_paths = HashSet::new();
+        let mut allowed_git_repos = HashSet::new();
+        let mut disallowed_git_repos = HashSet::new();
         for (spec, &value) in &config.allow_builds {
-            if is_dep_path_allow_build_key(spec) {
+            if is_git_repo_allow_build_key(spec) {
+                if value {
+                    allowed_git_repos.insert(spec.to_string());
+                } else {
+                    disallowed_git_repos.insert(spec.to_string());
+                }
+            } else if is_dep_path_allow_build_key(spec) {
                 if value {
                     allowed_dep_paths.insert(normalize_build_dep_path(spec));
                 } else {
@@ -176,7 +190,19 @@ impl AllowBuildPolicy {
             allowed_dep_paths,
             disallowed_dep_paths,
             config.dangerously_allow_all_builds,
-        ))
+        )
+        .with_git_repo_rules(allowed_git_repos, disallowed_git_repos))
+    }
+
+    #[must_use]
+    fn with_git_repo_rules(
+        mut self,
+        allowed_git_repos: HashSet<String>,
+        disallowed_git_repos: HashSet<String>,
+    ) -> Self {
+        self.allowed_git_repos = allowed_git_repos;
+        self.disallowed_git_repos = disallowed_git_repos;
+        self
     }
 
     /// Check whether a package is allowed to run build scripts.
@@ -190,6 +216,12 @@ impl AllowBuildPolicy {
         if self.disallowed_dep_paths.contains(&normalized_dep_path) {
             return Some(false);
         }
+        let git_repo_key = git_repo_allow_build_key_from_dep_path(&normalized_dep_path);
+        if let Some(git_repo_key) = git_repo_key
+            && self.disallowed_git_repos.contains(git_repo_key)
+        {
+            return Some(false);
+        }
         let (name, version) = parse_name_version_from_key(&normalized_dep_path);
         let name_at_version = format!("{name}@{version}");
         if self.expanded_disallowed.contains(&name)
@@ -198,6 +230,11 @@ impl AllowBuildPolicy {
             return Some(false);
         }
         if self.allowed_dep_paths.contains(&normalized_dep_path) {
+            return Some(true);
+        }
+        if let Some(git_repo_key) = git_repo_key
+            && self.allowed_git_repos.contains(git_repo_key)
+        {
             return Some(true);
         }
         // Package-name rules require a trusted package identity. A
@@ -257,6 +294,22 @@ fn parse_dep_path_name_version(pkg_id: &str) -> Option<(&str, &str)> {
         version = &version[..idx];
     }
     Some((name, version))
+}
+
+fn is_git_repo_allow_build_key(spec: &str) -> bool {
+    !spec.contains('#') && is_git_repo_dep_path(spec)
+}
+
+fn git_repo_allow_build_key_from_dep_path(dep_path: &str) -> Option<&str> {
+    if !is_git_repo_dep_path(dep_path) {
+        return None;
+    }
+    let ref_start = dep_path.find('#')?;
+    Some(&dep_path[..ref_start])
+}
+
+fn is_git_repo_dep_path(dep_path: &str) -> bool {
+    dep_path.starts_with("git+") || dep_path.contains("@git+")
 }
 
 fn is_dep_path_allow_build_key(spec: &str) -> bool {

--- a/pacquet/crates/package-manager/src/build_modules.rs
+++ b/pacquet/crates/package-manager/src/build_modules.rs
@@ -304,8 +304,10 @@ fn git_repo_allow_build_key_from_dep_path(dep_path: &str) -> Option<&str> {
     if !is_git_repo_dep_path(dep_path) {
         return None;
     }
-    let ref_start = dep_path.find('#')?;
-    Some(&dep_path[..ref_start])
+    Some(match dep_path.find('#') {
+        Some(ref_start) => &dep_path[..ref_start],
+        None => dep_path,
+    })
 }
 
 fn is_git_repo_dep_path(dep_path: &str) -> bool {

--- a/pacquet/crates/package-manager/src/build_modules.rs
+++ b/pacquet/crates/package-manager/src/build_modules.rs
@@ -164,9 +164,9 @@ impl AllowBuildPolicy {
         for (spec, &value) in &config.allow_builds {
             if is_git_repo_allow_build_key(spec) {
                 if value {
-                    allowed_git_repos.insert(spec.to_string());
+                    allowed_git_repos.insert(spec.clone());
                 } else {
-                    disallowed_git_repos.insert(spec.to_string());
+                    disallowed_git_repos.insert(spec.clone());
                 }
             } else if is_dep_path_allow_build_key(spec) {
                 if value {

--- a/pacquet/crates/package-manager/src/build_modules/tests.rs
+++ b/pacquet/crates/package-manager/src/build_modules/tests.rs
@@ -119,6 +119,7 @@ fn explicit_allow_by_git_repo_allows_untrusted_package_identity() {
     );
 
     assert_eq!(policy.check("foo@git+ssh://git@example.com/org/foo.git#abc123"), Some(true));
+    assert_eq!(policy.check("foo@git+ssh://git@example.com/org/foo.git"), Some(true));
     assert_eq!(
         policy.check("foo@git+ssh://git@example.com/org/foo.git#def456(react@19.0.0)"),
         Some(true),

--- a/pacquet/crates/package-manager/src/build_modules/tests.rs
+++ b/pacquet/crates/package-manager/src/build_modules/tests.rs
@@ -109,6 +109,26 @@ fn explicit_allow_by_dep_path_allows_untrusted_package_identity() {
 }
 
 #[test]
+fn explicit_allow_by_git_repo_allows_untrusted_package_identity() {
+    let policy = policy_from_specs(
+        [
+            ("foo@git+ssh://git@example.com/org/foo.git", true),
+            ("bar@git+ssh://git@example.com/org/bar.git", false),
+        ],
+        false,
+    );
+
+    assert_eq!(policy.check("foo@git+ssh://git@example.com/org/foo.git#abc123"), Some(true));
+    assert_eq!(
+        policy.check("foo@git+ssh://git@example.com/org/foo.git#def456(react@19.0.0)"),
+        Some(true),
+    );
+    assert_eq!(policy.check("foo@git+ssh://git@example.com/other/foo.git#abc123"), None);
+    assert_eq!(policy.check("foo@1.0.0"), None);
+    assert_eq!(policy.check("bar@git+ssh://git@example.com/org/bar.git#abc123"), Some(false));
+}
+
+#[test]
 fn explicit_allow_by_tarball_dep_path_allows_untrusted_package_identity() {
     let policy = policy_from_specs([("foo@https://example.com/foo.tgz", true)], false);
 

--- a/pnpm11/building/policy/src/index.ts
+++ b/pnpm11/building/policy/src/index.ts
@@ -124,7 +124,7 @@ function isGitRepoAllowBuildKey (pkg: string): boolean {
 function getGitRepoAllowBuildKeyFromDepPath (depPath: string): string | undefined {
   if (!isGitRepoDepPath(depPath)) return undefined
   const refStart = depPath.indexOf('#')
-  return refStart === -1 ? undefined : depPath.slice(0, refStart)
+  return refStart === -1 ? depPath : depPath.slice(0, refStart)
 }
 
 function isGitRepoDepPath (depPath: string): boolean {

--- a/pnpm11/building/policy/src/index.ts
+++ b/pnpm11/building/policy/src/index.ts
@@ -18,17 +18,21 @@ export function createAllowBuildFunction (
     const disallowedPackageBuilds = new Set<string>()
     const allowedDepPathBuilds = new Set<string>()
     const disallowedDepPathBuilds = new Set<string>()
+    const allowedGitRepoBuilds = new Set<string>()
+    const disallowedGitRepoBuilds = new Set<string>()
     for (const [pkg, value] of Object.entries(opts.allowBuilds)) {
       switch (value) {
         case true:
           addAllowBuildRule(pkg, {
             depPaths: allowedDepPathBuilds,
+            gitRepos: allowedGitRepoBuilds,
             packageSpecs: allowedPackageBuilds,
           })
           break
         case false:
           addAllowBuildRule(pkg, {
             depPaths: disallowedDepPathBuilds,
+            gitRepos: disallowedGitRepoBuilds,
             packageSpecs: disallowedPackageBuilds,
           })
           break
@@ -41,6 +45,10 @@ export function createAllowBuildFunction (
       if (disallowedDepPathBuilds.has(pkgIdWithPatchHash)) {
         return false
       }
+      const gitRepoKey = getGitRepoAllowBuildKeyFromDepPath(pkgIdWithPatchHash)
+      if (gitRepoKey != null && disallowedGitRepoBuilds.has(gitRepoKey)) {
+        return false
+      }
       const { name, version, nonSemverVersion } = dp.parse(depPath)
       const nameAtVersion = name != null && version != null ? `${name}@${version}` : undefined
       if (
@@ -50,6 +58,9 @@ export function createAllowBuildFunction (
         return false
       }
       if (allowedDepPathBuilds.has(pkgIdWithPatchHash)) {
+        return true
+      }
+      if (gitRepoKey != null && allowedGitRepoBuilds.has(gitRepoKey)) {
         return true
       }
       // Package-name rules require a trusted package identity. A
@@ -91,14 +102,33 @@ function addAllowBuildRule (
   pkg: string,
   target: {
     depPaths: Set<string>
+    gitRepos: Set<string>
     packageSpecs: Set<string>
   }
 ): void {
+  if (isGitRepoAllowBuildKey(pkg)) {
+    target.gitRepos.add(pkg)
+    return
+  }
   if (isDepPathAllowBuildKey(pkg)) {
     target.depPaths.add(dp.removePeersSuffix(pkg))
   } else {
     target.packageSpecs.add(pkg)
   }
+}
+
+function isGitRepoAllowBuildKey (pkg: string): boolean {
+  return !pkg.includes('#') && isGitRepoDepPath(pkg)
+}
+
+function getGitRepoAllowBuildKeyFromDepPath (depPath: string): string | undefined {
+  if (!isGitRepoDepPath(depPath)) return undefined
+  const refStart = depPath.indexOf('#')
+  return refStart === -1 ? undefined : depPath.slice(0, refStart)
+}
+
+function isGitRepoDepPath (depPath: string): boolean {
+  return depPath.startsWith('git+') || depPath.includes('@git+')
 }
 
 function isDepPathAllowBuildKey (pkg: string): boolean {

--- a/pnpm11/building/policy/test/index.ts
+++ b/pnpm11/building/policy/test/index.ts
@@ -113,6 +113,7 @@ it('should allow git-hosted depPaths by repository key', () => {
     },
   })
   expect(allowBuild!(depPath('foo@git+ssh://git@example.com/org/foo.git#abc123'))).toBe(true)
+  expect(allowBuild!(depPath('foo@git+ssh://git@example.com/org/foo.git'))).toBe(true)
   expect(allowBuild!(depPath('foo@git+ssh://git@example.com/org/foo.git#def456(react@19.0.0)'))).toBe(true)
   expect(allowBuild!(depPath('foo@git+ssh://git@example.com/other/foo.git#abc123'))).toBeUndefined()
   expect(allowBuild!(depPath('foo@1.0.0'))).toBeUndefined()

--- a/pnpm11/building/policy/test/index.ts
+++ b/pnpm11/building/policy/test/index.ts
@@ -105,6 +105,20 @@ it('should preserve patch hash in depPath allowBuild keys', () => {
   expect(allowBuild!(depPath('foo@https://example.com/foo.tgz(patch_hash=bbbb)(react@19.0.0)'))).toBeUndefined()
 })
 
+it('should allow git-hosted depPaths by repository key', () => {
+  const allowBuild = createAllowBuildFunction({
+    allowBuilds: {
+      'foo@git+ssh://git@example.com/org/foo.git': true,
+      'bar@git+ssh://git@example.com/org/bar.git': false,
+    },
+  })
+  expect(allowBuild!(depPath('foo@git+ssh://git@example.com/org/foo.git#abc123'))).toBe(true)
+  expect(allowBuild!(depPath('foo@git+ssh://git@example.com/org/foo.git#def456(react@19.0.0)'))).toBe(true)
+  expect(allowBuild!(depPath('foo@git+ssh://git@example.com/other/foo.git#abc123'))).toBeUndefined()
+  expect(allowBuild!(depPath('foo@1.0.0'))).toBeUndefined()
+  expect(allowBuild!(depPath('bar@git+ssh://git@example.com/org/bar.git#abc123'))).toBe(false)
+})
+
 it('should allow untrusted package identity by source-only depPath', () => {
   const allowBuild = createAllowBuildFunction({
     allowBuilds: { 'github.com/org/foo/abc123': true },

--- a/pnpm11/installing/deps-installer/test/install/lifecycleScripts.ts
+++ b/pnpm11/installing/deps-installer/test/install/lifecycleScripts.ts
@@ -339,6 +339,28 @@ test('run prepare script for git-hosted dependencies', async () => {
   ])
 })
 
+test('run prepare script for git-hosted dependencies allowed by repository', async () => {
+  const project = prepareEmpty()
+  const gitDependency = await createGitPreparePackage()
+  const repoAllowBuildKey = `test-git-fetch@${gitDependency.replace(/#[^#]+$/, '')}`
+
+  await addDependenciesToPackage({}, [gitDependency], testDefaults({
+    fastUnpack: false,
+    allowBuilds: { [repoAllowBuildKey]: true },
+  }))
+
+  const scripts = project.requireModule('test-git-fetch/output.json')
+  expect(scripts).toStrictEqual([
+    'preinstall',
+    'install',
+    'postinstall',
+    'prepare',
+    'preinstall',
+    'install',
+    'postinstall',
+  ])
+})
+
 async function createGitPreparePackage (): Promise<string> {
   const repoDir = path.resolve('test-git-fetch-src')
   fs.mkdirSync(repoDir)


### PR DESCRIPTION
## Summary

Allows `allowBuilds` keys for git-hosted packages to omit the resolved commit hash, for example `pkg@git+ssh://host/org/repo.git`.

Keeps package-name-only approvals registry-only, so `pkg: true` still does not approve git artifacts. The same policy is implemented in the TypeScript CLI and the Rust `pacquet/` port, with a changeset for `pnpm` and `@pnpm/building.policy`.

Fixes pnpm/pnpm#12367.

Validation:

- `corepack pnpm --filter @pnpm/building.policy test -- --runTestsByPath test/index.ts`
- `corepack pnpm --filter @pnpm/installing.deps-installer compile`
- `cargo fmt --check -- pacquet/crates/package-manager/src/build_modules.rs pacquet/crates/package-manager/src/build_modules/tests.rs`
- `cargo test -p pacquet-package-manager explicit_allow_by_git_repo_allows_untrusted_package_identity -- --nocapture`
- `corepack pnpm exec cspell .changeset/allow-git-repo-builds.md pnpm11/building/policy/src/index.ts pnpm11/building/policy/test/index.ts pnpm11/installing/deps-installer/test/install/lifecycleScripts.ts --no-progress`
- `git diff --check`

Full Rust workspace pre-push reached `cargo clippy --all-targets --workspace -- -D warnings` but could not complete in this container because compiling the workspace filled the local filesystem.

## Squash Commit Body

```text
Allow git-hosted build approvals to match the package/repository portion of a git depPath before the resolved commit hash.

This lets trusted git repositories continue running build scripts after branch updates without adding a new hash-qualified `allowBuilds` entry for every resolved commit. Exact depPath rules still work, disallow rules still win first, and package-name-only allow rules remain limited to trusted registry-style depPaths so git artifacts are not approved by name alone.

Fixes pnpm/pnpm#12367.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added repository URL–based allow/block rules for git-hosted package builds, so trusted repos remain allowed after branch/commit changes.
  - Repository-based build permissions now apply during installation, enabling expected lifecycle script execution for allowed git dependencies.

- **Bug Fixes**
  - Improved git-hosted dependency matching across URL fragment and nested package identity variants.
  - Ensures non-git packages aren’t impacted by git-repository rules.

- **Tests**
  - Extended coverage for git-repo allow/deny matching and lifecycle script order for allowed git dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->