### PR TITLE
fix: register pn alias in generated completions

### DIFF
--- a/.changeset/smooth-rules-hear.md
+++ b/.changeset/smooth-rules-hear.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/cli.commands": patch
+"pnpm": patch
+---
+
+Register the `pn` alias in generated shell completion scripts.

--- a/cspell.json
+++ b/cspell.json
@@ -50,6 +50,7 @@
     "codenames",
     "codesign",
     "colorterm",
+    "compdef",
     "comver",
     "copyfiles",
     "corejs",

--- a/pnpm11/cli/commands/src/completion/generateCompletion.ts
+++ b/pnpm11/cli/commands/src/completion/generateCompletion.ts
@@ -25,11 +25,43 @@ export interface Context {
 
 export type CompletionGenerator = (_opts: unknown, params: string[]) => Promise<void>
 
+const PNPM_COMMAND = 'pnpm'
+const PNPM_SHORT_ALIAS = 'pn'
+
+function registerShortAlias (output: string, shell: string): string {
+  switch (shell) {
+    case 'bash':
+      return output.replace(
+        `complete -o default -F _${PNPM_COMMAND}_completion ${PNPM_COMMAND}`,
+        `complete -o default -F _${PNPM_COMMAND}_completion ${PNPM_COMMAND} ${PNPM_SHORT_ALIAS}`
+      )
+    case 'fish':
+      return output.replace(
+        `complete -f -d '${PNPM_COMMAND}' -c ${PNPM_COMMAND} -a "(_${PNPM_COMMAND}_completion)"`,
+        `complete -f -d '${PNPM_COMMAND}' -c ${PNPM_COMMAND} -a "(_${PNPM_COMMAND}_completion)"\ncomplete -f -d '${PNPM_COMMAND}' -c ${PNPM_SHORT_ALIAS} -a "(_${PNPM_COMMAND}_completion)"`
+      )
+    case 'pwsh':
+      return output.replace(
+        `Register-ArgumentCompleter -CommandName '${PNPM_COMMAND}' -ScriptBlock`,
+        `Register-ArgumentCompleter -CommandName '${PNPM_COMMAND}','${PNPM_SHORT_ALIAS}' -ScriptBlock`
+      )
+    case 'zsh':
+      return output
+        .replace(`#compdef ${PNPM_COMMAND}`, `#compdef ${PNPM_COMMAND} ${PNPM_SHORT_ALIAS}`)
+        .replace(
+          `compdef _${PNPM_COMMAND}_completion ${PNPM_COMMAND}`,
+          `compdef _${PNPM_COMMAND}_completion ${PNPM_COMMAND} ${PNPM_SHORT_ALIAS}`
+        )
+    default:
+      return output
+  }
+}
+
 export function createCompletionGenerator (ctx: Context): CompletionGenerator {
   return async function handler (_opts: unknown, params: string[]): Promise<void> {
     const shell = getShellFromParams(params)
-    const output = await getCompletionScript({ name: 'pnpm', completer: 'pnpm', shell })
-    ctx.log(output)
+    const output = await getCompletionScript({ name: PNPM_COMMAND, completer: PNPM_COMMAND, shell })
+    ctx.log(registerShortAlias(output, shell))
   }
 }
 

--- a/pnpm11/cli/commands/src/completion/generateCompletion.ts
+++ b/pnpm11/cli/commands/src/completion/generateCompletion.ts
@@ -1,4 +1,4 @@
-import { getCompletionScript, SUPPORTED_SHELLS } from '@pnpm/tabtab'
+import { getCompletionScript, SUPPORTED_SHELLS, type SupportedShell } from '@pnpm/tabtab'
 import { renderHelp } from 'render-help'
 
 import { getShellFromParams } from './getShell.js'
@@ -28,7 +28,7 @@ export type CompletionGenerator = (_opts: unknown, params: string[]) => Promise<
 const PNPM_COMMAND = 'pnpm'
 const PNPM_SHORT_ALIAS = 'pn'
 
-function registerShortAlias (output: string, shell: string): string {
+function registerShortAlias (output: string, shell: SupportedShell): string {
   switch (shell) {
     case 'bash':
       return output.replace(
@@ -52,8 +52,6 @@ function registerShortAlias (output: string, shell: string): string {
           `compdef _${PNPM_COMMAND}_completion ${PNPM_COMMAND}`,
           `compdef _${PNPM_COMMAND}_completion ${PNPM_COMMAND} ${PNPM_SHORT_ALIAS}`
         )
-    default:
-      return output
   }
 }
 

--- a/pnpm11/cli/commands/src/completion/generateCompletion.ts
+++ b/pnpm11/cli/commands/src/completion/generateCompletion.ts
@@ -28,6 +28,14 @@ export type CompletionGenerator = (_opts: unknown, params: string[]) => Promise<
 const PNPM_COMMAND = 'pnpm'
 const PNPM_SHORT_ALIAS = 'pn'
 
+export function createCompletionGenerator (ctx: Context): CompletionGenerator {
+  return async function handler (_opts: unknown, params: string[]): Promise<void> {
+    const shell = getShellFromParams(params)
+    const output = await getCompletionScript({ name: PNPM_COMMAND, completer: PNPM_COMMAND, shell })
+    ctx.log(registerShortAlias(output, shell))
+  }
+}
+
 function registerShortAlias (output: string, shell: SupportedShell): string {
   switch (shell) {
     case 'bash':
@@ -52,14 +60,6 @@ function registerShortAlias (output: string, shell: SupportedShell): string {
           `compdef _${PNPM_COMMAND}_completion ${PNPM_COMMAND}`,
           `compdef _${PNPM_COMMAND}_completion ${PNPM_COMMAND} ${PNPM_SHORT_ALIAS}`
         )
-  }
-}
-
-export function createCompletionGenerator (ctx: Context): CompletionGenerator {
-  return async function handler (_opts: unknown, params: string[]): Promise<void> {
-    const shell = getShellFromParams(params)
-    const output = await getCompletionScript({ name: PNPM_COMMAND, completer: PNPM_COMMAND, shell })
-    ctx.log(registerShortAlias(output, shell))
   }
 }
 

--- a/pnpm11/cli/commands/test/completion/generateCompletion.ts
+++ b/pnpm11/cli/commands/test/completion/generateCompletion.ts
@@ -47,3 +47,23 @@ for (const shell of SUPPORTED_SHELLS) {
     expect(log).toHaveBeenCalledTimes(1)
   })
 }
+
+test.each([
+  ['bash', ['complete -o default -F _pnpm_completion pnpm pn']],
+  ['fish', [
+    'complete -f -d \'pnpm\' -c pnpm -a "(_pnpm_completion)"',
+    'complete -f -d \'pnpm\' -c pn -a "(_pnpm_completion)"',
+  ]],
+  ['pwsh', ['Register-ArgumentCompleter -CommandName \'pnpm\',\'pn\' -ScriptBlock']],
+  ['zsh', [
+    '#compdef pnpm pn',
+    'compdef _pnpm_completion pnpm pn',
+  ]],
+])('pnpm completion %s registers the pn alias', async (shell, expectedSnippets) => {
+  const { log, handler } = createHandler()
+  await handler({}, [shell])
+  const output = log.mock.calls[0][0]
+  for (const snippet of expectedSnippets) {
+    expect(output).toContain(snippet)
+  }
+})


### PR DESCRIPTION
## Summary

- Registers the `pn` alias alongside `pnpm` in generated bash, fish, pwsh, and zsh completion scripts.
- Adds generator coverage for the alias registration.
- Adds a patch changeset for `@pnpm/cli.commands` and `pnpm`.

Fixes pnpm/pnpm#11955.

## Validation

- `PATH="/tmp/pnpm-dev-bin:/root/.local/share/pnpm/bin:$PATH" corepack pnpm --filter @pnpm/cli.commands test pnpm11/cli/commands/test/completion/generateCompletion.ts`
- `node pnpm11/pnpm/bin/pnpm.mjs completion zsh | rg '#compdef|compdef _pnpm_completion'`
- `node pnpm11/pnpm/bin/pnpm.mjs completion bash | rg 'complete -o default'`
- `PATH="/tmp/pnpm-dev-bin:/root/.local/share/pnpm/bin:$PATH" corepack pnpm --filter pnpm compile`
- `PATH="/tmp/pnpm-dev-bin:/root/.local/share/pnpm/bin:$PATH" corepack pnpm --filter @pnpm/cli.commands lint`
- `PATH="/tmp/pnpm-dev-bin:/root/.local/share/pnpm/bin:$PATH" corepack pnpm spellcheck`
- `PATH="/tmp/pnpm-dev-bin:/root/.local/share/pnpm/bin:$PATH" git push -u fork fix-pn-zsh-completion-alias` — passed the available pre-push checks; `cargo-dylint` and `taplo` were skipped by the hook because they are not installed locally.

## Squash Commit Body

```text
Register the pn short alias in generated shell completion scripts.

pnpm exposes pn as a binary alias, but completion generation only registered
pnpm with the supported shells. This meant zsh completions generated by
pnpm completion zsh registered pnpm only, so pn did not receive the same
completion function.

Post-process the tabtab-generated scripts to register pn alongside pnpm for
bash, fish, pwsh, and zsh, and cover each shell in the completion generator
tests.

Fixes pnpm/pnpm#11955.
```

## Checklist

- [x] TypeScript CLI updated; no `pacquet/` port is needed because `pacquet completion` targets the `pacquet` command, not the `pnpm`/`pn` binaries.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Documentation is not needed; generated completion behavior is covered by tests and the changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shell completion now registers the `pn` shortcut alias alongside `pnpm` for Bash, Fish, PowerShell, and Zsh.
* **Tests**
  * Added Jest coverage to verify the `pn` alias appears correctly in the generated completion output for each supported shell.
* **Chores**
  * Updated spelling configuration to recognize an additional term used in completion script directives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->