### PR TITLE
fix: allow global named registries config

### DIFF
--- a/.changeset/global-registries-config.md
+++ b/.changeset/global-registries-config.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/config.commands": patch
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Allow `registries` and `namedRegistries` to be configured in the global `config.yaml` file.

--- a/pacquet/crates/cli/src/cli_args/config.rs
+++ b/pacquet/crates/cli/src/cli_args/config.rs
@@ -410,7 +410,7 @@ fn segment_to_string(segment: &Segment) -> String {
 /// `validateWorkspaceKey`: a known `types` key becomes camelCase; otherwise it
 /// must already be camelCase.
 fn validate_workspace_key(key: &str) -> Result<String, ConfigError> {
-    if config_types::is_type_key(key) {
+    if config_types::is_type_key(key) || config_types::is_config_file_key(key) {
         return Ok(naming_cases::to_camel_case(key));
     }
     if !naming_cases::is_camel_case(key) {

--- a/pacquet/crates/cli/src/cli_args/config/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/config/tests.rs
@@ -122,6 +122,42 @@ fn set_pnpm_key_global_writes_config_yaml_as_number() {
 }
 
 #[test]
+fn set_registries_and_named_registries_global_writes_config_yaml() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("global-config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let config = config_with_dir(&config_dir);
+
+    let registries = json!({
+        "default": "https://registry.example.com/",
+        "@scope": "https://scope.example.com/",
+    });
+    config_set(
+        &config,
+        tmp.path(),
+        flags(true, None, true),
+        "registries",
+        Some(registries.to_string()),
+    )
+    .unwrap();
+
+    let named_registries = json!({ "work": "https://work.example.com/" });
+    config_set(
+        &config,
+        tmp.path(),
+        flags(true, None, true),
+        "named-registries",
+        Some(named_registries.to_string()),
+    )
+    .unwrap();
+
+    assert_eq!(
+        read_yaml(&config_dir.join("config.yaml")).unwrap(),
+        json!({ "registries": registries, "namedRegistries": named_registries }),
+    );
+}
+
+#[test]
 fn set_camel_key_location_global() {
     let tmp = TempDir::new().unwrap();
     let config_dir = tmp.path().join("global-config");

--- a/pacquet/crates/config/src/config_types.rs
+++ b/pacquet/crates/config/src/config_types.rs
@@ -307,6 +307,11 @@ const PNPM_CONFIG_FILE_KEYS: &[&str] = &[
     "virtual-store-dir-max-length",
 ];
 
+/// Structured YAML settings parsed from `pnpm-workspace.yaml` / global
+/// `config.yaml` that have no scalar CLI config type
+/// (`structuredConfigFileKeys` in `configFileKey.ts`).
+const STRUCTURED_CONFIG_FILE_KEYS: &[&str] = &["named-registries", "registries"];
+
 /// Keys present in `pnpmTypes` but excluded from the global config file
 /// (`excludedPnpmKeys` in `configFileKey.ts`) — CLI flags and workspace-only
 /// settings.
@@ -436,6 +441,11 @@ fn pnpm_config_file_keys() -> &'static HashSet<&'static str> {
     SET.get_or_init(|| PNPM_CONFIG_FILE_KEYS.iter().copied().collect())
 }
 
+fn structured_config_file_keys() -> &'static HashSet<&'static str> {
+    static SET: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    SET.get_or_init(|| STRUCTURED_CONFIG_FILE_KEYS.iter().copied().collect())
+}
+
 fn excluded_pnpm_keys() -> &'static HashSet<&'static str> {
     static SET: OnceLock<HashSet<&'static str>> = OnceLock::new();
     SET.get_or_init(|| EXCLUDED_PNPM_KEYS.iter().copied().collect())
@@ -468,6 +478,7 @@ pub fn is_ini_config_key(key: &str) -> bool {
 #[must_use]
 pub fn is_config_file_key(kebab_key: &str) -> bool {
     pnpm_config_file_keys().contains(kebab_key)
+        || structured_config_file_keys().contains(kebab_key)
         || (npm_config_type_keys().contains(kebab_key) && !excluded_pnpm_keys().contains(kebab_key))
 }
 

--- a/pacquet/crates/config/src/config_types/tests.rs
+++ b/pacquet/crates/config/src/config_types/tests.rs
@@ -48,6 +48,9 @@ fn config_file_keys() {
     // npm-compatible, not excluded
     assert!(is_config_file_key("fetch-retries"));
     assert!(is_config_file_key("registry"));
+    // structured YAML settings without scalar CLI types
+    assert!(is_config_file_key("registries"));
+    assert!(is_config_file_key("named-registries"));
     // excluded workspace-only / CLI keys
     assert!(!is_config_file_key("catalog-mode"));
     assert!(!is_config_file_key("node-linker"));

--- a/pacquet/crates/config/src/tests.rs
+++ b/pacquet/crates/config/src/tests.rs
@@ -692,6 +692,59 @@ pub fn json_env_env_default_wins_over_workspace_yaml_default() {
     );
 }
 
+/// End-to-end: a `registries` alias in the user's global `config.yaml`
+/// cannot rebind a `pnpm_config__auth` token to a different host. The
+/// `_auth` routes sit above global-config registries in the merge, so the
+/// `@victim-scope` token stays on its declared host and the attacker host
+/// receives no credential. Mirrors the reader test
+/// `global config.yaml registries cannot redirect pnpm_config__auth routes`.
+#[test]
+pub fn global_config_yaml_registries_cannot_redirect_json_env_token() {
+    let xdg = tempdir().expect("xdg tempdir");
+    let config_dir = xdg.path().join("pnpm");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.yaml"),
+        "registries:\n  '@victim-scope': https://attacker.example/\n",
+    )
+    .expect("write global config.yaml");
+
+    let project = tempdir().expect("project tempdir");
+    set_fake_env(&[
+        ("XDG_CONFIG_HOME", xdg.path().to_str().unwrap()),
+        (
+            "pnpm_config__auth",
+            r#"{"https://npm.pkg.github.com":{"@victim-scope":{"authToken":"secret-token"}}}"#,
+        ),
+    ]);
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(
+        config.registries.get("@victim-scope").map(String::as_str),
+        Some("https://npm.pkg.github.com/"),
+    );
+    assert_eq!(
+        config
+            .auth_headers
+            .for_url_with_package(
+                "https://npm.pkg.github.com/victim-scope/foo",
+                Some("@victim-scope/foo")
+            )
+            .as_deref(),
+        Some("Bearer secret-token"),
+    );
+    assert!(
+        config
+            .auth_headers
+            .for_url_with_package(
+                "https://attacker.example/victim-scope/foo",
+                Some("@victim-scope/foo")
+            )
+            .is_none(),
+        "global-config registry alias must not receive the env token",
+    );
+}
+
 /// End-to-end: the `_auth` key of the global pnpm `config.yaml`
 /// configures registry auth and the inferred routes, just like the
 /// `pnpm_config__auth` env var.

--- a/pnpm11/config/commands/src/configSet.ts
+++ b/pnpm11/config/commands/src/configSet.ts
@@ -194,7 +194,7 @@ export class ConfigSetUnsupportedWorkspaceKeyError extends PnpmError {
  * Return the camelCase of {@link key} if it's valid.
  */
 function validateWorkspaceKey (key: string): string {
-  if (Object.hasOwn(types, key)) return camelCase(key)
+  if (Object.hasOwn(types, key) || isConfigFileKey(key)) return camelCase(key)
   if (!isCamelCase(key)) throw new ConfigSetUnsupportedWorkspaceKeyError(key)
   return key
 }

--- a/pnpm11/config/commands/test/configSet.test.ts
+++ b/pnpm11/config/commands/test/configSet.test.ts
@@ -106,6 +106,54 @@ test('config set pnpm-specific key using the global option', async () => {
   })
 })
 
+test('config set registries and named registries using the global option', async () => {
+  const tmp = tempDir()
+  const configDir = path.join(tmp, 'global-config')
+  const initConfig = {
+    globalRc: undefined,
+    globalYaml: {
+      storeDir: '~/store',
+    },
+    localRc: undefined,
+    localYaml: undefined,
+  } satisfies ConfigFilesData
+  const registries = {
+    default: 'https://registry.example.com/',
+    '@scope': 'https://scope.example.com/',
+  }
+  const namedRegistries = {
+    work: 'https://work.example.com/',
+  }
+  writeConfigFiles(configDir, tmp, initConfig)
+
+  await config.handler(createConfigCommandOpts({
+    dir: process.cwd(),
+    cliOptions: {},
+    configDir,
+    global: true,
+    json: true,
+    authConfig: {},
+  }), ['set', 'registries', JSON.stringify(registries)])
+
+  await config.handler(createConfigCommandOpts({
+    dir: process.cwd(),
+    cliOptions: {},
+    configDir,
+    global: true,
+    json: true,
+    authConfig: {},
+  }), ['set', 'named-registries', JSON.stringify(namedRegistries)])
+
+  expect(readConfigFiles(configDir, tmp)).toEqual({
+    ...initConfig,
+    globalYaml: {
+      ...initConfig.globalYaml,
+      registries,
+      namedRegistries,
+    },
+  })
+})
+
 test('config set using the location=global option', async () => {
   const tmp = tempDir()
   const configDir = path.join(tmp, 'global-config')

--- a/pnpm11/config/reader/src/configFileKey.ts
+++ b/pnpm11/config/reader/src/configFileKey.ts
@@ -79,6 +79,16 @@ export const pnpmConfigFileKeys = [
 export type PnpmConfigFileKey = typeof pnpmConfigFileKeys[number]
 
 /**
+ * Structured YAML settings that are parsed from pnpm-workspace.yaml but don't
+ * have scalar CLI config types.
+ */
+export const structuredConfigFileKeys = [
+  'named-registries',
+  'registries',
+] as const
+export type StructuredConfigFileKey = typeof structuredConfigFileKeys[number]
+
+/**
  * Keys that present in {@link pnpmTypes} but are excluded from {@link ConfigFileKey}.
  * They are usually CLI flags or workspace-only settings.
  */
@@ -184,11 +194,12 @@ export const _proofNoContradiction = (carrier: PnpmConfigFileKey & ExcludedPnpmK
 export type NpmConfigFileKey = Exclude<NpmKey, ExcludedPnpmKey>
 
 /** Key that is valid in a global config file. */
-export type ConfigFileKey = NpmConfigFileKey | PnpmConfigFileKey
+export type ConfigFileKey = NpmConfigFileKey | PnpmConfigFileKey | StructuredConfigFileKey
 
 const setOfPnpmConfigFilesKeys: ReadonlySet<string> = new Set(pnpmConfigFileKeys)
+const setOfStructuredConfigFilesKeys: ReadonlySet<string> = new Set(structuredConfigFileKeys)
 const setOfExcludedPnpmKeys: ReadonlySet<string> = new Set(excludedPnpmKeys)
 
 /** Whether the key (in kebab-case) is a valid key in a global config file. */
 export const isConfigFileKey = (kebabKey: string): kebabKey is ConfigFileKey =>
-  setOfPnpmConfigFilesKeys.has(kebabKey) || (kebabKey in npmConfigTypes && !setOfExcludedPnpmKeys.has(kebabKey))
+  setOfPnpmConfigFilesKeys.has(kebabKey) || setOfStructuredConfigFilesKeys.has(kebabKey) || (kebabKey in npmConfigTypes && !setOfExcludedPnpmKeys.has(kebabKey))

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -303,6 +303,7 @@ export async function getConfig (opts: {
     ?? `${packageManager.name}/${packageManager.version} npm/? node/${process.version} ${process.platform} ${process.arch}`
   pnpmConfig.authConfig = pickIniConfig(npmrcResult.rawConfig)
 
+  let globalYamlRegistries: Record<string, string> | undefined
   // Reuse the global config.yaml already read for npmrcAuthFile
   const globalYamlConfig = globalYamlConfigForNpmrcAuthFile
   if (globalYamlConfig) {
@@ -326,6 +327,7 @@ export async function getConfig (opts: {
       workspaceDir: undefined,
       workspaceManifest: globalYamlConfig,
     })
+    globalYamlRegistries = pnpmConfig.registries as Record<string, string> | undefined
   }
   const networkConfigs = getNetworkConfigs(pnpmConfig.authConfig)
   const registriesFromNpmrc = {
@@ -435,6 +437,7 @@ export async function getConfig (opts: {
   pnpmConfig.packageManager = packageManager
 
   pnpmConfig.rootProjectManifestDir = pnpmConfig.lockfileDir ?? pnpmConfig.workspaceDir ?? pnpmConfig.dir
+  let workspaceManifestRegistries: Record<string, string> | undefined
   if (!opts.ignoreLocalSettings) {
     pnpmConfig.rootProjectManifest = await safeReadProjectManifestOnly(pnpmConfig.rootProjectManifestDir) ?? undefined
     if (pnpmConfig.rootProjectManifest != null) {
@@ -466,6 +469,9 @@ export async function getConfig (opts: {
           workspaceDir: pnpmConfig.workspaceDir,
           workspaceManifest,
         })
+        if (workspaceManifest.registries != null) {
+          workspaceManifestRegistries = pnpmConfig.registries as Record<string, string> | undefined
+        }
       }
     } else if (cliOptions['global']) {
       // For global installs, read settings from pnpm-workspace.yaml in the global package directory
@@ -477,6 +483,9 @@ export async function getConfig (opts: {
           workspaceDir: pnpmConfig.globalPkgDir,
           workspaceManifest,
         })
+        if (workspaceManifest.registries != null) {
+          workspaceManifestRegistries = pnpmConfig.registries as Record<string, string> | undefined
+        }
       }
     }
   }
@@ -486,10 +495,10 @@ export async function getConfig (opts: {
   // via `authConfig`, so they're re-applied last here to avoid being buried
   // by yaml. `cliScopedRegistries` iterates raw `cliOptions` because
   // `explicitlySetKeys` is camelCased, which mangles `@org-a:registry`.
-  const workspaceRegistries = pnpmConfig.registries as Record<string, string> | undefined
   pnpmConfig.registries = {
     ...registriesFromNpmrc,
-    ...workspaceRegistries,
+    ...globalYamlRegistries,
+    ...workspaceManifestRegistries,
     // `_auth` routes win over repo-controlled yaml on conflicting scopes.
     ...npmrcResult.jsonAuth.registries,
     // CLI per-scope registries last, so `--@scope:registry=...` wins over

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -1385,12 +1385,11 @@ test('global config.yaml registries cannot redirect pnpm_config__auth routes', a
     },
   })
 
-  process.env.XDG_CONFIG_HOME = path.resolve('.config')
-
   const { config } = await getConfig({
     cliOptions: {},
     env: {
       ...env,
+      XDG_CONFIG_HOME: path.resolve('.config'),
       pnpm_config__auth: JSON.stringify({
         'https://registry.npmjs.org': {
           '@victim-scope': { authToken: 'secret-token' },

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -3588,6 +3588,40 @@ describe('global config.yaml', () => {
     expect(config.registries.default).toBe('https://trusted.example.com/npm/')
   })
 
+  test('reads registries and named registries from global config.yaml', async () => {
+    prepareEmpty()
+
+    fs.mkdirSync('.config/pnpm', { recursive: true })
+    writeYamlFileSync('.config/pnpm/config.yaml', {
+      registries: {
+        default: 'https://${PNPM_TEST_HOST}/npm/',
+        '@scope': 'https://${PNPM_TEST_HOST}/scope/',
+      },
+      namedRegistries: {
+        work: 'https://${PNPM_TEST_HOST}/work/',
+      },
+    })
+
+    process.env.XDG_CONFIG_HOME = path.resolve('.config')
+    process.env.PNPM_TEST_HOST = 'trusted.example.com'
+
+    const { config, warnings } = await getConfig({
+      cliOptions: {},
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(config.registries.default).toBe('https://trusted.example.com/npm/')
+    expect(config.registries['@scope']).toBe('https://trusted.example.com/scope/')
+    expect(config.namedRegistries).toStrictEqual({
+      work: 'https://trusted.example.com/work/',
+    })
+    expect(warnings.find((w) => w.includes('global config file'))).toBeUndefined()
+  })
+
   test('reads user-level preference settings from global config.yaml', async () => {
     prepareEmpty()
 

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -1375,6 +1375,39 @@ test('repo registry config cannot redirect pnpm_config__auth tokens', async () =
   expect(config.authConfig['//registry.npmjs.org/:@victim-scope:_authToken']).toBe('secret-token')
 })
 
+test('global config.yaml registries cannot redirect pnpm_config__auth routes', async () => {
+  prepareEmpty()
+
+  fs.mkdirSync('.config/pnpm', { recursive: true })
+  writeYamlFileSync('.config/pnpm/config.yaml', {
+    registries: {
+      '@victim-scope': 'https://attacker.example/',
+    },
+  })
+
+  process.env.XDG_CONFIG_HOME = path.resolve('.config')
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://registry.npmjs.org': {
+          '@victim-scope': { authToken: 'secret-token' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+    workspaceDir: process.cwd(),
+  })
+
+  // `_auth` routes sit above global config.yaml in the registries merge, so a
+  // user's global registry alias cannot rebind an `_auth` token's host.
+  expect(config.registries['@victim-scope']).toBe('https://registry.npmjs.org/')
+  expect(config.authConfig['//attacker.example/:_authToken']).toBeUndefined()
+  expect(config.authConfig['//registry.npmjs.org/:@victim-scope:_authToken']).toBe('secret-token')
+})
+
 async function expectAuthError (auth: unknown): Promise<Error> {
   let error: Error | undefined
   try {

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -3622,6 +3622,37 @@ describe('global config.yaml', () => {
     expect(warnings.find((w) => w.includes('global config file'))).toBeUndefined()
   })
 
+  test('workspace manifest registries win over global config.yaml registries', async () => {
+    prepareEmpty()
+
+    fs.mkdirSync('.config/pnpm', { recursive: true })
+    writeYamlFileSync('.config/pnpm/config.yaml', {
+      registries: {
+        default: 'https://global.example.com/npm/',
+        '@scope': 'https://global.example.com/scope/',
+      },
+    })
+    writeYamlFileSync('pnpm-workspace.yaml', {
+      registries: {
+        default: 'https://workspace.example.com/npm/',
+      },
+    })
+
+    process.env.XDG_CONFIG_HOME = path.resolve('.config')
+
+    const { config } = await getConfig({
+      cliOptions: {},
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(config.registries.default).toBe('https://workspace.example.com/npm/')
+    expect(config.registries['@scope']).toBe('https://global.example.com/scope/')
+  })
+
   test('reads user-level preference settings from global config.yaml', async () => {
     prepareEmpty()
 


### PR DESCRIPTION
## Summary

- Allows `registries` and `namedRegistries` in the global `config.yaml` allowlist (TypeScript CLI and pacquet).
- Preserves global YAML registries through the registry merge path, below `_auth` and CLI overrides.
- Makes `pnpm config set --global registries`/`named-registries` succeed instead of erroring with an unsupported-key error, in both stacks.
- Adds config reader, `config set`, precedence, and security regression coverage.

Fixes pnpm/pnpm#12858.

## Validation

TypeScript CLI:

- `pnpm --filter @pnpm/config.commands test test/configSet.test.ts`
- `pnpm --filter @pnpm/config.reader test test/index.ts`
- `pnpm --filter @pnpm/config.commands lint` / `pnpm --filter @pnpm/config.reader lint`

pacquet:

- `cargo nextest run -p pacquet-config -p pacquet-cli`
- `cargo clippy --locked -p pacquet-config -p pacquet-cli --all-targets -- --deny warnings`
- `cargo fmt -p pacquet-config -p pacquet-cli -- --check`

## Squash Commit Body

```text
Allow global config.yaml to carry registries and namedRegistries.

pnpm already parses those fields from YAML settings, but the global config
allowlist filtered them out and pnpm config set --global rejected them. That
leaves global installs unable to resolve named registry aliases.

Add registries/named-registries to the global YAML key allowlist, preserve
global YAML registries through the registry merge path (below _auth and CLI),
and make pnpm config set --global accept them. Mirror the same fix in pacquet
so both stacks stay behaviorally identical.

Add config set, reader, precedence, and security-regression coverage — the
latter asserting a global registry alias cannot rebind an _auth token's host.

Fixes pnpm/pnpm#12858.
```

## Checklist

- [x] TypeScript CLI updated and mirrored in `pacquet/` (config-file key allowlist and `config set` validation), so both stacks stay in sync.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Documentation is not needed; the behavior is covered by tests and the changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now configure `registries` and `namedRegistries` in the global `config.yaml` file.
* **Bug Fixes**
  * Improved merging and precedence of registry settings from global config, workspace manifests, and command-line inputs.
  * Expanded support for structured workspace/global config keys used for `registries` and `named-registries`.
  * Prevented global `registries` settings from redirecting `_auth` token routing unexpectedly.
* **Tests**
  * Added coverage for loading/persisting `registries`/`namedRegistries` and verifying precedence and security behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
