### PR TITLE
fix(deploy): preserve local tarball package names

### DIFF
--- a/.changeset/deploy-local-tarball-names.md
+++ b/.changeset/deploy-local-tarball-names.md
@@ -1,6 +1,7 @@
 ---
 "@pnpm/releasing.commands": patch
 "pnpm": patch
+"pacquet": patch
 ---
 
 Fixed `pnpm deploy` with a shared lockfile so local `file:` tarball dependencies keep their package name in the generated deploy lockfile. This prevents warm-store deploys from failing with `ERR_PNPM_UNEXPECTED_PKG_CONTENT_IN_STORE` when the tarball filename includes the version.

--- a/.changeset/deploy-local-tarball-names.md
+++ b/.changeset/deploy-local-tarball-names.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+Fixed `pnpm deploy` with a shared lockfile so local `file:` tarball dependencies keep their package name in the generated deploy lockfile. This prevents warm-store deploys from failing with `ERR_PNPM_UNEXPECTED_PKG_CONTENT_IN_STORE` when the tarball filename includes the version.

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -815,7 +815,7 @@ fn create_deploy_files(
         }
         let project_root =
             validate_lockfile_local_path(&lockfile_dir.join(importer_path), lockfile_dir)?;
-        let package_key = create_file_url_key(&project_root, "", &selected.all_projects)?;
+        let package_key = create_file_url_key(&project_root, "", &selected.all_projects, None)?;
         packages.insert(
             package_key,
             PackageMetadata {
@@ -851,7 +851,7 @@ fn create_deploy_files(
         let project_root =
             validate_lockfile_local_path(&lockfile_dir.join(importer_path), lockfile_dir)?;
         let bases = ResolveBases { file_base: lockfile_dir, link_base: &project_root };
-        let package_key = create_file_url_key(&project_root, "", &selected.all_projects)?;
+        let package_key = create_file_url_key(&project_root, "", &selected.all_projects, None)?;
         snapshots.insert(
             package_key,
             project_snapshot_to_snapshot_entry(project_snapshot, &ctx, &bases)?,
@@ -1084,7 +1084,7 @@ fn convert_importer_version_to_snapshot_ref(
     bases: &ResolveBases,
 ) -> miette::Result<SnapshotDepRef> {
     if let Some(local) = resolve_importer_dep_version(version, bases) {
-        return local_to_snapshot_dep_ref(&local, ctx);
+        return local_to_snapshot_dep_ref(alias, &local, ctx);
     }
     Ok(match version {
         ImporterDepVersion::Regular(version) => SnapshotDepRef::Plain(version.clone()),
@@ -1092,7 +1092,7 @@ fn convert_importer_version_to_snapshot_ref(
         ImporterDepVersion::Link(target) => SnapshotDepRef::Link(target.clone()),
         ImporterDepVersion::File(payload) => {
             let local = resolve_file_payload(bases.file_base, payload).with_alias(alias);
-            local_to_snapshot_dep_ref(&local, ctx)?
+            local_to_snapshot_dep_ref(alias, &local, ctx)?
         }
     })
 }
@@ -1104,7 +1104,7 @@ fn convert_snapshot_dep_ref(
     bases: &ResolveBases,
 ) -> miette::Result<SnapshotDepRef> {
     if let Some(local) = resolve_snapshot_dep_ref(alias, dep_ref, bases) {
-        return local_to_snapshot_dep_ref(&local, ctx);
+        return local_to_snapshot_dep_ref(alias, &local, ctx);
     }
     Ok(dep_ref.clone())
 }
@@ -1173,7 +1173,7 @@ impl LocalResolve {
 }
 
 fn local_to_importer_dep_version(
-    _alias: &PkgName,
+    alias: &PkgName,
     local: &LocalResolve,
     ctx: &ConvertCtx,
 ) -> miette::Result<ImporterDepVersion> {
@@ -1181,11 +1181,12 @@ fn local_to_importer_dep_version(
     if same_path(&resolved_path, ctx.deployed_project_root) {
         return Ok(ImporterDepVersion::Link(".".to_string()));
     }
-    let key = create_file_url_key(&resolved_path, &local.suffix, ctx.all_projects)?;
+    let key = create_file_url_key(&resolved_path, &local.suffix, ctx.all_projects, Some(alias))?;
     Ok(ImporterDepVersion::Alias(key))
 }
 
 fn local_to_snapshot_dep_ref(
+    alias: &PkgName,
     local: &LocalResolve,
     ctx: &ConvertCtx,
 ) -> miette::Result<SnapshotDepRef> {
@@ -1193,13 +1194,18 @@ fn local_to_snapshot_dep_ref(
     if same_path(&resolved_path, ctx.deployed_project_root) {
         return Ok(SnapshotDepRef::Link(".".to_string()));
     }
-    Ok(SnapshotDepRef::Alias(create_file_url_key(&resolved_path, &local.suffix, ctx.all_projects)?))
+    Ok(SnapshotDepRef::Alias(create_file_url_key(
+        &resolved_path,
+        &local.suffix,
+        ctx.all_projects,
+        Some(alias),
+    )?))
 }
 
 fn convert_package_key(key: &PackageKey, ctx: &ConvertCtx) -> miette::Result<PackageKey> {
     let VersionPart::File(path) = key.suffix.version() else { return Ok(key.clone()) };
     let resolved = validate_lockfile_local_path(&ctx.lockfile_dir.join(path), ctx.lockfile_dir)?;
-    create_file_url_key(&resolved, key.suffix.peer(), ctx.all_projects)
+    create_file_url_key(&resolved, key.suffix.peer(), ctx.all_projects, Some(&key.name))
 }
 
 fn validate_lockfile_local_path(path: &Path, lockfile_dir: &Path) -> miette::Result<PathBuf> {
@@ -1215,6 +1221,7 @@ fn create_file_url_key(
     resolved_path: &Path,
     suffix: &str,
     all_projects: &[ProjectInfo],
+    package_name: Option<&PkgName>,
 ) -> miette::Result<PkgNameVerPeer> {
     let normalized = lexical_normalize(resolved_path);
     let normalized_display = normalized.display();
@@ -1226,6 +1233,7 @@ fn create_file_url_key(
         .find(|project| same_path(&project.root_dir, &normalized))
         .and_then(|project| project.name.as_deref())
         .map(str::to_string)
+        .or_else(|| package_name.map(PkgName::to_string))
         .or_else(|| normalized.file_name().map(|name| name.to_string_lossy().into_owned()))
         .unwrap_or_else(|| normalized.display().to_string());
     format!("{name}@{dep_file_url}{suffix}")

--- a/pnpm/crates/cli/src/cli_args/deploy/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy/tests.rs
@@ -1,9 +1,9 @@
 use super::{
-    ConvertCtx, convert_package_metadata, create_deploy_install_config, split_local_payload,
-    validate_lockfile_local_path,
+    ConvertCtx, convert_package_key, convert_package_metadata, create_deploy_install_config,
+    split_local_payload, validate_lockfile_local_path,
 };
 use pacquet_config::{Config, NodeLinker};
-use pacquet_lockfile::{LockfileResolution, PackageMetadata, TarballResolution};
+use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, TarballResolution};
 use std::path::Path;
 
 #[cfg(unix)]
@@ -107,6 +107,31 @@ fn convert_package_metadata_rebases_file_tarball_resolution_to_deploy_dir() {
         }
         other => panic!("expected tarball resolution, got {other:?}"),
     }
+}
+
+#[test]
+fn convert_package_key_preserves_local_tarball_name() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let lockfile_dir = tmp.path().join("workspace");
+    let deploy_dir = lockfile_dir.join("deploy");
+    let deployed_project_root = lockfile_dir.join("packages/app");
+    let all_projects = Vec::new();
+    let ctx = ConvertCtx {
+        all_projects: &all_projects,
+        deploy_dir: &deploy_dir,
+        lockfile_dir: &lockfile_dir,
+        deployed_project_root: &deployed_project_root,
+    };
+    let key: PackageKey =
+        "tar-pkg@file:vendor/tar-pkg-1.0.0.tgz".parse().expect("parse package key");
+
+    let converted = convert_package_key(&key, &ctx).expect("convert package key");
+
+    assert_eq!(
+        converted.name.to_string(),
+        "tar-pkg",
+        "the tarball's package name must be kept, not the tarball filename",
+    );
 }
 
 #[cfg(unix)]

--- a/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
+++ b/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
@@ -76,9 +76,8 @@ export function createDeployFiles ({
       lockfileDir,
       projectRootDirRealPath: rootProjectManifestDir,
     })
-    const inputPackageName = dp.parse(inputDepPath).name
     const outputDepPath = resolveResult
-      ? createFileUrlDepPath(resolveResult, allProjects, resolveResult.packageName ?? inputPackageName)
+      ? createFileUrlDepPath(resolveResult, allProjects)
       : inputDepPath
     targetPackageSnapshots[outputDepPath] = convertPackageSnapshot(inputSnapshot, {
       allProjects,
@@ -120,8 +119,9 @@ export function createDeployFiles ({
         continue
       }
 
+      resolveResult.packageName ??= name
       targetSpecifiers[name] = targetDependencies[name] =
-        resolveResult.resolvedPath === deployedProjectRealPath ? 'link:.' : createFileUrlDepPath(resolveResult, allProjects, resolveResult.packageName ?? name)
+        resolveResult.resolvedPath === deployedProjectRealPath ? 'link:.' : createFileUrlDepPath(resolveResult, allProjects)
     }
   }
 
@@ -253,7 +253,8 @@ function convertResolvedDependencies (
       continue
     }
 
-    output[key] = createFileUrlDepPath(resolveResult, opts.allProjects, resolveResult.packageName ?? key)
+    resolveResult.packageName ??= key
+    output[key] = createFileUrlDepPath(resolveResult, opts.allProjects)
   }
 
   return output
@@ -300,9 +301,8 @@ function resolveLinkOrFile (pkgVer: string, opts: Pick<ConvertOptions, 'lockfile
 }
 
 function createFileUrlDepPath (
-  { resolvedPath, suffix }: Pick<ResolveLinkOrFileResult, 'resolvedPath' | 'suffix'>,
-  allProjects: CreateDeployFilesOptions['allProjects'],
-  packageName?: string
+  { resolvedPath, suffix, packageName }: Pick<ResolveLinkOrFileResult, 'resolvedPath' | 'suffix' | 'packageName'>,
+  allProjects: CreateDeployFilesOptions['allProjects']
 ): DepPath {
   const depFileUrl = url.pathToFileURL(resolvedPath).toString()
   const project = allProjects.find(project => project.rootDirRealPath === resolvedPath)

--- a/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
+++ b/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
@@ -76,8 +76,9 @@ export function createDeployFiles ({
       lockfileDir,
       projectRootDirRealPath: rootProjectManifestDir,
     })
+    const inputPackageName = dp.parse(inputDepPath).name
     const outputDepPath = resolveResult
-      ? createFileUrlDepPath(resolveResult, allProjects)
+      ? createFileUrlDepPath(resolveResult, allProjects, resolveResult.packageName ?? inputPackageName)
       : inputDepPath
     targetPackageSnapshots[outputDepPath] = convertPackageSnapshot(inputSnapshot, {
       allProjects,
@@ -120,7 +121,7 @@ export function createDeployFiles ({
       }
 
       targetSpecifiers[name] = targetDependencies[name] =
-        resolveResult.resolvedPath === deployedProjectRealPath ? 'link:.' : createFileUrlDepPath(resolveResult, allProjects)
+        resolveResult.resolvedPath === deployedProjectRealPath ? 'link:.' : createFileUrlDepPath(resolveResult, allProjects, resolveResult.packageName ?? name)
     }
   }
 
@@ -252,7 +253,7 @@ function convertResolvedDependencies (
       continue
     }
 
-    output[key] = createFileUrlDepPath(resolveResult, opts.allProjects)
+    output[key] = createFileUrlDepPath(resolveResult, opts.allProjects, resolveResult.packageName ?? key)
   }
 
   return output
@@ -262,6 +263,7 @@ interface ResolveLinkOrFileResult {
   scheme: 'link:' | 'file:'
   resolvedPath: string
   suffix?: string
+  packageName?: string
 }
 
 function resolveLinkOrFile (pkgVer: string, opts: Pick<ConvertOptions, 'lockfileDir' | 'projectRootDirRealPath'>): ResolveLinkOrFileResult | undefined {
@@ -277,7 +279,7 @@ function resolveLinkOrFile (pkgVer: string, opts: Pick<ConvertOptions, 'lockfile
   const resolveSchemeResult = resolveScheme('file:', lockfileDir) ?? resolveScheme('link:', projectRootDirRealPath)
   if (resolveSchemeResult) return resolveSchemeResult
 
-  const { nonSemverVersion, patchHash, peerDepGraphHash, version } = dp.parse(pkgVer)
+  const { name, nonSemverVersion, patchHash, peerDepGraphHash, version } = dp.parse(pkgVer)
   if (!nonSemverVersion) return undefined
 
   if (version) {
@@ -292,16 +294,18 @@ function resolveLinkOrFile (pkgVer: string, opts: Pick<ConvertOptions, 'lockfile
   }
 
   parseResult.suffix = `${patchHash ?? ''}${peerDepGraphHash ?? ''}`
+  parseResult.packageName = name
 
   return parseResult
 }
 
 function createFileUrlDepPath (
   { resolvedPath, suffix }: Pick<ResolveLinkOrFileResult, 'resolvedPath' | 'suffix'>,
-  allProjects: CreateDeployFilesOptions['allProjects']
+  allProjects: CreateDeployFilesOptions['allProjects'],
+  packageName?: string
 ): DepPath {
   const depFileUrl = url.pathToFileURL(resolvedPath).toString()
   const project = allProjects.find(project => project.rootDirRealPath === resolvedPath)
-  const name = project?.manifest.name ?? path.basename(resolvedPath)
+  const name = project?.manifest.name ?? packageName ?? path.basename(resolvedPath)
   return `${name}@${depFileUrl}${suffix ?? ''}` as DepPath
 }

--- a/pnpm11/releasing/commands/test/deploy/createDeployFiles.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/createDeployFiles.test.ts
@@ -1,0 +1,71 @@
+import path from 'node:path'
+import url from 'node:url'
+
+import { expect, test } from '@jest/globals'
+import type { LockfileObject } from '@pnpm/lockfile.types'
+import type { DepPath, ProjectId, ProjectRootDirRealPath } from '@pnpm/types'
+
+import { createDeployFiles } from '../../src/deploy/createDeployFiles.js'
+
+test('createDeployFiles keeps local tarball package names when rewriting file URLs', () => {
+  const lockfileDir = path.resolve('workspace')
+  const deployDir = path.join(lockfileDir, 'out')
+  const tarball = path.join(lockfileDir, 'vendor/tar-pkg-1.0.0.tgz')
+  const tarballUrl = url.pathToFileURL(tarball).toString()
+  const inputDepPath = 'tar-pkg@file:vendor/tar-pkg-1.0.0.tgz' as DepPath
+  const outputDepPath = `tar-pkg@${tarballUrl}` as DepPath
+  const outputDepPathWithTarballFilename = `tar-pkg-1.0.0.tgz@${tarballUrl}` as DepPath
+  const projectId = '.' as ProjectId
+  const lockfile: LockfileObject = {
+    lockfileVersion: '9.0',
+    settings: {
+      autoInstallPeers: true,
+      excludeLinksFromLockfile: false,
+      injectWorkspacePackages: true,
+    },
+    importers: {
+      [projectId]: {
+        specifiers: {
+          'tar-pkg': 'file:vendor/tar-pkg-1.0.0.tgz',
+        },
+        dependencies: {
+          'tar-pkg': 'file:vendor/tar-pkg-1.0.0.tgz',
+        },
+      },
+    },
+    packages: {
+      [inputDepPath]: {
+        resolution: {
+          integrity: 'sha512-test',
+          tarball: 'file:vendor/tar-pkg-1.0.0.tgz',
+        },
+        version: '1.0.0',
+      },
+    },
+  }
+
+  const { lockfile: deployLockfile, manifest } = createDeployFiles({
+    allProjects: [{
+      rootDirRealPath: lockfileDir as ProjectRootDirRealPath,
+      manifest: {
+        name: 'app',
+        version: '1.0.0',
+      },
+    }],
+    deployDir,
+    lockfile,
+    lockfileDir,
+    selectedProjectManifest: {
+      name: 'app',
+      version: '1.0.0',
+    },
+    projectId,
+    rootProjectManifestDir: lockfileDir,
+  })
+
+  expect(manifest.dependencies).toStrictEqual({
+    'tar-pkg': outputDepPath,
+  })
+  expect(deployLockfile.packages?.[outputDepPath]).toBeDefined()
+  expect(deployLockfile.packages?.[outputDepPathWithTarballFilename]).toBeUndefined()
+})

--- a/pnpm11/releasing/commands/test/deploy/shared-lockfile.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/shared-lockfile.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import url from 'node:url'
+import { createGzip } from 'node:zlib'
 
 import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
 import { assertProject } from '@pnpm/assert-project'
@@ -9,6 +10,7 @@ import { preparePackages } from '@pnpm/prepare'
 import { fixtures } from '@pnpm/test-fixtures'
 import type { ProjectManifest } from '@pnpm/types'
 import { filterProjectsBySelectorObjectsFromDir } from '@pnpm/workspace.projects-filter'
+import tar from 'tar-stream'
 import { writeYamlFile } from 'write-yaml-file'
 
 import { DEFAULT_OPTS } from './utils/index.js'
@@ -45,6 +47,21 @@ function readPackageJson (manifestDir: string): unknown {
   const manifestPath = path.resolve(manifestDir, 'package.json')
   const manifestText = fs.readFileSync(manifestPath, 'utf-8')
   return JSON.parse(manifestText)
+}
+
+async function writePackageTarball (tarballPath: string, manifest: ProjectManifest): Promise<void> {
+  const pack = tar.pack()
+  pack.entry({ name: 'package/package.json' }, JSON.stringify(manifest, undefined, 2))
+  pack.entry({ name: 'package/index.js' }, '')
+
+  const tarball = fs.createWriteStream(tarballPath)
+  pack.pipe(createGzip()).pipe(tarball)
+  pack.finalize()
+
+  return new Promise((resolve, reject) => {
+    tarball.on('close', resolve)
+    tarball.on('error', reject)
+  })
 }
 
 test('deploy with a shared lockfile after full install', async () => {
@@ -272,8 +289,6 @@ test('deploy with a shared lockfile after full install', async () => {
 })
 
 test('deploy with a shared lockfile reuses local tarball package name from the warm store (#12792)', async () => {
-  const tarballPath = path.resolve('vendor/tar-pkg-1.0.0.tgz')
-
   preparePackages([{
     location: '.',
     package: {
@@ -285,8 +300,12 @@ test('deploy with a shared lockfile reuses local tarball package name from the w
       },
     },
   }])
+  const tarballPath = path.resolve('vendor/tar-pkg-1.0.0.tgz')
   fs.mkdirSync('vendor')
-  f.copy('tar-pkg-1.0.0.tgz', tarballPath)
+  await writePackageTarball(tarballPath, {
+    name: 'tar-pkg',
+    version: '1.0.0',
+  })
 
   const {
     allProjects,

--- a/pnpm11/releasing/commands/test/deploy/shared-lockfile.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/shared-lockfile.test.ts
@@ -271,6 +271,62 @@ test('deploy with a shared lockfile after full install', async () => {
   }
 })
 
+test('deploy with a shared lockfile reuses local tarball package name from the warm store (#12792)', async () => {
+  const tarballPath = path.resolve('vendor/tar-pkg-1.0.0.tgz')
+
+  preparePackages([{
+    location: '.',
+    package: {
+      name: 'app',
+      version: '1.0.0',
+      private: true,
+      dependencies: {
+        'tar-pkg': 'file:vendor/tar-pkg-1.0.0.tgz',
+      },
+    },
+  }])
+  fs.mkdirSync('vendor')
+  f.copy('tar-pkg-1.0.0.tgz', tarballPath)
+
+  const {
+    allProjects,
+    allProjectsGraph,
+    selectedProjectsGraph,
+  } = await filterProjectsBySelectorObjectsFromDir(process.cwd(), [{ namePattern: 'app' }])
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    allProjects,
+    allProjectsGraph,
+    selectedProjectsGraph: allProjectsGraph,
+    dir: process.cwd(),
+    recursive: true,
+    lockfileDir: process.cwd(),
+    workspaceDir: process.cwd(),
+  })
+
+  const deployOpts = {
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    rootProjectManifest: allProjects[0].manifest,
+    rootProjectManifestDir: process.cwd(),
+    recursive: true,
+    selectedProjectsGraph,
+    sharedWorkspaceLockfile: true,
+    lockfileDir: process.cwd(),
+    workspaceDir: process.cwd(),
+  }
+  await deploy.handler(deployOpts, ['out1'])
+  await deploy.handler(deployOpts, ['out2'])
+
+  const project = assertProject(path.resolve('out2'))
+  project.has('tar-pkg')
+
+  const lockfilePackages = Object.keys(project.readLockfile().packages ?? {})
+  expect(lockfilePackages).toStrictEqual([expect.stringMatching(/^tar-pkg@file:/)])
+})
+
 test('the deploy manifest should inherit some fields from the pnpm object from the root manifest and the manifest of the selected project', async () => {
   const rootOverrides = {
     'is-positive': '2.0.0',


### PR DESCRIPTION
## Summary

- Keep the package name from the source lockfile when `pnpm deploy` rewrites local `file:` tarball dependencies.
- Add coverage for the deploy lockfile rewrite and the warm-store shared-lockfile deploy path.

## Why

Fixes pnpm/pnpm#12792. On the second deploy with a warm store, the generated deploy lockfile used the tarball filename as the package name, so the store content check expected `is-positive-3.1.0.tgz@3.1.0` while the stored package was `is-positive@3.1.0`.

## Validation

- `corepack pnpm --filter @pnpm/releasing.commands compile` — passed
- `NODE_OPTIONS="${NODE_OPTIONS:-} --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" corepack pnpm exec jest test/deploy/createDeployFiles.test.ts --config ../../__utils__/jest-config/jest-preset.js --rootDir /root/oss/pnpm/pnpm11/releasing/commands --runInBand` — passed
- `corepack pnpm --filter pnpm compile` — passed
- Branch-local two-deploy warm-store smoke test using `node pnpm11/pnpm/bin/pnpm.mjs` — passed
- `git push` pre-push hook — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm deploy` so local `file:`/tarball dependencies preserve the intended package name in generated manifests and deploy lockfiles, with consistent “file URL” dependency key naming (including alias/link cases).
  * Improved shared-workspace-lockfile deploy to avoid warm-store failures for local tarballs whose filenames include version numbers.
* **Tests**
  * Added coverage for deploy-time rewriting of local tarball dependency specifiers and key preservation.
  * Added coverage for shared lockfile deploy behavior with local tarball inputs.
* **Chores**
  * Updated patch-level release metadata for releaser tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Written by an agent (Codex, gpt-5.5).