### PR TITLE
fix: limit concurrent reads of unsaved dependencies

### DIFF
--- a/.changeset/limit-unsaved-dep-reads.md
+++ b/.changeset/limit-unsaved-dep-reads.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/deps.inspection.tree-builder": patch
+"pnpm": patch
+---
+
+`pnpm list` and `pnpm why` no longer crash with `EMFILE: too many open files` when a project has a large number of unsaved dependencies (packages present in `node_modules` but not in the lockfile). The reads of those packages are now concurrency-limited.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3585,6 +3585,9 @@ importers:
       normalize-path:
         specifier: 'catalog:'
         version: 3.0.0
+      p-limit:
+        specifier: 'catalog:'
+        version: 7.3.0
       path-absolute:
         specifier: 'catalog:'
         version: 2.0.0

--- a/pnpm11/deps/inspection/tree-builder/package.json
+++ b/pnpm11/deps/inspection/tree-builder/package.json
@@ -50,6 +50,7 @@
     "@pnpm/util.lex-comparator": "catalog:",
     "load-json-file": "catalog:",
     "normalize-path": "catalog:",
+    "p-limit": "catalog:",
     "path-absolute": "catalog:",
     "realpath-missing": "catalog:",
     "resolve-link-target": "catalog:",

--- a/pnpm11/deps/inspection/tree-builder/src/buildDependenciesTree.ts
+++ b/pnpm11/deps/inspection/tree-builder/src/buildDependenciesTree.ts
@@ -16,6 +16,7 @@ import { safeReadPackageJsonFromDir } from '@pnpm/pkg-manifest.reader'
 import { StoreIndex } from '@pnpm/store.index'
 import { DEPENDENCIES_FIELDS, type DependenciesField, type Finder, type Registries } from '@pnpm/types'
 import normalizePath from 'normalize-path'
+import pLimit from 'p-limit'
 import { pathAbsolute } from 'path-absolute'
 import { realpathMissing } from 'realpath-missing'
 import { resolveLinkTarget } from 'resolve-link-target'
@@ -24,6 +25,8 @@ import { buildDependencyGraph } from './buildDependencyGraph.js'
 import type { DependencyNode } from './DependencyNode.js'
 import { type BaseTreeOpts, getTree, type MaterializationCache } from './getTree.js'
 import type { TreeNodeId } from './TreeNodeId.js'
+
+const limitUnsavedReads = pLimit(4)
 
 export interface DependenciesTree {
   dependencies?: DependencyNode[]
@@ -207,7 +210,7 @@ async function dependenciesHierarchyForPackage (
     const savedDeps = getAllDirectDependencies(currentLockfile.importers[importerId])
     const unsavedDeps = ((await readModulesDir(modulesDir)) ?? []).filter((directDep) => !savedDeps[directDep])
     if (unsavedDeps.length > 0) await Promise.all(
-      unsavedDeps.map(async (unsavedDep) => {
+      unsavedDeps.map((unsavedDep) => limitUnsavedReads(async () => {
         let pkgPath = path.join(modulesDir, unsavedDep)
         let version!: string
         try {
@@ -229,7 +232,7 @@ async function dependenciesHierarchyForPackage (
         }
         result.unsavedDependencies = result.unsavedDependencies ?? []
         result.unsavedDependencies.push(pkg)
-      })
+      }))
     )
   }
 


### PR DESCRIPTION
## Summary

`pnpm list` (and `pnpm why`) can crash with `EMFILE: too many open files` on projects that have a large number of *unsaved* dependencies — packages present in `node_modules` but absent from the lockfile. `buildDependenciesTree` reads each of those packages with an unbounded `Promise.all(...)`, opening a filesystem handle for every package at once.

This bounds the concurrency of those reads with `p-limit`, mirroring how the sibling `@pnpm/deps.inspection.list` already limits its package reads (`readPkg.ts` uses `pLimit(4)`).

## Root cause

In `pnpm11/deps/inspection/tree-builder/src/buildDependenciesTree.ts`, every unsaved dependency is read concurrently:

```ts
if (unsavedDeps.length > 0) await Promise.all(
  unsavedDeps.map(async (unsavedDep) => {
    // resolveLinkTarget(...) / safeReadPackageJsonFromDir(...)
  })
)
```

With enough unsaved deps, the number of simultaneous open file handles exceeds the OS limit and the command throws `EMFILE`.

## The fix

Wrap the per-dependency read in a module-level `pLimit(4)` (`limitUnsavedReads`) so at most 4 packages are read at a time. This is the same approach the sibling `@pnpm/deps.inspection.list` already uses in `readPkg.ts` (`const limitPkgReads = pLimit(4)`).

`p-limit` is already in the workspace catalog and used elsewhere in the repo — no new external dependency is introduced.

## Testing

The change only bounds concurrency; the resulting dependency tree is unchanged, so it is behavior-neutral. `p-limit` resolves from the catalog and the `@pnpm/deps.inspection.tree-builder` build type-checks. No dedicated unit test is added, matching the sibling `readPkg.ts` limiter which is likewise untested (an EMFILE repro requires exhausting file descriptors, which isn't practical to assert deterministically).

close #12426


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes in `pnpm list` and `pnpm why` for projects with many unsaved dependencies.
  * Improved stability by concurrency-limiting reads involved in “unsaved dependencies” detection, preventing “EMFILE: too many open files” errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->