### PR TITLE
perf(npm-resolver): stop retaining raw registry bodies in the memoized fetch cache

### DIFF
--- a/.changeset/cold-resolution-memory.md
+++ b/.changeset/cold-resolution-memory.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Reduced peak memory usage during cold-cache dependency resolution. The metadata fetch is memoized for the whole resolution phase, and it was retaining each package's raw registry response body (used only to mirror the response to disk) for that entire time. The raw body is now released as soon as the disk mirror is written. On large graphs that fetch full metadata (e.g. with `minimumReleaseAge` or `trustPolicy` enabled) this cuts peak RSS by roughly 30%, back in line with pnpm 10. The resolved lockfile is unchanged.
+Reduced peak memory usage during cold-cache dependency resolution. The metadata fetch is memoized for the whole resolution phase, and it was retaining each package's raw registry response body (used only to mirror the response to disk) for that entire time. The memoized cache now holds a body-less copy, so the raw body only lives as long as the call that writes the disk mirror. On large graphs that fetch full metadata (e.g. with `minimumReleaseAge` or `trustPolicy` enabled) this cuts peak RSS by roughly 30%, back in line with pnpm 10. The resolved lockfile is unchanged.

--- a/.changeset/cold-resolution-memory.md
+++ b/.changeset/cold-resolution-memory.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"pnpm": patch
+---
+
+Reduced peak memory usage during cold-cache dependency resolution. The metadata fetch is memoized for the whole resolution phase, and it was retaining each package's raw registry response body (used only to mirror the response to disk) for that entire time. The raw body is now released as soon as the disk mirror is written. On large graphs that fetch full metadata (e.g. with `minimumReleaseAge` or `trustPolicy` enabled) this cuts peak RSS by roughly 30%, back in line with pnpm 10. The resolved lockfile is unchanged.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -809,9 +809,6 @@ catalogs:
     p-map-values:
       specifier: ^0.1.0
       version: 0.1.0
-    p-memoize:
-      specifier: 8.0.0
-      version: 8.0.0
     p-queue:
       specifier: ^9.3.0
       version: 9.3.0
@@ -8816,9 +8813,6 @@ importers:
       p-limit:
         specifier: 'catalog:'
         version: 7.3.0
-      p-memoize:
-        specifier: 'catalog:'
-        version: 8.0.0
       parse-npm-tarball-url:
         specifier: 'catalog:'
         version: 5.0.0
@@ -15745,10 +15739,6 @@ packages:
   p-memoize@4.0.1:
     resolution: {integrity: sha512-km0sP12uE0dOZ5qP+s7kGVf07QngxyG0gS8sYFvFWhqlgzOsSy+m71aUejf/0akxj5W7gE//2G74qTv6b4iMog==}
     engines: {node: '>=10'}
-
-  p-memoize@8.0.0:
-    resolution: {integrity: sha512-jdZ10MCxavHoIHwJ5oweOtYy6ElPixEHaMkz0AuaEMovR1MRpVvYFzIEHRxgMEpXYzNpRVByFAniAzwmd1/uug==}
-    engines: {node: '>=20'}
 
   p-queue@6.6.2:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
@@ -24014,11 +24004,6 @@ snapshots:
     dependencies:
       mem: 6.1.1
       mimic-fn: 3.1.0
-
-  p-memoize@8.0.0:
-    dependencies:
-      mimic-function: 5.0.1
-      type-fest: 4.41.0
 
   p-queue@6.6.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -263,7 +263,6 @@ catalog:
   p-filter: ^4.1.0
   p-limit: ^7.3.0
   p-map-values: ^0.1.0
-  p-memoize: 8.0.0
   p-queue: ^9.3.0
   parse-json: ^8.3.0
   parse-npm-tarball-url: ^5.0.0

--- a/pnpm11/resolving/npm-resolver/package.json
+++ b/pnpm11/resolving/npm-resolver/package.json
@@ -55,7 +55,6 @@
     "lru-cache": "catalog:",
     "normalize-path": "catalog:",
     "p-limit": "catalog:",
-    "p-memoize": "catalog:",
     "parse-npm-tarball-url": "catalog:",
     "path-temp": "catalog:",
     "ramda": "catalog:",

--- a/pnpm11/resolving/npm-resolver/src/fetch.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetch.ts
@@ -38,11 +38,12 @@ interface RegistryResponse {
 
 export interface FetchMetadataResult {
   meta: PackageMeta
-  // The raw registry response body, used only to mirror the response to disk
-  // without re-serializing `meta`. A fresh fetch always sets it, but the
-  // resolver drops it once the mirror is written so the memoized fetch cache
-  // does not pin these (potentially tens-of-MB) strings for the whole
-  // resolution phase (see pickPackage.ts).
+  /**
+   * The raw registry response body, used only to mirror the response to disk
+   * without re-serializing `meta`. A fresh fetch always sets it; consumers of
+   * the memoized fetch detach it as soon as they receive the result (see
+   * `takeJsonText` in pickPackage.ts) so the memo cache never pins it.
+   */
   jsonText: string | undefined
   etag?: string
   notModified?: false

--- a/pnpm11/resolving/npm-resolver/src/fetch.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetch.ts
@@ -40,9 +40,10 @@ export interface FetchMetadataResult {
   meta: PackageMeta
   /**
    * The raw registry response body, used only to mirror the response to disk
-   * without re-serializing `meta`. A fresh fetch always sets it; consumers of
-   * the memoized fetch detach it as soon as they receive the result (see
-   * `detachFetchResult` in pickPackage.ts) so the memo cache never pins it.
+   * without re-serializing `meta`. A fresh fetch always sets it, but it
+   * reaches only the caller that initiated the request: the phase-long memo
+   * cache holds a body-less clone (see memoizeFetchMetadata.ts), so cache
+   * hits see `undefined` and the cache never pins the body.
    */
   jsonText: string | undefined
   etag?: string

--- a/pnpm11/resolving/npm-resolver/src/fetch.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetch.ts
@@ -38,7 +38,12 @@ interface RegistryResponse {
 
 export interface FetchMetadataResult {
   meta: PackageMeta
-  jsonText: string
+  // The raw registry response body, used only to mirror the response to disk
+  // without re-serializing `meta`. A fresh fetch always sets it, but the
+  // resolver drops it once the mirror is written so the memoized fetch cache
+  // does not pin these (potentially tens-of-MB) strings for the whole
+  // resolution phase (see pickPackage.ts).
+  jsonText: string | undefined
   etag?: string
   notModified?: false
 }

--- a/pnpm11/resolving/npm-resolver/src/fetch.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetch.ts
@@ -42,7 +42,7 @@ export interface FetchMetadataResult {
    * The raw registry response body, used only to mirror the response to disk
    * without re-serializing `meta`. A fresh fetch always sets it; consumers of
    * the memoized fetch detach it as soon as they receive the result (see
-   * `takeJsonText` in pickPackage.ts) so the memo cache never pins it.
+   * `detachFetchResult` in pickPackage.ts) so the memo cache never pins it.
    */
   jsonText: string | undefined
   etag?: string

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -43,13 +43,13 @@ import {
 import { resolveWorkspaceRange } from '@pnpm/workspace.range-resolver'
 import { LRUCache } from 'lru-cache'
 import normalize from 'normalize-path'
-import pMemoize, { pMemoizeClear } from 'p-memoize'
 import { clone } from 'ramda'
 import semver from 'semver'
 import ssri from 'ssri'
 import versionSelectorType from 'version-selector-type'
 
 import { fetchMetadataFromFromRegistry, type FetchMetadataFromFromRegistryOptions, RegistryResponseError } from './fetch.js'
+import { memoizeFetchMetadata } from './memoizeFetchMetadata.js'
 import { normalizeRegistryUrl } from './normalizeRegistryUrl.js'
 import {
   BUILTIN_NAMED_REGISTRIES,
@@ -217,9 +217,7 @@ export function createNpmResolver (
     timeout: opts.timeout ?? 60000,
     fetchWarnTimeoutMs: opts.fetchWarnTimeoutMs ?? 10 * 1000, // 10 sec
   }
-  const fetch = pMemoize(fetchMetadataFromFromRegistry.bind(null, fetchOpts), {
-    cacheKey: (...args) => JSON.stringify(args),
-  })
+  const { fetch, clear: clearFetchCache } = memoizeFetchMetadata(fetchMetadataFromFromRegistry.bind(null, fetchOpts))
   // Track ownership so `clearCache()` below only wipes the in-memory
   // cache when this factory created it. A caller-supplied
   // `opts.metaCache` may be shared with another resolver instance (or
@@ -296,7 +294,7 @@ export function createNpmResolver (
       if (ownsMetaCache && 'clear' in metaCache && typeof metaCache.clear === 'function') {
         metaCache.clear()
       }
-      pMemoizeClear(fetch)
+      clearFetchCache()
     },
   }
 }

--- a/pnpm11/resolving/npm-resolver/src/memoizeFetchMetadata.ts
+++ b/pnpm11/resolving/npm-resolver/src/memoizeFetchMetadata.ts
@@ -1,0 +1,50 @@
+import type {
+  FetchMetadataNotModifiedResult,
+  FetchMetadataOptions,
+  FetchMetadataResult,
+} from './fetch.js'
+
+export type FetchMetadata = (pkgName: string, opts: FetchMetadataOptions) => Promise<FetchMetadataResult | FetchMetadataNotModifiedResult>
+
+export interface MemoizedFetchMetadata {
+  fetch: FetchMetadata
+  clear: () => void
+}
+
+/**
+ * Memoizes metadata fetches for the whole resolution phase (cleared via
+ * `clear`, see `clearResolutionCache`), deduplicating concurrent and repeat
+ * requests for the same package.
+ *
+ * Unlike a plain memoizer, the cache holds a body-less clone of each result:
+ * `jsonText` — the raw registry response body, up to tens of MB for a popular
+ * package — reaches only the caller that initiated the fetch, which is the
+ * caller that writes the disk mirror. A phase-long cache that kept the bodies
+ * would pin hundreds of MB on large cold-cache graphs. A cache-hit caller
+ * that also writes the mirror falls back to `JSON.stringify(meta)` in
+ * `prepareJsonForDisk`, which is equivalent on read: `loadMeta` re-derives
+ * `etag` from the headers line.
+ *
+ * A rejected fetch is evicted so a transient network failure is retried by
+ * the next request instead of being cached for the rest of the phase.
+ */
+export function memoizeFetchMetadata (fetch: FetchMetadata): MemoizedFetchMetadata {
+  const cache = new Map<string, ReturnType<FetchMetadata>>()
+  return {
+    fetch: (pkgName, opts) => {
+      const key = JSON.stringify([pkgName, opts])
+      const cached = cache.get(key)
+      if (cached != null) return cached
+      const pending = fetch(pkgName, opts)
+      const bodiless = pending.then((result) =>
+        result.notModified ? result : { ...result, jsonText: undefined }
+      )
+      bodiless.catch(() => cache.delete(key))
+      cache.set(key, bodiless)
+      return pending
+    },
+    clear: () => {
+      cache.clear()
+    },
+  }
+}

--- a/pnpm11/resolving/npm-resolver/src/memoizeFetchMetadata.ts
+++ b/pnpm11/resolving/npm-resolver/src/memoizeFetchMetadata.ts
@@ -16,7 +16,7 @@ export interface MemoizedFetchMetadata {
  * `clear`, see `clearResolutionCache`), deduplicating concurrent and repeat
  * requests for the same package.
  *
- * Unlike a plain memoizer, the cache holds a body-less clone of each result:
+ * Unlike plain memoization, the cache holds a body-less clone of each result:
  * `jsonText` — the raw registry response body, up to tens of MB for a popular
  * package — reaches only the caller that initiated the fetch, which is the
  * caller that writes the disk mirror. A phase-long cache that kept the bodies

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -499,12 +499,11 @@ export async function pickPackage (
       // The fetch is memoized (see index.ts), so its result is retained for the
       // whole resolution phase. jsonText — the raw registry body, up to tens of
       // MB for popular packages — is only needed for the disk-mirror write
-      // above, so release it here to keep the memo cache from pinning it. This
-      // mirrors the projection pnpm applies to the verifier caches in #11878.
+      // above, so release it here to keep the memo cache from pinning it.
       // A concurrent caller sharing this memo entry that reads jsonText after
       // this point just falls back to JSON.stringify(meta) in prepareJsonForDisk.
       resultToSave.jsonText = undefined
-      if (resultToSave !== fetchResult) fetchResult.jsonText = undefined
+      fetchResult.jsonText = undefined
       meta.etag = resultToSave.etag
       // only save meta to cache, when it is fresh
       ctx.metaCache.set(cacheKey, meta)

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -433,6 +433,7 @@ export async function pickPackage (
 
       let meta = fetchResult.meta
       let resultToSave: FetchMetadataResult = fetchResult
+      let jsonTextForDisk = takeJsonText(fetchResult)
 
       // When minimumReleaseAge is active and we fetched abbreviated metadata,
       // check if the package was recently modified and needs full metadata
@@ -458,7 +459,7 @@ export async function pickPackage (
         if (!isModifiedValid || modifiedDate > opts.publishedBy) {
           // Save the abbreviated metadata to the abbreviated cache before re-fetching full.
           if (!opts.dryRun) {
-            const abbreviatedJson = prepareJsonForDisk(fetchResult.meta, fetchResult.etag, fetchResult.jsonText)
+            const abbreviatedJson = prepareJsonForDisk(fetchResult.meta, fetchResult.etag, jsonTextForDisk)
             // Fire-and-forget save to the abbreviated cache path (pkgMirror).
             runLimited(pkgMirror, (limit) => limit(async () => {
               try {
@@ -475,6 +476,7 @@ export async function pickPackage (
           })
           if (!fullFetchResult.notModified) {
             resultToSave = fullFetchResult
+            jsonTextForDisk = takeJsonText(fullFetchResult)
             meta = fullFetchResult.meta
           }
         }
@@ -487,7 +489,7 @@ export async function pickPackage (
         // Serialize before setting meta.etag so it only lives in the headers line, not the body.
         const jsonForDisk = ctx.filterMetadata
           ? prepareJsonForDisk(meta, resultToSave.etag)
-          : prepareJsonForDisk(resultToSave.meta, resultToSave.etag, resultToSave.jsonText)
+          : prepareJsonForDisk(resultToSave.meta, resultToSave.etag, jsonTextForDisk)
         runLimited(pkgMirror, (limit) => limit(async () => {
           try {
             await saveMeta(pkgMirror, jsonForDisk)
@@ -496,14 +498,6 @@ export async function pickPackage (
           }
         }))
       }
-      // The fetch is memoized (see index.ts), so its result is retained for the
-      // whole resolution phase. jsonText — the raw registry body, up to tens of
-      // MB for popular packages — is only needed for the disk-mirror write
-      // above, so release it here to keep the memo cache from pinning it.
-      // A concurrent caller sharing this memo entry that reads jsonText after
-      // this point just falls back to JSON.stringify(meta) in prepareJsonForDisk.
-      resultToSave.jsonText = undefined
-      fetchResult.jsonText = undefined
       meta.etag = resultToSave.etag
       // only save meta to cache, when it is fresh
       ctx.metaCache.set(cacheKey, meta)
@@ -534,7 +528,8 @@ export async function pickPackage (
 // silently bypassing the minimumReleaseAge guarantee for affected packages.
 //
 // Returns the original meta when no upgrade is needed. When an upgrade
-// happens, returns both the upgraded meta and the underlying fetch result
+// happens, returns both the upgraded meta and a snapshot of the fetch (with
+// the raw body already detached from the memoized result — see takeJsonText)
 // so callers can persist it to disk and avoid re-fetching on next install.
 async function maybeUpgradeAbbreviatedMetaForReleaseAge (
   ctx: {
@@ -549,7 +544,7 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
     registry: string
   },
   meta: PackageMeta
-): Promise<{ meta: PackageMeta, upgradedFrom?: FetchMetadataResult }> {
+): Promise<{ meta: PackageMeta, upgradedFrom?: UpgradedMetaFetch }> {
   if (
     ctx.offline === true ||
     !opts.publishedBy ||
@@ -586,7 +581,41 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
     // `pickMatchingVersionFinal` will fall through to its warn-and-skip path.
     return { meta }
   }
-  return { meta: fullFetchResult.meta, upgradedFrom: fullFetchResult }
+  return {
+    meta: fullFetchResult.meta,
+    upgradedFrom: {
+      meta: fullFetchResult.meta,
+      etag: fullFetchResult.etag,
+      jsonText: takeJsonText(fullFetchResult),
+    },
+  }
+}
+
+/**
+ * What {@link persistUpgradedMeta} needs from an upgrade fetch, detached from
+ * the memoized fetch result so it dies with the resolving call — even on the
+ * dryRun paths that never persist.
+ */
+interface UpgradedMetaFetch {
+  meta: PackageMeta
+  etag?: string
+  jsonText?: string
+}
+
+/**
+ * Detach the raw response body from a fetch result. The fetch is memoized for
+ * the whole resolution phase (see the resolver factory in index.ts), so a body
+ * left on the result — up to tens of MB for a popular package — would stay
+ * resident until resolution ends. Taking it at acquisition bounds its lifetime
+ * to the call that writes the disk mirror. A concurrent caller sharing the
+ * memoized result loses the race for the body and falls back to
+ * `JSON.stringify(meta)` in {@link prepareJsonForDisk}, which is equivalent on
+ * read: `loadMeta` re-derives `etag` from the headers line.
+ */
+function takeJsonText (result: FetchMetadataResult): string | undefined {
+  const { jsonText } = result
+  result.jsonText = undefined
+  return jsonText
 }
 
 // Persists upgraded full metadata to the on-disk cache mirror and returns
@@ -596,7 +625,7 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
 function persistUpgradedMeta (
   ctx: { filterMetadata?: boolean },
   pkgMirror: string,
-  upgradedFrom: FetchMetadataResult
+  upgradedFrom: UpgradedMetaFetch
 ): PackageMeta {
   const metaForCache = ctx.filterMetadata ? clearMeta(upgradedFrom.meta) : upgradedFrom.meta
   const jsonForDisk = ctx.filterMetadata
@@ -609,10 +638,6 @@ function persistUpgradedMeta (
       // We don't care if this file was not written to the cache
     }
   }))
-  // Release the raw body now that the mirror is written; `upgradedFrom` came
-  // from the memoized fetch and would otherwise keep jsonText resident for the
-  // whole resolution phase (see the main path in pickPackage).
-  upgradedFrom.jsonText = undefined
   return metaForCache
 }
 

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -431,8 +431,8 @@ export async function pickPackage (
           `Metadata cache for ${spec.name} is unreadable after receiving 304 Not Modified`)
       }
 
-      let resultToSave = detachFetchResult(fetchResult)
-      let meta = resultToSave.meta
+      let meta = fetchResult.meta
+      let resultToSave: FetchMetadataResult = fetchResult
 
       // When minimumReleaseAge is active and we fetched abbreviated metadata,
       // check if the package was recently modified and needs full metadata
@@ -474,8 +474,8 @@ export async function pickPackage (
             registry: opts.registry,
           })
           if (!fullFetchResult.notModified) {
-            resultToSave = detachFetchResult(fullFetchResult)
-            meta = resultToSave.meta
+            resultToSave = fullFetchResult
+            meta = fullFetchResult.meta
           }
         }
       }
@@ -526,9 +526,8 @@ export async function pickPackage (
 // silently bypassing the minimumReleaseAge guarantee for affected packages.
 //
 // Returns the original meta when no upgrade is needed. When an upgrade
-// happens, returns both the upgraded meta and a detached snapshot of the
-// fetch (see detachFetchResult) so callers can persist it to disk and avoid
-// re-fetching on next install.
+// happens, returns both the upgraded meta and the underlying fetch result
+// so callers can persist it to disk and avoid re-fetching on next install.
 async function maybeUpgradeAbbreviatedMetaForReleaseAge (
   ctx: {
     fetch: (pkgName: string, opts: { registry: string, authHeaderValue?: string, fullMetadata?: boolean, etag?: string, modified?: string }) => Promise<FetchMetadataResult | FetchMetadataNotModifiedResult>
@@ -542,7 +541,7 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
     registry: string
   },
   meta: PackageMeta
-): Promise<{ meta: PackageMeta, upgradedFrom?: DetachedFetchResult }> {
+): Promise<{ meta: PackageMeta, upgradedFrom?: FetchMetadataResult }> {
   if (
     ctx.offline === true ||
     !opts.publishedBy ||
@@ -579,38 +578,7 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
     // `pickMatchingVersionFinal` will fall through to its warn-and-skip path.
     return { meta }
   }
-  return {
-    meta: fullFetchResult.meta,
-    upgradedFrom: detachFetchResult(fullFetchResult),
-  }
-}
-
-/**
- * Everything a disk-mirror write needs from a fetch, detached from the
- * memoized fetch result so it dies with the resolving call — even on the
- * dryRun paths that never persist. See {@link detachFetchResult}.
- */
-interface DetachedFetchResult {
-  meta: PackageMeta
-  etag?: string
-  jsonText?: string
-}
-
-/**
- * Snapshot a fetch result and strip the raw response body off the original.
- * The fetch is memoized for the whole resolution phase (see the resolver
- * factory in index.ts), so a body left on the result — up to tens of MB for a
- * popular package — would stay resident until resolution ends. Detaching at
- * acquisition bounds the body's lifetime to the call that writes the disk
- * mirror. A concurrent caller sharing the memoized result loses the race for
- * the body and falls back to `JSON.stringify(meta)` in
- * {@link prepareJsonForDisk}, which is equivalent on read: `loadMeta`
- * re-derives `etag` from the headers line.
- */
-function detachFetchResult (result: FetchMetadataResult): DetachedFetchResult {
-  const { meta, etag, jsonText } = result
-  result.jsonText = undefined
-  return { meta, etag, jsonText }
+  return { meta: fullFetchResult.meta, upgradedFrom: fullFetchResult }
 }
 
 // Persists upgraded full metadata to the on-disk cache mirror and returns
@@ -620,7 +588,7 @@ function detachFetchResult (result: FetchMetadataResult): DetachedFetchResult {
 function persistUpgradedMeta (
   ctx: { filterMetadata?: boolean },
   pkgMirror: string,
-  upgradedFrom: DetachedFetchResult
+  upgradedFrom: FetchMetadataResult
 ): PackageMeta {
   const metaForCache = ctx.filterMetadata ? clearMeta(upgradedFrom.meta) : upgradedFrom.meta
   const jsonForDisk = ctx.filterMetadata

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -431,9 +431,8 @@ export async function pickPackage (
           `Metadata cache for ${spec.name} is unreadable after receiving 304 Not Modified`)
       }
 
-      let meta = fetchResult.meta
-      let resultToSave: FetchMetadataResult = fetchResult
-      let jsonTextForDisk = takeJsonText(fetchResult)
+      let resultToSave = detachFetchResult(fetchResult)
+      let meta = resultToSave.meta
 
       // When minimumReleaseAge is active and we fetched abbreviated metadata,
       // check if the package was recently modified and needs full metadata
@@ -459,7 +458,7 @@ export async function pickPackage (
         if (!isModifiedValid || modifiedDate > opts.publishedBy) {
           // Save the abbreviated metadata to the abbreviated cache before re-fetching full.
           if (!opts.dryRun) {
-            const abbreviatedJson = prepareJsonForDisk(fetchResult.meta, fetchResult.etag, jsonTextForDisk)
+            const abbreviatedJson = prepareJsonForDisk(resultToSave.meta, resultToSave.etag, resultToSave.jsonText)
             // Fire-and-forget save to the abbreviated cache path (pkgMirror).
             runLimited(pkgMirror, (limit) => limit(async () => {
               try {
@@ -475,9 +474,8 @@ export async function pickPackage (
             registry: opts.registry,
           })
           if (!fullFetchResult.notModified) {
-            resultToSave = fullFetchResult
-            jsonTextForDisk = takeJsonText(fullFetchResult)
-            meta = fullFetchResult.meta
+            resultToSave = detachFetchResult(fullFetchResult)
+            meta = resultToSave.meta
           }
         }
       }
@@ -489,7 +487,7 @@ export async function pickPackage (
         // Serialize before setting meta.etag so it only lives in the headers line, not the body.
         const jsonForDisk = ctx.filterMetadata
           ? prepareJsonForDisk(meta, resultToSave.etag)
-          : prepareJsonForDisk(resultToSave.meta, resultToSave.etag, jsonTextForDisk)
+          : prepareJsonForDisk(resultToSave.meta, resultToSave.etag, resultToSave.jsonText)
         runLimited(pkgMirror, (limit) => limit(async () => {
           try {
             await saveMeta(pkgMirror, jsonForDisk)
@@ -528,9 +526,9 @@ export async function pickPackage (
 // silently bypassing the minimumReleaseAge guarantee for affected packages.
 //
 // Returns the original meta when no upgrade is needed. When an upgrade
-// happens, returns both the upgraded meta and a snapshot of the fetch (with
-// the raw body already detached from the memoized result — see takeJsonText)
-// so callers can persist it to disk and avoid re-fetching on next install.
+// happens, returns both the upgraded meta and a detached snapshot of the
+// fetch (see detachFetchResult) so callers can persist it to disk and avoid
+// re-fetching on next install.
 async function maybeUpgradeAbbreviatedMetaForReleaseAge (
   ctx: {
     fetch: (pkgName: string, opts: { registry: string, authHeaderValue?: string, fullMetadata?: boolean, etag?: string, modified?: string }) => Promise<FetchMetadataResult | FetchMetadataNotModifiedResult>
@@ -544,7 +542,7 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
     registry: string
   },
   meta: PackageMeta
-): Promise<{ meta: PackageMeta, upgradedFrom?: UpgradedMetaFetch }> {
+): Promise<{ meta: PackageMeta, upgradedFrom?: DetachedFetchResult }> {
   if (
     ctx.offline === true ||
     !opts.publishedBy ||
@@ -583,39 +581,36 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
   }
   return {
     meta: fullFetchResult.meta,
-    upgradedFrom: {
-      meta: fullFetchResult.meta,
-      etag: fullFetchResult.etag,
-      jsonText: takeJsonText(fullFetchResult),
-    },
+    upgradedFrom: detachFetchResult(fullFetchResult),
   }
 }
 
 /**
- * What {@link persistUpgradedMeta} needs from an upgrade fetch, detached from
- * the memoized fetch result so it dies with the resolving call — even on the
- * dryRun paths that never persist.
+ * Everything a disk-mirror write needs from a fetch, detached from the
+ * memoized fetch result so it dies with the resolving call — even on the
+ * dryRun paths that never persist. See {@link detachFetchResult}.
  */
-interface UpgradedMetaFetch {
+interface DetachedFetchResult {
   meta: PackageMeta
   etag?: string
   jsonText?: string
 }
 
 /**
- * Detach the raw response body from a fetch result. The fetch is memoized for
- * the whole resolution phase (see the resolver factory in index.ts), so a body
- * left on the result — up to tens of MB for a popular package — would stay
- * resident until resolution ends. Taking it at acquisition bounds its lifetime
- * to the call that writes the disk mirror. A concurrent caller sharing the
- * memoized result loses the race for the body and falls back to
- * `JSON.stringify(meta)` in {@link prepareJsonForDisk}, which is equivalent on
- * read: `loadMeta` re-derives `etag` from the headers line.
+ * Snapshot a fetch result and strip the raw response body off the original.
+ * The fetch is memoized for the whole resolution phase (see the resolver
+ * factory in index.ts), so a body left on the result — up to tens of MB for a
+ * popular package — would stay resident until resolution ends. Detaching at
+ * acquisition bounds the body's lifetime to the call that writes the disk
+ * mirror. A concurrent caller sharing the memoized result loses the race for
+ * the body and falls back to `JSON.stringify(meta)` in
+ * {@link prepareJsonForDisk}, which is equivalent on read: `loadMeta`
+ * re-derives `etag` from the headers line.
  */
-function takeJsonText (result: FetchMetadataResult): string | undefined {
-  const { jsonText } = result
+function detachFetchResult (result: FetchMetadataResult): DetachedFetchResult {
+  const { meta, etag, jsonText } = result
   result.jsonText = undefined
-  return jsonText
+  return { meta, etag, jsonText }
 }
 
 // Persists upgraded full metadata to the on-disk cache mirror and returns
@@ -625,7 +620,7 @@ function takeJsonText (result: FetchMetadataResult): string | undefined {
 function persistUpgradedMeta (
   ctx: { filterMetadata?: boolean },
   pkgMirror: string,
-  upgradedFrom: UpgradedMetaFetch
+  upgradedFrom: DetachedFetchResult
 ): PackageMeta {
   const metaForCache = ctx.filterMetadata ? clearMeta(upgradedFrom.meta) : upgradedFrom.meta
   const jsonForDisk = ctx.filterMetadata

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -496,6 +496,15 @@ export async function pickPackage (
           }
         }))
       }
+      // The fetch is memoized (see index.ts), so its result is retained for the
+      // whole resolution phase. jsonText — the raw registry body, up to tens of
+      // MB for popular packages — is only needed for the disk-mirror write
+      // above, so release it here to keep the memo cache from pinning it. This
+      // mirrors the projection pnpm applies to the verifier caches in #11878.
+      // A concurrent caller sharing this memo entry that reads jsonText after
+      // this point just falls back to JSON.stringify(meta) in prepareJsonForDisk.
+      resultToSave.jsonText = undefined
+      if (resultToSave !== fetchResult) fetchResult.jsonText = undefined
       meta.etag = resultToSave.etag
       // only save meta to cache, when it is fresh
       ctx.metaCache.set(cacheKey, meta)
@@ -601,6 +610,10 @@ function persistUpgradedMeta (
       // We don't care if this file was not written to the cache
     }
   }))
+  // Release the raw body now that the mirror is written; `upgradedFrom` came
+  // from the memoized fetch and would otherwise keep jsonText resident for the
+  // whole resolution phase (see the main path in pickPackage).
+  upgradedFrom.jsonText = undefined
   return metaForCache
 }
 

--- a/pnpm11/resolving/npm-resolver/test/memoizeFetchMetadata.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/memoizeFetchMetadata.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from '@jest/globals'
+import type { PackageMeta } from '@pnpm/resolving.registry.types'
+
+import type { FetchMetadataResult } from '../src/fetch.js'
+import { memoizeFetchMetadata } from '../src/memoizeFetchMetadata.js'
+
+const REGISTRY = 'https://registry.npmjs.org/'
+
+function fooFetchResult (): FetchMetadataResult {
+  return {
+    meta: { name: 'foo' } as PackageMeta,
+    jsonText: '{"name":"foo"}',
+    etag: '"abc"',
+  }
+}
+
+test('the initiating caller receives the raw body; cache hits get a body-less clone sharing the same meta', async () => {
+  const result = fooFetchResult()
+  let calls = 0
+  const { fetch } = memoizeFetchMetadata(async () => {
+    calls++
+    return result
+  })
+
+  const first = await fetch('foo', { registry: REGISTRY })
+  expect(first).toBe(result)
+  if (first.notModified) throw new Error('expected a fresh fetch result')
+  expect(first.jsonText).toBe('{"name":"foo"}')
+
+  const second = await fetch('foo', { registry: REGISTRY })
+  expect(calls).toBe(1)
+  if (second.notModified) throw new Error('expected a cached fetch result')
+  expect(second.jsonText).toBeUndefined()
+  expect(second.meta).toBe(result.meta)
+  expect(second.etag).toBe(result.etag)
+  // The clone keeps the original intact for the initiating caller.
+  expect(result.jsonText).toBe('{"name":"foo"}')
+})
+
+test('a caller arriving while the fetch is in flight gets the body-less clone', async () => {
+  let release!: (result: FetchMetadataResult) => void
+  const { fetch } = memoizeFetchMetadata(async () => new Promise<FetchMetadataResult>((resolve) => {
+    release = resolve
+  }))
+
+  const firstPromise = fetch('foo', { registry: REGISTRY })
+  const secondPromise = fetch('foo', { registry: REGISTRY })
+  release(fooFetchResult())
+
+  const [first, second] = await Promise.all([firstPromise, secondPromise])
+  if (first.notModified || second.notModified) throw new Error('expected fresh fetch results')
+  expect(first.jsonText).toBe('{"name":"foo"}')
+  expect(second.jsonText).toBeUndefined()
+})
+
+test('requests with different options are cached separately', async () => {
+  const fetchedOpts: boolean[] = []
+  const { fetch } = memoizeFetchMetadata(async (pkgName, opts) => {
+    fetchedOpts.push(opts.fullMetadata === true)
+    return fooFetchResult()
+  })
+
+  await fetch('foo', { registry: REGISTRY })
+  await fetch('foo', { registry: REGISTRY, fullMetadata: true })
+  await fetch('foo', { registry: REGISTRY })
+  expect(fetchedOpts).toEqual([false, true])
+})
+
+test('a rejected fetch is evicted so the next request retries', async () => {
+  let calls = 0
+  const { fetch } = memoizeFetchMetadata(async () => {
+    calls++
+    if (calls === 1) throw new Error('network down')
+    return fooFetchResult()
+  })
+
+  await expect(fetch('foo', { registry: REGISTRY })).rejects.toThrow('network down')
+  const retried = await fetch('foo', { registry: REGISTRY })
+  if (retried.notModified) throw new Error('expected a fresh fetch result')
+  expect(retried.meta.name).toBe('foo')
+  expect(calls).toBe(2)
+})
+
+test('clear() empties the cache', async () => {
+  let calls = 0
+  const { fetch, clear } = memoizeFetchMetadata(async () => {
+    calls++
+    return fooFetchResult()
+  })
+
+  await fetch('foo', { registry: REGISTRY })
+  clear()
+  await fetch('foo', { registry: REGISTRY })
+  expect(calls).toBe(2)
+})
+
+test('notModified results pass through unchanged', async () => {
+  const { fetch } = memoizeFetchMetadata(async () => ({ notModified: true as const }))
+
+  const first = await fetch('foo', { registry: REGISTRY })
+  const second = await fetch('foo', { registry: REGISTRY })
+  expect(first.notModified).toBe(true)
+  expect(second).toBe(first)
+})

--- a/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
@@ -1,4 +1,5 @@
 import { rmSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 
 import { expect, test } from '@jest/globals'
 import { ABBREVIATED_META_DIR } from '@pnpm/constants'
@@ -16,6 +17,16 @@ import {
 } from '../src/pickPackage.js'
 
 const REGISTRY = 'https://registry.npmjs.org/'
+
+async function readMirrorWithRetry (pkgMirror: string, attempts: number): Promise<string | undefined> {
+  try {
+    return await readFile(pkgMirror, 'utf8')
+  } catch {
+    if (attempts <= 0) return undefined
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    return readMirrorWithRetry(pkgMirror, attempts - 1)
+  }
+}
 
 function fooMeta (): PackageMeta {
   return {
@@ -152,6 +163,40 @@ test('prefer-offline resolution promotes the disk-loaded packument into the in-m
   rmSync(pkgMirror)
   const second = await pickPackage(ctx, spec, opts)
   expect(second.pickedPackage?.version).toBe('1.0.0')
+})
+
+test('the raw response body is written to the disk mirror and then released from the fetch result', async () => {
+  const meta = fooMeta()
+  // A body distinct from the compact JSON.stringify(meta) so we can prove the
+  // mirror is written from the raw response text, not re-serialized.
+  const rawBody = JSON.stringify(meta, null, 2)
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, REGISTRY, 'foo')
+
+  let fetchResult: { meta: PackageMeta, jsonText: string | undefined, etag: string | undefined } | undefined
+  const ctx = {
+    fetch: async () => {
+      fetchResult = { meta, jsonText: rawBody, etag: undefined }
+      return fetchResult
+    },
+    metaCache: createMetaCache(),
+    cacheDir,
+  }
+  // A range spec avoids the exact-version fast path and, with no on-disk mirror,
+  // forces the network-fetch branch that writes the mirror and caches the meta.
+  const spec: RegistryPackageSpec = { type: 'range', name: 'foo', fetchSpec: '^1.0.0' }
+
+  const res = await pickPackage(ctx, spec, { registry: REGISTRY, dryRun: false, preferredVersionSelectors: undefined })
+  expect(res.pickedPackage?.version).toBe('1.0.0')
+
+  // The mirror is written fire-and-forget, so retry until it appears.
+  const mirror = await readMirrorWithRetry(pkgMirror, 100)
+  // The body after the headers line is the raw response text, unchanged.
+  expect(mirror?.slice(mirror.indexOf('\n') + 1)).toBe(rawBody)
+
+  // Once the mirror is written, the raw body must be released so the memoized
+  // fetch result stops pinning it for the rest of the resolution phase.
+  expect(fetchResult?.jsonText).toBeUndefined()
 })
 
 test('a disk-promoted cache entry that cannot satisfy the spec falls back to the registry under prefer-offline', async () => {

--- a/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
@@ -165,7 +165,7 @@ test('prefer-offline resolution promotes the disk-loaded packument into the in-m
   expect(second.pickedPackage?.version).toBe('1.0.0')
 })
 
-test('the raw response body is detached from the fetch result and still written verbatim to the disk mirror', async () => {
+test('the raw response body is written verbatim to the disk mirror', async () => {
   const meta = fooMeta()
   // A body distinct from the compact JSON.stringify(meta) so we can prove the
   // mirror is written from the raw response text, not re-serialized.
@@ -173,12 +173,8 @@ test('the raw response body is detached from the fetch result and still written 
   const cacheDir = temporaryDirectory()
   const pkgMirror = getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, REGISTRY, 'foo')
 
-  let fetchResult: { meta: PackageMeta, jsonText: string | undefined, etag: string | undefined } | undefined
   const ctx = {
-    fetch: async () => {
-      fetchResult = { meta, jsonText: rawBody, etag: undefined }
-      return fetchResult
-    },
+    fetch: async () => ({ meta, jsonText: rawBody, etag: undefined }),
     metaCache: createMetaCache(),
     cacheDir,
   }
@@ -188,10 +184,6 @@ test('the raw response body is detached from the fetch result and still written 
 
   const res = await pickPackage(ctx, spec, { registry: REGISTRY, dryRun: false, preferredVersionSelectors: undefined })
   expect(res.pickedPackage?.version).toBe('1.0.0')
-
-  // The raw body is detached from the (memoized) fetch result before
-  // pickPackage returns, so it can't stay pinned for the resolution phase.
-  expect(fetchResult?.jsonText).toBeUndefined()
 
   // The mirror is written fire-and-forget, so retry until it appears.
   const mirror = await readMirrorWithRetry(pkgMirror, 100)

--- a/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
@@ -165,7 +165,7 @@ test('prefer-offline resolution promotes the disk-loaded packument into the in-m
   expect(second.pickedPackage?.version).toBe('1.0.0')
 })
 
-test('the raw response body is written to the disk mirror and then released from the fetch result', async () => {
+test('the raw response body is detached from the fetch result and still written verbatim to the disk mirror', async () => {
   const meta = fooMeta()
   // A body distinct from the compact JSON.stringify(meta) so we can prove the
   // mirror is written from the raw response text, not re-serialized.
@@ -189,14 +189,14 @@ test('the raw response body is written to the disk mirror and then released from
   const res = await pickPackage(ctx, spec, { registry: REGISTRY, dryRun: false, preferredVersionSelectors: undefined })
   expect(res.pickedPackage?.version).toBe('1.0.0')
 
+  // The raw body is detached from the (memoized) fetch result before
+  // pickPackage returns, so it can't stay pinned for the resolution phase.
+  expect(fetchResult?.jsonText).toBeUndefined()
+
   // The mirror is written fire-and-forget, so retry until it appears.
   const mirror = await readMirrorWithRetry(pkgMirror, 100)
   // The body after the headers line is the raw response text, unchanged.
   expect(mirror?.slice(mirror.indexOf('\n') + 1)).toBe(rawBody)
-
-  // Once the mirror is written, the raw body must be released so the memoized
-  // fetch result stops pinning it for the rest of the resolution phase.
-  expect(fetchResult?.jsonText).toBeUndefined()
 })
 
 test('a disk-promoted cache entry that cannot satisfy the spec falls back to the registry under prefer-offline', async () => {


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#12868.

The npm-resolver memoizes its metadata fetch for the whole resolution phase (`pMemoize` in `resolving/npm-resolver/src/index.ts`, cleared once by `clearResolutionCache()` after resolution finishes). Each memoized `FetchMetadataResult` carries `jsonText`, the raw registry response body, which exists only so the on-disk metadata mirror can be written verbatim without re-serializing `meta`. Because the memo cache is unbounded and lives for the entire phase, every raw body stays resident until the phase ends. On large cold-cache graphs that fetch full metadata (for example with `minimumReleaseAge` or `trustPolicy` enabled) these bodies add up to hundreds of MB, which is enough to OOM-kill a 3 GB CI runner such as Mend-hosted Renovate. This is the v10 to v11 regression reported in pnpm/pnpm#12868: v10 never kept the raw text on the memoized result.

This PR enforces the invariant at the cache boundary: the memoized fetch (`memoizeFetchMetadata`, replacing `p-memoize`, which has no hook between compute and store) caches a body-less shallow clone of each result, so `jsonText` reaches only the caller that initiated the fetch — the one that writes the disk mirror — and dies with that call. The cache is structurally incapable of pinning a body, no matter who consumes the fetch, including the abbreviated-to-full upgrade path and dry-run paths that never persist. The in-memory `metaCache` only ever holds the parsed `meta`.

As measured in pnpm/pnpm#12868 on the reproduction graph (1,771 packages, full-policy, cold cache):

| build | peak RSS | Δ | lockfile |
|---|---|---|---|
| 11.10.0 stock | 2,438 MB | — | baseline |
| this PR | 1,704 MB | −733 MB (−30%) | byte-identical |

1,704 MB is back at the v10 level (1,634–1,670 MB). The approach follows the projection pnpm already applies to the verifier caches in pnpm/pnpm#11878.

### Safety

- The initiating caller's result is untouched (the cache stores a clone, not a mutation), so every reader of the body within that call provably sees it. `prepareJsonForDisk` builds the output string synchronously, so the fire-and-forget `saveMeta` holds the finished string, not the `jsonText` reference.
- Cache-hit callers deterministically see `jsonText: undefined` (they share the same `meta` object, only the body is absent). A hit caller that writes the mirror falls back to `JSON.stringify(meta)` in `prepareJsonForDisk`, which is functionally equivalent: `loadMeta` always overwrites `meta.etag` from the headers line on read, and the body re-parses to an equivalent `meta`. The resolved lockfile is byte-identical either way.
- `memoizeFetchMetadata` preserves the p-memoize semantics resolution relies on: concurrent in-flight requests are deduplicated, rejected fetches are evicted so transient network failures retry, and `clearCache()` empties the map.

### Parity

pacquet has no equivalent code path (its fetch result does not retain a raw response body; its mirror is an indexed byte-span format), so there is nothing to port. This is a TypeScript-only memory optimization with no user-visible behavior change.

### Follow-up (out of scope here)

The resolver's `metaCache` is a count-based `LRUCache` (`max: 10000, ttl: 120s`) that never evicts at install scale, already reported in pnpm/pnpm#8864. Switching it to a byte-size-based LRU (`maxSize` / `sizeCalculation`) is a smaller, separate win and is left out to keep this PR focused.

## Squash Commit Body

```text
The npm-resolver memoizes its metadata fetch for the whole resolution phase
and clears it only once, via clearResolutionCache(), after resolution ends.
Each memoized FetchMetadataResult carried jsonText, the raw registry response
body kept only to mirror the response to disk without re-serializing meta.
With an unbounded memo cache living for the entire phase, every raw body
stayed resident until the end. On large cold-cache graphs that fetch full
metadata (minimumReleaseAge / trustPolicy) these bodies reached hundreds of
MB and OOM-killed 3GB CI runners. v10 did not keep the raw text on the
memoized result, so this was a v10-to-v11 regression.

Enforce the invariant at the cache boundary: the memoized fetch
(memoizeFetchMetadata, replacing p-memoize, which has no hook between compute
and store) caches a body-less shallow clone of each result, so jsonText
reaches only the caller that initiated the fetch — the one that writes the
disk mirror — and dies with that call. The cache is structurally incapable of
pinning a body regardless of who consumes the fetch. Peak RSS drops by ~30%
(back to the v10 level) with a byte-identical lockfile. Cache-hit callers see
jsonText undefined and fall back to JSON.stringify(meta) in
prepareJsonForDisk, which is functionally equivalent because loadMeta
re-derives etag from the headers line on read. The replacement preserves
p-memoize's semantics: in-flight dedup, eviction of rejections, and cache
clearing. Follows the projection applied to the verifier caches in
pnpm/pnpm#11878.

Closes pnpm/pnpm#12868.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  (pacquet has no raw-body retention on its fetch result — nothing to port; see Parity.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
