### PR TITLE
fix(pacquet): reject lockfile names that escape node_modules (GHSA-2rx9-3g3h-c2jv)

### DIFF
--- a/pacquet/crates/lockfile-verification/src/lib.rs
+++ b/pacquet/crates/lockfile-verification/src/lib.rs
@@ -11,6 +11,7 @@
 //! JSONL stat-and-skip cache.
 //!
 //! Public surface today: [`verify_lockfile_resolutions()`],
+//! [`verify_lockfile_dependency_names()`],
 //! [`collect_resolution_policy_violations()`], [`hash_lockfile()`],
 //! [`VerifyError`], and [`RenderedViolation`] — the last lets a caller
 //! that resolved violations out-of-process (e.g. the pnpr client
@@ -35,5 +36,6 @@ pub use hash_lockfile::hash_lockfile;
 pub use record_lockfile_verified::record_lockfile_verified;
 pub use verify_lockfile_resolutions::{
     RESOLUTION_SHAPE_MISMATCH_VIOLATION_CODE, VerifyLockfileResolutionsOptions,
-    collect_resolution_policy_violations, verify_lockfile_resolutions,
+    collect_resolution_policy_violations, verify_lockfile_dependency_names,
+    verify_lockfile_resolutions,
 };

--- a/pacquet/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
+++ b/pacquet/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
@@ -67,6 +67,12 @@ pub async fn verify_lockfile_resolutions<Reporter: self::Reporter>(
     verifiers: &[Arc<dyn ResolutionVerifier>],
     opts: &VerifyLockfileResolutionsOptions<'_>,
 ) -> Result<(), VerifyError> {
+    // Offline structural gate first: reject invalid dependency names
+    // before the `packages`-absent short-circuit and the cache lookup,
+    // so a lockfile that carries a path-traversal alias but no
+    // `packages:` section (e.g. only `link:` deps) is still rejected.
+    verify_lockfile_dependency_names(lockfile)?;
+
     if lockfile.packages.is_none() {
         return Ok(());
     }
@@ -123,10 +129,7 @@ pub async fn verify_lockfile_resolutions<Reporter: self::Reporter>(
         cache_precomputed = result.precomputed;
     }
 
-    let (candidates, shape_violations, invalid_aliases) = collect_candidates(lockfile);
-    if !invalid_aliases.is_empty() {
-        return Err(VerifyError::invalid_dependency_aliases(&invalid_aliases));
-    }
+    let (candidates, shape_violations) = collect_candidates(lockfile);
     if !shape_violations.is_empty() {
         return Err(build_verification_error(shape_violations));
     }
@@ -205,7 +208,7 @@ pub async fn collect_resolution_policy_violations(
     // Shape violations and invalid aliases are deliberately not
     // collected here: they are hard tampering failures, not policy
     // picks a caller may auto-exclude.
-    let (candidates, _shape_violations, _invalid_aliases) = collect_candidates(lockfile);
+    let (candidates, _shape_violations) = collect_candidates(lockfile);
     // `Err(message)` is a transport failure the caller must surface rather than
     // treat as "no violations" — see [`run_fan_out`].
     run_fan_out(candidates, verifiers, concurrency).await
@@ -326,6 +329,61 @@ fn push_invalid_aliases<'alias>(
     }
 }
 
+/// Collect every lockfile-controlled dependency name that isn't a valid
+/// npm package name. Three sources, each of which becomes a
+/// `node_modules/<name>` path component at install time:
+///
+/// - every importer's direct-dependency aliases,
+/// - every snapshot's own package name (the `snapshots:` map key), and
+/// - every snapshot's `dependencies` / `optionalDependencies` aliases.
+///
+/// A name carrying a `..` traversal, a `/`, or a reserved value such as
+/// `node_modules` / `.bin` / `.pnpm` could make an install write outside
+/// the intended directory or overwrite pnpm-owned layout.
+fn collect_invalid_dependency_names(lockfile: &Lockfile) -> std::collections::BTreeSet<String> {
+    let mut invalid = std::collections::BTreeSet::new();
+    for importer in lockfile.importers.values() {
+        for deps in
+            [&importer.dependencies, &importer.dev_dependencies, &importer.optional_dependencies]
+        {
+            push_invalid_aliases(deps.iter().flatten().map(|(alias, _)| alias), &mut invalid);
+        }
+    }
+    if let Some(snapshots) = lockfile.snapshots.as_ref() {
+        for (key, snapshot) in snapshots {
+            push_invalid_aliases(std::iter::once(&key.name), &mut invalid);
+            for deps in [&snapshot.dependencies, &snapshot.optional_dependencies] {
+                push_invalid_aliases(deps.iter().flatten().map(|(alias, _)| alias), &mut invalid);
+            }
+        }
+    }
+    invalid
+}
+
+/// Reject a lockfile whose dependency names or aliases are not valid npm
+/// package names.
+///
+/// This is an offline, network-free structural check — it does **not**
+/// depend on the resolution-policy verifiers, so it must run on every
+/// install, **including under `trustLockfile`**, which disables the
+/// policy fan-out. A crafted lockfile alias becomes a filesystem path
+/// (`node_modules/<alias>`, a virtual-store slot's inner
+/// `node_modules/<name>`, a bin, a hoisted link), and pacquet's
+/// [`PkgName`] parser does not validate against npm's package-name
+/// rules, so an unchecked `..`/`/`-bearing name escapes the intended
+/// directory.
+///
+/// Surfaces [`VerifyError::InvalidDependencyAlias`]
+/// (`ERR_PNPM_INVALID_DEPENDENCY_NAME`) listing every offender.
+pub fn verify_lockfile_dependency_names(lockfile: &Lockfile) -> Result<(), VerifyError> {
+    let invalid = collect_invalid_dependency_names(lockfile);
+    if invalid.is_empty() {
+        return Ok(());
+    }
+    let invalid: Vec<String> = invalid.into_iter().collect();
+    Err(VerifyError::invalid_dependency_aliases(&invalid))
+}
+
 /// One `(name, version, resolution)` tuple deduplicated from
 /// `lockfile.packages`.
 struct Candidate {
@@ -343,36 +401,10 @@ struct Candidate {
 /// `BTreeMap` over a serialized key gives deterministic iteration
 /// order for tests; the fan-out runs across the value iter so order
 /// doesn't affect correctness, only the reproducibility of failures.
-fn collect_candidates(
-    lockfile: &Lockfile,
-) -> (Vec<Candidate>, Vec<ResolutionPolicyViolation>, Vec<String>) {
+fn collect_candidates(lockfile: &Lockfile) -> (Vec<Candidate>, Vec<ResolutionPolicyViolation>) {
     let Some(packages) = lockfile.packages.as_ref() else {
-        return (Vec::new(), Vec::new(), Vec::new());
+        return (Vec::new(), Vec::new());
     };
-    // Pacquet keeps the alias-bearing maps in `importers` / `snapshots`,
-    // separate from the `packages` metadata the loop below walks, so
-    // they're scanned here in the same pass.
-    let mut invalid_aliases: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-    for importer in lockfile.importers.values() {
-        for deps in
-            [&importer.dependencies, &importer.dev_dependencies, &importer.optional_dependencies]
-        {
-            push_invalid_aliases(
-                deps.iter().flatten().map(|(alias, _)| alias),
-                &mut invalid_aliases,
-            );
-        }
-    }
-    if let Some(snapshots) = lockfile.snapshots.as_ref() {
-        for snapshot in snapshots.values() {
-            for deps in [&snapshot.dependencies, &snapshot.optional_dependencies] {
-                push_invalid_aliases(
-                    deps.iter().flatten().map(|(alias, _)| alias),
-                    &mut invalid_aliases,
-                );
-            }
-        }
-    }
     let mut deduped: BTreeMap<String, Candidate> = BTreeMap::new();
     let mut shape_violations = Vec::new();
     for (key, metadata) in packages {
@@ -412,7 +444,7 @@ fn collect_candidates(
             resolution: metadata.resolution.clone(),
         });
     }
-    (deduped.into_values().collect(), shape_violations, invalid_aliases.into_iter().collect())
+    (deduped.into_values().collect(), shape_violations)
 }
 
 /// Run every active verifier against every candidate with a

--- a/pacquet/crates/lockfile-verification/src/verify_lockfile_resolutions/tests.rs
+++ b/pacquet/crates/lockfile-verification/src/verify_lockfile_resolutions/tests.rs
@@ -884,6 +884,66 @@ snapshots:
 }
 
 #[tokio::test]
+async fn rejects_a_traversal_snapshot_package_name() {
+    // The snapshot's own package name (the `snapshots:` key) becomes
+    // `<slot>/node_modules/<name>` at extract time — a sink the alias
+    // scan of the dependency maps alone doesn't cover.
+    let lockfile = parse(
+        "lockfileVersion: '9.0'
+
+packages:
+
+  ../../../escape@1.0.0:
+    resolution: {integrity: sha512-deadbeef}
+
+snapshots:
+
+  ../../../escape@1.0.0: {}
+",
+    );
+    let err = verify_lockfile_resolutions::<SilentReporter>(
+        &lockfile,
+        &[],
+        &VerifyLockfileResolutionsOptions::default(),
+    )
+    .await
+    .expect_err("a traversal snapshot package name must be rejected");
+    let VerifyError::InvalidDependencyAlias { breakdown, .. } = err else {
+        panic!("expected InvalidDependencyAlias, got {err:?}");
+    };
+    assert!(breakdown.contains("../../../escape"), "breakdown {breakdown:?}");
+}
+
+#[test]
+fn verify_lockfile_dependency_names_rejects_a_packages_less_lockfile() {
+    // A lockfile with only `link:` deps has no `packages:` section, so
+    // the resolution fan-out short-circuits — but the offline name check
+    // must still reject a traversal importer alias.
+    let lockfile = parse(
+        "lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      '../../escaped-link':
+        specifier: link:./local
+        version: link:local
+",
+    );
+    assert!(lockfile.packages.is_none(), "fixture must have no packages section");
+    let err = super::verify_lockfile_dependency_names(&lockfile)
+        .expect_err("a traversal alias in a packages-less lockfile must be rejected");
+    assert!(matches!(err, VerifyError::InvalidDependencyAlias { .. }), "got {err:?}");
+}
+
+#[test]
+fn verify_lockfile_dependency_names_accepts_a_clean_lockfile() {
+    super::verify_lockfile_dependency_names(&parse(TWO_PKG_LOCKFILE))
+        .expect("a lockfile with valid names must pass");
+}
+
+#[tokio::test]
 async fn accepts_valid_scoped_and_unscoped_aliases() {
     let lockfile = parse(
         "lockfileVersion: '9.0'

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -882,6 +882,19 @@ where
             Some(&allow_build_policy),
         );
 
+        // Reject a lockfile whose dependency names, aliases, or
+        // virtual-store slots would escape the project or the store once
+        // joined into a filesystem path. Runs before any materialization
+        // and before the warm-install skip filter, and unconditionally —
+        // so it is not bypassed by `trustLockfile`, which disables the
+        // resolution-verification fan-out where the offline name check
+        // would otherwise run. The slot-containment half needs the
+        // install-time `layout`, so it can't live in the verifier crate.
+        pacquet_lockfile_verification::verify_lockfile_dependency_names(lockfile)
+            .map_err(InstallFrozenLockfileError::LockfileVerification)?;
+        crate::validate_virtual_store_slot_containment(snapshots, &layout)
+            .map_err(InstallFrozenLockfileError::LockfileVerification)?;
+
         // The frozen path runs no resolve-time prefetcher, so the warm
         // batch owns package-status progress for store hits. An empty set
         // leaves every warm package reported as `found_in_store`.

--- a/pacquet/crates/package-manager/src/lib.rs
+++ b/pacquet/crates/package-manager/src/lib.rs
@@ -49,6 +49,7 @@ mod tarball_prefetch;
 mod update;
 mod update_project_manifest;
 mod update_project_manifest_object;
+mod validate_lockfile_paths;
 mod version_policy;
 mod virtual_store_layout;
 
@@ -96,6 +97,7 @@ pub use tarball_prefetch::*;
 pub use update::*;
 pub use update_project_manifest::*;
 pub use update_project_manifest_object::*;
+pub use validate_lockfile_paths::*;
 pub use version_policy::*;
 pub use virtual_store_layout::*;
 

--- a/pacquet/crates/package-manager/src/validate_lockfile_paths.rs
+++ b/pacquet/crates/package-manager/src/validate_lockfile_paths.rs
@@ -1,0 +1,52 @@
+//! Reject a lockfile whose virtual-store slots would escape the store
+//! root once materialized.
+//!
+//! Dependency-name validation lives in the lockfile verifier
+//! ([`pacquet_lockfile_verification::verify_lockfile_dependency_names`]),
+//! which the install runs unconditionally. This module covers the one
+//! escape that name validation alone can't: the global-virtual-store
+//! slot path inserts the package name and the version-derived segment as
+//! raw path components (unlike the legacy flat name, which `/`-escapes),
+//! so a traversal in the version escapes the store even when the name is
+//! valid. The check needs the install-time [`VirtualStoreLayout`], which
+//! is why it lives here rather than in the verifier crate.
+
+use crate::VirtualStoreLayout;
+use pacquet_fs::is_subdir;
+use pacquet_lockfile::{PackageKey, SnapshotEntry};
+use pacquet_lockfile_verification::VerifyError;
+use std::collections::{BTreeSet, HashMap};
+
+/// Reject the install when any snapshot's computed virtual-store slot
+/// resolves outside the store root. The whole `snapshots` map is
+/// scanned — not just the survivors of the warm-install skip filter —
+/// so a poisoned snapshot that would be skipped as unchanged is still
+/// rejected before any directory is created.
+///
+/// Surfaces [`VerifyError::InvalidDependencyAlias`]
+/// (`ERR_PNPM_INVALID_DEPENDENCY_NAME`), the same code the name check
+/// raises, listing every offending snapshot key.
+pub fn validate_virtual_store_slot_containment(
+    snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
+    layout: &VirtualStoreLayout,
+) -> Result<(), VerifyError> {
+    let Some(snapshots) = snapshots else {
+        return Ok(());
+    };
+    let mut escaped: BTreeSet<String> = BTreeSet::new();
+    for key in snapshots.keys() {
+        // Lexical containment: the slot does not exist yet, so this must
+        // not touch the filesystem.
+        if !is_subdir(layout.package_store_dir(), &layout.slot_dir(key)) {
+            escaped.insert(key.to_string());
+        }
+    }
+    if escaped.is_empty() {
+        return Ok(());
+    }
+    let escaped: Vec<String> = escaped.into_iter().collect();
+    Err(VerifyError::invalid_dependency_aliases(&escaped))
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/package-manager/src/validate_lockfile_paths/tests.rs
+++ b/pacquet/crates/package-manager/src/validate_lockfile_paths/tests.rs
@@ -1,0 +1,51 @@
+use super::validate_virtual_store_slot_containment;
+use crate::VirtualStoreLayout;
+use miette::Diagnostic;
+use pacquet_lockfile::{PackageKey, SnapshotEntry};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+fn assert_invalid_dependency_name_code(err: &pacquet_lockfile_verification::VerifyError) {
+    let code = err.code().map(|code| code.to_string());
+    assert_eq!(code.as_deref(), Some("ERR_PNPM_INVALID_DEPENDENCY_NAME"));
+}
+
+#[test]
+fn accepts_snapshots_whose_slots_stay_in_the_store() {
+    let layout = VirtualStoreLayout::legacy(
+        PathBuf::from("/project/node_modules/.pnpm"),
+        pacquet_config::default_virtual_store_dir_max_length() as usize,
+    );
+    let mut snapshots = HashMap::new();
+    snapshots.insert("@scope/foo@1.2.3".parse::<PackageKey>().unwrap(), SnapshotEntry::default());
+    snapshots.insert("bar@4.5.6".parse::<PackageKey>().unwrap(), SnapshotEntry::default());
+    validate_virtual_store_slot_containment(Some(&snapshots), &layout)
+        .expect("contained slots must pass");
+}
+
+#[test]
+fn rejects_a_global_virtual_store_version_escape() {
+    // Under the global virtual store the slot path inserts the version
+    // segment as a raw path component (unlike the legacy flat name, which
+    // escapes `/`). A traversal-bearing version escapes the store root
+    // even though the package name itself is valid, so the containment
+    // check — not the name check — is what rejects it.
+    let key: PackageKey = "evil@../../../escaped".parse().expect("parse escaping version key");
+
+    let mut config = pacquet_config::Config::new();
+    config.enable_global_virtual_store = true;
+    config.global_virtual_store_dir = PathBuf::from("/store/links");
+
+    let mut snapshots = HashMap::new();
+    snapshots.insert(key.clone(), SnapshotEntry::default());
+    let layout = VirtualStoreLayout::new(&config, None, Some(&snapshots), None, None);
+    assert!(
+        !pacquet_fs::is_subdir(layout.package_store_dir(), &layout.slot_dir(&key)),
+        "the crafted slot must actually escape the store for this test to be meaningful",
+    );
+
+    let err = validate_virtual_store_slot_containment(Some(&snapshots), &layout)
+        .expect_err("a slot that escapes the store root must be rejected");
+    assert_invalid_dependency_name_code(&err);
+    assert!(err.to_string().contains("evil@"), "offender listed: {err}");
+}


### PR DESCRIPTION
## Summary

Fixes the pacquet path-traversal reported in **GHSA-2rx9-3g3h-c2jv / CAND-PNPM-027** (CWE-22 / CWE-59 / CWE-73).

A crafted `pnpm-lock.yaml` could carry a dependency alias, snapshot package name, or virtual-store slot with path-traversal segments (e.g. `../../escaped-link`). During `pacquet install` — notably `--frozen-lockfile --trust-lockfile` — those lockfile-controlled strings were joined into filesystem paths and could create symlinks, directories, or bins **outside** the project / `node_modules` boundary. `PkgName` parsing does not validate against npm's package-name rules, so `..`/`/`-bearing names flow straight into the many install-time `Path::join` sinks (direct/transitive symlinks, slot extraction dirs, bins, hoisted links, and — under the global virtual store — the slot path itself via its version-derived segment).

**Root cause:** the lockfile verifier already validated dependency aliases, but that check only ran inside the resolution-policy fan-out, which `trustLockfile` disables (empty verifiers → the frozen path returns before ever calling the verifier). It also never covered snapshot *package names* or packages-less (`link:`-only) lockfiles.

**Fix**

- Add `verify_lockfile_dependency_names` to `pacquet-lockfile-verification`: an offline, network-free structural check over importer aliases, **snapshot package names**, and snapshot dependency aliases (reusing the existing `is_valid_old_npm_package_name` rule and `ERR_PNPM_INVALID_DEPENDENCY_NAME` error). `verify_lockfile_resolutions` now runs it **before** the `packages`-absent short-circuit and the cache lookup, closing the `link:`-only bypass.
- Call it **unconditionally** from `InstallFrozenLockfile::run` — before any materialization and before the warm-install skip filter — so `trustLockfile` can no longer bypass it.
- Add `validate_virtual_store_slot_containment` to `pacquet-package-manager`: a lexical `is_subdir` check on each snapshot's computed slot, rejecting a global-virtual-store slot whose version-derived segment escapes the store root (the one escape name validation alone can't catch; it needs the install-time `VirtualStoreLayout`, which is why this half stays in `package-manager`).

Reproduced end-to-end against the built binary: before the fix, `pacquet install --frozen-lockfile --trust-lockfile` on a lockfile with a `../../escaped-link` dependency created a symlink outside the project; after, the install aborts with `ERR_PNPM_INVALID_DEPENDENCY_NAME` and writes nothing outside the project. Verified for both a `packages:`-backed lockfile and a `link:`-only (no `packages:`) lockfile.

## Squash Commit Body

```text
A crafted pnpm-lock.yaml could carry a dependency alias, snapshot package
name, or virtual-store slot with path-traversal segments (e.g.
`../../escaped-link`). During `pacquet install` — notably
`--frozen-lockfile --trust-lockfile` — those lockfile-controlled strings
were joined into filesystem paths and could create symlinks, directories,
or bins outside the project / node_modules boundary (CWE-22 / CWE-59).

The lockfile verifier already validated dependency aliases, but the check
only ran inside the resolution-policy fan-out, which trustLockfile
disables — and it never covered snapshot package names or packages-less
(link:-only) lockfiles.

- Add verify_lockfile_dependency_names, an offline structural check over
  importer aliases, snapshot package names, and snapshot dependency
  aliases, and run it in verify_lockfile_resolutions before the
  packages-absent short-circuit and the cache lookup.
- Call it unconditionally from InstallFrozenLockfile::run — before any
  materialization and the warm-install skip filter — so trustLockfile
  cannot bypass it.
- Add validate_virtual_store_slot_containment to reject a
  global-virtual-store slot whose version-derived segment escapes the
  store root, the one escape name validation alone cannot catch.

Rejections surface ERR_PNPM_INVALID_DEPENDENCY_NAME.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting. — pacquet-only: the advisory notes the escape is specific to pacquet (`PkgName` is more permissive than the TS resolver), so no TypeScript-CLI or lockfile-format change is needed.
- [x] Added a changeset if this PR changes any published package. — N/A: Rust-only change; pacquet is not a changeset-versioned npm package.
- [x] Added or updated tests. — 3 new verifier tests (snapshot-key name, packages-less `link:` case, clean lockfile) + 2 package-manager containment tests; full `pacquet-package-manager` (654) and `pacquet-lockfile-verification` (47) lib suites pass; `cargo clippy --deny warnings` and `cargo fmt` clean.
- [x] Updated the documentation if needed. — N/A.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader lockfile safety checks during install and verification.
  * Lockfiles with unsafe dependency names or paths are now rejected earlier, helping prevent filesystem escape issues.
  * Virtual store placement is now validated to ensure computed paths stay within the expected package store.

* **Bug Fixes**
  * Improved handling of lockfiles without package sections.
  * Unsafe entries are now blocked consistently, even when some verification paths would otherwise be skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->