### PR TITLE
feat(overrides): add convergence overrides ("pkg@": exact version)

### DIFF
--- a/.changeset/olive-pandas-converge.md
+++ b/.changeset/olive-pandas-converge.md
@@ -1,0 +1,15 @@
+---
+"@pnpm/config.parse-overrides": minor
+"@pnpm/hooks.read-package-hook": minor
+"@pnpm/installing.deps-installer": minor
+"pnpm": minor
+---
+
+Added a new override selector form with an empty range — `"pkg@": "<version>"` — called a convergence override. It rewrites a dependency edge only when its exact version satisfies the edge's declared range, so compatible consumers converge on one version while incompatible consumers keep their own resolution — now and for any dependent added in the future [#12794](https://github.com/pnpm/pnpm/issues/12794).
+
+```yaml
+overrides:
+  "form-data@": 4.0.6
+```
+
+The value must be an exact version. When a full resolution detects that every declared range also admits a newer version, pnpm warns that the override is stale and names the version to converge on. Previously an empty range in an override selector was undocumented and behaved like a bare (unscoped) override.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4035,6 +4035,7 @@ version = "0.0.1"
 dependencies = [
  "derive_more",
  "miette 7.6.0",
+ "node-semver",
  "pacquet-catalogs-resolver",
  "pacquet-catalogs-types",
  "pacquet-resolving-parse-wanted-dependency",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2424,6 +2424,9 @@ importers:
       '@pnpm/resolving.parse-wanted-dependency':
         specifier: workspace:*
         version: link:../../resolving/parse-wanted-dependency
+      semver:
+        specifier: 'catalog:'
+        version: 7.8.5
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -2431,6 +2434,9 @@ importers:
       '@pnpm/config.parse-overrides':
         specifier: workspace:*
         version: 'link:'
+      '@types/semver':
+        specifier: 'catalog:'
+        version: 7.7.1
 
   pnpm11/config/pick-registry-for-package:
     dependencies:
@@ -5524,6 +5530,9 @@ importers:
       '@pnpm/config.parse-overrides':
         specifier: workspace:*
         version: link:../../config/parse-overrides
+      '@pnpm/config.version-policy':
+        specifier: workspace:*
+        version: link:../../config/version-policy
       '@pnpm/constants':
         specifier: workspace:*
         version: link:../../core/constants

--- a/pnpm/crates/cli/tests/convergence_overrides.rs
+++ b/pnpm/crates/cli/tests/convergence_overrides.rs
@@ -1,0 +1,116 @@
+//! Convergence overrides (`"pkg@": "<exact version>"`) end to end: the
+//! override rewrites only the dependency edges its version satisfies,
+//! and a full resolution warns when every declared range admits a
+//! version newer than the override's value.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::{fs, path::Path};
+
+const DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
+
+/// Append an `overrides` block to the `pnpm-workspace.yaml` the mocked
+/// registry already wrote (it carries `storeDir`/`cacheDir`, so the
+/// tests must extend it rather than overwrite it).
+fn add_overrides(workspace: &Path, block: &str) {
+    let path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&path).unwrap_or_default();
+    if !yaml.is_empty() && !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    yaml.push_str(block);
+    fs::write(&path, yaml).expect("update pnpm-workspace.yaml");
+}
+
+fn write_manifest(workspace: &Path, dep_spec: &str) {
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "convergence-fixture",
+            "version": "1.0.0",
+            "dependencies": { DEP: dep_spec },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+}
+
+#[test]
+fn install_applies_convergence_override_and_warns_when_stale() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, "^100.0.0");
+    // The fixture registry serves 100.0.0, 100.1.0, and 101.0.0, so the
+    // pinned 100.0.0 is stale: 100.1.0 also satisfies ^100.0.0.
+    add_overrides(&workspace, &format!("overrides:\n  \"{DEP}@\": 100.0.0\n"));
+
+    let output = pacquet.with_arg("install").assert().success();
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+    eprintln!("STDOUT:\n{stdout}\n");
+
+    assert!(
+        workspace.join("node_modules/.pnpm/@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0").exists(),
+        "the convergence override should pin the satisfying edge to exactly 100.0.0",
+    );
+    assert!(stdout.contains(&format!(
+        "The convergence override \"{DEP}@\": \"100.0.0\" is stale: \
+         every declared range of {DEP} also admits 100.1.0. \
+         Change the override's value to 100.1.0 in pnpm-workspace.yaml, \
+         or remove the override and run \"pnpm dedupe\"."
+    )));
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn install_stays_silent_when_the_convergence_override_is_not_stale() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, "^100.0.0");
+    add_overrides(&workspace, &format!("overrides:\n  \"{DEP}@\": 100.1.0\n"));
+
+    let output = pacquet.with_arg("install").assert().success();
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+    eprintln!("STDOUT:\n{stdout}\n");
+
+    assert!(
+        workspace.join("node_modules/.pnpm/@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0").exists(),
+        "the convergence override should rewrite the edge to 100.1.0",
+    );
+    assert!(
+        !stdout.contains("is stale"),
+        "100.1.0 is already the best version every declared range admits",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn install_leaves_incompatible_edges_on_their_own_resolution() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    // 101.0.0 does not satisfy ^100.0.0, so the edge keeps its own
+    // resolution (the highest of ^100.0.0) and no staleness warning
+    // fires — 101.0.0 is outside every declared range.
+    write_manifest(&workspace, "^100.0.0");
+    add_overrides(&workspace, &format!("overrides:\n  \"{DEP}@\": 101.0.0\n"));
+
+    let output = pacquet.with_arg("install").assert().success();
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+    eprintln!("STDOUT:\n{stdout}\n");
+
+    assert!(
+        workspace.join("node_modules/.pnpm/@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0").exists(),
+        "an incompatible convergence override must leave the edge untouched",
+    );
+    assert!(!stdout.contains("is stale"));
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/config-parse-overrides/Cargo.toml
+++ b/pnpm/crates/config-parse-overrides/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace  = true
 [dependencies]
 derive_more                               = { workspace = true }
 miette                                    = { workspace = true }
+node-semver                               = { workspace = true }
 pacquet-catalogs-resolver                 = { workspace = true }
 pacquet-catalogs-types                    = { workspace = true }
 pacquet-resolving-parse-wanted-dependency = { workspace = true }

--- a/pnpm/crates/config-parse-overrides/src/lib.rs
+++ b/pnpm/crates/config-parse-overrides/src/lib.rs
@@ -13,6 +13,7 @@
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;
+use node_semver::Version;
 use pacquet_catalogs_resolver::{CatalogResolutionResult, WantedDependency, resolve_from_catalog};
 use pacquet_catalogs_types::Catalogs;
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
@@ -38,6 +39,13 @@ pub struct VersionOverride {
     /// workspace's catalogs before this is stored, so downstream
     /// consumers never see the `catalog:` form here.
     pub new_bare_specifier: String,
+
+    /// `true` for empty-range selectors (`"pkg@"`): a convergence
+    /// override. It applies to a dependency edge only when
+    /// [`Self::new_bare_specifier`] (always an exact version) satisfies
+    /// the edge's declared range, so applying it can never violate a
+    /// consumer's range.
+    pub converge: bool,
 }
 
 /// A name (and optional version-range scope) used to identify either
@@ -69,6 +77,33 @@ pub enum ParseOverridesError {
     CatalogInOverrides {
         #[error(not(source))]
         message: String,
+    },
+
+    /// A `parent>child` selector uses an empty range on either side.
+    /// The empty-range form is reserved for standalone convergence
+    /// overrides (`ERR_PNPM_INVALID_CONVERGENCE_OVERRIDE`).
+    #[display(
+        r#"Cannot use an empty range in the "{selector}" selector: convergence overrides ("pkg@") cannot be combined with parent>child selectors"#
+    )]
+    #[diagnostic(code(ERR_PNPM_INVALID_CONVERGENCE_OVERRIDE))]
+    EmptyRangeInParentChildSelector {
+        #[error(not(source))]
+        selector: String,
+    },
+
+    /// A convergence override's (catalog-resolved) value is not an
+    /// exact semver version. Ranges, dist-tags, `-`, and protocol
+    /// specs have no defined "satisfies" relation against a declared
+    /// range (`ERR_PNPM_INVALID_CONVERGENCE_OVERRIDE`).
+    #[display(
+        r#"The value of the convergence override "{selector}" must be an exact version, but got "{value}""#
+    )]
+    #[diagnostic(code(ERR_PNPM_INVALID_CONVERGENCE_OVERRIDE))]
+    ConvergenceValueNotExactVersion {
+        #[error(not(source))]
+        selector: String,
+        #[error(not(source))]
+        value: String,
     },
 }
 
@@ -106,11 +141,14 @@ where
         let (parent_pkg, target_pkg) = parse_pkg_and_parent_selector(selector)?;
         let resolved_specifier =
             resolve_catalog_in_value(catalogs, &target_pkg.name, new_bare_specifier)?;
+        let converge =
+            check_converge(selector, parent_pkg.as_ref(), &target_pkg, &resolved_specifier)?;
         out.push(VersionOverride {
             selector: selector.clone(),
             parent_pkg,
             target_pkg,
             new_bare_specifier: resolved_specifier,
+            converge,
         });
     }
     Ok(out)
@@ -160,6 +198,38 @@ fn find_parent_delimiter(selector: &str) -> Option<usize> {
             None
         }
     })
+}
+
+/// Decide [`VersionOverride::converge`] for a parsed entry: a
+/// standalone selector with an empty-string range (`"pkg@"`) is a
+/// convergence override, and its (catalog-resolved) value must be an
+/// exact semver version. Runs after catalog resolution so a
+/// `catalog:` value is validated in its resolved form.
+fn check_converge(
+    selector: &str,
+    parent_pkg: Option<&PackageSelector>,
+    target_pkg: &PackageSelector,
+    new_bare_specifier: &str,
+) -> Result<bool, ParseOverridesError> {
+    let empty_range_in_parent_child_selector = parent_pkg.is_some_and(|parent| {
+        parent.bare_specifier.as_deref() == Some("")
+            || target_pkg.bare_specifier.as_deref() == Some("")
+    });
+    if empty_range_in_parent_child_selector {
+        return Err(ParseOverridesError::EmptyRangeInParentChildSelector {
+            selector: selector.to_string(),
+        });
+    }
+    if target_pkg.bare_specifier.as_deref() != Some("") {
+        return Ok(false);
+    }
+    if Version::parse(new_bare_specifier).is_err() {
+        return Err(ParseOverridesError::ConvergenceValueNotExactVersion {
+            selector: selector.to_string(),
+            value: new_bare_specifier.to_string(),
+        });
+    }
+    Ok(true)
 }
 
 fn parse_pkg_selector(selector: &str) -> Result<PackageSelector, ParseOverridesError> {

--- a/pnpm/crates/config-parse-overrides/src/tests.rs
+++ b/pnpm/crates/config-parse-overrides/src/tests.rs
@@ -16,6 +16,7 @@ fn vo(
         parent_pkg: parent,
         target_pkg: target,
         new_bare_specifier: new_bare.to_string(),
+        converge: false,
     }
 }
 
@@ -174,6 +175,59 @@ fn catalog_protocol_with_named_catalog_resolves() {
     let input = HashMap::from([("bar".to_string(), "catalog:shared".to_string())]);
     let out = parse_overrides(&input, &catalogs).unwrap();
     assert_eq!(out, vec![vo("bar", "2.0.0", None, sel("bar", None))]);
+}
+
+#[test]
+fn parses_convergence_override() {
+    for (selector, version, name) in
+        [("foo@", "1.2.3", "foo"), ("@scope/foo@", "2.0.0-beta.1", "@scope/foo")]
+    {
+        let input = HashMap::from([(selector.to_string(), version.to_string())]);
+        let out = parse_overrides(&input, &Catalogs::new()).unwrap();
+        let expected =
+            VersionOverride { converge: true, ..vo(selector, version, None, sel(name, Some(""))) };
+        assert_eq!(out, vec![expected]);
+    }
+}
+
+#[test]
+fn resolves_catalog_value_of_convergence_override() {
+    let mut catalogs = Catalogs::new();
+    let mut default = Catalog::new();
+    default.insert("foo".to_string(), "1.2.3".to_string());
+    catalogs.insert("default".to_string(), default);
+
+    let input = HashMap::from([("foo@".to_string(), "catalog:".to_string())]);
+    let out = parse_overrides(&input, &catalogs).unwrap();
+    let expected =
+        VersionOverride { converge: true, ..vo("foo@", "1.2.3", None, sel("foo", Some(""))) };
+    assert_eq!(out, vec![expected]);
+}
+
+#[test]
+fn rejects_non_exact_convergence_override_values() {
+    for value in ["^1.2.3", "latest", "-", "link:../foo", "npm:bar@1.2.3"] {
+        let input = HashMap::from([("foo@".to_string(), value.to_string())]);
+        let message = parse_overrides(&input, &Catalogs::new()).unwrap_err().to_string();
+        eprintln!("MESSAGE:\n{message}\n");
+        assert_eq!(
+            message,
+            format!(
+                r#"The value of the convergence override "foo@" must be an exact version, but got "{value}""#
+            ),
+        );
+    }
+}
+
+#[test]
+fn rejects_empty_range_in_parent_child_selector() {
+    let input = HashMap::from([("bar>foo@".to_string(), "1.2.3".to_string())]);
+    let message = parse_overrides(&input, &Catalogs::new()).unwrap_err().to_string();
+    eprintln!("MESSAGE:\n{message}\n");
+    assert_eq!(
+        message,
+        r#"Cannot use an empty range in the "bar>foo@" selector: convergence overrides ("pkg@") cannot be combined with parent>child selectors"#,
+    );
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -255,6 +255,35 @@ fn dedupe_peers_round_trips_through_lockfile_settings() {
 }
 
 #[test]
+fn overrides_flow_into_lockfile_verbatim_including_convergence_selectors() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "fixture",
+        "version": "1.0.0",
+    }));
+    let graph = DependenciesGraph::new();
+
+    let mut overrides = IndexMap::new();
+    overrides.insert("foo@^4.0.0".to_string(), "4.0.9".to_string());
+    overrides.insert("form-data@".to_string(), "4.0.6".to_string());
+
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest,
+        &graph,
+        BTreeMap::new(),
+        true,
+        false,
+        Some(overrides.clone()),
+        None,
+    ));
+    assert_eq!(lockfile.overrides.as_ref(), Some(&overrides));
+
+    let yaml = serde_saphyr::to_string(&lockfile).unwrap();
+    eprintln!("YAML:\n{yaml}\n");
+    let reparsed: pacquet_lockfile::Lockfile = serde_saphyr::from_str(&yaml).unwrap();
+    assert_eq!(reparsed.overrides, Some(overrides));
+}
+
+#[test]
 fn patched_dependencies_flow_into_lockfile_and_empty_is_omitted() {
     let (_tmp, manifest) = write_manifest(json!({
         "name": "fixture",

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1145,7 +1145,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         let full_resolution = lockfile_reuse_seed.is_none()
             || matches!(
                 update_reuse_scope,
-                pacquet_resolving_deps_resolver::UpdateReuseScope::None
+                pacquet_resolving_deps_resolver::UpdateReuseScope::None,
             );
 
         let workspace_opts = pacquet_resolving_deps_resolver::WorkspaceResolveOptions {

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1127,6 +1127,27 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             update_reuse_scope = pacquet_resolving_deps_resolver::UpdateReuseScope::None;
         }
 
+        // Hand the resolver the prior lockfile so it can reuse
+        // already-resolved subtrees instead of re-resolving from the
+        // registry (see pnpm/plans/LOCKFILE_RESOLUTION_REUSE.md).
+        // Withhold it when packageExtensions or overrides drifted:
+        // both settings rewrite package dependency sets, so the
+        // recorded subtree is stale. pnpm likewise invalidates the
+        // lockfile on these settings changes.
+        let lockfile_reuse_seed = wanted_lockfile.filter(|lockfile| {
+            lockfile.package_extensions_checksum == package_extensions_checksum
+                && overrides_match(lockfile.overrides.as_ref(), resolved_overrides.as_ref())
+        });
+        // Reused subtrees never stream their manifests through the
+        // versions overrider, so only a resolution with no reuse at all
+        // collects the complete declared-range set the convergence
+        // staleness check needs.
+        let full_resolution = lockfile_reuse_seed.is_none()
+            || matches!(
+                update_reuse_scope,
+                pacquet_resolving_deps_resolver::UpdateReuseScope::None
+            );
+
         let workspace_opts = pacquet_resolving_deps_resolver::WorkspaceResolveOptions {
             dedupe_peers: config.dedupe_peers,
             dedupe_injected_deps: config.dedupe_injected_deps,
@@ -1141,20 +1162,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             skipped_optional_log: Some(skipped_optional_log_fn::<Reporter>()),
             pick_lowest_direct,
             time_based,
-            // Hand the resolver the prior lockfile so it can reuse
-            // already-resolved subtrees instead of re-resolving from the
-            // registry (see pnpm/plans/LOCKFILE_RESOLUTION_REUSE.md).
-            // Withhold it when packageExtensions or overrides drifted:
-            // both settings rewrite package dependency sets, so the
-            // recorded subtree is stale. pnpm likewise invalidates the
-            // lockfile on these settings changes.
-            wanted_lockfile: wanted_lockfile
-                .filter(|lockfile| {
-                    lockfile.package_extensions_checksum == package_extensions_checksum
-                        && overrides_match(lockfile.overrides.as_ref(), resolved_overrides.as_ref())
-                })
-                .cloned()
-                .map(Arc::new),
+            wanted_lockfile: lockfile_reuse_seed.cloned().map(Arc::new),
             update_reuse_scope,
             auto_install_peers: config.auto_install_peers,
             registries,
@@ -1256,6 +1264,44 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             nodes = total_nodes,
             "phase complete",
         );
+
+        // Only a full resolution walks every manifest through the
+        // versions overrider, making the collected declared ranges
+        // complete enough for the staleness verdict; partial (reuse-
+        // seeded) resolutions must stay silent to avoid false positives
+        // from unseen ranges. Runs before the resolver chain is dropped
+        // so the per-range picks reuse the still-warm packument cache.
+        if full_resolution
+            && let (Some(parsed), Some(overrider)) =
+                (parsed_overrides.as_ref(), versions_overrider.as_ref())
+        {
+            let declared_ranges = overrider.converge_declared_ranges();
+            let stale_check_opts = ResolveOptions {
+                project_dir: lockfile_dir.to_path_buf(),
+                lockfile_dir: lockfile_dir.to_path_buf(),
+                default_tag: Some("latest".to_string()),
+                published_by,
+                published_by_exclude: published_by_exclude.clone(),
+                ..ResolveOptions::default()
+            };
+            let stale =
+                crate::warn_on_stale_convergence_overrides::find_stale_convergence_overrides(
+                    parsed,
+                    &declared_ranges,
+                    |name, range| {
+                        crate::warn_on_stale_convergence_overrides::resolve_best_admitted_version(
+                            &*npm_resolver,
+                            &stale_check_opts,
+                            name,
+                            range,
+                        )
+                    },
+                )
+                .await;
+            crate::warn_on_stale_convergence_overrides::warn_stale_convergence_overrides::<Reporter>(
+                &stale,
+            );
+        }
 
         // Drop the resolver (and its packument cache) before the
         // install pass. Dropping `resolver` releases the

--- a/pnpm/crates/package-manager/src/lib.rs
+++ b/pnpm/crates/package-manager/src/lib.rs
@@ -54,6 +54,7 @@ mod update_project_manifest_object;
 mod validate_lockfile_paths;
 mod version_policy;
 mod virtual_store_layout;
+mod warn_on_stale_convergence_overrides;
 
 pub use add::*;
 pub use build_modules::*;

--- a/pnpm/crates/package-manager/src/overrides.rs
+++ b/pnpm/crates/package-manager/src/overrides.rs
@@ -19,14 +19,15 @@ use pacquet_config_parse_overrides::{PackageSelector, VersionOverride};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use serde_json::Value;
 use std::{
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 /// In-memory hook that applies the parsed `pnpm.overrides` set to a
 /// manifest. Cheap to construct — partitioning the overrides into the
-/// parent-scoped vs. generic buckets happens once, and each call to
-/// [`Self::apply`] walks the dep maps in place.
+/// parent-scoped vs. generic vs. convergence buckets happens once, and
+/// each call to [`Self::apply`] walks the dep maps in place.
 pub struct VersionsOverrider {
     /// Overrides whose key carries a `parent>child` shape — only
     /// applied when the manifest being rewritten matches the parent
@@ -34,6 +35,28 @@ pub struct VersionsOverrider {
     parent_scoped: Vec<ResolvedOverride>,
     /// Generic overrides (no parent half). Apply to every manifest.
     generic: Vec<ResolvedOverride>,
+    /// Convergence overrides (`"pkg@"`), keyed by target package name
+    /// (at most one per name — the overrides map's keys are unique).
+    /// Consulted only for edges no explicit override claims.
+    converge: HashMap<String, ConvergeOverride>,
+    /// Every declared semver range seen for packages that have a
+    /// convergence override, whether or not the override's version
+    /// satisfied it. Feeds the staleness check for convergence
+    /// overrides after a full resolution. Edges claimed by an explicit
+    /// override are not recorded — the convergence override never
+    /// governs them.
+    converge_declared_ranges: Mutex<HashMap<String, HashSet<String>>>,
+}
+
+/// A convergence override's replacement value, with the exact version
+/// pre-parsed once at construction time. `version` is `None` when the
+/// value isn't a parseable semver version (only reachable for
+/// hand-built [`VersionOverride`] entries — [`pacquet_config_parse_overrides::parse_overrides`]
+/// rejects such values); the override then never rewrites an edge,
+/// matching how an unsatisfiable version behaves.
+struct ConvergeOverride {
+    new_bare_specifier: String,
+    version: Option<Version>,
 }
 
 /// `VersionOverride` augmented with a pre-parsed [`LocalTarget`] for
@@ -72,7 +95,18 @@ impl VersionsOverrider {
     pub fn new(overrides: &[VersionOverride], root_dir: &Path) -> Self {
         let mut parent_scoped = Vec::new();
         let mut generic = Vec::new();
+        let mut converge = HashMap::new();
         for override_entry in overrides {
+            if override_entry.converge {
+                converge.insert(
+                    override_entry.target_pkg.name.clone(),
+                    ConvergeOverride {
+                        new_bare_specifier: override_entry.new_bare_specifier.clone(),
+                        version: Version::parse(&override_entry.new_bare_specifier).ok(),
+                    },
+                );
+                continue;
+            }
             let resolved = ResolvedOverride {
                 inner: override_entry.clone(),
                 local_target: parse_local_target(&override_entry.new_bare_specifier, root_dir),
@@ -83,13 +117,30 @@ impl VersionsOverrider {
                 generic.push(resolved);
             }
         }
-        VersionsOverrider { parent_scoped, generic }
+        VersionsOverrider {
+            parent_scoped,
+            generic,
+            converge,
+            converge_declared_ranges: Mutex::new(HashMap::new()),
+        }
     }
 
     /// `true` when the hook has no entries and can be skipped.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.parent_scoped.is_empty() && self.generic.is_empty()
+        self.parent_scoped.is_empty() && self.generic.is_empty() && self.converge.is_empty()
+    }
+
+    /// Snapshot of every declared range recorded so far for packages
+    /// governed by a convergence override. Read by the staleness check
+    /// after a full resolution has streamed every manifest through
+    /// this hook.
+    #[must_use]
+    pub fn converge_declared_ranges(&self) -> HashMap<String, HashSet<String>> {
+        self.converge_declared_ranges
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
     }
 
     /// Apply the override set to `manifest` in place. `manifest_dir`
@@ -119,7 +170,16 @@ impl VersionsOverrider {
     /// the manifest.
     #[must_use]
     pub fn apply_to_arc(&self, manifest: Arc<Value>, manifest_dir: Option<&Path>) -> Arc<Value> {
-        if self.is_empty() || !self.has_applicable_override(&manifest) {
+        if self.is_empty() {
+            return manifest;
+        }
+        if !self.has_applicable_override(&manifest) {
+            // Nothing rewrites, so the shared value is returned as-is —
+            // but the declared ranges of converge-governed edges must
+            // still reach the staleness collector (`apply_to_value`
+            // records them as a side effect of its walk, which is
+            // skipped here).
+            self.record_converge_declared_ranges(&manifest);
             return manifest;
         }
         let mut cloned = (*manifest).clone();
@@ -171,8 +231,36 @@ impl VersionsOverrider {
         map.iter().any(|(name, spec)| {
             spec.as_str().is_some_and(|spec| {
                 self.choose_override(applicable_parent_scoped, name, spec).is_some()
+                    || self.converge_applies(name, spec)
             })
         })
+    }
+
+    /// Record the declared ranges of every converge-governed edge in
+    /// `value`, without rewriting anything. Same claimed-edge exclusion
+    /// as the rewrite walk: an edge an explicit override picks up is
+    /// never governed by the convergence override, so its range does
+    /// not participate in the staleness verdict.
+    fn record_converge_declared_ranges(&self, value: &Value) {
+        if self.converge.is_empty() {
+            return;
+        }
+        let applicable_parent_scoped = self.applicable_parent_scoped(value);
+        for group in [
+            DependencyGroup::Prod,
+            DependencyGroup::Optional,
+            DependencyGroup::Dev,
+            DependencyGroup::Peer,
+        ] {
+            let key: &'static str = group.into();
+            let Some(map) = value.get(key).and_then(Value::as_object) else { continue };
+            for (name, spec) in map {
+                let Some(spec) = spec.as_str() else { continue };
+                if self.choose_override(&applicable_parent_scoped, name, spec).is_none() {
+                    self.try_record_converge_range(name, spec);
+                }
+            }
+        }
     }
 
     fn override_group(
@@ -194,6 +282,9 @@ impl VersionsOverrider {
 
         for (name, spec) in entries {
             let Some(chosen) = self.choose_override(applicable_parent_scoped, &name, &spec) else {
+                if let Some(new_spec) = self.converge_dep(&name, &spec) {
+                    map.insert(name, Value::String(new_spec));
+                }
                 continue;
             };
 
@@ -231,6 +322,15 @@ impl VersionsOverrider {
 
         for (name, spec) in entries {
             let Some(chosen) = self.choose_override(applicable_parent_scoped, &name, &spec) else {
+                // A convergence override's value is an exact version —
+                // always a valid peer range — so the rewrite stays in
+                // `peerDependencies`.
+                if let Some(new_spec) = self.converge_dep(&name, &spec)
+                    && let Some(peers) =
+                        value.get_mut("peerDependencies").and_then(Value::as_object_mut)
+                {
+                    peers.insert(name, Value::String(new_spec));
+                }
                 continue;
             };
 
@@ -304,6 +404,55 @@ impl VersionsOverrider {
         sort_by_specificity(&mut matching);
         matching.into_iter().next()
     }
+
+    /// Consult the convergence override for an edge no explicit
+    /// override claimed: record the declared range for the staleness
+    /// check, then return the exact version when it satisfies the
+    /// declared range — incompatible edges keep their own resolution.
+    fn converge_dep(&self, dep_name: &str, dep_spec: &str) -> Option<String> {
+        let range = self.try_record_converge_range(dep_name, dep_spec)?;
+        let entry = &self.converge[dep_name];
+        let version = entry.version.as_ref()?;
+        range.satisfies(version).then(|| entry.new_bare_specifier.clone())
+    }
+
+    /// Rewrite-only variant of [`Self::converge_dep`] for
+    /// [`Self::has_applicable_override`]'s clone gate: same verdict,
+    /// no collector side effect.
+    fn converge_applies(&self, dep_name: &str, dep_spec: &str) -> bool {
+        self.converge.get(dep_name).is_some_and(|entry| {
+            entry.version.as_ref().is_some_and(|version| {
+                parse_declared_range(dep_spec).is_some_and(|range| range.satisfies(version))
+            })
+        })
+    }
+
+    /// When `dep_name` is converge-governed and `dep_spec` is a plain
+    /// semver range, record the range into the staleness collector and
+    /// return it parsed. `None` skips the edge entirely.
+    fn try_record_converge_range(&self, dep_name: &str, dep_spec: &str) -> Option<Range> {
+        self.converge.get(dep_name)?;
+        let range = parse_declared_range(dep_spec)?;
+        self.converge_declared_ranges
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .entry(dep_name.to_string())
+            .or_default()
+            .insert(dep_spec.to_string());
+        Some(range)
+    }
+}
+
+/// Parse a dependency edge's declared spec for the convergence
+/// consult. Only plain semver ranges participate — `workspace:`,
+/// `catalog:`, `npm:`, git/URL, and dist-tag specifiers have no
+/// defined "satisfies" relation and yield `None`. An empty declared
+/// spec counts as `*`.
+pub(crate) fn parse_declared_range(spec: &str) -> Option<Range> {
+    if spec.is_empty() {
+        return Some(Range::any());
+    }
+    Range::parse(spec).ok()
 }
 
 /// A valid peer range is a parseable semver range, or any expression

--- a/pnpm/crates/package-manager/src/overrides/tests.rs
+++ b/pnpm/crates/package-manager/src/overrides/tests.rs
@@ -312,6 +312,139 @@ fn dash_override_deletes_the_peer_dependency() {
 }
 
 #[test]
+fn convergence_override_rewrites_only_edges_its_version_satisfies() {
+    let overrides = parsed(&[("form-data@", "4.0.6")]);
+    let overrider = VersionsOverrider::new(&overrides, Path::new("/workspace"));
+
+    let mut satisfied = manifest_from_value(json!({
+        "dependencies": { "form-data": "^4.0.5" },
+        "optionalDependencies": { "other-form-data": "^3.0.0" },
+    }));
+    overrider.apply(&mut satisfied, Some(Path::new("/workspace")));
+    assert_eq!(dep_spec(&satisfied, "dependencies", "form-data"), Some("4.0.6"));
+    assert_eq!(dep_spec(&satisfied, "optionalDependencies", "other-form-data"), Some("^3.0.0"));
+
+    // Incompatible with 4.0.6, so the edge keeps its own resolution.
+    let mut incompatible = manifest_from_value(json!({
+        "dependencies": { "form-data": "^3.0.0" },
+    }));
+    overrider.apply(&mut incompatible, Some(Path::new("/workspace")));
+    assert_eq!(dep_spec(&incompatible, "dependencies", "form-data"), Some("^3.0.0"));
+}
+
+#[test]
+fn convergence_override_skips_non_range_specifiers() {
+    let overrides = parsed(&[("foo@", "4.0.6")]);
+    let overrider = VersionsOverrider::new(&overrides, Path::new("/workspace"));
+
+    let mut manifest = manifest_from_value(json!({
+        "dependencies": { "foo": "github:org/foo" },
+        "devDependencies": { "foo": "workspace:^" },
+        "optionalDependencies": { "foo": "latest" },
+    }));
+    overrider.apply(&mut manifest, Some(Path::new("/workspace")));
+
+    assert_eq!(dep_spec(&manifest, "dependencies", "foo"), Some("github:org/foo"));
+    assert_eq!(dep_spec(&manifest, "devDependencies", "foo"), Some("workspace:^"));
+    assert_eq!(dep_spec(&manifest, "optionalDependencies", "foo"), Some("latest"));
+}
+
+#[test]
+fn convergence_override_treats_an_empty_declared_spec_as_match_all() {
+    let overrides = parsed(&[("foo@", "4.0.6")]);
+    let overrider = VersionsOverrider::new(&overrides, Path::new("/workspace"));
+
+    let mut manifest = manifest_from_value(json!({
+        "dependencies": { "foo": "" },
+    }));
+    overrider.apply(&mut manifest, Some(Path::new("/workspace")));
+
+    assert_eq!(dep_spec(&manifest, "dependencies", "foo"), Some("4.0.6"));
+    let declared_ranges = overrider.converge_declared_ranges();
+    dbg!(&declared_ranges);
+    let expected = std::collections::HashMap::from([(
+        "foo".to_string(),
+        std::collections::HashSet::from([String::new()]),
+    )]);
+    assert_eq!(declared_ranges, expected);
+}
+
+#[test]
+fn convergence_override_rewrites_peer_dependencies_it_satisfies() {
+    let overrides = parsed(&[("foo@", "4.0.6")]);
+    let overrider = VersionsOverrider::new(&overrides, Path::new("/workspace"));
+
+    let mut manifest = manifest_from_value(json!({
+        "peerDependencies": { "foo": "^4.0.0" },
+    }));
+    overrider.apply(&mut manifest, Some(Path::new("/workspace")));
+
+    assert_eq!(dep_spec(&manifest, "peerDependencies", "foo"), Some("4.0.6"));
+    assert_eq!(dep_spec(&manifest, "dependencies", "foo"), None);
+}
+
+#[test]
+fn explicit_overrides_win_over_a_convergence_override() {
+    let overrides = parsed(&[("foo@^4.0.0", "4.0.9"), ("foo@", "4.0.6")]);
+    let overrider = VersionsOverrider::new(&overrides, Path::new("/workspace"));
+
+    let mut manifest = manifest_from_value(json!({
+        "dependencies": { "foo": "^4.0.5", "bar": "1.0.0" },
+    }));
+    overrider.apply(&mut manifest, Some(Path::new("/workspace")));
+
+    assert_eq!(dep_spec(&manifest, "dependencies", "foo"), Some("4.0.9"));
+    assert_eq!(dep_spec(&manifest, "dependencies", "bar"), Some("1.0.0"));
+}
+
+#[test]
+fn collects_declared_ranges_of_convergence_governed_packages() {
+    let overrides = parsed(&[("foo@", "4.0.6")]);
+    let overrider = VersionsOverrider::new(&overrides, Path::new("/workspace"));
+
+    let mut first = manifest_from_value(json!({
+        "dependencies": { "foo": "^4.0.5", "bar": "^1.0.0" },
+    }));
+    overrider.apply(&mut first, Some(Path::new("/workspace")));
+    let mut second = manifest_from_value(json!({
+        "dependencies": { "foo": "^3.0.0" },
+        "devDependencies": { "foo": "workspace:^" },
+    }));
+    overrider.apply(&mut second, Some(Path::new("/workspace")));
+
+    let declared_ranges = overrider.converge_declared_ranges();
+    dbg!(&declared_ranges);
+    let expected = std::collections::HashMap::from([(
+        "foo".to_string(),
+        std::collections::HashSet::from(["^4.0.5".to_string(), "^3.0.0".to_string()]),
+    )]);
+    assert_eq!(declared_ranges, expected);
+}
+
+#[test]
+fn apply_to_arc_records_declared_ranges_when_nothing_rewrites() {
+    let overrides = parsed(&[("foo@", "4.0.6")]);
+    let overrider = VersionsOverrider::new(&overrides, Path::new("/workspace"));
+
+    let original = std::sync::Arc::new(json!({
+        "dependencies": { "foo": "^3.0.0" },
+    }));
+    let updated = overrider.apply_to_arc(std::sync::Arc::clone(&original), None);
+
+    assert!(
+        std::sync::Arc::ptr_eq(&original, &updated),
+        "an unsatisfied convergence override must not clone",
+    );
+    let declared_ranges = overrider.converge_declared_ranges();
+    dbg!(&declared_ranges);
+    let expected = std::collections::HashMap::from([(
+        "foo".to_string(),
+        std::collections::HashSet::from(["^3.0.0".to_string()]),
+    )]);
+    assert_eq!(declared_ranges, expected);
+}
+
+#[test]
 fn apply_to_arc_clones_when_only_a_peer_matches() {
     let overrides = parsed(&[("ajv@<8.18.0", ">=8.18.0")]);
     let overrider = VersionsOverrider::new(&overrides, Path::new("/workspace"));

--- a/pnpm/crates/package-manager/src/warn_on_stale_convergence_overrides.rs
+++ b/pnpm/crates/package-manager/src/warn_on_stale_convergence_overrides.rs
@@ -1,0 +1,136 @@
+//! Staleness check for convergence overrides (`"pkg@": "<version>"`).
+//!
+//! A convergence override's value is derived state — the best version
+//! that converges the currently declared ranges. It goes stale when
+//! dependents start declaring ranges that admit newer versions: the
+//! override then keeps the edges it governs on the old version while
+//! newer edges resolve past it, producing the duplication the entry
+//! was written to prevent.
+//!
+//! Must only run after a full resolution: only then has every manifest
+//! streamed through the versions overrider, so the collected declared
+//! ranges are complete. The frozen-lockfile and optimistic-repeat
+//! install paths never run this check.
+
+use crate::overrides::parse_declared_range;
+use node_semver::Version;
+use pacquet_config_parse_overrides::VersionOverride;
+use pacquet_reporter::{GlobalLog, LogEvent, LogLevel, Reporter};
+use pacquet_resolving_resolver_base::{ResolveOptions, Resolver, WantedDependency};
+use std::{
+    collections::{HashMap, HashSet},
+    future::Future,
+};
+
+/// A convergence override whose value can be raised: `best` is newer
+/// than `current_value` and satisfies every declared range of `name`.
+pub(crate) struct StaleConvergenceOverride {
+    pub name: String,
+    pub current_value: String,
+    pub best: Version,
+}
+
+/// For each convergence override, resolve every collected declared
+/// range through `resolve_range` and report the override as stale when
+/// a resolved version newer than the override's value satisfies every
+/// collected range — a strictly better convergence.
+///
+/// A range that fails to resolve contributes no candidate but still
+/// participates in the satisfies-every-range check, so failures can
+/// only suppress the verdict, never fabricate one.
+pub(crate) async fn find_stale_convergence_overrides<ResolveRange, ResolveRangeFuture>(
+    parsed_overrides: &[VersionOverride],
+    converge_declared_ranges: &HashMap<String, HashSet<String>>,
+    resolve_range: ResolveRange,
+) -> Vec<StaleConvergenceOverride>
+where
+    ResolveRange: Fn(String, String) -> ResolveRangeFuture,
+    ResolveRangeFuture: Future<Output = Option<Version>>,
+{
+    let mut stale = Vec::new();
+    for override_entry in parsed_overrides.iter().filter(|entry| entry.converge) {
+        let name = &override_entry.target_pkg.name;
+        let Some(ranges) = converge_declared_ranges.get(name) else { continue };
+        let Ok(current) = Version::parse(&override_entry.new_bare_specifier) else { continue };
+        // The collector only records parseable ranges, so a `None`
+        // here is unreachable in practice; bailing out keeps the
+        // "satisfies EVERY collected range" guarantee if it ever
+        // happens.
+        let Some(parsed_ranges) =
+            ranges.iter().map(|range| parse_declared_range(range)).collect::<Option<Vec<_>>>()
+        else {
+            continue;
+        };
+        if parsed_ranges.is_empty() {
+            continue;
+        }
+        let mut candidates = Vec::new();
+        for range in ranges {
+            if let Some(version) = resolve_range(name.clone(), range.clone()).await {
+                candidates.push(version);
+            }
+        }
+        candidates.retain(|candidate| *candidate > current);
+        candidates.sort_unstable_by(|lhs, rhs| rhs.cmp(lhs));
+        let best = candidates
+            .into_iter()
+            .find(|candidate| parsed_ranges.iter().all(|range| range.satisfies(candidate)));
+        if let Some(best) = best {
+            stale.push(StaleConvergenceOverride {
+                name: name.clone(),
+                current_value: override_entry.new_bare_specifier.clone(),
+                best,
+            });
+        }
+    }
+    stale
+}
+
+/// Resolve the best version `range` admits for `name` through the
+/// resolver chain. Metadata is already cached from the resolution that
+/// just ran, and the release-age policy carried by `opts` applies, so
+/// the answer is a version the resolver would actually pick. `None`
+/// when the range fails to resolve or the pick violates a resolution
+/// policy.
+pub(crate) async fn resolve_best_admitted_version(
+    resolver: &dyn Resolver,
+    opts: &ResolveOptions,
+    name: String,
+    range: String,
+) -> Option<Version> {
+    let wanted = WantedDependency {
+        alias: Some(name),
+        bare_specifier: Some(range),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, opts).await.ok().flatten()?;
+    if result.policy_violation.is_some() {
+        return None;
+    }
+    result.name_ver.map(|name_ver| name_ver.suffix)
+}
+
+/// Emit the `pnpm:global` warning for each stale convergence override
+/// — the counterpart of pnpm's `globalWarn` emission, parsed by the
+/// shared default reporter.
+pub(crate) fn warn_stale_convergence_overrides<Reporter: self::Reporter>(
+    stale: &[StaleConvergenceOverride],
+) {
+    for entry in stale {
+        Reporter::emit(&LogEvent::Global(GlobalLog {
+            level: LogLevel::Warn,
+            message: stale_convergence_override_warning(entry),
+        }));
+    }
+}
+
+fn stale_convergence_override_warning(
+    StaleConvergenceOverride { name, current_value, best }: &StaleConvergenceOverride,
+) -> String {
+    format!(
+        "The convergence override \"{name}@\": \"{current_value}\" is stale: every declared range of {name} also admits {best}. Change the override's value to {best} in pnpm-workspace.yaml, or remove the override and run \"pnpm dedupe\"."
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/package-manager/src/warn_on_stale_convergence_overrides.rs
+++ b/pnpm/crates/package-manager/src/warn_on_stale_convergence_overrides.rs
@@ -13,10 +13,12 @@
 //! install paths never run this check.
 
 use crate::overrides::parse_declared_range;
+use futures_util::future;
 use node_semver::Version;
 use pacquet_config_parse_overrides::VersionOverride;
 use pacquet_reporter::{GlobalLog, LogEvent, LogLevel, Reporter};
 use pacquet_resolving_resolver_base::{ResolveOptions, Resolver, WantedDependency};
+use pipe_trait::Pipe;
 use std::{
     collections::{HashMap, HashSet},
     future::Future,
@@ -64,12 +66,14 @@ where
         if parsed_ranges.is_empty() {
             continue;
         }
-        let mut candidates = Vec::new();
-        for range in ranges {
-            if let Some(version) = resolve_range(name.clone(), range.clone()).await {
-                candidates.push(version);
-            }
-        }
+        let mut candidates: Vec<Version> = ranges
+            .iter()
+            .map(|range| resolve_range(name.clone(), range.clone()))
+            .pipe(future::join_all)
+            .await
+            .into_iter()
+            .flatten()
+            .collect();
         candidates.retain(|candidate| *candidate > current);
         candidates.sort_unstable_by(|lhs, rhs| rhs.cmp(lhs));
         let best = candidates

--- a/pnpm/crates/package-manager/src/warn_on_stale_convergence_overrides.rs
+++ b/pnpm/crates/package-manager/src/warn_on_stale_convergence_overrides.rs
@@ -128,7 +128,7 @@ fn stale_convergence_override_warning(
     StaleConvergenceOverride { name, current_value, best }: &StaleConvergenceOverride,
 ) -> String {
     format!(
-        "The convergence override \"{name}@\": \"{current_value}\" is stale: every declared range of {name} also admits {best}. Change the override's value to {best} in pnpm-workspace.yaml, or remove the override and run \"pnpm dedupe\"."
+        r#"The convergence override "{name}@": "{current_value}" is stale: every declared range of {name} also admits {best}. Change the override's value to {best} in pnpm-workspace.yaml, or remove the override and run "pnpm dedupe"."#,
     )
 }
 

--- a/pnpm/crates/package-manager/src/warn_on_stale_convergence_overrides/tests.rs
+++ b/pnpm/crates/package-manager/src/warn_on_stale_convergence_overrides/tests.rs
@@ -105,6 +105,6 @@ fn warning_message_matches_the_shared_wording() {
     eprintln!("MESSAGE:\n{message}\n");
     assert_eq!(
         message,
-        "The convergence override \"form-data@\": \"4.0.6\" is stale: every declared range of form-data also admits 4.0.9. Change the override's value to 4.0.9 in pnpm-workspace.yaml, or remove the override and run \"pnpm dedupe\".",
+        r#"The convergence override "form-data@": "4.0.6" is stale: every declared range of form-data also admits 4.0.9. Change the override's value to 4.0.9 in pnpm-workspace.yaml, or remove the override and run "pnpm dedupe"."#,
     );
 }

--- a/pnpm/crates/package-manager/src/warn_on_stale_convergence_overrides/tests.rs
+++ b/pnpm/crates/package-manager/src/warn_on_stale_convergence_overrides/tests.rs
@@ -1,0 +1,110 @@
+use super::{
+    StaleConvergenceOverride, find_stale_convergence_overrides, stale_convergence_override_warning,
+};
+use node_semver::Version;
+use pacquet_catalogs_types::Catalogs;
+use pacquet_config_parse_overrides::{VersionOverride, parse_overrides};
+use std::collections::{HashMap, HashSet};
+
+fn converge_override(name: &str, value: &str) -> Vec<VersionOverride> {
+    let input = HashMap::from([(format!("{name}@"), value.to_string())]);
+    parse_overrides(&input, &Catalogs::new()).expect("parse_overrides fixture")
+}
+
+fn ranges(name: &str, declared: &[&str]) -> HashMap<String, HashSet<String>> {
+    HashMap::from([(name.to_string(), declared.iter().map(|range| (*range).to_string()).collect())])
+}
+
+/// Canned per-range registry answers standing in for the resolver: a
+/// missing entry models a range that fails to resolve.
+fn canned(answers: &[(&str, &str)]) -> impl Fn(String, String) -> BestVersionFuture {
+    let answers: HashMap<String, Version> = answers
+        .iter()
+        .map(|(range, version)| ((*range).to_string(), Version::parse(version).unwrap()))
+        .collect();
+    move |_name, range| {
+        let version = answers.get(&range).cloned();
+        Box::pin(async move { version })
+    }
+}
+
+type BestVersionFuture = std::pin::Pin<Box<dyn std::future::Future<Output = Option<Version>>>>;
+
+#[tokio::test]
+async fn reports_the_best_newer_version_admitted_by_every_range() {
+    let overrides = converge_override("foo", "4.0.6");
+    let declared = ranges("foo", &["^4.0.5", "^4.0.0"]);
+    let stale = find_stale_convergence_overrides(
+        &overrides,
+        &declared,
+        canned(&[("^4.0.5", "4.0.9"), ("^4.0.0", "4.0.9")]),
+    )
+    .await;
+
+    assert_eq!(stale.len(), 1);
+    let StaleConvergenceOverride { name, current_value, best } = &stale[0];
+    assert_eq!(name, "foo");
+    assert_eq!(current_value, "4.0.6");
+    assert_eq!(best.to_string(), "4.0.9");
+}
+
+#[tokio::test]
+async fn silent_when_no_candidate_satisfies_every_range() {
+    let overrides = converge_override("foo", "4.0.6");
+    let declared = ranges("foo", &["^4.0.5", "^3.0.0"]);
+    let stale = find_stale_convergence_overrides(
+        &overrides,
+        &declared,
+        canned(&[("^4.0.5", "4.0.9"), ("^3.0.0", "3.5.0")]),
+    )
+    .await;
+
+    assert!(stale.is_empty(), "no single version converges ^4.0.5 and ^3.0.0");
+}
+
+#[tokio::test]
+async fn silent_when_no_candidate_is_newer_than_the_override_value() {
+    let overrides = converge_override("foo", "4.0.6");
+    let declared = ranges("foo", &["^4.0.0"]);
+    let stale =
+        find_stale_convergence_overrides(&overrides, &declared, canned(&[("^4.0.0", "4.0.6")]))
+            .await;
+
+    assert!(stale.is_empty(), "the override already pins the best admitted version");
+}
+
+#[tokio::test]
+async fn unresolved_range_stays_in_the_satisfies_check() {
+    let overrides = converge_override("foo", "4.0.6");
+    // `4.0.6` (an exact declared range) fails to resolve — it yields no
+    // candidate, but the `^4.0.5` candidate must still satisfy it.
+    let declared = ranges("foo", &["^4.0.5", "4.0.6"]);
+    let stale =
+        find_stale_convergence_overrides(&overrides, &declared, canned(&[("^4.0.5", "4.0.9")]))
+            .await;
+
+    assert!(stale.is_empty(), "4.0.9 does not satisfy the declared exact range 4.0.6");
+}
+
+#[tokio::test]
+async fn silent_when_no_declared_range_was_collected() {
+    let overrides = converge_override("foo", "4.0.6");
+    let stale = find_stale_convergence_overrides(&overrides, &HashMap::new(), canned(&[])).await;
+
+    assert!(stale.is_empty(), "nothing declared the package, so nothing can be converged");
+}
+
+#[test]
+fn warning_message_matches_the_shared_wording() {
+    let entry = StaleConvergenceOverride {
+        name: "form-data".to_string(),
+        current_value: "4.0.6".to_string(),
+        best: Version::parse("4.0.9").unwrap(),
+    };
+    let message = stale_convergence_override_warning(&entry);
+    eprintln!("MESSAGE:\n{message}\n");
+    assert_eq!(
+        message,
+        "The convergence override \"form-data@\": \"4.0.6\" is stale: every declared range of form-data also admits 4.0.9. Change the override's value to 4.0.9 in pnpm-workspace.yaml, or remove the override and run \"pnpm dedupe\".",
+    );
+}

--- a/pnpm11/config/parse-overrides/package.json
+++ b/pnpm11/config/parse-overrides/package.json
@@ -34,11 +34,13 @@
     "@pnpm/catalogs.resolver": "workspace:*",
     "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/error": "workspace:*",
-    "@pnpm/resolving.parse-wanted-dependency": "workspace:*"
+    "@pnpm/resolving.parse-wanted-dependency": "workspace:*",
+    "semver": "catalog:"
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
-    "@pnpm/config.parse-overrides": "workspace:*"
+    "@pnpm/config.parse-overrides": "workspace:*",
+    "@types/semver": "catalog:"
   },
   "engines": {
     "node": ">=22.13"

--- a/pnpm11/config/parse-overrides/src/index.ts
+++ b/pnpm11/config/parse-overrides/src/index.ts
@@ -2,6 +2,7 @@ import { matchCatalogResolveResult, resolveFromCatalog } from '@pnpm/catalogs.re
 import type { Catalogs } from '@pnpm/catalogs.types'
 import { PnpmError } from '@pnpm/error'
 import { parseWantedDependency } from '@pnpm/resolving.parse-wanted-dependency'
+import semver from 'semver'
 
 const DELIMITER_REGEX = /[^ |@]>/
 
@@ -10,6 +11,13 @@ export interface VersionOverride {
   parentPkg?: PackageSelector
   targetPkg: PackageSelector
   newBareSpecifier: string
+  /**
+   * True for empty-range selectors (`"pkg@"`): a convergence override. It
+   * applies to a dependency edge only when `newBareSpecifier` (always an
+   * exact version) satisfies the edge's declared range, so applying it can
+   * never violate a consumer's range.
+   */
+  converge?: boolean
 }
 
 export interface PackageSelector {
@@ -35,12 +43,27 @@ export function parseOverrides (
           throw new PnpmError('CATALOG_IN_OVERRIDES', `Could not resolve a catalog in the overrides: ${error.message}`)
         },
       })
-      return {
+      const override = {
         selector,
         newBareSpecifier: resolvedCatalog ?? newBareSpecifier,
         ...result,
       }
+      return markConvergeOverride(override)
     })
+}
+
+function markConvergeOverride (override: VersionOverride): VersionOverride {
+  const emptyRangeInParentChildSelector = override.parentPkg != null &&
+    (override.parentPkg.bareSpecifier === '' || override.targetPkg.bareSpecifier === '')
+  if (emptyRangeInParentChildSelector) {
+    throw new PnpmError('INVALID_CONVERGENCE_OVERRIDE', `Cannot use an empty range in the "${override.selector}" selector: convergence overrides ("pkg@") cannot be combined with parent>child selectors`)
+  }
+  if (override.targetPkg.bareSpecifier !== '') return override
+  if (semver.valid(override.newBareSpecifier) == null) {
+    throw new PnpmError('INVALID_CONVERGENCE_OVERRIDE', `The value of the convergence override "${override.selector}" must be an exact version, but got "${override.newBareSpecifier}"`)
+  }
+  override.converge = true
+  return override
 }
 
 export function parsePkgAndParentSelector (selector: string): Pick<VersionOverride, 'parentPkg' | 'targetPkg'> {

--- a/pnpm11/config/parse-overrides/test/index.ts
+++ b/pnpm11/config/parse-overrides/test/index.ts
@@ -52,3 +52,46 @@ test('parseOverrides() throws an exception on invalid selector', () => {
   expect(() => parseOverrides({ '%': '2' }, {})).toThrow('Cannot parse the "%" selector')
   expect(() => parseOverrides({ 'foo > bar': '2' }, {})).toThrow('Cannot parse the "foo > bar" selector')
 })
+
+test.each([
+  ['foo@', '1.2.3'],
+  ['@scope/foo@', '2.0.0-beta.1'],
+])('parseOverrides() parses the "%s" convergence override', (selector, version) => {
+  expect(parseOverrides({ [selector]: version }, {})).toEqual([
+    {
+      selector,
+      newBareSpecifier: version,
+      targetPkg: { name: selector.slice(0, -1), bareSpecifier: '' },
+      converge: true,
+    },
+  ])
+})
+
+test('parseOverrides() resolves a catalog value of a convergence override', () => {
+  expect(parseOverrides({ 'foo@': 'catalog:' }, { default: { foo: '1.2.3' } })).toEqual([
+    {
+      selector: 'foo@',
+      newBareSpecifier: '1.2.3',
+      targetPkg: { name: 'foo', bareSpecifier: '' },
+      converge: true,
+    },
+  ])
+})
+
+test.each([
+  ['^1.2.3'],
+  ['latest'],
+  ['-'],
+  ['link:../foo'],
+  ['npm:bar@1.2.3'],
+])('parseOverrides() throws when the value of a convergence override is "%s"', (value) => {
+  expect(() => parseOverrides({ 'foo@': value }, {})).toThrow(
+    `The value of the convergence override "foo@" must be an exact version, but got "${value}"`
+  )
+})
+
+test('parseOverrides() throws when an empty range is used in a parent>child selector', () => {
+  expect(() => parseOverrides({ 'bar>foo@': '1.2.3' }, {})).toThrow(
+    'Cannot use an empty range in the "bar>foo@" selector'
+  )
+})

--- a/pnpm11/hooks/read-package-hook/src/createReadPackageHook.ts
+++ b/pnpm11/hooks/read-package-hook/src/createReadPackageHook.ts
@@ -9,7 +9,7 @@ import { isEmpty, pipeWith } from 'ramda'
 
 import { createOptionalDependenciesRemover } from './createOptionalDependenciesRemover.js'
 import { createPackageExtender } from './createPackageExtender.js'
-import { createVersionsOverrider, type VersionOverrideWithoutRawSelector } from './createVersionsOverrider.js'
+import { createVersionsOverrider, type CreateVersionsOverriderOptions, type VersionOverrideWithoutRawSelector } from './createVersionsOverrider.js'
 
 type PackageExtensionField = 'dependencies' | 'optionalDependencies' | 'peerDependencies' | 'peerDependenciesMeta'
 
@@ -44,6 +44,7 @@ export function createReadPackageHook (
     ignoreCompatibilityDb,
     lockfileDir,
     overrides,
+    convergeDeclaredRanges,
     ignoredOptionalDependencies,
     packageExtensions,
     readPackageHook,
@@ -51,6 +52,7 @@ export function createReadPackageHook (
     ignoreCompatibilityDb?: boolean
     lockfileDir: string
     overrides?: VersionOverrideWithoutRawSelector[]
+    convergeDeclaredRanges?: CreateVersionsOverriderOptions['convergeDeclaredRanges']
     ignoredOptionalDependencies?: string[]
     packageExtensions?: Record<string, PackageExtension>
     readPackageHook?: ReadPackageHook[] | ReadPackageHook
@@ -70,7 +72,7 @@ export function createReadPackageHook (
     hooks.push(readPackageHook)
   }
   if (!isEmpty(overrides ?? {})) {
-    hooks.push(createVersionsOverrider(overrides!, lockfileDir))
+    hooks.push(createVersionsOverrider(overrides!, lockfileDir, { convergeDeclaredRanges }))
   }
   if (ignoredOptionalDependencies && !isEmpty(ignoredOptionalDependencies)) {
     hooks.push(createOptionalDependenciesRemover(ignoredOptionalDependencies))

--- a/pnpm11/hooks/read-package-hook/src/createVersionsOverrider.ts
+++ b/pnpm11/hooks/read-package-hook/src/createVersionsOverrider.ts
@@ -11,16 +11,30 @@ import { isIntersectingRange } from './isIntersectingRange.js'
 
 export type VersionOverrideWithoutRawSelector = Omit<VersionOverrideBase, 'selector'>
 
+export interface CreateVersionsOverriderOptions {
+  /**
+   * Populated with every declared semver range seen for packages that have a
+   * convergence override, whether or not the override's version satisfied it.
+   * Feeds the staleness check for convergence overrides after a full
+   * resolution. Edges claimed by an explicit override are not recorded — the
+   * convergence override never governs them.
+   */
+  convergeDeclaredRanges?: Map<string, Set<string>>
+}
+
 export function createVersionsOverrider (
   overrides: VersionOverrideWithoutRawSelector[],
-  rootDir: string
+  rootDir: string,
+  opts?: CreateVersionsOverriderOptions
 ): ReadPackageHook {
+  const [convergeOverrides, explicitOverrides] = partition(({ converge }) => converge === true, overrides)
   const [versionOverrides, genericVersionOverrides] = partition(({ parentPkg }) => parentPkg != null,
-    overrides.map((override) => ({
+    explicitOverrides.map((override) => ({
       ...override,
       localTarget: createLocalTarget(override, rootDir),
     }))
   ) as [VersionOverrideWithParent[], VersionOverride[]]
+  const convergeVersions = new Map(convergeOverrides.map((override) => [override.targetPkg.name, override.newBareSpecifier]))
   return ((manifest: PackageManifest, dir?: string) => {
     const versionOverridesWithParent = versionOverrides.filter(({ parentPkg }) => {
       return (
@@ -28,7 +42,10 @@ export function createVersionsOverrider (
         (!parentPkg.bareSpecifier || semver.satisfies(manifest.version, parentPkg.bareSpecifier))
       )
     })
-    overrideDepsOfPkg({ manifest, dir }, versionOverridesWithParent, genericVersionOverrides)
+    overrideDepsOfPkg({ manifest, dir }, versionOverridesWithParent, genericVersionOverrides, {
+      convergeVersions,
+      convergeDeclaredRanges: opts?.convergeDeclaredRanges,
+    })
 
     return manifest
   }) as ReadPackageHook
@@ -68,10 +85,11 @@ interface VersionOverrideWithParent extends VersionOverride {
 function overrideDepsOfPkg (
   { manifest, dir }: { manifest: PackageManifest, dir: string | undefined },
   versionOverrides: VersionOverrideWithParent[],
-  genericVersionOverrides: VersionOverride[]
+  genericVersionOverrides: VersionOverride[],
+  convergeOpts: ConvergeOptions
 ): void {
   const { dependencies, optionalDependencies, devDependencies, peerDependencies } = manifest
-  const _overrideDeps = overrideDeps.bind(null, { versionOverrides, genericVersionOverrides, dir })
+  const _overrideDeps = overrideDeps.bind(null, { versionOverrides, genericVersionOverrides, dir, convergeOpts })
   for (const deps of [dependencies, optionalDependencies, devDependencies]) {
     if (deps) {
       _overrideDeps(deps, undefined)
@@ -83,11 +101,17 @@ function overrideDepsOfPkg (
   }
 }
 
+interface ConvergeOptions {
+  convergeVersions: Map<string, string>
+  convergeDeclaredRanges?: Map<string, Set<string>>
+}
+
 function overrideDeps (
-  { versionOverrides, genericVersionOverrides, dir }: {
+  { versionOverrides, genericVersionOverrides, dir, convergeOpts }: {
     versionOverrides: VersionOverrideWithParent[]
     genericVersionOverrides: VersionOverride[]
     dir: string | undefined
+    convergeOpts: ConvergeOptions
   },
   deps: Dependencies,
   peerDeps: Dependencies | undefined
@@ -106,7 +130,10 @@ function overrideDeps (
           targetPkg.name === name && isIntersectingRange(targetPkg.bareSpecifier, bareSpecifier)
       )
     )
-    if (!versionOverride) continue
+    if (!versionOverride) {
+      convergeDep(convergeOpts, { deps, peerDeps }, name, bareSpecifier)
+      continue
+    }
 
     if (versionOverride.newBareSpecifier === '-') {
       if (peerDeps) {
@@ -125,6 +152,37 @@ function overrideDeps (
     } else if (isValidPeerRange(newBareSpecifier)) {
       peerDeps[versionOverride.targetPkg.name] = newBareSpecifier
     }
+  }
+}
+
+/**
+ * A convergence override (`"pkg@": "<version>"`) rewrites a dependency edge
+ * only when its version satisfies the edge's declared range, so incompatible
+ * consumers keep their own resolution. Only plain semver ranges participate:
+ * `workspace:`, `catalog:`, `npm:`, git/URL, and dist-tag specifiers have no
+ * defined "satisfies" relation and are left untouched.
+ */
+function convergeDep (
+  { convergeVersions, convergeDeclaredRanges }: ConvergeOptions,
+  { deps, peerDeps }: { deps: Dependencies, peerDeps: Dependencies | undefined },
+  name: string,
+  bareSpecifier: string
+): void {
+  const convergeVersion = convergeVersions.get(name)
+  if (convergeVersion == null || semver.validRange(bareSpecifier, true) == null) return
+  if (convergeDeclaredRanges != null) {
+    let ranges = convergeDeclaredRanges.get(name)
+    if (ranges == null) {
+      ranges = new Set()
+      convergeDeclaredRanges.set(name, ranges)
+    }
+    ranges.add(bareSpecifier)
+  }
+  if (!semver.satisfies(convergeVersion, bareSpecifier, true)) return
+  if (peerDeps == null) {
+    deps[name] = convergeVersion
+  } else {
+    peerDeps[name] = convergeVersion
   }
 }
 

--- a/pnpm11/hooks/read-package-hook/test/createVersionOverrider.test.ts
+++ b/pnpm11/hooks/read-package-hook/test/createVersionOverrider.test.ts
@@ -766,3 +766,142 @@ test('createVersionsOverrider() moves invalid versions from peerDependencies to 
     },
   })
 })
+
+test('createVersionsOverrider() convergence override rewrites only edges its version satisfies', () => {
+  const overrider = createVersionsOverrider([
+    {
+      targetPkg: { name: 'form-data', bareSpecifier: '' },
+      newBareSpecifier: '4.0.6',
+      converge: true,
+    },
+  ], process.cwd())
+  expect(overrider({
+    dependencies: {
+      'form-data': '^4.0.5',
+    },
+    optionalDependencies: {
+      'other-form-data': '^3.0.0',
+    },
+  })).toStrictEqual({
+    dependencies: {
+      'form-data': '4.0.6',
+    },
+    optionalDependencies: {
+      'other-form-data': '^3.0.0',
+    },
+  })
+  // Incompatible with 4.0.6, so the edge keeps its own resolution.
+  expect(overrider({
+    dependencies: {
+      'form-data': '^3.0.0',
+    },
+  })).toStrictEqual({
+    dependencies: {
+      'form-data': '^3.0.0',
+    },
+  })
+})
+
+test('createVersionsOverrider() convergence override skips non-range specifiers', () => {
+  const overrider = createVersionsOverrider([
+    {
+      targetPkg: { name: 'foo', bareSpecifier: '' },
+      newBareSpecifier: '4.0.6',
+      converge: true,
+    },
+  ], process.cwd())
+  expect(overrider({
+    dependencies: {
+      foo: 'github:org/foo',
+    },
+    devDependencies: {
+      foo: 'workspace:^',
+    },
+    optionalDependencies: {
+      foo: 'latest',
+    },
+  })).toStrictEqual({
+    dependencies: {
+      foo: 'github:org/foo',
+    },
+    devDependencies: {
+      foo: 'workspace:^',
+    },
+    optionalDependencies: {
+      foo: 'latest',
+    },
+  })
+})
+
+test('createVersionsOverrider() convergence override rewrites peer dependencies it satisfies', () => {
+  const overrider = createVersionsOverrider([
+    {
+      targetPkg: { name: 'foo', bareSpecifier: '' },
+      newBareSpecifier: '4.0.6',
+      converge: true,
+    },
+  ], process.cwd())
+  expect(overrider({
+    peerDependencies: {
+      foo: '^4.0.0',
+    },
+  })).toStrictEqual({
+    dependencies: {},
+    peerDependencies: {
+      foo: '4.0.6',
+    },
+  })
+})
+
+test('createVersionsOverrider() explicit overrides win over a convergence override', () => {
+  const overrider = createVersionsOverrider([
+    {
+      targetPkg: { name: 'foo', bareSpecifier: '^4.0.0' },
+      newBareSpecifier: '4.0.9',
+    },
+    {
+      targetPkg: { name: 'foo', bareSpecifier: '' },
+      newBareSpecifier: '4.0.6',
+      converge: true,
+    },
+  ], process.cwd())
+  expect(overrider({
+    dependencies: {
+      foo: '^4.0.5',
+      bar: '1.0.0',
+    },
+  })).toStrictEqual({
+    dependencies: {
+      foo: '4.0.9',
+      bar: '1.0.0',
+    },
+  })
+})
+
+test('createVersionsOverrider() collects declared ranges of convergence-governed packages', () => {
+  const convergeDeclaredRanges = new Map<string, Set<string>>()
+  const overrider = createVersionsOverrider([
+    {
+      targetPkg: { name: 'foo', bareSpecifier: '' },
+      newBareSpecifier: '4.0.6',
+      converge: true,
+    },
+  ], process.cwd(), { convergeDeclaredRanges })
+  overrider({
+    dependencies: {
+      foo: '^4.0.5',
+      bar: '^1.0.0',
+    },
+  })
+  overrider({
+    dependencies: {
+      foo: '^3.0.0',
+    },
+    devDependencies: {
+      foo: 'workspace:^',
+    },
+  })
+  expect(convergeDeclaredRanges).toStrictEqual(new Map([
+    ['foo', new Set(['^4.0.5', '^3.0.0'])],
+  ]))
+})

--- a/pnpm11/installing/deps-installer/package.json
+++ b/pnpm11/installing/deps-installer/package.json
@@ -71,6 +71,7 @@
     "@pnpm/config.matcher": "workspace:*",
     "@pnpm/config.normalize-registries": "workspace:*",
     "@pnpm/config.parse-overrides": "workspace:*",
+    "@pnpm/config.version-policy": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",
     "@pnpm/crypto.hash": "workspace:*",

--- a/pnpm11/installing/deps-installer/src/install/extendInstallOptions.ts
+++ b/pnpm11/installing/deps-installer/src/install/extendInstallOptions.ts
@@ -394,6 +394,12 @@ const defaults = (opts: InstallOptions): StrictInstallOptions => {
 export interface ProcessedInstallOptions extends StrictInstallOptions {
   readPackageHook?: ReadPackageHook
   parsedOverrides: VersionOverride[]
+  /**
+   * Present when the overrides contain convergence entries (`"pkg@"`). The
+   * versions overrider fills it with every declared semver range it sees for
+   * those packages; the staleness check reads it after a full resolution.
+   */
+  convergeDeclaredRanges?: Map<string, Set<string>>
 }
 
 export function extendOptions (
@@ -414,10 +420,14 @@ export function extendOptions (
     storeDir: defaultOpts.storeDir,
     parsedOverrides: parseOverrides(opts.overrides ?? {}, opts.catalogs ?? {}),
   }
+  if (extendedOpts.parsedOverrides.some(({ converge }) => converge)) {
+    extendedOpts.convergeDeclaredRanges = new Map()
+  }
   extendedOpts.readPackageHook = createReadPackageHook({
     ignoreCompatibilityDb: extendedOpts.ignoreCompatibilityDb,
     readPackageHook: extendedOpts.hooks?.readPackage,
     overrides: extendedOpts.parsedOverrides,
+    convergeDeclaredRanges: extendedOpts.convergeDeclaredRanges,
     lockfileDir: extendedOpts.lockfileDir,
     packageExtensions: extendedOpts.packageExtensions,
     ignoredOptionalDependencies: extendedOpts.ignoredOptionalDependencies,

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -106,6 +106,7 @@ import { linkPackages } from './link.js'
 import { reportPeerDependencyIssues } from './reportPeerDependencyIssues.js'
 import { validateModules } from './validateModules.js'
 import { verifyLockfileResolutions } from './verifyLockfileResolutions.js'
+import { warnOnStaleConvergenceOverrides } from './warnOnStaleConvergenceOverrides.js'
 import { writeLockfilesAndRecordVerified } from './writeLockfilesAndRecordVerified.js'
 import { writeWantedLockfileAndRecordVerified } from './writeWantedLockfileAndRecordVerified.js'
 
@@ -1617,6 +1618,20 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
       handleResolutionPolicyViolations: opts.handleResolutionPolicyViolations,
     }
   )
+  // Only a full resolution walks every manifest through the versions
+  // overrider, making the collected declared ranges complete enough for the
+  // staleness verdict; partial resolutions must stay silent to avoid false
+  // positives from unseen ranges.
+  if (opts.convergeDeclaredRanges != null && (forceFullResolution || opts.dedupe)) {
+    await warnOnStaleConvergenceOverrides({
+      convergeDeclaredRanges: opts.convergeDeclaredRanges,
+      parsedOverrides: opts.parsedOverrides,
+      requestPackage: opts.storeController.requestPackage,
+      lockfileDir: opts.lockfileDir,
+      minimumReleaseAge: opts.minimumReleaseAge,
+      minimumReleaseAgeExclude: opts.minimumReleaseAgeExclude,
+    })
+  }
   if (!opts.include.optionalDependencies || !opts.include.devDependencies || !opts.include.dependencies) {
     linkedDependenciesByProjectId = mapValues(
       (linkedDeps) => linkedDeps.filter((linkedDep) =>

--- a/pnpm11/installing/deps-installer/src/install/warnOnStaleConvergenceOverrides.ts
+++ b/pnpm11/installing/deps-installer/src/install/warnOnStaleConvergenceOverrides.ts
@@ -1,0 +1,68 @@
+import type { VersionOverride } from '@pnpm/config.parse-overrides'
+import { getPublishedByPolicy } from '@pnpm/config.version-policy'
+import { globalWarn } from '@pnpm/logger'
+import type { RequestPackageFunction } from '@pnpm/store.controller-types'
+import semver from 'semver'
+
+export interface WarnOnStaleConvergenceOverridesOptions {
+  convergeDeclaredRanges: Map<string, Set<string>>
+  parsedOverrides: VersionOverride[]
+  requestPackage: RequestPackageFunction
+  lockfileDir: string
+  minimumReleaseAge?: number
+  minimumReleaseAgeExclude?: string[]
+}
+
+/**
+ * A convergence override's value is derived state — the best version that
+ * converges the currently declared ranges. It goes stale when dependents
+ * start declaring ranges that admit newer versions: the override then keeps
+ * the edges it governs on the old version while newer edges resolve past it,
+ * producing the duplication the entry was written to prevent.
+ *
+ * Must only run after a full resolution: only then has every manifest
+ * streamed through the versions overrider, so `convergeDeclaredRanges` holds
+ * the complete set of declared ranges. For each convergence override this
+ * resolves every declared range to the best version it admits (metadata is
+ * already cached from the resolution that just ran, and the release-age
+ * policy applies, so the recommendation is a version the resolver would
+ * actually pick) and warns when a version newer than the override's value
+ * satisfies every declared range — a strictly better convergence.
+ *
+ * A range that fails to resolve contributes no candidate but still
+ * participates in the satisfies-every-range check, so failures can only
+ * suppress the warning, never fabricate one.
+ */
+export async function warnOnStaleConvergenceOverrides (opts: WarnOnStaleConvergenceOverridesOptions): Promise<void> {
+  const convergeOverrides = opts.parsedOverrides.filter(({ converge }) => converge)
+  if (convergeOverrides.length === 0) return
+  const { publishedBy, publishedByExclude } = getPublishedByPolicy(opts)
+  await Promise.all(convergeOverrides.map(async (override) => {
+    const name = override.targetPkg.name
+    const ranges = opts.convergeDeclaredRanges.get(name)
+    if (ranges == null || ranges.size === 0) return
+    const candidates = await Promise.all([...ranges].map(async (range) => {
+      try {
+        const response = await opts.requestPackage({ alias: name, bareSpecifier: range }, {
+          downloadPriority: 0,
+          lockfileDir: opts.lockfileDir,
+          projectDir: opts.lockfileDir,
+          preferredVersions: {},
+          skipFetch: true,
+          publishedBy,
+          publishedByExclude,
+        })
+        if (response.body.policyViolation != null) return undefined
+        return response.body.manifest?.version
+      } catch {
+        return undefined
+      }
+    }))
+    const best = candidates
+      .filter((version): version is string => version != null && semver.gt(version, override.newBareSpecifier))
+      .sort(semver.rcompare)
+      .find((version) => [...ranges].every((range) => semver.satisfies(version, range, true)))
+    if (best == null) return
+    globalWarn(`The convergence override "${name}@": "${override.newBareSpecifier}" is stale: every declared range of ${name} also admits ${best}. Change the override's value to ${best} in pnpm-workspace.yaml, or remove the override and run "pnpm dedupe".`)
+  }))
+}

--- a/pnpm11/installing/deps-installer/test/install/convergenceOverrides.ts
+++ b/pnpm11/installing/deps-installer/test/install/convergenceOverrides.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@jest/globals'
+import { addDependenciesToPackage } from '@pnpm/installing.deps-installer'
+import { streamParser } from '@pnpm/logger'
+import { prepareEmpty } from '@pnpm/prepare'
+import { addDistTag } from '@pnpm/testing.registry-mock'
+
+import { testDefaults } from '../utils/index.js'
+
+test('convergence override rewrites only the edges its version satisfies', async () => {
+  const project = prepareEmpty()
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+
+  const overrides = {
+    '@pnpm.e2e/dep-of-pkg-with-1-dep@': '100.0.0',
+  }
+  await addDependenciesToPackage({},
+    ['@pnpm.e2e/pkg-with-1-dep@100.0.0', '@pnpm.e2e/dep-of-pkg-with-1-dep@101.0.0'],
+    testDefaults({ overrides })
+  )
+
+  const lockfile = project.readLockfile()
+  // The transitive edge (declared as ^100.0.0) is governed: it converges on
+  // 100.0.0 instead of resolving to the latest 100.1.0.
+  expect(lockfile.snapshots['@pnpm.e2e/pkg-with-1-dep@100.0.0'].dependencies?.['@pnpm.e2e/dep-of-pkg-with-1-dep']).toBe('100.0.0')
+  // The direct dependency pinned to an incompatible version keeps its own
+  // resolution.
+  expect(lockfile.packages).toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@101.0.0'])
+  expect(lockfile.overrides).toStrictEqual({
+    '@pnpm.e2e/dep-of-pkg-with-1-dep@': '100.0.0',
+  })
+})
+
+test('a stale convergence override is reported with the version every declared range admits', async () => {
+  prepareEmpty()
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+
+  const overrides = {
+    '@pnpm.e2e/dep-of-pkg-with-1-dep@': '100.0.0',
+  }
+  const warnings: string[] = []
+  const reporter = (log: { level?: string, message?: string }) => {
+    if (log.level === 'warn' && log.message != null) warnings.push(log.message)
+  }
+  streamParser.on('data', reporter as never)
+  try {
+    // The only declared range is ^100.0.0 (from pkg-with-1-dep), which also
+    // admits the latest 100.1.0, so the override is stale.
+    await addDependenciesToPackage({},
+      ['@pnpm.e2e/pkg-with-1-dep@100.0.0'],
+      testDefaults({ overrides })
+    )
+  } finally {
+    streamParser.removeListener('data', reporter as never)
+  }
+
+  expect(warnings).toContainEqual(expect.stringContaining('The convergence override "@pnpm.e2e/dep-of-pkg-with-1-dep@": "100.0.0" is stale'))
+  expect(warnings).toContainEqual(expect.stringContaining('Change the override\'s value to 100.1.0'))
+})

--- a/pnpm11/installing/deps-installer/test/install/warnOnStaleConvergenceOverrides.test.ts
+++ b/pnpm11/installing/deps-installer/test/install/warnOnStaleConvergenceOverrides.test.ts
@@ -1,3 +1,5 @@
+import util from 'node:util'
+
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import type { PackageResponse, RequestPackageFunction } from '@pnpm/store.controller-types'
 
@@ -16,7 +18,7 @@ function fakeRequestPackage (versionByRange: Record<string, string | Error>): Re
   return (async (wantedDependency: { alias?: string, bareSpecifier?: string }) => {
     const version = versionByRange[wantedDependency.bareSpecifier!]
     if (version == null) throw new Error(`Unexpected range ${wantedDependency.bareSpecifier!}`)
-    if (version instanceof Error) throw version
+    if (util.types.isNativeError(version)) throw version
     return {
       body: {
         manifest: { name: wantedDependency.alias, version },

--- a/pnpm11/installing/deps-installer/test/install/warnOnStaleConvergenceOverrides.test.ts
+++ b/pnpm11/installing/deps-installer/test/install/warnOnStaleConvergenceOverrides.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import type { PackageResponse, RequestPackageFunction } from '@pnpm/store.controller-types'
+
+jest.unstable_mockModule('@pnpm/logger', () => ({
+  globalWarn: jest.fn(),
+}))
+
+const { globalWarn } = await import('@pnpm/logger')
+const { warnOnStaleConvergenceOverrides } = await import('../../lib/install/warnOnStaleConvergenceOverrides.js')
+
+beforeEach(() => {
+  jest.mocked(globalWarn).mockClear()
+})
+
+function fakeRequestPackage (versionByRange: Record<string, string | Error>): RequestPackageFunction {
+  return (async (wantedDependency: { alias?: string, bareSpecifier?: string }) => {
+    const version = versionByRange[wantedDependency.bareSpecifier!]
+    if (version == null) throw new Error(`Unexpected range ${wantedDependency.bareSpecifier!}`)
+    if (version instanceof Error) throw version
+    return {
+      body: {
+        manifest: { name: wantedDependency.alias, version },
+      },
+    } as unknown as PackageResponse
+  }) as RequestPackageFunction
+}
+
+const FOO_CONVERGENCE_OVERRIDE = {
+  selector: 'foo@',
+  targetPkg: { name: 'foo', bareSpecifier: '' },
+  newBareSpecifier: '4.0.6',
+  converge: true,
+}
+
+test('warns when a newer version satisfies every declared range', async () => {
+  await warnOnStaleConvergenceOverrides({
+    convergeDeclaredRanges: new Map([['foo', new Set(['^4.0.5', '>=4.0.0 <5.0.0'])]]),
+    parsedOverrides: [FOO_CONVERGENCE_OVERRIDE],
+    requestPackage: fakeRequestPackage({
+      '^4.0.5': '4.0.9',
+      '>=4.0.0 <5.0.0': '4.0.9',
+    }),
+    lockfileDir: process.cwd(),
+  })
+  expect(globalWarn).toHaveBeenCalledTimes(1)
+  const warning = jest.mocked(globalWarn).mock.calls[0][0]
+  expect(warning).toContain('"foo@": "4.0.6" is stale')
+  expect(warning).toContain('4.0.9')
+})
+
+test('does not warn when an exact declared range caps the convergence at the current value', async () => {
+  await warnOnStaleConvergenceOverrides({
+    convergeDeclaredRanges: new Map([['foo', new Set(['^4.0.5', '4.0.6'])]]),
+    parsedOverrides: [FOO_CONVERGENCE_OVERRIDE],
+    requestPackage: fakeRequestPackage({
+      '^4.0.5': '4.0.9',
+      '4.0.6': '4.0.6',
+    }),
+    lockfileDir: process.cwd(),
+  })
+  expect(globalWarn).not.toHaveBeenCalled()
+})
+
+test('does not warn when the value is already the best convergence', async () => {
+  await warnOnStaleConvergenceOverrides({
+    convergeDeclaredRanges: new Map([['foo', new Set(['^4.0.5'])]]),
+    parsedOverrides: [FOO_CONVERGENCE_OVERRIDE],
+    requestPackage: fakeRequestPackage({
+      '^4.0.5': '4.0.6',
+    }),
+    lockfileDir: process.cwd(),
+  })
+  expect(globalWarn).not.toHaveBeenCalled()
+})
+
+test('still warns when one range fails to resolve but another range supplies an all-satisfying candidate', async () => {
+  await warnOnStaleConvergenceOverrides({
+    convergeDeclaredRanges: new Map([['foo', new Set(['^4.0.5', '^4.0.7'])]]),
+    parsedOverrides: [FOO_CONVERGENCE_OVERRIDE],
+    requestPackage: fakeRequestPackage({
+      '^4.0.5': '4.0.9',
+      '^4.0.7': new Error('registry down'),
+    }),
+    lockfileDir: process.cwd(),
+  })
+  expect(globalWarn).toHaveBeenCalledTimes(1)
+  expect(jest.mocked(globalWarn).mock.calls[0][0]).toContain('4.0.9')
+})
+
+test('does not warn for packages without collected ranges', async () => {
+  await warnOnStaleConvergenceOverrides({
+    convergeDeclaredRanges: new Map(),
+    parsedOverrides: [FOO_CONVERGENCE_OVERRIDE],
+    requestPackage: fakeRequestPackage({}),
+    lockfileDir: process.cwd(),
+  })
+  expect(globalWarn).not.toHaveBeenCalled()
+})

--- a/pnpm11/installing/deps-installer/tsconfig.json
+++ b/pnpm11/installing/deps-installer/tsconfig.json
@@ -64,6 +64,9 @@
       "path": "../../config/parse-overrides"
     },
     {
+      "path": "../../config/version-policy"
+    },
+    {
       "path": "../../core/constants"
     },
     {


### PR DESCRIPTION
## Summary

Implements the convergence override selector proposed in pnpm/pnpm#12794, in both stacks (Related to pnpm/pnpm#12794 — the lifecycle follow-ups below remain open).

A new override selector form with an empty range — `"pkg@": "<exact version>"` — applies the override to a dependency edge `pkg@R` iff the version satisfies `R`: compatible consumers converge on the version, incompatible consumers keep their own resolution, and dependents added later are governed automatically. This is semver-safe by construction (unlike a bare override) and future-proof (unlike range-scoped overrides, which silently stop covering new compatible ranges).

What lands here:

- **Parsing** — `"pkg@"` selectors are recognized as convergence overrides; the value must be an exact version, and empty ranges in `parent>child` selectors are rejected (both `ERR_PNPM_INVALID_CONVERGENCE_OVERRIDE`). An empty range previously slipped through undocumented and behaved like a bare override.
- **Resolution semantics** — the versions overrider rewrites an edge only when the value satisfies the declared range (loose semver, matching the npm picker); explicit `"pkg"`/`"pkg@range"` overrides win over `"pkg@"`; `workspace:`, `catalog:`, `npm:`, git/URL, and dist-tag specifiers are skipped.
- **Staleness detection** (lifecycle rule 3 of the issue) ships with the syntax, since a stale entry can cause exactly the duplication it exists to prevent: after a full resolution (the only time the collected declared-range set is complete), each entry checks whether a newer version satisfies every declared range, and warns with the concrete replacement value. Failed range resolutions can only suppress the warning, never fabricate one; the release-age policy applies to the recommendation.

Deferred follow-ups from the issue's lifecycle plan (called out per the sync rule): `pnpm update` / `pnpm dedupe` refreshing and pruning managed entries (rules 1–2), and `pnpm outdated` listing stale entries (rule 4). Documentation for pnpm.io also still needs a PR.

Verified end-to-end with the bundled CLI against the live registry: converge applied below latest, stale warning with exact recommendation, fresh value silent, incompatible edge untouched. Test suites run: parse-overrides (15), read-package-hook (37), deps-installer new + overrides/dedupe/peer regression suites, peers-checker, deps-status; pacquet: config-parse-overrides (17), package-manager (694), targeted CLI integration suites (68) incl. byte-exact warning assertions; clippy/dylint/fmt/doc clean.

## Squash Commit Body

```text
Implements the empty-range override selector from pnpm/pnpm#12794 in both
stacks. "form-data@": "4.0.6" rewrites a dependency edge to exactly 4.0.6
iff 4.0.6 satisfies the edge's declared range, so compatible consumers
converge while incompatible ones keep their own resolution — semver-safe
by construction, unlike a bare override, and future-proof against new
compatible dependents, unlike a range-scoped one.

Design decisions:

- The value must be an exact version (ERR_PNPM_INVALID_CONVERGENCE_OVERRIDE
  otherwise): a range value would make "satisfies" ill-defined (issue open
  question 4).
- Empty ranges are rejected inside parent>child selectors, reserving that
  design space until precedence there is settled (open question 5, first
  half); when "pkg" or "pkg@range" and "pkg@" both match an edge, the
  explicit override wins.
- Satisfies checks use loose semver, matching the npm picker; workspace:,
  catalog:, npm:, git/URL, and dist-tag specifiers are skipped ("satisfies"
  is only defined against a semver range — open question 3).
- Staleness detection (lifecycle rule 3) ships with the syntax: after a
  full resolution — the only time the versions overrider has seen every
  manifest, so the collected declared-range set is complete — each
  convergence entry resolves every declared range against the cached
  registry metadata (release-age policy applied), and if a version newer
  than the value satisfies every declared range, install warns with that
  concrete replacement value. Partial resolutions stay silent to avoid
  false positives from unseen ranges; failed range resolutions can only
  suppress the warning, never fabricate one.
- An empty range previously slipped through parsing and behaved like a bare
  override; that undocumented accident is replaced by validation and the
  converge semantics.

pacquet mirrors the TS behavior byte-for-byte: same error code and
messages, same warning text on the pnpm:global warn channel, same
precedence and skip rules, with matching test coverage.

Deferred follow-ups from the issue's lifecycle plan: pnpm update / pnpm
dedupe refreshing and pruning managed entries (rules 1-2) and pnpm
outdated listing stale entries (rule 4).

Related to pnpm/pnpm#12794.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. (pnpm.io docs PR still needed — noted in Summary.)

---
Written by an agent (Claude Code, claude-fable-5) on behalf of zkochan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added convergence override support for selectors like `pkg@` to coordinate compatible dependency resolutions.
  * Convergence overrides validate exact versions and support catalog-sourced values.
  * Installs now emit warnings when convergence overrides become stale based on declared ranges.
* **Bug Fixes**
  * Invalid `parent>child` selectors can’t use empty ranges.
  * Convergence override values must be exact versions; otherwise they’re rejected.
* **Tests**
  * Expanded unit, installer, and CLI end-to-end coverage for convergence rewrites and stale-warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->