### PR TITLE
fix: respect workspace root ignores when packing

### DIFF
--- a/.changeset/workspace-pack-gitignore.md
+++ b/.changeset/workspace-pack-gitignore.md
@@ -2,6 +2,7 @@
 "@pnpm/fs.packlist": patch
 "@pnpm/releasing.commands": patch
 "pnpm": patch
+"pacquet": patch
 ---
 
 `pnpm pack` now respects workspace-root `.npmignore` and `.gitignore` files when packing workspace packages.

--- a/.changeset/workspace-pack-gitignore.md
+++ b/.changeset/workspace-pack-gitignore.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/fs.packlist": patch
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+`pnpm pack` now respects workspace-root `.npmignore` and `.gitignore` files when packing workspace packages.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4777,6 +4777,9 @@ importers:
 
   pnpm11/fs/packlist:
     dependencies:
+      is-subdir:
+        specifier: 'catalog:'
+        version: 2.0.0
       npm-packlist:
         specifier: 'catalog:'
         version: 10.0.4

--- a/pnpm/crates/fs-packlist/src/lib.rs
+++ b/pnpm/crates/fs-packlist/src/lib.rs
@@ -112,7 +112,25 @@ const ALWAYS_EXCLUDED_SUFFIXES: &[&str] = &[".orig"];
 /// file the published tarball should contain. Paths are relative to
 /// `pkg_dir`, with no leading `./`.
 pub fn packlist(pkg_dir: &Path, manifest: &Value) -> Result<Vec<String>, PacklistError> {
-    let mut out: BTreeSet<String> = collect_own_files(pkg_dir, manifest)?;
+    packlist_with_options(pkg_dir, manifest, PacklistOptions::default())
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct PacklistOptions<'a> {
+    pub workspace_dir: Option<&'a Path>,
+}
+
+/// Variant of [`packlist`] that lets callers pass workspace context.
+/// Workspace packages honor ancestor `.npmignore` / `.gitignore` files
+/// between the workspace root and the package, matching npm-packlist's
+/// `prefix` / `workspaces` behavior. Callers without workspace context
+/// keep the safer package-only walk.
+pub fn packlist_with_options(
+    pkg_dir: &Path,
+    manifest: &Value,
+    options: PacklistOptions<'_>,
+) -> Result<Vec<String>, PacklistError> {
+    let mut out: BTreeSet<String> = collect_own_files(pkg_dir, manifest, options.workspace_dir)?;
     collect_bundled_files(pkg_dir, manifest, &mut out)?;
     Ok(out.into_iter().collect())
 }
@@ -229,7 +247,7 @@ fn collect_bundled_files(
             .ok()
             .flatten()
             .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
-        for rel in collect_own_files(&dep_dir, &dep_manifest)? {
+        for rel in collect_own_files(&dep_dir, &dep_manifest, None)? {
             out.insert(format!("{prefix}/{rel}"));
         }
         for name in nested_bundle_dep_names(&dep_manifest) {
@@ -270,7 +288,11 @@ fn resolve_bundled_dependency(name: &str, from_dir: &Path, root: &Path) -> Optio
 /// allowlist, and the always-included / `main` / `bin` force-includes.
 /// This is the per-package packlist with no `bundleDependencies`
 /// traversal; [`collect_bundled_files`] layers the closure on top.
-fn collect_own_files(pkg_dir: &Path, manifest: &Value) -> Result<BTreeSet<String>, PacklistError> {
+fn collect_own_files(
+    pkg_dir: &Path,
+    manifest: &Value,
+    workspace_dir: Option<&Path>,
+) -> Result<BTreeSet<String>, PacklistError> {
     let files_field = manifest.get("files").and_then(Value::as_array);
     let files_matcher: Option<Gitignore> =
         files_field.and_then(|arr| build_files_matcher(pkg_dir, arr));
@@ -296,6 +318,7 @@ fn collect_own_files(pkg_dir: &Path, manifest: &Value) -> Result<BTreeSet<String
     // already been deleted by [`crate::GitFetcher`] before this point.
     let mut builder = WalkBuilder::new(pkg_dir);
     builder
+        .current_dir(pkg_dir)
         .standard_filters(false)
         .hidden(false)
         .git_ignore(true)
@@ -309,6 +332,7 @@ fn collect_own_files(pkg_dir: &Path, manifest: &Value) -> Result<BTreeSet<String
         // would leak into the published file set.
         .parents(false)
         .add_custom_ignore_filename(".npmignore");
+    add_workspace_ignore_files(&mut builder, pkg_dir, workspace_dir)?;
 
     for entry in builder.build() {
         let entry = entry.map_err(|err| io_error(pkg_dir, into_io(err)))?;
@@ -384,6 +408,51 @@ fn collect_own_files(pkg_dir: &Path, manifest: &Value) -> Result<BTreeSet<String
     }
 
     Ok(out)
+}
+
+fn add_workspace_ignore_files(
+    builder: &mut WalkBuilder,
+    pkg_dir: &Path,
+    workspace_dir: Option<&Path>,
+) -> Result<(), PacklistError> {
+    let Some(workspace_dir) = workspace_dir else { return Ok(()) };
+    let Ok(rel) = pkg_dir.strip_prefix(workspace_dir) else { return Ok(()) };
+    if rel.as_os_str().is_empty() {
+        return Ok(());
+    }
+    let Some(pkg_parent) = pkg_dir.parent() else { return Ok(()) };
+    let Ok(parent_rel) = pkg_parent.strip_prefix(workspace_dir) else { return Ok(()) };
+
+    let mut current = workspace_dir.to_path_buf();
+    add_workspace_ignore_file(builder, pkg_dir, &current)?;
+    for component in parent_rel.components() {
+        let Component::Normal(segment) = component else { return Ok(()) };
+        current.push(segment);
+        add_workspace_ignore_file(builder, pkg_dir, &current)?;
+    }
+    Ok(())
+}
+
+fn add_workspace_ignore_file(
+    builder: &mut WalkBuilder,
+    pkg_dir: &Path,
+    dir: &Path,
+) -> Result<(), PacklistError> {
+    let npmignore = dir.join(".npmignore");
+    let gitignore = dir.join(".gitignore");
+    let ignore_file = if npmignore.is_file() {
+        Some(npmignore)
+    } else if gitignore.is_file() {
+        Some(gitignore)
+    } else {
+        None
+    };
+    if let Some(ignore_file) = ignore_file
+        && let Some(error) = builder.add_ignore(&ignore_file)
+    {
+        return Err(io_error(pkg_dir, into_io(error)));
+    }
+    Ok(())
 }
 
 /// Compile the `manifest.files` allowlist into a single `Gitignore`

--- a/pnpm/crates/fs-packlist/src/lib.rs
+++ b/pnpm/crates/fs-packlist/src/lib.rs
@@ -426,6 +426,11 @@ fn add_workspace_ignore_files(
     let mut current = workspace_dir.to_path_buf();
     add_workspace_ignore_file(builder, pkg_dir, &current)?;
     for component in parent_rel.components() {
+        // `parent_rel` is `pkg_parent` relative to `workspace_dir`, so a
+        // clean descendant chain yields only `Normal` components. Anything
+        // else (a stray `..` or root/prefix from a non-canonical path) means
+        // we can't trust the remaining chain, so stop rather than walk out of
+        // the workspace; the already-added root ignore stays in effect.
         let Component::Normal(segment) = component else { return Ok(()) };
         current.push(segment);
         add_workspace_ignore_file(builder, pkg_dir, &current)?;

--- a/pnpm/crates/fs-packlist/src/lib.rs
+++ b/pnpm/crates/fs-packlist/src/lib.rs
@@ -115,7 +115,7 @@ pub fn packlist(pkg_dir: &Path, manifest: &Value) -> Result<Vec<String>, Packlis
     packlist_with_options(pkg_dir, manifest, PacklistOptions::default())
 }
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct PacklistOptions<'a> {
     pub workspace_dir: Option<&'a Path>,
 }

--- a/pnpm/crates/fs-packlist/src/tests.rs
+++ b/pnpm/crates/fs-packlist/src/tests.rs
@@ -1,4 +1,4 @@
-use super::packlist;
+use super::{PacklistOptions, packlist, packlist_with_options};
 use serde_json::json;
 use std::{fs, path::Path};
 use tempfile::tempdir;
@@ -430,6 +430,55 @@ fn npmignore_in_parent_dir_does_not_leak_in() {
         out.contains(&"index.js".to_string()),
         "parent-directory .gitignore must NOT leak into the packlist: {out:?}",
     );
+}
+
+#[test]
+fn workspace_root_gitignore_excludes_workspace_package_files() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".gitignore"), "dist/\n").unwrap();
+    let root = dir.path().join("packages").join("pkg");
+    fs::create_dir_all(&root).unwrap();
+    touch(&root, "package.json");
+    touch(&root, "dist/generated.js");
+    touch(&root, "src/index.js");
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let out = packlist_with_options(
+        &root,
+        &manifest,
+        PacklistOptions { workspace_dir: Some(dir.path()) },
+    )
+    .unwrap();
+
+    assert!(out.contains(&"src/index.js".to_string()), "{out:?}");
+    assert!(
+        !out.contains(&"dist/generated.js".to_string()),
+        "workspace-root .gitignore must exclude `dist/`; received {out:?}",
+    );
+}
+
+#[test]
+fn unrelated_workspace_dir_does_not_apply_workspace_gitignore() {
+    let workspace = tempdir().unwrap();
+    fs::write(workspace.path().join(".gitignore"), "dist/\n").unwrap();
+    let package = tempdir().unwrap();
+    touch(package.path(), "package.json");
+    touch(package.path(), "dist/generated.js");
+    touch(package.path(), "src/index.js");
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let out = packlist_with_options(
+        package.path(),
+        &manifest,
+        PacklistOptions { workspace_dir: Some(workspace.path()) },
+    )
+    .unwrap();
+
+    assert!(
+        out.contains(&"dist/generated.js".to_string()),
+        "unrelated workspace_dir must not apply workspace-root ignores: {out:?}",
+    );
+    assert!(out.contains(&"src/index.js".to_string()), "{out:?}");
 }
 
 #[test]

--- a/pnpm/crates/fs-packlist/src/tests.rs
+++ b/pnpm/crates/fs-packlist/src/tests.rs
@@ -458,6 +458,35 @@ fn workspace_root_gitignore_excludes_workspace_package_files() {
 }
 
 #[test]
+fn workspace_root_npmignore_takes_precedence_over_gitignore() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".gitignore"), "src/\n").unwrap();
+    fs::write(dir.path().join(".npmignore"), "dist/\n").unwrap();
+    let root = dir.path().join("packages").join("pkg");
+    fs::create_dir_all(&root).unwrap();
+    touch(&root, "package.json");
+    touch(&root, "dist/generated.js");
+    touch(&root, "src/index.js");
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let out = packlist_with_options(
+        &root,
+        &manifest,
+        PacklistOptions { workspace_dir: Some(dir.path()) },
+    )
+    .unwrap();
+
+    assert!(
+        out.contains(&"src/index.js".to_string()),
+        "workspace-root .npmignore must take precedence over .gitignore; received {out:?}",
+    );
+    assert!(
+        !out.contains(&"dist/generated.js".to_string()),
+        "workspace-root .npmignore must exclude `dist/`; received {out:?}",
+    );
+}
+
+#[test]
 fn unrelated_workspace_dir_does_not_apply_workspace_gitignore() {
     let workspace = tempdir().unwrap();
     fs::write(workspace.path().join(".gitignore"), "dist/\n").unwrap();

--- a/pnpm/crates/fs-packlist/src/tests.rs
+++ b/pnpm/crates/fs-packlist/src/tests.rs
@@ -486,6 +486,36 @@ fn workspace_root_npmignore_takes_precedence_over_gitignore() {
     );
 }
 
+// A package-level `.npmignore` negation must win over a workspace-root
+// ignore: the workspace-root file is added at the lowest precedence tier
+// (`WalkBuilder::add_ignore`), below the package's own discovered ignore
+// files, matching npm-packlist's ancestor-first ordering.
+#[test]
+fn package_npmignore_negation_overrides_workspace_root_gitignore() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".gitignore"), "dist/\n").unwrap();
+    let root = dir.path().join("packages").join("pkg");
+    fs::create_dir_all(&root).unwrap();
+    touch(&root, "package.json");
+    write(&root, ".npmignore", "!dist/\n");
+    touch(&root, "dist/generated.js");
+    touch(&root, "src/index.js");
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let out = packlist_with_options(
+        &root,
+        &manifest,
+        PacklistOptions { workspace_dir: Some(dir.path()) },
+    )
+    .unwrap();
+
+    assert!(
+        out.contains(&"dist/generated.js".to_string()),
+        "package-level `!dist/` must re-include files the workspace-root .gitignore excluded; received {out:?}",
+    );
+    assert!(out.contains(&"src/index.js".to_string()), "{out:?}");
+}
+
 #[test]
 fn unrelated_workspace_dir_does_not_apply_workspace_gitignore() {
     let workspace = tempdir().unwrap();

--- a/pnpm/crates/pack/src/lib.rs
+++ b/pnpm/crates/pack/src/lib.rs
@@ -35,7 +35,7 @@ use pacquet_executor::{
 use pacquet_exportable_manifest::{
     CreateExportableManifestError, CreateExportableManifestOptions, create_exportable_manifest,
 };
-use pacquet_fs_packlist::{PacklistError, packlist};
+use pacquet_fs_packlist::{PacklistError, PacklistOptions, packlist_with_options};
 use pacquet_hooks::{HookContext, LogFn, PnpmfileHooks};
 use pacquet_package_manifest::{PackageManifestError, safe_read_package_json_from_dir};
 use pacquet_reporter::{HookLog, LogEvent, LogLevel, Reporter};
@@ -310,7 +310,12 @@ where
     let (tarball_name, pack_destination) =
         resolve_output(opts, &normalized_name, &published_version)?;
 
-    let files = packlist(&dir, &publish_manifest).map_err(PackError::Packlist)?;
+    let files = packlist_with_options(
+        &dir,
+        &publish_manifest,
+        PacklistOptions { workspace_dir: opts.workspace_dir.as_deref() },
+    )
+    .map_err(PackError::Packlist)?;
     let mut files_map = build_files_map(&dir, &files);
     inject_workspace_license(opts, &dir, &files, &mut files_map);
 

--- a/pnpm/crates/pack/src/tests.rs
+++ b/pnpm/crates/pack/src/tests.rs
@@ -399,6 +399,7 @@ fn workspace_root_gitignore_excludes_workspace_package_files() {
         dry_run: false,
         pack_destination: None,
         out: None,
+        before_packing_hooks: Vec::new(),
     };
 
     let result = api::<SilentReporter, Host>(&opts).unwrap();

--- a/pnpm/crates/pack/src/tests.rs
+++ b/pnpm/crates/pack/src/tests.rs
@@ -369,6 +369,65 @@ fn symlinked_workspace_license_is_not_injected() {
     assert!(!names.contains(&"package/LICENSE".to_string()));
 }
 
+#[test]
+fn workspace_root_gitignore_excludes_workspace_package_files() {
+    let workspace = tempdir().unwrap();
+    std::fs::write(workspace.path().join(".gitignore"), "dist/\n").unwrap();
+    let pkg_dir = workspace.path().join("packages").join("foo");
+    std::fs::create_dir_all(&pkg_dir).unwrap();
+    std::fs::write(
+        pkg_dir.join("package.json"),
+        serde_json::to_string(&json!({ "name": "foo", "version": "1.0.0" })).unwrap(),
+    )
+    .unwrap();
+    touch(&pkg_dir, "dist/generated.js", "generated");
+    touch(&pkg_dir, "src/index.js", "source");
+
+    let opts = PackOptions {
+        dir: pkg_dir.clone(),
+        catalogs: BTreeMap::new(),
+        ignore_scripts: true,
+        unsafe_perm: true,
+        embed_readme: false,
+        pack_gzip_level: None,
+        node_linker: NodeLinker::Isolated,
+        skip_manifest_obfuscation: false,
+        user_agent: "pacquet".to_string(),
+        extra_bin_paths: Vec::new(),
+        extra_env: HashMap::new(),
+        workspace_dir: Some(workspace.path().to_path_buf()),
+        dry_run: false,
+        pack_destination: None,
+        out: None,
+    };
+
+    let result = api::<SilentReporter, Host>(&opts).unwrap();
+
+    assert!(result.contents.contains(&"src/index.js".to_string()));
+    assert!(!result.contents.contains(&"dist/generated.js".to_string()));
+    let names = tarball_entry_names(&pkg_dir.join("foo-1.0.0.tgz"));
+    assert!(names.contains(&"package/src/index.js".to_string()));
+    assert!(!names.contains(&"package/dist/generated.js".to_string()));
+}
+
+#[test]
+fn unrelated_workspace_dir_does_not_apply_workspace_gitignore() {
+    let workspace = tempdir().unwrap();
+    std::fs::write(workspace.path().join(".gitignore"), "dist/\n").unwrap();
+    let (package, mut opts) = fixture(&json!({ "name": "foo", "version": "1.0.0" }));
+    touch(package.path(), "dist/generated.js", "generated");
+    touch(package.path(), "src/index.js", "source");
+    opts.workspace_dir = Some(workspace.path().to_path_buf());
+
+    let result = api::<SilentReporter, Host>(&opts).unwrap();
+
+    assert!(result.contents.contains(&"dist/generated.js".to_string()));
+    assert!(result.contents.contains(&"src/index.js".to_string()));
+    let names = tarball_entry_names(&package.path().join("foo-1.0.0.tgz"));
+    assert!(names.contains(&"package/dist/generated.js".to_string()));
+    assert!(names.contains(&"package/src/index.js".to_string()));
+}
+
 /// The write-phase DI seam: a fake whose `FsWrite` fails with
 /// `PermissionDenied` must surface as `PackError::WriteTarball`. This is
 /// the branch a real fixture can't reach portably, justifying the `Sys`

--- a/pnpm11/fs/packlist/package.json
+++ b/pnpm11/fs/packlist/package.json
@@ -30,6 +30,7 @@
     "test": "pn compile"
   },
   "dependencies": {
+    "is-subdir": "catalog:",
     "npm-packlist": "catalog:"
   },
   "devDependencies": {

--- a/pnpm11/fs/packlist/src/index.ts
+++ b/pnpm11/fs/packlist/src/index.ts
@@ -21,11 +21,25 @@ interface TreeNode {
 
 export async function packlist (pkgDir: string, opts?: {
   manifest?: Record<string, unknown>
+  workspaceDir?: string
 }): Promise<string[]> {
-  const pkg = opts?.manifest ?? readPackageJson(pkgDir)
-  const tree = buildRootTree(pkgDir, pkg)
-  const files = await npmPacklist(tree)
+  const resolvedPkgDir = path.resolve(pkgDir)
+  const workspaceDir = opts?.workspaceDir == null ? undefined : path.resolve(opts.workspaceDir)
+  const pkg = opts?.manifest ?? readPackageJson(resolvedPkgDir)
+  const tree = buildRootTree(resolvedPkgDir, pkg)
+  const packlistOpts = workspaceDir != null && isSubdir(workspaceDir, resolvedPkgDir)
+    ? { prefix: workspaceDir, workspaces: [resolvedPkgDir] }
+    : undefined
+  const files = await npmPacklist(tree, packlistOpts)
   return files.map((file) => file.replace(/^\.[/\\]/, ''))
+}
+
+function isSubdir (parentDir: string, childDir: string): boolean {
+  const relative = path.relative(parentDir, childDir)
+  return relative !== '' &&
+    relative !== '..' &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
 }
 
 function buildRootTree (pkgDir: string, pkg: Record<string, unknown>): TreeNode {

--- a/pnpm11/fs/packlist/src/index.ts
+++ b/pnpm11/fs/packlist/src/index.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import util from 'node:util'
 
+import { isSubdir } from 'is-subdir'
 import npmPacklist from 'npm-packlist'
 
 interface Edge {
@@ -27,19 +28,11 @@ export async function packlist (pkgDir: string, opts?: {
   const workspaceDir = opts?.workspaceDir == null ? undefined : path.resolve(opts.workspaceDir)
   const pkg = opts?.manifest ?? readPackageJson(resolvedPkgDir)
   const tree = buildRootTree(resolvedPkgDir, pkg)
-  const packlistOpts = workspaceDir != null && isSubdir(workspaceDir, resolvedPkgDir)
+  const packlistOpts = workspaceDir != null && workspaceDir !== resolvedPkgDir && isSubdir(workspaceDir, resolvedPkgDir)
     ? { prefix: workspaceDir, workspaces: [resolvedPkgDir] }
     : undefined
   const files = await npmPacklist(tree, packlistOpts)
   return files.map((file) => file.replace(/^\.[/\\]/, ''))
-}
-
-function isSubdir (parentDir: string, childDir: string): boolean {
-  const relative = path.relative(parentDir, childDir)
-  return relative !== '' &&
-    relative !== '..' &&
-    !relative.startsWith(`..${path.sep}`) &&
-    !path.isAbsolute(relative)
 }
 
 function buildRootTree (pkgDir: string, pkg: Record<string, unknown>): TreeNode {

--- a/pnpm11/releasing/commands/src/publish/pack.ts
+++ b/pnpm11/releasing/commands/src/publish/pack.ts
@@ -271,6 +271,7 @@ export async function api (opts: PackOptions): Promise<PackResult> {
   }
   const files = await packlist(dir, {
     manifest: publishManifest as Record<string, unknown>,
+    workspaceDir: opts.workspaceDir,
   })
   const filesMap = Object.fromEntries(files.map((file) => [`package/${file}`, path.join(dir, file)]))
   // cspell:disable-next-line

--- a/pnpm11/releasing/commands/test/publish/pack.ts
+++ b/pnpm11/releasing/commands/test/publish/pack.ts
@@ -441,6 +441,38 @@ test('pack: uses workspace root gitignore for workspace packages', async () => {
   expect(workspaceOutput).not.toContain('dist/generated.js')
 })
 
+test('pack: package-level .npmignore negation overrides workspace root gitignore', async () => {
+  preparePackages([
+    {
+      name: 'project',
+      version: '1.0.0',
+    },
+  ])
+
+  const workspaceDir = process.cwd()
+  writeYamlFileSync('pnpm-workspace.yaml', { packages: ['project'] })
+  fs.writeFileSync('.gitignore', 'dist/\n', 'utf8')
+
+  process.chdir('project')
+  fs.writeFileSync('.npmignore', '!dist/\n', 'utf8')
+  fs.mkdirSync('dist')
+  fs.mkdirSync('src')
+  fs.writeFileSync('dist/generated.js', 'generated', 'utf8')
+  fs.writeFileSync('src/index.js', 'source', 'utf8')
+
+  const output = await pack.handler({
+    ...DEFAULT_OPTS,
+    argv: { original: [] },
+    dir: process.cwd(),
+    extraBinPaths: [],
+    dryRun: true,
+    workspaceDir,
+  })
+
+  expect(output).toContain('src/index.js')
+  expect(output).toContain('dist/generated.js')
+})
+
 // A symlinked workspace-root LICENSE must not be injected: following it would
 // leak the target's bytes — potentially a file outside the workspace — into
 // the published tarball.

--- a/pnpm11/releasing/commands/test/publish/pack.ts
+++ b/pnpm11/releasing/commands/test/publish/pack.ts
@@ -395,6 +395,52 @@ test('pack: includes prepack-generated files removed by postpack', async () => {
   expect(fs.existsSync('package/generated.txt')).toBeTruthy()
 })
 
+test('pack: uses workspace root gitignore for workspace packages', async () => {
+  preparePackages([
+    {
+      name: 'project',
+      version: '1.0.0',
+    },
+  ])
+
+  const workspaceDir = process.cwd()
+  writeYamlFileSync('pnpm-workspace.yaml', { packages: ['project'] })
+  fs.writeFileSync('.gitignore', 'dist/\n', 'utf8')
+
+  process.chdir('project')
+  fs.mkdirSync('dist')
+  fs.mkdirSync('src')
+  fs.writeFileSync('dist/generated.js', 'generated', 'utf8')
+  fs.writeFileSync('src/index.js', 'source', 'utf8')
+
+  const packOpts = {
+    ...DEFAULT_OPTS,
+    argv: { original: [] },
+    dir: process.cwd(),
+    extraBinPaths: [],
+    dryRun: true,
+  }
+
+  const withoutWorkspaceOutput = await pack.handler(packOpts)
+  expect(withoutWorkspaceOutput).toContain('dist/generated.js')
+
+  const unrelatedWorkspaceDir = path.join(workspaceDir, 'unrelated-workspace')
+  fs.mkdirSync(unrelatedWorkspaceDir)
+  const unrelatedWorkspaceOutput = await pack.handler({
+    ...packOpts,
+    workspaceDir: unrelatedWorkspaceDir,
+  })
+  expect(unrelatedWorkspaceOutput).toContain('dist/generated.js')
+
+  const workspaceOutput = await pack.handler({
+    ...packOpts,
+    workspaceDir,
+  })
+
+  expect(workspaceOutput).toContain('src/index.js')
+  expect(workspaceOutput).not.toContain('dist/generated.js')
+})
+
 // A symlinked workspace-root LICENSE must not be injected: following it would
 // leak the target's bytes — potentially a file outside the workspace — into
 // the published tarball.


### PR DESCRIPTION
## Summary

- Fixes pnpm/pnpm#12560 by passing workspace context into packlist when packing workspace packages.
- Mirrors the behavior in pacquet and covers workspace, no-context, and unrelated-workspace cases.

## Squash Commit Body

```text
Fixes pnpm/pnpm#12560.

Workspace package packing now passes workspace context into packlist only when the package is actually under that workspace root. That lets workspace-root .npmignore/.gitignore files affect sub-package packing while preserving package-only behavior for normal packlist calls and unrelated workspaceDir values.

The pacquet packlist and pack path use the same workspace-aware rules so the Rust port stays aligned with the TypeScript CLI.
```

## Validation

- `corepack pnpm --filter @pnpm/releasing.commands test pnpm11/releasing/commands/test/publish/pack.ts -t 'workspace root gitignore'` - passed\n- `corepack pnpm --filter @pnpm/fs.packlist test` - passed\n- `cargo fmt --all -- --check` - passed\n- `cargo test -p pacquet-fs-packlist -- --nocapture` - passed\n- `cargo test -p pacquet-pack -- --nocapture` - passed\n\n## Checklist\n\n- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting.\n- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users - it becomes a release note.\n- [x] Added or updated tests.\n- [x] Updated the documentation if needed.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm pack` now uses workspace-root `.npmignore` and `.gitignore` when packaging workspace packages.
  * Workspace ignore rules are inherited correctly for workspace context, and `.npmignore` takes precedence over `.gitignore`.

* **Bug Fixes**
  * Packing from the wrong directory (non-workspace context) no longer incorrectly applies workspace-root ignore rules.

* **Tests**
  * Added coverage for workspace vs non-workspace packing scenarios, including precedence and file inclusion/exclusion assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Written by an agent (Codex, gpt-5.5).