### PR TITLE
fix: install active pnpm version when self-updating

### DIFF
--- a/.changeset/self-update-active-version.md
+++ b/.changeset/self-update-active-version.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/engine.pm.commands": patch
+"pnpm": patch
+---
+
+`pnpm self-update <version>` now installs the requested pnpm version when it matches the currently running version but is missing from the global self-update directory.

--- a/pacquet/crates/cli/src/cli_args/self_update.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update.rs
@@ -18,7 +18,9 @@ use miette::{Context, Diagnostic, IntoDiagnostic};
 use pacquet_cmd_shim::{Host as CmdShimHost, link_bins_of_packages_with_excludes};
 use pacquet_config::{Config, PACQUET_VERSION};
 use pacquet_fs::force_symlink_dir;
-use pacquet_global::{create_global_cache_key, get_hash_link, read_installed_packages};
+use pacquet_global::{
+    create_global_cache_key, find_global_package, get_hash_link, read_installed_packages,
+};
 use pacquet_lockfile::EnvLockfile;
 use pacquet_package_manifest::PackageManifest;
 use pacquet_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
@@ -185,8 +187,12 @@ async fn handler<Reporter: self::Reporter + 'static>(
         .await;
     }
 
-    // Global switch.
-    if target_version == PACQUET_VERSION {
+    // Global switch. Version equality with the running binary alone must
+    // not skip the update: a removed global install can be recovered by
+    // running a local pnpm of the same version (see pnpm/pnpm#12877).
+    if target_version == PACQUET_VERSION
+        && is_installed_globally(config.global_pkg_dir.as_deref(), &target_version)?
+    {
         return Ok(Some(format!(
             r#"The currently active pnpm v{PACQUET_VERSION} is already "{bare_specifier}" and doesn't need an update"#,
         )));
@@ -439,6 +445,22 @@ fn registries_for_cache_key(config: &Config) -> Vec<(String, String)> {
     let mut registries = vec![("default".to_string(), bootstrap.registry.clone())];
     registries.extend(bootstrap.registries.iter().map(|(key, value)| (key.clone(), value.clone())));
     registries
+}
+
+/// Whether the global packages directory already holds the engine that a
+/// switch to `version` would install, at exactly that version.
+fn is_installed_globally(global_pkg_dir: Option<&Path>, version: &str) -> miette::Result<bool> {
+    let Some(global_pkg_dir) = global_pkg_dir else {
+        return Ok(false);
+    };
+    let package = install_pnpm::pnpm_package_to_install(version);
+    let existing = find_global_package(global_pkg_dir, package.name)
+        .into_diagnostic()
+        .wrap_err("scan global packages")?;
+    Ok(existing.is_some_and(|existing| {
+        install_pnpm::installed_version(&existing.install_dir, package.name).as_deref()
+            == Some(version)
+    }))
 }
 
 /// `true` when pnpm is running under corepack, which manages its own

--- a/pacquet/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -105,7 +105,7 @@ pub(super) async fn install_pnpm<Reporter: self::Reporter + 'static>(
 
 /// The installed wrapper's recorded version, or `None` when the install is
 /// absent or unreadable.
-fn installed_version(install_dir: &Path, package_name: &str) -> Option<String> {
+pub(super) fn installed_version(install_dir: &Path, package_name: &str) -> Option<String> {
     let pkg_json = package_dir(install_dir, package_name).join("package.json");
     let text = fs::read_to_string(pkg_json).ok()?;
     let value: Value = serde_json::from_str(&text).ok()?;

--- a/pacquet/crates/cli/src/cli_args/self_update/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/self_update/tests.rs
@@ -1,4 +1,5 @@
-use super::{update_version_constraint, version_lt};
+use super::{install_pnpm, is_installed_globally, update_version_constraint, version_lt};
+use std::{fs, path::Path};
 
 #[test]
 fn version_constraint_preserves_pinning_style() {
@@ -14,6 +15,38 @@ fn version_constraint_preserves_pinning_style() {
     assert_eq!(update_version_constraint(Some("1.0.0"), "2.0.0"), "2.0.0");
     // A complex multi-comparator range falls back to a caret range.
     assert_eq!(update_version_constraint(Some(">=1.0.0 <2.0.0"), "3.0.0"), "^3.0.0");
+}
+
+fn seed_global_engine(global_dir: &Path, package_name: &str, version: &str) {
+    let install_dir = global_dir.join(format!("pnpm-{version}"));
+    let package_dir = install_pnpm::package_dir(&install_dir, package_name);
+    fs::create_dir_all(&package_dir).unwrap();
+    fs::write(
+        install_dir.join("package.json"),
+        format!(r#"{{"dependencies":{{"{package_name}":"{version}"}}}}"#),
+    )
+    .unwrap();
+    fs::write(
+        package_dir.join("package.json"),
+        format!(r#"{{"name":"{package_name}","version":"{version}"}}"#),
+    )
+    .unwrap();
+    pacquet_fs::force_symlink_dir(&install_dir, &global_dir.join(format!("hash-{version}")))
+        .unwrap();
+}
+
+#[test]
+fn is_installed_globally_requires_a_matching_global_install() {
+    assert!(!is_installed_globally(None, "11.0.0").unwrap());
+
+    let global_dir = tempfile::tempdir().unwrap();
+    let global_dir = global_dir.path();
+    assert!(!is_installed_globally(Some(global_dir), "11.0.0").unwrap());
+
+    seed_global_engine(global_dir, "@pnpm/exe", "11.0.0");
+    assert!(is_installed_globally(Some(global_dir), "11.0.0").unwrap());
+    // A different target version of the same engine package is not a match.
+    assert!(!is_installed_globally(Some(global_dir), "11.1.0").unwrap());
 }
 
 #[test]

--- a/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -192,17 +192,9 @@ async function installPnpmToGlobalDir (
   const globalDir = opts.globalPkgDir!
   cleanOrphanedInstallDirs(globalDir)
 
-  // Check if already installed globally
-  const existing = findGlobalPackage(globalDir, pkgName)
-  if (existing) {
-    const pkgJsonPath = path.join(existing.installDir, 'node_modules', pkgName, 'package.json')
-    try {
-      const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'))
-      if (pkgJson.version === version) {
-        const binDir = path.join(existing.installDir, 'bin')
-        return { alreadyExisted: true, installDir: existing.installDir, binDir }
-      }
-    } catch {}
+  const existingInstallDir = await findGlobalPnpmInstallDir(globalDir, pkgName, version)
+  if (existingInstallDir != null) {
+    return { alreadyExisted: true, installDir: existingInstallDir, binDir: path.join(existingInstallDir, 'bin') }
   }
 
   const installDir = createInstallDir(globalDir)
@@ -250,6 +242,21 @@ async function installPnpmToGlobalDir (
     } catch {}
     throw err
   }
+}
+
+/**
+ * The install dir under `globalDir` that already holds `pkgName` at exactly
+ * `version`, or `undefined` when the global install is missing, at a
+ * different version, or unreadable.
+ */
+export async function findGlobalPnpmInstallDir (globalDir: string, pkgName: string, version: string): Promise<string | undefined> {
+  const existing = findGlobalPackage(globalDir, pkgName)
+  if (!existing) return undefined
+  try {
+    const pkgJson = JSON.parse(await fs.promises.readFile(path.join(existing.installDir, 'node_modules', pkgName, 'package.json'), 'utf8'))
+    if (pkgJson.version === version) return existing.installDir
+  } catch {}
+  return undefined
 }
 
 async function installFromLockfile (

--- a/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
@@ -7,6 +7,7 @@ import { docsUrl } from '@pnpm/cli.utils'
 import { type Config, type ConfigContext, parsePackageManager, shouldPersistLockfile, types as allTypes } from '@pnpm/config.reader'
 import { createPackageVersionPolicyOrThrow, getPublishedByPolicy } from '@pnpm/config.version-policy'
 import { PnpmError } from '@pnpm/error'
+import { findGlobalPackage } from '@pnpm/global.packages'
 import { createResolver, makeResolutionStrict } from '@pnpm/installing.client'
 import { resolvePackageManagerIntegrities } from '@pnpm/installing.env-installer'
 import { readEnvLockfile } from '@pnpm/lockfile.fs'
@@ -19,7 +20,7 @@ import { pick } from 'ramda'
 import { renderHelp } from 'render-help'
 import semver from 'semver'
 
-import { installPnpm } from './installPnpm.js'
+import { installPnpm, pnpmPackageNameToInstall } from './installPnpm.js'
 
 export function rcOptionsTypes (): Record<string, unknown> {
   return pick([], allTypes)
@@ -224,7 +225,10 @@ export async function handler (
       return `The current project is already set to use pnpm v${resolution.manifest.version}`
     }
   }
-  if (resolution.manifest.version === packageManager.version) {
+  if (
+    resolution.manifest.version === packageManager.version &&
+    isInstalledGlobally(opts.globalPkgDir, pnpmPackageNameToInstall(resolution.manifest.version), resolution.manifest.version)
+  ) {
     return `The currently active ${packageManager.name} v${packageManager.version} is already "${bareSpecifier}" and doesn't need an update`
   }
 
@@ -286,6 +290,17 @@ function hasLegacyHomeDirShim (pnpmHomeDir: string): boolean {
   return false
 }
 
+function isInstalledGlobally (globalPkgDir: string, pkgName: string, version: string): boolean {
+  const existing = findGlobalPackage(globalPkgDir, pkgName)
+  if (!existing) return false
+  try {
+    const manifest = JSON.parse(fs.readFileSync(path.join(existing.installDir, 'node_modules', pkgName, 'package.json'), 'utf8'))
+    return manifest.version === version
+  } catch {
+    return false
+  }
+}
+
 /**
  * Returns the updated version constraint for devEngines.packageManager.
  * - Exact versions and simple ranges (^, ~) are updated to the new version,
@@ -343,4 +358,3 @@ async function readProjectPinnedPnpmVersion (rootProjectManifestDir: string, spe
   }
   return lockfilePinned ?? specMin
 }
-

--- a/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
@@ -227,7 +227,7 @@ export async function handler (
   }
   if (
     resolution.manifest.version === packageManager.version &&
-    isInstalledGlobally(opts.globalPkgDir, pnpmPackageNameToInstall(resolution.manifest.version), resolution.manifest.version)
+    await isInstalledGlobally(opts.globalPkgDir, pnpmPackageNameToInstall(resolution.manifest.version), resolution.manifest.version)
   ) {
     return `The currently active ${packageManager.name} v${packageManager.version} is already "${bareSpecifier}" and doesn't need an update`
   }
@@ -290,11 +290,11 @@ function hasLegacyHomeDirShim (pnpmHomeDir: string): boolean {
   return false
 }
 
-function isInstalledGlobally (globalPkgDir: string, pkgName: string, version: string): boolean {
+async function isInstalledGlobally (globalPkgDir: string, pkgName: string, version: string): Promise<boolean> {
   const existing = findGlobalPackage(globalPkgDir, pkgName)
   if (!existing) return false
   try {
-    const manifest = JSON.parse(fs.readFileSync(path.join(existing.installDir, 'node_modules', pkgName, 'package.json'), 'utf8'))
+    const manifest = JSON.parse(await fs.promises.readFile(path.join(existing.installDir, 'node_modules', pkgName, 'package.json'), 'utf8'))
     return manifest.version === version
   } catch {
     return false

--- a/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
@@ -7,7 +7,6 @@ import { docsUrl } from '@pnpm/cli.utils'
 import { type Config, type ConfigContext, parsePackageManager, shouldPersistLockfile, types as allTypes } from '@pnpm/config.reader'
 import { createPackageVersionPolicyOrThrow, getPublishedByPolicy } from '@pnpm/config.version-policy'
 import { PnpmError } from '@pnpm/error'
-import { findGlobalPackage } from '@pnpm/global.packages'
 import { createResolver, makeResolutionStrict } from '@pnpm/installing.client'
 import { resolvePackageManagerIntegrities } from '@pnpm/installing.env-installer'
 import { readEnvLockfile } from '@pnpm/lockfile.fs'
@@ -20,7 +19,7 @@ import { pick } from 'ramda'
 import { renderHelp } from 'render-help'
 import semver from 'semver'
 
-import { installPnpm, pnpmPackageNameToInstall } from './installPnpm.js'
+import { findGlobalPnpmInstallDir, installPnpm, pnpmPackageNameToInstall } from './installPnpm.js'
 
 export function rcOptionsTypes (): Record<string, unknown> {
   return pick([], allTypes)
@@ -225,9 +224,12 @@ export async function handler (
       return `The current project is already set to use pnpm v${resolution.manifest.version}`
     }
   }
+  // Version equality with the running binary alone must not skip the
+  // update: a removed global install can be recovered by running a local
+  // pnpm of the same version (see pnpm/pnpm#12877).
   if (
     resolution.manifest.version === packageManager.version &&
-    await isInstalledGlobally(opts.globalPkgDir, pnpmPackageNameToInstall(resolution.manifest.version), resolution.manifest.version)
+    await findGlobalPnpmInstallDir(opts.globalPkgDir, pnpmPackageNameToInstall(resolution.manifest.version), resolution.manifest.version) != null
   ) {
     return `The currently active ${packageManager.name} v${packageManager.version} is already "${bareSpecifier}" and doesn't need an update`
   }
@@ -288,17 +290,6 @@ function hasLegacyHomeDirShim (pnpmHomeDir: string): boolean {
     if (fs.existsSync(path.join(pnpmHomeDir, name))) return true
   }
   return false
-}
-
-async function isInstalledGlobally (globalPkgDir: string, pkgName: string, version: string): Promise<boolean> {
-  const existing = findGlobalPackage(globalPkgDir, pkgName)
-  if (!existing) return false
-  try {
-    const manifest = JSON.parse(await fs.promises.readFile(path.join(existing.installDir, 'node_modules', pkgName, 'package.json'), 'utf8'))
-    return manifest.version === version
-  } catch {
-    return false
-  }
 }
 
 /**

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -15,18 +15,20 @@ const require = createRequire(import.meta.dirname)
 const pnpmTarballPath = require.resolve('@pnpm/tgz-fixtures/tgz/pnpm-9.1.0.tgz')
 
 const actualModule = await import('@pnpm/cli.meta')
+const mockPackageManager = {
+  name: 'pnpm',
+  version: '9.0.0',
+}
 jest.unstable_mockModule('@pnpm/cli.meta', () => {
   return {
     ...actualModule,
-    packageManager: {
-      name: 'pnpm',
-      version: '9.0.0',
-    },
+    packageManager: mockPackageManager,
   }
 })
 const { selfUpdate, installPnpm, linkExePlatformBinary, exePlatformPkgDirName, exePlatformPkgDirNameNext, pnpmPackageNameToInstall } = await import('@pnpm/engine.pm.commands')
 
 beforeEach(async () => {
+  mockPackageManager.version = '9.0.0'
   await setupMockAgent()
   getMockAgent().enableNetConnect()
 })
@@ -141,6 +143,18 @@ function mockRegistryForUpdate (registry: string, version: string, metadata: obj
   getMockAgent().get(registry.replace(/\/$/, ''))
     .intercept({ path: `/pnpm/-/pnpm-${version}.tgz`, method: 'GET' })
     .reply(200, tgzData)
+}
+
+function seedGlobalPnpm (opts: ReturnType<typeof prepareOptions>, version: string): string {
+  const installDir = path.join(opts.globalPkgDir, `pnpm-${version}`)
+  const pkgDir = path.join(installDir, 'node_modules', 'pnpm')
+  fs.mkdirSync(pkgDir, { recursive: true })
+  fs.writeFileSync(path.join(installDir, 'package.json'), JSON.stringify({ dependencies: { pnpm: version } }), 'utf8')
+  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: 'pnpm', version, bin: { pnpm: 'bin.js' } }), 'utf8')
+  fs.writeFileSync(path.join(pkgDir, 'bin.js'), `#!/usr/bin/env node
+console.log('${version}')`, 'utf8')
+  fs.symlinkSync(installDir, path.join(opts.globalPkgDir, `hash-${version}`))
+  return installDir
 }
 
 test('self-update', async () => {
@@ -258,6 +272,7 @@ test('self-update by exact version', async () => {
 
 test('self-update does nothing when pnpm is up to date', async () => {
   const opts = prepare()
+  seedGlobalPnpm(opts, '9.0.0')
   getMockAgent().get(opts.registries.default.replace(/\/$/, ''))
     .intercept({ path: '/pnpm', method: 'GET' })
     .reply(200, createMetadata('9.0.0', opts.registries.default))
@@ -265,6 +280,31 @@ test('self-update does nothing when pnpm is up to date', async () => {
   const output = await selfUpdate.handler(opts, [])
 
   expect(output).toBe('The currently active pnpm v9.0.0 is already "latest" and doesn\'t need an update')
+})
+
+test('self-update installs the active pnpm version when it is missing from the global dir', async () => {
+  mockPackageManager.version = '9.1.0'
+  const opts = prepare()
+  mockRegistryForUpdate(opts.registries.default, '9.1.0', createMetadata('9.1.0', opts.registries.default))
+
+  const output = await selfUpdate.handler(opts, ['9.1.0'])
+
+  expect(output).toBe('Successfully updated pnpm to v9.1.0')
+  const globalEntries = fs.readdirSync(opts.globalPkgDir)
+  const installDirName = globalEntries.find((e) => fs.lstatSync(path.join(opts.globalPkgDir, e)).isDirectory())
+  expect(installDirName).toBeDefined()
+  const pnpmPkgJson = JSON.parse(fs.readFileSync(path.join(opts.globalPkgDir, installDirName!, 'node_modules/pnpm/package.json'), 'utf8'))
+  expect(pnpmPkgJson.version).toBe('9.1.0')
+
+  const pnpmEnv = prependDirsToPath([path.join(opts.pnpmHomeDir, 'bin')])
+  const { status, stdout } = spawn.sync('pnpm', ['-v'], {
+    env: {
+      ...process.env,
+      [pnpmEnv.name]: pnpmEnv.value,
+    },
+  })
+  expect(status).toBe(0)
+  expect(stdout.toString().trim()).toBe('9.1.0')
 })
 
 test('self-update respects minimumReleaseAge for implicit latest resolution', async () => {
@@ -387,9 +427,11 @@ test('global self-update respects minimumReleaseAge: skips immature latest, no-o
   // wantedPackageManager) must not jump to a "latest" version younger than
   // minimumReleaseAge. Active pnpm is mocked as 9.0.0 at the top of this
   // file. The registry's `latest` (9.1.0) is 8h old — immature — so the
-  // resolver should fall back to 9.0.0, which equals the active version,
-  // producing a no-op rather than reinstalling.
+  // resolver should fall back to 9.0.0, which equals the active version and is
+  // already installed globally, producing a no-op rather than reinstalling.
   const opts = prepare()
+  seedGlobalPnpm(opts, '9.0.0')
+  const globalEntriesBefore = fs.readdirSync(opts.globalPkgDir).sort()
   const now = Date.now()
   const metadata = createMetadata('9.1.0', opts.registries.default, ['9.0.0'], {
     '9.0.0': new Date(now - 48 * 60 * 60 * 1000).toISOString(),
@@ -405,9 +447,7 @@ test('global self-update respects minimumReleaseAge: skips immature latest, no-o
   }, [])
 
   expect(output).toBe('The currently active pnpm v9.0.0 is already "latest" and doesn\'t need an update')
-  // No global install dir should have been created.
-  const globalDir = path.join(opts.pnpmHomeDir, 'global', 'v11')
-  expect(fs.existsSync(globalDir)).toBe(false)
+  expect(fs.readdirSync(opts.globalPkgDir).sort()).toStrictEqual(globalEntriesBefore)
 })
 
 test('self-update respects minimumReleaseAgeExclude for implicit latest resolution', async () => {


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#12877.

`pnpm self-update <version>` no longer exits early just because the requested version matches the currently running local pnpm. It only treats that case as a no-op when the same pnpm package is already present in the global self-update directory; otherwise it installs and links the requested version.

The same fix is mirrored in pacquet (`self_update.rs`), whose no-op path had the identical version-equality check. On the TypeScript side, the global-install check is now shared between the no-op guard and the installer via a single `findGlobalPnpmInstallDir` helper.

## Squash Commit Body

```text
Fixes pnpm/pnpm#12877.

The self-update command previously skipped work whenever the resolved target
version matched the currently running pnpm version. That breaks recovery from a
removed global install when a local project pnpm is used to reinstall the same
version globally.

Check the global self-update directory before taking the active-version no-op
path, and add coverage for both cases: already installed globally and missing
globally. Apply the same fix to pacquet's self-update, and deduplicate the
TypeScript global-install check into a shared findGlobalPnpmInstallDir helper.
```

## Checklist

- [x] The change is applied to both stacks: the TypeScript self-update command and pacquet's `self-update`.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users - it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `pnpm self-update <version>` behavior: when the requested version matches the currently running one but isn’t available in the global self-update location, the correct pnpm version is now installed.
  * Updated the “already up to date” check to verify the expected global pnpm installation is present, rather than relying on version equality alone.
  * Added/strengthened handling for missing or unreadable global install data so self-update decisions are more accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Written by an agent (Codex, gpt-5.5).