### PR TITLE
test: make git-resolver and dlx git tests immune to GitHub flakiness

### DIFF
--- a/pnpm11/exec/commands/test/dlx.e2e.ts
+++ b/pnpm11/exec/commands/test/dlx.e2e.ts
@@ -108,8 +108,14 @@ test('dlx install from git', async () => {
     storeDir: path.resolve('store'),
     cacheDir: path.resolve('cache'),
     // A git-hosted artifact has an untrusted package identity, so it has to
-    // be approved by its depPath, not by package name.
-    allowBuild: ['shx@https://codeload.github.com/shelljs/shx/tar.gz/0dcbb9d1022037268959f8b706e0f06a6fd43fde'],
+    // be approved by its depPath, not by package name. Both resolution shapes
+    // are approved because the resolver degrades from the hosted tarball to a
+    // git clone when the repository visibility probe fails (e.g. GitHub rate
+    // limiting on CI).
+    allowBuild: [
+      'shx@https://codeload.github.com/shelljs/shx/tar.gz/0dcbb9d1022037268959f8b706e0f06a6fd43fde',
+      'shx@git+https://github.com/shelljs/shx.git#0dcbb9d1022037268959f8b706e0f06a6fd43fde',
+    ],
   }, ['shelljs/shx#0dcbb9d1022037268959f8b706e0f06a6fd43fde', 'touch', 'foo'])
 
   expect(fs.existsSync('foo')).toBeTruthy()

--- a/pnpm11/resolving/git-resolver/test/index.ts
+++ b/pnpm11/resolving/git-resolver/test/index.ts
@@ -4,11 +4,9 @@ import path from 'node:path'
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import isWindows from 'is-windows'
 
-const { fetchWithDispatcher: fetchWithDispatcherOriginal } = await import('@pnpm/network.fetch')
 jest.unstable_mockModule('@pnpm/network.fetch', () => ({
   fetchWithDispatcher: jest.fn(),
 }))
-const { gracefulGit: gitOriginal } = await import('graceful-git')
 jest.unstable_mockModule('graceful-git', () => ({
   gracefulGit: jest.fn(),
 }))
@@ -19,15 +17,9 @@ const { createGitResolver } = await import('@pnpm/resolving.git-resolver')
 const resolveFromGit = createGitResolver({})
 
 beforeEach(() => {
-  jest.mocked(git).mockImplementation(gitOriginal)
-  jest.mocked(fetchWithDispatcher).mockImplementation(fetchWithDispatcherOriginal)
+  jest.mocked(git).mockImplementation(lsRemoteFromFixture)
+  mockFetchAsPublic()
 })
-
-function mockFetchAsPrivate (): void {
-  jest.mocked(fetchWithDispatcher).mockImplementation(async (_url, _opts) => {
-    return { ok: false } as any // eslint-disable-line @typescript-eslint/no-explicit-any
-  })
-}
 
 test('resolveFromGit() with commit', async () => {
   const resolveResult = await resolveFromGit({ bareSpecifier: 'zkochan/is-negative#163360a8d3ae6bee9524541043197ff356f8ed99' })
@@ -544,6 +536,7 @@ test('resolve a private repository using the HTTPS protocol without auth token',
 })
 
 test('resolve a private repository using the HTTPS protocol with a commit hash', async () => {
+  mockFetchAsPrivate()
   jest.mocked(git).mockImplementation(async (args: string[]) => {
     expect(args).toContain('ls-remote')
     expect(args).toContain('https://github.com/foo/bar.git')
@@ -628,3 +621,57 @@ cba04669e621b85fbdb33371604de1a2898e68e9\trefs/tags/v0.0.39',
     resolvedVia: 'git-repository',
   })
 })
+
+function mockFetchAsPublic (): void {
+  jest.mocked(fetchWithDispatcher).mockImplementation(async (_url, _opts) => {
+    return { ok: true } as any // eslint-disable-line @typescript-eslint/no-explicit-any
+  })
+}
+
+function mockFetchAsPrivate (): void {
+  jest.mocked(fetchWithDispatcher).mockImplementation(async (_url, _opts) => {
+    return { ok: false } as any // eslint-disable-line @typescript-eslint/no-explicit-any
+  })
+}
+
+async function lsRemoteFromFixture (args: string[]): Promise<{ stdout: string }> {
+  const repo = args.find((arg) => REPO_REFS[arg] != null)
+  if (args[0] !== 'ls-remote' || repo == null) {
+    throw new Error(`No fixture for git command: git ${args.join(' ')}`)
+  }
+  return {
+    stdout: REPO_REFS[repo].map(([commit, ref]) => `${commit}\t${ref}`).join('\n'),
+  }
+}
+
+// Captured from `git ls-remote` against the real repositories (abridged for
+// cmd-shim). The commit hashes expected by the tests come from these refs.
+const REPO_REFS: Record<string, Array<[commit: string, ref: string]>> = {
+  'https://github.com/zkochan/is-negative.git': [
+    ['1d7e288222b53a0cab90a331f1865220ec29560c', 'HEAD'],
+    ['4c39fbc124cd4944ee51cb082ad49320fab58121', 'refs/heads/canary'],
+    ['1d7e288222b53a0cab90a331f1865220ec29560c', 'refs/heads/master'],
+    ['163360a8d3ae6bee9524541043197ff356f8ed99', 'refs/tags/1.0.0'],
+    ['9a89df745b2ec20ae7445d3d9853ceaeef5b0b72', 'refs/tags/1.0.1'],
+    ['f7dec4d66a5a56719e49b9f94a24d73f924ddeb3', 'refs/tags/1.0.1^{}'],
+    ['ec74951f0a5d3ba294e11a49230529e89f0ebac7', 'refs/tags/2.0.0'],
+    ['219c424611ff4a2af15f7deeff4f93c62558c43d', 'refs/tags/2.0.0^{}'],
+    ['2fa0531ab04e300a24ef4fd7fb3a280eccb7ccc5', 'refs/tags/2.0.1'],
+    ['6dcce91c268805d456b8a575b67d7febc7ae2933', 'refs/tags/2.0.1^{}'],
+    ['94cd32f6b993eebb3abe891efbec6656b4c56532', 'refs/tags/2.0.2'],
+    ['2a6169d91678bdf435503a35742ca12a1af85396', 'refs/tags/2.0.2^{}'],
+    ['54355c870aab5b671fc7abe261d004b326a2592d', 'refs/tags/2.1.0'],
+    ['a6c51a38c6c1753e8ea1b51dfb4e6f2f8fb55557', 'refs/tags/2.1.0^{}'],
+  ],
+  'https://github.com/zoli-forks/cmd-shim.git': [
+    ['a00a83a1593edb6e395d3ce41f2ef70edf7e2cf5', 'HEAD'],
+    ['884988ef307d9d6e5bc2b93ba013baed552d5091', 'refs/heads/fix/now-cli-issue'],
+    ['a00a83a1593edb6e395d3ce41f2ef70edf7e2cf5', 'refs/heads/main'],
+  ],
+  'https://github.com/pnpm-e2e/simple-pkg.git': [
+    ['2fce895ee534a38989bb67fdb8684f520827f614', 'HEAD'],
+    ['2fce895ee534a38989bb67fdb8684f520827f614', 'refs/heads/branch/with-slash'],
+    ['2fce895ee534a38989bb67fdb8684f520827f614', 'refs/heads/deadbeef'],
+    ['2fce895ee534a38989bb67fdb8684f520827f614', 'refs/heads/main'],
+  ],
+}

--- a/pnpm11/resolving/git-resolver/test/parsePref.test.ts
+++ b/pnpm11/resolving/git-resolver/test/parsePref.test.ts
@@ -1,6 +1,12 @@
-import { expect, test } from '@jest/globals'
+import { expect, jest, test } from '@jest/globals'
 
-import { parseBareSpecifier } from '../lib/parseBareSpecifier.js'
+jest.unstable_mockModule('@pnpm/network.fetch', () => ({
+  fetchWithDispatcher: jest.fn(async () => ({ ok: true })),
+}))
+jest.unstable_mockModule('graceful-git', () => ({
+  gracefulGit: jest.fn(async () => ({ stdout: '' })),
+}))
+const { parseBareSpecifier } = await import('../lib/parseBareSpecifier.js')
 
 test.each([
   ['ssh://username:password@example.com:repo.git', 'ssh://username:password@example.com/repo.git'],


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Two CI failures on 2026-07-09 ([main](https://github.com/pnpm/pnpm/actions/runs/29026897310/job/86153736091), [PR 12846](https://github.com/pnpm/pnpm/actions/runs/29029971938/job/86170695840)) traced back to the same root cause: when GitHub throttles the shared runner IPs, the single-attempt HEAD probe in `isRepoPublic()` fails and git resolution silently degrades from the hosted codeload tarball to a `git+https` clone, changing the resolved id. This PR makes the affected tests immune to that nondeterminism:

- **`resolving/git-resolver/test/index.ts`** hit live github.com by default — the `fetchWithDispatcher`/`graceful-git` mocks existed but `beforeEach` restored the real implementations. The mocks are now the default: fetch reports every repository as public, and git serves `ls-remote` output from a fixture table captured from the real repositories (same commit hashes the assertions already expected). Tests that exercise the private-repo fallback keep overriding the mocks. The suite runs offline and drops from ~40s to under half a second.
- **`resolving/git-resolver/test/parsePref.test.ts`** had one live-network case (`git+https://github.com/pnpm/pnpm.git`) — same mock treatment.
- **`exec/commands/test/dlx.e2e.ts`** ("dlx install from git") stays a genuine e2e test against GitHub, but its `allowBuild` list now approves both resolution shapes of the same commit (codeload tarball and `git+https` clone), so the fallback no longer trips the `GIT_DEP_PREPARE_NOT_ALLOWED` gate.

Not included (possible follow-up): retrying the `isRepoPublic()` HEAD probe in the resolver itself, so transient network failures don't change the resolution shape written to users' lockfiles. That is a user-visible behavior change and needs a matching pacquet change, so it belongs in its own PR.

## Squash Commit Body

```text
The git-resolver unit tests hit live github.com by default: the mocks for
fetchWithDispatcher and graceful-git existed, but beforeEach restored the
real implementations. When GitHub throttles the shared CI runner IPs, the
HEAD probe in isRepoPublic() fails (it has zero retries and treats any
error as "private"), and resolution silently degrades from the hosted
tarball to a git clone, changing the resolved id and failing the
assertions.

The mocks are now the default: fetch reports every repository as public
and graceful-git serves ls-remote output from a fixture table captured
from the real repositories, with the same commit hashes the assertions
already expected. The private-repo-over-HTTPS test now calls
mockFetchAsPrivate() explicitly instead of relying on a real 404 for the
nonexistent github.com/foo/bar. The one live-network case in
parsePref.test.ts got the same treatment. The suite drops from ~40s to
under half a second and runs offline.

The dlx e2e test stays a genuine end-to-end test against GitHub, but its
allowBuild list now approves both resolution shapes of the same commit
(codeload tarball and git+https clone), so the resolver's
rate-limit-induced fallback no longer trips the
GIT_DEP_PREPARE_NOT_ALLOWED gate.
```

## Checklist

- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for installing packages from Git repositories, especially when repository visibility checks return different results.
  * Expanded coverage for Git-based install scenarios so behavior is more consistent across hosted and direct Git resolutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->