### PR TITLE
chore(release): 11.11.0

### DIFF
--- a/.changeset/access-command.md
+++ b/.changeset/access-command.md
@@ -1,6 +1,0 @@
----
-"@pnpm/registry-access.commands": minor
-"pnpm": minor
----
-
-Added the `pnpm access` command for managing package access and visibility on the registry, supporting listing packages and collaborators, getting and setting package status and MFA requirements, and granting or revoking team access.

--- a/.changeset/allow-git-repo-builds.md
+++ b/.changeset/allow-git-repo-builds.md
@@ -1,6 +1,0 @@
----
-"@pnpm/building.policy": patch
-"pnpm": patch
----
-
-Allow `allowBuilds` entries for git-hosted packages to match by repository URL without pinning the resolved commit hash. This lets trusted git repositories keep running their build scripts after branch updates without approving each new commit, while package-name-only rules still do not approve git-hosted artifacts.

--- a/.changeset/cold-resolution-memory.md
+++ b/.changeset/cold-resolution-memory.md
@@ -1,6 +1,0 @@
----
-"@pnpm/resolving.npm-resolver": patch
-"pnpm": patch
----
-
-Reduced peak memory usage during cold-cache dependency resolution. The metadata fetch is memoized for the whole resolution phase, and it was retaining each package's raw registry response body (used only to mirror the response to disk) for that entire time. The memoized cache now holds a body-less copy, so the raw body only lives as long as the call that writes the disk mirror. On large graphs that fetch full metadata (e.g. with `minimumReleaseAge` or `trustPolicy` enabled) this cuts peak RSS by roughly 30%, back in line with pnpm 10. The resolved lockfile is unchanged.

--- a/.changeset/contain-virtual-store-package-name.md
+++ b/.changeset/contain-virtual-store-package-name.md
@@ -1,8 +1,0 @@
----
-"@pnpm/deps.graph-builder": patch
-"@pnpm/deps.graph-hasher": patch
-"@pnpm/lockfile.to-pnp": patch
-"pnpm": patch
----
-
-Prevent a crafted `pnpm-lock.yaml` from writing package content outside the virtual store. A dependency path key whose name reconstructs to a path-traversal sequence (e.g. `../../../tmp/x@1.0.0`) is now rejected by the isolated (virtual-store) linker and the Plug'n'Play resolver map, matching the containment already applied to the hoisted linker. Under the global virtual store, a traversal in the version-derived path segment (e.g. a snapshot `version: "../../x"`) is now rejected at `formatGlobalVirtualStorePath`, the single point every global-virtual-store slot path funnels through — closing the same escape in the isolated linker, the resolver's dependency-graph builder, and the config-dependency installer.

--- a/.changeset/env-lockfile-symlink.md
+++ b/.changeset/env-lockfile-symlink.md
@@ -1,6 +1,0 @@
----
-"@pnpm/lockfile.fs": patch
-"pnpm": patch
----
-
-Reject symlinked `pnpm-lock.yaml` files when reading or writing the env lockfile document.

--- a/.changeset/global-registries-config.md
+++ b/.changeset/global-registries-config.md
@@ -1,7 +1,0 @@
----
-"@pnpm/config.commands": patch
-"@pnpm/config.reader": patch
-"pnpm": patch
----
-
-Allow `registries` and `namedRegistries` to be configured in the global `config.yaml` file.

--- a/.changeset/isolated-linker-name-traversal.md
+++ b/.changeset/isolated-linker-name-traversal.md
@@ -1,8 +1,0 @@
----
-"@pnpm/installing.deps-resolver": patch
-"@pnpm/deps.graph-builder": patch
-"@pnpm/installing.env-installer": patch
-"pnpm": patch
----
-
-Fixed a path traversal vulnerability where a dependency whose manifest `name` was a scoped path traversal (e.g. `@x/../../../<path>`) could be written outside `node_modules` to an attacker-controlled location during `pnpm install`, even with `--ignore-scripts`. The isolated linker now validates the package name before using it as a directory name, matching the existing protection in the hoisted linker.

--- a/.changeset/optional-locked-resolution-failure.md
+++ b/.changeset/optional-locked-resolution-failure.md
@@ -1,6 +1,0 @@
----
-"@pnpm/installing.deps-resolver": patch
-"pnpm": patch
----
-
-Fail instead of silently removing an optional dependency's locked entries from `pnpm-lock.yaml` when the registry cannot resolve it. Previously, when registry metadata lacked a version that the lockfile already pinned (for example, a mirror that had not synced a recent release yet), `pnpm install` and `pnpm dedupe` silently dropped the optional dependency's entries — emptying maps such as the platform binaries of `@napi-rs/canvas` — so the lockfile differed between machines and frozen installs on other hosts had nothing to link [#12853](https://github.com/pnpm/pnpm/issues/12853).

--- a/.changeset/peer-closures-root-context.md
+++ b/.changeset/peer-closures-root-context.md
@@ -1,6 +1,0 @@
----
-"@pnpm/installing.deps-resolver": patch
-"pnpm": patch
----
-
-Fixed peer dependency resolution with `autoInstallPeers` when a workspace package depends on a version of a package that a transitive dependency's self-contained closure also provides for itself. The peer providers that are attached to the root project for reuse are no longer peer-resolved a second time in the root context, so packages inside such a closure no longer get their peers bound to the root project's incompatible version [#4993](https://github.com/pnpm/pnpm/issues/4993).

--- a/.changeset/proxy-fields-env-expansion.md
+++ b/.changeset/proxy-fields-env-expansion.md
@@ -1,6 +1,0 @@
----
-"@pnpm/config.reader": patch
-"pnpm": patch
----
-
-`${...}` environment-variable placeholders in the `httpProxy`, `httpsProxy`, `noProxy`, `proxy`, and `noproxy` settings are no longer expanded when these settings come from a project's `pnpm-workspace.yaml`. They now receive the same protection already applied to `registry`, `namedRegistries`, and `pnprServer`.

--- a/.changeset/publish-redact-registry-credentials.md
+++ b/.changeset/publish-redact-registry-credentials.md
@@ -1,6 +1,0 @@
----
-"@pnpm/releasing.commands": patch
-"pnpm": patch
----
-
-`pnpm publish` no longer prints credentials when the target registry is configured with inline `user:pass@` credentials (e.g. `registry=https://user:pass@example.com/`). They are now redacted both from the "publishing to registry" line and from the OIDC (trusted publishing) failure messages.

--- a/.changeset/self-update-trust-policy.md
+++ b/.changeset/self-update-trust-policy.md
@@ -1,6 +1,0 @@
----
-"@pnpm/engine.pm.commands": patch
-"pnpm": patch
----
-
-`pnpm self-update` now honors `trustPolicy=no-downgrade`. It resolves the target pnpm version against full registry metadata, so it refuses to switch to a version whose supply-chain trust evidence is weaker than an earlier-published one, the same way a regular install does.

--- a/.changeset/smooth-rules-hear.md
+++ b/.changeset/smooth-rules-hear.md
@@ -1,6 +1,0 @@
----
-"@pnpm/cli.commands": patch
-"pnpm": patch
----
-
-Register the `pn` alias in generated shell completion scripts.

--- a/.changeset/standalone-downgrade-pnpm.md
+++ b/.changeset/standalone-downgrade-pnpm.md
@@ -1,6 +1,0 @@
----
-"@pnpm/global.commands": patch
-"pnpm": patch
----
-
-Fixed standalone installer downgrades from pnpm v12 to v11.

--- a/.changeset/validate-runtime-name.md
+++ b/.changeset/validate-runtime-name.md
@@ -1,6 +1,0 @@
----
-"@pnpm/engine.runtime.commands": patch
-"pnpm": patch
----
-
-`pnpm runtime set <name> <version>` now validates its arguments: the name must be `node`, `deno`, or `bun`, and the version must not contain a comma. Previously these were interpolated straight into a `pnpm add` selector, where an unsupported name or a comma (e.g. `node 22,is-positive`) could be misread as a list of packages or a local directory and install unintended packages or bins.

--- a/.meta-updater/CHANGELOG.md
+++ b/.meta-updater/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm-private/updater
 
+## 1100.0.23
+
+### Patch Changes
+
+- Updated dependencies [f8058eb]
+  - @pnpm/lockfile.fs@1100.1.9
+
 ## 1100.0.22
 
 ### Patch Changes

--- a/.meta-updater/package.json
+++ b/.meta-updater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm-private/updater",
-  "version": "1100.0.22",
+  "version": "1100.0.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pnpm11/auth/commands/CHANGELOG.md
+++ b/pnpm11/auth/commands/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/auth.commands
 
+## 1100.2.8
+
+### Patch Changes
+
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/config.reader@1101.11.1
+
 ## 1100.2.7
 
 ### Patch Changes

--- a/pnpm11/auth/commands/package.json
+++ b/pnpm11/auth/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/auth.commands",
-  "version": "1100.2.7",
+  "version": "1100.2.8",
   "description": "Commands for authentication with npm registries",
   "keywords": [
     "pnpm",

--- a/pnpm11/building/after-install/CHANGELOG.md
+++ b/pnpm11/building/after-install/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @pnpm/building.after-install
 
+## 1102.0.4
+
+### Patch Changes
+
+- Updated dependencies [c70e33e]
+- Updated dependencies [51300fd]
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/building.policy@1100.0.12
+  - @pnpm/deps.graph-hasher@1100.2.8
+  - @pnpm/config.reader@1101.11.1
+  - @pnpm/installing.context@1100.0.22
+  - @pnpm/store.connection-manager@1100.3.4
+
 ## 1102.0.3
 
 ### Patch Changes

--- a/pnpm11/building/after-install/package.json
+++ b/pnpm11/building/after-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/building.after-install",
-  "version": "1102.0.3",
+  "version": "1102.0.4",
   "description": "Rebuild packages that are already installed by running their lifecycle scripts",
   "keywords": [
     "pnpm",

--- a/pnpm11/building/commands/CHANGELOG.md
+++ b/pnpm11/building/commands/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @pnpm/building.commands
 
+## 1100.1.9
+
+### Patch Changes
+
+- Updated dependencies [c70e33e]
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/building.policy@1100.0.12
+  - @pnpm/config.reader@1101.11.1
+  - @pnpm/building.after-install@1102.0.4
+  - @pnpm/installing.commands@1100.10.3
+  - @pnpm/store.connection-manager@1100.3.4
+
 ## 1100.1.8
 
 ### Patch Changes

--- a/pnpm11/building/commands/package.json
+++ b/pnpm11/building/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/building.commands",
-  "version": "1100.1.8",
+  "version": "1100.1.9",
   "description": "Commands for rebuilding and managing dependency builds",
   "keywords": [
     "pnpm",

--- a/pnpm11/building/during-install/CHANGELOG.md
+++ b/pnpm11/building/during-install/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @pnpm/building.during-install
 
+## 1102.0.4
+
+### Patch Changes
+
+- Updated dependencies [51300fd]
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/deps.graph-hasher@1100.2.8
+  - @pnpm/config.reader@1101.11.1
+
 ## 1102.0.3
 
 ### Patch Changes

--- a/pnpm11/building/during-install/package.json
+++ b/pnpm11/building/during-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/building.during-install",
-  "version": "1102.0.3",
+  "version": "1102.0.4",
   "description": "Build packages in node_modules",
   "keywords": [
     "pnpm",

--- a/pnpm11/building/policy/CHANGELOG.md
+++ b/pnpm11/building/policy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/building.policy
 
+## 1100.0.12
+
+### Patch Changes
+
+- c70e33e: Allow `allowBuilds` entries for git-hosted packages to match by repository URL without pinning the resolved commit hash. This lets trusted git repositories keep running their build scripts after branch updates without approving each new commit, while package-name-only rules still do not approve git-hosted artifacts.
+
 ## 1100.0.11
 
 ### Patch Changes

--- a/pnpm11/building/policy/package.json
+++ b/pnpm11/building/policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/building.policy",
-  "version": "1100.0.11",
+  "version": "1100.0.12",
   "description": "Create a function for filtering out dependencies that are not allowed to be built",
   "keywords": [
     "pnpm",

--- a/pnpm11/cache/api/CHANGELOG.md
+++ b/pnpm11/cache/api/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @pnpm/cache.api
 
+## 1100.0.26
+
+### Patch Changes
+
+- Updated dependencies [3067e4f]
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/resolving.npm-resolver@1102.1.2
+  - @pnpm/config.reader@1101.11.1
+
 ## 1100.0.25
 
 ### Patch Changes

--- a/pnpm11/cache/api/package.json
+++ b/pnpm11/cache/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/cache.api",
-  "version": "1100.0.25",
+  "version": "1100.0.26",
   "description": "API for controlling the cache",
   "keywords": [
     "pnpm",

--- a/pnpm11/cache/commands/CHANGELOG.md
+++ b/pnpm11/cache/commands/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @pnpm/cache.commands
 
+## 1100.0.27
+
+### Patch Changes
+
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/config.reader@1101.11.1
+  - @pnpm/cache.api@1100.0.26
+
 ## 1100.0.26
 
 ### Patch Changes

--- a/pnpm11/cache/commands/package.json
+++ b/pnpm11/cache/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/cache.commands",
-  "version": "1100.0.26",
+  "version": "1100.0.27",
   "description": "Commands for controlling the cache",
   "keywords": [
     "pnpm",

--- a/pnpm11/cli/commands/CHANGELOG.md
+++ b/pnpm11/cli/commands/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @pnpm/cli.commands
 
+## 1100.0.25
+
+### Patch Changes
+
+- a8ad82d: Register the `pn` alias in generated shell completion scripts.
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/config.reader@1101.11.1
+
 ## 1100.0.24
 
 ### Patch Changes

--- a/pnpm11/cli/commands/package.json
+++ b/pnpm11/cli/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/cli.commands",
-  "version": "1100.0.24",
+  "version": "1100.0.25",
   "description": "Commands for pnpm CLI",
   "keywords": [
     "pnpm",

--- a/pnpm11/cli/default-reporter/CHANGELOG.md
+++ b/pnpm11/cli/default-reporter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/default-reporter
 
+## 1100.3.5
+
+### Patch Changes
+
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/config.reader@1101.11.1
+
 ## 1100.3.4
 
 ### Patch Changes

--- a/pnpm11/cli/default-reporter/package.json
+++ b/pnpm11/cli/default-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/cli.default-reporter",
-  "version": "1100.3.4",
+  "version": "1100.3.5",
   "description": "The default reporter of pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/config/commands/CHANGELOG.md
+++ b/pnpm11/config/commands/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @pnpm/plugin-commands-config
 
+## 1100.0.26
+
+### Patch Changes
+
+- 9318a11: Allow `registries` and `namedRegistries` to be configured in the global `config.yaml` file.
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/config.reader@1101.11.1
+
 ## 1100.0.25
 
 ### Patch Changes

--- a/pnpm11/config/commands/package.json
+++ b/pnpm11/config/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/config.commands",
-  "version": "1100.0.25",
+  "version": "1100.0.26",
   "description": "Commands for reading and writing settings to/from config files",
   "keywords": [
     "pnpm",

--- a/pnpm11/config/reader/CHANGELOG.md
+++ b/pnpm11/config/reader/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/config
 
+## 1101.11.1
+
+### Patch Changes
+
+- 9318a11: Allow `registries` and `namedRegistries` to be configured in the global `config.yaml` file.
+- 5a4daec: `${...}` environment-variable placeholders in the `httpProxy`, `httpsProxy`, `noProxy`, `proxy`, and `noproxy` settings are no longer expanded when these settings come from a project's `pnpm-workspace.yaml`. They now receive the same protection already applied to `registry`, `namedRegistries`, and `pnprServer`.
+
 ## 1101.11.0
 
 ### Minor Changes

--- a/pnpm11/config/reader/package.json
+++ b/pnpm11/config/reader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/config.reader",
-  "version": "1101.11.0",
+  "version": "1101.11.1",
   "description": "Gets configuration options for pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/compliance/audit/CHANGELOG.md
+++ b/pnpm11/deps/compliance/audit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/audit
 
+## 1101.0.20
+
+### Patch Changes
+
+- Updated dependencies [f8058eb]
+  - @pnpm/lockfile.fs@1100.1.9
+
 ## 1101.0.19
 
 ### Patch Changes

--- a/pnpm11/deps/compliance/audit/package.json
+++ b/pnpm11/deps/compliance/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.compliance.audit",
-  "version": "1101.0.19",
+  "version": "1101.0.20",
   "description": "Audit a lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/compliance/commands/CHANGELOG.md
+++ b/pnpm11/deps/compliance/commands/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @pnpm/deps.compliance.commands
 
+## 1101.5.2
+
+### Patch Changes
+
+- Updated dependencies [f8058eb]
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/lockfile.fs@1100.1.9
+  - @pnpm/config.reader@1101.11.1
+  - @pnpm/installing.commands@1100.10.3
+  - @pnpm/deps.compliance.audit@1101.0.20
+  - @pnpm/deps.compliance.license-scanner@1100.0.23
+
 ## 1101.5.1
 
 ### Patch Changes

--- a/pnpm11/deps/compliance/commands/package.json
+++ b/pnpm11/deps/compliance/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.compliance.commands",
-  "version": "1101.5.1",
+  "version": "1101.5.2",
   "description": "pnpm commands for audit, licenses, and sbom",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/compliance/license-scanner/CHANGELOG.md
+++ b/pnpm11/deps/compliance/license-scanner/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/license-scanner
 
+## 1100.0.23
+
+### Patch Changes
+
+- Updated dependencies [f8058eb]
+  - @pnpm/lockfile.fs@1100.1.9
+
 ## 1100.0.22
 
 ### Patch Changes

--- a/pnpm11/deps/compliance/license-scanner/package.json
+++ b/pnpm11/deps/compliance/license-scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.compliance.license-scanner",
-  "version": "1100.0.22",
+  "version": "1100.0.23",
   "description": "Check for licenses packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/graph-builder/CHANGELOG.md
+++ b/pnpm11/deps/graph-builder/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @pnpm/deps.graph-builder
 
+## 1100.0.20
+
+### Patch Changes
+
+- 51300fd: Prevent a crafted `pnpm-lock.yaml` from writing package content outside the virtual store. A dependency path key whose name reconstructs to a path-traversal sequence (e.g. `../../../tmp/x@1.0.0`) is now rejected by the isolated (virtual-store) linker and the Plug'n'Play resolver map, matching the containment already applied to the hoisted linker. Under the global virtual store, a traversal in the version-derived path segment (e.g. a snapshot `version: "../../x"`) is now rejected at `formatGlobalVirtualStorePath`, the single point every global-virtual-store slot path funnels through — closing the same escape in the isolated linker, the resolver's dependency-graph builder, and the config-dependency installer.
+- 51300fd: Fixed a path traversal vulnerability where a dependency whose manifest `name` was a scoped path traversal (e.g. `@x/../../../<path>`) could be written outside `node_modules` to an attacker-controlled location during `pnpm install`, even with `--ignore-scripts`. The isolated linker now validates the package name before using it as a directory name, matching the existing protection in the hoisted linker.
+- Updated dependencies [51300fd]
+- Updated dependencies [f8058eb]
+  - @pnpm/deps.graph-hasher@1100.2.8
+  - @pnpm/lockfile.fs@1100.1.9
+
 ## 1100.0.19
 
 ### Patch Changes

--- a/pnpm11/deps/graph-builder/package.json
+++ b/pnpm11/deps/graph-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.graph-builder",
-  "version": "1100.0.19",
+  "version": "1100.0.20",
   "description": "A package for building a dependency graph from a lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/graph-hasher/CHANGELOG.md
+++ b/pnpm11/deps/graph-hasher/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/calc-dep-state
 
+## 1100.2.8
+
+### Patch Changes
+
+- 51300fd: Prevent a crafted `pnpm-lock.yaml` from writing package content outside the virtual store. A dependency path key whose name reconstructs to a path-traversal sequence (e.g. `../../../tmp/x@1.0.0`) is now rejected by the isolated (virtual-store) linker and the Plug'n'Play resolver map, matching the containment already applied to the hoisted linker. Under the global virtual store, a traversal in the version-derived path segment (e.g. a snapshot `version: "../../x"`) is now rejected at `formatGlobalVirtualStorePath`, the single point every global-virtual-store slot path funnels through — closing the same escape in the isolated linker, the resolver's dependency-graph builder, and the config-dependency installer.
+
 ## 1100.2.7
 
 ### Patch Changes

--- a/pnpm11/deps/graph-hasher/package.json
+++ b/pnpm11/deps/graph-hasher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.graph-hasher",
-  "version": "1100.2.7",
+  "version": "1100.2.8",
   "description": "Calculates the state of a dependency",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/inspection/commands/CHANGELOG.md
+++ b/pnpm11/deps/inspection/commands/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @pnpm/deps.inspection.commands
 
+## 1100.5.1
+
+### Patch Changes
+
+- Updated dependencies [3067e4f]
+- Updated dependencies [f8058eb]
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+- Updated dependencies [25bd5c3]
+  - @pnpm/resolving.npm-resolver@1102.1.2
+  - @pnpm/lockfile.fs@1100.1.9
+  - @pnpm/config.reader@1101.11.1
+  - @pnpm/global.commands@1100.0.32
+  - @pnpm/deps.inspection.outdated@1100.1.12
+  - @pnpm/resolving.default-resolver@1100.3.12
+  - @pnpm/deps.inspection.list@1100.0.22
+  - @pnpm/deps.inspection.peers-checker@1100.0.18
+
 ## 1100.5.0
 
 ### Minor Changes

--- a/pnpm11/deps/inspection/commands/package.json
+++ b/pnpm11/deps/inspection/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.commands",
-  "version": "1100.5.0",
+  "version": "1100.5.1",
   "description": "The list, ll, why, and outdated commands of pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/inspection/list/CHANGELOG.md
+++ b/pnpm11/deps/inspection/list/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/list
 
+## 1100.0.22
+
+### Patch Changes
+
+- Updated dependencies [f8058eb]
+  - @pnpm/lockfile.fs@1100.1.9
+  - @pnpm/deps.inspection.tree-builder@1100.0.19
+
 ## 1100.0.21
 
 ### Patch Changes

--- a/pnpm11/deps/inspection/list/package.json
+++ b/pnpm11/deps/inspection/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.list",
-  "version": "1100.0.21",
+  "version": "1100.0.22",
   "description": "List installed packages in a symlinked `node_modules`",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/inspection/outdated/CHANGELOG.md
+++ b/pnpm11/deps/inspection/outdated/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @pnpm/outdated
 
+## 1100.1.12
+
+### Patch Changes
+
+- Updated dependencies [3067e4f]
+- Updated dependencies [f8058eb]
+  - @pnpm/resolving.npm-resolver@1102.1.2
+  - @pnpm/lockfile.fs@1100.1.9
+  - @pnpm/installing.client@1100.2.12
+
 ## 1100.1.11
 
 ### Patch Changes

--- a/pnpm11/deps/inspection/outdated/package.json
+++ b/pnpm11/deps/inspection/outdated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.outdated",
-  "version": "1100.1.11",
+  "version": "1100.1.12",
   "description": "Check for outdated packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/inspection/peers-checker/CHANGELOG.md
+++ b/pnpm11/deps/inspection/peers-checker/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/deps.inspection.peers-checker
 
+## 1100.0.18
+
+### Patch Changes
+
+- Updated dependencies [f8058eb]
+  - @pnpm/lockfile.fs@1100.1.9
+
 ## 1100.0.17
 
 ### Patch Changes

--- a/pnpm11/deps/inspection/peers-checker/package.json
+++ b/pnpm11/deps/inspection/peers-checker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.peers-checker",
-  "version": "1100.0.17",
+  "version": "1100.0.18",
   "description": "Check for unmet and missing peer dependency issues from the lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/inspection/tree-builder/CHANGELOG.md
+++ b/pnpm11/deps/inspection/tree-builder/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/reviewing.dependencies-hierarchy
 
+## 1100.0.19
+
+### Patch Changes
+
+- Updated dependencies [f8058eb]
+  - @pnpm/lockfile.fs@1100.1.9
+
 ## 1100.0.18
 
 ### Patch Changes

--- a/pnpm11/deps/inspection/tree-builder/package.json
+++ b/pnpm11/deps/inspection/tree-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.tree-builder",
-  "version": "1100.0.18",
+  "version": "1100.0.19",
   "description": "Creates a dependencies hierarchy for a symlinked `node_modules`",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/status/CHANGELOG.md
+++ b/pnpm11/deps/status/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @pnpm/deps.status
 
+## 1100.1.5
+
+### Patch Changes
+
+- Updated dependencies [f8058eb]
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/lockfile.fs@1100.1.9
+  - @pnpm/config.reader@1101.11.1
+  - @pnpm/installing.context@1100.0.22
+  - @pnpm/workspace.state@1100.0.26
+  - @pnpm/lockfile.verification@1100.0.22
+  - @pnpm/lockfile.settings-checker@1100.1.1
+
 ## 1100.1.4
 
 ### Patch Changes

--- a/pnpm11/deps/status/package.json
+++ b/pnpm11/deps/status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.status",
-  "version": "1100.1.4",
+  "version": "1100.1.5",
   "description": "Check dependencies status",
   "keywords": [
     "pnpm",

--- a/pnpm11/engine/pm/commands/CHANGELOG.md
+++ b/pnpm11/engine/pm/commands/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @pnpm/engine.pm.commands
 
+## 1101.2.1
+
+### Patch Changes
+
+- dcfc611: `pnpm self-update` now honors `trustPolicy=no-downgrade`. It resolves the target pnpm version against full registry metadata, so it refuses to switch to a version whose supply-chain trust evidence is weaker than an earlier-published one, the same way a regular install does.
+- Updated dependencies [c70e33e]
+- Updated dependencies [3067e4f]
+- Updated dependencies [51300fd]
+- Updated dependencies [f8058eb]
+- Updated dependencies [9318a11]
+- Updated dependencies [51300fd]
+- Updated dependencies [5a4daec]
+- Updated dependencies [25bd5c3]
+  - @pnpm/building.policy@1100.0.12
+  - @pnpm/resolving.npm-resolver@1102.1.2
+  - @pnpm/deps.graph-hasher@1100.2.8
+  - @pnpm/lockfile.fs@1100.1.9
+  - @pnpm/config.reader@1101.11.1
+  - @pnpm/installing.env-installer@1102.0.4
+  - @pnpm/global.commands@1100.0.32
+  - @pnpm/installing.deps-restorer@1102.1.3
+  - @pnpm/installing.client@1100.2.12
+  - @pnpm/store.connection-manager@1100.3.4
+  - @pnpm/store.controller@1102.0.3
+
 ## 1101.2.0
 
 ### Minor Changes

--- a/pnpm11/engine/pm/commands/package.json
+++ b/pnpm11/engine/pm/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/engine.pm.commands",
-  "version": "1101.2.0",
+  "version": "1101.2.1",
   "description": "pnpm commands for self-updating and setting up pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/engine/runtime/bun-resolver/CHANGELOG.md
+++ b/pnpm11/engine/runtime/bun-resolver/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/resolving.bun-resolver
 
+## 1102.0.4
+
+### Patch Changes
+
+- Updated dependencies [3067e4f]
+  - @pnpm/resolving.npm-resolver@1102.1.2
+
 ## 1102.0.3
 
 ### Patch Changes

--- a/pnpm11/engine/runtime/bun-resolver/package.json
+++ b/pnpm11/engine/runtime/bun-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/engine.runtime.bun-resolver",
-  "version": "1102.0.3",
+  "version": "1102.0.4",
   "description": "Resolves the Bun runtime",
   "keywords": [
     "pnpm",

--- a/pnpm11/engine/runtime/commands/CHANGELOG.md
+++ b/pnpm11/engine/runtime/commands/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @pnpm/engine.runtime.commands
 
+## 1100.1.9
+
+### Patch Changes
+
+- 23996e9: `pnpm runtime set <name> <version>` now validates its arguments: the name must be `node`, `deno`, or `bun`, and the version must not contain a comma. Previously these were interpolated straight into a `pnpm add` selector, where an unsupported name or a comma (e.g. `node 22,is-positive`) could be misread as a list of packages or a local directory and install unintended packages or bins.
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/config.reader@1101.11.1
+  - @pnpm/engine.runtime.node-resolver@1101.1.11
+
 ## 1100.1.8
 
 ### Patch Changes

--- a/pnpm11/engine/runtime/commands/package.json
+++ b/pnpm11/engine/runtime/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/engine.runtime.commands",
-  "version": "1100.1.8",
+  "version": "1100.1.9",
   "description": "pnpm commands for managing runtimes",
   "keywords": [
     "pnpm",

--- a/pnpm11/engine/runtime/deno-resolver/CHANGELOG.md
+++ b/pnpm11/engine/runtime/deno-resolver/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/resolving.deno-resolver
 
+## 1102.0.4
+
+### Patch Changes
+
+- Updated dependencies [3067e4f]
+  - @pnpm/resolving.npm-resolver@1102.1.2
+
 ## 1102.0.3
 
 ### Patch Changes

--- a/pnpm11/engine/runtime/deno-resolver/package.json
+++ b/pnpm11/engine/runtime/deno-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/engine.runtime.deno-resolver",
-  "version": "1102.0.3",
+  "version": "1102.0.4",
   "description": "Resolves the Deno runtime",
   "keywords": [
     "pnpm",

--- a/pnpm11/engine/runtime/node-resolver/CHANGELOG.md
+++ b/pnpm11/engine/runtime/node-resolver/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/node.resolver
 
+## 1101.1.11
+
+### Patch Changes
+
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/config.reader@1101.11.1
+
 ## 1101.1.10
 
 ### Patch Changes

--- a/pnpm11/engine/runtime/node-resolver/package.json
+++ b/pnpm11/engine/runtime/node-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/engine.runtime.node-resolver",
-  "version": "1101.1.10",
+  "version": "1101.1.11",
   "description": "Resolves a Node.js version specifier to an exact Node.js version",
   "keywords": [
     "pnpm",

--- a/pnpm11/exec/commands/CHANGELOG.md
+++ b/pnpm11/exec/commands/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @pnpm/plugin-commands-script-runners
 
+## 1100.3.3
+
+### Patch Changes
+
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+- Updated dependencies [23996e9]
+  - @pnpm/config.reader@1101.11.1
+  - @pnpm/engine.runtime.commands@1100.1.9
+  - @pnpm/building.commands@1100.1.9
+  - @pnpm/installing.commands@1100.10.3
+  - @pnpm/installing.client@1100.2.12
+  - @pnpm/deps.status@1100.1.5
+
 ## 1100.3.2
 
 ### Patch Changes

--- a/pnpm11/exec/commands/package.json
+++ b/pnpm11/exec/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/exec.commands",
-  "version": "1100.3.2",
+  "version": "1100.3.3",
   "description": "Commands for running scripts",
   "keywords": [
     "pnpm",

--- a/pnpm11/global/commands/CHANGELOG.md
+++ b/pnpm11/global/commands/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @pnpm/global.commands
 
+## 1100.0.32
+
+### Patch Changes
+
+- 25bd5c3: Fixed standalone installer downgrades from pnpm v12 to v11.
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/config.reader@1101.11.1
+  - @pnpm/installing.deps-installer@1102.2.1
+  - @pnpm/deps.inspection.list@1100.0.22
+  - @pnpm/store.connection-manager@1100.3.4
+
 ## 1100.0.31
 
 ### Patch Changes

--- a/pnpm11/global/commands/package.json
+++ b/pnpm11/global/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/global.commands",
-  "version": "1100.0.31",
+  "version": "1100.0.32",
   "description": "Global package command handlers for pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/client/CHANGELOG.md
+++ b/pnpm11/installing/client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @pnpm/client
 
+## 1100.2.12
+
+### Patch Changes
+
+- Updated dependencies [3067e4f]
+  - @pnpm/resolving.npm-resolver@1102.1.2
+  - @pnpm/resolving.default-resolver@1100.3.12
+  - @pnpm/engine.runtime.node-resolver@1101.1.11
+
 ## 1100.2.11
 
 ### Patch Changes

--- a/pnpm11/installing/client/package.json
+++ b/pnpm11/installing/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.client",
-  "version": "1100.2.11",
+  "version": "1100.2.12",
   "description": "Creates the package resolve and fetch functions",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/commands/CHANGELOG.md
+++ b/pnpm11/installing/commands/CHANGELOG.md
@@ -1,5 +1,33 @@
 # @pnpm/plugin-commands-installation
 
+## 1100.10.3
+
+### Patch Changes
+
+- Updated dependencies [c70e33e]
+- Updated dependencies [3067e4f]
+- Updated dependencies [f8058eb]
+- Updated dependencies [9318a11]
+- Updated dependencies [51300fd]
+- Updated dependencies [5a4daec]
+- Updated dependencies [25bd5c3]
+  - @pnpm/building.policy@1100.0.12
+  - @pnpm/resolving.npm-resolver@1102.1.2
+  - @pnpm/lockfile.fs@1100.1.9
+  - @pnpm/config.reader@1101.11.1
+  - @pnpm/installing.env-installer@1102.0.4
+  - @pnpm/global.commands@1100.0.32
+  - @pnpm/building.after-install@1102.0.4
+  - @pnpm/installing.deps-installer@1102.2.1
+  - @pnpm/deps.inspection.outdated@1100.1.12
+  - @pnpm/workspace.projects-graph@1100.0.22
+  - @pnpm/deps.status@1100.1.5
+  - @pnpm/installing.context@1100.0.22
+  - @pnpm/store.connection-manager@1100.3.4
+  - @pnpm/workspace.state@1100.0.26
+  - @pnpm/store.controller@1102.0.3
+  - @pnpm/workspace.projects-filter@1100.0.25
+
 ## 1100.10.2
 
 ### Patch Changes

--- a/pnpm11/installing/commands/package.json
+++ b/pnpm11/installing/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.commands",
-  "version": "1100.10.2",
+  "version": "1100.10.3",
   "description": "Commands for installation",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/context/CHANGELOG.md
+++ b/pnpm11/installing/context/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @pnpm/get-context
 
+## 1100.0.22
+
+### Patch Changes
+
+- Updated dependencies [f8058eb]
+  - @pnpm/lockfile.fs@1100.1.9
+  - @pnpm/installing.read-projects-context@1100.0.19
+  - @pnpm/store.controller@1102.0.3
+
 ## 1100.0.21
 
 ### Patch Changes

--- a/pnpm11/installing/context/package.json
+++ b/pnpm11/installing/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.context",
-  "version": "1100.0.21",
+  "version": "1100.0.22",
   "description": "Gets context information about a project",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/deps-installer/CHANGELOG.md
+++ b/pnpm11/installing/deps-installer/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @pnpm/core
 
+## 1102.2.1
+
+### Patch Changes
+
+- Updated dependencies [c70e33e]
+- Updated dependencies [51300fd]
+- Updated dependencies [f8058eb]
+- Updated dependencies [51300fd]
+- Updated dependencies [14332f0]
+- Updated dependencies [fecfe83]
+  - @pnpm/building.policy@1100.0.12
+  - @pnpm/deps.graph-hasher@1100.2.8
+  - @pnpm/lockfile.to-pnp@1100.1.3
+  - @pnpm/lockfile.fs@1100.1.9
+  - @pnpm/installing.deps-resolver@1100.2.7
+  - @pnpm/building.after-install@1102.0.4
+  - @pnpm/installing.deps-restorer@1102.1.3
+  - @pnpm/building.during-install@1102.0.4
+  - @pnpm/installing.context@1100.0.22
+  - @pnpm/pnpr.client@1.3.1
+  - @pnpm/installing.package-requester@1102.1.1
+  - @pnpm/lockfile.verification@1100.0.22
+  - @pnpm/lockfile.settings-checker@1100.1.1
+
 ## 1102.2.0
 
 ### Minor Changes

--- a/pnpm11/installing/deps-installer/package.json
+++ b/pnpm11/installing/deps-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.deps-installer",
-  "version": "1102.2.0",
+  "version": "1102.2.1",
   "description": "Fast, disk space efficient installation engine",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/deps-resolver/CHANGELOG.md
+++ b/pnpm11/installing/deps-resolver/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @pnpm/resolve-dependencies
 
+## 1100.2.7
+
+### Patch Changes
+
+- 51300fd: Fixed a path traversal vulnerability where a dependency whose manifest `name` was a scoped path traversal (e.g. `@x/../../../<path>`) could be written outside `node_modules` to an attacker-controlled location during `pnpm install`, even with `--ignore-scripts`. The isolated linker now validates the package name before using it as a directory name, matching the existing protection in the hoisted linker.
+- 14332f0: Fail instead of silently removing an optional dependency's locked entries from `pnpm-lock.yaml` when the registry cannot resolve it. Previously, when registry metadata lacked a version that the lockfile already pinned (for example, a mirror that had not synced a recent release yet), `pnpm install` and `pnpm dedupe` silently dropped the optional dependency's entries — emptying maps such as the platform binaries of `@napi-rs/canvas` — so the lockfile differed between machines and frozen installs on other hosts had nothing to link [#12853](https://github.com/pnpm/pnpm/issues/12853).
+- fecfe83: Fixed peer dependency resolution with `autoInstallPeers` when a workspace package depends on a version of a package that a transitive dependency's self-contained closure also provides for itself. The peer providers that are attached to the root project for reuse are no longer peer-resolved a second time in the root context, so packages inside such a closure no longer get their peers bound to the root project's incompatible version [#4993](https://github.com/pnpm/pnpm/issues/4993).
+- Updated dependencies [3067e4f]
+- Updated dependencies [51300fd]
+  - @pnpm/resolving.npm-resolver@1102.1.2
+  - @pnpm/deps.graph-hasher@1100.2.8
+
 ## 1100.2.6
 
 ### Patch Changes

--- a/pnpm11/installing/deps-resolver/package.json
+++ b/pnpm11/installing/deps-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.deps-resolver",
-  "version": "1100.2.6",
+  "version": "1100.2.7",
   "description": "Resolves dependency graph of a package",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/deps-restorer/CHANGELOG.md
+++ b/pnpm11/installing/deps-restorer/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @pnpm/headless
 
+## 1102.1.3
+
+### Patch Changes
+
+- Updated dependencies [c70e33e]
+- Updated dependencies [51300fd]
+- Updated dependencies [f8058eb]
+- Updated dependencies [51300fd]
+  - @pnpm/building.policy@1100.0.12
+  - @pnpm/deps.graph-builder@1100.0.20
+  - @pnpm/deps.graph-hasher@1100.2.8
+  - @pnpm/lockfile.to-pnp@1100.1.3
+  - @pnpm/lockfile.fs@1100.1.9
+  - @pnpm/building.during-install@1102.0.4
+  - @pnpm/installing.linking.real-hoist@1100.1.5
+  - @pnpm/installing.package-requester@1102.1.1
+
 ## 1102.1.2
 
 ### Patch Changes

--- a/pnpm11/installing/deps-restorer/package.json
+++ b/pnpm11/installing/deps-restorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.deps-restorer",
-  "version": "1102.1.2",
+  "version": "1102.1.3",
   "description": "Fast installation using only pnpm-lock.yaml",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/env-installer/CHANGELOG.md
+++ b/pnpm11/installing/env-installer/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @pnpm/config.deps-installer
 
+## 1102.0.4
+
+### Patch Changes
+
+- 51300fd: Fixed a path traversal vulnerability where a dependency whose manifest `name` was a scoped path traversal (e.g. `@x/../../../<path>`) could be written outside `node_modules` to an attacker-controlled location during `pnpm install`, even with `--ignore-scripts`. The isolated linker now validates the package name before using it as a directory name, matching the existing protection in the hoisted linker.
+- Updated dependencies [3067e4f]
+- Updated dependencies [51300fd]
+- Updated dependencies [f8058eb]
+- Updated dependencies [51300fd]
+- Updated dependencies [14332f0]
+- Updated dependencies [fecfe83]
+  - @pnpm/resolving.npm-resolver@1102.1.2
+  - @pnpm/deps.graph-hasher@1100.2.8
+  - @pnpm/lockfile.fs@1100.1.9
+  - @pnpm/installing.deps-resolver@1100.2.7
+  - @pnpm/store.controller@1102.0.3
+
 ## 1102.0.3
 
 ### Patch Changes

--- a/pnpm11/installing/env-installer/package.json
+++ b/pnpm11/installing/env-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.env-installer",
-  "version": "1102.0.3",
+  "version": "1102.0.4",
   "description": "Installer for configurational dependencies",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/read-projects-context/CHANGELOG.md
+++ b/pnpm11/installing/read-projects-context/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/read-projects-context
 
+## 1100.0.19
+
+### Patch Changes
+
+- Updated dependencies [f8058eb]
+  - @pnpm/lockfile.fs@1100.1.9
+
 ## 1100.0.18
 
 ### Patch Changes

--- a/pnpm11/installing/read-projects-context/package.json
+++ b/pnpm11/installing/read-projects-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.read-projects-context",
-  "version": "1100.0.18",
+  "version": "1100.0.19",
   "description": "Reads the current state of projects from modules manifest",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/fs/CHANGELOG.md
+++ b/pnpm11/lockfile/fs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/lockfile-file
 
+## 1100.1.9
+
+### Patch Changes
+
+- f8058eb: Reject symlinked `pnpm-lock.yaml` files when reading or writing the env lockfile document.
+
 ## 1100.1.8
 
 ### Patch Changes

--- a/pnpm11/lockfile/fs/package.json
+++ b/pnpm11/lockfile/fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.fs",
-  "version": "1100.1.8",
+  "version": "1100.1.9",
   "description": "Read/write pnpm-lock.yaml files",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/make-dedicated-lockfile/CHANGELOG.md
+++ b/pnpm11/lockfile/make-dedicated-lockfile/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/make-dedicated-lockfile
 
+## 1100.0.23
+
+### Patch Changes
+
+- Updated dependencies [f8058eb]
+  - @pnpm/lockfile.fs@1100.1.9
+
 ## 1100.0.22
 
 ### Patch Changes

--- a/pnpm11/lockfile/make-dedicated-lockfile/package.json
+++ b/pnpm11/lockfile/make-dedicated-lockfile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.make-dedicated-lockfile",
-  "version": "1100.0.22",
+  "version": "1100.0.23",
   "description": "Creates a dedicated lockfile for a subset of workspace projects",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/settings-checker/CHANGELOG.md
+++ b/pnpm11/lockfile/settings-checker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/lockfile.settings-checker
 
+## 1100.1.1
+
+### Patch Changes
+
+- @pnpm/lockfile.verification@1100.0.22
+
 ## 1100.1.0
 
 ### Minor Changes

--- a/pnpm11/lockfile/settings-checker/package.json
+++ b/pnpm11/lockfile/settings-checker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.settings-checker",
-  "version": "1100.1.0",
+  "version": "1100.1.1",
   "description": "Utilities to check if lockfile settings are out-of-date",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/to-pnp/CHANGELOG.md
+++ b/pnpm11/lockfile/to-pnp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/lockfile-to-pnp
 
+## 1100.1.3
+
+### Patch Changes
+
+- 51300fd: Prevent a crafted `pnpm-lock.yaml` from writing package content outside the virtual store. A dependency path key whose name reconstructs to a path-traversal sequence (e.g. `../../../tmp/x@1.0.0`) is now rejected by the isolated (virtual-store) linker and the Plug'n'Play resolver map, matching the containment already applied to the hoisted linker. Under the global virtual store, a traversal in the version-derived path segment (e.g. a snapshot `version: "../../x"`) is now rejected at `formatGlobalVirtualStorePath`, the single point every global-virtual-store slot path funnels through — closing the same escape in the isolated linker, the resolver's dependency-graph builder, and the config-dependency installer.
+- Updated dependencies [f8058eb]
+  - @pnpm/lockfile.fs@1100.1.9
+
 ## 1100.1.2
 
 ### Patch Changes

--- a/pnpm11/lockfile/to-pnp/package.json
+++ b/pnpm11/lockfile/to-pnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.to-pnp",
-  "version": "1100.1.2",
+  "version": "1100.1.3",
   "description": "Creates a Plug'n'Play file from a pnpm-lock.yaml",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/verification/CHANGELOG.md
+++ b/pnpm11/lockfile/verification/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/lockfile.verification
 
+## 1100.0.22
+
+### Patch Changes
+
+- @pnpm/installing.context@1100.0.22
+
 ## 1100.0.21
 
 ### Patch Changes

--- a/pnpm11/lockfile/verification/package.json
+++ b/pnpm11/lockfile/verification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.verification",
-  "version": "1100.0.21",
+  "version": "1100.0.22",
   "description": "Checks a lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/modules-mounter/daemon/CHANGELOG.md
+++ b/pnpm11/modules-mounter/daemon/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @pnpm/mount-modules
 
+## 1100.0.26
+
+### Patch Changes
+
+- Updated dependencies [f8058eb]
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/lockfile.fs@1100.1.9
+  - @pnpm/config.reader@1101.11.1
+
 ## 1100.0.25
 
 ### Patch Changes

--- a/pnpm11/modules-mounter/daemon/package.json
+++ b/pnpm11/modules-mounter/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/modules-mounter.daemon",
-  "version": "1100.0.25",
+  "version": "1100.0.26",
   "description": "Mounts a node_modules directory with FUSE",
   "keywords": [
     "pnpm",

--- a/pnpm11/patching/commands/CHANGELOG.md
+++ b/pnpm11/patching/commands/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @pnpm/plugin-commands-patching
 
+## 1100.1.9
+
+### Patch Changes
+
+- Updated dependencies [f8058eb]
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/lockfile.fs@1100.1.9
+  - @pnpm/config.reader@1101.11.1
+  - @pnpm/installing.commands@1100.10.3
+  - @pnpm/store.connection-manager@1100.3.4
+
 ## 1100.1.8
 
 ### Patch Changes

--- a/pnpm11/patching/commands/package.json
+++ b/pnpm11/patching/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/patching.commands",
-  "version": "1100.1.8",
+  "version": "1100.1.9",
   "description": "Commands for creating patches",
   "keywords": [
     "pnpm",

--- a/pnpm11/pkg-manifest/commands/CHANGELOG.md
+++ b/pnpm11/pkg-manifest/commands/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/pkg-manifest.commands
 
+## 1100.1.10
+
+### Patch Changes
+
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/config.reader@1101.11.1
+
 ## 1100.1.9
 
 ### Patch Changes

--- a/pnpm11/pkg-manifest/commands/package.json
+++ b/pnpm11/pkg-manifest/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/pkg-manifest.commands",
-  "version": "1100.1.9",
+  "version": "1100.1.10",
   "description": "Commands for managing package.json",
   "keywords": [
     "pnpm",

--- a/pnpm11/pnpm/CHANGELOG.md
+++ b/pnpm11/pnpm/CHANGELOG.md
@@ -1,5 +1,28 @@
 # pnpm
 
+## 11.11.0
+
+### Minor Changes
+
+- 508b8c2: Added the `pnpm access` command for managing package access and visibility on the registry, supporting listing packages and collaborators, getting and setting package status and MFA requirements, and granting or revoking team access.
+
+### Patch Changes
+
+- c70e33e: Allow `allowBuilds` entries for git-hosted packages to match by repository URL without pinning the resolved commit hash. This lets trusted git repositories keep running their build scripts after branch updates without approving each new commit, while package-name-only rules still do not approve git-hosted artifacts.
+- 3067e4f: Reduced peak memory usage during cold-cache dependency resolution. The metadata fetch is memoized for the whole resolution phase, and it was retaining each package's raw registry response body (used only to mirror the response to disk) for that entire time. The memoized cache now holds a body-less copy, so the raw body only lives as long as the call that writes the disk mirror. On large graphs that fetch full metadata (e.g. with `minimumReleaseAge` or `trustPolicy` enabled) this cuts peak RSS by roughly 30%, back in line with pnpm 10. The resolved lockfile is unchanged.
+- 51300fd: Prevent a crafted `pnpm-lock.yaml` from writing package content outside the virtual store. A dependency path key whose name reconstructs to a path-traversal sequence (e.g. `../../../tmp/x@1.0.0`) is now rejected by the isolated (virtual-store) linker and the Plug'n'Play resolver map, matching the containment already applied to the hoisted linker. Under the global virtual store, a traversal in the version-derived path segment (e.g. a snapshot `version: "../../x"`) is now rejected at `formatGlobalVirtualStorePath`, the single point every global-virtual-store slot path funnels through — closing the same escape in the isolated linker, the resolver's dependency-graph builder, and the config-dependency installer.
+- f8058eb: Reject symlinked `pnpm-lock.yaml` files when reading or writing the env lockfile document.
+- 9318a11: Allow `registries` and `namedRegistries` to be configured in the global `config.yaml` file.
+- 51300fd: Fixed a path traversal vulnerability where a dependency whose manifest `name` was a scoped path traversal (e.g. `@x/../../../<path>`) could be written outside `node_modules` to an attacker-controlled location during `pnpm install`, even with `--ignore-scripts`. The isolated linker now validates the package name before using it as a directory name, matching the existing protection in the hoisted linker.
+- 14332f0: Fail instead of silently removing an optional dependency's locked entries from `pnpm-lock.yaml` when the registry cannot resolve it. Previously, when registry metadata lacked a version that the lockfile already pinned (for example, a mirror that had not synced a recent release yet), `pnpm install` and `pnpm dedupe` silently dropped the optional dependency's entries — emptying maps such as the platform binaries of `@napi-rs/canvas` — so the lockfile differed between machines and frozen installs on other hosts had nothing to link [#12853](https://github.com/pnpm/pnpm/issues/12853).
+- fecfe83: Fixed peer dependency resolution with `autoInstallPeers` when a workspace package depends on a version of a package that a transitive dependency's self-contained closure also provides for itself. The peer providers that are attached to the root project for reuse are no longer peer-resolved a second time in the root context, so packages inside such a closure no longer get their peers bound to the root project's incompatible version [#4993](https://github.com/pnpm/pnpm/issues/4993).
+- 5a4daec: `${...}` environment-variable placeholders in the `httpProxy`, `httpsProxy`, `noProxy`, `proxy`, and `noproxy` settings are no longer expanded when these settings come from a project's `pnpm-workspace.yaml`. They now receive the same protection already applied to `registry`, `namedRegistries`, and `pnprServer`.
+- d1da02e: `pnpm publish` no longer prints credentials when the target registry is configured with inline `user:pass@` credentials (e.g. `registry=https://user:pass@example.com/`). They are now redacted both from the "publishing to registry" line and from the OIDC (trusted publishing) failure messages.
+- dcfc611: `pnpm self-update` now honors `trustPolicy=no-downgrade`. It resolves the target pnpm version against full registry metadata, so it refuses to switch to a version whose supply-chain trust evidence is weaker than an earlier-published one, the same way a regular install does.
+- a8ad82d: Register the `pn` alias in generated shell completion scripts.
+- 25bd5c3: Fixed standalone installer downgrades from pnpm v12 to v11.
+- 23996e9: `pnpm runtime set <name> <version>` now validates its arguments: the name must be `node`, `deno`, or `bun`, and the version must not contain a comma. Previously these were interpolated straight into a `pnpm add` selector, where an unsupported name or a comma (e.g. `node 22,is-positive`) could be misread as a list of packages or a local directory and install unintended packages or bins.
+
 ## 11.10.0
 
 ### Minor Changes

--- a/pnpm11/pnpm/artifacts/darwin-arm64/package.json
+++ b/pnpm11/pnpm/artifacts/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/macos-arm64",
-  "version": "11.10.0",
+  "version": "11.11.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/exe/package.json
+++ b/pnpm11/pnpm/artifacts/exe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/exe",
-  "version": "11.10.0",
+  "version": "11.11.0",
   "description": "Fast, disk space efficient package manager",
   "keywords": [
     "pnpm",

--- a/pnpm11/pnpm/artifacts/linux-arm64-musl/package.json
+++ b/pnpm11/pnpm/artifacts/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linuxstatic-arm64",
-  "version": "11.10.0",
+  "version": "11.11.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/linux-arm64/package.json
+++ b/pnpm11/pnpm/artifacts/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linux-arm64",
-  "version": "11.10.0",
+  "version": "11.11.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/linux-x64-musl/package.json
+++ b/pnpm11/pnpm/artifacts/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linuxstatic-x64",
-  "version": "11.10.0",
+  "version": "11.11.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/linux-x64/package.json
+++ b/pnpm11/pnpm/artifacts/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linux-x64",
-  "version": "11.10.0",
+  "version": "11.11.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/win32-arm64/package.json
+++ b/pnpm11/pnpm/artifacts/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/win-arm64",
-  "version": "11.10.0",
+  "version": "11.11.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/win32-x64/package.json
+++ b/pnpm11/pnpm/artifacts/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/win-x64",
-  "version": "11.10.0",
+  "version": "11.11.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/package.json
+++ b/pnpm11/pnpm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm",
-  "version": "11.10.0",
+  "version": "11.11.0",
   "description": "Fast, disk space efficient package manager",
   "keywords": [
     "pnpm",

--- a/pnpm11/registry-access/commands/CHANGELOG.md
+++ b/pnpm11/registry-access/commands/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @pnpm/registry-access.commands
 
+## 1100.4.0
+
+### Minor Changes
+
+- 508b8c2: Added the `pnpm access` command for managing package access and visibility on the registry, supporting listing packages and collaborators, getting and setting package status and MFA requirements, and granting or revoking team access.
+
+### Patch Changes
+
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/config.reader@1101.11.1
+
 ## 1100.3.7
 
 ### Patch Changes

--- a/pnpm11/registry-access/commands/package.json
+++ b/pnpm11/registry-access/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/registry-access.commands",
-  "version": "1100.3.7",
+  "version": "1100.4.0",
   "description": "Commands for managing packages on the registry",
   "keywords": [
     "pnpm",

--- a/pnpm11/releasing/commands/CHANGELOG.md
+++ b/pnpm11/releasing/commands/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @pnpm/releasing.commands
 
+## 1100.5.4
+
+### Patch Changes
+
+- d1da02e: `pnpm publish` no longer prints credentials when the target registry is configured with inline `user:pass@` credentials (e.g. `registry=https://user:pass@example.com/`). They are now redacted both from the "publishing to registry" line and from the OIDC (trusted publishing) failure messages.
+- Updated dependencies [f8058eb]
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+- Updated dependencies [23996e9]
+  - @pnpm/lockfile.fs@1100.1.9
+  - @pnpm/config.reader@1101.11.1
+  - @pnpm/engine.runtime.commands@1100.1.9
+  - @pnpm/installing.commands@1100.10.3
+  - @pnpm/installing.client@1100.2.12
+  - @pnpm/engine.runtime.node-resolver@1101.1.11
+
 ## 1100.5.3
 
 ### Patch Changes

--- a/pnpm11/releasing/commands/package.json
+++ b/pnpm11/releasing/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/releasing.commands",
-  "version": "1100.5.3",
+  "version": "1100.5.4",
   "description": "Commands for deploy, pack, and publish",
   "keywords": [
     "pnpm",

--- a/pnpm11/resolving/default-resolver/CHANGELOG.md
+++ b/pnpm11/resolving/default-resolver/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @pnpm/default-resolver
 
+## 1100.3.12
+
+### Patch Changes
+
+- Updated dependencies [3067e4f]
+  - @pnpm/resolving.npm-resolver@1102.1.2
+  - @pnpm/engine.runtime.bun-resolver@1102.0.4
+  - @pnpm/engine.runtime.deno-resolver@1102.0.4
+  - @pnpm/engine.runtime.node-resolver@1101.1.11
+
 ## 1100.3.11
 
 ### Patch Changes

--- a/pnpm11/resolving/default-resolver/package.json
+++ b/pnpm11/resolving/default-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/resolving.default-resolver",
-  "version": "1100.3.11",
+  "version": "1100.3.12",
   "description": "pnpm's default package resolver",
   "keywords": [
     "pnpm",

--- a/pnpm11/resolving/npm-resolver/CHANGELOG.md
+++ b/pnpm11/resolving/npm-resolver/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/npm-resolver
 
+## 1102.1.2
+
+### Patch Changes
+
+- 3067e4f: Reduced peak memory usage during cold-cache dependency resolution. The metadata fetch is memoized for the whole resolution phase, and it was retaining each package's raw registry response body (used only to mirror the response to disk) for that entire time. The memoized cache now holds a body-less copy, so the raw body only lives as long as the call that writes the disk mirror. On large graphs that fetch full metadata (e.g. with `minimumReleaseAge` or `trustPolicy` enabled) this cuts peak RSS by roughly 30%, back in line with pnpm 10. The resolved lockfile is unchanged.
+
 ## 1102.1.1
 
 ### Patch Changes

--- a/pnpm11/resolving/npm-resolver/package.json
+++ b/pnpm11/resolving/npm-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/resolving.npm-resolver",
-  "version": "1102.1.1",
+  "version": "1102.1.2",
   "description": "Resolver for npm-hosted packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/store/commands/CHANGELOG.md
+++ b/pnpm11/store/commands/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @pnpm/store.commands
 
+## 1100.0.30
+
+### Patch Changes
+
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/config.reader@1101.11.1
+  - @pnpm/installing.client@1100.2.12
+  - @pnpm/installing.context@1100.0.22
+  - @pnpm/store.connection-manager@1100.3.4
+
 ## 1100.0.29
 
 ### Patch Changes

--- a/pnpm11/store/commands/package.json
+++ b/pnpm11/store/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/store.commands",
-  "version": "1100.0.29",
+  "version": "1100.0.30",
   "description": "Commands for controlling and inspecting the store",
   "keywords": [
     "pnpm",

--- a/pnpm11/store/connection-manager/CHANGELOG.md
+++ b/pnpm11/store/connection-manager/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @pnpm/store-connection-manager
 
+## 1100.3.4
+
+### Patch Changes
+
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/config.reader@1101.11.1
+  - @pnpm/installing.client@1100.2.12
+  - @pnpm/store.controller@1102.0.3
+
 ## 1100.3.3
 
 ### Patch Changes

--- a/pnpm11/store/connection-manager/package.json
+++ b/pnpm11/store/connection-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/store.connection-manager",
-  "version": "1100.3.3",
+  "version": "1100.3.4",
   "description": "Create a pnpm store controller",
   "keywords": [
     "pnpm",

--- a/pnpm11/testing/temp-store/CHANGELOG.md
+++ b/pnpm11/testing/temp-store/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/testing.temp-store
 
+## 1100.1.13
+
+### Patch Changes
+
+- @pnpm/installing.client@1100.2.12
+- @pnpm/store.controller@1102.0.3
+
 ## 1100.1.12
 
 ### Patch Changes

--- a/pnpm11/testing/temp-store/package.json
+++ b/pnpm11/testing/temp-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/testing.temp-store",
-  "version": "1100.1.12",
+  "version": "1100.1.13",
   "description": "A temporary store for testing purposes",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/commands/CHANGELOG.md
+++ b/pnpm11/workspace/commands/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/plugin-commands-init
 
+## 1100.1.24
+
+### Patch Changes
+
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/config.reader@1101.11.1
+
 ## 1100.1.23
 
 ### Patch Changes

--- a/pnpm11/workspace/commands/package.json
+++ b/pnpm11/workspace/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.commands",
-  "version": "1100.1.23",
+  "version": "1100.1.24",
   "description": "Create a package.json file",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/projects-filter/CHANGELOG.md
+++ b/pnpm11/workspace/projects-filter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/filter-workspace-packages
 
+## 1100.0.25
+
+### Patch Changes
+
+- @pnpm/workspace.projects-graph@1100.0.22
+
 ## 1100.0.24
 
 ### Patch Changes

--- a/pnpm11/workspace/projects-filter/package.json
+++ b/pnpm11/workspace/projects-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.projects-filter",
-  "version": "1100.0.24",
+  "version": "1100.0.25",
   "description": "Filters packages in a workspace",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/projects-graph/CHANGELOG.md
+++ b/pnpm11/workspace/projects-graph/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/workspace.pkgs-graph
 
+## 1100.0.22
+
+### Patch Changes
+
+- Updated dependencies [3067e4f]
+  - @pnpm/resolving.npm-resolver@1102.1.2
+
 ## 1100.0.21
 
 ### Patch Changes

--- a/pnpm11/workspace/projects-graph/package.json
+++ b/pnpm11/workspace/projects-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.projects-graph",
-  "version": "1100.0.21",
+  "version": "1100.0.22",
   "description": "Create a graph from an array of packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/state/CHANGELOG.md
+++ b/pnpm11/workspace/state/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/workspace.state
 
+## 1100.0.26
+
+### Patch Changes
+
+- Updated dependencies [9318a11]
+- Updated dependencies [5a4daec]
+  - @pnpm/config.reader@1101.11.1
+
 ## 1100.0.25
 
 ### Patch Changes

--- a/pnpm11/workspace/state/package.json
+++ b/pnpm11/workspace/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.state",
-  "version": "1100.0.25",
+  "version": "1100.0.26",
   "description": "Track the list of actual paths of workspace packages in a cache",
   "keywords": [
     "pnpm",

--- a/pnpr/client/CHANGELOG.md
+++ b/pnpr/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/agent.client
 
+## 1.3.1
+
+### Patch Changes
+
+- Updated dependencies [f8058eb]
+  - @pnpm/lockfile.fs@1100.1.9
+
 ## 1.3.0
 
 ### Minor Changes

--- a/pnpr/client/package.json
+++ b/pnpr/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/pnpr.client",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Client for the pnpr server — resolves a project server-side and receives the resolved lockfile",
   "keywords": [
     "pnpm",


### PR DESCRIPTION
Automated release PR created by the create-release-pr workflow.

Releasing `main` as pnpm v11.11.0. Merging this PR consumes the pending changesets and records them in the `.changeset-released` ledger under `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing registry package access from the CLI.
* **Bug Fixes**
  * Improved install behavior for optional dependencies when the expected package version can’t be resolved.
  * Fixed a number of edge cases around install, workspace, lockfile, publish, and self-update flows.
* **Chores**
  * Updated version numbers across the pnpm 11 release packages and related artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->