### PR TITLE
fix(resolver): recover from unsolicited 304 responses

### DIFF
--- a/.changeset/retry-invalid-304.md
+++ b/.changeset/retry-invalid-304.md
@@ -4,3 +4,5 @@
 ---
 
 Retry package metadata requests when a registry or proxy returns `304 Not Modified` to an unconditional request, preventing false `ERR_PNPM_CACHE_MISSING_AFTER_304` failures [pnpm/pnpm#12882](https://github.com/pnpm/pnpm/issues/12882).
+
+If the retry also returns `304`, report `ERR_PNPM_META_NOT_MODIFIED_WITHOUT_CACHE` instead.

--- a/.changeset/retry-invalid-304.md
+++ b/.changeset/retry-invalid-304.md
@@ -1,6 +1,7 @@
 ---
 "@pnpm/resolving.npm-resolver": patch
 "pnpm": patch
+"pacquet": patch
 ---
 
 Retry package metadata requests when a registry or proxy returns `304 Not Modified` to an unconditional request, preventing false `ERR_PNPM_CACHE_MISSING_AFTER_304` failures [pnpm/pnpm#12882](https://github.com/pnpm/pnpm/issues/12882).

--- a/.changeset/retry-invalid-304.md
+++ b/.changeset/retry-invalid-304.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"pnpm": patch
+---
+
+Retry package metadata requests when a registry or proxy returns `304 Not Modified` to an unconditional request, preventing false `ERR_PNPM_CACHE_MISSING_AFTER_304` failures [pnpm/pnpm#12882](https://github.com/pnpm/pnpm/issues/12882).

--- a/pnpm/crates/resolving-npm-resolver/src/errors.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/errors.rs
@@ -67,12 +67,10 @@ pub enum FetchMetadataError {
         error: serde_json::Error,
     },
 
-    /// `META_NOT_MODIFIED_WITHOUT_CACHE`. Surfaces only when a
-    /// stale-but-removed mirror plus an `If-None-Match` header the
-    /// caller-provided cache headers carried (impossible in pacquet's
-    /// chain because we always read headers off a present mirror)
-    /// would trip a 304 reply we have no body to satisfy — a
-    /// defense-in-depth check for hand-edited caches.
+    /// `META_NOT_MODIFIED_WITHOUT_CACHE`. Surfaces when a registry
+    /// repeats an unsolicited 304 after a cache-bypassing retry, or
+    /// when a stale-but-removed mirror leaves no body to satisfy a
+    /// valid conditional response.
     #[display("Registry returned 304 for {pkg_name} without an existing cache to refresh.")]
     #[diagnostic(code(pacquet_resolving_npm_resolver::not_modified_without_cache))]
     NotModifiedWithoutCache {

--- a/pnpm/crates/resolving-npm-resolver/src/errors.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/errors.rs
@@ -67,12 +67,12 @@ pub enum FetchMetadataError {
         error: serde_json::Error,
     },
 
-    /// `META_NOT_MODIFIED_WITHOUT_CACHE`. Surfaces when a registry
+    /// `ERR_PNPM_META_NOT_MODIFIED_WITHOUT_CACHE`. Surfaces when a registry
     /// repeats an unsolicited 304 after a cache-bypassing retry, or
     /// when a stale-but-removed mirror leaves no body to satisfy a
     /// valid conditional response.
     #[display("Registry returned 304 for {pkg_name} without an existing cache to refresh.")]
-    #[diagnostic(code(pacquet_resolving_npm_resolver::not_modified_without_cache))]
+    #[diagnostic(code(ERR_PNPM_META_NOT_MODIFIED_WITHOUT_CACHE))]
     NotModifiedWithoutCache {
         #[error(not(source))]
         pkg_name: String,

--- a/pnpm/crates/resolving-npm-resolver/src/errors.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/errors.rs
@@ -68,9 +68,8 @@ pub enum FetchMetadataError {
     },
 
     /// `ERR_PNPM_META_NOT_MODIFIED_WITHOUT_CACHE`. Surfaces when a registry
-    /// repeats an unsolicited 304 after a cache-bypassing retry, or
-    /// when a stale-but-removed mirror leaves no body to satisfy a
-    /// valid conditional response.
+    /// repeats an unsolicited 304 after a cache-bypassing retry, leaving no
+    /// body and no validator that could have justified the response.
     #[display("Registry returned 304 for {pkg_name} without an existing cache to refresh.")]
     #[diagnostic(code(ERR_PNPM_META_NOT_MODIFIED_WITHOUT_CACHE))]
     NotModifiedWithoutCache {

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
@@ -18,10 +18,11 @@
 //! demands it.
 
 use pacquet_network::{
-    AuthHeaders, RetryOpts, ThrottledClient, redact_url_credentials, retry_async, send_with_retry,
+    AuthHeaders, RetryOpts, ThrottledClient, ThrottledClientGuard, redact_url_credentials,
+    retry_async, send_with_retry,
 };
 use pacquet_registry::Package;
-use reqwest::{StatusCode, header};
+use reqwest::{Response, StatusCode, header};
 
 use crate::{FetchMetadataError, mirror::clear_meta, registry_url::to_registry_url};
 
@@ -89,6 +90,75 @@ pub enum FetchFullMetadataOutcome {
     NotModified,
 }
 
+pub(crate) struct MetadataRequestOptions<'a> {
+    pub pkg_name: &'a str,
+    pub url: &'a str,
+    pub accept: &'a str,
+    pub http_client: &'a ThrottledClient,
+    pub auth_headers: &'a AuthHeaders,
+    pub etag: Option<&'a str>,
+    pub modified: Option<&'a str>,
+    pub retry_opts: RetryOpts,
+}
+
+/// Send a metadata GET, retrying an unsolicited 304 once with intermediary
+/// cache reuse disabled. A repeated 304 cannot validate any local body and is
+/// reported with the same error in both pnpm implementations.
+pub(crate) async fn send_metadata_request<'a>(
+    opts: &MetadataRequestOptions<'a>,
+) -> Result<(ThrottledClientGuard<'a>, Response), FetchMetadataError> {
+    let etag = opts.etag.filter(|value| !value.is_empty());
+    let modified = opts.modified.filter(|value| !value.is_empty());
+    let has_validator = etag.is_some() || modified.is_some();
+    let build_request = |client: &reqwest::Client, bypass_cache: bool| {
+        let mut request = client.get(opts.url).header(header::ACCEPT, opts.accept);
+        if let Some(value) = opts.auth_headers.for_url_with_package(opts.url, Some(opts.pkg_name)) {
+            request = request.header(header::AUTHORIZATION, value);
+        }
+        if let Some(etag) = etag {
+            request = request.header(header::IF_NONE_MATCH, etag);
+        }
+        if let Some(modified) = modified {
+            request = request.header(header::IF_MODIFIED_SINCE, modified);
+        }
+        if bypass_cache {
+            request = request.header(header::CACHE_CONTROL, "no-cache");
+        }
+        request
+    };
+
+    let (client, response) =
+        send_with_retry(opts.http_client, opts.url, opts.retry_opts, |client| {
+            build_request(client, false)
+        })
+        .await
+        .map_err(|error| FetchMetadataError::Network {
+            url: redact_url_credentials(opts.url),
+            error,
+        })?;
+    if response.status() != StatusCode::NOT_MODIFIED || has_validator {
+        return Ok((client, response));
+    }
+
+    drop(client);
+    let (client, response) =
+        send_with_retry(opts.http_client, opts.url, opts.retry_opts, |client| {
+            build_request(client, true)
+        })
+        .await
+        .map_err(|error| FetchMetadataError::Network {
+            url: redact_url_credentials(opts.url),
+            error,
+        })?;
+    if response.status() == StatusCode::NOT_MODIFIED {
+        drop(client);
+        return Err(FetchMetadataError::NotModifiedWithoutCache {
+            pkg_name: opts.pkg_name.to_string(),
+        });
+    }
+    Ok((client, response))
+}
+
 /// Fetch the registry metadata document for `pkg_name`. The
 /// `full_metadata` flag on [`FetchFullMetadataOptions`] picks
 /// between the full and abbreviated packument forms.
@@ -99,25 +169,17 @@ pub async fn fetch_full_metadata(
     let url = to_registry_url(opts.registry, pkg_name);
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
     retry_async(&url, opts.retry_opts, FetchMetadataError::is_body_retryable, || async {
-        let (client, response) =
-            send_with_retry(opts.http_client, &url, opts.retry_opts, |client| {
-                let mut request = client.get(&url).header(header::ACCEPT, accept);
-                if let Some(value) = opts.auth_headers.for_url_with_package(&url, Some(pkg_name)) {
-                    request = request.header(header::AUTHORIZATION, value);
-                }
-                if let Some(etag) = opts.etag {
-                    request = request.header(header::IF_NONE_MATCH, etag);
-                }
-                if let Some(modified) = opts.modified {
-                    request = request.header(header::IF_MODIFIED_SINCE, modified);
-                }
-                request
-            })
-            .await
-            .map_err(|error| FetchMetadataError::Network {
-                url: redact_url_credentials(&url),
-                error,
-            })?;
+        let (client, response) = send_metadata_request(&MetadataRequestOptions {
+            pkg_name,
+            url: &url,
+            accept,
+            http_client: opts.http_client,
+            auth_headers: opts.auth_headers,
+            etag: opts.etag,
+            modified: opts.modified,
+            retry_opts: opts.retry_opts,
+        })
+        .await?;
         if response.status() == StatusCode::NOT_MODIFIED {
             return Ok(FetchFullMetadataOutcome::NotModified);
         }

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -16,7 +16,7 @@
 use std::path::Path;
 
 use pacquet_network::{
-    AuthHeaders, RetryOpts, ThrottledClient, redact_url_credentials, retry_async, send_with_retry,
+    AuthHeaders, RetryOpts, ThrottledClient, redact_url_credentials, retry_async,
 };
 use pacquet_registry::Package;
 use pipe_trait::Pipe;
@@ -25,8 +25,8 @@ use reqwest::{StatusCode, header};
 use crate::{
     FetchMetadataError,
     fetch_full_metadata::{
-        ACCEPT_ABBREVIATED_DOC, ACCEPT_FULL_DOC, is_abbreviated_content_type,
-        normalize_abbreviated_meta,
+        ACCEPT_ABBREVIATED_DOC, ACCEPT_FULL_DOC, MetadataRequestOptions,
+        is_abbreviated_content_type, normalize_abbreviated_meta, send_metadata_request,
     },
     mirror::{
         ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, clear_meta,
@@ -108,27 +108,17 @@ pub async fn fetch_full_metadata_cached(
     // headers and all, so a `304` stays a success that returns the
     // cached mirror body rather than re-fetching it.
     retry_async(&url, opts.retry_opts, FetchMetadataError::is_body_retryable, || async {
-        let (client, response) =
-            send_with_retry(opts.http_client, &url, opts.retry_opts, |client| {
-                let mut request = client.get(&url).header(header::ACCEPT, accept);
-                if let Some(value) = opts.auth_headers.for_url_with_package(&url, Some(pkg_name)) {
-                    request = request.header(header::AUTHORIZATION, value);
-                }
-                if let Some(headers) = cache_headers.as_ref() {
-                    if let Some(etag) = headers.etag.as_deref() {
-                        request = request.header(header::IF_NONE_MATCH, etag);
-                    }
-                    if let Some(modified) = headers.modified.as_deref() {
-                        request = request.header(header::IF_MODIFIED_SINCE, modified);
-                    }
-                }
-                request
-            })
-            .await
-            .map_err(|error| FetchMetadataError::Network {
-                url: redact_url_credentials(&url),
-                error,
-            })?;
+        let (client, response) = send_metadata_request(&MetadataRequestOptions {
+            pkg_name,
+            url: &url,
+            accept,
+            http_client: opts.http_client,
+            auth_headers: opts.auth_headers,
+            etag: cache_headers.as_ref().and_then(|headers| headers.etag.as_deref()),
+            modified: cache_headers.as_ref().and_then(|headers| headers.modified.as_deref()),
+            retry_opts: opts.retry_opts,
+        })
+        .await?;
 
         if response.status() == StatusCode::NOT_MODIFIED {
             // No body to stream — release the connection and its

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
@@ -171,6 +171,7 @@ async fn repeated_unsolicited_304_reports_missing_cache() {
     };
 
     let error = fetch_full_metadata_cached("acme", &opts).await.expect_err("304 needs a cache");
+    dbg!(&error);
     assert!(matches!(
         error,
         FetchMetadataError::NotModifiedWithoutCache { ref pkg_name } if pkg_name == "acme"

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
@@ -1,10 +1,14 @@
+use mockito::Matcher;
 use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use tempfile::TempDir;
 
 use super::{FetchFullMetadataCachedOptions, fetch_full_metadata_cached};
-use crate::mirror::{
-    ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, get_pkg_mirror_path, load_meta,
-    load_meta_headers,
+use crate::{
+    FetchMetadataError,
+    mirror::{
+        ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, get_pkg_mirror_path,
+        load_meta, load_meta_headers,
+    },
 };
 
 const PACKAGE_BODY: &str = r#"{
@@ -89,6 +93,90 @@ async fn cold_cache_writes_mirror_on_200() {
     assert!(mirror_path.exists(), "mirror file written");
     let headers = load_meta_headers(&mirror_path).expect("headers readable");
     assert_eq!(headers.etag.as_deref(), Some(r#"W/"fresh""#));
+}
+
+#[tokio::test]
+async fn unsolicited_304_retries_without_cache() {
+    let mut server = mockito::Server::new_async().await;
+    let first = server
+        .mock("GET", "/acme")
+        .match_header("if-none-match", Matcher::Missing)
+        .match_header("if-modified-since", Matcher::Missing)
+        .match_header("cache-control", Matcher::Missing)
+        .with_status(304)
+        .expect(1)
+        .create_async()
+        .await;
+    let second = server
+        .mock("GET", "/acme")
+        .match_header("if-none-match", Matcher::Missing)
+        .match_header("if-modified-since", Matcher::Missing)
+        .match_header("cache-control", "no-cache")
+        .with_status(200)
+        .with_body(PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let cache = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let opts = FetchFullMetadataCachedOptions {
+        registry: &registry,
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        cache_dir: Some(cache.path()),
+        full_metadata: true,
+        filter_metadata: false,
+        retry_opts: no_retry_opts(),
+    };
+
+    let pkg = fetch_full_metadata_cached("acme", &opts).await.expect("retry returns metadata");
+    assert_eq!(pkg.name, "acme");
+    first.assert_async().await;
+    second.assert_async().await;
+}
+
+#[tokio::test]
+async fn repeated_unsolicited_304_reports_missing_cache() {
+    let mut server = mockito::Server::new_async().await;
+    let first = server
+        .mock("GET", "/acme")
+        .match_header("cache-control", Matcher::Missing)
+        .with_status(304)
+        .expect(1)
+        .create_async()
+        .await;
+    let second = server
+        .mock("GET", "/acme")
+        .match_header("cache-control", "no-cache")
+        .with_status(304)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let cache = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let opts = FetchFullMetadataCachedOptions {
+        registry: &registry,
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        cache_dir: Some(cache.path()),
+        full_metadata: true,
+        filter_metadata: false,
+        retry_opts: no_retry_opts(),
+    };
+
+    let error = fetch_full_metadata_cached("acme", &opts).await.expect_err("304 needs a cache");
+    assert!(matches!(
+        error,
+        FetchMetadataError::NotModifiedWithoutCache { ref pkg_name } if pkg_name == "acme"
+    ));
+    first.assert_async().await;
+    second.assert_async().await;
 }
 
 #[tokio::test]

--- a/pnpm11/resolving/npm-resolver/src/fetch.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetch.ts
@@ -148,20 +148,31 @@ export async function fetchMetadataFromFromRegistry (
 ): Promise<FetchMetadataResult | FetchMetadataNotModifiedResult> {
   const uri = toUri(pkgName, registry)
   const op = retry.operation(fetchOpts.retry)
+  const ifModifiedSince = cachedModified ? new Date(cachedModified).toUTCString() : undefined
+  const hasValidator = Boolean(cachedEtag || ifModifiedSince)
   return new Promise((resolve, reject) => {
     op.attempt(async (attempt) => {
       let response: RegistryResponse
       const startTime = Date.now()
       try {
-        response = await fetchOpts.fetch(uri, {
+        const requestOptions = {
           authHeaderValue,
           compress: true,
           fullMetadata,
           ifNoneMatch: cachedEtag,
-          ifModifiedSince: cachedModified ? new Date(cachedModified).toUTCString() : undefined,
+          ifModifiedSince,
           retry: fetchOpts.retry,
           timeout: fetchOpts.timeout,
-        }) as RegistryResponse
+        }
+        response = await fetchOpts.fetch(uri, requestOptions) as RegistryResponse
+        if (response.status === 304 && !hasValidator) {
+          response = await fetchOpts.fetch(uri, {
+            ...requestOptions,
+            headers: {
+              'cache-control': 'no-cache',
+            },
+          }) as RegistryResponse
+        }
       } catch (error: any) { // eslint-disable-line
         // Redact credentials embedded in the URL from the cause as well, not
         // just the top-level message: a reporter or debugger that renders
@@ -176,6 +187,13 @@ export async function fetchMetadataFromFromRegistry (
         return
       }
       if (response.status === 304) {
+        if (!hasValidator) {
+          reject(new PnpmError(
+            'META_NOT_MODIFIED_WITHOUT_CACHE',
+            `Registry returned 304 for ${pkgName} without an existing cache to refresh.`
+          ))
+          return
+        }
         resolve({ notModified: true })
         return
       }

--- a/pnpm11/resolving/npm-resolver/test/ifModifiedSince.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/ifModifiedSince.test.ts
@@ -169,3 +169,62 @@ test('fetch without conditional headers when no local cache exists', async () =>
   expect(resolveResult!.resolvedVia).toBe('npm-registry')
   expect(resolveResult!.id).toBe('is-positive@3.1.0')
 })
+
+test('retry when an unconditional metadata request receives 304 Not Modified', async () => {
+  const registry = getMockAgent().get(registries.default.replace(/\/$/, ''))
+  registry
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(304, '')
+  registry
+    .intercept({
+      path: '/is-positive',
+      method: 'GET',
+      headers: {
+        'cache-control': 'no-cache',
+      },
+    })
+    .reply(200, isPositiveMeta)
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registries,
+  })
+  const resolveResult = await resolveFromNpm(
+    { alias: 'is-positive', bareSpecifier: '^3.0.0' },
+    {}
+  )
+
+  expect(resolveResult!.resolvedVia).toBe('npm-registry')
+  expect(resolveResult!.id).toBe('is-positive@3.1.0')
+})
+
+test('report an invalid response when an unconditional 304 retry also returns 304', async () => {
+  const registry = getMockAgent().get(registries.default.replace(/\/$/, ''))
+  registry
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(304, '')
+  registry
+    .intercept({
+      path: '/is-positive',
+      method: 'GET',
+      headers: {
+        'cache-control': 'no-cache',
+      },
+    })
+    .reply(304, '')
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registries,
+  })
+
+  await expect(resolveFromNpm(
+    { alias: 'is-positive', bareSpecifier: '^3.0.0' },
+    {}
+  )).rejects.toMatchObject({
+    code: 'ERR_PNPM_META_NOT_MODIFIED_WITHOUT_CACHE',
+    message: 'Registry returned 304 for is-positive without an existing cache to refresh.',
+  })
+})


### PR DESCRIPTION
## Summary

- retry unsolicited metadata `304` responses once with `Cache-Control: no-cache`
- keep the TypeScript resolver and pacquet behavior aligned, including the repeated-`304` error path

Fixes pnpm/pnpm#12882.

## Squash Commit Body

```text
A 304 response is only meaningful when pnpm sent an ETag or
Last-Modified validator. Some caching proxies return 304 to a cold,
unconditional request, leaving pnpm without a metadata body.

Retry that response once with cache reuse disabled. If the retry still
returns 304, report META_NOT_MODIFIED_WITHOUT_CACHE instead of treating
a missing cache as validated.

Fixes pnpm/pnpm#12882.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port.
- [x] Added a changeset for the published resolver package and pnpm.
- [x] Added or updated tests.

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * pnpm now retries package metadata requests when the registry/proxy returns `304 Not Modified` and then succeeds by re-fetching with `Cache-Control: no-cache`.
  * Avoids incorrect failures when the retry returns usable metadata.
  * If `304` persists without a cached validator, pnpm now fails with `ERR_PNPM_META_NOT_MODIFIED_WITHOUT_CACHE` and a clearer message.
* **Tests**
  * Added additional Jest and Tokio coverage for unconditional `304` retry success and repeated `304` failure cases.
* **Chores**
  * Patch version bumps and release documentation for the updated `304` handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->