### PR TITLE
feat(cli): support `--store-dir` in pacquet

### DIFF
--- a/pacquet/crates/cli/src/cli_args/cli_command.rs
+++ b/pacquet/crates/cli/src/cli_args/cli_command.rs
@@ -91,6 +91,18 @@ pub struct CliArgs {
     #[clap(short = 'C', long, default_value = ".")]
     pub dir: PathBuf,
 
+    /// Directory in which the package store is created. Relative paths
+    /// are resolved from the workspace root, or from `--dir` outside a
+    /// workspace. Overrides the configured `storeDir` for this invocation.
+    #[clap(
+        long = "store-dir",
+        value_name = "DIR",
+        global = true,
+        overrides_with = "store_dir",
+        value_parser = parse_store_dir
+    )]
+    pub store_dir: Option<PathBuf>,
+
     /// Path to a `.npmrc` to read auth settings from, overriding the
     /// default `~/.npmrc`. Mirrors pnpm's `--npmrc-auth-file` (and its
     /// `--userconfig` alias) and sets
@@ -154,6 +166,10 @@ pub struct CliArgs {
     /// Recursive only: keep going after a project fails.
     #[clap(long = "no-bail", global = true, hide = true)]
     pub no_bail: bool,
+}
+
+fn parse_store_dir(value: &str) -> Result<PathBuf, std::convert::Infallible> {
+    Ok(PathBuf::from(value))
 }
 
 impl CliArgs {

--- a/pacquet/crates/cli/src/cli_args/dispatch.rs
+++ b/pacquet/crates/cli/src/cli_args/dispatch.rs
@@ -3,7 +3,10 @@ use super::{
     dispatch_install, dispatch_query, dispatch_script,
     reporter::{ReporterType, configure_default_reporter, reporter_emit},
 };
-use crate::{State, config_overrides::ConfigOverrides};
+use crate::{
+    State,
+    config_overrides::{ConfigOverrides, apply_store_dir_override},
+};
 use miette::{Context, IntoDiagnostic};
 use pacquet_config::{Config, Host, default_pnpm_home_dir};
 use pacquet_default_reporter::SummaryScope;
@@ -84,6 +87,11 @@ impl CliArgs {
             return false;
         };
         config_overrides.apply(&mut config);
+        if let Some(store_dir) = self.store_dir.as_deref()
+            && apply_store_dir_override::<Host>(&mut config, store_dir, &dir).is_err()
+        {
+            return false;
+        }
         configure_default_reporter(self.reporter, &dir, SummaryScope::CurrentPrefix);
         let emit = reporter_emit(self.reporter);
         let finished = install_args.finished_via_up_to_date_fast_path(&dir, &config, emit);
@@ -114,6 +122,7 @@ impl CliArgs {
         let CliArgs {
             command,
             dir,
+            store_dir,
             npmrc_auth_file,
             recursive,
             reporter,
@@ -182,8 +191,13 @@ impl CliArgs {
         let load_config = |anchor: &Path| -> miette::Result<&'static mut Config> {
             Config { npmrc_auth_file: npmrc_auth_file.clone(), ..Config::default() }
                 .current::<Host>(anchor)
-                .map(|mut cfg| {
+                .map_err(miette::Report::new)
+                .wrap_err("load configuration")
+                .and_then(|mut cfg| {
                     config_overrides.apply(&mut cfg);
+                    if let Some(store_dir) = store_dir.as_deref() {
+                        apply_store_dir_override::<Host>(&mut cfg, store_dir, anchor)?;
+                    }
                     // `--recursive` / `--filter` / `--filter-prod` are
                     // CLI-only upstream (not `.npmrc` / yaml keys), so the
                     // global flags are threaded in here. Mirrors pnpm's
@@ -195,10 +209,8 @@ impl CliArgs {
                         cfg.workspace_concurrency =
                             pacquet_config::resolve_child_concurrency(Some(workspace_concurrency));
                     }
-                    Config::leak(cfg)
+                    Ok(Config::leak(cfg))
                 })
-                .map_err(miette::Report::new)
-                .wrap_err("load configuration")
         };
         // Resolve `.npmrc` / `pnpm-workspace.yaml` from the canonicalized
         // `--dir` rather than the process cwd, matching pnpm 11 (which

--- a/pacquet/crates/cli/src/cli_args/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/tests.rs
@@ -9,6 +9,7 @@ use super::{
 };
 use clap::Parser;
 use pacquet_default_reporter::SummaryScope;
+use std::path::Path;
 use tempfile::TempDir;
 
 fn install_args(argv: &[&str]) -> InstallArgs {
@@ -20,6 +21,24 @@ fn install_args(argv: &[&str]) -> InstallArgs {
 
 fn default_reporter_summary_scope(argv: &[&str]) -> SummaryScope {
     CliArgs::try_parse_from(argv).expect("parses").command.default_reporter_summary_scope()
+}
+
+#[test]
+fn store_dir_is_global_and_parses_on_either_side_of_the_subcommand() {
+    for argv in [
+        ["pacquet", "--store-dir", "custom-store", "install"].as_slice(),
+        ["pacquet", "install", "--store-dir=custom-store"].as_slice(),
+    ] {
+        let parsed = CliArgs::try_parse_from(argv).expect("parses global --store-dir");
+        assert_eq!(parsed.store_dir.as_deref(), Some(Path::new("custom-store")));
+    }
+}
+
+#[test]
+fn store_dir_accepts_an_explicit_empty_value() {
+    let parsed = CliArgs::try_parse_from(["pacquet", "store", "path", "--store-dir="])
+        .expect("parses empty global --store-dir");
+    assert_eq!(parsed.store_dir.as_deref(), Some(Path::new("")));
 }
 
 #[test]

--- a/pacquet/crates/cli/src/config_deps.rs
+++ b/pacquet/crates/cli/src/config_deps.rs
@@ -466,14 +466,15 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
     }
     if let Some(store_dir) = changed_store_dir {
         apply_store_dir_override::<Host>(config, Path::new(&store_dir), &base_dir)?;
+    } else {
+        let virtual_store_dir_explicit = config.explicit_settings.contains_key("virtualStoreDir");
+        let global_virtual_store_dir_explicit =
+            config.explicit_settings.contains_key("globalVirtualStoreDir");
+        config.apply_global_virtual_store_derivation(
+            virtual_store_dir_explicit,
+            global_virtual_store_dir_explicit,
+        );
     }
-    let virtual_store_dir_explicit = config.explicit_settings.contains_key("virtualStoreDir");
-    let global_virtual_store_dir_explicit =
-        config.explicit_settings.contains_key("globalVirtualStoreDir");
-    config.apply_global_virtual_store_derivation(
-        virtual_store_dir_explicit,
-        global_virtual_store_dir_explicit,
-    );
     Ok(())
 }
 

--- a/pacquet/crates/cli/src/config_deps.rs
+++ b/pacquet/crates/cli/src/config_deps.rs
@@ -452,16 +452,26 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
     let changed_store_dir = delta.get("storeDir").and_then(Value::as_str).map(str::to_owned);
     let changed_virtual_store_dir = delta.get("virtualStoreDir").cloned();
     let changed_global_virtual_store_dir = delta.get("globalVirtualStoreDir").cloned();
+    let virtual_store_dir_cleared = changed_virtual_store_dir.as_ref().is_some_and(Value::is_null);
     let delta_settings: WorkspaceSettings = serde_json::from_value(delta)
         .into_diagnostic()
         .wrap_err("deserialize the updateConfig hook result")?;
     delta_settings.apply_to(config, &base_dir);
+    if virtual_store_dir_cleared {
+        config.virtual_store_dir = base_dir.join("node_modules/.pnpm");
+    }
     for (key, value) in [
         ("virtualStoreDir", changed_virtual_store_dir),
         ("globalVirtualStoreDir", changed_global_virtual_store_dir),
     ] {
-        if let Some(value) = value {
-            config.explicit_settings.insert(key.to_string(), value);
+        match value {
+            Some(Value::Null) => {
+                config.explicit_settings.remove(key);
+            }
+            Some(value) => {
+                config.explicit_settings.insert(key.to_string(), value);
+            }
+            None => {}
         }
     }
     if let Some(store_dir) = changed_store_dir {

--- a/pacquet/crates/cli/src/config_deps.rs
+++ b/pacquet/crates/cli/src/config_deps.rs
@@ -7,9 +7,10 @@
 //! lockfile. Plugin-hook loading (the `updateConfig` half) is wired in
 //! separately.
 
+use crate::config_overrides::apply_store_dir_override;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use pacquet_catalogs_config::get_catalogs_from_workspace_manifest;
-use pacquet_config::{Config, WorkspaceSettings};
+use pacquet_config::{Config, Host, WorkspaceSettings};
 use pacquet_env_installer::{
     ConfigDepsInstallOptions, resolve_and_install_config_deps, resolve_package_manager_integrities,
 };
@@ -401,6 +402,9 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
         .into_diagnostic()
         .wrap_err("reading catalogs for updateConfig hooks")?;
     if let Some(object) = input.as_object_mut() {
+        if let Some(store_dir) = config.explicit_settings.get("storeDir") {
+            object.insert("storeDir".to_string(), store_dir.clone());
+        }
         object.insert(
             "catalogs".to_string(),
             serde_json::to_value(&yaml_catalogs).into_diagnostic()?,
@@ -445,10 +449,31 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
     if delta.as_object().is_none_or(serde_json::Map::is_empty) {
         return Ok(());
     }
+    let changed_store_dir = delta.get("storeDir").and_then(Value::as_str).map(str::to_owned);
+    let changed_virtual_store_dir = delta.get("virtualStoreDir").cloned();
+    let changed_global_virtual_store_dir = delta.get("globalVirtualStoreDir").cloned();
     let delta_settings: WorkspaceSettings = serde_json::from_value(delta)
         .into_diagnostic()
         .wrap_err("deserialize the updateConfig hook result")?;
     delta_settings.apply_to(config, &base_dir);
+    for (key, value) in [
+        ("virtualStoreDir", changed_virtual_store_dir),
+        ("globalVirtualStoreDir", changed_global_virtual_store_dir),
+    ] {
+        if let Some(value) = value {
+            config.explicit_settings.insert(key.to_string(), value);
+        }
+    }
+    if let Some(store_dir) = changed_store_dir {
+        apply_store_dir_override::<Host>(config, Path::new(&store_dir), &base_dir)?;
+    }
+    let virtual_store_dir_explicit = config.explicit_settings.contains_key("virtualStoreDir");
+    let global_virtual_store_dir_explicit =
+        config.explicit_settings.contains_key("globalVirtualStoreDir");
+    config.apply_global_virtual_store_derivation(
+        virtual_store_dir_explicit,
+        global_virtual_store_dir_explicit,
+    );
     Ok(())
 }
 

--- a/pacquet/crates/cli/src/config_deps/tests.rs
+++ b/pacquet/crates/cli/src/config_deps/tests.rs
@@ -1,8 +1,52 @@
-use std::path::Path;
+use std::{fs, path::Path};
 
-use pacquet_config::{Config, TrustPolicy};
+use pacquet_config::{Config, Host, TrustPolicy};
+use pacquet_reporter::SilentReporter;
 
-use super::resolve_pnpm_version;
+use super::{resolve_pnpm_version, run_update_config_hooks};
+
+#[tokio::test]
+async fn update_config_null_clears_virtual_store_dir() {
+    let root = tempfile::tempdir().expect("workspace tempdir");
+    fs::write(root.path().join("pnpm-workspace.yaml"), "virtualStoreDir: pinned-virtual\n")
+        .expect("write workspace settings");
+    fs::write(
+        root.path().join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) { config.virtualStoreDir = null; return config } } }",
+    )
+    .expect("write pnpmfile");
+    let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");
+
+    run_update_config_hooks::<SilentReporter>(&mut config, root.path())
+        .await
+        .expect("run updateConfig hook");
+
+    assert_eq!(config.virtual_store_dir, root.path().join("node_modules/.pnpm"));
+    assert!(!config.explicit_settings.contains_key("virtualStoreDir"));
+}
+
+#[tokio::test]
+async fn update_config_null_clears_global_virtual_store_dir() {
+    let root = tempfile::tempdir().expect("workspace tempdir");
+    fs::write(
+        root.path().join("pnpm-workspace.yaml"),
+        "enableGlobalVirtualStore: true\nvirtualStoreDir: pinned-virtual\nglobalVirtualStoreDir: pinned-global\n",
+    )
+    .expect("write workspace settings");
+    fs::write(
+        root.path().join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) { config.globalVirtualStoreDir = null; return config } } }",
+    )
+    .expect("write pnpmfile");
+    let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");
+
+    run_update_config_hooks::<SilentReporter>(&mut config, root.path())
+        .await
+        .expect("run updateConfig hook");
+
+    assert_eq!(config.global_virtual_store_dir, root.path().join("pinned-virtual"));
+    assert!(!config.explicit_settings.contains_key("globalVirtualStoreDir"));
+}
 
 /// `Accept` header the resolver sends for full metadata
 /// (`ACCEPT_FULL_DOC`); only the full packument carries the per-version

--- a/pacquet/crates/cli/src/config_overrides.rs
+++ b/pacquet/crates/cli/src/config_overrides.rs
@@ -1,10 +1,62 @@
 use crate::cli_args::CliArgs;
 use clap::CommandFactory;
-use pacquet_config::Config;
+use pacquet_config::{Config, GetHomeDir, Host};
+use pacquet_fs::lexical_normalize;
+use pacquet_store_dir::StoreDir;
 use std::{
     collections::BTreeMap,
     ffi::{OsStr, OsString},
+    path::Path,
 };
+
+pub(crate) fn apply_store_dir_override<Sys: GetHomeDir>(
+    config: &mut Config,
+    store_dir: &Path,
+    dir: &Path,
+) -> miette::Result<()> {
+    let workspace_dir = config.workspace_dir.as_deref().unwrap_or(dir).to_path_buf();
+    if store_dir.as_os_str().is_empty() {
+        config.reset_store_dir_to_default::<Host>(&workspace_dir);
+        config
+            .explicit_settings
+            .insert("storeDir".to_string(), serde_json::Value::String(String::new()));
+        return Ok(());
+    }
+    let resolved = if let Some(relative) = home_relative_store_dir(store_dir) {
+        Sys::home_dir()
+            .ok_or_else(|| {
+                let store_dir_display = store_dir.display();
+                miette::miette!(
+                    "Cannot resolve store directory {} because the home directory is unknown",
+                    store_dir_display,
+                )
+            })?
+            .join(relative)
+    } else if store_dir.is_absolute() {
+        store_dir.to_path_buf()
+    } else {
+        workspace_dir.join(store_dir)
+    };
+    config.store_dir = StoreDir::from(lexical_normalize(&resolved));
+    if let Some(store_dir) = store_dir.to_str() {
+        config
+            .explicit_settings
+            .insert("storeDir".to_string(), serde_json::Value::String(store_dir.to_string()));
+    }
+    let virtual_store_dir_explicit = config.explicit_settings.contains_key("virtualStoreDir");
+    let global_virtual_store_dir_explicit =
+        config.explicit_settings.contains_key("globalVirtualStoreDir");
+    config.apply_global_virtual_store_derivation(
+        virtual_store_dir_explicit,
+        global_virtual_store_dir_explicit,
+    );
+    Ok(())
+}
+
+fn home_relative_store_dir(store_dir: &Path) -> Option<&Path> {
+    let store_dir = store_dir.to_str()?;
+    store_dir.strip_prefix("~/").or_else(|| store_dir.strip_prefix(r"~\")).map(Path::new)
+}
 
 /// CLI overrides parsed from pnpm's `--config.<key>=<value>` dotted-key
 /// syntax. Upstream pnpm uses [`npm-conf`](https://github.com/npm/npm-conf)
@@ -47,6 +99,9 @@ impl ConfigOverrides {
                 continue;
             }
             match classify(&arg) {
+                ConfigToken::WellFormed { key: "store-dir", value } => {
+                    remaining.push(OsString::from(format!("--store-dir={value}")));
+                }
                 ConfigToken::WellFormed { key, value } => overrides.set(key, value),
                 ConfigToken::Malformed => {}
                 ConfigToken::NotOurs => remaining.push(arg),
@@ -146,7 +201,13 @@ fn global_option_width(arg: &str) -> Option<usize> {
     let (name, has_value) = name.split_once('=').map_or((name, false), |(name, _)| (name, true));
     let consumes_value = matches!(
         name,
-        "dir" | "filter" | "filter-prod" | "npmrc-auth-file" | "reporter" | "userconfig",
+        "dir"
+            | "filter"
+            | "filter-prod"
+            | "npmrc-auth-file"
+            | "reporter"
+            | "store-dir"
+            | "userconfig",
     );
     Some(if consumes_value && !has_value { 2 } else { 1 })
 }

--- a/pacquet/crates/cli/src/config_overrides.rs
+++ b/pacquet/crates/cli/src/config_overrides.rs
@@ -1,6 +1,6 @@
 use crate::cli_args::CliArgs;
 use clap::CommandFactory;
-use pacquet_config::{Config, GetHomeDir, Host};
+use pacquet_config::{Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe};
 use pacquet_fs::lexical_normalize;
 use pacquet_store_dir::StoreDir;
 use std::{
@@ -9,14 +9,17 @@ use std::{
     path::Path,
 };
 
-pub(crate) fn apply_store_dir_override<Sys: GetHomeDir>(
+pub(crate) fn apply_store_dir_override<Sys>(
     config: &mut Config,
     store_dir: &Path,
     dir: &Path,
-) -> miette::Result<()> {
+) -> miette::Result<()>
+where
+    Sys: EnvVar + GetCurrentDir + GetHomeDir + LinkProbe,
+{
     let workspace_dir = config.workspace_dir.as_deref().unwrap_or(dir).to_path_buf();
     if store_dir.as_os_str().is_empty() {
-        config.reset_store_dir_to_default::<Host>(&workspace_dir);
+        config.reset_store_dir_to_default::<Sys>(&workspace_dir);
         config
             .explicit_settings
             .insert("storeDir".to_string(), serde_json::Value::String(String::new()));

--- a/pacquet/crates/cli/src/config_overrides/tests.rs
+++ b/pacquet/crates/cli/src/config_overrides/tests.rs
@@ -1,5 +1,5 @@
 use super::{ConfigOverrides, apply_store_dir_override};
-use pacquet_config::{Config, GetHomeDir};
+use pacquet_config::{Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe};
 use pretty_assertions::assert_eq;
 use std::{ffi::OsString, path::PathBuf};
 
@@ -161,6 +161,24 @@ fn store_dir_override_resolves_from_workspace_root() {
         }
     }
 
+    impl EnvVar for FakeHome {
+        fn var(_: &str) -> Option<String> {
+            unreachable!("relative store directory does not consult environment variables")
+        }
+    }
+
+    impl GetCurrentDir for FakeHome {
+        fn current_dir() -> std::io::Result<PathBuf> {
+            unreachable!("relative store directory does not consult the current directory")
+        }
+    }
+
+    impl LinkProbe for FakeHome {
+        fn can_link_between_dirs(_: &std::path::Path, _: &std::path::Path) -> bool {
+            unreachable!("relative store directory does not probe filesystem linkability")
+        }
+    }
+
     let temp_dir = std::env::temp_dir();
     let workspace_dir = temp_dir.join("pacquet-store-dir-workspace");
     let package_dir = workspace_dir.join("packages/app");
@@ -186,6 +204,24 @@ fn store_dir_override_expands_quoted_home_path() {
         }
     }
 
+    impl EnvVar for FakeHome {
+        fn var(_: &str) -> Option<String> {
+            unreachable!("home-relative store directory does not consult environment variables")
+        }
+    }
+
+    impl GetCurrentDir for FakeHome {
+        fn current_dir() -> std::io::Result<PathBuf> {
+            unreachable!("home-relative store directory does not consult the current directory")
+        }
+    }
+
+    impl LinkProbe for FakeHome {
+        fn can_link_between_dirs(_: &std::path::Path, _: &std::path::Path) -> bool {
+            unreachable!("home-relative store directory does not probe filesystem linkability")
+        }
+    }
+
     let mut config = Config::default();
     apply_store_dir_override::<FakeHome>(
         &mut config,
@@ -201,5 +237,46 @@ fn store_dir_override_expands_quoted_home_path() {
     assert_eq!(
         config.explicit_settings.get("storeDir"),
         Some(&serde_json::Value::String("~/quoted-store".to_string())),
+    );
+}
+
+#[test]
+fn empty_store_dir_override_uses_the_injected_default_provider() {
+    struct FakeDefault;
+
+    impl EnvVar for FakeDefault {
+        fn var(name: &str) -> Option<String> {
+            (name == "PNPM_HOME").then(|| "/fake/pnpm-home".to_string())
+        }
+    }
+
+    impl GetCurrentDir for FakeDefault {
+        fn current_dir() -> std::io::Result<PathBuf> {
+            unreachable!("PNPM_HOME determines the default before the current directory is needed")
+        }
+    }
+
+    impl GetHomeDir for FakeDefault {
+        fn home_dir() -> Option<PathBuf> {
+            Some(PathBuf::from("/fake/home"))
+        }
+    }
+
+    impl LinkProbe for FakeDefault {
+        fn can_link_between_dirs(_: &std::path::Path, _: &std::path::Path) -> bool {
+            true
+        }
+    }
+
+    let workspace_dir = std::env::temp_dir();
+    let mut config = Config { workspace_dir: Some(workspace_dir.clone()), ..Config::default() };
+
+    apply_store_dir_override::<FakeDefault>(&mut config, std::path::Path::new(""), &workspace_dir)
+        .expect("restore the default store directory");
+
+    assert_eq!(config.store_dir.root(), std::path::Path::new("/fake/pnpm-home/store/v11"));
+    assert_eq!(
+        config.explicit_settings.get("storeDir"),
+        Some(&serde_json::Value::String(String::new())),
     );
 }

--- a/pacquet/crates/cli/src/config_overrides/tests.rs
+++ b/pacquet/crates/cli/src/config_overrides/tests.rs
@@ -1,7 +1,7 @@
-use super::ConfigOverrides;
-use pacquet_config::Config;
+use super::{ConfigOverrides, apply_store_dir_override};
+use pacquet_config::{Config, GetHomeDir};
 use pretty_assertions::assert_eq;
-use std::ffi::OsString;
+use std::{ffi::OsString, path::PathBuf};
 
 fn argv<Items: IntoIterator<Item = &'static str>>(items: Items) -> Vec<OsString> {
     items.into_iter().map(OsString::from).collect()
@@ -142,4 +142,64 @@ fn apply_is_a_noop_when_no_overrides_set() {
     let mut config = Config::default();
     overrides.apply(&mut config);
     assert_eq!(config.registry, default_registry);
+}
+
+#[test]
+fn dotted_store_dir_is_rewritten_for_the_global_parser() {
+    let (_, remaining) =
+        ConfigOverrides::extract(argv(["pacquet", "install", "--config.store-dir=dotted-store"]));
+    assert_eq!(remaining, argv(["pacquet", "install", "--store-dir=dotted-store"]));
+}
+
+#[test]
+fn store_dir_override_resolves_from_workspace_root() {
+    struct FakeHome;
+
+    impl GetHomeDir for FakeHome {
+        fn home_dir() -> Option<PathBuf> {
+            unreachable!("relative store directory does not consult the home directory")
+        }
+    }
+
+    let temp_dir = std::env::temp_dir();
+    let workspace_dir = temp_dir.join("pacquet-store-dir-workspace");
+    let package_dir = workspace_dir.join("packages/app");
+    let mut config = Config { workspace_dir: Some(workspace_dir.clone()), ..Config::default() };
+
+    apply_store_dir_override::<FakeHome>(
+        &mut config,
+        std::path::Path::new("relative-store"),
+        &package_dir,
+    )
+    .expect("resolve relative store directory");
+
+    assert_eq!(config.store_dir.root(), workspace_dir.join("relative-store/v11"));
+}
+
+#[test]
+fn store_dir_override_expands_quoted_home_path() {
+    struct FakeHome;
+
+    impl GetHomeDir for FakeHome {
+        fn home_dir() -> Option<PathBuf> {
+            Some(std::env::temp_dir().join("pacquet-store-dir-home"))
+        }
+    }
+
+    let mut config = Config::default();
+    apply_store_dir_override::<FakeHome>(
+        &mut config,
+        std::path::Path::new("~/quoted-store"),
+        std::path::Path::new("ignored-package-dir"),
+    )
+    .expect("expand home-relative store directory");
+
+    assert_eq!(
+        config.store_dir.root(),
+        std::env::temp_dir().join("pacquet-store-dir-home/quoted-store/v11"),
+    );
+    assert_eq!(
+        config.explicit_settings.get("storeDir"),
+        Some(&serde_json::Value::String("~/quoted-store".to_string())),
+    );
 }

--- a/pacquet/crates/cli/src/config_overrides/tests.rs
+++ b/pacquet/crates/cli/src/config_overrides/tests.rs
@@ -1,5 +1,6 @@
 use super::{ConfigOverrides, apply_store_dir_override};
 use pacquet_config::{Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe};
+use pacquet_store_dir::STORE_VERSION;
 use pretty_assertions::assert_eq;
 use std::{ffi::OsString, path::PathBuf};
 
@@ -191,7 +192,7 @@ fn store_dir_override_resolves_from_workspace_root() {
     )
     .expect("resolve relative store directory");
 
-    assert_eq!(config.store_dir.root(), workspace_dir.join("relative-store/v11"));
+    assert_eq!(config.store_dir.root(), workspace_dir.join("relative-store").join(STORE_VERSION));
 }
 
 #[test]
@@ -232,7 +233,7 @@ fn store_dir_override_expands_quoted_home_path() {
 
     assert_eq!(
         config.store_dir.root(),
-        std::env::temp_dir().join("pacquet-store-dir-home/quoted-store/v11"),
+        std::env::temp_dir().join("pacquet-store-dir-home/quoted-store").join(STORE_VERSION),
     );
     assert_eq!(
         config.explicit_settings.get("storeDir"),
@@ -274,7 +275,10 @@ fn empty_store_dir_override_uses_the_injected_default_provider() {
     apply_store_dir_override::<FakeDefault>(&mut config, std::path::Path::new(""), &workspace_dir)
         .expect("restore the default store directory");
 
-    assert_eq!(config.store_dir.root(), std::path::Path::new("/fake/pnpm-home/store/v11"));
+    assert_eq!(
+        config.store_dir.root(),
+        std::path::Path::new("/fake/pnpm-home/store").join(STORE_VERSION),
+    );
     assert_eq!(
         config.explicit_settings.get("storeDir"),
         Some(&serde_json::Value::String(String::new())),

--- a/pacquet/crates/cli/tests/config_dependencies.rs
+++ b/pacquet/crates/cli/tests/config_dependencies.rs
@@ -175,3 +175,72 @@ fn update_config_hook_injects_catalog() {
 
     drop((root, mock_instance));
 }
+
+#[test]
+fn update_config_observes_and_can_replace_the_cli_store_dir() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    _utils::enable_gvs_in_workspace_yaml(&workspace, "");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { "@pnpm.e2e/foo": "100.0.0" } }).to_string(),
+    )
+    .expect("write package.json");
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        "const fs = require('fs');\nconst path = require('path');\nmodule.exports = { hooks: { updateConfig (config) {\n  fs.writeFileSync(path.join(__dirname, 'observed-store.txt'), String(config.storeDir));\n  config.storeDir = 'hook-store';\n  return config;\n} } }",
+    )
+    .expect("write .pnpmfile.cjs");
+
+    pacquet_at(&workspace).with_args(["install", "--store-dir=cli-store"]).assert().success();
+
+    let observed = fs::read_to_string(workspace.join("observed-store.txt"))
+        .expect("read store observed by updateConfig");
+    assert_eq!(observed, "cli-store");
+
+    let modules = pacquet_modules_yaml::read_modules_layout::<pacquet_modules_yaml::Host>(
+        &workspace.join("node_modules"),
+    )
+    .expect("read .modules.yaml")
+    .expect(".modules.yaml exists");
+    let hook_store =
+        dunce::canonicalize(&workspace).expect("canonicalize workspace").join("hook-store/v11");
+    assert_eq!(
+        dunce::canonicalize(&modules.store_dir).expect("canonicalize recorded store"),
+        hook_store,
+    );
+    assert_eq!(
+        dunce::canonicalize(&modules.virtual_store_dir)
+            .expect("canonicalize recorded virtual store"),
+        hook_store.join("links"),
+    );
+    assert!(hook_store.join("index.db").is_file());
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn update_config_observes_an_empty_cli_store_dir() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), serde_json::json!({}).to_string())
+        .expect("write package.json");
+    fs::write(workspace.join("pnpm-workspace.yaml"), "storeDir: yaml-store\n")
+        .expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        "const fs = require('fs');\nconst path = require('path');\nmodule.exports = { hooks: { updateConfig (config) {\n  fs.writeFileSync(path.join(__dirname, 'observed-store.txt'), JSON.stringify(config.storeDir));\n  return config;\n} } }",
+    )
+    .expect("write .pnpmfile.cjs");
+
+    pacquet_at(&workspace).with_args(["install", "--store-dir="]).assert().success();
+
+    assert_eq!(
+        fs::read_to_string(workspace.join("observed-store.txt"))
+            .expect("read store observed by updateConfig"),
+        r#""""#,
+    );
+
+    drop(root);
+}

--- a/pacquet/crates/cli/tests/config_dependencies.rs
+++ b/pacquet/crates/cli/tests/config_dependencies.rs
@@ -216,7 +216,9 @@ fn update_config_observes_and_can_replace_the_cli_store_dir() {
             .expect("canonicalize recorded virtual store"),
         hook_store.join("links"),
     );
-    assert!(hook_store.join("index.db").is_file());
+    let index_path = hook_store.join("index.db");
+    eprintln!("Checking for hook store index: {}", index_path.display());
+    assert!(index_path.is_file());
 
     drop((root, mock_instance));
 }

--- a/pacquet/crates/cli/tests/install.rs
+++ b/pacquet/crates/cli/tests/install.rs
@@ -52,6 +52,100 @@ fn should_install_dependencies() {
     drop((root, mock_instance));
 }
 
+#[test]
+fn store_dir_cli_option_overrides_config_and_resolves_from_dir() {
+    let CommandTempCwd { mut pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir: configured_store_dir, mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/hello-world-js-bin-parent": "1.0.0",
+        },
+    });
+    fs::write(&manifest_path, package_json_content.to_string()).expect("write to package.json");
+
+    pacquet
+        .current_dir(root.path())
+        .arg("--dir")
+        .arg(&workspace)
+        .args(["install", "--store-dir", "cli-store"])
+        .assert()
+        .success();
+
+    let cli_store_dir = workspace.join("cli-store/v11");
+    eprintln!("CLI store must be resolved from --dir and populated: {cli_store_dir:?}");
+    assert!(cli_store_dir.join("index.db").is_file());
+
+    eprintln!("Configured store must not be populated when the CLI overrides it");
+    assert!(!configured_store_dir.join("v11/index.db").exists());
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn frozen_install_honors_the_store_dir_cli_option() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/hello-world-js-bin-parent": "1.0.0",
+        },
+    });
+    fs::write(&manifest_path, package_json_content.to_string()).expect("write to package.json");
+    pacquet.with_arg("install").assert().success();
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+
+    std::process::Command::cargo_bin("pacquet")
+        .expect("find the pacquet binary")
+        .with_current_dir(&workspace)
+        .with_args(["install", "--frozen-lockfile", "--store-dir=frozen-store"])
+        .assert()
+        .success();
+
+    let frozen_store = workspace.join("frozen-store/v11");
+    eprintln!("Frozen install must populate the CLI-selected store: {frozen_store:?}");
+    assert!(frozen_store.join("index.db").is_file());
+
+    drop((root, mock_instance));
+}
+
+#[cfg(unix)]
+#[test]
+fn store_dir_cli_option_updates_derived_global_virtual_store() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    enable_gvs_in_workspace_yaml(&workspace, "");
+    let manifest_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/hello-world-js-bin-parent": "1.0.0",
+        },
+    });
+    fs::write(&manifest_path, package_json_content.to_string()).expect("write to package.json");
+
+    pacquet.with_args(["install", "--store-dir=cli-store"]).assert().success();
+
+    let symlink_path = workspace.join("node_modules/@pnpm.e2e/hello-world-js-bin-parent");
+    let canonical = symlink_path.pipe(fs::canonicalize).expect("canonicalize symlink");
+    let cli_store_dir = workspace.join("cli-store/v11");
+    let canonical_store = cli_store_dir.pipe(fs::canonicalize).expect("canonicalize CLI store");
+    let gvs_root = canonical_store.join("links");
+    eprintln!("Derived global virtual store must follow the CLI store: {gvs_root:?}");
+    assert!(
+        canonical.starts_with(&gvs_root),
+        "expected the package directory under {gvs_root:?}, got {canonical:?}",
+    );
+
+    drop((root, mock_instance));
+}
+
 /// A project manifest that declares a dependency under a path-traversal
 /// name is rejected by the resolver on a fresh install — before any
 /// resolution or fetch, and long before the name could become a

--- a/pacquet/crates/cli/tests/install.rs
+++ b/pacquet/crates/cli/tests/install.rs
@@ -3,6 +3,7 @@ pub use _utils::*;
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
+use pacquet_store_dir::STORE_VERSION;
 use pacquet_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
     fixtures::{BIG_LOCKFILE, BIG_MANIFEST},
@@ -74,12 +75,12 @@ fn store_dir_cli_option_overrides_config_and_resolves_from_dir() {
         .assert()
         .success();
 
-    let cli_store_dir = workspace.join("cli-store/v11");
+    let cli_store_dir = workspace.join("cli-store").join(STORE_VERSION);
     eprintln!("CLI store must be resolved from --dir and populated: {cli_store_dir:?}");
     assert!(cli_store_dir.join("index.db").is_file());
 
     eprintln!("Configured store must not be populated when the CLI overrides it");
-    assert!(!configured_store_dir.join("v11/index.db").exists());
+    assert!(!configured_store_dir.join(STORE_VERSION).join("index.db").exists());
 
     drop((root, mock_instance));
 }
@@ -107,7 +108,7 @@ fn frozen_install_honors_the_store_dir_cli_option() {
         .assert()
         .success();
 
-    let frozen_store = workspace.join("frozen-store/v11");
+    let frozen_store = workspace.join("frozen-store").join(STORE_VERSION);
     eprintln!("Frozen install must populate the CLI-selected store: {frozen_store:?}");
     assert!(frozen_store.join("index.db").is_file());
 
@@ -134,7 +135,7 @@ fn store_dir_cli_option_updates_derived_global_virtual_store() {
 
     let symlink_path = workspace.join("node_modules/@pnpm.e2e/hello-world-js-bin-parent");
     let canonical = symlink_path.pipe(fs::canonicalize).expect("canonicalize symlink");
-    let cli_store_dir = workspace.join("cli-store/v11");
+    let cli_store_dir = workspace.join("cli-store").join(STORE_VERSION);
     let canonical_store = cli_store_dir.pipe(fs::canonicalize).expect("canonicalize CLI store");
     let gvs_root = canonical_store.join("links");
     eprintln!("Derived global virtual store must follow the CLI store: {gvs_root:?}");

--- a/pacquet/crates/cli/tests/store.rs
+++ b/pacquet/crates/cli/tests/store.rs
@@ -114,6 +114,9 @@ fn empty_store_dir_override_restores_the_platform_default() {
         .args(["store", "path"])
         .output()
         .expect("read the default store path");
+    eprintln!("default status={}", default_output.status);
+    eprintln!("default stdout={}", String::from_utf8_lossy(&default_output.stdout));
+    eprintln!("default stderr={}", String::from_utf8_lossy(&default_output.stderr));
     assert!(default_output.status.success());
     let default_store = String::from_utf8_lossy(&default_output.stdout).trim_end().to_owned();
 

--- a/pacquet/crates/cli/tests/store.rs
+++ b/pacquet/crates/cli/tests/store.rs
@@ -1,3 +1,4 @@
+use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_store_dir::STORE_VERSION;
 use pacquet_testing_utils::bin::CommandTempCwd;
@@ -6,6 +7,7 @@ use pretty_assertions::assert_eq;
 use std::{
     fs,
     path::{Path, PathBuf},
+    process::Command,
 };
 
 /// Canonicalize a path the same way the production CLI does. The CLI
@@ -46,6 +48,88 @@ fn store_path_should_return_store_dir_from_pnpm_workspace_yaml() {
             .to_string_lossy()
             .pipe_as_ref(normalize),
     );
+
+    drop(root);
+}
+
+#[test]
+fn store_path_resolves_global_and_dotted_overrides_from_workspace_root() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write pnpm-workspace.yaml");
+    let package_dir = workspace.join("packages/app");
+    fs::create_dir_all(&package_dir).expect("create nested workspace package");
+
+    for (store_arg, expected_name) in [
+        ("--store-dir=global-store", "global-store"),
+        ("--config.store-dir=dotted-store", "dotted-store"),
+    ] {
+        let output = Command::cargo_bin("pacquet")
+            .expect("find the pacquet binary")
+            .with_current_dir(root.path())
+            .arg("--dir")
+            .arg(&package_dir)
+            .arg(store_arg)
+            .args(["store", "path"])
+            .output()
+            .expect("run pacquet store path with override");
+        eprintln!("stderr={}", String::from_utf8_lossy(&output.stderr));
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim_end(),
+            canonicalize(&workspace).join(expected_name).join(STORE_VERSION).to_string_lossy(),
+        );
+    }
+
+    drop(root);
+}
+
+#[test]
+fn store_path_expands_a_quoted_home_override() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+    let output = pacquet
+        .with_args(["store", "path", "--store-dir=~/pacquet-quoted-store"])
+        .output()
+        .expect("run pacquet store path with home-relative override");
+    eprintln!("stderr={}", String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim_end(),
+        home::home_dir()
+            .expect("home directory")
+            .join("pacquet-quoted-store")
+            .join(STORE_VERSION)
+            .to_string_lossy(),
+    );
+
+    drop(root);
+}
+
+#[test]
+fn empty_store_dir_override_restores_the_platform_default() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let default_output = Command::cargo_bin("pacquet")
+        .expect("find the pacquet binary")
+        .with_current_dir(&workspace)
+        .args(["store", "path"])
+        .output()
+        .expect("read the default store path");
+    assert!(default_output.status.success());
+    let default_store = String::from_utf8_lossy(&default_output.stdout).trim_end().to_owned();
+
+    fs::write(workspace.join("pnpm-workspace.yaml"), "storeDir: yaml-store\n")
+        .expect("write configured store directory");
+    for store_arg in ["--store-dir=", "--config.store-dir="] {
+        let output = Command::cargo_bin("pacquet")
+            .expect("find the pacquet binary")
+            .with_current_dir(&workspace)
+            .args(["store", "path", store_arg])
+            .output()
+            .expect("run store path with an empty override");
+        eprintln!("stderr={}", String::from_utf8_lossy(&output.stderr));
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim_end(), default_store);
+    }
 
     drop(root);
 }

--- a/pacquet/crates/cli/tests/store.rs
+++ b/pacquet/crates/cli/tests/store.rs
@@ -87,19 +87,22 @@ fn store_path_resolves_global_and_dotted_overrides_from_workspace_root() {
 #[test]
 fn store_path_expands_a_quoted_home_override() {
     let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+    let home_dir = root.path().join("home");
+    fs::create_dir_all(&home_dir).expect("create home directory");
     let output = pacquet
         .with_args(["store", "path", "--store-dir=~/pacquet-quoted-store"])
+        .env("HOME", &home_dir)
+        .env("USERPROFILE", &home_dir)
         .output()
         .expect("run pacquet store path with home-relative override");
-    eprintln!("stderr={}", String::from_utf8_lossy(&output.stderr));
+    if !output.status.success() {
+        eprintln!("stdout={}", String::from_utf8_lossy(&output.stdout));
+        eprintln!("stderr={}", String::from_utf8_lossy(&output.stderr));
+    }
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8_lossy(&output.stdout).trim_end(),
-        home::home_dir()
-            .expect("home directory")
-            .join("pacquet-quoted-store")
-            .join(STORE_VERSION)
-            .to_string_lossy(),
+        home_dir.join("pacquet-quoted-store").join(STORE_VERSION).to_string_lossy(),
     );
 
     drop(root);

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1679,6 +1679,39 @@ impl Config {
             };
     }
 
+    /// Restore the smart default store after a higher-precedence config
+    /// source explicitly clears `storeDir`.
+    pub fn reset_store_dir_to_default<Sys>(&mut self, start_dir: &Path)
+    where
+        Sys: EnvVar + GetCurrentDir + GetHomeDir + LinkProbe,
+    {
+        self.store_dir = default_store_dir::<Sys>();
+        self.resolve_default_store_dir::<Sys>(start_dir);
+        self.explicit_settings.remove("storeDir");
+        let virtual_store_dir_explicit = self.explicit_settings.contains_key("virtualStoreDir");
+        let global_virtual_store_dir_explicit =
+            self.explicit_settings.contains_key("globalVirtualStoreDir");
+        self.apply_global_virtual_store_derivation(
+            virtual_store_dir_explicit,
+            global_virtual_store_dir_explicit,
+        );
+    }
+
+    fn resolve_default_store_dir<Sys: GetHomeDir + LinkProbe>(&mut self, start_dir: &Path) {
+        let Some(home_dir) = Sys::home_dir() else {
+            return;
+        };
+        // `store_dir.root()` includes the layout version, so its parent is
+        // the unversioned store and the next parent is pnpm's home directory.
+        // The linkability probe only cares about that directory's volume;
+        // fall back to the user's home when either parent is unavailable.
+        let store_root_versioned = self.store_dir.root().to_path_buf();
+        let store_root = store_root_versioned.parent().unwrap_or(&home_dir).to_path_buf();
+        let pnpm_home_dir = store_root.parent().unwrap_or(&home_dir).to_path_buf();
+        let resolved = store_path::resolve_store_dir::<Sys>(store_root, &pnpm_home_dir, start_dir);
+        self.store_dir = StoreDir::from(resolved);
+    }
+
     /// Return the `virtualStoreDir` value pnpm exposes externally — the
     /// path written into `.modules.yaml` and emitted in the `pnpm:context`
     /// NDJSON event.
@@ -2133,22 +2166,8 @@ impl Config {
         // Without this, typescript-eslint's case-folded path cache
         // diverges from TypeScript's case-sensitive program when the
         // workspace is case-sensitive and the home is not.
-        if !store_dir_explicit && let Some(home_dir) = Sys::home_dir() {
-            // `store_dir.root()` already carries the [`STORE_VERSION`]
-            // suffix that [`StoreDir::from`] applied, so the
-            // un-suffixed home store sits one level above. The "pnpm
-            // home dir" pnpm probes against is the parent of that
-            // un-suffixed home store (`~/Library/pnpm` for
-            // `~/Library/pnpm/store`). Fall back to the user's actual
-            // home whenever a parent is unavailable — same-volume
-            // linkability is what we're after, and the home dir is on
-            // the same volume as any of its children.
-            let store_root_versioned = self.store_dir.root().to_path_buf();
-            let store_root = store_root_versioned.parent().unwrap_or(&home_dir).to_path_buf();
-            let pnpm_home_dir = store_root.parent().unwrap_or(&home_dir).to_path_buf();
-            let resolved =
-                store_path::resolve_store_dir::<Sys>(store_root, &pnpm_home_dir, start_dir);
-            self.store_dir = StoreDir::from(resolved);
+        if !store_dir_explicit {
+            self.resolve_default_store_dir::<Sys>(start_dir);
         }
 
         // Derive `global_virtual_store_dir` last so it sees the final


### PR DESCRIPTION
## Summary

Add pnpm-compatible `--store-dir` support to the Rust pacquet CLI. Related to pnpm/pnpm#11633.

- Accept `--store-dir` globally, before or after subcommands, together with the dotted `--config.store-dir` form.
- Resolve relative paths from the workspace root, expand quoted `~/` paths, and preserve pnpm's single-`v11` store layout.
- Expose the raw CLI value to `updateConfig` hooks and recompute global virtual store paths when hooks replace it.
- Treat hook-returned `null` virtual-store values as explicit clears and re-derive their defaults.
- Treat an explicit empty value as a request to restore the platform's volume-aware default store while still exposing `""` to hooks.
- Cover regular and frozen installs, nested workspaces, global virtual stores, hooks, dotted options, and empty overrides.

The TypeScript CLI already implements this behavior; this change brings pacquet into parity.

No changeset is included. This is a pacquet-only parity change, pacquet's Rust crates and native wrapper are not released through the root Changesets workspace, and the published TypeScript `pnpm` package already exposes this flag.

Validation:

- `typos pacquet pnpr`
- `cargo fmt`
- `just check`
- `just test` (5,605 passed, 3 skipped)
- `just lint`
- Full pre-push hook: TypeScript compile/lint/spell/meta checks and Rust fmt, clippy, docs, dylint, and Taplo

The unscoped `just ready` command was also run. Its `typos` step currently scans `pnpm11/` and `cspell.json`, unlike CI's `pacquet pnpr` scope, and fails on existing commit hashes and spelling fixtures. The CI-scoped spelling check and every remaining `just ready` step pass.

## Squash Commit Body

```text
Accept global and dotted store directory overrides with pnpm-compatible path and config precedence.

Expose overrides to updateConfig hooks and keep global virtual store derivation in sync. Preserve the raw empty CLI value for hooks while restoring the platform's volume-aware default store for the effective configuration.

Cover workspace-relative paths, quoted home paths, frozen installs, global virtual stores, hook replacement, and empty overrides.

Related to pnpm/pnpm#11633
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pacquet/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global `--store-dir` / `store-dir` support to override the configured store location (including `--config.store-dir`), with relative paths, `~/...`, and empty values (`--store-dir=`).
  * Install behavior, `store path`, derived virtual store locations, and `updateConfig` hook inputs now reflect the CLI-selected store directory.
* **Bug Fixes**
  * Clearing an explicit store directory now reliably restores the platform default store location, including the install “up to date” fast path.
  * Hook-driven `virtualStoreDir` / `globalVirtualStoreDir` set to `null` now resets derived paths and clears related explicit settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->