### PR TITLE
fix(pacquet): put workspace root node_modules/.bin on script PATH

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ init:
 
 # When ready, run the same CI commands
 ready:
-  typos
+  typos pacquet pnpr
   cargo fmt
   just check
   just test

--- a/pacquet/crates/cli/tests/run.rs
+++ b/pacquet/crates/cli/tests/run.rs
@@ -332,6 +332,44 @@ fn run_finds_local_bin_on_path() {
     drop(root);
 }
 
+/// Running a script from a workspace member resolves binaries from the
+/// workspace root's `node_modules/.bin` — pnpm puts it on PATH via
+/// `extraBinPaths`, so root-level dev tools are callable from every
+/// workspace project.
+#[cfg(unix)]
+#[test]
+fn run_finds_workspace_root_bin_on_path() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - project\n")
+        .expect("write pnpm-workspace.yaml");
+    let bin_dir = workspace.join("node_modules").join(".bin");
+    fs::create_dir_all(&bin_dir).expect("create workspace-root node_modules/.bin");
+    write_executable(&bin_dir.join("root-tool"), "#!/bin/sh\ntouch root-tool-ran.txt\n");
+    let project = workspace.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let manifest = json!({
+        "name": "project",
+        "version": "0.0.0",
+        "scripts": { "build": "root-tool" },
+    })
+    .to_string();
+    fs::write(project.join("package.json"), manifest).expect("write package.json");
+
+    std::process::Command::cargo_bin("pacquet")
+        .expect("find pacquet binary")
+        .with_current_dir(&project)
+        .with_arg("run")
+        .with_arg("build")
+        .assert()
+        .success();
+    assert!(
+        project.join("root-tool-ran.txt").exists(),
+        "the workspace root's node_modules/.bin should be on the script's PATH",
+    );
+
+    drop(root);
+}
+
 #[cfg(unix)]
 #[test]
 fn top_level_fallback_runs_script_before_local_bin() {

--- a/pacquet/crates/cli/tests/run_recursive.rs
+++ b/pacquet/crates/cli/tests/run_recursive.rs
@@ -138,6 +138,37 @@ fn top_level_fallback_enters_recursive_run() {
     drop(root);
 }
 
+/// A member's script resolves binaries from the workspace root's
+/// `node_modules/.bin` — pnpm puts it on PATH via `extraBinPaths`, so
+/// root-level dev tools are callable from every workspace project.
+#[test]
+fn recursive_run_finds_workspace_root_bin_on_path() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[(
+            "project-1",
+            json!({
+                "name": "project-1",
+                "version": "1.0.0",
+                "scripts": { "build": "root-tool" },
+            }),
+        )],
+    );
+    let bin_dir = workspace.join("node_modules").join(".bin");
+    fs::create_dir_all(&bin_dir).expect("create workspace-root node_modules/.bin");
+    write_executable(&bin_dir.join("root-tool"), "#!/bin/sh\ntouch root-tool-ran.txt\n");
+
+    pacquet.with_arg("-r").with_arg("run").with_arg("build").assert().success();
+
+    assert!(
+        workspace.join("project-1").join("root-tool-ran.txt").exists(),
+        "the workspace root's node_modules/.bin should be on the script's PATH",
+    );
+
+    drop(root);
+}
+
 #[test]
 fn recursive_lifecycle_aliases_use_recursive_run_options() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();

--- a/pacquet/crates/cli/tests/run_recursive.rs
+++ b/pacquet/crates/cli/tests/run_recursive.rs
@@ -169,6 +169,39 @@ fn recursive_run_finds_workspace_root_bin_on_path() {
     drop(root);
 }
 
+/// The project's own `node_modules/.bin` outranks the workspace root's:
+/// when both provide the same tool, the member's copy runs. Ports the
+/// `testBinPriority` step of `pnpm recursive run finds bins from the root
+/// of the workspace` (`pnpm/test/recursive/run.ts`).
+#[test]
+fn recursive_run_prefers_project_bin_over_workspace_root_bin() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[(
+            "project-1",
+            json!({
+                "name": "project-1",
+                "version": "1.0.0",
+                "scripts": { "build": "print-version > version.txt" },
+            }),
+        )],
+    );
+    for (dir, version) in [(workspace.clone(), "2.0.0"), (workspace.join("project-1"), "1.0.0")] {
+        let bin_dir = dir.join("node_modules").join(".bin");
+        fs::create_dir_all(&bin_dir).expect("create node_modules/.bin");
+        write_executable(&bin_dir.join("print-version"), &format!("#!/bin/sh\necho {version}\n"));
+    }
+
+    pacquet.with_arg("-r").with_arg("run").with_arg("build").assert().success();
+
+    let version = fs::read_to_string(workspace.join("project-1").join("version.txt"))
+        .expect("read version.txt");
+    assert_eq!(version.trim(), "1.0.0", "the project's own bin must win over the root's");
+
+    drop(root);
+}
+
 #[test]
 fn recursive_lifecycle_aliases_use_recursive_run_options() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1120,10 +1120,10 @@ pub struct Config {
 
     /// `extraBinPaths`: directories prepended to `PATH` (after the
     /// project's own `node_modules/.bin`) when running scripts and
-    /// `pnpm exec`. pnpm computes this as the workspace root's
-    /// `node_modules/.bin` inside a workspace and leaves it empty
-    /// otherwise. pacquet defaults it empty until workspace support
-    /// lands.
+    /// `pnpm exec`. Computed as the workspace root's
+    /// `node_modules/.bin` inside a workspace and left empty
+    /// otherwise, so workspace-root dev tools are callable from every
+    /// member's scripts.
     pub extra_bin_paths: Vec<PathBuf>,
 
     /// `unsafePerm` from `pnpm-workspace.yaml`. When `false`,
@@ -2183,6 +2183,15 @@ impl Config {
             .global_bin_dir
             .clone()
             .or_else(|| pnpm_home_dir.as_ref().map(|home| home.join("bin")));
+
+        // Inside a workspace, scripts and `pnpm exec` also get the
+        // workspace root's `node_modules/.bin` on PATH — pnpm's
+        // `extraBinPaths = [join(workspaceDir, 'node_modules', '.bin')]`.
+        self.extra_bin_paths = self
+            .workspace_dir
+            .as_deref()
+            .map(|dir| vec![dir.join("node_modules").join(".bin")])
+            .unwrap_or_default();
 
         Ok(self)
     }

--- a/pacquet/crates/config/src/tests.rs
+++ b/pacquet/crates/config/src/tests.rs
@@ -2363,3 +2363,19 @@ pub fn npmrc_auth_file_relative_resolving_elsewhere_keeps_warning() {
         "expected the auth warning when the relative npmrcAuthFile does not resolve to the project .npmrc, got: {warnings:?}",
     );
 }
+
+// Port of `extraBinPaths` in `config/reader/test/index.ts` — empty outside
+// a workspace; exactly the workspace root's `node_modules/.bin` inside one.
+#[test]
+pub fn extra_bin_paths_lists_workspace_root_bin_only_inside_a_workspace() {
+    let project = tempdir().expect("project tempdir");
+    set_fake_env(&[]);
+
+    let config = load_with_fake_env(project.path());
+    assert_eq!(config.extra_bin_paths, Vec::<PathBuf>::new());
+
+    fs::write(project.path().join("pnpm-workspace.yaml"), "packages:\n  - .\n")
+        .expect("write pnpm-workspace.yaml");
+    let config = load_with_fake_env(project.path());
+    assert_eq!(config.extra_bin_paths, vec![project.path().join("node_modules").join(".bin")]);
+}

--- a/pacquet/plans/TEST_PORTING.md
+++ b/pacquet/plans/TEST_PORTING.md
@@ -255,6 +255,11 @@ Rust port notes:
 - Start with single root workspace lockfile and direct workspace links.
 - Add subset/partial install tests only after Rust has project selection semantics.
 
+## Workspace Script `PATH` (`extraBinPaths`)
+
+- [x] `TypeScript repo: pnpm/test/recursive/run.ts:8` `pnpm recursive run finds bins from the root of the workspace` — the run-related assertions are ported as `recursive_run_finds_workspace_root_bin_on_path` and `recursive_run_prefers_project_bin_over_workspace_root_bin` (`crates/cli/tests/run_recursive.rs`) plus `run_finds_workspace_root_bin_on_path` for the member-dir `pnpm run` step (`crates/cli/tests/run.rs`). The upstream test's `-r install` postinstall and `recursive rebuild` steps are install/rebuild coverage, tracked with those features.
+- [x] `TypeScript repo: config/reader/test/index.ts:2421` `extraBinPaths` — ported as `extra_bin_paths_lists_workspace_root_bin_only_inside_a_workspace` (`crates/config/src/tests.rs`).
+
 ## Workspace Project Filtering (`--filter`)
 
 Ported into the new `pacquet-workspace-projects-filter` and


### PR DESCRIPTION
## Summary

In pacquet, scripts run in a workspace member could not find binaries installed at the workspace root — e.g. `pacquet -F ./pnpm11/building/commands test` failed with `tsgo: command not found`, while the TypeScript CLI handled the same invocation fine.

The TypeScript CLI puts the workspace root's `node_modules/.bin` on `PATH` for every project's scripts via `extraBinPaths` (set in the config reader). Pacquet had the `extra_bin_paths` plumbing all the way through `run`, recursive run, `exec`, `dlx`, `pack`, and `publish`, but nothing ever populated the field, so member scripts only saw their own `.bin`.

This PR populates `Config::extra_bin_paths` with `<workspace_dir>/node_modules/.bin` when a workspace is discovered, mirroring the TypeScript config reader. All existing consumers of the field pick up the fix.

The gap existed because the behavior-defining upstream tests were never ported and were missing from `pacquet/plans/TEST_PORTING.md`: `pnpm/test/recursive/run.ts` ("pnpm recursive run finds bins from the root of the workspace") and the config reader's `extraBinPaths` test. This PR ports them — regression tests for root-bin resolution in plain and filtered-recursive `run`, the bin-priority rule (a project's own `node_modules/.bin` outranks the workspace root's), and the config-level population — and records them in the porting plan.

Also fixes `just ready` failing on a clean tree: its bare `typos` invocation scanned the whole repo and tripped over generated files under `pnpm11/` (changeset hashes in `CHANGELOG.md`s, PGP key blobs), which the TypeScript side covers with cspell instead. The recipe is now scoped to `pacquet pnpr`, matching what CI's spell-check job runs.

## Squash Commit Body

```text
pnpm adds the workspace root's node_modules/.bin to PATH for scripts and
exec in every workspace project (extraBinPaths in the config reader), so
root-level dev tools like tsgo are callable from member packages. pacquet
had the extra_bin_paths plumbing through run/exec/dlx/pack/publish, but
nothing ever populated it, so member scripts failed with 'command not
found' for workspace-root binaries.

Populate extra_bin_paths in Config::current from the discovered workspace
dir, mirroring pnpm's config reader.

The gap survived because the behavior-defining upstream tests were never
ported: pnpm/test/recursive/run.ts 'pnpm recursive run finds bins from
the root of the workspace' and the config reader's 'extraBinPaths' test.
Port them — regression tests for root-bin resolution in plain and
filtered-recursive run, the bin-priority rule (a project's own
node_modules/.bin outranks the workspace root's), and the config-level
population — and record them in plans/TEST_PORTING.md.

Also scope the typos invocation in the just ready recipe to pacquet and
pnpr, matching CI's spell-check job; the bare invocation failed on
generated files under pnpm11 that cspell covers instead.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  (Pacquet-only fix: the TypeScript CLI already behaves correctly; pacquet
  now matches it.)
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace package scripts can now locate executables from the workspace root `node_modules/.bin`.
  - Recursive workspace script execution now prioritizes the correct `node_modules/.bin` (root vs package-local) on `PATH`.

- **Documentation**
  - Clarified how `extraBinPaths` is derived inside and outside workspaces.

- **Tests**
  - Added Unix-only CLI integration tests for normal and recursive `run` behavior in workspaces.
  - Added a configuration unit test validating `extraBinPaths` with and without `pnpm-workspace.yaml`.

- **Chores**
  - Updated typo-checking command targets in the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->