### PR TITLE
ci: derive latest-<major> dist-tag from the version in the Tag workflow

### DIFF
--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -7,7 +7,7 @@ on:
         description: Version
         required: true
       tag:
-        description: Tag
+        description: Tag (use latest-<major> when tagging an older release line)
         default: latest
         required: true
 
@@ -23,16 +23,48 @@ jobs:
         api_token: ${{ secrets.GARNET_API_TOKEN }}
     - name: Setup Node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+    # The latest-<major> tag is derived from the version instead of being
+    # hardcoded per release branch, so dispatching this workflow from the wrong
+    # branch cannot point a newer line's tag at an older release
+    # (https://github.com/pnpm/pnpm/issues/12906).
+    - name: Validate version and tag
+      env:
+        VERSION: ${{ github.event.inputs.version }}
+        TAG: ${{ github.event.inputs.tag }}
+      run: |
+        if ! printf '%s\n' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[.0-9A-Za-z-]+)?$'; then
+          echo "::error::Version must be an exact semver version like 11.2.0. Got: ${VERSION}"
+          exit 1
+        fi
+        MAJOR="${VERSION%%.*}"
+        case "$TAG" in
+          latest-*)
+            if [ "$TAG" != "latest-${MAJOR}" ]; then
+              echo "::error::Tag ${TAG} does not match the major version of ${VERSION}. Expected latest-${MAJOR}."
+              exit 1
+            fi
+            ;;
+          latest)
+            CURRENT_LATEST_MAJOR="$(npm view pnpm dist-tags.latest | cut -d . -f 1)"
+            if [ "$MAJOR" -lt "$CURRENT_LATEST_MAJOR" ]; then
+              echo "::error::Refusing to move the latest tag back from v${CURRENT_LATEST_MAJOR} to ${VERSION}. Use latest-${MAJOR} to tag an older release line."
+              exit 1
+            fi
+            ;;
+        esac
     - name: Update tag
       env:
         "npm_config_//registry.npmjs.org/:_authToken": ${{ secrets.NPM_TOKEN }}
         VERSION: ${{ github.event.inputs.version }}
         TAG: ${{ github.event.inputs.tag }}
       run: |
-        npm dist-tag add "pnpm@${VERSION}" latest-11
-        npm dist-tag add "pnpm@${VERSION}" "${TAG}"
-        npm dist-tag add "@pnpm/exe@${VERSION}" latest-11
-        npm dist-tag add "@pnpm/exe@${VERSION}" "${TAG}"
+        MAJOR="${VERSION%%.*}"
+        npm dist-tag add "pnpm@${VERSION}" "latest-${MAJOR}"
+        npm dist-tag add "@pnpm/exe@${VERSION}" "latest-${MAJOR}"
+        if [ "$TAG" != "latest-${MAJOR}" ]; then
+          npm dist-tag add "pnpm@${VERSION}" "${TAG}"
+          npm dist-tag add "@pnpm/exe@${VERSION}" "${TAG}"
+        fi
 
   publish-to-winget:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#12906.

The Tag workflow (`update-latest.yml`) hardcoded the `latest-11` dist-tag and applied it unconditionally to whatever version was passed in. Each release branch carries its own copy with its own hardcoded major (`release/10` hardcodes `latest-10`), so dispatching the workflow from the wrong branch applied the wrong line's tag — tagging `10.34.5` from `main` pointed `latest-11` at a v10 release. (The registry tags themselves have already been repaired; this PR prevents a recurrence.)

This PR makes the workflow branch-agnostic and adds guardrails:

- `latest-<major>` is now derived from the version input instead of being hardcoded, so it always lands on the correct release line no matter which branch the workflow is dispatched from.
- A validation step fails the run before any dist-tag is touched when:
  - the version isn't an exact semver version,
  - the requested tag is `latest-N` with an N that doesn't match the version's major (the exact pnpm/pnpm#12906 scenario),
  - the requested tag is `latest` (the default input) but the version's major is older than the major currently tagged `latest` — catching the "forgot to change the default tag when tagging a backport" case.

The validation logic was exercised locally against the incident scenario (`10.34.5` + `latest-11` → fails), correct backport tagging (`10.34.5` + `latest-10` → passes), a normal release (`11.2.0` + `latest` → passes), a backport with the forgotten default tag (`10.34.5` + `latest` → fails), a prerelease (`11.0.0-beta.1` + `latest-11` → passes), and a malformed version (`v11.2.0` → fails).

The same change should be applied to the workflow copy on `release/10` (and future release branches), though with the derivation in place, dispatching from `main` now works correctly for any release line.

## Squash Commit Body

```text
The Tag workflow hardcoded the latest-11 dist-tag (each release branch
carried its own hardcoded major), so dispatching it from the wrong branch
applied the wrong line's tag: tagging 10.34.5 from main pointed latest-11
at a v10 release.

Derive latest-<major> from the version input instead, and fail fast when
the requested tag names a different major than the version, or when a
plain 'latest' tag would move backwards to an older major.

Closes pnpm/pnpm#12906.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
  (CI-workflow-only change — nothing to port.)

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release tag validation to ensure version tags follow the expected format.
  * Added safeguards to prevent the default `latest` tag from being moved to an older major release.
  * Automatically applies major-version tags consistently across supported package distributions.

* **Documentation**
  * Updated guidance for tagging older release lines using the `latest-<major>` format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->