### PR TITLE
ci: stop bumping pacquet config dep and self-update pnpm from next-12

### DIFF
--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -48,12 +48,9 @@ jobs:
         git fetch origin main
         git checkout -B chore/update-lockfile FETCH_HEAD
 
-    - name: Update dependencies, Node.js, pnpm, and pacquet versions
+    - name: Update dependencies, Node.js, and pnpm versions
       timeout-minutes: 20
       run: |
-        # Bump the pacquet config dependency to the latest release.
-        pnpm add --config @pnpm/pacquet
-
         # Bump Node.js to the latest 26.x and record it in devEngines.runtime.
         pnpm runtime set node 26
 
@@ -70,8 +67,10 @@ jobs:
 
         # Bump pnpm itself last: this rewrites the `packageManager` and
         # `devEngines.packageManager` pins, so doing it after the install steps
-        # keeps them running on the action-provided pnpm.
-        pnpm self-update latest
+        # keeps them running on the action-provided pnpm. The repo is on the v12
+        # prereleases, which are published under the next-12 dist-tag; `latest`
+        # would downgrade back to v11.
+        pnpm self-update next-12
 
     - name: Check for changes
       id: changes
@@ -88,7 +87,7 @@ jobs:
         GH_TOKEN: ${{ secrets.UPDATE_LOCKFILE_TOKEN }}
       run: |
         git add -A
-        git commit -m "chore: update lockfile, Node.js, pnpm, and pacquet versions"
+        git commit -m "chore: update lockfile, Node.js, and pnpm versions"
         git push -f "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" chore/update-lockfile
 
     - name: Create PR if needed
@@ -104,13 +103,12 @@ jobs:
           echo "PR already exists; today's changes were force-pushed to it"
         else
           gh pr create \
-            --title "chore: update lockfile, Node.js, pnpm, and pacquet versions" \
+            --title "chore: update lockfile, Node.js, and pnpm versions" \
             --body "This automated PR refreshes the project's pinned versions:
 
         - Updates the lockfile to the latest compatible versions of dependencies.
         - Bumps Node.js to the latest 26.x release, propagated into the CI, release, and benchmark workflows via the meta-updater.
-        - Bumps pnpm to the latest release (\`packageManager\` and \`devEngines.packageManager\`).
-        - Bumps the \`@pnpm/pacquet\` config dependency to its latest release.
+        - Bumps pnpm to the latest \`next-12\` release (\`packageManager\` and \`devEngines.packageManager\`).
 
         Created by the update-lockfile workflow." \
             --base main \


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

The daily `update-lockfile` workflow was written when the repo still had the `@pnpm/pacquet` config dependency and was on pnpm v11. Both premises are now stale:

- It runs `pnpm add --config @pnpm/pacquet`, which would re-add the config dependency that has since been removed from `pnpm-workspace.yaml`.
- It runs `pnpm self-update latest`, but the repo is now pinned to the pnpm v12 prereleases (`pnpm@12.0.0-alpha.5`), which are published under the `next-12` dist-tag. `latest` would downgrade the `packageManager` and `devEngines.packageManager` pins back to v11.

This PR drops the config-dependency bump and switches the self-update to the `next-12` dist-tag, updating the step names, generated commit message, and generated PR text to match.

## Squash Commit Body

```text
The update-lockfile workflow still bumped the @pnpm/pacquet config
dependency, which has since been removed from the repo, so the daily
run would have re-added it. It also ran `pnpm self-update latest`, but
the repo is now on the pnpm v12 prereleases published under the
next-12 dist-tag, so `latest` would have downgraded the packageManager
and devEngines.packageManager pins back to v11.

Drop the config-dependency bump and self-update from next-12 instead,
updating the step names, commit message, and PR text accordingly.
```

## Checklist

- [x] The change is CI-workflow-only, so there is nothing to port to the Rust `pacquet/` side.
- [x] No changeset: no published package is affected.

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance to focus on lockfile refreshes, Node.js 26.x updates, and pnpm updates.
  * Changed the pnpm update channel to the `next-12` prerelease series.
  * Revised generated commit and pull request messaging to match the updated maintenance scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->